### PR TITLE
🛡️ Sentinel: [security improvement] Restrict internal redirect targets

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -22,3 +22,8 @@
 **Vulnerability:** Accidental leakage of sensitive keys (API keys, tokens, passwords) and HTTP headers (Authorization, Cookie) into application logs when logging request/response bodies or authentication objects.
 **Learning:** Centralizing redaction at the logger level using `pino`'s built-in `redact` feature provides a failsafe against developer oversight when logging complex objects that might contain secrets.
 **Prevention:** Configure a global list of sensitive paths and wildcards (e.g., `*.password`, `headers["x-api-key"]`) in the root logger to ensure consistent redaction across the entire application.
+
+## 2026-05-30 - [Enhancement] Restricting Internal Redirect Targets
+**Vulnerability:** The `sanitizeReturnTo` utility prevented external open redirects but allowed redirecting back to sensitive internal authentication routes (e.g., `/auth/sign-in`, `/auth/callback`). This could be exploited to create redirect loops or target sensitive callback logic.
+**Learning:** Redirect sanitizers must account for internal "restricted" paths that, while technically local, should never be the destination of a `returnTo` parameter to avoid auth flow abuse.
+**Prevention:** Maintain a centralized blacklist of restricted authentication paths within the URL sanitizer and ensure it is used by all login/session redirection logic.

--- a/apps/hyperlocalise-web/src/lib/workos/return-to.test.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/return-to.test.ts
@@ -31,8 +31,9 @@ describe("sanitizeReturnTo", () => {
     expect(sanitizeReturnTo("/auth/github/callback")).toBe("/dashboard");
   });
 
-  it("should return the fallback if the value starts with a restricted auth path followed by ? or /", () => {
+  it("should return the fallback if the value starts with a restricted auth path followed by ?, #, or /", () => {
     expect(sanitizeReturnTo("/auth/sign-in?foo=bar")).toBe("/dashboard");
+    expect(sanitizeReturnTo("/auth/sign-in#section")).toBe("/dashboard");
     expect(sanitizeReturnTo("/auth/callback/extra")).toBe("/dashboard");
   });
 

--- a/apps/hyperlocalise-web/src/lib/workos/return-to.test.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/return-to.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeReturnTo } from "./return-to";
+
+describe("sanitizeReturnTo", () => {
+  it("should return the original value if it is a valid path", () => {
+    expect(sanitizeReturnTo("/dashboard")).toBe("/dashboard");
+    expect(sanitizeReturnTo("/projects")).toBe("/projects");
+    expect(sanitizeReturnTo("/org/abc/settings")).toBe("/org/abc/settings");
+  });
+
+  it("should return the fallback if the value is null or undefined", () => {
+    expect(sanitizeReturnTo(null)).toBe("/dashboard");
+    expect(sanitizeReturnTo(undefined)).toBe("/dashboard");
+    expect(sanitizeReturnTo(null, "/custom")).toBe("/custom");
+  });
+
+  it("should return the fallback if the value does not start with /", () => {
+    expect(sanitizeReturnTo("https://example.com")).toBe("/dashboard");
+    expect(sanitizeReturnTo("dashboard")).toBe("/dashboard");
+  });
+
+  it("should return the fallback if the value starts with // or /\\", () => {
+    expect(sanitizeReturnTo("//example.com")).toBe("/dashboard");
+    expect(sanitizeReturnTo("/\\example.com")).toBe("/dashboard");
+  });
+
+  it("should return the fallback if the value is a restricted auth path", () => {
+    expect(sanitizeReturnTo("/auth/sign-in")).toBe("/dashboard");
+    expect(sanitizeReturnTo("/auth/sign-out")).toBe("/dashboard");
+    expect(sanitizeReturnTo("/auth/callback")).toBe("/dashboard");
+    expect(sanitizeReturnTo("/auth/github/callback")).toBe("/dashboard");
+  });
+
+  it("should return the fallback if the value starts with a restricted auth path followed by ? or /", () => {
+    expect(sanitizeReturnTo("/auth/sign-in?foo=bar")).toBe("/dashboard");
+    expect(sanitizeReturnTo("/auth/callback/extra")).toBe("/dashboard");
+  });
+
+  it("should not return the fallback for paths that just contain the restricted path as a substring", () => {
+    expect(sanitizeReturnTo("/not/auth/sign-in")).toBe("/not/auth/sign-in");
+    expect(sanitizeReturnTo("/auth/sign-in-not-really")).toBe("/auth/sign-in-not-really");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/workos/return-to.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/return-to.ts
@@ -1,5 +1,21 @@
+const RESTRICTED_PATHS = [
+  "/auth/sign-in",
+  "/auth/sign-out",
+  "/auth/callback",
+  "/auth/github/callback",
+];
+
 export function sanitizeReturnTo(value: string | null | undefined, fallback = "/dashboard") {
   if (!value || !value.startsWith("/") || value.startsWith("//") || value.startsWith("/\\")) {
+    return fallback;
+  }
+
+  // Prevent redirect loops by avoiding sensitive auth routes.
+  const isRestricted = RESTRICTED_PATHS.some(
+    (path) => value === path || value.startsWith(`${path}?`) || value.startsWith(`${path}/`),
+  );
+
+  if (isRestricted) {
     return fallback;
   }
 

--- a/apps/hyperlocalise-web/src/lib/workos/return-to.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/return-to.ts
@@ -11,8 +11,10 @@ export function sanitizeReturnTo(value: string | null | undefined, fallback = "/
   }
 
   // Prevent redirect loops by avoiding sensitive auth routes.
+  // We check the path part of the URL (before ? or #) to avoid bypasses.
+  const urlPath = value.split(/[?#]/)[0];
   const isRestricted = RESTRICTED_PATHS.some(
-    (path) => value === path || value.startsWith(`${path}?`) || value.startsWith(`${path}/`),
+    (path) => urlPath === path || urlPath.startsWith(`${path}/`),
   );
 
   if (isRestricted) {


### PR DESCRIPTION
Restricts the `sanitizeReturnTo` utility from allowing redirects back to sensitive internal authentication routes like `/auth/sign-in` and `/auth/callback`. This prevents potential redirect loops and hardens the auth flow against internal target abuse.

Includes unit tests for the new sanitization rules in `apps/hyperlocalise-web/src/lib/workos/return-to.test.ts`.

---
*PR created automatically by Jules for task [12110577410675140311](https://jules.google.com/task/12110577410675140311) started by @cungminh2710*