### PR TITLE
fix(web): align jobs UI with durable job kinds

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/chat-request/chat-request.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/chat-request/chat-request.route.test.ts
@@ -177,4 +177,27 @@ describe("chat request uploads", () => {
       filename: "source.txt",
     });
   });
+
+  it("rejects image uploads until visual asset jobs are available", async () => {
+    const identity = createWorkosIdentity();
+    const headers = await authHeadersFor(identity);
+    const formData = new FormData();
+    formData.set("text", "Localize this campaign image");
+    formData.append("files", new File(["image"], "banner.png", { type: "image/png" }));
+
+    const response = await app.request(
+      `/api/orgs/${identity.organization.slug}/chat-requests/upload`,
+      {
+        method: "POST",
+        headers,
+        body: formData,
+      },
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "unsupported_translation_source_file",
+      filename: "banner.png",
+    });
+  });
 });

--- a/apps/hyperlocalise-web/src/api/routes/chat-request/chat-request.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/chat-request/chat-request.route.ts
@@ -8,7 +8,7 @@ import { workosAuthMiddleware } from "@/api/auth/workos";
 import type { FileStorageAdapter } from "@/lib/file-storage";
 import { createStoredFile } from "@/lib/file-storage/records";
 import { addInteractionMessage, createInteraction } from "@/lib/interactions";
