### PR TITLE
HL-325: Add PHP array locale parser and serializer support

### DIFF
--- a/apps/cli/cmd/check_test.go
+++ b/apps/cli/cmd/check_test.go
@@ -55,6 +55,53 @@ func TestCheckCommandNoFindings(t *testing.T) {
 	}
 }
 
+func TestCheckCommandPHPArrayLocaleNoFindings(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "i18n.jsonc")
+	sourcePath := filepath.Join(dir, "resources", "lang", "en", "messages.php")
+	targetPath := filepath.Join(dir, "resources", "lang", "fr", "messages.php")
+
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
+		t.Fatalf("create source dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		t.Fatalf("create target dir: %v", err)
+	}
+	source := `<?php
+return [
+    'auth' => ['failed' => 'These credentials do not match our records.'],
+    'welcome' => 'Welcome, :name!',
+];
+`
+	target := `<?php
+return [
+    'auth' => ['failed' => 'Ces identifiants ne correspondent pas a nos dossiers.'],
+    'welcome' => 'Bienvenue, :name!',
+];
+`
+	if err := os.WriteFile(sourcePath, []byte(source), 0o600); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+	if err := os.WriteFile(targetPath, []byte(target), 0o600); err != nil {
+		t.Fatalf("write target file: %v", err)
+	}
+
+	writeCheckConfig(t, configPath, sourcePath, targetPath, []string{"fr"})
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"check", "--config", configPath})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("check command without findings: %v", err)
+	}
+	if !strings.Contains(out.String(), "No problems.") {
+		t.Fatalf("expected no-findings stylish output, got %q", out.String())
+	}
+}
+
 func TestCheckCommandJSONReportIncludesDefaultFindings(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "i18n.jsonc")

--- a/apps/cli/cmd/run_test.go
+++ b/apps/cli/cmd/run_test.go
@@ -136,6 +136,80 @@ func TestRunDryRunLiquidReportUsesGeneratedLiquidKeys(t *testing.T) {
 	}
 }
 
+func TestRunDryRunPHPArrayReportUsesLocaleKeys(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "i18n.jsonc")
+	reportPath := filepath.Join(dir, "report.json")
+	sourcePath := filepath.Join(dir, "resources", "lang", "en", "messages.php")
+	targetPath := filepath.Join(dir, "resources", "lang", "fr", "messages.php")
+
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
+		t.Fatalf("create source dir: %v", err)
+	}
+	source := `<?php
+
+return [
+    'auth' => [
+        'failed' => 'These credentials do not match our records.',
+    ],
+    'items' => [
+        'one' => ':count item',
+        'other' => ':count items',
+    ],
+];
+`
+	if err := os.WriteFile(sourcePath, []byte(source), 0o600); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+
+	content := `{
+	  "locales": {"source":"en","targets":["fr"]},
+	  "buckets": {"ui":{"files":[{"from":"` + filepath.ToSlash(sourcePath) + `","to":"` + filepath.ToSlash(targetPath) + `"}]}},
+	  "groups": {"default":{"targets":["fr"],"buckets":["ui"]}},
+	  "llm": {"profiles":{"default":{"provider":"openai","model":"gpt-4.1-mini","prompt":"Translate {{input}}"}}}
+	}`
+	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"run", "--config", configPath, "--dry-run", "--output", reportPath, "--output-detail", "full"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("run command php dry-run: %v", err)
+	}
+	if !strings.Contains(out.String(), "dry_run=true") {
+		t.Fatalf("expected dry-run output, got %q", out.String())
+	}
+	if _, err := os.Stat(targetPath); !os.IsNotExist(err) {
+		t.Fatalf("expected no target file written in dry-run, stat err=%v", err)
+	}
+
+	reportContent, err := os.ReadFile(reportPath)
+	if err != nil {
+		t.Fatalf("read run report: %v", err)
+	}
+	var report runsvc.Report
+	if err := json.Unmarshal(reportContent, &report); err != nil {
+		t.Fatalf("decode run report: %v\n%s", err, reportContent)
+	}
+	if report.ExecutableTotal != 3 || len(report.Executable) != 3 {
+		t.Fatalf("expected three PHP tasks, got %+v", report)
+	}
+	keys := map[string]struct{}{}
+	for _, task := range report.Executable {
+		keys[task.EntryKey] = struct{}{}
+	}
+	for _, key := range []string{"auth.failed", "items.one", "items.other"} {
+		if _, ok := keys[key]; !ok {
+			t.Fatalf("expected PHP key %q in report, got %+v", key, report.Executable)
+		}
+	}
+}
+
 func TestRunDryRunWarnsWhenLegacyPromptIsConfigured(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "i18n.jsonc")

--- a/apps/cli/cmd/status_test.go
+++ b/apps/cli/cmd/status_test.go
@@ -299,6 +299,51 @@ func TestStatusCommandBucketFilterUsesLocalstoreNamespace(t *testing.T) {
 	}
 }
 
+func TestStatusCommandPHPArrayLocale(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "i18n.jsonc")
+	sourcePath := filepath.Join(dir, "resources", "lang", "en", "messages.php")
+	targetPath := filepath.Join(dir, "resources", "lang", "fr", "messages.php")
+
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
+		t.Fatalf("mkdir source dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		t.Fatalf("mkdir target dir: %v", err)
+	}
+	source := `<?php return ['auth' => ['failed' => 'These credentials do not match our records.']];`
+	target := `<?php return ['auth' => ['failed' => 'Ces identifiants ne correspondent pas a nos dossiers.']];`
+	if err := os.WriteFile(sourcePath, []byte(source), 0o600); err != nil {
+		t.Fatalf("write source php: %v", err)
+	}
+	if err := os.WriteFile(targetPath, []byte(target), 0o600); err != nil {
+		t.Fatalf("write target php: %v", err)
+	}
+
+	content := `{
+  "locales": {"source":"en","targets":["fr"]},
+  "buckets": {"ui":{"files":[{"from":"` + filepath.ToSlash(sourcePath) + `","to":"` + filepath.ToSlash(filepath.Join(dir, "resources", "lang", "[locale]", "messages.php")) + `"}]}},
+  "groups": {"default":{"targets":["fr"],"buckets":["ui"]}},
+  "llm": {"profiles":{"default":{"provider":"openai","model":"gpt-4.1-mini","prompt":"Translate"}}}
+}`
+	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"status", "--config", configPath})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute status command: %v", err)
+	}
+	if got := out.String(); !strings.Contains(got, "auth.failed") || !strings.Contains(got, ",fr,translated,unknown,") {
+		t.Fatalf("expected PHP locale status row, got: %s", got)
+	}
+}
+
 func TestStatusCommandMarkdownIdenticalSegmentIsSourceMatch(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "i18n.jsonc")

