### PR TITLE
feat(agent): add durable repo/TMS ToolLoopAgent workflow runner

### DIFF
--- a/apps/hyperlocalise-web/src/workflows/repo-tms-agent.test.ts
+++ b/apps/hyperlocalise-web/src/workflows/repo-tms-agent.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi, beforeEach } from "vite-plus/test";
+
+vi.mock("workflow", () => ({
+  getWorkflowMetadata: vi.fn(() => ({ workflowRunId: "run_123" })),
+}));
+
+const stopMock = vi.fn();
+const createMock = vi.fn(async () => ({ sandboxId: "sbx_1" }));
+const getMock = vi.fn(async () => ({ stop: stopMock }));
+
+vi.mock("@vercel/sandbox", () => ({ Sandbox: { create: createMock, get: getMock } }));
+
+const generateMock = vi.fn(async () => ({ text: "done" }));
+const toolLoopAgentCtor = vi.fn(function ToolLoopAgent() {
+  return { generate: generateMock };
+});
+vi.mock("ai", () => ({ ToolLoopAgent: toolLoopAgentCtor }));
+
+vi.mock("@/lib/agents/hyperlocalise-agent", () => ({
+  getHyperlocaliseAgentModel: vi.fn(() => ({ modelId: "x" })),
+  buildHyperlocaliseAgentInstructions: vi.fn(() => "sys"),
+}));
+
+vi.mock("@/lib/tools/registry", () => ({ buildTools: vi.fn(() => ({})) }));
+
+import { repoTmsAgentWorkflow } from "./repo-tms-agent";
+
+const baseTask = {
+  id: "task_1",
+  source: "github",
+  sourceThreadId: "thread_1",
+  actor: { sourceUserId: "u1" },
+  organizationId: "org_1",
+  projectId: null,
+  workMode: "read_only",
+  instructions: "run checks",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  idempotencyKey: "idem",
+} as const;
+
+describe("repoTmsAgentWorkflow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createMock.mockResolvedValue({ sandboxId: "sbx_1" });
+    generateMock.mockResolvedValue({ text: "done" });
+  });
+
+  it("returns success state with source target and workflowRunId", async () => {
+    const result = await repoTmsAgentWorkflow(baseTask as never);
+
+    expect(result).toEqual({
+      ok: true,
+      workflowRunId: "run_123",
+      sourceReplyTarget: { source: "github", threadId: "thread_1" },
+      summary: "done",
+    });
+  });
+
+  it("cleans up disposable sandbox runs", async () => {
+    await repoTmsAgentWorkflow({
+      ...baseTask,
+      githubContext: { resolved: true, installationId: 1, repositoryFullName: "acme/repo" },
+    } as never);
+
+    expect(createMock).toHaveBeenCalled();
+    expect(stopMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("captures failures from tool execution", async () => {
+    generateMock.mockRejectedValueOnce(new Error("tool failed"));
+
+    const result = await repoTmsAgentWorkflow(baseTask as never);
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("tool failed");
+  });
+
+  it("keeps write-mode sandbox available", async () => {
+    await repoTmsAgentWorkflow({
+      ...baseTask,
+      workMode: "write",
+      githubContext: { resolved: true, installationId: 1, repositoryFullName: "acme/repo" },
+    } as never);
+
+    expect(stopMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/hyperlocalise-web/src/workflows/repo-tms-agent.test.ts
+++ b/apps/hyperlocalise-web/src/workflows/repo-tms-agent.test.ts
@@ -4,17 +4,43 @@ vi.mock("workflow", () => ({
   getWorkflowMetadata: vi.fn(() => ({ workflowRunId: "run_123" })),
 }));
 
-const stopMock = vi.fn();
-const createMock = vi.fn(async () => ({ sandboxId: "sbx_1" }));
-const getMock = vi.fn(async () => ({ stop: stopMock }));
+const {
+  authMock,
+  createMock,
+  generateMock,
+  getInstallationOctokitMock,
+  getMock,
+  stopMock,
+  toolLoopAgentCtor,
+} = vi.hoisted(() => {
+  const authMock = vi.fn(async () => ({ token: "installation-token" }));
+  const stopMock = vi.fn();
+  const createMock = vi.fn(async () => ({ sandboxId: "sbx_1" }));
+  const getMock = vi.fn(async () => ({ stop: stopMock }));
+  const getInstallationOctokitMock = vi.fn(async () => ({ auth: authMock }));
+  const generateMock = vi.fn(async () => ({ text: "done" }));
+  const toolLoopAgentCtor = vi.fn(function ToolLoopAgent(_options: unknown) {
+    return { generate: generateMock };
+  });
+
+  return {
+    authMock,
+    createMock,
+    generateMock,
+    getInstallationOctokitMock,
+    getMock,
+    stopMock,
+    toolLoopAgentCtor,
+  };
+});
 
 vi.mock("@vercel/sandbox", () => ({ Sandbox: { create: createMock, get: getMock } }));
 
-const generateMock = vi.fn(async () => ({ text: "done" }));
-const toolLoopAgentCtor = vi.fn(function ToolLoopAgent() {
-  return { generate: generateMock };
-});
 vi.mock("ai", () => ({ ToolLoopAgent: toolLoopAgentCtor }));
+
+vi.mock("@/lib/agents/github/app", () => ({
+  getInstallationOctokit: getInstallationOctokitMock,
+}));
 
 vi.mock("@/lib/agents/hyperlocalise-agent", () => ({
   getHyperlocaliseAgentModel: vi.fn(() => ({ modelId: "x" })),
@@ -41,13 +67,26 @@ const baseTask = {
 describe("repoTmsAgentWorkflow", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    authMock.mockResolvedValue({ token: "installation-token" });
     createMock.mockResolvedValue({ sandboxId: "sbx_1" });
     generateMock.mockResolvedValue({ text: "done" });
+    getInstallationOctokitMock.mockResolvedValue({ auth: authMock });
+    getMock.mockResolvedValue({ stop: stopMock });
+    stopMock.mockResolvedValue(undefined);
   });
 
   it("returns success state with source target and workflowRunId", async () => {
     const result = await repoTmsAgentWorkflow(baseTask as never);
 
+    expect(toolLoopAgentCtor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instructions: "sys",
+        experimental_context: { sandboxId: null, repoTmsTaskId: "task_1" },
+      }),
+    );
+    expect(generateMock).toHaveBeenCalledWith({
+      messages: [{ role: "user", content: "run checks" }],
+    });
     expect(result).toEqual({
       ok: true,
       workflowRunId: "run_123",
@@ -62,8 +101,29 @@ describe("repoTmsAgentWorkflow", () => {
       githubContext: { resolved: true, installationId: 1, repositoryFullName: "acme/repo" },
     } as never);
 
-    expect(createMock).toHaveBeenCalled();
+    expect(getInstallationOctokitMock).toHaveBeenCalledWith(1);
+    expect(authMock).toHaveBeenCalledWith({ type: "installation" });
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: expect.objectContaining({
+          password: "installation-token",
+          username: "x-access-token",
+        }),
+      }),
+    );
     expect(stopMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows a larger repo task tool-call budget", async () => {
+    await repoTmsAgentWorkflow(baseTask as never);
+
+    const options = toolLoopAgentCtor.mock.calls[0]?.[0] as unknown as {
+      stopWhen: Array<(step: { steps: unknown[] }) => boolean>;
+    };
+    const shouldStop = options.stopWhen[0];
+
+    expect(shouldStop({ steps: Array.from({ length: 19 }) })).toBe(false);
+    expect(shouldStop({ steps: Array.from({ length: 20 }) })).toBe(true);
   });
 
   it("captures failures from tool execution", async () => {
@@ -83,5 +143,22 @@ describe("repoTmsAgentWorkflow", () => {
     } as never);
 
     expect(stopMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves the structured result when cleanup fails", async () => {
+    stopMock.mockRejectedValueOnce(new Error("cleanup failed"));
+
+    const result = await repoTmsAgentWorkflow({
+      ...baseTask,
+      githubContext: { resolved: true, installationId: 1, repositoryFullName: "acme/repo" },
+    } as never);
+
+    expect(result).toEqual({
+      ok: true,
+      workflowRunId: "run_123",
+      sourceReplyTarget: { source: "github", threadId: "thread_1" },
+      summary: "done",
+    });
+    expect(stopMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/hyperlocalise-web/src/workflows/repo-tms-agent.test.ts
+++ b/apps/hyperlocalise-web/src/workflows/repo-tms-agent.test.ts
@@ -6,6 +6,8 @@ vi.mock("workflow", () => ({
 
 const {
   authMock,
+  buildHyperlocaliseAgentInstructionsMock,
+  buildToolsMock,
   createMock,
   generateMock,
   getInstallationOctokitMock,
@@ -14,6 +16,8 @@ const {
   toolLoopAgentCtor,
 } = vi.hoisted(() => {
   const authMock = vi.fn(async () => ({ token: "installation-token" }));
+  const buildHyperlocaliseAgentInstructionsMock = vi.fn(() => "sys");
+  const buildToolsMock = vi.fn(() => ({}));
   const stopMock = vi.fn();
   const createMock = vi.fn(async () => ({ sandboxId: "sbx_1" }));
   const getMock = vi.fn(async () => ({ stop: stopMock }));
@@ -25,6 +29,8 @@ const {
 
   return {
     authMock,
+    buildHyperlocaliseAgentInstructionsMock,
+    buildToolsMock,
     createMock,
     generateMock,
     getInstallationOctokitMock,
@@ -44,10 +50,10 @@ vi.mock("@/lib/agents/github/app", () => ({
 
 vi.mock("@/lib/agents/hyperlocalise-agent", () => ({
   getHyperlocaliseAgentModel: vi.fn(() => ({ modelId: "x" })),
-  buildHyperlocaliseAgentInstructions: vi.fn(() => "sys"),
+  buildHyperlocaliseAgentInstructions: buildHyperlocaliseAgentInstructionsMock,
 }));
 
-vi.mock("@/lib/tools/registry", () => ({ buildTools: vi.fn(() => ({})) }));
+vi.mock("@/lib/tools/registry", () => ({ buildTools: buildToolsMock }));
 
 import { repoTmsAgentWorkflow } from "./repo-tms-agent";
 
@@ -124,6 +130,31 @@ describe("repoTmsAgentWorkflow", () => {
 
     expect(shouldStop({ steps: Array.from({ length: 19 }) })).toBe(false);
     expect(shouldStop({ steps: Array.from({ length: 20 }) })).toBe(true);
+  });
+
+  it("uses member permissions when the task actor role is unresolved", async () => {
+    await repoTmsAgentWorkflow(baseTask as never);
+
+    expect(buildToolsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: "task_1",
+        organizationId: "org_1",
+        membershipRole: "member",
+        projectId: null,
+      }),
+    );
+  });
+
+  it.each([
+    ["slack", "slack"],
+    ["github", "github"],
+    ["chat_ui", "web"],
+  ] as const)("maps %s tasks to %s agent instructions", async (source, surface) => {
+    await repoTmsAgentWorkflow({ ...baseTask, source } as never);
+
+    expect(buildHyperlocaliseAgentInstructionsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ surface }),
+    );
   });
 
   it("captures failures from tool execution", async () => {

--- a/apps/hyperlocalise-web/src/workflows/repo-tms-agent.ts
+++ b/apps/hyperlocalise-web/src/workflows/repo-tms-agent.ts
@@ -3,6 +3,7 @@ import { Sandbox } from "@vercel/sandbox";
 import { getWorkflowMetadata } from "workflow";
 
 import type { RepoTmsAgentTask } from "@/lib/agents/repo-tms-task";
+import { getInstallationOctokit } from "@/lib/agents/github/app";
 import {
   buildHyperlocaliseAgentInstructions,
   getHyperlocaliseAgentModel,
@@ -20,6 +21,43 @@ export type RepoTmsWorkflowResult = {
 };
 
 const sandboxTimeoutMs = 10 * 60 * 1000;
+const agentStepLimit = 20;
+
+type InstallationAuth = {
+  token: string;
+};
+
+type ResolvedRepoTmsGitHubContext = Extract<
+  NonNullable<RepoTmsAgentTask["githubContext"]>,
+  { resolved: true }
+>;
+
+async function createRepoTmsSandbox(githubContext: ResolvedRepoTmsGitHubContext): Promise<string> {
+  "use step";
+
+  const octokit = await getInstallationOctokit(githubContext.installationId);
+  const { token } = (await octokit.auth({ type: "installation" })) as InstallationAuth;
+  const sandbox = await Sandbox.create({
+    source: {
+      type: "git",
+      url: `https://github.com/${githubContext.repositoryFullName}.git`,
+      revision: githubContext.commitSha ?? githubContext.branch ?? "HEAD",
+      depth: 1,
+      username: "x-access-token",
+      password: token,
+    },
+    timeout: sandboxTimeoutMs,
+  });
+
+  return sandbox.sandboxId;
+}
+
+async function stopRepoTmsSandbox(sandboxId: string): Promise<void> {
+  "use step";
+
+  const sandbox = await Sandbox.get({ sandboxId });
+  await sandbox.stop();
+}
 
 export async function repoTmsAgentWorkflow(task: RepoTmsAgentTask): Promise<RepoTmsWorkflowResult> {
   "use workflow";
@@ -29,16 +67,7 @@ export async function repoTmsAgentWorkflow(task: RepoTmsAgentTask): Promise<Repo
 
   try {
     if (task.githubContext?.resolved) {
-      const sandbox = await Sandbox.create({
-        source: {
-          type: "git",
-          url: `https://github.com/${task.githubContext.repositoryFullName}.git`,
-          revision: task.githubContext.commitSha ?? task.githubContext.branch ?? "HEAD",
-          depth: 1,
-        },
-        timeout: sandboxTimeoutMs,
-      });
-      sandboxId = sandbox.sandboxId;
+      sandboxId = await createRepoTmsSandbox(task.githubContext);
     }
 
     const toolContext: ToolContext = {
@@ -53,19 +82,19 @@ export async function repoTmsAgentWorkflow(task: RepoTmsAgentTask): Promise<Repo
     const agent = new ToolLoopAgent({
       model: getHyperlocaliseAgentModel(),
       tools,
-      stopWhen: [(step) => step.steps.length >= 5],
-      system: buildHyperlocaliseAgentInstructions({
+      stopWhen: [(step) => step.steps.length >= agentStepLimit],
+      instructions: buildHyperlocaliseAgentInstructions({
         surface: "github",
         projectId: task.projectId,
         additionalInstructions: sandboxId
           ? `Sandbox id available to tools: ${sandboxId}. Access repo only via tools.`
           : "No repository sandbox required for this task.",
       }),
+      experimental_context: { sandboxId, repoTmsTaskId: task.id },
     });
 
     const result = await agent.generate({
       messages: [{ role: "user", content: task.instructions }] as ModelMessage[],
-      experimental_context: { sandboxId, repoTmsTaskId: task.id },
     });
 
     return {
@@ -85,8 +114,11 @@ export async function repoTmsAgentWorkflow(task: RepoTmsAgentTask): Promise<Repo
     };
   } finally {
     if (sandboxId && task.workMode !== "write") {
-      const sandbox = await Sandbox.get({ sandboxId });
-      await sandbox.stop();
+      try {
+        await stopRepoTmsSandbox(sandboxId);
+      } catch {
+        // Best-effort cleanup; preserve the structured workflow result.
+      }
     }
   }
 }

--- a/apps/hyperlocalise-web/src/workflows/repo-tms-agent.ts
+++ b/apps/hyperlocalise-web/src/workflows/repo-tms-agent.ts
@@ -3,7 +3,10 @@ import { Sandbox } from "@vercel/sandbox";
 import { getWorkflowMetadata } from "workflow";
 
 import type { RepoTmsAgentTask } from "@/lib/agents/repo-tms-task";
-import { buildHyperlocaliseAgentInstructions, getHyperlocaliseAgentModel } from "@/lib/agents/hyperlocalise-agent";
+import {
+  buildHyperlocaliseAgentInstructions,
+  getHyperlocaliseAgentModel,
+} from "@/lib/agents/hyperlocalise-agent";
 import type { ToolContext } from "@/lib/tools/types";
 import { buildTools } from "@/lib/tools/registry";
 import { db } from "@/lib/database";

--- a/apps/hyperlocalise-web/src/workflows/repo-tms-agent.ts
+++ b/apps/hyperlocalise-web/src/workflows/repo-tms-agent.ts
@@ -1,0 +1,89 @@
+import { ToolLoopAgent, type ModelMessage, type ToolSet } from "ai";
+import { Sandbox } from "@vercel/sandbox";
+import { getWorkflowMetadata } from "workflow";
+
+import type { RepoTmsAgentTask } from "@/lib/agents/repo-tms-task";
+import { buildHyperlocaliseAgentInstructions, getHyperlocaliseAgentModel } from "@/lib/agents/hyperlocalise-agent";
+import type { ToolContext } from "@/lib/tools/types";
+import { buildTools } from "@/lib/tools/registry";
+import { db } from "@/lib/database";
+
+export type RepoTmsWorkflowResult = {
+  ok: boolean;
+  workflowRunId: string;
+  sourceReplyTarget: { source: RepoTmsAgentTask["source"]; threadId: string };
+  summary: string;
+  error?: string;
+};
+
+const sandboxTimeoutMs = 10 * 60 * 1000;
+
+export async function repoTmsAgentWorkflow(task: RepoTmsAgentTask): Promise<RepoTmsWorkflowResult> {
+  "use workflow";
+
+  const { workflowRunId } = getWorkflowMetadata();
+  let sandboxId: string | null = null;
+
+  try {
+    if (task.githubContext?.resolved) {
+      const sandbox = await Sandbox.create({
+        source: {
+          type: "git",
+          url: `https://github.com/${task.githubContext.repositoryFullName}.git`,
+          revision: task.githubContext.commitSha ?? task.githubContext.branch ?? "HEAD",
+          depth: 1,
+        },
+        timeout: sandboxTimeoutMs,
+      });
+      sandboxId = sandbox.sandboxId;
+    }
+
+    const toolContext: ToolContext = {
+      conversationId: task.id,
+      organizationId: task.organizationId,
+      membershipRole: "owner",
+      projectId: task.projectId,
+      db,
+    };
+
+    const tools = buildTools(toolContext) as ToolSet;
+    const agent = new ToolLoopAgent({
+      model: getHyperlocaliseAgentModel(),
+      tools,
+      stopWhen: [(step) => step.steps.length >= 5],
+      system: buildHyperlocaliseAgentInstructions({
+        surface: "github",
+        projectId: task.projectId,
+        additionalInstructions: sandboxId
+          ? `Sandbox id available to tools: ${sandboxId}. Access repo only via tools.`
+          : "No repository sandbox required for this task.",
+      }),
+    });
+
+    const result = await agent.generate({
+      messages: [{ role: "user", content: task.instructions }] as ModelMessage[],
+      experimental_context: { sandboxId, repoTmsTaskId: task.id },
+    });
+
+    return {
+      ok: true,
+      workflowRunId,
+      sourceReplyTarget: { source: task.source, threadId: task.sourceThreadId },
+      summary: result.text.trim() || "Completed repo/TMS agent task.",
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      ok: false,
+      workflowRunId,
+      sourceReplyTarget: { source: task.source, threadId: task.sourceThreadId },
+      summary: "Repo/TMS workflow failed.",
+      error: message,
+    };
+  } finally {
+    if (sandboxId && task.workMode !== "write") {
+      const sandbox = await Sandbox.get({ sandboxId });
+      await sandbox.stop();
+    }
+  }
+}

--- a/apps/hyperlocalise-web/src/workflows/repo-tms-agent.ts
+++ b/apps/hyperlocalise-web/src/workflows/repo-tms-agent.ts
@@ -113,7 +113,7 @@ export async function repoTmsAgentWorkflow(task: RepoTmsAgentTask): Promise<Repo
       error: message,
     };
   } finally {
-    if (sandboxId && task.workMode !== "write") {
+    if (sandboxId && task.workMode === "read_only") {
       try {
         await stopRepoTmsSandbox(sandboxId);
       } catch {

--- a/apps/hyperlocalise-web/src/workflows/repo-tms-agent.ts
+++ b/apps/hyperlocalise-web/src/workflows/repo-tms-agent.ts
@@ -73,7 +73,7 @@ export async function repoTmsAgentWorkflow(task: RepoTmsAgentTask): Promise<Repo
     const toolContext: ToolContext = {
       conversationId: task.id,
       organizationId: task.organizationId,
-      membershipRole: "owner",
+      membershipRole: "member",
       projectId: task.projectId,
       db,
     };
@@ -84,7 +84,7 @@ export async function repoTmsAgentWorkflow(task: RepoTmsAgentTask): Promise<Repo
       tools,
       stopWhen: [(step) => step.steps.length >= agentStepLimit],
       instructions: buildHyperlocaliseAgentInstructions({
-        surface: "github",
+        surface: task.source === "slack" ? "slack" : task.source === "github" ? "github" : "web",
         projectId: task.projectId,
         additionalInstructions: sandboxId
           ? `Sandbox id available to tools: ${sandboxId}. Access repo only via tools.`


### PR DESCRIPTION
### Motivation
- Provide a durable workflow to run repo/TMS ToolLoopAgent execution outside the sandbox while exposing sandbox-backed repo tools.
- Create or restore a repo sandbox only when GitHub context is resolved and ensure disposable-run sandboxes are cleaned up.
- Surface a stable workflow result that records success/failure, source reply routing, `workflowRunId`, and a final summary.

### Description
- Add `apps/hyperlocalise-web/src/workflows/repo-tms-agent.ts` implementing `repoTmsAgentWorkflow` which creates a git `Sandbox` when `task.githubContext.resolved`, builds a `ToolLoopAgent` with `buildTools`, and passes `experimental_context` containing the `sandboxId` and `repoTmsTaskId`.
- Return a typed `RepoTmsWorkflowResult` with `ok`, `workflowRunId`, `sourceReplyTarget`, `summary`, and optional `error` for failures.
- Ensure sandbox cleanup by stopping the sandbox in `finally` for non-`write` runs while preserving sandboxes for `write` mode.
- Add `apps/hyperlocalise-web/src/workflows/repo-tms-agent.test.ts` with mock-based tests that cover the success path, tool failure handling, disposable sandbox cleanup, and write-mode retention.

### Testing
- `make fmt` completed successfully in this environment.
- `make lint` failed here due to a missing `/root/go/bin/golangci-lint` binary, so the full lint pass did not complete.
- Attempts to run `vp check --fix` and `vp test` failed because the `vp` binary is not available in this environment, so the TypeScript/Vite+ test runner could not be executed.
- Unit tests for the new workflow were added (mocked sandbox and agent), but they could not be executed here due to the missing `vp` tooling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e42de4a24832c82cf6dad6be59890)