### PR TITLE
feat(cli): add Lokalise source download

### DIFF
--- a/apps/cli/cmd/lokalise.go
+++ b/apps/cli/cmd/lokalise.go
@@ -169,7 +169,7 @@ func resolveLokaliseDownloadSourcesConfig(cmd *cobra.Command, o lokaliseDownload
 		if !flagChanged(cmd, "source-locale") && cfg.SourceLanguage == "" {
 			cfg.SourceLanguage = loaded.SourceLanguage
 		}
-		cfg.APIToken = loaded.APIToken
+		// Config.APIToken is json:"-"; ResolveConfig fills it from the environment when auth is required.
 	}
 
 	format := strings.TrimSpace(o.format)
@@ -338,16 +338,16 @@ func resolveLokaliseGlossaryConfig(o lokaliseGlossaryDownloadOptions) (lokalise.
 		return lokalise.Config{}, fmt.Errorf("lokalise glossary download: --project-id is required unless --config points to a Lokalise storage config")
 	}
 	if cfg.APITokenEnv == "" {
-		cfg.APITokenEnv = "LOKALISE_API_TOKEN"
+		cfg.APITokenEnv = lokalise.DefaultTokenEnvName
 	}
 	if strings.TrimSpace(cfg.APIToken) == "" {
 		token := strings.TrimSpace(os.Getenv(cfg.APITokenEnv))
-		if token == "" && cfg.APITokenEnv != "LOKALISE_API_TOKEN" {
-			token = strings.TrimSpace(os.Getenv("LOKALISE_API_TOKEN"))
+		if token == "" && cfg.APITokenEnv != lokalise.DefaultTokenEnvName {
+			token = strings.TrimSpace(os.Getenv(lokalise.DefaultTokenEnvName))
 		}
 		if token == "" {
-			if cfg.APITokenEnv != "LOKALISE_API_TOKEN" {
-				return lokalise.Config{}, fmt.Errorf("lokalise glossary download: API token is required (%s or LOKALISE_API_TOKEN)", cfg.APITokenEnv)
+			if cfg.APITokenEnv != lokalise.DefaultTokenEnvName {
+				return lokalise.Config{}, fmt.Errorf("lokalise glossary download: API token is required (%s or %s)", cfg.APITokenEnv, lokalise.DefaultTokenEnvName)
 			}
 			return lokalise.Config{}, fmt.Errorf("lokalise glossary download: API token is required (%s)", cfg.APITokenEnv)
 		}
@@ -395,7 +395,7 @@ func decodeLokaliseStorageConfig(raw json.RawMessage) (lokalise.Config, error) {
 		return lokalise.Config{}, fmt.Errorf("lokalise config: decode: %w", err)
 	}
 	if _, exists := rawMap["apiToken"]; exists {
-		return lokalise.Config{}, fmt.Errorf("lokalise config: apiToken is not supported; use LOKALISE_API_TOKEN")
+		return lokalise.Config{}, fmt.Errorf("lokalise config: apiToken is not supported; use %s", lokalise.DefaultTokenEnvName)
 	}
 
 	var cfg lokalise.Config
@@ -411,12 +411,6 @@ func flagChanged(cmd *cobra.Command, name string) bool {
 }
 
 func writeLokaliseDownloadedSource(path string, content []byte, force bool) error {
-	if err := validateLokaliseDownloadSourcesOutputPath(path, force); err != nil {
-		return err
-	}
-	if path == "" || path == "-" {
-		return fmt.Errorf("lokalise download sources: output file path is required")
-	}
 	if dir := filepath.Dir(path); dir != "." {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			return fmt.Errorf("lokalise download sources: mkdir output directory: %w", err)

--- a/apps/cli/cmd/lokalise.go
+++ b/apps/cli/cmd/lokalise.go
@@ -467,7 +467,7 @@ func validateLokaliseDownloadSourcesOutputPath(path string, force bool) error {
 		if !force {
 			return fmt.Errorf("lokalise download sources: output file %q already exists; use --force to overwrite", path)
 		}
-	} else if err != nil && !os.IsNotExist(err) {
+	} else if !os.IsNotExist(err) {
 		return fmt.Errorf("lokalise download sources: stat output file %q: %w", path, err)
 	}
 	return nil

--- a/apps/cli/cmd/lokalise.go
+++ b/apps/cli/cmd/lokalise.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -213,7 +212,7 @@ func loadLokaliseDownloadSourcesStorageConfig(configPath string) (lokalise.Confi
 	if !strings.EqualFold(strings.TrimSpace(cfg.Storage.Adapter), lokalise.AdapterName) {
 		return lokalise.Config{}, fmt.Errorf("lokalise download sources: storage.adapter must be %q", lokalise.AdapterName)
 	}
-	parsed, err := decodeLokaliseStorageConfig(cfg.Storage.Config)
+	parsed, err := lokalise.DecodeConfig(cfg.Storage.Config)
 	if err != nil {
 		return lokalise.Config{}, fmt.Errorf("lokalise download sources: %w", err)
 	}
@@ -387,25 +386,6 @@ func loadLokaliseStorageConfig(configPath string) (lokalise.Config, error) {
 		return lokalise.Config{}, fmt.Errorf("lokalise glossary download: %w", err)
 	}
 	return parsed, nil
-}
-
-func decodeLokaliseStorageConfig(raw json.RawMessage) (lokalise.Config, error) {
-	if len(raw) == 0 {
-		return lokalise.Config{}, nil
-	}
-	var rawMap map[string]json.RawMessage
-	if err := json.Unmarshal(raw, &rawMap); err != nil {
-		return lokalise.Config{}, fmt.Errorf("lokalise config: decode: %w", err)
-	}
-	if _, exists := rawMap["apiToken"]; exists {
-		return lokalise.Config{}, fmt.Errorf("lokalise config: apiToken is not supported; use %s", lokalise.DefaultTokenEnvName)
-	}
-
-	var cfg lokalise.Config
-	if err := json.Unmarshal(raw, &cfg); err != nil {
-		return lokalise.Config{}, fmt.Errorf("lokalise config: decode: %w", err)
-	}
-	return cfg, nil
 }
 
 func flagChanged(cmd *cobra.Command, name string) bool {

--- a/apps/cli/cmd/lokalise.go
+++ b/apps/cli/cmd/lokalise.go
@@ -39,6 +39,7 @@ type lokaliseDownloadSourcesOptions struct {
 	tokenEnv       string
 	apiBaseURL     string
 	timeoutSeconds int
+	allPlatforms   bool
 	force          bool
 	dryRun         bool
 }
@@ -96,6 +97,7 @@ func newLokaliseDownloadSourcesCmd() *cobra.Command {
 	cmd.Flags().StringVar(&o.tokenEnv, "token-env", "", "environment variable containing the Lokalise API token")
 	cmd.Flags().StringVar(&o.apiBaseURL, "api-base-url", "", "Lokalise API base URL")
 	cmd.Flags().IntVar(&o.timeoutSeconds, "timeout-seconds", 0, "HTTP timeout in seconds")
+	cmd.Flags().BoolVar(&o.allPlatforms, "all-platforms", false, "include all Lokalise platforms in the export")
 	cmd.Flags().BoolVar(&o.force, "force", false, "overwrite an existing output file")
 	cmd.Flags().BoolVar(&o.dryRun, "dry-run", false, "preview command without downloading content")
 	return cmd
@@ -195,6 +197,7 @@ func resolveLokaliseDownloadSourcesConfig(cmd *cobra.Command, o lokaliseDownload
 		ProjectID:    strings.TrimSpace(cfg.ProjectID),
 		SourceLocale: strings.TrimSpace(cfg.SourceLanguage),
 		FileFormat:   format,
+		AllPlatforms: o.allPlatforms,
 	}
 	return cfg, input, nil
 }

--- a/apps/cli/cmd/lokalise.go
+++ b/apps/cli/cmd/lokalise.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -29,11 +30,32 @@ type lokaliseGlossaryDownloadOptions struct {
 	timeoutSeconds int
 }
 
+type lokaliseDownloadSourcesOptions struct {
+	configPath     string
+	projectID      string
+	sourceLocale   string
+	format         string
+	output         string
+	tokenEnv       string
+	apiBaseURL     string
+	timeoutSeconds int
+	force          bool
+	dryRun         bool
+}
+
 type lokaliseGlossaryCSVWriter interface {
 	WriteGlossaryCSV(context.Context, lokalise.GlossaryDownloadInput, io.Writer) (lokalise.GlossaryDownloadResult, error)
 }
 
+type lokaliseSourceDownloader interface {
+	DownloadSourceFile(context.Context, lokalise.SourceDownloadInput) (lokalise.SourceDownloadResult, error)
+}
+
 var newLokaliseGlossaryCSVWriter = func(cfg lokalise.Config) (lokaliseGlossaryCSVWriter, error) {
+	return lokalise.NewHTTPClient(cfg)
+}
+
+var newLokaliseSourceDownloader = func(cfg lokalise.Config) (lokaliseSourceDownloader, error) {
 	return lokalise.NewHTTPClient(cfg)
 }
 
@@ -42,8 +64,157 @@ func newLokaliseCmd() *cobra.Command {
 		Use:   "lokalise",
 		Short: "Lokalise workflow commands",
 	}
+	cmd.AddCommand(newLokaliseDownloadCmd())
 	cmd.AddCommand(newLokaliseGlossaryCmd())
 	return cmd
+}
+
+func newLokaliseDownloadCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "download",
+		Short: "download files from Lokalise",
+	}
+	cmd.AddCommand(newLokaliseDownloadSourcesCmd())
+	return cmd
+}
+
+func newLokaliseDownloadSourcesCmd() *cobra.Command {
+	o := lokaliseDownloadSourcesOptions{}
+	cmd := &cobra.Command{
+		Use:          "sources",
+		Short:        "download source files from Lokalise",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return executeLokaliseDownloadSources(cmd, o)
+		},
+	}
+	cmd.Flags().StringVar(&o.configPath, "config", "", "path to i18n.yml with storage.adapter=lokalise")
+	cmd.Flags().StringVar(&o.projectID, "project-id", "", "Lokalise project ID; overrides storage.config.projectID")
+	cmd.Flags().StringVar(&o.sourceLocale, "source-locale", "", "Lokalise source language ISO to export")
+	cmd.Flags().StringVar(&o.format, "format", "", "Lokalise file format to export")
+	cmd.Flags().StringVarP(&o.output, "output", "o", "", "output bundle path; omit or use - for stdout")
+	cmd.Flags().StringVar(&o.tokenEnv, "token-env", "", "environment variable containing the Lokalise API token")
+	cmd.Flags().StringVar(&o.apiBaseURL, "api-base-url", "", "Lokalise API base URL")
+	cmd.Flags().IntVar(&o.timeoutSeconds, "timeout-seconds", 0, "HTTP timeout in seconds")
+	cmd.Flags().BoolVar(&o.force, "force", false, "overwrite an existing output file")
+	cmd.Flags().BoolVar(&o.dryRun, "dry-run", false, "preview command without downloading content")
+	return cmd
+}
+
+func executeLokaliseDownloadSources(cmd *cobra.Command, o lokaliseDownloadSourcesOptions) error {
+	cfg, input, err := resolveLokaliseDownloadSourcesConfig(cmd, o, !o.dryRun)
+	if err != nil {
+		return err
+	}
+
+	outputPath := strings.TrimSpace(o.output)
+	if o.dryRun {
+		destination := outputPath
+		if destination == "" {
+			destination = "-"
+		}
+		_, err := fmt.Fprintf(cmd.OutOrStdout(), "dry-run action=lokalise-download-sources project_id=%s source_locale=%s format=%s output=%s\n", input.ProjectID, input.SourceLocale, input.FileFormat, destination)
+		return err
+	}
+	if err := validateLokaliseDownloadSourcesOutputPath(outputPath, o.force); err != nil {
+		return err
+	}
+
+	client, err := newLokaliseSourceDownloader(cfg)
+	if err != nil {
+		return err
+	}
+	result, err := client.DownloadSourceFile(backgroundContext(), input)
+	if err != nil {
+		return fmt.Errorf("lokalise download sources: %w", err)
+	}
+
+	if outputPath == "" || outputPath == "-" {
+		_, err := cmd.OutOrStdout().Write(result.Content)
+		return err
+	}
+	if err := writeLokaliseDownloadedSource(outputPath, result.Content, o.force); err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "downloaded file=%s bytes=%d locale=%s format=%s\n", outputPath, len(result.Content), result.SourceLocale, result.Format)
+	return err
+}
+
+func resolveLokaliseDownloadSourcesConfig(cmd *cobra.Command, o lokaliseDownloadSourcesOptions, requireAuth bool) (lokalise.Config, lokalise.SourceDownloadInput, error) {
+	cfg := lokalise.Config{
+		ProjectID:      strings.TrimSpace(o.projectID),
+		APITokenEnv:    strings.TrimSpace(o.tokenEnv),
+		APIBaseURL:     strings.TrimSpace(o.apiBaseURL),
+		SourceLanguage: strings.TrimSpace(o.sourceLocale),
+		TimeoutSeconds: o.timeoutSeconds,
+	}
+
+	if strings.TrimSpace(o.configPath) != "" {
+		loaded, err := loadLokaliseDownloadSourcesStorageConfig(o.configPath)
+		if err != nil {
+			return lokalise.Config{}, lokalise.SourceDownloadInput{}, err
+		}
+		if !flagChanged(cmd, "project-id") && cfg.ProjectID == "" {
+			cfg.ProjectID = loaded.ProjectID
+		}
+		if !flagChanged(cmd, "token-env") && cfg.APITokenEnv == "" {
+			cfg.APITokenEnv = loaded.APITokenEnv
+		}
+		if !flagChanged(cmd, "api-base-url") && cfg.APIBaseURL == "" {
+			cfg.APIBaseURL = loaded.APIBaseURL
+		}
+		if !flagChanged(cmd, "timeout-seconds") && cfg.TimeoutSeconds <= 0 {
+			cfg.TimeoutSeconds = loaded.TimeoutSeconds
+		}
+		if !flagChanged(cmd, "source-locale") && cfg.SourceLanguage == "" {
+			cfg.SourceLanguage = loaded.SourceLanguage
+		}
+		cfg.APIToken = loaded.APIToken
+	}
+
+	format := strings.TrimSpace(o.format)
+	if strings.TrimSpace(cfg.ProjectID) == "" {
+		return lokalise.Config{}, lokalise.SourceDownloadInput{}, fmt.Errorf("lokalise download sources: --project-id is required (or projectID in --config)")
+	}
+	if strings.TrimSpace(cfg.SourceLanguage) == "" {
+		return lokalise.Config{}, lokalise.SourceDownloadInput{}, fmt.Errorf("lokalise download sources: --source-locale is required (or sourceLanguage in --config)")
+	}
+	if format == "" {
+		return lokalise.Config{}, lokalise.SourceDownloadInput{}, fmt.Errorf("lokalise download sources: --format is required")
+	}
+
+	if requireAuth {
+		resolved, err := lokalise.ResolveConfig(cfg)
+		if err != nil {
+			return lokalise.Config{}, lokalise.SourceDownloadInput{}, fmt.Errorf("lokalise download sources: %w", err)
+		}
+		cfg = resolved
+	}
+
+	input := lokalise.SourceDownloadInput{
+		ProjectID:    strings.TrimSpace(cfg.ProjectID),
+		SourceLocale: strings.TrimSpace(cfg.SourceLanguage),
+		FileFormat:   format,
+	}
+	return cfg, input, nil
+}
+
+func loadLokaliseDownloadSourcesStorageConfig(configPath string) (lokalise.Config, error) {
+	cfg, err := i18nconfig.Load(configPath)
+	if err != nil {
+		return lokalise.Config{}, fmt.Errorf("lokalise download sources: load config: %w", err)
+	}
+	if cfg.Storage == nil {
+		return lokalise.Config{}, fmt.Errorf("lokalise download sources: storage config is required")
+	}
+	if !strings.EqualFold(strings.TrimSpace(cfg.Storage.Adapter), lokalise.AdapterName) {
+		return lokalise.Config{}, fmt.Errorf("lokalise download sources: storage.adapter must be %q", lokalise.AdapterName)
+	}
+	parsed, err := decodeLokaliseStorageConfig(cfg.Storage.Config)
+	if err != nil {
+		return lokalise.Config{}, fmt.Errorf("lokalise download sources: %w", err)
+	}
+	return parsed, nil
 }
 
 func newLokaliseGlossaryCmd() *cobra.Command {
@@ -213,4 +384,114 @@ func loadLokaliseStorageConfig(configPath string) (lokalise.Config, error) {
 		return lokalise.Config{}, fmt.Errorf("lokalise glossary download: %w", err)
 	}
 	return parsed, nil
+}
+
+func decodeLokaliseStorageConfig(raw json.RawMessage) (lokalise.Config, error) {
+	if len(raw) == 0 {
+		return lokalise.Config{}, nil
+	}
+	var rawMap map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &rawMap); err != nil {
+		return lokalise.Config{}, fmt.Errorf("lokalise config: decode: %w", err)
+	}
+	if _, exists := rawMap["apiToken"]; exists {
+		return lokalise.Config{}, fmt.Errorf("lokalise config: apiToken is not supported; use LOKALISE_API_TOKEN")
+	}
+
+	var cfg lokalise.Config
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return lokalise.Config{}, fmt.Errorf("lokalise config: decode: %w", err)
+	}
+	return cfg, nil
+}
+
+func flagChanged(cmd *cobra.Command, name string) bool {
+	flag := cmd.Flags().Lookup(name)
+	return flag != nil && flag.Changed
+}
+
+func writeLokaliseDownloadedSource(path string, content []byte, force bool) error {
+	if err := validateLokaliseDownloadSourcesOutputPath(path, force); err != nil {
+		return err
+	}
+	if path == "" || path == "-" {
+		return fmt.Errorf("lokalise download sources: output file path is required")
+	}
+	if dir := filepath.Dir(path); dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("lokalise download sources: mkdir output directory: %w", err)
+		}
+	}
+	if force {
+		return writeLokaliseDownloadedFileAtomic("lokalise download sources", path, content, 0o644)
+	}
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		if os.IsExist(err) {
+			return fmt.Errorf("lokalise download sources: output file %q already exists; use --force to overwrite", path)
+		}
+		return fmt.Errorf("lokalise download sources: open output file %q: %w", path, err)
+	}
+	if _, err := file.Write(content); err != nil {
+		_ = file.Close()
+		_ = os.Remove(path)
+		return fmt.Errorf("lokalise download sources: write output file %q: %w", path, err)
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(path)
+		return fmt.Errorf("lokalise download sources: close output file %q: %w", path, err)
+	}
+	return nil
+}
+
+func writeLokaliseDownloadedFileAtomic(action, path string, content []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	file, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("%s: create temp output file %q: %w", action, path, err)
+	}
+	tempPath := file.Name()
+	renamed := false
+	defer func() {
+		if !renamed {
+			_ = os.Remove(tempPath)
+		}
+	}()
+	if _, err := file.Write(content); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("%s: write temp output file %q: %w", action, path, err)
+	}
+	if err := file.Chmod(perm); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("%s: chmod temp output file %q: %w", action, path, err)
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("%s: sync temp output file %q: %w", action, path, err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("%s: close temp output file %q: %w", action, path, err)
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		return fmt.Errorf("%s: replace output file %q: %w", action, path, err)
+	}
+	renamed = true
+	return nil
+}
+
+func validateLokaliseDownloadSourcesOutputPath(path string, force bool) error {
+	if path == "" || path == "-" {
+		return nil
+	}
+	if info, err := os.Stat(path); err == nil {
+		if info.IsDir() {
+			return fmt.Errorf("lokalise download sources: output file %q is a directory", path)
+		}
+		if !force {
+			return fmt.Errorf("lokalise download sources: output file %q already exists; use --force to overwrite", path)
+		}
+	} else if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("lokalise download sources: stat output file %q: %w", path, err)
+	}
+	return nil
 }

