### PR TITLE
feat(slack): enqueue repo TMS workflow from Slack

### DIFF
--- a/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
@@ -9,30 +9,21 @@ import {
   handleSubscribedMessage,
   wrapThreadPost,
 } from "./bot";
+import { buildRepoTmsTaskIdempotencyKey } from "@/lib/agents/repo-tms-task";
 
 const {
   agentGenerateMock,
-  buildRepoTmsGitHubContextInstructionsMock,
   createConversationToolLoopAgentMock,
   loadMessagesMock,
   resolveSlackRepoTmsGitHubContextMock,
 } = vi.hoisted(() => ({
   agentGenerateMock: vi.fn(),
-  buildRepoTmsGitHubContextInstructionsMock: vi.fn(
-    (context: { repositoryFullName: string; pullRequestNumber?: number }) =>
-      `Resolved GitHub repository context:\n- repository: ${context.repositoryFullName}\n${
-        context.pullRequestNumber === undefined
-          ? ""
-          : `- pullRequestNumber: ${context.pullRequestNumber}`
-      }`,
-  ),
   createConversationToolLoopAgentMock: vi.fn(() => ({
     generate: agentGenerateMock,
   })),
   loadMessagesMock: vi.fn(async () => []),
   resolveSlackRepoTmsGitHubContextMock: vi.fn(),
 }));
-
 
 const { enqueueRepoTmsTaskMock } = vi.hoisted(() => ({
   enqueueRepoTmsTaskMock: vi.fn(async () => ({ ids: ["run-123"] })),
@@ -78,7 +69,6 @@ vi.mock("@/lib/agents/repo-tms-context", async (importOriginal) => {
   const original = await importOriginal<typeof import("@/lib/agents/repo-tms-context")>();
   return {
     ...original,
-    buildRepoTmsGitHubContextInstructions: buildRepoTmsGitHubContextInstructionsMock,
     resolveSlackRepoTmsGitHubContext: resolveSlackRepoTmsGitHubContextMock,
   };
 });
@@ -532,8 +522,45 @@ describe("handleNewConversation", () => {
     });
     expect(createConversationToolLoopAgentMock).not.toHaveBeenCalled();
     expect(enqueueRepoTmsTaskMock).toHaveBeenCalledTimes(1);
+    expect(enqueueRepoTmsTaskMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "slack",
+        sourceThreadId: thread.id,
+        actor: {
+          sourceUserId: message.author.userId,
+          userId: "user-123",
+          email: "alice@example.com",
+          displayName: "Alice",
+        },
+        organizationId: "org-123",
+        projectId: "project-123",
+        workMode: "approval_required",
+        instructions: "Can you check https://github.com/acme/web/pull/42",
+        githubContext: {
+          resolved: true,
+          installationId: 12345,
+          repositoryFullName: "acme/web",
+          pullRequestNumber: 42,
+        },
+        idempotencyKey: buildRepoTmsTaskIdempotencyKey({
+          source: "slack",
+          sourceThreadId: thread.id,
+          organizationId: "org-123",
+          instructions: "Can you check https://github.com/acme/web/pull/42",
+          githubContext: {
+            resolved: true,
+            installationId: 12345,
+            repositoryFullName: "acme/web",
+            pullRequestNumber: 42,
+          },
+        }),
+      }),
+    );
     expect(posts).toEqual([
-      { markdown: "Queued your repo/TMS workflow. I'll post progress and final results in this thread." },
+      {
+        markdown:
+          "Queued your repo/TMS workflow. I'll post progress and final results in this thread.",
+      },
     ]);
   });
 

--- a/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
@@ -33,6 +33,14 @@ const {
   resolveSlackRepoTmsGitHubContextMock: vi.fn(),
 }));
 
