### PR TITLE
feat(web): add Smartling credential validation and project listing

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/external-tms-provider-credential/external-tms-provider-credential.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/external-tms-provider-credential/external-tms-provider-credential.route.ts
@@ -4,7 +4,11 @@ import { validator } from "hono/validator";
 import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
 import { notFoundResponse } from "@/api/response.schema";
 import { fetchCrowdinProjects } from "@/lib/providers/crowdin/crowdin-project-fetcher";
-import { syncExternalTmsProjects } from "@/lib/providers/external-tms-project-sync";
+import { fetchSmartlingProjects } from "@/lib/providers/smartling/smartling-project-fetcher";
+import {
+  syncExternalTmsProjects,
+  type ExternalTmsProjectFetcher,
+} from "@/lib/providers/external-tms-project-sync";
 import {
   assertExternalTmsCredentialAdmin,
   deleteOrganizationExternalTmsProviderCredential,
@@ -160,14 +164,22 @@ export function createExternalTmsProviderCredentialRoutes() {
           return c.json({ error: "invalid_external_tms_provider_kind" }, 400);
         }
 
-        if (providerKind.data !== "crowdin") {
+        const fetchProjectsByProvider: Partial<
+          Record<(typeof providerKind)["data"], ExternalTmsProjectFetcher>
+        > = {
+          crowdin: fetchCrowdinProjects,
+          smartling: fetchSmartlingProjects,
+        };
+
+        const fetchProjects = fetchProjectsByProvider[providerKind.data];
+        if (!fetchProjects) {
           return c.json({ error: "provider_sync_not_implemented" }, 501);
         }
 
         const result = await syncExternalTmsProjects({
           organizationId: c.var.auth.organization.localOrganizationId,
           providerKind: providerKind.data,
-          fetchProjects: fetchCrowdinProjects,
+          fetchProjects,
         });
 
         return c.json({ externalTmsProjectSync: result }, 200);

--- a/apps/hyperlocalise-web/src/api/routes/external-tms-provider-credential/external-tms-provider-credential.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/external-tms-provider-credential/external-tms-provider-credential.test.ts
@@ -769,6 +769,370 @@ describe("externalTmsProviderCredentialRoutes", () => {
     expect(runs[0]?.status).toBe("failed");
   });
 
+  it("returns connected Smartling health and records a health check sync run", async () => {
+    const identity = fixture.createWorkosIdentityWithRole("admin");
+    const headers = await fixture.authHeadersFor(identity);
+    const authContext = globalThis.__testApiAuthContext!;
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          response: {
+            code: "SUCCESS",
+            data: {
+              accessToken: "access-token",
+              refreshToken: "refresh-token",
+              expiresIn: 480,
+            },
+          },
+        }),
+        { status: 200 },
+      );
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    await upsertOrganizationExternalTmsProviderCredential({
+      organizationId: authContext.organization.localOrganizationId,
+      userId: authContext.user.localUserId,
+      role: authContext.membership.role,
+      providerKind: "smartling",
+      displayName: "Smartling",
+      secretMaterial: JSON.stringify({
+        userIdentifier: "smartling-user",
+        userSecret: "smartling-secret",
+        accountUid: "acct-1",
+      }),
+    });
+
+    const response = await client.api.orgs[":organizationSlug"]["external-tms-provider-credential"][
+      ":providerKind"
+    ]["health-check"].$post(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing",
+          providerKind: "smartling",
+        },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      externalTmsProviderHealth: {
+        providerKind: "smartling",
+        status: "connected",
+        availability: "available",
+        authValidity: "valid",
+        errorCode: null,
+      },
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.smartling.com/auth-api/v2/authenticate",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          userIdentifier: "smartling-user",
+          userSecret: "smartling-secret",
+        }),
+      }),
+    );
+  });
+
+  it("returns smartling_auth_invalid when Smartling rejects credentials", async () => {
+    const identity = fixture.createWorkosIdentityWithRole("admin");
+    const headers = await fixture.authHeadersFor(identity);
+    const authContext = globalThis.__testApiAuthContext!;
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          response: {
+            code: "AUTHENTICATION_ERROR",
+            errors: [{ message: "Invalid credentials" }],
+          },
+        }),
+        { status: 401 },
+      );
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    await upsertOrganizationExternalTmsProviderCredential({
+      organizationId: authContext.organization.localOrganizationId,
+      userId: authContext.user.localUserId,
+      role: authContext.membership.role,
+      providerKind: "smartling",
+      displayName: "Smartling",
+      secretMaterial: "smartling-user:smartling-secret:acct-1",
+    });
+
+    const response = await client.api.orgs[":organizationSlug"]["external-tms-provider-credential"][
+      ":providerKind"
+    ]["health-check"].$post(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing",
+          providerKind: "smartling",
+        },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      externalTmsProviderHealth: {
+        providerKind: "smartling",
+        status: "error",
+        authValidity: "invalid",
+        errorCode: "smartling_auth_invalid",
+      },
+    });
+  });
+
+  it("returns smartling_api_unavailable when Smartling rejects paid API access", async () => {
+    const identity = fixture.createWorkosIdentityWithRole("admin");
+    const headers = await fixture.authHeadersFor(identity);
+    const authContext = globalThis.__testApiAuthContext!;
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          response: {
+            code: "FEATURE_NOT_AVAILABLE",
+            errors: [{ message: "API access is not enabled on your subscription" }],
+          },
+        }),
+        { status: 403 },
+      );
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    await upsertOrganizationExternalTmsProviderCredential({
+      organizationId: authContext.organization.localOrganizationId,
+      userId: authContext.user.localUserId,
+      role: authContext.membership.role,
+      providerKind: "smartling",
+      displayName: "Smartling",
+      secretMaterial: "smartling-user:smartling-secret:acct-1",
+    });
+
+    const response = await client.api.orgs[":organizationSlug"]["external-tms-provider-credential"][
+      ":providerKind"
+    ]["health-check"].$post(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing",
+          providerKind: "smartling",
+        },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      externalTmsProviderHealth: {
+        providerKind: "smartling",
+        status: "degraded",
+        errorCode: "smartling_api_unavailable",
+      },
+    });
+  });
+
+  it("syncs Smartling projects and locales into connected TMS project records", async () => {
+    const identity = fixture.createWorkosIdentityWithRole("admin");
+    const headers = await fixture.authHeadersFor(identity);
+    const authContext = globalThis.__testApiAuthContext!;
+
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.endsWith("/authenticate")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: { accessToken: "access-token", expiresIn: 3600 },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (url.includes("/accounts/acct-1/projects")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: {
+                items: [
+                  {
+                    accountUid: "acct-1",
+                    projectId: "proj-1",
+                    projectName: "Marketing Website",
+                    sourceLocaleId: "en-US",
+                    archived: false,
+                    projectTypeCode: "GDN",
+                  },
+                ],
+                totalCount: 1,
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (url.includes("/projects/proj-1")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: {
+                accountUid: "acct-1",
+                projectId: "proj-1",
+                projectName: "Marketing Website",
+                sourceLocaleId: "en-US",
+                archived: false,
+                projectTypeCode: "GDN",
+                targetLocales: [
+                  { localeId: "de-DE", description: "German", enabled: true },
+                  { localeId: "fr-FR", description: "French", enabled: true },
+                ],
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response("Not Found", { status: 404 });
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    await upsertOrganizationExternalTmsProviderCredential({
+      organizationId: authContext.organization.localOrganizationId,
+      userId: authContext.user.localUserId,
+      role: authContext.membership.role,
+      providerKind: "smartling",
+      displayName: "Smartling",
+      secretMaterial: JSON.stringify({
+        userIdentifier: "smartling-user",
+        userSecret: "smartling-secret",
+        accountUid: "acct-1",
+      }),
+    });
+
+    const response = await client.api.orgs[":organizationSlug"]["external-tms-provider-credential"][
+      ":providerKind"
+    ]["sync-projects"].$post(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing",
+          providerKind: "smartling",
+        },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(200);
+    const data = (await response.json()) as {
+      externalTmsProjectSync: {
+        status: string;
+        counts: {
+          projectsDiscovered: number;
+          projectsSynced: number;
+          localesSynced: number;
+        };
+      };
+    };
+    expect(data.externalTmsProjectSync.status).toBe("succeeded");
+    expect(data.externalTmsProjectSync.counts).toEqual({
+      projectsDiscovered: 1,
+      projectsSynced: 1,
+      projectsFailed: 0,
+      localesSynced: 3,
+    });
+
+    const projects = await db
+      .select()
+      .from(schema.projects)
+      .where(
+        and(
+          eq(schema.projects.organizationId, authContext.organization.localOrganizationId),
+          eq(schema.projects.externalProviderKind, "smartling"),
+        ),
+      );
+
+    expect(projects).toHaveLength(1);
+    expect(projects[0]).toMatchObject({
+      name: "Marketing Website",
+      sourceLocale: "en-US",
+      targetLocales: ["de-DE", "fr-FR"],
+      externalProjectId: "proj-1",
+      isActive: true,
+      source: "external_tms",
+    });
+  });
+
+  it("records a failed sync run when Smartling auth is invalid", async () => {
+    const identity = fixture.createWorkosIdentityWithRole("admin");
+    const headers = await fixture.authHeadersFor(identity);
+    const authContext = globalThis.__testApiAuthContext!;
+
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.endsWith("/authenticate")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "AUTHENTICATION_ERROR",
+              errors: [{ message: "Invalid credentials" }],
+            },
+          }),
+          { status: 401 },
+        );
+      }
+
+      return new Response("Not Found", { status: 404 });
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    await upsertOrganizationExternalTmsProviderCredential({
+      organizationId: authContext.organization.localOrganizationId,
+      userId: authContext.user.localUserId,
+      role: authContext.membership.role,
+      providerKind: "smartling",
+      displayName: "Smartling",
+      secretMaterial: "smartling-user:invalid-secret:acct-1",
+    });
+
+    const response = await client.api.orgs[":organizationSlug"]["external-tms-provider-credential"][
+      ":providerKind"
+    ]["sync-projects"].$post(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing",
+          providerKind: "smartling",
+        },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(500);
+
+    const runs = await db
+      .select()
+      .from(schema.providerSyncRuns)
+      .where(
+        and(
+          eq(schema.providerSyncRuns.organizationId, authContext.organization.localOrganizationId),
+          eq(schema.providerSyncRuns.providerKind, "smartling"),
+          eq(schema.providerSyncRuns.kind, "project_scan"),
+        ),
+      );
+
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.status).toBe("failed");
+  });
+
   it("returns 501 for providers that do not yet support project sync", async () => {
     const identity = fixture.createWorkosIdentityWithRole("admin");
     const headers = await fixture.authHeadersFor(identity);

--- a/apps/hyperlocalise-web/src/lib/providers/external-tms-health-check.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/external-tms-health-check.ts
@@ -167,17 +167,16 @@ async function validateExternalTmsCredential(input: {
   const rateLimit = readRateLimitHints(response.headers);
 
   if (input.providerKind === "smartling") {
+    const body = await readResponseBody(response);
+
     if (response.ok) {
-      const smartlingHealth = await readSmartlingHealthFromResponse(response);
+      const smartlingHealth = parseSmartlingHealthFromBody(response.status, body);
       if (smartlingHealth) {
         return { ...smartlingHealth, rateLimit };
       }
     }
 
-    const smartlingError = classifySmartlingHttpError(
-      response.status,
-      await readResponseBody(response),
-    );
+    const smartlingError = classifySmartlingHttpError(response.status, body);
     return {
       status: smartlingError.errorCode === "smartling_auth_invalid" ? "error" : "degraded",
       availability:
@@ -232,17 +231,17 @@ async function validateExternalTmsCredential(input: {
   };
 }
 
-async function readSmartlingHealthFromResponse(
-  response: Response,
-): Promise<Omit<ExternalTmsHealthCheckResult, "lastSuccessfulSyncAt" | "rateLimit"> | null> {
-  const body = await readResponseBody(response);
+function parseSmartlingHealthFromBody(
+  status: number,
+  body: unknown,
+): Omit<ExternalTmsHealthCheckResult, "lastSuccessfulSyncAt" | "rateLimit"> | null {
   if (!body || typeof body !== "object") return null;
 
   const envelope = body as {
     response?: { code?: string; data?: { accessToken?: string } };
   };
   if (envelope.response?.code !== "SUCCESS" || !envelope.response.data?.accessToken) {
-    const classified = classifySmartlingHttpError(response.status, body);
+    const classified = classifySmartlingHttpError(status, body);
     return {
       status: classified.errorCode === "smartling_auth_invalid" ? "error" : "degraded",
       availability: classified.errorCode === "smartling_unavailable" ? "unavailable" : "available",

--- a/apps/hyperlocalise-web/src/lib/providers/external-tms-health-check.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/external-tms-health-check.ts
@@ -4,6 +4,8 @@ import { db, schema } from "@/lib/database";
 import { decryptProviderCredential } from "@/lib/security/provider-credential-crypto";
 
 import type { ExternalTmsProviderKind } from "./organization-external-tms-provider-credentials";
+import { parseSmartlingCredentials } from "./smartling/smartling-credentials";
+import { classifySmartlingHttpError } from "./smartling/smartling-api";
 
 export type ExternalTmsHealthStatus = "connected" | "degraded" | "error";
 export type ExternalTmsAvailability = "available" | "unavailable" | "unknown";
@@ -122,6 +124,21 @@ async function validateExternalTmsCredential(input: {
   baseUrl: string | null;
   fetchFn: typeof fetch;
 }): Promise<Omit<ExternalTmsHealthCheckResult, "lastSuccessfulSyncAt">> {
+  if (input.providerKind === "smartling") {
+    try {
+      parseSmartlingCredentials(input.secretMaterial);
+    } catch {
+      return {
+        status: "error",
+        availability: "unknown",
+        authValidity: "unknown",
+        errorCode: "smartling_credentials_invalid",
+        message: "Smartling credentials must include a user identifier and user secret.",
+        rateLimit: emptyRateLimitHints(),
+      };
+    }
+  }
+
   const request = buildValidationRequest(input);
   if (!request) {
     return {
@@ -148,6 +165,29 @@ async function validateExternalTmsCredential(input: {
     };
   }
   const rateLimit = readRateLimitHints(response.headers);
+
+  if (input.providerKind === "smartling") {
+    if (response.ok) {
+      const smartlingHealth = await readSmartlingHealthFromResponse(response);
+      if (smartlingHealth) {
+        return { ...smartlingHealth, rateLimit };
+      }
+    }
+
+    const smartlingError = classifySmartlingHttpError(
+      response.status,
+      await readResponseBody(response),
+    );
+    return {
+      status: smartlingError.errorCode === "smartling_auth_invalid" ? "error" : "degraded",
+      availability:
+        smartlingError.errorCode === "smartling_unavailable" ? "unavailable" : "available",
+      authValidity: smartlingError.errorCode === "smartling_auth_invalid" ? "invalid" : "unknown",
+      errorCode: smartlingError.errorCode,
+      message: smartlingError.message,
+      rateLimit,
+    };
+  }
 
   if (response.status === 401 || response.status === 403) {
     return {
@@ -192,6 +232,43 @@ async function validateExternalTmsCredential(input: {
   };
 }
 
+async function readSmartlingHealthFromResponse(
+  response: Response,
+): Promise<Omit<ExternalTmsHealthCheckResult, "lastSuccessfulSyncAt" | "rateLimit"> | null> {
+  const body = await readResponseBody(response);
+  if (!body || typeof body !== "object") return null;
+
+  const envelope = body as {
+    response?: { code?: string; data?: { accessToken?: string } };
+  };
+  if (envelope.response?.code !== "SUCCESS" || !envelope.response.data?.accessToken) {
+    const classified = classifySmartlingHttpError(response.status, body);
+    return {
+      status: classified.errorCode === "smartling_auth_invalid" ? "error" : "degraded",
+      availability: classified.errorCode === "smartling_unavailable" ? "unavailable" : "available",
+      authValidity: classified.errorCode === "smartling_auth_invalid" ? "invalid" : "unknown",
+      errorCode: classified.errorCode,
+      message: classified.message,
+    };
+  }
+
+  return {
+    status: "connected",
+    availability: "available",
+    authValidity: "valid",
+    errorCode: null,
+    message: null,
+  };
+}
+
+async function readResponseBody(response: Response) {
+  try {
+    return await response.json();
+  } catch {
+    return await response.text().catch(() => null);
+  }
+}
+
 function buildValidationRequest(input: {
   providerKind: ExternalTmsProviderKind;
   secretMaterial: string;
@@ -223,17 +300,24 @@ function buildValidationRequest(input: {
       };
     }
     case "smartling": {
-      const credentials = parseSmartlingCredentials(input.secretMaterial);
-      const baseUrl = normalizeBaseUrl(input.baseUrl, "https://api.smartling.com/auth-api/v2");
-      if (!baseUrl) return null;
-      return {
-        url: `${baseUrl}/authenticate`,
-        init: {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(credentials),
-        },
-      };
+      try {
+        const credentials = parseSmartlingCredentials(input.secretMaterial);
+        const baseUrl = normalizeBaseUrl(input.baseUrl, "https://api.smartling.com/auth-api/v2");
+        if (!baseUrl) return null;
+        return {
+          url: `${baseUrl}/authenticate`,
+          init: {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              userIdentifier: credentials.userIdentifier,
+              userSecret: credentials.userSecret,
+            }),
+          },
+        };
+      } catch {
+        return null;
+      }
     }
   }
 }
@@ -311,25 +395,6 @@ function isBlockedIpv6Address(hostname: string) {
   }
 
   return false;
-}
-
-function parseSmartlingCredentials(secretMaterial: string) {
-  try {
-    const parsed = JSON.parse(secretMaterial) as unknown;
-    if (
-      parsed &&
-      typeof parsed === "object" &&
-      "userIdentifier" in parsed &&
-      "userSecret" in parsed
-    ) {
-      return parsed;
-    }
-  } catch {
-    // Fall through to the compact `userIdentifier:userSecret` form.
-  }
-
-  const [userIdentifier, ...secretParts] = secretMaterial.split(":");
-  return { userIdentifier, userSecret: secretParts.join(":") };
 }
 
 function readRateLimitHints(headers: Headers): ExternalTmsRateLimitHints {

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-api.test.ts
@@ -217,6 +217,27 @@ describe("SmartlingApiClient", () => {
       errorCode: "smartling_api_unavailable",
     });
   });
+
+  it("uses classified error codes for non-success envelopes on HTTP 200", async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          response: {
+            code: "MAX_OPERATIONS_LIMIT_EXCEEDED",
+            errors: [{ message: "Rate limit exceeded" }],
+          },
+        }),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+
+    await expect(client.authenticate()).rejects.toMatchObject({
+      status: 200,
+      code: "smartling_request_failed",
+    });
+  });
 });
 
 describe("deriveServiceBaseUrl", () => {

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-api.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import {
+  SmartlingApiClient,
+  SmartlingApiError,
+  classifySmartlingHttpError,
+  deriveServiceBaseUrl,
+} from "./smartling-api";
+
+describe("SmartlingApiClient", () => {
+  const credentials = {
+    userIdentifier: "user-1",
+    userSecret: "secret-1",
+    accountUid: "acct-1",
+  };
+
+  function createClient(fetchFn: typeof fetch) {
+    return new SmartlingApiClient({
+      credentials,
+      authBaseUrl: "https://api.smartling.test/auth-api/v2",
+      accountsBaseUrl: "https://api.smartling.test/accounts-api/v2",
+      projectsBaseUrl: "https://api.smartling.test/projects-api/v2",
+      fetchFn,
+    });
+  }
+
+  it("authenticates and caches the access token", async () => {
+    const fetchMock = vi.fn(async (url, init) => {
+      if (String(url).endsWith("/authenticate") && init?.method === "POST") {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: {
+                accessToken: "access-token",
+                refreshToken: "refresh-token",
+                expiresIn: 3600,
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response("Not Found", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    const first = await client.getAccessToken();
+    const second = await client.getAccessToken();
+
+    expect(first).toBe("access-token");
+    expect(second).toBe("access-token");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("refreshes the access token when it is near expiry", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+
+    const fetchMock = vi.fn(async (url) => {
+      if (String(url).endsWith("/authenticate/refresh")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: {
+                accessToken: "refreshed-token",
+                refreshToken: "refresh-token",
+                expiresIn: 3600,
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (String(url).endsWith("/authenticate")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: {
+                accessToken: "access-token",
+                refreshToken: "refresh-token",
+                expiresIn: 1,
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response("Not Found", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    await client.getAccessToken();
+    vi.setSystemTime(new Date("2026-01-01T00:00:02.000Z"));
+    const refreshed = await client.getAccessToken();
+
+    expect(refreshed).toBe("refreshed-token");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.smartling.test/auth-api/v2/authenticate/refresh",
+      expect.objectContaining({ method: "POST" }),
+    );
+
+    vi.useRealTimers();
+  });
+
+  it("lists account projects with pagination", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      if (String(url).endsWith("/authenticate")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: { accessToken: "access-token", expiresIn: 3600 },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (String(url).includes("/accounts/acct-1/projects")) {
+        if (String(url).includes("offset=0")) {
+          return new Response(
+            JSON.stringify({
+              response: {
+                code: "SUCCESS",
+                data: {
+                  items: [
+                    {
+                      accountUid: "acct-1",
+                      projectId: "proj-1",
+                      projectName: "Marketing",
+                      sourceLocaleId: "en-US",
+                      archived: false,
+                      projectTypeCode: "GDN",
+                    },
+                  ],
+                  totalCount: 2,
+                },
+              },
+            }),
+            { status: 200 },
+          );
+        }
+
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: {
+                items: [
+                  {
+                    accountUid: "acct-1",
+                    projectId: "proj-2",
+                    projectName: "Mobile",
+                    sourceLocaleId: "en-US",
+                    archived: false,
+                  },
+                ],
+                totalCount: 2,
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response("Not Found", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    const projects = await client.listAccountProjects("acct-1");
+
+    expect(projects).toHaveLength(2);
+    expect(projects[0]).toMatchObject({
+      projectId: "proj-1",
+      projectName: "Marketing",
+      sourceLocaleId: "en-US",
+    });
+  });
+
+  it("throws SmartlingApiError on auth failure", async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          response: {
+            code: "AUTHENTICATION_ERROR",
+            errors: [{ message: "Invalid credentials" }],
+          },
+        }),
+        { status: 401 },
+      );
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+
+    await expect(client.authenticate()).rejects.toBeInstanceOf(SmartlingApiError);
+    await expect(client.authenticate()).rejects.toMatchObject({
+      status: 401,
+      code: "smartling_auth_invalid",
+    });
+  });
+
+  it("classifies paid or unavailable API responses", () => {
+    expect(
+      classifySmartlingHttpError(403, {
+        response: {
+          code: "FEATURE_NOT_AVAILABLE",
+          errors: [{ message: "API access is not enabled on your subscription" }],
+        },
+      }),
+    ).toMatchObject({
+      errorCode: "smartling_api_unavailable",
+    });
+  });
+});
+
+describe("deriveServiceBaseUrl", () => {
+  it("derives accounts and projects base URLs from the auth base URL", () => {
+    expect(deriveServiceBaseUrl("https://api.smartling.test/auth-api/v2", "accounts")).toBe(
+      "https://api.smartling.test/accounts-api/v2",
+    );
+    expect(deriveServiceBaseUrl("https://api.smartling.test/auth-api/v2", "projects")).toBe(
+      "https://api.smartling.test/projects-api/v2",
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-api.ts
@@ -376,12 +376,7 @@ async function parseSmartlingResponse<T>(response: Response, url: string): Promi
 
   if (envelope.response.code !== "SUCCESS") {
     const classified = classifySmartlingHttpError(response.status, body);
-    throw new SmartlingApiError(
-      classified.message,
-      response.status,
-      envelope.response.code ?? classified.errorCode,
-      body,
-    );
+    throw new SmartlingApiError(classified.message, response.status, classified.errorCode, body);
   }
 
   return envelope.response.data;

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-api.ts
@@ -1,0 +1,420 @@
+/**
+ * Smartling API client for authentication and project discovery.
+ *
+ * This module intentionally implements only the endpoints required for
+ * credential validation and the TMS connector project-scan flow.
+ */
+
+import { parseSmartlingCredentials, type SmartlingCredentials } from "./smartling-credentials";
+
+const DEFAULT_AUTH_BASE_URL = "https://api.smartling.com/auth-api/v2";
+const DEFAULT_ACCOUNTS_BASE_URL = "https://api.smartling.com/accounts-api/v2";
+const DEFAULT_PROJECTS_BASE_URL = "https://api.smartling.com/projects-api/v2";
+const TOKEN_REFRESH_SKEW_MS = 60_000;
+const DEFAULT_PAGE_SIZE = 500;
+
+export interface SmartlingApiClientOptions {
+  credentials: SmartlingCredentials | string;
+  authBaseUrl?: string;
+  accountsBaseUrl?: string;
+  projectsBaseUrl?: string;
+  fetchFn?: typeof fetch;
+}
+
+export interface SmartlingAuthTokens {
+  accessToken: string;
+  refreshToken: string | null;
+  expiresAt: number | null;
+}
+
+export interface SmartlingAccountProjectSummary {
+  accountUid: string;
+  projectId: string;
+  projectName: string;
+  sourceLocaleId: string;
+  archived: boolean;
+  projectTypeCode: string | null;
+}
+
+export interface SmartlingTargetLocale {
+  localeId: string;
+  description: string | null;
+  enabled: boolean;
+}
+
+export interface SmartlingProjectDetails {
+  accountUid: string;
+  projectId: string;
+  projectName: string;
+  sourceLocaleId: string;
+  archived: boolean;
+  projectTypeCode: string | null;
+  targetLocales: SmartlingTargetLocale[];
+}
+
+type SmartlingEnvelope<T> = {
+  response: {
+    code: string;
+    data: T;
+    errors?: Array<{ key?: string; message?: string }>;
+  };
+};
+
+type SmartlingAuthResponseData = {
+  accessToken: string;
+  refreshToken?: string;
+  expiresIn?: number;
+  refreshExpiresIn?: number;
+  tokenType?: string;
+};
+
+type SmartlingAccountProjectListData = {
+  items: Array<{
+    accountUid: string;
+    projectId: string;
+    projectName: string;
+    sourceLocaleId: string;
+    archived?: boolean;
+    projectTypeCode?: string;
+  }>;
+  totalCount?: number;
+};
+
+export class SmartlingApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly code: string | null,
+    readonly responseBody: unknown,
+  ) {
+    super(message);
+    this.name = "SmartlingApiError";
+  }
+}
+
+export class SmartlingApiClient {
+  private readonly credentials: SmartlingCredentials;
+  private readonly authBaseUrl: string;
+  private readonly accountsBaseUrl: string;
+  private readonly projectsBaseUrl: string;
+  private readonly fetchFn: typeof fetch;
+  private tokens: SmartlingAuthTokens | null = null;
+
+  constructor(options: SmartlingApiClientOptions) {
+    this.credentials =
+      typeof options.credentials === "string"
+        ? parseSmartlingCredentials(options.credentials)
+        : options.credentials;
+    this.authBaseUrl = normalizeServiceBaseUrl(options.authBaseUrl, DEFAULT_AUTH_BASE_URL);
+    this.accountsBaseUrl = normalizeServiceBaseUrl(
+      options.accountsBaseUrl ?? deriveServiceBaseUrl(this.authBaseUrl, "accounts"),
+      DEFAULT_ACCOUNTS_BASE_URL,
+    );
+    this.projectsBaseUrl = normalizeServiceBaseUrl(
+      options.projectsBaseUrl ?? deriveServiceBaseUrl(this.authBaseUrl, "projects"),
+      DEFAULT_PROJECTS_BASE_URL,
+    );
+    this.fetchFn = options.fetchFn ?? fetch;
+  }
+
+  get credentialScope() {
+    return {
+      accountUid: this.credentials.accountUid ?? null,
+      projectId: this.credentials.projectId ?? null,
+    };
+  }
+
+  async authenticate(): Promise<SmartlingAuthTokens> {
+    const data = await this.post<SmartlingAuthResponseData>(
+      `${this.authBaseUrl}/authenticate`,
+      "",
+      {
+        userIdentifier: this.credentials.userIdentifier,
+        userSecret: this.credentials.userSecret,
+      },
+    );
+
+    this.tokens = toAuthTokens(data);
+    return this.tokens;
+  }
+
+  async refreshAccessToken(refreshToken: string): Promise<SmartlingAuthTokens> {
+    const data = await this.post<SmartlingAuthResponseData>(
+      `${this.authBaseUrl}/authenticate/refresh`,
+      "",
+      { refreshToken },
+    );
+
+    this.tokens = toAuthTokens(data);
+    return this.tokens;
+  }
+
+  async getAccessToken(): Promise<string> {
+    const now = Date.now();
+    if (this.tokens?.accessToken) {
+      if (!this.tokens.expiresAt || this.tokens.expiresAt - TOKEN_REFRESH_SKEW_MS > now) {
+        return this.tokens.accessToken;
+      }
+
+      if (this.tokens.refreshToken) {
+        const refreshed = await this.refreshAccessToken(this.tokens.refreshToken);
+        return refreshed.accessToken;
+      }
+    }
+
+    const authenticated = await this.authenticate();
+    return authenticated.accessToken;
+  }
+
+  async listAccountProjects(accountUid: string): Promise<SmartlingAccountProjectSummary[]> {
+    const token = await this.getAccessToken();
+    const projects: SmartlingAccountProjectSummary[] = [];
+    let offset = 0;
+
+    while (true) {
+      const params = new URLSearchParams({
+        limit: String(DEFAULT_PAGE_SIZE),
+        offset: String(offset),
+      });
+      const data = await this.get<SmartlingAccountProjectListData>(
+        `${this.accountsBaseUrl}/accounts/${encodeURIComponent(accountUid)}/projects?${params.toString()}`,
+        token,
+      );
+
+      const page = (data.items ?? []).map((item) => ({
+        accountUid: item.accountUid,
+        projectId: item.projectId,
+        projectName: item.projectName,
+        sourceLocaleId: item.sourceLocaleId,
+        archived: item.archived ?? false,
+        projectTypeCode: item.projectTypeCode ?? null,
+      }));
+      projects.push(...page);
+
+      offset += page.length;
+      if (page.length === 0) {
+        break;
+      }
+
+      const totalCount = data.totalCount;
+      if (typeof totalCount === "number") {
+        if (offset >= totalCount) {
+          break;
+        }
+      } else if (page.length < DEFAULT_PAGE_SIZE) {
+        break;
+      }
+    }
+
+    return projects;
+  }
+
+  async getProjectDetails(projectId: string): Promise<SmartlingProjectDetails> {
+    const token = await this.getAccessToken();
+    const data = await this.get<SmartlingProjectDetails>(
+      `${this.projectsBaseUrl}/projects/${encodeURIComponent(projectId)}`,
+      token,
+    );
+
+    return {
+      accountUid: data.accountUid,
+      projectId: data.projectId,
+      projectName: data.projectName,
+      sourceLocaleId: data.sourceLocaleId,
+      archived: data.archived ?? false,
+      projectTypeCode: data.projectTypeCode ?? null,
+      targetLocales: (data.targetLocales ?? []).map((locale) => ({
+        localeId: locale.localeId,
+        description: locale.description ?? null,
+        enabled: locale.enabled ?? true,
+      })),
+    };
+  }
+
+  async listDiscoverableProjects(): Promise<SmartlingProjectDetails[]> {
+    if (this.credentials.projectId) {
+      return [await this.getProjectDetails(this.credentials.projectId)];
+    }
+
+    const accountUid = this.credentials.accountUid;
+    if (!accountUid) {
+      throw new Error("smartling_account_uid_required");
+    }
+
+    const summaries = await this.listAccountProjects(accountUid);
+    return summaries
+      .filter((project) => !project.archived)
+      .map((summary) => ({
+        accountUid: summary.accountUid,
+        projectId: summary.projectId,
+        projectName: summary.projectName,
+        sourceLocaleId: summary.sourceLocaleId,
+        archived: summary.archived,
+        projectTypeCode: summary.projectTypeCode,
+        targetLocales: [],
+      }));
+  }
+
+  private async get<T>(url: string, token: string): Promise<T> {
+    const response = await this.fetchFn(url, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+    });
+
+    return parseSmartlingResponse<T>(response, url);
+  }
+
+  private async post<T>(url: string, token: string, payload: unknown): Promise<T> {
+    const response = await this.fetchFn(url, {
+      method: "POST",
+      headers: {
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+
+    return parseSmartlingResponse<T>(response, url);
+  }
+}
+
+export function deriveServiceBaseUrl(authBaseUrl: string, service: "accounts" | "projects") {
+  const normalized = normalizeServiceBaseUrl(authBaseUrl, authBaseUrl);
+  if (normalized.includes("/auth-api/")) {
+    return normalized.replace("/auth-api/", `/${service}-api/`);
+  }
+
+  return service === "accounts" ? DEFAULT_ACCOUNTS_BASE_URL : DEFAULT_PROJECTS_BASE_URL;
+}
+
+export function normalizeServiceBaseUrl(baseUrl: string | undefined, fallback: string) {
+  try {
+    const url = new URL(baseUrl ?? fallback);
+    url.pathname = url.pathname.replace(/\/+$/, "");
+    url.search = "";
+    url.hash = "";
+    return url.toString().replace(/\/+$/, "");
+  } catch {
+    return fallback;
+  }
+}
+
+export function classifySmartlingHttpError(status: number, responseBody: unknown) {
+  const responseCode = readSmartlingResponseCode(responseBody);
+  const combinedMessage = collectSmartlingErrorMessage(responseBody).toLowerCase();
+
+  if (status === 401 || responseCode === "AUTHENTICATION_ERROR") {
+    return {
+      errorCode: "smartling_auth_invalid",
+      message: "Smartling rejected the stored credential.",
+    };
+  }
+
+  if (
+    status === 402 ||
+    status === 403 ||
+    responseCode === "FEATURE_NOT_AVAILABLE" ||
+    responseCode === "NOT_AUTHORIZED" ||
+    combinedMessage.includes("not available") ||
+    combinedMessage.includes("not enabled") ||
+    combinedMessage.includes("subscription") ||
+    combinedMessage.includes("paid plan") ||
+    combinedMessage.includes("api access")
+  ) {
+    return {
+      errorCode: "smartling_api_unavailable",
+      message:
+        "Smartling rejected the request because this API or account capability is unavailable on the current plan.",
+    };
+  }
+
+  if (status === 429 || responseCode === "TOO_MANY_REQUESTS") {
+    return {
+      errorCode: "smartling_rate_limited",
+      message: "Smartling rate limited the request.",
+    };
+  }
+
+  if (status >= 500) {
+    return {
+      errorCode: "smartling_unavailable",
+      message: "Smartling is temporarily unavailable.",
+    };
+  }
+
+  return {
+    errorCode: "smartling_request_failed",
+    message: `Smartling returned HTTP ${status}.`,
+  };
+}
+
+async function parseSmartlingResponse<T>(response: Response, url: string): Promise<T> {
+  let body: unknown = null;
+  try {
+    body = await response.json();
+  } catch {
+    body = await response.text().catch(() => null);
+  }
+
+  if (!response.ok) {
+    const classified = classifySmartlingHttpError(response.status, body);
+    throw new SmartlingApiError(classified.message, response.status, classified.errorCode, body);
+  }
+
+  const envelope = body as SmartlingEnvelope<T>;
+  if (!envelope?.response) {
+    throw new SmartlingApiError(
+      `Smartling API returned an unexpected response for ${url}`,
+      response.status,
+      "smartling_response_invalid",
+      body,
+    );
+  }
+
+  if (envelope.response.code !== "SUCCESS") {
+    const classified = classifySmartlingHttpError(response.status, body);
+    throw new SmartlingApiError(
+      classified.message,
+      response.status,
+      envelope.response.code ?? classified.errorCode,
+      body,
+    );
+  }
+
+  return envelope.response.data;
+}
+
+function toAuthTokens(data: SmartlingAuthResponseData): SmartlingAuthTokens {
+  const expiresAt =
+    typeof data.expiresIn === "number" && data.expiresIn > 0
+      ? Date.now() + data.expiresIn * 1000
+      : null;
+
+  return {
+    accessToken: data.accessToken,
+    refreshToken: data.refreshToken ?? null,
+    expiresAt,
+  };
+}
+
+function readSmartlingResponseCode(responseBody: unknown) {
+  if (!responseBody || typeof responseBody !== "object") return null;
+  const response = (responseBody as SmartlingEnvelope<unknown>).response;
+  return typeof response?.code === "string" ? response.code : null;
+}
+
+function collectSmartlingErrorMessage(responseBody: unknown) {
+  if (!responseBody || typeof responseBody !== "object") {
+    return typeof responseBody === "string" ? responseBody : "";
+  }
+
+  const response = (responseBody as SmartlingEnvelope<unknown>).response;
+  const errors = Array.isArray(response?.errors) ? response.errors : [];
+  return errors
+    .map((error) => (typeof error?.message === "string" ? error.message : ""))
+    .filter(Boolean)
+    .join(" ");
+}

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-credentials.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-credentials.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { parseSmartlingCredentials } from "./smartling-credentials";
+
+describe("parseSmartlingCredentials", () => {
+  it("parses JSON credentials with account and project identifiers", () => {
+    expect(
+      parseSmartlingCredentials(
+        JSON.stringify({
+          userIdentifier: "user-1",
+          userSecret: "secret-1",
+          accountUid: "acct-1",
+          projectId: "proj-1",
+        }),
+      ),
+    ).toEqual({
+      userIdentifier: "user-1",
+      userSecret: "secret-1",
+      accountUid: "acct-1",
+      projectId: "proj-1",
+    });
+  });
+
+  it("parses compact user:secret:accountUid credentials", () => {
+    expect(parseSmartlingCredentials("user-1:secret-1:acct-1")).toEqual({
+      userIdentifier: "user-1",
+      userSecret: "secret-1",
+      accountUid: "acct-1",
+    });
+  });
+
+  it("parses compact user:secret credentials", () => {
+    expect(parseSmartlingCredentials("user-1:secret-1")).toEqual({
+      userIdentifier: "user-1",
+      userSecret: "secret-1",
+    });
+  });
+
+  it("parses JSON credentials when the secret contains colons", () => {
+    expect(
+      parseSmartlingCredentials(
+        JSON.stringify({
+          userIdentifier: "user-1",
+          userSecret: "secret:with:colons",
+        }),
+      ),
+    ).toEqual({
+      userIdentifier: "user-1",
+      userSecret: "secret:with:colons",
+    });
+  });
+
+  it("rejects empty credentials", () => {
+    expect(() => parseSmartlingCredentials("   ")).toThrow("smartling_credentials_invalid");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-credentials.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-credentials.ts
@@ -1,0 +1,82 @@
+export type SmartlingCredentials = {
+  userIdentifier: string;
+  userSecret: string;
+  accountUid?: string;
+  projectId?: string;
+};
+
+export function parseSmartlingCredentials(secretMaterial: string): SmartlingCredentials {
+  const trimmed = secretMaterial.trim();
+  if (!trimmed) {
+    throw new Error("smartling_credentials_invalid");
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (parsed && typeof parsed === "object") {
+      const record = parsed as Record<string, unknown>;
+      const userIdentifier = readCredentialField(record, ["userIdentifier", "userId", "user_id"]);
+      const userSecret = readCredentialField(record, ["userSecret", "secret", "user_secret"]);
+      if (userIdentifier && userSecret) {
+        return {
+          userIdentifier,
+          userSecret,
+          accountUid: readOptionalCredentialField(record, [
+            "accountUid",
+            "accountId",
+            "account_id",
+          ]),
+          projectId: readOptionalCredentialField(record, ["projectId", "project_id"]),
+        };
+      }
+    }
+  } catch {
+    // Fall through to compact credential forms.
+  }
+
+  const colonParts = trimmed.split(":");
+  if (colonParts.length === 4) {
+    const [userIdentifier, userSecret, accountUid, projectId] = colonParts;
+    if (userIdentifier && userSecret) {
+      return {
+        userIdentifier,
+        userSecret,
+        accountUid: accountUid || undefined,
+        projectId: projectId || undefined,
+      };
+    }
+  }
+
+  if (colonParts.length === 3) {
+    const [userIdentifier, userSecret, accountUid] = colonParts;
+    if (userIdentifier && userSecret) {
+      return {
+        userIdentifier,
+        userSecret,
+        accountUid: accountUid || undefined,
+      };
+    }
+  }
+
+  const [userIdentifier, ...secretParts] = colonParts;
+  const userSecret = secretParts.join(":");
+  if (userIdentifier && userSecret) {
+    return { userIdentifier, userSecret };
+  }
+
+  throw new Error("smartling_credentials_invalid");
+}
+
+function readCredentialField(record: Record<string, unknown>, keys: string[]) {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return null;
+}
+
+function readOptionalCredentialField(record: Record<string, unknown>, keys: string[]) {
+  return readCredentialField(record, keys) ?? undefined;
+}

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-project-fetcher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-project-fetcher.test.ts
@@ -118,6 +118,90 @@ describe("fetchSmartlingProjects", () => {
     });
   });
 
+  it("fetches project details with bounded concurrency", async () => {
+    let inFlightProjectRequests = 0;
+    let maxInFlightProjectRequests = 0;
+
+    const fetchMock = vi.fn(async (url) => {
+      if (String(url).endsWith("/authenticate")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: { accessToken: "access-token", expiresIn: 3600 },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (String(url).includes("/accounts/acct-1/projects")) {
+        const items = Array.from({ length: 25 }, (_, index) => ({
+          accountUid: "acct-1",
+          projectId: `proj-${index + 1}`,
+          projectName: `Project ${index + 1}`,
+          sourceLocaleId: "en-US",
+          archived: false,
+          projectTypeCode: "GDN",
+        }));
+
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: { items, totalCount: items.length },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (String(url).includes("/projects/proj-")) {
+        inFlightProjectRequests += 1;
+        maxInFlightProjectRequests = Math.max(maxInFlightProjectRequests, inFlightProjectRequests);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        inFlightProjectRequests -= 1;
+
+        const projectId = String(url).split("/projects/")[1];
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: {
+                accountUid: "acct-1",
+                projectId,
+                projectName: `Project ${projectId}`,
+                sourceLocaleId: "en-US",
+                archived: false,
+                projectTypeCode: "GDN",
+                targetLocales: [{ localeId: "de-DE", description: "German", enabled: true }],
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response("Not Found", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const projects = await fetchSmartlingProjects({
+      organizationId: "org-1",
+      providerKind: "smartling",
+      credential,
+      secretMaterial: JSON.stringify({
+        userIdentifier: "user-1",
+        userSecret: "secret-1",
+        accountUid: "acct-1",
+      }),
+    });
+
+    expect(projects).toHaveLength(25);
+    expect(maxInFlightProjectRequests).toBeLessThanOrEqual(15);
+  });
+
   it("throws smartling_auth_invalid when authentication fails", async () => {
     const fetchMock = vi.fn(async () => {
       return new Response(

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-project-fetcher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-project-fetcher.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { fetchSmartlingProjects } from "./smartling-project-fetcher";
+
+describe("fetchSmartlingProjects", () => {
+  const credential = {
+    id: "cred-1",
+    organizationId: "org-1",
+    providerKind: "smartling" as const,
+    displayName: "Smartling",
+    region: null,
+    baseUrl: null,
+    validationStatus: "connected",
+    validationMessage: null,
+    lastValidatedAt: null,
+    encryptionAlgorithm: "aes-256-gcm",
+    keyVersion: 1,
+    ciphertext: "cipher",
+    iv: "iv",
+    authTag: "tag",
+    maskedSecretSuffix: "cret",
+    createdByUserId: "user-1",
+    updatedByUserId: "user-1",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  it("normalizes account projects and locales into the shared provider model", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      if (String(url).endsWith("/authenticate")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: { accessToken: "access-token", expiresIn: 3600 },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (String(url).includes("/accounts/acct-1/projects")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: {
+                items: [
+                  {
+                    accountUid: "acct-1",
+                    projectId: "proj-1",
+                    projectName: "Marketing Website",
+                    sourceLocaleId: "en-US",
+                    archived: false,
+                    projectTypeCode: "GDN",
+                  },
+                ],
+                totalCount: 1,
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (String(url).includes("/projects/proj-1")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: {
+                accountUid: "acct-1",
+                projectId: "proj-1",
+                projectName: "Marketing Website",
+                sourceLocaleId: "en-US",
+                archived: false,
+                projectTypeCode: "GDN",
+                targetLocales: [
+                  { localeId: "de-DE", description: "German", enabled: true },
+                  { localeId: "fr-FR", description: "French", enabled: false },
+                ],
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response("Not Found", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const projects = await fetchSmartlingProjects({
+      organizationId: "org-1",
+      providerKind: "smartling",
+      credential,
+      secretMaterial: JSON.stringify({
+        userIdentifier: "user-1",
+        userSecret: "secret-1",
+        accountUid: "acct-1",
+      }),
+    });
+
+    expect(projects).toHaveLength(1);
+    expect(projects[0]).toEqual({
+      externalProjectId: "proj-1",
+      name: "Marketing Website",
+      sourceLocale: "en-US",
+      targetLocales: ["de-DE"],
+      externalProjectUrl:
+        "https://dashboard.smartling.com/app/accounts/acct-1/project/proj-1/dashboard",
+      isActive: true,
+      metadata: {
+        accountUid: "acct-1",
+        projectTypeCode: "GDN",
+      },
+    });
+  });
+
+  it("throws smartling_auth_invalid when authentication fails", async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          response: {
+            code: "AUTHENTICATION_ERROR",
+            errors: [{ message: "Invalid credentials" }],
+          },
+        }),
+        { status: 401 },
+      );
+    }) as unknown as typeof fetch;
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      fetchSmartlingProjects({
+        organizationId: "org-1",
+        providerKind: "smartling",
+        credential,
+        secretMaterial: "user-1:secret-1:acct-1",
+      }),
+    ).rejects.toThrow("smartling_auth_invalid");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-project-fetcher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-project-fetcher.ts
@@ -3,6 +3,8 @@ import type { ExternalTmsProjectFetcher } from "@/lib/providers/external-tms-pro
 import { parseSmartlingCredentials } from "./smartling-credentials";
 import { SmartlingApiClient, SmartlingApiError } from "./smartling-api";
 
+const PROJECT_DETAIL_FETCH_CONCURRENCY = 15;
+
 export const fetchSmartlingProjects: ExternalTmsProjectFetcher = async ({
   credential,
   secretMaterial,
@@ -31,8 +33,10 @@ export const fetchSmartlingProjects: ExternalTmsProjectFetcher = async ({
     throw error;
   }
 
-  const results = await Promise.all(
-    summaries.map(async (summary) => {
+  const results = await mapInBatches(
+    summaries,
+    PROJECT_DETAIL_FETCH_CONCURRENCY,
+    async (summary) => {
       if (summary.targetLocales.length > 0) {
         return normalizeSmartlingProject(summary);
       }
@@ -44,12 +48,15 @@ export const fetchSmartlingProjects: ExternalTmsProjectFetcher = async ({
         if (error instanceof SmartlingApiError && error.status === 401) {
           throw new Error("smartling_auth_invalid");
         }
+        if (error instanceof SmartlingApiError && error.code === "smartling_api_unavailable") {
+          throw new Error("smartling_api_unavailable");
+        }
 
         return normalizeSmartlingProject(summary, {
           syncWarning: error instanceof Error ? error.message : "project_details_fetch_failed",
         });
       }
-    }),
+    },
   );
 
   return results;
@@ -88,4 +95,21 @@ function normalizeSmartlingProject(
 
 function buildSmartlingProjectUrl(accountUid: string, projectId: string) {
   return `https://dashboard.smartling.com/app/accounts/${encodeURIComponent(accountUid)}/project/${encodeURIComponent(projectId)}/dashboard`;
+}
+
+async function mapInBatches<T, R>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = [];
+  const batchSize = Math.max(1, concurrency);
+
+  for (let index = 0; index < items.length; index += batchSize) {
+    const batch = items.slice(index, index + batchSize);
+    const batchResults = await Promise.all(batch.map((item) => mapper(item)));
+    results.push(...batchResults);
+  }
+
+  return results;
 }

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-project-fetcher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-project-fetcher.ts
@@ -1,0 +1,91 @@
+import type { ExternalTmsProjectFetcher } from "@/lib/providers/external-tms-project-sync";
+
+import { parseSmartlingCredentials } from "./smartling-credentials";
+import { SmartlingApiClient, SmartlingApiError } from "./smartling-api";
+
+export const fetchSmartlingProjects: ExternalTmsProjectFetcher = async ({
+  credential,
+  secretMaterial,
+}) => {
+  const credentials = parseSmartlingCredentials(secretMaterial);
+  const client = new SmartlingApiClient({
+    credentials,
+    authBaseUrl: credential.baseUrl ?? undefined,
+  });
+
+  let summaries;
+  try {
+    summaries = await client.listDiscoverableProjects();
+  } catch (error) {
+    if (error instanceof SmartlingApiError) {
+      if (error.code === "smartling_auth_invalid" || error.status === 401) {
+        throw new Error("smartling_auth_invalid");
+      }
+      if (error.code === "smartling_api_unavailable") {
+        throw new Error("smartling_api_unavailable");
+      }
+    }
+    if (error instanceof Error && error.message === "smartling_account_uid_required") {
+      throw error;
+    }
+    throw error;
+  }
+
+  const results = await Promise.all(
+    summaries.map(async (summary) => {
+      if (summary.targetLocales.length > 0) {
+        return normalizeSmartlingProject(summary);
+      }
+
+      try {
+        const details = await client.getProjectDetails(summary.projectId);
+        return normalizeSmartlingProject(details);
+      } catch (error) {
+        if (error instanceof SmartlingApiError && error.status === 401) {
+          throw new Error("smartling_auth_invalid");
+        }
+
+        return normalizeSmartlingProject(summary, {
+          syncWarning: error instanceof Error ? error.message : "project_details_fetch_failed",
+        });
+      }
+    }),
+  );
+
+  return results;
+};
+
+function normalizeSmartlingProject(
+  project: {
+    accountUid: string;
+    projectId: string;
+    projectName: string;
+    sourceLocaleId: string;
+    archived: boolean;
+    projectTypeCode: string | null;
+    targetLocales: Array<{ localeId: string; enabled?: boolean }>;
+  },
+  extras?: { syncWarning?: string },
+) {
+  const targetLocales = project.targetLocales
+    .filter((locale) => locale.enabled !== false)
+    .map((locale) => locale.localeId);
+
+  return {
+    externalProjectId: project.projectId,
+    name: project.projectName,
+    sourceLocale: project.sourceLocaleId,
+    targetLocales,
+    externalProjectUrl: buildSmartlingProjectUrl(project.accountUid, project.projectId),
+    isActive: !project.archived,
+    metadata: {
+      accountUid: project.accountUid,
+      projectTypeCode: project.projectTypeCode,
+      ...(extras?.syncWarning ? { syncWarning: extras.syncWarning } : {}),
+    },
+  };
+}
+
+function buildSmartlingProjectUrl(accountUid: string, projectId: string) {
+  return `https://dashboard.smartling.com/app/accounts/${encodeURIComponent(accountUid)}/project/${encodeURIComponent(projectId)}/dashboard`;
+}


### PR DESCRIPTION
## What changed

Adds the first Smartling TMS connector slice for credential validation and project discovery:

- Smartling API client with authenticate/refresh token handling, account project listing, and per-project locale discovery
- Credential parsing for JSON and compact `user:secret[:accountUid][:projectId]` formats
- Provider health checks that validate Smartling `SUCCESS` auth responses and surface `smartling_auth_invalid` / `smartling_api_unavailable` errors
- `POST /external-tms-provider-credential/smartling/sync-projects` wired through the shared project sync orchestrator
- Unit and route tests for auth failure handling and project/locale normalization

Closes HL-343.

## How to test

- `cd apps/hyperlocalise-web && vp test src/lib/providers/smartling src/api/routes/external-tms-provider-credential/external-tms-provider-credential.test.ts`
- `cd apps/hyperlocalise-web && vp check --fix`
- In the app, save Smartling credentials as JSON with `userIdentifier`, `userSecret`, and `accountUid`, then run health check and project sync from Integrations

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix` on touched web paths)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the first Smartling TMS connector slice: a typed API client with authenticate/refresh token handling and paginated project listing, credential parsing for JSON and compact `user:secret[:accountUid][:projectId]` formats, provider health checks that map Smartling envelope codes to internal error codes, and a `POST /sync-projects` route wired through the shared project-sync orchestrator with a bounded-concurrency fetcher.

- **Credential parsing** (`smartling-credentials.ts`) is extracted from `external-tms-health-check.ts` into its own module supporting JSON, compact, and field-alias forms with clear validation errors.
- **API client** (`smartling-api.ts`) implements authenticate, refresh, account project list (paginated), and per-project detail fetch; the `classifySmartlingHttpError` helper centralises HTTP status → internal error code mapping for both health-check and fetcher callers.
- **Project fetcher** (`smartling-project-fetcher.ts`) resolves the previous unbounded-concurrency concern by processing detail fetches in batches of 15 via `mapInBatches`, and the route dispatch in the credential route is refactored from a hardcoded Crowdin guard to a provider-keyed map.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all changes are additive and the new Smartling path does not affect existing Crowdin or other provider flows.

The new Smartling path is cleanly isolated behind the provider-keyed dispatch map. The two findings are in the token-management helpers and only manifest under conditions that are very unlikely within a single short-lived sync run (refresh token revocation mid-sync, or token expiry coinciding with a full 15-slot batch). No correctness bug affects the happy path or existing providers.

apps/hyperlocalise-web/src/lib/providers/smartling/smartling-api.ts — specifically the getAccessToken token-refresh logic.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/hyperlocalise-web/src/lib/providers/smartling/smartling-api.ts | New Smartling API client with auth, token refresh, project listing and detail fetching. Token refresh has no fallback to re-authentication on failure and no concurrent-call deduplication. |
| apps/hyperlocalise-web/src/lib/providers/smartling/smartling-credentials.ts | New credential parser supporting JSON and colon-delimited compact formats with aliases for common field names. Logic is clear and well-tested. |
| apps/hyperlocalise-web/src/lib/providers/smartling/smartling-project-fetcher.ts | Project fetcher with bounded concurrency (15 slots) via mapInBatches, addresses the previous rate-limiting concern. Per-project errors are caught and surfaced as syncWarning metadata. |
| apps/hyperlocalise-web/src/lib/providers/external-tms-health-check.ts | Smartling health-check path added with single-read body buffering (resolves previous double-read bug), early credential validation, and correct error classification for auth vs plan-level failures. |
| apps/hyperlocalise-web/src/api/routes/external-tms-provider-credential/external-tms-provider-credential.route.ts | Route dispatch refactored from a hardcoded Crowdin check to a provider-keyed map; Smartling added cleanly. |
| apps/hyperlocalise-web/src/lib/providers/smartling/smartling-api.test.ts | Comprehensive unit tests for auth caching, token refresh timing, pagination, error classification, and classified error codes on HTTP 200 non-SUCCESS envelopes. |
| apps/hyperlocalise-web/src/lib/providers/smartling/smartling-project-fetcher.test.ts | Tests normalization, bounded-concurrency enforcement (max-in-flight assertion), and auth error propagation. |
| apps/hyperlocalise-web/src/lib/providers/smartling/smartling-credentials.test.ts | Covers JSON, compact, and colon-in-secret cases; empty input rejection. |
| apps/hyperlocalise-web/src/api/routes/external-tms-provider-credential/external-tms-provider-credential.test.ts | Route-level integration tests for Smartling health check (connected, auth invalid, API unavailable) and project sync (success, auth failure). |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Route as POST /sync-projects
    participant Fetcher as fetchSmartlingProjects
    participant Client as SmartlingApiClient
    participant SL as Smartling API

    Route->>Fetcher: "{ credential, secretMaterial }"
    Fetcher->>Fetcher: parseSmartlingCredentials()
    Fetcher->>Client: new SmartlingApiClient(credentials)
    Fetcher->>Client: listDiscoverableProjects()
    alt projectId credential
        Client->>Client: getAccessToken() → authenticate()
        Client->>SL: "GET /projects-api/v2/projects/{projectId}"
        SL-->>Client: ProjectDetails (with targetLocales)
    else accountUid credential
        Client->>Client: getAccessToken() → authenticate()
        Client->>SL: "GET /accounts-api/v2/accounts/{uid}/projects?limit=500&offset=0"
        SL-->>Client: "[ProjectSummary] (targetLocales=[])"
    end
    Client-->>Fetcher: [SmartlingProjectDetails]
    loop "mapInBatches (concurrency=15)"
        Fetcher->>Client: getProjectDetails(projectId)
        Client->>Client: getAccessToken() → cached / refresh / re-auth
        Client->>SL: "GET /projects-api/v2/projects/{projectId}"
        SL-->>Client: ProjectDetails
        Client-->>Fetcher: details
    end
    Fetcher->>Fetcher: normalizeSmartlingProject()
    Fetcher-->>Route: ExternalTmsProject[]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/hyperlocalise-web/src/lib/providers/smartling/smartling-api.ts`, line 1208-1215 ([link](https://github.com/hyperlocalise/hyperlocalise/blob/5277c1ac18c5047190934a306664ad8297c4e0c0/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-api.ts#L1208-L1215)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`SmartlingApiError.code` set to raw Smartling envelope code, not the classified error code**

   When the response is HTTP 2xx but `envelope.response.code !== "SUCCESS"` (e.g., `"MAX_OPERATIONS_LIMIT_EXCEEDED"`, `"VALIDATION_ERROR"`), the thrown `SmartlingApiError.code` is the raw Smartling code, not the internal classified code. Callers in `smartling-project-fetcher.ts` test `error.code === "smartling_api_unavailable"` which will never match for these raw Smartling codes, silently bypassing the special error handling. The error will still propagate via the final `throw error`, but without the expected classification — the sync run message will contain the raw API-internal string rather than the user-facing error.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/hyperlocalise-web/src/lib/providers/smartling/smartling-api.ts
   Line: 1208-1215

   Comment:
   **`SmartlingApiError.code` set to raw Smartling envelope code, not the classified error code**

   When the response is HTTP 2xx but `envelope.response.code !== "SUCCESS"` (e.g., `"MAX_OPERATIONS_LIMIT_EXCEEDED"`, `"VALIDATION_ERROR"`), the thrown `SmartlingApiError.code` is the raw Smartling code, not the internal classified code. Callers in `smartling-project-fetcher.ts` test `error.code === "smartling_api_unavailable"` which will never match for these raw Smartling codes, silently bypassing the special error handling. The error will still propagate via the final `throw error`, but without the expected classification — the sync run message will contain the raw API-internal string rather than the user-facing error.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hyperlocalise%2Fhyperlocalise%22%20on%20the%20existing%20branch%20%22cungminh2710%2Fhl-343-implement-smartling-credential-validation-and-project%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cungminh2710%2Fhl-343-implement-smartling-credential-validation-and-project%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fhyperlocalise-web%2Fsrc%2Flib%2Fproviders%2Fsmartling%2Fsmartling-api.ts%0ALine%3A%201208-1215%0A%0AComment%3A%0A**%60SmartlingApiError.code%60%20set%20to%20raw%20Smartling%20envelope%20code%2C%20not%20the%20classified%20error%20code**%0A%0AWhen%20the%20response%20is%20HTTP%202xx%20but%20%60envelope.response.code%20!%3D%3D%20%22SUCCESS%22%60%20%28e.g.%2C%20%60%22MAX_OPERATIONS_LIMIT_EXCEEDED%22%60%2C%20%60%22VALIDATION_ERROR%22%60%29%2C%20the%20thrown%20%60SmartlingApiError.code%60%20is%20the%20raw%20Smartling%20code%2C%20not%20the%20internal%20classified%20code.%20Callers%20in%20%60smartling-project-fetcher.ts%60%20test%20%60error.code%20%3D%3D%3D%20%22smartling_api_unavailable%22%60%20which%20will%20never%20match%20for%20these%20raw%20Smartling%20codes%2C%20silently%20bypassing%20the%20special%20error%20handling.%20The%20error%20will%20still%20propagate%20via%20the%20final%20%60throw%20error%60%2C%20but%20without%20the%20expected%20classification%20%E2%80%94%20the%20sync%20run%20message%20will%20contain%20the%20raw%20API-internal%20string%20rather%20than%20the%20user-facing%20error.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hyperlocalise%2Fhyperlocalise%22%20on%20the%20existing%20branch%20%22cungminh2710%2Fhl-343-implement-smartling-credential-validation-and-project%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cungminh2710%2Fhl-343-implement-smartling-credential-validation-and-project%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fhyperlocalise-web%2Fsrc%2Flib%2Fproviders%2Fsmartling%2Fsmartling-api.ts%3A159-165%0ANo%20fallback%20to%20fresh%20authentication%20after%20a%20refresh%20failure.%20If%20%60this.tokens.refreshToken%60%20is%20set%20but%20the%20refresh%20API%20call%20fails%20%28e.g.%2C%20the%20token%20was%20revoked%20or%20expired%20server-side%20mid-sync%29%2C%20the%20error%20propagates%20immediately%20without%20attempting%20a%20fresh%20%60authenticate%28%29%60.%20The%20client%20is%20then%20stuck%20in%20a%20broken%20state%20for%20the%20remainder%20of%20the%20sync%20run.%20Adding%20a%20fallback%20%60authenticate%28%29%60%20after%20a%20failed%20refresh%20makes%20the%20client%20self-healing.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20if%20%28this.tokens.refreshToken%29%20%7B%0A%20%20%20%20%20%20%20%20try%20%7B%0A%20%20%20%20%20%20%20%20%20%20const%20refreshed%20%3D%20await%20this.refreshAccessToken%28this.tokens.refreshToken%29%3B%0A%20%20%20%20%20%20%20%20%20%20return%20refreshed.accessToken%3B%0A%20%20%20%20%20%20%20%20%7D%20catch%20%7B%0A%20%20%20%20%20%20%20%20%20%20%2F%2F%20Refresh%20token%20may%20have%20been%20revoked%3B%20fall%20through%20to%20full%20re-authentication.%0A%20%20%20%20%20%20%20%20%20%20this.tokens%20%3D%20null%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%0A%20%20%20%20const%20authenticated%20%3D%20await%20this.authenticate%28%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fhyperlocalise-web%2Fsrc%2Flib%2Fproviders%2Fsmartling%2Fsmartling-api.ts%3A1003-1018%0A**Concurrent%20token%20refresh%20under%20batch%20concurrency**%0A%0A%60getAccessToken%28%29%60%20has%20no%20in-flight%20deduplication.%20When%20%60mapInBatches%60%20fires%20up%20to%2015%20%60getProjectDetails%60%20calls%20in%20parallel%2C%20each%20independently%20calls%20%60getAccessToken%28%29%60.%20If%20the%20token%20is%20near%20expiry%20at%20that%20moment%2C%20all%2015%20callers%20pass%20the%20expiry%20check%20before%20any%20of%20them%20has%20updated%20%60this.tokens%60%2C%20and%20all%2015%20issue%20independent%20%60refreshAccessToken%28%29%60%20calls.%20The%20last%20write%20to%20%60this.tokens%60%20wins%20%28tokens%20are%20still%20valid%29%2C%20but%20up%20to%2014%20requests%20are%20wasted.%20Consider%20memoizing%20the%20in-flight%20refresh%20promise%20with%20a%20%60this._refreshPromise%60%20field%20that%20is%20awaited%20by%20subsequent%20callers%20and%20cleared%20on%20resolution.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/hyperlocalise-web/src/lib/providers/smartling/smartling-api.ts:159-165
No fallback to fresh authentication after a refresh failure. If `this.tokens.refreshToken` is set but the refresh API call fails (e.g., the token was revoked or expired server-side mid-sync), the error propagates immediately without attempting a fresh `authenticate()`. The client is then stuck in a broken state for the remainder of the sync run. Adding a fallback `authenticate()` after a failed refresh makes the client self-healing.

```suggestion
      if (this.tokens.refreshToken) {
        try {
          const refreshed = await this.refreshAccessToken(this.tokens.refreshToken);
          return refreshed.accessToken;
        } catch {
          // Refresh token may have been revoked; fall through to full re-authentication.
          this.tokens = null;
        }
      }
    }

    const authenticated = await this.authenticate();
```

### Issue 2 of 2
apps/hyperlocalise-web/src/lib/providers/smartling/smartling-api.ts:1003-1018
**Concurrent token refresh under batch concurrency**

`getAccessToken()` has no in-flight deduplication. When `mapInBatches` fires up to 15 `getProjectDetails` calls in parallel, each independently calls `getAccessToken()`. If the token is near expiry at that moment, all 15 callers pass the expiry check before any of them has updated `this.tokens`, and all 15 issue independent `refreshAccessToken()` calls. The last write to `this.tokens` wins (tokens are still valid), but up to 14 requests are wasted. Consider memoizing the in-flight refresh promise with a `this._refreshPromise` field that is awaited by subsequent callers and cleared on resolution.


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(smartling): address health check, co..."](https://github.com/hyperlocalise/hyperlocalise/commit/6233f8daf3db983478b8fdb8925132dcbd31e894) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33444835)</sub>

<!-- /greptile_comment -->