### PR TITLE
🧪 Scout: support numeric ICU placeholders

### DIFF
--- a/internal/i18n/icuparser/coverage_test.go
+++ b/internal/i18n/icuparser/coverage_test.go
@@ -128,7 +128,7 @@ func TestInvariantHelpersEdgeCases(t *testing.T) {
 	if !slicesEqual([]int{1}, []int{1}) || slicesEqual([]int{1}, []int{2}) || slicesEqual([]int{1}, []int{1, 1}) {
 		t.Fatal("slicesEqual broken")
 	}
-	if isPlaceholderName("") || isPlaceholderName("9bad") || isPlaceholderName("a b") {
+	if isPlaceholderName("") || isPlaceholderName("*bad") || isPlaceholderName("a b") {
 		t.Fatal("isPlaceholderName should reject")
 	}
 }

--- a/internal/i18n/icuparser/invariant.go
+++ b/internal/i18n/icuparser/invariant.go
@@ -316,7 +316,7 @@ func isASCIIDigit(b byte) bool {
 }
 
 func isPlaceholderFirstRune(r rune) bool {
-	return isASCIILetter(r) || r == '_' || r == '$'
+	return isASCIILetter(r) || isASCIIDigitRune(r) || r == '_' || r == '$'
 }
 
 func isPlaceholderSubsequentRune(r rune) bool {

--- a/internal/i18n/icuparser/invariant_test.go
+++ b/internal/i18n/icuparser/invariant_test.go
@@ -118,3 +118,31 @@ func TestSelectArgumentInPlaceholders(t *testing.T) {
 		t.Errorf("expected 'gender' in placeholders, got %v", inv.Placeholders)
 	}
 }
+
+func TestNumericPlaceholderInPlaceholders(t *testing.T) {
+	// Numeric ICU arguments (e.g. {0}, {1}) MUST be included in the invariant's
+	// Placeholder list for tool parity.
+	msg := "{0} and {1}"
+	inv, err := ParseInvariant(msg)
+	if err != nil {
+		t.Fatalf("ParseInvariant failed: %v", err)
+	}
+
+	found0 := false
+	found1 := false
+	for _, p := range inv.Placeholders {
+		if p == "0" {
+			found0 = true
+		}
+		if p == "1" {
+			found1 = true
+		}
+	}
+
+	if !found0 {
+		t.Errorf("expected '0' in placeholders, got %v", inv.Placeholders)
+	}
+	if !found1 {
+		t.Errorf("expected '1' in placeholders, got %v", inv.Placeholders)
+	}
+}


### PR DESCRIPTION
- 💡 What: Enabled extraction of numeric ICU arguments (e.g., `{0}`, `{1}`) into the `Invariant` metadata.
- 🎯 Why: Numeric placeholders are common in ICU messages and must be identified for parity and validation.
- 🧩 Scope: `internal/i18n/icuparser/invariant.go` and its tests.
- ✅ Verification: Ran `go test -v internal/i18n/icuparser/...` and `go test ./...`.
- 🛡️ Confidence: Protects against missing placeholders in systems using numeric ICU arguments.

---
*PR created automatically by Jules for task [73418342093906865](https://jules.google.com/task/73418342093906865) started by @cungminh2710*