### PR TITLE
[codex] Remove stale TODO comments

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/mcp/mcp.route.test.ts
@@ -216,7 +216,6 @@ describe("mcpRoutes", () => {
     await expect(response.json()).resolves.toEqual({ error: "invalid_client" });
   });
 
-  // TODO: Re-enable after diagnosing the CI-only 500 during MCP authorization code exchange.
   it("exchanges a PKCE-bound authorization code for persisted MCP tokens", async () => {
     const identity = fixture.createWorkosIdentity();
     await fixture.authHeadersFor(identity);

--- a/apps/hyperlocalise-web/src/lib/tools/interaction-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/interaction-tools.ts
@@ -6,15 +6,7 @@ import { schema } from "@/lib/database";
 import type { ToolContext } from "./types";
 
 /**
- * TODO: Resolve or archive the interaction's inbox item.
- *
- * PRODUCT.md requirement: "The interaction records the result, and the inbox item remains open,
- * resolved, or archived."
- *
- * Implementation plan:
- * 1. Accept `status`: "active" | "archived" (or add "resolved" to the `inboxStatusEnum`).
- * 2. Update `inboxItems.status` for the current interaction.
- * 3. Return the new status.
+ * Marks the current interaction's inbox item as active or archived.
  *
  * Example usage: user says "That's all I needed, thanks."
  */


### PR DESCRIPTION
## Summary

- Remove a stale MCP route test TODO that referenced re-enabling an already-active test.
- Reword the interaction resolution tool comment so it reflects the implemented inbox status update behavior.

## Impact

- Comment-only cleanup; no runtime behavior changes.

## Validation

- make fmt
- make lint
- make test
- vp check --fix not run: vp is not installed on PATH and no local apps/hyperlocalise-web/node_modules/.bin/vp was present.
- vp test not run: vp is not installed on PATH and no local apps/hyperlocalise-web/node_modules/.bin/vp was present.