--- a/apps/cli/cmd/lokalise_test.go
+++ b/apps/cli/cmd/lokalise_test.go
@@ -194,6 +194,35 @@ func TestLokaliseDownloadSourcesWritesStdout(t *testing.T) {
 	if fake.in.ProjectID != "project-1" || fake.in.SourceLocale != "en" || fake.in.FileFormat != "json" {
 		t.Fatalf("unexpected input: %+v", fake.in)
 	}
+	if fake.in.AllPlatforms {
+		t.Fatalf("all platforms should be opt-in, got input: %+v", fake.in)
+	}
+}
+
+func TestLokaliseDownloadSourcesAllPlatformsFlag(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("LOKALISE_TEST_TOKEN", "secret")
+	fake := &fakeLokaliseSourceDownloader{
+		result: lokalise.SourceDownloadResult{SourceLocale: "en", Format: "json", Content: []byte("zip-bytes")},
+	}
+	oldFactory := newLokaliseSourceDownloader
+	newLokaliseSourceDownloader = func(lokalise.Config) (lokaliseSourceDownloader, error) {
+		return fake, nil
+	}
+	defer func() { newLokaliseSourceDownloader = oldFactory }()
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"lokalise", "download", "sources", "--project-id", "project-1", "--source-locale", "en", "--format", "json", "--all-platforms", "--token-env", "LOKALISE_TEST_TOKEN"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute lokalise download: %v", err)
+	}
+	if !fake.in.AllPlatforms {
+		t.Fatalf("expected all platforms input, got %+v", fake.in)
+	}
 }
 
 func TestLokaliseDownloadSourcesWritesOutputFile(t *testing.T) {

--- a/apps/cli/cmd/lokalise_test.go
+++ b/apps/cli/cmd/lokalise_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -139,6 +140,202 @@ func TestLokaliseGlossaryDownloadRequiresProjectIDOrConfig(t *testing.T) {
 	}
 }
 
