### PR TITLE
feat(cli): crowdin branch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@
 - Run `make lint`.
 - Run `make test`.
 
-In apps/hyperlocalise-web:
+In apps/hyperlocalise-web, if we change these folder:
 
 - Run `vp test`
 - Run `vp check --fix`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@
 - Run `make lint`.
 - Run `make test`.
 
-In apps/hyperlocalise-web, if we change these folder:
+In apps/hyperlocalise-web, if we change these folders:
 
 - Run `vp test`
 - Run `vp check --fix`

--- a/apps/cli/cmd/crowdin.go
+++ b/apps/cli/cmd/crowdin.go
@@ -19,6 +19,7 @@ var crowdinTemplateFS embed.FS
 type crowdinCommonOptions struct {
 	configPath   string
 	identityPath string
+	branch       string
 	languages    []string
 	dryRun       bool
 }
@@ -90,7 +91,7 @@ func newCrowdinConfigValidateCmd() *cobra.Command {
 			return err
 		},
 	}
-	addCrowdinCommonFlags(cmd, &o, false)
+	addCrowdinCommonFlags(cmd, &o, false, false)
 	return cmd
 }
 
@@ -123,11 +124,11 @@ func newCrowdinUploadSourcesCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			result, err := adapter.UploadSources(backgroundContext(), crowdinstorageRequestSources(cfg))
+			result, err := adapter.UploadSources(backgroundContext(), crowdinstorageRequestSources(cfg, o.branch))
 			return writeCrowdinResultError(cmd, "upload-sources", result, err)
 		},
 	}
-	addCrowdinCommonFlags(cmd, &o, false)
+	addCrowdinCommonFlags(cmd, &o, false, true)
 	return cmd
 }
 
@@ -150,11 +151,11 @@ func newCrowdinUploadTranslationsCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			result, err := adapter.UploadTranslations(backgroundContext(), crowdinstorageRequestTranslations(cfg, o.languages))
+			result, err := adapter.UploadTranslations(backgroundContext(), crowdinstorageRequestTranslations(cfg, o.languages, o.branch))
 			return writeCrowdinResultError(cmd, "upload-translations", result, err)
 		},
 	}
-	addCrowdinCommonFlags(cmd, &o, true)
+	addCrowdinCommonFlags(cmd, &o, true, true)
 	return cmd
 }
 
@@ -177,18 +178,21 @@ func newCrowdinDownloadCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			result, err := adapter.DownloadTranslations(backgroundContext(), crowdinstorageRequestDownload(cfg, o.languages))
+			result, err := adapter.DownloadTranslations(backgroundContext(), crowdinstorageRequestDownload(cfg, o.languages, o.branch))
 			return writeCrowdinResultError(cmd, "download-translations", result, err)
 		},
 	}
-	addCrowdinCommonFlags(cmd, &o, true)
+	addCrowdinCommonFlags(cmd, &o, true, true)
 	return cmd
 }
 
