### PR TITLE
🛡️ Sentinel: [HIGH] Harden file download routes against XSS

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/file/file.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/file/file.route.ts
@@ -63,8 +63,9 @@ export function createFileRoutes(options: CreateFileRoutesOptions = {}) {
       );
       c.header(
         "Content-Disposition",
-        `inline; filename*=UTF-8''${encodeURIComponent(file.filename)}`,
+        `attachment; filename*=UTF-8''${encodeURIComponent(file.filename)}`,
       );
+      c.header("Content-Security-Policy", "default-src 'none'; sandbox;");
 
       return c.body(storedObject.body);
     });

--- a/apps/hyperlocalise-web/src/api/routes/file/file.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/file/file.route.ts
@@ -66,6 +66,8 @@ export function createFileRoutes(options: CreateFileRoutesOptions = {}) {
         `attachment; filename*=UTF-8''${encodeURIComponent(file.filename)}`,
       );
       c.header("Content-Security-Policy", "default-src 'none'; sandbox;");
+      c.header("X-Download-Options", "noopen");
+      c.header("Cache-Control", "no-store");
 
       return c.body(storedObject.body);
     });

--- a/apps/hyperlocalise-web/src/api/routes/public-files/public-files.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/public-files/public-files.route.ts
@@ -175,12 +175,17 @@ export function createPublicFileRoutes(options: CreatePublicFileRoutesOptions = 
         return fileNotFoundResponse(c);
       }
 
-      c.header("Content-Type", storedObject.contentType ?? file.contentType);
+      c.header(
+        "Content-Type",
+        storedObject.contentType ?? file.contentType ?? "application/octet-stream",
+      );
       c.header(
         "Content-Disposition",
         `attachment; filename*=UTF-8''${encodeURIComponent(file.filename)}`,
       );
       c.header("Content-Security-Policy", "default-src 'none'; sandbox;");
+      c.header("X-Download-Options", "noopen");
+      c.header("Cache-Control", "no-store");
 
       return c.body(storedObject.body);
     });

--- a/apps/hyperlocalise-web/src/api/routes/public-files/public-files.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/public-files/public-files.route.ts
@@ -180,6 +180,7 @@ export function createPublicFileRoutes(options: CreatePublicFileRoutesOptions = 
         "Content-Disposition",
         `attachment; filename*=UTF-8''${encodeURIComponent(file.filename)}`,
       );
+      c.header("Content-Security-Policy", "default-src 'none'; sandbox;");
 
       return c.body(storedObject.body);
     });


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: User-uploaded files were being served with `Content-Disposition: inline` (in some cases) and without a restrictive Content Security Policy (CSP).
🎯 Impact: An attacker could upload a malicious HTML or SVG file. If a user was tricked into opening it, the script would execute in the context of the application's origin, potentially leading to session theft or other XSS-based attacks.
🔧 Fix:
- Forced `Content-Disposition: attachment` for all file downloads to ensure they are downloaded rather than rendered by the browser.
- Added `Content-Security-Policy: default-src 'none'; sandbox;` to file download responses to prevent script execution even if the file is somehow rendered.
✅ Verification:
- Modified `apps/hyperlocalise-web/src/api/routes/file/file.route.ts` and `apps/hyperlocalise-web/src/api/routes/public-files/public-files.route.ts`.
- Verified changes by reading files.
- Ran `vp check --fix` to ensure code quality.

---
*PR created automatically by Jules for task [8560804183284562733](https://jules.google.com/task/8560804183284562733) started by @cungminh2710*