### PR TITLE
cli: add --file and --key filters to `check` command

### DIFF
--- a/apps/cli/cmd/check.go
+++ b/apps/cli/cmd/check.go
@@ -72,6 +72,8 @@ type checkOptions struct {
 	locales       []string
 	group         string
 	bucket        string
+	file          string
+	key           string
 	checks        []string
 	excludeChecks []string
 	format        string
@@ -229,6 +231,8 @@ func newCheckCmd() *cobra.Command {
 	cmd.Flags().StringSliceVar(&o.locales, "locale", nil, "target locale(s) to check")
 	cmd.Flags().StringVar(&o.group, "group", "", "filter by group name")
 	cmd.Flags().StringVar(&o.bucket, "bucket", "", "filter by bucket name")
+	cmd.Flags().StringVar(&o.file, "file", "", "filter by source file path")
+	cmd.Flags().StringVar(&o.key, "key", "", "filter by translation key")
 	cmd.Flags().StringSliceVar(&o.checks, "check", nil, "check(s) to run")
 	cmd.Flags().StringSliceVar(&o.excludeChecks, "exclude-check", nil, "default check(s) to skip")
 	cmd.Flags().StringVar(&o.format, "format", o.format, "output format: stylish (default), text, or json")
@@ -317,7 +321,7 @@ func runCheck(ctx context.Context, o checkOptions) (checkReport, error) {
 	resolveSpan.End()
 
 	_, collectSpan := tr.Start(ctx, "check.collect_findings")
-	findings, err := collectCheckFindings(cfg, buckets, locales, enabledChecks)
+	findings, err := collectCheckFindings(cfg, buckets, locales, enabledChecks, o.file, o.key)
 	if err != nil {
 		collectSpan.SetStatus(codes.Error, "collect_findings")
 		collectSpan.End()
@@ -609,13 +613,17 @@ func resolveEnabledChecks(includes, excludes []string) ([]string, error) {
 	return enabled, nil
 }
 
-func collectCheckFindings(cfg *config.I18NConfig, buckets, locales, enabledChecks []string) ([]checkFinding, error) {
+func collectCheckFindings(cfg *config.I18NConfig, buckets, locales, enabledChecks []string, sourceFileFilter, keyFilter string) ([]checkFinding, error) {
 	parser := translationfileparser.NewDefaultStrategy()
 	resolver := checkLocationResolver{content: make(map[string][]byte)}
 	checkSet := make(map[string]struct{}, len(enabledChecks))
 	for _, check := range enabledChecks {
 		checkSet[check] = struct{}{}
 	}
+
+	keyFilter = strings.TrimSpace(keyFilter)
+	fileFilter := filepath.Clean(strings.TrimSpace(sourceFileFilter))
+	filterByFile := strings.TrimSpace(sourceFileFilter) != ""
 
 	var findings []checkFinding
 	for _, bucketName := range buckets {
@@ -628,6 +636,9 @@ func collectCheckFindings(cfg *config.I18NConfig, buckets, locales, enabledCheck
 			}
 			for _, sourcePath := range sourcePaths {
 				if shouldIgnoreSourcePathForStatus(sourcePath, cfg.Locales.Targets) {
+					continue
+				}
+				if filterByFile && filepath.Clean(sourcePath) != fileFilter {
 					continue
 				}
 				sourceEntries, err := readEntriesForStatus(parser, sourcePath)
@@ -646,25 +657,27 @@ func collectCheckFindings(cfg *config.I18NConfig, buckets, locales, enabledCheck
 						return nil, err
 					}
 					if !targetExists {
-						if _, ok := checkSet[checkMissingTargetFile]; ok {
-							annotationFile, annotationLine := resolver.resolve(sourcePath, targetPath, "", "", "", true)
-							findings = append(findings, checkFinding{
-								Type:           checkMissingTargetFile,
-								Severity:       severityForCheck(checkMissingTargetFile),
-								Bucket:         bucketName,
-								Locale:         locale,
-								SourceFile:     sourcePath,
-								TargetFile:     targetPath,
-								Message:        "target file does not exist",
-								AnnotationFile: annotationFile,
-								AnnotationLine: annotationLine,
-							})
+						if keyFilter == "" {
+							if _, ok := checkSet[checkMissingTargetFile]; ok {
+								annotationFile, annotationLine := resolver.resolve(sourcePath, targetPath, "", "", "", true)
+								findings = append(findings, checkFinding{
+									Type:           checkMissingTargetFile,
+									Severity:       severityForCheck(checkMissingTargetFile),
+									Bucket:         bucketName,
+									Locale:         locale,
+									SourceFile:     sourcePath,
+									TargetFile:     targetPath,
+									Message:        "target file does not exist",
+									AnnotationFile: annotationFile,
+									AnnotationLine: annotationLine,
+								})
+							}
 						}
 						continue
 					}
 
-					findings = append(findings, collectEntryCheckFindings(&resolver, bucketName, locale, sourcePath, targetPath, sourceEntries, targetEntries, checkSet)...)
-					if hasCheck(checkSet, checkMarkdownAST) && isMarkdownPath(targetPath) {
+					findings = append(findings, collectEntryCheckFindings(&resolver, bucketName, locale, sourcePath, targetPath, sourceEntries, targetEntries, checkSet, keyFilter)...)
+					if keyFilter == "" && hasCheck(checkSet, checkMarkdownAST) && isMarkdownPath(targetPath) {
 						findings = append(findings, collectMarkdownASTParityFindings(&resolver, bucketName, locale, sourcePath, targetPath, sourceContent, targetContent)...)
 					}
 				}
@@ -703,7 +716,7 @@ func readCheckTargetEntries(parser *translationfileparser.Strategy, sourcePath, 
 	return targetEntries, nil, nil, true, nil
 }
 
-func collectEntryCheckFindings(resolver *checkLocationResolver, bucketName, locale, sourcePath, targetPath string, sourceEntries, targetEntries map[string]string, checkSet map[string]struct{}) []checkFinding {
+func collectEntryCheckFindings(resolver *checkLocationResolver, bucketName, locale, sourcePath, targetPath string, sourceEntries, targetEntries map[string]string, checkSet map[string]struct{}, keyFilter string) []checkFinding {
 	keys := make([]string, 0, len(sourceEntries))
 	for key := range sourceEntries {
 		keys = append(keys, key)
@@ -712,6 +725,9 @@ func collectEntryCheckFindings(resolver *checkLocationResolver, bucketName, loca
 
 	findings := make([]checkFinding, 0)
 	for _, key := range keys {
+		if keyFilter != "" && key != keyFilter {
+			continue
+		}
 		sourceValue := sourceEntries[key]
 		targetValue, hasTargetKey := targetEntries[key]
 		isWhitespaceOnlyTarget := hasTargetKey && targetValue != "" && strings.TrimSpace(targetValue) == ""
@@ -837,6 +853,9 @@ func collectEntryCheckFindings(resolver *checkLocationResolver, bucketName, loca
 		}
 		slices.Sort(orphanedKeys)
 		for _, key := range orphanedKeys {
+			if keyFilter != "" && key != keyFilter {
+				continue
+			}
 			annotationFile, annotationLine := resolver.resolve(sourcePath, targetPath, key, "", targetEntries[key], false)
 			findings = append(findings, checkFinding{
 				Type:           checkOrphanedKey,

--- a/apps/cli/cmd/check.go
+++ b/apps/cli/cmd/check.go
@@ -622,8 +622,16 @@ func collectCheckFindings(cfg *config.I18NConfig, buckets, locales, enabledCheck
 	}
 
 	keyFilter = strings.TrimSpace(keyFilter)
-	fileFilter := filepath.Clean(strings.TrimSpace(sourceFileFilter))
-	filterByFile := strings.TrimSpace(sourceFileFilter) != ""
+	trimmedFileFilter := strings.TrimSpace(sourceFileFilter)
+	filterByFile := trimmedFileFilter != ""
+	fileFilter := ""
+	if filterByFile {
+		var err error
+		fileFilter, err = filepath.Abs(trimmedFileFilter)
+		if err != nil {
+			return nil, fmt.Errorf("resolve --file path %q: %w", trimmedFileFilter, err)
+		}
+	}
 
 	var findings []checkFinding
 	for _, bucketName := range buckets {
@@ -638,8 +646,11 @@ func collectCheckFindings(cfg *config.I18NConfig, buckets, locales, enabledCheck
 				if shouldIgnoreSourcePathForStatus(sourcePath, cfg.Locales.Targets) {
 					continue
 				}
-				if filterByFile && filepath.Clean(sourcePath) != fileFilter {
-					continue
+				if filterByFile {
+					absSourcePath, err := filepath.Abs(sourcePath)
+					if err != nil || absSourcePath != fileFilter {
+						continue
+					}
 				}
 				sourceEntries, err := readEntriesForStatus(parser, sourcePath)
 				if err != nil {

--- a/apps/cli/cmd/check_test.go
+++ b/apps/cli/cmd/check_test.go
@@ -146,6 +146,7 @@ func TestCollectEntryCheckFindingsSkipsRedundantChecksForWhitespaceOnlyNotLocali
 			checkWhitespaceOnly: {},
 			checkHTMLTag:        {},
 		},
+		"",
 	)
 
 	if len(findings) != 1 {
@@ -498,6 +499,67 @@ func TestCheckCommandFiltersByBucketAndLocale(t *testing.T) {
 	}
 	if finding.AnnotationFile == "" || finding.AnnotationLine == 0 {
 		t.Fatalf("expected annotation location: %+v", finding)
+	}
+}
+
+func TestCheckCommandFiltersByFileAndKey(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "i18n.jsonc")
+	oneSourcePath := filepath.Join(dir, "content", "en", "one.json")
+	twoSourcePath := filepath.Join(dir, "content", "en", "two.json")
+	oneTargetPath := filepath.Join(dir, "dist", "fr", "one.json")
+	twoTargetPath := filepath.Join(dir, "dist", "fr", "two.json")
+
+	for _, path := range []string{oneSourcePath, twoSourcePath, oneTargetPath, twoTargetPath} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("create dir for %s: %v", path, err)
+		}
+	}
+	if err := os.WriteFile(oneSourcePath, []byte(`{"hello":"Hello","cta":"Submit"}`), 0o600); err != nil {
+		t.Fatalf("write first source: %v", err)
+	}
+	if err := os.WriteFile(twoSourcePath, []byte(`{"hello":"Hello"}`), 0o600); err != nil {
+		t.Fatalf("write second source: %v", err)
+	}
+	if err := os.WriteFile(oneTargetPath, []byte(`{"hello":"Bonjour","cta":""}`), 0o600); err != nil {
+		t.Fatalf("write first target: %v", err)
+	}
+	if err := os.WriteFile(twoTargetPath, []byte(`{"hello":""}`), 0o600); err != nil {
+		t.Fatalf("write second target: %v", err)
+	}
+
+	content := `{
+	  "locales": {"source":"en","targets":["fr"]},
+	  "buckets": {
+	    "ui":{"files":[{"from":"` + filepath.ToSlash(oneSourcePath) + `","to":"` + filepath.ToSlash(filepath.Join(dir, "dist", "[locale]", "one.json")) + `"}]},
+	    "docs":{"files":[{"from":"` + filepath.ToSlash(twoSourcePath) + `","to":"` + filepath.ToSlash(filepath.Join(dir, "dist", "[locale]", "two.json")) + `"}]}
+	  },
+	  "groups": {"default":{"targets":["fr"],"buckets":["ui","docs"]}},
+	  "llm": {"profiles":{"default":{"provider":"openai","model":"gpt-4.1-mini","prompt":"Translate {{input}}"}}}
+	}`
+	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"check", "--config", configPath, "--file", oneSourcePath, "--key", "cta", "--check", checkNotLocalized, "--format", "json", "--no-fail"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("check command with --file and --key filters: %v", err)
+	}
+	var report checkReport
+	if err := json.Unmarshal(out.Bytes(), &report); err != nil {
+		t.Fatalf("parse filtered json output: %v", err)
+	}
+	if report.Summary.Total != 1 {
+		t.Fatalf("expected one finding, got %+v", report)
+	}
+	finding := report.Findings[0]
+	if finding.SourceFile != oneSourcePath || finding.Key != "cta" || finding.Type != checkNotLocalized {
+		t.Fatalf("unexpected finding with file/key filters: %+v", finding)
 	}
 }
 

--- a/apps/cli/cmd/check_test.go
+++ b/apps/cli/cmd/check_test.go
@@ -563,6 +563,53 @@ func TestCheckCommandFiltersByFileAndKey(t *testing.T) {
 	}
 }
 
+func TestCheckCommandFiltersByRelativeFilePath(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "i18n.jsonc")
+	sourcePath := filepath.Join(dir, "content", "en", "one.json")
+	targetPath := filepath.Join(dir, "dist", "fr", "one.json")
+
+	for _, path := range []string{sourcePath, targetPath} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("create dir for %s: %v", path, err)
+		}
+	}
+	if err := os.WriteFile(sourcePath, []byte(`{"cta":"Submit"}`), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	if err := os.WriteFile(targetPath, []byte(`{"cta":""}`), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+
+	writeCheckConfig(t, configPath, sourcePath, targetPath, []string{"fr"})
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory: %v", err)
+	}
+	relSourcePath, err := filepath.Rel(wd, sourcePath)
+	if err != nil {
+		t.Fatalf("build relative source path: %v", err)
+	}
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"check", "--config", configPath, "--file", relSourcePath, "--key", "cta", "--check", checkNotLocalized, "--format", "json", "--no-fail"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("check command with relative --file path: %v", err)
+	}
+	var report checkReport
+	if err := json.Unmarshal(out.Bytes(), &report); err != nil {
+		t.Fatalf("parse filtered json output: %v", err)
+	}
+	if report.Summary.Total != 1 {
+		t.Fatalf("expected one finding, got %+v", report)
+	}
+}
+
 func TestCheckCommandChecksMDXContent(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "i18n.jsonc")


### PR DESCRIPTION
### Motivation

- Allow running the `check` command narrowly against a single source file and/or a single translation key to speed up triage and reduce noise.

### Description

- Add `file` and `key` fields to `checkOptions` and expose them as `--file` and `--key` CLI flags on the `check` command.
- Extend `collectCheckFindings` to accept `sourceFileFilter` and `keyFilter` parameters and apply a file-level filter when enumerating source paths.
- Extend `collectEntryCheckFindings` to accept `keyFilter` and skip non-matching keys, and suppress `check_missing_target_file` and `checkMarkdownAST` findings when a key filter is provided.
- Update tests and call sites to match the new signatures and add `TestCheckCommandFiltersByFileAndKey` to verify filtering behavior.

### Testing

- Ran `go test ./apps/cli -run TestCheckCommandFiltersByFileAndKey` and the new test passed.
- Ran `go test ./...` and the full test suite completed successfully with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0919d76d0832cb01596e39c583688)