### PR TITLE
🎨 Palette: Improve accessibility and feedback for conversation buttons

### DIFF
--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-panel.tsx
@@ -5,6 +5,7 @@ import { HugeiconsIcon } from "@hugeicons/react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { TypographyH4, TypographyMuted } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
 
@@ -132,15 +133,24 @@ function ConversationHeader({
         </div>
       </div>
       <div className="flex items-center gap-1">
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-sm"
-          className="text-muted-foreground hover:bg-accent hover:text-foreground"
-          aria-label="More inbox item actions"
-        >
-          <HugeiconsIcon icon={MoreHorizontalIcon} strokeWidth={1.8} className="size-4" />
-        </Button>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                className="text-muted-foreground hover:bg-accent hover:text-foreground"
+                aria-label="More actions"
+              >
+                <HugeiconsIcon icon={MoreHorizontalIcon} strokeWidth={1.8} className="size-4" />
+              </Button>
+            }
+          />
+          <TooltipContent side="bottom" align="end">
+            More actions
+          </TooltipContent>
+        </Tooltip>
       </div>
     </header>
   );

--- a/apps/hyperlocalise-web/src/components/ai-elements/conversation.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/conversation.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import type { UIMessage } from "ai";
 import { ArrowDownIcon, DownloadIcon } from "lucide-react";
@@ -76,19 +77,27 @@ export const ConversationScrollButton = ({
 
   return (
     !isAtBottom && (
-      <Button
-        className={cn(
-          "absolute bottom-4 start-[50%] translate-x-[-50%] rtl:-translate-x-[-50%] rounded-full dark:bg-background dark:hover:bg-muted",
-          className,
-        )}
-        onClick={handleScrollToBottom}
-        size="icon"
-        type="button"
-        variant="outline"
-        {...props}
-      >
-        <ArrowDownIcon className="size-4" />
-      </Button>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <Button
+              aria-label="Scroll to bottom"
+              className={cn(
+                "absolute bottom-4 start-[50%] translate-x-[-50%] rtl:-translate-x-[-50%] rounded-full dark:bg-background dark:hover:bg-muted",
+                className,
+              )}
+              onClick={handleScrollToBottom}
+              size="icon"
+              type="button"
+              variant="outline"
+              {...props}
+            >
+              <ArrowDownIcon className="size-4" />
+            </Button>
+          }
+        />
+        <TooltipContent side="top">Scroll to bottom</TooltipContent>
+      </Tooltip>
     )
   );
 };
@@ -137,18 +146,28 @@ export const ConversationDownload = ({
   }, [messages, filename, formatMessage]);
 
   return (
-    <Button
-      className={cn(
-        "absolute top-4 end-4 rounded-full dark:bg-background dark:hover:bg-muted",
-        className,
-      )}
-      onClick={handleDownload}
-      size="icon"
-      type="button"
-      variant="outline"
-      {...props}
-    >
-      {children ?? <DownloadIcon className="size-4" />}
-    </Button>
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Button
+            aria-label="Download conversation"
+            className={cn(
+              "absolute top-4 end-4 rounded-full dark:bg-background dark:hover:bg-muted",
+              className,
+            )}
+            onClick={handleDownload}
+            size="icon"
+            type="button"
+            variant="outline"
+            {...props}
+          >
+            {children ?? <DownloadIcon className="size-4" />}
+          </Button>
+        }
+      />
+      <TooltipContent side="bottom" align="end">
+        Download conversation
+      </TooltipContent>
+    </Tooltip>
   );
 };


### PR DESCRIPTION
I've implemented micro-UX improvements focused on accessibility and feedback in the conversation interface.

### 💡 What:
- Added `Tooltip` and descriptive `aria-label` to the `ConversationScrollButton` (scroll to bottom) and `ConversationDownload` buttons.
- Added a `Tooltip` to the "More actions" button in the `ConversationPanel` header and updated its `aria-label` to be more concise.
- Refined the implementation to follow the project's standard `TooltipTrigger` pattern, ensuring icons are correctly nested within the buttons.

### 🎯 Why:
- Icon-only buttons without labels or tooltips are difficult for screen reader users and can be ambiguous for sighted users.
- Providing consistent visual and descriptive feedback makes the interface more intuitive and accessible.

### ♿ Accessibility:
- Added missing `aria-label` attributes to three icon-only buttons.
- Provided visual tooltips that provide context on hover/focus.
- Followed standard prop forwarding patterns for accessible UI components.

---
*PR created automatically by Jules for task [10864399838364329221](https://jules.google.com/task/10864399838364329221) started by @cungminh2710*