### PR TITLE
feat(cli): add Phrase glossary download command

### DIFF
--- a/apps/cli/cmd/phrase.go
+++ b/apps/cli/cmd/phrase.go
@@ -235,6 +235,11 @@ func executePhraseGlossaryDownload(cmd *cobra.Command, o phraseGlossaryDownloadO
 		if err != nil {
 			return fmt.Errorf("phrase glossary download: create temp output file %q: %w", outputPath, err)
 		}
+		if err := file.Chmod(0o644); err != nil {
+			_ = file.Close()
+			_ = os.Remove(file.Name())
+			return fmt.Errorf("phrase glossary download: chmod temp output file %q: %w", outputPath, err)
+		}
 		tempPath = file.Name()
 		out = file
 	}

--- a/apps/cli/cmd/phrase.go
+++ b/apps/cli/cmd/phrase.go
@@ -52,6 +52,17 @@ type phraseDownloadTranslationsOptions struct {
 	dryRun        bool
 }
 
+type phraseGlossaryDownloadOptions struct {
+	accountID  string
+	glossaryID string
+	languages  []string
+	output     string
+	tokenEnv   string
+	apiBaseURL string
+	force      bool
+	dryRun     bool
+}
+
 func newPhraseCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "phrase",
@@ -59,6 +70,7 @@ func newPhraseCmd() *cobra.Command {
 	}
 	cmd.AddCommand(newPhraseUploadCmd())
 	cmd.AddCommand(newPhraseDownloadCmd())
+	cmd.AddCommand(newPhraseGlossaryCmd())
 	return cmd
 }
 
@@ -78,6 +90,36 @@ func newPhraseDownloadCmd() *cobra.Command {
 	}
 	cmd.AddCommand(newPhraseDownloadSourcesCmd())
 	cmd.AddCommand(newPhraseDownloadTranslationsCmd())
+	return cmd
+}
+
+func newPhraseGlossaryCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "glossary",
+		Short: "Phrase glossary commands",
+	}
+	cmd.AddCommand(newPhraseGlossaryDownloadCmd())
+	return cmd
+}
+
+func newPhraseGlossaryDownloadCmd() *cobra.Command {
+	o := phraseGlossaryDownloadOptions{tokenEnv: "PHRASE_API_TOKEN"}
+	cmd := &cobra.Command{
+		Use:          "download",
+		Short:        "download Phrase glossary terms as CSV",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return executePhraseGlossaryDownload(cmd, o)
+		},
+	}
+	cmd.Flags().StringVar(&o.accountID, "account-id", "", "Phrase account ID")
+	cmd.Flags().StringVar(&o.glossaryID, "glossary-id", "", "Phrase glossary ID")
+	cmd.Flags().StringSliceVarP(&o.languages, "language", "l", nil, "translation locale(s) to include")
+	cmd.Flags().StringVarP(&o.output, "output", "o", "", "output file path; omit or use - for stdout")
+	cmd.Flags().StringVar(&o.tokenEnv, "token-env", o.tokenEnv, "environment variable containing the Phrase API token")
+	cmd.Flags().StringVar(&o.apiBaseURL, "api-base-url", "", "Phrase API base URL")
+	cmd.Flags().BoolVar(&o.force, "force", false, "overwrite an existing output file")
+	cmd.Flags().BoolVar(&o.dryRun, "dry-run", false, "preview command without downloading content")
 	return cmd
 }
 
@@ -149,6 +191,85 @@ func newPhraseUploadSourcesCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&o.skipUploadTags, "skip-upload-tags", false, "do not create upload tags in Phrase")
 	cmd.Flags().BoolVar(&o.dryRun, "dry-run", false, "preview command without uploading files")
 	return cmd
