### PR TITLE
Makefile: bootstrap pnpm & vite-plus and add `vp` test/check targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,18 @@ run: ## run the app
 
 .PHONY: bootstrap
 bootstrap: ## download tool and module dependencies
+	command -v pnpm >/dev/null 2>&1 || curl -fsSL https://get.pnpm.io/install.sh | sh -
+	command -v vp >/dev/null 2>&1 || pnpm add -g vite-plus
 	go mod download
 	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(golangci_lint_version)
+
+.PHONY: vp-test
+vp-test: ## run JavaScript tests via Vite+
+	vp test
+
+.PHONY: vp-check
+vp-check: ## run JS formatting/lint/type-checks via Vite+
+	vp check
 
 .PHONY: test-root
 test-root: clean ## run root-module tests with JSON output and coverage

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ test-workspace: clean ## run workspace tests
 	go tool cover -func=coverage.out | sort -rnk3
 
 .PHONY: test
-test: test-workspace ## run workspace-wide tests
+test: test-workspace vp-test ## run workspace-wide tests
 
 
 .PHONY: bench-runsvc
@@ -85,7 +85,7 @@ fmt: ## format go files
 
 
 .PHONY: lint
-lint: ## lint go files
+lint: vp-check ## lint go files
 	$(golangci_lint_bin) run ./...
 
 


### PR DESCRIPTION
### Motivation
- Enable JavaScript tooling in the repository by ensuring `pnpm` and `vite-plus` are available during bootstrap.  
- Provide lightweight Makefile targets to run Vite+ test and check flows from the workspace without adding separate scripts.  

### Description
- Updated the `bootstrap` target in the `Makefile` to install `pnpm` if missing and to globally add `vite-plus` (`vp`) via `pnpm`.  
- Added a `vp-test` target that runs `vp test` to execute JavaScript tests.  
- Added a `vp-check` target that runs `vp check` to perform JS formatting/lint/type-checks.  

### Testing
- No automated tests were run as part of this Makefile-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2d7e3b174832cb3215028ece39784)