### PR TITLE
feat(cli): crowdin download approved only

### DIFF
--- a/apps/cli/cmd/crowdin.go
+++ b/apps/cli/cmd/crowdin.go
@@ -244,7 +244,7 @@ func crowdinstorageRequestDownload(cfg storage.FileWorkflowConfig, languages []s
 		overrides.SkipUntranslatedStrings = &skipUntranslatedStrings
 	}
 	req := storage.FileDownloadTranslationsRequest{Config: cfg, Languages: languages, MergeApproved: mergeApproved}
-	if overrides.ExportOnlyApproved != nil || overrides.SkipUntranslatedStrings != nil || overrides.SkipUntranslatedFiles != nil {
+	if overrides.ExportOnlyApproved != nil || overrides.SkipUntranslatedStrings != nil {
 		req.ExportOverrides = &overrides
 	}
 	return req

--- a/apps/cli/cmd/crowdin.go
+++ b/apps/cli/cmd/crowdin.go
@@ -17,11 +17,14 @@ const crowdinTemplateFilename = "crowdin.yml"
 var crowdinTemplateFS embed.FS
 
 type crowdinCommonOptions struct {
-	configPath   string
-	identityPath string
-	branch       string
-	languages    []string
-	dryRun       bool
+	configPath              string
+	identityPath            string
+	branch                  string
+	languages               []string
+	exportOnlyApproved      bool
+	skipUntranslatedStrings bool
+	mergeApproved           bool
+	dryRun                  bool
 }
 
 func newCrowdinCmd() *cobra.Command {
@@ -171,18 +174,21 @@ func newCrowdinDownloadCmd() *cobra.Command {
 				return err
 			}
 			if o.dryRun {
-				_, err := fmt.Fprintf(cmd.OutOrStdout(), "dry-run action=download-translations files=%d languages=%s\n", len(cfg.Files), strings.Join(o.languages, ","))
+				_, err := fmt.Fprintf(cmd.OutOrStdout(), "dry-run action=download-translations files=%d languages=%s export_only_approved=%t skip_untranslated_strings=%t merge_approved=%t\n", len(cfg.Files), strings.Join(o.languages, ","), o.exportOnlyApproved, o.skipUntranslatedStrings, o.mergeApproved)
 				return err
 			}
 			adapter, err := crowdinstorage.NewFileAdapter(cfg)
 			if err != nil {
 				return err
 			}
-			result, err := adapter.DownloadTranslations(backgroundContext(), crowdinstorageRequestDownload(cfg, o.languages, o.branch))
+			result, err := adapter.DownloadTranslations(backgroundContext(), crowdinstorageRequestDownload(cfg, o.languages, o.branch, o.exportOnlyApproved, o.skipUntranslatedStrings, o.mergeApproved))
 			return writeCrowdinResultError(cmd, "download-translations", result, err)
 		},
 	}
 	addCrowdinCommonFlags(cmd, &o, true, true)
+	cmd.Flags().BoolVar(&o.exportOnlyApproved, "export-only-approved", false, "download approved translations only")
+	cmd.Flags().BoolVar(&o.skipUntranslatedStrings, "skip-untranslated-strings", false, "omit untranslated strings from downloaded files")
+	cmd.Flags().BoolVar(&o.mergeApproved, "merge-approved", false, "merge approved downloaded JSON strings into existing translation files")
 	return cmd
 }
 
@@ -228,9 +234,20 @@ func crowdinstorageRequestTranslations(cfg storage.FileWorkflowConfig, languages
 	return storage.FileUploadTranslationsRequest{Config: cfg, Languages: languages}
 }
 
