### PR TITLE
fix(cli): stabilize markdown lock hashes across inserts

### DIFF
--- a/apps/cli/internal/i18n/runsvc/cache_key.go
+++ b/apps/cli/internal/i18n/runsvc/cache_key.go
@@ -1,8 +1,14 @@
 package runsvc
 
 import (
+	"regexp"
+	"strconv"
 	"strings"
 )
+
+const markdownLockSourceContext = "markdown_segment_context=content_hash_only:v1"
+
+var markdownStructuralOrdinalPattern = regexp.MustCompile(`\[(\d+)\]`)
 
 func normalizeSourceForCache(source string) string {
 	normalized := strings.ReplaceAll(source, "\r\n", "\n")
@@ -15,6 +21,95 @@ func sourceContextFingerprint(task Task) string {
 	return hashSourceText(strings.Join([]string{
 		"source_context=" + normalizeSourceForCache(effectiveContext),
 	}, "\n"))
+}
+
+func sourceContextFingerprintForLock(task Task) string {
+	effectiveContext := sanitizePromptContext(task.SourceContext, maxSourceContextLen)
+	if isMarkdownEntryKey(task.EntryKey) {
+		// Markdown context is prompt-only. Including structural or adjacent hints
+		// in the lock hash makes unchanged md.<hash> entries miss after inserts.
+		effectiveContext = markdownLockSourceContext
+	}
+	return hashSourceText(strings.Join([]string{
+		"source_context=" + normalizeSourceForCache(effectiveContext),
+	}, "\n"))
+}
+
+func isMarkdownEntryKey(key string) bool {
+	return strings.HasPrefix(strings.TrimSpace(key), "md.")
+}
+
+func legacyMarkdownContextSensitiveLockTaskHashCandidates(task Task) []string {
+	if !isMarkdownEntryKey(task.EntryKey) {
+		return nil
+	}
+
+	contexts := legacyMarkdownSourceContextVariants(task.SourceContext)
+	candidates := make([]string, 0, len(contexts)*2)
+	for _, context := range contexts {
+		candidate := task
+		candidate.SourceContext = context
+		candidates = append(
+			candidates,
+			legacyContextSensitiveLockTaskHash(candidate),
+			legacyDefaultContextSensitiveLockTaskHash(candidate),
+		)
+	}
+	return candidates
+}
+
+func legacyMarkdownSourceContextVariants(context string) []string {
+	// Older lockfiles included markdown structural paths. Try nearby previous
+	// ordinals so common insertions can migrate instead of retranslating below.
+	normalized := strings.ReplaceAll(context, "\r\n", "\n")
+	normalized = strings.ReplaceAll(normalized, "\r", "\n")
+	contexts := []string{normalized}
+	lines := strings.Split(normalized, "\n")
+	for idx, line := range lines {
+		if !strings.HasPrefix(strings.TrimSpace(line), "Structural path:") {
+			continue
+		}
+		for _, lineVariant := range markdownStructuralPathLegacyLineVariants(line) {
+			variantLines := append([]string(nil), lines...)
+			variantLines[idx] = lineVariant
+			contexts = append(contexts, strings.Join(variantLines, "\n"))
+		}
+	}
+	return dedupeStrings(contexts)
+}
+
+func markdownStructuralPathLegacyLineVariants(line string) []string {
+	const maxShift = 8
+
+	matches := markdownStructuralOrdinalPattern.FindAllStringSubmatchIndex(line, -1)
+	var variants []string
+	for _, match := range matches {
+		if len(match) < 4 || match[2] < 0 || match[3] < 0 {
+			continue
+		}
+		ordinal, err := strconv.Atoi(line[match[2]:match[3]])
+		if err != nil || ordinal <= 0 {
+			continue
+		}
+		for shift := 1; shift <= maxShift && shift <= ordinal; shift++ {
+			replacement := strconv.Itoa(ordinal - shift)
+			variants = append(variants, line[:match[2]]+replacement+line[match[3]:])
+		}
+	}
+	return dedupeStrings(variants)
+}
+
+func dedupeStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
 }
 
 func precomputeStableTaskCacheFields(task *Task) {
@@ -34,6 +129,15 @@ func precomputeStableTaskCacheFields(task *Task) {
 
 func lockTaskHash(task Task) string {
 	precomputeStableTaskCacheFields(&task)
+	return lockTaskHashWithContextFingerprint(task, sourceContextFingerprintForLock(task), false)
+}
+
+func legacyContextSensitiveLockTaskHash(task Task) string {
+	precomputeStableTaskCacheFields(&task)
+	return lockTaskHashWithContextFingerprint(task, task.sourceContextFingerprint, false)
+}
+
+func lockTaskHashWithContextFingerprint(task Task, sourceContextFingerprint string, includeLegacyDefaults bool) string {
 	parts := []string{
 		"source_norm_hash=" + task.sourceTextHash,
 		"source_locale=" + strings.TrimSpace(task.SourceLocale),
@@ -42,12 +146,24 @@ func lockTaskHash(task Task) string {
 		"model=" + strings.TrimSpace(task.Model),
 		"profile=" + strings.TrimSpace(task.ProfileName),
 		"prompt_version_hash=" + strings.TrimSpace(task.PromptVersion),
-		"parser_mode=" + strings.TrimSpace(task.ParserMode),
-		"source_context_fingerprint=" + task.sourceContextFingerprint,
-		"context_key=" + strings.TrimSpace(task.ContextKey),
-		"context_provider=" + strings.TrimSpace(task.ContextProvider),
-		"context_model=" + strings.TrimSpace(task.ContextModel),
 	}
+	if includeLegacyDefaults {
+		parts = append(parts, "glossary_termbase_version_hash=none")
+	}
+	parts = append(
+		parts,
+		"parser_mode="+strings.TrimSpace(task.ParserMode),
+		"source_context_fingerprint="+sourceContextFingerprint,
+	)
+	if includeLegacyDefaults {
+		parts = append(parts, "retrieval_corpus_snapshot_version="+legacyDefaultRetrievalSnapshot())
+	}
+	parts = append(
+		parts,
+		"context_key="+strings.TrimSpace(task.ContextKey),
+		"context_provider="+strings.TrimSpace(task.ContextProvider),
+		"context_model="+strings.TrimSpace(task.ContextModel),
+	)
 	if isImageTask(task) {
 		parts = append(
 			parts,
@@ -68,29 +184,10 @@ func legacyDefaultRetrievalSnapshot() string {
 
 func legacyDefaultLockTaskHash(task Task) string {
 	precomputeStableTaskCacheFields(&task)
-	parts := []string{
-		"source_norm_hash=" + task.sourceTextHash,
-		"source_locale=" + strings.TrimSpace(task.SourceLocale),
-		"target_locale=" + strings.TrimSpace(task.TargetLocale),
-		"provider=" + strings.TrimSpace(task.Provider),
-		"model=" + strings.TrimSpace(task.Model),
-		"profile=" + strings.TrimSpace(task.ProfileName),
-		"prompt_version_hash=" + strings.TrimSpace(task.PromptVersion),
-		"glossary_termbase_version_hash=none",
-		"parser_mode=" + strings.TrimSpace(task.ParserMode),
-		"source_context_fingerprint=" + task.sourceContextFingerprint,
-		"retrieval_corpus_snapshot_version=" + legacyDefaultRetrievalSnapshot(),
-		"context_key=" + strings.TrimSpace(task.ContextKey),
-		"context_provider=" + strings.TrimSpace(task.ContextProvider),
-		"context_model=" + strings.TrimSpace(task.ContextModel),
-	}
-	if isImageTask(task) {
-		parts = append(
-			parts,
-			"task_kind="+strings.TrimSpace(task.Kind),
-			"output_format="+strings.TrimSpace(task.OutputFormat),
-		)
-	}
-	canonical := strings.Join(parts, "\n")
-	return lockStoredFingerprint(canonical)
+	return lockTaskHashWithContextFingerprint(task, sourceContextFingerprintForLock(task), true)
+}
+
+func legacyDefaultContextSensitiveLockTaskHash(task Task) string {
+	precomputeStableTaskCacheFields(&task)
+	return lockTaskHashWithContextFingerprint(task, task.sourceContextFingerprint, true)
 }

--- a/apps/cli/internal/i18n/runsvc/cache_key.go
+++ b/apps/cli/internal/i18n/runsvc/cache_key.go
@@ -79,6 +79,9 @@ func legacyMarkdownSourceContextVariants(context string) []string {
 }
 
 func markdownStructuralPathLegacyLineVariants(line string) []string {
+	// Try nearby previous ordinals for one structural path component at a time.
+	// Combined shifts across multiple components may still fall through to
+	// retranslation; maxShift bounds this best-effort migration window.
 	const maxShift = 8
 
 	matches := markdownStructuralOrdinalPattern.FindAllStringSubmatchIndex(line, -1)

--- a/apps/cli/internal/i18n/runsvc/lock_filter_test.go
+++ b/apps/cli/internal/i18n/runsvc/lock_filter_test.go
@@ -198,6 +198,35 @@ func TestApplyLockFilterMigratesLegacyMarkdownContextSensitiveTaskHash(t *testin
 	}
 }
 
+func TestLockTaskHashCandidatesOmitsMarkdownLegacyDefaultLockTaskHash(t *testing.T) {
+	task := baseLockTask()
+	task.TargetPath = "/tmp/out.md"
+	task.SourcePath = "/tmp/source.md"
+	task.EntryKey = "md.0123456789abcdef"
+	task.SourceText = "Keep this translated."
+	task.ParserMode = "other"
+	task.SourceContext = strings.Join([]string{
+		"Markdown translatable segment.",
+		"Structural path: Paragraph[2]/line[0]",
+	}, "\n")
+
+	candidates := lockTaskHashCandidates(task)
+	deadCandidate := legacyDefaultLockTaskHash(task)
+	for _, candidate := range candidates {
+		if candidate == deadCandidate {
+			t.Fatalf("expected markdown candidates to omit legacy default lock task hash")
+		}
+	}
+
+	contextSensitiveLegacyDefault := legacyDefaultContextSensitiveLockTaskHash(task)
+	for _, candidate := range candidates {
+		if candidate == contextSensitiveLegacyDefault {
+			return
+		}
+	}
+	t.Fatalf("expected markdown candidates to include context-sensitive legacy default task hash")
+}
+
 func TestApplyLockFilterLegacyFullTaskHashMatchesShortFingerprint(t *testing.T) {
 	task := baseLockTask()
 	task.TargetPath = "/tmp/out.json"

--- a/apps/cli/internal/i18n/runsvc/lock_filter_test.go
+++ b/apps/cli/internal/i18n/runsvc/lock_filter_test.go
@@ -83,6 +83,121 @@ func TestApplyLockFilterDoesNotSkipWhenTaskHashChanges(t *testing.T) {
 	}
 }
 
+func TestApplyLockFilterMigratesLegacyMarkdownWhenInsertedParagraphShiftsStructuralPath(t *testing.T) {
+	task := baseLockTask()
+	task.TargetPath = "/tmp/out.md"
+	task.SourcePath = "/tmp/source.md"
+	task.EntryKey = "md.0123456789abcdef"
+	task.SourceText = "Keep this translated."
+	task.ParserMode = "other"
+	task.SourceContext = strings.Join([]string{
+		"Markdown translatable segment.",
+		"Preserve every internal placeholder token matching the pattern \\x1eHLMDPH_...\\x1f exactly (do not translate, remove, or rename them).",
+		"Structural path: Paragraph[3]/line[0]",
+	}, "\n")
+
+	old := task
+	old.SourceContext = strings.ReplaceAll(task.SourceContext, "Paragraph[3]", "Paragraph[2]")
+
+	completed := map[string]lockfile.RunCompletion{
+		taskIdentity(task.TargetPath, task.EntryKey): {
+			SourceHash: hashSourceText(old.SourceText),
+			TaskHash:   legacyContextSensitiveLockTaskHash(old),
+		},
+	}
+
+	report, executable, _, migrated, err := applyLockFilter([]Task{task}, completed, nil, "", false)
+	if err != nil {
+		t.Fatalf("applyLockFilter: %v", err)
+	}
+	if report.SkippedByLock != 1 {
+		t.Fatalf("expected unchanged markdown segment to be skipped, got report %+v", report)
+	}
+	if len(executable) != 0 {
+		t.Fatalf("expected no executable tasks, got %d", len(executable))
+	}
+	if !migrated {
+		t.Fatalf("expected legacy markdown task hash to migrate")
+	}
+	if got, want := completed[taskIdentity(task.TargetPath, task.EntryKey)].TaskHash, lockTaskHash(task); got != want {
+		t.Fatalf("expected migrated task hash %q, got %q", want, got)
+	}
+}
+
+func TestLockTaskHashIgnoresMarkdownPromptContext(t *testing.T) {
+	task := baseLockTask()
+	task.TargetPath = "/tmp/out.md"
+	task.SourcePath = "/tmp/source.md"
+	task.EntryKey = "md.0123456789abcdef"
+	task.SourceText = "Keep this translated."
+	task.ParserMode = "other"
+	task.SourceContext = strings.Join([]string{
+		"Markdown translatable segment.",
+		"Structural path: List[0]/ListItem[2]/Paragraph[0]/line[0]",
+		"Adjacent source before (context only; do not translate this line): - ",
+	}, "\n")
+
+	changedContext := task
+	changedContext.SourceContext = strings.Join([]string{
+		"Markdown translatable segment.",
+		"Structural path: List[0]/ListItem[3]/Paragraph[0]/line[0]",
+		"Adjacent source before (context only; do not translate this line): New item.",
+	}, "\n")
+
+	if lockTaskHash(task) != lockTaskHash(changedContext) {
+		t.Fatalf("expected markdown prompt context changes to stay out of lock task hash")
+	}
+}
+
+func TestLockTaskHashStillIncludesNonMarkdownSourceContext(t *testing.T) {
+	task := baseLockTask()
+	task.TargetPath = "/tmp/out.json"
+	task.SourcePath = "/tmp/source.json"
+	task.EntryKey = "hello"
+	task.SourceContext = "Description: short greeting"
+
+	changed := task
+	changed.SourceContext = "Description: CTA label"
+
+	if lockTaskHash(task) == lockTaskHash(changed) {
+		t.Fatalf("expected non-markdown source context changes to affect task hash")
+	}
+}
+
+func TestApplyLockFilterMigratesLegacyMarkdownContextSensitiveTaskHash(t *testing.T) {
+	task := baseLockTask()
+	task.TargetPath = "/tmp/out.md"
+	task.SourcePath = "/tmp/source.md"
+	task.EntryKey = "md.0123456789abcdef"
+	task.SourceText = "Keep this translated."
+	task.ParserMode = "other"
+	task.SourceContext = strings.Join([]string{
+		"Markdown translatable segment.",
+		"Structural path: Paragraph[2]/line[0]",
+	}, "\n")
+
+	completed := map[string]lockfile.RunCompletion{
+		taskIdentity(task.TargetPath, task.EntryKey): {
+			SourceHash: hashSourceText(task.SourceText),
+			TaskHash:   legacyContextSensitiveLockTaskHash(task),
+		},
+	}
+
+	report, executable, _, migrated, err := applyLockFilter([]Task{task}, completed, nil, "", false)
+	if err != nil {
+		t.Fatalf("applyLockFilter: %v", err)
+	}
+	if report.SkippedByLock != 1 || len(executable) != 0 {
+		t.Fatalf("expected legacy markdown task hash to skip, report=%+v executable=%d", report, len(executable))
+	}
+	if !migrated {
+		t.Fatalf("expected legacy markdown task hash to migrate")
+	}
+	if got, want := completed[taskIdentity(task.TargetPath, task.EntryKey)].TaskHash, lockTaskHash(task); got != want {
+		t.Fatalf("expected migrated task hash %q, got %q", want, got)
+	}
+}
+
 func TestApplyLockFilterLegacyFullTaskHashMatchesShortFingerprint(t *testing.T) {
 	task := baseLockTask()
 	task.TargetPath = "/tmp/out.json"

--- a/apps/cli/internal/i18n/runsvc/run_orchestrator.go
+++ b/apps/cli/internal/i18n/runsvc/run_orchestrator.go
@@ -279,12 +279,11 @@ func taskLockSourceHash(task Task) string {
 }
 
 func lockTaskHashCandidates(task Task) []string {
-	candidates := []string{
-		lockTaskHash(task),
-		legacyDefaultLockTaskHash(task),
-	}
+	candidates := []string{lockTaskHash(task)}
 	if isMarkdownEntryKey(task.EntryKey) {
 		candidates = append(candidates, legacyMarkdownContextSensitiveLockTaskHashCandidates(task)...)
+	} else {
+		candidates = append(candidates, legacyDefaultLockTaskHash(task))
 	}
 
 	seen := map[string]struct{}{}

--- a/apps/cli/internal/i18n/runsvc/run_orchestrator.go
+++ b/apps/cli/internal/i18n/runsvc/run_orchestrator.go
@@ -227,10 +227,10 @@ func applyLockFilterWithReader(planned []Task, completed map[string]lockfile.Run
 	for _, task := range planned {
 		identity := taskIdentity(task.TargetPath, task.EntryKey)
 		sourceHash := taskLockSourceHash(task)
-		taskHash := lockTaskHash(task)
-		legacyTaskHash := legacyDefaultLockTaskHash(task)
-		if cp, ok := checkpoints[identity]; ok && checkpointMatchesActiveRun(cp, activeRunID) && checkpointMatchesTask(cp, sourceHash, taskHash, legacyTaskHash) {
-			if strings.TrimSpace(cp.TaskHash) == "" {
+		taskHashes := lockTaskHashCandidates(task)
+		taskHash := taskHashes[0]
+		if cp, ok := checkpoints[identity]; ok && checkpointMatchesActiveRun(cp, activeRunID) && checkpointMatchesTask(cp, sourceHash, taskHashes) {
+			if !lockFingerprintEqual(cp.TaskHash, taskHash) {
 				cp.TaskHash = taskHash
 				checkpoints[identity] = cp
 				lockMigrated = true
@@ -254,8 +254,8 @@ func applyLockFilterWithReader(planned []Task, completed map[string]lockfile.Run
 				return Report{}, nil, nil, false, fmt.Errorf("stage checkpoint output for %s: %w", identity, stageErr)
 			}
 		}
-		if c, ok := completed[identity]; ok && completionMatchesTask(c, sourceHash, taskHash, legacyTaskHash) {
-			if strings.TrimSpace(c.TaskHash) == "" {
+		if c, ok := completed[identity]; ok && completionMatchesTask(c, sourceHash, taskHashes) {
+			if !lockFingerprintEqual(c.TaskHash, taskHash) {
 				c.TaskHash = taskHash
 				completed[identity] = c
 				lockMigrated = true
@@ -278,6 +278,30 @@ func taskLockSourceHash(task Task) string {
 	return lockStoredFingerprint(task.SourceText)
 }
 
+func lockTaskHashCandidates(task Task) []string {
+	candidates := []string{
+		lockTaskHash(task),
+		legacyDefaultLockTaskHash(task),
+	}
+	if isMarkdownEntryKey(task.EntryKey) {
+		candidates = append(candidates, legacyMarkdownContextSensitiveLockTaskHashCandidates(task)...)
+	}
+
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		if strings.TrimSpace(candidate) == "" {
+			continue
+		}
+		if _, ok := seen[candidate]; ok {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		out = append(out, candidate)
+	}
+	return out
+}
+
 func ensureActiveRunID(state *lockfile.File) string {
 	return state.ActiveRunID
 }
@@ -286,20 +310,27 @@ func checkpointMatchesActiveRun(cp lockfile.RunCheckpoint, activeRunID string) b
 	return activeRunID != "" && cp.RunID == activeRunID
 }
 
-func completionMatchesTask(completion lockfile.RunCompletion, sourceHash, taskHash, legacyTaskHash string) bool {
+func completionMatchesTask(completion lockfile.RunCompletion, sourceHash string, taskHashes []string) bool {
 	if strings.TrimSpace(completion.TaskHash) != "" {
-		return lockFingerprintEqual(completion.TaskHash, taskHash) ||
-			lockFingerprintEqual(completion.TaskHash, legacyTaskHash)
+		return lockFingerprintEqualAny(completion.TaskHash, taskHashes)
 	}
 	return lockFingerprintEqual(completion.SourceHash, sourceHash)
 }
 
-func checkpointMatchesTask(checkpoint lockfile.RunCheckpoint, sourceHash, taskHash, legacyTaskHash string) bool {
+func checkpointMatchesTask(checkpoint lockfile.RunCheckpoint, sourceHash string, taskHashes []string) bool {
 	if strings.TrimSpace(checkpoint.TaskHash) != "" {
-		return lockFingerprintEqual(checkpoint.TaskHash, taskHash) ||
-			lockFingerprintEqual(checkpoint.TaskHash, legacyTaskHash)
+		return lockFingerprintEqualAny(checkpoint.TaskHash, taskHashes)
 	}
 	return lockFingerprintEqual(checkpoint.SourceHash, sourceHash)
+}
+
+func lockFingerprintEqualAny(stored string, computed []string) bool {
+	for _, candidate := range computed {
+		if lockFingerprintEqual(stored, candidate) {
+			return true
+		}
+	}
+	return false
 }
 
 func nextRunID(now time.Time) string {

--- a/apps/cli/internal/i18n/runsvc/service_test.go
+++ b/apps/cli/internal/i18n/runsvc/service_test.go
@@ -2410,6 +2410,121 @@ func TestRunWritesMarkdownWithInsertedSectionWhenExistingTargetPresent(t *testin
 	}
 }
 
+func TestRunMarkdownInsertionSkipsFollowingLegacyTaskHashEntries(t *testing.T) {
+	sourcePath := "/tmp/source.md"
+	targetPath := "/tmp/out.md"
+	sourceBefore := "# Guide\n\nExisting intro.\n\nExisting outro.\n"
+	sourceAfter := "# Guide\n\nExisting intro.\n\nNew section added.\n\nExisting outro.\n"
+	targetBefore := "# Guide\n\nIntro existant.\n\nConclusion existante.\n"
+	cfg := testConfig(sourcePath, targetPath)
+
+	planner := newTestService()
+	planner.readFile = func(path string) ([]byte, error) {
+		if path == sourcePath {
+			return []byte(sourceBefore), nil
+		}
+		return nil, os.ErrNotExist
+	}
+	beforeTasks, _, err := planner.planTasks(&cfg, "", "", nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("plan before tasks: %v", err)
+	}
+	if len(beforeTasks) == 0 {
+		t.Fatalf("expected markdown tasks before insertion")
+	}
+
+	completed := map[string]lockfile.RunCompletion{}
+	for _, task := range beforeTasks {
+		completed[taskIdentity(task.TargetPath, task.EntryKey)] = lockfile.RunCompletion{
+			SourceHash: taskLockSourceHash(task),
+			TaskHash:   legacyContextSensitiveLockTaskHash(task),
+		}
+	}
+	lockState := &lockfile.File{RunCompleted: completed}
+
+	svc := newTestService()
+	svc.loadConfig = func(_ string) (*config.I18NConfig, error) {
+		return &cfg, nil
+	}
+	svc.loadLock = func(_ string) (*lockfile.File, error) { return lockState, nil }
+	svc.saveLock = func(_ string, f lockfile.File) error {
+		*lockState = f
+		return nil
+	}
+	svc.readFile = func(path string) ([]byte, error) {
+		switch path {
+		case sourcePath:
+			return []byte(sourceAfter), nil
+		case targetPath:
+			return []byte(targetBefore), nil
+		default:
+			return nil, os.ErrNotExist
+		}
+	}
+
+	var translated []string
+	svc.translate = func(_ context.Context, req translator.Request) (string, error) {
+		translated = append(translated, req.Source)
+		if req.Source != "New section added." {
+			t.Fatalf("unexpected translation request for unchanged markdown entry: %q", req.Source)
+		}
+		return "Nouvelle section ajoutee.", nil
+	}
+
+	var written []byte
+	svc.writeFile = func(path string, content []byte) error {
+		if path != targetPath {
+			t.Fatalf("unexpected write path %q", path)
+		}
+		written = append([]byte(nil), content...)
+		return nil
+	}
+
+	report, err := svc.Run(context.Background(), Input{Workers: 1})
+	if err != nil {
+		t.Fatalf("run execution: %v", err)
+	}
+	if report.SkippedByLock != len(beforeTasks) || report.ExecutableTotal != 1 || report.Succeeded != 1 {
+		t.Fatalf("expected only inserted markdown section to execute, got %+v", report)
+	}
+	if len(translated) != 1 || translated[0] != "New section added." {
+		t.Fatalf("expected one translation call for inserted section, got %v", translated)
+	}
+
+	out := string(written)
+	for _, want := range []string{"Intro existant.", "Nouvelle section ajoutee.", "Conclusion existante."} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected output to contain %q, got %q", want, out)
+		}
+	}
+
+	afterPlanner := newTestService()
+	afterPlanner.readFile = func(path string) ([]byte, error) {
+		if path == sourcePath {
+			return []byte(sourceAfter), nil
+		}
+		return nil, os.ErrNotExist
+	}
+	afterTasks, _, err := afterPlanner.planTasks(&cfg, "", "", nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("plan after tasks: %v", err)
+	}
+	var outroTask Task
+	for _, task := range afterTasks {
+		if task.SourceText == "Existing outro." {
+			outroTask = task
+			break
+		}
+	}
+	if outroTask.EntryKey == "" {
+		t.Fatalf("expected task for unchanged trailing markdown section")
+	}
+	completion := lockState.RunCompleted[taskIdentity(targetPath, outroTask.EntryKey)]
+	if got, want := completion.TaskHash, lockTaskHash(outroTask); got != want {
+		t.Fatalf("expected trailing section lock hash migrated to %q, got %q", want, got)
+	}
+}
+
 func TestRunWritesAppleStringsUsingSourceTemplateWhenTargetMissing(t *testing.T) {
 	svc := newTestService()
 	sourcePath := "/tmp/source.strings"


### PR DESCRIPTION
## What changed

- Exclude markdown prompt-only context from lock task hashes so unchanged `md.<hash>` entries do not get retranslated when paragraphs, sentences, or list items are inserted above them.
- Preserve markdown prompt context for translation quality, but keep lock identity tied to stable task dimensions.
- Add migration support for older markdown `task_hash` values that included structural paths.
- Add lock-filter and end-to-end run tests covering inserted markdown sections and legacy hash migration.

## How to test

- `go test ./apps/cli/internal/i18n/runsvc`
- `make fmt`
- `make lint`
- `make test`
- `git diff --check`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
