### PR TITLE
Add `entries` CLI command and persist file translation memory entries in workflow

### DIFF
--- a/apps/cli/cmd/entries.go
+++ b/apps/cli/cmd/entries.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+ 	"bytes"
+ 	"encoding/json"
+ 	"fmt"
+ 	"os"
+ 	"strings"
+
+ 	"github.com/hyperlocalise/hyperlocalise/internal/i18n/translationfileparser"
+ 	"github.com/spf13/cobra"
+)
+
+func newEntriesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "entries <translation-file>",
+		Short:        "print parsed translation entries as key/value JSON",
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path := strings.TrimSpace(args[0])
+			if path == "" {
+				return fmt.Errorf("entries translation file path cannot be empty")
+			}
+			content, err := os.ReadFile(path)
+			if err != nil {
+				return fmt.Errorf("read entries input %q: %w", path, err)
+			}
+			entries, err := translationfileparser.NewDefaultStrategy().Parse(path, content)
+			if err != nil {
+				return err
+			}
+			var buf bytes.Buffer
+			enc := json.NewEncoder(&buf)
+			enc.SetIndent("", "  ")
+			enc.SetEscapeHTML(false)
+			if err := enc.Encode(entries); err != nil {
+				return fmt.Errorf("encode entries output: %w", err)
+			}
+			_, err = cmd.OutOrStdout().Write(buf.Bytes())
+			return err
+		},
+	}
+	return cmd
+}
+

--- a/apps/cli/cmd/entries.go
+++ b/apps/cli/cmd/entries.go
@@ -1,14 +1,14 @@
 package cmd
 
 import (
- 	"bytes"
- 	"encoding/json"
- 	"fmt"
- 	"os"
- 	"strings"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
 
- 	"github.com/hyperlocalise/hyperlocalise/internal/i18n/translationfileparser"
- 	"github.com/spf13/cobra"
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/translationfileparser"
+	"github.com/spf13/cobra"
 )
 
 func newEntriesCmd() *cobra.Command {
@@ -43,4 +43,3 @@ func newEntriesCmd() *cobra.Command {
 	}
 	return cmd
 }
-

--- a/apps/cli/cmd/entries_test.go
+++ b/apps/cli/cmd/entries_test.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+  "bytes"
+  "encoding/json"
+  "os"
+  "path/filepath"
+  "testing"
+)
+
+func TestEntriesCommandOutputsParsedEntries(t *testing.T) {
+  dir := t.TempDir()
+  path := filepath.Join(dir, "en.json")
+  if err := os.WriteFile(path, []byte(`{"title":"Hello","nested":{"cta":"Click"}}`), 0o600); err != nil {
+    t.Fatal(err)
+  }
+
+  root := newRootCmd("test")
+  out := bytes.NewBuffer(nil)
+  root.SetOut(out)
+  root.SetErr(out)
+  root.SetArgs([]string{"entries", path})
+  if err := root.Execute(); err != nil {
+    t.Fatalf("execute entries: %v", err)
+  }
+
+  var payload map[string]string
+  if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+    t.Fatalf("decode output: %v", err)
+  }
+  if payload["title"] != "Hello" || payload["nested.cta"] != "Click" {
+    t.Fatalf("unexpected payload: %+v", payload)
+  }
+}

