### PR TITLE
fix(cli): fail run on markdown AST parity mismatch at flush

### DIFF
--- a/apps/cli/internal/i18n/runsvc/output_flush_test.go
+++ b/apps/cli/internal/i18n/runsvc/output_flush_test.go
@@ -150,6 +150,41 @@ func TestParseExistingTargetEntriesCSV(t *testing.T) {
 	}
 }
 
+func TestFlushOutputForTargetMarkdownASTParityNoWrite(t *testing.T) {
+	source := []byte("# Welcome\n\nHello world.\n")
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "en", "page.md")
+	targetPath := filepath.Join(dir, "fr", "page.md")
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(sourcePath, source, 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	key := markdownEntryKeyForValue(t, source, "Hello world.")
+
+	svc := newTestService()
+	svc.readFile = os.ReadFile
+	svc.writeFile = func(path string, _ []byte) error {
+		t.Fatalf("writeFile should not run on AST mismatch, got path %q", path)
+		return nil
+	}
+
+	_, err := svc.flushOutputForTarget(targetPath, stagedOutput{
+		entries: map[string]string{
+			key: "Bonjour monde.\n\n# Injected heading\n",
+		},
+		sourcePath:   sourcePath,
+		targetLocale: "fr",
+	}, nil)
+	if err == nil {
+		t.Fatal("expected markdown AST parity error")
+	}
+	if !strings.Contains(err.Error(), "markdown AST parity mismatch") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestFlushOutputForTargetWrapsWriteError(t *testing.T) {
 	targetPath := filepath.Join(t.TempDir(), "fr.json")
 	sourcePath := filepath.Join(t.TempDir(), "en.json")

--- a/apps/cli/internal/i18n/runsvc/output_marshal.go
+++ b/apps/cli/internal/i18n/runsvc/output_marshal.go
@@ -135,7 +135,9 @@ func (s *Service) marshalMarkdownTarget(path, sourcePath string, stagedEntries m
 		if os.IsNotExist(err) {
 			content, diags := translationfileparser.MarshalMarkdownWithDiagnostics(sourceTemplate, stagedEntries, mdx)
 			warnings := markdownRenderWarnings(path, diags)
-			warnings = append(warnings, translationfileparser.MarkdownASTParityWarnings(sourceTemplate, content, sourcePath, path)...)
+			if astErr := markdownASTParityFlushError(path, sourceTemplate, content, sourcePath); astErr != nil {
+				return nil, nil, astErr
+			}
 			return content, warnings, nil
 		}
 		return nil, nil, fmt.Errorf("flush outputs: read target file %q: %w", path, err)
@@ -143,8 +145,18 @@ func (s *Service) marshalMarkdownTarget(path, sourcePath string, stagedEntries m
 
 	content, diags := translationfileparser.MarshalMarkdownWithTargetFallbackDiagnostics(sourceTemplate, targetTemplate, stagedEntries, mdx)
 	warnings := markdownRenderWarnings(path, diags)
-	warnings = append(warnings, translationfileparser.MarkdownASTParityWarnings(sourceTemplate, content, sourcePath, path)...)
+	if astErr := markdownASTParityFlushError(path, sourceTemplate, content, sourcePath); astErr != nil {
+		return nil, nil, astErr
+	}
 	return content, warnings, nil
+}
+
+func markdownASTParityFlushError(targetPath string, sourceTemplate, marshaledContent []byte, sourcePath string) error {
+	msgs := translationfileparser.MarkdownASTParityWarnings(sourceTemplate, marshaledContent, sourcePath, targetPath)
+	if len(msgs) == 0 {
+		return nil
+	}
+	return fmt.Errorf("flush outputs: markdown AST parity mismatch for %q: %s", targetPath, strings.Join(msgs, "; "))
 }
 
 func (s *Service) marshalHTMLTarget(path, sourcePath string, stagedEntries map[string]string) ([]byte, []string, error) {

--- a/apps/cli/internal/i18n/runsvc/output_marshal_test.go
+++ b/apps/cli/internal/i18n/runsvc/output_marshal_test.go
@@ -100,21 +100,48 @@ func TestHasExactKeySet(t *testing.T) {
 	}
 }
 
-func TestMarkdownFlushMergesRenderAndASTParityWarnings(t *testing.T) {
-	src := []byte("# One\n\n## Two\n\n")
-	out := []byte("plain text only\n")
-	path := "/tmp/out/fr/page.md"
-	w1 := markdownRenderWarnings(path, translationfileparser.MarkdownRenderDiagnostics{SourceFallbackKeys: []string{"md.aaa"}})
-	w2 := translationfileparser.MarkdownASTParityWarnings(src, out, "/en/page.md", path)
-	merged := append(append([]string{}, w1...), w2...)
-	if len(merged) < 2 {
-		t.Fatalf("expected render + AST warnings, got %#v", merged)
+func markdownEntryKeyForValue(t *testing.T, content []byte, want string) string {
+	t.Helper()
+	entries, err := translationfileparser.MarkdownParser{}.Parse(content)
+	if err != nil {
+		t.Fatalf("parse markdown: %v", err)
 	}
-	if !strings.Contains(merged[0], "fell back to source") {
-		t.Fatalf("expected render warning first: %q", merged[0])
+	for k, v := range entries {
+		if v == want {
+			return k
+		}
 	}
-	if !strings.Contains(merged[1], "markdown AST parity") {
-		t.Fatalf("expected AST parity warning: %q", merged[1])
+	t.Fatalf("no markdown entry with value %q, got %#v", want, entries)
+	panic("unreachable")
+}
+
+func TestMarshalMarkdownTargetMarkdownASTParityError(t *testing.T) {
+	source := []byte("# Welcome\n\nHello world.\n")
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "en", "page.md")
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(sourcePath, source, 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	targetPath := filepath.Join(dir, "fr", "page.md")
+	key := markdownEntryKeyForValue(t, source, "Hello world.")
+
+	svc := newTestService()
+	svc.readFile = os.ReadFile
+
+	_, _, err := svc.marshalMarkdownTarget(targetPath, sourcePath, map[string]string{
+		key: "Bonjour monde.\n\n# Injected heading\n",
+	})
+	if err == nil {
+		t.Fatal("expected markdown AST parity error")
+	}
+	if !strings.Contains(err.Error(), "markdown AST parity mismatch") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(err.Error(), targetPath) {
+		t.Fatalf("error should mention target path: %v", err)
 	}
 }
 


### PR DESCRIPTION
## What changed

Markdown/MDX flush now treats document-level AST parity (the same path-set comparison as `check`’s `markdown_ast_mismatch`) as a hard error instead of a run warning.

- After marshaling, if `MarkdownASTParityWarnings` is non-empty, `marshalMarkdownTarget` returns an error so the target file is not written and the run records a failure.
- Render/placeholder fallback diagnostics (`markdownRenderWarnings`) remain warnings only.

This keeps `run` from exiting cleanly while leaving structurally invalid markdown on disk.

## How to test

~~~bash
make fmt
make lint
make test
~~~

Optional: run `hyperlocalise run` / `hyperlocalise check` on markdown where structure drifts and confirm the run fails instead of succeeding with only warnings.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review