### PR TITLE
fix(release): include install.sh in GoReleaser checksums for hl update

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -50,6 +50,8 @@ release:
 
 checksum:
   name_template: checksums.txt
+  extra_files:
+    - glob: ./install.sh
 
 changelog:
   sort: asc


### PR DESCRIPTION
## What changed

GoReleaser was uploading `install.sh` as a release extra file, but `checksums.txt` only covered build artifacts (archives, packages, etc.). The `hl update` command downloads `install.sh` and looks up its SHA-256 in `checksums.txt`, which caused `checksum entry not found for "install.sh"`.

Added `checksum.extra_files` with `./install.sh` so the published `checksums.txt` includes a line for `install.sh`, matching the file attached to the release.

**Note:** This takes effect for **new** releases built after this change. Users need a release produced with this config before `hl update` succeeds against GitHub `latest`.

## How to test

- `make fmt`, `make lint`, `make test`
- After the next release: run `hl update` and confirm it no longer fails on the installer checksum step (optional: inspect the release’s `checksums.txt` for an `install.sh` line).

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review