### PR TITLE
Improve Pre-Translation API Parity

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -17,3 +17,9 @@
 **Learning:** The Crowdin Source Strings API v2 returns `hasPlurals` and `isIcu` fields which were missing from the `SourceString` model. Additionally, `isIcu` can be specified when adding a new string but was missing from `SourceStringsAddRequest`.
 
 **Action:** Added `HasPlurals`, `IsIcu`, `CommentsCount`, and `IssuesCount` fields to the `SourceString` response model and `IsIcu` (*bool) to the `SourceStringsAddRequest` model. Updated contract tests to verify correct parsing and serialization of these fields. Fixed a typo in the `SourceStringsAddRequest` documentation comment.
+
+## 2026-05-29 - Improve Pre-Translation parity for branches and directories
+
+**Learning:** The Crowdin API v2 Apply Pre-Translation endpoint supports `branchIds` and `directoryIds` in the request body, allowing for more granular targeting than just `fileIds`. Additionally, the response attributes include `directoryIds`.
+
+**Action:** Added `BranchIDs` and `DirectoryIDs` to `PreTranslationRequest` and `DirectoryIDs` to `PreTranslationAttributes` in `model/translations.go`. Updated `PreTranslationRequest.Validate()` to require at least one of `fileIds`, `branchIds`, or `directoryIds`. Verified with updated unit tests.

--- a/third_party/crowdin-api-client-go/crowdin/model/translations.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/translations.go
@@ -23,6 +23,7 @@ type (
 	PreTranslationAttributes struct {
 		LanguageIDs                   []string `json:"languageIds"`
 		BranchIDs                     []int    `json:"branchIds,omitempty"`
+		DirectoryIDs                  []int    `json:"directoryIds,omitempty"`
 		FileIDs                       []int    `json:"fileIds,omitempty"`
 		Method                        *string  `json:"method,omitempty"`
 		AutoApproveOption             *string  `json:"autoApproveOption,omitempty"`
@@ -90,7 +91,11 @@ type PreTranslationRequest struct {
 	// Set of languages to which pre-translation should be applied.
 	LanguageIDs []string `json:"languageIds"`
 	// Files array that should be translated.
-	FileIDs []int `json:"fileIds"`
+	FileIDs []int `json:"fileIds,omitempty"`
+	// Branch identifiers.
+	BranchIDs []int `json:"branchIds,omitempty"`
+	// Directory identifiers.
+	DirectoryIDs []int `json:"directoryIds,omitempty"`
 	// Defines pre-translation method. Enum: "tm", "mt", "ai". Default: "tm".
 	//  - tm – pre-translation via Translation Memory.
 	//  - mt – pre-translation via Machine Translation. "mt" should be used with `engineId` parameter.
@@ -142,8 +147,8 @@ func (r *PreTranslationRequest) Validate() error {
 	if len(r.LanguageIDs) == 0 {
 		return errors.New("languageIds is required")
 	}
-	if len(r.FileIDs) == 0 {
-		return errors.New("fileIds is required")
+	if len(r.FileIDs) == 0 && len(r.BranchIDs) == 0 && len(r.DirectoryIDs) == 0 {
+		return errors.New("one of fileIds, branchIds or directoryIds is required")
 	}
 	if r.Method == "ai" && r.AIPromptID == 0 {
 		return errors.New("aiPromptId is required")

--- a/third_party/crowdin-api-client-go/crowdin/model/translations_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/translations_test.go
@@ -24,9 +24,9 @@ func TestPreTranslationRequestValidate(t *testing.T) {
 			err:  "languageIds is required",
 		},
 		{
-			name: "missing fileIds",
+			name: "missing fileIds, branchIds and directoryIds",
 			req:  &PreTranslationRequest{LanguageIDs: []string{"uk"}},
-			err:  "fileIds is required",
+			err:  "one of fileIds, branchIds or directoryIds is required",
 		},
 		{
 			name: "valid request",
@@ -65,6 +65,22 @@ func TestPreTranslationRequestValidate(t *testing.T) {
 			req: &PreTranslationRequest{
 				LanguageIDs: []string{"uk"}, FileIDs: []int{1, 2},
 				Method: "mt", EngineID: 1, AutoApproveOption: "all", DuplicateTranslations: toPtr(false),
+			},
+			valid: true,
+		},
+		{
+			name: "valid request with branchIds",
+			req: &PreTranslationRequest{
+				LanguageIDs: []string{"uk"}, BranchIDs: []int{1},
+				Method: "tm",
+			},
+			valid: true,
+		},
+		{
+			name: "valid request with directoryIds",
+			req: &PreTranslationRequest{
+				LanguageIDs: []string{"uk"}, DirectoryIDs: []int{1},
+				Method: "tm",
 			},
 			valid: true,
 		},


### PR DESCRIPTION
This change improves the Crowdin API v2 parity for the Pre-Translation endpoint by adding support for branch and directory targeting in the request body and response attributes. It also updates the validation logic to allow any of these filters.

---
*PR created automatically by Jules for task [497437363431000083](https://jules.google.com/task/497437363431000083) started by @cungminh2710*