### PR TITLE
fix(web): make app shell title route-aware

### DIFF
--- a/apps/hyperlocalise-web/src/components/app/app-shell-client.tsx
+++ b/apps/hyperlocalise-web/src/components/app/app-shell-client.tsx
@@ -2,6 +2,7 @@
 
 import type { CSSProperties, ReactNode } from "react";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { ArrowRight01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 
@@ -24,6 +25,7 @@ import {
   SidebarTrigger,
 } from "@/components/ui/sidebar";
 import { cn } from "@/lib/utils";
+import { getAppShellTitle } from "./app-shell-title";
 import { NavUser } from "./nav-user";
 
 type AppShellClientProps = {
@@ -51,6 +53,9 @@ export function AppShellClient({
   organizations,
   user,
 }: AppShellClientProps) {
+  const pathname = usePathname();
+  const pageTitle = getAppShellTitle(pathname);
+
   return (
     <SidebarProvider
       defaultOpen
@@ -149,7 +154,7 @@ export function AppShellClient({
         <div className="sticky top-0 z-20 border-b border-white/8 bg-[#050505]/96 backdrop-blur">
           <div className="flex h-14 items-center gap-3 px-4 sm:px-6 lg:px-8">
             <SidebarTrigger className="text-white hover:bg-white/8 hover:text-white md:hidden" />
-            <p className="font-heading text-base font-medium text-white">Dashboard</p>
+            <p className="font-heading text-base font-medium text-white">{pageTitle}</p>
           </div>
         </div>
 

--- a/apps/hyperlocalise-web/src/components/app/app-shell-title.test.ts
+++ b/apps/hyperlocalise-web/src/components/app/app-shell-title.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { getAppShellTitle } from "./app-shell-title";
+
+describe("getAppShellTitle", () => {
+  it.each([
+    ["/org/acme/dashboard", "Dashboard"],
+    ["/org/acme/projects", "Projects"],
+    ["/org/acme/jobs", "Jobs"],
+    ["/org/acme/glossaries", "Glossaries"],
+    ["/org/acme/agent", "Agent"],
+    ["/org/acme/integrations", "Integrations"],
+    ["/org/acme/settings", "Settings"],
+    ["/org/acme/settings/account", "Account"],
+    ["/org/acme/settings/billing", "Billing"],
+    ["/org/acme/settings/notifications", "Notifications"],
+  ])("returns the route title for %s", (pathname, title) => {
+    expect(getAppShellTitle(pathname)).toBe(title);
+  });
+
+  it("falls back to dashboard for unknown or empty paths", () => {
+    expect(getAppShellTitle(null)).toBe("Dashboard");
+    expect(getAppShellTitle("/org/acme/unknown")).toBe("Dashboard");
+  });
+});

--- a/apps/hyperlocalise-web/src/components/app/app-shell-title.ts
+++ b/apps/hyperlocalise-web/src/components/app/app-shell-title.ts
@@ -11,6 +11,10 @@ const ROUTE_TITLES = {
   settings: "Settings",
 } as const;
 
+function isRouteTitleKey(value: string): value is keyof typeof ROUTE_TITLES {
+  return value in ROUTE_TITLES;
+}
+
 export function getAppShellTitle(pathname: string | null): string {
   if (!pathname) {
     return ROUTE_TITLES.dashboard;
@@ -22,8 +26,8 @@ export function getAppShellTitle(pathname: string | null): string {
   const [section, subsection] = routeSegments;
 
   if (section === "settings" && subsection) {
-    return ROUTE_TITLES[subsection as keyof typeof ROUTE_TITLES] ?? ROUTE_TITLES.settings;
+    return isRouteTitleKey(subsection) ? ROUTE_TITLES[subsection] : ROUTE_TITLES.settings;
   }
 
-  return ROUTE_TITLES[section as keyof typeof ROUTE_TITLES] ?? ROUTE_TITLES.dashboard;
+  return section && isRouteTitleKey(section) ? ROUTE_TITLES[section] : ROUTE_TITLES.dashboard;
 }

--- a/apps/hyperlocalise-web/src/components/app/app-shell-title.ts
+++ b/apps/hyperlocalise-web/src/components/app/app-shell-title.ts
@@ -1,0 +1,29 @@
+const ROUTE_TITLES = {
+  account: "Account",
+  agent: "Agent",
+  billing: "Billing",
+  dashboard: "Dashboard",
+  glossaries: "Glossaries",
+  integrations: "Integrations",
+  jobs: "Jobs",
+  notifications: "Notifications",
+  projects: "Projects",
+  settings: "Settings",
+} as const;
+
+export function getAppShellTitle(pathname: string | null): string {
+  if (!pathname) {
+    return ROUTE_TITLES.dashboard;
+  }
+
+  const segments = pathname.split("/").filter(Boolean);
+  const organizationIndex = segments.indexOf("org");
+  const routeSegments = organizationIndex >= 0 ? segments.slice(organizationIndex + 2) : segments;
+  const [section, subsection] = routeSegments;
+
+  if (section === "settings" && subsection) {
+    return ROUTE_TITLES[subsection as keyof typeof ROUTE_TITLES] ?? ROUTE_TITLES.settings;
+  }
+
+  return ROUTE_TITLES[section as keyof typeof ROUTE_TITLES] ?? ROUTE_TITLES.dashboard;
+}

--- a/apps/hyperlocalise-web/src/components/app/dashboard-page-content.tsx
+++ b/apps/hyperlocalise-web/src/components/app/dashboard-page-content.tsx
@@ -318,7 +318,7 @@ export function DashboardPageContent() {
           </CardHeader>
           <CardContent className="px-0 pb-3">
             <div className="overflow-x-auto">
-              <div className="min-w-[42rem]">
+              <div className="min-w-2xl">
                 <div className="grid grid-cols-[minmax(10rem,1fr)_7rem_minmax(8rem,1fr)_6rem_6rem_minmax(10rem,1fr)] gap-3 px-5 py-2 text-xs font-medium tracking-[0.08em] text-white/38 uppercase">
                   <p>Locale</p>
                   <p>Status</p>
@@ -497,7 +497,7 @@ export function DashboardPageContent() {
           </CardHeader>
           <CardContent className="px-0 pb-3">
             <div className="overflow-x-auto">
-              <div className="min-w-[58rem]">
+              <div className="min-w-232">
                 <div className="grid grid-cols-[minmax(11rem,1.1fr)_8rem_8rem_5rem_7rem_7rem_7rem_minmax(11rem,1fr)_7rem] gap-3 px-5 py-2 text-xs font-medium tracking-[0.08em] text-white/38 uppercase">
                   <p>Job</p>
                   <p>Source</p>


### PR DESCRIPTION
## What changed

Updated the authenticated app shell header to derive its page title from the current route instead of always rendering `Dashboard`.

Added a small `getAppShellTitle` helper for workspace routes and settings subroutes, plus unit coverage for dashboard, projects, jobs, glossaries, agent, integrations, settings, account, billing, and notifications pages.

## How to test

- `make fmt`
- `make lint`
- `make test`
- `vp test`
- `vp check --fix`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
