### PR TITLE
🛡️ Sentinel: Mask Secrets in Prompt Debug Logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - [Enhancement] Masking Secrets in Prompt Debug Logs
+**Vulnerability:** API keys (OpenAI, Google, etc.) could be leaked into plaintext log files if prompt debugging (`HYPERLOCALISE_PROMPT_DEBUG`) is enabled and the prompts or outputs contain those keys.
+**Learning:** Debug logging of raw LLM interactions is a common source of accidental credential exposure, especially when developers use few-shot examples or context that includes real or placeholder secrets.
+**Prevention:** Implement a central sanitization helper (`maskSecrets`) that uses regex to identify and redact sensitive patterns (e.g., `sk-`, `hl_`, `AIza`) before any data is written to persistent logs.

--- a/internal/i18n/translator/debug_log.go
+++ b/internal/i18n/translator/debug_log.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -35,7 +36,10 @@ type promptDebugEvent struct {
 	DurationMS     int64  `json:"duration_ms,omitempty"`
 }
 
-var translatorPromptDebugLogger promptDebugLogger
+var (
+	translatorPromptDebugLogger promptDebugLogger
+	secretRegex                 = regexp.MustCompile(`(?i)(sk-[a-z0-9-]{20,}|hl_[a-z0-9]{20,}|AIza[a-z0-9_-]{35})`)
+)
 
 func logPromptCall(req Request, providerName, systemPrompt, userPrompt string) {
 	translatorPromptDebugLogger.write(promptDebugEvent{
@@ -45,8 +49,8 @@ func logPromptCall(req Request, providerName, systemPrompt, userPrompt string) {
 		Model:          strings.TrimSpace(req.Model),
 		Source:         strings.TrimSpace(req.Source),
 		TargetLanguage: strings.TrimSpace(req.TargetLanguage),
-		SystemPrompt:   systemPrompt,
-		UserPrompt:     userPrompt,
+		SystemPrompt:   maskSecrets(systemPrompt),
+		UserPrompt:     maskSecrets(userPrompt),
 	})
 }
 
@@ -58,7 +62,7 @@ func logPromptResult(req Request, providerName, output string, err error, durati
 		Model:          strings.TrimSpace(req.Model),
 		Source:         strings.TrimSpace(req.Source),
 		TargetLanguage: strings.TrimSpace(req.TargetLanguage),
-		Output:         output,
+		Output:         maskSecrets(output),
 		DurationMS:     duration.Milliseconds(),
 	}
 	if err != nil {
@@ -125,4 +129,16 @@ func parsePromptDebugBool(raw string) bool {
 	default:
 		return false
 	}
+}
+
+func maskSecrets(text string) string {
+	if text == "" {
+		return ""
+	}
+	return secretRegex.ReplaceAllStringFunc(text, func(match string) string {
+		if len(match) < 8 {
+			return "****"
+		}
+		return match[:4] + "..." + match[len(match)-4:]
+	})
 }

--- a/internal/i18n/translator/debug_log.go
+++ b/internal/i18n/translator/debug_log.go
@@ -38,7 +38,7 @@ type promptDebugEvent struct {
 
 var (
 	translatorPromptDebugLogger promptDebugLogger
-	secretRegex                 = regexp.MustCompile(`(?i)(sk-[a-z0-9-]{20,}|hl_[a-z0-9]{20,}|AIza[a-z0-9_-]{35})`)
+	secretRegex                 = regexp.MustCompile(`(?i)\b(sk-[a-z0-9-]{20,}|hl_[a-z0-9]{20,}|AIza[a-z0-9_-]{35,})\b`)
 )
 
 func logPromptCall(req Request, providerName, systemPrompt, userPrompt string) {
@@ -136,9 +136,9 @@ func maskSecrets(text string) string {
 		return ""
 	}
 	return secretRegex.ReplaceAllStringFunc(text, func(match string) string {
-		if len(match) < 8 {
+		if len(match) < 12 {
 			return "****"
 		}
-		return match[:4] + "..." + match[len(match)-4:]
+		return match[:8] + "..." + match[len(match)-4:]
 	})
 }

--- a/internal/i18n/translator/debug_log.go
+++ b/internal/i18n/translator/debug_log.go
@@ -66,7 +66,7 @@ func logPromptResult(req Request, providerName, output string, err error, durati
 		DurationMS:     duration.Milliseconds(),
 	}
 	if err != nil {
-		event.Error = err.Error()
+		event.Error = maskSecrets(err.Error())
 	}
 	translatorPromptDebugLogger.write(event)
 }

--- a/internal/i18n/translator/debug_log_test.go
+++ b/internal/i18n/translator/debug_log_test.go
@@ -3,6 +3,7 @@ package translator
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -211,5 +212,42 @@ func TestTranslateSanitizesPromptDebugLog(t *testing.T) {
 	_ = json.Unmarshal([]byte(lines[1]), &resultEvent)
 	if resultEvent.Output != "output with hl_abc12...cdef" {
 		t.Errorf("output not sanitized: %q", resultEvent.Output)
+	}
+}
+
+func TestTranslateSanitizesErrorInPromptDebugLog(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "prompt.log")
+	t.Setenv(envPromptDebugEnabled, "1")
+	t.Setenv(envPromptDebugPath, logPath)
+
+	tool := &Tool{providers: map[string]Provider{}}
+	if err := tool.Register(fakeProvider{
+		name: ProviderOpenAI,
+		err:  errors.New("failed with secret hl_abc1234567890abcdef1234567890abcdef"),
+	}); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+
+	_, _ = tool.Translate(context.Background(), Request{
+		Source:         "hello",
+		TargetLanguage: "fr",
+		ModelProvider:  ProviderOpenAI,
+		Model:          "gpt-5-mini",
+	})
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+
+	lines := splitNonEmptyLines(string(data))
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 log lines, got %d", len(lines))
+	}
+
+	var resultEvent promptDebugEvent
+	_ = json.Unmarshal([]byte(lines[1]), &resultEvent)
+	if resultEvent.Error != "failed with secret hl_abc12...cdef" {
+		t.Errorf("error not sanitized: %q", resultEvent.Error)
 	}
 }

