### PR TITLE
Fix Crowdin Organization Webhook path and improve model parity for WebURL

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -53,3 +53,9 @@
 **Learning:** The Crowdin Bundles API v2 returns an `eta` field in bundle export responses, and the Tasks API supports filtering by `workflowStepId` via query parameters. These were missing from the Go SDK models and request options.
 
 **Action:** Added `ETA` to the `BundleExport` model in `model/bundles.go`. Added `WorkflowStepID` to `TasksListOptions` and updated its `Values()` method in `model/tasks.go` to encode it. Updated contract tests in `bundles_test.go` and `tasks_test.go` to verify parity.
+
+## 2026-06-26 - Fix Organization Webhooks path and improve model parity for WebURL
+
+**Learning:** The Crowdin API v2 for Organization Webhooks (account-level) uses the path `/api/v2/webhooks`, unlike project webhooks which are under `/api/v2/projects/{projectId}/webhooks`. The SDK was incorrectly using the project-specific path for account-level additions. Additionally, many core models like Branch, Directory, and File include a `webUrl` field in their responses which was missing from the SDK.
+
+**Action:** Updated `OrganizationWebhooksService.Add` to use the correct account-level path and removed the redundant `projectID` parameter. Added `WebURL` field to `Branch`, `Directory`, and `File` models in `model/branches.go` and `model/source_files.go`. Updated comprehensive test suites in `webhooks_organization_test.go`, `branches_test.go`, and `source_files_test.go` to verify correct parsing and serialization.

--- a/third_party/crowdin-api-client-go/crowdin/branches_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/branches_test.go
@@ -29,7 +29,8 @@ func TestBranchesService_List(t *testing.T) {
 						"createdAt": "2023-09-16T13:48:04+00:00",
 						"updatedAt": "2023-09-19T13:25:27+00:00",
 						"exportPattern": "%_three_letters_code%",
-						"priority": "normal"
+						"priority": "normal",
+						"webUrl": "https://crowdin.com/project/project-identifier/settings#branches"
 					}
 				}
 			],
@@ -55,6 +56,7 @@ func TestBranchesService_List(t *testing.T) {
 			UpdatedAt:     "2023-09-19T13:25:27+00:00",
 			ExportPattern: ToPtr("%_three_letters_code%"),
 			Priority:      ToPtr("normal"),
+			WebURL:        "https://crowdin.com/project/project-identifier/settings#branches",
 		},
 	}
 	if !reflect.DeepEqual(branches, want) {
@@ -85,7 +87,8 @@ func TestBranchesService_ListWithQueryParams(t *testing.T) {
 						"createdAt": "2023-09-16T13:48:04+00:00",
 						"updatedAt": "2023-09-19T13:25:27+00:00",
 						"exportPattern": "%_three_letters_code%",
-						"priority": "normal"
+						"priority": "normal",
+						"webUrl": "https://crowdin.com/project/project-identifier/settings#branches"
 					}
 				}
 			],
@@ -115,6 +118,7 @@ func TestBranchesService_ListWithQueryParams(t *testing.T) {
 			UpdatedAt:     "2023-09-19T13:25:27+00:00",
 			ExportPattern: ToPtr("%_three_letters_code%"),
 			Priority:      ToPtr("normal"),
+			WebURL:        "https://crowdin.com/project/project-identifier/settings#branches",
 		},
 	}
 	if !reflect.DeepEqual(branches, want) {
@@ -138,7 +142,8 @@ func TestBranchesService_Get(t *testing.T) {
 				"createdAt": "2023-09-16T13:48:04+00:00",
 				"updatedAt": "2023-09-19T13:25:27+00:00",
 				"exportPattern": "%_three_letters_code%",
-				"priority": "normal"
+				"priority": "normal",
+				"webUrl": "https://crowdin.com/project/project-identifier/settings#branches"
 			}
 		}`)
 	})
@@ -157,6 +162,7 @@ func TestBranchesService_Get(t *testing.T) {
 		UpdatedAt:     "2023-09-19T13:25:27+00:00",
 		ExportPattern: ToPtr("%_three_letters_code%"),
 		Priority:      ToPtr("normal"),
+		WebURL:        "https://crowdin.com/project/project-identifier/settings#branches",
 	}
 	if !reflect.DeepEqual(branch, want) {
 		t.Errorf("Branches.Get returned %+v, want %+v", branch, want)
@@ -207,7 +213,8 @@ func TestBranchesService_Add(t *testing.T) {
 				"createdAt": "2023-09-16T13:48:04+00:00",
 				"updatedAt": "2023-09-19T13:25:27+00:00",
 				"exportPattern": "%_three_letters_code%",
-				"priority": "normal"
+				"priority": "normal",
+				"webUrl": "https://crowdin.com/project/project-identifier/settings#branches"
 			}
 		}`)
 	})
