### PR TITLE
chore: add CODEOWNERS for repository ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @MuenYu @cungminh2710


### PR DESCRIPTION
## What changed

Added a repository-level `CODEOWNERS` file that assigns default ownership to `@MuenYu` and `@cungminh2710`.

## How to test

- Verify `.github/CODEOWNERS` exists and contains `* @MuenYu @cungminh2710`.

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review
EOF && gh pr create --title "chore: add CODEOWNERS for repository ownership" --body-file /tmp/pr-body.md --base main --draft && rm /tmp/pr-body.md