### PR TITLE
🧪 Scout: improve Markdown block structure validation tests

### DIFF
--- a/internal/i18n/translationfileparser/markdown_segment_heuristics_test.go
+++ b/internal/i18n/translationfileparser/markdown_segment_heuristics_test.go
@@ -5,39 +5,116 @@ import (
 	"testing"
 )
 
-func TestValidateMarkdownTranslatedBlockStructureSingleLineSourceOK(t *testing.T) {
-	if err := ValidateMarkdownTranslatedBlockStructure("Hello.", "Bonjour."); err != nil {
-		t.Fatalf("expected nil, got %v", err)
+func TestValidateMarkdownTranslatedBlockStructure(t *testing.T) {
+	tests := []struct {
+		name    string
+		source  string
+		target  string
+		wantErr string
+	}{
+		{
+			name:   "basic single line OK",
+			source: "Hello.",
+			target: "Bonjour.",
+		},
+		{
+			name:   "multi-line target OK if no blocks introduced",
+			source: "Hello world.",
+			target: "Bonjour le monde.\n\nC'est une belle journée.",
+		},
+		{
+			name:   "skips validation for multi-line source",
+			source: "# Title\n\nBody.",
+			target: "# Title\n\nBody.\n\n# Extra heading",
+		},
+		{
+			name:    "rejects injected heading",
+			source:  "Hello.",
+			target:  "Bonjour.\n\n# Heading",
+			wantErr: "ATX heading",
+		},
+		{
+			name:   "allows heading if source has it",
+			source: "# Hello",
+			target: "# Bonjour",
+		},
+		{
+			name:    "rejects injected code fence",
+			source:  "Hello.",
+			target:  "Bonjour.\n\n```go\nfmt.Println()\n```",
+			wantErr: "fenced code delimiter",
+		},
+		{
+			name:   "allows code fence if source has it",
+			source: "```go\n```",
+			target: "```rust\n```",
+		},
+		{
+			name:    "rejects injected thematic break",
+			source:  "Hello.",
+			target:  "Bonjour.\n\n---",
+			wantErr: "thematic break",
+		},
+		{
+			name:   "allows thematic break if source has it",
+			source: "---",
+			target: "***",
+		},
+		{
+			name:    "rejects injected blockquote",
+			source:  "Hello.",
+			target:  "Bonjour.\n\n> Quote",
+			wantErr: "blockquote",
+		},
+		{
+			name:   "allows blockquote if source has it",
+			source: "> Hello",
+			target: "> Bonjour",
+		},
+		{
+			name:    "rejects injected ordered list",
+			source:  "Hello.",
+			target:  "Bonjour.\n\n1. First item",
+			wantErr: "ordered list",
+		},
+		{
+			name:   "allows ordered list if source has it",
+			source: "1. Hello",
+			target: "1. Bonjour",
+		},
+		{
+			name:    "rejects injected bullet list",
+			source:  "Hello.",
+			target:  "Bonjour.\n\n- Item",
+			wantErr: "bullet list",
+		},
+		{
+			name:   "allows bullet list if source has it",
+			source: "* Hello",
+			target: "- Bonjour",
+		},
+		{
+			name:   "empty translation is OK",
+			source: "Hello",
+			target: "",
+		},
 	}
-}
 
-func TestValidateMarkdownTranslatedBlockStructureSkipsMultiLineSource(t *testing.T) {
-	src := "# Title\n\nBody line."
-	tgt := "# Title\n\nBody line.\n\n# Extra"
-	if err := ValidateMarkdownTranslatedBlockStructure(src, tgt); err != nil {
-		t.Fatalf("expected no heuristic error for multi-line source, got %v", err)
-	}
-}
-
-func TestValidateMarkdownTranslatedBlockStructureRejectsInjectedHeading(t *testing.T) {
-	err := ValidateMarkdownTranslatedBlockStructure("Hello world.", "Bonjour.\n\n# Bad")
-	if err == nil {
-		t.Fatal("expected error")
-	}
-	if !strings.Contains(err.Error(), "ATX heading") {
-		t.Fatalf("unexpected: %v", err)
-	}
-}
-
-func TestValidateMarkdownTranslatedBlockStructureAllowsHeadingWhenSourceHasIt(t *testing.T) {
-	if err := ValidateMarkdownTranslatedBlockStructure("# A", "# B"); err != nil {
-		t.Fatalf("expected nil, got %v", err)
-	}
-}
-
-func TestValidateMarkdownTranslatedBlockStructureRejectsThematicBreak(t *testing.T) {
-	err := ValidateMarkdownTranslatedBlockStructure("Hello.", "Hi.\n\n---\n")
-	if err == nil {
-		t.Fatal("expected error")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateMarkdownTranslatedBlockStructure(tt.source, tt.target)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tt.wantErr)
+				}
+			}
+		})
 	}
 }

--- a/internal/i18n/translationfileparser/markdown_segment_heuristics_test.go
+++ b/internal/i18n/translationfileparser/markdown_segment_heuristics_test.go
@@ -46,8 +46,8 @@ func TestValidateMarkdownTranslatedBlockStructure(t *testing.T) {
 		},
 		{
 			name:   "allows code fence if source has it",
-			source: "```go\n```",
-			target: "```rust\n```",
+			source: "```",
+			target: "```",
 		},
 		{
 			name:    "rejects injected thematic break",

--- a/internal/i18n/translationfileparser/markdown_segment_heuristics_test.go
+++ b/internal/i18n/translationfileparser/markdown_segment_heuristics_test.go
@@ -46,8 +46,8 @@ func TestValidateMarkdownTranslatedBlockStructure(t *testing.T) {
 		},
 		{
 			name:   "allows code fence if source has it",
-			source: "```",
-			target: "```",
+			source: "```go",
+			target: "```rust",
 		},
 		{
 			name:    "rejects injected thematic break",


### PR DESCRIPTION
This change refactors and expands the unit tests for `ValidateMarkdownTranslatedBlockStructure` in `internal/i18n/translationfileparser/markdown_segment_heuristics.go`.

The individual test functions in `internal/i18n/translationfileparser/markdown_segment_heuristics_test.go` were replaced with a single, comprehensive table-driven test `TestValidateMarkdownTranslatedBlockStructure`.

Key improvements:
- Added explicit coverage for code fences, blockquotes, ordered lists, and bullet lists injections.
- Verified that multi-line translations are allowed as long as they don't introduce restricted block structures.
- Verified that existing blocks in the source are allowed in the translation.
- Ensured all existing behaviors (like skipping multi-line source validation) are preserved.

These tests increase confidence in the heuristic checks that prevent LLMs or translators from accidentally breaking page layout by injecting block-level Markdown into inline segments.

---
*PR created automatically by Jules for task [3658934318252836453](https://jules.google.com/task/3658934318252836453) started by @cungminh2710*