### PR TITLE
fix(check): align MDX annotation lines and narrow html_tag_mismatch

### DIFF
--- a/apps/cli/cmd/check.go
+++ b/apps/cli/cmd/check.go
@@ -1258,6 +1258,12 @@ func (r *checkLocationResolver) resolveInFile(filePath, key, value string) (stri
 		content = data
 		r.content[filePath] = data
 	}
+	ext := strings.ToLower(filepath.Ext(filePath))
+	if (ext == ".md" || ext == ".mdx") && strings.HasPrefix(key, "md.") {
+		if line := translationfileparser.LineForMarkdownKey(content, ext == ".mdx", key); line > 0 {
+			return filePath, line
+		}
+	}
 	if line := lineForKey(content, key); line > 0 {
 		return filePath, line
 	}

--- a/docs/commands/check.mdx
+++ b/docs/commands/check.mdx
@@ -18,7 +18,7 @@ Each check has a **severity** (`error` or `warning`) in the report JSON and in *
 - `not_localized`: target key is missing or the target value is empty (after trimming)
 - `missing_target_file`: resolved target file does not exist
 - `placeholder_mismatch`: placeholders differ from the source
-- `html_tag_mismatch`: HTML tag structure differs from the source
+- `html_tag_mismatch`: inline HTML tag **names** (known elements from the HTML tokenizer’s tag set) differ in sequence between source and target. Angle-bracket text in paths or docs—such as `&lt;name&gt;` in `llm.profiles.&lt;name&gt;.provider`—does not count as HTML for this check
 - `icu_shape_mismatch`: ICU structure differs from the source or is malformed (non-markdown files)
 - `markdown_ast_mismatch`: markdown or MDX document structure differs from the source (heading/component tree parity)
 
@@ -40,7 +40,7 @@ Selecting `--check icu_shape_mismatch` runs ICU checks only; it does not include
 - `--exclude-check`: skip specific default checks (repeatable)
 - `--format`: output format (`stylish` default, `text`, or `json`). **Stylish** prints ESLint-style diagnostics grouped by file; when stdout is a terminal, severities use color (no color when piped or in typical CI logs).
 - `--output-file`: write the same human or JSON format as stdout to a file
-- `--json-report`: always write the full machine-readable JSON report to this path, regardless of `--format` (useful in CI: stylish logs plus a JSON artifact for tooling)
+- `--json-report`: always write the full machine-readable JSON report to this path, regardless of `--format` (useful in CI: stylish logs plus a JSON artifact for tooling). Findings include `annotationFile` and `annotationLine` when the CLI can map a key to a line. For **`.md` / `.mdx`** segments with keys prefixed `md.`, the line is taken from the markdown/MDX parse order (start of that translatable segment). For other files, resolution falls back to searching for a quoted key fragment or a substring of the segment text in the target file, which can mis-rank lines when the same text appears more than once
 - `--no-fail`: return exit code `0` even when findings exist
 - `--quiet`: omit **warning** findings from stdout, `--output-file`, and `--json-report`; use exit code `0` when the full result would be warnings only. The internal check still runs on all severities; **`--fix`** still plans from the full result (including warnings) so fixable issues are not skipped.
 - `--fix`: after reporting, retranslate **fixable** findings using the same AI pipeline as [`run`](/commands/run) (same config, profiles, and environment variables). Applies to keyed findings of types `not_localized`, `whitespace_only`, `placeholder_mismatch`, `html_tag_mismatch`, and `icu_shape_mismatch`. For **`markdown_ast_mismatch`** on `.md`/`.mdx` files (per-file findings, often without a `key`), `--fix` retranslates **all** aligned segments for that source/target/locale pair so structure can realign. Does not fix `same_as_source` (intentional copy), missing target files, or orphaned keys.

--- a/internal/i18n/htmltagparity/BUILD.bazel
+++ b/internal/i18n/htmltagparity/BUILD.bazel
@@ -5,4 +5,7 @@ go_library(
     srcs = glob(["*.go"], exclude = ["*_test.go"]),
     importpath = "github.com/hyperlocalise/hyperlocalise/internal/i18n/htmltagparity",
     visibility = ["//visibility:public"],
+    deps = [
+        "@org_golang_x_net//html/atom",
+    ],
 )

