### PR TITLE
fix(crowdin): improve Glossary and TM model parity

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -53,3 +53,9 @@
 **Learning:** The Crowdin Bundles API v2 returns an `eta` field in bundle export responses, and the Tasks API supports filtering by `workflowStepId` via query parameters. These were missing from the Go SDK models and request options.
 
 **Action:** Added `ETA` to the `BundleExport` model in `model/bundles.go`. Added `WorkflowStepID` to `TasksListOptions` and updated its `Values()` method in `model/tasks.go` to encode it. Updated contract tests in `bundles_test.go` and `tasks_test.go` to verify parity.
+
+## 2026-06-26 - Improve Glossary and TM model parity for updatedAt and translationOfTermId
+
+**Learning:** The Crowdin API v2 for Glossaries and Translation Memories returns an `updatedAt` field in their resource responses, which was missing from the Go SDK models. Additionally, the Add Term endpoint supports a deprecated `translationOfTermId` field for linking translations, which can still be useful for legacy integrations.
+
+**Action:** Added `UpdatedAt` (string) to `Glossary` and `TranslationMemory` models. Added `TranslationOfTermID` (int) to `TermAddRequest`. Updated contract tests in `glossaries_test.go` and `translation_memory_test.go` to verify correct parsing and serialization of these fields.

--- a/third_party/crowdin-api-client-go/crowdin/glossaries_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/glossaries_test.go
@@ -314,7 +314,8 @@ func TestGlossariesService_GetGlossary(t *testing.T) {
 				"defaultProjectIds": [2],
 				"projectIds": [6],
 				"webUrl": "https://example.crowdin.com/u/glossaries/1",
-				"createdAt": "2023-09-16T13:42:04+00:00"
+				"createdAt": "2023-09-16T13:42:04+00:00",
+				"updatedAt": "2023-09-16T13:42:04+00:00"
 			}
 		}`)
 	})
@@ -336,6 +337,7 @@ func TestGlossariesService_GetGlossary(t *testing.T) {
 		ProjectIDs:        []int{6},
 		WebURL:            "https://example.crowdin.com/u/glossaries/1",
 		CreatedAt:         "2023-09-16T13:42:04+00:00",
+		UpdatedAt:         "2023-09-16T13:42:04+00:00",
 	}
 	assert.Equal(t, expected, glossary)
 }
@@ -1178,7 +1180,8 @@ func TestGlossariesService_AddTerm(t *testing.T) {
 			"gender": "masculine",
 			"note": "string",
 			"url": "https://example.com/base-url",
-			"conceptId": 1
+			"conceptId": 1,
+			"translationOfTermId": 2
 		}`)
 
 		fmt.Fprint(w, `{
@@ -1204,16 +1207,17 @@ func TestGlossariesService_AddTerm(t *testing.T) {
 	})
 
 	req := &model.TermAddRequest{
-		LanguageID:   "fr",
-		Text:         "Voir",
-		Description:  "use for pages only (check screenshots)",
-		PartOfSpeech: "verb",
-		Status:       "preferred",
-		Type:         "abbreviation",
-		Gender:       "masculine",
-		Note:         "string",
-		URL:          "https://example.com/base-url",
-		ConceptID:    1,
+		LanguageID:          "fr",
+		Text:                "Voir",
+		Description:         "use for pages only (check screenshots)",
+		PartOfSpeech:        "verb",
+		Status:              "preferred",
+		Type:                "abbreviation",
+		Gender:              "masculine",
+		Note:                "string",
+		URL:                 "https://example.com/base-url",
+		ConceptID:           1,
+		TranslationOfTermID: 2,
 	}
 	term, resp, err := client.Glossaries.AddTerm(context.Background(), 1, req)
 	require.NoError(t, err)

--- a/third_party/crowdin-api-client-go/crowdin/model/glossaries.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/glossaries.go
@@ -127,6 +127,7 @@ type Glossary struct {
 	ProjectIDs        []int    `json:"projectIds"`
 	WebURL            string   `json:"webUrl"`
 	CreatedAt         string   `json:"createdAt"`
+	UpdatedAt         string   `json:"updatedAt"`
 }
 
 // GlossaryResponse defines the structure of a response when
@@ -494,6 +495,9 @@ type TermAddRequest struct {
 	URL string `json:"url,omitempty"`
 	// Defines whether to add translation to the existing term.
 	ConceptID int `json:"conceptId,omitempty"`
+	// Defines whether to add translation to the existing term.
+	// Deprecated: Use ConceptID instead.
+	TranslationOfTermID int `json:"translationOfTermId,omitempty"`
 }
 
 // Validate checks if the request is valid.

--- a/third_party/crowdin-api-client-go/crowdin/model/translation_memory.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/translation_memory.go
@@ -20,6 +20,7 @@ type TranslationMemory struct {
 	ProjectIDs        []int    `json:"projectIds"`
 	WebURL            string   `json:"webUrl"`
 	CreatedAt         string   `json:"createdAt"`
+	UpdatedAt         string   `json:"updatedAt"`
 }
 
 // TranslationMemoryResponse defines the structure of the response

--- a/third_party/crowdin-api-client-go/crowdin/translation_memory_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/translation_memory_test.go
@@ -32,7 +32,8 @@ func TestTranslationMemoryService_GetTM(t *testing.T) {
 				"defaultProjectIds": [2],
 				"projectIds": [2],
 				"webUrl": "https://crowdin.com/profile/username/resources/traslation-memory/1",
-				"createdAt": "2023-09-16T13:42:04+00:00"
+				"createdAt": "2023-09-16T13:42:04+00:00",
+				"updatedAt": "2023-09-16T13:42:04+00:00"
 			}
 		}`)
 	})
@@ -54,6 +55,7 @@ func TestTranslationMemoryService_GetTM(t *testing.T) {
 		ProjectIDs:        []int{2},
 		WebURL:            "https://crowdin.com/profile/username/resources/traslation-memory/1",
 		CreatedAt:         "2023-09-16T13:42:04+00:00",
+		UpdatedAt:         "2023-09-16T13:42:04+00:00",
 	}
 	assert.Equal(t, expected, tm)
 }


### PR DESCRIPTION
This PR improves the Crowdin API v2 client's correctness by adding missing fields to the Glossary and Translation Memory models. Specifically, it adds the updatedAt field to both resource models and the translationOfTermId field to the Add Term request model, ensuring better parity with the official API documentation. Corresponding contract tests have been updated to verify these changes.

---
*PR created automatically by Jules for task [10572755340098248591](https://jules.google.com/task/10572755340098248591) started by @cungminh2710*