### PR TITLE
🛡️ Sentinel: Fix RBAC bypass in chat agent tools

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The API lacked standard security headers (e.g., `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`), leaving it more exposed to MIME-type sniffing, clickjacking, and referrer information leaks.
 **Learning:** Modern web frameworks like Hono often have middleware dedicated to applying these security best practices with minimal configuration, making it easy to implement defense-in-depth.
 **Prevention:** Always apply a `secureHeaders` middleware to the root of the API instance to ensure consistent security policies across all endpoints.
+
+## 2026-05-15 - [High] Broken Function Level Authorization in Agent Tools
+**Vulnerability:** AI-triggered mutation tools (creating jobs, glossaries, TMs) lacked RBAC checks, allowing users with the "member" role to perform administrative actions through the chat agent that were blocked in the equivalent REST API.
+**Learning:** Agent-based tool execution can bypass standard route-level middleware if the tool context does not explicitly carry and check user permissions.
+**Prevention:** Include `membershipRole` in the `ToolContext` passed to all AI tools and enforce `isMutationAllowed` checks (limiting to owner/admin) within the tool execution logic.

--- a/apps/hyperlocalise-web/src/api/routes/agent-slack/agent-slack.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/agent-slack/agent-slack.route.ts
@@ -93,6 +93,8 @@ export function createAgentSlackRoutes() {
           "mpim:history",
           "mpim:read",
           "reactions:read",
+          "users:read",
+          "users:read.email",
         ].join(","),
       );
       url.searchParams.set("redirect_uri", redirectUri);

