### PR TITLE
fix(cli): preserve extract message formatting

### DIFF
--- a/apps/cli/cmd/extract.go
+++ b/apps/cli/cmd/extract.go
@@ -79,6 +79,7 @@ func writeExtractOutput(cmd *cobra.Command, messages []extractMessage, options e
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf)
 	enc.SetIndent("", "  ")
+	enc.SetEscapeHTML(false)
 	if err := enc.Encode(payload); err != nil {
 		return fmt.Errorf("encode extract output: %w", err)
 	}

--- a/apps/cli/cmd/extract_icu.go
+++ b/apps/cli/cmd/extract_icu.go
@@ -191,10 +191,10 @@ func writeExtractICUArgument(b *strings.Builder, value string) {
 func writeExtractICUTypedArgument(b *strings.Builder, value, kind, style string) {
 	b.WriteByte('{')
 	b.WriteString(value)
-	b.WriteString(", ")
+	b.WriteByte(',')
 	b.WriteString(kind)
 	if style != "" {
-		b.WriteString(", ")
+		b.WriteByte(',')
 		b.WriteString(style)
 	}
 	b.WriteByte('}')

--- a/apps/cli/cmd/extract_icu.go
+++ b/apps/cli/cmd/extract_icu.go
@@ -203,9 +203,8 @@ func writeExtractICUTypedArgument(b *strings.Builder, value, kind, style string)
 func writeExtractICUSelect(b *strings.Builder, element icuparser.SelectElement) {
 	b.WriteByte('{')
 	b.WriteString(element.Value)
-	b.WriteString(", select,")
+	b.WriteString(",select,")
 	for _, option := range element.Options {
-		b.WriteByte(' ')
 		b.WriteString(option.Selector)
 		b.WriteByte('{')
 		b.WriteString(renderExtractICUElements(option.Value, false))
@@ -218,16 +217,18 @@ func writeExtractICUPlural(b *strings.Builder, element icuparser.PluralElement) 
 	b.WriteByte('{')
 	b.WriteString(element.Value)
 	if element.Type() == icuparser.TypeSelectOrdinal {
-		b.WriteString(", selectordinal,")
+		b.WriteString(",selectordinal,")
 	} else {
-		b.WriteString(", plural,")
+		b.WriteString(",plural,")
 	}
 	if element.Offset != 0 {
-		b.WriteString(" offset:")
+		b.WriteString("offset:")
 		b.WriteString(strconv.Itoa(element.Offset))
+		if len(element.Options) > 0 {
+			b.WriteByte(' ')
+		}
 	}
 	for _, option := range element.Options {
-		b.WriteByte(' ')
 		b.WriteString(option.Selector)
 		b.WriteByte('{')
 		b.WriteString(renderExtractICUElements(option.Value, true))

--- a/apps/cli/cmd/extract_icu_test.go
+++ b/apps/cli/cmd/extract_icu_test.go
@@ -53,6 +53,11 @@ func TestFlattenExtractICUMessage(t *testing.T) {
 			want: "{count,plural,offset:1 =0{Invite nobody.}one{Invite {name}.}other{Invite {name} and # others.}}",
 		},
 		{
+			name: "typed arguments use compact commas in flattened selectors",
+			in:   "Total {amount, number} due {dueDate, date, medium} for {count, plural, one{one item} other{# items}}.",
+			want: "{count,plural,one{Total {amount,number} due {dueDate,date,medium} for one item.}other{Total {amount,number} due {dueDate,date,medium} for # items.}}",
+		},
+		{
 			name: "unsupported custom formatter stays unchanged",
 			in:   "You waited {count, plural, one{{duration, duration} day} other{{duration, duration} days}}.",
 			want: "You waited {count, plural, one{{duration, duration} day} other{{duration, duration} days}}.",

--- a/apps/cli/cmd/extract_icu_test.go
+++ b/apps/cli/cmd/extract_icu_test.go
@@ -1,6 +1,10 @@
 package cmd
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/icuparser"
+)
 
 func TestFlattenExtractICUMessage(t *testing.T) {
 	tests := []struct {
@@ -16,37 +20,37 @@ func TestFlattenExtractICUMessage(t *testing.T) {
 		{
 			name: "plural hoists prefix suffix and pound",
 			in:   "You have {count, plural, one{one project} other{# projects}}.",
-			want: "{count, plural, one{You have one project.} other{You have # projects.}}",
+			want: "{count,plural,one{You have one project.}other{You have # projects.}}",
 		},
 		{
 			name: "select hoists prefix and suffix",
 			in:   "The {gender, select, female{hostess} male{host} other{host}} arrived.",
-			want: "{gender, select, female{The hostess arrived.} male{The host arrived.} other{The host arrived.}}",
+			want: "{gender,select,female{The hostess arrived.}male{The host arrived.}other{The host arrived.}}",
 		},
 		{
 			name: "selectordinal hoists prefix and suffix",
 			in:   "You finished {place, selectordinal, one{#st} two{#nd} few{#rd} other{#th}}.",
-			want: "{place, selectordinal, one{You finished #st.} two{You finished #nd.} few{You finished #rd.} other{You finished #th.}}",
+			want: "{place,selectordinal,one{You finished #st.}two{You finished #nd.}few{You finished #rd.}other{You finished #th.}}",
 		},
 		{
 			name: "nested selectors are flattened recursively",
 			in:   "{gender, select, female{She has {count, plural, one{one file} other{# files}}} male{He has {count, plural, one{one file} other{# files}}} other{They have {count, plural, one{one file} other{# files}}}}.",
-			want: "{gender, select, female{{count, plural, one{She has one file.} other{She has # files.}}} male{{count, plural, one{He has one file.} other{He has # files.}}} other{{count, plural, one{They have one file.} other{They have # files.}}}}",
+			want: "{gender,select,female{{count,plural,one{She has one file.}other{She has # files.}}}male{{count,plural,one{He has one file.}other{He has # files.}}}other{{count,plural,one{They have one file.}other{They have # files.}}}}",
 		},
 		{
 			name: "rich text tags are preserved in plural branches",
 			in:   "{count, plural, one{<b>One file</b>} other{<b># files</b>}} selected.",
-			want: "{count, plural, one{<b>One file</b> selected.} other{<b># files</b> selected.}}",
+			want: "{count,plural,one{<b>One file</b> selected.}other{<b># files</b> selected.}}",
 		},
 		{
 			name: "quoted braces in literals are preserved",
 			in:   "Set '{'count'}' to {count, plural, one{one value} other{# values}}.",
-			want: "{count, plural, one{Set '{'count'}' to one value.} other{Set '{'count'}' to # values.}}",
+			want: "{count,plural,one{Set '{'count'}' to one value.}other{Set '{'count'}' to # values.}}",
 		},
 		{
 			name: "plural offset is preserved",
 			in:   "Invite {count, plural, offset:1 =0{nobody} one{{name}} other{{name} and # others}}.",
-			want: "{count, plural, offset:1 =0{Invite nobody.} one{Invite {name}.} other{Invite {name} and # others.}}",
+			want: "{count,plural,offset:1 =0{Invite nobody.}one{Invite {name}.}other{Invite {name} and # others.}}",
 		},
 		{
 			name: "unsupported custom formatter stays unchanged",
@@ -63,6 +67,9 @@ func TestFlattenExtractICUMessage(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Fatalf("flattened message = %q, want %q", got, tt.want)
+			}
+			if _, err := icuparser.Parse(got, nil); err != nil {
+				t.Fatalf("flattened message should parse as ICU: %v", err)
 			}
 		})
 	}

--- a/apps/cli/cmd/extract_test.go
+++ b/apps/cli/cmd/extract_test.go
@@ -110,6 +110,45 @@ export function AppHeader() {
 	}
 }
 
+func TestExtractCommandDoesNotEscapeRichTextTagsInJSON(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	writeExtractTestFile(t, filepath.Join(dir, "src", "App.tsx"), `
+import { defineMessage } from "react-intl";
+
+export const redirect = defineMessage({
+  id: "app.redirect",
+  defaultMessage: "If you weren't redirected, <link>click here</link>",
+});
+
+export const sop = defineMessage({
+  id: "app.sop",
+  defaultMessage: "Use <atSymbol>@</atSymbol> in the SOP to reference capabilities.",
+});
+`)
+
+	cmd := newExtractCmd()
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"src"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute extract command: %v", err)
+	}
+
+	raw := out.String()
+	if strings.Contains(raw, `\u003c`) || strings.Contains(raw, `\u003e`) {
+		t.Fatalf("output should keep rich text tags unescaped: %s", raw)
+	}
+	if !strings.Contains(raw, `<link>click here</link>`) {
+		t.Fatalf("output missing unescaped link tag: %s", raw)
+	}
+	if !strings.Contains(raw, `<atSymbol>@</atSymbol>`) {
+		t.Fatalf("output missing unescaped atSymbol tag: %s", raw)
+	}
+}
+
 func TestExtractCommandPrefixesIDWithNormalizedFilename(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
@@ -211,7 +250,7 @@ export const message: { id: "app.types"; defaultMessage: "Types" };
 	if err := json.Unmarshal(content, &catalog); err != nil {
 		t.Fatalf("decode formatjs catalog: %v\noutput=%s", err, string(content))
 	}
-	if got, want := catalog["app.title"]["defaultMessage"], "{count, plural, one{I have a dog} other{I have many dogs}}"; got != want {
+	if got, want := catalog["app.title"]["defaultMessage"], "{count,plural,one{I have a dog}other{I have many dogs}}"; got != want {
 		t.Fatalf("app.title defaultMessage = %q, want %q", got, want)
 	}
 	if _, ok := catalog["app.title"]["description"]; ok {
@@ -254,7 +293,7 @@ export const title = defineMessage({
 	if got, want := len(catalog), 1; got != want {
 		t.Fatalf("message count = %d, want %d; output=%s", got, want, out.String())
 	}
-	if got, want := catalog["app.title"].DefaultMessage, "{count, plural, one{You have one project.} other{You have # projects.}}"; got != want {
+	if got, want := catalog["app.title"].DefaultMessage, "{count,plural,one{You have one project.}other{You have # projects.}}"; got != want {
 		t.Fatalf("flattened defaultMessage = %q, want %q", got, want)
 	}
 	if strings.Contains(out.String(), `"id":`) {


### PR DESCRIPTION
## What changed

- Disable HTML escaping in extract JSON output so rich text placeholders stay readable, like `<link>click here</link>`.
- Render flattened ICU selectors compactly, like `{mode,select,view{...}}`.
- Add regression tests for rich text tags and compact flattened ICU output.

## How to test

- `go test ./apps/cli/cmd -run 'TestExtractCommand|TestFlattenExtractICUMessage'`
- `make fmt`
- `make lint`
- `make test`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review