### PR TITLE
fix(phrase): normalize TM language handling

### DIFF
--- a/apps/cli/cmd/BUILD.bazel
+++ b/apps/cli/cmd/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//apps/cli/internal/progressui",
         "//internal/i18n/htmltagparity",
         "//internal/i18n/icuparser",
+        "//internal/i18n/locales",
         "//internal/i18n/storage",
         "//internal/i18n/storage/crowdin",
         "//internal/i18n/storage/phrase",

--- a/apps/cli/cmd/phrase.go
+++ b/apps/cli/cmd/phrase.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/locales"
 	"github.com/hyperlocalise/hyperlocalise/internal/i18n/storage/phrase"
 	"github.com/spf13/cobra"
 )
@@ -804,22 +805,7 @@ func validatePhraseDownloadOutputPath(path string, force bool) error {
 }
 
 func normalizePhraseLocales(values []string) []string {
-	locales := make([]string, 0, len(values))
-	seen := make(map[string]struct{}, len(values))
-	for _, value := range values {
-		for _, part := range strings.Split(value, ",") {
-			locale := strings.TrimSpace(part)
-			if locale == "" {
-				continue
-			}
-			if _, ok := seen[locale]; ok {
-				continue
-			}
-			seen[locale] = struct{}{}
-			locales = append(locales, locale)
-		}
-	}
-	return locales
+	return locales.NormalizeList(values)
 }
 
 func phraseTranslationOutputPaths(output string, locales []string) ([]string, error) {

--- a/internal/i18n/locales/BUILD.bazel
+++ b/internal/i18n/locales/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "locales",
+    srcs = ["normalize.go"],
+    importpath = "github.com/hyperlocalise/hyperlocalise/internal/i18n/locales",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "locales_test",
+    srcs = ["normalize_test.go"],
+    embed = [":locales"],
+)

--- a/internal/i18n/locales/normalize.go
+++ b/internal/i18n/locales/normalize.go
@@ -1,0 +1,23 @@
+package locales
+
+import "strings"
+
+// NormalizeList trims, splits on commas, and deduplicates locale or language codes.
+func NormalizeList(values []string) []string {
+	normalized := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		for _, part := range strings.Split(value, ",") {
+			trimmed := strings.TrimSpace(part)
+			if trimmed == "" {
+				continue
+			}
+			if _, ok := seen[trimmed]; ok {
+				continue
+			}
+			seen[trimmed] = struct{}{}
+			normalized = append(normalized, trimmed)
+		}
+	}
+	return normalized
+}

--- a/internal/i18n/locales/normalize.go
+++ b/internal/i18n/locales/normalize.go
@@ -12,10 +12,11 @@ func NormalizeList(values []string) []string {
 			if trimmed == "" {
 				continue
 			}
-			if _, ok := seen[trimmed]; ok {
+			key := strings.ToLower(trimmed)
+			if _, ok := seen[key]; ok {
 				continue
 			}
-			seen[trimmed] = struct{}{}
+			seen[key] = struct{}{}
 			normalized = append(normalized, trimmed)
 		}
 	}

--- a/internal/i18n/locales/normalize_test.go
+++ b/internal/i18n/locales/normalize_test.go
@@ -1,0 +1,14 @@
+package locales
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestNormalizeListSplitsTrimsAndDeduplicates(t *testing.T) {
+	got := NormalizeList([]string{" fr-FR, de-DE ", "fr-FR", "", " es-ES "})
+	want := []string{"fr-FR", "de-DE", "es-ES"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("NormalizeList() = %#v, want %#v", got, want)
+	}
+}

