### PR TITLE
HL-320: Add Java .properties locale parser and serializer support

### DIFF
--- a/apps/cli/cmd/check_test.go
+++ b/apps/cli/cmd/check_test.go
@@ -171,6 +171,42 @@ func TestCheckCommandJSONReportIncludesDefaultFindings(t *testing.T) {
 	}
 }
 
+func TestCheckCommandPropertiesFileRecognized(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "i18n.jsonc")
+	sourcePath := filepath.Join(dir, "content", "en", "messages.properties")
+	targetPath := filepath.Join(dir, "dist", "fr", "messages.properties")
+
+	for _, path := range []string{sourcePath, targetPath} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("create dir for %s: %v", path, err)
+		}
+	}
+	if err := os.WriteFile(sourcePath, []byte("welcome.message=Hello {0}\n"), 0o600); err != nil {
+		t.Fatalf("write source properties: %v", err)
+	}
+	if err := os.WriteFile(targetPath, []byte("welcome.message=Bonjour\nextra=Ancien\n"), 0o600); err != nil {
+		t.Fatalf("write target properties: %v", err)
+	}
+	writeCheckConfig(t, configPath, sourcePath, targetPath, []string{"fr"})
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"check", "--config", configPath, "--format", "json", "--no-fail"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("check command: %v", err)
+	}
+	var report checkReport
+	if err := json.Unmarshal(out.Bytes(), &report); err != nil {
+		t.Fatalf("parse json output: %v\noutput=%s", err, out.String())
+	}
+	assertFindingType(t, report.Findings, checkPlaceholder)
+	assertFindingType(t, report.Findings, checkOrphanedKey)
+}
+
 func TestCollectEntryCheckFindingsSkipsRedundantChecksForWhitespaceOnlyNotLocalizedValues(t *testing.T) {
 	findings := collectEntryCheckFindings(
 		&checkLocationResolver{},

--- a/apps/cli/cmd/run_test.go
+++ b/apps/cli/cmd/run_test.go
@@ -68,6 +68,46 @@ func TestRunDryRunDoesNotWriteTargets(t *testing.T) {
 	}
 }
 
+func TestRunDryRunPropertiesFileRecognized(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "i18n.jsonc")
+	sourcePath := filepath.Join(dir, "content", "en", "messages.properties")
+	targetPath := filepath.Join(dir, "dist", "fr", "messages.properties")
+
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
+		t.Fatalf("create source dir: %v", err)
+	}
+	if err := os.WriteFile(sourcePath, []byte("# Checkout\nwelcome.message=Hello {0}\n"), 0o600); err != nil {
+		t.Fatalf("write source properties: %v", err)
+	}
+
+	content := `{
+	  "locales": {"source":"en","targets":["fr"]},
+	  "buckets": {"ui":{"files":[{"from":"` + filepath.ToSlash(sourcePath) + `","to":"` + filepath.ToSlash(targetPath) + `"}]}},
+	  "groups": {"default":{"targets":["fr"],"buckets":["ui"]}},
+	  "llm": {"profiles":{"default":{"provider":"openai","model":"gpt-4.1-mini","prompt":"Translate {{input}}"}}}
+	}`
+	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"run", "--config", configPath, "--dry-run"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("run command properties dry-run: %v", err)
+	}
+	if !strings.Contains(out.String(), "planned_total=1") || !strings.Contains(out.String(), filepath.ToSlash(targetPath)) {
+		t.Fatalf("expected .properties dry-run task, got %q", out.String())
+	}
+	if _, err := os.Stat(targetPath); !os.IsNotExist(err) {
+		t.Fatalf("expected no target file written in dry-run, stat err=%v", err)
+	}
+}
+
 func TestRunDryRunSupportsYAMLFiles(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "i18n.jsonc")
@@ -84,6 +124,7 @@ func TestRunDryRunSupportsYAMLFiles(t *testing.T) {
 	content := `{
 	  "locales": {"source":"en","targets":["fr"]},
 	  "buckets": {"ui":{"files":[{"from":"` + filepath.ToSlash(sourcePath) + `","to":"` + filepath.ToSlash(filepath.Join(dir, "dist", "[locale]", "strings.yaml")) + `"}]}},
+	  "groups": {"default":{"targets":["fr"],"buckets":["ui"]}},
 	  "llm": {"profiles":{"default":{"provider":"openai","model":"gpt-4.1-mini","prompt":"Translate {{input}}"}}}
 	}`
 	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {

--- a/apps/cli/cmd/status_test.go
+++ b/apps/cli/cmd/status_test.go
@@ -299,6 +299,49 @@ func TestStatusCommandBucketFilterUsesLocalstoreNamespace(t *testing.T) {
 	}
 }
 
+func TestStatusCommandPropertiesFileRecognized(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "i18n.jsonc")
+	sourcePath := filepath.Join(dir, "content", "en", "messages.properties")
+	targetPath := filepath.Join(dir, "dist", "fr", "messages.properties")
+
+	for _, path := range []string{sourcePath, targetPath} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", path, err)
+		}
+	}
+	if err := os.WriteFile(sourcePath, []byte("welcome.message=Hello {0}\n"), 0o600); err != nil {
+		t.Fatalf("write source properties: %v", err)
+	}
+	if err := os.WriteFile(targetPath, []byte("welcome.message=Bonjour {0}\n"), 0o600); err != nil {
+		t.Fatalf("write target properties: %v", err)
+	}
+
+	content := `{
+  "locales": {"source":"en","targets":["fr"]},
+  "buckets": {"ui":{"files":[{"from":"` + filepath.ToSlash(sourcePath) + `","to":"` + filepath.ToSlash(targetPath) + `"}]}},
+  "groups": {"default":{"targets":["fr"],"buckets":["ui"]}},
+  "llm": {"profiles":{"default":{"provider":"openai","model":"gpt-4.1-mini","prompt":"Translate"}}}
+}`
+	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"status", "--config", configPath, "--bucket", "ui"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute status command: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "welcome.message") || !strings.Contains(got, ",fr,translated,unknown,") {
+		t.Fatalf("expected translated .properties row, got: %s", got)
+	}
+}
+
 func TestStatusCommandReadsYAMLFiles(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "i18n.jsonc")

