### PR TITLE
fix(poeditor): support terms file uploads

### DIFF
--- a/internal/i18n/storage/poeditor/adapter.go
+++ b/internal/i18n/storage/poeditor/adapter.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -28,6 +30,7 @@ type Config struct {
 type Client interface {
 	ListTerms(ctx context.Context, in ListTermsInput) ([]TermTranslation, string, error)
 	UpsertTranslations(ctx context.Context, in UpsertTranslationsInput) (string, error)
+	UploadTermsFile(ctx context.Context, in UploadTermsFileInput) (UploadTermsFileResult, error)
 }
 
 type Adapter struct {
@@ -207,6 +210,75 @@ func (a *Adapter) Push(ctx context.Context, req storage.PushRequest) (storage.Pu
 		Applied:  applied,
 		Revision: revision,
 	}, nil
+}
+
+func (a *Adapter) FileWorkflowCapabilities() storage.FileWorkflowCapabilities {
+	return storage.FileWorkflowCapabilities{
+		SupportsSourceUpload: true,
+	}
+}
+
+func (a *Adapter) UploadSources(ctx context.Context, req storage.FileUploadSourcesRequest) (storage.FileOperationResult, error) {
+	cfg := req.Config
+	if strings.TrimSpace(cfg.ProjectID) == "" {
+		cfg.ProjectID = a.cfg.ProjectID
+	}
+	if strings.TrimSpace(cfg.APIToken) == "" {
+		cfg.APIToken = a.cfg.APIToken
+	}
+	if strings.TrimSpace(cfg.BasePath) == "" {
+		cfg.BasePath = "."
+	}
+
+	result := storage.FileOperationResult{}
+	for _, fileGroup := range cfg.Files {
+		sourcePaths, err := resolveSourcePaths(cfg.BasePath, fileGroup.Source)
+		if err != nil {
+			return result, err
+		}
+		if len(sourcePaths) == 0 {
+			result.Warnings = append(result.Warnings, storage.Warning{
+				Message: fmt.Sprintf("source pattern %q matched no files", fileGroup.Source),
+			})
+			continue
+		}
+
+		for _, sourcePath := range sourcePaths {
+			_, err := a.client.UploadTermsFile(ctx, UploadTermsFileInput{
+				ProjectID: cfg.ProjectID,
+				APIToken:  cfg.APIToken,
+				FilePath:  sourcePath,
+			})
+			if err != nil {
+				return result, fmt.Errorf("poeditor upload source %s: %w", sourcePath, err)
+			}
+			result.Processed = append(result.Processed, sourcePath)
+		}
+	}
+	return result, nil
+}
+
+func (a *Adapter) UploadTranslations(ctx context.Context, req storage.FileUploadTranslationsRequest) (storage.FileOperationResult, error) {
+	return storage.FileOperationResult{}, fmt.Errorf("poeditor adapter: UploadTranslations not implemented")
+}
+
+func (a *Adapter) DownloadTranslations(ctx context.Context, req storage.FileDownloadTranslationsRequest) (storage.FileOperationResult, error) {
+	return storage.FileOperationResult{}, fmt.Errorf("poeditor adapter: DownloadTranslations not implemented")
+}
+
+func resolveSourcePaths(basePath, pattern string) ([]string, error) {
+	localPattern := strings.TrimPrefix(filepath.ToSlash(pattern), "/")
+	localPattern = filepath.Clean(filepath.Join(basePath, filepath.FromSlash(localPattern)))
+
+	if !strings.ContainsAny(localPattern, "*?[") {
+		return []string{localPattern}, nil
+	}
+	matches, err := filepath.Glob(localPattern)
+	if err != nil {
+		return nil, err
+	}
+	slices.Sort(matches)
+	return matches, nil
 }
 
 type TermTranslation struct {

--- a/internal/i18n/storage/poeditor/adapter.go
+++ b/internal/i18n/storage/poeditor/adapter.go
@@ -271,6 +271,12 @@ func resolveSourcePaths(basePath, pattern string) ([]string, error) {
 	localPattern = filepath.Clean(filepath.Join(basePath, filepath.FromSlash(localPattern)))
 
 	if !strings.ContainsAny(localPattern, "*?[") {
+		if _, err := os.Stat(localPattern); err != nil {
+			if os.IsNotExist(err) {
+				return nil, nil
+			}
+			return nil, err
+		}
 		return []string{localPattern}, nil
 	}
 	matches, err := filepath.Glob(localPattern)

--- a/internal/i18n/storage/poeditor/adapter_test.go
+++ b/internal/i18n/storage/poeditor/adapter_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -16,6 +17,7 @@ type fakeClient struct {
 	listRevision string
 	upsertIn     UpsertTranslationsInput
 	upsertErr    error
+	uploads      []UploadTermsFileInput
 }
 
 func (f *fakeClient) ListTerms(_ context.Context, _ ListTermsInput) ([]TermTranslation, string, error) {
@@ -28,6 +30,11 @@ func (f *fakeClient) UpsertTranslations(_ context.Context, in UpsertTranslations
 		return "", f.upsertErr
 	}
 	return "rev2", nil
+}
+
+func (f *fakeClient) UploadTermsFile(_ context.Context, in UploadTermsFileInput) (UploadTermsFileResult, error) {
+	f.uploads = append(f.uploads, in)
+	return UploadTermsFileResult{}, f.upsertErr
 }
 
 func TestParseConfigUsesEnvToken(t *testing.T) {
@@ -189,5 +196,91 @@ func TestAdapterNameAndCapabilities(t *testing.T) {
 	}
 	if caps.SupportsDeletes {
 		t.Fatalf("expected SupportsDeletes=false")
+	}
+}
+
+func TestAdapterFileWorkflowCapabilities(t *testing.T) {
+	adapter, err := NewWithClient(Config{ProjectID: "123", APIToken: "token"}, &fakeClient{})
+	if err != nil {
+		t.Fatalf("new adapter: %v", err)
+	}
+
+	caps := adapter.FileWorkflowCapabilities()
+	if !caps.SupportsSourceUpload {
+		t.Fatalf("expected source upload support")
+	}
+	if caps.SupportsTranslationUpload || caps.SupportsTranslationExport || caps.SupportsSourceDownload {
+		t.Fatalf("unexpected file workflow capabilities: %+v", caps)
+	}
+}
+
+func TestAdapterUploadSourcesUploadsTermsFiles(t *testing.T) {
+	client := &fakeClient{}
+	adapter, err := NewWithClient(Config{ProjectID: "123", APIToken: "token"}, client)
+	if err != nil {
+		t.Fatalf("new adapter: %v", err)
+	}
+
+	tempDir := t.TempDir()
+	sourcePath := filepath.Join(tempDir, "messages.json")
+	if err := os.WriteFile(sourcePath, []byte(`{"hello":"Hello"}`), 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+
+	result, err := adapter.UploadSources(context.Background(), storage.FileUploadSourcesRequest{
+		Config: storage.FileWorkflowConfig{
+			BasePath: tempDir,
+			Files: []storage.FileGroupSpec{
+				{Source: "messages.json"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("upload sources: %v", err)
+	}
+	if got := len(result.Processed); got != 1 {
+		t.Fatalf("expected 1 processed source, got %d", got)
+	}
+	if result.Processed[0] != sourcePath {
+		t.Fatalf("unexpected processed source: %q", result.Processed[0])
+	}
+	if got := len(client.uploads); got != 1 {
+		t.Fatalf("expected 1 upload call, got %d", got)
+	}
+	upload := client.uploads[0]
+	if upload.ProjectID != "123" || upload.APIToken != "token" || upload.FilePath != sourcePath {
+		t.Fatalf("unexpected upload input: %+v", upload)
+	}
+}
+
+func TestAdapterUploadSourcesWarnsWhenGlobMatchesNoFiles(t *testing.T) {
+	client := &fakeClient{}
+	adapter, err := NewWithClient(Config{ProjectID: "123", APIToken: "token"}, client)
+	if err != nil {
+		t.Fatalf("new adapter: %v", err)
+	}
+
+	result, err := adapter.UploadSources(context.Background(), storage.FileUploadSourcesRequest{
+		Config: storage.FileWorkflowConfig{
+			BasePath: t.TempDir(),
+			Files: []storage.FileGroupSpec{
+				{Source: "*.po"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("upload sources: %v", err)
+	}
+	if got := len(result.Processed); got != 0 {
+		t.Fatalf("expected no processed sources, got %d", got)
+	}
+	if got := len(client.uploads); got != 0 {
+		t.Fatalf("expected no upload calls, got %d", got)
+	}
+	if got := len(result.Warnings); got != 1 {
+		t.Fatalf("expected 1 warning, got %d", got)
+	}
+	if !strings.Contains(result.Warnings[0].Message, `source pattern "*.po" matched no files`) {
+		t.Fatalf("unexpected warning: %+v", result.Warnings[0])
 	}
 }

--- a/internal/i18n/storage/poeditor/adapter_test.go
+++ b/internal/i18n/storage/poeditor/adapter_test.go
@@ -284,3 +284,35 @@ func TestAdapterUploadSourcesWarnsWhenGlobMatchesNoFiles(t *testing.T) {
 		t.Fatalf("unexpected warning: %+v", result.Warnings[0])
 	}
 }
+
+func TestAdapterUploadSourcesWarnsWhenLiteralFileIsMissing(t *testing.T) {
+	client := &fakeClient{}
+	adapter, err := NewWithClient(Config{ProjectID: "123", APIToken: "token"}, client)
+	if err != nil {
+		t.Fatalf("new adapter: %v", err)
+	}
+
+	result, err := adapter.UploadSources(context.Background(), storage.FileUploadSourcesRequest{
+		Config: storage.FileWorkflowConfig{
+			BasePath: t.TempDir(),
+			Files: []storage.FileGroupSpec{
+				{Source: "missing.po"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("upload sources: %v", err)
+	}
+	if got := len(result.Processed); got != 0 {
+		t.Fatalf("expected no processed sources, got %d", got)
+	}
+	if got := len(client.uploads); got != 0 {
+		t.Fatalf("expected no upload calls, got %d", got)
+	}
+	if got := len(result.Warnings); got != 1 {
+		t.Fatalf("expected 1 warning, got %d", got)
+	}
+	if !strings.Contains(result.Warnings[0].Message, `source pattern "missing.po" matched no files`) {
+		t.Fatalf("unexpected warning: %+v", result.Warnings[0])
+	}
+}

--- a/internal/i18n/storage/poeditor/http_client.go
+++ b/internal/i18n/storage/poeditor/http_client.go
@@ -4,19 +4,94 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 )
 
 const apiBaseURL = "https://api.poeditor.com/v2"
 
+type apiEnvelope struct {
+	Response struct {
+		Status  string `json:"status"`
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	} `json:"response"`
+}
+
+func (e apiEnvelope) check(endpoint string) error {
+	status := strings.ToLower(strings.TrimSpace(e.Response.Status))
+	code := strings.TrimSpace(e.Response.Code)
+	message := strings.TrimSpace(e.Response.Message)
+	if status == "" || status == "success" {
+		return nil
+	}
+	if message == "" {
+		message = "request failed"
+	}
+	if code != "" {
+		return fmt.Errorf("poeditor request %s: api error %s: %s", endpoint, code, message)
+	}
+	return fmt.Errorf("poeditor request %s: api error: %s", endpoint, message)
+}
+
+type translationContent struct {
+	stringValue string
+}
+
+func (c *translationContent) UnmarshalJSON(data []byte) error {
+	var value string
+	if err := json.Unmarshal(data, &value); err == nil {
+		c.stringValue = value
+		return nil
+	}
+	var object map[string]string
+	if err := json.Unmarshal(data, &object); err == nil {
+		raw, err := json.Marshal(object)
+		if err != nil {
+			return err
+		}
+		c.stringValue = string(raw)
+		return nil
+	}
+	return fmt.Errorf("unsupported translation content: %s", strings.TrimSpace(string(data)))
+}
+
+func (c translationContent) String() string {
+	return c.stringValue
+}
+
 type HTTPClient struct {
 	baseURL string
 	http    *http.Client
+}
+
+type UploadTermsFileInput struct {
+	ProjectID string
+	APIToken  string
+	FilePath  string
+	SyncTerms bool
+	Tags      string
+}
+
+type UploadTermsFileResult struct {
+	Terms struct {
+		Parsed  int `json:"parsed"`
+		Added   int `json:"added"`
+		Deleted int `json:"deleted"`
+	} `json:"terms"`
+	Translations struct {
+		Parsed  int `json:"parsed"`
+		Added   int `json:"added"`
+		Updated int `json:"updated"`
+	} `json:"translations"`
 }
 
 func NewHTTPClient(cfg Config) (*HTTPClient, error) {
@@ -34,68 +109,132 @@ func NewHTTPClient(cfg Config) (*HTTPClient, error) {
 }
 
 func (c *HTTPClient) ListTerms(ctx context.Context, in ListTermsInput) ([]TermTranslation, string, error) {
-	var response struct {
-		Result struct {
-			Code    string `json:"code"`
-			Message string `json:"message"`
-		} `json:"result"`
-		Terms []struct {
-			Term         string `json:"term"`
-			Context      string `json:"context"`
-			Translations []struct {
-				Language string `json:"language"`
-				Content  string `json:"content"`
-			} `json:"translations"`
-		} `json:"terms"`
-	}
-
-	values := url.Values{}
-	values.Set("api_token", in.APIToken)
-	values.Set("id", in.ProjectID)
-	if err := c.postForm(ctx, "/terms/list", values, &response); err != nil {
-		return nil, "", err
-	}
-
-	allowed := make(map[string]struct{}, len(in.Locales))
-	for _, locale := range in.Locales {
-		allowed[strings.TrimSpace(locale)] = struct{}{}
+	locales := trimLocales(in.Locales)
+	if len(locales) == 0 {
+		discovered, err := c.listLanguages(ctx, in)
+		if err != nil {
+			return nil, "", err
+		}
+		locales = discovered
 	}
 
 	out := make([]TermTranslation, 0)
-	for _, term := range response.Terms {
-		for _, tr := range term.Translations {
-			if len(allowed) > 0 {
-				if _, ok := allowed[tr.Language]; !ok {
-					continue
-				}
-			}
-			out = append(out, TermTranslation{
-				Term:    term.Term,
-				Context: term.Context,
-				Locale:  tr.Language,
-				Value:   tr.Content,
-			})
+	for _, locale := range locales {
+		terms, err := c.listTermsForLanguage(ctx, in, locale)
+		if err != nil {
+			return nil, "", err
 		}
+		out = append(out, terms...)
 	}
 
 	revision := time.Now().UTC().Format(time.RFC3339Nano)
 	return out, revision, nil
 }
 
+func (c *HTTPClient) listLanguages(ctx context.Context, in ListTermsInput) ([]string, error) {
+	var response struct {
+		apiEnvelope
+		Result struct {
+			Languages []struct {
+				Code string `json:"code"`
+			} `json:"languages"`
+		} `json:"result"`
+	}
+	values := url.Values{}
+	values.Set("api_token", in.APIToken)
+	values.Set("id", in.ProjectID)
+	if err := c.postForm(ctx, "/languages/list", values, &response); err != nil {
+		return nil, err
+	}
+	locales := make([]string, 0, len(response.Result.Languages))
+	for _, language := range response.Result.Languages {
+		code := strings.TrimSpace(language.Code)
+		if code != "" {
+			locales = append(locales, code)
+		}
+	}
+	return locales, nil
+}
+
+func (c *HTTPClient) listTermsForLanguage(ctx context.Context, in ListTermsInput, locale string) ([]TermTranslation, error) {
+	var response struct {
+		apiEnvelope
+		Result struct {
+			Terms []struct {
+				Term        string `json:"term"`
+				Context     string `json:"context"`
+				Translation struct {
+					Content translationContent `json:"content"`
+				} `json:"translation"`
+			} `json:"terms"`
+		} `json:"result"`
+	}
+	values := url.Values{}
+	values.Set("api_token", in.APIToken)
+	values.Set("id", in.ProjectID)
+	values.Set("language", locale)
+	if err := c.postForm(ctx, "/terms/list", values, &response); err != nil {
+		return nil, err
+	}
+
+	out := make([]TermTranslation, 0, len(response.Result.Terms))
+	for _, term := range response.Result.Terms {
+		value := term.Translation.Content.String()
+		if strings.TrimSpace(value) == "" {
+			continue
+		}
+		out = append(out, TermTranslation{
+			Term:    term.Term,
+			Context: term.Context,
+			Locale:  locale,
+			Value:   value,
+		})
+	}
+	return out, nil
+}
+
 func (c *HTTPClient) UpsertTranslations(ctx context.Context, in UpsertTranslationsInput) (string, error) {
-	byLocale := make(map[string][]map[string]string)
+	byLocale := make(map[string][]translationUpdate)
+	terms := make([]termAdd, 0, len(in.Entries))
+	seenTerms := make(map[string]struct{}, len(in.Entries))
 	for _, entry := range in.Entries {
 		if strings.TrimSpace(entry.Locale) == "" {
 			continue
 		}
-		item := map[string]string{
-			"term":        entry.Term,
-			"translation": entry.Value,
+		termKey := entry.Term + "\x00" + entry.Context
+		if _, exists := seenTerms[termKey]; !exists {
+			terms = append(terms, termAdd{
+				Term:    entry.Term,
+				Context: entry.Context,
+			})
+			seenTerms[termKey] = struct{}{}
+		}
+		item := translationUpdate{
+			Term: entry.Term,
+			Translation: translationUpdateValue{
+				Content: entry.Value,
+			},
 		}
 		if strings.TrimSpace(entry.Context) != "" {
-			item["context"] = entry.Context
+			item.Context = entry.Context
 		}
 		byLocale[entry.Locale] = append(byLocale[entry.Locale], item)
+	}
+
+	if len(terms) > 0 {
+		raw, err := json.Marshal(terms)
+		if err != nil {
+			return "", fmt.Errorf("marshal poeditor terms payload: %w", err)
+		}
+		values := url.Values{}
+		values.Set("api_token", in.APIToken)
+		values.Set("id", in.ProjectID)
+		values.Set("data", string(raw))
+
+		var response struct{ apiEnvelope }
+		if err := c.postForm(ctx, "/terms/add", values, &response); err != nil {
+			return "", err
+		}
 	}
 
 	for locale, items := range byLocale {
@@ -110,18 +249,79 @@ func (c *HTTPClient) UpsertTranslations(ctx context.Context, in UpsertTranslatio
 		values.Set("language", locale)
 		values.Set("data", string(raw))
 
-		var response struct {
-			Result struct {
-				Code    string `json:"code"`
-				Message string `json:"message"`
-			} `json:"result"`
-		}
-		if err := c.postForm(ctx, "/translations/update", values, &response); err != nil {
+		var response struct{ apiEnvelope }
+		if err := c.postForm(ctx, "/languages/update", values, &response); err != nil {
 			return "", err
 		}
 	}
 
 	return time.Now().UTC().Format(time.RFC3339Nano), nil
+}
+
+func (c *HTTPClient) UploadTermsFile(ctx context.Context, in UploadTermsFileInput) (UploadTermsFileResult, error) {
+	var result UploadTermsFileResult
+	if strings.TrimSpace(in.ProjectID) == "" {
+		return result, fmt.Errorf("poeditor upload terms: project id is required")
+	}
+	if strings.TrimSpace(in.APIToken) == "" {
+		return result, fmt.Errorf("poeditor upload terms: API token is required")
+	}
+	if strings.TrimSpace(in.FilePath) == "" {
+		return result, fmt.Errorf("poeditor upload terms: file path is required")
+	}
+
+	fields := map[string]string{
+		"api_token": in.APIToken,
+		"id":        in.ProjectID,
+		"updating":  "terms",
+	}
+	if in.SyncTerms {
+		fields["sync_terms"] = "1"
+	}
+	if strings.TrimSpace(in.Tags) != "" {
+		fields["tags"] = in.Tags
+	}
+
+	var response struct {
+		apiEnvelope
+		Result UploadTermsFileResult `json:"result"`
+	}
+	if err := c.postMultipartFile(ctx, "/projects/upload", fields, "file", in.FilePath, &response); err != nil {
+		return result, err
+	}
+	return response.Result, nil
+}
+
+type termAdd struct {
+	Term    string `json:"term"`
+	Context string `json:"context,omitempty"`
+}
+
+type translationUpdate struct {
+	Term        string                 `json:"term"`
+	Context     string                 `json:"context,omitempty"`
+	Translation translationUpdateValue `json:"translation"`
+}
+
+type translationUpdateValue struct {
+	Content string `json:"content"`
+}
+
+func trimLocales(locales []string) []string {
+	seen := make(map[string]struct{}, len(locales))
+	out := make([]string, 0, len(locales))
+	for _, locale := range locales {
+		trimmed := strings.TrimSpace(locale)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		out = append(out, trimmed)
+	}
+	return out
 }
 
 func (c *HTTPClient) postForm(ctx context.Context, endpoint string, values url.Values, out any) error {
@@ -147,6 +347,91 @@ func (c *HTTPClient) postForm(ctx context.Context, endpoint string, values url.V
 	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
 		return fmt.Errorf("poeditor decode %s response: %w", endpoint, err)
 	}
+	if envelope, ok := out.(interface {
+		check(string) error
+	}); ok {
+		if err := envelope.check(endpoint); err != nil {
+			return err
+		}
+	}
 
 	return nil
+}
+
+func (c *HTTPClient) postMultipartFile(ctx context.Context, endpoint string, fields map[string]string, fileFieldName, filePath string, out any) error {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("poeditor request %s: open file: %w", endpoint, err)
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+
+	pr, pw := io.Pipe()
+	writer := multipart.NewWriter(pw)
+	writeErrCh := make(chan error, 1)
+	go func() {
+		var werr error
+		defer func() {
+			_ = pw.CloseWithError(werr)
+			writeErrCh <- werr
+		}()
+		for key, value := range fields {
+			if werr = writer.WriteField(key, value); werr != nil {
+				werr = fmt.Errorf("write form field %s: %w", key, werr)
+				return
+			}
+		}
+		var part io.Writer
+		part, werr = writer.CreateFormFile(fileFieldName, filepath.Base(filePath))
+		if werr != nil {
+			werr = fmt.Errorf("create form file: %w", werr)
+			return
+		}
+		if _, werr = io.Copy(part, file); werr != nil {
+			werr = fmt.Errorf("copy file to form: %w", werr)
+			return
+		}
+		if werr = writer.Close(); werr != nil {
+			werr = fmt.Errorf("close multipart writer: %w", werr)
+		}
+	}()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+endpoint, pr)
+	if err != nil {
+		_ = pr.CloseWithError(err)
+		writeErr := <-writeErrCh
+		return errors.Join(fmt.Errorf("poeditor request build %s: %w", endpoint, err), writeErr)
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		_ = pr.CloseWithError(err)
+		writeErr := <-writeErrCh
+		return errors.Join(fmt.Errorf("poeditor request %s: %w", endpoint, err), writeErr)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		writeErr := <-writeErrCh
+		return errors.Join(fmt.Errorf("poeditor request %s: status %d: %s", endpoint, resp.StatusCode, strings.TrimSpace(string(body))), writeErr)
+	}
+
+	decodeErr := json.NewDecoder(resp.Body).Decode(out)
+	writeErr := <-writeErrCh
+	if decodeErr != nil {
+		return errors.Join(fmt.Errorf("poeditor decode %s response: %w", endpoint, decodeErr), writeErr)
+	}
+	if envelope, ok := out.(interface {
+		check(string) error
+	}); ok {
+		if err := envelope.check(endpoint); err != nil {
+			return errors.Join(err, writeErr)
+		}
+	}
+	return writeErr
 }

--- a/internal/i18n/storage/poeditor/http_client.go
+++ b/internal/i18n/storage/poeditor/http_client.go
@@ -81,6 +81,11 @@ type UploadTermsFileInput struct {
 	Tags      string
 }
 
+type multipartField struct {
+	key   string
+	value string
+}
+
 type UploadTermsFileResult struct {
 	Terms struct {
 		Parsed  int `json:"parsed"`
@@ -250,7 +255,7 @@ func (c *HTTPClient) UpsertTranslations(ctx context.Context, in UpsertTranslatio
 		values.Set("data", string(raw))
 
 		var response struct{ apiEnvelope }
-		if err := c.postForm(ctx, "/languages/update", values, &response); err != nil {
+		if err := c.postForm(ctx, "/translations/update", values, &response); err != nil {
 			return "", err
 		}
 	}
@@ -270,16 +275,16 @@ func (c *HTTPClient) UploadTermsFile(ctx context.Context, in UploadTermsFileInpu
 		return result, fmt.Errorf("poeditor upload terms: file path is required")
 	}
 
-	fields := map[string]string{
-		"api_token": in.APIToken,
-		"id":        in.ProjectID,
-		"updating":  "terms",
+	fields := []multipartField{
+		{key: "api_token", value: in.APIToken},
+		{key: "id", value: in.ProjectID},
+		{key: "updating", value: "terms"},
 	}
 	if in.SyncTerms {
-		fields["sync_terms"] = "1"
+		fields = append(fields, multipartField{key: "sync_terms", value: "1"})
 	}
 	if strings.TrimSpace(in.Tags) != "" {
-		fields["tags"] = in.Tags
+		fields = append(fields, multipartField{key: "tags", value: in.Tags})
 	}
 
 	var response struct {
@@ -358,7 +363,7 @@ func (c *HTTPClient) postForm(ctx context.Context, endpoint string, values url.V
 	return nil
 }
 
-func (c *HTTPClient) postMultipartFile(ctx context.Context, endpoint string, fields map[string]string, fileFieldName, filePath string, out any) error {
+func (c *HTTPClient) postMultipartFile(ctx context.Context, endpoint string, fields []multipartField, fileFieldName, filePath string, out any) error {
 	file, err := os.Open(filePath)
 	if err != nil {
 		return fmt.Errorf("poeditor request %s: open file: %w", endpoint, err)
@@ -376,9 +381,9 @@ func (c *HTTPClient) postMultipartFile(ctx context.Context, endpoint string, fie
 			_ = pw.CloseWithError(werr)
 			writeErrCh <- werr
 		}()
-		for key, value := range fields {
-			if werr = writer.WriteField(key, value); werr != nil {
-				werr = fmt.Errorf("write form field %s: %w", key, werr)
+		for _, field := range fields {
+			if werr = writer.WriteField(field.key, field.value); werr != nil {
+				werr = fmt.Errorf("write form field %s: %w", field.key, werr)
 				return
 			}
 		}

--- a/internal/i18n/storage/poeditor/http_client_test.go
+++ b/internal/i18n/storage/poeditor/http_client_test.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -249,8 +250,8 @@ func TestHTTPClientUpsertTranslationsSendsGroupedPayload(t *testing.T) {
 	if seenPaths["/terms/add"] != 1 {
 		t.Fatalf("expected one terms/add call, got paths: %+v", seenPaths)
 	}
-	if seenPaths["/languages/update"] != 2 {
-		t.Fatalf("expected two languages/update calls, got paths: %+v", seenPaths)
+	if seenPaths["/translations/update"] != 2 {
+		t.Fatalf("expected two translations/update calls, got paths: %+v", seenPaths)
 	}
 }
 
@@ -268,40 +269,59 @@ func TestHTTPClientUploadTermsFileUsesProjectsUpload(t *testing.T) {
 		if ct := r.Header.Get("Content-Type"); !strings.Contains(ct, "multipart/form-data") {
 			t.Fatalf("unexpected content-type: %s", ct)
 		}
-		if err := r.ParseMultipartForm(1 << 20); err != nil {
-			t.Fatalf("parse multipart: %v", err)
+		reader, err := r.MultipartReader()
+		if err != nil {
+			t.Fatalf("read multipart: %v", err)
 		}
-		if got := r.FormValue("api_token"); got != "token" {
+
+		var fieldOrder []string
+		fieldValues := map[string]string{}
+		var fileName string
+		var fileContent string
+		for {
+			part, err := reader.NextPart()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				t.Fatalf("read multipart part: %v", err)
+			}
+			name := part.FormName()
+			fieldOrder = append(fieldOrder, name)
+			content, err := io.ReadAll(part)
+			if err != nil {
+				t.Fatalf("read multipart %s: %v", name, err)
+			}
+			if part.FileName() != "" {
+				fileName = part.FileName()
+				fileContent = string(content)
+				continue
+			}
+			fieldValues[name] = string(content)
+		}
+		if want := []string{"api_token", "id", "updating", "sync_terms", "tags", "file"}; !slices.Equal(fieldOrder, want) {
+			t.Fatalf("unexpected multipart field order: got %v want %v", fieldOrder, want)
+		}
+		if got := fieldValues["api_token"]; got != "token" {
 			t.Fatalf("unexpected api_token: %q", got)
 		}
-		if got := r.FormValue("id"); got != "123" {
+		if got := fieldValues["id"]; got != "123" {
 			t.Fatalf("unexpected project id: %q", got)
 		}
-		if got := r.FormValue("updating"); got != "terms" {
+		if got := fieldValues["updating"]; got != "terms" {
 			t.Fatalf("unexpected updating mode: %q", got)
 		}
-		if got := r.FormValue("sync_terms"); got != "1" {
+		if got := fieldValues["sync_terms"]; got != "1" {
 			t.Fatalf("unexpected sync_terms: %q", got)
 		}
-		if got := r.FormValue("tags"); got != `{"all":"imported"}` {
+		if got := fieldValues["tags"]; got != `{"all":"imported"}` {
 			t.Fatalf("unexpected tags: %q", got)
 		}
 
-		file, header, err := r.FormFile("file")
-		if err != nil {
-			t.Fatalf("read multipart file: %v", err)
+		if fileName != "messages.po" {
+			t.Fatalf("unexpected uploaded filename: %q", fileName)
 		}
-		defer func() {
-			_ = file.Close()
-		}()
-		if header.Filename != "messages.po" {
-			t.Fatalf("unexpected uploaded filename: %q", header.Filename)
-		}
-		content, err := io.ReadAll(file)
-		if err != nil {
-			t.Fatalf("read uploaded file: %v", err)
-		}
-		if got := string(content); got != "msgid \"hello\"\nmsgstr \"\"\n" {
+		if got := fileContent; got != "msgid \"hello\"\nmsgstr \"\"\n" {
 			t.Fatalf("unexpected uploaded content: %q", got)
 		}
 

--- a/internal/i18n/storage/poeditor/http_client_test.go
+++ b/internal/i18n/storage/poeditor/http_client_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -24,6 +26,8 @@ func TestNewHTTPClientUsesDefaultTimeout(t *testing.T) {
 }
 
 func TestHTTPClientListTermsFiltersLocales(t *testing.T) {
+	var requestedLanguages []string
+
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/terms/list" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
@@ -45,18 +49,18 @@ func TestHTTPClientListTermsFiltersLocales(t *testing.T) {
 		if got := values.Get("id"); got != "123" {
 			t.Fatalf("unexpected project id: %q", got)
 		}
+		if got := values.Get("language"); got != "fr" {
+			t.Fatalf("unexpected language: %q", got)
+		}
+		requestedLanguages = append(requestedLanguages, values.Get("language"))
 
 		_, _ = fmt.Fprint(w, `{
-			"result":{"code":"200","message":"OK"},
-			"terms":[
-				{"term":"hello","context":"home","translations":[
-					{"language":"fr","content":"bonjour"},
-					{"language":"de","content":"hallo"}
-				]},
-				{"term":"bye","context":"","translations":[
-					{"language":"fr","content":"au revoir"}
-				]}
-			]
+			"response":{"status":"success","code":"200","message":"OK"},
+			"result":{"terms":[
+				{"term":"hello","context":"home","translation":{"content":"bonjour"}},
+				{"term":"bye","context":"","translation":{"content":"au revoir"}},
+				{"term":"empty","context":"","translation":{"content":""}}
+			]}
 		}`)
 	}))
 	defer srv.Close()
@@ -80,10 +84,71 @@ func TestHTTPClientListTermsFiltersLocales(t *testing.T) {
 	if got := len(entries); got != 2 {
 		t.Fatalf("expected 2 filtered entries, got %d", got)
 	}
+	if got := len(requestedLanguages); got != 1 {
+		t.Fatalf("expected one language-specific request, got %d", got)
+	}
 	for _, e := range entries {
 		if e.Locale != "fr" {
 			t.Fatalf("expected filtered locale fr, got %+v", e)
 		}
+	}
+}
+
+func TestHTTPClientListTermsDiscoversLanguages(t *testing.T) {
+	var requestedLanguages []string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		values, err := url.ParseQuery(string(body))
+		if err != nil {
+			t.Fatalf("parse form body: %v", err)
+		}
+
+		switch r.URL.Path {
+		case "/languages/list":
+			if got := values.Get("api_token"); got != "token" {
+				t.Fatalf("unexpected api_token: %q", got)
+			}
+			if got := values.Get("id"); got != "123" {
+				t.Fatalf("unexpected project id: %q", got)
+			}
+			_, _ = fmt.Fprint(w, `{
+				"response":{"status":"success","code":"200","message":"OK"},
+				"result":{"languages":[{"code":"fr"},{"code":"de"}]}
+			}`)
+		case "/terms/list":
+			locale := values.Get("language")
+			requestedLanguages = append(requestedLanguages, locale)
+			_, _ = fmt.Fprintf(w, `{
+				"response":{"status":"success","code":"200","message":"OK"},
+				"result":{"terms":[{"term":"hello","context":"","translation":{"content":"hello-%s"}}]}
+			}`, locale)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	client := &HTTPClient{
+		baseURL: srv.URL,
+		http:    srv.Client(),
+	}
+
+	entries, _, err := client.ListTerms(context.Background(), ListTermsInput{
+		ProjectID: "123",
+		APIToken:  "token",
+	})
+	if err != nil {
+		t.Fatalf("list terms: %v", err)
+	}
+	if got := strings.Join(requestedLanguages, ","); got != "fr,de" {
+		t.Fatalf("unexpected language requests: %s", got)
+	}
+	if got := len(entries); got != 2 {
+		t.Fatalf("expected discovered language entries, got %d", got)
 	}
 }
 
@@ -132,28 +197,141 @@ func TestHTTPClientUpsertTranslationsSendsGroupedPayload(t *testing.T) {
 	if revision == "" {
 		t.Fatalf("expected revision")
 	}
-	if got := len(calls); got != 2 {
-		t.Fatalf("expected 2 locale-grouped calls, got %d", got)
+	if got := len(calls); got != 3 {
+		t.Fatalf("expected terms add plus language update calls for 2 locales, got %d", got)
 	}
 
+	seenPaths := map[string]int{}
 	for _, call := range calls {
-		if call.Path != "/translations/update" {
-			t.Fatalf("unexpected path: %s", call.Path)
-		}
 		if call.Values.Get("api_token") != "token" || call.Values.Get("id") != "123" {
 			t.Fatalf("unexpected auth/id form values: %+v", call.Values)
 		}
+		seenPaths[call.Path]++
 		raw := call.Values.Get("data")
 		if raw == "" {
 			t.Fatalf("missing data payload")
 		}
-		var payload []map[string]string
+		if call.Path == "/terms/add" {
+			var terms []struct {
+				Term    string `json:"term"`
+				Context string `json:"context"`
+			}
+			if err := json.Unmarshal([]byte(raw), &terms); err != nil {
+				t.Fatalf("decode terms payload: %v", err)
+			}
+			if got := len(terms); got != 3 {
+				t.Fatalf("expected unique terms payload, got %d", got)
+			}
+			continue
+		}
+		var payload []struct {
+			Term        string `json:"term"`
+			Context     string `json:"context"`
+			Translation struct {
+				Content string `json:"content"`
+			} `json:"translation"`
+		}
 		if err := json.Unmarshal([]byte(raw), &payload); err != nil {
 			t.Fatalf("decode data payload: %v", err)
 		}
 		if len(payload) == 0 {
 			t.Fatalf("expected non-empty payload")
 		}
+		for _, item := range payload {
+			if item.Term == "" {
+				t.Fatalf("missing term in payload: %+v", payload)
+			}
+			if item.Translation.Content == "" {
+				t.Fatalf("missing nested translation content in payload: %+v", payload)
+			}
+		}
+	}
+	if seenPaths["/terms/add"] != 1 {
+		t.Fatalf("expected one terms/add call, got paths: %+v", seenPaths)
+	}
+	if seenPaths["/languages/update"] != 2 {
+		t.Fatalf("expected two languages/update calls, got paths: %+v", seenPaths)
+	}
+}
+
+func TestHTTPClientUploadTermsFileUsesProjectsUpload(t *testing.T) {
+	tempDir := t.TempDir()
+	sourcePath := filepath.Join(tempDir, "messages.po")
+	if err := os.WriteFile(sourcePath, []byte("msgid \"hello\"\nmsgstr \"\"\n"), 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/projects/upload" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if ct := r.Header.Get("Content-Type"); !strings.Contains(ct, "multipart/form-data") {
+			t.Fatalf("unexpected content-type: %s", ct)
+		}
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Fatalf("parse multipart: %v", err)
+		}
+		if got := r.FormValue("api_token"); got != "token" {
+			t.Fatalf("unexpected api_token: %q", got)
+		}
+		if got := r.FormValue("id"); got != "123" {
+			t.Fatalf("unexpected project id: %q", got)
+		}
+		if got := r.FormValue("updating"); got != "terms" {
+			t.Fatalf("unexpected updating mode: %q", got)
+		}
+		if got := r.FormValue("sync_terms"); got != "1" {
+			t.Fatalf("unexpected sync_terms: %q", got)
+		}
+		if got := r.FormValue("tags"); got != `{"all":"imported"}` {
+			t.Fatalf("unexpected tags: %q", got)
+		}
+
+		file, header, err := r.FormFile("file")
+		if err != nil {
+			t.Fatalf("read multipart file: %v", err)
+		}
+		defer func() {
+			_ = file.Close()
+		}()
+		if header.Filename != "messages.po" {
+			t.Fatalf("unexpected uploaded filename: %q", header.Filename)
+		}
+		content, err := io.ReadAll(file)
+		if err != nil {
+			t.Fatalf("read uploaded file: %v", err)
+		}
+		if got := string(content); got != "msgid \"hello\"\nmsgstr \"\"\n" {
+			t.Fatalf("unexpected uploaded content: %q", got)
+		}
+
+		_, _ = fmt.Fprint(w, `{
+			"response":{"status":"success","code":"200","message":"OK"},
+			"result":{
+				"terms":{"parsed":1,"added":1,"deleted":0},
+				"translations":{"parsed":0,"added":0,"updated":0}
+			}
+		}`)
+	}))
+	defer srv.Close()
+
+	client := &HTTPClient{
+		baseURL: srv.URL,
+		http:    srv.Client(),
+	}
+
+	result, err := client.UploadTermsFile(context.Background(), UploadTermsFileInput{
+		ProjectID: "123",
+		APIToken:  "token",
+		FilePath:  sourcePath,
+		SyncTerms: true,
+		Tags:      `{"all":"imported"}`,
+	})
+	if err != nil {
+		t.Fatalf("upload terms file: %v", err)
+	}
+	if result.Terms.Parsed != 1 || result.Terms.Added != 1 {
+		t.Fatalf("unexpected upload result: %+v", result)
 	}
 }
 
@@ -189,5 +367,22 @@ func TestHTTPClientPostFormDecodeError(t *testing.T) {
 	err := client.postForm(context.Background(), "/x", url.Values{"a": {"1"}}, &struct{}{})
 	if err == nil || !strings.Contains(err.Error(), "decode /x response") {
 		t.Fatalf("expected decode error, got %v", err)
+	}
+}
+
+func TestHTTPClientPostFormAPIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"response":{"status":"fail","code":"403","message":"Denied"}}`)
+	}))
+	defer srv.Close()
+
+	client := &HTTPClient{
+		baseURL: srv.URL,
+		http:    srv.Client(),
+	}
+
+	err := client.postForm(context.Background(), "/x", url.Values{"a": {"1"}}, &struct{ apiEnvelope }{})
+	if err == nil || !strings.Contains(err.Error(), "api error 403: Denied") {
+		t.Fatalf("expected API envelope error, got %v", err)
 	}
 }


### PR DESCRIPTION
## What changed

Added POEditor source file upload support through `projects/upload`.

The POEditor adapter can now upload source files as terms using multipart form data with `updating=terms`. The client also now matches POEditor’s documented response shapes for term listing and translation updates, including per-language term reads and API error envelopes.

## How to test

- `go test ./internal/i18n/storage/poeditor`
- `make fmt`
- `make lint`
- `make test`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
