### PR TITLE
🧪 Scout: fix nested pound handling in ICU select blocks

### DIFF
--- a/internal/i18n/icuparser/coverage_test.go
+++ b/internal/i18n/icuparser/coverage_test.go
@@ -251,7 +251,7 @@ func TestPeekReadEdges(t *testing.T) {
 
 func TestParseArgumentLikeExpectedOpenBrace(t *testing.T) {
 	p := astParser{src: "", pos: 0}
-	if _, err := p.parseArgumentLike(); err == nil || !strings.Contains(err.Error(), "expected '{'") {
+	if _, err := p.parseArgumentLike(parseCtx{}); err == nil || !strings.Contains(err.Error(), "expected '{'") {
 		t.Fatalf("got %v", err)
 	}
 }

--- a/internal/i18n/icuparser/invariant.go
+++ b/internal/i18n/icuparser/invariant.go
@@ -254,9 +254,17 @@ func countPounds(elems []Element) int {
 		case TagElement:
 			total += countPounds(v.Children)
 		case SelectElement:
+			// For select elements, we take the maximum number of pounds found in any of its
+			// branches. Only one branch can be active at a time, so this correctly
+			// represents the contribution of this select block to the parent plural's
+			// pound count.
+			maxPounds := 0
 			for _, opt := range v.Options {
-				total += countPounds(opt.Value)
+				if n := countPounds(opt.Value); n > maxPounds {
+					maxPounds = n
+				}
 			}
+			total += maxPounds
 		case PluralElement:
 			// Stop recursion into nested plurals because '#' within them
 			// refers to the nested plural's argument.

--- a/internal/i18n/icuparser/invariant_test.go
+++ b/internal/i18n/icuparser/invariant_test.go
@@ -286,6 +286,8 @@ func TestHasDuplicatePounds(t *testing.T) {
 		{"duplicate in other branch", "{n, plural, one {#} other {##}}", true},
 		{"multiple blocks, one duplicate", "{n1, plural, one {#}}{n2, plural, one {##}}", true},
 		{"nested duplicate", "{n1, plural, one {{n2, plural, other {##}}}}", true},
+		{"select inside plural", "{n, plural, other {{gender, select, male {# he} female {# she} other {# they}}}}", false},
+		{"select inside plural duplicate", "{n, plural, other {# {gender, select, male {#} female {she} other {they}}}}", true},
 		{"select block", "{gender, select, male {he} female {she} other {they}}", false},
 		{"selectordinal duplicate", "{n, selectordinal, one {##st} other {#th}}", true},
 		{"mustache placeholder", "Hello {{name}}", false},

--- a/internal/i18n/icuparser/parse.go
+++ b/internal/i18n/icuparser/parse.go
@@ -82,7 +82,7 @@ func (p *astParser) handleMessageChar(out *[]Element, text *strings.Builder, ctx
 	switch p.src[p.pos] {
 	case '{':
 		flushText()
-		el, err := p.parseArgumentLike()
+		el, err := p.parseArgumentLike(ctx)
 		if err != nil {
 			return false, err
 		}
@@ -155,7 +155,7 @@ func (p *astParser) handleOpenTag(text *strings.Builder, ctx parseCtx, out *[]El
 	return true, nil
 }
 
-func (p *astParser) parseArgumentLike() (Element, error) {
+func (p *astParser) parseArgumentLike(ctx parseCtx) (Element, error) {
 	if !p.consume('{') {
 		return nil, fmt.Errorf("expected '{' at %d", p.pos)
 	}
@@ -184,7 +184,7 @@ func (p *astParser) parseArgumentLike() (Element, error) {
 		return p.parseSimpleTypedArgument(arg, kind)
 	}
 	if kind == "select" {
-		return p.parseSelectArgument(arg)
+		return p.parseSelectArgument(arg, ctx)
 	}
 	if kind == "plural" || kind == "selectordinal" {
 		return p.parsePluralArgument(arg, kind)
@@ -286,12 +286,12 @@ func (p *astParser) finishTimeElement(arg, style string) (Element, error) {
 	}, nil
 }
 
-func (p *astParser) parseSelectArgument(arg string) (Element, error) {
+func (p *astParser) parseSelectArgument(arg string, ctx parseCtx) (Element, error) {
 	if !p.consume(',') {
 		return nil, fmt.Errorf("expected ',' before select options at %d", p.pos)
 	}
 	p.skipSpaces()
-	opts, err := p.parseSelectOptions(parseCtx{})
+	opts, err := p.parseSelectOptions(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -537,7 +537,7 @@ func (p *astParser) handleTagBodyChar(out *[]Element, text *strings.Builder, ctx
 	switch p.peek() {
 	case '{':
 		flushText()
-		el, err := p.parseArgumentLike()
+		el, err := p.parseArgumentLike(ctx)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
💡 What: Fixed ICU parser to correctly identify `#` signs inside `select` blocks that are nested within `plural` blocks. Also improved the `countPounds` invariant check to correctly handle `select` branches by taking the maximum pound count across branches.

🎯 Why: Previously, `#` inside a nested `select` was treated as literal text, leading to incorrect invariant extraction and potentially missing duplicate `#` validation errors.

🧩 Scope: `internal/i18n/icuparser/parse.go`, `internal/i18n/icuparser/invariant.go`, and `internal/i18n/icuparser/invariant_test.go`.

✅ Verification: Ran `go test ./internal/i18n/icuparser/...` and verified that the new regression tests pass. Also verified that `apps/cli` tests still pass.

🛡️ Confidence: High. The fix correctly models ICU semantics (only one branch of a select is active at a time) and ensures structural parity checks are accurate.

---
*PR created automatically by Jules for task [2929650030477416127](https://jules.google.com/task/2929650030477416127) started by @cungminh2710*