### PR TITLE
Add translation job API (create/list/get/cancel) with Inngest integration and tests

### DIFF
--- a/apps/hyperlocalise-web/src/api/app.ts
+++ b/apps/hyperlocalise-web/src/api/app.ts
@@ -3,11 +3,13 @@ import { Hono } from "hono";
 import { authRoutes } from "./routes/auth";
 import { healthRoutes } from "./routes/health";
 import { projectRoutes } from "./routes/project/project.route";
+import { translationJobRoutes } from "./routes/translation-job/translation-job.route";
 
 export const app = new Hono()
   .basePath("/api")
   .route("/health", healthRoutes)
   .route("/auth", authRoutes)
-  .route("/project", projectRoutes);
+  .route("/project", projectRoutes)
+  .route("/translation", translationJobRoutes);
 
 export type AppType = typeof app;

--- a/apps/hyperlocalise-web/src/api/routes/translation-job/translation-job.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/translation-job/translation-job.route.ts
@@ -1,0 +1,271 @@
+import { randomUUID } from "node:crypto";
+
+import { and, desc, eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { validator } from "hono/validator";
+
+import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
+import { db, schema } from "@/lib/database";
+import { inngestClient } from "@/lib/inngest/client";
+
+import {
+  createTranslationJobBodySchema,
+  listTranslationJobsQuerySchema,
+  translationJobIdParamsSchema,
+} from "./translation-job.schema";
+
+const allowedMutationRoles = new Set<string>(["owner", "admin"]);
+
+type QueuePublisher = {
+  send(event: {
+    name: "translation/job.queued";
+    data: {
+      jobId: string;
+      projectId: string;
+      organizationId: string;
+      createdByUserId: string;
+      type: "string" | "file";
+      inputPayload: unknown;
+    };
+  }): Promise<{ ids: string[] }>;
+};
+
+async function enqueueTranslationJob(
+  publisher: QueuePublisher,
+  payload: Parameters<QueuePublisher["send"]>[0],
+) {
+  const queued = await publisher.send(payload);
+  return queued.ids.at(0) ?? null;
+}
+
+function isMutationAllowed(role: string) {
+  return allowedMutationRoles.has(role);
+}
+
+function invalidTranslationJobPayloadResponse(c: {
+  json(body: { error: string }, status: 400): Response;
+}) {
+  return c.json({ error: "invalid_translation_job_payload" }, 400);
+}
+
+function translationJobNotFoundResponse(c: {
+  json(body: { error: string }, status: 404): Response;
+}) {
+  return c.json({ error: "translation_job_not_found" }, 404);
+}
+
+function projectNotFoundResponse(c: { json(body: { error: string }, status: 404): Response }) {
+  return c.json({ error: "project_not_found" }, 404);
+}
+
+function forbiddenResponse(c: { json(body: { error: string }, status: 403): Response }) {
+  return c.json({ error: "forbidden" }, 403);
+}
+
+function conflictResponse(c: { json(body: { error: string }, status: 409): Response }) {
+  return c.json({ error: "translation_job_conflict" }, 409);
+}
+
+const validateTranslationJobParams = validator("param", (value, c) => {
+  const parsed = translationJobIdParamsSchema.safeParse(value);
+
+  if (!parsed.success) {
+    return translationJobNotFoundResponse(c);
+  }
+
+  return parsed.data;
+});
+
+const validateCreateTranslationJobBody = validator("json", (value, c) => {
+  const parsed = createTranslationJobBodySchema.safeParse(value);
+
+  if (!parsed.success) {
+    return invalidTranslationJobPayloadResponse(c);
+  }
+
+  return parsed.data;
+});
+
+const validateListTranslationJobsQuery = validator("query", (value, c) => {
+  const parsed = listTranslationJobsQuerySchema.safeParse(value);
+
+  if (!parsed.success) {
+    return invalidTranslationJobPayloadResponse(c);
+  }
+
+  return parsed.data;
+});
+
+export const translationJobRoutes = new Hono<{ Variables: AuthVariables }>()
+  .use("*", workosAuthMiddleware)
+  .post("/jobs", validateCreateTranslationJobBody, async (c) => {
+    if (!isMutationAllowed(c.var.auth.membership.role)) {
+      return forbiddenResponse(c);
+    }
+
+    const payload = c.req.valid("json");
+    const [project] = await db
+      .select({ id: schema.translationProjects.id })
+      .from(schema.translationProjects)
+      .where(
+        and(
+          eq(schema.translationProjects.id, payload.projectId),
+          eq(
+            schema.translationProjects.organizationId,
+            c.var.auth.organization.localOrganizationId,
+          ),
+        ),
+      )
+      .limit(1);
+
+    if (!project) {
+      return projectNotFoundResponse(c);
+    }
+
+    const jobId = `job_${randomUUID()}`;
+    const [createdJob] = await db
+      .insert(schema.translationJobs)
+      .values({
+        id: jobId,
+        projectId: project.id,
+        createdByUserId: c.var.auth.user.localUserId,
+        type: payload.type,
+        status: "queued",
+        inputPayload: payload.inputPayload,
+      })
+      .returning();
+
+    const workflowRunId = await enqueueTranslationJob(inngestClient, {
+      name: "translation/job.queued",
+      data: {
+        jobId: createdJob.id,
+        projectId: createdJob.projectId,
+        organizationId: c.var.auth.organization.localOrganizationId,
+        createdByUserId: c.var.auth.user.localUserId,
+        type: createdJob.type,
+        inputPayload: createdJob.inputPayload,
+      },
+    });
+
+    const [job] = await db
+      .update(schema.translationJobs)
+      .set({ workflowRunId })
+      .where(eq(schema.translationJobs.id, createdJob.id))
+      .returning();
+
+    return c.json({ job: job ?? createdJob }, 201);
+  })
+  .get("/jobs", validateListTranslationJobsQuery, async (c) => {
+    const query = c.req.valid("query");
+
+    const projectFilter = query.projectId
+      ? [eq(schema.translationJobs.projectId, query.projectId)]
+      : [];
+
+    const statusFilter = query.status ? [eq(schema.translationJobs.status, query.status)] : [];
+
+    const jobs = await db
+      .select()
+      .from(schema.translationJobs)
+      .innerJoin(
+        schema.translationProjects,
+        eq(schema.translationProjects.id, schema.translationJobs.projectId),
+      )
+      .where(
+        and(
+          eq(
+            schema.translationProjects.organizationId,
+            c.var.auth.organization.localOrganizationId,
+          ),
+          ...projectFilter,
+          ...statusFilter,
+        ),
+      )
+      .orderBy(desc(schema.translationJobs.createdAt))
+      .limit(query.limit ?? 50);
+
+    return c.json(
+      {
+        jobs: jobs.map((row) => row.translation_jobs),
+      },
+      200,
+    );
+  })
+  .get("/jobs/:jobId", validateTranslationJobParams, async (c) => {
+    const params = c.req.valid("param");
+
+    const [job] = await db
+      .select({
+        job: schema.translationJobs,
+      })
+      .from(schema.translationJobs)
+      .innerJoin(
+        schema.translationProjects,
+        eq(schema.translationProjects.id, schema.translationJobs.projectId),
+      )
+      .where(
+        and(
+          eq(schema.translationJobs.id, params.jobId),
+          eq(
+            schema.translationProjects.organizationId,
+            c.var.auth.organization.localOrganizationId,
+          ),
+        ),
+      )
+      .limit(1);
+
+    if (!job) {
+      return translationJobNotFoundResponse(c);
+    }
+
+    return c.json({ job: job.job }, 200);
+  })
+  .post("/jobs/:jobId/cancel", validateTranslationJobParams, async (c) => {
+    if (!isMutationAllowed(c.var.auth.membership.role)) {
+      return forbiddenResponse(c);
+    }
+
+    const params = c.req.valid("param");
+
+    const [job] = await db
+      .select({
+        id: schema.translationJobs.id,
+        status: schema.translationJobs.status,
+      })
+      .from(schema.translationJobs)
+      .innerJoin(
+        schema.translationProjects,
+        eq(schema.translationProjects.id, schema.translationJobs.projectId),
+      )
+      .where(
+        and(
+          eq(schema.translationJobs.id, params.jobId),
+          eq(
+            schema.translationProjects.organizationId,
+            c.var.auth.organization.localOrganizationId,
+          ),
+        ),
+      )
+      .limit(1);
+
+    if (!job) {
+      return translationJobNotFoundResponse(c);
+    }
+
+    if (job.status !== "queued" && job.status !== "running") {
+      return conflictResponse(c);
+    }
+
+    const [updated] = await db
+      .update(schema.translationJobs)
+      .set({
+        status: "failed",
+        outcomeKind: "error",
+        lastError: "canceled_by_user",
+        completedAt: new Date(),
+      })
+      .where(eq(schema.translationJobs.id, job.id))
+      .returning();
+
+    return c.json({ job: updated }, 200);
+  });

--- a/apps/hyperlocalise-web/src/api/routes/translation-job/translation-job.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/translation-job/translation-job.schema.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+
+export const translationJobIdParamsSchema = z.object({
+  jobId: z.string().trim().min(1),
+});
+
+export const createTranslationJobBodySchema = z.object({
+  projectId: z.string().trim().min(1),
+  type: z.enum(["string", "file"]),
+  inputPayload: z.unknown(),
+});
+
+export const listTranslationJobsQuerySchema = z.object({
+  projectId: z.string().trim().min(1).optional(),
+  status: z.enum(["queued", "running", "succeeded", "failed"]).optional(),
+  limit: z
+    .string()
+    .regex(/^\d+$/)
+    .transform((value) => Number(value))
+    .pipe(z.number().int().min(1).max(100))
+    .optional(),
+});
+
+export type TranslationJobIdParams = z.infer<typeof translationJobIdParamsSchema>;
+export type CreateTranslationJobBody = z.infer<typeof createTranslationJobBodySchema>;
+export type ListTranslationJobsQuery = z.infer<typeof listTranslationJobsQuerySchema>;

--- a/apps/hyperlocalise-web/src/api/routes/translation-job/translation-job.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/translation-job/translation-job.test.ts
@@ -1,0 +1,315 @@
+import "dotenv/config";
+
+import { randomUUID } from "node:crypto";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+
+import { eq } from "drizzle-orm";
+import { testClient } from "hono/testing";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import { AUTH_CONTEXT_HEADER, type WorkosAuthIdentity } from "@/api/auth/workos";
+import { db, schema } from "@/lib/database";
+
+const createdWorkosUserIds = new Set<string>();
+const createdWorkosOrganizationIds = new Set<string>();
+
+function createWorkosIdentity(
+  role: WorkosAuthIdentity["membership"]["role"] = "owner",
+): WorkosAuthIdentity {
+  const suffix = randomUUID();
+  const workosUserId = `user_${suffix}`;
+  const workosOrganizationId = `org_${suffix}`;
+
+  createdWorkosUserIds.add(workosUserId);
+  createdWorkosOrganizationIds.add(workosOrganizationId);
+
+  return {
+    user: {
+      workosUserId,
+      email: `${suffix}@example.com`,
+    },
+    organization: {
+      workosOrganizationId,
+      name: `Example Org ${suffix}`,
+      slug: `example-org-${suffix}`,
+    },
+    membership: {
+      workosMembershipId: `membership_${suffix}`,
+      role,
+    },
+  };
+}
+
+async function seedProject(identity: WorkosAuthIdentity, name: string) {
+  const { app } = await import("@/api/app");
+  const client = testClient(app);
+
+  const createResponse = await client.api.project.$post(
+    {
+      json: {
+        name,
+      },
+    },
+    {
+      headers: {
+        [AUTH_CONTEXT_HEADER]: JSON.stringify(identity),
+      },
+    },
+  );
+
+  if (createResponse.status !== 201) {
+    const body = await createResponse.json();
+    throw new Error(`failed to seed project: ${JSON.stringify(body)}`);
+  }
+
+  const body = (await createResponse.json()) as { project: { id: string } };
+  return body.project.id;
+}
+
+async function readJsonBody(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+
+  for await (const chunk of req) {
+    chunks.push(Buffer.from(chunk));
+  }
+
+  if (chunks.length === 0) {
+    return {};
+  }
+
+  return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+}
+
+async function startFakeInngestServer() {
+  const requests: {
+    method: string;
+    url: string;
+    body: unknown;
+  }[] = [];
+
+  const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+    const body = await readJsonBody(req);
+
+    requests.push({
+      method: req.method ?? "",
+      url: req.url ?? "",
+      body,
+    });
+
+    res.statusCode = 200;
+    res.setHeader("content-type", "application/json");
+    res.end(
+      JSON.stringify({
+        ids: [`run_${randomUUID()}`],
+        status: 200,
+      }),
+    );
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+
+  const address = server.address();
+
+  if (!address || typeof address === "string") {
+    throw new Error("failed to bind fake inngest server");
+  }
+
+  return {
+    requests,
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    close: async () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+
+          resolve();
+        });
+      }),
+  };
+}
+
+beforeAll(async () => {
+  await db.$client.query("select 1");
+});
+
+afterEach(async () => {
+  for (const workosOrganizationId of createdWorkosOrganizationIds) {
+    await db
+      .delete(schema.organizations)
+      .where(eq(schema.organizations.workosOrganizationId, workosOrganizationId));
+  }
+
+  for (const workosUserId of createdWorkosUserIds) {
+    await db.delete(schema.users).where(eq(schema.users.workosUserId, workosUserId));
+  }
+
+  createdWorkosOrganizationIds.clear();
+  createdWorkosUserIds.clear();
+});
+
+describe("translationJobRoutes", () => {
+  it("creates a translation job, enqueues through inngest, then fetches and lists it", async () => {
+    const fakeInngestServer = await startFakeInngestServer();
+
+    process.env.INNGEST_EVENT_KEY = "test-event-key";
+    process.env.INNGEST_BASE_URL = fakeInngestServer.baseUrl;
+
+    const { app } = await import("@/api/app");
+    const client = testClient(app);
+
+    const identity = createWorkosIdentity();
+    const projectId = await seedProject(identity, "Docs");
+
+    const createResponse = await client.api.translation.jobs.$post(
+      {
+        json: {
+          projectId,
+          type: "string",
+          inputPayload: {
+            sourceText: "Welcome",
+            sourceLocale: "en",
+            targetLocales: ["es"],
+          },
+        },
+      },
+      {
+        headers: {
+          [AUTH_CONTEXT_HEADER]: JSON.stringify(identity),
+        },
+      },
+    );
+
+    expect(createResponse.status).toBe(201);
+    const createdBody = (await createResponse.json()) as {
+      job: {
+        id: string;
+        projectId: string;
+        workflowRunId: string | null;
+      };
+    };
+
+    expect(createdBody.job.id).toMatch(/^job_/);
+    expect(createdBody.job.projectId).toBe(projectId);
+    expect(createdBody.job.workflowRunId).toMatch(/^run_/);
+
+    expect(fakeInngestServer.requests).toHaveLength(1);
+    expect(fakeInngestServer.requests[0]?.method).toBe("POST");
+    expect(fakeInngestServer.requests[0]?.url).toContain("test-event-key");
+    expect(fakeInngestServer.requests[0]?.body).toMatchObject({
+      name: "translation/job.queued",
+      data: {
+        jobId: createdBody.job.id,
+        projectId,
+      },
+    });
+
+    const getResponse = await client.api.translation.jobs[":jobId"].$get(
+      {
+        param: {
+          jobId: createdBody.job.id,
+        },
+      },
+      {
+        headers: {
+          [AUTH_CONTEXT_HEADER]: JSON.stringify(identity),
+        },
+      },
+    );
+
+    expect(getResponse.status).toBe(200);
+    const getBody = (await getResponse.json()) as { job: { id: string; projectId: string } };
+    expect(getBody.job.id).toBe(createdBody.job.id);
+    expect(getBody.job.projectId).toBe(projectId);
+
+    const listResponse = await client.api.translation.jobs.$get(
+      {
+        query: {
+          projectId,
+        },
+      },
+      {
+        headers: {
+          [AUTH_CONTEXT_HEADER]: JSON.stringify(identity),
+        },
+      },
+    );
+
+    expect(listResponse.status).toBe(200);
+    const listBody = (await listResponse.json()) as {
+      jobs: Array<{ id: string; projectId: string }>;
+    };
+    expect(listBody.jobs).toHaveLength(1);
+    expect(listBody.jobs[0]?.id).toBe(createdBody.job.id);
+
+    await fakeInngestServer.close();
+  });
+
+  it("cancels an in-flight translation job", async () => {
+    const fakeInngestServer = await startFakeInngestServer();
+
+    process.env.INNGEST_EVENT_KEY = "test-event-key";
+    process.env.INNGEST_BASE_URL = fakeInngestServer.baseUrl;
+
+    const { app } = await import("@/api/app");
+    const client = testClient(app);
+
+    const identity = createWorkosIdentity();
+    const projectId = await seedProject(identity, "Website");
+
+    const createResponse = await client.api.translation.jobs.$post(
+      {
+        json: {
+          projectId,
+          type: "string",
+          inputPayload: {
+            sourceText: "Home",
+            sourceLocale: "en",
+            targetLocales: ["fr"],
+          },
+        },
+      },
+      {
+        headers: {
+          [AUTH_CONTEXT_HEADER]: JSON.stringify(identity),
+        },
+      },
+    );
+
+    const createdBody = (await createResponse.json()) as { job: { id: string } };
+
+    const cancelResponse = await client.api.translation.jobs[":jobId"].cancel.$post(
+      {
+        param: {
+          jobId: createdBody.job.id,
+        },
+      },
+      {
+        headers: {
+          [AUTH_CONTEXT_HEADER]: JSON.stringify(identity),
+        },
+      },
+    );
+
+    expect(cancelResponse.status).toBe(200);
+    const canceledBody = (await cancelResponse.json()) as {
+      job: {
+        id: string;
+        status: string;
+        outcomeKind: string | null;
+        lastError: string | null;
+      };
+    };
+
+    expect(canceledBody.job.id).toBe(createdBody.job.id);
+    expect(canceledBody.job.status).toBe("failed");
+    expect(canceledBody.job.outcomeKind).toBe("error");
+    expect(canceledBody.job.lastError).toBe("canceled_by_user");
+
+    await fakeInngestServer.close();
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/inngest/client.ts
+++ b/apps/hyperlocalise-web/src/lib/inngest/client.ts
@@ -1,0 +1,11 @@
+import { Inngest } from "inngest";
+
+export function createInngestClient() {
+  return new Inngest({
+    id: "hyperlocalise-web",
+    eventKey: process.env.INNGEST_EVENT_KEY,
+    baseUrl: process.env.INNGEST_BASE_URL,
+  });
+}
+
+export const inngestClient = createInngestClient();

--- a/docs/adr/2026-04-05-translation-job-routes-design.md
+++ b/docs/adr/2026-04-05-translation-job-routes-design.md
@@ -1,0 +1,29 @@
+# Translation Job Routes + Integration Testing Design
+
+## Scope
+Implement translation job API operations with Hono routes:
+- create
+- get by id
+- list
+- cancel
+
+Testing must use the real API app and real database integration (no route mocking), and include local Inngest integration coverage.
+
+## Chosen approach
+Use thin route handlers mounted from `src/api/app.ts` with direct Drizzle DB access and Inngest event publishing through a small shared client module.
+
+## Data flow
+1. `POST /api/translation/jobs` validates payload and organization/project access.
+2. A job row is inserted in `translation_jobs` with status `queued`.
+3. An Inngest event is sent (`translation/job.queued`) and the first event/run id is persisted into `workflow_run_id`.
+4. The created job is returned.
+
+`GET /api/translation/jobs/:jobId` and `GET /api/translation/jobs` scope reads by the caller organization.
+
+`POST /api/translation/jobs/:jobId/cancel` checks mutation role and only allows cancellation from `queued`/`running`; it transitions to `failed` with `error` outcome payload metadata (`lastError = canceled_by_user`).
+
+## Testing strategy
+- Route integration tests call the real exported app via `hono/testing` `testClient`.
+- Tests authenticate using real auth middleware with `x-hyperlocalise-auth` header.
+- DB integration is real Drizzle/Postgres, with cleanup by deleting created org/user records.
+- Inngest integration uses a local HTTP test server and the real `Inngest` client configured with local `INNGEST_BASE_URL`, asserting the queued event request shape.


### PR DESCRIPTION
### Motivation

- Add first-class translation job support so projects can enqueue, list, fetch, and cancel translation jobs and persist workflow run ids from the queueing system.

### Description

- Register new `/api/translation` routes in `app.ts` and implement handlers in `translation-job.route.ts` providing `POST /jobs`, `GET /jobs`, `GET /jobs/:jobId`, and `POST /jobs/:jobId/cancel` with WorkOS auth and role checks.
- Add request validation schemas in `translation-job.schema.ts` using `zod` and Hono validators, and perform DB operations using Drizzle for create/read/update flows scoped to the caller organization.
- Introduce an Inngest client wrapper in `lib/inngest/client.ts` and enqueue events when jobs are created, persisting the returned `workflowRunId` on the job row.
- Add integration tests in `translation-job.test.ts` that run the real Hono app and DB, seed projects via the real API, use a local fake Inngest HTTP server, and assert event payloads and job lifecycle behavior.
- Add an ADR documenting the design and testing approach in `docs/adr/2026-04-05-translation-job-routes-design.md`.

### Testing

- Ran the new integration tests with `vitest` via `vitest` and the translation job test suite passed (tests exercise creation, enqueueing to a local fake Inngest server, retrieval, listing, and cancellation). 
- Tests use the real app exported from `@/api/app`, real Drizzle/Postgres DB connections, and a local fake Inngest server to validate event requests; all assertions in `translation-job.test.ts` succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d27a83c228832ca6eb8a1e2b5152b8)