### PR TITLE
wip: sync TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,9 +224,10 @@ Flags:
 - `--config` - path to i18n config (optional, defaults to i18n.jsonc in cwd)
 - `--locale` - target locale(s) to sync (can be repeated)
 - `--dry-run` - preview changes without applying (default: true)
-- `--output` - output format: text or json
+- `--output` - output format: text, json, or markdown
 - `--fail-on-conflict` - return error if conflicts are detected (default: true)
 - `--apply-curated-over-draft` - allow pull to update local draft entries with curated remote values (default: true)
+- `--interactive`, `-i` - launch a TTY selector for locales, files, and flags
 
 ### sync push
 
@@ -240,9 +241,12 @@ Flags:
 - `--config` - path to i18n config (optional, defaults to i18n.jsonc in cwd)
 - `--locale` - target locale(s) to sync (can be repeated)
 - `--dry-run` - preview changes without applying (default: true)
-- `--output` - output format: text or json
+- `--output` - output format: text, json, or markdown
 - `--fail-on-conflict` - return error if conflicts are detected (default: true)
 - `--force-conflicts` - allow overwriting remote mismatches despite conflict policies (default: false)
+- `--interactive`, `-i` - launch a TTY selector for locales, files, and flags
+
+Interactive `sync push` starts with target locales selected by default. The source locale is available as an explicit opt-in when your adapter or workflow needs it.
 
 ## status
 

