### PR TITLE
fix(crowdin): accept extra Crowdin crowdin.yml fields for strict YAML decode

### DIFF
--- a/docs/commands/crowdin.mdx
+++ b/docs/commands/crowdin.mdx
@@ -24,9 +24,11 @@ Use them when you want Crowdin-compatible file mode:
 - source-file upload from `files[].source`
 - translation upload from `files[].translation`
 - translation download/export back into your repo
-- strict validation of supported `crowdin.yml` fields
+- strict YAML decoding: only keys Crowdin documents and `hl` recognizes may appear in `crowdin.yml` (unknown keys still error)
 
 ## Supported config fields
+
+These drive Hyperlocalise Crowdin file mode:
 
 - `project_id`
 - `project_id_env`
@@ -45,13 +47,20 @@ Use them when you want Crowdin-compatible file mode:
 - `files[].skip_untranslated_files`
 - `files[].export_only_approved`
 
+## Crowdin CLI compatibility (parsed, not applied)
+
+The decoder also accepts several Crowdin-documented keys so you can reuse a standard `crowdin.yml` without stripping metadata. Hyperlocalise does **not** implement behavior for these yet; they are ignored after parse:
+
+- Root: `export_languages`, `branch`, `pull_request_title`, `pull_request_labels`, `commit_message`, `append_commit_message`, `pull_request_assignees`, `pull_request_reviewers`
+- Per file: `type`, `dest`, `update_option`, `export_pattern`, `translate_content`, `translate_attributes`, `content_segmentation`, `translatable_elements`, `ignore`, `translation_replace`, `first_line_contains_header`, `scheme`, `custom_segmentation`, `escape_quotes`, `escape_special_characters`, `labels`
+
 ## Unsupported features
 
-Validation fails closed for unsupported Crowdin CLI features.
+YAML keys not listed above still cause a decode error (`KnownFields`).
 
 This v1 file-mode implementation does not support:
 
-- branch workflows
+- branch workflows (the `branch` field is accepted but not used)
 - TM, glossary, task, screenshot, comment, distribution, or app commands
 - permissive "warn and ignore" compatibility mode
 - interactive Crowdin project bootstrap

