### PR TITLE
Auto-migrate legacy key renames in run lock filter and add tests

### DIFF
--- a/docs/configuration/i18n-config.mdx
+++ b/docs/configuration/i18n-config.mdx
@@ -24,7 +24,6 @@ Each file mapping uses:
 
 Use `{{source}}`, `{{target}}`, and `{{localeDir}}` in templates. `{{localeDir}}` resolves to an empty segment when target equals source, and to the target locale otherwise.
 
-
 ### CSV file mapping patterns
 
 Use bucket file mappings to model CSV workflows.

--- a/internal/config/i18n.go
+++ b/internal/config/i18n.go
@@ -425,6 +425,7 @@ func validateBucket(name string, bucket BucketConfig) error {
 		if !containsPlaceholder(fromSuffix) && !containsPlaceholder(toSuffix) && fromSuffix != toSuffix {
 			return fmt.Errorf("buckets.%s.files[%d]: file suffix mismatch: from=%q and to=%q must have the same extension", name, i, file.From, file.To)
 		}
+
 	}
 
 	return nil

--- a/internal/i18n/runsvc/run_orchestrator.go
+++ b/internal/i18n/runsvc/run_orchestrator.go
@@ -178,24 +178,146 @@ func applyLockFilter(planned []Task, completed map[string]lockfile.RunCompletion
 		return report, planned, checkpointStaged, nil
 	}
 
+	activeKeysByTarget := buildActiveKeysByTarget(planned)
+	consumedLegacy := map[string]struct{}{}
+	seenWarnings := map[string]struct{}{}
+
 	for _, task := range planned {
 		identity := taskIdentity(task.TargetPath, task.EntryKey)
 		sourceHash := hashSourceText(task.SourceText)
+
 		if cp, ok := checkpoints[identity]; ok && checkpointMatchesActiveRun(cp, activeRunID) && cp.SourceHash == sourceHash {
 			if err := stageTaskOutput(checkpointStaged, task.TargetPath, task.SourcePath, task.SourceLocale, task.TargetLocale, task.EntryKey, cp.Value, nil); err != nil {
 				return Report{}, nil, nil, fmt.Errorf("stage checkpoint output for %s: %w", identity, err)
 			}
 		}
+
 		if c, ok := completed[identity]; ok && c.SourceHash == sourceHash {
 			report.SkippedByLock++
 			report.Skipped = append(report.Skipped, task)
 			continue
 		}
+
+		legacyIdentity, conflictWarning := inferRenameLegacyIdentity(task, sourceHash, activeKeysByTarget, completed, checkpoints, activeRunID, consumedLegacy)
+		if conflictWarning != "" {
+			appendUniqueWarning(&report.Warnings, seenWarnings, conflictWarning)
+		}
+		if legacyIdentity != "" {
+			appendUniqueWarning(&report.Warnings, seenWarnings, fmt.Sprintf(`key_rename target=%q old_key=%q new_key=%q`, task.TargetPath, entryKeyFromIdentity(legacyIdentity), task.EntryKey))
+			if cp, ok := checkpoints[legacyIdentity]; ok && checkpointMatchesActiveRun(cp, activeRunID) && cp.SourceHash == sourceHash {
+				if err := stageTaskOutput(checkpointStaged, task.TargetPath, task.SourcePath, task.SourceLocale, task.TargetLocale, task.EntryKey, cp.Value, nil); err != nil {
+					return Report{}, nil, nil, fmt.Errorf("stage checkpoint output for %s (renamed from %s): %w", identity, legacyIdentity, err)
+				}
+				delete(checkpoints, legacyIdentity)
+			}
+			if c, ok := completed[legacyIdentity]; ok && c.SourceHash == sourceHash {
+				completed[identity] = c
+				delete(completed, legacyIdentity)
+				report.SkippedByLock++
+				report.Skipped = append(report.Skipped, task)
+				continue
+			}
+		}
+
 		report.Executable = append(report.Executable, task)
 		executable = append(executable, task)
 	}
 	report.ExecutableTotal = len(executable)
 	return report, executable, checkpointStaged, nil