-func addCrowdinCommonFlags(cmd *cobra.Command, o *crowdinCommonOptions, includeLanguages bool) {
+func addCrowdinCommonFlags(cmd *cobra.Command, o *crowdinCommonOptions, includeLanguages, includeBranch bool) {
 	cmd.Flags().StringVar(&o.configPath, "config", "", "path to crowdin.yml")
 	cmd.Flags().StringVar(&o.identityPath, "identity", "", "path to Crowdin identity file")
 	cmd.Flags().BoolVar(&o.dryRun, "dry-run", false, "preview command without applying remote or local changes")
+	if includeBranch {
+		cmd.Flags().StringVar(&o.branch, "branch", "", "Crowdin branch name to process")
+	}
 	if includeLanguages {
 		cmd.Flags().StringSliceVarP(&o.languages, "language", "l", nil, "target language(s) to process")
 	}
@@ -214,14 +218,24 @@ func writeCrowdinResultError(cmd *cobra.Command, action string, result storage.F
 	return opErr
 }
 
-func crowdinstorageRequestSources(cfg storage.FileWorkflowConfig) storage.FileUploadSourcesRequest {
+func crowdinstorageRequestSources(cfg storage.FileWorkflowConfig, branch string) storage.FileUploadSourcesRequest {
+	cfg = overrideCrowdinBranch(cfg, branch)
 	return storage.FileUploadSourcesRequest{Config: cfg}
 }
 
-func crowdinstorageRequestTranslations(cfg storage.FileWorkflowConfig, languages []string) storage.FileUploadTranslationsRequest {
+func crowdinstorageRequestTranslations(cfg storage.FileWorkflowConfig, languages []string, branch string) storage.FileUploadTranslationsRequest {
+	cfg = overrideCrowdinBranch(cfg, branch)
 	return storage.FileUploadTranslationsRequest{Config: cfg, Languages: languages}
 }
 
-func crowdinstorageRequestDownload(cfg storage.FileWorkflowConfig, languages []string) storage.FileDownloadTranslationsRequest {
+func crowdinstorageRequestDownload(cfg storage.FileWorkflowConfig, languages []string, branch string) storage.FileDownloadTranslationsRequest {
+	cfg = overrideCrowdinBranch(cfg, branch)
 	return storage.FileDownloadTranslationsRequest{Config: cfg, Languages: languages}
+}
+
+func overrideCrowdinBranch(cfg storage.FileWorkflowConfig, branch string) storage.FileWorkflowConfig {
+	if trimmed := strings.TrimSpace(branch); trimmed != "" {
+		cfg.Branch = trimmed
+	}
+	return cfg
 }

--- a/apps/cli/cmd/crowdin_test.go
+++ b/apps/cli/cmd/crowdin_test.go
@@ -141,6 +141,25 @@ func TestWriteCrowdinResultErrorReturnsWriteErrorWhenOperationSucceeds(t *testin
 	}
 }
 
+func TestCrowdinBranchOverrideAppliesToRequests(t *testing.T) {
+	cfg := storage.FileWorkflowConfig{Branch: "config-branch"}
+
+	sourceReq := crowdinstorageRequestSources(cfg, "flag-branch")
+	if sourceReq.Config.Branch != "flag-branch" {
+		t.Fatalf("source branch = %q, want flag-branch", sourceReq.Config.Branch)
+	}
+
+	translationsReq := crowdinstorageRequestTranslations(cfg, nil, "")
+	if translationsReq.Config.Branch != "config-branch" {
+		t.Fatalf("translation branch = %q, want config-branch", translationsReq.Config.Branch)
+	}
+
+	downloadReq := crowdinstorageRequestDownload(cfg, nil, "  flag-branch  ")
+	if downloadReq.Config.Branch != "flag-branch" {
+		t.Fatalf("download branch = %q, want trimmed flag-branch", downloadReq.Config.Branch)
+	}
+}
+
 type crowdinFailingWriter struct{}
 
 func (f *crowdinFailingWriter) Write(_ []byte) (int, error) {

--- a/docs/commands/crowdin.mdx
+++ b/docs/commands/crowdin.mdx
@@ -8,9 +8,9 @@ description: "Crowdin-compatible file workflow commands powered by crowdin.yml."
 ```bash
 hyperlocalise crowdin init
 hyperlocalise crowdin config validate [--config <path>] [--identity <path>]
-hyperlocalise crowdin upload sources [--config <path>] [--identity <path>]
-hyperlocalise crowdin upload translations [--config <path>] [--identity <path>] [--language <locale>]
-hyperlocalise crowdin download [--config <path>] [--identity <path>] [--language <locale>]
+hyperlocalise crowdin upload sources [--config <path>] [--identity <path>] [--branch <name>]
+hyperlocalise crowdin upload translations [--config <path>] [--identity <path>] [--branch <name>] [--language <locale>]
+hyperlocalise crowdin download [--config <path>] [--identity <path>] [--branch <name>] [--language <locale>]
 ```
 
 ## What this command family does
@@ -24,6 +24,7 @@ Use them when you want Crowdin-compatible file mode:
 - source-file upload from `files[].source`
 - translation upload from `files[].translation`
 - translation download/export back into your repo
+- branch-scoped upload and download with root `branch:` or `--branch`
 - strict YAML decoding: only keys Crowdin documents and `hl` recognizes may appear in `crowdin.yml` (unknown keys still error)
 
 ## Supported config fields
@@ -38,6 +39,7 @@ These drive Hyperlocalise Crowdin file mode:
 - `base_url_env`
 - `base_path`
 - `base_path_env`
+- `branch`
 - `preserve_hierarchy`
 - `files[].source`
 - `files[].translation`
@@ -51,7 +53,7 @@ These drive Hyperlocalise Crowdin file mode:
 
 The decoder also accepts several Crowdin-documented keys so you can reuse a standard `crowdin.yml` without stripping metadata. Hyperlocalise does **not** implement behavior for these yet; they are ignored after parse:
 
-- Root: `export_languages`, `branch`, `pull_request_title`, `pull_request_labels`, `commit_message`, `append_commit_message`, `pull_request_assignees`, `pull_request_reviewers`
+- Root: `export_languages`, `pull_request_title`, `pull_request_labels`, `commit_message`, `append_commit_message`, `pull_request_assignees`, `pull_request_reviewers`
 - Per file: `type`, `dest`, `update_option`, `export_pattern`, `translate_content`, `translate_attributes`, `content_segmentation`, `translatable_elements`, `ignore`, `translation_replace`, `first_line_contains_header`, `scheme`, `custom_segmentation`, `escape_quotes`, `escape_special_characters`, `labels`
 
 ## Unsupported features
@@ -60,7 +62,6 @@ YAML keys not listed above still cause a decode error (`KnownFields`).
 
 This v1 file-mode implementation does not support:
 
-- branch workflows (the `branch` field is accepted but not used)
 - TM, glossary, task, screenshot, comment, distribution, or app commands
 - permissive "warn and ignore" compatibility mode
 - interactive Crowdin project bootstrap
@@ -83,6 +84,12 @@ Upload only French translations:
 
 ```bash
 hyperlocalise crowdin upload translations --language fr
+```
+
+Upload sources to a Crowdin branch:
+
+```bash
+hyperlocalise crowdin upload sources --branch feature/login
 ```
 
 Download only approved French translations:

--- a/docs/storage/crowdin.mdx
+++ b/docs/storage/crowdin.mdx
@@ -81,6 +81,7 @@ Supported `crowdin.yml` fields in v1:
 - `base_url_env`
 - `base_path`
 - `base_path_env`
+- `branch`
 - `preserve_hierarchy`
 - `files[].source`
 - `files[].translation`
@@ -99,6 +100,8 @@ hyperlocalise crowdin upload sources
 hyperlocalise crowdin upload translations --language fr
 hyperlocalise crowdin download --language fr
 ```
+
+Use root `branch:` in `crowdin.yml` or pass `--branch <name>` to upload and download files from a Crowdin branch. The flag overrides the config value for that command.
 
 Validation fails closed on unsupported Crowdin fields or commands.
 

--- a/docs/vi-VN/commands/crowdin.mdx
+++ b/docs/vi-VN/commands/crowdin.mdx
@@ -8,9 +8,9 @@ description: "Các lệnh quy trình tệp tương thích với Crowdin được
 ```bash
 hyperlocalise crowdin init
 hyperlocalise crowdin config validate [--config <path>] [--identity <path>]
-hyperlocalise crowdin upload sources [--config <path>] [--identity <path>]
-hyperlocalise crowdin upload translations [--config <path>] [--identity <path>] [--language <locale>]
-hyperlocalise crowdin download [--config <path>] [--identity <path>] [--language <locale>]
+hyperlocalise crowdin upload sources [--config <path>] [--identity <path>] [--branch <name>]
+hyperlocalise crowdin upload translations [--config <path>] [--identity <path>] [--branch <name>] [--language <locale>]
+hyperlocalise crowdin download [--config <path>] [--identity <path>] [--branch <name>] [--language <locale>]
 ```
 
 ## Bộ lệnh này làm gì
@@ -24,6 +24,7 @@ Sử dụng chúng khi bạn muốn chế độ tệp tương thích với Crowd
 - tải lên tệp nguồn từ `files[].source`
 - tải lên bản dịch từ `files[].translation`
 - tải xuống/xuất bản dịch trở lại vào kho lưu trữ của bạn
+- tải lên và tải xuống theo nhánh bằng `branch:` ở gốc hoặc `--branch`
 - xác thực nghiêm ngặt các trường `crowdin.yml` được hỗ trợ
 
 ## Các trường cấu hình được hỗ trợ
@@ -36,6 +37,7 @@ Sử dụng chúng khi bạn muốn chế độ tệp tương thích với Crowd
 - `base_url_env`
 - `base_path`
 - `base_path_env`
+- `branch`
 - `preserve_hierarchy`
 - `files[].source`
 - `files[].translation`
@@ -51,7 +53,6 @@ Xác thực sẽ thất bại mặc định với các tính năng Crowdin CLI k
 
 Việc triển khai chế độ tệp v1 này không hỗ trợ:
 
-- luồng công việc nhánh
 - TM, bảng thuật ngữ, nhiệm vụ, ảnh chụp màn hình, bình luận, phân phối hoặc lệnh ứng dụng
 - chế độ tương thích "cảnh báo và bỏ qua" mang tính cho phép
 - khởi động dự án Crowdin tương tác
@@ -74,6 +75,12 @@ Chỉ tải lên bản dịch tiếng Pháp:
 
 ```bash
 hyperlocalise crowdin upload translations --language fr
+```
+
+Tải tệp nguồn lên một nhánh Crowdin:
+
+```bash
+hyperlocalise crowdin upload sources --branch feature/login
 ```
 
 Tải xuống chỉ các bản dịch tiếng Pháp đã được phê duyệt:

--- a/docs/vi-VN/storage/crowdin.mdx
+++ b/docs/vi-VN/storage/crowdin.mdx
@@ -81,6 +81,7 @@ Các trường `crowdin.yml` được hỗ trợ trong v1:
 - `base_url_env`
 - `base_path`
 - `base_path_env`
+- `branch`
 - `preserve_hierarchy`
 - `files[].source`
 - `files[].translation`
@@ -99,6 +100,8 @@ hyperlocalise crowdin upload sources
 hyperlocalise crowdin upload translations --language fr
 hyperlocalise crowdin download --language fr
 ```
+
+Dùng `branch:` ở gốc trong `crowdin.yml` hoặc truyền `--branch <name>` để tải lên và tải xuống tệp từ một nhánh Crowdin. Cờ này ghi đè giá trị cấu hình cho lệnh hiện tại.
 
 Xác thực sẽ thất bại an toàn khi gặp các trường hoặc lệnh Crowdin không được hỗ trợ.
 

--- a/docs/zh-CN/commands/crowdin.mdx
+++ b/docs/zh-CN/commands/crowdin.mdx
@@ -8,9 +8,9 @@ description: "由 crowdin.yml 驱动的 Crowdin 兼容文件工作流命令。"
 ```bash
 hyperlocalise crowdin init
 hyperlocalise crowdin config validate [--config <path>] [--identity <path>]
-hyperlocalise crowdin upload sources [--config <path>] [--identity <path>]
-hyperlocalise crowdin upload translations [--config <path>] [--identity <path>] [--language <locale>]
-hyperlocalise crowdin download [--config <path>] [--identity <path>] [--language <locale>]
+hyperlocalise crowdin upload sources [--config <path>] [--identity <path>] [--branch <name>]
+hyperlocalise crowdin upload translations [--config <path>] [--identity <path>] [--branch <name>] [--language <locale>]
+hyperlocalise crowdin download [--config <path>] [--identity <path>] [--branch <name>] [--language <locale>]
 ```
 
 ## 此命令系列的作用
@@ -24,6 +24,7 @@ hyperlocalise crowdin download [--config <path>] [--identity <path>] [--language
 - 从 `files[].source` 上传源文件
 - 从 `files[].translation` 上传翻译
 - 将翻译下载/导出回你的仓库
+- 使用根级 `branch:` 或 `--branch` 进行分支范围的上传和下载
 - 受支持的`crowdin.yml`字段的严格验证
 
 ## 支持的配置字段
@@ -36,6 +37,7 @@ hyperlocalise crowdin download [--config <path>] [--identity <path>] [--language
 - `base_url_env`
 - `base_path`
 - `base_path_env`
+- `branch`
 - `preserve_hierarchy`
 - `files[].source`
 - `files[].translation`
@@ -51,7 +53,6 @@ hyperlocalise crowdin download [--config <path>] [--identity <path>] [--language
 
 此 v1 文件模式实现不支持：
 
-- 分支工作流
 - TM、词汇表、任务、截图、评论、分发或应用命令
 - 宽松的“警告并忽略”兼容模式
 - 交互式 Crowdin 项目引导程序
@@ -74,6 +75,12 @@ hyperlocalise crowdin upload sources
 
 ```bash
 hyperlocalise crowdin upload translations --language fr
+```
+
+上传源文件到 Crowdin 分支：
+
+```bash
+hyperlocalise crowdin upload sources --branch feature/login
 ```
 
 仅下载已批准的法语译文：

--- a/docs/zh-CN/storage/crowdin.mdx
+++ b/docs/zh-CN/storage/crowdin.mdx
@@ -81,6 +81,7 @@ v1 中支持的`crowdin.yml`字段：
 - `base_url_env`
 - `base_path`
 - `base_path_env`
+- `branch`
 - `preserve_hierarchy`
 - `files[].source`
 - `files[].translation`
@@ -99,6 +100,8 @@ hyperlocalise crowdin upload sources
 hyperlocalise crowdin upload translations --language fr
 hyperlocalise crowdin download --language fr
 ```
+
+使用 `crowdin.yml` 根级 `branch:` 或传递 `--branch <name>`，可以从 Crowdin 分支上传和下载文件。该标志会覆盖当前命令的配置值。
 
 对不受支持的 Crowdin 字段或命令，验证将失败并保持关闭状态。
 

--- a/internal/i18n/storage/crowdin/fileconfig.go
+++ b/internal/i18n/storage/crowdin/fileconfig.go
@@ -39,9 +39,11 @@ type fileConfigYAML struct {
 	PreserveHierarchy bool            `yaml:"preserve_hierarchy"`
 	Files             []fileGroupYAML `yaml:"files"`
 
+	// Optional Crowdin branch used to scope API calls.
+	Branch string `yaml:"branch"`
+
 	// Optional Crowdin CLI / VCS keys (parsed for YAML compatibility; hl file mode does not use them yet).
 	ExportLanguages      []string `yaml:"export_languages"`
-	Branch               string   `yaml:"branch"`
 	PullRequestTitle     string   `yaml:"pull_request_title"`
 	PullRequestLabels    []string `yaml:"pull_request_labels"`
 	CommitMessage        string   `yaml:"commit_message"`

--- a/internal/i18n/storage/crowdin/fileconfig.go
+++ b/internal/i18n/storage/crowdin/fileconfig.go
@@ -195,6 +195,7 @@ func normalizeFileWorkflowConfig(raw fileConfigYAML, identity identityConfigYAML
 		APIToken:          apiToken,
 		APIBaseURL:        baseURL,
 		BasePath:          basePath,
+		Branch:            strings.TrimSpace(raw.Branch),
 		PreserveHierarchy: raw.PreserveHierarchy,
 		Files:             files,
 	}, nil

--- a/internal/i18n/storage/crowdin/fileconfig_test.go
+++ b/internal/i18n/storage/crowdin/fileconfig_test.go
@@ -202,6 +202,9 @@ files:
 	if len(cfg.Files) != 1 {
 		t.Fatalf("files len = %d, want 1", len(cfg.Files))
 	}
+	if cfg.Branch != "main" {
+		t.Fatalf("branch = %q, want main", cfg.Branch)
+	}
 	raw, err := decodeYAMLFile[fileConfigYAML](configPath)
 	if err != nil {
 		t.Fatalf("decode raw config: %v", err)

--- a/internal/i18n/storage/crowdin/filemode.go
+++ b/internal/i18n/storage/crowdin/filemode.go
@@ -15,10 +15,11 @@ import (
 
 type FileClient interface {
 	ResolveLocales(ctx context.Context, projectID string, requested []string) ([]string, error)
-	EnsureDirectory(ctx context.Context, projectID, path string) (int, error)
-	FindDirectory(ctx context.Context, projectID, path string) (int, error)
-	UpsertSourceFile(ctx context.Context, projectID string, directoryID int, name, localPath string, group storage.FileGroupSpec) (int, error)
-	FindFile(ctx context.Context, projectID string, directoryID int, name string) (int, error)
+	ResolveBranch(ctx context.Context, projectID, branch string) (int, error)
+	EnsureDirectory(ctx context.Context, projectID string, branchID int, path string) (int, error)
+	FindDirectory(ctx context.Context, projectID string, branchID int, path string) (int, error)
+	UpsertSourceFile(ctx context.Context, projectID string, branchID, directoryID int, name, localPath string, group storage.FileGroupSpec) (int, error)
+	FindFile(ctx context.Context, projectID string, branchID, directoryID int, name string) (int, error)
 	UploadTranslationFile(ctx context.Context, projectID, languageID string, fileID int, localPath string) error
 	DownloadTranslationFile(ctx context.Context, projectID string, fileID int, languageID string, opts storage.FileExportOptions) ([]byte, error)
 }
@@ -68,6 +69,10 @@ func (a *FileAdapter) FileWorkflowCapabilities() storage.FileWorkflowCapabilitie
 
 func (a *FileAdapter) UploadSources(ctx context.Context, req storage.FileUploadSourcesRequest) (storage.FileOperationResult, error) {
 	config := a.effectiveConfig(req.Config)
+	branchID, err := a.resolveBranchID(ctx, config)
+	if err != nil {
+		return storage.FileOperationResult{}, err
+	}
 	processed := make([]string, 0)
 	for _, group := range config.Files {
 		sourcePaths, err := resolveCrowdinSourcePaths(config.BasePath, group.Source)
@@ -79,11 +84,11 @@ func (a *FileAdapter) UploadSources(ctx context.Context, req storage.FileUploadS
 			if err != nil {
 				return storage.FileOperationResult{Processed: processed}, err
 			}
-			dirID, name, err := a.ensureRemoteLocation(ctx, config.ProjectID, remotePath)
+			dirID, name, err := a.ensureRemoteLocation(ctx, config.ProjectID, branchID, remotePath)
 			if err != nil {
 				return storage.FileOperationResult{Processed: processed}, err
 			}
-			if _, err := a.client.UpsertSourceFile(ctx, config.ProjectID, dirID, name, sourcePath, group); err != nil {
+			if _, err := a.client.UpsertSourceFile(ctx, config.ProjectID, branchID, dirID, name, sourcePath, group); err != nil {
 				return storage.FileOperationResult{Processed: processed}, err
 			}
 			processed = append(processed, remotePath)
@@ -96,6 +101,10 @@ func (a *FileAdapter) UploadSources(ctx context.Context, req storage.FileUploadS
 func (a *FileAdapter) UploadTranslations(ctx context.Context, req storage.FileUploadTranslationsRequest) (storage.FileOperationResult, error) {
 	config := a.effectiveConfig(req.Config)
 	locales, err := a.client.ResolveLocales(ctx, config.ProjectID, req.Languages)
+	if err != nil {
+		return storage.FileOperationResult{}, err
+	}
+	branchID, err := a.resolveBranchID(ctx, config)
 	if err != nil {
 		return storage.FileOperationResult{}, err
 	}
@@ -114,11 +123,11 @@ func (a *FileAdapter) UploadTranslations(ctx context.Context, req storage.FileUp
 			if err != nil {
 				return storage.FileOperationResult{Processed: processed, Skipped: skipped}, err
 			}
-			dirID, name, err := a.findRemoteLocation(ctx, config.ProjectID, remotePath)
+			dirID, name, err := a.findRemoteLocation(ctx, config.ProjectID, branchID, remotePath)
 			if err != nil {
 				return storage.FileOperationResult{Processed: processed, Skipped: skipped}, err
 			}
-			fileID, err := a.client.FindFile(ctx, config.ProjectID, dirID, name)
+			fileID, err := a.client.FindFile(ctx, config.ProjectID, branchID, dirID, name)
 			if err != nil {
 				return storage.FileOperationResult{Processed: processed, Skipped: skipped}, err
 			}
@@ -157,6 +166,10 @@ func (a *FileAdapter) DownloadTranslations(ctx context.Context, req storage.File
 	if err != nil {
 		return storage.FileOperationResult{}, err
 	}
+	branchID, err := a.resolveBranchID(ctx, config)
+	if err != nil {
+		return storage.FileOperationResult{}, err
+	}
 
 	processed := make([]string, 0)
 	skipped := make([]string, 0)
@@ -172,11 +185,11 @@ func (a *FileAdapter) DownloadTranslations(ctx context.Context, req storage.File
 			if err != nil {
 				return storage.FileOperationResult{Processed: processed, Skipped: skipped}, err
 			}
-			dirID, name, err := a.findRemoteLocation(ctx, config.ProjectID, remotePath)
+			dirID, name, err := a.findRemoteLocation(ctx, config.ProjectID, branchID, remotePath)
 			if err != nil {
 				return storage.FileOperationResult{Processed: processed, Skipped: skipped}, err
 			}
-			fileID, err := a.client.FindFile(ctx, config.ProjectID, dirID, name)
+			fileID, err := a.client.FindFile(ctx, config.ProjectID, branchID, dirID, name)
 			if err != nil {
 				return storage.FileOperationResult{Processed: processed, Skipped: skipped}, err
 			}
@@ -216,24 +229,32 @@ func (a *FileAdapter) effectiveConfig(cfg storage.FileWorkflowConfig) storage.Fi
 	return a.cfg
 }
 
-func (a *FileAdapter) ensureRemoteLocation(ctx context.Context, projectID, remotePath string) (int, string, error) {
+func (a *FileAdapter) resolveBranchID(ctx context.Context, cfg storage.FileWorkflowConfig) (int, error) {
+	branch := strings.TrimSpace(cfg.Branch)
+	if branch == "" {
+		return 0, nil
+	}
+	return a.client.ResolveBranch(ctx, cfg.ProjectID, branch)
+}
+
+func (a *FileAdapter) ensureRemoteLocation(ctx context.Context, projectID string, branchID int, remotePath string) (int, string, error) {
 	dirPath := filepath.ToSlash(filepath.Dir(remotePath))
 	if dirPath == "." {
 		dirPath = ""
 	}
-	dirID, err := a.client.EnsureDirectory(ctx, projectID, dirPath)
+	dirID, err := a.client.EnsureDirectory(ctx, projectID, branchID, dirPath)
 	if err != nil {
 		return 0, "", err
 	}
 	return dirID, filepath.Base(remotePath), nil
 }
 
-func (a *FileAdapter) findRemoteLocation(ctx context.Context, projectID, remotePath string) (int, string, error) {
+func (a *FileAdapter) findRemoteLocation(ctx context.Context, projectID string, branchID int, remotePath string) (int, string, error) {
 	dirPath := filepath.ToSlash(filepath.Dir(remotePath))
 	if dirPath == "." {
 		dirPath = ""
 	}
-	dirID, err := a.client.FindDirectory(ctx, projectID, dirPath)
+	dirID, err := a.client.FindDirectory(ctx, projectID, branchID, dirPath)
 	if err != nil {
 		return 0, "", err
 	}

--- a/internal/i18n/storage/crowdin/filemode_test.go
+++ b/internal/i18n/storage/crowdin/filemode_test.go
@@ -13,16 +13,22 @@ import (
 )
 
 type fakeFileClient struct {
-	locales              []string
-	ensuredDirectories   []string
-	foundDirectories     []string
-	upsertedSources      []string
-	uploadedTranslations []string
-	downloaded           []string
-	downloadOptions      []storage.FileExportOptions
-	directories          map[string]int
-	files                map[string]int
-	failFindMissing      bool
+	locales                []string
+	branchByName           map[string]int
+	resolvedBranches       []string
+	ensureBranchIDs        []int
+	findDirectoryBranchIDs []int
+	upsertBranchIDs        []int
+	findFileBranchIDs      []int
+	ensuredDirectories     []string
+	foundDirectories       []string
+	upsertedSources        []string
+	uploadedTranslations   []string
+	downloaded             []string
+	downloadOptions        []storage.FileExportOptions
+	directories            map[string]int
+	files                  map[string]int
+	failFindMissing        bool
 }
 
 func (f *fakeFileClient) ResolveLocales(_ context.Context, _ string, requested []string) ([]string, error) {
@@ -32,12 +38,22 @@ func (f *fakeFileClient) ResolveLocales(_ context.Context, _ string, requested [
 	return append([]string(nil), f.locales...), nil
 }
 
-func (f *fakeFileClient) EnsureDirectory(_ context.Context, _ string, path string) (int, error) {
+func (f *fakeFileClient) ResolveBranch(_ context.Context, _ string, branch string) (int, error) {
+	f.resolvedBranches = append(f.resolvedBranches, branch)
+	if id, ok := f.branchByName[branch]; ok {
+		return id, nil
+	}
+	return 0, fmt.Errorf("crowdin branch %q not found", branch)
+}
+
+func (f *fakeFileClient) EnsureDirectory(_ context.Context, _ string, branchID int, path string) (int, error) {
+	f.ensureBranchIDs = append(f.ensureBranchIDs, branchID)
 	f.ensuredDirectories = append(f.ensuredDirectories, path)
 	return len(f.ensuredDirectories), nil
 }
 
-func (f *fakeFileClient) FindDirectory(_ context.Context, _ string, path string) (int, error) {
+func (f *fakeFileClient) FindDirectory(_ context.Context, _ string, branchID int, path string) (int, error) {
+	f.findDirectoryBranchIDs = append(f.findDirectoryBranchIDs, branchID)
 	f.foundDirectories = append(f.foundDirectories, path)
 	if strings.TrimSpace(path) == "" {
 		return 0, nil
@@ -48,7 +64,8 @@ func (f *fakeFileClient) FindDirectory(_ context.Context, _ string, path string)
 	return 0, fmt.Errorf("remote directory %q not found", path)
 }
 
-func (f *fakeFileClient) UpsertSourceFile(_ context.Context, _ string, _ int, name, localPath string, _ storage.FileGroupSpec) (int, error) {
+func (f *fakeFileClient) UpsertSourceFile(_ context.Context, _ string, branchID, _ int, name, localPath string, _ storage.FileGroupSpec) (int, error) {
+	f.upsertBranchIDs = append(f.upsertBranchIDs, branchID)
 	if f.files == nil {
 		f.files = make(map[string]int)
 	}
@@ -58,7 +75,8 @@ func (f *fakeFileClient) UpsertSourceFile(_ context.Context, _ string, _ int, na
 	return id, nil
 }
 
-func (f *fakeFileClient) FindFile(_ context.Context, _ string, _ int, name string) (int, error) {
+func (f *fakeFileClient) FindFile(_ context.Context, _ string, branchID, _ int, name string) (int, error) {
+	f.findFileBranchIDs = append(f.findFileBranchIDs, branchID)
 	if id, ok := f.files[name]; ok {
 		return id, nil
 	}
@@ -312,6 +330,48 @@ func TestFileAdapterUploadSourcesFlattensWhenHierarchyDisabled(t *testing.T) {
 	}
 	if !reflect.DeepEqual(result.Processed, []string{"messages.json"}) {
 		t.Fatalf("processed = %#v, want flattened path", result.Processed)
+	}
+}
+
+func TestFileAdapterUsesConfiguredBranchForFileWorkflow(t *testing.T) {
+	base := t.TempDir()
+	writeJSONFixture(t, filepath.Join(base, "messages.json"), `{"hello":"Hello"}`)
+	writeJSONFixture(t, filepath.Join(base, "dist", "fr", "messages.json"), `{"hello":"Bonjour"}`)
+
+	client := &fakeFileClient{
+		locales:      []string{"fr"},
+		branchByName: map[string]int{"feature/login": 42},
+		files:        map[string]int{"messages.json": 7},
+	}
+	adapter := mustNewFileAdapterForTest(t, storage.FileWorkflowConfig{
+		ProjectID: "123",
+		APIToken:  "token",
+		BasePath:  base,
+		Branch:    "feature/login",
+		Files: []storage.FileGroupSpec{{
+			Source:      "/messages.json",
+			Translation: "/dist/%locale%/%original_file_name%",
+		}},
+	}, client)
+
+	if _, err := adapter.UploadSources(context.Background(), storage.FileUploadSourcesRequest{}); err != nil {
+		t.Fatalf("upload sources: %v", err)
+	}
+	if _, err := adapter.UploadTranslations(context.Background(), storage.FileUploadTranslationsRequest{}); err != nil {
+		t.Fatalf("upload translations: %v", err)
+	}
+	if _, err := adapter.DownloadTranslations(context.Background(), storage.FileDownloadTranslationsRequest{}); err != nil {
+		t.Fatalf("download translations: %v", err)
+	}
+
+	if got, want := client.resolvedBranches, []string{"feature/login", "feature/login", "feature/login"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("resolved branches = %#v, want %#v", got, want)
+	}
+	if got, want := client.upsertBranchIDs, []int{42}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("upsert branch IDs = %#v, want %#v", got, want)
+	}
+	if got, want := client.findFileBranchIDs, []int{42, 42}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("find file branch IDs = %#v, want %#v", got, want)
 	}
 }
 

--- a/internal/i18n/storage/crowdin/http_client.go
+++ b/internal/i18n/storage/crowdin/http_client.go
@@ -322,7 +322,41 @@ func (c *HTTPClient) ResolveLocales(ctx context.Context, projectID string, reque
 	return c.resolveLocales(ctx, projectInt, requested)
 }
 
-func (c *HTTPClient) EnsureDirectory(ctx context.Context, projectID, path string) (int, error) {
+func (c *HTTPClient) ResolveBranch(ctx context.Context, projectID, branch string) (int, error) {
+	projectInt, err := parseProjectID(projectID)
+	if err != nil {
+		return 0, err
+	}
+	branch = strings.TrimSpace(branch)
+	if branch == "" {
+		return 0, nil
+	}
+	offset := 0
+	for {
+		branches, _, err := c.client.Branches.List(ctx, projectInt, &model.BranchesListOptions{
+			Name: branch,
+			ListOptions: model.ListOptions{
+				Limit:  pageLimit,
+				Offset: offset,
+			},
+		})
+		if err != nil {
+			return 0, fmt.Errorf("list branches for %q: %w", branch, err)
+		}
+		for _, item := range branches {
+			if item != nil && item.Name == branch {
+				return item.ID, nil
+			}
+		}
+		if len(branches) < pageLimit {
+			break
+		}
+		offset += pageLimit
+	}
+	return 0, fmt.Errorf("crowdin branch %q not found", branch)
+}
+
+func (c *HTTPClient) EnsureDirectory(ctx context.Context, projectID string, branchID int, path string) (int, error) {
 	projectInt, err := parseProjectID(projectID)
 	if err != nil {
 		return 0, err
@@ -334,7 +368,7 @@ func (c *HTTPClient) EnsureDirectory(ctx context.Context, projectID, path string
 
 	parentID := 0
 	for _, segment := range strings.Split(normalized, "/") {
-		directory, err := c.findDirectory(ctx, projectInt, parentID, segment)
+		directory, err := c.findDirectory(ctx, projectInt, branchID, parentID, segment)
 		if err != nil {
 			return 0, err
 		}
@@ -342,13 +376,15 @@ func (c *HTTPClient) EnsureDirectory(ctx context.Context, projectID, path string
 			req := &model.DirectoryAddRequest{Name: segment}
 			if parentID > 0 {
 				req.DirectoryID = parentID
+			} else if branchID > 0 {
+				req.BranchID = branchID
 			}
 			directory, _, err = c.client.SourceFiles.AddDirectory(ctx, projectInt, req)
 			if err != nil {
 				if !isConflictError(err) {
 					return 0, fmt.Errorf("create directory %q: %w", segment, err)
 				}
-				directory, err = c.findDirectory(ctx, projectInt, parentID, segment)
+				directory, err = c.findDirectory(ctx, projectInt, branchID, parentID, segment)
 				if err != nil {
 					return 0, err
 				}
@@ -362,7 +398,7 @@ func (c *HTTPClient) EnsureDirectory(ctx context.Context, projectID, path string
 	return parentID, nil
 }
 
-func (c *HTTPClient) FindDirectory(ctx context.Context, projectID, path string) (int, error) {
+func (c *HTTPClient) FindDirectory(ctx context.Context, projectID string, branchID int, path string) (int, error) {
 	projectInt, err := parseProjectID(projectID)
 	if err != nil {
 		return 0, err
@@ -374,7 +410,7 @@ func (c *HTTPClient) FindDirectory(ctx context.Context, projectID, path string) 
 
 	parentID := 0
 	for _, segment := range strings.Split(normalized, "/") {
-		directory, err := c.findDirectory(ctx, projectInt, parentID, segment)
+		directory, err := c.findDirectory(ctx, projectInt, branchID, parentID, segment)
 		if err != nil {
 			return 0, err
 		}
@@ -386,7 +422,7 @@ func (c *HTTPClient) FindDirectory(ctx context.Context, projectID, path string) 
 	return parentID, nil
 }
 
-func (c *HTTPClient) UpsertSourceFile(ctx context.Context, projectID string, directoryID int, name, localPath string, group storage.FileGroupSpec) (int, error) {
+func (c *HTTPClient) UpsertSourceFile(ctx context.Context, projectID string, branchID, directoryID int, name, localPath string, group storage.FileGroupSpec) (int, error) {
 	projectInt, err := parseProjectID(projectID)
 	if err != nil {
 		return 0, err
@@ -396,7 +432,7 @@ func (c *HTTPClient) UpsertSourceFile(ctx context.Context, projectID string, dir
 		return 0, err
 	}
 
-	file, err := c.findFile(ctx, projectInt, directoryID, name)
+	file, err := c.findFile(ctx, projectInt, branchID, directoryID, name)
 	if err != nil {
 		return 0, err
 	}
@@ -408,6 +444,8 @@ func (c *HTTPClient) UpsertSourceFile(ctx context.Context, projectID string, dir
 		}
 		if directoryID > 0 {
 			req.DirectoryID = directoryID
+		} else if branchID > 0 {
+			req.BranchID = branchID
 		}
 		file, _, err = c.client.SourceFiles.AddFile(ctx, projectInt, req)
 		if err != nil {
@@ -437,12 +475,12 @@ func (c *HTTPClient) UpsertSourceFile(ctx context.Context, projectID string, dir
 	return file.ID, nil
 }
 
-func (c *HTTPClient) FindFile(ctx context.Context, projectID string, directoryID int, name string) (int, error) {
+func (c *HTTPClient) FindFile(ctx context.Context, projectID string, branchID, directoryID int, name string) (int, error) {
 	projectInt, err := parseProjectID(projectID)
 	if err != nil {
 		return 0, err
 	}
-	file, err := c.findFile(ctx, projectInt, directoryID, name)
+	file, err := c.findFile(ctx, projectInt, branchID, directoryID, name)
 	if err != nil {
 		return 0, err
 	}
@@ -510,10 +548,12 @@ func (c *HTTPClient) uploadStorage(ctx context.Context, localPath string) (int, 
 	return store.ID, nil
 }
 
-func (c *HTTPClient) findDirectory(ctx context.Context, projectID, parentDirectoryID int, name string) (*model.Directory, error) {
+func (c *HTTPClient) findDirectory(ctx context.Context, projectID, branchID, parentDirectoryID int, name string) (*model.Directory, error) {
 	opts := &model.DirectoryListOptions{Filter: name, ListOptions: model.ListOptions{Limit: pageLimit}}
 	if parentDirectoryID > 0 {
 		opts.DirectoryID = parentDirectoryID
+	} else if branchID > 0 {
+		opts.BranchID = branchID
 	}
 	directories, _, err := c.client.SourceFiles.ListDirectories(ctx, projectID, opts)
 	if err != nil {
@@ -527,10 +567,12 @@ func (c *HTTPClient) findDirectory(ctx context.Context, projectID, parentDirecto
 	return nil, nil
 }
 
-func (c *HTTPClient) findFile(ctx context.Context, projectID, directoryID int, name string) (*model.File, error) {
+func (c *HTTPClient) findFile(ctx context.Context, projectID, branchID, directoryID int, name string) (*model.File, error) {
 	opts := &model.FileListOptions{Filter: name, ListOptions: model.ListOptions{Limit: pageLimit}}
 	if directoryID > 0 {
 		opts.DirectoryID = directoryID
+	} else if branchID > 0 {
+		opts.BranchID = branchID
 	}
 	files, _, err := c.client.SourceFiles.ListFiles(ctx, projectID, opts)
 	if err != nil {

--- a/internal/i18n/storage/crowdin/http_client_test.go
+++ b/internal/i18n/storage/crowdin/http_client_test.go
@@ -1,16 +1,23 @@
 package crowdin
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
+	sdkcrowdin "github.com/crowdin/crowdin-api-client-go/crowdin"
 	"github.com/crowdin/crowdin-api-client-go/crowdin/model"
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/storage"
 )
 
 func TestParseProjectID(t *testing.T) {
@@ -244,4 +251,203 @@ func TestAPIBaseURLRoundTripperRewritesCloudHost(t *testing.T) {
 	if seenHost != parsed.Host {
 		t.Fatalf("unexpected rewritten host: %q", seenHost)
 	}
+}
+
+func TestHTTPClientResolveBranchFindsExactName(t *testing.T) {
+	client, mux, teardown := newCrowdinHTTPClientForTest(t)
+	defer teardown()
+
+	mux.HandleFunc("/api/v2/projects/123/branches", func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(t, r, http.MethodGet, "/api/v2/projects/123/branches?limit=500&name=feature%2Flogin")
+		_, _ = io.WriteString(w, `{"data":[{"data":{"id":42,"projectId":123,"name":"feature/login","title":"Feature Login"}}]}`)
+	})
+
+	id, err := client.ResolveBranch(context.Background(), "123", "feature/login")
+	if err != nil {
+		t.Fatalf("resolve branch: %v", err)
+	}
+	if id != 42 {
+		t.Fatalf("branch id = %d, want 42", id)
+	}
+}
+
+func TestHTTPClientResolveBranchErrorsWhenMissing(t *testing.T) {
+	client, mux, teardown := newCrowdinHTTPClientForTest(t)
+	defer teardown()
+
+	mux.HandleFunc("/api/v2/projects/123/branches", func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(t, r, http.MethodGet, "/api/v2/projects/123/branches?limit=500&name=missing")
+		_, _ = io.WriteString(w, `{"data":[{"data":{"id":7,"projectId":123,"name":"other","title":"Other"}}]}`)
+	})
+
+	_, err := client.ResolveBranch(context.Background(), "123", "missing")
+	if err == nil || !strings.Contains(err.Error(), `crowdin branch "missing" not found`) {
+		t.Fatalf("expected missing branch error, got %v", err)
+	}
+}
+
+func TestHTTPClientEnsureDirectoryScopesRootToBranchAndNestedToDirectory(t *testing.T) {
+	client, mux, teardown := newCrowdinHTTPClientForTest(t)
+	defer teardown()
+
+	postCount := 0
+	mux.HandleFunc("/api/v2/projects/123/directories", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method + " " + r.RequestURI {
+		case http.MethodGet + " /api/v2/projects/123/directories?branchId=42&filter=src&limit=500":
+			_, _ = io.WriteString(w, `{"data":[]}`)
+		case http.MethodPost + " /api/v2/projects/123/directories":
+			postCount++
+			if postCount == 1 {
+				assertJSONBody(t, r, map[string]any{"name": "src", "branchId": float64(42)})
+				_, _ = io.WriteString(w, `{"data":{"id":8,"projectId":123,"branchId":42,"name":"src"}}`)
+				return
+			}
+			assertJSONBody(t, r, map[string]any{"name": "nested", "directoryId": float64(8)})
+			_, _ = io.WriteString(w, `{"data":{"id":9,"projectId":123,"directoryId":8,"name":"nested"}}`)
+		case http.MethodGet + " /api/v2/projects/123/directories?directoryId=8&filter=nested&limit=500":
+			_, _ = io.WriteString(w, `{"data":[]}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.RequestURI)
+		}
+	})
+
+	id, err := client.EnsureDirectory(context.Background(), "123", 42, "src/nested")
+	if err != nil {
+		t.Fatalf("ensure directory: %v", err)
+	}
+	if id != 9 {
+		t.Fatalf("directory id = %d, want 9", id)
+	}
+}
+
+func TestHTTPClientFindDirectoryAndFileUseBranchForRootLookups(t *testing.T) {
+	client, mux, teardown := newCrowdinHTTPClientForTest(t)
+	defer teardown()
+
+	mux.HandleFunc("/api/v2/projects/123/directories", func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(t, r, http.MethodGet, "/api/v2/projects/123/directories?branchId=42&filter=src&limit=500")
+		_, _ = io.WriteString(w, `{"data":[{"data":{"id":8,"projectId":123,"branchId":42,"name":"src"}}]}`)
+	})
+	mux.HandleFunc("/api/v2/projects/123/files", func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(t, r, http.MethodGet, "/api/v2/projects/123/files?branchId=42&filter=messages.json&limit=500")
+		_, _ = io.WriteString(w, `{"data":[{"data":{"id":17,"projectId":123,"branchId":42,"name":"messages.json"}}]}`)
+	})
+
+	dirID, err := client.FindDirectory(context.Background(), "123", 42, "src")
+	if err != nil {
+		t.Fatalf("find directory: %v", err)
+	}
+	if dirID != 8 {
+		t.Fatalf("directory id = %d, want 8", dirID)
+	}
+	fileID, err := client.FindFile(context.Background(), "123", 42, 0, "messages.json")
+	if err != nil {
+		t.Fatalf("find file: %v", err)
+	}
+	if fileID != 17 {
+		t.Fatalf("file id = %d, want 17", fileID)
+	}
+}
+
+func TestHTTPClientUpsertSourceFileAddsRootFileToBranch(t *testing.T) {
+	client, mux, teardown := newCrowdinHTTPClientForTest(t)
+	defer teardown()
+
+	localPath := writeHTTPClientFixture(t, "messages.json", `{"hello":"Hello"}`)
+
+	mux.HandleFunc("/api/v2/storages", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("storage method = %s, want POST", r.Method)
+		}
+		_, _ = io.WriteString(w, `{"data":{"id":61,"fileName":"messages.json"}}`)
+	})
+	mux.HandleFunc("/api/v2/projects/123/files", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method + " " + r.RequestURI {
+		case http.MethodGet + " /api/v2/projects/123/files?branchId=42&filter=messages.json&limit=500":
+			_, _ = io.WriteString(w, `{"data":[]}`)
+		case http.MethodPost + " /api/v2/projects/123/files":
+			assertJSONBody(t, r, map[string]any{
+				"storageId": float64(61),
+				"name":      "messages.json",
+				"branchId":  float64(42),
+			})
+			_, _ = io.WriteString(w, `{"data":{"id":17,"projectId":123,"branchId":42,"name":"messages.json"}}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.RequestURI)
+		}
+	})
+
+	id, err := client.UpsertSourceFile(context.Background(), "123", 42, 0, "messages.json", localPath, storage.FileGroupSpec{})
+	if err != nil {
+		t.Fatalf("upsert source file: %v", err)
+	}
+	if id != 17 {
+		t.Fatalf("file id = %d, want 17", id)
+	}
+}
+
+func newCrowdinHTTPClientForTest(t *testing.T) (*HTTPClient, *http.ServeMux, func()) {
+	t.Helper()
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+
+	overrideURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server url: %v", err)
+	}
+	httpClient := server.Client()
+	httpClient.Transport = &apiBaseURLRoundTripper{
+		base:      httpClient.Transport,
+		override:  overrideURL,
+		cloudHost: "api.crowdin.com",
+	}
+	sdkClient, err := sdkcrowdin.NewClient("token", sdkcrowdin.WithHTTPClient(httpClient))
+	if err != nil {
+		t.Fatalf("new sdk client: %v", err)
+	}
+	return &HTTPClient{client: sdkClient, httpClient: httpClient}, mux, server.Close
+}
+
+func assertRequest(t *testing.T, r *http.Request, method, requestURI string) {
+	t.Helper()
+	if r.Method != method {
+		t.Fatalf("method = %s, want %s", r.Method, method)
+	}
+	if r.RequestURI != requestURI {
+		t.Fatalf("request URI = %s, want %s", r.RequestURI, requestURI)
+	}
+}
+
+func assertJSONBody(t *testing.T, r *http.Request, want map[string]any) {
+	t.Helper()
+	var got map[string]any
+	if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+		t.Fatalf("decode request body: %v", err)
+	}
+	if !mapsEqual(got, want) {
+		gotJSON, _ := json.Marshal(got)
+		wantJSON, _ := json.Marshal(want)
+		t.Fatalf("request body = %s, want %s", gotJSON, wantJSON)
+	}
+}
+
+func mapsEqual(got, want map[string]any) bool {
+	gotJSON, err := json.Marshal(got)
+	if err != nil {
+		return false
+	}
+	wantJSON, err := json.Marshal(want)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(gotJSON, wantJSON)
+}
+
+func writeHTTPClientFixture(t *testing.T, name, content string) string {
+	t.Helper()
+	path := t.TempDir() + "/" + name
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
 }

--- a/internal/i18n/storage/types.go
+++ b/internal/i18n/storage/types.go
@@ -150,6 +150,7 @@ type FileWorkflowConfig struct {
 	APIToken          string          `json:"-"`
 	APIBaseURL        string          `json:"api_base_url,omitempty"`
 	BasePath          string          `json:"base_path,omitempty"`
+	Branch            string          `json:"branch,omitempty"`
 	PreserveHierarchy bool            `json:"preserve_hierarchy,omitempty"`
 	Files             []FileGroupSpec `json:"files"`
 }


### PR DESCRIPTION
## What changed

Added Crowdin branch support to the `hyperlocalise crowdin` file-mode workflow.

- Supports root-level `branch:` in `crowdin.yml`
- Adds `--branch <name>` to:
  - `hyperlocalise crowdin upload sources`
  - `hyperlocalise crowdin upload translations`
  - `hyperlocalise crowdin download`
- Makes `--branch` override the config value for the current command
- Resolves Crowdin branch names to branch IDs before file operations
- Scopes source upload, directory lookup, file lookup, translation upload, and translation download to the selected branch
- Updates Crowdin command/storage docs in English, zh-CN, and vi-VN
- Adds adapter and HTTP-client tests for branch propagation and Crowdin API request shape

## How to test

```bash
go test ./internal/i18n/storage/crowdin
go test ./apps/cli/cmd
make fmt
make lint
make test
```

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