-func crowdinstorageRequestDownload(cfg storage.FileWorkflowConfig, languages []string, branch string) storage.FileDownloadTranslationsRequest {
+func crowdinstorageRequestDownload(cfg storage.FileWorkflowConfig, languages []string, branch string, exportOnlyApproved, skipUntranslatedStrings, mergeApproved bool) storage.FileDownloadTranslationsRequest {
 	cfg = overrideCrowdinBranch(cfg, branch)
-	return storage.FileDownloadTranslationsRequest{Config: cfg, Languages: languages}
+	overrides := storage.FileExportOptions{}
+	if exportOnlyApproved {
+		overrides.ExportOnlyApproved = &exportOnlyApproved
+	}
+	if skipUntranslatedStrings {
+		overrides.SkipUntranslatedStrings = &skipUntranslatedStrings
+	}
+	req := storage.FileDownloadTranslationsRequest{Config: cfg, Languages: languages, MergeApproved: mergeApproved}
+	if overrides.ExportOnlyApproved != nil || overrides.SkipUntranslatedStrings != nil || overrides.SkipUntranslatedFiles != nil {
+		req.ExportOverrides = &overrides
+	}
+	return req
 }
 
 func overrideCrowdinBranch(cfg storage.FileWorkflowConfig, branch string) storage.FileWorkflowConfig {

--- a/apps/cli/cmd/crowdin_test.go
+++ b/apps/cli/cmd/crowdin_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -154,9 +155,41 @@ func TestCrowdinBranchOverrideAppliesToRequests(t *testing.T) {
 		t.Fatalf("translation branch = %q, want config-branch", translationsReq.Config.Branch)
 	}
 
-	downloadReq := crowdinstorageRequestDownload(cfg, nil, "  flag-branch  ")
+	downloadReq := crowdinstorageRequestDownload(cfg, nil, "  flag-branch  ", false, false, false)
 	if downloadReq.Config.Branch != "flag-branch" {
 		t.Fatalf("download branch = %q, want trimmed flag-branch", downloadReq.Config.Branch)
+	}
+}
+
+func TestCrowdinDownloadFlagsApplyRequestOptions(t *testing.T) {
+	cfg := storage.FileWorkflowConfig{}
+
+	req := crowdinstorageRequestDownload(cfg, []string{"fr"}, "", true, true, true)
+
+	if got, want := req.Languages, []string{"fr"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("languages = %#v, want %#v", got, want)
+	}
+	if req.ExportOverrides.ExportOnlyApproved == nil || !*req.ExportOverrides.ExportOnlyApproved {
+		t.Fatalf("export only approved = %#v, want true", req.ExportOverrides.ExportOnlyApproved)
+	}
+	if req.ExportOverrides.SkipUntranslatedStrings == nil || !*req.ExportOverrides.SkipUntranslatedStrings {
+		t.Fatalf("skip untranslated strings = %#v, want true", req.ExportOverrides.SkipUntranslatedStrings)
+	}
+	if !req.MergeApproved {
+		t.Fatalf("merge approved = false, want true")
+	}
+}
+
+func TestCrowdinDownloadFlagsOmitRequestOptionsWhenUnset(t *testing.T) {
+	cfg := storage.FileWorkflowConfig{}
+
+	req := crowdinstorageRequestDownload(cfg, nil, "", false, false, false)
+
+	if req.ExportOverrides != nil {
+		t.Fatalf("export overrides = %#v, want nil", req.ExportOverrides)
+	}
+	if req.MergeApproved {
+		t.Fatalf("merge approved = true, want false")
 	}
 }
 

--- a/docs/commands/crowdin.mdx
+++ b/docs/commands/crowdin.mdx
@@ -10,7 +10,7 @@ hyperlocalise crowdin init
 hyperlocalise crowdin config validate [--config <path>] [--identity <path>]
 hyperlocalise crowdin upload sources [--config <path>] [--identity <path>] [--branch <name>]
 hyperlocalise crowdin upload translations [--config <path>] [--identity <path>] [--branch <name>] [--language <locale>]
-hyperlocalise crowdin download [--config <path>] [--identity <path>] [--branch <name>] [--language <locale>]
+hyperlocalise crowdin download [--config <path>] [--identity <path>] [--branch <name>] [--language <locale>] [--export-only-approved] [--skip-untranslated-strings] [--merge-approved]
 ```
 
 ## What this command family does
@@ -94,13 +94,24 @@ hyperlocalise crowdin upload sources --branch feature/login
 
 Download only approved French translations:
 
+```bash
+hyperlocalise crowdin download --language fr --export-only-approved --skip-untranslated-strings
+```
+
+Or configure the export behavior in `crowdin.yml`:
+
 ```yaml
 files:
   - source: /src/messages.json
     translation: /locales/%locale%/%original_file_name%
     export_only_approved: true
+    skip_untranslated_strings: true
 ```
 
+Merge approved JSON strings into the existing local translation file without deleting local keys that are absent from the approved export:
+
 ```bash
-hyperlocalise crowdin download --language fr
+hyperlocalise crowdin download --language fr --merge-approved
 ```
+
+`--merge-approved` currently supports JSON object translation files. It forces an approved-only sparse export for the request, then overwrites only keys present in the approved Crowdin payload.

--- a/docs/storage/crowdin.mdx
+++ b/docs/storage/crowdin.mdx
@@ -98,8 +98,11 @@ hyperlocalise crowdin init
 hyperlocalise crowdin config validate
 hyperlocalise crowdin upload sources
 hyperlocalise crowdin upload translations --language fr
-hyperlocalise crowdin download --language fr
+hyperlocalise crowdin download --language fr --export-only-approved --skip-untranslated-strings
+hyperlocalise crowdin download --language fr --merge-approved
 ```
+
+`--merge-approved` merges approved JSON object keys into existing local translation files and preserves local keys omitted from Crowdin's approved export.
 
 Use root `branch:` in `crowdin.yml` or pass `--branch <name>` to upload and download files from a Crowdin branch. The flag overrides the config value for that command.
 

--- a/internal/i18n/storage/crowdin/filemode.go
+++ b/internal/i18n/storage/crowdin/filemode.go
@@ -1,14 +1,17 @@
 package crowdin
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/hyperlocalise/hyperlocalise/internal/i18n/storage"
@@ -253,8 +256,8 @@ func effectiveFileExportOptions(base storage.FileExportOptions, overrides *stora
 }
 
 func mergeApprovedJSONFile(targetPath string, approvedPayload []byte) ([]byte, error) {
-	approved := make(map[string]any)
-	if err := json.Unmarshal(approvedPayload, &approved); err != nil {
+	approved, err := decodeOrderedJSONObject(approvedPayload)
+	if err != nil {
 		return nil, fmt.Errorf("merge approved translations: downloaded payload for %s must be a JSON object: %w", targetPath, err)
 	}
 	if len(approved) == 0 {
@@ -265,23 +268,159 @@ func mergeApprovedJSONFile(targetPath string, approvedPayload []byte) ([]byte, e
 		}
 	}
 
-	merged := make(map[string]any)
+	var merged orderedJSONObject
 	if existing, err := os.ReadFile(targetPath); err == nil {
-		if err := json.Unmarshal(existing, &merged); err != nil {
+		merged, err = decodeOrderedJSONObject(existing)
+		if err != nil {
 			return nil, fmt.Errorf("merge approved translations: existing file %s must be a JSON object: %w", targetPath, err)
 		}
 	} else if !os.IsNotExist(err) {
 		return nil, fmt.Errorf("merge approved translations: read existing translation file: %w", err)
 	}
 
-	for key, value := range approved {
-		merged[key] = value
-	}
-	payload, err := json.MarshalIndent(merged, "", "  ")
+	merged, err = mergeOrderedJSONObjects(merged, approved)
 	if err != nil {
-		return nil, fmt.Errorf("merge approved translations: encode merged JSON: %w", err)
+		return nil, fmt.Errorf("merge approved translations: merge nested JSON objects: %w", err)
 	}
+	payload := formatOrderedJSONObject(merged, 0)
 	return append(payload, '\n'), nil
+}
+
+type orderedJSONMember struct {
+	key   string
+	value json.RawMessage
+}
+
+type orderedJSONObject []orderedJSONMember
+
+func decodeOrderedJSONObject(payload []byte) (orderedJSONObject, error) {
+	dec := json.NewDecoder(bytes.NewReader(payload))
+
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, err
+	}
+	delim, ok := tok.(json.Delim)
+	if !ok || delim != '{' {
+		return nil, fmt.Errorf("root value is %T, not object", tok)
+	}
+
+	var obj orderedJSONObject
+	for dec.More() {
+		tok, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		key, ok := tok.(string)
+		if !ok {
+			return nil, fmt.Errorf("object key is %T, not string", tok)
+		}
+		var value json.RawMessage
+		if err := dec.Decode(&value); err != nil {
+			return nil, err
+		}
+		obj = append(obj, orderedJSONMember{key: key, value: value})
+	}
+
+	tok, err = dec.Token()
+	if err != nil {
+		return nil, err
+	}
+	delim, ok = tok.(json.Delim)
+	if !ok || delim != '}' {
+		return nil, fmt.Errorf("object is not closed")
+	}
+	if _, err := dec.Token(); err != io.EOF {
+		if err == nil {
+			return nil, fmt.Errorf("payload contains trailing JSON tokens")
+		}
+		return nil, err
+	}
+	return obj, nil
+}
+
+func mergeOrderedJSONObjects(existing, approved orderedJSONObject) (orderedJSONObject, error) {
+	merged := append(orderedJSONObject(nil), existing...)
+	for _, approvedMember := range approved {
+		existingIndex := orderedJSONObjectIndex(merged, approvedMember.key)
+		if existingIndex == -1 {
+			merged = append(merged, orderedJSONMember{key: approvedMember.key, value: append(json.RawMessage(nil), approvedMember.value...)})
+			continue
+		}
+		existingMember := merged[existingIndex]
+		if !isJSONObject(existingMember.value) || !isJSONObject(approvedMember.value) {
+			merged[existingIndex].value = append(json.RawMessage(nil), approvedMember.value...)
+			continue
+		}
+		existingObject, err := decodeOrderedJSONObject(existingMember.value)
+		if err != nil {
+			return nil, err
+		}
+		approvedObject, err := decodeOrderedJSONObject(approvedMember.value)
+		if err != nil {
+			return nil, err
+		}
+		nested, err := mergeOrderedJSONObjects(existingObject, approvedObject)
+		if err != nil {
+			return nil, err
+		}
+		merged[existingIndex].value = formatOrderedJSONObject(nested, 0)
+	}
+	return merged, nil
+}
+
+func orderedJSONObjectIndex(obj orderedJSONObject, key string) int {
+	for i, member := range obj {
+		if member.key == key {
+			return i
+		}
+	}
+	return -1
+}
+
+func isJSONObject(payload []byte) bool {
+	trimmed := bytes.TrimSpace(payload)
+	return len(trimmed) > 0 && trimmed[0] == '{'
+}
+
+func formatOrderedJSONObject(obj orderedJSONObject, level int) []byte {
+	if len(obj) == 0 {
+		return []byte("{}")
+	}
+
+	indent := strings.Repeat("  ", level)
+	childIndent := strings.Repeat("  ", level+1)
+	var buf bytes.Buffer
+	buf.WriteString("{\n")
+	for i, member := range obj {
+		if i > 0 {
+			buf.WriteString(",\n")
+		}
+		buf.WriteString(childIndent)
+		buf.WriteString(strconv.Quote(member.key))
+		buf.WriteString(": ")
+		buf.Write(formatOrderedJSONValue(member.value, level+1))
+	}
+	buf.WriteByte('\n')
+	buf.WriteString(indent)
+	buf.WriteByte('}')
+	return buf.Bytes()
+}
+
+func formatOrderedJSONValue(payload []byte, level int) []byte {
+	if isJSONObject(payload) {
+		obj, err := decodeOrderedJSONObject(payload)
+		if err == nil {
+			return formatOrderedJSONObject(obj, level)
+		}
+	}
+
+	var buf bytes.Buffer
+	indent := strings.Repeat("  ", level)
+	if err := json.Indent(&buf, payload, indent, "  "); err == nil {
+		return buf.Bytes()
+	}
+	return bytes.TrimSpace(payload)
 }
 
 func (a *FileAdapter) effectiveConfig(cfg storage.FileWorkflowConfig) storage.FileWorkflowConfig {

--- a/internal/i18n/storage/crowdin/filemode.go
+++ b/internal/i18n/storage/crowdin/filemode.go
@@ -2,6 +2,7 @@ package crowdin
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io/fs"
 	"os"
@@ -198,7 +199,14 @@ func (a *FileAdapter) DownloadTranslations(ctx context.Context, req storage.File
 					skipped = append(skipped, remotePath+"@"+locale)
 					continue
 				}
-				payload, err := a.client.DownloadTranslationFile(ctx, config.ProjectID, fileID, locale, group.Export)
+				exportOptions := effectiveFileExportOptions(group.Export, req.ExportOverrides)
+				if req.MergeApproved {
+					exportOnlyApproved := true
+					skipUntranslatedStrings := true
+					exportOptions.ExportOnlyApproved = &exportOnlyApproved
+					exportOptions.SkipUntranslatedStrings = &skipUntranslatedStrings
+				}
+				payload, err := a.client.DownloadTranslationFile(ctx, config.ProjectID, fileID, locale, exportOptions)
 				if err != nil {
 					return storage.FileOperationResult{Processed: processed, Skipped: skipped}, err
 				}
@@ -208,6 +216,12 @@ func (a *FileAdapter) DownloadTranslations(ctx context.Context, req storage.File
 				}
 				if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
 					return storage.FileOperationResult{Processed: processed, Skipped: skipped}, fmt.Errorf("mkdir translation output: %w", err)
+				}
+				if req.MergeApproved {
+					payload, err = mergeApprovedJSONFile(targetPath, payload)
+					if err != nil {
+						return storage.FileOperationResult{Processed: processed, Skipped: skipped}, err
+					}
 				}
 				if err := os.WriteFile(targetPath, payload, 0o644); err != nil {
 					return storage.FileOperationResult{Processed: processed, Skipped: skipped}, fmt.Errorf("write translation output: %w", err)
@@ -220,6 +234,54 @@ func (a *FileAdapter) DownloadTranslations(ctx context.Context, req storage.File
 	slices.Sort(processed)
 	slices.Sort(skipped)
 	return storage.FileOperationResult{Processed: processed, Skipped: skipped}, nil
+}
+
+func effectiveFileExportOptions(base storage.FileExportOptions, overrides *storage.FileExportOptions) storage.FileExportOptions {
+	if overrides == nil {
+		return base
+	}
+	if overrides.SkipUntranslatedStrings != nil {
+		base.SkipUntranslatedStrings = overrides.SkipUntranslatedStrings
+	}
+	if overrides.SkipUntranslatedFiles != nil {
+		base.SkipUntranslatedFiles = overrides.SkipUntranslatedFiles
+	}
+	if overrides.ExportOnlyApproved != nil {
+		base.ExportOnlyApproved = overrides.ExportOnlyApproved
+	}
+	return base
+}
+
+func mergeApprovedJSONFile(targetPath string, approvedPayload []byte) ([]byte, error) {
+	approved := make(map[string]any)
+	if err := json.Unmarshal(approvedPayload, &approved); err != nil {
+		return nil, fmt.Errorf("merge approved translations: downloaded payload for %s must be a JSON object: %w", targetPath, err)
+	}
+	if len(approved) == 0 {
+		if existing, err := os.ReadFile(targetPath); err == nil {
+			return existing, nil
+		} else if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("merge approved translations: read existing translation file: %w", err)
+		}
+	}
+
+	merged := make(map[string]any)
+	if existing, err := os.ReadFile(targetPath); err == nil {
+		if err := json.Unmarshal(existing, &merged); err != nil {
+			return nil, fmt.Errorf("merge approved translations: existing file %s must be a JSON object: %w", targetPath, err)
+		}
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("merge approved translations: read existing translation file: %w", err)
+	}
+
+	for key, value := range approved {
+		merged[key] = value
+	}
+	payload, err := json.MarshalIndent(merged, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("merge approved translations: encode merged JSON: %w", err)
+	}
+	return append(payload, '\n'), nil
 }
 
 func (a *FileAdapter) effectiveConfig(cfg storage.FileWorkflowConfig) storage.FileWorkflowConfig {

--- a/internal/i18n/storage/crowdin/filemode_test.go
+++ b/internal/i18n/storage/crowdin/filemode_test.go
@@ -26,6 +26,7 @@ type fakeFileClient struct {
 	uploadedTranslations   []string
 	downloaded             []string
 	downloadOptions        []storage.FileExportOptions
+	downloadPayload        []byte
 	directories            map[string]int
 	files                  map[string]int
 	failFindMissing        bool
@@ -96,6 +97,9 @@ func (f *fakeFileClient) UploadTranslationFile(_ context.Context, _ string, lang
 func (f *fakeFileClient) DownloadTranslationFile(_ context.Context, _ string, fileID int, languageID string, opts storage.FileExportOptions) ([]byte, error) {
 	f.downloaded = append(f.downloaded, fmt.Sprintf("%s:%d", languageID, fileID))
 	f.downloadOptions = append(f.downloadOptions, opts)
+	if f.downloadPayload != nil {
+		return f.downloadPayload, nil
+	}
 	return []byte("translated-" + languageID), nil
 }
 
@@ -273,6 +277,286 @@ func TestFileAdapterDownloadTranslationsPropagatesExportOptions(t *testing.T) {
 	}
 	if !reflect.DeepEqual(client.foundDirectories, []string{"src"}) {
 		t.Fatalf("found directories = %#v, want translation lookup only", client.foundDirectories)
+	}
+}
+
+func TestFileAdapterDownloadTranslationsAppliesExportOverrides(t *testing.T) {
+	base := t.TempDir()
+	writeJSONFixture(t, filepath.Join(base, "src", "messages.json"), `{"hello":"Hello"}`)
+
+	client := &fakeFileClient{
+		locales:         []string{"fr"},
+		directories:     map[string]int{"src": 1},
+		failFindMissing: true,
+	}
+	adapter := mustNewFileAdapterForTest(t, storage.FileWorkflowConfig{
+		ProjectID:         "123",
+		APIToken:          "token",
+		BasePath:          base,
+		PreserveHierarchy: true,
+		Files: []storage.FileGroupSpec{{
+			Source:      "/src/*.json",
+			Translation: "/download/%locale%/%original_file_name%",
+		}},
+	}, client)
+
+	if _, err := adapter.UploadSources(context.Background(), storage.FileUploadSourcesRequest{}); err != nil {
+		t.Fatalf("upload sources: %v", err)
+	}
+	_, err := adapter.DownloadTranslations(context.Background(), storage.FileDownloadTranslationsRequest{
+		ExportOverrides: &storage.FileExportOptions{
+			ExportOnlyApproved:      boolPtr(true),
+			SkipUntranslatedStrings: boolPtr(true),
+		},
+	})
+	if err != nil {
+		t.Fatalf("download translations: %v", err)
+	}
+	if got, want := client.downloadOptions[0], (storage.FileExportOptions{
+		SkipUntranslatedStrings: boolPtr(true),
+		ExportOnlyApproved:      boolPtr(true),
+	}); !reflect.DeepEqual(got, want) {
+		t.Fatalf("download options = %#v, want %#v", got, want)
+	}
+}
+
+func TestFileAdapterDownloadTranslationsMergesApprovedJSON(t *testing.T) {
+	base := t.TempDir()
+	writeJSONFixture(t, filepath.Join(base, "src", "messages.json"), `{"hello":"Hello","bye":"Bye"}`)
+	targetPath := writeJSONFixture(t, filepath.Join(base, "download", "fr", "messages.json"), `{"hello":"Bonjour old","bye":"Au revoir","draft":"Brouillon"}`)
+
+	client := &fakeFileClient{
+		locales:         []string{"fr"},
+		directories:     map[string]int{"src": 1},
+		failFindMissing: true,
+		downloadPayload: []byte(`{"hello":"Bonjour approved"}`),
+	}
+	adapter := mustNewFileAdapterForTest(t, storage.FileWorkflowConfig{
+		ProjectID:         "123",
+		APIToken:          "token",
+		BasePath:          base,
+		PreserveHierarchy: true,
+		Files: []storage.FileGroupSpec{{
+			Source:      "/src/*.json",
+			Translation: "/download/%locale%/%original_file_name%",
+		}},
+	}, client)
+
+	if _, err := adapter.UploadSources(context.Background(), storage.FileUploadSourcesRequest{}); err != nil {
+		t.Fatalf("upload sources: %v", err)
+	}
+	if _, err := adapter.DownloadTranslations(context.Background(), storage.FileDownloadTranslationsRequest{MergeApproved: true}); err != nil {
+		t.Fatalf("download translations: %v", err)
+	}
+	if got, want := client.downloadOptions[0], (storage.FileExportOptions{
+		SkipUntranslatedStrings: boolPtr(true),
+		ExportOnlyApproved:      boolPtr(true),
+	}); !reflect.DeepEqual(got, want) {
+		t.Fatalf("download options = %#v, want %#v", got, want)
+	}
+	payload, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	want := "{\n  \"bye\": \"Au revoir\",\n  \"draft\": \"Brouillon\",\n  \"hello\": \"Bonjour approved\"\n}\n"
+	if string(payload) != want {
+		t.Fatalf("payload = %q, want %q", string(payload), want)
+	}
+}
+
+func TestFileAdapterDownloadTranslationsMergeApprovedCreatesMissingJSON(t *testing.T) {
+	base := t.TempDir()
+	writeJSONFixture(t, filepath.Join(base, "src", "messages.json"), `{"hello":"Hello"}`)
+	targetPath := filepath.Join(base, "download", "fr", "messages.json")
+
+	client := &fakeFileClient{
+		locales:         []string{"fr"},
+		directories:     map[string]int{"src": 1},
+		failFindMissing: true,
+		downloadPayload: []byte(`{"hello":"Bonjour"}`),
+	}
+	adapter := mustNewFileAdapterForTest(t, storage.FileWorkflowConfig{
+		ProjectID:         "123",
+		APIToken:          "token",
+		BasePath:          base,
+		PreserveHierarchy: true,
+		Files: []storage.FileGroupSpec{{
+			Source:      "/src/*.json",
+			Translation: "/download/%locale%/%original_file_name%",
+		}},
+	}, client)
+
+	if _, err := adapter.UploadSources(context.Background(), storage.FileUploadSourcesRequest{}); err != nil {
+		t.Fatalf("upload sources: %v", err)
+	}
+	result, err := adapter.DownloadTranslations(context.Background(), storage.FileDownloadTranslationsRequest{MergeApproved: true})
+	if err != nil {
+		t.Fatalf("download translations: %v", err)
+	}
+	if got, want := result.Processed, []string{targetPath}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("processed = %#v, want %#v", got, want)
+	}
+	payload, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	want := "{\n  \"hello\": \"Bonjour\"\n}\n"
+	if string(payload) != want {
+		t.Fatalf("payload = %q, want %q", string(payload), want)
+	}
+}
+
+func TestFileAdapterDownloadTranslationsMergeApprovedEmptyPayloadPreservesExistingJSON(t *testing.T) {
+	base := t.TempDir()
+	writeJSONFixture(t, filepath.Join(base, "src", "messages.json"), `{"hello":"Hello"}`)
+	targetPath := writeJSONFixture(t, filepath.Join(base, "download", "fr", "messages.json"), "{\n  \"hello\": \"Bonjour local\"\n}\n")
+
+	client := &fakeFileClient{
+		locales:         []string{"fr"},
+		directories:     map[string]int{"src": 1},
+		failFindMissing: true,
+		downloadPayload: []byte(`{}`),
+	}
+	adapter := mustNewFileAdapterForTest(t, storage.FileWorkflowConfig{
+		ProjectID:         "123",
+		APIToken:          "token",
+		BasePath:          base,
+		PreserveHierarchy: true,
+		Files: []storage.FileGroupSpec{{
+			Source:      "/src/*.json",
+			Translation: "/download/%locale%/%original_file_name%",
+		}},
+	}, client)
+
+	if _, err := adapter.UploadSources(context.Background(), storage.FileUploadSourcesRequest{}); err != nil {
+		t.Fatalf("upload sources: %v", err)
+	}
+	if _, err := adapter.DownloadTranslations(context.Background(), storage.FileDownloadTranslationsRequest{MergeApproved: true}); err != nil {
+		t.Fatalf("download translations: %v", err)
+	}
+	payload, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	want := "{\n  \"hello\": \"Bonjour local\"\n}\n"
+	if string(payload) != want {
+		t.Fatalf("payload = %q, want %q", string(payload), want)
+	}
+}
+
+func TestFileAdapterDownloadTranslationsMergeApprovedRejectsDownloadedJSONArray(t *testing.T) {
+	base := t.TempDir()
+	writeJSONFixture(t, filepath.Join(base, "src", "messages.json"), `{"hello":"Hello"}`)
+	targetPath := writeJSONFixture(t, filepath.Join(base, "download", "fr", "messages.json"), `{"hello":"Bonjour local"}`)
+
+	client := &fakeFileClient{
+		locales:         []string{"fr"},
+		directories:     map[string]int{"src": 1},
+		failFindMissing: true,
+		downloadPayload: []byte(`["not","an","object"]`),
+	}
+	adapter := mustNewFileAdapterForTest(t, storage.FileWorkflowConfig{
+		ProjectID:         "123",
+		APIToken:          "token",
+		BasePath:          base,
+		PreserveHierarchy: true,
+		Files: []storage.FileGroupSpec{{
+			Source:      "/src/*.json",
+			Translation: "/download/%locale%/%original_file_name%",
+		}},
+	}, client)
+
+	if _, err := adapter.UploadSources(context.Background(), storage.FileUploadSourcesRequest{}); err != nil {
+		t.Fatalf("upload sources: %v", err)
+	}
+	_, err := adapter.DownloadTranslations(context.Background(), storage.FileDownloadTranslationsRequest{MergeApproved: true})
+	if err == nil || !strings.Contains(err.Error(), "downloaded payload") {
+		t.Fatalf("expected downloaded payload error, got %v", err)
+	}
+	payload, readErr := os.ReadFile(targetPath)
+	if readErr != nil {
+		t.Fatalf("read target: %v", readErr)
+	}
+	if string(payload) != `{"hello":"Bonjour local"}` {
+		t.Fatalf("target was modified after failed merge: %q", string(payload))
+	}
+}
+
+func TestFileAdapterDownloadTranslationsMergeApprovedRejectsExistingJSONArray(t *testing.T) {
+	base := t.TempDir()
+	writeJSONFixture(t, filepath.Join(base, "src", "messages.json"), `{"hello":"Hello"}`)
+	targetPath := writeJSONFixture(t, filepath.Join(base, "download", "fr", "messages.json"), `["not","an","object"]`)
+
+	client := &fakeFileClient{
+		locales:         []string{"fr"},
+		directories:     map[string]int{"src": 1},
+		failFindMissing: true,
+		downloadPayload: []byte(`{"hello":"Bonjour approved"}`),
+	}
+	adapter := mustNewFileAdapterForTest(t, storage.FileWorkflowConfig{
+		ProjectID:         "123",
+		APIToken:          "token",
+		BasePath:          base,
+		PreserveHierarchy: true,
+		Files: []storage.FileGroupSpec{{
+			Source:      "/src/*.json",
+			Translation: "/download/%locale%/%original_file_name%",
+		}},
+	}, client)
+
+	if _, err := adapter.UploadSources(context.Background(), storage.FileUploadSourcesRequest{}); err != nil {
+		t.Fatalf("upload sources: %v", err)
+	}
+	_, err := adapter.DownloadTranslations(context.Background(), storage.FileDownloadTranslationsRequest{MergeApproved: true})
+	if err == nil || !strings.Contains(err.Error(), "existing file") {
+		t.Fatalf("expected existing file error, got %v", err)
+	}
+	payload, readErr := os.ReadFile(targetPath)
+	if readErr != nil {
+		t.Fatalf("read target: %v", readErr)
+	}
+	if string(payload) != `["not","an","object"]` {
+		t.Fatalf("target was modified after failed merge: %q", string(payload))
+	}
+}
+
+func TestFileAdapterDownloadTranslationsMergeApprovedOverridesFalseConfigExportOptions(t *testing.T) {
+	base := t.TempDir()
+	writeJSONFixture(t, filepath.Join(base, "src", "messages.json"), `{"hello":"Hello"}`)
+	writeJSONFixture(t, filepath.Join(base, "download", "fr", "messages.json"), `{"hello":"Bonjour local"}`)
+
+	client := &fakeFileClient{
+		locales:         []string{"fr"},
+		directories:     map[string]int{"src": 1},
+		failFindMissing: true,
+		downloadPayload: []byte(`{"hello":"Bonjour approved"}`),
+	}
+	adapter := mustNewFileAdapterForTest(t, storage.FileWorkflowConfig{
+		ProjectID:         "123",
+		APIToken:          "token",
+		BasePath:          base,
+		PreserveHierarchy: true,
+		Files: []storage.FileGroupSpec{{
+			Source:      "/src/*.json",
+			Translation: "/download/%locale%/%original_file_name%",
+			Export: storage.FileExportOptions{
+				SkipUntranslatedStrings: boolPtr(false),
+				ExportOnlyApproved:      boolPtr(false),
+			},
+		}},
+	}, client)
+
+	if _, err := adapter.UploadSources(context.Background(), storage.FileUploadSourcesRequest{}); err != nil {
+		t.Fatalf("upload sources: %v", err)
+	}
+	if _, err := adapter.DownloadTranslations(context.Background(), storage.FileDownloadTranslationsRequest{MergeApproved: true}); err != nil {
+		t.Fatalf("download translations: %v", err)
+	}
+	if got, want := client.downloadOptions[0], (storage.FileExportOptions{
+		SkipUntranslatedStrings: boolPtr(true),
+		ExportOnlyApproved:      boolPtr(true),
+	}); !reflect.DeepEqual(got, want) {
+		t.Fatalf("download options = %#v, want %#v", got, want)
 	}
 }
 

--- a/internal/i18n/storage/crowdin/filemode_test.go
+++ b/internal/i18n/storage/crowdin/filemode_test.go
@@ -358,7 +358,45 @@ func TestFileAdapterDownloadTranslationsMergesApprovedJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read target: %v", err)
 	}
-	want := "{\n  \"bye\": \"Au revoir\",\n  \"draft\": \"Brouillon\",\n  \"hello\": \"Bonjour approved\"\n}\n"
+	want := "{\n  \"hello\": \"Bonjour approved\",\n  \"bye\": \"Au revoir\",\n  \"draft\": \"Brouillon\"\n}\n"
+	if string(payload) != want {
+		t.Fatalf("payload = %q, want %q", string(payload), want)
+	}
+}
+
+func TestFileAdapterDownloadTranslationsMergeApprovedPreservesNestedJSON(t *testing.T) {
+	base := t.TempDir()
+	writeJSONFixture(t, filepath.Join(base, "src", "messages.json"), `{"nav":{"home":"Home","about":"About"},"footer":{"legal":"Legal"}}`)
+	targetPath := writeJSONFixture(t, filepath.Join(base, "download", "fr", "messages.json"), `{"nav":{"home":"Accueil old","about":"A propos"},"footer":{"legal":"Mentions"},"draft":"Brouillon"}`)
+
+	client := &fakeFileClient{
+		locales:         []string{"fr"},
+		directories:     map[string]int{"src": 1},
+		failFindMissing: true,
+		downloadPayload: []byte(`{"nav":{"home":"Accueil approved"},"cta":"Commencer"}`),
+	}
+	adapter := mustNewFileAdapterForTest(t, storage.FileWorkflowConfig{
+		ProjectID:         "123",
+		APIToken:          "token",
+		BasePath:          base,
+		PreserveHierarchy: true,
+		Files: []storage.FileGroupSpec{{
+			Source:      "/src/*.json",
+			Translation: "/download/%locale%/%original_file_name%",
+		}},
+	}, client)
+
+	if _, err := adapter.UploadSources(context.Background(), storage.FileUploadSourcesRequest{}); err != nil {
+		t.Fatalf("upload sources: %v", err)
+	}
+	if _, err := adapter.DownloadTranslations(context.Background(), storage.FileDownloadTranslationsRequest{MergeApproved: true}); err != nil {
+		t.Fatalf("download translations: %v", err)
+	}
+	payload, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	want := "{\n  \"nav\": {\n    \"home\": \"Accueil approved\",\n    \"about\": \"A propos\"\n  },\n  \"footer\": {\n    \"legal\": \"Mentions\"\n  },\n  \"draft\": \"Brouillon\",\n  \"cta\": \"Commencer\"\n}\n"
 	if string(payload) != want {
 		t.Fatalf("payload = %q, want %q", string(payload), want)
 	}

--- a/internal/i18n/storage/types.go
+++ b/internal/i18n/storage/types.go
@@ -168,8 +168,10 @@ type FileUploadTranslationsRequest struct {
 
 // FileDownloadTranslationsRequest downloads translated files into the workspace.
 type FileDownloadTranslationsRequest struct {
-	Config    FileWorkflowConfig `json:"config"`
-	Languages []string           `json:"languages,omitempty"`
+	Config          FileWorkflowConfig `json:"config"`
+	Languages       []string           `json:"languages,omitempty"`
+	ExportOverrides *FileExportOptions `json:"export_overrides,omitempty"`
+	MergeApproved   bool               `json:"merge_approved,omitempty"`
 }
 
 // FileOperationResult returns normalized file-mode execution details.


### PR DESCRIPTION
## What changed

Adds Crowdin download support for approved-only exports and approved-string merging.

- Added `hyperlocalise crowdin download --export-only-approved`.
- Added `--skip-untranslated-strings` for sparse approved-only downloads.
- Added `--merge-approved` to merge approved JSON object keys into existing translation files without deleting local keys absent from the Crowdin export.
- Added request-level export overrides for Crowdin file downloads.
- Updated Crowdin command/storage docs with approved-only and merge examples.
- Expanded tests for CLI flags, export override propagation, JSON merge behavior, empty approved payloads, invalid JSON shape handling, and local-file preservation on merge errors.

## How to test

- `go test ./apps/cli/cmd ./internal/i18n/storage/crowdin`
- `make fmt`
- `make lint`
- `make test`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
