### PR TITLE
fix(crowdin): improve SourceString parity for masterStringId and isIcu filter

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -35,3 +35,9 @@
 **Learning:** Crowdin API v2 for Glossaries and Translation Memories includes a `description` field for both, and Translation Memories also support a `groupId` field in both responses and addition requests. These fields were missing from the Go SDK models, preventing users from fully managing these resources, especially in Enterprise environments where resource organization into groups is common.
 
 **Action:** Added `Description` field to `Glossary` and `GlossaryAddRequest` in `model/glossaries.go`. Added `Description` and `GroupID` fields to `TranslationMemory`, and `GroupID` (*int) to `TranslationMemoryAddRequest` in `model/translation_memory.go`. Updated contract tests in `glossaries_test.go` and `translation_memory_test.go` to verify correct parsing and serialization.
+
+## 2026-05-17 - Improve SourceString parity for masterStringId and isIcu filter
+
+**Learning:** The Crowdin Source Strings API v2 supports adding duplicate strings by specifying a `masterStringId` and filtering strings by their ICU status using an `isIcu` query parameter. These were missing from the SDK's `SourceStringsAddRequest` and `SourceStringsListOptions` respectively.
+
+**Action:** Added `MasterStringID` (*int) to `SourceStringsAddRequest` and `IsIcu` (*int) to `SourceStringsListOptions`. Updated `SourceStringsListOptions.Values()` to include the `isIcu` parameter in query strings. Verified with updated unit tests in `source_strings_test.go`.

--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -36,8 +36,8 @@
 
 **Action:** Added `Description` field to `Glossary` and `GlossaryAddRequest` in `model/glossaries.go`. Added `Description` and `GroupID` fields to `TranslationMemory`, and `GroupID` (*int) to `TranslationMemoryAddRequest` in `model/translation_memory.go`. Updated contract tests in `glossaries_test.go` and `translation_memory_test.go` to verify correct parsing and serialization.
 
-## 2026-05-17 - Improve SourceString parity for masterStringId and isIcu filter
+## 2026-05-17 - Improve SourceString parity for masterStringId, isIcu, and excludeLabelIds
 
-**Learning:** The Crowdin Source Strings API v2 supports adding duplicate strings by specifying a `masterStringId` and filtering strings by their ICU status using an `isIcu` query parameter. These were missing from the SDK's `SourceStringsAddRequest` and `SourceStringsListOptions` respectively.
+**Learning:** The Crowdin Source Strings API v2 supports adding duplicate strings by specifying a `masterStringId` and filtering strings by their ICU status (`isIcu`) or by excluding specific labels (`excludeLabelIds`). These parameters were missing from the SDK's `SourceStringsAddRequest` and `SourceStringsListOptions`.
 
-**Action:** Added `MasterStringID` (*int) to `SourceStringsAddRequest` and `IsIcu` (*int) to `SourceStringsListOptions`. Updated `SourceStringsListOptions.Values()` to include the `isIcu` parameter in query strings. Verified with updated unit tests in `source_strings_test.go`.
+**Action:** Added `MasterStringID` (*int) to `SourceStringsAddRequest`. Added `IsIcu` (*int) and `ExcludeLabelIDs` ([]int) to `SourceStringsListOptions`. Updated `SourceStringsListOptions.Values()` to correctly encode these parameters in query strings. Verified with updated unit tests in `source_strings_test.go`.

