### PR TITLE
🛡️ Sentinel: Add input length limits to API schemas

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/provider-credential/provider-credential.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/provider-credential/provider-credential.schema.ts
@@ -9,7 +9,7 @@ import {
 export const updateProviderCredentialBodySchema = z
   .object({
     provider: llmProviderSchema,
-    apiKey: z.string().trim().min(1, "API key is required.").max(1024),
+    apiKey: z.string().trim().min(1, "API key is required.").max(4096),
     defaultModel: z.string().trim().min(1, "Default model is required.").max(256),
   })
   .superRefine((value, context) => {

--- a/apps/hyperlocalise-web/src/api/routes/provider-credential/provider-credential.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/provider-credential/provider-credential.schema.ts
@@ -9,8 +9,8 @@ import {
 export const updateProviderCredentialBodySchema = z
   .object({
     provider: llmProviderSchema,
-    apiKey: z.string().trim().min(1, "API key is required."),
-    defaultModel: z.string().trim().min(1, "Default model is required."),
+    apiKey: z.string().trim().min(1, "API key is required.").max(1024),
+    defaultModel: z.string().trim().min(1, "Default model is required.").max(256),
   })
   .superRefine((value, context) => {
     if (

--- a/apps/hyperlocalise-web/src/api/routes/provider-credential/security-limits.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/provider-credential/security-limits.test.ts
@@ -4,7 +4,7 @@ import { addTeamMemberBodySchema } from "../team/team.schema";
 
 describe("Schema length limits", () => {
   it("should enforce max length on provider credential apiKey", () => {
-    const longKey = "a".repeat(1025);
+    const longKey = "a".repeat(4097);
     const result = updateProviderCredentialBodySchema.safeParse({
       provider: "openai",
       apiKey: longKey,
@@ -13,7 +13,6 @@ describe("Schema length limits", () => {
     expect(result.success).toBe(false);
     if (!result.success) {
       const issues = result.error.issues;
-      // console.log('apiKey issues:', JSON.stringify(issues, null, 2));
       const issue = issues.find((i) => i.code === "too_big" && i.path.includes("apiKey"));
       expect(issue).toBeDefined();
     }

--- a/apps/hyperlocalise-web/src/api/routes/provider-credential/security-limits.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/provider-credential/security-limits.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { updateProviderCredentialBodySchema } from "./provider-credential.schema";
-import { addTeamMemberBodySchema } from "../team/team.schema";
+import { addTeamMemberBodySchema, teamMemberParamsSchema } from "../team/team.schema";
 
 describe("Schema length limits", () => {
   it("should enforce max length on provider credential apiKey", () => {
@@ -34,7 +34,7 @@ describe("Schema length limits", () => {
     }
   });
 
-  it("should enforce max length on team member workosUserId", () => {
+  it("should enforce max length on team member workosUserId in body", () => {
     const longId = "a".repeat(257);
     const result = addTeamMemberBodySchema.safeParse({
       workosUserId: longId,
@@ -43,7 +43,20 @@ describe("Schema length limits", () => {
     expect(result.success).toBe(false);
     if (!result.success) {
       const issues = result.error.issues;
-      // console.log('workosUserId issues:', JSON.stringify(issues, null, 2));
+      const issue = issues.find((i) => i.code === "too_big" && i.path.includes("workosUserId"));
+      expect(issue).toBeDefined();
+    }
+  });
+
+  it("should enforce max length on team member workosUserId in params", () => {
+    const longId = "a".repeat(257);
+    const result = teamMemberParamsSchema.safeParse({
+      teamId: "00000000-0000-0000-0000-000000000000",
+      workosUserId: longId,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issues = result.error.issues;
       const issue = issues.find((i) => i.code === "too_big" && i.path.includes("workosUserId"));
       expect(issue).toBeDefined();
     }

--- a/apps/hyperlocalise-web/src/api/routes/provider-credential/security-limits.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/provider-credential/security-limits.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { updateProviderCredentialBodySchema } from "./provider-credential.schema";
+import { addTeamMemberBodySchema } from "../team/team.schema";
+
+describe("Schema length limits", () => {
+  it("should enforce max length on provider credential apiKey", () => {
+    const longKey = "a".repeat(1025);
+    const result = updateProviderCredentialBodySchema.safeParse({
+      provider: "openai",
+      apiKey: longKey,
+      defaultModel: "gpt-4o",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issues = result.error.issues;
+      // console.log('apiKey issues:', JSON.stringify(issues, null, 2));
+      const issue = issues.find((i) => i.code === "too_big" && i.path.includes("apiKey"));
+      expect(issue).toBeDefined();
+    }
+  });
+
+  it("should enforce max length on provider credential defaultModel", () => {
+    const longModel = "a".repeat(257);
+    const result = updateProviderCredentialBodySchema.safeParse({
+      provider: "openai",
+      apiKey: "valid-key",
+      defaultModel: longModel,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issues = result.error.issues;
+      // console.log('defaultModel issues:', JSON.stringify(issues, null, 2));
+      const issue = issues.find((i) => i.code === "too_big" && i.path.includes("defaultModel"));
+      expect(issue).toBeDefined();
+    }
+  });
+
+  it("should enforce max length on team member workosUserId", () => {
+    const longId = "a".repeat(257);
+    const result = addTeamMemberBodySchema.safeParse({
+      workosUserId: longId,
+      role: "member",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issues = result.error.issues;
+      // console.log('workosUserId issues:', JSON.stringify(issues, null, 2));
+      const issue = issues.find((i) => i.code === "too_big" && i.path.includes("workosUserId"));
+      expect(issue).toBeDefined();
+    }
+  });
+});

--- a/apps/hyperlocalise-web/src/api/routes/team/team.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/team/team.schema.ts
@@ -28,7 +28,7 @@ export const teamIdParamsSchema = z.object({
 
 export const teamMemberParamsSchema = z.object({
   teamId: z.string().uuid(),
-  workosUserId: z.string().min(1),
+  workosUserId: z.string().min(1).max(256),
 });
 
 export const teamRecordSchema = z.object({
@@ -53,7 +53,7 @@ export const teamSummarySchema = teamRecordSchema
   });
 
 export const teamMemberSchema = z.object({
-  workosUserId: z.string(),
+  workosUserId: z.string().max(256),
   email: z.string().email(),
   role: teamRoleSchema,
 });

--- a/apps/hyperlocalise-web/src/api/routes/team/team.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/team/team.schema.ts
@@ -18,7 +18,7 @@ export const updateTeamBodySchema = createTeamBodySchema
   .refine((value) => value.name !== undefined || value.slug !== undefined);
 
 export const addTeamMemberBodySchema = z.object({
-  workosUserId: z.string().trim().min(1),
+  workosUserId: z.string().trim().min(1).max(256),
   role: teamRoleSchema.optional(),
 });
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing input length limits on user-provided string fields in API schemas (DoS risk).
🎯 Impact: Excessively large payloads could lead to memory exhaustion, database storage abuse, or processing delays.
🔧 Fix: Added `.max()` constraints to `apiKey`, `defaultModel`, and `workosUserId` in Zod schemas.
✅ Verification: Created `security-limits.test.ts` and verified that the constraints are correctly enforced. Ran `vp check` to ensure code quality.

---
*PR created automatically by Jules for task [1422058522226021486](https://jules.google.com/task/1422058522226021486) started by @cungminh2710*