### PR TITLE
fix(crowdin): harden glossary CSV export

### DIFF
--- a/apps/cli/cmd/crowdin.go
+++ b/apps/cli/cmd/crowdin.go
@@ -260,7 +260,9 @@ func newCrowdinGlossaryDownloadCmd() *cobra.Command {
 			}
 			if err != nil {
 				if strings.TrimSpace(o.outputPath) != "" {
-					_ = os.Remove(o.outputPath)
+					if removeErr := os.Remove(o.outputPath); removeErr != nil && !os.IsNotExist(removeErr) {
+						return fmt.Errorf("%w; also failed to remove partial output: %v", err, removeErr)
+					}
 				}
 				return err
 			}

--- a/apps/cli/cmd/crowdin.go
+++ b/apps/cli/cmd/crowdin.go
@@ -259,6 +259,9 @@ func newCrowdinGlossaryDownloadCmd() *cobra.Command {
 				}
 			}
 			if err != nil {
+				if strings.TrimSpace(o.outputPath) != "" {
+					_ = os.Remove(o.outputPath)
+				}
 				return err
 			}
 			if strings.TrimSpace(o.outputPath) != "" {

--- a/internal/i18n/storage/crowdin/glossary.go
+++ b/internal/i18n/storage/crowdin/glossary.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"slices"
-	"sort"
 	"strings"
 
 	"github.com/crowdin/crowdin-api-client-go/crowdin/model"
@@ -180,22 +179,26 @@ func glossaryCSVRows(
 	}
 
 	sortedTerms := slices.Clone(terms)
-	sort.SliceStable(sortedTerms, func(i, j int) bool {
-		left := sortedTerms[i]
-		right := sortedTerms[j]
+	slices.SortStableFunc(sortedTerms, func(left, right *model.Term) int {
+		if left == nil && right == nil {
+			return 0
+		}
 		if left == nil {
-			return false
+			return 1
 		}
 		if right == nil {
-			return true
+			return -1
 		}
 		if left.ConceptID != right.ConceptID {
-			return left.ConceptID < right.ConceptID
+			return left.ConceptID - right.ConceptID
 		}
 		if left.LanguageID != right.LanguageID {
-			return left.LanguageID < right.LanguageID
+			if left.LanguageID < right.LanguageID {
+				return -1
+			}
+			return 1
 		}
-		return left.ID < right.ID
+		return left.ID - right.ID
 	})
 
 	rows := make([][]string, 0, len(sortedTerms))
@@ -238,11 +241,18 @@ func glossaryCSVRow(glossaryID int, sourceLanguage string, term *model.Term, con
 		"",
 	}
 	if concept != nil {
-		row[15] = concept.Subject
-		row[16] = concept.Definition
-		row[17] = concept.Note
-		row[18] = concept.URL
-		row[19] = concept.Figure
+		const (
+			idxConceptSubject    = 15
+			idxConceptDefinition = 16
+			idxConceptNote       = 17
+			idxConceptURL        = 18
+			idxConceptFigure     = 19
+		)
+		row[idxConceptSubject] = concept.Subject
+		row[idxConceptDefinition] = concept.Definition
+		row[idxConceptNote] = concept.Note
+		row[idxConceptURL] = concept.URL
+		row[idxConceptFigure] = concept.Figure
 	}
 	return row
 }

--- a/internal/i18n/storage/crowdin/glossary.go
+++ b/internal/i18n/storage/crowdin/glossary.go
@@ -1,6 +1,7 @@
 package crowdin
 
 import (
+	"cmp"
 	"context"
 	"encoding/csv"
 	"fmt"
@@ -190,7 +191,7 @@ func glossaryCSVRows(
 			return -1
 		}
 		if left.ConceptID != right.ConceptID {
-			return left.ConceptID - right.ConceptID
+			return cmp.Compare(left.ConceptID, right.ConceptID)
 		}
 		if left.LanguageID != right.LanguageID {
 			if left.LanguageID < right.LanguageID {
@@ -198,7 +199,7 @@ func glossaryCSVRows(
 			}
 			return 1
 		}
-		return left.ID - right.ID
+		return cmp.Compare(left.ID, right.ID)
 	})
 
 	rows := make([][]string, 0, len(sortedTerms))


### PR DESCRIPTION
### Motivation
- Prevent partially-written glossary CSV files being left behind when an export or file close fails, which can cause subsequent runs to consume or overwrite incomplete output.
- Make the mapping of concept fields to CSV columns explicit to avoid silent corruption if columns are reordered in the future.
- Simplify and modernize term sorting by using the Go 1.21+ `slices` API to remove an unnecessary `sort` import.

### Description
- When `WriteGlossaryCSV` or the file `Close` returns an error for explicit `--output` downloads, remove the partially-written file before returning the error in `apps/cli/cmd/crowdin.go` to avoid leaving stale output on disk.
- Replace hardcoded positional writes (`row[15]`..`row[19]`) with named local constants (`idxConceptSubject`, `idxConceptDefinition`, `idxConceptNote`, `idxConceptURL`, `idxConceptFigure`) in `internal/i18n/storage/crowdin/glossary.go` so column indices are explicit and maintainable.
- Replace `sort.SliceStable` with `slices.SortStableFunc` and drop the `sort` import in `internal/i18n/storage/crowdin/glossary.go` to use a stable, idiomatic comparison that pairs with `slices.Clone`.
- Run `gofmt/gofumpt`/`gci` formatting as part of the change.

### Testing
- Ran `make fmt`, which succeeded. 
- Ran `go test ./apps/cli/cmd ./internal/i18n/storage/crowdin`, which succeeded. 
- Running `make lint` failed in this environment because installing/running `golangci-lint` was blocked by toolchain/proxy limitations. 
- Running `make test` workspace-wide failed due to a local Go toolchain mismatch unrelated to these changes (compile version vs tool version), so full workspace tests could not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe642f8684832c995b76390534a245)