### PR TITLE
feat(cli): phrase download translation

### DIFF
--- a/apps/cli/cmd/phrase.go
+++ b/apps/cli/cmd/phrase.go
@@ -39,6 +39,19 @@ type phraseDownloadSourcesOptions struct {
 	dryRun       bool
 }
 
+type phraseDownloadTranslationsOptions struct {
+	projectID     string
+	targetLocales []string
+	format        string
+	output        string
+	branch        string
+	tags          []string
+	tokenEnv      string
+	apiBaseURL    string
+	force         bool
+	dryRun        bool
+}
+
 func newPhraseCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "phrase",
@@ -64,6 +77,7 @@ func newPhraseDownloadCmd() *cobra.Command {
 		Short: "download files from Phrase",
 	}
 	cmd.AddCommand(newPhraseDownloadSourcesCmd())
+	cmd.AddCommand(newPhraseDownloadTranslationsCmd())
 	return cmd
 }
 
@@ -81,6 +95,29 @@ func newPhraseDownloadSourcesCmd() *cobra.Command {
 	cmd.Flags().StringVar(&o.sourceLocale, "source-locale", "", "Phrase source locale ID or name")
 	cmd.Flags().StringVar(&o.format, "format", "", "Phrase file format, for example json, yml, or strings")
 	cmd.Flags().StringVarP(&o.output, "output", "o", "", "output file path; omit or use - for stdout")
+	cmd.Flags().StringVar(&o.branch, "branch", "", "Phrase branch name")
+	cmd.Flags().StringSliceVar(&o.tags, "tag", nil, "tag(s) to limit downloaded keys")
+	cmd.Flags().StringVar(&o.tokenEnv, "token-env", o.tokenEnv, "environment variable containing the Phrase API token")
+	cmd.Flags().StringVar(&o.apiBaseURL, "api-base-url", "", "Phrase API base URL")
+	cmd.Flags().BoolVar(&o.force, "force", false, "overwrite an existing output file")
+	cmd.Flags().BoolVar(&o.dryRun, "dry-run", false, "preview command without downloading content")
+	return cmd
+}
+
+func newPhraseDownloadTranslationsCmd() *cobra.Command {
+	o := phraseDownloadTranslationsOptions{tokenEnv: "PHRASE_API_TOKEN"}
+	cmd := &cobra.Command{
+		Use:          "translations",
+		Short:        "download translated content from Phrase",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return executePhraseDownloadTranslations(cmd, o)
+		},
+	}
+	cmd.Flags().StringVar(&o.projectID, "project-id", "", "Phrase project ID")
+	cmd.Flags().StringSliceVarP(&o.targetLocales, "target-locale", "l", nil, "Phrase target locale ID(s) or name(s)")
+	cmd.Flags().StringVar(&o.format, "format", "", "Phrase file format, for example json, yml, or strings")
+	cmd.Flags().StringVarP(&o.output, "output", "o", "", "output file path; omit or use - for stdout when downloading one locale; use %locale% for multiple locales")
 	cmd.Flags().StringVar(&o.branch, "branch", "", "Phrase branch name")
 	cmd.Flags().StringSliceVar(&o.tags, "tag", nil, "tag(s) to limit downloaded keys")
 	cmd.Flags().StringVar(&o.tokenEnv, "token-env", o.tokenEnv, "environment variable containing the Phrase API token")
@@ -168,6 +205,74 @@ func executePhraseUploadSources(cmd *cobra.Command, o phraseUploadSourcesOptions
 	return err
 }
 
