### PR TITLE
feat(cli): align run locale flag with check/status

### DIFF
--- a/apps/cli/cmd/run.go
+++ b/apps/cli/cmd/run.go
@@ -28,6 +28,8 @@ type runOptions struct {
 	progress                  string
 	bucket                    string
 	group                     string
+	locales                   []string
+	targetLocaleAlias         []string
 	targetLocales             []string
 	sourcePaths               []string
 	outputPath                string
@@ -72,13 +74,24 @@ func newRunCmd() *cobra.Command {
 	cmd.Flags().StringVar(&o.progress, "progress", string(progressui.ModeAuto), "progress rendering mode: auto|on|off")
 	cmd.Flags().StringVar(&o.bucket, "bucket", "", "only run tasks for the given bucket")
 	cmd.Flags().StringVar(&o.group, "group", "", "only run tasks for the given group")
-	cmd.Flags().StringSliceVar(&o.targetLocales, "target-locale", nil, "only run tasks for the given target locale(s)")
+	cmd.Flags().StringSliceVar(&o.locales, "locale", nil, "only run tasks for the given target locale(s)")
+	cmd.Flags().StringSliceVar(&o.targetLocaleAlias, "target-locale", nil, "alias for --locale")
 	cmd.Flags().StringVar(&o.outputPath, "output", "", "report output JSON path")
 	cmd.Flags().BoolVar(&o.experimentalContextMemory, "experimental-context-memory", o.experimentalContextMemory, "enable experimental two-stage context memory generation before translation")
 	cmd.Flags().StringVar(&o.contextMemoryScope, "context-memory-scope", runsvc.ContextMemoryScopeFile, "scope for experimental context memory: file|bucket|group")
 	cmd.Flags().IntVar(&o.contextMemoryMaxChars, "context-memory-max-chars", 1200, "maximum context memory characters injected into each translation request")
 
 	return cmd
+}
+
+func mergeRunLocaleFlags(primary, alias []string) []string {
+	if len(primary) == 0 && len(alias) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(primary)+len(alias))
+	out = append(out, primary...)
+	out = append(out, alias...)
+	return out
 }
 
 func executeRun(cmd *cobra.Command, o runOptions) error {
@@ -89,13 +102,17 @@ func executeRun(cmd *cobra.Command, o runOptions) error {
 	if workers < 1 {
 		return fmt.Errorf("invalid --workers value %d: must be >= 1", workers)
 	}
-	if cmd.Flags().Changed("target-locale") {
-		if len(o.targetLocales) == 0 {
-			return fmt.Errorf("invalid --target-locale value: must not be empty")
+	var targetLocales []string
+	if o.interactive {
+		targetLocales = o.targetLocales
+	} else if cmd.Flags().Changed("locale") || cmd.Flags().Changed("target-locale") {
+		targetLocales = mergeRunLocaleFlags(o.locales, o.targetLocaleAlias)
+		if len(targetLocales) == 0 {
+			return fmt.Errorf("invalid --locale value: must not be empty")
 		}
-		for _, locale := range o.targetLocales {
+		for _, locale := range targetLocales {
 			if strings.TrimSpace(locale) == "" {
-				return fmt.Errorf("invalid --target-locale value: must not be empty")
+				return fmt.Errorf("invalid --locale value: must not be empty")
 			}
 		}
 	}
@@ -139,7 +156,7 @@ func executeRun(cmd *cobra.Command, o runOptions) error {
 		Workers:                   workers,
 		Bucket:                    o.bucket,
 		Group:                     o.group,
-		TargetLocales:             o.targetLocales,
+		TargetLocales:             targetLocales,
 		SourcePaths:               o.sourcePaths,
 		ExperimentalContextMemory: o.experimentalContextMemory,
 		ContextMemoryScope:        contextMemoryScope,
@@ -181,8 +198,12 @@ func syncInteractiveScopeFlags(cmd *cobra.Command, o runOptions) {
 	if flag := cmd.Flags().Lookup("bucket"); flag != nil {
 		flag.Changed = strings.TrimSpace(o.bucket) != ""
 	}
+	hasLocales := len(o.targetLocales) > 0
+	if flag := cmd.Flags().Lookup("locale"); flag != nil {
+		flag.Changed = hasLocales
+	}
 	if flag := cmd.Flags().Lookup("target-locale"); flag != nil {
-		flag.Changed = len(o.targetLocales) > 0
+		flag.Changed = hasLocales
 	}
 }
 

--- a/apps/cli/cmd/run_test.go
+++ b/apps/cli/cmd/run_test.go
@@ -383,7 +383,7 @@ func TestRunDryRunFiltersByTargetLocale(t *testing.T) {
 	out := bytes.NewBuffer(nil)
 	cmd.SetOut(out)
 	cmd.SetErr(out)
-	cmd.SetArgs([]string{"run", "--config", configPath, "--dry-run", "--target-locale", "de"})
+	cmd.SetArgs([]string{"run", "--config", configPath, "--dry-run", "--locale", "de"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("run command dry-run filtered target locale: %v", err)
@@ -509,7 +509,7 @@ func TestRunRejectsEmptyTargetLocale(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected empty target locale error")
 	}
-	if !strings.Contains(err.Error(), "invalid --target-locale value: must not be empty") {
+	if !strings.Contains(err.Error(), "invalid --locale value: must not be empty") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -547,7 +547,7 @@ func TestRunRejectsWhitespaceTargetLocale(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected whitespace target locale error")
 	}
-	if !strings.Contains(err.Error(), "invalid --target-locale value: must not be empty") {
+	if !strings.Contains(err.Error(), "invalid --locale value: must not be empty") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -586,7 +586,7 @@ func TestRunRejectsMixedEmptyTargetLocaleValue(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected mixed empty target locale error")
 	}
-	if !strings.Contains(err.Error(), "invalid --target-locale value: must not be empty") {
+	if !strings.Contains(err.Error(), "invalid --locale value: must not be empty") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if strings.Contains(out.String(), filepath.ToSlash(frTargetPath)) || strings.Contains(out.String(), filepath.ToSlash(deTargetPath)) {

--- a/docs/commands/run.mdx
+++ b/docs/commands/run.mdx
@@ -6,7 +6,7 @@ description: "Plan and execute local translation generation from configured sour
 ## Usage
 
 ```bash
-hyperlocalise run [--config <path>] [--group <name>] [--bucket <name>] [--target-locale <locale>] [--dry-run] [--workers <count>] [--output <report.json>] [--experimental-context-memory] [--context-memory-scope <file|bucket|group>] [--context-memory-max-chars <count>]
+hyperlocalise run [--config <path>] [--group <name>] [--bucket <name>] [--locale <locale>] [--dry-run] [--workers <count>] [--output <report.json>] [--experimental-context-memory] [--context-memory-scope <file|bucket|group>] [--context-memory-max-chars <count>]
 ```
 
 ## Behavior
@@ -76,7 +76,7 @@ When writing CSV targets, `run` preserves the existing header and non-target col
 - `--config`: path to config file (default `i18n.yml`, falling back to `i18n.jsonc`, in the current directory)
 - `--group`: run only tasks for the given group name
 - `--bucket`: run only tasks for the given bucket name
-- `--target-locale`: run only tasks for the given target locale (repeatable)
+- `--locale`: run only tasks for the given target locale (repeatable); `--target-locale` is an alias
 - `--dry-run`: print plan only, do not translate or write files
 - `--force`: rerun all planned tasks and ignore lockfile skip state
 - `--prune`: remove target keys that no longer exist in source files
@@ -160,10 +160,10 @@ If the bucket does not exist in your config, `run` fails with an `unknown bucket
 
 ## Scope runs to one target locale
 
-Use `--target-locale` when you want to re-run only specific locales without changing group or bucket selection. You can repeat the flag to select multiple locales.
+Use `--locale` when you want to re-run only specific locales without changing group or bucket selection. You can repeat the flag to select multiple locales. The same filter is available as `--target-locale` for compatibility with older scripts.
 
 ```bash
-hyperlocalise run --group tests --target-locale fr --target-locale de --dry-run
+hyperlocalise run --group tests --locale fr --locale de --dry-run
 ```
 
 If a requested locale is not present in `locales.targets`, `run` fails with an `unknown target locale` planning error. When combined with `--group`, only locales that belong to that group are planned.
@@ -171,7 +171,7 @@ If a requested locale is not present in `locales.targets`, `run` fails with an `
 When combined with `--prune`, stale-key detection is also limited to the selected target locales. `run` only scans and prunes target files that belong to the filtered locale set.
 
 ```bash
-hyperlocalise run --prune --target-locale de --dry-run
+hyperlocalise run --prune --locale de --dry-run
 ```
 
 ## Force rerun all planned tasks


### PR DESCRIPTION
## What changed

`hyperlocalise run` now uses **`--locale`** as the primary flag for filtering target locales (same naming as `check` and **`status`**). **`--target-locale`** remains supported as an **alias**; values from `--locale` and `--target-locale` are merged when both appear.

Validation messages refer to `--locale`. Interactive run behavior is unchanged (wizard-selected locales still take precedence).

English docs under `docs/commands/run.mdx` are updated; localized doc pages were not changed.

## How to test

- `make fmt && make lint && make test`
- Smoke the CLI:
  - `hyperlocalise run --config <path> --dry-run --locale de`
  - `hyperlocalise run --config <path> --dry-run --target-locale de` (alias)
  - Optional: `--locale fr --target-locale de` and confirm both locales are included in the plan

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review