### PR TITLE
🧪 Scout: support non-ASCII letters in ICU placeholders

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -15,3 +15,7 @@
 ## 2025-05-15 - [ICU Select Argument Parity]
 **Learning:** `SelectElement` arguments were missing from the extracted `Placeholders` list in `Invariant` metadata, despite being structural arguments like `PluralElement` arguments. This inconsistency can lead to incomplete placeholder validation in downstream tools.
 **Action:** Ensure all ICU argument-bearing elements (`Argument`, `Number`, `Date`, `Time`, `Plural`, `Select`) call `appendPlaceholder` during invariant collection.
+
+## 2025-05-22 - [Unicode Placeholder Support]
+**Learning:** ICU and mustache-style placeholders were restricted to ASCII letters, causing validation failures for non-Latin scripts or mathematical symbols (e.g., {π}).
+**Action:** Use `unicode.IsLetter` in placeholder validation helpers to ensure broad script support while maintaining structural integrity.

--- a/internal/i18n/icuparser/invariant.go
+++ b/internal/i18n/icuparser/invariant.go
@@ -5,6 +5,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"unicode"
 )
 
 type Invariant struct {
@@ -321,16 +322,13 @@ func isASCIIDigit(b byte) bool {
 }
 
 func isPlaceholderFirstRune(r rune) bool {
-	return isASCIILetter(r) || isASCIIDigitRune(r) || r == '_' || r == '$'
+	return unicode.IsLetter(r) || isASCIIDigitRune(r) || r == '_' || r == '$'
 }
 
 func isPlaceholderSubsequentRune(r rune) bool {
-	return isASCIILetter(r) || isASCIIDigitRune(r) || r == '_' || r == '.' || r == '-' || r == '$'
+	return unicode.IsLetter(r) || isASCIIDigitRune(r) || r == '_' || r == '.' || r == '-' || r == '$'
 }
 
-func isASCIILetter(r rune) bool {
-	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
-}
 
 func isASCIIDigitRune(r rune) bool {
 	return r >= '0' && r <= '9'

--- a/internal/i18n/icuparser/invariant.go
+++ b/internal/i18n/icuparser/invariant.go
@@ -329,7 +329,6 @@ func isPlaceholderSubsequentRune(r rune) bool {
 	return unicode.IsLetter(r) || isASCIIDigitRune(r) || r == '_' || r == '.' || r == '-' || r == '$'
 }
 
-
 func isASCIIDigitRune(r rune) bool {
 	return r >= '0' && r <= '9'
 }

--- a/internal/i18n/icuparser/invariant_test.go
+++ b/internal/i18n/icuparser/invariant_test.go
@@ -138,6 +138,11 @@ func TestParseInvariantMustacheNormalization(t *testing.T) {
 			msg:  "Value: {{my-dash-id}}",
 			want: []string{"my-dash-id"},
 		},
+		{
+			name: "mustache with unicode",
+			msg:  "Hello {{π}}",
+			want: []string{"π"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -242,6 +247,27 @@ func TestSelectArgumentInPlaceholders(t *testing.T) {
 
 	if !found {
 		t.Errorf("expected 'gender' in placeholders, got %v", inv.Placeholders)
+	}
+}
+
+func TestUnicodePlaceholderInPlaceholders(t *testing.T) {
+	// Unicode letters (e.g. π) MUST be supported in placeholders.
+	msg := "Hello {π}"
+	inv, err := ParseInvariant(msg)
+	if err != nil {
+		t.Fatalf("ParseInvariant failed: %v", err)
+	}
+
+	found := false
+	for _, p := range inv.Placeholders {
+		if p == "π" {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Errorf("expected 'π' in placeholders, got %v", inv.Placeholders)
 	}
 }
 


### PR DESCRIPTION
Expanded placeholder name validation to include Unicode letters, improving support for diverse languages and symbols. Verified with new test cases in `invariant_test.go` covering both standard ICU and mustache-style fallback.

---
*PR created automatically by Jules for task [971642249305691734](https://jules.google.com/task/971642249305691734) started by @cungminh2710*