### PR TITLE
feat(cli): add OpenAI image localization support

### DIFF
--- a/apps/cli/internal/i18n/runsvc/cache_key.go
+++ b/apps/cli/internal/i18n/runsvc/cache_key.go
@@ -22,13 +22,19 @@ func precomputeStableTaskCacheFields(task *Task) {
 		return
 	}
 
+	if isImageTask(*task) {
+		task.sourceTextHash = strings.TrimSpace(task.sourceFingerprint)
+		task.sourceContextFingerprint = sourceContextFingerprint(Task{})
+		return
+	}
+
 	task.sourceTextHash = hashSourceText(normalizeSourceForCache(task.SourceText))
 	task.sourceContextFingerprint = sourceContextFingerprint(*task)
 }
 
 func lockTaskHash(task Task) string {
 	precomputeStableTaskCacheFields(&task)
-	canonical := strings.Join([]string{
+	parts := []string{
 		"source_norm_hash=" + task.sourceTextHash,
 		"source_locale=" + strings.TrimSpace(task.SourceLocale),
 		"target_locale=" + strings.TrimSpace(task.TargetLocale),
@@ -41,7 +47,14 @@ func lockTaskHash(task Task) string {
 		"context_key=" + strings.TrimSpace(task.ContextKey),
 		"context_provider=" + strings.TrimSpace(task.ContextProvider),
 		"context_model=" + strings.TrimSpace(task.ContextModel),
-	}, "\n")
+	}
+	if isImageTask(task) {
+		parts = append(parts,
+			"task_kind="+strings.TrimSpace(task.Kind),
+			"output_format="+strings.TrimSpace(task.OutputFormat),
+		)
+	}
+	canonical := strings.Join(parts, "\n")
 	return lockStoredFingerprint(canonical)
 }
 
@@ -54,7 +67,7 @@ func legacyDefaultRetrievalSnapshot() string {
 
 func legacyDefaultLockTaskHash(task Task) string {
 	precomputeStableTaskCacheFields(&task)
-	canonical := strings.Join([]string{
+	parts := []string{
 		"source_norm_hash=" + task.sourceTextHash,
 		"source_locale=" + strings.TrimSpace(task.SourceLocale),
 		"target_locale=" + strings.TrimSpace(task.TargetLocale),
@@ -69,6 +82,13 @@ func legacyDefaultLockTaskHash(task Task) string {
 		"context_key=" + strings.TrimSpace(task.ContextKey),
 		"context_provider=" + strings.TrimSpace(task.ContextProvider),
 		"context_model=" + strings.TrimSpace(task.ContextModel),
-	}, "\n")
+	}
+	if isImageTask(task) {
+		parts = append(parts,
+			"task_kind="+strings.TrimSpace(task.Kind),
+			"output_format="+strings.TrimSpace(task.OutputFormat),
+		)
+	}
+	canonical := strings.Join(parts, "\n")
 	return lockStoredFingerprint(canonical)
 }

--- a/apps/cli/internal/i18n/runsvc/executor.go
+++ b/apps/cli/internal/i18n/runsvc/executor.go
@@ -45,6 +45,8 @@ type stagedOutput struct {
 	sourcePath   string
 	sourceLocale string
 	targetLocale string
+	binary       []byte
+	binaryOutput bool
 }
 
 type executorState struct {
@@ -82,7 +84,8 @@ func newExecutorState(tasks []Task, initialStaged map[string]stagedOutput, prune
 	for targetPath, output := range initialStaged {
 		entries := map[string]string{}
 		maps.Copy(entries, output.entries)
-		staged[targetPath] = stagedOutput{entries: entries, sourcePath: output.sourcePath, sourceLocale: output.sourceLocale, targetLocale: output.targetLocale}
+		binary := append([]byte(nil), output.binary...)
+		staged[targetPath] = stagedOutput{entries: entries, sourcePath: output.sourcePath, sourceLocale: output.sourceLocale, targetLocale: output.targetLocale, binary: binary, binaryOutput: output.binaryOutput}
 	}
 
 	state := &executorState{
@@ -504,21 +507,44 @@ func (s *Service) processTask(ctx context.Context, task Task, completions chan<-
 		task.ContextMemory = s.resolveTaskContextMemory(ctx, task, state, emitter)
 	}
 	taskHash := lockTaskHash(task)
-	sourceHash := lockStoredFingerprint(task.SourceText)
-	translated, err := s.translateWithRetry(translator.WithUsageCollector(ctx, &usage), task)
-	if err != nil {
-		recordTaskFailure(&state.report, &state.reportMu, state.total, task, err, emitter)
-		markTargetFailed(task.TargetPath, &state.pendingMu, state.failedTargets, targetFailures, ctx)
-		return false
-	}
-	if err := stageTaskOutput(state.staged, task.TargetPath, task.SourcePath, task.SourceLocale, task.TargetLocale, task.EntryKey, translated, &state.stageMu); err != nil {
-		recordTaskFailure(&state.report, &state.reportMu, state.total, task, err, emitter)
-		markTargetFailed(task.TargetPath, &state.pendingMu, state.failedTargets, targetFailures, ctx)
-		return false
+	sourceHash := taskLockSourceHash(task)
+	var outputValue string
+	if isImageTask(task) {
+		sourceImage := task.sourceImage
+		if len(sourceImage) == 0 {
+			recordTaskFailure(&state.report, &state.reportMu, state.total, task, fmt.Errorf("read source image %q: empty image content", task.SourcePath), emitter)
+			markTargetFailed(task.TargetPath, &state.pendingMu, state.failedTargets, targetFailures, ctx)
+			return false
+		}
+		edited, err := s.editImage(translator.WithUsageCollector(ctx, &usage), buildImageEditRequest(task, sourceImage))
+		if err != nil {
+			recordTaskFailure(&state.report, &state.reportMu, state.total, task, err, emitter)
+			markTargetFailed(task.TargetPath, &state.pendingMu, state.failedTargets, targetFailures, ctx)
+			return false
+		}
+		if err := stageImageOutput(state.staged, task.TargetPath, task.SourcePath, task.SourceLocale, task.TargetLocale, edited, &state.stageMu); err != nil {
+			recordTaskFailure(&state.report, &state.reportMu, state.total, task, err, emitter)
+			markTargetFailed(task.TargetPath, &state.pendingMu, state.failedTargets, targetFailures, ctx)
+			return false
+		}
+		outputValue = encodeImageCheckpoint(edited)
+	} else {
+		translated, err := s.translateWithRetry(translator.WithUsageCollector(ctx, &usage), task)
+		if err != nil {
+			recordTaskFailure(&state.report, &state.reportMu, state.total, task, err, emitter)
+			markTargetFailed(task.TargetPath, &state.pendingMu, state.failedTargets, targetFailures, ctx)
+			return false
+		}
+		if err := stageTaskOutput(state.staged, task.TargetPath, task.SourcePath, task.SourceLocale, task.TargetLocale, task.EntryKey, translated, &state.stageMu); err != nil {
+			recordTaskFailure(&state.report, &state.reportMu, state.total, task, err, emitter)
+			markTargetFailed(task.TargetPath, &state.pendingMu, state.failedTargets, targetFailures, ctx)
+			return false
+		}
+		outputValue = translated
 	}
 
 	select {
-	case completions <- taskCompletion{identity: taskIdentity(task.TargetPath, task.EntryKey), entryKey: task.EntryKey, value: translated, sourceHash: sourceHash, taskHash: taskHash, targetPath: task.TargetPath, sourcePath: task.SourcePath, targetLocale: task.TargetLocale}:
+	case completions <- taskCompletion{identity: taskIdentity(task.TargetPath, task.EntryKey), entryKey: task.EntryKey, value: outputValue, sourceHash: sourceHash, taskHash: taskHash, targetPath: task.TargetPath, sourcePath: task.SourcePath, targetLocale: task.TargetLocale}:
 		state.reportMu.Lock()
 		state.report.Succeeded++
 		state.report.TokenUsage = addTokenUsage(state.report.TokenUsage, toRunTokenUsage(usage))
@@ -625,6 +651,36 @@ func stageTaskOutput(staged map[string]stagedOutput, targetPath, sourcePath, sou
 		return fmt.Errorf("output staging conflict: %s already staged with different value", taskIdentity(targetPath, entryKey))
 	}
 	bucket.entries[entryKey] = value
+	staged[targetPath] = bucket
+	return nil
+}
+
+func stageImageOutput(staged map[string]stagedOutput, targetPath, sourcePath, sourceLocale, targetLocale string, content []byte, stageMu *sync.Mutex) error {
+	if stageMu != nil {
+		stageMu.Lock()
+		defer stageMu.Unlock()
+	}
+	if len(content) == 0 {
+		return fmt.Errorf("output staging conflict: %s has empty image content", targetPath)
+	}
+
+	bucket, ok := staged[targetPath]
+	if !ok {
+		bucket = stagedOutput{entries: map[string]string{}, sourcePath: sourcePath, sourceLocale: sourceLocale, targetLocale: targetLocale}
+		staged[targetPath] = bucket
+	} else if bucket.sourcePath != sourcePath {
+		return fmt.Errorf("output staging conflict: %s has conflicting source paths", targetPath)
+	} else if bucket.sourceLocale != "" && bucket.sourceLocale != sourceLocale {
+		return fmt.Errorf("output staging conflict: %s has conflicting source locales", targetPath)
+	} else if bucket.targetLocale != "" && bucket.targetLocale != targetLocale {
+		return fmt.Errorf("output staging conflict: %s has conflicting target locales", targetPath)
+	}
+	if len(bucket.entries) > 0 && !bucket.binaryOutput {
+		return fmt.Errorf("output staging conflict: %s mixes text and image outputs", targetPath)
+	}
+
+	bucket.binary = append(bucket.binary[:0], content...)
+	bucket.binaryOutput = true
 	staged[targetPath] = bucket
 	return nil
 }

--- a/apps/cli/internal/i18n/runsvc/executor.go
+++ b/apps/cli/internal/i18n/runsvc/executor.go
@@ -646,6 +646,9 @@ func stageTaskOutput(staged map[string]stagedOutput, targetPath, sourcePath, sou
 	} else if bucket.targetLocale != "" && bucket.targetLocale != targetLocale {
 		return fmt.Errorf("output staging conflict: %s has conflicting target locales", targetPath)
 	}
+	if bucket.binaryOutput {
+		return fmt.Errorf("output staging conflict: %s mixes image and text outputs", targetPath)
+	}
 
 	if existing, exists := bucket.entries[entryKey]; exists && existing != value {
 		return fmt.Errorf("output staging conflict: %s already staged with different value", taskIdentity(targetPath, entryKey))

--- a/apps/cli/internal/i18n/runsvc/executor.go
+++ b/apps/cli/internal/i18n/runsvc/executor.go
@@ -681,6 +681,9 @@ func stageImageOutput(staged map[string]stagedOutput, targetPath, sourcePath, so
 	if len(bucket.entries) > 0 && !bucket.binaryOutput {
 		return fmt.Errorf("output staging conflict: %s mixes text and image outputs", targetPath)
 	}
+	if bucket.binaryOutput && len(bucket.binary) > 0 {
+		return fmt.Errorf("output staging conflict: %s already staged with binary content", targetPath)
+	}
 
 	bucket.binary = append(bucket.binary[:0], content...)
 	bucket.binaryOutput = true

--- a/apps/cli/internal/i18n/runsvc/image_task.go
+++ b/apps/cli/internal/i18n/runsvc/image_task.go
@@ -1,0 +1,86 @@
+package runsvc
+
+import (
+	"crypto/sha512"
+	"encoding/base64"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/translator"
+)
+
+const (
+	taskKindText       = ""
+	taskKindImage      = "image"
+	imageEntryKey      = "__image__"
+	imagePromptVersion = "image-localize-v1"
+)
+
+func isImageTask(task Task) bool {
+	return task.Kind == taskKindImage
+}
+
+func isSupportedImagePath(path string) bool {
+	switch strings.ToLower(filepath.Ext(strings.TrimSpace(path))) {
+	case ".png", ".jpg", ".jpeg", ".webp":
+		return true
+	default:
+		return false
+	}
+}
+
+func imageOutputFormat(path string) (string, error) {
+	switch strings.ToLower(filepath.Ext(strings.TrimSpace(path))) {
+	case ".png":
+		return "png", nil
+	case ".jpg", ".jpeg":
+		return "jpeg", nil
+	case ".webp":
+		return "webp", nil
+	default:
+		return "", fmt.Errorf("unsupported image target extension %q for %q", filepath.Ext(path), path)
+	}
+}
+
+func imageSourceFingerprint(content []byte) string {
+	sum := sha512.Sum512(content)
+	return fmt.Sprintf("%x", sum[:])
+}
+
+func imageLockSourceHash(content []byte) string {
+	return lockStoredFingerprint(imageSourceFingerprint(content))
+}
+
+func imageEditPrompt(targetLocale string) string {
+	return strings.TrimSpace(fmt.Sprintf(
+		"Localize the visible text in this image into %s. Preserve the original layout, composition, branding, colors, typography style, aspect ratio, and all non-text visual elements. Only change text that should be localized for the target language. Return the finished localized image with no explanations.",
+		strings.TrimSpace(targetLocale),
+	))
+}
+
+func buildImageEditRequest(task Task, sourceImage []byte) translator.ImageEditRequest {
+	return translator.ImageEditRequest{
+		SourceImage:    sourceImage,
+		TargetLanguage: task.TargetLocale,
+		ModelProvider:  task.Provider,
+		Model:          task.Model,
+		Prompt:         imageEditPrompt(task.TargetLocale),
+		OutputFormat:   task.OutputFormat,
+	}
+}
+
+func encodeImageCheckpoint(content []byte) string {
+	return base64.StdEncoding.EncodeToString(content)
+}
+
+func decodeImageCheckpoint(value string) ([]byte, error) {
+	content, err := base64.StdEncoding.DecodeString(strings.TrimSpace(value))
+	if err != nil {
+		return nil, fmt.Errorf("decode image checkpoint: %w", err)
+	}
+	if len(content) == 0 {
+		return nil, fmt.Errorf("decode image checkpoint: empty image content")
+	}
+	return content, nil
+}

--- a/apps/cli/internal/i18n/runsvc/image_task.go
+++ b/apps/cli/internal/i18n/runsvc/image_task.go
@@ -12,10 +12,11 @@ import (
 )
 
 const (
-	taskKindText       = ""
-	taskKindImage      = "image"
-	imageEntryKey      = "__image__"
-	imagePromptVersion = "image-localize-v1"
+	taskKindText          = ""
+	taskKindImage         = "image"
+	imageEntryKey         = "__image__"
+	imagePromptVersion    = "image-localize-v1"
+	imageCheckpointPrefix = "sha512:"
 )
 
 func isImageTask(task Task) bool {
@@ -74,7 +75,7 @@ func buildImageEditRequest(task Task, sourceImage []byte) translator.ImageEditRe
 }
 
 func encodeImageCheckpoint(content []byte) string {
-	return base64.StdEncoding.EncodeToString(content)
+	return imageCheckpointPrefix + imageSourceFingerprint(content)
 }
 
 func decodeImageCheckpoint(value string) ([]byte, error) {
@@ -84,6 +85,31 @@ func decodeImageCheckpoint(value string) ([]byte, error) {
 	}
 	if len(content) == 0 {
 		return nil, fmt.Errorf("decode image checkpoint: empty image content")
+	}
+	return content, nil
+}
+
+func isImageCheckpointHash(value string) bool {
+	return strings.HasPrefix(strings.TrimSpace(value), imageCheckpointPrefix)
+}
+
+func readImageCheckpointContent(value, targetPath string, readFile func(string) ([]byte, error)) ([]byte, error) {
+	value = strings.TrimSpace(value)
+	if !isImageCheckpointHash(value) {
+		return decodeImageCheckpoint(value)
+	}
+	if readFile == nil {
+		return nil, fmt.Errorf("read image checkpoint %q: no file reader configured", targetPath)
+	}
+	content, err := readFile(targetPath)
+	if err != nil {
+		return nil, fmt.Errorf("read image checkpoint %q: %w", targetPath, err)
+	}
+	if len(content) == 0 {
+		return nil, fmt.Errorf("read image checkpoint %q: empty image content", targetPath)
+	}
+	if got := imageCheckpointPrefix + imageSourceFingerprint(content); got != value {
+		return nil, fmt.Errorf("read image checkpoint %q: content hash mismatch", targetPath)
 	}
 	return content, nil
 }

--- a/apps/cli/internal/i18n/runsvc/image_task.go
+++ b/apps/cli/internal/i18n/runsvc/image_task.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha512"
 	"encoding/base64"
 	"fmt"
+	"mime"
 	"path/filepath"
 	"strings"
 
@@ -67,6 +68,8 @@ func buildImageEditRequest(task Task, sourceImage []byte) translator.ImageEditRe
 		Model:          task.Model,
 		Prompt:         imageEditPrompt(task.TargetLocale),
 		OutputFormat:   task.OutputFormat,
+		SourceFilename: filepath.Base(task.SourcePath),
+		SourceMIMEType: mime.TypeByExtension(filepath.Ext(task.SourcePath)),
 	}
 }
 

--- a/apps/cli/internal/i18n/runsvc/image_task_test.go
+++ b/apps/cli/internal/i18n/runsvc/image_task_test.go
@@ -1,0 +1,225 @@
+package runsvc
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hyperlocalise/hyperlocalise/apps/cli/internal/i18n/lockfile"
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/translator"
+	config "github.com/hyperlocalise/hyperlocalise/pkg/i18nconfig"
+)
+
+func imageTestConfig(sourcePath, targetPath string) config.I18NConfig {
+	cfg := testConfig(sourcePath, targetPath)
+	cfg.Locales.Targets = []string{"fr", "de"}
+	cfg.Groups["default"] = config.GroupConfig{Targets: []string{"fr", "de"}, Buckets: []string{"ui"}}
+	profile := cfg.LLM.Profiles["default"]
+	profile.Model = "ignored-text-model"
+	cfg.LLM.Profiles["default"] = profile
+	return cfg
+}
+
+func TestRunImageDryRunPlansOneTaskPerTargetLocale(t *testing.T) {
+	svc := newTestService()
+	sourcePath := "/tmp/source.png"
+	svc.loadConfig = func(_ string) (*config.I18NConfig, error) {
+		cfg := imageTestConfig(sourcePath, "/tmp/[locale]/image.png")
+		return &cfg, nil
+	}
+	svc.readFile = func(path string) ([]byte, error) {
+		if path == sourcePath {
+			return []byte("source-image"), nil
+		}
+		return nil, filepath.ErrBadPattern
+	}
+	svc.editImage = func(_ context.Context, _ translator.ImageEditRequest) ([]byte, error) {
+		t.Fatal("editImage should not be called during dry-run")
+		return nil, nil
+	}
+
+	report, err := svc.Run(context.Background(), Input{DryRun: true})
+	if err != nil {
+		t.Fatalf("run dry-run: %v", err)
+	}
+	if report.PlannedTotal != 2 || report.ExecutableTotal != 2 {
+		t.Fatalf("planned/executable = %d/%d, want 2/2", report.PlannedTotal, report.ExecutableTotal)
+	}
+	for _, task := range report.Executable {
+		if task.Kind != taskKindImage {
+			t.Fatalf("task kind = %q, want image", task.Kind)
+		}
+		if task.Model != translator.OpenAIImageModel {
+			t.Fatalf("task model = %q, want %q", task.Model, translator.OpenAIImageModel)
+		}
+		if task.EntryKey != imageEntryKey {
+			t.Fatalf("task entry key = %q, want %q", task.EntryKey, imageEntryKey)
+		}
+	}
+}
+
+func TestRunImageRejectsNonOpenAIProvider(t *testing.T) {
+	svc := newTestService()
+	sourcePath := "/tmp/source.png"
+	svc.loadConfig = func(_ string) (*config.I18NConfig, error) {
+		cfg := imageTestConfig(sourcePath, "/tmp/fr/image.png")
+		profile := cfg.LLM.Profiles["default"]
+		profile.Provider = "anthropic"
+		cfg.LLM.Profiles["default"] = profile
+		return &cfg, nil
+	}
+	svc.readFile = func(path string) ([]byte, error) {
+		if path == sourcePath {
+			return []byte("source-image"), nil
+		}
+		return nil, filepath.ErrBadPattern
+	}
+
+	_, err := svc.Run(context.Background(), Input{DryRun: true})
+	if err == nil {
+		t.Fatal("expected non-OpenAI provider error")
+	}
+	if got := err.Error(); !strings.Contains(got, "image localization is only supported with provider \"openai\"") || !strings.Contains(got, sourcePath) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunImageEditWritesLocalizedImage(t *testing.T) {
+	svc := newTestService()
+	sourcePath := "/tmp/source.png"
+	targetPath := "/tmp/fr/image.webp"
+	localized := []byte("localized-webp")
+	svc.loadConfig = func(_ string) (*config.I18NConfig, error) {
+		cfg := testConfig(sourcePath, targetPath)
+		profile := cfg.LLM.Profiles["default"]
+		profile.Model = "ignored-text-model"
+		cfg.LLM.Profiles["default"] = profile
+		return &cfg, nil
+	}
+	svc.readFile = func(path string) ([]byte, error) {
+		if path == sourcePath {
+			return []byte("source-image"), nil
+		}
+		return nil, filepath.ErrBadPattern
+	}
+	var gotReq translator.ImageEditRequest
+	svc.editImage = func(_ context.Context, req translator.ImageEditRequest) ([]byte, error) {
+		gotReq = req
+		return localized, nil
+	}
+	var wrotePath string
+	var wroteContent []byte
+	svc.writeFile = func(path string, content []byte) error {
+		wrotePath = path
+		wroteContent = append([]byte(nil), content...)
+		return nil
+	}
+
+	report, err := svc.Run(context.Background(), Input{Workers: 1})
+	if err != nil {
+		t.Fatalf("run image edit: %v", err)
+	}
+	if report.Succeeded != 1 || report.Failed != 0 {
+		t.Fatalf("succeeded/failed = %d/%d, want 1/0", report.Succeeded, report.Failed)
+	}
+	if wrotePath != targetPath || !bytes.Equal(wroteContent, localized) {
+		t.Fatalf("write = (%q, %q), want (%q, %q)", wrotePath, string(wroteContent), targetPath, string(localized))
+	}
+	if gotReq.Model != translator.OpenAIImageModel {
+		t.Fatalf("image model = %q, want %q", gotReq.Model, translator.OpenAIImageModel)
+	}
+	if gotReq.OutputFormat != "webp" {
+		t.Fatalf("output format = %q, want webp", gotReq.OutputFormat)
+	}
+	if !strings.Contains(gotReq.Prompt, "fr") {
+		t.Fatalf("prompt should include target locale, got %q", gotReq.Prompt)
+	}
+}
+
+func TestRunImageOutputFormatByTargetExtension(t *testing.T) {
+	for _, tt := range []struct {
+		targetPath string
+		want       string
+	}{
+		{targetPath: "/tmp/fr/image.png", want: "png"},
+		{targetPath: "/tmp/fr/image.jpg", want: "jpeg"},
+		{targetPath: "/tmp/fr/image.jpeg", want: "jpeg"},
+		{targetPath: "/tmp/fr/image.webp", want: "webp"},
+	} {
+		t.Run(filepath.Ext(tt.targetPath), func(t *testing.T) {
+			svc := newTestService()
+			sourcePath := "/tmp/source.png"
+			svc.loadConfig = func(_ string) (*config.I18NConfig, error) {
+				cfg := testConfig(sourcePath, tt.targetPath)
+				return &cfg, nil
+			}
+			svc.readFile = func(path string) ([]byte, error) {
+				if path == sourcePath {
+					return []byte("source-image"), nil
+				}
+				return nil, filepath.ErrBadPattern
+			}
+			var gotFormat string
+			svc.editImage = func(_ context.Context, req translator.ImageEditRequest) ([]byte, error) {
+				gotFormat = req.OutputFormat
+				return []byte("localized-image"), nil
+			}
+
+			if _, err := svc.Run(context.Background(), Input{Workers: 1}); err != nil {
+				t.Fatalf("run image edit: %v", err)
+			}
+			if gotFormat != tt.want {
+				t.Fatalf("output format = %q, want %q", gotFormat, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunImageLockSkip(t *testing.T) {
+	sourcePath := "/tmp/source.png"
+	targetPath := "/tmp/fr/image.png"
+	lockState := &lockfile.File{
+		LocaleStates:  map[string]lockfile.LocaleCheckpoint{},
+		RunCompleted:  map[string]lockfile.RunCompletion{},
+		RunCheckpoint: map[string]lockfile.RunCheckpoint{},
+	}
+	newImageService := func() *Service {
+		svc := newTestService()
+		svc.loadConfig = func(_ string) (*config.I18NConfig, error) {
+			cfg := testConfig(sourcePath, targetPath)
+			return &cfg, nil
+		}
+		svc.loadLock = func(_ string) (*lockfile.File, error) { return lockState, nil }
+		svc.saveLock = func(_ string, f lockfile.File) error {
+			*lockState = f
+			return nil
+		}
+		svc.readFile = func(path string) ([]byte, error) {
+			if path == sourcePath {
+				return []byte("source-image"), nil
+			}
+			return nil, filepath.ErrBadPattern
+		}
+		return svc
+	}
+
+	first := newImageService()
+	if _, err := first.Run(context.Background(), Input{Workers: 1}); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+
+	second := newImageService()
+	second.editImage = func(_ context.Context, _ translator.ImageEditRequest) ([]byte, error) {
+		t.Fatal("editImage should not be called for lock-skipped image")
+		return nil, nil
+	}
+	report, err := second.Run(context.Background(), Input{Workers: 1})
+	if err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	if report.SkippedByLock != 1 || report.ExecutableTotal != 0 {
+		t.Fatalf("skipped/executable = %d/%d, want 1/0", report.SkippedByLock, report.ExecutableTotal)
+	}
+}

--- a/apps/cli/internal/i18n/runsvc/image_task_test.go
+++ b/apps/cli/internal/i18n/runsvc/image_task_test.go
@@ -22,6 +22,44 @@ func imageTestConfig(sourcePath, targetPath string) config.I18NConfig {
 	return cfg
 }
 
+func TestImageCheckpointStoresHashAndReadsTargetFile(t *testing.T) {
+	content := []byte("localized-image")
+	checkpoint := encodeImageCheckpoint(content)
+	if !strings.HasPrefix(checkpoint, imageCheckpointPrefix) {
+		t.Fatalf("checkpoint = %q, want hash prefix", checkpoint)
+	}
+	if strings.Contains(checkpoint, "localized-image") {
+		t.Fatalf("checkpoint should not contain image bytes")
+	}
+
+	got, err := readImageCheckpointContent(checkpoint, "/tmp/out.png", func(path string) ([]byte, error) {
+		if path != "/tmp/out.png" {
+			t.Fatalf("read path = %q, want /tmp/out.png", path)
+		}
+		return content, nil
+	})
+	if err != nil {
+		t.Fatalf("read checkpoint: %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Fatalf("content = %q, want %q", string(got), string(content))
+	}
+}
+
+func TestStageImageOutputRejectsDuplicateBinary(t *testing.T) {
+	staged := map[string]stagedOutput{}
+	if err := stageImageOutput(staged, "/tmp/out.png", "/tmp/source.png", "en", "fr", []byte("first"), nil); err != nil {
+		t.Fatalf("stage first image: %v", err)
+	}
+	err := stageImageOutput(staged, "/tmp/out.png", "/tmp/source.png", "en", "fr", []byte("second"), nil)
+	if err == nil || !strings.Contains(err.Error(), "already staged with binary content") {
+		t.Fatalf("expected duplicate binary conflict, got %v", err)
+	}
+	if !bytes.Equal(staged["/tmp/out.png"].binary, []byte("first")) {
+		t.Fatalf("duplicate stage overwrote binary content")
+	}
+}
+
 func TestRunImageDryRunPlansOneTaskPerTargetLocale(t *testing.T) {
 	svc := newTestService()
 	sourcePath := "/tmp/source.png"

--- a/apps/cli/internal/i18n/runsvc/output_flush.go
+++ b/apps/cli/internal/i18n/runsvc/output_flush.go
@@ -65,6 +65,19 @@ func (s *Service) flushOutputs(ctx context.Context, retry *markdownParityRetryIn
 }
 
 func (s *Service) flushOutputForTarget(targetPath string, output stagedOutput, keep map[string]struct{}) ([]string, error) {
+	if output.binaryOutput {
+		if keep != nil {
+			return nil, nil
+		}
+		if len(output.binary) == 0 {
+			return nil, fmt.Errorf("flush outputs: image target %q has empty content", targetPath)
+		}
+		if err := s.writeFile(targetPath, output.binary); err != nil {
+			return nil, fmt.Errorf("flush outputs: write %q: %w", targetPath, err)
+		}
+		return nil, nil
+	}
+
 	values, loadWarnings, err := s.loadExistingTargetWithWarnings(targetPath, output.targetLocale)
 	if err != nil {
 		return nil, err

--- a/apps/cli/internal/i18n/runsvc/output_prune.go
+++ b/apps/cli/internal/i18n/runsvc/output_prune.go
@@ -10,6 +10,9 @@ import (
 func buildPlannedTargetMetadata(planned []Task) (map[string]stagedOutput, error) {
 	metadata := make(map[string]stagedOutput, len(planned))
 	for _, task := range planned {
+		if isImageTask(task) {
+			continue
+		}
 		existing, ok := metadata[task.TargetPath]
 		if !ok {
 			metadata[task.TargetPath] = stagedOutput{
@@ -36,6 +39,9 @@ func buildPlannedTargetMetadata(planned []Task) (map[string]stagedOutput, error)
 func buildPlannedTargetKeySet(planned []Task) map[string]map[string]struct{} {
 	keep := map[string]map[string]struct{}{}
 	for _, task := range planned {
+		if isImageTask(task) {
+			continue
+		}
 		bucket := keep[task.TargetPath]
 		if bucket == nil {
 			bucket = map[string]struct{}{}

--- a/apps/cli/internal/i18n/runsvc/run_orchestrator.go
+++ b/apps/cli/internal/i18n/runsvc/run_orchestrator.go
@@ -222,7 +222,7 @@ func applyLockFilter(planned []Task, completed map[string]lockfile.RunCompletion
 
 	for _, task := range planned {
 		identity := taskIdentity(task.TargetPath, task.EntryKey)
-		sourceHash := lockStoredFingerprint(task.SourceText)
+		sourceHash := taskLockSourceHash(task)
 		taskHash := lockTaskHash(task)
 		legacyTaskHash := legacyDefaultLockTaskHash(task)
 		if cp, ok := checkpoints[identity]; ok && checkpointMatchesActiveRun(cp, activeRunID) && checkpointMatchesTask(cp, sourceHash, taskHash, legacyTaskHash) {
@@ -231,8 +231,18 @@ func applyLockFilter(planned []Task, completed map[string]lockfile.RunCompletion
 				checkpoints[identity] = cp
 				lockMigrated = true
 			}
-			if err := stageTaskOutput(checkpointStaged, task.TargetPath, task.SourcePath, task.SourceLocale, task.TargetLocale, task.EntryKey, cp.Value, nil); err != nil {
-				return Report{}, nil, nil, false, fmt.Errorf("stage checkpoint output for %s: %w", identity, err)
+			var stageErr error
+			if isImageTask(task) {
+				content, err := decodeImageCheckpoint(cp.Value)
+				if err != nil {
+					return Report{}, nil, nil, false, fmt.Errorf("stage checkpoint output for %s: %w", identity, err)
+				}
+				stageErr = stageImageOutput(checkpointStaged, task.TargetPath, task.SourcePath, task.SourceLocale, task.TargetLocale, content, nil)
+			} else {
+				stageErr = stageTaskOutput(checkpointStaged, task.TargetPath, task.SourcePath, task.SourceLocale, task.TargetLocale, task.EntryKey, cp.Value, nil)
+			}
+			if stageErr != nil {
+				return Report{}, nil, nil, false, fmt.Errorf("stage checkpoint output for %s: %w", identity, stageErr)
 			}
 		}
 		if c, ok := completed[identity]; ok && completionMatchesTask(c, sourceHash, taskHash, legacyTaskHash) {
@@ -250,6 +260,13 @@ func applyLockFilter(planned []Task, completed map[string]lockfile.RunCompletion
 	}
 	report.ExecutableTotal = len(executable)
 	return report, executable, checkpointStaged, lockMigrated, nil
+}
+
+func taskLockSourceHash(task Task) string {
+	if isImageTask(task) {
+		return strings.TrimSpace(task.sourceFingerprint)
+	}
+	return lockStoredFingerprint(task.SourceText)
 }
 
 func ensureActiveRunID(state *lockfile.File) string {

--- a/apps/cli/internal/i18n/runsvc/run_orchestrator.go
+++ b/apps/cli/internal/i18n/runsvc/run_orchestrator.go
@@ -68,7 +68,7 @@ func (s *Service) Run(ctx context.Context, in Input) (report Report, err error) 
 	initializeLockState(state)
 
 	activeRunID := ensureActiveRunID(state)
-	report, executable, checkpointStaged, lockMigrated, err := applyLockFilter(planned, state.RunCompleted, state.RunCheckpoint, activeRunID, in.Force)
+	report, executable, checkpointStaged, lockMigrated, err := applyLockFilterWithReader(planned, state.RunCompleted, state.RunCheckpoint, activeRunID, in.Force, s.readFile)
 	if err != nil {
 		endRunSpan(lockSpan, err, "lock_filter")
 		return Report{}, err
@@ -210,6 +210,10 @@ func initializeLockState(state *lockfile.File) {
 }
 
 func applyLockFilter(planned []Task, completed map[string]lockfile.RunCompletion, checkpoints map[string]lockfile.RunCheckpoint, activeRunID string, force bool) (Report, []Task, map[string]stagedOutput, bool, error) {
+	return applyLockFilterWithReader(planned, completed, checkpoints, activeRunID, force, nil)
+}
+
+func applyLockFilterWithReader(planned []Task, completed map[string]lockfile.RunCompletion, checkpoints map[string]lockfile.RunCheckpoint, activeRunID string, force bool, readFile func(string) ([]byte, error)) (Report, []Task, map[string]stagedOutput, bool, error) {
 	report := Report{PlannedTotal: len(planned)}
 	executable := make([]Task, 0, len(planned))
 	checkpointStaged := map[string]stagedOutput{}
@@ -233,8 +237,13 @@ func applyLockFilter(planned []Task, completed map[string]lockfile.RunCompletion
 			}
 			var stageErr error
 			if isImageTask(task) {
-				content, err := decodeImageCheckpoint(cp.Value)
+				content, err := readImageCheckpointContent(cp.Value, task.TargetPath, readFile)
 				if err != nil {
+					if isImageCheckpointHash(cp.Value) {
+						report.Executable = append(report.Executable, task)
+						executable = append(executable, task)
+						continue
+					}
 					return Report{}, nil, nil, false, fmt.Errorf("stage checkpoint output for %s: %w", identity, err)
 				}
 				stageErr = stageImageOutput(checkpointStaged, task.TargetPath, task.SourcePath, task.SourceLocale, task.TargetLocale, content, nil)

--- a/apps/cli/internal/i18n/runsvc/service.go
+++ b/apps/cli/internal/i18n/runsvc/service.go
@@ -144,6 +144,7 @@ type Event struct {
 }
 
 type Task struct {
+	Kind         string `json:"kind,omitempty"`
 	SourceLocale string `json:"sourceLocale"`
 	TargetLocale string `json:"targetLocale"`
 	SourcePath   string `json:"sourcePath"`
@@ -171,9 +172,12 @@ type Task struct {
 	SourceContext   string `json:"-"`
 	ParserMode      string `json:"-"`
 	PromptVersion   string `json:"-"`
+	OutputFormat    string `json:"-"`
 
 	sourceTextHash           string
 	sourceContextFingerprint string
+	sourceFingerprint        string
+	sourceImage              []byte
 }
 
 type Failure struct {
@@ -231,6 +235,7 @@ type Service struct {
 	readFile   func(path string) ([]byte, error)
 	writeFile  func(path string, content []byte) error
 	translate  func(ctx context.Context, req translator.Request) (string, error)
+	editImage  func(ctx context.Context, req translator.ImageEditRequest) ([]byte, error)
 	newParser  func() *translationfileparser.Strategy
 	now        func() time.Time
 	numCPU     func() int
@@ -249,6 +254,7 @@ func New() *Service {
 			return writeBytesAtomic(path, content)
 		},
 		translate: translator.Translate,
+		editImage: translator.EditImage,
 		newParser: translationfileparser.NewDefaultStrategy,
 		now:       func() time.Time { return time.Now().UTC() },
 		numCPU:    runtime.NumCPU,
@@ -388,6 +394,65 @@ func (s *Service) planTasks(cfg *config.I18NConfig, onlyBucket, onlyGroup string
 					}
 					if len(filteredSourcePaths) > 0 {
 						matchedSourcePaths[sourcePath] = struct{}{}
+					}
+					if isSupportedImagePath(sourcePath) {
+						sourceContent, err := s.readFile(sourcePath)
+						if err != nil {
+							if os.IsNotExist(err) {
+								return nil, nil, fmt.Errorf("planning tasks: source file %q does not exist", sourcePath)
+							}
+							return nil, nil, fmt.Errorf("planning tasks: read source image %q: %w", sourcePath, err)
+						}
+						sourceFingerprint := imageLockSourceHash(sourceContent)
+						for _, target := range targets {
+							resolvedTargetPattern := pathresolver.ResolveTargetPath(file.To, cfg.Locales.Source, target)
+							targetPath, err := resolveTargetPath(sourcePattern, resolvedTargetPattern, sourcePath)
+							if err != nil {
+								return nil, nil, fmt.Errorf("planning tasks: resolve target path for source %q: %w", sourcePath, err)
+							}
+							outputFormat, err := imageOutputFormat(targetPath)
+							if err != nil {
+								return nil, nil, fmt.Errorf("planning tasks: image target %q: %w", targetPath, err)
+							}
+							if strings.ToLower(strings.TrimSpace(profile.Provider)) != translator.ProviderOpenAI {
+								return nil, nil, fmt.Errorf("planning tasks: image source %q uses profile %q with provider %q; image localization is only supported with provider %q", sourcePath, profileName, profile.Provider, translator.ProviderOpenAI)
+							}
+							task := Task{
+								Kind:              taskKindImage,
+								SourceLocale:      cfg.Locales.Source,
+								TargetLocale:      target,
+								SourcePath:        sourcePath,
+								TargetPath:        targetPath,
+								EntryKey:          imageEntryKey,
+								SourceText:        sourcePath,
+								ProfileName:       profileName,
+								Provider:          translator.ProviderOpenAI,
+								Model:             translator.OpenAIImageModel,
+								ContextProvider:   contextProvider,
+								ContextModel:      contextModel,
+								GroupName:         groupName,
+								BucketName:        bucketName,
+								ParserMode:        taskKindImage,
+								PromptVersion:     imagePromptVersion,
+								OutputFormat:      outputFormat,
+								sourceFingerprint: sourceFingerprint,
+								sourceImage:       append([]byte(nil), sourceContent...),
+							}
+							precomputeStableTaskCacheFields(&task)
+							if filterFixes {
+								if len(fixSet) == 0 {
+									continue
+								}
+								mk := fixTargetMatchKey(task.SourcePath, task.TargetPath, task.TargetLocale, task.EntryKey)
+								if _, ok := fixSet[mk]; ok {
+									matchedFix[mk] = struct{}{}
+								} else {
+									continue
+								}
+							}
+							tasks = append(tasks, task)
+						}
+						continue
 					}
 					sourceEntries, sourceContextByKey, parserMode, err := s.loadSourceEntriesCached(parser, sourceCache, sourcePath)
 					if err != nil {

--- a/apps/cli/internal/i18n/runsvc/service.go
+++ b/apps/cli/internal/i18n/runsvc/service.go
@@ -404,6 +404,9 @@ func (s *Service) planTasks(cfg *config.I18NConfig, onlyBucket, onlyGroup string
 							return nil, nil, fmt.Errorf("planning tasks: read source image %q: %w", sourcePath, err)
 						}
 						sourceFingerprint := imageLockSourceHash(sourceContent)
+						if strings.ToLower(strings.TrimSpace(profile.Provider)) != translator.ProviderOpenAI {
+							return nil, nil, fmt.Errorf("planning tasks: image source %q uses profile %q with provider %q; image localization is only supported with provider %q", sourcePath, profileName, profile.Provider, translator.ProviderOpenAI)
+						}
 						for _, target := range targets {
 							resolvedTargetPattern := pathresolver.ResolveTargetPath(file.To, cfg.Locales.Source, target)
 							targetPath, err := resolveTargetPath(sourcePattern, resolvedTargetPattern, sourcePath)
@@ -413,9 +416,6 @@ func (s *Service) planTasks(cfg *config.I18NConfig, onlyBucket, onlyGroup string
 							outputFormat, err := imageOutputFormat(targetPath)
 							if err != nil {
 								return nil, nil, fmt.Errorf("planning tasks: image target %q: %w", targetPath, err)
-							}
-							if strings.ToLower(strings.TrimSpace(profile.Provider)) != translator.ProviderOpenAI {
-								return nil, nil, fmt.Errorf("planning tasks: image source %q uses profile %q with provider %q; image localization is only supported with provider %q", sourcePath, profileName, profile.Provider, translator.ProviderOpenAI)
 							}
 							task := Task{
 								Kind:              taskKindImage,
@@ -436,7 +436,7 @@ func (s *Service) planTasks(cfg *config.I18NConfig, onlyBucket, onlyGroup string
 								PromptVersion:     imagePromptVersion,
 								OutputFormat:      outputFormat,
 								sourceFingerprint: sourceFingerprint,
-								sourceImage:       append([]byte(nil), sourceContent...),
+								sourceImage:       sourceContent,
 							}
 							precomputeStableTaskCacheFields(&task)
 							if filterFixes {

--- a/apps/cli/internal/i18n/runsvc/service_test.go
+++ b/apps/cli/internal/i18n/runsvc/service_test.go
@@ -2819,6 +2819,9 @@ func newTestService() *Service {
 		translate: func(_ context.Context, req translator.Request) (string, error) {
 			return strings.ToUpper(req.Source), nil
 		},
+		editImage: func(_ context.Context, _ translator.ImageEditRequest) ([]byte, error) {
+			return []byte("localized-image"), nil
+		},
 		newParser: translationfileparser.NewDefaultStrategy,
 		now:       func() time.Time { return now },
 		numCPU:    func() int { return 2 },

--- a/internal/i18n/translator/provider_openai.go
+++ b/internal/i18n/translator/provider_openai.go
@@ -25,3 +25,16 @@ func (p *OpenAIProvider) Translate(ctx context.Context, req Request) (string, er
 
 	return translateWithOpenAICompatibleClient(ctx, ProviderOpenAI, req, option.WithAPIKey(apiKey))
 }
+
+var openAIImageEditFunc = func(ctx context.Context, req ImageEditRequest, opts ...option.RequestOption) ([]byte, error) {
+	return editImageWithOpenAICompatibleClient(ctx, ProviderOpenAI, req, opts...)
+}
+
+func (p *OpenAIProvider) EditImage(ctx context.Context, req ImageEditRequest) ([]byte, error) {
+	apiKey := strings.TrimSpace(os.Getenv(defaultOpenAIAPIKeyEnv))
+	if apiKey == "" {
+		return nil, fmt.Errorf("openai provider: API key is required (%s)", defaultOpenAIAPIKeyEnv)
+	}
+
+	return openAIImageEditFunc(ctx, req, option.WithAPIKey(apiKey))
+}

--- a/internal/i18n/translator/provider_openai_compatible.go
+++ b/internal/i18n/translator/provider_openai_compatible.go
@@ -1,7 +1,9 @@
 package translator
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
 	"fmt"
 	"strings"
 
@@ -35,6 +37,43 @@ func translateWithOpenAICompatibleClient(ctx context.Context, providerName strin
 	return output, nil
 }
 
+func editImageWithOpenAICompatibleClient(ctx context.Context, providerName string, req ImageEditRequest, opts ...option.RequestOption) ([]byte, error) {
+	client := newOpenAIClient(opts...)
+
+	resp, err := client.Images.Edit(ctx, openai.ImageEditParams{
+		Image: openai.ImageEditParamsImageUnion{
+			OfFile: bytes.NewReader(req.SourceImage),
+		},
+		Prompt:       req.Prompt,
+		Model:        openai.ImageModel(strings.TrimSpace(req.Model)),
+		N:            openai.Int(1),
+		OutputFormat: openai.ImageEditParamsOutputFormat(strings.ToLower(strings.TrimSpace(req.OutputFormat))),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%s edit image: %w", providerName, err)
+	}
+	if resp == nil || len(resp.Data) == 0 {
+		return nil, fmt.Errorf("%s image response: no image returned", providerName)
+	}
+	encoded := strings.TrimSpace(resp.Data[0].B64JSON)
+	if encoded == "" {
+		return nil, fmt.Errorf("%s image response: empty base64 image", providerName)
+	}
+	content, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("%s image response: decode base64 image: %w", providerName, err)
+	}
+	if len(content) == 0 {
+		return nil, fmt.Errorf("%s image response: empty decoded image", providerName)
+	}
+
+	if usage, ok := usageFromImagesResponse(resp); ok {
+		SetUsage(ctx, usage)
+	}
+
+	return content, nil
+}
+
 func usageFromGenerateTextResponse(resp *openai.ChatCompletion) (Usage, bool) {
 	if resp == nil {
 		return Usage{}, false
@@ -50,5 +89,21 @@ func usageFromGenerateTextResponse(resp *openai.ChatCompletion) (Usage, bool) {
 		return Usage{}, false
 	}
 
+	return Usage{PromptTokens: prompt, CompletionTokens: completion, TotalTokens: total}, true
+}
+
+func usageFromImagesResponse(resp *openai.ImagesResponse) (Usage, bool) {
+	if resp == nil {
+		return Usage{}, false
+	}
+	prompt := int(resp.Usage.InputTokens)
+	completion := int(resp.Usage.OutputTokens)
+	total := int(resp.Usage.TotalTokens)
+	if total == 0 && (prompt != 0 || completion != 0) {
+		total = prompt + completion
+	}
+	if prompt == 0 && completion == 0 && total == 0 {
+		return Usage{}, false
+	}
 	return Usage{PromptTokens: prompt, CompletionTokens: completion, TotalTokens: total}, true
 }

--- a/internal/i18n/translator/provider_openai_compatible.go
+++ b/internal/i18n/translator/provider_openai_compatible.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/openai/openai-go/v3"
@@ -42,7 +43,7 @@ func editImageWithOpenAICompatibleClient(ctx context.Context, providerName strin
 
 	resp, err := client.Images.Edit(ctx, openai.ImageEditParams{
 		Image: openai.ImageEditParamsImageUnion{
-			OfFile: bytes.NewReader(req.SourceImage),
+			OfFile: imageUploadReader(req.SourceImage, req.SourceFilename, req.SourceMIMEType),
 		},
 		Prompt:       req.Prompt,
 		Model:        openai.ImageModel(strings.TrimSpace(req.Model)),
@@ -72,6 +73,36 @@ func editImageWithOpenAICompatibleClient(ctx context.Context, providerName strin
 	}
 
 	return content, nil
+}
+
+type namedImageReader struct {
+	*bytes.Reader
+	filename    string
+	contentType string
+}
+
+func imageUploadReader(content []byte, filename, contentType string) io.Reader {
+	filename = strings.TrimSpace(filename)
+	if filename == "" {
+		filename = "source-image"
+	}
+	contentType = strings.TrimSpace(contentType)
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+	return namedImageReader{
+		Reader:      bytes.NewReader(content),
+		filename:    filename,
+		contentType: contentType,
+	}
+}
+
+func (r namedImageReader) Filename() string {
+	return r.filename
+}
+
+func (r namedImageReader) ContentType() string {
+	return r.contentType
 }
 
 func usageFromGenerateTextResponse(resp *openai.ChatCompletion) (Usage, bool) {

--- a/internal/i18n/translator/tool.go
+++ b/internal/i18n/translator/tool.go
@@ -37,6 +37,16 @@ func Translate(ctx context.Context, req Request) (string, error) {
 	return defaultTool.Translate(ctx, req)
 }
 
+func EditImage(ctx context.Context, req ImageEditRequest) ([]byte, error) {
+	defaultToolOnce.Do(func() {
+		defaultTool, defaultToolInitErr = New()
+	})
+	if defaultToolInitErr != nil {
+		return nil, defaultToolInitErr
+	}
+	return defaultTool.EditImage(ctx, req)
+}
+
 func New() (*Tool, error) {
 	t := &Tool{providers: map[string]Provider{}}
 	if err := RegisterBuiltins(t); err != nil {
@@ -112,4 +122,41 @@ func (t *Tool) Translate(ctx context.Context, req Request) (string, error) {
 	translated = strings.TrimSpace(translated)
 	logPromptResult(req, providerName, translated, nil, duration)
 	return translated, nil
+}
+
+func (t *Tool) EditImage(ctx context.Context, req ImageEditRequest) ([]byte, error) {
+	if err := validateImageEditRequest(req); err != nil {
+		return nil, err
+	}
+
+	providerName := normalizeProvider(req.ModelProvider)
+	if providerName == "" {
+		providerName = ProviderOpenAI
+	}
+
+	t.mu.RLock()
+	provider, ok := t.providers[providerName]
+	t.mu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("edit image: unknown model provider %q", providerName)
+	}
+	imageProvider, ok := provider.(ImageProvider)
+	if !ok {
+		return nil, fmt.Errorf("edit image: provider %q does not support image editing", providerName)
+	}
+
+	tctx, span := otel.Tracer(otelTracerName).Start(ctx, "edit_image")
+	defer span.End()
+	span.SetAttributes(attribute.String("llm.provider", providerName))
+
+	start := time.Now()
+	image, err := imageProvider.EditImage(tctx, req)
+	duration := time.Since(start)
+	if err != nil {
+		span.SetStatus(codes.Error, "edit_image_failed")
+		logPromptResult(Request{TargetLanguage: req.TargetLanguage, ModelProvider: providerName, Model: req.Model, UserPrompt: req.Prompt}, providerName, "", err, duration)
+		return nil, fmt.Errorf("edit image with provider %q: %w", providerName, err)
+	}
+	logPromptResult(Request{TargetLanguage: req.TargetLanguage, ModelProvider: providerName, Model: req.Model, UserPrompt: req.Prompt}, providerName, "<image>", nil, duration)
+	return image, nil
 }

--- a/internal/i18n/translator/translator_test.go
+++ b/internal/i18n/translator/translator_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
 )
 
 type fakeProvider struct {
@@ -36,6 +37,25 @@ func (p captureProvider) Translate(_ context.Context, req Request) (string, erro
 		*p.got = req
 	}
 	return "ok", nil
+}
+
+type fakeImageProvider struct {
+	name   string
+	result []byte
+	got    *ImageEditRequest
+}
+
+func (p fakeImageProvider) Name() string { return p.name }
+
+func (p fakeImageProvider) Translate(_ context.Context, _ Request) (string, error) {
+	return "ok", nil
+}
+
+func (p fakeImageProvider) EditImage(_ context.Context, req ImageEditRequest) ([]byte, error) {
+	if p.got != nil {
+		*p.got = req
+	}
+	return p.result, nil
 }
 
 func TestRegisterRejectsDuplicateProvider(t *testing.T) {
@@ -86,6 +106,62 @@ func TestTranslateUsesRegisteredProvider(t *testing.T) {
 	}
 	if translated != "bonjour" {
 		t.Fatalf("unexpected translation: %q", translated)
+	}
+}
+
+func TestEditImageUsesRegisteredImageProvider(t *testing.T) {
+	t.Parallel()
+
+	tool := &Tool{providers: map[string]Provider{}}
+	var got ImageEditRequest
+	if err := tool.Register(fakeImageProvider{name: ProviderOpenAI, result: []byte("image"), got: &got}); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+
+	image, err := tool.EditImage(context.Background(), ImageEditRequest{
+		SourceImage:    []byte("source"),
+		TargetLanguage: "fr",
+		Model:          OpenAIImageModel,
+		Prompt:         "localize",
+		OutputFormat:   "png",
+	})
+	if err != nil {
+		t.Fatalf("edit image: %v", err)
+	}
+	if string(image) != "image" {
+		t.Fatalf("image = %q, want image", string(image))
+	}
+	if got.Model != OpenAIImageModel || got.OutputFormat != "png" {
+		t.Fatalf("request model/format = %q/%q", got.Model, got.OutputFormat)
+	}
+}
+
+func TestOpenAIProviderEditImageUsesFixedRequest(t *testing.T) {
+	t.Setenv(defaultOpenAIAPIKeyEnv, "test-key")
+	original := openAIImageEditFunc
+	defer func() { openAIImageEditFunc = original }()
+
+	var got ImageEditRequest
+	openAIImageEditFunc = func(_ context.Context, req ImageEditRequest, _ ...option.RequestOption) ([]byte, error) {
+		got = req
+		return []byte("image"), nil
+	}
+
+	image, err := NewOpenAIProvider().EditImage(context.Background(), ImageEditRequest{
+		SourceImage:    []byte("source"),
+		TargetLanguage: "fr",
+		Model:          OpenAIImageModel,
+		Prompt:         "localize",
+		OutputFormat:   "jpeg",
+	})
+	if err != nil {
+		t.Fatalf("openai edit image: %v", err)
+	}
+	if string(image) != "image" {
+		t.Fatalf("image = %q, want image", string(image))
+	}
+	if got.Model != OpenAIImageModel || got.OutputFormat != "jpeg" || got.Prompt != "localize" {
+		t.Fatalf("request = %+v", got)
 	}
 }
 

--- a/internal/i18n/translator/types.go
+++ b/internal/i18n/translator/types.go
@@ -37,6 +37,8 @@ type Provider interface {
 
 type ImageEditRequest struct {
 	SourceImage    []byte
+	SourceFilename string
+	SourceMIMEType string
 	TargetLanguage string
 	ModelProvider  string
 	Model          string

--- a/internal/i18n/translator/types.go
+++ b/internal/i18n/translator/types.go
@@ -18,6 +18,8 @@ const (
 	ProviderBedrock     = "bedrock"
 )
 
+const OpenAIImageModel = "gpt-image-2-2026-04-21"
+
 type Request struct {
 	Source         string
 	TargetLanguage string
@@ -33,6 +35,20 @@ type Provider interface {
 	Translate(ctx context.Context, req Request) (string, error)
 }
 
+type ImageEditRequest struct {
+	SourceImage    []byte
+	TargetLanguage string
+	ModelProvider  string
+	Model          string
+	Prompt         string
+	OutputFormat   string
+}
+
+type ImageProvider interface {
+	Name() string
+	EditImage(ctx context.Context, req ImageEditRequest) ([]byte, error)
+}
+
 func validateRequest(req Request) error {
 	if strings.TrimSpace(req.Source) == "" {
 		return fmt.Errorf("translate request: source is required")
@@ -42,6 +58,27 @@ func validateRequest(req Request) error {
 	}
 	if strings.TrimSpace(req.Model) == "" {
 		return fmt.Errorf("translate request: model is required")
+	}
+	return nil
+}
+
+func validateImageEditRequest(req ImageEditRequest) error {
+	if len(req.SourceImage) == 0 {
+		return fmt.Errorf("image edit request: source image is required")
+	}
+	if strings.TrimSpace(req.TargetLanguage) == "" {
+		return fmt.Errorf("image edit request: target language is required")
+	}
+	if strings.TrimSpace(req.Model) == "" {
+		return fmt.Errorf("image edit request: model is required")
+	}
+	if strings.TrimSpace(req.Prompt) == "" {
+		return fmt.Errorf("image edit request: prompt is required")
+	}
+	switch strings.ToLower(strings.TrimSpace(req.OutputFormat)) {
+	case "png", "jpeg", "webp":
+	default:
+		return fmt.Errorf("image edit request: unsupported output format %q", req.OutputFormat)
 	}
 	return nil
 }

--- a/pkg/i18nconfig/i18n.go
+++ b/pkg/i18nconfig/i18n.go
@@ -440,7 +440,7 @@ func validateBucket(name string, bucket BucketConfig) error {
 
 		fromSuffix := getFileSuffix(file.From)
 		toSuffix := getFileSuffix(file.To)
-		if !containsPlaceholder(fromSuffix) && !containsPlaceholder(toSuffix) && fromSuffix != toSuffix {
+		if !containsPlaceholder(fromSuffix) && !containsPlaceholder(toSuffix) && fromSuffix != toSuffix && !isSupportedImageSuffixPair(fromSuffix, toSuffix) {
 			return fmt.Errorf("buckets.%s.files[%d]: file suffix mismatch: from=%q and to=%q must have the same extension", name, i, file.From, file.To)
 		}
 	}
@@ -457,6 +457,19 @@ func containsPlaceholder(s string) bool {
 		strings.Contains(s, "{{source}}") ||
 		strings.Contains(s, "{{target}}") ||
 		strings.Contains(s, "{{localeDir}}")
+}
+
+func isSupportedImageSuffixPair(fromSuffix, toSuffix string) bool {
+	return isSupportedImageSuffix(fromSuffix) && isSupportedImageSuffix(toSuffix)
+}
+
+func isSupportedImageSuffix(suffix string) bool {
+	switch strings.ToLower(strings.TrimSpace(suffix)) {
+	case ".png", ".jpg", ".jpeg", ".webp":
+		return true
+	default:
+		return false
+	}
 }
 
 func (c I18NConfig) validateGroups(targetSet map[string]struct{}, bucketSet map[string]struct{}) (map[string]struct{}, error) {

--- a/pkg/i18nconfig/i18n_test.go
+++ b/pkg/i18nconfig/i18n_test.go
@@ -304,6 +304,15 @@ func TestLoad(t *testing.T) {
 			}`,
 		},
 		{
+			name: "valid bucket file mapping image suffix conversion",
+			content: `{
+			  "locales": {"source": "en-US", "targets": ["es-ES"]},
+			  "buckets": {"ui": {"files": [{"from": "assets/banner.png", "to": "assets/banner.es.webp"}]}},
+			  "groups": {"g": {"targets": ["es-ES"], "buckets": ["ui"]}},
+			  "llm": {"profiles": {"default": {"provider": "openai", "model": "x", "prompt": "p"}}}
+			}`,
+		},
+		{
 			name: "valid bucket file mapping same suffix no extension",
 			content: `{
 			  "locales": {"source": "en-US", "targets": ["es-ES"]},


### PR DESCRIPTION
## What changed

Adds image file support to `hyperlocalise run` for `.png`, `.jpg`, `.jpeg`, and `.webp` sources. Image mappings are routed through OpenAI image edits only, using the fixed `gpt-image-2-2026-04-21` model, with target output format inferred from the target extension.

Also adds image-task lock identity, binary output staging/writes, OpenAI image edit plumbing, and config validation support for image-to-image extension conversion.

## How to test

- `make fmt`
- `make lint`
- `make test`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
