### PR TITLE
refactor(web): remove deprecated translation job queue APIs

### DIFF
--- a/apps/hyperlocalise-web/src/api/app.ts
+++ b/apps/hyperlocalise-web/src/api/app.ts
@@ -4,7 +4,8 @@ import type { FileStorageAdapter } from "@/lib/file-storage";
 import type {
   EmailAgentTaskQueue,
   GitHubFixQueue,
-  TranslationJobQueue,
+  JobQueue,
+  TranslationJobEventData,
 } from "@/lib/workflow/types";
 import { createAgentEmailRoutes } from "./routes/agent-email/agent-email.route";
 import { createApiKeyRoutes } from "./routes/api-key/api-key.route";
@@ -28,12 +29,8 @@ type CreateAppOptions = {
   emailAgentTaskQueue?: EmailAgentTaskQueue;
   githubFixQueue?: GitHubFixQueue;
   githubWebhookHandler?: (request: Request) => Promise<Response>;
-  jobQueue?: TranslationJobQueue;
+  jobQueue?: JobQueue<TranslationJobEventData>;
   fileStorageAdapter?: FileStorageAdapter;
-  /**
-   * @deprecated Use `jobQueue`.
-   */
-  translationJobQueue?: TranslationJobQueue;
 };
 
 export function createApp(options: CreateAppOptions = {}) {

--- a/apps/hyperlocalise-web/src/api/routes/api-key/api-key.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/api-key/api-key.test.ts
@@ -15,10 +15,10 @@ vi.mock("@/api/auth/workos-session", () => ({
 import { createApp } from "@/api/app";
 import { db, schema } from "@/lib/database";
 import { generateApiKey, hashApiKey, getApiKeyPrefix } from "@/lib/api-keys";
-import type { TranslationJobQueue } from "@/lib/workflow/types";
+import type { JobQueue, TranslationJobEventData } from "@/lib/workflow/types";
 import { createProjectTestFixture } from "../project/project.fixture";
 
-function createInlineTestJobQueue(): TranslationJobQueue {
+function createInlineTestJobQueue(): JobQueue<TranslationJobEventData> {
   return {
     async enqueue(event) {
       return { ids: [event.jobId] };

--- a/apps/hyperlocalise-web/src/api/routes/auth.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/auth.test.ts
@@ -11,10 +11,6 @@ const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
   resolveApiAuthContextFromSessionMock: vi.fn(),
 }));
 
-vi.mock("@/lib/translation/translation-job-queued-function", () => ({
-  translationJobQueuedFunction: {},
-}));
-
 async function createClient(
   options: {
     sessionAuthContext?: ApiAuthContext | null;

--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
@@ -8,7 +8,7 @@ import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
 import { db, schema } from "@/lib/database";
 import { getStoredFileForJobScope } from "@/lib/file-storage/records";
 import { inferSupportedFileTranslationFileFormat } from "@/lib/translation/file-formats";
-import type { TranslationJobQueue } from "@/lib/workflow/types";
+import type { JobQueue, TranslationJobEventData } from "@/lib/workflow/types";
 
 import {
   forbiddenResponse,
@@ -25,7 +25,7 @@ import {
 } from "./job.schema";
 
 type CreateJobRoutesOptions = {
-  jobQueue: TranslationJobQueue;
+  jobQueue: JobQueue<TranslationJobEventData>;
 };
 
 const jobSelect = {
@@ -304,6 +304,7 @@ export function createJobRoutes(options: CreateJobRoutesOptions) {
 
       try {
         await options.jobQueue.enqueue({
+          kind: "translation",
           jobId: job.id,
           projectId: job.projectId ?? params.projectId,
           type: job.type,

--- a/apps/hyperlocalise-web/src/api/routes/project/job.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.schema.ts
@@ -59,11 +59,5 @@ export const jobListQuerySchema = z.object({
 });
 
 export type CreateJobBody = z.infer<typeof createJobBodySchema>;
-/**
- * @deprecated Use this only inside the translation job detail/worker path.
- */
 export type StringTranslationJobInput = z.infer<typeof stringTranslationJobInputSchema>;
-/**
- * @deprecated Use this only inside the translation job detail/worker path.
- */
 export type FileTranslationJobInput = z.infer<typeof fileTranslationJobInputSchema>;

--- a/apps/hyperlocalise-web/src/api/routes/project/job.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.test.ts
@@ -8,7 +8,7 @@ import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
 
 import { createApp } from "@/api/app";
 import { db, schema } from "@/lib/database";
-import type { TranslationJobQueue } from "@/lib/workflow/types";
+import type { JobQueue, TranslationJobEventData } from "@/lib/workflow/types";
 import { createProjectTestFixture } from "./project.fixture";
 
 const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
@@ -19,7 +19,7 @@ vi.mock("@/api/auth/workos-session", () => ({
   resolveApiAuthContextFromSession: resolveApiAuthContextFromSessionMock,
 }));
 
-function createInlineTestJobQueue(): TranslationJobQueue {
+function createInlineTestJobQueue(): JobQueue<TranslationJobEventData> {
   return {
     async enqueue(event) {
       return { ids: [event.jobId] };

--- a/apps/hyperlocalise-web/src/api/routes/project/job.workflow.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.workflow.test.ts
@@ -8,10 +8,13 @@ import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
 import { db, schema } from "@/lib/database";
 import { encryptProviderCredential } from "@/lib/security/provider-credential-crypto";
 import {
+  claimTranslationJob,
   completeTranslationJob,
-  createTranslationJobQueuedFunction,
+  executeClaimedTranslationJob,
   failTranslationJob,
 } from "@/lib/translation/translation-job-queued-function";
+import type { StringTranslationGenerator } from "@/lib/translation/string-job-executor";
+import type { TranslationJobEventData } from "@/lib/workflow/types";
 
 import { createProjectTestFixture } from "./project.fixture";
 
@@ -85,7 +88,38 @@ async function insertJob(input: {
   });
 }
 
-describe("executeTranslationJobQueued", () => {
+async function executeTranslationJob(input: {
+  event: TranslationJobEventData;
+  runId: string;
+  translateStringJob?: StringTranslationGenerator;
+}) {
+  const claim = await claimTranslationJob({ event: input.event, runId: input.runId });
+
+  if (claim.kind === "skipped") {
+    return claim.job;
+  }
+
+  const execution = await executeClaimedTranslationJob(claim.job, input.translateStringJob);
+
+  if (!execution.ok) {
+    return failTranslationJob({
+      jobId: claim.job.id,
+      projectId: claim.job.projectId,
+      workflowRunId: claim.job.workflowRunId,
+      code: execution.code,
+      message: execution.message,
+    });
+  }
+
+  return completeTranslationJob({
+    jobId: claim.job.id,
+    projectId: claim.job.projectId,
+    workflowRunId: claim.job.workflowRunId,
+    result: execution.result,
+  });
+}
+
+describe("translation job workflow helpers", () => {
   it("records the workflow run id and completes an existing queued string job", async () => {
     const { project, user } = await projectFixture.createStoredProjectFixture();
     const job = await insertJob({
@@ -101,20 +135,18 @@ describe("executeTranslationJobQueued", () => {
       },
     });
 
-    const executeTranslationJobQueued = createTranslationJobQueuedFunction({
+    const result = await executeTranslationJob({
+      runId: `run_${randomUUID()}`,
+      event: {
+        kind: "translation",
+        jobId: job.id,
+        projectId: project.id,
+        type: "string",
+      },
       async translateStringJob() {
         return {
           translations: [{ locale: "fr-FR", text: "Bonjour le monde" }],
         };
-      },
-    });
-
-    const result = await executeTranslationJobQueued({
-      runId: `run_${randomUUID()}`,
-      event: {
-        jobId: job.id,
-        projectId: project.id,
-        type: "string",
       },
     });
 
@@ -173,17 +205,15 @@ describe("executeTranslationJobQueued", () => {
     const translateStringJob = vi.fn(async () => ({
       translations: [{ locale: "fr-FR", text: "Bonjour le monde" }],
     }));
-    const executeTranslationJobQueued = createTranslationJobQueuedFunction({
-      translateStringJob,
-    });
-
-    const result = await executeTranslationJobQueued({
+    const result = await executeTranslationJob({
       runId: `run_${randomUUID()}`,
       event: {
+        kind: "translation",
         jobId: job.id,
         projectId: project.id,
         type: "string",
       },
+      translateStringJob,
     });
 
     expect(result).toEqual(
@@ -280,10 +310,10 @@ describe("executeTranslationJobQueued", () => {
       },
     });
 
-    const executeTranslationJobQueued = createTranslationJobQueuedFunction();
-    const result = await executeTranslationJobQueued({
+    const result = await executeTranslationJob({
       runId: `run_${randomUUID()}`,
       event: {
+        kind: "translation",
         jobId: job.id,
         projectId: project.id,
         type: "string",
@@ -324,10 +354,10 @@ describe("executeTranslationJobQueued", () => {
       },
     });
 
-    const executeTranslationJobQueued = createTranslationJobQueuedFunction();
-    const result = await executeTranslationJobQueued({
+    const result = await executeTranslationJob({
       runId: `run_${randomUUID()}`,
       event: {
+        kind: "translation",
         jobId: job.id,
         projectId: project.id,
         type: "string",
@@ -365,16 +395,15 @@ describe("executeTranslationJobQueued", () => {
     const translateStringJob = vi.fn(async () => ({
       translations: [{ locale: "fr-FR", text: "Bonjour le monde" }],
     }));
-    const executeTranslationJobQueued = createTranslationJobQueuedFunction({
-      translateStringJob,
-    });
-    const result = await executeTranslationJobQueued({
+    const result = await executeTranslationJob({
       runId: `run_${randomUUID()}`,
       event: {
+        kind: "translation",
         jobId: job.id,
         projectId: project.id,
         type: "string",
       },
+      translateStringJob,
     });
 
     expect(result).toEqual(

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -7,8 +7,8 @@ import { validator } from "hono/validator";
 import { workosAuthMiddleware, type ApiAuthContext, type AuthVariables } from "@/api/auth/workos";
 import { db, schema } from "@/lib/database";
 import type { Project } from "@/lib/database/types";
-import type { TranslationJobQueue } from "@/lib/workflow/types";
-import { createTranslationJobQueue } from "@/workflows/adapters";
+import type { JobQueue, TranslationJobEventData } from "@/lib/workflow/types";
+import { createTranslationJobEventQueue } from "@/workflows/adapters";
 
 import {
   createProjectBodySchema,
@@ -120,15 +120,11 @@ const validateUpdateProjectBody = validator("json", (value, c) => {
 });
 
 type CreateProjectRoutesOptions = {
-  jobQueue?: TranslationJobQueue;
-  /**
-   * @deprecated Use `jobQueue`.
-   */
-  translationJobQueue?: TranslationJobQueue;
+  jobQueue?: JobQueue<TranslationJobEventData>;
 };
 
 export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
-  const jobQueue = options.jobQueue ?? options.translationJobQueue ?? createTranslationJobQueue();
+  const jobQueue = options.jobQueue ?? createTranslationJobEventQueue();
 
   return new Hono<{ Variables: AuthVariables }>()
     .use("*", workosAuthMiddleware)

--- a/apps/hyperlocalise-web/src/api/routes/public-jobs/public-jobs.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/public-jobs/public-jobs.route.ts
@@ -16,7 +16,7 @@ import {
   inferSupportedFileTranslationFileFormat,
   supportedTranslationFileFormats,
 } from "@/lib/translation/file-formats";
-import type { TranslationJobQueue } from "@/lib/workflow/types";
+import type { JobQueue, TranslationJobEventData } from "@/lib/workflow/types";
 
 const createPublicJobBodySchema = z.discriminatedUnion("type", [
   z.object({
@@ -98,7 +98,7 @@ const validateJobIdParams = validator("param", (value, c) => {
 });
 
 type CreatePublicJobRoutesOptions = {
-  jobQueue?: TranslationJobQueue;
+  jobQueue?: JobQueue<TranslationJobEventData>;
 };
 
 export function createPublicJobRoutes(options: CreatePublicJobRoutesOptions = {}) {
@@ -176,6 +176,7 @@ export function createPublicJobRoutes(options: CreatePublicJobRoutesOptions = {}
       if (options.jobQueue) {
         try {
           await options.jobQueue.enqueue({
+            kind: "translation",
             jobId: job.id,
             projectId: payload.projectId,
             type: payload.type,

--- a/apps/hyperlocalise-web/src/api/routes/team/team.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/team/team.test.ts
@@ -11,10 +11,6 @@ const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
   resolveApiAuthContextFromSessionMock: vi.fn(() => globalThis.__testApiAuthContext ?? null),
 }));
 
-vi.mock("@/lib/translation/translation-job-queued-function", () => ({
-  translationJobQueuedFunction: {},
-}));
-
 vi.mock("@/api/auth/workos-session", () => ({
   resolveApiAuthContextFromSession: resolveApiAuthContextFromSessionMock,
 }));

--- a/apps/hyperlocalise-web/src/lib/database/types.ts
+++ b/apps/hyperlocalise-web/src/lib/database/types.ts
@@ -12,8 +12,6 @@ import type {
   teamMemberships,
   teams,
   projects,
-  translationJobOutcomeKindEnum,
-  translationJobTypeEnum,
   interactions,
   inboxItems,
   interactionMessages,
@@ -30,20 +28,6 @@ export type JobKind = (typeof jobKindEnum.enumValues)[number];
 export type JobStatus = (typeof jobStatusEnum.enumValues)[number];
 export type TranslationJobDetails = typeof translationJobDetails.$inferSelect;
 export type NewTranslationJobDetails = typeof translationJobDetails.$inferInsert;
-
-/**
- * @deprecated Prefer `JobKind`, `JobStatus`, and `TranslationJobDetails`.
- * Translation-specific job fields now live in `translation_job_details`.
- */
-export type TranslationJobType = (typeof translationJobTypeEnum.enumValues)[number];
-/**
- * @deprecated Use `JobStatus` for all job lifecycle state.
- */
-export type TranslationJobStatus = JobStatus;
-/**
- * @deprecated Prefer reading `TranslationJobDetails["outcomeKind"]` for translation jobs.
- */
-export type TranslationJobOutcomeKind = (typeof translationJobOutcomeKindEnum.enumValues)[number];
 export type OrganizationMembershipRole = (typeof organizationMembershipRoleEnum.enumValues)[number];
 export type LlmProvider = (typeof llmProviderEnum.enumValues)[number];
 export type OrganizationApiKey = typeof organizationApiKeys.$inferSelect;

--- a/apps/hyperlocalise-web/src/lib/tools/job-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/job-tools.ts
@@ -11,14 +11,14 @@ import {
   isImageTranslationFileFormat,
   supportedTranslationFileFormats,
 } from "@/lib/translation/file-formats";
-import { createTranslationJobQueue } from "@/workflows/adapters";
+import { createTranslationJobEventQueue } from "@/workflows/adapters";
 
 import type { ToolContext } from "./types";
 
 const jobKinds = ["translation", "research", "review", "sync", "asset_management"] as const;
 type JobKind = (typeof jobKinds)[number];
 
-const translationJobQueue = createTranslationJobQueue();
+const jobQueue = createTranslationJobEventQueue();
 
 export function createUnavailableJobKindTool(capability: string) {
   return tool({
@@ -173,7 +173,7 @@ async function createQueuedJob(ctx: ToolContext, input: Parameters<typeof queued
  * 3. Insert into `jobs` table with `kind = "translation"`, `status = "queued"`,
  *    `interactionId` set to the current conversation, `projectId` if available.
  * 4. Insert into `translationJobDetails` with the appropriate `type`.
- * 5. Enqueue the job via the `TranslationJobQueue` adapter (see `job.route.ts`).
+ * 5. Enqueue the job via the translation job queue adapter (see `job.route.ts`).
  * 6. Return the created job ID and status.
  *
  * Example usage: user says "Please translate these release notes into Japanese and Vietnamese."
@@ -302,7 +302,8 @@ export function createTranslationJobTool(ctx: ToolContext) {
       });
 
       try {
-        const result = await translationJobQueue.enqueue({
+        const result = await jobQueue.enqueue({
+          kind: "translation",
           jobId: job.id,
           projectId: ctx.projectId,
           type: input.type,

--- a/apps/hyperlocalise-web/src/lib/translation/translation-job-queued-function.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/translation-job-queued-function.ts
@@ -5,7 +5,7 @@ import {
   type StringTranslationJobInput,
 } from "@/api/routes/project/job.schema";
 import { db, schema } from "@/lib/database";
-import type { TranslationJobQueuedEventData } from "@/lib/workflow/types";
+import type { TranslationJobEventData } from "@/lib/workflow/types";
 import { decryptProviderCredential } from "@/lib/security/provider-credential-crypto";
 import {
   createOpenAIStringTranslationGenerator,
@@ -14,12 +14,8 @@ import {
 } from "@/lib/translation/string-job-executor";
 import { normalizeTranslationMemorySourceText } from "@/lib/translation/normalizeTranslationMemorySourceText";
 
-type CreateTranslationJobQueuedFunctionOptions = {
-  translateStringJob?: StringTranslationGenerator;
-};
-
-type ExecuteTranslationJobQueuedInput = {
-  event: TranslationJobQueuedEventData;
+type ClaimTranslationJobInput = {
+  event: TranslationJobEventData;
   runId: string;
 };
 
@@ -91,10 +87,6 @@ export type TranslationJobExecutionResult =
       code: string;
       message: string;
     };
-
-function formatExecutionError(error: unknown) {
-  return error instanceof Error ? error.message : "translation job execution failed";
-}
 
 function buildTsQuery(input: string): string {
   return input
@@ -312,11 +304,7 @@ async function getStoredJob(jobId: string, projectId: string) {
   return job ? { ...job, projectId: job.projectId ?? projectId } : undefined;
 }
 
-/**
- * @deprecated Use a generic job claim helper for new job workers. This remains
- * scoped to translation jobs while the translation worker is migrated.
- */
-export async function claimTranslationJob(input: ExecuteTranslationJobQueuedInput) {
+export async function claimTranslationJob(input: ClaimTranslationJobInput) {
   const attachedJob = await db
     .update(schema.jobs)
     .set({
@@ -551,9 +539,6 @@ async function loadOrganizationOpenAITranslationGenerator(projectId: string) {
   } as const;
 }
 
-/**
- * @deprecated Use generic job execution dispatch for new job kinds.
- */
 export async function executeClaimedTranslationJob(
   claimedJob: ClaimedTranslationJob,
   translateStringJobOverride?: StringTranslationGenerator,
@@ -634,9 +619,6 @@ export async function executeClaimedTranslationJob(
   };
 }
 
-/**
- * @deprecated Use generic job completion helpers plus type-specific detail updates.
- */
 export async function completeTranslationJob(input: {
   jobId: string;
   projectId: string;
@@ -689,9 +671,6 @@ export async function completeTranslationJob(input: {
   return succeededJob;
 }
 
-/**
- * @deprecated Use generic job failure helpers plus type-specific detail updates.
- */
 export async function failTranslationJob(input: {
   jobId: string;
   projectId: string;
@@ -747,56 +726,3 @@ export async function failTranslationJob(input: {
 
   return failedJob;
 }
-
-/**
- * @deprecated Use a generic queued-job workflow function for new job kinds.
- */
-export function createTranslationJobQueuedFunction(
-  options: CreateTranslationJobQueuedFunctionOptions = {},
-) {
-  const translateStringJob = options.translateStringJob;
-
-  return async ({ event, runId }: ExecuteTranslationJobQueuedInput) => {
-    const claim = await claimTranslationJob({ event, runId });
-
-    if (claim.kind === "skipped") {
-      return claim.job;
-    }
-
-    try {
-      const execution = await executeClaimedTranslationJob(claim.job, translateStringJob);
-
-      if (!execution.ok) {
-        return failTranslationJob({
-          jobId: claim.job.id,
-          projectId: claim.job.projectId,
-          workflowRunId: claim.job.workflowRunId,
-          code: execution.code,
-          message: execution.message,
-        });
-      }
-
-      return completeTranslationJob({
-        jobId: claim.job.id,
-        projectId: claim.job.projectId,
-        workflowRunId: claim.job.workflowRunId,
-        result: execution.result,
-      });
-    } catch (error) {
-      const message = formatExecutionError(error);
-
-      return failTranslationJob({
-        jobId: claim.job.id,
-        projectId: claim.job.projectId,
-        workflowRunId: claim.job.workflowRunId,
-        code: "translation_execution_failed",
-        message,
-      });
-    }
-  };
-}
-
-/**
- * @deprecated Use generic queued-job execution for new job kinds.
- */
-export const executeTranslationJobQueued = createTranslationJobQueuedFunction();

--- a/apps/hyperlocalise-web/src/lib/workflow/ids.ts
+++ b/apps/hyperlocalise-web/src/lib/workflow/ids.ts
@@ -1,7 +1,7 @@
 import type { GitHubReviewTriggerType } from "./types";
 
-export function getTranslationJobQueuedEventId(jobId: string) {
-  return `translation-job-queued:${jobId}`;
+export function getTranslationJobEventId(jobId: string) {
+  return `translation-job:${jobId}`;
 }
 
 export function getGitHubReviewKey(input: {

--- a/apps/hyperlocalise-web/src/lib/workflow/ids.ts
+++ b/apps/hyperlocalise-web/src/lib/workflow/ids.ts
@@ -1,9 +1,5 @@
 import type { GitHubReviewTriggerType } from "./types";
 
-export function getTranslationJobEventId(jobId: string) {
-  return `translation-job:${jobId}`;
-}
-
 export function getGitHubReviewKey(input: {
   repositoryOwner: string;
   repositoryName: string;

--- a/apps/hyperlocalise-web/src/lib/workflow/types.ts
+++ b/apps/hyperlocalise-web/src/lib/workflow/types.ts
@@ -1,12 +1,11 @@
-/**
- * @deprecated Use a generic job-queued event keyed by `kind` for new workflow handlers.
- * This event remains for the current translation worker compatibility path.
- */
-export type TranslationJobQueuedEventData = {
+export type JobEventData<Kind extends string, Type extends string = string> = {
+  kind: Kind;
   jobId: string;
   projectId: string;
-  type: "string" | "file";
+  type: Type;
 };
+
+export type TranslationJobEventData = JobEventData<"translation", "string" | "file">;
 
 export type GitHubReviewTriggerType = "pull_request" | "mention";
 
@@ -58,17 +57,11 @@ export type GitHubFixRequestedEventData = {
   scope: GitHubFixScope;
 };
 
-/**
- * @deprecated Use a generic job queue for new job kinds. This queue is retained
- * for the existing translation worker adapter.
- */
-export type TranslationJobQueue = {
-  enqueue(event: TranslationJobQueuedEventData): Promise<{ ids: string[] }>;
+export type JobQueue<Event> = {
+  enqueue(event: Event): Promise<{ ids: string[] }>;
 };
 
-export type GitHubFixQueue = {
-  enqueue(event: GitHubFixRequestedEventData): Promise<{ ids: string[] }>;
-};
+export type GitHubFixQueue = JobQueue<GitHubFixRequestedEventData>;
 
 export type EmailAgentTaskAttachment = {
   id: string;
@@ -100,6 +93,4 @@ export type EmailAgentTask = {
   };
 };
 
-export type EmailAgentTaskQueue = {
-  enqueue(task: EmailAgentTask): Promise<{ ids: string[] }>;
-};
+export type EmailAgentTaskQueue = JobQueue<EmailAgentTask>;

--- a/apps/hyperlocalise-web/src/workflows/adapters.ts
+++ b/apps/hyperlocalise-web/src/workflows/adapters.ts
@@ -7,10 +7,11 @@ import { translationJobWorkflow } from "./translation-job";
 import type {
   EmailAgentTaskQueue,
   GitHubFixQueue,
-  TranslationJobQueue,
+  JobQueue,
+  TranslationJobEventData,
 } from "@/lib/workflow/types";
 
-export function createTranslationJobQueue(): TranslationJobQueue {
+export function createTranslationJobEventQueue(): JobQueue<TranslationJobEventData> {
   return {
     async enqueue(event) {
       const workflow = event.type === "file" ? fileTranslationJobWorkflow : translationJobWorkflow;

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -18,7 +18,7 @@ import {
   writeFileToSandbox,
   writeTempConfig,
 } from "@/lib/translation/sandbox-translation";
-import type { TranslationJobQueuedEventData } from "@/lib/workflow/types";
+import type { TranslationJobEventData } from "@/lib/workflow/types";
 import {
   claimTranslationJobStep,
   completeFileTranslationJobStep,
@@ -99,7 +99,7 @@ async function logDiagnosticsStep(
   );
 }
 
-export async function fileTranslationJobWorkflow(event: TranslationJobQueuedEventData) {
+export async function fileTranslationJobWorkflow(event: TranslationJobEventData) {
   "use workflow";
 
   const { workflowRunId } = getWorkflowMetadata();

--- a/apps/hyperlocalise-web/src/workflows/steps/translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/translation-job.ts
@@ -12,10 +12,10 @@ import {
   failTranslationJob,
   type ClaimedTranslationJob,
 } from "@/lib/translation/translation-job-queued-function";
-import type { TranslationJobQueuedEventData } from "@/lib/workflow/types";
+import type { TranslationJobEventData } from "@/lib/workflow/types";
 
 export async function claimTranslationJobStep(input: {
-  event: TranslationJobQueuedEventData;
+  event: TranslationJobEventData;
   runId: string;
 }) {
   "use step";

--- a/apps/hyperlocalise-web/src/workflows/translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/translation-job.ts
@@ -1,5 +1,5 @@
 import { getWorkflowMetadata } from "workflow";
-import type { TranslationJobQueuedEventData } from "@/lib/workflow/types";
+import type { TranslationJobEventData } from "@/lib/workflow/types";
 import {
   claimTranslationJobStep,
   completeTranslationJobStep,
@@ -11,7 +11,7 @@ function formatExecutionError(error: unknown) {
   return error instanceof Error ? error.message : "translation job execution failed";
 }
 
-export async function translationJobWorkflow(event: TranslationJobQueuedEventData) {
+export async function translationJobWorkflow(event: TranslationJobEventData) {
   "use workflow";
 
   const { workflowRunId } = getWorkflowMetadata();


### PR DESCRIPTION
## What changed

Removed deprecated translation job queue types, aliases, and legacy queued-function exports from the web app.

This replaces translation-specific queue/event names with generic job event types, removes unused deprecated database aliases, and updates tests to exercise the active translation job helper flow directly.

## How to test

- `vp check --fix`
- `vp test`
- `make fmt`
- `make lint`
- `make test`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
