### PR TITLE
feat(web): show synced TMS files in unified Files UI (HL-366)

### DIFF
--- a/apps/hyperlocalise-web/src/api/app.ts
+++ b/apps/hyperlocalise-web/src/api/app.ts
@@ -30,6 +30,7 @@ import { createResendWebhookRoutes } from "./routes/resend-webhook/resend-webhoo
 import { createSlackOAuthRoutes } from "./routes/slack-oauth/slack-oauth.route";
 import { createSlackWebhookRoutes } from "./routes/slack-webhook/slack-webhook.route";
 import { createFileRoutes } from "./routes/file/file.route";
+import { createWorkspaceFilesRoutes } from "./routes/workspace-files/workspace-files.route";
 import { createExternalTmsProviderCredentialRoutes } from "./routes/external-tms-provider-credential/external-tms-provider-credential.route";
 import { createTeamRoutes } from "./routes/team/team.route";
 import { workosWebhookRoutes } from "./routes/workos-webhook/workos-webhook.route";
@@ -110,6 +111,7 @@ function createOrgScopedAppRoutes(
     .route("/agent-slack", createAgentSlackRoutes())
     .route("/teams", createTeamRoutes())
     .route("/files", createFileRoutes({ fileStorageAdapter: options.fileStorageAdapter }))
+    .route("/workspace-files", createWorkspaceFilesRoutes())
     .route("/conversations", createConversationRoutes())
     .route(
       "/chat-requests",

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -28,7 +28,7 @@ import {
   pullExternalTmsTaskContent,
   pushExternalTmsTranslations,
 } from "@/lib/providers/external-tms-content-sync";
-import { filterProjectFiles, listProjectFilesForProject } from "@/lib/projects/project-files";
+import { listFilteredProjectFiles } from "@/lib/projects/project-files";
 import type { ExternalTmsResourceType } from "@/lib/providers/organization-external-tms-files";
 import { bufferFromStream } from "@/lib/streams";
 import { inferSupportedFileTranslationFileFormat } from "@/lib/translation/file-formats";
@@ -601,21 +601,19 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
           ? ([query.resourceType] as ExternalTmsResourceType[])
           : undefined;
 
-      const mergedFiles = await listProjectFilesForProject({
+      const files = await listFilteredProjectFiles({
         organizationId: c.var.auth.organization.localOrganizationId,
         projectId: params.projectId,
-        limit: query.limit,
+        query: {
+          ...query,
+          origin: query.origin ?? "all",
+          resourceType: query.resourceType ?? "all",
+          providerKind: query.providerKind ?? "all",
+          locale: query.locale ?? "all",
+          syncState: query.syncState ?? "all",
+        },
         resourceTypes,
       });
-
-      const files = filterProjectFiles(mergedFiles, {
-        origin: query.origin ?? "all",
-        resourceType: query.resourceType ?? "all",
-        providerKind: query.providerKind ?? "all",
-        locale: query.locale ?? "all",
-        syncState: query.syncState ?? "all",
-        search: query.search,
-      }).slice(0, query.limit);
 
       return c.json({ files }, 200);
     })

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -28,7 +28,8 @@ import {
   pullExternalTmsTaskContent,
   pushExternalTmsTranslations,
 } from "@/lib/providers/external-tms-content-sync";
-import { listExternalTmsFilesForProject } from "@/lib/providers/organization-external-tms-files";
+import { filterProjectFiles, listProjectFilesForProject } from "@/lib/projects/project-files";
+import type { ExternalTmsResourceType } from "@/lib/providers/organization-external-tms-files";
 import { bufferFromStream } from "@/lib/streams";
 import { inferSupportedFileTranslationFileFormat } from "@/lib/translation/file-formats";
 import type { JobQueue, TranslationJobEventData } from "@/lib/workflow/types";
@@ -595,182 +596,26 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
         return projectNotFoundResponse(c);
       }
 
-      const versionsSubquery = db
-        .select({
-          versionId: schema.repositorySourceFileVersions.id,
-          sourcePath: schema.repositorySourceFileVersions.sourcePath,
-          sourceHash: schema.repositorySourceFileVersions.sourceHash,
-          commitSha: schema.repositorySourceFileVersions.commitSha,
-          workflowRunId: schema.repositorySourceFileVersions.workflowRunId,
-          uploadedAt: schema.repositorySourceFileVersions.createdAt,
-          storedFileId: schema.repositorySourceFileVersions.storedFileId,
-          metadata: schema.storedFiles.metadata,
-          filename: schema.storedFiles.filename,
-          byteSize: schema.storedFiles.byteSize,
-          rowNumber:
-            sql<number>`ROW_NUMBER() OVER (PARTITION BY ${schema.repositorySourceFileVersions.sourcePath} ORDER BY ${schema.repositorySourceFileVersions.createdAt} DESC)`.as(
-              "rn",
-            ),
-        })
-        .from(schema.repositorySourceFileVersions)
-        .innerJoin(
-          schema.storedFiles,
-          eq(schema.storedFiles.id, schema.repositorySourceFileVersions.storedFileId),
-        )
-        .where(
-          and(
-            eq(schema.storedFiles.projectId, params.projectId),
-            eq(schema.storedFiles.role, "source"),
-            eq(schema.storedFiles.sourceKind, "repository_file"),
-            eq(schema.storedFiles.organizationId, c.var.auth.organization.localOrganizationId),
-          ),
-        )
-        .as("versions_sq");
+      const resourceTypes =
+        query.resourceType && query.resourceType !== "all"
+          ? ([query.resourceType] as ExternalTmsResourceType[])
+          : undefined;
 
-      const versions = await db
-        .select({
-          versionId: versionsSubquery.versionId,
-          sourcePath: versionsSubquery.sourcePath,
-          sourceHash: versionsSubquery.sourceHash,
-          commitSha: versionsSubquery.commitSha,
-          workflowRunId: versionsSubquery.workflowRunId,
-          uploadedAt: versionsSubquery.uploadedAt,
-          storedFileId: versionsSubquery.storedFileId,
-          metadata: versionsSubquery.metadata,
-          filename: versionsSubquery.filename,
-          byteSize: versionsSubquery.byteSize,
-        })
-        .from(versionsSubquery)
-        .where(eq(versionsSubquery.rowNumber, 1));
-
-      const versionIds = versions.map((v) => v.versionId);
-      const providerFiles = await listExternalTmsFilesForProject({
+      const mergedFiles = await listProjectFilesForProject({
         organizationId: c.var.auth.organization.localOrganizationId,
         projectId: params.projectId,
         limit: query.limit,
+        resourceTypes,
       });
 
-      const latestJobs = new Map<
-        string,
-        {
-          jobId: string;
-          jobStatus: string;
-          jobCreatedAt: Date;
-          jobType: string;
-        }
-      >();
-
-      if (versionIds.length > 0) {
-        const jobsSubquery = db
-          .select({
-            versionId: schema.translationJobDetails.sourceFileVersionId,
-            jobId: schema.jobs.id,
-            jobStatus: schema.jobs.status,
-            jobCreatedAt: schema.jobs.createdAt,
-            jobType: schema.translationJobDetails.type,
-            rowNumber:
-              sql<number>`ROW_NUMBER() OVER (PARTITION BY ${schema.translationJobDetails.sourceFileVersionId} ORDER BY ${schema.jobs.createdAt} DESC)`.as(
-                "rn",
-              ),
-          })
-          .from(schema.jobs)
-          .innerJoin(
-            schema.translationJobDetails,
-            eq(schema.translationJobDetails.jobId, schema.jobs.id),
-          )
-          .where(
-            and(
-              eq(schema.jobs.projectId, params.projectId),
-              inArray(schema.translationJobDetails.sourceFileVersionId, versionIds),
-            ),
-          )
-          .as("jobs_sq");
-
-        const jobs = await db
-          .select({
-            versionId: jobsSubquery.versionId,
-            jobId: jobsSubquery.jobId,
-            jobStatus: jobsSubquery.jobStatus,
-            jobCreatedAt: jobsSubquery.jobCreatedAt,
-            jobType: jobsSubquery.jobType,
-          })
-          .from(jobsSubquery)
-          .where(eq(jobsSubquery.rowNumber, 1));
-
-        for (const j of jobs) {
-          if (j.versionId) {
-            latestJobs.set(j.versionId, j);
-          }
-        }
-      }
-
-      const nativeFiles = versions.map((v) => {
-        const job = latestJobs.get(v.versionId);
-        return {
-          origin: "repository" as const,
-          sourcePath: v.sourcePath,
-          sourceHash: v.sourceHash,
-          commitSha: v.commitSha,
-          workflowRunId: v.workflowRunId,
-          uploadedAt: v.uploadedAt.toISOString(),
-          storedFileId: v.storedFileId,
-          metadata: v.metadata as Record<string, unknown>,
-          filename: v.filename,
-          byteSize: v.byteSize,
-          provider: null,
-          latestJob: job
-            ? {
-                id: job.jobId,
-                status: job.jobStatus,
-                createdAt: job.jobCreatedAt.toISOString(),
-                type: job.jobType,
-              }
-            : null,
-        };
-      });
-
-      const nativeFileByStoredFileId = new Map(
-        nativeFiles.map((file) => [file.storedFileId, file]),
-      );
-      const providerBackedFiles = providerFiles.map((file) => {
-        const linkedNativeFile = file.storedFileId
-          ? nativeFileByStoredFileId.get(file.storedFileId)
-          : undefined;
-
-        return {
-          origin: "provider" as const,
-          sourcePath: file.sourcePath,
-          sourceHash: file.sourceHash,
-          commitSha: null,
-          workflowRunId: null,
-          uploadedAt:
-            file.lastSyncedAt?.toISOString() ??
-            linkedNativeFile?.uploadedAt ??
-            file.updatedAt.toISOString(),
-          storedFileId: file.storedFileId,
-          metadata: file.providerPayload as Record<string, unknown>,
-          filename: file.displayName,
-          byteSize: linkedNativeFile?.byteSize ?? null,
-          provider: {
-            kind: file.providerKind,
-            resourceType: file.resourceType,
-            externalProjectId: file.externalProjectId,
-            externalResourceId: file.externalResourceId,
-            externalUrl: file.externalUrl,
-            syncState: file.syncState,
-            sourceLocale: file.sourceLocale,
-            targetLocales: file.targetLocales,
-            localeReadiness: file.localeReadiness as Record<string, unknown>,
-            revision: file.revision,
-            format: file.format,
-          },
-          latestJob: linkedNativeFile?.latestJob ?? null,
-        };
-      });
-
-      const files = [...nativeFiles, ...providerBackedFiles].sort((a, b) =>
-        a.sourcePath.localeCompare(b.sourcePath),
-      );
+      const files = filterProjectFiles(mergedFiles, {
+        origin: query.origin ?? "all",
+        resourceType: query.resourceType ?? "all",
+        providerKind: query.providerKind ?? "all",
+        locale: query.locale ?? "all",
+        syncState: query.syncState ?? "all",
+        search: query.search,
+      }).slice(0, query.limit);
 
       return c.json({ files }, 200);
     })

--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -106,6 +106,7 @@ export const projectFileRecordSchema = z.object({
       localeReadiness: z.record(z.string(), z.unknown()),
       revision: z.string().nullable(),
       format: z.string().nullable(),
+      lastSyncedAt: z.string().nullable(),
     })
     .nullable()
     .default(null),
@@ -130,8 +131,30 @@ export const projectFilesResponseSchema = z.object({
   files: z.array(projectFileRecordSchema),
 });
 
+const projectFilesFilterOriginSchema = z.enum(["all", "repository", "provider"]).default("all");
+const projectFilesFilterResourceTypeSchema = z.enum(["all", "file", "key"]).default("all");
+const projectFilesFilterProviderKindSchema = z
+  .enum(["all", "crowdin", "smartling", "phrase", "lokalise"])
+  .default("all");
+
 export const projectFilesQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(1_000).optional().default(500),
+  search: z.string().trim().max(256).optional(),
+  origin: projectFilesFilterOriginSchema.optional(),
+  resourceType: projectFilesFilterResourceTypeSchema.optional(),
+  providerKind: projectFilesFilterProviderKindSchema.optional(),
+  locale: z.string().trim().max(32).optional(),
+  syncState: z.string().trim().max(64).optional(),
+  projectId: z.string().trim().max(128).optional(),
+});
+
+export const workspaceFileRecordSchema = projectFileRecordSchema.extend({
+  projectId: z.string(),
+  projectName: z.string(),
+});
+
+export const workspaceFilesResponseSchema = z.object({
+  files: z.array(workspaceFileRecordSchema),
 });
 
 export const projectFileDetailQuerySchema = z.object({
@@ -210,3 +233,5 @@ export type ProjectFileVersionRecord = z.infer<typeof projectFileVersionRecordSc
 export type ProjectFileOutputRecord = z.infer<typeof projectFileOutputRecordSchema>;
 export type ProjectFileJobRecord = z.infer<typeof projectFileJobRecordSchema>;
 export type ProjectFileDetailResponse = z.infer<typeof projectFileDetailResponseSchema>;
+export type WorkspaceFileRecord = z.infer<typeof workspaceFileRecordSchema>;
+export type WorkspaceFilesResponse = z.infer<typeof workspaceFilesResponseSchema>;

--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -83,7 +83,7 @@ export const projectsResponseSchema = z.object({
 });
 
 export const projectFileRecordSchema = z.object({
-  origin: z.enum(["repository", "provider"]).default("repository"),
+  origin: z.enum(["repository", "provider", "combined"]).default("repository"),
   sourcePath: z.string(),
   sourceHash: z.string().nullable(),
   commitSha: z.string().nullable(),

--- a/apps/hyperlocalise-web/src/api/routes/project/project.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.test.ts
@@ -612,6 +612,100 @@ describe("projectRoutes", () => {
     ]);
   });
 
+  it("combines repository and provider records for the same source path", async () => {
+    const identity = createWorkosIdentity();
+    const createdResponse = await createProjectViaApi(identity);
+    const createdBody = (await createdResponse.json()) as ProjectResponse;
+    const projectId = createdBody.project.id;
+    const sourcePath = "locales/en/home.json";
+
+    const [storedFile] = await db
+      .insert(schema.storedFiles)
+      .values({
+        id: `file_${randomUUID()}`,
+        organizationId: createdBody.project.organizationId,
+        projectId,
+        role: "source",
+        sourceKind: "repository_file",
+        storageProvider: "vercel_blob",
+        storageKey: `test/${projectId}/home.json`,
+        storageUrl: `https://example.com/${projectId}/home.json`,
+        filename: "home.json",
+        contentType: "application/json",
+        byteSize: 120,
+        sha256: "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+        metadata: { sourcePath },
+      })
+      .returning();
+
+    const [sourceFile] = await db
+      .insert(schema.repositorySourceFiles)
+      .values({
+        organizationId: createdBody.project.organizationId,
+        projectId,
+        sourcePath,
+      })
+      .returning();
+
+    await db.insert(schema.repositorySourceFileVersions).values({
+      repositorySourceFileId: sourceFile.id,
+      organizationId: createdBody.project.organizationId,
+      projectId,
+      sourcePath,
+      storedFileId: storedFile.id,
+      sourceHash: "repo-hash",
+      commitSha: "deadbeef",
+    });
+
+    await upsertExternalTmsFile({
+      organizationId: createdBody.project.organizationId,
+      projectId,
+      providerKind: "phrase",
+      externalProjectId: "phrase-project-1",
+      resourceType: "file",
+      externalResourceId: "file-1",
+      sourcePath,
+      displayName: "home.json",
+      format: "json",
+      sourceLocale: "en",
+      targetLocales: ["fr"],
+      sourceHash: "provider-hash",
+      revision: "one",
+      syncState: "synced",
+    });
+
+    for (const origin of ["all", "repository", "provider"] as const) {
+      const response = await client.api.orgs[":organizationSlug"].projects[":projectId"].files.$get(
+        {
+          param: { organizationSlug: identity.organization.slug ?? "missing-slug", projectId },
+          query: { limit: "500", origin },
+        },
+        {
+          headers: await authHeadersFor(identity),
+        },
+      );
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as ProjectFilesResponse;
+      expect(body.files).toHaveLength(1);
+      expect(body.files[0]).toMatchObject({
+        origin: "combined",
+        sourcePath,
+        sourceHash: "repo-hash",
+        commitSha: "deadbeef",
+        storedFileId: storedFile.id,
+        filename: "home.json",
+        byteSize: 120,
+        provider: expect.objectContaining({
+          kind: "phrase",
+          externalResourceId: "file-1",
+          syncState: "synced",
+          revision: "one",
+        }),
+      });
+    }
+  });
+
   it("filters project files by resource type and provider kind", async () => {
     const identity = createWorkosIdentity();
     const createdResponse = await createProjectViaApi(identity);

--- a/apps/hyperlocalise-web/src/api/routes/project/project.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.test.ts
@@ -612,6 +612,59 @@ describe("projectRoutes", () => {
     ]);
   });
 
+  it("filters project files by resource type and provider kind", async () => {
+    const identity = createWorkosIdentity();
+    const createdResponse = await createProjectViaApi(identity);
+    const createdBody = (await createdResponse.json()) as ProjectResponse;
+    const projectId = createdBody.project.id;
+
+    await upsertExternalTmsFile({
+      organizationId: createdBody.project.organizationId,
+      projectId,
+      providerKind: "phrase",
+      externalProjectId: "phrase-project-1",
+      resourceType: "file",
+      externalResourceId: "file-1",
+      sourcePath: "locales/en/home.json",
+      displayName: "home.json",
+      syncState: "synced",
+    });
+
+    await upsertExternalTmsFile({
+      organizationId: createdBody.project.organizationId,
+      projectId,
+      providerKind: "crowdin",
+      externalProjectId: "crowdin-project-1",
+      resourceType: "key",
+      externalResourceId: "key-1",
+      sourcePath: "keys/home.title",
+      displayName: "home.title",
+      syncState: "pending",
+    });
+
+    const response = await client.api.orgs[":organizationSlug"].projects[":projectId"].files.$get(
+      {
+        param: { organizationSlug: identity.organization.slug ?? "missing-slug", projectId },
+        query: { limit: "500", resourceType: "key", providerKind: "crowdin" },
+      },
+      {
+        headers: await authHeadersFor(identity),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as ProjectFilesResponse;
+    expect(body.files).toEqual([
+      expect.objectContaining({
+        sourcePath: "keys/home.title",
+        provider: expect.objectContaining({
+          kind: "crowdin",
+          resourceType: "key",
+        }),
+      }),
+    ]);
+  });
+
   it("limits provider-backed files when listing project files", async () => {
     const identity = createWorkosIdentity();
     const createdResponse = await createProjectViaApi(identity);

--- a/apps/hyperlocalise-web/src/api/routes/workspace-files/workspace-files.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/workspace-files/workspace-files.route.ts
@@ -1,4 +1,4 @@
-import { desc, eq } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { validator } from "hono/validator";
 
@@ -24,10 +24,18 @@ export function createWorkspaceFilesRoutes() {
     .use("*", workosAuthMiddleware)
     .get("/", validateWorkspaceFilesQuery, async (c) => {
       const query = c.req.valid("query");
+      const projectWhere =
+        query.projectId && query.projectId !== "all"
+          ? and(
+              eq(schema.projects.organizationId, c.var.auth.organization.localOrganizationId),
+              eq(schema.projects.id, query.projectId),
+            )
+          : eq(schema.projects.organizationId, c.var.auth.organization.localOrganizationId);
+
       const projects = await db
         .select({ id: schema.projects.id, name: schema.projects.name })
         .from(schema.projects)
-        .where(eq(schema.projects.organizationId, c.var.auth.organization.localOrganizationId))
+        .where(projectWhere)
         .orderBy(desc(schema.projects.createdAt));
 
       const files = await listWorkspaceFiles({

--- a/apps/hyperlocalise-web/src/api/routes/workspace-files/workspace-files.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/workspace-files/workspace-files.route.ts
@@ -1,0 +1,51 @@
+import { desc, eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { validator } from "hono/validator";
+
+import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
+import { db, schema } from "@/lib/database";
+import { listWorkspaceFiles } from "@/lib/projects/project-files";
+
+import { projectFilesQuerySchema } from "../project/project.schema";
+import { invalidProjectPayloadResponse } from "../project/project.shared";
+
+const validateWorkspaceFilesQuery = validator("query", (value, c) => {
+  const parsed = projectFilesQuerySchema.safeParse(value);
+
+  if (!parsed.success) {
+    return invalidProjectPayloadResponse(c);
+  }
+
+  return parsed.data;
+});
+
+export function createWorkspaceFilesRoutes() {
+  return new Hono<{ Variables: AuthVariables }>()
+    .use("*", workosAuthMiddleware)
+    .get("/", validateWorkspaceFilesQuery, async (c) => {
+      const query = c.req.valid("query");
+      const projects = await db
+        .select({ id: schema.projects.id, name: schema.projects.name })
+        .from(schema.projects)
+        .where(eq(schema.projects.organizationId, c.var.auth.organization.localOrganizationId))
+        .orderBy(desc(schema.projects.createdAt));
+
+      const files = await listWorkspaceFiles({
+        organizationId: c.var.auth.organization.localOrganizationId,
+        projects: projects.map((project) => ({
+          projectId: project.id,
+          projectName: project.name,
+        })),
+        query: {
+          ...query,
+          origin: query.origin ?? "all",
+          resourceType: query.resourceType ?? "all",
+          providerKind: query.providerKind ?? "all",
+          locale: query.locale ?? "all",
+          syncState: query.syncState ?? "all",
+        },
+      });
+
+      return c.json({ files }, 200);
+    });
+}

--- a/apps/hyperlocalise-web/src/api/routes/workspace-files/workspace-files.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/workspace-files/workspace-files.test.ts
@@ -1,0 +1,86 @@
+import "dotenv/config";
+
+import { testClient } from "hono/testing";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
+
+import { app } from "@/api/app";
+import { db } from "@/lib/database";
+import { upsertExternalTmsFile } from "@/lib/providers/organization-external-tms-files";
+
+import { createProjectTestFixture } from "../project/project.fixture";
+import type { ProjectResponse, WorkspaceFilesResponse } from "../project/project.schema";
+
+const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
+  resolveApiAuthContextFromSessionMock: vi.fn(
+    (options) =>
+      globalThis.__resolveTestApiAuthContextFromSession?.(options) ??
+      globalThis.__testApiAuthContext ??
+      null,
+  ),
+}));
+
+vi.mock("@/api/auth/workos-session", () => ({
+  resolveApiAuthContextFromSession: resolveApiAuthContextFromSessionMock,
+}));
+
+const client = testClient(app);
+const projectFixture = createProjectTestFixture(client);
+const { authHeadersFor, createProjectViaApi, createWorkosIdentity } = projectFixture;
+
+beforeAll(async () => {
+  await db.$client.query("select 1");
+});
+
+afterEach(async () => {
+  vi.clearAllMocks();
+  await projectFixture.cleanup();
+});
+
+describe("workspace files API", () => {
+  it("lists provider-backed files across projects with project metadata", async () => {
+    const identity = createWorkosIdentity();
+    const createdResponse = await createProjectViaApi(identity, { name: "Marketing site" });
+    const createdBody = (await createdResponse.json()) as ProjectResponse;
+    const projectId = createdBody.project.id;
+
+    await upsertExternalTmsFile({
+      organizationId: createdBody.project.organizationId,
+      projectId,
+      providerKind: "phrase",
+      externalProjectId: "phrase-project-1",
+      resourceType: "file",
+      externalResourceId: "file-1",
+      sourcePath: "locales/en/home.json",
+      displayName: "home.json",
+      syncState: "synced",
+      lastSyncedAt: new Date("2026-01-02T00:00:00.000Z"),
+    });
+
+    const response = await client.api.orgs[":organizationSlug"]["workspace-files"].$get(
+      {
+        param: { organizationSlug: identity.organization.slug ?? "missing-slug" },
+        query: { limit: "500", origin: "provider" },
+      },
+      {
+        headers: await authHeadersFor(identity),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as WorkspaceFilesResponse;
+    expect(body.files).toEqual([
+      expect.objectContaining({
+        projectId,
+        projectName: "Marketing site",
+        origin: "provider",
+        sourcePath: "locales/en/home.json",
+        provider: expect.objectContaining({
+          kind: "phrase",
+          resourceType: "file",
+          syncState: "synced",
+          lastSyncedAt: "2026-01-02T00:00:00.000Z",
+        }),
+      }),
+    ]);
+  });
+});

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/_components/workspace-files-shared.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/_components/workspace-files-shared.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useMemo } from "react";
 import { SearchIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 
@@ -324,40 +323,4 @@ export function WorkspaceFilesFilterBar({
       </div>
     </div>
   );
-}
-
-export function useClientFileFilters(files: ProjectFileRecord[], filters: WorkspaceFileFilters) {
-  return useMemo(() => {
-    const search = filters.search.trim().toLowerCase();
-
-    return files.filter((file) => {
-      if (filters.origin !== "all" && file.origin !== filters.origin) return false;
-      if (filters.resourceType !== "all") {
-        const type = file.provider?.resourceType ?? "file";
-        if (type !== filters.resourceType) return false;
-      }
-      if (filters.providerKind !== "all" && file.provider?.kind !== filters.providerKind) {
-        return false;
-      }
-      if (filters.syncState !== "all") {
-        const state = file.provider?.syncState ?? "";
-        if (state !== filters.syncState) return false;
-      }
-      if (filters.locale !== "all") {
-        const locales = [
-          file.provider?.sourceLocale,
-          ...(file.provider?.targetLocales ?? []),
-        ].filter(Boolean);
-        if (!locales.includes(filters.locale)) return false;
-      }
-      if (search) {
-        const haystack = [file.sourcePath, file.filename, file.provider?.kind]
-          .filter(Boolean)
-          .join(" ")
-          .toLowerCase();
-        if (!haystack.includes(search)) return false;
-      }
-      return true;
-    });
-  }, [files, filters]);
 }

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/_components/workspace-files-shared.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/_components/workspace-files-shared.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect } from "react";
 import { SearchIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 
@@ -78,6 +79,28 @@ export const defaultWorkspaceFileFilters: WorkspaceFileFilters = {
   syncState: "all",
   projectId: "all",
 };
+
+export function workspaceFileFiltersWithoutLocale(
+  filters: WorkspaceFileFilters,
+): WorkspaceFileFilters {
+  return { ...filters, locale: "all" };
+}
+
+export function useStaleLocaleFilterReset(
+  filters: WorkspaceFileFilters,
+  onFiltersChange: (next: WorkspaceFileFilters) => void,
+  localeOptions: string[],
+) {
+  useEffect(() => {
+    if (filters.locale === "all") {
+      return;
+    }
+
+    if (!localeOptions.includes(filters.locale)) {
+      onFiltersChange({ ...filters, locale: "all" });
+    }
+  }, [filters, localeOptions, onFiltersChange]);
+}
 
 const PROVIDER_LABELS: Record<string, string> = {
   crowdin: "Crowdin",

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/_components/workspace-files-shared.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/_components/workspace-files-shared.tsx
@@ -1,0 +1,363 @@
+"use client";
+
+import { useMemo } from "react";
+import { SearchIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+import type { ProjectFileRecord, ProjectFilesQuery } from "@/api/routes/project/project.schema";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+
+import { toneClass, type Tone } from "./workspace-resource-shared";
+
+export type WorkspaceFileFilters = {
+  search: string;
+  origin: string;
+  resourceType: string;
+  providerKind: string;
+  locale: string;
+  syncState: string;
+  projectId: string;
+};
+
+type ProjectFilesApiQuery = {
+  limit: string;
+  search?: string;
+  origin?: NonNullable<ProjectFilesQuery["origin"]>;
+  resourceType?: NonNullable<ProjectFilesQuery["resourceType"]>;
+  providerKind?: NonNullable<ProjectFilesQuery["providerKind"]>;
+  locale?: string;
+  syncState?: string;
+  projectId?: string;
+};
+
+export function toProjectFilesApiQuery(filters: WorkspaceFileFilters): ProjectFilesApiQuery {
+  const query: ProjectFilesApiQuery = {
+    limit: "500",
+  };
+
+  const search = filters.search.trim();
+  if (search) {
+    query.search = search;
+  }
+  if (filters.origin !== "all") {
+    query.origin = filters.origin as NonNullable<ProjectFilesQuery["origin"]>;
+  }
+  if (filters.resourceType !== "all") {
+    query.resourceType = filters.resourceType as NonNullable<ProjectFilesQuery["resourceType"]>;
+  }
+  if (filters.providerKind !== "all") {
+    query.providerKind = filters.providerKind as NonNullable<ProjectFilesQuery["providerKind"]>;
+  }
+  if (filters.locale !== "all") {
+    query.locale = filters.locale;
+  }
+  if (filters.syncState !== "all") {
+    query.syncState = filters.syncState;
+  }
+  if (filters.projectId !== "all") {
+    query.projectId = filters.projectId;
+  }
+
+  return query;
+}
+
+export const defaultWorkspaceFileFilters: WorkspaceFileFilters = {
+  search: "",
+  origin: "all",
+  resourceType: "all",
+  providerKind: "all",
+  locale: "all",
+  syncState: "all",
+  projectId: "all",
+};
+
+const PROVIDER_LABELS: Record<string, string> = {
+  crowdin: "Crowdin",
+  smartling: "Smartling",
+  phrase: "Phrase",
+  lokalise: "Lokalise",
+};
+
+const RELATIVE_TIME_FORMATTER = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
+
+export function formatRelativeTimestamp(value: string | null) {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  const deltaSeconds = Math.round((date.getTime() - Date.now()) / 1000);
+  const absoluteSeconds = Math.abs(deltaSeconds);
+  if (absoluteSeconds < 60) return RELATIVE_TIME_FORMATTER.format(deltaSeconds, "second");
+  if (absoluteSeconds < 3_600)
+    return RELATIVE_TIME_FORMATTER.format(Math.round(deltaSeconds / 60), "minute");
+  if (absoluteSeconds < 86_400)
+    return RELATIVE_TIME_FORMATTER.format(Math.round(deltaSeconds / 3_600), "hour");
+  if (absoluteSeconds < 2_592_000)
+    return RELATIVE_TIME_FORMATTER.format(Math.round(deltaSeconds / 86_400), "day");
+  return date.toLocaleDateString();
+}
+
+export function providerLabel(kind: string) {
+  return PROVIDER_LABELS[kind] ?? kind;
+}
+
+function syncTone(syncState: string): Tone {
+  switch (syncState) {
+    case "synced":
+      return "safe";
+    case "stale":
+    case "changed":
+      return "watch";
+    case "pending":
+      return "info";
+    default:
+      return "info";
+  }
+}
+
+export function ProviderKindBadge({ kind }: { kind: string }) {
+  return (
+    <Badge variant="secondary" className="rounded-full text-[10px]">
+      {providerLabel(kind)}
+    </Badge>
+  );
+}
+
+export function SourceOriginBadge({ origin }: { origin: ProjectFileRecord["origin"] }) {
+  return (
+    <Badge variant="outline" className="rounded-full text-[10px]">
+      {origin === "provider" ? "Provider" : "Repository"}
+    </Badge>
+  );
+}
+
+export function ResourceTypeBadge({
+  resourceType,
+}: {
+  resourceType: "file" | "key" | null | undefined;
+}) {
+  if (!resourceType) return null;
+  return (
+    <Badge variant="outline" className="rounded-full text-[10px] uppercase">
+      {resourceType}
+    </Badge>
+  );
+}
+
+export function SyncStateBadge({ syncState }: { syncState: string }) {
+  return (
+    <Badge
+      variant="outline"
+      className={cn("rounded-full text-[10px]", toneClass(syncTone(syncState)))}
+    >
+      {syncState}
+    </Badge>
+  );
+}
+
+export function collectLocaleOptions(files: ProjectFileRecord[]) {
+  const locales = new Set<string>();
+  for (const file of files) {
+    if (file.provider?.sourceLocale) {
+      locales.add(file.provider.sourceLocale);
+    }
+    for (const locale of file.provider?.targetLocales ?? []) {
+      locales.add(locale);
+    }
+  }
+  return Array.from(locales).sort((a, b) => a.localeCompare(b));
+}
+
+export function summarizeLocaleReadiness(localeReadiness: Record<string, unknown>) {
+  const entries = Object.entries(localeReadiness);
+  if (entries.length === 0) return null;
+
+  const ready = entries.filter(([, value]) => value === "ready" || value === "complete").length;
+  const missing = entries.filter(([, value]) => value === "missing" || value === "stale").length;
+  const changed = entries.filter(([, value]) => value === "changed").length;
+
+  const parts: string[] = [];
+  if (ready > 0) parts.push(`${ready} ready`);
+  if (missing > 0) parts.push(`${missing} missing`);
+  if (changed > 0) parts.push(`${changed} changed`);
+
+  return parts.length > 0 ? parts.join(" · ") : `${entries.length} locales`;
+}
+
+export function WorkspaceFilesFilterBar({
+  filters,
+  onFiltersChange,
+  localeOptions,
+  projectOptions,
+  showProjectFilter = true,
+}: {
+  filters: WorkspaceFileFilters;
+  onFiltersChange: (next: WorkspaceFileFilters) => void;
+  localeOptions: string[];
+  projectOptions: { id: string; name: string }[];
+  showProjectFilter?: boolean;
+}) {
+  const update = (patch: Partial<WorkspaceFileFilters>) => {
+    onFiltersChange({ ...filters, ...patch });
+  };
+
+  return (
+    <div className="flex flex-col gap-3 rounded-lg border border-foreground/8 bg-foreground/2.5 p-4">
+      <div className="relative">
+        <HugeiconsIcon
+          icon={SearchIcon}
+          strokeWidth={1.8}
+          className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-foreground/34"
+        />
+        <Input
+          value={filters.search}
+          onChange={(event) => update({ search: event.target.value })}
+          placeholder="Search by path, name, or provider ID"
+          className="pl-9"
+        />
+      </div>
+
+      <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
+        {showProjectFilter ? (
+          <Select
+            value={filters.projectId}
+            onValueChange={(value) => update({ projectId: value ?? "all" })}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Project" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All projects</SelectItem>
+              {projectOptions.map((project) => (
+                <SelectItem key={project.id} value={project.id}>
+                  {project.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        ) : null}
+
+        <Select
+          value={filters.origin}
+          onValueChange={(value) => update({ origin: value ?? "all" })}
+        >
+          <SelectTrigger>
+            <SelectValue placeholder="Source" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All sources</SelectItem>
+            <SelectItem value="repository">Repository</SelectItem>
+            <SelectItem value="provider">Provider</SelectItem>
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={filters.resourceType}
+          onValueChange={(value) => update({ resourceType: value ?? "all" })}
+        >
+          <SelectTrigger>
+            <SelectValue placeholder="Type" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All types</SelectItem>
+            <SelectItem value="file">Files</SelectItem>
+            <SelectItem value="key">Keys</SelectItem>
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={filters.providerKind}
+          onValueChange={(value) => update({ providerKind: value ?? "all" })}
+        >
+          <SelectTrigger>
+            <SelectValue placeholder="Provider" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All providers</SelectItem>
+            <SelectItem value="crowdin">Crowdin</SelectItem>
+            <SelectItem value="smartling">Smartling</SelectItem>
+            <SelectItem value="phrase">Phrase</SelectItem>
+            <SelectItem value="lokalise">Lokalise</SelectItem>
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={filters.locale}
+          onValueChange={(value) => update({ locale: value ?? "all" })}
+        >
+          <SelectTrigger>
+            <SelectValue placeholder="Locale" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All locales</SelectItem>
+            {localeOptions.map((locale) => (
+              <SelectItem key={locale} value={locale}>
+                {locale}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={filters.syncState}
+          onValueChange={(value) => update({ syncState: value ?? "all" })}
+        >
+          <SelectTrigger>
+            <SelectValue placeholder="Sync state" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All sync states</SelectItem>
+            <SelectItem value="synced">Synced</SelectItem>
+            <SelectItem value="pending">Pending</SelectItem>
+            <SelectItem value="stale">Stale</SelectItem>
+            <SelectItem value="changed">Changed</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}
+
+export function useClientFileFilters(files: ProjectFileRecord[], filters: WorkspaceFileFilters) {
+  return useMemo(() => {
+    const search = filters.search.trim().toLowerCase();
+
+    return files.filter((file) => {
+      if (filters.origin !== "all" && file.origin !== filters.origin) return false;
+      if (filters.resourceType !== "all") {
+        const type = file.provider?.resourceType ?? "file";
+        if (type !== filters.resourceType) return false;
+      }
+      if (filters.providerKind !== "all" && file.provider?.kind !== filters.providerKind) {
+        return false;
+      }
+      if (filters.syncState !== "all") {
+        const state = file.provider?.syncState ?? "";
+        if (state !== filters.syncState) return false;
+      }
+      if (filters.locale !== "all") {
+        const locales = [
+          file.provider?.sourceLocale,
+          ...(file.provider?.targetLocales ?? []),
+        ].filter(Boolean);
+        if (!locales.includes(filters.locale)) return false;
+      }
+      if (search) {
+        const haystack = [file.sourcePath, file.filename, file.provider?.kind]
+          .filter(Boolean)
+          .join(" ")
+          .toLowerCase();
+        if (!haystack.includes(search)) return false;
+      }
+      return true;
+    });
+  }, [files, filters]);
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/_components/workspace-files-shared.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/_components/workspace-files-shared.tsx
@@ -154,9 +154,16 @@ export function ProviderKindBadge({ kind }: { kind: string }) {
 }
 
 export function SourceOriginBadge({ origin }: { origin: ProjectFileRecord["origin"] }) {
+  const label =
+    origin === "combined"
+      ? "Repository + Provider"
+      : origin === "provider"
+        ? "Provider"
+        : "Repository";
+
   return (
     <Badge variant="outline" className="rounded-full text-[10px]">
-      {origin === "provider" ? "Provider" : "Repository"}
+      {label}
     </Badge>
   );
 }

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/files/_components/files-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/files/_components/files-page-content.tsx
@@ -1,16 +1,41 @@
 "use client";
 
+import { useMemo, useState } from "react";
 import Link from "next/link";
-import { Folder01Icon, FolderKanbanIcon } from "@hugeicons/core-free-icons";
+import { ArrowRight01Icon, File01Icon, Folder01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useQuery } from "@tanstack/react-query";
 
+import type {
+  WorkspaceFileRecord,
+  WorkspaceFilesResponse,
+} from "@/api/routes/project/project.schema";
 import { apiClient } from "@/lib/api-client-instance";
 
+import {
+  collectLocaleOptions,
+  defaultWorkspaceFileFilters,
+  formatRelativeTimestamp,
+  ProviderKindBadge,
+  ResourceTypeBadge,
+  SourceOriginBadge,
+  summarizeLocaleReadiness,
+  SyncStateBadge,
+  WorkspaceFilesFilterBar,
+  toProjectFilesApiQuery,
+  type WorkspaceFileFilters,
+} from "../../_components/workspace-files-shared";
 import { PageHeader } from "../../_components/workspace-resource-shared";
 import { TypographyH3, TypographyP } from "@/components/ui/typography";
 
+function fileDetailHref(organizationSlug: string, file: WorkspaceFileRecord) {
+  const params = new URLSearchParams({ sourcePath: file.sourcePath });
+  return `/org/${organizationSlug}/projects/${file.projectId}/files?${params.toString()}`;
+}
+
 export function FilesPageContent({ organizationSlug }: { organizationSlug: string }) {
+  const [filters, setFilters] = useState<WorkspaceFileFilters>(defaultWorkspaceFileFilters);
+
   const projectsQuery = useQuery({
     queryKey: ["translation-projects", organizationSlug],
     queryFn: async () => {
@@ -27,7 +52,49 @@ export function FilesPageContent({ organizationSlug }: { organizationSlug: strin
     },
   });
 
-  const projects = projectsQuery.data ?? [];
+  const filesQuery = useQuery({
+    queryKey: ["workspace-files", organizationSlug, filters],
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"]["workspace-files"].$get({
+        param: { organizationSlug },
+        query: toProjectFilesApiQuery(filters),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to load files (${response.status})`);
+      }
+
+      return (await response.json()) as WorkspaceFilesResponse;
+    },
+  });
+
+  const files = filesQuery.data?.files ?? [];
+  const localeOptions = useMemo(() => collectLocaleOptions(files), [files]);
+  const projectOptions = useMemo(
+    () =>
+      (projectsQuery.data ?? []).map((project) => ({
+        id: project.id,
+        name: project.name,
+      })),
+    [projectsQuery.data],
+  );
+
+  const groupedByProject = useMemo(() => {
+    const groups = new Map<string, { projectName: string; files: WorkspaceFileRecord[] }>();
+
+    for (const file of files) {
+      const existing = groups.get(file.projectId);
+      if (existing) {
+        existing.files.push(file);
+      } else {
+        groups.set(file.projectId, { projectName: file.projectName, files: [file] });
+      }
+    }
+
+    return Array.from(groups.entries()).sort(([, a], [, b]) =>
+      a.projectName.localeCompare(b.projectName),
+    );
+  }, [files]);
 
   return (
     <div className="mx-auto flex w-full max-w-6xl flex-col gap-5">
@@ -35,55 +102,115 @@ export function FilesPageContent({ organizationSlug }: { organizationSlug: strin
         icon={Folder01Icon}
         label="Workspace"
         title="Files"
-        description="Browse repository source files by project. Select a project to view its file tree and translation jobs."
+        description="Browse repository source files and synced TMS provider files and keys across projects."
       />
 
-      {projectsQuery.isLoading ? (
-        <TypographyP className="text-sm text-foreground/52">Loading projects…</TypographyP>
-      ) : projectsQuery.isError ? (
-        <TypographyP className="text-sm text-flame-100">Failed to load projects.</TypographyP>
-      ) : projects.length === 0 ? (
+      <WorkspaceFilesFilterBar
+        filters={filters}
+        onFiltersChange={setFilters}
+        localeOptions={localeOptions}
+        projectOptions={projectOptions}
+      />
+
+      {filesQuery.isLoading || projectsQuery.isLoading ? (
+        <TypographyP className="text-sm text-foreground/52">Loading files…</TypographyP>
+      ) : filesQuery.isError ? (
+        <TypographyP className="text-sm text-flame-100">Failed to load files.</TypographyP>
+      ) : files.length === 0 ? (
         <div className="flex min-h-56 flex-col justify-between gap-8 rounded-lg border border-foreground/8 bg-foreground/2.5 p-8">
           <div className="max-w-xl">
             <TypographyP className="text-sm font-medium text-foreground">
-              Create your first localization project
+              No files match these filters
             </TypographyP>
             <TypographyP className="mt-2 text-sm leading-6 text-foreground/52">
-              Projects are where repository source files live. Create a project to start browsing
-              and translating files.
+              Sync files from a connected TMS provider or upload repository source files in a
+              project to see them here.
             </TypographyP>
             <Link
               href={`/org/${organizationSlug}/integrations`}
               className="mt-3 inline-flex items-center gap-2 text-sm text-foreground/54 hover:text-foreground"
             >
-              <span>Or connect a TMS provider to import existing files</span>
+              <span>Connect a TMS provider</span>
             </Link>
           </div>
         </div>
       ) : (
-        <div className="grid gap-3 lg:grid-cols-2">
-          {projects.map((project) => (
-            <Link
-              key={project.id}
-              href={`/org/${organizationSlug}/projects/${project.id}/files`}
-              className="min-w-0 rounded-lg border border-foreground/8 bg-foreground/2.5 p-4 transition-colors hover:border-foreground/14 hover:bg-foreground/4"
+        <div className="flex flex-col gap-6">
+          {groupedByProject.map(([projectId, group]) => (
+            <section
+              key={projectId}
+              className="rounded-lg border border-foreground/8 bg-foreground/2.5"
             >
-              <div className="flex items-start gap-3">
-                <HugeiconsIcon
-                  icon={FolderKanbanIcon}
-                  strokeWidth={1.8}
-                  className="mt-0.5 size-5 shrink-0 text-foreground/42"
-                />
-                <div className="min-w-0">
-                  <TypographyH3 className="min-w-0 truncate text-base font-medium text-foreground">
-                    {project.name}
-                  </TypographyH3>
-                  <TypographyP className="mt-1 truncate text-xs text-foreground/36">
-                    {project.id}
-                  </TypographyP>
-                </div>
+              <div className="flex items-center justify-between gap-3 border-b border-foreground/8 px-4 py-3">
+                <TypographyH3 className="text-base font-medium text-foreground">
+                  {group.projectName}
+                </TypographyH3>
+                <TypographyP className="text-xs text-foreground/42">
+                  {group.files.length} {group.files.length === 1 ? "file" : "files"}
+                </TypographyP>
               </div>
-            </Link>
+
+              <ul className="divide-y divide-foreground/8">
+                {group.files.map((file) => {
+                  const readiness = file.provider
+                    ? summarizeLocaleReadiness(file.provider.localeReadiness)
+                    : null;
+
+                  return (
+                    <li key={`${file.projectId}:${file.sourcePath}`}>
+                      <Link
+                        href={fileDetailHref(organizationSlug, file)}
+                        className="flex flex-col gap-2 px-4 py-3 transition-colors hover:bg-foreground/4 sm:flex-row sm:items-center sm:justify-between"
+                      >
+                        <div className="flex min-w-0 items-start gap-3">
+                          <HugeiconsIcon
+                            icon={File01Icon}
+                            strokeWidth={1.8}
+                            className="mt-0.5 size-4 shrink-0 text-foreground/42"
+                          />
+                          <div className="min-w-0">
+                            <TypographyP className="truncate text-sm font-medium text-foreground">
+                              {file.filename}
+                            </TypographyP>
+                            <TypographyP className="mt-0.5 truncate font-mono text-xs text-foreground/42">
+                              {file.sourcePath}
+                            </TypographyP>
+                            {readiness ? (
+                              <TypographyP className="mt-1 text-xs text-foreground/42">
+                                Locales: {readiness}
+                              </TypographyP>
+                            ) : null}
+                          </div>
+                        </div>
+
+                        <div className="flex flex-wrap items-center gap-2 sm:justify-end">
+                          <SourceOriginBadge origin={file.origin} />
+                          {file.provider ? (
+                            <>
+                              <ProviderKindBadge kind={file.provider.kind} />
+                              <ResourceTypeBadge resourceType={file.provider.resourceType} />
+                              <SyncStateBadge syncState={file.provider.syncState} />
+                              <TypographyP className="text-xs text-foreground/42">
+                                Synced {formatRelativeTimestamp(file.provider.lastSyncedAt)}
+                              </TypographyP>
+                            </>
+                          ) : (
+                            <TypographyP className="text-xs text-foreground/42">
+                              Updated {formatRelativeTimestamp(file.uploadedAt)}
+                            </TypographyP>
+                          )}
+                          <HugeiconsIcon
+                            icon={ArrowRight01Icon}
+                            strokeWidth={1.8}
+                            className="size-4 text-foreground/34"
+                          />
+                        </div>
+                      </Link>
+                    </li>
+                  );
+                })}
+              </ul>
+            </section>
           ))}
         </div>
       )}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/files/_components/files-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/files/_components/files-page-content.tsx
@@ -77,6 +77,7 @@ export function FilesPageContent({ organizationSlug }: { organizationSlug: strin
 
   const localeDiscoveryQuery = useQuery({
     queryKey: ["workspace-files-locales", organizationSlug, filtersForLocaleOptions],
+    placeholderData: (previousData) => previousData,
     queryFn: async () => {
       const response = await apiClient.api.orgs[":organizationSlug"]["workspace-files"].$get({
         param: { organizationSlug },

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/files/_components/files-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/files/_components/files-page-content.tsx
@@ -21,8 +21,10 @@ import {
   SourceOriginBadge,
   summarizeLocaleReadiness,
   SyncStateBadge,
+  useStaleLocaleFilterReset,
   WorkspaceFilesFilterBar,
   toProjectFilesApiQuery,
+  workspaceFileFiltersWithoutLocale,
   type WorkspaceFileFilters,
 } from "../../_components/workspace-files-shared";
 import { PageHeader } from "../../_components/workspace-resource-shared";
@@ -52,6 +54,11 @@ export function FilesPageContent({ organizationSlug }: { organizationSlug: strin
     },
   });
 
+  const filtersForLocaleOptions = useMemo(
+    () => workspaceFileFiltersWithoutLocale(filters),
+    [filters],
+  );
+
   const filesQuery = useQuery({
     queryKey: ["workspace-files", organizationSlug, filters],
     queryFn: async () => {
@@ -68,8 +75,29 @@ export function FilesPageContent({ organizationSlug }: { organizationSlug: strin
     },
   });
 
+  const localeDiscoveryQuery = useQuery({
+    queryKey: ["workspace-files-locales", organizationSlug, filtersForLocaleOptions],
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"]["workspace-files"].$get({
+        param: { organizationSlug },
+        query: toProjectFilesApiQuery(filtersForLocaleOptions),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to load locale options (${response.status})`);
+      }
+
+      return (await response.json()) as WorkspaceFilesResponse;
+    },
+  });
+
   const files = filesQuery.data?.files ?? [];
-  const localeOptions = useMemo(() => collectLocaleOptions(files), [files]);
+  const localeOptions = useMemo(
+    () => collectLocaleOptions(localeDiscoveryQuery.data?.files ?? []),
+    [localeDiscoveryQuery.data],
+  );
+
+  useStaleLocaleFilterReset(filters, setFilters, localeOptions);
   const projectOptions = useMemo(
     () =>
       (projectsQuery.data ?? []).map((project) => ({

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/files/_components/files-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/files/_components/files-page-content.tsx
@@ -186,7 +186,7 @@ export function FilesPageContent({ organizationSlug }: { organizationSlug: strin
                     : null;
 
                   return (
-                    <li key={`${file.projectId}:${file.sourcePath}`}>
+                    <li key={`${file.projectId}:${file.origin}:${file.sourcePath}`}>
                       <Link
                         href={fileDetailHref(organizationSlug, file)}
                         className="flex flex-col gap-2 px-4 py-3 transition-colors hover:bg-foreground/4 sm:flex-row sm:items-center sm:justify-between"

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
@@ -406,6 +406,7 @@ export function ProjectFilesPageContent({
 
   const localeDiscoveryQuery = useQuery({
     queryKey: ["project-files-locales", organizationSlug, projectId, filtersForLocaleOptions],
+    placeholderData: (previousData) => previousData,
     queryFn: async () => {
       const response = await apiClient.api.orgs[":organizationSlug"].projects[
         ":projectId"

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
@@ -447,6 +447,8 @@ export function ProjectFilesPageContent({
   useStaleLocaleFilterReset(filters, setFilters, localeOptions);
   const tree = buildTree(files);
   const selectedFile = files.find((f) => f.sourcePath === selectedPath);
+  const providerOnlyFilterActive =
+    filters.origin === "all" && (filters.locale !== "all" || filters.syncState !== "all");
   const fileDetail = fileDetailQuery.data?.file;
   const versions = useMemo(() => fileDetail?.versions ?? [], [fileDetail?.versions]);
   const selectedVersion =
@@ -485,12 +487,6 @@ export function ProjectFilesPageContent({
       current && versions.some((version) => version.id === current) ? current : versions[1]?.id,
     );
   }, [versions]);
-
-  useEffect(() => {
-    if (initialSourcePath) {
-      setSelectedPath(initialSourcePath);
-    }
-  }, [initialSourcePath]);
 
   useEffect(() => {
     if (filesQuery.isLoading || filesQuery.isFetching) {
@@ -590,7 +586,9 @@ export function ProjectFilesPageContent({
                 className="size-8 text-foreground/24"
               />
               <TypographyP className="text-sm text-foreground/52">
-                No source files found for this project.
+                {providerOnlyFilterActive
+                  ? "No provider-backed files match these filters. Locale and sync-state filters do not include repository files."
+                  : "No source files found for this project."}
               </TypographyP>
             </div>
           ) : (

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
@@ -29,7 +29,9 @@ import {
   summarizeLocaleReadiness,
   SyncStateBadge,
   toProjectFilesApiQuery,
+  useStaleLocaleFilterReset,
   WorkspaceFilesFilterBar,
+  workspaceFileFiltersWithoutLocale,
   type WorkspaceFileFilters,
 } from "../../../../_components/workspace-files-shared";
 import {
@@ -380,6 +382,11 @@ export function ProjectFilesPageContent({
     },
   });
 
+  const filtersForLocaleOptions = useMemo(
+    () => workspaceFileFiltersWithoutLocale(filters),
+    [filters],
+  );
+
   const filesQuery = useQuery({
     queryKey: ["project-files", organizationSlug, projectId, filters],
     queryFn: async () => {
@@ -391,6 +398,23 @@ export function ProjectFilesPageContent({
       });
       if (!response.ok) {
         throw new Error(`Failed to load files (${response.status})`);
+      }
+      const body = await response.json();
+      return body.files as ProjectFileRecord[];
+    },
+  });
+
+  const localeDiscoveryQuery = useQuery({
+    queryKey: ["project-files-locales", organizationSlug, projectId, filtersForLocaleOptions],
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"].projects[
+        ":projectId"
+      ].files.$get({
+        param: { organizationSlug, projectId },
+        query: toProjectFilesApiQuery(filtersForLocaleOptions),
+      });
+      if (!response.ok) {
+        throw new Error(`Failed to load locale options (${response.status})`);
       }
       const body = await response.json();
       return body.files as ProjectFileRecord[];
@@ -415,7 +439,12 @@ export function ProjectFilesPageContent({
   });
 
   const files = filesQuery.data ?? [];
-  const localeOptions = useMemo(() => collectLocaleOptions(files), [files]);
+  const localeOptions = useMemo(
+    () => collectLocaleOptions(localeDiscoveryQuery.data ?? []),
+    [localeDiscoveryQuery.data],
+  );
+
+  useStaleLocaleFilterReset(filters, setFilters, localeOptions);
   const tree = buildTree(files);
   const selectedFile = files.find((f) => f.sourcePath === selectedPath);
   const fileDetail = fileDetailQuery.data?.file;

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import {
   ArrowLeft01Icon,
   Download01Icon,
@@ -18,6 +19,19 @@ import { Button } from "@/components/ui/button";
 import { apiClient } from "@/lib/api-client-instance";
 import { cn } from "@/lib/utils";
 
+import {
+  collectLocaleOptions,
+  defaultWorkspaceFileFilters,
+  formatRelativeTimestamp,
+  ProviderKindBadge,
+  ResourceTypeBadge,
+  SourceOriginBadge,
+  summarizeLocaleReadiness,
+  SyncStateBadge,
+  toProjectFilesApiQuery,
+  WorkspaceFilesFilterBar,
+  type WorkspaceFileFilters,
+} from "../../../../_components/workspace-files-shared";
 import {
   PageHeader,
   toneClass,
@@ -302,10 +316,13 @@ function FileTreeNode({ node }: { node: TreeNode }) {
         <div className="flex min-w-0 flex-1 items-center gap-2">
           <span className="size-4 shrink-0" />
           <span className="truncate">{node.name}</span>
+          <SourceOriginBadge origin={node.file.origin} />
           {node.file.provider ? (
-            <Badge variant="outline" className="ml-auto shrink-0 rounded-full text-xs">
-              {node.file.provider.kind}
-            </Badge>
+            <>
+              <ProviderKindBadge kind={node.file.provider.kind} />
+              <ResourceTypeBadge resourceType={node.file.provider.resourceType} />
+              <SyncStateBadge syncState={node.file.provider.syncState} />
+            </>
           ) : null}
           {node.file.latestJob ? (
             <Badge
@@ -341,7 +358,10 @@ export function ProjectFilesPageContent({
   organizationSlug: string;
   projectId: string;
 }) {
-  const [selectedPath, setSelectedPath] = useState<string | undefined>();
+  const searchParams = useSearchParams();
+  const initialSourcePath = searchParams.get("sourcePath") ?? undefined;
+  const [filters, setFilters] = useState<WorkspaceFileFilters>(defaultWorkspaceFileFilters);
+  const [selectedPath, setSelectedPath] = useState<string | undefined>(initialSourcePath);
   const [selectedVersionId, setSelectedVersionId] = useState<string | undefined>();
   const [baseVersionId, setBaseVersionId] = useState<string | undefined>();
   const [compareVersionId, setCompareVersionId] = useState<string | undefined>();
@@ -361,13 +381,13 @@ export function ProjectFilesPageContent({
   });
 
   const filesQuery = useQuery({
-    queryKey: ["project-files", organizationSlug, projectId],
+    queryKey: ["project-files", organizationSlug, projectId, filters],
     queryFn: async () => {
       const response = await apiClient.api.orgs[":organizationSlug"].projects[
         ":projectId"
       ].files.$get({
         param: { organizationSlug, projectId },
-        query: { limit: "500" },
+        query: toProjectFilesApiQuery(filters),
       });
       if (!response.ok) {
         throw new Error(`Failed to load files (${response.status})`);
@@ -395,6 +415,7 @@ export function ProjectFilesPageContent({
   });
 
   const files = filesQuery.data ?? [];
+  const localeOptions = useMemo(() => collectLocaleOptions(files), [files]);
   const tree = buildTree(files);
   const selectedFile = files.find((f) => f.sourcePath === selectedPath);
   const fileDetail = fileDetailQuery.data?.file;
@@ -436,8 +457,21 @@ export function ProjectFilesPageContent({
     );
   }, [versions]);
 
+  useEffect(() => {
+    if (initialSourcePath) {
+      setSelectedPath(initialSourcePath);
+    }
+  }, [initialSourcePath]);
+
+  useEffect(() => {
+    if (selectedPath && !files.some((file) => file.sourcePath === selectedPath)) {
+      setSelectedPath(files[0]?.sourcePath);
+    }
+  }, [files, selectedPath]);
+
   const stats = {
     total: files.length,
+    provider: files.filter((f) => f.origin === "provider").length,
     withJobs: files.filter((f) => f.latestJob !== null).length,
     latestUpload:
       files.length > 0
@@ -461,15 +495,29 @@ export function ProjectFilesPageContent({
           icon={Folder01Icon}
           label="Project files"
           title={projectQuery.data?.name ?? "Project files"}
-          description="Browse repository source files and their latest translation jobs for this project."
+          description="Browse repository source files, synced provider files, and translation keys for this project."
         />
       </div>
 
-      <div className="grid gap-3 md:grid-cols-3">
+      <WorkspaceFilesFilterBar
+        filters={filters}
+        onFiltersChange={setFilters}
+        localeOptions={localeOptions}
+        projectOptions={[]}
+        showProjectFilter={false}
+      />
+
+      <div className="grid gap-3 md:grid-cols-4">
         <div className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-4">
-          <TypographyP className="text-sm text-foreground/52">Source files</TypographyP>
+          <TypographyP className="text-sm text-foreground/52">Matching files</TypographyP>
           <TypographyP className="mt-2 font-heading text-3xl font-medium text-foreground">
             {stats.total}
+          </TypographyP>
+        </div>
+        <div className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-4">
+          <TypographyP className="text-sm text-foreground/52">Provider-backed</TypographyP>
+          <TypographyP className="mt-2 font-heading text-3xl font-medium text-foreground">
+            {stats.provider}
           </TypographyP>
         </div>
         <div className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-4">
@@ -500,7 +548,7 @@ export function ProjectFilesPageContent({
                 className="size-8 text-foreground/24"
               />
               <TypographyP className="text-sm text-foreground/52">
-                No repository source files found for this project.
+                No source files found for this project.
               </TypographyP>
             </div>
           ) : (
@@ -552,17 +600,20 @@ export function ProjectFilesPageContent({
                         Provider
                       </TypographyP>
                       <div className="mt-1 flex flex-wrap items-center gap-2">
-                        <Badge variant="outline" className="rounded-full">
-                          {selectedFile.provider.kind}
-                        </Badge>
-                        <Badge variant="outline" className="rounded-full">
-                          {selectedFile.provider.resourceType}
-                        </Badge>
-                        <Badge variant="outline" className="rounded-full">
-                          {selectedFile.provider.syncState}
-                        </Badge>
+                        <ProviderKindBadge kind={selectedFile.provider.kind} />
+                        <ResourceTypeBadge resourceType={selectedFile.provider.resourceType} />
+                        <SyncStateBadge syncState={selectedFile.provider.syncState} />
+                        <SourceOriginBadge origin={selectedFile.origin} />
                       </div>
                     </div>
+                    <DetailRow
+                      label="Last synced"
+                      value={
+                        selectedFile.provider.lastSyncedAt
+                          ? formatRelativeTimestamp(selectedFile.provider.lastSyncedAt)
+                          : null
+                      }
+                    />
                     <DetailRow
                       label="External ID"
                       value={selectedFile.provider.externalResourceId}
@@ -580,11 +631,7 @@ export function ProjectFilesPageContent({
                     />
                     <DetailRow
                       label="Locale readiness"
-                      value={
-                        Object.keys(selectedFile.provider.localeReadiness).length > 0
-                          ? JSON.stringify(selectedFile.provider.localeReadiness)
-                          : null
-                      }
+                      value={summarizeLocaleReadiness(selectedFile.provider.localeReadiness)}
                     />
                     {selectedFile.provider.externalUrl ? (
                       <Button

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
@@ -510,7 +510,7 @@ export function ProjectFilesPageContent({
 
   const stats = {
     total: files.length,
-    provider: files.filter((f) => f.origin === "provider").length,
+    provider: files.filter((f) => f.provider !== null).length,
     withJobs: files.filter((f) => f.latestJob !== null).length,
     latestUpload:
       files.length > 0

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
@@ -464,10 +464,23 @@ export function ProjectFilesPageContent({
   }, [initialSourcePath]);
 
   useEffect(() => {
-    if (selectedPath && !files.some((file) => file.sourcePath === selectedPath)) {
-      setSelectedPath(files[0]?.sourcePath);
+    if (filesQuery.isLoading || filesQuery.isFetching) {
+      return;
     }
-  }, [files, selectedPath]);
+
+    if (files.length === 0) {
+      return;
+    }
+
+    if (!selectedPath) {
+      setSelectedPath(files[0].sourcePath);
+      return;
+    }
+
+    if (!files.some((file) => file.sourcePath === selectedPath)) {
+      setSelectedPath(files[0].sourcePath);
+    }
+  }, [files, selectedPath, filesQuery.isLoading, filesQuery.isFetching]);
 
   const stats = {
     total: files.length,

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/page.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/page.tsx
@@ -1,4 +1,7 @@
+import { Suspense } from "react";
+
 import { ProjectFilesPageContent } from "./_components/project-files-page-content";
+import { TypographyP } from "@/components/ui/typography";
 
 export default async function ProjectFilesPage({
   params,
@@ -7,5 +10,11 @@ export default async function ProjectFilesPage({
 }) {
   const { organizationSlug, projectId } = await params;
 
-  return <ProjectFilesPageContent organizationSlug={organizationSlug} projectId={projectId} />;
+  return (
+    <Suspense
+      fallback={<TypographyP className="text-sm text-foreground/52">Loading files…</TypographyP>}
+    >
+      <ProjectFilesPageContent organizationSlug={organizationSlug} projectId={projectId} />
+    </Suspense>
+  );
 }

--- a/apps/hyperlocalise-web/src/lib/async/map-with-concurrency.ts
+++ b/apps/hyperlocalise-web/src/lib/async/map-with-concurrency.ts
@@ -1,0 +1,28 @@
+export async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T) => Promise<R>,
+) {
+  if (items.length === 0) {
+    return [] as R[];
+  }
+
+  const results: R[] = Array.from({ length: items.length });
+  let nextIndex = 0;
+
+  async function worker() {
+    while (true) {
+      const currentIndex = nextIndex;
+      nextIndex += 1;
+      if (currentIndex >= items.length) {
+        return;
+      }
+
+      results[currentIndex] = await mapper(items[currentIndex] as T);
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, () => worker());
+  await Promise.all(workers);
+  return results;
+}

--- a/apps/hyperlocalise-web/src/lib/projects/project-files.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/project-files.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
+
+import { filterProjectFiles } from "./project-files";
+
+const baseFile: ProjectFileRecord = {
+  origin: "provider",
+  sourcePath: "keys/home.title",
+  sourceHash: null,
+  commitSha: null,
+  workflowRunId: null,
+  uploadedAt: "2026-01-01T00:00:00.000Z",
+  storedFileId: null,
+  metadata: {},
+  filename: "home.title",
+  byteSize: null,
+  provider: {
+    kind: "phrase",
+    resourceType: "key",
+    externalProjectId: "ext-1",
+    externalResourceId: "key-1",
+    externalUrl: null,
+    syncState: "pending",
+    sourceLocale: "en",
+    targetLocales: ["fr"],
+    localeReadiness: { fr: "missing" },
+    revision: "1",
+    format: "icu",
+    lastSyncedAt: "2026-01-02T00:00:00.000Z",
+  },
+  latestJob: null,
+};
+
+describe("filterProjectFiles", () => {
+  it("filters by origin, resource type, provider, locale, and sync state", () => {
+    const files: ProjectFileRecord[] = [
+      baseFile,
+      {
+        ...baseFile,
+        origin: "repository",
+        sourcePath: "src/en.json",
+        filename: "en.json",
+        provider: null,
+      },
+      {
+        ...baseFile,
+        sourcePath: "locales/home.json",
+        filename: "home.json",
+        provider: {
+          ...baseFile.provider!,
+          resourceType: "file",
+          syncState: "synced",
+          targetLocales: ["de"],
+        },
+      },
+    ];
+
+    expect(
+      filterProjectFiles(files, {
+        origin: "provider",
+        resourceType: "key",
+        providerKind: "phrase",
+        locale: "fr",
+        syncState: "pending",
+        search: "home.title",
+      }),
+    ).toEqual([baseFile]);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/projects/project-files.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/project-files.ts
@@ -1,9 +1,14 @@
 import { and, eq, inArray, sql } from "drizzle-orm";
 
-import type { ProjectFileRecord, ProjectFilesQuery } from "@/api/routes/project/project.schema";
+import type {
+  ProjectFileRecord,
+  ProjectFilesQuery,
+  WorkspaceFileRecord,
+} from "@/api/routes/project/project.schema";
 import { db, schema } from "@/lib/database";
 import {
   listExternalTmsFilesForProject,
+  maxExternalTmsFilesLimit,
   type ExternalTmsResourceType,
 } from "@/lib/providers/organization-external-tms-files";
 
@@ -15,10 +20,25 @@ export type ProjectFileListContext = {
 type ProjectFileJobStatus = NonNullable<ProjectFileRecord["latestJob"]>["status"];
 type ProjectFileJobType = NonNullable<ProjectFileRecord["latestJob"]>["type"];
 
-export type WorkspaceFileRecord = ProjectFileRecord & {
-  projectId: string;
-  projectName: string;
-};
+type ProjectFileFilterQuery = Pick<
+  ProjectFilesQuery,
+  "origin" | "resourceType" | "providerKind" | "locale" | "syncState" | "search"
+>;
+
+export function hasActiveProjectFileFilters(query: ProjectFileFilterQuery) {
+  return Boolean(
+    query.search?.trim() ||
+    (query.origin && query.origin !== "all") ||
+    (query.resourceType && query.resourceType !== "all") ||
+    (query.providerKind && query.providerKind !== "all") ||
+    (query.locale && query.locale !== "all") ||
+    (query.syncState && query.syncState !== "all"),
+  );
+}
+
+function resolveProviderFetchLimit(query: ProjectFileFilterQuery, responseLimit: number) {
+  return hasActiveProjectFileFilters(query) ? maxExternalTmsFilesLimit : responseLimit;
+}
 
 function matchesLocale(file: ProjectFileRecord, locale: string) {
   if (file.provider?.sourceLocale === locale) {
@@ -27,13 +47,7 @@ function matchesLocale(file: ProjectFileRecord, locale: string) {
   return file.provider?.targetLocales.includes(locale) ?? false;
 }
 
-export function filterProjectFiles(
-  files: ProjectFileRecord[],
-  query: Pick<
-    ProjectFilesQuery,
-    "origin" | "resourceType" | "providerKind" | "locale" | "syncState" | "search"
-  >,
-) {
+export function filterProjectFiles(files: ProjectFileRecord[], query: ProjectFileFilterQuery) {
   const search = query.search?.trim().toLowerCase();
 
   return files.filter((file) => {
@@ -85,10 +99,26 @@ export function filterProjectFiles(
   });
 }
 
+export async function listFilteredProjectFiles(input: {
+  organizationId: string;
+  projectId: string;
+  query: ProjectFilesQuery;
+  resourceTypes?: ExternalTmsResourceType[];
+}) {
+  const mergedFiles = await listProjectFilesForProject({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    providerFetchLimit: resolveProviderFetchLimit(input.query, input.query.limit),
+    resourceTypes: input.resourceTypes,
+  });
+
+  return filterProjectFiles(mergedFiles, input.query).slice(0, input.query.limit);
+}
+
 export async function listProjectFilesForProject(input: {
   organizationId: string;
   projectId: string;
-  limit: number;
+  providerFetchLimit?: number;
   resourceTypes?: ExternalTmsResourceType[];
 }) {
   const versionsSubquery = db
@@ -144,7 +174,7 @@ export async function listProjectFilesForProject(input: {
     organizationId: input.organizationId,
     projectId: input.projectId,
     resourceTypes: input.resourceTypes,
-    limit: input.limit,
+    limit: input.providerFetchLimit ?? maxExternalTmsFilesLimit,
   });
 
   const latestJobs = new Map<
@@ -284,21 +314,18 @@ export async function listWorkspaceFiles(input: {
       ? input.projects.filter((project) => project.projectId === input.query.projectId)
       : input.projects;
 
-  const perProjectLimit = Math.max(
-    1,
-    Math.ceil(input.query.limit / Math.max(projectIds.length, 1)),
-  );
+  const providerFetchLimit = resolveProviderFetchLimit(input.query, input.query.limit);
 
   const fileGroups = await Promise.all(
     projectIds.map(async (project) => {
       const files = await listProjectFilesForProject({
         organizationId: input.organizationId,
         projectId: project.projectId,
-        limit: perProjectLimit,
+        providerFetchLimit,
         resourceTypes,
       });
 
-      const filtered = filterProjectFiles(files, input.query).slice(0, perProjectLimit);
+      const filtered = filterProjectFiles(files, input.query);
 
       return filtered.map(
         (file): WorkspaceFileRecord => ({

--- a/apps/hyperlocalise-web/src/lib/projects/project-files.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/project-files.ts
@@ -1,0 +1,325 @@
+import { and, eq, inArray, sql } from "drizzle-orm";
+
+import type { ProjectFileRecord, ProjectFilesQuery } from "@/api/routes/project/project.schema";
+import { db, schema } from "@/lib/database";
+import {
+  listExternalTmsFilesForProject,
+  type ExternalTmsResourceType,
+} from "@/lib/providers/organization-external-tms-files";
+
+export type ProjectFileListContext = {
+  projectId: string;
+  projectName: string;
+};
+
+type ProjectFileJobStatus = NonNullable<ProjectFileRecord["latestJob"]>["status"];
+type ProjectFileJobType = NonNullable<ProjectFileRecord["latestJob"]>["type"];
+
+export type WorkspaceFileRecord = ProjectFileRecord & {
+  projectId: string;
+  projectName: string;
+};
+
+function matchesLocale(file: ProjectFileRecord, locale: string) {
+  if (file.provider?.sourceLocale === locale) {
+    return true;
+  }
+  return file.provider?.targetLocales.includes(locale) ?? false;
+}
+
+export function filterProjectFiles(
+  files: ProjectFileRecord[],
+  query: Pick<
+    ProjectFilesQuery,
+    "origin" | "resourceType" | "providerKind" | "locale" | "syncState" | "search"
+  >,
+) {
+  const search = query.search?.trim().toLowerCase();
+
+  return files.filter((file) => {
+    if (query.origin && query.origin !== "all" && file.origin !== query.origin) {
+      return false;
+    }
+
+    if (query.resourceType && query.resourceType !== "all") {
+      const resourceType = file.provider?.resourceType ?? "file";
+      if (resourceType !== query.resourceType) {
+        return false;
+      }
+    }
+
+    if (query.providerKind && query.providerKind !== "all") {
+      if (file.provider?.kind !== query.providerKind) {
+        return false;
+      }
+    }
+
+    if (query.syncState && query.syncState !== "all") {
+      if ((file.provider?.syncState ?? "repository") !== query.syncState) {
+        return false;
+      }
+    }
+
+    if (query.locale && query.locale !== "all" && !matchesLocale(file, query.locale)) {
+      return false;
+    }
+
+    if (search) {
+      const haystack = [
+        file.sourcePath,
+        file.filename,
+        file.provider?.kind,
+        file.provider?.resourceType,
+        file.provider?.externalResourceId,
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+
+      if (!haystack.includes(search)) {
+        return false;
+      }
+    }
+
+    return true;
+  });
+}
+
+export async function listProjectFilesForProject(input: {
+  organizationId: string;
+  projectId: string;
+  limit: number;
+  resourceTypes?: ExternalTmsResourceType[];
+}) {
+  const versionsSubquery = db
+    .select({
+      versionId: schema.repositorySourceFileVersions.id,
+      sourcePath: schema.repositorySourceFileVersions.sourcePath,
+      sourceHash: schema.repositorySourceFileVersions.sourceHash,
+      commitSha: schema.repositorySourceFileVersions.commitSha,
+      workflowRunId: schema.repositorySourceFileVersions.workflowRunId,
+      uploadedAt: schema.repositorySourceFileVersions.createdAt,
+      storedFileId: schema.repositorySourceFileVersions.storedFileId,
+      metadata: schema.storedFiles.metadata,
+      filename: schema.storedFiles.filename,
+      byteSize: schema.storedFiles.byteSize,
+      rowNumber:
+        sql<number>`ROW_NUMBER() OVER (PARTITION BY ${schema.repositorySourceFileVersions.sourcePath} ORDER BY ${schema.repositorySourceFileVersions.createdAt} DESC)`.as(
+          "rn",
+        ),
+    })
+    .from(schema.repositorySourceFileVersions)
+    .innerJoin(
+      schema.storedFiles,
+      eq(schema.storedFiles.id, schema.repositorySourceFileVersions.storedFileId),
+    )
+    .where(
+      and(
+        eq(schema.storedFiles.projectId, input.projectId),
+        eq(schema.storedFiles.role, "source"),
+        eq(schema.storedFiles.sourceKind, "repository_file"),
+        eq(schema.storedFiles.organizationId, input.organizationId),
+      ),
+    )
+    .as("versions_sq");
+
+  const versions = await db
+    .select({
+      versionId: versionsSubquery.versionId,
+      sourcePath: versionsSubquery.sourcePath,
+      sourceHash: versionsSubquery.sourceHash,
+      commitSha: versionsSubquery.commitSha,
+      workflowRunId: versionsSubquery.workflowRunId,
+      uploadedAt: versionsSubquery.uploadedAt,
+      storedFileId: versionsSubquery.storedFileId,
+      metadata: versionsSubquery.metadata,
+      filename: versionsSubquery.filename,
+      byteSize: versionsSubquery.byteSize,
+    })
+    .from(versionsSubquery)
+    .where(eq(versionsSubquery.rowNumber, 1));
+
+  const versionIds = versions.map((v) => v.versionId);
+  const providerFiles = await listExternalTmsFilesForProject({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    resourceTypes: input.resourceTypes,
+    limit: input.limit,
+  });
+
+  const latestJobs = new Map<
+    string,
+    {
+      jobId: string;
+      jobStatus: string;
+      jobCreatedAt: Date;
+      jobType: string;
+    }
+  >();
+
+  if (versionIds.length > 0) {
+    const jobsSubquery = db
+      .select({
+        versionId: schema.translationJobDetails.sourceFileVersionId,
+        jobId: schema.jobs.id,
+        jobStatus: schema.jobs.status,
+        jobCreatedAt: schema.jobs.createdAt,
+        jobType: schema.translationJobDetails.type,
+        rowNumber:
+          sql<number>`ROW_NUMBER() OVER (PARTITION BY ${schema.translationJobDetails.sourceFileVersionId} ORDER BY ${schema.jobs.createdAt} DESC)`.as(
+            "rn",
+          ),
+      })
+      .from(schema.jobs)
+      .innerJoin(
+        schema.translationJobDetails,
+        eq(schema.translationJobDetails.jobId, schema.jobs.id),
+      )
+      .where(
+        and(
+          eq(schema.jobs.projectId, input.projectId),
+          inArray(schema.translationJobDetails.sourceFileVersionId, versionIds),
+        ),
+      )
+      .as("jobs_sq");
+
+    const jobs = await db
+      .select({
+        versionId: jobsSubquery.versionId,
+        jobId: jobsSubquery.jobId,
+        jobStatus: jobsSubquery.jobStatus,
+        jobCreatedAt: jobsSubquery.jobCreatedAt,
+        jobType: jobsSubquery.jobType,
+      })
+      .from(jobsSubquery)
+      .where(eq(jobsSubquery.rowNumber, 1));
+
+    for (const job of jobs) {
+      if (job.versionId) {
+        latestJobs.set(job.versionId, job);
+      }
+    }
+  }
+
+  const nativeFiles: ProjectFileRecord[] = versions.map((v) => {
+    const job = latestJobs.get(v.versionId);
+    return {
+      origin: "repository" as const,
+      sourcePath: v.sourcePath,
+      sourceHash: v.sourceHash,
+      commitSha: v.commitSha,
+      workflowRunId: v.workflowRunId,
+      uploadedAt: v.uploadedAt.toISOString(),
+      storedFileId: v.storedFileId,
+      metadata: v.metadata as Record<string, unknown>,
+      filename: v.filename,
+      byteSize: v.byteSize,
+      provider: null,
+      latestJob: job
+        ? {
+            id: job.jobId,
+            status: job.jobStatus as ProjectFileJobStatus,
+            createdAt: job.jobCreatedAt.toISOString(),
+            type: job.jobType as ProjectFileJobType,
+          }
+        : null,
+    };
+  });
+
+  const nativeFileByStoredFileId = new Map(nativeFiles.map((file) => [file.storedFileId, file]));
+  const providerBackedFiles: ProjectFileRecord[] = providerFiles.map((file) => {
+    const linkedNativeFile = file.storedFileId
+      ? nativeFileByStoredFileId.get(file.storedFileId)
+      : undefined;
+
+    return {
+      origin: "provider" as const,
+      sourcePath: file.sourcePath,
+      sourceHash: file.sourceHash,
+      commitSha: null,
+      workflowRunId: null,
+      uploadedAt:
+        file.lastSyncedAt?.toISOString() ??
+        linkedNativeFile?.uploadedAt ??
+        file.updatedAt.toISOString(),
+      storedFileId: file.storedFileId,
+      metadata: file.providerPayload as Record<string, unknown>,
+      filename: file.displayName,
+      byteSize: linkedNativeFile?.byteSize ?? null,
+      provider: {
+        kind: file.providerKind,
+        resourceType: file.resourceType,
+        externalProjectId: file.externalProjectId,
+        externalResourceId: file.externalResourceId,
+        externalUrl: file.externalUrl,
+        syncState: file.syncState,
+        sourceLocale: file.sourceLocale,
+        targetLocales: file.targetLocales,
+        localeReadiness: file.localeReadiness as Record<string, unknown>,
+        revision: file.revision,
+        format: file.format,
+        lastSyncedAt: file.lastSyncedAt?.toISOString() ?? null,
+      },
+      latestJob: linkedNativeFile?.latestJob ?? null,
+    };
+  });
+
+  return [...nativeFiles, ...providerBackedFiles].sort((a, b) =>
+    a.sourcePath.localeCompare(b.sourcePath),
+  );
+}
+
+export async function listWorkspaceFiles(input: {
+  organizationId: string;
+  projects: ProjectFileListContext[];
+  query: ProjectFilesQuery;
+}) {
+  const resourceTypes =
+    input.query.resourceType && input.query.resourceType !== "all"
+      ? ([input.query.resourceType] as ExternalTmsResourceType[])
+      : undefined;
+
+  const projectIds =
+    input.query.projectId && input.query.projectId !== "all"
+      ? input.projects.filter((project) => project.projectId === input.query.projectId)
+      : input.projects;
+
+  const perProjectLimit = Math.max(
+    1,
+    Math.ceil(input.query.limit / Math.max(projectIds.length, 1)),
+  );
+
+  const fileGroups = await Promise.all(
+    projectIds.map(async (project) => {
+      const files = await listProjectFilesForProject({
+        organizationId: input.organizationId,
+        projectId: project.projectId,
+        limit: perProjectLimit,
+        resourceTypes,
+      });
+
+      const filtered = filterProjectFiles(files, input.query).slice(0, perProjectLimit);
+
+      return filtered.map(
+        (file): WorkspaceFileRecord => ({
+          ...file,
+          projectId: project.projectId,
+          projectName: project.projectName,
+        }),
+      );
+    }),
+  );
+
+  const files = fileGroups
+    .flat()
+    .sort((a, b) => {
+      const projectCompare = a.projectName.localeCompare(b.projectName);
+      if (projectCompare !== 0) {
+        return projectCompare;
+      }
+      return a.sourcePath.localeCompare(b.sourcePath);
+    })
+    .slice(0, input.query.limit);
+
+  return files;
+}

--- a/apps/hyperlocalise-web/src/lib/projects/project-files.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/project-files.ts
@@ -1,5 +1,6 @@
 import { and, eq, inArray, sql } from "drizzle-orm";
 
+import { mapWithConcurrency } from "@/lib/async/map-with-concurrency";
 import type {
   ProjectFileRecord,
   ProjectFilesQuery,
@@ -16,6 +17,8 @@ export type ProjectFileListContext = {
   projectId: string;
   projectName: string;
 };
+
+const workspaceFilesProjectConcurrency = 5;
 
 type ProjectFileJobStatus = NonNullable<ProjectFileRecord["latestJob"]>["status"];
 type ProjectFileJobType = NonNullable<ProjectFileRecord["latestJob"]>["type"];
@@ -316,8 +319,10 @@ export async function listWorkspaceFiles(input: {
 
   const providerFetchLimit = resolveProviderFetchLimit(input.query, input.query.limit);
 
-  const fileGroups = await Promise.all(
-    projectIds.map(async (project) => {
+  const fileGroups = await mapWithConcurrency(
+    projectIds,
+    workspaceFilesProjectConcurrency,
+    async (project) => {
       const files = await listProjectFilesForProject({
         organizationId: input.organizationId,
         projectId: project.projectId,
@@ -334,7 +339,7 @@ export async function listWorkspaceFiles(input: {
           projectName: project.projectName,
         }),
       );
-    }),
+    },
   );
 
   const files = fileGroups

--- a/apps/hyperlocalise-web/src/lib/projects/project-files.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/project-files.ts
@@ -9,7 +9,6 @@ import type {
 import { db, schema } from "@/lib/database";
 import {
   listExternalTmsFilesForProject,
-  maxExternalTmsFilesLimit,
   type ExternalTmsResourceType,
 } from "@/lib/providers/organization-external-tms-files";
 
@@ -28,21 +27,6 @@ type ProjectFileFilterQuery = Pick<
   "origin" | "resourceType" | "providerKind" | "locale" | "syncState" | "search"
 >;
 
-export function hasActiveProjectFileFilters(query: ProjectFileFilterQuery) {
-  return Boolean(
-    query.search?.trim() ||
-    (query.origin && query.origin !== "all") ||
-    (query.resourceType && query.resourceType !== "all") ||
-    (query.providerKind && query.providerKind !== "all") ||
-    (query.locale && query.locale !== "all") ||
-    (query.syncState && query.syncState !== "all"),
-  );
-}
-
-function resolveProviderFetchLimit(query: ProjectFileFilterQuery, responseLimit: number) {
-  return hasActiveProjectFileFilters(query) ? maxExternalTmsFilesLimit : responseLimit;
-}
-
 function matchesLocale(file: ProjectFileRecord, locale: string) {
   if (file.provider?.sourceLocale === locale) {
     return true;
@@ -50,11 +34,24 @@ function matchesLocale(file: ProjectFileRecord, locale: string) {
   return file.provider?.targetLocales.includes(locale) ?? false;
 }
 
+function matchesOrigin(
+  file: ProjectFileRecord,
+  origin: NonNullable<ProjectFileFilterQuery["origin"]>,
+) {
+  if (origin === "all") {
+    return true;
+  }
+  if (origin === "repository") {
+    return file.origin === "repository" || file.origin === "combined";
+  }
+  return file.origin === "provider" || file.origin === "combined";
+}
+
 export function filterProjectFiles(files: ProjectFileRecord[], query: ProjectFileFilterQuery) {
   const search = query.search?.trim().toLowerCase();
 
   return files.filter((file) => {
-    if (query.origin && query.origin !== "all" && file.origin !== query.origin) {
+    if (query.origin && !matchesOrigin(file, query.origin)) {
       return false;
     }
 
@@ -111,7 +108,8 @@ export async function listFilteredProjectFiles(input: {
   const mergedFiles = await listProjectFilesForProject({
     organizationId: input.organizationId,
     projectId: input.projectId,
-    providerFetchLimit: resolveProviderFetchLimit(input.query, input.query.limit),
+    providerFetchLimit: input.query.limit,
+    providerFilters: input.query,
     resourceTypes: input.resourceTypes,
   });
 
@@ -122,6 +120,7 @@ export async function listProjectFilesForProject(input: {
   organizationId: string;
   projectId: string;
   providerFetchLimit?: number;
+  providerFilters?: ProjectFileFilterQuery;
   resourceTypes?: ExternalTmsResourceType[];
 }) {
   const versionsSubquery = db
@@ -177,7 +176,8 @@ export async function listProjectFilesForProject(input: {
     organizationId: input.organizationId,
     projectId: input.projectId,
     resourceTypes: input.resourceTypes,
-    limit: input.providerFetchLimit ?? maxExternalTmsFilesLimit,
+    filters: input.providerFilters,
+    limit: input.providerFetchLimit,
   });
 
   const latestJobs = new Map<
@@ -260,10 +260,35 @@ export async function listProjectFilesForProject(input: {
   });
 
   const nativeFileByStoredFileId = new Map(nativeFiles.map((file) => [file.storedFileId, file]));
+  const nativeFileBySourcePath = new Map(nativeFiles.map((file) => [file.sourcePath, file]));
+  const combinedSourcePaths = new Set<string>();
   const providerBackedFiles: ProjectFileRecord[] = providerFiles.map((file) => {
-    const linkedNativeFile = file.storedFileId
-      ? nativeFileByStoredFileId.get(file.storedFileId)
-      : undefined;
+    const linkedNativeFile =
+      nativeFileBySourcePath.get(file.sourcePath) ??
+      (file.storedFileId ? nativeFileByStoredFileId.get(file.storedFileId) : undefined);
+    const provider = {
+      kind: file.providerKind,
+      resourceType: file.resourceType,
+      externalProjectId: file.externalProjectId,
+      externalResourceId: file.externalResourceId,
+      externalUrl: file.externalUrl,
+      syncState: file.syncState,
+      sourceLocale: file.sourceLocale,
+      targetLocales: file.targetLocales,
+      localeReadiness: file.localeReadiness as Record<string, unknown>,
+      revision: file.revision,
+      format: file.format,
+      lastSyncedAt: file.lastSyncedAt?.toISOString() ?? null,
+    };
+
+    if (linkedNativeFile) {
+      combinedSourcePaths.add(linkedNativeFile.sourcePath);
+      return {
+        ...linkedNativeFile,
+        origin: "combined" as const,
+        provider,
+      };
+    }
 
     return {
       origin: "provider" as const,
@@ -271,35 +296,20 @@ export async function listProjectFilesForProject(input: {
       sourceHash: file.sourceHash,
       commitSha: null,
       workflowRunId: null,
-      uploadedAt:
-        file.lastSyncedAt?.toISOString() ??
-        linkedNativeFile?.uploadedAt ??
-        file.updatedAt.toISOString(),
+      uploadedAt: file.lastSyncedAt?.toISOString() ?? file.updatedAt.toISOString(),
       storedFileId: file.storedFileId,
       metadata: file.providerPayload as Record<string, unknown>,
       filename: file.displayName,
-      byteSize: linkedNativeFile?.byteSize ?? null,
-      provider: {
-        kind: file.providerKind,
-        resourceType: file.resourceType,
-        externalProjectId: file.externalProjectId,
-        externalResourceId: file.externalResourceId,
-        externalUrl: file.externalUrl,
-        syncState: file.syncState,
-        sourceLocale: file.sourceLocale,
-        targetLocales: file.targetLocales,
-        localeReadiness: file.localeReadiness as Record<string, unknown>,
-        revision: file.revision,
-        format: file.format,
-        lastSyncedAt: file.lastSyncedAt?.toISOString() ?? null,
-      },
-      latestJob: linkedNativeFile?.latestJob ?? null,
+      byteSize: null,
+      provider,
+      latestJob: null,
     };
   });
 
-  return [...nativeFiles, ...providerBackedFiles].sort((a, b) =>
-    a.sourcePath.localeCompare(b.sourcePath),
-  );
+  return [
+    ...nativeFiles.filter((file) => !combinedSourcePaths.has(file.sourcePath)),
+    ...providerBackedFiles,
+  ].sort((a, b) => a.sourcePath.localeCompare(b.sourcePath));
 }
 
 export async function listWorkspaceFiles(input: {
@@ -317,8 +327,6 @@ export async function listWorkspaceFiles(input: {
       ? input.projects.filter((project) => project.projectId === input.query.projectId)
       : input.projects;
 
-  const providerFetchLimit = resolveProviderFetchLimit(input.query, input.query.limit);
-
   const fileGroups = await mapWithConcurrency(
     projectIds,
     workspaceFilesProjectConcurrency,
@@ -326,7 +334,8 @@ export async function listWorkspaceFiles(input: {
       const files = await listProjectFilesForProject({
         organizationId: input.organizationId,
         projectId: project.projectId,
-        providerFetchLimit,
+        providerFetchLimit: input.query.limit,
+        providerFilters: input.query,
         resourceTypes,
       });
 

--- a/apps/hyperlocalise-web/src/lib/providers/organization-external-tms-files.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/organization-external-tms-files.test.ts
@@ -233,4 +233,59 @@ describe("organizationExternalTmsFiles", () => {
 
     expect(files.map((file) => file.sourcePath)).toEqual(["keys/one", "keys/three"]);
   });
+
+  it("applies provider filters before limiting rows", async () => {
+    const { organizationId, projectId } = await createProject();
+
+    await upsertExternalTmsFile({
+      organizationId,
+      projectId,
+      providerKind: "phrase",
+      externalProjectId: "phrase-project-1",
+      resourceType: "key",
+      externalResourceId: "early-key",
+      sourcePath: "keys/aaa",
+      sourceLocale: "en",
+      targetLocales: ["de"],
+      syncState: "synced",
+    });
+    await upsertExternalTmsFile({
+      organizationId,
+      projectId,
+      providerKind: "phrase",
+      externalProjectId: "phrase-project-1",
+      resourceType: "key",
+      externalResourceId: "middle-key",
+      sourcePath: "keys/bbb",
+      sourceLocale: "en",
+      targetLocales: ["es"],
+      syncState: "synced",
+    });
+    await upsertExternalTmsFile({
+      organizationId,
+      projectId,
+      providerKind: "crowdin",
+      externalProjectId: "crowdin-project-1",
+      resourceType: "key",
+      externalResourceId: "needle-key",
+      sourcePath: "keys/zzz",
+      sourceLocale: "en",
+      targetLocales: ["fr"],
+      syncState: "changed",
+    });
+
+    const files = await listExternalTmsFilesForProject({
+      organizationId,
+      projectId,
+      limit: 1,
+      filters: {
+        providerKind: "crowdin",
+        locale: "fr",
+        syncState: "changed",
+        search: "needle",
+      },
+    });
+
+    expect(files.map((file) => file.externalResourceId)).toEqual(["needle-key"]);
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/organization-external-tms-files.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/organization-external-tms-files.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq, ilike, inArray, or, sql, type SQL } from "drizzle-orm";
 
 import { db, schema } from "@/lib/database";
 import { normalizeSourcePath } from "@/lib/file-storage/records";
@@ -32,6 +32,13 @@ export type ExternalTmsFileInput = {
   localeReadiness?: Record<string, unknown>;
   providerPayload?: Record<string, unknown>;
   lastSyncedAt?: Date | null;
+};
+
+export type ExternalTmsFileListFilters = {
+  providerKind?: ExternalTmsProviderKind | "all";
+  locale?: string;
+  syncState?: string;
+  search?: string;
 };
 
 function defaultDisplayName(sourcePath: string) {
@@ -109,15 +116,51 @@ export async function listExternalTmsFilesForProject(input: {
   organizationId: string;
   projectId: string;
   resourceTypes?: ExternalTmsResourceType[];
+  filters?: ExternalTmsFileListFilters;
   limit?: number;
 }) {
-  const filters = [
+  const filters: SQL[] = [
     eq(schema.externalTmsFiles.organizationId, input.organizationId),
     eq(schema.externalTmsFiles.projectId, input.projectId),
   ];
 
   if (input.resourceTypes && input.resourceTypes.length > 0) {
     filters.push(inArray(schema.externalTmsFiles.resourceType, input.resourceTypes));
+  }
+
+  if (input.filters?.providerKind && input.filters.providerKind !== "all") {
+    filters.push(eq(schema.externalTmsFiles.providerKind, input.filters.providerKind));
+  }
+
+  const syncState = input.filters?.syncState?.trim();
+  if (syncState && syncState !== "all") {
+    filters.push(eq(schema.externalTmsFiles.syncState, syncState));
+  }
+
+  const locale = input.filters?.locale?.trim();
+  if (locale && locale !== "all") {
+    const localeFilter = or(
+      eq(schema.externalTmsFiles.sourceLocale, locale),
+      sql`${schema.externalTmsFiles.targetLocales} @> ${JSON.stringify([locale])}::jsonb`,
+    );
+    if (localeFilter) {
+      filters.push(localeFilter);
+    }
+  }
+
+  const search = input.filters?.search?.trim();
+  if (search) {
+    const pattern = `%${search}%`;
+    const searchFilter = or(
+      ilike(schema.externalTmsFiles.sourcePath, pattern),
+      ilike(schema.externalTmsFiles.displayName, pattern),
+      ilike(schema.externalTmsFiles.externalResourceId, pattern),
+      sql`${schema.externalTmsFiles.providerKind}::text ILIKE ${pattern}`,
+      sql`${schema.externalTmsFiles.resourceType}::text ILIKE ${pattern}`,
+    );
+    if (searchFilter) {
+      filters.push(searchFilter);
+    }
   }
 
   return db

--- a/apps/hyperlocalise-web/src/lib/providers/organization-external-tms-files.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/organization-external-tms-files.ts
@@ -6,7 +6,7 @@ import { normalizeSourcePath } from "@/lib/file-storage/records";
 import type { ExternalTmsProviderKind } from "./organization-external-tms-provider-credentials";
 
 const defaultExternalTmsFilesLimit = 500;
-const maxExternalTmsFilesLimit = 1_000;
+export const maxExternalTmsFilesLimit = 1_000;
 
 export type ExternalTmsResourceType =
   (typeof schema.externalTmsResourceTypeEnum.enumValues)[number];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Extends the existing Files experience so native Hyperlocalise repository sources and synced TMS provider files/keys appear in one UI.

- **Org Files page** (`/org/[slug]/files`): unified list grouped by project with search, provider, project, source type (repository vs provider / file vs key), locale, and sync state filters.
- **Project Files page**: same filter bar and richer metadata (provider badge, origin, resource type, sync state, locale readiness summary, last sync).
- **API**: `GET /api/orgs/:organizationSlug/workspace-files` for org-wide browsing; project `GET .../files` gains query filters and `lastSyncedAt` on provider payloads.
- **Shared logic**: `src/lib/projects/project-files.ts` centralizes listing, merging repository + `external_tms_files`, and server-side filtering.

Selecting a file links to the existing project file detail flow via `?sourcePath=...`.

Resolves HL-366.

## How to test

1. Start Postgres (`docker compose up -d`) and apply migrations (`vp run db:migrate` in `apps/hyperlocalise-web`).
2. Seed or sync provider files for a project (Phrase/Crowdin fixtures in existing tests).
3. Open `/org/{slug}/files` — confirm native and provider items appear with filters and project grouping.
4. Open `/org/{slug}/projects/{id}/files` — confirm filters, badges, and deep link selection via `sourcePath`.
5. Run checks:
   - `cd apps/hyperlocalise-web && vp check --fix`
   - `vp test src/lib/projects/project-files.test.ts`
   - `vp test src/api/routes/workspace-files/workspace-files.test.ts`
   - `vp test src/api/routes/project/project.test.ts` (requires DB)

## Checklist

- [x] I ran `vp check --fix` locally
- [x] Unit test for `filterProjectFiles` passes
- [ ] Integration API tests pass in CI (require Postgres)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-366](https://linear.app/hyperlocalise/issue/HL-366/show-synced-tms-files-and-keys-in-existing-files-page)

<div><a href="https://cursor.com/agents/bc-ff58f754-eb92-4f9e-86c1-ef12af347ba7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff58f754-eb92-4f9e-86c1-ef12af347ba7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

