### PR TITLE
docs: fix web app path references

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Useful repo paths:
 
 - `apps/cli/`: CLI application entrypoint
 - `apps/cli/cmd/`: CLI command handlers
-- `apps/web/`: web app workspace
+- `apps/hyperlocalise-web/`: web app workspace
 - `internal/`: shared internal packages
 - `pkg/platform/`: runtime, auth, transport, and observability helpers
 - `api/proto/`: protobuf contract workspace

--- a/apps/hyperlocalise-web/AGENTS.md
+++ b/apps/hyperlocalise-web/AGENTS.md
@@ -16,7 +16,7 @@ Follow the official Hono best-practices guide for this app: [Best Practices](htt
 
 - Prefer route-local handlers instead of Rails-style controller functions. Define the handler inline where the path is declared so `c.req.param()` and other route types infer correctly.
 - Split larger APIs into route modules and mount them with `app.route(...)`.
-- Keep the root API app in [`src/api/app.ts`](/Users/minhcung/work/hyperlocalise/apps/hyperlocalise-web/src/api/app.ts). If a test or feature needs an app instance, import the factory or app from there instead of constructing a separate ad hoc `new Hono()` shape in the test file.
+- Keep the root API app in [`src/api/app.ts`](src/api/app.ts). If a test or feature needs an app instance, import the factory or app from there instead of constructing a separate ad hoc `new Hono()` shape in the test file.
 
 ## Middleware
 
@@ -27,7 +27,7 @@ Follow the official Hono best-practices guide for this app: [Best Practices](htt
 ## Testing
 
 - Use Hono's `testClient` for route tests.
-- Test the real API app exported from [`src/api/app.ts`](/Users/minhcung/work/hyperlocalise/apps/hyperlocalise-web/src/api/app.ts) when possible, rather than rebuilding a parallel test-only app structure.
+- Test the real API app exported from [`src/api/app.ts`](src/api/app.ts) when possible, rather than rebuilding a parallel test-only app structure.
 
 <!-- END:hono-agent-rules -->
 


### PR DESCRIPTION
## Summary
- Update the README development path for the web app workspace.
- Replace local absolute links in the web app agent guide with repo-relative links.

## Testing
- make fmt
- make lint
- make test