### PR TITLE
fix(web): resolve interaction inbox status

### DIFF
--- a/apps/hyperlocalise-web/src/lib/tools/interaction-tools.test.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/interaction-tools.test.ts
@@ -1,0 +1,132 @@
+import "dotenv/config";
+
+import { randomUUID } from "node:crypto";
+
+import { eq } from "drizzle-orm";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+
+import { db, schema } from "@/lib/database";
+import { createResolveInteractionTool } from "./interaction-tools";
+
+const createdWorkosOrganizationIds = new Set<string>();
+
+async function createOrganization() {
+  const suffix = randomUUID();
+  const workosOrganizationId = `org_${suffix}`;
+  createdWorkosOrganizationIds.add(workosOrganizationId);
+
+  const [organization] = await db
+    .insert(schema.organizations)
+    .values({
+      workosOrganizationId,
+      name: `Example Org ${suffix}`,
+      slug: `example-org-${suffix}`,
+    })
+    .returning();
+
+  return organization;
+}
+
+async function createInteractionWithInboxItem(organizationId: string) {
+  const [interaction] = await db
+    .insert(schema.interactions)
+    .values({
+      organizationId,
+      source: "chat_ui",
+      title: "Test conversation",
+    })
+    .returning();
+
+  await db.insert(schema.inboxItems).values({
+    interactionId: interaction.id,
+    organizationId,
+    status: "active",
+  });
+
+  return interaction;
+}
+
+async function executeResolveInteractionTool(input: {
+  conversationId: string;
+  organizationId: string;
+}) {
+  const resolveInteraction = createResolveInteractionTool({
+    conversationId: input.conversationId,
+    organizationId: input.organizationId,
+    projectId: null,
+    db,
+  });
+
+  if (!resolveInteraction.execute) {
+    throw new Error("resolve interaction tool is missing execute");
+  }
+
+  return resolveInteraction.execute(
+    { status: "archived" },
+    { toolCallId: "test-tool-call", messages: [] },
+  );
+}
+
+afterEach(async () => {
+  for (const workosOrganizationId of createdWorkosOrganizationIds) {
+    await db
+      .delete(schema.organizations)
+      .where(eq(schema.organizations.workosOrganizationId, workosOrganizationId));
+  }
+
+  createdWorkosOrganizationIds.clear();
+});
+
+describe("createResolveInteractionTool", () => {
+  it("updates the current interaction inbox item status", async () => {
+    const organization = await createOrganization();
+    const interaction = await createInteractionWithInboxItem(organization.id);
+
+    const result = await executeResolveInteractionTool({
+      conversationId: interaction.id,
+      organizationId: organization.id,
+    });
+
+    expect(result).toEqual({ success: true, status: "archived" });
+
+    const [item] = await db
+      .select({ status: schema.inboxItems.status })
+      .from(schema.inboxItems)
+      .where(eq(schema.inboxItems.interactionId, interaction.id))
+      .limit(1);
+
+    expect(item?.status).toBe("archived");
+  });
+
+  it("returns failure when the current interaction has no inbox item", async () => {
+    const organization = await createOrganization();
+
+    const result = await executeResolveInteractionTool({
+      conversationId: randomUUID(),
+      organizationId: organization.id,
+    });
+
+    expect(result).toEqual({ success: false, status: null, error: "Inbox item not found." });
+  });
+
+  it("does not update an inbox item from another organization", async () => {
+    const owningOrganization = await createOrganization();
+    const otherOrganization = await createOrganization();
+    const interaction = await createInteractionWithInboxItem(owningOrganization.id);
+
+    const result = await executeResolveInteractionTool({
+      conversationId: interaction.id,
+      organizationId: otherOrganization.id,
+    });
+
+    expect(result).toEqual({ success: false, status: null, error: "Inbox item not found." });
+
+    const [item] = await db
+      .select({ status: schema.inboxItems.status })
+      .from(schema.inboxItems)
+      .where(eq(schema.inboxItems.interactionId, interaction.id))
+      .limit(1);
+
+    expect(item?.status).toBe("active");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/tools/interaction-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/interaction-tools.ts
@@ -1,6 +1,8 @@
 import { tool } from "ai";
+import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 
+import { schema } from "@/lib/database";
 import type { ToolContext } from "./types";
 
 /**
@@ -16,17 +18,30 @@ import type { ToolContext } from "./types";
  *
  * Example usage: user says "That's all I needed, thanks."
  */
-export function createResolveInteractionTool(_ctx: ToolContext) {
+export function createResolveInteractionTool(ctx: ToolContext) {
   return tool({
     description:
       "Resolve or archive the current conversation so it no longer appears as requiring attention in the inbox.",
     inputSchema: z.object({
       status: z.enum(["active", "archived"]).describe("Desired inbox status."),
     }),
-    execute: async () => {
-      // TODO: implement inbox status update.
-      // Schema: `inboxItems`. Consider adding "resolved" to `inboxStatusEnum`.
-      return { success: false, status: null };
+    execute: async ({ status }) => {
+      const [item] = await ctx.db
+        .update(schema.inboxItems)
+        .set({ status })
+        .where(
+          and(
+            eq(schema.inboxItems.interactionId, ctx.conversationId),
+            eq(schema.inboxItems.organizationId, ctx.organizationId),
+          ),
+        )
+        .returning({ status: schema.inboxItems.status });
+
+      if (!item) {
+        return { success: false, status: null, error: "Inbox item not found." };
+      }
+
+      return { success: true, status: item.status };
     },
   });
 }


### PR DESCRIPTION
## Summary
- Update the resolve interaction tool to archive or reactivate the current interaction's scoped inbox item.
- Return the actual updated inbox status and a not-found error when no scoped inbox item exists.
- Add focused tool tests for success, missing item, and cross-tenant isolation.

## Validation
- `make bootstrap`
- `make fmt`
- `make lint`
- `make test`
- `vp test apps/hyperlocalise-web/src/lib/tools/interaction-tools.test.ts` blocked: `vp` command not found
- `vp check --fix` blocked: `vp` command not found
- `vp test` blocked: `vp` command not found