### PR TITLE
feat(web): add Smartling file listing and job sync (HL-344, HL-345)

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -14,11 +14,20 @@ import { fetchCrowdinFileKeys } from "@/lib/providers/crowdin/crowdin-file-fetch
 import { fetchCrowdinJobTasks } from "@/lib/providers/crowdin/crowdin-job-task-fetcher";
 import { pushCrowdinTranslations } from "@/lib/providers/crowdin/crowdin-translation-pusher";
 import {
+  syncExternalTmsFileKeys,
+  type ExternalTmsFileKeyFetcher,
+} from "@/lib/providers/external-tms-file-sync";
+import {
+  syncExternalTmsJobTasks,
+  type ExternalTmsJobTaskFetcher,
+} from "@/lib/providers/external-tms-job-sync";
+import type { ExternalTmsProviderKind } from "@/lib/providers/organization-external-tms-provider-credentials";
+import { fetchSmartlingFileKeys } from "@/lib/providers/smartling/smartling-file-fetcher";
+import { fetchSmartlingJobTasks } from "@/lib/providers/smartling/smartling-job-fetcher";
+import {
   pullExternalTmsTaskContent,
   pushExternalTmsTranslations,
 } from "@/lib/providers/external-tms-content-sync";
-import { syncExternalTmsFileKeys } from "@/lib/providers/external-tms-file-sync";
-import { syncExternalTmsJobTasks } from "@/lib/providers/external-tms-job-sync";
 import { listExternalTmsFilesForProject } from "@/lib/providers/organization-external-tms-files";
 import { bufferFromStream } from "@/lib/streams";
 import { inferSupportedFileTranslationFileFormat } from "@/lib/translation/file-formats";
@@ -286,6 +295,20 @@ async function inlineTextContent(input: {
     text: new TextDecoder("utf-8", { fatal: false }).decode(buffer),
   };
 }
+
+const fileKeyFetchersByProvider: Partial<
+  Record<ExternalTmsProviderKind, ExternalTmsFileKeyFetcher>
+> = {
+  crowdin: fetchCrowdinFileKeys,
+  smartling: fetchSmartlingFileKeys,
+};
+
+const jobTaskFetchersByProvider: Partial<
+  Record<ExternalTmsProviderKind, ExternalTmsJobTaskFetcher>
+> = {
+  crowdin: fetchCrowdinJobTasks,
+  smartling: fetchSmartlingJobTasks,
+};
 
 export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
   const jobQueue = options.jobQueue ?? createTranslationJobEventQueue();
@@ -790,15 +813,20 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
         return projectNotFoundResponse(c);
       }
 
-      if (project.externalProviderKind !== "crowdin") {
+      if (!project.externalProviderKind) {
+        return c.json({ error: "provider_sync_not_implemented" }, 501);
+      }
+
+      const fetchFileKeys = fileKeyFetchersByProvider[project.externalProviderKind];
+      if (!fetchFileKeys) {
         return c.json({ error: "provider_sync_not_implemented" }, 501);
       }
 
       const result = await syncExternalTmsFileKeys({
         organizationId: c.var.auth.organization.localOrganizationId,
         projectId: project.id,
-        providerKind: "crowdin",
-        fetchFileKeys: fetchCrowdinFileKeys,
+        providerKind: project.externalProviderKind,
+        fetchFileKeys,
       });
 
       return c.json({ externalTmsFileKeySync: result }, result.status === "failed" ? 207 : 200);
@@ -815,15 +843,20 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
         return projectNotFoundResponse(c);
       }
 
-      if (project.externalProviderKind !== "crowdin") {
+      if (!project.externalProviderKind) {
+        return c.json({ error: "provider_sync_not_implemented" }, 501);
+      }
+
+      const fetchJobTasks = jobTaskFetchersByProvider[project.externalProviderKind];
+      if (!fetchJobTasks) {
         return c.json({ error: "provider_sync_not_implemented" }, 501);
       }
 
       const result = await syncExternalTmsJobTasks({
         organizationId: c.var.auth.organization.localOrganizationId,
         projectId: project.id,
-        providerKind: "crowdin",
-        fetchJobTasks: fetchCrowdinJobTasks,
+        providerKind: project.externalProviderKind,
+        fetchJobTasks,
       });
 
       return c.json({ externalTmsJobTaskSync: result }, result.status === "failed" ? 207 : 200);

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-api.test.ts
@@ -20,6 +20,9 @@ describe("SmartlingApiClient", () => {
       authBaseUrl: "https://api.smartling.test/auth-api/v2",
       accountsBaseUrl: "https://api.smartling.test/accounts-api/v2",
       projectsBaseUrl: "https://api.smartling.test/projects-api/v2",
+      filesBaseUrl: "https://api.smartling.test/files-api/v2",
+      stringsBaseUrl: "https://api.smartling.test/strings-api/v2",
+      jobsBaseUrl: "https://api.smartling.test/jobs-api/v3",
       fetchFn,
     });
   }
@@ -238,6 +241,150 @@ describe("SmartlingApiClient", () => {
       code: "smartling_request_failed",
     });
   });
