### PR TITLE
feat(cli): add diff-scoped validation for changed keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ The CLI centers on four workflows:
 
 Other commands include `init`, `completion`, `update`, and `version`.
 
+For review-time validation, `check` also supports `--diff-stdin` to scope findings to changed keys from a unified patch for configured `.json`, `.jsonc`, and `.arb` translation files.
+
 Use `hyperlocalise --help` for the local command surface, or see the docs for full flags, examples, and provider-specific setup.
 
 ## GitHub Action

--- a/apps/cli/cmd/check.go
+++ b/apps/cli/cmd/check.go
@@ -74,6 +74,8 @@ type checkOptions struct {
 	bucket        string
 	file          string
 	key           string
+	diffStdin     bool
+	diffContent   []byte
 	checks        []string
 	excludeChecks []string
 	format        string
@@ -117,6 +119,44 @@ type checkReport struct {
 	Summary  checkSummary   `json:"summary"`
 }
 
+type checkTargetDescriptor struct {
+	locale     string
+	targetPath string
+}
+
+type checkSourceDescriptor struct {
+	bucketName string
+	sourcePath string
+	targets    []checkTargetDescriptor
+}
+
+type checkConfigIndex struct {
+	sources        []checkSourceDescriptor
+	sourceByPath   map[string]checkSourceDescriptor
+	targetToSource map[string]checkTargetLookup
+}
+
+type checkTargetLookup struct {
+	sourcePath string
+	locale     string
+}
+
+type checkSourceScope struct {
+	keys    map[string]struct{}
+	locales map[string]struct{}
+}
+
+type checkSelection struct {
+	bySource   map[string]checkSourceScope
+	globalKeys map[string]struct{}
+	diffMode   bool
+}
+
+type diffChangedFile struct {
+	path string
+	keys map[string]struct{}
+}
+
 func defaultCheckOptions() checkOptions {
 	return checkOptions{format: "stylish"}
 }
@@ -147,6 +187,15 @@ func newCheckCmd() *cobra.Command {
 			)
 			if o.fix {
 				span.SetAttributes(attribute.Int("cli.workers", o.workers))
+			}
+			if o.diffStdin {
+				diffContent, err := io.ReadAll(cmd.InOrStdin())
+				if err != nil {
+					span.SetStatus(codes.Error, "read_diff_stdin")
+					return fmt.Errorf("read diff from stdin: %w", err)
+				}
+				o.diffContent = diffContent
+				span.SetAttributes(attribute.Bool("cli.check.diff_stdin", true))
 			}
 
 			report, err := runCheck(ctx, o)
@@ -233,6 +282,7 @@ func newCheckCmd() *cobra.Command {
 	cmd.Flags().StringVar(&o.bucket, "bucket", "", "filter by bucket name")
 	cmd.Flags().StringVar(&o.file, "file", "", "filter by source file path")
 	cmd.Flags().StringVar(&o.key, "key", "", "filter by translation key")
+	cmd.Flags().BoolVar(&o.diffStdin, "diff-stdin", false, "read a unified diff from stdin and validate changed keys only for supported key-value files")
 	cmd.Flags().StringSliceVar(&o.checks, "check", nil, "check(s) to run")
 	cmd.Flags().StringSliceVar(&o.excludeChecks, "exclude-check", nil, "default check(s) to skip")
 	cmd.Flags().StringVar(&o.format, "format", o.format, "output format: stylish (default), text, or json")
@@ -282,6 +332,9 @@ func summarySeverityCount(s checkSummary, sev string) int {
 
 func runCheck(ctx context.Context, o checkOptions) (checkReport, error) {
 	tr := otel.Tracer(cliotel.InstrumentationName)
+	if o.diffStdin && strings.TrimSpace(o.file) != "" {
+		return checkReport{}, fmt.Errorf("--diff-stdin cannot be combined with --file")
+	}
 
 	_, resolveSpan := tr.Start(ctx, "check.resolve")
 	cfg, err := config.Load(o.configPath)
@@ -320,8 +373,25 @@ func runCheck(ctx context.Context, o checkOptions) (checkReport, error) {
 	)
 	resolveSpan.End()
 
+	index, err := buildCheckConfigIndex(cfg, buckets, locales)
+	if err != nil {
+		return checkReport{}, err
+	}
+
+	selection, err := buildCheckSelection(index, o.file, o.key)
+	if err != nil {
+		return checkReport{}, err
+	}
+	if o.diffStdin {
+		selection, err = buildCheckSelectionFromDiff(index, o.diffContent, o.key)
+		if err != nil {
+			return checkReport{}, err
+		}
+		enabledChecks = restrictChecksForDiffMode(enabledChecks)
+	}
+
 	_, collectSpan := tr.Start(ctx, "check.collect_findings")
-	findings, err := collectCheckFindings(cfg, buckets, locales, enabledChecks, o.file, o.key)
+	findings, err := collectCheckFindings(index, enabledChecks, selection)
 	if err != nil {
 		collectSpan.SetStatus(codes.Error, "collect_findings")
 		collectSpan.End()
@@ -331,6 +401,157 @@ func runCheck(ctx context.Context, o checkOptions) (checkReport, error) {
 
 	sortCheckFindings(findings)
 	return checkReport{Checks: enabledChecks, Findings: findings, Summary: summarizeCheckFindings(findings)}, nil
+}
+
+func buildCheckConfigIndex(cfg *config.I18NConfig, buckets, locales []string) (*checkConfigIndex, error) {
+	index := &checkConfigIndex{
+		sourceByPath:   make(map[string]checkSourceDescriptor),
+		targetToSource: make(map[string]checkTargetLookup),
+	}
+
+	for _, bucketName := range buckets {
+		bucket := cfg.Buckets[bucketName]
+		for _, file := range bucket.Files {
+			sourcePattern := pathresolver.ResolveSourcePath(file.From, cfg.Locales.Source)
+			sourcePaths, err := resolveSourcePathsForStatus(sourcePattern)
+			if err != nil {
+				return nil, fmt.Errorf("resolve source paths for %q: %w", sourcePattern, err)
+			}
+			for _, sourcePath := range sourcePaths {
+				if shouldIgnoreSourcePathForStatus(sourcePath, cfg.Locales.Targets) {
+					continue
+				}
+
+				desc := checkSourceDescriptor{
+					bucketName: bucketName,
+					sourcePath: sourcePath,
+					targets:    make([]checkTargetDescriptor, 0, len(locales)),
+				}
+				for _, locale := range locales {
+					targetPattern := pathresolver.ResolveTargetPath(file.To, cfg.Locales.Source, locale)
+					targetPath, err := resolveTargetPathForStatus(sourcePattern, targetPattern, sourcePath)
+					if err != nil {
+						return nil, fmt.Errorf("resolve target path for source %q: %w", sourcePath, err)
+					}
+					desc.targets = append(desc.targets, checkTargetDescriptor{
+						locale:     locale,
+						targetPath: targetPath,
+					})
+					index.targetToSource[filepath.Clean(targetPath)] = checkTargetLookup{
+						sourcePath: sourcePath,
+						locale:     locale,
+					}
+				}
+				index.sources = append(index.sources, desc)
+				index.sourceByPath[filepath.Clean(sourcePath)] = desc
+			}
+		}
+	}
+
+	return index, nil
+}
+
+func buildCheckSelection(index *checkConfigIndex, sourceFileFilter, keyFilter string) (checkSelection, error) {
+	selection := checkSelection{}
+
+	trimmedKey := strings.TrimSpace(keyFilter)
+	if trimmedKey != "" {
+		selection.globalKeys = map[string]struct{}{trimmedKey: {}}
+	}
+
+	trimmedFile := strings.TrimSpace(sourceFileFilter)
+	if trimmedFile == "" {
+		return selection, nil
+	}
+	fileFilter, err := filepath.Abs(trimmedFile)
+	if err != nil {
+		return checkSelection{}, fmt.Errorf("resolve --file path %q: %w", trimmedFile, err)
+	}
+	fileFilter = filepath.Clean(fileFilter)
+	if _, ok := index.sourceByPath[fileFilter]; !ok {
+		selection.bySource = map[string]checkSourceScope{}
+		return selection, nil
+	}
+	selection.bySource = map[string]checkSourceScope{
+		fileFilter: {},
+	}
+	return selection, nil
+}
+
+func buildCheckSelectionFromDiff(index *checkConfigIndex, diffContent []byte, keyFilter string) (checkSelection, error) {
+	changedFiles, err := parseUnifiedDiffChangedFiles(diffContent)
+	if err != nil {
+		return checkSelection{}, err
+	}
+
+	selection := checkSelection{
+		bySource: make(map[string]checkSourceScope),
+		diffMode: true,
+	}
+	filterKey := strings.TrimSpace(keyFilter)
+
+	for _, changed := range changedFiles {
+		changedPath := filepath.Clean(changed.path)
+		if sourceDesc, ok := index.sourceByPath[changedPath]; ok {
+			scope := selection.bySource[filepath.Clean(sourceDesc.sourcePath)]
+			scope.keys = intersectChangedKeys(scope.keys, changed.keys, filterKey)
+			selection.bySource[filepath.Clean(sourceDesc.sourcePath)] = scope
+			continue
+		}
+		targetLookup, ok := index.targetToSource[changedPath]
+		if !ok {
+			continue
+		}
+		scope := selection.bySource[filepath.Clean(targetLookup.sourcePath)]
+		scope.keys = intersectChangedKeys(scope.keys, changed.keys, filterKey)
+		if scope.locales == nil {
+			scope.locales = make(map[string]struct{})
+		}
+		scope.locales[targetLookup.locale] = struct{}{}
+		selection.bySource[filepath.Clean(targetLookup.sourcePath)] = scope
+	}
+
+	for sourcePath, scope := range selection.bySource {
+		if len(scope.keys) == 0 {
+			delete(selection.bySource, sourcePath)
+		}
+	}
+
+	return selection, nil
+}
+
+func intersectChangedKeys(existing, changed map[string]struct{}, filterKey string) map[string]struct{} {
+	if len(changed) == 0 {
+		return existing
+	}
+	if existing == nil {
+		existing = make(map[string]struct{}, len(changed))
+	}
+	for key := range changed {
+		if filterKey != "" && key != filterKey {
+			continue
+		}
+		existing[key] = struct{}{}
+	}
+	return existing
+}
+
+func restrictChecksForDiffMode(enabledChecks []string) []string {
+	allowed := map[string]struct{}{
+		checkNotLocalized:   {},
+		checkSameAsSource:   {},
+		checkWhitespaceOnly: {},
+		checkPlaceholder:    {},
+		checkHTMLTag:        {},
+		checkICUShape:       {},
+	}
+	out := make([]string, 0, len(enabledChecks))
+	for _, check := range enabledChecks {
+		if _, ok := allowed[check]; ok {
+			out = append(out, check)
+		}
+	}
+	return out
 }
 
 func applyCheckQuiet(r checkReport, quiet bool) checkReport {
@@ -613,7 +834,7 @@ func resolveEnabledChecks(includes, excludes []string) ([]string, error) {
 	return enabled, nil
 }
 
-func collectCheckFindings(cfg *config.I18NConfig, buckets, locales, enabledChecks []string, sourceFileFilter, keyFilter string) ([]checkFinding, error) {
+func collectCheckFindings(index *checkConfigIndex, enabledChecks []string, selection checkSelection) ([]checkFinding, error) {
 	parser := translationfileparser.NewDefaultStrategy()
 	resolver := checkLocationResolver{content: make(map[string][]byte)}
 	checkSet := make(map[string]struct{}, len(enabledChecks))
@@ -621,77 +842,47 @@ func collectCheckFindings(cfg *config.I18NConfig, buckets, locales, enabledCheck
 		checkSet[check] = struct{}{}
 	}
 
-	keyFilter = strings.TrimSpace(keyFilter)
-	trimmedFileFilter := strings.TrimSpace(sourceFileFilter)
-	filterByFile := trimmedFileFilter != ""
-	fileFilter := ""
-	if filterByFile {
-		var err error
-		fileFilter, err = filepath.Abs(trimmedFileFilter)
-		if err != nil {
-			return nil, fmt.Errorf("resolve --file path %q: %w", trimmedFileFilter, err)
-		}
-	}
-
 	var findings []checkFinding
-	for _, bucketName := range buckets {
-		bucket := cfg.Buckets[bucketName]
-		for _, file := range bucket.Files {
-			sourcePattern := pathresolver.ResolveSourcePath(file.From, cfg.Locales.Source)
-			sourcePaths, err := resolveSourcePathsForStatus(sourcePattern)
-			if err != nil {
-				return nil, fmt.Errorf("resolve source paths for %q: %w", sourcePattern, err)
+	for _, sourceDesc := range index.sources {
+		if !selection.allowsSource(sourceDesc.sourcePath) {
+			continue
+		}
+		sourceEntries, err := readEntriesForStatus(parser, sourceDesc.sourcePath)
+		if err != nil {
+			return nil, err
+		}
+		for _, target := range sourceDesc.targets {
+			if !selection.allowsLocale(sourceDesc.sourcePath, target.locale) {
+				continue
 			}
-			for _, sourcePath := range sourcePaths {
-				if shouldIgnoreSourcePathForStatus(sourcePath, cfg.Locales.Targets) {
-					continue
-				}
-				if filterByFile {
-					absSourcePath, err := filepath.Abs(sourcePath)
-					if err != nil || absSourcePath != fileFilter {
-						continue
-					}
-				}
-				sourceEntries, err := readEntriesForStatus(parser, sourcePath)
-				if err != nil {
-					return nil, err
-				}
-				for _, locale := range locales {
-					targetPattern := pathresolver.ResolveTargetPath(file.To, cfg.Locales.Source, locale)
-					targetPath, err := resolveTargetPathForStatus(sourcePattern, targetPattern, sourcePath)
-					if err != nil {
-						return nil, fmt.Errorf("resolve target path for source %q: %w", sourcePath, err)
-					}
 
-					targetEntries, sourceContent, targetContent, targetExists, err := readCheckTargetEntries(parser, sourcePath, targetPath)
-					if err != nil {
-						return nil, err
-					}
-					if !targetExists {
-						if keyFilter == "" {
-							if _, ok := checkSet[checkMissingTargetFile]; ok {
-								annotationFile, annotationLine := resolver.resolve(sourcePath, targetPath, "", "", "", true)
-								findings = append(findings, checkFinding{
-									Type:           checkMissingTargetFile,
-									Severity:       severityForCheck(checkMissingTargetFile),
-									Bucket:         bucketName,
-									Locale:         locale,
-									SourceFile:     sourcePath,
-									TargetFile:     targetPath,
-									Message:        "target file does not exist",
-									AnnotationFile: annotationFile,
-									AnnotationLine: annotationLine,
-								})
-							}
-						}
-						continue
-					}
-
-					findings = append(findings, collectEntryCheckFindings(&resolver, bucketName, locale, sourcePath, targetPath, sourceEntries, targetEntries, checkSet, keyFilter)...)
-					if keyFilter == "" && hasCheck(checkSet, checkMarkdownAST) && isMarkdownPath(targetPath) {
-						findings = append(findings, collectMarkdownASTParityFindings(&resolver, bucketName, locale, sourcePath, targetPath, sourceContent, targetContent)...)
+			targetEntries, sourceContent, targetContent, targetExists, err := readCheckTargetEntries(parser, sourceDesc.sourcePath, target.targetPath)
+			if err != nil {
+				return nil, err
+			}
+			if !targetExists {
+				if selection.shouldRunFileScopedChecks() {
+					if _, ok := checkSet[checkMissingTargetFile]; ok {
+						annotationFile, annotationLine := resolver.resolve(sourceDesc.sourcePath, target.targetPath, "", "", "", true)
+						findings = append(findings, checkFinding{
+							Type:           checkMissingTargetFile,
+							Severity:       severityForCheck(checkMissingTargetFile),
+							Bucket:         sourceDesc.bucketName,
+							Locale:         target.locale,
+							SourceFile:     sourceDesc.sourcePath,
+							TargetFile:     target.targetPath,
+							Message:        "target file does not exist",
+							AnnotationFile: annotationFile,
+							AnnotationLine: annotationLine,
+						})
 					}
 				}
+				continue
+			}
+
+			findings = append(findings, collectEntryCheckFindings(&resolver, sourceDesc.bucketName, target.locale, sourceDesc.sourcePath, target.targetPath, sourceEntries, targetEntries, checkSet, selection)...)
+			if selection.shouldRunFileScopedChecks() && hasCheck(checkSet, checkMarkdownAST) && isMarkdownPath(target.targetPath) {
+				findings = append(findings, collectMarkdownASTParityFindings(&resolver, sourceDesc.bucketName, target.locale, sourceDesc.sourcePath, target.targetPath, sourceContent, targetContent)...)
 			}
 		}
 	}
@@ -727,7 +918,7 @@ func readCheckTargetEntries(parser *translationfileparser.Strategy, sourcePath, 
 	return targetEntries, nil, nil, true, nil
 }
 
-func collectEntryCheckFindings(resolver *checkLocationResolver, bucketName, locale, sourcePath, targetPath string, sourceEntries, targetEntries map[string]string, checkSet map[string]struct{}, keyFilter string) []checkFinding {
+func collectEntryCheckFindings(resolver *checkLocationResolver, bucketName, locale, sourcePath, targetPath string, sourceEntries, targetEntries map[string]string, checkSet map[string]struct{}, selection checkSelection) []checkFinding {
 	keys := make([]string, 0, len(sourceEntries))
 	for key := range sourceEntries {
 		keys = append(keys, key)
@@ -736,7 +927,7 @@ func collectEntryCheckFindings(resolver *checkLocationResolver, bucketName, loca
 
 	findings := make([]checkFinding, 0)
 	for _, key := range keys {
-		if keyFilter != "" && key != keyFilter {
+		if !selection.allowsKey(sourcePath, key) {
 			continue
 		}
 		sourceValue := sourceEntries[key]
@@ -864,7 +1055,7 @@ func collectEntryCheckFindings(resolver *checkLocationResolver, bucketName, loca
 		}
 		slices.Sort(orphanedKeys)
 		for _, key := range orphanedKeys {
-			if keyFilter != "" && key != keyFilter {
+			if !selection.allowsKey(sourcePath, key) {
 				continue
 			}
 			annotationFile, annotationLine := resolver.resolve(sourcePath, targetPath, key, "", targetEntries[key], false)
@@ -953,6 +1144,254 @@ func collectMarkdownASTParityFindings(resolver *checkLocationResolver, bucketNam
 	}
 
 	return findings
+}
+
+func (s checkSelection) allowsSource(sourcePath string) bool {
+	if len(s.bySource) == 0 {
+		return true
+	}
+	_, ok := s.bySource[filepath.Clean(sourcePath)]
+	return ok
+}
+
+func (s checkSelection) allowsLocale(sourcePath, locale string) bool {
+	if len(s.bySource) == 0 {
+		return true
+	}
+	scope, ok := s.bySource[filepath.Clean(sourcePath)]
+	if !ok {
+		return false
+	}
+	if len(scope.locales) == 0 {
+		return true
+	}
+	_, ok = scope.locales[locale]
+	return ok
+}
+
+func (s checkSelection) allowsKey(sourcePath, key string) bool {
+	if len(s.bySource) > 0 {
+		scope, ok := s.bySource[filepath.Clean(sourcePath)]
+		if !ok {
+			return false
+		}
+		if len(scope.keys) > 0 {
+			if _, ok := scope.keys[key]; !ok {
+				return false
+			}
+		} else if s.diffMode {
+			return false
+		}
+	}
+	if len(s.globalKeys) == 0 {
+		return true
+	}
+	_, ok := s.globalKeys[key]
+	return ok
+}
+
+func (s checkSelection) shouldRunFileScopedChecks() bool {
+	return !s.diffMode && len(s.globalKeys) == 0
+}
+
+func parseUnifiedDiffChangedFiles(content []byte) ([]diffChangedFile, error) {
+	diffText := strings.ReplaceAll(string(content), "\r\n", "\n")
+	if strings.TrimSpace(diffText) == "" {
+		return nil, fmt.Errorf("read diff from stdin: input is empty")
+	}
+
+	lines := strings.Split(diffText, "\n")
+	files := make(map[string]map[string]struct{})
+	var currentPath string
+	sawPatch := false
+	inHunk := false
+	var stack []string
+
+	for _, rawLine := range lines {
+		line := strings.TrimRight(rawLine, "\r")
+		switch {
+		case strings.HasPrefix(line, "diff --git "):
+			sawPatch = true
+			currentPath = ""
+			inHunk = false
+			stack = nil
+		case strings.HasPrefix(line, "+++ "):
+			sawPatch = true
+			path := parseDiffPath(strings.TrimSpace(strings.TrimPrefix(line, "+++ ")))
+			if path == "" {
+				currentPath = ""
+				inHunk = false
+				stack = nil
+				continue
+			}
+			currentPath = path
+			inHunk = false
+			stack = nil
+			if _, ok := files[currentPath]; !ok {
+				files[currentPath] = make(map[string]struct{})
+			}
+		case strings.HasPrefix(line, "@@ "):
+			if currentPath == "" {
+				continue
+			}
+			inHunk = true
+			stack = nil
+		default:
+			if !inHunk || currentPath == "" || line == "" {
+				continue
+			}
+			if line[0] != ' ' && line[0] != '+' && line[0] != '-' {
+				continue
+			}
+			if line[0] == ' ' {
+				stack = advanceDiffKeyStack(strings.TrimSpace(line[1:]), stack)
+				if _, nextStack, ok := parseDiffTranslationKeyLine(line, stack); ok {
+					stack = nextStack
+				}
+				continue
+			}
+			if key, nextStack, ok := parseDiffTranslationKeyLine(line, stack); ok {
+				stack = nextStack
+				if key != "" {
+					files[currentPath][key] = struct{}{}
+				}
+				continue
+			}
+			stack = advanceDiffKeyStack(strings.TrimSpace(line[1:]), stack)
+		}
+	}
+
+	if !sawPatch {
+		return nil, fmt.Errorf("read diff from stdin: malformed unified diff")
+	}
+
+	changedFiles := make([]diffChangedFile, 0, len(files))
+	for path, keys := range files {
+		if !isDiffKeyValueSupportedPath(path) {
+			continue
+		}
+		changedFiles = append(changedFiles, diffChangedFile{path: path, keys: keys})
+	}
+	slices.SortFunc(changedFiles, func(a, b diffChangedFile) int {
+		return strings.Compare(a.path, b.path)
+	})
+	return changedFiles, nil
+}
+
+func parseDiffPath(raw string) string {
+	if raw == "" || raw == "/dev/null" {
+		return ""
+	}
+	if idx := strings.IndexByte(raw, '\t'); idx >= 0 {
+		raw = raw[:idx]
+	}
+	raw = strings.TrimSpace(strings.Trim(raw, `"`))
+	switch {
+	case strings.HasPrefix(raw, "a/"), strings.HasPrefix(raw, "b/"):
+		return raw[2:]
+	default:
+		return raw
+	}
+}
+
+func isDiffKeyValueSupportedPath(path string) bool {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".json", ".jsonc", ".arb":
+		return true
+	default:
+		return false
+	}
+}
+
+func parseDiffTranslationKeyLine(line string, stack []string) (string, []string, bool) {
+	content := strings.TrimSpace(line[1:])
+	if content == "" || strings.HasPrefix(content, "//") || strings.HasPrefix(content, "/*") {
+		return "", stack, false
+	}
+	for len(content) > 0 && content[0] == '}' {
+		if len(stack) > 0 {
+			stack = stack[:len(stack)-1]
+		}
+		content = strings.TrimSpace(content[1:])
+	}
+	if !strings.HasPrefix(content, `"`) {
+		return "", stack, false
+	}
+	key, remainder, ok := parseJSONObjectKey(content)
+	if !ok {
+		return "", stack, false
+	}
+	if strings.HasPrefix(key, "@") {
+		if strings.HasPrefix(remainder, "{") {
+			nextStack := append(append([]string(nil), stack...), key)
+			return "", nextStack, true
+		}
+		return "", stack, false
+	}
+	for _, segment := range stack {
+		if strings.HasPrefix(segment, "@") {
+			if strings.HasPrefix(remainder, "{") {
+				nextStack := append(append([]string(nil), stack...), key)
+				return "", nextStack, true
+			}
+			return "", stack, false
+		}
+	}
+
+	fullKey := key
+	if len(stack) > 0 {
+		fullKey = strings.Join(append(append([]string(nil), stack...), key), ".")
+	}
+
+	if strings.HasPrefix(remainder, "{") {
+		nextStack := append(append([]string(nil), stack...), key)
+		return normalizeChangedDiffKey(fullKey), nextStack, true
+	}
+	return normalizeChangedDiffKey(fullKey), stack, true
+}
+
+func parseJSONObjectKey(content string) (string, string, bool) {
+	if !strings.HasPrefix(content, `"`) {
+		return "", "", false
+	}
+	escaped := false
+	for i := 1; i < len(content); i++ {
+		switch {
+		case escaped:
+			escaped = false
+		case content[i] == '\\':
+			escaped = true
+		case content[i] == '"':
+			rawKey := content[1:i]
+			var key string
+			if err := json.Unmarshal([]byte(`"`+rawKey+`"`), &key); err != nil {
+				return "", "", false
+			}
+			remainder := strings.TrimSpace(content[i+1:])
+			if !strings.HasPrefix(remainder, ":") {
+				return "", "", false
+			}
+			return key, strings.TrimSpace(remainder[1:]), true
+		}
+	}
+	return "", "", false
+}
+
+func advanceDiffKeyStack(content string, stack []string) []string {
+	for len(content) > 0 && content[0] == '}' {
+		if len(stack) > 0 {
+			stack = stack[:len(stack)-1]
+		}
+		content = strings.TrimSpace(content[1:])
+	}
+	return stack
+}
+
+func normalizeChangedDiffKey(key string) string {
+	if strings.HasSuffix(key, ".defaultMessage") {
+		return strings.TrimSuffix(key, ".defaultMessage")
+	}
+	return key
 }
 
 func hasCheck(checkSet map[string]struct{}, name string) bool {

--- a/apps/cli/cmd/check.go
+++ b/apps/cli/cmd/check.go
@@ -142,8 +142,9 @@ type checkTargetLookup struct {
 }
 
 type checkSourceScope struct {
-	keys    map[string]struct{}
-	locales map[string]struct{}
+	keys         map[string]struct{}
+	locales      map[string]struct{}
+	sourceInDiff bool
 }
 
 type checkSelection struct {
@@ -495,6 +496,8 @@ func buildCheckSelectionFromDiff(index *checkConfigIndex, diffContent []byte, ke
 		if sourceDesc, ok := index.sourceByPath[changedPath]; ok {
 			scope := selection.bySource[filepath.Clean(sourceDesc.sourcePath)]
 			scope.keys = intersectChangedKeys(scope.keys, changed.keys, filterKey)
+			scope.sourceInDiff = true
+			scope.locales = nil
 			selection.bySource[filepath.Clean(sourceDesc.sourcePath)] = scope
 			continue
 		}
@@ -504,10 +507,12 @@ func buildCheckSelectionFromDiff(index *checkConfigIndex, diffContent []byte, ke
 		}
 		scope := selection.bySource[filepath.Clean(targetLookup.sourcePath)]
 		scope.keys = intersectChangedKeys(scope.keys, changed.keys, filterKey)
-		if scope.locales == nil {
-			scope.locales = make(map[string]struct{})
+		if !scope.sourceInDiff {
+			if scope.locales == nil {
+				scope.locales = make(map[string]struct{})
+			}
+			scope.locales[targetLookup.locale] = struct{}{}
 		}
-		scope.locales[targetLookup.locale] = struct{}{}
 		selection.bySource[filepath.Clean(targetLookup.sourcePath)] = scope
 	}
 
@@ -1148,7 +1153,7 @@ func collectMarkdownASTParityFindings(resolver *checkLocationResolver, bucketNam
 
 func (s checkSelection) allowsSource(sourcePath string) bool {
 	if len(s.bySource) == 0 {
-		return true
+		return !s.diffMode
 	}
 	_, ok := s.bySource[filepath.Clean(sourcePath)]
 	return ok

--- a/apps/cli/cmd/check_test.go
+++ b/apps/cli/cmd/check_test.go
@@ -1188,11 +1188,58 @@ func TestCheckCommandDiffStdinScopesKeysPerFile(t *testing.T) {
 	}
 }
 
+func TestCheckCommandDiffStdinSourceAndTargetTogetherKeepAllLocales(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "i18n.jsonc")
+	sourcePath := filepath.Join(dir, "content", "en", "strings.json")
+	frTargetPath := filepath.Join(dir, "dist", "fr", "strings.json")
+	deTargetPath := filepath.Join(dir, "dist", "de", "strings.json")
+
+	for _, path := range []string{sourcePath, frTargetPath, deTargetPath} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("create dir for %s: %v", path, err)
+		}
+	}
+	if err := os.WriteFile(sourcePath, []byte("{\n  \"hello\": \"Hello\"\n}\n"), 0o600); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+	if err := os.WriteFile(frTargetPath, []byte("{\n  \"hello\": \"\"\n}\n"), 0o600); err != nil {
+		t.Fatalf("write fr target file: %v", err)
+	}
+	if err := os.WriteFile(deTargetPath, []byte("{\n  \"hello\": \"\"\n}\n"), 0o600); err != nil {
+		t.Fatalf("write de target file: %v", err)
+	}
+	writeCheckConfigWithMappings(t, configPath, []checkConfigMapping{{source: sourcePath, target: filepath.Join(dir, "dist", "[locale]", "strings.json")}}, []string{"fr", "de"})
+
+	diff := unifiedDiffForPath(sourcePath, `@@ -1,3 +1,3 @@
+ {
+-  "hello": "Hi"
++  "hello": "Hello"
+ }
+`) + "\n" + unifiedDiffForPath(frTargetPath, `@@ -1,3 +1,3 @@
+ {
+-  "hello": "Bonjour"
++  "hello": ""
+ }
+`)
+
+	report := executeCheckJSON(t, configPath, diff, "--diff-stdin", "--no-fail")
+	if len(report.Findings) != 2 {
+		t.Fatalf("expected both locales to remain in scope, got %+v", report.Findings)
+	}
+	locales := []string{report.Findings[0].Locale, report.Findings[1].Locale}
+	slices.Sort(locales)
+	if !reflect.DeepEqual(locales, []string{"de", "fr"}) {
+		t.Fatalf("unexpected locales after mixed source/target diff: %+v", locales)
+	}
+}
+
 func TestCheckCommandDiffStdinIgnoresUnsupportedFileTypes(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "i18n.jsonc")
-	sourcePath := filepath.Join(dir, "content", "en", "doc.md")
-	targetPath := filepath.Join(dir, "dist", "fr", "doc.md")
+	sourcePath := filepath.Join(dir, "content", "en", "strings.json")
+	targetPath := filepath.Join(dir, "dist", "fr", "strings.json")
+	unsupportedPath := filepath.Join(dir, "src", "feature.ts")
 
 	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
 		t.Fatalf("create source dir: %v", err)
@@ -1200,17 +1247,20 @@ func TestCheckCommandDiffStdinIgnoresUnsupportedFileTypes(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
 		t.Fatalf("create target dir: %v", err)
 	}
-	if err := os.WriteFile(sourcePath, []byte("# Hello\n"), 0o600); err != nil {
+	if err := os.MkdirAll(filepath.Dir(unsupportedPath), 0o755); err != nil {
+		t.Fatalf("create unsupported dir: %v", err)
+	}
+	if err := os.WriteFile(sourcePath, []byte("{\n  \"hello\": \"Hello\"\n}\n"), 0o600); err != nil {
 		t.Fatalf("write source file: %v", err)
 	}
-	if err := os.WriteFile(targetPath, []byte("# Bonjour\n"), 0o600); err != nil {
+	if err := os.WriteFile(targetPath, []byte("{\n  \"hello\": \"\"\n}\n"), 0o600); err != nil {
 		t.Fatalf("write target file: %v", err)
 	}
 	writeCheckConfig(t, configPath, sourcePath, targetPath, []string{"fr"})
 
-	report := executeCheckJSON(t, configPath, unifiedDiffForPath(sourcePath, `@@ -1 +1 @@
--# Hi
-+# Hello
+	report := executeCheckJSON(t, configPath, unifiedDiffForPath(unsupportedPath, `@@ -1 +1 @@
+-const enabled = false;
++const enabled = true;
 `), "--diff-stdin", "--no-fail")
 	if report.Summary.Total != 0 {
 		t.Fatalf("expected unsupported diff path to be ignored, got %+v", report)

--- a/apps/cli/cmd/check_test.go
+++ b/apps/cli/cmd/check_test.go
@@ -146,7 +146,7 @@ func TestCollectEntryCheckFindingsSkipsRedundantChecksForWhitespaceOnlyNotLocali
 			checkWhitespaceOnly: {},
 			checkHTMLTag:        {},
 		},
-		"",
+		checkSelection{},
 	)
 
 	if len(findings) != 1 {
@@ -1054,6 +1054,313 @@ func TestWriteCheckTextAndSummaryMapErrors(t *testing.T) {
 	}
 }
 
+func TestCheckCommandDiffStdinScopesChangedSourceKeyOnly(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "i18n.jsonc")
+	sourcePath := filepath.Join(dir, "content", "en", "strings.json")
+	targetPath := filepath.Join(dir, "dist", "fr", "strings.json")
+
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
+		t.Fatalf("create source dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		t.Fatalf("create target dir: %v", err)
+	}
+	if err := os.WriteFile(sourcePath, []byte("{\n  \"hello\": \"Hello {name}\",\n  \"html\": \"<strong>Hello</strong>\"\n}\n"), 0o600); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+	if err := os.WriteFile(targetPath, []byte("{\n  \"hello\": \"\",\n  \"html\": \"<em>Bonjour</em>\"\n}\n"), 0o600); err != nil {
+		t.Fatalf("write target file: %v", err)
+	}
+	writeCheckConfig(t, configPath, sourcePath, targetPath, []string{"fr"})
+
+	report := executeCheckJSON(t, configPath, unifiedDiffForPath(sourcePath, `@@ -1,4 +1,4 @@
+ {
+-  "hello": "Hi {name}",
++  "hello": "Hello {name}",
+   "html": "<strong>Hello</strong>"
+ }
+`), "--diff-stdin", "--no-fail")
+
+	if len(report.Findings) != 2 {
+		t.Fatalf("expected 2 diff-scoped findings for the changed key, got %+v", report.Findings)
+	}
+	for _, finding := range report.Findings {
+		if finding.Key != "hello" {
+			t.Fatalf("expected only changed key findings, got %+v", report.Findings)
+		}
+		if finding.Type == checkHTMLTag {
+			t.Fatalf("expected unchanged html key to stay out of scope, got %+v", report.Findings)
+		}
+	}
+}
+
+func TestCheckCommandDiffStdinTargetFileMapsBackToSourceKey(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "i18n.jsonc")
+	sourcePath := filepath.Join(dir, "content", "en", "strings.json")
+	targetPath := filepath.Join(dir, "dist", "fr", "strings.json")
+
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
+		t.Fatalf("create source dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		t.Fatalf("create target dir: %v", err)
+	}
+	if err := os.WriteFile(sourcePath, []byte("{\n  \"hello\": \"Hello\",\n  \"bye\": \"Bye\"\n}\n"), 0o600); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+	if err := os.WriteFile(targetPath, []byte("{\n  \"hello\": \"\",\n  \"bye\": \"Au revoir\"\n}\n"), 0o600); err != nil {
+		t.Fatalf("write target file: %v", err)
+	}
+	writeCheckConfig(t, configPath, sourcePath, targetPath, []string{"fr"})
+
+	report := executeCheckJSON(t, configPath, unifiedDiffForPath(targetPath, `@@ -1,4 +1,4 @@
+ {
+-  "hello": "Bonjour",
++  "hello": "",
+   "bye": "Au revoir"
+ }
+`), "--diff-stdin", "--no-fail")
+
+	if len(report.Findings) != 1 {
+		t.Fatalf("expected 1 finding, got %+v", report.Findings)
+	}
+	finding := report.Findings[0]
+	if finding.SourceFile != sourcePath || finding.TargetFile != targetPath || finding.Key != "hello" {
+		t.Fatalf("unexpected source/target mapping: %+v", finding)
+	}
+}
+
+func TestCheckCommandDiffStdinScopesKeysPerFile(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "i18n.jsonc")
+	sourceOne := filepath.Join(dir, "content", "en", "one.json")
+	targetOne := filepath.Join(dir, "dist", "fr", "one.json")
+	sourceTwo := filepath.Join(dir, "content", "en", "two.json")
+	targetTwo := filepath.Join(dir, "dist", "fr", "two.json")
+
+	for _, path := range []string{sourceOne, targetOne, sourceTwo, targetTwo} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("create dir for %s: %v", path, err)
+		}
+	}
+	if err := os.WriteFile(sourceOne, []byte("{\n  \"hello\": \"Hello\",\n  \"unused\": \"Still ok\"\n}\n"), 0o600); err != nil {
+		t.Fatalf("write source one: %v", err)
+	}
+	if err := os.WriteFile(targetOne, []byte("{\n  \"hello\": \"\",\n  \"unused\": \"\"\n}\n"), 0o600); err != nil {
+		t.Fatalf("write target one: %v", err)
+	}
+	if err := os.WriteFile(sourceTwo, []byte("{\n  \"bye\": \"Bye\",\n  \"unused\": \"Still ok\"\n}\n"), 0o600); err != nil {
+		t.Fatalf("write source two: %v", err)
+	}
+	if err := os.WriteFile(targetTwo, []byte("{\n  \"bye\": \"\",\n  \"unused\": \"\"\n}\n"), 0o600); err != nil {
+		t.Fatalf("write target two: %v", err)
+	}
+	writeCheckConfigWithMappings(t, configPath, []checkConfigMapping{
+		{source: sourceOne, target: targetOne},
+		{source: sourceTwo, target: targetTwo},
+	}, []string{"fr"})
+
+	diff := unifiedDiffForPath(sourceOne, `@@ -1,4 +1,4 @@
+ {
+-  "hello": "Hi",
++  "hello": "Hello",
+   "unused": "Still ok"
+ }
+`) + "\n" + unifiedDiffForPath(sourceTwo, `@@ -1 +1 @@
+@@ -1,4 +1,4 @@
+ {
+-  "bye": "Ciao",
++  "bye": "Bye",
+   "unused": "Still ok"
+ }
+`)
+
+	report := executeCheckJSON(t, configPath, diff, "--diff-stdin", "--no-fail")
+	if len(report.Findings) != 2 {
+		t.Fatalf("expected 2 scoped findings, got %+v", report.Findings)
+	}
+	got := []string{report.Findings[0].Key, report.Findings[1].Key}
+	slices.Sort(got)
+	if !reflect.DeepEqual(got, []string{"bye", "hello"}) {
+		t.Fatalf("unexpected scoped keys: %+v", got)
+	}
+}
+
+func TestCheckCommandDiffStdinIgnoresUnsupportedFileTypes(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "i18n.jsonc")
+	sourcePath := filepath.Join(dir, "content", "en", "doc.md")
+	targetPath := filepath.Join(dir, "dist", "fr", "doc.md")
+
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
+		t.Fatalf("create source dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		t.Fatalf("create target dir: %v", err)
+	}
+	if err := os.WriteFile(sourcePath, []byte("# Hello\n"), 0o600); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+	if err := os.WriteFile(targetPath, []byte("# Bonjour\n"), 0o600); err != nil {
+		t.Fatalf("write target file: %v", err)
+	}
+	writeCheckConfig(t, configPath, sourcePath, targetPath, []string{"fr"})
+
+	report := executeCheckJSON(t, configPath, unifiedDiffForPath(sourcePath, `@@ -1 +1 @@
+-# Hi
++# Hello
+`), "--diff-stdin", "--no-fail")
+	if report.Summary.Total != 0 {
+		t.Fatalf("expected unsupported diff path to be ignored, got %+v", report)
+	}
+}
+
+func TestCheckCommandDiffStdinSkipsNonDiffChecks(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "i18n.jsonc")
+	sourcePath := filepath.Join(dir, "content", "en", "strings.json")
+	targetPath := filepath.Join(dir, "dist", "fr", "strings.json")
+
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
+		t.Fatalf("create source dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		t.Fatalf("create target dir: %v", err)
+	}
+	if err := os.WriteFile(sourcePath, []byte(`{"hello":"Hello"}`), 0o600); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+	if err := os.WriteFile(targetPath, []byte(`{"hello":"Bonjour","extra":"orphan"}`), 0o600); err != nil {
+		t.Fatalf("write target file: %v", err)
+	}
+	writeCheckConfig(t, configPath, sourcePath, targetPath, []string{"fr"})
+
+	report := executeCheckJSON(t, configPath, unifiedDiffForPath(targetPath, `@@ -1 +1 @@
+-{"hello":"Bonjour","extra":"orphan-old"}
++{"hello":"Bonjour","extra":"orphan"}
+`), "--diff-stdin", "--no-fail", "--check", checkOrphanedKey, "--check", checkMissingTargetFile, "--check", checkMarkdownAST, "--check", checkNotLocalized)
+
+	if report.Summary.Total != 0 {
+		t.Fatalf("expected skipped non-diff checks to emit no findings, got %+v", report)
+	}
+	for _, finding := range report.Findings {
+		switch finding.Type {
+		case checkMissingTargetFile, checkOrphanedKey, checkMarkdownAST:
+			t.Fatalf("unexpected skipped diff-mode finding: %+v", finding)
+		}
+	}
+}
+
+func TestCheckCommandDiffStdinRejectsEmptyAndMalformedInput(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "i18n.jsonc")
+	sourcePath := filepath.Join(dir, "content", "en", "strings.json")
+	targetPath := filepath.Join(dir, "dist", "fr", "strings.json")
+
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
+		t.Fatalf("create source dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		t.Fatalf("create target dir: %v", err)
+	}
+	if err := os.WriteFile(sourcePath, []byte(`{"hello":"Hello"}`), 0o600); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+	if err := os.WriteFile(targetPath, []byte(`{"hello":"Bonjour"}`), 0o600); err != nil {
+		t.Fatalf("write target file: %v", err)
+	}
+	writeCheckConfig(t, configPath, sourcePath, targetPath, []string{"fr"})
+
+	cmd := newRootCmd("")
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetIn(strings.NewReader(""))
+	cmd.SetArgs([]string{"check", "--config", configPath, "--diff-stdin", "--no-fail"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "input is empty") {
+		t.Fatalf("expected empty diff error, got %v", err)
+	}
+
+	cmd = newRootCmd("")
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetIn(strings.NewReader("not a unified diff"))
+	cmd.SetArgs([]string{"check", "--config", configPath, "--diff-stdin", "--no-fail"})
+	err = cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "malformed unified diff") {
+		t.Fatalf("expected malformed diff error, got %v", err)
+	}
+}
+
+func TestCheckCommandDiffStdinRejectsFileFlag(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "i18n.jsonc")
+	sourcePath := filepath.Join(dir, "content", "en", "strings.json")
+	targetPath := filepath.Join(dir, "dist", "fr", "strings.json")
+
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
+		t.Fatalf("create source dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		t.Fatalf("create target dir: %v", err)
+	}
+	if err := os.WriteFile(sourcePath, []byte(`{"hello":"Hello"}`), 0o600); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+	if err := os.WriteFile(targetPath, []byte(`{"hello":"Bonjour"}`), 0o600); err != nil {
+		t.Fatalf("write target file: %v", err)
+	}
+	writeCheckConfig(t, configPath, sourcePath, targetPath, []string{"fr"})
+
+	cmd := newRootCmd("")
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetIn(strings.NewReader(unifiedDiffForPath(sourcePath, `@@ -1 +1 @@
+-{"hello":"Hi"}
++{"hello":"Hello"}
+`)))
+	cmd.SetArgs([]string{"check", "--config", configPath, "--diff-stdin", "--file", sourcePath, "--no-fail"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "cannot be combined with --file") {
+		t.Fatalf("expected --diff-stdin/--file rejection, got %v", err)
+	}
+}
+
+func TestCheckCommandDiffStdinIntersectsWithKeyFlag(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "i18n.jsonc")
+	sourcePath := filepath.Join(dir, "content", "en", "strings.json")
+	targetPath := filepath.Join(dir, "dist", "fr", "strings.json")
+
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
+		t.Fatalf("create source dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		t.Fatalf("create target dir: %v", err)
+	}
+	if err := os.WriteFile(sourcePath, []byte("{\n  \"hello\": \"Hello\",\n  \"bye\": \"Bye\"\n}\n"), 0o600); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+	if err := os.WriteFile(targetPath, []byte("{\n  \"hello\": \"\",\n  \"bye\": \"\"\n}\n"), 0o600); err != nil {
+		t.Fatalf("write target file: %v", err)
+	}
+	writeCheckConfig(t, configPath, sourcePath, targetPath, []string{"fr"})
+
+	report := executeCheckJSON(t, configPath, unifiedDiffForPath(sourcePath, `@@ -1,4 +1,4 @@
+ {
+   "hello": "Hello",
+-  "bye": "Goodbye"
++  "bye": "Bye"
+ }
+`), "--diff-stdin", "--no-fail", "--key", "bye")
+
+	if len(report.Findings) != 1 || report.Findings[0].Key != "bye" {
+		t.Fatalf("expected key intersection to keep only bye, got %+v", report.Findings)
+	}
+}
+
 type failingWriter struct{}
 
 func (failingWriter) Write([]byte) (int, error) {
@@ -1061,20 +1368,57 @@ func (failingWriter) Write([]byte) (int, error) {
 }
 
 func writeCheckConfig(t *testing.T, configPath, sourcePath, targetPath string, locales []string) {
+	writeCheckConfigWithMappings(t, configPath, []checkConfigMapping{{source: sourcePath, target: targetPath}}, locales)
+}
+
+type checkConfigMapping struct {
+	source string
+	target string
+}
+
+func writeCheckConfigWithMappings(t *testing.T, configPath string, mappings []checkConfigMapping, locales []string) {
 	t.Helper()
 	quotedLocales := make([]string, 0, len(locales))
 	for _, locale := range locales {
 		quotedLocales = append(quotedLocales, `"`+locale+`"`)
 	}
+	fileMappings := make([]string, 0, len(mappings))
+	for _, mapping := range mappings {
+		fileMappings = append(fileMappings, `{"from":"`+filepath.ToSlash(mapping.source)+`","to":"`+filepath.ToSlash(mapping.target)+`"}`)
+	}
 	content := `{
 	  "locales": {"source":"en","targets":[` + strings.Join(quotedLocales, ",") + `]},
-	  "buckets": {"ui":{"files":[{"from":"` + filepath.ToSlash(sourcePath) + `","to":"` + filepath.ToSlash(targetPath) + `"}]}},
+	  "buckets": {"ui":{"files":[` + strings.Join(fileMappings, ",") + `]}},
 	  "groups": {"default":{"targets":[` + strings.Join(quotedLocales, ",") + `],"buckets":["ui"]}},
 	  "llm": {"profiles":{"default":{"provider":"openai","model":"gpt-4.1-mini","prompt":"Translate {{input}}"}}}
 	}`
 	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
+}
+
+func executeCheckJSON(t *testing.T, configPath, diff string, extraArgs ...string) checkReport {
+	t.Helper()
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetIn(strings.NewReader(diff))
+	args := append([]string{"check", "--config", configPath, "--format", "json"}, extraArgs...)
+	cmd.SetArgs(args)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute check command: %v", err)
+	}
+	var report checkReport
+	if err := json.Unmarshal(out.Bytes(), &report); err != nil {
+		t.Fatalf("parse json output: %v\noutput=%s", err, out.String())
+	}
+	return report
+}
+
+func unifiedDiffForPath(path, hunk string) string {
+	slashPath := filepath.ToSlash(path)
+	return "diff --git a/" + slashPath + " b/" + slashPath + "\n--- a/" + slashPath + "\n+++ b/" + slashPath + "\n" + strings.TrimSuffix(hunk, "\n") + "\n"
 }
 
 func assertFindingType(t *testing.T, findings []checkFinding, want string) {

--- a/docs/adr/2026-04-17-check-diff-stdin-design.md
+++ b/docs/adr/2026-04-17-check-diff-stdin-design.md
@@ -1,0 +1,89 @@
+# Diff-scoped check mode for changed keys
+
+## Summary
+
+Add `hyperlocalise check --diff-stdin` to read a unified git patch from stdin, extract changed translation keys for configured key-value files, and run key-scoped validation only for those keys.
+
+Supported diff-scoped file types in this change:
+
+- `.json`
+- `.jsonc`
+- `.arb`
+
+Excluded from this change:
+
+- `.yaml`
+- `.yml`
+- non-entry-based formats such as markdown, HTML, CSV, XLIFF, PO, and Apple strings variants
+
+## Goals
+
+- Keep normal `check` behavior unchanged
+- Support source-file and target-file patches
+- Scope findings by source file, target locale, and changed key
+- Allow `--key` to further intersect the diff-derived key set
+- Skip checks that do not make sense without a full-file scan
+
+## Design
+
+### Selection model
+
+Replace the single `keyFilter` string with a selection model that can express:
+
+- unrestricted scans
+- a global `--key` filter
+- per-source-file changed-key sets from diff input
+- locale restrictions when the patch touches a target file only
+
+This keeps the collection layer shared while making diff mode an explicit scope constraint.
+
+### Config-backed file index
+
+Build a resolved config index before collecting findings:
+
+- each concrete source file maps to its bucket and resolved target files
+- each concrete target file maps back to its source file and locale
+
+This lets diff parsing stay path-based while the collector still uses the normal config-expanded translation graph.
+
+### Diff parsing
+
+Parse a standard unified git patch from stdin.
+
+- accept configured `.json`, `.jsonc`, and `.arb` files only
+- ignore unsupported file types in the patch
+- extract changed keys from added and removed object-key lines in hunks
+- treat configured files with no identifiable changed keys as no-op scope entries instead of widening to full-file validation
+
+The extraction is intentionally line-based. It follows object nesting well enough for supported key-value files without trying to fully reconstruct arbitrary document edits.
+
+### Diff-mode checks
+
+Keep only key-scoped checks in diff mode:
+
+- `not_localized`
+- `same_as_source`
+- `whitespace_only`
+- `placeholder_mismatch`
+- `html_tag_mismatch`
+- `icu_shape_mismatch`
+
+Skip these checks in diff mode:
+
+- `missing_target_file`
+- `orphaned_key`
+- `markdown_ast_mismatch`
+
+## Testing
+
+Add command-level coverage for:
+
+- source-file diff scoping
+- target-file diff mapping back to source
+- per-file key isolation across multi-file patches
+- unsupported file types in diff input
+- skipped checks in diff mode
+- empty and malformed stdin diffs
+- `--diff-stdin` with `--file`
+- `--diff-stdin` with `--key`
+- unchanged normal `check` behavior through existing tests

--- a/docs/commands/check.mdx
+++ b/docs/commands/check.mdx
@@ -13,6 +13,8 @@ hyperlocalise check [--config <path>] [flags]
 
 Each check has a **severity** (`error` or `warning`) in the report JSON and in **stylish** output. Exit code `1` applies when any finding exists unless you pass `--no-fail`. With **`--quiet`**, only **error** findings count toward the exit code and printed/JSON output; warning-only runs exit `0`.
 
+With **`--diff-stdin`**, `check` reads a unified git patch from stdin and validates **changed keys only** for supported key-value translation files: **`.json`**, **`.jsonc`**, and **`.arb`**. In this mode, the CLI ignores unsupported file types in the patch, treats configured files with no identifiable changed keys as a no-op, and skips file-level or document-level checks that do not fit key-scoped diff validation.
+
 ### Error
 
 - `not_localized`: target key is missing or the target value is empty (after trimming)
@@ -36,6 +38,9 @@ Selecting `--check icu_shape_mismatch` runs ICU checks only; it does not include
 - `--locale`: target locale filter (repeatable)
 - `--group`: filter by group name
 - `--bucket`: filter by bucket name
+- `--file`: filter by source file path. Not supported with **`--diff-stdin`**
+- `--key`: filter by translation key. With **`--diff-stdin`**, this becomes an extra intersection filter on top of the changed keys extracted from the patch
+- `--diff-stdin`: read a unified diff from stdin and validate changed keys only. Supports configured **`.json`**, **`.jsonc`**, and **`.arb`** files. Runs only key-scoped checks: `not_localized`, `same_as_source`, `whitespace_only`, `placeholder_mismatch`, `html_tag_mismatch`, and `icu_shape_mismatch`. Skips `missing_target_file`, `orphaned_key`, and `markdown_ast_mismatch`
 - `--check`: run only specific checks (repeatable)
 - `--exclude-check`: skip specific default checks (repeatable)
 - `--format`: output format (`stylish` default, `text`, or `json`). **Stylish** prints ESLint-style diagnostics grouped by file; when stdout is a terminal, severities use color (no color when piped or in typical CI logs).
@@ -75,6 +80,10 @@ hyperlocalise check --fix --locale fr --bucket ui
 
 ```bash
 hyperlocalise check --fix --fix-dry-run --no-fail
+```
+
+```bash
+git diff --cached | hyperlocalise check --diff-stdin --no-fail
 ```
 
 ## See also


### PR DESCRIPTION
## What changed

Add `hyperlocalise check --diff-stdin` to scope validation to changed translation keys from a unified diff on stdin.

This change:
- reads unified git patch input from `stdin`
- supports configured key-value translation files only: `.json`, `.jsonc`, and `.arb`
- maps changed target-file paths back to their source file and locale
- intersects diff-derived keys with `--key` when both are provided
- skips non-key-scoped checks in diff mode instead of widening to a full scan
- updates English docs and README to describe the new mode and its limits

## How to test

- Run `make fmt`
- Run `make lint`
- Run `make test`
- Optionally verify the new flow manually with:
  `git diff --cached | hyperlocalise check --diff-stdin --no-fail`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
