### PR TITLE
fix(extract): support computed keys and generated FormatJS ids

### DIFF
--- a/apps/cli/cmd/extract.go
+++ b/apps/cli/cmd/extract.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"bytes"
+	"crypto/sha512"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"html"
@@ -596,7 +598,11 @@ func extractMessageDescriptor(src, file string, objectStart, objectEnd int) (ext
 
 	id, ok := values["id"]
 	if !ok || strings.TrimSpace(id) == "" {
-		return extractMessage{}, false, nil
+		defaultMessage, ok := values["defaultMessage"]
+		if !ok {
+			return extractMessage{}, false, nil
+		}
+		id = generatedFormatJSMessageID(defaultMessage, values["description"])
 	}
 
 	return extractMessage{
@@ -678,6 +684,10 @@ func readObjectPropertyKey(src string, index int) (string, int, bool) {
 	if index >= len(src) {
 		return "", index, false
 	}
+	if src[index] == '[' {
+		end, ok := findMatchingDelimiter(src, index, '[', ']')
+		return "", end + 1, ok
+	}
 	if isStringQuote(src[index]) {
 		value, next, ok := parseStaticStringLiteral(src, index)
 		return value, next, ok
@@ -744,7 +754,16 @@ func extractReactIntlJSXMessages(src, file string) ([]extractMessage, error) {
 		if err != nil {
 			return nil, err
 		}
-		if id, ok := attrs["id"]; ok && strings.TrimSpace(id) != "" {
+		id := attrs["id"]
+		if strings.TrimSpace(id) == "" {
+			defaultMessage, ok := attrs["defaultMessage"]
+			if !ok {
+				i = tagEnd + 1
+				continue
+			}
+			id = generatedFormatJSMessageID(defaultMessage, attrs["description"])
+		}
+		if strings.TrimSpace(id) != "" {
 			messages = append(messages, extractMessage{
 				ID:             id,
 				DefaultMessage: attrs["defaultMessage"],
@@ -757,6 +776,11 @@ func extractReactIntlJSXMessages(src, file string) ([]extractMessage, error) {
 	}
 
 	return messages, nil
+}
+
+func generatedFormatJSMessageID(defaultMessage, description string) string {
+	sum := sha512.Sum512([]byte(defaultMessage + "#" + description))
+	return base64.StdEncoding.EncodeToString(sum[:])[:6]
 }
 
 func isReactIntlJSXName(name string) bool {

--- a/apps/cli/cmd/extract.go
+++ b/apps/cli/cmd/extract.go
@@ -779,7 +779,11 @@ func extractReactIntlJSXMessages(src, file string) ([]extractMessage, error) {
 }
 
 func generatedFormatJSMessageID(defaultMessage, description string) string {
-	sum := sha512.Sum512([]byte(defaultMessage + "#" + description))
+	content := defaultMessage
+	if description != "" {
+		content = defaultMessage + "#" + description
+	}
+	sum := sha512.Sum512([]byte(content))
 	return base64.StdEncoding.EncodeToString(sum[:])[:6]
 }
 

--- a/apps/cli/cmd/extract_test.go
+++ b/apps/cli/cmd/extract_test.go
@@ -110,6 +110,105 @@ export function AppHeader() {
 	}
 }
 
+func TestExtractCommandExtractsDefineMessagesWithComputedKeys(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	writeExtractTestFile(t, filepath.Join(dir, "src", "DeleteAccount.tsx"), `
+import { defineMessages } from "react-intl";
+
+enum UserDeleteReason {
+  Leaving_current_role = "Leaving_current_role",
+  Switching_to_another_product = "Switching_to_another_product",
+}
+
+const DELETE_REASON_LABELS = defineMessages({
+  [UserDeleteReason.Leaving_current_role]: {
+    id: '8+RXxBclvz',
+    defaultMessage: 'Leaving current role',
+    description: 'Account deletion survey: reason option',
+  },
+  [UserDeleteReason.Switching_to_another_product]: {
+    id: '5faw+pEI3P',
+    defaultMessage: 'Switching to another product',
+    description: 'Account deletion survey: reason option',
+  },
+});
+`)
+
+	cmd := newExtractCmd()
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"src"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute extract command: %v", err)
+	}
+
+	catalog := decodeExtractTestCatalog(t, out.Bytes())
+	if got, want := len(catalog), 2; got != want {
+		t.Fatalf("message count = %d, want %d; output=%s", got, want, out.String())
+	}
+	if got, want := catalog["8+RXxBclvz"].DefaultMessage, "Leaving current role"; got != want {
+		t.Fatalf("computed-key message defaultMessage = %q, want %q", got, want)
+	}
+	if got, want := catalog["5faw+pEI3P"].Description, "Account deletion survey: reason option"; got != want {
+		t.Fatalf("computed-key message description = %q, want %q", got, want)
+	}
+}
+
+func TestExtractCommandGeneratesFormatJSIDForMissingID(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	writeExtractTestFile(t, filepath.Join(dir, "src", "DocumentPreview.tsx"), `
+import { defineMessages, FormattedMessage } from "react-intl";
+
+const messages = defineMessages({
+  title: {
+    defaultMessage: 'Document preview \u2014 {documentName}',
+    description:
+      'Dialog title for previewing a generated document with the document name appended',
+  },
+});
+
+export function DocumentPreview() {
+  return (
+    <FormattedMessage
+      defaultMessage="Open document"
+      description="Button label for opening the generated document preview"
+    />
+  );
+}
+`)
+
+	cmd := newExtractCmd()
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"src"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute extract command: %v", err)
+	}
+
+	catalog := decodeExtractTestCatalog(t, out.Bytes())
+	got, ok := catalog["OVx7L4"]
+	if !ok {
+		t.Fatalf("missing generated FormatJS id OVx7L4 in output=%s", out.String())
+	}
+	if got.DefaultMessage != "Document preview \u2014 {documentName}" {
+		t.Fatalf("generated-id defaultMessage = %q", got.DefaultMessage)
+	}
+	if got.Description != "Dialog title for previewing a generated document with the document name appended" {
+		t.Fatalf("generated-id description = %q", got.Description)
+	}
+
+	jsxID := generatedFormatJSMessageID("Open document", "Button label for opening the generated document preview")
+	if _, ok := catalog[jsxID]; !ok {
+		t.Fatalf("missing generated JSX id %q in output=%s", jsxID, out.String())
+	}
+}
+
 func TestExtractCommandDoesNotEscapeRichTextTagsInJSON(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)

--- a/apps/cli/cmd/extract_test.go
+++ b/apps/cli/cmd/extract_test.go
@@ -170,6 +170,9 @@ const messages = defineMessages({
     description:
       'Dialog title for previewing a generated document with the document name appended',
   },
+  save: {
+    defaultMessage: 'Save document',
+  },
 });
 
 export function DocumentPreview() {
@@ -178,6 +181,7 @@ export function DocumentPreview() {
       defaultMessage="Open document"
       description="Button label for opening the generated document preview"
     />
+    <FormattedMessage defaultMessage="Close preview" />
   );
 }
 `)
@@ -202,10 +206,20 @@ export function DocumentPreview() {
 	if got.Description != "Dialog title for previewing a generated document with the document name appended" {
 		t.Fatalf("generated-id description = %q", got.Description)
 	}
+	if got, ok := catalog["cBUY8d"]; !ok {
+		t.Fatalf("missing generated FormatJS id cBUY8d for descriptor without description in output=%s", out.String())
+	} else if got.DefaultMessage != "Save document" {
+		t.Fatalf("generated-id defaultMessage = %q", got.DefaultMessage)
+	}
 
 	jsxID := generatedFormatJSMessageID("Open document", "Button label for opening the generated document preview")
 	if _, ok := catalog[jsxID]; !ok {
 		t.Fatalf("missing generated JSX id %q in output=%s", jsxID, out.String())
+	}
+	if got, ok := catalog["8jAKYt"]; !ok {
+		t.Fatalf("missing generated JSX id 8jAKYt for message without description in output=%s", out.String())
+	} else if got.DefaultMessage != "Close preview" {
+		t.Fatalf("generated JSX defaultMessage = %q", got.DefaultMessage)
 	}
 }
 


### PR DESCRIPTION
## What changed

Updated the CLI React Intl extractor to handle more FormatJS-compatible message descriptors.

- Extracts nested `defineMessages` descriptors whose object keys are computed expressions, such as enum-backed keys.
- Generates FormatJS-style ids for descriptors without an explicit `id` when `defaultMessage` is present.
- Adds regression coverage for computed keys and generated ids with neutral fixture copy.

## How to test

- `go test ./apps/cli/cmd`
- `make fmt`
- `make lint`
- `make test`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review