### PR TITLE
refactor(web): switch GitHub chat state to Postgres adapter

### DIFF
--- a/apps/hyperlocalise-web/package.json
+++ b/apps/hyperlocalise-web/package.json
@@ -15,7 +15,7 @@
     "@base-ui/react": "1.4.1",
     "@chat-adapter/github": "^4.15.0",
     "@chat-adapter/state-memory": "^4.15.0",
-    "@chat-adapter/state-redis": "^4.15.0",
+    "@chat-adapter/state-pg": "^4.15.0",
     "@hookform/resolvers": "5.2.2",
     "@hugeicons/core-free-icons": "4.1.1",
     "@hugeicons/react": "1.1.6",

--- a/apps/hyperlocalise-web/pnpm-lock.yaml
+++ b/apps/hyperlocalise-web/pnpm-lock.yaml
@@ -24,9 +24,9 @@ importers:
       '@chat-adapter/state-memory':
         specifier: ^4.15.0
         version: 4.26.0
-      '@chat-adapter/state-redis':
+      '@chat-adapter/state-pg':
         specifier: ^4.15.0
-        version: 4.26.0(@opentelemetry/api@1.9.1)
+        version: 4.26.0
       '@hookform/resolvers':
         specifier: 5.2.2
         version: 5.2.2(react-hook-form@7.73.1(react@19.2.5))
@@ -523,8 +523,8 @@ packages:
   '@chat-adapter/state-memory@4.26.0':
     resolution: {integrity: sha512-FsfyM/A9Bf1yFc1FWmOsK+a4YVwm5FogX25hZxFG6cEvyFb6Cd924SsbtvF06yItY/7J2UFetCsMmBPkdPKshQ==}
 
-  '@chat-adapter/state-redis@4.26.0':
-    resolution: {integrity: sha512-NSX2E6wkDlg0AMfKFx4LPoV6cBHolL08Ht3cT+S01jss24t9GzlDw/BUsrWOeoTElwEhxZcQw5bUkStUAA7JMg==}
+  '@chat-adapter/state-pg@4.26.0':
+    resolution: {integrity: sha512-YnLDURfimQfZx7qeqoN2IdFpOH0xk4DUQcIDvNNnsgId6z40Lh4CyJqoZpiHE+y8EHAy3kJf43plWfxJVuB50A==}
 
   '@clack/core@1.0.1':
     resolution: {integrity: sha512-WKeyK3NOBwDOzagPR5H08rFk9D/WuN705yEbuZvKqlkmoLM2woKtXb10OO2k1NoSU4SFG947i2/SCYh+2u5e4g==}
@@ -2216,42 +2216,6 @@ packages:
       '@types/react':
         optional: true
 
