### PR TITLE
feat(repo-tools): add read-only TMS CLI allowlist and artifact hints

### DIFF
--- a/apps/hyperlocalise-web/src/lib/tools/repo-tools.test.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/repo-tools.test.ts
@@ -324,6 +324,32 @@ describe("createRunHyperlocaliseCliTool", () => {
     expect((result as { stdout: string }).stdout).toContain("subcommand=check");
   });
 
+  it("allows read-only provider downloads", async () => {
+    const ctx = createTestContext();
+    ctx.bash.registerCommand(
+      defineCommand("hl", async (args) => ({
+        stdout: `subcommand=${args.join(" ")}\n`,
+        stderr: "",
+        exitCode: 0,
+      })),
+    );
+
+    const t = createRunHyperlocaliseCliTool(ctx);
+    const result = await t.execute!(
+      { subcommand: "phrase", args: ["glossary", "download"] },
+      toolCallInfo,
+    );
+    expect(result).toMatchObject({ success: true, exitCode: 0 });
+  });
+
+  it("rejects write-capable provider actions", async () => {
+    const ctx = createTestContext();
+    const t = createRunHyperlocaliseCliTool(ctx);
+    await expect(
+      t.execute!({ subcommand: "phrase", args: ["translations", "upload"] }, toolCallInfo),
+    ).rejects.toThrow("Only read-only TMS actions are allowed");
+  });
+
   it("constructs args safely", async () => {
     const ctx = createTestContext();
     ctx.bash.registerCommand(

--- a/apps/hyperlocalise-web/src/lib/tools/repo-tools.test.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/repo-tools.test.ts
@@ -301,7 +301,7 @@ describe("createRunHyperlocaliseCliTool", () => {
   it("rejects unapproved subcommand at schema level", async () => {
     const ctx = createTestContext();
     const t = createRunHyperlocaliseCliTool(ctx);
-    // The tool schema only allows check/status/extract, so parse should fail.
+    // The tool schema only allows check/status/extract/crowdin/lokalise/phrase, so parse should fail.
     const parse = (t as unknown as { inputSchema: z.ZodSchema<unknown> }).inputSchema.safeParse({
       subcommand: "sync",
     });

--- a/apps/hyperlocalise-web/src/lib/tools/repo-tools.test.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/repo-tools.test.ts
@@ -324,31 +324,37 @@ describe("createRunHyperlocaliseCliTool", () => {
     expect((result as { stdout: string }).stdout).toContain("subcommand=check");
   });
 
-  it("allows read-only provider downloads", async () => {
-    const ctx = createTestContext();
-    ctx.bash.registerCommand(
-      defineCommand("hl", async (args) => ({
-        stdout: `subcommand=${args.join(" ")}\n`,
-        stderr: "",
-        exitCode: 0,
-      })),
-    );
+  it.each(["phrase", "crowdin", "lokalise"] as const)(
+    "allows read-only provider downloads for %s",
+    async (provider) => {
+      const ctx = createTestContext();
+      ctx.bash.registerCommand(
+        defineCommand("hl", async (args) => ({
+          stdout: `subcommand=${args.join(" ")}\n`,
+          stderr: "",
+          exitCode: 0,
+        })),
+      );
 
-    const t = createRunHyperlocaliseCliTool(ctx);
-    const result = await t.execute!(
-      { subcommand: "phrase", args: ["glossary", "download"] },
-      toolCallInfo,
-    );
-    expect(result).toMatchObject({ success: true, exitCode: 0 });
-  });
+      const t = createRunHyperlocaliseCliTool(ctx);
+      const result = await t.execute!(
+        { subcommand: provider, args: ["glossary", "download"] },
+        toolCallInfo,
+      );
+      expect(result).toMatchObject({ success: true, exitCode: 0 });
+    },
+  );
 
-  it("rejects write-capable provider actions", async () => {
-    const ctx = createTestContext();
-    const t = createRunHyperlocaliseCliTool(ctx);
-    await expect(
-      t.execute!({ subcommand: "phrase", args: ["translations", "upload"] }, toolCallInfo),
-    ).rejects.toThrow("Only read-only TMS actions are allowed");
-  });
+  it.each(["phrase", "crowdin", "lokalise"] as const)(
+    "rejects write-capable provider actions for %s",
+    async (provider) => {
+      const ctx = createTestContext();
+      const t = createRunHyperlocaliseCliTool(ctx);
+      await expect(
+        t.execute!({ subcommand: provider, args: ["translations", "upload"] }, toolCallInfo),
+      ).rejects.toThrow("Only read-only TMS actions are allowed");
+    },
+  );
 
   it("constructs args safely", async () => {
     const ctx = createTestContext();

--- a/apps/hyperlocalise-web/src/lib/tools/repo-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/repo-tools.ts
@@ -496,20 +496,30 @@ export type RunHyperlocaliseCliOutput = {
   truncated: boolean;
 };
 
+const HL_SUBCOMMANDS = ["check", "status", "extract", "crowdin", "lokalise", "phrase"] as const;
+const READ_ONLY_TMS_ACTIONS = new Set([
+  "config",
+  "check",
+  "translations:download",
+  "glossary:download",
+  "tm:download",
+]);
+
 /**
  * Run an allowlisted hyperlocalise CLI subcommand with structured inputs.
  */
 export function createRunHyperlocaliseCliTool(ctx: RepoToolContext) {
   return tool({
     description:
-      "Run an allowlisted hyperlocalise CLI subcommand (check, status, extract) with structured arguments. Does not expose arbitrary shell execution.",
+      "Run an allowlisted hyperlocalise CLI subcommand for read-only repo/TMS checks. Does not expose arbitrary shell execution.",
     inputSchema: z.object({
-      subcommand: z.enum(["check", "status", "extract"]).describe("The subcommand to run."),
+      subcommand: z.enum(HL_SUBCOMMANDS).describe("The subcommand to run."),
       args: z.array(z.string()).optional().describe("Positional arguments."),
       flags: z.record(z.string(), z.string()).optional().describe("Key-value flags (--key=value)."),
       boolFlags: z.array(z.string()).optional().describe("Boolean flags (--flag)."),
     }),
     execute: async ({ subcommand, args, flags, boolFlags }) => {
+      assertReadOnlyAction(subcommand, args);
       const commandArgs = buildHlArgs({ subcommand, args, flags, boolFlags });
       const result = await ctx.bash.exec("hl", { args: commandArgs });
 
@@ -517,6 +527,7 @@ export function createRunHyperlocaliseCliTool(ctx: RepoToolContext) {
       const redactedStderr = redact(result.stderr);
 
       const report = extractReport(subcommand, redactedStdout);
+      const artifact = summarizeArtifactHint(subcommand, commandArgs, redactedStdout);
 
       const { text: stdout, truncated: stdoutTruncated } = truncate(
         redactedStdout,
@@ -547,6 +558,7 @@ export function createRunHyperlocaliseCliTool(ctx: RepoToolContext) {
         stderr,
         changedPaths,
         report,
+        artifact,
         truncated: stdoutTruncated || stderrTruncated,
       };
     },
@@ -621,4 +633,35 @@ function extractReport(subcommand: string, stdout: string): unknown {
   } catch {
     return undefined;
   }
+}
+
+function assertReadOnlyAction(subcommand: string, args?: string[]): void {
+  if (subcommand === "check" || subcommand === "status" || subcommand === "extract") return;
+
+  const actionKey = [args?.[0], args?.[1]].filter(Boolean).join(":");
+  if (!READ_ONLY_TMS_ACTIONS.has(actionKey)) {
+    throw new Error(
+      `Only read-only TMS actions are allowed. Received "${subcommand} ${args?.join(" ") ?? ""}".`,
+    );
+  }
+}
+
+function summarizeArtifactHint(subcommand: string, commandArgs: string[], stdout: string) {
+  const outputFlag = commandArgs.find((arg) => arg.startsWith("--output="));
+  if (outputFlag) {
+    return {
+      kind: "file",
+      path: outputFlag.slice("--output=".length),
+      note: "Use readRepoFile or readStoredFile to inspect this artifact.",
+    };
+  }
+
+  if (stdout.length > DEFAULT_MAX_OUTPUT_BYTES / 2 || subcommand === "extract") {
+    return {
+      kind: "inline",
+      note: "Large output detected; prefer --output=<path> for structured artifact capture.",
+    };
+  }
+
+  return undefined;
 }

--- a/apps/hyperlocalise-web/src/lib/tools/repo-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/repo-tools.ts
@@ -639,16 +639,21 @@ function extractReport(subcommand: string, stdout: string): unknown {
 function assertReadOnlyAction(subcommand: string, args?: string[]): void {
   if (subcommand === "check" || subcommand === "status" || subcommand === "extract") return;
 
-  const actionKey = [args?.[0], args?.[1]].filter(Boolean).join(":");
-  const providerScopedKey = [subcommand, actionKey].filter(Boolean).join(":");
-  if (!READ_ONLY_TMS_ACTIONS.has(actionKey) && !READ_ONLY_TMS_ACTIONS.has(providerScopedKey)) {
-    throw new Error(
-      `Only read-only TMS actions are allowed. Received "${subcommand} ${args?.join(" ") ?? ""}".`,
-    );
+  const actionKey = args && args.length >= 2 ? `${args[0]}:${args[1]}` : (args?.[0] ?? "");
+  if (READ_ONLY_TMS_ACTIONS.has(actionKey)) {
+    if (!actionKey.includes(":") || (args?.length ?? 0) >= 2) return;
   }
+
+  throw new Error(
+    `Only read-only TMS actions are allowed. Received "${subcommand} ${args?.join(" ") ?? ""}".`,
+  );
 }
 
-function summarizeArtifactHint(subcommand: string, commandArgs: string[], stdout: string) {
+function summarizeArtifactHint(
+  subcommand: string,
+  commandArgs: string[],
+  stdout: string,
+): RunHyperlocaliseCliOutput["artifact"] {
   const outputFlag = commandArgs.find((arg) => arg.startsWith("--output="));
   if (outputFlag) {
     return {

--- a/apps/hyperlocalise-web/src/lib/tools/repo-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/repo-tools.ts
@@ -493,6 +493,7 @@ export type RunHyperlocaliseCliOutput = {
   stderr: string;
   changedPaths: string[];
   report?: unknown;
+  artifact?: { kind: "file"; path: string; note: string } | { kind: "inline"; note: string };
   truncated: boolean;
 };
 
@@ -639,7 +640,8 @@ function assertReadOnlyAction(subcommand: string, args?: string[]): void {
   if (subcommand === "check" || subcommand === "status" || subcommand === "extract") return;
 
   const actionKey = [args?.[0], args?.[1]].filter(Boolean).join(":");
-  if (!READ_ONLY_TMS_ACTIONS.has(actionKey)) {
+  const providerScopedKey = [subcommand, actionKey].filter(Boolean).join(":");
+  if (!READ_ONLY_TMS_ACTIONS.has(actionKey) && !READ_ONLY_TMS_ACTIONS.has(providerScopedKey)) {
     throw new Error(
       `Only read-only TMS actions are allowed. Received "${subcommand} ${args?.join(" ") ?? ""}".`,
     );


### PR DESCRIPTION
### Motivation
- Enable repo/TMS agents to run safe, read-only `hl` provider flows (config detection, downloads, dry-runs) without exposing credentials or allowing mutating TMS/repo actions.
- Prefer structured, referenceable artifacts over dumping large CLI output so agents can return concise summaries and point to stored results.
- Prevent accidental write operations from agent-invoked provider subcommands by enforcing an explicit allowlist.

### Description
- Expanded allowed `hl` subcommands by adding provider entry points: `crowdin`, `lokalise`, and `phrase` via `HL_SUBCOMMANDS` and updated the tool description and input schema in `createRunHyperlocaliseCliTool`.
- Added an action gate `assertReadOnlyAction` backed by `READ_ONLY_TMS_ACTIONS` to reject write-capable provider actions and surface a clear error for disallowed requests.
- Added artifact hinting with `summarizeArtifactHint` which returns a lightweight artifact pointer when `--output=<path>` is present or when CLI output is large, and included the `artifact` field in the tool result.
- Kept existing redaction and truncation behavior and added unit tests in `apps/hyperlocalise-web/src/lib/tools/repo-tools.test.ts` to cover allowed provider read-only downloads and rejection of write-style actions.

### Testing
- Ran `make fmt` which completed successfully to format code.
- Attempted `vp check --fix` but it failed in this environment because `vp` is not installed, so frontend checks were not executed here.
- Ran `make lint` which failed because `golangci-lint` is not available in the environment, so linting could not be verified.
- Ran `make test` which failed due to a Go toolchain version mismatch in this environment, so full test suite execution could not be completed; unit tests for `repo-tools` were added but not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e6314a224832c9a5d709d9a828838)