--- a/third_party/crowdin-api-client-go/crowdin/model/source_strings.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/source_strings.go
@@ -53,6 +53,9 @@ type SourceStringsListOptions struct {
 	// Filter strings by labelIds (Label Identifiers).
 	// Example: labelIds=1,2,3,4,5.
 	LabelIDs []int `json:"labelIds,omitempty"`
+	// Filter strings by excludeLabelIds (Exclude Label Identifiers).
+	// Example: excludeLabelIds=1,2,3,4,5.
+	ExcludeLabelIDs []int `json:"excludeLabelIds,omitempty"`
 	// File Identifier.
 	// Note: Can't be used with `directoryId` or `branchId` in same request.
 	FileID int `json:"fileId,omitempty"`
@@ -97,6 +100,9 @@ func (o *SourceStringsListOptions) Values() (url.Values, bool) {
 	}
 	if len(o.LabelIDs) > 0 {
 		v.Add("labelIds", JoinSlice(o.LabelIDs))
+	}
+	if len(o.ExcludeLabelIDs) > 0 {
+		v.Add("excludeLabelIds", JoinSlice(o.ExcludeLabelIDs))
 	}
 	if o.FileID > 0 {
 		v.Add("fileId", fmt.Sprintf("%d", o.FileID))

--- a/third_party/crowdin-api-client-go/crowdin/model/source_strings.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/source_strings.go
@@ -69,6 +69,8 @@ type SourceStringsListOptions struct {
 	// Note: Can be used only with `denormalizePlaceholders`, `offset` and
 	// `limit` in same request.
 	CroQL string `json:"croql,omitempty"`
+	// Filter strings by isIcu. Enum: 0, 1.
+	IsIcu *int `json:"isIcu,omitempty"`
 	// Filter strings by `identifier`, `text` or `context`.
 	Filter string `json:"filter,omitempty"`
 	// Specify field to be the target of filtering. It can be one scope or
@@ -89,6 +91,9 @@ func (o *SourceStringsListOptions) Values() (url.Values, bool) {
 	if o.DenormalizePlaceholders != nil &&
 		(*o.DenormalizePlaceholders == 0 || *o.DenormalizePlaceholders == 1) {
 		v.Add("denormalizePlaceholders", fmt.Sprintf("%d", *o.DenormalizePlaceholders))
+	}
+	if o.IsIcu != nil && (*o.IsIcu == 0 || *o.IsIcu == 1) {
+		v.Add("isIcu", fmt.Sprintf("%d", *o.IsIcu))
 	}
 	if len(o.LabelIDs) > 0 {
 		v.Add("labelIds", JoinSlice(o.LabelIDs))
@@ -161,6 +166,8 @@ type SourceStringsAddRequest struct {
 	Identifier string `json:"identifier,omitempty"`
 	// Use to provide additional information for better source text understanding.
 	Context string `json:"context,omitempty"`
+	// Master string identifier.
+	MasterStringID *int `json:"masterStringId,omitempty"`
 	// Defines whether to make string unavailable for translation. Default: false.
 	IsHidden *bool `json:"isHidden,omitempty"`
 	// Defines whether string is ICU.

--- a/third_party/crowdin-api-client-go/crowdin/model/source_strings_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/source_strings_test.go
@@ -31,13 +31,18 @@ func TestSourceStringsListOptionsValues(t *testing.T) {
 			out:  "isIcu=1",
 		},
 		{
+			name: "with ExcludeLabelIDs",
+			opts: &SourceStringsListOptions{ExcludeLabelIDs: []int{4, 5}},
+			out:  "excludeLabelIds=4%2C5",
+		},
+		{
 			name: "with all options",
 			opts: &SourceStringsListOptions{
-				DenormalizePlaceholders: toPtr(1), LabelIDs: []int{1, 2, 3},
+				DenormalizePlaceholders: toPtr(1), LabelIDs: []int{1, 2, 3}, ExcludeLabelIDs: []int{4, 5},
 				FileID: 1, BranchID: 1, DirectoryID: 1, TaskID: 2, CroQL: "croql", Filter: "text", Scope: "identifier",
 				IsIcu: toPtr(0),
 			},
-			out: "branchId=1&croql=croql&denormalizePlaceholders=1&directoryId=1&fileId=1&filter=text&isIcu=0&labelIds=1%2C2%2C3&scope=identifier&taskId=2",
+			out: "branchId=1&croql=croql&denormalizePlaceholders=1&directoryId=1&excludeLabelIds=4%2C5&fileId=1&filter=text&isIcu=0&labelIds=1%2C2%2C3&scope=identifier&taskId=2",
 		},
 	}
 

--- a/third_party/crowdin-api-client-go/crowdin/model/source_strings_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/source_strings_test.go
@@ -26,12 +26,18 @@ func TestSourceStringsListOptionsValues(t *testing.T) {
 			out:  "denormalizePlaceholders=0",
 		},
 		{
+			name: "with IsIcu = 1",
+			opts: &SourceStringsListOptions{IsIcu: toPtr(1)},
+			out:  "isIcu=1",
+		},
+		{
 			name: "with all options",
 			opts: &SourceStringsListOptions{
 				DenormalizePlaceholders: toPtr(1), LabelIDs: []int{1, 2, 3},
 				FileID: 1, BranchID: 1, DirectoryID: 1, TaskID: 2, CroQL: "croql", Filter: "text", Scope: "identifier",
+				IsIcu: toPtr(0),
 			},
-			out: "branchId=1&croql=croql&denormalizePlaceholders=1&directoryId=1&fileId=1&filter=text&labelIds=1%2C2%2C3&scope=identifier&taskId=2",
+			out: "branchId=1&croql=croql&denormalizePlaceholders=1&directoryId=1&fileId=1&filter=text&isIcu=0&labelIds=1%2C2%2C3&scope=identifier&taskId=2",
 		},
 	}
 
@@ -134,6 +140,11 @@ func TestSourceStringsAddRequestValidate(t *testing.T) {
 		{
 			name:  "valid request",
 			req:   &SourceStringsAddRequest{Text: "Not all videos are shown to users.", Identifier: "name", FileID: 1},
+			valid: true,
+		},
+		{
+			name:  "valid request with MasterStringID",
+			req:   &SourceStringsAddRequest{Text: "Duplicate text", FileID: 1, MasterStringID: toPtr(123)},
 			valid: true,
 		},
 		{


### PR DESCRIPTION
Added MasterStringID to SourceStringsAddRequest to support creating duplicate strings. Added IsIcu filter to SourceStringsListOptions and updated its Values() method to include the isIcu query parameter. Verified with new unit tests in source_strings_test.go.

Docs:
- Add String: https://developer.crowdin.com/api/v2/#operation/api.projects.strings.post
- List Strings: https://developer.crowdin.com/api/v2/#operation/api.projects.strings.getMany

---
*PR created automatically by Jules for task [3886555559198091633](https://jules.google.com/task/3886555559198091633) started by @cungminh2710*