+func executePhraseDownloadTranslations(cmd *cobra.Command, o phraseDownloadTranslationsOptions) error {
+	if strings.TrimSpace(o.projectID) == "" {
+		return fmt.Errorf("phrase download translations: --project-id is required")
+	}
+	locales := normalizePhraseLocales(o.targetLocales)
+	if len(locales) == 0 {
+		return fmt.Errorf("phrase download translations: at least one --target-locale is required")
+	}
+	if strings.TrimSpace(o.format) == "" {
+		return fmt.Errorf("phrase download translations: --format is required")
+	}
+
+	outputPath := strings.TrimSpace(o.output)
+	outputs, err := phraseTranslationOutputPaths(outputPath, locales)
+	if err != nil {
+		return err
+	}
+	if o.dryRun {
+		destination := outputPath
+		if destination == "" {
+			destination = "-"
+		}
+		_, err := fmt.Fprintf(cmd.OutOrStdout(), "dry-run action=phrase-download-translations project_id=%s target_locales=%s format=%s output=%s\n", strings.TrimSpace(o.projectID), strings.Join(locales, ","), strings.TrimSpace(o.format), destination)
+		return err
+	}
+	for _, output := range outputs {
+		if err := validatePhraseDownloadTranslationsOutputPath(output, o.force); err != nil {
+			return err
+		}
+	}
+
+	token, err := phraseAPIToken("phrase download translations", o.tokenEnv)
+	if err != nil {
+		return err
+	}
+
+	client, err := phrase.NewHTTPClientWithBaseURL(phrase.Config{}, o.apiBaseURL, &http.Client{Timeout: 30 * time.Second})
+	if err != nil {
+		return err
+	}
+	for idx, locale := range locales {
+		result, err := client.DownloadTranslationFile(backgroundContext(), phrase.TranslationDownloadInput{
+			ProjectID:  strings.TrimSpace(o.projectID),
+			APIToken:   token,
+			LocaleID:   locale,
+			FileFormat: strings.TrimSpace(o.format),
+			Branch:     strings.TrimSpace(o.branch),
+			Tags:       o.tags,
+		})
+		if err != nil {
+			return fmt.Errorf("phrase download translations: %w", err)
+		}
+
+		output := outputs[idx]
+		if output == "" || output == "-" {
+			_, err := cmd.OutOrStdout().Write(result.Content)
+			return err
+		}
+		if err := writePhraseDownloadedTranslation(output, result.Content, o.force); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "downloaded file=%s bytes=%d locale=%s format=%s\n", output, len(result.Content), result.LocaleID, result.Format); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func executePhraseDownloadSources(cmd *cobra.Command, o phraseDownloadSourcesOptions) error {
 	if strings.TrimSpace(o.projectID) == "" {
 		return fmt.Errorf("phrase download sources: --project-id is required")
@@ -242,6 +347,38 @@ func phraseAPIToken(action, tokenEnv string) (string, error) {
 	return token, nil
 }
 
+func writePhraseDownloadedTranslation(path string, content []byte, force bool) error {
+	if err := validatePhraseDownloadTranslationsOutputPath(path, force); err != nil {
+		return err
+	}
+	if path == "" || path == "-" {
+		return fmt.Errorf("phrase download translations: output file path is required")
+	}
+	if dir := filepath.Dir(path); dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("phrase download translations: mkdir output directory: %w", err)
+		}
+	}
+	if force {
+		return writePhraseDownloadedFileAtomic("phrase download translations", path, content, 0o644)
+	}
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		if os.IsExist(err) {
+			return fmt.Errorf("phrase download translations: output file %q already exists; use --force to overwrite", path)
+		}
+		return fmt.Errorf("phrase download translations: open output file %q: %w", path, err)
+	}
+	if _, err := file.Write(content); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("phrase download translations: write output file %q: %w", path, err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("phrase download translations: close output file %q: %w", path, err)
+	}
+	return nil
+}
+
 func writePhraseDownloadedSource(path string, content []byte, force bool) error {
 	if err := validatePhraseDownloadOutputPath(path, force); err != nil {
 		return err
@@ -255,7 +392,7 @@ func writePhraseDownloadedSource(path string, content []byte, force bool) error 
 		}
 	}
 	if force {
-		return writePhraseDownloadedSourceAtomic(path, content, 0o644)
+		return writePhraseDownloadedFileAtomic("phrase download sources", path, content, 0o644)
 	}
 	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
 	if err != nil {
@@ -274,11 +411,11 @@ func writePhraseDownloadedSource(path string, content []byte, force bool) error 
 	return nil
 }
 
