### PR TITLE
Improve Source Files and Branches API parity

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -35,3 +35,9 @@
 **Learning:** Crowdin API v2 for Glossaries and Translation Memories includes a `description` field for both, and Translation Memories also support a `groupId` field in both responses and addition requests. These fields were missing from the Go SDK models, preventing users from fully managing these resources, especially in Enterprise environments where resource organization into groups is common.
 
 **Action:** Added `Description` field to `Glossary` and `GlossaryAddRequest` in `model/glossaries.go`. Added `Description` and `GroupID` fields to `TranslationMemory`, and `GroupID` (*int) to `TranslationMemoryAddRequest` in `model/translation_memory.go`. Updated contract tests in `glossaries_test.go` and `translation_memory_test.go` to verify correct parsing and serialization.
+
+## 2026-06-19 - Add WebURL and improve Recursion parameter parity
+
+**Learning:** Several standard fields were missing from the Source Files and Branches models. Most resources in the Crowdin API v2 include a `webUrl` field, which was absent from `Branch`, `Directory`, and `File` response models. Additionally, the `recursion` query parameter in file and directory list operations is often documented as an integer (0 or 1), but the SDK only supported string values.
+
+**Action:** Added `WebURL` field to `Branch`, `Directory`, and `File` structs. Updated `DirectoryListOptions.Values()` and `FileListOptions.Values()` to handle `Recursion` as `string`, `int`, or `bool` (mapping booleans to "1" or "0"). Updated contract tests in `branches_test.go` and `source_files_test.go` to verify parity.

--- a/third_party/crowdin-api-client-go/crowdin/branches_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/branches_test.go
@@ -29,7 +29,8 @@ func TestBranchesService_List(t *testing.T) {
 						"createdAt": "2023-09-16T13:48:04+00:00",
 						"updatedAt": "2023-09-19T13:25:27+00:00",
 						"exportPattern": "%_three_letters_code%",
-						"priority": "normal"
+						"priority": "normal",
+						"webUrl": "https://crowdin.com/project/test/branches/34"
 					}
 				}
 			],
@@ -55,6 +56,7 @@ func TestBranchesService_List(t *testing.T) {
 			UpdatedAt:     "2023-09-19T13:25:27+00:00",
 			ExportPattern: ToPtr("%_three_letters_code%"),
 			Priority:      ToPtr("normal"),
+			WebURL:        "https://crowdin.com/project/test/branches/34",
 		},
 	}
 	if !reflect.DeepEqual(branches, want) {
@@ -85,7 +87,8 @@ func TestBranchesService_ListWithQueryParams(t *testing.T) {
 						"createdAt": "2023-09-16T13:48:04+00:00",
 						"updatedAt": "2023-09-19T13:25:27+00:00",
 						"exportPattern": "%_three_letters_code%",
-						"priority": "normal"
+						"priority": "normal",
+						"webUrl": "https://crowdin.com/project/test/branches/34"
 					}
 				}
 			],
@@ -115,6 +118,7 @@ func TestBranchesService_ListWithQueryParams(t *testing.T) {
 			UpdatedAt:     "2023-09-19T13:25:27+00:00",
 			ExportPattern: ToPtr("%_three_letters_code%"),
 			Priority:      ToPtr("normal"),
+			WebURL:        "https://crowdin.com/project/test/branches/34",
 		},
 	}
 	if !reflect.DeepEqual(branches, want) {
@@ -138,7 +142,8 @@ func TestBranchesService_Get(t *testing.T) {
 				"createdAt": "2023-09-16T13:48:04+00:00",
 				"updatedAt": "2023-09-19T13:25:27+00:00",
 				"exportPattern": "%_three_letters_code%",
-				"priority": "normal"
+				"priority": "normal",
+				"webUrl": "https://crowdin.com/project/test/branches/34"
 			}
 		}`)
 	})
@@ -157,6 +162,7 @@ func TestBranchesService_Get(t *testing.T) {
 		UpdatedAt:     "2023-09-19T13:25:27+00:00",
 		ExportPattern: ToPtr("%_three_letters_code%"),
 		Priority:      ToPtr("normal"),
+		WebURL:        "https://crowdin.com/project/test/branches/34",
 	}
 	if !reflect.DeepEqual(branch, want) {
 		t.Errorf("Branches.Get returned %+v, want %+v", branch, want)
@@ -207,7 +213,8 @@ func TestBranchesService_Add(t *testing.T) {
 				"createdAt": "2023-09-16T13:48:04+00:00",
 				"updatedAt": "2023-09-19T13:25:27+00:00",
 				"exportPattern": "%_three_letters_code%",
-				"priority": "normal"
+				"priority": "normal",
+				"webUrl": "https://crowdin.com/project/test/branches/34"
 			}
 		}`)
 	})
