### PR TITLE
HL-324: Add Fluent .ftl parser and serializer support

### DIFF
--- a/apps/cli/cmd/check_test.go
+++ b/apps/cli/cmd/check_test.go
@@ -55,6 +55,41 @@ func TestCheckCommandNoFindings(t *testing.T) {
 	}
 }
 
+func TestCheckCommandRecognizesFluentFiles(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "i18n.jsonc")
+	sourcePath := filepath.Join(dir, "content", "en.ftl")
+	targetPath := filepath.Join(dir, "dist", "fr.ftl")
+
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
+		t.Fatalf("create source dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		t.Fatalf("create target dir: %v", err)
+	}
+	if err := os.WriteFile(sourcePath, []byte("hello = Hello { $name }\n"), 0o600); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+	if err := os.WriteFile(targetPath, []byte("hello = Bonjour { $name }\n"), 0o600); err != nil {
+		t.Fatalf("write target file: %v", err)
+	}
+
+	writeCheckConfig(t, configPath, sourcePath, targetPath, []string{"fr"})
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"check", "--config", configPath})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("check command fluent: %v", err)
+	}
+	if !strings.Contains(out.String(), "No problems.") {
+		t.Fatalf("expected no-findings stylish output, got %q", out.String())
+	}
+}
+
 func TestCheckCommandJSONReportIncludesDefaultFindings(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "i18n.jsonc")

--- a/apps/cli/cmd/run_test.go
+++ b/apps/cli/cmd/run_test.go
@@ -68,6 +68,46 @@ func TestRunDryRunDoesNotWriteTargets(t *testing.T) {
 	}
 }
 
+func TestRunDryRunRecognizesFluentFiles(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "i18n.jsonc")
+	sourcePath := filepath.Join(dir, "content", "en.ftl")
+	targetPath := filepath.Join(dir, "dist", "fr.ftl")
+
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
+		t.Fatalf("create source dir: %v", err)
+	}
+	if err := os.WriteFile(sourcePath, []byte("hello = Hello { $name }\n"), 0o600); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+
+	content := `{
+	  "locales": {"source":"en","targets":["fr"]},
+	  "buckets": {"ui":{"files":[{"from":"` + filepath.ToSlash(sourcePath) + `","to":"` + filepath.ToSlash(targetPath) + `"}]}},
+	  "groups": {"default":{"targets":["fr"],"buckets":["ui"]}},
+	  "llm": {"profiles":{"default":{"provider":"openai","model":"gpt-4.1-mini","prompt":"Translate {{input}}"}}}
+	}`
+	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"run", "--config", configPath, "--dry-run"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("run command fluent dry-run: %v", err)
+	}
+	if !strings.Contains(out.String(), "dry_run=true") {
+		t.Fatalf("expected dry-run output, got %q", out.String())
+	}
+	if _, err := os.Stat(targetPath); !os.IsNotExist(err) {
+		t.Fatalf("expected no target file written in dry-run, stat err=%v", err)
+	}
+}
+
 func TestRunDryRunLiquidReportUsesGeneratedLiquidKeys(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "i18n.jsonc")

--- a/apps/cli/cmd/status_test.go
+++ b/apps/cli/cmd/status_test.go
@@ -299,6 +299,48 @@ func TestStatusCommandBucketFilterUsesLocalstoreNamespace(t *testing.T) {
 	}
 }
 
+func TestStatusCommandRecognizesFluentFiles(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "i18n.jsonc")
+	sourcePath := filepath.Join(dir, "content", "en.ftl")
+	targetPath := filepath.Join(dir, "dist", "fr.ftl")
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
+		t.Fatalf("mkdir source dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		t.Fatalf("mkdir target dir: %v", err)
+	}
+	if err := os.WriteFile(sourcePath, []byte("hello = Hello { $name }\n"), 0o600); err != nil {
+		t.Fatalf("write source fluent: %v", err)
+	}
+	if err := os.WriteFile(targetPath, []byte("hello = Bonjour { $name }\n"), 0o600); err != nil {
+		t.Fatalf("write target fluent: %v", err)
+	}
+
+	content := `{
+  "locales": {"source":"en","targets":["fr"]},
+  "buckets": {"ui":{"files":[{"from":"` + filepath.ToSlash(sourcePath) + `","to":"` + filepath.ToSlash(targetPath) + `"}]}},
+  "groups": {"default":{"targets":["fr"],"buckets":["ui"]}},
+  "llm": {"profiles":{"default":{"provider":"openai","model":"gpt-4.1-mini","prompt":"Translate"}}}
+}`
+	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"status", "--config", configPath, "--bucket", "ui"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute status command: %v", err)
+	}
+	if got := out.String(); !strings.Contains(got, "hello,") || !strings.Contains(got, ",fr,translated,unknown,") {
+		t.Fatalf("expected translated fluent status row, got: %s", got)
+	}
+}
+
 func TestStatusCommandMarkdownIdenticalSegmentIsSourceMatch(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "i18n.jsonc")

--- a/apps/cli/cmd/sync_hyperlocalise.go
+++ b/apps/cli/cmd/sync_hyperlocalise.go
@@ -556,6 +556,8 @@ func inferHyperlocaliseFileFormat(path string) string {
 		return "stringsdict"
 	case ".csv":
 		return "csv"
+	case ".ftl":
+		return "fluent"
 	default:
 		return ""
 	}