+func TestLokaliseDownloadSourcesDryRun(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"lokalise", "download", "sources", "--project-id", "project-1", "--source-locale", "en", "--format", "json", "--output", "source.zip", "--dry-run"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute lokalise download dry-run: %v", err)
+	}
+	output := out.String()
+	if !strings.Contains(output, "dry-run action=lokalise-download-sources") ||
+		!strings.Contains(output, "project_id=project-1") ||
+		!strings.Contains(output, "source_locale=en") ||
+		!strings.Contains(output, "output=source.zip") {
+		t.Fatalf("unexpected output: %q", output)
+	}
+}
+
+func TestLokaliseDownloadSourcesWritesStdout(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("LOKALISE_TEST_TOKEN", "secret")
+	fake := &fakeLokaliseSourceDownloader{
+		result: lokalise.SourceDownloadResult{SourceLocale: "en", Format: "json", Content: []byte("zip-bytes")},
+	}
+	oldFactory := newLokaliseSourceDownloader
+	newLokaliseSourceDownloader = func(cfg lokalise.Config) (lokaliseSourceDownloader, error) {
+		if cfg.ProjectID != "project-1" || cfg.APIToken != "secret" {
+			t.Fatalf("unexpected config: %+v", cfg)
+		}
+		return fake, nil
+	}
+	defer func() { newLokaliseSourceDownloader = oldFactory }()
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"lokalise", "download", "sources", "--project-id", "project-1", "--source-locale", "en", "--format", "json", "--token-env", "LOKALISE_TEST_TOKEN"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute lokalise download: %v", err)
+	}
+	if got := out.String(); got != "zip-bytes" {
+		t.Fatalf("unexpected stdout content: %q", got)
+	}
+	if !fake.called {
+		t.Fatalf("expected downloader to be called")
+	}
+	if fake.in.ProjectID != "project-1" || fake.in.SourceLocale != "en" || fake.in.FileFormat != "json" {
+		t.Fatalf("unexpected input: %+v", fake.in)
+	}
+}
+
+func TestLokaliseDownloadSourcesWritesOutputFile(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("LOKALISE_TEST_TOKEN", "secret")
+	fake := &fakeLokaliseSourceDownloader{
+		result: lokalise.SourceDownloadResult{SourceLocale: "en", Format: "json", Content: []byte("zip-bytes")},
+	}
+	oldFactory := newLokaliseSourceDownloader
+	newLokaliseSourceDownloader = func(lokalise.Config) (lokaliseSourceDownloader, error) {
+		return fake, nil
+	}
+	defer func() { newLokaliseSourceDownloader = oldFactory }()
+
+	outputPath := filepath.Join(t.TempDir(), "downloads", "source.zip")
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"lokalise", "download", "sources", "--project-id", "project-1", "--source-locale", "en", "--format", "json", "--output", outputPath, "--token-env", "LOKALISE_TEST_TOKEN"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute lokalise download: %v", err)
+	}
+	content, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read output file: %v", err)
+	}
+	if string(content) != "zip-bytes" {
+		t.Fatalf("unexpected file content: %q", string(content))
+	}
+	if !strings.Contains(out.String(), "downloaded file="+outputPath) || !strings.Contains(out.String(), "bytes=9") {
+		t.Fatalf("unexpected output: %q", out.String())
+	}
+}
+
+func TestLokaliseDownloadSourcesRefusesOverwriteWithoutForce(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("LOKALISE_TEST_TOKEN", "secret")
+	outputPath := filepath.Join(t.TempDir(), "source.zip")
+	if err := os.WriteFile(outputPath, []byte("old"), 0o644); err != nil {
+		t.Fatalf("write existing output: %v", err)
+	}
+
+	fake := &fakeLokaliseSourceDownloader{}
+	oldFactory := newLokaliseSourceDownloader
+	newLokaliseSourceDownloader = func(lokalise.Config) (lokaliseSourceDownloader, error) {
+		return fake, nil
+	}
+	defer func() { newLokaliseSourceDownloader = oldFactory }()
+
+	cmd := newRootCmd("")
+	cmd.SetArgs([]string{"lokalise", "download", "sources", "--project-id", "project-1", "--source-locale", "en", "--format", "json", "--output", outputPath, "--token-env", "LOKALISE_TEST_TOKEN"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected overwrite error")
+	}
+	if !strings.Contains(err.Error(), "already exists; use --force to overwrite") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fake.called {
+		t.Fatalf("downloader should not be called when output already exists")
+	}
+}
+
+func TestLokaliseDownloadSourcesForceOverwritesOutputFile(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("LOKALISE_TEST_TOKEN", "secret")
+	fake := &fakeLokaliseSourceDownloader{
+		result: lokalise.SourceDownloadResult{SourceLocale: "en", Format: "json", Content: []byte("new")},
+	}
+	oldFactory := newLokaliseSourceDownloader
+	newLokaliseSourceDownloader = func(lokalise.Config) (lokaliseSourceDownloader, error) {
+		return fake, nil
+	}
+	defer func() { newLokaliseSourceDownloader = oldFactory }()
+
+	outputPath := filepath.Join(t.TempDir(), "source.zip")
+	if err := os.WriteFile(outputPath, []byte("old"), 0o644); err != nil {
+		t.Fatalf("write existing output: %v", err)
+	}
+	cmd := newRootCmd("")
+	cmd.SetArgs([]string{"lokalise", "download", "sources", "--project-id", "project-1", "--source-locale", "en", "--format", "json", "--output", outputPath, "--force", "--token-env", "LOKALISE_TEST_TOKEN"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute lokalise download with force: %v", err)
+	}
+	content, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read output file: %v", err)
+	}
+	if string(content) != "new" {
+		t.Fatalf("unexpected file content: %q", string(content))
+	}
+}
+
+func TestLokaliseDownloadSourcesUsesConfig(t *testing.T) {
+	t.Setenv("LOKALISE_CONFIG_TOKEN", "cfg-secret")
+	configPath := writeLokaliseDownloadConfig(t)
+	outputPath := filepath.Join(t.TempDir(), "source.zip")
+
+	fake := &fakeLokaliseSourceDownloader{
+		result: lokalise.SourceDownloadResult{SourceLocale: "en-US", Format: "json", Content: []byte("zip-bytes")},
+	}
+	oldFactory := newLokaliseSourceDownloader
+	newLokaliseSourceDownloader = func(cfg lokalise.Config) (lokaliseSourceDownloader, error) {
+		if cfg.ProjectID != "cfg-project" || cfg.SourceLanguage != "en-US" || cfg.APIToken != "cfg-secret" || cfg.APIBaseURL != "https://example.invalid/api2" || cfg.TimeoutSeconds != 7 {
+			t.Fatalf("unexpected config: %+v", cfg)
+		}
+		return fake, nil
+	}
+	defer func() { newLokaliseSourceDownloader = oldFactory }()
+
+	cmd := newRootCmd("")
+	cmd.SetArgs([]string{"lokalise", "download", "sources", "--config", configPath, "--format", "json", "--output", outputPath})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute lokalise download from config: %v", err)
+	}
+	if fake.in.ProjectID != "cfg-project" || fake.in.SourceLocale != "en-US" {
+		t.Fatalf("unexpected input: %+v", fake.in)
+	}
+}
+
+func TestLokaliseDownloadSourcesTokenErrorListsFallback(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("LOKALISE_CUSTOM_TOKEN", "")
+	t.Setenv("LOKALISE_API_TOKEN", "")
+
+	cmd := newRootCmd("")
+	cmd.SetArgs([]string{"lokalise", "download", "sources", "--project-id", "project-1", "--source-locale", "en", "--format", "json", "--token-env", "LOKALISE_CUSTOM_TOKEN"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected missing token error")
+	}
+	if !strings.Contains(err.Error(), "LOKALISE_CUSTOM_TOKEN or LOKALISE_API_TOKEN") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 type fakeLokaliseGlossaryCSVWriter struct {
 	req lokalise.GlossaryDownloadInput
 	err error
@@ -153,4 +350,75 @@ func (f *fakeLokaliseGlossaryCSVWriter) WriteGlossaryCSV(_ context.Context, req 
 		return lokalise.GlossaryDownloadResult{}, err
 	}
 	return lokalise.GlossaryDownloadResult{Terms: 1, Rows: 1}, nil
+}
+
+type fakeLokaliseSourceDownloader struct {
+	result lokalise.SourceDownloadResult
+	err    error
+	in     lokalise.SourceDownloadInput
+	called bool
+}
+
+func (f *fakeLokaliseSourceDownloader) DownloadSourceFile(_ context.Context, in lokalise.SourceDownloadInput) (lokalise.SourceDownloadResult, error) {
+	f.called = true
+	f.in = in
+	if f.err != nil {
+		return lokalise.SourceDownloadResult{}, f.err
+	}
+	return f.result, nil
+}
+
+func writeLokaliseDownloadConfig(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	sourceDir := filepath.Join(dir, "lang")
+	if err := os.MkdirAll(sourceDir, 0o755); err != nil {
+		t.Fatalf("mkdir source dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceDir, "en-US.json"), []byte(`{"hello":"Hello"}`), 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+	content := fmt.Sprintf(`{
+  "locales": {
+    "source": "en-US",
+    "targets": ["fr-FR"]
+  },
+  "buckets": {
+    "json": {
+      "files": [
+        {"from": %q, "to": %q}
+      ]
+    }
+  },
+  "groups": {
+    "default": {
+      "targets": ["fr-FR"],
+      "buckets": ["json"]
+    }
+  },
+  "llm": {
+    "profiles": {
+      "default": {
+        "provider": "openai",
+        "model": "gpt-4.1-mini",
+        "prompt": "Translate."
+      }
+    }
+  },
+  "storage": {
+    "adapter": "lokalise",
+    "config": {
+      "projectID": "cfg-project",
+      "apiTokenEnv": "LOKALISE_CONFIG_TOKEN",
+      "apiBaseURL": "https://example.invalid/api2",
+      "sourceLanguage": "en-US",
+      "timeoutSeconds": 7
+    }
+  }
+}`, "lang/en-US.json", "lang/fr-FR.json")
+	path := filepath.Join(dir, "i18n.jsonc")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
 }

--- a/internal/i18n/storage/lokalise/adapter.go
+++ b/internal/i18n/storage/lokalise/adapter.go
@@ -15,7 +15,6 @@ const (
 	AdapterName = "lokalise"
 	// DefaultTokenEnvName is the fallback environment variable for Lokalise API tokens.
 	DefaultTokenEnvName = "LOKALISE_API_TOKEN"
-	defaultTokenEnvName = DefaultTokenEnvName
 )
 
 type Config struct {
@@ -105,7 +104,7 @@ func DecodeConfig(raw json.RawMessage) (Config, error) {
 		return cfg, fmt.Errorf("lokalise config: decode: %w", err)
 	}
 	if _, exists := rawMap["apiToken"]; exists {
-		return cfg, fmt.Errorf("lokalise config: apiToken is not supported; use %s", defaultTokenEnvName)
+		return cfg, fmt.Errorf("lokalise config: apiToken is not supported; use %s", DefaultTokenEnvName)
 	}
 	if err := json.Unmarshal(raw, &cfg); err != nil {
 		return cfg, fmt.Errorf("lokalise config: decode: %w", err)
@@ -116,12 +115,12 @@ func DecodeConfig(raw json.RawMessage) (Config, error) {
 // ResolveConfig applies Lokalise defaults and resolves token-based auth.
 func ResolveConfig(cfg Config) (Config, error) {
 	if strings.TrimSpace(cfg.APITokenEnv) == "" {
-		cfg.APITokenEnv = defaultTokenEnvName
+		cfg.APITokenEnv = DefaultTokenEnvName
 	}
 	if strings.TrimSpace(cfg.APIToken) == "" {
 		cfg.APIToken = os.Getenv(cfg.APITokenEnv)
-		if strings.TrimSpace(cfg.APIToken) == "" && cfg.APITokenEnv != defaultTokenEnvName {
-			cfg.APIToken = os.Getenv(defaultTokenEnvName)
+		if strings.TrimSpace(cfg.APIToken) == "" && cfg.APITokenEnv != DefaultTokenEnvName {
+			cfg.APIToken = os.Getenv(DefaultTokenEnvName)
 		}
 	}
 	if cfg.TimeoutSeconds <= 0 {
@@ -141,12 +140,12 @@ func validateConfig(cfg Config) error {
 	if strings.TrimSpace(cfg.APIToken) == "" {
 		tokenEnv := strings.TrimSpace(cfg.APITokenEnv)
 		if tokenEnv == "" {
-			tokenEnv = defaultTokenEnvName
+			tokenEnv = DefaultTokenEnvName
 		}
-		if tokenEnv != defaultTokenEnvName {
-			return fmt.Errorf("lokalise config: API token is required (%s or %s)", tokenEnv, defaultTokenEnvName)
+		if tokenEnv != DefaultTokenEnvName {
+			return fmt.Errorf("lokalise config: API token is required (%s or %s)", tokenEnv, DefaultTokenEnvName)
 		}
-		return fmt.Errorf("lokalise config: API token is required (%s)", defaultTokenEnvName)
+		return fmt.Errorf("lokalise config: API token is required (%s)", DefaultTokenEnvName)
 	}
 	return nil
 }

--- a/internal/i18n/storage/lokalise/adapter.go
+++ b/internal/i18n/storage/lokalise/adapter.go
@@ -12,8 +12,10 @@ import (
 )
 
 const (
-	AdapterName         = "lokalise"
-	defaultTokenEnvName = "LOKALISE_API_TOKEN"
+	AdapterName = "lokalise"
+	// DefaultTokenEnvName is the fallback environment variable for Lokalise API tokens.
+	DefaultTokenEnvName = "LOKALISE_API_TOKEN"
+	defaultTokenEnvName = DefaultTokenEnvName
 )
 
 type Config struct {

--- a/internal/i18n/storage/lokalise/adapter.go
+++ b/internal/i18n/storage/lokalise/adapter.go
@@ -86,6 +86,20 @@ func ParseConfig(raw json.RawMessage) (Config, error) {
 	if len(raw) == 0 {
 		return cfg, fmt.Errorf("lokalise config: must not be empty")
 	}
+	cfg, err := DecodeConfig(raw)
+	if err != nil {
+		return cfg, err
+	}
+
+	return ResolveConfig(cfg)
+}
+
+// DecodeConfig decodes Lokalise storage config without resolving environment auth.
+func DecodeConfig(raw json.RawMessage) (Config, error) {
+	var cfg Config
+	if len(raw) == 0 {
+		return cfg, nil
+	}
 	var rawMap map[string]json.RawMessage
 	if err := json.Unmarshal(raw, &rawMap); err != nil {
 		return cfg, fmt.Errorf("lokalise config: decode: %w", err)
@@ -96,8 +110,7 @@ func ParseConfig(raw json.RawMessage) (Config, error) {
 	if err := json.Unmarshal(raw, &cfg); err != nil {
 		return cfg, fmt.Errorf("lokalise config: decode: %w", err)
 	}
-
-	return ResolveConfig(cfg)
+	return cfg, nil
 }
 
 // ResolveConfig applies Lokalise defaults and resolves token-based auth.

--- a/internal/i18n/storage/lokalise/adapter.go
+++ b/internal/i18n/storage/lokalise/adapter.go
@@ -95,6 +95,11 @@ func ParseConfig(raw json.RawMessage) (Config, error) {
 		return cfg, fmt.Errorf("lokalise config: decode: %w", err)
 	}
 
+	return ResolveConfig(cfg)
+}
+
+// ResolveConfig applies Lokalise defaults and resolves token-based auth.
+func ResolveConfig(cfg Config) (Config, error) {
 	if strings.TrimSpace(cfg.APITokenEnv) == "" {
 		cfg.APITokenEnv = defaultTokenEnvName
 	}
@@ -119,6 +124,13 @@ func validateConfig(cfg Config) error {
 		return fmt.Errorf("lokalise config: projectID is required")
 	}
 	if strings.TrimSpace(cfg.APIToken) == "" {
+		tokenEnv := strings.TrimSpace(cfg.APITokenEnv)
+		if tokenEnv == "" {
+			tokenEnv = defaultTokenEnvName
+		}
+		if tokenEnv != defaultTokenEnvName {
+			return fmt.Errorf("lokalise config: API token is required (%s or %s)", tokenEnv, defaultTokenEnvName)
+		}
 		return fmt.Errorf("lokalise config: API token is required (%s)", defaultTokenEnvName)
 	}
 	return nil

--- a/internal/i18n/storage/lokalise/adapter_test.go
+++ b/internal/i18n/storage/lokalise/adapter_test.go
@@ -58,6 +58,24 @@ func TestParseConfigRejectsInlineToken(t *testing.T) {
 	}
 }
 
+func TestDecodeConfigRejectsInlineToken(t *testing.T) {
+	_, err := DecodeConfig(json.RawMessage(`{"projectID":"123","apiToken":"inline"}`))
+	if err == nil || !strings.Contains(err.Error(), "apiToken is not supported") {
+		t.Fatalf("expected inline token rejection, got %v", err)
+	}
+}
+
+func TestDecodeConfigDoesNotResolveToken(t *testing.T) {
+	t.Setenv("LOKALISE_API_TOKEN", "env-token")
+	cfg, err := DecodeConfig(json.RawMessage(`{"projectID":"123"}`))
+	if err != nil {
+		t.Fatalf("decode config: %v", err)
+	}
+	if cfg.APIToken != "" {
+		t.Fatalf("DecodeConfig should not resolve auth token, got %q", cfg.APIToken)
+	}
+}
+
 func TestAdapterPullMapsKeyContextLanguage(t *testing.T) {
 	client := &fakeClient{
 		keys: []KeyTranslation{

--- a/internal/i18n/storage/lokalise/http_client.go
+++ b/internal/i18n/storage/lokalise/http_client.go
@@ -19,7 +19,7 @@ type HTTPClient struct {
 	api *lokaliseapi.Api
 	// apiToken is the single auth source for raw Lokalise API calls.
 	apiToken string
-	// baseURL and httpClient are kept for glossary endpoints that are called directly.
+	// baseURL and httpClient are kept for endpoints and bundles called directly.
 	baseURL    string
 	httpClient *http.Client
 }

--- a/internal/i18n/storage/lokalise/source_download.go
+++ b/internal/i18n/storage/lokalise/source_download.go
@@ -10,6 +10,8 @@ import (
 	lokaliseapi "github.com/lokalise/go-lokalise-api/v5"
 )
 
+const maxSourceDownloadBundleBytes int64 = 512 * 1024 * 1024
+
 // SourceDownloadInput describes one Lokalise source-locale file export.
 type SourceDownloadInput struct {
 	ProjectID    string
@@ -96,7 +98,7 @@ func (c *HTTPClient) downloadBundle(ctx context.Context, bundleURL string) ([]by
 		_ = resp.Body.Close()
 	}()
 
-	content, readErr := io.ReadAll(resp.Body)
+	content, readErr := readLimitedBundleBody(resp.Body, maxSourceDownloadBundleBytes)
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		if readErr != nil {
 			return nil, fmt.Errorf("GET %s: status %d and read error: %w", bundleURL, resp.StatusCode, readErr)
@@ -112,6 +114,17 @@ func (c *HTTPClient) downloadBundle(ctx context.Context, bundleURL string) ([]by
 	}
 	if len(content) == 0 {
 		return nil, fmt.Errorf("empty bundle response")
+	}
+	return content, nil
+}
+
+func readLimitedBundleBody(body io.Reader, maxBytes int64) ([]byte, error) {
+	content, err := io.ReadAll(io.LimitReader(body, maxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(content)) > maxBytes {
+		return nil, fmt.Errorf("response exceeds %d byte limit", maxBytes)
 	}
 	return content, nil
 }

--- a/internal/i18n/storage/lokalise/source_download.go
+++ b/internal/i18n/storage/lokalise/source_download.go
@@ -2,9 +2,11 @@ package lokalise
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 
 	lokaliseapi "github.com/lokalise/go-lokalise-api/v5"
@@ -92,12 +94,12 @@ func (c *HTTPClient) downloadBundle(ctx context.Context, bundleURL string) ([]by
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, bundleURL, nil)
 	if err != nil {
-		return nil, fmt.Errorf("build bundle request: %w", err)
+		return nil, fmt.Errorf("build bundle request for bundle URL: invalid URL")
 	}
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("GET %s: %w", bundleURL, err)
+		return nil, fmt.Errorf("GET bundle URL: %s", bundleRequestErrorMessage(err))
 	}
 	defer func() {
 		_ = resp.Body.Close()
@@ -111,13 +113,13 @@ func (c *HTTPClient) downloadBundle(ctx context.Context, bundleURL string) ([]by
 	content, readErr := readLimitedBundleBody(resp.Body, readLimit)
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		if readErr != nil {
-			return nil, fmt.Errorf("GET %s: status %d and read error: %w", bundleURL, resp.StatusCode, readErr)
+			return nil, fmt.Errorf("GET bundle URL: status %d and read error: %w", resp.StatusCode, readErr)
 		}
 		detail := strings.TrimSpace(string(content))
 		if detail == "" {
-			return nil, fmt.Errorf("GET %s: status %d", bundleURL, resp.StatusCode)
+			return nil, fmt.Errorf("GET bundle URL: status %d", resp.StatusCode)
 		}
-		return nil, fmt.Errorf("GET %s: status %d: %s", bundleURL, resp.StatusCode, detail)
+		return nil, fmt.Errorf("GET bundle URL: status %d: %s", resp.StatusCode, detail)
 	}
 	if readErr != nil {
 		return nil, fmt.Errorf("read bundle response: %w", readErr)
@@ -126,6 +128,20 @@ func (c *HTTPClient) downloadBundle(ctx context.Context, bundleURL string) ([]by
 		return nil, fmt.Errorf("empty bundle response")
 	}
 	return content, nil
+}
+
+func bundleRequestErrorMessage(err error) string {
+	if err == nil {
+		return "request failed"
+	}
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		if urlErr.Err != nil {
+			return urlErr.Err.Error()
+		}
+		return "request failed"
+	}
+	return "request failed"
 }
 
 func readLimitedBundleBody(body io.Reader, maxBytes int64) ([]byte, error) {

--- a/internal/i18n/storage/lokalise/source_download.go
+++ b/internal/i18n/storage/lokalise/source_download.go
@@ -141,7 +141,7 @@ func bundleRequestErrorMessage(err error) string {
 		}
 		return "request failed"
 	}
-	return "request failed"
+	return err.Error()
 }
 
 func readLimitedBundleBody(body io.Reader, maxBytes int64) ([]byte, error) {

--- a/internal/i18n/storage/lokalise/source_download.go
+++ b/internal/i18n/storage/lokalise/source_download.go
@@ -30,8 +30,10 @@ type SourceDownloadResult struct {
 	ProjectID    string
 	SourceLocale string
 	Format       string
-	BundleURL    string
-	Content      []byte
+	// BundleURL holds the pre-signed download URL returned by Lokalise.
+	// It may contain credential query parameters; do not log or serialize this field.
+	BundleURL string
+	Content   []byte
 }
 
 // DownloadSourceFile exports source-locale files from Lokalise and downloads the generated bundle.

--- a/internal/i18n/storage/lokalise/source_download.go
+++ b/internal/i18n/storage/lokalise/source_download.go
@@ -10,7 +10,10 @@ import (
 	lokaliseapi "github.com/lokalise/go-lokalise-api/v5"
 )
 
-const maxSourceDownloadBundleBytes int64 = 512 * 1024 * 1024
+const (
+	maxSourceDownloadBundleBytes    int64 = 512 * 1024 * 1024
+	maxSourceDownloadErrorBodyBytes int64 = 64 * 1024
+)
 
 // SourceDownloadInput describes one Lokalise source-locale file export.
 type SourceDownloadInput struct {
@@ -100,7 +103,12 @@ func (c *HTTPClient) downloadBundle(ctx context.Context, bundleURL string) ([]by
 		_ = resp.Body.Close()
 	}()
 
-	content, readErr := readLimitedBundleBody(resp.Body, maxSourceDownloadBundleBytes)
+	readLimit := maxSourceDownloadBundleBytes
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		readLimit = maxSourceDownloadErrorBodyBytes
+	}
+
+	content, readErr := readLimitedBundleBody(resp.Body, readLimit)
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		if readErr != nil {
 			return nil, fmt.Errorf("GET %s: status %d and read error: %w", bundleURL, resp.StatusCode, readErr)

--- a/internal/i18n/storage/lokalise/source_download.go
+++ b/internal/i18n/storage/lokalise/source_download.go
@@ -17,6 +17,7 @@ type SourceDownloadInput struct {
 	ProjectID    string
 	SourceLocale string
 	FileFormat   string
+	AllPlatforms bool
 }
 
 // SourceDownloadResult is the normalized content returned by a Lokalise export.
@@ -50,12 +51,13 @@ func (c *HTTPClient) DownloadSourceFile(ctx context.Context, in SourceDownloadIn
 	}
 
 	originalFilenames := true
+	allPlatforms := in.AllPlatforms
 	filesSvc := c.api.Files()
 	filesSvc.SetContext(ctx)
 	resp, err := filesSvc.Download(projectID, lokaliseapi.FileDownload{
 		Format:            format,
 		OriginalFilenames: &originalFilenames,
-		AllPlatforms:      true,
+		AllPlatforms:      allPlatforms,
 		FilterLangs:       []string{sourceLocale},
 	})
 	if err != nil {

--- a/internal/i18n/storage/lokalise/source_download.go
+++ b/internal/i18n/storage/lokalise/source_download.go
@@ -30,10 +30,7 @@ type SourceDownloadResult struct {
 	ProjectID    string
 	SourceLocale string
 	Format       string
-	// BundleURL holds the pre-signed download URL returned by Lokalise.
-	// It may contain credential query parameters; do not log or serialize this field.
-	BundleURL string
-	Content   []byte
+	Content      []byte
 }
 
 // DownloadSourceFile exports source-locale files from Lokalise and downloads the generated bundle.
@@ -84,7 +81,6 @@ func (c *HTTPClient) DownloadSourceFile(ctx context.Context, in SourceDownloadIn
 		ProjectID:    projectID,
 		SourceLocale: sourceLocale,
 		Format:       format,
-		BundleURL:    bundleURL,
 		Content:      content,
 	}, nil
 }

--- a/internal/i18n/storage/lokalise/source_download.go
+++ b/internal/i18n/storage/lokalise/source_download.go
@@ -88,9 +88,12 @@ func (c *HTTPClient) DownloadSourceFile(ctx context.Context, in SourceDownloadIn
 }
 
 func (c *HTTPClient) downloadBundle(ctx context.Context, bundleURL string) ([]byte, error) {
+	if c == nil {
+		return nil, fmt.Errorf("lokalise source download: http client is not configured")
+	}
 	httpClient := c.httpClient
 	if httpClient == nil {
-		httpClient = http.DefaultClient
+		return nil, fmt.Errorf("lokalise source download: http client is not configured")
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, bundleURL, nil)
 	if err != nil {

--- a/internal/i18n/storage/lokalise/source_download.go
+++ b/internal/i18n/storage/lokalise/source_download.go
@@ -1,0 +1,117 @@
+package lokalise
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	lokaliseapi "github.com/lokalise/go-lokalise-api/v5"
+)
+
+// SourceDownloadInput describes one Lokalise source-locale file export.
+type SourceDownloadInput struct {
+	ProjectID    string
+	SourceLocale string
+	FileFormat   string
+}
+
+// SourceDownloadResult is the normalized content returned by a Lokalise export.
+type SourceDownloadResult struct {
+	ProjectID    string
+	SourceLocale string
+	Format       string
+	BundleURL    string
+	Content      []byte
+}
+
+// DownloadSourceFile exports source-locale files from Lokalise and downloads the generated bundle.
+func (c *HTTPClient) DownloadSourceFile(ctx context.Context, in SourceDownloadInput) (SourceDownloadResult, error) {
+	if c == nil || c.api == nil {
+		return SourceDownloadResult{}, fmt.Errorf("lokalise source download: client is nil")
+	}
+	projectID := strings.TrimSpace(in.ProjectID)
+	sourceLocale := strings.TrimSpace(in.SourceLocale)
+	format := strings.TrimSpace(in.FileFormat)
+	if projectID == "" {
+		return SourceDownloadResult{}, fmt.Errorf("lokalise source download: project id is required")
+	}
+	if strings.TrimSpace(c.apiToken) == "" {
+		return SourceDownloadResult{}, fmt.Errorf("lokalise source download: api token is required")
+	}
+	if sourceLocale == "" {
+		return SourceDownloadResult{}, fmt.Errorf("lokalise source download: source locale is required")
+	}
+	if format == "" {
+		return SourceDownloadResult{}, fmt.Errorf("lokalise source download: file format is required")
+	}
+
+	originalFilenames := true
+	filesSvc := c.api.Files()
+	filesSvc.SetContext(ctx)
+	resp, err := filesSvc.Download(projectID, lokaliseapi.FileDownload{
+		Format:            format,
+		OriginalFilenames: &originalFilenames,
+		AllPlatforms:      true,
+		FilterLangs:       []string{sourceLocale},
+	})
+	if err != nil {
+		return SourceDownloadResult{}, fmt.Errorf("request export bundle: %w", err)
+	}
+
+	bundleURL := strings.TrimSpace(resp.BundleURL)
+	if bundleURL == "" {
+		return SourceDownloadResult{}, fmt.Errorf("lokalise source download: empty bundle URL")
+	}
+
+	content, err := c.downloadBundle(ctx, bundleURL)
+	if err != nil {
+		return SourceDownloadResult{}, fmt.Errorf("download export bundle: %w", err)
+	}
+	return SourceDownloadResult{
+		ProjectID:    projectID,
+		SourceLocale: sourceLocale,
+		Format:       format,
+		BundleURL:    bundleURL,
+		Content:      content,
+	}, nil
+}
+
+func (c *HTTPClient) downloadBundle(ctx context.Context, bundleURL string) ([]byte, error) {
+	httpClient := c.httpClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, bundleURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build bundle request: %w", err)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GET %s: %w", bundleURL, err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	content, readErr := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		if readErr != nil {
+			return nil, fmt.Errorf("GET %s: status %d and read error: %w", bundleURL, resp.StatusCode, readErr)
+		}
+		detail := strings.TrimSpace(string(content))
+		if detail == "" {
+			return nil, fmt.Errorf("GET %s: status %d", bundleURL, resp.StatusCode)
+		}
+		return nil, fmt.Errorf("GET %s: status %d: %s", bundleURL, resp.StatusCode, detail)
+	}
+	if readErr != nil {
+		return nil, fmt.Errorf("read bundle response: %w", readErr)
+	}
+	if len(content) == 0 {
+		return nil, fmt.Errorf("empty bundle response")
+	}
+	return content, nil
+}

--- a/internal/i18n/storage/lokalise/source_download_test.go
+++ b/internal/i18n/storage/lokalise/source_download_test.go
@@ -1,0 +1,187 @@
+package lokalise
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestDownloadSourceFileFetchesBundle(t *testing.T) {
+	var exportCalled bool
+	var bundleCalled bool
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api2/projects/project-1/files/download":
+			exportCalled = true
+			w.Header().Set("Content-Type", "application/json")
+			if r.Method != http.MethodPost {
+				t.Fatalf("method = %s, want POST", r.Method)
+			}
+			if got := r.Header.Get("X-Api-Token"); got != "secret" {
+				t.Fatalf("unexpected auth header: %q", got)
+			}
+			var body struct {
+				Format            string   `json:"format"`
+				OriginalFilenames *bool    `json:"original_filenames"`
+				AllPlatforms      bool     `json:"all_platforms"`
+				FilterLangs       []string `json:"filter_langs"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			if body.Format != "json" {
+				t.Fatalf("format = %q, want json", body.Format)
+			}
+			if body.OriginalFilenames == nil || !*body.OriginalFilenames {
+				t.Fatalf("expected original_filenames=true, got %#v", body.OriginalFilenames)
+			}
+			if !body.AllPlatforms {
+				t.Fatalf("expected all_platforms=true")
+			}
+			if len(body.FilterLangs) != 1 || body.FilterLangs[0] != "en" {
+				t.Fatalf("filter_langs = %#v, want [en]", body.FilterLangs)
+			}
+			_, _ = fmt.Fprintf(w, `{"project_id":"project-1","bundle_url":%q}`, server.URL+"/bundle/source.zip")
+		case "/bundle/source.zip":
+			bundleCalled = true
+			_, _ = w.Write([]byte("zip-bytes"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewHTTPClient(Config{
+		APIToken:       "secret",
+		APIBaseURL:     server.URL + "/api2/",
+		TimeoutSeconds: 1,
+	})
+	if err != nil {
+		t.Fatalf("new http client: %v", err)
+	}
+
+	result, err := client.DownloadSourceFile(t.Context(), SourceDownloadInput{
+		ProjectID:    " project-1 ",
+		SourceLocale: " en ",
+		FileFormat:   " json ",
+	})
+	if err != nil {
+		t.Fatalf("download source file: %v", err)
+	}
+	if !exportCalled || !bundleCalled {
+		t.Fatalf("expected export and bundle requests, export=%t bundle=%t", exportCalled, bundleCalled)
+	}
+	if string(result.Content) != "zip-bytes" {
+		t.Fatalf("unexpected content: %q", string(result.Content))
+	}
+	if result.ProjectID != "project-1" || result.SourceLocale != "en" || result.Format != "json" {
+		t.Fatalf("unexpected result metadata: %+v", result)
+	}
+	if result.BundleURL != server.URL+"/bundle/source.zip" {
+		t.Fatalf("unexpected bundle URL: %q", result.BundleURL)
+	}
+}
+
+func TestDownloadSourceFileValidatesRequiredFields(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+		in   SourceDownloadInput
+		want string
+	}{
+		{name: "project", cfg: Config{APIToken: "secret", TimeoutSeconds: 1}, in: SourceDownloadInput{SourceLocale: "en", FileFormat: "json"}, want: "project id is required"},
+		{name: "token", cfg: Config{TimeoutSeconds: 1}, in: SourceDownloadInput{ProjectID: "project-1", SourceLocale: "en", FileFormat: "json"}, want: "api token is required"},
+		{name: "locale", cfg: Config{APIToken: "secret", TimeoutSeconds: 1}, in: SourceDownloadInput{ProjectID: "project-1", FileFormat: "json"}, want: "source locale is required"},
+		{name: "format", cfg: Config{APIToken: "secret", TimeoutSeconds: 1}, in: SourceDownloadInput{ProjectID: "project-1", SourceLocale: "en"}, want: "file format is required"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := NewHTTPClient(tt.cfg)
+			if err != nil {
+				t.Fatalf("new http client: %v", err)
+			}
+			_, err = client.DownloadSourceFile(t.Context(), tt.in)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("expected %q error, got %v", tt.want, err)
+			}
+		})
+	}
+}
+
+func TestDownloadSourceFileAPIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	client, err := NewHTTPClient(Config{APIToken: "secret", APIBaseURL: server.URL + "/api2/", TimeoutSeconds: 1})
+	if err != nil {
+		t.Fatalf("new http client: %v", err)
+	}
+
+	_, err = client.DownloadSourceFile(t.Context(), SourceDownloadInput{
+		ProjectID:    "project-1",
+		SourceLocale: "en",
+		FileFormat:   "json",
+	})
+	if err == nil || !strings.Contains(err.Error(), "request export bundle") {
+		t.Fatalf("expected API error, got %v", err)
+	}
+}
+
+func TestDownloadSourceFileEmptyBundleURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"project_id":"project-1","bundle_url":""}`))
+	}))
+	defer server.Close()
+
+	client, err := NewHTTPClient(Config{APIToken: "secret", APIBaseURL: server.URL + "/api2/", TimeoutSeconds: 1})
+	if err != nil {
+		t.Fatalf("new http client: %v", err)
+	}
+
+	_, err = client.DownloadSourceFile(t.Context(), SourceDownloadInput{
+		ProjectID:    "project-1",
+		SourceLocale: "en",
+		FileFormat:   "json",
+	})
+	if err == nil || !strings.Contains(err.Error(), "empty bundle URL") {
+		t.Fatalf("expected empty bundle URL error, got %v", err)
+	}
+}
+
+func TestDownloadSourceFileBundleError(t *testing.T) {
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api2/projects/project-1/files/download":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{"project_id":"project-1","bundle_url":%q}`, server.URL+"/bundle/source.zip")
+		case "/bundle/source.zip":
+			http.Error(w, "missing bundle", http.StatusNotFound)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewHTTPClient(Config{APIToken: "secret", APIBaseURL: server.URL + "/api2/", TimeoutSeconds: 1})
+	if err != nil {
+		t.Fatalf("new http client: %v", err)
+	}
+
+	_, err = client.DownloadSourceFile(t.Context(), SourceDownloadInput{
+		ProjectID:    "project-1",
+		SourceLocale: "en",
+		FileFormat:   "json",
+	})
+	if err == nil || !strings.Contains(err.Error(), "status 404") {
+		t.Fatalf("expected bundle status error, got %v", err)
+	}
+}

