### PR TITLE
feat(hl-356): Implement Crowdin translation pull and write-back

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -9,8 +9,14 @@ import { db, schema } from "@/lib/database";
 import type { Project } from "@/lib/database/types";
 import { getFileStorageAdapter, type FileStorageAdapter } from "@/lib/file-storage";
 import { normalizeSourcePath } from "@/lib/file-storage/records";
+import { pullCrowdinTaskContent } from "@/lib/providers/crowdin/crowdin-content-puller";
 import { fetchCrowdinFileKeys } from "@/lib/providers/crowdin/crowdin-file-fetcher";
 import { fetchCrowdinJobTasks } from "@/lib/providers/crowdin/crowdin-job-task-fetcher";
+import { pushCrowdinTranslations } from "@/lib/providers/crowdin/crowdin-translation-pusher";
+import {
+  pullExternalTmsTaskContent,
+  pushExternalTmsTranslations,
+} from "@/lib/providers/external-tms-content-sync";
 import { syncExternalTmsFileKeys } from "@/lib/providers/external-tms-file-sync";
 import { syncExternalTmsJobTasks } from "@/lib/providers/external-tms-job-sync";
 import { listExternalTmsFilesForProject } from "@/lib/providers/organization-external-tms-files";
@@ -21,6 +27,8 @@ import { createTranslationJobEventQueue } from "@/workflows/adapters";
 
 import {
   createProjectBodySchema,
+  externalTmsContentSyncBodySchema,
+  externalTmsTranslationPushBodySchema,
   projectFileDetailQuerySchema,
   projectFilesQuerySchema,
   projectIdParamsSchema,
@@ -159,6 +167,26 @@ const validateCreateProjectBody = validator("json", (value, c) => {
 
 const validateUpdateProjectBody = validator("json", (value, c) => {
   const parsed = updateProjectBodySchema.safeParse(value);
+
+  if (!parsed.success) {
+    return invalidProjectPayloadResponse(c);
+  }
+
+  return parsed.data;
+});
+
+const validateExternalTmsContentSyncBody = validator("json", (value, c) => {
+  const parsed = externalTmsContentSyncBodySchema.safeParse(value);
+
+  if (!parsed.success) {
+    return invalidProjectPayloadResponse(c);
+  }
+
+  return parsed.data;
+});
+
+const validateExternalTmsTranslationPushBody = validator("json", (value, c) => {
+  const parsed = externalTmsTranslationPushBodySchema.safeParse(value);
 
   if (!parsed.success) {
     return invalidProjectPayloadResponse(c);
@@ -800,6 +828,74 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
 
       return c.json({ externalTmsJobTaskSync: result }, result.status === "failed" ? 207 : 200);
     })
+    .post(
+      "/:projectId/sync-pull-content",
+      validateProjectParams,
+      validateExternalTmsContentSyncBody,
+      async (c) => {
+        if (!isProjectMutationAllowed(c.var.auth.membership.role)) {
+          return forbiddenResponse(c);
+        }
+
+        const params = c.req.valid("param");
+        const payload = c.req.valid("json");
+        const project = await projectStore.getById(c.var.auth, params.projectId);
+
+        if (!project) {
+          return projectNotFoundResponse(c);
+        }
+
+        if (project.externalProviderKind !== "crowdin") {
+          return c.json({ error: "provider_sync_not_implemented" }, 501);
+        }
+
+        const result = await pullExternalTmsTaskContent({
+          organizationId: c.var.auth.organization.localOrganizationId,
+          projectId: project.id,
+          providerKind: "crowdin",
+          externalJobId: payload.externalJobId,
+          pullContent: pullCrowdinTaskContent,
+        });
+
+        return c.json({ externalTmsContentPull: result }, 200);
+      },
+    )
+    .post(
+      "/:projectId/sync-push-translations",
+      validateProjectParams,
+      validateExternalTmsTranslationPushBody,
+      async (c) => {
+        if (!isProjectMutationAllowed(c.var.auth.membership.role)) {
+          return forbiddenResponse(c);
+        }
+
+        const params = c.req.valid("param");
+        const payload = c.req.valid("json");
+        const project = await projectStore.getById(c.var.auth, params.projectId);
+
+        if (!project) {
+          return projectNotFoundResponse(c);
+        }
+
+        if (project.externalProviderKind !== "crowdin") {
+          return c.json({ error: "provider_sync_not_implemented" }, 501);
+        }
+
+        const result = await pushExternalTmsTranslations({
+          organizationId: c.var.auth.organization.localOrganizationId,
+          projectId: project.id,
+          providerKind: "crowdin",
+          externalJobId: payload.externalJobId,
+          translations: payload.translations,
+          pushTranslations: pushCrowdinTranslations,
+        });
+
+        return c.json(
+          { externalTmsTranslationPush: result },
+          result.status === "failed" ? 207 : 200,
+        );
+      },
+    )
     .delete("/:projectId", validateProjectParams, async (c) => {
       if (!isProjectMutationAllowed(c.var.auth.membership.role)) {
         return forbiddenResponse(c);

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -857,7 +857,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
           pullContent: pullCrowdinTaskContent,
         });
 
-        return c.json({ externalTmsContentPull: result }, 200);
+        return c.json({ externalTmsContentPull: result }, result.status === "failed" ? 207 : 200);
       },
     )
     .post(

--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { externalTmsTranslationPushBodySchema } from "./project.schema";
+
+describe("externalTmsTranslationPushBodySchema", () => {
+  it("requires either key or externalStringId on each translation", () => {
+    const result = externalTmsTranslationPushBodySchema.safeParse({
+      externalJobId: "2001",
+      translations: [{ locale: "fr", text: "Bonjour" }],
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe(
+        "Either key or externalStringId must be provided",
+      );
+    }
+  });
+
+  it("accepts translations identified by key", () => {
+    const result = externalTmsTranslationPushBodySchema.safeParse({
+      externalJobId: "2001",
+      translations: [{ locale: "fr", text: "Bonjour", key: "hello" }],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts translations identified by externalStringId", () => {
+    const result = externalTmsTranslationPushBodySchema.safeParse({
+      externalJobId: "2001",
+      translations: [{ locale: "fr", text: "Bonjour", externalStringId: "1001" }],
+    });
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -12,15 +12,20 @@ export const externalTmsTranslationPushBodySchema = z.object({
   externalJobId: z.string().trim().min(1).max(128),
   translations: z
     .array(
-      z.object({
-        externalStringId: z.string().trim().min(1).max(128).optional(),
-        key: z.string().trim().min(1).max(512).optional(),
-        locale: z.string().trim().min(1).max(32),
-        text: z.string(),
-        fileId: z.string().trim().min(1).max(128).optional(),
-        fileName: z.string().trim().min(1).max(256).optional(),
-        format: z.string().trim().min(1).max(64).optional(),
-      }),
+      z
+        .object({
+          externalStringId: z.string().trim().min(1).max(128).optional(),
+          key: z.string().trim().min(1).max(512).optional(),
+          locale: z.string().trim().min(1).max(32),
+          text: z.string(),
+          fileId: z.string().trim().min(1).max(128).optional(),
+          fileName: z.string().trim().min(1).max(256).optional(),
+          format: z.string().trim().min(1).max(64).optional(),
+        })
+        .refine((data) => data.key != null || data.externalStringId != null, {
+          message: "Either key or externalStringId must be provided",
+          path: ["key"],
+        }),
     )
     .min(1),
 });

--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -4,6 +4,27 @@ export const projectIdParamsSchema = z.object({
   projectId: z.string().trim().min(1).max(128),
 });
 
+export const externalTmsContentSyncBodySchema = z.object({
+  externalJobId: z.string().trim().min(1).max(128),
+});
+
+export const externalTmsTranslationPushBodySchema = z.object({
+  externalJobId: z.string().trim().min(1).max(128),
+  translations: z
+    .array(
+      z.object({
+        externalStringId: z.string().trim().min(1).max(128).optional(),
+        key: z.string().trim().min(1).max(512).optional(),
+        locale: z.string().trim().min(1).max(32),
+        text: z.string(),
+        fileId: z.string().trim().min(1).max(128).optional(),
+        fileName: z.string().trim().min(1).max(256).optional(),
+        format: z.string().trim().min(1).max(64).optional(),
+      }),
+    )
+    .min(1),
+});
+
 export const createProjectBodySchema = z.object({
   name: z.string().trim().min(1).max(200),
   description: z.string().max(10_000).optional(),

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-api.test.ts
@@ -381,6 +381,66 @@ describe("CrowdinApiClient", () => {
     });
   });
 
+  it("gets a task and uploads translations through storage", async () => {
+    const fetchMock = vi.fn(async (url, init) => {
+      const path = String(url);
+
+      if (path.endsWith("/projects/1/tasks/9")) {
+        return new Response(
+          JSON.stringify({
+            data: {
+              id: 9,
+              projectId: 1,
+              type: 0,
+              status: "todo",
+              title: "Task",
+              description: null,
+              targetLanguageId: "fr",
+              languageId: "fr",
+              fileIds: [101],
+              webUrl: "https://crowdin.com/project/1/tasks/9",
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.endsWith("/storages")) {
+        return new Response(JSON.stringify({ data: { id: 12, fileName: "fr.json" } }), {
+          status: 201,
+        });
+      }
+
+      if (path.endsWith("/projects/1/translations/fr") && init?.method === "POST") {
+        return new Response(
+          JSON.stringify({
+            data: { projectId: 1, storageId: 12, languageId: "fr", fileId: 101 },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    const task = await client.getTask(1, 9);
+    expect(task.targetLanguageId).toBe("fr");
+
+    const storage = await client.addStorage({
+      fileName: "fr.json",
+      content: new TextEncoder().encode('{"hello":"Bonjour"}'),
+      contentType: "application/json",
+    });
+    expect(storage.id).toBe(12);
+
+    const upload = await client.uploadTranslations(1, "fr", {
+      storageId: storage.id,
+      fileId: 101,
+    });
+    expect(upload.fileId).toBe(101);
+  });
+
   it("lists project language progress", async () => {
     const fetchMock = vi.fn(async () => {
       return new Response(

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-api.ts
@@ -109,6 +109,60 @@ export interface CrowdinLanguageProgress {
   approvalProgress: number;
 }
 
+export interface CrowdinTaskDetails extends CrowdinTask {
+  sourceLanguageId?: string;
+  targetLanguageId?: string;
+  stringIds?: number[] | null;
+}
+
+export interface CrowdinLanguageTranslation {
+  stringId: number;
+  contentType: string;
+  translationId: number | null;
+  text: string | null;
+  createdAt: string | null;
+}
+
+export interface CrowdinStringTranslation {
+  id: number;
+  text: string;
+  createdAt: string;
+}
+
+export interface CrowdinTranslationApproval {
+  id: number;
+  translationId: number;
+  stringId: number;
+  languageId: string;
+}
+
+export interface CrowdinStorage {
+  id: number;
+  fileName: string;
+}
+
+export interface CrowdinUploadTranslationsResult {
+  projectId: number;
+  storageId: number;
+  languageId: string;
+  fileId: number;
+}
+
+export interface CrowdinTranslationBuild {
+  id: number;
+  projectId: number;
+  status: string;
+  progress: number;
+  createdAt: string;
+  updatedAt: string;
+  finishedAt: string | null;
+}
+
+export interface CrowdinDownloadLink {
+  url: string;
+  expireIn?: string;
+}
+
 interface CrowdinListResponse<T> {
   data: Array<{ data: T }>;
   pagination?: {
@@ -341,6 +395,297 @@ export class CrowdinApiClient {
   }
 
   /**
+   * Get a single task by identifier.
+   */
+  async getTask(projectId: number, taskId: number): Promise<CrowdinTaskDetails> {
+    const response = await this.get<CrowdinGetResponse<CrowdinTaskDetails>>(
+      `/projects/${projectId}/tasks/${taskId}`,
+    );
+    return response.data;
+  }
+
+  /**
+   * List language-scoped translations for a project.
+   */
+  async listLanguageTranslations(
+    projectId: number,
+    languageId: string,
+    options?: { fileId?: number; stringIds?: number[] },
+  ): Promise<CrowdinLanguageTranslation[]> {
+    const translations: CrowdinLanguageTranslation[] = [];
+    let offset = 0;
+    const limit = 500;
+
+    while (true) {
+      const params = new URLSearchParams({
+        limit: String(limit),
+        offset: String(offset),
+      });
+      if (options?.fileId !== undefined) {
+        params.append("fileId", String(options.fileId));
+      }
+      if (options?.stringIds?.length) {
+        params.append("stringIds", options.stringIds.join(","));
+      }
+
+      const response = await this.get<CrowdinListResponse<CrowdinLanguageTranslation>>(
+        `/projects/${projectId}/languages/${languageId}/translations?${params.toString()}`,
+      );
+      const page = response.data.map((item) => item.data);
+      translations.push(...page);
+
+      if (page.length < limit) {
+        break;
+      }
+
+      offset += limit;
+    }
+
+    return translations;
+  }
+
+  /**
+   * List string translations for a specific string and language.
+   */
+  async listStringTranslations(
+    projectId: number,
+    stringId: number,
+    languageId: string,
+  ): Promise<CrowdinStringTranslation[]> {
+    const params = new URLSearchParams({
+      stringId: String(stringId),
+      languageId,
+      limit: "500",
+      offset: "0",
+    });
+    const response = await this.get<CrowdinListResponse<CrowdinStringTranslation>>(
+      `/projects/${projectId}/translations?${params.toString()}`,
+    );
+    return response.data.map((item) => item.data);
+  }
+
+  /**
+   * List translation approvals, optionally filtered by language.
+   */
+  async listTranslationApprovals(
+    projectId: number,
+    languageId?: string,
+  ): Promise<CrowdinTranslationApproval[]> {
+    const approvals: CrowdinTranslationApproval[] = [];
+    let offset = 0;
+    const limit = 500;
+
+    while (true) {
+      const params = new URLSearchParams({ limit: String(limit), offset: String(offset) });
+      if (languageId) {
+        params.append("languageId", languageId);
+      }
+
+      const response = await this.get<CrowdinListResponse<CrowdinTranslationApproval>>(
+        `/projects/${projectId}/approvals?${params.toString()}`,
+      );
+      const page = response.data.map((item) => item.data);
+      approvals.push(...page);
+
+      if (page.length < limit) {
+        break;
+      }
+
+      offset += limit;
+    }
+
+    return approvals;
+  }
+
+  /**
+   * Upload file bytes to Crowdin storage.
+   */
+  async addStorage(input: { fileName: string; content: Uint8Array; contentType?: string }) {
+    const url = `${this.baseUrl}/storages`;
+    const response = await this.fetchFn(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.token}`,
+        "Content-Type": input.contentType ?? "application/octet-stream",
+        "Crowdin-API-FileName": encodeURIComponent(input.fileName),
+      },
+      body: input.content as BodyInit,
+    });
+
+    if (!response.ok) {
+      let body: unknown;
+      try {
+        body = await response.json();
+      } catch {
+        body = await response.text().catch(() => null);
+      }
+
+      throw new CrowdinApiError(
+        `Crowdin API returned HTTP ${response.status} for /storages`,
+        response.status,
+        body,
+      );
+    }
+
+    const payload = (await response.json()) as CrowdinGetResponse<CrowdinStorage>;
+    return payload.data;
+  }
+
+  /**
+   * Import uploaded storage content as translations for a language.
+   */
+  async uploadTranslations(
+    projectId: number,
+    languageId: string,
+    input: {
+      storageId: number;
+      fileId: number;
+      autoApproveImported?: boolean;
+    },
+  ): Promise<CrowdinUploadTranslationsResult> {
+    const response = await this.post<CrowdinGetResponse<CrowdinUploadTranslationsResult>>(
+      `/projects/${projectId}/translations/${languageId}`,
+      {
+        storageId: input.storageId,
+        fileId: input.fileId,
+        autoApproveImported: input.autoApproveImported ?? true,
+      },
+    );
+    return response.data;
+  }
+
+  /**
+   * Start an async project translation build.
+   */
+  async buildProjectTranslation(
+    projectId: number,
+    input?: { targetLanguageIds?: string[]; exportApprovedOnly?: boolean },
+  ): Promise<CrowdinTranslationBuild> {
+    const response = await this.post<CrowdinGetResponse<CrowdinTranslationBuild>>(
+      `/projects/${projectId}/translations/builds`,
+      {
+        skipUntranslatedStrings: false,
+        skipUntranslatedFiles: false,
+        exportApprovedOnly: input?.exportApprovedOnly ?? false,
+        targetLanguageIds: input?.targetLanguageIds,
+      },
+    );
+    return response.data;
+  }
+
+  /**
+   * Check status of an async translation build.
+   */
+  async getTranslationBuildStatus(
+    projectId: number,
+    buildId: number,
+  ): Promise<CrowdinTranslationBuild> {
+    const response = await this.get<CrowdinGetResponse<CrowdinTranslationBuild>>(
+      `/projects/${projectId}/translations/builds/${buildId}`,
+    );
+    return response.data;
+  }
+
+  /**
+   * Get a download link for a completed translation build.
+   */
+  async downloadTranslationBuild(projectId: number, buildId: number): Promise<CrowdinDownloadLink> {
+    const response = await this.get<CrowdinGetResponse<CrowdinDownloadLink>>(
+      `/projects/${projectId}/translations/builds/${buildId}/download`,
+    );
+    return response.data;
+  }
+
+  /**
+   * Export strings for a task and return a download link when available.
+   */
+  async exportTaskStrings(projectId: number, taskId: number): Promise<CrowdinDownloadLink | null> {
+    const response = await this.fetchFn(
+      `${this.baseUrl}/projects/${projectId}/tasks/${taskId}/exports`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${this.token}`,
+          "Content-Type": "application/json",
+        },
+        body: "",
+      },
+    );
+
+    if (response.status === 204) {
+      return null;
+    }
+
+    if (!response.ok) {
+      let body: unknown;
+      try {
+        body = await response.json();
+      } catch {
+        body = await response.text().catch(() => null);
+      }
+
+      throw new CrowdinApiError(
+        `Crowdin API returned HTTP ${response.status} for /projects/${projectId}/tasks/${taskId}/exports`,
+        response.status,
+        body,
+      );
+    }
+
+    const payload = (await response.json()) as CrowdinGetResponse<CrowdinDownloadLink>;
+    return payload.data;
+  }
+
+  /**
+   * Download content from a Crowdin-provided URL.
+   */
+  async downloadUrl(url: string): Promise<Uint8Array> {
+    const response = await this.fetchFn(url, { method: "GET" });
+    if (!response.ok) {
+      throw new CrowdinApiError(
+        `Crowdin download returned HTTP ${response.status}`,
+        response.status,
+        null,
+      );
+    }
+
+    const buffer = await response.arrayBuffer();
+    return new Uint8Array(buffer);
+  }
+
+  /**
+   * Poll a translation build until it finishes or fails.
+   */
+  async waitForTranslationBuild(
+    projectId: number,
+    buildId: number,
+    options?: { maxAttempts?: number; delayMs?: number },
+  ): Promise<CrowdinTranslationBuild> {
+    const maxAttempts = options?.maxAttempts ?? 20;
+    const delayMs = options?.delayMs ?? 250;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+      const build = await this.getTranslationBuildStatus(projectId, buildId);
+      if (build.status === "finished") {
+        return build;
+      }
+      if (build.status === "failed" || build.status === "canceled") {
+        throw new CrowdinApiError(
+          `Crowdin translation build ${buildId} finished with status ${build.status}`,
+          500,
+          build,
+        );
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+
+    throw new CrowdinApiError(`Crowdin translation build ${buildId} timed out`, 504, {
+      buildId,
+      projectId,
+    });
+  }
+
+  /**
    * Get translation progress for each target language in a project.
    */
   async listProjectLanguageProgress(projectId: number): Promise<CrowdinLanguageProgress[]> {
@@ -365,15 +710,31 @@ export class CrowdinApiClient {
     return progress;
   }
 
+  private authHeaders(contentType = "application/json"): Record<string, string> {
+    return {
+      Authorization: `Bearer ${this.token}`,
+      "Content-Type": contentType,
+    };
+  }
+
   private async get<T>(path: string): Promise<T> {
-    const url = `${this.baseUrl}${path}`;
-    const response = await this.fetchFn(url, {
+    return this.request<T>(path, {
       method: "GET",
-      headers: {
-        Authorization: `Bearer ${this.token}`,
-        "Content-Type": "application/json",
-      },
+      headers: this.authHeaders(),
     });
+  }
+
+  private async post<T>(path: string, body: unknown): Promise<T> {
+    return this.request<T>(path, {
+      method: "POST",
+      headers: this.authHeaders(),
+      body: JSON.stringify(body),
+    });
+  }
+
+  private async request<T>(path: string, init: RequestInit): Promise<T> {
+    const url = `${this.baseUrl}${path}`;
+    const response = await this.fetchFn(url, init);
 
     if (!response.ok) {
       let body: unknown;

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-api.ts
@@ -345,16 +345,29 @@ export class CrowdinApiClient {
   /**
    * List source strings for a given project, optionally filtered by file.
    */
-  async listSourceStrings(projectId: number, fileId?: number): Promise<CrowdinSourceString[]> {
+  async listSourceStrings(
+    projectId: number,
+    fileId?: number,
+    stringIds?: number[],
+  ): Promise<CrowdinSourceString[]> {
     const strings: CrowdinSourceString[] = [];
     let offset = 0;
     const limit = 500;
 
-    const fileParam = fileId !== undefined ? `&fileId=${fileId}` : "";
-
     while (true) {
+      const params = new URLSearchParams({
+        limit: String(limit),
+        offset: String(offset),
+      });
+      if (fileId !== undefined) {
+        params.append("fileId", String(fileId));
+      }
+      if (stringIds?.length) {
+        params.append("stringIds", stringIds.join(","));
+      }
+
       const response = await this.get<CrowdinListResponse<CrowdinSourceString>>(
-        `/projects/${projectId}/strings?limit=${limit}&offset=${offset}${fileParam}`,
+        `/projects/${projectId}/strings?${params.toString()}`,
       );
       const page = response.data.map((item) => item.data);
       strings.push(...page);
@@ -452,16 +465,31 @@ export class CrowdinApiClient {
     stringId: number,
     languageId: string,
   ): Promise<CrowdinStringTranslation[]> {
-    const params = new URLSearchParams({
-      stringId: String(stringId),
-      languageId,
-      limit: "500",
-      offset: "0",
-    });
-    const response = await this.get<CrowdinListResponse<CrowdinStringTranslation>>(
-      `/projects/${projectId}/translations?${params.toString()}`,
-    );
-    return response.data.map((item) => item.data);
+    const translations: CrowdinStringTranslation[] = [];
+    let offset = 0;
+    const limit = 500;
+
+    while (true) {
+      const params = new URLSearchParams({
+        stringId: String(stringId),
+        languageId,
+        limit: String(limit),
+        offset: String(offset),
+      });
+      const response = await this.get<CrowdinListResponse<CrowdinStringTranslation>>(
+        `/projects/${projectId}/translations?${params.toString()}`,
+      );
+      const page = response.data.map((item) => item.data);
+      translations.push(...page);
+
+      if (page.length < limit) {
+        break;
+      }
+
+      offset += limit;
+    }
+
+    return translations;
   }
 
   /**
@@ -660,8 +688,8 @@ export class CrowdinApiClient {
     buildId: number,
     options?: { maxAttempts?: number; delayMs?: number },
   ): Promise<CrowdinTranslationBuild> {
-    const maxAttempts = options?.maxAttempts ?? 20;
-    const delayMs = options?.delayMs ?? 250;
+    const maxAttempts = options?.maxAttempts ?? 90;
+    const delayMs = options?.delayMs ?? 2000;
 
     for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
       const build = await this.getTranslationBuildStatus(projectId, buildId);

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-content-puller.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-content-puller.test.ts
@@ -74,10 +74,23 @@ describe("pullCrowdinTaskContent", () => {
         );
       }
 
-      if (path.includes("/projects/42/translations?") && path.includes("stringId=1001")) {
+      if (
+        path.includes("/projects/42/languages/fr/translations?") &&
+        path.includes("stringIds=1001")
+      ) {
         return new Response(
           JSON.stringify({
-            data: [{ data: { id: 9001, text: "Bonjour", createdAt: "2026-05-22T00:00:00Z" } }],
+            data: [
+              {
+                data: {
+                  stringId: 1001,
+                  contentType: "text",
+                  translationId: 9001,
+                  text: "Bonjour",
+                  createdAt: "2026-05-22T00:00:00Z",
+                },
+              },
+            ],
           }),
           { status: 200 },
         );
@@ -88,9 +101,9 @@ describe("pullCrowdinTaskContent", () => {
       }
 
       return new Response(JSON.stringify({ data: [] }), { status: 200 });
-    }) as unknown as typeof fetch;
+    });
 
-    globalThis.fetch = fetchMock;
+    globalThis.fetch = fetchMock as typeof fetch;
 
     const result = await pullCrowdinTaskContent({
       organizationId: "org_1",
@@ -113,5 +126,15 @@ describe("pullCrowdinTaskContent", () => {
       sourceText: "Hello",
       translations: [{ locale: "fr", text: "Bonjour", isApproved: true }],
     });
+
+    const languageTranslationCalls = fetchMock.mock.calls.filter(([url]) =>
+      String(url).includes("/projects/42/languages/fr/translations?"),
+    );
+    expect(languageTranslationCalls).toHaveLength(1);
+    expect(
+      fetchMock.mock.calls.some(([url]) =>
+        String(url).includes("/projects/42/translations?stringId="),
+      ),
+    ).toBe(false);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-content-puller.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-content-puller.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { pullCrowdinTaskContent } from "./crowdin-content-puller";
+
+describe("pullCrowdinTaskContent", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("pulls source strings and approved translations for a task", async () => {
+    const fetchMock = vi.fn(async (url, init) => {
+      const path = String(url);
+
+      if (path.endsWith("/projects/42/tasks/2001") && init?.method !== "POST") {
+        return new Response(
+          JSON.stringify({
+            data: {
+              id: 2001,
+              projectId: 42,
+              type: 0,
+              status: "in_progress",
+              title: "French task",
+              description: null,
+              sourceLanguageId: "en",
+              targetLanguageId: "fr",
+              languageId: "fr",
+              fileIds: [101],
+              stringIds: null,
+              assignees: null,
+              deadline: null,
+              webUrl: "https://crowdin.com/project/42/tasks/2001",
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/projects/42/strings?") && path.includes("fileId=101")) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  id: 1001,
+                  projectId: 42,
+                  fileId: 101,
+                  branchId: null,
+                  directoryId: null,
+                  identifier: "hello",
+                  text: "Hello",
+                  type: "text",
+                  context: null,
+                  labelIds: null,
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/projects/42/approvals?")) {
+        return new Response(
+          JSON.stringify({
+            data: [{ data: { id: 1, translationId: 9001, stringId: 1001, languageId: "fr" } }],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/projects/42/translations?") && path.includes("stringId=1001")) {
+        return new Response(
+          JSON.stringify({
+            data: [{ data: { id: 9001, text: "Bonjour", createdAt: "2026-05-22T00:00:00Z" } }],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.endsWith("/projects/42/tasks/2001/exports")) {
+        return new Response(null, { status: 204 });
+      }
+
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    globalThis.fetch = fetchMock;
+
+    const result = await pullCrowdinTaskContent({
+      organizationId: "org_1",
+      projectId: "proj_1",
+      providerKind: "crowdin",
+      externalProjectId: "42",
+      externalJobId: "2001",
+      credential: {
+        id: "cred_1",
+        baseUrl: "https://api.crowdin.test/api/v2",
+      } as never,
+      project: {} as never,
+      secretMaterial: "token",
+    });
+
+    expect(result.units).toHaveLength(1);
+    expect(result.units[0]).toMatchObject({
+      externalStringId: "1001",
+      key: "hello",
+      sourceText: "Hello",
+      translations: [{ locale: "fr", text: "Bonjour", isApproved: true }],
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-content-puller.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-content-puller.ts
@@ -2,6 +2,14 @@ import type { ExternalTmsContentPuller } from "@/lib/providers/external-tms-cont
 
 import { CrowdinApiClient, CrowdinApiError } from "./crowdin-api";
 
+function chunkArray<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
+}
+
 function sourceTextValue(text: string | Record<string, string>): string {
   if (typeof text === "string") {
     return text;
@@ -47,9 +55,9 @@ export const pullCrowdinTaskContent: ExternalTmsContentPuller = async ({
   const sourceStrings: Awaited<ReturnType<typeof client.listSourceStrings>> = [];
 
   if (stringIds.length > 0) {
-    const allStrings = await client.listSourceStrings(projectId);
-    const allowed = new Set(stringIds);
-    sourceStrings.push(...allStrings.filter((entry) => allowed.has(entry.id)));
+    for (const chunk of chunkArray(stringIds, 25)) {
+      sourceStrings.push(...(await client.listSourceStrings(projectId, undefined, chunk)));
+    }
   } else if (fileIds.length > 0) {
     for (const fileId of fileIds) {
       sourceStrings.push(...(await client.listSourceStrings(projectId, fileId)));

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-content-puller.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-content-puller.ts
@@ -69,34 +69,53 @@ export const pullCrowdinTaskContent: ExternalTmsContentPuller = async ({
   const approvals = await client.listTranslationApprovals(projectId, targetLanguageId);
   const approvedTranslationIds = new Set(approvals.map((approval) => approval.translationId));
 
-  const units: Awaited<ReturnType<ExternalTmsContentPuller>>["units"] = [];
+  const translationsByStringId = new Map<
+    number,
+    Awaited<ReturnType<typeof client.listLanguageTranslations>>
+  >();
+  const sourceStringIds = sourceStrings.map((sourceString) => sourceString.id);
 
-  for (const sourceString of sourceStrings) {
-    const translations = await client.listStringTranslations(
-      projectId,
-      sourceString.id,
-      targetLanguageId,
-    );
-
-    units.push({
-      externalStringId: String(sourceString.id),
-      key: sourceString.identifier,
-      sourceText: sourceTextValue(sourceString.text),
-      context: sourceString.context,
-      fileId: sourceString.fileId ? String(sourceString.fileId) : null,
-      translations: translations.map((translation) => ({
-        locale: targetLanguageId,
-        text: translation.text,
-        externalTranslationId: String(translation.id),
-        isApproved: approvedTranslationIds.has(translation.id),
-      })),
-      providerPayload: {
-        type: sourceString.type,
-        branchId: sourceString.branchId,
-        directoryId: sourceString.directoryId,
-      },
+  for (const chunk of chunkArray(sourceStringIds, 25)) {
+    const batch = await client.listLanguageTranslations(projectId, targetLanguageId, {
+      stringIds: chunk,
     });
+
+    for (const translation of batch) {
+      const existing = translationsByStringId.get(translation.stringId) ?? [];
+      existing.push(translation);
+      translationsByStringId.set(translation.stringId, existing);
+    }
   }
+
+  const units: Awaited<ReturnType<ExternalTmsContentPuller>>["units"] = sourceStrings.map(
+    (sourceString) => {
+      const translations = translationsByStringId.get(sourceString.id) ?? [];
+
+      return {
+        externalStringId: String(sourceString.id),
+        key: sourceString.identifier,
+        sourceText: sourceTextValue(sourceString.text),
+        context: sourceString.context,
+        fileId: sourceString.fileId ? String(sourceString.fileId) : null,
+        translations: translations
+          .filter((translation) => translation.text != null)
+          .map((translation) => ({
+            locale: targetLanguageId,
+            text: translation.text as string,
+            externalTranslationId:
+              translation.translationId != null ? String(translation.translationId) : null,
+            isApproved:
+              translation.translationId != null &&
+              approvedTranslationIds.has(translation.translationId),
+          })),
+        providerPayload: {
+          type: sourceString.type,
+          branchId: sourceString.branchId,
+          directoryId: sourceString.directoryId,
+        },
+      };
+    },
+  );
 
   let exportArtifact: Awaited<ReturnType<ExternalTmsContentPuller>>["exportArtifact"] = null;
   try {

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-content-puller.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-content-puller.ts
@@ -1,0 +1,122 @@
+import type { ExternalTmsContentPuller } from "@/lib/providers/external-tms-content-sync";
+
+import { CrowdinApiClient, CrowdinApiError } from "./crowdin-api";
+
+function sourceTextValue(text: string | Record<string, string>): string {
+  if (typeof text === "string") {
+    return text;
+  }
+
+  return text.one ?? text.other ?? Object.values(text)[0] ?? "";
+}
+
+export const pullCrowdinTaskContent: ExternalTmsContentPuller = async ({
+  credential,
+  externalProjectId,
+  externalJobId,
+  secretMaterial,
+}) => {
+  const client = new CrowdinApiClient({
+    token: secretMaterial,
+    baseUrl: credential.baseUrl ?? undefined,
+  });
+
+  const projectId = Number(externalProjectId);
+  const taskId = Number(externalJobId);
+  if (Number.isNaN(projectId) || Number.isNaN(taskId)) {
+    throw new Error("invalid_crowdin_project_or_task_id");
+  }
+
+  let task: Awaited<ReturnType<typeof client.getTask>>;
+  try {
+    task = await client.getTask(projectId, taskId);
+  } catch (error) {
+    if (error instanceof CrowdinApiError && error.status === 401) {
+      throw new Error("crowdin_auth_invalid");
+    }
+    throw error;
+  }
+
+  const targetLanguageId = task.targetLanguageId ?? task.languageId;
+  if (!targetLanguageId) {
+    throw new Error("crowdin_task_missing_target_language");
+  }
+
+  const fileIds = task.fileIds ?? [];
+  const stringIds = task.stringIds ?? [];
+  const sourceStrings: Awaited<ReturnType<typeof client.listSourceStrings>> = [];
+
+  if (stringIds.length > 0) {
+    const allStrings = await client.listSourceStrings(projectId);
+    const allowed = new Set(stringIds);
+    sourceStrings.push(...allStrings.filter((entry) => allowed.has(entry.id)));
+  } else if (fileIds.length > 0) {
+    for (const fileId of fileIds) {
+      sourceStrings.push(...(await client.listSourceStrings(projectId, fileId)));
+    }
+  } else {
+    sourceStrings.push(...(await client.listSourceStrings(projectId)));
+  }
+
+  const approvals = await client.listTranslationApprovals(projectId, targetLanguageId);
+  const approvedTranslationIds = new Set(approvals.map((approval) => approval.translationId));
+
+  const units: Awaited<ReturnType<ExternalTmsContentPuller>>["units"] = [];
+
+  for (const sourceString of sourceStrings) {
+    const translations = await client.listStringTranslations(
+      projectId,
+      sourceString.id,
+      targetLanguageId,
+    );
+
+    units.push({
+      externalStringId: String(sourceString.id),
+      key: sourceString.identifier,
+      sourceText: sourceTextValue(sourceString.text),
+      context: sourceString.context,
+      fileId: sourceString.fileId ? String(sourceString.fileId) : null,
+      translations: translations.map((translation) => ({
+        locale: targetLanguageId,
+        text: translation.text,
+        externalTranslationId: String(translation.id),
+        isApproved: approvedTranslationIds.has(translation.id),
+      })),
+      providerPayload: {
+        type: sourceString.type,
+        branchId: sourceString.branchId,
+        directoryId: sourceString.directoryId,
+      },
+    });
+  }
+
+  let exportArtifact: Awaited<ReturnType<ExternalTmsContentPuller>>["exportArtifact"] = null;
+  try {
+    const exportLink = await client.exportTaskStrings(projectId, taskId);
+    if (exportLink?.url) {
+      const bytes = await client.downloadUrl(exportLink.url);
+      exportArtifact = {
+        url: exportLink.url,
+        byteLength: bytes.byteLength,
+      };
+    }
+  } catch {
+    // Task export is best-effort for agent workflows.
+  }
+
+  return {
+    externalJobId: String(task.id),
+    externalTaskId: null,
+    sourceLocale: task.sourceLanguageId ?? null,
+    targetLocales: [targetLanguageId],
+    units,
+    exportArtifact,
+    providerPayload: {
+      status: task.status,
+      title: task.title,
+      fileIds: task.fileIds,
+      stringIds: task.stringIds,
+      webUrl: task.webUrl,
+    },
+  };
+};

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-translation-pusher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-translation-pusher.test.ts
@@ -185,4 +185,60 @@ describe("pushCrowdinTranslations", () => {
     expect(result.asyncOperations).toEqual([]);
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
+
+  it("reports missing translation keys as failures", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      const path = String(url);
+
+      if (path.endsWith("/projects/42/tasks/2001")) {
+        return new Response(
+          JSON.stringify({
+            data: {
+              id: 2001,
+              projectId: 42,
+              type: 0,
+              status: "in_progress",
+              title: "French task",
+              description: null,
+              targetLanguageId: "fr",
+              languageId: "fr",
+              fileIds: [101],
+              webUrl: "https://crowdin.com/project/42/tasks/2001",
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    globalThis.fetch = fetchMock;
+
+    const result = await pushCrowdinTranslations({
+      organizationId: "org_1",
+      projectId: "proj_1",
+      providerKind: "crowdin",
+      externalProjectId: "42",
+      externalJobId: "2001",
+      credential: {
+        id: "cred_1",
+        baseUrl: "https://api.crowdin.test/api/v2",
+      } as never,
+      project: {} as never,
+      secretMaterial: "token",
+      translations: [{ locale: "fr", text: "Bonjour", fileId: "101" }],
+    });
+
+    expect(result.uploaded).toBe(0);
+    expect(result.failed).toBe(1);
+    expect(result.failures).toEqual([
+      {
+        locale: "fr",
+        fileId: "101",
+        message: "crowdin_translation_missing_key",
+      },
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-translation-pusher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-translation-pusher.test.ts
@@ -128,4 +128,61 @@ describe("pushCrowdinTranslations", () => {
       ]),
     );
   });
+
+  it("reports missing file ids as failures and skips the build when nothing can be uploaded", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      const path = String(url);
+
+      if (path.endsWith("/projects/42/tasks/2001")) {
+        return new Response(
+          JSON.stringify({
+            data: {
+              id: 2001,
+              projectId: 42,
+              type: 0,
+              status: "in_progress",
+              title: "French task",
+              description: null,
+              targetLanguageId: "fr",
+              languageId: "fr",
+              fileIds: null,
+              webUrl: "https://crowdin.com/project/42/tasks/2001",
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    globalThis.fetch = fetchMock;
+
+    const result = await pushCrowdinTranslations({
+      organizationId: "org_1",
+      projectId: "proj_1",
+      providerKind: "crowdin",
+      externalProjectId: "42",
+      externalJobId: "2001",
+      credential: {
+        id: "cred_1",
+        baseUrl: "https://api.crowdin.test/api/v2",
+      } as never,
+      project: {} as never,
+      secretMaterial: "token",
+      translations: [{ locale: "fr", text: "Bonjour", key: "hello" }],
+    });
+
+    expect(result.uploaded).toBe(0);
+    expect(result.failed).toBe(1);
+    expect(result.failures).toEqual([
+      {
+        locale: "fr",
+        fileId: null,
+        message: "crowdin_translation_missing_file_id",
+      },
+    ]);
+    expect(result.asyncOperations).toEqual([]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-translation-pusher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-translation-pusher.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { pushCrowdinTranslations } from "./crowdin-translation-pusher";
+
+describe("pushCrowdinTranslations", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("uploads approved translations through storage/import and records async build metadata", async () => {
+    const fetchMock = vi.fn(async (url, init) => {
+      const path = String(url);
+
+      if (path.endsWith("/projects/42/tasks/2001")) {
+        return new Response(
+          JSON.stringify({
+            data: {
+              id: 2001,
+              projectId: 42,
+              type: 0,
+              status: "in_progress",
+              title: "French task",
+              description: null,
+              targetLanguageId: "fr",
+              languageId: "fr",
+              fileIds: [101],
+              webUrl: "https://crowdin.com/project/42/tasks/2001",
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.endsWith("/storages")) {
+        return new Response(JSON.stringify({ data: { id: 55, fileName: "fr.json" } }), {
+          status: 201,
+        });
+      }
+
+      if (path.endsWith("/projects/42/translations/fr")) {
+        return new Response(
+          JSON.stringify({
+            data: { projectId: 42, storageId: 55, languageId: "fr", fileId: 101 },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.endsWith("/projects/42/translations/builds") && init?.method === "POST") {
+        return new Response(
+          JSON.stringify({
+            data: {
+              id: 77,
+              projectId: 42,
+              status: "finished",
+              progress: 100,
+              createdAt: "2026-05-22T00:00:00Z",
+              updatedAt: "2026-05-22T00:00:01Z",
+              finishedAt: "2026-05-22T00:00:01Z",
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.endsWith("/projects/42/translations/builds/77")) {
+        return new Response(
+          JSON.stringify({
+            data: {
+              id: 77,
+              projectId: 42,
+              status: "finished",
+              progress: 100,
+              createdAt: "2026-05-22T00:00:00Z",
+              updatedAt: "2026-05-22T00:00:01Z",
+              finishedAt: "2026-05-22T00:00:01Z",
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.endsWith("/projects/42/translations/builds/77/download")) {
+        return new Response(
+          JSON.stringify({
+            data: { url: "https://downloads.crowdin.test/build-77.zip" },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    globalThis.fetch = fetchMock;
+
+    const result = await pushCrowdinTranslations({
+      organizationId: "org_1",
+      projectId: "proj_1",
+      providerKind: "crowdin",
+      externalProjectId: "42",
+      externalJobId: "2001",
+      credential: {
+        id: "cred_1",
+        baseUrl: "https://api.crowdin.test/api/v2",
+      } as never,
+      project: {} as never,
+      secretMaterial: "token",
+      translations: [{ locale: "fr", text: "Bonjour", fileId: "101", key: "hello" }],
+    });
+
+    expect(result.uploaded).toBe(1);
+    expect(result.failed).toBe(0);
+    expect(result.asyncOperations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "crowdin_upload_translations", storageId: 55 }),
+        expect.objectContaining({
+          type: "crowdin_translation_build",
+          buildId: 77,
+          downloadUrl: "https://downloads.crowdin.test/build-77.zip",
+        }),
+      ]),
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-translation-pusher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-translation-pusher.ts
@@ -54,10 +54,21 @@ export const pushCrowdinTranslations: ExternalTmsTranslationPusher = async ({
     throw new Error("crowdin_task_missing_target_language");
   }
 
+  let uploaded = 0;
+  let failed = 0;
+  const failures: Array<{ locale: string; message: string; fileId?: string | null }> = [];
+  const asyncOperations: Array<Record<string, unknown>> = [];
+
   const groups = new Map<string, FileUploadGroup>();
   for (const translation of translations) {
     const fileId = Number(translation.fileId ?? task.fileIds?.[0]);
     if (Number.isNaN(fileId)) {
+      failed += 1;
+      failures.push({
+        locale: translation.locale,
+        fileId: translation.fileId ?? null,
+        message: "crowdin_translation_missing_file_id",
+      });
       continue;
     }
 
@@ -76,10 +87,9 @@ export const pushCrowdinTranslations: ExternalTmsTranslationPusher = async ({
     groups.set(key, existing);
   }
 
-  let uploaded = 0;
-  let failed = 0;
-  const failures: Array<{ locale: string; message: string; fileId?: string | null }> = [];
-  const asyncOperations: Array<Record<string, unknown>> = [];
+  if (groups.size === 0) {
+    return { uploaded, failed, failures, asyncOperations };
+  }
 
   for (const group of groups.values()) {
     try {

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-translation-pusher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-translation-pusher.ts
@@ -12,6 +12,9 @@ type FileUploadGroup = {
 function buildJsonUpload(entries: Array<{ key: string; text: string }>) {
   const payload: Record<string, string> = {};
   for (const entry of entries) {
+    if (Object.prototype.hasOwnProperty.call(payload, entry.key)) {
+      console.warn(`buildJsonUpload: duplicate key "${entry.key}" – later value kept`);
+    }
     payload[entry.key] = entry.text;
   }
   const serialized = `${JSON.stringify(payload, null, 2)}\n`;
@@ -127,10 +130,7 @@ export const pushCrowdinTranslations: ExternalTmsTranslationPusher = async ({
       exportApprovedOnly: true,
     });
 
-    const finishedBuild = await client.waitForTranslationBuild(projectId, build.id, {
-      maxAttempts: 10,
-      delayMs: 100,
-    });
+    const finishedBuild = await client.waitForTranslationBuild(projectId, build.id);
 
     const downloadLink = await client.downloadTranslationBuild(projectId, finishedBuild.id);
     asyncOperations.push({

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-translation-pusher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-translation-pusher.ts
@@ -80,8 +80,19 @@ export const pushCrowdinTranslations: ExternalTmsTranslationPusher = async ({
       entries: [],
     };
 
+    const entryKey = translation.key ?? translation.externalStringId;
+    if (!entryKey) {
+      failed += 1;
+      failures.push({
+        locale: translation.locale,
+        fileId: translation.fileId ?? null,
+        message: "crowdin_translation_missing_key",
+      });
+      continue;
+    }
+
     existing.entries.push({
-      key: translation.key ?? translation.externalStringId ?? "unknown",
+      key: entryKey,
       text: translation.text,
     });
     groups.set(key, existing);

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-translation-pusher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-translation-pusher.ts
@@ -1,0 +1,157 @@
+import type { ExternalTmsTranslationPusher } from "@/lib/providers/external-tms-content-sync";
+
+import { CrowdinApiClient, CrowdinApiError } from "./crowdin-api";
+
+type FileUploadGroup = {
+  fileId: number;
+  locale: string;
+  fileName: string;
+  entries: Array<{ key: string; text: string }>;
+};
+
+function buildJsonUpload(entries: Array<{ key: string; text: string }>) {
+  const payload: Record<string, string> = {};
+  for (const entry of entries) {
+    payload[entry.key] = entry.text;
+  }
+  const serialized = `${JSON.stringify(payload, null, 2)}\n`;
+  return new TextEncoder().encode(serialized);
+}
+
+export const pushCrowdinTranslations: ExternalTmsTranslationPusher = async ({
+  credential,
+  externalProjectId,
+  externalJobId,
+  secretMaterial,
+  translations,
+}) => {
+  const client = new CrowdinApiClient({
+    token: secretMaterial,
+    baseUrl: credential.baseUrl ?? undefined,
+  });
+
+  const projectId = Number(externalProjectId);
+  const taskId = Number(externalJobId);
+  if (Number.isNaN(projectId) || Number.isNaN(taskId)) {
+    throw new Error("invalid_crowdin_project_or_task_id");
+  }
+
+  let task: Awaited<ReturnType<typeof client.getTask>>;
+  try {
+    task = await client.getTask(projectId, taskId);
+  } catch (error) {
+    if (error instanceof CrowdinApiError && error.status === 401) {
+      throw new Error("crowdin_auth_invalid");
+    }
+    throw error;
+  }
+
+  const targetLanguageId = task.targetLanguageId ?? task.languageId;
+  if (!targetLanguageId) {
+    throw new Error("crowdin_task_missing_target_language");
+  }
+
+  const groups = new Map<string, FileUploadGroup>();
+  for (const translation of translations) {
+    const fileId = Number(translation.fileId ?? task.fileIds?.[0]);
+    if (Number.isNaN(fileId)) {
+      continue;
+    }
+
+    const key = `${fileId}:${translation.locale}`;
+    const existing = groups.get(key) ?? {
+      fileId,
+      locale: translation.locale,
+      fileName: translation.fileName ?? `hyperlocalise-${fileId}-${translation.locale}.json`,
+      entries: [],
+    };
+
+    existing.entries.push({
+      key: translation.key ?? translation.externalStringId ?? "unknown",
+      text: translation.text,
+    });
+    groups.set(key, existing);
+  }
+
+  let uploaded = 0;
+  let failed = 0;
+  const failures: Array<{ locale: string; message: string; fileId?: string | null }> = [];
+  const asyncOperations: Array<Record<string, unknown>> = [];
+
+  for (const group of groups.values()) {
+    try {
+      const storage = await client.addStorage({
+        fileName: group.fileName,
+        content: buildJsonUpload(group.entries),
+        contentType: "application/json",
+      });
+
+      const importResult = await client.uploadTranslations(projectId, group.locale, {
+        storageId: storage.id,
+        fileId: group.fileId,
+        autoApproveImported: true,
+      });
+
+      uploaded += group.entries.length;
+      asyncOperations.push({
+        type: "crowdin_upload_translations",
+        storageId: storage.id,
+        fileId: group.fileId,
+        languageId: group.locale,
+        importResult,
+      });
+    } catch (error) {
+      failed += group.entries.length;
+      failures.push({
+        locale: group.locale,
+        fileId: String(group.fileId),
+        message: error instanceof Error ? error.message : "crowdin translation upload failed",
+      });
+      asyncOperations.push({
+        type: "crowdin_upload_translations",
+        fileId: group.fileId,
+        languageId: group.locale,
+        status: "failed",
+        error: error instanceof Error ? error.message : "crowdin translation upload failed",
+      });
+    }
+  }
+
+  if (groups.size > 0 && uploaded === 0 && failed > 0) {
+    return { uploaded, failed, failures, asyncOperations };
+  }
+
+  try {
+    const build = await client.buildProjectTranslation(projectId, {
+      targetLanguageIds: [targetLanguageId],
+      exportApprovedOnly: true,
+    });
+
+    const finishedBuild = await client.waitForTranslationBuild(projectId, build.id, {
+      maxAttempts: 10,
+      delayMs: 100,
+    });
+
+    const downloadLink = await client.downloadTranslationBuild(projectId, finishedBuild.id);
+    asyncOperations.push({
+      type: "crowdin_translation_build",
+      buildId: finishedBuild.id,
+      status: finishedBuild.status,
+      downloadUrl: downloadLink.url,
+    });
+  } catch (error) {
+    asyncOperations.push({
+      type: "crowdin_translation_build",
+      status: "failed",
+      error: error instanceof Error ? error.message : "crowdin translation build failed",
+      responseBody: error instanceof CrowdinApiError ? error.responseBody : undefined,
+    });
+    failures.push({
+      locale: targetLanguageId,
+      fileId: null,
+      message: error instanceof Error ? error.message : "crowdin translation build failed",
+    });
+  }
+
+  return { uploaded, failed, failures, asyncOperations };
+};

--- a/apps/hyperlocalise-web/src/lib/providers/external-tms-content-sync.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/external-tms-content-sync.test.ts
@@ -122,4 +122,35 @@ describe("external TMS content sync", () => {
     expect(syncRun?.status).toBe("failed");
     expect(syncRun?.errorMessage).toContain("failed");
   });
+
+  it("marks push_translations as failed when only the build step fails", async () => {
+    const { organization, project } = await createExternalTmsProject();
+    const pushTranslations: ExternalTmsTranslationPusher = async () => ({
+      uploaded: 1,
+      failed: 0,
+      asyncOperations: [
+        { type: "crowdin_upload_translations", status: "finished" },
+        { type: "crowdin_translation_build", status: "failed" },
+      ],
+      failures: [{ locale: "fr", message: "crowdin translation build timed out", fileId: null }],
+    });
+
+    const result = await pushExternalTmsTranslations({
+      organizationId: organization.id,
+      projectId: project.id,
+      providerKind: "crowdin",
+      externalJobId: "2001",
+      translations: [{ locale: "fr", text: "Bonjour", fileId: "101", key: "hello" }],
+      pushTranslations,
+    });
+
+    expect(result.status).toBe("failed");
+
+    const [syncRun] = await db
+      .select()
+      .from(schema.providerSyncRuns)
+      .where(eq(schema.providerSyncRuns.id, result.runId));
+
+    expect(syncRun?.status).toBe("failed");
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/external-tms-content-sync.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/external-tms-content-sync.test.ts
@@ -1,0 +1,125 @@
+import "dotenv/config";
+
+import { eq } from "drizzle-orm";
+import { afterEach, beforeAll, describe, expect, it } from "vite-plus/test";
+
+import { db, schema } from "@/lib/database";
+
+import { createProjectTestFixture } from "../../api/routes/project/project.fixture";
+import {
+  pullExternalTmsTaskContent,
+  pushExternalTmsTranslations,
+  type ExternalTmsContentPuller,
+  type ExternalTmsTranslationPusher,
+} from "./external-tms-content-sync";
+import { upsertOrganizationExternalTmsProviderCredential } from "./organization-external-tms-provider-credentials";
+
+const projectFixture = createProjectTestFixture();
+
+beforeAll(async () => {
+  await db.$client.query("select 1");
+});
+
+afterEach(async () => {
+  await projectFixture.cleanup();
+});
+
+async function createExternalTmsProject() {
+  const { organization, user, project } = await projectFixture.createStoredProjectFixture();
+  const credential = await upsertOrganizationExternalTmsProviderCredential({
+    organizationId: organization.id,
+    userId: user.id,
+    role: "owner",
+    providerKind: "crowdin",
+    displayName: "crowdin",
+    secretMaterial: "secret-token",
+    baseUrl: "https://api.crowdin.test/api/v2",
+  });
+
+  const [externalProject] = await db
+    .update(schema.projects)
+    .set({
+      source: "external_tms",
+      externalProviderCredentialId: credential.id,
+      externalProviderKind: "crowdin",
+      externalProjectId: "42",
+      targetLocales: ["fr"],
+    })
+    .where(eq(schema.projects.id, project.id))
+    .returning();
+
+  return { organization, credential, project: externalProject };
+}
+
+describe("external TMS content sync", () => {
+  it("records a pull_content sync run with discovered units", async () => {
+    const { organization, project } = await createExternalTmsProject();
+    const pullContent: ExternalTmsContentPuller = async () => ({
+      externalJobId: "2001",
+      targetLocales: ["fr"],
+      units: [
+        {
+          externalStringId: "1001",
+          key: "hello",
+          sourceText: "Hello",
+          translations: [{ locale: "fr", text: "Bonjour", isApproved: true }],
+        },
+      ],
+      exportArtifact: null,
+    });
+
+    const result = await pullExternalTmsTaskContent({
+      organizationId: organization.id,
+      projectId: project.id,
+      providerKind: "crowdin",
+      externalJobId: "2001",
+      pullContent,
+    });
+
+    expect(result.status).toBe("succeeded");
+    expect(result.counts).toEqual({
+      unitsDiscovered: 1,
+      translationsDiscovered: 1,
+      approvedTranslations: 1,
+    });
+
+    const [syncRun] = await db
+      .select()
+      .from(schema.providerSyncRuns)
+      .where(eq(schema.providerSyncRuns.id, result.runId));
+
+    expect(syncRun?.kind).toBe("pull_content");
+    expect(syncRun?.status).toBe("succeeded");
+  });
+
+  it("records a push_translations sync run and surfaces upload failures", async () => {
+    const { organization, project } = await createExternalTmsProject();
+    const pushTranslations: ExternalTmsTranslationPusher = async () => ({
+      uploaded: 0,
+      failed: 1,
+      asyncOperations: [{ type: "crowdin_upload_translations", status: "failed" }],
+      failures: [{ locale: "fr", message: "upload failed", fileId: "101" }],
+    });
+
+    const result = await pushExternalTmsTranslations({
+      organizationId: organization.id,
+      projectId: project.id,
+      providerKind: "crowdin",
+      externalJobId: "2001",
+      translations: [{ locale: "fr", text: "Bonjour", fileId: "101", key: "hello" }],
+      pushTranslations,
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.counts.translationsFailed).toBe(1);
+
+    const [syncRun] = await db
+      .select()
+      .from(schema.providerSyncRuns)
+      .where(eq(schema.providerSyncRuns.id, result.runId));
+
+    expect(syncRun?.kind).toBe("push_translations");
+    expect(syncRun?.status).toBe("failed");
+    expect(syncRun?.errorMessage).toContain("failed");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/external-tms-content-sync.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/external-tms-content-sync.ts
@@ -304,7 +304,7 @@ export async function pushExternalTmsTranslations(input: {
       asyncOperations: pushResult.asyncOperations.length,
     };
 
-    const status = pushResult.failed > 0 ? "failed" : "succeeded";
+    const status = pushResult.failed > 0 || pushResult.failures.length > 0 ? "failed" : "succeeded";
     const finishInput = {
       runId: run.id,
       organizationId: run.organizationId,
@@ -320,7 +320,7 @@ export async function pushExternalTmsTranslations(input: {
     if (status === "failed") {
       await failProviderSyncRun({
         ...finishInput,
-        errorMessage: "One or more provider translation uploads failed",
+        errorMessage: "One or more provider translation uploads or build steps failed",
         errorDetails: {
           failures: pushResult.failures,
           asyncOperations: pushResult.asyncOperations,

--- a/apps/hyperlocalise-web/src/lib/providers/external-tms-content-sync.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/external-tms-content-sync.ts
@@ -1,0 +1,402 @@
+import { and, eq } from "drizzle-orm";
+
+import { db, schema } from "@/lib/database";
+import type { ProviderSyncRunStatus } from "@/lib/database/types";
+import { decryptProviderCredential } from "@/lib/security/provider-credential-crypto";
+
+import type { ExternalTmsProviderKind } from "./organization-external-tms-provider-credentials";
+import {
+  completeProviderSyncRun,
+  failProviderSyncRun,
+  startProviderSyncRun,
+} from "./provider-sync-runs";
+
+type ExternalTmsCredential = typeof schema.organizationExternalTmsProviderCredentials.$inferSelect;
+type ExternalTmsProject = typeof schema.projects.$inferSelect;
+
+export type ExternalTmsTranslationUnit = {
+  externalStringId: string;
+  key: string;
+  sourceText: string;
+  context?: string | null;
+  fileId?: string | null;
+  translations: Array<{
+    locale: string;
+    text: string;
+    externalTranslationId?: string | null;
+    isApproved?: boolean;
+  }>;
+  providerPayload?: Record<string, unknown>;
+};
+
+export type ExternalTmsTaskContent = {
+  externalJobId: string;
+  externalTaskId?: string | null;
+  sourceLocale?: string | null;
+  targetLocales: string[];
+  units: ExternalTmsTranslationUnit[];
+  exportArtifact?: {
+    url: string;
+    format?: string | null;
+    byteLength?: number | null;
+  } | null;
+  providerPayload?: Record<string, unknown>;
+};
+
+export type ExternalTmsApprovedTranslationUpload = {
+  externalStringId?: string | null;
+  key?: string | null;
+  locale: string;
+  text: string;
+  fileId?: string | null;
+  fileName?: string | null;
+  format?: string | null;
+};
+
+export type ExternalTmsContentPuller = (input: {
+  organizationId: string;
+  projectId: string;
+  providerKind: ExternalTmsProviderKind;
+  externalProjectId: string;
+  externalJobId: string;
+  credential: ExternalTmsCredential;
+  project: ExternalTmsProject;
+  secretMaterial: string;
+}) => Promise<ExternalTmsTaskContent>;
+
+export type ExternalTmsTranslationPusher = (input: {
+  organizationId: string;
+  projectId: string;
+  providerKind: ExternalTmsProviderKind;
+  externalProjectId: string;
+  externalJobId: string;
+  credential: ExternalTmsCredential;
+  project: ExternalTmsProject;
+  secretMaterial: string;
+  translations: ExternalTmsApprovedTranslationUpload[];
+}) => Promise<{
+  uploaded: number;
+  failed: number;
+  asyncOperations: Array<Record<string, unknown>>;
+  failures: Array<{ locale: string; message: string; fileId?: string | null }>;
+}>;
+
+export type ExternalTmsContentSyncFailure = {
+  externalStringId: string | null;
+  locale: string | null;
+  message: string;
+};
+
+export type ExternalTmsContentPullResult = {
+  runId: string;
+  status: Extract<ProviderSyncRunStatus, "succeeded" | "failed">;
+  providerKind: ExternalTmsProviderKind;
+  providerCredentialId: string;
+  projectId: string;
+  content: ExternalTmsTaskContent;
+  counts: {
+    unitsDiscovered: number;
+    translationsDiscovered: number;
+    approvedTranslations: number;
+  };
+  failures: ExternalTmsContentSyncFailure[];
+};
+
+export type ExternalTmsTranslationPushResult = {
+  runId: string;
+  status: Extract<ProviderSyncRunStatus, "succeeded" | "failed">;
+  providerKind: ExternalTmsProviderKind;
+  providerCredentialId: string;
+  projectId: string;
+  counts: {
+    translationsRequested: number;
+    translationsUploaded: number;
+    translationsFailed: number;
+    asyncOperations: number;
+  };
+  failures: ExternalTmsContentSyncFailure[];
+  asyncOperations: Array<Record<string, unknown>>;
+};
+
+export async function pullExternalTmsTaskContent(input: {
+  organizationId: string;
+  projectId: string;
+  providerKind: ExternalTmsProviderKind;
+  externalJobId: string;
+  pullContent: ExternalTmsContentPuller;
+}): Promise<ExternalTmsContentPullResult> {
+  const project = await getExternalTmsProject(input);
+
+  if (!project?.externalProjectId) {
+    throw new Error("external_tms_project_not_found");
+  }
+
+  const credential = await getExternalTmsCredential({
+    organizationId: input.organizationId,
+    providerKind: input.providerKind,
+    credentialId: project.externalProviderCredentialId,
+  });
+
+  if (!credential) {
+    throw new Error("provider_credential_not_found");
+  }
+
+  const run = await startProviderSyncRun({
+    organizationId: input.organizationId,
+    providerKind: input.providerKind,
+    providerCredentialId: credential.id,
+    kind: "pull_content",
+    projectId: project.id,
+    externalProjectId: project.externalProjectId,
+    resourceType: "job_task",
+    resourceId: input.externalJobId,
+    externalResourceId: input.externalJobId,
+    providerMetadata: { credentialId: credential.id },
+  });
+
+  try {
+    const secretMaterial = decryptProviderCredential({
+      algorithm: credential.encryptionAlgorithm,
+      keyVersion: credential.keyVersion,
+      ciphertext: credential.ciphertext,
+      iv: credential.iv,
+      authTag: credential.authTag,
+    });
+
+    const content = await input.pullContent({
+      organizationId: input.organizationId,
+      projectId: project.id,
+      providerKind: input.providerKind,
+      externalProjectId: project.externalProjectId,
+      externalJobId: input.externalJobId,
+      credential,
+      project,
+      secretMaterial,
+    });
+
+    const translationsDiscovered = content.units.reduce(
+      (total, unit) => total + unit.translations.length,
+      0,
+    );
+    const approvedTranslations = content.units.reduce(
+      (total, unit) => total + unit.translations.filter((t) => t.isApproved).length,
+      0,
+    );
+
+    const counts = {
+      unitsDiscovered: content.units.length,
+      translationsDiscovered,
+      approvedTranslations,
+    };
+
+    await completeProviderSyncRun({
+      runId: run.id,
+      organizationId: run.organizationId,
+      counts,
+      providerMetadata: {
+        credentialId: credential.id,
+        externalJobId: input.externalJobId,
+        exportArtifact: content.exportArtifact ?? null,
+      },
+    });
+
+    return {
+      runId: run.id,
+      status: "succeeded",
+      providerKind: input.providerKind,
+      providerCredentialId: credential.id,
+      projectId: project.id,
+      content,
+      counts,
+      failures: [],
+    };
+  } catch (error) {
+    await failProviderSyncRun({
+      runId: run.id,
+      organizationId: run.organizationId,
+      errorMessage: error instanceof Error ? error.message : "provider content pull failed",
+      errorDetails: {
+        name: error instanceof Error ? error.name : "UnknownError",
+        stack: error instanceof Error ? error.stack : undefined,
+        externalJobId: input.externalJobId,
+      },
+      providerMetadata: { credentialId: credential.id },
+    });
+    throw error;
+  }
+}
+
+export async function pushExternalTmsTranslations(input: {
+  organizationId: string;
+  projectId: string;
+  providerKind: ExternalTmsProviderKind;
+  externalJobId: string;
+  translations: ExternalTmsApprovedTranslationUpload[];
+  pushTranslations: ExternalTmsTranslationPusher;
+}): Promise<ExternalTmsTranslationPushResult> {
+  const project = await getExternalTmsProject(input);
+
+  if (!project?.externalProjectId) {
+    throw new Error("external_tms_project_not_found");
+  }
+
+  const credential = await getExternalTmsCredential({
+    organizationId: input.organizationId,
+    providerKind: input.providerKind,
+    credentialId: project.externalProviderCredentialId,
+  });
+
+  if (!credential) {
+    throw new Error("provider_credential_not_found");
+  }
+
+  const run = await startProviderSyncRun({
+    organizationId: input.organizationId,
+    providerKind: input.providerKind,
+    providerCredentialId: credential.id,
+    kind: "push_translations",
+    projectId: project.id,
+    externalProjectId: project.externalProjectId,
+    resourceType: "job_task",
+    resourceId: input.externalJobId,
+    externalResourceId: input.externalJobId,
+    providerMetadata: {
+      credentialId: credential.id,
+      translationsRequested: input.translations.length,
+    },
+  });
+
+  const failures: ExternalTmsContentSyncFailure[] = [];
+
+  try {
+    const secretMaterial = decryptProviderCredential({
+      algorithm: credential.encryptionAlgorithm,
+      keyVersion: credential.keyVersion,
+      ciphertext: credential.ciphertext,
+      iv: credential.iv,
+      authTag: credential.authTag,
+    });
+
+    const pushResult = await input.pushTranslations({
+      organizationId: input.organizationId,
+      projectId: project.id,
+      providerKind: input.providerKind,
+      externalProjectId: project.externalProjectId,
+      externalJobId: input.externalJobId,
+      credential,
+      project,
+      secretMaterial,
+      translations: input.translations,
+    });
+
+    for (const failure of pushResult.failures) {
+      failures.push({
+        externalStringId: null,
+        locale: failure.locale,
+        message: failure.message,
+      });
+    }
+
+    const counts = {
+      translationsRequested: input.translations.length,
+      translationsUploaded: pushResult.uploaded,
+      translationsFailed: pushResult.failed,
+      asyncOperations: pushResult.asyncOperations.length,
+    };
+
+    const status = pushResult.failed > 0 ? "failed" : "succeeded";
+    const finishInput = {
+      runId: run.id,
+      organizationId: run.organizationId,
+      counts,
+      providerMetadata: {
+        credentialId: credential.id,
+        externalJobId: input.externalJobId,
+        asyncOperations: pushResult.asyncOperations,
+        failures: pushResult.failures,
+      },
+    };
+
+    if (status === "failed") {
+      await failProviderSyncRun({
+        ...finishInput,
+        errorMessage: "One or more provider translation uploads failed",
+        errorDetails: {
+          failures: pushResult.failures,
+          asyncOperations: pushResult.asyncOperations,
+        },
+      });
+    } else {
+      await completeProviderSyncRun(finishInput);
+    }
+
+    return {
+      runId: run.id,
+      status,
+      providerKind: input.providerKind,
+      providerCredentialId: credential.id,
+      projectId: project.id,
+      counts,
+      failures,
+      asyncOperations: pushResult.asyncOperations,
+    };
+  } catch (error) {
+    await failProviderSyncRun({
+      runId: run.id,
+      organizationId: run.organizationId,
+      errorMessage: error instanceof Error ? error.message : "provider translation push failed",
+      errorDetails: {
+        name: error instanceof Error ? error.name : "UnknownError",
+        stack: error instanceof Error ? error.stack : undefined,
+        externalJobId: input.externalJobId,
+      },
+      providerMetadata: { credentialId: credential.id },
+    });
+    throw error;
+  }
+}
+
+async function getExternalTmsProject(input: {
+  organizationId: string;
+  projectId: string;
+  providerKind: ExternalTmsProviderKind;
+}) {
+  const [project] = await db
+    .select()
+    .from(schema.projects)
+    .where(
+      and(
+        eq(schema.projects.id, input.projectId),
+        eq(schema.projects.organizationId, input.organizationId),
+        eq(schema.projects.externalProviderKind, input.providerKind),
+        eq(schema.projects.source, "external_tms"),
+      ),
+    )
+    .limit(1);
+
+  return project ?? null;
+}
+
+async function getExternalTmsCredential(input: {
+  organizationId: string;
+  providerKind: ExternalTmsProviderKind;
+  credentialId: string | null;
+}) {
+  if (!input.credentialId) {
+    return null;
+  }
+
+  const [credential] = await db
+    .select()
+    .from(schema.organizationExternalTmsProviderCredentials)
+    .where(
+      and(
+        eq(schema.organizationExternalTmsProviderCredentials.organizationId, input.organizationId),
+        eq(schema.organizationExternalTmsProviderCredentials.providerKind, input.providerKind),
+        eq(schema.organizationExternalTmsProviderCredentials.id, input.credentialId),
+      ),
+    )
+    .limit(1);
+
+  return credential ?? null;
+}


### PR DESCRIPTION
## What changed

Adds provider-neutral Crowdin task content pull and translation write-back for agent workflows.

- Introduces `pullExternalTmsTaskContent` and `pushExternalTmsTranslations` with `pull_content` / `push_translations` sync run logging
- Implements Crowdin pull (task strings, translations, approvals, optional export) and push (storage upload → import → async build polling)
- Extends `CrowdinApiClient` with storage, translation import, build status, and task export helpers
- Adds project routes: `POST /:projectId/sync-pull-content` and `POST /:projectId/sync-push-translations`

Closes HL-356.

## How to test

- `cd apps/hyperlocalise-web && vp test src/lib/providers/crowdin/crowdin-content-puller.test.ts src/lib/providers/crowdin/crowdin-translation-pusher.test.ts src/lib/providers/external-tms-content-sync.test.ts src/lib/providers/crowdin/crowdin-api.test.ts`
- `cd apps/hyperlocalise-web && vp check`
- Against a connected Crowdin external TMS project, call:
  - `POST /api/projects/:projectId/sync-pull-content` with `{ "externalJobId": "<taskId>" }`
  - `POST /api/projects/:projectId/sync-push-translations` with approved translation payloads

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds provider-neutral Crowdin content pull and translation write-back for agent workflows, introducing two new HTTP routes (`POST /:projectId/sync-pull-content` and `POST /:projectId/sync-push-translations`) and a three-layer implementation of schema validation → orchestration → Crowdin-specific API calls.

- **Pull flow**: `pullCrowdinTaskContent` fetches task metadata, chunks source-string and language-translation requests by ID to stay within API limits, collects approvals, and optionally exports a task artifact for agent consumption.
- **Push flow**: `pushCrowdinTranslations` groups translations by file/locale, uploads each group via Crowdin's storage→import API, and polls an async build; build failures are now surfaced in the `failures` array so `pushExternalTmsTranslations` correctly derives `status: "failed"` even when only the build step fails.
- **`CrowdinApiClient`** is extended with storage, import, build polling, and task-export helpers; `waitForTranslationBuild` defaults to 90 attempts × 2 s for a 3-minute window.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the core pull/push flows, sync-run accounting, and HTTP status derivation are all correct.

The major concerns from previous review rounds (build polling window, build-failure status misreporting, per-string approval truncation) have been addressed in the final code. Remaining notes are quality improvements: scoping the approvals fetch to task strings, clarifying the multi-file fallback, and correcting the empty-string JSON body on the task export call. None block correctness for the primary happy path.

crowdin-translation-pusher.ts (multi-file fileId defaulting), crowdin-content-puller.ts (unscoped approvals fetch), crowdin-api.ts (exportTaskStrings body)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-api.ts | Extends CrowdinApiClient with storage upload, translation import, build polling, and task export; adds pagination to listStringTranslations; minor issue with exportTaskStrings sending an empty string body alongside Content-Type: application/json. |
| apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-content-puller.ts | New puller that fetches task strings, translations, and approvals with chunked requests; correctly scopes source strings and language translations but fetches all approvals without task-scope filtering. |
| apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-translation-pusher.ts | New pusher grouping translations by file/locale and uploading via storage; build failure is now surfaced in failures array so status is correctly reported as "failed"; silent data loss possible when translations lack explicit fileId in multi-file tasks. |
| apps/hyperlocalise-web/src/lib/providers/external-tms-content-sync.ts | New orchestration layer that resolves project/credential, starts sync runs, delegates to provider-specific puller/pusher, and persists outcomes; status determination for push correctly uses both failed count and failures array length. |
| apps/hyperlocalise-web/src/api/routes/project/project.route.ts | Adds sync-pull-content and sync-push-translations routes with auth checks, provider guard, and consistent 207/200 status code handling. |
| apps/hyperlocalise-web/src/api/routes/project/project.schema.ts | Adds externalTmsContentSyncBodySchema and externalTmsTranslationPushBodySchema with a refinement requiring either key or externalStringId on each translation item. |
| apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-api.test.ts | Extends existing API client tests with storage upload, translation import, and getTask coverage. |
| apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-content-puller.test.ts | Integration test covering the happy path; verifies chunked language-translation calls and that per-string translation fallback is not used. |
| apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-translation-pusher.test.ts | Tests cover upload success, missing file ID failures, and missing key failures; build path uses an immediately-finished build in the mock. |
| apps/hyperlocalise-web/src/lib/providers/external-tms-content-sync.test.ts | DB-integrated tests for pull and push sync runs; includes a dedicated test for build-only failure resulting in "failed" status, confirming the fix for the previously flagged issue. |
| apps/hyperlocalise-web/src/api/routes/project/project.schema.test.ts | New schema tests covering the key/externalStringId refinement validation; straightforward and correct. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Route as project.route.ts
    participant Sync as external-tms-content-sync.ts
    participant Puller as crowdin-content-puller.ts
    participant Pusher as crowdin-translation-pusher.ts
    participant API as CrowdinApiClient

    Client->>Route: "POST /sync-pull-content {externalJobId}"
    Route->>Sync: pullExternalTmsTaskContent()
    Sync->>Sync: getExternalTmsProject + getExternalTmsCredential
    Sync->>Sync: startProviderSyncRun (pull_content)
    Sync->>Puller: pullCrowdinTaskContent()
    Puller->>API: getTask(projectId, taskId)
    Puller->>API: listSourceStrings (chunked by stringIds/fileIds)
    Puller->>API: listTranslationApprovals(projectId, languageId)
    Puller->>API: listLanguageTranslations (chunked by stringIds)
    Puller->>API: exportTaskStrings (best-effort)
    Puller-->>Sync: ExternalTmsTaskContent
    Sync->>Sync: completeProviderSyncRun
    Sync-->>Route: ExternalTmsContentPullResult
    Route-->>Client: "200 {externalTmsContentPull}"

    Client->>Route: "POST /sync-push-translations {externalJobId, translations}"
    Route->>Sync: pushExternalTmsTranslations()
    Sync->>Sync: startProviderSyncRun (push_translations)
    Sync->>Pusher: pushCrowdinTranslations()
    Pusher->>API: getTask(projectId, taskId)
    loop per file/locale group
        Pusher->>API: addStorage(fileName, jsonContent)
        Pusher->>API: uploadTranslations(projectId, languageId, storageId, fileId)
    end
    Pusher->>API: buildProjectTranslation(projectId)
    Pusher->>API: waitForTranslationBuild (poll up to 90x)
    Pusher->>API: downloadTranslationBuild
    Pusher-->>Sync: uploaded, failed, failures, asyncOperations
    Sync->>Sync: failProviderSyncRun or completeProviderSyncRun
    Sync-->>Route: ExternalTmsTranslationPushResult
    Route-->>Client: "200 or 207 {externalTmsTranslationPush}"
```
</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hyperlocalise%2Fhyperlocalise%22%20on%20the%20existing%20branch%20%22cungminh2710%2Fhl-356-implement-crowdin-translation-pull-and-write-back%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cungminh2710%2Fhl-356-implement-crowdin-translation-pull-and-write-back%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapps%2Fhyperlocalise-web%2Fsrc%2Flib%2Fproviders%2Fcrowdin%2Fcrowdin-api.ts%3A631-641%0A**Invalid%20JSON%20body%20sent%20to%20task%20export%20endpoint**%0A%0A%60exportTaskStrings%60%20passes%20%60body%3A%20%22%22%60%20%28an%20empty%20string%29%20alongside%20%60Content-Type%3A%20application%2Fjson%60.%20An%20empty%20string%20is%20not%20valid%20JSON.%20Strict%20HTTP%20intermediaries%20or%20future%20changes%20to%20Crowdin's%20API%20validation%20could%20reject%20this%20request%20with%20a%20400.%20The%20body%20should%20be%20%60null%60%20%28or%20omitted%20entirely%29%20when%20the%20endpoint%20takes%20no%20request%20payload.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fhyperlocalise-web%2Fsrc%2Flib%2Fproviders%2Fcrowdin%2Fcrowdin-translation-pusher.ts%3A63-73%0A**Multi-file%20task%20translations%20silently%20routed%20to%20first%20file%20when%20%60fileId%60%20is%20omitted**%0A%0AWhen%20a%20task%20has%20multiple%20files%20%28e.g.%20%60fileIds%3A%20%5B101%2C%20102%5D%60%29%20and%20a%20caller%20submits%20translations%20without%20an%20explicit%20%60fileId%60%2C%20all%20of%20them%20are%20bucketed%20into%20a%20single%20group%20keyed%20on%20%60task.fileIds%5B0%5D%60.%20Translations%20intended%20for%20file%20102%20are%20uploaded%20to%20file%20101%3B%20Crowdin%20matches%20keys%20against%20that%20file's%20string%20catalogue%20only%2C%20so%20any%20key%20that%20doesn't%20exist%20in%20file%20101%20is%20silently%20dropped.%20The%20schema%20marks%20%60fileId%60%20as%20optional%20and%20gives%20no%20hint%20that%20it%20is%20required%20for%20multi-file%20tasks%2C%20making%20this%20a%20silent%20data-loss%20path.%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Fhyperlocalise-web%2Fsrc%2Flib%2Fproviders%2Fcrowdin%2Fcrowdin-content-puller.ts%3A69-70%0A**%60listTranslationApprovals%60%20fetches%20all%20language%20approvals%20without%20task-scope%20filtering**%0A%0AEven%20when%20the%20task%20scopes%20to%20specific%20%60stringIds%60%20or%20%60fileIds%60%2C%20the%20approvals%20fetch%20returns%20every%20approval%20for%20the%20target%20language%20across%20the%20entire%20project.%20For%20large%20projects%20with%20many%20contributors%20or%20machine-translation%20runs%2C%20this%20can%20mean%20paging%20through%20tens%20of%20thousands%20of%20records.%20The%20Crowdin%20approvals%20endpoint%20supports%20%60fileId%60%20and%20%60stringId%60%20query%20parameters%3B%20passing%20the%20task's%20file%20or%20string%20IDs%20here%20would%20make%20the%20call%20proportional%20to%20task%20size%20rather%20than%20project%20size%2C%20consistent%20with%20how%20%60listSourceStrings%60%20and%20%60listLanguageTranslations%60%20are%20already%20scoped.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-api.ts:631-641
**Invalid JSON body sent to task export endpoint**

`exportTaskStrings` passes `body: ""` (an empty string) alongside `Content-Type: application/json`. An empty string is not valid JSON. Strict HTTP intermediaries or future changes to Crowdin's API validation could reject this request with a 400. The body should be `null` (or omitted entirely) when the endpoint takes no request payload.

### Issue 2 of 3
apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-translation-pusher.ts:63-73
**Multi-file task translations silently routed to first file when `fileId` is omitted**

When a task has multiple files (e.g. `fileIds: [101, 102]`) and a caller submits translations without an explicit `fileId`, all of them are bucketed into a single group keyed on `task.fileIds[0]`. Translations intended for file 102 are uploaded to file 101; Crowdin matches keys against that file's string catalogue only, so any key that doesn't exist in file 101 is silently dropped. The schema marks `fileId` as optional and gives no hint that it is required for multi-file tasks, making this a silent data-loss path.

### Issue 3 of 3
apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-content-puller.ts:69-70
**`listTranslationApprovals` fetches all language approvals without task-scope filtering**

Even when the task scopes to specific `stringIds` or `fileIds`, the approvals fetch returns every approval for the target language across the entire project. For large projects with many contributors or machine-translation runs, this can mean paging through tens of thousands of records. The Crowdin approvals endpoint supports `fileId` and `stringId` query parameters; passing the task's file or string IDs here would make the call proportional to task size rather than project size, consistent with how `listSourceStrings` and `listLanguageTranslations` are already scoped.

`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(crowdin): batch translation pulls an..."](https://github.com/hyperlocalise/hyperlocalise/commit/975208835693c8cad241e5f02ec8db01ec009cf6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33440403)</sub>

<!-- /greptile_comment -->