### PR TITLE
fix(email): encode Resend attachments as base64

### DIFF
--- a/apps/hyperlocalise-web/src/lib/resend/adapter.test.ts
+++ b/apps/hyperlocalise-web/src/lib/resend/adapter.test.ts
@@ -64,6 +64,45 @@ describe("createResendAdapter", () => {
     );
   });
 
+  it("sends posted file attachments as base64 strings", async () => {
+    const adapter = createResendAdapter({
+      apiKey: "test-key",
+      webhookSecret: "test-secret",
+      fromAddress: "agent@example.com",
+      fromName: "Hyperlocalise",
+    });
+    const threadId = adapter.encodeThreadId({
+      senderEmail: "sender@example.com",
+      threadHash: "thread_123",
+    });
+    const state = {
+      get: vi.fn(async () => null),
+    };
+
+    await adapter.initialize({ getState: () => state } as never);
+    await adapter.postMessage(threadId, {
+      raw: "Done",
+      files: [
+        {
+          data: Buffer.from("translated content"),
+          filename: "fr.json",
+          mimeType: "application/json",
+        },
+      ],
+    });
+
+    expect(mocks.send).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        attachments: [
+          {
+            filename: "fr.json",
+            content: Buffer.from("translated content").toString("base64"),
+          },
+        ],
+      }),
+    );
+  });
+
   it("stores the org inbound address as Reply-To from received email recipients", async () => {
     const adapter = createResendAdapter({
       apiKey: "test-key",

--- a/apps/hyperlocalise-web/src/lib/resend/adapter.ts
+++ b/apps/hyperlocalise-web/src/lib/resend/adapter.ts
@@ -18,6 +18,8 @@ import {
 import { createHash } from "node:crypto";
 import { Resend } from "resend";
 
+import { toBase64AttachmentContent } from "@/lib/resend/attachments";
+
 export type ResendThreadId = {
   senderEmail: string;
   threadHash: string;
@@ -376,7 +378,7 @@ class ResendAdapter implements Adapter<ResendThreadId, ResendRawMessage> {
       text,
       attachments: attachments.map((a) => ({
         filename: a.filename,
-        content: a.content,
+        content: toBase64AttachmentContent(a.content),
       })),
       headers,
     });

--- a/apps/hyperlocalise-web/src/lib/resend/attachments.test.ts
+++ b/apps/hyperlocalise-web/src/lib/resend/attachments.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { toBase64AttachmentContent } from "./attachments";
+
+describe("toBase64AttachmentContent", () => {
+  it("encodes binary attachment content for Resend", () => {
+    expect(toBase64AttachmentContent(Buffer.from("translated content"))).toBe(
+      "dHJhbnNsYXRlZCBjb250ZW50",
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/resend/attachments.ts
+++ b/apps/hyperlocalise-web/src/lib/resend/attachments.ts
@@ -1,0 +1,3 @@
+export function toBase64AttachmentContent(content: Buffer): string {
+  return content.toString("base64");
+}

--- a/apps/hyperlocalise-web/src/workflows/email-translation.ts
+++ b/apps/hyperlocalise-web/src/workflows/email-translation.ts
@@ -2,6 +2,7 @@ import { Sandbox } from "@vercel/sandbox";
 import { Resend } from "resend";
 
 import { env } from "@/lib/env";
+import { toBase64AttachmentContent } from "@/lib/resend/attachments";
 import type { EmailTranslationEventData } from "@/lib/workflow/types";
 
 const sandboxTimeoutMs = 10 * 60 * 1000;
@@ -190,7 +191,7 @@ async function sendReplyEmail(
     attachments: [
       {
         filename: outputFilename,
-        content: translatedContent,
+        content: toBase64AttachmentContent(translatedContent),
       },
     ],
     headers: {


### PR DESCRIPTION
## What changed

Encode outgoing Resend email attachment content as base64 before sending replies.

This fixes workflow failures like:

`Attachment content must be a base64-encoded string.`

The change covers both translated-file reply emails and bot-posted file attachments through the Resend adapter. It also adds focused tests for the attachment encoder and outgoing Resend payload.

## How to test

- `vp test src/lib/resend/attachments.test.ts src/lib/resend/adapter.test.ts src/workflows/email-translation.test.ts`
- `make fmt`
- `vp test`
- `make lint`
- `make test`
- `vp check --fix`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
