### PR TITLE
fix(crowdin): improve Bundle and Task model parity

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -47,3 +47,9 @@
 **Learning:** The Crowdin Files API v2 returns `isReadOnly` for both files and directories, and file updates support `excludedTargetLanguages` and `fields`. Additionally, the `recursion` parameter in list operations is documented as `any` but was only handled as `string` in the SDK, causing issues when passed as `bool` or `int`.
 
 **Action:** Added `IsReadOnly` (*bool) to the `File` model and `ExcludedTargetLanguages` ([]string) and `Fields` (map[string]any) to `FileUpdateRestoreRequest`. Updated `DirectoryListOptions` and `FileListOptions` to handle `Recursion` using `fmt.Sprintf("%v", ...)` to support all common types. Verified with updated contract tests in `source_files_test.go` and `model/source_files_test.go`.
+
+## 2026-06-19 - Improve Bundle and Task model parity for ETA and workflowStepId
+
+**Learning:** The Crowdin Bundles API v2 returns an `eta` field in bundle export responses, and the Tasks API supports filtering by `workflowStepId` via query parameters. These were missing from the Go SDK models and request options.
+
+**Action:** Added `ETA` to the `BundleExport` model in `model/bundles.go`. Added `WorkflowStepID` to `TasksListOptions` and updated its `Values()` method in `model/tasks.go` to encode it. Updated contract tests in `bundles_test.go` and `tasks_test.go` to verify parity.

--- a/third_party/crowdin-api-client-go/crowdin/bundles_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/bundles_test.go
@@ -348,6 +348,7 @@ func TestBundlesService_Export(t *testing.T) {
 		UpdatedAt:  "2023-09-23T11:26:54+00:00",
 		StartedAt:  "2023-09-23T11:26:54+00:00",
 		FinishedAt: "2023-09-23T11:26:54+00:00",
+		ETA:        "1 second",
 	}
 	assert.Equal(t, expected, export)
 }
@@ -435,6 +436,7 @@ func TestBundlesService_CheckExportStatus(t *testing.T) {
 		UpdatedAt:  "2023-09-23T11:26:54+00:00",
 		StartedAt:  "2023-09-23T11:26:54+00:00",
 		FinishedAt: "2023-09-23T11:26:54+00:00",
+		ETA:        "1 second",
 	}
 	assert.Equal(t, expected, status)
 }

--- a/third_party/crowdin-api-client-go/crowdin/model/bundles.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/bundles.go
@@ -92,6 +92,7 @@ type BundleExport struct {
 	UpdatedAt  string `json:"updatedAt"`
 	StartedAt  string `json:"startedAt"`
 	FinishedAt string `json:"finishedAt"`
+	ETA        string `json:"eta,omitempty"`
 }
 
 // BundleExportResponse defines the structure of a response

--- a/third_party/crowdin-api-client-go/crowdin/model/tasks.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/tasks.go
@@ -108,6 +108,8 @@ type TasksListOptions struct {
 	Status []TaskStatus `json:"status,omitempty"`
 	// List tasks for specified assignee.
 	AssigneeID int `json:"assigneeId,omitempty"`
+	// List tasks for specified workflow step.
+	WorkflowStepID int `json:"workflowStepId,omitempty"`
 
 	ListOptions
 }
@@ -129,6 +131,9 @@ func (o *TasksListOptions) Values() (url.Values, bool) {
 	}
 	if o.AssigneeID > 0 {
 		v.Add("assigneeId", fmt.Sprintf("%d", o.AssigneeID))
+	}
+	if o.WorkflowStepID > 0 {
+		v.Add("workflowStepId", fmt.Sprintf("%d", o.WorkflowStepID))
 	}
 
 	return v, len(v) > 0

--- a/third_party/crowdin-api-client-go/crowdin/tasks_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/tasks_test.go
@@ -257,6 +257,13 @@ func TestTasksService_List(t *testing.T) {
 			},
 			want: "?assigneeId=123&limit=25&offset=10&orderBy=createdAt+desc%2Ctitle&status=todo%2Cin_progress",
 		},
+		{
+			name: "with workflowStepId",
+			options: &model.TasksListOptions{
+				WorkflowStepID: 10,
+			},
+			want: "?workflowStepId=10",
+		},
 	}
 
 	client, mux, teardown := setupClient()


### PR DESCRIPTION
Improved the Crowdin Go SDK fork's parity with API v2 by adding missing fields and parameters for Bundles and Tasks. This includes the `ETA` field in `BundleExport` and `WorkflowStepID` filter in `TasksListOptions`. Updated contract tests to ensure correct serialization and response parsing.

---
*PR created automatically by Jules for task [16742704906357166006](https://jules.google.com/task/16742704906357166006) started by @cungminh2710*