### PR TITLE
fix(web): add job retry and manual failure actions

### DIFF
--- a/apps/hyperlocalise-web/src/api/app.ts
+++ b/apps/hyperlocalise-web/src/api/app.ts
@@ -24,6 +24,7 @@ import { createResendWebhookRoutes } from "./routes/resend-webhook";
 import { createFileRoutes } from "./routes/file/file.route";
 import { createTeamRoutes } from "./routes/team/team.route";
 import { workosWebhookRoutes } from "./routes/workos-webhook";
+import { createTranslationJobEventQueue } from "@/workflows/adapters";
 
 type CreateAppOptions = {
   emailAgentTaskQueue?: EmailAgentTaskQueue;
@@ -34,15 +35,17 @@ type CreateAppOptions = {
 };
 
 export function createApp(options: CreateAppOptions = {}) {
+  const jobQueue = options.jobQueue ?? createTranslationJobEventQueue();
+
   return new Hono()
     .basePath("/api")
     .route("/auth", authRoutes)
     .route("/glossary", createGlossaryRoutes())
     .route("/orgs/:organizationSlug/glossaries", createGlossaryRoutes())
     .route("/health", healthRoutes)
-    .route("/project", createProjectRoutes(options))
-    .route("/orgs/:organizationSlug/projects", createProjectRoutes(options))
-    .route("/orgs/:organizationSlug/jobs", createWorkspaceJobRoutes())
+    .route("/project", createProjectRoutes({ ...options, jobQueue }))
+    .route("/orgs/:organizationSlug/projects", createProjectRoutes({ ...options, jobQueue }))
+    .route("/orgs/:organizationSlug/jobs", createWorkspaceJobRoutes({ jobQueue }))
     .route("/orgs/:organizationSlug/provider-credential", createProviderCredentialRoutes())
     .route("/orgs/:organizationSlug/agent-email", createAgentEmailRoutes())
     .route("/orgs/:organizationSlug/teams", createTeamRoutes())

--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, or } from "drizzle-orm";
 import { Hono } from "hono";
 import { validator } from "hono/validator";
 
@@ -25,6 +25,10 @@ import {
 } from "./job.schema";
 
 type CreateJobRoutesOptions = {
+  jobQueue: JobQueue<TranslationJobEventData>;
+};
+
+type CreateWorkspaceJobRoutesOptions = {
   jobQueue: JobQueue<TranslationJobEventData>;
 };
 
@@ -77,6 +81,10 @@ function jobNotFoundResponse(c: { json(body: { error: string }, status: 404): Re
 
 function jobQueueUnavailableResponse(c: { json(body: { error: string }, status: 503): Response }) {
   return c.json({ error: "job_queue_unavailable" }, 503);
+}
+
+function jobActionUnavailableResponse(c: { json(body: { error: string }, status: 409): Response }) {
+  return c.json({ error: "job_action_unavailable" }, 409);
 }
 
 function sourceFileNotFoundResponse(c: { json(body: { error: string }, status: 404): Response }) {
@@ -149,6 +157,23 @@ function jobListFilters(input: {
   }
 
   return filters;
+}
+
+function retryableJobWhere(input: { organizationId: string; jobId: string }) {
+  return and(
+    eq(schema.jobs.id, input.jobId),
+    eq(schema.jobs.organizationId, input.organizationId),
+    eq(schema.jobs.kind, "translation"),
+    or(eq(schema.jobs.status, "queued"), eq(schema.jobs.status, "failed")),
+  );
+}
+
+function activeJobWhere(input: { organizationId: string; jobId: string }) {
+  return and(
+    eq(schema.jobs.id, input.jobId),
+    eq(schema.jobs.organizationId, input.organizationId),
+    or(eq(schema.jobs.status, "queued"), eq(schema.jobs.status, "running")),
+  );
 }
 
 const validateProjectParams = validator("param", (value, c) => {
@@ -380,7 +405,7 @@ export function createJobRoutes(options: CreateJobRoutesOptions) {
     });
 }
 
-export function createWorkspaceJobRoutes() {
+export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOptions) {
   return new Hono<{ Variables: AuthVariables }>()
     .use("*", workosAuthMiddleware)
     .get("/", validateJobListQuery, async (c) => {
@@ -453,6 +478,206 @@ export function createWorkspaceJobRoutes() {
       if (!job) {
         return jobNotFoundResponse(c);
       }
+
+      return c.json({ job }, 200);
+    })
+    .post("/:jobId/retry", validateWorkspaceJobParams, async (c) => {
+      if (!isProjectMutationAllowed(c.var.auth.membership.role)) {
+        return forbiddenResponse(c);
+      }
+
+      const params = c.req.valid("param");
+      const [job] = await db
+        .select({
+          id: schema.jobs.id,
+          projectId: schema.jobs.projectId,
+          type: schema.translationJobDetails.type,
+        })
+        .from(schema.jobs)
+        .innerJoin(
+          schema.translationJobDetails,
+          eq(schema.translationJobDetails.jobId, schema.jobs.id),
+        )
+        .where(
+          retryableJobWhere({
+            organizationId: c.var.auth.organization.localOrganizationId,
+            jobId: params.jobId,
+          }),
+        )
+        .limit(1);
+
+      if (!job) {
+        const [existingJob] = await db
+          .select({ id: schema.jobs.id })
+          .from(schema.jobs)
+          .where(
+            and(
+              eq(schema.jobs.id, params.jobId),
+              eq(schema.jobs.organizationId, c.var.auth.organization.localOrganizationId),
+            ),
+          )
+          .limit(1);
+
+        return existingJob ? jobActionUnavailableResponse(c) : jobNotFoundResponse(c);
+      }
+
+      if (!job.projectId || !job.type) {
+        return jobActionUnavailableResponse(c);
+      }
+
+      await db.transaction(async (tx) => {
+        await tx
+          .update(schema.jobs)
+          .set({
+            status: "queued",
+            workflowRunId: null,
+            lastError: null,
+            outcomePayload: null,
+            completedAt: null,
+          })
+          .where(
+            retryableJobWhere({
+              organizationId: c.var.auth.organization.localOrganizationId,
+              jobId: params.jobId,
+            }),
+          );
+
+        await tx
+          .update(schema.translationJobDetails)
+          .set({ outcomeKind: null })
+          .where(eq(schema.translationJobDetails.jobId, params.jobId));
+      });
+
+      try {
+        await options.jobQueue.enqueue({
+          kind: "translation",
+          jobId: job.id,
+          projectId: job.projectId,
+          type: job.type,
+        });
+      } catch (error) {
+        await db
+          .update(schema.jobs)
+          .set({
+            status: "failed",
+            lastError: error instanceof Error ? error.message : "translation job queue unavailable",
+            completedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(schema.jobs.id, params.jobId),
+              eq(schema.jobs.organizationId, c.var.auth.organization.localOrganizationId),
+            ),
+          );
+
+        return jobQueueUnavailableResponse(c);
+      }
+
+      const [updatedJob] = await db
+        .select(jobWithProjectSelect)
+        .from(schema.jobs)
+        .leftJoin(
+          schema.translationJobDetails,
+          eq(schema.translationJobDetails.jobId, schema.jobs.id),
+        )
+        .leftJoin(schema.reviewJobDetails, eq(schema.reviewJobDetails.jobId, schema.jobs.id))
+        .leftJoin(schema.syncJobDetails, eq(schema.syncJobDetails.jobId, schema.jobs.id))
+        .leftJoin(
+          schema.assetManagementJobDetails,
+          eq(schema.assetManagementJobDetails.jobId, schema.jobs.id),
+        )
+        .leftJoin(
+          schema.projects,
+          and(
+            eq(schema.projects.id, schema.jobs.projectId),
+            eq(schema.projects.organizationId, schema.jobs.organizationId),
+          ),
+        )
+        .where(
+          and(
+            eq(schema.jobs.id, params.jobId),
+            eq(schema.jobs.organizationId, c.var.auth.organization.localOrganizationId),
+          ),
+        )
+        .limit(1);
+
+      return c.json({ job: updatedJob }, 200);
+    })
+    .post("/:jobId/mark-failed", validateWorkspaceJobParams, async (c) => {
+      if (!isProjectMutationAllowed(c.var.auth.membership.role)) {
+        return forbiddenResponse(c);
+      }
+
+      const params = c.req.valid("param");
+      const [updatedJob] = await db
+        .update(schema.jobs)
+        .set({
+          status: "failed",
+          workflowRunId: null,
+          lastError: "Marked failed by user",
+          outcomePayload: {
+            code: "manual_failure",
+            message: "Marked failed by user",
+          },
+          completedAt: new Date(),
+        })
+        .where(
+          activeJobWhere({
+            organizationId: c.var.auth.organization.localOrganizationId,
+            jobId: params.jobId,
+          }),
+        )
+        .returning({ id: schema.jobs.id, kind: schema.jobs.kind });
+
+      if (!updatedJob) {
+        const [existingJob] = await db
+          .select({ id: schema.jobs.id })
+          .from(schema.jobs)
+          .where(
+            and(
+              eq(schema.jobs.id, params.jobId),
+              eq(schema.jobs.organizationId, c.var.auth.organization.localOrganizationId),
+            ),
+          )
+          .limit(1);
+
+        return existingJob ? jobActionUnavailableResponse(c) : jobNotFoundResponse(c);
+      }
+
+      if (updatedJob.kind === "translation") {
+        await db
+          .update(schema.translationJobDetails)
+          .set({ outcomeKind: "error" })
+          .where(eq(schema.translationJobDetails.jobId, params.jobId));
+      }
+
+      const [job] = await db
+        .select(jobWithProjectSelect)
+        .from(schema.jobs)
+        .leftJoin(
+          schema.translationJobDetails,
+          eq(schema.translationJobDetails.jobId, schema.jobs.id),
+        )
+        .leftJoin(schema.reviewJobDetails, eq(schema.reviewJobDetails.jobId, schema.jobs.id))
+        .leftJoin(schema.syncJobDetails, eq(schema.syncJobDetails.jobId, schema.jobs.id))
+        .leftJoin(
+          schema.assetManagementJobDetails,
+          eq(schema.assetManagementJobDetails.jobId, schema.jobs.id),
+        )
+        .leftJoin(
+          schema.projects,
+          and(
+            eq(schema.projects.id, schema.jobs.projectId),
+            eq(schema.projects.organizationId, schema.jobs.organizationId),
+          ),
+        )
+        .where(
+          and(
+            eq(schema.jobs.id, params.jobId),
+            eq(schema.jobs.organizationId, c.var.auth.organization.localOrganizationId),
+          ),
+        )
+        .limit(1);
 
       return c.json({ job }, 200);
     });

--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
@@ -525,8 +525,11 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
         return jobActionUnavailableResponse(c);
       }
 
-      await db.transaction(async (tx) => {
-        await tx
+      const projectId = job.projectId;
+      const type = job.type;
+
+      const retriedJob = await db.transaction(async (tx) => {
+        const [updatedJob] = await tx
           .update(schema.jobs)
           .set({
             status: "queued",
@@ -540,20 +543,31 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
               organizationId: c.var.auth.organization.localOrganizationId,
               jobId: params.jobId,
             }),
-          );
+          )
+          .returning({ id: schema.jobs.id, projectId: schema.jobs.projectId });
+
+        if (!updatedJob) {
+          return null;
+        }
 
         await tx
           .update(schema.translationJobDetails)
           .set({ outcomeKind: null })
           .where(eq(schema.translationJobDetails.jobId, params.jobId));
+
+        return { id: updatedJob.id, projectId, type };
       });
+
+      if (!retriedJob) {
+        return jobActionUnavailableResponse(c);
+      }
 
       try {
         await options.jobQueue.enqueue({
           kind: "translation",
-          jobId: job.id,
-          projectId: job.projectId,
-          type: job.type,
+          jobId: retriedJob.id,
+          projectId: retriedJob.projectId,
+          type: retriedJob.type,
         });
       } catch (error) {
         await db

--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
@@ -570,19 +570,27 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
           type: retriedJob.type,
         });
       } catch (error) {
-        await db
-          .update(schema.jobs)
-          .set({
-            status: "failed",
-            lastError: error instanceof Error ? error.message : "translation job queue unavailable",
-            completedAt: new Date(),
-          })
-          .where(
-            and(
-              eq(schema.jobs.id, params.jobId),
-              eq(schema.jobs.organizationId, c.var.auth.organization.localOrganizationId),
-            ),
-          );
+        await db.transaction(async (tx) => {
+          await tx
+            .update(schema.jobs)
+            .set({
+              status: "failed",
+              lastError:
+                error instanceof Error ? error.message : "translation job queue unavailable",
+              completedAt: new Date(),
+            })
+            .where(
+              and(
+                eq(schema.jobs.id, params.jobId),
+                eq(schema.jobs.organizationId, c.var.auth.organization.localOrganizationId),
+              ),
+            );
+
+          await tx
+            .update(schema.translationJobDetails)
+            .set({ outcomeKind: "error" })
+            .where(eq(schema.translationJobDetails.jobId, params.jobId));
+        });
 
         return jobQueueUnavailableResponse(c);
       }

--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
@@ -623,25 +623,36 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
       }
 
       const params = c.req.valid("param");
-      const [updatedJob] = await db
-        .update(schema.jobs)
-        .set({
-          status: "failed",
-          workflowRunId: null,
-          lastError: "Marked failed by user",
-          outcomePayload: {
-            code: "manual_failure",
-            message: "Marked failed by user",
-          },
-          completedAt: new Date(),
-        })
-        .where(
-          activeJobWhere({
-            organizationId: c.var.auth.organization.localOrganizationId,
-            jobId: params.jobId,
-          }),
-        )
-        .returning({ id: schema.jobs.id, kind: schema.jobs.kind });
+      const updatedJob = await db.transaction(async (tx) => {
+        const [job] = await tx
+          .update(schema.jobs)
+          .set({
+            status: "failed",
+            workflowRunId: null,
+            lastError: "Marked failed by user",
+            outcomePayload: {
+              code: "manual_failure",
+              message: "Marked failed by user",
+            },
+            completedAt: new Date(),
+          })
+          .where(
+            activeJobWhere({
+              organizationId: c.var.auth.organization.localOrganizationId,
+              jobId: params.jobId,
+            }),
+          )
+          .returning({ id: schema.jobs.id, kind: schema.jobs.kind });
+
+        if (job?.kind === "translation") {
+          await tx
+            .update(schema.translationJobDetails)
+            .set({ outcomeKind: "error" })
+            .where(eq(schema.translationJobDetails.jobId, params.jobId));
+        }
+
+        return job;
+      });
 
       if (!updatedJob) {
         const [existingJob] = await db
@@ -656,13 +667,6 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
           .limit(1);
 
         return existingJob ? jobActionUnavailableResponse(c) : jobNotFoundResponse(c);
-      }
-
-      if (updatedJob.kind === "translation") {
-        await db
-          .update(schema.translationJobDetails)
-          .set({ outcomeKind: "error" })
-          .where(eq(schema.translationJobDetails.jobId, params.jobId));
       }
 
       const [job] = await db

--- a/apps/hyperlocalise-web/src/api/routes/project/job.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.test.ts
@@ -584,6 +584,124 @@ describe("jobRoutes", () => {
     });
   });
 
