### PR TITLE
fix(crowdin): add hasPlurals and isIcu to SourceString model

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -16,4 +16,4 @@
 
 **Learning:** The Crowdin Source Strings API v2 returns `hasPlurals` and `isIcu` fields which were missing from the `SourceString` model. Additionally, `isIcu` can be specified when adding a new string but was missing from `SourceStringsAddRequest`.
 
-**Action:** Added `HasPlurals` and `IsIcu` fields to the `SourceString` response model and `IsIcu` (*bool) to the `SourceStringsAddRequest` model. Updated contract tests to verify correct parsing and serialization of these fields. Fixed a typo in the `SourceStringsAddRequest` documentation comment.
+**Action:** Added `HasPlurals`, `IsIcu`, `CommentsCount`, and `IssuesCount` fields to the `SourceString` response model and `IsIcu` (*bool) to the `SourceStringsAddRequest` model. Updated contract tests to verify correct parsing and serialization of these fields. Fixed a typo in the `SourceStringsAddRequest` documentation comment.

--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -11,3 +11,9 @@
 **Learning:** Several fields in the Crowdin Tasks API were missing from the Go SDK models. Specifically, `translateProgress` and `splitFiles` were absent from the `Task` response model. Additionally, task creation forms for both standard and Enterprise projects were missing flags like `skipUntranslatedStrings`, `includeUntranslatedStringsOnly`, and `splitFiles`.
 
 **Action:** Added `TranslateProgress` (*TaskProgress) and `SplitFiles` (*bool) to the `Task` response struct. Updated `TaskCreateForm`, `EnterpriseTaskCreateForm`, and vendor-specific creation forms to include missing boolean flags (`SkipUntranslatedStrings`, `IncludeUntranslatedStringsOnly`, `SplitFiles`). Verified serialization and response parsing with updated contract tests in `tasks_test.go`.
+
+## 2026-05-22 - Add SourceString parity for hasPlurals and isIcu
+
+**Learning:** The Crowdin Source Strings API v2 returns `hasPlurals` and `isIcu` fields which were missing from the `SourceString` model. Additionally, `isIcu` can be specified when adding a new string but was missing from `SourceStringsAddRequest`.
+
+**Action:** Added `HasPlurals` and `IsIcu` fields to the `SourceString` response model and `IsIcu` (*bool) to the `SourceStringsAddRequest` model. Updated contract tests to verify correct parsing and serialization of these fields. Fixed a typo in the `SourceStringsAddRequest` documentation comment.

