### PR TITLE
[codex] Align golangci-lint version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 projectname?=hyperlocalise
 version?=$(shell git describe --abbrev=0 --tags 2>/dev/null || echo dev)
-golangci_lint_version?=v2.12.1
+golangci_lint_version?=v2.12.2
 gobin?=$(shell go env GOPATH)/bin
 golangci_lint_bin?=$(gobin)/golangci-lint
 fmt_go_files:=$(filter-out %.pb.go,$(shell git ls-files '*.go' | while read -r f; do [ -f "$$f" ] && printf '%s\n' "$$f"; done))


### PR DESCRIPTION
## Summary

- Align the Makefile golangci-lint install pin with the Go tool dependency version.
- Keep bootstrap and lint using golangci-lint v2.12.2.

## Why

The Makefile installed golangci-lint v2.12.1 while go.mod tracked github.com/golangci/golangci-lint/v2 v2.12.2, which made local bootstrap tooling disagree with the module tool version.

## Validation

- make bootstrap
- make lint
- make fmt
- make test
