### PR TITLE
⚡ Bolt: optimize segment key and placeholder generation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -43,3 +43,7 @@
 ## 2026-06-10 - Optimizing recursive JSON marshaling
 **Learning:** Similar to `flattenJSON` in the parser, using `fmt.Sprintf` for key construction in recursive JSON rewriting (e.g., `rewriteJSONArray`) adds significant allocation and formatting overhead. String concatenation with `strconv.Itoa` is a much more efficient alternative for these hot paths.
 **Action:** Replaced `fmt.Sprintf("%s[%d]", ...)` with manual concatenation in `internal/i18n/translationfileparser/json_marshal.go`.
+
+## 2026-06-12 - Optimizing segment key and placeholder generation across parsers
+**Learning:** Hot paths in parser logic, such as segment key generation, hashing for placeholders, and path construction, accumulate significant overhead when using `fmt.Sprintf`. String concatenation combined with `strconv.Itoa` is a much more efficient alternative, reducing reflection and formatting costs.
+**Action:** Replaced `fmt.Sprintf` with concatenation and `strconv.Itoa` in `html_parser.go`, `markdown_parser.go`, `liquid_parser.go`, and `markdown_mdx_parser.go`.

--- a/code_review_request.md
+++ b/code_review_request.md
@@ -1,3 +1,0 @@
-Optimized segment key and placeholder generation in HTML, Markdown, Liquid, and MDX parsers.
-Replaced `fmt.Sprintf` with string concatenation and `strconv.Itoa` in hot paths (segment key generation, hashing, placeholder token creation, and MDX path generation).
-This follows existing optimization patterns in the codebase (`json_parser.go`, `json_marshal.go`) to reduce reflection and formatting overhead, leading to fewer allocations and faster execution.

--- a/code_review_request.md
+++ b/code_review_request.md
@@ -1,0 +1,3 @@
+Optimized segment key and placeholder generation in HTML, Markdown, Liquid, and MDX parsers.
+Replaced `fmt.Sprintf` with string concatenation and `strconv.Itoa` in hot paths (segment key generation, hashing, placeholder token creation, and MDX path generation).
+This follows existing optimization patterns in the codebase (`json_parser.go`, `json_marshal.go`) to reduce reflection and formatting overhead, leading to fewer allocations and faster execution.

