### PR TITLE
refactor(api): extract schemas for agent and conversation route modules

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/agent-email/agent-email.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/agent-email/agent-email.route.ts
@@ -3,7 +3,6 @@ import { randomBytes } from "node:crypto";
 import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { validator } from "hono/validator";
-import { z } from "zod";
 
 import { type AuthVariables, workosAuthMiddleware } from "@/api/auth/workos";
 import { db, schema } from "@/lib/database";
@@ -11,9 +10,7 @@ import { assertProviderCredentialAdmin } from "@/lib/providers/organization-prov
 
 const inboundEmailDomain = "inbox.hyperlocalise.com";
 
-const updateEmailAgentBodySchema = z.object({
-  enabled: z.boolean(),
-});
+import { updateEmailAgentBodySchema } from "./agent-email.schema";
 
 function normalizeSlug(value: string | null | undefined) {
   const normalized = (value ?? "")

--- a/apps/hyperlocalise-web/src/api/routes/agent-email/agent-email.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/agent-email/agent-email.route.ts
@@ -8,9 +8,9 @@ import { type AuthVariables, workosAuthMiddleware } from "@/api/auth/workos";
 import { db, schema } from "@/lib/database";
 import { assertProviderCredentialAdmin } from "@/lib/providers/organization-provider-credentials";
 
-const inboundEmailDomain = "inbox.hyperlocalise.com";
-
 import { updateEmailAgentBodySchema } from "./agent-email.schema";
+
+const inboundEmailDomain = "inbox.hyperlocalise.com";
 
 function normalizeSlug(value: string | null | undefined) {
   const normalized = (value ?? "")

--- a/apps/hyperlocalise-web/src/api/routes/agent-email/agent-email.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/agent-email/agent-email.schema.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const updateEmailAgentBodySchema = z.object({
+  enabled: z.boolean(),
+});

--- a/apps/hyperlocalise-web/src/api/routes/agent-slack/agent-slack.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/agent-slack/agent-slack.route.ts
@@ -1,7 +1,6 @@
 import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { validator } from "hono/validator";
-import { z } from "zod";
 
 import { type AuthVariables, workosAuthMiddleware } from "@/api/auth/workos";
 import { getSlackRedirectUri } from "@/api/routes/slack-oauth";
@@ -10,9 +9,7 @@ import { db, schema } from "@/lib/database";
 import { env } from "@/lib/env";
 import { assertProviderCredentialAdmin } from "@/lib/providers/organization-provider-credentials";
 
-const updateSlackAgentBodySchema = z.object({
-  enabled: z.boolean(),
-});
+import { updateSlackAgentBodySchema } from "./agent-slack.schema";
 
 const validateUpdateSlackAgentBody = validator("json", (value, c) => {
   const parsed = updateSlackAgentBodySchema.safeParse(value);

--- a/apps/hyperlocalise-web/src/api/routes/agent-slack/agent-slack.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/agent-slack/agent-slack.schema.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const updateSlackAgentBodySchema = z.object({
+  enabled: z.boolean(),
+});

--- a/apps/hyperlocalise-web/src/api/routes/chat-request/chat-request.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/chat-request/chat-request.route.ts
@@ -1,7 +1,6 @@
 import { Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
 import { validator } from "hono/validator";
-import { z } from "zod";
 
 import type { AuthVariables } from "@/api/auth/workos";
 import { workosAuthMiddleware } from "@/api/auth/workos";
@@ -10,10 +9,7 @@ import { createStoredFile } from "@/lib/file-storage/records";
 import { addInteractionMessage, createInteraction } from "@/lib/interactions";
 import { inferSupportedFileTranslationFileFormat } from "@/lib/translation/file-formats";
 
-const chatRequestBodySchema = z.object({
-  text: z.string().trim().min(1).max(10000),
-  projectId: z.string().optional(),
-});
+import { chatRequestBodySchema, multipartChatRequestSchema } from "./chat-request.schema";
 
 const validateChatRequestBody = validator("json", (value, c) => {
   const parsed = chatRequestBodySchema.safeParse(value);
@@ -25,11 +21,6 @@ const validateChatRequestBody = validator("json", (value, c) => {
 
 const maxChatUploadBytes = 25 * 1024 * 1024;
 const maxChatUploadFiles = 5;
-
-const multipartChatRequestSchema = z.object({
-  text: z.string().trim().max(10000).default(""),
-  projectId: z.string().trim().min(1).optional(),
-});
 
 type CreateChatRequestRoutesOptions = {
   fileStorageAdapter?: FileStorageAdapter;

--- a/apps/hyperlocalise-web/src/api/routes/chat-request/chat-request.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/chat-request/chat-request.schema.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const chatRequestBodySchema = z.object({
+  text: z.string().trim().min(1).max(10000),
+  projectId: z.string().optional(),
+});
+
+export const multipartChatRequestSchema = z.object({
+  text: z.string().trim().max(10000).default(""),
+  projectId: z.string().trim().min(1).optional(),
+});

--- a/apps/hyperlocalise-web/src/api/routes/conversation/chat-stream.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/chat-stream.route.ts
@@ -1,6 +1,5 @@
 import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
-import { z } from "zod";
 
 import type { AuthVariables } from "@/api/auth/workos";
 import { workosAuthMiddleware } from "@/api/auth/workos";
@@ -11,9 +10,7 @@ import {
 import { db, schema } from "@/lib/database";
 import { addInteractionMessage } from "@/lib/interactions";
 
-const conversationIdParamsSchema = z.object({
-  conversationId: z.uuid(),
-});
+import { conversationIdParamsSchema } from "./conversation.schema";
 
 export function createChatStreamRoutes() {
   return new Hono<{ Variables: AuthVariables }>()

--- a/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.ts
@@ -2,7 +2,6 @@ import { and, desc, eq, inArray, lt } from "drizzle-orm";
 import { Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
 import { validator } from "hono/validator";
-import { z } from "zod";
 
 import type { AuthVariables } from "@/api/auth/workos";
 import { workosAuthMiddleware } from "@/api/auth/workos";
@@ -13,16 +12,7 @@ import { createStoredFile } from "@/lib/file-storage/records";
 import { addInteractionMessage } from "@/lib/interactions";
 
 import { createChatStreamRoutes } from "./chat-stream.route";
-
-const conversationIdParamsSchema = z.object({
-  conversationId: z.uuid(),
-});
-
-const listConversationsQuerySchema = z.object({
-  status: z.enum(["active", "archived"]).optional(),
-  limit: z.coerce.number().int().min(1).max(100).optional().default(50),
-  cursor: z.string().optional(),
-});
+import { conversationIdParamsSchema, listConversationsQuerySchema } from "./conversation.schema";
 
 const maxMessageUploadBytes = 25 * 1024 * 1024;
 const maxMessageUploadFiles = 5;

--- a/apps/hyperlocalise-web/src/api/routes/conversation/conversation.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/conversation.schema.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const conversationIdParamsSchema = z.object({
+  conversationId: z.uuid(),
+});
+
+export const listConversationsQuerySchema = z.object({
+  status: z.enum(["active", "archived"]).optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional().default(50),
+  cursor: z.string().optional(),
+});

--- a/apps/hyperlocalise-web/src/api/routes/github-installation/github-installation.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/github-installation/github-installation.route.ts
@@ -3,7 +3,6 @@ import { randomUUID } from "node:crypto";
 import { and, count, eq, ilike, inArray } from "drizzle-orm";
 import { Hono } from "hono";
 import { validator } from "hono/validator";
-import { z } from "zod";
 
 import { isAdminRole } from "@/api/auth/roles";
 import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
@@ -16,13 +15,7 @@ import {
 } from "@/lib/agents/github/oauth-state";
 import { syncInstallationRepositories } from "@/lib/agents/github/repositories";
 
-const updateRepositoriesSchema = z.object({
-  enabledRepositoryIds: z.array(z.string().regex(/^\d+$/)).default([]),
-});
-
-const searchRepositoriesSchema = z.object({
-  q: z.string().optional(),
-});
+import { searchRepositoriesSchema, updateRepositoriesSchema } from "./github-installation.schema";
 
 const validateRepositorySearch = validator("query", (value) => {
   const parsed = searchRepositoriesSchema.safeParse(value);

--- a/apps/hyperlocalise-web/src/api/routes/github-installation/github-installation.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/github-installation/github-installation.schema.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const updateRepositoriesSchema = z.object({
+  enabledRepositoryIds: z.array(z.string().regex(/^\d+$/)).default([]),
+});
+
+export const searchRepositoriesSchema = z.object({
+  q: z.string().optional(),
+});


### PR DESCRIPTION
### Motivation
- Normalize agent-facing and conversation route folders to the standardized Hono route/schema structure by moving inline request/param validation into dedicated schema files.
- Make route modules smaller and more consistent so route-local validation is typed and re-usable across related route files (e.g. chat-stream vs conversation).

### Description
- Added route-local schema files: `agent-email.schema.ts`, `agent-slack.schema.ts`, `chat-request.schema.ts`, `conversation.schema.ts`, and `github-installation.schema.ts` containing the Zod request/param/query schemas. 
- Updated corresponding route modules to import and use the new schemas instead of defining Zod shapes inline in the `*.route.ts` files. 
- Kept all route handlers, middleware usage, and runtime/provider boundaries unchanged so behavior is preserved. 
- Committed the change with message `refactor(api): extract route schemas for agent and conversation routes`.

### Testing
- Ran `make fmt` and it completed successfully. 
- Ran `make lint` but it failed in this environment because `golangci-lint` is not installed (`/root/go/bin/golangci-lint: No such file or directory`). 
- Attempted `make test` (invokes `go test`) but the full test run could not be completed in this environment; `vp` commands (`vp check --fix`, `vp test`) are also unavailable here (`vp: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b87fbf940832c82a2bbc3c4fa6e39)