### PR TITLE
feat(github-agent): queue repo/TMS workflows from GitHub mentions

### DIFF
--- a/apps/hyperlocalise-web/src/lib/agents/github/bot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/bot.test.ts
@@ -8,54 +8,75 @@ const {
   createInteractionMock,
   findInteractionBySourceThreadIdMock,
   buildGitHubFixRequestInputMock,
+  buildGitHubRepoTmsRequestInputMock,
   claimGitHubAgentRequestMock,
   loadMessagesMock,
   markGitHubAgentRequestEnqueuedMock,
+  createRepoTmsAgentTaskQueueMock,
   getInstallationOctokitMock,
   releaseGitHubAgentRequestClaimMock,
+  repoTmsQueueEnqueueMock,
   selectMock,
-} = vi.hoisted(() => ({
-  addInteractionMessageMock: vi.fn(),
-  agentGenerateMock: vi.fn(),
-  buildGitHubFixRequestInputMock: vi.fn((event: unknown) => ({
-    requestKind: "fix",
-    githubInstallationId: "54321",
-    repositoryFullName: "owner/repo",
-    pullRequestNumber: 42,
-    commentId: "123",
-    scopeType: "review_comment",
-    scopeKey: JSON.stringify(event),
-  })),
-  claimGitHubAgentRequestMock: vi.fn(),
-  createHyperlocaliseAgentMock: vi.fn((_settings: unknown) => ({
-    generate: agentGenerateMock,
-  })),
-  createInteractionMock: vi.fn(),
-  findInteractionBySourceThreadIdMock: vi.fn(),
-  loadMessagesMock: vi.fn(async () => [{ role: "user", content: "@hyperlocalise fix" }]),
-  markGitHubAgentRequestEnqueuedMock: vi.fn(),
-  getInstallationOctokitMock: vi.fn(async () => ({
-    rest: {
-      pulls: {
-        get: vi.fn(async () => ({
-          data: {
-            head: {
-              ref: "feature/i18n",
-              sha: "head-sha",
+} = vi.hoisted(() => {
+  const agentGenerateMock = vi.fn();
+  const repoTmsQueueEnqueueMock = vi.fn();
+
+  return {
+    addInteractionMessageMock: vi.fn(),
+    agentGenerateMock,
+    buildGitHubFixRequestInputMock: vi.fn((event: unknown) => ({
+      requestKind: "fix",
+      githubInstallationId: "54321",
+      repositoryFullName: "owner/repo",
+      pullRequestNumber: 42,
+      commentId: "123",
+      scopeType: "review_comment",
+      scopeKey: JSON.stringify(event),
+    })),
+    buildGitHubRepoTmsRequestInputMock: vi.fn((input: unknown) => ({
+      requestKind: "repo_tms",
+      githubInstallationId: "54321",
+      repositoryFullName: "owner/repo",
+      pullRequestNumber: 42,
+      commentId: "123",
+      scopeType: "repo_tms",
+      scopeKey: JSON.stringify(input),
+    })),
+    claimGitHubAgentRequestMock: vi.fn(),
+    createHyperlocaliseAgentMock: vi.fn((_settings: unknown) => ({
+      generate: agentGenerateMock,
+    })),
+    createInteractionMock: vi.fn(),
+    createRepoTmsAgentTaskQueueMock: vi.fn(() => ({
+      enqueue: repoTmsQueueEnqueueMock,
+    })),
+    findInteractionBySourceThreadIdMock: vi.fn(),
+    loadMessagesMock: vi.fn(async () => [{ role: "user", content: "@hyperlocalise fix" }]),
+    markGitHubAgentRequestEnqueuedMock: vi.fn(),
+    getInstallationOctokitMock: vi.fn(async () => ({
+      rest: {
+        pulls: {
+          get: vi.fn(async () => ({
+            data: {
+              head: {
+                ref: "feature/i18n",
+                sha: "head-sha",
+              },
             },
-          },
-        })),
+          })),
+        },
+        repos: {
+          getCollaboratorPermissionLevel: vi.fn(async () => ({
+            data: { permission: "write" },
+          })),
+        },
       },
-      repos: {
-        getCollaboratorPermissionLevel: vi.fn(async () => ({
-          data: { permission: "write" },
-        })),
-      },
-    },
-  })),
-  releaseGitHubAgentRequestClaimMock: vi.fn(),
-  selectMock: vi.fn(),
-}));
+    })),
+    releaseGitHubAgentRequestClaimMock: vi.fn(),
+    repoTmsQueueEnqueueMock,
+    selectMock: vi.fn(),
+  };
+});
 
 vi.mock("@/lib/agents/hyperlocalise-agent", () => {
   return {
@@ -84,9 +105,14 @@ vi.mock("@/lib/interactions", () => ({
 
 vi.mock("@/lib/agents/github/request-idempotency", () => ({
   buildGitHubFixRequestInput: buildGitHubFixRequestInputMock,
+  buildGitHubRepoTmsRequestInput: buildGitHubRepoTmsRequestInputMock,
   claimGitHubAgentRequest: claimGitHubAgentRequestMock,
   markGitHubAgentRequestEnqueued: markGitHubAgentRequestEnqueuedMock,
   releaseGitHubAgentRequestClaim: releaseGitHubAgentRequestClaimMock,
+}));
+
+vi.mock("@/workflows/adapters", () => ({
+  createRepoTmsAgentTaskQueue: createRepoTmsAgentTaskQueueMock,
 }));
 
 vi.mock("@/lib/agents/github/app", () => ({
@@ -110,6 +136,7 @@ import { handleMention } from "./bot";
 
 function createThread() {
   const addReactionMock = vi.fn(async () => undefined);
+  const getInstallationIdMock = vi.fn(async (): Promise<string | null> => "54321");
   const posts: unknown[] = [];
   const setStateMock = vi.fn(async () => undefined);
   const thread = {
@@ -121,11 +148,11 @@ function createThread() {
     setState: setStateMock,
     adapter: {
       addReaction: addReactionMock,
-      getInstallationId: vi.fn(async () => "54321"),
+      getInstallationId: getInstallationIdMock,
     },
   } as unknown as Thread<Record<string, unknown>>;
 
-  return { addReactionMock, posts, setStateMock, thread };
+  return { addReactionMock, getInstallationIdMock, posts, setStateMock, thread };
 }
 
 function createMessage(input: { text?: string; raw?: Record<string, unknown> } = {}): Message {
@@ -180,6 +207,7 @@ describe("GitHub command routing", () => {
       alreadyQueued: false,
       requestId: "request_123",
     });
+    repoTmsQueueEnqueueMock.mockResolvedValue({ ids: ["repo_tms_run_123"] });
     findInteractionBySourceThreadIdMock.mockResolvedValue(null);
     markGitHubAgentRequestEnqueuedMock.mockResolvedValue(undefined);
     createInteractionMock.mockResolvedValue({
@@ -193,11 +221,37 @@ describe("GitHub command routing", () => {
     const { addReactionMock, thread } = createThread();
     const queue = { enqueue: vi.fn() };
 
-    await handleMention(thread, createMessage({ text: "@hyperlocalise status" }), { queue });
+    await handleMention(thread, createMessage({ text: "@octocat status" }), { queue });
 
     expect(createHyperlocaliseAgentMock).not.toHaveBeenCalled();
     expect(queue.enqueue).not.toHaveBeenCalled();
     expect(addReactionMock).not.toHaveBeenCalled();
+  });
+
+  it("ignores an empty hyperlocalise mention", async () => {
+    const { addReactionMock, thread } = createThread();
+    const queue = { enqueue: vi.fn() };
+
+    await handleMention(thread, createMessage({ text: "@hyperlocalise" }), { queue });
+
+    expect(createHyperlocaliseAgentMock).not.toHaveBeenCalled();
+    expect(queue.enqueue).not.toHaveBeenCalled();
+    expect(createRepoTmsAgentTaskQueueMock).not.toHaveBeenCalled();
+    expect(addReactionMock).not.toHaveBeenCalled();
+  });
+
+  it("uses a command-neutral message when GitHub App installation is missing", async () => {
+    const { getInstallationIdMock, posts, thread } = createThread();
+    const queue = { enqueue: vi.fn() };
+    getInstallationIdMock.mockResolvedValueOnce(null);
+
+    await handleMention(thread, createMessage({ text: "@hyperlocalise sync repo translations" }), {
+      queue,
+    });
+
+    expect(createHyperlocaliseAgentMock).not.toHaveBeenCalled();
+    expect(queue.enqueue).not.toHaveBeenCalled();
+    expect(posts).toEqual(["GitHub App installation is not configured for `@hyperlocalise`."]);
   });
 
   it("validates PR context before invoking the agent", async () => {
@@ -221,7 +275,7 @@ describe("GitHub command routing", () => {
     expect(createHyperlocaliseAgentMock).not.toHaveBeenCalled();
     expect(queue.enqueue).not.toHaveBeenCalled();
     expect(posts).toEqual([
-      "I can only run `@hyperlocalise fix` from pull request comments or inline pull request review comments.",
+      "I can only run `@hyperlocalise` from pull request comments or inline pull request review comments.",
     ]);
   });
 
@@ -248,7 +302,52 @@ describe("GitHub command routing", () => {
     expect(createHyperlocaliseAgentMock).not.toHaveBeenCalled();
     expect(queue.enqueue).not.toHaveBeenCalled();
     expect(posts).toEqual([
-      "I can only run `@hyperlocalise fix` for repository collaborators with write access.",
+      "I can only run `@hyperlocalise` commands for repository collaborators with write access.",
+    ]);
+  });
+
+  it("denies repo/TMS commands when collaborator permission lookup fails", async () => {
+    const { posts, thread } = createThread();
+    const queue = { enqueue: vi.fn() };
+    getInstallationOctokitMock.mockResolvedValueOnce({
+      rest: {
+        pulls: {
+          get: vi.fn(async () => ({
+            data: { head: { ref: "feature/i18n", sha: "head-sha" } },
+          })),
+        },
+        repos: {
+          getCollaboratorPermissionLevel: vi.fn(async () => {
+            throw Object.assign(new Error("not found"), { status: 404 });
+          }),
+        },
+      },
+    });
+
+    await handleMention(thread, createMessage({ text: "@hyperlocalise sync repo translations" }), {
+      queue,
+    });
+
+    expect(createRepoTmsAgentTaskQueueMock).not.toHaveBeenCalled();
+    expect(repoTmsQueueEnqueueMock).not.toHaveBeenCalled();
+    expect(posts).toEqual([
+      "I can only run `@hyperlocalise` commands for repository collaborators with write access.",
+    ]);
+  });
+
+  it("does not add the repo/TMS reaction when the workspace cannot be resolved", async () => {
+    const { addReactionMock, posts, thread } = createThread();
+    const queue = { enqueue: vi.fn() };
+    mockOrganizationLookup(null);
+
+    await handleMention(thread, createMessage({ text: "@hyperlocalise sync repo translations" }), {
+      queue,
+    });
+
+    expect(repoTmsQueueEnqueueMock).not.toHaveBeenCalled();
+    expect(addReactionMock).not.toHaveBeenCalled();
+    expect(posts).toEqual([
+      "I could not resolve the Hyperlocalise workspace for this GitHub installation.",
     ]);
   });
 

--- a/apps/hyperlocalise-web/src/lib/agents/github/bot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/bot.test.ts
@@ -351,6 +351,24 @@ describe("GitHub command routing", () => {
     ]);
   });
 
+  it("reports repo/TMS claim failures before adding the reaction", async () => {
+    const { addReactionMock, posts, thread } = createThread();
+    const queue = { enqueue: vi.fn() };
+    claimGitHubAgentRequestMock.mockRejectedValueOnce(new Error("claimed"));
+
+    await expect(
+      handleMention(thread, createMessage({ text: "@hyperlocalise sync repo translations" }), {
+        queue,
+      }),
+    ).rejects.toThrow("claimed");
+
+    expect(repoTmsQueueEnqueueMock).not.toHaveBeenCalled();
+    expect(addReactionMock).not.toHaveBeenCalled();
+    expect(posts).toEqual([
+      "I could not queue this repo/TMS workflow right now. Please try again in a moment.",
+    ]);
+  });
+
   it("routes fix through a restricted ToolLoopAgent tool", async () => {
     const { addReactionMock, posts, setStateMock, thread } = createThread();
     const queue = { enqueue: vi.fn(async () => ({ ids: ["run_123"] })) };

--- a/apps/hyperlocalise-web/src/lib/agents/github/bot.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/bot.ts
@@ -21,7 +21,11 @@ import {
 } from "@/lib/interactions";
 import { db, schema } from "@/lib/database";
 import { eq } from "drizzle-orm";
-import type { GitHubFixRequestedEventData, GitHubFixQueue, RepoTmsAgentTaskQueue } from "@/lib/workflow/types";
+import type {
+  GitHubFixRequestedEventData,
+  GitHubFixQueue,
+  RepoTmsAgentTaskQueue,
+} from "@/lib/workflow/types";
 
 import { parseHyperlocaliseCommand } from "./commands";
 import { buildFixEvent } from "./events";
@@ -30,7 +34,12 @@ import { createGitHubFixTools } from "./tools";
 import { createRepoTmsAgentTaskQueue } from "@/workflows/adapters";
 import { buildRepoTmsTaskIdempotencyKey } from "@/lib/agents/repo-tms-task";
 import { randomUUID } from "node:crypto";
-import { buildGitHubRepoTmsRequestInput, claimGitHubAgentRequest, markGitHubAgentRequestEnqueued, releaseGitHubAgentRequestClaim } from "./request-idempotency";
+import {
+  buildGitHubRepoTmsRequestInput,
+  claimGitHubAgentRequest,
+  markGitHubAgentRequestEnqueued,
+  releaseGitHubAgentRequestClaim,
+} from "./request-idempotency";
 
 type GitHubBotOptions = {
   githubFixQueue: GitHubFixQueue;
@@ -83,7 +92,7 @@ export async function handleMention(
 
   const installationId = await (thread.adapter as GitHubAdapter).getInstallationId(thread);
   if (!installationId) {
-    await thread.post("GitHub App installation is not configured for `@hyperlocalise fix`.");
+    await thread.post("GitHub App installation is not configured for `@hyperlocalise`.");
     return;
   }
   const githubInstallationId = String(installationId);
@@ -96,14 +105,14 @@ export async function handleMention(
   });
   if (!event) {
     await thread.post(
-      "I can only run `@hyperlocalise fix` from pull request comments or inline pull request review comments.",
+      "I can only run `@hyperlocalise` from pull request comments or inline pull request review comments.",
     );
     return;
   }
 
-  if (command.command === "fix" && !(await requesterCanRunFix(event))) {
+  if (!(await requesterCanRunFix(event))) {
     await thread.post(
-      "I can only run `@hyperlocalise fix` for repository collaborators with write access.",
+      "I can only run `@hyperlocalise` commands for repository collaborators with write access.",
     );
     return;
   }
@@ -155,15 +164,22 @@ export async function handleMention(
     // Best-effort tracking
   }
 
-  await thread.adapter.addReaction(thread.id, message.id, emoji.eyes);
-
   if (command.command === "repo_tms") {
-    const taskQueue: RepoTmsAgentTaskQueue = createRepoTmsAgentTaskQueue();
-    const githubContext = githubContextResolution.context;
-    if (!organizationId) {
-      await thread.post("I could not resolve the Hyperlocalise workspace for this GitHub installation.");
+    if (githubContextResolution.status !== "resolved") {
+      await thread.post(
+        "I need a pull request context for this GitHub request. Please run the command from a PR comment or an inline PR review comment.",
+      );
       return;
     }
+    if (!organizationId) {
+      await thread.post(
+        "I could not resolve the Hyperlocalise workspace for this GitHub installation.",
+      );
+      return;
+    }
+    await thread.adapter.addReaction(thread.id, message.id, emoji.eyes);
+    const taskQueue: RepoTmsAgentTaskQueue = createRepoTmsAgentTaskQueue();
+    const githubContext = githubContextResolution.context;
     const claim = await claimGitHubAgentRequest(
       buildGitHubRepoTmsRequestInput({
         installationId: event.installationId,
@@ -183,7 +199,10 @@ export async function handleMention(
         id: randomUUID(),
         source: "github",
         sourceThreadId: thread.id,
-        actor: { sourceUserId: message.author.userId, displayName: message.author.fullName ?? message.author.userName },
+        actor: {
+          sourceUserId: message.author.userId,
+          displayName: message.author.fullName ?? message.author.userName,
+        },
         organizationId,
         projectId: null,
         workMode: "approval_required",
@@ -198,16 +217,24 @@ export async function handleMention(
           githubContext,
         }),
       });
-      await markGitHubAgentRequestEnqueued({ requestId: claim.requestId, workflowRunIds: result.ids });
-      await thread.post("Queued your repo/TMS workflow. I will post progress and completion updates on this pull request.");
+      await markGitHubAgentRequestEnqueued({
+        requestId: claim.requestId,
+        workflowRunIds: result.ids,
+      });
+      await thread.post(
+        "Queued your repo/TMS workflow. I will post progress and completion updates on this pull request.",
+      );
     } catch (error) {
       await releaseGitHubAgentRequestClaim(claim.requestId);
-      await thread.post("I could not queue this repo/TMS workflow right now. Please try again in a moment.");
+      await thread.post(
+        "I could not queue this repo/TMS workflow right now. Please try again in a moment.",
+      );
       throw error;
     }
     return;
   }
 
+  await thread.adapter.addReaction(thread.id, message.id, emoji.eyes);
   await thread.setState({ lastFixEvent: event });
 
   const tools = createGitHubFixTools({ event, queue });

--- a/apps/hyperlocalise-web/src/lib/agents/github/bot.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/bot.ts
@@ -21,12 +21,16 @@ import {
 } from "@/lib/interactions";
 import { db, schema } from "@/lib/database";
 import { eq } from "drizzle-orm";
-import type { GitHubFixRequestedEventData, GitHubFixQueue } from "@/lib/workflow/types";
+import type { GitHubFixRequestedEventData, GitHubFixQueue, RepoTmsAgentTaskQueue } from "@/lib/workflow/types";
 
-import { parseFixCommand } from "./commands";
+import { parseHyperlocaliseCommand } from "./commands";
 import { buildFixEvent } from "./events";
 import { requesterCanRunFix } from "./permissions";
 import { createGitHubFixTools } from "./tools";
+import { createRepoTmsAgentTaskQueue } from "@/workflows/adapters";
+import { buildRepoTmsTaskIdempotencyKey } from "@/lib/agents/repo-tms-task";
+import { randomUUID } from "node:crypto";
+import { buildGitHubRepoTmsRequestInput, claimGitHubAgentRequest, markGitHubAgentRequestEnqueued, releaseGitHubAgentRequestClaim } from "./request-idempotency";
 
 type GitHubBotOptions = {
   githubFixQueue: GitHubFixQueue;
@@ -72,7 +76,7 @@ export async function handleMention(
     return;
   }
 
-  const command = parseFixCommand(message.text);
+  const command = parseHyperlocaliseCommand(message.text);
   if (!command) {
     return;
   }
@@ -97,7 +101,7 @@ export async function handleMention(
     return;
   }
 
-  if (!(await requesterCanRunFix(event))) {
+  if (command.command === "fix" && !(await requesterCanRunFix(event))) {
     await thread.post(
       "I can only run `@hyperlocalise fix` for repository collaborators with write access.",
     );
@@ -113,10 +117,11 @@ export async function handleMention(
     return;
   }
 
+  const organizationId = await getOrganizationIdByInstallationId(githubInstallationId);
+
   // Conversation tracking
   let conversationId: string | undefined;
   try {
-    const organizationId = await getOrganizationIdByInstallationId(githubInstallationId);
     if (organizationId) {
       const existing = await findInteractionBySourceThreadId({
         organizationId,
@@ -151,6 +156,58 @@ export async function handleMention(
   }
 
   await thread.adapter.addReaction(thread.id, message.id, emoji.eyes);
+
+  if (command.command === "repo_tms") {
+    const taskQueue: RepoTmsAgentTaskQueue = createRepoTmsAgentTaskQueue();
+    const githubContext = githubContextResolution.context;
+    if (!organizationId) {
+      await thread.post("I could not resolve the Hyperlocalise workspace for this GitHub installation.");
+      return;
+    }
+    const claim = await claimGitHubAgentRequest(
+      buildGitHubRepoTmsRequestInput({
+        installationId: event.installationId,
+        repositoryFullName: event.repositoryFullName,
+        pullRequestNumber: event.pullRequestNumber,
+        commentId: event.trigger.commentId,
+        instructions: command.instructions,
+      }),
+    );
+    if (claim.alreadyQueued) {
+      await thread.post("This repo/TMS request is already queued.");
+      return;
+    }
+
+    try {
+      const result = await taskQueue.enqueue({
+        id: randomUUID(),
+        source: "github",
+        sourceThreadId: thread.id,
+        actor: { sourceUserId: message.author.userId, displayName: message.author.fullName ?? message.author.userName },
+        organizationId,
+        projectId: null,
+        workMode: "approval_required",
+        instructions: command.instructions,
+        githubContext: githubContext,
+        createdAt: new Date().toISOString(),
+        idempotencyKey: buildRepoTmsTaskIdempotencyKey({
+          source: "github",
+          sourceThreadId: thread.id,
+          organizationId,
+          instructions: command.instructions,
+          githubContext,
+        }),
+      });
+      await markGitHubAgentRequestEnqueued({ requestId: claim.requestId, workflowRunIds: result.ids });
+      await thread.post("Queued your repo/TMS workflow. I will post progress and completion updates on this pull request.");
+    } catch (error) {
+      await releaseGitHubAgentRequestClaim(claim.requestId);
+      await thread.post("I could not queue this repo/TMS workflow right now. Please try again in a moment.");
+      throw error;
+    }
+    return;
+  }
+
   await thread.setState({ lastFixEvent: event });
 
   const tools = createGitHubFixTools({ event, queue });

--- a/apps/hyperlocalise-web/src/lib/agents/github/bot.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/bot.ts
@@ -177,23 +177,31 @@ export async function handleMention(
       );
       return;
     }
-    await thread.adapter.addReaction(thread.id, message.id, emoji.eyes);
     const taskQueue: RepoTmsAgentTaskQueue = createRepoTmsAgentTaskQueue();
     const githubContext = githubContextResolution.context;
-    const claim = await claimGitHubAgentRequest(
-      buildGitHubRepoTmsRequestInput({
-        installationId: event.installationId,
-        repositoryFullName: event.repositoryFullName,
-        pullRequestNumber: event.pullRequestNumber,
-        commentId: event.trigger.commentId,
-        instructions: command.instructions,
-      }),
-    );
+    let claim: Awaited<ReturnType<typeof claimGitHubAgentRequest>>;
+    try {
+      claim = await claimGitHubAgentRequest(
+        buildGitHubRepoTmsRequestInput({
+          installationId: event.installationId,
+          repositoryFullName: event.repositoryFullName,
+          pullRequestNumber: event.pullRequestNumber,
+          commentId: event.trigger.commentId,
+          instructions: command.instructions,
+        }),
+      );
+    } catch (error) {
+      await thread.post(
+        "I could not queue this repo/TMS workflow right now. Please try again in a moment.",
+      );
+      throw error;
+    }
     if (claim.alreadyQueued) {
       await thread.post("This repo/TMS request is already queued.");
       return;
     }
 
+    await thread.adapter.addReaction(thread.id, message.id, emoji.eyes);
     try {
       const result = await taskQueue.enqueue({
         id: randomUUID(),

--- a/apps/hyperlocalise-web/src/lib/agents/github/commands.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/commands.ts
@@ -28,6 +28,10 @@ export function parseHyperlocaliseCommand(text: string): HyperlocaliseCommand | 
     };
   }
 
+  if (parts.length === 0) {
+    return null;
+  }
+
   return {
     command: "repo_tms",
     instructions: parts.join(" "),

--- a/apps/hyperlocalise-web/src/lib/agents/github/commands.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/commands.ts
@@ -3,7 +3,14 @@ export type HyperlocaliseFixCommand = {
   locale: string | null;
 };
 
-export function parseFixCommand(text: string): HyperlocaliseFixCommand | null {
+export type HyperlocaliseRepoTmsCommand = {
+  command: "repo_tms";
+  instructions: string;
+};
+
+export type HyperlocaliseCommand = HyperlocaliseFixCommand | HyperlocaliseRepoTmsCommand;
+
+export function parseHyperlocaliseCommand(text: string): HyperlocaliseCommand | null {
   const mentionIndex = text.toLowerCase().indexOf("@hyperlocalise");
   if (mentionIndex < 0) {
     return null;
@@ -14,12 +21,15 @@ export function parseFixCommand(text: string): HyperlocaliseFixCommand | null {
     .split(/\s+/)
     .filter(Boolean);
 
-  if (parts[0]?.toLowerCase() !== "fix") {
-    return null;
+  if (parts[0]?.toLowerCase() === "fix") {
+    return {
+      command: "fix",
+      locale: parts[1] ?? null,
+    };
   }
 
   return {
-    command: "fix",
-    locale: parts[1] ?? null,
+    command: "repo_tms",
+    instructions: parts.join(" "),
   };
 }

--- a/apps/hyperlocalise-web/src/lib/agents/github/events.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/events.ts
@@ -2,7 +2,7 @@ import type { GitHubRawMessage } from "@chat-adapter/github";
 
 import type { GitHubFixRequestedEventData } from "@/lib/workflow/types";
 
-import type { HyperlocaliseFixCommand } from "./commands";
+import type { HyperlocaliseCommand } from "./commands";
 
 function splitRepository(fullName: string) {
   const [repositoryOwner, repositoryName] = fullName.split("/");
@@ -15,7 +15,7 @@ function splitRepository(fullName: string) {
 
 export function buildFixEvent(input: {
   raw: GitHubRawMessage;
-  command: HyperlocaliseFixCommand;
+  command: HyperlocaliseCommand;
   installationId: number;
   requesterLogin: string;
 }): GitHubFixRequestedEventData | null {
@@ -66,7 +66,7 @@ export function buildFixEvent(input: {
       originalLine: input.raw.comment.original_line ?? null,
       side: input.raw.comment.side ?? null,
       commitSha: input.raw.comment.commit_id ?? input.raw.comment.original_commit_id ?? null,
-      locale: input.command.locale,
+      locale: input.command.command === "fix" ? input.command.locale : null,
     },
   };
 }

--- a/apps/hyperlocalise-web/src/lib/agents/github/request-idempotency.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/request-idempotency.ts
@@ -104,8 +104,6 @@ export function buildGitHubFixRequestInput(
   };
 }
 
-
-
 export function buildGitHubRepoTmsRequestInput(input: {
   installationId: number;
   repositoryFullName: string;

--- a/apps/hyperlocalise-web/src/lib/agents/github/request-idempotency.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/request-idempotency.ts
@@ -104,6 +104,25 @@ export function buildGitHubFixRequestInput(
   };
 }
 
+
+
+export function buildGitHubRepoTmsRequestInput(input: {
+  installationId: number;
+  repositoryFullName: string;
+  pullRequestNumber: number;
+  commentId: number | null;
+  instructions: string;
+}): GitHubAgentRequestInput {
+  return {
+    requestKind: "repo_tms",
+    githubInstallationId: String(input.installationId),
+    repositoryFullName: input.repositoryFullName,
+    pullRequestNumber: input.pullRequestNumber,
+    commentId: String(input.commentId ?? 0),
+    scopeType: "repo_tms",
+    scopeKey: input.instructions,
+  };
+}
 export async function claimGitHubAgentRequest(
   values: GitHubAgentRequestInput,
 ): Promise<GitHubAgentRequestClaim> {


### PR DESCRIPTION
### Motivation

- Extend the GitHub bot so `@hyperlocalise` mentions can enqueue broader repo/TMS agent tasks in addition to the narrow `@hyperlocalise fix` workflow while preserving existing behavior and permissions.
- Reuse the existing GitHub installation, PR context resolution, and durable idempotency patterns to avoid duplicate workflow runs and provide source-specific feedback.

### Description

- Replace `parseFixCommand` with `parseHyperlocaliseCommand` and add `repo_tms` command type to accept freeform repo/TMS instructions from mentions.
- Add a new GitHub-side repo/TMS queueing branch in `bot.ts` that resolves GitHub/PR context, claims a persistent request row, enqueues a `RepoTmsAgentTask` via `createRepoTmsAgentTaskQueue()`, marks the request enqueued, and posts queue/duplicate/failure replies to the PR thread.
- Use `buildRepoTmsTaskIdempotencyKey` and `randomUUID()` to build deterministic task idempotency and task IDs for queued repo/TMS tasks.
- Extend request idempotency module with `buildGitHubRepoTmsRequestInput(...)` so repo/TMS GitHub requests reuse the same claim/enqueue lifecycle (`claimGitHubAgentRequest`, `markGitHubAgentRequestEnqueued`, `releaseGitHubAgentRequestClaim`).

### Testing

- Ran `make fmt` successfully.
- Ran the targeted frontend unit test `pnpm -s test src/lib/agents/github/bot.test.ts` which succeeded.
- `make lint` could not complete in this environment due to a missing `golangci-lint` binary (failure outside code changes).
- `make test` for the full repo could not complete here due to a Go toolchain version mismatch in the environment (failure unrelated to the change itself).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e5612375c832c9dc7542620c25345)