### PR TITLE
🎨 Palette: Improve ProjectDialog accessibility and add character counters

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-12 - [Project Form Accessibility & Feedback]
+**Learning:** In `apps/hyperlocalise-web`, the semantic form field pattern (using `Field`, `FieldLabel`, `FieldError`) should be consistently applied to replace basic `<label>` tags. This pattern improves layout consistency and provides a standard hook for accessibility features like `aria-describedby` for character counters.
+**Action:** Always use the `Field` component family for complex forms and ensure supplementary information like character counts are explicitly linked to inputs via unique IDs and ARIA attributes.

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/_components/project-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/_components/project-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type FormEvent, useEffect, useState } from "react";
+import { type FormEvent, useEffect, useId, useState } from "react";
 import { SaveIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { Field, FieldError, FieldLabel } from "@/components/ui/field";
 
 import {
   projectFormHasErrors,
@@ -43,6 +44,12 @@ export function ProjectDialog({
 }) {
   const [values, setValues] = useState<ProjectFormValues>(initialValues);
   const [errors, setErrors] = useState<ProjectFormErrors>({});
+  const nameId = useId();
+  const nameCountId = useId();
+  const descriptionId = useId();
+  const descriptionCountId = useId();
+  const contextId = useId();
+  const contextCountId = useId();
 
   useEffect(() => {
     if (open) {
@@ -82,39 +89,62 @@ export function ProjectDialog({
             <DialogDescription className="text-foreground/52">{description}</DialogDescription>
           </DialogHeader>
           <div className="grid gap-4">
-            <label className="grid gap-2">
-              <span className="text-sm font-medium text-foreground">Name</span>
+            <Field className="gap-1.5">
+              <FieldLabel htmlFor={nameId}>Name</FieldLabel>
               <Input
+                id={nameId}
                 value={values.name}
                 onChange={(event) => {
                   setValues((current) => ({ ...current, name: event.target.value }));
                 }}
                 aria-invalid={Boolean(errors.name)}
+                aria-describedby={nameCountId}
                 disabled={isSaving}
                 placeholder="Marketing site launch"
                 className="border-foreground/10 bg-foreground/6 text-foreground placeholder:text-foreground/32"
               />
-              {errors.name ? <span className="text-xs text-flame-100">{errors.name}</span> : null}
-            </label>
-            <label className="grid gap-2">
-              <span className="text-sm font-medium text-foreground">Description</span>
+              <div className="flex items-center justify-between gap-2">
+                <FieldError errors={errors.name ? [{ message: errors.name }] : undefined} />
+                <span
+                  id={nameCountId}
+                  className="ml-auto tabular-nums text-[10px] font-medium text-foreground/32"
+                >
+                  {values.name.length} / 200
+                </span>
+              </div>
+            </Field>
+
+            <Field className="gap-1.5">
+              <FieldLabel htmlFor={descriptionId}>Description</FieldLabel>
               <Textarea
+                id={descriptionId}
                 value={values.description}
                 onChange={(event) => {
                   setValues((current) => ({ ...current, description: event.target.value }));
                 }}
                 aria-invalid={Boolean(errors.description)}
+                aria-describedby={descriptionCountId}
                 disabled={isSaving}
                 placeholder="Project scope, release, or ownership notes"
                 className="min-h-24 border-foreground/10 bg-foreground/6 text-foreground placeholder:text-foreground/32"
               />
-              {errors.description ? (
-                <span className="text-xs text-flame-100">{errors.description}</span>
-              ) : null}
-            </label>
-            <label className="grid gap-2">
-              <span className="text-sm font-medium text-foreground">Translation context</span>
+              <div className="flex items-center justify-between gap-2">
+                <FieldError
+                  errors={errors.description ? [{ message: errors.description }] : undefined}
+                />
+                <span
+                  id={descriptionCountId}
+                  className="ml-auto tabular-nums text-[10px] font-medium text-foreground/32"
+                >
+                  {values.description.length.toLocaleString()} / 10,000
+                </span>
+              </div>
+            </Field>
+
+            <Field className="gap-1.5">
+              <FieldLabel htmlFor={contextId}>Translation context</FieldLabel>
               <Textarea
+                id={contextId}
                 value={values.translationContext}
                 onChange={(event) => {
                   setValues((current) => ({
@@ -123,14 +153,25 @@ export function ProjectDialog({
                   }));
                 }}
                 aria-invalid={Boolean(errors.translationContext)}
+                aria-describedby={contextCountId}
                 disabled={isSaving}
                 placeholder="Tone, terminology, product rules, or locale guidance"
                 className="min-h-28 border-foreground/10 bg-foreground/6 text-foreground placeholder:text-foreground/32"
               />
-              {errors.translationContext ? (
-                <span className="text-xs text-flame-100">{errors.translationContext}</span>
-              ) : null}
-            </label>
+              <div className="flex items-center justify-between gap-2">
+                <FieldError
+                  errors={
+                    errors.translationContext ? [{ message: errors.translationContext }] : undefined
+                  }
+                />
+                <span
+                  id={contextCountId}
+                  className="ml-auto tabular-nums text-[10px] font-medium text-foreground/32"
+                >
+                  {values.translationContext.length.toLocaleString()} / 20,000
+                </span>
+              </div>
+            </Field>
           </div>
           <DialogFooter>
             <Button


### PR DESCRIPTION
I've implemented a micro-UX improvement for the `ProjectDialog` in `apps/hyperlocalise-web`.

### 💡 What:
- Refactored the project creation/edit form to use standardized semantic components (`Field`, `FieldLabel`, `FieldError`).
- Added character counters to all text inputs (Name, Description, Translation Context) with real-time updates.
- Linked character counters to their respective inputs using `aria-describedby`.

### 🎯 Why:
The previous implementation used basic `<label>` tags and lacked feedback on field length limits, despite the backend having strict validation rules (e.g., 200 chars for names). This improvement helps users stay within limits while filling out the form and makes the interface feel more polished and responsive.

### ♿ Accessibility:
- Replaced implicit labels with explicit `htmlFor` associations using `useId`.
- Added `aria-describedby` to inputs so screen reader users can discover the character limits and current count.
- Used `FieldError` for standardized error reporting that is also accessible.

### 🎨 Visual Polish:
- Used `tabular-nums` for counters to prevent "jitter" when the count changes.
- Consistent spacing and typography using existing design system classes.

---
*PR created automatically by Jules for task [17344304926480646357](https://jules.google.com/task/17344304926480646357) started by @cungminh2710*