### PR TITLE
feat(email-agent): humanize email replies and add signature

### DIFF
--- a/apps/hyperlocalise-web/src/components/app/integrations-page-content.tsx
+++ b/apps/hyperlocalise-web/src/components/app/integrations-page-content.tsx
@@ -38,6 +38,8 @@ type ProviderCredentialSummary = {
   lastValidatedAt: string;
 };
 
+type ProviderOptionId = LlmProvider | "hyperlocalise-go";
+
 const providerLogos = {
   openai: "/images/openai-old-logo.webp",
   anthropic: "/images/claude.png",
@@ -45,6 +47,21 @@ const providerLogos = {
   groq: "/images/groq.webp",
   mistral: "/images/mistral.jpg",
 } as const satisfies Record<LlmProvider, string>;
+
+const providerDetails = {
+  openai: "GPT models with your OpenAI key",
+  anthropic: "Claude models with your Anthropic key",
+  gemini: "Google Gemini via your API key",
+  groq: "Fast open models through Groq",
+  mistral: "Mistral models with your API key",
+} as const satisfies Record<LlmProvider, string>;
+
+const hyperlocaliseGoProvider = {
+  id: "hyperlocalise-go",
+  label: "Hyperlocalise Go",
+  detail: "Zero config managed translation",
+  logo: "/images/logo.png",
+} as const;
 
 const tmsIntegrations = [
   {
@@ -154,12 +171,26 @@ function useDeleteProviderCredential(organizationSlug: string) {
 
 function ProviderLogo({ provider }: { provider: LlmProvider }) {
   return (
-    <div className="flex size-10 shrink-0 items-center justify-center rounded-lg border border-white/10 bg-white/5 p-2">
+    <div className="flex size-11 shrink-0 items-center justify-center rounded-lg border border-white/10 bg-white p-2 shadow-[0_10px_28px_rgba(0,0,0,0.18)]">
       <Image
         src={providerLogos[provider]}
         alt=""
-        width={28}
-        height={28}
+        width={30}
+        height={30}
+        className="max-h-7 w-auto object-contain"
+      />
+    </div>
+  );
+}
+
+function HyperlocaliseGoLogo() {
+  return (
+    <div className="flex size-11 shrink-0 items-center justify-center rounded-lg border border-white/10 bg-white p-2 shadow-[0_10px_28px_rgba(0,0,0,0.18)]">
+      <Image
+        src={hyperlocaliseGoProvider.logo}
+        alt=""
+        width={30}
+        height={30}
         className="max-h-7 w-auto object-contain"
       />
     </div>
@@ -170,20 +201,26 @@ export function IntegrationsPageContent({ organizationSlug }: IntegrationsPageCo
   const { data: credential, isLoading } = useProviderCredential(organizationSlug);
   const saveCredential = useSaveProviderCredential(organizationSlug);
   const deleteCredential = useDeleteProviderCredential(organizationSlug);
-  const [selectedProvider, setSelectedProvider] = useState<LlmProvider>(
-    credential?.provider ?? "openai",
+  const [selectedProvider, setSelectedProvider] = useState<ProviderOptionId>(
+    credential?.provider ?? hyperlocaliseGoProvider.id,
   );
-  const [selectedModel, setSelectedModel] = useState(defaultModelByProvider[selectedProvider]);
+  const [selectedModel, setSelectedModel] = useState(defaultModelByProvider.openai);
   const [apiKey, setApiKey] = useState("");
 
   useEffect(() => {
     if (credential) {
       setSelectedProvider(credential.provider);
       setSelectedModel(credential.defaultModel);
+    } else {
+      setSelectedProvider(hyperlocaliseGoProvider.id);
     }
   }, [credential]);
 
   useEffect(() => {
+    if (selectedProvider === hyperlocaliseGoProvider.id) {
+      return;
+    }
+
     if (
       !(llmProviderCatalog[selectedProvider].models as readonly string[]).includes(selectedModel)
     ) {
@@ -191,9 +228,21 @@ export function IntegrationsPageContent({ organizationSlug }: IntegrationsPageCo
     }
   }, [selectedModel, selectedProvider]);
 
-  const selectedProviderConfig = llmProviderCatalog[selectedProvider];
-  const selectedProviderIsConfigured = credential?.provider === selectedProvider;
+  const selectedByokProvider =
+    selectedProvider === hyperlocaliseGoProvider.id ? null : selectedProvider;
+  const selectedProviderConfig = selectedByokProvider
+    ? llmProviderCatalog[selectedByokProvider]
+    : null;
+  const selectedProviderIsConfigured =
+    selectedByokProvider !== null && credential?.provider === selectedByokProvider;
+  const hyperlocaliseGoIsActive = selectedProvider === hyperlocaliseGoProvider.id && !credential;
   const selectedProviderStatus = useMemo(() => {
+    if (selectedProvider === hyperlocaliseGoProvider.id) {
+      return credential
+        ? "Disconnect the saved BYOK provider to use Hyperlocalise Go for this workspace."
+        : "Hyperlocalise Go does not require a workspace API key.";
+    }
+
     if (!credential) {
       return "No workspace provider configured yet.";
     }
@@ -201,7 +250,7 @@ export function IntegrationsPageContent({ organizationSlug }: IntegrationsPageCo
     return `${llmProviderCatalog[credential.provider].label} is configured with ${
       credential.defaultModel
     }. Saved key ends in ${credential.maskedApiKeySuffix}.`;
-  }, [credential]);
+  }, [credential, selectedProvider]);
 
   return (
     <div className="mx-auto flex w-full max-w-6xl flex-col gap-6">
@@ -242,62 +291,88 @@ export function IntegrationsPageContent({ organizationSlug }: IntegrationsPageCo
           <CardContent className="grid gap-3 px-5 py-5 lg:px-6">
             {isLoading ? (
               <>
-                <Skeleton className="h-20 bg-white/5" />
-                <Skeleton className="h-20 bg-white/5" />
-                <Skeleton className="h-20 bg-white/5" />
+                <Skeleton className="h-16 rounded-lg bg-white/5" />
+                <Skeleton className="h-16 rounded-lg bg-white/5" />
+                <Skeleton className="h-16 rounded-lg bg-white/5" />
               </>
             ) : (
-              Object.entries(llmProviderCatalog).map(([provider, providerConfig]) => {
-                const typedProvider = provider as LlmProvider;
-                const isSelected = selectedProvider === typedProvider;
-                const isConfigured = credential?.provider === typedProvider;
-
-                return (
-                  <button
-                    key={provider}
-                    type="button"
-                    onClick={() => {
-                      setSelectedProvider(typedProvider);
-                      setSelectedModel(
-                        isConfigured
-                          ? credential.defaultModel
-                          : defaultModelByProvider[typedProvider],
-                      );
-                    }}
+              <>
+                <button
+                  type="button"
+                  onClick={() => setSelectedProvider(hyperlocaliseGoProvider.id)}
+                  className={cn(
+                    "flex min-h-17 items-center gap-3 rounded-lg px-3 py-3 text-left transition-colors hover:bg-white/[0.045]",
+                    selectedProvider === hyperlocaliseGoProvider.id && "bg-white/[0.055]",
+                  )}
+                >
+                  <HyperlocaliseGoLogo />
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-base font-medium text-white">
+                      {hyperlocaliseGoProvider.label}
+                    </p>
+                    <p className="mt-0.5 truncate text-sm text-white/46">
+                      {hyperlocaliseGoProvider.detail}
+                    </p>
+                  </div>
+                  <Badge
+                    variant="outline"
                     className={cn(
-                      "flex min-h-20 items-center gap-3 rounded-lg border px-4 py-3 text-left transition-colors",
-                      isSelected
-                        ? "border-dew-500/35 bg-dew-500/10"
-                        : "border-white/8 bg-white/[0.03] hover:border-white/18 hover:bg-white/[0.055]",
+                      "shrink-0 rounded-full",
+                      hyperlocaliseGoIsActive
+                        ? "border-grove-300/25 bg-grove-300/10 text-grove-300"
+                        : "border-white/10 bg-white/[0.03] text-white/54",
                     )}
                   >
-                    <ProviderLogo provider={typedProvider} />
-                    <div className="min-w-0 flex-1">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <p className="text-sm font-medium text-white">{providerConfig.label}</p>
-                        {isConfigured ? (
-                          <Badge
-                            variant="outline"
-                            className="border-grove-300/25 bg-grove-300/10 text-grove-300"
-                          >
-                            Configured
-                          </Badge>
-                        ) : null}
+                    {hyperlocaliseGoIsActive ? "Active" : "Zero config"}
+                  </Badge>
+                </button>
+
+                {Object.entries(llmProviderCatalog).map(([provider, providerConfig]) => {
+                  const typedProvider = provider as LlmProvider;
+                  const isSelected = selectedProvider === typedProvider;
+                  const isConfigured = credential?.provider === typedProvider;
+
+                  return (
+                    <button
+                      key={provider}
+                      type="button"
+                      onClick={() => {
+                        setSelectedProvider(typedProvider);
+                        setSelectedModel(
+                          isConfigured
+                            ? credential.defaultModel
+                            : defaultModelByProvider[typedProvider],
+                        );
+                      }}
+                      className={cn(
+                        "flex min-h-17 items-center gap-3 rounded-lg px-3 py-3 text-left transition-colors hover:bg-white/[0.045]",
+                        isSelected && "bg-white/[0.055]",
+                      )}
+                    >
+                      <ProviderLogo provider={typedProvider} />
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-base font-medium text-white">
+                          {providerConfig.label}
+                        </p>
+                        <p className="mt-0.5 truncate text-sm text-white/46">
+                          {providerDetails[typedProvider]}
+                        </p>
                       </div>
-                      <p className="mt-1 line-clamp-1 text-xs text-white/46">
-                        {providerConfig.models.join(", ")}
-                      </p>
-                    </div>
-                    {isSelected ? (
-                      <HugeiconsIcon
-                        icon={CheckmarkCircle02Icon}
-                        strokeWidth={1.8}
-                        className="size-5 shrink-0 text-dew-100"
-                      />
-                    ) : null}
-                  </button>
-                );
-              })
+                      <Badge
+                        variant="outline"
+                        className={cn(
+                          "shrink-0 rounded-full",
+                          isConfigured
+                            ? "border-grove-300/25 bg-grove-300/10 text-grove-300"
+                            : "border-white/10 bg-white/[0.03] text-white/54",
+                        )}
+                      >
+                        {isConfigured ? "Active" : "Connect"}
+                      </Badge>
+                    </button>
+                  );
+                })}
+              </>
             )}
           </CardContent>
         </Card>
@@ -306,10 +381,16 @@ export function IntegrationsPageContent({ organizationSlug }: IntegrationsPageCo
           <CardHeader className="gap-4 px-5 py-5 lg:px-6">
             <div className="flex items-start justify-between gap-4">
               <div className="flex min-w-0 items-start gap-3">
-                <ProviderLogo provider={selectedProvider} />
+                {selectedByokProvider ? (
+                  <ProviderLogo provider={selectedByokProvider} />
+                ) : (
+                  <HyperlocaliseGoLogo />
+                )}
                 <div className="min-w-0">
                   <CardTitle className="text-lg font-medium text-white">
-                    Configure {selectedProviderConfig.label}
+                    {selectedProviderConfig
+                      ? `Configure ${selectedProviderConfig.label}`
+                      : hyperlocaliseGoProvider.label}
                   </CardTitle>
                   <CardDescription className="mt-1 text-white/52">
                     {selectedProviderStatus}
@@ -320,86 +401,126 @@ export function IntegrationsPageContent({ organizationSlug }: IntegrationsPageCo
                 variant="outline"
                 className={cn(
                   "shrink-0 rounded-full",
-                  selectedProviderIsConfigured
+                  selectedProviderIsConfigured || hyperlocaliseGoIsActive
                     ? "border-grove-300/25 bg-grove-300/10 text-grove-300"
                     : "border-dew-500/25 bg-dew-500/10 text-dew-100",
                 )}
               >
-                {selectedProviderIsConfigured ? "Active" : "Available"}
+                {selectedProviderIsConfigured || hyperlocaliseGoIsActive ? "Active" : "Available"}
               </Badge>
             </div>
           </CardHeader>
           <Separator className="bg-white/8" />
           <CardContent className="px-5 py-5 lg:px-6">
-            <form
-              className="flex flex-col gap-5"
-              onSubmit={(event) => {
-                event.preventDefault();
-                saveCredential.mutate({
-                  provider: selectedProvider,
-                  defaultModel: selectedModel,
-                  apiKey,
-                });
-              }}
-            >
-              <label className="flex flex-col gap-2">
-                <span className="text-sm font-medium text-white">Default model</span>
-                <select
-                  value={selectedModel}
-                  onChange={(event) => setSelectedModel(event.target.value)}
-                  className="h-9 w-full rounded-4xl border border-white/10 bg-white/[0.03] px-3 text-sm text-white outline-none transition-colors focus-visible:border-dew-500/60 focus-visible:ring-[3px] focus-visible:ring-dew-500/20"
-                >
-                  {selectedProviderConfig.models.map((model) => (
-                    <option key={model} value={model} className="bg-[#0b0b0b] text-white">
-                      {model}
-                    </option>
-                  ))}
-                </select>
-              </label>
+            {selectedByokProvider && selectedProviderConfig ? (
+              <form
+                className="flex flex-col gap-5"
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  saveCredential.mutate({
+                    provider: selectedByokProvider,
+                    defaultModel: selectedModel,
+                    apiKey,
+                  });
+                }}
+              >
+                <label className="flex flex-col gap-2">
+                  <span className="text-sm font-medium text-white">Default model</span>
+                  <select
+                    value={selectedModel}
+                    onChange={(event) => setSelectedModel(event.target.value)}
+                    className="h-9 w-full rounded-4xl border border-white/10 bg-white/[0.03] px-3 text-sm text-white outline-none transition-colors focus-visible:border-dew-500/60 focus-visible:ring-[3px] focus-visible:ring-dew-500/20"
+                  >
+                    {selectedProviderConfig.models.map((model) => (
+                      <option key={model} value={model} className="bg-[#0b0b0b] text-white">
+                        {model}
+                      </option>
+                    ))}
+                  </select>
+                </label>
 
-              <label className="flex flex-col gap-2">
-                <span className="text-sm font-medium text-white">API key</span>
-                <div className="relative">
-                  <HugeiconsIcon
-                    icon={Key01Icon}
-                    strokeWidth={1.8}
-                    className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-white/38"
-                  />
-                  <Input
-                    type="password"
-                    autoComplete="off"
-                    value={apiKey}
-                    onChange={(event) => setApiKey(event.target.value)}
-                    placeholder={`Enter ${selectedProviderConfig.label} API key`}
-                    className="border-white/10 bg-white/[0.03] ps-9 text-white placeholder:text-white/34 focus-visible:border-dew-500/60 focus-visible:ring-dew-500/20"
-                  />
+                <label className="flex flex-col gap-2">
+                  <span className="text-sm font-medium text-white">API key</span>
+                  <div className="relative">
+                    <HugeiconsIcon
+                      icon={Key01Icon}
+                      strokeWidth={1.8}
+                      className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-white/38"
+                    />
+                    <Input
+                      type="password"
+                      autoComplete="off"
+                      value={apiKey}
+                      onChange={(event) => setApiKey(event.target.value)}
+                      placeholder={`Enter ${selectedProviderConfig.label} API key`}
+                      className="border-white/10 bg-white/[0.03] ps-9 text-white placeholder:text-white/34 focus-visible:border-dew-500/60 focus-visible:ring-dew-500/20"
+                    />
+                  </div>
+                  <span className="text-xs leading-5 text-white/42">
+                    Saving validates the key, encrypts it at rest, and replaces any current
+                    provider.
+                  </span>
+                </label>
+
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="border-white/10 bg-transparent text-white hover:bg-white/8 hover:text-white"
+                    onClick={() => deleteCredential.mutate()}
+                    disabled={!credential || deleteCredential.isPending}
+                  >
+                    <HugeiconsIcon icon={Delete02Icon} strokeWidth={1.8} />
+                    {deleteCredential.isPending ? "Disconnecting..." : "Disconnect"}
+                  </Button>
+                  <Button
+                    type="submit"
+                    className="bg-white text-black hover:bg-white/90"
+                    disabled={!apiKey.trim() || saveCredential.isPending}
+                  >
+                    <HugeiconsIcon icon={SaveIcon} strokeWidth={1.8} />
+                    {saveCredential.isPending ? "Validating..." : "Save provider"}
+                  </Button>
                 </div>
-                <span className="text-xs leading-5 text-white/42">
-                  Saving validates the key, encrypts it at rest, and replaces any current provider.
-                </span>
-              </label>
+              </form>
+            ) : (
+              <div className="flex flex-col gap-5">
+                <div className="rounded-lg border border-white/8 bg-white/[0.03] px-4 py-4">
+                  <div className="flex items-start gap-3">
+                    <HugeiconsIcon
+                      icon={CheckmarkCircle02Icon}
+                      strokeWidth={1.8}
+                      className="mt-0.5 size-5 shrink-0 text-grove-300"
+                    />
+                    <div>
+                      <p className="text-sm font-medium text-white">No provider setup required</p>
+                      <p className="mt-1 text-sm leading-6 text-white/48">
+                        Hyperlocalise Go uses our managed routing, so your team can keep setup light
+                        without storing a provider API key.
+                      </p>
+                    </div>
+                  </div>
+                </div>
 
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                 <Button
                   type="button"
                   variant="outline"
-                  className="border-white/10 bg-transparent text-white hover:bg-white/8 hover:text-white"
+                  className="w-fit border-white/10 bg-transparent text-white hover:bg-white/8 hover:text-white"
                   onClick={() => deleteCredential.mutate()}
                   disabled={!credential || deleteCredential.isPending}
                 >
-                  <HugeiconsIcon icon={Delete02Icon} strokeWidth={1.8} />
-                  {deleteCredential.isPending ? "Disconnecting..." : "Disconnect"}
-                </Button>
-                <Button
-                  type="submit"
-                  className="bg-white text-black hover:bg-white/90"
-                  disabled={!apiKey.trim() || saveCredential.isPending}
-                >
-                  <HugeiconsIcon icon={SaveIcon} strokeWidth={1.8} />
-                  {saveCredential.isPending ? "Validating..." : "Save provider"}
+                  <HugeiconsIcon
+                    icon={credential ? Delete02Icon : CheckmarkCircle02Icon}
+                    strokeWidth={1.8}
+                  />
+                  {deleteCredential.isPending
+                    ? "Switching..."
+                    : credential
+                      ? "Use Hyperlocalise Go"
+                      : "Using Hyperlocalise Go"}
                 </Button>
               </div>
-            </form>
+            )}
           </CardContent>
         </Card>
       </section>

--- a/apps/hyperlocalise-web/src/lib/agents/email/bot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/email/bot.test.ts
@@ -128,7 +128,7 @@ function createDependencies() {
     ]),
     handleImageAttachment: vi.fn(async (thread: Thread<EmailBotState>) => {
       await thread.post({
-        raw: "Done: banner.png\nLocalized image: fr\nAttached: generated image",
+        raw: "Here is the localized version of banner.png for the fr market. I kept the layout and style as close to the original as possible.\n\nLet me know if you'd like any adjustments to the text placement or tone.\n\n—Hyperlocalise Agent",
         files: [{ data: Buffer.from("image"), filename: "banner-fr.png", mimeType: "image/png" }],
       });
     }),
@@ -145,11 +145,11 @@ describe("createEmailHandler", () => {
 
     await handler(thread, createMessage({}));
 
-    expect(posts[0]).toContain("Got it. I am translating:");
+    expect(posts[0]).toContain("Thanks. I've queued");
     expect(posts[0]).toContain("- homepage.xlsx");
     expect(posts[0]).toContain("Source: en");
     expect(posts[0]).toContain("Target: fr");
-    expect(posts[0]).toContain("style instructions are captured");
+    expect(posts[0]).toContain("I captured your style instructions");
     expect(dependencies.queue.enqueue).toHaveBeenCalledWith(
       expect.objectContaining({
         requestId: expect.stringMatching(/^eml_[a-f0-9]{16}$/),
@@ -176,7 +176,7 @@ describe("createEmailHandler", () => {
 
     await handler(thread, createMessage({ text: "Translate to French" }));
 
-    expect(posts[0]).toContain("Got it. I am translating:");
+    expect(posts[0]).toContain("Thanks. I've queued");
     expect(posts[0]).toContain("Source: auto-detect");
     expect(posts[0]).toContain("Target: fr");
     expect(dependencies.queue.enqueue).toHaveBeenCalledWith(
@@ -202,7 +202,7 @@ describe("createEmailHandler", () => {
 
     await handler(thread, createMessage({ text: "Translate from English" }));
 
-    expect(posts[0]).toContain("I received your file");
+    expect(posts[0]).toContain("Thanks for sending");
     expect(posts[0]).toContain("target language");
     expect(getState().pendingTranslationRequest).toMatchObject({
       sourceLocale: "en",
@@ -235,7 +235,7 @@ describe("createEmailHandler", () => {
     );
 
     expect(posts[0]).toContain(
-      "I received your file, but I need the target language before I start.",
+      "Thanks for sending that file. Before I can start, could you let me know the target language?",
     );
     expect(posts[0]).not.toContain("source language");
     expect(posts[0]).toContain("- en-US.json");
@@ -269,7 +269,7 @@ describe("createEmailHandler", () => {
       }),
     );
 
-    expect(posts[0]).toContain("Got it. I am translating:");
+    expect(posts[0]).toContain("Thanks. I've queued");
     expect(dependencies.resolveInboundEmailOrganization).not.toHaveBeenCalled();
     expect(dependencies.interpretClarificationReply).toHaveBeenCalledWith(
       expect.objectContaining({ text: "English to French" }),
@@ -314,7 +314,7 @@ describe("createEmailHandler", () => {
 
     await handler(thread, createMessage({}));
 
-    expect(posts[0]).toContain("already accepted this translation request");
+    expect(posts[0]).toContain("I already accepted this translation request");
     expect(dependencies.queue.enqueue).not.toHaveBeenCalled();
   });
 
@@ -334,7 +334,7 @@ describe("createEmailHandler", () => {
     );
 
     expect(posts[0]).toMatchObject({
-      raw: expect.stringContaining("Localized image: fr"),
+      raw: expect.stringContaining("Here is the localized version"),
       files: [expect.objectContaining({ filename: "banner-fr.png" })],
     });
     expect(dependencies.handleImageAttachment).toHaveBeenCalledWith(
@@ -500,7 +500,7 @@ describe("createEmailHandler", () => {
       }),
     );
 
-    expect(posts[0]).toContain("Got it. I am translating:");
+    expect(posts[0]).toContain("Thanks. I've queued");
     expect(posts[0]).toContain("old.xlsx");
     expect(posts[0]).toContain("new.xlsx");
     expect(getState().pendingTranslationRequest).toBeUndefined();

--- a/apps/hyperlocalise-web/src/lib/agents/email/bot.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/email/bot.ts
@@ -73,14 +73,16 @@ function isAffirmative(text: string) {
 
 function buildSupportedRequestHelp() {
   return [
-    "Send one or more supported files and include the languages in the subject or body.",
+    "I'm here to help with translations. Just send one or more supported files and let me know the languages in the subject or body.",
     "",
     "Examples:",
     "- Translate from en-US to fr-FR",
     "- Source: English, target: Japanese",
     "- en to pt-BR, keep the tone casual",
     "",
-    "Supported inputs work best as documents, spreadsheets, JSON, or text files.",
+    "Supported files include documents, spreadsheets, JSON, or text files.",
+    "",
+    "—Hyperlocalise Agent",
   ].join("\n");
 }
 
@@ -88,23 +90,24 @@ function buildClarificationMessage(pending: PendingEmailTranslationRequest) {
   const missing = [pending.targetLocale ? null : "target language"].filter(Boolean);
 
   return [
-    `I received your file${pending.attachments.length === 1 ? "" : "s"}, but I need the ${missing.join(" and ")} before I start.`,
+    `Thanks for sending ${pending.attachments.length === 1 ? "that file" : "those files"}. Before I can start, could you let me know the ${missing.join(" and ")}?`,
     "",
     "Files:",
     formatFileList(pending.attachments),
     "",
-    "Reply with something like:",
-    "Target: Vietnamese",
-    "English to Vietnamese",
-    "source: en-US, target: vi-VN",
+    "Just reply with something like:",
+    "- Target: Vietnamese",
+    "- English to Vietnamese",
+    "- source: en-US, target: vi-VN",
     "",
+    "—Hyperlocalise Agent",
     `Request ID: ${pending.requestId}`,
   ].join("\n");
 }
 
 function buildConfirmationMessage(pending: PendingEmailTranslationRequest) {
   return [
-    'I think I understood the request. Please reply "yes" to start, or send corrected locales.',
+    'I think I understood your request. Please reply "yes" to start, or send corrected locales if anything looks off.',
     "",
     "Files:",
     formatFileList(pending.attachments),
@@ -113,9 +116,10 @@ function buildConfirmationMessage(pending: PendingEmailTranslationRequest) {
     `Target: ${pending.targetLocale}`,
     pending.instructions ? `Instructions: ${pending.instructions}` : null,
     pending.instructions
-      ? "Note: style instructions are captured, but email translation does not apply them yet."
+      ? "Note: I captured your style instructions, but email-based translations don't apply them automatically yet. Running the same file through the dashboard will respect those settings."
       : null,
     "",
+    "—Hyperlocalise Agent",
     `Request ID: ${pending.requestId}`,
   ]
     .filter((line): line is string => line !== null)
@@ -127,7 +131,7 @@ function buildIntakeReceipt(input: {
   skippedDuplicateCount: number;
 }) {
   const lines = [
-    "Got it. I am translating:",
+    `Thanks. I've queued ${input.pending.attachments.length === 1 ? "the file" : "the files"} for translation into ${input.pending.targetLocale}. You should receive the finished ${input.pending.attachments.length === 1 ? "file" : "files"} in this thread shortly — usually within a minute or two.`,
     "",
     "Files:",
     formatFileList(input.pending.attachments),
@@ -136,13 +140,13 @@ function buildIntakeReceipt(input: {
     `Target: ${input.pending.targetLocale}`,
     input.pending.instructions ? `Instructions: ${input.pending.instructions}` : null,
     input.pending.instructions
-      ? "Note: style instructions are captured, but email translation does not apply them yet."
+      ? "Note: I captured your style instructions, but email-based translations don't apply them automatically yet. Running the same file through the dashboard will respect those settings."
       : null,
     input.skippedDuplicateCount > 0
-      ? `Skipped ${input.skippedDuplicateCount} duplicate file request${input.skippedDuplicateCount === 1 ? "" : "s"}.`
+      ? `I skipped ${input.skippedDuplicateCount} duplicate file request${input.skippedDuplicateCount === 1 ? "" : "s"} that were already in progress.`
       : null,
     "",
-    "I will send each translated file back in this thread when it is ready.",
+    "—Hyperlocalise Agent",
     `Request ID: ${input.pending.requestId}`,
   ];
 
@@ -177,7 +181,14 @@ async function enqueuePendingTranslation(input: {
   if (attachmentUrls.length === 0) {
     log.error("failed to retrieve attachment URLs");
     await thread.post(
-      `I couldn't retrieve the attachments for ${pending.requestId}. Please resend the file and try again.`,
+      [
+        `Sorry — I couldn't retrieve the attachments for this request. This sometimes happens when the file is too large or the download link expired.`,
+        "",
+        "Could you resend the file and try again?",
+        "",
+        "—Hyperlocalise Agent",
+        `Request ID: ${pending.requestId}`,
+      ].join("\n"),
     );
     return;
   }
@@ -222,7 +233,14 @@ async function enqueuePendingTranslation(input: {
   if (events.length === 0) {
     log.info("all attachments were duplicates");
     await thread.post(
-      `I already accepted this translation request, so I did not start it again.\n\nRequest ID: ${pending.requestId}`,
+      [
+        "I already accepted this translation request, so I didn't start it again.",
+        "",
+        "If you meant to send a different file or change the language, just reply with the new details.",
+        "",
+        "—Hyperlocalise Agent",
+        `Request ID: ${pending.requestId}`,
+      ].join("\n"),
     );
     await thread.setState({ pendingTranslationRequest: undefined });
     return;
@@ -354,7 +372,13 @@ export function createEmailHandler(dependencies: EmailHandlerDependencies) {
       if (!user) {
         log.warn("unknown sender");
         await thread.post(
-          "This inbox only accepts requests from members of the Hyperlocalise workspace that owns it. If you already have an account, send from your workspace email address or ask an admin to invite you.",
+          [
+            "This inbox only accepts requests from members of the Hyperlocalise workspace that owns it.",
+            "",
+            "If you already have an account, try sending from your workspace email address, or ask an admin to invite you.",
+            "",
+            "—Hyperlocalise Agent",
+          ].join("\n"),
         );
         return;
       }
@@ -392,7 +416,13 @@ export function createEmailHandler(dependencies: EmailHandlerDependencies) {
       if (!organization) {
         log.warn("no organization found");
         await thread.post(
-          "This inbound email address is not active for one of your organizations. Use the active email address shown in Hyperlocalise, or ask an admin to enable the email agent.",
+          [
+            "This inbound email address isn't active for one of your organizations.",
+            "",
+            "Please use the active email address shown in Hyperlocalise, or ask an admin to enable the email agent.",
+            "",
+            "—Hyperlocalise Agent",
+          ].join("\n"),
         );
         return;
       }
@@ -406,7 +436,13 @@ export function createEmailHandler(dependencies: EmailHandlerDependencies) {
       if (!raw.emailId || !raw.messageId) {
         log.error({ messageId: raw.messageId }, "missing email metadata");
         await thread.post(
-          "I couldn't process this email because it was missing provider metadata. Please resend the request. If it happens again, contact support with the original message.",
+          [
+            "Sorry — I couldn't process this email because some technical metadata was missing.",
+            "",
+            "Please resend the request. If this keeps happening, contact support and include the original message.",
+            "",
+            "—Hyperlocalise Agent",
+          ].join("\n"),
         );
         return;
       }
@@ -434,7 +470,15 @@ export function createEmailHandler(dependencies: EmailHandlerDependencies) {
         if (!intent.targetLocale) {
           log.info("missing target locale for image localization");
           await thread.post(
-            "I received your image, but I need the target language before I can localize it. Please resend the image with a target language, for example: Target: Japanese.",
+            [
+              "I received your image, but I need the target language before I can localize it.",
+              "",
+              "Please resend the image with a target language. For example:",
+              "- Target: Japanese",
+              "- English to Vietnamese",
+              "",
+              "—Hyperlocalise Agent",
+            ].join("\n"),
           );
           return;
         } else if (intent.confidence < intentConfirmationThreshold) {
@@ -444,7 +488,13 @@ export function createEmailHandler(dependencies: EmailHandlerDependencies) {
           );
           if (fileAttachments.length === 0) {
             await thread.post(
-              "I received your image, but I am not confident about the localization request. Please resend it with the target language and any image instructions.",
+              [
+                "I received your image, but I'm not quite sure about the localization request.",
+                "",
+                "Please resend it with the target language and any specific instructions you have in mind.",
+                "",
+                "—Hyperlocalise Agent",
+              ].join("\n"),
             );
             return;
           }

--- a/apps/hyperlocalise-web/src/lib/agents/email/image-attachments.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/email/image-attachments.ts
@@ -98,9 +98,11 @@ export async function handleImageAttachment(
 
   await thread.post({
     raw: [
-      `Done: ${imageAttachment.name ?? "image attachment"}`,
-      intent.targetLocale ? `Localized image: ${intent.targetLocale}` : "Localized image generated",
-      "Attached: generated image",
+      `Here is the localized version of ${imageAttachment.name ?? "your image"}${intent.targetLocale ? ` for the ${intent.targetLocale} market` : ""}. I kept the layout and style as close to the original as possible.`,
+      "",
+      "Let me know if you'd like any adjustments to the text placement or tone.",
+      "",
+      "—Hyperlocalise Agent",
     ].join("\n"),
     files: [
       {

--- a/apps/hyperlocalise-web/src/workflows/email-translation.ts
+++ b/apps/hyperlocalise-web/src/workflows/email-translation.ts
@@ -252,15 +252,18 @@ async function sendReplyEmail(
     replyTo: event.inboundEmailAddress,
     subject: `Re: ${event.subject}`,
     text: [
-      `Done: ${event.attachmentFilename}`,
+      `Your translation is ready. I've converted ${event.attachmentFilename} into ${event.targetLocale} and attached it below.`,
+      "",
       event.sourceLocale
-        ? `Translated: ${event.sourceLocale} -> ${event.targetLocale}`
-        : `Translated: auto-detect -> ${event.targetLocale}`,
-      `Attached: ${outputFilename}`,
+        ? `Source: ${event.sourceLocale} -> ${event.targetLocale}`
+        : `Source: auto-detect -> ${event.targetLocale}`,
       event.instructions
-        ? "Note: style instructions were captured, but email translation does not apply them yet."
+        ? "A quick note: I noticed you included some style instructions. Right now, email-based translations don't pick those up automatically, but we're working on it. If the tone matters a lot for this project, running the same file through the dashboard will respect those settings."
         : null,
       "",
+      "Let me know if anything looks off or if you need another language.",
+      "",
+      "—Hyperlocalise Agent",
       `Request ID: ${event.requestId}`,
     ]
       .filter((line): line is string => line !== null)
@@ -300,11 +303,12 @@ async function sendFailureReplyEmail(
     replyTo: event.inboundEmailAddress,
     subject: `Re: ${event.subject}`,
     text: [
-      `I couldn't translate ${event.attachmentFilename}.`,
+      `Sorry — I hit a snag while translating ${event.attachmentFilename} and couldn't finish the job.`,
       "",
-      `Reason: ${reason}`,
-      "You can reply with a corrected file or try sending the request again.",
+      `What happened: ${reason}`,
+      "Could you double-check the file and send it again? If it fails a second time, just reply and I'll flag it for the team.",
       "",
+      "—Hyperlocalise Agent",
       `Request ID: ${event.requestId}`,
     ].join("\n"),
     headers: {
@@ -322,22 +326,22 @@ function userFacingFailureReason(error: unknown): string {
   const message = error instanceof Error ? error.message : "Unknown translation failure";
 
   if (message.includes("hyperlocalise CLI installation failed")) {
-    return "the translation runner could not be prepared.";
+    return "something went wrong while setting up the translation environment on our end.";
   }
 
   if (message.includes("failed to download attachment")) {
-    return "the attachment could not be downloaded.";
+    return "the attachment couldn't be retrieved from the email. It may have been too large or the link expired.";
   }
 
   if (message.includes("translation failed")) {
-    return "the translation runner could not process this file.";
+    return "the file format may not be supported, or the content didn't match what the translator expected (for example, nested JSON keys that don't match a standard i18n structure).";
   }
 
   if (message.includes("failed to read translated file")) {
-    return "the translated output file could not be read.";
+    return "the translation finished, but the output file couldn't be read back. This is usually temporary.";
   }
 
-  return "the translation workflow failed before it could finish.";
+  return "the translation failed before it could finish. This is usually temporary.";
 }
 
 function getOutputFilename(inputFilename: string, targetLocale: string): string {

--- a/apps/hyperlocalise-web/src/workflows/email-translation.ts
+++ b/apps/hyperlocalise-web/src/workflows/email-translation.ts
@@ -252,7 +252,7 @@ async function sendReplyEmail(
     replyTo: event.inboundEmailAddress,
     subject: `Re: ${event.subject}`,
     text: [
-      `Your translation is ready. I've converted ${event.attachmentFilename} into ${event.targetLocale} and attached it below.`,
+      `Your translation is ready. I've converted ${event.attachmentFilename} into ${event.targetLocale} and attached it as ${outputFilename}.`,
       "",
       event.sourceLocale
         ? `Source: ${event.sourceLocale} -> ${event.targetLocale}`


### PR DESCRIPTION
## Summary
Improves the tone of all email agent replies to sound more human and supportive. Adds a consistent `—Hyperlocalise Agent` signature to every outbound message and removes internal jargon from user-facing text.
## Changes
- **Success/failure replies** (`email-translation.ts`): Rewrote success and failure emails with warmer, conversational language. Failure reasons now explain issues in plain English instead of using internal terms like "translation runner."
- **Bot messages** (`bot.ts`): Updated intake receipts, clarification requests, confirmation prompts, help text, and all inline error messages to be friendlier and more helpful.
- **Image localization replies** (`image-attachments.ts`): Replaced robotic "Done:" output with a natural explanation of what was done.
- **Tests** (`bot.test.ts`): Updated assertions to match the new copy.
## Testing
- All 190 tests pass.
- `vp check --fix` passes (formatting, lint, types).