### PR TITLE
feat(cli): add Smartling translation memory download command

### DIFF
--- a/apps/cli/cmd/smartling.go
+++ b/apps/cli/cmd/smartling.go
@@ -27,6 +27,7 @@ func newSmartlingCmd() *cobra.Command {
 		Short: "Smartling compatibility subcommands",
 	}
 	cmd.AddCommand(newSmartlingGlossaryCmd())
+	cmd.AddCommand(newSmartlingTranslationMemoryCmd())
 	return cmd
 }
 
@@ -132,6 +133,129 @@ func newSmartlingGlossaryDownloadCmd() *cobra.Command {
 
 	_ = cmd.MarkFlagRequired("account-uid")
 	_ = cmd.MarkFlagRequired("glossary-uid")
+
+	return cmd
+}
+
+type smartlingTranslationMemoryDownloadOptions struct {
+	accountUID           string
+	translationMemoryUID string
+	userIdentifier       string
+	userSecret           string
+	userSecretEnv        string
+	sourceLanguage       string
+	targetLanguages      []string
+	format               string
+	outputPath           string
+}
+
+func newSmartlingTranslationMemoryCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "tm",
+		Aliases: []string{"translation-memory"},
+		Short:   "Smartling translation memory commands",
+	}
+	cmd.AddCommand(newSmartlingTranslationMemoryDownloadCmd())
+	return cmd
+}
+
+func newSmartlingTranslationMemoryDownloadCmd() *cobra.Command {
+	o := smartlingTranslationMemoryDownloadOptions{}
+	cmd := &cobra.Command{
+		Use:          "download",
+		Short:        "download Smartling translation memory entries",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			outputFormat, err := normalizeTranslationMemoryDownloadFormat(o.format)
+			if err != nil {
+				return fmt.Errorf("smartling tm download: %w", err)
+			}
+
+			ctx := context.Background()
+			cfg := smartling.Config{
+				UserIdentifier: strings.TrimSpace(o.userIdentifier),
+				UserSecret:     strings.TrimSpace(o.userSecret),
+				UserSecretEnv:  strings.TrimSpace(o.userSecretEnv),
+			}
+
+			if cfg.UserSecret == "" {
+				envVar := cfg.UserSecretEnv
+				if envVar == "" {
+					envVar = "SMARTLING_USER_SECRET"
+				}
+				cfg.UserSecret = os.Getenv(envVar)
+			}
+			if cfg.UserIdentifier == "" {
+				cfg.UserIdentifier = os.Getenv("SMARTLING_USER_IDENTIFIER")
+			}
+			if cfg.UserIdentifier == "" || cfg.UserSecret == "" {
+				return fmt.Errorf("smartling tm download: credentials are required (via flags or SMARTLING_USER_IDENTIFIER/SMARTLING_USER_SECRET)")
+			}
+
+			client, err := smartling.NewHTTPClient(cfg)
+			if err != nil {
+				return err
+			}
+
+			outputPath := strings.TrimSpace(o.outputPath)
+			out := cmd.OutOrStdout()
+			var closeOut func() error
+			var tempPath string
+			if outputPath != "" {
+				file, err := os.CreateTemp(filepath.Dir(outputPath), "."+filepath.Base(outputPath)+".*.tmp")
+				if err != nil {
+					return fmt.Errorf("create temporary translation memory output: %w", err)
+				}
+				out = file
+				tempPath = file.Name()
+				closeOut = file.Close
+			}
+
+			result, err := writeSmartlingTranslationMemory(ctx, client, smartling.TranslationMemoryDownloadRequest{
+				AccountUID:           o.accountUID,
+				TranslationMemoryUID: o.translationMemoryUID,
+				SourceLanguage:       o.sourceLanguage,
+				TargetLanguages:      o.targetLanguages,
+			}, outputFormat, out)
+
+			if closeOut != nil {
+				if closeErr := closeOut(); closeErr != nil && err == nil {
+					err = fmt.Errorf("close translation memory output: %w", closeErr)
+				}
+			}
+
+			if err != nil {
+				if tempPath != "" {
+					_ = os.Remove(tempPath)
+				}
+				return err
+			}
+
+			if outputPath != "" {
+				if err := os.Rename(tempPath, outputPath); err != nil {
+					_ = os.Remove(tempPath)
+					return fmt.Errorf("replace translation memory output: %w", err)
+				}
+				_, _ = writeTranslationMemoryDownloadSummary(cmd.OutOrStdout(), outputPath, outputFormat, result.Rows, result.Segments)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&o.accountUID, "account-uid", "", "Smartling account UID")
+	cmd.Flags().StringVar(&o.translationMemoryUID, "tm-uid", "", "Smartling translation memory UID")
+	cmd.Flags().StringVar(&o.userIdentifier, "user-id", "", "Smartling user identifier")
+	cmd.Flags().StringVar(&o.userSecret, "user-secret", "", "Smartling user secret")
+	cmd.Flags().StringVar(&o.userSecretEnv, "user-secret-env", "", "Environment variable for Smartling user secret")
+	cmd.Flags().StringVar(&o.sourceLanguage, "source-language", "", "source language ID to export")
+	cmd.Flags().StringSliceVarP(&o.targetLanguages, "target-language", "l", nil, "target language ID(s) to export")
+	cmd.Flags().StringVar(&o.format, "format", "csv", "download format: csv or tmx")
+	cmd.Flags().StringVarP(&o.outputPath, "output", "o", "", "write output to file instead of stdout")
+
+	_ = cmd.MarkFlagRequired("account-uid")
+	_ = cmd.MarkFlagRequired("tm-uid")
+	_ = cmd.MarkFlagRequired("source-language")
 
 	return cmd
 }

--- a/apps/cli/cmd/smartling_test.go
+++ b/apps/cli/cmd/smartling_test.go
@@ -33,3 +33,32 @@ func TestSmartlingGlossaryDownloadFlags(t *testing.T) {
 		t.Error("help output missing required flags")
 	}
 }