@@ -231,6 +238,7 @@ func TestBranchesService_Add(t *testing.T) {
 		UpdatedAt:     "2023-09-19T13:25:27+00:00",
 		ExportPattern: ToPtr("%_three_letters_code%"),
 		Priority:      ToPtr("normal"),
+		WebURL:        "https://crowdin.com/project/project-identifier/settings#branches",
 	}
 	if !reflect.DeepEqual(branch, want) {
 		t.Errorf("Branches.Add returned %+v, want %+v", branch, want)
@@ -254,7 +262,8 @@ func TestBranchesService_AddWithRequiredBodyParams(t *testing.T) {
 				"createdAt": "2023-09-16T13:48:04+00:00",
 				"updatedAt": "2023-09-19T13:25:27+00:00",
 				"exportPattern": "%_three_letters_code%",
-				"priority": "normal"
+				"priority": "normal",
+				"webUrl": "https://crowdin.com/project/project-identifier/settings#branches"
 			}
 		}`)
 	})
@@ -275,6 +284,7 @@ func TestBranchesService_AddWithRequiredBodyParams(t *testing.T) {
 		UpdatedAt:     "2023-09-19T13:25:27+00:00",
 		ExportPattern: ToPtr("%_three_letters_code%"),
 		Priority:      ToPtr("normal"),
+		WebURL:        "https://crowdin.com/project/project-identifier/settings#branches",
 	}
 	if !reflect.DeepEqual(branch, want) {
 		t.Errorf("Branches.Add returned %+v, want %+v", branch, want)
@@ -299,7 +309,8 @@ func TestBranchesService_Edit(t *testing.T) {
 				"createdAt": "2023-09-16T13:48:04+00:00",
 				"updatedAt": "2023-09-19T13:25:27+00:00",
 				"exportPattern": "%_three_letters_code%",
-				"priority": "normal"
+				"priority": "normal",
+				"webUrl": "https://crowdin.com/project/project-identifier/settings#branches"
 			}
 		}`)
 	})
@@ -315,9 +326,19 @@ func TestBranchesService_Edit(t *testing.T) {
 		t.Errorf("Branches.Edit returned error: %v", err)
 	}
 
-	want := "develop-master"
-	if branch.Name != want {
-		t.Errorf("Branches.Edit returned %+v, want %+v", branch.Name, want)
+	want := &model.Branch{
+		ID:            34,
+		ProjectID:     2,
+		Name:          "develop-master",
+		Title:         "Master branch",
+		CreatedAt:     "2023-09-16T13:48:04+00:00",
+		UpdatedAt:     "2023-09-19T13:25:27+00:00",
+		ExportPattern: ToPtr("%_three_letters_code%"),
+		Priority:      ToPtr("normal"),
+		WebURL:        "https://crowdin.com/project/project-identifier/settings#branches",
+	}
+	if !reflect.DeepEqual(branch, want) {
+		t.Errorf("Branches.Edit returned %+v, want %+v", branch, want)
 	}
 }
 

--- a/third_party/crowdin-api-client-go/crowdin/model/branches.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/branches.go
@@ -15,6 +15,7 @@ type Branch struct {
 	UpdatedAt     string  `json:"updatedAt"`
 	ExportPattern *string `json:"exportPattern,omitempty"`
 	Priority      *string `json:"priority,omitempty"`
+	WebURL        string  `json:"webUrl"`
 }
 
 // BranchesGetResponse describes a response with a single branch.

