### PR TITLE
fix(web): type JSON-LD schema data

### DIFF
--- a/apps/hyperlocalise-web/src/components/seo/json-ld.tsx
+++ b/apps/hyperlocalise-web/src/components/seo/json-ld.tsx
@@ -1,10 +1,6 @@
 import type { Thing, WithContext } from "schema-dts";
 
-export function JsonLd({
-  data,
-}: {
-  data: WithContext<Thing>;
-}) {
+export function JsonLd({ data }: { data: WithContext<Thing> }) {
   return (
     <script
       type="application/ld+json"

--- a/apps/hyperlocalise-web/src/components/seo/json-ld.tsx
+++ b/apps/hyperlocalise-web/src/components/seo/json-ld.tsx
@@ -1,10 +1,9 @@
-import type { WithContext } from "schema-dts";
+import type { Thing, WithContext } from "schema-dts";
 
 export function JsonLd({
   data,
 }: {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  data: WithContext<any>;
+  data: WithContext<Thing>;
 }) {
   return (
     <script


### PR DESCRIPTION
## Summary
- Replace the JSON-LD component's `WithContext<any>` prop with `WithContext<Thing>` from `schema-dts`.
- Remove the `no-explicit-any` eslint suppression while preserving the existing JSON-LD script output.
- Confirm the existing `JsonLd` caller remains compatible with its `WebApplication` schema.

## Verification
- Not run: `vp check --fix` and `vp test` because `vp` is not available in this environment (`command -v vp` returned no path).