### PR TITLE
[codex] Refresh project documentation

### DIFF
--- a/apps/hyperlocalise-web/README.md
+++ b/apps/hyperlocalise-web/README.md
@@ -1,36 +1,55 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Hyperlocalise Web
 
-## Getting Started
+This is the Hyperlocalise web application. It lives in `apps/hyperlocalise-web`
+inside the monorepo and runs as a Next.js app with the Vite+ toolchain.
 
-First, run the development server:
+Use `vp` for package management, local development, checks, and tests. Do not
+run `npm`, `pnpm`, `yarn`, `npx`, or direct Vitest/Oxlint commands in this app.
+
+## Setup
+
+From `apps/hyperlocalise-web`, install dependencies with Vite+:
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+vp install
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+## Development
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+Start the local development server:
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+```bash
+vp dev
+```
 
-## Learn More
+By default, the app is available at `http://localhost:3000`. If that port is in
+use, pass a different one:
 
-To learn more about Next.js, take a look at the following resources:
+```bash
+vp dev --port 3001
+```
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+## Validation
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+Run the Vite+ checks before sending web changes for review:
 
-## Deploy on Vercel
+```bash
+vp check --fix
+vp test
+```
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+`vp check --fix` formats, lints, and type-checks the app. `vp test` runs the
+JavaScript test suite through the Vite+ bundled test runner.
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+## Useful Paths
+
+- `src/app/`: Next.js app routes and pages
+- `src/api/`: Hono API routes mounted through the Next.js API adapter
+- `src/lib/database/`: Drizzle schema and database helpers
+- `drizzle/`: generated migrations and metadata
+- `vite.config.ts`: Vite+ configuration for formatting, linting, tests, and
+  path aliases
+
+For database schema changes, edit `src/lib/database/schema.ts`, then run
+`vp run db:generate` and commit the generated migration files together with the
+schema update.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,36 +1,42 @@
-> **First-time setup**: Customize this file for your project. Prompt the user to customize this file for their project.
-> For Mintlify product knowledge (components, configuration, writing standards),
-> install the Mintlify skill: `npx skills add https://mintlify.com/docs`
+# Documentation Agent Instructions
 
-# Documentation project instructions
+This directory is the Mintlify documentation site for Hyperlocalise.
 
-## About this project
+## Project Context
 