+
+func TestSmartlingTMDownloadFlags(t *testing.T) {
+	root := newRootCmd("test")
+	out := &bytes.Buffer{}
+	root.SetOut(out)
+	root.SetErr(out)
+
+	// Test missing required flags
+	root.SetArgs([]string{"smartling", "tm", "download"})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected error for missing required flags")
+	}
+	if !strings.Contains(err.Error(), "required flag(s)") {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Test help output
+	out.Reset()
+	root.SetArgs([]string{"smartling", "tm", "download", "--help"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("help failed: %v", err)
+	}
+	if !strings.Contains(out.String(), "--account-uid") ||
+		!strings.Contains(out.String(), "--tm-uid") ||
+		!strings.Contains(out.String(), "--source-language") {
+		t.Error("help output missing required flags")
+	}
+}

--- a/apps/cli/cmd/translation_memory_format.go
+++ b/apps/cli/cmd/translation_memory_format.go
@@ -8,6 +8,7 @@ import (
 
 	crowdinstorage "github.com/hyperlocalise/hyperlocalise/internal/i18n/storage/crowdin"
 	"github.com/hyperlocalise/hyperlocalise/internal/i18n/storage/phrase"
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/storage/smartling"
 )
 
 const (
@@ -55,4 +56,20 @@ func writeTranslationMemoryDownloadSummary(w io.Writer, outputPath, format strin
 		return fmt.Fprintf(w, "wrote %s rows=%d segments=%d\n", outputPath, rows, segments)
 	}
 	return fmt.Fprintf(w, "wrote %s format=%s rows=%d segments=%d\n", outputPath, format, rows, segments)
+}
+
+type smartlingTranslationMemoryWriter interface {
+	WriteTranslationMemoryCSV(ctx context.Context, req smartling.TranslationMemoryDownloadRequest, w io.Writer) (smartling.TranslationMemoryDownloadResult, error)
+	WriteTranslationMemoryTMX(ctx context.Context, req smartling.TranslationMemoryDownloadRequest, w io.Writer) (smartling.TranslationMemoryDownloadResult, error)
+}
+
+func writeSmartlingTranslationMemory(ctx context.Context, client smartlingTranslationMemoryWriter, req smartling.TranslationMemoryDownloadRequest, format string, w io.Writer) (smartling.TranslationMemoryDownloadResult, error) {
+	switch format {
+	case translationMemoryFormatCSV:
+		return client.WriteTranslationMemoryCSV(ctx, req, w)
+	case translationMemoryFormatTMX:
+		return client.WriteTranslationMemoryTMX(ctx, req, w)
+	default:
+		return smartling.TranslationMemoryDownloadResult{}, fmt.Errorf("unsupported translation memory format %q", format)
+	}
 }

--- a/internal/i18n/storage/smartling/http_client.go
+++ b/internal/i18n/storage/smartling/http_client.go
@@ -21,6 +21,7 @@ const (
 	authAPIBaseURL     = "https://api.smartling.com/auth-api/v2"
 	stringsAPIBaseURL  = "https://api.smartling.com/strings-api/v2"
 	glossaryAPIBaseURL = "https://api.smartling.com/glossary-api/v2"
+	tmAPIBaseURL       = "https://api.smartling.com/translation-memory-api/v2"
 	translationsLimit  = 500
 	glossaryLimit      = 500
 )
@@ -29,6 +30,7 @@ type HTTPClient struct {
 	authBaseURL     string
 	stringsBaseURL  string
 	glossaryBaseURL string
+	tmBaseURL       string
 	http            *http.Client
 	userIdentifier  string
 	userSecret      string
@@ -48,6 +50,7 @@ func NewHTTPClient(cfg Config) (*HTTPClient, error) {
 		authBaseURL:     authAPIBaseURL,
 		stringsBaseURL:  stringsAPIBaseURL,
 		glossaryBaseURL: glossaryAPIBaseURL,
+		tmBaseURL:       tmAPIBaseURL,
 		http:            &http.Client{Timeout: timeout},
 		userIdentifier:  cfg.UserIdentifier,
 		userSecret:      cfg.UserSecret,

--- a/internal/i18n/storage/smartling/translation_memory.go
+++ b/internal/i18n/storage/smartling/translation_memory.go
@@ -1,0 +1,268 @@
+package smartling
+
+import (
+	"cmp"
+	"context"
+	"encoding/csv"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/url"
+	"slices"
+	"strings"
+)
+
+// TranslationMemoryDownloadRequest identifies the Smartling translation memory to export.
+type TranslationMemoryDownloadRequest struct {
+	AccountUID           string
+	TranslationMemoryUID string
+	SourceLanguage       string
+	TargetLanguages      []string
+}
+
+// TranslationMemoryDownloadResult summarizes a Smartling translation memory export.
+type TranslationMemoryDownloadResult struct {
+	Rows     int
+	Segments int
+}
+
+type smartlingTMEntry struct {
+	EntryUID       string                   `json:"entryUid"`
+	SourceText     string                   `json:"sourceText"`
+	SourceLocaleID string                   `json:"sourceLocaleId"`
+	Translations   []smartlingTMTranslation `json:"translations"`
+}
+
+type smartlingTMTranslation struct {
+	TargetLocaleID  string `json:"targetLocaleId"`
+	TranslationText string `json:"translationText"`
+}
+
+func (c *HTTPClient) listTranslationMemoryEntries(ctx context.Context, token string, req TranslationMemoryDownloadRequest) ([]smartlingTMEntry, error) {
+	var entries []smartlingTMEntry
+	offset := 0
+	limit := 500
+
+	for {
+		endpoint := fmt.Sprintf("%s/accounts/%s/translation-memories/%s/entries", c.tmBaseURL, url.PathEscape(req.AccountUID), url.PathEscape(req.TranslationMemoryUID))
+		params := url.Values{}
+		params.Set("sourceLocaleId", req.SourceLanguage)
+		if len(req.TargetLanguages) > 0 {
+			params.Set("targetLocaleIds", strings.Join(req.TargetLanguages, ","))
+		}
+		params.Set("limit", fmt.Sprintf("%d", limit))
+		params.Set("offset", fmt.Sprintf("%d", offset))
+		fullURL := endpoint + "?" + params.Encode()
+
+		var resp struct {
+			Response struct {
+				Code string `json:"code"`
+			} `json:"response"`
+			Data struct {
+				Items []smartlingTMEntry `json:"items"`
+			} `json:"data"`
+		}
+
+		if err := c.getJSON(ctx, fullURL, token, &resp); err != nil {
+			return nil, fmt.Errorf("list translation memory entries: %w", err)
+		}
+
+		entries = append(entries, resp.Data.Items...)
+		if len(resp.Data.Items) < limit {
+			break
+		}
+		offset += limit
+	}
+	return entries, nil
+}
+
+var smartlingTMCSVHeader = []string{
+	"tm_uid",
+	"entry_uid",
+	"source_locale",
+	"target_locale",
+	"source_text",
+	"target_text",
+}
+
+// WriteTranslationMemoryCSV downloads Smartling translation memory entries and writes them as stable CSV.
+func (c *HTTPClient) WriteTranslationMemoryCSV(ctx context.Context, req TranslationMemoryDownloadRequest, w io.Writer) (TranslationMemoryDownloadResult, error) {
+	if strings.TrimSpace(req.AccountUID) == "" {
+		return TranslationMemoryDownloadResult{}, fmt.Errorf("smartling tm download: account uid is required")
+	}
+	if strings.TrimSpace(req.TranslationMemoryUID) == "" {
+		return TranslationMemoryDownloadResult{}, fmt.Errorf("smartling tm download: tm uid is required")
+	}
+	if strings.TrimSpace(req.SourceLanguage) == "" {
+		return TranslationMemoryDownloadResult{}, fmt.Errorf("smartling tm download: source language is required")
+	}
+	if w == nil {
+		return TranslationMemoryDownloadResult{}, fmt.Errorf("smartling tm download: writer is nil")
+	}
+
+	token, err := c.accessToken(ctx)
+	if err != nil {
+		return TranslationMemoryDownloadResult{}, err
+	}
+
+	entries, err := c.listTranslationMemoryEntries(ctx, token, req)
+	if err != nil {
+		return TranslationMemoryDownloadResult{}, err
+	}
+
+	rows := smartlingTMCSVRows(req.TranslationMemoryUID, entries)
+
+	writer := csv.NewWriter(w)
+	if err := writer.Write(smartlingTMCSVHeader); err != nil {
+		return TranslationMemoryDownloadResult{}, fmt.Errorf("write smartling tm csv header: %w", err)
+	}
+	for _, row := range rows {
+		if err := writer.Write(row); err != nil {
+			return TranslationMemoryDownloadResult{}, fmt.Errorf("write smartling tm csv row: %w", err)
+		}
+	}
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return TranslationMemoryDownloadResult{}, fmt.Errorf("flush smartling tm csv: %w", err)
+	}
+
+	return TranslationMemoryDownloadResult{Rows: len(rows), Segments: len(entries)}, nil
+}
+
+func smartlingTMCSVRows(tmUID string, entries []smartlingTMEntry) [][]string {
+	sortedEntries := slices.Clone(entries)
+	slices.SortStableFunc(sortedEntries, func(left, right smartlingTMEntry) int {
+		return cmp.Compare(left.EntryUID, right.EntryUID)
+	})
+
+	var rows [][]string
+	for _, entry := range sortedEntries {
+		translations := slices.Clone(entry.Translations)
+		slices.SortStableFunc(translations, func(left, right smartlingTMTranslation) int {
+			return cmp.Compare(left.TargetLocaleID, right.TargetLocaleID)
+		})
+
+		for _, translation := range translations {
+			rows = append(rows, []string{
+				tmUID,
+				entry.EntryUID,
+				entry.SourceLocaleID,
+				translation.TargetLocaleID,
+				entry.SourceText,
+				translation.TranslationText,
+			})
+		}
+	}
+	return rows
+}
+
+// WriteTranslationMemoryTMX downloads Smartling translation memory entries and writes them as TMX.
+func (c *HTTPClient) WriteTranslationMemoryTMX(ctx context.Context, req TranslationMemoryDownloadRequest, w io.Writer) (TranslationMemoryDownloadResult, error) {
+	if strings.TrimSpace(req.AccountUID) == "" {
+		return TranslationMemoryDownloadResult{}, fmt.Errorf("smartling tm download: account uid is required")
+	}
+	if strings.TrimSpace(req.TranslationMemoryUID) == "" {
+		return TranslationMemoryDownloadResult{}, fmt.Errorf("smartling tm download: tm uid is required")
+	}
+	if strings.TrimSpace(req.SourceLanguage) == "" {
+		return TranslationMemoryDownloadResult{}, fmt.Errorf("smartling tm download: source language is required")
+	}
+	if w == nil {
+		return TranslationMemoryDownloadResult{}, fmt.Errorf("smartling tm download: writer is nil")
+	}
+
+	token, err := c.accessToken(ctx)
+	if err != nil {
+		return TranslationMemoryDownloadResult{}, err
+	}
+
+	entries, err := c.listTranslationMemoryEntries(ctx, token, req)
+	if err != nil {
+		return TranslationMemoryDownloadResult{}, err
+	}
+
+	if _, err := io.WriteString(w, xml.Header); err != nil {
+		return TranslationMemoryDownloadResult{}, fmt.Errorf("write smartling tm tmx header: %w", err)
+	}
+
+	encoder := xml.NewEncoder(w)
+	encoder.Indent("", "  ")
+
+	tmxStart := xml.StartElement{Name: xml.Name{Local: "tmx"}, Attr: []xml.Attr{{Name: xml.Name{Local: "version"}, Value: "1.4"}}}
+	if err := encoder.EncodeToken(tmxStart); err != nil {
+		return TranslationMemoryDownloadResult{}, fmt.Errorf("write smartling tm tmx: %w", err)
+	}
+
+	headerStart := xml.StartElement{Name: xml.Name{Local: "header"}, Attr: []xml.Attr{
+		{Name: xml.Name{Local: "creationtool"}, Value: "hyperlocalise"},
+		{Name: xml.Name{Local: "creationtoolversion"}, Value: "1"},
+		{Name: xml.Name{Local: "segtype"}, Value: "sentence"},
+		{Name: xml.Name{Local: "adminlang"}, Value: "en"},
+		{Name: xml.Name{Local: "srclang"}, Value: req.SourceLanguage},
+		{Name: xml.Name{Local: "datatype"}, Value: "PlainText"},
+	}}
+	if err := encoder.EncodeToken(headerStart); err != nil {
+		return TranslationMemoryDownloadResult{}, fmt.Errorf("write smartling tm tmx header: %w", err)
+	}
+	if err := encoder.EncodeToken(headerStart.End()); err != nil {
+		return TranslationMemoryDownloadResult{}, fmt.Errorf("write smartling tm tmx header: %w", err)
+	}
+
+	bodyStart := xml.StartElement{Name: xml.Name{Local: "body"}}
+	if err := encoder.EncodeToken(bodyStart); err != nil {
+		return TranslationMemoryDownloadResult{}, fmt.Errorf("write smartling tm tmx body: %w", err)
+	}
+
+	rowCount := 0
+	for _, entry := range entries {
+		tuStart := xml.StartElement{Name: xml.Name{Local: "tu"}, Attr: []xml.Attr{{Name: xml.Name{Local: "tuid"}, Value: entry.EntryUID}}}
+		if err := encoder.EncodeToken(tuStart); err != nil {
+			return TranslationMemoryDownloadResult{}, fmt.Errorf("write smartling tm tmx unit: %w", err)
+		}
+
+		// Source
+		tuvSourceStart := xml.StartElement{Name: xml.Name{Local: "tuv"}, Attr: []xml.Attr{{Name: xml.Name{Local: "xml:lang"}, Value: entry.SourceLocaleID}}}
+		if err := encoder.EncodeToken(tuvSourceStart); err != nil {
+			return TranslationMemoryDownloadResult{}, fmt.Errorf("write smartling tm tmx variant: %w", err)
+		}
+		segStart := xml.StartElement{Name: xml.Name{Local: "seg"}}
+		if err := encoder.EncodeElement(entry.SourceText, segStart); err != nil {
+			return TranslationMemoryDownloadResult{}, fmt.Errorf("write smartling tm tmx segment: %w", err)
+		}
+		if err := encoder.EncodeToken(tuvSourceStart.End()); err != nil {
+			return TranslationMemoryDownloadResult{}, fmt.Errorf("write smartling tm tmx variant: %w", err)
+		}
+		rowCount++
+
+		// Targets
+		for _, tr := range entry.Translations {
+			tuvTargetStart := xml.StartElement{Name: xml.Name{Local: "tuv"}, Attr: []xml.Attr{{Name: xml.Name{Local: "xml:lang"}, Value: tr.TargetLocaleID}}}
+			if err := encoder.EncodeToken(tuvTargetStart); err != nil {
+				return TranslationMemoryDownloadResult{}, fmt.Errorf("write smartling tm tmx variant: %w", err)
+			}
+			if err := encoder.EncodeElement(tr.TranslationText, segStart); err != nil {
+				return TranslationMemoryDownloadResult{}, fmt.Errorf("write smartling tm tmx segment: %w", err)
+			}
+			if err := encoder.EncodeToken(tuvTargetStart.End()); err != nil {
+				return TranslationMemoryDownloadResult{}, fmt.Errorf("write smartling tm tmx variant: %w", err)
+			}
+			rowCount++
+		}
+
+		if err := encoder.EncodeToken(tuStart.End()); err != nil {
+			return TranslationMemoryDownloadResult{}, fmt.Errorf("write smartling tm tmx unit: %w", err)
+		}
+	}
+
+	if err := encoder.EncodeToken(bodyStart.End()); err != nil {
+		return TranslationMemoryDownloadResult{}, fmt.Errorf("write smartling tm tmx body: %w", err)
+	}
+	if err := encoder.EncodeToken(tmxStart.End()); err != nil {
+		return TranslationMemoryDownloadResult{}, fmt.Errorf("write smartling tm tmx: %w", err)
+	}
+	if err := encoder.Flush(); err != nil {
+		return TranslationMemoryDownloadResult{}, fmt.Errorf("flush smartling tm tmx: %w", err)
+	}
+
+	return TranslationMemoryDownloadResult{Rows: rowCount, Segments: len(entries)}, nil
+}

--- a/internal/i18n/storage/smartling/translation_memory_test.go
+++ b/internal/i18n/storage/smartling/translation_memory_test.go
@@ -41,7 +41,6 @@ func TestHTTPClientWriteTranslationMemoryCSV(t *testing.T) {
 		TranslationMemoryUID: "tm1",
 		SourceLanguage:       "en-US",
 	}, out)
-
 	if err != nil {
 		t.Fatalf("WriteTranslationMemoryCSV: %v", err)
 	}
@@ -83,7 +82,6 @@ func TestHTTPClientWriteTranslationMemoryTMX(t *testing.T) {
 		TranslationMemoryUID: "tm1",
 		SourceLanguage:       "en-US",
 	}, out)
