### PR TITLE
feat(web): add zero-org onboarding and encrypted org provider setup

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -40,8 +40,6 @@ jobs:
     env:
       CI: "true"
       DATABASE_URL: postgres://hyperlocalise:hyperlocalise@127.0.0.1:5432/hyperlocalise?sslmode=disable
-      INNGEST_EVENT_KEY: fake-inngest-event-key
-      INNGEST_SIGNING_KEY: fake-inngest-signing-key
     defaults:
       run:
         working-directory: apps/hyperlocalise-web

--- a/apps/hyperlocalise-web/drizzle/0002_flashy_ravenous.sql
+++ b/apps/hyperlocalise-web/drizzle/0002_flashy_ravenous.sql
@@ -1,0 +1,24 @@
+CREATE TYPE "public"."llm_provider" AS ENUM('openai', 'anthropic', 'gemini', 'groq', 'mistral');--> statement-breakpoint
+CREATE TABLE "organization_llm_provider_credentials" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"organization_id" uuid NOT NULL,
+	"created_by_user_id" uuid,
+	"updated_by_user_id" uuid,
+	"provider" "llm_provider" NOT NULL,
+	"default_model" text NOT NULL,
+	"masked_api_key_suffix" text NOT NULL,
+	"encryption_algorithm" text NOT NULL,
+	"ciphertext" text NOT NULL,
+	"iv" text NOT NULL,
+	"auth_tag" text NOT NULL,
+	"key_version" integer DEFAULT 1 NOT NULL,
+	"last_validated_at" timestamp with time zone NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "organization_llm_provider_credentials" ADD CONSTRAINT "organization_llm_provider_credentials_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "organization_llm_provider_credentials" ADD CONSTRAINT "organization_llm_provider_credentials_created_by_user_id_users_id_fk" FOREIGN KEY ("created_by_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "organization_llm_provider_credentials" ADD CONSTRAINT "organization_llm_provider_credentials_updated_by_user_id_users_id_fk" FOREIGN KEY ("updated_by_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "organization_llm_provider_credentials_org_key" ON "organization_llm_provider_credentials" USING btree ("organization_id");--> statement-breakpoint
+CREATE INDEX "idx_organization_llm_provider_credentials_updated_at" ON "organization_llm_provider_credentials" USING btree ("updated_at");

--- a/apps/hyperlocalise-web/drizzle/meta/0002_snapshot.json
+++ b/apps/hyperlocalise-web/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,1995 @@
+{
+  "id": "cebd9c25-56d4-4fa6-aa1a-05bc09b1289a",
+  "prevId": "02f205dd-be59-4e0b-a01a-92f20711750f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.organization_llm_provider_credentials": {
+      "name": "organization_llm_provider_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "llm_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_model": {
+          "name": "default_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "masked_api_key_suffix": {
+          "name": "masked_api_key_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encryption_algorithm": {
+          "name": "encryption_algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "last_validated_at": {
+          "name": "last_validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_llm_provider_credentials_org_key": {
+          "name": "organization_llm_provider_credentials_org_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organization_llm_provider_credentials_updated_at": {
+          "name": "idx_organization_llm_provider_credentials_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_llm_provider_credentials_organization_id_organizations_id_fk": {
+          "name": "organization_llm_provider_credentials_organization_id_organizations_id_fk",
+          "tableFrom": "organization_llm_provider_credentials",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_llm_provider_credentials_created_by_user_id_users_id_fk": {
+          "name": "organization_llm_provider_credentials_created_by_user_id_users_id_fk",
+          "tableFrom": "organization_llm_provider_credentials",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "organization_llm_provider_credentials_updated_by_user_id_users_id_fk": {
+          "name": "organization_llm_provider_credentials_updated_by_user_id_users_id_fk",
+          "tableFrom": "organization_llm_provider_credentials",
+          "tableTo": "users",
+          "columnsFrom": ["updated_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_memberships": {
+      "name": "organization_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workos_membership_id": {
+          "name": "workos_membership_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "organization_membership_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_memberships_org_user_key": {
+          "name": "organization_memberships_org_user_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_memberships_workos_membership_id_key": {
+          "name": "organization_memberships_workos_membership_id_key",
+          "columns": [
+            {
+              "expression": "workos_membership_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organization_memberships_user_id": {
+          "name": "idx_organization_memberships_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_memberships_organization_id_organizations_id_fk": {
+          "name": "organization_memberships_organization_id_organizations_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_memberships_user_id_users_id_fk": {
+          "name": "organization_memberships_user_id_users_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workos_organization_id": {
+          "name": "workos_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organizations_workos_organization_id_key": {
+          "name": "organizations_workos_organization_id_key",
+          "columns": [
+            {
+              "expression": "workos_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organizations_slug_key": {
+          "name": "organizations_slug_key",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organizations_created_at": {
+          "name": "idx_organizations_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_memberships": {
+      "name": "team_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "team_membership_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_memberships_team_user_key": {
+          "name": "team_memberships_team_user_key",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_team_memberships_user_id": {
+          "name": "idx_team_memberships_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_memberships_team_id_teams_id_fk": {
+          "name": "team_memberships_team_id_teams_id_fk",
+          "tableFrom": "team_memberships",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_memberships_user_id_users_id_fk": {
+          "name": "team_memberships_user_id_users_id_fk",
+          "tableFrom": "team_memberships",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "teams_org_slug_key": {
+          "name": "teams_org_slug_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_teams_org_created_at": {
+          "name": "idx_teams_org_created_at",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "teams_organization_id_organizations_id_fk": {
+          "name": "teams_organization_id_organizations_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.translation_glossaries": {
+      "name": "translation_glossaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "source_locale": {
+          "name": "source_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_locale": {
+          "name": "target_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "translation_asset_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_translation_glossaries_org_created_at": {
+          "name": "idx_translation_glossaries_org_created_at",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_translation_glossaries_org_locale_pair": {
+          "name": "idx_translation_glossaries_org_locale_pair",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_translation_glossaries_created_by_user_id": {
+          "name": "idx_translation_glossaries_created_by_user_id",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "translation_glossaries_organization_id_organizations_id_fk": {
+          "name": "translation_glossaries_organization_id_organizations_id_fk",
+          "tableFrom": "translation_glossaries",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "translation_glossaries_created_by_user_id_users_id_fk": {
+          "name": "translation_glossaries_created_by_user_id_users_id_fk",
+          "tableFrom": "translation_glossaries",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.translation_glossary_terms": {
+      "name": "translation_glossary_terms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "glossary_id": {
+          "name": "glossary_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_term": {
+          "name": "source_term",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_term": {
+          "name": "target_term",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "part_of_speech": {
+          "name": "part_of_speech",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "case_sensitive": {
+          "name": "case_sensitive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "forbidden": {
+          "name": "forbidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "\n      setweight(to_tsvector('simple', coalesce(source_term, '')), 'A') ||\n      setweight(to_tsvector('simple', coalesce(target_term, '')), 'B') ||\n      setweight(to_tsvector('simple', coalesce(description, '')), 'C')\n    ",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "translation_glossary_terms_glossary_source_term_key": {
+          "name": "translation_glossary_terms_glossary_source_term_key",
+          "columns": [
+            {
+              "expression": "glossary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_term",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translation_glossary_terms_glossary_source_term_ci_key": {
+          "name": "translation_glossary_terms_glossary_source_term_ci_key",
+          "columns": [
+            {
+              "expression": "glossary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"source_term\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"translation_glossary_terms\".\"case_sensitive\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_translation_glossary_terms_glossary_created_at": {
+          "name": "idx_translation_glossary_terms_glossary_created_at",
+          "columns": [
+            {
+              "expression": "glossary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_translation_glossary_terms_search_vector": {
+          "name": "idx_translation_glossary_terms_search_vector",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "translation_glossary_terms_glossary_id_translation_glossaries_id_fk": {
+          "name": "translation_glossary_terms_glossary_id_translation_glossaries_id_fk",
+          "tableFrom": "translation_glossary_terms",
+          "tableTo": "translation_glossaries",
+          "columnsFrom": ["glossary_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.translation_jobs": {
+      "name": "translation_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "translation_job_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "translation_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "input_payload": {
+          "name": "input_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome_kind": {
+          "name": "outcome_kind",
+          "type": "translation_job_outcome_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome_payload": {
+          "name": "outcome_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_translation_jobs_project_created_at": {
+          "name": "idx_translation_jobs_project_created_at",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_translation_jobs_created_by_user_id": {
+          "name": "idx_translation_jobs_created_by_user_id",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_translation_jobs_workflow_run_id": {
+          "name": "idx_translation_jobs_workflow_run_id",
+          "columns": [
+            {
+              "expression": "workflow_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_translation_jobs_status": {
+          "name": "idx_translation_jobs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "translation_jobs_project_id_translation_projects_id_fk": {
+          "name": "translation_jobs_project_id_translation_projects_id_fk",
+          "tableFrom": "translation_jobs",
+          "tableTo": "translation_projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "translation_jobs_created_by_user_id_users_id_fk": {
+          "name": "translation_jobs_created_by_user_id_users_id_fk",
+          "tableFrom": "translation_jobs",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.translation_memories": {
+      "name": "translation_memories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "translation_asset_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_translation_memories_org_created_at": {
+          "name": "idx_translation_memories_org_created_at",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_translation_memories_created_by_user_id": {
+          "name": "idx_translation_memories_created_by_user_id",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "translation_memories_organization_id_organizations_id_fk": {
+          "name": "translation_memories_organization_id_organizations_id_fk",
+          "tableFrom": "translation_memories",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "translation_memories_created_by_user_id_users_id_fk": {
+          "name": "translation_memories_created_by_user_id_users_id_fk",
+          "tableFrom": "translation_memories",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.translation_memory_entries": {
+      "name": "translation_memory_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "translation_memory_id": {
+          "name": "translation_memory_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_locale": {
+          "name": "source_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_locale": {
+          "name": "target_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_text": {
+          "name": "source_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_source_text": {
+          "name": "normalized_source_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_text": {
+          "name": "target_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_score": {
+          "name": "match_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "\n      setweight(to_tsvector('simple', coalesce(source_text, '')), 'A') ||\n      setweight(to_tsvector('simple', coalesce(target_text, '')), 'B')\n    ",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "translation_memory_entries_memory_locale_source_key": {
+          "name": "translation_memory_entries_memory_locale_source_key",
+          "columns": [
+            {
+              "expression": "translation_memory_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_source_text",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_translation_memory_entries_memory_locale_pair": {
+          "name": "idx_translation_memory_entries_memory_locale_pair",
+          "columns": [
+            {
+              "expression": "translation_memory_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_translation_memory_entries_external_key": {
+          "name": "idx_translation_memory_entries_external_key",
+          "columns": [
+            {
+              "expression": "external_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_translation_memory_entries_search_vector": {
+          "name": "idx_translation_memory_entries_search_vector",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "translation_memory_entries_translation_memory_id_translation_memories_id_fk": {
+          "name": "translation_memory_entries_translation_memory_id_translation_memories_id_fk",
+          "tableFrom": "translation_memory_entries",
+          "tableTo": "translation_memories",
+          "columnsFrom": ["translation_memory_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "translation_memory_entries_match_score_check": {
+          "name": "translation_memory_entries_match_score_check",
+          "value": "\"translation_memory_entries\".\"match_score\" >= 0 AND \"translation_memory_entries\".\"match_score\" <= 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.translation_project_glossaries": {
+      "name": "translation_project_glossaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "glossary_id": {
+          "name": "glossary_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "translation_project_glossaries_project_glossary_key": {
+          "name": "translation_project_glossaries_project_glossary_key",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "glossary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_translation_project_glossaries_project_priority": {
+          "name": "idx_translation_project_glossaries_project_priority",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "translation_project_glossaries_project_id_translation_projects_id_fk": {
+          "name": "translation_project_glossaries_project_id_translation_projects_id_fk",
+          "tableFrom": "translation_project_glossaries",
+          "tableTo": "translation_projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "translation_project_glossaries_glossary_id_translation_glossaries_id_fk": {
+          "name": "translation_project_glossaries_glossary_id_translation_glossaries_id_fk",
+          "tableFrom": "translation_project_glossaries",
+          "tableTo": "translation_glossaries",
+          "columnsFrom": ["glossary_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.translation_project_memories": {
+      "name": "translation_project_memories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "translation_memory_id": {
+          "name": "translation_memory_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "translation_project_memories_project_memory_key": {
+          "name": "translation_project_memories_project_memory_key",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "translation_memory_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_translation_project_memories_project_priority": {
+          "name": "idx_translation_project_memories_project_priority",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "translation_project_memories_project_id_translation_projects_id_fk": {
+          "name": "translation_project_memories_project_id_translation_projects_id_fk",
+          "tableFrom": "translation_project_memories",
+          "tableTo": "translation_projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "translation_project_memories_translation_memory_id_translation_memories_id_fk": {
+          "name": "translation_project_memories_translation_memory_id_translation_memories_id_fk",
+          "tableFrom": "translation_project_memories",
+          "tableTo": "translation_memories",
+          "columnsFrom": ["translation_memory_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.translation_projects": {
+      "name": "translation_projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "translation_context": {
+          "name": "translation_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_translation_projects_org_created_at": {
+          "name": "idx_translation_projects_org_created_at",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_translation_projects_created_by_user_id": {
+          "name": "idx_translation_projects_created_by_user_id",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "translation_projects_organization_id_organizations_id_fk": {
+          "name": "translation_projects_organization_id_organizations_id_fk",
+          "tableFrom": "translation_projects",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "translation_projects_created_by_user_id_users_id_fk": {
+          "name": "translation_projects_created_by_user_id_users_id_fk",
+          "tableFrom": "translation_projects",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workos_user_id": {
+          "name": "workos_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_workos_user_id_key": {
+          "name": "users_workos_user_id_key",
+          "columns": [
+            {
+              "expression": "workos_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_key": {
+          "name": "users_email_key",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_created_at": {
+          "name": "idx_users_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.llm_provider": {
+      "name": "llm_provider",
+      "schema": "public",
+      "values": ["openai", "anthropic", "gemini", "groq", "mistral"]
+    },
+    "public.organization_membership_role": {
+      "name": "organization_membership_role",
+      "schema": "public",
+      "values": ["owner", "admin", "member"]
+    },
+    "public.team_membership_role": {
+      "name": "team_membership_role",
+      "schema": "public",
+      "values": ["manager", "member"]
+    },
+    "public.translation_asset_status": {
+      "name": "translation_asset_status",
+      "schema": "public",
+      "values": ["draft", "active", "archived"]
+    },
+    "public.translation_job_outcome_kind": {
+      "name": "translation_job_outcome_kind",
+      "schema": "public",
+      "values": ["string_result", "file_result", "error"]
+    },
+    "public.translation_job_status": {
+      "name": "translation_job_status",
+      "schema": "public",
+      "values": ["queued", "running", "succeeded", "failed"]
+    },
+    "public.translation_job_type": {
+      "name": "translation_job_type",
+      "schema": "public",
+      "values": ["string", "file"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/hyperlocalise-web/drizzle/meta/_journal.json
+++ b/apps/hyperlocalise-web/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1776487629773,
       "tag": "0001_mysterious_union_jack",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1776492379761,
+      "tag": "0002_flashy_ravenous",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/hyperlocalise-web/src/api/app.ts
+++ b/apps/hyperlocalise-web/src/api/app.ts
@@ -6,6 +6,7 @@ import { githubWebhookRoutes } from "./routes/github-webhook";
 import { healthRoutes } from "./routes/health";
 import { createGlossaryRoutes } from "./routes/glossary/glossary.route";
 import { createProjectRoutes } from "./routes/project/project.route";
+import { createProviderCredentialRoutes } from "./routes/provider-credential/provider-credential.route";
 import { createTeamRoutes } from "./routes/team/team.route";
 import { workosWebhookRoutes } from "./routes/workos-webhook";
 
@@ -25,6 +26,7 @@ export function createApp(options: CreateAppOptions = {}) {
     .route("/webhooks/workos", workosWebhookRoutes)
     .route("/project", createProjectRoutes(options))
     .route("/orgs/:organizationSlug/projects", createProjectRoutes(options))
+    .route("/orgs/:organizationSlug/provider-credential", createProviderCredentialRoutes())
     .route("/orgs/:organizationSlug/teams", createTeamRoutes());
 }
 

--- a/apps/hyperlocalise-web/src/api/routes/auth.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/auth.test.ts
@@ -11,17 +11,6 @@ const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
   resolveApiAuthContextFromSessionMock: vi.fn(),
 }));
 
-vi.mock("inngest/hono", () => ({
-  serve: () => () => new Response(null, { status: 204 }),
-}));
-
-vi.mock("@/lib/inngest", () => ({
-  inngest: {},
-  createInngestTranslationJobQueue: () => ({
-    enqueue: async () => ({ ids: [] }),
-  }),
-}));
-
 vi.mock("@/lib/translation/translation-job-queued-function", () => ({
   translationJobQueuedFunction: {},
 }));

--- a/apps/hyperlocalise-web/src/api/routes/provider-credential/provider-credential.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/provider-credential/provider-credential.route.ts
@@ -1,0 +1,127 @@
+import { Hono, type Context } from "hono";
+import { validator } from "hono/validator";
+
+import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
+import {
+  assertProviderCredentialAdmin,
+  deleteOrganizationProviderCredential,
+  getOrganizationProviderCredentialSummary,
+  revealOrganizationProviderCredential,
+  upsertOrganizationProviderCredential,
+} from "@/lib/providers/organization-provider-credentials";
+
+import {
+  revealProviderCredentialBodySchema,
+  updateProviderCredentialBodySchema,
+} from "./provider-credential.schema";
+
+function invalidProviderCredentialPayloadResponse(c: Context) {
+  return c.json({ error: "invalid_provider_credential_payload" as const }, 400);
+}
+
+const validateUpdateProviderCredentialBody = validator("json", (value, c) => {
+  const parsed = updateProviderCredentialBodySchema.safeParse(value);
+  if (!parsed.success) {
+    return invalidProviderCredentialPayloadResponse(c);
+  }
+
+  return parsed.data;
+});
+
+const validateRevealProviderCredentialBody = validator("json", (value, c) => {
+  const parsed = revealProviderCredentialBodySchema.safeParse(value);
+  if (!parsed.success) {
+    return invalidProviderCredentialPayloadResponse(c);
+  }
+
+  return parsed.data;
+});
+
+export function createProviderCredentialRoutes() {
+  return new Hono<{ Variables: AuthVariables }>()
+    .use("*", workosAuthMiddleware)
+    .get("/", async (c) => {
+      const providerCredential = await getOrganizationProviderCredentialSummary(
+        c.var.auth.organization.localOrganizationId,
+      );
+
+      return c.json({ providerCredential }, 200);
+    })
+    .put("/", validateUpdateProviderCredentialBody, async (c) => {
+      try {
+        assertProviderCredentialAdmin(c.var.auth.membership.role);
+      } catch {
+        return c.json({ error: "forbidden" as const }, 403);
+      }
+
+      const payload = c.req.valid("json");
+
+      try {
+        const providerCredential = await upsertOrganizationProviderCredential({
+          organizationId: c.var.auth.organization.localOrganizationId,
+          userId: c.var.auth.user.localUserId,
+          provider: payload.provider,
+          apiKey: payload.apiKey,
+          defaultModel: payload.defaultModel,
+        });
+
+        return c.json({ providerCredential }, 200);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "provider_validation_failed";
+
+        if (message === "unsupported_provider_model") {
+          return c.json({ error: "invalid_provider_model" as const }, 400);
+        }
+
+        return c.json(
+          {
+            error: "provider_validation_failed" as const,
+            message,
+          },
+          422,
+        );
+      }
+    })
+    .post("/reveal", validateRevealProviderCredentialBody, async (c) => {
+      try {
+        const revealedCredential = await revealOrganizationProviderCredential({
+          organizationId: c.var.auth.organization.localOrganizationId,
+          role: c.var.auth.membership.role,
+        });
+
+        if (!revealedCredential) {
+          return c.json({ error: "provider_credential_not_found" as const }, 404);
+        }
+
+        return c.json({ providerCredential: revealedCredential }, 200);
+      } catch (error) {
+        if (error instanceof Error && error.message === "forbidden") {
+          return c.json({ error: "forbidden" as const }, 403);
+        }
+
+        throw error;
+      }
+    })
+    .delete("/", async (c) => {
+      try {
+        const deleted = await deleteOrganizationProviderCredential({
+          organizationId: c.var.auth.organization.localOrganizationId,
+          role: c.var.auth.membership.role,
+        });
+
+        if (!deleted) {
+          return c.json({ error: "provider_credential_not_found" as const }, 404);
+        }
+
+        return c.body(null, 204);
+      } catch (error) {
+        if (error instanceof Error && error.message === "forbidden") {
+          return c.json({ error: "forbidden" as const }, 403);
+        }
+
+        throw error;
+      }
+    });
+}
+
+export const providerCredentialRoutes = createProviderCredentialRoutes();

--- a/apps/hyperlocalise-web/src/api/routes/provider-credential/provider-credential.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/provider-credential/provider-credential.schema.ts
@@ -1,0 +1,33 @@
+import { z } from "zod";
+
+import {
+  defaultModelByProvider,
+  llmProviderSchema,
+  llmProviderCatalog,
+} from "@/lib/providers/catalog";
+
+export const updateProviderCredentialBodySchema = z
+  .object({
+    provider: llmProviderSchema,
+    apiKey: z.string().trim().min(1, "API key is required."),
+    defaultModel: z.string().trim().min(1, "Default model is required."),
+  })
+  .superRefine((value, context) => {
+    if (
+      !(llmProviderCatalog[value.provider].models as readonly string[]).includes(value.defaultModel)
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Choose a supported model for the selected provider.",
+        path: ["defaultModel"],
+      });
+    }
+  });
+
+export const revealProviderCredentialBodySchema = z.object({
+  confirmed: z.literal(true),
+});
+
+export const providerCredentialDefaults = Object.fromEntries(
+  Object.entries(defaultModelByProvider).map(([provider, model]) => [provider, model]),
+);

--- a/apps/hyperlocalise-web/src/api/routes/provider-credential/provider-credential.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/provider-credential/provider-credential.test.ts
@@ -1,0 +1,194 @@
+import "dotenv/config";
+
+import { eq } from "drizzle-orm";
+import { testClient } from "hono/testing";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
+
+import { app } from "@/api/app";
+import { createProjectTestFixture } from "@/api/routes/project/project.fixture";
+import { db, schema } from "@/lib/database";
+
+const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
+  resolveApiAuthContextFromSessionMock: vi.fn(() => globalThis.__testApiAuthContext ?? null),
+}));
+
+vi.mock("inngest/hono", () => ({
+  serve: () => () => new Response(null, { status: 204 }),
+}));
+
+vi.mock("@/lib/inngest", () => ({
+  inngest: {},
+  createInngestTranslationJobQueue: () => ({
+    enqueue: async () => ({ ids: [] }),
+  }),
+}));
+
+vi.mock("@/lib/translation/translation-job-queued-function", () => ({
+  translationJobQueuedFunction: {},
+}));
+
+vi.mock("@/api/auth/workos-session", () => ({
+  resolveApiAuthContextFromSession: resolveApiAuthContextFromSessionMock,
+}));
+
+const client = testClient(app);
+const fixture = createProjectTestFixture(client);
+
+describe("providerCredentialRoutes", () => {
+  beforeAll(async () => {
+    await db.$client.query("select 1");
+    await db.$client.query(`
+      DO $$
+      BEGIN
+        CREATE TYPE llm_provider AS ENUM ('openai', 'anthropic', 'gemini', 'groq', 'mistral');
+      EXCEPTION
+        WHEN duplicate_object THEN NULL;
+      END $$;
+    `);
+    await db.$client.query(`
+      CREATE TABLE IF NOT EXISTS organization_llm_provider_credentials (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+        organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE cascade,
+        created_by_user_id uuid REFERENCES users(id) ON DELETE set null,
+        updated_by_user_id uuid REFERENCES users(id) ON DELETE set null,
+        provider llm_provider NOT NULL,
+        default_model text NOT NULL,
+        masked_api_key_suffix text NOT NULL,
+        encryption_algorithm text NOT NULL,
+        ciphertext text NOT NULL,
+        iv text NOT NULL,
+        auth_tag text NOT NULL,
+        key_version integer DEFAULT 1 NOT NULL,
+        last_validated_at timestamp with time zone NOT NULL,
+        created_at timestamp with time zone DEFAULT now() NOT NULL,
+        updated_at timestamp with time zone DEFAULT now() NOT NULL
+      );
+    `);
+    await db.$client.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS organization_llm_provider_credentials_org_key
+      ON organization_llm_provider_credentials (organization_id);
+    `);
+  });
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    await fixture.cleanup();
+  });
+
+  it("stores an encrypted provider credential for org admins", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(JSON.stringify({ ok: true }), { status: 200 })),
+    );
+
+    const identity = fixture.createWorkosIdentityWithRole("admin");
+    const organizationSlug = identity.organization.slug ?? "missing-slug";
+    const response = await client.api.orgs[":organizationSlug"]["provider-credential"].$put(
+      {
+        param: { organizationSlug },
+        json: {
+          provider: "openai",
+          apiKey: "sk-live-provider-key",
+          defaultModel: "gpt-4.1-mini",
+        },
+      },
+      {
+        headers: await fixture.authHeadersFor(identity),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      providerCredential: {
+        provider: "openai",
+        defaultModel: "gpt-4.1-mini",
+        maskedApiKeySuffix: "-key",
+      },
+    });
+
+    const authContext = globalThis.__testApiAuthContext;
+    const [storedCredential] = await db
+      .select()
+      .from(schema.organizationLlmProviderCredentials)
+      .where(
+        eq(
+          schema.organizationLlmProviderCredentials.organizationId,
+          authContext?.organization.localOrganizationId ?? "missing-org-id",
+        ),
+      );
+    expect(authContext).toBeDefined();
+    expect(storedCredential?.ciphertext).not.toContain("sk-live-provider-key");
+    expect(storedCredential?.maskedApiKeySuffix).toBe("-key");
+  });
+
+  it("blocks org members from managing provider credentials", async () => {
+    const identity = fixture.createWorkosIdentityWithRole("member");
+    const organizationSlug = identity.organization.slug ?? "missing-slug";
+
+    const response = await client.api.orgs[":organizationSlug"]["provider-credential"].$put(
+      {
+        param: { organizationSlug },
+        json: {
+          provider: "openai",
+          apiKey: "sk-member-key",
+          defaultModel: "gpt-4.1-mini",
+        },
+      },
+      {
+        headers: await fixture.authHeadersFor(identity),
+      },
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: "forbidden",
+    });
+  });
+
+  it("reveals a stored provider credential only after explicit confirmation", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(JSON.stringify({ ok: true }), { status: 200 })),
+    );
+
+    const identity = fixture.createWorkosIdentity();
+    const organizationSlug = identity.organization.slug ?? "missing-slug";
+    const headers = await fixture.authHeadersFor(identity);
+
+    await client.api.orgs[":organizationSlug"]["provider-credential"].$put(
+      {
+        param: { organizationSlug },
+        json: {
+          provider: "openai",
+          apiKey: "sk-reveal-provider-key",
+          defaultModel: "gpt-4.1-mini",
+        },
+      },
+      { headers },
+    );
+
+    const revealResponse = await client.api.orgs[":organizationSlug"]["provider-credential"][
+      "reveal"
+    ].$post(
+      {
+        param: { organizationSlug },
+        json: {
+          confirmed: true,
+        },
+      },
+      { headers },
+    );
+
+    expect(revealResponse.status).toBe(200);
+    await expect(revealResponse.json()).resolves.toMatchObject({
+      providerCredential: {
+        apiKey: "sk-reveal-provider-key",
+        summary: {
+          provider: "openai",
+          defaultModel: "gpt-4.1-mini",
+        },
+      },
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/api/routes/provider-credential/provider-credential.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/provider-credential/provider-credential.test.ts
@@ -12,21 +12,6 @@ const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
   resolveApiAuthContextFromSessionMock: vi.fn(() => globalThis.__testApiAuthContext ?? null),
 }));
 
-vi.mock("inngest/hono", () => ({
-  serve: () => () => new Response(null, { status: 204 }),
-}));
-
-vi.mock("@/lib/inngest", () => ({
-  inngest: {},
-  createInngestTranslationJobQueue: () => ({
-    enqueue: async () => ({ ids: [] }),
-  }),
-}));
-
-vi.mock("@/lib/translation/translation-job-queued-function", () => ({
-  translationJobQueuedFunction: {},
-}));
-
 vi.mock("@/api/auth/workos-session", () => ({
   resolveApiAuthContextFromSession: resolveApiAuthContextFromSessionMock,
 }));

--- a/apps/hyperlocalise-web/src/api/routes/team/team.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/team/team.test.ts
@@ -11,17 +11,6 @@ const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
   resolveApiAuthContextFromSessionMock: vi.fn(() => globalThis.__testApiAuthContext ?? null),
 }));
 
-vi.mock("inngest/hono", () => ({
-  serve: () => () => new Response(null, { status: 204 }),
-}));
-
-vi.mock("@/lib/inngest", () => ({
-  inngest: {},
-  createInngestTranslationJobQueue: () => ({
-    enqueue: async () => ({ ids: [] }),
-  }),
-}));
-
 vi.mock("@/lib/translation/translation-job-queued-function", () => ({
   translationJobQueuedFunction: {},
 }));

--- a/apps/hyperlocalise-web/src/app/auth/onboarding/_components/onboarding-wizard.tsx
+++ b/apps/hyperlocalise-web/src/app/auth/onboarding/_components/onboarding-wizard.tsx
@@ -1,0 +1,486 @@
+"use client";
+
+import type { ComponentProps, ReactNode } from "react";
+import { useActionState, useEffect, useState } from "react";
+import { useFormStatus } from "react-dom";
+import {
+  ArrowLeft01Icon,
+  ArrowRight01Icon,
+  CheckmarkCircle02Icon,
+  SparklesIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import Link from "next/link";
+
+import type { LlmProvider } from "@/lib/database/types";
+import { defaultModelByProvider, llmProviderCatalog } from "@/lib/providers/catalog";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldError,
+  FieldTitle,
+} from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { Progress, ProgressLabel } from "@/components/ui/progress";
+import { cn } from "@/lib/utils";
+
+import type { CreateWorkspaceActionState, SaveProviderActionState } from "../actions";
+import {
+  createWorkspaceAction,
+  finishOnboardingAction,
+  saveProviderCredentialAction,
+  skipProviderCredentialAction,
+} from "../actions";
+
+type OnboardingStep = "create" | "provider" | "ready";
+
+type OnboardingWizardProps = {
+  step: OnboardingStep;
+  organizationName?: string | null;
+  organizationSlug?: string | null;
+  providerSummary?: {
+    provider: string;
+    defaultModel: string;
+    maskedApiKeySuffix: string;
+  } | null;
+  providerSetupStatus?: "pending" | "configured" | "skipped";
+};
+
+const steps: Array<{ id: OnboardingStep; label: string; title: string }> = [
+  { id: "create", label: "01", title: "Create workspace" },
+  { id: "provider", label: "02", title: "Add AI provider" },
+  { id: "ready", label: "03", title: "Ready to go" },
+];
+
+function SubmitButton({
+  children,
+  ...props
+}: ComponentProps<typeof Button> & { children: ReactNode }) {
+  const { pending } = useFormStatus();
+
+  return (
+    <Button disabled={pending} {...props}>
+      {children}
+    </Button>
+  );
+}
+
+function StepProgress({ step }: { step: OnboardingStep }) {
+  const stepIndex = steps.findIndex((item) => item.id === step);
+  const progressValue = ((stepIndex + 1) / steps.length) * 100;
+
+  return (
+    <div className="space-y-6">
+      <Progress value={progressValue} className="gap-2">
+        <ProgressLabel>
+          Step {stepIndex + 1} of {steps.length}
+        </ProgressLabel>
+        <div className="ms-auto text-sm text-muted-foreground">{steps[stepIndex]?.title}</div>
+      </Progress>
+
+      <div className="grid grid-cols-3 gap-3">
+        {steps.map((item, index) => {
+          const isActive = item.id === step;
+          const isComplete = index < stepIndex;
+
+          return (
+            <div
+              key={item.id}
+              className={cn(
+                "rounded-3xl border px-4 py-3 text-left transition-colors",
+                isActive
+                  ? "border-primary/40 bg-primary/10 text-foreground"
+                  : isComplete
+                    ? "border-border/70 bg-background/80 text-foreground"
+                    : "border-border/60 bg-background/60 text-muted-foreground",
+              )}
+            >
+              <div className="text-xs font-medium tracking-[0.24em] text-muted-foreground">
+                {item.label}
+              </div>
+              <div className="mt-2 text-sm font-medium">{item.title}</div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function CreateWorkspaceStep({ organizationName }: { organizationName?: string | null }) {
+  const [state, formAction] = useActionState<CreateWorkspaceActionState, FormData>(
+    createWorkspaceAction,
+    {},
+  );
+
+  if (organizationName) {
+    return (
+      <div className="space-y-6">
+        <div className="space-y-3">
+          <h2 className="font-heading text-3xl font-semibold text-balance text-foreground">
+            Workspace created
+          </h2>
+          <p className="max-w-xl text-sm leading-6 text-muted-foreground">
+            Your workspace is ready. Continue to add the shared AI provider that this workspace will
+            use by default.
+          </p>
+        </div>
+
+        <Card className="border-border/70 bg-background/90">
+          <CardHeader>
+            <CardTitle>{organizationName}</CardTitle>
+            <CardDescription>
+              This workspace is already created. You can continue to provider setup now.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+
+        <div className="flex justify-end">
+          <Button nativeButton={false} render={<Link href="/auth/onboarding?step=provider" />}>
+            Continue
+            <HugeiconsIcon icon={ArrowRight01Icon} strokeWidth={2} />
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <form action={formAction} className="space-y-6">
+      <div className="space-y-3">
+        <h2 className="font-heading text-3xl font-semibold text-balance text-foreground">
+          Create your workspace
+        </h2>
+        <p className="max-w-xl text-sm leading-6 text-muted-foreground">
+          Start with the workspace name. You can configure the AI provider that powers it on the
+          next step.
+        </p>
+      </div>
+
+      {state.error ? (
+        <Alert variant="destructive">
+          <AlertTitle>Workspace creation failed</AlertTitle>
+          <AlertDescription>{state.error}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      <Field>
+        <FieldContent>
+          <FieldTitle>Workspace name</FieldTitle>
+          <Input
+            name="organizationName"
+            placeholder="Acme localisation"
+            defaultValue=""
+            aria-invalid={Boolean(state.fieldErrors?.organizationName)}
+          />
+          <FieldDescription>
+            This name becomes the workspace label people see across projects and settings.
+          </FieldDescription>
+          <FieldError>{state.fieldErrors?.organizationName}</FieldError>
+        </FieldContent>
+      </Field>
+
+      <div className="flex justify-end">
+        <SubmitButton nativeButton type="submit">
+          Create workspace
+          <HugeiconsIcon icon={ArrowRight01Icon} strokeWidth={2} />
+        </SubmitButton>
+      </div>
+    </form>
+  );
+}
+
+function ProviderCredentialStep({
+  providerSummary,
+}: {
+  providerSummary?: OnboardingWizardProps["providerSummary"];
+}) {
+  const [selectedProvider, setSelectedProvider] = useState<LlmProvider>(
+    (providerSummary?.provider as LlmProvider | undefined) ?? "openai",
+  );
+  const [selectedModel, setSelectedModel] = useState(
+    providerSummary?.defaultModel ?? defaultModelByProvider[selectedProvider],
+  );
+  const [state, formAction] = useActionState<SaveProviderActionState, FormData>(
+    saveProviderCredentialAction,
+    {},
+  );
+
+  useEffect(() => {
+    if (
+      !(llmProviderCatalog[selectedProvider].models as readonly string[]).includes(selectedModel)
+    ) {
+      setSelectedModel(defaultModelByProvider[selectedProvider]);
+    }
+  }, [selectedModel, selectedProvider]);
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-3">
+        <h2 className="font-heading text-3xl font-semibold text-balance text-foreground">
+          Add an AI provider
+        </h2>
+        <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
+          Save one shared provider for this workspace. We will validate the credential before
+          finishing setup.
+        </p>
+      </div>
+
+      {providerSummary ? (
+        <Alert>
+          <AlertTitle>Current workspace default</AlertTitle>
+          <AlertDescription>
+            {llmProviderCatalog[providerSummary.provider as LlmProvider]?.label ??
+              providerSummary.provider}{" "}
+            is already configured with {providerSummary.defaultModel}. The saved key ends in{" "}
+            {providerSummary.maskedApiKeySuffix}. Enter a new key below only if you want to replace
+            it.
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      {state.error ? (
+        <Alert variant="destructive">
+          <AlertTitle>Provider validation failed</AlertTitle>
+          <AlertDescription>{state.error}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      <form action={formAction} className="space-y-6">
+        <input type="hidden" name="provider" value={selectedProvider} />
+        <input type="hidden" name="defaultModel" value={selectedModel} />
+
+        <Field>
+          <FieldContent>
+            <FieldTitle>Provider</FieldTitle>
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+              {Object.entries(llmProviderCatalog).map(([provider, providerConfig]) => {
+                const isActive = provider === selectedProvider;
+
+                return (
+                  <button
+                    key={provider}
+                    type="button"
+                    onClick={() => {
+                      setSelectedProvider(provider as LlmProvider);
+                      setSelectedModel(defaultModelByProvider[provider as LlmProvider]);
+                    }}
+                    className={cn(
+                      "rounded-3xl border px-4 py-4 text-left transition-colors",
+                      isActive
+                        ? "border-primary/40 bg-primary/10 text-foreground shadow-[0_12px_30px_rgba(79,180,141,0.12)]"
+                        : "border-border/70 bg-background/80 text-foreground hover:border-primary/25 hover:bg-primary/5",
+                    )}
+                  >
+                    <div className="text-sm font-medium">{providerConfig.label}</div>
+                    <div className="mt-2 text-xs text-muted-foreground">
+                      {providerConfig.models.length} curated models
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+            <FieldError>{state.fieldErrors?.provider}</FieldError>
+          </FieldContent>
+        </Field>
+
+        <Field>
+          <FieldContent>
+            <FieldTitle>Default model</FieldTitle>
+            <select
+              value={selectedModel}
+              onChange={(event) => setSelectedModel(event.target.value)}
+              className="h-10 w-full rounded-4xl border border-input bg-input/30 px-3 text-sm outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+              aria-invalid={Boolean(state.fieldErrors?.defaultModel)}
+            >
+              {llmProviderCatalog[selectedProvider].models.map((model) => (
+                <option key={model} value={model}>
+                  {model}
+                </option>
+              ))}
+            </select>
+            <FieldDescription>
+              This becomes the initial workspace default for AI translation work.
+            </FieldDescription>
+            <FieldError>{state.fieldErrors?.defaultModel}</FieldError>
+          </FieldContent>
+        </Field>
+
+        <Field>
+          <FieldContent>
+            <FieldTitle>API key</FieldTitle>
+            <Input
+              name="apiKey"
+              type="password"
+              autoComplete="off"
+              placeholder={`Enter your ${llmProviderCatalog[selectedProvider].label} API key`}
+              aria-invalid={Boolean(state.fieldErrors?.apiKey)}
+            />
+            <FieldDescription>
+              The key is encrypted at rest in Postgres and only decrypted inside server-only code
+              paths.
+            </FieldDescription>
+            <FieldError>{state.fieldErrors?.apiKey}</FieldError>
+          </FieldContent>
+        </Field>
+
+        <div className="flex flex-wrap justify-between gap-3">
+          <Button
+            variant="ghost"
+            nativeButton={false}
+            render={<Link href="/auth/onboarding?step=create" />}
+          >
+            <HugeiconsIcon icon={ArrowLeft01Icon} strokeWidth={2} />
+            Back
+          </Button>
+
+          <div className="flex flex-wrap gap-3">
+            <SubmitButton
+              nativeButton
+              type="submit"
+              variant="outline"
+              formAction={skipProviderCredentialAction}
+            >
+              Skip for now
+            </SubmitButton>
+            <SubmitButton nativeButton type="submit">
+              Save provider
+              <HugeiconsIcon icon={ArrowRight01Icon} strokeWidth={2} />
+            </SubmitButton>
+          </div>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+function ReadyStep({
+  organizationName,
+  organizationSlug,
+  providerSummary,
+  providerSetupStatus,
+}: {
+  organizationName?: string | null;
+  organizationSlug?: string | null;
+  providerSummary?: OnboardingWizardProps["providerSummary"];
+  providerSetupStatus?: OnboardingWizardProps["providerSetupStatus"];
+}) {
+  const providerConfigured = Boolean(providerSummary);
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-3">
+        <h2 className="font-heading text-3xl font-semibold text-balance text-foreground">
+          Your workspace is ready
+        </h2>
+        <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
+          Enter the dashboard and start creating projects. Team invites can come after this.
+        </p>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <Card className="border-border/70 bg-background/90">
+          <CardHeader>
+            <CardTitle>{organizationName ?? "Workspace"}</CardTitle>
+            <CardDescription>Workspace slug: {organizationSlug ?? "pending"}</CardDescription>
+          </CardHeader>
+        </Card>
+        <Card className="border-border/70 bg-background/90">
+          <CardHeader>
+            <CardTitle>{providerConfigured ? "Provider configured" : "Provider skipped"}</CardTitle>
+            <CardDescription>
+              {providerConfigured && providerSummary
+                ? `${llmProviderCatalog[providerSummary.provider as LlmProvider]?.label ?? providerSummary.provider} • ${providerSummary.defaultModel}`
+                : providerSetupStatus === "skipped"
+                  ? "You can add a provider later from workspace settings."
+                  : "Add a provider before running AI-powered translation jobs."}
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </div>
+
+      <Alert>
+        <HugeiconsIcon
+          icon={providerConfigured ? CheckmarkCircle02Icon : SparklesIcon}
+          strokeWidth={2}
+        />
+        <AlertTitle>
+          {providerConfigured ? "Activation complete" : "One setup task left for AI runs"}
+        </AlertTitle>
+        <AlertDescription>
+          {providerConfigured
+            ? "The workspace has a validated shared provider and is ready for first use."
+            : "The workspace exists and you can explore it now. AI actions will prompt for provider setup later."}
+        </AlertDescription>
+      </Alert>
+
+      <div className="flex flex-wrap justify-between gap-3">
+        <Button
+          variant="ghost"
+          nativeButton={false}
+          render={<Link href="/auth/onboarding?step=provider" />}
+        >
+          <HugeiconsIcon icon={ArrowLeft01Icon} strokeWidth={2} />
+          Back
+        </Button>
+
+        <form action={finishOnboardingAction}>
+          <SubmitButton nativeButton type="submit">
+            Enter workspace
+            <HugeiconsIcon icon={ArrowRight01Icon} strokeWidth={2} />
+          </SubmitButton>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export function OnboardingWizard(props: OnboardingWizardProps) {
+  return (
+    <main className="min-h-svh bg-[radial-gradient(circle_at_top,rgba(79,180,141,0.16),transparent_55%),linear-gradient(180deg,#f7f8f7_0%,#eef2ee_100%)] px-4 py-8 text-foreground sm:px-6 sm:py-12">
+      <div className="mx-auto flex min-h-[calc(100svh-4rem)] w-full max-w-5xl items-center justify-center">
+        <Card className="w-full border-border/70 bg-background/92 shadow-[0_28px_80px_rgba(15,23,42,0.12)] backdrop-blur">
+          <CardContent className="grid gap-10 p-6 sm:p-8 lg:grid-cols-[0.9fr_1.1fr] lg:p-10">
+            <div className="space-y-8">
+              <div className="space-y-3">
+                <div className="text-xs font-medium tracking-[0.28em] text-muted-foreground uppercase">
+                  Hyperlocalise cloud setup
+                </div>
+                <h1 className="font-heading text-4xl leading-tight font-semibold text-balance text-foreground">
+                  Stand up the workspace before the first translation run.
+                </h1>
+                <p className="text-sm leading-6 text-muted-foreground">
+                  The onboarding flow stays linear on purpose: create the workspace, set its
+                  provider defaults, then land in the product without detours.
+                </p>
+              </div>
+
+              <StepProgress step={props.step} />
+            </div>
+
+            <div className="rounded-[2rem] border border-border/70 bg-background/80 p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.5)] sm:p-8">
+              {props.step === "create" ? (
+                <CreateWorkspaceStep organizationName={props.organizationName} />
+              ) : null}
+              {props.step === "provider" ? (
+                <ProviderCredentialStep providerSummary={props.providerSummary} />
+              ) : null}
+              {props.step === "ready" ? (
+                <ReadyStep
+                  organizationName={props.organizationName}
+                  organizationSlug={props.organizationSlug}
+                  providerSummary={props.providerSummary}
+                  providerSetupStatus={props.providerSetupStatus}
+                />
+              ) : null}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </main>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/auth/onboarding/actions.ts
+++ b/apps/hyperlocalise-web/src/app/auth/onboarding/actions.ts
@@ -7,6 +7,7 @@ import { updateProviderCredentialBodySchema } from "@/api/routes/provider-creden
 import { createWorkspaceForSessionUser } from "@/lib/onboarding/workspace";
 import { loadOnboardingContext } from "@/lib/onboarding/context";
 import {
+  assertProviderCredentialAdmin,
   getOrganizationProviderCredentialSummary,
   upsertOrganizationProviderCredential,
 } from "@/lib/providers/organization-provider-credentials";
@@ -75,10 +76,22 @@ export async function createWorkspaceAction(
     redirect("/auth/sign-in?returnTo=/auth/onboarding");
   }
 
-  const { organization } = await createWorkspaceForSessionUser({
-    sessionUser: session.user,
-    organizationName: parsed.data.organizationName,
-  });
+  let organization;
+
+  try {
+    ({ organization } = await createWorkspaceForSessionUser({
+      sessionUser: session.user,
+      organizationName: parsed.data.organizationName,
+    }));
+  } catch (error) {
+    if (error instanceof Error && error.message === "workspace_slug_conflict") {
+      return {
+        error: "Unable to create a unique workspace URL right now. Please retry.",
+      };
+    }
+
+    throw error;
+  }
 
   if (!organization.slug) {
     return {
@@ -124,6 +137,7 @@ export async function saveProviderCredentialAction(
   }
 
   try {
+    assertProviderCredentialAdmin(auth.membership.role);
     await upsertOrganizationProviderCredential({
       organizationId: auth.activeOrganization.localOrganizationId,
       userId: auth.user.localUserId,
@@ -135,7 +149,10 @@ export async function saveProviderCredentialAction(
     const message = error instanceof Error ? error.message : "Unable to validate the credential.";
 
     return {
-      error: message,
+      error:
+        message === "forbidden"
+          ? "You do not have permission to update provider credentials."
+          : message,
     };
   }
 

--- a/apps/hyperlocalise-web/src/app/auth/onboarding/actions.ts
+++ b/apps/hyperlocalise-web/src/app/auth/onboarding/actions.ts
@@ -1,0 +1,184 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { z } from "zod";
+
+import { updateProviderCredentialBodySchema } from "@/api/routes/provider-credential/provider-credential.schema";
+import { createWorkspaceForSessionUser } from "@/lib/onboarding/workspace";
+import { loadOnboardingContext } from "@/lib/onboarding/context";
+import {
+  getOrganizationProviderCredentialSummary,
+  upsertOrganizationProviderCredential,
+} from "@/lib/providers/organization-provider-credentials";
+import { setStoredActiveOrganizationSlug } from "@/lib/workos/active-organization";
+import {
+  clearStoredOnboardingState,
+  setStoredOnboardingState,
+} from "@/lib/workos/onboarding-state";
+
+export type CreateWorkspaceActionState = {
+  error?: string;
+  fieldErrors?: {
+    organizationName?: string;
+  };
+};
+
+export type SaveProviderActionState = {
+  error?: string;
+  fieldErrors?: {
+    provider?: string;
+    apiKey?: string;
+    defaultModel?: string;
+  };
+};
+
+const createWorkspaceSchema = z.object({
+  organizationName: z.string().trim().min(2, "Workspace name must be at least 2 characters."),
+});
+
+function getOrganizationDashboardPath(slug: string | null | undefined) {
+  if (!slug) {
+    return "/auth/access-denied?reason=missing-org-slug";
+  }
+
+  return `/org/${slug}/dashboard`;
+}
+
+export async function createWorkspaceAction(
+  _previousState: CreateWorkspaceActionState,
+  formData: FormData,
+): Promise<CreateWorkspaceActionState> {
+  const parsed = createWorkspaceSchema.safeParse({
+    organizationName: formData.get("organizationName"),
+  });
+
+  if (!parsed.success) {
+    const issue = parsed.error.flatten().fieldErrors.organizationName?.[0];
+    return {
+      fieldErrors: {
+        organizationName: issue,
+      },
+    };
+  }
+
+  const { session, onboardingState, auth } = await loadOnboardingContext();
+
+  if (onboardingState?.organizationSlug) {
+    redirect("/auth/onboarding?step=provider");
+  }
+
+  if (auth?.activeOrganization.slug) {
+    redirect(getOrganizationDashboardPath(auth.activeOrganization.slug));
+  }
+
+  if (!session.user) {
+    redirect("/auth/sign-in?returnTo=/auth/onboarding");
+  }
+
+  const { organization } = await createWorkspaceForSessionUser({
+    sessionUser: session.user,
+    organizationName: parsed.data.organizationName,
+  });
+
+  if (!organization.slug) {
+    return {
+      error: "We created the workspace, but could not prepare its URL. Please retry.",
+    };
+  }
+
+  await setStoredActiveOrganizationSlug(organization.slug);
+  await setStoredOnboardingState({
+    organizationSlug: organization.slug,
+    providerSetupStatus: "pending",
+  });
+
+  redirect("/auth/onboarding?step=provider");
+}
+
+export async function saveProviderCredentialAction(
+  _previousState: SaveProviderActionState,
+  formData: FormData,
+): Promise<SaveProviderActionState> {
+  const parsed = updateProviderCredentialBodySchema.safeParse({
+    provider: formData.get("provider"),
+    apiKey: formData.get("apiKey"),
+    defaultModel: formData.get("defaultModel"),
+  });
+
+  if (!parsed.success) {
+    const flattened = parsed.error.flatten().fieldErrors;
+
+    return {
+      fieldErrors: {
+        provider: flattened.provider?.[0],
+        apiKey: flattened.apiKey?.[0],
+        defaultModel: flattened.defaultModel?.[0],
+      },
+    };
+  }
+
+  const { onboardingState, auth } = await loadOnboardingContext();
+
+  if (!onboardingState?.organizationSlug || !auth) {
+    redirect("/auth/onboarding");
+  }
+
+  try {
+    await upsertOrganizationProviderCredential({
+      organizationId: auth.activeOrganization.localOrganizationId,
+      userId: auth.user.localUserId,
+      provider: parsed.data.provider,
+      apiKey: parsed.data.apiKey,
+      defaultModel: parsed.data.defaultModel,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unable to validate the credential.";
+
+    return {
+      error: message,
+    };
+  }
+
+  await setStoredOnboardingState({
+    organizationSlug: onboardingState.organizationSlug,
+    providerSetupStatus: "configured",
+  });
+
+  redirect("/auth/onboarding?step=ready");
+}
+
+export async function skipProviderCredentialAction() {
+  const { onboardingState, auth } = await loadOnboardingContext();
+
+  if (!onboardingState?.organizationSlug || !auth) {
+    redirect("/auth/onboarding");
+  }
+
+  await setStoredOnboardingState({
+    organizationSlug: onboardingState.organizationSlug,
+    providerSetupStatus: "skipped",
+  });
+
+  redirect("/auth/onboarding?step=ready");
+}
+
+export async function finishOnboardingAction() {
+  const { onboardingState, auth } = await loadOnboardingContext();
+
+  if (!auth) {
+    redirect("/auth/onboarding");
+  }
+
+  if (onboardingState?.providerSetupStatus === "pending") {
+    const providerCredential = await getOrganizationProviderCredentialSummary(
+      auth.activeOrganization.localOrganizationId,
+    );
+
+    if (!providerCredential) {
+      redirect("/auth/onboarding?step=provider");
+    }
+  }
+
+  await clearStoredOnboardingState();
+  redirect(getOrganizationDashboardPath(auth.activeOrganization.slug));
+}

--- a/apps/hyperlocalise-web/src/app/auth/onboarding/page.tsx
+++ b/apps/hyperlocalise-web/src/app/auth/onboarding/page.tsx
@@ -1,0 +1,77 @@
+import { redirect } from "next/navigation";
+
+import { OnboardingWizard } from "@/app/auth/onboarding/_components/onboarding-wizard";
+import { loadOnboardingContext } from "@/lib/onboarding/context";
+import { getOrganizationProviderCredentialSummary } from "@/lib/providers/organization-provider-credentials";
+
+type Step = "create" | "provider" | "ready";
+
+function normalizeStep(value: string | string[] | undefined): Step | null {
+  const step = Array.isArray(value) ? value[0] : value;
+  if (step === "create" || step === "provider" || step === "ready") {
+    return step;
+  }
+
+  return null;
+}
+
+function getDashboardPath(slug: string | null | undefined) {
+  if (!slug) {
+    return "/auth/access-denied?reason=missing-org-slug";
+  }
+
+  return `/org/${slug}/dashboard`;
+}
+
+export default async function OnboardingPage({
+  searchParams,
+}: {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const params = searchParams ? await searchParams : {};
+  const requestedStep = normalizeStep(params.step);
+  const { onboardingState, auth } = await loadOnboardingContext();
+
+  if (!onboardingState) {
+    if (auth) {
+      redirect(getDashboardPath(auth.activeOrganization.slug));
+    }
+
+    return <OnboardingWizard step="create" />;
+  }
+
+  if (!auth || auth.activeOrganization.slug !== onboardingState.organizationSlug) {
+    redirect("/auth/onboarding");
+  }
+
+  const providerSummary = await getOrganizationProviderCredentialSummary(
+    auth.activeOrganization.localOrganizationId,
+  );
+  const maximumStep = providerSummary || onboardingState.providerSetupStatus !== "pending" ? 2 : 1;
+  const stepOrder: Step[] = ["create", "provider", "ready"];
+  const requestedStepIndex =
+    requestedStep === null ? maximumStep : stepOrder.findIndex((step) => step === requestedStep);
+  const safeStep = stepOrder[Math.min(requestedStepIndex, maximumStep)] ?? stepOrder[maximumStep];
+
+  if (!requestedStep || requestedStepIndex > maximumStep) {
+    redirect(`/auth/onboarding?step=${safeStep}`);
+  }
+
+  return (
+    <OnboardingWizard
+      step={safeStep}
+      organizationName={auth.activeOrganization.name}
+      organizationSlug={auth.activeOrganization.slug}
+      providerSummary={
+        providerSummary
+          ? {
+              provider: providerSummary.provider,
+              defaultModel: providerSummary.defaultModel,
+              maskedApiKeySuffix: providerSummary.maskedApiKeySuffix,
+            }
+          : null
+      }
+      providerSetupStatus={onboardingState.providerSetupStatus}
+    />
+  );
+}

--- a/apps/hyperlocalise-web/src/lib/database/schema.ts
+++ b/apps/hyperlocalise-web/src/lib/database/schema.ts
@@ -56,6 +56,13 @@ export const translationAssetStatusEnum = pgEnum("translation_asset_status", [
   "active",
   "archived",
 ]);
+export const llmProviderEnum = pgEnum("llm_provider", [
+  "openai",
+  "anthropic",
+  "gemini",
+  "groq",
+  "mistral",
+]);
 
 export const organizations = pgTable(
   "organizations",
@@ -479,6 +486,40 @@ export const translationProjectMemories = pgTable(
       table.translationMemoryId,
     ),
     index("idx_translation_project_memories_project_priority").on(table.projectId, table.priority),
+  ],
+);
+
+export const organizationLlmProviderCredentials = pgTable(
+  "organization_llm_provider_credentials",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organizationId: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    createdByUserId: uuid("created_by_user_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    updatedByUserId: uuid("updated_by_user_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    provider: llmProviderEnum("provider").notNull(),
+    defaultModel: text("default_model").notNull(),
+    maskedApiKeySuffix: text("masked_api_key_suffix").notNull(),
+    encryptionAlgorithm: text("encryption_algorithm").notNull(),
+    ciphertext: text("ciphertext").notNull(),
+    iv: text("iv").notNull(),
+    authTag: text("auth_tag").notNull(),
+    keyVersion: integer("key_version").notNull().default(1),
+    lastValidatedAt: timestamp("last_validated_at", { withTimezone: true }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow()
+      .$onUpdateFn(() => new Date()),
+  },
+  (table) => [
+    uniqueIndex("organization_llm_provider_credentials_org_key").on(table.organizationId),
+    index("idx_organization_llm_provider_credentials_updated_at").on(table.updatedAt),
   ],
 );
 

--- a/apps/hyperlocalise-web/src/lib/database/types.ts
+++ b/apps/hyperlocalise-web/src/lib/database/types.ts
@@ -1,4 +1,6 @@
 import type {
+  llmProviderEnum,
+  organizationLlmProviderCredentials,
   translationJobs,
   organizationMembershipRoleEnum,
   teamMembershipRoleEnum,
@@ -20,6 +22,11 @@ export type TranslationJobType = (typeof translationJobTypeEnum.enumValues)[numb
 export type TranslationJobStatus = (typeof translationJobStatusEnum.enumValues)[number];
 export type TranslationJobOutcomeKind = (typeof translationJobOutcomeKindEnum.enumValues)[number];
 export type OrganizationMembershipRole = (typeof organizationMembershipRoleEnum.enumValues)[number];
+export type LlmProvider = (typeof llmProviderEnum.enumValues)[number];
+export type OrganizationLlmProviderCredential =
+  typeof organizationLlmProviderCredentials.$inferSelect;
+export type NewOrganizationLlmProviderCredential =
+  typeof organizationLlmProviderCredentials.$inferInsert;
 export type Team = typeof teams.$inferSelect;
 export type NewTeam = typeof teams.$inferInsert;
 export type TeamMembership = typeof teamMemberships.$inferSelect;

--- a/apps/hyperlocalise-web/src/lib/env.ts
+++ b/apps/hyperlocalise-web/src/lib/env.ts
@@ -10,6 +10,7 @@ export const env = createEnv({
     NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
     DATABASE_URL: z.string().min(1),
     OPENAI_API_KEY: z.string().min(1).optional(),
+    PROVIDER_CREDENTIALS_MASTER_KEY: z.string().min(1),
     GITHUB_APP_WEBHOOK_SECRET: z.string().min(1).optional(),
     WORKOS_API_KEY: z.string().min(1).optional(),
     WORKOS_CLIENT_ID: z.string().min(1).optional(),
@@ -27,6 +28,9 @@ export const env = createEnv({
     NEXT_PUBLIC_APP_ENV: process.env.NEXT_PUBLIC_APP_ENV,
     DATABASE_URL: process.env.DATABASE_URL,
     OPENAI_API_KEY: process.env.OPENAI_API_KEY ?? (isTestEnv ? "test-openai-api-key" : undefined),
+    PROVIDER_CREDENTIALS_MASTER_KEY:
+      process.env.PROVIDER_CREDENTIALS_MASTER_KEY ??
+      (isTestEnv ? "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=" : undefined),
     GITHUB_APP_WEBHOOK_SECRET:
       process.env.GITHUB_APP_WEBHOOK_SECRET ??
       (isTestEnv ? "test-github-app-webhook-secret" : undefined),

--- a/apps/hyperlocalise-web/src/lib/onboarding/context.test.ts
+++ b/apps/hyperlocalise-web/src/lib/onboarding/context.test.ts
@@ -1,0 +1,60 @@
+import "dotenv/config";
+
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+const {
+  withAuthMock,
+  getStoredOnboardingStateMock,
+  clearStoredOnboardingStateMock,
+  resolveApiAuthContextFromSessionMock,
+} = vi.hoisted(() => ({
+  withAuthMock: vi.fn(),
+  getStoredOnboardingStateMock: vi.fn(),
+  clearStoredOnboardingStateMock: vi.fn(),
+  resolveApiAuthContextFromSessionMock: vi.fn(),
+}));
+
+vi.mock("@workos-inc/authkit-nextjs", () => ({
+  withAuth: withAuthMock,
+}));
+
+vi.mock("@/lib/workos/onboarding-state", () => ({
+  getStoredOnboardingState: getStoredOnboardingStateMock,
+  clearStoredOnboardingState: clearStoredOnboardingStateMock,
+}));
+
+vi.mock("@/api/auth/workos-session", () => ({
+  resolveApiAuthContextFromSession: resolveApiAuthContextFromSessionMock,
+}));
+
+describe("loadOnboardingContext", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("clears stale onboarding state when the stored org is no longer accessible", async () => {
+    const session = {
+      user: { id: "user_123", email: "person@example.com" },
+      organizationId: null,
+    };
+    withAuthMock.mockResolvedValue(session);
+    getStoredOnboardingStateMock.mockResolvedValue({
+      organizationSlug: "stale-org",
+      providerSetupStatus: "pending",
+    });
+    resolveApiAuthContextFromSessionMock.mockRejectedValue(new Error("organization_access_denied"));
+
+    const { loadOnboardingContext } = await import("./context");
+
+    await expect(loadOnboardingContext()).resolves.toEqual({
+      session,
+      onboardingState: null,
+      auth: null,
+    });
+    expect(resolveApiAuthContextFromSessionMock).toHaveBeenCalledWith({
+      session,
+      organizationSlug: "stale-org",
+    });
+    expect(clearStoredOnboardingStateMock).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/onboarding/context.ts
+++ b/apps/hyperlocalise-web/src/lib/onboarding/context.ts
@@ -1,0 +1,19 @@
+import { withAuth } from "@workos-inc/authkit-nextjs";
+
+import { resolveApiAuthContextFromSession } from "@/api/auth/workos-session";
+import { getStoredOnboardingState } from "@/lib/workos/onboarding-state";
+
+export async function loadOnboardingContext() {
+  const session = await withAuth({ ensureSignedIn: true });
+  const onboardingState = await getStoredOnboardingState();
+  const auth = await resolveApiAuthContextFromSession({
+    session,
+    organizationSlug: onboardingState?.organizationSlug,
+  });
+
+  return {
+    session,
+    onboardingState,
+    auth,
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/onboarding/context.ts
+++ b/apps/hyperlocalise-web/src/lib/onboarding/context.ts
@@ -1,15 +1,30 @@
 import { withAuth } from "@workos-inc/authkit-nextjs";
 
 import { resolveApiAuthContextFromSession } from "@/api/auth/workos-session";
-import { getStoredOnboardingState } from "@/lib/workos/onboarding-state";
+import {
+  clearStoredOnboardingState,
+  getStoredOnboardingState,
+} from "@/lib/workos/onboarding-state";
 
 export async function loadOnboardingContext() {
   const session = await withAuth({ ensureSignedIn: true });
-  const onboardingState = await getStoredOnboardingState();
-  const auth = await resolveApiAuthContextFromSession({
-    session,
-    organizationSlug: onboardingState?.organizationSlug,
-  });
+  let onboardingState = await getStoredOnboardingState();
+  let auth;
+
+  try {
+    auth = await resolveApiAuthContextFromSession({
+      session,
+      organizationSlug: onboardingState?.organizationSlug,
+    });
+  } catch (error) {
+    if (error instanceof Error && error.message === "organization_access_denied") {
+      await clearStoredOnboardingState();
+      onboardingState = null;
+      auth = null;
+    } else {
+      throw error;
+    }
+  }
 
   return {
     session,

--- a/apps/hyperlocalise-web/src/lib/onboarding/workspace.ts
+++ b/apps/hyperlocalise-web/src/lib/onboarding/workspace.ts
@@ -1,0 +1,86 @@
+import { randomUUID } from "node:crypto";
+
+import { eq } from "drizzle-orm";
+
+import { syncWorkosUser } from "@/api/auth/workos-sync";
+import { db, schema } from "@/lib/database";
+
+function slugifyOrganizationName(name: string) {
+  const normalized = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  return normalized || "workspace";
+}
+
+async function createUniqueOrganizationSlug(name: string) {
+  const baseSlug = slugifyOrganizationName(name);
+  let attempt = 0;
+
+  while (attempt < 100) {
+    const candidate = attempt === 0 ? baseSlug : `${baseSlug}-${attempt + 1}`;
+    const [existingOrganization] = await db
+      .select({ id: schema.organizations.id })
+      .from(schema.organizations)
+      .where(eq(schema.organizations.slug, candidate))
+      .limit(1);
+
+    if (!existingOrganization) {
+      return candidate;
+    }
+
+    attempt += 1;
+  }
+
+  return `${baseSlug}-${randomUUID().slice(0, 8)}`;
+}
+
+export async function createWorkspaceForSessionUser(input: {
+  sessionUser: {
+    id: string;
+    email: string;
+    firstName?: string | null;
+    lastName?: string | null;
+    profilePictureUrl?: string | null;
+  };
+  organizationName: string;
+}) {
+  const user = await syncWorkosUser(db, {
+    workosUserId: input.sessionUser.id,
+    email: input.sessionUser.email,
+    firstName: input.sessionUser.firstName ?? undefined,
+    lastName: input.sessionUser.lastName ?? undefined,
+    avatarUrl: input.sessionUser.profilePictureUrl ?? undefined,
+  });
+
+  return db.transaction(async (tx) => {
+    const slug = await createUniqueOrganizationSlug(input.organizationName);
+
+    const [organization] = await tx
+      .insert(schema.organizations)
+      .values({
+        workosOrganizationId: `local_org_${randomUUID()}`,
+        name: input.organizationName.trim(),
+        slug,
+      })
+      .returning({
+        id: schema.organizations.id,
+        name: schema.organizations.name,
+        slug: schema.organizations.slug,
+      });
+
+    await tx.insert(schema.organizationMemberships).values({
+      organizationId: organization.id,
+      userId: user.id,
+      role: "owner",
+      workosMembershipId: null,
+    });
+
+    return {
+      user,
+      organization,
+    };
+  });
+}

--- a/apps/hyperlocalise-web/src/lib/onboarding/workspace.ts
+++ b/apps/hyperlocalise-web/src/lib/onboarding/workspace.ts
@@ -15,13 +15,26 @@ function slugifyOrganizationName(name: string) {
   return normalized || "workspace";
 }
 
-async function createUniqueOrganizationSlug(name: string) {
+function isUniqueViolation(error: unknown) {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  if ("code" in error && error.code === "23505") {
+    return true;
+  }
+
+  const cause = "cause" in error ? error.cause : undefined;
+  return typeof cause === "object" && cause !== null && "code" in cause && cause.code === "23505";
+}
+
+async function createUniqueOrganizationSlug(name: string, dbHandle: Pick<typeof db, "select">) {
   const baseSlug = slugifyOrganizationName(name);
   let attempt = 0;
 
   while (attempt < 100) {
     const candidate = attempt === 0 ? baseSlug : `${baseSlug}-${attempt + 1}`;
-    const [existingOrganization] = await db
+    const [existingOrganization] = await dbHandle
       .select({ id: schema.organizations.id })
       .from(schema.organizations)
       .where(eq(schema.organizations.slug, candidate))
@@ -55,32 +68,44 @@ export async function createWorkspaceForSessionUser(input: {
     avatarUrl: input.sessionUser.profilePictureUrl ?? undefined,
   });
 
-  return db.transaction(async (tx) => {
-    const slug = await createUniqueOrganizationSlug(input.organizationName);
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      return await db.transaction(async (tx) => {
+        const slug = await createUniqueOrganizationSlug(input.organizationName, tx);
 
-    const [organization] = await tx
-      .insert(schema.organizations)
-      .values({
-        workosOrganizationId: `local_org_${randomUUID()}`,
-        name: input.organizationName.trim(),
-        slug,
-      })
-      .returning({
-        id: schema.organizations.id,
-        name: schema.organizations.name,
-        slug: schema.organizations.slug,
+        const [organization] = await tx
+          .insert(schema.organizations)
+          .values({
+            workosOrganizationId: `local_org_${randomUUID()}`,
+            name: input.organizationName.trim(),
+            slug,
+          })
+          .returning({
+            id: schema.organizations.id,
+            name: schema.organizations.name,
+            slug: schema.organizations.slug,
+          });
+
+        await tx.insert(schema.organizationMemberships).values({
+          organizationId: organization.id,
+          userId: user.id,
+          role: "owner",
+          workosMembershipId: null,
+        });
+
+        return {
+          user,
+          organization,
+        };
       });
+    } catch (error) {
+      if (isUniqueViolation(error)) {
+        continue;
+      }
 
-    await tx.insert(schema.organizationMemberships).values({
-      organizationId: organization.id,
-      userId: user.id,
-      role: "owner",
-      workosMembershipId: null,
-    });
+      throw error;
+    }
+  }
 
-    return {
-      user,
-      organization,
-    };
-  });
+  throw new Error("workspace_slug_conflict");
 }

--- a/apps/hyperlocalise-web/src/lib/providers/catalog.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/catalog.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+
+import type { LlmProvider } from "@/lib/database/types";
+
+export const curatedLlmProviders = [
+  "openai",
+  "anthropic",
+  "gemini",
+  "groq",
+  "mistral",
+] as const satisfies readonly LlmProvider[];
+
+export const llmProviderSchema = z.enum(curatedLlmProviders);
+
+export const llmProviderCatalog = {
+  openai: {
+    label: "OpenAI",
+    models: ["gpt-4.1-mini", "gpt-4.1", "gpt-4o-mini"],
+  },
+  anthropic: {
+    label: "Anthropic",
+    models: ["claude-3-5-haiku-20241022", "claude-3-7-sonnet-20250219"],
+  },
+  gemini: {
+    label: "Gemini",
+    models: ["gemini-2.0-flash", "gemini-2.5-flash-preview-04-17"],
+  },
+  groq: {
+    label: "Groq",
+    models: ["llama-3.1-8b-instant", "llama-3.3-70b-versatile"],
+  },
+  mistral: {
+    label: "Mistral",
+    models: ["mistral-small-latest", "mistral-large-latest"],
+  },
+} as const satisfies Record<LlmProvider, { label: string; models: readonly string[] }>;
+
+export const defaultModelByProvider = Object.fromEntries(
+  Object.entries(llmProviderCatalog).map(([provider, config]) => [provider, config.models[0]]),
+) as Record<LlmProvider, string>;
+
+export function isSupportedModelForProvider(provider: LlmProvider, model: string) {
+  return (llmProviderCatalog[provider].models as readonly string[]).includes(model);
+}

--- a/apps/hyperlocalise-web/src/lib/providers/organization-provider-credentials.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/organization-provider-credentials.ts
@@ -137,6 +137,7 @@ export async function revealOrganizationProviderCredential(input: {
     summary: summarizeCredential(credential),
     apiKey: decryptProviderCredential({
       algorithm: credential.encryptionAlgorithm,
+      keyVersion: credential.keyVersion,
       ciphertext: credential.ciphertext,
       iv: credential.iv,
       authTag: credential.authTag,

--- a/apps/hyperlocalise-web/src/lib/providers/organization-provider-credentials.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/organization-provider-credentials.ts
@@ -1,0 +1,192 @@
+import { and, eq } from "drizzle-orm";
+
+import { db, schema } from "@/lib/database";
+import type {
+  LlmProvider,
+  OrganizationLlmProviderCredential,
+  OrganizationMembershipRole,
+} from "@/lib/database/types";
+import { isSupportedModelForProvider } from "@/lib/providers/catalog";
+import { validateProviderCredential } from "@/lib/providers/validation";
+import {
+  decryptProviderCredential,
+  encryptProviderCredential,
+  maskProviderCredentialSuffix,
+} from "@/lib/security/provider-credential-crypto";
+
+export type OrganizationProviderCredentialSummary = {
+  organizationId: string;
+  provider: LlmProvider;
+  defaultModel: string;
+  maskedApiKeySuffix: string;
+  lastValidatedAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+function isProviderCredentialAdmin(role: OrganizationMembershipRole) {
+  return role === "owner" || role === "admin";
+}
+
+export function assertProviderCredentialAdmin(role: OrganizationMembershipRole) {
+  if (!isProviderCredentialAdmin(role)) {
+    throw new Error("forbidden");
+  }
+}
+
+async function getCredentialByOrganizationId(organizationId: string) {
+  const [credential] = await db
+    .select()
+    .from(schema.organizationLlmProviderCredentials)
+    .where(eq(schema.organizationLlmProviderCredentials.organizationId, organizationId))
+    .limit(1);
+
+  return credential ?? null;
+}
+
+export async function getOrganizationProviderCredentialSummary(organizationId: string) {
+  const credential = await getCredentialByOrganizationId(organizationId);
+
+  if (!credential) {
+    return null;
+  }
+
+  return summarizeCredential(credential);
+}
+
+function summarizeCredential(credential: OrganizationLlmProviderCredential) {
+  return {
+    organizationId: credential.organizationId,
+    provider: credential.provider,
+    defaultModel: credential.defaultModel,
+    maskedApiKeySuffix: credential.maskedApiKeySuffix,
+    lastValidatedAt: credential.lastValidatedAt,
+    createdAt: credential.createdAt,
+    updatedAt: credential.updatedAt,
+  } satisfies OrganizationProviderCredentialSummary;
+}
+
+export async function upsertOrganizationProviderCredential(input: {
+  organizationId: string;
+  userId: string;
+  provider: LlmProvider;
+  apiKey: string;
+  defaultModel: string;
+}) {
+  if (!isSupportedModelForProvider(input.provider, input.defaultModel)) {
+    throw new Error("unsupported_provider_model");
+  }
+
+  await validateProviderCredential({
+    provider: input.provider,
+    apiKey: input.apiKey,
+    model: input.defaultModel,
+  });
+
+  const now = new Date();
+  const encrypted = encryptProviderCredential(input.apiKey);
+  const [credential] = await db
+    .insert(schema.organizationLlmProviderCredentials)
+    .values({
+      organizationId: input.organizationId,
+      createdByUserId: input.userId,
+      updatedByUserId: input.userId,
+      provider: input.provider,
+      defaultModel: input.defaultModel,
+      maskedApiKeySuffix: maskProviderCredentialSuffix(input.apiKey),
+      encryptionAlgorithm: encrypted.algorithm,
+      ciphertext: encrypted.ciphertext,
+      iv: encrypted.iv,
+      authTag: encrypted.authTag,
+      keyVersion: encrypted.keyVersion,
+      lastValidatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: schema.organizationLlmProviderCredentials.organizationId,
+      set: {
+        updatedByUserId: input.userId,
+        provider: input.provider,
+        defaultModel: input.defaultModel,
+        maskedApiKeySuffix: maskProviderCredentialSuffix(input.apiKey),
+        encryptionAlgorithm: encrypted.algorithm,
+        ciphertext: encrypted.ciphertext,
+        iv: encrypted.iv,
+        authTag: encrypted.authTag,
+        keyVersion: encrypted.keyVersion,
+        lastValidatedAt: now,
+        updatedAt: now,
+      },
+    })
+    .returning();
+
+  return summarizeCredential(credential);
+}
+
+export async function revealOrganizationProviderCredential(input: {
+  organizationId: string;
+  role: OrganizationMembershipRole;
+}) {
+  assertProviderCredentialAdmin(input.role);
+
+  const credential = await getCredentialByOrganizationId(input.organizationId);
+  if (!credential) {
+    return null;
+  }
+
+  return {
+    summary: summarizeCredential(credential),
+    apiKey: decryptProviderCredential({
+      algorithm: credential.encryptionAlgorithm,
+      ciphertext: credential.ciphertext,
+      iv: credential.iv,
+      authTag: credential.authTag,
+    }),
+  };
+}
+
+export async function deleteOrganizationProviderCredential(input: {
+  organizationId: string;
+  role: OrganizationMembershipRole;
+}) {
+  assertProviderCredentialAdmin(input.role);
+
+  const deleted = await db
+    .delete(schema.organizationLlmProviderCredentials)
+    .where(eq(schema.organizationLlmProviderCredentials.organizationId, input.organizationId))
+    .returning({ id: schema.organizationLlmProviderCredentials.id });
+
+  return deleted.length > 0;
+}
+
+export async function getOrganizationProviderCredentialBySlugAndUser(input: {
+  organizationSlug: string;
+  localUserId: string;
+}) {
+  const [credential] = await db
+    .select({
+      provider: schema.organizationLlmProviderCredentials.provider,
+      defaultModel: schema.organizationLlmProviderCredentials.defaultModel,
+      maskedApiKeySuffix: schema.organizationLlmProviderCredentials.maskedApiKeySuffix,
+      lastValidatedAt: schema.organizationLlmProviderCredentials.lastValidatedAt,
+      createdAt: schema.organizationLlmProviderCredentials.createdAt,
+      updatedAt: schema.organizationLlmProviderCredentials.updatedAt,
+      organizationId: schema.organizationLlmProviderCredentials.organizationId,
+      membershipRole: schema.organizationMemberships.role,
+    })
+    .from(schema.organizationLlmProviderCredentials)
+    .innerJoin(
+      schema.organizations,
+      eq(schema.organizationLlmProviderCredentials.organizationId, schema.organizations.id),
+    )
+    .innerJoin(
+      schema.organizationMemberships,
+      and(
+        eq(schema.organizationMemberships.organizationId, schema.organizations.id),
+        eq(schema.organizationMemberships.userId, input.localUserId),
+      ),
+    )
+    .where(eq(schema.organizations.slug, input.organizationSlug))
+    .limit(1);
+
+  return credential ?? null;
+}

--- a/apps/hyperlocalise-web/src/lib/providers/validation.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/validation.ts
@@ -1,0 +1,106 @@
+import type { LlmProvider } from "@/lib/database/types";
+
+const validationPrompt = "ping";
+
+function createValidationError(message: string) {
+  const error = new Error(message);
+  error.name = "ProviderCredentialValidationError";
+  return error;
+}
+
+async function parseProviderError(response: Response) {
+  const bodyText = await response.text();
+
+  try {
+    const parsed = JSON.parse(bodyText) as {
+      error?: { message?: string } | string;
+      message?: string;
+    };
+
+    if (typeof parsed.error === "string") {
+      return parsed.error;
+    }
+
+    if (parsed.error && typeof parsed.error === "object" && parsed.error.message) {
+      return parsed.error.message;
+    }
+
+    if (parsed.message) {
+      return parsed.message;
+    }
+  } catch {}
+
+  return bodyText.trim() || `provider request failed with status ${response.status}`;
+}
+
+async function validateOpenAiCompatibleProvider(input: {
+  apiKey: string;
+  model: string;
+  provider: "openai" | "gemini" | "groq" | "mistral";
+}) {
+  const baseUrlByProvider = {
+    openai: "https://api.openai.com/v1/chat/completions",
+    gemini: "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions",
+    groq: "https://api.groq.com/openai/v1/chat/completions",
+    mistral: "https://api.mistral.ai/v1/chat/completions",
+  } as const;
+
+  const response = await fetch(baseUrlByProvider[input.provider], {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${input.apiKey}`,
+    },
+    body: JSON.stringify({
+      model: input.model,
+      messages: [{ role: "user", content: validationPrompt }],
+      max_tokens: 1,
+    }),
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  if (!response.ok) {
+    throw createValidationError(await parseProviderError(response));
+  }
+}
+
+async function validateAnthropicProvider(input: { apiKey: string; model: string }) {
+  const response = await fetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-api-key": input.apiKey,
+      "anthropic-version": "2023-06-01",
+    },
+    body: JSON.stringify({
+      model: input.model,
+      max_tokens: 1,
+      messages: [{ role: "user", content: validationPrompt }],
+    }),
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  if (!response.ok) {
+    throw createValidationError(await parseProviderError(response));
+  }
+}
+
+export async function validateProviderCredential(input: {
+  provider: LlmProvider;
+  apiKey: string;
+  model: string;
+}) {
+  switch (input.provider) {
+    case "anthropic":
+      return validateAnthropicProvider(input);
+    case "gemini":
+    case "groq":
+    case "mistral":
+    case "openai":
+      return validateOpenAiCompatibleProvider({
+        provider: input.provider,
+        apiKey: input.apiKey,
+        model: input.model,
+      });
+  }
+}

--- a/apps/hyperlocalise-web/src/lib/security/provider-credential-crypto.ts
+++ b/apps/hyperlocalise-web/src/lib/security/provider-credential-crypto.ts
@@ -17,14 +17,14 @@ function parseMasterKey(input: string) {
     return base64Buffer;
   }
 
-  if (trimmed.length === 32) {
-    return Buffer.from(trimmed, "utf8");
-  }
-
   throw new Error("invalid_provider_credentials_master_key");
 }
 
-function getMasterKey() {
+function getMasterKey(keyVersion = currentKeyVersion) {
+  if (keyVersion !== currentKeyVersion) {
+    throw new Error("unsupported_provider_credential_key_version");
+  }
+
   const key = parseMasterKey(env.PROVIDER_CREDENTIALS_MASTER_KEY);
   if (key.length !== 32) {
     throw new Error("invalid_provider_credentials_master_key");
@@ -50,6 +50,7 @@ export function encryptProviderCredential(plaintext: string) {
 
 export function decryptProviderCredential(input: {
   algorithm: string;
+  keyVersion: number;
   ciphertext: string;
   iv: string;
   authTag: string;
@@ -60,7 +61,7 @@ export function decryptProviderCredential(input: {
 
   const decipher = createDecipheriv(
     input.algorithm,
-    getMasterKey(),
+    getMasterKey(input.keyVersion),
     Buffer.from(input.iv, "base64"),
   );
   decipher.setAuthTag(Buffer.from(input.authTag, "base64"));

--- a/apps/hyperlocalise-web/src/lib/security/provider-credential-crypto.ts
+++ b/apps/hyperlocalise-web/src/lib/security/provider-credential-crypto.ts
@@ -1,0 +1,76 @@
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+
+import { env } from "@/lib/env";
+
+const encryptionAlgorithm = "aes-256-gcm";
+const currentKeyVersion = 1;
+
+function parseMasterKey(input: string) {
+  const trimmed = input.trim();
+
+  if (/^[0-9a-fA-F]{64}$/.test(trimmed)) {
+    return Buffer.from(trimmed, "hex");
+  }
+
+  const base64Buffer = Buffer.from(trimmed, "base64");
+  if (base64Buffer.length === 32 && base64Buffer.toString("base64") === trimmed) {
+    return base64Buffer;
+  }
+
+  if (trimmed.length === 32) {
+    return Buffer.from(trimmed, "utf8");
+  }
+
+  throw new Error("invalid_provider_credentials_master_key");
+}
+
+function getMasterKey() {
+  const key = parseMasterKey(env.PROVIDER_CREDENTIALS_MASTER_KEY);
+  if (key.length !== 32) {
+    throw new Error("invalid_provider_credentials_master_key");
+  }
+
+  return key;
+}
+
+export function encryptProviderCredential(plaintext: string) {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv(encryptionAlgorithm, getMasterKey(), iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+
+  return {
+    algorithm: encryptionAlgorithm,
+    keyVersion: currentKeyVersion,
+    ciphertext: ciphertext.toString("base64"),
+    iv: iv.toString("base64"),
+    authTag: authTag.toString("base64"),
+  };
+}
+
+export function decryptProviderCredential(input: {
+  algorithm: string;
+  ciphertext: string;
+  iv: string;
+  authTag: string;
+}) {
+  if (input.algorithm !== encryptionAlgorithm) {
+    throw new Error("unsupported_provider_credential_algorithm");
+  }
+
+  const decipher = createDecipheriv(
+    input.algorithm,
+    getMasterKey(),
+    Buffer.from(input.iv, "base64"),
+  );
+  decipher.setAuthTag(Buffer.from(input.authTag, "base64"));
+
+  return Buffer.concat([
+    decipher.update(Buffer.from(input.ciphertext, "base64")),
+    decipher.final(),
+  ]).toString("utf8");
+}
+
+export function maskProviderCredentialSuffix(secret: string) {
+  return secret.slice(-4).padStart(4, "•");
+}

--- a/apps/hyperlocalise-web/src/lib/workos/app-auth.test.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/app-auth.test.ts
@@ -59,4 +59,19 @@ describe("requireAppAuthContext", () => {
       session,
     });
   });
+
+  it("redirects to onboarding when the signed-in user has no memberships yet", async () => {
+    const session = {
+      user: { id: "user_123", email: "person@example.com" },
+      organizationId: null,
+    };
+    withAuthMock.mockResolvedValue(session);
+    getStoredActiveOrganizationSlugMock.mockResolvedValue(null);
+    resolveApiAuthContextFromSessionMock.mockResolvedValue(null);
+
+    const { requireAppAuthContext } = await import("./app-auth");
+
+    await expect(requireAppAuthContext()).rejects.toThrow("redirect:/auth/onboarding");
+    expect(redirectMock).toHaveBeenCalledWith("/auth/onboarding");
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/workos/app-auth.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/app-auth.ts
@@ -28,7 +28,7 @@ export async function requireAppAuthContext(options: { organizationSlug?: string
   }
 
   if (!auth) {
-    redirect("/auth/access-denied?reason=no-memberships");
+    redirect("/auth/onboarding");
   }
 
   return {

--- a/apps/hyperlocalise-web/src/lib/workos/onboarding-state.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/onboarding-state.ts
@@ -1,11 +1,14 @@
 import { cookies } from "next/headers";
+import { z } from "zod";
 
 export const onboardingStateCookieName = "hl_onboarding_state";
 
-export type OnboardingState = {
-  organizationSlug: string;
-  providerSetupStatus: "pending" | "configured" | "skipped";
-};
+const onboardingStateSchema = z.object({
+  organizationSlug: z.string().min(1),
+  providerSetupStatus: z.enum(["pending", "configured", "skipped"]),
+});
+
+export type OnboardingState = z.infer<typeof onboardingStateSchema>;
 
 export async function getStoredOnboardingState(): Promise<OnboardingState | null> {
   const rawValue = (await cookies()).get(onboardingStateCookieName)?.value;
@@ -14,7 +17,7 @@ export async function getStoredOnboardingState(): Promise<OnboardingState | null
   }
 
   try {
-    return JSON.parse(rawValue) as OnboardingState;
+    return onboardingStateSchema.parse(JSON.parse(rawValue));
   } catch {
     return null;
   }

--- a/apps/hyperlocalise-web/src/lib/workos/onboarding-state.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/onboarding-state.ts
@@ -1,0 +1,35 @@
+import { cookies } from "next/headers";
+
+export const onboardingStateCookieName = "hl_onboarding_state";
+
+export type OnboardingState = {
+  organizationSlug: string;
+  providerSetupStatus: "pending" | "configured" | "skipped";
+};
+
+export async function getStoredOnboardingState(): Promise<OnboardingState | null> {
+  const rawValue = (await cookies()).get(onboardingStateCookieName)?.value;
+  if (!rawValue) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(rawValue) as OnboardingState;
+  } catch {
+    return null;
+  }
+}
+
+export async function setStoredOnboardingState(state: OnboardingState) {
+  (await cookies()).set(onboardingStateCookieName, JSON.stringify(state), {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: 60 * 60,
+  });
+}
+
+export async function clearStoredOnboardingState() {
+  (await cookies()).delete(onboardingStateCookieName);
+}


### PR DESCRIPTION
## What changed

- Added a dedicated zero-org onboarding wizard for signed-in users who do not yet belong to an organization.
- Changed auth flow so zero-membership users go to onboarding instead of the access-denied page.
- Added org-scoped AI provider credential storage with encrypted-at-rest API keys in Postgres.
- Added provider validation, provider credential APIs, onboarding state handling, and the initial migration/schema updates needed to support the flow.

## How to test

- Run `make fmt`
- Run `make lint`
- Run `make test`
- In `apps/hyperlocalise-web`, run `vp check --fix`
- In `apps/hyperlocalise-web`, run `vp test`
- Manually verify:
  - sign in as a user with no org memberships and confirm you land on `/auth/onboarding`
  - create a workspace and confirm the flow advances to the provider step
  - save a valid provider key/model and confirm the flow reaches the ready step
  - skip provider setup and confirm the flow still reaches the ready step
  - confirm later org members without admin privileges cannot manage or reveal provider credentials

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
