### PR TITLE
🎨 Palette: Improve project management micro-UX

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-10 - [Standardizing Accessible Icon Buttons & Async Feedback]
+**Learning:** The idiomatic pattern for accessible icon buttons with tooltips in this app involves wrapping the `Button` in a `TooltipTrigger` (using the `render` prop) and providing both the icon and an `<span className="sr-only">` label as children. For async actions, adding the `Spinner` component to primary/destructive buttons during `isSaving`/`isDeleting` states significantly improves perceived responsiveness and prevents double-submissions.
+**Action:** Always use `sr-only` spans alongside tooltips for icon-only buttons, and prefer the `Spinner` component for all button loading states.

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/_components/delete-project-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/_components/delete-project-dialog.tsx
@@ -48,11 +48,7 @@ export function DeleteProjectDialog({
               }
             }}
           >
-            {isDeleting ? (
-              <Spinner />
-            ) : (
-              <HugeiconsIcon icon={Delete02Icon} strokeWidth={1.8} />
-            )}
+            {isDeleting ? <Spinner /> : <HugeiconsIcon icon={Delete02Icon} strokeWidth={1.8} />}
             {isDeleting ? "Deleting..." : "Delete"}
           </Button>
         </AlertDialogFooter>

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/_components/delete-project-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/_components/delete-project-dialog.tsx
@@ -1,6 +1,7 @@
 import { Delete02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 
+import { Spinner } from "@/components/ui/spinner";
 import {
   AlertDialog,
   AlertDialogCancel,
@@ -47,7 +48,11 @@ export function DeleteProjectDialog({
               }
             }}
           >
-            <HugeiconsIcon icon={Delete02Icon} strokeWidth={1.8} />
+            {isDeleting ? (
+              <Spinner />
+            ) : (
+              <HugeiconsIcon icon={Delete02Icon} strokeWidth={1.8} />
+            )}
             {isDeleting ? "Deleting..." : "Delete"}
           </Button>
         </AlertDialogFooter>

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/_components/project-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/_components/project-dialog.tsx
@@ -4,6 +4,7 @@ import { type FormEvent, useEffect, useState } from "react";
 import { SaveIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 
+import { Spinner } from "@/components/ui/spinner";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -141,7 +142,7 @@ export function ProjectDialog({
               Cancel
             </Button>
             <Button type="submit" disabled={isSaving}>
-              <HugeiconsIcon icon={SaveIcon} strokeWidth={1.8} />
+              {isSaving ? <Spinner /> : <HugeiconsIcon icon={SaveIcon} strokeWidth={1.8} />}
               {isSaving ? "Saving..." : "Save project"}
             </Button>
           </DialogFooter>

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.tsx
@@ -100,7 +100,7 @@ export function ProjectsTable({
                       }
                     >
                       <HugeiconsIcon icon={Edit02Icon} strokeWidth={1.8} />
-                      <span className="sr-only">Edit project</span>
+                      <span className="sr-only">Edit {project.name}</span>
                     </TooltipTrigger>
                     <TooltipContent side="bottom" align="center">
                       Edit project
@@ -122,7 +122,7 @@ export function ProjectsTable({
                       }
                     >
                       <HugeiconsIcon icon={Delete02Icon} strokeWidth={1.8} />
-                      <span className="sr-only">Delete project</span>
+                      <span className="sr-only">Delete {project.name}</span>
                     </TooltipTrigger>
                     <TooltipContent side="bottom" align="center">
                       Delete project

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.tsx
@@ -3,6 +3,7 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import type { UseQueryResult } from "@tanstack/react-query";
 
 import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 import type { ProjectListRow } from "./project-list";
 import { TypographyH3, TypographyP } from "@/components/ui/typography";
@@ -83,32 +84,50 @@ export function ProjectsTable({
                 </div>
 
                 <div className="flex shrink-0 items-center gap-1">
-                  <Button
-                    type="button"
-                    size="icon-sm"
-                    variant="ghost"
-                    aria-label={`Edit ${project.name}`}
-                    onClick={() => {
-                      onEditProject(project);
-                    }}
-                    disabled={isSavingProject}
-                    className="text-foreground/54 hover:text-foreground"
-                  >
-                    <HugeiconsIcon icon={Edit02Icon} strokeWidth={1.8} />
-                  </Button>
-                  <Button
-                    type="button"
-                    size="icon-sm"
-                    variant="ghost"
-                    aria-label={`Delete ${project.name}`}
-                    onClick={() => {
-                      onDeleteProject(project);
-                    }}
-                    disabled={isDeletingProject || isSavingProject}
-                    className="text-foreground/54 hover:text-foreground"
-                  >
-                    <HugeiconsIcon icon={Delete02Icon} strokeWidth={1.8} />
-                  </Button>
+                  <Tooltip>
+                    <TooltipTrigger
+                      render={
+                        <Button
+                          type="button"
+                          size="icon-sm"
+                          variant="ghost"
+                          onClick={() => {
+                            onEditProject(project);
+                          }}
+                          disabled={isSavingProject}
+                          className="text-foreground/54 hover:text-foreground"
+                        />
+                      }
+                    >
+                      <HugeiconsIcon icon={Edit02Icon} strokeWidth={1.8} />
+                      <span className="sr-only">Edit project</span>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom" align="center">
+                      Edit project
+                    </TooltipContent>
+                  </Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger
+                      render={
+                        <Button
+                          type="button"
+                          size="icon-sm"
+                          variant="ghost"
+                          onClick={() => {
+                            onDeleteProject(project);
+                          }}
+                          disabled={isDeletingProject || isSavingProject}
+                          className="text-foreground/54 hover:text-foreground"
+                        />
+                      }
+                    >
+                      <HugeiconsIcon icon={Delete02Icon} strokeWidth={1.8} />
+                      <span className="sr-only">Delete project</span>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom" align="center">
+                      Delete project
+                    </TooltipContent>
+                  </Tooltip>
                 </div>
               </div>
 


### PR DESCRIPTION
This PR implements several micro-UX improvements to the project management interface:

1. **Tooltips & Accessibility**: Icon-only buttons for editing and deleting projects in the `ProjectsTable` now have tooltips for sighted users and `sr-only` labels for screen reader accessibility.
2. **Async Feedback**: The "Save project" and "Delete project" buttons now display a loading spinner when a request is in progress, providing immediate visual feedback and preventing double-submissions.
3. **Consistency**: These changes follow the established design patterns in the codebase for better UI consistency.

♿ Accessibility improvements:
- Added `sr-only` spans to provide semantic labels to icon-only buttons.
- Integrated `Tooltip` components for hover-state discovery.

🎯 User problem solved:
- Icon-only buttons can be ambiguous without text labels.
- Destructive and saving actions need clear state feedback to ensure the user knows their request was acknowledged.

---
*PR created automatically by Jules for task [10566359126852354423](https://jules.google.com/task/10566359126852354423) started by @cungminh2710*