### PR TITLE
🧪 Scout: add unit tests for api-key utilities

### DIFF
--- a/apps/hyperlocalise-web/src/lib/api-keys.test.ts
+++ b/apps/hyperlocalise-web/src/lib/api-keys.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vite-plus/test";
 import { generateApiKey, getApiKeyPrefix, hashApiKey } from "./api-keys";
 
 describe("api-keys", () => {

--- a/apps/hyperlocalise-web/src/lib/api-keys.test.ts
+++ b/apps/hyperlocalise-web/src/lib/api-keys.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { generateApiKey, getApiKeyPrefix, hashApiKey } from "./api-keys";
+
+describe("api-keys", () => {
+  describe("generateApiKey", () => {
+    it("generates a key with the hl_ prefix", () => {
+      const key = generateApiKey();
+      expect(key.startsWith("hl_")).toBe(true);
+    });
+
+    it("generates a unique key each time", () => {
+      const key1 = generateApiKey();
+      const key2 = generateApiKey();
+      expect(key1).not.toBe(key2);
+    });
+
+    it("generates a key of expected length", () => {
+      const key = generateApiKey();
+      // hl_ (3) + 32 bytes base64url (approx 43-44 chars)
+      expect(key.length).toBeGreaterThan(40);
+    });
+  });
+
+  describe("hashApiKey", () => {
+    it("produces a consistent SHA-256 hash in hex", () => {
+      const key = "hl_test_key";
+      const hash = hashApiKey(key);
+      // echo -n "hl_test_key" | openssl dgst -sha256
+      // dc5371ae9c00ad488f90d632b68010cb8a019e2e944d741d4cb4a6e7e7a767b0
+      expect(hash).toBe("dc5371ae9c00ad488f90d632b68010cb8a019e2e944d741d4cb4a6e7e7a767b0");
+    });
+  });
+
+  describe("getApiKeyPrefix", () => {
+    it("extracts the first 8 characters of a key", () => {
+      const key = "hl_abcdefghijklmnopqrstuvwxyz";
+      expect(getApiKeyPrefix(key)).toBe("hl_abcde");
+    });
+
+    it("handles short keys by returning whatever is available", () => {
+      const key = "hl_";
+      expect(getApiKeyPrefix(key)).toBe("hl_");
+    });
+  });
+});


### PR DESCRIPTION
I have added unit tests for the API key utility functions in the web application. These tests ensure that API keys are generated correctly with the expected prefix, that hashing is consistent and matches standard SHA-256 output, and that prefix extraction behaves as expected. This increases confidence in our authentication and security layer.

Verification performed:
- Ran `vp test src/lib/api-keys.test.ts` (Passed 6/6)
- Ran `vp check --fix` (Passed)
- Ran full suite with `CI=true` to skip environment validation in the sandbox.

---
*PR created automatically by Jules for task [7548959551020885888](https://jules.google.com/task/7548959551020885888) started by @cungminh2710*