### PR TITLE
chore: configure Renovate without automerge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "automerge": false
+}


### PR DESCRIPTION
## What changed

Add Renovate onboarding config at `.github/renovate.json` so dependency updates are opened automatically as PRs, and keep merges manual by explicitly setting `automerge` to `false`.

## How to test

- Verify `.github/renovate.json` exists and contains valid JSON.
- Confirm Renovate is enabled for the repository; after it runs, dependency update PRs should be opened and not auto-merged.

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review
