### PR TITLE
🛡️ Sentinel: Expand secret masking in debug logs

### DIFF
--- a/internal/i18n/translator/debug_log.go
+++ b/internal/i18n/translator/debug_log.go
@@ -38,7 +38,8 @@ type promptDebugEvent struct {
 
 var (
 	translatorPromptDebugLogger promptDebugLogger
-	secretRegex                 = regexp.MustCompile(`(?i)\b(sk-[a-z0-9-]{20,}|hl_[a-z0-9]{20,}|gsk_[a-z0-9]{20,}|mistral_[a-z0-9]{20,}|AIza[a-z0-9_-]{35,}|AKIA[A-Z0-9]{16})\b`)
+	secretRegex                 = regexp.MustCompile(`\b(?i:(?:sk-[a-z0-9-]{20,}|hl_[a-z0-9]{20,}|gsk_[a-z0-9]{20,}|mistral_[a-z0-9]{20,}|AIza[a-z0-9_-]{35,}))\b|\bAKIA[A-Z0-9]{16}\b`)
+	awsSecretAccessKeyRegex     = regexp.MustCompile(`(?i)\b((?:aws[ \t_-]*)?secret[ \t_-]*access[ \t_-]*key)(["']?\s*[:=]\s*["']?)([A-Za-z0-9/+=]{40})(["']?)([^A-Za-z0-9/+=]|$)`)
 )
 
 func logPromptCall(req Request, providerName, systemPrompt, userPrompt string) {
@@ -135,10 +136,21 @@ func maskSecrets(text string) string {
 	if text == "" {
 		return ""
 	}
-	return secretRegex.ReplaceAllStringFunc(text, func(match string) string {
-		if len(match) < 12 {
-			return "****"
-		}
-		return match[:8] + "..." + match[len(match)-4:]
+	text = secretRegex.ReplaceAllStringFunc(text, func(match string) string {
+		return maskSecretValue(match)
 	})
+	return awsSecretAccessKeyRegex.ReplaceAllStringFunc(text, func(match string) string {
+		parts := awsSecretAccessKeyRegex.FindStringSubmatch(match)
+		if len(parts) != 6 {
+			return match
+		}
+		return parts[1] + parts[2] + maskSecretValue(parts[3]) + parts[4] + parts[5]
+	})
+}
+
+func maskSecretValue(value string) string {
+	if len(value) < 12 {
+		return "****"
+	}
+	return value[:8] + "..." + value[len(value)-4:]
 }

--- a/internal/i18n/translator/debug_log.go
+++ b/internal/i18n/translator/debug_log.go
@@ -38,7 +38,7 @@ type promptDebugEvent struct {
 
 var (
 	translatorPromptDebugLogger promptDebugLogger
-	secretRegex                 = regexp.MustCompile(`(?i)\b(sk-[a-z0-9-]{20,}|hl_[a-z0-9]{20,}|AIza[a-z0-9_-]{35,})\b`)
+	secretRegex                 = regexp.MustCompile(`(?i)\b(sk-[a-z0-9-]{20,}|hl_[a-z0-9]{20,}|gsk_[a-z0-9]{20,}|mistral_[a-z0-9]{20,}|AIza[a-z0-9_-]{35,}|AKIA[A-Z0-9]{16})\b`)
 )
 
 func logPromptCall(req Request, providerName, systemPrompt, userPrompt string) {

--- a/internal/i18n/translator/debug_log_test.go
+++ b/internal/i18n/translator/debug_log_test.go
@@ -141,6 +141,26 @@ func TestMaskSecrets(t *testing.T) {
 			want: "google AIzaSyA1...efGH",
 		},
 		{
+			name: "anthropic secret",
+			in:   "anthropic sk-ant-api03-1234567890abcdef1234567890abcdef1234567890abcdef",
+			want: "anthropic sk-ant-a...cdef",
+		},
+		{
+			name: "groq secret",
+			in:   "groq gsk_1234567890abcdef1234567890abcdef1234567890abcdef",
+			want: "groq gsk_1234...cdef",
+		},
+		{
+			name: "mistral secret",
+			in:   "mistral mistral_1234567890abcdef1234567890abcdef",
+			want: "mistral mistral_...cdef",
+		},
+		{
+			name: "aws access key",
+			in:   "aws AKIA1234567890ABCDEF",
+			want: "aws AKIA1234...CDEF",
+		},
+		{
 			name: "multiple secrets",
 			in:   "keys: sk-proj-1234567890abcdef1234567890abcdef1234567890abcdef and hl_abc1234567890abcdef1234567890abcdef",
 			want: "keys: sk-proj-...cdef and hl_abc12...cdef",

--- a/internal/i18n/translator/debug_log_test.go
+++ b/internal/i18n/translator/debug_log_test.go
@@ -161,6 +161,31 @@ func TestMaskSecrets(t *testing.T) {
 			want: "aws AKIA1234...CDEF",
 		},
 		{
+			name: "lowercase aws access key lookalike",
+			in:   "aws akia1234567890abcdef",
+			want: "aws akia1234567890abcdef",
+		},
+		{
+			name: "aws secret access key env var",
+			in:   "AWS_SECRET_ACCESS_KEY=AbCdEfGhIjKlMnOpQrStUvWxYz0123456789/+=A",
+			want: "AWS_SECRET_ACCESS_KEY=AbCdEfGh.../+=A",
+		},
+		{
+			name: "aws bedrock credentials",
+			in:   "AWS_ACCESS_KEY_ID=AKIA1234567890ABCDEF AWS_SECRET_ACCESS_KEY=AbCdEfGhIjKlMnOpQrStUvWxYz0123456789/+=A",
+			want: "AWS_ACCESS_KEY_ID=AKIA1234...CDEF AWS_SECRET_ACCESS_KEY=AbCdEfGh.../+=A",
+		},
+		{
+			name: "aws secret access key json",
+			in:   `{"secretAccessKey":"AbCdEfGhIjKlMnOpQrStUvWxYz0123456789/+=A","region":"us-east-1"}`,
+			want: `{"secretAccessKey":"AbCdEfGh.../+=A","region":"us-east-1"}`,
+		},
+		{
+			name: "unlabeled aws secret lookalike",
+			in:   "token AbCdEfGhIjKlMnOpQrStUvWxYz0123456789/+=A",
+			want: "token AbCdEfGhIjKlMnOpQrStUvWxYz0123456789/+=A",
+		},
+		{
 			name: "multiple secrets",
 			in:   "keys: sk-proj-1234567890abcdef1234567890abcdef1234567890abcdef and hl_abc1234567890abcdef1234567890abcdef",
 			want: "keys: sk-proj-...cdef and hl_abc12...cdef",


### PR DESCRIPTION
This PR enhances the security of the prompt debug logging mechanism by expanding the set of sensitive patterns that are automatically masked.

Currently, the `maskSecrets` function in `internal/i18n/translator/debug_log.go` redacts OpenAI, Hyperlocalise, and Google API keys. This change adds support for:
- **Groq:** `gsk_` prefix
- **Mistral:** `mistral_` prefix
- **AWS Access Keys:** `AKIA` prefix (useful for Bedrock provider)

Test coverage has been added for all new patterns in `internal/i18n/translator/debug_log_test.go`.

---
*PR created automatically by Jules for task [6495250313751197716](https://jules.google.com/task/6495250313751197716) started by @cungminh2710*