### PR TITLE
feat(cli): source download

### DIFF
--- a/apps/cli/cmd/phrase.go
+++ b/apps/cli/cmd/phrase.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -25,12 +26,26 @@ type phraseUploadSourcesOptions struct {
 	dryRun             bool
 }
 
+type phraseDownloadSourcesOptions struct {
+	projectID    string
+	sourceLocale string
+	format       string
+	output       string
+	branch       string
+	tags         []string
+	tokenEnv     string
+	apiBaseURL   string
+	force        bool
+	dryRun       bool
+}
+
 func newPhraseCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "phrase",
 		Short: "Phrase file workflow commands",
 	}
 	cmd.AddCommand(newPhraseUploadCmd())
+	cmd.AddCommand(newPhraseDownloadCmd())
 	return cmd
 }
 
@@ -40,6 +55,38 @@ func newPhraseUploadCmd() *cobra.Command {
 		Short: "upload files to Phrase",
 	}
 	cmd.AddCommand(newPhraseUploadSourcesCmd())
+	return cmd
+}
+
+func newPhraseDownloadCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "download",
+		Short: "download files from Phrase",
+	}
+	cmd.AddCommand(newPhraseDownloadSourcesCmd())
+	return cmd
+}
+
+func newPhraseDownloadSourcesCmd() *cobra.Command {
+	o := phraseDownloadSourcesOptions{tokenEnv: "PHRASE_API_TOKEN"}
+	cmd := &cobra.Command{
+		Use:          "sources",
+		Short:        "download source content from Phrase",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return executePhraseDownloadSources(cmd, o)
+		},
+	}
+	cmd.Flags().StringVar(&o.projectID, "project-id", "", "Phrase project ID")
+	cmd.Flags().StringVar(&o.sourceLocale, "source-locale", "", "Phrase source locale ID or name")
+	cmd.Flags().StringVar(&o.format, "format", "", "Phrase file format, for example json, yml, or strings")
+	cmd.Flags().StringVarP(&o.output, "output", "o", "", "output file path; omit or use - for stdout")
+	cmd.Flags().StringVar(&o.branch, "branch", "", "Phrase branch name")
+	cmd.Flags().StringSliceVar(&o.tags, "tag", nil, "tag(s) to limit downloaded keys")
+	cmd.Flags().StringVar(&o.tokenEnv, "token-env", o.tokenEnv, "environment variable containing the Phrase API token")
+	cmd.Flags().StringVar(&o.apiBaseURL, "api-base-url", "", "Phrase API base URL")
+	cmd.Flags().BoolVar(&o.force, "force", false, "overwrite an existing output file")
+	cmd.Flags().BoolVar(&o.dryRun, "dry-run", false, "preview command without downloading content")
 	return cmd
 }
 
@@ -87,21 +134,10 @@ func executePhraseUploadSources(cmd *cobra.Command, o phraseUploadSourcesOptions
 		return err
 	}
 
