### PR TITLE
Fix Crowdin download behavior and Enterprise parity

### DIFF
--- a/internal/i18n/storage/crowdin/filemode.go
+++ b/internal/i18n/storage/crowdin/filemode.go
@@ -233,6 +233,10 @@ func (a *FileAdapter) DownloadTranslations(ctx context.Context, req storage.File
 				if err != nil {
 					return storage.FileOperationResult{Processed: processed, Skipped: skipped}, err
 				}
+				if payload == nil {
+					skipped = append(skipped, remotePath+"@"+locale.Locale)
+					continue
+				}
 				targetPath, err := renderCrowdinTranslationPath(config.BasePath, group.Translation, locale.Locale, sourcePath, group.LanguagesMapping)
 				if err != nil {
 					return storage.FileOperationResult{Processed: processed, Skipped: skipped}, err

--- a/internal/i18n/storage/crowdin/filemode_test.go
+++ b/internal/i18n/storage/crowdin/filemode_test.go
@@ -116,10 +116,7 @@ func (f *fakeFileClient) DownloadSourceFile(_ context.Context, _ string, fileID 
 func (f *fakeFileClient) DownloadTranslationFile(_ context.Context, _ string, fileID int, languageID string, opts storage.FileExportOptions) ([]byte, error) {
 	f.downloaded = append(f.downloaded, fmt.Sprintf("%s:%d", languageID, fileID))
 	f.downloadOptions = append(f.downloadOptions, opts)
-	if f.downloadPayload != nil {
-		return f.downloadPayload, nil
-	}
-	return []byte("translated-" + languageID), nil
+	return f.downloadPayload, nil
 }
 
 func TestFileAdapterUploadSourcesRegistersRemoteFiles(t *testing.T) {
@@ -245,6 +242,7 @@ func TestFileAdapterDownloadTranslationsPropagatesExportOptions(t *testing.T) {
 		locales:         []ResolvedLocale{{LanguageID: "fr", Locale: "fr"}},
 		directories:     map[string]int{"src": 1},
 		failFindMissing: true,
+		downloadPayload: []byte("translated-fr"),
 	}
 	adapter := mustNewFileAdapterForTest(t, storage.FileWorkflowConfig{
 		ProjectID:         "123",
@@ -309,6 +307,7 @@ func TestFileAdapterDownloadTranslationsUsesLanguageIDForRequestAndLocaleForPath
 		},
 		directories:     map[string]int{"src": 1},
 		failFindMissing: true,
+		downloadPayload: []byte("translated-fr"),
 	}
 	adapter := mustNewFileAdapterForTest(t, storage.FileWorkflowConfig{
 		ProjectID:         "123",
@@ -843,6 +842,42 @@ func TestResolveCrowdinSourcePathsSupportsBracketClassesWithDoublestar(t *testin
 	want := []string{filepath.Join(base, "nested", "en.JSON")}
 	if !reflect.DeepEqual(matches, want) {
 		t.Fatalf("matches = %#v, want %#v", matches, want)
+	}
+}
+
+func TestFileAdapterDownloadTranslationsHandlesSkippedFiles(t *testing.T) {
+	base := t.TempDir()
+	writeJSONFixture(t, filepath.Join(base, "src", "messages.json"), `{"hello":"Hello"}`)
+
+	client := &fakeFileClient{
+		locales:         []ResolvedLocale{{LanguageID: "fr", Locale: "fr"}},
+		directories:     map[string]int{"src": 1},
+		files:           map[string]int{"messages.json": 1},
+		failFindMissing: true,
+		downloadPayload: nil, // Simulate skipped file (204 No Content -> nil payload)
+	}
+	adapter := mustNewFileAdapterForTest(t, storage.FileWorkflowConfig{
+		ProjectID:         "123",
+		APIToken:          "token",
+		BasePath:          base,
+		PreserveHierarchy: true,
+		Files: []storage.FileGroupSpec{{
+			Source:      "/src/*.json",
+			Translation: "/download/%locale%/%original_file_name%",
+		}},
+	}, client)
+
+	result, err := adapter.DownloadTranslations(context.Background(), storage.FileDownloadTranslationsRequest{})
+	if err != nil {
+		t.Fatalf("download translations: %v", err)
+	}
+
+	if len(result.Processed) != 0 {
+		t.Fatalf("processed = %v, want empty", result.Processed)
+	}
+	wantSkipped := []string{"src/messages.json@fr"}
+	if !reflect.DeepEqual(result.Skipped, wantSkipped) {
+		t.Fatalf("skipped = %v, want %v", result.Skipped, wantSkipped)
 	}
 }
 

--- a/internal/i18n/storage/crowdin/http_client.go
+++ b/internal/i18n/storage/crowdin/http_client.go
@@ -777,7 +777,8 @@ func (c *HTTPClient) DownloadTranslationFile(ctx context.Context, projectID stri
 		return nil, fmt.Errorf("build translation for file %d locale %s: %w", fileID, languageID, err)
 	}
 	if link == nil || strings.TrimSpace(link.URL) == "" {
-		return nil, fmt.Errorf("build translation for file %d locale %s: empty download link", fileID, languageID)
+		c.debugf("action=download-translation project_id=%d file_id=%d language_id=%s phase=skipped", projectInt, fileID, languageID)
+		return nil, nil
 	}
 	c.debugf("action=download-translation project_id=%d file_id=%d language_id=%s phase=download-artifact", projectInt, fileID, languageID)
 	return c.downloadURL(ctx, link.URL)

--- a/internal/i18n/storage/crowdin/http_client_test.go
+++ b/internal/i18n/storage/crowdin/http_client_test.go
@@ -583,9 +583,9 @@ func TestHTTPClientDownloadLogsOmitArtifactURL(t *testing.T) {
 	mux.HandleFunc("/api/v2/projects/123/translations/builds/files/17", func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(t, r, http.MethodPost, "/api/v2/projects/123/translations/builds/files/17")
 		assertJSONBody(t, r, map[string]any{
-			"targetLanguageId":        "fr",
+			"targetLanguageId":            "fr",
 			"exportWithMinApprovalsCount": 1,
-			"skipUntranslatedStrings": true,
+			"skipUntranslatedStrings":     true,
 		})
 		_, _ = io.WriteString(w, `{"data":{"url":"https://api.crowdin.com/downloads/secret-token.json"}}`)
 	})

--- a/internal/i18n/storage/crowdin/http_client_test.go
+++ b/internal/i18n/storage/crowdin/http_client_test.go
@@ -584,7 +584,7 @@ func TestHTTPClientDownloadLogsOmitArtifactURL(t *testing.T) {
 		assertRequest(t, r, http.MethodPost, "/api/v2/projects/123/translations/builds/files/17")
 		assertJSONBody(t, r, map[string]any{
 			"targetLanguageId":        "fr",
-			"exportApprovedOnly":      true,
+			"exportWithMinApprovalsCount": 1,
 			"skipUntranslatedStrings": true,
 		})
 		_, _ = io.WriteString(w, `{"data":{"url":"https://api.crowdin.com/downloads/secret-token.json"}}`)

--- a/third_party/crowdin-api-client-go/crowdin/model/translations.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/translations.go
@@ -181,6 +181,33 @@ type BuildProjectDirectoryTranslationRequest struct {
 	ExportStringsThatPassedWorkflow *bool `json:"exportStringsThatPassedWorkflow,omitempty"`
 }
 
+// MarshalJSON adapts directory build requests to Crowdin Enterprise behavior.
+func (r *BuildProjectDirectoryTranslationRequest) MarshalJSON() ([]byte, error) {
+	type buildProjectDirectoryTranslationRequest struct {
+		TargetLanguageIDs               []string `json:"targetLanguageIds,omitempty"`
+		SkipUntranslatedStrings         *bool    `json:"skipUntranslatedStrings,omitempty"`
+		SkipUntranslatedFiles           *bool    `json:"skipUntranslatedFiles,omitempty"`
+		PreserveFolderHierarchy         *bool    `json:"preserveFolderHierarchy,omitempty"`
+		ExportWithMinApprovalsCount     *int     `json:"exportWithMinApprovalsCount,omitempty"`
+		ExportStringsThatPassedWorkflow *bool    `json:"exportStringsThatPassedWorkflow,omitempty"`
+	}
+
+	exportWithMinApprovalsCount := r.ExportWithMinApprovalsCount
+	if r.ExportApprovedOnly != nil && *r.ExportApprovedOnly && exportWithMinApprovalsCount == nil {
+		minApprovalsCount := 1
+		exportWithMinApprovalsCount = &minApprovalsCount
+	}
+
+	return json.Marshal(buildProjectDirectoryTranslationRequest{
+		TargetLanguageIDs:               r.TargetLanguageIDs,
+		SkipUntranslatedStrings:         r.SkipUntranslatedStrings,
+		SkipUntranslatedFiles:           r.SkipUntranslatedFiles,
+		PreserveFolderHierarchy:         r.PreserveFolderHierarchy,
+		ExportWithMinApprovalsCount:     exportWithMinApprovalsCount,
+		ExportStringsThatPassedWorkflow: r.ExportStringsThatPassedWorkflow,
+	})
+}
+
 // Validate checks if the build project directory translation request is valid.
 // It implements the crowdin.RequestValidator interface.
 func (r *BuildProjectDirectoryTranslationRequest) Validate() error {
@@ -233,6 +260,31 @@ type BuildProjectFileTranslationRequest struct {
 	// Note: true value can't be used with `exportWithMinApprovalsCount>0` in same request
 	// or in projects without an assigned workflow.
 	ExportStringsThatPassedWorkflow *bool `json:"exportStringsThatPassedWorkflow,omitempty"`
+}
+
+// MarshalJSON adapts file build requests to Crowdin Enterprise behavior.
+func (r *BuildProjectFileTranslationRequest) MarshalJSON() ([]byte, error) {
+	type buildProjectFileTranslationRequest struct {
+		TargetLanguageID                string `json:"targetLanguageId"`
+		SkipUntranslatedStrings         *bool  `json:"skipUntranslatedStrings,omitempty"`
+		SkipUntranslatedFiles           *bool  `json:"skipUntranslatedFiles,omitempty"`
+		ExportWithMinApprovalsCount     *int   `json:"exportWithMinApprovalsCount,omitempty"`
+		ExportStringsThatPassedWorkflow *bool  `json:"exportStringsThatPassedWorkflow,omitempty"`
+	}
+
+	exportWithMinApprovalsCount := r.ExportWithMinApprovalsCount
+	if r.ExportApprovedOnly != nil && *r.ExportApprovedOnly && exportWithMinApprovalsCount == nil {
+		minApprovalsCount := 1
+		exportWithMinApprovalsCount = &minApprovalsCount
+	}
+
+	return json.Marshal(buildProjectFileTranslationRequest{
+		TargetLanguageID:                r.TargetLanguageID,
+		SkipUntranslatedStrings:         r.SkipUntranslatedStrings,
+		SkipUntranslatedFiles:           r.SkipUntranslatedFiles,
+		ExportWithMinApprovalsCount:     exportWithMinApprovalsCount,
+		ExportStringsThatPassedWorkflow: r.ExportStringsThatPassedWorkflow,
+	})
 }
 
 // Validate checks if the build project file translation request is valid.
@@ -542,6 +594,41 @@ type ExportTranslationRequest struct {
 	// Note: true value can't be used with `exportWithMinApprovalsCount>0` in same request
 	// or in projects without an assigned workflow.
 	ExportStringsThatPassedWorkflow *bool `json:"exportStringsThatPassedWorkflow,omitempty"`
+}
+
+// MarshalJSON adapts export translation requests to Crowdin Enterprise behavior.
+func (r *ExportTranslationRequest) MarshalJSON() ([]byte, error) {
+	type exportTranslationRequest struct {
+		TargetLanguageID                string   `json:"targetLanguageId"`
+		Format                          string   `json:"format,omitempty"`
+		LabelIDs                        []int    `json:"labelIds,omitempty"`
+		BranchIDs                       []int    `json:"branchIds,omitempty"`
+		DirectoryIDs                    []int    `json:"directoryIds,omitempty"`
+		FileIDs                         []int    `json:"fileIds,omitempty"`
+		SkipUntranslatedStrings         *bool    `json:"skipUntranslatedStrings,omitempty"`
+		SkipUntranslatedFiles           *bool    `json:"skipUntranslatedFiles,omitempty"`
+		ExportWithMinApprovalsCount     *int     `json:"exportWithMinApprovalsCount,omitempty"`
+		ExportStringsThatPassedWorkflow *bool    `json:"exportStringsThatPassedWorkflow,omitempty"`
+	}
+
+	exportWithMinApprovalsCount := r.ExportWithMinApprovalsCount
+	if r.ExportApprovedOnly != nil && *r.ExportApprovedOnly && exportWithMinApprovalsCount == nil {
+		minApprovalsCount := 1
+		exportWithMinApprovalsCount = &minApprovalsCount
+	}
+
+	return json.Marshal(exportTranslationRequest{
+		TargetLanguageID:                r.TargetLanguageID,
+		Format:                          r.Format,
+		LabelIDs:                        r.LabelIDs,
+		BranchIDs:                       r.BranchIDs,
+		DirectoryIDs:                    r.DirectoryIDs,
+		FileIDs:                         r.FileIDs,
+		SkipUntranslatedStrings:         r.SkipUntranslatedStrings,
+		SkipUntranslatedFiles:           r.SkipUntranslatedFiles,
+		ExportWithMinApprovalsCount:     exportWithMinApprovalsCount,
+		ExportStringsThatPassedWorkflow: r.ExportStringsThatPassedWorkflow,
+	})
 }
 
 // Validate checks if the request is valid.

--- a/third_party/crowdin-api-client-go/crowdin/model/translations.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/translations.go
@@ -599,16 +599,16 @@ type ExportTranslationRequest struct {
 // MarshalJSON adapts export translation requests to Crowdin Enterprise behavior.
 func (r *ExportTranslationRequest) MarshalJSON() ([]byte, error) {
 	type exportTranslationRequest struct {
-		TargetLanguageID                string   `json:"targetLanguageId"`
-		Format                          string   `json:"format,omitempty"`
-		LabelIDs                        []int    `json:"labelIds,omitempty"`
-		BranchIDs                       []int    `json:"branchIds,omitempty"`
-		DirectoryIDs                    []int    `json:"directoryIds,omitempty"`
-		FileIDs                         []int    `json:"fileIds,omitempty"`
-		SkipUntranslatedStrings         *bool    `json:"skipUntranslatedStrings,omitempty"`
-		SkipUntranslatedFiles           *bool    `json:"skipUntranslatedFiles,omitempty"`
-		ExportWithMinApprovalsCount     *int     `json:"exportWithMinApprovalsCount,omitempty"`
-		ExportStringsThatPassedWorkflow *bool    `json:"exportStringsThatPassedWorkflow,omitempty"`
+		TargetLanguageID                string `json:"targetLanguageId"`
+		Format                          string `json:"format,omitempty"`
+		LabelIDs                        []int  `json:"labelIds,omitempty"`
+		BranchIDs                       []int  `json:"branchIds,omitempty"`
+		DirectoryIDs                    []int  `json:"directoryIds,omitempty"`
+		FileIDs                         []int  `json:"fileIds,omitempty"`
+		SkipUntranslatedStrings         *bool  `json:"skipUntranslatedStrings,omitempty"`
+		SkipUntranslatedFiles           *bool  `json:"skipUntranslatedFiles,omitempty"`
+		ExportWithMinApprovalsCount     *int   `json:"exportWithMinApprovalsCount,omitempty"`
+		ExportStringsThatPassedWorkflow *bool  `json:"exportStringsThatPassedWorkflow,omitempty"`
 	}
 
 	exportWithMinApprovalsCount := r.ExportWithMinApprovalsCount

--- a/third_party/crowdin-api-client-go/crowdin/translations_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/translations_test.go
@@ -434,7 +434,6 @@ func TestTranslationsService_BuildProjectDirectoryTranslation(t *testing.T) {
 			"targetLanguageIds": ["uk"],
 			"skipUntranslatedStrings": false,
 			"skipUntranslatedFiles": false,
-			"exportApprovedOnly": false,
 			"exportWithMinApprovalsCount": 0,
 			"exportStringsThatPassedWorkflow": true,
 			"preserveFolderHierarchy": false
@@ -497,7 +496,6 @@ func TestTranslationsService_BuildProjectFileTranslation(t *testing.T) {
 			"targetLanguageId": "uk",
 			"skipUntranslatedStrings": true,
 			"skipUntranslatedFiles": false,
-			"exportApprovedOnly": false,
 			"exportWithMinApprovalsCount": 0,
 			"exportStringsThatPassedWorkflow": true
 		}`
@@ -980,8 +978,7 @@ func TestTranslationsService_ExportProjectTranslation(t *testing.T) {
 			"directoryIds": [3],
 			"fileIds": [4],
 			"skipUntranslatedStrings": false,
-			"skipUntranslatedFiles": false,
-			"exportApprovedOnly": false
+			"skipUntranslatedFiles": false
 		}`
 		testJSONBody(t, r, expectedReqBody)
 


### PR DESCRIPTION
Improved Crowdin download robustness by handling skipped files (204 No Content) and ensuring parity with Crowdin Enterprise API requirements for approved-only builds.

---
*PR created automatically by Jules for task [8259458148376514993](https://jules.google.com/task/8259458148376514993) started by @cungminh2710*