### PR TITLE
⚡ Bolt: Optimize Markdown segment and placeholder generation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -51,3 +51,7 @@
 ## 2026-05-21 - Optimizing ICU block formatting
 **Learning:** Using `fmt.Sprintf` with the reflection-based `%v` verb inside a loop to format complex structs (like `BlockSignature`) is a major performance bottleneck. Manual formatting with `strings.Builder` and `strconv.Itoa` avoids reflection and significantly reduces allocations.
 **Action:** Replaced `fmt.Sprintf` with manual formatting in `FormatICUBlocks`, resulting in a ~6.6x speedup and ~72% fewer allocations.
+
+## 2026-06-15 - Optimizing Markdown segment and placeholder generation
+**Learning:** Hot paths in Markdown parsing, such as frontmatter path generation, table row pathing, and placeholder hashing, benefit significantly from replacing `fmt.Sprintf` with string concatenation and `strconv.Itoa`. This reduces reflection overhead and allocations in paths that may be called thousands of times for large documents.
+**Action:** Replaced `fmt.Sprintf` with concatenation and `strconv.Itoa` in `internal/i18n/translationfileparser/markdown_md_parser.go`.

--- a/internal/i18n/translationfileparser/markdown_md_parser.go
+++ b/internal/i18n/translationfileparser/markdown_md_parser.go
@@ -3,7 +3,6 @@ package translationfileparser
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"fmt"
 	"slices"
 	"sort"
 	"strconv"
@@ -152,7 +151,7 @@ func collectFrontmatterCandidates(content []byte) ([]markdownSpanCandidate, int)
 				candidates = append(candidates, markdownSpanCandidate{
 					start:     valueStart,
 					stop:      valueEnd,
-					path:      fmt.Sprintf("frontmatter/%s", key),
+					path:      "frontmatter/" + key, // BOLT OPTIMIZATION: Use string concatenation instead of fmt.Sprintf
 					yamlPlain: true,
 				})
 			}
@@ -171,7 +170,7 @@ func collectFrontmatterCandidates(content []byte) ([]markdownSpanCandidate, int)
 		candidates = append(candidates, markdownSpanCandidate{
 			start: start,
 			stop:  stop,
-			path:  fmt.Sprintf("frontmatter/%s", key),
+			path:  "frontmatter/" + key, // BOLT OPTIMIZATION: Use string concatenation instead of fmt.Sprintf
 		})
 		offset += len(line)
 	}
@@ -238,7 +237,7 @@ func appendTableCandidates(out *[]markdownSpanCandidate, seen map[string]struct{
 			}
 		case *extast.TableRow:
 			if start, stop, ok := markdownTableRowSpan(typed, content, baseOffset); ok {
-				appendMarkdownCandidate(out, seen, start, stop, fmt.Sprintf("%s/row[%d]", markdownNodePath(table, 0), rowIndex))
+				appendMarkdownCandidate(out, seen, start, stop, markdownNodePath(table, 0)+"/row["+strconv.Itoa(rowIndex)+"]") // BOLT OPTIMIZATION: Use string concatenation and strconv.Itoa instead of fmt.Sprintf
 			}
 			rowIndex++
 		}
@@ -276,7 +275,7 @@ func appendMarkdownCandidate(out *[]markdownSpanCandidate, seen map[string]struc
 	if stop <= start {
 		return
 	}
-	key := fmt.Sprintf("%d:%d", start, stop)
+	key := strconv.Itoa(start) + ":" + strconv.Itoa(stop) // BOLT OPTIMIZATION: Use string concatenation and strconv.Itoa instead of fmt.Sprintf
 	if _, ok := seen[key]; ok {
 		return
 	}
@@ -462,10 +461,10 @@ func isHTMLTagNameChar(ch byte) bool {
 }
 
 func markdownPlaceholderToken(idx int, literal string) string {
-	return fmt.Sprintf("\x1eHLMDPH_%s_%d\x1f", strings.ToUpper(markdownPlaceholderHash(idx, literal)), idx)
+	return "\x1eHLMDPH_" + strings.ToUpper(markdownPlaceholderHash(idx, literal)) + "_" + strconv.Itoa(idx) + "\x1f" // BOLT OPTIMIZATION: Use string concatenation and strconv.Itoa instead of fmt.Sprintf
 }
 
 func markdownPlaceholderHash(idx int, literal string) string {
-	sum := sha256.Sum256([]byte(fmt.Sprintf("%d:%s", idx, literal)))
+	sum := sha256.Sum256([]byte(strconv.Itoa(idx) + ":" + literal)) // BOLT OPTIMIZATION: Use string concatenation and strconv.Itoa instead of fmt.Sprintf
 	return hex.EncodeToString(sum[:])[:12]
 }


### PR DESCRIPTION
💡 What: Replaced all `fmt.Sprintf` calls in `internal/i18n/translationfileparser/markdown_md_parser.go` with string concatenation and `strconv.Itoa`.
🎯 Why: `fmt.Sprintf` is expensive in hot paths due to reflection and formatting overhead. For simple integer-to-string conversions and fixed-pattern paths, concatenation is significantly more efficient.
📊 Impact: Reduces allocation overhead in document parsing loops, especially for large documents with many translatable segments or placeholders.
🔬 Measurement: Verified that all unit tests in `internal/i18n/translationfileparser` pass.

---
*PR created automatically by Jules for task [3969972897459164652](https://jules.google.com/task/3969972897459164652) started by @cungminh2710*