### PR TITLE
docs(readme): fix web app repo path

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Useful repo paths:
 
 - `apps/cli/`: CLI application entrypoint
 - `apps/cli/cmd/`: CLI command handlers
-- `apps/web/`: web app workspace
+- `apps/hyperlocalise-web/`: web app workspace
 - `internal/`: shared internal packages
 - `pkg/platform/`: runtime, auth, transport, and observability helpers
 - `api/proto/`: protobuf contract workspace


### PR DESCRIPTION
## Summary
- Correct the README Development repo path for the web app workspace.
- Leave `apps/web/lang` documentation examples unchanged because they describe user project paths, not this repository layout.

## Checks
- `make fmt`
- `make lint`
- `make test`
- `mint broken-links` from `docs/` reported a parsing warning for `docs/AGENTS.md` but completed with `success no broken links found`.