--- a/apps/cli/cmd/sync_hyperlocalise.go
+++ b/apps/cli/cmd/sync_hyperlocalise.go
@@ -556,6 +556,8 @@ func inferHyperlocaliseFileFormat(path string) string {
 		return "stringsdict"
 	case ".csv":
 		return "csv"
+	case ".properties":
+		return "properties"
 	default:
 		return ""
 	}
@@ -908,7 +910,7 @@ func contentTypeForPath(path string) string {
 	switch strings.ToLower(filepath.Ext(path)) {
 	case ".md", ".mdx":
 		return "text/markdown"
-	case ".po", ".strings", ".stringsdict":
+	case ".po", ".strings", ".stringsdict", ".properties":
 		return "text/plain"
 	default:
 		return "application/octet-stream"

--- a/apps/cli/internal/i18n/runsvc/output_marshal.go
+++ b/apps/cli/internal/i18n/runsvc/output_marshal.go
@@ -15,7 +15,7 @@ import (
 func (s *Service) marshalTargetFile(path, sourcePath, sourceLocale, targetLocale string, values map[string]string, stagedEntries map[string]string, pruneKeys map[string]struct{}) ([]byte, []string, error) {
 	ext := strings.ToLower(filepath.Ext(path))
 	switch ext {
-	case ".xlf", ".xlif", ".xliff", ".po", ".md", ".mdx", ".strings", ".stringsdict", ".csv", ".arb", ".html", ".liquid", ".xml", ".resx":
+	case ".xlf", ".xlif", ".xliff", ".po", ".md", ".mdx", ".strings", ".stringsdict", ".csv", ".arb", ".html", ".liquid", ".xml", ".resx", ".properties":
 		return s.marshalTemplateBasedTarget(ext, path, sourcePath, sourceLocale, targetLocale, values, stagedEntries)
 	case ".json", ".jsonc":
 		content, err := s.marshalJSONTargetWithFallback(path, sourcePath, values, pruneKeys)
@@ -38,7 +38,7 @@ func (s *Service) marshalTemplateBasedTarget(ext, path, sourcePath, sourceLocale
 	if ext == ".liquid" {
 		return s.marshalLiquidTarget(path, sourcePath, stagedEntries)
 	}
-	if ext == ".xlf" || ext == ".xlif" || ext == ".xliff" || ext == ".po" || ext == ".strings" || ext == ".stringsdict" || ext == ".arb" || ext == ".xml" || ext == ".resx" {
+	if ext == ".xlf" || ext == ".xlif" || ext == ".xliff" || ext == ".po" || ext == ".strings" || ext == ".stringsdict" || ext == ".arb" || ext == ".xml" || ext == ".resx" || ext == ".properties" {
 		content, err := s.marshalSourceTemplateTarget(ext, path, sourcePath, sourceLocale, targetLocale, values)
 		return content, nil, err
 	}
@@ -114,6 +114,12 @@ func (s *Service) marshalSourceTemplateTarget(ext, path, sourcePath, sourceLocal
 		return content, nil
 	case ".xml", ".resx":
 		content, err := translationfileparser.MarshalGenericXMLWithTargetLocale(template, values, sourceLocale, targetLocale)
+		if err != nil {
+			return nil, fmt.Errorf("flush outputs: marshal %q: %w", path, err)
+		}
+		return content, nil
+	case ".properties":
+		content, err := translationfileparser.MarshalJavaProperties(template, values)
 		if err != nil {
 			return nil, fmt.Errorf("flush outputs: marshal %q: %w", path, err)
 		}

--- a/apps/cli/internal/i18n/runsvc/output_marshal_test.go
+++ b/apps/cli/internal/i18n/runsvc/output_marshal_test.go
@@ -243,6 +243,33 @@ func TestMarshalTargetFileJSONC(t *testing.T) {
 	}
 }
 
+func TestMarshalSourceTemplateTargetJavaProperties(t *testing.T) {
+	sourcePath := filepath.Join(t.TempDir(), "source.properties")
+	targetPath := filepath.Join(t.TempDir(), "target.properties")
+	source := "# Checkout\nhello = Hello {0}\n"
+	target := "# Checkout translated\nhello = Salut {0}\n"
+	if err := os.WriteFile(sourcePath, []byte(source), 0o644); err != nil {
+		t.Fatalf("write source properties: %v", err)
+	}
+	if err := os.WriteFile(targetPath, []byte(target), 0o644); err != nil {
+		t.Fatalf("write target properties: %v", err)
+	}
+
+	svc := newTestService()
+	svc.readFile = os.ReadFile
+	content, err := svc.marshalSourceTemplateTarget(".properties", targetPath, sourcePath, "en", "fr", map[string]string{"hello": "Bonjour {0}"})
+	if err != nil {
+		t.Fatalf("marshal properties target: %v", err)
+	}
+	got := string(content)
+	if !strings.Contains(got, "# Checkout translated") {
+		t.Fatalf("expected target comments to be preserved, got %q", got)
+	}
+	if !strings.Contains(got, "hello = Bonjour {0}") {
+		t.Fatalf("expected translated properties value, got %q", got)
+	}
+}
+
 func TestMarshalTargetFileYAMLUsesTargetTemplate(t *testing.T) {
 	svc := newTestService()
 	svc.readFile = func(path string) ([]byte, error) {

--- a/apps/cli/internal/i18n/runsvc/service_test.go
+++ b/apps/cli/internal/i18n/runsvc/service_test.go
@@ -3817,6 +3817,7 @@ func TestMarshalTargetFileDispatchParity(t *testing.T) {
 		"/tmp/source.liquid":      []byte("<p>Hello</p>\n"),
 		"/tmp/source.xml":         []byte(`<locale><message key="hello">Hello</message></locale>`),
 		"/tmp/source.resx":        []byte(`<root><data name="hello"><value>Hello</value></data></root>`),
+		"/tmp/source.properties":  []byte("hello=Hello\n"),
 	}
 	svc.readFile = func(path string) ([]byte, error) {
 		if b, ok := sourceTemplate[path]; ok {
@@ -3843,6 +3844,7 @@ func TestMarshalTargetFileDispatchParity(t *testing.T) {
 		{target: "/tmp/out.liquid", source: "/tmp/source.liquid"},
 		{target: "/tmp/out.xml", source: "/tmp/source.xml"},
 		{target: "/tmp/out.resx", source: "/tmp/source.resx"},
+		{target: "/tmp/out.properties", source: "/tmp/source.properties"},
 	}
 
 	for _, tc := range cases {

--- a/docs/commands/run.mdx
+++ b/docs/commands/run.mdx
@@ -37,6 +37,7 @@ For lockfile fields, lifecycle, and reset guidance, see [Lockfile contract](/ref
 - `.stringsdict`
 - `.csv`
 - `.xml` and `.resx` for generic XML locale files
+- `.properties`
 
 For JSON (`.json`), `run` supports:
 
@@ -76,6 +77,9 @@ For Liquid (`.liquid`), `run` translates hardcoded visible template text and pre
 - HTML-shaped Liquid templates use the same visible-text extraction behavior as HTML
 
 For Apple/Xcode Strings (`.strings`), `run` preserves comments and key/value formatting from the template while replacing value literals with translated text.
+
+
+For Java properties (`.properties`), `run` supports per-locale key/value resource bundles such as `messages_en.properties` -> `messages_[locale].properties`. It parses Java-style separators (`=`, `:`, or whitespace), escaped keys and values, `\uXXXX` unicode escapes, and line continuations. Comments beginning with `#` or `!` are preserved and adjacent comments can be used as entry context. On write, existing key order, comments, separators, and spacing are preserved; translated values are normalized to single-line escaped values. Duplicate keys, malformed unicode escapes, invalid UTF-8 input, and dangling continuations fail with clear parse errors.
 
 
 For CSV (`.csv`), `run` supports two layouts:

--- a/docs/configuration/i18n-config.mdx
+++ b/docs/configuration/i18n-config.mdx
@@ -100,6 +100,20 @@ Shared multi-locale file:
 
 For shared multi-locale CSV files, keep one key column and one target locale column that `run` can update consistently.
 
+### Java properties file mapping patterns
+
+Use `.properties` mappings for Java resource bundles with one file per locale:
+
+```yaml
+buckets:
+  java:
+    files:
+      - from: src/main/resources/messages_{{source}}.properties
+        to: src/main/resources/messages_{{target}}.properties
+```
+
+Supported entries are flat Java properties keys with string values. Hyperlocalise preserves comments, separators, and key order on write; translated values are written as escaped single-line `.properties` values.
+
 ## Groups
 
 `groups.<name>` defines what to process together.

--- a/docs/reference/config-schema.mdx
+++ b/docs/reference/config-schema.mdx
@@ -57,3 +57,7 @@ Use `buckets.*.files[].from` and `to` to point at `.csv` files when you run CSV-
 
 - Per-locale files typically use `[locale]` in the `to` path.
 - Shared CSV files can reuse the same `from` and `to` path.
+
+## Java properties workflow note
+
+Use `buckets.*.files[].from` and `to` to point at per-locale `.properties` resource bundles, for example `messages_{{source}}.properties` -> `messages_{{target}}.properties`.

--- a/docs/troubleshooting/common-errors.mdx
+++ b/docs/troubleshooting/common-errors.mdx
@@ -34,7 +34,7 @@ Cause: a mapped source or target file uses an extension not supported by the loc
 
 Fixes:
 
-- use one of: `.json`, `.jsonc`, `.yaml`, `.yml`, `.xml`, `.resx`, `.arb`, `.xlf`, `.xlif`, `.xliff`, `.po`, `.html`, `.liquid`, `.md`, `.mdx`, `.strings`, `.stringsdict`, `.csv`
+- use one of: `.json`, `.jsonc`, `.yaml`, `.yml`, `.properties`, `.xml`, `.resx`, `.arb`, `.xlf`, `.xlif`, `.xliff`, `.po`, `.html`, `.liquid`, `.md`, `.mdx`, `.strings`, `.stringsdict`, `.csv`
 - verify bucket `from` and `to` paths resolve to the expected file names
 
 ## Provider auth failures

--- a/internal/i18n/translationfileparser/README.md
+++ b/internal/i18n/translationfileparser/README.md
@@ -17,10 +17,11 @@
 - `.stringsdict` via `AppleStringsdictParser` (Apple/Xcode plural dictionaries)
 - `.csv` via `CSVParser` (key/value and per-locale column layouts)
 - `.xml` / `.resx` via `GenericXMLParser` (non-Android generic XML locale files)
+- `.properties` via `JavaPropertiesParser` (Java resource bundles)
 
 ## Strategy API
 
-- `NewDefaultStrategy()` returns a strategy pre-registered with JSON, JSONC, YAML/YML, XLIFF, PO, Apple Strings, Markdown/MDX, CSV, Liquid, and HTML parsers.
+- `NewDefaultStrategy()` returns a strategy pre-registered with JSON, JSONC, YAML/YML, XLIFF, PO, Apple Strings, Markdown/MDX, CSV, Liquid, HTML, generic XML/RESX, and Java properties parsers.
 - `Register(ext, parser)` allows adding/replacing parser implementations by extension.
 - `Parse(path, content)` resolves parser by extension and returns `map[string]string`.
 
@@ -130,6 +131,15 @@
 - `MarshalGenericXMLWithTargetLocale(template, values, sourceLocale, targetLocale)` also rewrites root-element locale attributes (`xml:lang`, `lang`, `locale`, `language`, `code`) whose values match `sourceLocale`, adapting the original separator style (for example `en_US` -> `vi_VN`, `en` -> `vi`).
 - XML marshal values must be decoded plain text, not pre-escaped XML; the serializer escapes translated text and attributes during writeback.
 - Surrounding whitespace inside text-only leaf values is treated as part of the source value and replacement range, so translation providers that trim values may normalize that formatting.
+
+### Java Properties (`.properties`)
+
+- Parses Java-style key/value entries separated by `=`, `:`, or unescaped whitespace.
+- Supports escaped keys and values, `\t`, `\n`, `\r`, `\f`, escaped separators, `\uXXXX` unicode escapes, and logical line continuations.
+- Ignores blank lines and preserves `#` / `!` comments during marshal. Adjacent leading comments are returned as entry context by `ParseWithContext`.
+- `MarshalJavaProperties(template, values)` preserves key order, comments, separators, and spacing while replacing value literals. New keys are appended in sorted order.
+- Writeback normalizes translated values to single-line escaped values.
+- Duplicate keys, malformed unicode escapes, invalid UTF-8 input, and dangling continuations return explicit parse errors.
 
 ## Minimal usage
 

--- a/internal/i18n/translationfileparser/properties_parser.go
+++ b/internal/i18n/translationfileparser/properties_parser.go
@@ -1,0 +1,479 @@
+package translationfileparser
+
+import (
+	"cmp"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+	"unicode/utf16"
+	"unicode/utf8"
+)
+
+// JavaPropertiesParser parses Java .properties localization files.
+type JavaPropertiesParser struct{}
+
+type propertiesEntry struct {
+	key         string
+	sourceValue string
+	valueStart  int
+	valueEnd    int
+	comments    []string
+	line        int
+}
+
+type propertiesDocument struct {
+	template string
+	entries  []propertiesEntry
+}
+
+type propertiesLogicalLine struct {
+	text        string
+	rawEnd      int
+	boundaryRaw []int
+	line        int
+}
+
+func (p JavaPropertiesParser) Parse(content []byte) (map[string]string, error) {
+	values, _, err := p.ParseWithContext(content)
+	if err != nil {
+		return nil, err
+	}
+	return values, nil
+}
+
+func (p JavaPropertiesParser) ParseWithContext(content []byte) (map[string]string, map[string]string, error) {
+	doc, err := parseJavaPropertiesDocument(content)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	values := make(map[string]string, len(doc.entries))
+	contextByKey := map[string]string{}
+	for _, entry := range doc.entries {
+		values[entry.key] = entry.sourceValue
+		if len(entry.comments) == 0 {
+			continue
+		}
+		context := strings.TrimSpace(strings.Join(entry.comments, "\n"))
+		if context != "" {
+			contextByKey[entry.key] = context
+		}
+	}
+	if len(contextByKey) == 0 {
+		contextByKey = nil
+	}
+	return values, contextByKey, nil
+}
+
+// MarshalJavaProperties preserves comments, key order, and key separators while
+// replacing value literals. New keys are appended in sorted order.
+func MarshalJavaProperties(template []byte, values map[string]string) ([]byte, error) {
+	doc, err := parseJavaPropertiesDocument(template)
+	if err != nil {
+		return nil, err
+	}
+	return doc.render(values), nil
+}
+
+func parseJavaPropertiesDocument(content []byte) (propertiesDocument, error) {
+	if !utf8.Valid(content) {
+		return propertiesDocument{}, fmt.Errorf("properties decode: content must be valid UTF-8")
+	}
+
+	text := string(content)
+	doc := propertiesDocument{template: text, entries: []propertiesEntry{}}
+	seen := map[string]int{}
+	var pendingComments []string
+
+	for pos := 0; pos < len(text); {
+		contentStart, contentEnd, next := readPropertiesPhysicalLine(text, pos)
+		rawLine := text[contentStart:contentEnd]
+		first := firstPropertiesNonWhitespace(rawLine)
+		if first >= len(rawLine) {
+			pendingComments = nil
+			pos = next
+			continue
+		}
+		if rawLine[first] == '#' || rawLine[first] == '!' {
+			pendingComments = append(pendingComments, strings.TrimSpace(rawLine[first+1:]))
+			pos = next
+			continue
+		}
+
+		logical, nextPos, err := readPropertiesLogicalLine(text, pos)
+		if err != nil {
+			return propertiesDocument{}, err
+		}
+		entry, err := parseJavaPropertiesEntry(logical, pendingComments)
+		if err != nil {
+			return propertiesDocument{}, err
+		}
+		pendingComments = nil
+
+		if previousLine, ok := seen[entry.key]; ok {
+			return propertiesDocument{}, fmt.Errorf("line %d: duplicate properties key %q first defined on line %d", entry.line, entry.key, previousLine)
+		}
+		seen[entry.key] = entry.line
+		doc.entries = append(doc.entries, entry)
+		pos = nextPos
+	}
+
+	return doc, nil
+}
+
+func parseJavaPropertiesEntry(line propertiesLogicalLine, comments []string) (propertiesEntry, error) {
+	text := line.text
+	pos := 0
+	if strings.HasPrefix(text, "\ufeff") {
+		pos = len("\ufeff")
+	}
+	pos = skipPropertiesWhitespace(text, pos)
+	keyStart := pos
+	keyEnd := -1
+	escaped := false
+
+	for pos < len(text) {
+		ch := text[pos]
+		if escaped {
+			escaped = false
+			pos++
+			continue
+		}
+		if ch == '\\' {
+			escaped = true
+			pos++
+			continue
+		}
+		if ch == '=' || ch == ':' {
+			keyEnd = pos
+			pos++
+			break
+		}
+		if isPropertiesWhitespace(ch) {
+			keyEnd = pos
+			pos = skipPropertiesWhitespace(text, pos)
+			if pos < len(text) && (text[pos] == '=' || text[pos] == ':') {
+				pos++
+			}
+			break
+		}
+		pos++
+	}
+	if escaped {
+		return propertiesEntry{}, fmt.Errorf("line %d: dangling escape in key", line.line)
+	}
+	if keyEnd < 0 {
+		keyEnd = len(text)
+		pos = len(text)
+	}
+
+	valueStart := skipPropertiesWhitespace(text, pos)
+	key, err := decodeJavaPropertiesEscapes(text[keyStart:keyEnd])
+	if err != nil {
+		return propertiesEntry{}, fmt.Errorf("line %d: decode key: %w", line.line, err)
+	}
+	if key == "" {
+		return propertiesEntry{}, fmt.Errorf("line %d: properties key must not be empty", line.line)
+	}
+
+	value, err := decodeJavaPropertiesEscapes(text[valueStart:])
+	if err != nil {
+		return propertiesEntry{}, fmt.Errorf("line %d: decode value for key %q: %w", line.line, key, err)
+	}
+	valueStartRaw := line.boundaryRaw[valueStart]
+	return propertiesEntry{
+		key:         key,
+		sourceValue: value,
+		valueStart:  valueStartRaw,
+		valueEnd:    line.rawEnd,
+		comments:    slices.Clone(comments),
+		line:        line.line,
+	}, nil
+}
+
+func (d propertiesDocument) render(values map[string]string) []byte {
+	entries := slices.Clone(d.entries)
+	slices.SortFunc(entries, func(a, b propertiesEntry) int {
+		return cmp.Compare(a.valueStart, b.valueStart)
+	})
+
+	var b strings.Builder
+	seen := map[string]struct{}{}
+	cursor := 0
+	for _, entry := range entries {
+		if entry.valueStart < cursor || entry.valueStart > len(d.template) || entry.valueEnd > len(d.template) {
+			continue
+		}
+		seen[entry.key] = struct{}{}
+		b.WriteString(d.template[cursor:entry.valueStart])
+		if value, ok := values[entry.key]; ok {
+			b.WriteString(encodeJavaPropertiesValue(value))
+		} else {
+			b.WriteString(d.template[entry.valueStart:entry.valueEnd])
+		}
+		cursor = entry.valueEnd
+	}
+	b.WriteString(d.template[cursor:])
+
+	missing := make([]string, 0, len(values))
+	for key := range values {
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		missing = append(missing, key)
+	}
+	slices.Sort(missing)
+	if len(missing) == 0 {
+		return []byte(b.String())
+	}
+
+	rendered := b.String()
+	var out strings.Builder
+	out.WriteString(rendered)
+	if rendered != "" && !strings.HasSuffix(rendered, "\n") && !strings.HasSuffix(rendered, "\r") {
+		out.WriteByte('\n')
+	}
+	for _, key := range missing {
+		out.WriteString(encodeJavaPropertiesKey(key))
+		out.WriteByte('=')
+		out.WriteString(encodeJavaPropertiesValue(values[key]))
+		out.WriteByte('\n')
+	}
+	return []byte(out.String())
+}
+
+func readPropertiesLogicalLine(text string, start int) (propertiesLogicalLine, int, error) {
+	var b strings.Builder
+	boundaryRaw := []int{start}
+	pos := start
+	firstPhysicalLine := true
+	lineNumber := lineNumberAt(text, start)
+
+	for {
+		contentStart, contentEnd, next := readPropertiesPhysicalLine(text, pos)
+		appendStart := contentStart
+		if !firstPhysicalLine {
+			appendStart = skipPropertiesPhysicalWhitespace(text, appendStart, contentEnd)
+		}
+		appendEnd := contentEnd
+		continued := propertiesLineContinues(text[contentStart:contentEnd])
+		if continued {
+			appendEnd--
+		}
+		appendPropertiesRawSpan(&b, &boundaryRaw, text, appendStart, appendEnd)
+		if !continued {
+			return propertiesLogicalLine{
+				text:        b.String(),
+				rawEnd:      contentEnd,
+				boundaryRaw: boundaryRaw,
+				line:        lineNumber,
+			}, next, nil
+		}
+		if next >= len(text) {
+			return propertiesLogicalLine{}, next, fmt.Errorf("line %d: continuation escape at end of file", lineNumberAt(text, contentEnd))
+		}
+		pos = next
+		firstPhysicalLine = false
+	}
+}
+
+func readPropertiesPhysicalLine(text string, start int) (int, int, int) {
+	i := start
+	for i < len(text) && text[i] != '\n' && text[i] != '\r' {
+		i++
+	}
+	end := i
+	if i < len(text) {
+		if text[i] == '\r' && i+1 < len(text) && text[i+1] == '\n' {
+			i += 2
+		} else {
+			i++
+		}
+	}
+	return start, end, i
+}
+
+func appendPropertiesRawSpan(b *strings.Builder, boundaryRaw *[]int, text string, start, end int) {
+	for i := start; i < end; i++ {
+		b.WriteByte(text[i])
+		*boundaryRaw = append(*boundaryRaw, i+1)
+	}
+}
+
+func propertiesLineContinues(raw string) bool {
+	count := 0
+	for i := len(raw) - 1; i >= 0 && raw[i] == '\\'; i-- {
+		count++
+	}
+	return count%2 == 1
+}
+
+func firstPropertiesNonWhitespace(raw string) int {
+	i := 0
+	if strings.HasPrefix(raw, "\ufeff") {
+		i = len("\ufeff")
+	}
+	for i < len(raw) && isPropertiesWhitespace(raw[i]) {
+		i++
+	}
+	return i
+}
+
+func skipPropertiesWhitespace(s string, start int) int {
+	i := start
+	for i < len(s) && isPropertiesWhitespace(s[i]) {
+		i++
+	}
+	return i
+}
+
+func skipPropertiesPhysicalWhitespace(s string, start, end int) int {
+	i := start
+	for i < end && isPropertiesWhitespace(s[i]) {
+		i++
+	}
+	return i
+}
+
+func isPropertiesWhitespace(ch byte) bool {
+	return ch == ' ' || ch == '\t' || ch == '\f'
+}
+
+func decodeJavaPropertiesEscapes(raw string) (string, error) {
+	var b strings.Builder
+	for i := 0; i < len(raw); i++ {
+		ch := raw[i]
+		if ch != '\\' {
+			b.WriteByte(ch)
+			continue
+		}
+		i++
+		if i >= len(raw) {
+			return "", fmt.Errorf("dangling escape")
+		}
+		switch raw[i] {
+		case 't':
+			b.WriteByte('\t')
+		case 'n':
+			b.WriteByte('\n')
+		case 'r':
+			b.WriteByte('\r')
+		case 'f':
+			b.WriteByte('\f')
+		case 'u':
+			r, next, err := decodeJavaPropertiesUnicodeEscape(raw, i)
+			if err != nil {
+				return "", err
+			}
+			b.WriteRune(r)
+			i = next
+		default:
+			b.WriteByte(raw[i])
+		}
+	}
+	return b.String(), nil
+}
+
+func decodeJavaPropertiesUnicodeEscape(raw string, escapeIndex int) (rune, int, error) {
+	if escapeIndex+4 >= len(raw) {
+		return 0, escapeIndex, fmt.Errorf("invalid \\u escape")
+	}
+	value, err := strconv.ParseUint(raw[escapeIndex+1:escapeIndex+5], 16, 16)
+	if err != nil {
+		return 0, escapeIndex, fmt.Errorf("invalid \\u escape")
+	}
+	next := escapeIndex + 4
+	r := rune(value)
+	if !utf16.IsSurrogate(r) {
+		return r, next, nil
+	}
+	if r < 0xD800 || r > 0xDBFF {
+		return 0, escapeIndex, fmt.Errorf("invalid low surrogate without high surrogate")
+	}
+	if next+6 >= len(raw) || raw[next+1] != '\\' || raw[next+2] != 'u' {
+		return 0, escapeIndex, fmt.Errorf("invalid surrogate pair")
+	}
+	nextValue, err := strconv.ParseUint(raw[next+3:next+7], 16, 16)
+	if err != nil {
+		return 0, escapeIndex, fmt.Errorf("invalid surrogate pair")
+	}
+	nextRune := rune(nextValue)
+	if nextRune < 0xDC00 || nextRune > 0xDFFF {
+		return 0, escapeIndex, fmt.Errorf("invalid surrogate pair")
+	}
+	return utf16.DecodeRune(r, nextRune), next + 6, nil
+}
+
+func encodeJavaPropertiesKey(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch r {
+		case ' ':
+			b.WriteString(`\ `)
+		case '\\':
+			b.WriteString(`\\`)
+		case '=', ':', '#', '!':
+			b.WriteByte('\\')
+			b.WriteRune(r)
+		case '\t':
+			b.WriteString(`\t`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		case '\f':
+			b.WriteString(`\f`)
+		default:
+			if !writeJavaPropertiesEscapedRune(&b, r) {
+				b.WriteRune(r)
+			}
+		}
+	}
+	return b.String()
+}
+
+func encodeJavaPropertiesValue(s string) string {
+	var b strings.Builder
+	leadingSpace := true
+	for _, r := range s {
+		switch r {
+		case ' ':
+			if leadingSpace {
+				b.WriteString(`\ `)
+			} else {
+				b.WriteRune(r)
+			}
+			continue
+		case '\\':
+			b.WriteString(`\\`)
+		case '\t':
+			b.WriteString(`\t`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		case '\f':
+			b.WriteString(`\f`)
+		default:
+			if !writeJavaPropertiesEscapedRune(&b, r) {
+				b.WriteRune(r)
+			}
+		}
+		leadingSpace = false
+	}
+	return b.String()
+}
+
+func writeJavaPropertiesEscapedRune(b *strings.Builder, r rune) bool {
+	if r < 0x20 {
+		_, _ = fmt.Fprintf(b, `\u%04X`, r)
+		return true
+	}
+	if r > 0xFFFF {
+		hi, lo := utf16.EncodeRune(r)
+		_, _ = fmt.Fprintf(b, `\u%04X\u%04X`, hi, lo)
+		return true
+	}
+	return false
+}

--- a/internal/i18n/translationfileparser/properties_parser_test.go
+++ b/internal/i18n/translationfileparser/properties_parser_test.go
@@ -1,0 +1,145 @@
+package translationfileparser
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestJavaPropertiesParserParsesEscapesCommentsAndContinuations(t *testing.T) {
+	content := []byte(`# Checkout screen
+welcome.message = Hello {0}
+escaped\ key: Line one\nLine two
+path = C:\\Program Files\\Hyperlocalise
+unicode = Snowman \u2603
+spaced\:key value with \= equals and \: colon
+continued = first \
+    second
+`)
+
+	got, contextByKey, err := (JavaPropertiesParser{}).ParseWithContext(content)
+	if err != nil {
+		t.Fatalf("parse properties: %v", err)
+	}
+
+	assertPropertyValue(t, got, "welcome.message", "Hello {0}")
+	assertPropertyValue(t, got, "escaped key", "Line one\nLine two")
+	assertPropertyValue(t, got, "path", `C:\Program Files\Hyperlocalise`)
+	assertPropertyValue(t, got, "unicode", "Snowman \u2603")
+	assertPropertyValue(t, got, "spaced:key", "value with = equals and : colon")
+	assertPropertyValue(t, got, "continued", "first second")
+	if contextByKey["welcome.message"] != "Checkout screen" {
+		t.Fatalf("unexpected context for welcome.message: %#v", contextByKey)
+	}
+}
+
+func TestMarshalJavaPropertiesPreservesTemplateAndAppendsDeterministically(t *testing.T) {
+	template := []byte(`# Checkout screen
+welcome.message = Hello {0}
+untouched=Keep
+escaped\ key: Line one\nLine two
+`)
+
+	got, err := MarshalJavaProperties(template, map[string]string{
+		"welcome.message": "Bonjour {0}",
+		"escaped key":     "Ligne 1\nLigne 2",
+		"z.last":          "Dernier",
+		"a.first":         "Premier",
+	})
+	if err != nil {
+		t.Fatalf("marshal properties: %v", err)
+	}
+
+	want := `# Checkout screen
+welcome.message = Bonjour {0}
+untouched=Keep
+escaped\ key: Ligne 1\nLigne 2
+a.first=Premier
+z.last=Dernier
+`
+	if string(got) != want {
+		t.Fatalf("properties output mismatch\n got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestJavaPropertiesParserAndMarshalHandleUTF8BOM(t *testing.T) {
+	template := []byte("\xef\xbb\xbfwelcome.message=Hello {0}\n")
+
+	got, err := (JavaPropertiesParser{}).Parse(template)
+	if err != nil {
+		t.Fatalf("parse properties with BOM: %v", err)
+	}
+	assertPropertyValue(t, got, "welcome.message", "Hello {0}")
+	if _, ok := got["\ufeffwelcome.message"]; ok {
+		t.Fatalf("BOM must not be included in the first key: %#v", got)
+	}
+
+	rendered, err := MarshalJavaProperties(template, map[string]string{"welcome.message": "Bonjour {0}"})
+	if err != nil {
+		t.Fatalf("marshal properties with BOM: %v", err)
+	}
+	want := "\ufeffwelcome.message=Bonjour {0}\n"
+	if string(rendered) != want {
+		t.Fatalf("properties output mismatch\n got: %q\nwant: %q", rendered, want)
+	}
+}
+
+func TestPropertiesDocumentRenderAppendsEntriesSkippedByBoundsGuard(t *testing.T) {
+	doc := propertiesDocument{
+		template: "",
+		entries: []propertiesEntry{{
+			key:        "welcome.message",
+			valueStart: 12,
+			valueEnd:   18,
+		}},
+	}
+
+	got := string(doc.render(map[string]string{"welcome.message": "Bonjour"}))
+	if got != "welcome.message=Bonjour\n" {
+		t.Fatalf("expected skipped entry to be appended, got %q", got)
+	}
+}
+
+func TestMarshalJavaPropertiesEscapesNonBMPRunesAsSurrogatePairs(t *testing.T) {
+	template := []byte("emoji.value=old\n")
+
+	got, err := MarshalJavaProperties(template, map[string]string{
+		"emoji.value":         "Face \U0001F600",
+		"emoji.key\U0001F600": "new \U0001F600",
+	})
+	if err != nil {
+		t.Fatalf("marshal properties with non-BMP runes: %v", err)
+	}
+
+	want := "emoji.value=Face \\uD83D\\uDE00\nemoji.key\\uD83D\\uDE00=new \\uD83D\\uDE00\n"
+	if string(got) != want {
+		t.Fatalf("properties output mismatch\n got: %q\nwant: %q", got, want)
+	}
+}
+
+func TestJavaPropertiesParserRejectsMalformedUnicodeEscape(t *testing.T) {
+	_, err := (JavaPropertiesParser{}).Parse([]byte(`bad = \u12xz
+`))
+	if err == nil {
+		t.Fatal("expected malformed unicode escape error")
+	}
+	if !strings.Contains(err.Error(), "invalid \\u escape") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestJavaPropertiesParserRejectsDuplicateKeys(t *testing.T) {
+	_, err := (JavaPropertiesParser{}).Parse([]byte("hello=Hello\nhello=Bonjour\n"))
+	if err == nil {
+		t.Fatal("expected duplicate key error")
+	}
+	if !strings.Contains(err.Error(), "duplicate properties key") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func assertPropertyValue(t *testing.T, got map[string]string, key, want string) {
+	t.Helper()
+	if got[key] != want {
+		t.Fatalf("properties key %q = %q, want %q", key, got[key], want)
+	}
+}

--- a/internal/i18n/translationfileparser/strategy.go
+++ b/internal/i18n/translationfileparser/strategy.go
@@ -47,6 +47,7 @@ func NewDefaultStrategy() *Strategy {
 	s.Register(".csv", CSVParser{})
 	s.Register(".xml", GenericXMLParser{})
 	s.Register(".resx", GenericXMLParser{})
+	s.Register(".properties", JavaPropertiesParser{})
 	return s
 }
 

--- a/internal/i18n/translationfileparser/strategy_test.go
+++ b/internal/i18n/translationfileparser/strategy_test.go
@@ -272,6 +272,24 @@ func TestStrategyParsesGenericXML(t *testing.T) {
 	}
 }
 
+func TestStrategyParsesJavaProperties(t *testing.T) {
+	s := NewDefaultStrategy()
+
+	got, err := s.Parse("messages_fr.properties", []byte(`# Checkout
+welcome.message = Bonjour {0}
+escaped\ key: Ligne un\nLigne deux
+`))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got["welcome.message"] != "Bonjour {0}" {
+		t.Fatalf("unexpected welcome.message translation: %q", got["welcome.message"])
+	}
+	if got["escaped key"] != "Ligne un\nLigne deux" {
+		t.Fatalf("unexpected escaped key translation: %q", got["escaped key"])
+	}
+}
+
 func TestStrategyRegistersLiquidParser(t *testing.T) {
 	s := NewDefaultStrategy()
 


### PR DESCRIPTION
## What changed
- Added Java `.properties` parser and deterministic template-preserving serializer support.
- Registered `.properties` in the default local translation strategy and `run` writeback path.
- Added coverage for `status`, `check`, and `run --dry-run` recognizing `.properties` files.
- Addressed Greptile review feedback for UTF-8 BOM handling, skipped-entry writeback, safe entry sorting, and non-BMP surrogate-pair encoding.
- Documented supported `.properties` mapping patterns, escaping behavior, writeback behavior, and limitations.

## How to test
- `go test ./internal/i18n/translationfileparser -run 'Test(JavaProperties|PropertiesDocumentRender|MarshalJavaPropertiesEscapesNonBMP|StrategyParsesJavaProperties)' -count=1`
- `go test ./apps/cli/internal/i18n/runsvc -run 'TestMarshal(TargetFileDispatchParity|SourceTemplateTargetJavaProperties)' -count=1`
- `go test ./apps/cli/cmd -run 'Test(RunDryRunPropertiesFileRecognized|CheckCommandPropertiesFileRecognized|StatusCommandPropertiesFileRecognized)' -count=1`
- `golangci-lint run ./internal/i18n/translationfileparser ./apps/cli/internal/i18n/runsvc ./apps/cli/cmd`
- `make run`
- `make fmt`
- `make lint`

## Checklist
- [x] Parser and serializer support added for Java `.properties` files.
- [x] CLI recognition covered for `status`, `check`, and `run --dry-run`.
- [x] Docs updated with supported patterns and limitations.
- [x] Draft PR created.
- [x] 10-minute Greptile monitoring heartbeat created.
- [x] Greptile feedback has no actionable items left.
- [x] Final pre-ready checks completed: `make run`, `make fmt`, `make lint`.