### PR TITLE
⚡ Bolt: optimize recursive JSON marshaling keys

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -39,3 +39,7 @@
 ## 2026-06-05 - Optimizing recursive JSON flattening
 **Learning:** In recursive tree/map traversal (like `flattenJSON`), using `fmt.Sprintf` for key construction at every level accumulates significant allocation and formatting overhead. String concatenation with `strconv.Itoa` is considerably more efficient for these hot paths.
 **Action:** Replaced `fmt.Sprintf("%s[%d]", ...)` with manual concatenation in `internal/i18n/translationfileparser/json_parser.go`.
+
+## 2026-06-10 - Optimizing recursive JSON marshaling
+**Learning:** Similar to `flattenJSON` in the parser, using `fmt.Sprintf` for key construction in recursive JSON rewriting (e.g., `rewriteJSONArray`) adds significant allocation and formatting overhead. String concatenation with `strconv.Itoa` is a much more efficient alternative for these hot paths.
+**Action:** Replaced `fmt.Sprintf("%s[%d]", ...)` with manual concatenation in `internal/i18n/translationfileparser/json_marshal.go`.

--- a/internal/i18n/translationfileparser/json_marshal.go
+++ b/internal/i18n/translationfileparser/json_marshal.go
@@ -3,6 +3,7 @@ package translationfileparser
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 )
 
 // MarshalJSON rewrites a JSON translation file using the provided flattened values.
@@ -59,7 +60,9 @@ func rewriteJSONObject(payload map[string]any, prefix string, values map[string]
 
 func rewriteJSONArray(payload []any, prefix string, values map[string]string) {
 	for idx, raw := range payload {
-		fullKey := fmt.Sprintf("%s[%d]", prefix, idx)
+		// BOLT OPTIMIZATION: Use string concatenation and strconv.Itoa instead of fmt.Sprintf
+		// to reduce allocation and formatting overhead in recursive JSON rewriting.
+		fullKey := prefix + "[" + strconv.Itoa(idx) + "]"
 		switch typed := raw.(type) {
 		case string:
 			if replacement, ok := values[fullKey]; ok {


### PR DESCRIPTION
💡 What: Optimized the recursive key construction in `rewriteJSONArray` within `internal/i18n/translationfileparser/json_marshal.go`.
🎯 Why: `fmt.Sprintf` is expensive in hot recursive paths due to reflection and format string parsing. String concatenation and `strconv.Itoa` significantly reduce allocations and CPU overhead.
📊 Impact: Expected to reduce allocations and CPU time in recursive JSON rewriting by avoiding `fmt.Sprintf`.
🔬 Measurement: Verified with existing tests in `internal/i18n/translationfileparser`.

---
*PR created automatically by Jules for task [2080406341215887292](https://jules.google.com/task/2080406341215887292) started by @cungminh2710*