### PR TITLE
docs(docs): use distinct icons for global anchors

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -12,15 +12,18 @@
       "anchors": [
         {
           "anchor": "Hyperlocalise Cloud",
-          "href": "https://hyperlocalise.com"
+          "href": "https://hyperlocalise.com",
+          "icon": "cloud"
         },
         {
           "anchor": "GitHub",
-          "href": "https://github.com/hyperlocalise/hyperlocalise"
+          "href": "https://github.com/hyperlocalise/hyperlocalise",
+          "icon": "github"
         },
         {
           "anchor": "Issues",
-          "href": "https://github.com/hyperlocalise/hyperlocalise/issues"
+          "href": "https://github.com/hyperlocalise/hyperlocalise/issues",
+          "icon": "circle-exclamation"
         }
       ]
     },


### PR DESCRIPTION
### Motivation
- Improve clarity and visual distinction for the documentation site's global external links by assigning unique icons to each anchor.

### Description
- Added `icon` fields in `docs/docs.json` for the global `anchors`: `cloud` for Hyperlocalise Cloud, `github` for GitHub, and `circle-exclamation` for Issues.

### Testing
- Ran `make fmt` which succeeded; `make lint` failed because `/root/go/bin/golangci-lint` is missing; `make test` failed due to a Go toolchain version mismatch (`go1.26.0` vs `go1.25.1`), and `vp test` / `vp check --fix` were not run because `vp` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e40cbb8ab0832c8201decaa6fab3bc)