### PR TITLE
feat(cli): add Lokalise translation download

### DIFF
--- a/apps/cli/cmd/lokalise.go
+++ b/apps/cli/cmd/lokalise.go
@@ -896,7 +896,7 @@ func loadLokaliseStorageConfigForAction(configPath string, action string) (lokal
 	if !strings.EqualFold(strings.TrimSpace(cfg.Storage.Adapter), lokalise.AdapterName) {
 		return lokalise.Config{}, fmt.Errorf("%s: storage.adapter must be %q", action, lokalise.AdapterName)
 	}
-	parsed, err := lokalise.ParseConfig(cfg.Storage.Config)
+	parsed, err := lokalise.DecodeConfig(cfg.Storage.Config)
 	if err != nil {
 		return lokalise.Config{}, fmt.Errorf("%s: %w", action, err)
 	}

--- a/apps/cli/cmd/lokalise.go
+++ b/apps/cli/cmd/lokalise.go
@@ -270,13 +270,13 @@ func lokaliseProjectIDWithBranch(projectID, branch string) (string, error) {
 	return projectID + ":" + url.PathEscape(branch), nil
 }
 
-func lokaliseTranslationOutputPaths(output string, locales []string) ([]string, error) {
-	if len(locales) == 0 {
+func lokaliseTranslationOutputPaths(output string, targetLocales []string) ([]string, error) {
+	if len(targetLocales) == 0 {
 		return nil, nil
 	}
-	if len(locales) == 1 {
+	if len(targetLocales) == 1 {
 		if strings.Contains(output, "%locale%") {
-			return []string{strings.ReplaceAll(output, "%locale%", locales[0])}, nil
+			return []string{strings.ReplaceAll(output, "%locale%", targetLocales[0])}, nil
 		}
 		return []string{output}, nil
 	}
@@ -286,8 +286,8 @@ func lokaliseTranslationOutputPaths(output string, locales []string) ([]string, 
 	if !strings.Contains(output, "%locale%") {
 		return nil, fmt.Errorf("lokalise download translations: --output must include %%locale%% when downloading multiple target locales")
 	}
-	paths := make([]string, 0, len(locales))
-	for _, locale := range locales {
+	paths := make([]string, 0, len(targetLocales))
+	for _, locale := range targetLocales {
 		paths = append(paths, strings.ReplaceAll(output, "%locale%", locale))
 	}
 	return paths, nil

--- a/apps/cli/cmd/lokalise.go
+++ b/apps/cli/cmd/lokalise.go
@@ -149,24 +149,26 @@ func executeLokaliseDownloadTranslations(cmd *cobra.Command, o lokaliseDownloadT
 	for idx, file := range result.Files {
 		output := outputs[idx]
 		if output == "" || output == "-" {
-			_, err := cmd.OutOrStdout().Write(file.Content)
-			return err
-		}
-		outputExisted := false
-		if _, err := os.Stat(output); err == nil {
-			outputExisted = true
+			if _, err := cmd.OutOrStdout().Write(file.Content); err != nil {
+				return err
+			}
+			if result.Warning != "" {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: %s\n", result.Warning)
+			}
+			return nil
 		}
 		if err := writeLokaliseDownloadedTranslation(output, file.Content, o.force); err != nil {
 			removeLokaliseDownloadedOutputs(writtenOutputs)
 			return err
 		}
-		if !outputExisted {
-			writtenOutputs = append(writtenOutputs, output)
-		}
+		writtenOutputs = append(writtenOutputs, output)
 		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "downloaded file=%s bytes=%d locale=%s format=%s\n", output, len(file.Content), file.Locale, req.Format); err != nil {
 			removeLokaliseDownloadedOutputs(writtenOutputs)
 			return err
 		}
+	}
+	if result.Warning != "" {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: %s\n", result.Warning)
 	}
 	return nil
 }

--- a/apps/cli/cmd/lokalise.go
+++ b/apps/cli/cmd/lokalise.go
@@ -184,10 +184,12 @@ func resolveLokaliseDownloadTranslationsConfig(cmd *cobra.Command, o lokaliseDow
 		return lokalise.Config{}, lokalise.TranslationFileDownloadRequest{}, nil, fmt.Errorf("lokalise download translations: --project-id is required unless --config points to a Lokalise storage config")
 	}
 
-	if strings.TrimSpace(o.configPath) != "" || cfg.ProjectID == "" || len(targets) == 0 {
+	configPath := strings.TrimSpace(o.configPath)
+	shouldLoadConfig := configPath != "" || cfg.ProjectID == "" || (len(targets) == 0 && defaultI18NConfigExists())
+	if shouldLoadConfig {
 		loaded, err := loadLokaliseStorageConfigForAction(o.configPath, "lokalise download translations")
 		if err != nil {
-			if strings.TrimSpace(o.configPath) != "" || cfg.ProjectID == "" || len(targets) == 0 {
+			if configPath != "" || cfg.ProjectID == "" {
 				return lokalise.Config{}, lokalise.TranslationFileDownloadRequest{}, nil, err
 			}
 		} else {
@@ -342,10 +344,6 @@ func writeLokaliseDownloadedFileAtomic(path string, content []byte, perm os.File
 		_ = file.Close()
 		return fmt.Errorf("lokalise download translations: write temp output file %q: %w", path, err)
 	}
-	if err := file.Chmod(perm); err != nil {
-		_ = file.Close()
-		return fmt.Errorf("lokalise download translations: chmod temp output file %q: %w", path, err)
-	}
 	if err := file.Sync(); err != nil {
 		_ = file.Close()
 		return fmt.Errorf("lokalise download translations: sync temp output file %q: %w", path, err)
@@ -357,6 +355,7 @@ func writeLokaliseDownloadedFileAtomic(path string, content []byte, perm os.File
 		return fmt.Errorf("lokalise download translations: replace output file %q: %w", path, err)
 	}
 	renamed = true
+	_ = os.Chmod(path, perm)
 	return nil
 }
 

--- a/apps/cli/cmd/lokalise.go
+++ b/apps/cli/cmd/lokalise.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -29,11 +30,34 @@ type lokaliseGlossaryDownloadOptions struct {
 	timeoutSeconds int
 }
 
+type lokaliseDownloadTranslationsOptions struct {
+	configPath      string
+	projectID       string
+	targetLocales   []string
+	format          string
+	outputPath      string
+	bundleStructure string
+	branch          string
+	tokenEnv        string
+	apiBaseURL      string
+	timeoutSeconds  int
+	force           bool
+	dryRun          bool
+}
+
 type lokaliseGlossaryCSVWriter interface {
 	WriteGlossaryCSV(context.Context, lokalise.GlossaryDownloadInput, io.Writer) (lokalise.GlossaryDownloadResult, error)
 }
 
+type lokaliseTranslationDownloader interface {
+	DownloadTranslationFiles(context.Context, lokalise.TranslationFileDownloadRequest) (lokalise.TranslationFileDownloadResult, error)
+}
+
 var newLokaliseGlossaryCSVWriter = func(cfg lokalise.Config) (lokaliseGlossaryCSVWriter, error) {
+	return lokalise.NewHTTPClient(cfg)
+}
+
+var newLokaliseTranslationDownloader = func(cfg lokalise.Config) (lokaliseTranslationDownloader, error) {
 	return lokalise.NewHTTPClient(cfg)
 }
 
@@ -42,8 +66,349 @@ func newLokaliseCmd() *cobra.Command {
 		Use:   "lokalise",
 		Short: "Lokalise workflow commands",
 	}
+	cmd.AddCommand(newLokaliseDownloadCmd())
 	cmd.AddCommand(newLokaliseGlossaryCmd())
 	return cmd
+}
+
+func newLokaliseDownloadCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "download",
+		Short: "download files from Lokalise",
+	}
+	cmd.AddCommand(newLokaliseDownloadTranslationsCmd())
+	return cmd
+}
+
+func newLokaliseDownloadTranslationsCmd() *cobra.Command {
+	o := lokaliseDownloadTranslationsOptions{
+		tokenEnv:       "LOKALISE_API_TOKEN",
+		timeoutSeconds: 30,
+	}
+	cmd := &cobra.Command{
+		Use:          "translations",
+		Short:        "download translated content from Lokalise",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return executeLokaliseDownloadTranslations(cmd, o)
+		},
+	}
+	cmd.Flags().StringVar(&o.configPath, "config", "", "path to i18n.yml with storage.adapter=lokalise")
+	cmd.Flags().StringVar(&o.projectID, "project-id", "", "Lokalise project ID; overrides storage.config.projectID")
+	cmd.Flags().StringSliceVarP(&o.targetLocales, "target-locale", "l", nil, "Lokalise target locale(s) to export")
+	cmd.Flags().StringVar(&o.format, "format", "", "Lokalise file format, for example json, yaml, or strings")
+	cmd.Flags().StringVarP(&o.outputPath, "output", "o", "", "output file path; omit or use - for stdout when downloading one locale; use %locale% for multiple locales")
+	cmd.Flags().StringVar(&o.bundleStructure, "bundle-structure", "", "Lokalise bundle structure; defaults to %LANG_ISO%.%FORMAT%")
+	cmd.Flags().StringVar(&o.branch, "branch", "", "Lokalise branch name to export")
+	cmd.Flags().StringVar(&o.tokenEnv, "token-env", o.tokenEnv, "environment variable containing the Lokalise API token")
+	cmd.Flags().StringVar(&o.apiBaseURL, "api-base-url", "", "Lokalise API base URL")
+	cmd.Flags().IntVar(&o.timeoutSeconds, "timeout-seconds", o.timeoutSeconds, "HTTP timeout in seconds")
+	cmd.Flags().BoolVar(&o.force, "force", false, "overwrite an existing output file")
+	cmd.Flags().BoolVar(&o.dryRun, "dry-run", false, "preview command without downloading content")
+	return cmd
+}
+
+func executeLokaliseDownloadTranslations(cmd *cobra.Command, o lokaliseDownloadTranslationsOptions) error {
+	cfg, req, targets, err := resolveLokaliseDownloadTranslationsConfig(cmd, o, !o.dryRun)
+	if err != nil {
+		return err
+	}
+
+	outputPath := strings.TrimSpace(o.outputPath)
+	outputs, err := lokaliseTranslationOutputPaths(outputPath, targets)
+	if err != nil {
+		return err
+	}
+	if o.dryRun {
+		destination := outputPath
+		if destination == "" {
+			destination = "-"
+		}
+		_, err := fmt.Fprintf(cmd.OutOrStdout(), "dry-run action=lokalise-download-translations project_id=%s target_locales=%s format=%s output=%s\n", req.ProjectID, strings.Join(targets, ","), req.Format, destination)
+		return err
+	}
+	for _, output := range outputs {
+		if err := validateLokaliseDownloadOutputPath(output, o.force); err != nil {
+			return err
+		}
+	}
+
+	client, err := newLokaliseTranslationDownloader(cfg)
+	if err != nil {
+		return err
+	}
+	result, err := client.DownloadTranslationFiles(backgroundContext(), req)
+	if err != nil {
+		return fmt.Errorf("lokalise download translations: %w", err)
+	}
+	if len(result.Files) != len(outputs) {
+		return fmt.Errorf("lokalise download translations: downloaded %d file(s), expected %d", len(result.Files), len(outputs))
+	}
+
+	writtenOutputs := make([]string, 0, len(outputs))
+	for idx, file := range result.Files {
+		output := outputs[idx]
+		if output == "" || output == "-" {
+			_, err := cmd.OutOrStdout().Write(file.Content)
+			return err
+		}
+		outputExisted := false
+		if _, err := os.Stat(output); err == nil {
+			outputExisted = true
+		}
+		if err := writeLokaliseDownloadedTranslation(output, file.Content, o.force); err != nil {
+			removeLokaliseDownloadedOutputs(writtenOutputs)
+			return err
+		}
+		if !outputExisted {
+			writtenOutputs = append(writtenOutputs, output)
+		}
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "downloaded file=%s bytes=%d locale=%s format=%s\n", output, len(file.Content), file.Locale, req.Format); err != nil {
+			removeLokaliseDownloadedOutputs(writtenOutputs)
+			return err
+		}
+	}
+	return nil
+}
+
+func resolveLokaliseDownloadTranslationsConfig(cmd *cobra.Command, o lokaliseDownloadTranslationsOptions, requireAuth bool) (lokalise.Config, lokalise.TranslationFileDownloadRequest, []string, error) {
+	cfg := lokalise.Config{
+		ProjectID:      strings.TrimSpace(o.projectID),
+		APITokenEnv:    strings.TrimSpace(o.tokenEnv),
+		APIBaseURL:     strings.TrimSpace(o.apiBaseURL),
+		TimeoutSeconds: o.timeoutSeconds,
+	}
+	targets := normalizeLokaliseDownloadLocales(o.targetLocales)
+
+	if strings.TrimSpace(o.configPath) == "" && cfg.ProjectID == "" && !defaultI18NConfigExists() {
+		return lokalise.Config{}, lokalise.TranslationFileDownloadRequest{}, nil, fmt.Errorf("lokalise download translations: --project-id is required unless --config points to a Lokalise storage config")
+	}
+
+	if strings.TrimSpace(o.configPath) != "" || cfg.ProjectID == "" || len(targets) == 0 {
+		loaded, err := loadLokaliseStorageConfigForAction(o.configPath, "lokalise download translations")
+		if err != nil {
+			if strings.TrimSpace(o.configPath) != "" || cfg.ProjectID == "" || len(targets) == 0 {
+				return lokalise.Config{}, lokalise.TranslationFileDownloadRequest{}, nil, err
+			}
+		} else {
+			if cfg.ProjectID == "" {
+				cfg.ProjectID = loaded.ProjectID
+			}
+			if cfg.APITokenEnv == "" {
+				cfg.APITokenEnv = loaded.APITokenEnv
+			}
+			if cfg.APIBaseURL == "" {
+				cfg.APIBaseURL = loaded.APIBaseURL
+			}
+			if cfg.TimeoutSeconds <= 0 {
+				cfg.TimeoutSeconds = loaded.TimeoutSeconds
+			}
+			if strings.TrimSpace(cfg.APIToken) == "" {
+				cfg.APIToken = loaded.APIToken
+			}
+			if len(targets) == 0 {
+				targets = normalizeLokaliseDownloadLocales(loaded.TargetLanguages)
+			}
+		}
+	}
+	if strings.TrimSpace(cfg.ProjectID) == "" {
+		return lokalise.Config{}, lokalise.TranslationFileDownloadRequest{}, nil, fmt.Errorf("lokalise download translations: --project-id is required unless --config points to a Lokalise storage config")
+	}
+	if len(targets) == 0 {
+		return lokalise.Config{}, lokalise.TranslationFileDownloadRequest{}, nil, fmt.Errorf("lokalise download translations: at least one --target-locale is required (or targetLanguages in --config)")
+	}
+	format := normalizeLokaliseDownloadFormat(o.format)
+	if format == "" {
+		return lokalise.Config{}, lokalise.TranslationFileDownloadRequest{}, nil, fmt.Errorf("lokalise download translations: --format is required")
+	}
+	if cfg.APITokenEnv == "" {
+		cfg.APITokenEnv = "LOKALISE_API_TOKEN"
+	}
+	if strings.TrimSpace(cfg.APIToken) == "" {
+		if !requireAuth {
+			cfg.APIToken = "dry-run"
+		} else {
+			token := strings.TrimSpace(os.Getenv(cfg.APITokenEnv))
+			if token == "" && cfg.APITokenEnv != "LOKALISE_API_TOKEN" {
+				token = strings.TrimSpace(os.Getenv("LOKALISE_API_TOKEN"))
+			}
+			if token == "" {
+				if cfg.APITokenEnv != "LOKALISE_API_TOKEN" {
+					return lokalise.Config{}, lokalise.TranslationFileDownloadRequest{}, nil, fmt.Errorf("lokalise download translations: API token is required (%s or LOKALISE_API_TOKEN)", cfg.APITokenEnv)
+				}
+				return lokalise.Config{}, lokalise.TranslationFileDownloadRequest{}, nil, fmt.Errorf("lokalise download translations: API token is required (%s)", cfg.APITokenEnv)
+			}
+			cfg.APIToken = token
+		}
+	}
+	if cfg.TimeoutSeconds <= 0 {
+		cfg.TimeoutSeconds = 30
+	}
+	projectID, err := lokaliseProjectIDWithBranch(strings.TrimSpace(cfg.ProjectID), o.branch)
+	if err != nil {
+		return lokalise.Config{}, lokalise.TranslationFileDownloadRequest{}, nil, err
+	}
+	req := lokalise.TranslationFileDownloadRequest{
+		ProjectID:       projectID,
+		TargetLanguages: targets,
+		Format:          format,
+		BundleStructure: strings.TrimSpace(o.bundleStructure),
+	}
+	return cfg, req, targets, nil
+}
+
+func lokaliseProjectIDWithBranch(projectID, branch string) (string, error) {
+	branch = strings.TrimSpace(branch)
+	if branch == "" {
+		return projectID, nil
+	}
+	if strings.Contains(projectID, ":") {
+		return "", fmt.Errorf("lokalise download translations: --branch cannot be used when projectID already includes a branch")
+	}
+	return projectID + ":" + url.PathEscape(branch), nil
+}
+
+func lokaliseTranslationOutputPaths(output string, locales []string) ([]string, error) {
+	if len(locales) == 0 {
+		return nil, nil
+	}
+	if len(locales) == 1 {
+		if strings.Contains(output, "%locale%") {
+			return []string{strings.ReplaceAll(output, "%locale%", locales[0])}, nil
+		}
+		return []string{output}, nil
+	}
+	if output == "" || output == "-" {
+		return nil, fmt.Errorf("lokalise download translations: --output with %%locale%% is required when downloading multiple target locales")
+	}
+	if !strings.Contains(output, "%locale%") {
+		return nil, fmt.Errorf("lokalise download translations: --output must include %%locale%% when downloading multiple target locales")
+	}
+	paths := make([]string, 0, len(locales))
+	for _, locale := range locales {
+		paths = append(paths, strings.ReplaceAll(output, "%locale%", locale))
+	}
+	return paths, nil
+}
+
+func writeLokaliseDownloadedTranslation(path string, content []byte, force bool) error {
+	if err := validateLokaliseDownloadOutputPath(path, force); err != nil {
+		return err
+	}
+	if path == "" || path == "-" {
+		return fmt.Errorf("lokalise download translations: output file path is required")
+	}
+	if dir := filepath.Dir(path); dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("lokalise download translations: mkdir output directory: %w", err)
+		}
+	}
+	if force {
+		return writeLokaliseDownloadedFileAtomic(path, content, 0o644)
+	}
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		if os.IsExist(err) {
+			return fmt.Errorf("lokalise download translations: output file %q already exists; use --force to overwrite", path)
+		}
+		return fmt.Errorf("lokalise download translations: open output file %q: %w", path, err)
+	}
+	if _, err := file.Write(content); err != nil {
+		_ = file.Close()
+		_ = os.Remove(path)
+		return fmt.Errorf("lokalise download translations: write output file %q: %w", path, err)
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(path)
+		return fmt.Errorf("lokalise download translations: close output file %q: %w", path, err)
+	}
+	return nil
+}
+
+func writeLokaliseDownloadedFileAtomic(path string, content []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	file, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("lokalise download translations: create temp output file %q: %w", path, err)
+	}
+	tempPath := file.Name()
+	renamed := false
+	defer func() {
+		if !renamed {
+			_ = os.Remove(tempPath)
+		}
+	}()
+	if _, err := file.Write(content); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("lokalise download translations: write temp output file %q: %w", path, err)
+	}
+	if err := file.Chmod(perm); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("lokalise download translations: chmod temp output file %q: %w", path, err)
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("lokalise download translations: sync temp output file %q: %w", path, err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("lokalise download translations: close temp output file %q: %w", path, err)
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		return fmt.Errorf("lokalise download translations: replace output file %q: %w", path, err)
+	}
+	renamed = true
+	return nil
+}
+
+func validateLokaliseDownloadOutputPath(path string, force bool) error {
+	if path == "" || path == "-" {
+		return nil
+	}
+	if info, err := os.Stat(path); err == nil {
+		if info.IsDir() {
+			return fmt.Errorf("lokalise download translations: output file %q is a directory", path)
+		}
+		if !force {
+			return fmt.Errorf("lokalise download translations: output file %q already exists; use --force to overwrite", path)
+		}
+	} else if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("lokalise download translations: stat output file %q: %w", path, err)
+	}
+	return nil
+}
+
+func removeLokaliseDownloadedOutputs(paths []string) {
+	for i := len(paths) - 1; i >= 0; i-- {
+		_ = os.Remove(paths[i])
+	}
+}
+
+func normalizeLokaliseDownloadFormat(format string) string {
+	trimmed := strings.TrimPrefix(strings.TrimSpace(format), ".")
+	if strings.EqualFold(trimmed, "yml") {
+		return "yaml"
+	}
+	return trimmed
+}
+
+func normalizeLokaliseDownloadLocales(values []string) []string {
+	out := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		for _, part := range strings.Split(value, ",") {
+			trimmed := strings.TrimSpace(part)
+			if trimmed == "" {
+				continue
+			}
+			key := strings.ToLower(trimmed)
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			out = append(out, trimmed)
+		}
+	}
+	return out
 }
 
 func newLokaliseGlossaryCmd() *cobra.Command {
@@ -198,19 +563,23 @@ func defaultI18NConfigExists() bool {
 }
 
 func loadLokaliseStorageConfig(configPath string) (lokalise.Config, error) {
+	return loadLokaliseStorageConfigForAction(configPath, "lokalise glossary download")
+}
+
+func loadLokaliseStorageConfigForAction(configPath string, action string) (lokalise.Config, error) {
 	cfg, err := i18nconfig.Load(configPath)
 	if err != nil {
-		return lokalise.Config{}, fmt.Errorf("lokalise glossary download: load config: %w", err)
+		return lokalise.Config{}, fmt.Errorf("%s: load config: %w", action, err)
 	}
 	if cfg.Storage == nil {
-		return lokalise.Config{}, fmt.Errorf("lokalise glossary download: storage config is required")
+		return lokalise.Config{}, fmt.Errorf("%s: storage config is required", action)
 	}
 	if !strings.EqualFold(strings.TrimSpace(cfg.Storage.Adapter), lokalise.AdapterName) {
-		return lokalise.Config{}, fmt.Errorf("lokalise glossary download: storage.adapter must be %q", lokalise.AdapterName)
+		return lokalise.Config{}, fmt.Errorf("%s: storage.adapter must be %q", action, lokalise.AdapterName)
 	}
 	parsed, err := lokalise.ParseConfig(cfg.Storage.Config)
 	if err != nil {
-		return lokalise.Config{}, fmt.Errorf("lokalise glossary download: %w", err)
+		return lokalise.Config{}, fmt.Errorf("%s: %w", action, err)
 	}
 	return parsed, nil
 }

--- a/apps/cli/cmd/lokalise.go
+++ b/apps/cli/cmd/lokalise.go
@@ -82,7 +82,6 @@ func newLokaliseDownloadCmd() *cobra.Command {
 
 func newLokaliseDownloadTranslationsCmd() *cobra.Command {
 	o := lokaliseDownloadTranslationsOptions{
-		tokenEnv:       "LOKALISE_API_TOKEN",
 		timeoutSeconds: 30,
 	}
 	cmd := &cobra.Command{
@@ -109,7 +108,7 @@ func newLokaliseDownloadTranslationsCmd() *cobra.Command {
 }
 
 func executeLokaliseDownloadTranslations(cmd *cobra.Command, o lokaliseDownloadTranslationsOptions) error {
-	cfg, req, targets, err := resolveLokaliseDownloadTranslationsConfig(cmd, o, !o.dryRun)
+	cfg, req, targets, err := resolveLokaliseDownloadTranslationsConfig(o, !o.dryRun)
 	if err != nil {
 		return err
 	}
@@ -171,7 +170,7 @@ func executeLokaliseDownloadTranslations(cmd *cobra.Command, o lokaliseDownloadT
 	return nil
 }
 
-func resolveLokaliseDownloadTranslationsConfig(cmd *cobra.Command, o lokaliseDownloadTranslationsOptions, requireAuth bool) (lokalise.Config, lokalise.TranslationFileDownloadRequest, []string, error) {
+func resolveLokaliseDownloadTranslationsConfig(o lokaliseDownloadTranslationsOptions, requireAuth bool) (lokalise.Config, lokalise.TranslationFileDownloadRequest, []string, error) {
 	cfg := lokalise.Config{
 		ProjectID:      strings.TrimSpace(o.projectID),
 		APITokenEnv:    strings.TrimSpace(o.tokenEnv),

--- a/apps/cli/cmd/lokalise.go
+++ b/apps/cli/cmd/lokalise.go
@@ -144,6 +144,13 @@ func executeLokaliseDownloadTranslations(cmd *cobra.Command, o lokaliseDownloadT
 	if len(result.Files) != len(outputs) {
 		return fmt.Errorf("lokalise download translations: downloaded %d file(s), expected %d", len(result.Files), len(outputs))
 	}
+	if len(outputs) > 1 {
+		for _, output := range outputs {
+			if output == "" || output == "-" {
+				return fmt.Errorf("lokalise download translations: stdout output is only supported for one target locale")
+			}
+		}
+	}
 
 	writtenOutputs := make([]string, 0, len(outputs))
 	for idx, file := range result.Files {
@@ -269,6 +276,8 @@ func lokaliseProjectIDWithBranch(projectID, branch string) (string, error) {
 	if strings.Contains(projectID, ":") {
 		return "", fmt.Errorf("lokalise download translations: --branch cannot be used when projectID already includes a branch")
 	}
+	// go-lokalise-api interpolates projectID into the request path directly.
+	// Escape the branch once here; storage tests assert Resty preserves it.
 	return projectID + ":" + url.PathEscape(branch), nil
 }
 

--- a/apps/cli/cmd/lokalise.go
+++ b/apps/cli/cmd/lokalise.go
@@ -144,13 +144,6 @@ func executeLokaliseDownloadTranslations(cmd *cobra.Command, o lokaliseDownloadT
 	if len(result.Files) != len(outputs) {
 		return fmt.Errorf("lokalise download translations: downloaded %d file(s), expected %d", len(result.Files), len(outputs))
 	}
-	if len(outputs) > 1 {
-		for _, output := range outputs {
-			if output == "" || output == "-" {
-				return fmt.Errorf("lokalise download translations: stdout output is only supported for one target locale")
-			}
-		}
-	}
 
 	writtenOutputs := make([]string, 0, len(outputs))
 	for idx, file := range result.Files {

--- a/apps/cli/cmd/lokalise.go
+++ b/apps/cli/cmd/lokalise.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/locales"
 	"github.com/hyperlocalise/hyperlocalise/internal/i18n/storage/lokalise"
 	i18nconfig "github.com/hyperlocalise/hyperlocalise/pkg/i18nconfig"
 	"github.com/spf13/cobra"
@@ -293,11 +294,11 @@ func lokaliseTranslationOutputPaths(output string, locales []string) ([]string, 
 }
 
 func writeLokaliseDownloadedTranslation(path string, content []byte, force bool) error {
-	if err := validateLokaliseDownloadOutputPath(path, force); err != nil {
-		return err
-	}
 	if path == "" || path == "-" {
 		return fmt.Errorf("lokalise download translations: output file path is required")
+	}
+	if err := validateLokaliseDownloadOutputPath(path, force); err != nil {
+		return err
 	}
 	if dir := filepath.Dir(path); dir != "." {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -390,23 +391,7 @@ func normalizeLokaliseDownloadFormat(format string) string {
 }
 
 func normalizeLokaliseDownloadLocales(values []string) []string {
-	out := make([]string, 0, len(values))
-	seen := make(map[string]struct{}, len(values))
-	for _, value := range values {
-		for _, part := range strings.Split(value, ",") {
-			trimmed := strings.TrimSpace(part)
-			if trimmed == "" {
-				continue
-			}
-			key := strings.ToLower(trimmed)
-			if _, ok := seen[key]; ok {
-				continue
-			}
-			seen[key] = struct{}{}
-			out = append(out, trimmed)
-		}
-	}
-	return out
+	return locales.NormalizeList(values)
 }
 
 func newLokaliseGlossaryCmd() *cobra.Command {

--- a/apps/cli/cmd/lokalise.go
+++ b/apps/cli/cmd/lokalise.go
@@ -187,7 +187,7 @@ func resolveLokaliseDownloadTranslationsConfig(o lokaliseDownloadTranslationsOpt
 	configPath := strings.TrimSpace(o.configPath)
 	shouldLoadConfig := configPath != "" || cfg.ProjectID == "" || (len(targets) == 0 && defaultI18NConfigExists())
 	if shouldLoadConfig {
-		loaded, err := loadLokaliseStorageConfigForAction(o.configPath, "lokalise download translations")
+		loaded, err := loadLokaliseStorageConfigForAction(configPath, "lokalise download translations")
 		if err != nil {
 			if configPath != "" || cfg.ProjectID == "" {
 				return lokalise.Config{}, lokalise.TranslationFileDownloadRequest{}, nil, err

--- a/apps/cli/cmd/lokalise_test.go
+++ b/apps/cli/cmd/lokalise_test.go
@@ -7,11 +7,243 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/hyperlocalise/hyperlocalise/internal/i18n/storage/lokalise"
 )
+
+func TestLokaliseDownloadTranslationsWritesSingleLocaleToStdout(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("LOKALISE_API_TOKEN", "secret")
+
+	oldFactory := newLokaliseTranslationDownloader
+	defer func() {
+		newLokaliseTranslationDownloader = oldFactory
+	}()
+	fake := &fakeLokaliseTranslationDownloader{
+		files: []lokalise.TranslationFile{{
+			Locale:  "fr",
+			Name:    "fr.json",
+			Content: []byte(`{"hello":"Bonjour"}`),
+		}},
+	}
+	newLokaliseTranslationDownloader = func(cfg lokalise.Config) (lokaliseTranslationDownloader, error) {
+		if cfg.ProjectID != "project-1" || cfg.APIToken != "secret" {
+			t.Fatalf("config = %#v, want project/token from flags and env", cfg)
+		}
+		return fake, nil
+	}
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"lokalise", "download", "translations", "--project-id", "project-1", "--target-locale", "fr", "--format", "json"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute lokalise download translations: %v", err)
+	}
+	if got, want := out.String(), `{"hello":"Bonjour"}`; got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+	if fake.req.ProjectID != "project-1" || fake.req.Format != "json" {
+		t.Fatalf("request = %#v, want project/format", fake.req)
+	}
+	if got, want := fake.req.TargetLanguages, []string{"fr"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("target locales = %#v, want %#v", got, want)
+	}
+}
+
+func TestLokaliseDownloadTranslationsWritesMultipleLocalesToFiles(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("LOKALISE_API_TOKEN", "secret")
+
+	oldFactory := newLokaliseTranslationDownloader
+	defer func() {
+		newLokaliseTranslationDownloader = oldFactory
+	}()
+	newLokaliseTranslationDownloader = func(lokalise.Config) (lokaliseTranslationDownloader, error) {
+		return &fakeLokaliseTranslationDownloader{
+			files: []lokalise.TranslationFile{
+				{Locale: "fr", Name: "fr.json", Content: []byte(`{"hello":"Bonjour"}`)},
+				{Locale: "de", Name: "de.json", Content: []byte(`{"hello":"Hallo"}`)},
+			},
+		}, nil
+	}
+
+	dir := t.TempDir()
+	outputPattern := filepath.Join(dir, "%locale%.json")
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"lokalise", "download", "translations", "--project-id", "project-1", "--target-locale", "fr,de", "--format", "json", "--output", outputPattern})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute lokalise download translations: %v", err)
+	}
+	frPayload, err := os.ReadFile(filepath.Join(dir, "fr.json"))
+	if err != nil {
+		t.Fatalf("read fr output: %v", err)
+	}
+	if string(frPayload) != `{"hello":"Bonjour"}` {
+		t.Fatalf("fr payload = %q", string(frPayload))
+	}
+	dePayload, err := os.ReadFile(filepath.Join(dir, "de.json"))
+	if err != nil {
+		t.Fatalf("read de output: %v", err)
+	}
+	if string(dePayload) != `{"hello":"Hallo"}` {
+		t.Fatalf("de payload = %q", string(dePayload))
+	}
+	output := out.String()
+	if !strings.Contains(output, "downloaded file="+filepath.Join(dir, "fr.json")) || !strings.Contains(output, "locale=de") {
+		t.Fatalf("summary output = %q", output)
+	}
+}
+
+func TestLokaliseDownloadTranslationsUsesStorageConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("LOKALISE_TEST_TOKEN", "secret")
+
+	configPath := filepath.Join(dir, "i18n.yml")
+	if err := os.WriteFile(configPath, []byte(`
+locales:
+  source: en
+  targets:
+    - fr
+buckets:
+  ui:
+    files:
+      - from: content/en.json
+        to: dist/{{target}}.json
+llm:
+  profiles:
+    default:
+      provider: openai
+      model: test
+storage:
+  adapter: lokalise
+  config:
+    projectID: project-from-config
+    apiTokenEnv: LOKALISE_TEST_TOKEN
+    targetLanguages:
+      - fr
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	oldFactory := newLokaliseTranslationDownloader
+	defer func() {
+		newLokaliseTranslationDownloader = oldFactory
+	}()
+	fake := &fakeLokaliseTranslationDownloader{
+		files: []lokalise.TranslationFile{{Locale: "fr", Name: "fr.json", Content: []byte(`{"hello":"Bonjour"}`)}},
+	}
+	newLokaliseTranslationDownloader = func(cfg lokalise.Config) (lokaliseTranslationDownloader, error) {
+		if cfg.ProjectID != "project-from-config" || cfg.APIToken != "secret" {
+			t.Fatalf("config = %#v, want project/token from config", cfg)
+		}
+		return fake, nil
+	}
+
+	outputPath := filepath.Join(dir, "fr.json")
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"lokalise", "download", "translations", "--config", configPath, "--format", "json", "--output", outputPath})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute lokalise download translations: %v", err)
+	}
+	if fake.req.ProjectID != "project-from-config" || !reflect.DeepEqual(fake.req.TargetLanguages, []string{"fr"}) {
+		t.Fatalf("request = %#v, want values from storage config", fake.req)
+	}
+}
+
+func TestLokaliseDownloadTranslationsRequiresOutputPatternForMultipleLocales(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("LOKALISE_API_TOKEN", "secret")
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"lokalise", "download", "translations", "--project-id", "project-1", "--target-locale", "fr", "--target-locale", "de", "--format", "json"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--output with %locale%") {
+		t.Fatalf("error = %v, want output pattern error", err)
+	}
+}
+
+func TestLokaliseDownloadTranslationsDryRunDoesNotRequireToken(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"lokalise", "download", "translations", "--project-id", "project-1", "--target-locale", "fr", "--format", "json", "--dry-run"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute dry-run: %v", err)
+	}
+	if got := out.String(); !strings.Contains(got, "dry-run action=lokalise-download-translations") || !strings.Contains(got, "target_locales=fr") {
+		t.Fatalf("dry-run output = %q", got)
+	}
+}
+
+func TestLokaliseDownloadTranslationsRejectsExistingOutputWithoutForce(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("LOKALISE_API_TOKEN", "secret")
+
+	oldFactory := newLokaliseTranslationDownloader
+	defer func() {
+		newLokaliseTranslationDownloader = oldFactory
+	}()
+	newLokaliseTranslationDownloader = func(lokalise.Config) (lokaliseTranslationDownloader, error) {
+		t.Fatalf("downloader should not be created when output validation fails")
+		return nil, nil
+	}
+
+	outputPath := filepath.Join(t.TempDir(), "fr.json")
+	if err := os.WriteFile(outputPath, []byte("existing"), 0o644); err != nil {
+		t.Fatalf("write existing output: %v", err)
+	}
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"lokalise", "download", "translations", "--project-id", "project-1", "--target-locale", "fr", "--format", "json", "--output", outputPath})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("error = %v, want already exists", err)
+	}
+}
+
+func TestLokaliseDownloadTranslationsRequiresInputs(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"lokalise", "download", "translations"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected missing project input error")
+	}
+	if !strings.Contains(err.Error(), "--project-id") {
+		t.Fatalf("error = %v, want --project-id", err)
+	}
+}
 
 func TestLokaliseGlossaryDownloadWritesCSVToStdout(t *testing.T) {
 	t.Chdir(t.TempDir())
@@ -153,4 +385,18 @@ func (f *fakeLokaliseGlossaryCSVWriter) WriteGlossaryCSV(_ context.Context, req 
 		return lokalise.GlossaryDownloadResult{}, err
 	}
 	return lokalise.GlossaryDownloadResult{Terms: 1, Rows: 1}, nil
+}
+
+type fakeLokaliseTranslationDownloader struct {
+	req   lokalise.TranslationFileDownloadRequest
+	files []lokalise.TranslationFile
+	err   error
+}
+
+func (f *fakeLokaliseTranslationDownloader) DownloadTranslationFiles(_ context.Context, req lokalise.TranslationFileDownloadRequest) (lokalise.TranslationFileDownloadResult, error) {
+	f.req = req
+	if f.err != nil {
+		return lokalise.TranslationFileDownloadResult{}, f.err
+	}
+	return lokalise.TranslationFileDownloadResult{Files: append([]lokalise.TranslationFile(nil), f.files...)}, nil
 }

--- a/apps/cli/cmd/lokalise_test.go
+++ b/apps/cli/cmd/lokalise_test.go
@@ -155,7 +155,7 @@ storage:
 	out := bytes.NewBuffer(nil)
 	cmd.SetOut(out)
 	cmd.SetErr(out)
-	cmd.SetArgs([]string{"lokalise", "download", "translations", "--config", configPath, "--format", "json", "--output", outputPath})
+	cmd.SetArgs([]string{"lokalise", "download", "translations", "--config", "  " + configPath + "  ", "--format", "json", "--output", outputPath})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("execute lokalise download translations: %v", err)

--- a/apps/cli/cmd/lokalise_test.go
+++ b/apps/cli/cmd/lokalise_test.go
@@ -338,6 +338,16 @@ func TestLokaliseDownloadTranslationsPrintsAPIWarning(t *testing.T) {
 	}
 }
 
+func TestLokaliseProjectIDWithBranchEscapesBranchOnce(t *testing.T) {
+	got, err := lokaliseProjectIDWithBranch("project-1", " feature/my-branch ")
+	if err != nil {
+		t.Fatalf("project ID with branch: %v", err)
+	}
+	if want := "project-1:feature%2Fmy-branch"; got != want {
+		t.Fatalf("project ID = %q, want %q", got, want)
+	}
+}
+
 func TestLokaliseDownloadTranslationsRequiresInputs(t *testing.T) {
 	t.Chdir(t.TempDir())
 

--- a/apps/cli/cmd/lokalise_test.go
+++ b/apps/cli/cmd/lokalise_test.go
@@ -200,6 +200,26 @@ func TestLokaliseDownloadTranslationsDryRunDoesNotRequireToken(t *testing.T) {
 	}
 }
 
+func TestLokaliseDownloadTranslationsDryRunWithConfigDoesNotRequireToken(t *testing.T) {
+	t.Setenv("LOKALISE_CONFIG_TOKEN", "")
+	t.Setenv("LOKALISE_API_TOKEN", "")
+
+	configPath := writeLokaliseDownloadConfig(t)
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"lokalise", "download", "translations", "--config", configPath, "--target-locale", "fr-FR", "--format", "json", "--dry-run"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute dry-run with config: %v", err)
+	}
+	output := out.String()
+	if !strings.Contains(output, "project_id=cfg-project") || !strings.Contains(output, "target_locales=fr-FR") {
+		t.Fatalf("dry-run output = %q", output)
+	}
+}
+
 func TestLokaliseDownloadTranslationsRejectsExistingOutputWithoutForce(t *testing.T) {
 	t.Chdir(t.TempDir())
 	t.Setenv("LOKALISE_API_TOKEN", "secret")

--- a/apps/cli/cmd/lokalise_test.go
+++ b/apps/cli/cmd/lokalise_test.go
@@ -227,6 +227,42 @@ func TestLokaliseDownloadTranslationsRejectsExistingOutputWithoutForce(t *testin
 	}
 }
 
+func TestLokaliseDownloadTranslationsForceOverwritesExistingOutput(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("LOKALISE_API_TOKEN", "secret")
+
+	oldFactory := newLokaliseTranslationDownloader
+	defer func() {
+		newLokaliseTranslationDownloader = oldFactory
+	}()
+	newLokaliseTranslationDownloader = func(lokalise.Config) (lokaliseTranslationDownloader, error) {
+		return &fakeLokaliseTranslationDownloader{
+			files: []lokalise.TranslationFile{{Locale: "fr", Name: "fr.json", Content: []byte(`{"hello":"Bonjour"}`)}},
+		}, nil
+	}
+
+	outputPath := filepath.Join(t.TempDir(), "fr.json")
+	if err := os.WriteFile(outputPath, []byte("existing"), 0o644); err != nil {
+		t.Fatalf("write existing output: %v", err)
+	}
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"lokalise", "download", "translations", "--project-id", "project-1", "--target-locale", "fr", "--format", "json", "--output", outputPath, "--force"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute lokalise download translations: %v", err)
+	}
+	content, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if got, want := string(content), `{"hello":"Bonjour"}`; got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
 func TestLokaliseDownloadTranslationsRequiresInputs(t *testing.T) {
 	t.Chdir(t.TempDir())
 
@@ -242,6 +278,25 @@ func TestLokaliseDownloadTranslationsRequiresInputs(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "--project-id") {
 		t.Fatalf("error = %v, want --project-id", err)
+	}
+}
+
+func TestLokaliseDownloadTranslationsRequiresTargetLocaleBeforeOptionalConfigError(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("LOKALISE_API_TOKEN", "secret")
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"lokalise", "download", "translations", "--project-id", "project-1", "--format", "json"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "at least one --target-locale is required") {
+		t.Fatalf("error = %v, want target locale requirement", err)
+	}
+	if strings.Contains(err.Error(), "load config") {
+		t.Fatalf("error = %v, should not surface optional config load failure", err)
 	}
 }
 

--- a/apps/cli/cmd/lokalise_test.go
+++ b/apps/cli/cmd/lokalise_test.go
@@ -263,6 +263,81 @@ func TestLokaliseDownloadTranslationsForceOverwritesExistingOutput(t *testing.T)
 	}
 }
 
+func TestLokaliseDownloadTranslationsForceRemovesOverwrittenOutputOnLaterFailure(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("LOKALISE_API_TOKEN", "secret")
+
+	dir := t.TempDir()
+	frPath := filepath.Join(dir, "fr.json")
+	dePath := filepath.Join(dir, "de.json")
+	if err := os.WriteFile(frPath, []byte("existing"), 0o644); err != nil {
+		t.Fatalf("write existing output: %v", err)
+	}
+
+	oldFactory := newLokaliseTranslationDownloader
+	defer func() {
+		newLokaliseTranslationDownloader = oldFactory
+	}()
+	newLokaliseTranslationDownloader = func(lokalise.Config) (lokaliseTranslationDownloader, error) {
+		return &fakeLokaliseTranslationDownloader{
+			files: []lokalise.TranslationFile{
+				{Locale: "fr", Name: "fr.json", Content: []byte(`{"hello":"Bonjour"}`)},
+				{Locale: "de", Name: "de.json", Content: []byte(`{"hello":"Hallo"}`)},
+			},
+			beforeReturn: func() {
+				if err := os.Mkdir(dePath, 0o755); err != nil {
+					t.Fatalf("create conflicting output directory: %v", err)
+				}
+			},
+		}, nil
+	}
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"lokalise", "download", "translations", "--project-id", "project-1", "--target-locale", "fr,de", "--format", "json", "--output", filepath.Join(dir, "%locale%.json"), "--force"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "is a directory") {
+		t.Fatalf("error = %v, want later output write failure", err)
+	}
+	if _, err := os.Stat(frPath); !os.IsNotExist(err) {
+		t.Fatalf("fr output should be removed after partial failure, stat err = %v", err)
+	}
+}
+
+func TestLokaliseDownloadTranslationsPrintsAPIWarning(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("LOKALISE_API_TOKEN", "secret")
+
+	oldFactory := newLokaliseTranslationDownloader
+	defer func() {
+		newLokaliseTranslationDownloader = oldFactory
+	}()
+	newLokaliseTranslationDownloader = func(lokalise.Config) (lokaliseTranslationDownloader, error) {
+		return &fakeLokaliseTranslationDownloader{
+			files:   []lokalise.TranslationFile{{Locale: "fr", Name: "fr.json", Content: []byte(`{"hello":"Bonjour"}`)}},
+			warning: "some translations are incomplete",
+		}, nil
+	}
+
+	outputPath := filepath.Join(t.TempDir(), "fr.json")
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	errOut := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(errOut)
+	cmd.SetArgs([]string{"lokalise", "download", "translations", "--project-id", "project-1", "--target-locale", "fr", "--format", "json", "--output", outputPath})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute lokalise download translations: %v", err)
+	}
+	if got := errOut.String(); !strings.Contains(got, "warning: some translations are incomplete") {
+		t.Fatalf("stderr = %q, want API warning", got)
+	}
+}
+
 func TestLokaliseDownloadTranslationsRequiresInputs(t *testing.T) {
 	t.Chdir(t.TempDir())
 
@@ -443,9 +518,11 @@ func (f *fakeLokaliseGlossaryCSVWriter) WriteGlossaryCSV(_ context.Context, req 
 }
 
 type fakeLokaliseTranslationDownloader struct {
-	req   lokalise.TranslationFileDownloadRequest
-	files []lokalise.TranslationFile
-	err   error
+	req          lokalise.TranslationFileDownloadRequest
+	files        []lokalise.TranslationFile
+	warning      string
+	beforeReturn func()
+	err          error
 }
 
 func (f *fakeLokaliseTranslationDownloader) DownloadTranslationFiles(_ context.Context, req lokalise.TranslationFileDownloadRequest) (lokalise.TranslationFileDownloadResult, error) {
@@ -453,5 +530,11 @@ func (f *fakeLokaliseTranslationDownloader) DownloadTranslationFiles(_ context.C
 	if f.err != nil {
 		return lokalise.TranslationFileDownloadResult{}, f.err
 	}
-	return lokalise.TranslationFileDownloadResult{Files: append([]lokalise.TranslationFile(nil), f.files...)}, nil
+	if f.beforeReturn != nil {
+		f.beforeReturn()
+	}
+	return lokalise.TranslationFileDownloadResult{
+		Files:   append([]lokalise.TranslationFile(nil), f.files...),
+		Warning: f.warning,
+	}, nil
 }

--- a/apps/cli/cmd/lokalise_test.go
+++ b/apps/cli/cmd/lokalise_test.go
@@ -144,7 +144,7 @@ storage:
 		files: []lokalise.TranslationFile{{Locale: "fr", Name: "fr.json", Content: []byte(`{"hello":"Bonjour"}`)}},
 	}
 	newLokaliseTranslationDownloader = func(cfg lokalise.Config) (lokaliseTranslationDownloader, error) {
-		if cfg.ProjectID != "project-from-config" || cfg.APIToken != "secret" {
+		if cfg.ProjectID != "project-from-config" || cfg.APIToken != "secret" || cfg.APITokenEnv != "LOKALISE_TEST_TOKEN" {
 			t.Fatalf("config = %#v, want project/token from config", cfg)
 		}
 		return fake, nil

--- a/internal/i18n/storage/lokalise/BUILD.bazel
+++ b/internal/i18n/storage/lokalise/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "lokalise",
@@ -7,6 +7,16 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//internal/i18n/locales",
+        "//internal/i18n/storage",
+        "@com_github_lokalise_go_lokalise_api_v5//:go-lokalise-api",
+    ],
+)
+
+go_test(
+    name = "lokalise_test",
+    srcs = glob(["*_test.go"]),
+    embed = [":lokalise"],
+    deps = [
         "//internal/i18n/storage",
         "@com_github_lokalise_go_lokalise_api_v5//:go-lokalise-api",
     ],

--- a/internal/i18n/storage/lokalise/BUILD.bazel
+++ b/internal/i18n/storage/lokalise/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/hyperlocalise/hyperlocalise/internal/i18n/storage/lokalise",
     visibility = ["//visibility:public"],
     deps = [
+        "//internal/i18n/locales",
         "//internal/i18n/storage",
         "@com_github_lokalise_go_lokalise_api_v5//:go-lokalise-api",
     ],

--- a/internal/i18n/storage/lokalise/file_download.go
+++ b/internal/i18n/storage/lokalise/file_download.go
@@ -15,6 +15,8 @@ import (
 
 const defaultTranslationBundleStructure = "%LANG_ISO%.%FORMAT%"
 
+var maxTranslationBundleBytes int64 = 256 << 20
+
 // TranslationFileDownloadRequest identifies a Lokalise file export.
 type TranslationFileDownloadRequest struct {
 	ProjectID       string
@@ -112,9 +114,12 @@ func (c *HTTPClient) downloadURL(ctx context.Context, rawURL string) ([]byte, er
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("download lokalise bundle: unexpected status %s", resp.Status)
 	}
-	payload, err := io.ReadAll(resp.Body)
+	payload, err := io.ReadAll(io.LimitReader(resp.Body, maxTranslationBundleBytes+1))
 	if err != nil {
 		return nil, fmt.Errorf("read lokalise bundle: %w", err)
+	}
+	if int64(len(payload)) > maxTranslationBundleBytes {
+		return nil, fmt.Errorf("read lokalise bundle: bundle too large (max %d bytes)", maxTranslationBundleBytes)
 	}
 	return payload, nil
 }

--- a/internal/i18n/storage/lokalise/file_download.go
+++ b/internal/i18n/storage/lokalise/file_download.go
@@ -168,9 +168,12 @@ func readZipFile(file *zip.File) ([]byte, error) {
 	defer func() {
 		_ = reader.Close()
 	}()
-	content, err := io.ReadAll(reader)
+	content, err := io.ReadAll(io.LimitReader(reader, maxTranslationBundleBytes+1))
 	if err != nil {
 		return nil, fmt.Errorf("read lokalise bundle file %q: %w", file.Name, err)
+	}
+	if int64(len(content)) > maxTranslationBundleBytes {
+		return nil, fmt.Errorf("read lokalise bundle file %q: file too large (max %d bytes)", file.Name, maxTranslationBundleBytes)
 	}
 	return content, nil
 }

--- a/internal/i18n/storage/lokalise/file_download.go
+++ b/internal/i18n/storage/lokalise/file_download.go
@@ -16,8 +16,10 @@ import (
 
 const defaultTranslationBundleStructure = "%LANG_ISO%.%FORMAT%"
 
-var maxTranslationBundleBytes int64 = 256 << 20
-var maxTranslationEntryBytes int64 = 32 << 20
+var (
+	maxTranslationBundleBytes int64 = 256 << 20
+	maxTranslationEntryBytes  int64 = 32 << 20
+)
 
 // TranslationFileDownloadRequest identifies a Lokalise file export.
 type TranslationFileDownloadRequest struct {

--- a/internal/i18n/storage/lokalise/file_download.go
+++ b/internal/i18n/storage/lokalise/file_download.go
@@ -17,6 +17,7 @@ import (
 const defaultTranslationBundleStructure = "%LANG_ISO%.%FORMAT%"
 
 var maxTranslationBundleBytes int64 = 256 << 20
+var maxTranslationEntryBytes int64 = 32 << 20
 
 // TranslationFileDownloadRequest identifies a Lokalise file export.
 type TranslationFileDownloadRequest struct {
@@ -169,12 +170,12 @@ func readZipFile(file *zip.File) ([]byte, error) {
 	defer func() {
 		_ = reader.Close()
 	}()
-	content, err := io.ReadAll(io.LimitReader(reader, maxTranslationBundleBytes+1))
+	content, err := io.ReadAll(io.LimitReader(reader, maxTranslationEntryBytes+1))
 	if err != nil {
 		return nil, fmt.Errorf("read lokalise bundle file %q: %w", file.Name, err)
 	}
-	if int64(len(content)) > maxTranslationBundleBytes {
-		return nil, fmt.Errorf("read lokalise bundle file %q: file too large (max %d bytes)", file.Name, maxTranslationBundleBytes)
+	if int64(len(content)) > maxTranslationEntryBytes {
+		return nil, fmt.Errorf("read lokalise bundle file %q: file too large (max %d bytes)", file.Name, maxTranslationEntryBytes)
 	}
 	return content, nil
 }

--- a/internal/i18n/storage/lokalise/file_download.go
+++ b/internal/i18n/storage/lokalise/file_download.go
@@ -49,8 +49,8 @@ func (c *HTTPClient) DownloadTranslationFiles(ctx context.Context, req Translati
 	if projectID == "" {
 		return TranslationFileDownloadResult{}, fmt.Errorf("lokalise translation download: project id is required")
 	}
-	locales := normalizeTranslationDownloadLanguages(req.TargetLanguages)
-	if len(locales) == 0 {
+	targetLocales := normalizeTranslationDownloadLanguages(req.TargetLanguages)
+	if len(targetLocales) == 0 {
 		return TranslationFileDownloadResult{}, fmt.Errorf("lokalise translation download: at least one target locale is required")
 	}
 	format := normalizeTranslationDownloadFormat(req.Format)
@@ -72,7 +72,7 @@ func (c *HTTPClient) DownloadTranslationFiles(ctx context.Context, req Translati
 		Format:            format,
 		OriginalFilenames: &originalFilenames,
 		BundleStructure:   bundleStructure,
-		FilterLangs:       locales,
+		FilterLangs:       targetLocales,
 	})
 	if err != nil {
 		return TranslationFileDownloadResult{}, fmt.Errorf("request lokalise translation download: %w", err)
@@ -85,7 +85,7 @@ func (c *HTTPClient) DownloadTranslationFiles(ctx context.Context, req Translati
 	if err != nil {
 		return TranslationFileDownloadResult{}, err
 	}
-	files, err := extractLokaliseTranslationBundle(payload, locales, format, bundleStructure)
+	files, err := extractLokaliseTranslationBundle(payload, targetLocales, format, bundleStructure)
 	if err != nil {
 		return TranslationFileDownloadResult{}, err
 	}
@@ -125,7 +125,7 @@ func (c *HTTPClient) downloadURL(ctx context.Context, rawURL string) ([]byte, er
 	return payload, nil
 }
 
-func extractLokaliseTranslationBundle(payload []byte, locales []string, format, bundleStructure string) ([]TranslationFile, error) {
+func extractLokaliseTranslationBundle(payload []byte, targetLocales []string, format, bundleStructure string) ([]TranslationFile, error) {
 	reader, err := zip.NewReader(bytes.NewReader(payload), int64(len(payload)))
 	if err != nil {
 		return nil, fmt.Errorf("read lokalise translation bundle: %w", err)
@@ -141,8 +141,8 @@ func extractLokaliseTranslationBundle(payload []byte, locales []string, format, 
 		return nil, fmt.Errorf("lokalise translation download: downloaded bundle did not contain files")
 	}
 
-	files := make([]TranslationFile, 0, len(locales))
-	for _, locale := range locales {
+	files := make([]TranslationFile, 0, len(targetLocales))
+	for _, locale := range targetLocales {
 		expectedName := renderLokaliseBundlePath(bundleStructure, locale, format)
 		file, ok := byName[expectedName]
 		if !ok {

--- a/internal/i18n/storage/lokalise/file_download.go
+++ b/internal/i18n/storage/lokalise/file_download.go
@@ -1,0 +1,209 @@
+package lokalise
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+
+	lokaliseapi "github.com/lokalise/go-lokalise-api/v5"
+)
+
+const defaultTranslationBundleStructure = "%LANG_ISO%.%FORMAT%"
+
+// TranslationFileDownloadRequest identifies a Lokalise file export.
+type TranslationFileDownloadRequest struct {
+	ProjectID       string
+	TargetLanguages []string
+	Format          string
+	BundleStructure string
+}
+
+// TranslationFile is one extracted file from a Lokalise download bundle.
+type TranslationFile struct {
+	Locale  string
+	Name    string
+	Content []byte
+}
+
+// TranslationFileDownloadResult summarizes a Lokalise translation file export.
+type TranslationFileDownloadResult struct {
+	Files     []TranslationFile
+	BundleURL string
+	Warning   string
+}
+
+// DownloadTranslationFiles downloads a Lokalise file export and extracts one file per requested locale.
+func (c *HTTPClient) DownloadTranslationFiles(ctx context.Context, req TranslationFileDownloadRequest) (TranslationFileDownloadResult, error) {
+	if c == nil || c.api == nil {
+		return TranslationFileDownloadResult{}, fmt.Errorf("lokalise translation download: client is nil")
+	}
+	projectID := strings.TrimSpace(req.ProjectID)
+	if projectID == "" {
+		return TranslationFileDownloadResult{}, fmt.Errorf("lokalise translation download: project id is required")
+	}
+	locales := normalizeTranslationDownloadLanguages(req.TargetLanguages)
+	if len(locales) == 0 {
+		return TranslationFileDownloadResult{}, fmt.Errorf("lokalise translation download: at least one target locale is required")
+	}
+	format := normalizeTranslationDownloadFormat(req.Format)
+	if format == "" {
+		return TranslationFileDownloadResult{}, fmt.Errorf("lokalise translation download: format is required")
+	}
+	bundleStructure := strings.TrimSpace(req.BundleStructure)
+	if bundleStructure == "" {
+		bundleStructure = defaultTranslationBundleStructure
+	}
+	if !strings.Contains(bundleStructure, "%LANG_ISO%") {
+		return TranslationFileDownloadResult{}, fmt.Errorf("lokalise translation download: bundle structure must include %%LANG_ISO%%")
+	}
+
+	filesSvc := c.api.Files()
+	filesSvc.SetContext(ctx)
+	originalFilenames := false
+	download, err := filesSvc.Download(projectID, lokaliseapi.FileDownload{
+		Format:            format,
+		OriginalFilenames: &originalFilenames,
+		BundleStructure:   bundleStructure,
+		FilterLangs:       locales,
+	})
+	if err != nil {
+		return TranslationFileDownloadResult{}, fmt.Errorf("request lokalise translation download: %w", err)
+	}
+	if strings.TrimSpace(download.BundleURL) == "" {
+		return TranslationFileDownloadResult{}, fmt.Errorf("lokalise translation download: response did not include bundle URL")
+	}
+
+	payload, err := c.downloadURL(ctx, download.BundleURL)
+	if err != nil {
+		return TranslationFileDownloadResult{}, err
+	}
+	files, err := extractLokaliseTranslationBundle(payload, locales, format, bundleStructure)
+	if err != nil {
+		return TranslationFileDownloadResult{}, err
+	}
+	return TranslationFileDownloadResult{
+		Files:     files,
+		BundleURL: download.BundleURL,
+		Warning:   download.Warning,
+	}, nil
+}
+
+func (c *HTTPClient) downloadURL(ctx context.Context, rawURL string) ([]byte, error) {
+	httpClient := c.httpClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create lokalise bundle request: %w", err)
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("download lokalise bundle: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("download lokalise bundle: unexpected status %s", resp.Status)
+	}
+	payload, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read lokalise bundle: %w", err)
+	}
+	return payload, nil
+}
+
+func extractLokaliseTranslationBundle(payload []byte, locales []string, format, bundleStructure string) ([]TranslationFile, error) {
+	reader, err := zip.NewReader(bytes.NewReader(payload), int64(len(payload)))
+	if err != nil {
+		return nil, fmt.Errorf("read lokalise translation bundle: %w", err)
+	}
+	byName := make(map[string]*zip.File, len(reader.File))
+	for _, file := range reader.File {
+		if file == nil || file.FileInfo().IsDir() {
+			continue
+		}
+		byName[normalizeBundlePath(file.Name)] = file
+	}
+	if len(byName) == 0 {
+		return nil, fmt.Errorf("lokalise translation download: downloaded bundle did not contain files")
+	}
+
+	files := make([]TranslationFile, 0, len(locales))
+	for _, locale := range locales {
+		expectedName := renderLokaliseBundlePath(bundleStructure, locale, format)
+		file, ok := byName[expectedName]
+		if !ok {
+			return nil, fmt.Errorf("lokalise translation download: downloaded bundle did not include locale %q at %q", locale, expectedName)
+		}
+		content, err := readZipFile(file)
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, TranslationFile{
+			Locale:  locale,
+			Name:    expectedName,
+			Content: content,
+		})
+	}
+	return files, nil
+}
+
+func readZipFile(file *zip.File) ([]byte, error) {
+	reader, err := file.Open()
+	if err != nil {
+		return nil, fmt.Errorf("open lokalise bundle file %q: %w", file.Name, err)
+	}
+	defer func() {
+		_ = reader.Close()
+	}()
+	content, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("read lokalise bundle file %q: %w", file.Name, err)
+	}
+	return content, nil
+}
+
+func renderLokaliseBundlePath(pattern, locale, format string) string {
+	rendered := strings.ReplaceAll(pattern, "%LANG_ISO%", locale)
+	rendered = strings.ReplaceAll(rendered, "%FORMAT%", normalizeTranslationDownloadFormat(format))
+	return normalizeBundlePath(rendered)
+}
+
+func normalizeBundlePath(path string) string {
+	return strings.TrimLeft(filepath.ToSlash(strings.TrimSpace(path)), "/")
+}
+
+func normalizeTranslationDownloadFormat(format string) string {
+	trimmed := strings.TrimPrefix(strings.TrimSpace(format), ".")
+	if strings.EqualFold(trimmed, "yml") {
+		return "yaml"
+	}
+	return trimmed
+}
+
+func normalizeTranslationDownloadLanguages(languages []string) []string {
+	normalized := make([]string, 0, len(languages))
+	seen := make(map[string]struct{}, len(languages))
+	for _, language := range languages {
+		for _, part := range strings.Split(language, ",") {
+			trimmed := strings.TrimSpace(part)
+			if trimmed == "" {
+				continue
+			}
+			key := strings.ToLower(trimmed)
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			normalized = append(normalized, trimmed)
+		}
+	}
+	return normalized
+}

--- a/internal/i18n/storage/lokalise/file_download.go
+++ b/internal/i18n/storage/lokalise/file_download.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/locales"
 	lokaliseapi "github.com/lokalise/go-lokalise-api/v5"
 )
 
@@ -197,21 +198,5 @@ func normalizeTranslationDownloadFormat(format string) string {
 }
 
 func normalizeTranslationDownloadLanguages(languages []string) []string {
-	normalized := make([]string, 0, len(languages))
-	seen := make(map[string]struct{}, len(languages))
-	for _, language := range languages {
-		for _, part := range strings.Split(language, ",") {
-			trimmed := strings.TrimSpace(part)
-			if trimmed == "" {
-				continue
-			}
-			key := strings.ToLower(trimmed)
-			if _, ok := seen[key]; ok {
-				continue
-			}
-			seen[key] = struct{}{}
-			normalized = append(normalized, trimmed)
-		}
-	}
-	return normalized
+	return locales.NormalizeList(languages)
 }

--- a/internal/i18n/storage/lokalise/file_download_test.go
+++ b/internal/i18n/storage/lokalise/file_download_test.go
@@ -1,0 +1,211 @@
+package lokalise
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestDownloadTranslationFilesExtractsRequestedLocales(t *testing.T) {
+	client, mux, baseURL, teardown := newLokaliseTranslationDownloadClientForTest(t)
+	defer teardown()
+
+	mux.HandleFunc("/api2/projects/project-1/files/download", func(w http.ResponseWriter, r *http.Request) {
+		assertLokaliseDownloadRequest(t, r)
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if got, want := body["format"], "json"; got != want {
+			t.Fatalf("format = %#v, want %#v", got, want)
+		}
+		if got, want := body["original_filenames"], false; got != want {
+			t.Fatalf("original_filenames = %#v, want %#v", got, want)
+		}
+		if got, want := body["bundle_structure"], "%LANG_ISO%.%FORMAT%"; got != want {
+			t.Fatalf("bundle_structure = %#v, want %#v", got, want)
+		}
+		gotLangs := stringSliceFromJSON(t, body["filter_langs"])
+		if want := []string{"fr", "de"}; !reflect.DeepEqual(gotLangs, want) {
+			t.Fatalf("filter_langs = %#v, want %#v", gotLangs, want)
+		}
+		writeLokaliseJSON(t, w, map[string]any{
+			"project_id": "project-1",
+			"bundle_url": baseURL + "/bundle.zip",
+		})
+	})
+	mux.HandleFunc("/bundle.zip", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/zip")
+		_, _ = w.Write(lokaliseZipFixture(t, map[string]string{
+			"fr.json": `{"hello":"Bonjour"}`,
+			"de.json": `{"hello":"Hallo"}`,
+		}))
+	})
+
+	result, err := client.DownloadTranslationFiles(context.Background(), TranslationFileDownloadRequest{
+		ProjectID:       "project-1",
+		TargetLanguages: []string{"fr", "de"},
+		Format:          "json",
+	})
+	if err != nil {
+		t.Fatalf("download translations: %v", err)
+	}
+	if result.BundleURL != baseURL+"/bundle.zip" {
+		t.Fatalf("bundle URL = %q", result.BundleURL)
+	}
+	if len(result.Files) != 2 {
+		t.Fatalf("files = %#v, want 2", result.Files)
+	}
+	if got, want := result.Files[0].Locale, "fr"; got != want {
+		t.Fatalf("first locale = %q, want %q", got, want)
+	}
+	if got, want := string(result.Files[0].Content), `{"hello":"Bonjour"}`; got != want {
+		t.Fatalf("first content = %q, want %q", got, want)
+	}
+	if got, want := result.Files[1].Locale, "de"; got != want {
+		t.Fatalf("second locale = %q, want %q", got, want)
+	}
+}
+
+func TestDownloadTranslationFilesUsesCustomBundleStructure(t *testing.T) {
+	client, mux, baseURL, teardown := newLokaliseTranslationDownloadClientForTest(t)
+	defer teardown()
+
+	mux.HandleFunc("/api2/projects/project-1/files/download", func(w http.ResponseWriter, r *http.Request) {
+		assertLokaliseDownloadRequest(t, r)
+		writeLokaliseJSON(t, w, map[string]any{
+			"project_id": "project-1",
+			"bundle_url": baseURL + "/bundle.zip",
+		})
+	})
+	mux.HandleFunc("/bundle.zip", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(lokaliseZipFixture(t, map[string]string{
+			"locales/fr/messages.yaml": "hello: Bonjour\n",
+		}))
+	})
+
+	result, err := client.DownloadTranslationFiles(context.Background(), TranslationFileDownloadRequest{
+		ProjectID:       "project-1",
+		TargetLanguages: []string{"fr"},
+		Format:          ".yml",
+		BundleStructure: "locales/%LANG_ISO%/messages.%FORMAT%",
+	})
+	if err != nil {
+		t.Fatalf("download translations: %v", err)
+	}
+	if got, want := result.Files[0].Name, "locales/fr/messages.yaml"; got != want {
+		t.Fatalf("bundle path = %q, want %q", got, want)
+	}
+}
+
+func TestDownloadTranslationFilesReturnsAPIError(t *testing.T) {
+	client, mux, _, teardown := newLokaliseTranslationDownloadClientForTest(t)
+	defer teardown()
+
+	mux.HandleFunc("/api2/projects/project-1/files/download", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"error":{"message":"unauthorized"}}`, http.StatusUnauthorized)
+	})
+
+	_, err := client.DownloadTranslationFiles(context.Background(), TranslationFileDownloadRequest{
+		ProjectID:       "project-1",
+		TargetLanguages: []string{"fr"},
+		Format:          "json",
+	})
+	if err == nil || !strings.Contains(err.Error(), "request lokalise translation download") {
+		t.Fatalf("error = %v, want wrapped download request error", err)
+	}
+}
+
+func TestDownloadTranslationFilesErrorsWhenLocaleMissingFromBundle(t *testing.T) {
+	client, mux, baseURL, teardown := newLokaliseTranslationDownloadClientForTest(t)
+	defer teardown()
+
+	mux.HandleFunc("/api2/projects/project-1/files/download", func(w http.ResponseWriter, _ *http.Request) {
+		writeLokaliseJSON(t, w, map[string]any{
+			"project_id": "project-1",
+			"bundle_url": baseURL + "/bundle.zip",
+		})
+	})
+	mux.HandleFunc("/bundle.zip", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(lokaliseZipFixture(t, map[string]string{
+			"de.json": `{"hello":"Hallo"}`,
+		}))
+	})
+
+	_, err := client.DownloadTranslationFiles(context.Background(), TranslationFileDownloadRequest{
+		ProjectID:       "project-1",
+		TargetLanguages: []string{"fr"},
+		Format:          "json",
+	})
+	if err == nil || !strings.Contains(err.Error(), `did not include locale "fr"`) {
+		t.Fatalf("error = %v, want missing locale error", err)
+	}
+}
+
+func newLokaliseTranslationDownloadClientForTest(t *testing.T) (*HTTPClient, *http.ServeMux, string, func()) {
+	t.Helper()
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	client, err := NewHTTPClient(Config{
+		APIToken:       "token",
+		APIBaseURL:     server.URL + "/api2",
+		TimeoutSeconds: 1,
+	})
+	if err != nil {
+		t.Fatalf("new http client: %v", err)
+	}
+	return client, mux, server.URL, server.Close
+}
+
+func assertLokaliseDownloadRequest(t *testing.T, r *http.Request) {
+	t.Helper()
+	if r.Method != http.MethodPost {
+		t.Fatalf("method = %s, want POST", r.Method)
+	}
+	if token := r.Header.Get("X-Api-Token"); token != "token" {
+		t.Fatalf("X-Api-Token = %q, want token", token)
+	}
+}
+
+func stringSliceFromJSON(t *testing.T, value any) []string {
+	t.Helper()
+	raw, ok := value.([]any)
+	if !ok {
+		t.Fatalf("value = %#v, want JSON array", value)
+	}
+	out := make([]string, 0, len(raw))
+	for _, item := range raw {
+		itemString, ok := item.(string)
+		if !ok {
+			t.Fatalf("array item = %#v, want string", item)
+		}
+		out = append(out, itemString)
+	}
+	return out
+}
+
+func lokaliseZipFixture(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zipWriter := zip.NewWriter(&buf)
+	for name, content := range files {
+		file, err := zipWriter.Create(name)
+		if err != nil {
+			t.Fatalf("create zip file %q: %v", name, err)
+		}
+		if _, err := fmt.Fprint(file, content); err != nil {
+			t.Fatalf("write zip file %q: %v", name, err)
+		}
+	}
+	if err := zipWriter.Close(); err != nil {
+		t.Fatalf("close zip: %v", err)
+	}
+	return buf.Bytes()
+}

--- a/internal/i18n/storage/lokalise/file_download_test.go
+++ b/internal/i18n/storage/lokalise/file_download_test.go
@@ -210,10 +210,10 @@ func TestDownloadTranslationFilesErrorsWhenBundleTooLarge(t *testing.T) {
 }
 
 func TestExtractTranslationBundleErrorsWhenEntryTooLarge(t *testing.T) {
-	oldLimit := maxTranslationBundleBytes
-	maxTranslationBundleBytes = 4
+	oldLimit := maxTranslationEntryBytes
+	maxTranslationEntryBytes = 4
 	defer func() {
-		maxTranslationBundleBytes = oldLimit
+		maxTranslationEntryBytes = oldLimit
 	}()
 
 	payload := lokaliseZipFixture(t, map[string]string{

--- a/internal/i18n/storage/lokalise/file_download_test.go
+++ b/internal/i18n/storage/lokalise/file_download_test.go
@@ -105,6 +105,36 @@ func TestDownloadTranslationFilesUsesCustomBundleStructure(t *testing.T) {
 	}
 }
 
+func TestDownloadTranslationFilesPreservesEscapedBranchProjectID(t *testing.T) {
+	client, mux, baseURL, teardown := newLokaliseTranslationDownloadClientForTest(t)
+	defer teardown()
+
+	mux.HandleFunc("/api2/projects/", func(w http.ResponseWriter, r *http.Request) {
+		assertLokaliseDownloadRequest(t, r)
+		if got, want := r.URL.EscapedPath(), "/api2/projects/project-1:feature%2Fmy-branch/files/download"; got != want {
+			t.Fatalf("escaped path = %q, want %q", got, want)
+		}
+		writeLokaliseJSON(t, w, map[string]any{
+			"project_id": "project-1:feature%2Fmy-branch",
+			"bundle_url": baseURL + "/bundle.zip",
+		})
+	})
+	mux.HandleFunc("/bundle.zip", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(lokaliseZipFixture(t, map[string]string{
+			"fr.json": `{"hello":"Bonjour"}`,
+		}))
+	})
+
+	_, err := client.DownloadTranslationFiles(context.Background(), TranslationFileDownloadRequest{
+		ProjectID:       "project-1:feature%2Fmy-branch",
+		TargetLanguages: []string{"fr"},
+		Format:          "json",
+	})
+	if err != nil {
+		t.Fatalf("download translations: %v", err)
+	}
+}
+
 func TestDownloadTranslationFilesReturnsAPIError(t *testing.T) {
 	client, mux, _, teardown := newLokaliseTranslationDownloadClientForTest(t)
 	defer teardown()

--- a/internal/i18n/storage/lokalise/file_download_test.go
+++ b/internal/i18n/storage/lokalise/file_download_test.go
@@ -179,6 +179,23 @@ func TestDownloadTranslationFilesErrorsWhenBundleTooLarge(t *testing.T) {
 	}
 }
 
+func TestExtractTranslationBundleErrorsWhenEntryTooLarge(t *testing.T) {
+	oldLimit := maxTranslationBundleBytes
+	maxTranslationBundleBytes = 4
+	defer func() {
+		maxTranslationBundleBytes = oldLimit
+	}()
+
+	payload := lokaliseZipFixture(t, map[string]string{
+		"fr.json": "12345",
+	})
+
+	_, err := extractLokaliseTranslationBundle(payload, []string{"fr"}, "json", defaultTranslationBundleStructure)
+	if err == nil || !strings.Contains(err.Error(), "file too large") {
+		t.Fatalf("error = %v, want file too large", err)
+	}
+}
+
 func newLokaliseTranslationDownloadClientForTest(t *testing.T) (*HTTPClient, *http.ServeMux, string, func()) {
 	t.Helper()
 	mux := http.NewServeMux()

--- a/internal/i18n/storage/lokalise/file_download_test.go
+++ b/internal/i18n/storage/lokalise/file_download_test.go
@@ -149,6 +149,36 @@ func TestDownloadTranslationFilesErrorsWhenLocaleMissingFromBundle(t *testing.T)
 	}
 }
 
+func TestDownloadTranslationFilesErrorsWhenBundleTooLarge(t *testing.T) {
+	client, mux, baseURL, teardown := newLokaliseTranslationDownloadClientForTest(t)
+	defer teardown()
+
+	oldLimit := maxTranslationBundleBytes
+	maxTranslationBundleBytes = 4
+	defer func() {
+		maxTranslationBundleBytes = oldLimit
+	}()
+
+	mux.HandleFunc("/api2/projects/project-1/files/download", func(w http.ResponseWriter, _ *http.Request) {
+		writeLokaliseJSON(t, w, map[string]any{
+			"project_id": "project-1",
+			"bundle_url": baseURL + "/bundle.zip",
+		})
+	})
+	mux.HandleFunc("/bundle.zip", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("12345"))
+	})
+
+	_, err := client.DownloadTranslationFiles(context.Background(), TranslationFileDownloadRequest{
+		ProjectID:       "project-1",
+		TargetLanguages: []string{"fr"},
+		Format:          "json",
+	})
+	if err == nil || !strings.Contains(err.Error(), "bundle too large") {
+		t.Fatalf("error = %v, want bundle too large", err)
+	}
+}
+
 func newLokaliseTranslationDownloadClientForTest(t *testing.T) (*HTTPClient, *http.ServeMux, string, func()) {
 	t.Helper()
 	mux := http.NewServeMux()


### PR DESCRIPTION
## Summary
- Add `lokalise download translations` with project/locale/format inputs, config fallback, dry-run, force overwrite, stdout, and `%locale%` output patterns.
- Implement Lokalise file export via the files download API using `format`, `original_filenames=false`, `bundle_structure`, and `filter_langs`.
- Download the returned ZIP bundle URL and extract one file per requested locale with clear errors for missing locales, empty bundles, API failures, auth failures, and missing config.

## API check
- Verified against Lokalise's file download endpoint: `POST /projects/{project_id}:{branch}/files/download`, which exports a ZIP bundle URL and accepts `format`, `original_filenames`, `bundle_structure`, and `filter_langs`.
- Confirmed the repo's `go-lokalise-api/v5` dependency exposes the matching `FileDownload` request fields and `FileDownloadResponse.BundleURL`.

## Validation
- `go test ./internal/i18n/storage/lokalise`
- `go test ./apps/cli/cmd -run "TestLokalise"`
- `go test ./internal/i18n/storage/...`
- `go test ./apps/cli/cmd` still fails on existing unrelated Windows path/permission-sensitive tests outside this change.