-	tokenEnv := strings.TrimSpace(o.tokenEnv)
-	if tokenEnv == "" {
-		tokenEnv = "PHRASE_API_TOKEN"
+	token, err := phraseAPIToken("phrase upload sources", o.tokenEnv)
+	if err != nil {
+		return err
 	}
-	token := strings.TrimSpace(os.Getenv(tokenEnv))
-	if token == "" && tokenEnv != "PHRASE_API_TOKEN" {
-		token = strings.TrimSpace(os.Getenv("PHRASE_API_TOKEN"))
-	}
-	if token == "" {
-		if tokenEnv != "PHRASE_API_TOKEN" {
-			return fmt.Errorf("phrase upload sources: API token is required (%s or PHRASE_API_TOKEN)", tokenEnv)
-		}
-		return fmt.Errorf("phrase upload sources: API token is required (%s)", tokenEnv)
-	}
-
 	client, err := phrase.NewHTTPClientWithBaseURL(phrase.Config{}, o.apiBaseURL, &http.Client{Timeout: 30 * time.Second})
 	if err != nil {
 		return err
@@ -130,6 +166,123 @@ func executePhraseUploadSources(cmd *cobra.Command, o phraseUploadSourcesOptions
 	}
 	_, err = fmt.Fprintf(cmd.OutOrStdout(), "action=phrase-upload-sources processed=%d skipped=0 warnings=0\n", processed)
 	return err
+}
+
+func executePhraseDownloadSources(cmd *cobra.Command, o phraseDownloadSourcesOptions) error {
+	if strings.TrimSpace(o.projectID) == "" {
+		return fmt.Errorf("phrase download sources: --project-id is required")
+	}
+	if strings.TrimSpace(o.sourceLocale) == "" {
+		return fmt.Errorf("phrase download sources: --source-locale is required")
+	}
+	if strings.TrimSpace(o.format) == "" {
+		return fmt.Errorf("phrase download sources: --format is required")
+	}
+
+	outputPath := strings.TrimSpace(o.output)
+	if o.dryRun {
+		destination := outputPath
+		if destination == "" {
+			destination = "-"
+		}
+		_, err := fmt.Fprintf(cmd.OutOrStdout(), "dry-run action=phrase-download-sources project_id=%s source_locale=%s format=%s output=%s\n", strings.TrimSpace(o.projectID), strings.TrimSpace(o.sourceLocale), strings.TrimSpace(o.format), destination)
+		return err
+	}
+	if err := validatePhraseDownloadOutputPath(outputPath, o.force); err != nil {
+		return err
+	}
+
+	token, err := phraseAPIToken("phrase download sources", o.tokenEnv)
+	if err != nil {
+		return err
+	}
+
+	client, err := phrase.NewHTTPClientWithBaseURL(phrase.Config{}, o.apiBaseURL, &http.Client{Timeout: 30 * time.Second})
+	if err != nil {
+		return err
+	}
+	result, err := client.DownloadSourceFile(backgroundContext(), phrase.SourceDownloadInput{
+		ProjectID:  strings.TrimSpace(o.projectID),
+		APIToken:   token,
+		LocaleID:   strings.TrimSpace(o.sourceLocale),
+		FileFormat: strings.TrimSpace(o.format),
+		Branch:     strings.TrimSpace(o.branch),
+		Tags:       o.tags,
+	})
+	if err != nil {
+		return fmt.Errorf("phrase download sources: %w", err)
+	}
+
+	if outputPath == "" || outputPath == "-" {
+		_, err := cmd.OutOrStdout().Write(result.Content)
+		return err
+	}
+	if err := writePhraseDownloadedSource(outputPath, result.Content, o.force); err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "downloaded file=%s bytes=%d locale=%s format=%s\n", outputPath, len(result.Content), result.LocaleID, result.Format)
+	return err
+}
+
+func phraseAPIToken(action, tokenEnv string) (string, error) {
+	tokenEnv = strings.TrimSpace(tokenEnv)
+	if tokenEnv == "" {
+		tokenEnv = "PHRASE_API_TOKEN"
+	}
+	token := strings.TrimSpace(os.Getenv(tokenEnv))
+	if token == "" && tokenEnv != "PHRASE_API_TOKEN" {
+		token = strings.TrimSpace(os.Getenv("PHRASE_API_TOKEN"))
+	}
+	if token == "" {
+		if tokenEnv != "PHRASE_API_TOKEN" {
+			return "", fmt.Errorf("%s: API token is required (%s or PHRASE_API_TOKEN)", action, tokenEnv)
+		}
+		return "", fmt.Errorf("%s: API token is required (%s)", action, tokenEnv)
+	}
+	return token, nil
+}
+
+func writePhraseDownloadedSource(path string, content []byte, force bool) error {
+	if err := validatePhraseDownloadOutputPath(path, force); err != nil {
+		return err
+	}
+	if path == "" || path == "-" {
+		return fmt.Errorf("phrase download sources: output file path is required")
+	}
+	if dir := filepath.Dir(path); dir != "." && dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("phrase download sources: mkdir output directory: %w", err)
+		}
+	}
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return fmt.Errorf("phrase download sources: open output file %q: %w", path, err)
+	}
+	if _, err := file.Write(content); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("phrase download sources: write output file %q: %w", path, err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("phrase download sources: close output file %q: %w", path, err)
+	}
+	return nil
+}
+
+func validatePhraseDownloadOutputPath(path string, force bool) error {
+	if path == "" || path == "-" {
+		return nil
+	}
+	if info, err := os.Stat(path); err == nil {
+		if info.IsDir() {
+			return fmt.Errorf("phrase download sources: output file %q is a directory", path)
+		}
+		if !force {
+			return fmt.Errorf("phrase download sources: output file %q already exists; use --force to overwrite", path)
+		}
+	} else if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("phrase download sources: stat output file %q: %w", path, err)
+	}
+	return nil
 }
 
 func validatePhraseSourceFiles(paths []string) ([]string, error) {

--- a/apps/cli/cmd/phrase.go
+++ b/apps/cli/cmd/phrase.go
@@ -249,13 +249,19 @@ func writePhraseDownloadedSource(path string, content []byte, force bool) error 
 	if path == "" || path == "-" {
 		return fmt.Errorf("phrase download sources: output file path is required")
 	}
-	if dir := filepath.Dir(path); dir != "." && dir != "" {
+	if dir := filepath.Dir(path); dir != "." {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			return fmt.Errorf("phrase download sources: mkdir output directory: %w", err)
 		}
 	}
-	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if force {
+		return writePhraseDownloadedSourceAtomic(path, content, 0o644)
+	}
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
 	if err != nil {
+		if os.IsExist(err) {
+			return fmt.Errorf("phrase download sources: output file %q already exists; use --force to overwrite", path)
+		}
 		return fmt.Errorf("phrase download sources: open output file %q: %w", path, err)
 	}
 	if _, err := file.Write(content); err != nil {
@@ -265,6 +271,41 @@ func writePhraseDownloadedSource(path string, content []byte, force bool) error 
 	if err := file.Close(); err != nil {
 		return fmt.Errorf("phrase download sources: close output file %q: %w", path, err)
 	}
+	return nil
+}
+
+func writePhraseDownloadedSourceAtomic(path string, content []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	file, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("phrase download sources: create temp output file %q: %w", path, err)
+	}
+	tempPath := file.Name()
+	renamed := false
+	defer func() {
+		if !renamed {
+			_ = os.Remove(tempPath)
+		}
+	}()
+	if _, err := file.Write(content); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("phrase download sources: write temp output file %q: %w", path, err)
+	}
+	if err := file.Chmod(perm); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("phrase download sources: chmod temp output file %q: %w", path, err)
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("phrase download sources: sync temp output file %q: %w", path, err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("phrase download sources: close temp output file %q: %w", path, err)
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		return fmt.Errorf("phrase download sources: replace output file %q: %w", path, err)
+	}
+	renamed = true
 	return nil
 }
 