+
+const { enqueueRepoTmsTaskMock } = vi.hoisted(() => ({
+  enqueueRepoTmsTaskMock: vi.fn(async () => ({ ids: ["run-123"] })),
+}));
+
+vi.mock("@/workflows/adapters", () => ({
+  createRepoTmsAgentTaskQueue: vi.fn(() => ({ enqueue: enqueueRepoTmsTaskMock })),
+}));
 vi.mock("@/lib/env", () => ({
   env: {
     SLACK_CLIENT_ID: "test-client-id",
@@ -522,13 +530,11 @@ describe("handleNewConversation", () => {
       channelId: "C123",
       requirePullRequest: true,
     });
-    expect(createConversationToolLoopAgentMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        intent: { kind: "repo_tms", githubContextRequirement: "pull_request" },
-        additionalInstructions: expect.stringContaining("repository: acme/web"),
-      }),
-    );
-    expect(posts).toEqual([{ markdown: "AI response" }]);
+    expect(createConversationToolLoopAgentMock).not.toHaveBeenCalled();
+    expect(enqueueRepoTmsTaskMock).toHaveBeenCalledTimes(1);
+    expect(posts).toEqual([
+      { markdown: "Queued your repo/TMS workflow. I'll post progress and final results in this thread." },
+    ]);
   });
 
   it("asks a Slack follow-up when repo/TMS context is unresolved", async () => {

--- a/apps/hyperlocalise-web/src/lib/agents/slack/bot.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/bot.ts
@@ -10,12 +10,10 @@ import {
   loadInteractionModelMessages,
   replaceLastUserMessage,
 } from "@/lib/agents/hyperlocalise-agent";
-import {
-  buildRepoTmsGitHubContextInstructions,
-  resolveSlackRepoTmsGitHubContext,
-} from "@/lib/agents/repo-tms-context";
+import { resolveSlackRepoTmsGitHubContext } from "@/lib/agents/repo-tms-context";
 import {
   buildRepoTmsTaskIdempotencyKey,
+  type RepoTmsAgentGitHubContext,
   type RepoTmsAgentTask,
 } from "@/lib/agents/repo-tms-task";
 import { createRepoTmsAgentTaskQueue } from "@/workflows/adapters";
@@ -166,7 +164,7 @@ async function processSlackMessage(
     const intent = classifyHyperlocaliseAgentIntent({ surface: "slack", text: message.text });
     const intentInstructions = buildHyperlocaliseAgentIntentInstructions(intent);
     const additionalInstructions = [buildSlackFileTranslationInstructions(), intentInstructions];
-    let resolvedRepoTmsContext: RepoTmsAgentTask["githubContext"];
+    let resolvedRepoTmsContext: RepoTmsAgentGitHubContext | undefined;
 
     if (intent.kind === "repo_tms") {
       const githubContextResolution = await resolveSlackRepoTmsGitHubContext({
@@ -187,9 +185,6 @@ async function processSlackMessage(
 
       if (githubContextResolution.status === "resolved") {
         resolvedRepoTmsContext = githubContextResolution.context;
-        additionalInstructions.push(
-          buildRepoTmsGitHubContextInstructions(githubContextResolution.context),
-        );
       }
     }
 
@@ -215,10 +210,7 @@ async function processSlackMessage(
           sourceThreadId: thread.id,
           organizationId,
           instructions: message.text,
-          githubContext:
-            resolvedRepoTmsContext && resolvedRepoTmsContext.resolved
-              ? resolvedRepoTmsContext
-              : undefined,
+          githubContext: resolvedRepoTmsContext,
         }),
       };
       await createRepoTmsAgentTaskQueue().enqueue(repoTmsTask);

--- a/apps/hyperlocalise-web/src/lib/agents/slack/bot.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/bot.ts
@@ -1,4 +1,5 @@
 import { Chat, emoji } from "chat";
+import { randomUUID } from "node:crypto";
 import { createSlackAdapter } from "@chat-adapter/slack";
 import type { Message, Thread, UserInfo } from "chat";
 
@@ -13,6 +14,11 @@ import {
   buildRepoTmsGitHubContextInstructions,
   resolveSlackRepoTmsGitHubContext,
 } from "@/lib/agents/repo-tms-context";
+import {
+  buildRepoTmsTaskIdempotencyKey,
+  type RepoTmsAgentTask,
+} from "@/lib/agents/repo-tms-task";
+import { createRepoTmsAgentTaskQueue } from "@/workflows/adapters";
 import { createChatStateAdapter } from "@/lib/agents/runtime/state";
 import { wrapThreadPostForInteraction } from "@/lib/agents/runtime/tracking";
 import { db } from "@/lib/database";
@@ -160,6 +166,7 @@ async function processSlackMessage(
     const intent = classifyHyperlocaliseAgentIntent({ surface: "slack", text: message.text });
     const intentInstructions = buildHyperlocaliseAgentIntentInstructions(intent);
     const additionalInstructions = [buildSlackFileTranslationInstructions(), intentInstructions];
+    let resolvedRepoTmsContext: RepoTmsAgentTask["githubContext"];
 
     if (intent.kind === "repo_tms") {
       const githubContextResolution = await resolveSlackRepoTmsGitHubContext({
@@ -179,10 +186,50 @@ async function processSlackMessage(
       }
 
       if (githubContextResolution.status === "resolved") {
+        resolvedRepoTmsContext = githubContextResolution.context;
         additionalInstructions.push(
           buildRepoTmsGitHubContextInstructions(githubContextResolution.context),
         );
       }
+    }
+
+    if (intent.kind === "repo_tms") {
+      const repoTmsTask: RepoTmsAgentTask = {
+        id: randomUUID(),
+        source: "slack",
+        sourceThreadId: thread.id,
+        actor: {
+          sourceUserId: message.author.userId,
+          userId: membership.localUserId,
+          email: slackUser?.email,
+          displayName: message.author.fullName ?? message.author.userName,
+        },
+        organizationId,
+        projectId,
+        workMode: "approval_required",
+        instructions: message.text,
+        githubContext: resolvedRepoTmsContext,
+        createdAt: new Date().toISOString(),
+        idempotencyKey: buildRepoTmsTaskIdempotencyKey({
+          source: "slack",
+          sourceThreadId: thread.id,
+          organizationId,
+          instructions: message.text,
+          githubContext:
+            resolvedRepoTmsContext && resolvedRepoTmsContext.resolved
+              ? resolvedRepoTmsContext
+              : undefined,
+        }),
+      };
+      await createRepoTmsAgentTaskQueue().enqueue(repoTmsTask);
+
+      await removeEyesReaction(thread, message);
+      wrapThreadPost(thread, interactionId);
+      await thread.post({
+        markdown:
+          "Queued your repo/TMS workflow. I'll post progress and final results in this thread.",
+      });
+      return;
     }
 
     const imageAttachments = getSlackImageAttachments(message);

--- a/apps/hyperlocalise-web/src/lib/workflow/types.ts
+++ b/apps/hyperlocalise-web/src/lib/workflow/types.ts
@@ -95,3 +95,5 @@ export type EmailAgentTask = {
 };
 
 export type EmailAgentTaskQueue = JobQueue<EmailAgentTask>;
+
+export type RepoTmsAgentTaskQueue = JobQueue<import("@/lib/agents/repo-tms-task").RepoTmsAgentTask>;

--- a/apps/hyperlocalise-web/src/workflows/adapters.ts
+++ b/apps/hyperlocalise-web/src/workflows/adapters.ts
@@ -3,11 +3,13 @@ import { start } from "workflow/api";
 import { emailTranslationWorkflow } from "./email-translation";
 import { fileTranslationJobWorkflow } from "./file-translation-job";
 import { githubFixWorkflow } from "./github-fix";
+import { repoTmsAgentWorkflow } from "./repo-tms-agent";
 import { translationJobWorkflow } from "./translation-job";
 import type {
   EmailAgentTaskQueue,
   GitHubFixQueue,
   JobQueue,
+  RepoTmsAgentTaskQueue,
   TranslationJobEventData,
 } from "@/lib/workflow/types";
 
@@ -44,6 +46,15 @@ export function createEmailAgentTaskQueue(): EmailAgentTaskQueue {
       return {
         ids: [run.runId],
       };
+    },
+  };
+}
+
+export function createRepoTmsAgentTaskQueue(): RepoTmsAgentTaskQueue {
+  return {
+    async enqueue(task) {
+      const run = await start(repoTmsAgentWorkflow, [task]);
+      return { ids: [run.runId] };
     },
   };
 }


### PR DESCRIPTION
### Motivation

- Prevent long-running agent or sandbox CLI work from executing inline in the Slack handler by turning Slack repo/TMS intents into durable queued workflows. 
- Persist Slack/thread/actor/organization/project/GitHub context and an idempotency key so queued runs can be deduplicated and reply into the originating thread. 

### Description

- Route repo/TMS Slack intents to a durable `RepoTmsAgentTask` instead of running the tool-loop agent inline by building a task payload and calling a queue adapter. 
- Add `createRepoTmsAgentTaskQueue()` in `apps/hyperlocalise-web/src/workflows/adapters.ts` which starts the `repoTmsAgentWorkflow`. 
- Update `apps/hyperlocalise-web/src/lib/agents/slack/bot.ts` to: import `randomUUID`, assemble the `RepoTmsAgentTask` (actor, thread, org, project, instructions, GitHub context, `idempotencyKey`), enqueue it, and immediately post an acknowledgment back to the Slack thread. 
- Add a typed queue alias `RepoTmsAgentTaskQueue` in `apps/hyperlocalise-web/src/lib/workflow/types.ts`. 
- Update `apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts` to mock the new queue adapter and assert that repo/TMS intents are enqueued and the handler replies immediately (and that the inline agent is not invoked for those intents). 

### Testing

- Ran `make fmt` successfully. 
- Ran `make lint` but it failed in this environment due to a missing linter binary (`/root/go/bin/golangci-lint`), so lint could not be verified here. 
- Ran `make test` but it failed in this environment due to a Go toolchain version mismatch (`go1.26.1` vs `go1.25.1`), so the full test suite could not be completed here. 
- Attempted to run the targeted frontend test with `vp test` but `vp` was not available in this environment, so the updated Slack bot tests were not executed end-to-end here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e4ef193fc832ca6001fd716ec9585)