### PR TITLE
fix(crowdin): align project model with API v2 parity

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -1,0 +1,7 @@
+# Crowdin Steward's Journal
+
+## 2026-05-08 - Fix Project model parity for DelayedWorkflowStart and AiPreTranslate
+
+**Learning:** Crowdin API v2 uses `delayedWorkflowStart` as the JSON field name for delaying workflows, but the SDK was using `delayedTranslations`. Additionally, the `aiPreTranslate` field was missing from the `Project` response model despite being present in `ProjectsAddRequest`.
+
+**Action:** Updated `DelayedWorkflowStart` JSON tags in both `Project` and `ProjectsAddRequest` models. Added `AiPreTranslate` field to the `Project` model to ensure full response parity. Verified with contract tests using real API JSON shapes.

--- a/third_party/crowdin-api-client-go/crowdin/model/projects.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/projects.go
@@ -60,7 +60,7 @@ type (
 		QAChecksIgnorableCategories     map[string]bool            `json:"qaChecksIgnorableCategories,omitempty"`
 		CustomQACheckIDs                []int                      `json:"customQACheckIds,omitempty"`
 		LanguageMapping                 map[string]LanguageMapping `json:"languageMapping,omitempty"`
-		DelayedWorkflowStart            bool                       `json:"delayedTranslations,omitempty"`
+		DelayedWorkflowStart            bool                       `json:"delayedWorkflowStart,omitempty"`
 		NotificationSettings            *NotificationSettings      `json:"notificationSettings,omitempty"`
 		DefaultTMID                     int                        `json:"defaultTmId,omitempty"`
 		DefaultGlossaryID               int                        `json:"defaultGlossaryId,omitempty"`
@@ -70,6 +70,7 @@ type (
 		NormalizePlaceholder            bool                       `json:"normalizePlaceholder,omitempty"`
 		TMPreTranslate                  *ProjectTMPreTranslate     `json:"tmPreTranslate,omitempty"`
 		MTPreTranslate                  *ProjectMTPreTranslate     `json:"mtPreTranslate,omitempty"`
+		AiPreTranslate                  *ProjectAiPreTranslate     `json:"aiPreTranslate,omitempty"`
 		SaveMetaInfoInSource            bool                       `json:"saveMetaInfoInSource,omitempty"`
 		SkipUntranslatedFiles           bool                       `json:"skipUntranslatedFiles,omitempty"`
 		InContext                       bool                       `json:"inContext,omitempty"`
@@ -311,7 +312,7 @@ type ProjectsAddRequest struct {
 	//      between versions branches
 	TranslateDuplicates *int `json:"translateDuplicates,omitempty"`
 	// Delay workflow start after project creation. Default: false.
-	DelayedWorkflowStart *bool `json:"delayedTranslations,omitempty"`
+	DelayedWorkflowStart *bool `json:"delayedWorkflowStart,omitempty"`
 	// Defines whether to export only approved strings.
 	// Note: value greater than 0 can't be used with `exportStringsThatPassedWorkflow=true`
 	//       in same request.

--- a/third_party/crowdin-api-client-go/crowdin/parity_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/parity_test.go
@@ -1,0 +1,67 @@
+package crowdin
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/crowdin/crowdin-api-client-go/crowdin/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProjectsService_Get_Parity(t *testing.T) {
+	client, mux, teardown := setupClient()
+	defer teardown()
+
+	mux.HandleFunc("/api/v2/projects/1", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		fmt.Fprint(w, `{
+			"data": {
+				"id": 1,
+				"name": "Project 1",
+				"delayedWorkflowStart": true,
+				"aiPreTranslate": {
+					"enabled": true,
+					"aiPrompts": [
+						{
+							"aiPromptId": 123,
+							"languageIds": ["en"]
+						}
+					]
+				}
+			}
+		}`)
+	})
+
+	project, _, err := client.Projects.Get(context.Background(), 1)
+	require.NoError(t, err)
+
+	// This should PASS now
+	assert.True(t, project.DelayedWorkflowStart, "DelayedWorkflowStart should be true")
+	assert.NotNil(t, project.AiPreTranslate, "AiPreTranslate should not be nil")
+	assert.Equal(t, 123, project.AiPreTranslate.AiPrompts[0].AiPromptID)
+}
+
+func TestProjectsService_Add_Parity(t *testing.T) {
+	client, mux, teardown := setupClient()
+	defer teardown()
+
+	mux.HandleFunc("/api/v2/projects", func(w http.ResponseWriter, r *http.Request) {
+		testJSONBody(t, r, `{
+			"name": "New Project",
+			"sourceLanguageId": "en",
+			"delayedWorkflowStart": true
+		}`)
+		fmt.Fprint(w, `{"data": {"id": 1}}`)
+	})
+
+	req := &model.ProjectsAddRequest{
+		Name:                 "New Project",
+		SourceLanguageID:     "en",
+		DelayedWorkflowStart: ToPtr(true),
+	}
+	_, _, err := client.Projects.Add(context.Background(), req)
+	require.NoError(t, err)
+}

--- a/third_party/crowdin-api-client-go/crowdin/parity_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/parity_test.go
@@ -41,6 +41,7 @@ func TestProjectsService_Get_Parity(t *testing.T) {
 	// This should PASS now
 	assert.True(t, project.DelayedWorkflowStart, "DelayedWorkflowStart should be true")
 	assert.NotNil(t, project.AiPreTranslate, "AiPreTranslate should not be nil")
+	assert.Equal(t, true, *project.AiPreTranslate.Enabled, "AiPreTranslate.Enabled should be true")
 	assert.Equal(t, 123, project.AiPreTranslate.AiPrompts[0].AiPromptID)
 }
 


### PR DESCRIPTION
This PR improves Crowdin API v2 parity by correcting the JSON tags for project workflow delay and adding the missing AI pre-translation field to the project response model.

Specifically:
- Changed `delayedTranslations` to `delayedWorkflowStart` in `Project` and `ProjectsAddRequest` structs.
- Added `AiPreTranslate` field to the `Project` response struct.
- Added contract tests in `parity_test.go` to ensure these fields are correctly unmarshaled from documented Crowdin API v2 response shapes.
- Updated the Crowdin Steward journal.

Docs: https://developer.crowdin.com/api/v2/#operation/api.projects.get

---
*PR created automatically by Jules for task [15811096023177573221](https://jules.google.com/task/15811096023177573221) started by @cungminh2710*