-func writePhraseDownloadedSourceAtomic(path string, content []byte, perm os.FileMode) error {
+func writePhraseDownloadedFileAtomic(action, path string, content []byte, perm os.FileMode) error {
 	dir := filepath.Dir(path)
 	file, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
 	if err != nil {
-		return fmt.Errorf("phrase download sources: create temp output file %q: %w", path, err)
+		return fmt.Errorf("%s: create temp output file %q: %w", action, path, err)
 	}
 	tempPath := file.Name()
 	renamed := false
@@ -289,23 +426,40 @@ func writePhraseDownloadedSourceAtomic(path string, content []byte, perm os.File
 	}()
 	if _, err := file.Write(content); err != nil {
 		_ = file.Close()
-		return fmt.Errorf("phrase download sources: write temp output file %q: %w", path, err)
+		return fmt.Errorf("%s: write temp output file %q: %w", action, path, err)
 	}
 	if err := file.Chmod(perm); err != nil {
 		_ = file.Close()
-		return fmt.Errorf("phrase download sources: chmod temp output file %q: %w", path, err)
+		return fmt.Errorf("%s: chmod temp output file %q: %w", action, path, err)
 	}
 	if err := file.Sync(); err != nil {
 		_ = file.Close()
-		return fmt.Errorf("phrase download sources: sync temp output file %q: %w", path, err)
+		return fmt.Errorf("%s: sync temp output file %q: %w", action, path, err)
 	}
 	if err := file.Close(); err != nil {
-		return fmt.Errorf("phrase download sources: close temp output file %q: %w", path, err)
+		return fmt.Errorf("%s: close temp output file %q: %w", action, path, err)
 	}
 	if err := os.Rename(tempPath, path); err != nil {
-		return fmt.Errorf("phrase download sources: replace output file %q: %w", path, err)
+		return fmt.Errorf("%s: replace output file %q: %w", action, path, err)
 	}
 	renamed = true
+	return nil
+}
+
+func validatePhraseDownloadTranslationsOutputPath(path string, force bool) error {
+	if path == "" || path == "-" {
+		return nil
+	}
+	if info, err := os.Stat(path); err == nil {
+		if info.IsDir() {
+			return fmt.Errorf("phrase download translations: output file %q is a directory", path)
+		}
+		if !force {
+			return fmt.Errorf("phrase download translations: output file %q already exists; use --force to overwrite", path)
+		}
+	} else if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("phrase download translations: stat output file %q: %w", path, err)
+	}
 	return nil
 }
 
@@ -324,6 +478,48 @@ func validatePhraseDownloadOutputPath(path string, force bool) error {
 		return fmt.Errorf("phrase download sources: stat output file %q: %w", path, err)
 	}
 	return nil