--- a/third_party/crowdin-api-client-go/crowdin/model/source_files.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/source_files.go
@@ -16,6 +16,7 @@ type Directory struct {
 	Title         string `json:"title"`
 	ExportPattern string `json:"exportPattern"`
 	Path          string `json:"path"`
+	WebURL        string `json:"webUrl"`
 	IsReadOnly    *bool  `json:"isReadOnly,omitempty"`
 	Priority      string `json:"priority"`
 	CreatedAt     string `json:"createdAt"`
@@ -136,6 +137,7 @@ type File struct {
 	Context     *string `json:"context,omitempty"`
 	Type        string  `json:"type"`
 	Path        string  `json:"path"`
+	WebURL      string  `json:"webUrl"`
 	Status      string  `json:"status"`
 	Fields      any     `json:"fields,omitempty"`
 	IsReadOnly  *bool   `json:"isReadOnly,omitempty"`

--- a/third_party/crowdin-api-client-go/crowdin/source_files_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/source_files_test.go
@@ -33,6 +33,7 @@ func TestSourceFilesService_ListDirectories(t *testing.T) {
 						"title": "Description materials",
 						"exportPattern": "/localization/%locale%/file_name",
 						"path": "/main",
+						"webUrl": "https://crowdin.com/project/project-identifier/settings#files",
 						"isReadOnly": true,
 						"priority": "normal",
 						"createdAt": "2024-04-18T14:14:00+00:00",
@@ -60,6 +61,7 @@ func TestSourceFilesService_ListDirectories(t *testing.T) {
 			Title:         "Description materials",
 			ExportPattern: "/localization/%locale%/file_name",
 			Path:          "/main",
+			WebURL:        "https://crowdin.com/project/project-identifier/settings#files",
 			IsReadOnly:    ToPtr(true),
 			Priority:      "normal",
 			CreatedAt:     "2024-04-18T14:14:00+00:00",
@@ -91,7 +93,7 @@ func TestDirectory_MarshalJSON_IsReadOnly(t *testing.T) {
 	b, err := json.Marshal(directory)
 	require.NoError(t, err)
 
-	assert.JSONEq(t, `{"id":0,"projectId":0,"name":"","title":"","exportPattern":"","path":"","isReadOnly":false,"priority":"","createdAt":"","updatedAt":""}`, string(b))
+	assert.JSONEq(t, `{"id":0,"projectId":0,"name":"","title":"","exportPattern":"","path":"","isReadOnly":false,"priority":"","createdAt":"","updatedAt":"","webUrl":""}`, string(b))
 
 	directory.IsReadOnly = nil
 	b, err = json.Marshal(directory)
@@ -177,6 +179,7 @@ func TestSourceFilesService_GetDirectory(t *testing.T) {
 				"title": "Description materials",
 				"exportPattern": "/localization/%locale%/file_name",
 				"path": "/main",
+				"webUrl": "https://crowdin.com/project/project-identifier/settings#files",
 				"priority": "normal",
 				"createdAt": "2024-04-18T14:14:00+00:00",
 				"updatedAt": "2024-04-18T14:14:00+00:00"
@@ -196,6 +199,7 @@ func TestSourceFilesService_GetDirectory(t *testing.T) {
 		Title:         "Description materials",
 		ExportPattern: "/localization/%locale%/file_name",
 		Path:          "/main",
+		WebURL:        "https://crowdin.com/project/project-identifier/settings#files",
 		Priority:      "normal",
 		CreatedAt:     "2024-04-18T14:14:00+00:00",
 		UpdatedAt:     "2024-04-18T14:14:00+00:00",
@@ -226,6 +230,7 @@ func TestSourceFilesService_AddDirectory(t *testing.T) {
 				"title": "New Directory",
 				"exportPattern": "/localization/%locale%/new_file_name",
 				"path": "/new_directory",
+				"webUrl": "https://crowdin.com/project/project-identifier/settings#files",
 				"priority": "normal",
 				"createdAt": "2024-04-18T14:14:00+00:00",
 				"updatedAt": "2024-04-18T14:14:00+00:00"
@@ -252,6 +257,7 @@ func TestSourceFilesService_AddDirectory(t *testing.T) {
 		Title:         "New Directory",
 		ExportPattern: "/localization/%locale%/new_file_name",
 		Path:          "/new_directory",
+		WebURL:        "https://crowdin.com/project/project-identifier/settings#files",
 		Priority:      "normal",
 		CreatedAt:     "2024-04-18T14:14:00+00:00",
 		UpdatedAt:     "2024-04-18T14:14:00+00:00",
@@ -298,6 +304,7 @@ func TestSourceFilesService_EditDirectory(t *testing.T) {
 				"title": "Description materials",
 				"exportPattern": "/localization/%locale%/file_name",
 				"path": "/main",
+				"webUrl": "https://crowdin.com/project/project-identifier/settings#files",
 				"priority": "normal",
 				"createdAt": "2024-04-18T14:14:00+00:00",
 				"updatedAt": "2024-04-18T14:14:00+00:00"
@@ -324,6 +331,7 @@ func TestSourceFilesService_EditDirectory(t *testing.T) {
 		Title:         "Description materials",
 		ExportPattern: "/localization/%locale%/file_name",
 		Path:          "/main",
+		WebURL:        "https://crowdin.com/project/project-identifier/settings#files",
 		Priority:      "normal",
 		CreatedAt:     "2024-04-18T14:14:00+00:00",
 		UpdatedAt:     "2024-04-18T14:14:00+00:00",
@@ -569,6 +577,7 @@ func TestSourceFilesService_GetFile(t *testing.T) {
 				"context": "Context for translators",
 				"type": "xliff",
 				"path": "/directory1/directory2/filename.extension",
+				"webUrl": "https://crowdin.com/project/project-identifier/settings#files",
 				"status": "active",
 				"fields": {
 					"fieldSlug": "fieldValue"
@@ -591,6 +600,7 @@ func TestSourceFilesService_GetFile(t *testing.T) {
 		Context:     ToPtr("Context for translators"),
 		Type:        "xliff",
 		Path:        "/directory1/directory2/filename.extension",
+		WebURL:      "https://crowdin.com/project/project-identifier/settings#files",
 		Status:      "active",
 		Fields:      map[string]any{"fieldSlug": "fieldValue"},
 		IsReadOnly:  ToPtr(true),

--- a/third_party/crowdin-api-client-go/crowdin/webhooks_organization.go
+++ b/third_party/crowdin-api-client-go/crowdin/webhooks_organization.go
@@ -55,11 +55,11 @@ func (s *OrganizationWebhooksService) Get(ctx context.Context, organizationWebho
 // Add creates a new webhook.
 //
 // https://developer.crowdin.com/api/v2/#operation/api.webhooks.post
-func (s *OrganizationWebhooksService) Add(ctx context.Context, projectID int, req *model.WebhookAddRequest) (
+func (s *OrganizationWebhooksService) Add(ctx context.Context, req *model.WebhookAddRequest) (
 	*model.Webhook, *Response, error,
 ) {
 	res := new(model.WebhookResponse)
-	resp, err := s.client.Post(ctx, fmt.Sprintf("/api/v2/projects/%d/webhooks", projectID), req, res)
+	resp, err := s.client.Post(ctx, "/api/v2/webhooks", req, res)
 
 	return res.Data, resp, err
 }

--- a/third_party/crowdin-api-client-go/crowdin/webhooks_organization_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/webhooks_organization_test.go
@@ -279,7 +279,7 @@ func TestOrganizationWebhooksService_Add(t *testing.T) {
 	client, mux, teardowm := setupClient()
 	defer teardowm()
 
-	const path = "/api/v2/projects/1/webhooks"
+	const path = "/api/v2/webhooks"
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		testURL(t, r, path)
@@ -318,7 +318,7 @@ func TestOrganizationWebhooksService_Add(t *testing.T) {
 			"Authorization": "Bearer ef231f493cafe336f98d486f596282205b3c2a0",
 		},
 	}
-	webhook, resp, err := client.OrganizationWebhooks.Add(context.Background(), 1, req)
+	webhook, resp, err := client.OrganizationWebhooks.Add(context.Background(), req)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 	assert.Equal(t, 4, webhook.ID)


### PR DESCRIPTION
This PR improves the Crowdin Go SDK's parity with API v2 by addressing two main areas:

1. **Organization Webhooks Fix**: The `Add` method for organization-level webhooks was incorrectly using a project-specific API path. This has been corrected to the account-level endpoint `/api/v2/webhooks`, and the method signature was simplified by removing the unused `projectID` parameter.
2. **Model Parity Enhancements**: The `WebURL` field was added to the `Branch`, `Directory`, and `File` models to match the official API response shapes.

All relevant tests in `webhooks_organization_test.go`, `branches_test.go`, and `source_files_test.go` have been updated and are passing.

Docs: 
- Organization Webhooks: https://developer.crowdin.com/api/v2/#operation/api.webhooks.post
- Branch Model: https://developer.crowdin.com/api/v2/#operation/api.projects.branches.get
- Directory Model: https://developer.crowdin.com/api/v2/#operation/api.projects.directories.get
- File Model: https://developer.crowdin.com/api/v2/#operation/api.projects.files.get

---
*PR created automatically by Jules for task [5873716987069933284](https://jules.google.com/task/5873716987069933284) started by @cungminh2710*