-- This is a documentation site built on [Mintlify](https://mintlify.com)
-- Pages are MDX files with YAML frontmatter
-- Configuration lives in `docs.json`
-- Run `mint dev` to preview locally
-- Run `mint broken-links` to check links
+- Write for Hyperlocalise users and contributors.
+- Pages are MDX files with YAML frontmatter.
+- Site configuration and navigation live in `docs.json`.
+- English source docs live directly under `docs/`.
+- Localized docs live under `docs/zh-CN/` and `docs/vi-VN/`.
 
-## Terminology
+## Local Workflow
 
-<!-- Add product-specific terms and preferred usage -->
-<!-- Example: Use "workspace" not "project", "member" not "user" -->
+Run Mintlify commands from the `docs` directory:
 
-## Style preferences
+```bash
+mint dev
+mint broken-links
+```
 
-<!-- Add any project-specific style rules below -->
+Use `mint dev` to preview pages locally at `http://localhost:3000`. Use
+`mint broken-links` when a change touches navigation, page slugs, or links.
 
-- Use active voice and second person ("you")
-- Keep sentences concise — one idea per sentence
-- Use sentence case for headings
-- Bold for UI elements: Click **Settings**
-- Code formatting for file names, commands, paths, and code references
+## Writing Style
 
-## Content boundaries
+- Use active voice and second person.
+- Prefer short sentences with one idea each.
+- Put the user's goal before implementation details.
+- Use sentence case for headings.
+- Use backticks for commands, paths, filenames, configuration keys, and code.
+- Use bold only for visible UI labels, such as **Settings**.
+- Keep examples runnable and aligned with the current CLI behavior.
 
-<!-- Define what should and shouldn't be documented -->
-<!-- Example: Don't document internal admin features -->
+## Content Boundaries
 
-- Unless the user explicitly asks for localized documentation updates, only edit the default English docs under `docs/`.
-- Do not modify files under locale directories such as `docs/zh-CN/` or `docs/vi-VN/` for routine docs cleanup or copy changes.
+- Edit only the default English docs unless the user asks for localized docs.
+- Do not modify files under `docs/zh-CN/` or `docs/vi-VN/` during routine docs
+  cleanup or copy changes.
+- Keep Mintlify component usage consistent with the surrounding page.
+- Update `docs.json` in the same change when you add, remove, rename, or move a
+  page.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,34 +1,55 @@
-> **Customize this file**: Tailor this template to your project by noting specific contribution types you're looking for, adding a Code of Conduct, or adjusting the writing guidelines to match your style.
+# Contribute to the Documentation
 
-# Contribute to the documentation
+Thanks for improving the Hyperlocalise docs. These docs explain how to install,
+configure, and operate Hyperlocalise, plus how to contribute to the project.
 
-Thank you for your interest in contributing to our documentation! This guide will help you get started.
+## What to Edit
 
-## How to contribute
+- Update English docs under `docs/` for routine fixes and new content.
+- Update `docs.json` when you add, move, rename, or remove a page.
+- Leave `docs/zh-CN/` and `docs/vi-VN/` unchanged unless you are explicitly
+  updating localized content.
+- Keep product behavior, command flags, and examples aligned with the CLI and
+  web app code.
 
-### Option 1: Edit directly on GitHub
+## Local Development
 
-1. Navigate to the page you want to edit
-2. Click the "Edit this file" button (the pencil icon)
-3. Make your changes and submit a pull request
+1. Install the Mintlify CLI:
 
-### Option 2: Local development
+   ```bash
+   npm i -g mint
+   ```
 
-1. Fork and clone this repository
-2. Install the Mintlify CLI: `npm i -g mint`
-3. Create a branch for your changes
-4. Make changes
-5. Navigate to the docs directory and run `mint dev`
-6. Preview your changes at `http://localhost:3000`
-7. Commit your changes and submit a pull request
+2. Run the preview server from the `docs` directory:
 
-For more details on local development, see our [development guide](development.mdx).
+   ```bash
+   mint dev
+   ```
 
-## Writing guidelines
+3. Open `http://localhost:3000` and review the changed pages.
 
-- **Use active voice**: "Run the command" not "The command should be run"
-- **Address the reader directly**: Use "you" instead of "the user"
-- **Keep sentences concise**: Aim for one idea per sentence
-- **Lead with the goal**: Start instructions with what the user wants to accomplish
-- **Use consistent terminology**: Don't alternate between synonyms for the same concept
-- **Include examples**: Show, don't just tell
+4. Check links when the change touches navigation or cross-page references:
+
+   ```bash
+   mint broken-links
+   ```
+
+For broader repository setup, see `contributing/development.mdx`.
+
+## Writing Guidelines
+
+- Use active voice: "Run the command" instead of "The command should be run."
+- Address the reader directly with "you."
+- Keep sentences concise, with one idea per sentence.
+- Lead with the user's goal before explaining details.
+- Use consistent terms for the same concept.
+- Include examples for commands, configuration, and expected output.
+- Use sentence case for headings.
+- Format commands, paths, filenames, keys, and code values with backticks.
+- Bold UI labels only when referring to visible interface text.
+
+## Pull Requests
+
+Before opening a pull request, preview the docs locally and run the repository
+validation requested for your change. Keep documentation-only pull requests
+focused on the affected pages and navigation updates.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,55 +1,65 @@
-# Mintlify Starter Kit
+# Hyperlocalise Docs
 
-Use the starter kit to get your docs deployed and ready to customize.
+This directory contains the Mintlify documentation site for Hyperlocalise. The
+site covers the CLI, configuration, provider setup, storage adapters, workflows,
+and contributor guides.
 
-Click the green **Use this template** button at the top of this repo to copy the Mintlify starter kit. The starter kit contains examples with
+## Structure
 
-- Guide pages
-- Navigation
-- Customizations
-- API reference pages
-- Use of popular components
+- `docs.json`: Mintlify site configuration and navigation
+- `index.mdx`: English docs landing page
+- `getting-started/`, `commands/`, `configuration/`, `workflows/`: product
+  documentation
+- `providers/` and `storage/`: integration guides
+- `contributing/`: contributor and maintainer documentation
+- `zh-CN/` and `vi-VN/`: localized documentation
 
-**[Follow the full quickstart guide](https://starter.mintlify.com/quickstart)**
+Do not edit localized docs under `zh-CN/` or `vi-VN/` unless the change is
+explicitly for those locales.
 
-## AI-assisted writing
+## Local Preview
 
-Set up your AI coding tool to work with Mintlify:
+Install the Mintlify CLI:
+
+```bash
+npm i -g mint
+```
+
+Run the preview server from this `docs` directory, where `docs.json` lives:
+
+```bash
+mint dev
+```
+
+The local preview runs at `http://localhost:3000`.
+
+## Checks
+
+Check links before publishing larger documentation changes:
+
+```bash
+mint broken-links
+```
+
+If the local preview behaves unexpectedly, update the CLI:
+
+```bash
+mint update
+```
+
+## Publishing
+
+Mintlify deploys the documentation from the repository after changes land on the
+configured default branch. Keep navigation updates in `docs.json` together with
+the pages they add or remove.
+
+## AI-Assisted Writing
+
+Mintlify provides an optional documentation skill for AI coding tools:
 
 ```bash
 npx skills add https://mintlify.com/docs
 ```
 
-This command installs Mintlify's documentation skill for your configured AI tools like Claude Code, Cursor, Windsurf, and others. The skill includes component reference, writing standards, and workflow guidance.
-
-See the [AI tools guides](/ai-tools) for tool-specific setup.
-
-## Development
-
-Install the [Mintlify CLI](https://www.npmjs.com/package/mint) to preview your documentation changes locally. To install, use the following command:
-
-```
-npm i -g mint
-```
-
-Run the following command at the root of your documentation, where your `docs.json` is located:
-
-```
-mint dev
-```
-
-View your local preview at `http://localhost:3000`.
-
-## Publishing changes
-
-Install our GitHub app from your [dashboard](https://dashboard.mintlify.com/settings/organization/github-app) to propagate changes from your repo to your deployment. Changes are deployed to production automatically after pushing to the default branch.
-
-## Need help?
-
-### Troubleshooting
-
-- If your dev environment isn't running: Run `mint update` to ensure you have the most recent version of the CLI.
-- If a page loads as a 404: Make sure you are running in a folder with a valid `docs.json`.
-
-### Resources
-- [Mintlify documentation](https://mintlify.com/docs)
+Use it for Mintlify component references, writing standards, and docs workflow
+guidance when it is available in your environment.


### PR DESCRIPTION
## Summary

- Replace create-next-app starter text in the web README with Hyperlocalise web app setup and Vite+ workflow guidance.
- Replace Mintlify starter/customization placeholder text in the docs README, contributing guide, and docs agent instructions.
- Preserve the localized docs boundary for `docs/zh-CN/` and `docs/vi-VN/`.

## Validation

- `vp install`
- `vp check --fix`
- `vp test` (65 files, 413 tests, against disposable Postgres test DB)
- `make fmt`
- `make lint`
- `make test`