--- a/apps/cli/cmd/phrase_test.go
+++ b/apps/cli/cmd/phrase_test.go
@@ -259,6 +259,41 @@ func TestPhraseDownloadSourcesRefusesOverwriteWithoutForce(t *testing.T) {
 	}
 }
 
+func TestPhraseDownloadSourcesForceOverwritesOutputFile(t *testing.T) {
+	t.Setenv("PHRASE_TEST_TOKEN", "secret")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"hello":"Hello"}`))
+	}))
+	defer server.Close()
+
+	outputPath := filepath.Join(t.TempDir(), "en.json")
+	if err := os.WriteFile(outputPath, []byte(`{"old":"Old"}`), 0o644); err != nil {
+		t.Fatalf("write existing output: %v", err)
+	}
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"phrase", "download", "sources", "--project-id", "project-1", "--source-locale", "en", "--format", "json", "--output", outputPath, "--force", "--token-env", "PHRASE_TEST_TOKEN", "--api-base-url", server.URL})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute phrase download with force: %v", err)
+	}
+	content, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read output file: %v", err)
+	}
+	if string(content) != `{"hello":"Hello"}` {
+		t.Fatalf("unexpected file content: %q", string(content))
+	}
+	matches, err := filepath.Glob(filepath.Join(filepath.Dir(outputPath), "."+filepath.Base(outputPath)+".tmp-*"))
+	if err != nil {
+		t.Fatalf("glob temp files: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("expected no temp files, got %v", matches)
+	}
+}
+
 func TestPhraseDownloadSourcesTokenErrorListsFallback(t *testing.T) {
 	t.Setenv("PHRASE_CUSTOM_TOKEN", "")
 	t.Setenv("PHRASE_API_TOKEN", "")

--- a/apps/cli/cmd/phrase_test.go
+++ b/apps/cli/cmd/phrase_test.go
@@ -157,3 +157,120 @@ func TestPhraseUploadSourcesUploadsToPhraseAPI(t *testing.T) {
 		t.Fatalf("unexpected output: %q", output)
 	}
 }
+
+func TestPhraseDownloadSourcesDryRun(t *testing.T) {
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"phrase", "download", "sources", "--project-id", "project-1", "--source-locale", "en", "--format", "json", "--output", "en.json", "--dry-run"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute phrase download dry-run: %v", err)
+	}
+	if !strings.Contains(out.String(), "dry-run action=phrase-download-sources") || !strings.Contains(out.String(), "output=en.json") {
+		t.Fatalf("unexpected output: %q", out.String())
+	}
+}
+
+func TestPhraseDownloadSourcesWritesStdout(t *testing.T) {
+	t.Setenv("PHRASE_TEST_TOKEN", "secret")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/projects/project-1/locales/en/download" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "token secret" {
+			t.Fatalf("unexpected auth header: %q", r.Header.Get("Authorization"))
+		}
+		if got := r.URL.Query().Get("file_format"); got != "json" {
+			t.Fatalf("file_format = %q, want json", got)
+		}
+		if got := r.URL.Query().Get("branch"); got != "main" {
+			t.Fatalf("branch = %q, want main", got)
+		}
+		if got := r.URL.Query().Get("tags"); got != "app,source" {
+			t.Fatalf("tags = %q, want app,source", got)
+		}
+		_, _ = w.Write([]byte(`{"hello":"Hello"}`))
+	}))
+	defer server.Close()
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"phrase", "download", "sources", "--project-id", "project-1", "--source-locale", "en", "--format", "json", "--branch", "main", "--tag", "app", "--tag", "source", "--token-env", "PHRASE_TEST_TOKEN", "--api-base-url", server.URL})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute phrase download: %v", err)
+	}
+	if got := out.String(); got != `{"hello":"Hello"}` {
+		t.Fatalf("unexpected stdout content: %q", got)
+	}
+}
+
+func TestPhraseDownloadSourcesWritesOutputFile(t *testing.T) {
+	t.Setenv("PHRASE_TEST_TOKEN", "secret")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"hello":"Hello"}`))
+	}))
+	defer server.Close()
+
+	outputPath := filepath.Join(t.TempDir(), "locales", "en.json")
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"phrase", "download", "sources", "--project-id", "project-1", "--source-locale", "en", "--format", "json", "--output", outputPath, "--token-env", "PHRASE_TEST_TOKEN", "--api-base-url", server.URL})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute phrase download: %v", err)
+	}
+	content, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read output file: %v", err)
+	}
+	if string(content) != `{"hello":"Hello"}` {
+		t.Fatalf("unexpected file content: %q", string(content))
+	}
+	if !strings.Contains(out.String(), "downloaded file="+outputPath) || !strings.Contains(out.String(), "bytes=17") {
+		t.Fatalf("unexpected output: %q", out.String())
+	}
+}
+
+func TestPhraseDownloadSourcesRefusesOverwriteWithoutForce(t *testing.T) {
+	t.Setenv("PHRASE_TEST_TOKEN", "secret")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"hello":"Hello"}`))
+	}))
+	defer server.Close()
+
+	outputPath := filepath.Join(t.TempDir(), "en.json")
+	if err := os.WriteFile(outputPath, []byte(`{"old":"Old"}`), 0o644); err != nil {
+		t.Fatalf("write existing output: %v", err)
+	}
+	cmd := newRootCmd("")
+	cmd.SetArgs([]string{"phrase", "download", "sources", "--project-id", "project-1", "--source-locale", "en", "--format", "json", "--output", outputPath, "--token-env", "PHRASE_TEST_TOKEN", "--api-base-url", server.URL})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected overwrite error")
+	}
+	if !strings.Contains(err.Error(), "already exists; use --force to overwrite") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPhraseDownloadSourcesTokenErrorListsFallback(t *testing.T) {
+	t.Setenv("PHRASE_CUSTOM_TOKEN", "")
+	t.Setenv("PHRASE_API_TOKEN", "")
+
+	cmd := newRootCmd("")
+	cmd.SetArgs([]string{"phrase", "download", "sources", "--project-id", "project-1", "--source-locale", "en", "--format", "json", "--token-env", "PHRASE_CUSTOM_TOKEN"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected missing token error")
+	}
+	if !strings.Contains(err.Error(), "PHRASE_CUSTOM_TOKEN or PHRASE_API_TOKEN") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/i18n/storage/phrase/http_client_test.go
+++ b/internal/i18n/storage/phrase/http_client_test.go
@@ -166,6 +166,75 @@ func TestHTTPClientUploadSourceFileMultipart(t *testing.T) {
 	}
 }
 
+func TestHTTPClientDownloadSourceFile(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/projects/p/locales/en/download", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %s, want GET", r.Method)
+		}
+		if r.Header.Get("Authorization") != "token x" {
+			t.Fatalf("unexpected auth header: %q", r.Header.Get("Authorization"))
+		}
+		if got := r.URL.Query().Get("file_format"); got != "json" {
+			t.Fatalf("file_format = %q, want json", got)
+		}
+		if got := r.URL.Query().Get("branch"); got != "main" {
+			t.Fatalf("branch = %q, want main", got)
+		}
+		if got := r.URL.Query().Get("tags"); got != "app,source" {
+			t.Fatalf("tags = %q, want app,source", got)
+		}
+		_, _ = w.Write([]byte(`{"hello":"Hello"}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client, err := NewHTTPClientWithBaseURL(Config{}, srv.URL, srv.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := client.DownloadSourceFile(context.Background(), SourceDownloadInput{
+		ProjectID:  "p",
+		APIToken:   "x",
+		LocaleID:   "en",
+		FileFormat: "json",
+		Branch:     "main",
+		Tags:       []string{"app", "source"},
+	})
+	if err != nil {
+		t.Fatalf("download source file: %v", err)
+	}
+	if string(result.Content) != `{"hello":"Hello"}` || result.LocaleID != "en" || result.Format != "json" {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+}
+
+func TestHTTPClientDownloadSourceFileAPIError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/projects/p/locales/missing/download", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"Locale not found"}`, http.StatusNotFound)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client, err := NewHTTPClientWithBaseURL(Config{}, srv.URL, srv.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.DownloadSourceFile(context.Background(), SourceDownloadInput{
+		ProjectID:  "p",
+		APIToken:   "x",
+		LocaleID:   "missing",
+		FileFormat: "json",
+	})
+	if err == nil {
+		t.Fatalf("expected API error")
+	}
+	if !strings.Contains(err.Error(), "status=404") || !strings.Contains(err.Error(), "Locale not found") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestEncodeDecodeEntriesJSON(t *testing.T) {
 	in := []storage.Entry{{Key: "a", Locale: "fr", Value: "A"}, {Key: "b", Locale: "fr", Value: ""}, {Key: "a", Locale: "de", Value: "AA"}}
 	data, err := encodeEntriesJSON(in)

--- a/internal/i18n/storage/phrase/source_download.go
+++ b/internal/i18n/storage/phrase/source_download.go
@@ -1,0 +1,102 @@
+package phrase
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/antihax/optional"
+	phraseapi "github.com/phrase/phrase-go/v4"
+)
+
+// SourceDownloadInput describes one Phrase source locale download.
+type SourceDownloadInput struct {
+	ProjectID  string
+	APIToken   string
+	LocaleID   string
+	FileFormat string
+	Branch     string
+	Tags       []string
+}
+
+// SourceDownloadResult is the normalized content returned by a Phrase locale download.
+type SourceDownloadResult struct {
+	LocaleID string
+	Format   string
+	Content  []byte
+}
+
+// DownloadSourceFile downloads source locale content from Phrase Strings.
+func (c *HTTPClient) DownloadSourceFile(ctx context.Context, in SourceDownloadInput) (SourceDownloadResult, error) {
+	if strings.TrimSpace(in.ProjectID) == "" {
+		return SourceDownloadResult{}, fmt.Errorf("phrase source download: project id is required")
+	}
+	if strings.TrimSpace(in.APIToken) == "" {
+		return SourceDownloadResult{}, fmt.Errorf("phrase source download: api token is required")
+	}
+	if strings.TrimSpace(in.LocaleID) == "" {
+		return SourceDownloadResult{}, fmt.Errorf("phrase source download: source locale is required")
+	}
+	if strings.TrimSpace(in.FileFormat) == "" {
+		return SourceDownloadResult{}, fmt.Errorf("phrase source download: file format is required")
+	}
+
+	opts := phraseapi.LocaleDownloadOpts{
+		FileFormat: optional.NewString(strings.TrimSpace(in.FileFormat)),
+	}
+	if branch := strings.TrimSpace(in.Branch); branch != "" {
+		opts.Branch = optional.NewString(branch)
+	}
+	if tags := joinTrimmed(in.Tags); tags != "" {
+		opts.Tags = optional.NewString(tags)
+	}
+
+	content, err := c.downloadSourceFile(ctx, strings.TrimSpace(in.APIToken), strings.TrimSpace(in.ProjectID), strings.TrimSpace(in.LocaleID), &opts)
+	if err != nil {
+		return SourceDownloadResult{}, fmt.Errorf("phrase source download %q: %w", in.LocaleID, err)
+	}
+	return SourceDownloadResult{
+		LocaleID: strings.TrimSpace(in.LocaleID),
+		Format:   strings.TrimSpace(in.FileFormat),
+		Content:  content,
+	}, nil
+}
+
+func (c *HTTPClient) downloadSourceFile(ctx context.Context, token, projectID, localeID string, opts *phraseapi.LocaleDownloadOpts) ([]byte, error) {
+	authCtx := context.WithValue(ctx, phraseapi.ContextAPIKey, phraseapi.APIKey{Key: token, Prefix: "token"})
+	attempt := 0
+	for {
+		file, resp, err := c.phraseClient.LocalesApi.LocaleDownload(authCtx, projectID, localeID, opts)
+		if err == nil {
+			return readAndRemovePhraseTempFile(file)
+		}
+		if !shouldRetry(apiResponseHTTPResponse(resp), err) || attempt >= maxRetries {
+			return nil, phraseAPIError("GET", fmt.Sprintf("/projects/%s/locales/%s/download", projectID, localeID), resp, err)
+		}
+		delay := retryDelay(attempt, apiResponseHTTPResponse(resp))
+		attempt++
+		if err := sleepWithContext(ctx, delay); err != nil {
+			return nil, err
+		}
+	}
+}
+
+func readAndRemovePhraseTempFile(file *os.File) ([]byte, error) {
+	if file == nil {
+		return nil, fmt.Errorf("empty download response")
+	}
+	name := file.Name()
+	defer func() {
+		_ = file.Close()
+		if name != "" {
+			_ = os.Remove(name)
+		}
+	}()
+	content, err := io.ReadAll(file)
+	if err != nil {
+		return nil, fmt.Errorf("read download response: %w", err)
+	}
+	return content, nil
+}

--- a/internal/i18n/storage/phrase/source_download.go
+++ b/internal/i18n/storage/phrase/source_download.go
@@ -94,6 +94,9 @@ func readAndRemovePhraseTempFile(file *os.File) ([]byte, error) {
 			_ = os.Remove(name)
 		}
 	}()
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return nil, fmt.Errorf("seek download response: %w", err)
+	}
 	content, err := io.ReadAll(file)
 	if err != nil {
 		return nil, fmt.Errorf("read download response: %w", err)


### PR DESCRIPTION
## What changed

Added a Phrase source download flow for the CLI.

- Added `phrase download sources` with project, source locale, format, output, overwrite, branch, tag, token env, and API base URL flags.
- Added a Phrase storage helper for downloading source locale content through the Phrase API.
- Reused the existing Phrase auth pattern, including custom token env fallback to `PHRASE_API_TOKEN`.
- Added tests for command parsing, stdout/file output, overwrite protection, token errors, and mocked Phrase API success/error responses.

## How to test

- `make fmt`
- `make lint`
- `make test`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
