### PR TITLE
⚡ Bolt: remove redundant TooltipProvider instances

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -3,3 +3,7 @@
 ## 2024-05-24 - Initializing Bolt's Journal
 **Learning:** Always keep a record of critical performance learnings to avoid repeating mistakes.
 **Action:** Created this file to track future insights.
+
+## 2025-05-15 - Redundant TooltipProvider Removal
+**Learning:** Nested `TooltipProvider` instances in React components (like `Message`, `Artifact`, `WebPreview`) add unnecessary context overhead and can lead to desynced timers if the root already provides one. In this codebase, `apps/hyperlocalise-web/src/app/layout.tsx` provides a global `TooltipProvider`.
+**Action:** Removed local `TooltipProvider` instances from `ai-elements` components to streamline the React tree and reduce memory/render overhead.

--- a/apps/hyperlocalise-web/src/components/ai-elements/artifact.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/artifact.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import type { LucideIcon } from "lucide-react";
 import { XIcon } from "lucide-react";
@@ -84,6 +84,11 @@ export const ArtifactAction = ({
   variant = "ghost",
   ...props
 }: ArtifactActionProps) => {
+  /**
+   * BOLT OPTIMIZATION: Remove redundant TooltipProvider.
+   * RootLayout already provides a TooltipProvider. Local providers add
+   * unnecessary React context overhead and can lead to desynced timers.
+   */
   const button = (
     <Button
       className={cn("size-8 p-0 text-muted-foreground hover:text-foreground", className)}
@@ -99,14 +104,12 @@ export const ArtifactAction = ({
 
   if (tooltip) {
     return (
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger>{button}</TooltipTrigger>
-          <TooltipContent>
-            <TypographyP>{tooltip}</TypographyP>
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger>{button}</TooltipTrigger>
+        <TooltipContent>
+          <TypographyP>{tooltip}</TypographyP>
+        </TooltipContent>
+      </Tooltip>
     );
   }
 

--- a/apps/hyperlocalise-web/src/components/ai-elements/message.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/message.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 import { ButtonGroup, ButtonGroupText } from "@/components/ui/button-group";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { cjk } from "@streamdown/cjk";
 import { code } from "@streamdown/code";
@@ -67,6 +67,11 @@ export const MessageAction = ({
   size = "icon-sm",
   ...props
 }: MessageActionProps) => {
+  /**
+   * BOLT OPTIMIZATION: Remove redundant TooltipProvider.
+   * RootLayout already provides a TooltipProvider. Local providers add
+   * unnecessary React context overhead and can lead to desynced timers.
+   */
   const button = (
     <Button size={size} type="button" variant={variant} {...props}>
       {children}
@@ -76,14 +81,12 @@ export const MessageAction = ({
 
   if (tooltip) {
     return (
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger>{button}</TooltipTrigger>
-          <TooltipContent>
-            <TypographyP>{tooltip}</TypographyP>
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger>{button}</TooltipTrigger>
+        <TooltipContent>
+          <TypographyP>{tooltip}</TypographyP>
+        </TooltipContent>
+      </Tooltip>
     );
   }
 

--- a/apps/hyperlocalise-web/src/components/ai-elements/tooltip-provider.test.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/tooltip-provider.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vite-plus/test";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { MessageAction } from "./message";

--- a/apps/hyperlocalise-web/src/components/ai-elements/tooltip-provider.test.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/tooltip-provider.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MessageAction } from "./message";
+import { ArtifactAction } from "./artifact";
+import { WebPreviewNavigationButton } from "./web-preview";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+describe("Tooltip Redundancy Optimization", () => {
+  it("MessageAction renders correctly within a TooltipProvider", () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(
+        TooltipProvider,
+        {},
+        React.createElement(
+          MessageAction,
+          { tooltip: "Test Tooltip", label: "Test Label" },
+          "Click me"
+        )
+      )
+    );
+    // Should contain the button text and the sr-only label
+    expect(markup).toContain("Click me");
+    expect(markup).toContain("Test Label");
+    // Since it's a Tooltip, it should have the data-slot="tooltip-trigger" from our TooltipTrigger
+    expect(markup).toContain('data-slot="tooltip-trigger"');
+  });
+
+  it("ArtifactAction renders correctly within a TooltipProvider", () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(
+        TooltipProvider,
+        {},
+        React.createElement(
+          ArtifactAction,
+          { tooltip: "Artifact Tooltip", label: "Artifact Label" },
+          "Artifact"
+        )
+      )
+    );
+    expect(markup).toContain("Artifact");
+    expect(markup).toContain("Artifact Label");
+    expect(markup).toContain('data-slot="tooltip-trigger"');
+  });
+
+  it("WebPreviewNavigationButton renders correctly within a TooltipProvider", () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(
+        TooltipProvider,
+        {},
+        React.createElement(
+          WebPreviewNavigationButton,
+          { tooltip: "Web Tooltip" },
+          "Web"
+        )
+      )
+    );
+    expect(markup).toContain("Web");
+    expect(markup).toContain('data-slot="tooltip-trigger"');
+  });
+});

--- a/apps/hyperlocalise-web/src/components/ai-elements/tooltip-provider.test.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/tooltip-provider.test.ts
@@ -15,9 +15,9 @@ describe("Tooltip Redundancy Optimization", () => {
         React.createElement(
           MessageAction,
           { tooltip: "Test Tooltip", label: "Test Label" },
-          "Click me"
-        )
-      )
+          "Click me",
+        ),
+      ),
     );
     // Should contain the button text and the sr-only label
     expect(markup).toContain("Click me");
