### PR TITLE
fix(web): route email replies to org inboxes

### DIFF
--- a/apps/hyperlocalise-web/src/lib/resend/adapter.test.ts
+++ b/apps/hyperlocalise-web/src/lib/resend/adapter.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { createResendAdapter } from "./adapter";
+
+const mocks = vi.hoisted(() => ({
+  send: vi.fn(async () => ({ data: { id: "email_reply" }, error: null })),
+}));
+
+vi.mock("resend", () => ({
+  Resend: vi.fn(function Resend() {
+    return {
+      emails: {
+        send: mocks.send,
+      },
+    };
+  }),
+}));
+
+describe("createResendAdapter", () => {
+  it("sets Reply-To from inbound thread metadata when posting a reply", async () => {
+    const adapter = createResendAdapter({
+      apiKey: "test-key",
+      webhookSecret: "test-secret",
+      fromAddress: "agent@example.com",
+      fromName: "Hyperlocalise",
+    });
+    const threadId = adapter.encodeThreadId({
+      senderEmail: "sender@example.com",
+      threadHash: "thread_123",
+    });
+    const metadataKey = `resend:thread:${threadId}:metadata`;
+    const state = {
+      get: vi.fn(async (key: string) =>
+        key === metadataKey
+          ? {
+              subject: "Translate",
+              messageId: "message_123",
+              replyToAddress: "example-org@inbox.hyperlocalise.com",
+            }
+          : null,
+      ),
+    };
+
+    await adapter.initialize({ getState: () => state } as never);
+    await adapter.postMessage(threadId, "Got it.");
+
+    expect(mocks.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: "Hyperlocalise <agent@example.com>",
+        to: "sender@example.com",
+        replyTo: "example-org@inbox.hyperlocalise.com",
+        subject: "Re: Translate",
+      }),
+    );
+  });
+
+  it("stores the org inbound address as Reply-To from received email recipients", async () => {
+    const adapter = createResendAdapter({
+      apiKey: "test-key",
+      webhookSecret: "",
+      fromAddress: "agent@example.com",
+      fromName: "Hyperlocalise",
+    });
+    const state = {
+      get: vi.fn(async () => null),
+      set: vi.fn(async (_key: string, _metadata: unknown, _ttl: number) => undefined),
+    };
+
+    await adapter.initialize({
+      getState: () => state,
+      processMessage: vi.fn(),
+    } as never);
+    await adapter.handleWebhook(
+      new Request("https://example.com/webhook", {
+        method: "POST",
+        body: JSON.stringify({
+          type: "email.received",
+          data: {
+            email_id: "email_123",
+            from: "Sender <sender@example.com>",
+            to: [
+              "Support <support@example.com>",
+              "Example Org <example-org@inbox.hyperlocalise.com>",
+            ],
+            subject: "Translate",
+            text: "Translate from en to fr",
+            message_id: "message_123",
+            attachments: [],
+          },
+        }),
+      }),
+    );
+
+    expect(state.set).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        replyToAddress: "example-org@inbox.hyperlocalise.com",
+      }),
+      expect.any(Number),
+    );
+  });
+
+  it("isolates thread metadata by org inbound address for the same sender and subject", async () => {
+    const adapter = createResendAdapter({
+      apiKey: "test-key",
+      webhookSecret: "",
+      fromAddress: "agent@example.com",
+      fromName: "Hyperlocalise",
+    });
+    const state = {
+      get: vi.fn(async () => null),
+      set: vi.fn(async (_key: string, _metadata: unknown, _ttl: number) => undefined),
+    };
+
+    await adapter.initialize({
+      getState: () => state,
+      processMessage: vi.fn(),
+    } as never);
+
+    for (const [emailId, inboundAddress] of [
+      ["email_123", "example-org@inbox.hyperlocalise.com"],
+      ["email_456", "other-org@inbox.hyperlocalise.com"],
+    ] as const) {
+      await adapter.handleWebhook(
+        new Request("https://example.com/webhook", {
+          method: "POST",
+          body: JSON.stringify({
+            type: "email.received",
+            data: {
+              email_id: emailId,
+              from: "Sender <sender@example.com>",
+              to: [`Org <${inboundAddress}>`],
+              subject: "Translate",
+              text: "Translate from en to fr",
+              message_id: `message_${emailId}`,
+              attachments: [],
+            },
+          }),
+        }),
+      );
+    }
+
+    expect(state.set).toHaveBeenCalledTimes(2);
+    expect(state.set.mock.calls[0]?.[0]).not.toBe(state.set.mock.calls[1]?.[0]);
+    expect(state.set.mock.calls[0]?.[1]).toMatchObject({
+      replyToAddress: "example-org@inbox.hyperlocalise.com",
+    });
+    expect(state.set.mock.calls[1]?.[1]).toMatchObject({
+      replyToAddress: "other-org@inbox.hyperlocalise.com",
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/resend/adapter.ts
+++ b/apps/hyperlocalise-web/src/lib/resend/adapter.ts
@@ -42,6 +42,7 @@ export type ResendRawMessage = {
 export interface ResendAdapterConfig {
   fromAddress: string;
   fromName?: string;
+  replyToAddress?: string;
   apiKey?: string;
   webhookSecret?: string;
   userName?: string;
@@ -61,16 +62,23 @@ function hashString(str: string): string {
   return createHash("sha256").update(str).digest("hex").slice(0, 12);
 }
 
-function getThreadHash(subject: string): string {
-  return hashString(normalizeSubject(subject));
+function getThreadHash(subject: string, replyToAddress?: string): string {
+  return hashString(`${normalizeSubject(subject)}:${replyToAddress?.toLowerCase() ?? ""}`);
 }
 
 function parseEmailAddress(address: string): { name?: string; email: string } {
-  const match = address.match(/^(?:"?([^"]*)"?\s*)?<?([^>]+)>?$/);
-  if (match) {
-    return { name: match[1]?.trim(), email: match[2]?.trim() ?? address };
+  const bracketed = address.match(/^\s*(?:"?([^"<]*)"?\s*)?<([^>]+)>\s*$/);
+  if (bracketed) {
+    return { name: bracketed[1]?.trim(), email: bracketed[2]?.trim() ?? address };
   }
   return { email: address.trim() };
+}
+
+function getReplyToAddress(addresses: string[]) {
+  const parsed = addresses.map((address) => parseEmailAddress(address).email);
+  return (
+    parsed.find((email) => email.toLowerCase().endsWith("@inbox.hyperlocalise.com")) ?? parsed[0]
+  );
 }
 
 const THREAD_METADATA_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
@@ -84,6 +92,7 @@ class ResendAdapter implements Adapter<ResendThreadId, ResendRawMessage> {
   private readonly resend: Resend;
   private readonly fromAddress: string;
   private readonly fromName: string;
+  private readonly replyToAddress?: string;
   private readonly webhookSecret: string;
   private readonly logger: Logger;
   private chat?: ChatInstance;
@@ -91,6 +100,7 @@ class ResendAdapter implements Adapter<ResendThreadId, ResendRawMessage> {
   constructor(config: ResendAdapterConfig) {
     this.fromAddress = config.fromAddress;
     this.fromName = config.fromName ?? "Bot";
+    this.replyToAddress = config.replyToAddress;
     this.userName = config.userName ?? "email-bot";
     this.webhookSecret = config.webhookSecret ?? process.env.RESEND_WEBHOOK_SECRET ?? "";
     this.resend = new Resend(config.apiKey ?? process.env.RESEND_API_KEY);
@@ -114,14 +124,14 @@ class ResendAdapter implements Adapter<ResendThreadId, ResendRawMessage> {
 
   private async getThreadMetadata(
     threadId: string,
-  ): Promise<{ subject: string; messageId: string } | null> {
+  ): Promise<{ subject: string; messageId: string; replyToAddress?: string } | null> {
     const state = this.getStateAdapter();
     return state.get(this.getThreadStateKey(threadId));
   }
 
   private async setThreadMetadata(
     threadId: string,
-    metadata: { subject: string; messageId: string },
+    metadata: { subject: string; messageId: string; replyToAddress?: string },
   ): Promise<void> {
     const state = this.getStateAdapter();
     await state.set(this.getThreadStateKey(threadId), metadata, THREAD_METADATA_TTL_MS);
@@ -146,11 +156,14 @@ class ResendAdapter implements Adapter<ResendThreadId, ResendRawMessage> {
     return `resend:${senderEmail}`;
   }
 
-  parseMessage(raw: ResendRawMessage): Message<ResendRawMessage> {
+  parseMessage(
+    raw: ResendRawMessage,
+    replyToAddress = getReplyToAddress(raw.to),
+  ): Message<ResendRawMessage> {
     const { email } = parseEmailAddress(raw.from);
     const threadId = this.encodeThreadId({
       senderEmail: email,
-      threadHash: getThreadHash(raw.subject),
+      threadHash: getThreadHash(raw.subject, replyToAddress),
     });
 
     const author: Author = {
@@ -264,11 +277,13 @@ class ResendAdapter implements Adapter<ResendThreadId, ResendRawMessage> {
         : [],
     };
 
-    const message = this.parseMessage(rawMessage);
+    const replyToAddress = getReplyToAddress(rawMessage.to);
+    const message = this.parseMessage(rawMessage, replyToAddress);
 
     const metadata = {
       subject: rawMessage.subject,
       messageId: rawMessage.messageId,
+      replyToAddress,
     };
     await this.setThreadMetadata(message.threadId, metadata);
 
@@ -325,6 +340,7 @@ class ResendAdapter implements Adapter<ResendThreadId, ResendRawMessage> {
     const result = await this.resend.emails.send({
       from: `${this.fromName} <${this.fromAddress}>`,
       to: senderEmail,
+      replyTo: metadata?.replyToAddress ?? this.replyToAddress,
       subject,
       text,
       attachments: attachments.map((a) => ({

--- a/apps/hyperlocalise-web/src/workflows/email-translation.ts
+++ b/apps/hyperlocalise-web/src/workflows/email-translation.ts
@@ -106,6 +106,7 @@ async function sendReplyEmail(
   const result = await resend.emails.send({
     from: `${env.RESEND_FROM_NAME ?? "Hyperlocalise"} <${event.inboundEmailAddress}>`,
     to: event.senderEmail,
+    replyTo: event.inboundEmailAddress,
     subject: `Re: ${event.subject}`,
     text: [
       `Done: ${event.attachmentFilename}`,
@@ -150,6 +151,7 @@ async function sendFailureReplyEmail(
   const result = await resend.emails.send({
     from: `${env.RESEND_FROM_NAME ?? "Hyperlocalise"} <${event.inboundEmailAddress}>`,
     to: event.senderEmail,
+    replyTo: event.inboundEmailAddress,
     subject: `Re: ${event.subject}`,
     text: [
       `I couldn't translate ${event.attachmentFilename}.`,


### PR DESCRIPTION
## What changed

Added `Reply-To` routing for email agent replies so users respond back to the organization-specific inbound inbox, even when outbound email uses a shared sender address.

This also isolates Resend thread metadata by org inbound address, preventing same-sender/same-subject emails across different org inboxes from sharing reply routing state.

## How to test

- `vp check --fix`
- `vp test`
- `make fmt`
- `make lint`
- `make test`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
