### PR TITLE
feat(phrase): implement Phrase keys and locale file discovery (HL-349)

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -22,6 +22,7 @@ import {
   type ExternalTmsJobTaskFetcher,
 } from "@/lib/providers/external-tms-job-sync";
 import type { ExternalTmsProviderKind } from "@/lib/providers/organization-external-tms-provider-credentials";
+import { fetchPhraseFileKeys } from "@/lib/providers/phrase/phrase-file-fetcher";
 import { fetchSmartlingFileKeys } from "@/lib/providers/smartling/smartling-file-fetcher";
 import { fetchSmartlingJobTasks } from "@/lib/providers/smartling/smartling-job-fetcher";
 import {
@@ -300,6 +301,7 @@ const fileKeyFetchersByProvider: Partial<
   Record<ExternalTmsProviderKind, ExternalTmsFileKeyFetcher>
 > = {
   crowdin: fetchCrowdinFileKeys,
+  phrase: fetchPhraseFileKeys,
   smartling: fetchSmartlingFileKeys,
 };
 

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-api.test.ts
@@ -79,6 +79,77 @@ describe("PhraseApiClient", () => {
     expect(String(vi.mocked(fetchMock).mock.calls[0]?.[0])).toContain(PHRASE_US_BASE_URL);
   });
 
+  it("lists keys, uploads, and translations with branch filters", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      const path = String(url);
+
+      if (path.includes("/keys")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "key-1",
+              name: "home.hero.title",
+              tags: ["app"],
+              custom_metadata: { screen: "home" },
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/uploads")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "upload-1",
+              filename: "home.json",
+              format: "json",
+              tags: ["app"],
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/translations")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "tr-1",
+              key_id: "key-1",
+              locale_name: "fr",
+              content: "Bonjour",
+              state: "translated",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify([]), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    const keys = await client.listKeys("proj-1", { branch: "feature" });
+    const uploads = await client.listUploads("proj-1", { branch: "feature" });
+    const translations = await client.listTranslations("proj-1", "fr", { branch: "feature" });
+
+    expect(keys[0]).toMatchObject({
+      id: "key-1",
+      name: "home.hero.title",
+      tags: ["app"],
+      customMetadata: { screen: "home" },
+    });
+    expect(uploads[0]).toMatchObject({ id: "upload-1", filename: "home.json", format: "json" });
+    expect(translations[0]).toMatchObject({
+      keyId: "key-1",
+      localeName: "fr",
+      content: "Bonjour",
+      state: "translated",
+    });
+    expect(String(vi.mocked(fetchMock).mock.calls[0]?.[0])).toContain("branch=feature");
+  });
+
   it("throws PhraseApiError for non-success responses", async () => {
     const fetchMock = vi.fn(async () => {
       return new Response(JSON.stringify({ message: "Unauthorized" }), { status: 401 });

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-api.ts
@@ -1,8 +1,5 @@
 /**
- * Phrase Strings API v2 client for project discovery and locale metadata.
- *
- * This module only implements endpoints required for the TMS connector
- * project-scan flow.
+ * Phrase Strings API v2 client for TMS connector discovery and file/key sync.
  */
 
 import { resolvePhraseBaseUrl } from "./phrase-base-url";
@@ -36,6 +33,66 @@ export interface PhraseLocale {
   code: string | null;
   default: boolean;
 }
+
+export interface PhraseBranch {
+  name: string;
+  merged: boolean | null;
+  state: string | null;
+}
+
+export interface PhraseKey {
+  id: string;
+  name: string;
+  description: string | null;
+  nameHash: string | null;
+  plural: boolean;
+  useOrdinalRules: boolean;
+  tags: string[];
+  dataType: string | null;
+  customMetadata: Record<string, unknown>;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+export interface PhraseTranslation {
+  id: string;
+  keyId: string;
+  localeName: string;
+  content: string | null;
+  state: string | null;
+  unverified: boolean;
+  excluded: boolean;
+  pluralSuffix: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+export interface PhraseUpload {
+  id: string;
+  filename: string;
+  format: string | null;
+  state: string | null;
+  tag: string | null;
+  tags: string[];
+  url: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+export interface PhraseLocaleDownloadMetadata {
+  localeId: string;
+  localeName: string;
+  fileFormat: string;
+  branch: string | null;
+  tags: string[];
+  downloadPath: string;
+  options: Record<string, unknown>;
+}
+
+export type PhraseListOptions = {
+  branch?: string | null;
+  perPage?: number;
+};
 
 export class PhraseApiError extends Error {
   constructor(
@@ -87,16 +144,108 @@ export class PhraseApiClient {
     return projects;
   }
 
-  async listLocales(projectId: string): Promise<PhraseLocale[]> {
-    const locales: PhraseLocale[] = [];
+  async listLocales(projectId: string, options: PhraseListOptions = {}): Promise<PhraseLocale[]> {
+    return this.paginate({
+      buildPath: (page, perPage) =>
+        this.buildPath(`/projects/${encodeURIComponent(projectId)}/locales`, {
+          page,
+          per_page: perPage,
+          branch: options.branch,
+        }),
+      normalize: (record) => normalizePhraseLocale(record as PhraseLocaleApiRecord),
+    });
+  }
+
+  async listBranches(projectId: string): Promise<PhraseBranch[]> {
+    return this.paginate({
+      buildPath: (page, perPage) =>
+        this.buildPath(`/projects/${encodeURIComponent(projectId)}/branches`, {
+          page,
+          per_page: perPage,
+        }),
+      normalize: (record) => normalizePhraseBranch(record as PhraseBranchApiRecord),
+    });
+  }
+
+  async listKeys(projectId: string, options: PhraseListOptions = {}): Promise<PhraseKey[]> {
+    return this.paginate({
+      buildPath: (page, perPage) =>
+        this.buildPath(`/projects/${encodeURIComponent(projectId)}/keys`, {
+          page,
+          per_page: perPage,
+          branch: options.branch,
+        }),
+      normalize: (record) => normalizePhraseKey(record as PhraseKeyApiRecord),
+    });
+  }
+
+  async listTranslations(
+    projectId: string,
+    localeName: string,
+    options: PhraseListOptions = {},
+  ): Promise<PhraseTranslation[]> {
+    return this.paginate({
+      buildPath: (page, perPage) =>
+        this.buildPath(`/projects/${encodeURIComponent(projectId)}/translations`, {
+          page,
+          per_page: perPage,
+          locale_name: localeName,
+          branch: options.branch,
+        }),
+      normalize: (record) => normalizePhraseTranslation(record as PhraseTranslationApiRecord),
+    });
+  }
+
+  async listUploads(projectId: string, options: PhraseListOptions = {}): Promise<PhraseUpload[]> {
+    return this.paginate({
+      buildPath: (page, perPage) =>
+        this.buildPath(`/projects/${encodeURIComponent(projectId)}/uploads`, {
+          page,
+          per_page: perPage,
+          branch: options.branch,
+        }),
+      normalize: (record) => normalizePhraseUpload(record as PhraseUploadApiRecord),
+    });
+  }
+
+  buildLocaleDownloadMetadata(input: {
+    projectId: string;
+    locale: PhraseLocale;
+    fileFormat: string | null;
+    branch?: string | null;
+    tags?: string[];
+  }): PhraseLocaleDownloadMetadata {
+    const localeName = input.locale.name.trim();
+    const fileFormat = input.fileFormat?.trim() || "json";
+    const branch = input.branch?.trim() || null;
+    const tags = input.tags ?? [];
+
+    return {
+      localeId: input.locale.id,
+      localeName,
+      fileFormat,
+      branch,
+      tags,
+      downloadPath: `/projects/${encodeURIComponent(input.projectId)}/locales/${encodeURIComponent(input.locale.id)}/download`,
+      options: {
+        file_format: fileFormat,
+        ...(branch ? { branch } : {}),
+        ...(tags.length > 0 ? { tags: tags.join(",") } : {}),
+      },
+    };
+  }
+
+  private async paginate<T>(input: {
+    buildPath: (page: number, perPage: number) => string;
+    normalize: (record: unknown) => T;
+  }): Promise<T[]> {
+    const items: T[] = [];
     let page = 1;
     const perPage = 100;
 
     while (true) {
-      const pageItems = await this.get<PhraseLocaleApiRecord[]>(
-        `/projects/${encodeURIComponent(projectId)}/locales?page=${page}&per_page=${perPage}`,
-      );
-      locales.push(...pageItems.map(normalizePhraseLocale));
+      const pageItems = await this.get<unknown[]>(input.buildPath(page, perPage));
+      items.push(...pageItems.map(input.normalize));
 
       if (pageItems.length < perPage) {
         break;
@@ -105,7 +254,23 @@ export class PhraseApiClient {
       page += 1;
     }
 
-    return locales;
+    return items;
+  }
+
+  private buildPath(
+    path: string,
+    query: Record<string, string | number | null | undefined>,
+  ): string {
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(query)) {
+      if (value === null || value === undefined || value === "") {
+        continue;
+      }
+      params.set(key, String(value));
+    }
+
+    const queryString = params.toString();
+    return queryString ? `${path}?${queryString}` : path;
   }
 
   private authHeaders(): Record<string, string> {
@@ -161,6 +326,60 @@ type PhraseLocaleApiRecord = {
   default?: boolean;
 };
 
+type PhraseBranchApiRecord = {
+  name: string;
+  merged?: boolean | null;
+  state?: string | null;
+};
+
+type PhraseKeyApiRecord = {
+  id: string;
+  name: string;
+  description?: string | null;
+  name_hash?: string | null;
+  plural?: boolean;
+  use_ordinal_rules?: boolean;
+  tags?: string[];
+  data_type?: string | null;
+  custom_metadata?: Record<string, unknown> | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+};
+
+type PhraseTranslationApiRecord = {
+  id: string;
+  key_id: string;
+  locale_name?: string;
+  content?: string | null;
+  state?: string | null;
+  unverified?: boolean;
+  excluded?: boolean;
+  plural_suffix?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+  key?: {
+    id: string;
+    name?: string;
+  };
+  locale?: {
+    id?: string;
+    name?: string;
+    code?: string | null;
+  };
+};
+
+type PhraseUploadApiRecord = {
+  id: string;
+  filename: string;
+  format?: string | null;
+  state?: string | null;
+  tag?: string | null;
+  tags?: string[];
+  url?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+};
+
 function normalizePhraseProject(project: PhraseProjectApiRecord): PhraseProject {
   return {
     id: project.id,
@@ -179,5 +398,65 @@ function normalizePhraseLocale(locale: PhraseLocaleApiRecord): PhraseLocale {
     name: locale.name,
     code: locale.code ?? null,
     default: locale.default ?? false,
+  };
+}
+
+function normalizePhraseBranch(branch: PhraseBranchApiRecord): PhraseBranch {
+  return {
+    name: branch.name,
+    merged: branch.merged ?? null,
+    state: branch.state ?? null,
+  };
+}
+
+function normalizePhraseKey(key: PhraseKeyApiRecord): PhraseKey {
+  return {
+    id: key.id,
+    name: key.name,
+    description: key.description ?? null,
+    nameHash: key.name_hash ?? null,
+    plural: key.plural ?? false,
+    useOrdinalRules: key.use_ordinal_rules ?? false,
+    tags: key.tags ?? [],
+    dataType: key.data_type ?? null,
+    customMetadata: key.custom_metadata ?? {},
+    createdAt: key.created_at ?? null,
+    updatedAt: key.updated_at ?? null,
+  };
+}
+
+function normalizePhraseTranslation(translation: PhraseTranslationApiRecord): PhraseTranslation {
+  const keyId = translation.key_id || translation.key?.id || "";
+  const localeName =
+    translation.locale_name?.trim() ||
+    translation.locale?.name?.trim() ||
+    translation.locale?.code?.trim() ||
+    "";
+
+  return {
+    id: translation.id,
+    keyId,
+    localeName,
+    content: translation.content ?? null,
+    state: translation.state ?? null,
+    unverified: translation.unverified ?? false,
+    excluded: translation.excluded ?? false,
+    pluralSuffix: translation.plural_suffix ?? null,
+    createdAt: translation.created_at ?? null,
+    updatedAt: translation.updated_at ?? null,
+  };
+}
+
+function normalizePhraseUpload(upload: PhraseUploadApiRecord): PhraseUpload {
+  return {
+    id: upload.id,
+    filename: upload.filename,
+    format: upload.format ?? null,
+    state: upload.state ?? null,
+    tag: upload.tag ?? null,
+    tags: upload.tags ?? [],
+    url: upload.url ?? null,
+    createdAt: upload.created_at ?? null,
+    updatedAt: upload.updated_at ?? null,
   };
 }

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-file-fetcher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-file-fetcher.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { fetchPhraseFileKeys } from "./phrase-file-fetcher";
+
+describe("fetchPhraseFileKeys", () => {
+  let originalFetch: typeof fetch;
+
+  const credential = {
+    id: "cred-1",
+    organizationId: "org-1",
+    providerKind: "phrase" as const,
+    displayName: "Phrase",
+    region: null,
+    baseUrl: null,
+    validationStatus: "connected",
+    validationMessage: null,
+    lastValidatedAt: null,
+    encryptionAlgorithm: "aes-256-gcm",
+    keyVersion: 1,
+    ciphertext: "cipher",
+    iv: "iv",
+    authTag: "tag",
+    maskedSecretSuffix: "cret",
+    createdByUserId: "user-1",
+    updatedByUserId: "user-1",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  const project = {
+    providerMetadata: {
+      slug: "marketing-website",
+      mainFormat: "json",
+      accountSlug: "acme",
+    },
+  } as never;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("returns normalized upload and key metadata with branch and tag filters", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      const path = String(url);
+
+      if (path.includes("/branches")) {
+        return new Response(
+          JSON.stringify([{ name: "feature", merged: false, state: "success" }]),
+          {
+            status: 200,
+          },
+        );
+      }
+
+      if (path.includes("/locales")) {
+        return new Response(
+          JSON.stringify([
+            { id: "loc-en", name: "en", code: "en-US", default: true },
+            { id: "loc-fr", name: "fr", code: "fr-FR", default: false },
+            { id: "loc-de", name: "de", code: "de-DE", default: false },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/uploads") && path.includes("branch=feature")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "upload-feature",
+              filename: "home.json",
+              format: "json",
+              state: "success",
+              tags: ["app"],
+              url: "https://app.phrase.com/upload/feature",
+              updated_at: "2026-05-01T00:00:00Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/uploads")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "upload-1",
+              filename: "home.json",
+              format: "json",
+              state: "success",
+              tags: ["app"],
+              url: "https://app.phrase.com/upload/1",
+              updated_at: "2026-05-01T00:00:00Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/keys") && path.includes("branch=feature")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "key-feature",
+              name: "feature.title",
+              description: "Feature headline",
+              tags: ["app"],
+              custom_metadata: { screen: "home" },
+              data_type: "string",
+              updated_at: "2026-05-02T00:00:00Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/keys")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "key-1",
+              name: "home.hero.title",
+              description: "Hero headline",
+              tags: ["app", "marketing"],
+              custom_metadata: { screen: "home" },
+              data_type: "icu",
+              updated_at: "2026-05-02T00:00:00Z",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/translations") && path.includes("locale_name=fr")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "tr-fr-1",
+              key_id: "key-1",
+              locale_name: "fr",
+              content: "Bonjour",
+              state: "translated",
+              unverified: false,
+              excluded: false,
+            },
+            {
+              id: "tr-fr-feature",
+              key_id: "key-feature",
+              locale_name: "fr",
+              content: "Feature",
+              state: "translated",
+              unverified: false,
+              excluded: false,
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/translations") && path.includes("locale_name=de")) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+
+      if (path.includes("/translations") && path.includes("locale_name=en")) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+
+      return new Response(JSON.stringify([]), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    globalThis.fetch = fetchMock;
+
+    const result = await fetchPhraseFileKeys({
+      organizationId: "org-1",
+      projectId: "project-1",
+      providerKind: "phrase",
+      externalProjectId: "proj-1",
+      credential,
+      project,
+      secretMaterial: "phrase-secret",
+    });
+
+    const defaultKey = result.find(
+      (item) => item.resourceType === "key" && item.externalResourceId === "key-1",
+    );
+    expect(defaultKey).toMatchObject({
+      sourcePath: "keys/home.hero.title",
+      displayName: "home.hero.title",
+      format: "icu",
+      sourceLocale: "en-US",
+      targetLocales: ["fr-FR", "de-DE"],
+      localeReadiness: {
+        "fr-FR": "ready",
+        "de-DE": "missing",
+      },
+      providerPayload: {
+        id: "key-1",
+        key: "home.hero.title",
+        branch: null,
+        tags: ["app", "marketing"],
+        customMetadata: { screen: "home" },
+      },
+    });
+
+    const branchKey = result.find(
+      (item) => item.resourceType === "key" && item.externalResourceId === "feature::key-feature",
+    );
+    expect(branchKey).toMatchObject({
+      sourcePath: "feature/keys/feature.title",
+      providerPayload: expect.objectContaining({
+        branch: "feature",
+        tags: ["app"],
+      }),
+    });
+
+    const defaultFile = result.find(
+      (item) => item.resourceType === "file" && item.externalResourceId === "upload-1",
+    );
+    expect(defaultFile).toMatchObject({
+      sourcePath: "locales/en-US/home.json",
+      displayName: "home.json",
+      localeReadiness: {
+        "fr-FR": "ready",
+        "de-DE": "missing",
+      },
+      providerPayload: expect.objectContaining({
+        branch: null,
+        tags: ["app"],
+        localeDownload: expect.objectContaining({
+          localeId: "loc-en",
+          localeName: "en",
+          fileFormat: "json",
+          downloadPath: "/projects/proj-1/locales/loc-en/download",
+        }),
+      }),
+    });
+  });
+
+  it("throws phrase_auth_invalid for unauthorized responses", async () => {
+    globalThis.fetch = vi.fn(async () => {
+      return new Response(JSON.stringify({ message: "Unauthorized" }), { status: 401 });
+    }) as unknown as typeof fetch;
+
+    await expect(
+      fetchPhraseFileKeys({
+        organizationId: "org-1",
+        projectId: "project-1",
+        providerKind: "phrase",
+        externalProjectId: "proj-1",
+        credential,
+        project,
+        secretMaterial: "phrase-secret",
+      }),
+    ).rejects.toThrow("phrase_auth_invalid");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-file-fetcher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-file-fetcher.test.ts
@@ -130,6 +130,15 @@ describe("fetchPhraseFileKeys", () => {
               data_type: "icu",
               updated_at: "2026-05-02T00:00:00Z",
             },
+            {
+              id: "key-2",
+              name: "home.hero.subtitle",
+              description: "Hero subtitle",
+              tags: ["app"],
+              custom_metadata: { screen: "home" },
+              data_type: "icu",
+              updated_at: "2026-05-02T00:00:00Z",
+            },
           ]),
           { status: 200 },
         );
@@ -146,6 +155,15 @@ describe("fetchPhraseFileKeys", () => {
               state: "translated",
               unverified: false,
               excluded: false,
+            },
+            {
+              id: "tr-fr-2",
+              key_id: "key-2",
+              locale_name: "fr",
+              content: "Sous-titre",
+              state: "translated",
+              unverified: false,
+              excluded: true,
             },
             {
               id: "tr-fr-feature",

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-file-fetcher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-file-fetcher.ts
@@ -190,8 +190,9 @@ async function loadTranslationsByKeyId(input: {
 }) {
   const translationsByKeyId = new Map<string, Map<string, PhraseTranslation>>();
   const listOptions = input.branch ? { branch: input.branch } : {};
+  const targetLocales = input.locales.filter((locale) => !locale.default);
 
-  await mapWithConcurrency(input.locales, LOCALE_FETCH_CONCURRENCY, async (locale) => {
+  await mapWithConcurrency(targetLocales, LOCALE_FETCH_CONCURRENCY, async (locale) => {
     try {
       const translations = await input.client.listTranslations(
         input.projectId,
@@ -213,6 +214,7 @@ async function loadTranslationsByKeyId(input: {
       if (error instanceof PhraseApiError && error.status === 401) {
         throw new Error("phrase_auth_invalid");
       }
+      throw error;
     }
   });
 

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-file-fetcher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-file-fetcher.ts
@@ -1,0 +1,361 @@
+import type { ExternalTmsFileKeyFetcher } from "@/lib/providers/external-tms-file-sync";
+
+import {
+  PhraseApiClient,
+  PhraseApiError,
+  type PhraseKey,
+  type PhraseLocale,
+  type PhraseTranslation,
+} from "./phrase-api";
+import {
+  buildPhraseKeyExternalResourceId,
+  buildPhraseKeySourcePath,
+  buildPhraseUploadSourcePath,
+  mapPhraseTranslationReadiness,
+} from "./phrase-locale-readiness";
+
+const LOCALE_FETCH_CONCURRENCY = 8;
+
+export const fetchPhraseFileKeys: ExternalTmsFileKeyFetcher = async ({
+  credential,
+  externalProjectId,
+  project,
+  secretMaterial,
+}) => {
+  const client = new PhraseApiClient({
+    token: secretMaterial,
+    region: credential.region,
+    baseUrl: credential.baseUrl,
+  });
+
+  if (!externalProjectId.trim()) {
+    throw new Error("invalid_phrase_project_id");
+  }
+
+  let locales: PhraseLocale[];
+  let branches: string[];
+  try {
+    [locales, branches] = await Promise.all([
+      client.listLocales(externalProjectId),
+      client.listBranches(externalProjectId).then((items) => items.map((branch) => branch.name)),
+    ]);
+  } catch (error) {
+    throw mapPhraseFetcherError(error);
+  }
+
+  const { sourceLocale, targetLocales, targetLocaleRefs, sourceLocaleRef } =
+    partitionPhraseLocales(locales);
+  const branchScopes = buildBranchScopes(branches);
+  const projectMetadata = readProjectMetadata(project);
+  const mainFormat =
+    typeof projectMetadata.mainFormat === "string" ? projectMetadata.mainFormat : null;
+  const accountSlug =
+    typeof projectMetadata.accountSlug === "string" ? projectMetadata.accountSlug : null;
+  const projectSlug = typeof projectMetadata.slug === "string" ? projectMetadata.slug : null;
+
+  const results: Awaited<ReturnType<ExternalTmsFileKeyFetcher>> = [];
+
+  for (const branch of branchScopes) {
+    const listOptions = branch ? { branch } : {};
+
+    let keys: PhraseKey[];
+    let uploads: Awaited<ReturnType<typeof client.listUploads>>;
+    try {
+      [keys, uploads] = await Promise.all([
+        client.listKeys(externalProjectId, listOptions),
+        client.listUploads(externalProjectId, listOptions),
+      ]);
+    } catch (error) {
+      throw mapPhraseFetcherError(error);
+    }
+
+    const translationsByKeyId = await loadTranslationsByKeyId({
+      client,
+      projectId: externalProjectId,
+      locales,
+      branch,
+    });
+
+    for (const upload of uploads) {
+      const sourcePath = buildPhraseUploadSourcePath(sourceLocale, upload.filename);
+      const uploadTags = mergeTags(upload.tags, upload.tag);
+      const localeReadiness = buildUploadLocaleReadiness({
+        keys,
+        uploadsTags: uploadTags,
+        targetLocaleRefs,
+        translationsByKeyId,
+      });
+
+      results.push({
+        externalResourceId: buildUploadExternalResourceId(upload.id, branch),
+        resourceType: "file",
+        sourcePath,
+        displayName: upload.filename,
+        format: upload.format ?? mainFormat,
+        sourceLocale,
+        targetLocales,
+        revision: upload.updatedAt ?? upload.createdAt ?? null,
+        externalUrl: upload.url ?? buildPhraseProjectUrl(accountSlug, projectSlug),
+        syncState: upload.state === "success" ? "synced" : "pending",
+        localeReadiness,
+        providerPayload: {
+          id: upload.id,
+          name: upload.filename,
+          branch,
+          tags: uploadTags,
+          tag: upload.tag,
+          state: upload.state,
+          format: upload.format,
+          url: upload.url,
+          localeDownload: sourceLocaleRef
+            ? client.buildLocaleDownloadMetadata({
+                projectId: externalProjectId,
+                locale: sourceLocaleRef,
+                fileFormat: upload.format ?? mainFormat,
+                branch,
+                tags: uploadTags,
+              })
+            : null,
+        },
+      });
+    }
+
+    for (const key of keys) {
+      const localeReadiness = buildKeyLocaleReadiness({
+        keyId: key.id,
+        targetLocaleRefs,
+        translationsByKeyId,
+      });
+
+      results.push({
+        externalResourceId: buildPhraseKeyExternalResourceId(key.id, branch),
+        resourceType: "key",
+        sourcePath: buildPhraseKeySourcePath(key.name, branch),
+        displayName: key.name,
+        format: key.dataType ?? mainFormat,
+        sourceLocale,
+        targetLocales,
+        revision: key.updatedAt ?? key.createdAt ?? null,
+        externalUrl: buildPhraseProjectUrl(accountSlug, projectSlug),
+        syncState: "synced",
+        localeReadiness,
+        providerPayload: {
+          id: key.id,
+          key: key.name,
+          name: key.name,
+          description: key.description,
+          branch,
+          tags: key.tags,
+          customMetadata: key.customMetadata,
+          nameHash: key.nameHash,
+          plural: key.plural,
+          useOrdinalRules: key.useOrdinalRules,
+          dataType: key.dataType,
+          createdAt: key.createdAt,
+          updatedAt: key.updatedAt,
+        },
+      });
+    }
+  }
+
+  return results;
+};
+
+function buildBranchScopes(branches: string[]) {
+  const unique = new Set<string>();
+  for (const branch of branches) {
+    const trimmed = branch.trim();
+    if (trimmed) {
+      unique.add(trimmed);
+    }
+  }
+
+  return [null, ...unique];
+}
+
+function buildUploadExternalResourceId(uploadId: string, branch: string | null) {
+  const trimmedBranch = branch?.trim();
+  if (!trimmedBranch) {
+    return uploadId;
+  }
+
+  return `${trimmedBranch}::${uploadId}`;
+}
+
+async function loadTranslationsByKeyId(input: {
+  client: PhraseApiClient;
+  projectId: string;
+  locales: PhraseLocale[];
+  branch: string | null;
+}) {
+  const translationsByKeyId = new Map<string, Map<string, PhraseTranslation>>();
+  const listOptions = input.branch ? { branch: input.branch } : {};
+
+  await mapWithConcurrency(input.locales, LOCALE_FETCH_CONCURRENCY, async (locale) => {
+    try {
+      const translations = await input.client.listTranslations(
+        input.projectId,
+        locale.name,
+        listOptions,
+      );
+
+      for (const translation of translations) {
+        if (!translation.keyId) {
+          continue;
+        }
+
+        const byLocale =
+          translationsByKeyId.get(translation.keyId) ?? new Map<string, PhraseTranslation>();
+        byLocale.set(locale.name, translation);
+        translationsByKeyId.set(translation.keyId, byLocale);
+      }
+    } catch (error) {
+      if (error instanceof PhraseApiError && error.status === 401) {
+        throw new Error("phrase_auth_invalid");
+      }
+    }
+  });
+
+  return translationsByKeyId;
+}
+
+function buildKeyLocaleReadiness(input: {
+  keyId: string;
+  targetLocaleRefs: PhraseLocale[];
+  translationsByKeyId: Map<string, Map<string, PhraseTranslation>>;
+}) {
+  const localeReadiness: Record<string, string> = {};
+  const translationsByLocale = input.translationsByKeyId.get(input.keyId);
+
+  for (const locale of input.targetLocaleRefs) {
+    const localeKey = localeIdentifier(locale) ?? locale.name;
+    const translation = translationsByLocale?.get(locale.name);
+    localeReadiness[localeKey] = mapPhraseTranslationReadiness({
+      content: translation?.content,
+      state: translation?.state,
+      unverified: translation?.unverified,
+      excluded: translation?.excluded,
+    });
+  }
+
+  return localeReadiness;
+}
+
+function buildUploadLocaleReadiness(input: {
+  keys: PhraseKey[];
+  uploadsTags: string[];
+  targetLocaleRefs: PhraseLocale[];
+  translationsByKeyId: Map<string, Map<string, PhraseTranslation>>;
+}) {
+  const scopedKeys =
+    input.uploadsTags.length === 0
+      ? input.keys
+      : input.keys.filter((key) => key.tags.some((tag) => input.uploadsTags.includes(tag)));
+
+  const localeReadiness: Record<string, string> = {};
+  for (const locale of input.targetLocaleRefs) {
+    const localeKey = localeIdentifier(locale) ?? locale.name;
+    const statuses = scopedKeys.map((key) => {
+      const translation = input.translationsByKeyId.get(key.id)?.get(locale.name);
+      return mapPhraseTranslationReadiness({
+        content: translation?.content,
+        state: translation?.state,
+        unverified: translation?.unverified,
+        excluded: translation?.excluded,
+      });
+    });
+
+    if (statuses.length === 0) {
+      localeReadiness[localeKey] = "missing";
+      continue;
+    }
+
+    if (statuses.every((status) => status === "ready")) {
+      localeReadiness[localeKey] = "ready";
+      continue;
+    }
+
+    if (statuses.some((status) => status === "ready" || status === "unverified")) {
+      localeReadiness[localeKey] = "unverified";
+      continue;
+    }
+
+    localeReadiness[localeKey] = "missing";
+  }
+
+  return localeReadiness;
+}
+
+function partitionPhraseLocales(locales: PhraseLocale[]) {
+  const source = locales.find((locale) => locale.default);
+  const sourceLocaleRef = source ?? null;
+  const sourceLocale = localeIdentifier(source);
+  const targetLocaleRefs = locales.filter((locale) => !locale.default);
+  const targetLocales = targetLocaleRefs
+    .map((locale) => localeIdentifier(locale))
+    .filter((locale): locale is string => Boolean(locale));
+
+  return {
+    sourceLocale,
+    targetLocales,
+    targetLocaleRefs,
+    sourceLocaleRef,
+  };
+}
+
+function localeIdentifier(locale: PhraseLocale | undefined) {
+  if (!locale) return null;
+  return locale.code?.trim() || locale.name.trim() || null;
+}
+
+function readProjectMetadata(project: { providerMetadata: Record<string, unknown> }) {
+  return project.providerMetadata;
+}
+
+function mergeTags(tags: string[], tag: string | null) {
+  const merged = new Set(tags);
+  if (tag?.trim()) {
+    merged.add(tag.trim());
+  }
+
+  return [...merged];
+}
+
+function buildPhraseProjectUrl(accountSlug: string | null, projectSlug: string | null) {
+  if (!accountSlug || !projectSlug) {
+    return null;
+  }
+
+  return `https://app.phrase.com/accounts/${accountSlug}/projects/${projectSlug}`;
+}
+
+function mapPhraseFetcherError(error: unknown) {
+  if (error instanceof PhraseApiError && error.status === 401) {
+    return new Error("phrase_auth_invalid");
+  }
+
+  return error instanceof Error ? error : new Error("phrase_fetch_failed");
+}
+
+async function mapWithConcurrency<T>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T) => Promise<void>,
+) {
+  let nextIndex = 0;
+
+  async function worker() {
+    while (true) {
+      const currentIndex = nextIndex;
+      nextIndex += 1;
+      if (currentIndex >= items.length) {
+        return;
+      }
+
+      await mapper(items[currentIndex] as T);
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, () => worker());
+  await Promise.all(workers);
+}

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-file-fetcher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-file-fetcher.ts
@@ -272,12 +272,19 @@ function buildUploadLocaleReadiness(input: {
       continue;
     }
 
-    if (statuses.every((status) => status === "ready")) {
+    const activeStatuses = statuses.filter((status) => status !== "excluded");
+
+    if (activeStatuses.length === 0) {
+      localeReadiness[localeKey] = "excluded";
+      continue;
+    }
+
+    if (activeStatuses.every((status) => status === "ready")) {
       localeReadiness[localeKey] = "ready";
       continue;
     }
 
-    if (statuses.some((status) => status === "ready" || status === "unverified")) {
+    if (activeStatuses.some((status) => status === "ready" || status === "unverified")) {
       localeReadiness[localeKey] = "unverified";
       continue;
     }

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-locale-readiness.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-locale-readiness.test.ts
@@ -29,6 +29,17 @@ describe("phrase locale readiness", () => {
     ).toBe("missing");
   });
 
+  it("maps non-translated content to unverified", () => {
+    expect(
+      mapPhraseTranslationReadiness({
+        content: "Draft copy",
+        state: "draft",
+        unverified: false,
+        excluded: false,
+      }),
+    ).toBe("unverified");
+  });
+
   it("maps unverified translated content to unverified", () => {
     expect(
       mapPhraseTranslationReadiness({

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-locale-readiness.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-locale-readiness.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  buildPhraseKeyExternalResourceId,
+  buildPhraseKeySourcePath,
+  mapPhraseTranslationReadiness,
+} from "./phrase-locale-readiness";
+
+describe("phrase locale readiness", () => {
+  it("maps translated content to ready", () => {
+    expect(
+      mapPhraseTranslationReadiness({
+        content: "Bonjour",
+        state: "translated",
+        unverified: false,
+        excluded: false,
+      }),
+    ).toBe("ready");
+  });
+
+  it("maps empty content to missing", () => {
+    expect(
+      mapPhraseTranslationReadiness({
+        content: "",
+        state: "translated",
+        unverified: false,
+        excluded: false,
+      }),
+    ).toBe("missing");
+  });
+
+  it("maps unverified translated content to unverified", () => {
+    expect(
+      mapPhraseTranslationReadiness({
+        content: "Bonjour",
+        state: "translated",
+        unverified: true,
+        excluded: false,
+      }),
+    ).toBe("unverified");
+  });
+
+  it("scopes key identity by branch when present", () => {
+    expect(buildPhraseKeyExternalResourceId("key-1", "feature")).toBe("feature::key-1");
+    expect(buildPhraseKeyExternalResourceId("key-1", null)).toBe("key-1");
+    expect(buildPhraseKeySourcePath("home.hero.title", null)).toBe("keys/home.hero.title");
+    expect(buildPhraseKeySourcePath("home.hero.title", "feature")).toBe(
+      "feature/keys/home.hero.title",
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-locale-readiness.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-locale-readiness.ts
@@ -1,0 +1,58 @@
+export type PhraseLocaleReadinessStatus = "ready" | "missing" | "unverified" | "excluded";
+
+export function mapPhraseTranslationReadiness(input: {
+  content?: string | null;
+  state?: string | null;
+  unverified?: boolean;
+  excluded?: boolean;
+}): PhraseLocaleReadinessStatus {
+  if (input.excluded) {
+    return "excluded";
+  }
+
+  const content = input.content?.trim();
+  if (!content) {
+    return "missing";
+  }
+
+  if (input.unverified) {
+    return "unverified";
+  }
+
+  const state = (input.state ?? "").trim().toLowerCase();
+  if (state === "translated") {
+    return "ready";
+  }
+
+  return "ready";
+}
+
+export function buildPhraseKeyExternalResourceId(keyId: string, branch: string | null) {
+  const trimmedId = keyId.trim();
+  const trimmedBranch = branch?.trim();
+  if (!trimmedBranch) {
+    return trimmedId;
+  }
+
+  return `${trimmedBranch}::${trimmedId}`;
+}
+
+export function buildPhraseKeySourcePath(keyName: string, branch: string | null) {
+  const trimmedName = keyName.trim();
+  const trimmedBranch = branch?.trim();
+  if (!trimmedBranch) {
+    return `keys/${trimmedName}`;
+  }
+
+  return `${trimmedBranch}/keys/${trimmedName}`;
+}
+
+export function buildPhraseUploadSourcePath(sourceLocale: string | null, filename: string) {
+  const trimmedFilename = filename.trim();
+  const trimmedLocale = sourceLocale?.trim();
+  if (!trimmedLocale) {
+    return `uploads/${trimmedFilename}`;
+  }
+
+  return `locales/${trimmedLocale}/${trimmedFilename}`;
+}

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-locale-readiness.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-locale-readiness.ts
@@ -24,7 +24,7 @@ export function mapPhraseTranslationReadiness(input: {
     return "ready";
   }
 
-  return "ready";
+  return "unverified";
 }
 
 export function buildPhraseKeyExternalResourceId(keyId: string, branch: string | null) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements HL-349 by syncing Phrase Strings keys, uploads, and locale download metadata into the unified `external_tms_files` model.

- Extends `PhraseApiClient` with paginated `listKeys`, `listTranslations`, `listUploads`, and `listBranches`, plus locale download metadata helpers
- Adds `fetchPhraseFileKeys` to discover keys and upload-backed locale files per branch scope
- Preserves branch, tags, custom metadata, and key names in `providerPayload`
- Normalizes per-locale translation readiness (`ready`, `missing`, `unverified`, `excluded`)
- Registers Phrase in `POST /projects/:projectId/sync-files` (no longer returns 501)

### Review fixes (Greptile)

- **Readiness mapping:** Non-`translated` Phrase states with content map to `unverified`
- **Translation fetch errors:** Non-401 API errors propagate instead of silently marking keys missing
- **Performance:** Skip translation fetches for default (source) locales
- **Upload aggregation:** Excluded keys are filtered out before locale readiness rollup so mixed ready/excluded keys still report `ready`

## Testing

- `vp test src/lib/providers/phrase` (19 tests)
- `vp check` (0 errors)

## Linear

Resolves HL-349
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-349](https://linear.app/hyperlocalise/issue/HL-349/implement-phrase-keys-and-locale-file-discovery)

<div><a href="https://cursor.com/agents/bc-df514ac6-364b-4424-bbd7-bf105f4e6e44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df514ac6-364b-4424-bbd7-bf105f4e6e44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

