### PR TITLE
fix(crowdin): improve pre-translation parity and fix TagsDetection typo

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -23,3 +23,9 @@
 **Learning:** The Crowdin API v2 Apply Pre-Translation endpoint supports `branchIds` and `directoryIds` in the request body, allowing for more granular targeting than just `fileIds`. Additionally, the response attributes include `directoryIds`.
 
 **Action:** Added `BranchIDs` and `DirectoryIDs` to `PreTranslationRequest` and `DirectoryIDs` to `PreTranslationAttributes` in `model/translations.go`. Updated `PreTranslationRequest.Validate()` to require at least one of `fileIds`, `branchIds`, or `directoryIds`. Verified with updated unit tests.
+
+## 2026-06-05 - Improve Pre-Translation parity and fix TagsDetection typo
+
+**Learning:** The Pre-Translation status response includes an `eta` field and several attributes (`engineId`, `aiPromptId`, `fallbackLanguages`, `labelIds`, `excludeLabelIds`) that were missing from the SDK models. Additionally, documentation for `TagsDetection` was using incorrect values for "Skip tags".
+
+**Action:** Added `ETA` to `PreTranslation` and missing fields to `PreTranslationAttributes`. Used `*int` for `EngineID` and `AIPromptID` to correctly handle zero values vs omission. Updated `PreTranslationRequest` to include these fields as well. Corrected the `TagsDetection` comment in `ProjectsAddRequest`. Updated contract tests to verify parsing of these new fields.

