### PR TITLE
feat(cli): add Crowdin TM CSV download

### DIFF
--- a/apps/cli/cmd/crowdin.go
+++ b/apps/cli/cmd/crowdin.go
@@ -38,11 +38,28 @@ type crowdinGlossaryDownloadOptions struct {
 	outputPath   string
 }
 
+type crowdinTranslationMemoryDownloadOptions struct {
+	configPath          string
+	identityPath        string
+	translationMemoryID int
+	sourceLanguage      string
+	targetLanguages     []string
+	outputPath          string
+}
+
 type crowdinGlossaryCSVWriter interface {
 	WriteGlossaryCSV(context.Context, crowdinstorage.GlossaryDownloadRequest, io.Writer) (crowdinstorage.GlossaryDownloadResult, error)
 }
 
+type crowdinTranslationMemoryCSVWriter interface {
+	WriteTranslationMemoryCSV(context.Context, crowdinstorage.TranslationMemoryDownloadRequest, io.Writer) (crowdinstorage.TranslationMemoryDownloadResult, error)
+}
+
 var newCrowdinGlossaryCSVWriter = func(cfg crowdinstorage.Config) (crowdinGlossaryCSVWriter, error) {
+	return crowdinstorage.NewHTTPClient(cfg)
+}
+
+var newCrowdinTranslationMemoryCSVWriter = func(cfg crowdinstorage.Config) (crowdinTranslationMemoryCSVWriter, error) {
 	return crowdinstorage.NewHTTPClient(cfg)
 }
 
@@ -57,6 +74,7 @@ func newCrowdinCmd() *cobra.Command {
 	cmd.AddCommand(newCrowdinUploadCmd())
 	cmd.AddCommand(newCrowdinDownloadCmd())
 	cmd.AddCommand(newCrowdinGlossaryCmd())
+	cmd.AddCommand(newCrowdinTranslationMemoryCmd())
 
 	return cmd
 }
