### PR TITLE
feat(cli): add Lokalise source upload command

### DIFF
--- a/apps/cli/cmd/lokalise.go
+++ b/apps/cli/cmd/lokalise.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -12,6 +13,8 @@ import (
 	i18nconfig "github.com/hyperlocalise/hyperlocalise/pkg/i18nconfig"
 	"github.com/spf13/cobra"
 )
+
+const defaultLokaliseAPITokenEnv = "LOKALISE_API_TOKEN"
 
 // Flow for `hyperlocalise lokalise glossary download`:
 // 1. Cobra parses flags into lokaliseGlossaryDownloadOptions.
@@ -29,11 +32,38 @@ type lokaliseGlossaryDownloadOptions struct {
 	timeoutSeconds int
 }
 
+type lokaliseUploadSourcesOptions struct {
+	configPath          string
+	projectID           string
+	sourceLocale        string
+	files               []string
+	format              string
+	branch              string
+	tags                []string
+	tokenEnv            string
+	apiBaseURL          string
+	timeoutSeconds      int
+	convertPlaceholders bool
+	replaceModified     bool
+	distinguishByFile   bool
+	applyTM             bool
+	skipDetectLangISO   bool
+	dryRun              bool
+}
+
 type lokaliseGlossaryCSVWriter interface {
 	WriteGlossaryCSV(context.Context, lokalise.GlossaryDownloadInput, io.Writer) (lokalise.GlossaryDownloadResult, error)
 }
 
+type lokaliseSourceUploader interface {
+	UploadSourceFile(context.Context, lokalise.SourceUploadInput) (lokalise.SourceUploadResult, error)
+}
+
 var newLokaliseGlossaryCSVWriter = func(cfg lokalise.Config) (lokaliseGlossaryCSVWriter, error) {
+	return lokalise.NewHTTPClient(cfg)
+}
+
+var newLokaliseSourceUploader = func(cfg lokalise.Config) (lokaliseSourceUploader, error) {
 	return lokalise.NewHTTPClient(cfg)
 }
 
@@ -43,6 +73,7 @@ func newLokaliseCmd() *cobra.Command {
 		Short: "Lokalise workflow commands",
 	}
 	cmd.AddCommand(newLokaliseGlossaryCmd())
+	cmd.AddCommand(newLokaliseUploadCmd())
 	return cmd
 }
 
@@ -52,6 +83,47 @@ func newLokaliseGlossaryCmd() *cobra.Command {
 		Short: "Lokalise glossary commands",
 	}
 	cmd.AddCommand(newLokaliseGlossaryDownloadCmd())
+	return cmd
+}
+
+func newLokaliseUploadCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "upload",
+		Short: "upload files to Lokalise",
+	}
+	cmd.AddCommand(newLokaliseUploadSourcesCmd())
+	return cmd
+}
+
+func newLokaliseUploadSourcesCmd() *cobra.Command {
+	o := lokaliseUploadSourcesOptions{
+		tokenEnv:       defaultLokaliseAPITokenEnv,
+		timeoutSeconds: 30,
+	}
+	cmd := &cobra.Command{
+		Use:          "sources",
+		Short:        "upload source files to Lokalise",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return executeLokaliseUploadSources(cmd, o)
+		},
+	}
+	cmd.Flags().StringVar(&o.configPath, "config", "", "path to i18n config with storage.adapter=lokalise")
+	cmd.Flags().StringVar(&o.projectID, "project-id", "", "Lokalise project identifier")
+	cmd.Flags().StringVar(&o.sourceLocale, "source-locale", "", "source locale ISO in the uploaded file")
+	cmd.Flags().StringArrayVarP(&o.files, "file", "f", nil, "source file path(s) to upload")
+	cmd.Flags().StringVar(&o.format, "format", "", "Lokalise file format; defaults to each file extension")
+	cmd.Flags().StringVar(&o.branch, "branch", "", "Lokalise branch name")
+	cmd.Flags().StringSliceVar(&o.tags, "tag", nil, "tag(s) to assign to uploaded keys")
+	cmd.Flags().StringVar(&o.tokenEnv, "token-env", o.tokenEnv, "environment variable containing the Lokalise API token")
+	cmd.Flags().StringVar(&o.apiBaseURL, "api-base-url", "", "Lokalise API base URL")
+	cmd.Flags().IntVar(&o.timeoutSeconds, "timeout-seconds", o.timeoutSeconds, "Lokalise API timeout in seconds")
+	cmd.Flags().BoolVar(&o.convertPlaceholders, "convert-placeholders", false, "convert placeholders to Lokalise universal placeholders")
+	cmd.Flags().BoolVar(&o.replaceModified, "replace-modified", false, "replace translations modified in the uploaded file")
+	cmd.Flags().BoolVar(&o.distinguishByFile, "distinguish-by-file", false, "allow same key names in different filenames")
+	cmd.Flags().BoolVar(&o.applyTM, "apply-tm", false, "apply 100% translation memory matches during import")
+	cmd.Flags().BoolVar(&o.skipDetectLangISO, "skip-detect-lang-iso", false, "skip automatic language detection by filename")
+	cmd.Flags().BoolVar(&o.dryRun, "dry-run", false, "preview command without uploading files")
 	return cmd
 }
 
