### PR TITLE
ci: add precommit target for shared validation flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,17 +27,5 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: make fmt
-        run: make fmt
-
-      - name: git diff
-        run: git diff --exit-code
-
-      - name: make lint
-        run: make lint
-
-      - name: make test
-        run: make test
-
-      - name: make build
-        run: make build
+      - name: make precommit
+        run: make precommit

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,15 @@ fmt: ## format go files
 lint: ## lint go files
 	$(golangci_lint_bin) run
 
+
+.PHONY: precommit
+precommit: ## run local CI validation flow
+	make fmt
+	git diff --exit-code
+	make lint
+	make test
+	make build
+
 .PHONY: staticcheck
 staticcheck: ## run staticcheck directly
 	go tool staticcheck ./...


### PR DESCRIPTION
## What changed

- Added a new `precommit` target to `Makefile` that runs the same validation sequence used in CI (`make fmt`, `git diff --exit-code`, `make lint`, `make test`, `make build`).
- Updated the CI workflow to call `make precommit` instead of duplicating each validation step, so local and CI checks stay aligned.

## How to test

- Run `make precommit`.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