+}
+
+func normalizePhraseLocales(values []string) []string {
+	locales := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		for _, part := range strings.Split(value, ",") {
+			locale := strings.TrimSpace(part)
+			if locale == "" {
+				continue
+			}
+			if _, ok := seen[locale]; ok {
+				continue
+			}
+			seen[locale] = struct{}{}
+			locales = append(locales, locale)
+		}
+	}
+	return locales
+}
+
+func phraseTranslationOutputPaths(output string, locales []string) ([]string, error) {
+	if len(locales) == 0 {
+		return nil, nil
+	}
+	if len(locales) == 1 {
+		if strings.Contains(output, "%locale%") {
+			return []string{strings.ReplaceAll(output, "%locale%", locales[0])}, nil
+		}
+		return []string{output}, nil
+	}
+	if output == "" || output == "-" {
+		return nil, fmt.Errorf("phrase download translations: --output with %%locale%% is required when downloading multiple target locales")
+	}
+	if !strings.Contains(output, "%locale%") {
+		return nil, fmt.Errorf("phrase download translations: --output must include %%locale%% when downloading multiple target locales")
+	}
+	paths := make([]string, 0, len(locales))
+	for _, locale := range locales {
+		paths = append(paths, strings.ReplaceAll(output, "%locale%", locale))
+	}
+	return paths, nil
 }
 
 func validatePhraseSourceFiles(paths []string) ([]string, error) {

--- a/apps/cli/cmd/phrase.go
+++ b/apps/cli/cmd/phrase.go
@@ -245,6 +245,7 @@ func executePhraseDownloadTranslations(cmd *cobra.Command, o phraseDownloadTrans
 	if err != nil {
 		return err
 	}
+	writtenOutputs := make([]string, 0, len(outputs))
 	for idx, locale := range locales {
 		result, err := client.DownloadTranslationFile(backgroundContext(), phrase.TranslationDownloadInput{
 			ProjectID:  strings.TrimSpace(o.projectID),
@@ -255,6 +256,7 @@ func executePhraseDownloadTranslations(cmd *cobra.Command, o phraseDownloadTrans
 			Tags:       o.tags,
 		})
 		if err != nil {
+			removePhraseDownloadedTranslationOutputs(writtenOutputs)
 			return fmt.Errorf("phrase download translations: %w", err)
 		}
 
@@ -264,9 +266,12 @@ func executePhraseDownloadTranslations(cmd *cobra.Command, o phraseDownloadTrans
 			return err
 		}
 		if err := writePhraseDownloadedTranslation(output, result.Content, o.force); err != nil {
+			removePhraseDownloadedTranslationOutputs(writtenOutputs)
 			return err
 		}
+		writtenOutputs = append(writtenOutputs, output)
 		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "downloaded file=%s bytes=%d locale=%s format=%s\n", output, len(result.Content), result.LocaleID, result.Format); err != nil {
+			removePhraseDownloadedTranslationOutputs(writtenOutputs)
 			return err
 		}
 	}
@@ -371,12 +376,20 @@ func writePhraseDownloadedTranslation(path string, content []byte, force bool) e
 	}
 	if _, err := file.Write(content); err != nil {
 		_ = file.Close()
+		_ = os.Remove(path)
 		return fmt.Errorf("phrase download translations: write output file %q: %w", path, err)
 	}
 	if err := file.Close(); err != nil {
+		_ = os.Remove(path)
 		return fmt.Errorf("phrase download translations: close output file %q: %w", path, err)
 	}
 	return nil
+}
+
+func removePhraseDownloadedTranslationOutputs(paths []string) {
+	for i := len(paths) - 1; i >= 0; i-- {
+		_ = os.Remove(paths[i])
+	}
 }
 
 func writePhraseDownloadedSource(path string, content []byte, force bool) error {

--- a/apps/cli/cmd/phrase.go
+++ b/apps/cli/cmd/phrase.go
@@ -265,11 +265,17 @@ func executePhraseDownloadTranslations(cmd *cobra.Command, o phraseDownloadTrans
 			_, err := cmd.OutOrStdout().Write(result.Content)
 			return err
 		}
+		outputExisted := false
+		if _, err := os.Stat(output); err == nil {
+			outputExisted = true
+		}
 		if err := writePhraseDownloadedTranslation(output, result.Content, o.force); err != nil {
 			removePhraseDownloadedTranslationOutputs(writtenOutputs)
 			return err
 		}
-		writtenOutputs = append(writtenOutputs, output)
+		if !outputExisted {
+			writtenOutputs = append(writtenOutputs, output)
+		}
 		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "downloaded file=%s bytes=%d locale=%s format=%s\n", output, len(result.Content), result.LocaleID, result.Format); err != nil {
 			removePhraseDownloadedTranslationOutputs(writtenOutputs)
 			return err

--- a/apps/cli/cmd/phrase_test.go
+++ b/apps/cli/cmd/phrase_test.go
@@ -486,6 +486,53 @@ func TestPhraseDownloadTranslationsRemovesWrittenFilesOnLaterFailure(t *testing.
 	}
 }
 