--- a/internal/i18n/storage/crowdin/fileconfig.go
+++ b/internal/i18n/storage/crowdin/fileconfig.go
@@ -38,6 +38,16 @@ type fileConfigYAML struct {
 	BasePathEnv       string          `yaml:"base_path_env"`
 	PreserveHierarchy bool            `yaml:"preserve_hierarchy"`
 	Files             []fileGroupYAML `yaml:"files"`
+
+	// Optional Crowdin CLI / VCS keys (parsed for YAML compatibility; hl file mode does not use them yet).
+	ExportLanguages      []string `yaml:"export_languages"`
+	Branch               string   `yaml:"branch"`
+	PullRequestTitle     string   `yaml:"pull_request_title"`
+	PullRequestLabels    []string `yaml:"pull_request_labels"`
+	CommitMessage        string   `yaml:"commit_message"`
+	AppendCommitMessage  *bool    `yaml:"append_commit_message"`
+	PullRequestAssignees []any    `yaml:"pull_request_assignees"`
+	PullRequestReviewers []any    `yaml:"pull_request_reviewers"`
 }
 
 type identityConfigYAML struct {
@@ -50,6 +60,24 @@ type identityConfigYAML struct {
 }
 
 type fileGroupYAML struct {
+	// Optional Crowdin CLI fields (parsed for compatibility; hl file mode does not use them yet).
+	Type                    string            `yaml:"type"`
+	Dest                    string            `yaml:"dest"`
+	UpdateOption            string            `yaml:"update_option"`
+	ExportPattern           string            `yaml:"export_pattern"`
+	TranslateContent        any               `yaml:"translate_content"` // bool or 0/1 in Crowdin examples
+	TranslateAttributes     any               `yaml:"translate_attributes"`
+	ContentSegmentation     any               `yaml:"content_segmentation"`
+	TranslatableElements    []string          `yaml:"translatable_elements"`
+	Ignore                  []string          `yaml:"ignore"`
+	TranslationReplace      map[string]string `yaml:"translation_replace"`
+	FirstLineContainsHeader *bool             `yaml:"first_line_contains_header"`
+	Scheme                  string            `yaml:"scheme"`
+	CustomSegmentation      string            `yaml:"custom_segmentation"`
+	EscapeQuotes            *int              `yaml:"escape_quotes"`
+	EscapeSpecialCharacters *int              `yaml:"escape_special_characters"`
+	Labels                  []string          `yaml:"labels"`
+
 	Source                  string                       `yaml:"source"`
 	Translation             string                       `yaml:"translation"`
 	LanguagesMapping        map[string]map[string]string `yaml:"languages_mapping"`

--- a/internal/i18n/storage/crowdin/fileconfig.go
+++ b/internal/i18n/storage/crowdin/fileconfig.go
@@ -61,13 +61,15 @@ type identityConfigYAML struct {
 
 type fileGroupYAML struct {
 	// Optional Crowdin CLI fields (parsed for compatibility; hl file mode does not use them yet).
-	Type                    string            `yaml:"type"`
-	Dest                    string            `yaml:"dest"`
-	UpdateOption            string            `yaml:"update_option"`
-	ExportPattern           string            `yaml:"export_pattern"`
-	TranslateContent        any               `yaml:"translate_content"` // bool or 0/1 in Crowdin examples
-	TranslateAttributes     any               `yaml:"translate_attributes"`
-	ContentSegmentation     any               `yaml:"content_segmentation"`
+	Type          string `yaml:"type"`
+	Dest          string `yaml:"dest"`
+	UpdateOption  string `yaml:"update_option"`
+	ExportPattern string `yaml:"export_pattern"`
+	// Crowdin accepts bool or 0/1 scalars; using any keeps YAML compatibility but does not reject other scalars.
+	// hl does not apply these fields yet; callers would need a type switch if they ever do.
+	TranslateContent        any               `yaml:"translate_content"`    // bool, 0, or 1
+	TranslateAttributes     any               `yaml:"translate_attributes"` // same semantics
+	ContentSegmentation     any               `yaml:"content_segmentation"` // same semantics
 	TranslatableElements    []string          `yaml:"translatable_elements"`
 	Ignore                  []string          `yaml:"ignore"`
 	TranslationReplace      map[string]string `yaml:"translation_replace"`

--- a/internal/i18n/storage/crowdin/fileconfig_test.go
+++ b/internal/i18n/storage/crowdin/fileconfig_test.go
@@ -123,6 +123,86 @@ files:
 	}
 }
 
+func TestLoadFileWorkflowConfigAcceptsCrowdinCLIFileMetadata(t *testing.T) {
+	t.Setenv(defaultProjectIDEnvName, "123")
+	t.Setenv(defaultAPITokenEnvName, "secret")
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "crowdin.yml")
+	if err := os.WriteFile(configPath, []byte(`
+files:
+  - source: /src/en.json
+    type: json
+    translation: /dist/%locale%/%original_file_name%
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, _, err := LoadFileWorkflowConfig(configPath, "")
+	if err != nil {
+		t.Fatalf("load file workflow config: %v", err)
+	}
+	if len(cfg.Files) != 1 {
+		t.Fatalf("files len = %d, want 1", len(cfg.Files))
+	}
+}
+
+func TestLoadFileWorkflowConfigAcceptsExtendedCrowdinCLIKeys(t *testing.T) {
+	t.Setenv(defaultProjectIDEnvName, "123")
+	t.Setenv(defaultAPITokenEnvName, "secret")
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "crowdin.yml")
+	if err := os.WriteFile(configPath, []byte(`
+export_languages:
+  - uk
+  - ja
+branch: main
+pull_request_title: Custom
+pull_request_labels:
+  - crowdin
+commit_message: "[ci skip]"
+append_commit_message: false
+pull_request_assignees:
+  - alice
+  - 42
+pull_request_reviewers:
+  - bob
+files:
+  - source: /src/**/*.xml
+    dest: /dest/%file_name%.xml
+    translation: /dist/%locale%/%original_file_name%
+    type: xml
+    update_option: update_as_unapproved
+    ignore:
+      - /src/legacy/**/*
+    translation_replace:
+      _en: ""
+    first_line_contains_header: true
+    scheme: identifier,source_phrase,context,uk
+    custom_segmentation: /rules/sample.srx.xml
+    translate_content: 0
+    translate_attributes: 1
+    content_segmentation: 1
+    translatable_elements:
+      - /content/text
+    escape_quotes: 1
+    escape_special_characters: 0
+    labels:
+      - android
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, _, err := LoadFileWorkflowConfig(configPath, "")
+	if err != nil {
+		t.Fatalf("load file workflow config: %v", err)
+	}
+	if len(cfg.Files) != 1 {
+		t.Fatalf("files len = %d, want 1", len(cfg.Files))
+	}
+}
+
 func TestLoadFileWorkflowConfigAcceptsLanguagesMappingPlaceholder(t *testing.T) {
 	t.Setenv(defaultProjectIDEnvName, "123")
 	t.Setenv(defaultAPITokenEnvName, "secret")

--- a/internal/i18n/storage/crowdin/fileconfig_test.go
+++ b/internal/i18n/storage/crowdin/fileconfig_test.go
@@ -174,6 +174,7 @@ files:
     translation: /dist/%locale%/%original_file_name%
     type: xml
     update_option: update_as_unapproved
+    export_pattern: /dist/%two_letters_code%/%original_file_name%
     ignore:
       - /src/legacy/**/*
     translation_replace:
@@ -200,6 +201,14 @@ files:
 	}
 	if len(cfg.Files) != 1 {
 		t.Fatalf("files len = %d, want 1", len(cfg.Files))
+	}
+	raw, err := decodeYAMLFile[fileConfigYAML](configPath)
+	if err != nil {
+		t.Fatalf("decode raw config: %v", err)
+	}
+	wantExport := "/dist/%two_letters_code%/%original_file_name%"
+	if got := raw.Files[0].ExportPattern; got != wantExport {
+		t.Fatalf("export_pattern = %q, want %q", got, wantExport)
 	}
 }
 


### PR DESCRIPTION
## What changed

Crowdin file mode reads `crowdin.yml` with `yaml.Decoder` and `KnownFields(true)`, so any key Crowdin documents but we did not declare caused failures (for example `field type not found in type crowdin.fileGroupYAML`).

- Extended `fileConfigYAML` and `fileGroupYAML` with additional Crowdin-documented keys so standard configs decode successfully. Values are stored only for YAML compatibility; Hyperlocalise still does not implement behavior for these options (same as existing optional fields such as `type` / `dest`).
- Widened `translate_content` (and related import-style fields) to types that accept Crowdin’s `0` / `1` scalars as well as booleans where applicable.
- Added tests covering typical Crowdin CLI metadata on root and per-file entries.
- Updated `docs/commands/crowdin.mdx` to separate **fields that drive `hl`** from **parse-only compatibility** keys and to clarify that unknown keys still error.

## How to test

- `make fmt && make lint && make test`
- `hl crowdin config validate` (or `download` / `upload` as you prefer) using a `crowdin.yml` that includes Crowdin defaults such as `files[].type`, `files[].ignore`, `export_languages`, or VCS-related root keys (`pull_request_title`, `commit_message`, etc.) and confirm it loads without decode errors.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review