-  '@redis/bloom@5.12.1':
-    resolution: {integrity: sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA==}
-    engines: {node: '>= 18.19.0'}
-    peerDependencies:
-      '@redis/client': ^5.12.1
-
-  '@redis/client@5.12.1':
-    resolution: {integrity: sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==}
-    engines: {node: '>= 18.19.0'}
-    peerDependencies:
-      '@node-rs/xxhash': ^1.1.0
-      '@opentelemetry/api': '>=1 <2'
-    peerDependenciesMeta:
-      '@node-rs/xxhash':
-        optional: true
-      '@opentelemetry/api':
-        optional: true
-
-  '@redis/json@5.12.1':
-    resolution: {integrity: sha512-eOze75esLve4vfqDel7aMX08CNaiLLQS2fV8mpRN9NxPe1rVR4vQyYiW/OgtGUysF6QOr9ANhfxABKNOJfXdKg==}
-    engines: {node: '>= 18.19.0'}
-    peerDependencies:
-      '@redis/client': ^5.12.1
-
-  '@redis/search@5.12.1':
-    resolution: {integrity: sha512-ItlxbxC9cKI6IU1TLWoczwJCRb6TdmkEpWv05UrPawqaAnWGRu3rcIqsc5vN483T2fSociuyV1UkWIL5I4//2w==}
-    engines: {node: '>= 18.19.0'}
-    peerDependencies:
-      '@redis/client': ^5.12.1
-
-  '@redis/time-series@5.12.1':
-    resolution: {integrity: sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ==}
-    engines: {node: '>= 18.19.0'}
-    peerDependencies:
-      '@redis/client': ^5.12.1
-
   '@reduxjs/toolkit@2.11.2':
     resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
     peerDependencies:
@@ -3628,10 +3592,6 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
-
-  cluster-key-slot@1.1.2:
-    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
-    engines: {node: '>=0.10.0'}
 
   cmdk@1.1.1:
     resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
@@ -5573,10 +5533,6 @@ packages:
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  redis@5.12.1:
-    resolution: {integrity: sha512-LDsoVvb/CpoV9EN3FXvgvSHNJWuCIzl9MiO3ppOevuGLpSGJhwfQjpEwfFJcQvNSddHADDdZaWx0HnmMxRXG7g==}
-    engines: {node: '>= 18.19.0'}
-
   redux-thunk@3.1.0:
     resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
     peerDependencies:
@@ -6961,13 +6917,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@chat-adapter/state-redis@4.26.0(@opentelemetry/api@1.9.1)':
+  '@chat-adapter/state-pg@4.26.0':
     dependencies:
       chat: 4.26.0
-      redis: 5.12.1(@opentelemetry/api@1.9.1)
+      pg: 8.20.0
     transitivePeerDependencies:
-      - '@node-rs/xxhash'
-      - '@opentelemetry/api'
+      - pg-native
       - supports-color
 
   '@clack/core@1.0.1':
@@ -8215,28 +8170,6 @@ snapshots:
       react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
-
-  '@redis/bloom@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))':
-    dependencies:
-      '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
-
-  '@redis/client@5.12.1(@opentelemetry/api@1.9.1)':
-    dependencies:
-      cluster-key-slot: 1.1.2
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-
-  '@redis/json@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))':
-    dependencies:
-      '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
-
-  '@redis/search@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))':
-    dependencies:
-      '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
-
-  '@redis/time-series@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))':
-    dependencies:
-      '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
 
   '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.5)(redux@5.0.1))(react@19.2.5)':
     dependencies:
@@ -9726,8 +9659,6 @@ snapshots:
     optional: true
 
   clsx@2.1.1: {}
-
-  cluster-key-slot@1.1.2: {}
 
   cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
@@ -11721,17 +11652,6 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
       - redux
-
-  redis@5.12.1(@opentelemetry/api@1.9.1):
-    dependencies:
-      '@redis/bloom': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))
-      '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
-      '@redis/json': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))
-      '@redis/search': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))
-      '@redis/time-series': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))
-    transitivePeerDependencies:
-      - '@node-rs/xxhash'
-      - '@opentelemetry/api'
 
   redux-thunk@3.1.0(redux@5.0.1):
     dependencies:

--- a/apps/hyperlocalise-web/src/lib/chat-state.ts
+++ b/apps/hyperlocalise-web/src/lib/chat-state.ts
@@ -1,0 +1,30 @@
+import { createMemoryState } from "@chat-adapter/state-memory";
+
+import { env } from "@/lib/env";
+
+type ChatStateAdapter = ReturnType<typeof createMemoryState>;
+
+type PostgresStateFactory = (options: { connectionString: string }) => ChatStateAdapter;
+
+export function createChatStateAdapter(): ChatStateAdapter {
+  if (!env.CHAT_STATE_DATABASE_URL) {
+    return createMemoryState();
+  }
+
+  let createPostgresState: PostgresStateFactory;
+
+  try {
+    ({ createPostgresState } = require("@chat-adapter/state-pg") as {
+      createPostgresState: PostgresStateFactory;
+    });
+  } catch (err) {
+    if (err instanceof Error && (err as NodeJS.ErrnoException).code === "MODULE_NOT_FOUND") {
+      throw new Error(
+        "CHAT_STATE_DATABASE_URL is set but @chat-adapter/state-pg is not installed. Add @chat-adapter/state-pg to dependencies.",
+      );
+    }
+    throw err;
+  }
+
+  return createPostgresState({ connectionString: env.CHAT_STATE_DATABASE_URL });
+}