@@ -124,6 +196,157 @@ func newLokaliseGlossaryDownloadCmd() *cobra.Command {
 	cmd.Flags().StringVar(&o.apiBaseURL, "api-base-url", "", "Lokalise API base URL")
 	cmd.Flags().IntVar(&o.timeoutSeconds, "timeout-seconds", 0, "HTTP timeout in seconds")
 	return cmd
+}
+
+func executeLokaliseUploadSources(cmd *cobra.Command, o lokaliseUploadSourcesOptions) error {
+	cfg, sourceLocale, err := resolveLokaliseUploadSourcesConfig(cmd, o, !o.dryRun)
+	if err != nil {
+		return err
+	}
+	files, err := validateLokaliseSourceFiles(o.files, o.format)
+	if err != nil {
+		return err
+	}
+	if o.dryRun {
+		format := strings.TrimSpace(o.format)
+		if format == "" {
+			format = "auto"
+		}
+		_, err := fmt.Fprintf(cmd.OutOrStdout(), "dry-run action=lokalise-upload-sources project_id=%s source_locale=%s format=%s files=%d\n", cfg.ProjectID, sourceLocale, format, len(files))
+		return err
+	}
+
+	client, err := newLokaliseSourceUploader(cfg)
+	if err != nil {
+		return err
+	}
+	processed := 0
+	for _, file := range files {
+		result, err := client.UploadSourceFile(backgroundContext(), lokalise.SourceUploadInput{
+			ProjectID:           cfg.ProjectID,
+			SourceLocale:        sourceLocale,
+			FilePath:            file,
+			FileFormat:          strings.TrimSpace(o.format),
+			Branch:              strings.TrimSpace(o.branch),
+			Tags:                o.tags,
+			ConvertPlaceholders: o.convertPlaceholders,
+			ReplaceModified:     o.replaceModified,
+			DistinguishByFile:   o.distinguishByFile,
+			ApplyTM:             o.applyTM,
+			SkipDetectLangISO:   o.skipDetectLangISO,
+		})
+		if err != nil {
+			return fmt.Errorf("lokalise upload sources: %w", err)
+		}
+		processed++
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "uploaded file=%s process_id=%s status=%s type=%s\n", file, result.ProcessID, result.Status, result.Type); err != nil {
+			return err
+		}
+	}
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "action=lokalise-upload-sources processed=%d skipped=0 warnings=0\n", processed)
+	return err
+}
+
+func resolveLokaliseUploadSourcesConfig(cmd *cobra.Command, o lokaliseUploadSourcesOptions, requireAuth bool) (lokalise.Config, string, error) {
+	cfg := lokalise.Config{}
+	if strings.TrimSpace(o.configPath) != "" {
+		loaded, err := i18nconfig.Load(o.configPath)
+		if err != nil {
+			return lokalise.Config{}, "", err
+		}
+		if loaded.Storage == nil {
+			return lokalise.Config{}, "", fmt.Errorf("lokalise upload sources: --config must include storage.adapter=lokalise")
+		}
+		if !strings.EqualFold(strings.TrimSpace(loaded.Storage.Adapter), lokalise.AdapterName) {
+			return lokalise.Config{}, "", fmt.Errorf("lokalise upload sources: --config storage.adapter must be %q", lokalise.AdapterName)
+		}
+		decoded, err := decodeLokaliseStorageConfig(loaded.Storage.Config)
+		if err != nil {
+			return lokalise.Config{}, "", err
+		}
+		cfg = decoded
+	}
+
+	if lokaliseFlagChanged(cmd, "project-id") || strings.TrimSpace(cfg.ProjectID) == "" {
+		cfg.ProjectID = strings.TrimSpace(o.projectID)
+	}
+	if lokaliseFlagChanged(cmd, "token-env") || strings.TrimSpace(cfg.APITokenEnv) == "" {
+		cfg.APITokenEnv = strings.TrimSpace(o.tokenEnv)
+	}
+	if lokaliseFlagChanged(cmd, "api-base-url") || strings.TrimSpace(cfg.APIBaseURL) == "" {
+		cfg.APIBaseURL = strings.TrimSpace(o.apiBaseURL)
+	}
+	if lokaliseFlagChanged(cmd, "timeout-seconds") || cfg.TimeoutSeconds <= 0 {
+		cfg.TimeoutSeconds = o.timeoutSeconds
+	}
+	if lokaliseFlagChanged(cmd, "source-locale") || strings.TrimSpace(cfg.SourceLanguage) == "" {
+		cfg.SourceLanguage = strings.TrimSpace(o.sourceLocale)
+	}
+
+	if strings.TrimSpace(cfg.ProjectID) == "" {
+		return lokalise.Config{}, "", fmt.Errorf("lokalise upload sources: --project-id is required (or projectID in --config)")
+	}
+	if strings.TrimSpace(cfg.SourceLanguage) == "" {
+		return lokalise.Config{}, "", fmt.Errorf("lokalise upload sources: --source-locale is required (or sourceLanguage in --config)")
+	}
+	if requireAuth {
+		resolved, err := lokalise.ResolveConfig(cfg)
+		if err != nil {
+			return lokalise.Config{}, "", fmt.Errorf("lokalise upload sources: %w", err)
+		}
+		return resolved, strings.TrimSpace(cfg.SourceLanguage), nil
+	}
+	if strings.TrimSpace(cfg.APITokenEnv) == "" {
+		cfg.APITokenEnv = defaultLokaliseAPITokenEnv
+	}
+	if cfg.TimeoutSeconds <= 0 {
+		cfg.TimeoutSeconds = o.timeoutSeconds
+	}
+	return cfg, strings.TrimSpace(cfg.SourceLanguage), nil
+}
+
+func decodeLokaliseStorageConfig(raw json.RawMessage) (lokalise.Config, error) {
+	if len(raw) == 0 {
+		return lokalise.Config{}, nil
+	}
+	var rawMap map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &rawMap); err != nil {
+		return lokalise.Config{}, fmt.Errorf("lokalise config: decode: %w", err)
+	}
+	if _, exists := rawMap["apiToken"]; exists {
+		return lokalise.Config{}, fmt.Errorf("lokalise config: apiToken is not supported; use %s", defaultLokaliseAPITokenEnv)
+	}
+
+	var cfg lokalise.Config
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return lokalise.Config{}, fmt.Errorf("lokalise config: decode: %w", err)
+	}
+	return cfg, nil
+}
+
+func validateLokaliseSourceFiles(paths []string, format string) ([]string, error) {
+	files := make([]string, 0, len(paths))
+	for _, path := range paths {
+		trimmed := strings.TrimSpace(path)
+		if trimmed == "" {
+			continue
+		}
+		info, err := os.Stat(trimmed)
+		if err != nil {
+			return nil, fmt.Errorf("lokalise upload sources: stat source file %q: %w", trimmed, err)
+		}
+		if info.IsDir() {
+			return nil, fmt.Errorf("lokalise upload sources: source file %q is a directory", trimmed)
+		}
+		if strings.TrimSpace(format) == "" && strings.TrimPrefix(filepath.Ext(trimmed), ".") == "" {
+			return nil, fmt.Errorf("lokalise upload sources: could not determine file format for %q; use --format", trimmed)
+		}
+		files = append(files, trimmed)
+	}
+	if len(files) == 0 {
+		return nil, fmt.Errorf("lokalise upload sources: at least one --file is required")
+	}
+	return files, nil
 }
 
 // resolveLokaliseGlossaryConfig keeps the command non-interactive:
@@ -213,4 +436,9 @@ func loadLokaliseStorageConfig(configPath string) (lokalise.Config, error) {
 		return lokalise.Config{}, fmt.Errorf("lokalise glossary download: %w", err)
 	}
 	return parsed, nil
+}
+
+func lokaliseFlagChanged(cmd *cobra.Command, name string) bool {
+	flag := cmd.Flags().Lookup(name)
+	return flag != nil && flag.Changed
 }