--- a/internal/i18n/translationfileparser/html_parser.go
+++ b/internal/i18n/translationfileparser/html_parser.go
@@ -5,10 +5,10 @@ package translationfileparser
 // so that the LLM translates clean prose while the markup is restored on marshal.
 
 import (
+	"strconv"
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
-	"fmt"
 	"io"
 	"regexp"
 	"strings"
@@ -283,8 +283,9 @@ func protectHTMLInlineSyntax(segment string) (string, map[string]string, string,
 	placeholderCount := 0
 
 	appendPlaceholder := func(literal string) string {
-		sum := sha256.Sum256([]byte(fmt.Sprintf("%d:%s", placeholderCount, literal)))
-		ph := fmt.Sprintf("\x1eHLHTPH_%s_%d\x1f", strings.ToUpper(hex.EncodeToString(sum[:])[:12]), placeholderCount)
+		// BOLT OPTIMIZATION: Use string concatenation and strconv.Itoa instead of fmt.Sprintf
+		sum := sha256.Sum256([]byte(strconv.Itoa(placeholderCount) + ":" + literal))
+		ph := "\x1eHLHTPH_" + strings.ToUpper(hex.EncodeToString(sum[:])[:12]) + "_" + strconv.Itoa(placeholderCount) + "\x1f"
 		placeholderCount++
 		placeholders[ph] = literal
 		return ph
@@ -315,9 +316,10 @@ func htmlSegmentKey(segment string, occurrences map[string]int) string {
 	count := occurrences[hash]
 	occurrences[hash] = count + 1
 	if count == 0 {
-		return fmt.Sprintf("html.%s", hash)
+		// BOLT OPTIMIZATION: Use string concatenation and strconv.Itoa instead of fmt.Sprintf
+		return "html." + hash
 	}
-	return fmt.Sprintf("html.%s.%d", hash, count+1)
+	return "html." + hash + "." + strconv.Itoa(count+1)
 }
 
 // expandHTMLPlaceholders replaces sentinel tokens in rendered with their original

--- a/internal/i18n/translationfileparser/html_parser.go
+++ b/internal/i18n/translationfileparser/html_parser.go
@@ -5,12 +5,12 @@ package translationfileparser
 // so that the LLM translates clean prose while the markup is restored on marshal.
 
 import (
-	"strconv"
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"io"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"golang.org/x/net/html"

--- a/internal/i18n/translationfileparser/liquid_parser.go
+++ b/internal/i18n/translationfileparser/liquid_parser.go
@@ -1,13 +1,13 @@
 package translationfileparser
 
 import (
-	"strconv"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"html"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 	"unicode"
 )

--- a/internal/i18n/translationfileparser/liquid_parser.go
+++ b/internal/i18n/translationfileparser/liquid_parser.go
@@ -1,6 +1,7 @@
 package translationfileparser
 
 import (
+	"strconv"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -234,8 +235,9 @@ func appendLiquidBoundaryPlaceholder(literal string, placeholders map[string]str
 }
 
 func liquidPlaceholderToken(index int, literal string) string {
-	sum := sha256.Sum256([]byte(fmt.Sprintf("%d:%s", index, literal)))
-	return fmt.Sprintf("\x1eHLLQPH_%s_%d\x1f", strings.ToUpper(hex.EncodeToString(sum[:])[:12]), index)
+	// BOLT OPTIMIZATION: Use string concatenation and strconv.Itoa instead of fmt.Sprintf
+	sum := sha256.Sum256([]byte(strconv.Itoa(index) + ":" + literal))
+	return "\x1eHLLQPH_" + strings.ToUpper(hex.EncodeToString(sum[:])[:12]) + "_" + strconv.Itoa(index) + "\x1f"
 }
 
 func updateLiquidHTMLTagState(input string, index int, ch byte, inHTMLTag *bool, htmlQuote *byte) {
@@ -386,9 +388,10 @@ func liquidSegmentKey(segment string, occurrences map[string]int) string {
 	count := occurrences[hash]
 	occurrences[hash] = count + 1
 	if count == 0 {
-		return fmt.Sprintf("liquid.%s", hash)
+		// BOLT OPTIMIZATION: Use string concatenation and strconv.Itoa instead of fmt.Sprintf
+		return "liquid." + hash
 	}
-	return fmt.Sprintf("liquid.%s.%d", hash, count+1)
+	return "liquid." + hash + "." + strconv.Itoa(count+1)
 }
 
 func (d liquidDocument) render(values map[string]string) ([]byte, LiquidRenderDiagnostics) {

--- a/internal/i18n/translationfileparser/markdown_mdx_parser.go
+++ b/internal/i18n/translationfileparser/markdown_mdx_parser.go
@@ -1,7 +1,7 @@
 package translationfileparser
 
 import (
-	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -163,7 +163,8 @@ func (s *mdxPathState) nextTextPath(line string, stack []mdxContainer) string {
 	base += "/" + mdxLineKind(line)
 	ordinal := s.textOrdinals[base]
 	s.textOrdinals[base] = ordinal + 1
-	return fmt.Sprintf("%s/text[%d]", base, ordinal)
+	// BOLT OPTIMIZATION: Use string concatenation and strconv.Itoa instead of fmt.Sprintf
+	return base + "/text[" + strconv.Itoa(ordinal) + "]"
 }
 
 func mdxLineKind(line string) string {

--- a/internal/i18n/translationfileparser/markdown_parser.go
+++ b/internal/i18n/translationfileparser/markdown_parser.go
@@ -3,7 +3,6 @@ package translationfileparser
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"fmt"
 	"math"
 	"regexp"
 	"slices"
@@ -98,9 +97,10 @@ func markdownSegmentKey(segment string, occurrences map[string]int) string {
 	count := occurrences[hash]
 	occurrences[hash] = count + 1
 	if count == 0 {
-		return fmt.Sprintf("md.%s", hash)
+		// BOLT OPTIMIZATION: Use string concatenation and strconv.Itoa instead of fmt.Sprintf
+		return "md." + hash
 	}
-	return fmt.Sprintf("md.%s.%d", hash, count+1)
+	return "md." + hash + "." + strconv.Itoa(count+1)
 }
 
 func emitMarkdownLineParts(line string, doc *markdownDocument, appendKey func(markdownPart), state *markdownParseState, path string) {
@@ -314,8 +314,9 @@ func protectMarkdownInlineSyntax(segment string) (string, map[string]string, str
 	placeholderCount := 0
 
 	appendPlaceholder := func(literal string) {
-		sum := sha256.Sum256([]byte(fmt.Sprintf("%d:%s", placeholderCount, literal)))
-		placeholder := fmt.Sprintf("\x1eHLMDPH_%s_%d\x1f", strings.ToUpper(hex.EncodeToString(sum[:])[:12]), placeholderCount)
+		// BOLT OPTIMIZATION: Use string concatenation and strconv.Itoa instead of fmt.Sprintf
+		sum := sha256.Sum256([]byte(strconv.Itoa(placeholderCount) + ":" + literal))
+		placeholder := "\x1eHLMDPH_" + strings.ToUpper(hex.EncodeToString(sum[:])[:12]) + "_" + strconv.Itoa(placeholderCount) + "\x1f"
 		placeholderCount++
 		// Placeholder sentinels are exposed through Parse() and must survive translation
 		// round-trips so renderMarkdownPart can restore protected markdown/JSX literals.


### PR DESCRIPTION
Optimized the segment key and placeholder generation in HTML, Markdown, Liquid, and MDX parsers by replacing \`fmt.Sprintf\` with string concatenation and \`strconv.Itoa\` in hot paths.

This change reduces reflection and formatting overhead during document parsing, leading to fewer allocations and faster execution. This follows established optimization patterns in the codebase's JSON parsers.

Impact:
- Reduced allocation overhead in parser hot paths.
- Faster segment key and placeholder generation.

Verified with existing tests in \`internal/i18n/translationfileparser\`.

---
*PR created automatically by Jules for task [1848272994502090964](https://jules.google.com/task/1848272994502090964) started by @cungminh2710*