### PR TITLE
Improve Crowdin Glossary and TM model parity

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -29,3 +29,9 @@
 **Learning:** The Pre-Translation status response includes an `eta` field and several attributes (`engineId`, `aiPromptId`, `fallbackLanguages`, `labelIds`, `excludeLabelIds`) that were missing from the SDK models. Additionally, documentation for `TagsDetection` was using incorrect values for "Skip tags".
 
 **Action:** Added `ETA` to `PreTranslation` and missing fields to `PreTranslationAttributes`. Used `*int` for `EngineID` and `AIPromptID` to correctly handle zero values vs omission. Updated `PreTranslationRequest` to include these fields as well. Corrected the `TagsDetection` comment in `ProjectsAddRequest`. Updated contract tests to verify parsing of these new fields.
+
+## 2026-06-12 - Improve Glossary and TM model parity for description and groupId
+
+**Learning:** Crowdin API v2 for Glossaries and Translation Memories includes a `description` field for both, and Translation Memories also support a `groupId` field in both responses and addition requests. These fields were missing from the Go SDK models, preventing users from fully managing these resources, especially in Enterprise environments where resource organization into groups is common.
+
+**Action:** Added `Description` field to `Glossary` and `GlossaryAddRequest` in `model/glossaries.go`. Added `Description` and `GroupID` fields to `TranslationMemory`, and `GroupID` (*int) to `TranslationMemoryAddRequest` in `model/translation_memory.go`. Updated contract tests in `glossaries_test.go` and `translation_memory_test.go` to verify correct parsing and serialization.