@@ -279,6 +297,80 @@ func newCrowdinGlossaryDownloadCmd() *cobra.Command {
 	cmd.Flags().StringSliceVarP(&o.languages, "language", "l", nil, "term language(s) to include")
 	cmd.Flags().StringVarP(&o.outputPath, "output", "o", "", "write CSV to file instead of stdout")
 	_ = cmd.MarkFlagRequired("glossary-id")
+	return cmd
+}
+
+func newCrowdinTranslationMemoryCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "tm",
+		Aliases: []string{"translation-memory"},
+		Short:   "Crowdin translation memory commands",
+	}
+	cmd.AddCommand(newCrowdinTranslationMemoryDownloadCmd())
+	return cmd
+}
+
+func newCrowdinTranslationMemoryDownloadCmd() *cobra.Command {
+	o := crowdinTranslationMemoryDownloadOptions{}
+	cmd := &cobra.Command{
+		Use:          "download",
+		Short:        "download Crowdin translation memory entries as CSV",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, _, err := crowdinstorage.LoadClientConfig(o.configPath, o.identityPath)
+			if err != nil {
+				return err
+			}
+			client, err := newCrowdinTranslationMemoryCSVWriter(cfg)
+			if err != nil {
+				return err
+			}
+
+			out := cmd.OutOrStdout()
+			var closeOut func() error
+			if strings.TrimSpace(o.outputPath) != "" {
+				file, err := os.Create(o.outputPath)
+				if err != nil {
+					return fmt.Errorf("create translation memory csv: %w", err)
+				}
+				out = file
+				closeOut = file.Close
+			}
+
+			result, err := client.WriteTranslationMemoryCSV(backgroundContext(), crowdinstorage.TranslationMemoryDownloadRequest{
+				TranslationMemoryID: o.translationMemoryID,
+				SourceLanguage:      o.sourceLanguage,
+				TargetLanguages:     o.targetLanguages,
+			}, out)
+			if closeOut != nil {
+				if closeErr := closeOut(); closeErr != nil && err == nil {
+					err = fmt.Errorf("close translation memory csv: %w", closeErr)
+				}
+			}
+			if err != nil {
+				if strings.TrimSpace(o.outputPath) != "" {
+					if removeErr := os.Remove(o.outputPath); removeErr != nil && !os.IsNotExist(removeErr) {
+						return fmt.Errorf("%w; also failed to remove partial output: %v", err, removeErr)
+					}
+				}
+				return err
+			}
+			if strings.TrimSpace(o.outputPath) != "" {
+				_, err = fmt.Fprintf(cmd.OutOrStdout(), "wrote %s rows=%d segments=%d\n", o.outputPath, result.Rows, result.Segments)
+				return err
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&o.configPath, "config", "", "path to crowdin.yml")
+	cmd.Flags().StringVar(&o.identityPath, "identity", "", "path to Crowdin identity file")
+	cmd.Flags().IntVar(&o.translationMemoryID, "tm-id", 0, "Crowdin translation memory identifier")
+	cmd.Flags().StringVar(&o.sourceLanguage, "source-language", "", "source language ID to export")
+	cmd.Flags().StringSliceVarP(&o.targetLanguages, "target-language", "l", nil, "target language ID(s) to export")
+	cmd.Flags().StringVarP(&o.outputPath, "output", "o", "", "write CSV to file instead of stdout")
+	_ = cmd.MarkFlagRequired("tm-id")
+	_ = cmd.MarkFlagRequired("source-language")
+	_ = cmd.MarkFlagRequired("target-language")
 	return cmd
 }
 

--- a/apps/cli/cmd/crowdin.go
+++ b/apps/cli/cmd/crowdin.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/hyperlocalise/hyperlocalise/internal/i18n/storage"
@@ -326,14 +327,17 @@ func newCrowdinTranslationMemoryDownloadCmd() *cobra.Command {
 				return err
 			}
 
+			outputPath := strings.TrimSpace(o.outputPath)
 			out := cmd.OutOrStdout()
 			var closeOut func() error
-			if strings.TrimSpace(o.outputPath) != "" {
-				file, err := os.Create(o.outputPath)
+			var tempPath string
+			if outputPath != "" {
+				file, err := os.CreateTemp(filepath.Dir(outputPath), "."+filepath.Base(outputPath)+".*.tmp")
 				if err != nil {
-					return fmt.Errorf("create translation memory csv: %w", err)
+					return fmt.Errorf("create temporary translation memory csv: %w", err)
 				}
 				out = file
+				tempPath = file.Name()
 				closeOut = file.Close
 			}
 
@@ -348,15 +352,21 @@ func newCrowdinTranslationMemoryDownloadCmd() *cobra.Command {
 				}
 			}
 			if err != nil {
-				if strings.TrimSpace(o.outputPath) != "" {
-					if removeErr := os.Remove(o.outputPath); removeErr != nil && !os.IsNotExist(removeErr) {
-						return fmt.Errorf("%w; also failed to remove partial output: %v", err, removeErr)
+				if tempPath != "" {
+					if removeErr := os.Remove(tempPath); removeErr != nil && !os.IsNotExist(removeErr) {
+						return fmt.Errorf("%w; also failed to remove temporary output: %v", err, removeErr)
 					}
 				}
 				return err
 			}
-			if strings.TrimSpace(o.outputPath) != "" {
-				_, err = fmt.Fprintf(cmd.OutOrStdout(), "wrote %s rows=%d segments=%d\n", o.outputPath, result.Rows, result.Segments)
+			if outputPath != "" {
+				if err := os.Rename(tempPath, outputPath); err != nil {
+					if removeErr := os.Remove(tempPath); removeErr != nil && !os.IsNotExist(removeErr) {
+						return fmt.Errorf("replace translation memory csv: %w; also failed to remove temporary output: %v", err, removeErr)
+					}
+					return fmt.Errorf("replace translation memory csv: %w", err)
+				}
+				_, err = fmt.Fprintf(cmd.OutOrStdout(), "wrote %s rows=%d segments=%d\n", outputPath, result.Rows, result.Segments)
 				return err
 			}
 			return nil

--- a/apps/cli/cmd/crowdin_test.go
+++ b/apps/cli/cmd/crowdin_test.go
@@ -319,3 +319,118 @@ func (f *fakeCrowdinGlossaryCSVWriter) WriteGlossaryCSV(_ context.Context, req c
 	}
 	return crowdinstorage.GlossaryDownloadResult{Terms: 1}, nil
 }
+
+func TestCrowdinTranslationMemoryDownloadWritesCSVToStdout(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("CROWDIN_PROJECT_ID", "123")
+	t.Setenv("CROWDIN_PERSONAL_TOKEN", "secret")
+
+	if err := os.WriteFile(filepath.Join(dir, "crowdin.yml"), []byte(`
+project_id: 123
+`), 0o644); err != nil {
+		t.Fatalf("write crowdin config: %v", err)
+	}
+
+	oldFactory := newCrowdinTranslationMemoryCSVWriter
+	defer func() {
+		newCrowdinTranslationMemoryCSVWriter = oldFactory
+	}()
+	fake := &fakeCrowdinTranslationMemoryCSVWriter{}
+	newCrowdinTranslationMemoryCSVWriter = func(cfg crowdinstorage.Config) (crowdinTranslationMemoryCSVWriter, error) {
+		if cfg.ProjectID != "123" || cfg.APIToken != "secret" {
+			t.Fatalf("config = %#v, want project/token from crowdin config", cfg)
+		}
+		return fake, nil
+	}
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"crowdin", "tm", "download", "--tm-id", "44", "--source-language", "en", "--target-language", "fr"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute crowdin tm download: %v", err)
+	}
+	if got, want := out.String(), "source_text,target_text\nCheckout,Commander\n"; got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+	if fake.req.TranslationMemoryID != 44 {
+		t.Fatalf("tm id = %d, want 44", fake.req.TranslationMemoryID)
+	}
+	if fake.req.SourceLanguage != "en" {
+		t.Fatalf("source language = %q, want en", fake.req.SourceLanguage)
+	}
+	if got, want := fake.req.TargetLanguages, []string{"fr"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("target languages = %#v, want %#v", got, want)
+	}
+}
+
+func TestCrowdinTranslationMemoryDownloadWritesCSVToFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("CROWDIN_PROJECT_ID", "123")
+	t.Setenv("CROWDIN_PERSONAL_TOKEN", "secret")
+
+	if err := os.WriteFile(filepath.Join(dir, "crowdin.yml"), []byte(`
+project_id: 123
+`), 0o644); err != nil {
+		t.Fatalf("write crowdin config: %v", err)
+	}
+
+	oldFactory := newCrowdinTranslationMemoryCSVWriter
+	defer func() {
+		newCrowdinTranslationMemoryCSVWriter = oldFactory
+	}()
+	newCrowdinTranslationMemoryCSVWriter = func(crowdinstorage.Config) (crowdinTranslationMemoryCSVWriter, error) {
+		return &fakeCrowdinTranslationMemoryCSVWriter{}, nil
+	}
+
+	outputPath := filepath.Join(dir, "tm.csv")
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"crowdin", "translation-memory", "download", "--tm-id", "44", "--source-language", "en", "--target-language", "fr", "--output", outputPath})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute crowdin tm download: %v", err)
+	}
+	content, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if got, want := string(content), "source_text,target_text\nCheckout,Commander\n"; got != want {
+		t.Fatalf("file = %q, want %q", got, want)
+	}
+	if !strings.Contains(out.String(), "wrote "+outputPath+" rows=1 segments=1") {
+		t.Fatalf("summary output = %q", out.String())
+	}
+}
+
+func TestCrowdinTranslationMemoryDownloadRequiresInputs(t *testing.T) {
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"crowdin", "tm", "download"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected missing tm input error")
+	}
+	if !strings.Contains(err.Error(), `required flag(s)`) || !strings.Contains(err.Error(), `"tm-id"`) {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+type fakeCrowdinTranslationMemoryCSVWriter struct {
+	req crowdinstorage.TranslationMemoryDownloadRequest
+}
+
+func (f *fakeCrowdinTranslationMemoryCSVWriter) WriteTranslationMemoryCSV(_ context.Context, req crowdinstorage.TranslationMemoryDownloadRequest, w io.Writer) (crowdinstorage.TranslationMemoryDownloadResult, error) {
+	f.req = req
+	if _, err := io.WriteString(w, "source_text,target_text\nCheckout,Commander\n"); err != nil {
+		return crowdinstorage.TranslationMemoryDownloadResult{}, err
+	}
+	return crowdinstorage.TranslationMemoryDownloadResult{Rows: 1, Segments: 1}, nil
+}

--- a/apps/cli/cmd/crowdin_test.go
+++ b/apps/cli/cmd/crowdin_test.go
@@ -423,12 +423,59 @@ func TestCrowdinTranslationMemoryDownloadRequiresInputs(t *testing.T) {
 	}
 }
 
