### PR TITLE
feat(cli): add Smartling source download command

### DIFF
--- a/apps/cli/cmd/smartling.go
+++ b/apps/cli/cmd/smartling.go
@@ -95,7 +95,7 @@ func newSmartlingDownloadSourcesCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&o.projectID, "project-id", "", "Smartling project ID")
-	cmd.Flags().StringVar(&o.sourceLocale, "source-locale", "", "Smartling source locale ID")
+	cmd.Flags().StringVar(&o.sourceLocale, "source-locale", "", "deprecated; Smartling source downloads use the project source locale")
 	cmd.Flags().StringVar(&o.fileURI, "file-uri", "", "Smartling file URI")
 	cmd.Flags().StringVarP(&o.output, "output", "o", "", "output file path; omit or use - for stdout")
 	cmd.Flags().StringVar(&o.userIdentifier, "user-id", "", "Smartling user identifier")
@@ -104,8 +104,8 @@ func newSmartlingDownloadSourcesCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&o.force, "force", false, "overwrite an existing output file")
 	cmd.Flags().BoolVar(&o.dryRun, "dry-run", false, "preview command without downloading content")
 	_ = cmd.MarkFlagRequired("project-id")
-	_ = cmd.MarkFlagRequired("source-locale")
 	_ = cmd.MarkFlagRequired("file-uri")
+	_ = cmd.Flags().MarkDeprecated("source-locale", "Smartling source downloads use the project source locale; omit this flag")
 	return cmd
 }
 
@@ -138,9 +138,6 @@ func executeSmartlingDownloadSources(cmd *cobra.Command, o smartlingDownloadSour
 	if strings.TrimSpace(o.projectID) == "" {
 		return fmt.Errorf("smartling download sources: --project-id is required")
 	}
-	if strings.TrimSpace(o.sourceLocale) == "" {
-		return fmt.Errorf("smartling download sources: --source-locale is required")
-	}
 	if strings.TrimSpace(o.fileURI) == "" {
 		return fmt.Errorf("smartling download sources: --file-uri is required")
 	}
@@ -151,7 +148,7 @@ func executeSmartlingDownloadSources(cmd *cobra.Command, o smartlingDownloadSour
 		if destination == "" {
 			destination = "-"
 		}
-		_, err := fmt.Fprintf(cmd.OutOrStdout(), "dry-run action=smartling-download-sources project_id=%s source_locale=%s file_uri=%s output=%s\n", strings.TrimSpace(o.projectID), strings.TrimSpace(o.sourceLocale), strings.TrimSpace(o.fileURI), destination)
+		_, err := fmt.Fprintf(cmd.OutOrStdout(), "dry-run action=smartling-download-sources project_id=%s file_uri=%s output=%s\n", strings.TrimSpace(o.projectID), strings.TrimSpace(o.fileURI), destination)
 		return err
 	}
 	if err := validateSmartlingDownloadSourcesOutputPath(outputPath, o.force); err != nil {
@@ -185,9 +182,8 @@ func executeSmartlingDownloadSources(cmd *cobra.Command, o smartlingDownloadSour
 		return err
 	}
 	result, err := client.DownloadSourceFile(backgroundContext(), smartling.SourceDownloadInput{
-		ProjectID:    strings.TrimSpace(o.projectID),
-		FileURI:      strings.TrimSpace(o.fileURI),
-		SourceLocale: strings.TrimSpace(o.sourceLocale),
+		ProjectID: strings.TrimSpace(o.projectID),
+		FileURI:   strings.TrimSpace(o.fileURI),
 	})
 	if err != nil {
 		return fmt.Errorf("smartling download sources: %w", err)
@@ -200,7 +196,7 @@ func executeSmartlingDownloadSources(cmd *cobra.Command, o smartlingDownloadSour
 	if err := writeSmartlingDownloadedSource(outputPath, result.Content, o.force); err != nil {
 		return err
 	}
-	_, err = fmt.Fprintf(cmd.OutOrStdout(), "downloaded file=%s bytes=%d source_locale=%s file_uri=%s\n", outputPath, len(result.Content), result.SourceLocale, result.FileURI)
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "downloaded file=%s bytes=%d file_uri=%s\n", outputPath, len(result.Content), result.FileURI)
 	return err
 }
 

--- a/apps/cli/cmd/smartling.go
+++ b/apps/cli/cmd/smartling.go
@@ -46,21 +46,67 @@ type smartlingDownloadTranslationsOptions struct {
 	dryRun         bool
 }
 
+type smartlingDownloadSourcesOptions struct {
+	projectID      string
+	sourceLocale   string
+	fileURI        string
+	output         string
+	userIdentifier string
+	userSecret     string
+	userSecretEnv  string
+	force          bool
+	dryRun         bool
+}
+
 func newSmartlingDownloadCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "download",
 		Short: "download files from Smartling",
 	}
+	cmd.AddCommand(newSmartlingDownloadSourcesCmd())
 	cmd.AddCommand(newSmartlingDownloadTranslationsCmd())
 	return cmd
+}
+
+var newSmartlingSourceDownloader = func(cfg smartling.Config) (smartlingSourceDownloader, error) {
+	return smartling.NewHTTPClient(cfg)
 }
 
 var newSmartlingTranslationDownloader = func(cfg smartling.Config) (smartlingTranslationDownloader, error) {
 	return smartling.NewHTTPClient(cfg)
 }
 