--- a/third_party/crowdin-api-client-go/crowdin/glossaries_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/glossaries_test.go
@@ -305,6 +305,7 @@ func TestGlossariesService_GetGlossary(t *testing.T) {
 			"data": {
 				"id": 2,
 				"name": "Be My Eyes iOS's Glossary",
+				"description": "This is a sample description.",
 				"groupId": 2,
 				"userId": 2,
 				"terms": 25,
@@ -325,6 +326,7 @@ func TestGlossariesService_GetGlossary(t *testing.T) {
 	expected := &model.Glossary{
 		ID:                2,
 		Name:              "Be My Eyes iOS's Glossary",
+		Description:       "This is a sample description.",
 		GroupID:           2,
 		UserID:            2,
 		Terms:             25,
@@ -457,12 +459,13 @@ func TestGlossariesService_AddGlossary(t *testing.T) {
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
 		testURL(t, r, path)
-		testBody(t, r, `{"name":"Be My Eyes iOS's Glossary","languageId":"fr","groupId":0}`+"\n")
+		testBody(t, r, `{"name":"Be My Eyes iOS's Glossary","description":"New Glossary Description","languageId":"fr","groupId":0}`+"\n")
 
 		fmt.Fprint(w, `{
 			"data": {
 				"id": 2,
 				"name": "Be My Eyes iOS's Glossary",
+				"description": "New Glossary Description",
 				"groupId": 2,
 				"userId": 2,
 				"terms": 25,
@@ -477,9 +480,10 @@ func TestGlossariesService_AddGlossary(t *testing.T) {
 	})
 
 	req := &model.GlossaryAddRequest{
-		Name:       "Be My Eyes iOS's Glossary",
-		LanguageID: "fr",
-		GroupID:    ToPtr(0),
+		Name:        "Be My Eyes iOS's Glossary",
+		Description: "New Glossary Description",
+		LanguageID:  "fr",
+		GroupID:     ToPtr(0),
 	}
 	glossary, resp, err := client.Glossaries.AddGlossary(context.Background(), req)
 	require.NoError(t, err)
@@ -488,6 +492,7 @@ func TestGlossariesService_AddGlossary(t *testing.T) {
 	expected := &model.Glossary{
 		ID:                2,
 		Name:              "Be My Eyes iOS's Glossary",
+		Description:       "New Glossary Description",
 		GroupID:           2,
 		UserID:            2,
 		Terms:             25,

--- a/third_party/crowdin-api-client-go/crowdin/model/glossaries.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/glossaries.go
@@ -117,6 +117,7 @@ func (r *ConceptUpdateRequest) Validate() error {
 type Glossary struct {
 	ID                int      `json:"id"`
 	Name              string   `json:"name"`
+	Description       string   `json:"description,omitempty"`
 	GroupID           int      `json:"groupId"`
 	UserID            int      `json:"userId"`
 	Terms             int      `json:"terms"`
@@ -182,6 +183,8 @@ func (o *GlossariesListOptions) Values() (url.Values, bool) {
 type GlossaryAddRequest struct {
 	// Glossary name.
 	Name string `json:"name"`
+	// Glossary description.
+	Description string `json:"description,omitempty"`
 	// Glossary Language Identifier.
 	LanguageID string `json:"languageId"`
 	// Group Identifier - defines group to which Glossary is added.

--- a/third_party/crowdin-api-client-go/crowdin/model/translation_memory.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/translation_memory.go
@@ -10,7 +10,7 @@ import (
 type TranslationMemory struct {
 	ID                int      `json:"id"`
 	UserID            int      `json:"userId"`
-	GroupID           int      `json:"groupId,omitempty"`
+	GroupID           int      `json:"groupId"`
 	Name              string   `json:"name"`
 	Description       string   `json:"description,omitempty"`
 	LanguageID        string   `json:"languageId"`
@@ -71,6 +71,8 @@ func (o *TranslationMemoriesListOptions) Values() (url.Values, bool) {
 type TranslationMemoryAddRequest struct {
 	// Translation Memory name.
 	Name string `json:"name"`
+	// Translation Memory description.
+	Description string `json:"description,omitempty"`
 	// Translation Memory Language Identifier.
 	LanguageID string `json:"languageId"`
 	// Group Identifier - defines group to which Translation Memory is added.

--- a/third_party/crowdin-api-client-go/crowdin/model/translation_memory.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/translation_memory.go
@@ -10,7 +10,9 @@ import (
 type TranslationMemory struct {
 	ID                int      `json:"id"`
 	UserID            int      `json:"userId"`
+	GroupID           int      `json:"groupId,omitempty"`
 	Name              string   `json:"name"`
+	Description       string   `json:"description,omitempty"`
 	LanguageID        string   `json:"languageId"`
 	LanguageIDs       []string `json:"languageIds"`
 	SegmentsCount     int      `json:"segmentsCount"`
@@ -71,6 +73,10 @@ type TranslationMemoryAddRequest struct {
 	Name string `json:"name"`
 	// Translation Memory Language Identifier.
 	LanguageID string `json:"languageId"`
+	// Group Identifier - defines group to which Translation Memory is added.
+	// If `0` – Translation Memory will be available for all projects and groups
+	// in your workspace. Default: 0.
+	GroupID *int `json:"groupId,omitempty"`
 }
 
 // Validate checks if the TranslationMemoryAddRequest is valid.

--- a/third_party/crowdin-api-client-go/crowdin/translation_memory_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/translation_memory_test.go
@@ -23,7 +23,9 @@ func TestTranslationMemoryService_GetTM(t *testing.T) {
 			"data": {
 				"id": 4,
 				"userId": 2,
+				"groupId": 1,
 				"name": "Knowledge Base's TM",
+				"description": "TM description",
 				"languageId": "fr",
 				"languageIds": ["el"],
 				"segmentsCount": 21,
@@ -42,7 +44,9 @@ func TestTranslationMemoryService_GetTM(t *testing.T) {
 	expected := &model.TranslationMemory{
 		ID:                4,
 		UserID:            2,
+		GroupID:           1,
 		Name:              "Knowledge Base's TM",
+		Description:       "TM description",
 		LanguageID:        "fr",
 		LanguageIDs:       []string{"el"},
 		SegmentsCount:     21,
@@ -162,13 +166,15 @@ func TestTranslationMemoryService_AddTM(t *testing.T) {
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
 		testURL(t, r, path)
-		testBody(t, r, `{"name":"Knowledge Base's TM","languageId":"fr"}`+"\n")
+		testBody(t, r, `{"name":"Knowledge Base's TM","languageId":"fr","groupId":2}`+"\n")
 
 		fmt.Fprint(w, `{
 			"data": {
 				"id": 4,
 				"userId": 2,
+				"groupId": 2,
 				"name": "Knowledge Base's TM",
+				"description": "New TM description",
 				"languageId": "fr",
 				"languageIds": ["el"],
 				"segmentsCount": 21,
@@ -183,6 +189,7 @@ func TestTranslationMemoryService_AddTM(t *testing.T) {
 	req := &model.TranslationMemoryAddRequest{
 		Name:       "Knowledge Base's TM",
 		LanguageID: "fr",
+		GroupID:    ToPtr(2),
 	}
 	tm, resp, err := client.TranslationMemory.AddTM(context.Background(), req)
 	require.NoError(t, err)
@@ -191,7 +198,9 @@ func TestTranslationMemoryService_AddTM(t *testing.T) {
 	expected := &model.TranslationMemory{
 		ID:                4,
 		UserID:            2,
+		GroupID:           2,
 		Name:              "Knowledge Base's TM",
+		Description:       "New TM description",
 		LanguageID:        "fr",
 		LanguageIDs:       []string{"el"},
 		SegmentsCount:     21,


### PR DESCRIPTION
Improved API parity for Glossaries and Translation Memories in the Crowdin Go SDK fork by adding missing 'description' and 'groupId' fields. These fields are essential for proper resource management, especially in Enterprise environments. Verified changes with updated contract tests and ensured compatibility with existing call sites.

---
*PR created automatically by Jules for task [6591158035700023011](https://jules.google.com/task/6591158035700023011) started by @cungminh2710*