### PR TITLE
fix(github-installation): revoke app install on disconnect

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/github-installation/github-installation.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/github-installation/github-installation.route.ts
@@ -13,6 +13,7 @@ import {
   getGitHubStateSecret,
   signGitHubState,
 } from "@/lib/agents/github/oauth-state";
+import { getGitHubApp } from "@/lib/agents/github/app";
 import { syncInstallationRepositories } from "@/lib/agents/github/repositories";
 
 import { searchRepositoriesSchema, updateRepositoriesSchema } from "./github-installation.schema";
@@ -199,22 +200,40 @@ export function createGithubInstallationRoutes() {
         return c.json({ error: "forbidden" }, 403);
       }
 
-      const deleted = await db
-        .delete(schema.githubInstallations)
-        .where(
-          eq(
-            schema.githubInstallations.organizationId,
-            c.var.auth.organization.localOrganizationId,
-          ),
-        )
-        .returning({ id: schema.githubInstallations.id });
+      const organizationId = c.var.auth.organization.localOrganizationId;
+      const [installation] = await db
+        .select({
+          id: schema.githubInstallations.id,
+          githubInstallationId: schema.githubInstallations.githubInstallationId,
+        })
+        .from(schema.githubInstallations)
+        .where(eq(schema.githubInstallations.organizationId, organizationId))
+        .limit(1);
 
-      if (deleted.length === 0) {
+      if (!installation) {
         return c.json({ error: "github_installation_not_found" }, 404);
       }
 
-      // TODO: call GitHub API to delete the app installation if we want to
-      // fully revoke access rather than just unlinking the local record.
+      try {
+        await getGitHubApp().octokit.request("DELETE /app/installations/{installation_id}", {
+          installation_id: Number.parseInt(installation.githubInstallationId, 10),
+        });
+      } catch (error) {
+        if (
+          !(
+            typeof error === "object" &&
+            error !== null &&
+            "status" in error &&
+            (error.status === 404 || error.status === 410)
+          )
+        ) {
+          return c.json({ error: "github_installation_revoke_failed" }, 502);
+        }
+      }
+
+      await db
+        .delete(schema.githubInstallations)
+        .where(eq(schema.githubInstallations.id, installation.id));
 
       return c.body(null, 204);
     });

--- a/apps/hyperlocalise-web/src/api/routes/github-installation/github-installation.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/github-installation/github-installation.route.ts
@@ -227,6 +227,7 @@ export function createGithubInstallationRoutes() {
             (error.status === 404 || error.status === 410)
           )
         ) {
+          console.error("GitHub installation revocation failed", error);
           return c.json({ error: "github_installation_revoke_failed" }, 502);
         }
       }

--- a/apps/hyperlocalise-web/src/api/routes/github-installation/github-installation.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/github-installation/github-installation.test.ts
@@ -267,9 +267,7 @@ describe("githubInstallationRoutes", () => {
     const [installation] = await db
       .select()
       .from(schema.githubInstallations)
-      .where(
-        eq(schema.githubInstallations.organizationId, auth.organization.localOrganizationId),
-      );
+      .where(eq(schema.githubInstallations.organizationId, auth.organization.localOrganizationId));
     expect(installation).toBeUndefined();
   });
 
@@ -287,9 +285,25 @@ describe("githubInstallationRoutes", () => {
     const [installation] = await db
       .select()
       .from(schema.githubInstallations)
-      .where(
-        eq(schema.githubInstallations.organizationId, auth.organization.localOrganizationId),
-      );
+      .where(eq(schema.githubInstallations.organizationId, auth.organization.localOrganizationId));
+    expect(installation).toBeUndefined();
+  });
+
+  it("cleans up local state when GitHub returns 410 Gone", async () => {
+    deleteInstallationMock.mockRejectedValueOnce({ status: 410 });
+    const { auth, headers, organizationSlug } = await createInstallationFixture("admin");
+
+    const response = await client.api.orgs[":organizationSlug"]["github-installation"].$delete(
+      { param: { organizationSlug } },
+      { headers },
+    );
+
+    expect(response.status).toBe(204);
+
+    const [installation] = await db
+      .select()
+      .from(schema.githubInstallations)
+      .where(eq(schema.githubInstallations.organizationId, auth.organization.localOrganizationId));
     expect(installation).toBeUndefined();
   });
 
