### PR TITLE
feat(cli): add Crowdin glossary CSV download

### DIFF
--- a/apps/cli/cmd/crowdin.go
+++ b/apps/cli/cmd/crowdin.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"context"
 	"embed"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -28,6 +30,22 @@ type crowdinCommonOptions struct {
 	dryRun                  bool
 }
 
+type crowdinGlossaryDownloadOptions struct {
+	configPath   string
+	identityPath string
+	glossaryID   int
+	languages    []string
+	outputPath   string
+}
+
+type crowdinGlossaryCSVWriter interface {
+	WriteGlossaryCSV(context.Context, crowdinstorage.GlossaryDownloadRequest, io.Writer) (crowdinstorage.GlossaryDownloadResult, error)
+}
+
+var newCrowdinGlossaryCSVWriter = func(cfg crowdinstorage.Config) (crowdinGlossaryCSVWriter, error) {
+	return crowdinstorage.NewHTTPClient(cfg)
+}
+
 func newCrowdinCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "crowdin",
@@ -38,6 +56,7 @@ func newCrowdinCmd() *cobra.Command {
 	cmd.AddCommand(newCrowdinConfigCmd())
 	cmd.AddCommand(newCrowdinUploadCmd())
 	cmd.AddCommand(newCrowdinDownloadCmd())
+	cmd.AddCommand(newCrowdinGlossaryCmd())
 
 	return cmd
 }
@@ -191,6 +210,70 @@ func newCrowdinDownloadCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&o.skipUntranslatedStrings, "skip-untranslated-strings", false, "omit untranslated strings from downloaded files")
 	cmd.Flags().BoolVar(&o.mergeApproved, "merge-approved", false, "merge approved downloaded JSON strings into existing translation files")
 	cmd.Flags().BoolVar(&o.includeSources, "include-sources", false, "also download source files into files[].source paths")
+	return cmd
+}
+
+func newCrowdinGlossaryCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "glossary",
+		Short: "Crowdin glossary commands",
+	}
+	cmd.AddCommand(newCrowdinGlossaryDownloadCmd())
+	return cmd
+}
+
+func newCrowdinGlossaryDownloadCmd() *cobra.Command {
+	o := crowdinGlossaryDownloadOptions{}
+	cmd := &cobra.Command{
+		Use:          "download",
+		Short:        "download Crowdin glossary terms as CSV",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, _, err := crowdinstorage.LoadClientConfig(o.configPath, o.identityPath)
+			if err != nil {
+				return err
+			}
+			client, err := newCrowdinGlossaryCSVWriter(cfg)
+			if err != nil {
+				return err
+			}
+
+			out := cmd.OutOrStdout()
+			var closeOut func() error
+			if strings.TrimSpace(o.outputPath) != "" {
+				file, err := os.Create(o.outputPath)
+				if err != nil {
+					return fmt.Errorf("create glossary csv: %w", err)
+				}
+				out = file
+				closeOut = file.Close
+			}
+
+			result, err := client.WriteGlossaryCSV(backgroundContext(), crowdinstorage.GlossaryDownloadRequest{
+				GlossaryID: o.glossaryID,
+				Languages:  o.languages,
+			}, out)
+			if closeOut != nil {
+				if closeErr := closeOut(); closeErr != nil && err == nil {
+					err = fmt.Errorf("close glossary csv: %w", closeErr)
+				}
+			}
+			if err != nil {
+				return err
+			}
+			if strings.TrimSpace(o.outputPath) != "" {
+				_, err = fmt.Fprintf(cmd.OutOrStdout(), "wrote %s terms=%d\n", o.outputPath, result.Terms)
+				return err
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&o.configPath, "config", "", "path to crowdin.yml")
+	cmd.Flags().StringVar(&o.identityPath, "identity", "", "path to Crowdin identity file")
+	cmd.Flags().IntVar(&o.glossaryID, "glossary-id", 0, "Crowdin glossary identifier")
+	cmd.Flags().StringSliceVarP(&o.languages, "language", "l", nil, "term language(s) to include")
+	cmd.Flags().StringVarP(&o.outputPath, "output", "o", "", "write CSV to file instead of stdout")
+	_ = cmd.MarkFlagRequired("glossary-id")
 	return cmd
 }
 

--- a/apps/cli/cmd/crowdin_test.go
+++ b/apps/cli/cmd/crowdin_test.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -10,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/hyperlocalise/hyperlocalise/internal/i18n/storage"
+	crowdinstorage "github.com/hyperlocalise/hyperlocalise/internal/i18n/storage/crowdin"
 	"github.com/spf13/cobra"
 )
 
