### PR TITLE
feat(hl-371): implement provider agent translation workflow

### DIFF
--- a/apps/hyperlocalise-web/src/api/app.ts
+++ b/apps/hyperlocalise-web/src/api/app.ts
@@ -6,6 +6,7 @@ import type {
   EmailAgentTaskQueue,
   GitHubFixQueue,
   JobQueue,
+  ProviderAgentTranslationQueue,
   TranslationJobEventData,
 } from "@/lib/workflow/types";
 import { handleUnexpectedError, notFoundHandler } from "./errors";
@@ -32,18 +33,24 @@ import { createFileRoutes } from "./routes/file/file.route";
 import { createExternalTmsProviderCredentialRoutes } from "./routes/external-tms-provider-credential/external-tms-provider-credential.route";
 import { createTeamRoutes } from "./routes/team/team.route";
 import { workosWebhookRoutes } from "./routes/workos-webhook/workos-webhook.route";
-import { createTranslationJobEventQueue } from "@/workflows/adapters";
+import {
+  createTranslationJobEventQueue,
+  createProviderAgentTranslationQueue,
+} from "@/workflows/adapters";
 
 type CreateAppOptions = {
   emailAgentTaskQueue?: EmailAgentTaskQueue;
   githubFixQueue?: GitHubFixQueue;
   githubWebhookHandler?: (request: Request) => Promise<Response>;
   jobQueue?: JobQueue<TranslationJobEventData>;
+  providerAgentTranslationQueue?: ProviderAgentTranslationQueue;
   fileStorageAdapter?: FileStorageAdapter;
 };
 
 export function createApp(options: CreateAppOptions = {}) {
   const jobQueue = options.jobQueue ?? createTranslationJobEventQueue();
+  const providerAgentTranslationQueue =
+    options.providerAgentTranslationQueue ?? createProviderAgentTranslationQueue();
 
   return new Hono()
     .use("*", secureHeaders())
@@ -52,8 +59,11 @@ export function createApp(options: CreateAppOptions = {}) {
     .notFound(notFoundHandler)
     .route("/", createInternalRoutes())
     .route("/auth", createAuthRoutes())
-    .route("/", createLegacyAppRoutes({ ...options, jobQueue }))
-    .route("/orgs/:organizationSlug", createOrgScopedAppRoutes({ ...options, jobQueue }))
+    .route("/", createLegacyAppRoutes({ ...options, jobQueue, providerAgentTranslationQueue }))
+    .route(
+      "/orgs/:organizationSlug",
+      createOrgScopedAppRoutes({ ...options, jobQueue, providerAgentTranslationQueue }),
+    )
     .route("/v1", createPublicApiRoutes({ ...options, jobQueue }))
     .route("/webhooks", createWebhookRoutes(options));
 }
@@ -79,12 +89,21 @@ function createLegacyAppRoutes(
 }
 
 function createOrgScopedAppRoutes(
-  options: CreateAppOptions & { jobQueue: JobQueue<TranslationJobEventData> },
+  options: CreateAppOptions & {
+    jobQueue: JobQueue<TranslationJobEventData>;
+    providerAgentTranslationQueue: ProviderAgentTranslationQueue;
+  },
 ) {
   return new Hono()
     .route("/glossaries", createGlossaryRoutes())
     .route("/projects", createProjectRoutes(options))
-    .route("/jobs", createWorkspaceJobRoutes({ jobQueue: options.jobQueue }))
+    .route(
+      "/jobs",
+      createWorkspaceJobRoutes({
+        jobQueue: options.jobQueue,
+        providerAgentTranslationQueue: options.providerAgentTranslationQueue,
+      }),
+    )
     .route("/provider-credential", createProviderCredentialRoutes())
     .route("/external-tms-provider-credential", createExternalTmsProviderCredentialRoutes())
     .route("/agent-email", createAgentEmailRoutes())

--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
@@ -18,7 +18,11 @@ import {
   getStoredFileForJobScope,
 } from "@/lib/file-storage/records";
 import { inferSupportedFileTranslationFileFormat } from "@/lib/translation/file-formats";
-import type { JobQueue, TranslationJobEventData } from "@/lib/workflow/types";
+import type {
+  JobQueue,
+  ProviderAgentTranslationQueue,
+  TranslationJobEventData,
+} from "@/lib/workflow/types";
 
 import {
   forbiddenResponse,
@@ -49,6 +53,7 @@ type CreateJobRoutesOptions = {
 
 type CreateWorkspaceJobRoutesOptions = {
   jobQueue: JobQueue<TranslationJobEventData>;
+  providerAgentTranslationQueue: ProviderAgentTranslationQueue;
 };
 
 const jobSelect = {
@@ -688,6 +693,13 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
           },
           hyperlocaliseJobId: job.id,
         });
+
+        if (payload.action === "translate_with_agent") {
+          await options.providerAgentTranslationQueue.enqueue({
+            agentRunId: agentRun.id,
+            organizationId,
+          });
+        }
 
         return c.json({ agentRun: serializeAgentRun(agentRun) }, 201);
       },

--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
@@ -30,7 +30,7 @@ import {
   isProjectMutationAllowed,
   projectNotFoundResponse,
 } from "./project.shared";
-import { createAgentRun, listAgentRuns } from "@/lib/providers/agent-runs";
+import { createAgentRun, failAgentRun, listAgentRuns } from "@/lib/providers/agent-runs";
 import {
   getJobProviderActionAvailability,
   getJobProviderActionDefinition,
@@ -695,10 +695,27 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
         });
 
         if (payload.action === "translate_with_agent") {
-          await options.providerAgentTranslationQueue.enqueue({
-            agentRunId: agentRun.id,
-            organizationId,
-          });
+          try {
+            await options.providerAgentTranslationQueue.enqueue({
+              agentRunId: agentRun.id,
+              organizationId,
+            });
+          } catch (error) {
+            await failAgentRun({
+              runId: agentRun.id,
+              organizationId,
+              outputSummary: { code: "agent_run_queue_unavailable" },
+              warnings: [
+                error instanceof Error ? error.message : "agent translation queue unavailable",
+              ],
+            });
+
+            return serviceUnavailableResponse(
+              c,
+              "agent_run_queue_unavailable",
+              "Agent translation queue is unavailable",
+            );
+          }
         }
 
         return c.json({ agentRun: serializeAgentRun(agentRun) }, 201);

--- a/apps/hyperlocalise-web/src/api/routes/project/job.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.test.ts
@@ -8,7 +8,11 @@ import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { createApp } from "@/api/app";
 import { db, schema } from "@/lib/database";
-import type { JobQueue, TranslationJobEventData } from "@/lib/workflow/types";
+import type {
+  JobQueue,
+  ProviderAgentTranslationQueue,
+  TranslationJobEventData,
+} from "@/lib/workflow/types";
 import { createProjectTestFixture } from "./project.fixture";
 import type { JobRecord, WorkspaceJobRecord } from "./job.schema";
 import type { ProjectResponse } from "./project.schema";
@@ -35,7 +39,20 @@ function createInlineTestJobQueue(): JobQueue<TranslationJobEventData> {
   };
 }
 
-const client = testClient(createApp({ jobQueue: createInlineTestJobQueue() }));
+function createInlineTestProviderAgentTranslationQueue(): ProviderAgentTranslationQueue {
+  return {
+    async enqueue(event) {
+      return { ids: [event.agentRunId] };
+    },
+  };
+}
+
+const client = testClient(
+  createApp({
+    jobQueue: createInlineTestJobQueue(),
+    providerAgentTranslationQueue: createInlineTestProviderAgentTranslationQueue(),
+  }),
+);
 const appClient = client;
 const projectFixture = createProjectTestFixture(client);
 const {

--- a/apps/hyperlocalise-web/src/api/routes/project/job.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.test.ts
@@ -1164,6 +1164,73 @@ describe("jobRoutes", () => {
     });
   });
 
