### PR TITLE
fix(web): wrap inbox reply composer in prompt input provider

### DIFF
--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.tsx
@@ -19,6 +19,7 @@ import {
   PromptInputBody,
   PromptInputButton,
   PromptInputFooter,
+  PromptInputProvider,
   PromptInputSubmit,
   PromptInputTextarea,
   PromptInputTools,
@@ -78,19 +79,29 @@ type ApiProject = {
   name: string;
 };
 
-export function ReplyComposer({
-  conversationProjectId,
-  disabled,
-  isStreaming,
-  onSend,
-  organizationSlug,
-}: {
+type ReplyComposerProps = {
   conversationProjectId: string | null;
   disabled: boolean;
   isStreaming: boolean;
   onSend: (text: string, files: File[]) => void | Promise<void>;
   organizationSlug: string;
-}) {
+};
+
+export function ReplyComposer(props: ReplyComposerProps) {
+  return (
+    <PromptInputProvider>
+      <ReplyComposerContent {...props} />
+    </PromptInputProvider>
+  );
+}
+
+function ReplyComposerContent({
+  conversationProjectId,
+  disabled,
+  isStreaming,
+  onSend,
+  organizationSlug,
+}: ReplyComposerProps) {
   const [replyText, setReplyText] = useState("");
   const [selectedProjectId, setSelectedProjectId] = useState(conversationProjectId ?? "");
 


### PR DESCRIPTION
## What changed

Wrapped the inbox reply composer content in `PromptInputProvider` so `usePromptInputAttachments()` is called within the required prompt input context. This fixes the runtime error when opening the chat inbox.

## How to test

- `make fmt`
- `make lint`
- `make test`
- `vp test`
- `vp check --fix`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