--- a/apps/hyperlocalise-web/src/lib/email-bot.ts
+++ b/apps/hyperlocalise-web/src/lib/email-bot.ts
@@ -1,10 +1,9 @@
-import { createMemoryState } from "@chat-adapter/state-memory";
-import { createRedisState } from "@chat-adapter/state-redis";
 import { eq, sql } from "drizzle-orm";
 import { Chat } from "chat";
 import type { Message, Thread } from "chat";
 import { Resend } from "resend";
 
+import { createChatStateAdapter } from "@/lib/chat-state";
 import { db, schema } from "@/lib/database";
 import { env } from "@/lib/env";
 import { regenerateImageFromAttachment } from "@/lib/image-generation";
@@ -23,10 +22,6 @@ type EmailBotState = {
 let botInstance: Chat<{ resend: ReturnType<typeof createResendAdapter> }, EmailBotState> | null =
   null;
 let botQueue: EmailTranslationQueue | null = null;
-
-function createStateAdapter() {
-  return env.REDIS_URL ? createRedisState({ url: env.REDIS_URL }) : createMemoryState();
-}
 
 function parseLocales(text: string): { sourceLocale: string | null; targetLocale: string | null } {
   const patterns = [
@@ -264,7 +259,7 @@ export async function getEmailBot(options?: { emailTranslationQueue?: EmailTrans
       }),
     },
     logger: "info",
-    state: createStateAdapter(),
+    state: createChatStateAdapter(),
     userName: "hyperlocalise",
   });
 