+type smartlingSourceDownloader interface {
+	DownloadSourceFile(context.Context, smartling.SourceDownloadInput) (smartling.SourceDownloadResult, error)
+}
+
 type smartlingTranslationDownloader interface {
 	DownloadTranslationFile(context.Context, smartling.TranslationDownloadInput) (smartling.TranslationDownloadResult, error)
+}
+
+func newSmartlingDownloadSourcesCmd() *cobra.Command {
+	o := smartlingDownloadSourcesOptions{}
+	cmd := &cobra.Command{
+		Use:          "sources",
+		Short:        "download source files from Smartling",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return executeSmartlingDownloadSources(cmd, o)
+		},
+	}
+	cmd.Flags().StringVar(&o.projectID, "project-id", "", "Smartling project ID")
+	cmd.Flags().StringVar(&o.sourceLocale, "source-locale", "", "Smartling source locale ID")
+	cmd.Flags().StringVar(&o.fileURI, "file-uri", "", "Smartling file URI")
+	cmd.Flags().StringVarP(&o.output, "output", "o", "", "output file path; omit or use - for stdout")
+	cmd.Flags().StringVar(&o.userIdentifier, "user-id", "", "Smartling user identifier")
+	cmd.Flags().StringVar(&o.userSecret, "user-secret", "", "Smartling user secret")
+	cmd.Flags().StringVar(&o.userSecretEnv, "user-secret-env", "", "Environment variable for Smartling user secret")
+	cmd.Flags().BoolVar(&o.force, "force", false, "overwrite an existing output file")
+	cmd.Flags().BoolVar(&o.dryRun, "dry-run", false, "preview command without downloading content")
+	_ = cmd.MarkFlagRequired("project-id")
+	_ = cmd.MarkFlagRequired("source-locale")
+	_ = cmd.MarkFlagRequired("file-uri")
+	return cmd
 }
 
 func newSmartlingDownloadTranslationsCmd() *cobra.Command {
@@ -86,6 +132,76 @@ func newSmartlingDownloadTranslationsCmd() *cobra.Command {
 	_ = cmd.MarkFlagRequired("target-locale")
 	_ = cmd.MarkFlagRequired("file-uri")
 	return cmd
+}
+
+func executeSmartlingDownloadSources(cmd *cobra.Command, o smartlingDownloadSourcesOptions) error {
+	if strings.TrimSpace(o.projectID) == "" {
+		return fmt.Errorf("smartling download sources: --project-id is required")
+	}
+	if strings.TrimSpace(o.sourceLocale) == "" {
+		return fmt.Errorf("smartling download sources: --source-locale is required")
+	}
+	if strings.TrimSpace(o.fileURI) == "" {
+		return fmt.Errorf("smartling download sources: --file-uri is required")
+	}
+
+	outputPath := strings.TrimSpace(o.output)
+	if o.dryRun {
+		destination := outputPath
+		if destination == "" {
+			destination = "-"
+		}
+		_, err := fmt.Fprintf(cmd.OutOrStdout(), "dry-run action=smartling-download-sources project_id=%s source_locale=%s file_uri=%s output=%s\n", strings.TrimSpace(o.projectID), strings.TrimSpace(o.sourceLocale), strings.TrimSpace(o.fileURI), destination)
+		return err
+	}
+	if err := validateSmartlingDownloadSourcesOutputPath(outputPath, o.force); err != nil {
+		return err
+	}
+
+	cfg := smartling.Config{
+		ProjectID:      strings.TrimSpace(o.projectID),
+		UserIdentifier: strings.TrimSpace(o.userIdentifier),
+		UserSecret:     strings.TrimSpace(o.userSecret),
+		UserSecretEnv:  strings.TrimSpace(o.userSecretEnv),
+	}
+
+	if cfg.UserSecret == "" {
+		envVar := cfg.UserSecretEnv
+		if envVar == "" {
+			envVar = "SMARTLING_USER_SECRET"
+		}
+		cfg.UserSecret = os.Getenv(envVar)
+	}
+	if cfg.UserIdentifier == "" {
+		cfg.UserIdentifier = os.Getenv("SMARTLING_USER_IDENTIFIER")
+	}
+
+	if cfg.UserIdentifier == "" || cfg.UserSecret == "" {
+		return fmt.Errorf("smartling download sources: credentials are required (via flags or SMARTLING_USER_IDENTIFIER/SMARTLING_USER_SECRET)")
+	}
+
+	client, err := newSmartlingSourceDownloader(cfg)
+	if err != nil {
+		return err
+	}
+	result, err := client.DownloadSourceFile(backgroundContext(), smartling.SourceDownloadInput{
+		ProjectID:    strings.TrimSpace(o.projectID),
+		FileURI:      strings.TrimSpace(o.fileURI),
+		SourceLocale: strings.TrimSpace(o.sourceLocale),
+	})
+	if err != nil {
+		return fmt.Errorf("smartling download sources: %w", err)
+	}
+
+	if outputPath == "" || outputPath == "-" {
+		_, err := cmd.OutOrStdout().Write(result.Content)
+		return err
+	}
+	if err := writeSmartlingDownloadedSource(outputPath, result.Content, o.force); err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "downloaded file=%s bytes=%d source_locale=%s file_uri=%s\n", outputPath, len(result.Content), result.SourceLocale, result.FileURI)
+	return err
 }
 
 func executeSmartlingDownloadTranslations(cmd *cobra.Command, o smartlingDownloadTranslationsOptions) error {
@@ -226,6 +342,23 @@ func validateSmartlingDownloadTranslationsOutputPath(path string, force bool) er
 	return nil
 }
 
