### PR TITLE
fix(cli): deduplicate merged locale flags

### DIFF
--- a/apps/cli/cmd/run.go
+++ b/apps/cli/cmd/run.go
@@ -88,9 +88,15 @@ func mergeRunLocaleFlags(primary, alias []string) []string {
 	if len(primary) == 0 && len(alias) == 0 {
 		return nil
 	}
+	seen := make(map[string]struct{}, len(primary)+len(alias))
 	out := make([]string, 0, len(primary)+len(alias))
-	out = append(out, primary...)
-	out = append(out, alias...)
+	for _, locale := range append(primary, alias...) {
+		if _, ok := seen[locale]; ok {
+			continue
+		}
+		seen[locale] = struct{}{}
+		out = append(out, locale)
+	}
 	return out
 }
 

--- a/apps/cli/cmd/run.go
+++ b/apps/cli/cmd/run.go
@@ -90,7 +90,14 @@ func mergeRunLocaleFlags(primary, alias []string) []string {
 	}
 	seen := make(map[string]struct{}, len(primary)+len(alias))
 	out := make([]string, 0, len(primary)+len(alias))
-	for _, locale := range append(primary, alias...) {
+	for _, locale := range primary {
+		if _, ok := seen[locale]; ok {
+			continue
+		}
+		seen[locale] = struct{}{}
+		out = append(out, locale)
+	}
+	for _, locale := range alias {
 		if _, ok := seen[locale]; ok {
 			continue
 		}

--- a/apps/cli/cmd/run_test.go
+++ b/apps/cli/cmd/run_test.go
@@ -399,6 +399,90 @@ func TestRunDryRunFiltersByTargetLocale(t *testing.T) {
 	}
 }
 
+func TestRunDryRunMergesLocaleAndTargetLocaleFlags(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "i18n.jsonc")
+	sourcePath := filepath.Join(dir, "content", "en", "strings.json")
+	frTargetPath := filepath.Join(dir, "dist", "fr", "strings.json")
+	deTargetPath := filepath.Join(dir, "dist", "de", "strings.json")
+
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
+		t.Fatalf("create source dir: %v", err)
+	}
+	if err := os.WriteFile(sourcePath, []byte(`{"hello":"Hello"}`), 0o600); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+
+	content := `{
+	  "locales": {"source":"en","targets":["fr","de"]},
+	  "buckets": {"ui":{"files":[{"from":"` + filepath.ToSlash(sourcePath) + `","to":"` + filepath.ToSlash(filepath.Join(dir, "dist", "{{target}}", "strings.json")) + `"}]}},
+	  "groups": {"default":{"targets":["fr","de"],"buckets":["ui"]}},
+	  "llm": {"profiles":{"default":{"provider":"openai","model":"gpt-4.1-mini","prompt":"Translate {{input}}"}}}
+	}`
+	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"run", "--config", configPath, "--dry-run", "--locale", "fr", "--target-locale", "de"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("run command dry-run merged locale flags: %v", err)
+	}
+	if !strings.Contains(out.String(), "planned_total=2") {
+		t.Fatalf("expected two planned tasks, got %q", out.String())
+	}
+	if !strings.Contains(out.String(), filepath.ToSlash(frTargetPath)) {
+		t.Fatalf("expected fr locale task, got %q", out.String())
+	}
+	if !strings.Contains(out.String(), filepath.ToSlash(deTargetPath)) {
+		t.Fatalf("expected de locale task, got %q", out.String())
+	}
+}
+
+func TestRunDryRunDeduplicatesMergedLocaleFlags(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "i18n.jsonc")
+	sourcePath := filepath.Join(dir, "content", "en", "strings.json")
+	deTargetPath := filepath.Join(dir, "dist", "de", "strings.json")
+
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
+		t.Fatalf("create source dir: %v", err)
+	}
+	if err := os.WriteFile(sourcePath, []byte(`{"hello":"Hello"}`), 0o600); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+
+	content := `{
+	  "locales": {"source":"en","targets":["de"]},
+	  "buckets": {"ui":{"files":[{"from":"` + filepath.ToSlash(sourcePath) + `","to":"` + filepath.ToSlash(filepath.Join(dir, "dist", "{{target}}", "strings.json")) + `"}]}},
+	  "groups": {"default":{"targets":["de"],"buckets":["ui"]}},
+	  "llm": {"profiles":{"default":{"provider":"openai","model":"gpt-4.1-mini","prompt":"Translate {{input}}"}}}
+	}`
+	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"run", "--config", configPath, "--dry-run", "--locale", "de", "--target-locale", "de"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("run command dry-run deduplicated locale flags: %v", err)
+	}
+	if !strings.Contains(out.String(), "planned_total=1") {
+		t.Fatalf("expected one planned task, got %q", out.String())
+	}
+	if strings.Count(out.String(), filepath.ToSlash(deTargetPath)) != 1 {
+		t.Fatalf("expected de locale planned once, got %q", out.String())
+	}
+}
+
 func TestRunTargetLocaleRespectsGroupTargets(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "i18n.jsonc")


### PR DESCRIPTION
### Motivation

- Prevent planning/executing the same locale twice when `--locale` and `--target-locale` supply overlapping values, which could cause duplicate tasks.  

### Description

- Update `mergeRunLocaleFlags` in `apps/cli/cmd/run.go` to deduplicate merged `--locale` and `--target-locale` values while preserving first-seen order.  
- Add `TestRunDryRunMergesLocaleAndTargetLocaleFlags` to verify that `--locale fr --target-locale de` results in both locales being planned.  
- Add `TestRunDryRunDeduplicatesMergedLocaleFlags` to assert that duplicate values like `--locale de --target-locale de` are planned only once.  
- No change to existing validation of empty/whitespace locale values.

### Testing

- Ran code formatter with `make fmt` (succeeded).  
- Attempted `make bootstrap` and `make lint` but `make bootstrap` failed in this environment due to network access to `proxy.golang.org` when installing `golangci-lint`, causing `make lint` to be skipped.  
- Ran workspace tests with `make test` which failed due to a Go toolchain mismatch in this environment (`compile: version "go1.26.0" does not match go tool version "go1.25.1"`).  
- Ran package tests for the CLI package with `go test ./apps/cli/cmd` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7b0795454832cb49f1275a337ae84)