+}
+
+func buildActiveKeysByTarget(tasks []Task) map[string]map[string]struct{} {
+	active := make(map[string]map[string]struct{}, len(tasks))
+	for _, task := range tasks {
+		if _, ok := active[task.TargetPath]; !ok {
+			active[task.TargetPath] = map[string]struct{}{}
+		}
+		active[task.TargetPath][task.EntryKey] = struct{}{}
+	}
+	return active
+}
+
+func inferRenameLegacyIdentity(task Task, sourceHash string, activeKeysByTarget map[string]map[string]struct{}, completed map[string]lockfile.RunCompletion, checkpoints map[string]lockfile.RunCheckpoint, activeRunID string, consumedLegacy map[string]struct{}) (legacyIdentity string, conflictWarning string) {
+	candidates := make([]string, 0, 2)
+	candidateSet := map[string]struct{}{}
+	addCandidate := func(identity string) {
+		if _, consumed := consumedLegacy[identity]; consumed {
+			return
+		}
+		if _, exists := candidateSet[identity]; exists {
+			return
+		}
+		candidateSet[identity] = struct{}{}
+		candidates = append(candidates, identity)
+	}
+
+	for identity, completion := range completed {
+		targetPath, entryKey, ok := splitTaskIdentity(identity)
+		if !ok || targetPath != task.TargetPath {
+			continue
+		}
+		if completion.SourceHash != sourceHash || entryKey == task.EntryKey {
+			continue
+		}
+		if _, stillActive := activeKeysByTarget[task.TargetPath][entryKey]; stillActive {
+			continue
+		}
+		addCandidate(identity)
+	}
+	for identity, checkpoint := range checkpoints {
+		targetPath, entryKey, ok := splitTaskIdentity(identity)
+		if !ok || targetPath != task.TargetPath {
+			continue
+		}
+		if !checkpointMatchesActiveRun(checkpoint, activeRunID) || checkpoint.SourceHash != sourceHash || entryKey == task.EntryKey {
+			continue
+		}
+		if _, stillActive := activeKeysByTarget[task.TargetPath][entryKey]; stillActive {
+			continue
+		}
+		addCandidate(identity)
+	}
+
+	if len(candidates) == 1 {
+		consumedLegacy[candidates[0]] = struct{}{}
+		return candidates[0], ""
+	}
+	if len(candidates) > 1 {
+		keys := make([]string, 0, len(candidates))
+		for _, identity := range candidates {
+			keys = append(keys, entryKeyFromIdentity(identity))
+		}
+		sort.Strings(keys)
+		return "", fmt.Sprintf(`key_rename_conflict target=%q new_key=%q message="ambiguous rename candidates: %s"`, task.TargetPath, task.EntryKey, strings.Join(keys, ","))
+	}
+	return "", ""
+}
+
+func splitTaskIdentity(identity string) (targetPath, entryKey string, ok bool) {
+	targetPath, entryKey, ok = strings.Cut(identity, "::")
+	if !ok || strings.TrimSpace(targetPath) == "" || strings.TrimSpace(entryKey) == "" {
+		return "", "", false
+	}
+	return targetPath, entryKey, true
+}
+
+func entryKeyFromIdentity(identity string) string {
+	_, entryKey, ok := splitTaskIdentity(identity)
+	if !ok {
+		return ""
+	}
+	return entryKey
+}
+
+func appendUniqueWarning(warnings *[]string, seen map[string]struct{}, warning string) {
+	if strings.TrimSpace(warning) == "" {
+		return
+	}
+	if _, ok := seen[warning]; ok {
+		return
+	}
+	seen[warning] = struct{}{}
+	*warnings = append(*warnings, warning)
 }
 
 func ensureActiveRunID(state *lockfile.File) string {

--- a/internal/i18n/runsvc/run_orchestrator_test.go
+++ b/internal/i18n/runsvc/run_orchestrator_test.go
@@ -1,0 +1,78 @@
+package runsvc
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/quiet-circles/hyperlocalise/internal/i18n/lockfile"
+)
+
+func TestApplyLockFilterAutoMigratesCompletedRenameIdentity(t *testing.T) {
+	task := Task{TargetPath: "/tmp/out.json", SourcePath: "/tmp/source.json", SourceLocale: "en", TargetLocale: "fr", EntryKey: "new", SourceText: "Hello"}
+	completed := map[string]lockfile.RunCompletion{
+		taskIdentity(task.TargetPath, "old"): {SourceHash: hashSourceText("Hello")},
+	}
+	report, executable, _, err := applyLockFilter([]Task{task}, completed, map[string]lockfile.RunCheckpoint{}, "", false)
+	if err != nil {
+		t.Fatalf("apply lock filter: %v", err)
+	}
+	if len(executable) != 0 {
+		t.Fatalf("expected rename to be skipped by migrated lock completion, got %d executable tasks", len(executable))
+	}
+	if report.SkippedByLock != 1 {
+		t.Fatalf("skipped by lock=%d, want 1", report.SkippedByLock)
+	}
+	warnings := strings.Join(report.Warnings, "\n")
+	if !strings.Contains(warnings, `key_rename target="/tmp/out.json" old_key="old" new_key="new"`) {
+		t.Fatalf("expected key_rename warning, got %q", warnings)
+	}
+	if _, ok := completed[taskIdentity(task.TargetPath, "new")]; !ok {
+		t.Fatalf("expected migrated completion for new identity")
+	}
+	if _, ok := completed[taskIdentity(task.TargetPath, "old")]; ok {
+		t.Fatalf("expected old identity removed after migration")
+	}
+}
+
+func TestApplyLockFilterAutoMigratesCheckpointRenameIdentity(t *testing.T) {
+	task := Task{TargetPath: "/tmp/out.json", SourcePath: "/tmp/source.json", SourceLocale: "en", TargetLocale: "fr", EntryKey: "new", SourceText: "Hello"}
+	checkpoints := map[string]lockfile.RunCheckpoint{
+		taskIdentity(task.TargetPath, "old"): {
+			RunID:      "run_1",
+			SourceHash: hashSourceText("Hello"),
+			Value:      "Bonjour",
+		},
+	}
+	report, executable, staged, err := applyLockFilter([]Task{task}, map[string]lockfile.RunCompletion{}, checkpoints, "run_1", false)
+	if err != nil {
+		t.Fatalf("apply lock filter: %v", err)
+	}
+	if report.ExecutableTotal != 1 || len(executable) != 1 {
+		t.Fatalf("expected task to remain executable after checkpoint staging, got %d", len(executable))
+	}
+	if got := staged[task.TargetPath].entries[task.EntryKey]; got != "Bonjour" {
+		t.Fatalf("staged checkpoint value=%q, want Bonjour", got)
+	}
+	if _, ok := checkpoints[taskIdentity(task.TargetPath, "old")]; ok {
+		t.Fatalf("expected old checkpoint identity removed after migration")
+	}
+}
+
+func TestApplyLockFilterAutoRenameConflictWhenAmbiguous(t *testing.T) {
+	task := Task{TargetPath: "/tmp/out.json", EntryKey: "new", SourceText: "Hello"}
+	completed := map[string]lockfile.RunCompletion{
+		taskIdentity(task.TargetPath, "old1"): {SourceHash: hashSourceText("Hello")},
+		taskIdentity(task.TargetPath, "old2"): {SourceHash: hashSourceText("Hello")},
+	}
+	report, executable, _, err := applyLockFilter([]Task{task}, completed, map[string]lockfile.RunCheckpoint{}, "", false)
+	if err != nil {
+		t.Fatalf("apply lock filter: %v", err)
+	}
+	if len(executable) != 1 {
+		t.Fatalf("expected task to remain executable on conflict, got %d", len(executable))
+	}
+	warnings := strings.Join(report.Warnings, "\n")
+	if !strings.Contains(warnings, "key_rename_conflict") {
+		t.Fatalf("expected conflict warning, got %q", warnings)
+	}
+}


