### PR TITLE
🧪 Scout: fix ICU select argument placeholder extraction

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -11,3 +11,7 @@
 ## 2025-05-15 - [ICU Nested Plural Pound Scoping]
 **Learning:** In ICU message syntax, the `#` symbol refers only to the argument of the *nearest* enclosing plural block. If plurals are nested, `#` inside the inner block does not refer to the outer plural's argument. Analyzing message invariants (e.g., counting pound usages) must respect this scoping by stopping recursion at nested plural boundaries.
 **Action:** When traversing ICU AST for pound counting or validation, treat `PluralElement` as a scoping boundary; recurse into its branches for its own analysis, but exclude its children when calculating metrics for a parent plural.
+
+## 2025-05-15 - [ICU Select Argument Parity]
+**Learning:** `SelectElement` arguments were missing from the extracted `Placeholders` list in `Invariant` metadata, despite being structural arguments like `PluralElement` arguments. This inconsistency can lead to incomplete placeholder validation in downstream tools.
+**Action:** Ensure all ICU argument-bearing elements (`Argument`, `Number`, `Date`, `Time`, `Plural`, `Select`) call `appendPlaceholder` during invariant collection.

--- a/internal/i18n/icuparser/invariant.go
+++ b/internal/i18n/icuparser/invariant.go
@@ -159,6 +159,7 @@ func appendPlaceholder(inv *Invariant, value string) {
 }
 
 func appendSelectBlockInvariant(inv *Invariant, v SelectElement, pluralArg string) {
+	appendPlaceholder(inv, v.Value)
 	inv.ICUBlocks = append(inv.ICUBlocks, BlockSignature{
 		Arg:     v.Value,
 		Type:    "select",

--- a/internal/i18n/icuparser/invariant_test.go
+++ b/internal/i18n/icuparser/invariant_test.go
@@ -96,3 +96,25 @@ func TestCountPoundsNestedPlurals(t *testing.T) {
 		}
 	}
 }
+
+func TestSelectArgumentInPlaceholders(t *testing.T) {
+	// Select arguments MUST be included in the invariant's Placeholder list,
+	// just like plural arguments and simple interpolation placeholders.
+	msg := "{gender, select, male {male} other {other}}"
+	inv, err := ParseInvariant(msg)
+	if err != nil {
+		t.Fatalf("ParseInvariant failed: %v", err)
+	}
+
+	found := false
+	for _, p := range inv.Placeholders {
+		if p == "gender" {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Errorf("expected 'gender' in placeholders, got %v", inv.Placeholders)
+	}
+}

--- a/internal/i18n/icuparser/parser_test.go
+++ b/internal/i18n/icuparser/parser_test.go
@@ -36,7 +36,7 @@ func TestParserFeatureParitySubset(t *testing.T) {
 		{
 			name:             "nested select plural",
 			msg:              "{gender, select, male {{count, plural, one {He has one} other {He has #}}} female {{count, plural, one {She has one} other {She has #}}} other {They have {count}}}",
-			wantPlaceholders: []string{"count", "count", "count", "count", "count"},
+			wantPlaceholders: []string{"count", "count", "count", "count", "count", "gender"},
 			wantICU: []BlockSignature{
 				{Arg: "count", Type: "plural", Options: []string{"one", "other"}, Pounds: []int{0, 1}},
 				{Arg: "count", Type: "plural", Options: []string{"one", "other"}, Pounds: []int{0, 1}},


### PR DESCRIPTION
- 💡 What: Added `appendPlaceholder` call for `SelectElement` in `invariant.go`.
- 🎯 Why: Ensures parity with other ICU elements where structural arguments (like `count` in `plural`) are captured as placeholders.
- 🧩 Scope: `internal/i18n/icuparser/invariant.go`, `internal/i18n/icuparser/invariant_test.go`, `internal/i18n/icuparser/parser_test.go`.
- ✅ Verification: `go test ./...` from the root.
- 🛡️ Confidence: Protects against incomplete placeholder validation in downstream tools for ICU messages using `select` blocks.

---
*PR created automatically by Jules for task [6460399650356880506](https://jules.google.com/task/6460399650356880506) started by @cungminh2710*