--- a/apps/hyperlocalise-web/src/lib/env.ts
+++ b/apps/hyperlocalise-web/src/lib/env.ts
@@ -31,8 +31,8 @@ export const env = createEnv({
     /** Server-generated secret for signing OAuth `state` parameters during GitHub App installation. */
     GITHUB_OAUTH_STATE_SECRET: z.string().min(1).optional(),
 
-    /** Redis connection URL for caching, session state, or task queuing. Optional — falls back to in-memory adapters. */
-    REDIS_URL: z.url().optional(),
+    /** Postgres URL dedicated to chat state persistence. Optional — falls back to in-memory adapters. */
+    CHAT_STATE_DATABASE_URL: z.string().min(1).optional(),
 
     /** WorkOS API key for authentication and organization management. */
     WORKOS_API_KEY: z.string().min(1).optional(),
@@ -88,7 +88,7 @@ export const env = createEnv({
     GITHUB_OAUTH_STATE_SECRET:
       process.env.GITHUB_OAUTH_STATE_SECRET ??
       (isTestEnv ? "test-github-oauth-state-secret" : undefined),
-    REDIS_URL: process.env.REDIS_URL,
+    CHAT_STATE_DATABASE_URL: process.env.CHAT_STATE_DATABASE_URL,
     WORKOS_API_KEY: process.env.WORKOS_API_KEY ?? (isTestEnv ? "test-workos-api-key" : undefined),
     WORKOS_CLIENT_ID: process.env.WORKOS_CLIENT_ID ?? (isTestEnv ? "client_test" : undefined),
     WORKOS_REDIRECT_URI:

--- a/apps/hyperlocalise-web/src/lib/github-bot.ts
+++ b/apps/hyperlocalise-web/src/lib/github-bot.ts
@@ -1,9 +1,9 @@
 import type { GitHubAdapter, GitHubRawMessage } from "@chat-adapter/github";
 import { createGitHubAdapter } from "@chat-adapter/github";
-import { createMemoryState } from "@chat-adapter/state-memory";
 import { Chat, emoji } from "chat";
 import type { Message, Thread } from "chat";
 
+import { createChatStateAdapter } from "@/lib/chat-state";
 import { env } from "@/lib/env";
 import type { GitHubFixRequestedEventData, GitHubFixQueue } from "@/lib/workflow/types";
 
@@ -23,26 +23,6 @@ type GitHubBotState = {
 let botInstance: Chat<{ github: ReturnType<typeof createGitHubAdapter> }, GitHubBotState> | null =
   null;
 let botQueue: GitHubFixQueue | null = null;
-
-function createStateAdapter() {
-  if (!env.CHAT_STATE_DATABASE_URL) {
-    return createMemoryState();
-  }
-
-  try {
-    const { createPostgresState } = require("@chat-adapter/state-pg") as {
-      createPostgresState: (options: {
-        connectionString: string;
-      }) => ReturnType<typeof createMemoryState>;
-    };
-
-    return createPostgresState({ connectionString: env.CHAT_STATE_DATABASE_URL });
-  } catch {
-    throw new Error(
-      "CHAT_STATE_DATABASE_URL is set but @chat-adapter/state-pg is not installed. Add @chat-adapter/state-pg to dependencies.",
-    );
-  }
-}
 
 function parseFixCommand(text: string): HyperlocaliseFixCommand | null {
   const mentionIndex = text.toLowerCase().indexOf("@hyperlocalise");
@@ -182,7 +162,7 @@ export async function getGitHubBot(options: GitHubBotOptions) {
       }),
     },
     logger: "info",
-    state: createStateAdapter(),
+    state: createChatStateAdapter(),
     userName: "hyperlocalise",
   });
 

--- a/apps/hyperlocalise-web/src/lib/github-bot.ts
+++ b/apps/hyperlocalise-web/src/lib/github-bot.ts
@@ -1,7 +1,6 @@
 import type { GitHubAdapter, GitHubRawMessage } from "@chat-adapter/github";
 import { createGitHubAdapter } from "@chat-adapter/github";
 import { createMemoryState } from "@chat-adapter/state-memory";
-import { createRedisState } from "@chat-adapter/state-redis";
 import { Chat, emoji } from "chat";
 import type { Message, Thread } from "chat";
 
@@ -26,7 +25,23 @@ let botInstance: Chat<{ github: ReturnType<typeof createGitHubAdapter> }, GitHub
 let botQueue: GitHubFixQueue | null = null;
 
 function createStateAdapter() {
-  return env.REDIS_URL ? createRedisState({ url: env.REDIS_URL }) : createMemoryState();
+  if (!env.CHAT_STATE_DATABASE_URL) {
+    return createMemoryState();
+  }
+
+  try {
+    const { createPostgresState } = require("@chat-adapter/state-pg") as {
+      createPostgresState: (options: {
+        connectionString: string;
+      }) => ReturnType<typeof createMemoryState>;
+    };
+
+    return createPostgresState({ connectionString: env.CHAT_STATE_DATABASE_URL });
+  } catch {
+    throw new Error(
+      "CHAT_STATE_DATABASE_URL is set but @chat-adapter/state-pg is not installed. Add @chat-adapter/state-pg to dependencies.",
+    );
+  }
 }
 
 function parseFixCommand(text: string): HyperlocaliseFixCommand | null {


### PR DESCRIPTION
### Motivation
- Replace the Redis-backed chat state used by the GitHub bot with a Postgres-backed state adapter for durable, centralized chat state persistence. 
- Use a separate environment variable for chat state so the application can use a different DB instance than the main app `DATABASE_URL`.

### Description
- Added a new server env `CHAT_STATE_DATABASE_URL` and wired it into the typed env in `apps/hyperlocalise-web/src/lib/env.ts`.
- Replaced the dependency reference to `@chat-adapter/state-redis` with `@chat-adapter/state-pg` in `apps/hyperlocalise-web/package.json`.
- Switched runtime wiring in `apps/hyperlocalise-web/src/lib/github-bot.ts` to use `createPostgresState` when `CHAT_STATE_DATABASE_URL` is set, while preserving an in-memory fallback when it is not.
- Implemented a lazy `require()` and a clear runtime error when `CHAT_STATE_DATABASE_URL` is provided but `@chat-adapter/state-pg` is not installed to avoid type-time install issues in restricted environments.

### Testing
- Ran `make fmt` which completed successfully.
- Ran `cd apps/hyperlocalise-web && pnpm exec vp check --fix` which passed with no type/lint errors after the changes.
- Running `cd apps/hyperlocalise-web && pnpm exec vp test` initially failed because `DATABASE_URL` was not set in the environment, and when re-run with `DATABASE_URL=postgres://localhost:5432/test` the test suite failed due to no local Postgres instance available (`ECONNREFUSED`).
- `make lint` and top-level `make test` could not complete successfully in this sandbox due to bootstrap/Go toolchain and tooling installation issues (forbidden fetchs and version mismatch).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8e0e6cee0832c913cbc4bdc2a6cb1)