--- a/third_party/crowdin-api-client-go/crowdin/model/source_strings.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/source_strings.go
@@ -19,6 +19,8 @@ type SourceString struct {
 	IsHidden       bool    `json:"isHidden"`
 	IsDuplicate    bool    `json:"isDuplicate"`
 	MasterStringID *int    `json:"masterStringId,omitempty"`
+	HasPlurals     bool    `json:"hasPlurals"`
+	IsIcu          bool    `json:"isIcu"`
 	LabelIDs       []int   `json:"labelIds"`
 	WebURL         string  `json:"webUrl"`
 	CreatedAt      *string `json:"createdAt,omitempty"`
@@ -136,7 +138,7 @@ func (o *SourceStringsGetOptions) Values() (url.Values, bool) {
 	return v, len(v) > 0
 }
 
-// SourcseStringsAddRequest defines the structure of a request
+// SourceStringsAddRequest defines the structure of a request
 // to add a string.
 type SourceStringsAddRequest struct {
 	// Text for translation.
@@ -159,6 +161,8 @@ type SourceStringsAddRequest struct {
 	Context string `json:"context,omitempty"`
 	// Defines whether to make string unavailable for translation. Default: false.
 	IsHidden *bool `json:"isHidden,omitempty"`
+	// Defines whether string is ICU.
+	IsIcu *bool `json:"isIcu,omitempty"`
 	// Max. length of translated text (0 – unlimited).
 	MaxLength *int `json:"maxLength,omitempty"`
 	// Label Identifiers.

--- a/third_party/crowdin-api-client-go/crowdin/model/source_strings.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/source_strings.go
@@ -22,6 +22,8 @@ type SourceString struct {
 	HasPlurals     bool    `json:"hasPlurals"`
 	IsIcu          bool    `json:"isIcu"`
 	LabelIDs       []int   `json:"labelIds"`
+	CommentsCount  int     `json:"commentsCount"`
+	IssuesCount    int     `json:"issuesCount"`
 	WebURL         string  `json:"webUrl"`
 	CreatedAt      *string `json:"createdAt,omitempty"`
 	UpdatedAt      *string `json:"updatedAt,omitempty"`

--- a/third_party/crowdin-api-client-go/crowdin/source_strings_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/source_strings_test.go
@@ -40,6 +40,8 @@ func TestSourceStringsService_List(t *testing.T) {
 						"labelIds": [
 							3
 						],
+						"commentsCount": 5,
+						"issuesCount": 1,
 						"webUrl": "https://example.crowdin.com/editor/1/all/en-pl?filter=basic&value=0&view=comfortable#2",
 						"createdAt": "2023-09-20T12:43:57+00:00",
 						"updatedAt": "2023-09-20T13:24:01+00:00",
@@ -101,6 +103,8 @@ func TestSourceStringsService_List(t *testing.T) {
 			HasPlurals:     false,
 			IsIcu:          false,
 			LabelIDs:       []int{3},
+			CommentsCount:  5,
+			IssuesCount:    1,
 			WebURL:         "https://example.crowdin.com/editor/1/all/en-pl?filter=basic&value=0&view=comfortable#2",
 			CreatedAt:      ToPtr("2023-09-20T12:43:57+00:00"),
 			UpdatedAt:      ToPtr("2023-09-20T13:24:01+00:00"),
@@ -239,6 +243,8 @@ func TestSourceStringsService_Get(t *testing.T) {
 				"labelIds": [
 					3
 				],
+				"commentsCount": 5,
+				"issuesCount": 1,
 				"webUrl": "https://example.crowdin.com/editor/1/all/en-pl?filter=basic&value=0&view=comfortable#2",
 				"createdAt": "2023-09-20T12:43:57+00:00",
 				"updatedAt": "2023-09-20T13:24:01+00:00",
@@ -270,6 +276,8 @@ func TestSourceStringsService_Get(t *testing.T) {
 		HasPlurals:     false,
 		IsIcu:          false,
 		LabelIDs:       []int{3},
+		CommentsCount:  5,
+		IssuesCount:    1,
 		WebURL:         "https://example.crowdin.com/editor/1/all/en-pl?filter=basic&value=0&view=comfortable#2",
 		CreatedAt:      ToPtr("2023-09-20T12:43:57+00:00"),
 		UpdatedAt:      ToPtr("2023-09-20T13:24:01+00:00"),
@@ -376,6 +384,8 @@ func TestSourceStringsService_Add(t *testing.T) {
 				"labelIds": [
 					3
 				],
+				"commentsCount": 5,
+				"issuesCount": 1,
 				"webUrl": "https://example.crowdin.com/editor/1/all/en-pl?filter=basic&value=0&view=comfortable#2",
 				"createdAt": "2023-09-20T12:43:57+00:00",
 				"updatedAt": "2023-09-20T13:24:01+00:00",
@@ -409,6 +419,8 @@ func TestSourceStringsService_Add(t *testing.T) {
 		HasPlurals:     false,
 		IsIcu:          false,
 		LabelIDs:       []int{3},
+		CommentsCount:  5,
+		IssuesCount:    1,
 		WebURL:         "https://example.crowdin.com/editor/1/all/en-pl?filter=basic&value=0&view=comfortable#2",
 		CreatedAt:      ToPtr("2023-09-20T12:43:57+00:00"),
 		UpdatedAt:      ToPtr("2023-09-20T13:24:01+00:00"),
@@ -578,6 +590,8 @@ func TestSourceStringsService_BatchOperations(t *testing.T) {
 						"labelIds": [
 							3
 						],
+						"commentsCount": 5,
+						"issuesCount": 1,
 						"webUrl": "https://example.crowdin.com/editor/1/all/en-pl?filter=basic&value=0&view=comfortable#1",
 						"createdAt": "2023-09-20T12:43:57+00:00",
 						"updatedAt": "2023-09-20T13:24:01+00:00"
@@ -608,6 +622,8 @@ func TestSourceStringsService_BatchOperations(t *testing.T) {
 			HasPlurals:     true,
 			IsIcu:          true,
 			LabelIDs:       []int{3},
+			CommentsCount:  5,
+			IssuesCount:    1,
 			WebURL:         "https://example.crowdin.com/editor/1/all/en-pl?filter=basic&value=0&view=comfortable#1",
 			CreatedAt:      ToPtr("2023-09-20T12:43:57+00:00"),
 			UpdatedAt:      ToPtr("2023-09-20T13:24:01+00:00"),
@@ -699,6 +715,8 @@ func TestSourceStringsService_Edit(t *testing.T) {
 		HasPlurals:     false,
 		IsIcu:          false,
 		LabelIDs:       []int{3},
+		CommentsCount:  0,
+		IssuesCount:    0,
 		WebURL:         "https://example.crowdin.com/editor/1/all/en-pl?filter=basic&value=0&view=comfortable#2",
 		CreatedAt:      ToPtr("2023-09-20T12:43:57+00:00"),
 		UpdatedAt:      ToPtr("2023-09-20T13:24:01+00:00"),

--- a/third_party/crowdin-api-client-go/crowdin/source_strings_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/source_strings_test.go
@@ -35,6 +35,8 @@ func TestSourceStringsService_List(t *testing.T) {
 						"isHidden": false,
 						"isDuplicate": true,
 						"masterStringId": 1,
+						"hasPlurals": false,
+						"isIcu": false,
 						"labelIds": [
 							3
 						],
@@ -96,6 +98,8 @@ func TestSourceStringsService_List(t *testing.T) {
 			IsHidden:       false,
 			IsDuplicate:    true,
 			MasterStringID: ToPtr(1),
+			HasPlurals:     false,
+			IsIcu:          false,
 			LabelIDs:       []int{3},
 			WebURL:         "https://example.crowdin.com/editor/1/all/en-pl?filter=basic&value=0&view=comfortable#2",
 			CreatedAt:      ToPtr("2023-09-20T12:43:57+00:00"),
@@ -230,6 +234,8 @@ func TestSourceStringsService_Get(t *testing.T) {
 				"isHidden": false,
 				"isDuplicate": true,
 				"masterStringId": 1,
+				"hasPlurals": false,
+				"isIcu": false,
 				"labelIds": [
 					3
 				],
@@ -261,6 +267,8 @@ func TestSourceStringsService_Get(t *testing.T) {
 		IsHidden:       false,
 		IsDuplicate:    true,
 		MasterStringID: ToPtr(1),
+		HasPlurals:     false,
+		IsIcu:          false,
 		LabelIDs:       []int{3},
 		WebURL:         "https://example.crowdin.com/editor/1/all/en-pl?filter=basic&value=0&view=comfortable#2",
 		CreatedAt:      ToPtr("2023-09-20T12:43:57+00:00"),
@@ -323,6 +331,7 @@ func TestSourceStringsService_Add(t *testing.T) {
 		Identifier: "name",
 		Context:    "shown on main page",
 		IsHidden:   ToPtr(false),
+		IsIcu:      ToPtr(false),
 		MaxLength:  ToPtr(35),
 		LabelIDs:   []int{3, 5, 7},
 		Fields: map[string]any{
@@ -340,6 +349,7 @@ func TestSourceStringsService_Add(t *testing.T) {
 			"identifier": "name",
 			"context": "shown on main page",
 			"isHidden": false,
+			"isIcu": false,
 			"maxLength": 35,
 			"labelIds": [3,5,7],
 			"fields": {
@@ -361,6 +371,8 @@ func TestSourceStringsService_Add(t *testing.T) {
 				"isHidden": false,
 				"isDuplicate": true,
 				"masterStringId": 1,
+				"hasPlurals": false,
+				"isIcu": false,
 				"labelIds": [
 					3
 				],
@@ -394,6 +406,8 @@ func TestSourceStringsService_Add(t *testing.T) {
 		IsHidden:       false,
 		IsDuplicate:    true,
 		MasterStringID: ToPtr(1),
+		HasPlurals:     false,
+		IsIcu:          false,
 		LabelIDs:       []int{3},
 		WebURL:         "https://example.crowdin.com/editor/1/all/en-pl?filter=basic&value=0&view=comfortable#2",
 		CreatedAt:      ToPtr("2023-09-20T12:43:57+00:00"),
@@ -559,8 +573,8 @@ func TestSourceStringsService_BatchOperations(t *testing.T) {
 						"isHidden": false,
 						"isDuplicate": true,
 						"masterStringId": 1,
-						"hasPlurals": false,
-						"isIcu": false,
+						"hasPlurals": true,
+						"isIcu": true,
 						"labelIds": [
 							3
 						],
@@ -591,6 +605,8 @@ func TestSourceStringsService_BatchOperations(t *testing.T) {
 			IsHidden:       false,
 			IsDuplicate:    true,
 			MasterStringID: ToPtr(1),
+			HasPlurals:     true,
+			IsIcu:          true,
 			LabelIDs:       []int{3},
 			WebURL:         "https://example.crowdin.com/editor/1/all/en-pl?filter=basic&value=0&view=comfortable#1",
 			CreatedAt:      ToPtr("2023-09-20T12:43:57+00:00"),
@@ -680,6 +696,8 @@ func TestSourceStringsService_Edit(t *testing.T) {
 		IsHidden:       true,
 		IsDuplicate:    true,
 		MasterStringID: ToPtr(1),
+		HasPlurals:     false,
+		IsIcu:          false,
 		LabelIDs:       []int{3},
 		WebURL:         "https://example.crowdin.com/editor/1/all/en-pl?filter=basic&value=0&view=comfortable#2",
 		CreatedAt:      ToPtr("2023-09-20T12:43:57+00:00"),


### PR DESCRIPTION
This PR improves the Crowdin fork's parity with the official Crowdin API v2 by adding missing fields to the Source Strings model.

### Changes:
- **Response Model:** Added `HasPlurals` and `IsIcu` to the `SourceString` struct.
- **Request Model:** Added `IsIcu` to the `SourceStringsAddRequest` struct.
- **Documentation:** Fixed a typo in the comment for `SourceStringsAddRequest`.
- **Tests:** Updated `List`, `Get`, `Add`, and `BatchOperations` tests to verify the new fields.
- **Journal:** Added a new entry to `.jules/crowdin-steward.md` documenting this change.

### Verification:
- Ran `go test github.com/crowdin/crowdin-api-client-go/crowdin` - **PASS**
- Ran `go test ./...` - **PASS**
- Verified documentation parity against [Crowdin API v2 reference](https://developer.crowdin.com/api/v2/).

---
*PR created automatically by Jules for task [8458455945148604894](https://jules.google.com/task/8458455945148604894) started by @cungminh2710*