### PR TITLE
fix(crowdin): improve project and TM parity for Enterprise fields

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -65,3 +65,15 @@
 **Learning:** The Crowdin API v2 for Glossaries and Translation Memories returns an `updatedAt` field in their resource responses, which was missing from the Go SDK models. Additionally, the Add Term endpoint supports a deprecated `translationOfTermId` field for linking translations, which can still be useful for legacy integrations.
 
 **Action:** Added `UpdatedAt` (string) to `Glossary` and `TranslationMemory` models. Added `TranslationOfTermID` (int) to `TermAddRequest`. Updated contract tests in `glossaries_test.go` and `translation_memory_test.go` to verify correct parsing and serialization of these fields.
+
+## 2026-07-03 - Improve Project and TM parity for Enterprise fields and GroupID filtering
+
+**Learning:** Crowdin Enterprise API v2 includes several fields in the Project response model (, , ) that were missing from the SDK. Additionally, listing projects and translation memories supports filtering by `groupId`. Using `*int` for the GroupID field allows the SDK to explicitly send `groupId=0` (for root group) while omitting it when nil.
+
+**Action:** Added `TemplateID`, `VendorID`, and `MTEngineID` to the `Project` struct in `model/projects.go`. Added `GroupID (*int)` to `ProjectsListOptions` and `TranslationMemoriesListOptions`. Updated `Values()` methods to correctly encode the `groupId` parameter. Verified with updated contract tests in `projects_test.go` and `model/translation_memory_test.go`.
+
+## 2026-07-03 - Improve Project and TM parity for Enterprise fields and GroupID filtering
+
+**Learning:** Crowdin Enterprise API v2 includes several fields in the Project response model (`templateId`, `vendorId`, `mtEngineId`) that were missing from the SDK. Additionally, listing projects and translation memories supports filtering by `groupId`. Using `*int` for the GroupID field allows the SDK to explicitly send `groupId=0` (for root group) while omitting it when nil.
+
+**Action:** Added `TemplateID`, `VendorID`, and `MTEngineID` to the `Project` struct in `model/projects.go`. Added `GroupID (*int)` to `ProjectsListOptions` and `TranslationMemoriesListOptions`. Updated `Values()` methods to correctly encode the `groupId` parameter. Verified with updated contract tests in `projects_test.go` and `model/translation_memory_test.go`.

--- a/third_party/crowdin-api-client-go/crowdin/model/projects.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/projects.go
@@ -79,6 +79,11 @@ type (
 		InContextProcessHiddenStrings   bool                       `json:"inContextProcessHiddenStrings,omitempty"`
 		InContextPseudoLanguageID       string                     `json:"inContextPseudoLanguageId,omitempty"`
 		InContextPseudoLanguage         *Language                  `json:"inContextPseudoLanguage,omitempty"`
+
+		// [Enterprise client]
+		TemplateID int `json:"templateId,omitempty"`
+		VendorID   int `json:"vendorId,omitempty"`
+		MTEngineID int `json:"mtEngineId,omitempty"`
 	}
 
 	ProjectTMPenalties struct {
@@ -147,6 +152,8 @@ type ProjectsListOptions struct {
 	HasManagerAccess *int `json:"hasManagerAccess,omitempty"`
 	// Set type to 0 to get all file based projects. Enum: 0, 1.
 	Type *int `json:"type,omitempty"`
+	// Group identifier.
+	GroupID *int `json:"groupId,omitempty"`
 }
 
 // Values returns the url.Values representation of ProjectsListOptions.
@@ -169,6 +176,9 @@ func (o *ProjectsListOptions) Values() (url.Values, bool) {
 	}
 	if o.Type != nil && (*o.Type == 0 || *o.Type == 1) {
 		v.Add("type", fmt.Sprintf("%d", *o.Type))
+	}
+	if o.GroupID != nil {
+		v.Add("groupId", fmt.Sprintf("%d", *o.GroupID))
 	}
 	return v, len(v) > 0
 }

