### PR TITLE
feat(cli): markdown AST parity scope retry and flush-time validation

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -55,6 +55,7 @@ checksum:
 
 changelog:
   sort: asc
+  use: github
   groups:
     - title: Features
       regexp: '^feat(\(.+\))?:.*$'

--- a/apps/cli/internal/i18n/runsvc/executor.go
+++ b/apps/cli/internal/i18n/runsvc/executor.go
@@ -64,6 +64,9 @@ type executorState struct {
 	report               executionReport
 	omitPerEntryBatches  bool
 
+	runCtx      context.Context
+	parityRetry *markdownParityRetryInput
+
 	stageMu   sync.Mutex
 	pendingMu sync.Mutex
 	reportMu  sync.Mutex
@@ -121,7 +124,7 @@ func newExecutorState(tasks []Task, initialStaged map[string]stagedOutput, prune
 	return state, nil
 }
 
-func (s *Service) executePool(ctx context.Context, tasks []Task, initialStaged map[string]stagedOutput, lockPath string, lockState *lockfile.File, workers int, activeRunID string, pruneTargets map[string]map[string]struct{}, contextPlan contextMemoryPlan, l1 cache.ExactCache, emitter *eventEmitter, omitPerEntryBatches bool) (map[string]stagedOutput, map[string]struct{}, executionReport, error) {
+func (s *Service) executePool(ctx context.Context, tasks []Task, initialStaged map[string]stagedOutput, lockPath string, lockState *lockfile.File, workers int, activeRunID string, pruneTargets map[string]map[string]struct{}, contextPlan contextMemoryPlan, l1 cache.ExactCache, emitter *eventEmitter, omitPerEntryBatches bool, parityRetry *markdownParityRetryInput) (map[string]stagedOutput, map[string]struct{}, executionReport, error) {
 	scheduledTasks := tasks
 	if contextPlan.Enabled {
 		scheduledTasks = interleaveTasksByContextKey(tasks)
@@ -131,6 +134,8 @@ func (s *Service) executePool(ctx context.Context, tasks []Task, initialStaged m
 	if err != nil {
 		return nil, nil, executionReport{}, err
 	}
+	state.runCtx = ctx
+	state.parityRetry = parityRetry
 
 	if contextPlan.Enabled {
 		if err := s.precomputeContextMemory(ctx, state, emitter, workers); err != nil {
@@ -422,7 +427,6 @@ func (s *Service) flushIfTargetCompleted(targetPath, sourcePath string, state *e
 	if remaining == 0 {
 		if _, done := state.flushedTargets[targetPath]; !done {
 			shouldFlush = true
-			state.flushedTargets[targetPath] = struct{}{}
 			if knownSourcePath := state.sourceByTarget[targetPath]; knownSourcePath != "" {
 				expectedSourcePath = knownSourcePath
 			}
@@ -440,9 +444,6 @@ func (s *Service) flushIfTargetCompleted(targetPath, sourcePath string, state *e
 
 	state.stageMu.Lock()
 	output, ok := state.staged[targetPath]
-	if ok {
-		delete(state.staged, targetPath)
-	}
 	state.stageMu.Unlock()
 
 	if !ok {
@@ -457,10 +458,26 @@ func (s *Service) flushIfTargetCompleted(targetPath, sourcePath string, state *e
 		output.targetLocale = expectedTargetLocale
 	}
 
-	warnings, err := s.flushOutputForTarget(targetPath, output, state.pruneTargets[targetPath])
+	ctx := state.runCtx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	warnings, err := s.flushOutputForTargetWithMarkdownParityRetry(ctx, state.parityRetry, targetPath, output, state.pruneTargets[targetPath])
 	if err != nil {
+		state.stageMu.Lock()
+		delete(state.staged, targetPath)
+		state.stageMu.Unlock()
 		return err
 	}
+
+	state.stageMu.Lock()
+	delete(state.staged, targetPath)
+	state.stageMu.Unlock()
+
+	state.pendingMu.Lock()
+	state.flushedTargets[targetPath] = struct{}{}
+	state.pendingMu.Unlock()
+
 	if len(warnings) > 0 {
 		state.reportMu.Lock()
 		state.report.Warnings = append(state.report.Warnings, warnings...)

--- a/apps/cli/internal/i18n/runsvc/markdown_parity_retry.go
+++ b/apps/cli/internal/i18n/runsvc/markdown_parity_retry.go
@@ -1,0 +1,82 @@
+package runsvc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/translationfileparser"
+	"github.com/hyperlocalise/hyperlocalise/pkg/i18nconfig"
+)
+
+const markdownParityScopeMaxPasses = 3
+
+// markdownParityRetryInput carries planning inputs for re-translating an entire MD/MDX
+// scope after a composed AST parity failure.
+type markdownParityRetryInput struct {
+	cfg           *config.I18NConfig
+	bucket        string
+	group         string
+	targetLocales []string
+	sourcePaths   []string
+}
+
+func markdownParityFixContext(msgs []string) string {
+	var b strings.Builder
+	b.WriteString("The assembled markdown file failed structural parity with the source template (same rules as the CLI check command).\n")
+	b.WriteString("Return only a translation for this segment. Do not add headings (#), lists, thematic break lines (---), fenced code blocks (```), or blockquote lines (>) unless the source segment already contains the same markdown line pattern.\n")
+	b.WriteString("Preserve internal HLMDPH placeholder tokens exactly.\n\nDetails:\n")
+	b.WriteString(strings.Join(msgs, "\n"))
+	return b.String()
+}
+
+func (s *Service) retryMarkdownASTParityScope(ctx context.Context, in *markdownParityRetryInput, targetPath string, output stagedOutput, parityMsgs []string) error {
+	if in == nil || in.cfg == nil {
+		return errors.New("markdown parity retry: missing config")
+	}
+	if len(output.entries) == 0 {
+		return errors.New("markdown parity retry: no staged entries")
+	}
+	fixCtx := markdownParityFixContext(parityMsgs)
+	var lastMarshalErr error
+	for pass := 0; pass < markdownParityScopeMaxPasses; pass++ {
+		tasks, _, err := s.planTasks(in.cfg, in.bucket, in.group, in.targetLocales, in.sourcePaths, nil, []FixMarkdownScope{{
+			SourcePath:   output.sourcePath,
+			TargetPath:   targetPath,
+			TargetLocale: output.targetLocale,
+		}})
+		if err != nil {
+			return err
+		}
+		if len(tasks) == 0 {
+			return fmt.Errorf("markdown parity retry: no tasks planned for source=%q target=%q locale=%q", output.sourcePath, targetPath, output.targetLocale)
+		}
+		for _, task := range tasks {
+			t := task
+			materializeTaskPrompts(&t)
+			if strings.TrimSpace(fixCtx) != "" {
+				t.UserPrompt = strings.TrimSpace(t.UserPrompt) + "\n\n" + fixCtx
+			}
+			translated, err := s.translateWithRetry(ctx, t)
+			if err != nil {
+				return err
+			}
+			output.entries[t.EntryKey] = translated
+		}
+		_, _, lastMarshalErr = s.marshalMarkdownTarget(targetPath, output.sourcePath, output.entries)
+		if lastMarshalErr == nil {
+			return nil
+		}
+		var pe *translationfileparser.MarkdownASTParityError
+		if errors.As(lastMarshalErr, &pe) && len(pe.Messages) > 0 {
+			fixCtx = markdownParityFixContext(pe.Messages)
+			continue
+		}
+		return lastMarshalErr
+	}
+	if lastMarshalErr == nil {
+		return errors.New("markdown parity retry: exhausted passes without marshal error")
+	}
+	return fmt.Errorf("markdown parity retry exhausted after %d passes: %w", markdownParityScopeMaxPasses, lastMarshalErr)
+}

--- a/apps/cli/internal/i18n/runsvc/markdown_parity_retry.go
+++ b/apps/cli/internal/i18n/runsvc/markdown_parity_retry.go
@@ -75,8 +75,5 @@ func (s *Service) retryMarkdownASTParityScope(ctx context.Context, in *markdownP
 		}
 		return lastMarshalErr
 	}
-	if lastMarshalErr == nil {
-		return errors.New("markdown parity retry: exhausted passes without marshal error")
-	}
 	return fmt.Errorf("markdown parity retry exhausted after %d passes: %w", markdownParityScopeMaxPasses, lastMarshalErr)
 }

--- a/apps/cli/internal/i18n/runsvc/markdown_parity_retry_test.go
+++ b/apps/cli/internal/i18n/runsvc/markdown_parity_retry_test.go
@@ -1,0 +1,71 @@
+package runsvc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/translator"
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/translationfileparser"
+)
+
+func TestRetryMarkdownASTParityScopeExhausted(t *testing.T) {
+	sourcePath := "/tmp/source.md"
+	targetPath := "/tmp/out.md"
+	source := "Hello world.\n"
+
+	entries, err := translationfileparser.MarkdownParser{}.Parse([]byte(source))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected markdown entries")
+	}
+
+	cfg := testConfig(sourcePath, targetPath)
+	in := &markdownParityRetryInput{
+		cfg:           &cfg,
+		bucket:        "ui",
+		group:         "default",
+		targetLocales: []string{"fr"},
+		sourcePaths:   []string{sourcePath},
+	}
+
+	svc := newTestService()
+	svc.readFile = func(path string) ([]byte, error) {
+		if path == sourcePath {
+			return []byte(source), nil
+		}
+		return nil, fmt.Errorf("unexpected readFile %q", path)
+	}
+	svc.translate = func(_ context.Context, req translator.Request) (string, error) {
+		return req.Source, nil
+	}
+
+	t.Cleanup(func() { marshalMarkdownTargetHook = nil })
+	marshalMarkdownTargetHook = func(path, srcPath string, _ map[string]string) ([]byte, []string, error) {
+		if path != targetPath || srcPath != sourcePath {
+			t.Fatalf("unexpected marshal paths %q %q", path, srcPath)
+		}
+		return nil, nil, &translationfileparser.MarkdownASTParityError{
+			TargetPath: path,
+			Messages:   []string{"stub parity"},
+		}
+	}
+
+	out := stagedOutput{
+		entries:      entries,
+		sourcePath:   sourcePath,
+		sourceLocale: "en",
+		targetLocale: "fr",
+	}
+
+	rerr := svc.retryMarkdownASTParityScope(context.Background(), in, targetPath, out, []string{"initial"})
+	if rerr == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(rerr.Error(), "markdown parity retry exhausted after 3 passes") {
+		t.Fatalf("unexpected error: %v", rerr)
+	}
+}

--- a/apps/cli/internal/i18n/runsvc/markdown_parity_retry_test.go
+++ b/apps/cli/internal/i18n/runsvc/markdown_parity_retry_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hyperlocalise/hyperlocalise/internal/i18n/translator"
 	"github.com/hyperlocalise/hyperlocalise/internal/i18n/translationfileparser"
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/translator"
 )
 
 func TestRetryMarkdownASTParityScopeExhausted(t *testing.T) {

--- a/apps/cli/internal/i18n/runsvc/output_flush.go
+++ b/apps/cli/internal/i18n/runsvc/output_flush.go
@@ -30,7 +30,7 @@ func (s *Service) flushOutputForTargetWithMarkdownParityRetry(ctx context.Contex
 		return warn, err
 	}
 	if rerr := s.retryMarkdownASTParityScope(ctx, retry, targetPath, output, pe.Messages); rerr != nil {
-		return nil, fmt.Errorf("%w: scope parity retry: %v", err, rerr)
+		return nil, fmt.Errorf("markdown AST parity scope retry failed for %q: %w", targetPath, rerr)
 	}
 	return s.flushOutputForTarget(targetPath, output, keep)
 }

--- a/apps/cli/internal/i18n/runsvc/output_flush.go
+++ b/apps/cli/internal/i18n/runsvc/output_flush.go
@@ -3,6 +3,8 @@ package runsvc
 // Output flushing coordinates reading existing targets, merging staged values, and writing final content.
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"os"
@@ -13,7 +15,27 @@ import (
 	"github.com/hyperlocalise/hyperlocalise/internal/i18n/translationfileparser"
 )
 
-func (s *Service) flushOutputs(staged map[string]stagedOutput, pruneTargets map[string]map[string]struct{}, pruneMetadata map[string]stagedOutput) ([]string, error) {
+func markdownFlushTargetPath(path string) bool {
+	ext := strings.ToLower(filepath.Ext(path))
+	return ext == ".md" || ext == ".mdx"
+}
+
+func (s *Service) flushOutputForTargetWithMarkdownParityRetry(ctx context.Context, retry *markdownParityRetryInput, targetPath string, output stagedOutput, keep map[string]struct{}) ([]string, error) {
+	warn, err := s.flushOutputForTarget(targetPath, output, keep)
+	if err == nil {
+		return warn, nil
+	}
+	var pe *translationfileparser.MarkdownASTParityError
+	if retry == nil || !errors.As(err, &pe) || !markdownFlushTargetPath(targetPath) {
+		return warn, err
+	}
+	if rerr := s.retryMarkdownASTParityScope(ctx, retry, targetPath, output, pe.Messages); rerr != nil {
+		return nil, fmt.Errorf("%w: scope parity retry: %v", err, rerr)
+	}
+	return s.flushOutputForTarget(targetPath, output, keep)
+}
+
+func (s *Service) flushOutputs(ctx context.Context, retry *markdownParityRetryInput, staged map[string]stagedOutput, pruneTargets map[string]map[string]struct{}, pruneMetadata map[string]stagedOutput) ([]string, error) {
 	targetPaths := make([]string, 0, len(staged)+len(pruneTargets))
 	for path := range staged {
 		targetPaths = append(targetPaths, path)
@@ -24,13 +46,16 @@ func (s *Service) flushOutputs(staged map[string]stagedOutput, pruneTargets map[
 	slices.Sort(targetPaths)
 	targetPaths = slices.Compact(targetPaths)
 
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	var warnings []string
 	for _, targetPath := range targetPaths {
 		output, ok := staged[targetPath]
 		if !ok {
 			output = pruneMetadata[targetPath]
 		}
-		targetWarnings, err := s.flushOutputForTarget(targetPath, output, pruneTargets[targetPath])
+		targetWarnings, err := s.flushOutputForTargetWithMarkdownParityRetry(ctx, retry, targetPath, output, pruneTargets[targetPath])
 		if err != nil {
 			return nil, err
 		}

--- a/apps/cli/internal/i18n/runsvc/output_flush_test.go
+++ b/apps/cli/internal/i18n/runsvc/output_flush_test.go
@@ -1,6 +1,7 @@
 package runsvc
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"os"
@@ -84,7 +85,7 @@ func TestFlushOutputsSortedUniqueTargets(t *testing.T) {
 		paths[1]: {"k": {}},
 	}
 
-	_, err := svc.flushOutputs(staged, prune, nil)
+	_, err := svc.flushOutputs(context.Background(), nil, staged, prune, nil)
 	if err != nil {
 		t.Fatalf("flush outputs: %v", err)
 	}
@@ -227,7 +228,7 @@ func TestFlushOutputsPruneOnlyMissingTargetAfterScan(t *testing.T) {
 	}
 	svc.writeFile = func(_ string, _ []byte) error { return nil }
 
-	_, err := svc.flushOutputs(nil, map[string]map[string]struct{}{
+	_, err := svc.flushOutputs(context.Background(), nil, nil, map[string]map[string]struct{}{
 		targetPath: {"hello": {}},
 	}, nil)
 	if err == nil {
@@ -260,7 +261,7 @@ func TestFlushOutputsPruneOnlyUsesPlannedMetadata(t *testing.T) {
 		return nil
 	}
 
-	_, err := svc.flushOutputs(nil, map[string]map[string]struct{}{
+	_, err := svc.flushOutputs(context.Background(), nil, nil, map[string]map[string]struct{}{
 		targetPath: {"hello": {}},
 	}, map[string]stagedOutput{
 		targetPath: {entries: map[string]string{}, sourcePath: sourcePath, sourceLocale: "en", targetLocale: "fr"},

--- a/apps/cli/internal/i18n/runsvc/output_marshal.go
+++ b/apps/cli/internal/i18n/runsvc/output_marshal.go
@@ -123,8 +123,14 @@ func hasExactKeySet(a, b map[string]string) bool {
 	return true
 }
 
+// marshalMarkdownTargetHook is set by tests to stub marshalling (e.g. parity retry exhaustion).
+var marshalMarkdownTargetHook func(path, sourcePath string, stagedEntries map[string]string) ([]byte, []string, error)
+
 func (s *Service) marshalMarkdownTarget(path, sourcePath string, stagedEntries map[string]string) ([]byte, []string, error) {
-	mdx := strings.ToLower(filepath.Ext(path)) == ".mdx"
+	if marshalMarkdownTargetHook != nil {
+		return marshalMarkdownTargetHook(path, sourcePath, stagedEntries)
+	}
+	mdx := strings.EqualFold(filepath.Ext(sourcePath), ".mdx")
 	sourceTemplate, err := s.readFile(sourcePath)
 	if err != nil {
 		return nil, nil, fmt.Errorf("flush outputs: read template source %q: %w", sourcePath, err)

--- a/apps/cli/internal/i18n/runsvc/output_marshal.go
+++ b/apps/cli/internal/i18n/runsvc/output_marshal.go
@@ -152,11 +152,10 @@ func (s *Service) marshalMarkdownTarget(path, sourcePath string, stagedEntries m
 }
 
 func markdownASTParityFlushError(targetPath string, sourceTemplate, marshaledContent []byte, sourcePath string) error {
-	msgs := translationfileparser.MarkdownASTParityWarnings(sourceTemplate, marshaledContent, sourcePath, targetPath)
-	if len(msgs) == 0 {
-		return nil
+	if err := translationfileparser.ValidateMarkdownMarshaledASTParity(sourceTemplate, marshaledContent, sourcePath, targetPath); err != nil {
+		return fmt.Errorf("flush outputs: markdown AST parity mismatch for %q: %w", targetPath, err)
 	}
-	return fmt.Errorf("flush outputs: markdown AST parity mismatch for %q: %s", targetPath, strings.Join(msgs, "; "))
+	return nil
 }
 
 func (s *Service) marshalHTMLTarget(path, sourcePath string, stagedEntries map[string]string) ([]byte, []string, error) {

--- a/apps/cli/internal/i18n/runsvc/run_orchestrator.go
+++ b/apps/cli/internal/i18n/runsvc/run_orchestrator.go
@@ -115,7 +115,14 @@ func (s *Service) Run(ctx context.Context, in Input) (report Report, err error) 
 	if cacheSvc != nil {
 		l1Cache = cacheSvc.L1
 	}
-	staged, flushedTargets, execReport, err := s.executePool(ctx, executable, checkpointStaged, in.LockPath, state, in.Workers, activeRunID, pruneTargets, contextPlan, l1Cache, emitter, summaryReportMode)
+	parityRetry := &markdownParityRetryInput{
+		cfg:           cfg,
+		bucket:        in.Bucket,
+		group:         in.Group,
+		targetLocales: in.TargetLocales,
+		sourcePaths:   in.SourcePaths,
+	}
+	staged, flushedTargets, execReport, err := s.executePool(ctx, executable, checkpointStaged, in.LockPath, state, in.Workers, activeRunID, pruneTargets, contextPlan, l1Cache, emitter, summaryReportMode, parityRetry)
 	report.Succeeded = execReport.Succeeded
 	report.Failed = execReport.Failed
 	report.PersistedToLock = execReport.PersistedToLock
@@ -133,7 +140,7 @@ func (s *Service) Run(ctx context.Context, in Input) (report Report, err error) 
 
 	emitter.emit(Event{Kind: EventPhase, Phase: PhaseFinalizingOutput})
 	remainingPruneTargets, remainingPruneMetadata := remainingPruneTargets(pruneTargets, pruneMetadata, flushedTargets)
-	flushWarnings, err := s.flushOutputs(staged, remainingPruneTargets, remainingPruneMetadata)
+	flushWarnings, err := s.flushOutputs(ctx, parityRetry, staged, remainingPruneTargets, remainingPruneMetadata)
 	report.Warnings = append(report.Warnings, flushWarnings...)
 	if err != nil {
 		emitter.emit(completedEvent(report))

--- a/apps/cli/internal/i18n/runsvc/service_test.go
+++ b/apps/cli/internal/i18n/runsvc/service_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1485,6 +1486,61 @@ func TestRunWritesMarkdownUsingSourceTemplateWhenTargetMissing(t *testing.T) {
 	}
 	if !strings.Contains(out, "FR(Heading)") || !strings.Contains(out, "FR(Hello `code` and [docs](https://example.com).)") {
 		t.Fatalf("expected markdown text translated, got %q", out)
+	}
+}
+
+func TestRunMarkdownParityScopeRetryFixesFlush(t *testing.T) {
+	svc := newTestService()
+	sourcePath := "/tmp/source.md"
+	targetPath := "/tmp/out.md"
+	source := "Para line one\nline two\n"
+
+	keys, err := translationfileparser.MarkdownParser{}.Parse([]byte(source))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	nKeys := len(keys)
+	if nKeys < 1 {
+		t.Fatalf("expected at least one markdown key, got %d", nKeys)
+	}
+
+	svc.loadConfig = func(_ string) (*config.I18NConfig, error) {
+		cfg := testConfig(sourcePath, targetPath)
+		return &cfg, nil
+	}
+	svc.readFile = func(path string) ([]byte, error) {
+		switch path {
+		case sourcePath:
+			return []byte(source), nil
+		default:
+			return nil, os.ErrNotExist
+		}
+	}
+	var calls atomic.Int32
+	svc.translate = func(_ context.Context, req translator.Request) (string, error) {
+		if int(calls.Add(1)) <= nKeys {
+			return req.Source + "\n\n# Injected\n", nil
+		}
+		return "FIXED_SEGMENT", nil
+	}
+	var written []byte
+	svc.writeFile = func(path string, content []byte) error {
+		if path != targetPath {
+			t.Fatalf("unexpected write path %q", path)
+		}
+		written = append([]byte(nil), content...)
+		return nil
+	}
+
+	_, err = svc.Run(context.Background(), Input{Workers: 1})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !strings.Contains(string(written), "FIXED_SEGMENT") {
+		t.Fatalf("expected retried translation in output, got %q", string(written))
+	}
+	if strings.Contains(string(written), "# Injected") {
+		t.Fatalf("did not expect injected heading after retry, got %q", string(written))
 	}
 }
 

--- a/apps/cli/internal/i18n/runsvc/translation_output_validate.go
+++ b/apps/cli/internal/i18n/runsvc/translation_output_validate.go
@@ -32,7 +32,7 @@ func translationOutputKindForSourcePath(path string) translationOutputKind {
 
 // validateTranslatedOutput runs all applicable post-translate checks for the task's source path kind.
 //
-//   - Markdown / MDX: internal HLMDPH sentinel multiset only (ICU rules are not applied; see check command).
+//   - Markdown / MDX: cheap single-line-segment block-structure heuristic, then internal HLMDPH sentinel multiset (ICU rules are not applied; see check command). Full composed files still use AST parity at flush.
 //   - HTML: normalized HTML tag-name sequence must match source, then ICU invariant on the segment text.
 //   - Everything else: ICU MessageFormat / placeholder parity via validateTranslatedInvariant.
 func validateTranslatedOutput(task Task, translated string) error {
@@ -42,6 +42,9 @@ func validateTranslatedOutput(task Task, translated string) error {
 func validateTranslatedOutputForKind(kind translationOutputKind, source, translated string) error {
 	switch kind {
 	case translationOutputMarkdown:
+		if err := translationfileparser.ValidateMarkdownTranslatedBlockStructure(source, translated); err != nil {
+			return &postTranslateValidationError{msg: err.Error()}
+		}
 		if err := translationfileparser.ValidateMarkdownInternalPlaceholders(source, translated); err != nil {
 			return &postTranslateValidationError{msg: err.Error()}
 		}

--- a/apps/cli/internal/i18n/runsvc/translation_output_validate_test.go
+++ b/apps/cli/internal/i18n/runsvc/translation_output_validate_test.go
@@ -51,6 +51,21 @@ func TestValidateTranslatedOutputMatrix(t *testing.T) {
 			errContains: "placeholder",
 		},
 		{
+			name:        "markdown_single_line_injected_heading",
+			path:        "/en/a.md",
+			source:      "Hello.",
+			translated:  "Bonjour.\n\n# Bad",
+			wantErr:     true,
+			errContains: "structure",
+		},
+		{
+			name:       "markdown_multiline_source_skips_block_heuristic",
+			path:       "/en/a.md",
+			source:     "Line1\nLine2",
+			translated: "L1\n\n# X",
+			wantErr:    false,
+		},
+		{
 			name:       "markdown_skips_icu_even_if_invalid_message_shape",
 			path:       "/en/a.md",
 			source:     "{not, valid icu",

--- a/internal/i18n/translationfileparser/markdown_ast_parity.go
+++ b/internal/i18n/translationfileparser/markdown_ast_parity.go
@@ -7,6 +7,30 @@ import (
 	"strings"
 )
 
+// MarkdownASTParityError is returned by [ValidateMarkdownMarshaledASTParity] when
+// the marshaled document's translatable-structure path set differs from the source template.
+type MarkdownASTParityError struct {
+	TargetPath string
+	Messages   []string
+}
+
+func (e *MarkdownASTParityError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return fmt.Sprintf("markdown AST parity mismatch for %q: %s", e.TargetPath, strings.Join(e.Messages, "; "))
+}
+
+// ValidateMarkdownMarshaledASTParity returns nil when marshaled output matches the source
+// template's structural path set under the same MDX mode as the source path (see [MarkdownASTParityWarnings]).
+func ValidateMarkdownMarshaledASTParity(sourceContent, marshaledContent []byte, sourcePath, targetPath string) error {
+	msgs := MarkdownASTParityWarnings(sourceContent, marshaledContent, sourcePath, targetPath)
+	if len(msgs) == 0 {
+		return nil
+	}
+	return &MarkdownASTParityError{TargetPath: targetPath, Messages: msgs}
+}
+
 // MarkdownASTParityWarnings returns human-readable warnings when the set of
 // MarkdownASTPaths for marshaled output differs from the source template,
 // using the same path-set comparison as the check command.
@@ -14,10 +38,11 @@ func MarkdownASTParityWarnings(sourceContent, marshaledContent []byte, sourcePat
 	if len(sourceContent) == 0 || len(marshaledContent) == 0 {
 		return nil
 	}
-	sourceMDX := strings.EqualFold(filepath.Ext(sourcePath), ".mdx")
-	targetMDX := strings.EqualFold(filepath.Ext(targetPath), ".mdx")
-	sourcePaths := MarkdownASTPaths(sourceContent, sourceMDX)
-	targetPaths := MarkdownASTPaths(marshaledContent, targetMDX)
+	// Use the source template's MDX flag for both parses so parity compares the same
+	// extraction rules used when planning tasks from the source file.
+	mdx := strings.EqualFold(filepath.Ext(sourcePath), ".mdx")
+	sourcePaths := MarkdownASTPaths(sourceContent, mdx)
+	targetPaths := MarkdownASTPaths(marshaledContent, mdx)
 
 	sourceSet := make(map[string]struct{}, len(sourcePaths))
 	for _, p := range sourcePaths {

--- a/internal/i18n/translationfileparser/markdown_ast_parity_test.go
+++ b/internal/i18n/translationfileparser/markdown_ast_parity_test.go
@@ -1,6 +1,7 @@
 package translationfileparser
 
 import (
+	"errors"
 	"strings"
 	"testing"
 )
@@ -11,6 +12,25 @@ func TestMarkdownASTParityWarningsNone(t *testing.T) {
 	w := MarkdownASTParityWarnings(src, out, "/en/page.md", "/fr/page.md")
 	if len(w) != 0 {
 		t.Fatalf("expected no warnings, got %v", w)
+	}
+}
+
+func TestValidateMarkdownMarshaledASTParityError(t *testing.T) {
+	src := []byte("# One\n\n## Two\n")
+	out := []byte("plain text only\n")
+	err := ValidateMarkdownMarshaledASTParity(src, out, "/a.md", "/b.md")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var pe *MarkdownASTParityError
+	if !errors.As(err, &pe) {
+		t.Fatalf("expected MarkdownASTParityError, got %T: %v", err, err)
+	}
+	if pe.TargetPath != "/b.md" {
+		t.Fatalf("TargetPath: %q", pe.TargetPath)
+	}
+	if len(pe.Messages) == 0 {
+		t.Fatal("expected messages")
 	}
 }
 

--- a/internal/i18n/translationfileparser/markdown_segment_heuristics.go
+++ b/internal/i18n/translationfileparser/markdown_segment_heuristics.go
@@ -1,0 +1,50 @@
+package translationfileparser
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var (
+	markdownHeadingLineRe       = regexp.MustCompile(`(?m)^#{1,6}\s`)
+	markdownFenceBacktickLineRe = regexp.MustCompile("(?m)^```")
+	markdownThematicBreakLineRe = regexp.MustCompile(`(?m)^[ \t]*(?:-{3,}|\*{3,}|_{3,})[ \t]*$`)
+	markdownBlockquoteLineRe    = regexp.MustCompile(`(?m)^>`)
+	markdownOrderedListLineRe   = regexp.MustCompile(`(?m)^\d+[.)][ \t]`)
+	markdownBulletListLineRe    = regexp.MustCompile(`(?m)^[-*+][ \t]`)
+)
+
+// ValidateMarkdownTranslatedBlockStructure rejects translations that introduce common
+// block-level markdown line patterns absent from the source segment. This is a cheap
+// pre-check; full-document safety still requires [ValidateMarkdownMarshaledASTParity].
+//
+// Rules apply only when the source segment contains no newlines, so multi-line source
+// segments (headings, lists, etc. in context) are not rejected aggressively.
+func ValidateMarkdownTranslatedBlockStructure(source, translated string) error {
+	if strings.TrimSpace(translated) == "" {
+		return nil
+	}
+	if strings.Contains(source, "\n") {
+		return nil
+	}
+	if markdownHeadingLineRe.MatchString(translated) && !markdownHeadingLineRe.MatchString(source) {
+		return fmt.Errorf("markdown structure: translation introduces ATX heading line(s); keep block structure aligned with the source segment")
+	}
+	if markdownFenceBacktickLineRe.MatchString(translated) && !markdownFenceBacktickLineRe.MatchString(source) {
+		return fmt.Errorf("markdown structure: translation introduces fenced code delimiter line(s)")
+	}
+	if markdownThematicBreakLineRe.MatchString(translated) && !markdownThematicBreakLineRe.MatchString(source) {
+		return fmt.Errorf("markdown structure: translation introduces thematic break line(s)")
+	}
+	if markdownBlockquoteLineRe.MatchString(translated) && !markdownBlockquoteLineRe.MatchString(source) {
+		return fmt.Errorf("markdown structure: translation introduces blockquote line(s)")
+	}
+	if markdownOrderedListLineRe.MatchString(translated) && !markdownOrderedListLineRe.MatchString(source) {
+		return fmt.Errorf("markdown structure: translation introduces ordered list line(s)")
+	}
+	if markdownBulletListLineRe.MatchString(translated) && !markdownBulletListLineRe.MatchString(source) {
+		return fmt.Errorf("markdown structure: translation introduces bullet list line(s)")
+	}
+	return nil
+}

--- a/internal/i18n/translationfileparser/markdown_segment_heuristics_test.go
+++ b/internal/i18n/translationfileparser/markdown_segment_heuristics_test.go
@@ -1,0 +1,43 @@
+package translationfileparser
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateMarkdownTranslatedBlockStructureSingleLineSourceOK(t *testing.T) {
+	if err := ValidateMarkdownTranslatedBlockStructure("Hello.", "Bonjour."); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+func TestValidateMarkdownTranslatedBlockStructureSkipsMultiLineSource(t *testing.T) {
+	src := "# Title\n\nBody line."
+	tgt := "# Title\n\nBody line.\n\n# Extra"
+	if err := ValidateMarkdownTranslatedBlockStructure(src, tgt); err != nil {
+		t.Fatalf("expected no heuristic error for multi-line source, got %v", err)
+	}
+}
+
+func TestValidateMarkdownTranslatedBlockStructureRejectsInjectedHeading(t *testing.T) {
+	err := ValidateMarkdownTranslatedBlockStructure("Hello world.", "Bonjour.\n\n# Bad")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "ATX heading") {
+		t.Fatalf("unexpected: %v", err)
+	}
+}
+
+func TestValidateMarkdownTranslatedBlockStructureAllowsHeadingWhenSourceHasIt(t *testing.T) {
+	if err := ValidateMarkdownTranslatedBlockStructure("# A", "# B"); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+func TestValidateMarkdownTranslatedBlockStructureRejectsThematicBreak(t *testing.T) {
+	err := ValidateMarkdownTranslatedBlockStructure("Hello.", "Hi.\n\n---\n")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}


### PR DESCRIPTION
## What changed

- Ground-truth parity: added ValidateMarkdownMarshaledASTParity and MarkdownASTParityError in translationfileparser; flush errors use %w so errors.As works.
- MDX consistency: MarkdownASTParityWarnings parses source and marshaled bytes with the source path’s .md / .mdx mode (aligned with planning).
- Scope-level retry: on markdown flush parity failure, replan the whole file (FixMarkdownScope), append parity messages to prompts, re-translate up to three full passes, then flush again; still no write until parity passes or retries exhaust.
- Executor / flush: staged output and flushedTargets update only after a successful flush; on flush error that target’s staging is cleared so final flushOutputs does not fail unrelated targets.
- Heuristics: ValidateMarkdownTranslatedBlockStructure for markdown when the source segment has no newlines, before HLMDPH placeholder checks.

## How to test

Run:

make fmt && make lint && make test

Then:

go test ./internal/i18n/translationfileparser/ -run 'MarkdownAST|MarkdownSegment|ValidateMarkdown' -count=1

go test ./apps/cli/internal/i18n/runsvc/ -run 'MarkdownParity|ContinuesWhenOne|ValidateTranslatedOutputMatrix' -count=1

## Checklist

- [x] I ran relevant checks locally (make fmt, make lint, make test)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review