--- a/internal/i18n/htmltagparity/htmltagparity.go
+++ b/internal/i18n/htmltagparity/htmltagparity.go
@@ -6,6 +6,8 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+
+	"golang.org/x/net/html/atom"
 )
 
 var tagPattern = regexp.MustCompile(`</?[A-Za-z][^>]*?>`)
@@ -13,8 +15,8 @@ var tagPattern = regexp.MustCompile(`</?[A-Za-z][^>]*?>`)
 // Mismatch reports whether the normalized HTML tag name sequences differ
 // between source and target (same semantics as check hasHTMLTagMismatch).
 func Mismatch(sourceValue, targetValue string) bool {
-	sourceTags := normalizeTagNames(tagPattern.FindAllString(sourceValue, -1))
-	targetTags := normalizeTagNames(tagPattern.FindAllString(targetValue, -1))
+	sourceTags := filterKnownHTMLTagNames(normalizeTagNames(tagPattern.FindAllString(sourceValue, -1)))
+	targetTags := filterKnownHTMLTagNames(normalizeTagNames(tagPattern.FindAllString(targetValue, -1)))
 	return !slices.Equal(sourceTags, targetTags)
 }
 
@@ -35,6 +37,19 @@ func normalizeTagNames(tags []string) []string {
 			continue
 		}
 		out = append(out, parts[0])
+	}
+	return out
+}
+
+// filterKnownHTMLTagNames keeps only names that exist in golang.org/x/net/html/atom, after stripping a
+// leading "/" from closing-tag tokens. Patterns such as <name> in documented paths are ignored.
+func filterKnownHTMLTagNames(names []string) []string {
+	out := make([]string, 0, len(names))
+	for _, n := range names {
+		tag := strings.TrimPrefix(n, "/")
+		if atom.Lookup([]byte(tag)) != 0 {
+			out = append(out, tag)
+		}
 	}
 	return out
 }

--- a/internal/i18n/htmltagparity/htmltagparity.go
+++ b/internal/i18n/htmltagparity/htmltagparity.go
@@ -41,14 +41,15 @@ func normalizeTagNames(tags []string) []string {
 	return out
 }
 
-// filterKnownHTMLTagNames keeps only names that exist in golang.org/x/net/html/atom, after stripping a
-// leading "/" from closing-tag tokens. Patterns such as <name> in documented paths are ignored.
+// filterKnownHTMLTagNames keeps only names that exist in golang.org/x/net/html/atom.
+// A leading "/" (closing tag) is stripped only for Lookup; the token passed through
+// preserves opening vs closing. Patterns such as <name> in documented paths are ignored.
 func filterKnownHTMLTagNames(names []string) []string {
 	out := make([]string, 0, len(names))
 	for _, n := range names {
 		tag := strings.TrimPrefix(n, "/")
 		if atom.Lookup([]byte(tag)) != 0 {
-			out = append(out, tag)
+			out = append(out, n)
 		}
 	}
 	return out

--- a/internal/i18n/htmltagparity/htmltagparity_test.go
+++ b/internal/i18n/htmltagparity/htmltagparity_test.go
@@ -31,3 +31,11 @@ func TestMismatchPlainText(t *testing.T) {
 		t.Fatalf("plain text should not mismatch")
 	}
 }
+
+func TestMismatchIgnoresAngleBracketPathTokens(t *testing.T) {
+	src := "Use `bedrock` in `llm.profiles.<name>.provider`."
+	tgt := "Sử dụng 'bedrock' trong 'llm.profiles.<name>.provider'."
+	if Mismatch(src, tgt) {
+		t.Fatalf("expected <name> in paths not to count as HTML tags")
+	}
+}

--- a/internal/i18n/htmltagparity/htmltagparity_test.go
+++ b/internal/i18n/htmltagparity/htmltagparity_test.go
@@ -18,6 +18,14 @@ func TestMismatchExtraTag(t *testing.T) {
 	}
 }
 
