### PR TITLE
fix(web): tighten fromThrowable types

### DIFF
--- a/apps/hyperlocalise-web/src/lib/primitives/result/results.ts
+++ b/apps/hyperlocalise-web/src/lib/primitives/result/results.ts
@@ -88,10 +88,10 @@ export async function fromThrowableAsync<T>(promise: Promise<T>): Promise<Result
  * @param fn function to wrap with ok on success or err on failure
  * @param errorFn when an error is thrown, this will wrap the error result if provided
  */
-export function fromThrowable<Fn extends (...args: readonly unknown[]) => unknown>(
-  fn: Fn,
+export function fromThrowable<Args extends readonly unknown[], Value>(
+  fn: (...args: Args) => Value,
   errorFn?: (e: unknown) => unknown,
-): (...args: Parameters<Fn>) => Result<ReturnType<Fn>, unknown> {
+): (...args: Args) => Result<Value, unknown> {
   return (...args) => {
     try {
       const result = fn(...args);

--- a/apps/hyperlocalise-web/src/lib/primitives/result/results.ts
+++ b/apps/hyperlocalise-web/src/lib/primitives/result/results.ts
@@ -88,14 +88,12 @@ export async function fromThrowableAsync<T>(promise: Promise<T>): Promise<Result
  * @param fn function to wrap with ok on success or err on failure
  * @param errorFn when an error is thrown, this will wrap the error result if provided
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function fromThrowable<Fn extends (...args: readonly any[]) => any>(
+export function fromThrowable<Fn extends (...args: readonly unknown[]) => unknown>(
   fn: Fn,
   errorFn?: (e: unknown) => unknown,
 ): (...args: Parameters<Fn>) => Result<ReturnType<Fn>, unknown> {
   return (...args) => {
     try {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const result = fn(...args);
       return ok(result);
     } catch (e) {


### PR DESCRIPTION
## Summary
- Replace `fromThrowable`'s `any` function constraint with `unknown`-based types.
- Remove now-unnecessary eslint disables while preserving parameter and return inference.

## Testing
- Not run: `vp` is not available in this environment.