### PR TITLE
refactor(agents): unify ToolLoopAgent routing

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/conversation/chat-stream.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/chat-stream.route.ts
@@ -1,70 +1,19 @@
-import { openai } from "@ai-sdk/openai";
-import { eq, and } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
-import { streamText } from "ai";
 import { z } from "zod";
 
 import type { AuthVariables } from "@/api/auth/workos";
 import { workosAuthMiddleware } from "@/api/auth/workos";
+import {
+  createConversationToolLoopAgent,
+  loadInteractionModelMessages,
+} from "@/lib/agents/hyperlocalise-agent";
 import { db, schema } from "@/lib/database";
-import { env } from "@/lib/env";
 import { addInteractionMessage } from "@/lib/interactions";
-
-import { buildTools } from "@/lib/tools/registry";
 
 const conversationIdParamsSchema = z.object({
   conversationId: z.uuid(),
 });
-
-function getChatModel() {
-  if (!env.OPENAI_API_KEY) {
-    throw new Error("OPENAI_API_KEY is not configured");
-  }
-  return openai("gpt-5.4-mini");
-}
-
-function buildSystemPrompt(projectId: string | null) {
-  const lines = [
-    "You are Hyperlocalise, an expert localization and translation assistant.",
-    "You help teams translate content, manage glossaries, review translations, and organize localization projects.",
-    "You can answer questions about:",
-    "- Translation strategies and best practices",
-    "- Locale-specific formatting, cultural adaptation, and regional conventions",
-    "- Managing translation workflows, jobs, and project organization",
-    "- Using glossaries and translation memories effectively",
-    "- Quality assurance and review processes for localized content",
-    "",
-    "Project context:",
-  ];
-
-  if (projectId) {
-    lines.push(
-      `- This conversation is attached to project ${projectId}.`,
-      "- Call getProjectContext when you need the project's name, description, translation rules, or attached glossaries and memories.",
-      "- Call updateInteractionProject only if the user explicitly says they want to switch to a different project.",
-    );
-  } else {
-    lines.push(
-      "- This conversation is NOT attached to a project yet.",
-      "- If the user mentions a project by name, call listProjects to find it, then call updateInteractionProject to attach it.",
-      "- If the user asks about translation without mentioning a project, you can still call queryGlossary and queryTranslationMemory org-wide.",
-      "- If a project would help (e.g. the user says 'for the mobile app'), always attach it before translating.",
-    );
-  }
-
-  lines.push(
-    "",
-    "Guidelines:",
-    "- Be concise but thorough in your responses",
-    "- When suggesting translations, consider context, tone, and target audience",
-    "- If you need more information to provide a good answer, ask clarifying questions",
-    "- You can create translation jobs, suggest glossary terms, and inspect existing jobs",
-    "- Review, research, sync, and asset-management jobs are not runnable yet; use the matching unavailable-job tool if a user asks to queue one",
-    "- Always maintain a professional, helpful tone",
-  );
-
-  return lines.join("\n");
-}
 
 export function createChatStreamRoutes() {
   return new Hono<{ Variables: AuthVariables }>()
@@ -78,7 +27,6 @@ export function createChatStreamRoutes() {
       const { conversationId } = paramResult.data;
       const orgId = c.var.auth.activeOrganization.localOrganizationId;
 
-      // Verify conversation exists and belongs to the org
       const [conversation] = await db
         .select({
           id: schema.interactions.id,
@@ -102,38 +50,17 @@ export function createChatStreamRoutes() {
         return c.json({ error: "conversation_not_replyable" }, 400);
       }
 
-      // Load conversation history for context
-      const messages = await db
-        .select({
-          senderType: schema.interactionMessages.senderType,
-          text: schema.interactionMessages.text,
-        })
-        .from(schema.interactionMessages)
-        .where(eq(schema.interactionMessages.interactionId, conversationId))
-        .orderBy(schema.interactionMessages.createdAt)
-        .limit(50);
-
-      // Convert to AI SDK message format
-      const chatMessages = messages.map((msg) => ({
-        role: msg.senderType === "user" ? ("user" as const) : ("assistant" as const),
-        content: msg.text,
-      }));
-
-      const tools = buildTools({
-        conversationId,
-        organizationId: orgId,
-        membershipRole: c.var.auth.membership.role,
-        projectId: conversation.projectId ?? null,
-        db,
-      });
-
-      const result = streamText({
-        model: getChatModel(),
-        system: buildSystemPrompt(conversation.projectId),
-        messages: chatMessages,
-        tools,
+      const chatMessages = await loadInteractionModelMessages(conversationId);
+      const agent = createConversationToolLoopAgent({
+        surface: "web",
+        toolContext: {
+          conversationId,
+          organizationId: orgId,
+          membershipRole: c.var.auth.membership.role,
+          projectId: conversation.projectId ?? null,
+          db,
+        },
         onFinish: async ({ text }) => {
-          // Persist the AI response to the database
           try {
             await addInteractionMessage({
               interactionId: conversationId,
@@ -141,11 +68,12 @@ export function createChatStreamRoutes() {
               text,
             });
           } catch (error) {
-            // Log but don't fail the stream if persistence fails
             console.error("Failed to persist agent message:", error);
           }
         },
       });
+
+      const result = await agent.stream({ messages: chatMessages });
 
       return result.toUIMessageStreamResponse({ sendReasoning: true, sendSources: true });
     });

--- a/apps/hyperlocalise-web/src/api/routes/resend-webhook.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/resend-webhook.test.ts
@@ -27,6 +27,9 @@ vi.mock("@/workflows/adapters", () => ({
   createEmailAgentTaskQueue: vi.fn(() => ({
     enqueue: vi.fn(async () => ({ ids: ["run_123"] })),
   })),
+  createTranslationJobEventQueue: vi.fn(() => ({
+    enqueue: vi.fn(async () => ({ ids: ["run_123"] })),
+  })),
 }));
 
 describe("resendWebhookRoutes", () => {

--- a/apps/hyperlocalise-web/src/lib/agents/email/bot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/email/bot.test.ts
@@ -24,6 +24,9 @@ vi.mock("@/lib/resend/adapter", () => ({
 
 vi.mock("@/workflows/adapters", () => ({
   createEmailAgentTaskQueue: vi.fn(),
+  createTranslationJobEventQueue: vi.fn(() => ({
+    enqueue: vi.fn(async () => ({ ids: ["run_123"] })),
+  })),
 }));
 
 function createThread(initialState: EmailBotState = {}) {

--- a/apps/hyperlocalise-web/src/lib/agents/email/bot.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/email/bot.ts
@@ -716,7 +716,7 @@ export function createEmailHandler(dependencies: EmailHandlerDependencies) {
         }
 
         if (track && conversationId) {
-          await wrapThreadPostForInteraction(thread, conversationId, track.addMessage);
+          wrapThreadPostForInteraction(thread, conversationId, track.addMessage);
         }
 
         log.info("resuming pending clarification");
@@ -786,7 +786,7 @@ export function createEmailHandler(dependencies: EmailHandlerDependencies) {
       }
 
       if (track && conversationId) {
-        await wrapThreadPostForInteraction(thread, conversationId, track.addMessage);
+        wrapThreadPostForInteraction(thread, conversationId, track.addMessage);
       }
 
       const intent = await dependencies.interpretEmailRequest({

--- a/apps/hyperlocalise-web/src/lib/agents/email/bot.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/email/bot.ts
@@ -4,6 +4,7 @@ import type { Message, Thread } from "chat";
 import { and, eq } from "drizzle-orm";
 
 import { createChatStateAdapter } from "@/lib/agents/runtime/state";
+import { wrapThreadPostForInteraction } from "@/lib/agents/runtime/tracking";
 import { db, schema } from "@/lib/database";
 import { env } from "@/lib/env";
 import { createChatLogger, createLogger } from "@/lib/log";
@@ -714,27 +715,9 @@ export function createEmailHandler(dependencies: EmailHandlerDependencies) {
           }
         }
 
-        // Wrap thread.post to also save agent messages
-        const originalPost = thread.post.bind(thread);
-        const trackedPost = async (...args: Parameters<typeof originalPost>) => {
-          const result = await originalPost(...args);
-          if (track && conversationId) {
-            try {
-              const text = typeof args[0] === "string" ? args[0] : "";
-              if (text) {
-                await track.addMessage({
-                  interactionId: conversationId,
-                  senderType: "agent",
-                  text,
-                });
-              }
-            } catch {
-              // Best-effort tracking
-            }
-          }
-          return result;
-        };
-        (thread as { post: typeof trackedPost }).post = trackedPost;
+        if (track && conversationId) {
+          await wrapThreadPostForInteraction(thread, conversationId, track.addMessage);
+        }
 
         log.info("resuming pending clarification");
         await handlePendingClarification({
@@ -802,28 +785,9 @@ export function createEmailHandler(dependencies: EmailHandlerDependencies) {
         }
       }
 
-      // Wrap thread.post to also save agent messages
-      const originalPost = thread.post.bind(thread);
-      const trackedPost = async (...args: Parameters<typeof originalPost>) => {
-        const result = await originalPost(...args);
-        if (track && conversationId) {
-          try {
-            const text = typeof args[0] === "string" ? args[0] : "";
-            if (text) {
-              await track.addMessage({
-                interactionId: conversationId,
-                senderType: "agent",
-                text,
-              });
-            }
-          } catch {
-            // Best-effort tracking
-          }
-        }
-        return result;
-      };
-      // Replace thread.post temporarily for this handler invocation
-      (thread as { post: typeof trackedPost }).post = trackedPost;
+      if (track && conversationId) {
+        await wrapThreadPostForInteraction(thread, conversationId, track.addMessage);
+      }
 
       const intent = await dependencies.interpretEmailRequest({
         subject: raw.subject ?? "",

--- a/apps/hyperlocalise-web/src/lib/agents/email/intent.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/email/intent.ts
@@ -1,8 +1,7 @@
-import { createOpenAI } from "@ai-sdk/openai";
 import { generateText, Output, type LanguageModel } from "ai";
 import { z } from "zod";
 
-import { env } from "@/lib/env";
+import { getHyperlocaliseAgentModel } from "@/lib/agents/hyperlocalise-agent";
 import type { EmailAgentIntentKind } from "./types";
 
 const emailRequestIntentSchema = z.object({
@@ -19,15 +18,6 @@ export type EmailRequestIntent = z.infer<typeof emailRequestIntentSchema>;
 type CreateEmailRequestInterpreterOptions = {
   model: LanguageModel;
 };
-
-function getEmailIntentModel() {
-  if (!env.OPENAI_API_KEY) {
-    throw new Error("OPENAI_API_KEY is not configured");
-  }
-
-  const provider = createOpenAI({ apiKey: env.OPENAI_API_KEY });
-  return provider("gpt-5.4-mini");
-}
 
 export function normalizeLocale(locale: string | null) {
   const value = locale?.trim().replaceAll("_", "-");
@@ -149,7 +139,7 @@ export async function interpretEmailRequest(input: {
   text: string;
 }): Promise<EmailRequestIntent> {
   const interpret = createEmailRequestInterpreter({
-    model: getEmailIntentModel(),
+    model: getHyperlocaliseAgentModel(),
   });
 
   return interpret(input);
@@ -159,7 +149,7 @@ export async function interpretClarificationReply(input: {
   text: string;
 }): Promise<EmailRequestIntent> {
   const interpret = createClarificationInterpreter({
-    model: getEmailIntentModel(),
+    model: getHyperlocaliseAgentModel(),
   });
 
   return interpret(input);

--- a/apps/hyperlocalise-web/src/lib/agents/github/bot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/bot.test.ts
@@ -1,0 +1,235 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import type { Message, Thread } from "chat";
+
+const {
+  addInteractionMessageMock,
+  agentGenerateMock,
+  createHyperlocaliseAgentMock,
+  createInteractionMock,
+  findInteractionBySourceThreadIdMock,
+  loadMessagesMock,
+  selectMock,
+} = vi.hoisted(() => ({
+  addInteractionMessageMock: vi.fn(),
+  agentGenerateMock: vi.fn(),
+  createHyperlocaliseAgentMock: vi.fn((_settings: unknown) => ({
+    generate: agentGenerateMock,
+  })),
+  createInteractionMock: vi.fn(),
+  findInteractionBySourceThreadIdMock: vi.fn(),
+  loadMessagesMock: vi.fn(async () => [{ role: "user", content: "@hyperlocalise fix" }]),
+  selectMock: vi.fn(),
+}));
+
+vi.mock("@/lib/agents/hyperlocalise-agent", () => {
+  return {
+    createHyperlocaliseAgent: createHyperlocaliseAgentMock,
+    loadInteractionModelMessages: loadMessagesMock,
+  };
+});
+
+vi.mock("@/lib/database", () => ({
+  db: {
+    select: selectMock,
+  },
+  schema: {
+    githubInstallations: {
+      githubInstallationId: "githubInstallationId",
+      organizationId: "organizationId",
+    },
+  },
+}));
+
+vi.mock("@/lib/interactions", () => ({
+  addInteractionMessage: addInteractionMessageMock,
+  createInteraction: createInteractionMock,
+  findInteractionBySourceThreadId: findInteractionBySourceThreadIdMock,
+}));
+
+vi.mock("@/lib/agents/runtime/state", () => ({
+  createChatStateAdapter: vi.fn(),
+}));
+
+vi.mock("@/lib/env", () => ({
+  env: {
+    GITHUB_APP_ID: "app_123",
+    GITHUB_APP_PRIVATE_KEY: "private-key",
+    GITHUB_APP_WEBHOOK_SECRET: "secret",
+    OPENAI_API_KEY: "openai-key",
+  },
+}));
+
+import { handleMention } from "./bot";
+
+function createThread() {
+  const addReactionMock = vi.fn(async () => undefined);
+  const posts: unknown[] = [];
+  const setStateMock = vi.fn(async () => undefined);
+  const thread = {
+    id: "github:owner/repo:pull/42",
+    post: vi.fn(async (message: unknown) => {
+      posts.push(message);
+      return { id: "sent_123" };
+    }),
+    setState: setStateMock,
+    adapter: {
+      addReaction: addReactionMock,
+      getInstallationId: vi.fn(async () => "54321"),
+    },
+  } as unknown as Thread<Record<string, unknown>>;
+
+  return { addReactionMock, posts, setStateMock, thread };
+}
+
+function createMessage(input: { text?: string; raw?: Record<string, unknown> } = {}): Message {
+  return {
+    id: "comment_123",
+    threadId: "github:owner/repo:pull/42",
+    text: input.text ?? "@hyperlocalise fix vi",
+    raw:
+      input.raw ??
+      ({
+        type: "pull_request_review_comment",
+        repository: { full_name: "owner/repo" },
+        prNumber: 42,
+        comment: {
+          id: 123,
+          path: "app.ts",
+          line: 10,
+          original_line: 10,
+          side: "RIGHT",
+          commit_id: "abc123",
+        },
+      } satisfies Record<string, unknown>),
+    author: {
+      userId: "octocat",
+      userName: "octocat",
+      fullName: "Octo Cat",
+      isBot: false,
+      isMe: false,
+    },
+    metadata: { dateSent: new Date(), edited: false },
+    formatted: { type: "root", children: [] },
+  } as unknown as Message;
+}
+
+function mockOrganizationLookup(organizationId: string | null) {
+  selectMock.mockReturnValue({
+    from: vi.fn(() => ({
+      where: vi.fn(() => ({
+        limit: vi.fn(async () => (organizationId ? [{ organizationId }] : [])),
+      })),
+    })),
+  });
+}
+
+describe("GitHub command routing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockOrganizationLookup("org_123");
+    agentGenerateMock.mockResolvedValue({ text: "Queued the fix workflow." });
+    addInteractionMessageMock.mockResolvedValue({ id: "msg_123" });
+    findInteractionBySourceThreadIdMock.mockResolvedValue(null);
+    createInteractionMock.mockResolvedValue({
+      id: "interaction_123",
+      title: "owner/repo#42",
+      projectId: null,
+    });
+  });
+
+  it("ignores unknown commands", async () => {
+    const { addReactionMock, thread } = createThread();
+    const queue = { enqueue: vi.fn() };
+
+    await handleMention(thread, createMessage({ text: "@hyperlocalise status" }), { queue });
+
+    expect(createHyperlocaliseAgentMock).not.toHaveBeenCalled();
+    expect(queue.enqueue).not.toHaveBeenCalled();
+    expect(addReactionMock).not.toHaveBeenCalled();
+  });
+
+  it("validates PR context before invoking the agent", async () => {
+    const { posts, thread } = createThread();
+    const queue = { enqueue: vi.fn() };
+
+    await handleMention(
+      thread,
+      createMessage({
+        raw: {
+          type: "issue_comment",
+          threadType: "issue",
+          repository: { full_name: "owner/repo" },
+          prNumber: 42,
+          comment: { id: 123 },
+        },
+      }),
+      { queue },
+    );
+
+    expect(createHyperlocaliseAgentMock).not.toHaveBeenCalled();
+    expect(queue.enqueue).not.toHaveBeenCalled();
+    expect(posts).toEqual([
+      "I can only run `@hyperlocalise fix` from pull request comments or inline pull request review comments.",
+    ]);
+  });
+
+  it("routes fix through a restricted ToolLoopAgent tool", async () => {
+    const { addReactionMock, posts, setStateMock, thread } = createThread();
+    const queue = { enqueue: vi.fn(async () => ({ ids: ["run_123"] })) };
+    createHyperlocaliseAgentMock.mockImplementationOnce((settings: unknown) => {
+      const { tools } = settings as {
+        tools: {
+          enqueueGitHubFix: { execute?: (input: Record<string, never>) => Promise<unknown> };
+        };
+      };
+      return {
+        generate: vi.fn(async () => {
+          await tools.enqueueGitHubFix.execute?.({});
+          return { text: "Queued the fix workflow." };
+        }),
+      };
+    });
+
+    await handleMention(thread, createMessage(), { queue });
+
+    expect(createHyperlocaliseAgentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        surface: "github",
+        projectId: null,
+        activeTools: ["enqueueGitHubFix"],
+      }),
+    );
+    const agentSettings = createHyperlocaliseAgentMock.mock.calls[0]?.[0] as
+      | { tools?: unknown }
+      | undefined;
+    expect(agentSettings?.tools).toEqual(
+      expect.objectContaining({
+        enqueueGitHubFix: expect.objectContaining({
+          description: expect.stringContaining("Queue the validated GitHub"),
+        }),
+      }),
+    );
+    expect(queue.enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repositoryFullName: "owner/repo",
+        pullRequestNumber: 42,
+        scope: expect.objectContaining({
+          type: "review_comment",
+          locale: "vi",
+        }),
+      }),
+    );
+    expect(addReactionMock).toHaveBeenCalledWith(thread.id, "comment_123", expect.anything());
+    expect(setStateMock).toHaveBeenCalledWith({
+      lastFixEvent: expect.objectContaining({
+        repositoryFullName: "owner/repo",
+      }),
+    });
+    expect(addInteractionMessageMock).toHaveBeenCalledWith({
+      interactionId: "interaction_123",
+      senderType: "user",
+      text: "@hyperlocalise fix vi",
+    });
+    expect(posts).toEqual(["Queued the fix workflow."]);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/agents/github/bot.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/bot.ts
@@ -3,7 +3,12 @@ import { createGitHubAdapter } from "@chat-adapter/github";
 import { Chat, emoji } from "chat";
 import type { Message, Thread } from "chat";
 
+import {
+  createHyperlocaliseAgent,
+  loadInteractionModelMessages,
+} from "@/lib/agents/hyperlocalise-agent";
 import { createChatStateAdapter } from "@/lib/agents/runtime/state";
+import { wrapThreadPostForInteraction } from "@/lib/agents/runtime/tracking";
 import { env } from "@/lib/env";
 import {
   addInteractionMessage,
@@ -16,6 +21,7 @@ import type { GitHubFixRequestedEventData, GitHubFixQueue } from "@/lib/workflow
 
 import { parseFixCommand } from "./commands";
 import { buildFixEvent } from "./events";
+import { createGitHubFixTools } from "./tools";
 
 type GitHubBotOptions = {
   githubFixQueue: GitHubFixQueue;
@@ -38,8 +44,24 @@ async function getOrganizationIdByInstallationId(installationId: string) {
   return installation?.organizationId ?? null;
 }
 
-async function handleMention(thread: Thread<GitHubBotState>, message: Message) {
-  const queue = botQueue;
+function buildGitHubFixInstructions(event: GitHubFixRequestedEventData) {
+  return [
+    "The GitHub command router already validated this request.",
+    "Call enqueueGitHubFix exactly once before replying.",
+    "After the tool succeeds, tell the user the fix workflow has been queued.",
+    "",
+    `Repository: ${event.repositoryFullName}`,
+    `Pull request: #${event.pullRequestNumber}`,
+    `Scope: ${event.scope.type}`,
+  ].join("\n");
+}
+
+export async function handleMention(
+  thread: Thread<GitHubBotState>,
+  message: Message,
+  options: { queue?: GitHubFixQueue } = {},
+) {
+  const queue = options.queue ?? botQueue;
   if (!queue) {
     return;
   }
@@ -99,26 +121,7 @@ async function handleMention(thread: Thread<GitHubBotState>, message: Message) {
         text: message.text,
       });
 
-      // Wrap thread.post to track agent replies
-      const originalPost = thread.post.bind(thread);
-      (thread as { post: typeof originalPost }).post = async (
-        ...args: Parameters<typeof originalPost>
-      ) => {
-        const result = await originalPost(...args);
-        try {
-          const text = typeof args[0] === "string" ? args[0] : "";
-          if (text) {
-            await addInteractionMessage({
-              interactionId: conversationId!,
-              senderType: "agent",
-              text,
-            });
-          }
-        } catch {
-          // Best-effort tracking
-        }
-        return result;
-      };
+      await wrapThreadPostForInteraction(thread, conversationId);
     }
   } catch {
     // Best-effort tracking
@@ -126,7 +129,35 @@ async function handleMention(thread: Thread<GitHubBotState>, message: Message) {
 
   await thread.adapter.addReaction(thread.id, message.id, emoji.eyes);
   await thread.setState({ lastFixEvent: event });
-  await queue.enqueue(event);
+
+  const tools = createGitHubFixTools({ event, queue });
+  const agent = createHyperlocaliseAgent({
+    surface: "github",
+    projectId: null,
+    tools,
+    activeTools: ["enqueueGitHubFix"],
+    additionalInstructions: buildGitHubFixInstructions(event),
+    prepareStep: ({ stepNumber }) => {
+      if (stepNumber === 0) {
+        return {
+          activeTools: ["enqueueGitHubFix"],
+          toolChoice: { type: "tool", toolName: "enqueueGitHubFix" },
+        };
+      }
+
+      return {
+        toolChoice: "none",
+      };
+    },
+  });
+  const messages = conversationId
+    ? await loadInteractionModelMessages(conversationId)
+    : [{ role: "user" as const, content: message.text }];
+  const result = await agent.generate({ messages });
+
+  if (result.text.trim()) {
+    await thread.post(result.text);
+  }
 }
 
 export async function getGitHubBot(options: GitHubBotOptions) {
@@ -152,7 +183,7 @@ export async function getGitHubBot(options: GitHubBotOptions) {
     userName: "hyperlocalise",
   });
 
-  botInstance.onNewMention(handleMention);
+  botInstance.onNewMention((thread, message) => handleMention(thread, message));
 
   return botInstance;
 }

--- a/apps/hyperlocalise-web/src/lib/agents/github/bot.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/bot.ts
@@ -121,7 +121,7 @@ export async function handleMention(
         text: message.text,
       });
 
-      await wrapThreadPostForInteraction(thread, conversationId);
+      wrapThreadPostForInteraction(thread, conversationId);
     }
   } catch {
     // Best-effort tracking

--- a/apps/hyperlocalise-web/src/lib/agents/github/tools.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/tools.ts
@@ -1,0 +1,42 @@
+import { tool } from "ai";
+import { z } from "zod";
+
+import type { GitHubFixQueue, GitHubFixRequestedEventData } from "@/lib/workflow/types";
+
+type CreateGitHubFixToolInput = {
+  event: GitHubFixRequestedEventData;
+  queue: GitHubFixQueue;
+};
+
+export function createGitHubFixTools({ event, queue }: CreateGitHubFixToolInput) {
+  let enqueued = false;
+
+  return {
+    enqueueGitHubFix: tool({
+      description:
+        "Queue the validated GitHub pull request fix workflow. This tool must only be used after the command router has validated the GitHub context.",
+      inputSchema: z.object({}),
+      execute: async () => {
+        if (enqueued) {
+          return {
+            success: true,
+            alreadyQueued: true,
+            repository: event.repositoryFullName,
+            pullRequestNumber: event.pullRequestNumber,
+          };
+        }
+
+        enqueued = true;
+        const result = await queue.enqueue(event);
+
+        return {
+          success: true,
+          workflowRunIds: result.ids,
+          repository: event.repositoryFullName,
+          pullRequestNumber: event.pullRequestNumber,
+          scope: event.scope.type,
+        };
+      },
+    }),
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/agents/hyperlocalise-agent.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/hyperlocalise-agent.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const { openaiMock, stepCountIsMock, toolLoopAgentMock, buildToolsMock } = vi.hoisted(() => ({
+  openaiMock: vi.fn(() => "mock-model"),
+  stepCountIsMock: vi.fn((count: number) => ({ stepLimit: count })),
+  toolLoopAgentMock: vi.fn(function ToolLoopAgent(settings: unknown) {
+    return { settings };
+  }),
+  buildToolsMock: vi.fn(() => ({ listProjects: { description: "mock tool" } })),
+}));
+
+vi.mock("@ai-sdk/openai", () => ({
+  openai: openaiMock,
+}));
+
+vi.mock("ai", async () => {
+  const actual = await vi.importActual<typeof import("ai")>("ai");
+
+  return {
+    ...actual,
+    stepCountIs: stepCountIsMock,
+    ToolLoopAgent: toolLoopAgentMock,
+  };
+});
+
+vi.mock("@/lib/env", () => ({
+  env: {
+    OPENAI_API_KEY: "test-openai-key",
+  },
+}));
+
+vi.mock("@/lib/tools/registry", () => ({
+  buildTools: buildToolsMock,
+}));
+
+vi.mock("@/lib/database", () => ({
+  db: {},
+  schema: {
+    interactionMessages: {
+      senderType: "senderType",
+      text: "text",
+      interactionId: "interactionId",
+      createdAt: "createdAt",
+    },
+  },
+}));
+
+import {
+  buildHyperlocaliseAgentInstructions,
+  createConversationToolLoopAgent,
+  createHyperlocaliseAgent,
+  hyperlocaliseAgentStepLimit,
+  replaceLastUserMessage,
+  toModelMessages,
+} from "./hyperlocalise-agent";
+
+describe("hyperlocalise agent core", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("builds project-aware Slack instructions", () => {
+    const instructions = buildHyperlocaliseAgentInstructions({
+      surface: "slack",
+      projectId: "proj_123",
+    });
+
+    expect(instructions).toContain("Slack-friendly");
+    expect(instructions).toContain("This conversation is attached to project proj_123.");
+    expect(instructions).toContain("Call getProjectContext");
+  });
+
+  it("builds missing-project guidance for web conversations", () => {
+    const instructions = buildHyperlocaliseAgentInstructions({
+      surface: "web",
+      projectId: null,
+    });
+
+    expect(instructions).toContain("This conversation is NOT attached to a project yet.");
+    expect(instructions).toContain("call listProjects");
+  });
+
+  it("converts interaction rows to model messages", () => {
+    expect(
+      toModelMessages([
+        { senderType: "user", text: "Hello" },
+        { senderType: "agent", text: "Hi" },
+      ]),
+    ).toEqual([
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Hi" },
+    ]);
+  });
+
+  it("replaces the freshest user message", () => {
+    expect(
+      replaceLastUserMessage(
+        [
+          { role: "user", content: "old" },
+          { role: "assistant", content: "reply" },
+        ],
+        "fresh",
+      ),
+    ).toEqual([
+      { role: "user", content: "fresh" },
+      { role: "assistant", content: "reply" },
+    ]);
+  });
+
+  it("creates a ToolLoopAgent with shared defaults", () => {
+    const tools = { example: { description: "tool" } } as never;
+
+    createHyperlocaliseAgent({
+      surface: "github",
+      projectId: null,
+      tools,
+      activeTools: ["example"],
+    });
+
+    expect(openaiMock).toHaveBeenCalledWith("gpt-5.4-mini");
+    expect(stepCountIsMock).toHaveBeenCalledWith(hyperlocaliseAgentStepLimit);
+    expect(toolLoopAgentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "mock-model",
+        tools,
+        activeTools: ["example"],
+        stopWhen: { stepLimit: 5 },
+      }),
+    );
+  });
+
+  it("builds request-scoped tools for conversational agents", () => {
+    const toolContext = {
+      conversationId: "conv_123",
+      organizationId: "org_123",
+      membershipRole: "admin" as const,
+      projectId: null,
+      db: {} as never,
+    };
+
+    createConversationToolLoopAgent({
+      surface: "web",
+      toolContext,
+    });
+
+    expect(buildToolsMock).toHaveBeenCalledWith(toolContext);
+    expect(toolLoopAgentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tools: { listProjects: { description: "mock tool" } },
+      }),
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/agents/hyperlocalise-agent.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/hyperlocalise-agent.ts
@@ -1,0 +1,194 @@
+import { openai } from "@ai-sdk/openai";
+import { eq } from "drizzle-orm";
+import {
+  stepCountIs,
+  ToolLoopAgent,
+  type LanguageModel,
+  type ModelMessage,
+  type ToolLoopAgentSettings,
+  type ToolSet,
+} from "ai";
+
+import { db, schema } from "@/lib/database";
+import { env } from "@/lib/env";
+import { buildTools } from "@/lib/tools/registry";
+import type { ToolContext } from "@/lib/tools/types";
+
+export const hyperlocaliseAgentModelId = "gpt-5.4-mini";
+export const hyperlocaliseAgentStepLimit = 5;
+
+export type HyperlocaliseAgentSurface = "web" | "slack" | "github";
+
+type InteractionHistoryRow = {
+  senderType: "user" | "agent";
+  text: string;
+};
+
+type CreateHyperlocaliseAgentInput<TOOLS extends ToolSet> = {
+  surface: HyperlocaliseAgentSurface;
+  projectId: string | null;
+  tools: TOOLS;
+  model?: LanguageModel;
+  additionalInstructions?: string;
+  activeTools?: ToolLoopAgentSettings<never, TOOLS>["activeTools"];
+  prepareStep?: ToolLoopAgentSettings<never, TOOLS>["prepareStep"];
+  toolChoice?: ToolLoopAgentSettings<never, TOOLS>["toolChoice"];
+  onFinish?: ToolLoopAgentSettings<never, TOOLS>["onFinish"];
+};
+
+type CreateConversationAgentInput = {
+  surface: HyperlocaliseAgentSurface;
+  toolContext: ToolContext;
+  additionalInstructions?: string;
+  onFinish?: ToolLoopAgentSettings<never, ToolSet>["onFinish"];
+};
+
+export function getHyperlocaliseAgentModel() {
+  if (!env.OPENAI_API_KEY) {
+    throw new Error("OPENAI_API_KEY is not configured");
+  }
+
+  return openai(hyperlocaliseAgentModelId);
+}
+
+export function buildHyperlocaliseAgentInstructions(input: {
+  surface: HyperlocaliseAgentSurface;
+  projectId: string | null;
+  additionalInstructions?: string;
+}) {
+  const lines = [
+    "You are Hyperlocalise, an expert localization and translation assistant.",
+    "You help teams translate content, manage glossaries, review translations, and organize localization projects.",
+  ];
+
+  if (input.surface === "slack") {
+    lines.push(
+      "Keep responses concise and Slack-friendly. Use markdown formatting when it improves readability.",
+    );
+  } else if (input.surface === "github") {
+    lines.push(
+      "Keep GitHub replies concise, concrete, and focused on the requested repository action.",
+    );
+  }
+
+  lines.push(
+    "",
+    "You can answer questions about:",
+    "- Translation strategies and best practices",
+    "- Locale-specific formatting, cultural adaptation, and regional conventions",
+    "- Managing translation workflows, jobs, and project organization",
+    "- Using glossaries and translation memories effectively",
+    "- Quality assurance and review processes for localized content",
+    "",
+    "Project context:",
+  );
+
+  if (input.projectId) {
+    lines.push(
+      `- This conversation is attached to project ${input.projectId}.`,
+      "- Call getProjectContext when you need the project's name, description, translation rules, or attached glossaries and memories.",
+      "- Call updateInteractionProject only if the user explicitly says they want to switch to a different project.",
+    );
+  } else {
+    lines.push(
+      "- This conversation is NOT attached to a project yet.",
+      "- If the user mentions a project by name, call listProjects to find it, then call updateInteractionProject to attach it.",
+      "- If the user asks about translation without mentioning a project, you can still call queryGlossary and queryTranslationMemory org-wide.",
+      "- If a project would help (e.g. the user says 'for the mobile app'), always attach it before translating.",
+    );
+  }
+
+  lines.push(
+    "",
+    "Guidelines:",
+    "- Be concise but thorough. Responses should be scannable.",
+    "- When suggesting translations, consider context, tone, and target audience.",
+    "- If you need more information to provide a good answer, ask clarifying questions.",
+    "- You can create translation jobs, suggest glossary terms, and inspect existing jobs.",
+    "- Review, research, sync, and asset-management jobs are not runnable yet; use the matching unavailable-job tool if a user asks to queue one.",
+    "- Always maintain a professional, helpful tone.",
+    "- If a request is outside your capabilities, give a clear fallback response explaining what you can do instead.",
+  );
+
+  if (input.additionalInstructions?.trim()) {
+    lines.push("", "Surface-specific instructions:", input.additionalInstructions.trim());
+  }
+
+  return lines.join("\n");
+}
+
+export function toModelMessages(rows: InteractionHistoryRow[]): ModelMessage[] {
+  return rows.map((row) => ({
+    role: row.senderType === "user" ? "user" : "assistant",
+    content: row.text,
+  }));
+}
+
+export function replaceLastUserMessage(messages: ModelMessage[], text: string): ModelMessage[] {
+  const nextMessages = [...messages];
+  const lastUserIndex = nextMessages.findLastIndex((message) => message.role === "user");
+
+  if (lastUserIndex >= 0) {
+    nextMessages[lastUserIndex] = { role: "user", content: text };
+    return nextMessages;
+  }
+
+  nextMessages.push({ role: "user", content: text });
+  return nextMessages;
+}
+
+export async function loadInteractionModelMessages(interactionId: string): Promise<ModelMessage[]> {
+  const messages = await db
+    .select({
+      senderType: schema.interactionMessages.senderType,
+      text: schema.interactionMessages.text,
+    })
+    .from(schema.interactionMessages)
+    .where(eq(schema.interactionMessages.interactionId, interactionId))
+    .orderBy(schema.interactionMessages.createdAt)
+    .limit(50);
+
+  return toModelMessages(messages);
+}
+
+export function createHyperlocaliseAgent<TOOLS extends ToolSet>({
+  surface,
+  projectId,
+  tools,
+  model,
+  additionalInstructions,
+  activeTools,
+  prepareStep,
+  toolChoice,
+  onFinish,
+}: CreateHyperlocaliseAgentInput<TOOLS>) {
+  return new ToolLoopAgent({
+    model: model ?? getHyperlocaliseAgentModel(),
+    instructions: buildHyperlocaliseAgentInstructions({
+      surface,
+      projectId,
+      additionalInstructions,
+    }),
+    tools,
+    activeTools,
+    prepareStep,
+    toolChoice,
+    onFinish,
+    stopWhen: stepCountIs(hyperlocaliseAgentStepLimit),
+  });
+}
+
+export function createConversationToolLoopAgent({
+  surface,
+  toolContext,
+  additionalInstructions,
+  onFinish,
+}: CreateConversationAgentInput) {
+  return createHyperlocaliseAgent({
+    surface,
+    projectId: toolContext.projectId,
+    tools: buildTools(toolContext),
+    additionalInstructions,
+    onFinish,
+  });
+}

--- a/apps/hyperlocalise-web/src/lib/agents/runtime/tracking.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/runtime/tracking.test.ts
@@ -28,7 +28,7 @@ describe("wrapThreadPostForInteraction", () => {
     const addMessage = vi.fn(async () => ({ id: "msg_123" }));
     const { thread } = createThread();
 
-    await wrapThreadPostForInteraction(thread, "interaction_123", addMessage);
+    wrapThreadPostForInteraction(thread, "interaction_123", addMessage);
     await thread.post("Agent reply");
 
     expect(addMessage).toHaveBeenCalledWith({
@@ -42,7 +42,7 @@ describe("wrapThreadPostForInteraction", () => {
     const addMessage = vi.fn(async () => ({ id: "msg_123" }));
     const { thread } = createThread();
 
-    await wrapThreadPostForInteraction(thread, "interaction_123", addMessage);
+    wrapThreadPostForInteraction(thread, "interaction_123", addMessage);
     await thread.post({ markdown: "complex" });
 
     expect(addMessage).not.toHaveBeenCalled();
@@ -52,8 +52,8 @@ describe("wrapThreadPostForInteraction", () => {
     const addMessage = vi.fn(async () => ({ id: "msg_123" }));
     const { thread } = createThread();
 
-    await wrapThreadPostForInteraction(thread, "interaction_123", addMessage);
-    await wrapThreadPostForInteraction(thread, "interaction_456", addMessage);
+    wrapThreadPostForInteraction(thread, "interaction_123", addMessage);
+    wrapThreadPostForInteraction(thread, "interaction_456", addMessage);
     await thread.post("Agent reply");
 
     expect(addMessage).toHaveBeenCalledTimes(1);

--- a/apps/hyperlocalise-web/src/lib/agents/runtime/tracking.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/runtime/tracking.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import type { Thread } from "chat";
+
+vi.mock("@/lib/interactions", () => ({
+  addInteractionMessage: vi.fn(),
+}));
+
+import { wrapThreadPostForInteraction } from "./tracking";
+
+function createThread() {
+  const posts: unknown[] = [];
+  const thread = {
+    post: vi.fn(async (message: unknown) => {
+      posts.push(message);
+      return { id: "sent_123" };
+    }),
+  } as unknown as Thread<Record<string, unknown>>;
+
+  return { posts, thread };
+}
+
+describe("wrapThreadPostForInteraction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("persists string agent posts", async () => {
+    const addMessage = vi.fn(async () => ({ id: "msg_123" }));
+    const { thread } = createThread();
+
+    await wrapThreadPostForInteraction(thread, "interaction_123", addMessage);
+    await thread.post("Agent reply");
+
+    expect(addMessage).toHaveBeenCalledWith({
+      interactionId: "interaction_123",
+      senderType: "agent",
+      text: "Agent reply",
+    });
+  });
+
+  it("does not persist non-string posts", async () => {
+    const addMessage = vi.fn(async () => ({ id: "msg_123" }));
+    const { thread } = createThread();
+
+    await wrapThreadPostForInteraction(thread, "interaction_123", addMessage);
+    await thread.post({ markdown: "complex" });
+
+    expect(addMessage).not.toHaveBeenCalled();
+  });
+
+  it("updates the tracked interaction without double wrapping", async () => {
+    const addMessage = vi.fn(async () => ({ id: "msg_123" }));
+    const { thread } = createThread();
+
+    await wrapThreadPostForInteraction(thread, "interaction_123", addMessage);
+    await wrapThreadPostForInteraction(thread, "interaction_456", addMessage);
+    await thread.post("Agent reply");
+
+    expect(addMessage).toHaveBeenCalledTimes(1);
+    expect(addMessage).toHaveBeenCalledWith({
+      interactionId: "interaction_456",
+      senderType: "agent",
+      text: "Agent reply",
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/agents/runtime/tracking.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/runtime/tracking.ts
@@ -15,7 +15,7 @@ type TrackedPostState = {
 
 const trackedThreadPosts = new WeakMap<object, TrackedPostState>();
 
-export async function wrapThreadPostForInteraction<TState>(
+export function wrapThreadPostForInteraction<TState>(
   thread: Thread<TState>,
   interactionId: string,
   addMessage: AddAgentMessage = addInteractionMessage,

--- a/apps/hyperlocalise-web/src/lib/agents/runtime/tracking.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/runtime/tracking.ts
@@ -1,0 +1,53 @@
+import type { Thread } from "chat";
+
+import { addInteractionMessage } from "@/lib/interactions";
+
+type AddAgentMessage = (input: {
+  interactionId: string;
+  senderType: "agent";
+  text: string;
+}) => Promise<unknown>;
+
+type TrackedPostState = {
+  addMessage: AddAgentMessage;
+  interactionId: string;
+};
+
+const trackedThreadPosts = new WeakMap<object, TrackedPostState>();
+
+export async function wrapThreadPostForInteraction<TState>(
+  thread: Thread<TState>,
+  interactionId: string,
+  addMessage: AddAgentMessage = addInteractionMessage,
+) {
+  const existing = trackedThreadPosts.get(thread);
+  if (existing) {
+    existing.interactionId = interactionId;
+    existing.addMessage = addMessage;
+    return;
+  }
+
+  const trackedState: TrackedPostState = { interactionId, addMessage };
+  trackedThreadPosts.set(thread, trackedState);
+
+  const originalPost = thread.post.bind(thread);
+  thread.post = async (...args: Parameters<typeof originalPost>) => {
+    const result = await originalPost(...args);
+
+    try {
+      const content = args[0];
+      const text = typeof content === "string" ? content : "";
+      if (text) {
+        await trackedState.addMessage({
+          interactionId: trackedState.interactionId,
+          senderType: "agent",
+          text,
+        });
+      }
+    } catch {
+      // Best-effort tracking
+    }
+
+    return result;
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
@@ -179,7 +179,7 @@ describe("wrapThreadPost", () => {
 
   it("persists agent replies after posting", async () => {
     const { thread } = createThread();
-    await wrapThreadPost(thread, "interaction-123");
+    wrapThreadPost(thread, "interaction-123");
 
     await thread.post("Agent reply");
 
@@ -192,7 +192,7 @@ describe("wrapThreadPost", () => {
 
   it("does not persist non-string posts", async () => {
     const { thread } = createThread();
-    await wrapThreadPost(thread, "interaction-123");
+    wrapThreadPost(thread, "interaction-123");
 
     await thread.post({ markdown: "complex" });
 
@@ -201,8 +201,8 @@ describe("wrapThreadPost", () => {
 
   it("does not double-wrap the same thread", async () => {
     const { thread } = createThread();
-    await wrapThreadPost(thread, "interaction-123");
-    await wrapThreadPost(thread, "interaction-123");
+    wrapThreadPost(thread, "interaction-123");
+    wrapThreadPost(thread, "interaction-123");
 
     await thread.post("Agent reply");
 

--- a/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
@@ -9,6 +9,16 @@ import {
   wrapThreadPost,
 } from "./bot";
 
+const { agentGenerateMock, createConversationToolLoopAgentMock, loadMessagesMock } = vi.hoisted(
+  () => ({
+    agentGenerateMock: vi.fn(),
+    createConversationToolLoopAgentMock: vi.fn(() => ({
+      generate: agentGenerateMock,
+    })),
+    loadMessagesMock: vi.fn(async () => []),
+  }),
+);
+
 vi.mock("@/lib/env", () => ({
   env: {
     SLACK_CLIENT_ID: "test-client-id",
@@ -17,18 +27,25 @@ vi.mock("@/lib/env", () => ({
   },
 }));
 
-vi.mock("@ai-sdk/openai", () => ({
-  openai: vi.fn(() => "mock-model"),
-}));
-
-vi.mock("ai", () => ({
-  generateText: vi.fn(),
-  stepCountIs: vi.fn((n: number) => n),
-}));
-
-vi.mock("@/lib/tools/registry", () => ({
-  buildTools: vi.fn(() => ({})),
-}));
+vi.mock("@/lib/agents/hyperlocalise-agent", () => {
+  return {
+    createConversationToolLoopAgent: createConversationToolLoopAgentMock,
+    loadInteractionModelMessages: loadMessagesMock,
+    replaceLastUserMessage: (
+      messages: Array<{ role: "user" | "assistant"; content: string }>,
+      text: string,
+    ) => {
+      const nextMessages = [...messages];
+      const lastUserIndex = nextMessages.findLastIndex((message) => message.role === "user");
+      if (lastUserIndex >= 0) {
+        nextMessages[lastUserIndex] = { role: "user", content: text };
+        return nextMessages;
+      }
+      nextMessages.push({ role: "user", content: text });
+      return nextMessages;
+    },
+  };
+});
 
 vi.mock("@/lib/agents/slack/helpers", () => ({
   findSlackConnector: vi.fn(),
@@ -78,7 +95,6 @@ vi.mock("@/lib/database", () => {
   };
 });
 
-import { generateText } from "ai";
 import { findSlackConnector, lookupMembership } from "@/lib/agents/slack/helpers";
 import {
   addInteractionMessage,
@@ -236,7 +252,8 @@ describe("getOrCreateInteraction", () => {
 describe("handleNewConversation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(generateText).mockResolvedValue({ text: "AI response" } as never);
+    agentGenerateMock.mockResolvedValue({ text: "AI response" });
+    loadMessagesMock.mockResolvedValue([]);
   });
 
   it("ignores bot messages", async () => {
@@ -312,7 +329,20 @@ describe("handleNewConversation", () => {
       senderEmail: "alice@example.com",
     });
     expect(getSubscribed()).toBe(true);
-    expect(generateText).toHaveBeenCalled();
+    expect(createConversationToolLoopAgentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        surface: "slack",
+        toolContext: expect.objectContaining({
+          conversationId: "interaction-123",
+          organizationId: "org-123",
+          membershipRole: "member",
+          projectId: null,
+        }),
+      }),
+    );
+    expect(agentGenerateMock).toHaveBeenCalledWith({
+      messages: [{ role: "user", content: "Help me translate" }],
+    });
     expect(posts).toEqual(["AI response"]);
   });
 
@@ -346,7 +376,7 @@ describe("handleNewConversation", () => {
       senderEmail: "alice@example.com",
     });
     expect(getSubscribed()).toBe(false);
-    expect(generateText).toHaveBeenCalled();
+    expect(agentGenerateMock).toHaveBeenCalled();
     expect(posts).toEqual(["AI response"]);
   });
 });
@@ -354,7 +384,8 @@ describe("handleNewConversation", () => {
 describe("handleSubscribedMessage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(generateText).mockResolvedValue({ text: "AI response" } as never);
+    agentGenerateMock.mockResolvedValue({ text: "AI response" });
+    loadMessagesMock.mockResolvedValue([]);
   });
 
   it("ignores bot messages", async () => {
@@ -394,7 +425,7 @@ describe("handleSubscribedMessage", () => {
       text: "Second message",
       senderEmail: "alice@example.com",
     });
-    expect(generateText).toHaveBeenCalled();
+    expect(agentGenerateMock).toHaveBeenCalled();
     expect(posts).toEqual(["AI response"]);
 
     // Agent reply should also be persisted

--- a/apps/hyperlocalise-web/src/lib/agents/slack/bot.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/bot.ts
@@ -37,8 +37,8 @@ async function getSlackUser(
   return (await thread.adapter.getUser?.(userId)) ?? null;
 }
 
-export async function wrapThreadPost(thread: Thread<SlackBotState>, interactionId: string) {
-  await wrapThreadPostForInteraction(thread, interactionId);
+export function wrapThreadPost(thread: Thread<SlackBotState>, interactionId: string) {
+  wrapThreadPostForInteraction(thread, interactionId);
 }
 
 export async function getOrCreateInteraction(
@@ -91,7 +91,7 @@ async function processSlackMessage(
       : null;
 
     if (!membership) {
-      await wrapThreadPost(thread, interactionId);
+      wrapThreadPost(thread, interactionId);
       await thread.post(
         "I couldn't verify your account in this Hyperlocalise workspace. Please make sure your Slack email matches your Hyperlocalise account email.",
       );
@@ -110,12 +110,12 @@ async function processSlackMessage(
     });
     const result = await agent.generate({ messages: chatMessages });
 
-    await wrapThreadPost(thread, interactionId);
+    wrapThreadPost(thread, interactionId);
     if (result.text.trim()) {
       await thread.post(result.text);
     }
   } catch {
-    await wrapThreadPost(thread, interactionId);
+    wrapThreadPost(thread, interactionId);
     await thread.post(
       "I'm having trouble processing that right now. I can help with translation jobs, project questions, glossary lookups, and job status checks. How can I assist you?",
     );
@@ -153,7 +153,7 @@ export async function handleNewConversation(thread: Thread<SlackBotState>, messa
   });
 
   if (isNew) {
-    await wrapThreadPost(thread, interaction.id);
+    wrapThreadPost(thread, interaction.id);
     await thread.subscribe();
   }
 

--- a/apps/hyperlocalise-web/src/lib/agents/slack/bot.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/bot.ts
@@ -1,12 +1,15 @@
-import { openai } from "@ai-sdk/openai";
 import { Chat } from "chat";
 import { createSlackAdapter } from "@chat-adapter/slack";
-import { eq } from "drizzle-orm";
-import { generateText, stepCountIs } from "ai";
 import type { Message, Thread, UserInfo } from "chat";
 
+import {
+  createConversationToolLoopAgent,
+  loadInteractionModelMessages,
+  replaceLastUserMessage,
+} from "@/lib/agents/hyperlocalise-agent";
 import { createChatStateAdapter } from "@/lib/agents/runtime/state";
-import { db, schema } from "@/lib/database";
+import { wrapThreadPostForInteraction } from "@/lib/agents/runtime/tracking";
+import { db } from "@/lib/database";
 import { env } from "@/lib/env";
 import { createChatLogger } from "@/lib/log";
 import {
@@ -14,7 +17,6 @@ import {
   createInteraction,
   findInteractionBySourceThreadId,
 } from "@/lib/interactions";
-import { buildTools } from "@/lib/tools/registry";
 
 import { findSlackConnector, lookupMembership } from "./helpers";
 
@@ -22,8 +24,6 @@ type SlackBotState = Record<string, unknown>;
 
 let botInstance: Chat<{ slack: ReturnType<typeof createSlackAdapter> }, SlackBotState> | null =
   null;
-
-const wrappedThreads = new WeakSet<Thread<SlackBotState>>();
 
 export function extractTeamId(message: Message): string | null {
   const raw = message.raw as { team_id?: string; team?: string } | undefined;
@@ -38,29 +38,7 @@ async function getSlackUser(
 }
 
 export async function wrapThreadPost(thread: Thread<SlackBotState>, interactionId: string) {
-  if (wrappedThreads.has(thread)) {
-    return;
-  }
-  wrappedThreads.add(thread);
-
-  const originalPost = thread.post.bind(thread);
-  thread.post = async (...args: Parameters<typeof originalPost>) => {
-    const result = await originalPost(...args);
-    try {
-      const content = args[0];
-      const text = typeof content === "string" ? content : "";
-      if (text) {
-        await addInteractionMessage({
-          interactionId,
-          senderType: "agent",
-          text,
-        });
-      }
-    } catch {
-      // Best-effort tracking
-    }
-    return result;
-  };
+  await wrapThreadPostForInteraction(thread, interactionId);
 }
 
 export async function getOrCreateInteraction(
@@ -94,76 +72,6 @@ export async function getOrCreateInteraction(
   };
 }
 
-function getChatModel() {
-  if (!env.OPENAI_API_KEY) {
-    throw new Error("OPENAI_API_KEY is not configured");
-  }
-  return openai("gpt-5.4-mini");
-}
-
-function buildSlackSystemPrompt(projectId: string | null) {
-  const lines = [
-    "You are Hyperlocalise, an expert localization and translation assistant in Slack.",
-    "You help teams translate content, manage glossaries, review translations, and organize localization projects.",
-    "Keep responses concise and Slack-friendly. Use markdown formatting when it improves readability.",
-    "",
-    "You can answer questions about:",
-    "- Translation strategies and best practices",
-    "- Locale-specific formatting, cultural adaptation, and regional conventions",
-    "- Managing translation workflows, jobs, and project organization",
-    "- Using glossaries and translation memories effectively",
-    "- Quality assurance and review processes for localized content",
-    "",
-    "Project context:",
-  ];
-
-  if (projectId) {
-    lines.push(
-      `- This conversation is attached to project ${projectId}.`,
-      "- Call getProjectContext when you need the project's name, description, translation rules, or attached glossaries and memories.",
-      "- Call updateInteractionProject only if the user explicitly says they want to switch to a different project.",
-    );
-  } else {
-    lines.push(
-      "- This conversation is NOT attached to a project yet.",
-      "- If the user mentions a project by name, call listProjects to find it, then call updateInteractionProject to attach it.",
-      "- If the user asks about translation without mentioning a project, you can still call queryGlossary and queryTranslationMemory org-wide.",
-      "- If a project would help (e.g. the user says 'for the mobile app'), always attach it before translating.",
-    );
-  }
-
-  lines.push(
-    "",
-    "Guidelines:",
-    "- Be concise but thorough. Slack messages should be scannable.",
-    "- When suggesting translations, consider context, tone, and target audience",
-    "- If you need more information to provide a good answer, ask clarifying questions",
-    "- You can create translation jobs, suggest glossary terms, and inspect existing jobs",
-    "- Review, research, sync, and asset-management jobs are not runnable yet; use the matching unavailable-job tool if a user asks to queue one",
-    "- Always maintain a professional, helpful tone",
-    "- If a request is outside your capabilities, give a clear fallback response explaining what you can do instead",
-  );
-
-  return lines.join("\n");
-}
-
-async function loadConversationHistory(interactionId: string) {
-  const messages = await db
-    .select({
-      senderType: schema.interactionMessages.senderType,
-      text: schema.interactionMessages.text,
-    })
-    .from(schema.interactionMessages)
-    .where(eq(schema.interactionMessages.interactionId, interactionId))
-    .orderBy(schema.interactionMessages.createdAt)
-    .limit(50);
-
-  return messages.map((msg) => ({
-    role: msg.senderType === "user" ? ("user" as const) : ("assistant" as const),
-    content: msg.text,
-  }));
-}
-
 async function processSlackMessage(
   thread: Thread<SlackBotState>,
   message: Message,
@@ -172,16 +80,10 @@ async function processSlackMessage(
   projectId: string | null,
 ) {
   try {
-    const chatMessages = await loadConversationHistory(interactionId);
-
-    // Replace the last user message with the current one (it was just persisted)
-    // to ensure we have the freshest text
-    const lastUserIndex = chatMessages.findLastIndex((m) => m.role === "user");
-    if (lastUserIndex >= 0) {
-      chatMessages[lastUserIndex] = { role: "user", content: message.text };
-    } else {
-      chatMessages.push({ role: "user", content: message.text });
-    }
+    const chatMessages = replaceLastUserMessage(
+      await loadInteractionModelMessages(interactionId),
+      message.text,
+    );
 
     const slackUser = await getSlackUser(thread, message.author.userId);
     const membership = slackUser?.email
@@ -196,21 +98,17 @@ async function processSlackMessage(
       return;
     }
 
-    const tools = buildTools({
-      conversationId: interactionId,
-      organizationId,
-      membershipRole: membership.role,
-      projectId,
-      db,
+    const agent = createConversationToolLoopAgent({
+      surface: "slack",
+      toolContext: {
+        conversationId: interactionId,
+        organizationId,
+        membershipRole: membership.role,
+        projectId,
+        db,
+      },
     });
-
-    const result = await generateText({
-      model: getChatModel(),
-      system: buildSlackSystemPrompt(projectId),
-      messages: chatMessages,
-      tools,
-      stopWhen: stepCountIs(5),
-    });
+    const result = await agent.generate({ messages: chatMessages });
 
     await wrapThreadPost(thread, interactionId);
     if (result.text.trim()) {

--- a/apps/hyperlocalise-web/src/lib/resend/adapter.ts
+++ b/apps/hyperlocalise-web/src/lib/resend/adapter.ts
@@ -328,7 +328,7 @@ class ResendAdapter implements Adapter<ResendThreadId, ResendRawMessage> {
       return new Response(JSON.stringify({ error: "not_initialized" }), { status: 503 });
     }
 
-    void this.chat.processMessage(this, message.threadId, message, options);
+    this.chat.processMessage(this, message.threadId, message, options);
     return new Response(JSON.stringify({ status: "ok" }), { status: 200 });
   }
 

--- a/apps/hyperlocalise-web/src/lib/resend/adapter.ts
+++ b/apps/hyperlocalise-web/src/lib/resend/adapter.ts
@@ -328,7 +328,7 @@ class ResendAdapter implements Adapter<ResendThreadId, ResendRawMessage> {
       return new Response(JSON.stringify({ error: "not_initialized" }), { status: 503 });
     }
 
-    this.chat.processMessage(this, message.threadId, message, options);
+    void this.chat.processMessage(this, message.threadId, message, options);
     return new Response(JSON.stringify({ status: "ok" }), { status: 200 });
   }
 


### PR DESCRIPTION
## What changed

Refactored agent surfaces around a shared request-scoped `ToolLoopAgent` pattern.

- Added shared agent core for model setup, prompts, history loading, tool wiring, and step limits.
- Moved web chat and Slack replies onto the shared agent.
- Added deterministic GitHub command routing for `@hyperlocalise fix`, with a restricted agent tool for queueing the validated fix workflow.
- Kept email’s intake workflow separate while sharing model/tracking infrastructure where appropriate.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