--- a/third_party/crowdin-api-client-go/crowdin/model/projects_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/projects_test.go
@@ -31,12 +31,17 @@ func TestProjectsListOptionsValues(t *testing.T) {
 			out:  "type=0",
 		},
 		{
+			name: "with groupId = 0",
+			opts: &ProjectsListOptions{GroupID: toPtr(0)},
+			out:  "groupId=0",
+		},
+		{
 			name: "with all options",
 			opts: &ProjectsListOptions{
 				OrderBy: "createdAt desc,name,id", UserID: 1, HasManagerAccess: toPtr(1),
-				Type: toPtr(1), ListOptions: ListOptions{Offset: 1, Limit: 10},
+				Type: toPtr(1), GroupID: toPtr(2), ListOptions: ListOptions{Offset: 1, Limit: 10},
 			},
-			out: "hasManagerAccess=1&limit=10&offset=1&orderBy=createdAt+desc%2Cname%2Cid&type=1&userId=1",
+			out: "groupId=2&hasManagerAccess=1&limit=10&offset=1&orderBy=createdAt+desc%2Cname%2Cid&type=1&userId=1",
 		},
 	}
 

--- a/third_party/crowdin-api-client-go/crowdin/model/translation_memory.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/translation_memory.go
@@ -44,6 +44,8 @@ type TranslationMemoriesListOptions struct {
 	OrderBy string `json:"orderBy,omitempty"`
 	// Project Member Identifier.
 	UserID int `json:"userId,omitempty"`
+	// Group identifier.
+	GroupID *int `json:"groupId,omitempty"`
 
 	ListOptions
 }
@@ -62,6 +64,9 @@ func (o *TranslationMemoriesListOptions) Values() (url.Values, bool) {
 	}
 	if o.UserID > 0 {
 		v.Add("userId", fmt.Sprintf("%d", o.UserID))
+	}
+	if o.GroupID != nil {
+		v.Add("groupId", fmt.Sprintf("%d", *o.GroupID))
 	}
 
 	return v, len(v) > 0

--- a/third_party/crowdin-api-client-go/crowdin/model/translation_memory_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/translation_memory_test.go
@@ -21,12 +21,17 @@ func TestTranslationMemoriesListOptionsValues(t *testing.T) {
 			opts: &TranslationMemoriesListOptions{},
 		},
 		{
+			name: "with groupId = 0",
+			opts: &TranslationMemoriesListOptions{GroupID: toPtr(0)},
+			out:  "groupId=0",
+		},
+		{
 			name: "all options",
 			opts: &TranslationMemoriesListOptions{
-				OrderBy: "createdAt desc,name", UserID: 1,
+				OrderBy: "createdAt desc,name", UserID: 1, GroupID: toPtr(2),
 				ListOptions: ListOptions{Limit: 10, Offset: 5},
 			},
-			out: "limit=10&offset=5&orderBy=createdAt+desc%2Cname&userId=1",
+			out: "groupId=2&limit=10&offset=5&orderBy=createdAt+desc%2Cname&userId=1",
 		},
 	}
 

--- a/third_party/crowdin-api-client-go/crowdin/projects_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/projects_test.go
@@ -209,7 +209,10 @@ func TestProjectsService_Get(t *testing.T) {
 				"textDirection": "ltr",
 				"dialectOf": null
 			},
-			"tmContextType": "segmentContext"
+			"tmContextType": "segmentContext",
+			"templateId": 10,
+			"vendorId": 11,
+			"mtEngineId": 12
 		}
 	}`
 
@@ -405,6 +408,9 @@ func TestProjectsService_Get(t *testing.T) {
 		TMContextType:          "segmentContext",
 		Background:             "data:image/png;base64,iVBORw0KGgo",
 		AssistActionAiPromptID: 0,
+		TemplateID:             10,
+		VendorID:               11,
+		MTEngineID:             12,
 	}
 	assert.Equal(t, expectedProjects, project)
 }


### PR DESCRIPTION
This PR improves the Crowdin Go SDK fork's parity with the official API v2, specifically for Enterprise features:

1.  **Project Model Update**: Added `TemplateID`, `VendorID`, and `MTEngineID` fields to the `Project` struct to capture workflow and vendor-related metadata returned by the Enterprise API.
2.  **Filtering by Group ID**: Added `GroupID (*int)` to both `ProjectsListOptions` and `TranslationMemoriesListOptions`. Using a pointer allows for explicitly filtering by the root group (`groupId=0`) while omitting the parameter when not set.
3.  **Tests**: Updated unit tests for URL parameter encoding and JSON unmarshaling to verify the new fields.

Verified with `GOWORK=off go test ./...` inside the Crowdin fork directory.

---
*PR created automatically by Jules for task [811358690853009464](https://jules.google.com/task/811358690853009464) started by @cungminh2710*