+func validateSmartlingDownloadSourcesOutputPath(path string, force bool) error {
+	if path == "" || path == "-" {
+		return nil
+	}
+	if info, err := os.Stat(path); err == nil {
+		if info.IsDir() {
+			return fmt.Errorf("smartling download sources: output file %q is a directory", path)
+		}
+		if !force {
+			return fmt.Errorf("smartling download sources: output file %q already exists; use --force to overwrite", path)
+		}
+	} else if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("smartling download sources: stat output file %q: %w", path, err)
+	}
+	return nil
+}
+
 func writeSmartlingDownloadedTranslation(path string, content []byte, force bool) error {
 	if err := validateSmartlingDownloadTranslationsOutputPath(path, force); err != nil {
 		return err
@@ -256,6 +389,40 @@ func writeSmartlingDownloadedTranslation(path string, content []byte, force bool
 	if err := file.Close(); err != nil {
 		_ = os.Remove(path)
 		return fmt.Errorf("smartling download translations: close output file %q: %w", path, err)
+	}
+	return nil
+}
+
+func writeSmartlingDownloadedSource(path string, content []byte, force bool) error {
+	if err := validateSmartlingDownloadSourcesOutputPath(path, force); err != nil {
+		return err
+	}
+	if path == "" || path == "-" {
+		return fmt.Errorf("smartling download sources: output file path is required")
+	}
+	if dir := filepath.Dir(path); dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("smartling download sources: mkdir output directory: %w", err)
+		}
+	}
+	if force {
+		return writeSmartlingDownloadedFileAtomic("smartling download sources", path, content, 0o644)
+	}
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		if os.IsExist(err) {
+			return fmt.Errorf("smartling download sources: output file %q already exists; use --force to overwrite", path)
+		}
+		return fmt.Errorf("smartling download sources: open output file %q: %w", path, err)
+	}
+	if _, err := file.Write(content); err != nil {
+		_ = file.Close()
+		_ = os.Remove(path)
+		return fmt.Errorf("smartling download sources: write output file %q: %w", path, err)
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(path)
+		return fmt.Errorf("smartling download sources: close output file %q: %w", path, err)
 	}
 	return nil
 }