-import { inferSupportedTranslationFileFormat } from "@/lib/translation/file-formats";
+import { inferSupportedFileTranslationFileFormat } from "@/lib/translation/file-formats";
 
 const chatRequestBodySchema = z.object({
   text: z.string().trim().min(1).max(10000),
@@ -93,7 +93,7 @@ export function createChatRequestRoutes(options: CreateChatRequestRoutesOptions 
         }
 
         for (const file of files) {
-          if (!inferSupportedTranslationFileFormat(file.name)) {
+          if (!inferSupportedFileTranslationFileFormat(file.name)) {
             return unsupportedTranslationSourceFileResponse(c, file.name);
           }
         }

--- a/apps/hyperlocalise-web/src/api/routes/conversation/chat-stream.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/chat-stream.route.ts
@@ -58,7 +58,8 @@ function buildSystemPrompt(projectId: string | null) {
     "- Be concise but thorough in your responses",
     "- When suggesting translations, consider context, tone, and target audience",
     "- If you need more information to provide a good answer, ask clarifying questions",
-    "- You can help create translation jobs, suggest glossary terms, or review existing translations",
+    "- You can create translation jobs, suggest glossary terms, and inspect existing jobs",
+    "- Review, research, sync, and asset-management jobs are not runnable yet; use the matching unavailable-job tool if a user asks to queue one",
     "- Always maintain a professional, helpful tone",
   );
 

--- a/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.ts
@@ -339,6 +339,7 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
         .select({
           id: schema.jobs.id,
           projectId: schema.jobs.projectId,
+          kind: schema.jobs.kind,
           type: schema.translationJobDetails.type,
           status: schema.jobs.status,
           outcomeKind: schema.translationJobDetails.outcomeKind,
@@ -346,16 +347,12 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
           completedAt: schema.jobs.completedAt,
         })
         .from(schema.jobs)
-        .innerJoin(
+        .leftJoin(
           schema.translationJobDetails,
           eq(schema.translationJobDetails.jobId, schema.jobs.id),
         )
         .where(
-          and(
-            eq(schema.jobs.kind, "translation"),
-            eq(schema.jobs.organizationId, orgId),
-            eq(schema.jobs.interactionId, conversationId),
-          ),
+          and(eq(schema.jobs.organizationId, orgId), eq(schema.jobs.interactionId, conversationId)),
         )
         .orderBy(desc(schema.jobs.createdAt));
 

--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
@@ -7,7 +7,7 @@ import { validator } from "hono/validator";
 import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
 import { db, schema } from "@/lib/database";
 import { getStoredFileForJobScope } from "@/lib/file-storage/records";
-import { inferSupportedTranslationFileFormat } from "@/lib/translation/file-formats";
+import { inferSupportedFileTranslationFileFormat } from "@/lib/translation/file-formats";
 import type { TranslationJobQueue } from "@/lib/workflow/types";
 
 import {
@@ -21,6 +21,7 @@ import {
   jobListQuerySchema,
   jobParamsSchema,
   jobProjectParamsSchema,
+  workspaceJobParamsSchema,
 } from "./job.schema";
 
 type CreateJobRoutesOptions = {
@@ -32,6 +33,8 @@ const jobSelect = {
   organizationId: schema.jobs.organizationId,
   projectId: schema.jobs.projectId,
   createdByUserId: schema.jobs.createdByUserId,
+  ownerUserId: schema.jobs.ownerUserId,
+  kind: schema.jobs.kind,
   type: schema.translationJobDetails.type,
   status: schema.jobs.status,
   inputPayload: schema.jobs.inputPayload,
@@ -40,6 +43,16 @@ const jobSelect = {
   lastError: schema.jobs.lastError,
   workflowRunId: schema.jobs.workflowRunId,
   interactionId: schema.jobs.interactionId,
+  contextSnapshot: schema.jobs.contextSnapshot,
+  reviewCriteria: schema.reviewJobDetails.criteria,
+  reviewTargetLocale: schema.reviewJobDetails.targetLocale,
+  reviewConfig: schema.reviewJobDetails.config,
+  syncConnectorKind: schema.syncJobDetails.connectorKind,
+  syncDirection: schema.syncJobDetails.direction,
+  syncExternalIdentifiers: schema.syncJobDetails.externalIdentifiers,
+  assetType: schema.assetManagementJobDetails.assetType,
+  assetOperation: schema.assetManagementJobDetails.operation,
+  assetConfig: schema.assetManagementJobDetails.config,
   createdAt: schema.jobs.createdAt,
   updatedAt: schema.jobs.updatedAt,
   completedAt: schema.jobs.completedAt,
@@ -87,14 +100,14 @@ async function getOwnedJob(projectId: string, jobId: string) {
   const [job] = await db
     .select(jobSelect)
     .from(schema.jobs)
-    .innerJoin(schema.translationJobDetails, eq(schema.translationJobDetails.jobId, schema.jobs.id))
-    .where(
-      and(
-        eq(schema.jobs.kind, "translation"),
-        eq(schema.jobs.projectId, projectId),
-        eq(schema.jobs.id, jobId),
-      ),
+    .leftJoin(schema.translationJobDetails, eq(schema.translationJobDetails.jobId, schema.jobs.id))
+    .leftJoin(schema.reviewJobDetails, eq(schema.reviewJobDetails.jobId, schema.jobs.id))
+    .leftJoin(schema.syncJobDetails, eq(schema.syncJobDetails.jobId, schema.jobs.id))
+    .leftJoin(
+      schema.assetManagementJobDetails,
+      eq(schema.assetManagementJobDetails.jobId, schema.jobs.id),
     )
+    .where(and(eq(schema.jobs.projectId, projectId), eq(schema.jobs.id, jobId)))
     .limit(1);
 
   return job ?? null;
@@ -103,12 +116,13 @@ async function getOwnedJob(projectId: string, jobId: string) {
 function jobListFilters(input: {
   organizationId?: string;
   projectId?: string;
+  kind?: "translation" | "research" | "review" | "sync" | "asset_management";
   type?: "string" | "file";
   status?: "queued" | "running" | "succeeded" | "failed" | "waiting_for_review" | "cancelled";
   mine?: boolean;
   userId?: string;
 }) {
-  const filters = [eq(schema.jobs.kind, "translation")];
+  const filters = [];
 
   if (input.organizationId) {
     filters.push(eq(schema.jobs.organizationId, input.organizationId));
@@ -116,6 +130,10 @@ function jobListFilters(input: {
 
   if (input.projectId) {
     filters.push(eq(schema.jobs.projectId, input.projectId));
+  }
+
+  if (input.kind) {
+    filters.push(eq(schema.jobs.kind, input.kind));
   }
 
   if (input.type) {
@@ -145,6 +163,16 @@ const validateProjectParams = validator("param", (value, c) => {
 
 const validateJobParams = validator("param", (value, c) => {
   const parsed = jobParamsSchema.safeParse(value);
+
+  if (!parsed.success) {
+    return jobNotFoundResponse(c);
+  }
+
+  return parsed.data;
+});
+
+const validateWorkspaceJobParams = validator("param", (value, c) => {
+  const parsed = workspaceJobParamsSchema.safeParse(value);
 
   if (!parsed.success) {
     return jobNotFoundResponse(c);
@@ -186,6 +214,7 @@ export function createJobRoutes(options: CreateJobRoutesOptions) {
 
       const filters = jobListFilters({
         projectId: params.projectId,
+        kind: query.kind,
         type: query.type,
         status: query.status,
         mine: query.mine,
@@ -195,9 +224,15 @@ export function createJobRoutes(options: CreateJobRoutesOptions) {
       const jobs = await db
         .select(jobSelect)
         .from(schema.jobs)
-        .innerJoin(
+        .leftJoin(
           schema.translationJobDetails,
           eq(schema.translationJobDetails.jobId, schema.jobs.id),
+        )
+        .leftJoin(schema.reviewJobDetails, eq(schema.reviewJobDetails.jobId, schema.jobs.id))
+        .leftJoin(schema.syncJobDetails, eq(schema.syncJobDetails.jobId, schema.jobs.id))
+        .leftJoin(
+          schema.assetManagementJobDetails,
+          eq(schema.assetManagementJobDetails.jobId, schema.jobs.id),
         )
         .where(and(...filters))
         .orderBy(desc(schema.jobs.createdAt))
@@ -231,7 +266,7 @@ export function createJobRoutes(options: CreateJobRoutesOptions) {
           return sourceFileNotFoundResponse(c);
         }
 
-        const inferredFileFormat = inferSupportedTranslationFileFormat(sourceFile.filename);
+        const inferredFileFormat = inferSupportedFileTranslationFileFormat(sourceFile.filename);
         if (!inferredFileFormat) {
           return unsupportedSourceFileFormatResponse(c);
         }
@@ -320,6 +355,7 @@ export function createJobRoutes(options: CreateJobRoutesOptions) {
         .select({
           id: schema.jobs.id,
           projectId: schema.jobs.projectId,
+          kind: schema.jobs.kind,
           type: schema.translationJobDetails.type,
           status: schema.jobs.status,
           createdAt: schema.jobs.createdAt,
@@ -328,17 +364,11 @@ export function createJobRoutes(options: CreateJobRoutesOptions) {
           lastError: schema.jobs.lastError,
         })
         .from(schema.jobs)
-        .innerJoin(
+        .leftJoin(
           schema.translationJobDetails,
           eq(schema.translationJobDetails.jobId, schema.jobs.id),
         )
-        .where(
-          and(
-            eq(schema.jobs.kind, "translation"),
-            eq(schema.jobs.projectId, params.projectId),
-            eq(schema.jobs.id, params.jobId),
-          ),
-        )
+        .where(and(eq(schema.jobs.projectId, params.projectId), eq(schema.jobs.id, params.jobId)))
         .limit(1);
 
       if (!job) {
@@ -356,6 +386,7 @@ export function createWorkspaceJobRoutes() {
       const query = c.req.valid("query");
       const filters = jobListFilters({
         organizationId: c.var.auth.organization.localOrganizationId,
+        kind: query.kind,
         type: query.type,
         status: query.status,
         mine: query.mine,
@@ -365,9 +396,15 @@ export function createWorkspaceJobRoutes() {
       const jobs = await db
         .select(jobWithProjectSelect)
         .from(schema.jobs)
-        .innerJoin(
+        .leftJoin(
           schema.translationJobDetails,
           eq(schema.translationJobDetails.jobId, schema.jobs.id),
+        )
+        .leftJoin(schema.reviewJobDetails, eq(schema.reviewJobDetails.jobId, schema.jobs.id))
+        .leftJoin(schema.syncJobDetails, eq(schema.syncJobDetails.jobId, schema.jobs.id))
+        .leftJoin(
+          schema.assetManagementJobDetails,
+          eq(schema.assetManagementJobDetails.jobId, schema.jobs.id),
         )
         .leftJoin(
           schema.projects,
@@ -381,5 +418,41 @@ export function createWorkspaceJobRoutes() {
         .limit(query.limit);
 
       return c.json({ jobs }, 200);
+    })
+    .get("/:jobId", validateWorkspaceJobParams, async (c) => {
+      const params = c.req.valid("param");
+      const [job] = await db
+        .select(jobWithProjectSelect)
+        .from(schema.jobs)
+        .leftJoin(
+          schema.translationJobDetails,
+          eq(schema.translationJobDetails.jobId, schema.jobs.id),
+        )
+        .leftJoin(schema.reviewJobDetails, eq(schema.reviewJobDetails.jobId, schema.jobs.id))
+        .leftJoin(schema.syncJobDetails, eq(schema.syncJobDetails.jobId, schema.jobs.id))
+        .leftJoin(
+          schema.assetManagementJobDetails,
+          eq(schema.assetManagementJobDetails.jobId, schema.jobs.id),
+        )
+        .leftJoin(
+          schema.projects,
+          and(
+            eq(schema.projects.id, schema.jobs.projectId),
+            eq(schema.projects.organizationId, schema.jobs.organizationId),
+          ),
+        )
+        .where(
+          and(
+            eq(schema.jobs.id, params.jobId),
+            eq(schema.jobs.organizationId, c.var.auth.organization.localOrganizationId),
+          ),
+        )
+        .limit(1);
+
+      if (!job) {
+        return jobNotFoundResponse(c);
+      }
+
+      return c.json({ job }, 200);
     });
 }

--- a/apps/hyperlocalise-web/src/api/routes/project/job.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.schema.ts
@@ -12,6 +12,10 @@ export const jobParamsSchema = z.object({
   jobId: z.string().trim().min(1),
 });
 
+export const workspaceJobParamsSchema = z.object({
+  jobId: z.string().trim().min(1),
+});
+
 const metadataSchema = z.record(z.string(), z.string()).optional();
 
 export const stringTranslationJobInputSchema = z.object({
@@ -43,6 +47,7 @@ export const createJobBodySchema = z.discriminatedUnion("type", [
 ]);
 
 export const jobListQuerySchema = z.object({
+  kind: z.enum(schema.jobKindEnum.enumValues).optional(),
   type: z.enum(schema.translationJobTypeEnum.enumValues).optional(),
   status: z.enum(schema.jobStatusEnum.enumValues).optional(),
   mine: z

--- a/apps/hyperlocalise-web/src/api/routes/project/job.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.test.ts
@@ -50,10 +50,11 @@ type ProjectResponse = {
 
 type JobRecord = {
   id: string;
-  projectId: string;
+  projectId: string | null;
   createdByUserId: string | null;
-  type: "string" | "file";
-  status: "queued" | "running" | "succeeded" | "failed";
+  kind: "translation" | "research" | "review" | "sync" | "asset_management";
+  type: "string" | "file" | null;
+  status: "queued" | "running" | "succeeded" | "failed" | "waiting_for_review" | "cancelled";
   inputPayload: Record<string, unknown>;
   outcomeKind: string | null;
   outcomePayload: Record<string, unknown> | null;
@@ -115,6 +116,38 @@ async function insertJob(params: {
 
     return { ...createdJob, type: details.type, outcomeKind: details.outcomeKind };
   });
+
+  return job;
+}
+
+async function insertResearchJob(params: {
+  projectId: string;
+  createdByUserId: string | null;
+  status?: "queued" | "running" | "succeeded" | "failed" | "waiting_for_review" | "cancelled";
+  inputPayload: Record<string, unknown>;
+}) {
+  const [project] = await db
+    .select({ organizationId: schema.projects.organizationId })
+    .from(schema.projects)
+    .where(eq(schema.projects.id, params.projectId))
+    .limit(1);
+
+  if (!project) {
+    throw new Error(`project ${params.projectId} not found`);
+  }
+
+  const [job] = await db
+    .insert(schema.jobs)
+    .values({
+      id: `job_${randomUUID()}`,
+      organizationId: project.organizationId,
+      projectId: params.projectId,
+      createdByUserId: params.createdByUserId,
+      kind: "research",
+      status: params.status ?? "queued",
+      inputPayload: params.inputPayload,
+    })
+    .returning();
 
   return job;
 }
@@ -434,6 +467,63 @@ describe("jobRoutes", () => {
     expect(body.jobs[0]?.projectName).toEqual(expect.any(String));
   });
 
+  it("lists non-translation jobs in project and workspace job feeds", async () => {
+    const identity = createWorkosIdentity();
+    const projectResponse = await createProjectViaApi(identity);
+    const project = ((await projectResponse.json()) as ProjectResponse).project;
+    const localUserId = await getLocalUserId(identity.user.workosUserId);
+    const authHeader = await authHeadersFor(identity);
+
+    const researchJob = await insertResearchJob({
+      projectId: project.id,
+      createdByUserId: localUserId,
+      status: "waiting_for_review",
+      inputPayload: {
+        scope: "cultural reference viability",
+        targetLocales: ["ja-JP"],
+      },
+    });
+
+    const projectJobsResponse = await client.api.project[":projectId"].jobs.$get(
+      {
+        param: { projectId: project.id },
+        query: { kind: "research", mine: "false", limit: "50" },
+      },
+      { headers: authHeader },
+    );
+
+    expect(projectJobsResponse.status).toBe(200);
+    await expect(projectJobsResponse.json()).resolves.toEqual({
+      jobs: [
+        expect.objectContaining({
+          id: researchJob.id,
+          kind: "research",
+          type: null,
+          status: "waiting_for_review",
+        }),
+      ],
+    });
+
+    const workspaceJobResponse = await client.api.orgs[":organizationSlug"].jobs[":jobId"].$get(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          jobId: researchJob.id,
+        },
+      },
+      { headers: authHeader },
+    );
+
+    expect(workspaceJobResponse.status).toBe(200);
+    await expect(workspaceJobResponse.json()).resolves.toEqual({
+      job: expect.objectContaining({
+        id: researchJob.id,
+        kind: "research",
+        projectName: expect.any(String),
+      }),
+    });
+  });
+
   it("returns a full job record and a lightweight status view", async () => {
     const identity = createWorkosIdentity();
     const projectResponse = await createProjectViaApi(identity);
@@ -584,7 +674,7 @@ describe("jobRoutes", () => {
 
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({
-      error: "invalid_job_payload",
+      error: "unsupported_source_file_format",
     });
   });
 
@@ -628,6 +718,40 @@ describe("jobRoutes", () => {
           targetLocales: ["fr-FR"],
         },
       },
+    });
+  });
+
+  it("rejects image file translation jobs until visual asset workers exist", async () => {
+    const identity = createWorkosIdentity();
+    const projectResponse = await createProjectViaApi(identity);
+    const project = ((await projectResponse.json()) as ProjectResponse).project;
+    const sourceFile = await insertStoredSourceFile({
+      projectId: project.id,
+      filename: "banner.png",
+      contentType: "image/png",
+    });
+
+    const response = await client.api.project[":projectId"].jobs.$post(
+      {
+        param: { projectId: project.id },
+        json: {
+          type: "file",
+          fileInput: {
+            sourceFileId: sourceFile.id,
+            fileFormat: "png",
+            sourceLocale: "en-US",
+            targetLocales: ["fr-FR"],
+          },
+        },
+      },
+      {
+        headers: await authHeadersFor(identity),
+      },
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "invalid_job_payload",
     });
   });
 

--- a/apps/hyperlocalise-web/src/api/routes/project/job.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.test.ts
@@ -751,7 +751,7 @@ describe("jobRoutes", () => {
 
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({
-      error: "invalid_job_payload",
+      error: "unsupported_source_file_format",
     });
   });
 

--- a/apps/hyperlocalise-web/src/api/routes/project/job.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.test.ts
@@ -674,7 +674,7 @@ describe("jobRoutes", () => {
 
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({
-      error: "unsupported_source_file_format",
+      error: "invalid_job_payload",
     });
   });
 

--- a/apps/hyperlocalise-web/src/api/routes/public-jobs/public-jobs.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/public-jobs/public-jobs.route.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { validator } from "hono/validator";
+import { z } from "zod";
 
 import {
   apiKeyAuthMiddleware,
@@ -11,10 +12,11 @@ import {
 } from "@/api/auth/api-key";
 import { db, schema } from "@/lib/database";
 import { getStoredFileForJobScope } from "@/lib/file-storage/records";
-import { inferSupportedTranslationFileFormat } from "@/lib/translation/file-formats";
+import {
+  inferSupportedFileTranslationFileFormat,
+  supportedTranslationFileFormats,
+} from "@/lib/translation/file-formats";
 import type { TranslationJobQueue } from "@/lib/workflow/types";
-import { supportedTranslationFileFormats } from "@/lib/translation/file-formats";
-import { z } from "zod";
 
 const createPublicJobBodySchema = z.discriminatedUnion("type", [
   z.object({
@@ -135,7 +137,7 @@ export function createPublicJobRoutes(options: CreatePublicJobRoutesOptions = {}
           return sourceFileNotFoundResponse(c);
         }
 
-        const inferredFileFormat = inferSupportedTranslationFileFormat(sourceFile.filename);
+        const inferredFileFormat = inferSupportedFileTranslationFileFormat(sourceFile.filename);
         if (!inferredFileFormat) {
           return unsupportedSourceFileFormatResponse(c);
         }
@@ -203,6 +205,7 @@ export function createPublicJobRoutes(options: CreatePublicJobRoutesOptions = {}
           id: schema.jobs.id,
           organizationId: schema.jobs.organizationId,
           projectId: schema.jobs.projectId,
+          kind: schema.jobs.kind,
           status: schema.jobs.status,
           type: schema.translationJobDetails.type,
           inputPayload: schema.jobs.inputPayload,
@@ -215,16 +218,12 @@ export function createPublicJobRoutes(options: CreatePublicJobRoutesOptions = {}
           completedAt: schema.jobs.completedAt,
         })
         .from(schema.jobs)
-        .innerJoin(
+        .leftJoin(
           schema.translationJobDetails,
           eq(schema.translationJobDetails.jobId, schema.jobs.id),
         )
         .where(
-          and(
-            eq(schema.jobs.kind, "translation"),
-            eq(schema.jobs.id, params.jobId),
-            eq(schema.jobs.organizationId, organizationId),
-          ),
+          and(eq(schema.jobs.id, params.jobId), eq(schema.jobs.organizationId, organizationId)),
         )
         .limit(1);
 
@@ -242,6 +241,7 @@ export function createPublicJobRoutes(options: CreatePublicJobRoutesOptions = {}
         .select({
           id: schema.jobs.id,
           projectId: schema.jobs.projectId,
+          kind: schema.jobs.kind,
           type: schema.translationJobDetails.type,
           status: schema.jobs.status,
           createdAt: schema.jobs.createdAt,
@@ -250,16 +250,12 @@ export function createPublicJobRoutes(options: CreatePublicJobRoutesOptions = {}
           lastError: schema.jobs.lastError,
         })
         .from(schema.jobs)
-        .innerJoin(
+        .leftJoin(
           schema.translationJobDetails,
           eq(schema.translationJobDetails.jobId, schema.jobs.id),
         )
         .where(
-          and(
-            eq(schema.jobs.kind, "translation"),
-            eq(schema.jobs.id, params.jobId),
-            eq(schema.jobs.organizationId, organizationId),
-          ),
+          and(eq(schema.jobs.id, params.jobId), eq(schema.jobs.organizationId, organizationId)),
         )
         .limit(1);
 

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/chat/_components/chat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/chat/_components/chat-page-content.tsx
@@ -92,10 +92,6 @@ const translationSourceFileAccept = [
   ".strings",
   ".stringsdict",
   ".csv",
-  ".png",
-  ".jpg",
-  ".jpeg",
-  ".webp",
 ].join(",");
 const maxTranslationSourceFiles = 5;
 
@@ -290,9 +286,9 @@ export function ChatPageContent({ organizationSlug }: { organizationSlug: string
                   <DropdownMenuSeparator />
                   <DropdownMenuGroup>
                     {attachOptions.slice(1).map((option) => (
-                      <DropdownMenuItem key={option.label}>
+                      <DropdownMenuItem key={option.label} disabled>
                         <HugeiconsIcon icon={option.icon} strokeWidth={1.8} className="size-4" />
-                        {option.label}
+                        {option.label} (soon)
                       </DropdownMenuItem>
                     ))}
                   </DropdownMenuGroup>

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-details.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-details.tsx
@@ -14,6 +14,14 @@ import {
   type LinkedJob,
 } from "./inbox-types";
 
+function formatJobKind(job: LinkedJob) {
+  if (job.kind === "translation" && job.type) {
+    return job.type;
+  }
+
+  return job.kind.replace("_", " ");
+}
+
 export function ConversationDetails({
   conversation,
   jobs,
@@ -77,7 +85,7 @@ export function ConversationDetails({
             {jobs.map((job) => (
               <a
                 key={job.id}
-                href={`/org/${organizationSlug}/jobs`}
+                href={`/org/${organizationSlug}/jobs/${job.id}`}
                 className="block py-2.5 transition-colors first:pt-0 last:pb-0 hover:text-foreground"
               >
                 <div className="flex items-center justify-between gap-2">
@@ -87,7 +95,7 @@ export function ConversationDetails({
                   </Badge>
                 </div>
                 <div className="mt-1 flex items-center gap-2 text-xs text-muted-foreground">
-                  <span className="uppercase">{job.type}</span>
+                  <span className="uppercase">{formatJobKind(job)}</span>
                   <span className="size-1 rounded-full bg-muted-foreground/20" />
                   <span>{formatRelativeTime(job.createdAt)}</span>
                 </div>

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-types.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-types.ts
@@ -27,9 +27,10 @@ export type ConversationMessage = {
 
 export type LinkedJob = {
   id: string;
-  projectId: string;
-  type: "string" | "file";
-  status: "queued" | "running" | "succeeded" | "failed";
+  projectId: string | null;
+  kind: "translation" | "research" | "review" | "sync" | "asset_management";
+  type: "string" | "file" | null;
+  status: "queued" | "running" | "succeeded" | "failed" | "waiting_for_review" | "cancelled";
   outcomeKind: "string_result" | "file_result" | "error" | null;
   createdAt: string;
   completedAt: string | null;
@@ -64,6 +65,8 @@ export const jobStatusStyles: Record<LinkedJob["status"], string> = {
   running: "bg-beam-500/14 text-beam-100",
   succeeded: "bg-grove-300/14 text-grove-100",
   failed: "bg-flame-500/14 text-flame-100",
+  waiting_for_review: "bg-bud-500/14 text-bud-100",
+  cancelled: "bg-muted text-muted-foreground",
 };
 
 export function formatRelativeTime(value: string | Date | null) {

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-detail-page-content.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowLeft02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useQuery } from "@tanstack/react-query";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { apiClient } from "@/lib/api-client-instance";
+import { cn } from "@/lib/utils";
+
+import { toneClass } from "../../../_components/workspace-resource-shared";
+
+type JobDetail = {
+  id: string;
+  projectId: string | null;
+  projectName: string | null;
+  createdByUserId: string | null;
+  ownerUserId: string | null;
+  kind: "translation" | "research" | "review" | "sync" | "asset_management";
+  type: "string" | "file" | null;
+  status: "queued" | "running" | "succeeded" | "failed" | "waiting_for_review" | "cancelled";
+  inputPayload: unknown;
+  outcomeKind: string | null;
+  outcomePayload: unknown;
+  lastError: string | null;
+  workflowRunId: string | null;
+  interactionId: string | null;
+  contextSnapshot: unknown;
+  reviewCriteria: string | null;
+  reviewTargetLocale: string | null;
+  reviewConfig: unknown;
+  syncConnectorKind: string | null;
+  syncDirection: string | null;
+  syncExternalIdentifiers: unknown;
+  assetType: string | null;
+  assetOperation: string | null;
+  assetConfig: unknown;
+  createdAt: string;
+  updatedAt: string;
+  completedAt: string | null;
+};
+
+function statusTone(status: JobDetail["status"]) {
+  switch (status) {
+    case "succeeded":
+      return "safe";
+    case "failed":
+      return "risk";
+    case "queued":
+    case "waiting_for_review":
+      return "watch";
+    default:
+      return "info";
+  }
+}
+
+function formatKind(job: JobDetail) {
+  if (job.kind === "translation" && job.type) {
+    return `translation · ${job.type}`;
+  }
+
+  return job.kind.replace("_", " ");
+}
+
+function formatDate(value: string | null) {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString();
+}
+
+function JsonBlock({ value }: { value: unknown }) {
+  return (
+    <pre className="max-h-96 overflow-auto rounded-lg border border-white/8 bg-white/[0.035] p-4 text-xs leading-6 text-white/72">
+      {JSON.stringify(value ?? null, null, 2)}
+    </pre>
+  );
+}
+
+function DetailRow({ label, value }: { label: string; value: string | null | undefined }) {
+  return (
+    <div className="grid gap-1 py-3 sm:grid-cols-[12rem_minmax(0,1fr)] sm:gap-4">
+      <dt className="text-sm text-white/42">{label}</dt>
+      <dd className="min-w-0 break-words text-sm text-white/74">{value || "—"}</dd>
+    </div>
+  );
+}
+
+export function JobDetailPageContent({
+  jobId,
+  organizationSlug,
+}: {
+  jobId: string;
+  organizationSlug: string;
+}) {
+  const jobQuery = useQuery({
+    queryKey: ["job", organizationSlug, jobId],
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"].jobs[":jobId"].$get({
+        param: { organizationSlug, jobId },
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to load job (${response.status})`);
+      }
+
+      const body = (await response.json()) as { job: JobDetail };
+      return body.job;
+    },
+  });
+
+  const job = jobQuery.data;
+
+  return (
+    <main className="mx-auto flex w-full max-w-6xl flex-col gap-5">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <Button
+            render={<Link href={`/org/${organizationSlug}/jobs`} />}
+            variant="ghost"
+            className="-ml-2 mb-2 text-white/54 hover:bg-white/6 hover:text-white"
+          >
+            <HugeiconsIcon icon={ArrowLeft02Icon} strokeWidth={1.8} />
+            Jobs
+          </Button>
+          <h1 className="break-words font-heading text-3xl font-semibold text-white md:text-4xl">
+            {job?.id ?? jobId}
+          </h1>
+        </div>
+        {job ? (
+          <Badge
+            variant="outline"
+            className={cn("w-fit rounded-full capitalize", toneClass(statusTone(job.status)))}
+          >
+            {job.status}
+          </Badge>
+        ) : null}
+      </div>
+
+      {jobQuery.isLoading ? (
+        <div className="rounded-lg border border-white/8 bg-[#0b0b0b] p-5">
+          <Skeleton className="h-5 w-48 bg-white/8" />
+          <Skeleton className="mt-4 h-40 w-full bg-white/8" />
+        </div>
+      ) : null}
+
+      {jobQuery.isError ? (
+        <div className="rounded-lg border border-flame-300/20 bg-flame-300/8 p-5 text-sm text-flame-100">
+          {jobQuery.error instanceof Error ? jobQuery.error.message : "Unable to load job"}
+        </div>
+      ) : null}
+
+      {job ? (
+        <>
+          <section className="rounded-lg border border-white/8 bg-[#0b0b0b] p-5">
+            <h2 className="font-heading text-lg font-medium text-white">Overview</h2>
+            <dl className="mt-3 divide-y divide-white/8">
+              <DetailRow label="Kind" value={formatKind(job)} />
+              <DetailRow label="Project" value={job.projectName ?? job.projectId ?? "Workspace"} />
+              <DetailRow label="Interaction" value={job.interactionId} />
+              <DetailRow label="Workflow run" value={job.workflowRunId} />
+              <DetailRow label="Created" value={formatDate(job.createdAt)} />
+              <DetailRow label="Updated" value={formatDate(job.updatedAt)} />
+              <DetailRow label="Completed" value={formatDate(job.completedAt)} />
+              <DetailRow label="Last error" value={job.lastError} />
+            </dl>
+          </section>
+
+          {job.kind === "review" || job.kind === "sync" || job.kind === "asset_management" ? (
+            <section className="rounded-lg border border-white/8 bg-[#0b0b0b] p-5">
+              <h2 className="font-heading text-lg font-medium text-white">Kind Details</h2>
+              <dl className="mt-3 divide-y divide-white/8">
+                {job.kind === "review" ? (
+                  <>
+                    <DetailRow label="Criteria" value={job.reviewCriteria} />
+                    <DetailRow label="Target locale" value={job.reviewTargetLocale} />
+                  </>
+                ) : null}
+                {job.kind === "sync" ? (
+                  <>
+                    <DetailRow label="Connector" value={job.syncConnectorKind} />
+                    <DetailRow label="Direction" value={job.syncDirection} />
+                  </>
+                ) : null}
+                {job.kind === "asset_management" ? (
+                  <>
+                    <DetailRow label="Asset type" value={job.assetType} />
+                    <DetailRow label="Operation" value={job.assetOperation} />
+                  </>
+                ) : null}
+              </dl>
+            </section>
+          ) : null}
+
+          <section className="grid gap-4 xl:grid-cols-2">
+            <div className="rounded-lg border border-white/8 bg-[#0b0b0b] p-5">
+              <h2 className="font-heading text-lg font-medium text-white">Input</h2>
+              <div className="mt-4">
+                <JsonBlock value={job.inputPayload} />
+              </div>
+            </div>
+            <div className="rounded-lg border border-white/8 bg-[#0b0b0b] p-5">
+              <h2 className="font-heading text-lg font-medium text-white">Output</h2>
+              <div className="mt-4">
+                <JsonBlock value={job.outcomePayload} />
+              </div>
+            </div>
+          </section>
+
+          <section className="rounded-lg border border-white/8 bg-[#0b0b0b] p-5">
+            <h2 className="font-heading text-lg font-medium text-white">Context Snapshot</h2>
+            <div className="mt-4">
+              <JsonBlock value={job.contextSnapshot} />
+            </div>
+          </section>
+        </>
+      ) : null}
+    </main>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/page.tsx
@@ -1,0 +1,11 @@
+import { JobDetailPageContent } from "./_components/job-detail-page-content";
+
+export default async function JobDetailPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string; jobId: string }>;
+}) {
+  const { organizationSlug, jobId } = await params;
+
+  return <JobDetailPageContent jobId={jobId} organizationSlug={organizationSlug} />;
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import Link from "next/link";
 import {
   FilterHorizontalIcon,
   MoreHorizontalCircle01Icon,
@@ -28,9 +29,10 @@ type JobsScope = "all" | "mine";
 
 type ApiJob = {
   id: string;
-  projectId: string;
+  projectId: string | null;
   createdByUserId: string | null;
-  type: "string" | "file";
+  kind: "translation" | "research" | "review" | "sync" | "asset_management";
+  type: "string" | "file" | null;
   status: "queued" | "running" | "succeeded" | "failed" | "waiting_for_review" | "cancelled";
   createdAt: string;
   updatedAt: string;
@@ -40,6 +42,12 @@ type ApiJob = {
   inputPayload: unknown;
   outcomeKind: string | null;
   outcomePayload: unknown;
+  reviewCriteria: string | null;
+  reviewTargetLocale: string | null;
+  syncConnectorKind: string | null;
+  syncDirection: string | null;
+  assetType: string | null;
+  assetOperation: string | null;
 };
 
 type JobRow = ApiJob & {
@@ -91,6 +99,28 @@ function formatRelativeTime(value: string | null) {
 }
 
 function getJobName(job: ApiJob) {
+  if (job.kind === "review" && job.reviewCriteria) {
+    return `Review: ${job.reviewCriteria}`.slice(0, 72);
+  }
+
+  if (job.kind === "sync" && job.syncConnectorKind) {
+    return `${job.syncDirection ?? "sync"} ${job.syncConnectorKind}`.slice(0, 72);
+  }
+
+  if (job.kind === "asset_management" && job.assetType) {
+    return `${job.assetOperation ?? "manage"} ${job.assetType}`.slice(0, 72);
+  }
+
+  if (
+    job.kind === "research" &&
+    typeof job.inputPayload === "object" &&
+    job.inputPayload &&
+    "scope" in job.inputPayload &&
+    typeof job.inputPayload.scope === "string"
+  ) {
+    return `Research: ${job.inputPayload.scope}`.slice(0, 72);
+  }
+
   if (
     typeof job.inputPayload === "object" &&
     job.inputPayload &&
@@ -110,6 +140,14 @@ function getJobName(job: ApiJob) {
   }
 
   return job.id;
+}
+
+function formatJobKind(job: ApiJob) {
+  if (job.kind === "translation" && job.type) {
+    return `${job.kind.replace("_", " ")} · ${job.type}`;
+  }
+
+  return job.kind.replace("_", " ");
 }
 
 function JobsStats({ jobs }: { jobs: JobRow[] }) {
@@ -147,10 +185,12 @@ function JobsList({
   emptyLabel,
   isLoading,
   jobs,
+  organizationSlug,
 }: {
   emptyLabel: string;
   isLoading: boolean;
   jobs: JobRow[];
+  organizationSlug: string;
 }) {
   if (isLoading) {
     return <p className="px-3 py-8 text-sm text-white/58">Loading jobs…</p>;
@@ -175,9 +215,11 @@ function JobsList({
             <div className="grid grid-cols-[minmax(18rem,1fr)_minmax(14rem,0.7fr)_9rem_11rem_3rem] items-center gap-4 px-3 py-4">
               <div className="min-w-0">
                 <p className="truncate text-base font-medium text-white">{getJobName(job)}</p>
-                <p className="mt-1 truncate text-xs text-white/38">{job.id}</p>
+                <p className="mt-1 truncate text-xs text-white/38">
+                  {formatJobKind(job)} · {job.id}
+                </p>
               </div>
-              <p className="truncate text-base text-white/58">{job.projectName}</p>
+              <p className="truncate text-base text-white/58">{job.projectName ?? "Workspace"}</p>
               <Badge
                 variant="outline"
                 className={cn("w-fit rounded-full capitalize", toneClass(jobTone(job.status)))}
@@ -187,9 +229,9 @@ function JobsList({
               <p className="text-right text-base text-white/58">
                 {formatRelativeTime(job.updatedAt)}
               </p>
-              <button
-                type="button"
-                aria-label={`Open actions for ${getJobName(job)}`}
+              <Link
+                href={`/org/${organizationSlug}/jobs/${job.id}`}
+                aria-label={`Open ${getJobName(job)}`}
                 className="flex size-9 items-center justify-center rounded-lg text-white/58 transition-colors hover:bg-white/6 hover:text-white"
               >
                 <HugeiconsIcon
@@ -197,7 +239,7 @@ function JobsList({
                   strokeWidth={2}
                   className="size-5"
                 />
-              </button>
+              </Link>
             </div>
             {index < jobs.length - 1 ? <Separator className="bg-white/8" /> : null}
           </div>
@@ -245,7 +287,7 @@ export function JobsPageContent({
       const matchesStatus = statusFilter === "all" || job.status === statusFilter;
       const matchesSearch =
         !normalizedSearch ||
-        [getJobName(job), job.projectName, job.id, job.type, job.status]
+        [getJobName(job), job.projectName, job.id, job.kind, job.type, job.status]
           .join(" ")
           .toLowerCase()
           .includes(normalizedSearch);
@@ -303,7 +345,12 @@ export function JobsPageContent({
 
         {errorMessage ? <p className="text-sm text-flame-100">{errorMessage}</p> : null}
 
-        <JobsList emptyLabel={emptyLabel} isLoading={isLoading} jobs={visibleJobs} />
+        <JobsList
+          emptyLabel={emptyLabel}
+          isLoading={isLoading}
+          jobs={visibleJobs}
+          organizationSlug={organizationSlug}
+        />
       </section>
     </div>
   );

--- a/apps/hyperlocalise-web/src/lib/tools/job-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/job-tools.ts
@@ -255,9 +255,7 @@ export function createTranslationJobTool(ctx: ToolContext) {
         if (inferredFileFormat !== input.fileFormat) {
           return {
             success: false,
-            error: inferredFileFormat
-              ? `fileFormat must match source file extension: expected ${inferredFileFormat}.`
-              : "Source file extension is not supported for translation jobs.",
+            error: `fileFormat must match source file extension: expected ${inferredFileFormat}.`,
           };
         }
       }

--- a/apps/hyperlocalise-web/src/lib/tools/job-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/job-tools.ts
@@ -8,6 +8,7 @@ import { schema } from "@/lib/database";
 import { getStoredFileForJobScope } from "@/lib/file-storage/records";
 import {
   inferSupportedTranslationFileFormat,
+  isImageTranslationFileFormat,
   supportedTranslationFileFormats,
 } from "@/lib/translation/file-formats";
 import { createTranslationJobQueue } from "@/workflows/adapters";
@@ -18,6 +19,20 @@ const jobKinds = ["translation", "research", "review", "sync", "asset_management
 type JobKind = (typeof jobKinds)[number];
 
 const translationJobQueue = createTranslationJobQueue();
+
+export function createUnavailableJobKindTool(capability: string) {
+  return tool({
+    description: `Explain that ${capability} jobs are not available yet. Use this when the user asks Hyperlocalise to create or run that kind of durable job.`,
+    inputSchema: z.object({
+      request: z.string().optional().describe("The user's request, if useful for the response."),
+    }),
+    execute: async () => ({
+      success: false,
+      code: "job_kind_unavailable",
+      error: `${capability} jobs are not available yet. Hyperlocalise can create and run translation jobs today; this request needs a future worker before it can be queued safely.`,
+    }),
+  });
+}
 
 const baseJobSelect = {
   id: schema.jobs.id,
@@ -223,6 +238,20 @@ export function createTranslationJobTool(ctx: ToolContext) {
         }
 
         const inferredFileFormat = inferSupportedTranslationFileFormat(sourceFile.filename);
+        if (!inferredFileFormat) {
+          return {
+            success: false,
+            error: "Source file extension is not supported for translation jobs.",
+          };
+        }
+
+        if (isImageTranslationFileFormat(inferredFileFormat)) {
+          return {
+            success: false,
+            error: "Image files are not supported for file translation jobs yet.",
+          };
+        }
+
         if (inferredFileFormat !== input.fileFormat) {
           return {
             success: false,

--- a/apps/hyperlocalise-web/src/lib/tools/registry.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/registry.ts
@@ -12,7 +12,12 @@ import {
   createUpdateGlossaryTool,
 } from "./glossary-tools";
 import { createReadStoredFileTool } from "./file-tools";
-import { createGetJobStatusTool, createListJobsTool, createTranslationJobTool } from "./job-tools";
+import {
+  createGetJobStatusTool,
+  createListJobsTool,
+  createTranslationJobTool,
+  createUnavailableJobKindTool,
+} from "./job-tools";
 import { createResolveInteractionTool } from "./interaction-tools";
 import {
   createCreateMemoryEntryTool,
@@ -67,9 +72,10 @@ export function buildTools(ctx: ToolContext): ToolSet {
 
     createTranslationJob: createTranslationJobTool(ctx),
     readStoredFile: createReadStoredFileTool(ctx),
-    // Review, research, sync, and asset-management job tools are intentionally
-    // not exposed until workers exist. Registering them now would create
-    // queued jobs that never execute.
+    createReviewJob: createUnavailableJobKindTool("Review"),
+    createResearchJob: createUnavailableJobKindTool("Research"),
+    createSyncJob: createUnavailableJobKindTool("Sync"),
+    createAssetManagementJob: createUnavailableJobKindTool("Asset-management"),
     listJobs: createListJobsTool(ctx),
     getJobStatus: createGetJobStatusTool(ctx),
     resolveInteraction: createResolveInteractionTool(ctx),

--- a/apps/hyperlocalise-web/src/lib/translation/file-formats.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/file-formats.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { inferSupportedTranslationFileFormat, isImageTranslationFileFormat } from "./file-formats";
+import {
+  inferSupportedFileTranslationFileFormat,
+  inferSupportedTranslationFileFormat,
+  isImageTranslationFileFormat,
+} from "./file-formats";
 
 describe("translation file formats", () => {
   it("infers structured translation formats from supported extensions", () => {
@@ -24,6 +28,7 @@ describe("translation file formats", () => {
     expect(inferSupportedTranslationFileFormat("banner.jpg")).toBe("jpeg");
     expect(inferSupportedTranslationFileFormat("banner.jpeg")).toBe("jpeg");
     expect(inferSupportedTranslationFileFormat("banner.webp")).toBe("webp");
+    expect(inferSupportedFileTranslationFileFormat("banner.png")).toBeNull();
     expect(isImageTranslationFileFormat("png")).toBe(true);
     expect(isImageTranslationFileFormat("json")).toBe(false);
   });

--- a/apps/hyperlocalise-web/src/lib/translation/file-formats.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/file-formats.ts
@@ -17,6 +17,23 @@ export const supportedTranslationFileFormats = [
 
 export type SupportedTranslationFileFormat = (typeof supportedTranslationFileFormats)[number];
 
+export const supportedFileTranslationFileFormats = [
+  "json",
+  "jsonc",
+  "arb",
+  "xliff",
+  "po",
+  "html",
+  "markdown",
+  "mdx",
+  "strings",
+  "stringsdict",
+  "csv",
+] as const;
+
+export type SupportedFileTranslationFileFormat =
+  (typeof supportedFileTranslationFileFormats)[number];
+
 const formatsByExtension: Record<string, SupportedTranslationFileFormat> = {
   ".json": "json",
   ".jsonc": "jsonc",
@@ -50,6 +67,12 @@ export function isImageTranslationFileFormat(
   );
 }
 
+export function isSupportedFileTranslationFileFormat(
+  format: SupportedTranslationFileFormat,
+): format is SupportedFileTranslationFileFormat {
+  return supportedFileTranslationFileFormats.includes(format as SupportedFileTranslationFileFormat);
+}
+
 export function inferSupportedTranslationFileFormat(
   filename: string,
 ): SupportedTranslationFileFormat | null {
@@ -59,4 +82,15 @@ export function inferSupportedTranslationFileFormat(
   }
 
   return formatsByExtension[filename.slice(dotIndex).toLowerCase()] ?? null;
+}
+
+export function inferSupportedFileTranslationFileFormat(
+  filename: string,
+): SupportedFileTranslationFileFormat | null {
+  const format = inferSupportedTranslationFileFormat(filename);
+  if (!format || !isSupportedFileTranslationFileFormat(format)) {
+    return null;
+  }
+
+  return format;
 }


### PR DESCRIPTION
## What changed

- Generalized project, workspace, conversation, and public job reads so job surfaces can show translation, review, research, sync, and asset-management jobs instead of translation-only rows.
- Added a workspace job detail route/page so linked inbox jobs open directly to inspect inputs, context, outputs, errors, and workflow state.
- Blocked image uploads from file translation paths until visual asset workers exist, with clearer unavailable responses from API/chat/tool surfaces.
- Registered unavailable review/research/sync/asset job tools so the agent responds honestly instead of silently hiding promised job capabilities.

## How to test

- `vp check --fix`
- `vp test src/lib/translation/file-formats.test.ts`
- `make fmt`
- `make lint`
- `make test`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
