### PR TITLE
fix(crowdin): improve Project and Directory model parity

### DIFF
--- a/third_party/crowdin-api-client-go/crowdin/model/projects.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/projects.go
@@ -33,6 +33,7 @@ type (
 		SourceLanguage       *Language   `json:"sourceLanguage"`
 		TargetLanguages      []*Language `json:"targetLanguages"`
 		WebURL               string      `json:"webUrl"`
+		Background           string      `json:"background,omitempty"`
 		Fields               any         `json:"fields,omitempty"`
 
 		ClientOrganizationID            int                        `json:"clientOrganizationId,omitempty"`
@@ -71,6 +72,7 @@ type (
 		TMPreTranslate                  *ProjectTMPreTranslate     `json:"tmPreTranslate,omitempty"`
 		MTPreTranslate                  *ProjectMTPreTranslate     `json:"mtPreTranslate,omitempty"`
 		AiPreTranslate                  *ProjectAiPreTranslate     `json:"aiPreTranslate,omitempty"`
+		AssistActionAiPromptID          int                        `json:"assistActionAiPromptId,omitempty"`
 		SaveMetaInfoInSource            bool                       `json:"saveMetaInfoInSource,omitempty"`
 		SkipUntranslatedFiles           bool                       `json:"skipUntranslatedFiles,omitempty"`
 		InContext                       bool                       `json:"inContext,omitempty"`

--- a/third_party/crowdin-api-client-go/crowdin/model/source_files.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/source_files.go
@@ -16,6 +16,7 @@ type Directory struct {
 	Title         string `json:"title"`
 	ExportPattern string `json:"exportPattern"`
 	Path          string `json:"path"`
+	IsReadOnly    bool   `json:"isReadOnly,omitempty"`
 	Priority      string `json:"priority"`
 	CreatedAt     string `json:"createdAt"`
 	UpdatedAt     string `json:"updatedAt"`

--- a/third_party/crowdin-api-client-go/crowdin/model/source_files.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/source_files.go
@@ -16,7 +16,7 @@ type Directory struct {
 	Title         string `json:"title"`
 	ExportPattern string `json:"exportPattern"`
 	Path          string `json:"path"`
-	IsReadOnly    bool   `json:"isReadOnly,omitempty"`
+	IsReadOnly    *bool  `json:"isReadOnly,omitempty"`
 	Priority      string `json:"priority"`
 	CreatedAt     string `json:"createdAt"`
 	UpdatedAt     string `json:"updatedAt"`

--- a/third_party/crowdin-api-client-go/crowdin/projects_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/projects_test.go
@@ -69,6 +69,7 @@ func TestProjectsService_Get(t *testing.T) {
 				}
 			],
 			"webUrl": "https://crowdin.com/project/some-project",
+			"background": "data:image/png;base64,iVBORw0KGgo",
 			"translateDuplicates": 2,
 			"tagsDetection": 0,
 			"glossaryAccess": false,
@@ -401,7 +402,9 @@ func TestProjectsService_Get(t *testing.T) {
 			TextDirection:       "ltr",
 			DialectOf:           "",
 		},
-		TMContextType: "segmentContext",
+		TMContextType:          "segmentContext",
+		Background:             "data:image/png;base64,iVBORw0KGgo",
+		AssistActionAiPromptID: 0,
 	}
 	assert.Equal(t, expectedProjects, project)
 }
@@ -600,6 +603,7 @@ func TestProjectsService_Get_Enterprise(t *testing.T) {
 				"textDirection": "ltr",
 				"dialectOf": null
 			},
+			"assistActionAiPromptId": 1,
 			"tmContextType": "segmentContext"
 		}
 	}`
@@ -630,6 +634,7 @@ func TestProjectsService_Get_Enterprise(t *testing.T) {
 		WorkflowID:        3,
 		HasCrowdsourcing:  false,
 		PublicDownloads:   true,
+		Background:        "data:image/png;base64,iVBORw0KGgo",
 		CreatedAt:         "2023-09-20T11:34:40+00:00",
 		UpdatedAt:         "2023-09-20T11:34:40+00:00",
 		LastActivity:      "2023-09-20T11:34:40+00:00",
@@ -786,7 +791,8 @@ func TestProjectsService_Get_Enterprise(t *testing.T) {
 			TextDirection:       "ltr",
 			DialectOf:           "",
 		},
-		TMContextType: "segmentContext",
+		TMContextType:          "segmentContext",
+		AssistActionAiPromptID: 1,
 	}
 	assert.Equal(t, expectedProjects, project)
 }

--- a/third_party/crowdin-api-client-go/crowdin/source_files_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/source_files_test.go
@@ -32,6 +32,7 @@ func TestSourceFilesService_ListDirectories(t *testing.T) {
 						"title": "Description materials",
 						"exportPattern": "/localization/%locale%/file_name",
 						"path": "/main",
+						"isReadOnly": true,
 						"priority": "normal",
 						"createdAt": "2024-04-18T14:14:00+00:00",
 						"updatedAt": "2024-04-18T14:14:00+00:00"
@@ -58,6 +59,7 @@ func TestSourceFilesService_ListDirectories(t *testing.T) {
 			Title:         "Description materials",
 			ExportPattern: "/localization/%locale%/file_name",
 			Path:          "/main",
+			IsReadOnly:    true,
 			Priority:      "normal",
 			CreatedAt:     "2024-04-18T14:14:00+00:00",
 			UpdatedAt:     "2024-04-18T14:14:00+00:00",

--- a/third_party/crowdin-api-client-go/crowdin/source_files_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/source_files_test.go
@@ -2,6 +2,7 @@ package crowdin
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -59,7 +60,7 @@ func TestSourceFilesService_ListDirectories(t *testing.T) {
 			Title:         "Description materials",
 			ExportPattern: "/localization/%locale%/file_name",
 			Path:          "/main",
-			IsReadOnly:    true,
+			IsReadOnly:    ToPtr(true),
 			Priority:      "normal",
 			CreatedAt:     "2024-04-18T14:14:00+00:00",
 			UpdatedAt:     "2024-04-18T14:14:00+00:00",
@@ -82,6 +83,21 @@ func TestSourceFilesService_ListDirectories_invalidJSON(t *testing.T) {
 	res, _, err := client.SourceFiles.ListDirectories(context.Background(), 1, nil)
 	require.Error(t, err)
 	assert.Nil(t, res)
+}
+
+func TestDirectory_MarshalJSON_IsReadOnly(t *testing.T) {
+	directory := &model.Directory{IsReadOnly: ToPtr(false)}
+
+	b, err := json.Marshal(directory)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{"id":0,"projectId":0,"name":"","title":"","exportPattern":"","path":"","isReadOnly":false,"priority":"","createdAt":"","updatedAt":""}`, string(b))
+
+	directory.IsReadOnly = nil
+	b, err = json.Marshal(directory)
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(b), "isReadOnly")
 }
 
 func TestSourceFilesService_ListDirectories_WithQueryParams(t *testing.T) {


### PR DESCRIPTION
Improved Crowdin API v2 parity for the Go client fork by adding missing fields to the `Project` and `Directory` models. Specifically, added `Background` and `AssistActionAiPromptID` to projects, and `IsReadOnly` to directories. These fields were identified from the Crowdin API v2 documentation and were missing from the local Go structs.

Verification:
- Updated unit tests in `third_party/crowdin-api-client-go/crowdin/projects_test.go` and `source_files_test.go`.
- Ran `go test github.com/crowdin/crowdin-api-client-go/crowdin` and confirmed all tests pass.
- Verified that the changes do not affect the main Hyperlocalise application by running `go test ./...` from the root.
- Cleaned up accidental file creation and fixed test mismatches identified during internal review.

---
*PR created automatically by Jules for task [4962385842085180952](https://jules.google.com/task/4962385842085180952) started by @cungminh2710*