--- a/apps/cli/cmd/smartling_test.go
+++ b/apps/cli/cmd/smartling_test.go
@@ -126,6 +126,33 @@ func TestSmartlingDownloadTranslationsFlags(t *testing.T) {
 	}
 }
 
+func TestSmartlingDownloadSourcesFlags(t *testing.T) {
+	root := newRootCmd("test")
+	out := &bytes.Buffer{}
+	root.SetOut(out)
+	root.SetErr(out)
+
+	root.SetArgs([]string{"smartling", "download", "sources"})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected error for missing required flags")
+	}
+	if !strings.Contains(err.Error(), "required flag(s)") {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	out.Reset()
+	root.SetArgs([]string{"smartling", "download", "sources", "--help"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("help failed: %v", err)
+	}
+	if !strings.Contains(out.String(), "--project-id") ||
+		!strings.Contains(out.String(), "--source-locale") ||
+		!strings.Contains(out.String(), "--file-uri") {
+		t.Error("help output missing required flags")
+	}
+}
+
 func TestSmartlingDownloadTranslationsDryRun(t *testing.T) {
 	root := newRootCmd("test")
 	out := &bytes.Buffer{}
@@ -150,6 +177,189 @@ func TestSmartlingDownloadTranslationsDryRun(t *testing.T) {
 		!strings.Contains(out.String(), "file_uri=test.json") ||
 		!strings.Contains(out.String(), "output=fr.json") {
 		t.Errorf("unexpected output: %s", out.String())
+	}
+}
+
+func TestSmartlingDownloadSourcesDryRun(t *testing.T) {
+	root := newRootCmd("test")
+	out := &bytes.Buffer{}
+	root.SetOut(out)
+	root.SetErr(out)
+
+	root.SetArgs([]string{
+		"smartling", "download", "sources",
+		"--project-id", "123",
+		"--source-locale", "en",
+		"--file-uri", "test.json",
+		"--output", "en.json",
+		"--dry-run",
+	})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+
+	if !strings.Contains(out.String(), "dry-run action=smartling-download-sources") ||
+		!strings.Contains(out.String(), "source_locale=en") ||
+		!strings.Contains(out.String(), "file_uri=test.json") ||
+		!strings.Contains(out.String(), "output=en.json") {
+		t.Errorf("unexpected output: %s", out.String())
+	}
+}
+
+type fakeSmartlingSourceDownloader struct {
+	result smartling.SourceDownloadResult
+	err    error
+}
+
+func (f *fakeSmartlingSourceDownloader) DownloadSourceFile(_ context.Context, in smartling.SourceDownloadInput) (smartling.SourceDownloadResult, error) {
+	if f.err != nil {
+		return smartling.SourceDownloadResult{}, f.err
+	}
+	if f.result.Content != nil {
+		return f.result, nil
+	}
+	return smartling.SourceDownloadResult{
+		SourceLocale: in.SourceLocale,
+		FileURI:      in.FileURI,
+		Content:      []byte(`{"hello":"Hello"}`),
+	}, nil
+}
+
+func TestSmartlingDownloadSourcesWritesStdout(t *testing.T) {
+	t.Setenv("SMARTLING_USER_IDENTIFIER", "uid")
+	t.Setenv("SMARTLING_USER_SECRET", "secret")
+
+	orig := newSmartlingSourceDownloader
+	newSmartlingSourceDownloader = func(_ smartling.Config) (smartlingSourceDownloader, error) {
+		return &fakeSmartlingSourceDownloader{}, nil
+	}
+	defer func() { newSmartlingSourceDownloader = orig }()
+
+	root := newRootCmd("test")
+	out := &bytes.Buffer{}
+	root.SetOut(out)
+	root.SetErr(out)
+
+	root.SetArgs([]string{
+		"smartling", "download", "sources",
+		"--project-id", "123",
+		"--source-locale", "en",
+		"--file-uri", "test.json",
+	})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+
+	if got := out.String(); got != `{"hello":"Hello"}` {
+		t.Errorf("unexpected stdout content: %s", got)
+	}
+}
+
+func TestSmartlingDownloadSourcesWritesOutputFile(t *testing.T) {
+	t.Setenv("SMARTLING_USER_IDENTIFIER", "uid")
+	t.Setenv("SMARTLING_USER_SECRET", "secret")
+
+	orig := newSmartlingSourceDownloader
+	newSmartlingSourceDownloader = func(_ smartling.Config) (smartlingSourceDownloader, error) {
+		return &fakeSmartlingSourceDownloader{}, nil
+	}
+	defer func() { newSmartlingSourceDownloader = orig }()
+
+	outputPath := filepath.Join(t.TempDir(), "en.json")
+	root := newRootCmd("test")
+	out := &bytes.Buffer{}
+	root.SetOut(out)
+	root.SetErr(out)
+
+	root.SetArgs([]string{
+		"smartling", "download", "sources",
+		"--project-id", "123",
+		"--source-locale", "en",
+		"--file-uri", "test.json",
+		"--output", outputPath,
+	})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+
+	content, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read output file: %v", err)
+	}
+	if string(content) != `{"hello":"Hello"}` {
+		t.Fatalf("unexpected file content: %q", string(content))
+	}
+	if !strings.Contains(out.String(), "downloaded file="+outputPath) ||
+		!strings.Contains(out.String(), "source_locale=en") ||
+		!strings.Contains(out.String(), "file_uri=test.json") {
+		t.Fatalf("unexpected output: %q", out.String())
+	}
+}
+
+func TestSmartlingDownloadSourcesRefusesOverwriteWithoutForce(t *testing.T) {
+	outputPath := filepath.Join(t.TempDir(), "en.json")
+	if err := os.WriteFile(outputPath, []byte(`{"old":"Old"}`), 0o644); err != nil {
+		t.Fatalf("write existing output: %v", err)
+	}
+
+	root := newRootCmd("test")
+	root.SetArgs([]string{
+		"smartling", "download", "sources",
+		"--project-id", "123",
+		"--source-locale", "en",
+		"--file-uri", "test.json",
+		"--output", outputPath,
+	})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected overwrite error")
+	}
+	if !strings.Contains(err.Error(), "already exists; use --force to overwrite") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSmartlingDownloadSourcesForceOverwritesOutputFile(t *testing.T) {
+	t.Setenv("SMARTLING_USER_IDENTIFIER", "uid")
+	t.Setenv("SMARTLING_USER_SECRET", "secret")
+
+	orig := newSmartlingSourceDownloader
+	newSmartlingSourceDownloader = func(_ smartling.Config) (smartlingSourceDownloader, error) {
+		return &fakeSmartlingSourceDownloader{}, nil
+	}
+	defer func() { newSmartlingSourceDownloader = orig }()
+
+	outputPath := filepath.Join(t.TempDir(), "en.json")
+	if err := os.WriteFile(outputPath, []byte(`{"old":"Old"}`), 0o644); err != nil {
+		t.Fatalf("write existing output: %v", err)
+	}
+
+	root := newRootCmd("test")
+	out := &bytes.Buffer{}
+	root.SetOut(out)
+	root.SetErr(out)
+	root.SetArgs([]string{
+		"smartling", "download", "sources",
+		"--project-id", "123",
+		"--source-locale", "en",
+		"--file-uri", "test.json",
+		"--output", outputPath,
+		"--force",
+	})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+	content, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read output file: %v", err)
+	}
+	if string(content) != `{"hello":"Hello"}` {
+		t.Fatalf("unexpected file content: %q", string(content))
 	}
 }
 