@@ -34,9 +34,9 @@ describe("Tooltip Redundancy Optimization", () => {
         React.createElement(
           ArtifactAction,
           { tooltip: "Artifact Tooltip", label: "Artifact Label" },
-          "Artifact"
-        )
-      )
+          "Artifact",
+        ),
+      ),
     );
     expect(markup).toContain("Artifact");
     expect(markup).toContain("Artifact Label");
@@ -48,12 +48,8 @@ describe("Tooltip Redundancy Optimization", () => {
       React.createElement(
         TooltipProvider,
         {},
-        React.createElement(
-          WebPreviewNavigationButton,
-          { tooltip: "Web Tooltip" },
-          "Web"
-        )
-      )
+        React.createElement(WebPreviewNavigationButton, { tooltip: "Web Tooltip" }, "Web"),
+      ),
     );
     expect(markup).toContain("Web");
     expect(markup).toContain('data-slot="tooltip-trigger"');

--- a/apps/hyperlocalise-web/src/components/ai-elements/web-preview.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/web-preview.tsx
@@ -3,7 +3,7 @@
 import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Input } from "@/components/ui/input";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { ChevronDownIcon } from "lucide-react";
 import type { ComponentProps, ReactNode } from "react";
@@ -95,27 +95,30 @@ export const WebPreviewNavigationButton = ({
   children,
   ...props
 }: WebPreviewNavigationButtonProps) => (
-  <TooltipProvider>
-    <Tooltip>
-      <TooltipTrigger
-        render={
-          <Button
-            className="h-8 w-8 p-0 hover:text-foreground"
-            disabled={disabled}
-            onClick={onClick}
-            size="sm"
-            variant="ghost"
-            {...props}
-          />
-        }
-      >
-        {children}
-      </TooltipTrigger>
-      <TooltipContent>
-        <TypographyP>{tooltip}</TypographyP>
-      </TooltipContent>
-    </Tooltip>
-  </TooltipProvider>
+  /**
+   * BOLT OPTIMIZATION: Remove redundant TooltipProvider.
+   * RootLayout already provides a TooltipProvider. Local providers add
+   * unnecessary React context overhead and can lead to desynced timers.
+   */
+  <Tooltip>
+    <TooltipTrigger
+      render={
+        <Button
+          className="h-8 w-8 p-0 hover:text-foreground"
+          disabled={disabled}
+          onClick={onClick}
+          size="sm"
+          variant="ghost"
+          {...props}
+        />
+      }
+    >
+      {children}
+    </TooltipTrigger>
+    <TooltipContent>
+      <TypographyP>{tooltip}</TypographyP>
+    </TooltipContent>
+  </Tooltip>
 );
 
 export type WebPreviewUrlProps = ComponentProps<typeof Input>;


### PR DESCRIPTION
This optimization removes redundant `TooltipProvider` instances from several components in the `ai-elements` library. Since a global `TooltipProvider` is already provided in the root `layout.tsx`, these local providers add unnecessary React context overhead, increase the depth of the React tree, and can lead to desynced timers for tooltip delays. By removing them, we streamline the component tree and improve rendering efficiency. Verified with 'vp check' and a new unit test.

---
*PR created automatically by Jules for task [293693068629722383](https://jules.google.com/task/293693068629722383) started by @cungminh2710*