+  it("marks the agent run failed when provider translation queueing fails", async () => {
+    const failingClient = testClient(
+      createApp({
+        jobQueue: createInlineTestJobQueue(),
+        providerAgentTranslationQueue: {
+          async enqueue() {
+            throw new Error("agent queue down");
+          },
+        },
+      }),
+    );
+    const identity = createWorkosIdentity();
+    const projectResponse = await createProjectViaApi(identity);
+    const project = ((await projectResponse.json()) as ProjectResponse).project;
+    const [organization] = await db
+      .select({ id: schema.organizations.id })
+      .from(schema.projects)
+      .innerJoin(schema.organizations, eq(schema.projects.organizationId, schema.organizations.id))
+      .where(eq(schema.projects.id, project.id))
+      .limit(1);
+
+    const externalJob = await upsertExternalJob({
+      organizationId: organization!.id,
+      projectId: project.id,
+      providerKind: "crowdin",
+      externalJobId: "crowdin-job-queue-fail",
+      externalStatus: "todo",
+      title: "Queue failure copy",
+    });
+
+    const response = await failingClient.api.orgs[":organizationSlug"].jobs[":jobId"][
+      "agent-runs"
+    ].$post(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          jobId: externalJob.id,
+        },
+        json: { action: "translate_with_agent" },
+      },
+      { headers: await authHeadersFor(identity) },
+    );
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "agent_run_queue_unavailable",
+      message: expect.any(String),
+    });
+
+    const agentRuns = await db
+      .select({
+        status: schema.agentRuns.status,
+        outputSummary: schema.agentRuns.outputSummary,
+        warnings: schema.agentRuns.warnings,
+      })
+      .from(schema.agentRuns)
+      .where(eq(schema.agentRuns.hyperlocaliseJobId, externalJob.id));
+
+    expect(agentRuns).toEqual([
+      expect.objectContaining({
+        status: "failed",
+        outputSummary: { code: "agent_run_queue_unavailable" },
+        warnings: ["agent queue down"],
+      }),
+    ]);
+  });
+
   it("rejects agent runs for native jobs", async () => {
     const identity = createWorkosIdentity();
     const projectResponse = await createProjectViaApi(identity);

--- a/apps/hyperlocalise-web/src/lib/providers/provider-agent-translate.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-agent-translate.test.ts
@@ -108,7 +108,7 @@ describe("executeProviderAgentTranslation", () => {
       ok: true,
       proposedCount: 1,
       unitsProcessed: 2,
-      skippedApproved: 1,
+      skippedApprovedLocales: 1,
       pullRunId: "pull-run-1",
     });
 
@@ -132,7 +132,7 @@ describe("executeProviderAgentTranslation", () => {
       pullRunId: "pull-run-1",
       proposedCount: 1,
       unitsProcessed: 2,
-      skippedApproved: 1,
+      skippedApprovedLocales: 1,
     });
   });
 