--- a/third_party/crowdin-api-client-go/crowdin/model/projects.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/projects.go
@@ -206,7 +206,7 @@ type ProjectsAddRequest struct {
 	Cname string `json:"cname,omitempty"`
 	// Project description.
 	Description string `json:"description,omitempty"`
-	// Values available: 0 - Auto, 1 - Count tags, 1 - Skip tags. Default: 0.
+	// Values available: 0 - Auto, 1 - Count tags, 2 - Skip tags. Default: 0.
 	TagsDetection *int `json:"tagsDetection,omitempty"`
 	// Allows machine translations (Microsoft Translator, Google Translate) be visible
 	// for translators in the Editor. Default: true.

--- a/third_party/crowdin-api-client-go/crowdin/model/translations.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/translations.go
@@ -18,19 +18,25 @@ type (
 		UpdatedAt  string                    `json:"updatedAt"`
 		StartedAt  string                    `json:"startedAt,omitempty"`
 		FinishedAt string                    `json:"finishedAt,omitempty"`
+		ETA        string                    `json:"eta,omitempty"`
 	}
 
 	PreTranslationAttributes struct {
-		LanguageIDs                   []string `json:"languageIds"`
-		BranchIDs                     []int    `json:"branchIds,omitempty"`
-		DirectoryIDs                  []int    `json:"directoryIds,omitempty"`
-		FileIDs                       []int    `json:"fileIds,omitempty"`
-		Method                        *string  `json:"method,omitempty"`
-		AutoApproveOption             *string  `json:"autoApproveOption,omitempty"`
-		DuplicateTranslations         *bool    `json:"duplicateTranslations,omitempty"`
-		SkipApprovedTranslations      *bool    `json:"skipApprovedTranslations,omitempty"`
-		TranslateUntranslatedOnly     *bool    `json:"translateUntranslatedOnly,omitempty"`
-		TranslateWithPerfectMatchOnly *bool    `json:"translateWithPerfectMatchOnly,omitempty"`
+		LanguageIDs                   []string            `json:"languageIds"`
+		BranchIDs                     []int               `json:"branchIds,omitempty"`
+		DirectoryIDs                  []int               `json:"directoryIds,omitempty"`
+		FileIDs                       []int               `json:"fileIds,omitempty"`
+		Method                        *string             `json:"method,omitempty"`
+		EngineID                      *int                `json:"engineId,omitempty"`
+		AIPromptID                    *int                `json:"aiPromptId,omitempty"`
+		AutoApproveOption             *string             `json:"autoApproveOption,omitempty"`
+		DuplicateTranslations         *bool               `json:"duplicateTranslations,omitempty"`
+		SkipApprovedTranslations      *bool               `json:"skipApprovedTranslations,omitempty"`
+		TranslateUntranslatedOnly     *bool               `json:"translateUntranslatedOnly,omitempty"`
+		TranslateWithPerfectMatchOnly *bool               `json:"translateWithPerfectMatchOnly,omitempty"`
+		FallbackLanguages             map[string][]string `json:"fallbackLanguages,omitempty"`
+		LabelIDs                      []int               `json:"labelIds,omitempty"`
+		ExcludeLabelIDs               []int               `json:"excludeLabelIds,omitempty"`
 	}
 
 	PreTranslationReport struct {
@@ -102,9 +108,9 @@ type PreTranslationRequest struct {
 	//  - ai – pre-translation via AI. "ai" should be used with `aiPromptId` parameter.
 	Method string `json:"method,omitempty"`
 	// Machine Translation engine Identifier. Required if `method` is set to "mt".
-	EngineID int `json:"engineId,omitempty"`
+	EngineID *int `json:"engineId,omitempty"`
 	// AI Prompt Identifier. Required if `method` is set to "ai".
-	AIPromptID int `json:"aiPromptId,omitempty"`
+	AIPromptID *int `json:"aiPromptId,omitempty"`
 	// Defines which translations added by TM pre-translation should be auto-approved. Default: "none".
 	// Enum: "all", "exceptAutoSubstituted", "perfectMatchApprovedOnly", "perfectMatchOnly", "none"
 	//  - all – all
@@ -150,10 +156,10 @@ func (r *PreTranslationRequest) Validate() error {
 	if len(r.FileIDs) == 0 && len(r.BranchIDs) == 0 && len(r.DirectoryIDs) == 0 {
 		return errors.New("one of fileIds, branchIds or directoryIds is required")
 	}
-	if r.Method == "ai" && r.AIPromptID == 0 {
+	if r.Method == "ai" && (r.AIPromptID == nil || *r.AIPromptID == 0) {
 		return errors.New("aiPromptId is required")
 	}
-	if r.Method == "mt" && r.EngineID == 0 {
+	if r.Method == "mt" && (r.EngineID == nil || *r.EngineID == 0) {
 		return errors.New("engineId is required")
 	}
 	return nil

--- a/third_party/crowdin-api-client-go/crowdin/model/translations_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/translations_test.go
@@ -32,7 +32,7 @@ func TestPreTranslationRequestValidate(t *testing.T) {
 			name: "valid request",
 			req: &PreTranslationRequest{
 				LanguageIDs: []string{"uk"}, FileIDs: []int{1, 2},
-				Method: "tm", EngineID: 1, AutoApproveOption: "all", DuplicateTranslations: toPtr(false),
+				Method: "tm", EngineID: toPtr(1), AutoApproveOption: "all", DuplicateTranslations: toPtr(false),
 			},
 			valid: true,
 		},
@@ -48,7 +48,7 @@ func TestPreTranslationRequestValidate(t *testing.T) {
 			name: "valid request with ai method",
 			req: &PreTranslationRequest{
 				LanguageIDs: []string{"uk"}, FileIDs: []int{1, 2},
-				Method: "ai", AIPromptID: 1, AutoApproveOption: "all", DuplicateTranslations: toPtr(false),
+				Method: "ai", AIPromptID: toPtr(1), AutoApproveOption: "all", DuplicateTranslations: toPtr(false),
 			},
 			valid: true,
 		},
@@ -64,7 +64,7 @@ func TestPreTranslationRequestValidate(t *testing.T) {
 			name: "valid request with mt method",
 			req: &PreTranslationRequest{
 				LanguageIDs: []string{"uk"}, FileIDs: []int{1, 2},
-				Method: "mt", EngineID: 1, AutoApproveOption: "all", DuplicateTranslations: toPtr(false),
+				Method: "mt", EngineID: toPtr(1), AutoApproveOption: "all", DuplicateTranslations: toPtr(false),
 			},
 			valid: true,
 		},

--- a/third_party/crowdin-api-client-go/crowdin/translations_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/translations_test.go
@@ -29,16 +29,24 @@ func TestTranslationsService_PreTranslationStatus(t *testing.T) {
 					"languageIds": ["uk"],
 					"fileIds": [742],
 					"method": "tm",
+					"engineId": 1,
+					"aiPromptId": 2,
 					"autoApproveOption": "all",
 					"duplicateTranslations": true,
 					"skipApprovedTranslations": true,
 					"translateUntranslatedOnly": true,
-					"translateWithPerfectMatchOnly": true
+					"translateWithPerfectMatchOnly": true,
+					"fallbackLanguages": {
+						"es": ["en"]
+					},
+					"labelIds": [3],
+					"excludeLabelIds": [4]
 				},
 				"createdAt": "2023-09-20T14:05:50+00:00",
 				"updatedAt": "2023-09-20T14:05:50+00:00",
 				"startedAt": "2023-08-24T14:15:22Z",
-				"finishedAt": "2023-08-24T14:15:22Z"
+				"finishedAt": "2023-08-24T14:15:22Z",
+				"eta": "10s"
 			}
 		}`)
 	})
@@ -54,16 +62,24 @@ func TestTranslationsService_PreTranslationStatus(t *testing.T) {
 			LanguageIDs:                   []string{"uk"},
 			FileIDs:                       []int{742},
 			Method:                        ToPtr("tm"),
+			EngineID:                      ToPtr(1),
+			AIPromptID:                    ToPtr(2),
 			AutoApproveOption:             ToPtr("all"),
 			DuplicateTranslations:         ToPtr(true),
 			SkipApprovedTranslations:      ToPtr(true),
 			TranslateUntranslatedOnly:     ToPtr(true),
 			TranslateWithPerfectMatchOnly: ToPtr(true),
+			FallbackLanguages: map[string][]string{
+				"es": {"en"},
+			},
+			LabelIDs:        []int{3},
+			ExcludeLabelIDs: []int{4},
 		},
 		CreatedAt:  "2023-09-20T14:05:50+00:00",
 		UpdatedAt:  "2023-09-20T14:05:50+00:00",
 		StartedAt:  "2023-08-24T14:15:22Z",
 		FinishedAt: "2023-08-24T14:15:22Z",
+		ETA:        "10s",
 	}
 	assert.Equal(t, expected, status)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -190,6 +206,8 @@ func TestTranslationsService_ListPreTranslations(t *testing.T) {
 								"method": "tm",
 								"branchIds": [2],
 								"languageIds": ["en", "de"],
+								"engineId": null,
+								"aiPromptId": null,
 								"excludeLabelIds": null,
 								"autoApproveOption": null,
 								"fallbackLanguages": null,
@@ -225,11 +243,16 @@ func TestTranslationsService_ListPreTranslations(t *testing.T) {
 					LanguageIDs:                   []string{"en", "de"},
 					FileIDs:                       nil,
 					Method:                        ToPtr("tm"),
+					EngineID:                      nil,
+					AIPromptID:                    nil,
 					AutoApproveOption:             nil,
 					DuplicateTranslations:         nil,
 					SkipApprovedTranslations:      nil,
 					TranslateUntranslatedOnly:     nil,
 					TranslateWithPerfectMatchOnly: nil,
+					FallbackLanguages:             nil,
+					LabelIDs:                      nil,
+					ExcludeLabelIDs:               nil,
 				},
 				CreatedAt:  "2024-11-10T19:14:37+00:00",
 				UpdatedAt:  "2024-11-10T19:14:45+00:00",
@@ -348,11 +371,17 @@ func TestTranslationsService_ApplyPreTranslation(t *testing.T) {
 					"languageIds": ["uk"],
 					"fileIds": [742],
 					"method": "tm",
+					"engineId": 1,
 					"autoApproveOption": "all",
 					"duplicateTranslations": true,
 					"skipApprovedTranslations": true,
 					"translateUntranslatedOnly": false,
-					"translateWithPerfectMatchOnly": true
+					"translateWithPerfectMatchOnly": true,
+					"fallbackLanguages": {
+						"languageId": ["uk"]
+					},
+					"labelIds": [1],
+					"excludeLabelIds": [2]
 				},
 				"createdAt": "2023-09-20T14:05:50+00:00",
 				"updatedAt": "2023-09-20T14:05:50+00:00",
@@ -366,7 +395,7 @@ func TestTranslationsService_ApplyPreTranslation(t *testing.T) {
 		LanguageIDs:                   []string{"uk"},
 		FileIDs:                       []int{742},
 		Method:                        "tm",
-		EngineID:                      1,
+		EngineID:                      ToPtr(1),
 		AutoApproveOption:             "all",
 		DuplicateTranslations:         ToPtr(true),
 		SkipApprovedTranslations:      ToPtr(true),
@@ -389,11 +418,18 @@ func TestTranslationsService_ApplyPreTranslation(t *testing.T) {
 			LanguageIDs:                   []string{"uk"},
 			FileIDs:                       []int{742},
 			Method:                        ToPtr("tm"),
+			EngineID:                      ToPtr(1),
+			AIPromptID:                    nil,
 			AutoApproveOption:             ToPtr("all"),
 			DuplicateTranslations:         ToPtr(true),
 			SkipApprovedTranslations:      ToPtr(true),
 			TranslateUntranslatedOnly:     ToPtr(false),
 			TranslateWithPerfectMatchOnly: ToPtr(true),
+			FallbackLanguages: map[string][]string{
+				"languageId": {"uk"},
+			},
+			LabelIDs:        []int{1},
+			ExcludeLabelIDs: []int{2},
 		},
 		CreatedAt:  "2023-09-20T14:05:50+00:00",
 		UpdatedAt:  "2023-09-20T14:05:50+00:00",


### PR DESCRIPTION
This PR improves the Crowdin fork's parity with the official API v2 for Pre-Translation operations.

Key changes:
- **Pre-Translation Models**: Added documented fields missing from the Go SDK, including `eta` in the main status response and `engineId`, `aiPromptId`, `fallbackLanguages`, `labelIds`, and `excludeLabelIds` in the attributes. 
- **Pointer Usage**: Following standard SDK patterns and code review feedback, `EngineID` and `AIPromptID` now use `*int` to correctly distinguish between a zero-value ID and an omitted field.
- **Documentation Fix**: Corrected a typo in the `ProjectsAddRequest` comment where "Skip tags" was listed as `1` instead of `2`.
- **Testing**: Updated and expanded contract tests in `translations_test.go` and `model/translations_test.go` to ensure these new fields are correctly handled during JSON serialization/unmarshaling.

Reference: https://developer.crowdin.com/api/v2/#operation/api.projects.pre-translations.get

---
*PR created automatically by Jules for task [17055019592892883755](https://jules.google.com/task/17055019592892883755) started by @cungminh2710*