+  it("retries a stale queued translation job from workspace job details", async () => {
+    const queuedEvents: TranslationJobEventData[] = [];
+    const retryClient = testClient(
+      createApp({
+        jobQueue: {
+          async enqueue(event) {
+            queuedEvents.push(event);
+            return { ids: [`run_${event.jobId}`] };
+          },
+        },
+      }),
+    );
+    const retryFixture = createProjectTestFixture(retryClient);
+    const identity = retryFixture.createWorkosIdentity();
+    const projectResponse = await retryFixture.createProjectViaApi(identity);
+    const project = ((await projectResponse.json()) as ProjectResponse).project;
+    const localUserId = await retryFixture.getLocalUserId(identity.user.workosUserId);
+    const job = await insertJob({
+      projectId: project.id,
+      createdByUserId: localUserId,
+      type: "string",
+      status: "queued",
+      inputPayload: {
+        sourceText: "Hello world",
+        sourceLocale: "en-US",
+        targetLocales: ["fr-FR"],
+      },
+      outcomeKind: "error",
+      outcomePayload: {
+        code: "workflow_failed",
+        message: "workflow failed before claiming",
+      },
+      lastError: "workflow failed before claiming",
+      workflowRunId: "run_stale",
+    });
+
+    const response = await retryClient.api.orgs[":organizationSlug"].jobs[":jobId"].retry.$post(
+      {
+        param: {
+          organizationSlug: identity.organization.slug!,
+          jobId: job.id,
+        },
+      },
+      {
+        headers: await retryFixture.authHeadersFor(identity),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      job: expect.objectContaining({
+        id: job.id,
+        status: "queued",
+        workflowRunId: null,
+        lastError: null,
+        outcomePayload: null,
+        outcomeKind: null,
+      }),
+    });
+    expect(queuedEvents).toEqual([
+      {
+        kind: "translation",
+        jobId: job.id,
+        projectId: project.id,
+        type: "string",
+      },
+    ]);
+
+    await retryFixture.cleanup();
+  });
+
+  it("marks an active workspace job as failed", async () => {
+    const identity = createWorkosIdentity();
+    const projectResponse = await createProjectViaApi(identity);
+    const project = ((await projectResponse.json()) as ProjectResponse).project;
+    const localUserId = await getLocalUserId(identity.user.workosUserId);
+    const job = await insertJob({
+      projectId: project.id,
+      createdByUserId: localUserId,
+      type: "string",
+      status: "running",
+      inputPayload: {
+        sourceText: "Hello world",
+        sourceLocale: "en-US",
+        targetLocales: ["fr-FR"],
+      },
+      workflowRunId: "run_active",
+    });
+
+    const response = await client.api.orgs[":organizationSlug"].jobs[":jobId"]["mark-failed"].$post(
+      {
+        param: {
+          organizationSlug: identity.organization.slug!,
+          jobId: job.id,
+        },
+      },
+      {
+        headers: await authHeadersFor(identity),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      job: expect.objectContaining({
+        id: job.id,
+        status: "failed",
+        workflowRunId: null,
+        lastError: "Marked failed by user",
+        outcomeKind: "error",
+        outcomePayload: {
+          code: "manual_failure",
+          message: "Marked failed by user",
+        },
+        completedAt: expect.any(String),
+      }),
+    });
+  });
+
   it("returns 403 when a member creates a translation job", async () => {
     const ownerIdentity = createWorkosIdentity();
     const projectResponse = await createProjectViaApi(ownerIdentity);

--- a/apps/hyperlocalise-web/src/api/routes/project/job.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.test.ts
@@ -655,6 +655,85 @@ describe("jobRoutes", () => {
     await retryFixture.cleanup();
   });
 
+  it("does not clear details or enqueue when a retryable job is claimed concurrently", async () => {
+    const queuedEvents: TranslationJobEventData[] = [];
+    const retryClient = testClient(
+      createApp({
+        jobQueue: {
+          async enqueue(event) {
+            queuedEvents.push(event);
+            return { ids: [`run_${event.jobId}`] };
+          },
+        },
+      }),
+    );
+    const retryFixture = createProjectTestFixture(retryClient);
+    const identity = retryFixture.createWorkosIdentity();
+    const projectResponse = await retryFixture.createProjectViaApi(identity);
+    const project = ((await projectResponse.json()) as ProjectResponse).project;
+    const localUserId = await retryFixture.getLocalUserId(identity.user.workosUserId);
+    const job = await insertJob({
+      projectId: project.id,
+      createdByUserId: localUserId,
+      type: "string",
+      status: "queued",
+      inputPayload: {
+        sourceText: "Hello world",
+        sourceLocale: "en-US",
+        targetLocales: ["fr-FR"],
+      },
+      outcomeKind: "error",
+      outcomePayload: {
+        code: "workflow_failed",
+        message: "workflow failed before claiming",
+      },
+      lastError: "workflow failed before claiming",
+      workflowRunId: "run_stale",
+    });
+    const originalTransaction = db.transaction.bind(db);
+    const transactionSpy = vi.spyOn(db, "transaction").mockImplementation(async (callback) => {
+      await db.update(schema.jobs).set({ status: "running" }).where(eq(schema.jobs.id, job.id));
+
+      return originalTransaction(callback);
+    });
+
+    try {
+      const response = await retryClient.api.orgs[":organizationSlug"].jobs[":jobId"].retry.$post(
+        {
+          param: {
+            organizationSlug: identity.organization.slug!,
+            jobId: job.id,
+          },
+        },
+        {
+          headers: await retryFixture.authHeadersFor(identity),
+        },
+      );
+
+      expect(response.status).toBe(409);
+      await expect(response.json()).resolves.toEqual({ error: "job_action_unavailable" });
+      expect(queuedEvents).toEqual([]);
+
+      const [details] = await db
+        .select({
+          status: schema.jobs.status,
+          outcomeKind: schema.translationJobDetails.outcomeKind,
+        })
+        .from(schema.jobs)
+        .innerJoin(
+          schema.translationJobDetails,
+          eq(schema.translationJobDetails.jobId, schema.jobs.id),
+        )
+        .where(eq(schema.jobs.id, job.id))
+        .limit(1);
+
+      expect(details).toEqual({ status: "running", outcomeKind: "error" });
+    } finally {
+      transactionSpy.mockRestore();
+      await retryFixture.cleanup();
+    }
+  });
+
   it("marks an active workspace job as failed", async () => {
     const identity = createWorkosIdentity();
     const projectResponse = await createProjectViaApi(identity);

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-detail-page-content.tsx
@@ -342,7 +342,14 @@ export function JobDetailPageContent({
         </>
       ) : null}
 
-      <AlertDialog open={markFailedDialogOpen} onOpenChange={setMarkFailedDialogOpen}>
+      <AlertDialog
+        open={markFailedDialogOpen}
+        onOpenChange={(open) => {
+          if (!markJobFailed.isPending) {
+            setMarkFailedDialogOpen(open);
+          }
+        }}
+      >
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>Mark job as failed?</AlertDialogTitle>

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-detail-page-content.tsx
@@ -1,18 +1,29 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
-import { ArrowLeft02Icon } from "@hugeicons/core-free-icons";
+import { ArrowLeft02Icon, RefreshIcon, StopCircleIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { TypographyH1, TypographyH2 } from "@/components/ui/typography";
 import { apiClient } from "@/lib/api-client-instance";
 import { cn } from "@/lib/utils";
 
 import { toneClass } from "../../../_components/workspace-resource-shared";
-import { TypographyH1, TypographyH2 } from "@/components/ui/typography";
 
 type JobDetail = {
   id: string;
@@ -81,6 +92,27 @@ function JsonBlock({ value }: { value: unknown }) {
   );
 }
 
+function canRetryJob(job: JobDetail) {
+  return job.kind === "translation" && (job.status === "queued" || job.status === "failed");
+}
+
+function canMarkJobFailed(job: JobDetail) {
+  return job.status === "queued" || job.status === "running";
+}
+
+async function parseActionError(response: Response, fallback: string) {
+  let error: string | undefined;
+
+  try {
+    const body = (await response.json()) as { error?: string };
+    error = body.error;
+  } catch {
+    error = undefined;
+  }
+
+  return error ? `${fallback}: ${error}` : `${fallback} (${response.status})`;
+}
+
 function DetailRow({ label, value }: { label: string; value: string | null | undefined }) {
   return (
     <div className="grid gap-1 py-3 sm:grid-cols-[12rem_minmax(0,1fr)] sm:gap-4">
@@ -97,8 +129,11 @@ export function JobDetailPageContent({
   jobId: string;
   organizationSlug: string;
 }) {
+  const [markFailedDialogOpen, setMarkFailedDialogOpen] = useState(false);
+  const queryClient = useQueryClient();
+  const jobQueryKey = ["job", organizationSlug, jobId] as const;
   const jobQuery = useQuery({
-    queryKey: ["job", organizationSlug, jobId],
+    queryKey: jobQueryKey,
     queryFn: async () => {
       const response = await apiClient.api.orgs[":organizationSlug"].jobs[":jobId"].$get({
         param: { organizationSlug, jobId },
@@ -113,7 +148,57 @@ export function JobDetailPageContent({
     },
   });
 
+  const retryJob = useMutation({
+    mutationFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"].jobs[":jobId"].retry.$post({
+        param: { organizationSlug, jobId },
+      });
+
+      if (!response.ok) {
+        throw new Error(await parseActionError(response, "Failed to retry job"));
+      }
+
+      const body = (await response.json()) as { job: JobDetail };
+      return body.job;
+    },
+    onSuccess: async (updatedJob) => {
+      queryClient.setQueryData(jobQueryKey, updatedJob);
+      await queryClient.invalidateQueries({ queryKey: ["jobs", organizationSlug] });
+      toast.success("Job queued for retry");
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Failed to retry job");
+    },
+  });
+
+  const markJobFailed = useMutation({
+    mutationFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"].jobs[":jobId"][
+        "mark-failed"
+      ].$post({
+        param: { organizationSlug, jobId },
+      });
+
+      if (!response.ok) {
+        throw new Error(await parseActionError(response, "Failed to mark job as failed"));
+      }
+
+      const body = (await response.json()) as { job: JobDetail };
+      return body.job;
+    },
+    onSuccess: async (updatedJob) => {
+      queryClient.setQueryData(jobQueryKey, updatedJob);
+      await queryClient.invalidateQueries({ queryKey: ["jobs", organizationSlug] });
+      setMarkFailedDialogOpen(false);
+      toast.success("Job marked as failed");
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Failed to mark job as failed");
+    },
+  });
+
   const job = jobQuery.data;
+  const showActions = job ? canRetryJob(job) || canMarkJobFailed(job) : false;
 
   return (
     <main className="mx-auto flex w-full max-w-6xl flex-col gap-5">
@@ -132,12 +217,39 @@ export function JobDetailPageContent({
           </TypographyH1>
         </div>
         {job ? (
-          <Badge
-            variant="outline"
-            className={cn("w-fit rounded-full capitalize", toneClass(statusTone(job.status)))}
-          >
-            {job.status}
-          </Badge>
+          <div className="flex flex-col items-start gap-3 sm:items-end">
+            <Badge
+              variant="outline"
+              className={cn("w-fit rounded-full capitalize", toneClass(statusTone(job.status)))}
+            >
+              {job.status}
+            </Badge>
+            {showActions ? (
+              <div className="flex flex-wrap gap-2 sm:justify-end">
+                {canRetryJob(job) ? (
+                  <Button
+                    size="sm"
+                    disabled={retryJob.isPending || markJobFailed.isPending}
+                    onClick={() => retryJob.mutate()}
+                  >
+                    <HugeiconsIcon icon={RefreshIcon} strokeWidth={1.8} />
+                    {retryJob.isPending ? "Retrying..." : "Retry job"}
+                  </Button>
+                ) : null}
+                {canMarkJobFailed(job) ? (
+                  <Button
+                    size="sm"
+                    variant="destructive"
+                    disabled={retryJob.isPending || markJobFailed.isPending}
+                    onClick={() => setMarkFailedDialogOpen(true)}
+                  >
+                    <HugeiconsIcon icon={StopCircleIcon} strokeWidth={1.8} />
+                    Mark as failed
+                  </Button>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
         ) : null}
       </div>
 
@@ -229,6 +341,29 @@ export function JobDetailPageContent({
           </section>
         </>
       ) : null}
+
+      <AlertDialog open={markFailedDialogOpen} onOpenChange={setMarkFailedDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Mark job as failed?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will stop the job from appearing queued or running and prevent the current
+              workflow run from updating it later.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={markJobFailed.isPending}>Cancel</AlertDialogCancel>
+            <Button
+              variant="destructive"
+              disabled={markJobFailed.isPending}
+              onClick={() => markJobFailed.mutate()}
+            >
+              <HugeiconsIcon icon={StopCircleIcon} strokeWidth={1.8} />
+              {markJobFailed.isPending ? "Marking..." : "Mark failed"}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </main>
   );
 }


### PR DESCRIPTION
## What changed

Added job recovery actions to the web job detail page so stuck queued or running jobs can be handled from the UI.

- Added `Retry job` for queued or failed translation jobs
- Added confirmed `Mark as failed` for queued or running jobs
- Clears stale `workflowRunId` state when retrying or manually failing a job
- Re-enqueues retried translation jobs through the existing job queue
- Added API route coverage for stale queued retry and active job manual failure

## How to test

- `vp check --fix`
- `vp test`
- `make fmt`
- `make lint`
- `make test`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