--- a/internal/i18n/translator/debug_log_test.go
+++ b/internal/i18n/translator/debug_log_test.go
@@ -117,3 +117,99 @@ func splitNonEmptyLines(s string) []string {
 	}
 	return lines
 }
+
+func TestMaskSecrets(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "openai secret",
+			in:   "my key is sk-proj-1234567890abcdef1234567890abcdef1234567890abcdef",
+			want: "my key is sk-p...cdef",
+		},
+		{
+			name: "hyperlocalise secret",
+			in:   "secret hl_abc1234567890abcdef1234567890abcdef",
+			want: "secret hl_a...cdef",
+		},
+		{
+			name: "google secret",
+			in:   "google AIzaSyA1234567890abcdef1234567890abcdefGH",
+			want: "google AIza...cdefGH",
+		},
+		{
+			name: "multiple secrets",
+			in:   "keys: sk-proj-1234567890abcdef1234567890abcdef1234567890abcdef and hl_abc1234567890abcdef1234567890abcdef",
+			want: "keys: sk-p...cdef and hl_a...cdef",
+		},
+		{
+			name: "no secrets",
+			in:   "Translate to fr: hello world",
+			want: "Translate to fr: hello world",
+		},
+		{
+			name: "empty",
+			in:   "",
+			want: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := maskSecrets(tc.in)
+			if got != tc.want {
+				t.Errorf("maskSecrets(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTranslateSanitizesPromptDebugLog(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "prompt.log")
+	t.Setenv(envPromptDebugEnabled, "1")
+	t.Setenv(envPromptDebugPath, logPath)
+
+	tool := &Tool{providers: map[string]Provider{}}
+	if err := tool.Register(fakeProvider{
+		name:   ProviderOpenAI,
+		result: "output with hl_abc1234567890abcdef1234567890abcdef",
+	}); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+
+	_, _ = tool.Translate(context.Background(), Request{
+		Source:         "hello",
+		TargetLanguage: "fr",
+		ModelProvider:  ProviderOpenAI,
+		Model:          "gpt-5-mini",
+		SystemPrompt:   "system sk-proj-1234567890abcdef1234567890abcdef1234567890abcdef",
+		UserPrompt:     "user sk-proj-1234567890abcdef1234567890abcdef1234567890abcdef",
+	})
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+
+	lines := splitNonEmptyLines(string(data))
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 log lines, got %d", len(lines))
+	}
+
+	var callEvent promptDebugEvent
+	_ = json.Unmarshal([]byte(lines[0]), &callEvent)
+	if callEvent.SystemPrompt != "system sk-p...cdef" {
+		t.Errorf("system prompt not sanitized: %q", callEvent.SystemPrompt)
+	}
+	if callEvent.UserPrompt != "user sk-p...cdef" {
+		t.Errorf("user prompt not sanitized: %q", callEvent.UserPrompt)
+	}
+
+	var resultEvent promptDebugEvent
+	_ = json.Unmarshal([]byte(lines[1]), &resultEvent)
+	if resultEvent.Output != "output with hl_a...cdef" {
+		t.Errorf("output not sanitized: %q", resultEvent.Output)
+	}
+}

--- a/internal/i18n/translator/debug_log_test.go
+++ b/internal/i18n/translator/debug_log_test.go
@@ -127,22 +127,22 @@ func TestMaskSecrets(t *testing.T) {
 		{
 			name: "openai secret",
 			in:   "my key is sk-proj-1234567890abcdef1234567890abcdef1234567890abcdef",
-			want: "my key is sk-p...cdef",
+			want: "my key is sk-proj-...cdef",
 		},
 		{
 			name: "hyperlocalise secret",
 			in:   "secret hl_abc1234567890abcdef1234567890abcdef",
-			want: "secret hl_a...cdef",
+			want: "secret hl_abc12...cdef",
 		},
 		{
 			name: "google secret",
 			in:   "google AIzaSyA1234567890abcdef1234567890abcdefGH",
-			want: "google AIza...cdefGH",
+			want: "google AIzaSyA1...efGH",
 		},
 		{
 			name: "multiple secrets",
 			in:   "keys: sk-proj-1234567890abcdef1234567890abcdef1234567890abcdef and hl_abc1234567890abcdef1234567890abcdef",
-			want: "keys: sk-p...cdef and hl_a...cdef",
+			want: "keys: sk-proj-...cdef and hl_abc12...cdef",
 		},
 		{
 			name: "no secrets",
@@ -200,16 +200,16 @@ func TestTranslateSanitizesPromptDebugLog(t *testing.T) {
 
 	var callEvent promptDebugEvent
 	_ = json.Unmarshal([]byte(lines[0]), &callEvent)
-	if callEvent.SystemPrompt != "system sk-p...cdef" {
+	if callEvent.SystemPrompt != "system sk-proj-...cdef" {
 		t.Errorf("system prompt not sanitized: %q", callEvent.SystemPrompt)
 	}
-	if callEvent.UserPrompt != "user sk-p...cdef" {
+	if callEvent.UserPrompt != "user sk-proj-...cdef" {
 		t.Errorf("user prompt not sanitized: %q", callEvent.UserPrompt)
 	}
 
 	var resultEvent promptDebugEvent
 	_ = json.Unmarshal([]byte(lines[1]), &resultEvent)
-	if resultEvent.Output != "output with hl_a...cdef" {
+	if resultEvent.Output != "output with hl_abc12...cdef" {
 		t.Errorf("output not sanitized: %q", resultEvent.Output)
 	}
 }


### PR DESCRIPTION
Implemented a secret-redaction mechanism for the prompt debug logger in the `internal/i18n/translator` package. This prevents sensitive API keys (OpenAI, Google, etc.) from being stored in plaintext log files when `HYPERLOCALISE_PROMPT_DEBUG` is enabled. Verified with new test cases and existing test suite.

---
*PR created automatically by Jules for task [12530861211084306391](https://jules.google.com/task/12530861211084306391) started by @cungminh2710*