### PR TITLE
docs(commands): add missing check command docs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -53,6 +53,7 @@
               "commands/init",
               "commands/crowdin",
               "commands/run",
+              "commands/check",
               "commands/eval",
               "commands/status",
               "commands/sync-pull",

--- a/docs/getting-started/install.mdx
+++ b/docs/getting-started/install.mdx
@@ -46,7 +46,7 @@ hyperlocalise version
 hyperlocalise --help
 ```
 
-Expected output includes the available commands: `init`, `run`, `status`, `sync`, `version`, and `update`.
+Expected output includes commands such as `init`, `crowdin`, `run`, `check`, `eval`, `status`, `sync pull`, `sync push`, `version`, and `update`.
 
 ## Install the Hyperlocalise skill (skills.sh)
 


### PR DESCRIPTION
### Motivation
- Ensure the CLI documentation and navigation include the `check` command and that the install verification text matches the current CLI command families.

### Description
- Add `commands/check` to the English Commands navigation in `docs/docs.json` and update the install verification text in `docs/getting-started/install.mdx` to list `check` and align the expected command list.

### Testing
- Attempted `make fmt`, `make lint`, and `make test`, but all failed in this environment due to toolchain download being blocked from `proxy.golang.org` and `/bin/golangci-lint` being unavailable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e30c4c0ac4832c875d30e7d0c1a81a)