@@ -199,8 +202,120 @@ func TestCrowdinDownloadFlagsOmitRequestOptionsWhenUnset(t *testing.T) {
 	}
 }
 
+func TestCrowdinGlossaryDownloadWritesCSVToStdout(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("CROWDIN_PROJECT_ID", "123")
+	t.Setenv("CROWDIN_PERSONAL_TOKEN", "secret")
+
+	if err := os.WriteFile(filepath.Join(dir, "crowdin.yml"), []byte(`
+project_id: 123
+`), 0o644); err != nil {
+		t.Fatalf("write crowdin config: %v", err)
+	}
+
+	oldFactory := newCrowdinGlossaryCSVWriter
+	defer func() {
+		newCrowdinGlossaryCSVWriter = oldFactory
+	}()
+	fake := &fakeCrowdinGlossaryCSVWriter{}
+	newCrowdinGlossaryCSVWriter = func(cfg crowdinstorage.Config) (crowdinGlossaryCSVWriter, error) {
+		if cfg.ProjectID != "123" || cfg.APIToken != "secret" {
+			t.Fatalf("config = %#v, want project/token from crowdin config", cfg)
+		}
+		return fake, nil
+	}
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"crowdin", "glossary", "download", "--glossary-id", "77", "--language", "fr"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute crowdin glossary download: %v", err)
+	}
+	if got, want := out.String(), "term\nCheckout\n"; got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+	if fake.req.GlossaryID != 77 {
+		t.Fatalf("glossary id = %d, want 77", fake.req.GlossaryID)
+	}
+	if got, want := fake.req.Languages, []string{"fr"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("languages = %#v, want %#v", got, want)
+	}
+}
+
+func TestCrowdinGlossaryDownloadWritesCSVToFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("CROWDIN_PROJECT_ID", "123")
+	t.Setenv("CROWDIN_PERSONAL_TOKEN", "secret")
+
+	if err := os.WriteFile(filepath.Join(dir, "crowdin.yml"), []byte(`
+project_id: 123
+`), 0o644); err != nil {
+		t.Fatalf("write crowdin config: %v", err)
+	}
+
+	oldFactory := newCrowdinGlossaryCSVWriter
+	defer func() {
+		newCrowdinGlossaryCSVWriter = oldFactory
+	}()
+	newCrowdinGlossaryCSVWriter = func(crowdinstorage.Config) (crowdinGlossaryCSVWriter, error) {
+		return &fakeCrowdinGlossaryCSVWriter{}, nil
+	}
+
+	outputPath := filepath.Join(dir, "glossary.csv")
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"crowdin", "glossary", "download", "--glossary-id", "77", "--output", outputPath})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute crowdin glossary download: %v", err)
+	}
+	content, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if got, want := string(content), "term\nCheckout\n"; got != want {
+		t.Fatalf("file = %q, want %q", got, want)
+	}
+	if !strings.Contains(out.String(), "wrote "+outputPath+" terms=1") {
+		t.Fatalf("summary output = %q", out.String())
+	}
+}
+
+func TestCrowdinGlossaryDownloadRequiresGlossaryID(t *testing.T) {
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"crowdin", "glossary", "download"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected missing glossary id error")
+	}
+	if !strings.Contains(err.Error(), `required flag(s) "glossary-id" not set`) {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 type crowdinFailingWriter struct{}
 
 func (f *crowdinFailingWriter) Write(_ []byte) (int, error) {
 	return 0, errors.New("write failed")
+}
+
+type fakeCrowdinGlossaryCSVWriter struct {
+	req crowdinstorage.GlossaryDownloadRequest
+}
+
+func (f *fakeCrowdinGlossaryCSVWriter) WriteGlossaryCSV(_ context.Context, req crowdinstorage.GlossaryDownloadRequest, w io.Writer) (crowdinstorage.GlossaryDownloadResult, error) {
+	f.req = req
+	if _, err := io.WriteString(w, "term\nCheckout\n"); err != nil {
+		return crowdinstorage.GlossaryDownloadResult{}, err
+	}
+	return crowdinstorage.GlossaryDownloadResult{Terms: 1}, nil
 }

--- a/docs/adr/2026-05-09-crowdin-glossary-download-design.md
+++ b/docs/adr/2026-05-09-crowdin-glossary-download-design.md
@@ -1,0 +1,19 @@
+# Crowdin Glossary Download Design
+
+## Context
+
+HL-243 adds a non-interactive CLI command for downloading Crowdin glossary terms and exporting them as deterministic CSV. The existing CLI already has a `crowdin` command tree and configuration loader for `crowdin.yml`, identity files, and Crowdin credentials.
+
+## Decision
+
+Add `crowdin glossary download` under the existing Crowdin command tree. The command reuses Crowdin file workflow configuration for API token, base URL, and project identity, then requires `--glossary-id` to select the glossary. It writes CSV to stdout by default and supports `--output` for file output.
+
+The implementation uses the Crowdin terms and concepts APIs instead of Crowdin's asynchronous export endpoint. This keeps the CSV schema stable and lets Hyperlocalise include source term, translated terms, language IDs, term metadata, and concept metadata with predictable headers.
+
+## Error Handling
+
+The command fails before making API calls when configuration or `--glossary-id` is missing. API failures are wrapped with the operation that failed, such as `get glossary` or `list glossary terms`. Empty glossaries still produce a header-only CSV.
+
+## Testing
+
+Tests cover CLI flag parsing and stdout/file output through a command-level fake. Crowdin API behavior is tested with mocked HTTP responses for CSV formatting, language filtering, pagination, empty results, and API errors.

--- a/internal/i18n/storage/crowdin/fileconfig.go
+++ b/internal/i18n/storage/crowdin/fileconfig.go
@@ -130,6 +130,43 @@ func LoadFileWorkflowConfig(path, identityPath string) (storage.FileWorkflowConf
 	return cfg, resolvedPath, nil
 }
 
+// LoadClientConfig loads Crowdin credentials and API settings without requiring file workflow entries.
+func LoadClientConfig(path, identityPath string) (Config, string, error) {
+	resolvedPath, err := ResolveFileConfigPath(path)
+	if err != nil {
+		return Config{}, "", err
+	}
+
+	projectCfg, err := decodeYAMLFile[fileConfigYAML](resolvedPath)
+	if err != nil {
+		return Config{}, "", err
+	}
+
+	identityCfg, err := loadIdentityConfig(identityPath)
+	if err != nil {
+		return Config{}, "", err
+	}
+
+	projectID, err := resolveProjectID(projectCfg, identityCfg)
+	if err != nil {
+		return Config{}, "", err
+	}
+	apiToken, err := resolveAPIToken(projectCfg, identityCfg)
+	if err != nil {
+		return Config{}, "", err
+	}
+	baseURL, err := resolveBaseURL(projectCfg, identityCfg)
+	if err != nil {
+		return Config{}, "", err
+	}
+
+	return Config{
+		ProjectID:  projectID,
+		APIToken:   apiToken,
+		APIBaseURL: baseURL,
+	}, resolvedPath, nil
+}
+
 func loadIdentityConfig(path string) (identityConfigYAML, error) {
 	if strings.TrimSpace(path) != "" {
 		return decodeYAMLFile[identityConfigYAML](path)

--- a/internal/i18n/storage/crowdin/fileconfig_test.go
+++ b/internal/i18n/storage/crowdin/fileconfig_test.go
@@ -44,6 +44,36 @@ files:
 	}
 }
 
+func TestLoadClientConfigDoesNotRequireFileWorkflowEntries(t *testing.T) {
+	t.Setenv(defaultProjectIDEnvName, "123")
+	t.Setenv(defaultAPITokenEnvName, "secret")
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "crowdin.yml")
+	if err := os.WriteFile(configPath, []byte(`
+base_url: https://api.crowdin.test
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, resolvedPath, err := LoadClientConfig(configPath, "")
+	if err != nil {
+		t.Fatalf("load client config: %v", err)
+	}
+	if resolvedPath != configPath {
+		t.Fatalf("resolved path = %q, want %q", resolvedPath, configPath)
+	}
+	if cfg.ProjectID != "123" {
+		t.Fatalf("project id = %q, want 123", cfg.ProjectID)
+	}
+	if cfg.APIToken != "secret" {
+		t.Fatalf("api token = %q, want secret", cfg.APIToken)
+	}
+	if cfg.APIBaseURL != "https://api.crowdin.test" {
+		t.Fatalf("api base url = %q, want https://api.crowdin.test", cfg.APIBaseURL)
+	}
+}
+
 func TestLoadFileWorkflowConfigRejectsUnsupportedPlaceholder(t *testing.T) {
 	t.Setenv(defaultProjectIDEnvName, "123")
 	t.Setenv(defaultAPITokenEnvName, "secret")

--- a/internal/i18n/storage/crowdin/glossary.go
+++ b/internal/i18n/storage/crowdin/glossary.go
@@ -1,0 +1,248 @@
+package crowdin
+
+import (
+	"context"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/crowdin/crowdin-api-client-go/crowdin/model"
+)
+
+const glossaryCSVPageLimit = 500
+
+var glossaryCSVHeader = []string{
+	"glossary_id",
+	"concept_id",
+	"term_id",
+	"source_language",
+	"source_term",
+	"language",
+	"term",
+	"description",
+	"part_of_speech",
+	"type",
+	"status",
+	"gender",
+	"note",
+	"url",
+	"lemma",
+	"concept_subject",
+	"concept_definition",
+	"concept_note",
+	"concept_url",
+	"concept_figure",
+}
+
+// GlossaryDownloadRequest identifies the glossary terms to export.
+type GlossaryDownloadRequest struct {
+	GlossaryID int
+	Languages  []string
+}
+
+// GlossaryDownloadResult summarizes a glossary CSV export.
+type GlossaryDownloadResult struct {
+	Terms int
+}
+
+// WriteGlossaryCSV downloads glossary terms and writes them as stable CSV.
+func (c *HTTPClient) WriteGlossaryCSV(ctx context.Context, req GlossaryDownloadRequest, w io.Writer) (GlossaryDownloadResult, error) {
+	if c == nil || c.client == nil {
+		return GlossaryDownloadResult{}, fmt.Errorf("crowdin glossary download: client is nil")
+	}
+	if req.GlossaryID <= 0 {
+		return GlossaryDownloadResult{}, fmt.Errorf("crowdin glossary download: glossary id must be positive")
+	}
+	if w == nil {
+		return GlossaryDownloadResult{}, fmt.Errorf("crowdin glossary download: writer is nil")
+	}
+
+	glossary, _, err := c.client.Glossaries.GetGlossary(ctx, req.GlossaryID)
+	if err != nil {
+		return GlossaryDownloadResult{}, fmt.Errorf("get glossary: %w", err)
+	}
+	if glossary == nil {
+		return GlossaryDownloadResult{}, fmt.Errorf("get glossary: empty response")
+	}
+
+	terms, err := c.listGlossaryTerms(ctx, req.GlossaryID)
+	if err != nil {
+		return GlossaryDownloadResult{}, err
+	}
+	concepts, err := c.listGlossaryConcepts(ctx, req.GlossaryID)
+	if err != nil {
+		return GlossaryDownloadResult{}, err
+	}
+
+	sourceTerms := sourceTermsByConcept(terms, glossary.LanguageID)
+	rows := glossaryCSVRows(req.GlossaryID, glossary.LanguageID, terms, concepts, sourceTerms, req.Languages)
+	writer := csv.NewWriter(w)
+	if err := writer.Write(glossaryCSVHeader); err != nil {
+		return GlossaryDownloadResult{}, fmt.Errorf("write glossary csv header: %w", err)
+	}
+	for _, row := range rows {
+		if err := writer.Write(row); err != nil {
+			return GlossaryDownloadResult{}, fmt.Errorf("write glossary csv row: %w", err)
+		}
+	}
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return GlossaryDownloadResult{}, fmt.Errorf("flush glossary csv: %w", err)
+	}
+
+	return GlossaryDownloadResult{Terms: len(rows)}, nil
+}
+
+func (c *HTTPClient) listGlossaryTerms(ctx context.Context, glossaryID int) ([]*model.Term, error) {
+	var terms []*model.Term
+	offset := 0
+
+	for {
+		page, _, err := c.client.Glossaries.ListTerms(ctx, glossaryID, &model.TermsListOptions{
+			OrderBy: "id",
+			ListOptions: model.ListOptions{
+				Limit:  glossaryCSVPageLimit,
+				Offset: offset,
+			},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list glossary terms: %w", err)
+		}
+		terms = append(terms, page...)
+		if len(page) < glossaryCSVPageLimit {
+			break
+		}
+		offset += glossaryCSVPageLimit
+	}
+
+	return terms, nil
+}
+
+func (c *HTTPClient) listGlossaryConcepts(ctx context.Context, glossaryID int) (map[int]*model.Concept, error) {
+	concepts := make(map[int]*model.Concept)
+	offset := 0
+
+	for {
+		page, _, err := c.client.Glossaries.ListConcepts(ctx, glossaryID, &model.ConceptsListOptions{
+			OrderBy: "id",
+			ListOptions: model.ListOptions{
+				Limit:  glossaryCSVPageLimit,
+				Offset: offset,
+			},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list glossary concepts: %w", err)
+		}
+		for _, concept := range page {
+			if concept != nil {
+				concepts[concept.ID] = concept
+			}
+		}
+		if len(page) < glossaryCSVPageLimit {
+			break
+		}
+		offset += glossaryCSVPageLimit
+	}
+
+	return concepts, nil
+}
+
+func sourceTermsByConcept(terms []*model.Term, sourceLanguage string) map[int]string {
+	sourceTerms := make(map[int]string)
+	for _, term := range terms {
+		if term == nil || term.ConceptID == 0 || term.LanguageID != sourceLanguage {
+			continue
+		}
+		if _, exists := sourceTerms[term.ConceptID]; !exists {
+			sourceTerms[term.ConceptID] = term.Text
+		}
+	}
+	return sourceTerms
+}
+
+func glossaryCSVRows(
+	glossaryID int,
+	sourceLanguage string,
+	terms []*model.Term,
+	concepts map[int]*model.Concept,
+	sourceTerms map[int]string,
+	languages []string,
+) [][]string {
+	languageSet := make(map[string]struct{}, len(languages))
+	for _, language := range languages {
+		trimmed := strings.TrimSpace(language)
+		if trimmed != "" {
+			languageSet[trimmed] = struct{}{}
+		}
+	}
+
+	sortedTerms := slices.Clone(terms)
+	sort.SliceStable(sortedTerms, func(i, j int) bool {
+		left := sortedTerms[i]
+		right := sortedTerms[j]
+		if left == nil {
+			return false
+		}
+		if right == nil {
+			return true
+		}
+		if left.ConceptID != right.ConceptID {
+			return left.ConceptID < right.ConceptID
+		}
+		if left.LanguageID != right.LanguageID {
+			return left.LanguageID < right.LanguageID
+		}
+		return left.ID < right.ID
+	})
+
+	rows := make([][]string, 0, len(sortedTerms))
+	for _, term := range sortedTerms {
+		if term == nil {
+			continue
+		}
+		if len(languageSet) > 0 {
+			if _, ok := languageSet[term.LanguageID]; !ok {
+				continue
+			}
+		}
+		concept := concepts[term.ConceptID]
+		rows = append(rows, glossaryCSVRow(glossaryID, sourceLanguage, term, concept, sourceTerms[term.ConceptID]))
+	}
+	return rows
+}
+
+func glossaryCSVRow(glossaryID int, sourceLanguage string, term *model.Term, concept *model.Concept, sourceTerm string) []string {
+	row := []string{
+		fmt.Sprintf("%d", glossaryID),
+		fmt.Sprintf("%d", term.ConceptID),
+		fmt.Sprintf("%d", term.ID),
+		sourceLanguage,
+		sourceTerm,
+		term.LanguageID,
+		term.Text,
+		term.Description,
+		term.PartOfSpeech,
+		term.Type,
+		term.Status,
+		term.Gender,
+		term.Note,
+		term.URL,
+		term.Lemma,
+		"",
+		"",
+		"",
+		"",
+		"",
+	}
+	if concept != nil {
+		row[15] = concept.Subject
+		row[16] = concept.Definition
+		row[17] = concept.Note
+		row[18] = concept.URL
+		row[19] = concept.Figure
+	}
+	return row
+}

--- a/internal/i18n/storage/crowdin/glossary_test.go
+++ b/internal/i18n/storage/crowdin/glossary_test.go
@@ -1,0 +1,237 @@
+package crowdin
+
+import (
+	"bytes"
+	"context"
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestWriteGlossaryCSVWritesStableRows(t *testing.T) {
+	client, mux, teardown := newCrowdinHTTPClientForTest(t)
+	defer teardown()
+
+	mux.HandleFunc("/api/v2/glossaries/77", func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(t, r, http.MethodGet, "/api/v2/glossaries/77")
+		writeJSON(t, w, map[string]any{
+			"data": map[string]any{
+				"id":         77,
+				"languageId": "en",
+			},
+		})
+	})
+	mux.HandleFunc("/api/v2/glossaries/77/concepts", func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(t, r, http.MethodGet, "/api/v2/glossaries/77/concepts?limit=500&orderBy=id")
+		writeJSON(t, w, map[string]any{
+			"data": []any{
+				map[string]any{"data": map[string]any{
+					"id":           9,
+					"subject":      "checkout",
+					"definition":   "Checkout action",
+					"note":         "Use for ecommerce buttons",
+					"url":          "https://example.test/concepts/9",
+					"figure":       "https://example.test/concepts/9.png",
+					"translatable": true,
+				}},
+			},
+			"pagination": map[string]any{"offset": 0, "limit": 500},
+		})
+	})
+	mux.HandleFunc("/api/v2/glossaries/77/terms", func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(t, r, http.MethodGet, "/api/v2/glossaries/77/terms?limit=500&orderBy=id")
+		writeJSON(t, w, map[string]any{
+			"data": []any{
+				map[string]any{"data": map[string]any{
+					"id":           4,
+					"glossaryId":   77,
+					"languageId":   "fr",
+					"text":         "Commander",
+					"description":  "Button label",
+					"partOfSpeech": "verb",
+					"status":       "preferred",
+					"type":         "full form",
+					"gender":       "other",
+					"note":         "Imperative",
+					"url":          "https://example.test/terms/4",
+					"conceptId":    9,
+					"lemma":        "commander",
+				}},
+				map[string]any{"data": map[string]any{
+					"id":         3,
+					"glossaryId": 77,
+					"languageId": "en",
+					"text":       "Checkout",
+					"conceptId":  9,
+					"lemma":      "checkout",
+				}},
+			},
+			"pagination": map[string]any{"offset": 0, "limit": 500},
+		})
+	})
+
+	var out bytes.Buffer
+	result, err := client.WriteGlossaryCSV(context.Background(), GlossaryDownloadRequest{
+		GlossaryID: 77,
+		Languages:  []string{"fr"},
+	}, &out)
+	if err != nil {
+		t.Fatalf("write glossary csv: %v", err)
+	}
+	if result.Terms != 1 {
+		t.Fatalf("terms = %d, want 1", result.Terms)
+	}
+
+	records, err := csv.NewReader(strings.NewReader(out.String())).ReadAll()
+	if err != nil {
+		t.Fatalf("read csv: %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("record count = %d, want 2: %q", len(records), out.String())
+	}
+	if got, want := records[0], glossaryCSVHeader; !equalStrings(got, want) {
+		t.Fatalf("header = %#v, want %#v", got, want)
+	}
+	wantRow := []string{
+		"77",
+		"9",
+		"4",
+		"en",
+		"Checkout",
+		"fr",
+		"Commander",
+		"Button label",
+		"verb",
+		"full form",
+		"preferred",
+		"other",
+		"Imperative",
+		"https://example.test/terms/4",
+		"commander",
+		"checkout",
+		"Checkout action",
+		"Use for ecommerce buttons",
+		"https://example.test/concepts/9",
+		"https://example.test/concepts/9.png",
+	}
+	if got := records[1]; !equalStrings(got, wantRow) {
+		t.Fatalf("row = %#v, want %#v", got, wantRow)
+	}
+}
+
+func TestWriteGlossaryCSVPaginatesTerms(t *testing.T) {
+	client, mux, teardown := newCrowdinHTTPClientForTest(t)
+	defer teardown()
+
+	mux.HandleFunc("/api/v2/glossaries/88", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, map[string]any{"data": map[string]any{"id": 88, "languageId": "en"}})
+	})
+	mux.HandleFunc("/api/v2/glossaries/88/concepts", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, map[string]any{"data": []any{}, "pagination": map[string]any{"offset": 0, "limit": 500}})
+	})
+	mux.HandleFunc("/api/v2/glossaries/88/terms", func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Query().Get("offset") {
+		case "":
+			writeJSON(t, w, map[string]any{
+				"data":       termPayload(500),
+				"pagination": map[string]any{"offset": 0, "limit": 500},
+			})
+		case "500":
+			writeJSON(t, w, map[string]any{
+				"data": []any{
+					map[string]any{"data": map[string]any{"id": 501, "languageId": "fr", "text": "Term 501", "conceptId": 501}},
+				},
+				"pagination": map[string]any{"offset": 500, "limit": 500},
+			})
+		default:
+			t.Fatalf("unexpected offset %q", r.URL.Query().Get("offset"))
+		}
+	})
+
+	var out bytes.Buffer
+	result, err := client.WriteGlossaryCSV(context.Background(), GlossaryDownloadRequest{GlossaryID: 88}, &out)
+	if err != nil {
+		t.Fatalf("write glossary csv: %v", err)
+	}
+	if result.Terms != 501 {
+		t.Fatalf("terms = %d, want 501", result.Terms)
+	}
+}
+
+func TestWriteGlossaryCSVHandlesEmptyGlossary(t *testing.T) {
+	client, mux, teardown := newCrowdinHTTPClientForTest(t)
+	defer teardown()
+
+	mux.HandleFunc("/api/v2/glossaries/89", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, map[string]any{"data": map[string]any{"id": 89, "languageId": "en"}})
+	})
+	mux.HandleFunc("/api/v2/glossaries/89/concepts", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, map[string]any{"data": []any{}, "pagination": map[string]any{"offset": 0, "limit": 500}})
+	})
+	mux.HandleFunc("/api/v2/glossaries/89/terms", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, map[string]any{"data": []any{}, "pagination": map[string]any{"offset": 0, "limit": 500}})
+	})
+
+	var out bytes.Buffer
+	result, err := client.WriteGlossaryCSV(context.Background(), GlossaryDownloadRequest{GlossaryID: 89}, &out)
+	if err != nil {
+		t.Fatalf("write glossary csv: %v", err)
+	}
+	if result.Terms != 0 {
+		t.Fatalf("terms = %d, want 0", result.Terms)
+	}
+	if got, want := strings.TrimSpace(out.String()), strings.Join(glossaryCSVHeader, ","); got != want {
+		t.Fatalf("csv = %q, want %q", got, want)
+	}
+}
+
+func TestWriteGlossaryCSVReturnsAPIError(t *testing.T) {
+	client, mux, teardown := newCrowdinHTTPClientForTest(t)
+	defer teardown()
+
+	mux.HandleFunc("/api/v2/glossaries/90", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"error":{"message":"unauthorized"}}`, http.StatusUnauthorized)
+	})
+
+	var out bytes.Buffer
+	_, err := client.WriteGlossaryCSV(context.Background(), GlossaryDownloadRequest{GlossaryID: 90}, &out)
+	if err == nil || !strings.Contains(err.Error(), "get glossary") {
+		t.Fatalf("error = %v, want get glossary error", err)
+	}
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, value any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(value); err != nil {
+		t.Fatalf("write json: %v", err)
+	}
+}
+
+func termPayload(count int) []any {
+	terms := make([]any, 0, count)
+	for i := 1; i <= count; i++ {
+		terms = append(terms, map[string]any{"data": map[string]any{
+			"id":         i,
+			"languageId": "fr",
+			"text":       fmt.Sprintf("Term %d", i),
+			"conceptId":  i,
+		}})
+	}
+	return terms
+}
+
+func equalStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for idx := range left {
+		if left[idx] != right[idx] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## What changed

Added `hyperlocalise crowdin glossary download` for exporting Crowdin glossary terms as deterministic CSV.

This includes:
- `--glossary-id` for selecting the Crowdin glossary
- `--language/-l` for optional term language filtering
- `--output/-o` for writing CSV to a file, with stdout as the default
- Stable CSV headers for source terms, translated terms, term metadata, and concept metadata
- Paginated Crowdin term/concept fetching
- Credentials-only Crowdin config loading so glossary export does not require `files:` entries

Also added an ADR documenting the design decision to use terms/concepts APIs instead of Crowdin’s async export endpoint.

## How to test

- `make fmt`
- `make lint`
- `make test`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
