### PR TITLE
Add beforePostGeneratedImage callback and options object to Slack image handler

### DIFF
--- a/apps/hyperlocalise-web/src/lib/agents/slack/bot.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/bot.ts
@@ -243,7 +243,13 @@ async function processSlackMessage(
 
       await removeEyesReaction(thread, message);
       wrapThreadPost(thread, interactionId);
-      await handleSlackImageAttachments(thread, message, imageAttachments, imageIntentMessages);
+      await handleSlackImageAttachments(thread, message, {
+        imageAttachments,
+        conversationMessages: imageIntentMessages,
+        beforePostGeneratedImage: async () => {
+          await removeEyesReaction(thread, message);
+        },
+      });
 
       if (storedFileAttachments.length === 0) {
         return;

--- a/apps/hyperlocalise-web/src/lib/agents/slack/image-attachments.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/image-attachments.ts
@@ -142,12 +142,19 @@ function buildImageFailureMessage(imageAttachment: ImageLocalizationAttachment) 
   return `Sorry, I couldn't localize ${imageAttachment.name ?? "that image"} right now. Please try again with the image and target language.`;
 }
 
+type HandleSlackImageAttachmentsOptions = {
+  imageAttachments?: ImageLocalizationAttachment[];
+  conversationMessages?: SlackImageIntentMessage[];
+  beforePostGeneratedImage?: () => Promise<void> | void;
+};
+
 export async function handleSlackImageAttachments(
   thread: SlackImageThread,
   message: Message,
-  imageAttachments = getSlackImageAttachments(message),
-  conversationMessages: SlackImageIntentMessage[] = [],
+  options: HandleSlackImageAttachmentsOptions = {},
 ) {
+  const imageAttachments = options.imageAttachments ?? getSlackImageAttachments(message);
+  const conversationMessages = options.conversationMessages ?? [];
   if (imageAttachments.length === 0) {
     return { handled: false, localizedCount: 0 };
   }
@@ -173,6 +180,7 @@ export async function handleSlackImageAttachments(
         contextLines: [message.text ? `Slack request: ${message.text}` : null],
       });
 
+      await options.beforePostGeneratedImage?.();
       await thread.post({
         raw: [
           `Here is the localized version of ${imageAttachment.name ?? "your image"} for ${targetLocale}. I kept the layout and style as close to the original as possible.`,

--- a/apps/hyperlocalise-web/src/lib/agents/slack/image-attachments.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/image-attachments.ts
@@ -142,7 +142,7 @@ function buildImageFailureMessage(imageAttachment: ImageLocalizationAttachment) 
   return `Sorry, I couldn't localize ${imageAttachment.name ?? "that image"} right now. Please try again with the image and target language.`;
 }
 
-type HandleSlackImageAttachmentsOptions = {
+export type HandleSlackImageAttachmentsOptions = {
   imageAttachments?: ImageLocalizationAttachment[];
   conversationMessages?: SlackImageIntentMessage[];
   beforePostGeneratedImage?: () => Promise<void> | void;
@@ -180,7 +180,17 @@ export async function handleSlackImageAttachments(
         contextLines: [message.text ? `Slack request: ${message.text}` : null],
       });
 
-      await options.beforePostGeneratedImage?.();
+      if (options.beforePostGeneratedImage) {
+        try {
+          await options.beforePostGeneratedImage();
+        } catch (error) {
+          console.error("Failed to run Slack pre-image-post hook", {
+            error,
+            imageName: imageAttachment.name,
+            targetLocale,
+          });
+        }
+      }
       await thread.post({
         raw: [
           `Here is the localized version of ${imageAttachment.name ?? "your image"} for ${targetLocale}. I kept the layout and style as close to the original as possible.`,


### PR DESCRIPTION
### Motivation
- Allow callers to run an action just before each generated localized image is posted (for example to remove a reaction) and to pass explicit image and conversation context into the handler.
- Make the image handling API more flexible by accepting an options object instead of positional parameters.

### Description
- Replace positional parameters on `handleSlackImageAttachments` with a single `options` object and add a `HandleSlackImageAttachmentsOptions` type containing `imageAttachments`, `conversationMessages`, and `beforePostGeneratedImage` callback.
- Use `options.imageAttachments` and `options.conversationMessages` when provided, otherwise fall back to existing behavior (`getSlackImageAttachments(message)` and `[]`).
- Invoke `options.beforePostGeneratedImage` (if provided) immediately before posting each localized file to the Slack thread.
- Update the Slack bot caller to pass the `imageAttachments`, `conversationMessages`, and a `beforePostGeneratedImage` that calls `removeEyesReaction`.

### Testing
- Ran the repository TypeScript build, linter, and unit test suite (`pnpm build`, `pnpm lint`, `pnpm test`); all checked steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e49cfc174832c9101a7a086a36af7)