### PR TITLE
🧪 Scout: improve NormalizeList unit test coverage

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -1,0 +1,5 @@
+# Scout's Journal
+
+## 2025-05-14 - [Go Coverage Tooling Fallback]
+**Learning:** In some environments, `make test` might fail if the `covdata` tool is missing from the Go installation, preventing workspace-wide coverage aggregation.
+**Action:** Use `go test ./...` from the repository root as a reliable fallback to verify Go code logic when coverage tools are unavailable.

--- a/internal/i18n/locales/normalize_test.go
+++ b/internal/i18n/locales/normalize_test.go
@@ -6,9 +6,39 @@ import (
 )
 
 func TestNormalizeListSplitsTrimsAndDeduplicates(t *testing.T) {
-	got := NormalizeList([]string{" fr-FR, de-DE ", "fr-fr", "", " es-ES "})
-	want := []string{"fr-FR", "de-DE", "es-ES"}
-	if !slices.Equal(got, want) {
-		t.Fatalf("NormalizeList() = %#v, want %#v", got, want)
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "basic splitting and deduplication",
+			in:   []string{" fr-FR, de-DE ", "fr-fr", "", " es-ES "},
+			want: []string{"fr-FR", "de-DE", "es-ES"},
+		},
+		{
+			name: "empty inputs and strings with only whitespace",
+			in:   []string{"", "  ", " \t\n "},
+			want: []string{},
+		},
+		{
+			name: "strings with only commas",
+			in:   []string{",", ",,,", " , , "},
+			want: []string{},
+		},
+		{
+			name: "multiple consecutive commas and mixed casing",
+			in:   []string{"en-US,,en-GB", "EN-US", "  fr-CA  ,  FR-ca "},
+			want: []string{"en-US", "en-GB", "fr-CA"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NormalizeList(tt.in)
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("NormalizeList() = %#v, want %#v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Refactored the `NormalizeList` unit test in `internal/i18n/locales/normalize_test.go` into a more robust, table-driven suite. Added specific test cases to cover edge cases like empty strings, whitespace-only inputs, multiple consecutive commas, and mixed-case deduplication. verified that all tests pass and that the utility behaves as expected when encountered with messy input.

---
*PR created automatically by Jules for task [4208125857238569136](https://jules.google.com/task/4208125857238569136) started by @cungminh2710*