### PR TITLE
🧪 Scout: fix pound counting in nested ICU plurals

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -7,3 +7,7 @@
 ## 2025-05-14 - [ICU Invariant Parity]
 **Learning:** Structural parity for ICU messages (verified via `SameICUBlocks`) should remain "loose" regarding the count of '#' symbols (`Pounds`) in plural branches. LLMs often perform valid linguistic rewrites (e.g., replacing `{count}` with `#` or vice-versa) that change the `Pounds` metadata but remain semantically correct. Tightening this check causes excessive false-positive validation failures.
 **Action:** Use `SameICUBlocks` for high-level structure (Arg, Type, Selectors) and rely on separate checks (like `HasDuplicatePounds`) for safety, rather than enforcing identical metadata counts.
+
+## 2025-05-15 - [ICU Nested Plural Pound Scoping]
+**Learning:** In ICU message syntax, the `#` symbol refers only to the argument of the *nearest* enclosing plural block. If plurals are nested, `#` inside the inner block does not refer to the outer plural's argument. Analyzing message invariants (e.g., counting pound usages) must respect this scoping by stopping recursion at nested plural boundaries.
+**Action:** When traversing ICU AST for pound counting or validation, treat `PluralElement` as a scoping boundary; recurse into its branches for its own analysis, but exclude its children when calculating metrics for a parent plural.

--- a/internal/i18n/icuparser/coverage_test.go
+++ b/internal/i18n/icuparser/coverage_test.go
@@ -103,13 +103,15 @@ type noopEl struct{}
 func (noopEl) Type() ElementType { return "noop" }
 
 func TestCountPoundsNested(t *testing.T) {
+	// countPounds should recurse into Tags and Selects, but NOT into nested Plurals,
+	// as '#' inside nested plurals refers to the nested plural's argument.
 	n := countPounds([]Element{
 		TagElement{Children: []Element{PoundElement{}}},
 		SelectElement{Options: []SelectOption{{Value: []Element{PoundElement{}, PoundElement{}}}}},
 		PluralElement{Options: []PluralOption{{Value: []Element{PoundElement{}}}}},
 	})
-	if n != 4 {
-		t.Fatalf("countPounds: got %d", n)
+	if n != 3 {
+		t.Fatalf("countPounds: got %d, expected 3 (1 from tag, 2 from select, 0 from nested plural)", n)
 	}
 }
 

--- a/internal/i18n/icuparser/invariant.go
+++ b/internal/i18n/icuparser/invariant.go
@@ -234,9 +234,9 @@ func countPounds(elems []Element) int {
 				total += countPounds(opt.Value)
 			}
 		case PluralElement:
-			for _, opt := range v.Options {
-				total += countPounds(opt.Value)
-			}
+			// Stop recursion into nested plurals because '#' within them
+			// refers to the nested plural's argument.
+			continue
 		}
 	}
 	return total

--- a/internal/i18n/icuparser/invariant_test.go
+++ b/internal/i18n/icuparser/invariant_test.go
@@ -64,24 +64,35 @@ func TestSameICUBlocks(t *testing.T) {
 
 func TestCountPoundsNestedPlurals(t *testing.T) {
 	// Inside the "one" branch of c1, there is one # (for c1) and a nested c2 plural.
-	// The # inside the c2 plural MUST NOT be counted towards c1's pound count.
+	// The # inside the c2 plural MUST NOT be counted towards c1's pound count,
+	// as it refers to c2.
 	msg := "{c1, plural, one {# {c2, plural, one {#} other {##}}}}"
 	inv, err := ParseInvariant(msg)
 	if err != nil {
 		t.Fatalf("ParseInvariant failed: %v", err)
 	}
 
-	foundC1 := false
-	for _, block := range inv.ICUBlocks {
-		if block.Arg == "c1" {
-			foundC1 = true
-			// Expected Pounds for c1: [1] (only the one # that refers to c1)
-			if len(block.Pounds) != 1 || block.Pounds[0] != 1 {
-				t.Errorf("expected c1 Pounds [1], got %v", block.Pounds)
-			}
-		}
+	// c1 has one option ("one") with 1 pound sign.
+	// c2 has two options ("one", "other") with 1 and 2 pound signs respectively.
+	expected := []struct {
+		arg    string
+		pounds []int
+	}{
+		{arg: "c1", pounds: []int{1}},
+		{arg: "c2", pounds: []int{1, 2}},
 	}
-	if !foundC1 {
-		t.Fatal("block c1 not found")
+
+	if len(inv.ICUBlocks) != len(expected) {
+		t.Fatalf("expected %d ICU blocks, got %d", len(expected), len(inv.ICUBlocks))
+	}
+
+	for i, exp := range expected {
+		block := inv.ICUBlocks[i]
+		if block.Arg != exp.arg {
+			t.Errorf("block %d: expected Arg %q, got %q", i, exp.arg, block.Arg)
+		}
+		if !slicesEqual(block.Pounds, exp.pounds) {
+			t.Errorf("block %d (%s): expected Pounds %v, got %v", i, exp.arg, exp.pounds, block.Pounds)
+		}
 	}
 }

--- a/internal/i18n/icuparser/invariant_test.go
+++ b/internal/i18n/icuparser/invariant_test.go
@@ -61,3 +61,27 @@ func TestSameICUBlocks(t *testing.T) {
 		})
 	}
 }
+
+func TestCountPoundsNestedPlurals(t *testing.T) {
+	// Inside the "one" branch of c1, there is one # (for c1) and a nested c2 plural.
+	// The # inside the c2 plural MUST NOT be counted towards c1's pound count.
+	msg := "{c1, plural, one {# {c2, plural, one {#} other {##}}}}"
+	inv, err := ParseInvariant(msg)
+	if err != nil {
+		t.Fatalf("ParseInvariant failed: %v", err)
+	}
+
+	foundC1 := false
+	for _, block := range inv.ICUBlocks {
+		if block.Arg == "c1" {
+			foundC1 = true
+			// Expected Pounds for c1: [1] (only the one # that refers to c1)
+			if len(block.Pounds) != 1 || block.Pounds[0] != 1 {
+				t.Errorf("expected c1 Pounds [1], got %v", block.Pounds)
+			}
+		}
+	}
+	if !foundC1 {
+		t.Fatal("block c1 not found")
+	}
+}


### PR DESCRIPTION
### 💡 What
Fixed incorrect pound symbol (`#`) counting in nested ICU plural blocks.

### 🎯 Why
In ICU message syntax, the `#` symbol is a shorthand for the numeric value of the *nearest* enclosing plural block. The existing `countPounds` function incorrectly recursed into nested plural blocks, causing outer plurals to "claim" pound symbols that actually belonged to their children. This led to incorrect invariant analysis and potential validation false positives.

### 🧩 Scope
- `internal/i18n/icuparser/invariant.go`: Updated `countPounds` to stop recursing into `PluralElement`.
- `internal/i18n/icuparser/invariant_test.go`: Added `TestCountPoundsNestedPlurals` regression test.
- `internal/i18n/icuparser/coverage_test.go`: Updated `TestCountPoundsNested` to assert correct scoping behavior.

### ✅ Verification
- Ran `go test ./...` - All tests passed.
- Verified fix with a dedicated repro case involving triple-nested plurals.

### 🛡️ Confidence
High. The fix aligns with official ICU specifications regarding pound symbol scoping and is verified by targeted unit tests.

---
*PR created automatically by Jules for task [16123639222195017445](https://jules.google.com/task/16123639222195017445) started by @cungminh2710*