+}
+
+func executePhraseGlossaryDownload(cmd *cobra.Command, o phraseGlossaryDownloadOptions) error {
+	if strings.TrimSpace(o.accountID) == "" {
+		return fmt.Errorf("phrase glossary download: --account-id is required")
+	}
+	if strings.TrimSpace(o.glossaryID) == "" {
+		return fmt.Errorf("phrase glossary download: --glossary-id is required")
+	}
+	outputPath := strings.TrimSpace(o.output)
+	if o.dryRun {
+		destination := outputPath
+		if destination == "" {
+			destination = "-"
+		}
+		_, err := fmt.Fprintf(cmd.OutOrStdout(), "dry-run action=phrase-glossary-download account_id=%s glossary_id=%s languages=%s output=%s\n", strings.TrimSpace(o.accountID), strings.TrimSpace(o.glossaryID), strings.Join(normalizePhraseLocales(o.languages), ","), destination)
+		return err
+	}
+	if err := validatePhraseGlossaryOutputPath(outputPath, o.force); err != nil {
+		return err
+	}
+	token, err := phraseAPIToken("phrase glossary download", o.tokenEnv)
+	if err != nil {
+		return err
+	}
+	client, err := phrase.NewHTTPClientWithBaseURL(phrase.Config{}, o.apiBaseURL, &http.Client{Timeout: 30 * time.Second})
+	if err != nil {
+		return err
+	}
+
+	out := cmd.OutOrStdout()
+	tempPath := ""
+	var file *os.File
+	if outputPath != "" && outputPath != "-" {
+		dir := filepath.Dir(outputPath)
+		if dir != "." {
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				return fmt.Errorf("phrase glossary download: mkdir output directory: %w", err)
+			}
+		}
+		file, err = os.CreateTemp(dir, "."+filepath.Base(outputPath)+".tmp-*")
+		if err != nil {
+			return fmt.Errorf("phrase glossary download: create temp output file %q: %w", outputPath, err)
+		}
+		tempPath = file.Name()
+		out = file
+	}
+
+	result, writeErr := client.WriteGlossaryCSV(backgroundContext(), phrase.GlossaryDownloadInput{
+		AccountID:  strings.TrimSpace(o.accountID),
+		GlossaryID: strings.TrimSpace(o.glossaryID),
+		APIToken:   token,
+		Locales:    normalizePhraseLocales(o.languages),
+	}, out)
+	if file != nil {
+		if syncErr := file.Sync(); syncErr != nil && writeErr == nil {
+			writeErr = fmt.Errorf("phrase glossary download: sync output file %q: %w", outputPath, syncErr)
+		}
+		if closeErr := file.Close(); closeErr != nil && writeErr == nil {
+			writeErr = fmt.Errorf("phrase glossary download: close output file %q: %w", outputPath, closeErr)
+		}
+	}
+	if writeErr != nil {
+		if tempPath != "" {
+			if removeErr := os.Remove(tempPath); removeErr != nil && !os.IsNotExist(removeErr) {
+				return fmt.Errorf("%w; also failed to remove partial output: %v", writeErr, removeErr)
+			}
+		}
+		return writeErr
+	}
+	if outputPath != "" && outputPath != "-" {
+		if err := os.Rename(tempPath, outputPath); err != nil {
+			_ = os.Remove(tempPath)
+			return fmt.Errorf("phrase glossary download: replace output file %q: %w", outputPath, err)
+		}
+		_, err = fmt.Fprintf(cmd.OutOrStdout(), "wrote %s terms=%d rows=%d\n", outputPath, result.Terms, result.Rows)
+		return err
+	}
+	return nil
 }
 
 func executePhraseUploadSources(cmd *cobra.Command, o phraseUploadSourcesOptions) error {
@@ -462,6 +583,23 @@ func writePhraseDownloadedFileAtomic(action, path string, content []byte, perm o
 		return fmt.Errorf("%s: replace output file %q: %w", action, path, err)
 	}
 	renamed = true
+	return nil
+}
+
+func validatePhraseGlossaryOutputPath(path string, force bool) error {
+	if path == "" || path == "-" {
+		return nil
+	}
+	if info, err := os.Stat(path); err == nil {
+		if info.IsDir() {
+			return fmt.Errorf("phrase glossary download: output file %q is a directory", path)
+		}
+		if !force {
+			return fmt.Errorf("phrase glossary download: output file %q already exists; use --force to overwrite", path)
+		}
+	} else if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("phrase glossary download: stat output file %q: %w", path, err)
+	}
 	return nil
 }
 

