### PR TITLE
docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,3 +26,43 @@ In apps/hyperlocalise-web, if we change these folders:
 - Run `vp check --fix`
 
 Do not finalize work until all commands complete successfully.
+
+## Cursor Cloud specific instructions
+
+### Prerequisites
+
+Docker must be running for the web app (PostgreSQL). Start the daemon and compose stack:
+
+```
+sudo dockerd &>/tmp/dockerd.log &
+sudo chmod 666 /var/run/docker.sock
+docker compose up -d          # starts Postgres 18 on :5432
+```
+
+Ensure `$(go env GOPATH)/bin` is on PATH for `golangci-lint`. The Makefile `bootstrap` target installs it, but it may build with a lower Go version. If `make lint` fails with a Go version mismatch, rebuild it from the workspace module:
+
+```
+go build -o $(go env GOPATH)/bin/golangci-lint github.com/golangci/golangci-lint/v2/cmd/golangci-lint
+```
+
+### Web app (apps/hyperlocalise-web)
+
+- Use `vp run dev` (not `vp dev`) to start the Next.js dev server — `vp dev` starts Vite directly.
+- Before the dev server works, create `apps/hyperlocalise-web/.env` with at minimum:
+  ```
+  DATABASE_URL=postgresql://hyperlocalise:hyperlocalise@localhost:5432/hyperlocalise
+  PROVIDER_CREDENTIALS_MASTER_KEY=MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=
+  NEXT_PUBLIC_WAITLIST_URL=https://example.com/waitlist
+  WORKOS_API_KEY=sk_test_placeholder
+  WORKOS_CLIENT_ID=client_placeholder
+  WORKOS_REDIRECT_URI=http://localhost:3000/auth/callback
+  NEXT_PUBLIC_WORKOS_REDIRECT_URI=http://localhost:3000/auth/callback
+  WORKOS_COOKIE_PASSWORD=this-is-a-test-cookie-password-at-least-32-characters
+  ```
+- Run `vp run db:migrate` after starting Postgres to apply Drizzle migrations.
+- The `make test` target uses coverage flags that may warn about a missing `covdata` tool — all actual tests still pass. Use `go test ./...` if you want a clean exit code without coverage.
+
+### CLI (Go)
+
+- Standard commands per `AGENTS.md`: `make bootstrap`, `make fmt`, `make lint`, `make test`.
+- Run the CLI with `go run ./apps/cli <command>`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Added `## Cursor Cloud specific instructions` section to `AGENTS.md` with non-obvious setup caveats discovered during environment setup:

- Docker/PostgreSQL startup instructions for the web app
- Gotcha: `vp run dev` (not `vp dev`) needed for Next.js dev server
- Required `.env` vars for the web app dev server (WorkOS AuthKit middleware requires `NEXT_PUBLIC_WORKOS_REDIRECT_URI`)
- `golangci-lint` Go version mismatch workaround
- `make test` `covdata` tool warning note

## How to test

These are documentation-only changes. Verify by reading the updated `AGENTS.md`.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db4c4bf5-3691-45d0-8b1d-316b19a4471d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db4c4bf5-3691-45d0-8b1d-316b19a4471d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