+func TestMismatchClosingVsOpening(t *testing.T) {
+	src := `<b>bold</b>`
+	tgt := `<b>bold<b>`
+	if !Mismatch(src, tgt) {
+		t.Fatalf("expected mismatch when closing tag is replaced by opening tag")
+	}
+}
+
 func TestMismatchReorderedTags(t *testing.T) {
 	src := `<p><span>a</span><em>b</em></p>`
 	tgt := `<p><em>b</em><span>a</span></p>`

--- a/internal/i18n/translationfileparser/markdown_parser.go
+++ b/internal/i18n/translationfileparser/markdown_parser.go
@@ -59,6 +59,20 @@ func MarkdownASTPaths(content []byte, mdx bool) []string {
 	return paths
 }
 
+// LineForMarkdownKey returns the 1-based source line of the first translatable markdown or MDX segment
+// with the given key (for example md.<hash>), or 0 if the key is not present.
+func LineForMarkdownKey(content []byte, mdx bool, key string) int {
+	doc, _ := parseMarkdownDocument(stripBOM(content), mdx)
+	line := 1
+	for _, part := range doc.parts {
+		if part.key == key {
+			return line
+		}
+		line += strings.Count(part.literal, "\n")
+	}
+	return 0
+}
+
 func (d markdownDocument) keyContexts() []markdownKeyContext {
 	out := make([]markdownKeyContext, 0)
 	for i, part := range d.parts {

--- a/internal/i18n/translationfileparser/markdown_parser_test.go
+++ b/internal/i18n/translationfileparser/markdown_parser_test.go
@@ -1731,6 +1731,42 @@ func findKeyByValue(values map[string]string, needle string) string {
 	return ""
 }
 
+func TestLineForMarkdownKeyMdx(t *testing.T) {
+	content := []byte("---\ntitle: \"T\"\n---\n\n## Section\n\n- Use `bedrock` in `llm.profiles.<name>.provider`.\n")
+	entries, err := (MarkdownParser{MDX: true}).Parse(content)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	var listKey string
+	for k, v := range entries {
+		if strings.HasPrefix(strings.TrimSpace(v), "Use ") {
+			listKey = k
+			break
+		}
+	}
+	if listKey == "" {
+		t.Fatalf("expected list item key, got entries=%v", entries)
+	}
+	if got := LineForMarkdownKey(content, true, listKey); got != 7 {
+		t.Fatalf("LineForMarkdownKey: got line %d, want 7", got)
+	}
+}
+
+func TestLineForMarkdownKeyMarkdown(t *testing.T) {
+	content := []byte("# Title\n\nHello world.\n\nSecond paragraph.\n")
+	entries, err := (MarkdownParser{MDX: false}).Parse(content)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	key := findKeyByValue(entries, "Hello world.")
+	if key == "" {
+		t.Fatalf("expected hello key")
+	}
+	if got := LineForMarkdownKey(content, false, key); got != 3 {
+		t.Fatalf("LineForMarkdownKey: got line %d, want 3", got)
+	}
+}
+
 func TestMarkdownParserParsePlainFrontmatterValues(t *testing.T) {
 	content := []byte("---\ntitle: Hello world\ndescription: A simple guide\ncount: 42\n---\n\nBody text.\n")
 	got, err := (MarkdownParser{}).Parse(content)


### PR DESCRIPTION
## What changed

- **`html_tag_mismatch`**: Only tag names recognized by `golang.org/x/net/html/atom` are compared, so angle-bracket placeholders such as `<name>` in strings like `llm.profiles.<name>.provider` no longer trigger false positives when source segments use internal markdown placeholders and targets keep raw angle brackets.
- **Annotation lines for `.md` / `.mdx`**: For keys prefixed with `md.`, `annotationLine` is derived from markdown/MDX parse order (start of the translatable segment) via `LineForMarkdownKey`, instead of relying on substring search in the file first—which could hit the wrong line or fall back to line 1.
- **Docs**: Updated `docs/commands/check.mdx` to describe the refined `html_tag_mismatch` behavior and how `annotationFile` / `annotationLine` are resolved for markdown vs other formats.

## How to test

    make fmt && make lint && make test

Optional spot-check:

    go test ./internal/i18n/htmltagparity/... ./internal/i18n/translationfileparser/... -run 'TestMismatch|TestLineForMarkdownKey' -count=1

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review