--- a/apps/cli/cmd/phrase_test.go
+++ b/apps/cli/cmd/phrase_test.go
@@ -549,3 +549,87 @@ func TestPhraseDownloadTranslationsRefusesOverwriteWithoutForce(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestPhraseGlossaryDownloadWritesCSVToStdout(t *testing.T) {
+	t.Setenv("PHRASE_TEST_TOKEN", "secret")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/accounts/acct-1/glossaries/gloss-1/terms" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "token secret" {
+			t.Fatalf("unexpected auth header: %q", r.Header.Get("Authorization"))
+		}
+		_, _ = w.Write([]byte(`[{"id":"term-1","term":"Checkout","description":"CTA","translatable":true,"case_sensitive":true,"translations":[{"id":"tr-1","locale_code":"fr-FR","content":"Paiement","created_at":"2024-03-01T00:00:00Z","updated_at":"2024-03-02T00:00:00Z"}],"created_at":"2024-01-03T00:00:00Z","updated_at":"2024-01-04T00:00:00Z"}]`))
+	}))
+	defer server.Close()
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"phrase", "glossary", "download", "--account-id", "acct-1", "--glossary-id", "gloss-1", "--language", "fr-FR", "--token-env", "PHRASE_TEST_TOKEN", "--api-base-url", server.URL})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute phrase glossary download: %v", err)
+	}
+	if !strings.Contains(out.String(), "account_id,glossary_id,term_id,source_term") || !strings.Contains(out.String(), "acct-1,gloss-1,term-1,Checkout,CTA,true,true,fr-FR,Paiement") {
+		t.Fatalf("unexpected output: %q", out.String())
+	}
+}
+
+func TestPhraseGlossaryDownloadWritesOutputFile(t *testing.T) {
+	t.Setenv("PHRASE_TEST_TOKEN", "secret")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`[{"id":"term-1","term":"Checkout","description":"CTA","translatable":true,"case_sensitive":true,"translations":[],"created_at":"2024-01-03T00:00:00Z","updated_at":"2024-01-04T00:00:00Z"}]`))
+	}))
+	defer server.Close()
+
+	outputPath := filepath.Join(t.TempDir(), "glossary.csv")
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"phrase", "glossary", "download", "--account-id", "acct-1", "--glossary-id", "gloss-1", "--output", outputPath, "--token-env", "PHRASE_TEST_TOKEN", "--api-base-url", server.URL})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute phrase glossary download: %v", err)
+	}
+	content, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if !strings.Contains(string(content), "acct-1,gloss-1,term-1,Checkout,CTA,true,true") {
+		t.Fatalf("unexpected file content: %q", string(content))
+	}
+	if !strings.Contains(out.String(), "wrote "+outputPath+" terms=1 rows=1") {
+		t.Fatalf("unexpected summary: %q", out.String())
+	}
+}
+
+func TestPhraseGlossaryDownloadRequiresAccountID(t *testing.T) {
+	cmd := newRootCmd("")
+	cmd.SetArgs([]string{"phrase", "glossary", "download", "--glossary-id", "gloss-1"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected missing account id error")
+	}
+	if !strings.Contains(err.Error(), "--account-id is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPhraseGlossaryDownloadRefusesOverwriteWithoutForce(t *testing.T) {
+	outputPath := filepath.Join(t.TempDir(), "glossary.csv")
+	if err := os.WriteFile(outputPath, []byte("old"), 0o644); err != nil {
+		t.Fatalf("write existing output: %v", err)
+	}
+	cmd := newRootCmd("")
+	cmd.SetArgs([]string{"phrase", "glossary", "download", "--account-id", "acct-1", "--glossary-id", "gloss-1", "--output", outputPath})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected overwrite error")
+	}
+	if !strings.Contains(err.Error(), "already exists; use --force to overwrite") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/apps/cli/cmd/phrase_test.go
+++ b/apps/cli/cmd/phrase_test.go
@@ -602,6 +602,13 @@ func TestPhraseGlossaryDownloadWritesOutputFile(t *testing.T) {
 	if !strings.Contains(out.String(), "wrote "+outputPath+" terms=1 rows=1") {
 		t.Fatalf("unexpected summary: %q", out.String())
 	}
+	info, err := os.Stat(outputPath)
+	if err != nil {
+		t.Fatalf("stat output: %v", err)
+	}
+	if got, want := info.Mode().Perm(), os.FileMode(0o644); got != want {
+		t.Fatalf("output permissions = %v, want %v", got, want)
+	}
 }
 
 func TestPhraseGlossaryDownloadRequiresAccountID(t *testing.T) {
@@ -613,6 +620,19 @@ func TestPhraseGlossaryDownloadRequiresAccountID(t *testing.T) {
 		t.Fatalf("expected missing account id error")
 	}
 	if !strings.Contains(err.Error(), "--account-id is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPhraseGlossaryDownloadRequiresGlossaryID(t *testing.T) {
+	cmd := newRootCmd("")
+	cmd.SetArgs([]string{"phrase", "glossary", "download", "--account-id", "acct-1"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected missing glossary id error")
+	}
+	if !strings.Contains(err.Error(), "--glossary-id is required") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/i18n/storage/phrase/glossary.go
+++ b/internal/i18n/storage/phrase/glossary.go
@@ -1,0 +1,189 @@
+package phrase
+
+import (
+	"cmp"
+	"context"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+)
+
+var glossaryCSVHeader = []string{
+	"account_id",
+	"glossary_id",
+	"term_id",
+	"source_term",
+	"description",
+	"translatable",
+	"case_sensitive",
+	"translation_locale",
+	"translated_term",
+	"translation_id",
+	"translation_created_at",
+	"translation_updated_at",
+	"term_created_at",
+	"term_updated_at",
+}
+
+// GlossaryDownloadInput identifies the Phrase term base to export.
+type GlossaryDownloadInput struct {
+	AccountID  string
+	GlossaryID string
+	APIToken   string
+	Locales    []string
+}
+
+// GlossaryDownloadResult summarizes a Phrase glossary CSV export.
+type GlossaryDownloadResult struct {
+	Terms int
+	Rows  int
+}
+
+type glossaryTerm struct {
+	ID            string                    `json:"id"`
+	Term          string                    `json:"term"`
+	Description   string                    `json:"description"`
+	Translatable  bool                      `json:"translatable"`
+	CaseSensitive bool                      `json:"case_sensitive"`
+	Translations  []glossaryTermTranslation `json:"translations"`
+	CreatedAt     string                    `json:"created_at"`
+	UpdatedAt     string                    `json:"updated_at"`
+}
+
+type glossaryTermTranslation struct {
+	ID         string `json:"id"`
+	LocaleCode string `json:"locale_code"`
+	Content    string `json:"content"`
+	CreatedAt  string `json:"created_at"`
+	UpdatedAt  string `json:"updated_at"`
+}
+
+// WriteGlossaryCSV downloads Phrase glossary terms and writes them as stable CSV.
+func (c *HTTPClient) WriteGlossaryCSV(ctx context.Context, in GlossaryDownloadInput, w io.Writer) (GlossaryDownloadResult, error) {
+	if strings.TrimSpace(in.AccountID) == "" {
+		return GlossaryDownloadResult{}, fmt.Errorf("phrase glossary download: account id is required")
+	}
+	if strings.TrimSpace(in.GlossaryID) == "" {
+		return GlossaryDownloadResult{}, fmt.Errorf("phrase glossary download: glossary id is required")
+	}
+	if strings.TrimSpace(in.APIToken) == "" {
+		return GlossaryDownloadResult{}, fmt.Errorf("phrase glossary download: api token is required")
+	}
+	if w == nil {
+		return GlossaryDownloadResult{}, fmt.Errorf("phrase glossary download: writer is nil")
+	}
+
+	terms, err := c.listGlossaryTerms(ctx, strings.TrimSpace(in.AccountID), strings.TrimSpace(in.GlossaryID), strings.TrimSpace(in.APIToken))
+	if err != nil {
+		return GlossaryDownloadResult{}, err
+	}
+	rows := phraseGlossaryCSVRows(strings.TrimSpace(in.AccountID), strings.TrimSpace(in.GlossaryID), terms, in.Locales)
+
+	writer := csv.NewWriter(w)
+	if err := writer.Write(glossaryCSVHeader); err != nil {
+		return GlossaryDownloadResult{}, fmt.Errorf("write phrase glossary csv header: %w", err)
+	}
+	for _, row := range rows {
+		if err := writer.Write(row); err != nil {
+			return GlossaryDownloadResult{}, fmt.Errorf("write phrase glossary csv row: %w", err)
+		}
+	}
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return GlossaryDownloadResult{}, fmt.Errorf("flush phrase glossary csv: %w", err)
+	}
+	return GlossaryDownloadResult{Terms: len(terms), Rows: len(rows)}, nil
+}
+
+func (c *HTTPClient) listGlossaryTerms(ctx context.Context, accountID, glossaryID, token string) ([]glossaryTerm, error) {
+	terms := make([]glossaryTerm, 0)
+	page := 1
+	for {
+		var pageItems []glossaryTerm
+		path := fmt.Sprintf("/accounts/%s/glossaries/%s/terms?page=%d&per_page=%d", url.PathEscape(accountID), url.PathEscape(glossaryID), page, defaultPageSize)
+		if err := c.doJSON(ctx, http.MethodGet, path, token, nil, &pageItems); err != nil {
+			return nil, fmt.Errorf("list phrase glossary terms: %w", err)
+		}
+		terms = append(terms, pageItems...)
+		if len(pageItems) < defaultPageSize {
+			break
+		}
+		page++
+	}
+	return terms, nil
+}
+
+func phraseGlossaryCSVRows(accountID, glossaryID string, terms []glossaryTerm, locales []string) [][]string {
+	localeSet := make(map[string]struct{}, len(locales))
+	for _, value := range locales {
+		for _, part := range strings.Split(value, ",") {
+			if locale := strings.TrimSpace(part); locale != "" {
+				localeSet[locale] = struct{}{}
+			}
+		}
+	}
+
+	sortedTerms := slices.Clone(terms)
+	slices.SortStableFunc(sortedTerms, func(left, right glossaryTerm) int {
+		if left.Term != right.Term {
+			return cmp.Compare(left.Term, right.Term)
+		}
+		return cmp.Compare(left.ID, right.ID)
+	})
+
+	rows := make([][]string, 0, len(sortedTerms))
+	for _, term := range sortedTerms {
+		translations := slices.Clone(term.Translations)
+		slices.SortStableFunc(translations, func(left, right glossaryTermTranslation) int {
+			if left.LocaleCode != right.LocaleCode {
+				return cmp.Compare(left.LocaleCode, right.LocaleCode)
+			}
+			return cmp.Compare(left.ID, right.ID)
+		})
+		wroteTranslation := false
+		for _, translation := range translations {
+			if len(localeSet) > 0 {
+				if _, ok := localeSet[translation.LocaleCode]; !ok {
+					continue
+				}
+			}
+			rows = append(rows, phraseGlossaryCSVRow(accountID, glossaryID, term, &translation))
+			wroteTranslation = true
+		}
+		if !wroteTranslation && len(localeSet) == 0 {
+			rows = append(rows, phraseGlossaryCSVRow(accountID, glossaryID, term, nil))
+		}
+	}
+	return rows
+}
+
+func phraseGlossaryCSVRow(accountID, glossaryID string, term glossaryTerm, translation *glossaryTermTranslation) []string {
+	row := []string{
+		accountID,
+		glossaryID,
+		term.ID,
+		term.Term,
+		term.Description,
+		fmt.Sprintf("%t", term.Translatable),
+		fmt.Sprintf("%t", term.CaseSensitive),
+		"",
+		"",
+		"",
+		"",
+		"",
+		term.CreatedAt,
+		term.UpdatedAt,
+	}
+	if translation != nil {
+		row[7] = translation.LocaleCode
+		row[8] = translation.Content
+		row[9] = translation.ID
+		row[10] = translation.CreatedAt
+		row[11] = translation.UpdatedAt
+	}
+	return row
+}

--- a/internal/i18n/storage/phrase/http_client_test.go
+++ b/internal/i18n/storage/phrase/http_client_test.go
@@ -1,8 +1,11 @@
 package phrase
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -301,5 +304,138 @@ func TestRetryDelayUsesExponentialBackoff(t *testing.T) {
 	d2 := retryDelay(1, nil)
 	if d2 <= d1 || d1 < 200*time.Millisecond {
 		t.Fatalf("unexpected delays: %s %s", d1, d2)
+	}
+}
+
+func TestHTTPClientWriteGlossaryCSV(t *testing.T) {
+	page := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/accounts/acct/glossaries/gloss/terms", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %s, want GET", r.Method)
+		}
+		if r.Header.Get("Authorization") != "token x" {
+			t.Fatalf("unexpected auth header: %q", r.Header.Get("Authorization"))
+		}
+		if got := r.URL.Query().Get("per_page"); got != "100" {
+			t.Fatalf("per_page = %q, want 100", got)
+		}
+		page++
+		switch r.URL.Query().Get("page") {
+		case "1":
+			_, _ = w.Write([]byte(`[
+				{"id":"term-2","term":"Cart","description":"Shopping cart","translatable":true,"case_sensitive":false,"translations":[{"id":"tr-2","locale_code":"de-DE","content":"Warenkorb","created_at":"2024-02-01T00:00:00Z","updated_at":"2024-02-02T00:00:00Z"}],"created_at":"2024-01-01T00:00:00Z","updated_at":"2024-01-02T00:00:00Z"},
+				{"id":"term-1","term":"Checkout","description":"CTA","translatable":true,"case_sensitive":true,"translations":[{"id":"tr-1","locale_code":"fr-FR","content":"Paiement","created_at":"2024-03-01T00:00:00Z","updated_at":"2024-03-02T00:00:00Z"}],"created_at":"2024-01-03T00:00:00Z","updated_at":"2024-01-04T00:00:00Z"}
+			]`))
+		case "2":
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			t.Fatalf("unexpected page: %s", r.URL.Query().Get("page"))
+		}
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client, err := NewHTTPClientWithBaseURL(Config{}, srv.URL, srv.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := bytes.NewBuffer(nil)
+	result, err := client.WriteGlossaryCSV(context.Background(), GlossaryDownloadInput{AccountID: "acct", GlossaryID: "gloss", APIToken: "x", Locales: []string{"fr-FR"}}, out)
+	if err != nil {
+		t.Fatalf("write glossary csv: %v", err)
+	}
+	if page != 1 {
+		t.Fatalf("page requests = %d, want 1", page)
+	}
+	if result.Terms != 2 || result.Rows != 1 {
+		t.Fatalf("result = %+v, want terms=2 rows=1", result)
+	}
+	want := "account_id,glossary_id,term_id,source_term,description,translatable,case_sensitive,translation_locale,translated_term,translation_id,translation_created_at,translation_updated_at,term_created_at,term_updated_at\nacct,gloss,term-1,Checkout,CTA,true,true,fr-FR,Paiement,tr-1,2024-03-01T00:00:00Z,2024-03-02T00:00:00Z,2024-01-03T00:00:00Z,2024-01-04T00:00:00Z\n"
+	if got := out.String(); got != want {
+		t.Fatalf("csv = %q, want %q", got, want)
+	}
+}
+
+func TestHTTPClientWriteGlossaryCSVPaginates(t *testing.T) {
+	pages := make([]string, 0, 2)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/accounts/acct/glossaries/gloss/terms", func(w http.ResponseWriter, r *http.Request) {
+		pages = append(pages, r.URL.Query().Get("page"))
+		switch r.URL.Query().Get("page") {
+		case "1":
+			terms := make([]glossaryTerm, defaultPageSize)
+			for i := range terms {
+				terms[i] = glossaryTerm{ID: fmt.Sprintf("term-%03d", i), Term: fmt.Sprintf("Term %03d", i)}
+			}
+			_ = json.NewEncoder(w).Encode(terms)
+		case "2":
+			_ = json.NewEncoder(w).Encode([]glossaryTerm{{ID: "term-last", Term: "Last"}})
+		default:
+			t.Fatalf("unexpected page: %s", r.URL.Query().Get("page"))
+		}
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client, err := NewHTTPClientWithBaseURL(Config{}, srv.URL, srv.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := client.WriteGlossaryCSV(context.Background(), GlossaryDownloadInput{AccountID: "acct", GlossaryID: "gloss", APIToken: "x"}, io.Discard)
+	if err != nil {
+		t.Fatalf("write glossary csv: %v", err)
+	}
+	if got, want := strings.Join(pages, ","), "1,2"; got != want {
+		t.Fatalf("pages = %s, want %s", got, want)
+	}
+	if result.Terms != defaultPageSize+1 || result.Rows != defaultPageSize+1 {
+		t.Fatalf("result = %+v, want %d terms/rows", result, defaultPageSize+1)
+	}
+}
+
+func TestHTTPClientWriteGlossaryCSVIncludesTermsWithoutTranslations(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/accounts/acct/glossaries/gloss/terms", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`[{"id":"term-1","term":"Brand","description":"Do not translate","translatable":false,"case_sensitive":true,"translations":[],"created_at":"2024-01-01T00:00:00Z","updated_at":"2024-01-02T00:00:00Z"}]`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client, err := NewHTTPClientWithBaseURL(Config{}, srv.URL, srv.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := bytes.NewBuffer(nil)
+	result, err := client.WriteGlossaryCSV(context.Background(), GlossaryDownloadInput{AccountID: "acct", GlossaryID: "gloss", APIToken: "x"}, out)
+	if err != nil {
+		t.Fatalf("write glossary csv: %v", err)
+	}
+	if result.Terms != 1 || result.Rows != 1 {
+		t.Fatalf("result = %+v, want terms=1 rows=1", result)
+	}
+	if !strings.Contains(out.String(), "acct,gloss,term-1,Brand,Do not translate,false,true,,,,,,2024-01-01T00:00:00Z,2024-01-02T00:00:00Z") {
+		t.Fatalf("unexpected csv: %q", out.String())
+	}
+}
+
+func TestHTTPClientWriteGlossaryCSVAPIError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/accounts/acct/glossaries/missing/terms", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"Glossary not found"}`, http.StatusNotFound)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client, err := NewHTTPClientWithBaseURL(Config{}, srv.URL, srv.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.WriteGlossaryCSV(context.Background(), GlossaryDownloadInput{AccountID: "acct", GlossaryID: "missing", APIToken: "x"}, bytes.NewBuffer(nil))
+	if err == nil {
+		t.Fatalf("expected API error")
+	}
+	if !strings.Contains(err.Error(), "status=404") || !strings.Contains(err.Error(), "Glossary not found") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
### Motivation

- Provide a CLI flow to export Phrase glossaries as CSV so glossary data can be reviewed or imported by downstream workflows, keeping parity with Crowdin's glossary command shape.
- Ensure the export is deterministic and handles pagination, language filtering, and provider-specific API behavior for reliable tooling integration.

### Description

- Add `phrase glossary download` CLI command with flags `--account-id`, `--glossary-id`, `--language` (repeatable), `--output` (file or stdout), `--token-env`, `--api-base-url`, `--force`, and `--dry-run` and matching validation/error messages.
- Implement Phrase glossary CSV export in `internal/i18n/storage/phrase/glossary.go` that pages the Phrase API (`/accounts/:account_id/glossaries/:glossary_id/terms`), stable-sorts rows, and emits a deterministic CSV header and row schema including term metadata and translation fields.
- Wire command to use the Phrase HTTP client with atomic temp-file writes, safe overwrite handling, and cleanup on error; add `validatePhraseGlossaryOutputPath` helper and temp-file rename flow to avoid partial outputs.
- Add unit tests: CLI tests in `apps/cli/cmd/phrase_test.go` (mocked HTTP server) and HTTP client tests in `internal/i18n/storage/phrase/http_client_test.go` covering stdout/file output, pagination, terms without translations, CSV formatting, API errors, and overwrite behavior.

### Testing

- Ran `make fmt` successfully to format changes.
- Ran focused unit tests with `go test ./internal/i18n/storage/phrase ./apps/cli/cmd -count=1` and the packages passed their tests.
- `make lint` did not complete due to the environment lacking the configured `/root/go/bin/golangci-lint` binary and installation attempts were blocked by network/permission issues, so linting remained unrun in this environment.
- `make test` (full workspace test) encountered toolchain/environment issues (Go stdlib/tool mismatch in this runner) and did not finish successfully; targeted package tests (above) were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe82467558832ca397929ca3571a6f)