### PR TITLE
feat(cli): add file mode for pull/push translation sync smartling

### DIFF
--- a/docs/storage/smartling.mdx
+++ b/docs/storage/smartling.mdx
@@ -30,9 +30,36 @@ export SMARTLING_USER_SECRET="your-smartling-user-secret"
 
 - `targetLanguages`
 - `timeoutSeconds` (defaults to `30`)
+- `mode` — `strings` (default) or `files`
+- `fileURI` — required when `mode` is `files`
+- `fileFormat` — required when `mode` is `files` (for example `json`)
+
+## Modes
+
+- `strings`: pull and push using Smartling string APIs.
+- `files`: pull and push using Smartling file download/upload APIs.
+
+## Files mode config example
+
+```jsonc
+{
+  "storage": {
+    "adapter": "smartling",
+    "config": {
+      "projectID": "your-project-id",
+      "userIdentifier": "your-smartling-user-identifier",
+      "userSecretEnv": "SMARTLING_USER_SECRET",
+      "mode": "files",
+      "fileURI": "translations.json",
+      "fileFormat": "json"
+    }
+  }
+}
+```
 
 ## Common issues
 
 - missing secret: export `SMARTLING_USER_SECRET` in the same shell session
 - missing user identifier: set `storage.config.userIdentifier`
 - locale mismatch: align `targetLanguages` with your project locales
+- file mode import failure: verify `fileFormat` matches your project settings

