### PR TITLE
fix(crowdin): skip source fallbacks in approved merges

### DIFF
--- a/docs/commands/crowdin.mdx
+++ b/docs/commands/crowdin.mdx
@@ -124,3 +124,4 @@ hyperlocalise crowdin download --language fr --merge-approved
 ```
 
 `--merge-approved` currently supports JSON object translation files. It forces an approved-only sparse export for the request, then overwrites only keys present in the approved Crowdin payload.
+Downloaded values that still match the source JSON are treated as Crowdin source-language fallbacks and are not merged over existing local translations.

--- a/docs/storage/crowdin.mdx
+++ b/docs/storage/crowdin.mdx
@@ -104,6 +104,7 @@ hyperlocalise crowdin download --language fr --include-sources
 ```
 
 `--merge-approved` merges approved JSON object keys into existing local translation files and preserves local keys omitted from Crowdin's approved export.
+When Crowdin includes source-language fallback values in that export, Hyperlocalise skips values that still match the source JSON so previously translated local strings are preserved.
 
 `--include-sources` also downloads matching Crowdin source files into the configured `files[].source` paths before writing translations. Exact source paths can be created locally if missing; globbed source paths are limited to files matched by local glob expansion.
 

--- a/internal/i18n/storage/crowdin/filemode.go
+++ b/internal/i18n/storage/crowdin/filemode.go
@@ -286,16 +286,17 @@ func mergeApprovedJSONFile(sourcePath, targetPath string, approvedPayload []byte
 		return nil, fmt.Errorf("merge approved translations: downloaded payload for %s must be a JSON object: %w", targetPath, err)
 	}
 	sourcePayload, err := os.ReadFile(sourcePath)