-
 	if err != nil {
 		t.Fatalf("WriteTranslationMemoryTMX: %v", err)
 	}

--- a/internal/i18n/storage/smartling/translation_memory_test.go
+++ b/internal/i18n/storage/smartling/translation_memory_test.go
@@ -1,0 +1,103 @@
+package smartling
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHTTPClientWriteTranslationMemoryCSV(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/authenticate":
+			_, _ = fmt.Fprint(w, `{"response":{"code":"SUCCESS"},"data":{"accessToken":"token"}}`)
+		case "/accounts/acc1/translation-memories/tm1/entries":
+			if r.URL.Query().Get("sourceLocaleId") != "en-US" {
+				t.Errorf("unexpected sourceLocaleId: %s", r.URL.Query().Get("sourceLocaleId"))
+			}
+			_, _ = fmt.Fprint(w, `{"response":{"code":"SUCCESS"},"data":{"items":[
+				{"entryUid":"e1","sourceText":"Hello","sourceLocaleId":"en-US","translations":[{"targetLocaleId":"fr-FR","translationText":"Bonjour"}]},
+				{"entryUid":"e2","sourceText":"Goodbye","sourceLocaleId":"en-US","translations":[{"targetLocaleId":"fr-FR","translationText":"Au revoir"}]}
+			]}}`)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	client := &HTTPClient{
+		authBaseURL: srv.URL,
+		tmBaseURL:   srv.URL,
+		http:        srv.Client(),
+	}
+
+	out := &bytes.Buffer{}
+	result, err := client.WriteTranslationMemoryCSV(context.Background(), TranslationMemoryDownloadRequest{
+		AccountUID:           "acc1",
+		TranslationMemoryUID: "tm1",
+		SourceLanguage:       "en-US",
+	}, out)
+
+	if err != nil {
+		t.Fatalf("WriteTranslationMemoryCSV: %v", err)
+	}
+	if result.Rows != 2 || result.Segments != 2 {
+		t.Errorf("unexpected result: %+v", result)
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "tm1,e1,en-US,fr-FR,Hello,Bonjour") ||
+		!strings.Contains(got, "tm1,e2,en-US,fr-FR,Goodbye,Au revoir") {
+		t.Errorf("unexpected csv output: %s", got)
+	}
+}
+
+func TestHTTPClientWriteTranslationMemoryTMX(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/authenticate":
+			_, _ = fmt.Fprint(w, `{"response":{"code":"SUCCESS"},"data":{"accessToken":"token"}}`)
+		case "/accounts/acc1/translation-memories/tm1/entries":
+			_, _ = fmt.Fprint(w, `{"response":{"code":"SUCCESS"},"data":{"items":[
+				{"entryUid":"e1","sourceText":"Hello","sourceLocaleId":"en-US","translations":[{"targetLocaleId":"fr-FR","translationText":"Bonjour"}]}
+			]}}`)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	client := &HTTPClient{
+		authBaseURL: srv.URL,
+		tmBaseURL:   srv.URL,
+		http:        srv.Client(),
+	}
+
+	out := &bytes.Buffer{}
+	result, err := client.WriteTranslationMemoryTMX(context.Background(), TranslationMemoryDownloadRequest{
+		AccountUID:           "acc1",
+		TranslationMemoryUID: "tm1",
+		SourceLanguage:       "en-US",
+	}, out)
+
+	if err != nil {
+		t.Fatalf("WriteTranslationMemoryTMX: %v", err)
+	}
+	if result.Rows != 2 || result.Segments != 1 {
+		t.Errorf("unexpected result: %+v", result)
+	}
+
+	got := out.String()
+	if !strings.Contains(got, `<tmx version="1.4">`) ||
+		!strings.Contains(got, `<tu tuid="e1">`) ||
+		!strings.Contains(got, `<tuv xml:lang="en-US">`) ||
+		!strings.Contains(got, `<seg>Hello</seg>`) ||
+		!strings.Contains(got, `<tuv xml:lang="fr-FR">`) ||
+		!strings.Contains(got, `<seg>Bonjour</seg>`) {
+		t.Errorf("unexpected tmx output: %s", got)
+	}
+}


### PR DESCRIPTION
Implemented Smartling Translation Memory download support for CSV and TMX formats in the CLI. Added the `smartling tm download` subcommand and core API logic in `internal/i18n/storage/smartling`. Verified with unit and integration tests.

---
*PR created automatically by Jules for task [9559181243856956173](https://jules.google.com/task/9559181243856956173) started by @cungminh2710*