### PR TITLE
feat(jobs): extend job detail with TMS provider actions (HL-369)

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/agent-run.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/agent-run.schema.ts
@@ -1,0 +1,82 @@
+import { z } from "zod";
+
+import * as schema from "@/lib/database/schema";
+import { jobProviderActionDefinitions } from "@/lib/providers/job-provider-actions";
+
+export const jobProviderActionIdSchema = z.enum([
+  "translate_with_agent",
+  "review_with_agent",
+  "fix_qa_issues",
+  "leave_provider_comment",
+  "push_approved_changes",
+]);
+
+export const createJobAgentRunBodySchema = z.object({
+  action: jobProviderActionIdSchema,
+});
+
+export const agentRunRecordSchema = z.object({
+  id: z.string().uuid(),
+  organizationId: z.string().uuid(),
+  providerKind: z.enum(schema.externalTmsProviderKindEnum.enumValues),
+  externalJobId: z.string(),
+  externalTaskId: z.string().nullable(),
+  kind: z.enum(schema.agentRunKindEnum.enumValues),
+  status: z.enum(schema.agentRunStatusEnum.enumValues),
+  actorUserId: z.string().uuid().nullable(),
+  inputSnapshot: z.record(z.string(), z.unknown()),
+  outputSummary: z.record(z.string(), z.unknown()),
+  changedItems: z.array(z.record(z.string(), z.unknown())),
+  warnings: z.array(z.string()),
+  hyperlocaliseJobId: z.string().nullable(),
+  startedAt: z.string().nullable(),
+  completedAt: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export const providerSourceFileRecordSchema = z.object({
+  id: z.string(),
+  displayName: z.string(),
+  sourcePath: z.string().nullable(),
+  resourceType: z.enum(schema.externalTmsResourceTypeEnum.enumValues).nullable(),
+  externalUrl: z.string().nullable(),
+});
+
+export const jobProviderActionAvailabilitySchema = z.object({
+  id: jobProviderActionIdSchema,
+  label: z.string(),
+  agentRunKind: z.enum(schema.agentRunKindEnum.enumValues),
+  visible: z.boolean(),
+  enabled: z.boolean(),
+  disabledReason: z.string().optional(),
+});
+
+export const workspaceJobDetailRecordSchema = z
+  .object({
+    providerSourceFiles: z.array(providerSourceFileRecordSchema).optional(),
+    providerActions: z.array(jobProviderActionAvailabilitySchema).optional(),
+  })
+  .passthrough();
+
+export const agentRunResponseSchema = z.object({
+  agentRun: agentRunRecordSchema,
+});
+
+export const agentRunsResponseSchema = z.object({
+  agentRuns: z.array(agentRunRecordSchema),
+});
+
+export const jobProviderActionsResponseSchema = z.object({
+  actions: z.array(jobProviderActionAvailabilitySchema),
+});
+
+export type CreateJobAgentRunBody = z.infer<typeof createJobAgentRunBodySchema>;
+export type AgentRunRecord = z.infer<typeof agentRunRecordSchema>;
+export type JobProviderActionAvailabilityRecord = z.infer<
+  typeof jobProviderActionAvailabilitySchema
+>;
+
+export const supportedJobProviderActionIds = jobProviderActionDefinitions.map(
+  (action) => action.id,
+);

--- a/apps/hyperlocalise-web/src/api/routes/project/agent-run.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/agent-run.schema.ts
@@ -1,15 +1,16 @@
 import { z } from "zod";
 
 import * as schema from "@/lib/database/schema";
-import { jobProviderActionDefinitions } from "@/lib/providers/job-provider-actions";
+import {
+  jobProviderActionDefinitions,
+  type JobProviderActionId,
+} from "@/lib/providers/job-provider-actions";
 
-export const jobProviderActionIdSchema = z.enum([
-  "translate_with_agent",
-  "review_with_agent",
-  "fix_qa_issues",
-  "leave_provider_comment",
-  "push_approved_changes",
-]);
+export const supportedJobProviderActionIds = jobProviderActionDefinitions.map(
+  (action) => action.id,
+) as [JobProviderActionId, ...JobProviderActionId[]];
+
+export const jobProviderActionIdSchema = z.enum(supportedJobProviderActionIds);
 
 export const createJobAgentRunBodySchema = z.object({
   action: jobProviderActionIdSchema,
@@ -76,7 +77,3 @@ export type AgentRunRecord = z.infer<typeof agentRunRecordSchema>;
 export type JobProviderActionAvailabilityRecord = z.infer<
   typeof jobProviderActionAvailabilitySchema
 >;
-
-export const supportedJobProviderActionIds = jobProviderActionDefinitions.map(
-  (action) => action.id,
-);

--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
@@ -681,10 +681,10 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
           kind: actionDefinition.agentRunKind,
           actorUserId: c.var.auth.user.localUserId,
           inputSnapshot: {
+            ...actionDefinition.inputSnapshot,
             action: payload.action,
             hyperlocaliseJobId: job.id,
             projectId: job.projectId,
-            ...actionDefinition.inputSnapshot,
           },
           hyperlocaliseJobId: job.id,
         });

--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
@@ -26,6 +26,15 @@ import {
   isProjectMutationAllowed,
   projectNotFoundResponse,
 } from "./project.shared";
+import { createAgentRun, listAgentRuns } from "@/lib/providers/agent-runs";
+import {
+  getJobProviderActionAvailability,
+  getJobProviderActionDefinition,
+  isJobProviderActionAvailable,
+} from "@/lib/providers/job-provider-actions";
+import { resolveProviderSourceFiles } from "@/lib/providers/job-provider-source-files";
+
+import { createJobAgentRunBodySchema } from "./agent-run.schema";
 import {
   createJobBodySchema,
   jobListQuerySchema,
@@ -191,6 +200,56 @@ const validateWorkspaceJobParams = validator("param", (value, c) => {
 
   return parsed.data;
 });
+
+const validateCreateJobAgentRunBody = validator("json", (value, c) => {
+  const parsed = createJobAgentRunBodySchema.safeParse(value);
+
+  if (!parsed.success) {
+    return validationErrorResponse(
+      c,
+      "invalid_agent_run_payload",
+      "Invalid agent run payload",
+      parsed.error.issues,
+    );
+  }
+
+  return parsed.data;
+});
+
+function serializeAgentRun(run: typeof schema.agentRuns.$inferSelect): Record<string, unknown> {
+  return {
+    ...run,
+    startedAt: run.startedAt?.toISOString() ?? null,
+    completedAt: run.completedAt?.toISOString() ?? null,
+    createdAt: run.createdAt.toISOString(),
+    updatedAt: run.updatedAt.toISOString(),
+  };
+}
+
+async function enrichProviderBackedJob(job: Record<string, unknown>) {
+  if (!job.externalProviderKind || !job.externalJobId || !job.projectId || !job.organizationId) {
+    return job;
+  }
+
+  const providerKind =
+    job.externalProviderKind as (typeof schema.externalTmsProviderKindEnum.enumValues)[number];
+
+  const [providerSourceFiles, providerActions] = await Promise.all([
+    resolveProviderSourceFiles({
+      organizationId: job.organizationId as string,
+      projectId: job.projectId as string,
+      providerKind,
+      providerPayload: (job.externalProviderPayload as Record<string, unknown> | null) ?? null,
+    }),
+    Promise.resolve(getJobProviderActionAvailability(providerKind)),
+  ]);
+
+  return {
+    ...job,
+    providerSourceFiles,
+    providerActions,
+  };
+}
 
 const validateCreateJobBody = validator("json", (value, c) => {
   const parsed = createJobBodySchema.safeParse(value);
@@ -500,8 +559,139 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
         return notFoundResponse(c, "job_not_found", "Job not found");
       }
 
-      return c.json({ job }, 200);
+      return c.json({ job: await enrichProviderBackedJob(job) }, 200);
     })
+    .get("/:jobId/agent-runs", validateWorkspaceJobParams, async (c) => {
+      const params = c.req.valid("param");
+      const organizationId = c.var.auth.organization.localOrganizationId;
+
+      const [job] = await db
+        .select({
+          externalProviderKind: schema.externalJobDetails.providerKind,
+          externalJobId: schema.externalJobDetails.externalJobId,
+          externalTaskId: schema.externalJobDetails.externalTaskId,
+        })
+        .from(schema.jobs)
+        .leftJoin(schema.externalJobDetails, eq(schema.externalJobDetails.jobId, schema.jobs.id))
+        .where(
+          and(eq(schema.jobs.id, params.jobId), eq(schema.jobs.organizationId, organizationId)),
+        )
+        .limit(1);
+
+      if (!job) {
+        return notFoundResponse(c, "job_not_found", "Job not found");
+      }
+
+      if (!job.externalProviderKind || !job.externalJobId) {
+        return c.json({ agentRuns: [] }, 200);
+      }
+
+      const agentRuns = await listAgentRuns({
+        organizationId,
+        providerKind: job.externalProviderKind,
+        externalJobId: job.externalJobId,
+        externalTaskId: job.externalTaskId ?? undefined,
+      });
+
+      return c.json({ agentRuns: agentRuns.map(serializeAgentRun) }, 200);
+    })
+    .get("/:jobId/provider-actions", validateWorkspaceJobParams, async (c) => {
+      const params = c.req.valid("param");
+      const organizationId = c.var.auth.organization.localOrganizationId;
+
+      const [job] = await db
+        .select({
+          externalProviderKind: schema.externalJobDetails.providerKind,
+        })
+        .from(schema.jobs)
+        .leftJoin(schema.externalJobDetails, eq(schema.externalJobDetails.jobId, schema.jobs.id))
+        .where(
+          and(eq(schema.jobs.id, params.jobId), eq(schema.jobs.organizationId, organizationId)),
+        )
+        .limit(1);
+
+      if (!job) {
+        return notFoundResponse(c, "job_not_found", "Job not found");
+      }
+
+      if (!job.externalProviderKind) {
+        return c.json({ actions: [] }, 200);
+      }
+
+      return c.json({ actions: getJobProviderActionAvailability(job.externalProviderKind) }, 200);
+    })
+    .post(
+      "/:jobId/agent-runs",
+      validateWorkspaceJobParams,
+      validateCreateJobAgentRunBody,
+      async (c) => {
+        if (!isProjectMutationAllowed(c.var.auth.membership.role)) {
+          return forbiddenResponse(c);
+        }
+
+        const params = c.req.valid("param");
+        const payload = c.req.valid("json");
+        const organizationId = c.var.auth.organization.localOrganizationId;
+
+        const [job] = await db
+          .select({
+            id: schema.jobs.id,
+            projectId: schema.jobs.projectId,
+            externalProviderKind: schema.externalJobDetails.providerKind,
+            externalJobId: schema.externalJobDetails.externalJobId,
+            externalTaskId: schema.externalJobDetails.externalTaskId,
+          })
+          .from(schema.jobs)
+          .leftJoin(schema.externalJobDetails, eq(schema.externalJobDetails.jobId, schema.jobs.id))
+          .where(
+            and(eq(schema.jobs.id, params.jobId), eq(schema.jobs.organizationId, organizationId)),
+          )
+          .limit(1);
+
+        if (!job) {
+          return notFoundResponse(c, "job_not_found", "Job not found");
+        }
+
+        if (!job.externalProviderKind || !job.externalJobId) {
+          return conflictResponse(
+            c,
+            "provider_job_required",
+            "Agent runs are only available for provider-backed jobs",
+          );
+        }
+
+        if (!isJobProviderActionAvailable(job.externalProviderKind, payload.action)) {
+          return conflictResponse(
+            c,
+            "provider_action_unavailable",
+            "This provider action is not available for the connected TMS",
+          );
+        }
+
+        const actionDefinition = getJobProviderActionDefinition(payload.action);
+        if (!actionDefinition) {
+          return badRequestResponse(c, "invalid_provider_action", "Unknown provider action");
+        }
+
+        const agentRun = await createAgentRun({
+          organizationId,
+          providerKind: job.externalProviderKind,
+          externalJobId: job.externalJobId,
+          externalTaskId: job.externalTaskId,
+          kind: actionDefinition.agentRunKind,
+          actorUserId: c.var.auth.user.localUserId,
+          inputSnapshot: {
+            action: payload.action,
+            hyperlocaliseJobId: job.id,
+            projectId: job.projectId,
+            ...actionDefinition.inputSnapshot,
+          },
+          hyperlocaliseJobId: job.id,
+        });
+
+        return c.json({ agentRun: serializeAgentRun(agentRun) }, 201);
+      },
+    )
     .post("/:jobId/retry", validateWorkspaceJobParams, async (c) => {
       if (!isProjectMutationAllowed(c.var.auth.membership.role)) {
         return forbiddenResponse(c);

--- a/apps/hyperlocalise-web/src/api/routes/project/job.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.test.ts
@@ -12,6 +12,7 @@ import type { JobQueue, TranslationJobEventData } from "@/lib/workflow/types";
 import { createProjectTestFixture } from "./project.fixture";
 import type { JobRecord, WorkspaceJobRecord } from "./job.schema";
 import type { ProjectResponse } from "./project.schema";
+import { upsertExternalJob } from "@/lib/providers/organization-external-tms-jobs";
 
 const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
   resolveApiAuthContextFromSessionMock: vi.fn(
@@ -1026,5 +1027,157 @@ describe("jobRoutes", () => {
         lastError: "queue down",
       }),
     ]);
+  });
+
+  it("returns provider metadata and actions for provider-backed workspace jobs", async () => {
+    const identity = createWorkosIdentity();
+    const projectResponse = await createProjectViaApi(identity);
+    const project = ((await projectResponse.json()) as ProjectResponse).project;
+    const [organization] = await db
+      .select({ id: schema.organizations.id })
+      .from(schema.projects)
+      .innerJoin(schema.organizations, eq(schema.projects.organizationId, schema.organizations.id))
+      .where(eq(schema.projects.id, project.id))
+      .limit(1);
+
+    const externalJob = await upsertExternalJob({
+      organizationId: organization!.id,
+      projectId: project.id,
+      providerKind: "crowdin",
+      externalJobId: "crowdin-job-detail-1",
+      externalTaskId: "crowdin-task-1",
+      externalStatus: "in_progress",
+      title: "Homepage strings",
+      targetLocales: ["fr-FR"],
+      assignedUsers: ["translator@example.com"],
+      externalUrl: "https://crowdin.com/project/demo/tasks/1",
+      providerPayload: { fileIds: [101] },
+    });
+
+    const response = await client.api.orgs[":organizationSlug"].jobs[":jobId"].$get(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          jobId: externalJob.id,
+        },
+      },
+      { headers: await authHeadersFor(identity) },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      job: expect.objectContaining({
+        id: externalJob.id,
+        externalProviderKind: "crowdin",
+        externalTitle: "Homepage strings",
+        externalStatus: "in_progress",
+        providerActions: expect.arrayContaining([
+          expect.objectContaining({
+            id: "translate_with_agent",
+            visible: true,
+            enabled: true,
+          }),
+        ]),
+        providerSourceFiles: [
+          expect.objectContaining({
+            id: "101",
+            displayName: "101",
+          }),
+        ],
+      }),
+    });
+  });
+
+  it("creates agent runs for supported provider actions", async () => {
+    const identity = createWorkosIdentity();
+    const projectResponse = await createProjectViaApi(identity);
+    const project = ((await projectResponse.json()) as ProjectResponse).project;
+    const [organization] = await db
+      .select({ id: schema.organizations.id })
+      .from(schema.projects)
+      .innerJoin(schema.organizations, eq(schema.projects.organizationId, schema.organizations.id))
+      .where(eq(schema.projects.id, project.id))
+      .limit(1);
+
+    const externalJob = await upsertExternalJob({
+      organizationId: organization!.id,
+      projectId: project.id,
+      providerKind: "crowdin",
+      externalJobId: "crowdin-job-detail-2",
+      externalStatus: "todo",
+      title: "Product copy",
+    });
+
+    const response = await client.api.orgs[":organizationSlug"].jobs[":jobId"]["agent-runs"].$post(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          jobId: externalJob.id,
+        },
+        json: { action: "translate_with_agent" },
+      },
+      { headers: await authHeadersFor(identity) },
+    );
+
+    expect(response.status).toBe(201);
+    const body = (await response.json()) as {
+      agentRun: { kind: string; status: string; externalJobId: string };
+    };
+    expect(body.agentRun).toMatchObject({
+      kind: "translate",
+      status: "queued",
+      externalJobId: "crowdin-job-detail-2",
+    });
+
+    const listResponse = await client.api.orgs[":organizationSlug"].jobs[":jobId"][
+      "agent-runs"
+    ].$get(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          jobId: externalJob.id,
+        },
+      },
+      { headers: await authHeadersFor(identity) },
+    );
+
+    expect(listResponse.status).toBe(200);
+    await expect(listResponse.json()).resolves.toEqual({
+      agentRuns: [expect.objectContaining({ kind: "translate", status: "queued" })],
+    });
+  });
+
+  it("rejects agent runs for native jobs", async () => {
+    const identity = createWorkosIdentity();
+    const projectResponse = await createProjectViaApi(identity);
+    const project = ((await projectResponse.json()) as ProjectResponse).project;
+    const localUserId = await getLocalUserId(identity.user.workosUserId);
+    const job = await insertJob({
+      projectId: project.id,
+      createdByUserId: localUserId,
+      type: "string",
+      status: "queued",
+      inputPayload: {
+        sourceText: "Hello",
+        sourceLocale: "en-US",
+        targetLocales: ["fr-FR"],
+      },
+    });
+
+    const response = await client.api.orgs[":organizationSlug"].jobs[":jobId"]["agent-runs"].$post(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          jobId: job.id,
+        },
+        json: { action: "translate_with_agent" },
+      },
+      { headers: await authHeadersFor(identity) },
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "provider_job_required",
+    });
   });
 });

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-detail-page-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import Link from "next/link";
 import { ArrowLeft02Icon, RefreshIcon, StopCircleIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -24,6 +24,8 @@ import { apiClient } from "@/lib/api-client-instance";
 import { cn } from "@/lib/utils";
 
 import { toneClass } from "../../../_components/workspace-resource-shared";
+
+import { JobProviderDetailSection } from "./job-provider-detail-section";
 
 type JobDetail = {
   id: string;
@@ -50,10 +52,46 @@ type JobDetail = {
   assetType: string | null;
   assetOperation: string | null;
   assetConfig: unknown;
+  externalProviderKind: string | null;
+  externalJobId: string | null;
+  externalTaskId: string | null;
+  externalStatus: string | null;
+  externalTitle: string | null;
+  externalDueDate: string | null;
+  externalTargetLocales: string[] | null;
+  externalAssignedUsers: string[] | null;
+  externalUrl: string | null;
+  externalSyncState: string | null;
+  externalProviderPayload: Record<string, unknown> | null;
+  linkedJobId: string | null;
+  providerSourceFiles?: Array<{
+    id: string;
+    displayName: string;
+    sourcePath: string | null;
+    resourceType: string | null;
+    externalUrl: string | null;
+  }>;
+  providerActions?: Array<{
+    id:
+      | "translate_with_agent"
+      | "review_with_agent"
+      | "fix_qa_issues"
+      | "leave_provider_comment"
+      | "push_approved_changes";
+    label: string;
+    agentRunKind: string;
+    visible: boolean;
+    enabled: boolean;
+    disabledReason?: string;
+  }>;
   createdAt: string;
   updatedAt: string;
   completedAt: string | null;
 };
+
+function isProviderBackedJob(job: JobDetail): job is JobDetail & { externalProviderKind: string } {
+  return Boolean(job.externalProviderKind);
+}
 
 function statusTone(status: JobDetail["status"]) {
   switch (status) {
@@ -123,11 +161,11 @@ async function parseActionError(response: Response, fallback: string) {
   return error ? `${fallback}: ${error}` : `${fallback} (${response.status})`;
 }
 
-function DetailRow({ label, value }: { label: string; value: string | null | undefined }) {
+function DetailRow({ label, value }: { label: string; value: ReactNode }) {
   return (
     <div className="grid gap-1 py-3 sm:grid-cols-[12rem_minmax(0,1fr)] sm:gap-4">
       <dt className="text-sm text-foreground/42">{label}</dt>
-      <dd className="min-w-0 wrap-break-word text-sm text-foreground/74">{value || "—"}</dd>
+      <dd className="min-w-0 wrap-break-word text-sm text-foreground/74">{value ?? "—"}</dd>
     </div>
   );
 }
@@ -223,7 +261,7 @@ export function JobDetailPageContent({
             Jobs
           </Button>
           <TypographyH1 className="wrap-break-word font-heading text-3xl font-semibold text-foreground md:text-4xl">
-            {job?.id ?? jobId}
+            {job?.externalTitle ?? job?.id ?? jobId}
           </TypographyH1>
         </div>
         {job ? (
@@ -283,7 +321,14 @@ export function JobDetailPageContent({
               Overview
             </TypographyH2>
             <dl className="mt-3 divide-y divide-foreground/8">
+              <DetailRow label="Job ID" value={job.id} />
               <DetailRow label="Kind" value={formatKind(job)} />
+              <DetailRow
+                label="Source"
+                value={
+                  isProviderBackedJob(job) ? `Provider · ${job.externalProviderKind}` : "Native"
+                }
+              />
               <DetailRow label="Project" value={job.projectName ?? job.projectId ?? "Workspace"} />
               <DetailRow label="Interaction" value={job.interactionId} />
               <DetailRow label="Workflow run" value={job.workflowRunId} />
@@ -293,6 +338,10 @@ export function JobDetailPageContent({
               <DetailRow label="Last error" value={job.lastError} />
             </dl>
           </section>
+
+          {isProviderBackedJob(job) ? (
+            <JobProviderDetailSection job={job} jobId={jobId} organizationSlug={organizationSlug} />
+          ) : null}
 
           {job.kind === "review" || job.kind === "sync" || job.kind === "asset_management" ? (
             <section className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-provider-detail-section.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-provider-detail-section.tsx
@@ -1,0 +1,330 @@
+"use client";
+
+import Link from "next/link";
+import type { ReactNode } from "react";
+import { AiMagicIcon, Comment01Icon, RefreshIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { TypographyH2 } from "@/components/ui/typography";
+import { apiClient } from "@/lib/api-client-instance";
+import type { JobProviderActionId } from "@/lib/providers/job-provider-actions";
+import { cn } from "@/lib/utils";
+
+import { toneClass } from "../../../_components/workspace-resource-shared";
+
+export type ProviderSourceFile = {
+  id: string;
+  displayName: string;
+  sourcePath: string | null;
+  resourceType: string | null;
+  externalUrl: string | null;
+};
+
+export type ProviderActionAvailability = {
+  id: JobProviderActionId;
+  label: string;
+  agentRunKind: string;
+  visible: boolean;
+  enabled: boolean;
+  disabledReason?: string;
+};
+
+export type ProviderBackedJobFields = {
+  externalProviderKind: string;
+  externalJobId: string | null;
+  externalTaskId: string | null;
+  externalStatus: string | null;
+  externalTitle: string | null;
+  externalDueDate: string | null;
+  externalTargetLocales: string[] | null;
+  externalAssignedUsers: string[] | null;
+  externalUrl: string | null;
+  externalSyncState: string | null;
+  externalProviderPayload: Record<string, unknown> | null;
+  lastError: string | null;
+  updatedAt: string;
+  providerSourceFiles?: ProviderSourceFile[];
+  providerActions?: ProviderActionAvailability[];
+};
+
+export type AgentRunRecord = {
+  id: string;
+  kind: string;
+  status: "queued" | "running" | "succeeded" | "failed" | "cancelled";
+  createdAt: string;
+  completedAt: string | null;
+};
+
+const DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+function formatDate(value: string | null) {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return DATE_FORMATTER.format(date);
+}
+
+function agentRunTone(status: AgentRunRecord["status"]) {
+  switch (status) {
+    case "succeeded":
+      return "safe";
+    case "failed":
+      return "risk";
+    case "queued":
+      return "watch";
+    default:
+      return "info";
+  }
+}
+
+function DetailRow({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <div className="grid gap-1 py-3 sm:grid-cols-[12rem_minmax(0,1fr)] sm:gap-4">
+      <dt className="text-sm text-foreground/42">{label}</dt>
+      <dd className="min-w-0 wrap-break-word text-sm text-foreground/74">{value ?? "—"}</dd>
+    </div>
+  );
+}
+
+function actionIcon(actionId: JobProviderActionId) {
+  switch (actionId) {
+    case "leave_provider_comment":
+      return Comment01Icon;
+    case "push_approved_changes":
+      return RefreshIcon;
+    default:
+      return AiMagicIcon;
+  }
+}
+
+async function parseActionError(response: Response, fallback: string) {
+  let error: string | undefined;
+
+  try {
+    const body = (await response.json()) as { error?: string; message?: string };
+    error = body.message ?? body.error;
+  } catch {
+    error = undefined;
+  }
+
+  return error ? `${fallback}: ${error}` : `${fallback} (${response.status})`;
+}
+
+export function JobProviderDetailSection({
+  job,
+  jobId,
+  organizationSlug,
+}: {
+  job: ProviderBackedJobFields;
+  jobId: string;
+  organizationSlug: string;
+}) {
+  const queryClient = useQueryClient();
+  const jobQueryKey = ["job", organizationSlug, jobId] as const;
+  const agentRunsQueryKey = ["job-agent-runs", organizationSlug, jobId] as const;
+
+  const agentRunsQuery = useQuery({
+    queryKey: agentRunsQueryKey,
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"].jobs[":jobId"][
+        "agent-runs"
+      ].$get({
+        param: { organizationSlug, jobId },
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to load agent runs (${response.status})`);
+      }
+
+      const body = (await response.json()) as { agentRuns: AgentRunRecord[] };
+      return body.agentRuns;
+    },
+  });
+
+  const startAgentRun = useMutation({
+    mutationFn: async (action: JobProviderActionId) => {
+      const response = await apiClient.api.orgs[":organizationSlug"].jobs[":jobId"][
+        "agent-runs"
+      ].$post({
+        param: { organizationSlug, jobId },
+        json: { action },
+      });
+
+      if (!response.ok) {
+        throw new Error(await parseActionError(response, "Failed to start agent run"));
+      }
+
+      const body = (await response.json()) as { agentRun: AgentRunRecord };
+      return body.agentRun;
+    },
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: agentRunsQueryKey }),
+        queryClient.invalidateQueries({ queryKey: jobQueryKey }),
+      ]);
+      toast.success("Agent run queued");
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Failed to start agent run");
+    },
+  });
+
+  const visibleActions = (job.providerActions ?? []).filter((action) => action.visible);
+  const sourceFiles = job.providerSourceFiles ?? [];
+
+  return (
+    <>
+      <section className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
+            Provider Details
+          </TypographyH2>
+          <Badge variant="outline" className="rounded-full capitalize">
+            {job.externalProviderKind}
+          </Badge>
+        </div>
+        <dl className="mt-3 divide-y divide-foreground/8">
+          <DetailRow label="Provider title" value={job.externalTitle} />
+          <DetailRow label="Provider status" value={job.externalStatus} />
+          <DetailRow label="Sync state" value={job.externalSyncState} />
+          <DetailRow label="Last sync" value={formatDate(job.updatedAt)} />
+          <DetailRow label="Target locales" value={job.externalTargetLocales?.join(", ")} />
+          <DetailRow label="Assignees" value={job.externalAssignedUsers?.join(", ")} />
+          <DetailRow label="Deadline" value={formatDate(job.externalDueDate)} />
+          <DetailRow label="External job ID" value={job.externalJobId} />
+          <DetailRow label="External task ID" value={job.externalTaskId} />
+          <DetailRow
+            label="Provider link"
+            value={
+              job.externalUrl ? (
+                <Link
+                  href={job.externalUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-foreground underline decoration-foreground/24 underline-offset-4 hover:decoration-foreground/48"
+                >
+                  Open in {job.externalProviderKind}
+                </Link>
+              ) : (
+                "—"
+              )
+            }
+          />
+          <DetailRow label="Raw error" value={job.lastError} />
+        </dl>
+      </section>
+
+      <section className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
+        <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
+          Source Files
+        </TypographyH2>
+        {sourceFiles.length > 0 ? (
+          <ul className="mt-4 space-y-2">
+            {sourceFiles.map((file) => (
+              <li
+                key={file.id}
+                className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-foreground/8 bg-foreground/3.5 px-3 py-2 text-sm"
+              >
+                <div className="min-w-0">
+                  <p className="font-medium text-foreground/82">{file.displayName}</p>
+                  {file.sourcePath ? (
+                    <p className="text-xs text-foreground/48">{file.sourcePath}</p>
+                  ) : null}
+                </div>
+                {file.externalUrl ? (
+                  <Link
+                    href={file.externalUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-xs text-foreground/62 underline decoration-foreground/24 underline-offset-4 hover:text-foreground"
+                  >
+                    Open
+                  </Link>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="mt-4 text-sm text-foreground/48">
+            No synced source files linked to this job.
+          </p>
+        )}
+      </section>
+
+      {visibleActions.length > 0 ? (
+        <section className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
+          <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
+            Agent Actions
+          </TypographyH2>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {visibleActions.map((action) => (
+              <Button
+                key={action.id}
+                size="sm"
+                variant={action.id === "push_approved_changes" ? "outline" : "default"}
+                disabled={!action.enabled || startAgentRun.isPending}
+                title={action.disabledReason}
+                onClick={() => startAgentRun.mutate(action.id)}
+              >
+                <HugeiconsIcon icon={actionIcon(action.id)} strokeWidth={1.8} />
+                {startAgentRun.isPending && startAgentRun.variables === action.id
+                  ? "Starting..."
+                  : action.label}
+              </Button>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      <section className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
+        <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
+          Agent Activity
+        </TypographyH2>
+        {agentRunsQuery.isLoading ? (
+          <Skeleton className="mt-4 h-20 w-full bg-foreground/8" />
+        ) : null}
+        {agentRunsQuery.isError ? (
+          <p className="mt-4 text-sm text-flame-100">
+            {agentRunsQuery.error instanceof Error
+              ? agentRunsQuery.error.message
+              : "Unable to load agent runs"}
+          </p>
+        ) : null}
+        {agentRunsQuery.data && agentRunsQuery.data.length > 0 ? (
+          <ul className="mt-4 space-y-2">
+            {agentRunsQuery.data.map((run) => (
+              <li
+                key={run.id}
+                className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-foreground/8 bg-foreground/3.5 px-3 py-2"
+              >
+                <div className="min-w-0">
+                  <p className="text-sm font-medium capitalize text-foreground/82">
+                    {run.kind.replace("_", " ")}
+                  </p>
+                  <p className="text-xs text-foreground/48">Started {formatDate(run.createdAt)}</p>
+                </div>
+                <Badge
+                  variant="outline"
+                  className={cn("rounded-full capitalize", toneClass(agentRunTone(run.status)))}
+                >
+                  {run.status}
+                </Badge>
+              </li>
+            ))}
+          </ul>
+        ) : null}
+        {agentRunsQuery.data && agentRunsQuery.data.length === 0 ? (
+          <p className="mt-4 text-sm text-foreground/48">No agent runs yet.</p>
+        ) : null}
+      </section>
+    </>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-provider-detail-section.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-provider-detail-section.tsx
@@ -307,7 +307,7 @@ export function JobProviderDetailSection({
               >
                 <div className="min-w-0">
                   <p className="text-sm font-medium capitalize text-foreground/82">
-                    {run.kind.replace("_", " ")}
+                    {run.kind.replaceAll("_", " ")}
                   </p>
                   <p className="text-xs text-foreground/48">Started {formatDate(run.createdAt)}</p>
                 </div>

--- a/apps/hyperlocalise-web/src/lib/providers/job-provider-actions.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/job-provider-actions.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  getJobProviderActionAvailability,
+  isJobProviderActionAvailable,
+} from "@/lib/providers/job-provider-actions";
+
+describe("job provider actions", () => {
+  it("enables crowdin translate and review actions", () => {
+    const actions = getJobProviderActionAvailability("crowdin");
+    const translate = actions.find((action) => action.id === "translate_with_agent");
+    const review = actions.find((action) => action.id === "review_with_agent");
+
+    expect(translate).toMatchObject({ visible: true, enabled: true });
+    expect(review).toMatchObject({ visible: true, enabled: true });
+    expect(isJobProviderActionAvailable("crowdin", "translate_with_agent")).toBe(true);
+  });
+
+  it("hides phrase QA fix when QA is unsupported", () => {
+    const actions = getJobProviderActionAvailability("phrase");
+    const qaFix = actions.find((action) => action.id === "fix_qa_issues");
+
+    expect(qaFix).toMatchObject({
+      visible: true,
+      enabled: false,
+    });
+    expect(qaFix?.disabledReason).toContain("Phrase QA");
+  });
+
+  it("returns no visible actions for unknown providers", () => {
+    const actions = getJobProviderActionAvailability("unknown-provider");
+    expect(actions.every((action) => !action.visible)).toBe(true);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/job-provider-actions.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/job-provider-actions.test.ts
@@ -16,7 +16,7 @@ describe("job provider actions", () => {
     expect(isJobProviderActionAvailable("crowdin", "translate_with_agent")).toBe(true);
   });
 
-  it("hides phrase QA fix when QA is unsupported", () => {
+  it("shows phrase QA fix as disabled when QA is unsupported", () => {
     const actions = getJobProviderActionAvailability("phrase");
     const qaFix = actions.find((action) => action.id === "fix_qa_issues");
 

--- a/apps/hyperlocalise-web/src/lib/providers/job-provider-actions.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/job-provider-actions.ts
@@ -1,0 +1,133 @@
+import type { AgentRunKind } from "@/lib/database/types";
+
+import {
+  getTmsProviderActionCapability,
+  type TmsProviderCapabilityAction,
+} from "./tms-capabilities";
+
+export type JobProviderActionId =
+  | "translate_with_agent"
+  | "review_with_agent"
+  | "fix_qa_issues"
+  | "leave_provider_comment"
+  | "push_approved_changes";
+
+export type JobProviderActionDefinition = {
+  id: JobProviderActionId;
+  label: string;
+  agentRunKind: AgentRunKind;
+  requiredCapabilities: TmsProviderCapabilityAction[];
+  inputSnapshot?: Record<string, unknown>;
+};
+
+export const jobProviderActionDefinitions: JobProviderActionDefinition[] = [
+  {
+    id: "translate_with_agent",
+    label: "Translate with agent",
+    agentRunKind: "translate",
+    requiredCapabilities: ["jobs.read", "keys.read", "write_back.translation"],
+  },
+  {
+    id: "review_with_agent",
+    label: "Review with agent",
+    agentRunKind: "review",
+    requiredCapabilities: ["jobs.read", "comments.read"],
+  },
+  {
+    id: "fix_qa_issues",
+    label: "Fix QA issues",
+    agentRunKind: "qa_fix",
+    requiredCapabilities: ["qa.run", "write_back.translation"],
+  },
+  {
+    id: "leave_provider_comment",
+    label: "Leave provider comment",
+    agentRunKind: "comment_only",
+    requiredCapabilities: ["comments.write"],
+  },
+  {
+    id: "push_approved_changes",
+    label: "Push approved changes",
+    agentRunKind: "translate",
+    requiredCapabilities: ["write_back.translation", "status_transitions.write"],
+    inputSnapshot: { action: "push_approved" },
+  },
+];
+
+export type JobProviderActionAvailability = {
+  id: JobProviderActionId;
+  label: string;
+  agentRunKind: AgentRunKind;
+  visible: boolean;
+  enabled: boolean;
+  disabledReason?: string;
+};
+
+function resolveActionAvailability(
+  providerKind: string,
+  action: JobProviderActionDefinition,
+): JobProviderActionAvailability {
+  const capabilityResults = action.requiredCapabilities.map((capability) =>
+    getTmsProviderActionCapability(providerKind, capability),
+  );
+
+  const unsupported = capabilityResults.find((capability) => !capability.supported);
+  if (unsupported) {
+    if (unsupported.ui.state === "hidden") {
+      return {
+        id: action.id,
+        label: action.label,
+        agentRunKind: action.agentRunKind,
+        visible: false,
+        enabled: false,
+      };
+    }
+
+    return {
+      id: action.id,
+      label: action.label,
+      agentRunKind: action.agentRunKind,
+      visible: true,
+      enabled: false,
+      disabledReason: unsupported.ui.disabledReason,
+    };
+  }
+
+  const disabled = capabilityResults.find((capability) => capability.ui.state === "disabled");
+  if (disabled) {
+    return {
+      id: action.id,
+      label: action.label,
+      agentRunKind: action.agentRunKind,
+      visible: true,
+      enabled: false,
+      disabledReason: disabled.ui.disabledReason,
+    };
+  }
+
+  return {
+    id: action.id,
+    label: action.label,
+    agentRunKind: action.agentRunKind,
+    visible: true,
+    enabled: true,
+  };
+}
+
+export function getJobProviderActionAvailability(providerKind: string) {
+  return jobProviderActionDefinitions.map((action) =>
+    resolveActionAvailability(providerKind, action),
+  );
+}
+
+export function getJobProviderActionDefinition(actionId: JobProviderActionId) {
+  return jobProviderActionDefinitions.find((action) => action.id === actionId) ?? null;
+}
+
+export function isJobProviderActionAvailable(providerKind: string, actionId: JobProviderActionId) {
+  const availability = getJobProviderActionAvailability(providerKind).find(
+    (action) => action.id === actionId,
+  );
+
+  return availability?.enabled ?? false;
+}

--- a/apps/hyperlocalise-web/src/lib/providers/job-provider-source-files.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/job-provider-source-files.ts
@@ -1,0 +1,72 @@
+import { and, eq, inArray } from "drizzle-orm";
+
+import { db, schema } from "@/lib/database";
+
+import type { ExternalTmsProviderKind } from "./organization-external-tms-provider-credentials";
+
+function extractProviderFileIds(providerPayload: Record<string, unknown> | null | undefined) {
+  if (!providerPayload) return [];
+
+  const fileIds = providerPayload.fileIds;
+  if (!Array.isArray(fileIds)) return [];
+
+  return fileIds
+    .map((fileId) => {
+      if (typeof fileId === "number" || typeof fileId === "string") {
+        return String(fileId);
+      }
+      return null;
+    })
+    .filter((fileId): fileId is string => Boolean(fileId));
+}
+
+export async function resolveProviderSourceFiles(input: {
+  organizationId: string;
+  projectId: string;
+  providerKind: ExternalTmsProviderKind;
+  providerPayload: Record<string, unknown> | null | undefined;
+}) {
+  const fileIds = extractProviderFileIds(input.providerPayload);
+  if (fileIds.length === 0) return [];
+
+  const files = await db
+    .select({
+      externalResourceId: schema.externalTmsFiles.externalResourceId,
+      resourceType: schema.externalTmsFiles.resourceType,
+      displayName: schema.externalTmsFiles.displayName,
+      sourcePath: schema.externalTmsFiles.sourcePath,
+      externalUrl: schema.externalTmsFiles.externalUrl,
+    })
+    .from(schema.externalTmsFiles)
+    .where(
+      and(
+        eq(schema.externalTmsFiles.organizationId, input.organizationId),
+        eq(schema.externalTmsFiles.projectId, input.projectId),
+        eq(schema.externalTmsFiles.providerKind, input.providerKind),
+        inArray(schema.externalTmsFiles.externalResourceId, fileIds),
+      ),
+    );
+
+  const filesById = new Map(files.map((file) => [file.externalResourceId, file]));
+
+  return fileIds.map((fileId) => {
+    const file = filesById.get(fileId);
+    if (file) {
+      return {
+        id: fileId,
+        displayName: file.displayName,
+        sourcePath: file.sourcePath,
+        resourceType: file.resourceType,
+        externalUrl: file.externalUrl,
+      };
+    }
+
+    return {
+      id: fileId,
+      displayName: fileId,
+      sourcePath: null,
+      resourceType: null,
+      externalUrl: null,
+    };
+  });
+}


### PR DESCRIPTION
## What changed

Extends the existing job detail page for provider-backed TMS jobs with provider metadata, capability-gated agent actions, and agent run history.

- Enriches workspace job detail API responses with provider source files and available actions
- Adds agent run list/create endpoints scoped to provider-backed jobs
- Adds a provider detail section in the job detail UI with translate, review, QA fix, comment, and push actions disabled when unsupported
- Keeps native Hyperlocalise job detail behavior unchanged

Closes HL-369.

## How to test

- `cd apps/hyperlocalise-web && vp check --fix`
- `cd apps/hyperlocalise-web && vp test src/api/routes/project/job.test.ts src/lib/providers/job-provider-actions.test.ts`
- Open a provider-backed job detail page and verify provider metadata, source files, and agent action buttons render
- Start an agent action and confirm a queued run appears in agent activity

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)