+
+  it("lists project files with pagination", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      if (String(url).endsWith("/authenticate")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: { accessToken: "access-token", expiresIn: 3600 },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (String(url).includes("/files/list") && String(url).includes("offset=0")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: {
+                items: [{ fileUri: "a.json", fileType: "json" }],
+                totalCount: 2,
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (String(url).includes("/files/list")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: {
+                items: [{ fileUri: "b.json", fileType: "json" }],
+                totalCount: 2,
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response("Not Found", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    const files = await client.listProjectFiles("proj-1");
+
+    expect(files).toHaveLength(2);
+    expect(files[0]?.fileUri).toBe("a.json");
+    expect(files[1]?.fileUri).toBe("b.json");
+  });
+
+  it("lists source strings filtered by fileUri", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      if (String(url).endsWith("/authenticate")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: { accessToken: "access-token", expiresIn: 3600 },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (String(url).includes("/source-strings")) {
+        expect(String(url)).toContain("fileUri=messages.json");
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: {
+                items: [{ hashcode: "hash-1", stringText: "Hello", fileUri: "messages.json" }],
+                totalCount: 1,
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response("Not Found", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    const strings = await client.listSourceStrings("proj-1", { fileUri: "messages.json" });
+
+    expect(strings).toHaveLength(1);
+    expect(strings[0]).toMatchObject({ hashcode: "hash-1", stringText: "Hello" });
+  });
+
+  it("lists jobs for a project", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      if (String(url).endsWith("/authenticate")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: { accessToken: "access-token", expiresIn: 3600 },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (String(url).includes("/jobs-api/v3/projects/proj-1/jobs")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: {
+                items: [
+                  {
+                    translationJobUid: "job-1",
+                    jobName: "Launch",
+                    jobStatus: "AWAITING_AUTHORIZATION",
+                    targetLocaleIds: ["fr-FR"],
+                  },
+                ],
+                totalCount: 1,
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response("Not Found", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    const jobs = await client.listJobs("proj-1");
+
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0]).toMatchObject({
+      translationJobUid: "job-1",
+      jobStatus: "AWAITING_AUTHORIZATION",
+    });
+  });
 });
 
 describe("deriveServiceBaseUrl", () => {
@@ -247,6 +394,18 @@ describe("deriveServiceBaseUrl", () => {
     );
     expect(deriveServiceBaseUrl("https://api.smartling.test/auth-api/v2", "projects")).toBe(
       "https://api.smartling.test/projects-api/v2",
+    );
+  });
+
+  it("derives files, strings, and jobs base URLs from the auth base URL", () => {
+    expect(deriveServiceBaseUrl("https://api.smartling.test/auth-api/v2", "files")).toBe(
+      "https://api.smartling.test/files-api/v2",
+    );
+    expect(deriveServiceBaseUrl("https://api.smartling.test/auth-api/v2", "strings")).toBe(
+      "https://api.smartling.test/strings-api/v2",
+    );
+    expect(deriveServiceBaseUrl("https://api.smartling.test/auth-api/v2", "jobs")).toBe(
+      "https://api.smartling.test/jobs-api/v3",
     );
   });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-api.ts
@@ -10,6 +10,9 @@ import { parseSmartlingCredentials, type SmartlingCredentials } from "./smartlin
 const DEFAULT_AUTH_BASE_URL = "https://api.smartling.com/auth-api/v2";
 const DEFAULT_ACCOUNTS_BASE_URL = "https://api.smartling.com/accounts-api/v2";
 const DEFAULT_PROJECTS_BASE_URL = "https://api.smartling.com/projects-api/v2";
+const DEFAULT_FILES_BASE_URL = "https://api.smartling.com/files-api/v2";
+const DEFAULT_STRINGS_BASE_URL = "https://api.smartling.com/strings-api/v2";
+const DEFAULT_JOBS_BASE_URL = "https://api.smartling.com/jobs-api/v3";
 const TOKEN_REFRESH_SKEW_MS = 60_000;
 const DEFAULT_PAGE_SIZE = 500;
 
@@ -18,6 +21,9 @@ export interface SmartlingApiClientOptions {
   authBaseUrl?: string;
   accountsBaseUrl?: string;
   projectsBaseUrl?: string;
+  filesBaseUrl?: string;
+  stringsBaseUrl?: string;
+  jobsBaseUrl?: string;
   fetchFn?: typeof fetch;
 }
 
@@ -50,6 +56,46 @@ export interface SmartlingProjectDetails {
   archived: boolean;
   projectTypeCode: string | null;
   targetLocales: SmartlingTargetLocale[];
+}
+
+export interface SmartlingFileSummary {
+  fileUri: string;
+  fileType?: string | null;
+  lastUploaded?: string | null;
+  hasInstructions?: boolean;
+  directives?: Record<string, unknown>;
+}
+
+export interface SmartlingFileLocaleStatus {
+  localeId: string;
+  completedStringCount?: number;
+  authorizedStringCount?: number;
+  lastCompleted?: string | null;
+  lastAuthorized?: string | null;
+}
+
+export interface SmartlingSourceString {
+  hashcode: string;
+  stringText?: string | null;
+  fileUri?: string | null;
+  variant?: string | null;
+  stringVariantUid?: string | null;
+  createdDate?: string | null;
+  modifiedDate?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+export interface SmartlingJobSummary {
+  translationJobUid: string;
+  jobName: string;
+  jobStatus: string;
+  description?: string | null;
+  dueDate?: string | null;
+  targetLocaleIds: string[];
+  createdDate?: string | null;
+  modifiedDate?: string | null;
+  referenceNumber?: string | null;
+  jobNumber?: string | null;
 }
 
 type SmartlingEnvelope<T> = {
@@ -97,6 +143,9 @@ export class SmartlingApiClient {
   private readonly authBaseUrl: string;
   private readonly accountsBaseUrl: string;
   private readonly projectsBaseUrl: string;
+  private readonly filesBaseUrl: string;
+  private readonly stringsBaseUrl: string;
+  private readonly jobsBaseUrl: string;
   private readonly fetchFn: typeof fetch;
   private tokens: SmartlingAuthTokens | null = null;
 
@@ -113,6 +162,18 @@ export class SmartlingApiClient {
     this.projectsBaseUrl = normalizeServiceBaseUrl(
       options.projectsBaseUrl ?? deriveServiceBaseUrl(this.authBaseUrl, "projects"),
       DEFAULT_PROJECTS_BASE_URL,
+    );
+    this.filesBaseUrl = normalizeServiceBaseUrl(
+      options.filesBaseUrl ?? deriveServiceBaseUrl(this.authBaseUrl, "files"),
+      DEFAULT_FILES_BASE_URL,
+    );
+    this.stringsBaseUrl = normalizeServiceBaseUrl(
+      options.stringsBaseUrl ?? deriveServiceBaseUrl(this.authBaseUrl, "strings"),
+      DEFAULT_STRINGS_BASE_URL,
+    );
+    this.jobsBaseUrl = normalizeServiceBaseUrl(
+      options.jobsBaseUrl ?? deriveServiceBaseUrl(this.authBaseUrl, "jobs"),
+      DEFAULT_JOBS_BASE_URL,
     );
     this.fetchFn = options.fetchFn ?? fetch;
   }
@@ -255,6 +316,107 @@ export class SmartlingApiClient {
       }));
   }
 
+  async listProjectFiles(projectId: string): Promise<SmartlingFileSummary[]> {
+    const token = await this.getAccessToken();
+    const files: SmartlingFileSummary[] = [];
+
+    await paginateSmartlingList({
+      fetchPage: async (offset, limit) => {
+        const params = new URLSearchParams({
+          limit: String(limit),
+          offset: String(offset),
+        });
+        const data = await this.get<{ items?: SmartlingFileSummary[]; totalCount?: number }>(
+          `${this.filesBaseUrl}/projects/${encodeURIComponent(projectId)}/files/list?${params.toString()}`,
+          token,
+        );
+        return {
+          items: (data.items ?? []).map(normalizeSmartlingFileSummary),
+          totalCount: data.totalCount,
+        };
+      },
+      onPage: (page) => files.push(...page),
+    });
+
+    return files;
+  }
+
+  async getFileStatusForAllLocales(
+    projectId: string,
+    fileUri: string,
+  ): Promise<SmartlingFileLocaleStatus[]> {
+    const token = await this.getAccessToken();
+    const params = new URLSearchParams({ fileUri });
+    const data = await this.get<{ items?: SmartlingFileLocaleStatus[] }>(
+      `${this.filesBaseUrl}/projects/${encodeURIComponent(projectId)}/file/status?${params.toString()}`,
+      token,
+    );
+
+    return (data.items ?? []).map((item) => ({
+      localeId: item.localeId,
+      completedStringCount: item.completedStringCount,
+      authorizedStringCount: item.authorizedStringCount,
+      lastCompleted: item.lastCompleted ?? null,
+      lastAuthorized: item.lastAuthorized ?? null,
+    }));
+  }
+
+  async listSourceStrings(
+    projectId: string,
+    options?: { fileUri?: string },
+  ): Promise<SmartlingSourceString[]> {
+    const token = await this.getAccessToken();
+    const strings: SmartlingSourceString[] = [];
+
+    await paginateSmartlingList({
+      fetchPage: async (offset, limit) => {
+        const params = new URLSearchParams({
+          limit: String(limit),
+          offset: String(offset),
+        });
+        if (options?.fileUri) {
+          params.set("fileUri", options.fileUri);
+        }
+        const data = await this.get<{ items?: SmartlingSourceString[]; totalCount?: number }>(
+          `${this.stringsBaseUrl}/projects/${encodeURIComponent(projectId)}/source-strings?${params.toString()}`,
+          token,
+        );
+        return {
+          items: (data.items ?? []).map(normalizeSmartlingSourceString),
+          totalCount: data.totalCount,
+        };
+      },
+      onPage: (page) => strings.push(...page),
+    });
+
+    return strings;
+  }
+
+  async listJobs(projectId: string): Promise<SmartlingJobSummary[]> {
+    const token = await this.getAccessToken();
+    const jobs: SmartlingJobSummary[] = [];
+
+    await paginateSmartlingList({
+      fetchPage: async (offset, limit) => {
+        const params = new URLSearchParams({
+          limit: String(limit),
+          offset: String(offset),
+        });
+        const data = await this.get<{ items?: SmartlingJobSummary[]; totalCount?: number }>(
+          `${this.jobsBaseUrl}/projects/${encodeURIComponent(projectId)}/jobs?${params.toString()}`,
+          token,
+        );
+        return {
+          items: (data.items ?? []).map(normalizeSmartlingJobSummary),
+          totalCount: data.totalCount,
+        };
+      },
+      onPage: (page) => jobs.push(...page),
+    });
+
+    return jobs;
+  }
+
   private async get<T>(url: string, token: string): Promise<T> {
     const response = await this.fetchFn(url, {
       method: "GET",
@@ -281,13 +443,28 @@ export class SmartlingApiClient {
   }
 }
 
-export function deriveServiceBaseUrl(authBaseUrl: string, service: "accounts" | "projects") {
+export function deriveServiceBaseUrl(
+  authBaseUrl: string,
+  service: "accounts" | "projects" | "files" | "strings" | "jobs",
+) {
   const normalized = normalizeServiceBaseUrl(authBaseUrl, authBaseUrl);
   if (normalized.includes("/auth-api/")) {
-    return normalized.replace("/auth-api/", `/${service}-api/`);
+    const version = service === "jobs" ? "v3" : "v2";
+    return normalized.replace(/\/auth-api\/v\d+/, `/${service}-api/${version}`);
   }
 
-  return service === "accounts" ? DEFAULT_ACCOUNTS_BASE_URL : DEFAULT_PROJECTS_BASE_URL;
+  switch (service) {
+    case "accounts":
+      return DEFAULT_ACCOUNTS_BASE_URL;
+    case "projects":
+      return DEFAULT_PROJECTS_BASE_URL;
+    case "files":
+      return DEFAULT_FILES_BASE_URL;
+    case "strings":
+      return DEFAULT_STRINGS_BASE_URL;
+    case "jobs":
+      return DEFAULT_JOBS_BASE_URL;
+  }
 }
 
 export function normalizeServiceBaseUrl(baseUrl: string | undefined, fallback: string) {
@@ -412,4 +589,67 @@ function collectSmartlingErrorMessage(responseBody: unknown) {
     .map((error) => (typeof error?.message === "string" ? error.message : ""))
     .filter(Boolean)
     .join(" ");
+}
+
+async function paginateSmartlingList<T>(input: {
+  fetchPage: (offset: number, limit: number) => Promise<{ items: T[]; totalCount?: number }>;
+  onPage: (items: T[]) => void;
+}) {
+  let offset = 0;
+
+  while (true) {
+    const page = await input.fetchPage(offset, DEFAULT_PAGE_SIZE);
+    input.onPage(page.items);
+    offset += page.items.length;
+
+    if (page.items.length === 0) {
+      break;
+    }
+
+    if (typeof page.totalCount === "number") {
+      if (offset >= page.totalCount) {
+        break;
+      }
+    } else if (page.items.length < DEFAULT_PAGE_SIZE) {
+      break;
+    }
+  }
+}
+
+function normalizeSmartlingFileSummary(item: SmartlingFileSummary): SmartlingFileSummary {
+  return {
+    fileUri: item.fileUri,
+    fileType: item.fileType ?? null,
+    lastUploaded: item.lastUploaded ?? null,
+    hasInstructions: item.hasInstructions ?? false,
+    directives: item.directives ?? undefined,
+  };
+}
+
+function normalizeSmartlingSourceString(item: SmartlingSourceString): SmartlingSourceString {
+  return {
+    hashcode: item.hashcode,
+    stringText: item.stringText ?? null,
+    fileUri: item.fileUri ?? null,
+    variant: item.variant ?? null,
+    stringVariantUid: item.stringVariantUid ?? null,
+    createdDate: item.createdDate ?? null,
+    modifiedDate: item.modifiedDate ?? null,
+    metadata: item.metadata ?? undefined,
+  };
+}
+
+function normalizeSmartlingJobSummary(item: SmartlingJobSummary): SmartlingJobSummary {
+  return {
+    translationJobUid: item.translationJobUid,
+    jobName: item.jobName,
+    jobStatus: item.jobStatus,
+    description: item.description ?? null,
+    dueDate: item.dueDate ?? null,
+    targetLocaleIds: item.targetLocaleIds ?? [],
+    createdDate: item.createdDate ?? null,
+    modifiedDate: item.modifiedDate ?? null,
+    referenceNumber: item.referenceNumber ?? null,
+    jobNumber: item.jobNumber ?? null,
+  };
 }

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-api.ts
@@ -317,11 +317,11 @@ export class SmartlingApiClient {
   }
 
   async listProjectFiles(projectId: string): Promise<SmartlingFileSummary[]> {
-    const token = await this.getAccessToken();
     const files: SmartlingFileSummary[] = [];
 
     await paginateSmartlingList({
       fetchPage: async (offset, limit) => {
+        const token = await this.getAccessToken();
         const params = new URLSearchParams({
           limit: String(limit),
           offset: String(offset),
@@ -365,11 +365,11 @@ export class SmartlingApiClient {
     projectId: string,
     options?: { fileUri?: string },
   ): Promise<SmartlingSourceString[]> {
-    const token = await this.getAccessToken();
     const strings: SmartlingSourceString[] = [];
 
     await paginateSmartlingList({
       fetchPage: async (offset, limit) => {
+        const token = await this.getAccessToken();
         const params = new URLSearchParams({
           limit: String(limit),
           offset: String(offset),
@@ -393,11 +393,11 @@ export class SmartlingApiClient {
   }
 
   async listJobs(projectId: string): Promise<SmartlingJobSummary[]> {
-    const token = await this.getAccessToken();
     const jobs: SmartlingJobSummary[] = [];
 
     await paginateSmartlingList({
       fetchPage: async (offset, limit) => {
+        const token = await this.getAccessToken();
         const params = new URLSearchParams({
           limit: String(limit),
           offset: String(offset),

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-errors.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-errors.ts
@@ -1,0 +1,13 @@
+import { SmartlingApiError } from "./smartling-api";
+
+export function mapSmartlingFetcherError(error: unknown): Error {
+  if (error instanceof SmartlingApiError) {
+    if (error.code === "smartling_auth_invalid" || error.status === 401) {
+      return new Error("smartling_auth_invalid");
+    }
+    if (error.code === "smartling_api_unavailable") {
+      return new Error("smartling_api_unavailable");
+    }
+  }
+  return error instanceof Error ? error : new Error("smartling_request_failed");
+}

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-file-fetcher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-file-fetcher.test.ts
@@ -1,0 +1,323 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { fetchSmartlingFileKeys } from "./smartling-file-fetcher";
+
+describe("fetchSmartlingFileKeys", () => {
+  let originalFetch: typeof fetch;
+
+  const credential = {
+    id: "cred-1",
+    organizationId: "org-1",
+    providerKind: "smartling" as const,
+    displayName: "Smartling",
+    region: null,
+    baseUrl: null,
+    validationStatus: "connected",
+    validationMessage: null,
+    lastValidatedAt: null,
+    encryptionAlgorithm: "aes-256-gcm",
+    keyVersion: 1,
+    ciphertext: "cipher",
+    iv: "iv",
+    authTag: "tag",
+    maskedSecretSuffix: "cret",
+    createdByUserId: "user-1",
+    updatedByUserId: "user-1",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("returns normalized file and key metadata from Smartling", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      const path = String(url);
+
+      if (path.endsWith("/authenticate")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: { accessToken: "access-token", expiresIn: 3600 },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/source-strings")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: {
+                items: [
+                  {
+                    hashcode: "abc123",
+                    stringText: "Hello",
+                    fileUri: "locales/en.json",
+                  },
+                ],
+                totalCount: 1,
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/projects-api/v2/projects/proj-1")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: {
+                accountUid: "acct-1",
+                projectId: "proj-1",
+                projectName: "Marketing",
+                sourceLocaleId: "en-US",
+                archived: false,
+                targetLocales: [{ localeId: "de-DE", enabled: true }],
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/files/list")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: {
+                items: [
+                  {
+                    fileUri: "locales/en.json",
+                    fileType: "json",
+                    lastUploaded: "2026-05-01T00:00:00Z",
+                    hasInstructions: true,
+                    directives: { placeholder_format: "icu" },
+                  },
+                ],
+                totalCount: 1,
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/file/status")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: {
+                items: [
+                  {
+                    localeId: "de-DE",
+                    completedStringCount: 10,
+                    authorizedStringCount: 8,
+                  },
+                ],
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response("Not Found", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    globalThis.fetch = fetchMock;
+
+    const result = await fetchSmartlingFileKeys({
+      organizationId: "org-1",
+      projectId: "project-1",
+      providerKind: "smartling",
+      externalProjectId: "proj-1",
+      credential,
+      project: {} as never,
+      secretMaterial: "user:secret:acct-1",
+    });
+
+    expect(result).toHaveLength(2);
+
+    const file = result.find((item) => item.resourceType === "file");
+    expect(file).toMatchObject({
+      externalResourceId: "locales/en.json",
+      sourcePath: "locales/en.json",
+      format: "json",
+      sourceLocale: "en-US",
+      targetLocales: ["de-DE"],
+      revision: "2026-05-01T00:00:00Z",
+    });
+    expect(file?.localeReadiness).toMatchObject({
+      "de-DE": {
+        completedStringCount: 10,
+        authorizedStringCount: 8,
+      },
+    });
+    expect(file?.providerPayload).toMatchObject({
+      fileUri: "locales/en.json",
+      directives: { placeholder_format: "icu" },
+    });
+
+    const key = result.find((item) => item.resourceType === "key");
+    expect(key).toMatchObject({
+      externalResourceId: "abc123",
+      sourcePath: "locales/en.json/keys/abc123",
+      displayName: "Hello",
+    });
+  });
+
+  it("uses fileUri as stable file identity across repeated syncs", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      const path = String(url);
+
+      if (path.endsWith("/authenticate")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: { accessToken: "access-token", expiresIn: 3600 },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/projects-api/v2/projects/proj-1")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: {
+                accountUid: "acct-1",
+                projectId: "proj-1",
+                projectName: "Marketing",
+                sourceLocaleId: "en-US",
+                archived: false,
+                targetLocales: [],
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/files/list")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: {
+                items: [{ fileUri: "app/messages.json", fileType: "json" }],
+                totalCount: 1,
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/file/status")) {
+        return new Response(
+          JSON.stringify({
+            response: { code: "SUCCESS", data: { items: [] } },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/source-strings")) {
+        return new Response(
+          JSON.stringify({
+            response: { code: "SUCCESS", data: { items: [], totalCount: 0 } },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response("Not Found", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    globalThis.fetch = fetchMock;
+
+    const input = {
+      organizationId: "org-1",
+      projectId: "project-1",
+      providerKind: "smartling" as const,
+      externalProjectId: "proj-1",
+      credential,
+      project: {} as never,
+      secretMaterial: "user:secret:acct-1",
+    };
+
+    const first = await fetchSmartlingFileKeys(input);
+    const second = await fetchSmartlingFileKeys(input);
+
+    expect(first[0]?.externalResourceId).toBe("app/messages.json");
+    expect(second[0]?.externalResourceId).toBe("app/messages.json");
+    expect(first[0]?.externalResourceId).toBe(second[0]?.externalResourceId);
+  });
+
+  it("throws on invalid project id", async () => {
+    await expect(
+      fetchSmartlingFileKeys({
+        organizationId: "org-1",
+        projectId: "project-1",
+        providerKind: "smartling",
+        externalProjectId: "  ",
+        credential,
+        project: {} as never,
+        secretMaterial: "user:secret:acct-1",
+      }),
+    ).rejects.toThrow("invalid_smartling_project_id");
+  });
+
+  it("throws smartling_auth_invalid on 401", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      if (String(url).endsWith("/authenticate")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: { accessToken: "access-token", expiresIn: 3600 },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(
+        JSON.stringify({
+          response: { code: "AUTHENTICATION_ERROR", errors: [{ message: "Unauthorized" }] },
+        }),
+        { status: 401 },
+      );
+    }) as unknown as typeof fetch;
+
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      fetchSmartlingFileKeys({
+        organizationId: "org-1",
+        projectId: "project-1",
+        providerKind: "smartling",
+        externalProjectId: "proj-1",
+        credential,
+        project: {} as never,
+        secretMaterial: "user:secret:acct-1",
+      }),
+    ).rejects.toThrow("smartling_auth_invalid");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-file-fetcher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-file-fetcher.test.ts
@@ -173,7 +173,7 @@ describe("fetchSmartlingFileKeys", () => {
 
     const key = result.find((item) => item.resourceType === "key");
     expect(key).toMatchObject({
-      externalResourceId: "abc123",
+      externalResourceId: "locales/en.json::abc123",
       sourcePath: "locales/en.json/keys/abc123",
       displayName: "Hello",
     });
@@ -268,6 +268,106 @@ describe("fetchSmartlingFileKeys", () => {
     expect(first[0]?.externalResourceId).toBe("app/messages.json");
     expect(second[0]?.externalResourceId).toBe("app/messages.json");
     expect(first[0]?.externalResourceId).toBe(second[0]?.externalResourceId);
+  });
+
+  it("uses file-scoped externalResourceId for keys to avoid hash collisions across files", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      const path = String(url);
+
+      if (path.endsWith("/authenticate")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: { accessToken: "access-token", expiresIn: 3600 },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/projects-api/v2/projects/proj-1")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: {
+                accountUid: "acct-1",
+                projectId: "proj-1",
+                projectName: "Marketing",
+                sourceLocaleId: "en-US",
+                archived: false,
+                targetLocales: [],
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/files/list")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: {
+                items: [
+                  { fileUri: "locales/en.json", fileType: "json" },
+                  { fileUri: "locales/de.json", fileType: "json" },
+                ],
+                totalCount: 2,
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/file/status")) {
+        return new Response(
+          JSON.stringify({
+            response: { code: "SUCCESS", data: { items: [] } },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/source-strings")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: {
+                items: [{ hashcode: "shared-hash", stringText: "OK" }],
+                totalCount: 1,
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response("Not Found", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    globalThis.fetch = fetchMock;
+
+    const result = await fetchSmartlingFileKeys({
+      organizationId: "org-1",
+      projectId: "project-1",
+      providerKind: "smartling",
+      externalProjectId: "proj-1",
+      credential,
+      project: {} as never,
+      secretMaterial: "user:secret:acct-1",
+    });
+
+    const keys = result.filter((item) => item.resourceType === "key");
+    expect(keys).toHaveLength(2);
+    expect(keys.map((key) => key.externalResourceId).toSorted()).toEqual([
+      "locales/de.json::shared-hash",
+      "locales/en.json::shared-hash",
+    ]);
   });
 
   it("throws on invalid project id", async () => {

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-file-fetcher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-file-fetcher.ts
@@ -1,0 +1,156 @@
+import type { ExternalTmsFileKeyFetcher } from "@/lib/providers/external-tms-file-sync";
+
+import { parseSmartlingCredentials } from "./smartling-credentials";
+import { SmartlingApiClient, SmartlingApiError } from "./smartling-api";
+
+export const fetchSmartlingFileKeys: ExternalTmsFileKeyFetcher = async ({
+  credential,
+  externalProjectId,
+  secretMaterial,
+}) => {
+  const credentials = parseSmartlingCredentials(secretMaterial);
+  const client = new SmartlingApiClient({
+    credentials,
+    authBaseUrl: credential.baseUrl ?? undefined,
+  });
+
+  if (!externalProjectId.trim()) {
+    throw new Error("invalid_smartling_project_id");
+  }
+
+  let projectDetails;
+  try {
+    projectDetails = await client.getProjectDetails(externalProjectId);
+  } catch (error) {
+    throw mapSmartlingFetcherError(error);
+  }
+
+  const targetLocales = projectDetails.targetLocales
+    .filter((locale) => locale.enabled !== false)
+    .map((locale) => locale.localeId);
+  const accountUid = projectDetails.accountUid;
+
+  let files;
+  try {
+    files = await client.listProjectFiles(externalProjectId);
+  } catch (error) {
+    throw mapSmartlingFetcherError(error);
+  }
+
+  const results: Awaited<ReturnType<ExternalTmsFileKeyFetcher>> = [];
+
+  for (const file of files) {
+    let localeReadiness: Record<string, unknown> = {};
+    try {
+      const statuses = await client.getFileStatusForAllLocales(externalProjectId, file.fileUri);
+      localeReadiness = Object.fromEntries(
+        statuses.map((status) => [
+          status.localeId,
+          {
+            completedStringCount: status.completedStringCount,
+            authorizedStringCount: status.authorizedStringCount,
+            lastCompleted: status.lastCompleted,
+            lastAuthorized: status.lastAuthorized,
+          },
+        ]),
+      );
+    } catch {
+      // Locale status is best-effort; do not fail file sync if it is unavailable
+    }
+
+    results.push({
+      externalResourceId: file.fileUri,
+      resourceType: "file",
+      sourcePath: file.fileUri,
+      displayName: displayNameOf(file.fileUri),
+      format: file.fileType ?? null,
+      sourceLocale: projectDetails.sourceLocaleId,
+      targetLocales,
+      revision: file.lastUploaded ?? null,
+      externalUrl: buildSmartlingFileUrl(accountUid, externalProjectId, file.fileUri),
+      syncState: "synced",
+      localeReadiness,
+      providerPayload: {
+        fileUri: file.fileUri,
+        fileType: file.fileType,
+        lastUploaded: file.lastUploaded,
+        hasInstructions: file.hasInstructions,
+        directives: file.directives ?? null,
+      },
+    });
+  }
+
+  for (const file of files) {
+    try {
+      const strings = await client.listSourceStrings(externalProjectId, {
+        fileUri: file.fileUri,
+      });
+
+      for (const str of strings) {
+        const keyPath = `${file.fileUri}/keys/${str.hashcode}`;
+        results.push({
+          externalResourceId: str.hashcode,
+          resourceType: "key",
+          sourcePath: keyPath,
+          displayName: str.stringText ?? str.hashcode,
+          sourceLocale: projectDetails.sourceLocaleId,
+          targetLocales,
+          externalUrl: buildSmartlingFileUrl(accountUid, externalProjectId, file.fileUri),
+          providerPayload: {
+            hashcode: str.hashcode,
+            stringText: str.stringText,
+            fileUri: str.fileUri ?? file.fileUri,
+            variant: str.variant,
+            stringVariantUid: str.stringVariantUid,
+            createdDate: str.createdDate,
+            modifiedDate: str.modifiedDate,
+            metadata: str.metadata ?? null,
+          },
+        });
+      }
+    } catch (error) {
+      if (error instanceof SmartlingApiError && error.status === 401) {
+        throw new Error("smartling_auth_invalid");
+      }
+
+      results.push({
+        externalResourceId: file.fileUri,
+        resourceType: "key",
+        sourcePath: `${file.fileUri}/keys`,
+        displayName: `${displayNameOf(file.fileUri)} keys`,
+        syncErrorMessage: `Failed to list source strings for ${file.fileUri}: ${errorMessageOf(error)}`,
+        providerPayload: {
+          fileUri: file.fileUri,
+          fileType: file.fileType,
+        },
+      });
+    }
+  }
+
+  return results;
+};
+
+function displayNameOf(fileUri: string) {
+  return fileUri.split("/").filter(Boolean).at(-1) ?? fileUri;
+}
+
+function buildSmartlingFileUrl(accountUid: string, projectId: string, fileUri: string) {
+  const params = new URLSearchParams({ fileUri });
+  return `https://dashboard.smartling.com/app/accounts/${encodeURIComponent(accountUid)}/project/${encodeURIComponent(projectId)}/files?${params.toString()}`;
+}
+
+function errorMessageOf(error: unknown): string {
+  return error instanceof Error ? error.message : "unknown error";
+}
+
+function mapSmartlingFetcherError(error: unknown): Error {
+  if (error instanceof SmartlingApiError) {
+    if (error.code === "smartling_auth_invalid" || error.status === 401) {
+      return new Error("smartling_auth_invalid");
+    }
+    if (error.code === "smartling_api_unavailable") {
+      return new Error("smartling_api_unavailable");
+    }
+  }
+  return error instanceof Error ? error : new Error("smartling_request_failed");
+}

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-file-fetcher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-file-fetcher.ts
@@ -90,7 +90,7 @@ export const fetchSmartlingFileKeys: ExternalTmsFileKeyFetcher = async ({
       for (const str of strings) {
         const keyPath = `${file.fileUri}/keys/${str.hashcode}`;
         results.push({
-          externalResourceId: str.hashcode,
+          externalResourceId: `${file.fileUri}::${str.hashcode}`,
           resourceType: "key",
           sourcePath: keyPath,
           displayName: str.stringText ?? str.hashcode,

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-file-fetcher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-file-fetcher.ts
@@ -1,7 +1,8 @@
 import type { ExternalTmsFileKeyFetcher } from "@/lib/providers/external-tms-file-sync";
 
 import { parseSmartlingCredentials } from "./smartling-credentials";
-import { SmartlingApiClient, SmartlingApiError } from "./smartling-api";
+import { SmartlingApiClient } from "./smartling-api";
+import { mapSmartlingFetcherError } from "./smartling-errors";
 
 export const fetchSmartlingFileKeys: ExternalTmsFileKeyFetcher = async ({
   credential,
@@ -109,8 +110,9 @@ export const fetchSmartlingFileKeys: ExternalTmsFileKeyFetcher = async ({
         });
       }
     } catch (error) {
-      if (error instanceof SmartlingApiError && error.status === 401) {
-        throw new Error("smartling_auth_invalid");
+      const mapped = mapSmartlingFetcherError(error);
+      if (mapped.message === "smartling_auth_invalid") {
+        throw mapped;
       }
 
       results.push({
@@ -118,7 +120,7 @@ export const fetchSmartlingFileKeys: ExternalTmsFileKeyFetcher = async ({
         resourceType: "key",
         sourcePath: `${file.fileUri}/keys`,
         displayName: `${displayNameOf(file.fileUri)} keys`,
-        syncErrorMessage: `Failed to list source strings for ${file.fileUri}: ${errorMessageOf(error)}`,
+        syncErrorMessage: `Failed to list source strings for ${file.fileUri}: ${mapped.message}`,
         providerPayload: {
           fileUri: file.fileUri,
           fileType: file.fileType,
@@ -137,20 +139,4 @@ function displayNameOf(fileUri: string) {
 function buildSmartlingFileUrl(accountUid: string, projectId: string, fileUri: string) {
   const params = new URLSearchParams({ fileUri });
   return `https://dashboard.smartling.com/app/accounts/${encodeURIComponent(accountUid)}/project/${encodeURIComponent(projectId)}/files?${params.toString()}`;
-}
-
-function errorMessageOf(error: unknown): string {
-  return error instanceof Error ? error.message : "unknown error";
-}
-
-function mapSmartlingFetcherError(error: unknown): Error {
-  if (error instanceof SmartlingApiError) {
-    if (error.code === "smartling_auth_invalid" || error.status === 401) {
-      return new Error("smartling_auth_invalid");
-    }
-    if (error.code === "smartling_api_unavailable") {
-      return new Error("smartling_api_unavailable");
-    }
-  }
-  return error instanceof Error ? error : new Error("smartling_request_failed");
 }

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-job-fetcher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-job-fetcher.test.ts
@@ -1,0 +1,288 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { fetchSmartlingJobTasks } from "./smartling-job-fetcher";
+
+describe("fetchSmartlingJobTasks", () => {
+  let originalFetch: typeof fetch;
+
+  const credential = {
+    id: "cred-1",
+    organizationId: "org-1",
+    providerKind: "smartling" as const,
+    displayName: "Smartling",
+    region: null,
+    baseUrl: null,
+    validationStatus: "connected",
+    validationMessage: null,
+    lastValidatedAt: null,
+    encryptionAlgorithm: "aes-256-gcm",
+    keyVersion: 1,
+    ciphertext: "cipher",
+    iv: "iv",
+    authTag: "tag",
+    maskedSecretSuffix: "cret",
+    createdByUserId: "user-1",
+    updatedByUserId: "user-1",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("returns normalized job metadata from Smartling", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      const path = String(url);
+
+      if (path.endsWith("/authenticate")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: { accessToken: "access-token", expiresIn: 3600 },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/projects-api/v2/projects/proj-1")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: {
+                accountUid: "acct-1",
+                projectId: "proj-1",
+                projectName: "Marketing",
+                sourceLocaleId: "en-US",
+                archived: false,
+                targetLocales: [],
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/jobs-api/v3/projects/proj-1/jobs")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: {
+                items: [
+                  {
+                    translationJobUid: "job-1",
+                    jobName: "French launch",
+                    jobStatus: "IN_PROGRESS",
+                    dueDate: "2026-06-01T00:00:00Z",
+                    targetLocaleIds: ["fr-FR"],
+                    description: "Homepage strings",
+                  },
+                  {
+                    translationJobUid: "job-2",
+                    jobName: "Review pass",
+                    jobStatus: "In Review",
+                    targetLocaleIds: ["de-DE"],
+                  },
+                  {
+                    translationJobUid: "job-3",
+                    jobName: "Completed batch",
+                    jobStatus: "COMPLETED",
+                    targetLocaleIds: ["es-ES"],
+                  },
+                  {
+                    translationJobUid: "job-4",
+                    jobName: "Failed import",
+                    jobStatus: "FAILED",
+                    targetLocaleIds: ["it-IT"],
+                  },
+                ],
+                totalCount: 4,
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response("Not Found", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    globalThis.fetch = fetchMock;
+
+    const result = await fetchSmartlingJobTasks({
+      organizationId: "org-1",
+      projectId: "project-1",
+      providerKind: "smartling",
+      externalProjectId: "proj-1",
+      credential,
+      project: {} as never,
+      secretMaterial: "user:secret:acct-1",
+    });
+
+    expect(result).toHaveLength(4);
+
+    expect(result[0]).toMatchObject({
+      externalJobId: "job-1",
+      externalStatus: "IN_PROGRESS",
+      title: "French launch",
+      targetLocales: ["fr-FR"],
+      kind: "translation",
+    });
+    expect(result[0]?.externalUrl).toContain("/jobs/job-1");
+
+    expect(result[1]).toMatchObject({
+      externalJobId: "job-2",
+      externalStatus: "In Review",
+      kind: "review",
+    });
+
+    expect(result[2]).toMatchObject({
+      externalJobId: "job-3",
+      externalStatus: "COMPLETED",
+    });
+
+    expect(result[3]).toMatchObject({
+      externalJobId: "job-4",
+      externalStatus: "FAILED",
+    });
+  });
+
+  it("preserves stable job ids across repeated syncs", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      const path = String(url);
+
+      if (path.endsWith("/authenticate")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: { accessToken: "access-token", expiresIn: 3600 },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/projects-api/v2/projects/proj-1")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: {
+                accountUid: "acct-1",
+                projectId: "proj-1",
+                projectName: "Marketing",
+                sourceLocaleId: "en-US",
+                archived: false,
+                targetLocales: [],
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/jobs")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: {
+                items: [
+                  {
+                    translationJobUid: "job-stable-1",
+                    jobName: "Batch 1",
+                    jobStatus: "AWAITING_AUTHORIZATION",
+                    targetLocaleIds: ["fr-FR"],
+                  },
+                ],
+                totalCount: 1,
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response("Not Found", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    globalThis.fetch = fetchMock;
+
+    const input = {
+      organizationId: "org-1",
+      projectId: "project-1",
+      providerKind: "smartling" as const,
+      externalProjectId: "proj-1",
+      credential,
+      project: {} as never,
+      secretMaterial: "user:secret:acct-1",
+    };
+
+    const first = await fetchSmartlingJobTasks(input);
+    const second = await fetchSmartlingJobTasks(input);
+
+    expect(first[0]?.externalJobId).toBe("job-stable-1");
+    expect(second[0]?.externalJobId).toBe("job-stable-1");
+    expect(first[0]?.externalStatus).toBe(second[0]?.externalStatus);
+  });
+
+  it("throws on invalid project id", async () => {
+    await expect(
+      fetchSmartlingJobTasks({
+        organizationId: "org-1",
+        projectId: "project-1",
+        providerKind: "smartling",
+        externalProjectId: "",
+        credential,
+        project: {} as never,
+        secretMaterial: "user:secret:acct-1",
+      }),
+    ).rejects.toThrow("invalid_smartling_project_id");
+  });
+
+  it("throws smartling_auth_invalid on 401", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      if (String(url).endsWith("/authenticate")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: { accessToken: "access-token", expiresIn: 3600 },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(
+        JSON.stringify({
+          response: { code: "AUTHENTICATION_ERROR", errors: [{ message: "Unauthorized" }] },
+        }),
+        { status: 401 },
+      );
+    }) as unknown as typeof fetch;
+
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      fetchSmartlingJobTasks({
+        organizationId: "org-1",
+        projectId: "project-1",
+        providerKind: "smartling",
+        externalProjectId: "proj-1",
+        credential,
+        project: {} as never,
+        secretMaterial: "user:secret:acct-1",
+      }),
+    ).rejects.toThrow("smartling_auth_invalid");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-job-fetcher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-job-fetcher.ts
@@ -1,7 +1,8 @@
 import type { ExternalTmsJobTaskFetcher } from "@/lib/providers/external-tms-job-sync";
 
 import { parseSmartlingCredentials } from "./smartling-credentials";
-import { SmartlingApiClient, SmartlingApiError } from "./smartling-api";
+import { SmartlingApiClient } from "./smartling-api";
+import { mapSmartlingFetcherError } from "./smartling-errors";
 
 export const fetchSmartlingJobTasks: ExternalTmsJobTaskFetcher = async ({
   credential,
@@ -64,16 +65,4 @@ function mapSmartlingJobKind(jobStatus: string): "translation" | "review" {
     return "review";
   }
   return "translation";
-}
-
-function mapSmartlingFetcherError(error: unknown): Error {
-  if (error instanceof SmartlingApiError) {
-    if (error.code === "smartling_auth_invalid" || error.status === 401) {
-      return new Error("smartling_auth_invalid");
-    }
-    if (error.code === "smartling_api_unavailable") {
-      return new Error("smartling_api_unavailable");
-    }
-  }
-  return error instanceof Error ? error : new Error("smartling_request_failed");
 }

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-job-fetcher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-job-fetcher.ts
@@ -1,0 +1,79 @@
+import type { ExternalTmsJobTaskFetcher } from "@/lib/providers/external-tms-job-sync";
+
+import { parseSmartlingCredentials } from "./smartling-credentials";
+import { SmartlingApiClient, SmartlingApiError } from "./smartling-api";
+
+export const fetchSmartlingJobTasks: ExternalTmsJobTaskFetcher = async ({
+  credential,
+  externalProjectId,
+  secretMaterial,
+}) => {
+  const credentials = parseSmartlingCredentials(secretMaterial);
+  const client = new SmartlingApiClient({
+    credentials,
+    authBaseUrl: credential.baseUrl ?? undefined,
+  });
+
+  if (!externalProjectId.trim()) {
+    throw new Error("invalid_smartling_project_id");
+  }
+
+  let projectDetails;
+  let jobs;
+  try {
+    [projectDetails, jobs] = await Promise.all([
+      client.getProjectDetails(externalProjectId),
+      client.listJobs(externalProjectId),
+    ]);
+  } catch (error) {
+    throw mapSmartlingFetcherError(error);
+  }
+
+  const accountUid = projectDetails.accountUid;
+
+  return jobs.map((job) => ({
+    externalJobId: job.translationJobUid,
+    externalTaskId: null,
+    externalStatus: job.jobStatus,
+    title: job.jobName,
+    dueDate: job.dueDate ? new Date(job.dueDate) : null,
+    targetLocales: job.targetLocaleIds,
+    assignedUsers: [],
+    externalUrl: buildSmartlingJobUrl(accountUid, externalProjectId, job.translationJobUid),
+    providerPayload: {
+      description: job.description,
+      createdDate: job.createdDate,
+      modifiedDate: job.modifiedDate,
+      referenceNumber: job.referenceNumber,
+      jobNumber: job.jobNumber,
+      rawJobStatus: job.jobStatus,
+    },
+    kind: mapSmartlingJobKind(job.jobStatus),
+  }));
+};
+
+function buildSmartlingJobUrl(accountUid: string, projectId: string, translationJobUid: string) {
+  return `https://dashboard.smartling.com/app/accounts/${encodeURIComponent(accountUid)}/project/${encodeURIComponent(projectId)}/jobs/${encodeURIComponent(translationJobUid)}`;
+}
+
+function mapSmartlingJobKind(jobStatus: string): "translation" | "review" {
+  const normalized = jobStatus.toLowerCase().trim();
+  if (
+    ["in_review", "in-review", "in review", "in_edit", "in-edit", "in edit"].includes(normalized)
+  ) {
+    return "review";
+  }
+  return "translation";
+}
+
+function mapSmartlingFetcherError(error: unknown): Error {
+  if (error instanceof SmartlingApiError) {
+    if (error.code === "smartling_auth_invalid" || error.status === 401) {
+      return new Error("smartling_auth_invalid");
+    }
+    if (error.code === "smartling_api_unavailable") {
+      return new Error("smartling_api_unavailable");
+    }
+  }
+  return error instanceof Error ? error : new Error("smartling_request_failed");
+}


### PR DESCRIPTION
## What changed

Implements Smartling support for the unified TMS connector sync flows:

- **HL-344**: Fetch Smartling files and source strings into the normalized external file/key model, preserving `fileUri`, locale status, directives, and dashboard links.
- **HL-345**: Fetch Smartling jobs into the normalized external job model, mapping raw Smartling statuses for existing normalization and linking jobs to target locales.

Also extends `SmartlingApiClient` with Files, Strings, and Jobs API endpoints, and wires Smartling into `POST /:projectId/sync-files` and `POST /:projectId/sync-jobs` via provider dispatch maps (Crowdin behavior unchanged).

## How to test

- `cd apps/hyperlocalise-web && vp test src/lib/providers/smartling/`
- `cd apps/hyperlocalise-web && vp test && vp check --fix`
- Connect a Smartling-backed project and trigger file/key sync and job sync from the project API or UI; verify records appear in `external_tms_files` and external jobs.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)