--- a/cmd/run_interactive.go
+++ b/cmd/run_interactive.go
@@ -765,6 +765,11 @@ func (m *runInteractiveModel) applyTableSelection(value string) {
 }
 
 func (m *runInteractiveModel) continueFromFileStep() {
+	if len(m.selectedFiles) == 0 && m.selectedFile == "" && (m.tableFilter != "" || m.directoryScope != "") {
+		for _, path := range m.filteredVisibleFiles() {
+			m.selectedFiles[path] = struct{}{}
+		}
+	}
 	if len(m.selectedFiles) == 1 {
 		for path := range m.selectedFiles {
 			m.selectedFile = path
@@ -1288,6 +1293,46 @@ func (m runInteractiveModel) fileSelectionSummary() string {
 	return fmt.Sprintf("%d files selected", count)
 }
 
+func (m runInteractiveModel) effectiveSourcePaths() []string {
+	if len(m.selectedFiles) > 0 {
+		return sortedStringKeysFromSet(m.selectedFiles)
+	}
+	if m.selectedFile != "" {
+		return []string{m.selectedFile}
+	}
+	if m.tableFilter != "" || m.directoryScope != "" {
+		return m.filteredVisibleFiles()
+	}
+	return nil
+}
+
+func (m runInteractiveModel) filteredVisibleFiles() []string {
+	paths := make([]string, 0)
+	for _, value := range m.tableValues {
+		if value == "" {
+			continue
+		}
+		paths = append(paths, value)
+	}
+	if len(paths) > 0 {
+		return paths
+	}
+	seen := map[string]struct{}{}
+	for _, task := range m.catalog.TaskIndex {
+		if !m.matchesTask(task, "file") {
+			continue
+		}
+		if m.directoryScope != "" && !isWithinPath(task.SourcePath, m.directoryScope) {
+			continue
+		}
+		if m.tableFilter != "" && !strings.Contains(strings.ToLower(task.SourcePath), strings.ToLower(m.tableFilter)) {
+			continue
+		}
+		seen[task.SourcePath] = struct{}{}
+	}
+	return sortedStringKeysFromSet(seen)
+}
+
 func (m runInteractiveModel) helpBindings() runInteractiveHelp {
 	switch m.currentStep() {
 	case runInteractiveStepFile:
@@ -1356,10 +1401,8 @@ func (m runInteractiveModel) finalOptions() runOptions {
 	} else {
 		final.targetLocales = nil
 	}
-	if len(m.selectedFiles) > 0 {
-		final.sourcePaths = sortedStringKeysFromSet(m.selectedFiles)
-	} else if m.selectedFile != "" {
-		final.sourcePaths = []string{m.selectedFile}
+	if files := m.effectiveSourcePaths(); len(files) > 0 {
+		final.sourcePaths = files
 	} else {
 		final.sourcePaths = nil
 	}

--- a/cmd/run_interactive_test.go
+++ b/cmd/run_interactive_test.go
@@ -121,6 +121,36 @@ func TestRunInteractiveFinalOptionsIncludeMultipleSelectedFiles(t *testing.T) {
 	}
 }
 
+func TestRunInteractiveFinalOptionsUseFilteredFilesWhenNoExplicitSelection(t *testing.T) {
+	model := newRunInteractiveModel(
+		runsvc.SelectionCatalog{
+			ConfigPath: "/tmp/i18n.jsonc",
+			Files: []runsvc.SelectionFile{
+				{Path: "/tmp/content/en/a.json"},
+				{Path: "/tmp/content/en/b.json"},
+			},
+			TaskIndex: []runsvc.SelectionTaskIndex{
+				{Group: "default", Bucket: "ui", TargetLocale: "fr", SourcePath: "/tmp/content/en/a.json", TaskCount: 1},
+				{Group: "default", Bucket: "ui", TargetLocale: "fr", SourcePath: "/tmp/content/en/b.json", TaskCount: 1},
+			},
+		},
+		runOptions{configPath: "/tmp/i18n.jsonc"},
+	)
+
+	model.mode = runInteractiveModeFile
+	model.steps = runInteractiveStepsForMode(model.mode)
+	model.stepPos = 1
+	model.refreshStep()
+	model.tableFilter = "a.json"
+	model.refreshStep()
+	model.continueFromFileStep()
+
+	final := model.finalOptions()
+	if len(final.sourcePaths) != 1 || final.sourcePaths[0] != "/tmp/content/en/a.json" {
+		t.Fatalf("expected filtered source path, got %#v", final.sourcePaths)
+	}
+}
+
 func TestRunInteractiveSpaceTogglesFileSelection(t *testing.T) {
 	model := newRunInteractiveModel(
 		runsvc.SelectionCatalog{

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -19,7 +19,9 @@ import (
 
 type syncCommonOptions struct {
 	configPath            string
+	interactive           bool
 	locales               []string
+	sourcePaths           []string
 	dryRun                bool
 	output                string
 	failOnConflict        bool
@@ -28,7 +30,7 @@ type syncCommonOptions struct {
 
 func defaultSyncCommonOptions() syncCommonOptions {
 	return syncCommonOptions{
-		dryRun:                true,
+		dryRun:                false,
 		output:                "text",
 		failOnConflict:        true,
 		applyCuratedOverDraft: true,
@@ -48,8 +50,10 @@ func newSyncCmd() *cobra.Command {
 }
 
 func addSyncCommonFlags(cmd *cobra.Command, o *syncCommonOptions) {
+	cmd.Flags().BoolVarP(&o.interactive, "interactive", "i", false, "launch interactive sync selector in TTY")
 	cmd.Flags().StringVar(&o.configPath, "config", "", "path to i18n config")
 	cmd.Flags().StringSliceVar(&o.locales, "locale", nil, "target locale(s) to sync")
+	cmd.Flags().StringSliceVar(&o.sourcePaths, "file", nil, "source file(s) to sync")
 	cmd.Flags().BoolVar(&o.dryRun, "dry-run", o.dryRun, "preview changes without applying")
 	cmd.Flags().StringVar(&o.output, "output", o.output, "output format: text, json, or markdown")
 	cmd.Flags().BoolVar(&o.failOnConflict, "fail-on-conflict", o.failOnConflict, "return error if conflicts are detected")
@@ -93,6 +97,10 @@ func newSyncRuntime(configPath string) (*syncRuntime, error) {
 		remote: adapter,
 		svc:    syncsvc.New(),
 	}, nil
+}
+
+func (rt *syncRuntime) resolveScope(req syncsvc.LocalReadRequest) (syncsvc.Scope, error) {
+	return rt.local.ResolveScope(req)
 }
 
 func writeSyncReport(cmd *cobra.Command, report syncsvc.Report, output string) error {

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -104,10 +104,14 @@ func (rt *syncRuntime) resolveScope(req syncsvc.LocalReadRequest) (syncsvc.Scope
 }
 
 func writeSyncReport(cmd *cobra.Command, report syncsvc.Report, output string) error {
+	return writeSyncReportWriter(cmd.OutOrStdout(), report, output)
+}
+
+func writeSyncReportWriter(w io.Writer, report syncsvc.Report, output string) error {
 	switch strings.ToLower(strings.TrimSpace(output)) {
 	case "", "text":
 		_, err := fmt.Fprintf(
-			cmd.OutOrStdout(),
+			w,
 			"action=%s creates=%d updates=%d unchanged=%d conflicts=%d risky=%d applied=%d skipped=%d warnings=%d\n",
 			report.Action,
 			len(report.Creates),
@@ -121,11 +125,11 @@ func writeSyncReport(cmd *cobra.Command, report syncsvc.Report, output string) e
 		)
 		return err
 	case "json":
-		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc := json.NewEncoder(w)
 		enc.SetIndent("", "  ")
 		return enc.Encode(report)
 	case "md", "markdown":
-		return writeSyncMarkdown(cmd.OutOrStdout(), report)
+		return writeSyncMarkdown(w, report)
 	default:
 		return fmt.Errorf("unsupported output format %q", output)
 	}

--- a/cmd/sync_interactive.go
+++ b/cmd/sync_interactive.go
@@ -405,6 +405,9 @@ func (m syncInteractiveModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.execute = false
 				return m, tea.Quit
 			}
+			if m.step == syncInteractiveStepRun {
+				m.cancelRun()
+			}
 			m.step--
 			m.refresh()
 			return m, nil

--- a/cmd/sync_interactive.go
+++ b/cmd/sync_interactive.go
@@ -211,15 +211,7 @@ func runSyncInteractiveWizard(action string, seed syncCommonOptions, extra syncI
 	if !ok {
 		return syncInteractiveResult{}, fmt.Errorf("unexpected interactive model type %T", finalModel)
 	}
-	if typed.runErr != nil {
-		return syncInteractiveResult{}, typed.runErr
-	}
-
-	return syncInteractiveResult{
-		options: typed.finalOptions(),
-		extra:   typed.extra,
-		execute: false,
-	}, nil
+	return finalizeSyncInteractiveResult(typed, output)
 }
 
 func newSyncInteractiveModel(action string, catalog runsvc.SelectionCatalog, seed syncCommonOptions, extra syncInteractiveExtra) syncInteractiveModel {
@@ -231,7 +223,7 @@ func newSyncInteractiveModel(action string, catalog runsvc.SelectionCatalog, see
 	l.SetShowTitle(false)
 	l.SetFilteringEnabled(true)
 	l.AdditionalShortHelpKeys = keys.ShortHelp
-	l.AdditionalFullHelpKeys = func() []key.Binding { return []key.Binding{keys.Back, keys.ToggleHelp, keys.Quit} }
+	l.AdditionalFullHelpKeys = func() []key.Binding { return []key.Binding{keys.Filter, keys.Back, keys.ToggleHelp, keys.Quit} }
 
 	styles := table.DefaultStyles()
 	styles.Header = styles.Header.Bold(true).Foreground(lipgloss.Color("39"))
@@ -282,9 +274,9 @@ func newSyncInteractiveModel(action string, catalog runsvc.SelectionCatalog, see
 	}
 
 	for _, locale := range m.catalogLocales() {
-		selected := len(seed.locales) == 0 || containsString(seed.locales, locale)
-		if m.action == "push" && locale == strings.TrimSpace(m.catalog.SourceLocale) {
-			selected = true
+		selected := containsString(seed.locales, locale)
+		if len(seed.locales) == 0 {
+			selected = !(m.action == "push" && strings.EqualFold(strings.TrimSpace(locale), strings.TrimSpace(m.catalog.SourceLocale)))
 		}
 		if selected {
 			m.selectedLocales[locale] = struct{}{}
@@ -392,14 +384,27 @@ func (m syncInteractiveModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		switch {
 		case key.Matches(msg, m.keys.Quit):
+			if m.list.SettingFilter() {
+				break
+			}
 			m.cancelRun()
 			m.done = true
 			return m, tea.Quit
 		case key.Matches(msg, m.keys.ToggleHelp):
+			if m.list.SettingFilter() {
+				break
+			}
 			m.help.ShowAll = !m.help.ShowAll
 			m.list.Help.ShowAll = m.help.ShowAll
 			return m, nil
 		case key.Matches(msg, m.keys.Back):
+			if m.step != syncInteractiveStepFile && m.step != syncInteractiveStepRun {
+				if m.list.SettingFilter() || m.list.IsFiltered() {
+					m.list.ResetFilter()
+					m.list.ResetSelected()
+					return m, nil
+				}
+			}
 			if m.step == syncInteractiveStepLocale {
 				m.done = true
 				m.execute = false
@@ -608,7 +613,7 @@ func (m *syncInteractiveModel) refresh() {
 		items := []list.Item{
 			syncInteractiveListItem{title: checkboxTitle(m.options.dryRun, "Dry run"), description: "preview without applying", value: "dry-run"},
 			syncInteractiveListItem{title: checkboxTitle(m.options.failOnConflict, "Fail on conflict"), description: "return an error when conflicts exist", value: "fail-on-conflict"},
-			syncInteractiveListItem{title: "Output: " + strings.ToLower(strings.TrimSpace(m.options.output)), description: "cycle text -> json -> markdown", value: "output"},
+			syncInteractiveListItem{title: "Output: " + strings.ToLower(strings.TrimSpace(m.options.output)), description: "emit report after exit: text -> json -> markdown", value: "output"},
 		}
 		if m.action == "pull" {
 			items = append(items, syncInteractiveListItem{
@@ -917,10 +922,6 @@ func (m syncInteractiveModel) footer() string {
 
 func (m *syncInteractiveModel) toggleCurrentLocale() {
 	if item, ok := m.list.SelectedItem().(syncInteractiveListItem); ok {
-		if m.action == "push" && strings.EqualFold(strings.TrimSpace(item.value), strings.TrimSpace(m.catalog.SourceLocale)) {
-			m.selectedLocales[item.value] = struct{}{}
-			return
-		}
 		toggleStringSet(m.selectedLocales, item.value)
 	}
 }
@@ -1142,7 +1143,7 @@ func executeSyncInteractive(
 	}
 	log(fmt.Sprintf("loading local entries: locales=%d files=%d", len(options.locales), len(options.sourcePaths)))
 	if plan != nil {
-		rows, err := executionPlanRows(action, rt, readReq)
+		rows, err := executionPlanRows(ctx, action, rt, readReq)
 		if err != nil {
 			return syncsvc.Report{}, fmt.Errorf("build execution plan: %w", err)
 		}
@@ -1214,16 +1215,19 @@ func sendSyncInteractiveMsg(ctx context.Context, ch chan<- tea.Msg, msg tea.Msg)
 	}
 }
 
-func executionPlanRows(action string, rt *syncRuntime, readReq syncsvc.LocalReadRequest) ([]table.Row, error) {
+func executionPlanRows(ctx context.Context, action string, rt *syncRuntime, readReq syncsvc.LocalReadRequest) ([]table.Row, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	var (
 		snapshot storage.CatalogSnapshot
 		err      error
 	)
 	switch action {
 	case "pull":
-		snapshot, err = rt.local.ReadSnapshot(context.Background(), readReq)
+		snapshot, err = rt.local.ReadSnapshot(ctx, readReq)
 	default:
-		snapshot, err = rt.local.BuildPushSnapshot(context.Background(), readReq)
+		snapshot, err = rt.local.BuildPushSnapshot(ctx, readReq)
 	}
 	if err != nil {
 		return nil, err
@@ -1247,6 +1251,26 @@ func executionPlanRows(action string, rt *syncRuntime, readReq syncsvc.LocalRead
 		rows = append(rows, table.Row{"-", "-", "empty", "no local entries matched"})
 	}
 	return rows, nil
+}
+
+func finalizeSyncInteractiveResult(model syncInteractiveModel, output io.Writer) (syncInteractiveResult, error) {
+	if model.report != nil {
+		switch strings.ToLower(strings.TrimSpace(model.options.output)) {
+		case "json", "md", "markdown":
+			if err := writeSyncReportWriter(output, *model.report, model.options.output); err != nil {
+				return syncInteractiveResult{}, fmt.Errorf("write interactive sync report: %w", err)
+			}
+		}
+	}
+	if model.runErr != nil {
+		return syncInteractiveResult{}, model.runErr
+	}
+
+	return syncInteractiveResult{
+		options: model.finalOptions(),
+		extra:   model.extra,
+		execute: false,
+	}, nil
 }
 
 func (m syncInteractiveModel) catalogLocales() []string {

--- a/cmd/sync_interactive.go
+++ b/cmd/sync_interactive.go
@@ -149,6 +149,7 @@ type syncInteractiveModel struct {
 	runErr     error
 	runStarted bool
 	runMsgs    chan tea.Msg
+	runCancel  context.CancelFunc
 	runLogs    []string
 
 	width   int
@@ -339,6 +340,7 @@ func (m syncInteractiveModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.report = &msg.report
 		m.runErr = msg.err
 		m.finishedAt = time.Now()
+		m.cancelRun()
 		m.execute = msg.err == nil
 		m.done = msg.err == nil
 		if msg.err != nil {
@@ -390,6 +392,7 @@ func (m syncInteractiveModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		switch {
 		case key.Matches(msg, m.keys.Quit):
+			m.cancelRun()
 			m.done = true
 			return m, tea.Quit
 		case key.Matches(msg, m.keys.ToggleHelp):
@@ -645,6 +648,7 @@ func (m *syncInteractiveModel) refresh() {
 		m.runErr = nil
 		m.runStarted = false
 		m.runMsgs = nil
+		m.runCancel = nil
 		m.runLogs = nil
 		m.tableValues = nil
 		m.tableRows = m.pendingExecutionRows()
@@ -970,28 +974,39 @@ func (m *syncInteractiveModel) startRunCmd() tea.Cmd {
 	}
 	m.runStarted = true
 	m.runMsgs = make(chan tea.Msg, 8)
+	ctx, cancel := context.WithCancel(context.Background())
+	m.runCancel = cancel
 	action := m.action
 	options := m.finalOptions()
 	extra := m.extra
 	go func(ch chan tea.Msg) {
+		defer close(ch)
+		defer cancel()
 		report, err := executeSyncInteractive(
+			ctx,
 			action,
 			options,
 			extra,
 			func(rows []table.Row) {
-				ch <- syncExecutionPlanMsg{rows: rows}
+				sendSyncInteractiveMsg(ctx, ch, syncExecutionPlanMsg{rows: rows})
 			},
 			func(line string) {
-				ch <- syncExecutionLogMsg{line: line}
+				sendSyncInteractiveMsg(ctx, ch, syncExecutionLogMsg{line: line})
 			},
 			func(phase string, complete, total int) {
-				ch <- syncExecutionStageMsg{phase: phase, complete: complete, total: total}
+				sendSyncInteractiveMsg(ctx, ch, syncExecutionStageMsg{phase: phase, complete: complete, total: total})
 			},
 		)
-		ch <- syncExecutionFinishedMsg{report: report, err: err}
-		close(ch)
+		sendSyncInteractiveMsg(ctx, ch, syncExecutionFinishedMsg{report: report, err: err})
 	}(m.runMsgs)
 	return waitForSyncInteractiveMsg(m.runMsgs)
+}
+
+func (m *syncInteractiveModel) cancelRun() {
+	if m.runCancel != nil {
+		m.runCancel()
+		m.runCancel = nil
+	}
 }
 
 func (m syncInteractiveModel) finalOptions() syncCommonOptions {
@@ -1087,6 +1102,7 @@ func waitForSyncInteractiveMsg(ch <-chan tea.Msg) tea.Cmd {
 }
 
 func executeSyncInteractive(
+	ctx context.Context,
 	action string,
 	options syncCommonOptions,
 	extra syncInteractiveExtra,
@@ -1095,9 +1111,15 @@ func executeSyncInteractive(
 	progress func(phase string, complete, total int),
 ) (syncsvc.Report, error) {
 	log := func(line string) {
+		if ctx.Err() != nil {
+			return
+		}
 		if logf != nil {
 			logf(line)
 		}
+	}
+	if err := ctx.Err(); err != nil {
+		return syncsvc.Report{}, err
 	}
 	if progress != nil {
 		progress("initializing", 0, 5)
@@ -1124,6 +1146,9 @@ func executeSyncInteractive(
 		plan(rows)
 		log(fmt.Sprintf("queued entries: %d", len(rows)))
 	}
+	if err := ctx.Err(); err != nil {
+		return syncsvc.Report{}, err
+	}
 	scope, err := rt.resolveScope(readReq)
 	if err != nil {
 		return syncsvc.Report{}, fmt.Errorf("resolve sync scope: %w", err)
@@ -1137,7 +1162,7 @@ func executeSyncInteractive(
 	log("syncing remote storage")
 	switch action {
 	case "pull":
-		report, err := rt.svc.Pull(context.Background(), syncsvc.PullInput{
+		report, err := rt.svc.Pull(ctx, syncsvc.PullInput{
 			Adapter: rt.remote,
 			Local:   rt.local,
 			Request: storage.PullRequest{
@@ -1158,7 +1183,7 @@ func executeSyncInteractive(
 		log(fmt.Sprintf("pull result: creates=%d updates=%d conflicts=%d warnings=%d", len(report.Creates), len(report.Updates), len(report.Conflicts), len(report.Warnings)))
 		return report, err
 	default:
-		report, err := rt.svc.Push(context.Background(), syncsvc.PushInput{
+		report, err := rt.svc.Push(ctx, syncsvc.PushInput{
 			Adapter: rt.remote,
 			Local:   rt.local,
 			Read:    readReq,
@@ -1174,6 +1199,15 @@ func executeSyncInteractive(
 		}
 		log(fmt.Sprintf("push result: creates=%d updates=%d applied=%d conflicts=%d warnings=%d", len(report.Creates), len(report.Updates), len(report.Applied), len(report.Conflicts), len(report.Warnings)))
 		return report, err
+	}
+}
+
+func sendSyncInteractiveMsg(ctx context.Context, ch chan<- tea.Msg, msg tea.Msg) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case ch <- msg:
+		return true
 	}
 }
 

--- a/cmd/sync_interactive.go
+++ b/cmd/sync_interactive.go
@@ -276,7 +276,7 @@ func newSyncInteractiveModel(action string, catalog runsvc.SelectionCatalog, see
 	for _, locale := range m.catalogLocales() {
 		selected := containsString(seed.locales, locale)
 		if len(seed.locales) == 0 {
-			selected = !(m.action == "push" && strings.EqualFold(strings.TrimSpace(locale), strings.TrimSpace(m.catalog.SourceLocale)))
+			selected = m.action != "push" || !strings.EqualFold(strings.TrimSpace(locale), strings.TrimSpace(m.catalog.SourceLocale))
 		}
 		if selected {
 			m.selectedLocales[locale] = struct{}{}

--- a/cmd/sync_interactive.go
+++ b/cmd/sync_interactive.go
@@ -1,0 +1,1303 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"charm.land/bubbles/v2/help"
+	"charm.land/bubbles/v2/key"
+	"charm.land/bubbles/v2/list"
+	"charm.land/bubbles/v2/paginator"
+	"charm.land/bubbles/v2/progress"
+	"charm.land/bubbles/v2/table"
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/quiet-circles/hyperlocalise/internal/i18n/runsvc"
+	"github.com/quiet-circles/hyperlocalise/internal/i18n/storage"
+	"github.com/quiet-circles/hyperlocalise/internal/i18n/syncsvc"
+	"github.com/sahilm/fuzzy"
+)
+
+type syncInteractiveExtra struct {
+	forceConflicts bool
+}
+
+type syncInteractiveResult struct {
+	options syncCommonOptions
+	extra   syncInteractiveExtra
+	execute bool
+}
+
+type syncInteractiveStep int
+
+const (
+	syncInteractiveStepLocale syncInteractiveStep = iota
+	syncInteractiveStepFile
+	syncInteractiveStepOptions
+	syncInteractiveStepReview
+	syncInteractiveStepRun
+)
+
+type syncInteractiveKeyMap struct {
+	Back       key.Binding
+	Quit       key.Binding
+	Confirm    key.Binding
+	TogglePick key.Binding
+	ToggleAll  key.Binding
+	Filter     key.Binding
+	Inc        key.Binding
+	Dec        key.Binding
+	ToggleHelp key.Binding
+}
+
+func defaultSyncInteractiveKeyMap() syncInteractiveKeyMap {
+	return syncInteractiveKeyMap{
+		Back: key.NewBinding(
+			key.WithKeys("esc"),
+			key.WithHelp("esc", "back"),
+		),
+		Quit: key.NewBinding(
+			key.WithKeys("q", "ctrl+c"),
+			key.WithHelp("q", "quit"),
+		),
+		Confirm: key.NewBinding(
+			key.WithKeys("enter"),
+			key.WithHelp("enter", "confirm"),
+		),
+		TogglePick: key.NewBinding(
+			key.WithKeys("space"),
+			key.WithHelp("space", "toggle"),
+		),
+		ToggleAll: key.NewBinding(
+			key.WithKeys("a"),
+			key.WithHelp("a", "toggle all"),
+		),
+		Filter: key.NewBinding(
+			key.WithKeys("/"),
+			key.WithHelp("/", "filter"),
+		),
+		Inc: key.NewBinding(
+			key.WithKeys("right", "+", "="),
+			key.WithHelp("right/+", "next page"),
+		),
+		Dec: key.NewBinding(
+			key.WithKeys("left", "-"),
+			key.WithHelp("left/-", "prev page"),
+		),
+		ToggleHelp: key.NewBinding(
+			key.WithKeys("?"),
+			key.WithHelp("?", "toggle help"),
+		),
+	}
+}
+
+func (k syncInteractiveKeyMap) ShortHelp() []key.Binding {
+	return []key.Binding{k.Confirm, k.TogglePick, k.ToggleAll, k.Filter, k.Back, k.ToggleHelp, k.Quit}
+}
+
+func (k syncInteractiveKeyMap) FullHelp() [][]key.Binding {
+	return [][]key.Binding{{k.Confirm, k.TogglePick, k.ToggleAll, k.Filter, k.Dec, k.Inc, k.Back, k.ToggleHelp, k.Quit}}
+}
+
+type syncInteractiveListItem struct {
+	title       string
+	description string
+	value       string
+}
+
+func (i syncInteractiveListItem) Title() string       { return i.title }
+func (i syncInteractiveListItem) Description() string { return i.description }
+func (i syncInteractiveListItem) FilterValue() string {
+	return i.title + " " + i.description + " " + i.value
+}
+
+type syncInteractiveModel struct {
+	action string
+	step   syncInteractiveStep
+
+	catalog runsvc.SelectionCatalog
+	options syncCommonOptions
+	extra   syncInteractiveExtra
+
+	selectedLocales map[string]struct{}
+	selectedFiles   map[string]struct{}
+
+	list   list.Model
+	table  table.Model
+	pager  paginator.Model
+	bar    progress.Model
+	filter textinput.Model
+	help   help.Model
+	keys   syncInteractiveKeyMap
+
+	tableRows   []table.Row
+	tableValues []string
+	tableFilter string
+	filtering   bool
+
+	phase      string
+	startedAt  time.Time
+	finishedAt time.Time
+	report     *syncsvc.Report
+	runErr     error
+	runStarted bool
+	runMsgs    chan tea.Msg
+	runLogs    []string
+
+	width   int
+	height  int
+	errMsg  string
+	execute bool
+	done    bool
+
+	titleStyle  lipgloss.Style
+	metaStyle   lipgloss.Style
+	errorStyle  lipgloss.Style
+	accentStyle lipgloss.Style
+	okStyle     lipgloss.Style
+	failStyle   lipgloss.Style
+	warnStyle   lipgloss.Style
+}
+
+type syncExecutionStageMsg struct {
+	phase    string
+	complete int
+	total    int
+}
+
+type syncExecutionPlanMsg struct {
+	rows []table.Row
+}
+
+type syncExecutionFinishedMsg struct {
+	report syncsvc.Report
+	err    error
+}
+
+type syncExecutionLogMsg struct {
+	line string
+}
+
+func runSyncInteractiveWizard(action string, seed syncCommonOptions, extra syncInteractiveExtra, output io.Writer) (syncInteractiveResult, error) {
+	if !isTTYWriter(output) || !isTTYInput(os.Stdin) {
+		return syncInteractiveResult{}, fmt.Errorf("--interactive requires a TTY input and output")
+	}
+
+	catalog, err := runsvc.BuildSelectionCatalog(seed.configPath)
+	if err != nil {
+		return syncInteractiveResult{}, err
+	}
+
+	m := newSyncInteractiveModel(action, catalog, seed, extra)
+	p := tea.NewProgram(
+		m,
+		tea.WithOutput(output),
+		tea.WithInput(os.Stdin),
+	)
+	finalModel, err := p.Run()
+	if err != nil {
+		return syncInteractiveResult{}, err
+	}
+
+	typed, ok := finalModel.(syncInteractiveModel)
+	if !ok {
+		return syncInteractiveResult{}, fmt.Errorf("unexpected interactive model type %T", finalModel)
+	}
+	if typed.runErr != nil {
+		return syncInteractiveResult{}, typed.runErr
+	}
+
+	return syncInteractiveResult{
+		options: typed.finalOptions(),
+		extra:   typed.extra,
+		execute: false,
+	}, nil
+}
+
+func newSyncInteractiveModel(action string, catalog runsvc.SelectionCatalog, seed syncCommonOptions, extra syncInteractiveExtra) syncInteractiveModel {
+	keys := defaultSyncInteractiveKeyMap()
+	delegate := list.NewDefaultDelegate()
+	l := list.New(nil, delegate, 0, 0)
+	l.SetShowHelp(false)
+	l.SetShowStatusBar(false)
+	l.SetShowTitle(false)
+	l.SetFilteringEnabled(true)
+	l.AdditionalShortHelpKeys = keys.ShortHelp
+	l.AdditionalFullHelpKeys = func() []key.Binding { return []key.Binding{keys.Back, keys.ToggleHelp, keys.Quit} }
+
+	styles := table.DefaultStyles()
+	styles.Header = styles.Header.Bold(true).Foreground(lipgloss.Color("39"))
+	styles.Selected = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("230")).Background(lipgloss.Color("62"))
+	tbl := table.New(
+		table.WithFocused(true),
+		table.WithStyles(styles),
+		table.WithColumns([]table.Column{
+			{Title: "Pick", Width: 7},
+			{Title: "File", Width: 42},
+			{Title: "Keys", Width: 8},
+			{Title: "Targets", Width: 10},
+		}),
+	)
+
+	pg := paginator.New()
+	pg.Type = paginator.Arabic
+	pg.PerPage = 8
+
+	bar := progress.New(progress.WithWidth(40), progress.WithDefaultBlend())
+
+	filter := textinput.New()
+	filter.Prompt = "/ "
+	filter.Placeholder = "fuzzy filter files"
+
+	m := syncInteractiveModel{
+		action:          action,
+		step:            syncInteractiveStepLocale,
+		catalog:         catalog,
+		options:         seed,
+		extra:           extra,
+		selectedLocales: make(map[string]struct{}),
+		selectedFiles:   make(map[string]struct{}),
+		list:            l,
+		table:           tbl,
+		pager:           pg,
+		bar:             bar,
+		filter:          filter,
+		help:            help.New(),
+		keys:            keys,
+		titleStyle:      lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("45")),
+		metaStyle:       lipgloss.NewStyle().Foreground(lipgloss.Color("244")),
+		errorStyle:      lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Bold(true),
+		accentStyle:     lipgloss.NewStyle().Foreground(lipgloss.Color("81")).Bold(true),
+		okStyle:         lipgloss.NewStyle().Foreground(lipgloss.Color("42")).Bold(true),
+		failStyle:       lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Bold(true),
+		warnStyle:       lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Bold(true),
+	}
+
+	for _, locale := range m.catalogLocales() {
+		selected := len(seed.locales) == 0 || containsString(seed.locales, locale)
+		if m.action == "push" && locale == strings.TrimSpace(m.catalog.SourceLocale) {
+			selected = true
+		}
+		if selected {
+			m.selectedLocales[locale] = struct{}{}
+		}
+	}
+	for _, path := range m.catalogFiles() {
+		if len(seed.sourcePaths) == 0 || containsString(seed.sourcePaths, path) {
+			m.selectedFiles[path] = struct{}{}
+		}
+	}
+	m.refresh()
+	return m
+}
+
+func (m syncInteractiveModel) Init() tea.Cmd { return nil }
+
+func (m syncInteractiveModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		m.help.SetWidth(msg.Width)
+		m.list.SetSize(msg.Width-2, max(8, msg.Height-10))
+		m.table.SetWidth(max(40, msg.Width-2))
+		m.table.SetHeight(max(8, msg.Height-14))
+		m.pager.PerPage = max(5, msg.Height-16)
+		m.bar.SetWidth(max(20, msg.Width-24))
+		if m.step == syncInteractiveStepFile {
+			m.applyPaginatedRows()
+		}
+		return m, nil
+	case syncExecutionStageMsg:
+		m.phase = msg.phase
+		if msg.total > 0 {
+			pct := float64(msg.complete) / float64(msg.total)
+			cmd := m.bar.SetPercent(pct)
+			return m, tea.Batch(cmd, waitForSyncInteractiveMsg(m.runMsgs))
+		}
+		return m, waitForSyncInteractiveMsg(m.runMsgs)
+	case syncExecutionPlanMsg:
+		if len(msg.rows) > 0 {
+			m.tableRows = msg.rows
+			m.pager.Page = 0
+			m.applyPaginatedRows()
+		}
+		return m, waitForSyncInteractiveMsg(m.runMsgs)
+	case syncExecutionLogMsg:
+		if strings.TrimSpace(msg.line) != "" {
+			m.runLogs = append(m.runLogs, msg.line)
+		}
+		return m, waitForSyncInteractiveMsg(m.runMsgs)
+	case syncExecutionFinishedMsg:
+		m.report = &msg.report
+		m.runErr = msg.err
+		m.finishedAt = time.Now()
+		m.execute = msg.err == nil
+		m.done = msg.err == nil
+		if msg.err != nil {
+			m.phase = "failed"
+			m.runLogs = append(m.runLogs, "error: "+msg.err.Error())
+		} else {
+			m.phase = "completed"
+			m.runLogs = append(m.runLogs, "sync completed")
+		}
+		for _, warning := range msg.report.Warnings {
+			m.runLogs = append(m.runLogs, "warning: "+warning.Message)
+		}
+		m.tableRows, m.tableValues = m.executionRows()
+		m.pager.Page = 0
+		m.applyPaginatedRows()
+		targetPercent := 1.0
+		if msg.err != nil {
+			targetPercent = 0.85
+		}
+		cmd := m.bar.SetPercent(targetPercent)
+		return m, cmd
+	case progress.FrameMsg:
+		var cmd tea.Cmd
+		m.bar, cmd = m.bar.Update(msg)
+		return m, cmd
+	case tea.KeyPressMsg:
+		if m.filtering {
+			switch msg.String() {
+			case "esc":
+				m.filtering = false
+				m.tableFilter = ""
+				m.filter.SetValue("")
+				m.filter.Blur()
+				m.refresh()
+				m.table.SetCursor(0)
+				return m, nil
+			case "enter":
+				m.filtering = false
+				m.filter.Blur()
+				m.tableFilter = strings.TrimSpace(m.filter.Value())
+				m.refresh()
+				m.table.SetCursor(0)
+				return m, nil
+			}
+			var cmd tea.Cmd
+			m.filter, cmd = m.filter.Update(msg)
+			return m, cmd
+		}
+
+		switch {
+		case key.Matches(msg, m.keys.Quit):
+			m.done = true
+			return m, tea.Quit
+		case key.Matches(msg, m.keys.ToggleHelp):
+			m.help.ShowAll = !m.help.ShowAll
+			m.list.Help.ShowAll = m.help.ShowAll
+			return m, nil
+		case key.Matches(msg, m.keys.Back):
+			if m.step == syncInteractiveStepLocale {
+				m.done = true
+				m.execute = false
+				return m, tea.Quit
+			}
+			m.step--
+			m.refresh()
+			return m, nil
+		case key.Matches(msg, m.keys.Filter):
+			if m.step == syncInteractiveStepFile {
+				m.filtering = true
+				m.filter.SetValue(m.tableFilter)
+				m.filter.Focus()
+				m.table.SetCursor(0)
+				return m, nil
+			}
+		}
+	}
+
+	switch m.step {
+	case syncInteractiveStepFile:
+		return m.updateFileStep(msg)
+	case syncInteractiveStepRun:
+		return m.updateRunStep(msg)
+	default:
+		return m.updateListStep(msg)
+	}
+}
+
+func (m syncInteractiveModel) updateListStep(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	m.list, cmd = m.list.Update(msg)
+	keyMsg, ok := msg.(tea.KeyPressMsg)
+	if !ok {
+		return m, cmd
+	}
+
+	switch m.step {
+	case syncInteractiveStepLocale:
+		switch {
+		case key.Matches(keyMsg, m.keys.TogglePick):
+			m.toggleCurrentLocale()
+			m.refresh()
+			return m, nil
+		case key.Matches(keyMsg, m.keys.Confirm):
+			if len(m.selectedLocales) == 0 {
+				m.errMsg = "select at least one locale"
+				return m, nil
+			}
+			m.step = syncInteractiveStepFile
+			m.refresh()
+			return m, nil
+		}
+	case syncInteractiveStepOptions:
+		if item, ok := m.list.SelectedItem().(syncInteractiveListItem); ok {
+			switch {
+			case key.Matches(keyMsg, m.keys.TogglePick):
+				m.applyOption(item.value)
+				m.refresh()
+				return m, nil
+			case key.Matches(keyMsg, m.keys.Confirm):
+				if item.value == "continue" {
+					m.step = syncInteractiveStepReview
+				} else {
+					m.applyOption(item.value)
+				}
+				m.refresh()
+				return m, nil
+			}
+		}
+	case syncInteractiveStepReview:
+		if item, ok := m.list.SelectedItem().(syncInteractiveListItem); ok && key.Matches(keyMsg, m.keys.Confirm) {
+			switch item.value {
+			case "run":
+				m.step = syncInteractiveStepRun
+				m.refresh()
+				return m, m.startRunCmd()
+			case "back":
+				m.step = syncInteractiveStepOptions
+				m.refresh()
+				return m, nil
+			}
+		}
+	}
+
+	return m, cmd
+}
+
+func (m syncInteractiveModel) updateRunStep(msg tea.Msg) (tea.Model, tea.Cmd) {
+	keyMsg, ok := msg.(tea.KeyPressMsg)
+	if ok {
+		switch {
+		case key.Matches(keyMsg, m.keys.Inc), key.Matches(keyMsg, m.pager.KeyMap.NextPage):
+			m.pager.NextPage()
+			m.applyPaginatedRows()
+			return m, nil
+		case key.Matches(keyMsg, m.keys.Dec), key.Matches(keyMsg, m.pager.KeyMap.PrevPage):
+			m.pager.PrevPage()
+			m.applyPaginatedRows()
+			return m, nil
+		case key.Matches(keyMsg, m.keys.Confirm) && (m.report != nil || m.runErr != nil):
+			return m, tea.Quit
+		}
+	}
+	var cmd tea.Cmd
+	m.table, cmd = m.table.Update(msg)
+	return m, cmd
+}
+
+func (m syncInteractiveModel) updateFileStep(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	keyMsg, ok := msg.(tea.KeyPressMsg)
+	if ok {
+		switch {
+		case key.Matches(keyMsg, m.keys.Inc), key.Matches(keyMsg, m.pager.KeyMap.NextPage):
+			m.pager.NextPage()
+			m.applyPaginatedRows()
+			return m, nil
+		case key.Matches(keyMsg, m.keys.Dec), key.Matches(keyMsg, m.pager.KeyMap.PrevPage):
+			m.pager.PrevPage()
+			m.applyPaginatedRows()
+			return m, nil
+		case key.Matches(keyMsg, m.keys.TogglePick):
+			m.toggleCurrentFile()
+			m.refresh()
+			return m, nil
+		case key.Matches(keyMsg, m.keys.ToggleAll):
+			m.toggleAllFiles()
+			m.refresh()
+			return m, nil
+		case key.Matches(keyMsg, m.keys.Confirm):
+			if len(m.selectedFiles) == 0 {
+				m.errMsg = "select at least one file"
+				return m, nil
+			}
+			m.step = syncInteractiveStepOptions
+			m.refresh()
+			return m, nil
+		}
+	}
+
+	m.table, cmd = m.table.Update(msg)
+	return m, cmd
+}
+
+func (m syncInteractiveModel) View() tea.View {
+	title := m.titleStyle.Render("hyperlocalise sync interactive")
+	meta := m.metaStyle.Render(fmt.Sprintf(
+		"action=%s  locales=%d  files=%d  output=%s",
+		m.action,
+		len(m.selectedLocales),
+		len(m.selectedFiles),
+		m.options.output,
+	))
+
+	parts := []string{title, m.metaStyle.Render("config=" + emptyDash(m.catalog.ConfigPath)), meta, ""}
+	if m.errMsg != "" {
+		parts = append(parts, m.errorStyle.Render(m.errMsg), "")
+	}
+
+	switch m.step {
+	case syncInteractiveStepFile:
+		parts = append(parts, m.renderFileStep())
+	case syncInteractiveStepRun:
+		parts = append(parts, m.renderRunStep())
+	default:
+		parts = append(parts, m.renderListStep())
+	}
+
+	parts = append(parts, "", m.footer(), m.help.View(m.keys))
+	view := tea.NewView(strings.Join(parts, "\n"))
+	view.AltScreen = true
+	return view
+}
+
+func (m *syncInteractiveModel) refresh() {
+	m.errMsg = ""
+	switch m.step {
+	case syncInteractiveStepLocale:
+		currentIndex := m.list.Index()
+		m.list.Title = "Select locales"
+		items := make([]list.Item, 0, len(m.catalogLocales()))
+		for _, locale := range m.catalogLocales() {
+			_, selected := m.selectedLocales[locale]
+			items = append(items, syncInteractiveListItem{
+				title:       checkboxTitle(selected, locale),
+				description: "toggle with space, continue with enter",
+				value:       locale,
+			})
+		}
+		_ = m.list.SetItems(items)
+		if len(items) > 0 {
+			m.list.Select(clampIndex(currentIndex, len(items)))
+		}
+	case syncInteractiveStepFile:
+		currentValue := m.currentTableValue()
+		m.tableRows, m.tableValues = m.fileRows()
+		m.applyPaginatedRows()
+		m.restoreTableSelection(currentValue)
+	case syncInteractiveStepOptions:
+		currentIndex := m.list.Index()
+		m.list.Title = "Sync options"
+		items := []list.Item{
+			syncInteractiveListItem{title: checkboxTitle(m.options.dryRun, "Dry run"), description: "preview without applying", value: "dry-run"},
+			syncInteractiveListItem{title: checkboxTitle(m.options.failOnConflict, "Fail on conflict"), description: "return an error when conflicts exist", value: "fail-on-conflict"},
+			syncInteractiveListItem{title: "Output: " + strings.ToLower(strings.TrimSpace(m.options.output)), description: "cycle text -> json -> markdown", value: "output"},
+		}
+		if m.action == "pull" {
+			items = append(items, syncInteractiveListItem{
+				title:       checkboxTitle(m.options.applyCuratedOverDraft, "Apply curated over draft"),
+				description: "allow curated remote values to replace local draft entries",
+				value:       "apply-curated-over-draft",
+			})
+		}
+		if m.action == "push" {
+			items = append(items, syncInteractiveListItem{
+				title:       checkboxTitle(m.extra.forceConflicts, "Force conflicts"),
+				description: "allow push despite mismatch conflict policies",
+				value:       "force-conflicts",
+			})
+		}
+		items = append(items, syncInteractiveListItem{
+			title:       "Continue",
+			description: "review selections and run",
+			value:       "continue",
+		})
+		_ = m.list.SetItems(items)
+		if len(items) > 0 {
+			m.list.Select(clampIndex(currentIndex, len(items)))
+		}
+	case syncInteractiveStepReview:
+		currentIndex := m.list.Index()
+		m.list.Title = "Review"
+		_ = m.list.SetItems([]list.Item{
+			syncInteractiveListItem{title: "Run sync", description: "execute with the current selections", value: "run"},
+			syncInteractiveListItem{title: "Back", description: "return to options", value: "back"},
+		})
+		if count := len(m.list.Items()); count > 0 {
+			m.list.Select(clampIndex(currentIndex, count))
+		}
+	case syncInteractiveStepRun:
+		m.phase = "starting"
+		m.startedAt = time.Now()
+		m.finishedAt = time.Time{}
+		m.report = nil
+		m.runErr = nil
+		m.runStarted = false
+		m.runMsgs = nil
+		m.runLogs = nil
+		m.tableValues = nil
+		m.tableRows = m.pendingExecutionRows()
+		m.table.SetColumns([]table.Column{
+			{Title: "Key", Width: 28},
+			{Title: "Locale", Width: 10},
+			{Title: "Status", Width: 14},
+			{Title: "Detail", Width: max(20, m.width-60)},
+		})
+		m.pager.Page = 0
+		m.applyPaginatedRows()
+	}
+}
+
+func (m syncInteractiveModel) fileRows() ([]table.Row, []string) {
+	files := m.catalogFiles()
+	if m.tableFilter != "" {
+		matches := fuzzy.Find(strings.ToLower(m.tableFilter), lowerStrings(files))
+		filtered := make([]string, 0, len(matches))
+		for _, match := range matches {
+			filtered = append(filtered, files[match.Index])
+		}
+		files = filtered
+	}
+
+	rows := make([]table.Row, 0, len(files))
+	values := make([]string, 0, len(files))
+	for _, path := range files {
+		file := m.catalogFile(path)
+		_, selected := m.selectedFiles[path]
+		rows = append(rows, table.Row{
+			checkboxCell(selected),
+			filepath.ToSlash(path),
+			fmt.Sprintf("%d", m.catalogFileKeyCount(path)),
+			fmt.Sprintf("%d", file.TargetCount),
+		})
+		values = append(values, path)
+	}
+	return rows, values
+}
+
+func (m *syncInteractiveModel) applyPaginatedRows() {
+	m.pager.SetTotalPages(len(m.tableRows))
+	if m.pager.Page >= m.pager.TotalPages && m.pager.TotalPages > 0 {
+		m.pager.Page = m.pager.TotalPages - 1
+	}
+	if m.pager.Page < 0 {
+		m.pager.Page = 0
+	}
+	start, end := m.pager.GetSliceBounds(len(m.tableRows))
+	if start > end {
+		start, end = 0, 0
+	}
+	m.table.SetRows(m.tableRows[start:end])
+	m.table.SetCursor(0)
+}
+
+func (m syncInteractiveModel) currentTableValueIndex() int {
+	index := m.table.Cursor()
+	if index < 0 {
+		return -1
+	}
+	start, _ := m.pager.GetSliceBounds(len(m.tableRows))
+	return start + index
+}
+
+func (m syncInteractiveModel) currentTableValue() string {
+	index := m.currentTableValueIndex()
+	if index < 0 || index >= len(m.tableValues) {
+		return ""
+	}
+	return m.tableValues[index]
+}
+
+func (m *syncInteractiveModel) restoreTableSelection(value string) {
+	if value == "" {
+		return
+	}
+	index := -1
+	for i, candidate := range m.tableValues {
+		if candidate == value {
+			index = i
+			break
+		}
+	}
+	if index < 0 {
+		return
+	}
+	perPage := max(1, m.pager.PerPage)
+	m.pager.Page = index / perPage
+	if m.pager.TotalPages > 0 && m.pager.Page >= m.pager.TotalPages {
+		m.pager.Page = m.pager.TotalPages - 1
+	}
+	start, end := m.pager.GetSliceBounds(len(m.tableRows))
+	if start > end {
+		start, end = 0, 0
+	}
+	m.table.SetRows(m.tableRows[start:end])
+	m.table.SetCursor(index - start)
+}
+
+func clampIndex(index, count int) int {
+	if count <= 0 {
+		return 0
+	}
+	if index < 0 {
+		return 0
+	}
+	if index >= count {
+		return count - 1
+	}
+	return index
+}
+
+func (m syncInteractiveModel) renderListStep() string {
+	sections := []string{m.sectionTitle()}
+	if m.step == syncInteractiveStepReview {
+		sections = append(sections, m.reviewSummary())
+	}
+	sections = append(sections, m.list.View())
+	return strings.Join(sections, "\n\n")
+}
+
+func (m syncInteractiveModel) renderFileStep() string {
+	parts := []string{m.sectionTitle()}
+	if m.filtering {
+		parts = append(parts, m.filter.View())
+	} else if m.tableFilter != "" {
+		parts = append(parts, m.metaStyle.Render("filter="+m.tableFilter))
+	}
+	parts = append(parts,
+		m.metaStyle.Render("space toggles current file, a toggles all files, / fuzzy-filters, left/right changes page, enter continues"),
+		m.table.View(),
+		m.metaStyle.Render(m.table.HelpView()+"  "+m.pagerSummary()),
+	)
+	return strings.Join(parts, "\n\n")
+}
+
+func (m syncInteractiveModel) sectionTitle() string {
+	switch m.step {
+	case syncInteractiveStepLocale:
+		return m.accentStyle.Render("Locales")
+	case syncInteractiveStepFile:
+		return m.accentStyle.Render("Files")
+	case syncInteractiveStepOptions:
+		return m.accentStyle.Render("Flags")
+	default:
+		return m.accentStyle.Render("Review")
+	}
+}
+
+func (m syncInteractiveModel) renderRunStep() string {
+	elapsed := time.Since(m.startedAt)
+	if !m.finishedAt.IsZero() {
+		elapsed = m.finishedAt.Sub(m.startedAt)
+	}
+	status := m.metaStyle.Render(fmt.Sprintf("phase=%s  elapsed=%s", emptyDash(m.phase), elapsed.Round(time.Second)))
+	if m.startedAt.IsZero() {
+		status = m.metaStyle.Render("phase=" + emptyDash(m.phase))
+	}
+	parts := []string{
+		m.accentStyle.Render("Sync Run"),
+		m.bar.View(),
+		status,
+	}
+	if summary := m.runSummary(); summary != "" {
+		parts = append(parts, m.metaStyle.Render(summary))
+	}
+	if m.runErr != nil {
+		parts = append(parts, m.failStyle.Render(m.runErr.Error()))
+	}
+	if logs := m.renderRunLogs(); logs != "" {
+		parts = append(parts, logs)
+	}
+	parts = append(parts, m.table.View(), m.metaStyle.Render(m.table.HelpView()+"  "+m.pagerSummary()))
+	if m.report != nil || m.runErr != nil {
+		parts = append(parts, m.metaStyle.Render("enter closes, arrows/j/k move, left/right changes page"))
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+func (m syncInteractiveModel) renderRunLogs() string {
+	if len(m.runLogs) == 0 {
+		return ""
+	}
+	start := 0
+	if len(m.runLogs) > 8 {
+		start = len(m.runLogs) - 8
+	}
+	lines := []string{m.accentStyle.Render("Log")}
+	for _, line := range m.runLogs[start:] {
+		lines = append(lines, m.metaStyle.Render(line))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (m syncInteractiveModel) runSummary() string {
+	if m.report == nil {
+		return ""
+	}
+	parts := []string{
+		fmt.Sprintf(
+			"creates=%d updates=%d unchanged=%d conflicts=%d applied=%d skipped=%d warnings=%d",
+			len(m.report.Creates),
+			len(m.report.Updates),
+			len(m.report.Unchanged),
+			len(m.report.Conflicts),
+			len(m.report.Applied),
+			len(m.report.Skipped),
+			len(m.report.Warnings),
+		),
+	}
+	if len(m.report.Warnings) > 0 {
+		parts = append(parts, "warning="+m.report.Warnings[0].Message)
+	}
+	return strings.Join(parts, "\n")
+}
+
+func (m syncInteractiveModel) reviewSummary() string {
+	lines := []string{
+		fmt.Sprintf("Action: %s", m.action),
+		fmt.Sprintf("Locales: %s", strings.Join(sortedMapKeys(m.selectedLocales), ", ")),
+		fmt.Sprintf("Files: %d selected", len(m.selectedFiles)),
+		fmt.Sprintf("Dry run: %t", m.options.dryRun),
+		fmt.Sprintf("Fail on conflict: %t", m.options.failOnConflict),
+		fmt.Sprintf("Output: %s", m.options.output),
+	}
+	if m.action == "pull" {
+		lines = append(lines, fmt.Sprintf("Apply curated over draft: %t", m.options.applyCuratedOverDraft))
+	}
+	if m.action == "push" {
+		lines = append(lines, fmt.Sprintf("Force conflicts: %t", m.extra.forceConflicts))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (m syncInteractiveModel) pagerSummary() string {
+	total := len(m.tableRows)
+	if total == 0 {
+		return "page 0/0 rows 0-0 of 0"
+	}
+	start, end := m.pager.GetSliceBounds(total)
+	return fmt.Sprintf("page %d/%d rows %d-%d of %d", m.pager.Page+1, max(1, m.pager.TotalPages), start+1, end, total)
+}
+
+func (m syncInteractiveModel) footer() string {
+	switch m.step {
+	case syncInteractiveStepLocale:
+		return m.metaStyle.Render("Select locales to sync.")
+	case syncInteractiveStepFile:
+		return m.metaStyle.Render("Select source files to sync.")
+	case syncInteractiveStepOptions:
+		return m.metaStyle.Render("Toggle flags and continue.")
+	case syncInteractiveStepRun:
+		if m.report != nil || m.runErr != nil {
+			return m.metaStyle.Render("Sync finished. Press enter or q to exit.")
+		}
+		return m.metaStyle.Render("Sync running...")
+	default:
+		return m.metaStyle.Render("Confirm to run or go back.")
+	}
+}
+
+func (m *syncInteractiveModel) toggleCurrentLocale() {
+	if item, ok := m.list.SelectedItem().(syncInteractiveListItem); ok {
+		if m.action == "push" && strings.EqualFold(strings.TrimSpace(item.value), strings.TrimSpace(m.catalog.SourceLocale)) {
+			m.selectedLocales[item.value] = struct{}{}
+			return
+		}
+		toggleStringSet(m.selectedLocales, item.value)
+	}
+}
+
+func (m *syncInteractiveModel) toggleCurrentFile() {
+	index := m.currentTableValueIndex()
+	if index < 0 || index >= len(m.tableValues) {
+		return
+	}
+	toggleStringSet(m.selectedFiles, m.tableValues[index])
+}
+
+func (m *syncInteractiveModel) toggleAllFiles() {
+	files := m.tableValues
+	if len(files) == 0 {
+		return
+	}
+	allSelected := true
+	for _, file := range files {
+		if _, ok := m.selectedFiles[file]; !ok {
+			allSelected = false
+			break
+		}
+	}
+	if allSelected {
+		for _, file := range files {
+			delete(m.selectedFiles, file)
+		}
+		return
+	}
+	for _, file := range files {
+		m.selectedFiles[file] = struct{}{}
+	}
+}
+
+func (m *syncInteractiveModel) applyOption(value string) {
+	switch value {
+	case "dry-run":
+		m.options.dryRun = !m.options.dryRun
+	case "fail-on-conflict":
+		m.options.failOnConflict = !m.options.failOnConflict
+	case "apply-curated-over-draft":
+		m.options.applyCuratedOverDraft = !m.options.applyCuratedOverDraft
+	case "force-conflicts":
+		m.extra.forceConflicts = !m.extra.forceConflicts
+	case "output":
+		m.options.output = nextSyncOutput(m.options.output)
+	}
+}
+
+func (m *syncInteractiveModel) startRunCmd() tea.Cmd {
+	if m.runStarted {
+		return nil
+	}
+	m.runStarted = true
+	m.runMsgs = make(chan tea.Msg, 8)
+	action := m.action
+	options := m.finalOptions()
+	extra := m.extra
+	go func(ch chan tea.Msg) {
+		report, err := executeSyncInteractive(
+			action,
+			options,
+			extra,
+			func(rows []table.Row) {
+				ch <- syncExecutionPlanMsg{rows: rows}
+			},
+			func(line string) {
+				ch <- syncExecutionLogMsg{line: line}
+			},
+			func(phase string, complete, total int) {
+				ch <- syncExecutionStageMsg{phase: phase, complete: complete, total: total}
+			},
+		)
+		ch <- syncExecutionFinishedMsg{report: report, err: err}
+		close(ch)
+	}(m.runMsgs)
+	return waitForSyncInteractiveMsg(m.runMsgs)
+}
+
+func (m syncInteractiveModel) finalOptions() syncCommonOptions {
+	out := m.options
+	out.interactive = false
+	out.locales = sortedMapKeys(m.selectedLocales)
+	out.sourcePaths = sortedMapKeys(m.selectedFiles)
+	return out
+}
+
+func (m syncInteractiveModel) pendingExecutionRows() []table.Row {
+	m.table.SetColumns([]table.Column{
+		{Title: "Key", Width: 28},
+		{Title: "Locale", Width: 10},
+		{Title: "Status", Width: 14},
+		{Title: "Detail", Width: max(20, m.width-60)},
+	})
+	return []table.Row{{"-", "-", "pending", "preparing sync scope"}}
+}
+
+func (m syncInteractiveModel) executionRows() ([]table.Row, []string) {
+	if m.report == nil {
+		return m.pendingExecutionRows(), nil
+	}
+	type row struct {
+		key    string
+		locale string
+		status string
+		detail string
+	}
+	rows := make([]row, 0)
+	for _, entry := range m.report.Creates {
+		rows = append(rows, row{key: entry.Key, locale: entry.Locale, status: statusLabel("create", m.report, entry.ID()), detail: filepath.Base(entry.Namespace)})
+	}
+	for _, entry := range m.report.Updates {
+		rows = append(rows, row{key: entry.Key, locale: entry.Locale, status: statusLabel("update", m.report, entry.ID()), detail: filepath.Base(entry.Namespace)})
+	}
+	for _, id := range m.report.Unchanged {
+		rows = append(rows, row{key: id.Key, locale: id.Locale, status: "unchanged", detail: id.Context})
+	}
+	for _, conflict := range m.report.Conflicts {
+		rows = append(rows, row{key: conflict.ID.Key, locale: conflict.ID.Locale, status: "conflict", detail: conflict.Reason})
+	}
+	if m.runErr != nil && len(rows) == 0 {
+		rows = append(rows, row{key: "-", locale: "-", status: "failed", detail: m.runErr.Error()})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].locale == rows[j].locale {
+			return rows[i].key < rows[j].key
+		}
+		return rows[i].locale < rows[j].locale
+	})
+	out := make([]table.Row, 0, len(rows))
+	values := make([]string, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, table.Row{row.key, row.locale, row.status, row.detail})
+		values = append(values, row.locale+"\x00"+row.key)
+	}
+	if len(out) == 0 {
+		out = append(out, table.Row{"-", "-", "empty", "no entries matched"})
+	}
+	m.table.SetColumns([]table.Column{
+		{Title: "Key", Width: 28},
+		{Title: "Locale", Width: 10},
+		{Title: "Status", Width: 14},
+		{Title: "Detail", Width: max(20, m.width-60)},
+	})
+	return out, values
+}
+
+func statusLabel(base string, report *syncsvc.Report, id storage.EntryID) string {
+	for _, applied := range report.Applied {
+		if applied == id {
+			return "applied"
+		}
+	}
+	for _, skipped := range report.Skipped {
+		if skipped == id {
+			return "skipped"
+		}
+	}
+	return base
+}
+
+func waitForSyncInteractiveMsg(ch <-chan tea.Msg) tea.Cmd {
+	return func() tea.Msg {
+		msg, ok := <-ch
+		if !ok {
+			return nil
+		}
+		return msg
+	}
+}
+
+func executeSyncInteractive(
+	action string,
+	options syncCommonOptions,
+	extra syncInteractiveExtra,
+	plan func([]table.Row),
+	logf func(string),
+	progress func(phase string, complete, total int),
+) (syncsvc.Report, error) {
+	log := func(line string) {
+		if logf != nil {
+			logf(line)
+		}
+	}
+	if progress != nil {
+		progress("initializing", 0, 5)
+	}
+	log("initializing sync runtime")
+	rt, err := newSyncRuntime(options.configPath)
+	if err != nil {
+		return syncsvc.Report{}, fmt.Errorf("initialize sync runtime: %w", err)
+	}
+
+	readReq := syncsvc.LocalReadRequest{
+		Locales:     options.locales,
+		SourcePaths: options.sourcePaths,
+	}
+	if progress != nil {
+		progress("loading local entries", 1, 5)
+	}
+	log(fmt.Sprintf("loading local entries: locales=%d files=%d", len(options.locales), len(options.sourcePaths)))
+	if plan != nil {
+		rows, err := executionPlanRows(action, rt, readReq)
+		if err != nil {
+			return syncsvc.Report{}, fmt.Errorf("build execution plan: %w", err)
+		}
+		plan(rows)
+		log(fmt.Sprintf("queued entries: %d", len(rows)))
+	}
+	scope, err := rt.resolveScope(readReq)
+	if err != nil {
+		return syncsvc.Report{}, fmt.Errorf("resolve sync scope: %w", err)
+	}
+	log(fmt.Sprintf("resolved scope entries: %d", len(scope.Entries)))
+
+	if progress != nil {
+		progress("resolving scope", 2, 5)
+		progress("syncing remote", 3, 5)
+	}
+	log("syncing remote storage")
+	switch action {
+	case "pull":
+		report, err := rt.svc.Pull(context.Background(), syncsvc.PullInput{
+			Adapter: rt.remote,
+			Local:   rt.local,
+			Request: storage.PullRequest{
+				Locales:    options.locales,
+				Namespaces: append([]string(nil), options.sourcePaths...),
+			},
+			Read: readReq,
+			Options: syncsvc.PullOptions{
+				DryRun:                options.dryRun,
+				FailOnConflict:        options.failOnConflict,
+				ApplyCuratedOverDraft: options.applyCuratedOverDraft,
+			},
+			Scope: scope,
+		})
+		if progress != nil {
+			progress("finalizing", 5, 5)
+		}
+		log(fmt.Sprintf("pull result: creates=%d updates=%d conflicts=%d warnings=%d", len(report.Creates), len(report.Updates), len(report.Conflicts), len(report.Warnings)))
+		return report, err
+	default:
+		report, err := rt.svc.Push(context.Background(), syncsvc.PushInput{
+			Adapter: rt.remote,
+			Local:   rt.local,
+			Read:    readReq,
+			Options: syncsvc.PushOptions{
+				DryRun:         options.dryRun,
+				FailOnConflict: options.failOnConflict,
+				ForceConflicts: extra.forceConflicts,
+			},
+			Scope: scope,
+		})
+		if progress != nil {
+			progress("finalizing", 5, 5)
+		}
+		log(fmt.Sprintf("push result: creates=%d updates=%d applied=%d conflicts=%d warnings=%d", len(report.Creates), len(report.Updates), len(report.Applied), len(report.Conflicts), len(report.Warnings)))
+		return report, err
+	}
+}
+
+func executionPlanRows(action string, rt *syncRuntime, readReq syncsvc.LocalReadRequest) ([]table.Row, error) {
+	var (
+		snapshot storage.CatalogSnapshot
+		err      error
+	)
+	switch action {
+	case "pull":
+		snapshot, err = rt.local.ReadSnapshot(context.Background(), readReq)
+	default:
+		snapshot, err = rt.local.BuildPushSnapshot(context.Background(), readReq)
+	}
+	if err != nil {
+		return nil, err
+	}
+	rows := make([]table.Row, 0, len(snapshot.Entries))
+	sort.Slice(snapshot.Entries, func(i, j int) bool {
+		if snapshot.Entries[i].Locale == snapshot.Entries[j].Locale {
+			return snapshot.Entries[i].Key < snapshot.Entries[j].Key
+		}
+		return snapshot.Entries[i].Locale < snapshot.Entries[j].Locale
+	})
+	for _, entry := range snapshot.Entries {
+		rows = append(rows, table.Row{
+			entry.Key,
+			entry.Locale,
+			"queued",
+			filepath.Base(entry.Namespace),
+		})
+	}
+	if len(rows) == 0 {
+		rows = append(rows, table.Row{"-", "-", "empty", "no local entries matched"})
+	}
+	return rows, nil
+}
+
+func (m syncInteractiveModel) catalogLocales() []string {
+	locales := make([]string, 0, len(m.catalog.TargetLocales)+1)
+	for _, target := range m.catalog.TargetLocales {
+		locales = append(locales, target.Locale)
+	}
+	if m.action == "push" && strings.TrimSpace(m.catalog.SourceLocale) != "" && !containsString(locales, m.catalog.SourceLocale) {
+		locales = append(locales, m.catalog.SourceLocale)
+	}
+	sort.Strings(locales)
+	return locales
+}
+
+func (m syncInteractiveModel) catalogFiles() []string {
+	files := make([]string, 0, len(m.catalog.Files))
+	for _, file := range m.catalog.Files {
+		files = append(files, filepath.Clean(file.Path))
+	}
+	sort.Strings(files)
+	return files
+}
+
+func (m syncInteractiveModel) catalogFile(path string) runsvc.SelectionFile {
+	for _, file := range m.catalog.Files {
+		if filepath.Clean(file.Path) == filepath.Clean(path) {
+			return file
+		}
+	}
+	return runsvc.SelectionFile{Path: path}
+}
+
+func (m syncInteractiveModel) catalogFileKeyCount(path string) int {
+	maxTasks := 0
+	for _, task := range m.catalog.TaskIndex {
+		if filepath.Clean(task.SourcePath) != filepath.Clean(path) {
+			continue
+		}
+		if task.TaskCount > maxTasks {
+			maxTasks = task.TaskCount
+		}
+	}
+	return maxTasks
+}
+
+func nextSyncOutput(current string) string {
+	switch strings.ToLower(strings.TrimSpace(current)) {
+	case "json":
+		return "markdown"
+	case "markdown", "md":
+		return "text"
+	default:
+		return "json"
+	}
+}
+
+func checkboxTitle(selected bool, label string) string {
+	return checkboxCell(selected) + " " + label
+}
+
+func checkboxCell(selected bool) string {
+	if selected {
+		return "[x]"
+	}
+	return "[ ]"
+}
+
+func toggleStringSet(values map[string]struct{}, value string) {
+	if _, ok := values[value]; ok {
+		delete(values, value)
+		return
+	}
+	values[value] = struct{}{}
+}
+
+func lowerStrings(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		out = append(out, strings.ToLower(value))
+	}
+	return out
+}
+
+func containsString(values []string, needle string) bool {
+	for _, value := range values {
+		if filepath.Clean(value) == filepath.Clean(needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/sync_interactive_test.go
+++ b/cmd/sync_interactive_test.go
@@ -1,10 +1,13 @@
 package cmd
 
 import (
+	"bytes"
 	"testing"
 
+	"charm.land/bubbles/v2/list"
 	tea "charm.land/bubbletea/v2"
 	"github.com/quiet-circles/hyperlocalise/internal/i18n/runsvc"
+	"github.com/quiet-circles/hyperlocalise/internal/i18n/syncsvc"
 )
 
 func TestSyncInteractiveToggleAllFilesSelectsEveryFile(t *testing.T) {
@@ -58,7 +61,7 @@ func TestSyncInteractiveToggleAllFilesClearsEveryFile(t *testing.T) {
 	}
 }
 
-func TestSyncInteractivePushLocalesAlwaysSelectSource(t *testing.T) {
+func TestSyncInteractivePushDefaultsExcludeSourceLocale(t *testing.T) {
 	model := newSyncInteractiveModel(
 		"push",
 		runsvc.SelectionCatalog{
@@ -76,15 +79,15 @@ func TestSyncInteractivePushLocalesAlwaysSelectSource(t *testing.T) {
 	if len(locales) != 2 || locales[0] != "en" || locales[1] != "fr" {
 		t.Fatalf("expected source locale listed in push selector, got %#v", locales)
 	}
-	if _, ok := model.selectedLocales["en"]; !ok {
-		t.Fatalf("expected source locale selected by default for push, got %#v", model.selectedLocales)
+	if _, ok := model.selectedLocales["en"]; ok {
+		t.Fatalf("did not expect source locale selected by default for push, got %#v", model.selectedLocales)
 	}
 	if _, ok := model.selectedLocales["fr"]; !ok {
 		t.Fatalf("expected target locale selected by default for push, got %#v", model.selectedLocales)
 	}
 }
 
-func TestSyncInteractivePushSourceLocaleCannotBeDeselected(t *testing.T) {
+func TestSyncInteractivePushSourceLocaleCanBeToggled(t *testing.T) {
 	model := newSyncInteractiveModel(
 		"push",
 		runsvc.SelectionCatalog{
@@ -100,9 +103,87 @@ func TestSyncInteractivePushSourceLocaleCannotBeDeselected(t *testing.T) {
 	model.step = syncInteractiveStepLocale
 	model.refresh()
 
-	nextModel, _ := model.Update(tea.KeyPressMsg(tea.Key{Text: " "}))
+	nextModel, _ := model.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeySpace, Text: " "}))
 	typed := nextModel.(syncInteractiveModel)
 	if _, ok := typed.selectedLocales["en"]; !ok {
-		t.Fatalf("expected source locale to remain selected, got %#v", typed.selectedLocales)
+		t.Fatalf("expected source locale to be selectable, got %#v", typed.selectedLocales)
+	}
+
+	nextModel, _ = typed.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeySpace, Text: " "}))
+	typed = nextModel.(syncInteractiveModel)
+	if _, ok := typed.selectedLocales["en"]; ok {
+		t.Fatalf("expected source locale to be deselectable, got %#v", typed.selectedLocales)
+	}
+}
+
+func TestSyncInteractiveBackClearsListFilterBeforeLeavingStep(t *testing.T) {
+	model := newSyncInteractiveModel(
+		"pull",
+		runsvc.SelectionCatalog{
+			ConfigPath: "/tmp/i18n.jsonc",
+			TargetLocales: []runsvc.SelectionTargetLocale{
+				{Locale: "fr"},
+			},
+		},
+		syncCommonOptions{configPath: "/tmp/i18n.jsonc"},
+		syncInteractiveExtra{},
+	)
+	model.step = syncInteractiveStepOptions
+	model.refresh()
+	model.list.SetFilterText("dry")
+	model.list.SetFilterState(list.Filtering)
+
+	nextModel, _ := model.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEscape }))
+	typed := nextModel.(syncInteractiveModel)
+	if typed.step != syncInteractiveStepOptions {
+		t.Fatalf("expected to stay on options step, got %v", typed.step)
+	}
+	if typed.list.SettingFilter() || typed.list.IsFiltered() {
+		t.Fatalf("expected filter to be cleared")
+	}
+}
+
+func TestSyncInteractiveQuitDoesNotExitWhileTypingListFilter(t *testing.T) {
+	model := newSyncInteractiveModel(
+		"pull",
+		runsvc.SelectionCatalog{
+			ConfigPath: "/tmp/i18n.jsonc",
+			TargetLocales: []runsvc.SelectionTargetLocale{
+				{Locale: "fr"},
+			},
+		},
+		syncCommonOptions{configPath: "/tmp/i18n.jsonc"},
+		syncInteractiveExtra{},
+	)
+	model.step = syncInteractiveStepOptions
+	model.refresh()
+	model.list.SetFilterState(list.Filtering)
+
+	nextModel, _ := model.Update(tea.KeyPressMsg(tea.Key{Text: "q"}))
+	typed := nextModel.(syncInteractiveModel)
+	if typed.done {
+		t.Fatalf("expected filter input to consume q instead of quitting")
+	}
+	if got := typed.list.FilterInput.Value(); got != "q" {
+		t.Fatalf("expected q to be added to filter input, got %q", got)
+	}
+}
+
+func TestFinalizeSyncInteractiveResultWritesStructuredReport(t *testing.T) {
+	model := syncInteractiveModel{
+		options: syncCommonOptions{output: "json"},
+		report:  &syncsvc.Report{Action: "push"},
+	}
+
+	var out bytes.Buffer
+	result, err := finalizeSyncInteractiveResult(model, &out)
+	if err != nil {
+		t.Fatalf("finalizeSyncInteractiveResult() error = %v", err)
+	}
+	if result.execute {
+		t.Fatalf("expected interactive result to avoid re-execution")
+	}
+	if got := out.String(); got == "" || !bytes.Contains([]byte(got), []byte(`"action": "push"`)) {
+		t.Fatalf("expected JSON report output, got %q", got)
 	}
 }

--- a/cmd/sync_interactive_test.go
+++ b/cmd/sync_interactive_test.go
@@ -1,0 +1,108 @@
+package cmd
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/quiet-circles/hyperlocalise/internal/i18n/runsvc"
+)
+
+func TestSyncInteractiveToggleAllFilesSelectsEveryFile(t *testing.T) {
+	model := newSyncInteractiveModel(
+		"pull",
+		runsvc.SelectionCatalog{
+			ConfigPath: "/tmp/i18n.jsonc",
+			Files: []runsvc.SelectionFile{
+				{Path: "/tmp/content/en/a.json"},
+				{Path: "/tmp/content/en/b.json"},
+			},
+		},
+		syncCommonOptions{configPath: "/tmp/i18n.jsonc"},
+		syncInteractiveExtra{},
+	)
+	model.step = syncInteractiveStepFile
+	model.selectedFiles = map[string]struct{}{}
+	model.refresh()
+
+	nextModel, _ := model.Update(tea.KeyPressMsg(tea.Key{Text: "a"}))
+	typed := nextModel.(syncInteractiveModel)
+	if len(typed.selectedFiles) != 2 {
+		t.Fatalf("expected all files selected, got %#v", typed.selectedFiles)
+	}
+}
+
+func TestSyncInteractiveToggleAllFilesClearsEveryFile(t *testing.T) {
+	model := newSyncInteractiveModel(
+		"push",
+		runsvc.SelectionCatalog{
+			ConfigPath: "/tmp/i18n.jsonc",
+			Files: []runsvc.SelectionFile{
+				{Path: "/tmp/content/en/a.json"},
+				{Path: "/tmp/content/en/b.json"},
+			},
+		},
+		syncCommonOptions{configPath: "/tmp/i18n.jsonc"},
+		syncInteractiveExtra{},
+	)
+	model.step = syncInteractiveStepFile
+	model.selectedFiles = map[string]struct{}{
+		"/tmp/content/en/a.json": {},
+		"/tmp/content/en/b.json": {},
+	}
+	model.refresh()
+
+	nextModel, _ := model.Update(tea.KeyPressMsg(tea.Key{Text: "a"}))
+	typed := nextModel.(syncInteractiveModel)
+	if len(typed.selectedFiles) != 0 {
+		t.Fatalf("expected all files cleared, got %#v", typed.selectedFiles)
+	}
+}
+
+func TestSyncInteractivePushLocalesAlwaysSelectSource(t *testing.T) {
+	model := newSyncInteractiveModel(
+		"push",
+		runsvc.SelectionCatalog{
+			ConfigPath:   "/tmp/i18n.jsonc",
+			SourceLocale: "en",
+			TargetLocales: []runsvc.SelectionTargetLocale{
+				{Locale: "fr"},
+			},
+		},
+		syncCommonOptions{configPath: "/tmp/i18n.jsonc"},
+		syncInteractiveExtra{},
+	)
+
+	locales := model.catalogLocales()
+	if len(locales) != 2 || locales[0] != "en" || locales[1] != "fr" {
+		t.Fatalf("expected source locale listed in push selector, got %#v", locales)
+	}
+	if _, ok := model.selectedLocales["en"]; !ok {
+		t.Fatalf("expected source locale selected by default for push, got %#v", model.selectedLocales)
+	}
+	if _, ok := model.selectedLocales["fr"]; !ok {
+		t.Fatalf("expected target locale selected by default for push, got %#v", model.selectedLocales)
+	}
+}
+
+func TestSyncInteractivePushSourceLocaleCannotBeDeselected(t *testing.T) {
+	model := newSyncInteractiveModel(
+		"push",
+		runsvc.SelectionCatalog{
+			ConfigPath:   "/tmp/i18n.jsonc",
+			SourceLocale: "en",
+			TargetLocales: []runsvc.SelectionTargetLocale{
+				{Locale: "fr"},
+			},
+		},
+		syncCommonOptions{configPath: "/tmp/i18n.jsonc"},
+		syncInteractiveExtra{},
+	)
+	model.step = syncInteractiveStepLocale
+	model.refresh()
+
+	nextModel, _ := model.Update(tea.KeyPressMsg(tea.Key{Text: " "}))
+	typed := nextModel.(syncInteractiveModel)
+	if _, ok := typed.selectedLocales["en"]; !ok {
+		t.Fatalf("expected source locale to remain selected, got %#v", typed.selectedLocales)
+	}
+}

--- a/cmd/sync_interactive_test.go
+++ b/cmd/sync_interactive_test.go
@@ -133,7 +133,7 @@ func TestSyncInteractiveBackClearsListFilterBeforeLeavingStep(t *testing.T) {
 	model.list.SetFilterText("dry")
 	model.list.SetFilterState(list.Filtering)
 
-	nextModel, _ := model.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEscape }))
+	nextModel, _ := model.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEscape}))
 	typed := nextModel.(syncInteractiveModel)
 	if typed.step != syncInteractiveStepOptions {
 		t.Fatalf("expected to stay on options step, got %v", typed.step)

--- a/cmd/sync_pull.go
+++ b/cmd/sync_pull.go
@@ -16,25 +16,44 @@ func newSyncPullCmd() *cobra.Command {
 		Short:        "pull latest curated translations from remote storage",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if o.interactive {
+				result, err := runSyncInteractiveWizard("pull", o, syncInteractiveExtra{}, cmd.OutOrStdout())
+				if err != nil {
+					return err
+				}
+				if !result.execute {
+					return nil
+				}
+				o = result.options
+			}
+
 			rt, err := newSyncRuntime(o.configPath)
 			if err != nil {
 				return fmt.Errorf("initialize sync runtime: %w", err)
+			}
+			readReq := syncsvc.LocalReadRequest{
+				Locales:     o.locales,
+				SourcePaths: o.sourcePaths,
+			}
+			scope, err := rt.resolveScope(readReq)
+			if err != nil {
+				return fmt.Errorf("resolve sync scope: %w", err)
 			}
 
 			report, err := rt.svc.Pull(backgroundContext(), syncsvc.PullInput{
 				Adapter: rt.remote,
 				Local:   rt.local,
 				Request: storage.PullRequest{
-					Locales: o.locales,
+					Locales:    o.locales,
+					Namespaces: append([]string(nil), o.sourcePaths...),
 				},
-				Read: syncsvc.LocalReadRequest{
-					Locales: o.locales,
-				},
+				Read: readReq,
 				Options: syncsvc.PullOptions{
 					DryRun:                o.dryRun,
 					FailOnConflict:        o.failOnConflict,
 					ApplyCuratedOverDraft: o.applyCuratedOverDraft,
 				},
+				Scope: scope,
 			})
 			if writeErr := writeSyncReport(cmd, report, o.output); writeErr != nil {
 				return fmt.Errorf("write sync pull report: %w", writeErr)

--- a/cmd/sync_push.go
+++ b/cmd/sync_push.go
@@ -16,22 +16,41 @@ func newSyncPushCmd() *cobra.Command {
 		Short:        "push local translation changes to remote storage",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if o.interactive {
+				result, err := runSyncInteractiveWizard("push", o, syncInteractiveExtra{forceConflicts: forceConflicts}, cmd.OutOrStdout())
+				if err != nil {
+					return err
+				}
+				if !result.execute {
+					return nil
+				}
+				o = result.options
+				forceConflicts = result.extra.forceConflicts
+			}
+
 			rt, err := newSyncRuntime(o.configPath)
 			if err != nil {
 				return fmt.Errorf("initialize sync runtime: %w", err)
+			}
+			readReq := syncsvc.LocalReadRequest{
+				Locales:     o.locales,
+				SourcePaths: o.sourcePaths,
+			}
+			scope, err := rt.resolveScope(readReq)
+			if err != nil {
+				return fmt.Errorf("resolve sync scope: %w", err)
 			}
 
 			report, err := rt.svc.Push(backgroundContext(), syncsvc.PushInput{
 				Adapter: rt.remote,
 				Local:   rt.local,
-				Read: syncsvc.LocalReadRequest{
-					Locales: o.locales,
-				},
+				Read:    readReq,
 				Options: syncsvc.PushOptions{
 					DryRun:         o.dryRun,
 					FailOnConflict: o.failOnConflict,
 					ForceConflicts: forceConflicts,
 				},
+				Scope: scope,
 			})
 			if writeErr := writeSyncReport(cmd, report, o.output); writeErr != nil {
 				return fmt.Errorf("write sync push report: %w", writeErr)

--- a/docs/commands/sync-pull.mdx
+++ b/docs/commands/sync-pull.mdx
@@ -19,19 +19,22 @@ hyperlocalise sync pull [--config <path>] [flags]
 
 `sync pull` defaults to dry-run mode. Start by reviewing the report, then rerun with `--dry-run=false`.
 
+If you use `--interactive`, the TUI lets you choose locales, files, and flags before running. Choosing `--output json` or `--output markdown` prints the final report after the TUI exits.
+
 ## Flags
 
 - `--config`: config path
 - `--locale`: target locale(s), repeatable
 - `--dry-run`: preview only (default `true`)
-- `--output`: `text` or `json`
+- `--output`: `text`, `json`, or `markdown`
 - `--fail-on-conflict`: return error when conflicts are detected (default `true`)
 - `--apply-curated-over-draft`: allow curated remote values to replace local draft values (default `true`)
+- `--interactive`, `-i`: launch a TTY selector for locales, files, and flags
 
 ## Example
 
 ```bash
-hyperlocalise sync pull --locale es-ES --output json
+hyperlocalise sync pull --locale es-ES --output markdown
 ```
 
 See [conflict handling](/troubleshooting/conflicts) for resolution strategy.

--- a/docs/commands/sync-push.mdx
+++ b/docs/commands/sync-push.mdx
@@ -19,14 +19,17 @@ hyperlocalise sync push [--config <path>] [flags]
 
 `sync push` defaults to dry-run mode and conflict failure.
 
+If you use `--interactive`, the TUI starts with target locales selected by default. The source locale is available as an explicit opt-in when your adapter or workflow needs it. Choosing `--output json` or `--output markdown` prints the final report after the TUI exits.
+
 ## Flags
 
 - `--config`: config path
 - `--locale`: target locale(s), repeatable
 - `--dry-run`: preview only (default `true`)
-- `--output`: `text` or `json`
+- `--output`: `text`, `json`, or `markdown`
 - `--fail-on-conflict`: return error when conflicts are detected (default `true`)
 - `--force-conflicts`: allow overwrite for mismatch cases where policy allows (default `false`)
+- `--interactive`, `-i`: launch a TTY selector for locales, files, and flags
 
 ## Example
 

--- a/i18n.jsonc
+++ b/i18n.jsonc
@@ -35,6 +35,14 @@
         },
       ],
     },
+    "tests_key_value_json": {
+      "files": [
+        {
+          "from": "tests/key_value_json/en-US.json",
+          "to": "tests/key_value_json/[locale].json",
+        },
+      ],
+    },
     "tests_jsonc": {
       "files": [
         {
@@ -148,6 +156,7 @@
       "buckets": [
         "tests_arb",
         "tests_json",
+        "tests_key_value_json",
         "tests_jsonc",
         "tests_formatjs",
         "tests_xlf",
@@ -210,6 +219,13 @@
         "profile": "ollama",
       },
     ],
+  },
+  "storage": {
+    "adapter": "poeditor",
+    "config": {
+      "projectID": "824396",
+      "apiTokenEnv": "POEDITOR_API_TOKEN",
+    },
   },
   // Optional local cache foundation for run pipeline (disabled by default).
   // "cache": {

--- a/internal/i18n/localstore/jsonstore.go
+++ b/internal/i18n/localstore/jsonstore.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -14,12 +16,23 @@ import (
 	"github.com/quiet-circles/hyperlocalise/internal/i18n/pathresolver"
 	"github.com/quiet-circles/hyperlocalise/internal/i18n/storage"
 	"github.com/quiet-circles/hyperlocalise/internal/i18n/syncsvc"
+	"github.com/quiet-circles/hyperlocalise/internal/i18n/translationfileparser"
+	"github.com/tidwall/jsonc"
 )
 
 type JSONStore struct {
-	cfg           *config.I18NConfig
-	localePattern string
-	namespace     string
+	cfg                *config.I18NConfig
+	mappings           []fileMapping
+	mappingByNamespace map[string]fileMapping
+}
+
+type fileMapping struct {
+	SourcePattern string
+	SourcePath    string
+	TargetPattern string
+	Namespace     string
+	SourceEntries map[string]string
+	EntryContext  map[string]string
 }
 
 func NewJSONStore(cfg *config.I18NConfig) (*JSONStore, error) {
@@ -27,12 +40,21 @@ func NewJSONStore(cfg *config.I18NConfig) (*JSONStore, error) {
 		return nil, fmt.Errorf("new json store: config is nil")
 	}
 
-	localePattern, namespace, err := resolveLocalePattern(cfg.Buckets)
+	mappings, err := buildFileMappings(cfg)
 	if err != nil {
 		return nil, err
 	}
 
-	return &JSONStore{cfg: cfg, localePattern: localePattern, namespace: namespace}, nil
+	mappingByNamespace := make(map[string]fileMapping, len(mappings))
+	for _, mapping := range mappings {
+		mappingByNamespace[mapping.Namespace] = mapping
+	}
+
+	return &JSONStore{
+		cfg:                cfg,
+		mappings:           mappings,
+		mappingByNamespace: mappingByNamespace,
+	}, nil
 }
 
 func (s *JSONStore) ReadSnapshot(ctx context.Context, req syncsvc.LocalReadRequest) (storage.CatalogSnapshot, error) {
@@ -40,43 +62,116 @@ func (s *JSONStore) ReadSnapshot(ctx context.Context, req syncsvc.LocalReadReque
 }
 
 func (s *JSONStore) BuildPushSnapshot(ctx context.Context, req syncsvc.LocalReadRequest) (storage.CatalogSnapshot, error) {
-	return s.readSnapshot(ctx, req)
+	snapshot, err := s.readSnapshot(ctx, req)
+	if err != nil {
+		return storage.CatalogSnapshot{}, err
+	}
+	if s.cfg.Storage == nil || !strings.EqualFold(strings.TrimSpace(s.cfg.Storage.Adapter), "poeditor") {
+		return snapshot, nil
+	}
+	if !containsLocale(req.Locales, s.cfg.Locales.Source) {
+		return snapshot, nil
+	}
+
+	selectedMappings, err := s.selectedMappings(req.SourcePaths)
+	if err != nil {
+		return storage.CatalogSnapshot{}, err
+	}
+	for _, mapping := range selectedMappings {
+		for key, value := range mapping.SourceEntries {
+			snapshot.Entries = append(snapshot.Entries, storage.Entry{
+				Key:       key,
+				Context:   mapping.EntryContext[key],
+				Locale:    s.cfg.Locales.Source,
+				Value:     value,
+				Namespace: mapping.Namespace,
+				Provenance: storage.EntryProvenance{
+					Origin: storage.OriginHuman,
+					State:  storage.StateCurated,
+				},
+			})
+		}
+	}
+	return snapshot, nil
+}
+
+func containsLocale(locales []string, want string) bool {
+	want = strings.TrimSpace(want)
+	for _, locale := range locales {
+		if strings.TrimSpace(locale) == want {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *JSONStore) ResolveScope(req syncsvc.LocalReadRequest) (syncsvc.Scope, error) {
+	selectedMappings, err := s.selectedMappings(req.SourcePaths)
+	if err != nil {
+		return syncsvc.Scope{}, err
+	}
+	locales := s.selectedLocales(req.Locales)
+	scope := syncsvc.Scope{
+		Entries: make(map[storage.EntryID]syncsvc.ScopedEntry),
+	}
+
+	for _, mapping := range selectedMappings {
+		for key, context := range mapping.EntryContext {
+			for _, locale := range locales {
+				scope.Entries[storage.EntryID{
+					Key:     key,
+					Context: context,
+					Locale:  locale,
+				}] = syncsvc.ScopedEntry{Namespace: mapping.Namespace}
+			}
+		}
+	}
+
+	return scope, nil
 }
 
 func (s *JSONStore) readSnapshot(_ context.Context, req syncsvc.LocalReadRequest) (storage.CatalogSnapshot, error) {
-	locales := req.Locales
-	if len(locales) == 0 {
-		locales = append([]string(nil), s.cfg.Locales.Targets...)
+	locales := s.selectedLocales(req.Locales)
+	selectedMappings, err := s.selectedMappings(req.SourcePaths)
+	if err != nil {
+		return storage.CatalogSnapshot{}, err
 	}
 
 	var entries []storage.Entry
-	for _, locale := range locales {
-		path := s.localePath(locale)
-		valueMap, err := readLocaleValues(path)
-		if err != nil {
-			return storage.CatalogSnapshot{}, fmt.Errorf("read locale file %q: %w", path, err)
-		}
+	for _, mapping := range selectedMappings {
+		for _, locale := range locales {
+			path, err := mapping.targetPath(s.cfg.Locales.Source, locale)
+			if err != nil {
+				return storage.CatalogSnapshot{}, err
+			}
+			valueMap, err := readLocaleValues(path)
+			if err != nil {
+				return storage.CatalogSnapshot{}, fmt.Errorf("read locale file %q: %w", path, err)
+			}
 
-		metaMap, err := readLocaleMeta(metaPathFor(path))
-		if err != nil {
-			return storage.CatalogSnapshot{}, fmt.Errorf("read locale metadata %q: %w", metaPathFor(path), err)
-		}
+			metaMap, err := readLocaleMeta(metaPathFor(path))
+			if err != nil {
+				return storage.CatalogSnapshot{}, fmt.Errorf("read locale metadata %q: %w", metaPathFor(path), err)
+			}
 
-		for key, value := range valueMap {
-			entry := storage.Entry{
-				Key:       key,
-				Locale:    locale,
-				Value:     value,
-				Namespace: s.namespace,
+			for key, value := range valueMap {
+				context := mapping.EntryContext[key]
+				entry := storage.Entry{
+					Key:       key,
+					Context:   context,
+					Locale:    locale,
+					Value:     value,
+					Namespace: mapping.Namespace,
+				}
+				if meta, ok := metaMap[entryMetaID(key, context)]; ok {
+					entry.Provenance = meta.Provenance
+					entry.Remote = meta.Remote
+				}
+				if strings.TrimSpace(entry.Provenance.Origin) == "" {
+					entry.Provenance.Origin = storage.OriginUnknown
+				}
+				entries = append(entries, entry)
 			}
-			if meta, ok := metaMap[entryMetaID(key, "")]; ok {
-				entry.Provenance = meta.Provenance
-				entry.Remote = meta.Remote
-			}
-			if strings.TrimSpace(entry.Provenance.Origin) == "" {
-				entry.Provenance.Origin = storage.OriginUnknown
-			}
-			entries = append(entries, entry)
 		}
 	}
 
@@ -94,8 +189,18 @@ func (s *JSONStore) ApplyPull(_ context.Context, plan syncsvc.ApplyPullPlan) (sy
 
 	applied := make([]storage.EntryID, 0)
 
-	for locale, entries := range byLocale {
-		path := s.localePath(locale)
+	byTargetPath := make(map[string][]storage.Entry)
+	for locale, localeEntries := range byLocale {
+		for _, entry := range localeEntries {
+			path, err := s.targetPathForEntry(locale, entry)
+			if err != nil {
+				return syncsvc.ApplyResult{}, err
+			}
+			byTargetPath[path] = append(byTargetPath[path], entry)
+		}
+	}
+
+	for path, entries := range byTargetPath {
 		values, err := readLocaleValues(path)
 		if err != nil {
 			return syncsvc.ApplyResult{}, fmt.Errorf("read locale file %q before apply: %w", path, err)
@@ -126,31 +231,241 @@ func (s *JSONStore) ApplyPull(_ context.Context, plan syncsvc.ApplyPullPlan) (sy
 	return syncsvc.ApplyResult{Applied: applied}, nil
 }
 
-func (s *JSONStore) localePath(locale string) string {
-	return pathresolver.ResolveTargetPath(s.localePattern, s.cfg.Locales.Source, locale)
+func (s *JSONStore) selectedLocales(locales []string) []string {
+	if len(locales) == 0 {
+		return append([]string(nil), s.cfg.Locales.Targets...)
+	}
+	return append([]string(nil), locales...)
 }
 
-func resolveLocalePattern(buckets map[string]config.BucketConfig) (string, string, error) {
-	if len(buckets) == 0 {
-		return "", "", fmt.Errorf("new json store: buckets is required")
+func (s *JSONStore) selectedMappings(sourcePaths []string) ([]fileMapping, error) {
+	if len(sourcePaths) == 0 {
+		return append([]fileMapping(nil), s.mappings...), nil
 	}
 
-	names := make([]string, 0, len(buckets))
-	for name := range buckets {
-		names = append(names, name)
+	requested := make(map[string]struct{}, len(sourcePaths))
+	for _, path := range sourcePaths {
+		trimmed := strings.TrimSpace(path)
+		if trimmed == "" {
+			return nil, fmt.Errorf("sync file value must not be empty")
+		}
+		requested[filepath.Clean(trimmed)] = struct{}{}
 	}
-	sort.Strings(names)
 
-	for _, name := range names {
-		bucket := buckets[name]
+	selected := make([]fileMapping, 0, len(requested))
+	for _, mapping := range s.mappings {
+		if _, ok := requested[filepath.Clean(mapping.SourcePath)]; ok {
+			selected = append(selected, mapping)
+			delete(requested, filepath.Clean(mapping.SourcePath))
+		}
+	}
+	if len(requested) > 0 {
+		unmatched := make([]string, 0, len(requested))
+		for path := range requested {
+			unmatched = append(unmatched, path)
+		}
+		sort.Strings(unmatched)
+		if len(unmatched) == 1 {
+			return nil, fmt.Errorf("unknown sync source file %q", unmatched[0])
+		}
+		return nil, fmt.Errorf("unknown sync source files: %s", strings.Join(unmatched, ", "))
+	}
+
+	return selected, nil
+}
+
+func (s *JSONStore) targetPathForEntry(locale string, entry storage.Entry) (string, error) {
+	namespace := strings.TrimSpace(entry.Namespace)
+	if namespace == "" {
+		if len(s.mappings) == 1 {
+			return s.mappings[0].targetPath(s.cfg.Locales.Source, locale)
+		}
+		return "", fmt.Errorf("apply pull entry %s has no namespace", entry.ID())
+	}
+	mapping, ok := s.mappingByNamespace[namespace]
+	if !ok {
+		return "", fmt.Errorf("apply pull entry %s references unknown namespace %q", entry.ID(), namespace)
+	}
+	return mapping.targetPath(s.cfg.Locales.Source, locale)
+}
+
+func (m fileMapping) targetPath(sourceLocale, locale string) (string, error) {
+	resolvedPattern := pathresolver.ResolveTargetPath(m.TargetPattern, sourceLocale, locale)
+	return resolveTargetPath(m.SourcePattern, resolvedPattern, m.SourcePath)
+}
+
+func buildFileMappings(cfg *config.I18NConfig) ([]fileMapping, error) {
+	parser := translationfileparser.NewDefaultStrategy()
+	mappings := make([]fileMapping, 0)
+
+	bucketNames := make([]string, 0, len(cfg.Buckets))
+	for name := range cfg.Buckets {
+		bucketNames = append(bucketNames, name)
+	}
+	sort.Strings(bucketNames)
+
+	for _, bucketName := range bucketNames {
+		bucket := cfg.Buckets[bucketName]
 		for _, file := range bucket.Files {
-			if strings.TrimSpace(file.To) != "" {
-				return file.To, file.From, nil
+			sourcePattern := pathresolver.ResolveSourcePath(file.From, cfg.Locales.Source)
+			sourcePaths, err := resolveSourcePaths(sourcePattern)
+			if err != nil {
+				return nil, fmt.Errorf("new json store: resolve source paths for %q: %w", sourcePattern, err)
+			}
+			if len(sourcePaths) == 0 {
+				return nil, fmt.Errorf("new json store: source pattern %q matched no files", sourcePattern)
+			}
+			for _, sourcePath := range sourcePaths {
+				sourceEntries, entryContext, err := readSourceEntries(parser, sourcePath)
+				if err != nil {
+					return nil, err
+				}
+				mappings = append(mappings, fileMapping{
+					SourcePattern: sourcePattern,
+					SourcePath:    filepath.Clean(sourcePath),
+					TargetPattern: file.To,
+					Namespace:     filepath.Clean(sourcePath),
+					SourceEntries: sourceEntries,
+					EntryContext:  entryContext,
+				})
 			}
 		}
 	}
 
-	return "", "", fmt.Errorf("new json store: buckets.*.files[].to is required")
+	return mappings, nil
+}
+
+func readSourceEntries(parser *translationfileparser.Strategy, sourcePath string) (map[string]string, map[string]string, error) {
+	content, err := os.ReadFile(sourcePath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("new json store: read source file %q: %w", sourcePath, err)
+	}
+	entries, entryContext, err := parser.ParseWithContext(sourcePath, content)
+	if err != nil {
+		return nil, nil, fmt.Errorf("new json store: parse source file %q: %w", sourcePath, err)
+	}
+	if entries == nil {
+		entries = map[string]string{}
+	}
+	if entryContext == nil {
+		entryContext = map[string]string{}
+	}
+	return entries, entryContext, nil
+}
+
+func resolveSourcePaths(sourcePattern string) ([]string, error) {
+	if !strings.ContainsAny(sourcePattern, "*?[") {
+		return []string{sourcePattern}, nil
+	}
+	if !strings.Contains(sourcePattern, "**") {
+		matches, err := filepath.Glob(sourcePattern)
+		if err != nil {
+			return nil, err
+		}
+		sort.Strings(matches)
+		return matches, nil
+	}
+
+	normalizedPattern := filepath.ToSlash(sourcePattern)
+	re, err := globToRegex(normalizedPattern)
+	if err != nil {
+		return nil, err
+	}
+
+	baseDir := baseDirForDoublestar(sourcePattern)
+	matches := make([]string, 0)
+	err = filepath.WalkDir(baseDir, func(candidate string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if re.MatchString(filepath.ToSlash(candidate)) {
+			matches = append(matches, candidate)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Strings(matches)
+	return matches, nil
+}
+
+func resolveTargetPath(sourcePattern, targetPattern, sourcePath string) (string, error) {
+	if !strings.ContainsAny(sourcePattern, "*?[") {
+		return targetPattern, nil
+	}
+	if !strings.ContainsAny(targetPattern, "*?[") {
+		return "", fmt.Errorf("target pattern %q must include glob tokens when source pattern %q includes globs", targetPattern, sourcePattern)
+	}
+	sourceBase := globBaseDir(sourcePattern)
+	targetBase := globBaseDir(targetPattern)
+	relative, err := filepath.Rel(sourceBase, sourcePath)
+	if err != nil {
+		return "", err
+	}
+	parentPrefix := ".." + string(filepath.Separator)
+	if relative == ".." || strings.HasPrefix(relative, parentPrefix) {
+		return "", fmt.Errorf("source path %q escapes source base %q", sourcePath, sourceBase)
+	}
+	return filepath.Join(targetBase, relative), nil
+}
+
+func baseDirForDoublestar(pattern string) string {
+	normalized := filepath.ToSlash(pattern)
+	idx := strings.Index(normalized, "**")
+	if idx == -1 {
+		return filepath.Dir(pattern)
+	}
+	prefix := strings.TrimSuffix(normalized[:idx], "/")
+	if prefix == "" {
+		return "."
+	}
+	return filepath.FromSlash(prefix)
+}
+
+func globBaseDir(pattern string) string {
+	idx := strings.IndexAny(filepath.ToSlash(pattern), "*?[")
+	if idx == -1 {
+		return filepath.Dir(pattern)
+	}
+	prefix := filepath.ToSlash(pattern)[:idx]
+	prefix = strings.TrimSuffix(prefix, "/")
+	if prefix == "" {
+		return "."
+	}
+	return filepath.FromSlash(prefix)
+}
+
+func globToRegex(pattern string) (*regexp.Regexp, error) {
+	var b strings.Builder
+	b.WriteString("^")
+	for i := 0; i < len(pattern); {
+		switch pattern[i] {
+		case '*':
+			if i+1 < len(pattern) && pattern[i+1] == '*' {
+				if i+2 < len(pattern) && pattern[i+2] == '/' {
+					b.WriteString("(?:.*/)?")
+					i += 3
+					continue
+				}
+				b.WriteString(".*")
+				i += 2
+				continue
+			}
+			b.WriteString("[^/]*")
+		case '?':
+			b.WriteString("[^/]")
+		default:
+			b.WriteString(regexp.QuoteMeta(pattern[i : i+1]))
+		}
+		i++
+	}
+	b.WriteString("$")
+	return regexp.Compile(b.String())
 }
 
 type entryMeta struct {
@@ -167,8 +482,15 @@ func readLocaleValues(path string) (map[string]string, error) {
 		return nil, err
 	}
 
-	var values map[string]string
-	if err := json.Unmarshal(content, &values); err != nil {
+	parser := translationfileparser.NewDefaultStrategy()
+	values, err := parser.Parse(path, content)
+	if err != nil {
+		if ext := strings.ToLower(filepath.Ext(path)); ext == ".json" || ext == ".jsonc" {
+			recovered, recoverErr := parseJSONEntriesLenient(path, content)
+			if recoverErr == nil {
+				return recovered, nil
+			}
+		}
 		return nil, err
 	}
 	if values == nil {
@@ -232,4 +554,81 @@ func writeJSONAtomic(path string, v any) error {
 	}
 
 	return nil
+}
+
+func parseJSONEntriesLenient(path string, content []byte) (map[string]string, error) {
+	decoded := content
+	if strings.EqualFold(filepath.Ext(path), ".jsonc") {
+		decoded = jsonc.ToJSON(content)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(decoded, &payload); err != nil {
+		return nil, err
+	}
+	if payload == nil {
+		return map[string]string{}, nil
+	}
+
+	out := map[string]string{}
+	if isStrictFormatJSTemplate(payload) {
+		for _, key := range sortedMapKeysAny(payload) {
+			message, ok := payload[key].(map[string]any)
+			if !ok {
+				continue
+			}
+			raw, ok := message["defaultMessage"].(string)
+			if ok {
+				out[key] = raw
+			}
+		}
+		return out, nil
+	}
+	collectNestedJSONStrings(out, "", payload)
+	return out, nil
+}
+
+func isStrictFormatJSTemplate(payload map[string]any) bool {
+	if len(payload) == 0 {
+		return false
+	}
+	for _, raw := range payload {
+		message, ok := raw.(map[string]any)
+		if !ok {
+			return false
+		}
+		defaultMessage, ok := message["defaultMessage"]
+		if !ok {
+			return false
+		}
+		if _, ok := defaultMessage.(string); !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func collectNestedJSONStrings(out map[string]string, prefix string, payload map[string]any) {
+	for _, key := range sortedMapKeysAny(payload) {
+		value := payload[key]
+		fullKey := key
+		if prefix != "" {
+			fullKey = prefix + "." + key
+		}
+		switch typed := value.(type) {
+		case string:
+			out[fullKey] = typed
+		case map[string]any:
+			collectNestedJSONStrings(out, fullKey, typed)
+		}
+	}
+}
+
+func sortedMapKeysAny(values map[string]any) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }

--- a/internal/i18n/localstore/jsonstore.go
+++ b/internal/i18n/localstore/jsonstore.go
@@ -116,7 +116,8 @@ func (s *JSONStore) ResolveScope(req syncsvc.LocalReadRequest) (syncsvc.Scope, e
 	}
 
 	for _, mapping := range selectedMappings {
-		for key, context := range mapping.EntryContext {
+		for key := range mapping.SourceEntries {
+			context := mapping.EntryContext[key]
 			for _, locale := range locales {
 				scope.Entries[storage.EntryID{
 					Key:     key,

--- a/internal/i18n/localstore/jsonstore_test.go
+++ b/internal/i18n/localstore/jsonstore_test.go
@@ -93,6 +93,120 @@ func TestJSONStoreBuildPushSnapshotUsesSameReadPath(t *testing.T) {
 	}
 }
 
+func TestJSONStoreBuildPushSnapshotParsesFormatJSJSON(t *testing.T) {
+	dir := t.TempDir()
+	langDir := filepath.Join(dir, "lang")
+	if err := os.MkdirAll(langDir, 0o755); err != nil {
+		t.Fatalf("mkdir lang dir: %v", err)
+	}
+	content := `{
+  "auth.signIn.title": {"defaultMessage": "Dang nhap"},
+  "billing.trialNotice": {"defaultMessage": "Ban dung thu den {date}."}
+}
+`
+	if err := os.WriteFile(filepath.Join(langDir, "fr.json"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write locale file: %v", err)
+	}
+
+	store := mustNewStore(t, filepath.Join(dir, "lang", "[locale].json"))
+	snap, err := store.BuildPushSnapshot(context.Background(), syncsvc.LocalReadRequest{Locales: []string{"fr"}})
+	if err != nil {
+		t.Fatalf("build push snapshot: %v", err)
+	}
+	if got := len(snap.Entries); got != 2 {
+		t.Fatalf("expected 2 entries, got %d", got)
+	}
+	if got := snap.Entries[0].Value; strings.TrimSpace(got) == "" {
+		t.Fatalf("expected non-empty parsed value")
+	}
+}
+
+func TestJSONStoreBuildPushSnapshotIncludesSourceLocaleForPOEditorWhenSelected(t *testing.T) {
+	dir := t.TempDir()
+	langDir := filepath.Join(dir, "lang")
+	if err := os.MkdirAll(langDir, 0o755); err != nil {
+		t.Fatalf("mkdir lang dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(langDir, "en.json"), []byte("{\"hello\":\"Hello\"}\n"), 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(langDir, "fr.json"), []byte("{\"hello\":\"Bonjour\"}\n"), 0o644); err != nil {
+		t.Fatalf("write target file: %v", err)
+	}
+
+	store, err := NewJSONStore(&config.I18NConfig{
+		Locales: config.LocaleConfig{Source: "en", Targets: []string{"fr"}},
+		Buckets: map[string]config.BucketConfig{
+			"json": {Files: []config.BucketFileMapping{{From: filepath.Join(langDir, "en.json"), To: filepath.Join(langDir, "[locale].json")}}},
+		},
+		Groups: map[string]config.GroupConfig{
+			"default": {Targets: []string{"fr"}, Buckets: []string{"json"}},
+		},
+		LLM: config.LLMConfig{
+			Profiles: map[string]config.LLMProfile{"default": {Provider: "openai", Model: "gpt-4.1-mini"}},
+		},
+		Storage: &config.StorageConfig{Adapter: "poeditor"},
+	})
+	if err != nil {
+		t.Fatalf("new json store: %v", err)
+	}
+
+	snap, err := store.BuildPushSnapshot(context.Background(), syncsvc.LocalReadRequest{Locales: []string{"fr", "en"}})
+	if err != nil {
+		t.Fatalf("build push snapshot: %v", err)
+	}
+	locales := make(map[string]struct{})
+	for _, entry := range snap.Entries {
+		locales[entry.Locale] = struct{}{}
+	}
+	if _, ok := locales["en"]; !ok {
+		t.Fatalf("expected source locale entry in push snapshot, got %+v", snap.Entries)
+	}
+	if _, ok := locales["fr"]; !ok {
+		t.Fatalf("expected target locale entry in push snapshot, got %+v", snap.Entries)
+	}
+}
+
+func TestJSONStoreBuildPushSnapshotSkipsSourceLocaleWhenNotSelected(t *testing.T) {
+	dir := t.TempDir()
+	langDir := filepath.Join(dir, "lang")
+	if err := os.MkdirAll(langDir, 0o755); err != nil {
+		t.Fatalf("mkdir lang dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(langDir, "en.json"), []byte("{\"hello\":\"Hello\"}\n"), 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(langDir, "fr.json"), []byte("{\"hello\":\"Bonjour\"}\n"), 0o644); err != nil {
+		t.Fatalf("write target file: %v", err)
+	}
+
+	store, err := NewJSONStore(&config.I18NConfig{
+		Locales: config.LocaleConfig{Source: "en", Targets: []string{"fr"}},
+		Buckets: map[string]config.BucketConfig{
+			"json": {Files: []config.BucketFileMapping{{From: filepath.Join(langDir, "en.json"), To: filepath.Join(langDir, "[locale].json")}}},
+		},
+		Groups: map[string]config.GroupConfig{
+			"default": {Targets: []string{"fr"}, Buckets: []string{"json"}},
+		},
+		LLM: config.LLMConfig{
+			Profiles: map[string]config.LLMProfile{"default": {Provider: "openai", Model: "gpt-4.1-mini"}},
+		},
+		Storage: &config.StorageConfig{Adapter: "poeditor"},
+	})
+	if err != nil {
+		t.Fatalf("new json store: %v", err)
+	}
+
+	snap, err := store.BuildPushSnapshot(context.Background(), syncsvc.LocalReadRequest{Locales: []string{"fr"}})
+	if err != nil {
+		t.Fatalf("build push snapshot: %v", err)
+	}
+	for _, entry := range snap.Entries {
+		if entry.Locale == "en" {
+			t.Fatalf("did not expect source locale entry when not selected, got %+v", snap.Entries)
+		}
+	}
+}
 func TestJSONStoreLocaleDirTemplateSupportsSourceRoot(t *testing.T) {
 	dir := t.TempDir()
 	docsDir := filepath.Join(dir, "docs")
@@ -145,6 +259,17 @@ func TestEntryMetaIDStable(t *testing.T) {
 func mustNewStore(t *testing.T, pattern string) *JSONStore {
 	t.Helper()
 
+	sourcePath := filepath.Join(filepath.Dir(filepath.Dir(pattern)), "lang", "en.json")
+	if strings.Contains(pattern, "{{localeDir}}") {
+		sourcePath = filepath.Join(filepath.Dir(filepath.Dir(filepath.Dir(pattern))), "docs", "index.json")
+	}
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
+		t.Fatalf("mkdir source dir: %v", err)
+	}
+	if err := os.WriteFile(sourcePath, []byte("{\"hello\":\"Hello\"}\n"), 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+
 	store, err := NewJSONStore(&config.I18NConfig{
 		Locales: config.LocaleConfig{
 			Source:  "en",
@@ -153,7 +278,7 @@ func mustNewStore(t *testing.T, pattern string) *JSONStore {
 		Buckets: map[string]config.BucketConfig{
 			"json": {
 				Files: []config.BucketFileMapping{{
-					From: "lang/en.json",
+					From: sourcePath,
 					To:   pattern,
 				}},
 			},

--- a/internal/i18n/localstore/jsonstore_test.go
+++ b/internal/i18n/localstore/jsonstore_test.go
@@ -207,6 +207,31 @@ func TestJSONStoreBuildPushSnapshotSkipsSourceLocaleWhenNotSelected(t *testing.T
 		}
 	}
 }
+
+func TestJSONStoreResolveScopeIncludesContextlessKeys(t *testing.T) {
+	store := &JSONStore{
+		cfg: &config.I18NConfig{
+			Locales: config.LocaleConfig{Source: "en", Targets: []string{"fr"}},
+		},
+		mappings: []fileMapping{{
+			Namespace:     "ns",
+			SourceEntries: map[string]string{"plain": "Hello", "withContext": "Hi"},
+			EntryContext:  map[string]string{"withContext": "greeting"},
+		}},
+	}
+
+	scope, err := store.ResolveScope(syncsvc.LocalReadRequest{Locales: []string{"fr"}})
+	if err != nil {
+		t.Fatalf("resolve scope: %v", err)
+	}
+	if _, ok := scope.Entries[storage.EntryID{Key: "plain", Locale: "fr"}]; !ok {
+		t.Fatalf("expected contextless key in scope, got %+v", scope.Entries)
+	}
+	if _, ok := scope.Entries[storage.EntryID{Key: "withContext", Context: "greeting", Locale: "fr"}]; !ok {
+		t.Fatalf("expected contextual key in scope, got %+v", scope.Entries)
+	}
+}
+
 func TestJSONStoreLocaleDirTemplateSupportsSourceRoot(t *testing.T) {
 	dir := t.TempDir()
 	docsDir := filepath.Join(dir, "docs")

--- a/internal/i18n/runsvc/selection_catalog.go
+++ b/internal/i18n/runsvc/selection_catalog.go
@@ -10,6 +10,7 @@ import (
 
 type SelectionCatalog struct {
 	ConfigPath    string                  `json:"configPath,omitempty"`
+	SourceLocale  string                  `json:"sourceLocale,omitempty"`
 	TotalTasks    int                     `json:"totalTasks"`
 	TotalFiles    int                     `json:"totalFiles"`
 	Groups        []SelectionGroup        `json:"groups,omitempty"`
@@ -88,8 +89,9 @@ func (s *Service) BuildSelectionCatalog(configPath string) (SelectionCatalog, er
 	}
 
 	catalog := SelectionCatalog{
-		ConfigPath: configPath,
-		TotalTasks: len(planned),
+		ConfigPath:   configPath,
+		SourceLocale: cfg.Locales.Source,
+		TotalTasks:   len(planned),
 	}
 
 	groupAgg := map[string]*SelectionGroup{}

--- a/internal/i18n/storage/poeditor/adapter.go
+++ b/internal/i18n/storage/poeditor/adapter.go
@@ -44,9 +44,8 @@ type Adapter struct {
 	cfg    Config
 	client Client
 
-	supportedOnce sync.Once
-	supportedSet  map[string]string
-	supportedErr  error
+	supportedMu  sync.RWMutex
+	supportedSet map[string]string
 }
 
 func New(raw json.RawMessage) (storage.StorageAdapter, error) {
@@ -405,24 +404,33 @@ func (a *Adapter) configLocaleOverride(locale string) (string, bool) {
 }
 
 func (a *Adapter) supportedLanguages(ctx context.Context) (map[string]string, error) {
-	a.supportedOnce.Do(func() {
-		codes, err := a.client.AvailableLanguages(ctx, a.cfg.APIToken)
-		if err != nil {
-			a.supportedErr = err
-			return
-		}
-		a.supportedSet = make(map[string]string, len(codes))
-		for _, code := range codes {
-			trimmed := strings.TrimSpace(code)
-			if trimmed == "" {
-				continue
-			}
-			a.supportedSet[strings.ToLower(trimmed)] = trimmed
-		}
-	})
-	if a.supportedErr != nil {
-		return nil, a.supportedErr
+	a.supportedMu.RLock()
+	if a.supportedSet != nil {
+		supported := a.supportedSet
+		a.supportedMu.RUnlock()
+		return supported, nil
 	}
+	a.supportedMu.RUnlock()
+
+	a.supportedMu.Lock()
+	defer a.supportedMu.Unlock()
+	if a.supportedSet != nil {
+		return a.supportedSet, nil
+	}
+
+	codes, err := a.client.AvailableLanguages(ctx, a.cfg.APIToken)
+	if err != nil {
+		return nil, err
+	}
+	supported := make(map[string]string, len(codes))
+	for _, code := range codes {
+		trimmed := strings.TrimSpace(code)
+		if trimmed == "" {
+			continue
+		}
+		supported[strings.ToLower(trimmed)] = trimmed
+	}
+	a.supportedSet = supported
 	return a.supportedSet, nil
 }
 

--- a/internal/i18n/storage/poeditor/adapter.go
+++ b/internal/i18n/storage/poeditor/adapter.go
@@ -5,10 +5,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/quiet-circles/hyperlocalise/internal/i18n/storage"
+	"golang.org/x/text/language"
 )
 
 const (
@@ -17,22 +20,33 @@ const (
 )
 
 type Config struct {
-	ProjectID       string   `json:"projectID"`
-	APIToken        string   `json:"-"`
-	APITokenEnv     string   `json:"apiTokenEnv,omitempty"`
-	SourceLanguage  string   `json:"sourceLanguage,omitempty"`
-	TargetLanguages []string `json:"targetLanguages,omitempty"`
-	TimeoutSeconds  int      `json:"timeoutSeconds,omitempty"`
+	ProjectID       string            `json:"projectID"`
+	APIToken        string            `json:"-"`
+	APITokenEnv     string            `json:"apiTokenEnv,omitempty"`
+	SourceLanguage  string            `json:"sourceLanguage,omitempty"`
+	TargetLanguages []string          `json:"targetLanguages,omitempty"`
+	LocaleMap       map[string]string `json:"localeMap,omitempty"`
+	TimeoutSeconds  int               `json:"timeoutSeconds,omitempty"`
 }
 
 type Client interface {
 	ListTerms(ctx context.Context, in ListTermsInput) ([]TermTranslation, string, error)
+	ListProjectTerms(ctx context.Context, in ListTermsInput) ([]TermKey, string, error)
+	AvailableLanguages(ctx context.Context, apiToken string) ([]string, error)
+	AddTerms(ctx context.Context, in TermMutationInput) (string, error)
+	DeleteTerms(ctx context.Context, in TermMutationInput) (string, error)
 	UpsertTranslations(ctx context.Context, in UpsertTranslationsInput) (string, error)
+	ExportFile(ctx context.Context, in ExportFileInput) ([]TermTranslation, string, error)
+	UploadFile(ctx context.Context, in UploadFileInput) (UploadFileResult, string, error)
 }
 
 type Adapter struct {
 	cfg    Config
 	client Client
+
+	supportedOnce sync.Once
+	supportedSet  map[string]string
+	supportedErr  error
 }
 
 func New(raw json.RawMessage) (storage.StorageAdapter, error) {
@@ -56,6 +70,12 @@ func NewWithClient(cfg Config, client Client) (*Adapter, error) {
 	if client == nil {
 		return nil, fmt.Errorf("poeditor adapter: client must not be nil")
 	}
+	debug("adapter", "new", map[string]any{
+		"project_id":      strings.TrimSpace(cfg.ProjectID),
+		"source_language": strings.TrimSpace(cfg.SourceLanguage),
+		"target_count":    len(cfg.TargetLanguages),
+		"timeout_seconds": cfg.TimeoutSeconds,
+	})
 	return &Adapter{cfg: cfg, client: client}, nil
 }
 
@@ -108,7 +128,7 @@ func (a *Adapter) Name() string { return AdapterName }
 
 func (a *Adapter) Capabilities() storage.Capabilities {
 	return storage.Capabilities{
-		SupportsContext:    true,
+		SupportsContext:    false,
 		SupportsVersions:   false,
 		SupportsDeletes:    false,
 		SupportsNamespaces: false,
@@ -116,18 +136,29 @@ func (a *Adapter) Capabilities() storage.Capabilities {
 }
 
 func (a *Adapter) Pull(ctx context.Context, req storage.PullRequest) (storage.PullResult, error) {
+	debug("adapter", "pull_start", map[string]any{
+		"project_id": strings.TrimSpace(a.cfg.ProjectID),
+		"locales":    append([]string(nil), req.Locales...),
+	})
 	locales := req.Locales
 	if len(locales) == 0 && len(a.cfg.TargetLanguages) > 0 {
 		locales = append([]string(nil), a.cfg.TargetLanguages...)
 	}
+	remoteLocales, localeLookup, err := a.normalizeLocales(ctx, locales)
+	if err != nil {
+		debug("adapter", "pull_locale_normalize_error", map[string]any{"error": err.Error()})
+		return storage.PullResult{}, fmt.Errorf("poeditor pull locale normalization: %w", err)
+	}
 
-	terms, revision, err := a.client.ListTerms(ctx, ListTermsInput{
+	terms, revision, err := a.client.ExportFile(ctx, ExportFileInput{
 		ProjectID: a.cfg.ProjectID,
 		APIToken:  a.cfg.APIToken,
-		Locales:   locales,
+		Locales:   remoteLocales,
+		Type:      "key_value_json",
 	})
 	if err != nil {
-		return storage.PullResult{}, fmt.Errorf("poeditor pull: %w", err)
+		debug("adapter", "pull_error", map[string]any{"error": err.Error()})
+		return storage.PullResult{}, fmt.Errorf("poeditor export: %w", err)
 	}
 
 	entries := make([]storage.Entry, 0, len(terms))
@@ -142,7 +173,7 @@ func (a *Adapter) Pull(ctx context.Context, req storage.PullRequest) (storage.Pu
 		entries = append(entries, storage.Entry{
 			Key:     t.Term,
 			Context: t.Context,
-			Locale:  t.Locale,
+			Locale:  localeLookup.localForRemote(t.Locale),
 			Value:   t.Value,
 			Provenance: storage.EntryProvenance{
 				Origin:    storage.OriginHuman,
@@ -167,37 +198,83 @@ func (a *Adapter) Pull(ctx context.Context, req storage.PullRequest) (storage.Pu
 }
 
 func (a *Adapter) Push(ctx context.Context, req storage.PushRequest) (storage.PushResult, error) {
-	payload := make([]TermTranslation, 0, len(req.Entries))
+	debug("adapter", "push_start", map[string]any{
+		"project_id":  strings.TrimSpace(a.cfg.ProjectID),
+		"entry_count": len(req.Entries),
+		"locales":     append([]string(nil), req.Locales...),
+		"scope":       strings.TrimSpace(req.Options["scope"]),
+		"source_lang": strings.TrimSpace(a.cfg.SourceLanguage),
+	})
+	entriesByLocale := make(map[string][]storage.Entry)
 	for _, entry := range req.Entries {
 		if strings.TrimSpace(entry.Value) == "" {
 			continue
 		}
-		payload = append(payload, TermTranslation{
-			Term:    entry.Key,
-			Context: entry.Context,
-			Locale:  entry.Locale,
-			Value:   entry.Value,
-		})
+		if strings.TrimSpace(entry.Context) != "" {
+			return storage.PushResult{}, fmt.Errorf("poeditor upload does not support entry context; found context for key %q", entry.Key)
+		}
+		remoteLocale, err := a.normalizeLocale(ctx, entry.Locale)
+		if err != nil {
+			debug("adapter", "push_locale_normalize_error", map[string]any{
+				"locale": entry.Locale,
+				"error":  err.Error(),
+			})
+			return storage.PushResult{}, fmt.Errorf("poeditor push locale normalization for %q: %w", entry.Locale, err)
+		}
+		entry.Locale = remoteLocale
+		entriesByLocale[remoteLocale] = append(entriesByLocale[remoteLocale], entry)
 	}
 
-	revision, err := a.client.UpsertTranslations(ctx, UpsertTranslationsInput{
-		ProjectID: a.cfg.ProjectID,
-		APIToken:  a.cfg.APIToken,
-		Entries:   payload,
-	})
-	if err != nil {
-		return storage.PushResult{}, fmt.Errorf("poeditor push: %w", err)
+	result := storage.PushResult{}
+	sourceLocale := a.remoteSourceLanguage(ctx)
+	for _, locale := range sortedLocaleKeys(entriesByLocale) {
+		updating := "translations"
+		syncTerms := false
+		if strings.EqualFold(locale, sourceLocale) {
+			updating = "terms_translations"
+			syncTerms = strings.EqualFold(strings.TrimSpace(req.Options["scope"]), "full")
+		}
+		out, revision, err := a.client.UploadFile(ctx, UploadFileInput{
+			ProjectID: a.cfg.ProjectID,
+			APIToken:  a.cfg.APIToken,
+			Locale:    locale,
+			Entries:   entriesByLocale[locale],
+			Type:      "key_value_json",
+			Updating:  updating,
+			SyncTerms: syncTerms,
+		})
+		if err != nil {
+			debug("adapter", "upload_locale_error", map[string]any{"locale": locale, "error": err.Error()})
+			return result, fmt.Errorf("poeditor upload locale %s: %w", locale, err)
+		}
+		result.Revision = revision
+		result.Warnings = append(result.Warnings, storage.Warning{
+			Code: "poeditor_upload_summary",
+			Message: fmt.Sprintf(
+				"POEditor upload %s: terms parsed=%d added=%d deleted=%d; translations parsed=%d added=%d updated=%d",
+				locale,
+				out.TermsParsed,
+				out.TermsAdded,
+				out.TermsDeleted,
+				out.TranslationsParsed,
+				out.TranslationsAdded,
+				out.TranslationsUpdated,
+			),
+		})
 	}
 
 	applied := make([]storage.EntryID, 0, len(req.Entries))
 	for _, entry := range req.Entries {
 		applied = append(applied, entry.ID())
 	}
+	result.Applied = applied
+	debug("adapter", "push_complete", map[string]any{
+		"applied_count": len(result.Applied),
+		"warning_count": len(result.Warnings),
+		"locale_count":  len(entriesByLocale),
+	})
 
-	return storage.PushResult{
-		Applied:  applied,
-		Revision: revision,
-	}, nil
+	return result, nil
 }
 
 type TermTranslation struct {
@@ -207,6 +284,11 @@ type TermTranslation struct {
 	Value   string
 }
 
+type TermKey struct {
+	Term    string
+	Context string
+}
+
 type ListTermsInput struct {
 	ProjectID string
 	APIToken  string
@@ -214,7 +296,177 @@ type ListTermsInput struct {
 }
 
 type UpsertTranslationsInput struct {
+	ProjectID      string
+	APIToken       string
+	SourceLanguage string
+	Entries        []TermTranslation
+}
+
+type TermMutationInput struct {
 	ProjectID string
 	APIToken  string
-	Entries   []TermTranslation
+	Terms     []TermKey
+}
+
+type ExportFileInput struct {
+	ProjectID string
+	APIToken  string
+	Locales   []string
+	Type      string
+}
+
+type UploadFileInput struct {
+	ProjectID string
+	APIToken  string
+	Locale    string
+	Entries   []storage.Entry
+	Type      string
+	Updating  string
+	SyncTerms bool
+}
+
+type UploadFileResult struct {
+	TermsParsed         int
+	TermsAdded          int
+	TermsDeleted        int
+	TranslationsParsed  int
+	TranslationsAdded   int
+	TranslationsUpdated int
+}
+
+func (a *Adapter) remoteSourceLanguage(ctx context.Context) string {
+	locale, err := a.normalizeLocale(ctx, a.cfg.SourceLanguage)
+	if err != nil {
+		return a.cfg.SourceLanguage
+	}
+	return locale
+}
+
+func sortedLocaleKeys(entriesByLocale map[string][]storage.Entry) []string {
+	keys := make([]string, 0, len(entriesByLocale))
+	for locale := range entriesByLocale {
+		keys = append(keys, locale)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func (a *Adapter) normalizeLocales(ctx context.Context, locales []string) ([]string, localeLookup, error) {
+	lookup := localeLookup{
+		remoteToLocal: make(map[string]string, len(locales)),
+	}
+	normalized := make([]string, 0, len(locales))
+	seen := make(map[string]struct{}, len(locales))
+	for _, locale := range locales {
+		remote, err := a.normalizeLocale(ctx, locale)
+		if err != nil {
+			return nil, localeLookup{}, err
+		}
+		key := strings.ToLower(strings.TrimSpace(remote))
+		if _, ok := seen[key]; !ok {
+			normalized = append(normalized, remote)
+			seen[key] = struct{}{}
+		}
+		lookup.remoteToLocal[key] = locale
+	}
+	return normalized, lookup, nil
+}
+
+func (a *Adapter) normalizeLocale(ctx context.Context, locale string) (string, error) {
+	trimmed := strings.TrimSpace(locale)
+	if trimmed == "" {
+		return "", nil
+	}
+	if mapped, ok := a.configLocaleOverride(trimmed); ok {
+		return mapped, nil
+	}
+	supported, err := a.supportedLanguages(ctx)
+	if err != nil {
+		return "", err
+	}
+	for _, candidate := range localeCandidates(trimmed) {
+		if mapped, ok := supported[strings.ToLower(candidate)]; ok {
+			return mapped, nil
+		}
+	}
+	return "", fmt.Errorf("unsupported POEditor locale %q; add storage.config.localeMap override", trimmed)
+}
+
+func (a *Adapter) configLocaleOverride(locale string) (string, bool) {
+	if len(a.cfg.LocaleMap) == 0 {
+		return "", false
+	}
+	for key, value := range a.cfg.LocaleMap {
+		if strings.EqualFold(strings.TrimSpace(key), strings.TrimSpace(locale)) {
+			return strings.TrimSpace(value), true
+		}
+	}
+	return "", false
+}
+
+func (a *Adapter) supportedLanguages(ctx context.Context) (map[string]string, error) {
+	a.supportedOnce.Do(func() {
+		codes, err := a.client.AvailableLanguages(ctx, a.cfg.APIToken)
+		if err != nil {
+			a.supportedErr = err
+			return
+		}
+		a.supportedSet = make(map[string]string, len(codes))
+		for _, code := range codes {
+			trimmed := strings.TrimSpace(code)
+			if trimmed == "" {
+				continue
+			}
+			a.supportedSet[strings.ToLower(trimmed)] = trimmed
+		}
+	})
+	if a.supportedErr != nil {
+		return nil, a.supportedErr
+	}
+	return a.supportedSet, nil
+}
+
+type localeLookup struct {
+	remoteToLocal map[string]string
+}
+
+func (l localeLookup) localForRemote(remote string) string {
+	if local, ok := l.remoteToLocal[strings.ToLower(strings.TrimSpace(remote))]; ok {
+		return local
+	}
+	return remote
+}
+
+func localeCandidates(locale string) []string {
+	trimmed := strings.TrimSpace(strings.ReplaceAll(locale, "_", "-"))
+	if trimmed == "" {
+		return nil
+	}
+	candidates := make([]string, 0, 8)
+	addCandidate := func(value string) {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return
+		}
+		for _, existing := range candidates {
+			if strings.EqualFold(existing, value) {
+				return
+			}
+		}
+		candidates = append(candidates, value)
+	}
+
+	addCandidate(trimmed)
+	addCandidate(strings.ToLower(trimmed))
+	if base, err := language.Parse(trimmed); err == nil {
+		addCandidate(base.String())
+		baseTag, _ := base.Base()
+		if baseTag.String() != "" && baseTag.String() != "und" {
+			addCandidate(baseTag.String())
+		}
+	}
+	if idx := strings.Index(trimmed, "-"); idx > 0 {
+		addCandidate(trimmed[:idx])
+	}
+	return candidates
 }

--- a/internal/i18n/storage/poeditor/adapter_test.go
+++ b/internal/i18n/storage/poeditor/adapter_test.go
@@ -3,6 +3,7 @@ package poeditor
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -12,6 +13,7 @@ import (
 
 type fakeClient struct {
 	available    []string
+	availableErr error
 	exportOut    []TermTranslation
 	listRevision string
 	uploads      []UploadFileInput
@@ -26,6 +28,11 @@ func (f *fakeClient) ListProjectTerms(_ context.Context, _ ListTermsInput) ([]Te
 }
 
 func (f *fakeClient) AvailableLanguages(_ context.Context, _ string) ([]string, error) {
+	if f.availableErr != nil {
+		err := f.availableErr
+		f.availableErr = nil
+		return nil, err
+	}
 	return f.available, nil
 }
 
@@ -207,6 +214,30 @@ func TestAdapterLocaleMapOverrideWins(t *testing.T) {
 	}
 	if got := client.uploads[0].Locale; got != "vi-VN" {
 		t.Fatalf("expected locale override preserved, got %q", got)
+	}
+}
+
+func TestAdapterSupportedLanguagesRetriesAfterFailure(t *testing.T) {
+	client := &fakeClient{
+		available:    []string{"fr"},
+		availableErr: errors.New("temporary outage"),
+	}
+	adapter, err := NewWithClient(Config{ProjectID: "123", APIToken: "token", SourceLanguage: "en"}, client)
+	if err != nil {
+		t.Fatalf("new adapter: %v", err)
+	}
+
+	_, err = adapter.supportedLanguages(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "temporary outage") {
+		t.Fatalf("expected transient failure, got %v", err)
+	}
+
+	supported, err := adapter.supportedLanguages(context.Background())
+	if err != nil {
+		t.Fatalf("expected retry to succeed, got %v", err)
+	}
+	if got := supported["fr"]; got != "fr" {
+		t.Fatalf("expected cached locale after retry, got %#v", supported)
 	}
 }
 

--- a/internal/i18n/storage/poeditor/adapter_test.go
+++ b/internal/i18n/storage/poeditor/adapter_test.go
@@ -11,18 +11,47 @@ import (
 )
 
 type fakeClient struct {
-	terms        []TermTranslation
+	available    []string
+	exportOut    []TermTranslation
 	listRevision string
-	upsertIn     UpsertTranslationsInput
+	uploads      []UploadFileInput
 }
 
 func (f *fakeClient) ListTerms(_ context.Context, _ ListTermsInput) ([]TermTranslation, string, error) {
-	return f.terms, f.listRevision, nil
+	return nil, "", nil
 }
 
-func (f *fakeClient) UpsertTranslations(_ context.Context, in UpsertTranslationsInput) (string, error) {
-	f.upsertIn = in
-	return "rev2", nil
+func (f *fakeClient) ListProjectTerms(_ context.Context, _ ListTermsInput) ([]TermKey, string, error) {
+	return nil, "", nil
+}
+
+func (f *fakeClient) AvailableLanguages(_ context.Context, _ string) ([]string, error) {
+	return f.available, nil
+}
+
+func (f *fakeClient) AddTerms(_ context.Context, _ TermMutationInput) (string, error) {
+	return "", nil
+}
+
+func (f *fakeClient) DeleteTerms(_ context.Context, _ TermMutationInput) (string, error) {
+	return "", nil
+}
+
+func (f *fakeClient) UpsertTranslations(_ context.Context, _ UpsertTranslationsInput) (string, error) {
+	return "", nil
+}
+
+func (f *fakeClient) ExportFile(_ context.Context, _ ExportFileInput) ([]TermTranslation, string, error) {
+	return f.exportOut, f.listRevision, nil
+}
+
+func (f *fakeClient) UploadFile(_ context.Context, in UploadFileInput) (UploadFileResult, string, error) {
+	f.uploads = append(f.uploads, in)
+	return UploadFileResult{
+		TermsParsed:         len(in.Entries),
+		TranslationsParsed:  len(in.Entries),
+		TranslationsUpdated: len(in.Entries),
+	}, "rev2", nil
 }
 
 func TestParseConfigUsesEnvToken(t *testing.T) {
@@ -53,11 +82,10 @@ func TestParseConfigRejectsInlineToken(t *testing.T) {
 	}
 }
 
-func TestAdapterPullMapsTermContextLanguage(t *testing.T) {
+func TestAdapterPullUsesExportedFileEntries(t *testing.T) {
 	client := &fakeClient{
-		terms: []TermTranslation{
-			{Term: "hello", Context: "home", Locale: "fr", Value: "bonjour"},
-		},
+		exportOut:    []TermTranslation{{Term: "hello", Locale: "fr", Value: "bonjour"}},
+		available:    []string{"fr"},
 		listRevision: "rev1",
 	}
 	adapter, err := NewWithClient(Config{ProjectID: "123", APIToken: "token"}, client)
@@ -73,14 +101,63 @@ func TestAdapterPullMapsTermContextLanguage(t *testing.T) {
 		t.Fatalf("expected 1 entry, got %d", got)
 	}
 	entry := result.Snapshot.Entries[0]
-	if entry.Key != "hello" || entry.Context != "home" || entry.Locale != "fr" || entry.Value != "bonjour" {
+	if entry.Key != "hello" || entry.Locale != "fr" || entry.Value != "bonjour" {
 		t.Fatalf("unexpected entry mapping: %+v", entry)
 	}
 }
 
-func TestAdapterPushGroupsEntries(t *testing.T) {
-	client := &fakeClient{}
-	adapter, err := NewWithClient(Config{ProjectID: "123", APIToken: "token"}, client)
+func TestAdapterPushUploadsGroupedLocales(t *testing.T) {
+	client := &fakeClient{available: []string{"fr", "en-us"}}
+	adapter, err := NewWithClient(Config{ProjectID: "123", APIToken: "token", SourceLanguage: "en"}, client)
+	if err != nil {
+		t.Fatalf("new adapter: %v", err)
+	}
+
+	_, err = adapter.Push(context.Background(), storage.PushRequest{
+		Entries: []storage.Entry{{Key: "hello", Locale: "fr", Value: "bonjour"}},
+	})
+	if err != nil {
+		t.Fatalf("push: %v", err)
+	}
+	if got := len(client.uploads); got != 1 {
+		t.Fatalf("expected 1 upload, got %d", got)
+	}
+	if got := client.uploads[0].Locale; got != "fr" {
+		t.Fatalf("expected fr upload, got %+v", client.uploads[0])
+	}
+	if got := client.uploads[0].Updating; got != "translations" {
+		t.Fatalf("expected translations mode, got %q", got)
+	}
+}
+
+func TestAdapterPushSourceLocaleUsesTermsTranslationsAndFullSync(t *testing.T) {
+	client := &fakeClient{available: []string{"en-us"}}
+	adapter, err := NewWithClient(Config{ProjectID: "123", APIToken: "token", SourceLanguage: "en-US"}, client)
+	if err != nil {
+		t.Fatalf("new adapter: %v", err)
+	}
+
+	_, err = adapter.Push(context.Background(), storage.PushRequest{
+		Options: map[string]string{"scope": "full"},
+		Entries: []storage.Entry{{Key: "hello", Locale: "en-US", Value: "Hello"}},
+	})
+	if err != nil {
+		t.Fatalf("push: %v", err)
+	}
+	if got := len(client.uploads); got != 1 {
+		t.Fatalf("expected 1 upload, got %d", got)
+	}
+	if got := client.uploads[0].Updating; got != "terms_translations" {
+		t.Fatalf("expected terms_translations mode, got %q", got)
+	}
+	if !client.uploads[0].SyncTerms {
+		t.Fatalf("expected full-scope source upload to sync terms")
+	}
+}
+
+func TestAdapterPushRejectsContextForUploadMode(t *testing.T) {
+	client := &fakeClient{available: []string{"fr"}}
+	adapter, err := NewWithClient(Config{ProjectID: "123", APIToken: "token", SourceLanguage: "en"}, client)
 	if err != nil {
 		t.Fatalf("new adapter: %v", err)
 	}
@@ -88,11 +165,48 @@ func TestAdapterPushGroupsEntries(t *testing.T) {
 	_, err = adapter.Push(context.Background(), storage.PushRequest{
 		Entries: []storage.Entry{{Key: "hello", Context: "home", Locale: "fr", Value: "bonjour"}},
 	})
+	if err == nil || !strings.Contains(err.Error(), "does not support entry context") {
+		t.Fatalf("expected context rejection, got %v", err)
+	}
+}
+
+func TestAdapterNormalizesLocalesToPOEditorCodes(t *testing.T) {
+	client := &fakeClient{available: []string{"en-us", "vi", "zh-Hans"}}
+	adapter, err := NewWithClient(Config{ProjectID: "123", APIToken: "token", SourceLanguage: "en-US"}, client)
+	if err != nil {
+		t.Fatalf("new adapter: %v", err)
+	}
+
+	_, err = adapter.Push(context.Background(), storage.PushRequest{
+		Entries: []storage.Entry{{Key: "hello", Locale: "vi-VN", Value: "Xin chao"}},
+	})
 	if err != nil {
 		t.Fatalf("push: %v", err)
 	}
-	if got := len(client.upsertIn.Entries); got != 1 {
-		t.Fatalf("expected 1 upsert entry, got %d", got)
+	if got := client.uploads[0].Locale; got != "vi" {
+		t.Fatalf("expected vi-VN normalized to vi, got %q", got)
+	}
+}
+
+func TestAdapterLocaleMapOverrideWins(t *testing.T) {
+	client := &fakeClient{available: []string{"en-us", "vi", "vi-VN"}}
+	adapter, err := NewWithClient(Config{
+		ProjectID:      "123",
+		APIToken:       "token",
+		SourceLanguage: "en-US",
+		LocaleMap:      map[string]string{"vi-VN": "vi-VN"},
+	}, client)
+	if err != nil {
+		t.Fatalf("new adapter: %v", err)
+	}
+	_, err = adapter.Push(context.Background(), storage.PushRequest{
+		Entries: []storage.Entry{{Key: "hello", Locale: "vi-VN", Value: "Xin chao"}},
+	})
+	if err != nil {
+		t.Fatalf("push: %v", err)
+	}
+	if got := client.uploads[0].Locale; got != "vi-VN" {
+		t.Fatalf("expected locale override preserved, got %q", got)
 	}
 }
 
@@ -120,8 +234,8 @@ func TestAdapterNameAndCapabilities(t *testing.T) {
 	}
 
 	caps := adapter.Capabilities()
-	if !caps.SupportsContext {
-		t.Fatalf("expected SupportsContext")
+	if caps.SupportsContext {
+		t.Fatalf("expected SupportsContext=false")
 	}
 	if caps.SupportsVersions {
 		t.Fatalf("expected SupportsVersions=false")

--- a/internal/i18n/storage/poeditor/debug_log.go
+++ b/internal/i18n/storage/poeditor/debug_log.go
@@ -1,0 +1,93 @@
+package poeditor
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	envPOEditorDebugPath = "HYPERLOCALISE_POEDITOR_DEBUG_FILE"
+	envGenericDebug      = "DEBUG"
+	defaultDebugLogPath  = ".hyperlocalise/logs/poeditor.log"
+)
+
+type debugLogger struct {
+	mu sync.Mutex
+}
+
+type debugEvent struct {
+	Timestamp string         `json:"timestamp"`
+	Component string         `json:"component"`
+	Event     string         `json:"event"`
+	Fields    map[string]any `json:"fields,omitempty"`
+}
+
+var poeditorDebugLogger debugLogger
+
+func debug(component, event string, fields map[string]any) {
+	poeditorDebugLogger.write(debugEvent{
+		Timestamp: time.Now().UTC().Format(time.RFC3339Nano),
+		Component: component,
+		Event:     event,
+		Fields:    fields,
+	})
+}
+
+func (l *debugLogger) write(event debugEvent) {
+	enabled, path := resolveDebugConfig()
+	if !enabled {
+		return
+	}
+
+	data, err := json.Marshal(event)
+	if err != nil {
+		return
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return
+	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	_, _ = f.Write(append(data, '\n'))
+}
+
+func resolveDebugConfig() (bool, string) {
+	enabled := parseDebugBool(os.Getenv(envGenericDebug))
+	path := strings.TrimSpace(os.Getenv(envPOEditorDebugPath))
+	if path == "" {
+		path = defaultDebugLogPath
+	}
+	return enabled, path
+}
+
+func parseDebugBool(raw string) bool {
+	if strings.TrimSpace(raw) == "" {
+		return false
+	}
+	parsed, err := strconv.ParseBool(strings.TrimSpace(raw))
+	if err == nil {
+		return parsed
+	}
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "on", "yes", "y":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/i18n/storage/poeditor/debug_log_test.go
+++ b/internal/i18n/storage/poeditor/debug_log_test.go
@@ -1,0 +1,45 @@
+package poeditor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDebugWritesLogFileWhenEnabled(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), ".hyperlocalise", "logs", "poeditor.log")
+	t.Setenv("DEBUG", "1")
+	t.Setenv("HYPERLOCALISE_POEDITOR_DEBUG_FILE", logPath)
+
+	debug("adapter", "push_start", map[string]any{
+		"project_id": "123",
+		"api_token":  "secret",
+	})
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read debug log: %v", err)
+	}
+	text := string(data)
+	if !strings.Contains(text, `"component":"adapter"`) {
+		t.Fatalf("expected component in log, got %s", text)
+	}
+	if !strings.Contains(text, `"event":"push_start"`) {
+		t.Fatalf("expected event in log, got %s", text)
+	}
+}
+
+func TestSanitizeValuesRedactsToken(t *testing.T) {
+	values := sanitizeValues(map[string][]string{
+		"api_token": {"secret"},
+		"id":        {"123"},
+		"data":      {"payload"},
+	})
+	if got := values["api_token"]; got != "[redacted]" {
+		t.Fatalf("expected token redacted, got %#v", got)
+	}
+	if got := values["id"]; got != "123" {
+		t.Fatalf("expected id preserved, got %#v", got)
+	}
+}

--- a/internal/i18n/storage/poeditor/http_client.go
+++ b/internal/i18n/storage/poeditor/http_client.go
@@ -6,10 +6,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
+
+	"github.com/quiet-circles/hyperlocalise/internal/i18n/storage"
 )
 
 const apiBaseURL = "https://api.poeditor.com/v2"
@@ -25,34 +29,26 @@ func NewHTTPClient(cfg Config) (*HTTPClient, error) {
 		timeout = 30 * time.Second
 	}
 
-	return &HTTPClient{
+	client := &HTTPClient{
 		baseURL: apiBaseURL,
 		http: &http.Client{
 			Timeout: timeout,
 		},
-	}, nil
+	}
+	debug("http_client", "new", map[string]any{
+		"base_url":        client.baseURL,
+		"timeout_seconds": int(timeout / time.Second),
+	})
+	return client, nil
 }
 
 func (c *HTTPClient) ListTerms(ctx context.Context, in ListTermsInput) ([]TermTranslation, string, error) {
-	var response struct {
-		Result struct {
-			Code    string `json:"code"`
-			Message string `json:"message"`
-		} `json:"result"`
-		Terms []struct {
-			Term         string `json:"term"`
-			Context      string `json:"context"`
-			Translations []struct {
-				Language string `json:"language"`
-				Content  string `json:"content"`
-			} `json:"translations"`
-		} `json:"terms"`
-	}
-
-	values := url.Values{}
-	values.Set("api_token", in.APIToken)
-	values.Set("id", in.ProjectID)
-	if err := c.postForm(ctx, "/terms/list", values, &response); err != nil {
+	debug("http_client", "list_terms", map[string]any{
+		"project_id": strings.TrimSpace(in.ProjectID),
+		"locales":    append([]string(nil), in.Locales...),
+	})
+	terms, revision, err := c.listTermsRaw(ctx, in)
+	if err != nil {
 		return nil, "", err
 	}
 
@@ -62,7 +58,7 @@ func (c *HTTPClient) ListTerms(ctx context.Context, in ListTermsInput) ([]TermTr
 	}
 
 	out := make([]TermTranslation, 0)
-	for _, term := range response.Terms {
+	for _, term := range terms {
 		for _, tr := range term.Translations {
 			if len(allowed) > 0 {
 				if _, ok := allowed[tr.Language]; !ok {
@@ -78,11 +74,196 @@ func (c *HTTPClient) ListTerms(ctx context.Context, in ListTermsInput) ([]TermTr
 		}
 	}
 
-	revision := time.Now().UTC().Format(time.RFC3339Nano)
 	return out, revision, nil
 }
 
+func (c *HTTPClient) ListProjectTerms(ctx context.Context, in ListTermsInput) ([]TermKey, string, error) {
+	debug("http_client", "list_project_terms", map[string]any{
+		"project_id": strings.TrimSpace(in.ProjectID),
+	})
+	terms, revision, err := c.listTermsRaw(ctx, in)
+	if err != nil {
+		return nil, "", err
+	}
+	out := make([]TermKey, 0, len(terms))
+	for _, term := range terms {
+		out = append(out, TermKey{Term: term.Term, Context: term.Context})
+	}
+	return out, revision, nil
+}
+
+func (c *HTTPClient) AvailableLanguages(ctx context.Context, apiToken string) ([]string, error) {
+	debug("http_client", "available_languages", map[string]any{})
+	values := url.Values{}
+	values.Set("api_token", apiToken)
+	var response struct {
+		Result struct {
+			Languages []struct {
+				Code string `json:"code"`
+			} `json:"languages"`
+		} `json:"result"`
+	}
+	if err := c.postForm(ctx, "/languages/available", values, &response); err != nil {
+		return nil, err
+	}
+	codes := make([]string, 0, len(response.Result.Languages))
+	for _, language := range response.Result.Languages {
+		codes = append(codes, language.Code)
+	}
+	return codes, nil
+}
+
+func (c *HTTPClient) ExportFile(ctx context.Context, in ExportFileInput) ([]TermTranslation, string, error) {
+	debug("http_client", "export_file", map[string]any{
+		"project_id": strings.TrimSpace(in.ProjectID),
+		"locales":    append([]string(nil), in.Locales...),
+		"type":       in.Type,
+	})
+	out := make([]TermTranslation, 0)
+	for _, locale := range in.Locales {
+		exportURL, err := c.exportURL(ctx, in.ProjectID, in.APIToken, locale, in.Type)
+		if err != nil {
+			return nil, "", err
+		}
+		payload, err := c.downloadExport(ctx, exportURL)
+		if err != nil {
+			return nil, "", err
+		}
+		var values map[string]string
+		if err := json.Unmarshal(payload, &values); err != nil {
+			return nil, "", fmt.Errorf("decode exported %s file: %w", locale, err)
+		}
+		for key, value := range values {
+			out = append(out, TermTranslation{Term: key, Locale: locale, Value: value})
+		}
+	}
+	return out, time.Now().UTC().Format(time.RFC3339Nano), nil
+}
+
+func (c *HTTPClient) UploadFile(ctx context.Context, in UploadFileInput) (UploadFileResult, string, error) {
+	debug("http_client", "upload_file", map[string]any{
+		"project_id":  strings.TrimSpace(in.ProjectID),
+		"locale":      in.Locale,
+		"entry_count": len(in.Entries),
+		"updating":    in.Updating,
+		"sync_terms":  in.SyncTerms,
+	})
+	content, err := encodeEntriesJSON(in.Entries)
+	if err != nil {
+		return UploadFileResult{}, "", fmt.Errorf("encode upload file: %w", err)
+	}
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	if err := writer.WriteField("api_token", in.APIToken); err != nil {
+		return UploadFileResult{}, "", err
+	}
+	if err := writer.WriteField("id", in.ProjectID); err != nil {
+		return UploadFileResult{}, "", err
+	}
+	if err := writer.WriteField("language", in.Locale); err != nil {
+		return UploadFileResult{}, "", err
+	}
+	if err := writer.WriteField("updating", in.Updating); err != nil {
+		return UploadFileResult{}, "", err
+	}
+	if in.SyncTerms {
+		if err := writer.WriteField("sync_terms", "1"); err != nil {
+			return UploadFileResult{}, "", err
+		}
+	}
+	filePart, err := writer.CreateFormFile("file", fileNameForLocale(in.Locale, in.Type))
+	if err != nil {
+		return UploadFileResult{}, "", err
+	}
+	if _, err := filePart.Write(content); err != nil {
+		return UploadFileResult{}, "", err
+	}
+	if err := writer.Close(); err != nil {
+		return UploadFileResult{}, "", err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/projects/upload", &body)
+	if err != nil {
+		debug("http_client", "upload_file_build_error", map[string]any{"error": err.Error()})
+		return UploadFileResult{}, "", fmt.Errorf("poeditor upload build request: %w", err)
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	fields := map[string]any{
+		"api_token":          "[redacted]",
+		"id":                 in.ProjectID,
+		"language":           in.Locale,
+		"updating":           in.Updating,
+		"multipart_filename": fileNameForLocale(in.Locale, in.Type),
+		"file_bytes":         len(content),
+	}
+	if in.SyncTerms {
+		fields["sync_terms"] = "1"
+	}
+	debug("http_client", "upload_file_request_start", map[string]any{
+		"endpoint": "/projects/upload",
+		"fields":   fields,
+	})
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		debug("http_client", "upload_file_request_error", map[string]any{"error": err.Error()})
+		return UploadFileResult{}, "", fmt.Errorf("poeditor upload request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		payload, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		debug("http_client", "upload_file_status_error", map[string]any{
+			"status_code": resp.StatusCode,
+			"body":        strings.TrimSpace(string(payload)),
+		})
+		return UploadFileResult{}, "", fmt.Errorf("poeditor upload status %d: %s", resp.StatusCode, strings.TrimSpace(string(payload)))
+	}
+
+	var response struct {
+		Result struct {
+			Terms struct {
+				Parsed  int `json:"parsed"`
+				Added   int `json:"added"`
+				Deleted int `json:"deleted"`
+			} `json:"terms"`
+			Translations struct {
+				Parsed  int `json:"parsed"`
+				Added   int `json:"added"`
+				Updated int `json:"updated"`
+			} `json:"translations"`
+		} `json:"result"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		debug("http_client", "upload_file_decode_error", map[string]any{"error": err.Error()})
+		return UploadFileResult{}, "", fmt.Errorf("poeditor upload decode response: %w", err)
+	}
+	result := UploadFileResult{
+		TermsParsed:         response.Result.Terms.Parsed,
+		TermsAdded:          response.Result.Terms.Added,
+		TermsDeleted:        response.Result.Terms.Deleted,
+		TranslationsParsed:  response.Result.Translations.Parsed,
+		TranslationsAdded:   response.Result.Translations.Added,
+		TranslationsUpdated: response.Result.Translations.Updated,
+	}
+	debug("http_client", "upload_file_response", map[string]any{
+		"status_code":          resp.StatusCode,
+		"terms_parsed":         result.TermsParsed,
+		"terms_added":          result.TermsAdded,
+		"terms_deleted":        result.TermsDeleted,
+		"translations_parsed":  result.TranslationsParsed,
+		"translations_added":   result.TranslationsAdded,
+		"translations_updated": result.TranslationsUpdated,
+	})
+	return result, time.Now().UTC().Format(time.RFC3339Nano), nil
+}
+
 func (c *HTTPClient) UpsertTranslations(ctx context.Context, in UpsertTranslationsInput) (string, error) {
+	debug("http_client", "upsert_translations_start", map[string]any{
+		"project_id":      strings.TrimSpace(in.ProjectID),
+		"entry_count":     len(in.Entries),
+		"source_language": strings.TrimSpace(in.SourceLanguage),
+	})
 	byLocale := make(map[string][]map[string]string)
 	for _, entry := range in.Entries {
 		if strings.TrimSpace(entry.Locale) == "" {
@@ -98,7 +279,13 @@ func (c *HTTPClient) UpsertTranslations(ctx context.Context, in UpsertTranslatio
 		byLocale[entry.Locale] = append(byLocale[entry.Locale], item)
 	}
 
-	for locale, items := range byLocale {
+	locales := orderedLocales(byLocale, in.SourceLanguage)
+	for _, locale := range locales {
+		items := byLocale[locale]
+		debug("http_client", "upsert_translations_locale", map[string]any{
+			"locale": locale,
+			"count":  len(items),
+		})
 		raw, err := json.Marshal(items)
 		if err != nil {
 			return "", fmt.Errorf("marshal poeditor translations payload: %w", err)
@@ -117,6 +304,10 @@ func (c *HTTPClient) UpsertTranslations(ctx context.Context, in UpsertTranslatio
 			} `json:"result"`
 		}
 		if err := c.postForm(ctx, "/translations/update", values, &response); err != nil {
+			debug("http_client", "upsert_translations_error", map[string]any{
+				"locale": locale,
+				"error":  err.Error(),
+			})
 			return "", err
 		}
 	}
@@ -124,15 +315,209 @@ func (c *HTTPClient) UpsertTranslations(ctx context.Context, in UpsertTranslatio
 	return time.Now().UTC().Format(time.RFC3339Nano), nil
 }
 
+func (c *HTTPClient) AddTerms(ctx context.Context, in TermMutationInput) (string, error) {
+	debug("http_client", "add_terms", map[string]any{
+		"project_id": strings.TrimSpace(in.ProjectID),
+		"count":      len(in.Terms),
+	})
+	return c.postTermsMutation(ctx, "/terms/add", in)
+}
+
+func (c *HTTPClient) DeleteTerms(ctx context.Context, in TermMutationInput) (string, error) {
+	debug("http_client", "delete_terms", map[string]any{
+		"project_id": strings.TrimSpace(in.ProjectID),
+		"count":      len(in.Terms),
+	})
+	return c.postTermsMutation(ctx, "/terms/delete", in)
+}
+
+func (c *HTTPClient) listTermsRaw(ctx context.Context, in ListTermsInput) ([]termRecord, string, error) {
+	var response struct {
+		Result struct {
+			Code  string       `json:"code"`
+			Terms []termRecord `json:"terms"`
+		} `json:"result"`
+	}
+
+	values := url.Values{}
+	values.Set("api_token", in.APIToken)
+	values.Set("id", in.ProjectID)
+	if len(in.Locales) == 1 {
+		values.Set("language", in.Locales[0])
+	}
+	if err := c.postForm(ctx, "/terms/list", values, &response); err != nil {
+		return nil, "", err
+	}
+	if len(in.Locales) == 1 {
+		for i := range response.Result.Terms {
+			if response.Result.Terms[i].Translation.Language == "" {
+				response.Result.Terms[i].Translation.Language = in.Locales[0]
+			}
+			if strings.TrimSpace(response.Result.Terms[i].Translation.Content) != "" {
+				response.Result.Terms[i].Translations = append(response.Result.Terms[i].Translations, response.Result.Terms[i].Translation)
+			}
+		}
+	}
+	return response.Result.Terms, time.Now().UTC().Format(time.RFC3339Nano), nil
+}
+
+func (c *HTTPClient) postTermsMutation(ctx context.Context, endpoint string, in TermMutationInput) (string, error) {
+	if len(in.Terms) == 0 {
+		return time.Now().UTC().Format(time.RFC3339Nano), nil
+	}
+	payload := make([]map[string]string, 0, len(in.Terms))
+	for _, term := range in.Terms {
+		item := map[string]string{"term": term.Term}
+		if term.Context != "" {
+			item["context"] = term.Context
+		}
+		payload = append(payload, item)
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("marshal poeditor terms payload: %w", err)
+	}
+	values := url.Values{}
+	values.Set("api_token", in.APIToken)
+	values.Set("id", in.ProjectID)
+	values.Set("data", string(raw))
+	var response struct {
+		Result struct {
+			Code string `json:"code"`
+		} `json:"result"`
+	}
+	if err := c.postForm(ctx, endpoint, values, &response); err != nil {
+		return "", err
+	}
+	return time.Now().UTC().Format(time.RFC3339Nano), nil
+}
+
+type termRecord struct {
+	Term         string              `json:"term"`
+	Context      string              `json:"context"`
+	Translation  translationRecord   `json:"translation"`
+	Translations []translationRecord `json:"translations"`
+}
+
+type translationRecord struct {
+	Language string `json:"language"`
+	Content  string `json:"content"`
+}
+
+func orderedLocales(byLocale map[string][]map[string]string, sourceLanguage string) []string {
+	locales := make([]string, 0, len(byLocale))
+	for locale := range byLocale {
+		locales = append(locales, locale)
+	}
+	slices.Sort(locales)
+	sourceLanguage = strings.TrimSpace(sourceLanguage)
+	if sourceLanguage == "" {
+		return locales
+	}
+	index := slices.Index(locales, sourceLanguage)
+	if index <= 0 {
+		return locales
+	}
+	return append([]string{sourceLanguage}, append(locales[:index], locales[index+1:]...)...)
+}
+
+func encodeEntriesJSON(entries []storage.Entry) ([]byte, error) {
+	values := make(map[string]string, len(entries))
+	for _, entry := range entries {
+		values[entry.Key] = entry.Value
+	}
+	return json.Marshal(values)
+}
+
+func fileNameForLocale(locale, fileType string) string {
+	ext := "json"
+	if strings.TrimSpace(fileType) != "" && !strings.EqualFold(strings.TrimSpace(fileType), "key_value_json") {
+		ext = strings.TrimSpace(fileType)
+	}
+	trimmed := strings.TrimSpace(locale)
+	if trimmed == "" {
+		trimmed = "locale"
+	}
+	return trimmed + "." + ext
+}
+
+func (c *HTTPClient) exportURL(ctx context.Context, projectID, apiToken, locale, fileType string) (string, error) {
+	debug("http_client", "export_url_request", map[string]any{
+		"project_id": projectID,
+		"language":   locale,
+		"type":       fileType,
+	})
+	var response struct {
+		Result struct {
+			URL string `json:"url"`
+		} `json:"result"`
+	}
+	values := url.Values{}
+	values.Set("api_token", apiToken)
+	values.Set("id", projectID)
+	values.Set("language", locale)
+	values.Set("type", fileType)
+	if err := c.postForm(ctx, "/projects/export", values, &response); err != nil {
+		return "", err
+	}
+	url := strings.TrimSpace(response.Result.URL)
+	debug("http_client", "export_url_response", map[string]any{
+		"language":     locale,
+		"download_url": url,
+	})
+	return url, nil
+}
+
+func (c *HTTPClient) downloadExport(ctx context.Context, downloadURL string) ([]byte, error) {
+	debug("http_client", "export_download_start", map[string]any{
+		"download_url": truncateDebugValue(downloadURL, 300),
+	})
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+	if err != nil {
+		debug("http_client", "export_download_build_error", map[string]any{"error": err.Error()})
+		return nil, fmt.Errorf("poeditor export download request: %w", err)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		debug("http_client", "export_download_request_error", map[string]any{"error": err.Error()})
+		return nil, fmt.Errorf("poeditor export download: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		debug("http_client", "export_download_status_error", map[string]any{
+			"status_code": resp.StatusCode,
+			"body":        strings.TrimSpace(string(body)),
+		})
+		return nil, fmt.Errorf("poeditor export download status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	payload, err := io.ReadAll(resp.Body)
+	if err != nil {
+		debug("http_client", "export_download_read_error", map[string]any{"error": err.Error()})
+		return nil, fmt.Errorf("poeditor export read body: %w", err)
+	}
+	debug("http_client", "export_download_complete", map[string]any{
+		"status_code": resp.StatusCode,
+		"bytes":       len(payload),
+	})
+	return payload, nil
+}
+
 func (c *HTTPClient) postForm(ctx context.Context, endpoint string, values url.Values, out any) error {
+	debug("http_client", "request_start", map[string]any{
+		"endpoint": endpoint,
+		"fields":   sanitizeValues(values),
+	})
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+endpoint, bytes.NewBufferString(values.Encode()))
 	if err != nil {
+		debug("http_client", "request_build_error", map[string]any{"endpoint": endpoint, "error": err.Error()})
 		return fmt.Errorf("poeditor request build %s: %w", endpoint, err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	resp, err := c.http.Do(req)
 	if err != nil {
+		debug("http_client", "request_error", map[string]any{"endpoint": endpoint, "error": err.Error()})
 		return fmt.Errorf("poeditor request %s: %w", endpoint, err)
 	}
 	defer func() {
@@ -141,12 +526,44 @@ func (c *HTTPClient) postForm(ctx context.Context, endpoint string, values url.V
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		debug("http_client", "request_status_error", map[string]any{
+			"endpoint":    endpoint,
+			"status_code": resp.StatusCode,
+			"body":        strings.TrimSpace(string(body)),
+		})
 		return fmt.Errorf("poeditor request %s: status %d: %s", endpoint, resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		debug("http_client", "response_decode_error", map[string]any{"endpoint": endpoint, "error": err.Error()})
 		return fmt.Errorf("poeditor decode %s response: %w", endpoint, err)
 	}
+	debug("http_client", "request_complete", map[string]any{
+		"endpoint":    endpoint,
+		"status_code": resp.StatusCode,
+	})
 
 	return nil
+}
+
+func sanitizeValues(values url.Values) map[string]any {
+	out := make(map[string]any, len(values))
+	for key, items := range values {
+		switch key {
+		case "api_token":
+			out[key] = "[redacted]"
+		case "data":
+			out[key] = truncateDebugValue(strings.Join(items, ","), 1000)
+		default:
+			out[key] = strings.Join(items, ",")
+		}
+	}
+	return out
+}
+
+func truncateDebugValue(value string, maxLen int) string {
+	if maxLen <= 0 || len(value) <= maxLen {
+		return value
+	}
+	return value[:maxLen] + "...(truncated)"
 }

--- a/internal/i18n/storage/poeditor/http_client.go
+++ b/internal/i18n/storage/poeditor/http_client.go
@@ -424,6 +424,9 @@ func orderedLocales(byLocale map[string][]map[string]string, sourceLanguage stri
 func encodeEntriesJSON(entries []storage.Entry) ([]byte, error) {
 	values := make(map[string]string, len(entries))
 	for _, entry := range entries {
+		if _, exists := values[entry.Key]; exists {
+			return nil, fmt.Errorf("duplicate key %q in upload payload for locale %q", entry.Key, entry.Locale)
+		}
 		values[entry.Key] = entry.Value
 	}
 	return json.Marshal(values)

--- a/internal/i18n/storage/poeditor/http_client_test.go
+++ b/internal/i18n/storage/poeditor/http_client_test.go
@@ -2,15 +2,18 @@ package poeditor
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/quiet-circles/hyperlocalise/internal/i18n/storage"
 )
 
 func TestNewHTTPClientUsesDefaultTimeout(t *testing.T) {
@@ -23,137 +26,133 @@ func TestNewHTTPClientUsesDefaultTimeout(t *testing.T) {
 	}
 }
 
-func TestHTTPClientListTermsFiltersLocales(t *testing.T) {
+func TestHTTPClientExportFileDownloadsJSON(t *testing.T) {
+	var serverURL string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/terms/list" {
+		switch r.URL.Path {
+		case "/projects/export":
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read body: %v", err)
+			}
+			values, err := url.ParseQuery(string(body))
+			if err != nil {
+				t.Fatalf("parse form body: %v", err)
+			}
+			if got := values.Get("language"); got != "fr" {
+				t.Fatalf("unexpected language: %q", got)
+			}
+			_, _ = fmt.Fprintf(w, `{"result":{"url":"%s/download/fr.json"}}`, serverURL)
+		case "/download/fr.json":
+			_, _ = fmt.Fprint(w, `{"hello":"bonjour","bye":"au revoir"}`)
+		default:
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
-		if ct := r.Header.Get("Content-Type"); !strings.Contains(ct, "application/x-www-form-urlencoded") {
-			t.Fatalf("unexpected content-type: %s", ct)
-		}
-		body, err := io.ReadAll(r.Body)
-		if err != nil {
-			t.Fatalf("read body: %v", err)
-		}
-		values, err := url.ParseQuery(string(body))
-		if err != nil {
-			t.Fatalf("parse form body: %v", err)
-		}
-		if got := values.Get("api_token"); got != "token" {
-			t.Fatalf("unexpected api_token: %q", got)
-		}
-		if got := values.Get("id"); got != "123" {
-			t.Fatalf("unexpected project id: %q", got)
-		}
-
-		_, _ = fmt.Fprint(w, `{
-			"result":{"code":"200","message":"OK"},
-			"terms":[
-				{"term":"hello","context":"home","translations":[
-					{"language":"fr","content":"bonjour"},
-					{"language":"de","content":"hallo"}
-				]},
-				{"term":"bye","context":"","translations":[
-					{"language":"fr","content":"au revoir"}
-				]}
-			]
-		}`)
 	}))
 	defer srv.Close()
+	serverURL = srv.URL
 
-	client := &HTTPClient{
-		baseURL: srv.URL,
-		http:    srv.Client(),
-	}
-
-	entries, revision, err := client.ListTerms(context.Background(), ListTermsInput{
+	client := &HTTPClient{baseURL: srv.URL, http: srv.Client()}
+	entries, revision, err := client.ExportFile(context.Background(), ExportFileInput{
 		ProjectID: "123",
 		APIToken:  "token",
 		Locales:   []string{"fr"},
+		Type:      "key_value_json",
 	})
 	if err != nil {
-		t.Fatalf("list terms: %v", err)
+		t.Fatalf("export file: %v", err)
 	}
 	if revision == "" {
 		t.Fatalf("expected revision")
 	}
 	if got := len(entries); got != 2 {
-		t.Fatalf("expected 2 filtered entries, got %d", got)
-	}
-	for _, e := range entries {
-		if e.Locale != "fr" {
-			t.Fatalf("expected filtered locale fr, got %+v", e)
-		}
+		t.Fatalf("expected 2 entries, got %d", got)
 	}
 }
 
-func TestHTTPClientUpsertTranslationsSendsGroupedPayload(t *testing.T) {
-	var calls []struct {
-		Path   string
-		Values url.Values
-	}
-
+func TestHTTPClientAvailableLanguagesReadsCodes(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, err := io.ReadAll(r.Body)
-		if err != nil {
-			t.Fatalf("read body: %v", err)
+		if r.URL.Path != "/languages/available" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
-		values, err := url.ParseQuery(string(body))
-		if err != nil {
-			t.Fatalf("parse query: %v", err)
-		}
-		calls = append(calls, struct {
-			Path   string
-			Values url.Values
-		}{Path: r.URL.Path, Values: values})
-
-		_, _ = fmt.Fprint(w, `{"result":{"code":"200","message":"OK"}}`)
+		_, _ = fmt.Fprint(w, `{"result":{"languages":[{"code":"en-us"},{"code":"vi"},{"code":"zh-Hans"}]}}`)
 	}))
 	defer srv.Close()
 
-	client := &HTTPClient{
-		baseURL: srv.URL,
-		http:    srv.Client(),
+	client := &HTTPClient{baseURL: srv.URL, http: srv.Client()}
+	codes, err := client.AvailableLanguages(context.Background(), "token")
+	if err != nil {
+		t.Fatalf("available languages: %v", err)
+	}
+	if got := len(codes); got != 3 {
+		t.Fatalf("expected 3 codes, got %+v", codes)
+	}
+}
+
+func TestHTTPClientUploadFileUsesMultipartForm(t *testing.T) {
+	expectedFile, err := os.ReadFile(filepath.Join("..", "..", "..", "..", "tests", "key_value_json", "en-US.json"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
 	}
 
-	revision, err := client.UpsertTranslations(context.Background(), UpsertTranslationsInput{
+	uploads := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/projects/upload" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if !strings.Contains(r.Header.Get("Content-Type"), "multipart/form-data") {
+			t.Fatalf("unexpected content type: %s", r.Header.Get("Content-Type"))
+		}
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Fatalf("parse multipart: %v", err)
+		}
+		uploads++
+		if got := r.FormValue("language"); got != "en" {
+			t.Fatalf("unexpected language: %q", got)
+		}
+		if got := r.FormValue("updating"); got != "translations" {
+			t.Fatalf("unexpected updating: %q", got)
+		}
+		files := r.MultipartForm.File["file"]
+		if len(files) != 1 {
+			t.Fatalf("expected 1 uploaded file, got %d", len(files))
+		}
+		if got := files[0].Filename; got != "en.json" {
+			t.Fatalf("unexpected uploaded filename: %q", got)
+		}
+		file, err := files[0].Open()
+		if err != nil {
+			t.Fatalf("open uploaded file: %v", err)
+		}
+		defer func() { _ = file.Close() }()
+		body, err := io.ReadAll(file)
+		if err != nil {
+			t.Fatalf("read uploaded file: %v", err)
+		}
+		if strings.TrimSpace(string(body)) != strings.TrimSpace(string(expectedFile)) {
+			t.Fatalf("unexpected uploaded body: %s", string(body))
+		}
+		_, _ = fmt.Fprint(w, `{"result":{"terms":{"parsed":0,"added":0,"deleted":0},"translations":{"parsed":1,"added":0,"updated":1}}}`)
+	}))
+	defer srv.Close()
+
+	client := &HTTPClient{baseURL: srv.URL, http: srv.Client()}
+	out, _, err := client.UploadFile(context.Background(), UploadFileInput{
 		ProjectID: "123",
 		APIToken:  "token",
-		Entries: []TermTranslation{
-			{Term: "hello", Context: "home", Locale: "fr", Value: "bonjour"},
-			{Term: "bye", Locale: "fr", Value: "au revoir"},
-			{Term: "skip", Locale: "", Value: "x"},
-			{Term: "hello", Locale: "de", Value: "hallo"},
-		},
+		Locale:    "en",
+		Type:      "key_value_json",
+		Updating:  "translations",
+		Entries:   []storage.Entry{{Key: "hello", Locale: "en", Value: "bonjour"}},
 	})
 	if err != nil {
-		t.Fatalf("upsert translations: %v", err)
+		t.Fatalf("upload file: %v", err)
 	}
-	if revision == "" {
-		t.Fatalf("expected revision")
+	if uploads != 1 {
+		t.Fatalf("expected 1 upload, got %d", uploads)
 	}
-	if got := len(calls); got != 2 {
-		t.Fatalf("expected 2 locale-grouped calls, got %d", got)
-	}
-
-	for _, call := range calls {
-		if call.Path != "/translations/update" {
-			t.Fatalf("unexpected path: %s", call.Path)
-		}
-		if call.Values.Get("api_token") != "token" || call.Values.Get("id") != "123" {
-			t.Fatalf("unexpected auth/id form values: %+v", call.Values)
-		}
-		raw := call.Values.Get("data")
-		if raw == "" {
-			t.Fatalf("missing data payload")
-		}
-		var payload []map[string]string
-		if err := json.Unmarshal([]byte(raw), &payload); err != nil {
-			t.Fatalf("decode data payload: %v", err)
-		}
-		if len(payload) == 0 {
-			t.Fatalf("expected non-empty payload")
-		}
+	if out.TranslationsUpdated != 1 {
+		t.Fatalf("unexpected upload result: %+v", out)
 	}
 }
 

--- a/internal/i18n/storage/poeditor/http_client_test.go
+++ b/internal/i18n/storage/poeditor/http_client_test.go
@@ -156,6 +156,16 @@ func TestHTTPClientUploadFileUsesMultipartForm(t *testing.T) {
 	}
 }
 
+func TestEncodeEntriesJSONRejectsDuplicateKeys(t *testing.T) {
+	_, err := encodeEntriesJSON([]storage.Entry{
+		{Key: "hello", Locale: "fr", Value: "bonjour"},
+		{Key: "hello", Locale: "fr", Value: "salut"},
+	})
+	if err == nil || !strings.Contains(err.Error(), `duplicate key "hello"`) {
+		t.Fatalf("expected duplicate key error, got %v", err)
+	}
+}
+
 func TestHTTPClientPostFormHTTPError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "boom", http.StatusBadRequest)

--- a/internal/i18n/syncsvc/service.go
+++ b/internal/i18n/syncsvc/service.go
@@ -15,7 +15,8 @@ const (
 )
 
 type LocalReadRequest struct {
-	Locales []string
+	Locales     []string
+	SourcePaths []string
 }
 
 type PullOptions struct {
@@ -51,6 +52,7 @@ type PullInput struct {
 	Request storage.PullRequest
 	Read    LocalReadRequest
 	Options PullOptions
+	Scope   Scope
 }
 
 type PushInput struct {
@@ -58,6 +60,15 @@ type PushInput struct {
 	Local   LocalStore
 	Read    LocalReadRequest
 	Options PushOptions
+	Scope   Scope
+}
+
+type Scope struct {
+	Entries map[storage.EntryID]ScopedEntry
+}
+
+type ScopedEntry struct {
+	Namespace string
 }
 
 type Report struct {
@@ -91,6 +102,7 @@ func (s *Service) Pull(ctx context.Context, in PullInput) (Report, error) {
 	if err != nil {
 		return Report{}, fmt.Errorf("pull remote snapshot: %w", err)
 	}
+	remoteResult.Snapshot = filterSnapshot(remoteResult.Snapshot, in.Scope)
 
 	report := buildPullReport(localSnapshot, remoteResult.Snapshot, in.Options)
 	report.Action = "pull"
@@ -122,14 +134,48 @@ func (s *Service) Push(ctx context.Context, in PushInput) (Report, error) {
 		return Report{}, fmt.Errorf("build local push snapshot: %w", err)
 	}
 
+	if strings.EqualFold(strings.TrimSpace(in.Adapter.Name()), "poeditor") {
+		report, pushReq := buildUploadOnlyPushReport(localSnapshot)
+		report.Action = "push"
+		pushReq.Locales = append([]string(nil), in.Read.Locales...)
+		pushReq.Options = make(map[string]string, 1)
+		if len(in.Read.SourcePaths) == 0 {
+			pushReq.Options["scope"] = "full"
+		} else {
+			pushReq.Options["scope"] = "partial"
+		}
+		if in.Options.DryRun || len(pushReq.Entries) == 0 {
+			return report, nil
+		}
+
+		pushResult, err := in.Adapter.Push(ctx, pushReq)
+		report.Applied = append(report.Applied, pushResult.Applied...)
+		report.Skipped = append(report.Skipped, pushResult.Skipped...)
+		report.Conflicts = append(report.Conflicts, pushResult.Conflicts...)
+		report.Warnings = append(report.Warnings, pushResult.Warnings...)
+		if err != nil {
+			return report, fmt.Errorf("push remote changes: %w", err)
+		}
+
+		return report, nil
+	}
+
 	remoteResult, err := in.Adapter.Pull(ctx, storage.PullRequest{Locales: in.Read.Locales})
 	if err != nil {
 		return Report{}, fmt.Errorf("pull remote baseline: %w", err)
 	}
+	remoteResult.Snapshot = filterSnapshot(remoteResult.Snapshot, in.Scope)
 
 	report, pushReq := buildPushReport(localSnapshot, remoteResult.Snapshot, in.Options)
 	report.Action = "push"
 	report.Warnings = append(report.Warnings, remoteResult.Warnings...)
+	pushReq.Locales = append([]string(nil), in.Read.Locales...)
+	pushReq.Options = make(map[string]string, 1)
+	if len(in.Read.SourcePaths) == 0 {
+		pushReq.Options["scope"] = "full"
+	} else {
+		pushReq.Options["scope"] = "partial"
+	}
 
 	if in.Options.FailOnConflict && len(report.Conflicts) > 0 {
 		return report, fmt.Errorf("push conflicts detected: %d", len(report.Conflicts))
@@ -148,6 +194,35 @@ func (s *Service) Push(ctx context.Context, in PushInput) (Report, error) {
 	}
 
 	return report, nil
+}
+
+func buildUploadOnlyPushReport(local storage.CatalogSnapshot) (Report, storage.PushRequest) {
+	report := Report{
+		Updates: append([]storage.Entry(nil), local.Entries...),
+	}
+	pushReq := storage.PushRequest{
+		Entries: append([]storage.Entry(nil), local.Entries...),
+	}
+	sortReport(&report)
+	return report, pushReq
+}
+
+func filterSnapshot(snapshot storage.CatalogSnapshot, scope Scope) storage.CatalogSnapshot {
+	if len(scope.Entries) == 0 {
+		return snapshot
+	}
+
+	filtered := make([]storage.Entry, 0, len(snapshot.Entries))
+	for _, entry := range snapshot.Entries {
+		if scoped, ok := scope.Entries[entry.ID()]; ok {
+			if strings.TrimSpace(entry.Namespace) == "" {
+				entry.Namespace = scoped.Namespace
+			}
+			filtered = append(filtered, entry)
+		}
+	}
+	snapshot.Entries = filtered
+	return snapshot
 }
 
 func buildPullReport(local, remote storage.CatalogSnapshot, opts PullOptions) Report {

--- a/internal/i18n/syncsvc/service_test.go
+++ b/internal/i18n/syncsvc/service_test.go
@@ -37,14 +37,22 @@ func (f *fakeLocalStore) ApplyPull(_ context.Context, plan ApplyPullPlan) (Apply
 
 type fakeAdapter struct {
 	pullResult storage.PullResult
+	pullCount  int
 	pushReq    storage.PushRequest
 	pushResult storage.PushResult
 	pushErr    error
+	name       string
 }
 
-func (f *fakeAdapter) Name() string                       { return "fake" }
+func (f *fakeAdapter) Name() string {
+	if strings.TrimSpace(f.name) != "" {
+		return f.name
+	}
+	return "fake"
+}
 func (f *fakeAdapter) Capabilities() storage.Capabilities { return storage.Capabilities{} }
 func (f *fakeAdapter) Pull(_ context.Context, _ storage.PullRequest) (storage.PullResult, error) {
+	f.pullCount++
 	return f.pullResult, nil
 }
 
@@ -232,6 +240,49 @@ func TestPushUpdatesRemoteWhenMismatchIsSafe(t *testing.T) {
 	}
 	if got := len(report.Conflicts); got != 0 {
 		t.Fatalf("expected 0 conflicts, got %d", got)
+	}
+}
+
+func TestPushPOEditorSkipsRemoteBaselineAndUploadsDirectly(t *testing.T) {
+	svc := New()
+	local := &fakeLocalStore{
+		readSnapshot: storage.CatalogSnapshot{
+			Entries: []storage.Entry{{
+				Key:    "hello",
+				Locale: "fr",
+				Value:  "bonjour local curated",
+				Provenance: storage.EntryProvenance{
+					Origin: storage.OriginHuman,
+					State:  storage.StateCurated,
+				},
+			}},
+		},
+	}
+	adapter := &fakeAdapter{
+		name:       "poeditor",
+		pushResult: storage.PushResult{Applied: []storage.EntryID{{Key: "hello", Locale: "fr"}}},
+	}
+
+	report, err := svc.Push(context.Background(), PushInput{
+		Adapter: adapter,
+		Local:   local,
+		Read:    LocalReadRequest{Locales: []string{"fr"}},
+		Options: PushOptions{DryRun: false},
+	})
+	if err != nil {
+		t.Fatalf("push sync: %v", err)
+	}
+	if got := adapter.pullCount; got != 0 {
+		t.Fatalf("expected no remote baseline pull, got %d", got)
+	}
+	if got := len(adapter.pushReq.Entries); got != 1 {
+		t.Fatalf("expected direct upload of local entries, got %d", got)
+	}
+	if got := len(report.Updates); got != 1 {
+		t.Fatalf("expected 1 reported upload entry, got %d", got)
+	}
+	if got := len(report.Applied); got != 1 {
+		t.Fatalf("expected 1 applied entry, got %d", got)
 	}
 }
 

--- a/tests/key_value_json/en-US.json
+++ b/tests/key_value_json/en-US.json
@@ -1,0 +1,1 @@
+{"hello":"bonjour"}


### PR DESCRIPTION
## What changed

<!-- Describe the change and why it is needed. -->

## How to test

<!-- List manual checks or commands used to verify this change. -->

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a full interactive TUI wizard (`--interactive`/`-i`) for `sync push` and `sync pull`, backed by a new `syncInteractiveModel` (BubbleTea) that walks the user through locale selection, file selection, flag toggling, and review before running the sync in a background goroutine. It also upgrades the POEditor adapter to use the `projects/export` / `projects/upload` multipart API (replacing `UpsertTranslations`), adds locale normalization via BCP-47 candidate matching with an RWMutex-based retry-safe cache, introduces multi-file-mapping support in `JSONStore`, and adds an opt-in JSON debug logger.

Key changes and concerns:

- **Interactive mode silently breaks POEditor full-scope pushes** (`cmd/sync_interactive.go`): `newSyncInteractiveModel` pre-selects every catalog file, so `finalOptions().sourcePaths` is always non-empty. This causes `service.Push` to permanently set `scope = "partial"`, meaning `sync_terms = false` for source-locale POEditor uploads — terms deleted locally are **never deleted from POEditor** when using interactive mode. The equivalent non-interactive invocation (`sync push` without `--file`) correctly uses `scope = "full"`.
- **Adapter-specific coupling in `JSONStore.BuildPushSnapshot`** (`localstore/jsonstore.go`): The local store now contains `strings.EqualFold(adapter, "poeditor")` logic to decide whether to include source-locale entries, mirroring the existing coupling concern in `service.go`.
- Several issues were already flagged in prior review threads: `dryRun` default flip, `sync.Once` → RWMutex retry (addressed), `SupportsContext` breaking change, goroutine cancellation on back-navigation, `execute: false` dead-code paths, and `encodeEntriesJSON` duplicate-key detection (now implemented).
- The `sanitizeValues` and `debug_log.go` additions are well-implemented; API tokens are redacted and the logger is safely off by default.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge — interactive mode produces silently different (less complete) POEditor pushes than the non-interactive equivalent, with no documentation or user warning.
- The interactive wizard always produces a non-empty `sourcePaths` list, which permanently locks every interactive POEditor push to "partial" scope. This means `sync_terms` is never sent, so terms removed from local files are never deleted from POEditor via interactive mode. This is a silent behavioral regression for any team relying on full-sync term management. Combined with the still-open concerns from prior rounds (goroutine cancellation on back-navigation, `dryRun` default flip, `execute:false` dead-code, adapter coupling in both `service.go` and `jsonstore.go`), the PR carries meaningful risk.
- Pay close attention to `cmd/sync_interactive.go` (finalOptions sourcePaths) and `internal/i18n/syncsvc/service.go` (scope="full" guard), as their interaction is what produces the silent behavioral difference.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| cmd/sync_interactive.go | New 1364-line TUI wizard for sync push/pull; well-structured BubbleTea model with goroutine-based sync execution, but interactive mode always emits non-empty `sourcePaths` from `finalOptions()`, which permanently locks POEditor pushes to "partial" scope and prevents `sync_terms` from firing — a silent behavioral divergence from non-interactive runs. |
| internal/i18n/syncsvc/service.go | Adds Scope/filterSnapshot support and an upload-only fast path for POEditor; the `len(in.Read.SourcePaths) == 0` guard that sets scope to "full" is correct for non-interactive calls but is never triggered by the interactive wizard. |
| internal/i18n/localstore/jsonstore.go | Major multi-mapping refactor with glob support; `BuildPushSnapshot` introduces adapter-specific POEditor coupling that mirrors the architectural concern already present in service.go. |
| internal/i18n/storage/poeditor/adapter.go | Switches to RWMutex-based double-check locking for language caching (correctly retrying after transient failures), adds locale normalization via BCP-47 candidate list, and replaces `UpsertTranslations` with `UploadFile` multipart path; `SupportsContext` correctly set to `false`. |
| internal/i18n/storage/poeditor/http_client.go | Adds ExportFile (two-step GET via export URL), UploadFile (multipart form), AvailableLanguages, AddTerms/DeleteTerms; encodeEntriesJSON now rejects duplicates; comprehensive debug logging throughout. |
| cmd/sync.go | Adds `--interactive`/`-i` and `--file` flags; `dryRun` default flipped from `true` to `false` (already flagged as a breaking behavioral change); `writeSyncReportWriter` helper cleanly extracted. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant CLI as sync_push/pull (CLI)
    participant TUI as syncInteractiveModel (TUI)
    participant Goroutine as sync goroutine
    participant SyncSvc as syncsvc.Service
    participant LocalStore as JSONStore
    participant Adapter as POEditor Adapter
    participant API as POEditor API

    User->>CLI: hyperlocalise sync push -i
    CLI->>TUI: runSyncInteractiveWizard()
    TUI->>User: Step 1 — Select Locales
    User->>TUI: confirm locale selection
    TUI->>User: Step 2 — Select Files (all pre-selected)
    User->>TUI: confirm file selection
    TUI->>User: Step 3 — Toggle Flags (dry-run, etc.)
    User->>TUI: continue to Review
    TUI->>User: Step 4 — Review & confirm
    User->>TUI: "Run sync"
    TUI->>Goroutine: startRunCmd() — spawns goroutine
    Goroutine->>LocalStore: BuildPushSnapshot(sourcePaths)
    LocalStore-->>Goroutine: CatalogSnapshot (source + target entries)
    Goroutine->>TUI: syncExecutionPlanMsg (queued rows)
    Goroutine->>LocalStore: ResolveScope(sourcePaths)
    LocalStore-->>Goroutine: Scope{Entries}
    Goroutine->>SyncSvc: Push(PushInput{scope, sourcePaths})
    Note over SyncSvc: adapter.Name()=="poeditor" → upload-only path
    SyncSvc->>Adapter: Push(PushRequest{entries, scope="partial"})
    Note over Adapter: scope always "partial" from interactive<br/>→ SyncTerms=false for source locale
    Adapter->>API: AvailableLanguages (cached via RWMutex)
    API-->>Adapter: language codes
    Adapter->>API: POST /projects/upload (multipart, per locale)
    API-->>Adapter: UploadFileResult
    Adapter-->>SyncSvc: PushResult{Applied, Warnings}
    SyncSvc-->>Goroutine: Report
    Goroutine->>TUI: syncExecutionFinishedMsg
    TUI->>User: Step 5 — Run results table
    User->>TUI: enter/q to exit
    TUI-->>CLI: syncInteractiveResult{execute:false}
    CLI->>User: (optional JSON/markdown report printed)
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `internal/i18n/storage/poeditor/adapter.go`, line 623-629 ([link](https://github.com/quiet-circles/hyperlocalise/blob/5a88f9ea7dee4949cde9c7a48cd4e00e7afb2711/internal/i18n/storage/poeditor/adapter.go#L623-L629)) 

   **`SupportsContext: false` is a silent breaking change**

   `SupportsContext` has been flipped from `true` to `false`. The adapter also now hard-rejects any entry with a non-empty `Context` field in `Push`:

   ```go
   if strings.TrimSpace(entry.Context) != "" {
       return storage.PushResult{}, fmt.Errorf("poeditor upload does not support entry context; found context for key %q", entry.Key)
   }
   ```

   Any project that previously synced contextual terms (e.g. via FormatJS files where context is set) through POEditor will fail with a runtime error on their next `sync push`. This is a hard break with no graceful degradation or opt-out.

   The new upload-only path in `service.go` feeds all entries from `BuildPushSnapshot` directly into `Push`, including any entries whose `EntryContext` is non-empty. If a bucket mixes contextless keys with contextual keys (e.g. a mixed FormatJS file), the first contextual key will abort the entire push for that locale.

   Before merging, consider:
   1. Documenting this as a breaking change for users who have been relying on the (previously advertised) context support.
   2. Silently skipping context during the upload path and logging a warning rather than aborting, so non-contextual keys still sync.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/i18n/storage/poeditor/adapter.go
   Line: 623-629

   Comment:
   **`SupportsContext: false` is a silent breaking change**

   `SupportsContext` has been flipped from `true` to `false`. The adapter also now hard-rejects any entry with a non-empty `Context` field in `Push`:

   ```go
   if strings.TrimSpace(entry.Context) != "" {
       return storage.PushResult{}, fmt.Errorf("poeditor upload does not support entry context; found context for key %q", entry.Key)
   }
   ```

   Any project that previously synced contextual terms (e.g. via FormatJS files where context is set) through POEditor will fail with a runtime error on their next `sync push`. This is a hard break with no graceful degradation or opt-out.

   The new upload-only path in `service.go` feeds all entries from `BuildPushSnapshot` directly into `Push`, including any entries whose `EntryContext` is non-empty. If a bucket mixes contextless keys with contextual keys (e.g. a mixed FormatJS file), the first contextual key will abort the entire push for that locale.

   Before merging, consider:
   1. Documenting this as a breaking change for users who have been relying on the (previously advertised) context support.
   2. Silently skipping context during the upload path and logging a warning rather than aborting, so non-contextual keys still sync.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `internal/i18n/storage/poeditor/http_client.go`, line 3774-3779 ([link](https://github.com/quiet-circles/hyperlocalise/blob/5a88f9ea7dee4949cde9c7a48cd4e00e7afb2711/internal/i18n/storage/poeditor/http_client.go#L3774-L3779)) 

   **`encodeEntriesJSON` silently drops duplicate keys**

   When two `storage.Entry` values share the same `Key` (which can occur if the same source file is selected more than once, or if the snapshot builder produces duplicates), only the last value survives — the earlier one is silently overwritten by the map assignment:

   ```go
   for _, entry := range entries {
       values[entry.Key] = entry.Value   // last writer wins
   }
   ```

   Since the caller (`Push`) already groups entries by locale before calling `UploadFile`, duplicates within a single locale group would be quietly dropped. Consider asserting uniqueness and returning an error, or at least logging a debug warning, so data-loss surprises surface during development:

   ```go
   for _, entry := range entries {
       if _, exists := values[entry.Key]; exists {
           // duplicate key for this locale — last value wins; log or return error
       }
       values[entry.Key] = entry.Value
   }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/i18n/storage/poeditor/http_client.go
   Line: 3774-3779

   Comment:
   **`encodeEntriesJSON` silently drops duplicate keys**

   When two `storage.Entry` values share the same `Key` (which can occur if the same source file is selected more than once, or if the snapshot builder produces duplicates), only the last value survives — the earlier one is silently overwritten by the map assignment:

   ```go
   for _, entry := range entries {
       values[entry.Key] = entry.Value   // last writer wins
   }
   ```

   Since the caller (`Push`) already groups entries by locale before calling `UploadFile`, duplicates within a single locale group would be quietly dropped. Consider asserting uniqueness and returning an error, or at least logging a debug warning, so data-loss surprises surface during development:

   ```go
   for _, entry := range entries {
       if _, exists := values[entry.Key]; exists {
           // duplicate key for this locale — last value wins; log or return error
       }
       values[entry.Key] = entry.Value
   }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

3. `cmd/sync_interactive.go`, line 1392-1395 ([link](https://github.com/quiet-circles/hyperlocalise/blob/ceb170666167da761e7df9a95e4a84611887fd3e/cmd/sync_interactive.go#L1392-L1395)) 

   **`context.Background()` ignores cancellation in plan builder**

   `executionPlanRows` receives a `ctx` argument (the goroutine's cancellable context) but calls `ReadSnapshot`/`BuildPushSnapshot` with `context.Background()` instead. If the user cancels the interactive session while the plan is being built, the underlying store I/O won't be interrupted — the goroutine will stay alive until the file-system reads complete, then attempt to send to the (now-defunct) channel.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: cmd/sync_interactive.go
   Line: 1392-1395

   Comment:
   **`context.Background()` ignores cancellation in plan builder**

   `executionPlanRows` receives a `ctx` argument (the goroutine's cancellable context) but calls `ReadSnapshot`/`BuildPushSnapshot` with `context.Background()` instead. If the user cancels the interactive session while the plan is being built, the underlying store I/O won't be interrupted — the goroutine will stay alive until the file-system reads complete, then attempt to send to the (now-defunct) channel.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: cmd/sync_interactive.go
Line: 1019-1020

Comment:
**Interactive mode always produces "partial" scope — `sync_terms` never fires**

`newSyncInteractiveModel` pre-selects every catalog file (line ~508: `if len(seed.sourcePaths) == 0 { m.selectedFiles[path] = struct{}{} }`). Because the UI enforces "at least one file selected" before advancing, `m.selectedFiles` is **always non-empty** when the wizard finishes.

`finalOptions()` then sets `out.sourcePaths = sortedMapKeys(m.selectedFiles)` — a non-nil, non-empty slice — so `in.Read.SourcePaths` is never empty in interactive mode.

In `service.Push` the POEditor code path checks `len(in.Read.SourcePaths) == 0` to decide between `scope = "full"` and `scope = "partial"`. Because the slice is always non-empty from interactive mode, the scope is **always "partial"**, which means `SyncTerms = false` — terms removed from local files are **never deleted from POEditor** in an interactive push.

The equivalent non-interactive invocation (`hyperlocalise sync push` without `--file`) passes `SourcePaths = nil`, correctly triggering `scope = "full"` and `sync_terms = true` for the source locale.

A user who runs an interactive push with all files selected will get a fundamentally different (and less complete) result than the non-interactive equivalent. Consider treating "all catalog files selected" the same as "no explicit file filter" by comparing `len(m.selectedFiles) == len(m.catalogFiles())` and omitting `sourcePaths` from `finalOptions` in that case.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/i18n/localstore/jsonstore.go
Line: 49-58

Comment:
**Adapter-specific coupling in `BuildPushSnapshot`**

`BuildPushSnapshot` now contains `strings.EqualFold(s.cfg.Storage.Adapter, "poeditor")` to decide whether to augment the snapshot with source-locale entries. This places POEditor-specific business logic inside the generic local store — the same architectural coupling concern already raised for `service.go`.

The local store has no awareness of remote adapter capabilities and shouldn't need to. A cleaner approach would be to express the capability through the `StorageAdapter` interface (e.g., `IncludesSourceLocaleInPush() bool`) and let the caller (`service.Push`) pass that information into `BuildPushSnapshot` via the existing `LocalReadRequest`, or via a separate option struct. That keeps all adapter-specific branching in one place and prevents this list from growing as more adapters are added.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 3503e5b</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->