--- a/internal/i18n/storage/lokalise/source_download_test.go
+++ b/internal/i18n/storage/lokalise/source_download_test.go
@@ -226,6 +226,39 @@ func TestDownloadSourceFileBundleError(t *testing.T) {
 	}
 }
 
+func TestDownloadSourceFileLargeBundleErrorUsesSmallLimit(t *testing.T) {
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api2/projects/project-1/files/download":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{"project_id":"project-1","bundle_url":%q}`, server.URL+"/bundle/source.zip")
+		case "/bundle/source.zip":
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(strings.Repeat("x", int(maxSourceDownloadErrorBodyBytes)+1)))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewHTTPClient(Config{APIToken: "secret", APIBaseURL: server.URL + "/api2/", TimeoutSeconds: 1})
+	if err != nil {
+		t.Fatalf("new http client: %v", err)
+	}
+
+	_, err = client.DownloadSourceFile(t.Context(), SourceDownloadInput{
+		ProjectID:    "project-1",
+		SourceLocale: "en",
+		FileFormat:   "json",
+	})
+	if err == nil ||
+		!strings.Contains(err.Error(), "status 403") ||
+		!strings.Contains(err.Error(), fmt.Sprintf("exceeds %d byte limit", maxSourceDownloadErrorBodyBytes)) {
+		t.Fatalf("expected small error body limit, got %v", err)
+	}
+}
+
 func TestReadLimitedBundleBodyRejectsOversizedResponse(t *testing.T) {
 	content, err := readLimitedBundleBody(strings.NewReader("abcdef"), 5)
 	if err == nil || !strings.Contains(err.Error(), "exceeds 5 byte limit") {

--- a/internal/i18n/storage/lokalise/source_download_test.go
+++ b/internal/i18n/storage/lokalise/source_download_test.go
@@ -84,9 +84,6 @@ func TestDownloadSourceFileFetchesBundle(t *testing.T) {
 	if result.ProjectID != "project-1" || result.SourceLocale != "en" || result.Format != "json" {
 		t.Fatalf("unexpected result metadata: %+v", result)
 	}
-	if result.BundleURL != server.URL+"/bundle/source.zip" {
-		t.Fatalf("unexpected bundle URL: %q", result.BundleURL)
-	}
 }
 
 func TestDownloadSourceFileDefaultsToSinglePlatform(t *testing.T) {

--- a/internal/i18n/storage/lokalise/source_download_test.go
+++ b/internal/i18n/storage/lokalise/source_download_test.go
@@ -2,6 +2,7 @@ package lokalise
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -202,7 +203,7 @@ func TestDownloadSourceFileBundleError(t *testing.T) {
 		switch r.URL.Path {
 		case "/api2/projects/project-1/files/download":
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = fmt.Fprintf(w, `{"project_id":"project-1","bundle_url":%q}`, server.URL+"/bundle/source.zip")
+			_, _ = fmt.Fprintf(w, `{"project_id":"project-1","bundle_url":%q}`, server.URL+"/bundle/source.zip?X-Amz-Signature=secret-signature")
 		case "/bundle/source.zip":
 			http.Error(w, "missing bundle", http.StatusNotFound)
 		default:
@@ -223,6 +224,30 @@ func TestDownloadSourceFileBundleError(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), "status 404") {
 		t.Fatalf("expected bundle status error, got %v", err)
+	}
+	if strings.Contains(err.Error(), "X-Amz-Signature") || strings.Contains(err.Error(), "secret-signature") || strings.Contains(err.Error(), server.URL) {
+		t.Fatalf("bundle error leaked signed URL: %v", err)
+	}
+}
+
+func TestDownloadBundleRequestErrorRedactsBundleURL(t *testing.T) {
+	client := &HTTPClient{
+		httpClient: &http.Client{
+			Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return nil, errors.New("connection failed")
+			}),
+		},
+	}
+
+	_, err := client.downloadBundle(t.Context(), "https://example.invalid/source.zip?X-Goog-Signature=secret-signature")
+	if err == nil {
+		t.Fatalf("expected request error")
+	}
+	if !strings.Contains(err.Error(), "GET bundle URL") {
+		t.Fatalf("expected generic bundle URL label, got %v", err)
+	}
+	if strings.Contains(err.Error(), "example.invalid") || strings.Contains(err.Error(), "X-Goog-Signature") || strings.Contains(err.Error(), "secret-signature") {
+		t.Fatalf("request error leaked signed URL: %v", err)
 	}
 }
 
@@ -257,6 +282,12 @@ func TestDownloadSourceFileLargeBundleErrorUsesSmallLimit(t *testing.T) {
 		!strings.Contains(err.Error(), fmt.Sprintf("exceeds %d byte limit", maxSourceDownloadErrorBodyBytes)) {
 		t.Fatalf("expected small error body limit, got %v", err)
 	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }
 
 func TestReadLimitedBundleBodyRejectsOversizedResponse(t *testing.T) {

--- a/internal/i18n/storage/lokalise/source_download_test.go
+++ b/internal/i18n/storage/lokalise/source_download_test.go
@@ -69,6 +69,7 @@ func TestDownloadSourceFileFetchesBundle(t *testing.T) {
 		ProjectID:    " project-1 ",
 		SourceLocale: " en ",
 		FileFormat:   " json ",
+		AllPlatforms: true,
 	})
 	if err != nil {
 		t.Fatalf("download source file: %v", err)
@@ -84,6 +85,45 @@ func TestDownloadSourceFileFetchesBundle(t *testing.T) {
 	}
 	if result.BundleURL != server.URL+"/bundle/source.zip" {
 		t.Fatalf("unexpected bundle URL: %q", result.BundleURL)
+	}
+}
+
+func TestDownloadSourceFileDefaultsToSinglePlatform(t *testing.T) {
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api2/projects/project-1/files/download":
+			w.Header().Set("Content-Type", "application/json")
+			var body struct {
+				AllPlatforms bool `json:"all_platforms"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			if body.AllPlatforms {
+				t.Fatalf("all_platforms = true, want false by default")
+			}
+			_, _ = fmt.Fprintf(w, `{"project_id":"project-1","bundle_url":%q}`, server.URL+"/bundle/source.zip")
+		case "/bundle/source.zip":
+			_, _ = w.Write([]byte("zip-bytes"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewHTTPClient(Config{APIToken: "secret", APIBaseURL: server.URL + "/api2/", TimeoutSeconds: 1})
+	if err != nil {
+		t.Fatalf("new http client: %v", err)
+	}
+
+	_, err = client.DownloadSourceFile(t.Context(), SourceDownloadInput{
+		ProjectID:    "project-1",
+		SourceLocale: "en",
+		FileFormat:   "json",
+	})
+	if err != nil {
+		t.Fatalf("download source file: %v", err)
 	}
 }
 

--- a/internal/i18n/storage/lokalise/source_download_test.go
+++ b/internal/i18n/storage/lokalise/source_download_test.go
@@ -246,6 +246,9 @@ func TestDownloadBundleRequestErrorRedactsBundleURL(t *testing.T) {
 	if !strings.Contains(err.Error(), "GET bundle URL") {
 		t.Fatalf("expected generic bundle URL label, got %v", err)
 	}
+	if !strings.Contains(err.Error(), "connection failed") {
+		t.Fatalf("expected transport error detail, got %v", err)
+	}
 	if strings.Contains(err.Error(), "example.invalid") || strings.Contains(err.Error(), "X-Goog-Signature") || strings.Contains(err.Error(), "secret-signature") {
 		t.Fatalf("request error leaked signed URL: %v", err)
 	}

--- a/internal/i18n/storage/lokalise/source_download_test.go
+++ b/internal/i18n/storage/lokalise/source_download_test.go
@@ -185,3 +185,18 @@ func TestDownloadSourceFileBundleError(t *testing.T) {
 		t.Fatalf("expected bundle status error, got %v", err)
 	}
 }
+
+func TestReadLimitedBundleBodyRejectsOversizedResponse(t *testing.T) {
+	content, err := readLimitedBundleBody(strings.NewReader("abcdef"), 5)
+	if err == nil || !strings.Contains(err.Error(), "exceeds 5 byte limit") {
+		t.Fatalf("expected size limit error, got content=%q err=%v", string(content), err)
+	}
+
+	content, err = readLimitedBundleBody(strings.NewReader("abcde"), 5)
+	if err != nil {
+		t.Fatalf("read limited body at limit: %v", err)
+	}
+	if string(content) != "abcde" {
+		t.Fatalf("content = %q, want abcde", string(content))
+	}
+}

--- a/internal/i18n/storage/lokalise/source_download_test.go
+++ b/internal/i18n/storage/lokalise/source_download_test.go
@@ -254,6 +254,24 @@ func TestDownloadBundleRequestErrorRedactsBundleURL(t *testing.T) {
 	}
 }
 
+func TestDownloadBundleRequiresConfiguredHTTPClient(t *testing.T) {
+	tests := []struct {
+		name   string
+		client *HTTPClient
+	}{
+		{name: "nil client"},
+		{name: "nil http client", client: &HTTPClient{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.client.downloadBundle(t.Context(), "https://example.invalid/source.zip")
+			if err == nil || !strings.Contains(err.Error(), "http client is not configured") {
+				t.Fatalf("expected configured client error, got %v", err)
+			}
+		})
+	}
+}
+
 func TestDownloadSourceFileLargeBundleErrorUsesSmallLimit(t *testing.T) {
 	var server *httptest.Server
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- Add `hyperlocalise lokalise download sources` for exporting source-locale files from Lokalise.
- Use the existing Lokalise client shape: SDK `Files().Download` creates the export, then the returned `bundle_url` is fetched with the configured HTTP client.
- Support config/env auth, stdout or file output, `--force`, `--dry-run`, custom API base URL, and timeout handling.
- Cover command behavior and mocked Lokalise API download/error paths.

## API Behavior
- Lokalise returns a generated export bundle URL; this command writes the downloaded bundle bytes to stdout or the requested output path.
- Branches are supported through Lokalise's documented `projectID:branch` project identifier form.

## Tests
- `go test -count=1 ./internal/i18n/storage/lokalise`
- `go test -count=1 ./apps/cli/cmd -run TestLokalise`
- `git diff --check`
- Clean temp checkout focused proof: storage Lokalise package + `TestLokalise`

## Notes
- Draft PR: full WSL `go test -count=1 ./...` and CI/Greptile review are still the final gates.