### PR TITLE
feat(file-jobs): harden glossary validation and retry for file translation jobs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,8 @@
 
 ## Before Finalizing
 
+If we change Go code:
+
 - Run `make fmt`.
 - Run `make lint`.
 - Run `make test`.

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
@@ -22,7 +22,11 @@ vi.mock("@vercel/sandbox", () => ({
   },
 }));
 
-import { buildTempConfig, runSandboxCommand } from "@/lib/translation/sandbox-translation";
+import {
+  buildTempConfig,
+  runSandboxCommand,
+  userFacingFailureReason,
+} from "@/lib/translation/sandbox-translation";
 
 describe("sandbox command runner", () => {
   beforeEach(() => {
@@ -108,5 +112,25 @@ describe("sandbox translation temporary config", () => {
     expect(config).toContain("system_prompt:");
     expect(config).not.toContain("Project translation context:");
     expect(config).not.toContain("Glossary terms:");
+  });
+});
+
+describe("sandbox translation failure reasons", () => {
+  it("preserves glossary validation diagnostics for persisted job failures", () => {
+    const diagnostics = {
+      targetLocale: "fr-FR",
+      failedTermCount: 1,
+      failures: [
+        {
+          sourceTerm: "workspace",
+          targetTerm: "espace de travail",
+          forbidden: false,
+          reason: "missing_preferred_term",
+        },
+      ],
+    };
+    const message = `glossary validation failed: ${JSON.stringify(diagnostics)}`;
+
+    expect(userFacingFailureReason(new Error(message))).toBe(message);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.ts
@@ -13,6 +13,7 @@ export type SandboxTranslationContext = {
     targetTerm: string;
     targetLocale: string;
     forbidden?: boolean | null;
+    caseSensitive?: boolean | null;
     description?: string | null;
   }>;
 };

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.ts
@@ -226,6 +226,10 @@ export function getSandboxOutputFilename(attachmentFilename: string, targetLocal
 export function userFacingFailureReason(error: unknown): string {
   const message = error instanceof Error ? error.message : "Unknown translation failure";
 
+  if (message.startsWith("glossary validation failed")) {
+    return message;
+  }
+
   if (message.includes("hyperlocalise CLI installation failed")) {
     return "something went wrong while setting up the translation environment on our end.";
   }

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.test.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.test.ts
@@ -50,4 +50,46 @@ describe("validateGlossaryTermsInTranslation", () => {
       },
     ]);
   });
+
+  it("ignores terms with no configured constraint", () => {
+    const failures = validateGlossaryTermsInTranslation({
+      sourceText: "Click the workspace settings.",
+      translatedText: "Cliquez sur les paramètres.",
+      terms: [
+        {
+          sourceTerm: "workspace",
+          targetTerm: "espace de travail",
+          targetLocale: "fr-FR",
+          forbidden: null,
+        },
+      ],
+    });
+
+    expect(failures).toEqual([]);
+  });
+
+  it("respects case-sensitive glossary matching", () => {
+    const failures = validateGlossaryTermsInTranslation({
+      sourceText: "Use API credentials.",
+      translatedText: "Utilisez api credentials.",
+      terms: [
+        {
+          sourceTerm: "API",
+          targetTerm: "API",
+          targetLocale: "fr-FR",
+          forbidden: false,
+          caseSensitive: true,
+        },
+      ],
+    });
+
+    expect(failures).toEqual([
+      {
+        sourceTerm: "API",
+        targetTerm: "API",
+        forbidden: false,
+        reason: "missing_preferred_term",
+      },
+    ]);
+  });
 });

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.test.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { validateGlossaryTermsInTranslation } from "./file-translation-job";
+
+describe("validateGlossaryTermsInTranslation", () => {
+  it("includes approved preferred terms only when source term appears", () => {
+    const failures = validateGlossaryTermsInTranslation({
+      sourceText: "Welcome to Hyperlocalise.",
+      translatedText: "Bienvenue.",
+      terms: [
+        {
+          sourceTerm: "Hyperlocalise",
+          targetTerm: "Hyperlocalise",
+          targetLocale: "fr-FR",
+          forbidden: false,
+        },
+      ],
+    });
+
+    expect(failures).toEqual([
+      {
+        sourceTerm: "Hyperlocalise",
+        targetTerm: "Hyperlocalise",
+        forbidden: false,
+        reason: "missing_preferred_term",
+      },
+    ]);
+  });
+
+  it("flags forbidden target terms", () => {
+    const failures = validateGlossaryTermsInTranslation({
+      sourceText: "Click the workspace settings.",
+      translatedText: "Cliquez sur les paramètres de workspace.",
+      terms: [
+        {
+          sourceTerm: "workspace",
+          targetTerm: "workspace",
+          targetLocale: "fr-FR",
+          forbidden: true,
+        },
+      ],
+    });
+
+    expect(failures).toEqual([
+      {
+        sourceTerm: "workspace",
+        targetTerm: "workspace",
+        forbidden: true,
+        reason: "contains_forbidden_term",
+      },
+    ]);
+  });
+});

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -158,7 +158,7 @@ type GlossaryTermConstraint = {
   targetTerm: string;
   targetLocale: string;
   forbidden: boolean | null;
-  caseSensitive?: boolean;
+  caseSensitive?: boolean | null;
 };
 
 type GlossaryValidationFailure = {
@@ -182,13 +182,13 @@ export function validateGlossaryTermsInTranslation(input: {
   const failures: GlossaryValidationFailure[] = [];
 
   for (const term of input.terms) {
-    const caseSensitive = term.caseSensitive ?? false;
+    const caseSensitive = term.caseSensitive === true;
     if (!sourceContainsTerm(input.sourceText, { sourceTerm: term.sourceTerm, caseSensitive })) {
       continue;
     }
 
     const hasTarget = translationContainsTerm(input.translatedText, term.targetTerm, caseSensitive);
-    if (term.forbidden) {
+    if (term.forbidden === true) {
       if (hasTarget) {
         failures.push({
           sourceTerm: term.sourceTerm,
@@ -200,7 +200,7 @@ export function validateGlossaryTermsInTranslation(input: {
       continue;
     }
 
-    if (!hasTarget) {
+    if (term.forbidden === false && !hasTarget) {
       failures.push({
         sourceTerm: term.sourceTerm,
         targetTerm: term.targetTerm,
@@ -266,12 +266,13 @@ async function assembleFileTranslationContextStep(input: {
   const glossaryTerms = attachedTerms
     .filter((term) => sourceContainsTerm(sourceText, term))
     .slice(0, 50)
-    .map(({ sourceTerm, targetTerm, targetLocale, description, forbidden }) => ({
+    .map(({ sourceTerm, targetTerm, targetLocale, description, forbidden, caseSensitive }) => ({
       sourceTerm,
       targetTerm,
       targetLocale,
       description,
       forbidden,
+      caseSensitive,
     }));
 
   const context = {
@@ -419,6 +420,8 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
       });
     }
 
+    const sourceText = sourceContent.toString("utf8");
+
     for (const targetLocale of parsedInput.targetLocales) {
       const outputFilename = getSandboxOutputFilename(sourceFile.filename, targetLocale);
       let reusedEntries: Record<string, string> = {};
@@ -448,7 +451,6 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
           }
         : context;
 
-      const sourceText = sourceContent.toString("utf8");
       const runTranslationWithValidation = async (attempt: 1 | 2, retryFeedback?: string) => {
         const translation = await runTranslationStep(
           sandboxId,
@@ -475,6 +477,7 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
             targetTerm: term.targetTerm,
             targetLocale: term.targetLocale,
             forbidden: term.forbidden,
+            caseSensitive: term.caseSensitive,
           })),
         });
 

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -114,7 +114,7 @@ async function extractEntriesStep(sandboxId: string, path: string) {
   }
   return JSON.parse(result.output) as Record<string, string>;
 }
-async function readOutputStep(sandboxId: string, outputFile: string) {
+async function readOutputStep(sandboxId: string, outputFile: string, _attempt: 1 | 2) {
   "use step";
   return readTranslatedFile(sandboxId, outputFile);
 }
@@ -467,7 +467,7 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
           throw new Error(`translation failed for ${targetLocale}: ${translation.output}`);
         }
 
-        const translatedContent = await readOutputStep(sandboxId, outputFilename);
+        const translatedContent = await readOutputStep(sandboxId, outputFilename, attempt);
         const translatedText = translatedContent.toString("utf8");
         const glossaryFailures = validateGlossaryTermsInTranslation({
           sourceText,

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -153,6 +153,66 @@ function sourceContainsTerm(
   return sourceText.toLocaleLowerCase().includes(term.sourceTerm.toLocaleLowerCase());
 }
 
+type GlossaryTermConstraint = {
+  sourceTerm: string;
+  targetTerm: string;
+  targetLocale: string;
+  forbidden: boolean | null;
+  caseSensitive?: boolean;
+};
+
+type GlossaryValidationFailure = {
+  sourceTerm: string;
+  targetTerm: string;
+  forbidden: boolean;
+  reason: "missing_preferred_term" | "contains_forbidden_term";
+};
+
+function translationContainsTerm(text: string, term: string, caseSensitive: boolean) {
+  return caseSensitive
+    ? text.includes(term)
+    : text.toLocaleLowerCase().includes(term.toLocaleLowerCase());
+}
+
+export function validateGlossaryTermsInTranslation(input: {
+  sourceText: string;
+  translatedText: string;
+  terms: GlossaryTermConstraint[];
+}) {
+  const failures: GlossaryValidationFailure[] = [];
+
+  for (const term of input.terms) {
+    const caseSensitive = term.caseSensitive ?? false;
+    if (!sourceContainsTerm(input.sourceText, { sourceTerm: term.sourceTerm, caseSensitive })) {
+      continue;
+    }
+
+    const hasTarget = translationContainsTerm(input.translatedText, term.targetTerm, caseSensitive);
+    if (term.forbidden) {
+      if (hasTarget) {
+        failures.push({
+          sourceTerm: term.sourceTerm,
+          targetTerm: term.targetTerm,
+          forbidden: true,
+          reason: "contains_forbidden_term",
+        });
+      }
+      continue;
+    }
+
+    if (!hasTarget) {
+      failures.push({
+        sourceTerm: term.sourceTerm,
+        targetTerm: term.targetTerm,
+        forbidden: false,
+        reason: "missing_preferred_term",
+      });
+    }
+  }
+
+  return failures;
+}
+
 async function assembleFileTranslationContextStep(input: {
   jobId: string;
   projectId: string;
@@ -388,22 +448,61 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
           }
         : context;
 
-      const translation = await runTranslationStep(
-        sandboxId,
-        inputFilename,
-        outputFilename,
-        parsedInput.sourceLocale,
-        targetLocale,
-        instructions,
-        localeContext,
-        reusedEntries,
-      );
+      const sourceText = sourceContent.toString("utf8");
+      const runTranslationWithValidation = async (attempt: 1 | 2, retryFeedback?: string) => {
+        const translation = await runTranslationStep(
+          sandboxId,
+          inputFilename,
+          outputFilename,
+          parsedInput.sourceLocale,
+          targetLocale,
+          retryFeedback ? [instructions, retryFeedback].filter(Boolean).join("\n\n") : instructions,
+          localeContext,
+          reusedEntries,
+        );
 
-      if (translation.exitCode !== 0) {
-        throw new Error(`translation failed for ${targetLocale}: ${translation.output}`);
-      }
+        if (translation.exitCode !== 0) {
+          throw new Error(`translation failed for ${targetLocale}: ${translation.output}`);
+        }
 
-      const translatedContent = await readOutputStep(sandboxId, outputFilename);
+        const translatedContent = await readOutputStep(sandboxId, outputFilename);
+        const translatedText = translatedContent.toString("utf8");
+        const glossaryFailures = validateGlossaryTermsInTranslation({
+          sourceText,
+          translatedText,
+          terms: (localeContext.glossaryTerms ?? []).map((term) => ({
+            sourceTerm: term.sourceTerm,
+            targetTerm: term.targetTerm,
+            targetLocale: term.targetLocale,
+            forbidden: term.forbidden,
+          })),
+        });
+
+        if (glossaryFailures.length > 0 && attempt === 1) {
+          const feedback = [
+            `Glossary validation failed for locale ${targetLocale}. Fix these term constraints exactly and regenerate:`,
+            ...glossaryFailures.map((failure) =>
+              failure.forbidden
+                ? `- Forbidden term violation for source "${failure.sourceTerm}": do not use "${failure.targetTerm}"`
+                : `- Missing preferred term for source "${failure.sourceTerm}": must include "${failure.targetTerm}"`,
+            ),
+          ].join("\n");
+          return runTranslationWithValidation(2, feedback);
+        }
+
+        if (glossaryFailures.length > 0) {
+          const diagnostics = {
+            targetLocale,
+            failedTermCount: glossaryFailures.length,
+            failures: glossaryFailures,
+          };
+          throw new Error(`glossary validation failed: ${JSON.stringify(diagnostics)}`);
+        }
+
+        return translatedContent;
+      };
+
+      const translatedContent = await runTranslationWithValidation(1);
       await logDiagnosticsStep(
         claim.job.id,
         sourceFile.filename,


### PR DESCRIPTION
### Motivation

- Ensure the existing glossary system is used as constraints for file translation jobs so approved terms influence AI output and violations are detected.
- Provide clear, actionable diagnostics when glossary constraints are violated so jobs can either be retried with feedback or marked failed for operator attention.

### Description

- Add `validateGlossaryTermsInTranslation` with `GlossaryTermConstraint` and `GlossaryValidationFailure` types to check preferred and forbidden glossary terms in translated output. 
- Introduce `translationContainsTerm` helper and integrate glossary validation into `fileTranslationJobWorkflow` to run post-translation checks. 
- Implement a one-attempt retry path that reinvokes `runTranslationStep` with explicit glossary feedback injected into the instructions when validation fails, and throw structured diagnostics if the second attempt still violates constraints. 
- Persist the assembled glossary context snapshot to the job (existing `assembleFileTranslationContextStep` is used) and log diagnostics via `logTranslatedFileDiagnostics`. 
- Add focused unit tests in `apps/hyperlocalise-web/src/workflows/file-translation-job.test.ts` that cover a missing preferred-term case and a forbidden-term violation. 

### Testing

- Ran `make fmt` which completed successfully. 
- Ran `make lint` which failed in this environment due to a missing `golangci-lint` binary. 
- Started `make test` (Go test runner) but the full test run did not complete within the session time window. 
- Attempted frontend checks with `vp check --fix` which failed because `vp` is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f05b9e0a0832cbed8a25d33e66cc9)