-	if err != nil {
+	if err == nil {
+		source, err := decodeOrderedJSONObject(sourcePayload)
+		if err != nil {
+			return nil, fmt.Errorf("merge approved translations: source file %s must be a JSON object: %w", sourcePath, err)
+		}
+		approved, err = filterSourceFallbackJSONObjects(approved, source)
+		if err != nil {
+			return nil, fmt.Errorf("merge approved translations: filter source-language fallback values: %w", err)
+		}
+	} else if !os.IsNotExist(err) {
 		return nil, fmt.Errorf("merge approved translations: read source file %s: %w", sourcePath, err)
-	}
-	source, err := decodeOrderedJSONObject(sourcePayload)
-	if err != nil {
-		return nil, fmt.Errorf("merge approved translations: source file %s must be a JSON object: %w", sourcePath, err)
-	}
-	approved, err = filterSourceFallbackJSONObjects(approved, source)
-	if err != nil {
-		return nil, fmt.Errorf("merge approved translations: filter source-language fallback values: %w", err)
 	}
 	if len(approved) == 0 {
 		if existing, err := os.ReadFile(targetPath); err == nil {
@@ -459,11 +460,16 @@ func cloneOrderedJSONMember(member orderedJSONMember) orderedJSONMember {
 }
 
 func jsonValuesEqual(left, right json.RawMessage) (bool, error) {
-	var leftString, rightString string
-	if err := json.Unmarshal(left, &leftString); err == nil {
-		if err := json.Unmarshal(right, &rightString); err == nil {
-			return leftString == rightString, nil
-		}
+	leftString, leftIsString, err := decodeJSONString(left)
+	if err != nil {
+		return false, err
+	}
+	rightString, rightIsString, err := decodeJSONString(right)
+	if err != nil {
+		return false, err
+	}
+	if leftIsString || rightIsString {
+		return leftIsString && rightIsString && leftString == rightString, nil
 	}
 
 	var leftValue any
@@ -475,6 +481,17 @@ func jsonValuesEqual(left, right json.RawMessage) (bool, error) {
 		return false, err
 	}
 	return reflect.DeepEqual(leftValue, rightValue), nil
+}
+
+func decodeJSONString(payload json.RawMessage) (string, bool, error) {
+	if !bytes.HasPrefix(bytes.TrimSpace(payload), []byte(`"`)) {
+		return "", false, nil
+	}
+	var value string
+	if err := json.Unmarshal(payload, &value); err != nil {
+		return "", false, err
+	}
+	return value, true, nil
 }
 
 func orderedJSONObjectIndex(obj orderedJSONObject, key string) int {

--- a/internal/i18n/storage/crowdin/filemode.go
+++ b/internal/i18n/storage/crowdin/filemode.go
@@ -9,6 +9,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"slices"
 	"strconv"
@@ -245,7 +246,7 @@ func (a *FileAdapter) DownloadTranslations(ctx context.Context, req storage.File
 					return storage.FileOperationResult{Processed: processed, Skipped: skipped}, fmt.Errorf("mkdir translation output: %w", err)
 				}
 				if req.MergeApproved {
-					payload, err = mergeApprovedJSONFile(targetPath, payload)
+					payload, err = mergeApprovedJSONFile(sourcePath, targetPath, payload)
 					if err != nil {
 						return storage.FileOperationResult{Processed: processed, Skipped: skipped}, err
 					}
@@ -279,10 +280,22 @@ func effectiveFileExportOptions(base storage.FileExportOptions, overrides *stora
 	return base
 }
 
-func mergeApprovedJSONFile(targetPath string, approvedPayload []byte) ([]byte, error) {
+func mergeApprovedJSONFile(sourcePath, targetPath string, approvedPayload []byte) ([]byte, error) {
 	approved, err := decodeOrderedJSONObject(approvedPayload)
 	if err != nil {
 		return nil, fmt.Errorf("merge approved translations: downloaded payload for %s must be a JSON object: %w", targetPath, err)
+	}
+	sourcePayload, err := os.ReadFile(sourcePath)
+	if err != nil {
+		return nil, fmt.Errorf("merge approved translations: read source file %s: %w", sourcePath, err)
+	}
+	source, err := decodeOrderedJSONObject(sourcePayload)
+	if err != nil {
+		return nil, fmt.Errorf("merge approved translations: source file %s must be a JSON object: %w", sourcePath, err)
+	}
+	approved, err = filterSourceFallbackJSONObjects(approved, source)
+	if err != nil {
+		return nil, fmt.Errorf("merge approved translations: filter source-language fallback values: %w", err)
 	}
 	if len(approved) == 0 {
 		if existing, err := os.ReadFile(targetPath); err == nil {
@@ -391,6 +404,77 @@ func mergeOrderedJSONObjects(existing, approved orderedJSONObject) (orderedJSONO
 		merged[existingIndex].value = formatOrderedJSONObject(nested, 0)
 	}
 	return merged, nil
+}
+
+func filterSourceFallbackJSONObjects(approved, source orderedJSONObject) (orderedJSONObject, error) {
+	filtered := make(orderedJSONObject, 0, len(approved))
+	for _, approvedMember := range approved {
+		sourceIndex := orderedJSONObjectIndex(source, approvedMember.key)
+		if sourceIndex == -1 {
+			filtered = append(filtered, cloneOrderedJSONMember(approvedMember))
+			continue
+		}
+
+		sourceMember := source[sourceIndex]
+		if isJSONObject(approvedMember.value) && isJSONObject(sourceMember.value) {
+			approvedObject, err := decodeOrderedJSONObject(approvedMember.value)
+			if err != nil {
+				return nil, err
+			}
+			sourceObject, err := decodeOrderedJSONObject(sourceMember.value)
+			if err != nil {
+				return nil, err
+			}
+			nested, err := filterSourceFallbackJSONObjects(approvedObject, sourceObject)
+			if err != nil {
+				return nil, err
+			}
+			if len(nested) == 0 {
+				continue
+			}
+			filtered = append(filtered, orderedJSONMember{
+				key:   approvedMember.key,
+				value: formatOrderedJSONObject(nested, 0),
+			})
+			continue
+		}
+
+		equal, err := jsonValuesEqual(approvedMember.value, sourceMember.value)
+		if err != nil {
+			return nil, err
+		}
+		if equal {
+			continue
+		}
+		filtered = append(filtered, cloneOrderedJSONMember(approvedMember))
+	}
+	return filtered, nil
+}
+
+func cloneOrderedJSONMember(member orderedJSONMember) orderedJSONMember {
+	return orderedJSONMember{
+		key:   member.key,
+		value: append(json.RawMessage(nil), member.value...),
+	}
+}
+
+func jsonValuesEqual(left, right json.RawMessage) (bool, error) {
+	var leftString, rightString string
+	if err := json.Unmarshal(left, &leftString); err == nil {
+		if err := json.Unmarshal(right, &rightString); err == nil {
+			return leftString == rightString, nil
+		}
+	}
+
+	var leftValue any
+	if err := json.Unmarshal(left, &leftValue); err != nil {
+		return false, err
+	}
+	var rightValue any
+	if err := json.Unmarshal(right, &rightValue); err != nil {
+		return false, err
+	}
+	return reflect.DeepEqual(leftValue, rightValue), nil
 }
 
 func orderedJSONObjectIndex(obj orderedJSONObject, key string) int {

--- a/internal/i18n/storage/crowdin/filemode_test.go
+++ b/internal/i18n/storage/crowdin/filemode_test.go
@@ -516,6 +516,44 @@ func TestFileAdapterDownloadTranslationsMergeApprovedPreservesNestedJSON(t *test
 	}
 }
 
+func TestFileAdapterDownloadTranslationsMergeApprovedSkipsSourceFallbacks(t *testing.T) {
+	base := t.TempDir()
+	writeJSONFixture(t, filepath.Join(base, "src", "messages.json"), `{"hello":"Hello","bye":"Bye","nav":{"home":"Home","about":"About"},"new":"New"}`)
+	targetPath := writeJSONFixture(t, filepath.Join(base, "download", "fr", "messages.json"), `{"hello":"Bonjour old","bye":"Au revoir","nav":{"home":"Accueil","about":"A propos"},"draft":"Brouillon"}`)
+
+	client := &fakeFileClient{
+		locales:         []ResolvedLocale{{LanguageID: "fr", Locale: "fr"}},
+		directories:     map[string]int{"src": 1},
+		failFindMissing: true,
+		downloadPayload: []byte(`{"hello":"Bonjour approved","bye":"Bye","nav":{"home":"Home","about":"A propos approved"},"new":"New"}`),
+	}
+	adapter := mustNewFileAdapterForTest(t, storage.FileWorkflowConfig{
+		ProjectID:         "123",
+		APIToken:          "token",
+		BasePath:          base,
+		PreserveHierarchy: true,
+		Files: []storage.FileGroupSpec{{
+			Source:      "/src/*.json",
+			Translation: "/download/%locale%/%original_file_name%",
+		}},
+	}, client)
+
+	if _, err := adapter.UploadSources(context.Background(), storage.FileUploadSourcesRequest{}); err != nil {
+		t.Fatalf("upload sources: %v", err)
+	}
+	if _, err := adapter.DownloadTranslations(context.Background(), storage.FileDownloadTranslationsRequest{MergeApproved: true}); err != nil {
+		t.Fatalf("download translations: %v", err)
+	}
+	payload, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	want := "{\n  \"hello\": \"Bonjour approved\",\n  \"bye\": \"Au revoir\",\n  \"nav\": {\n    \"home\": \"Accueil\",\n    \"about\": \"A propos approved\"\n  },\n  \"draft\": \"Brouillon\"\n}\n"
+	if string(payload) != want {
+		t.Fatalf("payload = %q, want %q", string(payload), want)
+	}
+}
+
 func TestFileAdapterDownloadTranslationsMergeApprovedCreatesMissingJSON(t *testing.T) {
 	base := t.TempDir()
 	writeJSONFixture(t, filepath.Join(base, "src", "messages.json"), `{"hello":"Hello"}`)

--- a/internal/i18n/storage/crowdin/filemode_test.go
+++ b/internal/i18n/storage/crowdin/filemode_test.go
@@ -2,6 +2,7 @@ package crowdin
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -554,6 +555,41 @@ func TestFileAdapterDownloadTranslationsMergeApprovedSkipsSourceFallbacks(t *tes
 	}
 }
 
+func TestFileAdapterDownloadTranslationsMergeApprovedFallsBackWhenSourceMissing(t *testing.T) {
+	base := t.TempDir()
+	targetPath := writeJSONFixture(t, filepath.Join(base, "download", "fr", "messages.json"), `{"hello":"Bonjour old","draft":"Brouillon"}`)
+
+	client := &fakeFileClient{
+		locales:         []ResolvedLocale{{LanguageID: "fr", Locale: "fr"}},
+		directories:     map[string]int{"src": 1},
+		files:           map[string]int{"messages.json": 7},
+		failFindMissing: true,
+		downloadPayload: []byte(`{"hello":"Bonjour approved","bye":"Au revoir"}`),
+	}
+	adapter := mustNewFileAdapterForTest(t, storage.FileWorkflowConfig{
+		ProjectID:         "123",
+		APIToken:          "token",
+		BasePath:          base,
+		PreserveHierarchy: true,
+		Files: []storage.FileGroupSpec{{
+			Source:      "/src/messages.json",
+			Translation: "/download/%locale%/%original_file_name%",
+		}},
+	}, client)
+
+	if _, err := adapter.DownloadTranslations(context.Background(), storage.FileDownloadTranslationsRequest{MergeApproved: true}); err != nil {
+		t.Fatalf("download translations: %v", err)
+	}
+	payload, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	want := "{\n  \"hello\": \"Bonjour approved\",\n  \"draft\": \"Brouillon\",\n  \"bye\": \"Au revoir\"\n}\n"
+	if string(payload) != want {
+		t.Fatalf("payload = %q, want %q", string(payload), want)
+	}
+}
+
 func TestFileAdapterDownloadTranslationsMergeApprovedCreatesMissingJSON(t *testing.T) {
 	base := t.TempDir()
 	writeJSONFixture(t, filepath.Join(base, "src", "messages.json"), `{"hello":"Hello"}`)
@@ -916,6 +952,52 @@ func TestFileAdapterDownloadTranslationsHandlesSkippedFiles(t *testing.T) {
 	wantSkipped := []string{"src/messages.json@fr"}
 	if !reflect.DeepEqual(result.Skipped, wantSkipped) {
 		t.Fatalf("skipped = %v, want %v", result.Skipped, wantSkipped)
+	}
+}
+
+func TestJSONValuesEqual(t *testing.T) {
+	tests := []struct {
+		name  string
+		left  string
+		right string
+		want  bool
+	}{
+		{
+			name:  "matching strings",
+			left:  `"Hello"`,
+			right: `"Hello"`,
+			want:  true,
+		},
+		{
+			name:  "string and number are not equal",
+			left:  `"1"`,
+			right: `1`,
+			want:  false,
+		},
+		{
+			name:  "matching numbers",
+			left:  `1`,
+			right: `1`,
+			want:  true,
+		},
+		{
+			name:  "matching arrays",
+			left:  `[true,null]`,
+			right: `[true,null]`,
+			want:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := jsonValuesEqual(json.RawMessage(tt.left), json.RawMessage(tt.right))
+			if err != nil {
+				t.Fatalf("json values equal: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("jsonValuesEqual(%s, %s) = %v, want %v", tt.left, tt.right, got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## What changed

Updated Crowdin `--merge-approved` downloads so source-language fallback values do not overwrite existing local translations.

When Crowdin includes English strings in an approved-only export, Hyperlocalise now compares downloaded JSON values against the matching source JSON and skips values that still match the source. This preserves previously translated strings while still merging genuinely approved translations. Docs now describe this behavior.

## How to test

- `make fmt`
- `go test ./internal/i18n/storage/crowdin`
- `make lint`
- `make test`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