@@ -310,9 +324,7 @@ describe("githubInstallationRoutes", () => {
     const [installation] = await db
       .select()
       .from(schema.githubInstallations)
-      .where(
-        eq(schema.githubInstallations.organizationId, auth.organization.localOrganizationId),
-      );
+      .where(eq(schema.githubInstallations.organizationId, auth.organization.localOrganizationId));
     expect(installation).toBeDefined();
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/github-installation/github-installation.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/github-installation/github-installation.test.ts
@@ -7,6 +7,9 @@ import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
 const { syncInstallationRepositoriesMock } = vi.hoisted(() => ({
   syncInstallationRepositoriesMock: vi.fn(async () => []),
 }));
+const { deleteInstallationMock } = vi.hoisted(() => ({
+  deleteInstallationMock: vi.fn(async () => ({ status: 204 })),
+}));
 
 vi.mock("@/lib/agents/github/repositories", async (importOriginal) => {
   const original = await importOriginal<typeof import("@/lib/agents/github/repositories")>();
@@ -15,6 +18,13 @@ vi.mock("@/lib/agents/github/repositories", async (importOriginal) => {
     syncInstallationRepositories: syncInstallationRepositoriesMock,
   };
 });
+vi.mock("@/lib/agents/github/app", () => ({
+  getGitHubApp: () => ({
+    octokit: {
+      request: deleteInstallationMock,
+    },
+  }),
+}));
 
 const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
   resolveApiAuthContextFromSessionMock: vi.fn(() => globalThis.__testApiAuthContext ?? null),
@@ -236,5 +246,73 @@ describe("githubInstallationRoutes", () => {
       organizationId: globalThis.__testApiAuthContext?.organization.localOrganizationId,
       githubInstallationId: "987654",
     });
+  });
+
+  it("revokes the GitHub App installation and removes local state", async () => {
+    const { auth, headers, organizationSlug } = await createInstallationFixture("admin");
+
+    const response = await client.api.orgs[":organizationSlug"]["github-installation"].$delete(
+      { param: { organizationSlug } },
+      { headers },
+    );
+
+    expect(response.status).toBe(204);
+    expect(deleteInstallationMock).toHaveBeenCalledWith(
+      "DELETE /app/installations/{installation_id}",
+      {
+        installation_id: 987654,
+      },
+    );
+
+    const [installation] = await db
+      .select()
+      .from(schema.githubInstallations)
+      .where(
+        eq(schema.githubInstallations.organizationId, auth.organization.localOrganizationId),
+      );
+    expect(installation).toBeUndefined();
+  });
+
+  it("cleans up local state when GitHub installation is already removed", async () => {
+    deleteInstallationMock.mockRejectedValueOnce({ status: 404 });
+    const { auth, headers, organizationSlug } = await createInstallationFixture("admin");
+
+    const response = await client.api.orgs[":organizationSlug"]["github-installation"].$delete(
+      { param: { organizationSlug } },
+      { headers },
+    );
+
+    expect(response.status).toBe(204);
+
+    const [installation] = await db
+      .select()
+      .from(schema.githubInstallations)
+      .where(
+        eq(schema.githubInstallations.organizationId, auth.organization.localOrganizationId),
+      );
+    expect(installation).toBeUndefined();
+  });
+
+  it("does not remove local state when remote revocation fails", async () => {
+    deleteInstallationMock.mockRejectedValueOnce({ status: 500 });
+    const { auth, headers, organizationSlug } = await createInstallationFixture("admin");
+
+    const response = await client.api.orgs[":organizationSlug"]["github-installation"].$delete(
+      { param: { organizationSlug } },
+      { headers },
+    );
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual({
+      error: "github_installation_revoke_failed",
+    });
+
+    const [installation] = await db
+      .select()
+      .from(schema.githubInstallations)
+      .where(
+        eq(schema.githubInstallations.organizationId, auth.organization.localOrganizationId),
+      );
+    expect(installation).toBeDefined();
   });
 });


### PR DESCRIPTION
### Motivation
- The disconnect route previously deleted only the local `github_installations` record and did not revoke the GitHub App installation, which could leave the app installed and webhooks active in GitHub.
- This change ensures remote app access is revoked when an org disconnects to avoid a UI that reports a disconnected agent while remote access remains. 
- The route should remain resilient when the remote installation is already removed and surface clear errors when revocation fails.

### Description
- Call the GitHub App REST API `DELETE /app/installations/{installation_id}` via `getGitHubApp().octokit.request(...)` before removing local state. 
- Treat remote `404` and `410` responses as acceptable (already-removed) and continue to delete the local record. 
- If remote revocation fails with any other status, return `502` and the error envelope `{ error: "github_installation_revoke_failed" }` and do not remove local state. 
- Add unit/route tests in `github-installation.test.ts` that mock `getGitHubApp()` to cover successful revocation, already-removed installations, and remote revocation failures.

### Testing
- Ran `make fmt` successfully. 
- Ran `make lint` but it failed in this environment due to a missing `golangci-lint` binary (`/root/go/bin/golangci-lint`).
- Started `make test`; the test run was long-running and produced no full completion output within this session. 
- Attempted `vp check --fix` but the `vp` command was not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bc5a97b64832c8bef68b72f7b67f8)