### PR DESCRIPTION
### Motivation

- Ensure tasks whose keys were renamed in source but have identical source text to a previously completed/checkpointed key are recognized and skipped rather than retranslated. 
- Avoid false positives when a legacy key identity refers to an entry that is still active in the same run. 
- Surface clear warnings for automatic rename migrations and ambiguous rename candidates.

### Description

- Updated `applyLockFilter` to detect legacy identities for tasks and migrate completions/checkpoints when the `SourceHash` matches, by using an active-keys map and a consumed-legacy tracker. 
- Added helper functions `buildActiveKeysByTarget`, `inferRenameLegacyIdentity`, `splitTaskIdentity`, `entryKeyFromIdentity`, and `appendUniqueWarning` to encapsulate the rename candidate discovery, consumption, conflict detection, and unique warning emission. 
- Preserved and staged matching checkpoint values when migrating checkpoint identities and moved migrated `completed` entries to the new identity. 
- Added unit tests in `internal/i18n/runsvc/run_orchestrator_test.go` covering completion migration, checkpoint migration and ambiguous rename conflict cases. 
- Minor documentation and whitespace/validation tidy in `docs/configuration/i18n-config.mdx` and `internal/config/i18n.go`.

### Testing

- Ran the new package tests with `go test ./internal/i18n/runsvc` which executed `TestApplyLockFilterAutoMigratesCompletedRenameIdentity`, `TestApplyLockFilterAutoMigratesCheckpointRenameIdentity`, and `TestApplyLockFilterAutoRenameConflictWhenAmbiguous` and they all passed. 
- Ran `go test ./...` to validate broader package integration and no regressions were observed in CI-local runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acb2b433ec832c856f8dda97279d92)