--- a/apps/hyperlocalise-web/src/lib/providers/provider-agent-translate.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-agent-translate.test.ts
@@ -1,0 +1,189 @@
+import "dotenv/config";
+
+import { eq } from "drizzle-orm";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
+
+import { db, schema } from "@/lib/database";
+import type { ExternalTmsTaskContent } from "@/lib/providers/external-tms-content-sync";
+
+import { createProjectTestFixture } from "../../api/routes/project/project.fixture";
+import { createAgentRun, getAgentRun } from "./agent-runs";
+import { executeProviderAgentTranslation } from "./provider-agent-translate";
+
+const projectFixture = createProjectTestFixture();
+const pullExternalTmsTaskContentMock = vi.fn();
+const loadOrganizationOpenAITranslationGeneratorMock = vi.fn();
+
+vi.mock("@/lib/providers/external-tms-content-sync", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/providers/external-tms-content-sync")>();
+  return {
+    ...actual,
+    pullExternalTmsTaskContent: (...args: unknown[]) => pullExternalTmsTaskContentMock(...args),
+  };
+});
+
+vi.mock("@/lib/translation/load-organization-translation-generator", () => ({
+  loadOrganizationOpenAITranslationGenerator: (...args: unknown[]) =>
+    loadOrganizationOpenAITranslationGeneratorMock(...args),
+}));
+
+beforeAll(async () => {
+  await db.$client.query("select 1");
+});
+
+afterEach(async () => {
+  await projectFixture.cleanup();
+  pullExternalTmsTaskContentMock.mockReset();
+  loadOrganizationOpenAITranslationGeneratorMock.mockReset();
+});
+
+async function createExternalTmsProject() {
+  const { project } = await projectFixture.createStoredProjectFixture();
+
+  await db
+    .update(schema.projects)
+    .set({
+      source: "external_tms",
+      externalProviderKind: "crowdin",
+      externalProjectId: "123",
+    })
+    .where(eq(schema.projects.id, project.id));
+
+  return project;
+}
+
+const pulledContent: ExternalTmsTaskContent = {
+  externalJobId: "task-1",
+  sourceLocale: "en",
+  targetLocales: ["fr"],
+  units: [
+    {
+      externalStringId: "1",
+      key: "hello",
+      sourceText: "Hello",
+      translations: [],
+    },
+    {
+      externalStringId: "2",
+      key: "world",
+      sourceText: "World",
+      translations: [{ locale: "fr", text: "Monde", isApproved: true }],
+    },
+  ],
+};
+
+describe("executeProviderAgentTranslation", () => {
+  it("pulls provider content, proposes translations, and stores changed items", async () => {
+    const project = await createExternalTmsProject();
+
+    pullExternalTmsTaskContentMock.mockResolvedValue({
+      runId: "pull-run-1",
+      counts: { unitsDiscovered: 2, translationsDiscovered: 1, approvedTranslations: 1 },
+      content: pulledContent,
+    });
+
+    loadOrganizationOpenAITranslationGeneratorMock.mockResolvedValue({
+      ok: true,
+      project: { name: project.name, translationContext: project.translationContext },
+      translateStringJob: vi.fn(async () => ({
+        translations: [{ locale: "fr", text: "Bonjour" }],
+      })),
+    });
+
+    const run = await createAgentRun({
+      organizationId: project.organizationId,
+      providerKind: "crowdin",
+      externalJobId: "task-1",
+      kind: "translate",
+      inputSnapshot: { projectId: project.id, action: "translate_with_agent" },
+    });
+
+    const result = await executeProviderAgentTranslation({
+      agentRunId: run.id,
+      organizationId: project.organizationId,
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      proposedCount: 1,
+      unitsProcessed: 2,
+      skippedApproved: 1,
+      pullRunId: "pull-run-1",
+    });
+
+    const completed = await getAgentRun({
+      runId: run.id,
+      organizationId: project.organizationId,
+    });
+
+    expect(completed?.status).toBe("succeeded");
+    expect(completed?.changedItems).toEqual([
+      {
+        externalStringId: "1",
+        key: "hello",
+        locale: "fr",
+        sourceText: "Hello",
+        from: "",
+        to: "Bonjour",
+      },
+    ]);
+    expect(completed?.outputSummary).toMatchObject({
+      pullRunId: "pull-run-1",
+      proposedCount: 1,
+      unitsProcessed: 2,
+      skippedApproved: 1,
+    });
+  });
+
+  it("fails when the provider does not support content pull", async () => {
+    const project = await createExternalTmsProject();
+
+    const run = await createAgentRun({
+      organizationId: project.organizationId,
+      providerKind: "smartling",
+      externalJobId: "smartling-job-1",
+      kind: "translate",
+      inputSnapshot: { projectId: project.id, action: "translate_with_agent" },
+    });
+
+    const result = await executeProviderAgentTranslation({
+      agentRunId: run.id,
+      organizationId: project.organizationId,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: "unsupported_provider_pull",
+    });
+
+    const failed = await getAgentRun({
+      runId: run.id,
+      organizationId: project.organizationId,
+    });
+
+    expect(failed?.status).toBe("failed");
+    expect(pullExternalTmsTaskContentMock).not.toHaveBeenCalled();
+  });
+
+  it("fails when projectId is missing from the input snapshot", async () => {
+    const project = await createExternalTmsProject();
+
+    const run = await createAgentRun({
+      organizationId: project.organizationId,
+      providerKind: "crowdin",
+      externalJobId: "task-2",
+      kind: "translate",
+      inputSnapshot: { action: "translate_with_agent" },
+    });
+
+    const result = await executeProviderAgentTranslation({
+      agentRunId: run.id,
+      organizationId: project.organizationId,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: "missing_project_id",
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/provider-agent-translate.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-agent-translate.test.ts
@@ -7,6 +7,7 @@ import { db, schema } from "@/lib/database";
 import type { ExternalTmsTaskContent } from "@/lib/providers/external-tms-content-sync";
 
 import { createProjectTestFixture } from "../../api/routes/project/project.fixture";
+import * as agentRuns from "./agent-runs";
 import { createAgentRun, getAgentRun, startAgentRun } from "./agent-runs";
 import { executeProviderAgentTranslation } from "./provider-agent-translate";
 
@@ -185,6 +186,105 @@ describe("executeProviderAgentTranslation", () => {
       ok: false,
       code: "missing_project_id",
     });
+  });
+
+  it("fails the agent run when startAgentRun throws", async () => {
+    const project = await createExternalTmsProject();
+
+    const startSpy = vi
+      .spyOn(agentRuns, "startAgentRun")
+      .mockRejectedValueOnce(new Error("db unavailable"));
+
+    const run = await createAgentRun({
+      organizationId: project.organizationId,
+      providerKind: "crowdin",
+      externalJobId: "task-start-fail",
+      kind: "translate",
+      inputSnapshot: { projectId: project.id, action: "translate_with_agent" },
+    });
+
+    const result = await executeProviderAgentTranslation({
+      agentRunId: run.id,
+      organizationId: project.organizationId,
+    });
+
+    startSpy.mockRestore();
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: "agent_run_start_failed",
+    });
+    expect(pullExternalTmsTaskContentMock).not.toHaveBeenCalled();
+
+    const failed = await getAgentRun({
+      runId: run.id,
+      organizationId: project.organizationId,
+    });
+
+    expect(failed?.status).toBe("failed");
+    expect(failed?.outputSummary).toMatchObject({ code: "agent_run_start_failed" });
+  });
+
+  it("fails when the translation project no longer exists", async () => {
+    const project = await createExternalTmsProject();
+
+    pullExternalTmsTaskContentMock.mockResolvedValue({
+      runId: "pull-run-missing-project",
+      counts: { unitsDiscovered: 1, translationsDiscovered: 0, approvedTranslations: 0 },
+      content: {
+        externalJobId: "task-missing-project",
+        sourceLocale: "en",
+        targetLocales: ["fr"],
+        units: [
+          {
+            externalStringId: "1",
+            key: "gone",
+            sourceText: "Gone",
+            translations: [],
+          },
+        ],
+      },
+    });
+
+    loadOrganizationOpenAITranslationGeneratorMock.mockResolvedValue({
+      ok: true,
+      project: { name: project.name, translationContext: project.translationContext },
+      translateStringJob: vi.fn(async () => ({
+        translations: [{ locale: "fr", text: "Parti" }],
+      })),
+    });
+
+    const run = await createAgentRun({
+      organizationId: project.organizationId,
+      providerKind: "crowdin",
+      externalJobId: "task-missing-project",
+      kind: "translate",
+      inputSnapshot: { projectId: project.id, action: "translate_with_agent" },
+    });
+
+    await db.delete(schema.projects).where(eq(schema.projects.id, project.id));
+
+    const result = await executeProviderAgentTranslation({
+      agentRunId: run.id,
+      organizationId: project.organizationId,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: "translation_project_not_found",
+    });
+
+    const failed = await getAgentRun({
+      runId: run.id,
+      organizationId: project.organizationId,
+    });
+
+    expect(failed?.status).toBe("failed");
+    expect(failed?.outputSummary).toMatchObject({
+      code: "translation_project_not_found",
+      pullRunId: "pull-run-missing-project",
+    });
+    expect(failed?.warnings).toEqual(expect.arrayContaining([expect.stringContaining(project.id)]));
   });
 
   it("retries a running agent run after a worker crash", async () => {

--- a/apps/hyperlocalise-web/src/lib/providers/provider-agent-translate.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-agent-translate.test.ts
@@ -7,7 +7,7 @@ import { db, schema } from "@/lib/database";
 import type { ExternalTmsTaskContent } from "@/lib/providers/external-tms-content-sync";
 
 import { createProjectTestFixture } from "../../api/routes/project/project.fixture";
-import { createAgentRun, getAgentRun } from "./agent-runs";
+import { createAgentRun, getAgentRun, startAgentRun } from "./agent-runs";
 import { executeProviderAgentTranslation } from "./provider-agent-translate";
 
 const projectFixture = createProjectTestFixture();
@@ -185,5 +185,66 @@ describe("executeProviderAgentTranslation", () => {
       ok: false,
       code: "missing_project_id",
     });
+  });
+
+  it("retries a running agent run after a worker crash", async () => {
+    const project = await createExternalTmsProject();
+
+    pullExternalTmsTaskContentMock.mockResolvedValue({
+      runId: "pull-run-retry",
+      counts: { unitsDiscovered: 1, translationsDiscovered: 0, approvedTranslations: 0 },
+      content: {
+        externalJobId: "task-retry",
+        sourceLocale: "en",
+        targetLocales: ["fr"],
+        units: [
+          {
+            externalStringId: "1",
+            key: "retry",
+            sourceText: "Retry me",
+            translations: [],
+          },
+        ],
+      },
+    });
+
+    loadOrganizationOpenAITranslationGeneratorMock.mockResolvedValue({
+      ok: true,
+      project: { name: project.name, translationContext: project.translationContext },
+      translateStringJob: vi.fn(async () => ({
+        translations: [{ locale: "fr", text: "Reessayer" }],
+      })),
+    });
+
+    const run = await createAgentRun({
+      organizationId: project.organizationId,
+      providerKind: "crowdin",
+      externalJobId: "task-retry",
+      kind: "translate",
+      inputSnapshot: { projectId: project.id, action: "translate_with_agent" },
+    });
+
+    await startAgentRun({
+      runId: run.id,
+      organizationId: project.organizationId,
+    });
+
+    const result = await executeProviderAgentTranslation({
+      agentRunId: run.id,
+      organizationId: project.organizationId,
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      proposedCount: 1,
+      unitsProcessed: 1,
+    });
+
+    const completed = await getAgentRun({
+      runId: run.id,
+      organizationId: project.organizationId,
+    });
+
+    expect(completed?.status).toBe("succeeded");
   });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/provider-agent-translate.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-agent-translate.test.ts
@@ -8,7 +8,7 @@ import type { ExternalTmsTaskContent } from "@/lib/providers/external-tms-conten
 
 import { createProjectTestFixture } from "../../api/routes/project/project.fixture";
 import * as agentRuns from "./agent-runs";
-import { createAgentRun, getAgentRun, startAgentRun } from "./agent-runs";
+import { completeAgentRun, createAgentRun, getAgentRun, startAgentRun } from "./agent-runs";
 import { executeProviderAgentTranslation } from "./provider-agent-translate";
 
 const projectFixture = createProjectTestFixture();
@@ -285,6 +285,49 @@ describe("executeProviderAgentTranslation", () => {
       pullRunId: "pull-run-missing-project",
     });
     expect(failed?.warnings).toEqual(expect.arrayContaining([expect.stringContaining(project.id)]));
+  });
+
+  it("returns idempotent success when the agent run already completed", async () => {
+    const project = await createExternalTmsProject();
+
+    const run = await createAgentRun({
+      organizationId: project.organizationId,
+      providerKind: "crowdin",
+      externalJobId: "task-already-done",
+      kind: "translate",
+      inputSnapshot: { projectId: project.id, action: "translate_with_agent" },
+    });
+
+    await startAgentRun({
+      runId: run.id,
+      organizationId: project.organizationId,
+    });
+
+    await completeAgentRun({
+      runId: run.id,
+      organizationId: project.organizationId,
+      outputSummary: {
+        pullRunId: "pull-run-done",
+        proposedCount: 2,
+        unitsProcessed: 3,
+        skippedApprovedLocales: 1,
+      },
+    });
+
+    const result = await executeProviderAgentTranslation({
+      agentRunId: run.id,
+      organizationId: project.organizationId,
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      alreadyCompleted: true,
+      proposedCount: 2,
+      unitsProcessed: 3,
+      skippedApprovedLocales: 1,
+      pullRunId: "pull-run-done",
+    });
+    expect(pullExternalTmsTaskContentMock).not.toHaveBeenCalled();
   });
 
   it("retries a running agent run after a worker crash", async () => {

--- a/apps/hyperlocalise-web/src/lib/providers/provider-agent-translate.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-agent-translate.ts
@@ -50,18 +50,12 @@ function readProjectIdFromInputSnapshot(inputSnapshot: Record<string, unknown>):
   return typeof projectId === "string" && projectId.length > 0 ? projectId : null;
 }
 
-function readOutputSummaryNumber(
-  outputSummary: Record<string, unknown>,
-  key: string,
-): number {
+function readOutputSummaryNumber(outputSummary: Record<string, unknown>, key: string): number {
   const value = outputSummary[key];
   return typeof value === "number" && Number.isFinite(value) ? value : 0;
 }
 
-function readOutputSummaryString(
-  outputSummary: Record<string, unknown>,
-  key: string,
-): string {
+function readOutputSummaryString(outputSummary: Record<string, unknown>, key: string): string {
   const value = outputSummary[key];
   return typeof value === "string" ? value : "";
 }
@@ -241,8 +235,7 @@ export async function executeProviderAgentTranslation(input: {
     return {
       ok: false,
       agentRunId: input.agentRunId,
-      code:
-        run.status === "failed" ? "agent_run_already_failed" : "agent_run_already_cancelled",
+      code: run.status === "failed" ? "agent_run_already_failed" : "agent_run_already_cancelled",
       message: `Agent run is ${run.status}, expected queued or running`,
     };
   }

--- a/apps/hyperlocalise-web/src/lib/providers/provider-agent-translate.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-agent-translate.ts
@@ -32,7 +32,7 @@ export type ProviderAgentTranslationResult =
       agentRunId: string;
       proposedCount: number;
       unitsProcessed: number;
-      skippedApproved: number;
+      skippedApprovedLocales: number;
       pullRunId: string;
     }
   | {
@@ -91,7 +91,7 @@ async function translateProviderUnits(input: {
   const changedItems: ProviderAgentTranslationChangedItem[] = [];
   const warnings: string[] = [];
   let unitsProcessed = 0;
-  let skippedApproved = 0;
+  let skippedApprovedLocales = 0;
 
   const project = await loadTranslationContextProject(input.projectId);
   if (!project) {
@@ -100,7 +100,7 @@ async function translateProviderUnits(input: {
       changedItems,
       warnings: [`Translation project ${input.projectId} was not found`],
       unitsProcessed: 0,
-      skippedApproved: 0,
+      skippedApprovedLocales: 0,
     };
   }
 
@@ -113,7 +113,7 @@ async function translateProviderUnits(input: {
     const targetLocales = input.content.targetLocales.filter((locale) => {
       const existing = existingTranslationForLocale(unit, locale);
       if (shouldSkipApprovedTranslation(existing)) {
-        skippedApproved += 1;
+        skippedApprovedLocales += 1;
         return false;
       }
       return true;
@@ -175,7 +175,7 @@ async function translateProviderUnits(input: {
     changedItems,
     warnings,
     unitsProcessed,
-    skippedApproved,
+    skippedApprovedLocales,
   };
 }
 
@@ -388,7 +388,7 @@ export async function executeProviderAgentTranslation(input: {
       unitsDiscovered: pullResult.counts.unitsDiscovered,
       unitsProcessed: translationResult.unitsProcessed,
       proposedCount: translationResult.changedItems.length,
-      skippedApproved: translationResult.skippedApproved,
+      skippedApprovedLocales: translationResult.skippedApprovedLocales,
       targetLocales: pullResult.content.targetLocales,
       sourceLocale: pullResult.content.sourceLocale ?? defaultSourceLocale,
     },
@@ -401,7 +401,7 @@ export async function executeProviderAgentTranslation(input: {
     agentRunId: input.agentRunId,
     proposedCount: translationResult.changedItems.length,
     unitsProcessed: translationResult.unitsProcessed,
-    skippedApproved: translationResult.skippedApproved,
+    skippedApprovedLocales: translationResult.skippedApprovedLocales,
     pullRunId: pullResult.runId,
   };
 }

--- a/apps/hyperlocalise-web/src/lib/providers/provider-agent-translate.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-agent-translate.ts
@@ -10,7 +10,10 @@ import {
   type ExternalTmsTranslationUnit,
 } from "@/lib/providers/external-tms-content-sync";
 import { getProviderContentPuller } from "@/lib/providers/provider-content-pullers";
-import { assembleStringTranslationContextSnapshot } from "@/lib/translation/assemble-translation-context";
+import {
+  assembleStringTranslationContextSnapshot,
+  loadTranslationContextProject,
+} from "@/lib/translation/assemble-translation-context";
 import { loadOrganizationOpenAITranslationGenerator } from "@/lib/translation/load-organization-translation-generator";
 import type { StringTranslationGenerator } from "@/lib/translation/string-job-executor";
 
@@ -90,6 +93,16 @@ async function translateProviderUnits(input: {
   let unitsProcessed = 0;
   let skippedApproved = 0;
 
+  const project = await loadTranslationContextProject(input.projectId);
+  if (!project) {
+    return {
+      changedItems,
+      warnings: [`Translation project ${input.projectId} was not found`],
+      unitsProcessed: 0,
+      skippedApproved: 0,
+    };
+  }
+
   for (const unit of input.content.units) {
     if (!unit.sourceText.trim()) {
       continue;
@@ -119,6 +132,7 @@ async function translateProviderUnits(input: {
     const contextSnapshot = await assembleStringTranslationContextSnapshot(
       input.projectId,
       jobInput,
+      project,
     );
     if (!contextSnapshot.ok) {
       warnings.push(`Skipped ${unit.key}: ${contextSnapshot.message}`);
@@ -192,7 +206,7 @@ export async function executeProviderAgentTranslation(input: {
     };
   }
 
-  if (run.status !== "queued") {
+  if (run.status !== "queued" && run.status !== "running") {
     return {
       ok: false,
       agentRunId: input.agentRunId,
@@ -238,19 +252,21 @@ export async function executeProviderAgentTranslation(input: {
     };
   }
 
-  try {
-    await startAgentRun({
-      runId: run.id,
-      organizationId: input.organizationId,
-    });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : "Failed to start agent run";
-    return {
-      ok: false,
-      agentRunId: input.agentRunId,
-      code: "agent_run_start_failed",
-      message,
-    };
+  if (run.status === "queued") {
+    try {
+      await startAgentRun({
+        runId: run.id,
+        organizationId: input.organizationId,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to start agent run";
+      return {
+        ok: false,
+        agentRunId: input.agentRunId,
+        code: "agent_run_start_failed",
+        message,
+      };
+    }
   }
 
   let pullResult;

--- a/apps/hyperlocalise-web/src/lib/providers/provider-agent-translate.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-agent-translate.ts
@@ -1,0 +1,362 @@
+import {
+  completeAgentRun,
+  failAgentRun,
+  getAgentRun,
+  startAgentRun,
+} from "@/lib/providers/agent-runs";
+import {
+  pullExternalTmsTaskContent,
+  type ExternalTmsTaskContent,
+  type ExternalTmsTranslationUnit,
+} from "@/lib/providers/external-tms-content-sync";
+import { getProviderContentPuller } from "@/lib/providers/provider-content-pullers";
+import { assembleStringTranslationContextSnapshot } from "@/lib/translation/assemble-translation-context";
+import { loadOrganizationOpenAITranslationGenerator } from "@/lib/translation/load-organization-translation-generator";
+import type { StringTranslationGenerator } from "@/lib/translation/string-job-executor";
+
+export type ProviderAgentTranslationChangedItem = {
+  externalStringId: string;
+  key: string;
+  locale: string;
+  sourceText: string;
+  from: string;
+  to: string;
+};
+
+export type ProviderAgentTranslationResult =
+  | {
+      ok: true;
+      agentRunId: string;
+      proposedCount: number;
+      unitsProcessed: number;
+      skippedApproved: number;
+      pullRunId: string;
+    }
+  | {
+      ok: false;
+      agentRunId: string;
+      code: string;
+      message: string;
+    };
+
+const defaultSourceLocale = "en";
+
+function readProjectIdFromInputSnapshot(inputSnapshot: Record<string, unknown>): string | null {
+  const projectId = inputSnapshot.projectId;
+  return typeof projectId === "string" && projectId.length > 0 ? projectId : null;
+}
+
+function existingTranslationForLocale(unit: ExternalTmsTranslationUnit, locale: string) {
+  return unit.translations.find((translation) => translation.locale === locale) ?? null;
+}
+
+function shouldSkipApprovedTranslation(
+  translation: ExternalTmsTranslationUnit["translations"][number] | null,
+) {
+  return translation?.isApproved === true;
+}
+
+function buildJobInputForUnit(input: {
+  unit: ExternalTmsTranslationUnit;
+  sourceLocale: string;
+  targetLocales: string[];
+  providerKind: string;
+}) {
+  return {
+    sourceLocale: input.sourceLocale,
+    targetLocales: input.targetLocales,
+    sourceText: input.unit.sourceText,
+    context: input.unit.context ?? undefined,
+    metadata: {
+      externalStringId: input.unit.externalStringId,
+      key: input.unit.key,
+      fileId: input.unit.fileId ?? "",
+      providerKind: input.providerKind,
+    },
+  };
+}
+
+async function translateProviderUnits(input: {
+  projectId: string;
+  providerKind: string;
+  content: ExternalTmsTaskContent;
+  translateStringJob: StringTranslationGenerator;
+  projectName: string;
+  projectTranslationContext: string;
+}) {
+  const sourceLocale = input.content.sourceLocale ?? defaultSourceLocale;
+  const changedItems: ProviderAgentTranslationChangedItem[] = [];
+  const warnings: string[] = [];
+  let unitsProcessed = 0;
+  let skippedApproved = 0;
+
+  for (const unit of input.content.units) {
+    if (!unit.sourceText.trim()) {
+      continue;
+    }
+
+    unitsProcessed += 1;
+    const targetLocales = input.content.targetLocales.filter((locale) => {
+      const existing = existingTranslationForLocale(unit, locale);
+      if (shouldSkipApprovedTranslation(existing)) {
+        skippedApproved += 1;
+        return false;
+      }
+      return true;
+    });
+
+    if (targetLocales.length === 0) {
+      continue;
+    }
+
+    const jobInput = buildJobInputForUnit({
+      unit,
+      sourceLocale,
+      targetLocales,
+      providerKind: input.providerKind,
+    });
+
+    const contextSnapshot = await assembleStringTranslationContextSnapshot(
+      input.projectId,
+      jobInput,
+    );
+    if (!contextSnapshot.ok) {
+      warnings.push(`Skipped ${unit.key}: ${contextSnapshot.message}`);
+      continue;
+    }
+
+    try {
+      const result = await input.translateStringJob({
+        projectName: input.projectName,
+        projectTranslationContext: input.projectTranslationContext,
+        jobInput,
+        contextSnapshot: contextSnapshot.snapshot,
+      });
+
+      for (const translation of result.translations) {
+        const existing = existingTranslationForLocale(unit, translation.locale);
+        const from = existing?.text ?? "";
+
+        if (translation.text === from) {
+          continue;
+        }
+
+        changedItems.push({
+          externalStringId: unit.externalStringId,
+          key: unit.key,
+          locale: translation.locale,
+          sourceText: unit.sourceText,
+          from,
+          to: translation.text,
+        });
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "translation failed";
+      warnings.push(`Skipped ${unit.key}: ${message}`);
+    }
+  }
+
+  return {
+    changedItems,
+    warnings,
+    unitsProcessed,
+    skippedApproved,
+  };
+}
+
+export async function executeProviderAgentTranslation(input: {
+  agentRunId: string;
+  organizationId: string;
+  translateStringJobOverride?: StringTranslationGenerator;
+}): Promise<ProviderAgentTranslationResult> {
+  const run = await getAgentRun({
+    runId: input.agentRunId,
+    organizationId: input.organizationId,
+  });
+
+  if (!run) {
+    return {
+      ok: false,
+      agentRunId: input.agentRunId,
+      code: "agent_run_not_found",
+      message: "Agent run not found",
+    };
+  }
+
+  if (run.kind !== "translate") {
+    return {
+      ok: false,
+      agentRunId: input.agentRunId,
+      code: "unsupported_agent_run_kind",
+      message: `Agent run kind ${run.kind} is not supported for provider translation`,
+    };
+  }
+
+  if (run.status !== "queued") {
+    return {
+      ok: false,
+      agentRunId: input.agentRunId,
+      code: "agent_run_not_queued",
+      message: `Agent run is ${run.status}, expected queued`,
+    };
+  }
+
+  const projectId = readProjectIdFromInputSnapshot(run.inputSnapshot);
+  if (!projectId) {
+    await failAgentRun({
+      runId: run.id,
+      organizationId: input.organizationId,
+      outputSummary: { code: "missing_project_id" },
+      warnings: ["Agent run input snapshot is missing projectId"],
+    });
+
+    return {
+      ok: false,
+      agentRunId: input.agentRunId,
+      code: "missing_project_id",
+      message: "Agent run input snapshot is missing projectId",
+    };
+  }
+
+  const pullContent = getProviderContentPuller(run.providerKind);
+  if (!pullContent) {
+    await failAgentRun({
+      runId: run.id,
+      organizationId: input.organizationId,
+      outputSummary: {
+        code: "unsupported_provider_pull",
+        providerKind: run.providerKind,
+      },
+      warnings: [`Provider ${run.providerKind} does not support content pull yet`],
+    });
+
+    return {
+      ok: false,
+      agentRunId: input.agentRunId,
+      code: "unsupported_provider_pull",
+      message: `Provider ${run.providerKind} does not support content pull yet`,
+    };
+  }
+
+  try {
+    await startAgentRun({
+      runId: run.id,
+      organizationId: input.organizationId,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to start agent run";
+    return {
+      ok: false,
+      agentRunId: input.agentRunId,
+      code: "agent_run_start_failed",
+      message,
+    };
+  }
+
+  let pullResult;
+  try {
+    pullResult = await pullExternalTmsTaskContent({
+      organizationId: input.organizationId,
+      projectId,
+      providerKind: run.providerKind,
+      externalJobId: run.externalJobId,
+      pullContent,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Provider content pull failed";
+    await failAgentRun({
+      runId: run.id,
+      organizationId: input.organizationId,
+      outputSummary: { code: "provider_content_pull_failed" },
+      warnings: [message],
+    });
+
+    return {
+      ok: false,
+      agentRunId: input.agentRunId,
+      code: "provider_content_pull_failed",
+      message,
+    };
+  }
+
+  const organizationGenerator = await loadOrganizationOpenAITranslationGenerator(projectId);
+
+  if (!organizationGenerator.ok && !input.translateStringJobOverride) {
+    await failAgentRun({
+      runId: run.id,
+      organizationId: input.organizationId,
+      outputSummary: {
+        code: organizationGenerator.code,
+        pullRunId: pullResult.runId,
+        unitsDiscovered: pullResult.counts.unitsDiscovered,
+      },
+      warnings: [organizationGenerator.message],
+    });
+
+    return {
+      ok: false,
+      agentRunId: input.agentRunId,
+      code: organizationGenerator.code,
+      message: organizationGenerator.message,
+    };
+  }
+
+  const translateStringJob =
+    input.translateStringJobOverride ??
+    (organizationGenerator.ok ? organizationGenerator.translateStringJob : null);
+
+  if (!translateStringJob) {
+    await failAgentRun({
+      runId: run.id,
+      organizationId: input.organizationId,
+      outputSummary: {
+        code: "provider_credential_missing",
+        pullRunId: pullResult.runId,
+      },
+      warnings: ["No translation generator available for this organization"],
+    });
+
+    return {
+      ok: false,
+      agentRunId: input.agentRunId,
+      code: "provider_credential_missing",
+      message: "No translation generator available for this organization",
+    };
+  }
+
+  const translationResult = await translateProviderUnits({
+    projectId,
+    providerKind: run.providerKind,
+    content: pullResult.content,
+    translateStringJob,
+    projectName: organizationGenerator.ok ? organizationGenerator.project.name : "Provider job",
+    projectTranslationContext: organizationGenerator.ok
+      ? organizationGenerator.project.translationContext
+      : "",
+  });
+
+  await completeAgentRun({
+    runId: run.id,
+    organizationId: input.organizationId,
+    outputSummary: {
+      pullRunId: pullResult.runId,
+      unitsDiscovered: pullResult.counts.unitsDiscovered,
+      unitsProcessed: translationResult.unitsProcessed,
+      proposedCount: translationResult.changedItems.length,
+      skippedApproved: translationResult.skippedApproved,
+      targetLocales: pullResult.content.targetLocales,
+      sourceLocale: pullResult.content.sourceLocale ?? defaultSourceLocale,
+    },
+    changedItems: translationResult.changedItems,
+    warnings: translationResult.warnings,
+  });
+
+  return {
+    ok: true,
+    agentRunId: input.agentRunId,
+    proposedCount: translationResult.changedItems.length,
+    unitsProcessed: translationResult.unitsProcessed,
+    skippedApproved: translationResult.skippedApproved,
+    pullRunId: pullResult.runId,
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/providers/provider-agent-translate.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-agent-translate.ts
@@ -34,6 +34,7 @@ export type ProviderAgentTranslationResult =
       unitsProcessed: number;
       skippedApprovedLocales: number;
       pullRunId: string;
+      alreadyCompleted?: boolean;
     }
   | {
       ok: false;
@@ -47,6 +48,22 @@ const defaultSourceLocale = "en";
 function readProjectIdFromInputSnapshot(inputSnapshot: Record<string, unknown>): string | null {
   const projectId = inputSnapshot.projectId;
   return typeof projectId === "string" && projectId.length > 0 ? projectId : null;
+}
+
+function readOutputSummaryNumber(
+  outputSummary: Record<string, unknown>,
+  key: string,
+): number {
+  const value = outputSummary[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function readOutputSummaryString(
+  outputSummary: Record<string, unknown>,
+  key: string,
+): string {
+  const value = outputSummary[key];
+  return typeof value === "string" ? value : "";
 }
 
 function existingTranslationForLocale(unit: ExternalTmsTranslationUnit, locale: string) {
@@ -207,12 +224,26 @@ export async function executeProviderAgentTranslation(input: {
     };
   }
 
-  if (run.status !== "queued" && run.status !== "running") {
+  if (run.status === "succeeded") {
+    const outputSummary = run.outputSummary ?? {};
+    return {
+      ok: true,
+      agentRunId: input.agentRunId,
+      proposedCount: readOutputSummaryNumber(outputSummary, "proposedCount"),
+      unitsProcessed: readOutputSummaryNumber(outputSummary, "unitsProcessed"),
+      skippedApprovedLocales: readOutputSummaryNumber(outputSummary, "skippedApprovedLocales"),
+      pullRunId: readOutputSummaryString(outputSummary, "pullRunId"),
+      alreadyCompleted: true,
+    };
+  }
+
+  if (run.status === "failed" || run.status === "cancelled") {
     return {
       ok: false,
       agentRunId: input.agentRunId,
-      code: "agent_run_not_queued",
-      message: `Agent run is ${run.status}, expected queued`,
+      code:
+        run.status === "failed" ? "agent_run_already_failed" : "agent_run_already_cancelled",
+      message: `Agent run is ${run.status}, expected queued or running`,
     };
   }
 

--- a/apps/hyperlocalise-web/src/lib/providers/provider-agent-translate.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-agent-translate.ts
@@ -96,6 +96,7 @@ async function translateProviderUnits(input: {
   const project = await loadTranslationContextProject(input.projectId);
   if (!project) {
     return {
+      projectNotFound: true,
       changedItems,
       warnings: [`Translation project ${input.projectId} was not found`],
       unitsProcessed: 0,
@@ -260,6 +261,12 @@ export async function executeProviderAgentTranslation(input: {
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : "Failed to start agent run";
+      await failAgentRun({
+        runId: run.id,
+        organizationId: input.organizationId,
+        outputSummary: { code: "agent_run_start_failed" },
+        warnings: [message],
+      });
       return {
         ok: false,
         agentRunId: input.agentRunId,
@@ -350,6 +357,28 @@ export async function executeProviderAgentTranslation(input: {
       ? organizationGenerator.project.translationContext
       : "",
   });
+
+  if (translationResult.projectNotFound) {
+    const message =
+      translationResult.warnings[0] ?? `Translation project ${projectId} was not found`;
+    await failAgentRun({
+      runId: run.id,
+      organizationId: input.organizationId,
+      outputSummary: {
+        code: "translation_project_not_found",
+        pullRunId: pullResult.runId,
+        unitsDiscovered: pullResult.counts.unitsDiscovered,
+      },
+      warnings: translationResult.warnings,
+    });
+
+    return {
+      ok: false,
+      agentRunId: input.agentRunId,
+      code: "translation_project_not_found",
+      message,
+    };
+  }
 
   await completeAgentRun({
     runId: run.id,

--- a/apps/hyperlocalise-web/src/lib/providers/provider-content-pullers.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-content-pullers.ts
@@ -1,0 +1,15 @@
+import { pullCrowdinTaskContent } from "@/lib/providers/crowdin/crowdin-content-puller";
+import type { ExternalTmsContentPuller } from "@/lib/providers/external-tms-content-sync";
+
+import type { ExternalTmsProviderKind } from "./organization-external-tms-provider-credentials";
+
+export function getProviderContentPuller(
+  providerKind: ExternalTmsProviderKind,
+): ExternalTmsContentPuller | null {
+  switch (providerKind) {
+    case "crowdin":
+      return pullCrowdinTaskContent;
+    default:
+      return null;
+  }
+}

--- a/apps/hyperlocalise-web/src/lib/translation/assemble-translation-context.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/assemble-translation-context.ts
@@ -55,7 +55,13 @@ function buildTsQuery(input: string): string {
     .join(" & ");
 }
 
-async function loadProjectForContext(projectId: string) {
+export type TranslationContextProject = {
+  id: string;
+  name: string;
+  translationContext: string;
+};
+
+async function loadProjectForContext(projectId: string): Promise<TranslationContextProject | null> {
   const [project] = await db
     .select({
       id: schema.projects.id,
@@ -193,11 +199,17 @@ async function loadMemoryMatchesForContext(input: {
     .limit(10);
 }
 
+export async function loadTranslationContextProject(projectId: string) {
+  return loadProjectForContext(projectId);
+}
+
 export async function assembleStringTranslationContextSnapshot(
   projectId: string,
   jobInput: StringTranslationJobInput,
+  projectOverride?: TranslationContextProject | null,
 ) {
-  const project = await loadProjectForContext(projectId);
+  const project =
+    projectOverride === undefined ? await loadProjectForContext(projectId) : projectOverride;
   if (!project) {
     return {
       ok: false,

--- a/apps/hyperlocalise-web/src/lib/translation/assemble-translation-context.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/assemble-translation-context.ts
@@ -46,7 +46,7 @@ export type StringTranslationContextSnapshot = {
 
 function buildTsQuery(input: string): string {
   return input
-    .replace(/[&|!():*<>'"]/g, " ")
+    .replace(/[&|!():*<>'"-]/g, " ")
     .trim()
     .split(/\s+/)
     .filter(Boolean)

--- a/apps/hyperlocalise-web/src/lib/translation/assemble-translation-context.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/assemble-translation-context.ts
@@ -46,7 +46,7 @@ export type StringTranslationContextSnapshot = {
 
 function buildTsQuery(input: string): string {
   return input
-    .replace(/[&|!():*<>]/g, " ")
+    .replace(/[&|!():*<>'"]/g, " ")
     .trim()
     .split(/\s+/)
     .filter(Boolean)

--- a/apps/hyperlocalise-web/src/lib/translation/assemble-translation-context.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/assemble-translation-context.ts
@@ -1,0 +1,234 @@
+import { and, desc, eq, inArray, sql } from "drizzle-orm";
+
+import type { StringTranslationJobInput } from "@/api/routes/project/job.schema";
+import { db, schema } from "@/lib/database";
+import { normalizeTranslationMemorySourceText } from "@/lib/translation/normalizeTranslationMemorySourceText";
+
+const maxContextSearchTerms = 50;
+
+export type StringTranslationContextSnapshot = {
+  assembledAt: string;
+  project: {
+    id: string;
+    name: string;
+    translationContext: string;
+  };
+  job: {
+    sourceLocale: string;
+    targetLocales: string[];
+    sourceText: string;
+    context?: string;
+    metadata?: Record<string, string>;
+    maxLength?: number;
+  };
+  glossaryTerms: Array<{
+    id: string;
+    glossaryId: string;
+    glossaryName: string;
+    sourceTerm: string;
+    targetTerm: string;
+    targetLocale: string;
+    description: string | null;
+    forbidden: boolean | null;
+    rank: number;
+  }>;
+  translationMemoryMatches: Array<{
+    id: string;
+    memoryId: string;
+    sourceText: string;
+    targetText: string;
+    targetLocale: string;
+    provenance: string | null;
+    matchScore: number | null;
+    rank: number;
+  }>;
+};
+
+function buildTsQuery(input: string): string {
+  return input
+    .replace(/[&|!():*<>]/g, " ")
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, maxContextSearchTerms)
+    .map((word) => `${word}:*`)
+    .join(" & ");
+}
+
+async function loadProjectForContext(projectId: string) {
+  const [project] = await db
+    .select({
+      id: schema.projects.id,
+      name: schema.projects.name,
+      translationContext: schema.projects.translationContext,
+    })
+    .from(schema.projects)
+    .where(eq(schema.projects.id, projectId))
+    .limit(1);
+
+  return project ?? null;
+}
+
+async function loadGlossaryTermsForContext(input: {
+  projectId: string;
+  sourceLocale: string;
+  targetLocales: string[];
+  sourceText: string;
+}) {
+  const tsQuery = buildTsQuery(input.sourceText);
+  if (!tsQuery) {
+    return [];
+  }
+
+  const attached = await db
+    .select({ glossaryId: schema.projectGlossaries.glossaryId })
+    .from(schema.projectGlossaries)
+    .where(eq(schema.projectGlossaries.projectId, input.projectId));
+  const glossaryIds = attached.map((item) => item.glossaryId);
+  if (glossaryIds.length === 0) {
+    return [];
+  }
+
+  return db
+    .select({
+      id: schema.glossaryTerms.id,
+      glossaryId: schema.glossaryTerms.glossaryId,
+      glossaryName: schema.glossaries.name,
+      sourceTerm: schema.glossaryTerms.sourceTerm,
+      targetTerm: schema.glossaryTerms.targetTerm,
+      targetLocale: schema.glossaries.targetLocale,
+      description: schema.glossaryTerms.description,
+      forbidden: schema.glossaryTerms.forbidden,
+      rank: sql<number>`ts_rank(${schema.glossaryTerms.searchVector}, to_tsquery('simple', ${tsQuery}))`.as(
+        "rank",
+      ),
+    })
+    .from(schema.glossaryTerms)
+    .innerJoin(schema.glossaries, eq(schema.glossaryTerms.glossaryId, schema.glossaries.id))
+    .where(
+      and(
+        inArray(schema.glossaryTerms.glossaryId, glossaryIds),
+        eq(schema.glossaries.sourceLocale, input.sourceLocale),
+        inArray(schema.glossaries.targetLocale, input.targetLocales),
+        eq(schema.glossaries.status, "active"),
+        sql`${schema.glossaryTerms.searchVector} @@ to_tsquery('simple', ${tsQuery})`,
+      ),
+    )
+    .orderBy(desc(sql`rank`))
+    .limit(20);
+}
+
+async function loadMemoryMatchesForContext(input: {
+  projectId: string;
+  sourceLocale: string;
+  targetLocales: string[];
+  sourceText: string;
+}) {
+  const attached = await db
+    .select({ memoryId: schema.projectMemories.memoryId })
+    .from(schema.projectMemories)
+    .where(eq(schema.projectMemories.projectId, input.projectId));
+  const memoryIds = attached.map((item) => item.memoryId);
+  if (memoryIds.length === 0) {
+    return [];
+  }
+
+  const normalized = normalizeTranslationMemorySourceText(input.sourceText);
+  const exactMatches = await db
+    .select({
+      id: schema.memoryEntries.id,
+      memoryId: schema.memoryEntries.memoryId,
+      sourceText: schema.memoryEntries.sourceText,
+      targetText: schema.memoryEntries.targetText,
+      targetLocale: schema.memoryEntries.targetLocale,
+      provenance: schema.memoryEntries.provenance,
+      matchScore: schema.memoryEntries.matchScore,
+      rank: sql<number>`1`.as("rank"),
+    })
+    .from(schema.memoryEntries)
+    .where(
+      and(
+        inArray(schema.memoryEntries.memoryId, memoryIds),
+        eq(schema.memoryEntries.normalizedSourceText, normalized),
+        eq(schema.memoryEntries.sourceLocale, input.sourceLocale),
+        inArray(schema.memoryEntries.targetLocale, input.targetLocales),
+        eq(schema.memoryEntries.reviewStatus, "approved"),
+      ),
+    )
+    .limit(10);
+
+  if (exactMatches.length > 0) {
+    return exactMatches;
+  }
+
+  const tsQuery = buildTsQuery(input.sourceText);
+  if (!tsQuery) {
+    return [];
+  }
+
+  return db
+    .select({
+      id: schema.memoryEntries.id,
+      memoryId: schema.memoryEntries.memoryId,
+      sourceText: schema.memoryEntries.sourceText,
+      targetText: schema.memoryEntries.targetText,
+      targetLocale: schema.memoryEntries.targetLocale,
+      provenance: schema.memoryEntries.provenance,
+      matchScore: schema.memoryEntries.matchScore,
+      rank: sql<number>`ts_rank(${schema.memoryEntries.searchVector}, to_tsquery('simple', ${tsQuery}))`.as(
+        "rank",
+      ),
+    })
+    .from(schema.memoryEntries)
+    .where(
+      and(
+        inArray(schema.memoryEntries.memoryId, memoryIds),
+        eq(schema.memoryEntries.sourceLocale, input.sourceLocale),
+        inArray(schema.memoryEntries.targetLocale, input.targetLocales),
+        eq(schema.memoryEntries.reviewStatus, "approved"),
+        sql`${schema.memoryEntries.searchVector} @@ to_tsquery('simple', ${tsQuery})`,
+      ),
+    )
+    .orderBy(desc(sql`rank`))
+    .limit(10);
+}
+
+export async function assembleStringTranslationContextSnapshot(
+  projectId: string,
+  jobInput: StringTranslationJobInput,
+) {
+  const project = await loadProjectForContext(projectId);
+  if (!project) {
+    return {
+      ok: false,
+      code: "translation_project_not_found",
+      message: `translation project ${projectId} was not found`,
+    } as const;
+  }
+
+  const [glossaryTerms, translationMemoryMatches] = await Promise.all([
+    loadGlossaryTermsForContext({
+      projectId,
+      sourceLocale: jobInput.sourceLocale,
+      targetLocales: jobInput.targetLocales,
+      sourceText: jobInput.sourceText,
+    }),
+    loadMemoryMatchesForContext({
+      projectId,
+      sourceLocale: jobInput.sourceLocale,
+      targetLocales: jobInput.targetLocales,
+      sourceText: jobInput.sourceText,
+    }),
+  ]);
+
+  return {
+    ok: true,
+    snapshot: {
+      assembledAt: new Date().toISOString(),
+      project,
+      job: jobInput,
+      glossaryTerms,
+      translationMemoryMatches,
+    } satisfies StringTranslationContextSnapshot,
+  } as const;
+}

--- a/apps/hyperlocalise-web/src/lib/translation/load-organization-translation-generator.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/load-organization-translation-generator.ts
@@ -1,0 +1,109 @@
+import { and, eq } from "drizzle-orm";
+
+import { db, schema } from "@/lib/database";
+import { decryptProviderCredential } from "@/lib/security/provider-credential-crypto";
+import { createOpenAIStringTranslationGenerator } from "@/lib/translation/string-job-executor";
+
+export async function loadOrganizationOpenAITranslationGenerator(projectId: string) {
+  const [project] = await db
+    .select({
+      name: schema.projects.name,
+      translationContext: schema.projects.translationContext,
+      organizationId: schema.projects.organizationId,
+      provider: schema.organizationLlmProviderCredentials.provider,
+      defaultModel: schema.organizationLlmProviderCredentials.defaultModel,
+      encryptionAlgorithm: schema.organizationLlmProviderCredentials.encryptionAlgorithm,
+      ciphertext: schema.organizationLlmProviderCredentials.ciphertext,
+      iv: schema.organizationLlmProviderCredentials.iv,
+      authTag: schema.organizationLlmProviderCredentials.authTag,
+      keyVersion: schema.organizationLlmProviderCredentials.keyVersion,
+    })
+    .from(schema.projects)
+    .leftJoin(
+      schema.organizationLlmProviderCredentials,
+      and(
+        eq(
+          schema.organizationLlmProviderCredentials.organizationId,
+          schema.projects.organizationId,
+        ),
+        eq(schema.organizationLlmProviderCredentials.provider, "openai"),
+      ),
+    )
+    .where(eq(schema.projects.id, projectId))
+    .limit(1);
+
+  if (!project) {
+    return {
+      ok: false,
+      code: "translation_project_not_found",
+      message: `translation project ${projectId} was not found`,
+    } as const;
+  }
+
+  if (!project.provider) {
+    const [anyCredential] = await db
+      .select({
+        provider: schema.organizationLlmProviderCredentials.provider,
+      })
+      .from(schema.organizationLlmProviderCredentials)
+      .where(eq(schema.organizationLlmProviderCredentials.organizationId, project.organizationId))
+      .limit(1);
+
+    if (anyCredential) {
+      return {
+        ok: false,
+        code: "unsupported_provider",
+        message: `translation jobs support OpenAI provider credentials only, got ${anyCredential.provider}`,
+      } as const;
+    }
+
+    return {
+      ok: false,
+      code: "provider_credential_missing",
+      message: "organization OpenAI provider credential is not configured",
+    } as const;
+  }
+
+  if (project.provider !== "openai") {
+    return {
+      ok: false,
+      code: "unsupported_provider",
+      message: `translation jobs support OpenAI provider credentials only, got ${project.provider}`,
+    } as const;
+  }
+
+  if (
+    !project.defaultModel ||
+    !project.encryptionAlgorithm ||
+    !project.ciphertext ||
+    !project.iv ||
+    !project.authTag ||
+    project.keyVersion === null
+  ) {
+    return {
+      ok: false,
+      code: "provider_credential_invalid",
+      message: "organization OpenAI provider credential is incomplete",
+    } as const;
+  }
+
+  const apiKey = decryptProviderCredential({
+    algorithm: project.encryptionAlgorithm,
+    keyVersion: project.keyVersion,
+    ciphertext: project.ciphertext,
+    iv: project.iv,
+    authTag: project.authTag,
+  });
+
+  return {
+    ok: true,
+    project: {
+      name: project.name,
+      translationContext: project.translationContext,
+    },
+    translateStringJob: createOpenAIStringTranslationGenerator({
+      apiKey,
+      model: project.defaultModel,
+    }),
+  } as const;
+}

--- a/apps/hyperlocalise-web/src/lib/workflow/types.ts
+++ b/apps/hyperlocalise-web/src/lib/workflow/types.ts
@@ -97,3 +97,10 @@ export type EmailAgentTask = {
 export type EmailAgentTaskQueue = JobQueue<EmailAgentTask>;
 
 export type RepoTmsAgentTaskQueue = JobQueue<import("@/lib/agents/repo-tms-task").RepoTmsAgentTask>;
+
+export type ProviderAgentTranslationEventData = {
+  agentRunId: string;
+  organizationId: string;
+};
+
+export type ProviderAgentTranslationQueue = JobQueue<ProviderAgentTranslationEventData>;

--- a/apps/hyperlocalise-web/src/workflows/adapters.ts
+++ b/apps/hyperlocalise-web/src/workflows/adapters.ts
@@ -3,12 +3,14 @@ import { start } from "workflow/api";
 import { emailTranslationWorkflow } from "./email-translation";
 import { fileTranslationJobWorkflow } from "./file-translation-job";
 import { githubFixWorkflow } from "./github-fix";
+import { providerAgentTranslationWorkflow } from "./provider-agent-translation";
 import { repoTmsAgentWorkflow } from "./repo-tms-agent";
 import { translationJobWorkflow } from "./translation-job";
 import type {
   EmailAgentTaskQueue,
   GitHubFixQueue,
   JobQueue,
+  ProviderAgentTranslationQueue,
   RepoTmsAgentTaskQueue,
   TranslationJobEventData,
 } from "@/lib/workflow/types";
@@ -54,6 +56,15 @@ export function createRepoTmsAgentTaskQueue(): RepoTmsAgentTaskQueue {
   return {
     async enqueue(task) {
       const run = await start(repoTmsAgentWorkflow, [task]);
+      return { ids: [run.runId] };
+    },
+  };
+}
+
+export function createProviderAgentTranslationQueue(): ProviderAgentTranslationQueue {
+  return {
+    async enqueue(event) {
+      const run = await start(providerAgentTranslationWorkflow, [event]);
       return { ids: [run.runId] };
     },
   };

--- a/apps/hyperlocalise-web/src/workflows/provider-agent-translation.ts
+++ b/apps/hyperlocalise-web/src/workflows/provider-agent-translation.ts
@@ -1,0 +1,32 @@
+import { getWorkflowMetadata } from "workflow";
+
+import type { ProviderAgentTranslationEventData } from "@/lib/workflow/types";
+
+import { executeProviderAgentTranslationStep } from "./steps/provider-agent-translation";
+
+function formatExecutionError(error: unknown) {
+  return error instanceof Error ? error.message : "provider agent translation failed";
+}
+
+export async function providerAgentTranslationWorkflow(event: ProviderAgentTranslationEventData) {
+  "use workflow";
+
+  const { workflowRunId } = getWorkflowMetadata();
+
+  try {
+    const result = await executeProviderAgentTranslationStep(event);
+
+    return {
+      ...result,
+      workflowRunId,
+    };
+  } catch (error) {
+    return {
+      ok: false as const,
+      agentRunId: event.agentRunId,
+      code: "provider_agent_translation_failed",
+      message: formatExecutionError(error),
+      workflowRunId,
+    };
+  }
+}

--- a/apps/hyperlocalise-web/src/workflows/provider-agent-translation.ts
+++ b/apps/hyperlocalise-web/src/workflows/provider-agent-translation.ts
@@ -2,7 +2,10 @@ import { getWorkflowMetadata } from "workflow";
 
 import type { ProviderAgentTranslationEventData } from "@/lib/workflow/types";
 
-import { executeProviderAgentTranslationStep } from "./steps/provider-agent-translation";
+import {
+  executeProviderAgentTranslationStep,
+  failProviderAgentTranslationStep,
+} from "./steps/provider-agent-translation";
 
 function formatExecutionError(error: unknown) {
   return error instanceof Error ? error.message : "provider agent translation failed";
@@ -21,11 +24,15 @@ export async function providerAgentTranslationWorkflow(event: ProviderAgentTrans
       workflowRunId,
     };
   } catch (error) {
-    return {
-      ok: false as const,
+    const failure = await failProviderAgentTranslationStep({
       agentRunId: event.agentRunId,
+      organizationId: event.organizationId,
       code: "provider_agent_translation_failed",
       message: formatExecutionError(error),
+    });
+
+    return {
+      ...failure,
       workflowRunId,
     };
   }

--- a/apps/hyperlocalise-web/src/workflows/steps/provider-agent-translation.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/provider-agent-translation.ts
@@ -1,3 +1,4 @@
+import { failAgentRun } from "@/lib/providers/agent-runs";
 import { executeProviderAgentTranslation } from "@/lib/providers/provider-agent-translate";
 
 export async function executeProviderAgentTranslationStep(input: {
@@ -6,4 +7,27 @@ export async function executeProviderAgentTranslationStep(input: {
 }) {
   "use step";
   return executeProviderAgentTranslation(input);
+}
+
+export async function failProviderAgentTranslationStep(input: {
+  agentRunId: string;
+  organizationId: string;
+  code: string;
+  message: string;
+}) {
+  "use step";
+
+  await failAgentRun({
+    runId: input.agentRunId,
+    organizationId: input.organizationId,
+    outputSummary: { code: input.code },
+    warnings: [input.message],
+  });
+
+  return {
+    ok: false as const,
+    agentRunId: input.agentRunId,
+    code: input.code,
+    message: input.message,
+  };
 }

--- a/apps/hyperlocalise-web/src/workflows/steps/provider-agent-translation.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/provider-agent-translation.ts
@@ -1,0 +1,9 @@
+import { executeProviderAgentTranslation } from "@/lib/providers/provider-agent-translate";
+
+export async function executeProviderAgentTranslationStep(input: {
+  agentRunId: string;
+  organizationId: string;
+}) {
+  "use step";
+  return executeProviderAgentTranslation(input);
+}


### PR DESCRIPTION
Run translate-with-agent actions through a queued workflow that pulls TMS content, generates proposed translations, and stores diffs on agent runs without write-back.

## What changed

<!-- Describe the change and why it is needed. -->

## How to test

<!-- List manual checks or commands used to verify this change. -->

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review
