### PR TITLE
🧪 Scout: add prefix locale test for NormalizeList

### DIFF
--- a/internal/i18n/locales/normalize_test.go
+++ b/internal/i18n/locales/normalize_test.go
@@ -31,6 +31,11 @@ func TestNormalizeListSplitsTrimsAndDeduplicates(t *testing.T) {
 			in:   []string{"en-US,,en-GB", "EN-US", "  fr-CA  ,  FR-ca "},
 			want: []string{"en-US", "en-GB", "fr-CA"},
 		},
+		{
+			name: "prefix locales are distinct",
+			in:   []string{"en", "en-US", "en-GB"},
+			want: []string{"en", "en-US", "en-GB"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### 🧪 Scout: add prefix locale test for NormalizeList

#### 💡 What
Added a new regression test case to `TestNormalizeListSplitsTrimsAndDeduplicates` that verifies prefix locales are preserved as distinct entries.

#### 🎯 Why
In i18n normalization, it's critical that more specific locales (like `en-US`) are not "swallowed" or deduplicated against their base language prefixes (like `en`). This test provides a safeguard for this behavior.

#### 🧩 Scope
- `internal/i18n/locales/normalize_test.go`: Added the `prefix locales are distinct` test case.

#### ✅ Verification
- Ran `go test -v ./internal/i18n/locales/...` and confirmed all tests pass.
- Verified with code review.

#### 🛡️ Confidence
This test helps prevent regressions in locale list processing where specific regional configurations might be lost due to over-aggressive deduplication.

---
*PR created automatically by Jules for task [5499663944944525617](https://jules.google.com/task/5499663944944525617) started by @cungminh2710*