### PR TITLE
🎨 Palette: Chat and Search UX Polish

### DIFF
--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/agent/_components/github-agent-card.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/agent/_components/github-agent-card.tsx
@@ -349,7 +349,8 @@ export function GitHubAgentCard({ organizationSlug }: GitHubAgentCardProps) {
                     value={query}
                     onChange={(event) => setQuery(event.target.value)}
                     placeholder="Search repositories"
-                    className="h-10 w-full rounded-lg border border-foreground/10 bg-foreground/3 px-9 text-sm text-foreground outline-none placeholder:text-foreground/32 focus:border-foreground/20"
+                    aria-label="Search repositories"
+                    className="h-10 w-full rounded-lg border border-foreground/10 bg-foreground/3 px-9 text-sm text-foreground transition-all outline-none placeholder:text-foreground/32 focus:border-foreground/20 focus:ring-[3px] focus:ring-ring/50"
                   />
                 </div>
                 <Button

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/chat/_components/chat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/chat/_components/chat-page-content.tsx
@@ -29,6 +29,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Kbd } from "@/components/ui/kbd";
 import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
@@ -174,7 +175,7 @@ export function ChatPageContent({ organizationSlug }: { organizationSlug: string
               chatRequestMutation.mutate();
             }
           }}
-          className="overflow-hidden rounded-[1.35rem] bg-muted text-foreground shadow-2xl shadow-black/10"
+          className="overflow-hidden rounded-[1.35rem] bg-muted text-foreground shadow-2xl shadow-black/10 transition-all focus-within:ring-[3px] focus-within:ring-ring/50"
         >
           <label htmlFor="inbox-request" className="sr-only">
             Translation request
@@ -356,19 +357,29 @@ export function ChatPageContent({ organizationSlug }: { organizationSlug: string
                   </DropdownMenuGroup>
                 </DropdownMenuContent>
               </DropdownMenu>
-              <Button
-                type="submit"
-                disabled={!canSubmit}
-                className="rounded-full bg-primary text-primary-foreground hover:bg-primary/90"
-                aria-label="Send translation request"
-              >
-                {chatRequestMutation.isPending ? (
-                  <Spinner className="text-primary-foreground" />
-                ) : (
-                  <HugeiconsIcon icon={SentIcon} strokeWidth={2} />
-                )}
-                Send
-              </Button>
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      type="submit"
+                      disabled={!canSubmit}
+                      className="rounded-full bg-primary text-primary-foreground hover:bg-primary/90"
+                      aria-label="Send translation request"
+                    />
+                  }
+                >
+                  {chatRequestMutation.isPending ? (
+                    <Spinner className="text-primary-foreground" />
+                  ) : (
+                    <HugeiconsIcon icon={SentIcon} strokeWidth={2} />
+                  )}
+                  Send
+                </TooltipTrigger>
+                <TooltipContent side="top" align="end">
+                  Send request
+                  <Kbd className="ms-2 bg-background/20 text-background">Enter</Kbd>
+                </TooltipContent>
+              </Tooltip>
             </div>
           </div>
         </form>
@@ -384,7 +395,7 @@ export function ChatPageContent({ organizationSlug }: { organizationSlug: string
               <button
                 type="button"
                 onClick={() => setText(request.text)}
-                className="flex w-full items-start gap-3 px-4 py-3 text-left text-muted-foreground transition-colors hover:bg-muted/80 hover:text-foreground"
+                className="flex w-full items-start gap-3 px-4 py-3 text-left text-muted-foreground transition-colors hover:bg-muted/80 hover:text-foreground focus-visible:bg-muted/80 focus-visible:outline-none"
               >
                 <HugeiconsIcon
                   icon={request.icon}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/chat/_components/chat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/chat/_components/chat-page-content.tsx
@@ -175,7 +175,7 @@ export function ChatPageContent({ organizationSlug }: { organizationSlug: string
               chatRequestMutation.mutate();
             }
           }}
-          className="overflow-hidden rounded-[1.35rem] bg-muted text-foreground shadow-2xl shadow-black/10 transition-all focus-within:ring-[3px] focus-within:ring-ring/50"
+          className="overflow-hidden rounded-[1.35rem] bg-muted text-foreground shadow-2xl shadow-black/10 transition-all focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/50"
         >
           <label htmlFor="inbox-request" className="sr-only">
             Translation request
@@ -377,7 +377,7 @@ export function ChatPageContent({ organizationSlug }: { organizationSlug: string
                 </TooltipTrigger>
                 <TooltipContent side="top" align="end">
                   Send request
-                  <Kbd className="ms-2 bg-background/20 text-background">Enter</Kbd>
+                  <Kbd className="ms-2 bg-background/15 text-background">Enter</Kbd>
                 </TooltipContent>
               </Tooltip>
             </div>
@@ -395,7 +395,7 @@ export function ChatPageContent({ organizationSlug }: { organizationSlug: string
               <button
                 type="button"
                 onClick={() => setText(request.text)}
-                className="flex w-full items-start gap-3 px-4 py-3 text-left text-muted-foreground transition-colors hover:bg-muted/80 hover:text-foreground focus-visible:bg-muted/80 focus-visible:outline-none"
+                className="flex w-full items-start gap-3 px-4 py-3 text-left text-muted-foreground transition-colors outline-none hover:bg-muted/80 hover:text-foreground focus-visible:relative focus-visible:z-10 focus-visible:bg-muted/80 focus-visible:ring-[3px] focus-visible:ring-inset focus-visible:ring-ring/50"
               >
                 <HugeiconsIcon
                   icon={request.icon}


### PR DESCRIPTION
This PR introduces several micro-UX and accessibility improvements to the chat and agent interfaces.

### 💡 What
1. **Chat Interface Polish**:
   - The main chat input form now has a high-visibility focus ring (`ring-ring/50`) and smooth transitions when focused.
   - The "Send" button now features a tooltip that informs users they can press `Enter` to submit their request, improving discoverability.
   - Suggested request buttons are now keyboard-accessible with visible focus states.
2. **Search Accessibility**:
   - The repository search input in the GitHub Agent card now has a proper `aria-label`.
   - Enhanced focus ring added to the search input to match the system-wide focus pattern.

### 🎯 Why
These changes make the core interaction loops (sending a translation request and finding repositories) more intuitive and accessible. Keyboard users gain better navigation cues, and all users benefit from clearer focus indicators and shortcut hints.

### ♿ Accessibility
- Added `aria-label` to the repository search input.
- Ensured focus-visible states for all interactive suggested requests.
- Synchronized tooltips with accessible button labels.

---
*PR created automatically by Jules for task [7555856344766061628](https://jules.google.com/task/7555856344766061628) started by @cungminh2710*