### PR TITLE
🎨 Palette: Add tooltips to Inbox header buttons

### DIFF
--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-list.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-list.tsx
@@ -7,6 +7,7 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { TypographyMuted, TypographySmall } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
 
@@ -46,24 +47,38 @@ export const InboxList = memo(function InboxList({
           </div>
         </div>
         <div className="flex items-center gap-1">
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-sm"
-            className="text-muted-foreground hover:bg-accent hover:text-foreground"
-            aria-label="Filter inbox"
-          >
-            <HugeiconsIcon icon={FilterMailIcon} strokeWidth={1.8} className="size-4" />
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-sm"
-            className="text-muted-foreground hover:bg-accent hover:text-foreground"
-            aria-label="Inbox display settings"
-          >
-            <HugeiconsIcon icon={PreferenceHorizontalIcon} strokeWidth={1.8} className="size-4" />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  className="text-muted-foreground hover:bg-accent hover:text-foreground"
+                  aria-label="Filter inbox"
+                />
+              }
+            >
+              <HugeiconsIcon icon={FilterMailIcon} strokeWidth={1.8} className="size-4" />
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Filter inbox</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  className="text-muted-foreground hover:bg-accent hover:text-foreground"
+                  aria-label="Inbox display settings"
+                />
+              }
+            >
+              <HugeiconsIcon icon={PreferenceHorizontalIcon} strokeWidth={1.8} className="size-4" />
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Inbox display settings</TooltipContent>
+          </Tooltip>
         </div>
       </header>
 


### PR DESCRIPTION
Added tooltips to the icon-only buttons in the Inbox list header. This micro-UX improvement enhances the interface by providing clear labels for the filter and settings actions, making them more intuitive and accessible. The implementation follows the established pattern in the codebase using `@base-ui/react` tooltips with a `render` prop on the trigger to avoid nested button elements.

---
*PR created automatically by Jules for task [10668655557813693090](https://jules.google.com/task/10668655557813693090) started by @cungminh2710*