### PR TITLE
fix(github): handle slugless install callback redirect

### DIFF
--- a/apps/hyperlocalise-web/src/app/auth/github/callback/page.test.ts
+++ b/apps/hyperlocalise-web/src/app/auth/github/callback/page.test.ts
@@ -129,7 +129,7 @@ describe("GitHubCallbackPage", () => {
   });
 
   it("persists an installation, syncs repositories, and consumes state for the same admin user", async () => {
-    const { auth, nonce, slug, state } = await createCallbackState({ role: "admin" });
+    const { auth, nonce, state } = await createCallbackState({ role: "admin" });
 
     await expect(runCallback(state)).rejects.toThrow(
       `redirect:/org/${slug}/settings?github_connected=1`,
@@ -166,7 +166,7 @@ describe("GitHubCallbackPage", () => {
     });
 
     await expect(runCallback(state)).rejects.toThrow(
-      `redirect:/org/${slug}/settings?github_connected=1`,
+      "redirect:/dashboard?github_connected=1",
     );
 
     const [installation] = await db

--- a/apps/hyperlocalise-web/src/app/auth/github/callback/page.test.ts
+++ b/apps/hyperlocalise-web/src/app/auth/github/callback/page.test.ts
@@ -129,7 +129,7 @@ describe("GitHubCallbackPage", () => {
   });
 
   it("persists an installation, syncs repositories, and consumes state for the same admin user", async () => {
-    const { auth, nonce, state } = await createCallbackState({ role: "admin" });
+    const { auth, nonce, slug, state } = await createCallbackState({ role: "admin" });
 
     await expect(runCallback(state)).rejects.toThrow(
       `redirect:/org/${slug}/settings?github_connected=1`,
@@ -160,14 +160,12 @@ describe("GitHubCallbackPage", () => {
   });
 
   it("persists an installation when the signed state uses a null-slug organization id", async () => {
-    const { auth, nonce, slug, state } = await createCallbackState({
+    const { auth, nonce, state } = await createCallbackState({
       nullSlug: true,
       role: "admin",
     });
 
-    await expect(runCallback(state)).rejects.toThrow(
-      "redirect:/dashboard?github_connected=1",
-    );
+    await expect(runCallback(state)).rejects.toThrow("redirect:/dashboard?github_connected=1");
 
     const [installation] = await db
       .select()

--- a/apps/hyperlocalise-web/src/app/auth/github/callback/page.tsx
+++ b/apps/hyperlocalise-web/src/app/auth/github/callback/page.tsx
@@ -146,5 +146,9 @@ export default async function GitHubCallbackPage({ searchParams }: GitHubCallbac
     // Admins can refresh repositories from the GitHub agent settings card.
   }
 
-  redirect(`/org/${verified.slug}/settings?github_connected=1`);
+  const redirectPath = org.slug
+    ? `/org/${org.slug}/settings?github_connected=1`
+    : "/dashboard?github_connected=1";
+
+  redirect(redirectPath);
 }


### PR DESCRIPTION
### Motivation
- Organizations without a slug could complete the GitHub App install flow but be redirected to a broken `/org/<uuid>/settings` URL, so the callback must only use the slug when present and otherwise fall back to a safe dashboard redirect.

### Description
- Update the GitHub callback success redirect in `apps/hyperlocalise-web/src/app/auth/github/callback/page.tsx` to use `org.slug` only when present and otherwise redirect to `/dashboard?github_connected=1`, and adjust `apps/hyperlocalise-web/src/app/auth/github/callback/page.test.ts` to assert the slugless fallback behavior.

### Testing
- Ran `make fmt` which succeeded, and attempted `make lint` (failed due to missing `golangci-lint`), `make test` (failed due to Go toolchain version mismatch), and `vp check --fix` / `vp test` (failed in this environment because `vp` is not available).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c72dca53c832c9c0e07b58644a3d5)