### PR TITLE
feat(tms): Phrase credential validation and project listing (HL-348)

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/external-tms-provider-credential/external-tms-provider-credential.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/external-tms-provider-credential/external-tms-provider-credential.route.ts
@@ -4,6 +4,7 @@ import { validator } from "hono/validator";
 import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
 import { notFoundResponse } from "@/api/response.schema";
 import { fetchCrowdinProjects } from "@/lib/providers/crowdin/crowdin-project-fetcher";
+import { fetchPhraseProjects } from "@/lib/providers/phrase/phrase-project-fetcher";
 import { fetchSmartlingProjects } from "@/lib/providers/smartling/smartling-project-fetcher";
 import {
   syncExternalTmsProjects,
@@ -168,6 +169,7 @@ export function createExternalTmsProviderCredentialRoutes() {
           Record<(typeof providerKind)["data"], ExternalTmsProjectFetcher>
         > = {
           crowdin: fetchCrowdinProjects,
+          phrase: fetchPhraseProjects,
           smartling: fetchSmartlingProjects,
         };
 

--- a/apps/hyperlocalise-web/src/api/routes/external-tms-provider-credential/external-tms-provider-credential.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/external-tms-provider-credential/external-tms-provider-credential.test.ts
@@ -1133,10 +1133,41 @@ describe("externalTmsProviderCredentialRoutes", () => {
     expect(runs[0]?.status).toBe("failed");
   });
 
-  it("returns 501 for providers that do not yet support project sync", async () => {
+  it("syncs phrase projects and locales into connected TMS project records", async () => {
     const identity = fixture.createWorkosIdentityWithRole("admin");
     const headers = await fixture.authHeadersFor(identity);
     const authContext = globalThis.__testApiAuthContext!;
+
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes("/projects?page=1")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "proj-1",
+              name: "Marketing Website",
+              slug: "marketing-website",
+              main_format: "json",
+              account: { id: "acct-1", name: "Acme", slug: "acme" },
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      if (url.includes("/projects/proj-1/locales")) {
+        return new Response(
+          JSON.stringify([
+            { id: "loc-en", name: "en", code: "en-US", default: true },
+            { id: "loc-fr", name: "fr", code: "fr-FR", default: false },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify([]), { status: 200 });
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
 
     await upsertOrganizationExternalTmsProviderCredential({
       organizationId: authContext.organization.localOrganizationId,
@@ -1154,6 +1185,74 @@ describe("externalTmsProviderCredentialRoutes", () => {
         param: {
           organizationSlug: identity.organization.slug ?? "missing",
           providerKind: "phrase",
+        },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(200);
+    const data = (await response.json()) as {
+      externalTmsProjectSync: {
+        status: string;
+        counts: {
+          projectsDiscovered: number;
+          projectsSynced: number;
+          projectsFailed: number;
+          localesSynced: number;
+        };
+      };
+    };
+    expect(data.externalTmsProjectSync.status).toBe("succeeded");
+    expect(data.externalTmsProjectSync.counts).toEqual({
+      projectsDiscovered: 1,
+      projectsSynced: 1,
+      projectsFailed: 0,
+      localesSynced: 2,
+    });
+
+    const projects = await db
+      .select()
+      .from(schema.projects)
+      .where(
+        and(
+          eq(schema.projects.organizationId, authContext.organization.localOrganizationId),
+          eq(schema.projects.externalProviderKind, "phrase"),
+        ),
+      );
+
+    expect(projects).toHaveLength(1);
+    expect(projects[0]).toMatchObject({
+      name: "Marketing Website",
+      sourceLocale: "en-US",
+      targetLocales: ["fr-FR"],
+      externalProjectId: "proj-1",
+      externalProjectUrl: "https://app.phrase.com/accounts/acme/projects/marketing-website",
+      isActive: true,
+      source: "external_tms",
+    });
+  });
+
+  it("returns 501 for providers that do not yet support project sync", async () => {
+    const identity = fixture.createWorkosIdentityWithRole("admin");
+    const headers = await fixture.authHeadersFor(identity);
+    const authContext = globalThis.__testApiAuthContext!;
+
+    await upsertOrganizationExternalTmsProviderCredential({
+      organizationId: authContext.organization.localOrganizationId,
+      userId: authContext.user.localUserId,
+      role: authContext.membership.role,
+      providerKind: "lokalise",
+      displayName: "Lokalise",
+      secretMaterial: "lokalise-secret",
+    });
+
+    const response = await client.api.orgs[":organizationSlug"]["external-tms-provider-credential"][
+      ":providerKind"
+    ]["sync-projects"].$post(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing",
+          providerKind: "lokalise",
         },
       },
       { headers },

--- a/apps/hyperlocalise-web/src/lib/providers/external-tms-health-check.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/external-tms-health-check.ts
@@ -4,6 +4,7 @@ import { db, schema } from "@/lib/database";
 import { decryptProviderCredential } from "@/lib/security/provider-credential-crypto";
 
 import type { ExternalTmsProviderKind } from "./organization-external-tms-provider-credentials";
+import { resolvePhraseBaseUrl } from "./phrase/phrase-base-url";
 import { parseSmartlingCredentials } from "./smartling/smartling-credentials";
 import { classifySmartlingHttpError } from "./smartling/smartling-api";
 
@@ -68,6 +69,7 @@ export async function checkExternalTmsProviderHealth(input: {
     providerKind: input.providerKind,
     secretMaterial,
     baseUrl: credential.baseUrl,
+    region: credential.region,
     fetchFn: input.fetchFn ?? fetch,
   });
 
@@ -122,6 +124,7 @@ async function validateExternalTmsCredential(input: {
   providerKind: ExternalTmsProviderKind;
   secretMaterial: string;
   baseUrl: string | null;
+  region: string | null;
   fetchFn: typeof fetch;
 }): Promise<Omit<ExternalTmsHealthCheckResult, "lastSuccessfulSyncAt">> {
   if (input.providerKind === "smartling") {
@@ -272,6 +275,7 @@ function buildValidationRequest(input: {
   providerKind: ExternalTmsProviderKind;
   secretMaterial: string;
   baseUrl: string | null;
+  region: string | null;
 }): { url: string; init: RequestInit } | null {
   switch (input.providerKind) {
     case "crowdin": {
@@ -283,7 +287,10 @@ function buildValidationRequest(input: {
       };
     }
     case "phrase": {
-      const baseUrl = normalizeBaseUrl(input.baseUrl, "https://api.phrase.com/v2");
+      const baseUrl = normalizeBaseUrl(
+        resolvePhraseBaseUrl({ region: input.region, baseUrl: input.baseUrl }),
+        resolvePhraseBaseUrl({}),
+      );
       if (!baseUrl) return null;
       return {
         url: `${baseUrl}/user`,

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-api.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { PhraseApiClient, PhraseApiError } from "./phrase-api";
+import { PHRASE_US_BASE_URL } from "./phrase-base-url";
+
+describe("PhraseApiClient", () => {
+  function createClient(fetchFn: typeof fetch, options?: { region?: string; baseUrl?: string }) {
+    return new PhraseApiClient({
+      token: "test-token",
+      region: options?.region,
+      baseUrl: options?.baseUrl,
+      fetchFn,
+    });
+  }
+
+  it("lists projects with pagination", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      if (String(url).includes("page=1")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "proj-1",
+              name: "Marketing Website",
+              slug: "marketing-website",
+              main_format: "json",
+              account: { id: "acct-1", name: "Acme", slug: "acme" },
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify([]), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    const projects = await client.listProjects();
+
+    expect(projects).toHaveLength(1);
+    expect(projects[0]).toMatchObject({
+      id: "proj-1",
+      name: "Marketing Website",
+      slug: "marketing-website",
+      mainFormat: "json",
+      account: { id: "acct-1", slug: "acme" },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("lists locales for a project", async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        JSON.stringify([
+          { id: "loc-en", name: "en", code: "en-US", default: true },
+          { id: "loc-fr", name: "fr", code: "fr-FR", default: false },
+        ]),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    const locales = await client.listLocales("proj-1");
+
+    expect(locales).toEqual([
+      { id: "loc-en", name: "en", code: "en-US", default: true },
+      { id: "loc-fr", name: "fr", code: "fr-FR", default: false },
+    ]);
+  });
+
+  it("uses the US base URL when region is us", async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(JSON.stringify([]), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock, { region: "us" });
+    await client.listProjects();
+
+    expect(client.resolvedBaseUrl).toBe(PHRASE_US_BASE_URL);
+    expect(String(vi.mocked(fetchMock).mock.calls[0]?.[0])).toContain(PHRASE_US_BASE_URL);
+  });
+
+  it("throws PhraseApiError for non-success responses", async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(JSON.stringify({ message: "Unauthorized" }), { status: 401 });
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+
+    await expect(client.listProjects()).rejects.toBeInstanceOf(PhraseApiError);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-api.ts
@@ -1,0 +1,183 @@
+/**
+ * Phrase Strings API v2 client for project discovery and locale metadata.
+ *
+ * This module only implements endpoints required for the TMS connector
+ * project-scan flow.
+ */
+
+import { resolvePhraseBaseUrl } from "./phrase-base-url";
+
+export interface PhraseApiClientOptions {
+  token: string;
+  region?: string | null;
+  baseUrl?: string | null;
+  fetchFn?: typeof fetch;
+}
+
+export interface PhraseAccount {
+  id: string;
+  name: string;
+  slug: string;
+}
+
+export interface PhraseProject {
+  id: string;
+  name: string;
+  slug: string;
+  mainFormat: string | null;
+  account: PhraseAccount | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+export interface PhraseLocale {
+  id: string;
+  name: string;
+  code: string | null;
+  default: boolean;
+}
+
+export class PhraseApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly responseBody: unknown,
+  ) {
+    super(message);
+    this.name = "PhraseApiError";
+  }
+}
+
+export class PhraseApiClient {
+  private readonly token: string;
+  private readonly baseUrl: string;
+  private readonly fetchFn: typeof fetch;
+
+  constructor(options: PhraseApiClientOptions) {
+    this.token = options.token;
+    this.baseUrl = resolvePhraseBaseUrl({
+      region: options.region,
+      baseUrl: options.baseUrl,
+    });
+    this.fetchFn = options.fetchFn ?? fetch;
+  }
+
+  get resolvedBaseUrl() {
+    return this.baseUrl;
+  }
+
+  async listProjects(): Promise<PhraseProject[]> {
+    const projects: PhraseProject[] = [];
+    let page = 1;
+    const perPage = 100;
+
+    while (true) {
+      const pageItems = await this.get<PhraseProjectApiRecord[]>(
+        `/projects?page=${page}&per_page=${perPage}`,
+      );
+      projects.push(...pageItems.map(normalizePhraseProject));
+
+      if (pageItems.length < perPage) {
+        break;
+      }
+
+      page += 1;
+    }
+
+    return projects;
+  }
+
+  async listLocales(projectId: string): Promise<PhraseLocale[]> {
+    const locales: PhraseLocale[] = [];
+    let page = 1;
+    const perPage = 100;
+
+    while (true) {
+      const pageItems = await this.get<PhraseLocaleApiRecord[]>(
+        `/projects/${encodeURIComponent(projectId)}/locales?page=${page}&per_page=${perPage}`,
+      );
+      locales.push(...pageItems.map(normalizePhraseLocale));
+
+      if (pageItems.length < perPage) {
+        break;
+      }
+
+      page += 1;
+    }
+
+    return locales;
+  }
+
+  private authHeaders(): Record<string, string> {
+    return {
+      Authorization: `token ${this.token}`,
+    };
+  }
+
+  private async get<T>(path: string): Promise<T> {
+    return this.request<T>(path, {
+      method: "GET",
+      headers: this.authHeaders(),
+    });
+  }
+
+  private async request<T>(path: string, init: RequestInit): Promise<T> {
+    const url = `${this.baseUrl}${path}`;
+    const response = await this.fetchFn(url, init);
+
+    if (!response.ok) {
+      let body: unknown;
+      try {
+        body = await response.json();
+      } catch {
+        body = await response.text().catch(() => null);
+      }
+
+      throw new PhraseApiError(
+        `Phrase API returned HTTP ${response.status} for ${path}`,
+        response.status,
+        body,
+      );
+    }
+
+    return response.json() as Promise<T>;
+  }
+}
+
+type PhraseProjectApiRecord = {
+  id: string;
+  name: string;
+  slug: string;
+  main_format?: string | null;
+  account?: PhraseAccount | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+};
+
+type PhraseLocaleApiRecord = {
+  id: string;
+  name: string;
+  code?: string | null;
+  default?: boolean;
+};
+
+function normalizePhraseProject(project: PhraseProjectApiRecord): PhraseProject {
+  return {
+    id: project.id,
+    name: project.name,
+    slug: project.slug,
+    mainFormat: project.main_format ?? null,
+    account: project.account ?? null,
+    createdAt: project.created_at ?? null,
+    updatedAt: project.updated_at ?? null,
+  };
+}
+
+function normalizePhraseLocale(locale: PhraseLocaleApiRecord): PhraseLocale {
+  return {
+    id: locale.id,
+    name: locale.name,
+    code: locale.code ?? null,
+    default: locale.default ?? false,
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-base-url.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-base-url.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { PHRASE_EU_BASE_URL, PHRASE_US_BASE_URL, resolvePhraseBaseUrl } from "./phrase-base-url";
+
+describe("resolvePhraseBaseUrl", () => {
+  it("defaults to the EU datacenter when region and baseUrl are omitted", () => {
+    expect(resolvePhraseBaseUrl({})).toBe(PHRASE_EU_BASE_URL);
+  });
+
+  it("selects the US datacenter when region is us", () => {
+    expect(resolvePhraseBaseUrl({ region: "us" })).toBe(PHRASE_US_BASE_URL);
+    expect(resolvePhraseBaseUrl({ region: "USA" })).toBe(PHRASE_US_BASE_URL);
+  });
+
+  it("selects the EU datacenter when region is eu", () => {
+    expect(resolvePhraseBaseUrl({ region: "eu" })).toBe(PHRASE_EU_BASE_URL);
+    expect(resolvePhraseBaseUrl({ region: "Europe" })).toBe(PHRASE_EU_BASE_URL);
+  });
+
+  it("prefers an explicit baseUrl over region defaults", () => {
+    expect(
+      resolvePhraseBaseUrl({
+        region: "us",
+        baseUrl: "https://api.phrase.test/v2/",
+      }),
+    ).toBe("https://api.phrase.test/v2");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-base-url.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-base-url.ts
@@ -1,0 +1,19 @@
+export const PHRASE_EU_BASE_URL = "https://api.phrase.com/v2";
+export const PHRASE_US_BASE_URL = "https://api.us.app.phrase.com/v2";
+
+export function resolvePhraseBaseUrl(input: {
+  region?: string | null;
+  baseUrl?: string | null;
+}): string {
+  const explicitBaseUrl = input.baseUrl?.trim();
+  if (explicitBaseUrl) {
+    return explicitBaseUrl.replace(/\/+$/, "");
+  }
+
+  const region = input.region?.trim().toLowerCase();
+  if (region === "us" || region === "usa" || region === "united states") {
+    return PHRASE_US_BASE_URL;
+  }
+
+  return PHRASE_EU_BASE_URL;
+}

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-project-fetcher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-project-fetcher.test.ts
@@ -1,9 +1,11 @@
-import { describe, expect, it, vi } from "vite-plus/test";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { fetchPhraseProjects } from "./phrase-project-fetcher";
 import { PHRASE_US_BASE_URL } from "./phrase-base-url";
 
 describe("fetchPhraseProjects", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
   const credential = {
     id: "cred-1",
     organizationId: "org-1",

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-project-fetcher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-project-fetcher.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { fetchPhraseProjects } from "./phrase-project-fetcher";
+import { PHRASE_US_BASE_URL } from "./phrase-base-url";
+
+describe("fetchPhraseProjects", () => {
+  const credential = {
+    id: "cred-1",
+    organizationId: "org-1",
+    providerKind: "phrase" as const,
+    displayName: "Phrase",
+    region: null,
+    baseUrl: null,
+    validationStatus: "connected",
+    validationMessage: null,
+    lastValidatedAt: null,
+    encryptionAlgorithm: "aes-256-gcm",
+    keyVersion: 1,
+    ciphertext: "cipher",
+    iv: "iv",
+    authTag: "tag",
+    maskedSecretSuffix: "cret",
+    createdByUserId: "user-1",
+    updatedByUserId: "user-1",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  it("normalizes projects and locales into the shared provider model", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      if (String(url).endsWith("/projects?page=1&per_page=100")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "proj-1",
+              name: "Marketing Website",
+              slug: "marketing-website",
+              main_format: "json",
+              account: { id: "acct-1", name: "Acme", slug: "acme" },
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      if (String(url).includes("/projects/proj-1/locales")) {
+        return new Response(
+          JSON.stringify([
+            { id: "loc-en", name: "en", code: "en-US", default: true },
+            { id: "loc-fr", name: "fr", code: "fr-FR", default: false },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify([]), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const projects = await fetchPhraseProjects({
+      organizationId: "org-1",
+      providerKind: "phrase",
+      credential,
+      secretMaterial: "phrase-token",
+    });
+
+    expect(projects).toHaveLength(1);
+    expect(projects[0]).toEqual({
+      externalProjectId: "proj-1",
+      name: "Marketing Website",
+      sourceLocale: "en-US",
+      targetLocales: ["fr-FR"],
+      externalProjectUrl: "https://app.phrase.com/accounts/acme/projects/marketing-website",
+      isActive: true,
+      metadata: {
+        slug: "marketing-website",
+        mainFormat: "json",
+        accountId: "acct-1",
+        accountSlug: "acme",
+        locales: [
+          { id: "loc-en", name: "en", code: "en-US", default: true },
+          { id: "loc-fr", name: "fr", code: "fr-FR", default: false },
+        ],
+      },
+    });
+  });
+
+  it("uses the US datacenter when region is us", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      if (String(url).includes("/projects?")) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      return new Response(JSON.stringify([]), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchPhraseProjects({
+      organizationId: "org-1",
+      providerKind: "phrase",
+      credential: { ...credential, region: "us" },
+      secretMaterial: "phrase-token",
+    });
+
+    expect(String(vi.mocked(fetchMock).mock.calls[0]?.[0])).toContain(PHRASE_US_BASE_URL);
+  });
+
+  it("throws phrase_auth_invalid when authentication fails", async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(JSON.stringify({ message: "Unauthorized" }), { status: 401 });
+    }) as unknown as typeof fetch;
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      fetchPhraseProjects({
+        organizationId: "org-1",
+        providerKind: "phrase",
+        credential,
+        secretMaterial: "invalid-token",
+      }),
+    ).rejects.toThrow("phrase_auth_invalid");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-project-fetcher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-project-fetcher.ts
@@ -1,0 +1,127 @@
+import type { ExternalTmsProjectFetcher } from "@/lib/providers/external-tms-project-sync";
+
+import { PhraseApiClient, PhraseApiError } from "./phrase-api";
+
+const LOCALE_FETCH_CONCURRENCY = 15;
+
+export const fetchPhraseProjects: ExternalTmsProjectFetcher = async ({
+  credential,
+  secretMaterial,
+}) => {
+  const client = new PhraseApiClient({
+    token: secretMaterial,
+    region: credential.region,
+    baseUrl: credential.baseUrl,
+  });
+
+  let projects;
+  try {
+    projects = await client.listProjects();
+  } catch (error) {
+    if (error instanceof PhraseApiError && error.status === 401) {
+      throw new Error("phrase_auth_invalid");
+    }
+    throw error;
+  }
+
+  const results = await mapWithConcurrency(projects, LOCALE_FETCH_CONCURRENCY, async (project) => {
+    try {
+      const locales = await client.listLocales(project.id);
+      const { sourceLocale, targetLocales } = partitionPhraseLocales(locales);
+
+      return {
+        externalProjectId: project.id,
+        name: project.name,
+        sourceLocale,
+        targetLocales,
+        externalProjectUrl: buildPhraseProjectUrl(project),
+        isActive: true,
+        metadata: {
+          slug: project.slug,
+          mainFormat: project.mainFormat,
+          accountId: project.account?.id ?? null,
+          accountSlug: project.account?.slug ?? null,
+          locales: locales.map((locale) => ({
+            id: locale.id,
+            name: locale.name,
+            code: locale.code,
+            default: locale.default,
+          })),
+        },
+      };
+    } catch (error) {
+      if (error instanceof PhraseApiError && error.status === 401) {
+        throw new Error("phrase_auth_invalid");
+      }
+
+      return {
+        externalProjectId: project.id,
+        name: project.name,
+        sourceLocale: null,
+        targetLocales: [],
+        externalProjectUrl: buildPhraseProjectUrl(project),
+        isActive: true,
+        metadata: {
+          slug: project.slug,
+          mainFormat: project.mainFormat,
+          accountId: project.account?.id ?? null,
+          accountSlug: project.account?.slug ?? null,
+          syncWarning: error instanceof Error ? error.message : "locale_fetch_failed",
+        },
+      };
+    }
+  });
+
+  return results;
+};
+
+function partitionPhraseLocales(
+  locales: Array<{ name: string; code: string | null; default: boolean }>,
+) {
+  const source = locales.find((locale) => locale.default);
+  const sourceLocale = localeIdentifier(source);
+  const targetLocales = locales
+    .filter((locale) => !locale.default)
+    .map((locale) => localeIdentifier(locale))
+    .filter((locale): locale is string => Boolean(locale));
+
+  return {
+    sourceLocale,
+    targetLocales,
+  };
+}
+
+function localeIdentifier(locale: { name: string; code: string | null } | undefined) {
+  if (!locale) return null;
+  return locale.code?.trim() || locale.name.trim() || null;
+}
+
+function buildPhraseProjectUrl(project: { slug: string; account: { slug: string } | null }) {
+  if (!project.account?.slug) return null;
+  return `https://app.phrase.com/accounts/${project.account.slug}/projects/${project.slug}`;
+}
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T) => Promise<R>,
+) {
+  const results: R[] = Array.from({ length: items.length });
+  let nextIndex = 0;
+
+  async function worker() {
+    while (true) {
+      const currentIndex = nextIndex;
+      nextIndex += 1;
+      if (currentIndex >= items.length) {
+        return;
+      }
+
+      results[currentIndex] = await mapper(items[currentIndex] as T);
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, () => worker());
+  await Promise.all(workers);
+  return results;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the first Phrase Strings connector slice for the unified TMS workspace (HL-348).

- Resolves Phrase API base URLs from stored `region` and optional `baseUrl` (EU default, US datacenter support).
- Reuses the existing health-check flow with `GET /user` and `Authorization: token …` validation.
- Adds project discovery via `GET /projects` and per-project locale listing via `GET /projects/{id}/locales`.
- Normalizes Phrase project/locale metadata into connected TMS `projects` records through the existing idempotent sync orchestrator.
- Registers `phrase` on `POST …/sync-projects` (previously returned 501).

## Testing

- `vp test src/lib/providers/phrase` — 11 tests passing (base URL EU/US selection, API client, project fetcher, auth errors).
- `vp check --fix` on touched files — clean.
- Route integration tests in `external-tms-provider-credential.test.ts` require a configured Postgres `.env` (same as existing Crowdin/Smartling route tests).

## Linear

Closes HL-348
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-348](https://linear.app/hyperlocalise/issue/HL-348/implement-phrase-credential-validation-and-project-listing)

<div><a href="https://cursor.com/agents/bc-92ab8108-488f-4f4b-9756-e96ec2aa3eed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92ab8108-488f-4f4b-9756-e96ec2aa3eed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

