### PR TITLE
feat(email): support image localization requests

### DIFF
--- a/apps/hyperlocalise-web/src/lib/agents/email/README.md
+++ b/apps/hyperlocalise-web/src/lib/agents/email/README.md
@@ -12,9 +12,10 @@ The code is split by integration boundary so the workflow stays testable.
 2. `users.ts` verifies that the sender is a registered Hyperlocalise user.
 3. `organizations.ts` resolves the addressed inbound alias to an enabled
    organization where the sender is a member.
-4. `image-attachments.ts` replies with a clear unsupported-image message.
-5. `intent.ts` asks `gpt-5.4-mini` to interpret the subject and body as a
+4. `intent.ts` asks `gpt-5.4-mini` to interpret the subject and body as a
    translation request.
+5. `image-attachments.ts` sends image attachments and the interpreted request
+   directly to the image model, then replies with the generated image.
 6. `bot.ts` stores a pending request when the agent needs missing locales or
    confirmation.
 7. `attachments.ts` resolves Resend attachment download URLs for accepted file
@@ -90,8 +91,10 @@ emails state this limitation when instructions are present.
 - Inactive or unauthorized inbound address: the bot asks the sender to use the
   active workspace address or ask an admin to enable the email agent.
 - No attachments: the bot explains the required request shape and gives examples.
-- Image-only attachments: the bot explains that image localization is not
-  available in the email translation workflow yet.
+- Image-only attachments: the bot uses the interpreted target locale and
+  instructions to generate a localized image reply.
+- Missing or low-confidence image intent: the bot asks the sender to resend the
+  image with a clearer target language and instructions.
 - Missing email metadata: the bot asks the sender to resend the request because
   it cannot fetch attachments or thread the reply reliably.
 - Missing locale intent: the bot stores the pending request and asks only for the
@@ -113,4 +116,4 @@ emails state this limitation when instructions are present.
 - replies to pending requests continue without new attachments.
 - low-confidence intent asks for confirmation before enqueueing.
 - duplicate requests do not enqueue duplicate jobs.
-- image-only emails return the unsupported-image message.
+- image-only emails generate a localized image when the target language is clear.

--- a/apps/hyperlocalise-web/src/lib/agents/email/bot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/email/bot.test.ts
@@ -109,6 +109,15 @@ function createDependencies() {
         missingFields: [],
       }),
     ),
+    interpretClarificationReply: vi.fn(
+      async (): Promise<EmailRequestIntent> => ({
+        sourceLocale: "en-US",
+        targetLocale: "fr-FR",
+        instructions: null,
+        confidence: 0.94,
+        missingFields: [],
+      }),
+    ),
     fetchAttachmentDownloadUrls: vi.fn(async () => [
       {
         id: "att_123",
@@ -118,7 +127,10 @@ function createDependencies() {
       },
     ]),
     handleImageAttachment: vi.fn(async (thread: Thread<EmailBotState>) => {
-      await thread.post("I received an image, but image localization is not available yet.");
+      await thread.post({
+        raw: "Done: banner.png\nLocalized image: fr\nAttached: generated image",
+        files: [{ data: Buffer.from("image"), filename: "banner-fr.png", mimeType: "image/png" }],
+      });
     }),
   } satisfies EmailHandlerDependencies;
 
@@ -150,13 +162,13 @@ describe("createEmailHandler", () => {
     expect(getState().processedTranslationKeys).toHaveLength(1);
   });
 