--- a/apps/cli/cmd/entries_test.go
+++ b/apps/cli/cmd/entries_test.go
@@ -1,34 +1,34 @@
 package cmd
 
 import (
-  "bytes"
-  "encoding/json"
-  "os"
-  "path/filepath"
-  "testing"
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
 )
 
 func TestEntriesCommandOutputsParsedEntries(t *testing.T) {
-  dir := t.TempDir()
-  path := filepath.Join(dir, "en.json")
-  if err := os.WriteFile(path, []byte(`{"title":"Hello","nested":{"cta":"Click"}}`), 0o600); err != nil {
-    t.Fatal(err)
-  }
+	dir := t.TempDir()
+	path := filepath.Join(dir, "en.json")
+	if err := os.WriteFile(path, []byte(`{"title":"Hello","nested":{"cta":"Click"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
 
-  root := newRootCmd("test")
-  out := bytes.NewBuffer(nil)
-  root.SetOut(out)
-  root.SetErr(out)
-  root.SetArgs([]string{"entries", path})
-  if err := root.Execute(); err != nil {
-    t.Fatalf("execute entries: %v", err)
-  }
+	root := newRootCmd("test")
+	out := bytes.NewBuffer(nil)
+	root.SetOut(out)
+	root.SetErr(out)
+	root.SetArgs([]string{"entries", path})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute entries: %v", err)
+	}
 
-  var payload map[string]string
-  if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
-    t.Fatalf("decode output: %v", err)
-  }
-  if payload["title"] != "Hello" || payload["nested.cta"] != "Click" {
-    t.Fatalf("unexpected payload: %+v", payload)
-  }
+	var payload map[string]string
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+	if payload["title"] != "Hello" || payload["nested.cta"] != "Click" {
+		t.Fatalf("unexpected payload: %+v", payload)
+	}
 }

--- a/apps/cli/cmd/root.go
+++ b/apps/cli/cmd/root.go
@@ -50,6 +50,7 @@ func newRootCmd(version string) *cobra.Command {
 	cmd.AddCommand(newRunCmd())            // run subcommand
 	cmd.AddCommand(newExtractCmd())        // extract subcommand
 	cmd.AddCommand(newPackCmd())           // pack subcommand
+	cmd.AddCommand(newEntriesCmd())        // entries subcommand
 	cmd.AddCommand(newCheckCmd())          // check subcommand
 	cmd.AddCommand(newFixCmd())            // fix subcommand
 	cmd.AddCommand(newEvalCmd())           // eval subcommands

--- a/apps/hyperlocalise-web/src/lib/translation/file-translation-memory.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/file-translation-memory.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const {
+  eqMock,
+  fromMock,
+  insertMock,
+  onConflictDoUpdateMock,
+  selectMock,
+  sqlMock,
+  valuesMock,
+  whereMock,
+} = vi.hoisted(() => {
+  const onConflictDoUpdateMock = vi.fn(async () => undefined);
+  const valuesMock = vi.fn(() => ({ onConflictDoUpdate: onConflictDoUpdateMock }));
+  const insertMock = vi.fn(() => ({ values: valuesMock }));
+  const whereMock = vi.fn(async () => [{ memoryId: "memory_1" }, { memoryId: "memory_2" }]);
+  const fromMock = vi.fn(() => ({ where: whereMock }));
+  const selectMock = vi.fn(() => ({ from: fromMock }));
+
+  return {
+    eqMock: vi.fn(() => "project filter"),
+    fromMock,
+    insertMock,
+    onConflictDoUpdateMock,
+    selectMock,
+    sqlMock: vi.fn((strings: TemplateStringsArray) => ({ sql: strings.join("") })),
+    valuesMock,
+    whereMock,
+  };
+});
+
+vi.mock("drizzle-orm", () => ({
+  eq: eqMock,
+  sql: sqlMock,
+}));
+
+vi.mock("@/lib/database", () => ({
+  db: {
+    insert: insertMock,
+    select: selectMock,
+  },
+  schema: {
+    memoryEntries: {
+      externalKey: "externalKey",
+      memoryId: "memoryId",
+      metadata: "metadata",
+      normalizedSourceText: "normalizedSourceText",
+      provenance: "provenance",
+      sourceLocale: "sourceLocale",
+      targetLocale: "targetLocale",
+      targetText: "targetText",
+    },
+    projectMemories: {
+      memoryId: "memoryId",
+      projectId: "projectId",
+    },
+  },
+}));
+
+import { persistFileTranslationMemoryEntries } from "./file-translation-memory";
+
+describe("persistFileTranslationMemoryEntries", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("dedupes duplicate normalized sources before batch upsert", async () => {
+    await persistFileTranslationMemoryEntries({
+      jobId: "job_1",
+      projectId: "project_1",
+      sourceEntries: {
+        first: "Hello World",
+        second: " hello   world ",
+        third: "Goodbye",
+      },
+      sourceFileHash: "hash_1",
+      sourceLocale: "en",
+      sourcePath: "locales/en.json",
+      targetEntries: {
+        first: "Bonjour le monde",
+        second: "Salut le monde",
+        third: "Au revoir",
+      },
+      targetLocale: "fr",
+    });
+
+    const values = valuesMock.mock.calls[0]?.[0];
+
+    expect(values).toHaveLength(4);
+    expect(
+      values.map((value: { memoryId: string; normalizedSourceText: string }) =>
+        `${value.memoryId}:${value.normalizedSourceText}`,
+      ),
+    ).toEqual([
+      "memory_1:hello world",
+      "memory_2:hello world",
+      "memory_1:goodbye",
+      "memory_2:goodbye",
+    ]);
+    expect(
+      values.find(
+        (value: { memoryId: string; normalizedSourceText: string }) =>
+          value.memoryId === "memory_1" && value.normalizedSourceText === "hello world",
+      ),
+    ).toMatchObject({
+      externalKey: "job_1:fr:second",
+      metadata: { segmentKey: "second" },
+      sourceText: " hello   world ",
+      targetText: "Salut le monde",
+    });
+  });
+
+  it("uses the database clock for conflict update timestamps", async () => {
+    await persistFileTranslationMemoryEntries({
+      jobId: "job_1",
+      projectId: "project_1",
+      sourceEntries: { first: "Hello" },
+      sourceFileHash: "hash_1",
+      sourceLocale: "en",
+      sourcePath: "locales/en.json",
+      targetEntries: { first: "Bonjour" },
+      targetLocale: "fr",
+    });
+
+    expect(onConflictDoUpdateMock.mock.calls[0]?.[0].set.updatedAt).toEqual({ sql: "now()" });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/translation/file-translation-memory.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/file-translation-memory.test.ts
@@ -1,33 +1,35 @@
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
-const {
-  eqMock,
-  fromMock,
-  insertMock,
-  onConflictDoUpdateMock,
-  selectMock,
-  sqlMock,
-  valuesMock,
-  whereMock,
-} = vi.hoisted(() => {
-  const onConflictDoUpdateMock = vi.fn(async () => undefined);
-  const valuesMock = vi.fn(() => ({ onConflictDoUpdate: onConflictDoUpdateMock }));
-  const insertMock = vi.fn(() => ({ values: valuesMock }));
-  const whereMock = vi.fn(async () => [{ memoryId: "memory_1" }, { memoryId: "memory_2" }]);
-  const fromMock = vi.fn(() => ({ where: whereMock }));
-  const selectMock = vi.fn(() => ({ from: fromMock }));
+type UpsertedMemoryEntry = {
+  externalKey: string;
+  memoryId: string;
+  metadata: { segmentKey: string };
+  normalizedSourceText: string;
+  sourceText: string;
+  targetText: string;
+};
 
-  return {
-    eqMock: vi.fn(() => "project filter"),
-    fromMock,
-    insertMock,
-    onConflictDoUpdateMock,
-    selectMock,
-    sqlMock: vi.fn((strings: TemplateStringsArray) => ({ sql: strings.join("") })),
-    valuesMock,
-    whereMock,
-  };
-});
+const { eqMock, insertMock, onConflictDoUpdateMock, selectMock, sqlMock, valuesMock } = vi.hoisted(
+  () => {
+    const onConflictDoUpdateMock = vi.fn(async () => undefined);
+    const valuesMock = vi.fn((_values: UpsertedMemoryEntry[]) => ({
+      onConflictDoUpdate: onConflictDoUpdateMock,
+    }));
+    const insertMock = vi.fn(() => ({ values: valuesMock }));
+    const whereMock = vi.fn(async () => [{ memoryId: "memory_1" }, { memoryId: "memory_2" }]);
+    const fromMock = vi.fn(() => ({ where: whereMock }));
+    const selectMock = vi.fn(() => ({ from: fromMock }));
+
+    return {
+      eqMock: vi.fn(() => "project filter"),
+      insertMock,
+      onConflictDoUpdateMock,
+      selectMock,
+      sqlMock: vi.fn((strings: TemplateStringsArray) => ({ sql: strings.join("") })),
+      valuesMock,
+    };
+  },
+);
 
 vi.mock("drizzle-orm", () => ({
   eq: eqMock,
@@ -84,15 +86,12 @@ describe("persistFileTranslationMemoryEntries", () => {
       targetLocale: "fr",
     });
 
-    const values = valuesMock.mock.calls[0]?.[0];
+    expect(valuesMock).toHaveBeenCalledOnce();
+
+    const [values] = valuesMock.mock.calls[0];
 
     expect(values).toHaveLength(4);
-    expect(
-      values.map(
-        (value: { memoryId: string; normalizedSourceText: string }) =>
-          `${value.memoryId}:${value.normalizedSourceText}`,
-      ),
-    ).toEqual([
+    expect(values.map((value) => `${value.memoryId}:${value.normalizedSourceText}`)).toEqual([
       "memory_1:hello world",
       "memory_2:hello world",
       "memory_1:goodbye",
@@ -100,8 +99,7 @@ describe("persistFileTranslationMemoryEntries", () => {
     ]);
     expect(
       values.find(
-        (value: { memoryId: string; normalizedSourceText: string }) =>
-          value.memoryId === "memory_1" && value.normalizedSourceText === "hello world",
+        (value) => value.memoryId === "memory_1" && value.normalizedSourceText === "hello world",
       ),
     ).toMatchObject({
       externalKey: "job_1:fr:second",
@@ -123,6 +121,10 @@ describe("persistFileTranslationMemoryEntries", () => {
       targetLocale: "fr",
     });
 
-    expect(onConflictDoUpdateMock.mock.calls[0]?.[0].set.updatedAt).toEqual({ sql: "now()" });
+    expect(onConflictDoUpdateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        set: expect.objectContaining({ updatedAt: { sql: "now()" } }),
+      }),
+    );
   });
 });

--- a/apps/hyperlocalise-web/src/lib/translation/file-translation-memory.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/file-translation-memory.test.ts
@@ -88,8 +88,9 @@ describe("persistFileTranslationMemoryEntries", () => {
 
     expect(values).toHaveLength(4);
     expect(
-      values.map((value: { memoryId: string; normalizedSourceText: string }) =>
-        `${value.memoryId}:${value.normalizedSourceText}`,
+      values.map(
+        (value: { memoryId: string; normalizedSourceText: string }) =>
+          `${value.memoryId}:${value.normalizedSourceText}`,
       ),
     ).toEqual([
       "memory_1:hello world",

--- a/apps/hyperlocalise-web/src/lib/translation/file-translation-memory.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/file-translation-memory.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 
 import { db, schema } from "@/lib/database";
 import { normalizeTranslationMemorySourceText } from "@/lib/translation/normalizeTranslationMemorySourceText";
@@ -27,48 +27,43 @@ export async function persistFileTranslationMemoryEntries(input: {
   const memoryIds = attached.map((x) => x.memoryId);
   if (memoryIds.length === 0) return;
 
-  for (const unit of units) {
+  const values = units.flatMap((unit) => {
     const normalized = normalizeTranslationMemorySourceText(unit.sourceText);
-    await db
-      .insert(schema.memoryEntries)
-      .values(
-        memoryIds.map((memoryId) => ({
-          memoryId,
-          sourceLocale: input.sourceLocale,
-          targetLocale: input.targetLocale,
-          sourceText: unit.sourceText,
-          normalizedSourceText: normalized,
-          targetText: unit.targetText,
-          provenance: "file_job",
-          externalKey: `${input.jobId}:${input.targetLocale}:${unit.key}`,
-          metadata: {
-            projectId: input.projectId,
-            sourcePath: input.sourcePath,
-            sourceFileHash: input.sourceFileHash,
-            jobId: input.jobId,
-            segmentKey: unit.key,
-          },
-        })),
-      )
-      .onConflictDoUpdate({
-        target: [
-          schema.memoryEntries.memoryId,
-          schema.memoryEntries.sourceLocale,
-          schema.memoryEntries.targetLocale,
-          schema.memoryEntries.normalizedSourceText,
-        ],
-        set: {
-          targetText: unit.targetText,
-          provenance: "file_job",
-          externalKey: `${input.jobId}:${input.targetLocale}:${unit.key}`,
-          metadata: {
-            projectId: input.projectId,
-            sourcePath: input.sourcePath,
-            sourceFileHash: input.sourceFileHash,
-            jobId: input.jobId,
-            segmentKey: unit.key,
-          },
-        },
-      });
-  }
+    return memoryIds.map((memoryId) => ({
+      memoryId,
+      sourceLocale: input.sourceLocale,
+      targetLocale: input.targetLocale,
+      sourceText: unit.sourceText,
+      normalizedSourceText: normalized,
+      targetText: unit.targetText,
+      provenance: "file_job",
+      externalKey: `${input.jobId}:${input.targetLocale}:${unit.key}`,
+      metadata: {
+        projectId: input.projectId,
+        sourcePath: input.sourcePath,
+        sourceFileHash: input.sourceFileHash,
+        jobId: input.jobId,
+        segmentKey: unit.key,
+      },
+    }));
+  });
+
+  await db
+    .insert(schema.memoryEntries)
+    .values(values)
+    .onConflictDoUpdate({
+      target: [
+        schema.memoryEntries.memoryId,
+        schema.memoryEntries.sourceLocale,
+        schema.memoryEntries.targetLocale,
+        schema.memoryEntries.normalizedSourceText,
+      ],
+      set: {
+        targetText: sql`excluded.target_text`,
+        provenance: sql`excluded.provenance`,
+        externalKey: sql`excluded.external_key`,
+        metadata: sql`excluded.metadata`,
+        updatedAt: new Date(),
+      },
+    });
 }

--- a/apps/hyperlocalise-web/src/lib/translation/file-translation-memory.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/file-translation-memory.ts
@@ -27,26 +27,33 @@ export async function persistFileTranslationMemoryEntries(input: {
   const memoryIds = attached.map((x) => x.memoryId);
   if (memoryIds.length === 0) return;
 
-  const values = units.flatMap((unit) => {
+  const valueByConflictKey = new Map<string, typeof schema.memoryEntries.$inferInsert>();
+  for (const unit of units) {
     const normalized = normalizeTranslationMemorySourceText(unit.sourceText);
-    return memoryIds.map((memoryId) => ({
-      memoryId,
-      sourceLocale: input.sourceLocale,
-      targetLocale: input.targetLocale,
-      sourceText: unit.sourceText,
-      normalizedSourceText: normalized,
-      targetText: unit.targetText,
-      provenance: "file_job",
-      externalKey: `${input.jobId}:${input.targetLocale}:${unit.key}`,
-      metadata: {
-        projectId: input.projectId,
-        sourcePath: input.sourcePath,
-        sourceFileHash: input.sourceFileHash,
-        jobId: input.jobId,
-        segmentKey: unit.key,
-      },
-    }));
-  });
+    for (const memoryId of memoryIds) {
+      valueByConflictKey.set(
+        `${memoryId}:${input.sourceLocale}:${input.targetLocale}:${normalized}`,
+        {
+          memoryId,
+          sourceLocale: input.sourceLocale,
+          targetLocale: input.targetLocale,
+          sourceText: unit.sourceText,
+          normalizedSourceText: normalized,
+          targetText: unit.targetText,
+          provenance: "file_job",
+          externalKey: `${input.jobId}:${input.targetLocale}:${unit.key}`,
+          metadata: {
+            projectId: input.projectId,
+            sourcePath: input.sourcePath,
+            sourceFileHash: input.sourceFileHash,
+            jobId: input.jobId,
+            segmentKey: unit.key,
+          },
+        },
+      );
+    }
+  }
+  const values = [...valueByConflictKey.values()];
 
   await db
     .insert(schema.memoryEntries)
@@ -63,7 +70,7 @@ export async function persistFileTranslationMemoryEntries(input: {
         provenance: sql`excluded.provenance`,
         externalKey: sql`excluded.external_key`,
         metadata: sql`excluded.metadata`,
-        updatedAt: new Date(),
+        updatedAt: sql`now()`,
       },
     });
 }

--- a/apps/hyperlocalise-web/src/lib/translation/file-translation-memory.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/file-translation-memory.ts
@@ -1,0 +1,74 @@
+import { eq } from "drizzle-orm";
+
+import { db, schema } from "@/lib/database";
+import { normalizeTranslationMemorySourceText } from "@/lib/translation/normalizeTranslationMemorySourceText";
+
+export async function persistFileTranslationMemoryEntries(input: {
+  projectId: string;
+  jobId: string;
+  sourceLocale: string;
+  targetLocale: string;
+  sourcePath: string;
+  sourceFileHash: string;
+  sourceEntries: Record<string, string>;
+  targetEntries: Record<string, string>;
+}) {
+  const units = Object.entries(input.sourceEntries)
+    .map(([key, sourceText]) => ({ key, sourceText, targetText: input.targetEntries[key] ?? "" }))
+    .filter((unit) => unit.sourceText.trim().length > 0 && unit.targetText.trim().length > 0);
+  if (units.length === 0) {
+    return;
+  }
+
+  const attached = await db
+    .select({ memoryId: schema.projectMemories.memoryId })
+    .from(schema.projectMemories)
+    .where(eq(schema.projectMemories.projectId, input.projectId));
+  const memoryIds = attached.map((x) => x.memoryId);
+  if (memoryIds.length === 0) return;
+
+  for (const unit of units) {
+    const normalized = normalizeTranslationMemorySourceText(unit.sourceText);
+    await db
+      .insert(schema.memoryEntries)
+      .values(
+        memoryIds.map((memoryId) => ({
+          memoryId,
+          sourceLocale: input.sourceLocale,
+          targetLocale: input.targetLocale,
+          sourceText: unit.sourceText,
+          normalizedSourceText: normalized,
+          targetText: unit.targetText,
+          provenance: "file_job",
+          externalKey: `${input.jobId}:${input.targetLocale}:${unit.key}`,
+          metadata: {
+            projectId: input.projectId,
+            sourcePath: input.sourcePath,
+            sourceFileHash: input.sourceFileHash,
+            jobId: input.jobId,
+            segmentKey: unit.key,
+          },
+        })),
+      )
+      .onConflictDoUpdate({
+        target: [
+          schema.memoryEntries.memoryId,
+          schema.memoryEntries.sourceLocale,
+          schema.memoryEntries.targetLocale,
+          schema.memoryEntries.normalizedSourceText,
+        ],
+        set: {
+          targetText: unit.targetText,
+          provenance: "file_job",
+          externalKey: `${input.jobId}:${input.targetLocale}:${unit.key}`,
+          metadata: {
+            projectId: input.projectId,
+            sourcePath: input.sourcePath,
+            sourceFileHash: input.sourceFileHash,
+            jobId: input.jobId,
+            segmentKey: unit.key,
+          },
+        },
+      });
+  }
+}

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
@@ -1,4 +1,12 @@
-import { describe, expect, it, vi } from "vite-plus/test";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const sandboxMocks = vi.hoisted(() => {
+  const output = vi.fn();
+  const runCommand = vi.fn();
+  const get = vi.fn();
+
+  return { get, output, runCommand };
+});
 
 vi.mock("@/lib/env", () => ({
   env: {
@@ -8,7 +16,59 @@ vi.mock("@/lib/env", () => ({
   },
 }));
 
-import { buildTempConfig } from "@/lib/translation/sandbox-translation";
+vi.mock("@vercel/sandbox", () => ({
+  Sandbox: {
+    get: sandboxMocks.get,
+  },
+}));
+
+import { buildTempConfig, runSandboxCommand } from "@/lib/translation/sandbox-translation";
+
+describe("sandbox command runner", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("captures combined output by default", async () => {
+    sandboxMocks.output.mockResolvedValueOnce("stdout and stderr");
+    sandboxMocks.runCommand.mockResolvedValueOnce({
+      exitCode: 0,
+      output: sandboxMocks.output,
+    });
+    sandboxMocks.get.mockResolvedValueOnce({
+      runCommand: sandboxMocks.runCommand,
+    });
+
+    await expect(runSandboxCommand("sandbox_123", "echo", ["hello"])).resolves.toEqual({
+      exitCode: 0,
+      output: "stdout and stderr",
+    });
+
+    expect(sandboxMocks.output).toHaveBeenCalledWith("both");
+  });
+
+  it("can capture stdout only for machine-readable command output", async () => {
+    sandboxMocks.output.mockResolvedValueOnce('{"hello":"world"}');
+    sandboxMocks.runCommand.mockResolvedValueOnce({
+      exitCode: 0,
+      output: sandboxMocks.output,
+    });
+    sandboxMocks.get.mockResolvedValueOnce({
+      runCommand: sandboxMocks.runCommand,
+    });
+
+    await expect(
+      runSandboxCommand("sandbox_123", "bash", ["-c", "hl entries source.json"], {
+        output: "stdout",
+      }),
+    ).resolves.toEqual({
+      exitCode: 0,
+      output: '{"hello":"world"}',
+    });
+
+    expect(sandboxMocks.output).toHaveBeenCalledWith("stdout");
+  });
+});
 
 describe("sandbox translation temporary config", () => {
   it("augments file translation system prompt with project context, job context, and glossary", () => {

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.ts
@@ -34,7 +34,7 @@ export async function runSandboxCommand(
   sandboxId: string,
   command: string,
   args: string[],
-  options?: { env?: Record<string, string> },
+  options?: { env?: Record<string, string>; output?: "stdout" | "stderr" | "both" },
 ): Promise<{ exitCode: number; output: string }> {
   const sandbox = await Sandbox.get({ sandboxId });
   const result = await sandbox.runCommand({
@@ -44,7 +44,7 @@ export async function runSandboxCommand(
   });
   return {
     exitCode: result.exitCode,
-    output: await result.output("both"),
+    output: await result.output(options?.output ?? "both"),
   };
 }
 

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -3,6 +3,7 @@ import { and, asc, eq, inArray } from "drizzle-orm";
 
 import { db, schema } from "@/lib/database";
 import { logTranslatedFileDiagnostics } from "@/lib/translation/diagnostics";
+import { persistFileTranslationMemoryEntries } from "@/lib/translation/file-translation-memory";
 import {
   isImageTranslationFileFormat,
   type SupportedTranslationFileFormat,
@@ -83,6 +84,20 @@ async function runTranslationStep(
   );
 }
 
+
+async function extractEntriesStep(sandboxId: string, path: string) {
+  "use step";
+  const result = await runSandboxCommand(
+    sandboxId,
+    "bash",
+    ["-lc", `export PATH="$HOME/.local/bin:$PATH"; hl entries '${path.replaceAll("'", "'\''")}'`],
+    { env: getSandboxTranslationEnv() },
+  );
+  if (result.exitCode !== 0) {
+    throw new Error(`failed to extract entries for ${path}: ${result.output}`);
+  }
+  return JSON.parse(result.output) as Record<string, string>;
+}
 async function readOutputStep(sandboxId: string, outputFile: string) {
   "use step";
   return readTranslatedFile(sandboxId, outputFile);
@@ -357,6 +372,19 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
         filename: outputFilename,
         contentType: sourceFile.contentType,
         content: translatedContent,
+      });
+
+      const sourceEntries = await extractEntriesStep(sandboxId, inputFilename);
+      const targetEntries = await extractEntriesStep(sandboxId, outputFilename);
+      await persistFileTranslationMemoryEntries({
+        projectId: claim.job.projectId,
+        jobId: claim.job.id,
+        sourceLocale: parsedInput.sourceLocale,
+        targetLocale,
+        sourcePath: sourceFile.filename,
+        sourceFileHash: sourceFile.sha256,
+        sourceEntries,
+        targetEntries,
       });
 
       outputFiles.push({

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -93,8 +93,8 @@ async function extractEntriesStep(sandboxId: string, path: string) {
   const result = await runSandboxCommand(
     sandboxId,
     "bash",
-    ["-lc", `export PATH="$HOME/.local/bin:$PATH"; hl entries '${shellSingleQuote(path)}'`],
-    { env: getSandboxTranslationEnv() },
+    ["-c", `export PATH="$HOME/.local/bin:$PATH"; hl entries '${shellSingleQuote(path)}'`],
+    { env: getSandboxTranslationEnv(), output: "stdout" },
   );
   if (result.exitCode !== 0) {
     throw new Error(`failed to extract entries for ${path}: ${result.output}`);

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -93,7 +93,7 @@ async function extractEntriesStep(sandboxId: string, path: string) {
   const result = await runSandboxCommand(
     sandboxId,
     "bash",
-    ["-c", `export PATH="$HOME/.local/bin:$PATH"; hl entries '${shellSingleQuote(path)}'`],
+    ["-lc", `export PATH="$HOME/.local/bin:$PATH"; hl entries '${shellSingleQuote(path)}'`],
     { env: getSandboxTranslationEnv(), output: "stdout" },
   );
   if (result.exitCode !== 0) {

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -34,6 +34,10 @@ import {
   storeOutputFileStep,
 } from "./steps/translation-job";
 
+function shellSingleQuote(value: string) {
+  return value.replaceAll("'", "'\\''");
+}
+
 async function createSandboxStep() {
   "use step";
   return createTranslationSandbox();
@@ -76,7 +80,7 @@ async function runTranslationStep(
     "bash",
     [
       "-lc",
-      `export PATH="$HOME/.local/bin:$PATH"; hl run --config '${configPath.replaceAll("'", "'\\''")}' --locale '${targetLocale.replaceAll("'", "'\\''")}' --force --progress off`,
+      `export PATH="$HOME/.local/bin:$PATH"; hl run --config '${shellSingleQuote(configPath)}' --locale '${shellSingleQuote(targetLocale)}' --force --progress off`,
     ],
     {
       env: getSandboxTranslationEnv(),
@@ -84,13 +88,12 @@ async function runTranslationStep(
   );
 }
 
-
 async function extractEntriesStep(sandboxId: string, path: string) {
   "use step";
   const result = await runSandboxCommand(
     sandboxId,
     "bash",
-    ["-lc", `export PATH="$HOME/.local/bin:$PATH"; hl entries '${path.replaceAll("'", "'\''")}'`],
+    ["-lc", `export PATH="$HOME/.local/bin:$PATH"; hl entries '${shellSingleQuote(path)}'`],
     { env: getSandboxTranslationEnv() },
   );
   if (result.exitCode !== 0) {
@@ -330,6 +333,18 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
     await writeSourceFileStep(sandboxId, inputFilename, sourceContent);
 
     const outputFiles: Array<{ fileId: string; locale: string; filename: string }> = [];
+    let sourceEntries: Record<string, string> | null = null;
+
+    try {
+      sourceEntries = await extractEntriesStep(sandboxId, inputFilename);
+    } catch (error) {
+      console.warn("[file-translation-workflow] source TM extraction failed", {
+        jobId: claim.job.id,
+        projectId: claim.job.projectId,
+        sourcePath: sourceFile.filename,
+        error: userFacingFailureReason(error),
+      });
+    }
 
     for (const targetLocale of parsedInput.targetLocales) {
       const outputFilename = getSandboxOutputFilename(sourceFile.filename, targetLocale);
@@ -374,18 +389,30 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
         content: translatedContent,
       });
 
-      const sourceEntries = await extractEntriesStep(sandboxId, inputFilename);
-      const targetEntries = await extractEntriesStep(sandboxId, outputFilename);
-      await persistFileTranslationMemoryEntries({
-        projectId: claim.job.projectId,
-        jobId: claim.job.id,
-        sourceLocale: parsedInput.sourceLocale,
-        targetLocale,
-        sourcePath: sourceFile.filename,
-        sourceFileHash: sourceFile.sha256,
-        sourceEntries,
-        targetEntries,
-      });
+      if (sourceEntries) {
+        try {
+          const targetEntries = await extractEntriesStep(sandboxId, outputFilename);
+          await persistFileTranslationMemoryEntries({
+            projectId: claim.job.projectId,
+            jobId: claim.job.id,
+            sourceLocale: parsedInput.sourceLocale,
+            targetLocale,
+            sourcePath: sourceFile.filename,
+            sourceFileHash: sourceFile.sha256,
+            sourceEntries,
+            targetEntries,
+          });
+        } catch (error) {
+          console.warn("[file-translation-workflow] target TM persistence failed", {
+            jobId: claim.job.id,
+            projectId: claim.job.projectId,
+            targetLocale,
+            sourcePath: sourceFile.filename,
+            outputPath: outputFilename,
+            error: userFacingFailureReason(error),
+          });
+        }
+      }
 
       outputFiles.push({
         fileId: storedOutput.id,


### PR DESCRIPTION
### Motivation

- Provide a simple CLI to extract parsed translation entries from a translation file as key/value JSON for tooling and sandbox use.
- Capture source/target segment pairs produced by file translation jobs and persist them to project translation memories for future reuse.

### Description

- Add a new CLI subcommand `entries` implemented in `apps/cli/cmd/entries.go` that reads a translation file, parses entries with `translationfileparser`, and prints pretty JSON to stdout.
- Register the new command in the root command via `newEntriesCmd()` in `apps/cli/cmd/root.go` and add a unit test `TestEntriesCommandOutputsParsedEntries` in `apps/cli/cmd/entries_test.go` that validates the JSON output for flat and nested keys.
- Introduce `persistFileTranslationMemoryEntries` in `apps/hyperlocalise-web/src/lib/translation/file-translation-memory.ts` to insert/upsert memory entries into `memoryEntries`, including normalization, provenance, and metadata.
- Integrate extraction and persistence into the file translation workflow by adding `extractEntriesStep` and invoking `persistFileTranslationMemoryEntries` in `apps/hyperlocalise-web/src/workflows/file-translation-job.ts` after a file is translated and stored.

### Testing

- Ran the new CLI unit test `TestEntriesCommandOutputsParsedEntries` for the CLI package, and it passed.
- No automated tests were added for the new TypeScript persistence logic in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0eaa1f76a4832cae540d12eac14502)