### PR TITLE
test(api): cover org slug auth contract on org-scoped routes

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/auth/auth.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/auth/auth.route.test.ts
@@ -160,6 +160,63 @@ describe("authRoutes", () => {
     });
   });
 
+
+  it("passes route organizationSlug to session auth resolution for org-scoped routes", async () => {
+    const activeOrganization = {
+      workosOrganizationId: "org_123",
+      localOrganizationId: "local_org_123",
+      name: "Example Org",
+      slug: "example-org",
+      membership: {
+        workosMembershipId: "membership_123",
+        role: "owner" as const,
+      },
+    };
+
+    const authContext: ApiAuthContext = {
+      user: {
+        workosUserId: "user_123",
+        localUserId: "local_user_123",
+        email: "user@example.com",
+      },
+      organizations: [activeOrganization],
+      organization: activeOrganization,
+      activeOrganization,
+      membership: {
+        workosMembershipId: "membership_123",
+        role: "owner",
+      },
+      activeTeam: null,
+    };
+
+    const client = await createClient({ sessionAuthContext: authContext });
+
+    await client.api.orgs[":organizationSlug"].projects.$get(
+      { param: { organizationSlug: "target-org" } },
+      { headers: { cookie: "wos-session=test" } },
+    );
+
+    expect(resolveApiAuthContextFromSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ organizationSlug: "target-org" }),
+    );
+  });
+
+  it("returns 403 for org-scoped routes when requested organization slug is not accessible", async () => {
+    const client = await createClient();
+    resolveApiAuthContextFromSessionMock.mockRejectedValueOnce(new Error("organization_access_denied"));
+
+    const response = await client.api.orgs[":organizationSlug"].projects.$get(
+      { param: { organizationSlug: "forbidden-org" } },
+      { headers: { cookie: "wos-session=test" } },
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "organization_access_denied",
+      message: expect.any(String),
+    });
+  });
+
   it("does not remap downstream errors from the session auth path", async () => {
     const activeOrganization = {
       workosOrganizationId: "org_123",

--- a/apps/hyperlocalise-web/src/api/routes/auth/auth.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/auth/auth.route.test.ts
@@ -14,6 +14,7 @@ const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
 async function createClient(
   options: {
     sessionAuthContext?: ApiAuthContext | null;
+    mockProjectRoutes?: boolean;
   } = {},
 ) {
   vi.resetModules();
@@ -25,6 +26,18 @@ async function createClient(
       healthRoutes: new Hono().get("/", (c) => c.json({ ok: true }, 200)),
     };
   });
+
+  if (options.mockProjectRoutes) {
+    vi.doMock("../project/project.route", async () => {
+      const { Hono } = await import("hono");
+      const { workosAuthMiddleware } = await import("@/api/auth/workos");
+
+      return {
+        createProjectRoutes: () =>
+          new Hono().use("*", workosAuthMiddleware).get("/", (c) => c.json({ projects: [] }, 200)),
+      };
+    });
+  }
 
   resolveApiAuthContextFromSessionMock.mockResolvedValue(options.sessionAuthContext ?? null);
 
@@ -41,6 +54,8 @@ describe("authRoutes", () => {
   afterEach(() => {
     vi.resetModules();
     vi.doUnmock("../health");
+    vi.doUnmock("../project/project.route");
+    resolveApiAuthContextFromSessionMock.mockClear();
   });
 
   it("returns 401 when auth context is missing", async () => {
@@ -160,7 +175,6 @@ describe("authRoutes", () => {
     });
   });
 
-
   it("passes route organizationSlug to session auth resolution for org-scoped routes", async () => {
     const activeOrganization = {
       workosOrganizationId: "org_123",
@@ -189,21 +203,24 @@ describe("authRoutes", () => {
       activeTeam: null,
     };
 
-    const client = await createClient({ sessionAuthContext: authContext });
+    const client = await createClient({ sessionAuthContext: authContext, mockProjectRoutes: true });
 
-    await client.api.orgs[":organizationSlug"].projects.$get(
+    const response = await client.api.orgs[":organizationSlug"].projects.$get(
       { param: { organizationSlug: "target-org" } },
       { headers: { cookie: "wos-session=test" } },
     );
 
-    expect(resolveApiAuthContextFromSessionMock).toHaveBeenCalledWith(
+    expect(response.status).toBe(200);
+    expect(resolveApiAuthContextFromSessionMock).toHaveBeenLastCalledWith(
       expect.objectContaining({ organizationSlug: "target-org" }),
     );
   });
 
   it("returns 403 for org-scoped routes when requested organization slug is not accessible", async () => {
     const client = await createClient();
-    resolveApiAuthContextFromSessionMock.mockRejectedValueOnce(new Error("organization_access_denied"));
+    resolveApiAuthContextFromSessionMock.mockRejectedValueOnce(
+      new Error("organization_access_denied"),
+    );
 
     const response = await client.api.orgs[":organizationSlug"].projects.$get(
       { param: { organizationSlug: "forbidden-org" } },


### PR DESCRIPTION
### Motivation
- Ensure org-scoped routes enforce the contract between the URL `:organizationSlug` and the session-authenticated active organization as outlined in HL-297, so handlers do not silently ignore the route slug or allow unauthorized access.

### Description
- Add regression tests in `apps/hyperlocalise-web/src/api/routes/auth/auth.route.test.ts` that assert org-scoped requests pass the route `organizationSlug` into `resolveApiAuthContextFromSession` and that the session auth path receives the requested slug. 
- Add a regression test that simulates `resolveApiAuthContextFromSession` rejecting with `organization_access_denied` and verifies the org-scoped route returns `403` with the `organization_access_denied` error envelope. 
- Tests reuse the existing `createClient` test helper and the mocked `resolveApiAuthContextFromSession` to validate middleware behavior for org-scoped requests.

### Testing
- Ran `make fmt` which completed successfully.
- Attempted `vp check --fix` in the web workspace but it could not run in the environment because the `vp` command was not found.
- Ran `make lint` which failed in the environment due to a missing `/root/go/bin/golangci-lint` binary.
- Ran `make test` which exercised many Go test packages but the run encountered a Go toolchain mismatch (`go1.26.1` vs `go1.25.1`) causing compilation errors for some packages and preventing a clean test pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bf4d9e488832ca1f941a6a3041aa6)