@@ -231,6 +238,7 @@ func TestBranchesService_Add(t *testing.T) {
 		UpdatedAt:     "2023-09-19T13:25:27+00:00",
 		ExportPattern: ToPtr("%_three_letters_code%"),
 		Priority:      ToPtr("normal"),
+		WebURL:        "https://crowdin.com/project/test/branches/34",
 	}
 	if !reflect.DeepEqual(branch, want) {
 		t.Errorf("Branches.Add returned %+v, want %+v", branch, want)
@@ -254,7 +262,8 @@ func TestBranchesService_AddWithRequiredBodyParams(t *testing.T) {
 				"createdAt": "2023-09-16T13:48:04+00:00",
 				"updatedAt": "2023-09-19T13:25:27+00:00",
 				"exportPattern": "%_three_letters_code%",
-				"priority": "normal"
+				"priority": "normal",
+				"webUrl": "https://crowdin.com/project/test/branches/34"
 			}
 		}`)
 	})
@@ -275,6 +284,7 @@ func TestBranchesService_AddWithRequiredBodyParams(t *testing.T) {
 		UpdatedAt:     "2023-09-19T13:25:27+00:00",
 		ExportPattern: ToPtr("%_three_letters_code%"),
 		Priority:      ToPtr("normal"),
+		WebURL:        "https://crowdin.com/project/test/branches/34",
 	}
 	if !reflect.DeepEqual(branch, want) {
 		t.Errorf("Branches.Add returned %+v, want %+v", branch, want)

--- a/third_party/crowdin-api-client-go/crowdin/model/branches.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/branches.go
@@ -15,6 +15,7 @@ type Branch struct {
 	UpdatedAt     string  `json:"updatedAt"`
 	ExportPattern *string `json:"exportPattern,omitempty"`
 	Priority      *string `json:"priority,omitempty"`
+	WebURL        string  `json:"webUrl"`
 }
 
 // BranchesGetResponse describes a response with a single branch.

--- a/third_party/crowdin-api-client-go/crowdin/model/source_files.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/source_files.go
@@ -18,6 +18,7 @@ type Directory struct {
 	Path          string `json:"path"`
 	IsReadOnly    *bool  `json:"isReadOnly,omitempty"`
 	Priority      string `json:"priority"`
+	WebURL        string `json:"webUrl"`
 	CreatedAt     string `json:"createdAt"`
 	UpdatedAt     string `json:"updatedAt"`
 }
@@ -79,8 +80,19 @@ func (o *DirectoryListOptions) Values() (url.Values, bool) {
 	if o.Filter != "" {
 		v.Add("filter", o.Filter)
 	}
-	if recursion, ok := o.Recursion.(string); ok {
-		v.Add("recursion", recursion)
+	if o.Recursion != nil {
+		switch r := o.Recursion.(type) {
+		case string:
+			v.Add("recursion", r)
+		case int:
+			v.Add("recursion", fmt.Sprintf("%d", r))
+		case bool:
+			if r {
+				v.Add("recursion", "1")
+			} else {
+				v.Add("recursion", "0")
+			}
+		}
 	}
 
 	return v, len(v) > 0
@@ -137,6 +149,7 @@ type File struct {
 	Type        string  `json:"type"`
 	Path        string  `json:"path"`
 	Status      string  `json:"status"`
+	WebURL      string  `json:"webUrl"`
 	Fields      any     `json:"fields,omitempty"`
 
 	RevisionID             int            `json:"revisionId"`
@@ -206,8 +219,19 @@ func (o *FileListOptions) Values() (url.Values, bool) {
 	if o.Filter != "" {
 		v.Add("filter", o.Filter)
 	}
-	if recursion, ok := o.Recursion.(string); ok {
-		v.Add("recursion", recursion)
+	if o.Recursion != nil {
+		switch r := o.Recursion.(type) {
+		case string:
+			v.Add("recursion", r)
+		case int:
+			v.Add("recursion", fmt.Sprintf("%d", r))
+		case bool:
+			if r {
+				v.Add("recursion", "1")
+			} else {
+				v.Add("recursion", "0")
+			}
+		}
 	}
 
 	return v, len(v) > 0

--- a/third_party/crowdin-api-client-go/crowdin/source_files_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/source_files_test.go
@@ -35,6 +35,7 @@ func TestSourceFilesService_ListDirectories(t *testing.T) {
 						"path": "/main",
 						"isReadOnly": true,
 						"priority": "normal",
+						"webUrl": "https://crowdin.com/project/test/settings/files#4",
 						"createdAt": "2024-04-18T14:14:00+00:00",
 						"updatedAt": "2024-04-18T14:14:00+00:00"
 					}
@@ -62,6 +63,7 @@ func TestSourceFilesService_ListDirectories(t *testing.T) {
 			Path:          "/main",
 			IsReadOnly:    ToPtr(true),
 			Priority:      "normal",
+			WebURL:        "https://crowdin.com/project/test/settings/files#4",
 			CreatedAt:     "2024-04-18T14:14:00+00:00",
 			UpdatedAt:     "2024-04-18T14:14:00+00:00",
 		},
@@ -91,7 +93,7 @@ func TestDirectory_MarshalJSON_IsReadOnly(t *testing.T) {
 	b, err := json.Marshal(directory)
 	require.NoError(t, err)
 
-	assert.JSONEq(t, `{"id":0,"projectId":0,"name":"","title":"","exportPattern":"","path":"","isReadOnly":false,"priority":"","createdAt":"","updatedAt":""}`, string(b))
+	assert.JSONEq(t, `{"id":0,"projectId":0,"name":"","title":"","exportPattern":"","path":"","isReadOnly":false,"priority":"","webUrl":"","createdAt":"","updatedAt":""}`, string(b))
 
 	directory.IsReadOnly = nil
 	b, err = json.Marshal(directory)
@@ -140,6 +142,20 @@ func TestSourceFilesService_ListDirectories_WithQueryParams(t *testing.T) {
 			},
 			expect: "?branchId=1&directoryId=2&filter=name&limit=25&offset=10&orderBy=createdAt+desc%2Cname%2Cid&recursion=true",
 		},
+		{
+			name: "With recursion as int",
+			opts: &model.DirectoryListOptions{
+				Recursion: 1,
+			},
+			expect: "?recursion=1",
+		},
+		{
+			name: "With recursion as bool",
+			opts: &model.DirectoryListOptions{
+				Recursion: true,
+			},
+			expect: "?recursion=1",
+		},
 	}
 
 	for i, tt := range cases {
@@ -178,6 +194,7 @@ func TestSourceFilesService_GetDirectory(t *testing.T) {
 				"exportPattern": "/localization/%locale%/file_name",
 				"path": "/main",
 				"priority": "normal",
+				"webUrl": "https://crowdin.com/project/test/settings/files#2",
 				"createdAt": "2024-04-18T14:14:00+00:00",
 				"updatedAt": "2024-04-18T14:14:00+00:00"
 			}
@@ -197,6 +214,7 @@ func TestSourceFilesService_GetDirectory(t *testing.T) {
 		ExportPattern: "/localization/%locale%/file_name",
 		Path:          "/main",
 		Priority:      "normal",
+		WebURL:        "https://crowdin.com/project/test/settings/files#2",
 		CreatedAt:     "2024-04-18T14:14:00+00:00",
 		UpdatedAt:     "2024-04-18T14:14:00+00:00",
 	}
@@ -227,6 +245,7 @@ func TestSourceFilesService_AddDirectory(t *testing.T) {
 				"exportPattern": "/localization/%locale%/new_file_name",
 				"path": "/new_directory",
 				"priority": "normal",
+				"webUrl": "https://crowdin.com/project/test/settings/files#5",
 				"createdAt": "2024-04-18T14:14:00+00:00",
 				"updatedAt": "2024-04-18T14:14:00+00:00"
 			}
@@ -253,6 +272,7 @@ func TestSourceFilesService_AddDirectory(t *testing.T) {
 		ExportPattern: "/localization/%locale%/new_file_name",
 		Path:          "/new_directory",
 		Priority:      "normal",
+		WebURL:        "https://crowdin.com/project/test/settings/files#5",
 		CreatedAt:     "2024-04-18T14:14:00+00:00",
 		UpdatedAt:     "2024-04-18T14:14:00+00:00",
 	}
@@ -299,6 +319,7 @@ func TestSourceFilesService_EditDirectory(t *testing.T) {
 				"exportPattern": "/localization/%locale%/file_name",
 				"path": "/main",
 				"priority": "normal",
+				"webUrl": "https://crowdin.com/project/test/settings/files#4",
 				"createdAt": "2024-04-18T14:14:00+00:00",
 				"updatedAt": "2024-04-18T14:14:00+00:00"
 			}
@@ -325,6 +346,7 @@ func TestSourceFilesService_EditDirectory(t *testing.T) {
 		ExportPattern: "/localization/%locale%/file_name",
 		Path:          "/main",
 		Priority:      "normal",
+		WebURL:        "https://crowdin.com/project/test/settings/files#4",
 		CreatedAt:     "2024-04-18T14:14:00+00:00",
 		UpdatedAt:     "2024-04-18T14:14:00+00:00",
 	}
@@ -375,6 +397,7 @@ func TestSourceFilesService_ListFiles(t *testing.T) {
 						"type": "xliff",
 						"path": "/directory1/directory2/filename.extension",
 						"status": "active",
+						"webUrl": "https://crowdin.com/project/test/settings/files#44",
 						"fields": {
 							"key_1": "value_1",
 							"key_2": 2,
@@ -395,6 +418,7 @@ func TestSourceFilesService_ListFiles(t *testing.T) {
 						"type": "xliff",
 						"path": "/directory1/directory2/filename.extension",
 						"status": "active",
+						"webUrl": "https://crowdin.com/project/test/settings/files#45",
 						"fields": []
 					}
 				},
@@ -410,6 +434,7 @@ func TestSourceFilesService_ListFiles(t *testing.T) {
 						"type": "xliff",
 						"path": "/directory1/directory2/filename.extension",
 						"status": "active",
+						"webUrl": "https://crowdin.com/project/test/settings/files#46",
 						"fields": {}
 					}
 				}
@@ -436,6 +461,7 @@ func TestSourceFilesService_ListFiles(t *testing.T) {
 			Type:        "xliff",
 			Path:        "/directory1/directory2/filename.extension",
 			Status:      "active",
+			WebURL:      "https://crowdin.com/project/test/settings/files#44",
 			Fields: map[string]any{
 				"key_1": "value_1",
 				"key_2": float64(2),
@@ -454,6 +480,7 @@ func TestSourceFilesService_ListFiles(t *testing.T) {
 			Type:        "xliff",
 			Path:        "/directory1/directory2/filename.extension",
 			Status:      "active",
+			WebURL:      "https://crowdin.com/project/test/settings/files#45",
 			Fields:      []any{},
 		},
 		{
@@ -467,6 +494,7 @@ func TestSourceFilesService_ListFiles(t *testing.T) {
 			Type:        "xliff",
 			Path:        "/directory1/directory2/filename.extension",
 			Status:      "active",
+			WebURL:      "https://crowdin.com/project/test/settings/files#46",
 			Fields:      map[string]any{},
 		},
 	}
@@ -529,6 +557,20 @@ func TestSourceFilesService_ListFiles_WithQueryParams(t *testing.T) {
 			},
 			expect: "?branchId=1&directoryId=2&filter=name&limit=25&offset=10&orderBy=createdAt+desc%2Cname%2Cid&recursion=true",
 		},
+		{
+			name: "With recursion as int",
+			opts: &model.FileListOptions{
+				Recursion: 1,
+			},
+			expect: "?recursion=1",
+		},
+		{
+			name: "With recursion as bool",
+			opts: &model.FileListOptions{
+				Recursion: true,
+			},
+			expect: "?recursion=1",
+		},
 	}
 
 	for i, tt := range cases {
@@ -568,6 +610,7 @@ func TestSourceFilesService_GetFile(t *testing.T) {
 				"type": "xliff",
 				"path": "/directory1/directory2/filename.extension",
 				"status": "active",
+				"webUrl": "https://crowdin.com/project/test/settings/files#44",
 				"fields": {
 					"fieldSlug": "fieldValue"
 				}
@@ -589,6 +632,7 @@ func TestSourceFilesService_GetFile(t *testing.T) {
 		Type:        "xliff",
 		Path:        "/directory1/directory2/filename.extension",
 		Status:      "active",
+		WebURL:      "https://crowdin.com/project/test/settings/files#44",
 		Fields:      map[string]any{"fieldSlug": "fieldValue"},
 	}
 	assert.Equal(t, expected, file)


### PR DESCRIPTION
This PR improves the parity of the Crowdin Go SDK with official API v2 for Source Files and Branches.

Key changes:
- Added `WebURL` (string) to `Branch`, `Directory`, and `File` response models.
- Updated `DirectoryListOptions.Values()` and `FileListOptions.Values()` to handle the `Recursion` parameter more robustly, supporting `string`, `int`, and `bool` types.
- Updated contract tests with new JSON fixtures and assertions to ensure these fields are correctly parsed and serialized.

Verified with `GOWORK=off go test ./...` in the `third_party/crowdin-api-client-go` directory.

---
*PR created automatically by Jules for task [6748778271252916214](https://jules.google.com/task/6748778271252916214) started by @cungminh2710*