@@ -908,7 +910,7 @@ func contentTypeForPath(path string) string {
 	switch strings.ToLower(filepath.Ext(path)) {
 	case ".md", ".mdx":
 		return "text/markdown"
-	case ".po", ".strings", ".stringsdict":
+	case ".po", ".strings", ".stringsdict", ".ftl":
 		return "text/plain"
 	default:
 		return "application/octet-stream"

--- a/apps/cli/cmd/sync_test.go
+++ b/apps/cli/cmd/sync_test.go
@@ -68,6 +68,15 @@ func TestSyncPullRequiresHyperlocaliseConfig(t *testing.T) {
 	}
 }
 
+func TestHyperlocaliseSyncRecognizesFluentFiles(t *testing.T) {
+	if got := inferHyperlocaliseFileFormat("locales/en.ftl"); got != "fluent" {
+		t.Fatalf("inferHyperlocaliseFileFormat(.ftl) = %q, want fluent", got)
+	}
+	if got := contentTypeForPath("locales/en.ftl"); got != "text/plain" {
+		t.Fatalf("contentTypeForPath(.ftl) = %q, want text/plain", got)
+	}
+}
+
 func TestHyperlocalisePullUsesManifestJobWhenNewerSameFileJobExists(t *testing.T) {
 	dir := t.TempDir()
 	targetPattern := filepath.Join(dir, "locales", "{{target}}.json")

--- a/apps/cli/internal/i18n/runsvc/output_marshal.go
+++ b/apps/cli/internal/i18n/runsvc/output_marshal.go
@@ -15,7 +15,7 @@ import (
 func (s *Service) marshalTargetFile(path, sourcePath, sourceLocale, targetLocale string, values map[string]string, stagedEntries map[string]string, pruneKeys map[string]struct{}) ([]byte, []string, error) {
 	ext := strings.ToLower(filepath.Ext(path))
 	switch ext {
-	case ".xlf", ".xlif", ".xliff", ".po", ".md", ".mdx", ".strings", ".stringsdict", ".csv", ".arb", ".html", ".liquid":
+	case ".xlf", ".xlif", ".xliff", ".po", ".md", ".mdx", ".strings", ".stringsdict", ".csv", ".arb", ".ftl", ".html", ".liquid":
 		return s.marshalTemplateBasedTarget(ext, path, sourcePath, sourceLocale, targetLocale, values, stagedEntries)
 	case ".json", ".jsonc":
 		content, err := s.marshalJSONTargetWithFallback(path, sourcePath, values, pruneKeys)
@@ -35,7 +35,7 @@ func (s *Service) marshalTemplateBasedTarget(ext, path, sourcePath, sourceLocale
 	if ext == ".liquid" {
 		return s.marshalLiquidTarget(path, sourcePath, stagedEntries)
 	}
-	if ext == ".xlf" || ext == ".xlif" || ext == ".xliff" || ext == ".po" || ext == ".strings" || ext == ".stringsdict" || ext == ".arb" {
+	if ext == ".xlf" || ext == ".xlif" || ext == ".xliff" || ext == ".po" || ext == ".strings" || ext == ".stringsdict" || ext == ".arb" || ext == ".ftl" {
 		content, err := s.marshalSourceTemplateTarget(ext, path, sourcePath, sourceLocale, targetLocale, values)
 		return content, nil, err
 	}
@@ -105,6 +105,12 @@ func (s *Service) marshalSourceTemplateTarget(ext, path, sourcePath, sourceLocal
 		return content, nil
 	case ".arb":
 		content, err := translationfileparser.MarshalARB(template, sourceTemplate, values, targetLocale)
+		if err != nil {
+			return nil, fmt.Errorf("flush outputs: marshal %q: %w", path, err)
+		}
+		return content, nil
+	case ".ftl":
+		content, err := translationfileparser.MarshalFluent(template, values)
 		if err != nil {
 			return nil, fmt.Errorf("flush outputs: marshal %q: %w", path, err)
 		}

--- a/apps/cli/internal/i18n/runsvc/service_test.go
+++ b/apps/cli/internal/i18n/runsvc/service_test.go
@@ -3814,6 +3814,7 @@ func TestMarshalTargetFileDispatchParity(t *testing.T) {
 		"/tmp/source.csv":         []byte("key,source,target\nhello,Hello,Hello\n"),
 		"/tmp/source.json":        []byte(`{"hello":"Hello"}`),
 		"/tmp/source.arb":         []byte(`{"@@locale":"en","hello":"Hello","@hello":{"description":"Greeting"}}`),
+		"/tmp/source.ftl":         []byte("hello = Hello\n"),
 		"/tmp/source.liquid":      []byte("<p>Hello</p>\n"),
 	}
 	svc.readFile = func(path string) ([]byte, error) {
@@ -3838,6 +3839,7 @@ func TestMarshalTargetFileDispatchParity(t *testing.T) {
 		{target: "/tmp/out.csv", source: "/tmp/source.csv"},
 		{target: "/tmp/out.json", source: "/tmp/source.json"},
 		{target: "/tmp/out.arb", source: "/tmp/source.arb"},
+		{target: "/tmp/out.ftl", source: "/tmp/source.ftl"},
 		{target: "/tmp/out.liquid", source: "/tmp/source.liquid"},
 	}
 
@@ -4350,6 +4352,36 @@ func TestMarshalSourceTemplateTargetPrefersTargetTemplateForStringsWhenAllKeysPr
 	out := string(content)
 	if !strings.Contains(out, "target-comment") || strings.Contains(out, "source-comment") {
 		t.Fatalf("expected target template comment preserved, got %q", out)
+	}
+}
+
+func TestMarshalSourceTemplateTargetPrefersTargetTemplateForFluentWhenAllKeysPresent(t *testing.T) {
+	svc := newTestService()
+	sourcePath := "/tmp/source.ftl"
+	targetPath := "/tmp/out.ftl"
+	source := []byte("# source-comment\nhello = Hello\n")
+	target := []byte("# target-comment\nhello = Bonjour\n")
+	svc.readFile = func(path string) ([]byte, error) {
+		switch path {
+		case sourcePath:
+			return source, nil
+		case targetPath:
+			return target, nil
+		default:
+			return nil, os.ErrNotExist
+		}
+	}
+
+	content, err := svc.marshalSourceTemplateTarget(".ftl", targetPath, sourcePath, "en", "fr", map[string]string{"hello": "Salut"})
+	if err != nil {
+		t.Fatalf("marshal source-template target: %v", err)
+	}
+	out := string(content)
+	if !strings.Contains(out, "target-comment") || strings.Contains(out, "source-comment") {
+		t.Fatalf("expected target template comment preserved, got %q", out)
+	}
+	if !strings.Contains(out, "hello = Salut") {
+		t.Fatalf("expected fluent value replacement, got %q", out)
 	}
 }
 

--- a/docs/commands/run.mdx
+++ b/docs/commands/run.mdx
@@ -34,6 +34,7 @@ For lockfile fields, lifecycle, and reset guidance, see [Lockfile contract](/ref
 - `.strings`
 - `.stringsdict`
 - `.csv`
+- `.ftl`
 
 For JSON (`.json`), `run` supports:
 
@@ -79,6 +80,13 @@ For CSV (`.csv`), `run` supports two layouts:
 - per-locale column layout (for example: `id,en,fr,de`)
 
 When writing CSV targets, `run` preserves the existing header and non-target columns, updates matching keys in place, and appends new keys in deterministic sorted order.
+
+For Mozilla Fluent (`.ftl`), `run` supports top-level messages, message attributes, multiline values, and select/plural patterns represented as full message values:
+
+- attributes are exposed as dotted keys such as `brand.title`
+- comments, blank lines, and unparsed metadata are preserved when values are replaced in an existing template
+- Fluent terms (`-brand = ...`) and term references are not supported and fail with a clear parser error
+- newly appended message keys are sorted deterministically; new attributes can only be appended when their parent message is not already present in the template
 
 ## Flags
 

--- a/docs/configuration/i18n-config.mdx
+++ b/docs/configuration/i18n-config.mdx
@@ -77,6 +77,19 @@ Shared multi-locale file:
 
 For shared multi-locale CSV files, keep one key column and one target locale column that `run` can update consistently.
 
+### Fluent file mapping patterns
+
+Use `.ftl` mappings for Mozilla Fluent locale files:
+
+```json
+{
+  "from": "locales/en-US/messages.ftl",
+  "to": "locales/[locale]/messages.ftl"
+}
+```
+
+Hyperlocalise supports Fluent messages, attributes, multiline values, and select/plural values as full translation units. Attributes use dotted keys such as `brand.title`. Fluent terms are not supported and fail during parsing.
+
 ## Groups
 
 `groups.<name>` defines what to process together.

--- a/docs/reference/config-schema.mdx
+++ b/docs/reference/config-schema.mdx
@@ -57,3 +57,11 @@ Use `buckets.*.files[].from` and `to` to point at `.csv` files when you run CSV-
 
 - Per-locale files typically use `[locale]` in the `to` path.
 - Shared CSV files can reuse the same `from` and `to` path.
+
+## Fluent workflow note
+
+Use `buckets.*.files[].from` and `to` to point at `.ftl` files for Mozilla Fluent localization flows.
+
+- Per-locale files typically use `[locale]` in the `to` path, for example `locales/[locale]/messages.ftl`.
+- Supported entries include messages, attributes, multiline values, and select/plural patterns represented as full values.
+- Fluent terms are not supported and fail parsing instead of being rewritten.

--- a/docs/reference/output-formats.mdx
+++ b/docs/reference/output-formats.mdx
@@ -59,3 +59,7 @@ Common sync warning or conflict cases include:
 ## CSV translation files
 
 When `run` writes `.csv` translation targets, output row order is deterministic for newly appended keys (sorted by key), and existing rows keep their original order.
+
+## Fluent translation files
+
+When `run` writes `.ftl` translation targets, existing comments, blank lines, and message order come from the selected template. Parsed message and attribute value spans are replaced in place. Missing top-level message keys are appended in sorted order, and unsupported Fluent terms fail before output is written.

--- a/docs/troubleshooting/common-errors.mdx
+++ b/docs/troubleshooting/common-errors.mdx
@@ -34,7 +34,7 @@ Cause: a mapped source or target file uses an extension not supported by the loc
 
 Fixes:
 
-- use one of: `.json`, `.arb`, `.xlf`, `.xliff`, `.po`, `.html`, `.liquid`, `.md`, `.mdx`, `.strings`, `.stringsdict`, `.csv`
+- use one of: `.json`, `.arb`, `.xlf`, `.xliff`, `.po`, `.html`, `.liquid`, `.md`, `.mdx`, `.strings`, `.stringsdict`, `.csv`, `.ftl`
 - verify bucket `from` and `to` paths resolve to the expected file names
 
 ## Provider auth failures

--- a/docs/vi-VN/commands/run.mdx
+++ b/docs/vi-VN/commands/run.mdx
@@ -34,6 +34,7 @@ hyperlocalise run [--config <path>] [--group <name>] [--bucket <name>] [--file <
 - `.strings`
 - `.stringsdict`
 - `.csv`
+- `.ftl`
 
 Đối với JSON (`.json`), `run` hỗ trợ:
 

--- a/docs/vi-VN/troubleshooting/common-errors.mdx
+++ b/docs/vi-VN/troubleshooting/common-errors.mdx
@@ -34,7 +34,7 @@ Nguyên nhân: tệp nguồn hoặc tệp đích được ánh xạ sử dụng 
 
 Sửa lỗi:
 
-- sử dụng một trong các: `.json`, `.arb`, `.xlf`, `.xliff`, `.po`, `.html`, `.liquid`, `.md`, `.mdx`, `.strings`, `.stringsdict`, `.csv`
+- sử dụng một trong các: `.json`, `.arb`, `.xlf`, `.xliff`, `.po`, `.html`, `.liquid`, `.md`, `.mdx`, `.strings`, `.stringsdict`, `.csv`, `.ftl`
 - xác minh rằng các đường dẫn `from` và `to` trỏ tới đúng tên tệp như mong đợi
 
 ## Lỗi xác thực của nhà cung cấp

--- a/docs/zh-CN/commands/run.mdx
+++ b/docs/zh-CN/commands/run.mdx
@@ -34,6 +34,7 @@ hyperlocalise run [--config <path>] [--group <name>] [--bucket <name>] [--file <
 - `.strings`
 - `.stringsdict`
 - `.csv`
+- `.ftl`
 
 对于 JSON（`.json`），`run` 支持：
 

--- a/docs/zh-CN/troubleshooting/common-errors.mdx
+++ b/docs/zh-CN/troubleshooting/common-errors.mdx
@@ -34,7 +34,7 @@ hyperlocalise init --force
 
 修复：
 
-- 使用以下之一：`.json`、`.arb`、`.xlf`、`.xliff`、`.po`、`.html`、`.liquid`、`.md`、`.mdx`、`.strings`、`.stringsdict`、`.csv`
+- 使用以下之一：`.json`、`.arb`、`.xlf`、`.xliff`、`.po`、`.html`、`.liquid`、`.md`、`.mdx`、`.strings`、`.stringsdict`、`.csv`、`.ftl`
 - 验证存储桶 `from` 和 `to` 路径是否解析为预期的文件名
 
 ## 提供者身份验证失败

--- a/internal/i18n/translationfileparser/README.md
+++ b/internal/i18n/translationfileparser/README.md
@@ -15,10 +15,11 @@
 - `.strings` via `AppleStringsParser` (Apple/Xcode strings files)
 - `.stringsdict` via `AppleStringsdictParser` (Apple/Xcode plural dictionaries)
 - `.csv` via `CSVParser` (key/value and per-locale column layouts)
+- `.ftl` via `FluentParser` (Mozilla Fluent messages and attributes)
 
 ## Strategy API
 
-- `NewDefaultStrategy()` returns a strategy pre-registered with JSON, XLIFF, PO, Apple Strings, Markdown/MDX, and HTML parsers.
+- `NewDefaultStrategy()` returns a strategy pre-registered with JSON, JSONC, ARB, XLIFF, PO, HTML, Liquid, Markdown/MDX, Apple Strings/Stringsdict, CSV, and Fluent parsers.
 - `Register(ext, parser)` allows adding/replacing parser implementations by extension.
 - `Parse(path, content)` resolves parser by extension and returns `map[string]string`.
 
@@ -100,6 +101,16 @@
 - Validates that every `%#@token@` in `NSStringLocalizedFormatKey` matches a sibling substitution dictionary key.
 - Preserves plural category keys (`zero`, `one`, `two`, `few`, `many`, `other`) as part of flattened key paths.
 - `MarshalAppleStringsdict(template, values)` preserves plist/XML layout and replaces only `<string>` text values.
+
+### Fluent (`.ftl`)
+
+- Parses top-level message values into message IDs.
+- Parses message attributes into dotted keys.
+  - Example: `brand =` with `.title = Hyperlocalise` becomes `brand.title=Hyperlocalise`.
+- Multiline values and select/plural patterns are kept as a single translation value for the message or attribute.
+- Comments, blank lines, ordering, and unsupported metadata are preserved by `MarshalFluent(template, values)` because only parsed value spans are replaced.
+- Term definitions (`-brand = ...`) and term references are rejected with clear errors; they are not rewritten by the parser.
+- Newly appended message keys are written in sorted order. New attributes can be appended only when their parent message is not already present in the template.
 
 ## Minimal usage
 

--- a/internal/i18n/translationfileparser/fluent_parser.go
+++ b/internal/i18n/translationfileparser/fluent_parser.go
@@ -32,8 +32,9 @@ type fluentEntry struct {
 }
 
 type fluentDocument struct {
-	template string
-	entries  []fluentEntry
+	template   string
+	entries    []fluentEntry
+	messageIDs map[string]struct{}
 }
 
 func (p FluentParser) Parse(content []byte) (map[string]string, error) {
@@ -84,11 +85,14 @@ func (d fluentDocument) render(values map[string]string) ([]byte, error) {
 		return strings.Compare(a.key, b.key)
 	})
 
-	seen := make(map[string]struct{}, len(entries))
+	templateKeys := make(map[string]struct{}, len(entries)+len(d.messageIDs))
+	for messageID := range d.messageIDs {
+		templateKeys[messageID] = struct{}{}
+	}
 	var b strings.Builder
 	cursor := 0
 	for _, entry := range entries {
-		seen[entry.key] = struct{}{}
+		templateKeys[entry.key] = struct{}{}
 		if entry.valueStart < cursor || entry.valueStart > len(d.template) || entry.valueEnd > len(d.template) {
 			continue
 		}
@@ -102,7 +106,7 @@ func (d fluentDocument) render(values map[string]string) ([]byte, error) {
 	}
 	b.WriteString(d.template[cursor:])
 
-	if err := appendMissingFluentEntries(&b, values, seen); err != nil {
+	if err := appendMissingFluentEntries(&b, values, templateKeys); err != nil {
 		return nil, err
 	}
 
@@ -116,7 +120,7 @@ func parseFluentDocument(content []byte) (fluentDocument, error) {
 
 	text := string(content)
 	lines := scanFluentLines(text)
-	doc := fluentDocument{template: text, entries: []fluentEntry{}}
+	doc := fluentDocument{template: text, entries: []fluentEntry{}, messageIDs: map[string]struct{}{}}
 	seen := map[string]struct{}{}
 	pendingComments := []string{}
 	parentID := ""
@@ -168,6 +172,10 @@ func parseFluentDocument(content []byte) (fluentDocument, error) {
 		if !ok {
 			return fluentDocument{}, fmt.Errorf("line %d: expected Fluent message assignment", lineNumberAt(text, line.start))
 		}
+		if _, ok := doc.messageIDs[messageID]; ok {
+			return fluentDocument{}, fmt.Errorf("line %d: duplicate Fluent message id %q", lineNumberAt(text, line.start), messageID)
+		}
+		doc.messageIDs[messageID] = struct{}{}
 		context := formatFluentComments(pendingComments)
 		pendingComments = nil
 		parentID = messageID
@@ -393,8 +401,25 @@ func normalizeFluentValue(raw string) string {
 	for len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) == "" {
 		lines = lines[:len(lines)-1]
 	}
+	commonIndent := -1
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		indent := len(line) - len(strings.TrimLeft(line, " \t"))
+		if commonIndent < 0 || indent < commonIndent {
+			commonIndent = indent
+		}
+	}
+	if commonIndent < 0 {
+		commonIndent = 0
+	}
 	for i, line := range lines {
-		lines[i] = strings.TrimRight(strings.TrimLeft(line, " \t"), " \t")
+		if len(line) >= commonIndent {
+			lines[i] = strings.TrimRight(line[commonIndent:], " \t")
+		} else {
+			lines[i] = strings.TrimRight(line, " \t")
+		}
 	}
 	return strings.Join(lines, "\n")
 }
@@ -426,17 +451,17 @@ func encodeFluentValue(value, continuationIndent string, blockValue bool) string
 	return lines[0] + "\n" + continuationIndent + strings.Join(lines[1:], "\n"+continuationIndent)
 }
 
-func appendMissingFluentEntries(b *strings.Builder, values map[string]string, seen map[string]struct{}) error {
+func appendMissingFluentEntries(b *strings.Builder, values map[string]string, templateKeys map[string]struct{}) error {
 	messageKeys := []string{}
 	attrsByParent := map[string][]string{}
 
 	for key := range values {
-		if _, ok := seen[key]; ok {
+		if _, ok := templateKeys[key]; ok {
 			continue
 		}
 		parent, attr, ok := splitFluentAttributeKey(key)
 		if ok {
-			if _, parentExists := seen[parent]; parentExists {
+			if _, parentExists := templateKeys[parent]; parentExists {
 				return fmt.Errorf("fluent marshal: cannot append missing attribute %q because parent message %q already exists in template", key, parent)
 			}
 			attrsByParent[parent] = append(attrsByParent[parent], attr)

--- a/internal/i18n/translationfileparser/fluent_parser.go
+++ b/internal/i18n/translationfileparser/fluent_parser.go
@@ -425,10 +425,27 @@ func normalizeFluentValue(raw string) string {
 }
 
 func validateFluentValue(key, value string) error {
-	if strings.Contains(value, "{-") || strings.Contains(value, "{ -") {
+	if fluentValueReferencesTerm(value) {
 		return fmt.Errorf("fluent key %q references a term, which is not supported", key)
 	}
 	return nil
+}
+
+func fluentValueReferencesTerm(value string) bool {
+	for i := 0; i < len(value); i++ {
+		if value[i] != '{' {
+			continue
+		}
+
+		j := i + 1
+		for j < len(value) && (value[j] == ' ' || value[j] == '\t') {
+			j++
+		}
+		if j < len(value) && value[j] == '-' {
+			return true
+		}
+	}
+	return false
 }
 
 func encodeFluentValue(value, continuationIndent string, blockValue bool) string {

--- a/internal/i18n/translationfileparser/fluent_parser.go
+++ b/internal/i18n/translationfileparser/fluent_parser.go
@@ -90,23 +90,33 @@ func (d fluentDocument) render(values map[string]string) ([]byte, error) {
 		templateKeys[messageID] = struct{}{}
 	}
 	var b strings.Builder
+	hasRendered := false
+	renderedLastByte := byte(0)
+	writeRenderedString := func(value string) {
+		b.WriteString(value)
+		if len(value) == 0 {
+			return
+		}
+		hasRendered = true
+		renderedLastByte = value[len(value)-1]
+	}
 	cursor := 0
 	for _, entry := range entries {
 		templateKeys[entry.key] = struct{}{}
 		if entry.valueStart < cursor || entry.valueStart > len(d.template) || entry.valueEnd > len(d.template) {
 			continue
 		}
-		b.WriteString(d.template[cursor:entry.valueStart])
+		writeRenderedString(d.template[cursor:entry.valueStart])
 		if translated, ok := values[entry.key]; ok {
-			b.WriteString(encodeFluentValue(translated, entry.continuationIndent, entry.blockValue))
+			writeRenderedString(encodeFluentValue(translated, entry.continuationIndent, entry.blockValue))
 		} else {
-			b.WriteString(d.template[entry.valueStart:entry.valueEnd])
+			writeRenderedString(d.template[entry.valueStart:entry.valueEnd])
 		}
 		cursor = entry.valueEnd
 	}
-	b.WriteString(d.template[cursor:])
+	writeRenderedString(d.template[cursor:])
 
-	if err := appendMissingFluentEntries(&b, values, templateKeys); err != nil {
+	if err := appendMissingFluentEntries(&b, values, templateKeys, hasRendered && renderedLastByte == '\n'); err != nil {
 		return nil, err
 	}
 
@@ -468,7 +478,7 @@ func encodeFluentValue(value, continuationIndent string, blockValue bool) string
 	return lines[0] + "\n" + continuationIndent + strings.Join(lines[1:], "\n"+continuationIndent)
 }
 
-func appendMissingFluentEntries(b *strings.Builder, values map[string]string, templateKeys map[string]struct{}) error {
+func appendMissingFluentEntries(b *strings.Builder, values map[string]string, templateKeys map[string]struct{}, endsWithNewline bool) error {
 	messageKeys := []string{}
 	attrsByParent := map[string][]string{}
 
@@ -493,7 +503,7 @@ func appendMissingFluentEntries(b *strings.Builder, values map[string]string, te
 	if len(messageKeys) == 0 && len(attrsByParent) == 0 {
 		return nil
 	}
-	if b.Len() > 0 && !strings.HasSuffix(b.String(), "\n") {
+	if b.Len() > 0 && !endsWithNewline {
 		b.WriteByte('\n')
 	}
 

--- a/internal/i18n/translationfileparser/fluent_parser.go
+++ b/internal/i18n/translationfileparser/fluent_parser.go
@@ -91,14 +91,22 @@ func (d fluentDocument) render(values map[string]string) ([]byte, error) {
 	}
 	var b strings.Builder
 	hasRendered := false
-	renderedLastByte := byte(0)
+	renderedTrailingNewlines := 0
 	writeRenderedString := func(value string) {
 		b.WriteString(value)
 		if len(value) == 0 {
 			return
 		}
 		hasRendered = true
-		renderedLastByte = value[len(value)-1]
+		trailingNewlines := 0
+		for i := len(value) - 1; i >= 0 && value[i] == '\n'; i-- {
+			trailingNewlines++
+		}
+		if trailingNewlines == len(value) {
+			renderedTrailingNewlines += trailingNewlines
+		} else {
+			renderedTrailingNewlines = trailingNewlines
+		}
 	}
 	cursor := 0
 	for _, entry := range entries {
@@ -116,7 +124,7 @@ func (d fluentDocument) render(values map[string]string) ([]byte, error) {
 	}
 	writeRenderedString(d.template[cursor:])
 
-	if err := appendMissingFluentEntries(&b, values, templateKeys, hasRendered && renderedLastByte == '\n'); err != nil {
+	if err := appendMissingFluentEntries(&b, values, templateKeys, hasRendered, renderedTrailingNewlines); err != nil {
 		return nil, err
 	}
 
@@ -147,7 +155,11 @@ func parseFluentDocument(content []byte) (fluentDocument, error) {
 			continue
 		}
 		if isFluentComment(trimmed) {
-			pendingComments = append(pendingComments, fluentCommentText(trimmed))
+			if fluentCommentLevel(trimmed) == 1 {
+				pendingComments = append(pendingComments, fluentCommentText(trimmed))
+			} else {
+				pendingComments = nil
+			}
 			parentID = ""
 			parentContext = ""
 			i++
@@ -242,9 +254,6 @@ func fluentValueSpan(lines []fluentLine, index, valueStart int) (int, int) {
 		return valueStart, index
 	}
 	valueEnd := lines[index].end
-	if valueStart > valueEnd {
-		valueStart = valueEnd
-	}
 
 	next := index + 1
 	for next < len(lines) {
@@ -387,6 +396,14 @@ func isFluentComment(trimmed string) bool {
 	return strings.HasPrefix(trimmed, "#")
 }
 
+func fluentCommentLevel(trimmed string) int {
+	level := 0
+	for level < len(trimmed) && trimmed[level] == '#' {
+		level++
+	}
+	return level
+}
+
 func fluentCommentText(trimmed string) string {
 	return strings.TrimSpace(strings.TrimLeft(trimmed, "#"))
 }
@@ -478,7 +495,7 @@ func encodeFluentValue(value, continuationIndent string, blockValue bool) string
 	return lines[0] + "\n" + continuationIndent + strings.Join(lines[1:], "\n"+continuationIndent)
 }
 
-func appendMissingFluentEntries(b *strings.Builder, values map[string]string, templateKeys map[string]struct{}, endsWithNewline bool) error {
+func appendMissingFluentEntries(b *strings.Builder, values map[string]string, templateKeys map[string]struct{}, hasRendered bool, trailingNewlines int) error {
 	messageKeys := []string{}
 	attrsByParent := map[string][]string{}
 
@@ -503,8 +520,10 @@ func appendMissingFluentEntries(b *strings.Builder, values map[string]string, te
 	if len(messageKeys) == 0 && len(attrsByParent) == 0 {
 		return nil
 	}
-	if b.Len() > 0 && !endsWithNewline {
-		b.WriteByte('\n')
+	if hasRendered && trailingNewlines < 2 {
+		for i := trailingNewlines; i < 2; i++ {
+			b.WriteByte('\n')
+		}
 	}
 
 	topLevel := make([]string, 0, len(messageKeys)+len(attrsByParent))
@@ -520,7 +539,10 @@ func appendMissingFluentEntries(b *strings.Builder, values map[string]string, te
 		topLevel = append(topLevel, parent)
 	}
 	slices.Sort(topLevel)
-	for _, parent := range topLevel {
+	for index, parent := range topLevel {
+		if index > 0 {
+			b.WriteByte('\n')
+		}
 		if !isValidFluentIdentifier(parent) {
 			return fmt.Errorf("fluent marshal: invalid message id %q", parent)
 		}

--- a/internal/i18n/translationfileparser/fluent_parser.go
+++ b/internal/i18n/translationfileparser/fluent_parser.go
@@ -240,7 +240,7 @@ func fluentValueSpan(lines []fluentLine, index, valueStart int) (int, int) {
 	for next < len(lines) {
 		line := lines[next]
 		trimmed := strings.TrimSpace(line.text)
-		if trimmed == "" || isFluentComment(trimmed) {
+		if trimmed == "" {
 			break
 		}
 		if !fluentLineIndented(line.text) {

--- a/internal/i18n/translationfileparser/fluent_parser.go
+++ b/internal/i18n/translationfileparser/fluent_parser.go
@@ -428,8 +428,15 @@ func normalizeFluentValue(raw string) string {
 	for len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) == "" {
 		lines = lines[:len(lines)-1]
 	}
+	// Inline multiline values start beside "=", so derive structural indent
+	// from continuation lines and let encodeFluentValue add it back once.
+	indentFrom := 0
+	if len(lines) > 1 && !fluentLineIndented(lines[0]) {
+		indentFrom = 1
+	}
+
 	commonIndent := -1
-	for _, line := range lines {
+	for _, line := range lines[indentFrom:] {
 		if strings.TrimSpace(line) == "" {
 			continue
 		}
@@ -441,7 +448,12 @@ func normalizeFluentValue(raw string) string {
 	if commonIndent < 0 {
 		commonIndent = 0
 	}
-	for i, line := range lines {
+
+	if indentFrom > 0 {
+		lines[0] = strings.TrimRight(lines[0], " \t")
+	}
+	for i := indentFrom; i < len(lines); i++ {
+		line := lines[i]
 		if len(line) >= commonIndent {
 			lines[i] = strings.TrimRight(line[commonIndent:], " \t")
 		} else {

--- a/internal/i18n/translationfileparser/fluent_parser.go
+++ b/internal/i18n/translationfileparser/fluent_parser.go
@@ -1,0 +1,530 @@
+package translationfileparser
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"unicode/utf8"
+)
+
+// FluentParser parses Mozilla Fluent .ftl localization files.
+//
+// The supported subset is intentionally conservative: message values,
+// message attributes, multiline values, and select/plural patterns are treated
+// as complete translation units. Term definitions are rejected so unsupported
+// Fluent constructs do not get silently rewritten.
+type FluentParser struct{}
+
+type fluentLine struct {
+	start int
+	end   int
+	text  string
+}
+
+type fluentEntry struct {
+	key                string
+	sourceValue        string
+	context            string
+	valueStart         int
+	valueEnd           int
+	blockValue         bool
+	continuationIndent string
+}
+
+type fluentDocument struct {
+	template string
+	entries  []fluentEntry
+}
+
+func (p FluentParser) Parse(content []byte) (map[string]string, error) {
+	values, _, err := p.ParseWithContext(content)
+	if err != nil {
+		return nil, err
+	}
+	return values, nil
+}
+
+func (p FluentParser) ParseWithContext(content []byte) (map[string]string, map[string]string, error) {
+	doc, err := parseFluentDocument(content)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	values := map[string]string{}
+	contextByKey := map[string]string{}
+	for _, entry := range doc.entries {
+		values[entry.key] = entry.sourceValue
+		if strings.TrimSpace(entry.context) != "" {
+			contextByKey[entry.key] = entry.context
+		}
+	}
+	if len(contextByKey) == 0 {
+		return values, nil, nil
+	}
+	return values, contextByKey, nil
+}
+
+func MarshalFluent(template []byte, values map[string]string) ([]byte, error) {
+	doc, err := parseFluentDocument(template)
+	if err != nil {
+		return nil, err
+	}
+	return doc.render(values)
+}
+
+func (d fluentDocument) render(values map[string]string) ([]byte, error) {
+	entries := append([]fluentEntry(nil), d.entries...)
+	slices.SortFunc(entries, func(a, b fluentEntry) int {
+		if a.valueStart < b.valueStart {
+			return -1
+		}
+		if a.valueStart > b.valueStart {
+			return 1
+		}
+		return strings.Compare(a.key, b.key)
+	})
+
+	seen := make(map[string]struct{}, len(entries))
+	var b strings.Builder
+	cursor := 0
+	for _, entry := range entries {
+		seen[entry.key] = struct{}{}
+		if entry.valueStart < cursor || entry.valueStart > len(d.template) || entry.valueEnd > len(d.template) {
+			continue
+		}
+		b.WriteString(d.template[cursor:entry.valueStart])
+		if translated, ok := values[entry.key]; ok {
+			b.WriteString(encodeFluentValue(translated, entry.continuationIndent, entry.blockValue))
+		} else {
+			b.WriteString(d.template[entry.valueStart:entry.valueEnd])
+		}
+		cursor = entry.valueEnd
+	}
+	b.WriteString(d.template[cursor:])
+
+	if err := appendMissingFluentEntries(&b, values, seen); err != nil {
+		return nil, err
+	}
+
+	return []byte(b.String()), nil
+}
+
+func parseFluentDocument(content []byte) (fluentDocument, error) {
+	if !utf8.Valid(content) {
+		return fluentDocument{}, fmt.Errorf("fluent: content must be valid UTF-8")
+	}
+
+	text := string(content)
+	lines := scanFluentLines(text)
+	doc := fluentDocument{template: text, entries: []fluentEntry{}}
+	seen := map[string]struct{}{}
+	pendingComments := []string{}
+	parentID := ""
+	parentContext := ""
+
+	for i := 0; i < len(lines); {
+		line := lines[i]
+		trimmed := strings.TrimSpace(line.text)
+		if trimmed == "" {
+			pendingComments = nil
+			parentID = ""
+			parentContext = ""
+			i++
+			continue
+		}
+		if isFluentComment(trimmed) {
+			pendingComments = append(pendingComments, fluentCommentText(trimmed))
+			parentID = ""
+			parentContext = ""
+			i++
+			continue
+		}
+
+		if fluentLineIndented(line.text) {
+			attrID, valueStart, ok := parseFluentAttributeHeader(line)
+			if !ok {
+				return fluentDocument{}, fmt.Errorf("line %d: unexpected indented Fluent line", lineNumberAt(text, line.start))
+			}
+			if parentID == "" {
+				return fluentDocument{}, fmt.Errorf("line %d: Fluent attribute %q has no parent message", lineNumberAt(text, line.start), attrID)
+			}
+			key := parentID + "." + attrID
+			entry, next, err := parseFluentEntryValue(text, lines, i, valueStart, key, parentContext, fluentAttributeContinuationIndent(line.text))
+			if err != nil {
+				return fluentDocument{}, err
+			}
+			if err := addFluentEntry(&doc, seen, entry); err != nil {
+				return fluentDocument{}, err
+			}
+			i = next
+			continue
+		}
+
+		if strings.HasPrefix(trimmed, "-") {
+			return fluentDocument{}, fmt.Errorf("line %d: Fluent terms are not supported", lineNumberAt(text, line.start))
+		}
+
+		messageID, valueStart, ok := parseFluentMessageHeader(line)
+		if !ok {
+			return fluentDocument{}, fmt.Errorf("line %d: expected Fluent message assignment", lineNumberAt(text, line.start))
+		}
+		context := formatFluentComments(pendingComments)
+		pendingComments = nil
+		parentID = messageID
+		parentContext = context
+
+		entry, next, err := parseFluentEntryValue(text, lines, i, valueStart, messageID, context, "    ")
+		if err != nil {
+			return fluentDocument{}, err
+		}
+		if entry.sourceValue != "" || !nextLineIsFluentAttribute(lines, next) {
+			if err := addFluentEntry(&doc, seen, entry); err != nil {
+				return fluentDocument{}, err
+			}
+		}
+		i = next
+	}
+
+	return doc, nil
+}
+
+func addFluentEntry(doc *fluentDocument, seen map[string]struct{}, entry fluentEntry) error {
+	if _, ok := seen[entry.key]; ok {
+		return fmt.Errorf("fluent: duplicate entry key %q", entry.key)
+	}
+	if err := validateFluentValue(entry.key, entry.sourceValue); err != nil {
+		return err
+	}
+	seen[entry.key] = struct{}{}
+	doc.entries = append(doc.entries, entry)
+	return nil
+}
+
+func parseFluentEntryValue(text string, lines []fluentLine, index, valueStart int, key, context, continuationIndent string) (fluentEntry, int, error) {
+	valueEnd, next := fluentValueSpan(lines, index, valueStart)
+	raw := ""
+	if valueStart <= valueEnd {
+		raw = text[valueStart:valueEnd]
+	}
+	sourceValue := normalizeFluentValue(raw)
+	blockValue := strings.HasPrefix(raw, "\n") || strings.HasPrefix(raw, "\r\n")
+	return fluentEntry{
+		key:                key,
+		sourceValue:        sourceValue,
+		context:            context,
+		valueStart:         valueStart,
+		valueEnd:           valueEnd,
+		blockValue:         blockValue,
+		continuationIndent: continuationIndent,
+	}, next, nil
+}
+
+func fluentValueSpan(lines []fluentLine, index, valueStart int) (int, int) {
+	if index >= len(lines) {
+		return valueStart, index
+	}
+	valueEnd := lines[index].end
+	if valueStart > valueEnd {
+		valueStart = valueEnd
+	}
+
+	next := index + 1
+	for next < len(lines) {
+		line := lines[next]
+		trimmed := strings.TrimSpace(line.text)
+		if trimmed == "" || isFluentComment(trimmed) {
+			break
+		}
+		if !fluentLineIndented(line.text) {
+			break
+		}
+		if _, _, ok := parseFluentAttributeHeader(line); ok {
+			break
+		}
+		valueEnd = line.end
+		next++
+	}
+
+	return valueEnd, next
+}
+
+func scanFluentLines(text string) []fluentLine {
+	lines := []fluentLine{}
+	for start := 0; start < len(text); {
+		next := strings.IndexByte(text[start:], '\n')
+		lineEnd := len(text)
+		after := len(text)
+		if next >= 0 {
+			lineEnd = start + next
+			after = lineEnd + 1
+		}
+		end := lineEnd
+		if end > start && text[end-1] == '\r' {
+			end--
+		}
+		lines = append(lines, fluentLine{
+			start: start,
+			end:   end,
+			text:  text[start:end],
+		})
+		start = after
+	}
+	return lines
+}
+
+func parseFluentMessageHeader(line fluentLine) (string, int, bool) {
+	if fluentLineIndented(line.text) {
+		return "", 0, false
+	}
+	id, next, ok := parseFluentIdentifierAt(line.text, 0)
+	if !ok {
+		return "", 0, false
+	}
+	next = skipFluentInlineWhitespace(line.text, next)
+	if next >= len(line.text) || line.text[next] != '=' {
+		return "", 0, false
+	}
+	valueOffset := skipFluentInlineWhitespace(line.text, next+1)
+	return id, line.start + valueOffset, true
+}
+
+func parseFluentAttributeHeader(line fluentLine) (string, int, bool) {
+	offset := fluentIndentWidth(line.text)
+	if offset >= len(line.text) || line.text[offset] != '.' {
+		return "", 0, false
+	}
+	id, next, ok := parseFluentIdentifierAt(line.text, offset+1)
+	if !ok {
+		return "", 0, false
+	}
+	next = skipFluentInlineWhitespace(line.text, next)
+	if next >= len(line.text) || line.text[next] != '=' {
+		return "", 0, false
+	}
+	valueOffset := skipFluentInlineWhitespace(line.text, next+1)
+	return id, line.start + valueOffset, true
+}
+
+func parseFluentIdentifierAt(line string, start int) (string, int, bool) {
+	if start >= len(line) || !isFluentIdentifierStart(line[start]) {
+		return "", start, false
+	}
+	i := start + 1
+	for i < len(line) && isFluentIdentifierPart(line[i]) {
+		i++
+	}
+	return line[start:i], i, true
+}
+
+func isValidFluentIdentifier(id string) bool {
+	parsed, next, ok := parseFluentIdentifierAt(id, 0)
+	return ok && next == len(id) && parsed == id
+}
+
+func isFluentIdentifierStart(ch byte) bool {
+	return (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z')
+}
+
+func isFluentIdentifierPart(ch byte) bool {
+	return isFluentIdentifierStart(ch) || (ch >= '0' && ch <= '9') || ch == '_' || ch == '-'
+}
+
+func skipFluentInlineWhitespace(line string, start int) int {
+	i := start
+	for i < len(line) && (line[i] == ' ' || line[i] == '\t') {
+		i++
+	}
+	return i
+}
+
+func fluentLineIndented(line string) bool {
+	return len(line) > 0 && (line[0] == ' ' || line[0] == '\t')
+}
+
+func fluentIndentWidth(line string) int {
+	i := 0
+	for i < len(line) && (line[i] == ' ' || line[i] == '\t') {
+		i++
+	}
+	return i
+}
+
+func fluentAttributeContinuationIndent(line string) string {
+	indent := line[:fluentIndentWidth(line)]
+	if indent == "" {
+		indent = "    "
+	}
+	return indent + "    "
+}
+
+func nextLineIsFluentAttribute(lines []fluentLine, index int) bool {
+	if index >= len(lines) {
+		return false
+	}
+	_, _, ok := parseFluentAttributeHeader(lines[index])
+	return ok
+}
+
+func isFluentComment(trimmed string) bool {
+	return strings.HasPrefix(trimmed, "#")
+}
+
+func fluentCommentText(trimmed string) string {
+	return strings.TrimSpace(strings.TrimLeft(trimmed, "#"))
+}
+
+func formatFluentComments(comments []string) string {
+	parts := make([]string, 0, len(comments))
+	for _, comment := range comments {
+		if clean := strings.TrimSpace(comment); clean != "" {
+			parts = append(parts, clean)
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+func normalizeFluentValue(raw string) string {
+	raw = strings.ReplaceAll(raw, "\r\n", "\n")
+	raw = strings.ReplaceAll(raw, "\r", "\n")
+	lines := strings.Split(raw, "\n")
+	for len(lines) > 0 && strings.TrimSpace(lines[0]) == "" {
+		lines = lines[1:]
+	}
+	for len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) == "" {
+		lines = lines[:len(lines)-1]
+	}
+	for i, line := range lines {
+		lines[i] = strings.TrimRight(strings.TrimLeft(line, " \t"), " \t")
+	}
+	return strings.Join(lines, "\n")
+}
+
+func validateFluentValue(key, value string) error {
+	if strings.Contains(value, "{-") || strings.Contains(value, "{ -") {
+		return fmt.Errorf("fluent key %q references a term, which is not supported", key)
+	}
+	return nil
+}
+
+func encodeFluentValue(value, continuationIndent string, blockValue bool) string {
+	value = strings.ReplaceAll(value, "\r\n", "\n")
+	value = strings.ReplaceAll(value, "\r", "\n")
+	value = strings.TrimRight(value, "\n")
+	if continuationIndent == "" {
+		continuationIndent = "    "
+	}
+	if value == "" {
+		return ""
+	}
+	lines := strings.Split(value, "\n")
+	if blockValue {
+		return "\n" + continuationIndent + strings.Join(lines, "\n"+continuationIndent)
+	}
+	if len(lines) == 1 {
+		return lines[0]
+	}
+	return lines[0] + "\n" + continuationIndent + strings.Join(lines[1:], "\n"+continuationIndent)
+}
+
+func appendMissingFluentEntries(b *strings.Builder, values map[string]string, seen map[string]struct{}) error {
+	messageKeys := []string{}
+	attrsByParent := map[string][]string{}
+
+	for key := range values {
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		parent, attr, ok := splitFluentAttributeKey(key)
+		if ok {
+			if _, parentExists := seen[parent]; parentExists {
+				return fmt.Errorf("fluent marshal: cannot append missing attribute %q because parent message %q already exists in template", key, parent)
+			}
+			attrsByParent[parent] = append(attrsByParent[parent], attr)
+			continue
+		}
+		if !isValidFluentIdentifier(key) {
+			return fmt.Errorf("fluent marshal: invalid message id %q", key)
+		}
+		messageKeys = append(messageKeys, key)
+	}
+
+	if len(messageKeys) == 0 && len(attrsByParent) == 0 {
+		return nil
+	}
+	if b.Len() > 0 && !strings.HasSuffix(b.String(), "\n") {
+		b.WriteByte('\n')
+	}
+
+	topLevel := make([]string, 0, len(messageKeys)+len(attrsByParent))
+	hasMessage := make(map[string]struct{}, len(messageKeys))
+	for _, key := range messageKeys {
+		topLevel = append(topLevel, key)
+		hasMessage[key] = struct{}{}
+	}
+	for parent := range attrsByParent {
+		if _, ok := hasMessage[parent]; ok {
+			continue
+		}
+		topLevel = append(topLevel, parent)
+	}
+	slices.Sort(topLevel)
+	for _, parent := range topLevel {
+		if !isValidFluentIdentifier(parent) {
+			return fmt.Errorf("fluent marshal: invalid message id %q", parent)
+		}
+		if _, ok := hasMessage[parent]; ok {
+			writeFluentMessage(b, parent, values[parent])
+		} else {
+			b.WriteString(parent)
+			b.WriteString(" =\n")
+		}
+		attrs := attrsByParent[parent]
+		slices.Sort(attrs)
+		for _, attr := range attrs {
+			writeFluentAttribute(b, attr, values[parent+"."+attr])
+		}
+	}
+
+	return nil
+}
+
+func splitFluentAttributeKey(key string) (string, string, bool) {
+	parent, attr, ok := strings.Cut(key, ".")
+	if !ok || parent == "" || attr == "" || strings.Contains(attr, ".") {
+		return "", "", false
+	}
+	if !isValidFluentIdentifier(parent) || !isValidFluentIdentifier(attr) {
+		return "", "", false
+	}
+	return parent, attr, true
+}
+
+func writeFluentMessage(b *strings.Builder, key, value string) {
+	if strings.Contains(value, "\n") {
+		b.WriteString(key)
+		b.WriteString(" =")
+		b.WriteString(encodeFluentValue(value, "    ", true))
+		b.WriteByte('\n')
+		return
+	}
+	b.WriteString(key)
+	b.WriteString(" = ")
+	b.WriteString(value)
+	b.WriteByte('\n')
+}
+
+func writeFluentAttribute(b *strings.Builder, attr, value string) {
+	if strings.Contains(value, "\n") {
+		b.WriteString("    .")
+		b.WriteString(attr)
+		b.WriteString(" =")
+		b.WriteString(encodeFluentValue(value, "        ", true))
+		b.WriteByte('\n')
+		return
+	}
+	b.WriteString("    .")
+	b.WriteString(attr)
+	b.WriteString(" = ")
+	b.WriteString(value)
+	b.WriteByte('\n')
+}

--- a/internal/i18n/translationfileparser/fluent_parser_test.go
+++ b/internal/i18n/translationfileparser/fluent_parser_test.go
@@ -78,6 +78,37 @@ func TestFluentParserKeepsIndentedHashContinuationLines(t *testing.T) {
 	}
 }
 
+func TestMarshalFluentInlineMultilineValuesAreIdempotent(t *testing.T) {
+	template := []byte(`hello = First line
+    continuation
+`)
+
+	values, err := FluentParser{}.Parse(template)
+	if err != nil {
+		t.Fatalf("parse fluent: %v", err)
+	}
+	if got, want := values["hello"], "First line\ncontinuation"; got != want {
+		t.Fatalf("parsed inline multiline value mismatch\n got: %q\nwant: %q", got, want)
+	}
+
+	first, err := MarshalFluent(template, values)
+	if err != nil {
+		t.Fatalf("marshal fluent: %v", err)
+	}
+	second, err := MarshalFluent(first, values)
+	if err != nil {
+		t.Fatalf("marshal fluent again: %v", err)
+	}
+
+	want := string(template)
+	if string(first) != want {
+		t.Fatalf("first marshal changed inline multiline indentation\n got: %q\nwant: %q", string(first), want)
+	}
+	if string(second) != want {
+		t.Fatalf("second marshal changed inline multiline indentation\n got: %q\nwant: %q", string(second), want)
+	}
+}
+
 func TestMarshalFluentPreservesCommentsAndReplacesValues(t *testing.T) {
 	template := []byte(`# Greeting
 hello = Hello { $name }

--- a/internal/i18n/translationfileparser/fluent_parser_test.go
+++ b/internal/i18n/translationfileparser/fluent_parser_test.go
@@ -33,13 +33,33 @@ items =
 		"escaped":          "Use \\\\{literal\\\\} and C:\\\\Temp",
 		"brand.title":      "Hyperlocalise",
 		"brand.aria-label": "Open { $item }",
-		"items":            "{ $count ->\n[one] One item\n*[other] { $count } items\n}",
+		"items":            "{ $count ->\n    [one] One item\n   *[other] { $count } items\n}",
 	}
 	if !reflect.DeepEqual(values, want) {
 		t.Fatalf("parsed values mismatch\n got: %#v\nwant: %#v", values, want)
 	}
 	if !strings.Contains(ctx["hello"], "Greeting shown after sign-in.") {
 		t.Fatalf("expected comment context for hello, got %#v", ctx)
+	}
+}
+
+func TestFluentParserPreservesRelativeIndentation(t *testing.T) {
+	values, err := FluentParser{}.Parse([]byte(`nested =
+    { $gender ->
+        [male] { $count ->
+            [one] His item
+           *[other] His items
+        }
+       *[other] Their item
+    }
+`))
+	if err != nil {
+		t.Fatalf("parse fluent: %v", err)
+	}
+
+	want := "{ $gender ->\n    [male] { $count ->\n        [one] His item\n       *[other] His items\n    }\n   *[other] Their item\n}"
+	if values["nested"] != want {
+		t.Fatalf("expected relative indentation preserved\n got: %q\nwant: %q", values["nested"], want)
 	}
 }
 
@@ -83,6 +103,18 @@ items =
 `
 	if string(got) != want {
 		t.Fatalf("marshaled fluent mismatch\n got: %q\nwant: %q", string(got), want)
+	}
+}
+
+func TestMarshalFluentRejectsNewAttributeForExistingAttributeOnlyParent(t *testing.T) {
+	_, err := MarshalFluent([]byte(`brand =
+    .title = Hyperlocalise
+`), map[string]string{
+		"brand.title":  "Hyperlocalise FR",
+		"brand.footer": "Footer",
+	})
+	if err == nil || !strings.Contains(err.Error(), `cannot append missing attribute "brand.footer"`) {
+		t.Fatalf("expected missing attribute parent guard error, got %v", err)
 	}
 }
 

--- a/internal/i18n/translationfileparser/fluent_parser_test.go
+++ b/internal/i18n/translationfileparser/fluent_parser_test.go
@@ -63,6 +63,21 @@ func TestFluentParserPreservesRelativeIndentation(t *testing.T) {
 	}
 }
 
+func TestFluentParserKeepsIndentedHashContinuationLines(t *testing.T) {
+	values, err := FluentParser{}.Parse([]byte(`topic =
+    # trending
+    Now
+`))
+	if err != nil {
+		t.Fatalf("parse fluent: %v", err)
+	}
+
+	want := "# trending\nNow"
+	if values["topic"] != want {
+		t.Fatalf("expected indented hash line as value content\n got: %q\nwant: %q", values["topic"], want)
+	}
+}
+
 func TestMarshalFluentPreservesCommentsAndReplacesValues(t *testing.T) {
 	template := []byte(`# Greeting
 hello = Hello { $name }

--- a/internal/i18n/translationfileparser/fluent_parser_test.go
+++ b/internal/i18n/translationfileparser/fluent_parser_test.go
@@ -38,7 +38,7 @@ items =
 	if !reflect.DeepEqual(values, want) {
 		t.Fatalf("parsed values mismatch\n got: %#v\nwant: %#v", values, want)
 	}
-	if !strings.Contains(ctx["hello"], "Greeting shown after sign-in.") {
+	if got := ctx["hello"]; got != "Greeting shown after sign-in." {
 		t.Fatalf("expected comment context for hello, got %#v", ctx)
 	}
 }
@@ -145,13 +145,31 @@ func TestMarshalFluentAppendsMissingEntriesDeterministically(t *testing.T) {
 	}
 
 	want := `hello = Salut
+
 apple = Pomme
+
 brand =
     .title = Titre
+
 zebra = Zebre
 `
 	if string(got) != want {
 		t.Fatalf("marshaled fluent mismatch\n got: %q\nwant: %q", string(got), want)
+	}
+}
+
+func TestFluentParserExcludesFileAndGroupCommentsFromMessageContext(t *testing.T) {
+	_, ctx, err := FluentParser{}.ParseWithContext([]byte(`### Checkout
+## Signed-in view
+# Greeting shown after sign-in.
+hello = Hello
+`))
+	if err != nil {
+		t.Fatalf("parse fluent: %v", err)
+	}
+
+	if got := ctx["hello"]; got != "Greeting shown after sign-in." {
+		t.Fatalf("expected only message comment context, got %q", got)
 	}
 }
 

--- a/internal/i18n/translationfileparser/fluent_parser_test.go
+++ b/internal/i18n/translationfileparser/fluent_parser_test.go
@@ -170,8 +170,17 @@ func TestFluentParserRejectsAttributeWithoutParent(t *testing.T) {
 }
 
 func TestFluentParserRejectsTermReferences(t *testing.T) {
-	_, err := FluentParser{}.Parse([]byte("hello = Welcome { -brand }\n"))
-	if err == nil || !strings.Contains(err.Error(), "references a term") {
-		t.Fatalf("expected term reference error, got %v", err)
+	tests := []string{
+		"hello = Welcome {-brand }\n",
+		"hello = Welcome { -brand }\n",
+		"hello = Welcome {  -brand }\n",
+		"hello = Welcome {\t-brand }\n",
+	}
+
+	for _, input := range tests {
+		_, err := FluentParser{}.Parse([]byte(input))
+		if err == nil || !strings.Contains(err.Error(), "references a term") {
+			t.Fatalf("expected term reference error for %q, got %v", input, err)
+		}
 	}
 }

--- a/internal/i18n/translationfileparser/fluent_parser_test.go
+++ b/internal/i18n/translationfileparser/fluent_parser_test.go
@@ -1,0 +1,130 @@
+package translationfileparser
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestFluentParserParsesMessagesAttributesSelectorsAndContext(t *testing.T) {
+	content := []byte(`### Checkout
+# Greeting shown after sign-in.
+hello = Hello { $name }
+escaped = Use \\{literal\\} and C:\\Temp
+
+brand =
+    .title = Hyperlocalise
+    .aria-label = Open { $item }
+
+items =
+    { $count ->
+        [one] One item
+       *[other] { $count } items
+    }
+`)
+
+	values, ctx, err := FluentParser{}.ParseWithContext(content)
+	if err != nil {
+		t.Fatalf("parse fluent: %v", err)
+	}
+
+	want := map[string]string{
+		"hello":            "Hello { $name }",
+		"escaped":          "Use \\\\{literal\\\\} and C:\\\\Temp",
+		"brand.title":      "Hyperlocalise",
+		"brand.aria-label": "Open { $item }",
+		"items":            "{ $count ->\n[one] One item\n*[other] { $count } items\n}",
+	}
+	if !reflect.DeepEqual(values, want) {
+		t.Fatalf("parsed values mismatch\n got: %#v\nwant: %#v", values, want)
+	}
+	if !strings.Contains(ctx["hello"], "Greeting shown after sign-in.") {
+		t.Fatalf("expected comment context for hello, got %#v", ctx)
+	}
+}
+
+func TestMarshalFluentPreservesCommentsAndReplacesValues(t *testing.T) {
+	template := []byte(`# Greeting
+hello = Hello { $name }
+
+brand =
+    .title = Hyperlocalise
+    .aria-label = Open { $item }
+
+items =
+    { $count ->
+        [one] One item
+       *[other] { $count } items
+    }
+`)
+
+	got, err := MarshalFluent(template, map[string]string{
+		"hello":            "Bonjour { $name }",
+		"brand.title":      "Hyperlocalise FR",
+		"brand.aria-label": "Ouvrir { $item }",
+		"items":            "{ $count ->\n[one] Un article\n*[other] { $count } articles\n}",
+	})
+	if err != nil {
+		t.Fatalf("marshal fluent: %v", err)
+	}
+
+	want := `# Greeting
+hello = Bonjour { $name }
+
+brand =
+    .title = Hyperlocalise FR
+    .aria-label = Ouvrir { $item }
+
+items =
+    { $count ->
+    [one] Un article
+    *[other] { $count } articles
+    }
+`
+	if string(got) != want {
+		t.Fatalf("marshaled fluent mismatch\n got: %q\nwant: %q", string(got), want)
+	}
+}
+
+func TestMarshalFluentAppendsMissingEntriesDeterministically(t *testing.T) {
+	got, err := MarshalFluent([]byte("hello = Bonjour\n"), map[string]string{
+		"hello":       "Salut",
+		"zebra":       "Zebre",
+		"brand.title": "Titre",
+		"apple":       "Pomme",
+	})
+	if err != nil {
+		t.Fatalf("marshal fluent: %v", err)
+	}
+
+	want := `hello = Salut
+apple = Pomme
+brand =
+    .title = Titre
+zebra = Zebre
+`
+	if string(got) != want {
+		t.Fatalf("marshaled fluent mismatch\n got: %q\nwant: %q", string(got), want)
+	}
+}
+
+func TestFluentParserRejectsUnsupportedTerms(t *testing.T) {
+	_, err := FluentParser{}.Parse([]byte("-brand = Hyperlocalise\n"))
+	if err == nil || !strings.Contains(err.Error(), "terms are not supported") {
+		t.Fatalf("expected unsupported term error, got %v", err)
+	}
+}
+
+func TestFluentParserRejectsAttributeWithoutParent(t *testing.T) {
+	_, err := FluentParser{}.Parse([]byte("    .title = Missing parent\n"))
+	if err == nil || !strings.Contains(err.Error(), "has no parent message") {
+		t.Fatalf("expected attribute parent error, got %v", err)
+	}
+}
+
+func TestFluentParserRejectsTermReferences(t *testing.T) {
+	_, err := FluentParser{}.Parse([]byte("hello = Welcome { -brand }\n"))
+	if err == nil || !strings.Contains(err.Error(), "references a term") {
+		t.Fatalf("expected term reference error, got %v", err)
+	}
+}

--- a/internal/i18n/translationfileparser/strategy.go
+++ b/internal/i18n/translationfileparser/strategy.go
@@ -43,6 +43,7 @@ func NewDefaultStrategy() *Strategy {
 	s.Register(".strings", AppleStringsParser{})
 	s.Register(".stringsdict", AppleStringsdictParser{})
 	s.Register(".csv", CSVParser{})
+	s.Register(".ftl", FluentParser{})
 	return s
 }
 

--- a/internal/i18n/translationfileparser/strategy_test.go
+++ b/internal/i18n/translationfileparser/strategy_test.go
@@ -232,6 +232,18 @@ hello,bonjour
 	}
 }
 
+func TestStrategyParsesFluent(t *testing.T) {
+	s := NewDefaultStrategy()
+
+	got, err := s.Parse("fr.ftl", []byte("hello = Bonjour { $name }\n"))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got["hello"] != "Bonjour { $name }" {
+		t.Fatalf("unexpected hello translation: %q", got["hello"])
+	}
+}
+
 func TestStrategyRegistersLiquidParser(t *testing.T) {
 	s := NewDefaultStrategy()
 


### PR DESCRIPTION
## What changed
- Updated the HL-324 branch with latest `main`.
- Fixed Fluent inline multi-line normalization so continuation indentation stays stable across marshal cycles.
- Added a regression test for repeated marshal idempotence.

## How to test
- `go test ./internal/i18n/translationfileparser ./apps/cli/internal/i18n/runsvc ./apps/cli/cmd -run "Fluent|StrategyParsesFluent|MarshalTargetFileDispatchParity|RecognizesFluent"`

## Checklist
- [x] Branch updated with latest `main`
- [x] Regression test added
- [x] Focused tests pass