### PR TITLE
🛡️ Sentinel: [HIGH] Fix unauthorized HTML injection in Liquid/HTML parsers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** AI-triggered mutation tools (creating jobs, glossaries, TMs) lacked RBAC checks, allowing users with the "member" role to perform administrative actions through the chat agent that were blocked in the equivalent REST API.
 **Learning:** Agent-based tool execution can bypass standard route-level middleware if the tool context does not explicitly carry and check user permissions.
 **Prevention:** Include `membershipRole` in the `ToolContext` passed to all AI tools and enforce `isMutationAllowed` checks (limiting to owner/admin) within the tool execution logic.
+
+## 2026-05-20 - [High] Unauthorized HTML Injection in Liquid/HTML Translations
+**Vulnerability:** The Liquid and HTML parsers allowed translated segments to include raw HTML tags that were not present in the source. Since these parsers use placeholders for all original markup, any tag found in a translation segment (before placeholder expansion) is an unauthorized injection.
+**Learning:** Even when a parser correctly "protects" original markup with placeholders, it must also verify that no *new* markup is introduced in the "clean" text returned by translators.
+**Prevention:** Apply a `containsHTMLTag` check to all translated segments during the rendering phase. If any unauthorized tags are detected, fall back to the source text to prevent potential XSS.

--- a/internal/i18n/translationfileparser/html_parser.go
+++ b/internal/i18n/translationfileparser/html_parser.go
@@ -82,6 +82,10 @@ var htmlSkipElements = map[string]bool{
 // original unmodified bytes.
 var htmlTagPattern = regexp.MustCompile(`<(?:[^>"']*(?:"[^"]*"|'[^']*'))*[^>]*>`)
 
+func containsHTMLTag(s string) bool {
+	return htmlTagPattern.MatchString(s)
+}
+
 // htmlStructuralElements are container tags that are always emitted as
 // literals rather than buffered as inline content. This prevents </body>,
 // </html>, etc. from being wrapped in a translation unit when orphaned inline
@@ -408,6 +412,7 @@ func (d htmlDocument) render(values map[string]string) ([]byte, HTMLRenderDiagno
 		rendered := preserveChunkBoundaryWhitespace(part.source, translated)
 		// Ensure every placeholder survived translation. A dropped placeholder
 		// means source markup was lost; fall back rather than emit incomplete HTML.
+		// We also check for any newly introduced HTML tags to prevent XSS.
 		allPresent := true
 		for ph := range part.placeholders {
 			if !strings.Contains(rendered, ph) {
@@ -415,7 +420,7 @@ func (d htmlDocument) render(values map[string]string) ([]byte, HTMLRenderDiagno
 				break
 			}
 		}
-		if !allPresent {
+		if !allPresent || containsHTMLTag(rendered) {
 			diags.SourceFallbackKeys = append(diags.SourceFallbackKeys, part.key)
 			b.WriteString(expandHTMLPlaceholders(part.source, part.placeholders))
 			continue

--- a/internal/i18n/translationfileparser/html_parser_test.go
+++ b/internal/i18n/translationfileparser/html_parser_test.go
@@ -702,3 +702,38 @@ func TestHTMLParserImgWithoutAltDoesNotFragmentProse(t *testing.T) {
 		}
 	}
 }
+
+func TestMarshalHTMLRejectsUnauthorizedHTML(t *testing.T) {
+	template := []byte("<div>Hello <b>world</b></div>")
+	parser := HTMLParser{}
+	entries, err := parser.Parse(template)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	var key string
+	var source string
+	for k, v := range entries {
+		key = k
+		source = v
+		break
+	}
+
+	// Malicious translation containing an img tag with onerror
+	maliciousTranslation := source + "<img src=x onerror=alert(1)>"
+
+	translatedValues := map[string]string{
+		key: maliciousTranslation,
+	}
+
+	output, diags := MarshalHTML(template, translatedValues)
+	rendered := string(output)
+
+	if len(diags.SourceFallbackKeys) == 0 {
+		t.Errorf("Expected fallback for key %s, but got none", key)
+	}
+
+	if strings.Contains(rendered, "<img src=x") {
+		t.Errorf("Security vulnerability: output contains raw img tag: %s", rendered)
+	}
+}

--- a/internal/i18n/translationfileparser/liquid_parser.go
+++ b/internal/i18n/translationfileparser/liquid_parser.go
@@ -420,7 +420,7 @@ func (d liquidDocument) renderTextPart(part htmlPart, values map[string]string, 
 	}
 
 	rendered := preserveChunkBoundaryWhitespace(part.source, translated)
-	if !htmlPlaceholdersPresent(part, rendered) || !liquidPlaceholdersPresent(part.source, rendered) {
+	if !htmlPlaceholdersPresent(part, rendered) || !liquidPlaceholdersPresent(part.source, rendered) || containsHTMLTag(rendered) {
 		diags.SourceFallbackKeys = append(diags.SourceFallbackKeys, part.key)
 		return renderLiquidSourcePart(part, d.liquidPlaceholders)
 	}

--- a/internal/i18n/translationfileparser/liquid_parser.go
+++ b/internal/i18n/translationfileparser/liquid_parser.go
@@ -420,6 +420,8 @@ func (d liquidDocument) renderTextPart(part htmlPart, values map[string]string, 
 	}
 
 	rendered := preserveChunkBoundaryWhitespace(part.source, translated)
+	// Ensure every placeholder survived translation and no new HTML tags were
+	// introduced (to prevent XSS).
 	if !htmlPlaceholdersPresent(part, rendered) || !liquidPlaceholdersPresent(part.source, rendered) || containsHTMLTag(rendered) {
 		diags.SourceFallbackKeys = append(diags.SourceFallbackKeys, part.key)
 		return renderLiquidSourcePart(part, d.liquidPlaceholders)

--- a/internal/i18n/translationfileparser/liquid_parser_test.go
+++ b/internal/i18n/translationfileparser/liquid_parser_test.go
@@ -507,3 +507,38 @@ func liquidValueContaining(t *testing.T, values map[string]string, want string) 
 	t.Fatalf("expected value containing %q in %#v", want, values)
 	return ""
 }
+
+func TestMarshalLiquidRejectsUnauthorizedHTML(t *testing.T) {
+	template := []byte("<p>Welcome, {{ user.name }}!</p>")
+	parser := LiquidParser{}
+	entries, err := parser.Parse(template)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	var key string
+	var source string
+	for k, v := range entries {
+		key = k
+		source = v
+		break
+	}
+
+	// Malicious translation containing a script tag
+	maliciousTranslation := source + "<script>alert('XSS')</script>"
+
+	translatedValues := map[string]string{
+		key: maliciousTranslation,
+	}
+
+	output, diags := MarshalLiquid(template, translatedValues)
+	rendered := string(output)
+
+	if len(diags.SourceFallbackKeys) == 0 {
+		t.Errorf("Expected fallback for key %s, but got none", key)
+	}
+
+	if strings.Contains(rendered, "<script>") {
+		t.Errorf("Security vulnerability: output contains raw script tag: %s", rendered)
+	}
+}


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: Unauthorized HTML/Script injection in translated segments for Liquid and HTML templates.
🎯 **Impact**: Potential XSS if a translation provider or the translation memory is compromised and serves malicious markup.
🔧 **Fix**: Implemented a `containsHTMLTag` check during rendering that detects new HTML tags in translated segments and falls back to the original source text if any are found.
✅ **Verification**: Added `TestMarshalLiquidRejectsUnauthorizedHTML` and `TestMarshalHTMLRejectsUnauthorizedHTML` to verify the fix and ensure no regressions in existing parsing logic.

---
*PR created automatically by Jules for task [9748985962980347509](https://jules.google.com/task/9748985962980347509) started by @cungminh2710*