### PR TITLE
Add structural path metadata and safer .md parsing with path-based fallback alignment

### DIFF
--- a/internal/i18n/translationfileparser/markdown_parser.go
+++ b/internal/i18n/translationfileparser/markdown_parser.go
@@ -16,6 +16,7 @@ type markdownPart struct {
 	literal      string
 	key          string
 	source       string
+	path         string
 	placeholders map[string]string
 }
 
@@ -32,6 +33,7 @@ type markdownParseState struct {
 
 type markdownKeyContext struct {
 	text        string
+	path        string
 	prevLiteral string
 	nextLiteral string
 	partIndex   int
@@ -55,7 +57,7 @@ func (d markdownDocument) keyContexts() []markdownKeyContext {
 		if i+1 < len(d.parts) && d.parts[i+1].key == "" {
 			next = d.parts[i+1].literal
 		}
-		out = append(out, markdownKeyContext{text: renderMarkdownPart(part, part.source), prevLiteral: prev, nextLiteral: next, partIndex: i})
+		out = append(out, markdownKeyContext{text: renderMarkdownPart(part, part.source), path: part.path, prevLiteral: prev, nextLiteral: next, partIndex: i})
 	}
 	return out
 }
@@ -70,14 +72,22 @@ func parseMarkdownDocument(content []byte) (markdownDocument, map[string]string)
 	doc := markdownDocument{parts: make([]markdownPart, 0, len(lines))}
 	entries := map[string]string{}
 	hashOccurrences := map[string]int{}
+	pathOccurrences := map[string]int{}
 
 	inFrontmatter := len(lines) > 0 && strings.TrimSpace(lines[0]) == "---"
 
 	inFence := false
 	fenceMarker := ""
 	state := markdownParseState{}
+	prevBlank := true
+	inIndentedCodeBlock := false
 
 	appendKey := func(part markdownPart) {
+		if part.path != "" {
+			ord := pathOccurrences[part.path]
+			pathOccurrences[part.path] = ord + 1
+			part.path = fmt.Sprintf("%s#%d", part.path, ord)
+		}
 		key := markdownSegmentKey(part.source, hashOccurrences)
 		part.key = key
 		doc.parts = append(doc.parts, part)
@@ -93,40 +103,56 @@ func parseMarkdownDocument(content []byte) (markdownDocument, map[string]string)
 				inFrontmatter = false
 				continue
 			}
-			emitFrontmatterLineParts(line, &doc, func(segment string) {
-				appendKey(markdownPart{source: segment})
-			})
+			emitFrontmatterLineParts(line, &doc, appendKey)
 			continue
 		}
 
 		if inFence {
 			doc.parts = append(doc.parts, markdownPart{literal: line})
-			if strings.HasPrefix(trimmed, fenceMarker) {
+			if hasFenceMarker(line, fenceMarker) {
 				inFence = false
 				fenceMarker = ""
 			}
 			continue
 		}
 
-		if strings.HasPrefix(trimmed, "```") {
+		if marker, ok := parseFenceMarker(line); ok {
 			inFence = true
-			fenceMarker = "```"
+			fenceMarker = marker
 			doc.parts = append(doc.parts, markdownPart{literal: line})
+			prevBlank = strings.TrimSpace(line) == ""
 			continue
 		}
-		if strings.HasPrefix(trimmed, "~~~") {
-			inFence = true
-			fenceMarker = "~~~"
+
+		if inIndentedCodeBlock {
+			if strings.TrimSpace(line) == "" || isIndentedCodeLine(line) {
+				doc.parts = append(doc.parts, markdownPart{literal: line})
+				prevBlank = strings.TrimSpace(line) == ""
+				continue
+			}
+			inIndentedCodeBlock = false
+		}
+
+		if prevBlank && isIndentedCodeLine(line) {
+			inIndentedCodeBlock = true
 			doc.parts = append(doc.parts, markdownPart{literal: line})
+			prevBlank = strings.TrimSpace(line) == ""
+			continue
+		}
+		if isRawHTMLBlockLine(trimmed) {
+			doc.parts = append(doc.parts, markdownPart{literal: line})
+			prevBlank = strings.TrimSpace(line) == ""
 			continue
 		}
 
 		if isImportExportLine(trimmed) {
 			doc.parts = append(doc.parts, markdownPart{literal: line})
+			prevBlank = strings.TrimSpace(line) == ""
 			continue
 		}
 
 		emitMarkdownLineParts(line, &doc, appendKey, &state)
+		prevBlank = strings.TrimSpace(line) == ""
 	}
 
 	return doc, entries
@@ -159,6 +185,7 @@ func emitMarkdownLineParts(line string, doc *markdownDocument, appendKey func(ma
 	if prefix != "" {
 		doc.parts = append(doc.parts, markdownPart{literal: prefix})
 	}
+	path := markdownStructuralPath(prefix, body)
 	if body == "" {
 		return
 	}
@@ -205,13 +232,84 @@ func emitMarkdownLineParts(line string, doc *markdownDocument, appendKey func(ma
 		}
 		return
 	}
-	appendKey(markdownPart{source: placeholdered, placeholders: placeholders})
+	appendKey(markdownPart{source: placeholdered, path: path, placeholders: placeholders})
 	for _, literal := range trailingLiterals {
 		doc.parts = append(doc.parts, markdownPart{literal: literal})
 	}
 	if newline != "" {
 		doc.parts = append(doc.parts, markdownPart{literal: newline})
 	}
+}
+
+func parseFenceMarker(line string) (string, bool) {
+	trimmed := strings.TrimLeft(line, " \t>")
+	if strings.HasPrefix(trimmed, "```") {
+		return "```", true
+	}
+	if strings.HasPrefix(trimmed, "~~~") {
+		return "~~~", true
+	}
+	return "", false
+}
+
+func hasFenceMarker(line, marker string) bool {
+	trimmed := strings.TrimLeft(line, " \t>")
+	return strings.HasPrefix(trimmed, marker)
+}
+
+func isIndentedCodeLine(line string) bool {
+	t := strings.TrimRight(line, "\r\n")
+	if strings.TrimSpace(t) == "" {
+		return false
+	}
+	trimmed := strings.TrimLeft(t, " \t")
+	indent := len(t) - len(trimmed)
+	return indent >= 4
+}
+
+func isRawHTMLBlockLine(trimmed string) bool {
+	if !strings.HasPrefix(trimmed, "<") {
+		return false
+	}
+	if strings.HasPrefix(trimmed, "<!--") || strings.HasPrefix(trimmed, "<![CDATA[") {
+		return true
+	}
+	if len(trimmed) < 2 {
+		return false
+	}
+	idx := 1
+	if trimmed[idx] == '/' {
+		idx++
+	}
+	if idx >= len(trimmed) {
+		return false
+	}
+	ch := trimmed[idx]
+	return ch >= 'a' && ch <= 'z'
+}
+
+func markdownStructuralPath(prefix, body string) string {
+	bqDepth := strings.Count(prefix, ">")
+	kind := "paragraph"
+	trimmedPrefix := strings.TrimLeft(prefix, " \t")
+	for strings.HasPrefix(trimmedPrefix, ">") {
+		trimmedPrefix = strings.TrimLeft(strings.TrimPrefix(trimmedPrefix, ">"), " ")
+	}
+	switch {
+	case hasHeadingPrefix(trimmedPrefix + body):
+		hash := 0
+		for hash < len(trimmedPrefix) && trimmedPrefix[hash] == '#' {
+			hash++
+		}
+		kind = fmt.Sprintf("heading-%d", hash)
+	case hasBulletPrefix(trimmedPrefix):
+		kind = "list-ul"
+	case hasOrderedPrefix(trimmedPrefix):
+		kind = "list-ol"
+	case strings.HasPrefix(strings.TrimSpace(prefix+body), "|"):
+		kind = "table-row"
+	}
+	return fmt.Sprintf("bq:%d|kind:%s|inline:0", bqDepth, kind)
 }
 
 func findBraceExpressionEnd(line string, start int) int {
@@ -617,7 +715,7 @@ func stripTrailingJSXClosingLiterals(body string) (string, []string) {
 	}
 }
 
-func emitFrontmatterLineParts(line string, doc *markdownDocument, appendKey func(string)) {
+func emitFrontmatterLineParts(line string, doc *markdownDocument, appendKey func(markdownPart)) {
 	if strings.TrimSpace(line) == "" {
 		doc.parts = append(doc.parts, markdownPart{literal: line})
 		return
@@ -674,7 +772,7 @@ func emitFrontmatterLineParts(line string, doc *markdownDocument, appendKey func
 	}
 
 	doc.parts = append(doc.parts, markdownPart{literal: body[:colon+1] + valuePart[:lead] + string(quote)})
-	appendKey(quotedText)
+	appendKey(markdownPart{source: quotedText, path: fmt.Sprintf("frontmatter:%s|inline:0", key)})
 	doc.parts = append(doc.parts, markdownPart{literal: valueRest[end:] + newline})
 }
 
@@ -936,6 +1034,9 @@ func MarshalMarkdownWithTargetFallbackDiagnostics(sourceTemplate, targetTemplate
 	var diags MarkdownRenderDiagnostics
 
 	takeFallback := func(sourceCtx markdownKeyContext) (string, bool) {
+		if fallback, ok := takeMarkdownFallbackByPath(targetContexts, targetPartUsed, &targetCtxCursor, &targetPartCursor, sourceCtx); ok {
+			return fallback, true
+		}
 		for i := targetCtxCursor; i < len(targetContexts); i++ {
 			if targetPartUsed[targetContexts[i].partIndex] {
 				continue
@@ -1046,6 +1147,9 @@ func alignMarkdownFallback(sourceDoc markdownDocument, sourceEntries map[string]
 	aligned := make(map[string]string, len(sourceEntries))
 
 	takeFallback := func(sourceCtx markdownKeyContext) (string, bool) {
+		if fallback, ok := takeMarkdownFallbackByPath(targetContexts, targetPartUsed, &targetCtxCursor, &targetPartCursor, sourceCtx); ok {
+			return fallback, true
+		}
 		for i := targetCtxCursor; i < len(targetContexts); i++ {
 			if targetPartUsed[targetContexts[i].partIndex] {
 				continue
@@ -1206,4 +1310,36 @@ func takeMarkdownFallbackSpan(targetDoc markdownDocument, targetPartUsed []bool,
 		nextCursor = spanEnd
 	}
 	return b.String(), nextCursor, true
+}
+
+func takeMarkdownFallbackByPath(targetContexts []markdownKeyContext, targetPartUsed []bool, targetCtxCursor, targetPartCursor *int, sourceCtx markdownKeyContext) (string, bool) {
+	if sourceCtx.path == "" {
+		return "", false
+	}
+	for i := *targetCtxCursor; i < len(targetContexts); i++ {
+		ctx := targetContexts[i]
+		if targetPartUsed[ctx.partIndex] || ctx.path != sourceCtx.path {
+			continue
+		}
+		targetPartUsed[ctx.partIndex] = true
+		*targetCtxCursor = i + 1
+		if ctx.partIndex+1 > *targetPartCursor {
+			*targetPartCursor = ctx.partIndex + 1
+		}
+		return ctx.text, true
+	}
+	for i, ctx := range targetContexts {
+		if targetPartUsed[ctx.partIndex] || ctx.path != sourceCtx.path {
+			continue
+		}
+		targetPartUsed[ctx.partIndex] = true
+		if i >= *targetCtxCursor {
+			*targetCtxCursor = i + 1
+		}
+		if ctx.partIndex+1 > *targetPartCursor {
+			*targetPartCursor = ctx.partIndex + 1
+		}
+		return ctx.text, true
+	}
+	return "", false
 }

--- a/internal/i18n/translationfileparser/markdown_parser_test.go
+++ b/internal/i18n/translationfileparser/markdown_parser_test.go
@@ -1092,3 +1092,37 @@ func findKeyByValue(values map[string]string, needle string) string {
 	}
 	return ""
 }
+
+func TestMarkdownParserParseSkipsQuotedAndListNestedFencedCode(t *testing.T) {
+	template := []byte("> Intro line\n> ```ts\n> const msg = \"hello\"\n> ```\n\n- Item text\n  ```bash\n  echo \"skip\"\n  ```\n")
+
+	entries, err := (MarkdownParser{}).Parse(template)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	combined := strings.Join(mapValues(entries), "\n")
+	if strings.Contains(combined, "const msg") || strings.Contains(combined, "echo \"skip\"") {
+		t.Fatalf("expected nested fenced code excluded, got %q", combined)
+	}
+	if !strings.Contains(combined, "Intro line") || !strings.Contains(combined, "Item text") {
+		t.Fatalf("expected surrounding prose extracted, got %q", combined)
+	}
+}
+
+func TestMarkdownParserParseSkipsIndentedCodeBlocksAfterBlankLine(t *testing.T) {
+	template := []byte("Paragraph before.\n\n    npm run build\n    npm run test\n\nParagraph after.\n")
+
+	entries, err := (MarkdownParser{}).Parse(template)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	combined := strings.Join(mapValues(entries), "\n")
+	if strings.Contains(combined, "npm run build") || strings.Contains(combined, "npm run test") {
+		t.Fatalf("expected indented code block excluded, got %q", combined)
+	}
+	if !strings.Contains(combined, "Paragraph before.") || !strings.Contains(combined, "Paragraph after.") {
+		t.Fatalf("expected prose paragraphs extracted, got %q", combined)
+	}
+}


### PR DESCRIPTION
### Motivation
- Improve reliability of Markdown extraction/replacement by introducing stable structural identity for translatable spans to avoid greedy literal-based fallback matching.
- Make `.md` parsing more conservative around fenced/indented code and raw HTML so code blocks and markup are never mistaken for translatable prose.

### Description
- Add a `path` field to `markdownPart` and `markdownKeyContext` and attach a stable per-segment path+ordinal when keys are created so segments have structural identity.
- Populate `path` from a lightweight structural classifier via `markdownStructuralPath` during line emission and tag frontmatter quoted values with `frontmatter:<key>|inline:0` paths.
- Prioritise path+ordinal matching in fallback alignment by adding `takeMarkdownFallbackByPath` and invoking it first inside both `MarshalMarkdownWithTargetFallbackDiagnostics` and `alignMarkdownFallback` used by `AlignMarkdownTargetToSource`.
- Harden block parsing for `.md` by recognizing fenced markers after blockquote/list prefixes (`parseFenceMarker` / `hasFenceMarker`), skipping indented code blocks only when preceded by a blank line (`isIndentedCodeLine` + state `inIndentedCodeBlock`), and conservatively treating raw HTML block lines as non‑translatable (`isRawHTMLBlockLine`).
- Keep the existing lossless rendering strategy (source-slice replacement, placeholders and per-segment source fallback on corruption) intact.
- Add regression tests `TestMarkdownParserParseSkipsQuotedAndListNestedFencedCode` and `TestMarkdownParserParseSkipsIndentedCodeBlocksAfterBlankLine` to cover nested/quoted fences and indented blocks.

### Testing
- Ran `go test ./internal/i18n/translationfileparser -run Markdown -count=1` and the Markdown-focused tests passed.
- Ran `go test ./internal/i18n/translationfileparser ./internal/i18n/runsvc` and both packages' test suites passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad82410e30832ca29aaef275a02baf)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves Markdown translation reliability by adding structural `path` metadata to translatable segments (for stable identity in fallback alignment), hardening the block parser against fenced/indented code blocks and raw HTML, and introducing `takeMarkdownFallbackByPath` as a first-pass matching strategy in both `MarshalMarkdownWithTargetFallbackDiagnostics` and `alignMarkdownFallback`.

Key changes and issues found:

- **`isRawHTMLBlockLine` is over-broad (logic bug):** The function returns `true` for *any* line whose trimmed form starts with `<` followed by a lowercase letter. This silently skips lines beginning with inline HTML tags such as `<em>`, `<span>`, `<a>`, `<mark>`, etc., causing translatable prose on those lines to be lost. Only block-level tags (`div`, `section`, `article`, `p`, `table`, etc.) should be treated as raw HTML blocks.
- **Fence depth not tracked across blockquote levels (logic bug):** `parseFenceMarker` and `hasFenceMarker` both strip `>` characters before testing for the fence marker, so a fence opened at blockquote depth 1 (`> ```ts`) can be prematurely closed by a fence marker at depth 0 (bare ` ``` `). The fence depth should be recorded at open time and validated on close.
- **Heading level in `markdownStructuralPath` always `0` during JSX-tag continuations (logic bug):** When `state.inJSXTag` is `true`, `prefix` is `""`, so the `#`-counting loop in `markdownStructuralPath` iterates over an empty string and always produces `heading-0` regardless of actual heading level. The count should be taken from `trimmedPrefix + body` when `trimmedPrefix` is empty.
- The `path`/ordinal mechanism, `takeMarkdownFallbackByPath`, indented-code-block tracking, and the two new regression tests are well-designed and are a clear improvement over the prior greedy literal matching.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge — `isRawHTMLBlockLine` will silently drop translatable prose from any line starting with an inline HTML tag, and the fence-depth mismatch can corrupt parses of blockquote-nested code blocks.
- Three logic bugs were identified: (1) `isRawHTMLBlockLine` is far too aggressive and causes a regression for any document with inline HTML at line start; (2) fence open/close depth is untracked, enabling premature closure in blockquote contexts; (3) heading level computation is always 0 during JSX-tag continuation state, weakening the path-identity feature this PR introduces. The first two bugs affect production correctness directly.
- Pay close attention to `internal/i18n/translationfileparser/markdown_parser.go`, specifically the `isRawHTMLBlockLine`, `parseFenceMarker`/`hasFenceMarker`, and `markdownStructuralPath` functions.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| internal/i18n/translationfileparser/markdown_parser.go | Core parser file with three logic bugs: `isRawHTMLBlockLine` is too broad (matches inline HTML, silently drops translatable prose), `parseFenceMarker`/`hasFenceMarker` ignore blockquote depth causing premature fence closure, and `markdownStructuralPath` emits `heading-0` for all heading levels during JSX-tag-continuation state. The `path` metadata, `takeMarkdownFallbackByPath`, and indented-code-block tracking are otherwise well-structured. |
| internal/i18n/translationfileparser/markdown_parser_test.go | Adds two regression tests covering nested/blockquote-fenced code and indented code blocks after blank lines; both tests are well-structured and cover the targeted scenarios, but there is no test for `isRawHTMLBlockLine` behaviour or for the blockquote-depth fence-closure edge case. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Parse line] --> B{inFrontmatter?}
    B -- yes --> C[emitFrontmatterLineParts\nattaches frontmatter:key path]
    B -- no --> D{inFence?}
    D -- yes --> E[Emit as literal\ncheck hasFenceMarker depth-agnostic]
    D -- no --> F{parseFenceMarker?}
    F -- yes --> G[Set inFence + fenceMarker\nprevBlank = false]
    F -- no --> H{inIndentedCodeBlock?}
    H -- yes --> I{blank or isIndentedCodeLine?}
    I -- yes --> J[Emit as literal]
    I -- no --> K[inIndentedCodeBlock = false]
    K --> L{prevBlank AND isIndentedCodeLine?}
    L -- yes --> M[inIndentedCodeBlock = true\nEmit as literal]
    L -- no --> N{isRawHTMLBlockLine?\n⚠️ matches inline HTML too}
    N -- yes --> O[Emit as literal\n⚠️ prose lost]
    N -- no --> P{isImportExportLine?}
    P -- yes --> Q[Emit as literal]
    P -- no --> R[emitMarkdownLineParts\nmarkdownStructuralPath prefix+body\nappendKey with path]
    R --> S[appendKey\npath gets ordinal suffix\npath#0 path#1 ...]
    S --> T{Fallback alignment\ntakeMarkdownFallbackByPath first\nthen literal context match\nthen span match}
```
</details>

<sub>Last reviewed commit: 6999a4b</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->