--- a/internal/i18n/locales/normalize_test.go
+++ b/internal/i18n/locales/normalize_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestNormalizeListSplitsTrimsAndDeduplicates(t *testing.T) {
-	got := NormalizeList([]string{" fr-FR, de-DE ", "fr-FR", "", " es-ES "})
+	got := NormalizeList([]string{" fr-FR, de-DE ", "fr-fr", "", " es-ES "})
 	want := []string{"fr-FR", "de-DE", "es-ES"}
 	if !slices.Equal(got, want) {
 		t.Fatalf("NormalizeList() = %#v, want %#v", got, want)

--- a/internal/i18n/storage/phrase/BUILD.bazel
+++ b/internal/i18n/storage/phrase/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/hyperlocalise/hyperlocalise/internal/i18n/storage/phrase",
     visibility = ["//visibility:public"],
     deps = [
+        "//internal/i18n/locales",
         "//internal/i18n/storage",
         "@com_github_antihax_optional//:optional",
         "@com_github_phrase_phrase_go_v4//:phrase-go",

--- a/internal/i18n/storage/phrase/http_client_test.go
+++ b/internal/i18n/storage/phrase/http_client_test.go
@@ -558,6 +558,32 @@ func TestHTTPClientTMSDownloadRetriesNetworkErrors(t *testing.T) {
 	}
 }
 
+func TestPhraseTranslationMemoryCSVRowsMatchesLanguagesCaseInsensitively(t *testing.T) {
+	segments := []translationMemoryTU{
+		{
+			ID: "seg-1",
+			Variants: []translationMemoryTUV{
+				{Language: "en-us", Text: "Checkout"},
+				{Language: "fr-fr", Text: "Paiement"},
+			},
+		},
+	}
+
+	rows := phraseTranslationMemoryCSVRows("tm-1", segments, "en-US", []string{"fr-FR"})
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(rows))
+	}
+	if got, want := rows[0][3], "fr-fr"; got != want {
+		t.Fatalf("target locale = %q, want %q", got, want)
+	}
+	if got, want := rows[0][4], "Checkout"; got != want {
+		t.Fatalf("source text = %q, want %q", got, want)
+	}
+	if got, want := rows[0][5], "Paiement"; got != want {
+		t.Fatalf("target text = %q, want %q", got, want)
+	}
+}
+
 func TestPhraseTranslationMemoryCSVRowsMissingTUIDUsesUniqueSyntheticID(t *testing.T) {
 	segments := []translationMemoryTU{
 		{

--- a/internal/i18n/storage/phrase/http_client_test.go
+++ b/internal/i18n/storage/phrase/http_client_test.go
@@ -573,7 +573,7 @@ func TestPhraseTranslationMemoryCSVRowsMatchesLanguagesCaseInsensitively(t *test
 	if len(rows) != 1 {
 		t.Fatalf("rows = %d, want 1", len(rows))
 	}
-	if got, want := rows[0][3], "fr-fr"; got != want {
+	if got, want := rows[0][3], "fr-FR"; got != want {
 		t.Fatalf("target locale = %q, want %q", got, want)
 	}
 	if got, want := rows[0][4], "Checkout"; got != want {
@@ -581,6 +581,27 @@ func TestPhraseTranslationMemoryCSVRowsMatchesLanguagesCaseInsensitively(t *test
 	}
 	if got, want := rows[0][5], "Paiement"; got != want {
 		t.Fatalf("target text = %q, want %q", got, want)
+	}
+}
+
+func TestPhraseTranslationMemoryCSVRowsDeduplicatesCaseVariantTargets(t *testing.T) {
+	segments := []translationMemoryTU{
+		{
+			ID: "seg-1",
+			Variants: []translationMemoryTUV{
+				{Language: "en-US", Text: "Checkout"},
+				{Language: "fr-FR", Text: "Paiement"},
+				{Language: "fr-fr", Text: "Paiement duplicate"},
+			},
+		},
+	}
+
+	rows := phraseTranslationMemoryCSVRows("tm-1", segments, "en-US", []string{"fr-FR"})
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(rows))
+	}
+	if got, want := rows[0][3], "fr-FR"; got != want {
+		t.Fatalf("target locale = %q, want %q", got, want)
 	}
 }
 

--- a/internal/i18n/storage/phrase/translation_memory.go
+++ b/internal/i18n/storage/phrase/translation_memory.go
@@ -353,9 +353,9 @@ func decodeTranslationMemoryTUV(decoder *xml.Decoder, start xml.StartElement) (t
 }
 
 func phraseTranslationMemoryCSVRows(tmID string, segments []translationMemoryTU, sourceLanguage string, targetLanguages []string) [][]string {
-	targetSet := make(map[string]struct{})
+	targetSet := make(map[string]string)
 	for _, language := range locales.NormalizeList(targetLanguages) {
-		targetSet[language] = struct{}{}
+		targetSet[strings.ToLower(language)] = language
 	}
 	sortedSegments := slices.Clone(segments)
 	slices.SortStableFunc(sortedSegments, func(left, right translationMemoryTU) int {
@@ -414,25 +414,31 @@ func phraseTranslationMemorySyntheticSegmentID(used map[string]struct{}, next in
 	}
 }
 
-func phraseTranslationMemorySegmentVariants(segment translationMemoryTU, sourceLanguage string, targetSet map[string]struct{}) (*translationMemoryTUV, []translationMemoryTUV) {
+func phraseTranslationMemorySegmentVariants(segment translationMemoryTU, sourceLanguage string, targetSet map[string]string) (*translationMemoryTUV, []translationMemoryTUV) {
 	variants := slices.Clone(segment.Variants)
 	slices.SortStableFunc(variants, func(left, right translationMemoryTUV) int {
 		return strings.Compare(left.Language, right.Language)
 	})
 	var source *translationMemoryTUV
 	targets := make([]translationMemoryTUV, 0, len(variants))
+	seenTargets := make(map[string]struct{}, len(targetSet))
 	for idx := range variants {
 		variant := variants[idx]
 		if strings.EqualFold(variant.Language, sourceLanguage) && source == nil {
 			source = &variants[idx]
 			continue
 		}
-		for targetLang := range targetSet {
-			if strings.EqualFold(variant.Language, targetLang) {
-				targets = append(targets, variant)
-				break
-			}
+		targetKey := strings.ToLower(variant.Language)
+		targetLang, ok := targetSet[targetKey]
+		if !ok {
+			continue
 		}
+		if _, ok := seenTargets[targetKey]; ok {
+			continue
+		}
+		seenTargets[targetKey] = struct{}{}
+		variant.Language = targetLang
+		targets = append(targets, variant)
 	}
 	return source, targets
 }

--- a/internal/i18n/storage/phrase/translation_memory.go
+++ b/internal/i18n/storage/phrase/translation_memory.go
@@ -13,6 +13,8 @@ import (
 	"slices"
 	"strings"
 	"time"
+
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/locales"
 )
 
 const (
@@ -85,7 +87,7 @@ func (c *HTTPClient) WriteTranslationMemoryCSV(ctx context.Context, in Translati
 	if strings.TrimSpace(in.SourceLanguage) == "" {
 		return TranslationMemoryDownloadResult{}, fmt.Errorf("phrase translation memory download: source language is required")
 	}
-	targets := normalizePhraseTranslationMemoryLanguages(in.TargetLanguages)
+	targets := locales.NormalizeList(in.TargetLanguages)
 	if len(targets) == 0 {
 		return TranslationMemoryDownloadResult{}, fmt.Errorf("phrase translation memory download: at least one target language is required")
 	}
@@ -352,7 +354,7 @@ func decodeTranslationMemoryTUV(decoder *xml.Decoder, start xml.StartElement) (t
 
 func phraseTranslationMemoryCSVRows(tmID string, segments []translationMemoryTU, sourceLanguage string, targetLanguages []string) [][]string {
 	targetSet := make(map[string]struct{})
-	for _, language := range normalizePhraseTranslationMemoryLanguages(targetLanguages) {
+	for _, language := range locales.NormalizeList(targetLanguages) {
 		targetSet[language] = struct{}{}
 	}
 	sortedSegments := slices.Clone(segments)
@@ -421,32 +423,16 @@ func phraseTranslationMemorySegmentVariants(segment translationMemoryTU, sourceL
 	targets := make([]translationMemoryTUV, 0, len(variants))
 	for idx := range variants {
 		variant := variants[idx]
-		if variant.Language == sourceLanguage && source == nil {
+		if strings.EqualFold(variant.Language, sourceLanguage) && source == nil {
 			source = &variants[idx]
 			continue
 		}
-		if _, ok := targetSet[variant.Language]; ok {
-			targets = append(targets, variant)
+		for targetLang := range targetSet {
+			if strings.EqualFold(variant.Language, targetLang) {
+				targets = append(targets, variant)
+				break
+			}
 		}
 	}
 	return source, targets
-}
-
-func normalizePhraseTranslationMemoryLanguages(languages []string) []string {
-	normalized := make([]string, 0, len(languages))
-	seen := make(map[string]struct{}, len(languages))
-	for _, language := range languages {
-		for _, part := range strings.Split(language, ",") {
-			trimmed := strings.TrimSpace(part)
-			if trimmed == "" {
-				continue
-			}
-			if _, ok := seen[trimmed]; ok {
-				continue
-			}
-			seen[trimmed] = struct{}{}
-			normalized = append(normalized, trimmed)
-		}
-	}
-	return normalized
 }


### PR DESCRIPTION
### Motivation
- TMX `xml:lang` values are BCP 47 and should be matched case-insensitively, but the segment-matching logic compared language tags with a case-sensitive equality, causing missed rows when TMX used a different case (e.g. `fr-fr` vs `fr-FR`).
- The code duplicated logic for trimming/splitting/deduplicating language lists, increasing the chance of divergence; consolidating into a shared helper prevents future drift.

### Description
- Compare TMX `xml:lang` tags case-insensitively using `strings.EqualFold` for both source detection and target matching in `phraseTranslationMemorySegmentVariants` (now matches `variant.Language` to `sourceLanguage` and `targetSet` case-insensitively).
- Extract common language/locale list normalization into a new helper `internal/i18n/locales.NormalizeList` which trims, splits on commas, and deduplicates entries.
- Replace the TM-specific normalizer and the CLI's `normalizePhraseLocales` with calls to `locales.NormalizeList` so both CLI and storage code share the same behavior.
- Add regression tests: `internal/i18n/locales/normalize_test.go` for the normalizer and `TestPhraseTranslationMemoryCSVRowsMatchesLanguagesCaseInsensitively` in `internal/i18n/storage/phrase/http_client_test.go` to cover lowercase TMX tags matching mixed-case input.

### Testing
- Ran `go test ./internal/i18n/locales ./internal/i18n/storage/phrase ./apps/cli/cmd` and the targeted package tests completed successfully.
- Ran formatting with `make fmt` successfully in the workspace.
- `make lint` / `make bootstrap` were attempted but blocked in this environment due to missing `golangci-lint` installation and network/proxy restrictions fetching tools (reported as failures outside of the code changes).
- Full `make test` / workspace-wide test run was blocked in this environment by a Go toolchain mismatch during coverage builds (`go1.26.0` vs tool `go1.25.1`), so workspace-wide coverage steps were not completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feb18e609c832c8d9e9547d3f8d0f4)