### PR TITLE
feat(web): add authenticated file proxy, sandbox file translator, and agent file reader

### DIFF
--- a/apps/hyperlocalise-web/drizzle/0001_pale_star_brand.sql
+++ b/apps/hyperlocalise-web/drizzle/0001_pale_star_brand.sql
@@ -1,0 +1,37 @@
+CREATE TYPE "public"."stored_file_role" AS ENUM('source', 'output', 'reference', 'asset');--> statement-breakpoint
+CREATE TYPE "public"."stored_file_source_kind" AS ENUM('chat_upload', 'email_attachment', 'job_output', 'repository_file', 'tms_file');--> statement-breakpoint
+CREATE TABLE "stored_files" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organization_id" uuid NOT NULL,
+	"project_id" text,
+	"created_by_user_id" uuid,
+	"role" "stored_file_role" NOT NULL,
+	"source_kind" "stored_file_source_kind" NOT NULL,
+	"source_interaction_id" uuid,
+	"source_job_id" text,
+	"storage_provider" text NOT NULL,
+	"storage_key" text NOT NULL,
+	"storage_url" text NOT NULL,
+	"download_url" text,
+	"filename" text NOT NULL,
+	"content_type" text NOT NULL,
+	"byte_size" integer NOT NULL,
+	"sha256" text NOT NULL,
+	"etag" text,
+	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "stored_files" ADD CONSTRAINT "stored_files_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "stored_files" ADD CONSTRAINT "stored_files_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "stored_files" ADD CONSTRAINT "stored_files_created_by_user_id_users_id_fk" FOREIGN KEY ("created_by_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "stored_files" ADD CONSTRAINT "stored_files_source_interaction_id_interactions_id_fk" FOREIGN KEY ("source_interaction_id") REFERENCES "public"."interactions"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "stored_files" ADD CONSTRAINT "stored_files_source_job_id_jobs_id_fk" FOREIGN KEY ("source_job_id") REFERENCES "public"."jobs"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "stored_files_storage_provider_key" ON "stored_files" USING btree ("storage_provider","storage_key");--> statement-breakpoint
+CREATE INDEX "idx_stored_files_org_created_at" ON "stored_files" USING btree ("organization_id","created_at");--> statement-breakpoint
+CREATE INDEX "idx_stored_files_project_created_at" ON "stored_files" USING btree ("project_id","created_at");--> statement-breakpoint
+CREATE INDEX "idx_stored_files_created_by_user_id" ON "stored_files" USING btree ("created_by_user_id");--> statement-breakpoint
+CREATE INDEX "idx_stored_files_source_interaction" ON "stored_files" USING btree ("source_interaction_id");--> statement-breakpoint
+CREATE INDEX "idx_stored_files_source_job" ON "stored_files" USING btree ("source_job_id");--> statement-breakpoint
+CREATE INDEX "idx_stored_files_org_role" ON "stored_files" USING btree ("organization_id","role");

--- a/apps/hyperlocalise-web/drizzle/meta/0001_snapshot.json
+++ b/apps/hyperlocalise-web/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,3717 @@
+{
+  "id": "16aa6109-5427-4217-ac23-bfaa9c019f16",
+  "prevId": "889b6ab7-867a-4ec9-8ea9-d71954d1a9a6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.asset_management_job_details": {
+      "name": "asset_management_job_details",
+      "schema": "",
+      "columns": {
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "asset_type": {
+          "name": "asset_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "asset_management_job_details_job_id_jobs_id_fk": {
+          "name": "asset_management_job_details_job_id_jobs_id_fk",
+          "tableFrom": "asset_management_job_details",
+          "tableTo": "jobs",
+          "columnsFrom": ["job_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connectors": {
+      "name": "connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connectors_org_kind_key": {
+          "name": "connectors_org_kind_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connectors_org": {
+          "name": "idx_connectors_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connectors_organization_id_organizations_id_fk": {
+          "name": "connectors_organization_id_organizations_id_fk",
+          "tableFrom": "connectors",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installation_repositories": {
+      "name": "github_installation_repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_installation_id": {
+          "name": "github_installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_repository_id": {
+          "name": "github_repository_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private": {
+          "name": "private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installation_repositories_github_repository_id_key": {
+          "name": "github_installation_repositories_github_repository_id_key",
+          "columns": [
+            {
+              "expression": "github_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "github_repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_installation_repositories_org": {
+          "name": "idx_github_installation_repositories_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_installation_repositories_installation": {
+          "name": "idx_github_installation_repositories_installation",
+          "columns": [
+            {
+              "expression": "github_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_installation_repositories_org_enabled": {
+          "name": "idx_github_installation_repositories_org_enabled",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installation_repositories_organization_id_organizations_id_fk": {
+          "name": "github_installation_repositories_organization_id_organizations_id_fk",
+          "tableFrom": "github_installation_repositories",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installations": {
+      "name": "github_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_installation_id": {
+          "name": "github_installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_app_id": {
+          "name": "github_app_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installations_organization_id_key": {
+          "name": "github_installations_organization_id_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_installations_github_installation_id_key": {
+          "name": "github_installations_github_installation_id_key",
+          "columns": [
+            {
+              "expression": "github_installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_installations_created_at": {
+          "name": "idx_github_installations_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installations_organization_id_organizations_id_fk": {
+          "name": "github_installations_organization_id_organizations_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.glossaries": {
+      "name": "glossaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "source_locale": {
+          "name": "source_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_locale": {
+          "name": "target_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "asset_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "glossaries_id_organization_id_key": {
+          "name": "glossaries_id_organization_id_key",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_glossaries_org_created_at": {
+          "name": "idx_glossaries_org_created_at",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_glossaries_org_locale_pair": {
+          "name": "idx_glossaries_org_locale_pair",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_glossaries_created_by_user_id": {
+          "name": "idx_glossaries_created_by_user_id",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "glossaries_organization_id_organizations_id_fk": {
+          "name": "glossaries_organization_id_organizations_id_fk",
+          "tableFrom": "glossaries",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "glossaries_created_by_user_id_users_id_fk": {
+          "name": "glossaries_created_by_user_id_users_id_fk",
+          "tableFrom": "glossaries",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.glossary_terms": {
+      "name": "glossary_terms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "glossary_id": {
+          "name": "glossary_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_term": {
+          "name": "source_term",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_term": {
+          "name": "target_term",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "part_of_speech": {
+          "name": "part_of_speech",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "case_sensitive": {
+          "name": "case_sensitive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "forbidden": {
+          "name": "forbidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "review_status": {
+          "name": "review_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'approved'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "\n      setweight(to_tsvector('simple', coalesce(source_term, '')), 'A') ||\n      setweight(to_tsvector('simple', coalesce(target_term, '')), 'B') ||\n      setweight(to_tsvector('simple', coalesce(description, '')), 'C')\n    ",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "glossary_terms_glossary_source_term_key": {
+          "name": "glossary_terms_glossary_source_term_key",
+          "columns": [
+            {
+              "expression": "glossary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_term",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "glossary_terms_glossary_source_term_ci_key": {
+          "name": "glossary_terms_glossary_source_term_ci_key",
+          "columns": [
+            {
+              "expression": "glossary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"source_term\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"glossary_terms\".\"case_sensitive\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_glossary_terms_glossary_created_at": {
+          "name": "idx_glossary_terms_glossary_created_at",
+          "columns": [
+            {
+              "expression": "glossary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_glossary_terms_search_vector": {
+          "name": "idx_glossary_terms_search_vector",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "glossary_terms_glossary_id_glossaries_id_fk": {
+          "name": "glossary_terms_glossary_id_glossaries_id_fk",
+          "tableFrom": "glossary_terms",
+          "tableTo": "glossaries",
+          "columnsFrom": ["glossary_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbox_items": {
+      "name": "inbox_items",
+      "schema": "",
+      "columns": {
+        "interaction_id": {
+          "name": "interaction_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "inbox_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_inbox_items_org_status": {
+          "name": "idx_inbox_items_org_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inbox_items_org_updated": {
+          "name": "idx_inbox_items_org_updated",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inbox_items_interaction_id_interactions_id_fk": {
+          "name": "inbox_items_interaction_id_interactions_id_fk",
+          "tableFrom": "inbox_items",
+          "tableTo": "interactions",
+          "columnsFrom": ["interaction_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inbox_items_organization_id_organizations_id_fk": {
+          "name": "inbox_items_organization_id_organizations_id_fk",
+          "tableFrom": "inbox_items",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inbox_items_project_id_projects_id_fk": {
+          "name": "inbox_items_project_id_projects_id_fk",
+          "tableFrom": "inbox_items",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interaction_messages": {
+      "name": "interaction_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "interaction_id": {
+          "name": "interaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_type": {
+          "name": "sender_type",
+          "type": "message_sender_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_email": {
+          "name": "sender_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_interaction_messages_interaction_created": {
+          "name": "idx_interaction_messages_interaction_created",
+          "columns": [
+            {
+              "expression": "interaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "interaction_messages_interaction_id_interactions_id_fk": {
+          "name": "interaction_messages_interaction_id_interactions_id_fk",
+          "tableFrom": "interaction_messages",
+          "tableTo": "interactions",
+          "columnsFrom": ["interaction_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interactions": {
+      "name": "interactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "interaction_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_thread_id": {
+          "name": "source_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "interactions_id_organization_id_key": {
+          "name": "interactions_id_organization_id_key",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "interactions_org_source_thread_id_key": {
+          "name": "interactions_org_source_thread_id_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"interactions\".\"source_thread_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_interactions_org_last_message": {
+          "name": "idx_interactions_org_last_message",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "interactions_organization_id_organizations_id_fk": {
+          "name": "interactions_organization_id_organizations_id_fk",
+          "tableFrom": "interactions",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "interactions_project_id_projects_id_fk": {
+          "name": "interactions_project_id_projects_id_fk",
+          "tableFrom": "interactions",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "job_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "input_payload": {
+          "name": "input_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome_payload": {
+          "name": "outcome_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interaction_id": {
+          "name": "interaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_snapshot": {
+          "name": "context_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_jobs_org_created_at": {
+          "name": "idx_jobs_org_created_at",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_project_created_at": {
+          "name": "idx_jobs_project_created_at",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_created_by_user_id": {
+          "name": "idx_jobs_created_by_user_id",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_owner_user_id": {
+          "name": "idx_jobs_owner_user_id",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_kind_status": {
+          "name": "idx_jobs_kind_status",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_workflow_run_id": {
+          "name": "idx_jobs_workflow_run_id",
+          "columns": [
+            {
+              "expression": "workflow_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_status": {
+          "name": "idx_jobs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_interaction": {
+          "name": "idx_jobs_interaction",
+          "columns": [
+            {
+              "expression": "interaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "jobs_organization_id_organizations_id_fk": {
+          "name": "jobs_organization_id_organizations_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "jobs_project_id_projects_id_fk": {
+          "name": "jobs_project_id_projects_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "jobs_created_by_user_id_users_id_fk": {
+          "name": "jobs_created_by_user_id_users_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "jobs_owner_user_id_users_id_fk": {
+          "name": "jobs_owner_user_id_users_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "users",
+          "columnsFrom": ["owner_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "jobs_interaction_id_interactions_id_fk": {
+          "name": "jobs_interaction_id_interactions_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "interactions",
+          "columnsFrom": ["interaction_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memories": {
+      "name": "memories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "asset_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memories_id_organization_id_key": {
+          "name": "memories_id_organization_id_key",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memories_org_created_at": {
+          "name": "idx_memories_org_created_at",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memories_created_by_user_id": {
+          "name": "idx_memories_created_by_user_id",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memories_organization_id_organizations_id_fk": {
+          "name": "memories_organization_id_organizations_id_fk",
+          "tableFrom": "memories",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memories_created_by_user_id_users_id_fk": {
+          "name": "memories_created_by_user_id_users_id_fk",
+          "tableFrom": "memories",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_entries": {
+      "name": "memory_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "memory_id": {
+          "name": "memory_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_locale": {
+          "name": "source_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_locale": {
+          "name": "target_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_text": {
+          "name": "source_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_source_text": {
+          "name": "normalized_source_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_text": {
+          "name": "target_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_score": {
+          "name": "match_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_status": {
+          "name": "review_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'approved'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "\n      setweight(to_tsvector('simple', coalesce(source_text, '')), 'A') ||\n      setweight(to_tsvector('simple', coalesce(target_text, '')), 'B')\n    ",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memory_entries_memory_locale_source_key": {
+          "name": "memory_entries_memory_locale_source_key",
+          "columns": [
+            {
+              "expression": "memory_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_source_text",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_entries_memory_locale_pair": {
+          "name": "idx_memory_entries_memory_locale_pair",
+          "columns": [
+            {
+              "expression": "memory_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_entries_external_key": {
+          "name": "idx_memory_entries_external_key",
+          "columns": [
+            {
+              "expression": "external_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_memory_entries_search_vector": {
+          "name": "idx_memory_entries_search_vector",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_entries_memory_id_memories_id_fk": {
+          "name": "memory_entries_memory_id_memories_id_fk",
+          "tableFrom": "memory_entries",
+          "tableTo": "memories",
+          "columnsFrom": ["memory_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "memory_entries_match_score_check": {
+          "name": "memory_entries_match_score_check",
+          "value": "\"memory_entries\".\"match_score\" >= 0 AND \"memory_entries\".\"match_score\" <= 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization_llm_provider_credentials": {
+      "name": "organization_llm_provider_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "llm_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_model": {
+          "name": "default_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "masked_api_key_suffix": {
+          "name": "masked_api_key_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encryption_algorithm": {
+          "name": "encryption_algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "last_validated_at": {
+          "name": "last_validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_llm_provider_credentials_org_provider_key": {
+          "name": "organization_llm_provider_credentials_org_provider_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organization_llm_provider_credentials_updated_at": {
+          "name": "idx_organization_llm_provider_credentials_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_llm_provider_credentials_organization_id_organizations_id_fk": {
+          "name": "organization_llm_provider_credentials_organization_id_organizations_id_fk",
+          "tableFrom": "organization_llm_provider_credentials",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_llm_provider_credentials_created_by_user_id_users_id_fk": {
+          "name": "organization_llm_provider_credentials_created_by_user_id_users_id_fk",
+          "tableFrom": "organization_llm_provider_credentials",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "organization_llm_provider_credentials_updated_by_user_id_users_id_fk": {
+          "name": "organization_llm_provider_credentials_updated_by_user_id_users_id_fk",
+          "tableFrom": "organization_llm_provider_credentials",
+          "tableTo": "users",
+          "columnsFrom": ["updated_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_memberships": {
+      "name": "organization_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workos_membership_id": {
+          "name": "workos_membership_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "organization_membership_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_memberships_org_user_key": {
+          "name": "organization_memberships_org_user_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_memberships_workos_membership_id_key": {
+          "name": "organization_memberships_workos_membership_id_key",
+          "columns": [
+            {
+              "expression": "workos_membership_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organization_memberships_user_id": {
+          "name": "idx_organization_memberships_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_memberships_organization_id_organizations_id_fk": {
+          "name": "organization_memberships_organization_id_organizations_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_memberships_user_id_users_id_fk": {
+          "name": "organization_memberships_user_id_users_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workos_organization_id": {
+          "name": "workos_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organizations_workos_organization_id_key": {
+          "name": "organizations_workos_organization_id_key",
+          "columns": [
+            {
+              "expression": "workos_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organizations_slug_key": {
+          "name": "organizations_slug_key",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_organizations_created_at": {
+          "name": "idx_organizations_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_glossaries": {
+      "name": "project_glossaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "glossary_id": {
+          "name": "glossary_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_glossaries_project_glossary_key": {
+          "name": "project_glossaries_project_glossary_key",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "glossary_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_glossaries_org": {
+          "name": "idx_project_glossaries_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_glossaries_project_priority": {
+          "name": "idx_project_glossaries_project_priority",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_glossaries_organization_id_organizations_id_fk": {
+          "name": "project_glossaries_organization_id_organizations_id_fk",
+          "tableFrom": "project_glossaries",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_glossaries_project_id_projects_id_fk": {
+          "name": "project_glossaries_project_id_projects_id_fk",
+          "tableFrom": "project_glossaries",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_memories": {
+      "name": "project_memories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_id": {
+          "name": "memory_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_memories_project_memory_key": {
+          "name": "project_memories_project_memory_key",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "memory_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_memories_org": {
+          "name": "idx_project_memories_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_memories_project_priority": {
+          "name": "idx_project_memories_project_priority",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_memories_organization_id_organizations_id_fk": {
+          "name": "project_memories_organization_id_organizations_id_fk",
+          "tableFrom": "project_memories",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_memories_project_id_projects_id_fk": {
+          "name": "project_memories_project_id_projects_id_fk",
+          "tableFrom": "project_memories",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "translation_context": {
+          "name": "translation_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_id_organization_id_key": {
+          "name": "projects_id_organization_id_key",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_projects_org_created_at": {
+          "name": "idx_projects_org_created_at",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_projects_created_by_user_id": {
+          "name": "idx_projects_created_by_user_id",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_organization_id_organizations_id_fk": {
+          "name": "projects_organization_id_organizations_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "projects_created_by_user_id_users_id_fk": {
+          "name": "projects_created_by_user_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_job_details": {
+      "name": "review_job_details",
+      "schema": "",
+      "columns": {
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "criteria": {
+          "name": "criteria",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "target_locale": {
+          "name": "target_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "review_job_details_job_id_jobs_id_fk": {
+          "name": "review_job_details_job_id_jobs_id_fk",
+          "tableFrom": "review_job_details",
+          "tableTo": "jobs",
+          "columnsFrom": ["job_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stored_files": {
+      "name": "stored_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "stored_file_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "stored_file_source_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_interaction_id": {
+          "name": "source_interaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_job_id": {
+          "name": "source_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_provider": {
+          "name": "storage_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_url": {
+          "name": "storage_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "download_url": {
+          "name": "download_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "etag": {
+          "name": "etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stored_files_storage_provider_key": {
+          "name": "stored_files_storage_provider_key",
+          "columns": [
+            {
+              "expression": "storage_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "storage_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_stored_files_org_created_at": {
+          "name": "idx_stored_files_org_created_at",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_stored_files_project_created_at": {
+          "name": "idx_stored_files_project_created_at",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_stored_files_created_by_user_id": {
+          "name": "idx_stored_files_created_by_user_id",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_stored_files_source_interaction": {
+          "name": "idx_stored_files_source_interaction",
+          "columns": [
+            {
+              "expression": "source_interaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_stored_files_source_job": {
+          "name": "idx_stored_files_source_job",
+          "columns": [
+            {
+              "expression": "source_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_stored_files_org_role": {
+          "name": "idx_stored_files_org_role",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stored_files_organization_id_organizations_id_fk": {
+          "name": "stored_files_organization_id_organizations_id_fk",
+          "tableFrom": "stored_files",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stored_files_project_id_projects_id_fk": {
+          "name": "stored_files_project_id_projects_id_fk",
+          "tableFrom": "stored_files",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "stored_files_created_by_user_id_users_id_fk": {
+          "name": "stored_files_created_by_user_id_users_id_fk",
+          "tableFrom": "stored_files",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "stored_files_source_interaction_id_interactions_id_fk": {
+          "name": "stored_files_source_interaction_id_interactions_id_fk",
+          "tableFrom": "stored_files",
+          "tableTo": "interactions",
+          "columnsFrom": ["source_interaction_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "stored_files_source_job_id_jobs_id_fk": {
+          "name": "stored_files_source_job_id_jobs_id_fk",
+          "tableFrom": "stored_files",
+          "tableTo": "jobs",
+          "columnsFrom": ["source_job_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_job_details": {
+      "name": "sync_job_details",
+      "schema": "",
+      "columns": {
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "connector_kind": {
+          "name": "connector_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_identifiers": {
+          "name": "external_identifiers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sync_job_details_job_id_jobs_id_fk": {
+          "name": "sync_job_details_job_id_jobs_id_fk",
+          "tableFrom": "sync_job_details",
+          "tableTo": "jobs",
+          "columnsFrom": ["job_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_memberships": {
+      "name": "team_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "team_membership_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_memberships_team_user_key": {
+          "name": "team_memberships_team_user_key",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_team_memberships_user_id": {
+          "name": "idx_team_memberships_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_memberships_team_id_teams_id_fk": {
+          "name": "team_memberships_team_id_teams_id_fk",
+          "tableFrom": "team_memberships",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_memberships_user_id_users_id_fk": {
+          "name": "team_memberships_user_id_users_id_fk",
+          "tableFrom": "team_memberships",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "teams_org_slug_key": {
+          "name": "teams_org_slug_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_teams_org_created_at": {
+          "name": "idx_teams_org_created_at",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "teams_organization_id_organizations_id_fk": {
+          "name": "teams_organization_id_organizations_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tms_links": {
+      "name": "tms_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_account_id": {
+          "name": "external_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_project_id": {
+          "name": "external_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tms_links_org": {
+          "name": "idx_tms_links_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tms_links_org_provider": {
+          "name": "idx_tms_links_org_provider",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tms_links_organization_id_organizations_id_fk": {
+          "name": "tms_links_organization_id_organizations_id_fk",
+          "tableFrom": "tms_links",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tms_links_project_id_projects_id_fk": {
+          "name": "tms_links_project_id_projects_id_fk",
+          "tableFrom": "tms_links",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.translation_job_details": {
+      "name": "translation_job_details",
+      "schema": "",
+      "columns": {
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "translation_job_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome_kind": {
+          "name": "outcome_kind",
+          "type": "translation_job_outcome_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_translation_job_details_type": {
+          "name": "idx_translation_job_details_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_translation_job_details_outcome_kind": {
+          "name": "idx_translation_job_details_outcome_kind",
+          "columns": [
+            {
+              "expression": "outcome_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "translation_job_details_job_id_jobs_id_fk": {
+          "name": "translation_job_details_job_id_jobs_id_fk",
+          "tableFrom": "translation_job_details",
+          "tableTo": "jobs",
+          "columnsFrom": ["job_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workos_user_id": {
+          "name": "workos_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_workos_user_id_key": {
+          "name": "users_workos_user_id_key",
+          "columns": [
+            {
+              "expression": "workos_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_key": {
+          "name": "users_email_key",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_created_at": {
+          "name": "idx_users_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.asset_status": {
+      "name": "asset_status",
+      "schema": "public",
+      "values": ["draft", "active", "archived"]
+    },
+    "public.inbox_status": {
+      "name": "inbox_status",
+      "schema": "public",
+      "values": ["active", "archived"]
+    },
+    "public.interaction_source": {
+      "name": "interaction_source",
+      "schema": "public",
+      "values": ["chat_ui", "email_agent", "github_agent"]
+    },
+    "public.job_kind": {
+      "name": "job_kind",
+      "schema": "public",
+      "values": ["translation", "research", "review", "sync", "asset_management"]
+    },
+    "public.job_status": {
+      "name": "job_status",
+      "schema": "public",
+      "values": ["queued", "running", "succeeded", "failed", "waiting_for_review", "cancelled"]
+    },
+    "public.llm_provider": {
+      "name": "llm_provider",
+      "schema": "public",
+      "values": ["openai", "anthropic", "gemini", "groq", "mistral"]
+    },
+    "public.message_sender_type": {
+      "name": "message_sender_type",
+      "schema": "public",
+      "values": ["user", "agent"]
+    },
+    "public.organization_membership_role": {
+      "name": "organization_membership_role",
+      "schema": "public",
+      "values": ["owner", "admin", "member"]
+    },
+    "public.stored_file_role": {
+      "name": "stored_file_role",
+      "schema": "public",
+      "values": ["source", "output", "reference", "asset"]
+    },
+    "public.stored_file_source_kind": {
+      "name": "stored_file_source_kind",
+      "schema": "public",
+      "values": ["chat_upload", "email_attachment", "job_output", "repository_file", "tms_file"]
+    },
+    "public.team_membership_role": {
+      "name": "team_membership_role",
+      "schema": "public",
+      "values": ["manager", "member"]
+    },
+    "public.translation_job_outcome_kind": {
+      "name": "translation_job_outcome_kind",
+      "schema": "public",
+      "values": ["string_result", "file_result", "error"]
+    },
+    "public.translation_job_type": {
+      "name": "translation_job_type",
+      "schema": "public",
+      "values": ["string", "file"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/hyperlocalise-web/drizzle/meta/_journal.json
+++ b/apps/hyperlocalise-web/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1777728051870,
       "tag": "0000_furry_amphibian",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1777865982684,
+      "tag": "0001_pale_star_brand",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/hyperlocalise-web/package.json
+++ b/apps/hyperlocalise-web/package.json
@@ -29,6 +29,7 @@
     "@t3-oss/env-nextjs": "0.13.11",
     "@tanstack/react-query": "5.100.6",
     "@vercel/analytics": "2.0.1",
+    "@vercel/blob": "^2.3.3",
     "@vercel/sandbox": "1.10.0",
     "@workos-inc/authkit-nextjs": "4.0.1",
     "@xyflow/react": "^12.10.2",

--- a/apps/hyperlocalise-web/pnpm-lock.yaml
+++ b/apps/hyperlocalise-web/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@vercel/analytics':
         specifier: 2.0.1
         version: 2.0.1(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+      '@vercel/blob':
+        specifier: ^2.3.3
+        version: 2.3.3
       '@vercel/sandbox':
         specifier: 1.10.0
         version: 1.10.0
@@ -3171,6 +3174,10 @@ packages:
       vue-router:
         optional: true
 
+  '@vercel/blob@2.3.3':
+    resolution: {integrity: sha512-MtD7VLo6hU07eHR7bmk5SIMD290q574UaNYTe46qeyRT+hWrCy26CoAqfd7PnIefVXvRehRZBzukxuTO9iGTVg==}
+    engines: {node: '>=20.0.0'}
+
   '@vercel/cli-auth@0.0.1':
     resolution: {integrity: sha512-CnqiuMlZ4pjs2LCPYiR6aLKPPd3Xb8SBI1Y7eotXKgpx6qgrGNY+E7EIyUt5ErGHJGIrCZyGG5WEo4bHtVmz2Q==}
 
@@ -5089,6 +5096,10 @@ packages:
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
+  is-buffer@2.0.5:
+    resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
+    engines: {node: '>=4'}
+
   is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
@@ -6968,6 +6979,10 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  undici@6.25.0:
+    resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
+    engines: {node: '>=18.17'}
 
   undici@7.22.0:
     resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
@@ -10090,6 +10105,14 @@ snapshots:
       next: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
 
+  '@vercel/blob@2.3.3':
+    dependencies:
+      async-retry: 1.3.3
+      is-buffer: 2.0.5
+      is-node-process: 1.2.0
+      throttleit: 2.1.0
+      undici: 6.25.0
+
   '@vercel/cli-auth@0.0.1':
     dependencies:
       async-listen: 3.0.0
@@ -12259,6 +12282,8 @@ snapshots:
       is-decimal: 2.0.1
 
   is-arrayish@0.2.1: {}
+
+  is-buffer@2.0.5: {}
 
   is-decimal@2.0.1: {}
 
@@ -14470,6 +14495,8 @@ snapshots:
       unplugin: 2.3.11
 
   undici-types@7.16.0: {}
+
+  undici@6.25.0: {}
 
   undici@7.22.0: {}
 

--- a/apps/hyperlocalise-web/src/api/app.ts
+++ b/apps/hyperlocalise-web/src/api/app.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 
+import type { FileStorageAdapter } from "@/lib/file-storage";
 import type {
   EmailAgentTaskQueue,
   GitHubFixQueue,
@@ -17,6 +18,7 @@ import { createWorkspaceJobRoutes } from "./routes/project/job.route";
 import { createProjectRoutes } from "./routes/project/project.route";
 import { createProviderCredentialRoutes } from "./routes/provider-credential/provider-credential.route";
 import { createResendWebhookRoutes } from "./routes/resend-webhook";
+import { createFileRoutes } from "./routes/file/file.route";
 import { createTeamRoutes } from "./routes/team/team.route";
 import { workosWebhookRoutes } from "./routes/workos-webhook";
 
@@ -25,6 +27,7 @@ type CreateAppOptions = {
   githubFixQueue?: GitHubFixQueue;
   githubWebhookHandler?: (request: Request) => Promise<Response>;
   jobQueue?: TranslationJobQueue;
+  fileStorageAdapter?: FileStorageAdapter;
   /**
    * @deprecated Use `jobQueue`.
    */
@@ -44,8 +47,15 @@ export function createApp(options: CreateAppOptions = {}) {
     .route("/orgs/:organizationSlug/provider-credential", createProviderCredentialRoutes())
     .route("/orgs/:organizationSlug/agent-email", createAgentEmailRoutes())
     .route("/orgs/:organizationSlug/teams", createTeamRoutes())
+    .route(
+      "/orgs/:organizationSlug/files",
+      createFileRoutes({ fileStorageAdapter: options.fileStorageAdapter }),
+    )
     .route("/orgs/:organizationSlug/conversations", createConversationRoutes())
-    .route("/orgs/:organizationSlug/chat-requests", createChatRequestRoutes())
+    .route(
+      "/orgs/:organizationSlug/chat-requests",
+      createChatRequestRoutes({ fileStorageAdapter: options.fileStorageAdapter }),
+    )
     .route("/orgs/:organizationSlug/github-installation", createGithubInstallationRoutes())
     .route(
       "/webhooks/github",

--- a/apps/hyperlocalise-web/src/api/routes/chat-request/chat-request.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/chat-request/chat-request.route.test.ts
@@ -1,0 +1,180 @@
+import "dotenv/config";
+
+import { eq } from "drizzle-orm";
+import { testClient } from "hono/testing";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
+
+import { createApp } from "@/api/app";
+import { db, schema } from "@/lib/database";
+import type { FileStorageAdapter, PutStoredObjectInput } from "@/lib/file-storage";
+import { createProjectTestFixture } from "../project/project.fixture";
+
+const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
+  resolveApiAuthContextFromSessionMock: vi.fn(() => globalThis.__testApiAuthContext ?? null),
+}));
+
+vi.mock("@/api/auth/workos-session", () => ({
+  resolveApiAuthContextFromSession: resolveApiAuthContextFromSessionMock,
+}));
+
+function createMemoryFileStorageAdapter(): FileStorageAdapter {
+  return {
+    provider: "vercel_blob",
+    async put(input: PutStoredObjectInput) {
+      return {
+        provider: "vercel_blob",
+        key: input.key,
+        url: `https://blob.example/${input.key}`,
+        downloadUrl: `https://blob.example/${input.key}?download=1`,
+        contentType: input.contentType,
+        etag: "test-etag",
+      };
+    },
+    async get() {
+      return null;
+    },
+    async delete() {},
+    async getSignedUrl() {
+      return null;
+    },
+  };
+}
+
+const app = createApp({ fileStorageAdapter: createMemoryFileStorageAdapter() });
+const client = testClient(app);
+const { authHeadersFor, cleanup, createProjectViaApi, createWorkosIdentity } =
+  createProjectTestFixture(client);
+
+async function ensureStoredFilesTestSchema() {
+  await db.$client.query(`
+    DO $$
+    BEGIN
+      CREATE TYPE stored_file_role AS ENUM ('source', 'output', 'reference', 'asset');
+    EXCEPTION
+      WHEN duplicate_object THEN null;
+    END $$;
+  `);
+  await db.$client.query(`
+    DO $$
+    BEGIN
+      CREATE TYPE stored_file_source_kind AS ENUM (
+        'chat_upload',
+        'email_attachment',
+        'job_output',
+        'repository_file',
+        'tms_file'
+      );
+    EXCEPTION
+      WHEN duplicate_object THEN null;
+    END $$;
+  `);
+  await db.$client.query(`
+    CREATE TABLE IF NOT EXISTS stored_files (
+      id text PRIMARY KEY NOT NULL,
+      organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE cascade,
+      project_id text REFERENCES projects(id) ON DELETE set null,
+      created_by_user_id uuid REFERENCES users(id) ON DELETE set null,
+      role stored_file_role NOT NULL,
+      source_kind stored_file_source_kind NOT NULL,
+      source_interaction_id uuid REFERENCES interactions(id) ON DELETE set null,
+      source_job_id text REFERENCES jobs(id) ON DELETE set null,
+      storage_provider text NOT NULL,
+      storage_key text NOT NULL,
+      storage_url text NOT NULL,
+      download_url text,
+      filename text NOT NULL,
+      content_type text NOT NULL,
+      byte_size integer NOT NULL,
+      sha256 text NOT NULL,
+      etag text,
+      metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
+      created_at timestamp with time zone DEFAULT now() NOT NULL,
+      updated_at timestamp with time zone DEFAULT now() NOT NULL
+    )
+  `);
+}
+
+beforeAll(async () => {
+  await db.$client.query("select 1");
+  await ensureStoredFilesTestSchema();
+});
+
+afterEach(async () => {
+  vi.clearAllMocks();
+  await cleanup();
+});
+
+describe("chat request uploads", () => {
+  it("stores translation source files and links them to the chat message", async () => {
+    const identity = createWorkosIdentity();
+    const projectResponse = await createProjectViaApi(identity);
+    const projectBody = (await projectResponse.json()) as { project: { id: string } };
+    const headers = await authHeadersFor(identity);
+    const formData = new FormData();
+    formData.set("text", "Translate this to fr-FR");
+    formData.set("projectId", projectBody.project.id);
+    formData.append(
+      "files",
+      new File([JSON.stringify({ hello: "Hello" })], "source.json", {
+        type: "application/json",
+      }),
+    );
+
+    const response = await app.request(
+      `/api/orgs/${identity.organization.slug}/chat-requests/upload`,
+      {
+        method: "POST",
+        headers,
+        body: formData,
+      },
+    );
+
+    expect(response.status).toBe(201);
+    const body = (await response.json()) as {
+      conversation: { id: string };
+      files: Array<{ id: string; filename: string; sourceInteractionId: string }>;
+    };
+    expect(body.files).toHaveLength(1);
+    expect(body.files[0]).toMatchObject({
+      filename: "source.json",
+      sourceInteractionId: body.conversation.id,
+    });
+
+    const [message] = await db
+      .select()
+      .from(schema.interactionMessages)
+      .where(eq(schema.interactionMessages.interactionId, body.conversation.id))
+      .limit(1);
+
+    expect(message?.attachments).toEqual([
+      expect.objectContaining({
+        id: body.files[0]!.id,
+        filename: "source.json",
+        contentType: "application/json",
+      }),
+    ]);
+  });
+
+  it("rejects unsupported translation source files", async () => {
+    const identity = createWorkosIdentity();
+    const headers = await authHeadersFor(identity);
+    const formData = new FormData();
+    formData.set("text", "Translate this");
+    formData.append("files", new File(["hello"], "source.txt", { type: "text/plain" }));
+
+    const response = await app.request(
+      `/api/orgs/${identity.organization.slug}/chat-requests/upload`,
+      {
+        method: "POST",
+        headers,
+        body: formData,
+      },
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "unsupported_translation_source_file",
+      filename: "source.txt",
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/api/routes/chat-request/chat-request.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/chat-request/chat-request.route.ts
@@ -1,10 +1,14 @@
 import { Hono } from "hono";
+import { bodyLimit } from "hono/body-limit";
 import { validator } from "hono/validator";
 import { z } from "zod";
 
 import type { AuthVariables } from "@/api/auth/workos";
 import { workosAuthMiddleware } from "@/api/auth/workos";
+import type { FileStorageAdapter } from "@/lib/file-storage";
+import { createStoredFile } from "@/lib/file-storage/records";
 import { addInteractionMessage, createInteraction } from "@/lib/interactions";
+import { inferSupportedTranslationFileFormat } from "@/lib/translation/file-formats";
 
 const chatRequestBodySchema = z.object({
   text: z.string().trim().min(1).max(10000),
@@ -19,9 +23,134 @@ const validateChatRequestBody = validator("json", (value, c) => {
   return parsed.data;
 });
 
-export function createChatRequestRoutes() {
+const maxChatUploadBytes = 25 * 1024 * 1024;
+const maxChatUploadFiles = 5;
+
+const multipartChatRequestSchema = z.object({
+  text: z.string().trim().max(10000).default(""),
+  projectId: z.string().trim().min(1).optional(),
+});
+
+type CreateChatRequestRoutesOptions = {
+  fileStorageAdapter?: FileStorageAdapter;
+};
+
+function asString(value: unknown) {
+  return typeof value === "string" ? value : undefined;
+}
+
+function asFiles(value: unknown) {
+  const values = Array.isArray(value) ? value : value ? [value] : [];
+  return values.filter((item): item is File => item instanceof File && item.size > 0);
+}
+
+function invalidChatRequestResponse(c: { json(body: { error: string }, status: 400): Response }) {
+  return c.json({ error: "invalid_chat_request" }, 400);
+}
+
+function unsupportedTranslationSourceFileResponse(
+  c: {
+    json(body: { error: string; filename: string }, status: 400): Response;
+  },
+  filename: string,
+) {
+  return c.json({ error: "unsupported_translation_source_file", filename }, 400);
+}
+
+function tooManyTranslationSourceFilesResponse(c: {
+  json(body: { error: string; maxFiles: number }, status: 400): Response;
+}) {
+  return c.json({ error: "too_many_translation_source_files", maxFiles: maxChatUploadFiles }, 400);
+}
+
+export function createChatRequestRoutes(options: CreateChatRequestRoutesOptions = {}) {
   return new Hono<{ Variables: AuthVariables }>()
     .use("*", workosAuthMiddleware)
+    .post(
+      "/upload",
+      bodyLimit({
+        maxSize: maxChatUploadBytes,
+        onError: (c) => c.json({ error: "chat_upload_too_large" }, 413),
+      }),
+      async (c) => {
+        const body = await c.req.parseBody({ all: true });
+        const parsed = multipartChatRequestSchema.safeParse({
+          text: asString(body.text),
+          projectId: asString(body.projectId),
+        });
+
+        if (!parsed.success) {
+          return invalidChatRequestResponse(c);
+        }
+
+        const files = asFiles(body.files);
+        if (files.length === 0) {
+          return invalidChatRequestResponse(c);
+        }
+
+        if (files.length > maxChatUploadFiles) {
+          return tooManyTranslationSourceFilesResponse(c);
+        }
+
+        for (const file of files) {
+          if (!inferSupportedTranslationFileFormat(file.name)) {
+            return unsupportedTranslationSourceFileResponse(c, file.name);
+          }
+        }
+
+        const orgId = c.var.auth.activeOrganization.localOrganizationId;
+        const messageText = parsed.data.text || "Please translate the attached source file.";
+        const title = messageText.slice(0, 120);
+        const conversation = await createInteraction({
+          organizationId: orgId,
+          source: "chat_ui",
+          title,
+          projectId: parsed.data.projectId,
+        });
+
+        const storedFiles = await Promise.all(
+          files.map(async (file) =>
+            createStoredFile({
+              organizationId: orgId,
+              projectId: parsed.data.projectId,
+              createdByUserId: c.var.auth.user.localUserId,
+              role: "source",
+              sourceKind: "chat_upload",
+              sourceInteractionId: conversation.id,
+              filename: file.name,
+              contentType: file.type || "application/octet-stream",
+              content: await file.arrayBuffer(),
+              metadata: {
+                uploadSurface: "chat",
+                translationSource: true,
+              },
+              adapter: options.fileStorageAdapter,
+            }),
+          ),
+        );
+
+        const organizationSlug =
+          c.req.param("organizationSlug") ?? c.var.auth.activeOrganization.slug ?? "";
+
+        await addInteractionMessage({
+          interactionId: conversation.id,
+          senderType: "user",
+          text: messageText,
+          attachments: storedFiles.map((file) => ({
+            id: file.id,
+            filename: file.filename,
+            contentType: file.contentType,
+            url: organizationSlug
+              ? `/api/orgs/${organizationSlug}/files/${file.id}`
+              : (file.downloadUrl ?? file.storageUrl),
+          })),
+        });
+
+        // TODO: trigger agent processing here
+
+        return c.json({ conversation, files: storedFiles }, 201);
+      },
+    )
     .post("/", validateChatRequestBody, async (c) => {
       const body = c.req.valid("json");
       const orgId = c.var.auth.activeOrganization.localOrganizationId;

--- a/apps/hyperlocalise-web/src/api/routes/file/file.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/file/file.route.test.ts
@@ -1,0 +1,219 @@
+import "dotenv/config";
+
+import { testClient } from "hono/testing";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
+
+import { createApp } from "@/api/app";
+import { db } from "@/lib/database";
+import type { FileStorageAdapter, PutStoredObjectInput } from "@/lib/file-storage";
+import { createStoredFile } from "@/lib/file-storage/records";
+import { createProjectTestFixture } from "../project/project.fixture";
+
+const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
+  resolveApiAuthContextFromSessionMock: vi.fn(() => globalThis.__testApiAuthContext ?? null),
+}));
+
+vi.mock("@/api/auth/workos-session", () => ({
+  resolveApiAuthContextFromSession: resolveApiAuthContextFromSessionMock,
+}));
+
+function createMemoryFileStorageAdapter(): FileStorageAdapter {
+  const store = new Map<string, { buffer: Buffer; contentType: string }>();
+
+  return {
+    provider: "vercel_blob",
+    async put(input: PutStoredObjectInput) {
+      let buffer: Buffer;
+      if (input.body instanceof ReadableStream) {
+        const chunks: Uint8Array[] = [];
+        const reader = input.body.getReader();
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          if (value) chunks.push(value);
+        }
+        buffer = Buffer.concat(chunks.map((c) => Buffer.from(c)));
+      } else if (Buffer.isBuffer(input.body)) {
+        buffer = input.body;
+      } else if (input.body instanceof ArrayBuffer) {
+        buffer = Buffer.from(input.body);
+      } else if (input.body instanceof Uint8Array) {
+        buffer = Buffer.from(input.body.buffer, input.body.byteOffset, input.body.byteLength);
+      } else {
+        buffer = Buffer.from(await input.body.arrayBuffer());
+      }
+
+      store.set(input.key, { buffer, contentType: input.contentType });
+
+      return {
+        provider: "vercel_blob",
+        key: input.key,
+        url: `https://blob.example/${input.key}`,
+        downloadUrl: `https://blob.example/${input.key}?download=1`,
+        contentType: input.contentType,
+        etag: "test-etag",
+      };
+    },
+    async get(input) {
+      const entry = store.get(input.keyOrUrl);
+      if (!entry) return null;
+      return {
+        body: new ReadableStream({
+          start(controller) {
+            controller.enqueue(new Uint8Array(entry.buffer));
+            controller.close();
+          },
+        }),
+        contentType: entry.contentType,
+        etag: "test-etag",
+      };
+    },
+    async delete(input) {
+      store.delete(input.keyOrUrl);
+    },
+    async getSignedUrl(input) {
+      return `https://blob.example/${input.keyOrUrl}?signed=1`;
+    },
+  };
+}
+
+const fileStorageAdapter = createMemoryFileStorageAdapter();
+const app = createApp({ fileStorageAdapter });
+const client = testClient(app);
+const { authHeadersFor, cleanup, createWorkosIdentity } = createProjectTestFixture(client);
+
+async function ensureStoredFilesTestSchema() {
+  await db.$client.query(`
+    DO $$
+    BEGIN
+      CREATE TYPE stored_file_role AS ENUM ('source', 'output', 'reference', 'asset');
+    EXCEPTION
+      WHEN duplicate_object THEN null;
+    END $$;
+  `);
+  await db.$client.query(`
+    DO $$
+    BEGIN
+      CREATE TYPE stored_file_source_kind AS ENUM (
+        'chat_upload',
+        'email_attachment',
+        'job_output',
+        'repository_file',
+        'tms_file'
+      );
+    EXCEPTION
+      WHEN duplicate_object THEN null;
+    END $$;
+  `);
+  await db.$client.query(`
+    CREATE TABLE IF NOT EXISTS stored_files (
+      id text PRIMARY KEY NOT NULL,
+      organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE cascade,
+      project_id text REFERENCES projects(id) ON DELETE set null,
+      created_by_user_id uuid REFERENCES users(id) ON DELETE set null,
+      role stored_file_role NOT NULL,
+      source_kind stored_file_source_kind NOT NULL,
+      source_interaction_id uuid REFERENCES interactions(id) ON DELETE set null,
+      source_job_id text REFERENCES jobs(id) ON DELETE set null,
+      storage_provider text NOT NULL,
+      storage_key text NOT NULL,
+      storage_url text NOT NULL,
+      download_url text,
+      filename text NOT NULL,
+      content_type text NOT NULL,
+      byte_size integer NOT NULL,
+      sha256 text NOT NULL,
+      etag text,
+      metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
+      created_at timestamp with time zone DEFAULT now() NOT NULL,
+      updated_at timestamp with time zone DEFAULT now() NOT NULL
+    )
+  `);
+}
+
+beforeAll(async () => {
+  await db.$client.query("select 1");
+  await ensureStoredFilesTestSchema();
+});
+
+afterEach(async () => {
+  vi.clearAllMocks();
+  await cleanup();
+});
+
+describe("file download route", () => {
+  it("streams a stored file when the user belongs to the organization", async () => {
+    const identity = createWorkosIdentity();
+    const headers = await authHeadersFor(identity);
+    const orgId = globalThis.__testApiAuthContext!.activeOrganization.localOrganizationId;
+    const fileContent = Buffer.from(JSON.stringify({ hello: "world" }));
+
+    const file = await createStoredFile({
+      organizationId: orgId,
+      role: "source",
+      sourceKind: "chat_upload",
+      filename: "source.json",
+      contentType: "application/json",
+      content: fileContent,
+      adapter: fileStorageAdapter,
+    });
+
+    const response = await app.request(`/api/orgs/${identity.organization.slug}/files/${file.id}`, {
+      method: "GET",
+      headers,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("application/json");
+    expect(response.headers.get("content-disposition")).toContain("source.json");
+  });
+
+  it("returns 404 when the file does not exist", async () => {
+    const identity = createWorkosIdentity();
+    const headers = await authHeadersFor(identity);
+
+    const response = await app.request(
+      `/api/orgs/${identity.organization.slug}/files/file_missing`,
+      {
+        method: "GET",
+        headers,
+      },
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: "not_found" });
+  });
+
+  it("returns 404 when the file belongs to another organization", async () => {
+    const identityA = createWorkosIdentity();
+    const identityB = createWorkosIdentity();
+    const headersA = await authHeadersFor(identityA);
+    const authContextA = globalThis.__testApiAuthContext!;
+
+    // Switch to identityB and create a file in orgB
+    await authHeadersFor(identityB);
+    const orgIdB = globalThis.__testApiAuthContext!.activeOrganization.localOrganizationId;
+
+    const file = await createStoredFile({
+      organizationId: orgIdB,
+      role: "source",
+      sourceKind: "chat_upload",
+      filename: "source.json",
+      contentType: "application/json",
+      content: Buffer.from("secret"),
+      adapter: fileStorageAdapter,
+    });
+
+    // Restore identityA auth context and request
+    globalThis.__testApiAuthContext = authContextA;
+    const response = await app.request(
+      `/api/orgs/${identityA.organization.slug}/files/${file.id}`,
+      {
+        method: "GET",
+        headers: headersA,
+      },
+    );
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/apps/hyperlocalise-web/src/api/routes/file/file.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/file/file.route.ts
@@ -61,7 +61,10 @@ export function createFileRoutes(options: CreateFileRoutesOptions = {}) {
         "Content-Type",
         storedObject.contentType ?? file.contentType ?? "application/octet-stream",
       );
-      c.header("Content-Disposition", `inline; filename="${file.filename}"`);
+      c.header(
+        "Content-Disposition",
+        `inline; filename*=UTF-8''${encodeURIComponent(file.filename)}`,
+      );
 
       return c.body(storedObject.body);
     });

--- a/apps/hyperlocalise-web/src/api/routes/file/file.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/file/file.route.ts
@@ -1,0 +1,68 @@
+import { and, eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { z } from "zod";
+
+import type { AuthVariables } from "@/api/auth/workos";
+import { workosAuthMiddleware } from "@/api/auth/workos";
+import { db, schema } from "@/lib/database";
+import { getFileStorageAdapter, type FileStorageAdapter } from "@/lib/file-storage";
+
+const fileParamsSchema = z.object({
+  organizationSlug: z.string().trim().min(1),
+  fileId: z.string().trim().min(1),
+});
+
+function notFoundResponse(c: { json(body: { error: string }, status: 404): Response }) {
+  return c.json({ error: "not_found" }, 404);
+}
+
+type CreateFileRoutesOptions = {
+  fileStorageAdapter?: FileStorageAdapter;
+};
+
+export function createFileRoutes(options: CreateFileRoutesOptions = {}) {
+  return new Hono<{ Variables: AuthVariables }>()
+    .use("*", workosAuthMiddleware)
+    .get("/:fileId", async (c) => {
+      const parsed = fileParamsSchema.safeParse(c.req.param());
+      if (!parsed.success) {
+        return notFoundResponse(c);
+      }
+
+      const { fileId } = parsed.data;
+      const orgId = c.var.auth.activeOrganization.localOrganizationId;
+
+      const [file] = await db
+        .select({
+          id: schema.storedFiles.id,
+          organizationId: schema.storedFiles.organizationId,
+          storageProvider: schema.storedFiles.storageProvider,
+          storageKey: schema.storedFiles.storageKey,
+          storageUrl: schema.storedFiles.storageUrl,
+          filename: schema.storedFiles.filename,
+          contentType: schema.storedFiles.contentType,
+        })
+        .from(schema.storedFiles)
+        .where(and(eq(schema.storedFiles.id, fileId), eq(schema.storedFiles.organizationId, orgId)))
+        .limit(1);
+
+      if (!file) {
+        return notFoundResponse(c);
+      }
+
+      const adapter = options.fileStorageAdapter ?? getFileStorageAdapter();
+      const storedObject = await adapter.get({ keyOrUrl: file.storageKey });
+
+      if (!storedObject) {
+        return notFoundResponse(c);
+      }
+
+      c.header(
+        "Content-Type",
+        storedObject.contentType ?? file.contentType ?? "application/octet-stream",
+      );
+      c.header("Content-Disposition", `inline; filename="${file.filename}"`);
+
+      return c.body(storedObject.body);
+    });
+}

--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
@@ -6,6 +6,8 @@ import { validator } from "hono/validator";
 
 import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
 import { db, schema } from "@/lib/database";
+import { getStoredFileForJobScope } from "@/lib/file-storage/records";
+import { inferSupportedTranslationFileFormat } from "@/lib/translation/file-formats";
 import type { TranslationJobQueue } from "@/lib/workflow/types";
 
 import {
@@ -64,8 +66,21 @@ function jobQueueUnavailableResponse(c: { json(body: { error: string }, status: 
   return c.json({ error: "job_queue_unavailable" }, 503);
 }
 
-function fileJobsNotSupportedResponse(c: { json(body: { error: string }, status: 501): Response }) {
-  return c.json({ error: "file_jobs_not_supported" }, 501);
+function sourceFileNotFoundResponse(c: { json(body: { error: string }, status: 404): Response }) {
+  return c.json({ error: "source_file_not_found" }, 404);
+}
+
+function unsupportedSourceFileFormatResponse(c: {
+  json(body: { error: string }, status: 400): Response;
+}) {
+  return c.json({ error: "unsupported_source_file_format" }, 400);
+}
+
+function sourceFileFormatMismatchResponse(
+  c: { json(body: { error: string; expectedFileFormat: string }, status: 400): Response },
+  expectedFileFormat: string,
+) {
+  return c.json({ error: "source_file_format_mismatch", expectedFileFormat }, 400);
 }
 
 async function getOwnedJob(projectId: string, jobId: string) {
@@ -203,11 +218,28 @@ export function createJobRoutes(options: CreateJobRoutesOptions) {
         return projectNotFoundResponse(c);
       }
 
-      if (payload.type === "file") {
-        return fileJobsNotSupportedResponse(c);
-      }
+      const inputPayload = payload.type === "string" ? payload.stringInput : payload.fileInput;
 
-      const inputPayload = payload.stringInput;
+      if (payload.type === "file") {
+        const sourceFile = await getStoredFileForJobScope({
+          organizationId: c.var.auth.organization.localOrganizationId,
+          projectId: params.projectId,
+          fileId: payload.fileInput.sourceFileId,
+        });
+
+        if (!sourceFile) {
+          return sourceFileNotFoundResponse(c);
+        }
+
+        const inferredFileFormat = inferSupportedTranslationFileFormat(sourceFile.filename);
+        if (!inferredFileFormat) {
+          return unsupportedSourceFileFormatResponse(c);
+        }
+
+        if (inferredFileFormat !== payload.fileInput.fileFormat) {
+          return sourceFileFormatMismatchResponse(c, inferredFileFormat);
+        }
+      }
 
       const jobId = `job_${randomUUID()}`;
       const [job] = await db.transaction(async (tx) => {

--- a/apps/hyperlocalise-web/src/api/routes/project/job.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.schema.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import * as schema from "@/lib/database/schema";
+import { supportedTranslationFileFormats } from "@/lib/translation/file-formats";
 
 export const jobProjectParamsSchema = z.object({
   projectId: z.string().trim().min(1),
@@ -24,7 +25,7 @@ export const stringTranslationJobInputSchema = z.object({
 
 export const fileTranslationJobInputSchema = z.object({
   sourceFileId: z.string().trim().min(1),
-  fileFormat: z.enum(["xliff", "json", "po", "csv"]),
+  fileFormat: z.enum(supportedTranslationFileFormats),
   sourceLocale: z.string().trim().min(1).max(32),
   targetLocales: z.array(z.string().trim().min(1).max(32)).min(1),
   metadata: metadataSchema,

--- a/apps/hyperlocalise-web/src/api/routes/project/job.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.test.ts
@@ -119,8 +119,103 @@ async function insertJob(params: {
   return job;
 }
 
+async function insertStoredSourceFile(params: {
+  projectId: string;
+  filename?: string;
+  contentType?: string;
+  organizationId?: string;
+}) {
+  const [project] = await db
+    .select({ organizationId: schema.projects.organizationId })
+    .from(schema.projects)
+    .where(eq(schema.projects.id, params.projectId))
+    .limit(1);
+
+  if (!project && !params.organizationId) {
+    throw new Error(`project ${params.projectId} not found`);
+  }
+
+  const id = `file_${randomUUID()}`;
+  const filename = params.filename ?? "source.json";
+  const [file] = await db
+    .insert(schema.storedFiles)
+    .values({
+      id,
+      organizationId: params.organizationId ?? project!.organizationId,
+      projectId: params.projectId,
+      role: "source",
+      sourceKind: "chat_upload",
+      storageProvider: "vercel_blob",
+      storageKey: `test/${id}/${filename}`,
+      storageUrl: `https://example.com/${id}/${filename}`,
+      downloadUrl: `https://example.com/${id}/${filename}?download=1`,
+      filename,
+      contentType: params.contentType ?? "application/json",
+      byteSize: 2,
+      sha256: "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+      metadata: {},
+    })
+    .returning();
+
+  if (!file) {
+    throw new Error("stored file insert failed");
+  }
+
+  return file;
+}
+
+async function ensureStoredFilesTestSchema() {
+  await db.$client.query(`
+    DO $$
+    BEGIN
+      CREATE TYPE stored_file_role AS ENUM ('source', 'output', 'reference', 'asset');
+    EXCEPTION
+      WHEN duplicate_object THEN null;
+    END $$;
+  `);
+  await db.$client.query(`
+    DO $$
+    BEGIN
+      CREATE TYPE stored_file_source_kind AS ENUM (
+        'chat_upload',
+        'email_attachment',
+        'job_output',
+        'repository_file',
+        'tms_file'
+      );
+    EXCEPTION
+      WHEN duplicate_object THEN null;
+    END $$;
+  `);
+  await db.$client.query(`
+    CREATE TABLE IF NOT EXISTS stored_files (
+      id text PRIMARY KEY NOT NULL,
+      organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE cascade,
+      project_id text REFERENCES projects(id) ON DELETE set null,
+      created_by_user_id uuid REFERENCES users(id) ON DELETE set null,
+      role stored_file_role NOT NULL,
+      source_kind stored_file_source_kind NOT NULL,
+      source_interaction_id uuid REFERENCES interactions(id) ON DELETE set null,
+      source_job_id text REFERENCES jobs(id) ON DELETE set null,
+      storage_provider text NOT NULL,
+      storage_key text NOT NULL,
+      storage_url text NOT NULL,
+      download_url text,
+      filename text NOT NULL,
+      content_type text NOT NULL,
+      byte_size integer NOT NULL,
+      sha256 text NOT NULL,
+      etag text,
+      metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
+      created_at timestamp with time zone DEFAULT now() NOT NULL,
+      updated_at timestamp with time zone DEFAULT now() NOT NULL
+    )
+  `);
+}
+
 beforeAll(async () => {
   await db.$client.query("select 1");
+  await ensureStoredFilesTestSchema();
 });
 
 afterEach(async () => {
@@ -493,10 +588,15 @@ describe("jobRoutes", () => {
     });
   });
 
-  it("rejects file jobs until file execution is implemented", async () => {
+  it("creates file jobs when the source file belongs to the project", async () => {
     const identity = createWorkosIdentity();
     const projectResponse = await createProjectViaApi(identity);
     const project = ((await projectResponse.json()) as ProjectResponse).project;
+    const sourceFile = await insertStoredSourceFile({
+      projectId: project.id,
+      filename: "source.xliff",
+      contentType: "application/xliff+xml",
+    });
 
     const response = await client.api.project[":projectId"].jobs.$post(
       {
@@ -504,7 +604,7 @@ describe("jobRoutes", () => {
         json: {
           type: "file",
           fileInput: {
-            sourceFileId: "file_123",
+            sourceFileId: sourceFile.id,
             fileFormat: "xliff",
             sourceLocale: "en-US",
             targetLocales: ["fr-FR"],
@@ -516,9 +616,47 @@ describe("jobRoutes", () => {
       },
     );
 
-    expect(response.status).toBe(501);
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toMatchObject({
+      job: {
+        type: "file",
+        status: "queued",
+        inputPayload: {
+          sourceFileId: sourceFile.id,
+          fileFormat: "xliff",
+          sourceLocale: "en-US",
+          targetLocales: ["fr-FR"],
+        },
+      },
+    });
+  });
+
+  it("rejects file jobs when the source file is not in scope", async () => {
+    const identity = createWorkosIdentity();
+    const projectResponse = await createProjectViaApi(identity);
+    const project = ((await projectResponse.json()) as ProjectResponse).project;
+
+    const response = await client.api.project[":projectId"].jobs.$post(
+      {
+        param: { projectId: project.id },
+        json: {
+          type: "file",
+          fileInput: {
+            sourceFileId: "file_missing",
+            fileFormat: "xliff",
+            sourceLocale: "en-US",
+            targetLocales: ["fr-FR"],
+          },
+        },
+      },
+      {
+        headers: await authHeadersFor(identity),
+      },
+    );
+
+    expect(response.status).toBe(404);
     await expect(response.json()).resolves.toEqual({
-      error: "file_jobs_not_supported",
+      error: "source_file_not_found",
     });
   });
 

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/chat/_components/chat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/chat/_components/chat-page-content.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import {
   Add01Icon,
   AiImageIcon,
   AiWebBrowsingIcon,
   ArrowDown01Icon,
   BubbleChatTranslateIcon,
+  Cancel01Icon,
   SentIcon,
   CheckmarkCircle02Icon,
   Clock01Icon,
@@ -65,7 +66,7 @@ const suggestedRequests = [
 const attachOptions = [
   {
     icon: FileAttachmentIcon,
-    label: "Add photos & files",
+    label: "Add source files",
   },
   {
     icon: AiImageIcon,
@@ -77,6 +78,27 @@ const attachOptions = [
   },
 ] as const;
 
+const translationSourceFileAccept = [
+  ".json",
+  ".jsonc",
+  ".arb",
+  ".xlf",
+  ".xlif",
+  ".xliff",
+  ".po",
+  ".html",
+  ".md",
+  ".mdx",
+  ".strings",
+  ".stringsdict",
+  ".csv",
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".webp",
+].join(",");
+const maxTranslationSourceFiles = 5;
+
 type ApiProject = {
   id: string;
   name: string;
@@ -84,8 +106,10 @@ type ApiProject = {
 
 export function ChatPageContent({ organizationSlug }: { organizationSlug: string }) {
   const router = useRouter();
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const [selectedProjectId, setSelectedProjectId] = useState<string>("");
   const [text, setText] = useState("");
+  const [files, setFiles] = useState<File[]>([]);
   const projectsQuery = useQuery({
     queryKey: ["translation-projects", organizationSlug],
     queryFn: async () => {
@@ -108,6 +132,26 @@ export function ChatPageContent({ organizationSlug }: { organizationSlug: string
 
   const chatRequestMutation = useMutation({
     mutationFn: async () => {
+      if (files.length > 0) {
+        const formData = new FormData();
+        formData.set("text", text.trim() || "Please translate the attached source file.");
+        if (selectedProject?.id) {
+          formData.set("projectId", selectedProject.id);
+        }
+        for (const file of files) {
+          formData.append("files", file);
+        }
+
+        const response = await fetch(`/api/orgs/${organizationSlug}/chat-requests/upload`, {
+          method: "POST",
+          body: formData,
+        });
+        if (!response.ok) {
+          throw new Error(`Failed to send request (${response.status})`);
+        }
+        return response.json() as Promise<{ conversation: { id: string } }>;
+      }
+
       const response = await apiClient.api.orgs[":organizationSlug"]["chat-requests"].$post({
         param: { organizationSlug },
         json: {
@@ -124,6 +168,7 @@ export function ChatPageContent({ organizationSlug }: { organizationSlug: string
       router.push(`/org/${organizationSlug}/inbox/${data.conversation.id}`);
     },
   });
+  const canSubmit = Boolean(text.trim() || files.length > 0) && !chatRequestMutation.isPending;
 
   return (
     <main className="mx-auto flex min-h-[calc(100svh-7rem)] w-full max-w-6xl flex-col items-center justify-center px-4 py-8 sm:px-6">
@@ -137,7 +182,7 @@ export function ChatPageContent({ organizationSlug }: { organizationSlug: string
         <form
           onSubmit={(e) => {
             e.preventDefault();
-            if (text.trim() && !chatRequestMutation.isPending) {
+            if (canSubmit) {
               chatRequestMutation.mutate();
             }
           }}
@@ -153,7 +198,7 @@ export function ChatPageContent({ organizationSlug }: { organizationSlug: string
             onKeyDown={(e) => {
               if (e.key === "Enter" && !e.shiftKey) {
                 e.preventDefault();
-                if (text.trim() && !chatRequestMutation.isPending) {
+                if (canSubmit) {
                   chatRequestMutation.mutate();
                 }
               }
@@ -161,6 +206,55 @@ export function ChatPageContent({ organizationSlug }: { organizationSlug: string
             className="min-h-36 w-full resize-none bg-transparent px-4 py-4 text-base leading-6 text-foreground outline-none placeholder:text-muted-foreground sm:px-6 sm:py-5"
             placeholder="Paste source text or ask Hyperlocalise to translate a file, string, or inbox request..."
           />
+          <input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            accept={translationSourceFileAccept}
+            className="sr-only"
+            onChange={(e) => {
+              const nextFiles = Array.from(e.target.files ?? []);
+              setFiles((currentFiles) => {
+                const existing = new Set(
+                  currentFiles.map((file) => `${file.name}:${file.size}:${file.lastModified}`),
+                );
+                return [
+                  ...currentFiles,
+                  ...nextFiles.filter(
+                    (file) => !existing.has(`${file.name}:${file.size}:${file.lastModified}`),
+                  ),
+                ].slice(0, maxTranslationSourceFiles);
+              });
+              e.target.value = "";
+            }}
+          />
+          {files.length > 0 ? (
+            <div className="flex flex-wrap gap-2 border-t border-border px-4 pb-4 sm:px-6">
+              {files.map((file) => (
+                <span
+                  key={`${file.name}:${file.size}:${file.lastModified}`}
+                  className="inline-flex max-w-full items-center gap-2 rounded-full border border-border bg-muted px-3 py-1.5 text-sm text-foreground"
+                >
+                  <HugeiconsIcon
+                    icon={FileAttachmentIcon}
+                    strokeWidth={1.8}
+                    className="size-4 shrink-0 text-muted-foreground"
+                  />
+                  <span className="truncate">{file.name}</span>
+                  <button
+                    type="button"
+                    className="rounded-full text-muted-foreground transition-colors hover:text-foreground"
+                    aria-label={`Remove ${file.name}`}
+                    onClick={() =>
+                      setFiles((currentFiles) => currentFiles.filter((item) => item !== file))
+                    }
+                  >
+                    <HugeiconsIcon icon={Cancel01Icon} strokeWidth={1.8} className="size-3.5" />
+                  </button>
+                </span>
+              ))}
+            </div>
+          ) : null}
           <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border bg-muted px-4 py-3 sm:px-5">
             <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
               <DropdownMenu>
@@ -179,7 +273,12 @@ export function ChatPageContent({ organizationSlug }: { organizationSlug: string
                 </DropdownMenuTrigger>
                 <DropdownMenuContent className="min-w-52" align="start">
                   <DropdownMenuGroup>
-                    <DropdownMenuItem>
+                    <DropdownMenuItem
+                      onSelect={(event) => {
+                        event.preventDefault();
+                        fileInputRef.current?.click();
+                      }}
+                    >
                       <HugeiconsIcon
                         icon={attachOptions[0].icon}
                         strokeWidth={1.8}
@@ -264,7 +363,7 @@ export function ChatPageContent({ organizationSlug }: { organizationSlug: string
               </DropdownMenu>
               <Button
                 type="submit"
-                disabled={!text.trim() || chatRequestMutation.isPending}
+                disabled={!canSubmit}
                 className="rounded-full bg-primary text-primary-foreground hover:bg-primary/90"
                 aria-label="Send translation request"
               >

--- a/apps/hyperlocalise-web/src/lib/database/schema.ts
+++ b/apps/hyperlocalise-web/src/lib/database/schema.ts
@@ -87,6 +87,19 @@ export const interactionSourceEnum = pgEnum("interaction_source", [
 ]);
 export const inboxStatusEnum = pgEnum("inbox_status", ["active", "archived"]);
 export const messageSenderTypeEnum = pgEnum("message_sender_type", ["user", "agent"]);
+export const storedFileRoleEnum = pgEnum("stored_file_role", [
+  "source",
+  "output",
+  "reference",
+  "asset",
+]);
+export const storedFileSourceKindEnum = pgEnum("stored_file_source_kind", [
+  "chat_upload",
+  "email_attachment",
+  "job_output",
+  "repository_file",
+  "tms_file",
+]);
 
 export const organizations = pgTable(
   "organizations",
@@ -842,5 +855,72 @@ export const interactionMessages = pgTable(
   },
   (table) => [
     index("idx_interaction_messages_interaction_created").on(table.interactionId, table.createdAt),
+  ],
+);
+
+export const storedFiles = pgTable(
+  "stored_files",
+  {
+    // Stable file identifier used by jobs and interaction attachments.
+    id: text("id").primaryKey(),
+    // Tenant that owns this file.
+    organizationId: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    // Optional project scope. Null means the file is workspace-level.
+    projectId: text("project_id").references(() => projects.id, { onDelete: "set null" }),
+    // User who uploaded or generated the file, if known.
+    createdByUserId: uuid("created_by_user_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    // How this file is used in the product.
+    role: storedFileRoleEnum("role").notNull(),
+    // Where the file came from.
+    sourceKind: storedFileSourceKindEnum("source_kind").notNull(),
+    // Interaction that introduced the file, if any.
+    sourceInteractionId: uuid("source_interaction_id").references(() => interactions.id, {
+      onDelete: "set null",
+    }),
+    // Job that produced the file, if any.
+    sourceJobId: text("source_job_id").references(() => jobs.id, { onDelete: "set null" }),
+    // Object storage implementation that owns the bytes.
+    storageProvider: text("storage_provider").notNull(),
+    // Provider-specific object key or pathname.
+    storageKey: text("storage_key").notNull(),
+    // Provider URL retained for server-side retrieval and diagnostics.
+    storageUrl: text("storage_url").notNull(),
+    // Download URL when the provider returns one.
+    downloadUrl: text("download_url"),
+    // Original or generated filename shown to users.
+    filename: text("filename").notNull(),
+    // MIME type captured at storage time.
+    contentType: text("content_type").notNull(),
+    // File size in bytes.
+    byteSize: integer("byte_size").notNull(),
+    // SHA-256 of the stored bytes for dedupe and audit checks.
+    sha256: text("sha256").notNull(),
+    // Provider entity tag, when available.
+    etag: text("etag"),
+    // Extensible provenance or adapter metadata.
+    metadata: jsonb("metadata")
+      .$type<Record<string, unknown>>()
+      .notNull()
+      .default(sql`'{}'::jsonb`),
+    // When the file metadata record was first created.
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    // When the file metadata last changed.
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow()
+      .$onUpdateFn(() => new Date()),
+  },
+  (table) => [
+    uniqueIndex("stored_files_storage_provider_key").on(table.storageProvider, table.storageKey),
+    index("idx_stored_files_org_created_at").on(table.organizationId, table.createdAt),
+    index("idx_stored_files_project_created_at").on(table.projectId, table.createdAt),
+    index("idx_stored_files_created_by_user_id").on(table.createdByUserId),
+    index("idx_stored_files_source_interaction").on(table.sourceInteractionId),
+    index("idx_stored_files_source_job").on(table.sourceJobId),
+    index("idx_stored_files_org_role").on(table.organizationId, table.role),
   ],
 );

--- a/apps/hyperlocalise-web/src/lib/env.ts
+++ b/apps/hyperlocalise-web/src/lib/env.ts
@@ -63,6 +63,15 @@ export const env = createEnv({
 
     /** Display name for outbound emails sent by the email bot. */
     RESEND_FROM_NAME: z.string().min(1).optional(),
+
+    /** Object storage adapter for durable uploaded and generated files. */
+    FILE_STORAGE_PROVIDER: z.enum(["vercel_blob"]).default("vercel_blob"),
+
+    /** Default access level used for new stored files. */
+    FILE_STORAGE_ACCESS: z.enum(["private", "public"]).default("private"),
+
+    /** Vercel Blob read/write token used by the Vercel Blob storage adapter. */
+    BLOB_READ_WRITE_TOKEN: z.string().min(1).optional(),
   },
   client: {
     /** Public URL for the waitlist/sign-up page. Required for client-side redirects. */
@@ -108,6 +117,10 @@ export const env = createEnv({
     RESEND_FROM_ADDRESS:
       process.env.RESEND_FROM_ADDRESS ?? (isTestEnv ? "bot@example.com" : undefined),
     RESEND_FROM_NAME: process.env.RESEND_FROM_NAME ?? (isTestEnv ? "Hyperlocalise Bot" : undefined),
+    FILE_STORAGE_PROVIDER: process.env.FILE_STORAGE_PROVIDER,
+    FILE_STORAGE_ACCESS: process.env.FILE_STORAGE_ACCESS,
+    BLOB_READ_WRITE_TOKEN:
+      process.env.BLOB_READ_WRITE_TOKEN ?? (isTestEnv ? "test-blob-read-write-token" : undefined),
     NEXT_PUBLIC_WAITLIST_URL:
       process.env.NEXT_PUBLIC_WAITLIST_URL ??
       (isTestEnv ? "https://example.com/waitlist" : undefined),

--- a/apps/hyperlocalise-web/src/lib/file-storage/index.ts
+++ b/apps/hyperlocalise-web/src/lib/file-storage/index.ts
@@ -1,0 +1,34 @@
+import { env } from "@/lib/env";
+
+import { createVercelBlobFileStorage } from "./vercel-blob";
+
+import type { FileStorageAdapter } from "./types";
+
+let adapter: FileStorageAdapter | null = null;
+
+export function getFileStorageAdapter(): FileStorageAdapter {
+  if (adapter) {
+    return adapter;
+  }
+
+  switch (env.FILE_STORAGE_PROVIDER) {
+    case "vercel_blob":
+      adapter = createVercelBlobFileStorage({
+        token: env.BLOB_READ_WRITE_TOKEN,
+        defaultAccess: env.FILE_STORAGE_ACCESS,
+      });
+      return adapter;
+  }
+}
+
+export type {
+  DeleteStoredObjectInput,
+  FileStorageAccess,
+  FileStorageAdapter,
+  FileStorageProvider,
+  GetSignedUrlInput,
+  GetStoredObjectInput,
+  GetStoredObjectResult,
+  PutStoredObjectInput,
+  PutStoredObjectResult,
+} from "./types";

--- a/apps/hyperlocalise-web/src/lib/file-storage/records.ts
+++ b/apps/hyperlocalise-web/src/lib/file-storage/records.ts
@@ -93,35 +93,40 @@ export async function createStoredFile(input: CreateStoredFileInput) {
     contentType: input.contentType,
   });
 
-  const [file] = await db
-    .insert(schema.storedFiles)
-    .values({
-      id,
-      organizationId: input.organizationId,
-      projectId: input.projectId ?? null,
-      createdByUserId: input.createdByUserId ?? null,
-      role: input.role,
-      sourceKind: input.sourceKind,
-      sourceInteractionId: input.sourceInteractionId ?? null,
-      sourceJobId: input.sourceJobId ?? null,
-      storageProvider: uploaded.provider,
-      storageKey: uploaded.key,
-      storageUrl: uploaded.url,
-      downloadUrl: uploaded.downloadUrl,
-      filename: input.filename,
-      contentType: uploaded.contentType,
-      byteSize: content.byteLength,
-      sha256: await sha256Hex(content),
-      etag: uploaded.etag,
-      metadata: input.metadata ?? {},
-    })
-    .returning();
+  try {
+    const [file] = await db
+      .insert(schema.storedFiles)
+      .values({
+        id,
+        organizationId: input.organizationId,
+        projectId: input.projectId ?? null,
+        createdByUserId: input.createdByUserId ?? null,
+        role: input.role,
+        sourceKind: input.sourceKind,
+        sourceInteractionId: input.sourceInteractionId ?? null,
+        sourceJobId: input.sourceJobId ?? null,
+        storageProvider: uploaded.provider,
+        storageKey: uploaded.key,
+        storageUrl: uploaded.url,
+        downloadUrl: uploaded.downloadUrl,
+        filename: input.filename,
+        contentType: uploaded.contentType,
+        byteSize: content.byteLength,
+        sha256: await sha256Hex(content),
+        etag: uploaded.etag,
+        metadata: input.metadata ?? {},
+      })
+      .returning();
 
-  if (!file) {
-    throw new Error("Failed to create stored file: no row returned.");
+    if (!file) {
+      throw new Error("Failed to create stored file: no row returned.");
+    }
+
+    return file;
+  } catch (error) {
+    await adapter.delete({ keyOrUrl: uploaded.key });
+    throw error;
   }
-
-  return file;
 }
 
 export async function getStoredFileForJobScope(input: StoredFileScopeInput) {

--- a/apps/hyperlocalise-web/src/lib/file-storage/records.ts
+++ b/apps/hyperlocalise-web/src/lib/file-storage/records.ts
@@ -1,5 +1,3 @@
-import { createHash, randomUUID } from "node:crypto";
-
 import { and, eq, isNull, or, type SQL } from "drizzle-orm";
 
 import { db, schema } from "@/lib/database";
@@ -31,7 +29,19 @@ type StoredFileScopeInput = {
 };
 
 function createStoredFileId() {
-  return `file_${randomUUID()}`;
+  return `file_${crypto.randomUUID()}`;
+}
+
+async function sha256Hex(content: Buffer): Promise<string> {
+  const hashBuffer = await crypto.subtle.digest(
+    "SHA-256",
+    content.buffer.slice(
+      content.byteOffset,
+      content.byteOffset + content.byteLength,
+    ) as ArrayBuffer,
+  );
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
 }
 
 function safePathPart(value: string) {
@@ -101,7 +111,7 @@ export async function createStoredFile(input: CreateStoredFileInput) {
       filename: input.filename,
       contentType: uploaded.contentType,
       byteSize: content.byteLength,
-      sha256: createHash("sha256").update(content).digest("hex"),
+      sha256: await sha256Hex(content),
       etag: uploaded.etag,
       metadata: input.metadata ?? {},
     })

--- a/apps/hyperlocalise-web/src/lib/file-storage/records.ts
+++ b/apps/hyperlocalise-web/src/lib/file-storage/records.ts
@@ -130,6 +130,7 @@ export async function getStoredFileForJobScope(input: StoredFileScopeInput) {
     }
   }
 
+  const [file] = await db
     .select()
     .from(schema.storedFiles)
     .where(and(...filters))

--- a/apps/hyperlocalise-web/src/lib/file-storage/records.ts
+++ b/apps/hyperlocalise-web/src/lib/file-storage/records.ts
@@ -1,0 +1,139 @@
+import { createHash, randomUUID } from "node:crypto";
+
+import { and, eq, isNull, or, type SQL } from "drizzle-orm";
+
+import { db, schema } from "@/lib/database";
+
+import { getFileStorageAdapter, type FileStorageAdapter } from ".";
+
+type StoredFileRole = (typeof schema.storedFileRoleEnum.enumValues)[number];
+type StoredFileSourceKind = (typeof schema.storedFileSourceKindEnum.enumValues)[number];
+
+type CreateStoredFileInput = {
+  organizationId: string;
+  projectId?: string | null;
+  createdByUserId?: string | null;
+  role: StoredFileRole;
+  sourceKind: StoredFileSourceKind;
+  sourceInteractionId?: string | null;
+  sourceJobId?: string | null;
+  filename: string;
+  contentType: string;
+  content: Buffer | Uint8Array | ArrayBuffer;
+  metadata?: Record<string, unknown>;
+  adapter?: FileStorageAdapter;
+};
+
+type StoredFileScopeInput = {
+  organizationId: string;
+  projectId?: string | null;
+  fileId: string;
+};
+
+function createStoredFileId() {
+  return `file_${randomUUID()}`;
+}
+
+function safePathPart(value: string) {
+  return value.replace(/[^a-zA-Z0-9._-]/g, "_");
+}
+
+function bytesFromContent(content: Buffer | Uint8Array | ArrayBuffer) {
+  if (Buffer.isBuffer(content)) {
+    return content;
+  }
+
+  if (content instanceof ArrayBuffer) {
+    return Buffer.from(content);
+  }
+
+  return Buffer.from(content.buffer, content.byteOffset, content.byteLength);
+}
+
+function storageKey(input: {
+  organizationId: string;
+  projectId?: string | null;
+  id: string;
+  filename: string;
+}) {
+  const scope = input.projectId ? `projects/${safePathPart(input.projectId)}` : "workspace";
+  return [
+    "organizations",
+    safePathPart(input.organizationId),
+    scope,
+    "files",
+    input.id,
+    safePathPart(input.filename),
+  ].join("/");
+}
+
+export async function createStoredFile(input: CreateStoredFileInput) {
+  const adapter = input.adapter ?? getFileStorageAdapter();
+  const id = createStoredFileId();
+  const content = bytesFromContent(input.content);
+  const key = storageKey({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    id,
+    filename: input.filename,
+  });
+  const uploaded = await adapter.put({
+    key,
+    body: content,
+    contentType: input.contentType,
+  });
+
+  const [file] = await db
+    .insert(schema.storedFiles)
+    .values({
+      id,
+      organizationId: input.organizationId,
+      projectId: input.projectId ?? null,
+      createdByUserId: input.createdByUserId ?? null,
+      role: input.role,
+      sourceKind: input.sourceKind,
+      sourceInteractionId: input.sourceInteractionId ?? null,
+      sourceJobId: input.sourceJobId ?? null,
+      storageProvider: uploaded.provider,
+      storageKey: uploaded.key,
+      storageUrl: uploaded.url,
+      downloadUrl: uploaded.downloadUrl,
+      filename: input.filename,
+      contentType: uploaded.contentType,
+      byteSize: content.byteLength,
+      sha256: createHash("sha256").update(content).digest("hex"),
+      etag: uploaded.etag,
+      metadata: input.metadata ?? {},
+    })
+    .returning();
+
+  if (!file) {
+    throw new Error("Failed to create stored file: no row returned.");
+  }
+
+  return file;
+}
+
+export async function getStoredFileForJobScope(input: StoredFileScopeInput) {
+  const filters: SQL[] = [
+    eq(schema.storedFiles.id, input.fileId),
+    eq(schema.storedFiles.organizationId, input.organizationId),
+  ];
+
+  if (input.projectId) {
+    const projectScope = or(
+      eq(schema.storedFiles.projectId, input.projectId),
+      isNull(schema.storedFiles.projectId),
+    );
+    if (projectScope) {
+      filters.push(projectScope);
+    }
+  }
+
+    .select()
+    .from(schema.storedFiles)
+    .where(and(...filters))
+    .limit(1);
+
+  return file ?? null;
+}

--- a/apps/hyperlocalise-web/src/lib/file-storage/types.ts
+++ b/apps/hyperlocalise-web/src/lib/file-storage/types.ts
@@ -1,0 +1,46 @@
+export type FileStorageProvider = "vercel_blob";
+export type FileStorageAccess = "private" | "public";
+
+export type PutStoredObjectInput = {
+  key: string;
+  body: Blob | Buffer | ArrayBuffer | Uint8Array | ReadableStream;
+  contentType: string;
+  access?: FileStorageAccess;
+};
+
+export type PutStoredObjectResult = {
+  provider: FileStorageProvider;
+  key: string;
+  url: string;
+  downloadUrl: string | null;
+  contentType: string;
+  etag: string | null;
+};
+
+export type GetStoredObjectInput = {
+  keyOrUrl: string;
+  access?: FileStorageAccess;
+};
+
+export type GetStoredObjectResult = {
+  body: ReadableStream;
+  contentType: string | null;
+  etag: string | null;
+};
+
+export type DeleteStoredObjectInput = {
+  keyOrUrl: string;
+};
+
+export type GetSignedUrlInput = {
+  keyOrUrl: string;
+  expiresInSeconds?: number;
+};
+
+export type FileStorageAdapter = {
+  provider: FileStorageProvider;
+  put(input: PutStoredObjectInput): Promise<PutStoredObjectResult>;
+  get(input: GetStoredObjectInput): Promise<GetStoredObjectResult | null>;
+  delete(input: DeleteStoredObjectInput): Promise<void>;
+  getSignedUrl(input: GetSignedUrlInput): Promise<string | null>;
+};

--- a/apps/hyperlocalise-web/src/lib/file-storage/vercel-blob.ts
+++ b/apps/hyperlocalise-web/src/lib/file-storage/vercel-blob.ts
@@ -1,0 +1,65 @@
+import { del, get, head, put } from "@vercel/blob";
+
+import type { PutCommandOptions } from "@vercel/blob";
+import type {
+  FileStorageAccess,
+  FileStorageAdapter,
+  GetStoredObjectInput,
+  PutStoredObjectInput,
+} from "./types";
+
+type VercelBlobFileStorageOptions = {
+  token?: string;
+  defaultAccess: FileStorageAccess;
+};
+
+export function createVercelBlobFileStorage(
+  options: VercelBlobFileStorageOptions,
+): FileStorageAdapter {
+  return {
+    provider: "vercel_blob",
+    async put(input: PutStoredObjectInput) {
+      const blob = await put(input.key, input.body as Parameters<typeof put>[1], {
+        access: input.access ?? options.defaultAccess,
+        addRandomSuffix: false,
+        contentType: input.contentType,
+        token: options.token,
+      } satisfies PutCommandOptions);
+
+      return {
+        provider: "vercel_blob",
+        key: blob.pathname,
+        url: blob.url,
+        downloadUrl: blob.downloadUrl ?? null,
+        contentType: blob.contentType,
+        etag: blob.etag ?? null,
+      };
+    },
+    async get(input: GetStoredObjectInput) {
+      const blob = await get(input.keyOrUrl, {
+        access: input.access ?? options.defaultAccess,
+        token: options.token,
+      });
+
+      if (!blob?.stream) {
+        return null;
+      }
+
+      return {
+        body: blob.stream,
+        contentType: blob.blob.contentType ?? null,
+        etag: blob.blob.etag ?? null,
+      };
+    },
+    async delete(input) {
+      await del(input.keyOrUrl, { token: options.token });
+    },
+    async getSignedUrl(input) {
+      const blob = await head(input.keyOrUrl, {
+        token: options.token,
+      });
+
+      return blob?.url ?? null;
+    },
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/file-storage/vercel-blob.ts
+++ b/apps/hyperlocalise-web/src/lib/file-storage/vercel-blob.ts
@@ -55,6 +55,13 @@ export function createVercelBlobFileStorage(
       await del(input.keyOrUrl, { token: options.token });
     },
     async getSignedUrl(input) {
+      if (input.expiresInSeconds !== undefined) {
+        throw new Error(
+          "Vercel Blob SDK v2.3.3 does not support time-limited signed URLs. " +
+            "The URL returned by head() is already signed for private blobs but does not expire.",
+        );
+      }
+
       const blob = await head(input.keyOrUrl, {
         token: options.token,
       });

--- a/apps/hyperlocalise-web/src/lib/streams.ts
+++ b/apps/hyperlocalise-web/src/lib/streams.ts
@@ -1,0 +1,24 @@
+export function bufferFromStream(stream: ReadableStream<Uint8Array>): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const chunks: Uint8Array[] = [];
+    const reader = stream.getReader();
+
+    function read() {
+      reader
+        .read()
+        .then(({ done, value }) => {
+          if (done) {
+            resolve(Buffer.concat(chunks.map((c) => Buffer.from(c))));
+            return;
+          }
+          if (value) {
+            chunks.push(value);
+          }
+          read();
+        })
+        .catch(reject);
+    }
+
+    read();
+  });
+}

--- a/apps/hyperlocalise-web/src/lib/tools/file-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/file-tools.ts
@@ -5,33 +5,9 @@ import { and, eq } from "drizzle-orm";
 
 import { schema } from "@/lib/database";
 import { getFileStorageAdapter } from "@/lib/file-storage";
+import { bufferFromStream } from "@/lib/streams";
 
 import type { ToolContext } from "./types";
-
-function bufferFromStream(stream: ReadableStream<Uint8Array>): Promise<Buffer> {
-  return new Promise((resolve, reject) => {
-    const chunks: Uint8Array[] = [];
-    const reader = stream.getReader();
-
-    function read() {
-      reader
-        .read()
-        .then(({ done, value }) => {
-          if (done) {
-            resolve(Buffer.concat(chunks.map((c) => Buffer.from(c))));
-            return;
-          }
-          if (value) {
-            chunks.push(value);
-          }
-          read();
-        })
-        .catch(reject);
-    }
-
-    read();
-  });
-}
 
 /**
  * Read the contents of a stored file.

--- a/apps/hyperlocalise-web/src/lib/tools/file-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/file-tools.ts
@@ -1,0 +1,131 @@
+import { tool } from "ai";
+import { z } from "zod";
+
+import { and, eq } from "drizzle-orm";
+
+import { schema } from "@/lib/database";
+import { getFileStorageAdapter } from "@/lib/file-storage";
+
+import type { ToolContext } from "./types";
+
+function bufferFromStream(stream: ReadableStream<Uint8Array>): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const chunks: Uint8Array[] = [];
+    const reader = stream.getReader();
+
+    function read() {
+      reader
+        .read()
+        .then(({ done, value }) => {
+          if (done) {
+            resolve(Buffer.concat(chunks.map((c) => Buffer.from(c))));
+            return;
+          }
+          if (value) {
+            chunks.push(value);
+          }
+          read();
+        })
+        .catch(reject);
+    }
+
+    read();
+  });
+}
+
+/**
+ * Read the contents of a stored file.
+ *
+ * Useful when the user has uploaded a file and the agent needs to inspect
+ * its contents before creating a translation job or answering questions.
+ *
+ * Returns the file content as text for text-based formats (JSON, PO, XLIFF,
+ * HTML, Markdown, CSV, etc.). Returns an error for binary files.
+ */
+export function createReadStoredFileTool(ctx: ToolContext) {
+  return tool({
+    description:
+      "Read the text contents of a stored file. Use this to inspect uploaded translation source files before creating jobs.",
+    inputSchema: z.object({
+      fileId: z.string().describe("The stored file ID to read."),
+    }),
+    execute: async ({ fileId }) => {
+      const [file] = await ctx.db
+        .select({
+          id: schema.storedFiles.id,
+          organizationId: schema.storedFiles.organizationId,
+          projectId: schema.storedFiles.projectId,
+          storageKey: schema.storedFiles.storageKey,
+          filename: schema.storedFiles.filename,
+          contentType: schema.storedFiles.contentType,
+        })
+        .from(schema.storedFiles)
+        .where(
+          and(
+            eq(schema.storedFiles.id, fileId),
+            eq(schema.storedFiles.organizationId, ctx.organizationId),
+          ),
+        )
+        .limit(1);
+
+      if (!file) {
+        return {
+          success: false,
+          error: "File not found for this organization.",
+        };
+      }
+
+      if (ctx.projectId && file.projectId && file.projectId !== ctx.projectId) {
+        return {
+          success: false,
+          error: "File does not belong to the current project.",
+        };
+      }
+
+      const adapter = getFileStorageAdapter();
+      const storedObject = await adapter.get({ keyOrUrl: file.storageKey });
+
+      if (!storedObject) {
+        return {
+          success: false,
+          error: "File could not be retrieved from storage.",
+        };
+      }
+
+      try {
+        const buffer = await bufferFromStream(storedObject.body);
+
+        const isBinary =
+          file.contentType.startsWith("image/") ||
+          file.contentType === "application/octet-stream" ||
+          file.filename.match(/\.(png|jpg|jpeg|webp|gif|bmp|ico|pdf|zip|tar|gz|rar|7z)$/i);
+
+        if (isBinary) {
+          return {
+            success: false,
+            error:
+              "Binary files cannot be read as text. Use this tool for text-based translation files only.",
+            filename: file.filename,
+            byteLength: buffer.byteLength,
+          };
+        }
+
+        const text = buffer.toString("utf-8");
+
+        return {
+          success: true,
+          filename: file.filename,
+          contentType: file.contentType,
+          byteLength: buffer.byteLength,
+          content: text.slice(0, 50000),
+          truncated: text.length > 50000,
+        };
+      } catch {
+        return {
+          success: false,
+          error: "Failed to read file content.",
+        };
+      }
+    },
+  });
+}

--- a/apps/hyperlocalise-web/src/lib/tools/job-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/job-tools.ts
@@ -5,6 +5,11 @@ import { tool } from "ai";
 import { z } from "zod";
 
 import { schema } from "@/lib/database";
+import { getStoredFileForJobScope } from "@/lib/file-storage/records";
+import {
+  inferSupportedTranslationFileFormat,
+  supportedTranslationFileFormats,
+} from "@/lib/translation/file-formats";
 import { createTranslationJobQueue } from "@/workflows/adapters";
 
 import type { ToolContext } from "./types";
@@ -166,7 +171,7 @@ export function createTranslationJobTool(ctx: ToolContext) {
       sourceText: z.string().optional().describe("Source text for string jobs."),
       sourceFileId: z.string().optional().describe("Source file ID for file jobs."),
       fileFormat: z
-        .enum(["xliff", "json", "po", "csv"])
+        .enum(supportedTranslationFileFormats)
         .optional()
         .describe("File format for file jobs."),
       sourceLocale: z.string().describe("BCP-47 source locale tag."),
@@ -191,25 +196,60 @@ export function createTranslationJobTool(ctx: ToolContext) {
         };
       }
 
-      if (input.type === "file") {
-        return {
-          success: false,
-          error: "File translation jobs are not supported yet.",
-        };
-      }
-
-      if (!input.sourceText?.trim()) {
+      if (input.type === "string" && !input.sourceText?.trim()) {
         return { success: false, error: "sourceText is required for string translation jobs." };
       }
 
-      const inputPayload = {
-        sourceText: input.sourceText,
-        sourceLocale: input.sourceLocale,
-        targetLocales: input.targetLocales,
-        metadata: input.metadata,
-        context: input.context,
-        maxLength: input.maxLength,
-      };
+      if (input.type === "file") {
+        if (!input.sourceFileId?.trim()) {
+          return { success: false, error: "sourceFileId is required for file translation jobs." };
+        }
+
+        if (!input.fileFormat) {
+          return { success: false, error: "fileFormat is required for file translation jobs." };
+        }
+
+        const sourceFile = await getStoredFileForJobScope({
+          organizationId: ctx.organizationId,
+          projectId: ctx.projectId,
+          fileId: input.sourceFileId,
+        });
+
+        if (!sourceFile) {
+          return {
+            success: false,
+            error: "Source file was not found for this organization or project.",
+          };
+        }
+
+        const inferredFileFormat = inferSupportedTranslationFileFormat(sourceFile.filename);
+        if (inferredFileFormat !== input.fileFormat) {
+          return {
+            success: false,
+            error: inferredFileFormat
+              ? `fileFormat must match source file extension: expected ${inferredFileFormat}.`
+              : "Source file extension is not supported for translation jobs.",
+          };
+        }
+      }
+
+      const inputPayload =
+        input.type === "string"
+          ? {
+              sourceText: input.sourceText,
+              sourceLocale: input.sourceLocale,
+              targetLocales: input.targetLocales,
+              metadata: input.metadata,
+              context: input.context,
+              maxLength: input.maxLength,
+            }
+          : {
+              sourceFileId: input.sourceFileId,
+              fileFormat: input.fileFormat,
+              sourceLocale: input.sourceLocale,
+              targetLocales: input.targetLocales,
+              metadata: input.metadata,
+            };
 
       const job = await ctx.db.transaction(async (tx) => {
         const [createdJob] = await tx

--- a/apps/hyperlocalise-web/src/lib/tools/registry.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/registry.ts
@@ -11,6 +11,7 @@ import {
   createUpdateGlossaryTermTool,
   createUpdateGlossaryTool,
 } from "./glossary-tools";
+import { createReadStoredFileTool } from "./file-tools";
 import { createGetJobStatusTool, createListJobsTool, createTranslationJobTool } from "./job-tools";
 import { createResolveInteractionTool } from "./interaction-tools";
 import {
@@ -65,6 +66,7 @@ export function buildTools(ctx: ToolContext): ToolSet {
     deleteMemoryEntry: createDeleteMemoryEntryTool(ctx),
 
     createTranslationJob: createTranslationJobTool(ctx),
+    readStoredFile: createReadStoredFileTool(ctx),
     // Review, research, sync, and asset-management job tools are intentionally
     // not exposed until workers exist. Registering them now would create
     // queued jobs that never execute.

--- a/apps/hyperlocalise-web/src/lib/translation/diagnostics.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/diagnostics.ts
@@ -1,0 +1,89 @@
+import {
+  type AttachmentContent,
+  inferAttachmentContentType,
+  toAttachmentBuffer,
+} from "@/lib/resend/attachments";
+
+export type TranslatedFileDiagnostics = {
+  filename: string;
+  byteLength: number;
+  sha256: string;
+  firstBytesHex: string;
+  contentType: string;
+  isUtf8: boolean;
+  jsonParseOk: boolean | null;
+  jsonParseError: string | null;
+};
+
+async function sha256Hex(content: Buffer): Promise<string> {
+  const hashBuffer = await crypto.subtle.digest(
+    "SHA-256",
+    content.buffer.slice(
+      content.byteOffset,
+      content.byteOffset + content.byteLength,
+    ) as ArrayBuffer,
+  );
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function checkIsUtf8(buffer: Buffer): boolean {
+  try {
+    new TextDecoder("utf-8", { fatal: true }).decode(buffer);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function getTranslatedFileDiagnostics(
+  content: AttachmentContent,
+  filename: string,
+): Promise<TranslatedFileDiagnostics> {
+  const fileContent = toAttachmentBuffer(content);
+  const dotIndex = filename.lastIndexOf(".");
+  const ext = dotIndex === -1 ? "" : filename.slice(dotIndex).toLowerCase();
+  const isJsonLike = ext === ".json" || ext === ".jsonc";
+  let jsonParseOk: boolean | null = null;
+  let jsonParseError: string | null = null;
+
+  if (isJsonLike) {
+    try {
+      JSON.parse(fileContent.toString("utf8"));
+      jsonParseOk = true;
+    } catch (error) {
+      jsonParseOk = false;
+      jsonParseError = error instanceof Error ? error.message : String(error);
+    }
+  }
+
+  return {
+    filename,
+    byteLength: fileContent.byteLength,
+    sha256: await sha256Hex(fileContent),
+    firstBytesHex: fileContent.subarray(0, 16).toString("hex"),
+    contentType: inferAttachmentContentType(filename),
+    isUtf8: checkIsUtf8(fileContent),
+    jsonParseOk,
+    jsonParseError,
+  };
+}
+
+export async function logTranslatedFileDiagnostics(
+  requestId: string,
+  attachmentId: string,
+  sourceFilename: string,
+  targetLocale: string,
+  translatedContent: Buffer,
+  outputFilename: string,
+): Promise<void> {
+  const diagnostics = await getTranslatedFileDiagnostics(translatedContent, outputFilename);
+
+  console.info(`[sandbox-translation] translated file diagnostics`, {
+    requestId,
+    attachmentId,
+    sourceFilename,
+    targetLocale,
+    diagnostics,
+  });
+}

--- a/apps/hyperlocalise-web/src/lib/translation/file-formats.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/file-formats.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { inferSupportedTranslationFileFormat, isImageTranslationFileFormat } from "./file-formats";
+
+describe("translation file formats", () => {
+  it("infers structured translation formats from supported extensions", () => {
+    expect(inferSupportedTranslationFileFormat("messages.json")).toBe("json");
+    expect(inferSupportedTranslationFileFormat("messages.jsonc")).toBe("jsonc");
+    expect(inferSupportedTranslationFileFormat("app.arb")).toBe("arb");
+    expect(inferSupportedTranslationFileFormat("copy.xlf")).toBe("xliff");
+    expect(inferSupportedTranslationFileFormat("copy.xlif")).toBe("xliff");
+    expect(inferSupportedTranslationFileFormat("copy.xliff")).toBe("xliff");
+    expect(inferSupportedTranslationFileFormat("messages.po")).toBe("po");
+    expect(inferSupportedTranslationFileFormat("page.html")).toBe("html");
+    expect(inferSupportedTranslationFileFormat("readme.md")).toBe("markdown");
+    expect(inferSupportedTranslationFileFormat("page.mdx")).toBe("mdx");
+    expect(inferSupportedTranslationFileFormat("Localizable.strings")).toBe("strings");
+    expect(inferSupportedTranslationFileFormat("Localizable.stringsdict")).toBe("stringsdict");
+    expect(inferSupportedTranslationFileFormat("copy.csv")).toBe("csv");
+  });
+
+  it("infers CLI-supported image formats separately", () => {
+    expect(inferSupportedTranslationFileFormat("banner.png")).toBe("png");
+    expect(inferSupportedTranslationFileFormat("banner.jpg")).toBe("jpeg");
+    expect(inferSupportedTranslationFileFormat("banner.jpeg")).toBe("jpeg");
+    expect(inferSupportedTranslationFileFormat("banner.webp")).toBe("webp");
+    expect(isImageTranslationFileFormat("png")).toBe(true);
+    expect(isImageTranslationFileFormat("json")).toBe(false);
+  });
+
+  it("rejects unsupported file extensions", () => {
+    expect(inferSupportedTranslationFileFormat("brief.pdf")).toBeNull();
+    expect(inferSupportedTranslationFileFormat("spreadsheet.xlsx")).toBeNull();
+    expect(inferSupportedTranslationFileFormat("no-extension")).toBeNull();
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/translation/file-formats.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/file-formats.ts
@@ -1,0 +1,62 @@
+export const supportedTranslationFileFormats = [
+  "json",
+  "jsonc",
+  "arb",
+  "xliff",
+  "po",
+  "html",
+  "markdown",
+  "mdx",
+  "strings",
+  "stringsdict",
+  "csv",
+  "png",
+  "jpeg",
+  "webp",
+] as const;
+
+export type SupportedTranslationFileFormat = (typeof supportedTranslationFileFormats)[number];
+
+const formatsByExtension: Record<string, SupportedTranslationFileFormat> = {
+  ".json": "json",
+  ".jsonc": "jsonc",
+  ".arb": "arb",
+  ".xlf": "xliff",
+  ".xlif": "xliff",
+  ".xliff": "xliff",
+  ".po": "po",
+  ".html": "html",
+  ".md": "markdown",
+  ".mdx": "mdx",
+  ".strings": "strings",
+  ".stringsdict": "stringsdict",
+  ".csv": "csv",
+  ".png": "png",
+  ".jpg": "jpeg",
+  ".jpeg": "jpeg",
+  ".webp": "webp",
+};
+
+export const supportedImageTranslationFileFormats = ["png", "jpeg", "webp"] as const;
+
+export type SupportedImageTranslationFileFormat =
+  (typeof supportedImageTranslationFileFormats)[number];
+
+export function isImageTranslationFileFormat(
+  format: SupportedTranslationFileFormat,
+): format is SupportedImageTranslationFileFormat {
+  return supportedImageTranslationFileFormats.includes(
+    format as SupportedImageTranslationFileFormat,
+  );
+}
+
+export function inferSupportedTranslationFileFormat(
+  filename: string,
+): SupportedTranslationFileFormat | null {
+  const dotIndex = filename.lastIndexOf(".");
+  if (dotIndex === -1) {
+    return null;
+  }
+
+  return formatsByExtension[filename.slice(dotIndex).toLowerCase()] ?? null;
+}

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.ts
@@ -62,7 +62,7 @@ export async function writeFileToSandbox(
   content: Buffer,
 ): Promise<void> {
   const sandbox = await Sandbox.get({ sandboxId });
-  await sandbox.writeFiles([{ path: filename, content: content.toString("utf-8") }]);
+  await sandbox.writeFiles([{ path: filename, content: content }]);
 }
 
 export function buildTempConfig(

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.ts
@@ -1,17 +1,6 @@
-import { isUtf8 } from "node:buffer";
-import { createHash } from "node:crypto";
-
 import { Sandbox } from "@vercel/sandbox";
 
 import { env } from "@/lib/env";
-import { createLogger } from "@/lib/log";
-import {
-  type AttachmentContent,
-  inferAttachmentContentType,
-  toAttachmentBuffer,
-} from "@/lib/resend/attachments";
-
-const logger = createLogger("sandbox-translation");
 
 export const sandboxTimeoutMs = 10 * 60 * 1000;
 
@@ -159,72 +148,6 @@ export async function readTranslatedFile(sandboxId: string, outputFile: string):
     throw new Error(`failed to read translated file: ${outputFile}`);
   }
   return Buffer.from(content);
-}
-
-export type TranslatedFileDiagnostics = {
-  filename: string;
-  byteLength: number;
-  sha256: string;
-  firstBytesHex: string;
-  contentType: string;
-  isUtf8: boolean;
-  jsonParseOk: boolean | null;
-  jsonParseError: string | null;
-};
-
-export async function getTranslatedFileDiagnostics(
-  content: AttachmentContent,
-  filename: string,
-): Promise<TranslatedFileDiagnostics> {
-  const fileContent = toAttachmentBuffer(content);
-  const dotIndex = filename.lastIndexOf(".");
-  const ext = dotIndex === -1 ? "" : filename.slice(dotIndex).toLowerCase();
-  const isJsonLike = ext === ".json" || ext === ".jsonc";
-  let jsonParseOk: boolean | null = null;
-  let jsonParseError: string | null = null;
-
-  if (isJsonLike) {
-    try {
-      JSON.parse(fileContent.toString("utf8"));
-      jsonParseOk = true;
-    } catch (error) {
-      jsonParseOk = false;
-      jsonParseError = error instanceof Error ? error.message : String(error);
-    }
-  }
-
-  return {
-    filename,
-    byteLength: fileContent.byteLength,
-    sha256: createHash("sha256").update(fileContent).digest("hex"),
-    firstBytesHex: fileContent.subarray(0, 16).toString("hex"),
-    contentType: inferAttachmentContentType(filename),
-    isUtf8: isUtf8(fileContent),
-    jsonParseOk,
-    jsonParseError,
-  };
-}
-
-export async function logTranslatedFileDiagnostics(
-  requestId: string,
-  attachmentId: string,
-  sourceFilename: string,
-  targetLocale: string,
-  translatedContent: Buffer,
-  outputFilename: string,
-): Promise<void> {
-  const diagnostics = await getTranslatedFileDiagnostics(translatedContent, outputFilename);
-
-  logger.info(
-    {
-      requestId,
-      attachmentId,
-      sourceFilename,
-      targetLocale,
-      diagnostics,
-    },
-    "translated file diagnostics",
-  );
 }
 
 function shellQuote(value: string): string {

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.ts
@@ -1,0 +1,286 @@
+import { isUtf8 } from "node:buffer";
+import { createHash } from "node:crypto";
+
+import { Sandbox } from "@vercel/sandbox";
+
+import { env } from "@/lib/env";
+import { createLogger } from "@/lib/log";
+import {
+  type AttachmentContent,
+  inferAttachmentContentType,
+  toAttachmentBuffer,
+} from "@/lib/resend/attachments";
+
+const logger = createLogger("sandbox-translation");
+
+export const sandboxTimeoutMs = 10 * 60 * 1000;
+
+export async function createTranslationSandbox(): Promise<{ sandboxId: string }> {
+  const sandbox = await Sandbox.create({
+    timeout: sandboxTimeoutMs,
+  });
+
+  return { sandboxId: sandbox.sandboxId };
+}
+
+export async function stopTranslationSandbox(sandboxId: string): Promise<void> {
+  const sandbox = await Sandbox.get({ sandboxId });
+  await sandbox.stop();
+}
+
+export async function runSandboxCommand(
+  sandboxId: string,
+  command: string,
+  args: string[],
+  options?: { env?: Record<string, string> },
+): Promise<{ exitCode: number; output: string }> {
+  const sandbox = await Sandbox.get({ sandboxId });
+  const result = await sandbox.runCommand({
+    cmd: command,
+    args,
+    env: options?.env,
+  });
+  return {
+    exitCode: result.exitCode,
+    output: await result.output("both"),
+  };
+}
+
+export async function prepareSandbox(sandboxId: string): Promise<void> {
+  const installResult = await runSandboxCommand(sandboxId, "bash", [
+    "-lc",
+    'command -v hl >/dev/null 2>&1 || command -v hyperlocalise >/dev/null 2>&1 || (curl -fsSL https://hyperlocalise.com/install | bash); command -v hl >/dev/null 2>&1 || { mkdir -p ~/.local/bin; ln -sf "$(command -v hyperlocalise)" ~/.local/bin/hl; }',
+  ]);
+  if (installResult.exitCode !== 0) {
+    throw new Error(`hyperlocalise CLI installation failed: ${installResult.output}`);
+  }
+}
+
+export async function downloadAttachment(
+  sandboxId: string,
+  downloadUrl: string,
+  filename: string,
+): Promise<void> {
+  const result = await runSandboxCommand(sandboxId, "curl", ["-fsSL", "-o", filename, downloadUrl]);
+  if (result.exitCode !== 0) {
+    throw new Error(`failed to download attachment: ${result.output}`);
+  }
+}
+
+export async function writeFileToSandbox(
+  sandboxId: string,
+  filename: string,
+  content: Buffer,
+): Promise<void> {
+  const sandbox = await Sandbox.get({ sandboxId });
+  await sandbox.writeFiles([{ path: filename, content: content.toString("utf-8") }]);
+}
+
+export function buildTempConfig(
+  inputFile: string,
+  outputFile: string,
+  sourceLocale: string | null,
+  targetLocale: string,
+  instructions: string | null = null,
+): string {
+  const yamlString = (value: string) => JSON.stringify(value);
+  const normalizedInstructions = instructions?.trim();
+  const systemPrompt = [
+    "You are a translation assistant. Translate the user-provided source text into the requested target language.",
+    "Preserve meaning, placeholders, variables, formatting, HTML/Markdown structure, and ICU message syntax.",
+    "Do not translate programmatic identifiers inside placeholders or ICU selectors.",
+    normalizedInstructions ? `User style instructions: ${normalizedInstructions}` : null,
+    "Return only the translated text with no explanations, labels, markdown fences, or quotes unless the translated content itself requires them.",
+  ]
+    .filter((line): line is string => line !== null)
+    .join("\n");
+  const userPrompt = ["Translate from {{source}} to {{target}}.", "", "{{input}}"].join("\n");
+
+  return [
+    "locales:",
+    `  source: ${yamlString(sourceLocale ?? "auto")}`,
+    "  targets:",
+    `    - ${yamlString(targetLocale)}`,
+    "",
+    "buckets:",
+    "  email:",
+    "    files:",
+    `      - from: ${yamlString(inputFile)}`,
+    `        to: ${yamlString(outputFile)}`,
+    "",
+    "llm:",
+    "  profiles:",
+    "    default:",
+    "      provider: openai",
+    "      model: gpt-5.4-mini",
+    `      system_prompt: ${yamlString(systemPrompt)}`,
+    `      user_prompt: ${yamlString(userPrompt)}`,
+  ].join("\n");
+}
+
+export async function writeTempConfig(
+  sandboxId: string,
+  configContent: string,
+  configPath: string,
+): Promise<void> {
+  const sandbox = await Sandbox.get({ sandboxId });
+  await sandbox.writeFiles([{ path: configPath, content: configContent }]);
+}
+
+export async function runTranslationCommand(
+  sandboxId: string,
+  inputFile: string,
+  outputFile: string,
+  sourceLocale: string | null,
+  targetLocale: string,
+  instructions: string | null,
+): Promise<{ exitCode: number; output: string }> {
+  const configPath = "/tmp/hyperlocalise-email.yml";
+  const config = buildTempConfig(inputFile, outputFile, sourceLocale, targetLocale, instructions);
+  await writeTempConfig(sandboxId, config, configPath);
+
+  return runSandboxCommand(
+    sandboxId,
+    "bash",
+    [
+      "-lc",
+      `export PATH="$HOME/.local/bin:$PATH"; hl run --config ${shellQuote(configPath)} --locale ${shellQuote(targetLocale)} --force --progress off`,
+    ],
+    {
+      env: getSandboxTranslationEnv(),
+    },
+  );
+}
+
+export async function readTranslatedFile(sandboxId: string, outputFile: string): Promise<Buffer> {
+  const sandbox = await Sandbox.get({ sandboxId });
+  const content = await sandbox.readFileToBuffer({ path: outputFile });
+  if (!content) {
+    throw new Error(`failed to read translated file: ${outputFile}`);
+  }
+  return Buffer.from(content);
+}
+
+export type TranslatedFileDiagnostics = {
+  filename: string;
+  byteLength: number;
+  sha256: string;
+  firstBytesHex: string;
+  contentType: string;
+  isUtf8: boolean;
+  jsonParseOk: boolean | null;
+  jsonParseError: string | null;
+};
+
+export async function getTranslatedFileDiagnostics(
+  content: AttachmentContent,
+  filename: string,
+): Promise<TranslatedFileDiagnostics> {
+  const fileContent = toAttachmentBuffer(content);
+  const dotIndex = filename.lastIndexOf(".");
+  const ext = dotIndex === -1 ? "" : filename.slice(dotIndex).toLowerCase();
+  const isJsonLike = ext === ".json" || ext === ".jsonc";
+  let jsonParseOk: boolean | null = null;
+  let jsonParseError: string | null = null;
+
+  if (isJsonLike) {
+    try {
+      JSON.parse(fileContent.toString("utf8"));
+      jsonParseOk = true;
+    } catch (error) {
+      jsonParseOk = false;
+      jsonParseError = error instanceof Error ? error.message : String(error);
+    }
+  }
+
+  return {
+    filename,
+    byteLength: fileContent.byteLength,
+    sha256: createHash("sha256").update(fileContent).digest("hex"),
+    firstBytesHex: fileContent.subarray(0, 16).toString("hex"),
+    contentType: inferAttachmentContentType(filename),
+    isUtf8: isUtf8(fileContent),
+    jsonParseOk,
+    jsonParseError,
+  };
+}
+
+export async function logTranslatedFileDiagnostics(
+  requestId: string,
+  attachmentId: string,
+  sourceFilename: string,
+  targetLocale: string,
+  translatedContent: Buffer,
+  outputFilename: string,
+): Promise<void> {
+  const diagnostics = await getTranslatedFileDiagnostics(translatedContent, outputFilename);
+
+  logger.info(
+    {
+      requestId,
+      attachmentId,
+      sourceFilename,
+      targetLocale,
+      diagnostics,
+    },
+    "translated file diagnostics",
+  );
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+export function getSandboxTranslationEnv(): Record<string, string> {
+  if (!env.OPENAI_API_KEY) {
+    throw new Error("OPENAI_API_KEY is not configured");
+  }
+
+  return {
+    OPENAI_API_KEY: env.OPENAI_API_KEY,
+  };
+}
+
+export function getOutputFilename(inputFilename: string, targetLocale: string): string {
+  const lastDot = inputFilename.lastIndexOf(".");
+  if (lastDot === -1) {
+    return `${inputFilename}-${targetLocale}`;
+  }
+  const name = inputFilename.slice(0, lastDot);
+  const ext = inputFilename.slice(lastDot);
+  return `${name}-${targetLocale}${ext}`;
+}
+
+export function sanitizeFilename(email: string): string {
+  return email.replace(/[^a-zA-Z0-9._-]/g, "_");
+}
+
+export function getSandboxInputFilename(attachmentFilename: string): string {
+  return sanitizeFilename(attachmentFilename);
+}
+
+export function getSandboxOutputFilename(attachmentFilename: string, targetLocale: string): string {
+  return getOutputFilename(sanitizeFilename(attachmentFilename), targetLocale);
+}
+
+export function userFacingFailureReason(error: unknown): string {
+  const message = error instanceof Error ? error.message : "Unknown translation failure";
+
+  if (message.includes("hyperlocalise CLI installation failed")) {
+    return "something went wrong while setting up the translation environment on our end.";
+  }
+
+  if (message.includes("failed to download attachment")) {
+    return "the attachment couldn't be retrieved. It may have been too large or the link expired.";
+  }
+
+  if (message.includes("translation failed")) {
+    return "the file format may not be supported, or the content didn't match what the translator expected.";
+  }
+
+  if (message.includes("failed to read translated file")) {
+    return "the translation finished, but the output file couldn't be read back. This is usually temporary.";
+  }
+
+  return "the translation failed before it could finish. This is usually temporary.";
+}

--- a/apps/hyperlocalise-web/src/workflows/adapters.ts
+++ b/apps/hyperlocalise-web/src/workflows/adapters.ts
@@ -1,6 +1,7 @@
 import { start } from "workflow/api";
 
 import { emailTranslationWorkflow } from "./email-translation";
+import { fileTranslationJobWorkflow } from "./file-translation-job";
 import { githubFixWorkflow } from "./github-fix";
 import { translationJobWorkflow } from "./translation-job";
 import type {
@@ -12,7 +13,8 @@ import type {
 export function createTranslationJobQueue(): TranslationJobQueue {
   return {
     async enqueue(event) {
-      const run = await start(translationJobWorkflow, [event]);
+      const workflow = event.type === "file" ? fileTranslationJobWorkflow : translationJobWorkflow;
+      const run = await start(workflow, [event]);
 
       return {
         ids: [run.runId],

--- a/apps/hyperlocalise-web/src/workflows/email-translation.test.ts
+++ b/apps/hyperlocalise-web/src/workflows/email-translation.test.ts
@@ -8,9 +8,10 @@ vi.mock("@/lib/env", () => ({
   },
 }));
 
+import { getTranslatedFileDiagnostics } from "@/lib/translation/diagnostics";
+
 import {
   buildTempConfig,
-  getTranslatedFileDiagnostics,
   getSandboxInputFilename,
   getSandboxOutputFilename,
   getSandboxTranslationEnv,

--- a/apps/hyperlocalise-web/src/workflows/email-translation.ts
+++ b/apps/hyperlocalise-web/src/workflows/email-translation.ts
@@ -1,6 +1,3 @@
-import { isUtf8 } from "node:buffer";
-import { createHash } from "node:crypto";
-
 import { Sandbox } from "@vercel/sandbox";
 import { and, eq } from "drizzle-orm";
 import { Resend } from "resend";
@@ -8,17 +5,11 @@ import { getWorkflowMetadata } from "workflow";
 
 import { db, schema } from "@/lib/database";
 import { env } from "@/lib/env";
-import { createLogger } from "@/lib/log";
-import {
-  type AttachmentContent,
-  inferAttachmentContentType,
-  toAttachmentBuffer,
-  toBase64AttachmentContent,
-} from "@/lib/resend/attachments";
+import { inferAttachmentContentType, toBase64AttachmentContent } from "@/lib/resend/attachments";
+import { getTranslatedFileDiagnostics } from "@/lib/translation/diagnostics";
 import type { EmailAgentTask, EmailAgentTaskAttachment } from "@/lib/workflow/types";
 
 const sandboxTimeoutMs = 10 * 60 * 1000;
-const logger = createLogger("email-translation-workflow");
 
 async function createTranslationSandbox(): Promise<{ sandboxId: string }> {
   "use step";
@@ -171,52 +162,6 @@ async function readTranslatedFile(sandboxId: string, outputFile: string): Promis
   return Buffer.from(content);
 }
 
-type TranslatedFileDiagnostics = {
-  filename: string;
-  byteLength: number;
-  sha256: string;
-  firstBytesHex: string;
-  contentType: string;
-  isUtf8: boolean;
-  jsonParseOk: boolean | null;
-  jsonParseError: string | null;
-};
-
-export async function getTranslatedFileDiagnostics(
-  content: AttachmentContent,
-  filename: string,
-): Promise<TranslatedFileDiagnostics> {
-  "use step";
-
-  const fileContent = toAttachmentBuffer(content);
-  const dotIndex = filename.lastIndexOf(".");
-  const ext = dotIndex === -1 ? "" : filename.slice(dotIndex).toLowerCase();
-  const isJsonLike = ext === ".json" || ext === ".jsonc";
-  let jsonParseOk: boolean | null = null;
-  let jsonParseError: string | null = null;
-
-  if (isJsonLike) {
-    try {
-      JSON.parse(fileContent.toString("utf8"));
-      jsonParseOk = true;
-    } catch (error) {
-      jsonParseOk = false;
-      jsonParseError = error instanceof Error ? error.message : String(error);
-    }
-  }
-
-  return {
-    filename,
-    byteLength: fileContent.byteLength,
-    sha256: createHash("sha256").update(fileContent).digest("hex"),
-    firstBytesHex: fileContent.subarray(0, 16).toString("hex"),
-    contentType: inferAttachmentContentType(filename),
-    isUtf8: isUtf8(fileContent),
-    jsonParseOk,
-    jsonParseError,
-  };
-}
-
 async function logTranslatedFileDiagnostics(
   task: EmailAgentTask,
   attachment: EmailAgentTaskAttachment,
@@ -227,16 +172,13 @@ async function logTranslatedFileDiagnostics(
 
   const diagnostics = await getTranslatedFileDiagnostics(translatedContent, outputFilename);
 
-  logger.info(
-    {
-      requestId: task.requestId,
-      attachmentId: attachment.id,
-      sourceFilename: attachment.filename,
-      targetLocale: task.parameters.translate.targetLocale,
-      diagnostics,
-    },
-    "translated email attachment diagnostics",
-  );
+  console.info("[email-translation-workflow] translated email attachment diagnostics", {
+    requestId: task.requestId,
+    attachmentId: attachment.id,
+    sourceFilename: attachment.filename,
+    targetLocale: task.parameters.translate.targetLocale,
+    diagnostics,
+  });
 }
 
 function shellQuote(value: string): string {

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -5,13 +5,12 @@ import { and, eq } from "drizzle-orm";
 import { db, schema } from "@/lib/database";
 import { getFileStorageAdapter } from "@/lib/file-storage";
 import { createStoredFile } from "@/lib/file-storage/records";
-import { createLogger } from "@/lib/log";
+import { logTranslatedFileDiagnostics } from "@/lib/translation/diagnostics";
 import {
   createTranslationSandbox,
   getSandboxInputFilename,
   getSandboxOutputFilename,
   getSandboxTranslationEnv,
-  logTranslatedFileDiagnostics,
   prepareSandbox,
   readTranslatedFile,
   runSandboxCommand,
@@ -25,8 +24,6 @@ import {
   claimTranslationJob,
   failTranslationJob,
 } from "@/lib/translation/translation-job-queued-function";
-
-const logger = createLogger("file-translation-workflow");
 
 async function claimTranslationJobStep(input: {
   event: TranslationJobQueuedEventData;
@@ -354,14 +351,11 @@ export async function fileTranslationJobWorkflow(event: TranslationJobQueuedEven
     return outputFiles;
   } catch (error) {
     const reason = userFacingFailureReason(error);
-    logger.error(
-      {
-        jobId: claim.job.id,
-        projectId: claim.job.projectId,
-        error: reason,
-      },
-      "file translation failed",
-    );
+    console.error("[file-translation-workflow] file translation failed", {
+      jobId: claim.job.id,
+      projectId: claim.job.projectId,
+      error: reason,
+    });
     await failTranslationJobStep({
       jobId: claim.job.id,
       projectId: claim.job.projectId,

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -23,6 +23,10 @@ import {
 } from "@/lib/translation/sandbox-translation";
 import type { TranslationJobQueuedEventData } from "@/lib/workflow/types";
 import {
+  isImageTranslationFileFormat,
+  type SupportedTranslationFileFormat,
+} from "@/lib/translation/file-formats";
+import {
   claimTranslationJob,
   failTranslationJob,
 } from "@/lib/translation/translation-job-queued-function";
@@ -110,6 +114,27 @@ async function logDiagnosticsStep(
   );
 }
 
+async function storeOutputFileStep(input: {
+  organizationId: string;
+  projectId: string;
+  jobId: string;
+  filename: string;
+  contentType: string;
+  content: Buffer;
+}) {
+  "use step";
+  return createStoredFile({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    role: "output",
+    sourceKind: "job_output",
+    sourceJobId: input.jobId,
+    filename: input.filename,
+    contentType: input.contentType,
+    content: input.content,
+  });
+}
+
 async function completeFileTranslationJob(input: {
   jobId: string;
   projectId: string;
@@ -194,6 +219,17 @@ export async function fileTranslationJobWorkflow(event: TranslationJobQueuedEven
       message: "missing or invalid file translation job input",
     });
     throw new Error("invalid file job input");
+  }
+
+  if (isImageTranslationFileFormat(parsedInput.fileFormat as SupportedTranslationFileFormat)) {
+    await failTranslationJobStep({
+      jobId: claim.job.id,
+      projectId: claim.job.projectId,
+      workflowRunId: claim.job.workflowRunId,
+      code: "unsupported_file_format",
+      message: `binary image format '${parsedInput.fileFormat}' is not supported for file translation`,
+    });
+    throw new Error(`unsupported image format: ${parsedInput.fileFormat}`);
   }
 
   const [project] = await db
@@ -299,12 +335,10 @@ export async function fileTranslationJobWorkflow(event: TranslationJobQueuedEven
         outputFilename,
       );
 
-      const storedOutput = await createStoredFile({
+      const storedOutput = await storeOutputFileStep({
         organizationId: project.organizationId,
         projectId: claim.job.projectId,
-        role: "output",
-        sourceKind: "job_output",
-        sourceJobId: claim.job.id,
+        jobId: claim.job.id,
         filename: outputFilename,
         contentType: sourceFile.contentType,
         content: translatedContent,

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -1,0 +1,376 @@
+import { getWorkflowMetadata } from "workflow";
+
+import { and, eq } from "drizzle-orm";
+
+import { db, schema } from "@/lib/database";
+import { getFileStorageAdapter } from "@/lib/file-storage";
+import { createStoredFile } from "@/lib/file-storage/records";
+import { createLogger } from "@/lib/log";
+import {
+  createTranslationSandbox,
+  getSandboxInputFilename,
+  getSandboxOutputFilename,
+  getSandboxTranslationEnv,
+  logTranslatedFileDiagnostics,
+  prepareSandbox,
+  readTranslatedFile,
+  runSandboxCommand,
+  stopTranslationSandbox,
+  userFacingFailureReason,
+  writeFileToSandbox,
+  writeTempConfig,
+} from "@/lib/translation/sandbox-translation";
+import type { TranslationJobQueuedEventData } from "@/lib/workflow/types";
+import {
+  claimTranslationJob,
+  failTranslationJob,
+} from "@/lib/translation/translation-job-queued-function";
+
+const logger = createLogger("file-translation-workflow");
+
+async function claimTranslationJobStep(input: {
+  event: TranslationJobQueuedEventData;
+  runId: string;
+}) {
+  "use step";
+  return claimTranslationJob(input);
+}
+
+async function failTranslationJobStep(input: Parameters<typeof failTranslationJob>[0]) {
+  "use step";
+  return failTranslationJob(input);
+}
+
+async function createSandboxStep() {
+  "use step";
+  return createTranslationSandbox();
+}
+
+async function prepareSandboxStep(sandboxId: string) {
+  "use step";
+  return prepareSandbox(sandboxId);
+}
+
+async function writeSourceFileStep(sandboxId: string, filename: string, content: Buffer) {
+  "use step";
+  return writeFileToSandbox(sandboxId, filename, content);
+}
+
+async function runTranslationStep(
+  sandboxId: string,
+  inputFile: string,
+  outputFile: string,
+  sourceLocale: string | null,
+  targetLocale: string,
+  instructions: string | null,
+) {
+  "use step";
+
+  const configPath = "/tmp/hyperlocalise-file.yml";
+  const { buildTempConfig } = await import("@/lib/translation/sandbox-translation");
+  const config = buildTempConfig(inputFile, outputFile, sourceLocale, targetLocale, instructions);
+  await writeTempConfig(sandboxId, config, configPath);
+
+  return runSandboxCommand(
+    sandboxId,
+    "bash",
+    [
+      "-lc",
+      `export PATH="$HOME/.local/bin:$PATH"; hl run --config '${configPath.replaceAll("'", "'\\''")}' --locale '${targetLocale.replaceAll("'", "'\\''")}' --force --progress off`,
+    ],
+    {
+      env: getSandboxTranslationEnv(),
+    },
+  );
+}
+
+async function readOutputStep(sandboxId: string, outputFile: string) {
+  "use step";
+  return readTranslatedFile(sandboxId, outputFile);
+}
+
+async function stopSandboxStep(sandboxId: string) {
+  "use step";
+  return stopTranslationSandbox(sandboxId);
+}
+
+async function logDiagnosticsStep(
+  jobId: string,
+  sourceFilename: string,
+  targetLocale: string,
+  content: Buffer,
+  outputFilename: string,
+) {
+  "use step";
+  return logTranslatedFileDiagnostics(
+    jobId,
+    "file-translation",
+    sourceFilename,
+    targetLocale,
+    content,
+    outputFilename,
+  );
+}
+
+async function completeFileTranslationJob(input: {
+  jobId: string;
+  projectId: string;
+  workflowRunId: string;
+  outputFiles: Array<{ fileId: string; locale: string; filename: string }>;
+}) {
+  "use step";
+
+  const didSucceed = await db.transaction(async (tx) => {
+    const [updatedJob] = await tx
+      .update(schema.jobs)
+      .set({
+        status: "succeeded",
+        outcomePayload: {
+          outputFiles: input.outputFiles,
+        },
+        lastError: null,
+        completedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(schema.jobs.kind, "translation"),
+          eq(schema.jobs.id, input.jobId),
+          eq(schema.jobs.projectId, input.projectId),
+          eq(schema.jobs.workflowRunId, input.workflowRunId),
+        ),
+      )
+      .returning({ id: schema.jobs.id });
+
+    if (!updatedJob) {
+      return false;
+    }
+
+    await tx
+      .update(schema.translationJobDetails)
+      .set({ outcomeKind: "file_result" })
+      .where(eq(schema.translationJobDetails.jobId, input.jobId));
+
+    return true;
+  });
+
+  if (!didSucceed) {
+    throw new Error(
+      `translation job ${input.jobId} is not owned by workflow run ${input.workflowRunId}`,
+    );
+  }
+
+  return input.outputFiles;
+}
+
+function bufferFromStream(stream: ReadableStream<Uint8Array>): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const chunks: Uint8Array[] = [];
+    const reader = stream.getReader();
+
+    function read() {
+      reader
+        .read()
+        .then(({ done, value }) => {
+          if (done) {
+            resolve(Buffer.concat(chunks.map((c) => Buffer.from(c))));
+            return;
+          }
+          if (value) {
+            chunks.push(value);
+          }
+          read();
+        })
+        .catch(reject);
+    }
+
+    read();
+  });
+}
+
+export async function fileTranslationJobWorkflow(event: TranslationJobQueuedEventData) {
+  "use workflow";
+
+  const { workflowRunId } = getWorkflowMetadata();
+  const claim = await claimTranslationJobStep({ event, runId: workflowRunId });
+
+  if (claim.kind === "skipped") {
+    return claim.job;
+  }
+
+  if (claim.job.type !== "file") {
+    throw new Error(`fileTranslationJobWorkflow received non-file job: ${claim.job.type}`);
+  }
+
+  const parsedInput =
+    event.type === "file"
+      ? (claim.job.inputPayload as {
+          sourceFileId: string;
+          fileFormat: string;
+          sourceLocale: string;
+          targetLocales: string[];
+          metadata?: Record<string, string>;
+        })
+      : null;
+
+  if (!parsedInput) {
+    await failTranslationJobStep({
+      jobId: claim.job.id,
+      projectId: claim.job.projectId,
+      workflowRunId: claim.job.workflowRunId,
+      code: "invalid_file_job_input",
+      message: "missing or invalid file translation job input",
+    });
+    throw new Error("invalid file job input");
+  }
+
+  const [project] = await db
+    .select({ organizationId: schema.projects.organizationId })
+    .from(schema.projects)
+    .where(eq(schema.projects.id, claim.job.projectId))
+    .limit(1);
+
+  if (!project) {
+    await failTranslationJobStep({
+      jobId: claim.job.id,
+      projectId: claim.job.projectId,
+      workflowRunId: claim.job.workflowRunId,
+      code: "translation_project_not_found",
+      message: `project ${claim.job.projectId} not found`,
+    });
+    throw new Error("project not found");
+  }
+
+  const sourceFile = await db
+    .select()
+    .from(schema.storedFiles)
+    .where(
+      and(
+        eq(schema.storedFiles.id, parsedInput.sourceFileId),
+        eq(schema.storedFiles.organizationId, project.organizationId),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (!sourceFile) {
+    await failTranslationJobStep({
+      jobId: claim.job.id,
+      projectId: claim.job.projectId,
+      workflowRunId: claim.job.workflowRunId,
+      code: "source_file_not_found",
+      message: `source file ${parsedInput.sourceFileId} not found`,
+    });
+    throw new Error("source file not found");
+  }
+
+  const adapter = getFileStorageAdapter();
+  const storedObject = await adapter.get({ keyOrUrl: sourceFile.storageKey });
+
+  if (!storedObject) {
+    await failTranslationJobStep({
+      jobId: claim.job.id,
+      projectId: claim.job.projectId,
+      workflowRunId: claim.job.workflowRunId,
+      code: "source_file_unavailable",
+      message: `source file ${parsedInput.sourceFileId} could not be retrieved from storage`,
+    });
+    throw new Error("source file unavailable");
+  }
+
+  let sourceContent: Buffer;
+  try {
+    sourceContent = await bufferFromStream(storedObject.body);
+  } catch (error) {
+    await failTranslationJobStep({
+      jobId: claim.job.id,
+      projectId: claim.job.projectId,
+      workflowRunId: claim.job.workflowRunId,
+      code: "source_file_read_failed",
+      message: "failed to read source file content",
+    });
+    throw error;
+  }
+
+  const { sandboxId } = await createSandboxStep();
+  const inputFilename = getSandboxInputFilename(sourceFile.filename);
+  const instructions = parsedInput.metadata?.instructions ?? null;
+
+  try {
+    await prepareSandboxStep(sandboxId);
+    await writeSourceFileStep(sandboxId, inputFilename, sourceContent);
+
+    const outputFiles: Array<{ fileId: string; locale: string; filename: string }> = [];
+
+    for (const targetLocale of parsedInput.targetLocales) {
+      const outputFilename = getSandboxOutputFilename(sourceFile.filename, targetLocale);
+
+      const translation = await runTranslationStep(
+        sandboxId,
+        inputFilename,
+        outputFilename,
+        parsedInput.sourceLocale,
+        targetLocale,
+        instructions,
+      );
+
+      if (translation.exitCode !== 0) {
+        throw new Error(`translation failed for ${targetLocale}: ${translation.output}`);
+      }
+
+      const translatedContent = await readOutputStep(sandboxId, outputFilename);
+      await logDiagnosticsStep(
+        claim.job.id,
+        sourceFile.filename,
+        targetLocale,
+        translatedContent,
+        outputFilename,
+      );
+
+      const storedOutput = await createStoredFile({
+        organizationId: project.organizationId,
+        projectId: claim.job.projectId,
+        role: "output",
+        sourceKind: "job_output",
+        sourceJobId: claim.job.id,
+        filename: outputFilename,
+        contentType: sourceFile.contentType,
+        content: translatedContent,
+      });
+
+      outputFiles.push({
+        fileId: storedOutput.id,
+        locale: targetLocale,
+        filename: outputFilename,
+      });
+    }
+
+    await completeFileTranslationJob({
+      jobId: claim.job.id,
+      projectId: claim.job.projectId,
+      workflowRunId: claim.job.workflowRunId,
+      outputFiles,
+    });
+
+    return outputFiles;
+  } catch (error) {
+    const reason = userFacingFailureReason(error);
+    logger.error(
+      {
+        jobId: claim.job.id,
+        projectId: claim.job.projectId,
+        error: reason,
+      },
+      "file translation failed",
+    );
+    await failTranslationJobStep({
+      jobId: claim.job.id,
+      projectId: claim.job.projectId,
+      workflowRunId: claim.job.workflowRunId,
+      code: "file_translation_failed",
+      message: reason,
+    });
+    throw error;
+  } finally {
+    await stopSandboxStep(sandboxId);
+  }
+}

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -5,8 +5,10 @@ import { and, eq } from "drizzle-orm";
 import { db, schema } from "@/lib/database";
 import { getFileStorageAdapter } from "@/lib/file-storage";
 import { createStoredFile } from "@/lib/file-storage/records";
+import { bufferFromStream } from "@/lib/streams";
 import { logTranslatedFileDiagnostics } from "@/lib/translation/diagnostics";
 import {
+  buildTempConfig,
   createTranslationSandbox,
   getSandboxInputFilename,
   getSandboxOutputFilename,
@@ -64,7 +66,6 @@ async function runTranslationStep(
   "use step";
 
   const configPath = "/tmp/hyperlocalise-file.yml";
-  const { buildTempConfig } = await import("@/lib/translation/sandbox-translation");
   const config = buildTempConfig(inputFile, outputFile, sourceLocale, targetLocale, instructions);
   await writeTempConfig(sandboxId, config, configPath);
 
@@ -157,31 +158,6 @@ async function completeFileTranslationJob(input: {
   }
 
   return input.outputFiles;
-}
-
-function bufferFromStream(stream: ReadableStream<Uint8Array>): Promise<Buffer> {
-  return new Promise((resolve, reject) => {
-    const chunks: Uint8Array[] = [];
-    const reader = stream.getReader();
-
-    function read() {
-      reader
-        .read()
-        .then(({ done, value }) => {
-          if (done) {
-            resolve(Buffer.concat(chunks.map((c) => Buffer.from(c))));
-            return;
-          }
-          if (value) {
-            chunks.push(value);
-          }
-          read();
-        })
-        .catch(reject);
-    }
-
-    read();
-  });
 }
 
 export async function fileTranslationJobWorkflow(event: TranslationJobQueuedEventData) {


### PR DESCRIPTION
This PR fixes the broken chat-to-file-translation flow when using Vercel Blob private access, and adds missing infrastructure for agents to read uploaded files.
Problem
- File translation jobs created from chat uploads failed immediately with unsupported_job_type because the translation worker only handled type: "string".
- Private Vercel Blob URLs stored in chat message attachments were inaccessible to both clients and external systems (email sandbox, curl), causing 403s.
- The agent had no tool to inspect uploaded file contents before creating jobs.
Changes
Authenticated file download proxy
- New route: GET /api/orgs/:organizationSlug/files/:fileId
- Streams file content server-to-server with cookie auth so private blob URLs are never exposed to clients or external workers.
Chat upload uses proxy-safe URLs
- chat-request.route.ts now stores /api/orgs/{slug}/files/{id} in message attachments instead of raw blob URLs.
File translation workflow via hl sandbox
- New workflow: src/workflows/file-translation-job.ts
- Runs the same hl CLI translation pipeline as the email bot:
  1. Claim job
  2. Fetch source file from private blob
  3. Spin up Vercel Sandbox, install hl
  4. Run hl run per target locale
  5. Store output files as job_output and mark job file_result
- Queue adapter routes type: "file" jobs to the new workflow.
Shared sandbox utilities
- Extracted reusable sandbox helpers from email-translation.ts into src/lib/translation/sandbox-translation.ts (create/prepare/run/read/stop).
FileStorageAdapter: getSignedUrl
- Added getSignedUrl(input) to the adapter interface and Vercel Blob implementation for future integrations that need temporary signed URLs.
Agent tool: readStoredFile
- New tool lets the agent inspect uploaded translation source files before creating jobs.
- Returns text content for JSON/PO/XLIFF/HTML/CSV/etc.; rejects binary files.
Tests
- Added src/api/routes/file/file.route.test.ts covering auth, streaming, and cross-org 404s.
- Updated chat-request test mock adapter to include getSignedUrl.
Checklist
- [x] vp check --fix passes
- [x] vp test passes (219 tests)