### PR TITLE
[codex] Replace direct Vitest imports

### DIFF
--- a/apps/hyperlocalise-web/src/api/response.schema.test.ts
+++ b/apps/hyperlocalise-web/src/api/response.schema.test.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { testClient } from "hono/testing";
-import { describe, expect, expectTypeOf, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vite-plus/test";
 
 import { notFoundResponse } from "./response.schema";
 

--- a/apps/hyperlocalise-web/src/api/routes/health.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/health.test.ts
@@ -1,5 +1,5 @@
 import { testClient } from "hono/testing";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 async function createClient(isHealthy: boolean) {
   vi.resetModules();

--- a/apps/hyperlocalise-web/src/api/security-headers.test.ts
+++ b/apps/hyperlocalise-web/src/api/security-headers.test.ts
@@ -1,6 +1,6 @@
 import "dotenv/config";
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vite-plus/test";
 import { createApp } from "@/api/app";
 
 const app = createApp();

--- a/apps/hyperlocalise-web/src/components/ai-elements/schema-display.test.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/schema-display.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vite-plus/test";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { SchemaDisplay, SchemaDisplayPath } from "./schema-display";

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vite-plus/test";
 
 import { getAppShellTitle } from "./app-shell-title";
 

--- a/apps/hyperlocalise-web/src/lib/log.redaction.test.ts
+++ b/apps/hyperlocalise-web/src/lib/log.redaction.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect } from "vite-plus/test";
 import pino from "pino";
 import { REDACTION_PATHS } from "./log";
 

--- a/apps/hyperlocalise-web/src/lib/primitives/noNulls/noNulls.test.ts
+++ b/apps/hyperlocalise-web/src/lib/primitives/noNulls/noNulls.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vite-plus/test";
 
 import { noNulls } from "./noNulls";
 

--- a/apps/hyperlocalise-web/src/lib/primitives/result/results.test.ts
+++ b/apps/hyperlocalise-web/src/lib/primitives/result/results.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vite-plus/test";
 
 import { err, fromThrowable, fromThrowableAsync, isErr, isOk, ok, okOr, okOrElse } from "./results";
 

--- a/apps/hyperlocalise-web/src/lib/primitives/safeJsonParse/safeJsonParse.test.ts
+++ b/apps/hyperlocalise-web/src/lib/primitives/safeJsonParse/safeJsonParse.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vite-plus/test";
 
 import { isErr, isOk } from "../result/results";
 import { safeJsonParse } from "./safeJsonParse";

--- a/apps/hyperlocalise-web/src/lib/tools/rbac.test.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/rbac.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vite-plus/test";
 
 // Mock environment and database before importing tools
 vi.mock("@/lib/env", () => ({

--- a/apps/hyperlocalise-web/src/lib/translation/normalizeTranslationMemorySourceText.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/normalizeTranslationMemorySourceText.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vite-plus/test";
 
 import { normalizeTranslationMemorySourceText } from "./normalizeTranslationMemorySourceText";
 

--- a/apps/hyperlocalise-web/src/lib/workos/return-to.test.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/return-to.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vite-plus/test";
 import { sanitizeReturnTo } from "./return-to";
 
 describe("sanitizeReturnTo", () => {


### PR DESCRIPTION
## Summary

- Replace direct `vitest` test utility imports in web tests with `vite-plus/test`.
- Keep test behavior unchanged; only import module specifiers changed.

## Validation

- `vp check --fix`
- `vp test`
- `make fmt`
- `make lint`
- `make test`