+func TestPhraseDownloadTranslationsForceKeepsOverwrittenFileOnLaterFailure(t *testing.T) {
+	t.Setenv("PHRASE_TEST_TOKEN", "secret")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/projects/project-1/locales/fr/download":
+			_, _ = w.Write([]byte(`{"hello":"Bonjour"}`))
+		case "/projects/project-1/locales/de/download":
+			http.Error(w, `{"message":"Locale not found"}`, http.StatusNotFound)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	frPath := filepath.Join(dir, "fr.json")
+	dePath := filepath.Join(dir, "de.json")
+	if err := os.WriteFile(frPath, []byte(`{"old":"Fr"}`), 0o644); err != nil {
+		t.Fatalf("write existing fr output: %v", err)
+	}
+	if err := os.WriteFile(dePath, []byte(`{"old":"De"}`), 0o644); err != nil {
+		t.Fatalf("write existing de output: %v", err)
+	}
+
+	cmd := newRootCmd("")
+	cmd.SetArgs([]string{"phrase", "download", "translations", "--project-id", "project-1", "--target-locale", "fr", "--target-locale", "de", "--format", "json", "--output", filepath.Join(dir, "%locale%.json"), "--force", "--token-env", "PHRASE_TEST_TOKEN", "--api-base-url", server.URL})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected later locale failure")
+	}
+	fr, readErr := os.ReadFile(frPath)
+	if readErr != nil {
+		t.Fatalf("fr output should still exist after later failure: %v", readErr)
+	}
+	if string(fr) != `{"hello":"Bonjour"}` {
+		t.Fatalf("expected overwritten fr output to be kept, got %q", string(fr))
+	}
+	de, readErr := os.ReadFile(dePath)
+	if readErr != nil {
+		t.Fatalf("de output should still exist after failure: %v", readErr)
+	}
+	if string(de) != `{"old":"De"}` {
+		t.Fatalf("expected de output to remain unchanged, got %q", string(de))
+	}
+}
+
 func TestPhraseDownloadTranslationsRefusesOverwriteWithoutForce(t *testing.T) {
 	outputPath := filepath.Join(t.TempDir(), "fr.json")
 	if err := os.WriteFile(outputPath, []byte(`{"old":"Old"}`), 0o644); err != nil {

--- a/apps/cli/cmd/phrase_test.go
+++ b/apps/cli/cmd/phrase_test.go
@@ -309,3 +309,166 @@ func TestPhraseDownloadSourcesTokenErrorListsFallback(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestPhraseDownloadTranslationsDryRun(t *testing.T) {
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"phrase", "download", "translations", "--project-id", "project-1", "--target-locale", "fr", "--format", "json", "--output", "fr.json", "--dry-run"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute phrase translation download dry-run: %v", err)
+	}
+	if !strings.Contains(out.String(), "dry-run action=phrase-download-translations") || !strings.Contains(out.String(), "target_locales=fr") || !strings.Contains(out.String(), "output=fr.json") {
+		t.Fatalf("unexpected output: %q", out.String())
+	}
+}
+
+func TestPhraseDownloadTranslationsRequiresTargetLocale(t *testing.T) {
+	cmd := newRootCmd("")
+	cmd.SetArgs([]string{"phrase", "download", "translations", "--project-id", "project-1", "--format", "json"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected missing target locale error")
+	}
+	if !strings.Contains(err.Error(), "at least one --target-locale is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPhraseDownloadTranslationsWritesStdout(t *testing.T) {
+	t.Setenv("PHRASE_TEST_TOKEN", "secret")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/projects/project-1/locales/fr/download" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "token secret" {
+			t.Fatalf("unexpected auth header: %q", r.Header.Get("Authorization"))
+		}
+		if got := r.URL.Query().Get("file_format"); got != "json" {
+			t.Fatalf("file_format = %q, want json", got)
+		}
+		if got := r.URL.Query().Get("branch"); got != "main" {
+			t.Fatalf("branch = %q, want main", got)
+		}
+		if got := r.URL.Query().Get("tags"); got != "app,reviewed" {
+			t.Fatalf("tags = %q, want app,reviewed", got)
+		}
+		_, _ = w.Write([]byte(`{"hello":"Bonjour"}`))
+	}))
+	defer server.Close()
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"phrase", "download", "translations", "--project-id", "project-1", "--target-locale", "fr", "--format", "json", "--branch", "main", "--tag", "app", "--tag", "reviewed", "--token-env", "PHRASE_TEST_TOKEN", "--api-base-url", server.URL})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute phrase translation download: %v", err)
+	}
+	if got := out.String(); got != `{"hello":"Bonjour"}` {
+		t.Fatalf("unexpected stdout content: %q", got)
+	}
+}
+
+func TestPhraseDownloadTranslationsWritesOutputFile(t *testing.T) {
+	t.Setenv("PHRASE_TEST_TOKEN", "secret")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"hello":"Bonjour"}`))
+	}))
+	defer server.Close()
+
+	outputPath := filepath.Join(t.TempDir(), "locales", "fr.json")
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"phrase", "download", "translations", "--project-id", "project-1", "--target-locale", "fr", "--format", "json", "--output", outputPath, "--token-env", "PHRASE_TEST_TOKEN", "--api-base-url", server.URL})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute phrase translation download: %v", err)
+	}
+	content, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read output file: %v", err)
+	}
+	if string(content) != `{"hello":"Bonjour"}` {
+		t.Fatalf("unexpected file content: %q", string(content))
+	}
+	if !strings.Contains(out.String(), "downloaded file="+outputPath) || !strings.Contains(out.String(), "locale=fr") {
+		t.Fatalf("unexpected output: %q", out.String())
+	}
+}
+
+func TestPhraseDownloadTranslationsMultipleLocalesUseOutputPattern(t *testing.T) {
+	t.Setenv("PHRASE_TEST_TOKEN", "secret")
+	requests := make([]string, 0, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.URL.Path)
+		switch r.URL.Path {
+		case "/projects/project-1/locales/fr/download":
+			_, _ = w.Write([]byte(`{"hello":"Bonjour"}`))
+		case "/projects/project-1/locales/de/download":
+			_, _ = w.Write([]byte(`{"hello":"Hallo"}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	outputPattern := filepath.Join(dir, "%locale%.json")
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"phrase", "download", "translations", "--project-id", "project-1", "--target-locale", "fr,de", "--format", "json", "--output", outputPattern, "--token-env", "PHRASE_TEST_TOKEN", "--api-base-url", server.URL})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute phrase translation download: %v", err)
+	}
+	if len(requests) != 2 {
+		t.Fatalf("requests len = %d, want 2", len(requests))
+	}
+	fr, err := os.ReadFile(filepath.Join(dir, "fr.json"))
+	if err != nil {
+		t.Fatalf("read fr output: %v", err)
+	}
+	de, err := os.ReadFile(filepath.Join(dir, "de.json"))
+	if err != nil {
+		t.Fatalf("read de output: %v", err)
+	}
+	if string(fr) != `{"hello":"Bonjour"}` || string(de) != `{"hello":"Hallo"}` {
+		t.Fatalf("unexpected outputs: fr=%q de=%q", string(fr), string(de))
+	}
+}
+
+func TestPhraseDownloadTranslationsMultipleLocalesRequireOutputPattern(t *testing.T) {
+	cmd := newRootCmd("")
+	cmd.SetArgs([]string{"phrase", "download", "translations", "--project-id", "project-1", "--target-locale", "fr", "--target-locale", "de", "--format", "json", "--output", "translations.json", "--dry-run"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected output pattern error")
+	}
+	if !strings.Contains(err.Error(), "must include %locale%") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPhraseDownloadTranslationsRefusesOverwriteWithoutForce(t *testing.T) {
+	outputPath := filepath.Join(t.TempDir(), "fr.json")
+	if err := os.WriteFile(outputPath, []byte(`{"old":"Old"}`), 0o644); err != nil {
+		t.Fatalf("write existing output: %v", err)
+	}
+	cmd := newRootCmd("")
+	cmd.SetArgs([]string{"phrase", "download", "translations", "--project-id", "project-1", "--target-locale", "fr", "--format", "json", "--output", outputPath})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected overwrite error")
+	}
+	if !strings.Contains(err.Error(), "already exists; use --force to overwrite") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/apps/cli/cmd/phrase_test.go
+++ b/apps/cli/cmd/phrase_test.go
@@ -456,6 +456,36 @@ func TestPhraseDownloadTranslationsMultipleLocalesRequireOutputPattern(t *testin
 	}
 }
 
+func TestPhraseDownloadTranslationsRemovesWrittenFilesOnLaterFailure(t *testing.T) {
+	t.Setenv("PHRASE_TEST_TOKEN", "secret")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/projects/project-1/locales/fr/download":
+			_, _ = w.Write([]byte(`{"hello":"Bonjour"}`))
+		case "/projects/project-1/locales/de/download":
+			http.Error(w, `{"message":"Locale not found"}`, http.StatusNotFound)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	cmd := newRootCmd("")
+	cmd.SetArgs([]string{"phrase", "download", "translations", "--project-id", "project-1", "--target-locale", "fr", "--target-locale", "de", "--format", "json", "--output", filepath.Join(dir, "%locale%.json"), "--token-env", "PHRASE_TEST_TOKEN", "--api-base-url", server.URL})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected later locale failure")
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "fr.json")); !os.IsNotExist(statErr) {
+		t.Fatalf("fr output should be removed after later failure, stat err=%v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "de.json")); !os.IsNotExist(statErr) {
+		t.Fatalf("de output should not exist after failure, stat err=%v", statErr)
+	}
+}
+
 func TestPhraseDownloadTranslationsRefusesOverwriteWithoutForce(t *testing.T) {
 	outputPath := filepath.Join(t.TempDir(), "fr.json")
 	if err := os.WriteFile(outputPath, []byte(`{"old":"Old"}`), 0o644); err != nil {

--- a/internal/i18n/storage/phrase/http_client_test.go
+++ b/internal/i18n/storage/phrase/http_client_test.go
@@ -235,6 +235,49 @@ func TestHTTPClientDownloadSourceFileAPIError(t *testing.T) {
 	}
 }
 
+func TestHTTPClientDownloadTranslationFile(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/projects/p/locales/fr/download", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %s, want GET", r.Method)
+		}
+		if r.Header.Get("Authorization") != "token x" {
+			t.Fatalf("unexpected auth header: %q", r.Header.Get("Authorization"))
+		}
+		if got := r.URL.Query().Get("file_format"); got != "json" {
+			t.Fatalf("file_format = %q, want json", got)
+		}
+		if got := r.URL.Query().Get("branch"); got != "main" {
+			t.Fatalf("branch = %q, want main", got)
+		}
+		if got := r.URL.Query().Get("tags"); got != "app,reviewed" {
+			t.Fatalf("tags = %q, want app,reviewed", got)
+		}
+		_, _ = w.Write([]byte(`{"hello":"Bonjour"}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client, err := NewHTTPClientWithBaseURL(Config{}, srv.URL, srv.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := client.DownloadTranslationFile(context.Background(), TranslationDownloadInput{
+		ProjectID:  "p",
+		APIToken:   "x",
+		LocaleID:   "fr",
+		FileFormat: "json",
+		Branch:     "main",
+		Tags:       []string{"app", "reviewed"},
+	})
+	if err != nil {
+		t.Fatalf("download translation file: %v", err)
+	}
+	if string(result.Content) != `{"hello":"Bonjour"}` || result.LocaleID != "fr" || result.Format != "json" {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+}
+
 func TestEncodeDecodeEntriesJSON(t *testing.T) {
 	in := []storage.Entry{{Key: "a", Locale: "fr", Value: "A"}, {Key: "b", Locale: "fr", Value: ""}, {Key: "a", Locale: "de", Value: "AA"}}
 	data, err := encodeEntriesJSON(in)

--- a/internal/i18n/storage/phrase/source_download.go
+++ b/internal/i18n/storage/phrase/source_download.go
@@ -28,6 +28,23 @@ type SourceDownloadResult struct {
 	Content  []byte
 }
 
+// TranslationDownloadInput describes one Phrase target locale download.
+type TranslationDownloadInput struct {
+	ProjectID  string
+	APIToken   string
+	LocaleID   string
+	FileFormat string
+	Branch     string
+	Tags       []string
+}
+
+// TranslationDownloadResult is the normalized content returned by a Phrase target locale download.
+type TranslationDownloadResult struct {
+	LocaleID string
+	Format   string
+	Content  []byte
+}
+
 // DownloadSourceFile downloads source locale content from Phrase Strings.
 func (c *HTTPClient) DownloadSourceFile(ctx context.Context, in SourceDownloadInput) (SourceDownloadResult, error) {
 	if strings.TrimSpace(in.ProjectID) == "" {
@@ -58,6 +75,42 @@ func (c *HTTPClient) DownloadSourceFile(ctx context.Context, in SourceDownloadIn
 		return SourceDownloadResult{}, fmt.Errorf("phrase source download %q: %w", in.LocaleID, err)
 	}
 	return SourceDownloadResult{
+		LocaleID: strings.TrimSpace(in.LocaleID),
+		Format:   strings.TrimSpace(in.FileFormat),
+		Content:  content,
+	}, nil
+}
+
+// DownloadTranslationFile downloads target locale content from Phrase Strings.
+func (c *HTTPClient) DownloadTranslationFile(ctx context.Context, in TranslationDownloadInput) (TranslationDownloadResult, error) {
+	if strings.TrimSpace(in.ProjectID) == "" {
+		return TranslationDownloadResult{}, fmt.Errorf("phrase translation download: project id is required")
+	}
+	if strings.TrimSpace(in.APIToken) == "" {
+		return TranslationDownloadResult{}, fmt.Errorf("phrase translation download: api token is required")
+	}
+	if strings.TrimSpace(in.LocaleID) == "" {
+		return TranslationDownloadResult{}, fmt.Errorf("phrase translation download: target locale is required")
+	}
+	if strings.TrimSpace(in.FileFormat) == "" {
+		return TranslationDownloadResult{}, fmt.Errorf("phrase translation download: file format is required")
+	}
+
+	opts := phraseapi.LocaleDownloadOpts{
+		FileFormat: optional.NewString(strings.TrimSpace(in.FileFormat)),
+	}
+	if branch := strings.TrimSpace(in.Branch); branch != "" {
+		opts.Branch = optional.NewString(branch)
+	}
+	if tags := joinTrimmed(in.Tags); tags != "" {
+		opts.Tags = optional.NewString(tags)
+	}
+
+	content, err := c.downloadSourceFile(ctx, strings.TrimSpace(in.APIToken), strings.TrimSpace(in.ProjectID), strings.TrimSpace(in.LocaleID), &opts)
+	if err != nil {
+		return TranslationDownloadResult{}, fmt.Errorf("phrase translation download %q: %w", in.LocaleID, err)
+	}
+	return TranslationDownloadResult{
 		LocaleID: strings.TrimSpace(in.LocaleID),
 		Format:   strings.TrimSpace(in.FileFormat),
 		Content:  content,


### PR DESCRIPTION
## What changed

Adds `phrase download translations` for downloading translated Phrase locale content through the CLI.

- Supports required project, target locale, and file format inputs.
- Supports stdout for single-locale downloads.
- Supports file output with overwrite protection and `--force`.
- Supports multi-locale downloads with `%locale%` output path expansion.
- Reuses the existing Phrase API token, branch, tag, and API base URL patterns.
- Adds mocked CLI and Phrase HTTP client tests for parsing, output behavior, locale selection, and download requests.

## How to test

- `go test ./apps/cli/cmd ./internal/i18n/storage/phrase`
- `make fmt`
- `make lint`
- `make test`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
