### PR TITLE
fix(github): include new translation files in agent commits

### DIFF
--- a/apps/hyperlocalise-web/src/workflows/github-fix.test.ts
+++ b/apps/hyperlocalise-web/src/workflows/github-fix.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+vi.mock("@/lib/agents/github/app", () => ({
+  getInstallationOctokit: vi.fn(),
+}));
+
+import { getCommittableChangedPaths } from "./github-fix";
+
+describe("github fix committable changed paths", () => {
+  it("includes modified tracked translation files", () => {
+    const paths = getCommittableChangedPaths(" M locales/en.json\0");
+
+    expect(paths).toEqual(["locales/en.json"]);
+  });
+
+  it("includes untracked translation output files", () => {
+    const paths = getCommittableChangedPaths("?? apps/web/messages/fr.json\0");
+
+    expect(paths).toEqual(["apps/web/messages/fr.json"]);
+  });
+
+  it("excludes internal Hyperlocalise reports", () => {
+    const paths = getCommittableChangedPaths(
+      [
+        "?? .hyperlocalise/fix-report.json",
+        "?? .hyperlocalise/scoped-check-report.json",
+        " M locales/en.json",
+      ].join("\0"),
+    );
+
+    expect(paths).toEqual(["locales/en.json"]);
+  });
+
+  it("returns no committable paths for report-only output", () => {
+    const paths = getCommittableChangedPaths("?? .hyperlocalise/fix-report.json\0");
+
+    expect(paths).toEqual([]);
+  });
+});

--- a/apps/hyperlocalise-web/src/workflows/github-fix.test.ts
+++ b/apps/hyperlocalise-web/src/workflows/github-fix.test.ts
@@ -25,10 +25,22 @@ describe("github fix committable changed paths", () => {
         "?? .hyperlocalise/fix-report.json",
         "?? .hyperlocalise/scoped-check-report.json",
         " M locales/en.json",
-      ].join("\0"),
+      ].join("\0") + "\0",
     );
 
     expect(paths).toEqual(["locales/en.json"]);
+  });
+
+  it("skips the original path entry for staged renames", () => {
+    const paths = getCommittableChangedPaths("R  new.json\0old.json\0");
+
+    expect(paths).toEqual(["new.json"]);
+  });
+
+  it("skips the original path entry for staged copies", () => {
+    const paths = getCommittableChangedPaths("C  copied.json\0source.json\0");
+
+    expect(paths).toEqual(["copied.json"]);
   });
 
   it("returns no committable paths for report-only output", () => {

--- a/apps/hyperlocalise-web/src/workflows/github-fix.test.ts
+++ b/apps/hyperlocalise-web/src/workflows/github-fix.test.ts
@@ -48,4 +48,12 @@ describe("github fix committable changed paths", () => {
 
     expect(paths).toEqual([]);
   });
+
+  it("consumes original path entries when filtered renames target reports", () => {
+    const paths = getCommittableChangedPaths(
+      "R  .hyperlocalise/fix-report.json\0old.json\0 M locales/en.json\0",
+    );
+
+    expect(paths).toEqual(["locales/en.json"]);
+  });
 });

--- a/apps/hyperlocalise-web/src/workflows/github-fix.ts
+++ b/apps/hyperlocalise-web/src/workflows/github-fix.ts
@@ -268,12 +268,16 @@ export function getCommittableChangedPaths(statusOutput: string): string[] {
 
     const status = entry.slice(0, 2);
     const path = entry.slice(3);
+    const isRenameOrCopy = status[0] === "R" || status[0] === "C";
     if (!path || status === "!!" || isInternalReportPath(path)) {
+      if (isRenameOrCopy) {
+        index += 1;
+      }
       continue;
     }
 
     paths.push(path);
-    if (status[0] === "R" || status[0] === "C") {
+    if (isRenameOrCopy) {
       index += 1;
     }
   }

--- a/apps/hyperlocalise-web/src/workflows/github-fix.ts
+++ b/apps/hyperlocalise-web/src/workflows/github-fix.ts
@@ -242,21 +242,57 @@ async function runFixCommand(
   };
 }
 
-async function hasUncommittedChanges(sandboxId: string): Promise<boolean> {
+async function getSandboxChangedPaths(sandboxId: string): Promise<string[]> {
   "use step";
 
-  const result = await runSandboxCommand(sandboxId, "git", ["status", "--porcelain"]);
+  const result = await runSandboxCommand(sandboxId, "git", [
+    "status",
+    "--porcelain=v1",
+    "-z",
+    "--untracked-files=all",
+  ]);
   if (result.exitCode !== 0) {
     throw new Error(`git status failed: ${result.output}`);
   }
-  return result.output.trim().length > 0;
+  return getCommittableChangedPaths(result.output);
 }
 
-async function commitAndPush(sandboxId: string, headBranch: string): Promise<void> {
+export function getCommittableChangedPaths(statusOutput: string): string[] {
+  const paths: string[] = [];
+  const entries = statusOutput.split("\0");
+  for (let index = 0; index < entries.length; index += 1) {
+    const entry = entries[index];
+    if (!entry) {
+      continue;
+    }
+
+    const status = entry.slice(0, 2);
+    const path = entry.slice(3);
+    if (!path || status === "!!" || isInternalReportPath(path)) {
+      continue;
+    }
+
+    paths.push(path);
+    if (status[0] === "R" || status[0] === "C") {
+      index += 1;
+    }
+  }
+  return paths;
+}
+
+function isInternalReportPath(path: string): boolean {
+  return path === ".hyperlocalise" || path.startsWith(".hyperlocalise/");
+}
+
+async function commitAndPush(
+  sandboxId: string,
+  headBranch: string,
+  changedPaths: string[],
+): Promise<void> {
   "use step";
 
   for (const [command, args] of [
-    ["git", ["add", "-u"]],
+    ["git", ["add", "--", ...changedPaths]],
     ["git", ["commit", "-m", "fix(i18n): apply hyperlocalise fixes"]],
     ["git", ["push", "origin", headBranch]],
   ] satisfies Array<[string, string[]]>) {
@@ -334,14 +370,14 @@ export async function githubFixWorkflow(event: GitHubFixRequestedEventData) {
       return;
     }
 
-    const changed = await hasUncommittedChanges(sandboxId);
-    if (changed) {
-      await commitAndPush(sandboxId, pr.headBranch);
+    const changedPaths = await getSandboxChangedPaths(sandboxId);
+    if (changedPaths.length > 0) {
+      await commitAndPush(sandboxId, pr.headBranch, changedPaths);
     }
     await postPullRequestComment(
       event,
       formatFixSummary({
-        changed,
+        changed: changedPaths.length > 0,
         command: fix.command,
         exitCode: fix.exitCode,
         output: fix.output,


### PR DESCRIPTION
## What changed

- Stage explicit committable paths from `git status --porcelain=v1 -z --untracked-files=all` instead of using `git add -u`.
- Include untracked translation output files created by `hl fix`.
- Exclude internal `.hyperlocalise/` report artifacts from fix commits.
- Add workflow coverage for tracked changes, untracked outputs, report filtering, and report-only output.

## How to test

- `vp test src/workflows/github-fix.test.ts`
- `vp check --fix`
- `make fmt`
- `make lint`

Full `vp test` was blocked by local Postgres sandbox access to `localhost:5432`.
`make test` was blocked by a local Go toolchain mismatch: compiled packages are `go1.26.1`, current tool is `go1.26.0`.

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review