--- a/internal/i18n/storage/smartling/adapter.go
+++ b/internal/i18n/storage/smartling/adapter.go
@@ -59,6 +59,7 @@ type Client interface {
 type ExportFileInput struct {
 	ProjectID string
 	FileURI   string
+	FileType  string
 	Locales   []string
 }
 
@@ -232,16 +233,18 @@ func (a *Adapter) pullFiles(ctx context.Context, req storage.PullRequest) (stora
 	entries, revision, err := a.client.ExportFile(ctx, ExportFileInput{
 		ProjectID: a.cfg.ProjectID,
 		FileURI:   a.cfg.FileURI,
+		FileType:  a.cfg.FileFormat,
 		Locales:   locales,
 	})
-	if err != nil {
-		return storage.PullResult{}, fmt.Errorf("smartling pull files: %w", err)
-	}
 
 	now := time.Now().UTC()
 	normalized := normalizeEntries(entries, revision, now)
 	retrievedAt := now
-	return storage.PullResult{Snapshot: storage.CatalogSnapshot{Entries: normalized, Revision: revision, RetrievedAt: &retrievedAt}}, nil
+	result := storage.PullResult{Snapshot: storage.CatalogSnapshot{Entries: normalized, Revision: revision, RetrievedAt: &retrievedAt}}
+	if err != nil {
+		return result, fmt.Errorf("smartling pull files: %w", err)
+	}
+	return result, nil
 }
 
 func (a *Adapter) Push(ctx context.Context, req storage.PushRequest) (storage.PushResult, error) {

--- a/internal/i18n/storage/smartling/adapter.go
+++ b/internal/i18n/storage/smartling/adapter.go
@@ -15,6 +15,8 @@ import (
 const (
 	AdapterName             = "smartling"
 	defaultUserSecretEnvVar = "SMARTLING_USER_SECRET"
+	ModeStrings             = "strings"
+	ModeFiles               = "files"
 )
 
 type Config struct {
@@ -24,6 +26,9 @@ type Config struct {
 	UserSecretEnv   string   `json:"userSecretEnv,omitempty"`
 	TargetLanguages []string `json:"targetLanguages,omitempty"`
 	TimeoutSeconds  int      `json:"timeoutSeconds,omitempty"`
+	Mode            string   `json:"mode,omitempty"`
+	FileFormat      string   `json:"fileFormat,omitempty"`
+	FileURI         string   `json:"fileURI,omitempty"`
 }
 
 type StringTranslation struct {
@@ -47,6 +52,21 @@ type Client interface {
 	ListTranslations(ctx context.Context, in ListTranslationsInput) ([]StringTranslation, string, error)
 	UpsertTranslations(ctx context.Context, in UpsertTranslationsInput) (string, error)
 	UploadSourceFile(ctx context.Context, in SourceUploadInput) (SourceUploadResult, error)
+	ExportFile(ctx context.Context, in ExportFileInput) ([]storage.Entry, string, error)
+	ImportFile(ctx context.Context, in ImportFileInput) (string, error)
+}
+
+type ExportFileInput struct {
+	ProjectID string
+	FileURI   string
+	Locales   []string
+}
+
+type ImportFileInput struct {
+	ProjectID string
+	FileURI   string
+	FileType  string
+	Entries   []storage.Entry
 }
 
 type Adapter struct {
@@ -106,6 +126,12 @@ func ParseConfig(raw json.RawMessage) (Config, error) {
 	if cfg.TimeoutSeconds <= 0 {
 		cfg.TimeoutSeconds = 30
 	}
+	if strings.TrimSpace(cfg.Mode) == "" {
+		cfg.Mode = ModeStrings
+	}
+	if strings.TrimSpace(cfg.FileFormat) == "" {
+		cfg.FileFormat = "json"
+	}
 
 	if err := validateConfig(cfg); err != nil {
 		return cfg, err
@@ -123,14 +149,27 @@ func validateConfig(cfg Config) error {
 	if strings.TrimSpace(cfg.UserSecret) == "" {
 		return fmt.Errorf("smartling config: user secret is required (%s)", defaultUserSecretEnvVar)
 	}
+	mode := strings.ToLower(strings.TrimSpace(cfg.Mode))
+	if mode != ModeStrings && mode != ModeFiles {
+		return fmt.Errorf("smartling config: mode must be %q or %q", ModeStrings, ModeFiles)
+	}
+	if mode == ModeFiles {
+		if strings.TrimSpace(cfg.FileURI) == "" {
+			return fmt.Errorf("smartling config: fileURI is required in files mode")
+		}
+		if strings.TrimSpace(cfg.FileFormat) == "" {
+			return fmt.Errorf("smartling config: fileFormat is required in files mode")
+		}
+	}
 	return nil
 }
 
 func (a *Adapter) Name() string { return AdapterName }
 
 func (a *Adapter) Capabilities() storage.Capabilities {
+	mode := strings.ToLower(strings.TrimSpace(a.cfg.Mode))
 	return storage.Capabilities{
-		SupportsContext:    true,
+		SupportsContext:    mode == ModeStrings,
 		SupportsVersions:   false,
 		SupportsDeletes:    false,
 		SupportsNamespaces: false,
@@ -138,6 +177,15 @@ func (a *Adapter) Capabilities() storage.Capabilities {
 }
 
 func (a *Adapter) Pull(ctx context.Context, req storage.PullRequest) (storage.PullResult, error) {
+	switch strings.ToLower(strings.TrimSpace(a.cfg.Mode)) {
+	case ModeFiles:
+		return a.pullFiles(ctx, req)
+	default:
+		return a.pullStrings(ctx, req)
+	}
+}
+
+func (a *Adapter) pullStrings(ctx context.Context, req storage.PullRequest) (storage.PullResult, error) {
 	locales := req.Locales
 	if len(locales) == 0 && len(a.cfg.TargetLanguages) > 0 {
 		locales = append([]string(nil), a.cfg.TargetLanguages...)
@@ -148,7 +196,7 @@ func (a *Adapter) Pull(ctx context.Context, req storage.PullRequest) (storage.Pu
 		Locales:   locales,
 	})
 	if err != nil {
-		return storage.PullResult{}, fmt.Errorf("smartling pull: %w", err)
+		return storage.PullResult{}, fmt.Errorf("smartling pull strings: %w", err)
 	}
 
 	entries := make([]storage.Entry, 0, len(stringsOut))
@@ -175,7 +223,37 @@ func (a *Adapter) Pull(ctx context.Context, req storage.PullRequest) (storage.Pu
 	return storage.PullResult{Snapshot: storage.CatalogSnapshot{Entries: entries, Revision: revision, RetrievedAt: &retrievedAt}}, nil
 }
 
+func (a *Adapter) pullFiles(ctx context.Context, req storage.PullRequest) (storage.PullResult, error) {
+	locales := req.Locales
+	if len(locales) == 0 && len(a.cfg.TargetLanguages) > 0 {
+		locales = append([]string(nil), a.cfg.TargetLanguages...)
+	}
+
+	entries, revision, err := a.client.ExportFile(ctx, ExportFileInput{
+		ProjectID: a.cfg.ProjectID,
+		FileURI:   a.cfg.FileURI,
+		Locales:   locales,
+	})
+	if err != nil {
+		return storage.PullResult{}, fmt.Errorf("smartling pull files: %w", err)
+	}
+
+	now := time.Now().UTC()
+	normalized := normalizeEntries(entries, revision, now)
+	retrievedAt := now
+	return storage.PullResult{Snapshot: storage.CatalogSnapshot{Entries: normalized, Revision: revision, RetrievedAt: &retrievedAt}}, nil
+}
+
 func (a *Adapter) Push(ctx context.Context, req storage.PushRequest) (storage.PushResult, error) {
+	switch strings.ToLower(strings.TrimSpace(a.cfg.Mode)) {
+	case ModeFiles:
+		return a.pushFiles(ctx, req)
+	default:
+		return a.pushStrings(ctx, req)
+	}
+}
+
+func (a *Adapter) pushStrings(ctx context.Context, req storage.PushRequest) (storage.PushResult, error) {
 	payload := make([]StringTranslation, 0, len(req.Entries))
 	applied := make([]storage.EntryID, 0, len(req.Entries))
 	indexByID := make(map[storage.EntryID]int, len(req.Entries))
@@ -206,9 +284,56 @@ func (a *Adapter) Push(ctx context.Context, req storage.PushRequest) (storage.Pu
 
 	revision, err := a.client.UpsertTranslations(ctx, UpsertTranslationsInput{ProjectID: a.cfg.ProjectID, Entries: payload})
 	if err != nil {
-		return storage.PushResult{}, fmt.Errorf("smartling push: %w", err)
+		return storage.PushResult{}, fmt.Errorf("smartling push strings: %w", err)
 	}
 	return storage.PushResult{Applied: applied, Revision: revision}, nil
+}
+
+func (a *Adapter) pushFiles(ctx context.Context, req storage.PushRequest) (storage.PushResult, error) {
+	entries := filterEntries(req.Entries)
+	if len(entries) == 0 {
+		return storage.PushResult{Revision: time.Now().UTC().Format(time.RFC3339Nano)}, nil
+	}
+	revision, err := a.client.ImportFile(ctx, ImportFileInput{
+		ProjectID: a.cfg.ProjectID,
+		FileURI:   a.cfg.FileURI,
+		FileType:  a.cfg.FileFormat,
+		Entries:   entries,
+	})
+	if err != nil {
+		return storage.PushResult{}, fmt.Errorf("smartling push files: %w", err)
+	}
+	applied := make([]storage.EntryID, 0, len(entries))
+	for _, entry := range entries {
+		applied = append(applied, entry.ID())
+	}
+	return storage.PushResult{Applied: applied, Revision: revision}, nil
+}
+
+func filterEntries(entries []storage.Entry) []storage.Entry {
+	filtered := make([]storage.Entry, 0, len(entries))
+	for _, entry := range entries {
+		if strings.TrimSpace(entry.Key) == "" || strings.TrimSpace(entry.Locale) == "" || strings.TrimSpace(entry.Value) == "" {
+			continue
+		}
+		filtered = append(filtered, storage.Entry{Key: strings.TrimSpace(entry.Key), Context: entry.Context, Locale: strings.TrimSpace(entry.Locale), Value: entry.Value})
+	}
+	return filtered
+}
+
+func normalizeEntries(source []storage.Entry, revision string, now time.Time) []storage.Entry {
+	entries := make([]storage.Entry, 0, len(source))
+	for _, entry := range source {
+		if strings.TrimSpace(entry.Key) == "" || strings.TrimSpace(entry.Locale) == "" || strings.TrimSpace(entry.Value) == "" {
+			continue
+		}
+		entry.Key = strings.TrimSpace(entry.Key)
+		entry.Locale = strings.TrimSpace(entry.Locale)
+		entry.Provenance = storage.EntryProvenance{Origin: storage.OriginHuman, State: storage.StateCurated, UpdatedAt: now}
+		entry.Remote = storage.RemoteMeta{Adapter: AdapterName, Revision: revision}
+		entries = append(entries, entry)
+	}
+	return entries
 }
 
 func (a *Adapter) FileWorkflowCapabilities() storage.FileWorkflowCapabilities {

--- a/internal/i18n/storage/smartling/adapter_test.go
+++ b/internal/i18n/storage/smartling/adapter_test.go
@@ -42,10 +42,7 @@ func (f *fakeClient) UploadSourceFile(_ context.Context, _ SourceUploadInput) (S
 }
 
 func (f *fakeClient) ExportFile(_ context.Context, in ExportFileInput) ([]storage.Entry, string, error) {
-	if f.exportErr != nil {
-		return nil, "", f.exportErr
-	}
-	return f.exportOut, "rev-file", nil
+	return f.exportOut, "rev-file", f.exportErr
 }
 
 func (f *fakeClient) ImportFile(_ context.Context, in ImportFileInput) (string, error) {
@@ -289,6 +286,28 @@ func TestAdapterPullFilesDelegatesToExportFile(t *testing.T) {
 	entry := result.Snapshot.Entries[0]
 	if entry.Key != "hello" || entry.Locale != "fr" || entry.Value != "bonjour" {
 		t.Fatalf("unexpected entry mapping: %+v", entry)
+	}
+}
+
+func TestAdapterPullFilesPreservesPartialResultsOnError(t *testing.T) {
+	client := &fakeClient{
+		exportOut: []storage.Entry{{Key: "hello", Locale: "fr", Value: "bonjour"}},
+		exportErr: errors.New("some locales failed"),
+	}
+	adapter, err := NewWithClient(Config{ProjectID: "123", UserIdentifier: "uid", UserSecret: "sec", Mode: ModeFiles, FileURI: "translations.json", FileFormat: "json"}, client)
+	if err != nil {
+		t.Fatalf("new adapter: %v", err)
+	}
+
+	result, err := adapter.Pull(context.Background(), storage.PullRequest{Locales: []string{"fr", "de"}})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if got := len(result.Snapshot.Entries); got != 1 {
+		t.Fatalf("expected 1 partial entry, got %d", got)
+	}
+	if result.Snapshot.Entries[0].Value != "bonjour" {
+		t.Fatalf("unexpected partial entry: %+v", result.Snapshot.Entries[0])
 	}
 }
 

--- a/internal/i18n/storage/smartling/adapter_test.go
+++ b/internal/i18n/storage/smartling/adapter_test.go
@@ -18,6 +18,10 @@ type fakeClient struct {
 	upsertIn          UpsertTranslationsInput
 	upsertErr         error
 	uploadSourceCalls int
+	exportOut         []storage.Entry
+	exportErr         error
+	importIn          ImportFileInput
+	importErr         error
 }
 
 func (f *fakeClient) ListTranslations(_ context.Context, _ ListTranslationsInput) ([]StringTranslation, string, error) {
@@ -35,6 +39,21 @@ func (f *fakeClient) UpsertTranslations(_ context.Context, in UpsertTranslations
 func (f *fakeClient) UploadSourceFile(_ context.Context, _ SourceUploadInput) (SourceUploadResult, error) {
 	f.uploadSourceCalls++
 	return SourceUploadResult{}, f.upsertErr
+}
+
+func (f *fakeClient) ExportFile(_ context.Context, in ExportFileInput) ([]storage.Entry, string, error) {
+	if f.exportErr != nil {
+		return nil, "", f.exportErr
+	}
+	return f.exportOut, "rev-file", nil
+}
+
+func (f *fakeClient) ImportFile(_ context.Context, in ImportFileInput) (string, error) {
+	f.importIn = in
+	if f.importErr != nil {
+		return "", f.importErr
+	}
+	return "rev-file", nil
 }
 
 func TestParseConfigUsesEnvSecret(t *testing.T) {
@@ -67,7 +86,7 @@ func TestParseConfigRejectsInlineSecret(t *testing.T) {
 
 func TestAdapterPullMapsStringContextLanguage(t *testing.T) {
 	client := &fakeClient{items: []StringTranslation{{Key: "hello", Context: "home", Locale: "fr", Value: "bonjour"}}, listRevision: "rev1"}
-	adapter, err := NewWithClient(Config{ProjectID: "123", UserIdentifier: "uid", UserSecret: "sec"}, client)
+	adapter, err := NewWithClient(Config{ProjectID: "123", UserIdentifier: "uid", UserSecret: "sec", Mode: ModeStrings}, client)
 	if err != nil {
 		t.Fatalf("new adapter: %v", err)
 	}
@@ -87,7 +106,7 @@ func TestAdapterPullMapsStringContextLanguage(t *testing.T) {
 
 func TestAdapterPushGroupsEntries(t *testing.T) {
 	client := &fakeClient{}
-	adapter, err := NewWithClient(Config{ProjectID: "123", UserIdentifier: "uid", UserSecret: "sec"}, client)
+	adapter, err := NewWithClient(Config{ProjectID: "123", UserIdentifier: "uid", UserSecret: "sec", Mode: ModeStrings}, client)
 	if err != nil {
 		t.Fatalf("new adapter: %v", err)
 	}
@@ -103,7 +122,7 @@ func TestAdapterPushGroupsEntries(t *testing.T) {
 
 func TestAdapterPushAppliedOnlyIncludesSentEntries(t *testing.T) {
 	client := &fakeClient{}
-	adapter, err := NewWithClient(Config{ProjectID: "123", UserIdentifier: "uid", UserSecret: "sec"}, client)
+	adapter, err := NewWithClient(Config{ProjectID: "123", UserIdentifier: "uid", UserSecret: "sec", Mode: ModeStrings}, client)
 	if err != nil {
 		t.Fatalf("new adapter: %v", err)
 	}
@@ -130,7 +149,7 @@ func TestAdapterPushAppliedOnlyIncludesSentEntries(t *testing.T) {
 
 func TestAdapterPushPreservesTranslationWhitespace(t *testing.T) {
 	client := &fakeClient{}
-	adapter, err := NewWithClient(Config{ProjectID: "123", UserIdentifier: "uid", UserSecret: "sec"}, client)
+	adapter, err := NewWithClient(Config{ProjectID: "123", UserIdentifier: "uid", UserSecret: "sec", Mode: ModeStrings}, client)
 	if err != nil {
 		t.Fatalf("new adapter: %v", err)
 	}
@@ -149,7 +168,7 @@ func TestAdapterPushPreservesTranslationWhitespace(t *testing.T) {
 
 func TestAdapterPushDeduplicatesByEntryID(t *testing.T) {
 	client := &fakeClient{}
-	adapter, err := NewWithClient(Config{ProjectID: "123", UserIdentifier: "uid", UserSecret: "sec"}, client)
+	adapter, err := NewWithClient(Config{ProjectID: "123", UserIdentifier: "uid", UserSecret: "sec", Mode: ModeStrings}, client)
 	if err != nil {
 		t.Fatalf("new adapter: %v", err)
 	}
@@ -186,7 +205,7 @@ func TestAdapterPushDeduplicatesByEntryID(t *testing.T) {
 
 func TestAdapterPushReturnsErrorWithoutAppliedOnFailure(t *testing.T) {
 	client := &fakeClient{upsertErr: errors.New("boom")}
-	adapter, err := NewWithClient(Config{ProjectID: "123", UserIdentifier: "uid", UserSecret: "sec"}, client)
+	adapter, err := NewWithClient(Config{ProjectID: "123", UserIdentifier: "uid", UserSecret: "sec", Mode: ModeStrings}, client)
 	if err != nil {
 		t.Fatalf("new adapter: %v", err)
 	}
@@ -199,6 +218,96 @@ func TestAdapterPushReturnsErrorWithoutAppliedOnFailure(t *testing.T) {
 	}
 	if got := len(result.Applied); got != 0 {
 		t.Fatalf("expected no applied ids on error, got %d", got)
+	}
+}
+
+func TestParseConfigDefaultsToStringsMode(t *testing.T) {
+	t.Setenv("SMARTLING_USER_SECRET", "secret")
+	cfg, err := ParseConfig(json.RawMessage(`{"projectID":"123","userIdentifier":"uid"}`))
+	if err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	if cfg.Mode != ModeStrings {
+		t.Fatalf("expected default mode %q, got %q", ModeStrings, cfg.Mode)
+	}
+}
+
+func TestParseConfigRejectsInvalidMode(t *testing.T) {
+	t.Setenv("SMARTLING_USER_SECRET", "secret")
+	_, err := ParseConfig(json.RawMessage(`{"projectID":"123","userIdentifier":"uid","mode":"invalid"}`))
+	if err == nil || !strings.Contains(err.Error(), "mode must") {
+		t.Fatalf("expected mode validation error, got %v", err)
+	}
+}
+
+func TestParseConfigRequiresFileURIInFilesMode(t *testing.T) {
+	t.Setenv("SMARTLING_USER_SECRET", "secret")
+	_, err := ParseConfig(json.RawMessage(`{"projectID":"123","userIdentifier":"uid","mode":"files"}`))
+	if err == nil || !strings.Contains(err.Error(), "fileURI is required") {
+		t.Fatalf("expected fileURI required error, got %v", err)
+	}
+}
+
+func TestAdapterCapabilitiesInStringsMode(t *testing.T) {
+	t.Setenv("SMARTLING_USER_SECRET", "secret")
+	adapter, err := NewWithClient(Config{ProjectID: "123", UserIdentifier: "uid", UserSecret: "sec", Mode: ModeStrings}, &fakeClient{})
+	if err != nil {
+		t.Fatalf("new adapter: %v", err)
+	}
+	caps := adapter.Capabilities()
+	if !caps.SupportsContext {
+		t.Fatal("expected context support in strings mode")
+	}
+}
+
+func TestAdapterCapabilitiesInFilesMode(t *testing.T) {
+	t.Setenv("SMARTLING_USER_SECRET", "secret")
+	adapter, err := NewWithClient(Config{ProjectID: "123", UserIdentifier: "uid", UserSecret: "sec", Mode: ModeFiles, FileURI: "translations.json", FileFormat: "json"}, &fakeClient{})
+	if err != nil {
+		t.Fatalf("new adapter: %v", err)
+	}
+	caps := adapter.Capabilities()
+	if caps.SupportsContext {
+		t.Fatal("expected no context support in files mode")
+	}
+}
+
+func TestAdapterPullFilesDelegatesToExportFile(t *testing.T) {
+	client := &fakeClient{exportOut: []storage.Entry{{Key: "hello", Locale: "fr", Value: "bonjour"}}}
+	adapter, err := NewWithClient(Config{ProjectID: "123", UserIdentifier: "uid", UserSecret: "sec", Mode: ModeFiles, FileURI: "translations.json", FileFormat: "json"}, client)
+	if err != nil {
+		t.Fatalf("new adapter: %v", err)
+	}
+
+	result, err := adapter.Pull(context.Background(), storage.PullRequest{Locales: []string{"fr"}})
+	if err != nil {
+		t.Fatalf("pull files: %v", err)
+	}
+	if got := len(result.Snapshot.Entries); got != 1 {
+		t.Fatalf("expected 1 entry, got %d", got)
+	}
+	entry := result.Snapshot.Entries[0]
+	if entry.Key != "hello" || entry.Locale != "fr" || entry.Value != "bonjour" {
+		t.Fatalf("unexpected entry mapping: %+v", entry)
+	}
+}
+
+func TestAdapterPushFilesDelegatesToImportFile(t *testing.T) {
+	client := &fakeClient{}
+	adapter, err := NewWithClient(Config{ProjectID: "123", UserIdentifier: "uid", UserSecret: "sec", Mode: ModeFiles, FileURI: "translations.json", FileFormat: "json"}, client)
+	if err != nil {
+		t.Fatalf("new adapter: %v", err)
+	}
+
+	_, err = adapter.Push(context.Background(), storage.PushRequest{Entries: []storage.Entry{{Key: "hello", Locale: "fr", Value: "bonjour"}}})
+	if err != nil {
+		t.Fatalf("push files: %v", err)
+	}
+	if got := len(client.importIn.Entries); got != 1 {
+		t.Fatalf("expected 1 import entry, got %d", got)
+	}
+	if client.importIn.FileURI != "translations.json" || client.importIn.FileType != "json" {
+		t.Fatalf("unexpected import input: uri=%q type=%q", client.importIn.FileURI, client.importIn.FileType)
 	}
 }
 
@@ -215,7 +324,7 @@ func TestNewBuildsAdapterFromRawConfig(t *testing.T) {
 
 func TestAdapterUploadSources(t *testing.T) {
 	client := &fakeClient{}
-	adapter, err := NewWithClient(Config{ProjectID: "123", UserIdentifier: "uid", UserSecret: "sec"}, client)
+	adapter, err := NewWithClient(Config{ProjectID: "123", UserIdentifier: "uid", UserSecret: "sec", Mode: ModeStrings}, client)
 	if err != nil {
 		t.Fatalf("new adapter: %v", err)
 	}
@@ -251,7 +360,7 @@ func TestAdapterUploadSources(t *testing.T) {
 
 func TestAdapterUploadSourcesWarnsWhenSourcePatternMatchesNoFiles(t *testing.T) {
 	client := &fakeClient{}
-	adapter, err := NewWithClient(Config{ProjectID: "123", UserIdentifier: "uid", UserSecret: "sec"}, client)
+	adapter, err := NewWithClient(Config{ProjectID: "123", UserIdentifier: "uid", UserSecret: "sec", Mode: ModeStrings}, client)
 	if err != nil {
 		t.Fatalf("new adapter: %v", err)
 	}

--- a/internal/i18n/storage/smartling/http_client.go
+++ b/internal/i18n/storage/smartling/http_client.go
@@ -18,14 +18,16 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/storage"
 )
 
 const (
 	authAPIBaseURL     = "https://api.smartling.com/auth-api/v2"
 	stringsAPIBaseURL  = "https://api.smartling.com/strings-api/v2"
+	filesAPIBaseURL    = "https://api.smartling.com/files-api/v2"
 	glossaryAPIBaseURL = "https://api.smartling.com/glossary-api/v2"
 	tmAPIBaseURL       = "https://api.smartling.com/translation-memory-api/v2"
-	filesAPIBaseURL    = "https://api.smartling.com/files-api/v2"
 	translationsLimit  = 500
 	glossaryLimit      = 500
 )
@@ -33,9 +35,9 @@ const (
 type HTTPClient struct {
 	authBaseURL     string
 	stringsBaseURL  string
+	filesBaseURL    string
 	glossaryBaseURL string
 	tmBaseURL       string
-	filesBaseURL    string
 	http            *http.Client
 	userIdentifier  string
 	userSecret      string
@@ -54,9 +56,9 @@ func NewHTTPClient(cfg Config) (*HTTPClient, error) {
 	return &HTTPClient{
 		authBaseURL:     authAPIBaseURL,
 		stringsBaseURL:  stringsAPIBaseURL,
+		filesBaseURL:    filesAPIBaseURL,
 		glossaryBaseURL: glossaryAPIBaseURL,
 		tmBaseURL:       tmAPIBaseURL,
-		filesBaseURL:    filesAPIBaseURL,
 		http:            &http.Client{Timeout: timeout},
 		userIdentifier:  cfg.UserIdentifier,
 		userSecret:      cfg.UserSecret,
@@ -251,6 +253,63 @@ func (c *HTTPClient) UpsertTranslations(ctx context.Context, in UpsertTranslatio
 	return time.Now().UTC().Format(time.RFC3339Nano), nil
 }
 
+func (c *HTTPClient) ExportFile(ctx context.Context, in ExportFileInput) ([]storage.Entry, string, error) {
+	token, err := c.accessToken(ctx)
+	if err != nil {
+		return nil, "", err
+	}
+
+	revision := time.Now().UTC().Format(time.RFC3339Nano)
+	if len(in.Locales) == 0 {
+		return nil, revision, nil
+	}
+
+	entries := make([]storage.Entry, 0)
+	errs := make([]error, 0)
+	for _, locale := range in.Locales {
+		trimmedLocale := strings.TrimSpace(locale)
+		if trimmedLocale == "" {
+			continue
+		}
+		content, err := c.downloadFile(ctx, token, in.ProjectID, trimmedLocale, in.FileURI)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		localeEntries, err := decodeFileContent(content, trimmedLocale)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		entries = append(entries, localeEntries...)
+	}
+
+	if len(errs) > 0 {
+		return entries, revision, errors.Join(errs...)
+	}
+	return entries, revision, nil
+}
+
+func (c *HTTPClient) ImportFile(ctx context.Context, in ImportFileInput) (string, error) {
+	if len(in.Entries) == 0 {
+		return time.Now().UTC().Format(time.RFC3339Nano), nil
+	}
+	token, err := c.accessToken(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	content, err := encodeFileContent(in.Entries)
+	if err != nil {
+		return "", err
+	}
+
+	if err := c.uploadFile(ctx, token, in.ProjectID, in.FileURI, in.FileType, content); err != nil {
+		return "", err
+	}
+	return time.Now().UTC().Format(time.RFC3339Nano), nil
+}
+
 func (c *HTTPClient) authenticate(ctx context.Context) (string, error) {
 	endpoint := fmt.Sprintf("%s/authenticate", c.authBaseURL)
 	payload := map[string]string{
@@ -419,6 +478,107 @@ func (c *HTTPClient) do(req *http.Request, out any) error {
 		return fmt.Errorf("decode response: %w", err)
 	}
 	return nil
+}
+
+func (c *HTTPClient) downloadFile(ctx context.Context, token string, projectID string, locale string, fileURI string) ([]byte, error) {
+	endpoint := fmt.Sprintf("%s/projects/%s/locales/%s/file", c.filesBaseURL, url.PathEscape(projectID), url.PathEscape(locale))
+	params := url.Values{}
+	params.Set("fileUri", fileURI)
+	endpoint = endpoint + "?" + params.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("download file %s: %w", locale, err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return nil, fmt.Errorf("download file %s: status %d: %s", locale, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return io.ReadAll(resp.Body)
+}
+
+func (c *HTTPClient) uploadFile(ctx context.Context, token string, projectID string, fileURI string, fileType string, content []byte) error {
+	endpoint := fmt.Sprintf("%s/projects/%s/file", c.filesBaseURL, url.PathEscape(projectID))
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	if err := writer.WriteField("fileUri", fileURI); err != nil {
+		return fmt.Errorf("build upload: %w", err)
+	}
+	if err := writer.WriteField("fileType", fileType); err != nil {
+		return fmt.Errorf("build upload: %w", err)
+	}
+	part, err := writer.CreateFormFile("file", "translations.json")
+	if err != nil {
+		return fmt.Errorf("build upload: %w", err)
+	}
+	if _, err := part.Write(content); err != nil {
+		return fmt.Errorf("build upload: %w", err)
+	}
+	if err := writer.Close(); err != nil {
+		return fmt.Errorf("build upload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, &body)
+	if err != nil {
+		return fmt.Errorf("build upload request: %w", err)
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("upload file: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("upload file: status %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	return nil
+}
+
+func decodeFileContent(content []byte, locale string) ([]storage.Entry, error) {
+	var items map[string]string
+	if err := json.Unmarshal(content, &items); err != nil {
+		return nil, fmt.Errorf("decode file content for %s: %w", locale, err)
+	}
+	entries := make([]storage.Entry, 0, len(items))
+	for key, value := range items {
+		entries = append(entries, storage.Entry{Key: key, Locale: locale, Value: value})
+	}
+	return entries, nil
+}
+
+func encodeFileContent(entries []storage.Entry) ([]byte, error) {
+	items := make(map[string]map[string]string)
+	for _, entry := range entries {
+		if strings.TrimSpace(entry.Key) == "" || strings.TrimSpace(entry.Locale) == "" || strings.TrimSpace(entry.Value) == "" {
+			continue
+		}
+		if _, ok := items[entry.Locale]; !ok {
+			items[entry.Locale] = map[string]string{}
+		}
+		items[entry.Locale][entry.Key] = entry.Value
+	}
+	return json.Marshal(items)
 }
 
 // GlossaryDownloadRequest identifies the Smartling glossary to export.

--- a/internal/i18n/storage/smartling/http_client.go
+++ b/internal/i18n/storage/smartling/http_client.go
@@ -276,7 +276,7 @@ func (c *HTTPClient) ExportFile(ctx context.Context, in ExportFileInput) ([]stor
 			errs = append(errs, err)
 			continue
 		}
-		localeEntries, err := decodeFileContent(content, trimmedLocale)
+		localeEntries, err := decodeFileContent(content, trimmedLocale, in.FileType)
 		if err != nil {
 			errs = append(errs, err)
 			continue
@@ -520,7 +520,7 @@ func (c *HTTPClient) uploadFile(ctx context.Context, token string, projectID str
 	if err := writer.WriteField("fileType", fileType); err != nil {
 		return fmt.Errorf("build upload: %w", err)
 	}
-	part, err := writer.CreateFormFile("file", "translations.json")
+	part, err := writer.CreateFormFile("file", fileURI)
 	if err != nil {
 		return fmt.Errorf("build upload: %w", err)
 	}
@@ -555,13 +555,36 @@ func (c *HTTPClient) uploadFile(ctx context.Context, token string, projectID str
 	return nil
 }
 
-func decodeFileContent(content []byte, locale string) ([]storage.Entry, error) {
-	var items map[string]string
-	if err := json.Unmarshal(content, &items); err != nil {
+func decodeFileContent(content []byte, locale string, fileType string) ([]storage.Entry, error) {
+	fileType = strings.ToLower(strings.TrimSpace(fileType))
+	if fileType == "" {
+		fileType = "json"
+	}
+	if fileType != "json" {
+		return nil, fmt.Errorf("decode file content for %s: unsupported file type %q", locale, fileType)
+	}
+
+	// Try flat map first (one locale per file).
+	var flat map[string]string
+	if err := json.Unmarshal(content, &flat); err == nil {
+		entries := make([]storage.Entry, 0, len(flat))
+		for key, value := range flat {
+			entries = append(entries, storage.Entry{Key: key, Locale: locale, Value: value})
+		}
+		return entries, nil
+	}
+
+	// Fall back to nested locale-keyed map (matches encodeFileContent output).
+	var nested map[string]map[string]string
+	if err := json.Unmarshal(content, &nested); err != nil {
 		return nil, fmt.Errorf("decode file content for %s: %w", locale, err)
 	}
-	entries := make([]storage.Entry, 0, len(items))
-	for key, value := range items {
+	localeItems, ok := nested[locale]
+	if !ok {
+		return nil, fmt.Errorf("decode file content for %s: locale not found in nested map", locale)
+	}
+	entries := make([]storage.Entry, 0, len(localeItems))
+	for key, value := range localeItems {
 		entries = append(entries, storage.Entry{Key: key, Locale: locale, Value: value})
 	}
 	return entries, nil

--- a/internal/i18n/storage/smartling/http_client_test.go
+++ b/internal/i18n/storage/smartling/http_client_test.go
@@ -478,6 +478,7 @@ func TestHTTPClientExportFileDownloadsPerLocale(t *testing.T) {
 	entries, _, err := client.ExportFile(context.Background(), ExportFileInput{
 		ProjectID: "123",
 		FileURI:   "translations.json",
+		FileType:  "json",
 		Locales:   []string{"fr", "de"},
 	})
 	if err != nil {
@@ -513,6 +514,7 @@ func TestHTTPClientExportFileReturnsPartialOnLocaleError(t *testing.T) {
 	entries, _, err := client.ExportFile(context.Background(), ExportFileInput{
 		ProjectID: "123",
 		FileURI:   "translations.json",
+		FileType:  "json",
 		Locales:   []string{"fr", "de"},
 	})
 	if err == nil {
@@ -615,4 +617,32 @@ func writeTranslationsItemsResponse(w http.ResponseWriter, count int, start int,
 		)
 	}
 	_, _ = fmt.Fprint(w, `]}}`)
+}
+
+func TestDecodeFileContentNestedMap(t *testing.T) {
+	content := []byte(`{"fr":{"hello":"bonjour","goodbye":"au revoir"},"de":{"hello":"Hallo"}}`)
+	entries, err := decodeFileContent(content, "fr", "json")
+	if err != nil {
+		t.Fatalf("decode nested map: %v", err)
+	}
+	if got := len(entries); got != 2 {
+		t.Fatalf("expected 2 entries, got %d", got)
+	}
+	m := make(map[string]string, len(entries))
+	for _, e := range entries {
+		m[e.Key] = e.Value
+	}
+	if m["hello"] != "bonjour" || m["goodbye"] != "au revoir" {
+		t.Fatalf("unexpected decoded values: %v", m)
+	}
+}
+
+func TestDecodeFileContentUnsupportedFileType(t *testing.T) {
+	_, err := decodeFileContent([]byte("<xml></xml>"), "fr", "xliff")
+	if err == nil {
+		t.Fatal("expected error for unsupported file type")
+	}
+	if !strings.Contains(err.Error(), "unsupported file type") {
+		t.Fatalf("expected unsupported file type error, got: %v", err)
+	}
 }

--- a/internal/i18n/storage/smartling/http_client_test.go
+++ b/internal/i18n/storage/smartling/http_client_test.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/storage"
 )
 
 func TestNewHTTPClientUsesDefaultTimeout(t *testing.T) {
@@ -442,6 +444,144 @@ func TestHTTPClientUploadSourceFile(t *testing.T) {
 
 	if !result.OverWritten || result.StringCount != 10 || result.WordCount != 50 {
 		t.Fatalf("unexpected result: %+v", result)
+	}
+}
+
+func TestHTTPClientExportFileDownloadsPerLocale(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/authenticate":
+			_, _ = fmt.Fprint(w, `{"response":{"code":"SUCCESS"},"data":{"accessToken":"token"}}`)
+		case "/projects/123/locales/fr/file":
+			if r.URL.Query().Get("fileUri") != "translations.json" {
+				t.Fatalf("unexpected fileUri: %s", r.URL.Query().Get("fileUri"))
+			}
+			_, _ = fmt.Fprint(w, `{"hello":"Bonjour"}`)
+		case "/projects/123/locales/de/file":
+			if r.URL.Query().Get("fileUri") != "translations.json" {
+				t.Fatalf("unexpected fileUri: %s", r.URL.Query().Get("fileUri"))
+			}
+			_, _ = fmt.Fprint(w, `{"hello":"Hallo"}`)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	client := &HTTPClient{
+		authBaseURL:    srv.URL,
+		filesBaseURL:   srv.URL,
+		http:           srv.Client(),
+		userIdentifier: "id",
+		userSecret:     "secret",
+	}
+	entries, _, err := client.ExportFile(context.Background(), ExportFileInput{
+		ProjectID: "123",
+		FileURI:   "translations.json",
+		Locales:   []string{"fr", "de"},
+	})
+	if err != nil {
+		t.Fatalf("export file: %v", err)
+	}
+	if got := len(entries); got != 2 {
+		t.Fatalf("expected 2 entries, got %d", got)
+	}
+}
+
+func TestHTTPClientExportFileReturnsPartialOnLocaleError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/authenticate":
+			_, _ = fmt.Fprint(w, `{"response":{"code":"SUCCESS"},"data":{"accessToken":"token"}}`)
+		case "/projects/123/locales/fr/file":
+			http.Error(w, "not found", http.StatusNotFound)
+		case "/projects/123/locales/de/file":
+			_, _ = fmt.Fprint(w, `{"hello":"Hallo"}`)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	client := &HTTPClient{
+		authBaseURL:    srv.URL,
+		filesBaseURL:   srv.URL,
+		http:           srv.Client(),
+		userIdentifier: "id",
+		userSecret:     "secret",
+	}
+	entries, _, err := client.ExportFile(context.Background(), ExportFileInput{
+		ProjectID: "123",
+		FileURI:   "translations.json",
+		Locales:   []string{"fr", "de"},
+	})
+	if err == nil {
+		t.Fatal("expected error for failed locale")
+	}
+	if got := len(entries); got != 1 {
+		t.Fatalf("expected 1 entry from successful locale, got %d", got)
+	}
+}
+
+func TestHTTPClientImportFileUploadsMultipart(t *testing.T) {
+	var receivedFileURI, receivedFileType string
+	var receivedBody []byte
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/authenticate":
+			_, _ = fmt.Fprint(w, `{"response":{"code":"SUCCESS"},"data":{"accessToken":"token"}}`)
+		case "/projects/123/file":
+			if r.Method != http.MethodPost {
+				t.Fatalf("unexpected method: %s", r.Method)
+			}
+			file, header, err := r.FormFile("file")
+			if err != nil {
+				t.Fatalf("form file: %v", err)
+			}
+			defer func() { _ = file.Close() }()
+			receivedBody, _ = io.ReadAll(file)
+			receivedFileURI = r.FormValue("fileUri")
+			receivedFileType = r.FormValue("fileType")
+			if header.Filename != "translations.json" {
+				t.Fatalf("unexpected filename: %s", header.Filename)
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, `{"response":{"code":"SUCCESS"},"data":{"wordCount":1,"stringCount":1}}`)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	client := &HTTPClient{
+		authBaseURL:    srv.URL,
+		filesBaseURL:   srv.URL,
+		http:           srv.Client(),
+		userIdentifier: "id",
+		userSecret:     "secret",
+	}
+	_, err := client.ImportFile(context.Background(), ImportFileInput{
+		ProjectID: "123",
+		FileURI:   "translations.json",
+		FileType:  "json",
+		Entries:   []storage.Entry{{Key: "hello", Locale: "fr", Value: "bonjour"}},
+	})
+	if err != nil {
+		t.Fatalf("import file: %v", err)
+	}
+	if receivedFileURI != "translations.json" {
+		t.Fatalf("unexpected fileUri: %q", receivedFileURI)
+	}
+	if receivedFileType != "json" {
+		t.Fatalf("unexpected fileType: %q", receivedFileType)
+	}
+	var parsed map[string]map[string]string
+	if err := json.Unmarshal(receivedBody, &parsed); err != nil {
+		t.Fatalf("decode uploaded body: %v", err)
+	}
+	if parsed["fr"]["hello"] != "bonjour" {
+		t.Fatalf("unexpected uploaded content: %s", string(receivedBody))
 	}
 }
 


### PR DESCRIPTION
Adds file-mode support to the Smartling adapter so it can sync translations via Smartling's Files API, matching the existing Phrase adapter behavior.

## What's new

- Config fields: mode (strings | files), fileURI, and fileFormat.
  - strings remains the default for backward compatibility.
  - files mode requires fileURI and fileFormat (e.g. json).
- Pull (sync pull): downloads translated files per locale via GET /projects/{id}/locales/{localeId}/file and parses them into normalized entries.
- Push (sync push): encodes entries as locale-keyed JSON and uploads via POST /projects/{id}/file as multipart/form-data with fileUri and fileType.