### PR TITLE
Add support for prefilled translation entries in CLI run and file-translation workflow

### DIFF
--- a/apps/cli/cmd/run.go
+++ b/apps/cli/cmd/run.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -22,6 +24,8 @@ import (
 )
 
 type runOptions struct {
+	prefilledEntriesPath      string
+	prefilledTargetPath       string
 	configPath                string
 	interactive               bool
 	dryRun                    bool
@@ -84,6 +88,8 @@ func newRunCmd() *cobra.Command {
 	cmd.Flags().StringSliceVar(&o.locales, "locale", nil, "only run tasks for the given target locale(s)")
 	cmd.Flags().StringSliceVar(&o.targetLocaleAlias, "target-locale", nil, "alias for --locale")
 	cmd.Flags().StringVar(&o.outputPath, "output", "", "report output JSON path")
+	cmd.Flags().StringVar(&o.prefilledEntriesPath, "prefilled-entries", "", "JSON file containing prefilled translation entries keyed by entry id")
+	cmd.Flags().StringVar(&o.prefilledTargetPath, "prefilled-target-path", "", "target output path to apply --prefilled-entries to")
 	cmd.Flags().BoolVar(&o.experimentalContextMemory, "experimental-context-memory", o.experimentalContextMemory, "enable experimental two-stage context memory generation before translation")
 	cmd.Flags().StringVar(&o.contextMemoryScope, "context-memory-scope", runsvc.ContextMemoryScopeFile, "scope for experimental context memory: file|bucket|group")
 	cmd.Flags().IntVar(&o.contextMemoryMaxChars, "context-memory-max-chars", 1200, "maximum context memory characters injected into each translation request")
@@ -128,6 +134,27 @@ func normalizeRunFileFlags(paths []string) ([]string, error) {
 		normalized = append(normalized, trimmed)
 	}
 	return normalized, nil
+}
+
+func loadPrefilledEntries(path string) (map[string]string, error) {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return nil, nil
+	}
+	raw, err := os.ReadFile(trimmed)
+	if err != nil {
+		return nil, fmt.Errorf("read --prefilled-entries %q: %w", trimmed, err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	entries := map[string]string{}
+	if err := decoder.Decode(&entries); err != nil {
+		return nil, fmt.Errorf("parse --prefilled-entries %q: %w", trimmed, err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("parse --prefilled-entries %q: unexpected trailing data", trimmed)
+	}
+	return entries, nil
 }
 
 func executeRun(cmd *cobra.Command, o runOptions) error {
@@ -215,6 +242,14 @@ func executeRun(cmd *cobra.Command, o runOptions) error {
 		defer renderer.Close()
 	}
 
+	prefilledEntries, err := loadPrefilledEntries(o.prefilledEntriesPath)
+	if err != nil {
+		return err
+	}
+	if len(prefilledEntries) > 0 && strings.TrimSpace(o.prefilledTargetPath) == "" {
+		return fmt.Errorf("--prefilled-target-path is required when --prefilled-entries is provided")
+	}
+
 	input := runsvc.Input{
 		ConfigPath:                o.configPath,
 		DryRun:                    o.dryRun,
@@ -231,6 +266,8 @@ func executeRun(cmd *cobra.Command, o runOptions) error {
 		ContextMemoryScope:        contextMemoryScope,
 		ContextMemoryMaxChars:     o.contextMemoryMaxChars,
 		ReportJSONDetail:          jsonDetail,
+		PrefilledEntries:          prefilledEntries,
+		PrefilledTargetPath:       strings.TrimSpace(o.prefilledTargetPath),
 	}
 	if renderer != nil {
 		input.OnEvent = func(event runsvc.Event) {

--- a/apps/cli/internal/i18n/runsvc/run_orchestrator.go
+++ b/apps/cli/internal/i18n/runsvc/run_orchestrator.go
@@ -3,6 +3,7 @@ package runsvc
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -73,6 +74,17 @@ func (s *Service) Run(ctx context.Context, in Input) (report Report, err error) 
 		endRunSpan(lockSpan, err, "lock_filter")
 		return Report{}, err
 	}
+	executable, reusedByPrefill, prefillErr := applyPrefilledEntries(executable, checkpointStaged, in.PrefilledEntries, in.PrefilledTargetPath)
+	if prefillErr != nil {
+		endRunSpan(lockSpan, prefillErr, "apply_prefilled_entries")
+		return Report{}, prefillErr
+	}
+	if reusedByPrefill > 0 {
+		report.SkippedByLock += reusedByPrefill
+		report.ExecutableTotal = len(executable)
+		report.Warnings = append(report.Warnings, fmt.Sprintf("prefilled_entries_reused target=%s count=%d", in.PrefilledTargetPath, reusedByPrefill))
+	}
+
 	report.GeneratedAt = s.now()
 	report.ConfigPath = in.ConfigPath
 	report.Warnings = append(report.Warnings, planWarnings...)
@@ -166,6 +178,30 @@ func (s *Service) Run(ctx context.Context, in Input) (report Report, err error) 
 	report.PruneApplied = len(report.PruneCandidates)
 	emitter.emit(completedEvent(report))
 	return report, nil
+}
+
+func applyPrefilledEntries(tasks []Task, staged map[string]stagedOutput, entries map[string]string, targetPath string) (filtered []Task, reused int, err error) {
+	if len(entries) == 0 || strings.TrimSpace(targetPath) == "" {
+		return tasks, 0, nil
+	}
+	trimmedTargetPath := filepath.Clean(strings.TrimSpace(targetPath))
+	filtered = make([]Task, 0, len(tasks))
+	for _, task := range tasks {
+		if filepath.Clean(task.TargetPath) != trimmedTargetPath || isImageTask(task) {
+			filtered = append(filtered, task)
+			continue
+		}
+		value, ok := entries[task.EntryKey]
+		if !ok || strings.TrimSpace(value) == "" {
+			filtered = append(filtered, task)
+			continue
+		}
+		if err := stageTaskOutput(staged, task.TargetPath, task.SourcePath, task.SourceLocale, task.TargetLocale, task.EntryKey, value, nil); err != nil {
+			return nil, 0, fmt.Errorf("stage prefilled output for %s: %w", taskIdentity(task.TargetPath, task.EntryKey), err)
+		}
+		reused++
+	}
+	return filtered, reused, nil
 }
 
 func warningsForLegacyPrompts(tasks []Task) []string {

--- a/apps/cli/internal/i18n/runsvc/service.go
+++ b/apps/cli/internal/i18n/runsvc/service.go
@@ -49,7 +49,9 @@ type Input struct {
 	// ReportJSONDetail controls --output JSON shape: summary (aggregate-only) or full (complete report).
 	// The CLI defaults to summary; an empty value normalizes to full for backward compatibility with
 	// library callers that omit the field. Run applies NormalizeReportJSONDetail again (idempotent).
-	ReportJSONDetail string
+	ReportJSONDetail    string
+	PrefilledEntries    map[string]string
+	PrefilledTargetPath string
 }
 
 // FixTarget selects a subset of planned translation tasks when non-empty.

--- a/apps/hyperlocalise-web/src/lib/translation/file-translation-memory.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/file-translation-memory.test.ts
@@ -9,30 +9,43 @@ type UpsertedMemoryEntry = {
   targetText: string;
 };
 
-const { eqMock, insertMock, onConflictDoUpdateMock, selectMock, sqlMock, valuesMock } = vi.hoisted(
-  () => {
-    const onConflictDoUpdateMock = vi.fn(async () => undefined);
-    const valuesMock = vi.fn((_values: UpsertedMemoryEntry[]) => ({
-      onConflictDoUpdate: onConflictDoUpdateMock,
-    }));
-    const insertMock = vi.fn(() => ({ values: valuesMock }));
-    const whereMock = vi.fn(async () => [{ memoryId: "memory_1" }, { memoryId: "memory_2" }]);
-    const fromMock = vi.fn(() => ({ where: whereMock }));
-    const selectMock = vi.fn(() => ({ from: fromMock }));
+const {
+  andMock,
+  eqMock,
+  inArrayMock,
+  insertMock,
+  onConflictDoUpdateMock,
+  selectMock,
+  sqlMock,
+  valuesMock,
+  whereMock,
+} = vi.hoisted(() => {
+  const onConflictDoUpdateMock = vi.fn(async () => undefined);
+  const valuesMock = vi.fn((_values: UpsertedMemoryEntry[]) => ({
+    onConflictDoUpdate: onConflictDoUpdateMock,
+  }));
+  const insertMock = vi.fn(() => ({ values: valuesMock }));
+  const whereMock = vi.fn(async () => [{ memoryId: "memory_1" }, { memoryId: "memory_2" }]);
+  const fromMock = vi.fn(() => ({ where: whereMock }));
+  const selectMock = vi.fn(() => ({ from: fromMock }));
 
-    return {
-      eqMock: vi.fn(() => "project filter"),
-      insertMock,
-      onConflictDoUpdateMock,
-      selectMock,
-      sqlMock: vi.fn((strings: TemplateStringsArray) => ({ sql: strings.join("") })),
-      valuesMock,
-    };
-  },
-);
+  return {
+    andMock: vi.fn((...conditions: string[]) => ["and", conditions]),
+    eqMock: vi.fn(() => "project filter"),
+    inArrayMock: vi.fn(() => "memory filter"),
+    insertMock,
+    onConflictDoUpdateMock,
+    selectMock,
+    sqlMock: vi.fn((strings: TemplateStringsArray) => ({ sql: strings.join("") })),
+    valuesMock,
+    whereMock,
+  };
+});
 
 vi.mock("drizzle-orm", () => ({
+  and: andMock,
   eq: eqMock,
+  inArray: inArrayMock,
   sql: sqlMock,
 }));
 
@@ -59,7 +72,10 @@ vi.mock("@/lib/database", () => ({
   },
 }));
 
-import { persistFileTranslationMemoryEntries } from "./file-translation-memory";
+import {
+  persistFileTranslationMemoryEntries,
+  reuseFileTranslationMemoryEntries,
+} from "./file-translation-memory";
 
 describe("persistFileTranslationMemoryEntries", () => {
   beforeEach(() => {
@@ -126,5 +142,28 @@ describe("persistFileTranslationMemoryEntries", () => {
         set: expect.objectContaining({ updatedAt: { sql: "now()" } }),
       }),
     );
+  });
+});
+
+describe("reuseFileTranslationMemoryEntries", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("scopes reusable memory entry lookup to the project's attached memories", async () => {
+    whereMock
+      .mockResolvedValueOnce([{ memoryId: "memory_1" }, { memoryId: "memory_2" }])
+      .mockResolvedValueOnce([]);
+
+    await reuseFileTranslationMemoryEntries({
+      projectId: "project_1",
+      sourceEntries: { first: "Hello" },
+      sourceLocale: "en",
+      targetLocale: "fr",
+    });
+
+    expect(inArrayMock).toHaveBeenCalledWith("memoryId", ["memory_1", "memory_2"]);
+    expect(andMock).toHaveBeenCalledWith("project filter", "memory filter");
+    expect(whereMock.mock.calls[1]).toEqual([["and", ["project filter", "memory filter"]]]);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/translation/file-translation-memory.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/file-translation-memory.ts
@@ -1,4 +1,4 @@
-import { eq, sql } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import { createHash } from "node:crypto";
 
 import { db, schema } from "@/lib/database";
@@ -15,7 +15,12 @@ export async function reuseFileTranslationMemoryEntries(input: {
   sourceEntries: Record<string, string>;
 }) {
   const units = Object.entries(input.sourceEntries)
-    .map(([key, sourceText]) => ({ key, sourceText, normalizedSourceText: normalizeTranslationMemorySourceText(sourceText), sourceTextHash: sourceTextHash(sourceText) }))
+    .map(([key, sourceText]) => ({
+      key,
+      sourceText,
+      normalizedSourceText: normalizeTranslationMemorySourceText(sourceText),
+      sourceTextHash: sourceTextHash(sourceText),
+    }))
     .filter((unit) => unit.sourceText.trim().length > 0);
   if (units.length === 0) return {} as Record<string, string>;
 
@@ -34,15 +39,28 @@ export async function reuseFileTranslationMemoryEntries(input: {
       metadata: schema.memoryEntries.metadata,
     })
     .from(schema.memoryEntries)
-    .where(eq(schema.memoryEntries.sourceLocale, input.sourceLocale));
+    .where(
+      and(
+        eq(schema.memoryEntries.sourceLocale, input.sourceLocale),
+        inArray(schema.memoryEntries.memoryId, memoryIds),
+      ),
+    );
 
   const reusable: Record<string, string> = {};
   for (const unit of units) {
     const match = rows.find((row) => {
       if (!memoryIds.includes(row.memoryId)) return false;
       if (row.normalizedSourceText !== unit.normalizedSourceText) return false;
-      const metadata = row.metadata as { segmentKey?: string; sourceTextHash?: string; targetLocale?: string } | null;
-      return metadata?.segmentKey === unit.key && metadata?.sourceTextHash === unit.sourceTextHash && metadata?.targetLocale === input.targetLocale;
+      const metadata = row.metadata as {
+        segmentKey?: string;
+        sourceTextHash?: string;
+        targetLocale?: string;
+      } | null;
+      return (
+        metadata?.segmentKey === unit.key &&
+        metadata?.sourceTextHash === unit.sourceTextHash &&
+        metadata?.targetLocale === input.targetLocale
+      );
     });
     if (match?.targetText?.trim()) {
       reusable[unit.key] = match.targetText;

--- a/apps/hyperlocalise-web/src/lib/translation/file-translation-memory.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/file-translation-memory.ts
@@ -1,7 +1,56 @@
 import { eq, sql } from "drizzle-orm";
+import { createHash } from "node:crypto";
 
 import { db, schema } from "@/lib/database";
 import { normalizeTranslationMemorySourceText } from "@/lib/translation/normalizeTranslationMemorySourceText";
+
+function sourceTextHash(sourceText: string) {
+  return createHash("sha256").update(sourceText, "utf8").digest("hex");
+}
+
+export async function reuseFileTranslationMemoryEntries(input: {
+  projectId: string;
+  sourceLocale: string;
+  targetLocale: string;
+  sourceEntries: Record<string, string>;
+}) {
+  const units = Object.entries(input.sourceEntries)
+    .map(([key, sourceText]) => ({ key, sourceText, normalizedSourceText: normalizeTranslationMemorySourceText(sourceText), sourceTextHash: sourceTextHash(sourceText) }))
+    .filter((unit) => unit.sourceText.trim().length > 0);
+  if (units.length === 0) return {} as Record<string, string>;
+
+  const attached = await db
+    .select({ memoryId: schema.projectMemories.memoryId })
+    .from(schema.projectMemories)
+    .where(eq(schema.projectMemories.projectId, input.projectId));
+  const memoryIds = attached.map((x) => x.memoryId);
+  if (memoryIds.length === 0) return {} as Record<string, string>;
+
+  const rows = await db
+    .select({
+      memoryId: schema.memoryEntries.memoryId,
+      normalizedSourceText: schema.memoryEntries.normalizedSourceText,
+      targetText: schema.memoryEntries.targetText,
+      metadata: schema.memoryEntries.metadata,
+    })
+    .from(schema.memoryEntries)
+    .where(eq(schema.memoryEntries.sourceLocale, input.sourceLocale));
+
+  const reusable: Record<string, string> = {};
+  for (const unit of units) {
+    const match = rows.find((row) => {
+      if (!memoryIds.includes(row.memoryId)) return false;
+      if (row.normalizedSourceText !== unit.normalizedSourceText) return false;
+      const metadata = row.metadata as { segmentKey?: string; sourceTextHash?: string; targetLocale?: string } | null;
+      return metadata?.segmentKey === unit.key && metadata?.sourceTextHash === unit.sourceTextHash && metadata?.targetLocale === input.targetLocale;
+    });
+    if (match?.targetText?.trim()) {
+      reusable[unit.key] = match.targetText;
+    }
+  }
+
+  return reusable;
+}
 
 export async function persistFileTranslationMemoryEntries(input: {
   projectId: string;
@@ -48,6 +97,8 @@ export async function persistFileTranslationMemoryEntries(input: {
             sourceFileHash: input.sourceFileHash,
             jobId: input.jobId,
             segmentKey: unit.key,
+            sourceTextHash: sourceTextHash(unit.sourceText),
+            targetLocale: input.targetLocale,
           },
         },
       );

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -4,10 +4,6 @@ import { and, asc, eq, inArray } from "drizzle-orm";
 import { db, schema } from "@/lib/database";
 import { logTranslatedFileDiagnostics } from "@/lib/translation/diagnostics";
 import {
-  persistFileTranslationMemoryEntries,
-  reuseFileTranslationMemoryEntries,
-} from "@/lib/translation/file-translation-memory";
-import {
   isImageTranslationFileFormat,
   type SupportedTranslationFileFormat,
 } from "@/lib/translation/file-formats";
@@ -34,6 +30,8 @@ import {
   getProjectOrganizationStep,
   getStoredFileContentStep,
   getStoredFileStep,
+  persistFileTranslationMemoryEntriesStep,
+  reuseFileTranslationMemoryEntriesStep,
   storeOutputFileStep,
 } from "./steps/translation-job";
 
@@ -365,7 +363,7 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
       const outputFilename = getSandboxOutputFilename(sourceFile.filename, targetLocale);
       let reusedEntries: Record<string, string> = {};
       if (sourceEntries) {
-        reusedEntries = await reuseFileTranslationMemoryEntries({
+        reusedEntries = await reuseFileTranslationMemoryEntriesStep({
           projectId: claim.job.projectId,
           sourceLocale: parsedInput.sourceLocale,
           targetLocale,
@@ -426,7 +424,7 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
       if (sourceEntries) {
         try {
           const targetEntries = await extractEntriesStep(sandboxId, outputFilename);
-          await persistFileTranslationMemoryEntries({
+          await persistFileTranslationMemoryEntriesStep({
             projectId: claim.job.projectId,
             jobId: claim.job.id,
             sourceLocale: parsedInput.sourceLocale,

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -3,7 +3,10 @@ import { and, asc, eq, inArray } from "drizzle-orm";
 
 import { db, schema } from "@/lib/database";
 import { logTranslatedFileDiagnostics } from "@/lib/translation/diagnostics";
-import { persistFileTranslationMemoryEntries } from "@/lib/translation/file-translation-memory";
+import {
+  persistFileTranslationMemoryEntries,
+  reuseFileTranslationMemoryEntries,
+} from "@/lib/translation/file-translation-memory";
 import {
   isImageTranslationFileFormat,
   type SupportedTranslationFileFormat,
@@ -61,6 +64,7 @@ async function runTranslationStep(
   targetLocale: string,
   instructions: string | null,
   context: SandboxTranslationContext,
+  prefilledEntries: Record<string, string>,
 ) {
   "use step";
 
@@ -75,12 +79,23 @@ async function runTranslationStep(
   );
   await writeTempConfig(sandboxId, config, configPath);
 
+  const prefilledPath = `/tmp/hyperlocalise-prefilled-${targetLocale}.json`;
+  let prefilledFlags = "";
+  if (Object.keys(prefilledEntries).length > 0) {
+    await writeFileToSandbox(
+      sandboxId,
+      prefilledPath,
+      Buffer.from(JSON.stringify(prefilledEntries), "utf8"),
+    );
+    prefilledFlags = ` --prefilled-entries '${shellSingleQuote(prefilledPath)}' --prefilled-target-path '${shellSingleQuote(outputFile)}'`;
+  }
+
   return runSandboxCommand(
     sandboxId,
     "bash",
     [
       "-lc",
-      `export PATH="$HOME/.local/bin:$PATH"; hl run --config '${shellSingleQuote(configPath)}' --locale '${shellSingleQuote(targetLocale)}' --force --progress off`,
+      `export PATH="$HOME/.local/bin:$PATH"; hl run --config '${shellSingleQuote(configPath)}' --locale '${shellSingleQuote(targetLocale)}' --force --progress off${prefilledFlags}`,
     ],
     {
       env: getSandboxTranslationEnv(),
@@ -348,6 +363,24 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
 
     for (const targetLocale of parsedInput.targetLocales) {
       const outputFilename = getSandboxOutputFilename(sourceFile.filename, targetLocale);
+      let reusedEntries: Record<string, string> = {};
+      if (sourceEntries) {
+        reusedEntries = await reuseFileTranslationMemoryEntries({
+          projectId: claim.job.projectId,
+          sourceLocale: parsedInput.sourceLocale,
+          targetLocale,
+          sourceEntries,
+        });
+        if (Object.keys(reusedEntries).length > 0) {
+          console.info("[file-translation-workflow] matched reusable translation memory entries", {
+            jobId: claim.job.id,
+            projectId: claim.job.projectId,
+            targetLocale,
+            reusedEntryCount: Object.keys(reusedEntries).length,
+            sourceEntryCount: Object.keys(sourceEntries).length,
+          });
+        }
+      }
       const localeContext = context.glossaryTerms
         ? {
             ...context,
@@ -365,6 +398,7 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
         targetLocale,
         instructions,
         localeContext,
+        reusedEntries,
       );
 
       if (translation.exitCode !== 0) {

--- a/apps/hyperlocalise-web/src/workflows/steps/translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/translation-job.ts
@@ -12,6 +12,10 @@ import {
   failTranslationJob,
   type ClaimedTranslationJob,
 } from "@/lib/translation/translation-job-queued-function";
+import {
+  persistFileTranslationMemoryEntries,
+  reuseFileTranslationMemoryEntries,
+} from "@/lib/translation/file-translation-memory";
 import type { TranslationJobEventData } from "@/lib/workflow/types";
 
 export async function claimTranslationJobStep(input: {
@@ -288,6 +292,30 @@ export async function storeOutputFileStep(input: {
     await del(uploaded.pathname, { token: env.BLOB_READ_WRITE_TOKEN });
     throw error;
   }
+}
+
+export async function reuseFileTranslationMemoryEntriesStep(input: {
+  projectId: string;
+  sourceLocale: string;
+  targetLocale: string;
+  sourceEntries: Record<string, string>;
+}) {
+  "use step";
+  return reuseFileTranslationMemoryEntries(input);
+}
+
+export async function persistFileTranslationMemoryEntriesStep(input: {
+  projectId: string;
+  jobId: string;
+  sourceLocale: string;
+  targetLocale: string;
+  sourcePath: string;
+  sourceFileHash: string;
+  sourceEntries: Record<string, string>;
+  targetEntries: Record<string, string>;
+}) {
+  "use step";
+  return persistFileTranslationMemoryEntries(input);
 }
 
 export async function completeFileTranslationJobStep(input: {


### PR DESCRIPTION
### Motivation

- Allow pre-populating translation outputs from external sources (e.g. file TM reuse) so the run orchestrator can stage outputs and avoid re-translating entries. 
- Enable the file translation workflow to discover reusable TM matches and inject them into CLI-run invocations for per-file prefill behavior.

### Description

- CLI: added `--prefilled-entries` and `--prefilled-target-path` flags to `hl run`, plus `loadPrefilledEntries` to securely parse a JSON map of `entryId -> text` (decoder uses `DisallowUnknownFields` and verifies no trailing data) and validate that a target path is provided when entries are present. 
- Run service: extended `Input` with `PrefilledEntries` and `PrefilledTargetPath`, and integrated `applyPrefilledEntries` which stages outputs for matching tasks (by cleaned `TargetPath` and `EntryKey`), skips image tasks, counts reused entries, and returns errors on staging failure. The orchestrator increments `SkippedByLock` and appends a warning when entries are reused. 
- Web app: added `sourceTextHash` (SHA-256) to persisted TM metadata, implemented `reuseFileTranslationMemoryEntries` to prefer TM matches that match `normalizedSourceText`, `segmentKey`, `sourceTextHash`, and `targetLocale`, and updated `file-translation-job` to collect reused entries and pass them to the sandbox via temporary `--prefilled-entries`/`--prefilled-target-path` flags. 
- Misc: updated imports/usages and ensured safe filepath cleaning and string trimming during matching and staging.

### Testing

- Ran the Go unit/integration test suite with `go test ./...` for CLI and runsvc, and the TypeScript checks and tests with the workspace test command (`pnpm -w test`); all tests and type checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ef0f5e370832c8b72ab6e44340b0b)