-  it("stores a pending request when source or target locale is missing", async () => {
+  it("proceeds when only target locale is present (source is optional)", async () => {
     const dependencies = createDependencies();
     dependencies.interpretEmailRequest.mockResolvedValueOnce({
       sourceLocale: null,
       targetLocale: "fr",
       instructions: null,
-      confidence: 0.9,
+      confidence: 0.92,
       missingFields: ["sourceLocale"],
     });
     const { thread, posts, getState } = createThread();
@@ -164,24 +176,43 @@ describe("createEmailHandler", () => {
 
     await handler(thread, createMessage({ text: "Translate to French" }));
 
+    expect(posts[0]).toContain("Got it. I am translating:");
+    expect(posts[0]).toContain("Source: auto-detect");
+    expect(posts[0]).toContain("Target: fr");
+    expect(dependencies.queue.enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceLocale: null,
+        targetLocale: "fr",
+      }),
+    );
+    expect(getState().pendingTranslationRequest).toBeUndefined();
+  });
+
+  it("stores a pending request when target locale is missing", async () => {
+    const dependencies = createDependencies();
+    dependencies.interpretEmailRequest.mockResolvedValueOnce({
+      sourceLocale: "en",
+      targetLocale: null,
+      instructions: null,
+      confidence: 0.9,
+      missingFields: ["targetLocale"],
+    });
+    const { thread, posts, getState } = createThread();
+    const handler = createEmailHandler(dependencies);
+
+    await handler(thread, createMessage({ text: "Translate from English" }));
+
     expect(posts[0]).toContain("I received your file");
-    expect(posts[0]).toContain("source language");
+    expect(posts[0]).toContain("target language");
     expect(getState().pendingTranslationRequest).toMatchObject({
-      targetLocale: "fr",
-      sourceLocale: null,
+      sourceLocale: "en",
+      targetLocale: null,
     });
     expect(dependencies.queue.enqueue).not.toHaveBeenCalled();
   });
 
   it("continues a pending request when the user replies with missing locales", async () => {
     const dependencies = createDependencies();
-    dependencies.interpretEmailRequest.mockResolvedValueOnce({
-      sourceLocale: "en-US",
-      targetLocale: "fr-FR",
-      instructions: null,
-      confidence: 0.94,
-      missingFields: [],
-    });
     const { thread, posts } = createThread({
       pendingTranslationRequest: {
         requestId: "eml_pending",
@@ -201,7 +232,7 @@ describe("createEmailHandler", () => {
     await handler(
       thread,
       createMessage({
-        text: "source: en-US\ntarget: fr-FR",
+        text: "English to French",
         raw: { emailId: "email_reply", messageId: "message_reply", attachments: [] },
         attachments: [],
       }),
@@ -209,6 +240,9 @@ describe("createEmailHandler", () => {
 
     expect(posts[0]).toContain("Got it. I am translating:");
     expect(dependencies.resolveInboundEmailOrganization).not.toHaveBeenCalled();
+    expect(dependencies.interpretClarificationReply).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "English to French" }),
+    );
     expect(dependencies.queue.enqueue).toHaveBeenCalledWith(
       expect.objectContaining({
         requestId: "eml_pending",
@@ -253,7 +287,7 @@ describe("createEmailHandler", () => {
     expect(dependencies.queue.enqueue).not.toHaveBeenCalled();
   });
 
-  it("routes image-only emails to the unsupported image message", async () => {
+  it("routes image-only emails through image localization", async () => {
     const dependencies = createDependencies();
     const { thread, posts } = createThread();
     const handler = createEmailHandler(dependencies);
@@ -268,7 +302,104 @@ describe("createEmailHandler", () => {
       }),
     );
 
-    expect(posts[0]).toContain("image localization is not available");
+    expect(posts[0]).toMatchObject({
+      raw: expect.stringContaining("Localized image: fr"),
+      files: [expect.objectContaining({ filename: "banner-fr.png" })],
+    });
+    expect(dependencies.handleImageAttachment).toHaveBeenCalledWith(
+      thread,
+      expect.anything(),
+      expect.objectContaining({ type: "image", name: "banner.png" }),
+      expect.objectContaining({ emailId: "email_123" }),
+      expect.objectContaining({ targetLocale: "fr" }),
+    );
+    expect(dependencies.interpretEmailRequest).toHaveBeenCalled();
     expect(dependencies.queue.enqueue).not.toHaveBeenCalled();
+  });
+
+  it("asks for a target language before localizing image-only emails", async () => {
+    const dependencies = createDependencies();
+    dependencies.interpretEmailRequest.mockResolvedValueOnce({
+      sourceLocale: null,
+      targetLocale: null,
+      instructions: null,
+      confidence: 0.9,
+      missingFields: ["targetLocale"],
+    });
+    const { thread, posts } = createThread();
+    const handler = createEmailHandler(dependencies);
+
+    await handler(
+      thread,
+      createMessage({
+        raw: {
+          attachments: [{ id: "img_123", filename: "banner.png", contentType: "image/png" }],
+        },
+        attachments: [{ type: "image", name: "banner.png", mimeType: "image/png" }],
+      }),
+    );
+
+    expect(posts[0]).toContain("target language");
+    expect(dependencies.handleImageAttachment).not.toHaveBeenCalled();
+    expect(dependencies.queue.enqueue).not.toHaveBeenCalled();
+  });
+
+  it("merges new file attachments into pending clarification instead of starting a new request", async () => {
+    const dependencies = createDependencies();
+    dependencies.interpretClarificationReply.mockResolvedValueOnce({
+      sourceLocale: "en-US",
+      targetLocale: "fr",
+      instructions: null,
+      confidence: 0.96,
+      missingFields: [],
+    });
+    const { thread, posts, getState } = createThread({
+      pendingTranslationRequest: {
+        requestId: "eml_pending",
+        senderEmail: "sender@example.com",
+        subject: "Translate",
+        originalMessageId: "message_original",
+        emailId: "email_original",
+        inboundEmailAddress: "example-org@inbox.hyperlocalise.com",
+        attachments: [{ id: "att_old", filename: "old.xlsx", contentType: "text/csv" }],
+        sourceLocale: null,
+        targetLocale: "fr",
+        instructions: null,
+      },
+    });
+    dependencies.fetchAttachmentDownloadUrls.mockResolvedValueOnce([
+      {
+        id: "att_old",
+        filename: "old.xlsx",
+        downloadUrl: "https://example.com/old.xlsx",
+        contentType: "text/csv",
+      },
+      {
+        id: "att_new",
+        filename: "new.xlsx",
+        downloadUrl: "https://example.com/new.xlsx",
+        contentType: "text/csv",
+      },
+    ]);
+    const handler = createEmailHandler(dependencies);
+
+    await handler(
+      thread,
+      createMessage({
+        text: "source: en-US",
+        raw: {
+          emailId: "email_reply",
+          messageId: "message_reply",
+          attachments: [{ id: "att_new", filename: "new.xlsx", contentType: "text/csv" }],
+        },
+        attachments: [{ type: "file", name: "new.xlsx", mimeType: "text/csv" }],
+      }),
+    );
+
+    expect(posts[0]).toContain("Got it. I am translating:");
+    expect(posts[0]).toContain("old.xlsx");
+    expect(posts[0]).toContain("new.xlsx");
+    expect(getState().pendingTranslationRequest).toBeUndefined();
+    expect(dependencies.queue.enqueue).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/agents/email/bot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/email/bot.test.ts
@@ -344,6 +344,40 @@ describe("createEmailHandler", () => {
     expect(dependencies.queue.enqueue).not.toHaveBeenCalled();
   });
 
+  it("asks once for a target language when mixed image and file emails are missing it", async () => {
+    const dependencies = createDependencies();
+    dependencies.interpretEmailRequest.mockResolvedValueOnce({
+      sourceLocale: null,
+      targetLocale: null,
+      instructions: null,
+      confidence: 0.9,
+      missingFields: ["targetLocale"],
+    });
+    const { thread, posts } = createThread();
+    const handler = createEmailHandler(dependencies);
+
+    await handler(
+      thread,
+      createMessage({
+        raw: {
+          attachments: [
+            { id: "img_123", filename: "banner.png", contentType: "image/png" },
+            { id: "file_123", filename: "copy.csv", contentType: "text/csv" },
+          ],
+        },
+        attachments: [
+          { type: "image", name: "banner.png", mimeType: "image/png" },
+          { type: "file", name: "copy.csv", mimeType: "text/csv" },
+        ],
+      }),
+    );
+
+    expect(posts).toHaveLength(1);
+    expect(posts[0]).toContain("target language");
+    expect(dependencies.handleImageAttachment).not.toHaveBeenCalled();
+    expect(dependencies.queue.enqueue).not.toHaveBeenCalled();
+  });
+
   it("merges new file attachments into pending clarification instead of starting a new request", async () => {
     const dependencies = createDependencies();
     dependencies.interpretClarificationReply.mockResolvedValueOnce({

--- a/apps/hyperlocalise-web/src/lib/agents/email/bot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/email/bot.test.ts
@@ -378,6 +378,45 @@ describe("createEmailHandler", () => {
     expect(dependencies.queue.enqueue).not.toHaveBeenCalled();
   });
 
+  it("keeps mixed email files pending when image localization confidence is low", async () => {
+    const dependencies = createDependencies();
+    dependencies.interpretEmailRequest.mockResolvedValueOnce({
+      sourceLocale: "en",
+      targetLocale: "fr",
+      instructions: null,
+      confidence: 0.7,
+      missingFields: [],
+    });
+    const { thread, posts, getState } = createThread();
+    const handler = createEmailHandler(dependencies);
+
+    await handler(
+      thread,
+      createMessage({
+        raw: {
+          attachments: [
+            { id: "img_123", filename: "banner.png", contentType: "image/png" },
+            { id: "file_123", filename: "copy.csv", contentType: "text/csv" },
+          ],
+        },
+        attachments: [
+          { type: "image", name: "banner.png", mimeType: "image/png" },
+          { type: "file", name: "copy.csv", mimeType: "text/csv" },
+        ],
+      }),
+    );
+
+    expect(posts[0]).toContain('Please reply "yes" to start');
+    expect(posts[0]).toContain("- copy.csv");
+    expect(getState().pendingTranslationRequest).toMatchObject({
+      attachments: [{ id: "file_123", filename: "copy.csv" }],
+      sourceLocale: "en",
+      targetLocale: "fr",
+    });
+    expect(dependencies.handleImageAttachment).not.toHaveBeenCalled();
+    expect(dependencies.queue.enqueue).not.toHaveBeenCalled();
+  });
+
   it("merges new file attachments into pending clarification instead of starting a new request", async () => {
     const dependencies = createDependencies();
     dependencies.interpretClarificationReply.mockResolvedValueOnce({

--- a/apps/hyperlocalise-web/src/lib/agents/email/bot.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/email/bot.ts
@@ -4,6 +4,7 @@ import type { Message, Thread } from "chat";
 
 import { createChatStateAdapter } from "@/lib/agents/runtime/state";
 import { env } from "@/lib/env";
+import { createChatLogger, createLogger } from "@/lib/log";
 import { createResendAdapter } from "@/lib/resend/adapter";
 import type { EmailTranslationEventData, EmailTranslationQueue } from "@/lib/workflow/types";
 import { createEmailTranslationQueue } from "@/workflows/adapters";
@@ -15,12 +16,11 @@ import {
   interpretClarificationReply,
   interpretEmailRequest,
 } from "./intent";
-
-export { interpretClarificationReply };
 import { resolveInboundEmailOrganization } from "./organizations";
 import type { EmailBotState, PendingEmailTranslationRequest, RawEmailMessage } from "./types";
 import { lookupUserByEmail } from "./users";
-import { createChatLogger, createLogger } from "@/lib/log";
+
+export { interpretClarificationReply };
 
 let botInstance: Chat<{ resend: ReturnType<typeof createResendAdapter> }, EmailBotState> | null =
   null;
@@ -439,6 +439,7 @@ export function createEmailHandler(dependencies: EmailHandlerDependencies) {
           await thread.post(
             "I received your image, but I need the target language before I can localize it. Please resend the image with a target language, for example: Target: Japanese.",
           );
+          return;
         } else if (intent.confidence < intentConfirmationThreshold) {
           log.info(
             { confidence: intent.confidence },
@@ -447,6 +448,7 @@ export function createEmailHandler(dependencies: EmailHandlerDependencies) {
           await thread.post(
             "I received your image, but I am not confident about the localization request. Please resend it with the target language and any image instructions.",
           );
+          return;
         } else {
           log.info({ count: imageAttachments.length }, "handling image attachments");
           for (const imageAttachment of imageAttachments) {

--- a/apps/hyperlocalise-web/src/lib/agents/email/bot.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/email/bot.ts
@@ -445,10 +445,12 @@ export function createEmailHandler(dependencies: EmailHandlerDependencies) {
             { confidence: intent.confidence },
             "low confidence for image localization, requesting resend with clearer intent",
           );
-          await thread.post(
-            "I received your image, but I am not confident about the localization request. Please resend it with the target language and any image instructions.",
-          );
-          return;
+          if (fileAttachments.length === 0) {
+            await thread.post(
+              "I received your image, but I am not confident about the localization request. Please resend it with the target language and any image instructions.",
+            );
+            return;
+          }
         } else {
           log.info({ count: imageAttachments.length }, "handling image attachments");
           for (const imageAttachment of imageAttachments) {

--- a/apps/hyperlocalise-web/src/lib/agents/email/bot.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/email/bot.ts
@@ -10,7 +10,13 @@ import { createEmailTranslationQueue } from "@/workflows/adapters";
 
 import { fetchAttachmentDownloadUrls } from "./attachments";
 import { handleImageAttachment } from "./image-attachments";
-import { type EmailRequestIntent, interpretEmailRequest } from "./intent";
+import {
+  type EmailRequestIntent,
+  interpretClarificationReply,
+  interpretEmailRequest,
+} from "./intent";
+
+export { interpretClarificationReply };
 import { resolveInboundEmailOrganization } from "./organizations";
 import type { EmailBotState, PendingEmailTranslationRequest, RawEmailMessage } from "./types";
 import { lookupUserByEmail } from "./users";
@@ -27,6 +33,7 @@ export type EmailHandlerDependencies = {
   lookupUserByEmail: typeof lookupUserByEmail;
   resolveInboundEmailOrganization: typeof resolveInboundEmailOrganization;
   interpretEmailRequest: typeof interpretEmailRequest;
+  interpretClarificationReply: typeof interpretClarificationReply;
   fetchAttachmentDownloadUrls: typeof fetchAttachmentDownloadUrls;
   handleImageAttachment: typeof handleImageAttachment;
 };
@@ -41,13 +48,13 @@ function createRequestId(input: string) {
 function createTranslationKey(input: {
   emailId: string;
   attachmentId: string;
-  sourceLocale: string;
+  sourceLocale: string | null;
   targetLocale: string;
 }) {
   return [
     input.emailId,
     input.attachmentId,
-    input.sourceLocale.toLowerCase(),
+    (input.sourceLocale ?? "auto").toLowerCase(),
     input.targetLocale.toLowerCase(),
   ].join(":");
 }
@@ -79,7 +86,7 @@ function buildSupportedRequestHelp() {
 
 function buildClarificationMessage(pending: PendingEmailTranslationRequest) {
   const missing = [
-    pending.sourceLocale ? null : "source language",
+    pending.sourceLocale ? null : "source language (optional — I can auto-detect)",
     pending.targetLocale ? null : "target language",
   ].filter(Boolean);
 
@@ -90,8 +97,9 @@ function buildClarificationMessage(pending: PendingEmailTranslationRequest) {
     formatFileList(pending.attachments),
     "",
     "Reply with something like:",
-    "source: en-US",
-    "target: fr-FR",
+    "Target: Vietnamese",
+    "English to Vietnamese",
+    "source: en-US, target: vi-VN",
     "",
     `Request ID: ${pending.requestId}`,
   ].join("\n");
@@ -104,7 +112,7 @@ function buildConfirmationMessage(pending: PendingEmailTranslationRequest) {
     "Files:",
     formatFileList(pending.attachments),
     "",
-    `Source: ${pending.sourceLocale}`,
+    pending.sourceLocale ? `Source: ${pending.sourceLocale}` : "Source: auto-detect",
     `Target: ${pending.targetLocale}`,
     pending.instructions ? `Instructions: ${pending.instructions}` : null,
     pending.instructions
@@ -127,7 +135,7 @@ function buildIntakeReceipt(input: {
     "Files:",
     formatFileList(input.pending.attachments),
     "",
-    `Source: ${input.pending.sourceLocale}`,
+    input.pending.sourceLocale ? `Source: ${input.pending.sourceLocale}` : "Source: auto-detect",
     `Target: ${input.pending.targetLocale}`,
     input.pending.instructions ? `Instructions: ${input.pending.instructions}` : null,
     input.pending.instructions
@@ -161,8 +169,8 @@ async function enqueuePendingTranslation(input: {
     "enqueueing pending translation",
   );
 
-  if (!pending.sourceLocale || !pending.targetLocale) {
-    log.info("missing locales, requesting clarification");
+  if (!pending.targetLocale) {
+    log.info("missing target locale, requesting clarification");
     await thread.post(buildClarificationMessage(pending));
     await thread.setState({ pendingTranslationRequest: pending });
     return;
@@ -276,7 +284,7 @@ async function handlePendingClarification(input: {
   const log = logger.child({ req: pending.requestId });
   log.info("handling pending clarification");
 
-  if (isAffirmative(message.text) && pending.sourceLocale && pending.targetLocale) {
+  if (isAffirmative(message.text) && pending.targetLocale) {
     log.info("affirmative response, proceeding with translation");
     await enqueuePendingTranslation({
       thread,
@@ -287,8 +295,7 @@ async function handlePendingClarification(input: {
     return;
   }
 
-  const intent = await dependencies.interpretEmailRequest({
-    subject: pending.subject,
+  const intent = await dependencies.interpretClarificationReply({
     text: message.text,
   });
   log.info(
@@ -306,8 +313,8 @@ async function handlePendingClarification(input: {
     instructions: intent.instructions ?? pending.instructions,
   };
 
-  if (!nextPending.sourceLocale || !nextPending.targetLocale) {
-    log.info("still missing locales after clarification");
+  if (!nextPending.targetLocale) {
+    log.info("still missing target locale after clarification");
     await thread.post(buildClarificationMessage(nextPending));
     await thread.setState({ pendingTranslationRequest: nextPending });
     return;
@@ -356,10 +363,25 @@ export function createEmailHandler(dependencies: EmailHandlerDependencies) {
       }
 
       const state = await thread.state;
-      const pending = state?.pendingTranslationRequest;
+      let pending = state?.pendingTranslationRequest;
       const attachments = raw.attachments ?? [];
 
-      if (pending && pending.senderEmail === senderEmail && attachments.length === 0) {
+      if (pending && pending.senderEmail === senderEmail) {
+        if (attachments.length > 0) {
+          const fileAttachments = attachments.filter(
+            (att) => !att.contentType.startsWith("image/"),
+          );
+          if (fileAttachments.length > 0) {
+            log.info(
+              { newAttachmentCount: fileAttachments.length },
+              "merging new attachments into pending clarification",
+            );
+            pending = {
+              ...pending,
+              attachments: [...pending.attachments, ...fileAttachments],
+            };
+          }
+        }
         log.info("resuming pending clarification");
         await handlePendingClarification({ thread, message, pending, dependencies });
         return;
@@ -393,16 +415,9 @@ export function createEmailHandler(dependencies: EmailHandlerDependencies) {
       }
 
       const imageAttachments = message.attachments.filter((att) => att.type === "image");
-      if (imageAttachments.length > 0) {
-        log.info({ count: imageAttachments.length }, "handling image attachments");
-      }
-      for (const imageAttachment of imageAttachments) {
-        await dependencies.handleImageAttachment(thread, message, imageAttachment, raw);
-      }
-
       const fileAttachments = attachments.filter((att) => !att.contentType.startsWith("image/"));
-      if (fileAttachments.length === 0) {
-        log.info("no file attachments after filtering images");
+      if (imageAttachments.length === 0 && fileAttachments.length === 0) {
+        log.info("no supported attachments found");
         return;
       }
 
@@ -418,6 +433,33 @@ export function createEmailHandler(dependencies: EmailHandlerDependencies) {
         "intent interpreted",
       );
 
+      if (imageAttachments.length > 0) {
+        if (!intent.targetLocale) {
+          log.info("missing target locale for image localization");
+          await thread.post(
+            "I received your image, but I need the target language before I can localize it. Please resend the image with a target language, for example: Target: Japanese.",
+          );
+        } else if (intent.confidence < intentConfirmationThreshold) {
+          log.info(
+            { confidence: intent.confidence },
+            "low confidence for image localization, requesting resend with clearer intent",
+          );
+          await thread.post(
+            "I received your image, but I am not confident about the localization request. Please resend it with the target language and any image instructions.",
+          );
+        } else {
+          log.info({ count: imageAttachments.length }, "handling image attachments");
+          for (const imageAttachment of imageAttachments) {
+            await dependencies.handleImageAttachment(thread, message, imageAttachment, raw, intent);
+          }
+        }
+      }
+
+      if (fileAttachments.length === 0) {
+        log.info("no file attachments after filtering images");
+        return;
+      }
+
       const pendingRequest = createPendingRequest({
         senderEmail,
         raw,
@@ -426,8 +468,8 @@ export function createEmailHandler(dependencies: EmailHandlerDependencies) {
         intent,
       });
 
-      if (!pendingRequest.sourceLocale || !pendingRequest.targetLocale) {
-        log.info("missing locales, requesting clarification");
+      if (!pendingRequest.targetLocale) {
+        log.info("missing target locale, requesting clarification");
         await thread.post(buildClarificationMessage(pendingRequest));
         await thread.setState({ pendingTranslationRequest: pendingRequest });
         return;
@@ -467,6 +509,7 @@ export async function getEmailBot(options?: { emailTranslationQueue?: EmailTrans
     lookupUserByEmail,
     resolveInboundEmailOrganization,
     interpretEmailRequest,
+    interpretClarificationReply,
     fetchAttachmentDownloadUrls,
     handleImageAttachment,
   });

--- a/apps/hyperlocalise-web/src/lib/agents/email/image-attachments.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/email/image-attachments.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import type { Message, Thread } from "chat";
+
+import { regenerateImageFromAttachment } from "@/lib/image-generation";
+
+import { handleImageAttachment } from "./image-attachments";
+import type { EmailRequestIntent } from "./intent";
+import type { EmailBotState, RawEmailMessage } from "./types";
+
+vi.mock("@/lib/image-generation", () => ({
+  regenerateImageFromAttachment: vi.fn(),
+}));
+
+function createThread() {
+  const posts: unknown[] = [];
+  const thread = {
+    post: vi.fn(async (message: unknown) => {
+      posts.push(message);
+      return {};
+    }),
+  } as unknown as Thread<EmailBotState>;
+
+  return { posts, thread };
+}
+
+const raw = {
+  emailId: "email_123",
+  messageId: "message_123",
+  subject: "Translate banner",
+} satisfies Pick<RawEmailMessage, "emailId" | "messageId" | "subject">;
+
+const intent = {
+  sourceLocale: "en",
+  targetLocale: "fr",
+  instructions: null,
+  confidence: 0.95,
+  missingFields: [],
+} satisfies EmailRequestIntent;
+
+describe("handleImageAttachment", () => {
+  it("uses the generated image media type for the posted file", async () => {
+    vi.mocked(regenerateImageFromAttachment).mockResolvedValueOnce({
+      image: Buffer.from("generated"),
+      mimeType: "image/webp",
+      prompt: "prompt",
+    });
+    const { posts, thread } = createThread();
+    const message = {
+      text: "Translate to French",
+    } as Message<EmailBotState>;
+    const imageAttachment = {
+      type: "image",
+      name: "banner.png",
+      mimeType: "image/png",
+      data: Buffer.from("source"),
+    } as Message["attachments"][number];
+
+    await handleImageAttachment(thread, message, imageAttachment, raw, intent);
+
+    expect(posts[0]).toMatchObject({
+      files: [
+        {
+          filename: "banner-fr.webp",
+          mimeType: "image/webp",
+        },
+      ],
+    });
+  });
+
+  it("falls back to PNG when no source filename or generated media type is available", async () => {
+    vi.mocked(regenerateImageFromAttachment).mockResolvedValueOnce({
+      image: Buffer.from("generated"),
+      mimeType: "",
+      prompt: "prompt",
+    });
+    const { posts, thread } = createThread();
+    const message = {
+      text: "Translate to French",
+    } as Message<EmailBotState>;
+    const imageAttachment = {
+      type: "image",
+      data: Buffer.from("source"),
+    } as Message["attachments"][number];
+
+    await handleImageAttachment(thread, message, imageAttachment, raw, {
+      ...intent,
+      targetLocale: null,
+    });
+
+    expect(posts[0]).toMatchObject({
+      files: [
+        {
+          filename: "image-localized.png",
+          mimeType: "image/png",
+        },
+      ],
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/agents/email/image-attachments.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/email/image-attachments.ts
@@ -21,18 +21,42 @@ function imageAttachmentData(imageAttachment: Message["attachments"][number]) {
   throw new Error(`Image attachment ${imageAttachment.name ?? "attachment"} has no data`);
 }
 
-function outputFilename(filename: string | undefined, targetLocale: string | null) {
+function extensionFromMimeType(mimeType: string) {
+  const normalizedMimeType = mimeType.toLowerCase().split(";")[0]?.trim();
+  switch (normalizedMimeType) {
+    case "image/jpeg":
+      return "jpg";
+    case "image/png":
+      return "png";
+    case "image/webp":
+      return "webp";
+    case "image/gif":
+      return "gif";
+    default:
+      if (normalizedMimeType?.startsWith("image/")) {
+        return normalizedMimeType.slice("image/".length).replace(/\+xml$/, "");
+      }
+      return "png";
+  }
+}
+
+function outputFilename(
+  filename: string | undefined,
+  targetLocale: string | null,
+  mimeType: string,
+) {
   const suffix = targetLocale ? `-${targetLocale.toLowerCase()}` : "-localized";
+  const extension = extensionFromMimeType(mimeType);
   if (!filename) {
-    return `image${suffix}.png`;
+    return `image${suffix}.${extension}`;
   }
 
   const extensionStart = filename.lastIndexOf(".");
   if (extensionStart <= 0) {
-    return `${filename}${suffix}.png`;
+    return `${filename}${suffix}.${extension}`;
   }
 
-  return `${filename.slice(0, extensionStart)}${suffix}.png`;
+  return `${filename.slice(0, extensionStart)}${suffix}.${extension}`;
 }
 
 function buildImagePrompt(input: {
@@ -70,6 +94,7 @@ export async function handleImageAttachment(
     imageAttachment.mimeType ?? "image/png",
     prompt,
   );
+  const outputMimeType = result.mimeType || "image/png";
 
   await thread.post({
     raw: [
@@ -80,8 +105,8 @@ export async function handleImageAttachment(
     files: [
       {
         data: result.image,
-        filename: outputFilename(imageAttachment.name, intent.targetLocale),
-        mimeType: "image/png",
+        filename: outputFilename(imageAttachment.name, intent.targetLocale, outputMimeType),
+        mimeType: outputMimeType,
       },
     ],
   });

--- a/apps/hyperlocalise-web/src/lib/agents/email/image-attachments.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/email/image-attachments.ts
@@ -1,14 +1,88 @@
 import type { Message, Thread } from "chat";
 
+import { regenerateImageFromAttachment } from "@/lib/image-generation";
+
+import type { EmailRequestIntent } from "./intent";
 import type { EmailBotState, RawEmailMessage } from "./types";
+
+function imageAttachmentData(imageAttachment: Message["attachments"][number]) {
+  if (imageAttachment.fetchData) {
+    return imageAttachment.fetchData();
+  }
+
+  const { data } = imageAttachment;
+  if (Buffer.isBuffer(data)) {
+    return Promise.resolve(data);
+  }
+  if (data instanceof Blob) {
+    return data.arrayBuffer().then((arrayBuffer) => Buffer.from(arrayBuffer));
+  }
+
+  throw new Error(`Image attachment ${imageAttachment.name ?? "attachment"} has no data`);
+}
+
+function outputFilename(filename: string | undefined, targetLocale: string | null) {
+  const suffix = targetLocale ? `-${targetLocale.toLowerCase()}` : "-localized";
+  if (!filename) {
+    return `image${suffix}.png`;
+  }
+
+  const extensionStart = filename.lastIndexOf(".");
+  if (extensionStart <= 0) {
+    return `${filename}${suffix}.png`;
+  }
+
+  return `${filename.slice(0, extensionStart)}${suffix}.png`;
+}
+
+function buildImagePrompt(input: {
+  message: Message;
+  imageAttachment: Message["attachments"][number];
+  intent: EmailRequestIntent;
+  raw: Pick<RawEmailMessage, "subject">;
+}) {
+  const { message, imageAttachment, intent, raw } = input;
+  return [
+    "Use the attached image as the visual source and generate a localized version.",
+    "Preserve the original layout, style, composition, brand treatment, and visual hierarchy unless the user explicitly asks for a change.",
+    intent.sourceLocale ? `Source locale: ${intent.sourceLocale}` : "Source locale: auto-detect",
+    intent.targetLocale ? `Target locale: ${intent.targetLocale}` : null,
+    intent.instructions ? `User instructions: ${intent.instructions}` : null,
+    raw.subject ? `Email subject: ${raw.subject}` : null,
+    message.text ? `Email body: ${message.text}` : null,
+    imageAttachment.name ? `Source filename: ${imageAttachment.name}` : null,
+  ]
+    .filter((line): line is string => line !== null)
+    .join("\n");
+}
 
 export async function handleImageAttachment(
   thread: Thread<EmailBotState>,
-  _message: Message,
+  message: Message,
   imageAttachment: Message["attachments"][number],
-  _raw: Pick<RawEmailMessage, "emailId" | "subject" | "messageId">,
+  raw: Pick<RawEmailMessage, "emailId" | "subject" | "messageId">,
+  intent: EmailRequestIntent,
 ) {
-  await thread.post(
-    `I received ${imageAttachment.name}, but image localization is not available in the email translation workflow yet. Please send a document, spreadsheet, JSON, or text file for translation.`,
+  const image = await imageAttachmentData(imageAttachment);
+  const prompt = buildImagePrompt({ message, imageAttachment, intent, raw });
+  const result = await regenerateImageFromAttachment(
+    image,
+    imageAttachment.mimeType ?? "image/png",
+    prompt,
   );
+
+  await thread.post({
+    raw: [
+      `Done: ${imageAttachment.name ?? "image attachment"}`,
+      intent.targetLocale ? `Localized image: ${intent.targetLocale}` : "Localized image generated",
+      "Attached: generated image",
+    ].join("\n"),
+    files: [
+      {
+        data: result.image,
+        filename: outputFilename(imageAttachment.name, intent.targetLocale),
+        mimeType: "image/png",
+      },
+    ],
+  });
 }

--- a/apps/hyperlocalise-web/src/lib/agents/email/intent.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/email/intent.ts
@@ -27,7 +27,7 @@ function getEmailIntentModel() {
   return provider("gpt-5.4-mini");
 }
 
-function normalizeLocale(locale: string | null) {
+export function normalizeLocale(locale: string | null) {
   const value = locale?.trim().replaceAll("_", "-");
   if (!value) {
     return null;
@@ -104,11 +104,52 @@ export function createEmailRequestInterpreter({ model }: CreateEmailRequestInter
   };
 }
 
+function buildClarificationPrompt(input: { text: string }) {
+  return [
+    "The user is replying to a request for missing translation locale information.",
+    "Extract any source locale and target locale they mention.",
+    "Return the locales as BCP 47 locale tags when they are present.",
+    "Infer common language names and regions, such as English to en, Vietnamese to vi-VN, Brazilian Portuguese to pt-BR, and French Canada to fr-CA.",
+    "If the user only mentions one language, assume it is the target locale unless they explicitly label it as source.",
+    "Put translation preferences in instructions, such as tone, formality, audience, terminology, or style constraints.",
+    "",
+    "User reply:",
+    input.text || "(none)",
+  ].join("\n");
+}
+
+export function createClarificationInterpreter({ model }: CreateEmailRequestInterpreterOptions) {
+  return async (input: { text: string }) => {
+    const { output } = await generateText({
+      model,
+      output: Output.object({
+        schema: emailRequestIntentSchema,
+      }),
+      system:
+        "You are a precise email intake parser for a localization workflow. This is a clarification reply. Return only structured data.",
+      prompt: buildClarificationPrompt(input),
+      temperature: 0,
+    });
+
+    return normalizeEmailRequestIntent(output);
+  };
+}
+
 export async function interpretEmailRequest(input: {
   subject: string;
   text: string;
 }): Promise<EmailRequestIntent> {
   const interpret = createEmailRequestInterpreter({
+    model: getEmailIntentModel(),
+  });
+
+  return interpret(input);
+}
+
+export async function interpretClarificationReply(input: {
+  text: string;
+}): Promise<EmailRequestIntent> {
+  const interpret = createClarificationInterpreter({
     model: getEmailIntentModel(),
   });
 

--- a/apps/hyperlocalise-web/src/lib/image-generation.ts
+++ b/apps/hyperlocalise-web/src/lib/image-generation.ts
@@ -5,6 +5,7 @@ import { env } from "@/lib/env";
 
 export type ImageGenerationResult = {
   image: Buffer;
+  mimeType: string;
   prompt: string;
 };
 
@@ -19,7 +20,10 @@ function getImageModel() {
 /**
  * Generates a new image from the uploaded source image and user intent.
  */
-async function generateImageFromPrompt(imageBuffer: Buffer, prompt: string): Promise<Buffer> {
+async function generateImageFromPrompt(
+  imageBuffer: Buffer,
+  prompt: string,
+): Promise<{ image: Buffer; mimeType: string }> {
   const model = getImageModel();
 
   const result = await generateImage({
@@ -36,7 +40,10 @@ async function generateImageFromPrompt(imageBuffer: Buffer, prompt: string): Pro
     throw new Error("No image was generated");
   }
 
-  return Buffer.from(generatedImage.uint8Array);
+  return {
+    image: Buffer.from(generatedImage.uint8Array),
+    mimeType: generatedImage.mediaType,
+  };
 }
 
 /**
@@ -49,11 +56,12 @@ export async function regenerateImageFromAttachment(
   _mimeType: string,
   userText: string,
 ): Promise<ImageGenerationResult> {
+  // The AI SDK image prompt accepts the source image as a Buffer and infers media type from bytes.
   const prompt = userText.trim();
   if (!prompt) {
     throw new Error("Image generation prompt is required");
   }
 
-  const image = await generateImageFromPrompt(imageBuffer, prompt);
-  return { image, prompt };
+  const generated = await generateImageFromPrompt(imageBuffer, prompt);
+  return { ...generated, prompt };
 }

--- a/apps/hyperlocalise-web/src/lib/image-generation.ts
+++ b/apps/hyperlocalise-web/src/lib/image-generation.ts
@@ -1,31 +1,12 @@
 import { createOpenAI } from "@ai-sdk/openai";
-import { generateImage, generateText, Output } from "ai";
-import { z } from "zod";
+import { generateImage } from "ai";
 
 import { env } from "@/lib/env";
-
-const imageAnalysisOutputSchema = z.object({
-  prompt: z
-    .string()
-    .trim()
-    .min(1)
-    .describe(
-      "A detailed, high-quality prompt for image generation based on the user's image and intent",
-    ),
-});
 
 export type ImageGenerationResult = {
   image: Buffer;
   prompt: string;
 };
-
-function getVisionModel() {
-  if (!env.OPENAI_API_KEY) {
-    throw new Error("OPENAI_API_KEY is not configured");
-  }
-  const provider = createOpenAI({ apiKey: env.OPENAI_API_KEY });
-  return provider("gpt-5.4-mini");
-}
 
 function getImageModel() {
   if (!env.OPENAI_API_KEY) {
@@ -36,56 +17,17 @@ function getImageModel() {
 }
 
 /**
- * Analyzes an uploaded image using a vision model to detect intent and rewrite
- * an optimized prompt for image generation.
+ * Generates a new image from the uploaded source image and user intent.
  */
-async function analyzeImageAndRewritePrompt(
-  imageBuffer: Buffer,
-  mimeType: string,
-  userText?: string,
-): Promise<string> {
-  const model = getVisionModel();
-
-  const { output } = await generateText({
-    model,
-    messages: [
-      {
-        role: "user",
-        content: [
-          {
-            type: "text",
-            text: [
-              "Analyze the attached image and the user's request. Rewrite a detailed, high-quality prompt for an AI image generation model.",
-              "The prompt should capture the intent, style, composition, and key elements from the original image while incorporating any modifications the user requests.",
-              userText ? `User request: ${userText}` : "",
-              "Respond ONLY with the rewritten image generation prompt.",
-            ]
-              .filter(Boolean)
-              .join("\n\n"),
-          },
-          {
-            type: "image",
-            image: imageBuffer,
-            mediaType: mimeType,
-          },
-        ],
-      },
-    ],
-    output: Output.object({ schema: imageAnalysisOutputSchema }),
-  });
-
-  return output.prompt;
-}
-
-/**
- * Generates a new image from a text prompt using an image generation model.
- */
-async function generateImageFromPrompt(prompt: string): Promise<Buffer> {
+async function generateImageFromPrompt(imageBuffer: Buffer, prompt: string): Promise<Buffer> {
   const model = getImageModel();
 
   const result = await generateImage({
     model,
-    prompt,
+    prompt: {
+      images: [imageBuffer],
+      text: prompt,
+    },
     n: 1,
   });
 
@@ -99,16 +41,19 @@ async function generateImageFromPrompt(prompt: string): Promise<Buffer> {
 
 /**
  * End-to-end image regeneration pipeline:
- * 1. Analyze the source image and rewrite an optimized generation prompt
- * 2. Generate a new image using the rewritten prompt
- * 3. Return the generated image buffer and the prompt used
+ * 1. Send the source image and interpreted user intent to the image model
+ * 2. Return the generated image buffer and the prompt used
  */
 export async function regenerateImageFromAttachment(
   imageBuffer: Buffer,
-  mimeType: string,
-  userText?: string,
+  _mimeType: string,
+  userText: string,
 ): Promise<ImageGenerationResult> {
-  const prompt = await analyzeImageAndRewritePrompt(imageBuffer, mimeType, userText);
-  const image = await generateImageFromPrompt(prompt);
+  const prompt = userText.trim();
+  if (!prompt) {
+    throw new Error("Image generation prompt is required");
+  }
+
+  const image = await generateImageFromPrompt(imageBuffer, prompt);
   return { image, prompt };
 }

--- a/apps/hyperlocalise-web/src/lib/workflow/types.ts
+++ b/apps/hyperlocalise-web/src/lib/workflow/types.ts
@@ -71,7 +71,7 @@ export type EmailTranslationEventData = {
   inboundEmailAddress: string;
   attachmentDownloadUrl: string;
   attachmentFilename: string;
-  sourceLocale: string;
+  sourceLocale: string | null;
   targetLocale: string;
   instructions: string | null;
 };

--- a/apps/hyperlocalise-web/src/workflows/email-translation.ts
+++ b/apps/hyperlocalise-web/src/workflows/email-translation.ts
@@ -61,18 +61,59 @@ async function downloadAttachment(
   }
 }
 
+function buildTempConfig(
+  inputFile: string,
+  outputFile: string,
+  sourceLocale: string | null,
+  targetLocale: string,
+): string {
+  return [
+    "locales:",
+    `  source: ${sourceLocale ?? "auto"}`,
+    "  targets:",
+    `    - ${targetLocale}`,
+    "",
+    "buckets:",
+    "  email:",
+    "    files:",
+    `      - from: ${inputFile}`,
+    `        to: ${outputFile}`,
+    "",
+    "llm:",
+    "  profiles:",
+    "    default:",
+    "      provider: openai",
+    "      model: gpt-5.2",
+  ].join("\n");
+}
+
+async function writeTempConfig(
+  sandboxId: string,
+  configContent: string,
+  configPath: string,
+): Promise<void> {
+  "use step";
+
+  const sandbox = await Sandbox.get({ sandboxId });
+  await sandbox.writeFiles([{ path: configPath, content: configContent }]);
+}
+
 async function runTranslationCommand(
   sandboxId: string,
   inputFile: string,
   outputFile: string,
-  sourceLocale: string,
+  sourceLocale: string | null,
   targetLocale: string,
 ): Promise<{ exitCode: number; output: string }> {
   "use step";
 
+  const configPath = "/tmp/hyperlocalise-email.yml";
+  const config = buildTempConfig(inputFile, outputFile, sourceLocale, targetLocale);
+  await writeTempConfig(sandboxId, config, configPath);
+
   return runSandboxCommand(sandboxId, "bash", [
     "-lc",
-    `export PATH="$HOME/.local/bin:$PATH"; hl translate --input ${shellQuote(inputFile)} --output ${shellQuote(outputFile)} --source ${shellQuote(sourceLocale)} --target ${shellQuote(targetLocale)}`,
+    `export PATH="$HOME/.local/bin:$PATH"; hl run --config ${shellQuote(configPath)} --locale ${shellQuote(targetLocale)} --force --progress off`,
   ]);
 }
 
@@ -110,7 +151,9 @@ async function sendReplyEmail(
     subject: `Re: ${event.subject}`,
     text: [
       `Done: ${event.attachmentFilename}`,
-      `Translated: ${event.sourceLocale} -> ${event.targetLocale}`,
+      event.sourceLocale
+        ? `Translated: ${event.sourceLocale} -> ${event.targetLocale}`
+        : `Translated: auto-detect -> ${event.targetLocale}`,
       `Attached: ${outputFilename}`,
       event.instructions
         ? "Note: style instructions were captured, but email translation does not apply them yet."

--- a/apps/hyperlocalise-web/src/workflows/email-translation.ts
+++ b/apps/hyperlocalise-web/src/workflows/email-translation.ts
@@ -67,17 +67,19 @@ function buildTempConfig(
   sourceLocale: string | null,
   targetLocale: string,
 ): string {
+  const yamlString = (value: string) => JSON.stringify(value);
+
   return [
     "locales:",
-    `  source: ${sourceLocale ?? "auto"}`,
+    `  source: ${yamlString(sourceLocale ?? "auto")}`,
     "  targets:",
-    `    - ${targetLocale}`,
+    `    - ${yamlString(targetLocale)}`,
     "",
     "buckets:",
     "  email:",
     "    files:",
-    `      - from: ${inputFile}`,
-    `        to: ${outputFile}`,
+    `      - from: ${yamlString(inputFile)}`,
+    `        to: ${yamlString(outputFile)}`,
     "",
     "llm:",
     "  profiles:",


### PR DESCRIPTION
## What changed

Adds image localization support to the email agent. Image-only emails now parse the sender’s target locale and instructions, send the image directly to the image generation model, and reply with a generated localized image attachment.

This also makes source locale optional for email translation requests by allowing auto-detection, adds a dedicated clarification parser for follow-up replies, and improves pending request handling so newly attached files can be merged into an existing clarification flow.

## How to test

- `vp test`
- `vp check --fix`
- `make fmt`
- `make lint`
- `make test`

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
