### PR TITLE
fix(cli): write grouped readable lockfiles

### DIFF
--- a/apps/cli/internal/i18n/lockfile/lockfile.go
+++ b/apps/cli/internal/i18n/lockfile/lockfile.go
@@ -366,7 +366,7 @@ func isRunCompletionValue(key string, raw json.RawMessage) bool {
 	if trimmed[0] != '{' {
 		return false
 	}
-	return rawObjectHasStringField(trimmed, "source_hash", "task_hash", "s", "t", "completed_at")
+	return rawObjectHasStringField(trimmed, "source_hash", "task_hash", "s", "t")
 }
 
 func isRunCheckpointValue(key string, raw json.RawMessage) bool {
@@ -405,6 +405,9 @@ func rawObjectHasStringField(raw json.RawMessage, names ...string) bool {
 	var object map[string]json.RawMessage
 	if err := json.Unmarshal(raw, &object); err != nil {
 		return false
+	}
+	if len(object) == 0 {
+		return true
 	}
 	for _, name := range names {
 		field, ok := object[name]

--- a/apps/cli/internal/i18n/lockfile/lockfile.go
+++ b/apps/cli/internal/i18n/lockfile/lockfile.go
@@ -1,9 +1,11 @@
 package lockfile
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -41,6 +43,41 @@ type RunCheckpoint struct {
 	UpdatedAt    time.Time `json:"updated_at"`
 }
 
+type rawFile struct {
+	Adapter       string                      `json:"adapter,omitempty"`
+	ProjectID     string                      `json:"project_id,omitempty"`
+	LastPullAt    *time.Time                  `json:"last_pull_at,omitempty"`
+	ActiveRunID   string                      `json:"active_run_id,omitempty"`
+	LocaleStates  map[string]LocaleCheckpoint `json:"locale_states,omitempty"`
+	RunCompleted  json.RawMessage             `json:"run_completed,omitempty"`
+	RunCheckpoint json.RawMessage             `json:"run_checkpoint,omitempty"`
+}
+
+type diskFile struct {
+	Adapter       string                                  `json:"adapter,omitempty"`
+	ProjectID     string                                  `json:"project_id,omitempty"`
+	LastPullAt    *time.Time                              `json:"last_pull_at,omitempty"`
+	ActiveRunID   string                                  `json:"active_run_id,omitempty"`
+	LocaleStates  map[string]LocaleCheckpoint             `json:"locale_states,omitempty"`
+	RunCompleted  map[string]map[string]diskRunCompletion `json:"run_completed,omitempty"`
+	RunCheckpoint map[string]map[string]diskRunCheckpoint `json:"run_checkpoint,omitempty"`
+}
+
+type diskRunCompletion struct {
+	SourceHash string `json:"s,omitempty"`
+	TaskHash   string `json:"t,omitempty"`
+}
+
+type diskRunCheckpoint struct {
+	RunID        string     `json:"r,omitempty"`
+	SourcePath   string     `json:"p,omitempty"`
+	TargetLocale string     `json:"l,omitempty"`
+	Value        string     `json:"v,omitempty"`
+	SourceHash   string     `json:"s,omitempty"`
+	TaskHash     string     `json:"t,omitempty"`
+	UpdatedAt    *time.Time `json:"u,omitempty"`
+}
+
 func Load(path string) (*File, error) {
 	if path == "" {
 		path = DefaultPath
@@ -54,9 +91,26 @@ func Load(path string) (*File, error) {
 		return nil, fmt.Errorf("read lockfile: %w", err)
 	}
 
-	var f File
-	if err := json.Unmarshal(content, &f); err != nil {
+	var raw rawFile
+	if err := json.Unmarshal(content, &raw); err != nil {
 		return nil, fmt.Errorf("decode lockfile: %w", err)
+	}
+	completed, err := decodeRunCompleted(raw.RunCompleted)
+	if err != nil {
+		return nil, fmt.Errorf("decode lockfile run_completed: %w", err)
+	}
+	checkpoints, err := decodeRunCheckpoints(raw.RunCheckpoint)
+	if err != nil {
+		return nil, fmt.Errorf("decode lockfile run_checkpoint: %w", err)
+	}
+	f := File{
+		Adapter:       raw.Adapter,
+		ProjectID:     raw.ProjectID,
+		LastPullAt:    raw.LastPullAt,
+		ActiveRunID:   raw.ActiveRunID,
+		LocaleStates:  raw.LocaleStates,
+		RunCompleted:  completed,
+		RunCheckpoint: checkpoints,
 	}
 	if f.LocaleStates == nil {
 		f.LocaleStates = map[string]LocaleCheckpoint{}
@@ -85,7 +139,7 @@ func Save(path string, f File) error {
 		f.RunCheckpoint = map[string]RunCheckpoint{}
 	}
 
-	content, err := json.Marshal(f)
+	content, err := json.MarshalIndent(encodeDiskFile(f), "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal lockfile: %w", err)
 	}
@@ -95,4 +149,332 @@ func Save(path string, f File) error {
 		return fmt.Errorf("write lockfile: %w", err)
 	}
 	return nil
+}
+
+func decodeRunCompleted(raw json.RawMessage) (map[string]RunCompletion, error) {
+	completed := map[string]RunCompletion{}
+	if isEmptyRaw(raw) {
+		return completed, nil
+	}
+
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &top); err != nil {
+		return nil, err
+	}
+	for key, value := range top {
+		if isRunCompletionValue(key, value) {
+			completion, err := decodeRunCompletion(value)
+			if err != nil {
+				return nil, fmt.Errorf("%s: %w", key, err)
+			}
+			completed[key] = completion
+			continue
+		}
+
+		var entries map[string]json.RawMessage
+		if err := json.Unmarshal(value, &entries); err != nil {
+			return nil, fmt.Errorf("%s: %w", key, err)
+		}
+		for entryKey, entryValue := range entries {
+			completion, err := decodeRunCompletion(entryValue)
+			if err != nil {
+				return nil, fmt.Errorf("%s::%s: %w", key, entryKey, err)
+			}
+			completed[joinIdentity(key, entryKey)] = completion
+		}
+	}
+	return completed, nil
+}
+
+func decodeRunCompletion(raw json.RawMessage) (RunCompletion, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) > 0 && trimmed[0] == '[' {
+		var tuple []string
+		if err := json.Unmarshal(raw, &tuple); err != nil {
+			return RunCompletion{}, err
+		}
+		completion := RunCompletion{}
+		if len(tuple) > 0 {
+			completion.SourceHash = compactFingerprint(tuple[0])
+		}
+		if len(tuple) > 1 {
+			completion.TaskHash = compactFingerprint(tuple[1])
+		}
+		return completion, nil
+	}
+
+	var payload struct {
+		SourceHash      string `json:"source_hash"`
+		TaskHash        string `json:"task_hash"`
+		ShortSourceHash string `json:"s"`
+		ShortTaskHash   string `json:"t"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return RunCompletion{}, err
+	}
+	return RunCompletion{
+		SourceHash: compactFingerprint(firstNonEmpty(payload.SourceHash, payload.ShortSourceHash)),
+		TaskHash:   compactFingerprint(firstNonEmpty(payload.TaskHash, payload.ShortTaskHash)),
+	}, nil
+}
+
+func decodeRunCheckpoints(raw json.RawMessage) (map[string]RunCheckpoint, error) {
+	checkpoints := map[string]RunCheckpoint{}
+	if isEmptyRaw(raw) {
+		return checkpoints, nil
+	}
+
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &top); err != nil {
+		return nil, err
+	}
+	for key, value := range top {
+		if isRunCheckpointValue(key, value) {
+			targetPath, entryKey := splitIdentity(key)
+			checkpoint, err := decodeRunCheckpoint(value, targetPath, entryKey)
+			if err != nil {
+				return nil, fmt.Errorf("%s: %w", key, err)
+			}
+			checkpoints[joinIdentity(checkpoint.TargetPath, checkpoint.EntryKey)] = checkpoint
+			continue
+		}
+
+		var entries map[string]json.RawMessage
+		if err := json.Unmarshal(value, &entries); err != nil {
+			return nil, fmt.Errorf("%s: %w", key, err)
+		}
+		for entryKey, entryValue := range entries {
+			checkpoint, err := decodeRunCheckpoint(entryValue, key, entryKey)
+			if err != nil {
+				return nil, fmt.Errorf("%s::%s: %w", key, entryKey, err)
+			}
+			checkpoints[joinIdentity(checkpoint.TargetPath, checkpoint.EntryKey)] = checkpoint
+		}
+	}
+	return checkpoints, nil
+}
+
+func decodeRunCheckpoint(raw json.RawMessage, impliedTargetPath, impliedEntryKey string) (RunCheckpoint, error) {
+	var payload struct {
+		RunID             string     `json:"run_id"`
+		TargetPath        string     `json:"target_path"`
+		SourcePath        string     `json:"source_path"`
+		TargetLocale      string     `json:"target_locale"`
+		EntryKey          string     `json:"entry_key"`
+		Value             string     `json:"value"`
+		SourceHash        string     `json:"source_hash"`
+		TaskHash          string     `json:"task_hash"`
+		UpdatedAt         *time.Time `json:"updated_at"`
+		ShortRunID        string     `json:"r"`
+		ShortSourcePath   string     `json:"p"`
+		ShortTargetLocale string     `json:"l"`
+		ShortValue        string     `json:"v"`
+		ShortSourceHash   string     `json:"s"`
+		ShortTaskHash     string     `json:"t"`
+		ShortUpdatedAt    *time.Time `json:"u"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return RunCheckpoint{}, err
+	}
+
+	updatedAt := time.Time{}
+	if payload.UpdatedAt != nil {
+		updatedAt = *payload.UpdatedAt
+	}
+	if payload.ShortUpdatedAt != nil {
+		updatedAt = *payload.ShortUpdatedAt
+	}
+
+	return RunCheckpoint{
+		RunID:        firstNonEmpty(payload.RunID, payload.ShortRunID),
+		TargetPath:   firstNonEmpty(payload.TargetPath, impliedTargetPath),
+		SourcePath:   firstNonEmpty(payload.SourcePath, payload.ShortSourcePath),
+		TargetLocale: firstNonEmpty(payload.TargetLocale, payload.ShortTargetLocale),
+		EntryKey:     firstNonEmpty(payload.EntryKey, impliedEntryKey),
+		Value:        firstNonEmpty(payload.Value, payload.ShortValue),
+		SourceHash:   compactFingerprint(firstNonEmpty(payload.SourceHash, payload.ShortSourceHash)),
+		TaskHash:     compactFingerprint(firstNonEmpty(payload.TaskHash, payload.ShortTaskHash)),
+		UpdatedAt:    updatedAt,
+	}, nil
+}
+
+func encodeDiskFile(f File) diskFile {
+	return diskFile{
+		Adapter:       f.Adapter,
+		ProjectID:     f.ProjectID,
+		LastPullAt:    f.LastPullAt,
+		ActiveRunID:   f.ActiveRunID,
+		LocaleStates:  emptyMapAsNil(f.LocaleStates),
+		RunCompleted:  encodeRunCompleted(f.RunCompleted),
+		RunCheckpoint: encodeRunCheckpoints(f.RunCheckpoint),
+	}
+}
+
+func encodeRunCompleted(completed map[string]RunCompletion) map[string]map[string]diskRunCompletion {
+	if len(completed) == 0 {
+		return nil
+	}
+	grouped := map[string]map[string]diskRunCompletion{}
+	for identity, completion := range completed {
+		targetPath, entryKey := splitIdentity(identity)
+		if grouped[targetPath] == nil {
+			grouped[targetPath] = map[string]diskRunCompletion{}
+		}
+		grouped[targetPath][entryKey] = diskRunCompletion{
+			SourceHash: compactFingerprint(completion.SourceHash),
+			TaskHash:   compactFingerprint(completion.TaskHash),
+		}
+	}
+	return grouped
+}
+
+func encodeRunCheckpoints(checkpoints map[string]RunCheckpoint) map[string]map[string]diskRunCheckpoint {
+	if len(checkpoints) == 0 {
+		return nil
+	}
+	grouped := map[string]map[string]diskRunCheckpoint{}
+	for identity, checkpoint := range checkpoints {
+		targetPath, entryKey := splitCheckpointIdentity(identity, checkpoint)
+		if grouped[targetPath] == nil {
+			grouped[targetPath] = map[string]diskRunCheckpoint{}
+		}
+		diskCheckpoint := diskRunCheckpoint{
+			RunID:        checkpoint.RunID,
+			SourcePath:   checkpoint.SourcePath,
+			TargetLocale: checkpoint.TargetLocale,
+			Value:        checkpoint.Value,
+			SourceHash:   compactFingerprint(checkpoint.SourceHash),
+			TaskHash:     compactFingerprint(checkpoint.TaskHash),
+		}
+		if !checkpoint.UpdatedAt.IsZero() {
+			updatedAt := checkpoint.UpdatedAt
+			diskCheckpoint.UpdatedAt = &updatedAt
+		}
+		grouped[targetPath][entryKey] = diskCheckpoint
+	}
+	return grouped
+}
+
+func isRunCompletionValue(key string, raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return false
+	}
+	if trimmed[0] == '[' || strings.Contains(key, "::") {
+		return true
+	}
+	if trimmed[0] != '{' {
+		return false
+	}
+	return rawObjectHasStringField(trimmed, "source_hash", "task_hash", "s", "t", "completed_at")
+}
+
+func isRunCheckpointValue(key string, raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return false
+	}
+	if strings.Contains(key, "::") {
+		return true
+	}
+	if trimmed[0] != '{' {
+		return false
+	}
+	return rawObjectHasStringField(
+		trimmed,
+		"run_id",
+		"target_path",
+		"source_path",
+		"target_locale",
+		"entry_key",
+		"value",
+		"source_hash",
+		"task_hash",
+		"updated_at",
+		"r",
+		"p",
+		"l",
+		"v",
+		"s",
+		"t",
+		"u",
+	)
+}
+
+func rawObjectHasStringField(raw json.RawMessage, names ...string) bool {
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &object); err != nil {
+		return false
+	}
+	for _, name := range names {
+		field, ok := object[name]
+		if !ok {
+			continue
+		}
+		var value string
+		if err := json.Unmarshal(field, &value); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+func isEmptyRaw(raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	return len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null"))
+}
+
+func splitIdentity(identity string) (string, string) {
+	targetPath, entryKey, ok := strings.Cut(identity, "::")
+	if !ok {
+		return identity, ""
+	}
+	return targetPath, entryKey
+}
+
+func splitCheckpointIdentity(identity string, checkpoint RunCheckpoint) (string, string) {
+	targetPath, entryKey, ok := strings.Cut(identity, "::")
+	if ok {
+		return targetPath, entryKey
+	}
+	if checkpoint.TargetPath != "" || checkpoint.EntryKey != "" {
+		return checkpoint.TargetPath, checkpoint.EntryKey
+	}
+	return identity, ""
+}
+
+func joinIdentity(targetPath, entryKey string) string {
+	return targetPath + "::" + entryKey
+}
+
+func compactFingerprint(value string) string {
+	if len(value) != 128 {
+		return value
+	}
+	for _, c := range value {
+		if !isHex(c) {
+			return value
+		}
+	}
+	return strings.ToLower(value[:32])
+}
+
+func isHex(c rune) bool {
+	return ('0' <= c && c <= '9') || ('a' <= c && c <= 'f') || ('A' <= c && c <= 'F')
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func emptyMapAsNil[K comparable, V any](m map[K]V) map[K]V {
+	if len(m) == 0 {
+		return nil
+	}
+	return m
 }

--- a/apps/cli/internal/i18n/lockfile/lockfile.go
+++ b/apps/cli/internal/i18n/lockfile/lockfile.go
@@ -278,11 +278,11 @@ func decodeRunCheckpoint(raw json.RawMessage, impliedTargetPath, impliedEntryKey
 	}
 
 	updatedAt := time.Time{}
-	if payload.UpdatedAt != nil {
-		updatedAt = *payload.UpdatedAt
-	}
 	if payload.ShortUpdatedAt != nil {
 		updatedAt = *payload.ShortUpdatedAt
+	}
+	if payload.UpdatedAt != nil {
+		updatedAt = *payload.UpdatedAt
 	}
 
 	return RunCheckpoint{

--- a/apps/cli/internal/i18n/lockfile/lockfile_test.go
+++ b/apps/cli/internal/i18n/lockfile/lockfile_test.go
@@ -1,6 +1,7 @@
 package lockfile
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -167,6 +168,173 @@ func TestLoadLegacyRunCompletedWithCompletedAt(t *testing.T) {
 	}
 	if !strings.Contains(string(rewritten), "abc123") {
 		t.Fatalf("expected rewritten lockfile to preserve source_hash, got %s", string(rewritten))
+	}
+}
+
+func TestSaveWritesIndentedGroupedRunCompleted(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.lock.json")
+	fullSourceHash := strings.Repeat("a", 128)
+	fullTaskHash := strings.Repeat("B", 128)
+
+	if err := Save(path, File{
+		RunCompleted: map[string]RunCompletion{
+			"locales/fr.json::hello": {
+				SourceHash: fullSourceHash,
+				TaskHash:   fullTaskHash,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("save lockfile: %v", err)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read saved lockfile: %v", err)
+	}
+	rewritten := string(content)
+	if strings.Contains(rewritten, "source_hash") || strings.Contains(rewritten, "task_hash") {
+		t.Fatalf("expected compact hash keys, got %s", rewritten)
+	}
+	if strings.Contains(rewritten, fullSourceHash) || strings.Contains(rewritten, fullTaskHash) {
+		t.Fatalf("expected full hashes to be compacted, got %s", rewritten)
+	}
+	if !strings.Contains(rewritten, "\n  \"run_completed\": {\n") {
+		t.Fatalf("expected indented run_completed, got %s", rewritten)
+	}
+	var payload struct {
+		RunCompleted map[string]map[string]diskRunCompletion `json:"run_completed"`
+	}
+	if err := json.Unmarshal(content, &payload); err != nil {
+		t.Fatalf("decode saved lockfile: %v", err)
+	}
+	completionOnDisk := payload.RunCompleted["locales/fr.json"]["hello"]
+	if completionOnDisk.SourceHash != "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" || completionOnDisk.TaskHash != "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" {
+		t.Fatalf("expected grouped compact run_completed, got %+v", payload.RunCompleted)
+	}
+
+	got, err := Load(path)
+	if err != nil {
+		t.Fatalf("load compact lockfile: %v", err)
+	}
+	completion := got.RunCompleted["locales/fr.json::hello"]
+	if completion.SourceHash != "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" || completion.TaskHash != "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" {
+		t.Fatalf("unexpected compact completion: %+v", completion)
+	}
+}
+
+func TestLoadGroupedRunCompleted(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "grouped.lock.json")
+	content := []byte(`{
+	  "run_completed": {
+	    "locales/fr.json": {
+	      "hello": {"s": "source-a", "t": "task-a"},
+	      "bye": ["source-b", "task-b"]
+	    }
+	  }
+	}`)
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatalf("write compact lockfile: %v", err)
+	}
+
+	got, err := Load(path)
+	if err != nil {
+		t.Fatalf("load compact lockfile: %v", err)
+	}
+	if got.RunCompleted["locales/fr.json::hello"].SourceHash != "source-a" {
+		t.Fatalf("expected grouped object completion, got %+v", got.RunCompleted)
+	}
+	if got.RunCompleted["locales/fr.json::bye"].TaskHash != "task-b" {
+		t.Fatalf("expected grouped tuple completion, got %+v", got.RunCompleted)
+	}
+}
+
+func TestSaveAndLoadGroupedRunCheckpoint(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "checkpoint.lock.json")
+	now := time.Unix(1700000000, 0).UTC()
+	fullSourceHash := strings.Repeat("c", 128)
+	fullTaskHash := strings.Repeat("D", 128)
+
+	if err := Save(path, File{
+		ActiveRunID: "run_1",
+		RunCheckpoint: map[string]RunCheckpoint{
+			"locales/fr.json::hello": {
+				RunID:        "run_1",
+				TargetPath:   "locales/fr.json",
+				SourcePath:   "locales/en.json",
+				TargetLocale: "fr",
+				EntryKey:     "hello",
+				Value:        "Bonjour",
+				SourceHash:   fullSourceHash,
+				TaskHash:     fullTaskHash,
+				UpdatedAt:    now,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("save checkpoint lockfile: %v", err)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read saved lockfile: %v", err)
+	}
+	rewritten := string(content)
+	for _, legacyKey := range []string{"target_path", "entry_key", "source_hash", "task_hash", fullSourceHash, fullTaskHash} {
+		if strings.Contains(rewritten, legacyKey) {
+			t.Fatalf("expected compact checkpoint encoding without %q, got %s", legacyKey, rewritten)
+		}
+	}
+
+	got, err := Load(path)
+	if err != nil {
+		t.Fatalf("load checkpoint lockfile: %v", err)
+	}
+	checkpoint := got.RunCheckpoint["locales/fr.json::hello"]
+	if checkpoint.TargetPath != "locales/fr.json" || checkpoint.EntryKey != "hello" {
+		t.Fatalf("expected identity to round-trip from grouped checkpoint, got %+v", checkpoint)
+	}
+	if checkpoint.SourcePath != "locales/en.json" || checkpoint.TargetLocale != "fr" || checkpoint.Value != "Bonjour" {
+		t.Fatalf("unexpected checkpoint payload: %+v", checkpoint)
+	}
+	if checkpoint.SourceHash != "cccccccccccccccccccccccccccccccc" || checkpoint.TaskHash != "dddddddddddddddddddddddddddddddd" {
+		t.Fatalf("unexpected compact checkpoint hashes: %+v", checkpoint)
+	}
+	if !checkpoint.UpdatedAt.Equal(now) {
+		t.Fatalf("unexpected checkpoint updated_at: %+v", checkpoint.UpdatedAt)
+	}
+}
+
+func TestLoadLegacyFlatRunCheckpoint(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "legacy-checkpoint.lock.json")
+	fullSourceHash := strings.Repeat("e", 128)
+	content := []byte(`{
+	  "active_run_id": "run_1",
+	  "run_checkpoint": {
+	    "locales/fr.json::hello": {
+	      "run_id": "run_1",
+	      "target_path": "locales/fr.json",
+	      "source_path": "locales/en.json",
+	      "target_locale": "fr",
+	      "entry_key": "hello",
+	      "value": "Bonjour",
+	      "source_hash": "` + fullSourceHash + `",
+	      "updated_at": "2023-11-14T22:13:20Z"
+	    }
+	  }
+	}`)
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatalf("write legacy checkpoint lockfile: %v", err)
+	}
+
+	got, err := Load(path)
+	if err != nil {
+		t.Fatalf("load legacy checkpoint lockfile: %v", err)
+	}
+	checkpoint := got.RunCheckpoint["locales/fr.json::hello"]
+	if checkpoint.RunID != "run_1" || checkpoint.SourcePath != "locales/en.json" || checkpoint.Value != "Bonjour" {
+		t.Fatalf("unexpected legacy checkpoint: %+v", checkpoint)
+	}
+	if checkpoint.SourceHash != "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" {
+		t.Fatalf("expected compacted legacy checkpoint hash, got %+v", checkpoint)
 	}
 }
 

--- a/docs/reference/lockfile-contract.mdx
+++ b/docs/reference/lockfile-contract.mdx
@@ -11,7 +11,7 @@ The lockfile name is fixed to `.hyperlocalise.lock.json`.
 
 Keep the file in your project root so `run` and sync commands share the same checkpoint state.
 
-The CLI writes the lockfile as **compact JSON** (no indentation) to limit file size.
+The CLI writes the lockfile as **indented JSON** so diffs are readable. It keeps file size down by grouping task entries by target path and storing short field names.
 
 ## What the lockfile is for
 
@@ -41,8 +41,11 @@ Current shape:
     }
   },
   "run_completed": {
-    "apps/web/lang/es-ES.json::checkout.submit": {
-      "source_hash": "7f4f7d..."
+    "apps/web/lang/es-ES.json": {
+      "checkout.submit": {
+        "s": "7f4f7d...",
+        "t": "1a2b3c..."
+      }
     }
   }
 }
@@ -56,9 +59,19 @@ Field meanings:
 - `locale_states`: per-locale checkpoint map.
   - `revision`: adapter revision or cursor for incremental pull logic.
   - `updated_at`: last time that locale checkpoint was refreshed.
-- `run_completed`: per-task completion map used by `run` for skip decisions.
-  - `source_hash`: fingerprint of the source segment. New writes use a **32-character** lowercase hex prefix of SHA-512. Older lockfiles may still store the full **128-character** hex digest; both forms are accepted when deciding whether to skip work.
-  - `task_hash`: when present, fingerprint of task dimensions (model, prompt, context fields, and related inputs). It uses the same encoding rules as `source_hash`.
+- `run_completed`: per-task completion map used by `run` for skip decisions. Current writes group entries by target path.
+  - nested key: entry key inside the target file.
+  - `s`: fingerprint of the source segment.
+  - `t`: fingerprint of task dimensions, such as model, prompt, context fields, and related inputs.
+- `active_run_id`: identifier for an in-progress run. It is cleared after a successful run.
+- `run_checkpoint`: temporary per-task output checkpoint for interrupted runs. It is grouped by target path and cleared after a successful run.
+  - `r`: run identifier.
+  - `p`: source path.
+  - `l`: target locale.
+  - `v`: staged output value.
+  - `s`, `t`, and `u`: source fingerprint, task fingerprint, and update timestamp.
+
+New writes use a **32-character** lowercase hex prefix of SHA-512 for fingerprints. Older lockfiles may still store flat `target::entry` keys and full field names such as `source_hash` and `task_hash`. They may also store full **128-character** hex digests. The CLI accepts both shapes and both digest lengths.
 
 ## Lifecycle by command
 


### PR DESCRIPTION
## What changed

Updated `.hyperlocalise.lock.json` handling so the CLI writes a grouped, indented JSON format instead of flat one-line JSON.

- Groups `run_completed` and `run_checkpoint` entries by target path.
- Uses short on-disk field names for high-volume lockfile data.
- Compacts legacy 128-character SHA-512 fingerprints to the 32-character form already accepted by the CLI.
- Keeps backward compatibility for existing flat `target::entry` lockfiles and legacy field names.
- Updates the lockfile contract docs to describe the current readable format.

## How to test

- `go test ./apps/cli/internal/i18n/lockfile ./apps/cli/internal/i18n/runsvc`
- `make fmt`
- `make lint`
- `make test`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