+func TestCrowdinTranslationMemoryDownloadPreservesExistingFileOnError(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("CROWDIN_PROJECT_ID", "123")
+	t.Setenv("CROWDIN_PERSONAL_TOKEN", "secret")
+
+	if err := os.WriteFile(filepath.Join(dir, "crowdin.yml"), []byte(`
+project_id: 123
+`), 0o644); err != nil {
+		t.Fatalf("write crowdin config: %v", err)
+	}
+
+	oldFactory := newCrowdinTranslationMemoryCSVWriter
+	defer func() {
+		newCrowdinTranslationMemoryCSVWriter = oldFactory
+	}()
+	newCrowdinTranslationMemoryCSVWriter = func(crowdinstorage.Config) (crowdinTranslationMemoryCSVWriter, error) {
+		return &fakeCrowdinTranslationMemoryCSVWriter{err: errors.New("api failed")}, nil
+	}
+
+	outputPath := filepath.Join(dir, "tm.csv")
+	if err := os.WriteFile(outputPath, []byte("existing csv\n"), 0o644); err != nil {
+		t.Fatalf("write existing output: %v", err)
+	}
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"crowdin", "tm", "download", "--tm-id", "44", "--source-language", "en", "--target-language", "fr", "--output", outputPath})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "api failed") {
+		t.Fatalf("error = %v, want api failed", err)
+	}
+	content, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read existing output: %v", err)
+	}
+	if got, want := string(content), "existing csv\n"; got != want {
+		t.Fatalf("file = %q, want preserved %q", got, want)
+	}
+}
+
 type fakeCrowdinTranslationMemoryCSVWriter struct {
 	req crowdinstorage.TranslationMemoryDownloadRequest
+	err error
 }
 
 func (f *fakeCrowdinTranslationMemoryCSVWriter) WriteTranslationMemoryCSV(_ context.Context, req crowdinstorage.TranslationMemoryDownloadRequest, w io.Writer) (crowdinstorage.TranslationMemoryDownloadResult, error) {
 	f.req = req
+	if f.err != nil {
+		return crowdinstorage.TranslationMemoryDownloadResult{}, f.err
+	}
 	if _, err := io.WriteString(w, "source_text,target_text\nCheckout,Commander\n"); err != nil {
 		return crowdinstorage.TranslationMemoryDownloadResult{}, err
 	}

--- a/internal/i18n/storage/crowdin/translation_memory.go
+++ b/internal/i18n/storage/crowdin/translation_memory.go
@@ -14,25 +14,27 @@ import (
 
 const translationMemoryCSVPageLimit = 500
 
-var translationMemoryCSVHeader = []string{
-	"tm_id",
-	"segment_id",
-	"source_locale",
-	"target_locale",
-	"source_text",
-	"target_text",
-	"source_record_id",
-	"target_record_id",
-	"source_usage_count",
-	"target_usage_count",
-	"source_created_at",
-	"target_created_at",
-	"source_updated_at",
-	"target_updated_at",
-	"source_created_by",
-	"target_created_by",
-	"source_updated_by",
-	"target_updated_by",
+func translationMemoryCSVHeader() []string {
+	return []string{
+		"tm_id",
+		"segment_id",
+		"source_locale",
+		"target_locale",
+		"source_text",
+		"target_text",
+		"source_record_id",
+		"target_record_id",
+		"source_usage_count",
+		"target_usage_count",
+		"source_created_at",
+		"target_created_at",
+		"source_updated_at",
+		"target_updated_at",
+		"source_created_by",
+		"target_created_by",
+		"source_updated_by",
+		"target_updated_by",
+	}
 }
 
 // TranslationMemoryDownloadRequest identifies the Crowdin translation memory records to export.
@@ -73,7 +75,7 @@ func (c *HTTPClient) WriteTranslationMemoryCSV(ctx context.Context, req Translat
 
 	rows := translationMemoryCSVRows(req.TranslationMemoryID, segments, strings.TrimSpace(req.SourceLanguage), req.TargetLanguages)
 	writer := csv.NewWriter(w)
-	if err := writer.Write(translationMemoryCSVHeader); err != nil {
+	if err := writer.Write(translationMemoryCSVHeader()); err != nil {
 		return TranslationMemoryDownloadResult{}, fmt.Errorf("write translation memory csv header: %w", err)
 	}
 	for _, row := range rows {
@@ -204,10 +206,10 @@ func translationMemoryCSVRow(tmID, segmentID int, sourceLanguage string, source,
 		target.CreatedAt,
 		source.UpdatedAt,
 		target.UpdatedAt,
-		formatOptionalInt(source.CreatedBy),
-		formatOptionalInt(target.CreatedBy),
-		formatOptionalInt(source.UpdatedBy),
-		formatOptionalInt(target.UpdatedBy),
+		fmt.Sprintf("%d", source.CreatedBy),
+		fmt.Sprintf("%d", target.CreatedBy),
+		fmt.Sprintf("%d", source.UpdatedBy),
+		fmt.Sprintf("%d", target.UpdatedBy),
 	}
 }
 
@@ -226,11 +228,4 @@ func normalizeLanguages(languages []string) []string {
 		normalized = append(normalized, trimmed)
 	}
 	return normalized
-}
-
-func formatOptionalInt(value int) string {
-	if value == 0 {
-		return ""
-	}
-	return fmt.Sprintf("%d", value)
 }

--- a/internal/i18n/storage/crowdin/translation_memory.go
+++ b/internal/i18n/storage/crowdin/translation_memory.go
@@ -1,0 +1,236 @@
+package crowdin
+
+import (
+	"cmp"
+	"context"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+
+	"github.com/crowdin/crowdin-api-client-go/crowdin/model"
+)
+
+const translationMemoryCSVPageLimit = 500
+
+var translationMemoryCSVHeader = []string{
+	"tm_id",
+	"segment_id",
+	"source_locale",
+	"target_locale",
+	"source_text",
+	"target_text",
+	"source_record_id",
+	"target_record_id",
+	"source_usage_count",
+	"target_usage_count",
+	"source_created_at",
+	"target_created_at",
+	"source_updated_at",
+	"target_updated_at",
+	"source_created_by",
+	"target_created_by",
+	"source_updated_by",
+	"target_updated_by",
+}
+
+// TranslationMemoryDownloadRequest identifies the Crowdin translation memory records to export.
+type TranslationMemoryDownloadRequest struct {
+	TranslationMemoryID int
+	SourceLanguage      string
+	TargetLanguages     []string
+}
+
+// TranslationMemoryDownloadResult summarizes a translation memory CSV export.
+type TranslationMemoryDownloadResult struct {
+	Rows     int
+	Segments int
+}
+
+// WriteTranslationMemoryCSV downloads translation memory segments and writes source/target pairs as stable CSV.
+func (c *HTTPClient) WriteTranslationMemoryCSV(ctx context.Context, req TranslationMemoryDownloadRequest, w io.Writer) (TranslationMemoryDownloadResult, error) {
+	if c == nil || c.client == nil {
+		return TranslationMemoryDownloadResult{}, fmt.Errorf("crowdin translation memory download: client is nil")
+	}
+	if req.TranslationMemoryID <= 0 {
+		return TranslationMemoryDownloadResult{}, fmt.Errorf("crowdin translation memory download: translation memory id must be positive")
+	}
+	if strings.TrimSpace(req.SourceLanguage) == "" {
+		return TranslationMemoryDownloadResult{}, fmt.Errorf("crowdin translation memory download: source language is required")
+	}
+	if len(normalizeLanguages(req.TargetLanguages)) == 0 {
+		return TranslationMemoryDownloadResult{}, fmt.Errorf("crowdin translation memory download: at least one target language is required")
+	}
+	if w == nil {
+		return TranslationMemoryDownloadResult{}, fmt.Errorf("crowdin translation memory download: writer is nil")
+	}
+
+	segments, err := c.listTranslationMemorySegments(ctx, req.TranslationMemoryID)
+	if err != nil {
+		return TranslationMemoryDownloadResult{}, err
+	}
+
+	rows := translationMemoryCSVRows(req.TranslationMemoryID, segments, strings.TrimSpace(req.SourceLanguage), req.TargetLanguages)
+	writer := csv.NewWriter(w)
+	if err := writer.Write(translationMemoryCSVHeader); err != nil {
+		return TranslationMemoryDownloadResult{}, fmt.Errorf("write translation memory csv header: %w", err)
+	}
+	for _, row := range rows {
+		if err := writer.Write(row); err != nil {
+			return TranslationMemoryDownloadResult{}, fmt.Errorf("write translation memory csv row: %w", err)
+		}
+	}
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return TranslationMemoryDownloadResult{}, fmt.Errorf("flush translation memory csv: %w", err)
+	}
+
+	return TranslationMemoryDownloadResult{Rows: len(rows), Segments: len(segments)}, nil
+}
+
+func (c *HTTPClient) listTranslationMemorySegments(ctx context.Context, tmID int) ([]*model.TMSegment, error) {
+	var segments []*model.TMSegment
+	offset := 0
+
+	for {
+		page, _, err := c.client.TranslationMemory.ListTMSegments(ctx, tmID, &model.TMSegmentsListOptions{
+			OrderBy: "id",
+			ListOptions: model.ListOptions{
+				Limit:  translationMemoryCSVPageLimit,
+				Offset: offset,
+			},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list translation memory segments: %w", err)
+		}
+		segments = append(segments, page...)
+		if len(page) < translationMemoryCSVPageLimit {
+			break
+		}
+		offset += translationMemoryCSVPageLimit
+	}
+
+	return segments, nil
+}
+
+func translationMemoryCSVRows(tmID int, segments []*model.TMSegment, sourceLanguage string, targetLanguages []string) [][]string {
+	targetSet := make(map[string]struct{})
+	for _, language := range normalizeLanguages(targetLanguages) {
+		targetSet[language] = struct{}{}
+	}
+
+	sortedSegments := slices.Clone(segments)
+	slices.SortStableFunc(sortedSegments, func(left, right *model.TMSegment) int {
+		if left == nil && right == nil {
+			return 0
+		}
+		if left == nil {
+			return 1
+		}
+		if right == nil {
+			return -1
+		}
+		return cmp.Compare(left.ID, right.ID)
+	})
+
+	rows := make([][]string, 0, len(sortedSegments))
+	for _, segment := range sortedSegments {
+		if segment == nil {
+			continue
+		}
+		sourceRecord, targets := translationMemorySegmentRecords(segment, sourceLanguage, targetSet)
+		if sourceRecord == nil {
+			continue
+		}
+		for _, target := range targets {
+			rows = append(rows, translationMemoryCSVRow(tmID, segment.ID, sourceLanguage, sourceRecord, target))
+		}
+	}
+	return rows
+}
+
+func translationMemorySegmentRecords(segment *model.TMSegment, sourceLanguage string, targetSet map[string]struct{}) (*model.TMSegmentRecord, []*model.TMSegmentRecord) {
+	records := slices.Clone(segment.Records)
+	slices.SortStableFunc(records, func(left, right *model.TMSegmentRecord) int {
+		if left == nil && right == nil {
+			return 0
+		}
+		if left == nil {
+			return 1
+		}
+		if right == nil {
+			return -1
+		}
+		if left.LanguageID != right.LanguageID {
+			if left.LanguageID < right.LanguageID {
+				return -1
+			}
+			return 1
+		}
+		return cmp.Compare(left.ID, right.ID)
+	})
+
+	var sourceRecord *model.TMSegmentRecord
+	targets := make([]*model.TMSegmentRecord, 0, len(records))
+	for _, record := range records {
+		if record == nil {
+			continue
+		}
+		if record.LanguageID == sourceLanguage && sourceRecord == nil {
+			sourceRecord = record
+			continue
+		}
+		if _, ok := targetSet[record.LanguageID]; ok {
+			targets = append(targets, record)
+		}
+	}
+	return sourceRecord, targets
+}
+
+func translationMemoryCSVRow(tmID, segmentID int, sourceLanguage string, source, target *model.TMSegmentRecord) []string {
+	return []string{
+		fmt.Sprintf("%d", tmID),
+		fmt.Sprintf("%d", segmentID),
+		sourceLanguage,
+		target.LanguageID,
+		source.Text,
+		target.Text,
+		fmt.Sprintf("%d", source.ID),
+		fmt.Sprintf("%d", target.ID),
+		fmt.Sprintf("%d", source.UsageCount),
+		fmt.Sprintf("%d", target.UsageCount),
+		source.CreatedAt,
+		target.CreatedAt,
+		source.UpdatedAt,
+		target.UpdatedAt,
+		formatOptionalInt(source.CreatedBy),
+		formatOptionalInt(target.CreatedBy),
+		formatOptionalInt(source.UpdatedBy),
+		formatOptionalInt(target.UpdatedBy),
+	}
+}
+
+func normalizeLanguages(languages []string) []string {
+	normalized := make([]string, 0, len(languages))
+	seen := make(map[string]struct{}, len(languages))
+	for _, language := range languages {
+		trimmed := strings.TrimSpace(language)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		normalized = append(normalized, trimmed)
+	}
+	return normalized
+}
+
+func formatOptionalInt(value int) string {
+	if value == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%d", value)
+}

--- a/internal/i18n/storage/crowdin/translation_memory_test.go
+++ b/internal/i18n/storage/crowdin/translation_memory_test.go
@@ -51,10 +51,10 @@ func TestWriteTranslationMemoryCSVWritesStableRows(t *testing.T) {
 	if len(records) != 3 {
 		t.Fatalf("record count = %d, want 3: %q", len(records), out.String())
 	}
-	if got, want := records[0], translationMemoryCSVHeader; !equalStrings(got, want) {
+	if got, want := records[0], translationMemoryCSVHeader(); !equalStrings(got, want) {
 		t.Fatalf("header = %#v, want %#v", got, want)
 	}
-	wantFirst := []string{"44", "9", "en", "es", "Checkout", "Pagar", "91", "93", "5", "1", "2024-01-01T03:04:05+00:00", "", "2024-01-04T03:04:05+00:00", "", "3", "", "4", ""}
+	wantFirst := []string{"44", "9", "en", "es", "Checkout", "Pagar", "91", "93", "5", "1", "2024-01-01T03:04:05+00:00", "", "2024-01-04T03:04:05+00:00", "", "3", "0", "4", "0"}
 	if got := records[1]; !equalStrings(got, wantFirst) {
 		t.Fatalf("first row = %#v, want %#v", got, wantFirst)
 	}
@@ -119,7 +119,7 @@ func TestWriteTranslationMemoryCSVHandlesEmptyResults(t *testing.T) {
 	if result.Rows != 0 || result.Segments != 0 {
 		t.Fatalf("result = %#v, want zero result", result)
 	}
-	if got, want := strings.TrimSpace(out.String()), strings.Join(translationMemoryCSVHeader, ","); got != want {
+	if got, want := strings.TrimSpace(out.String()), strings.Join(translationMemoryCSVHeader(), ","); got != want {
 		t.Fatalf("csv = %q, want %q", got, want)
 	}
 }

--- a/internal/i18n/storage/crowdin/translation_memory_test.go
+++ b/internal/i18n/storage/crowdin/translation_memory_test.go
@@ -1,0 +1,162 @@
+package crowdin
+
+import (
+	"bytes"
+	"context"
+	"encoding/csv"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestWriteTranslationMemoryCSVWritesStableRows(t *testing.T) {
+	client, mux, teardown := newCrowdinHTTPClientForTest(t)
+	defer teardown()
+
+	mux.HandleFunc("/api/v2/tms/44/segments", func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(t, r, http.MethodGet, "/api/v2/tms/44/segments?limit=500&orderBy=id")
+		writeJSON(t, w, map[string]any{
+			"data": []any{
+				map[string]any{"data": map[string]any{
+					"id": 9,
+					"records": []any{
+						map[string]any{"id": 92, "languageId": "fr", "text": "Commander", "usageCount": 2, "createdBy": 7, "updatedBy": 8, "createdAt": "2024-01-02T03:04:05+00:00", "updatedAt": "2024-01-03T03:04:05+00:00"},
+						map[string]any{"id": 91, "languageId": "en", "text": "Checkout", "usageCount": 5, "createdBy": 3, "updatedBy": 4, "createdAt": "2024-01-01T03:04:05+00:00", "updatedAt": "2024-01-04T03:04:05+00:00"},
+						map[string]any{"id": 93, "languageId": "es", "text": "Pagar", "usageCount": 1},
+					},
+				}},
+			},
+			"pagination": map[string]any{"offset": 0, "limit": 500},
+		})
+	})
+
+	var out bytes.Buffer
+	result, err := client.WriteTranslationMemoryCSV(context.Background(), TranslationMemoryDownloadRequest{
+		TranslationMemoryID: 44,
+		SourceLanguage:      "en",
+		TargetLanguages:     []string{"fr", "es"},
+	}, &out)
+	if err != nil {
+		t.Fatalf("write translation memory csv: %v", err)
+	}
+	if result.Rows != 2 || result.Segments != 1 {
+		t.Fatalf("result = %#v, want rows=2 segments=1", result)
+	}
+
+	records, err := csv.NewReader(strings.NewReader(out.String())).ReadAll()
+	if err != nil {
+		t.Fatalf("read csv: %v", err)
+	}
+	if len(records) != 3 {
+		t.Fatalf("record count = %d, want 3: %q", len(records), out.String())
+	}
+	if got, want := records[0], translationMemoryCSVHeader; !equalStrings(got, want) {
+		t.Fatalf("header = %#v, want %#v", got, want)
+	}
+	wantFirst := []string{"44", "9", "en", "es", "Checkout", "Pagar", "91", "93", "5", "1", "2024-01-01T03:04:05+00:00", "", "2024-01-04T03:04:05+00:00", "", "3", "", "4", ""}
+	if got := records[1]; !equalStrings(got, wantFirst) {
+		t.Fatalf("first row = %#v, want %#v", got, wantFirst)
+	}
+	wantSecond := []string{"44", "9", "en", "fr", "Checkout", "Commander", "91", "92", "5", "2", "2024-01-01T03:04:05+00:00", "2024-01-02T03:04:05+00:00", "2024-01-04T03:04:05+00:00", "2024-01-03T03:04:05+00:00", "3", "7", "4", "8"}
+	if got := records[2]; !equalStrings(got, wantSecond) {
+		t.Fatalf("second row = %#v, want %#v", got, wantSecond)
+	}
+}
+
+func TestWriteTranslationMemoryCSVPaginatesSegments(t *testing.T) {
+	client, mux, teardown := newCrowdinHTTPClientForTest(t)
+	defer teardown()
+
+	mux.HandleFunc("/api/v2/tms/45/segments", func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Query().Get("offset") {
+		case "":
+			writeJSON(t, w, map[string]any{
+				"data":       tmSegmentPayload(500),
+				"pagination": map[string]any{"offset": 0, "limit": 500},
+			})
+		case "500":
+			writeJSON(t, w, map[string]any{
+				"data":       []any{tmSegmentData(501)},
+				"pagination": map[string]any{"offset": 500, "limit": 500},
+			})
+		default:
+			t.Fatalf("unexpected offset %q", r.URL.Query().Get("offset"))
+		}
+	})
+
+	var out bytes.Buffer
+	result, err := client.WriteTranslationMemoryCSV(context.Background(), TranslationMemoryDownloadRequest{
+		TranslationMemoryID: 45,
+		SourceLanguage:      "en",
+		TargetLanguages:     []string{"fr"},
+	}, &out)
+	if err != nil {
+		t.Fatalf("write translation memory csv: %v", err)
+	}
+	if result.Rows != 501 || result.Segments != 501 {
+		t.Fatalf("result = %#v, want rows=501 segments=501", result)
+	}
+}
+
+func TestWriteTranslationMemoryCSVHandlesEmptyResults(t *testing.T) {
+	client, mux, teardown := newCrowdinHTTPClientForTest(t)
+	defer teardown()
+
+	mux.HandleFunc("/api/v2/tms/46/segments", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, map[string]any{"data": []any{}, "pagination": map[string]any{"offset": 0, "limit": 500}})
+	})
+
+	var out bytes.Buffer
+	result, err := client.WriteTranslationMemoryCSV(context.Background(), TranslationMemoryDownloadRequest{
+		TranslationMemoryID: 46,
+		SourceLanguage:      "en",
+		TargetLanguages:     []string{"fr"},
+	}, &out)
+	if err != nil {
+		t.Fatalf("write translation memory csv: %v", err)
+	}
+	if result.Rows != 0 || result.Segments != 0 {
+		t.Fatalf("result = %#v, want zero result", result)
+	}
+	if got, want := strings.TrimSpace(out.String()), strings.Join(translationMemoryCSVHeader, ","); got != want {
+		t.Fatalf("csv = %q, want %q", got, want)
+	}
+}
+
+func TestWriteTranslationMemoryCSVReturnsAPIError(t *testing.T) {
+	client, mux, teardown := newCrowdinHTTPClientForTest(t)
+	defer teardown()
+
+	mux.HandleFunc("/api/v2/tms/47/segments", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"error":{"message":"unauthorized"}}`, http.StatusUnauthorized)
+	})
+
+	var out bytes.Buffer
+	_, err := client.WriteTranslationMemoryCSV(context.Background(), TranslationMemoryDownloadRequest{
+		TranslationMemoryID: 47,
+		SourceLanguage:      "en",
+		TargetLanguages:     []string{"fr"},
+	}, &out)
+	if err == nil || !strings.Contains(err.Error(), "list translation memory segments") {
+		t.Fatalf("error = %v, want list translation memory segments error", err)
+	}
+}
+
+func tmSegmentPayload(count int) []any {
+	segments := make([]any, 0, count)
+	for i := 1; i <= count; i++ {
+		segments = append(segments, tmSegmentData(i))
+	}
+	return segments
+}
+
+func tmSegmentData(id int) any {
+	return map[string]any{"data": map[string]any{
+		"id": id,
+		"records": []any{
+			map[string]any{"id": id*10 + 1, "languageId": "en", "text": fmt.Sprintf("Source %d", id)},
+			map[string]any{"id": id*10 + 2, "languageId": "fr", "text": fmt.Sprintf("Target %d", id)},
+		},
+	}}
+}


### PR DESCRIPTION
### Motivation
- Provide a CLI entrypoint to export Crowdin Translation Memory (TM) entries as deterministic CSV for downstream import/review workflows. 
- Reuse existing Crowdin client patterns and support non-interactive usage with config/identity files and stdout/file output.
- Ensure robust handling of pagination, empty results, and API errors so exports are reliable for large TMs.

### Description
- Add `crowdin tm download` (alias `crowdin translation-memory download`) CLI command with flags `--tm-id`, `--source-language`, `--target-language`, `--config`, `--identity`, and `--output` to write CSV to stdout or file.
- Implement TM export in `internal/i18n/storage/crowdin/translation_memory.go` which paginates `ListTMSegments`, normalizes languages, and emits a deterministic CSV schema including source/target text and stable metadata columns.
- Add unit tests: `internal/i18n/storage/crowdin/translation_memory_test.go` covers pagination, empty results, API error handling and stable CSV formatting; `apps/cli/cmd/crowdin_test.go` was extended with CLI-level tests for stdout/file output and required-flag validation using a fake CSV writer.

### Testing
- Ran formatting: `make fmt` (succeeded).
- Ran targeted unit tests: `go test -run 'TestWriteTranslationMemoryCSV|TestCrowdinTranslationMemoryDownload' ./internal/i18n/storage/crowdin ./apps/cli/cmd` (passed).
- Ran package tests: `go test ./apps/cli/cmd ./internal/i18n/storage/crowdin` (passed).
- Attempted workspace bootstrap and lint: `make bootstrap` failed to install `golangci-lint` due to `proxy.golang.org` returning `Forbidden`, and `make lint` failed because `golangci-lint` is not installed.
- Ran full test sweep via `make test` which surfaced an environment Go toolchain mismatch (compiled packages built with `go1.26.0` vs tool `go1.25.1`), causing some packages to fail to compile in this environment; the TM-related tests above executed and passed despite that mismatch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe81f803d4832c80fd95ca1ecf7e24)