### PR TITLE
🛡️ Sentinel: [security improvement] Add input length limits to translation push schema

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -17,7 +17,7 @@ export const externalTmsTranslationPushBodySchema = z.object({
           externalStringId: z.string().trim().min(1).max(128).optional(),
           key: z.string().trim().min(1).max(512).optional(),
           locale: z.string().trim().min(1).max(32),
-          text: z.string(),
+          text: z.string().max(100_000),
           fileId: z.string().trim().min(1).max(128).optional(),
           fileName: z.string().trim().min(1).max(256).optional(),
           format: z.string().trim().min(1).max(64).optional(),
@@ -27,7 +27,8 @@ export const externalTmsTranslationPushBodySchema = z.object({
           path: ["key"],
         }),
     )
-    .min(1),
+    .min(1)
+    .max(1000),
 });
 
 export const createProjectBodySchema = z.object({

--- a/apps/hyperlocalise-web/src/api/routes/security-limits-identifiers.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/security-limits-identifiers.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { projectIdParamsSchema } from "./project/project.schema";
+import {
+  projectIdParamsSchema,
+  externalTmsTranslationPushBodySchema,
+} from "./project/project.schema";
 import {
   jobProjectParamsSchema,
   jobParamsSchema,
@@ -109,5 +112,27 @@ describe("Identifier Schema length limits", () => {
     expect(multipartChatRequestSchema.safeParse({ text: "a", projectId: longId }).success).toBe(
       false,
     );
+  });
+
+  it("should enforce max length on translations in externalTmsTranslationPushBodySchema", () => {
+    const tooManyTranslations = Array.from({ length: 1001 }, (_, i) => ({
+      key: `key-${i}`,
+      locale: "en",
+      text: "a",
+    }));
+
+    expect(
+      externalTmsTranslationPushBodySchema.safeParse({
+        externalJobId: "valid",
+        translations: tooManyTranslations,
+      }).success,
+    ).toBe(false);
+
+    expect(
+      externalTmsTranslationPushBodySchema.safeParse({
+        externalJobId: "valid",
+        translations: [{ key: "k", locale: "en", text: "a".repeat(100_001) }],
+      }).success,
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing input length limits on `externalTmsTranslationPushBodySchema`.
🎯 Impact: Potential resource exhaustion (memory/CPU) if an attacker sends an extremely large translations array or very long translation text, leading to a Denial of Service (DoS).
🔧 Fix: Added Zod validation limits: `.max(1000)` for the translations array and `.max(100_000)` for the individual `text` fields.
✅ Verification: Added unit tests in `apps/hyperlocalise-web/src/api/routes/security-limits-identifiers.test.ts` to enforce these new constraints and verified they pass with `npx vp test`.

---
*PR created automatically by Jules for task [14009764145777994559](https://jules.google.com/task/14009764145777994559) started by @cungminh2710*