--- a/apps/cli/cmd/smartling_test.go
+++ b/apps/cli/cmd/smartling_test.go
@@ -147,9 +147,11 @@ func TestSmartlingDownloadSourcesFlags(t *testing.T) {
 		t.Fatalf("help failed: %v", err)
 	}
 	if !strings.Contains(out.String(), "--project-id") ||
-		!strings.Contains(out.String(), "--source-locale") ||
 		!strings.Contains(out.String(), "--file-uri") {
 		t.Error("help output missing required flags")
+	}
+	if strings.Contains(out.String(), "--source-locale") {
+		t.Error("help output includes unsupported source locale flag")
 	}
 }
 
@@ -189,7 +191,6 @@ func TestSmartlingDownloadSourcesDryRun(t *testing.T) {
 	root.SetArgs([]string{
 		"smartling", "download", "sources",
 		"--project-id", "123",
-		"--source-locale", "en",
 		"--file-uri", "test.json",
 		"--output", "en.json",
 		"--dry-run",
@@ -200,10 +201,37 @@ func TestSmartlingDownloadSourcesDryRun(t *testing.T) {
 	}
 
 	if !strings.Contains(out.String(), "dry-run action=smartling-download-sources") ||
-		!strings.Contains(out.String(), "source_locale=en") ||
 		!strings.Contains(out.String(), "file_uri=test.json") ||
 		!strings.Contains(out.String(), "output=en.json") {
 		t.Errorf("unexpected output: %s", out.String())
+	}
+	if strings.Contains(out.String(), "source_locale=") {
+		t.Errorf("unexpected source locale in output: %s", out.String())
+	}
+}
+
+func TestSmartlingDownloadSourcesSourceLocaleFlagDeprecated(t *testing.T) {
+	root := newRootCmd("test")
+	out := &bytes.Buffer{}
+	root.SetOut(out)
+	root.SetErr(out)
+
+	root.SetArgs([]string{
+		"smartling", "download", "sources",
+		"--project-id", "123",
+		"--source-locale", "fr",
+		"--file-uri", "test.json",
+		"--dry-run",
+	})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+	if !strings.Contains(out.String(), "Flag --source-locale has been deprecated") {
+		t.Errorf("expected deprecated flag warning, got: %s", out.String())
+	}
+	if strings.Contains(out.String(), "source_locale=") {
+		t.Errorf("unexpected source locale in output: %s", out.String())
 	}
 }
 
@@ -220,9 +248,8 @@ func (f *fakeSmartlingSourceDownloader) DownloadSourceFile(_ context.Context, in
 		return f.result, nil
 	}
 	return smartling.SourceDownloadResult{
-		SourceLocale: in.SourceLocale,
-		FileURI:      in.FileURI,
-		Content:      []byte(`{"hello":"Hello"}`),
+		FileURI: in.FileURI,
+		Content: []byte(`{"hello":"Hello"}`),
 	}, nil
 }
 
@@ -244,7 +271,6 @@ func TestSmartlingDownloadSourcesWritesStdout(t *testing.T) {
 	root.SetArgs([]string{
 		"smartling", "download", "sources",
 		"--project-id", "123",
-		"--source-locale", "en",
 		"--file-uri", "test.json",
 	})
 
@@ -276,7 +302,6 @@ func TestSmartlingDownloadSourcesWritesOutputFile(t *testing.T) {
 	root.SetArgs([]string{
 		"smartling", "download", "sources",
 		"--project-id", "123",
-		"--source-locale", "en",
 		"--file-uri", "test.json",
 		"--output", outputPath,
 	})
@@ -293,9 +318,11 @@ func TestSmartlingDownloadSourcesWritesOutputFile(t *testing.T) {
 		t.Fatalf("unexpected file content: %q", string(content))
 	}
 	if !strings.Contains(out.String(), "downloaded file="+outputPath) ||
-		!strings.Contains(out.String(), "source_locale=en") ||
 		!strings.Contains(out.String(), "file_uri=test.json") {
 		t.Fatalf("unexpected output: %q", out.String())
+	}
+	if strings.Contains(out.String(), "source_locale=") {
+		t.Fatalf("unexpected source locale in output: %q", out.String())
 	}
 }
 
@@ -309,7 +336,6 @@ func TestSmartlingDownloadSourcesRefusesOverwriteWithoutForce(t *testing.T) {
 	root.SetArgs([]string{
 		"smartling", "download", "sources",
 		"--project-id", "123",
-		"--source-locale", "en",
 		"--file-uri", "test.json",
 		"--output", outputPath,
 	})
@@ -345,7 +371,6 @@ func TestSmartlingDownloadSourcesForceOverwritesOutputFile(t *testing.T) {
 	root.SetArgs([]string{
 		"smartling", "download", "sources",
 		"--project-id", "123",
-		"--source-locale", "en",
 		"--file-uri", "test.json",
 		"--output", outputPath,
 		"--force",

--- a/internal/i18n/storage/smartling/http_client.go
+++ b/internal/i18n/storage/smartling/http_client.go
@@ -83,16 +83,14 @@ type SourceUploadResult struct {
 
 // SourceDownloadInput contains the parameters for downloading an original source file from Smartling.
 type SourceDownloadInput struct {
-	ProjectID    string
-	FileURI      string
-	SourceLocale string
+	ProjectID string
+	FileURI   string
 }
 
 // SourceDownloadResult contains the results of a source file download from Smartling.
 type SourceDownloadResult struct {
-	SourceLocale string
-	FileURI      string
-	Content      []byte
+	FileURI string
+	Content []byte
 }
 
 // UploadSourceFile uploads a source file to Smartling.
@@ -144,9 +142,6 @@ func (c *HTTPClient) DownloadSourceFile(ctx context.Context, in SourceDownloadIn
 	if strings.TrimSpace(in.FileURI) == "" {
 		return SourceDownloadResult{}, fmt.Errorf("smartling source download: file uri is required")
 	}
-	if strings.TrimSpace(in.SourceLocale) == "" {
-		return SourceDownloadResult{}, fmt.Errorf("smartling source download: source locale is required")
-	}
 
 	token, err := c.accessToken(ctx)
 	if err != nil {
@@ -159,9 +154,8 @@ func (c *HTTPClient) DownloadSourceFile(ctx context.Context, in SourceDownloadIn
 	}
 
 	return SourceDownloadResult{
-		SourceLocale: strings.TrimSpace(in.SourceLocale),
-		FileURI:      strings.TrimSpace(in.FileURI),
-		Content:      content,
+		FileURI: strings.TrimSpace(in.FileURI),
+		Content: content,
 	}, nil
 }
 

--- a/internal/i18n/storage/smartling/http_client.go
+++ b/internal/i18n/storage/smartling/http_client.go
@@ -81,6 +81,20 @@ type SourceUploadResult struct {
 	WordCount   int  `json:"wordCount"`
 }
 
+// SourceDownloadInput contains the parameters for downloading an original source file from Smartling.
+type SourceDownloadInput struct {
+	ProjectID    string
+	FileURI      string
+	SourceLocale string
+}
+
+// SourceDownloadResult contains the results of a source file download from Smartling.
+type SourceDownloadResult struct {
+	SourceLocale string
+	FileURI      string
+	Content      []byte
+}
+
 // UploadSourceFile uploads a source file to Smartling.
 func (c *HTTPClient) UploadSourceFile(ctx context.Context, in SourceUploadInput) (SourceUploadResult, error) {
 	if strings.TrimSpace(in.ProjectID) == "" {
@@ -120,6 +134,35 @@ func (c *HTTPClient) UploadSourceFile(ctx context.Context, in SourceUploadInput)
 	}
 
 	return resp.Data, nil
+}
+
+// DownloadSourceFile downloads the original source file content from Smartling.
+func (c *HTTPClient) DownloadSourceFile(ctx context.Context, in SourceDownloadInput) (SourceDownloadResult, error) {
+	if strings.TrimSpace(in.ProjectID) == "" {
+		return SourceDownloadResult{}, fmt.Errorf("smartling source download: project id is required")
+	}
+	if strings.TrimSpace(in.FileURI) == "" {
+		return SourceDownloadResult{}, fmt.Errorf("smartling source download: file uri is required")
+	}
+	if strings.TrimSpace(in.SourceLocale) == "" {
+		return SourceDownloadResult{}, fmt.Errorf("smartling source download: source locale is required")
+	}
+
+	token, err := c.accessToken(ctx)
+	if err != nil {
+		return SourceDownloadResult{}, err
+	}
+
+	content, err := c.downloadSourceFile(ctx, token, strings.TrimSpace(in.ProjectID), strings.TrimSpace(in.FileURI))
+	if err != nil {
+		return SourceDownloadResult{}, err
+	}
+
+	return SourceDownloadResult{
+		SourceLocale: strings.TrimSpace(in.SourceLocale),
+		FileURI:      strings.TrimSpace(in.FileURI),
+		Content:      content,
+	}, nil
 }
 
 func (c *HTTPClient) uploadMultipart(ctx context.Context, endpoint string, token string, params map[string]string, fileFieldName, filePath string, out any) error {
@@ -505,6 +548,35 @@ func (c *HTTPClient) downloadFile(ctx context.Context, token string, projectID s
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		return nil, fmt.Errorf("download file %s: status %d: %s", locale, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return io.ReadAll(resp.Body)
+}
+
+func (c *HTTPClient) downloadSourceFile(ctx context.Context, token string, projectID string, fileURI string) ([]byte, error) {
+	endpoint := fmt.Sprintf("%s/projects/%s/file", c.filesBaseURL, url.PathEscape(projectID))
+	params := url.Values{}
+	params.Set("fileUri", fileURI)
+	endpoint = endpoint + "?" + params.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("download source file: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return nil, fmt.Errorf("download source file: status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 	return io.ReadAll(resp.Body)
 }

--- a/internal/i18n/storage/smartling/http_client_test.go
+++ b/internal/i18n/storage/smartling/http_client_test.go
@@ -477,14 +477,13 @@ func TestHTTPClientDownloadSourceFile(t *testing.T) {
 		userSecret:     "secret",
 	}
 	result, err := client.DownloadSourceFile(context.Background(), SourceDownloadInput{
-		ProjectID:    "123",
-		SourceLocale: "en",
-		FileURI:      "source.json",
+		ProjectID: "123",
+		FileURI:   "source.json",
 	})
 	if err != nil {
 		t.Fatalf("download source file: %v", err)
 	}
-	if string(result.Content) != `{"hello":"Hello"}` || result.SourceLocale != "en" || result.FileURI != "source.json" {
+	if string(result.Content) != `{"hello":"Hello"}` || result.FileURI != "source.json" {
 		t.Fatalf("unexpected result: %+v", result)
 	}
 }
@@ -510,9 +509,8 @@ func TestHTTPClientDownloadSourceFileAPIError(t *testing.T) {
 		userSecret:     "secret",
 	}
 	_, err := client.DownloadSourceFile(context.Background(), SourceDownloadInput{
-		ProjectID:    "123",
-		SourceLocale: "en",
-		FileURI:      "missing.json",
+		ProjectID: "123",
+		FileURI:   "missing.json",
 	})
 	if err == nil {
 		t.Fatal("expected API error")

--- a/internal/i18n/storage/smartling/http_client_test.go
+++ b/internal/i18n/storage/smartling/http_client_test.go
@@ -447,6 +447,81 @@ func TestHTTPClientUploadSourceFile(t *testing.T) {
 	}
 }
 
+func TestHTTPClientDownloadSourceFile(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/authenticate":
+			_, _ = fmt.Fprint(w, `{"response":{"code":"SUCCESS"},"data":{"accessToken":"token"}}`)
+		case "/projects/123/file":
+			if r.Method != http.MethodGet {
+				t.Fatalf("unexpected method: %s", r.Method)
+			}
+			if got := r.Header.Get("Authorization"); got != "Bearer token" {
+				t.Fatalf("unexpected auth header: %q", got)
+			}
+			if got := r.URL.Query().Get("fileUri"); got != "source.json" {
+				t.Fatalf("unexpected fileUri: %q", got)
+			}
+			_, _ = fmt.Fprint(w, `{"hello":"Hello"}`)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	client := &HTTPClient{
+		authBaseURL:    srv.URL,
+		filesBaseURL:   srv.URL,
+		http:           srv.Client(),
+		userIdentifier: "id",
+		userSecret:     "secret",
+	}
+	result, err := client.DownloadSourceFile(context.Background(), SourceDownloadInput{
+		ProjectID:    "123",
+		SourceLocale: "en",
+		FileURI:      "source.json",
+	})
+	if err != nil {
+		t.Fatalf("download source file: %v", err)
+	}
+	if string(result.Content) != `{"hello":"Hello"}` || result.SourceLocale != "en" || result.FileURI != "source.json" {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+}
+
+func TestHTTPClientDownloadSourceFileAPIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/authenticate":
+			_, _ = fmt.Fprint(w, `{"response":{"code":"SUCCESS"},"data":{"accessToken":"token"}}`)
+		case "/projects/123/file":
+			http.Error(w, "not found", http.StatusNotFound)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	client := &HTTPClient{
+		authBaseURL:    srv.URL,
+		filesBaseURL:   srv.URL,
+		http:           srv.Client(),
+		userIdentifier: "id",
+		userSecret:     "secret",
+	}
+	_, err := client.DownloadSourceFile(context.Background(), SourceDownloadInput{
+		ProjectID:    "123",
+		SourceLocale: "en",
+		FileURI:      "missing.json",
+	})
+	if err == nil {
+		t.Fatal("expected API error")
+	}
+	if !strings.Contains(err.Error(), "status 404") || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestHTTPClientExportFileDownloadsPerLocale(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {


### PR DESCRIPTION
## What changed

- Add `smartling download sources` for downloading original Smartling source file content.
- Add Smartling source download client support using the project file endpoint.
- Support stdout/file output, overwrite protection with `--force`, dry-run output, and existing Smartling credential env/flag behavior.
- Cover command flags, stdout/file output, overwrite behavior, and mocked Smartling API handling.

## How to test

- `go test ./apps/cli/cmd`
- `go test ./internal/i18n/storage/smartling`
- `make fmt`
- `make lint`
- `make test`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