--- a/apps/hyperlocalise-web/src/api/routes/conversation/chat-stream.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/chat-stream.route.ts
@@ -122,6 +122,7 @@ export function createChatStreamRoutes() {
       const tools = buildTools({
         conversationId,
         organizationId: orgId,
+        membershipRole: c.var.auth.membership.role,
         projectId: conversation.projectId ?? null,
         db,
       });

--- a/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
@@ -280,7 +280,10 @@ describe("handleNewConversation", () => {
       organizationId: "org-123",
       enabled: true,
     } as never);
-    vi.mocked(lookupMembership).mockResolvedValue({ role: "member", localUserId: "user-123" } as never);
+    vi.mocked(lookupMembership).mockResolvedValue({
+      role: "member",
+      localUserId: "user-123",
+    } as never);
     vi.mocked(findInteractionBySourceThreadId).mockResolvedValue(null as never);
     vi.mocked(createInteraction).mockResolvedValue({
       id: "interaction-123",
@@ -322,7 +325,10 @@ describe("handleNewConversation", () => {
       organizationId: "org-123",
       enabled: true,
     } as never);
-    vi.mocked(lookupMembership).mockResolvedValue({ role: "member", localUserId: "user-123" } as never);
+    vi.mocked(lookupMembership).mockResolvedValue({
+      role: "member",
+      localUserId: "user-123",
+    } as never);
     vi.mocked(findInteractionBySourceThreadId).mockResolvedValue({
       id: "interaction-123",
       title: "Existing",
@@ -369,7 +375,10 @@ describe("handleSubscribedMessage", () => {
       organizationId: "org-123",
       enabled: true,
     } as never);
-    vi.mocked(lookupMembership).mockResolvedValue({ role: "member", localUserId: "user-123" } as never);
+    vi.mocked(lookupMembership).mockResolvedValue({
+      role: "member",
+      localUserId: "user-123",
+    } as never);
     vi.mocked(findInteractionBySourceThreadId).mockResolvedValue({
       id: "interaction-123",
       title: "Existing",

--- a/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import type { Message, Thread } from "chat";
 
 import {

--- a/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Message, Thread } from "chat";
 
 import {
@@ -32,6 +32,7 @@ vi.mock("@/lib/tools/registry", () => ({
 
 vi.mock("@/lib/agents/slack/helpers", () => ({
   findSlackConnector: vi.fn(),
+  lookupMembership: vi.fn(),
 }));
 
 vi.mock("@/lib/interactions", () => ({
@@ -78,7 +79,7 @@ vi.mock("@/lib/database", () => {
 });
 
 import { generateText } from "ai";
-import { findSlackConnector } from "@/lib/agents/slack/helpers";
+import { findSlackConnector, lookupMembership } from "@/lib/agents/slack/helpers";
 import {
   addInteractionMessage,
   createInteraction,
@@ -122,6 +123,12 @@ function createThread() {
     subscribe: vi.fn(async () => {
       subscribed = true;
     }),
+    adapter: {
+      getUser: vi.fn(async (userId: string) => ({
+        id: userId,
+        email: "alice@example.com",
+      })),
+    },
   } as unknown as Thread<Record<string, unknown>>;
 
   return { thread, posts, getSubscribed: () => subscribed };
@@ -273,6 +280,7 @@ describe("handleNewConversation", () => {
       organizationId: "org-123",
       enabled: true,
     } as never);
+    vi.mocked(lookupMembership).mockResolvedValue({ role: "member", localUserId: "user-123" } as never);
     vi.mocked(findInteractionBySourceThreadId).mockResolvedValue(null as never);
     vi.mocked(createInteraction).mockResolvedValue({
       id: "interaction-123",
@@ -298,6 +306,7 @@ describe("handleNewConversation", () => {
       interactionId: "interaction-123",
       senderType: "user",
       text: "Help me translate",
+      senderEmail: "alice@example.com",
     });
     expect(getSubscribed()).toBe(true);
     expect(generateText).toHaveBeenCalled();
@@ -313,6 +322,7 @@ describe("handleNewConversation", () => {
       organizationId: "org-123",
       enabled: true,
     } as never);
+    vi.mocked(lookupMembership).mockResolvedValue({ role: "member", localUserId: "user-123" } as never);
     vi.mocked(findInteractionBySourceThreadId).mockResolvedValue({
       id: "interaction-123",
       title: "Existing",
@@ -327,6 +337,7 @@ describe("handleNewConversation", () => {
       interactionId: "interaction-123",
       senderType: "user",
       text: "Follow up",
+      senderEmail: "alice@example.com",
     });
     expect(getSubscribed()).toBe(false);
     expect(generateText).toHaveBeenCalled();
@@ -358,6 +369,7 @@ describe("handleSubscribedMessage", () => {
       organizationId: "org-123",
       enabled: true,
     } as never);
+    vi.mocked(lookupMembership).mockResolvedValue({ role: "member", localUserId: "user-123" } as never);
     vi.mocked(findInteractionBySourceThreadId).mockResolvedValue({
       id: "interaction-123",
       title: "Existing",
@@ -371,6 +383,7 @@ describe("handleSubscribedMessage", () => {
       interactionId: "interaction-123",
       senderType: "user",
       text: "Second message",
+      senderEmail: "alice@example.com",
     });
     expect(generateText).toHaveBeenCalled();
     expect(posts).toEqual(["AI response"]);

--- a/apps/hyperlocalise-web/src/lib/agents/slack/bot.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/bot.ts
@@ -16,7 +16,7 @@ import {
 } from "@/lib/interactions";
 import { buildTools } from "@/lib/tools/registry";
 
-import { findSlackConnector } from "./helpers";
+import { findSlackConnector, lookupMembership } from "./helpers";
 
 type SlackBotState = Record<string, unknown>;
 
@@ -159,10 +159,10 @@ async function loadConversationHistory(interactionId: string) {
 
 async function processSlackMessage(
   thread: Thread<SlackBotState>,
+  message: Message,
   interactionId: string,
   organizationId: string,
   projectId: string | null,
-  userText: string,
 ) {
   try {
     const chatMessages = await loadConversationHistory(interactionId);
@@ -171,15 +171,28 @@ async function processSlackMessage(
     // to ensure we have the freshest text
     const lastUserIndex = chatMessages.findLastIndex((m) => m.role === "user");
     if (lastUserIndex >= 0) {
-      chatMessages[lastUserIndex] = { role: "user", content: userText };
+      chatMessages[lastUserIndex] = { role: "user", content: message.text };
     } else {
-      chatMessages.push({ role: "user", content: userText });
+      chatMessages.push({ role: "user", content: message.text });
+    }
+
+    const slackUser = await thread.adapter.getUser(message.author.userId);
+    const membership = slackUser?.email
+      ? await lookupMembership({ email: slackUser.email, organizationId })
+      : null;
+
+    if (!membership) {
+      await wrapThreadPost(thread, interactionId);
+      await thread.post(
+        "I couldn't verify your account in this Hyperlocalise workspace. Please make sure your Slack email matches your Hyperlocalise account email.",
+      );
+      return;
     }
 
     const tools = buildTools({
       conversationId: interactionId,
       organizationId,
-      membershipRole: "admin", // Slack bot operates as an admin within the org context it is connected to.
+      membershipRole: membership.role,
       projectId,
       db,
     });
@@ -225,10 +238,13 @@ export async function handleNewConversation(thread: Thread<SlackBotState>, messa
     message.text.slice(0, 100) || "Slack conversation",
   );
 
+  const slackUser = await thread.adapter.getUser(message.author.userId);
+
   await addInteractionMessage({
     interactionId: interaction.id,
     senderType: "user",
     text: message.text,
+    senderEmail: slackUser?.email,
   });
 
   if (isNew) {
@@ -238,10 +254,10 @@ export async function handleNewConversation(thread: Thread<SlackBotState>, messa
 
   await processSlackMessage(
     thread,
+    message,
     interaction.id,
     connector.organizationId,
     interaction.projectId,
-    message.text,
   );
 }
 
@@ -266,18 +282,21 @@ export async function handleSubscribedMessage(thread: Thread<SlackBotState>, mes
     message.text.slice(0, 100) || "Slack conversation",
   );
 
+  const slackUser = await thread.adapter.getUser(message.author.userId);
+
   await addInteractionMessage({
     interactionId: interaction.id,
     senderType: "user",
     text: message.text,
+    senderEmail: slackUser?.email,
   });
 
   await processSlackMessage(
     thread,
+    message,
     interaction.id,
     connector.organizationId,
     interaction.projectId,
-    message.text,
   );
 }
 

--- a/apps/hyperlocalise-web/src/lib/agents/slack/bot.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/bot.ts
@@ -179,6 +179,7 @@ async function processSlackMessage(
     const tools = buildTools({
       conversationId: interactionId,
       organizationId,
+      membershipRole: "admin", // Slack bot operates as an admin within the org context it is connected to.
       projectId,
       db,
     });

--- a/apps/hyperlocalise-web/src/lib/agents/slack/bot.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/bot.ts
@@ -3,7 +3,7 @@ import { Chat } from "chat";
 import { createSlackAdapter } from "@chat-adapter/slack";
 import { eq } from "drizzle-orm";
 import { generateText, stepCountIs } from "ai";
-import type { Message, Thread } from "chat";
+import type { Message, Thread, UserInfo } from "chat";
 
 import { createChatStateAdapter } from "@/lib/agents/runtime/state";
 import { db, schema } from "@/lib/database";
@@ -28,6 +28,13 @@ const wrappedThreads = new WeakSet<Thread<SlackBotState>>();
 export function extractTeamId(message: Message): string | null {
   const raw = message.raw as { team_id?: string; team?: string } | undefined;
   return raw?.team_id ?? raw?.team ?? null;
+}
+
+async function getSlackUser(
+  thread: Thread<SlackBotState>,
+  userId: string,
+): Promise<UserInfo | null> {
+  return (await thread.adapter.getUser?.(userId)) ?? null;
 }
 
 export async function wrapThreadPost(thread: Thread<SlackBotState>, interactionId: string) {
@@ -176,7 +183,7 @@ async function processSlackMessage(
       chatMessages.push({ role: "user", content: message.text });
     }
 
-    const slackUser = await thread.adapter.getUser(message.author.userId);
+    const slackUser = await getSlackUser(thread, message.author.userId);
     const membership = slackUser?.email
       ? await lookupMembership({ email: slackUser.email, organizationId })
       : null;
@@ -238,7 +245,7 @@ export async function handleNewConversation(thread: Thread<SlackBotState>, messa
     message.text.slice(0, 100) || "Slack conversation",
   );
 
-  const slackUser = await thread.adapter.getUser(message.author.userId);
+  const slackUser = await getSlackUser(thread, message.author.userId);
 
   await addInteractionMessage({
     interactionId: interaction.id,
@@ -282,7 +289,7 @@ export async function handleSubscribedMessage(thread: Thread<SlackBotState>, mes
     message.text.slice(0, 100) || "Slack conversation",
   );
 
-  const slackUser = await thread.adapter.getUser(message.author.userId);
+  const slackUser = await getSlackUser(thread, message.author.userId);
 
   await addInteractionMessage({
     interactionId: interaction.id,

--- a/apps/hyperlocalise-web/src/lib/agents/slack/helpers.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/helpers.ts
@@ -19,3 +19,22 @@ export async function findSlackConnector(teamId: string, options: { enabledOnly?
 
   return connector ?? null;
 }
+
+export async function lookupMembership(input: { email: string; organizationId: string }) {
+  const [membership] = await db
+    .select({
+      role: schema.organizationMemberships.role,
+      localUserId: schema.users.id,
+    })
+    .from(schema.organizationMemberships)
+    .innerJoin(schema.users, eq(schema.organizationMemberships.userId, schema.users.id))
+    .where(
+      and(
+        eq(schema.organizationMemberships.organizationId, input.organizationId),
+        eq(sql`lower(${schema.users.email})`, input.email.toLowerCase()),
+      ),
+    )
+    .limit(1);
+
+  return membership ?? null;
+}

--- a/apps/hyperlocalise-web/src/lib/tools/glossary-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/glossary-tools.ts
@@ -80,6 +80,13 @@ export function createCreateGlossaryTool(ctx: ToolContext) {
         .describe("BCP-47 target locale tag."),
     }),
     execute: async ({ name, description, sourceLocale, targetLocale }) => {
+      if (ctx.membershipRole !== "owner" && ctx.membershipRole !== "admin") {
+        return {
+          success: false,
+          error: "You do not have permission to create glossaries. Only organization owners and admins can perform this action.",
+        };
+      }
+
       const [glossary] = await ctx.db
         .insert(schema.glossaries)
         .values({
@@ -122,6 +129,13 @@ export function createUpdateGlossaryTool(ctx: ToolContext) {
       status: z.enum(["draft", "active", "archived"]).optional().describe("New status."),
     }),
     execute: async (input) => {
+      if (ctx.membershipRole !== "owner" && ctx.membershipRole !== "admin") {
+        return {
+          success: false,
+          error: "You do not have permission to update glossaries. Only organization owners and admins can perform this action.",
+        };
+      }
+
       const { glossaryId, ...rest } = input;
       const updates = Object.fromEntries(Object.entries(rest).filter(([, v]) => v !== undefined));
 
@@ -156,6 +170,13 @@ export function createDeleteGlossaryTool(ctx: ToolContext) {
       glossaryId: z.string().describe("The glossary ID to delete."),
     }),
     execute: async ({ glossaryId }) => {
+      if (ctx.membershipRole !== "owner" && ctx.membershipRole !== "admin") {
+        return {
+          success: false,
+          error: "You do not have permission to delete glossaries. Only organization owners and admins can perform this action.",
+        };
+      }
+
       const deleted = await ctx.db
         .delete(schema.glossaries)
         .where(
@@ -229,6 +250,13 @@ export function createCreateGlossaryTermTool(ctx: ToolContext) {
       forbidden: z.boolean().default(false).describe("Whether this translation is forbidden."),
     }),
     execute: async (input) => {
+      if (ctx.membershipRole !== "owner" && ctx.membershipRole !== "admin") {
+        return {
+          success: false,
+          error: "You do not have permission to create glossary terms. Only organization owners and admins can perform this action.",
+        };
+      }
+
       const { glossaryId, ...termData } = input;
 
       const glossary = await getOwnedGlossary(ctx.db, ctx.organizationId, glossaryId);
@@ -297,6 +325,13 @@ export function createUpdateGlossaryTermTool(ctx: ToolContext) {
         .describe("New review status."),
     }),
     execute: async (input) => {
+      if (ctx.membershipRole !== "owner" && ctx.membershipRole !== "admin") {
+        return {
+          success: false,
+          error: "You do not have permission to update glossary terms. Only organization owners and admins can perform this action.",
+        };
+      }
+
       const { termId, ...rest } = input;
       const updates = Object.fromEntries(Object.entries(rest).filter(([, v]) => v !== undefined));
 
@@ -334,6 +369,13 @@ export function createDeleteGlossaryTermTool(ctx: ToolContext) {
       termId: z.string().describe("The term ID to delete."),
     }),
     execute: async ({ termId }) => {
+      if (ctx.membershipRole !== "owner" && ctx.membershipRole !== "admin") {
+        return {
+          success: false,
+          error: "You do not have permission to delete glossary terms. Only organization owners and admins can perform this action.",
+        };
+      }
+
       // Verify ownership via the parent glossary.
       const [termWithGlossary] = await ctx.db
         .select({ glossaryOrgId: schema.glossaries.organizationId })

--- a/apps/hyperlocalise-web/src/lib/tools/glossary-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/glossary-tools.ts
@@ -83,7 +83,8 @@ export function createCreateGlossaryTool(ctx: ToolContext) {
       if (ctx.membershipRole !== "owner" && ctx.membershipRole !== "admin") {
         return {
           success: false,
-          error: "You do not have permission to create glossaries. Only organization owners and admins can perform this action.",
+          error:
+            "You do not have permission to create glossaries. Only organization owners and admins can perform this action.",
         };
       }
 
@@ -132,7 +133,8 @@ export function createUpdateGlossaryTool(ctx: ToolContext) {
       if (ctx.membershipRole !== "owner" && ctx.membershipRole !== "admin") {
         return {
           success: false,
-          error: "You do not have permission to update glossaries. Only organization owners and admins can perform this action.",
+          error:
+            "You do not have permission to update glossaries. Only organization owners and admins can perform this action.",
         };
       }
 
@@ -173,7 +175,8 @@ export function createDeleteGlossaryTool(ctx: ToolContext) {
       if (ctx.membershipRole !== "owner" && ctx.membershipRole !== "admin") {
         return {
           success: false,
-          error: "You do not have permission to delete glossaries. Only organization owners and admins can perform this action.",
+          error:
+            "You do not have permission to delete glossaries. Only organization owners and admins can perform this action.",
         };
       }
 
@@ -253,7 +256,8 @@ export function createCreateGlossaryTermTool(ctx: ToolContext) {
       if (ctx.membershipRole !== "owner" && ctx.membershipRole !== "admin") {
         return {
           success: false,
-          error: "You do not have permission to create glossary terms. Only organization owners and admins can perform this action.",
+          error:
+            "You do not have permission to create glossary terms. Only organization owners and admins can perform this action.",
         };
       }
 
@@ -328,7 +332,8 @@ export function createUpdateGlossaryTermTool(ctx: ToolContext) {
       if (ctx.membershipRole !== "owner" && ctx.membershipRole !== "admin") {
         return {
           success: false,
-          error: "You do not have permission to update glossary terms. Only organization owners and admins can perform this action.",
+          error:
+            "You do not have permission to update glossary terms. Only organization owners and admins can perform this action.",
         };
       }
 
@@ -372,7 +377,8 @@ export function createDeleteGlossaryTermTool(ctx: ToolContext) {
       if (ctx.membershipRole !== "owner" && ctx.membershipRole !== "admin") {
         return {
           success: false,
-          error: "You do not have permission to delete glossary terms. Only organization owners and admins can perform this action.",
+          error:
+            "You do not have permission to delete glossary terms. Only organization owners and admins can perform this action.",
         };
       }
 

--- a/apps/hyperlocalise-web/src/lib/tools/interaction-tools.test.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/interaction-tools.test.ts
@@ -53,6 +53,7 @@ async function executeResolveInteractionTool(input: {
   const resolveInteraction = createResolveInteractionTool({
     conversationId: input.conversationId,
     organizationId: input.organizationId,
+    membershipRole: "admin",
     projectId: null,
     db,
   });

--- a/apps/hyperlocalise-web/src/lib/tools/job-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/job-tools.ts
@@ -206,7 +206,8 @@ export function createTranslationJobTool(ctx: ToolContext) {
       if (ctx.membershipRole !== "owner" && ctx.membershipRole !== "admin") {
         return {
           success: false,
-          error: "You do not have permission to create translation jobs. Only organization owners and admins can perform this action.",
+          error:
+            "You do not have permission to create translation jobs. Only organization owners and admins can perform this action.",
         };
       }
 

--- a/apps/hyperlocalise-web/src/lib/tools/job-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/job-tools.ts
@@ -203,6 +203,13 @@ export function createTranslationJobTool(ctx: ToolContext) {
         .describe("Optional maximum string length for string jobs."),
     }),
     execute: async (input) => {
+      if (ctx.membershipRole !== "owner" && ctx.membershipRole !== "admin") {
+        return {
+          success: false,
+          error: "You do not have permission to create translation jobs. Only organization owners and admins can perform this action.",
+        };
+      }
+
       if (!ctx.projectId) {
         return {
           success: false,

--- a/apps/hyperlocalise-web/src/lib/tools/memory-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/memory-tools.ts
@@ -65,7 +65,8 @@ export function createCreateTranslationMemoryTool(ctx: ToolContext) {
       if (ctx.membershipRole !== "owner" && ctx.membershipRole !== "admin") {
         return {
           success: false,
-          error: "You do not have permission to create translation memories. Only organization owners and admins can perform this action.",
+          error:
+            "You do not have permission to create translation memories. Only organization owners and admins can perform this action.",
         };
       }
 
@@ -96,7 +97,8 @@ export function createUpdateTranslationMemoryTool(ctx: ToolContext) {
       if (ctx.membershipRole !== "owner" && ctx.membershipRole !== "admin") {
         return {
           success: false,
-          error: "You do not have permission to update translation memories. Only organization owners and admins can perform this action.",
+          error:
+            "You do not have permission to update translation memories. Only organization owners and admins can perform this action.",
         };
       }
 
@@ -137,7 +139,8 @@ export function createDeleteTranslationMemoryTool(ctx: ToolContext) {
       if (ctx.membershipRole !== "owner" && ctx.membershipRole !== "admin") {
         return {
           success: false,
-          error: "You do not have permission to delete translation memories. Only organization owners and admins can perform this action.",
+          error:
+            "You do not have permission to delete translation memories. Only organization owners and admins can perform this action.",
         };
       }
 
@@ -245,7 +248,8 @@ export function createCreateMemoryEntryTool(ctx: ToolContext) {
       if (ctx.membershipRole !== "owner" && ctx.membershipRole !== "admin") {
         return {
           success: false,
-          error: "You do not have permission to create translation memory entries. Only organization owners and admins can perform this action.",
+          error:
+            "You do not have permission to create translation memory entries. Only organization owners and admins can perform this action.",
         };
       }
 
@@ -342,7 +346,8 @@ export function createUpdateMemoryEntryTool(ctx: ToolContext) {
       if (ctx.membershipRole !== "owner" && ctx.membershipRole !== "admin") {
         return {
           success: false,
-          error: "You do not have permission to update translation memory entries. Only organization owners and admins can perform this action.",
+          error:
+            "You do not have permission to update translation memory entries. Only organization owners and admins can perform this action.",
         };
       }
 
@@ -393,7 +398,8 @@ export function createDeleteMemoryEntryTool(ctx: ToolContext) {
       if (ctx.membershipRole !== "owner" && ctx.membershipRole !== "admin") {
         return {
           success: false,
-          error: "You do not have permission to delete translation memory entries. Only organization owners and admins can perform this action.",
+          error:
+            "You do not have permission to delete translation memory entries. Only organization owners and admins can perform this action.",
         };
       }
 

--- a/apps/hyperlocalise-web/src/lib/tools/memory-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/memory-tools.ts
@@ -62,6 +62,13 @@ export function createCreateTranslationMemoryTool(ctx: ToolContext) {
       description: z.string().max(10_000).optional().describe("Optional description."),
     }),
     execute: async ({ name, description }) => {
+      if (ctx.membershipRole !== "owner" && ctx.membershipRole !== "admin") {
+        return {
+          success: false,
+          error: "You do not have permission to create translation memories. Only organization owners and admins can perform this action.",
+        };
+      }
+
       const [memory] = await ctx.db
         .insert(schema.memories)
         .values({
@@ -86,6 +93,13 @@ export function createUpdateTranslationMemoryTool(ctx: ToolContext) {
       status: z.enum(["draft", "active", "archived"]).optional().describe("New status."),
     }),
     execute: async (input) => {
+      if (ctx.membershipRole !== "owner" && ctx.membershipRole !== "admin") {
+        return {
+          success: false,
+          error: "You do not have permission to update translation memories. Only organization owners and admins can perform this action.",
+        };
+      }
+
       const { memoryId, ...rest } = input;
       const updates = Object.fromEntries(Object.entries(rest).filter(([, v]) => v !== undefined));
 
@@ -120,6 +134,13 @@ export function createDeleteTranslationMemoryTool(ctx: ToolContext) {
       memoryId: z.string().describe("The memory ID to delete."),
     }),
     execute: async ({ memoryId }) => {
+      if (ctx.membershipRole !== "owner" && ctx.membershipRole !== "admin") {
+        return {
+          success: false,
+          error: "You do not have permission to delete translation memories. Only organization owners and admins can perform this action.",
+        };
+      }
+
       const deleted = await ctx.db
         .delete(schema.memories)
         .where(
@@ -221,6 +242,13 @@ export function createCreateMemoryEntryTool(ctx: ToolContext) {
       externalKey: z.string().optional().describe("Optional external identifier."),
     }),
     execute: async (input) => {
+      if (ctx.membershipRole !== "owner" && ctx.membershipRole !== "admin") {
+        return {
+          success: false,
+          error: "You do not have permission to create translation memory entries. Only organization owners and admins can perform this action.",
+        };
+      }
+
       const { memoryId, ...entryData } = input;
 
       const memory = await getOwnedMemory(ctx.db, ctx.organizationId, memoryId);
@@ -311,6 +339,13 @@ export function createUpdateMemoryEntryTool(ctx: ToolContext) {
         .describe("New review status."),
     }),
     execute: async (input) => {
+      if (ctx.membershipRole !== "owner" && ctx.membershipRole !== "admin") {
+        return {
+          success: false,
+          error: "You do not have permission to update translation memory entries. Only organization owners and admins can perform this action.",
+        };
+      }
+
       const { entryId, sourceText, ...rest } = input;
       const updates: Record<string, unknown> = Object.fromEntries(
         Object.entries(rest).filter(([, v]) => v !== undefined),
@@ -355,6 +390,13 @@ export function createDeleteMemoryEntryTool(ctx: ToolContext) {
       entryId: z.string().describe("The entry ID to delete."),
     }),
     execute: async ({ entryId }) => {
+      if (ctx.membershipRole !== "owner" && ctx.membershipRole !== "admin") {
+        return {
+          success: false,
+          error: "You do not have permission to delete translation memory entries. Only organization owners and admins can perform this action.",
+        };
+      }
+
       // Verify ownership via the parent memory.
       const [entryWithMemory] = await ctx.db
         .select({ memoryOrgId: schema.memories.organizationId })

--- a/apps/hyperlocalise-web/src/lib/tools/rbac.test.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/rbac.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vite-plus/test";
+import { describe, expect, it, vi } from "vitest";
 
 // Mock environment and database before importing tools
 vi.mock("@/lib/env", () => ({

--- a/apps/hyperlocalise-web/src/lib/tools/rbac.test.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/rbac.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 vi.mock("@/lib/env", () => ({
   env: {
     DATABASE_URL: "postgres://localhost:5432/test",
-  }
+  },
 }));
 
 vi.mock("@/lib/database", () => ({
@@ -12,8 +12,8 @@ vi.mock("@/lib/database", () => ({
     transaction: vi.fn(),
     insert: vi.fn(() => ({
       values: vi.fn(() => ({
-        returning: vi.fn(() => [{ id: "job_123" }])
-      }))
+        returning: vi.fn(() => [{ id: "job_123" }]),
+      })),
     })),
   },
   schema: {
@@ -23,12 +23,20 @@ vi.mock("@/lib/database", () => ({
     glossaryTerms: { id: "glossaryTerms" },
     memories: { id: "memories" },
     memoryEntries: { id: "memoryEntries" },
-  }
+  },
 }));
 
 import { createTranslationJobTool } from "./job-tools";
-import { createCreateGlossaryTool, createUpdateGlossaryTool, createDeleteGlossaryTool } from "./glossary-tools";
-import { createCreateTranslationMemoryTool, createUpdateTranslationMemoryTool, createDeleteTranslationMemoryTool } from "./memory-tools";
+import {
+  createCreateGlossaryTool,
+  createUpdateGlossaryTool,
+  createDeleteGlossaryTool,
+} from "./glossary-tools";
+import {
+  createCreateTranslationMemoryTool,
+  createUpdateTranslationMemoryTool,
+  createDeleteTranslationMemoryTool,
+} from "./memory-tools";
 import type { ToolContext } from "./types";
 
 describe("Agent Tools RBAC", () => {
@@ -38,111 +46,120 @@ describe("Agent Tools RBAC", () => {
     membershipRole: role,
     projectId: "project_123",
     db: {
-        transaction: vi.fn(async (cb) => cb({
-            insert: vi.fn(() => ({
-                values: vi.fn(() => ({
-                    returning: vi.fn(() => [{ id: "mutated_123" }])
-                }))
-            })),
-            update: vi.fn(() => ({
-                set: vi.fn(() => ({
-                    where: vi.fn(() => ({
-                        returning: vi.fn(() => [{ id: "mutated_123" }])
-                    }))
-                }))
-            })),
-            delete: vi.fn(() => ({
-                where: vi.fn(() => ({
-                    returning: vi.fn(() => [{ id: "mutated_123" }])
-                }))
-            })),
-        })),
-        insert: vi.fn(() => ({
+      transaction: vi.fn(async (cb) =>
+        cb({
+          insert: vi.fn(() => ({
             values: vi.fn(() => ({
-                returning: vi.fn(() => [{ id: "mutated_123" }])
-            }))
-        })),
-        update: vi.fn(() => ({
+              returning: vi.fn(() => [{ id: "mutated_123" }]),
+            })),
+          })),
+          update: vi.fn(() => ({
             set: vi.fn(() => ({
-                where: vi.fn(() => ({
-                    returning: vi.fn(() => [{ id: "mutated_123" }])
-                }))
-            }))
-        })),
-        delete: vi.fn(() => ({
+              where: vi.fn(() => ({
+                returning: vi.fn(() => [{ id: "mutated_123" }]),
+              })),
+            })),
+          })),
+          delete: vi.fn(() => ({
             where: vi.fn(() => ({
-                returning: vi.fn(() => [{ id: "mutated_123" }])
-            }))
+              returning: vi.fn(() => [{ id: "mutated_123" }]),
+            })),
+          })),
+        }),
+      ),
+      insert: vi.fn(() => ({
+        values: vi.fn(() => ({
+          returning: vi.fn(() => [{ id: "mutated_123" }]),
         })),
+      })),
+      update: vi.fn(() => ({
+        set: vi.fn(() => ({
+          where: vi.fn(() => ({
+            returning: vi.fn(() => [{ id: "mutated_123" }]),
+          })),
+        })),
+      })),
+      delete: vi.fn(() => ({
+        where: vi.fn(() => ({
+          returning: vi.fn(() => [{ id: "mutated_123" }]),
+        })),
+      })),
     } as any,
   });
 
   const toolCallInfo = { toolCallId: "test-tool-call", messages: [] };
 
+  async function executeTool(tool: any, input: any) {
+    if (!tool.execute) {
+      throw new Error("Tool is missing execute");
+    }
+    return tool.execute(input, toolCallInfo);
+  }
+
   describe("Translation Job Tools", () => {
     it("denies access to members", async () => {
       const tool = createTranslationJobTool(mockCtx("member"));
-      const result = await tool.execute({
+      const result = await executeTool(tool, {
         type: "string",
         sourceText: "hello",
         sourceLocale: "en",
         targetLocales: ["fr"],
-      }, toolCallInfo);
+      });
       expect(result.success).toBe(false);
       expect(result.error).toContain("permission");
     });
 
     it("allows access to admins", async () => {
-        const tool = createTranslationJobTool(mockCtx("admin"));
-        const result = await tool.execute({
-          type: "string",
-          sourceText: "hello",
-          sourceLocale: "en",
-          targetLocales: ["fr"],
-        }, toolCallInfo);
-        // It fails later because of enqueuing/db, but we check that it didn't fail at the RBAC check
-        expect(result.error).not.toContain("permission");
+      const tool = createTranslationJobTool(mockCtx("admin"));
+      const result = await executeTool(tool, {
+        type: "string",
+        sourceText: "hello",
+        sourceLocale: "en",
+        targetLocales: ["fr"],
       });
+      // It fails later because of enqueuing/db, but we check that it didn't fail at the RBAC check
+      expect(result.error).not.toContain("permission");
+    });
   });
 
   describe("Glossary Tools", () => {
     it("denies create access to members", async () => {
       const tool = createCreateGlossaryTool(mockCtx("member"));
-      const result = await tool.execute({
+      const result = await executeTool(tool, {
         name: "Test",
         sourceLocale: "en",
         targetLocale: "fr",
-      }, toolCallInfo);
+      });
       expect(result.success).toBe(false);
       expect(result.error).toContain("permission");
     });
 
     it("allows create access to owners", async () => {
-        const tool = createCreateGlossaryTool(mockCtx("owner"));
-        const result = await tool.execute({
-          name: "Test",
-          sourceLocale: "en",
-          targetLocale: "fr",
-        }, toolCallInfo);
-        expect(result.success).not.toBe(false);
-        expect(result.error).toBeUndefined();
+      const tool = createCreateGlossaryTool(mockCtx("owner"));
+      const result = await executeTool(tool, {
+        name: "Test",
+        sourceLocale: "en",
+        targetLocale: "fr",
       });
+      expect(result.success).not.toBe(false);
+      expect(result.error).toBeUndefined();
+    });
 
     it("denies update access to members", async () => {
       const tool = createUpdateGlossaryTool(mockCtx("member"));
-      const result = await tool.execute({
+      const result = await executeTool(tool, {
         glossaryId: "g_123",
         name: "New Name",
-      }, toolCallInfo);
+      });
       expect(result.success).toBe(false);
       expect(result.error).toContain("permission");
     });
 
     it("denies delete access to members", async () => {
       const tool = createDeleteGlossaryTool(mockCtx("member"));
-      const result = await tool.execute({
+      const result = await executeTool(tool, {
         glossaryId: "g_123",
-      }, toolCallInfo);
+      });
       expect(result.success).toBe(false);
       expect(result.error).toContain("permission");
     });
@@ -151,28 +168,28 @@ describe("Agent Tools RBAC", () => {
   describe("Translation Memory Tools", () => {
     it("denies create access to members", async () => {
       const tool = createCreateTranslationMemoryTool(mockCtx("member"));
-      const result = await tool.execute({
+      const result = await executeTool(tool, {
         name: "Test",
-      }, toolCallInfo);
+      });
       expect(result.success).toBe(false);
       expect(result.error).toContain("permission");
     });
 
     it("denies update access to members", async () => {
       const tool = createUpdateTranslationMemoryTool(mockCtx("member"));
-      const result = await tool.execute({
+      const result = await executeTool(tool, {
         memoryId: "m_123",
         name: "New Name",
-      }, toolCallInfo);
+      });
       expect(result.success).toBe(false);
       expect(result.error).toContain("permission");
     });
 
     it("denies delete access to members", async () => {
       const tool = createDeleteTranslationMemoryTool(mockCtx("member"));
-      const result = await tool.execute({
+      const result = await executeTool(tool, {
         memoryId: "m_123",
-      }, toolCallInfo);
+      });
       expect(result.success).toBe(false);
       expect(result.error).toContain("permission");
     });

--- a/apps/hyperlocalise-web/src/lib/tools/rbac.test.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/rbac.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Mock environment and database before importing tools
+vi.mock("@/lib/env", () => ({
+  env: {
+    DATABASE_URL: "postgres://localhost:5432/test",
+  }
+}));
+
+vi.mock("@/lib/database", () => ({
+  db: {
+    transaction: vi.fn(),
+    insert: vi.fn(() => ({
+      values: vi.fn(() => ({
+        returning: vi.fn(() => [{ id: "job_123" }])
+      }))
+    })),
+  },
+  schema: {
+    jobs: { id: "jobs" },
+    translationJobDetails: { jobId: "jobId" },
+    glossaries: { id: "glossaries" },
+    glossaryTerms: { id: "glossaryTerms" },
+    memories: { id: "memories" },
+    memoryEntries: { id: "memoryEntries" },
+  }
+}));
+
+import { createTranslationJobTool } from "./job-tools";
+import { createCreateGlossaryTool, createUpdateGlossaryTool, createDeleteGlossaryTool } from "./glossary-tools";
+import { createCreateTranslationMemoryTool, createUpdateTranslationMemoryTool, createDeleteTranslationMemoryTool } from "./memory-tools";
+import type { ToolContext } from "./types";
+
+describe("Agent Tools RBAC", () => {
+  const mockCtx = (role: "owner" | "admin" | "member"): ToolContext => ({
+    conversationId: "conv_123",
+    organizationId: "org_123",
+    membershipRole: role,
+    projectId: "project_123",
+    db: {
+        transaction: vi.fn(async (cb) => cb({
+            insert: vi.fn(() => ({
+                values: vi.fn(() => ({
+                    returning: vi.fn(() => [{ id: "mutated_123" }])
+                }))
+            })),
+            update: vi.fn(() => ({
+                set: vi.fn(() => ({
+                    where: vi.fn(() => ({
+                        returning: vi.fn(() => [{ id: "mutated_123" }])
+                    }))
+                }))
+            })),
+            delete: vi.fn(() => ({
+                where: vi.fn(() => ({
+                    returning: vi.fn(() => [{ id: "mutated_123" }])
+                }))
+            })),
+        })),
+        insert: vi.fn(() => ({
+            values: vi.fn(() => ({
+                returning: vi.fn(() => [{ id: "mutated_123" }])
+            }))
+        })),
+        update: vi.fn(() => ({
+            set: vi.fn(() => ({
+                where: vi.fn(() => ({
+                    returning: vi.fn(() => [{ id: "mutated_123" }])
+                }))
+            }))
+        })),
+        delete: vi.fn(() => ({
+            where: vi.fn(() => ({
+                returning: vi.fn(() => [{ id: "mutated_123" }])
+            }))
+        })),
+    } as any,
+  });
+
+  const toolCallInfo = { toolCallId: "test-tool-call", messages: [] };
+
+  describe("Translation Job Tools", () => {
+    it("denies access to members", async () => {
+      const tool = createTranslationJobTool(mockCtx("member"));
+      const result = await tool.execute({
+        type: "string",
+        sourceText: "hello",
+        sourceLocale: "en",
+        targetLocales: ["fr"],
+      }, toolCallInfo);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("permission");
+    });
+
+    it("allows access to admins", async () => {
+        const tool = createTranslationJobTool(mockCtx("admin"));
+        const result = await tool.execute({
+          type: "string",
+          sourceText: "hello",
+          sourceLocale: "en",
+          targetLocales: ["fr"],
+        }, toolCallInfo);
+        // It fails later because of enqueuing/db, but we check that it didn't fail at the RBAC check
+        expect(result.error).not.toContain("permission");
+      });
+  });
+
+  describe("Glossary Tools", () => {
+    it("denies create access to members", async () => {
+      const tool = createCreateGlossaryTool(mockCtx("member"));
+      const result = await tool.execute({
+        name: "Test",
+        sourceLocale: "en",
+        targetLocale: "fr",
+      }, toolCallInfo);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("permission");
+    });
+
+    it("allows create access to owners", async () => {
+        const tool = createCreateGlossaryTool(mockCtx("owner"));
+        const result = await tool.execute({
+          name: "Test",
+          sourceLocale: "en",
+          targetLocale: "fr",
+        }, toolCallInfo);
+        expect(result.success).not.toBe(false);
+        expect(result.error).toBeUndefined();
+      });
+
+    it("denies update access to members", async () => {
+      const tool = createUpdateGlossaryTool(mockCtx("member"));
+      const result = await tool.execute({
+        glossaryId: "g_123",
+        name: "New Name",
+      }, toolCallInfo);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("permission");
+    });
+
+    it("denies delete access to members", async () => {
+      const tool = createDeleteGlossaryTool(mockCtx("member"));
+      const result = await tool.execute({
+        glossaryId: "g_123",
+      }, toolCallInfo);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("permission");
+    });
+  });
+
+  describe("Translation Memory Tools", () => {
+    it("denies create access to members", async () => {
+      const tool = createCreateTranslationMemoryTool(mockCtx("member"));
+      const result = await tool.execute({
+        name: "Test",
+      }, toolCallInfo);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("permission");
+    });
+
+    it("denies update access to members", async () => {
+      const tool = createUpdateTranslationMemoryTool(mockCtx("member"));
+      const result = await tool.execute({
+        memoryId: "m_123",
+        name: "New Name",
+      }, toolCallInfo);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("permission");
+    });
+
+    it("denies delete access to members", async () => {
+      const tool = createDeleteTranslationMemoryTool(mockCtx("member"));
+      const result = await tool.execute({
+        memoryId: "m_123",
+      }, toolCallInfo);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("permission");
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/tools/rbac.test.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/rbac.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vite-plus/test";
 
 // Mock environment and database before importing tools
 vi.mock("@/lib/env", () => ({

--- a/apps/hyperlocalise-web/src/lib/tools/types.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/types.ts
@@ -1,4 +1,5 @@
 import type { db } from "@/lib/database";
+import type { OrganizationMembershipRole } from "@/lib/database/types";
 
 /**
  * Request-scoped context passed to every chat tool.
@@ -9,6 +10,7 @@ import type { db } from "@/lib/database";
 export type ToolContext = {
   conversationId: string;
   organizationId: string;
+  membershipRole: OrganizationMembershipRole;
   projectId: string | null;
   db: typeof db;
 };


### PR DESCRIPTION
I have identified and fixed a high-severity security issue where organization members could bypass Role-Based Access Control (RBAC) by using the AI agent to perform administrative mutations.

Previously, tools for creating translation jobs, glossaries, and translation memories did not check the user's role, whereas the equivalent REST API restricted these actions to "owner" and "admin" roles.

I have:
1.  **Updated `ToolContext`**: Added `membershipRole` to the context passed to all agent tools.
2.  **Instrumented Chat Stream**: Ensured the authenticated user's role is passed into the tool context when the chat agent is initialized.
3.  **Hardened Tools**: Added explicit checks in `job-tools.ts`, `glossary-tools.ts`, and `memory-tools.ts` to return an error if a "member" attempts to execute a mutation tool.
4.  **Added Verification Tests**: Created `rbac.test.ts` which mocks different roles and verifies that "member" access is correctly denied while "owner"/"admin" access is preserved.

This fix ensures that the AI agent respects the same authorization policies as the rest of the application.

---
*PR created automatically by Jules for task [13340335579163263001](https://jules.google.com/task/13340335579163263001) started by @cungminh2710*