### PR TITLE
[codex] Gate API key listing

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/api-key/api-key.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/api-key/api-key.route.ts
@@ -39,6 +39,10 @@ export function createApiKeyRoutes() {
   return new Hono<{ Variables: AuthVariables }>()
     .use("*", workosAuthMiddleware)
     .get("/", async (c) => {
+      if (!isApiKeyMutationAllowed(c.var.auth.membership.role)) {
+        return forbiddenResponse(c);
+      }
+
       const keys = await db
         .select({
           id: schema.organizationApiKeys.id,

--- a/apps/hyperlocalise-web/src/api/routes/api-key/api-key.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/api-key/api-key.route.ts
@@ -15,7 +15,7 @@ import {
   apiKeyNotFoundResponse,
   forbiddenResponse,
   invalidApiKeyPayloadResponse,
-  isApiKeyMutationAllowed,
+  isApiKeyAdminActionAllowed,
   ownedApiKeyWhere,
 } from "./api-key.shared";
 
@@ -39,7 +39,7 @@ export function createApiKeyRoutes() {
   return new Hono<{ Variables: AuthVariables }>()
     .use("*", workosAuthMiddleware)
     .get("/", async (c) => {
-      if (!isApiKeyMutationAllowed(c.var.auth.membership.role)) {
+      if (!isApiKeyAdminActionAllowed(c.var.auth.membership.role)) {
         return forbiddenResponse(c);
       }
 
@@ -65,7 +65,7 @@ export function createApiKeyRoutes() {
       return c.json({ apiKeys: keys }, 200);
     })
     .post("/", validateCreateApiKeyBody, async (c) => {
-      if (!isApiKeyMutationAllowed(c.var.auth.membership.role)) {
+      if (!isApiKeyAdminActionAllowed(c.var.auth.membership.role)) {
         return forbiddenResponse(c);
       }
 
@@ -95,7 +95,7 @@ export function createApiKeyRoutes() {
       return c.json({ apiKey: { ...apiKey, key: plainKey } }, 201);
     })
     .delete("/:apiKeyId", validateApiKeyIdParams, async (c) => {
-      if (!isApiKeyMutationAllowed(c.var.auth.membership.role)) {
+      if (!isApiKeyAdminActionAllowed(c.var.auth.membership.role)) {
         return forbiddenResponse(c);
       }
 

--- a/apps/hyperlocalise-web/src/api/routes/api-key/api-key.shared.ts
+++ b/apps/hyperlocalise-web/src/api/routes/api-key/api-key.shared.ts
@@ -10,7 +10,7 @@ import {
 } from "@/api/errors";
 import { schema } from "@/lib/database";
 
-const allowedMutationRoles = new Set<string>(["owner", "admin"]);
+const allowedAdminActionRoles = new Set<string>(["owner", "admin"]);
 
 export function invalidApiKeyPayloadResponse(
   c: { json: JsonContext["json"] },
@@ -27,8 +27,8 @@ export function forbiddenResponse(c: { json: JsonContext["json"] }) {
   return sharedForbiddenResponse(c, "forbidden", "Insufficient permissions");
 }
 
-export function isApiKeyMutationAllowed(role: ApiAuthContext["membership"]["role"]) {
-  return allowedMutationRoles.has(role);
+export function isApiKeyAdminActionAllowed(role: ApiAuthContext["membership"]["role"]) {
+  return allowedAdminActionRoles.has(role);
 }
 
 export function ownedApiKeyWhere(auth: ApiAuthContext, apiKeyId: string) {

--- a/apps/hyperlocalise-web/src/api/routes/api-key/api-key.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/api-key/api-key.test.ts
@@ -87,6 +87,28 @@ describe("apiKeyRoutes", () => {
     );
   });
 
+  it("returns 200 when an admin lists API keys", async () => {
+    const ownerIdentity = createWorkosIdentity();
+    const adminIdentity = createWorkosIdentityForOrganization(ownerIdentity.organization, "admin");
+
+    await createApiKeyViaApi(ownerIdentity, { name: "Admin Visible Key" });
+
+    const response = await client.api.orgs[":organizationSlug"]["api-keys"].$get(
+      {
+        param: { organizationSlug: ownerIdentity.organization.slug ?? "missing-slug" },
+      },
+      {
+        headers: await authHeadersFor(adminIdentity),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { apiKeys: Array<{ name: string }> };
+    expect(body.apiKeys).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: "Admin Visible Key" })]),
+    );
+  });
+
   it("returns 403 when a member lists API keys", async () => {
     const ownerIdentity = createWorkosIdentity();
     const memberIdentity = createWorkosIdentityForOrganization(

--- a/apps/hyperlocalise-web/src/api/routes/api-key/api-key.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/api-key/api-key.test.ts
@@ -87,6 +87,29 @@ describe("apiKeyRoutes", () => {
     );
   });
 
+  it("returns 403 when a member lists API keys", async () => {
+    const ownerIdentity = createWorkosIdentity();
+    const memberIdentity = createWorkosIdentityForOrganization(
+      ownerIdentity.organization,
+      "member",
+    );
+
+    await createApiKeyViaApi(ownerIdentity, { name: "Hidden Key" });
+
+    const response = await client.api.orgs[":organizationSlug"]["api-keys"].$get(
+      {
+        param: { organizationSlug: ownerIdentity.organization.slug ?? "missing-slug" },
+      },
+      {
+        headers: await authHeadersFor(memberIdentity),
+      },
+    );
+
+    expect(response.status).toBe(403);
+    const responseBody = await response.json();
+    expect(responseBody).toMatchObject({ error: "forbidden", message: expect.any(String) });
+  });
+
   it("revokes an API key", async () => {
     const identity = createWorkosIdentity();
     const headers = await authHeadersFor(identity);


### PR DESCRIPTION
## Summary

- Require owner/admin permissions before listing organization API key metadata.
- Add a regression test proving a same-org member receives 403 for API key listing.

## Validation

- make bootstrap
- DATABASE_URL=postgres://hyperlocalise:hyperlocalise@localhost:5432/hyperlocalise ./node_modules/.bin/vp run db:migrate
- DATABASE_URL=postgres://hyperlocalise:hyperlocalise@localhost:5432/hyperlocalise ./node_modules/.bin/vp test
- ./node_modules/.bin/vp check --fix
- make fmt
- make lint
- make test