--- a/apps/cli/internal/i18n/runsvc/output_marshal.go
+++ b/apps/cli/internal/i18n/runsvc/output_marshal.go
@@ -15,7 +15,7 @@ import (
 func (s *Service) marshalTargetFile(path, sourcePath, sourceLocale, targetLocale string, values map[string]string, stagedEntries map[string]string, pruneKeys map[string]struct{}) ([]byte, []string, error) {
 	ext := strings.ToLower(filepath.Ext(path))
 	switch ext {
-	case ".xlf", ".xlif", ".xliff", ".po", ".md", ".mdx", ".strings", ".stringsdict", ".csv", ".arb", ".html", ".liquid":
+	case ".xlf", ".xlif", ".xliff", ".po", ".md", ".mdx", ".strings", ".stringsdict", ".csv", ".arb", ".html", ".liquid", ".php":
 		return s.marshalTemplateBasedTarget(ext, path, sourcePath, sourceLocale, targetLocale, values, stagedEntries)
 	case ".json", ".jsonc":
 		content, err := s.marshalJSONTargetWithFallback(path, sourcePath, values, pruneKeys)
@@ -35,7 +35,7 @@ func (s *Service) marshalTemplateBasedTarget(ext, path, sourcePath, sourceLocale
 	if ext == ".liquid" {
 		return s.marshalLiquidTarget(path, sourcePath, stagedEntries)
 	}
-	if ext == ".xlf" || ext == ".xlif" || ext == ".xliff" || ext == ".po" || ext == ".strings" || ext == ".stringsdict" || ext == ".arb" {
+	if ext == ".xlf" || ext == ".xlif" || ext == ".xliff" || ext == ".po" || ext == ".strings" || ext == ".stringsdict" || ext == ".arb" || ext == ".php" {
 		content, err := s.marshalSourceTemplateTarget(ext, path, sourcePath, sourceLocale, targetLocale, values)
 		return content, nil, err
 	}
@@ -105,6 +105,12 @@ func (s *Service) marshalSourceTemplateTarget(ext, path, sourcePath, sourceLocal
 		return content, nil
 	case ".arb":
 		content, err := translationfileparser.MarshalARB(template, sourceTemplate, values, targetLocale)
+		if err != nil {
+			return nil, fmt.Errorf("flush outputs: marshal %q: %w", path, err)
+		}
+		return content, nil
+	case ".php":
+		content, err := translationfileparser.MarshalPHPArrayLocale(template, values)
 		if err != nil {
 			return nil, fmt.Errorf("flush outputs: marshal %q: %w", path, err)
 		}

--- a/apps/cli/internal/i18n/runsvc/service.go
+++ b/apps/cli/internal/i18n/runsvc/service.go
@@ -967,6 +967,8 @@ func parserModeForSource(path string, content []byte) string {
 	switch {
 	case strings.HasSuffix(normalized, ".arb"):
 		return "arb"
+	case strings.HasSuffix(normalized, ".php"):
+		return "php_array"
 	case strings.HasSuffix(normalized, ".json"):
 		if isStrictFormatJSON(content) {
 			return "formatjs"

--- a/apps/cli/internal/i18n/runsvc/service_test.go
+++ b/apps/cli/internal/i18n/runsvc/service_test.go
@@ -2579,6 +2579,77 @@ func TestRunWritesAppleStringsUsingSourceTemplateWhenTargetMissing(t *testing.T)
 	}
 }
 
+func TestRunWritesPHPArrayLocaleUsingSourceTemplateWhenTargetMissing(t *testing.T) {
+	svc := newTestService()
+	sourcePath := "/tmp/source.php"
+	targetPath := "/tmp/out.php"
+	source := `<?php
+
+return [
+    // Authentication copy.
+    'auth' => [
+        'failed' => 'These credentials do not match our records.',
+    ],
+    'items' => [
+        'one' => ':count item',
+        'other' => ':count items',
+    ],
+];
+`
+
+	svc.loadConfig = func(_ string) (*config.I18NConfig, error) {
+		cfg := testConfig(sourcePath, targetPath)
+		return &cfg, nil
+	}
+	svc.readFile = func(path string) ([]byte, error) {
+		switch path {
+		case sourcePath:
+			return []byte(source), nil
+		default:
+			return nil, os.ErrNotExist
+		}
+	}
+	svc.translate = func(_ context.Context, req translator.Request) (string, error) {
+		switch req.Source {
+		case "These credentials do not match our records.":
+			return "Ces identifiants ne correspondent pas a nos dossiers.", nil
+		case ":count item":
+			return ":count element", nil
+		case ":count items":
+			return ":count elements", nil
+		default:
+			t.Fatalf("unexpected translation request: %q", req.Source)
+			return "", nil
+		}
+	}
+
+	var written []byte
+	svc.writeFile = func(path string, content []byte) error {
+		if path != targetPath {
+			t.Fatalf("unexpected write path %q", path)
+		}
+		written = append([]byte(nil), content...)
+		return nil
+	}
+
+	_, err := svc.Run(context.Background(), Input{})
+	if err != nil {
+		t.Fatalf("run execution: %v", err)
+	}
+
+	out := string(written)
+	for _, needle := range []string{
+		"// Authentication copy.",
+		"'failed' => 'Ces identifiants ne correspondent pas a nos dossiers.'",
+		"'one' => ':count element'",
+		"'other' => ':count elements'",
+	} {
+		if !strings.Contains(out, needle) {
+			t.Fatalf("expected PHP output to contain %q, got:\n%s", needle, out)
+		}
+	}
+}
+
 func TestRunWritesAppleStringsWithInsertedKeyWhenExistingTargetPresent(t *testing.T) {
 	svc := newTestService()
 	sourcePath := "/tmp/source.strings"

--- a/docs/commands/run.mdx
+++ b/docs/commands/run.mdx
@@ -34,6 +34,7 @@ For lockfile fields, lifecycle, and reset guidance, see [Lockfile contract](/ref
 - `.strings`
 - `.stringsdict`
 - `.csv`
+- `.php`
 
 For JSON (`.json`), `run` supports:
 
@@ -72,6 +73,23 @@ For Liquid (`.liquid`), `run` translates hardcoded visible template text and pre
 
 For Apple/Xcode Strings (`.strings`), `run` preserves comments and key/value formatting from the template while replacing value literals with translated text.
 
+For PHP locale arrays (`.php`), `run` supports files that consist of a PHP opening tag and a single static return array:
+
+- `return [ ... ];` and `return array(...);` are supported
+- quoted string keys are flattened with dotted paths, such as `auth.failed`
+- string values may use single or double quotes; comments, whitespace, key order, and array syntax are preserved when writing
+- nested arrays can model plural or select variants with keys such as `items.one` and `items.other`
+- executable PHP, variables, function calls, constants, `declare(...)`, and double-quoted interpolation are rejected with a clear parse error
+
+Example config mapping:
+
+```yaml
+buckets:
+  app:
+    files:
+      - from: resources/lang/en/messages.php
+        to: resources/lang/{{target}}/messages.php
+```
 
 For CSV (`.csv`), `run` supports two layouts:
 

--- a/docs/configuration/i18n-config.mdx
+++ b/docs/configuration/i18n-config.mdx
@@ -52,6 +52,21 @@ Each file mapping uses:
 
 Use `{{source}}`, `{{target}}`, and `{{localeDir}}` in templates. `{{localeDir}}` resolves to an empty segment when target equals source, and to the target locale otherwise.
 
+### PHP array locale mapping patterns
+
+Laravel-style locale arrays can be mapped directly when each file returns one static PHP array.
+
+```yaml
+buckets:
+  app:
+    files:
+      - from: resources/lang/en/messages.php
+        to: resources/lang/{{target}}/messages.php
+      - from: resources/lang/en/validation.php
+        to: resources/lang/{{target}}/validation.php
+```
+
+Supported PHP locale files must begin with `<?php` and return a static `[...]` or `array(...)` literal. Hyperlocalise translates string leaves, flattens nested keys with dotted paths, and preserves comments, ordering, and array syntax when writing. Dynamic PHP such as variables, function calls, constants, `declare(...)`, or interpolated double-quoted strings is intentionally rejected.
 
 ### CSV file mapping patterns
 

--- a/internal/i18n/translationfileparser/README.md
+++ b/internal/i18n/translationfileparser/README.md
@@ -135,6 +135,8 @@
 - Supports short arrays (`return [ ... ];`) and legacy arrays (`return array(...);`).
 - Requires quoted string keys and string-literal values; nested arrays are flattened with dotted keys.
   - Example: `['auth' => ['failed' => 'Invalid']]` -> `auth.failed=Invalid`
+- PHP keywords such as `return` and `array` are matched case-insensitively.
+- Double-quoted PHP string escapes are decoded, including byte truncation for octal escapes above `\377`.
 - Preserves comments, whitespace, key order, quote style, and array syntax on marshal by replacing only existing string value literals.
 - Supports plural/select-style variants represented as nested keys such as `items.one` and `items.other`.
 - Rejects executable or dynamic PHP constructs, including variables, function calls, constants, `declare(...)`, and double-quoted interpolation.

--- a/internal/i18n/translationfileparser/README.md
+++ b/internal/i18n/translationfileparser/README.md
@@ -15,10 +15,11 @@
 - `.strings` via `AppleStringsParser` (Apple/Xcode strings files)
 - `.stringsdict` via `AppleStringsdictParser` (Apple/Xcode plural dictionaries)
 - `.csv` via `CSVParser` (key/value and per-locale column layouts)
+- `.php` via `PHPArrayParser` (static PHP locale arrays)
 
 ## Strategy API
 
-- `NewDefaultStrategy()` returns a strategy pre-registered with JSON, XLIFF, PO, Apple Strings, Markdown/MDX, and HTML parsers.
+- `NewDefaultStrategy()` returns a strategy pre-registered with JSON, XLIFF, PO, Apple Strings, Markdown/MDX, HTML, CSV, and PHP array parsers.
 - `Register(ext, parser)` allows adding/replacing parser implementations by extension.
 - `Parse(path, content)` resolves parser by extension and returns `map[string]string`.
 
@@ -100,6 +101,16 @@
 - Validates that every `%#@token@` in `NSStringLocalizedFormatKey` matches a sibling substitution dictionary key.
 - Preserves plural category keys (`zero`, `one`, `two`, `few`, `many`, `other`) as part of flattened key paths.
 - `MarshalAppleStringsdict(template, values)` preserves plist/XML layout and replaces only `<string>` text values.
+
+### PHP Array Locales (`.php`)
+
+- Parses PHP files that begin with `<?php` and return one static array literal.
+- Supports short arrays (`return [ ... ];`) and legacy arrays (`return array(...);`).
+- Requires quoted string keys and string-literal values; nested arrays are flattened with dotted keys.
+  - Example: `['auth' => ['failed' => 'Invalid']]` -> `auth.failed=Invalid`
+- Preserves comments, whitespace, key order, quote style, and array syntax on marshal by replacing only existing string value literals.
+- Supports plural/select-style variants represented as nested keys such as `items.one` and `items.other`.
+- Rejects executable or dynamic PHP constructs, including variables, function calls, constants, `declare(...)`, and double-quoted interpolation.
 
 ## Minimal usage
 

--- a/internal/i18n/translationfileparser/php_array_parser.go
+++ b/internal/i18n/translationfileparser/php_array_parser.go
@@ -339,7 +339,7 @@ func (s *phpArrayScanner) consumeKeyword(keyword string) bool {
 }
 
 func (s *phpArrayScanner) hasKeywordAt(keyword string, pos int) bool {
-	if pos < 0 || pos+len(keyword) > len(s.text) || s.text[pos:pos+len(keyword)] != keyword {
+	if pos < 0 || pos+len(keyword) > len(s.text) || !strings.EqualFold(s.text[pos:pos+len(keyword)], keyword) {
 		return false
 	}
 	beforeOK := pos == 0 || !isPHPIdentifierByte(s.text[pos-1])
@@ -418,7 +418,7 @@ func readPHPOctalEscape(text string, start int) (byte, int, error) {
 		return 0, 0, fmt.Errorf("missing octal digits")
 	}
 	v, err := strconv.ParseUint(text[start:end], 8, 16)
-	if err != nil || v > 0xff {
+	if err != nil {
 		return 0, 0, fmt.Errorf("octal escape out of byte range")
 	}
 	return byte(v), end - start, nil

--- a/internal/i18n/translationfileparser/php_array_parser.go
+++ b/internal/i18n/translationfileparser/php_array_parser.go
@@ -302,7 +302,7 @@ func (s *phpArrayScanner) parseStringLiteral() (phpStringToken, error) {
 				return phpStringToken{}, fmt.Errorf("php locale array: unterminated unicode escape at line %d", lineNumberAt(s.text, i-2))
 			}
 			hex := s.text[i+1 : i+1+end]
-			v, err := strconv.ParseInt(hex, 16, 32)
+			v, err := strconv.ParseUint(hex, 16, 32)
 			if err != nil || v > 0x10FFFF {
 				return phpStringToken{}, fmt.Errorf("php locale array: invalid unicode escape at line %d", lineNumberAt(s.text, i-2))
 			}
@@ -436,6 +436,7 @@ func encodePHPStringLiteral(value string, quote byte) string {
 			"\r", "\\r",
 			"\t", "\\t",
 			"\v", "\\v",
+			"\x1b", "\\e",
 			"\f", "\\f",
 			"\"", "\\\"",
 			"$", "\\$",

--- a/internal/i18n/translationfileparser/php_array_parser.go
+++ b/internal/i18n/translationfileparser/php_array_parser.go
@@ -1,0 +1,416 @@
+package translationfileparser
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// PHPArrayParser parses PHP locale files that return a static array literal.
+type PHPArrayParser struct{}
+
+type phpArrayEntry struct {
+	key          string
+	sourceValue  string
+	valueLiteral string
+	valueStart   int
+	valueEnd     int
+	quote        byte
+}
+
+type phpArrayDocument struct {
+	template string
+	entries  []phpArrayEntry
+}
+
+type phpArrayScanner struct {
+	text    string
+	pos     int
+	entries []phpArrayEntry
+	seen    map[string]struct{}
+}
+
+type phpStringToken struct {
+	decoded string
+	raw     string
+	start   int
+	end     int
+	quote   byte
+}
+
+func (p PHPArrayParser) Parse(content []byte) (map[string]string, error) {
+	doc, err := parsePHPArrayDocument(content)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make(map[string]string, len(doc.entries))
+	for _, entry := range doc.entries {
+		out[entry.key] = entry.sourceValue
+	}
+	return out, nil
+}
+
+// MarshalPHPArrayLocale preserves the PHP array template while replacing only
+// supported static string value literals.
+func MarshalPHPArrayLocale(template []byte, values map[string]string) ([]byte, error) {
+	doc, err := parsePHPArrayDocument(template)
+	if err != nil {
+		return nil, err
+	}
+	return doc.render(values), nil
+}
+
+func (d phpArrayDocument) render(values map[string]string) []byte {
+	if len(d.entries) == 0 {
+		return []byte(d.template)
+	}
+
+	entries := append([]phpArrayEntry(nil), d.entries...)
+	sort.Slice(entries, func(i, j int) bool { return entries[i].valueStart < entries[j].valueStart })
+
+	var b strings.Builder
+	cursor := 0
+	for _, entry := range entries {
+		if entry.valueStart < cursor || entry.valueStart > len(d.template) || entry.valueEnd > len(d.template) {
+			continue
+		}
+		b.WriteString(d.template[cursor:entry.valueStart])
+		if translated, ok := values[entry.key]; ok {
+			b.WriteString(encodePHPStringLiteral(translated, entry.quote))
+		} else {
+			b.WriteString(entry.valueLiteral)
+		}
+		cursor = entry.valueEnd
+	}
+	b.WriteString(d.template[cursor:])
+	return []byte(b.String())
+}
+
+func parsePHPArrayDocument(content []byte) (phpArrayDocument, error) {
+	scanner := &phpArrayScanner{
+		text: string(content),
+		seen: map[string]struct{}{},
+	}
+
+	if strings.HasPrefix(scanner.text, "\ufeff") {
+		scanner.pos = len("\ufeff")
+	}
+	scanner.pos = skipPHPWhitespace(scanner.text, scanner.pos)
+	if !strings.HasPrefix(scanner.text[scanner.pos:], "<?php") {
+		return phpArrayDocument{}, fmt.Errorf("php locale array: expected <?php opening tag at line %d", lineNumberAt(scanner.text, scanner.pos))
+	}
+	scanner.pos += len("<?php")
+	scanner.skipTrivia()
+
+	if !scanner.consumeKeyword("return") {
+		return phpArrayDocument{}, fmt.Errorf("php locale array: expected return statement at line %d; only files returning a static array literal are supported", lineNumberAt(scanner.text, scanner.pos))
+	}
+	scanner.skipTrivia()
+
+	if err := scanner.parseArrayLiteral(nil); err != nil {
+		return phpArrayDocument{}, err
+	}
+	scanner.skipTrivia()
+
+	if scanner.pos < len(scanner.text) && scanner.text[scanner.pos] == ';' {
+		scanner.pos++
+		scanner.skipTrivia()
+	}
+	if strings.HasPrefix(scanner.text[scanner.pos:], "?>") {
+		scanner.pos += len("?>")
+		scanner.pos = skipPHPWhitespace(scanner.text, scanner.pos)
+	}
+	if scanner.pos != len(scanner.text) {
+		return phpArrayDocument{}, fmt.Errorf("php locale array: unsupported PHP code after return array at line %d", lineNumberAt(scanner.text, scanner.pos))
+	}
+
+	return phpArrayDocument{template: scanner.text, entries: scanner.entries}, nil
+}
+
+func (s *phpArrayScanner) parseArrayLiteral(prefix []string) error {
+	closeByte, err := s.consumeArrayOpen()
+	if err != nil {
+		return err
+	}
+
+	for {
+		s.skipTrivia()
+		if s.pos >= len(s.text) {
+			return fmt.Errorf("php locale array: unterminated array literal at line %d", lineNumberAt(s.text, s.pos))
+		}
+		if s.text[s.pos] == closeByte {
+			s.pos++
+			return nil
+		}
+
+		key, err := s.parseStringLiteral()
+		if err != nil {
+			return fmt.Errorf("php locale array: array keys must be quoted strings at line %d: %w", lineNumberAt(s.text, s.pos), err)
+		}
+		s.skipTrivia()
+		if !strings.HasPrefix(s.text[s.pos:], "=>") {
+			return fmt.Errorf("php locale array: expected => after key %q at line %d", key.decoded, lineNumberAt(s.text, s.pos))
+		}
+		s.pos += len("=>")
+		s.skipTrivia()
+
+		nextPath := append(append([]string{}, prefix...), key.decoded)
+		if err := s.parseArrayValue(nextPath); err != nil {
+			return err
+		}
+
+		s.skipTrivia()
+		if s.pos < len(s.text) && s.text[s.pos] == ',' {
+			s.pos++
+			continue
+		}
+		if s.pos < len(s.text) && s.text[s.pos] == closeByte {
+			continue
+		}
+		return fmt.Errorf("php locale array: expected comma or array close at line %d", lineNumberAt(s.text, s.pos))
+	}
+}
+
+func (s *phpArrayScanner) parseArrayValue(path []string) error {
+	if s.pos >= len(s.text) {
+		return fmt.Errorf("php locale array: missing value for key %q", strings.Join(path, "."))
+	}
+
+	switch {
+	case s.text[s.pos] == '\'' || s.text[s.pos] == '"':
+		value, err := s.parseStringLiteral()
+		if err != nil {
+			return err
+		}
+		key := strings.Join(path, ".")
+		if _, ok := s.seen[key]; ok {
+			return fmt.Errorf("php locale array: duplicate key %q", key)
+		}
+		s.seen[key] = struct{}{}
+		s.entries = append(s.entries, phpArrayEntry{
+			key:          key,
+			sourceValue:  value.decoded,
+			valueLiteral: value.raw,
+			valueStart:   value.start,
+			valueEnd:     value.end,
+			quote:        value.quote,
+		})
+		return nil
+	case s.startsArrayLiteral():
+		return s.parseArrayLiteral(path)
+	default:
+		return fmt.Errorf("php locale array: unsupported value for key %q at line %d; only string literals and nested arrays are supported", strings.Join(path, "."), lineNumberAt(s.text, s.pos))
+	}
+}
+
+func (s *phpArrayScanner) consumeArrayOpen() (byte, error) {
+	if s.pos < len(s.text) && s.text[s.pos] == '[' {
+		s.pos++
+		return ']', nil
+	}
+	if s.consumeKeyword("array") {
+		s.skipTrivia()
+		if s.pos >= len(s.text) || s.text[s.pos] != '(' {
+			return 0, fmt.Errorf("php locale array: expected ( after array keyword at line %d", lineNumberAt(s.text, s.pos))
+		}
+		s.pos++
+		return ')', nil
+	}
+	return 0, fmt.Errorf("php locale array: expected array literal at line %d", lineNumberAt(s.text, s.pos))
+}
+
+func (s *phpArrayScanner) startsArrayLiteral() bool {
+	if s.pos < len(s.text) && s.text[s.pos] == '[' {
+		return true
+	}
+	return s.hasKeywordAt("array", s.pos)
+}
+
+func (s *phpArrayScanner) parseStringLiteral() (phpStringToken, error) {
+	if s.pos >= len(s.text) || (s.text[s.pos] != '\'' && s.text[s.pos] != '"') {
+		return phpStringToken{}, fmt.Errorf("expected string literal")
+	}
+
+	quote := s.text[s.pos]
+	start := s.pos
+	i := start + 1
+	var b strings.Builder
+	for i < len(s.text) {
+		ch := s.text[i]
+		if ch == quote {
+			end := i + 1
+			raw := s.text[start:end]
+			s.pos = end
+			return phpStringToken{decoded: b.String(), raw: raw, start: start, end: end, quote: quote}, nil
+		}
+		if quote == '"' && ch == '$' {
+			return phpStringToken{}, fmt.Errorf("php locale array: dynamic interpolation is not supported in double-quoted strings at line %d", lineNumberAt(s.text, i))
+		}
+		if ch != '\\' {
+			b.WriteByte(ch)
+			i++
+			continue
+		}
+		if i+1 >= len(s.text) {
+			return phpStringToken{}, fmt.Errorf("php locale array: dangling string escape at line %d", lineNumberAt(s.text, i))
+		}
+		escaped := s.text[i+1]
+		i += 2
+		if quote == '\'' {
+			switch escaped {
+			case '\\', '\'':
+				b.WriteByte(escaped)
+			default:
+				b.WriteByte('\\')
+				b.WriteByte(escaped)
+			}
+			continue
+		}
+
+		switch escaped {
+		case 'n':
+			b.WriteByte('\n')
+		case 'r':
+			b.WriteByte('\r')
+		case 't':
+			b.WriteByte('\t')
+		case 'v':
+			b.WriteByte('\v')
+		case 'e':
+			b.WriteByte(0x1b)
+		case 'f':
+			b.WriteByte('\f')
+		case '\\', '"', '$':
+			b.WriteByte(escaped)
+		case 'x':
+			if i+2 > len(s.text) || !isPHPHexPair(s.text[i:i+2]) {
+				return phpStringToken{}, fmt.Errorf("php locale array: invalid hex escape at line %d", lineNumberAt(s.text, i-2))
+			}
+			v, _ := strconv.ParseUint(s.text[i:i+2], 16, 8)
+			b.WriteByte(byte(v))
+			i += 2
+		case 'u':
+			if i >= len(s.text) || s.text[i] != '{' {
+				return phpStringToken{}, fmt.Errorf("php locale array: invalid unicode escape at line %d", lineNumberAt(s.text, i-2))
+			}
+			end := strings.IndexByte(s.text[i+1:], '}')
+			if end < 0 {
+				return phpStringToken{}, fmt.Errorf("php locale array: unterminated unicode escape at line %d", lineNumberAt(s.text, i-2))
+			}
+			hex := s.text[i+1 : i+1+end]
+			v, err := strconv.ParseInt(hex, 16, 32)
+			if err != nil {
+				return phpStringToken{}, fmt.Errorf("php locale array: invalid unicode escape at line %d", lineNumberAt(s.text, i-2))
+			}
+			b.WriteRune(rune(v))
+			i += end + 2
+		default:
+			b.WriteByte('\\')
+			b.WriteByte(escaped)
+		}
+	}
+
+	return phpStringToken{}, fmt.Errorf("php locale array: unterminated string literal at line %d", lineNumberAt(s.text, start))
+}
+
+func (s *phpArrayScanner) skipTrivia() {
+	s.pos = skipPHPTrivia(s.text, s.pos)
+}
+
+func (s *phpArrayScanner) consumeKeyword(keyword string) bool {
+	if !s.hasKeywordAt(keyword, s.pos) {
+		return false
+	}
+	s.pos += len(keyword)
+	return true
+}
+
+func (s *phpArrayScanner) hasKeywordAt(keyword string, pos int) bool {
+	if pos < 0 || pos+len(keyword) > len(s.text) || s.text[pos:pos+len(keyword)] != keyword {
+		return false
+	}
+	beforeOK := pos == 0 || !isPHPIdentifierByte(s.text[pos-1])
+	after := pos + len(keyword)
+	afterOK := after >= len(s.text) || !isPHPIdentifierByte(s.text[after])
+	return beforeOK && afterOK
+}
+
+func skipPHPTrivia(text string, start int) int {
+	i := skipPHPWhitespace(text, start)
+	for i < len(text) {
+		switch {
+		case strings.HasPrefix(text[i:], "//"):
+			i += len("//")
+			for i < len(text) && text[i] != '\n' {
+				i++
+			}
+		case strings.HasPrefix(text[i:], "#"):
+			i++
+			for i < len(text) && text[i] != '\n' {
+				i++
+			}
+		case strings.HasPrefix(text[i:], "/*"):
+			end := strings.Index(text[i+2:], "*/")
+			if end < 0 {
+				return i
+			}
+			i = i + 2 + end + 2
+		default:
+			return i
+		}
+		i = skipPHPWhitespace(text, i)
+	}
+	return i
+}
+
+func skipPHPWhitespace(text string, start int) int {
+	i := start
+	for i < len(text) {
+		switch text[i] {
+		case ' ', '\n', '\r', '\t':
+			i++
+		default:
+			return i
+		}
+	}
+	return i
+}
+
+func isPHPIdentifierByte(ch byte) bool {
+	return ch == '_' || ch >= 'a' && ch <= 'z' || ch >= 'A' && ch <= 'Z' || ch >= '0' && ch <= '9'
+}
+
+func isPHPHexPair(s string) bool {
+	if len(s) != 2 {
+		return false
+	}
+	return isPHPHex(s[0]) && isPHPHex(s[1])
+}
+
+func isPHPHex(ch byte) bool {
+	return ch >= '0' && ch <= '9' || ch >= 'a' && ch <= 'f' || ch >= 'A' && ch <= 'F'
+}
+
+func encodePHPStringLiteral(value string, quote byte) string {
+	if quote == '"' {
+		escaped := strings.NewReplacer(
+			"\\", "\\\\",
+			"\n", "\\n",
+			"\r", "\\r",
+			"\t", "\\t",
+			"\v", "\\v",
+			"\f", "\\f",
+			"\"", "\\\"",
+			"$", "\\$",
+		).Replace(value)
+		return `"` + escaped + `"`
+	}
+
+	escaped := strings.NewReplacer(
+		"\\", "\\\\",
+		"'", "\\'",
+	).Replace(value)
+	return "'" + escaped + "'"
+}

--- a/internal/i18n/translationfileparser/php_array_parser.go
+++ b/internal/i18n/translationfileparser/php_array_parser.go
@@ -285,12 +285,12 @@ func (s *phpArrayScanner) parseStringLiteral() (phpStringToken, error) {
 		case '\\', '"', '$':
 			b.WriteByte(escaped)
 		case 'x':
-			if i+2 > len(s.text) || !isPHPHexPair(s.text[i:i+2]) {
+			v, consumed, ok := readPHPHexEscape(s.text, i)
+			if !ok {
 				return phpStringToken{}, fmt.Errorf("php locale array: invalid hex escape at line %d", lineNumberAt(s.text, i-2))
 			}
-			v, _ := strconv.ParseUint(s.text[i:i+2], 16, 8)
-			b.WriteByte(byte(v))
-			i += 2
+			b.WriteByte(v)
+			i += consumed
 		case 'u':
 			if i >= len(s.text) || s.text[i] != '{' {
 				return phpStringToken{}, fmt.Errorf("php locale array: invalid unicode escape at line %d", lineNumberAt(s.text, i-2))
@@ -307,6 +307,15 @@ func (s *phpArrayScanner) parseStringLiteral() (phpStringToken, error) {
 			b.WriteRune(rune(v))
 			i += end + 2
 		default:
+			if isPHPOctalDigit(escaped) {
+				v, consumed, err := readPHPOctalEscape(s.text, i-1)
+				if err != nil {
+					return phpStringToken{}, fmt.Errorf("php locale array: invalid octal escape at line %d", lineNumberAt(s.text, i-2))
+				}
+				b.WriteByte(v)
+				i += consumed - 1
+				continue
+			}
 			b.WriteByte('\\')
 			b.WriteByte(escaped)
 		}
@@ -382,15 +391,39 @@ func isPHPIdentifierByte(ch byte) bool {
 	return ch == '_' || ch >= 'a' && ch <= 'z' || ch >= 'A' && ch <= 'Z' || ch >= '0' && ch <= '9'
 }
 
-func isPHPHexPair(s string) bool {
-	if len(s) != 2 {
-		return false
+func readPHPHexEscape(text string, start int) (byte, int, bool) {
+	if start >= len(text) || !isPHPHex(text[start]) {
+		return 0, 0, false
 	}
-	return isPHPHex(s[0]) && isPHPHex(s[1])
+	end := start + 1
+	if end < len(text) && isPHPHex(text[end]) {
+		end++
+	}
+	v, _ := strconv.ParseUint(text[start:end], 16, 8)
+	return byte(v), end - start, true
 }
 
 func isPHPHex(ch byte) bool {
 	return ch >= '0' && ch <= '9' || ch >= 'a' && ch <= 'f' || ch >= 'A' && ch <= 'F'
+}
+
+func readPHPOctalEscape(text string, start int) (byte, int, error) {
+	end := start
+	for end < len(text) && end-start < 3 && isPHPOctalDigit(text[end]) {
+		end++
+	}
+	if end == start {
+		return 0, 0, fmt.Errorf("missing octal digits")
+	}
+	v, err := strconv.ParseUint(text[start:end], 8, 16)
+	if err != nil || v > 0xff {
+		return 0, 0, fmt.Errorf("octal escape out of byte range")
+	}
+	return byte(v), end - start, nil
+}
+
+func isPHPOctalDigit(ch byte) bool {
+	return ch >= '0' && ch <= '7'
 }
 
 func encodePHPStringLiteral(value string, quote byte) string {

--- a/internal/i18n/translationfileparser/php_array_parser.go
+++ b/internal/i18n/translationfileparser/php_array_parser.go
@@ -301,7 +301,7 @@ func (s *phpArrayScanner) parseStringLiteral() (phpStringToken, error) {
 			}
 			hex := s.text[i+1 : i+1+end]
 			v, err := strconv.ParseInt(hex, 16, 32)
-			if err != nil {
+			if err != nil || v > 0x10FFFF {
 				return phpStringToken{}, fmt.Errorf("php locale array: invalid unicode escape at line %d", lineNumberAt(s.text, i-2))
 			}
 			b.WriteRune(rune(v))

--- a/internal/i18n/translationfileparser/php_array_parser.go
+++ b/internal/i18n/translationfileparser/php_array_parser.go
@@ -293,7 +293,9 @@ func (s *phpArrayScanner) parseStringLiteral() (phpStringToken, error) {
 			i += consumed
 		case 'u':
 			if i >= len(s.text) || s.text[i] != '{' {
-				return phpStringToken{}, fmt.Errorf("php locale array: invalid unicode escape at line %d", lineNumberAt(s.text, i-2))
+				b.WriteByte('\\')
+				b.WriteByte('u')
+				continue
 			}
 			end := strings.IndexByte(s.text[i+1:], '}')
 			if end < 0 {

--- a/internal/i18n/translationfileparser/php_array_parser_test.go
+++ b/internal/i18n/translationfileparser/php_array_parser_test.go
@@ -153,6 +153,24 @@ func TestPHPArrayParserRejectsOutOfRangeUnicodeEscapes(t *testing.T) {
 	}
 }
 
+func TestPHPArrayParserKeepsUnbracedUEscapesLiteral(t *testing.T) {
+	content := []byte(`<?php return [
+    'username' => "\username",
+    'unicode_like' => "\u00e9",
+];`)
+
+	got, err := (PHPArrayParser{}).Parse(content)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got["username"] != `\username` {
+		t.Fatalf("username = %q, want literal \\username", got["username"])
+	}
+	if got["unicode_like"] != `\u00e9` {
+		t.Fatalf("unicode_like = %q, want literal \\u00e9", got["unicode_like"])
+	}
+}
+
 func TestPHPArrayParserRejectsDynamicValues(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/i18n/translationfileparser/php_array_parser_test.go
+++ b/internal/i18n/translationfileparser/php_array_parser_test.go
@@ -121,6 +121,24 @@ return array(
 	}
 }
 
+func TestPHPArrayParserMatchesKeywordsCaseInsensitively(t *testing.T) {
+	content := []byte(`<?php
+RETURN Array(
+    'validation' => ARRAY(
+        'required' => 'The :attribute field is required.',
+    ),
+);
+`)
+
+	got, err := (PHPArrayParser{}).Parse(content)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got["validation.required"] != "The :attribute field is required." {
+		t.Fatalf("unexpected parsed value: %#v", got)
+	}
+}
+
 func TestPHPArrayParserDecodesDoubleQuotedHexEscapes(t *testing.T) {
 	content := []byte(`<?php return [
     'one_digit' => "\xA",
@@ -154,6 +172,24 @@ func TestPHPArrayParserDecodesDoubleQuotedOctalEscapes(t *testing.T) {
 	}
 	if got["newline"] != "\n" {
 		t.Fatalf("newline = %q, want newline", got["newline"])
+	}
+}
+
+func TestPHPArrayParserTruncatesOverRangeOctalEscapes(t *testing.T) {
+	content := []byte(`<?php return [
+    'nul' => "\400",
+    'max_byte' => "\777",
+];`)
+
+	got, err := (PHPArrayParser{}).Parse(content)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got["nul"] != "\x00" {
+		t.Fatalf("nul = %q, want NUL", got["nul"])
+	}
+	if got["max_byte"] != "\xff" {
+		t.Fatalf("max_byte = %q, want 0xff", got["max_byte"])
 	}
 }
 

--- a/internal/i18n/translationfileparser/php_array_parser_test.go
+++ b/internal/i18n/translationfileparser/php_array_parser_test.go
@@ -1,0 +1,156 @@
+package translationfileparser
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPHPArrayParserParsesNestedStringsAndPluralVariants(t *testing.T) {
+	content := []byte(`<?php
+
+return [
+    // Authentication copy.
+    'auth' => [
+        'failed' => 'These credentials do not match our records.',
+        'password' => "The provided password is incorrect.",
+    ],
+    'items' => [
+        'one' => ':count item',
+        'other' => ':count items',
+    ],
+    'welcome' => 'Welcome, :name!',
+];
+`)
+
+	got, err := (PHPArrayParser{}).Parse(content)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	want := map[string]string{
+		"auth.failed":   "These credentials do not match our records.",
+		"auth.password": "The provided password is incorrect.",
+		"items.one":     ":count item",
+		"items.other":   ":count items",
+		"welcome":       "Welcome, :name!",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("entry count = %d, want %d (%#v)", len(got), len(want), got)
+	}
+	for key, value := range want {
+		if got[key] != value {
+			t.Fatalf("value for %s = %q, want %q", key, got[key], value)
+		}
+	}
+}
+
+func TestMarshalPHPArrayLocalePreservesCommentsMetadataAndPlaceholders(t *testing.T) {
+	template := []byte(`<?php
+
+return [
+    // Authentication copy.
+    'auth' => [
+        'failed' => 'These credentials do not match our records.',
+    ],
+    'items' => [
+        'one' => ':count item',
+        'other' => ':count items',
+    ],
+    'welcome' => "Welcome, :name!",
+];
+`)
+
+	out, err := MarshalPHPArrayLocale(template, map[string]string{
+		"auth.failed": "Ces identifiants ne correspondent pas a nos dossiers.",
+		"items.one":   ":count element",
+		"items.other": ":count elements",
+		"welcome":     "Bienvenue, :name!",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(out)
+	want := `<?php
+
+return [
+    // Authentication copy.
+    'auth' => [
+        'failed' => 'Ces identifiants ne correspondent pas a nos dossiers.',
+    ],
+    'items' => [
+        'one' => ':count element',
+        'other' => ':count elements',
+    ],
+    'welcome' => "Bienvenue, :name!",
+];
+`
+	if got != want {
+		t.Fatalf("output mismatch\n got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestPHPArrayParserSupportsLegacyArraySyntax(t *testing.T) {
+	content := []byte(`<?php
+return array(
+    'validation' => array(
+        'required' => 'The :attribute field is required.',
+    ),
+);
+`)
+
+	got, err := (PHPArrayParser{}).Parse(content)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got["validation.required"] != "The :attribute field is required." {
+		t.Fatalf("unexpected parsed value: %#v", got)
+	}
+}
+
+func TestPHPArrayParserRejectsDynamicValues(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "function call",
+			content: `<?php return ['hello' => __('Hello')];`,
+			want:    "unsupported value",
+		},
+		{
+			name:    "variable interpolation",
+			content: `<?php return ['hello' => "Hello $name"];`,
+			want:    "dynamic interpolation",
+		},
+		{
+			name:    "executable prefix",
+			content: `<?php $messages = ['hello' => 'Hello']; return $messages;`,
+			want:    "expected return statement",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := (PHPArrayParser{}).Parse([]byte(tt.content))
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("expected error containing %q, got %v", tt.want, err)
+			}
+		})
+	}
+}
+
+func TestStrategyParsesPHPArrayLocale(t *testing.T) {
+	s := NewDefaultStrategy()
+
+	got, err := s.Parse("resources/lang/en/messages.php", []byte(`<?php return ['home' => ['title' => 'Home']];`))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got["home.title"] != "Home" {
+		t.Fatalf("unexpected value: %#v", got)
+	}
+}

--- a/internal/i18n/translationfileparser/php_array_parser_test.go
+++ b/internal/i18n/translationfileparser/php_array_parser_test.go
@@ -89,6 +89,20 @@ return [
 	}
 }
 
+func TestMarshalPHPArrayLocaleEscapesDoubleQuotedEscapeBytes(t *testing.T) {
+	template := []byte(`<?php return ['alert' => "Alert"];`)
+
+	out, err := MarshalPHPArrayLocale(template, map[string]string{
+		"alert": "\x1b[31mAlert",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if got, want := string(out), `<?php return ['alert' => "\e[31mAlert"];`; got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
 func TestPHPArrayParserSupportsLegacyArraySyntax(t *testing.T) {
 	content := []byte(`<?php
 return array(
@@ -147,6 +161,14 @@ func TestPHPArrayParserRejectsOutOfRangeUnicodeEscapes(t *testing.T) {
 	_, err := (PHPArrayParser{}).Parse([]byte(`<?php return ['bad' => "\u{110000}"];`))
 	if err == nil {
 		t.Fatalf("expected error")
+	}
+	if !strings.Contains(err.Error(), "invalid unicode escape") {
+		t.Fatalf("expected invalid unicode escape error, got %v", err)
+	}
+
+	_, err = (PHPArrayParser{}).Parse([]byte(`<?php return ['bad' => "\u{-1}"];`))
+	if err == nil {
+		t.Fatalf("expected negative unicode escape error")
 	}
 	if !strings.Contains(err.Error(), "invalid unicode escape") {
 		t.Fatalf("expected invalid unicode escape error, got %v", err)

--- a/internal/i18n/translationfileparser/php_array_parser_test.go
+++ b/internal/i18n/translationfileparser/php_array_parser_test.go
@@ -107,6 +107,42 @@ return array(
 	}
 }
 
+func TestPHPArrayParserDecodesDoubleQuotedHexEscapes(t *testing.T) {
+	content := []byte(`<?php return [
+    'one_digit' => "\xA",
+    'two_digits' => "\x41",
+];`)
+
+	got, err := (PHPArrayParser{}).Parse(content)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got["one_digit"] != "\n" {
+		t.Fatalf("one_digit = %q, want newline", got["one_digit"])
+	}
+	if got["two_digits"] != "A" {
+		t.Fatalf("two_digits = %q, want A", got["two_digits"])
+	}
+}
+
+func TestPHPArrayParserDecodesDoubleQuotedOctalEscapes(t *testing.T) {
+	content := []byte(`<?php return [
+    'letter' => "\101",
+    'newline' => "\12",
+];`)
+
+	got, err := (PHPArrayParser{}).Parse(content)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got["letter"] != "A" {
+		t.Fatalf("letter = %q, want A", got["letter"])
+	}
+	if got["newline"] != "\n" {
+		t.Fatalf("newline = %q, want newline", got["newline"])
+	}
+}
+
 func TestPHPArrayParserRejectsDynamicValues(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/i18n/translationfileparser/php_array_parser_test.go
+++ b/internal/i18n/translationfileparser/php_array_parser_test.go
@@ -143,6 +143,16 @@ func TestPHPArrayParserDecodesDoubleQuotedOctalEscapes(t *testing.T) {
 	}
 }
 
+func TestPHPArrayParserRejectsOutOfRangeUnicodeEscapes(t *testing.T) {
+	_, err := (PHPArrayParser{}).Parse([]byte(`<?php return ['bad' => "\u{110000}"];`))
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(err.Error(), "invalid unicode escape") {
+		t.Fatalf("expected invalid unicode escape error, got %v", err)
+	}
+}
+
 func TestPHPArrayParserRejectsDynamicValues(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/i18n/translationfileparser/strategy.go
+++ b/internal/i18n/translationfileparser/strategy.go
@@ -43,6 +43,7 @@ func NewDefaultStrategy() *Strategy {
 	s.Register(".strings", AppleStringsParser{})
 	s.Register(".stringsdict", AppleStringsdictParser{})
 	s.Register(".csv", CSVParser{})
+	s.Register(".php", PHPArrayParser{})
 	return s
 }
 


### PR DESCRIPTION
## What changed
- Added static PHP return-array locale parsing and deterministic template-based serialization for `.php` files.
- Wired PHP locale arrays into default parsing, run writeback, parser mode tracking, status/check/run dry-run recognition, and focused tests.
- Documented supported PHP locale patterns, limitations, and example config mappings.

## How to test
- `go test -count=1 ./internal/i18n/translationfileparser/... ./apps/cli/internal/i18n/runsvc ./apps/cli/cmd -run "PHP|StrategyParsesPHP|RunDryRunPHP|StatusCommandPHP|CheckCommandPHP|RunWritesPHP"`
- `git diff --check`
- `make run`
- `make fmt`
- `make lint`

## Checklist
- [x] Treat HL-325 as a child issue of HL-274
- [x] Parser and serializer tests cover nested strings, variants, comments, metadata, placeholders, and unsupported dynamic constructs
- [x] `status`, `check`, and `run --dry-run` recognize PHP locale array files
- [x] Greptile review complete
- [x] Final checks: `make run`, `make fmt`, `make lint`