### PR TITLE
fix(cli): extract slash-prefixed JSX message ids

### DIFF
--- a/apps/cli/cmd/extract.go
+++ b/apps/cli/cmd/extract.go
@@ -1132,7 +1132,7 @@ func skipStringLiteral(src string, index int) int {
 }
 
 func skipComment(src string, index int) (int, bool) {
-	if index+1 >= len(src) {
+	if index >= len(src) || src[index] != '/' || index+1 >= len(src) {
 		return index, false
 	}
 

--- a/apps/cli/cmd/extract_test.go
+++ b/apps/cli/cmd/extract_test.go
@@ -149,6 +149,38 @@ export const sop = defineMessage({
 	}
 }
 
+func TestExtractCommandExtractsJSXMessageIDStartingWithSlash(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	source := `
+import { FormattedMessage } from "react-intl";
+
+export function App() {
+  return <FormattedMessage defaultMessage="Open settings" id="/app.settings.open" />;
+}
+`
+	writeExtractTestFile(t, filepath.Join(dir, "src", "App.tsx"), source)
+
+	cmd := newExtractCmd()
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"src"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute extract command: %v", err)
+	}
+
+	catalog := decodeExtractTestCatalog(t, out.Bytes())
+	got, ok := catalog["/app.settings.open"]
+	if !ok {
+		t.Fatalf("missing slash-prefixed id in output=%s", out.String())
+	}
+	if got.DefaultMessage != "Open settings" {
+		t.Fatalf("defaultMessage = %q, want %q", got.DefaultMessage, "Open settings")
+	}
+}
+
 func TestExtractCommandPrefixesIDWithNormalizedFilename(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)


### PR DESCRIPTION
## What changed

Fixed the React Intl extractor so JSX attributes with slash-prefixed string values, such as `id="/app.settings.open"`, are parsed correctly.

The issue was in comment skipping: the scanner could treat a quoted value beginning with `/` as a comment because it did not first verify that the current character was `/`. Added a generic regression test for slash-prefixed `FormattedMessage` ids.

## How to test

- `go test ./apps/cli/cmd -run TestExtractCommand -count=1`
- `make fmt`
- `make lint`
- `make test`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review