### PR TITLE
⚡ Bolt: optimize JSON parser key construction

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -35,3 +35,7 @@
 ## 2026-06-01 - Preferring strconv.Itoa over fmt.Sprintf in hot paths
 **Learning:** `fmt.Sprintf` is flexible but expensive due to reflection and parsing the format string. For simple integer conversions, `strconv.Itoa` is much faster and avoids unnecessary overhead.
 **Action:** Replaced `fmt.Sprintf("%s[%d]", ...)` with string concatenation and `strconv.Itoa` in `markdownNodePath`, contributing to a ~6x performance improvement.
+
+## 2026-06-05 - Optimizing recursive JSON flattening
+**Learning:** In recursive tree/map traversal (like `flattenJSON`), using `fmt.Sprintf` for key construction at every level accumulates significant allocation and formatting overhead. String concatenation with `strconv.Itoa` is considerably more efficient for these hot paths.
+**Action:** Replaced `fmt.Sprintf("%s[%d]", ...)` with manual concatenation in `internal/i18n/translationfileparser/json_parser.go`.

--- a/internal/i18n/translationfileparser/json_parser.go
+++ b/internal/i18n/translationfileparser/json_parser.go
@@ -3,7 +3,8 @@ package translationfileparser
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
+	"slices"
+	"strconv"
 	"strings"
 )
 
@@ -57,7 +58,7 @@ func parseStrictFormatJSMessages(out map[string]string, payload map[string]any) 
 	for key := range payload {
 		keys = append(keys, key)
 	}
-	sort.Strings(keys)
+	slices.Sort(keys)
 
 	for _, key := range keys {
 		message := payload[key].(map[string]any)
@@ -121,7 +122,7 @@ func flattenJSON(out map[string]string, prefix string, input map[string]any) err
 	for key := range input {
 		keys = append(keys, key)
 	}
-	sort.Strings(keys)
+	slices.Sort(keys)
 
 	for _, key := range keys {
 		value := input[key]
@@ -151,7 +152,9 @@ func flattenJSON(out map[string]string, prefix string, input map[string]any) err
 
 func flattenJSONArray(out map[string]string, prefix string, input []any) error {
 	for idx, item := range input {
-		itemKey := fmt.Sprintf("%s[%d]", prefix, idx)
+		// BOLT OPTIMIZATION: Use string concatenation and strconv.Itoa instead of fmt.Sprintf
+		// to reduce allocation and formatting overhead in recursive flattening.
+		itemKey := prefix + "[" + strconv.Itoa(idx) + "]"
 		switch typed := item.(type) {
 		case string:
 			out[itemKey] = typed


### PR DESCRIPTION
💡 What: Optimized the JSON parser's flattening logic by replacing `fmt.Sprintf` with string concatenation and `strconv.Itoa`.
🎯 Why: Using `fmt.Sprintf` in recursive functions like `flattenJSONArray` creates unnecessary allocation and formatting overhead, especially for deep or large JSON structures.
📊 Impact: Reduces allocations and improves performance in hot paths for JSON flattening.
🔬 Measurement: Verified correctness with existing tests in `internal/i18n/translationfileparser`.

---
*PR created automatically by Jules for task [4549146018286099068](https://jules.google.com/task/4549146018286099068) started by @cungminh2710*