### PR TITLE
🎨 Palette: Add tooltips and shortcut hints to icon buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-05-22 - [Tooltip and DropdownMenu Nesting]
 **Learning:** In this project's UI system (based on Base UI), combining a `Tooltip` and `DropdownMenu` on the same trigger requires specific nesting to avoid event conflicts. Nesting the `Tooltip` inside the `DropdownMenu` and wrapping the `DropdownMenuTrigger` with `TooltipTrigger` ensures the tooltip doesn't stay open when the menu is active and avoids event propagation issues.
 **Action:** Use the pattern `<DropdownMenu><Tooltip><TooltipTrigger render={<DropdownMenuTrigger ... />}>...</TooltipTrigger>...</Tooltip>...</DropdownMenu>` when adding tooltips to menu triggers.
+
+## 2025-05-24 - [Keyboard Shortcut Hints in Tooltips]
+**Learning:** Tooltips for icon-only buttons that have keyboard shortcuts should include the shortcut hint using the `Kbd` component. This improves discoverability for power users. Simple OS detection (Mac vs Others) should be used to show the correct modifier key (⌘ vs Ctrl).
+**Action:** Add `<Kbd className="ms-2">{isMac ? "⌘B" : "Ctrl+B"}</Kbd>` inside `TooltipContent` for actions with shortcuts.

--- a/apps/hyperlocalise-web/src/components/theme-toggle.tsx
+++ b/apps/hyperlocalise-web/src/components/theme-toggle.tsx
@@ -13,6 +13,7 @@ import {
   DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 type ThemeOption = "light" | "dark" | "system";
 
@@ -47,12 +48,21 @@ export function ThemeToggle() {
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger
-        render={<Button variant="outline" size="icon-sm" className="rounded-full" />}
-      >
-        <ThemeToggleIcon theme={triggerTheme} />
-        <span className="sr-only">Change theme</span>
-      </DropdownMenuTrigger>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <DropdownMenuTrigger
+              render={<Button variant="outline" size="icon-sm" className="rounded-full" />}
+            />
+          }
+        >
+          <ThemeToggleIcon theme={triggerTheme} />
+          <span className="sr-only">Change theme</span>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" align="center">
+          Change theme
+        </TooltipContent>
+      </Tooltip>
       <DropdownMenuContent align="end">
         <DropdownMenuRadioGroup
           aria-label="Color theme"

--- a/apps/hyperlocalise-web/src/components/ui/kbd.tsx
+++ b/apps/hyperlocalise-web/src/components/ui/kbd.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
+  return (
+    <kbd
+      data-slot="kbd"
+      className={cn(
+        "inline-flex h-5 items-center rounded-4xl bg-muted-foreground/10 px-1.5 font-mono text-[10px] font-medium text-muted-foreground select-none",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Kbd };

--- a/apps/hyperlocalise-web/src/components/ui/sidebar.tsx
+++ b/apps/hyperlocalise-web/src/components/ui/sidebar.tsx
@@ -6,6 +6,7 @@ import { useRender } from "@base-ui/react/use-render";
 import { cva, type VariantProps } from "class-variance-authority";
 
 import { useIsMobile } from "@/hooks/use-mobile";
+import { useIsMac } from "@/hooks/use-is-mac";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -248,14 +249,7 @@ function Sidebar({
 
 function SidebarTrigger({ className, onClick, ...props }: React.ComponentProps<typeof Button>) {
   const { toggleSidebar } = useSidebar();
-  const [mounted, setMounted] = React.useState(false);
-
-  React.useEffect(() => {
-    setMounted(true);
-  }, []);
-
-  const isMac =
-    mounted && typeof window !== "undefined" && /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+  const isMac = useIsMac();
 
   return (
     <Tooltip>

--- a/apps/hyperlocalise-web/src/components/ui/sidebar.tsx
+++ b/apps/hyperlocalise-web/src/components/ui/sidebar.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/components/ui/sheet";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { Kbd } from "@/components/ui/kbd";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { SidebarLeftIcon } from "@hugeicons/core-free-icons";
 
@@ -247,23 +248,41 @@ function Sidebar({
 
 function SidebarTrigger({ className, onClick, ...props }: React.ComponentProps<typeof Button>) {
   const { toggleSidebar } = useSidebar();
+  const [mounted, setMounted] = React.useState(false);
+
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const isMac =
+    mounted && typeof window !== "undefined" && /Mac|iPod|iPhone|iPad/.test(navigator.platform);
 
   return (
-    <Button
-      data-sidebar="trigger"
-      data-slot="sidebar-trigger"
-      variant="ghost"
-      size="icon-sm"
-      className={cn(className)}
-      onClick={(event) => {
-        onClick?.(event);
-        toggleSidebar();
-      }}
-      {...props}
-    >
-      <HugeiconsIcon icon={SidebarLeftIcon} strokeWidth={2} className="rtl:rotate-180" />
-      <span className="sr-only">Toggle Sidebar</span>
-    </Button>
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Button
+            data-sidebar="trigger"
+            data-slot="sidebar-trigger"
+            variant="ghost"
+            size="icon-sm"
+            className={cn(className)}
+            onClick={(event) => {
+              onClick?.(event);
+              toggleSidebar();
+            }}
+            {...props}
+          />
+        }
+      >
+        <HugeiconsIcon icon={SidebarLeftIcon} strokeWidth={2} className="rtl:rotate-180" />
+        <span className="sr-only">Toggle Sidebar</span>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" align="start">
+        Toggle Sidebar
+        <Kbd className="ms-2">{isMac ? "⌘B" : "Ctrl+B"}</Kbd>
+      </TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/apps/hyperlocalise-web/src/hooks/use-is-mac.ts
+++ b/apps/hyperlocalise-web/src/hooks/use-is-mac.ts
@@ -1,0 +1,11 @@
+import * as React from "react";
+
+export function useIsMac() {
+  const [isMac, setIsMac] = React.useState(false);
+
+  React.useEffect(() => {
+    setIsMac(/Mac|iPod|iPhone|iPad/.test(navigator.platform));
+  }, []);
+
+  return isMac;
+}


### PR DESCRIPTION
This PR adds small touches of delight and accessibility to the user interface by:

1. **Adding Tooltips to Icon-only Buttons**: Both the Theme Toggle and the Sidebar Trigger now have tooltips to provide immediate context on hover.
2. **Implementing a `Kbd` Component**: A new reusable UI component for rendering semantic keyboard shortcuts.
3. **Keyboard Shortcut Discoverability**: The Sidebar Trigger tooltip now includes the keyboard shortcut hint (`⌘B` on Mac, `Ctrl+B` otherwise), helping users learn the available shortcuts.
4. **Adhering to Complex Nesting Rules**: The Theme Toggle tooltip is nested correctly within the Dropdown Menu to prevent event conflicts, as per project guidelines.

These micro-UX improvements make the application more intuitive and accessible for all users.

---
*PR created automatically by Jules for task [300044822980616390](https://jules.google.com/task/300044822980616390) started by @cungminh2710*