--- a/apps/cli/cmd/lokalise.go
+++ b/apps/cli/cmd/lokalise.go
@@ -220,7 +220,7 @@ func executeLokaliseUploadSources(cmd *cobra.Command, o lokaliseUploadSourcesOpt
 	if err != nil {
 		return err
 	}
-	processed, skipped, warnings := 0, 0, 0
+	processed := 0
 	for _, file := range files {
 		result, err := client.UploadSourceFile(backgroundContext(), lokalise.SourceUploadInput{
 			ProjectID:           cfg.ProjectID,
@@ -243,7 +243,7 @@ func executeLokaliseUploadSources(cmd *cobra.Command, o lokaliseUploadSourcesOpt
 			return err
 		}
 	}
-	_, err = fmt.Fprintf(cmd.OutOrStdout(), "action=lokalise-upload-sources processed=%d skipped=%d warnings=%d\n", processed, skipped, warnings)
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "action=lokalise-upload-sources processed=%d\n", processed)
 	return err
 }
 

--- a/apps/cli/cmd/lokalise.go
+++ b/apps/cli/cmd/lokalise.go
@@ -220,7 +220,7 @@ func executeLokaliseUploadSources(cmd *cobra.Command, o lokaliseUploadSourcesOpt
 	if err != nil {
 		return err
 	}
-	processed := 0
+	processed, skipped, warnings := 0, 0, 0
 	for _, file := range files {
 		result, err := client.UploadSourceFile(backgroundContext(), lokalise.SourceUploadInput{
 			ProjectID:           cfg.ProjectID,
@@ -243,7 +243,7 @@ func executeLokaliseUploadSources(cmd *cobra.Command, o lokaliseUploadSourcesOpt
 			return err
 		}
 	}
-	_, err = fmt.Fprintf(cmd.OutOrStdout(), "action=lokalise-upload-sources processed=%d skipped=0 warnings=0\n", processed)
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "action=lokalise-upload-sources processed=%d skipped=%d warnings=%d\n", processed, skipped, warnings)
 	return err
 }
 

--- a/apps/cli/cmd/lokalise.go
+++ b/apps/cli/cmd/lokalise.go
@@ -294,13 +294,10 @@ func resolveLokaliseUploadSourcesConfig(cmd *cobra.Command, o lokaliseUploadSour
 		if err != nil {
 			return lokalise.Config{}, "", fmt.Errorf("lokalise upload sources: %w", err)
 		}
-		return resolved, strings.TrimSpace(cfg.SourceLanguage), nil
+		return resolved, strings.TrimSpace(resolved.SourceLanguage), nil
 	}
 	if strings.TrimSpace(cfg.APITokenEnv) == "" {
 		cfg.APITokenEnv = defaultLokaliseAPITokenEnv
-	}
-	if cfg.TimeoutSeconds <= 0 {
-		cfg.TimeoutSeconds = o.timeoutSeconds
 	}
 	return cfg, strings.TrimSpace(cfg.SourceLanguage), nil
 }

--- a/apps/cli/cmd/lokalise.go
+++ b/apps/cli/cmd/lokalise.go
@@ -199,11 +199,11 @@ func newLokaliseGlossaryDownloadCmd() *cobra.Command {
 }
 
 func executeLokaliseUploadSources(cmd *cobra.Command, o lokaliseUploadSourcesOptions) error {
-	cfg, sourceLocale, err := resolveLokaliseUploadSourcesConfig(cmd, o, !o.dryRun)
+	files, err := validateLokaliseSourceFiles(o.files, o.format)
 	if err != nil {
 		return err
 	}
-	files, err := validateLokaliseSourceFiles(o.files, o.format)
+	cfg, sourceLocale, err := resolveLokaliseUploadSourcesConfig(cmd, o, !o.dryRun)
 	if err != nil {
 		return err
 	}
@@ -310,8 +310,10 @@ func decodeLokaliseStorageConfig(raw json.RawMessage) (lokalise.Config, error) {
 	if err := json.Unmarshal(raw, &rawMap); err != nil {
 		return lokalise.Config{}, fmt.Errorf("lokalise config: decode: %w", err)
 	}
-	if _, exists := rawMap["apiToken"]; exists {
-		return lokalise.Config{}, fmt.Errorf("lokalise config: apiToken is not supported; use %s", defaultLokaliseAPITokenEnv)
+	for key := range rawMap {
+		if strings.EqualFold(key, "apiToken") {
+			return lokalise.Config{}, fmt.Errorf("lokalise config: apiToken is not supported; use %s", defaultLokaliseAPITokenEnv)
+		}
 	}
 
 	var cfg lokalise.Config

--- a/apps/cli/cmd/lokalise_test.go
+++ b/apps/cli/cmd/lokalise_test.go
@@ -241,7 +241,7 @@ func TestLokaliseUploadSourcesUploadsFiles(t *testing.T) {
 	if !strings.Contains(out.String(), "uploaded file="+sourcePath+" process_id=proc-1 status=queued type=file-import") {
 		t.Fatalf("missing upload output: %q", out.String())
 	}
-	if !strings.Contains(out.String(), "action=lokalise-upload-sources processed=1 skipped=0 warnings=0") {
+	if !strings.Contains(out.String(), "action=lokalise-upload-sources processed=1") {
 		t.Fatalf("missing summary output: %q", out.String())
 	}
 	if len(fake.inputs) != 1 {

--- a/apps/cli/cmd/lokalise_test.go
+++ b/apps/cli/cmd/lokalise_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -139,6 +140,209 @@ func TestLokaliseGlossaryDownloadRequiresProjectIDOrConfig(t *testing.T) {
 	}
 }
 
+func TestLokaliseUploadSourcesDryRunValidatesFiles(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "en.json")
+	if err := os.WriteFile(sourcePath, []byte(`{"hello":"Hello"}`), 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+	t.Setenv("LOKALISE_API_TOKEN", "")
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"lokalise", "upload", "sources", "--project-id", "project-1", "--source-locale", "en", "--file", sourcePath, "--dry-run"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute lokalise upload dry-run: %v", err)
+	}
+	if !strings.Contains(out.String(), "dry-run action=lokalise-upload-sources") || !strings.Contains(out.String(), "files=1") {
+		t.Fatalf("unexpected output: %q", out.String())
+	}
+}
+
+func TestLokaliseUploadSourcesRequiresFile(t *testing.T) {
+	t.Setenv("LOKALISE_API_TOKEN", "secret")
+
+	cmd := newRootCmd("")
+	cmd.SetArgs([]string{"lokalise", "upload", "sources", "--project-id", "project-1", "--source-locale", "en"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected missing file error")
+	}
+	if !strings.Contains(err.Error(), "at least one --file is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLokaliseUploadSourcesRequiresFormatForExtensionlessFile(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source")
+	if err := os.WriteFile(sourcePath, []byte(`hello=Hello`), 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+	t.Setenv("LOKALISE_API_TOKEN", "secret")
+
+	cmd := newRootCmd("")
+	cmd.SetArgs([]string{"lokalise", "upload", "sources", "--project-id", "project-1", "--source-locale", "en", "--file", sourcePath, "--dry-run"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "use --format") {
+		t.Fatalf("error = %v, want format hint", err)
+	}
+}
+
+func TestLokaliseUploadSourcesTokenErrorListsEnv(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "en.json")
+	if err := os.WriteFile(sourcePath, []byte(`{"hello":"Hello"}`), 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+	t.Setenv("LOKALISE_API_TOKEN", "")
+
+	cmd := newRootCmd("")
+	cmd.SetArgs([]string{"lokalise", "upload", "sources", "--project-id", "project-1", "--source-locale", "en", "--file", sourcePath})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "LOKALISE_API_TOKEN") {
+		t.Fatalf("error = %v, want token env hint", err)
+	}
+}
+
+func TestLokaliseUploadSourcesUploadsFiles(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "en.json")
+	if err := os.WriteFile(sourcePath, []byte(`{"hello":"Hello"}`), 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+	t.Setenv("LOKALISE_TEST_TOKEN", "secret")
+
+	oldFactory := newLokaliseSourceUploader
+	defer func() {
+		newLokaliseSourceUploader = oldFactory
+	}()
+	fake := &fakeLokaliseSourceUploader{}
+	newLokaliseSourceUploader = func(cfg lokalise.Config) (lokaliseSourceUploader, error) {
+		if cfg.ProjectID != "project-1" || cfg.APIToken != "secret" {
+			t.Fatalf("config = %#v, want project/token from flags and env", cfg)
+		}
+		return fake, nil
+	}
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"lokalise", "upload", "sources", "--project-id", "project-1", "--source-locale", "en", "--file", sourcePath, "--format", "json", "--branch", "main", "--tag", "app,source", "--token-env", "LOKALISE_TEST_TOKEN", "--convert-placeholders", "--replace-modified"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute lokalise upload: %v", err)
+	}
+	if !strings.Contains(out.String(), "uploaded file="+sourcePath+" process_id=proc-1 status=queued type=file-import") {
+		t.Fatalf("missing upload output: %q", out.String())
+	}
+	if !strings.Contains(out.String(), "action=lokalise-upload-sources processed=1 skipped=0 warnings=0") {
+		t.Fatalf("missing summary output: %q", out.String())
+	}
+	if len(fake.inputs) != 1 {
+		t.Fatalf("inputs = %#v, want one upload", fake.inputs)
+	}
+	input := fake.inputs[0]
+	if input.ProjectID != "project-1" || input.SourceLocale != "en" || input.FilePath != sourcePath || input.FileFormat != "json" || input.Branch != "main" {
+		t.Fatalf("input = %#v, want CLI values", input)
+	}
+	if !reflect.DeepEqual(input.Tags, []string{"app", "source"}) {
+		t.Fatalf("tags = %#v, want parsed CLI tags", input.Tags)
+	}
+	if !input.ConvertPlaceholders || !input.ReplaceModified {
+		t.Fatalf("options not passed through: %#v", input)
+	}
+}
+
+func TestLokaliseUploadSourcesUsesStorageConfig(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "en.json")
+	if err := os.WriteFile(sourcePath, []byte(`{"hello":"Hello"}`), 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+	t.Setenv("LOKALISE_TEST_TOKEN", "secret")
+
+	configPath := filepath.Join(dir, "i18n.yml")
+	if err := os.WriteFile(configPath, []byte(`
+locales:
+  source: en
+  targets:
+    - fr
+buckets:
+  ui:
+    files:
+      - from: content/en.json
+        to: dist/{{target}}.json
+llm:
+  profiles:
+    default:
+      provider: openai
+      model: test
+storage:
+  adapter: lokalise
+  config:
+    projectID: project-from-config
+    apiTokenEnv: LOKALISE_TEST_TOKEN
+    sourceLanguage: en
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	oldFactory := newLokaliseSourceUploader
+	defer func() {
+		newLokaliseSourceUploader = oldFactory
+	}()
+	fake := &fakeLokaliseSourceUploader{}
+	newLokaliseSourceUploader = func(cfg lokalise.Config) (lokaliseSourceUploader, error) {
+		if cfg.ProjectID != "project-from-config" || cfg.APIToken != "secret" {
+			t.Fatalf("config = %#v, want storage config", cfg)
+		}
+		return fake, nil
+	}
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"lokalise", "upload", "sources", "--config", configPath, "--file", sourcePath})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute lokalise upload: %v", err)
+	}
+	if len(fake.inputs) != 1 || fake.inputs[0].ProjectID != "project-from-config" || fake.inputs[0].SourceLocale != "en" {
+		t.Fatalf("inputs = %#v, want config values", fake.inputs)
+	}
+}
+
+func TestLokaliseUploadSourcesPreservesPartialProgressOnError(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "en.json")
+	if err := os.WriteFile(sourcePath, []byte(`{"hello":"Hello"}`), 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+	t.Setenv("LOKALISE_API_TOKEN", "secret")
+
+	oldFactory := newLokaliseSourceUploader
+	defer func() {
+		newLokaliseSourceUploader = oldFactory
+	}()
+	newLokaliseSourceUploader = func(lokalise.Config) (lokaliseSourceUploader, error) {
+		return &fakeLokaliseSourceUploader{err: errors.New("api failed")}, nil
+	}
+
+	cmd := newRootCmd("")
+	cmd.SetArgs([]string{"lokalise", "upload", "sources", "--project-id", "project-1", "--source-locale", "en", "--file", sourcePath})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "api failed") {
+		t.Fatalf("error = %v, want api failed", err)
+	}
+}
+
 type fakeLokaliseGlossaryCSVWriter struct {
 	req lokalise.GlossaryDownloadInput
 	err error
@@ -153,4 +357,17 @@ func (f *fakeLokaliseGlossaryCSVWriter) WriteGlossaryCSV(_ context.Context, req 
 		return lokalise.GlossaryDownloadResult{}, err
 	}
 	return lokalise.GlossaryDownloadResult{Terms: 1, Rows: 1}, nil
+}
+
+type fakeLokaliseSourceUploader struct {
+	inputs []lokalise.SourceUploadInput
+	err    error
+}
+
+func (f *fakeLokaliseSourceUploader) UploadSourceFile(_ context.Context, input lokalise.SourceUploadInput) (lokalise.SourceUploadResult, error) {
+	f.inputs = append(f.inputs, input)
+	if f.err != nil {
+		return lokalise.SourceUploadResult{}, f.err
+	}
+	return lokalise.SourceUploadResult{ProcessID: "proc-1", Type: "file-import", Status: "queued"}, nil
 }

--- a/apps/cli/cmd/lokalise_test.go
+++ b/apps/cli/cmd/lokalise_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"os"
@@ -162,7 +163,7 @@ func TestLokaliseUploadSourcesDryRunValidatesFiles(t *testing.T) {
 }
 
 func TestLokaliseUploadSourcesRequiresFile(t *testing.T) {
-	t.Setenv("LOKALISE_API_TOKEN", "secret")
+	t.Setenv("LOKALISE_API_TOKEN", "")
 
 	cmd := newRootCmd("")
 	cmd.SetArgs([]string{"lokalise", "upload", "sources", "--project-id", "project-1", "--source-locale", "en"})
@@ -173,6 +174,13 @@ func TestLokaliseUploadSourcesRequiresFile(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "at least one --file is required") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDecodeLokaliseStorageConfigRejectsInlineTokenCasing(t *testing.T) {
+	_, err := decodeLokaliseStorageConfig(json.RawMessage(`{"projectID":"project-1","APIToken":"inline"}`))
+	if err == nil || !strings.Contains(err.Error(), "apiToken is not supported") {
+		t.Fatalf("expected inline token rejection, got %v", err)
 	}
 }
 

--- a/internal/i18n/storage/lokalise/adapter.go
+++ b/internal/i18n/storage/lokalise/adapter.go
@@ -88,8 +88,10 @@ func ParseConfig(raw json.RawMessage) (Config, error) {
 	if err := json.Unmarshal(raw, &rawMap); err != nil {
 		return cfg, fmt.Errorf("lokalise config: decode: %w", err)
 	}
-	if _, exists := rawMap["apiToken"]; exists {
-		return cfg, fmt.Errorf("lokalise config: apiToken is not supported; use %s", defaultTokenEnvName)
+	for key := range rawMap {
+		if strings.EqualFold(key, "apiToken") {
+			return cfg, fmt.Errorf("lokalise config: apiToken is not supported; use %s", defaultTokenEnvName)
+		}
 	}
 	if err := json.Unmarshal(raw, &cfg); err != nil {
 		return cfg, fmt.Errorf("lokalise config: decode: %w", err)

--- a/internal/i18n/storage/lokalise/adapter.go
+++ b/internal/i18n/storage/lokalise/adapter.go
@@ -95,6 +95,11 @@ func ParseConfig(raw json.RawMessage) (Config, error) {
 		return cfg, fmt.Errorf("lokalise config: decode: %w", err)
 	}
 
+	return ResolveConfig(cfg)
+}
+
+// ResolveConfig applies Lokalise defaults and validates required auth fields.
+func ResolveConfig(cfg Config) (Config, error) {
 	if strings.TrimSpace(cfg.APITokenEnv) == "" {
 		cfg.APITokenEnv = defaultTokenEnvName
 	}

--- a/internal/i18n/storage/lokalise/adapter_test.go
+++ b/internal/i18n/storage/lokalise/adapter_test.go
@@ -58,6 +58,14 @@ func TestParseConfigRejectsInlineToken(t *testing.T) {
 	}
 }
 
+func TestParseConfigRejectsInlineTokenCasing(t *testing.T) {
+	t.Setenv("LOKALISE_API_TOKEN", "env-token")
+	_, err := ParseConfig(json.RawMessage(`{"projectID":"123","APIToken":"inline"}`))
+	if err == nil || !strings.Contains(err.Error(), "apiToken is not supported") {
+		t.Fatalf("expected inline token rejection, got %v", err)
+	}
+}
+
 func TestAdapterPullMapsKeyContextLanguage(t *testing.T) {
 	client := &fakeClient{
 		keys: []KeyTranslation{

--- a/internal/i18n/storage/lokalise/glossary_test.go
+++ b/internal/i18n/storage/lokalise/glossary_test.go
@@ -136,6 +136,36 @@ func TestHTTPClientWriteGlossaryCSV(t *testing.T) {
 	}
 }
 
+func TestHTTPClientWriteGlossaryCSVFollowsRedirects(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/projects/proj-1/glossary-terms", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/redirected/glossary-terms", http.StatusFound)
+	})
+	mux.HandleFunc("/redirected/glossary-terms", func(w http.ResponseWriter, _ *http.Request) {
+		writeLokaliseJSON(t, w, map[string]any{
+			"items": []any{},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client, err := NewHTTPClientWithBaseURL(Config{APIToken: "token"}, srv.URL, srv.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := bytes.NewBuffer(nil)
+	result, err := client.WriteGlossaryCSV(context.Background(), GlossaryDownloadInput{ProjectID: "proj-1"}, out)
+	if err != nil {
+		t.Fatalf("write glossary csv: %v", err)
+	}
+	if result.Terms != 0 || result.Rows != 0 {
+		t.Fatalf("result = %+v, want empty glossary", result)
+	}
+	if got := out.String(); !strings.Contains(got, "term;description;casesensitive;translatable;Forbidden;tags") {
+		t.Fatalf("output = %q, want base header", got)
+	}
+}
+
 func TestHTTPClientWriteGlossaryCSVFiltersLocaleColumns(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/projects/proj-1/glossary-terms", func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/i18n/storage/lokalise/http_client.go
+++ b/internal/i18n/storage/lokalise/http_client.go
@@ -19,7 +19,7 @@ type HTTPClient struct {
 	api *lokaliseapi.Api
 	// apiToken is the single auth source for raw Lokalise API calls.
 	apiToken string
-	// baseURL and httpClient are kept for glossary endpoints that are called directly.
+	// baseURL and httpClient are kept for glossary and file endpoints that are called directly.
 	baseURL    string
 	httpClient *http.Client
 }
@@ -29,13 +29,25 @@ func NewHTTPClient(cfg Config) (*HTTPClient, error) {
 	if timeout <= 0 {
 		timeout = 30 * time.Second
 	}
-	httpClient := &http.Client{Timeout: timeout}
+	httpClient := &http.Client{
+		Timeout: timeout,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
 	return NewHTTPClientWithBaseURL(cfg, cfg.APIBaseURL, httpClient)
 }
 
 func NewHTTPClientWithBaseURL(cfg Config, baseURL string, httpClient *http.Client) (*HTTPClient, error) {
 	if httpClient == nil {
 		return nil, fmt.Errorf("lokalise http client: client must not be nil")
+	}
+	if httpClient.CheckRedirect == nil {
+		cloned := *httpClient
+		cloned.CheckRedirect = func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		}
+		httpClient = &cloned
 	}
 	if strings.TrimSpace(baseURL) == "" {
 		baseURL = defaultBaseURL
@@ -47,7 +59,7 @@ func NewHTTPClientWithBaseURL(cfg Config, baseURL string, httpClient *http.Clien
 	apiToken := strings.TrimSpace(cfg.APIToken)
 
 	// Keep the SDK initialized with the same base URL/timeout as the raw client
-	// so existing key sync and new glossary export behavior stay aligned.
+	// so existing key sync, glossary export, and file upload behavior stay aligned.
 	api, err := lokaliseapi.New(
 		apiToken,
 		lokaliseapi.WithBaseURL(baseURL),

--- a/internal/i18n/storage/lokalise/http_client.go
+++ b/internal/i18n/storage/lokalise/http_client.go
@@ -29,25 +29,13 @@ func NewHTTPClient(cfg Config) (*HTTPClient, error) {
 	if timeout <= 0 {
 		timeout = 30 * time.Second
 	}
-	httpClient := &http.Client{
-		Timeout: timeout,
-		CheckRedirect: func(*http.Request, []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-	}
+	httpClient := &http.Client{Timeout: timeout}
 	return NewHTTPClientWithBaseURL(cfg, cfg.APIBaseURL, httpClient)
 }
 
 func NewHTTPClientWithBaseURL(cfg Config, baseURL string, httpClient *http.Client) (*HTTPClient, error) {
 	if httpClient == nil {
 		return nil, fmt.Errorf("lokalise http client: client must not be nil")
-	}
-	if httpClient.CheckRedirect == nil {
-		cloned := *httpClient
-		cloned.CheckRedirect = func(*http.Request, []*http.Request) error {
-			return http.ErrUseLastResponse
-		}
-		httpClient = &cloned
 	}
 	if strings.TrimSpace(baseURL) == "" {
 		baseURL = defaultBaseURL

--- a/internal/i18n/storage/lokalise/source_upload.go
+++ b/internal/i18n/storage/lokalise/source_upload.go
@@ -85,7 +85,10 @@ func (c *HTTPClient) UploadSourceFile(ctx context.Context, in SourceUploadInput)
 	}
 
 	info, statErr := os.Stat(in.FilePath)
-	if statErr == nil && info.Size() > maxLokaliseUploadFileBytes {
+	if statErr != nil {
+		return SourceUploadResult{}, fmt.Errorf("lokalise source upload: stat source file %q: %w", in.FilePath, statErr)
+	}
+	if info.Size() > maxLokaliseUploadFileBytes {
 		return SourceUploadResult{}, fmt.Errorf("lokalise source upload: source file %q exceeds maximum upload size (%d bytes)", in.FilePath, maxLokaliseUploadFileBytes)
 	}
 	content, err := os.ReadFile(in.FilePath)

--- a/internal/i18n/storage/lokalise/source_upload.go
+++ b/internal/i18n/storage/lokalise/source_upload.go
@@ -101,10 +101,14 @@ func (c *HTTPClient) UploadSourceFile(ctx context.Context, in SourceUploadInput)
 
 	var out lokaliseFileUploadResponse
 	path := fmt.Sprintf("/projects/%s/files/upload", lokaliseProjectPathSegment(in.ProjectID, in.Branch))
-	if err := c.doLokaliseUploadJSON(ctx, http.MethodPost, path, req, &out); err != nil {
+	meta, err := c.doLokaliseUploadJSON(ctx, http.MethodPost, path, req, &out)
+	if err != nil {
 		return SourceUploadResult{}, fmt.Errorf("lokalise source upload %q: %w", in.FilePath, err)
 	}
 	if strings.TrimSpace(out.Process.ID) == "" {
+		if meta.StatusCode == http.StatusFound {
+			return SourceUploadResult{}, fmt.Errorf("lokalise source upload %q: 302 queued response missing process id%s", in.FilePath, lokaliseUploadLocationSuffix(meta.Location))
+		}
 		return SourceUploadResult{}, fmt.Errorf("lokalise source upload %q: response missing process id", in.FilePath)
 	}
 	return SourceUploadResult{
@@ -115,14 +119,19 @@ func (c *HTTPClient) UploadSourceFile(ctx context.Context, in SourceUploadInput)
 	}, nil
 }
 
-func (c *HTTPClient) doLokaliseUploadJSON(ctx context.Context, method, path string, payload any, out any) error {
+type lokaliseUploadHTTPMeta struct {
+	StatusCode int
+	Location   string
+}
+
+func (c *HTTPClient) doLokaliseUploadJSON(ctx context.Context, method, path string, payload any, out any) (lokaliseUploadHTTPMeta, error) {
 	body, err := json.Marshal(payload)
 	if err != nil {
-		return err
+		return lokaliseUploadHTTPMeta{}, err
 	}
 	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, bytes.NewReader(body))
 	if err != nil {
-		return err
+		return lokaliseUploadHTTPMeta{}, err
 	}
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")
@@ -130,27 +139,51 @@ func (c *HTTPClient) doLokaliseUploadJSON(ctx context.Context, method, path stri
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return err
+		return lokaliseUploadHTTPMeta{}, err
 	}
 	defer func() {
 		_ = resp.Body.Close()
 	}()
+	meta := lokaliseUploadHTTPMeta{
+		StatusCode: resp.StatusCode,
+		Location:   strings.TrimSpace(resp.Header.Get("Location")),
+	}
 	if !isLokaliseUploadSuccessStatus(resp.StatusCode) {
 		raw, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return fmt.Errorf("lokalise API %s %s failed: status=%d body=%s", method, path, resp.StatusCode, strings.TrimSpace(string(raw)))
+		return meta, fmt.Errorf("lokalise API %s %s failed: status=%d body=%s", method, path, resp.StatusCode, strings.TrimSpace(string(raw)))
 	}
 	if out == nil {
 		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxLokaliseUploadResponseBody))
-		return nil
+		return meta, nil
+	}
+	if resp.StatusCode == http.StatusFound {
+		raw, err := io.ReadAll(io.LimitReader(resp.Body, maxLokaliseUploadResponseBody))
+		if err != nil {
+			return meta, fmt.Errorf("read lokalise API 302 response: %w", err)
+		}
+		if strings.TrimSpace(string(raw)) == "" {
+			return meta, fmt.Errorf("lokalise API %s %s returned 302 without JSON queued process body%s", method, path, lokaliseUploadLocationSuffix(meta.Location))
+		}
+		if err := json.NewDecoder(bytes.NewReader(raw)).Decode(out); err != nil {
+			return meta, fmt.Errorf("decode lokalise API 302 queued response%s: %w", lokaliseUploadLocationSuffix(meta.Location), err)
+		}
+		return meta, nil
 	}
 	if err := json.NewDecoder(io.LimitReader(resp.Body, maxLokaliseUploadResponseBody)).Decode(out); err != nil {
-		return fmt.Errorf("decode lokalise API response: %w", err)
+		return meta, fmt.Errorf("decode lokalise API response: %w", err)
 	}
-	return nil
+	return meta, nil
 }
 
 func isLokaliseUploadSuccessStatus(status int) bool {
-	return status >= 200 && status < 300 || status == http.StatusFound
+	return (status >= 200 && status < 300) || status == http.StatusFound
+}
+
+func lokaliseUploadLocationSuffix(location string) string {
+	if strings.TrimSpace(location) == "" {
+		return ""
+	}
+	return " location=" + strings.TrimSpace(location)
 }
 
 func resolveLokaliseUploadFormat(path, override string) (string, error) {

--- a/internal/i18n/storage/lokalise/source_upload.go
+++ b/internal/i18n/storage/lokalise/source_upload.go
@@ -137,7 +137,7 @@ func (c *HTTPClient) doLokaliseUploadJSON(ctx context.Context, method, path stri
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Api-Token", strings.TrimSpace(c.apiToken))
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := lokaliseUploadHTTPClient(c.httpClient).Do(req)
 	if err != nil {
 		return lokaliseUploadHTTPMeta{}, err
 	}
@@ -186,13 +186,21 @@ func lokaliseUploadLocationSuffix(location string) string {
 	return " location=" + strings.TrimSpace(location)
 }
 
+func lokaliseUploadHTTPClient(client *http.Client) *http.Client {
+	cloned := *client
+	cloned.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	return &cloned
+}
+
 func resolveLokaliseUploadFormat(path, override string) (string, error) {
 	if trimmed := strings.TrimSpace(override); trimmed != "" {
 		return strings.TrimPrefix(strings.ToLower(trimmed), "."), nil
 	}
 	ext := strings.TrimPrefix(strings.ToLower(filepath.Ext(path)), ".")
 	if ext == "" {
-		return "", fmt.Errorf("lokalise source upload: could not determine file format for %q; use --format", path)
+		return "", fmt.Errorf("lokalise source upload: could not determine file format for %q: no file extension and no format override provided", path)
 	}
 	return ext, nil
 }

--- a/internal/i18n/storage/lokalise/source_upload.go
+++ b/internal/i18n/storage/lokalise/source_upload.go
@@ -14,7 +14,10 @@ import (
 	"strings"
 )
 
-const maxLokaliseUploadResponseBody = 1 << 20
+const (
+	maxLokaliseUploadFileBytes    = 20 << 20
+	maxLokaliseUploadResponseBody = 1 << 20
+)
 
 // SourceUploadInput describes one Lokalise source file import.
 type SourceUploadInput struct {
@@ -81,6 +84,10 @@ func (c *HTTPClient) UploadSourceFile(ctx context.Context, in SourceUploadInput)
 		return SourceUploadResult{}, err
 	}
 
+	info, statErr := os.Stat(in.FilePath)
+	if statErr == nil && info.Size() > maxLokaliseUploadFileBytes {
+		return SourceUploadResult{}, fmt.Errorf("lokalise source upload: source file %q exceeds maximum upload size (%d bytes)", in.FilePath, maxLokaliseUploadFileBytes)
+	}
 	content, err := os.ReadFile(in.FilePath)
 	if err != nil {
 		return SourceUploadResult{}, fmt.Errorf("lokalise source upload: read source file %q: %w", in.FilePath, err)

--- a/internal/i18n/storage/lokalise/source_upload.go
+++ b/internal/i18n/storage/lokalise/source_upload.go
@@ -239,5 +239,8 @@ func normalizeLokaliseUploadTags(tags []string) []string {
 			out = append(out, trimmed)
 		}
 	}
+	if len(out) == 0 {
+		return nil
+	}
 	return out
 }

--- a/internal/i18n/storage/lokalise/source_upload.go
+++ b/internal/i18n/storage/lokalise/source_upload.go
@@ -84,16 +84,26 @@ func (c *HTTPClient) UploadSourceFile(ctx context.Context, in SourceUploadInput)
 		return SourceUploadResult{}, err
 	}
 
-	info, statErr := os.Stat(in.FilePath)
+	file, statErr := os.Open(in.FilePath)
+	if statErr != nil {
+		return SourceUploadResult{}, fmt.Errorf("lokalise source upload: open source file %q: %w", in.FilePath, statErr)
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+	info, statErr := file.Stat()
 	if statErr != nil {
 		return SourceUploadResult{}, fmt.Errorf("lokalise source upload: stat source file %q: %w", in.FilePath, statErr)
 	}
 	if info.Size() > maxLokaliseUploadFileBytes {
 		return SourceUploadResult{}, fmt.Errorf("lokalise source upload: source file %q exceeds maximum upload size (%d bytes)", in.FilePath, maxLokaliseUploadFileBytes)
 	}
-	content, err := os.ReadFile(in.FilePath)
+	content, err := io.ReadAll(io.LimitReader(file, maxLokaliseUploadFileBytes+1))
 	if err != nil {
 		return SourceUploadResult{}, fmt.Errorf("lokalise source upload: read source file %q: %w", in.FilePath, err)
+	}
+	if len(content) > maxLokaliseUploadFileBytes {
+		return SourceUploadResult{}, fmt.Errorf("lokalise source upload: source file %q exceeds maximum upload size (%d bytes)", in.FilePath, maxLokaliseUploadFileBytes)
 	}
 	req := lokaliseFileUploadRequest{
 		Data:                base64.StdEncoding.EncodeToString(content),

--- a/internal/i18n/storage/lokalise/source_upload.go
+++ b/internal/i18n/storage/lokalise/source_upload.go
@@ -1,0 +1,192 @@
+package lokalise
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const maxLokaliseUploadResponseBody = 1 << 20
+
+// SourceUploadInput describes one Lokalise source file import.
+type SourceUploadInput struct {
+	ProjectID           string
+	SourceLocale        string
+	FilePath            string
+	FileFormat          string
+	Branch              string
+	Tags                []string
+	ConvertPlaceholders bool
+	ReplaceModified     bool
+	DistinguishByFile   bool
+	ApplyTM             bool
+	SkipDetectLangISO   bool
+}
+
+// SourceUploadResult is the normalized subset of Lokalise's queued import response.
+type SourceUploadResult struct {
+	ProcessID string
+	Type      string
+	Status    string
+	Message   string
+}
+
+type lokaliseFileUploadRequest struct {
+	Data                string   `json:"data"`
+	Filename            string   `json:"filename"`
+	LangISO             string   `json:"lang_iso"`
+	Format              string   `json:"format,omitempty"`
+	Tags                []string `json:"tags,omitempty"`
+	ConvertPlaceholders bool     `json:"convert_placeholders,omitempty"`
+	ReplaceModified     bool     `json:"replace_modified,omitempty"`
+	DistinguishByFile   bool     `json:"distinguish_by_file,omitempty"`
+	ApplyTM             bool     `json:"apply_tm,omitempty"`
+	SkipDetectLangISO   bool     `json:"skip_detect_lang_iso,omitempty"`
+	Queue               bool     `json:"queue"`
+}
+
+type lokaliseFileUploadResponse struct {
+	Process struct {
+		ID      string `json:"process_id"`
+		Type    string `json:"type"`
+		Status  string `json:"status"`
+		Message string `json:"message"`
+	} `json:"process"`
+}
+
+// UploadSourceFile imports a source file into Lokalise and returns the queued import process.
+func (c *HTTPClient) UploadSourceFile(ctx context.Context, in SourceUploadInput) (SourceUploadResult, error) {
+	if c == nil || c.httpClient == nil {
+		return SourceUploadResult{}, fmt.Errorf("lokalise source upload: client is nil")
+	}
+	if strings.TrimSpace(in.ProjectID) == "" {
+		return SourceUploadResult{}, fmt.Errorf("lokalise source upload: project id is required")
+	}
+	if strings.TrimSpace(in.SourceLocale) == "" {
+		return SourceUploadResult{}, fmt.Errorf("lokalise source upload: source locale is required")
+	}
+	if strings.TrimSpace(in.FilePath) == "" {
+		return SourceUploadResult{}, fmt.Errorf("lokalise source upload: file path is required")
+	}
+	format, err := resolveLokaliseUploadFormat(in.FilePath, in.FileFormat)
+	if err != nil {
+		return SourceUploadResult{}, err
+	}
+
+	content, err := os.ReadFile(in.FilePath)
+	if err != nil {
+		return SourceUploadResult{}, fmt.Errorf("lokalise source upload: read source file %q: %w", in.FilePath, err)
+	}
+	req := lokaliseFileUploadRequest{
+		Data:                base64.StdEncoding.EncodeToString(content),
+		Filename:            filepath.Base(in.FilePath),
+		LangISO:             strings.TrimSpace(in.SourceLocale),
+		Format:              format,
+		Tags:                normalizeLokaliseUploadTags(in.Tags),
+		ConvertPlaceholders: in.ConvertPlaceholders,
+		ReplaceModified:     in.ReplaceModified,
+		DistinguishByFile:   in.DistinguishByFile,
+		ApplyTM:             in.ApplyTM,
+		SkipDetectLangISO:   in.SkipDetectLangISO,
+		Queue:               true,
+	}
+
+	var out lokaliseFileUploadResponse
+	path := fmt.Sprintf("/projects/%s/files/upload", lokaliseProjectPathSegment(in.ProjectID, in.Branch))
+	if err := c.doLokaliseUploadJSON(ctx, http.MethodPost, path, req, &out); err != nil {
+		return SourceUploadResult{}, fmt.Errorf("lokalise source upload %q: %w", in.FilePath, err)
+	}
+	if strings.TrimSpace(out.Process.ID) == "" {
+		return SourceUploadResult{}, fmt.Errorf("lokalise source upload %q: response missing process id", in.FilePath)
+	}
+	return SourceUploadResult{
+		ProcessID: strings.TrimSpace(out.Process.ID),
+		Type:      strings.TrimSpace(out.Process.Type),
+		Status:    strings.TrimSpace(out.Process.Status),
+		Message:   strings.TrimSpace(out.Process.Message),
+	}, nil
+}
+
+func (c *HTTPClient) doLokaliseUploadJSON(ctx context.Context, method, path string, payload any, out any) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Api-Token", strings.TrimSpace(c.apiToken))
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	if !isLokaliseUploadSuccessStatus(resp.StatusCode) {
+		raw, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("lokalise API %s %s failed: status=%d body=%s", method, path, resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+	if out == nil {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxLokaliseUploadResponseBody))
+		return nil
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxLokaliseUploadResponseBody)).Decode(out); err != nil {
+		return fmt.Errorf("decode lokalise API response: %w", err)
+	}
+	return nil
+}
+
+func isLokaliseUploadSuccessStatus(status int) bool {
+	return status >= 200 && status < 300 || status == http.StatusFound
+}
+
+func resolveLokaliseUploadFormat(path, override string) (string, error) {
+	if trimmed := strings.TrimSpace(override); trimmed != "" {
+		return strings.TrimPrefix(strings.ToLower(trimmed), "."), nil
+	}
+	ext := strings.TrimPrefix(strings.ToLower(filepath.Ext(path)), ".")
+	if ext == "" {
+		return "", fmt.Errorf("lokalise source upload: could not determine file format for %q; use --format", path)
+	}
+	return ext, nil
+}
+
+func lokaliseProjectPathSegment(projectID, branch string) string {
+	segment := url.PathEscape(strings.TrimSpace(projectID))
+	if trimmed := strings.TrimSpace(branch); trimmed != "" {
+		segment += ":" + url.PathEscape(trimmed)
+	}
+	return segment
+}
+
+func normalizeLokaliseUploadTags(tags []string) []string {
+	out := make([]string, 0, len(tags))
+	seen := make(map[string]struct{}, len(tags))
+	for _, tag := range tags {
+		for _, part := range strings.Split(tag, ",") {
+			trimmed := strings.TrimSpace(part)
+			if trimmed == "" {
+				continue
+			}
+			if _, ok := seen[trimmed]; ok {
+				continue
+			}
+			seen[trimmed] = struct{}{}
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}

--- a/internal/i18n/storage/lokalise/source_upload_test.go
+++ b/internal/i18n/storage/lokalise/source_upload_test.go
@@ -202,7 +202,7 @@ func TestUploadSourceFileRequiresFormatWhenExtensionMissing(t *testing.T) {
 		SourceLocale: "en",
 		FilePath:     sourcePath,
 	})
-	if err == nil || !strings.Contains(err.Error(), "use --format") {
+	if err == nil || !strings.Contains(err.Error(), "no file extension and no format override provided") {
 		t.Fatalf("error = %v, want format hint", err)
 	}
 }

--- a/internal/i18n/storage/lokalise/source_upload_test.go
+++ b/internal/i18n/storage/lokalise/source_upload_test.go
@@ -1,0 +1,199 @@
+package lokalise
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestUploadSourceFilePostsBase64Payload(t *testing.T) {
+	client, mux, teardown := newLokaliseUploadClientForTest(t)
+	defer teardown()
+
+	sourcePath := filepath.Join(t.TempDir(), "en.json")
+	if err := os.WriteFile(sourcePath, []byte(`{"hello":"Hello"}`), 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+
+	mux.HandleFunc("/api2/projects/project-1:feature%2Fnew-release/files/upload", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if got := r.Header.Get("X-Api-Token"); got != "secret" {
+			t.Fatalf("X-Api-Token = %q, want secret", got)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		encoded, ok := body["data"].(string)
+		if !ok {
+			t.Fatalf("data missing from body: %#v", body)
+		}
+		decoded, err := base64.StdEncoding.DecodeString(encoded)
+		if err != nil {
+			t.Fatalf("decode data: %v", err)
+		}
+		if got, want := string(decoded), `{"hello":"Hello"}`; got != want {
+			t.Fatalf("data = %q, want %q", got, want)
+		}
+		if body["filename"] != "en.json" || body["lang_iso"] != "en" || body["format"] != "json" {
+			t.Fatalf("unexpected body identity fields: %#v", body)
+		}
+		if body["convert_placeholders"] != true || body["replace_modified"] != true || body["apply_tm"] != true {
+			t.Fatalf("unexpected upload options: %#v", body)
+		}
+		tags, ok := body["tags"].([]any)
+		if !ok || len(tags) != 2 || tags[0] != "app" || tags[1] != "source" {
+			t.Fatalf("tags = %#v, want app/source", body["tags"])
+		}
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"project_id": "project-1",
+			"process": map[string]any{
+				"process_id": "proc-1",
+				"type":       "file-import",
+				"status":     "queued",
+			},
+		})
+	})
+
+	result, err := client.UploadSourceFile(context.Background(), SourceUploadInput{
+		ProjectID:           "project-1",
+		Branch:              "feature/new-release",
+		SourceLocale:        "en",
+		FilePath:            sourcePath,
+		Tags:                []string{"app,source", "app"},
+		ConvertPlaceholders: true,
+		ReplaceModified:     true,
+		ApplyTM:             true,
+	})
+	if err != nil {
+		t.Fatalf("upload source file: %v", err)
+	}
+	if result.ProcessID != "proc-1" || result.Status != "queued" || result.Type != "file-import" {
+		t.Fatalf("result = %#v, want queued proc-1", result)
+	}
+}
+
+func TestUploadSourceFileUsesFormatOverride(t *testing.T) {
+	client, mux, teardown := newLokaliseUploadClientForTest(t)
+	defer teardown()
+
+	sourcePath := filepath.Join(t.TempDir(), "source")
+	if err := os.WriteFile(sourcePath, []byte(`hello=Hello`), 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+
+	mux.HandleFunc("/api2/projects/project-1/files/upload", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body["format"] != "properties" {
+			t.Fatalf("format = %#v, want properties", body["format"])
+		}
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(map[string]any{"process": map[string]any{"process_id": "proc-2", "status": "queued"}})
+	})
+
+	_, err := client.UploadSourceFile(context.Background(), SourceUploadInput{
+		ProjectID:    "project-1",
+		SourceLocale: "en",
+		FilePath:     sourcePath,
+		FileFormat:   "properties",
+	})
+	if err != nil {
+		t.Fatalf("upload source file: %v", err)
+	}
+}
+
+func TestUploadSourceFileAcceptsAlreadyQueuedResponse(t *testing.T) {
+	client, mux, teardown := newLokaliseUploadClientForTest(t)
+	defer teardown()
+
+	sourcePath := filepath.Join(t.TempDir(), "en.json")
+	if err := os.WriteFile(sourcePath, []byte(`{"hello":"Hello"}`), 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+
+	mux.HandleFunc("/api2/projects/project-1/files/upload", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusFound)
+		_ = json.NewEncoder(w).Encode(map[string]any{"process": map[string]any{"process_id": "proc-queued", "status": "queued"}})
+	})
+
+	result, err := client.UploadSourceFile(context.Background(), SourceUploadInput{
+		ProjectID:    "project-1",
+		SourceLocale: "en",
+		FilePath:     sourcePath,
+	})
+	if err != nil {
+		t.Fatalf("upload source file: %v", err)
+	}
+	if result.ProcessID != "proc-queued" {
+		t.Fatalf("process id = %q, want proc-queued", result.ProcessID)
+	}
+}
+
+func TestUploadSourceFileReturnsAPIError(t *testing.T) {
+	client, mux, teardown := newLokaliseUploadClientForTest(t)
+	defer teardown()
+
+	sourcePath := filepath.Join(t.TempDir(), "en.bad")
+	if err := os.WriteFile(sourcePath, []byte(`bad`), 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+
+	mux.HandleFunc("/api2/projects/project-1/files/upload", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"error":{"message":"unsupported format"}}`, http.StatusBadRequest)
+	})
+
+	_, err := client.UploadSourceFile(context.Background(), SourceUploadInput{
+		ProjectID:    "project-1",
+		SourceLocale: "en",
+		FilePath:     sourcePath,
+	})
+	if err == nil || !strings.Contains(err.Error(), "status=400") || !strings.Contains(err.Error(), "unsupported format") {
+		t.Fatalf("error = %v, want unsupported format API error", err)
+	}
+}
+
+func TestUploadSourceFileRequiresFormatWhenExtensionMissing(t *testing.T) {
+	client, _, teardown := newLokaliseUploadClientForTest(t)
+	defer teardown()
+
+	sourcePath := filepath.Join(t.TempDir(), "source")
+	if err := os.WriteFile(sourcePath, []byte(`hello=Hello`), 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+
+	_, err := client.UploadSourceFile(context.Background(), SourceUploadInput{
+		ProjectID:    "project-1",
+		SourceLocale: "en",
+		FilePath:     sourcePath,
+	})
+	if err == nil || !strings.Contains(err.Error(), "use --format") {
+		t.Fatalf("error = %v, want format hint", err)
+	}
+}
+
+func newLokaliseUploadClientForTest(t *testing.T) (*HTTPClient, *http.ServeMux, func()) {
+	t.Helper()
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	client, err := NewHTTPClient(Config{
+		APIToken:       "secret",
+		APIBaseURL:     server.URL + "/api2",
+		TimeoutSeconds: 1,
+	})
+	if err != nil {
+		t.Fatalf("new http client: %v", err)
+	}
+	return client, mux, server.Close
+}

--- a/internal/i18n/storage/lokalise/source_upload_test.go
+++ b/internal/i18n/storage/lokalise/source_upload_test.go
@@ -188,6 +188,37 @@ func TestUploadSourceFileReturnsAPIError(t *testing.T) {
 	}
 }
 
+func TestUploadSourceFileRejectsLargeFile(t *testing.T) {
+	client, mux, teardown := newLokaliseUploadClientForTest(t)
+	defer teardown()
+
+	mux.HandleFunc("/api2/projects/project-1/files/upload", func(http.ResponseWriter, *http.Request) {
+		t.Fatalf("upload endpoint should not be called for oversized files")
+	})
+
+	sourcePath := filepath.Join(t.TempDir(), "large.json")
+	file, err := os.Create(sourcePath)
+	if err != nil {
+		t.Fatalf("create source file: %v", err)
+	}
+	if err := file.Truncate(maxLokaliseUploadFileBytes + 1); err != nil {
+		_ = file.Close()
+		t.Fatalf("truncate source file: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close source file: %v", err)
+	}
+
+	_, err = client.UploadSourceFile(context.Background(), SourceUploadInput{
+		ProjectID:    "project-1",
+		SourceLocale: "en",
+		FilePath:     sourcePath,
+	})
+	if err == nil || !strings.Contains(err.Error(), "exceeds maximum upload size") {
+		t.Fatalf("error = %v, want maximum upload size error", err)
+	}
+}
+
 func TestUploadSourceFileRequiresFormatWhenExtensionMissing(t *testing.T) {
 	client, _, teardown := newLokaliseUploadClientForTest(t)
 	defer teardown()

--- a/internal/i18n/storage/lokalise/source_upload_test.go
+++ b/internal/i18n/storage/lokalise/source_upload_test.go
@@ -21,9 +21,12 @@ func TestUploadSourceFilePostsBase64Payload(t *testing.T) {
 		t.Fatalf("write source file: %v", err)
 	}
 
-	mux.HandleFunc("/api2/projects/project-1:feature%2Fnew-release/files/upload", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api2/projects/", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if got, want := r.URL.EscapedPath(), "/api2/projects/project-1:feature%2Fnew-release/files/upload"; got != want {
+			t.Fatalf("path = %q, want %q", got, want)
 		}
 		if got := r.Header.Get("X-Api-Token"); got != "secret" {
 			t.Fatalf("X-Api-Token = %q, want secret", got)

--- a/internal/i18n/storage/lokalise/source_upload_test.go
+++ b/internal/i18n/storage/lokalise/source_upload_test.go
@@ -114,6 +114,38 @@ func TestUploadSourceFileUsesFormatOverride(t *testing.T) {
 	}
 }
 
+func TestUploadSourceFileOmitsEmptyTags(t *testing.T) {
+	client, mux, teardown := newLokaliseUploadClientForTest(t)
+	defer teardown()
+
+	sourcePath := filepath.Join(t.TempDir(), "en.json")
+	if err := os.WriteFile(sourcePath, []byte(`{"hello":"Hello"}`), 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+
+	mux.HandleFunc("/api2/projects/project-1/files/upload", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if _, exists := body["tags"]; exists {
+			t.Fatalf("tags should be omitted when empty, got body: %#v", body)
+		}
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(map[string]any{"process": map[string]any{"process_id": "proc-no-tags", "status": "queued"}})
+	})
+
+	_, err := client.UploadSourceFile(context.Background(), SourceUploadInput{
+		ProjectID:    "project-1",
+		SourceLocale: "en",
+		FilePath:     sourcePath,
+		Tags:         []string{"", " , "},
+	})
+	if err != nil {
+		t.Fatalf("upload source file: %v", err)
+	}
+}
+
 func TestUploadSourceFileAcceptsAlreadyQueuedResponse(t *testing.T) {
 	client, mux, teardown := newLokaliseUploadClientForTest(t)
 	defer teardown()

--- a/internal/i18n/storage/lokalise/source_upload_test.go
+++ b/internal/i18n/storage/lokalise/source_upload_test.go
@@ -141,6 +141,30 @@ func TestUploadSourceFileAcceptsAlreadyQueuedResponse(t *testing.T) {
 	}
 }
 
+func TestUploadSourceFileReportsRedirectWithoutProcessBody(t *testing.T) {
+	client, mux, teardown := newLokaliseUploadClientForTest(t)
+	defer teardown()
+
+	sourcePath := filepath.Join(t.TempDir(), "en.json")
+	if err := os.WriteFile(sourcePath, []byte(`{"hello":"Hello"}`), 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+
+	mux.HandleFunc("/api2/projects/project-1/files/upload", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", "/api2/projects/project-1/processes/proc-queued")
+		w.WriteHeader(http.StatusFound)
+	})
+
+	_, err := client.UploadSourceFile(context.Background(), SourceUploadInput{
+		ProjectID:    "project-1",
+		SourceLocale: "en",
+		FilePath:     sourcePath,
+	})
+	if err == nil || !strings.Contains(err.Error(), "302") || !strings.Contains(err.Error(), "location=/api2/projects/project-1/processes/proc-queued") {
+		t.Fatalf("error = %v, want 302 redirect location", err)
+	}
+}
+
 func TestUploadSourceFileReturnsAPIError(t *testing.T) {
 	client, mux, teardown := newLokaliseUploadClientForTest(t)
 	defer teardown()


### PR DESCRIPTION
﻿## What changed

Adds `lokalise upload sources` so users can upload one or more source files to Lokalise from the CLI using project/source inputs, optional config/env auth, tags, branch, format, and Lokalise upload options.

The implementation posts the documented Lokalise file upload payload (`data`, `filename`, `lang_iso`, `format`, and supported options), reports the queued import process, and handles documented `202` and future `302` queued responses.

## How to test

- `go test -count=1 ./internal/i18n/storage/lokalise ./apps/cli/cmd -run "TestLokalise|UploadSource"`
- `go build -ldflags "-X main.version=dev" -o $env:TEMP\hyperlocalise-hl247-check.exe ./apps/cli`
- `C:\Users\nguye\go\bin\golangci-lint.exe run ./internal/i18n/storage/lokalise ./apps/cli/cmd`
- `git diff --check`

Note: broader `go test -count=1 ./apps/cli/cmd` still fails on existing Windows-sensitive unrelated tests.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test` equivalent focused checks)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
