### PR TITLE
feat(web): implement Lokalise credential validation and project listing

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/external-tms-provider-credential/external-tms-provider-credential.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/external-tms-provider-credential/external-tms-provider-credential.route.ts
@@ -4,6 +4,7 @@ import { validator } from "hono/validator";
 import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
 import { notFoundResponse } from "@/api/response.schema";
 import { fetchCrowdinProjects } from "@/lib/providers/crowdin/crowdin-project-fetcher";
+import { fetchLokaliseProjects } from "@/lib/providers/lokalise/lokalise-project-fetcher";
 import { fetchPhraseProjects } from "@/lib/providers/phrase/phrase-project-fetcher";
 import { fetchSmartlingProjects } from "@/lib/providers/smartling/smartling-project-fetcher";
 import {
@@ -169,6 +170,7 @@ export function createExternalTmsProviderCredentialRoutes() {
           Record<(typeof providerKind)["data"], ExternalTmsProjectFetcher>
         > = {
           crowdin: fetchCrowdinProjects,
+          lokalise: fetchLokaliseProjects,
           phrase: fetchPhraseProjects,
           smartling: fetchSmartlingProjects,
         };

--- a/apps/hyperlocalise-web/src/api/routes/external-tms-provider-credential/external-tms-provider-credential.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/external-tms-provider-credential/external-tms-provider-credential.test.ts
@@ -558,6 +558,62 @@ describe("externalTmsProviderCredentialRoutes", () => {
     expect(summary?.lastValidatedAt).not.toBeNull();
   });
 
+  it("returns connected lokalise health via the /me endpoint", async () => {
+    const identity = fixture.createWorkosIdentityWithRole("admin");
+    const headers = await fixture.authHeadersFor(identity);
+    const authContext = globalThis.__testApiAuthContext!;
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          user_id: 420,
+          email: "user@example.com",
+          full_name: "Test User",
+        }),
+        { status: 200 },
+      );
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    await upsertOrganizationExternalTmsProviderCredential({
+      organizationId: authContext.organization.localOrganizationId,
+      userId: authContext.user.localUserId,
+      role: authContext.membership.role,
+      providerKind: "lokalise",
+      displayName: "Lokalise",
+      secretMaterial: "lokalise-secret",
+    });
+
+    const response = await client.api.orgs[":organizationSlug"]["external-tms-provider-credential"][
+      ":providerKind"
+    ]["health-check"].$post(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing",
+          providerKind: "lokalise",
+        },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      externalTmsProviderHealth: {
+        providerKind: "lokalise",
+        status: "connected",
+        availability: "available",
+        authValidity: "valid",
+        errorCode: null,
+      },
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.lokalise.com/api2/me",
+      expect.objectContaining({
+        headers: { "X-Api-Token": "lokalise-secret" },
+      }),
+    );
+  });
+
   it("syncs crowdin projects and normalizes them into connected project records", async () => {
     const identity = fixture.createWorkosIdentityWithRole("admin");
     const headers = await fixture.authHeadersFor(identity);
@@ -1232,10 +1288,47 @@ describe("externalTmsProviderCredentialRoutes", () => {
     });
   });
 
-  it("returns 501 for providers that do not yet support project sync", async () => {
+  it("syncs lokalise projects and normalizes them into connected project records", async () => {
     const identity = fixture.createWorkosIdentityWithRole("admin");
     const headers = await fixture.authHeadersFor(identity);
     const authContext = globalThis.__testApiAuthContext!;
+
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes("/projects?page=1") && !url.includes("/languages")) {
+        return new Response(
+          JSON.stringify({
+            projects: [
+              {
+                project_id: "proj.123",
+                name: "Marketing Website",
+                project_type: "localization_files",
+                team_id: 42,
+                base_language_id: 640,
+                base_language_iso: "en",
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (url.includes("/projects/proj.123/languages")) {
+        return new Response(
+          JSON.stringify({
+            project_id: "proj.123",
+            languages: [
+              { lang_id: 640, lang_iso: "en", lang_name: "English", is_rtl: false },
+              { lang_id: 673, lang_iso: "fr", lang_name: "French", is_rtl: false },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify({ projects: [], languages: [] }), { status: 200 });
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
 
     await upsertOrganizationExternalTmsProviderCredential({
       organizationId: authContext.organization.localOrganizationId,
@@ -1258,10 +1351,97 @@ describe("externalTmsProviderCredentialRoutes", () => {
       { headers },
     );
 
-    expect(response.status).toBe(501);
-    await expect(response.json()).resolves.toEqual({
-      error: "provider_sync_not_implemented",
+    expect(response.status).toBe(200);
+    const data = (await response.json()) as {
+      externalTmsProjectSync: {
+        status: string;
+        counts: {
+          projectsDiscovered: number;
+          projectsSynced: number;
+          projectsFailed: number;
+          localesSynced: number;
+        };
+      };
+    };
+    expect(data.externalTmsProjectSync.status).toBe("succeeded");
+    expect(data.externalTmsProjectSync.counts).toEqual({
+      projectsDiscovered: 1,
+      projectsSynced: 1,
+      projectsFailed: 0,
+      localesSynced: 2,
     });
+
+    const projects = await db
+      .select()
+      .from(schema.projects)
+      .where(
+        and(
+          eq(schema.projects.organizationId, authContext.organization.localOrganizationId),
+          eq(schema.projects.externalProviderKind, "lokalise"),
+        ),
+      );
+
+    expect(projects).toHaveLength(1);
+    expect(projects[0]).toMatchObject({
+      name: "Marketing Website",
+      sourceLocale: "en",
+      targetLocales: ["fr"],
+      externalProjectId: "proj.123",
+      externalProjectUrl: "https://app.lokalise.com/project/proj.123/",
+      isActive: true,
+      source: "external_tms",
+    });
+  });
+
+  it("records a failed sync run when lokalise auth is invalid", async () => {
+    const identity = fixture.createWorkosIdentityWithRole("admin");
+    const headers = await fixture.authHeadersFor(identity);
+    const authContext = globalThis.__testApiAuthContext!;
+
+    const fetchMock = vi.fn(async () => {
+      return new Response(JSON.stringify({ error: { message: "Invalid token" } }), {
+        status: 401,
+      });
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    await upsertOrganizationExternalTmsProviderCredential({
+      organizationId: authContext.organization.localOrganizationId,
+      userId: authContext.user.localUserId,
+      role: authContext.membership.role,
+      providerKind: "lokalise",
+      displayName: "Lokalise",
+      secretMaterial: "invalid-token",
+    });
+
+    const response = await client.api.orgs[":organizationSlug"]["external-tms-provider-credential"][
+      ":providerKind"
+    ]["sync-projects"].$post(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing",
+          providerKind: "lokalise",
+        },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(500);
+
+    const runs = await db
+      .select()
+      .from(schema.providerSyncRuns)
+      .where(
+        and(
+          eq(schema.providerSyncRuns.organizationId, authContext.organization.localOrganizationId),
+          eq(schema.providerSyncRuns.providerKind, "lokalise"),
+          eq(schema.providerSyncRuns.kind, "project_scan"),
+        ),
+      );
+
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.status).toBe("failed");
   });
 
   it("blocks non-admin project sync requests", async () => {

--- a/apps/hyperlocalise-web/src/lib/async/map-with-concurrency.test.ts
+++ b/apps/hyperlocalise-web/src/lib/async/map-with-concurrency.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { mapWithConcurrency } from "./map-with-concurrency";
+
+describe("mapWithConcurrency", () => {
+  it("aborts remaining workers when a mapper throws", async () => {
+    const mapper = vi.fn(async (item: number) => {
+      if (item === 0) {
+        throw new Error("fail");
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      return item;
+    });
+
+    await expect(mapWithConcurrency([0, 1, 2, 3, 4, 5], 3, mapper)).rejects.toThrow("fail");
+
+    expect(mapper).toHaveBeenCalledTimes(3);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/async/map-with-concurrency.ts
+++ b/apps/hyperlocalise-web/src/lib/async/map-with-concurrency.ts
@@ -9,16 +9,22 @@ export async function mapWithConcurrency<T, R>(
 
   const results: R[] = Array.from({ length: items.length });
   let nextIndex = 0;
+  const abortController = new AbortController();
 
   async function worker() {
-    while (true) {
+    while (!abortController.signal.aborted) {
       const currentIndex = nextIndex;
       nextIndex += 1;
       if (currentIndex >= items.length) {
         return;
       }
 
-      results[currentIndex] = await mapper(items[currentIndex] as T);
+      try {
+        results[currentIndex] = await mapper(items[currentIndex] as T);
+      } catch (error) {
+        abortController.abort();
+        throw error;
+      }
     }
   }
 

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-api.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import {
+  buildLokaliseProjectUrl,
+  LokaliseApiClient,
+  LokaliseApiError,
+  partitionLokaliseLocales,
+} from "./lokalise-api";
+
+describe("LokaliseApiClient", () => {
+  function createClient(fetchFn: typeof fetch) {
+    return new LokaliseApiClient({
+      token: "test-token",
+      baseUrl: "https://api.lokalise.test/api2",
+      fetchFn,
+    });
+  }
+
+  it("lists projects with pagination", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      if (String(url).includes("/projects?page=1")) {
+        return new Response(
+          JSON.stringify({
+            projects: [
+              {
+                project_id: "proj.123",
+                name: "Marketing Website",
+                project_type: "localization_files",
+                team_id: 42,
+                base_language_id: 640,
+                base_language_iso: "en",
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify({ projects: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    const projects = await client.listProjects();
+
+    expect(projects).toHaveLength(1);
+    expect(projects[0]).toMatchObject({
+      projectId: "proj.123",
+      name: "Marketing Website",
+      projectType: "localization_files",
+      teamId: 42,
+      baseLanguageId: 640,
+      baseLanguageIso: "en",
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.lokalise.test/api2/projects?page=1&limit=100",
+      expect.objectContaining({
+        headers: { "X-Api-Token": "test-token" },
+      }),
+    );
+  });
+
+  it("lists project languages with pagination", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      if (String(url).includes("/projects/proj.123/languages")) {
+        return new Response(
+          JSON.stringify({
+            project_id: "proj.123",
+            languages: [
+              { lang_id: 640, lang_iso: "en", lang_name: "English", is_rtl: false },
+              { lang_id: 673, lang_iso: "fr", lang_name: "French", is_rtl: false },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify({ languages: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    const languages = await client.listProjectLanguages("proj.123");
+
+    expect(languages).toHaveLength(2);
+    expect(languages[0]).toMatchObject({ langId: 640, langIso: "en", langName: "English" });
+    expect(languages[1]).toMatchObject({ langId: 673, langIso: "fr", langName: "French" });
+  });
+
+  it("throws LokaliseApiError on auth failure", async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(JSON.stringify({ error: { message: "Invalid token" } }), {
+        status: 401,
+      });
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+
+    await expect(client.listProjects()).rejects.toBeInstanceOf(LokaliseApiError);
+    await expect(client.listProjects()).rejects.toMatchObject({ status: 401 });
+  });
+});
+
+describe("partitionLokaliseLocales", () => {
+  it("uses base language metadata to split source and target locales", () => {
+    const { sourceLocale, targetLocales } = partitionLokaliseLocales(
+      { baseLanguageId: 640, baseLanguageIso: "en" },
+      [
+        { langId: 640, langIso: "en", langName: "English", isRtl: false },
+        { langId: 673, langIso: "fr", langName: "French", isRtl: false },
+      ],
+    );
+
+    expect(sourceLocale).toBe("en");
+    expect(targetLocales).toEqual(["fr"]);
+  });
+});
+
+describe("buildLokaliseProjectUrl", () => {
+  it("builds the app URL for a project", () => {
+    expect(buildLokaliseProjectUrl("proj.123")).toBe("https://app.lokalise.com/project/proj.123/");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-api.test.ts
@@ -112,6 +112,19 @@ describe("partitionLokaliseLocales", () => {
     expect(sourceLocale).toBe("en");
     expect(targetLocales).toEqual(["fr"]);
   });
+
+  it("returns no target locales when the source language cannot be determined", () => {
+    const { sourceLocale, targetLocales } = partitionLokaliseLocales(
+      { baseLanguageId: null, baseLanguageIso: null },
+      [
+        { langId: 640, langIso: "en", langName: "English", isRtl: false },
+        { langId: 673, langIso: "fr", langName: "French", isRtl: false },
+      ],
+    );
+
+    expect(sourceLocale).toBeNull();
+    expect(targetLocales).toEqual([]);
+  });
 });
 
 describe("buildLokaliseProjectUrl", () => {

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-api.ts
@@ -1,0 +1,209 @@
+/**
+ * Lokalise API v2 client for TMS connector discovery.
+ */
+
+export const LOKALISE_DEFAULT_BASE_URL = "https://api.lokalise.com/api2";
+
+export interface LokaliseApiClientOptions {
+  token: string;
+  baseUrl?: string | null;
+  fetchFn?: typeof fetch;
+}
+
+export interface LokaliseProject {
+  projectId: string;
+  name: string;
+  description: string | null;
+  projectType: string | null;
+  teamId: number | null;
+  baseLanguageId: number | null;
+  baseLanguageIso: string | null;
+  createdAt: string | null;
+}
+
+export interface LokaliseLanguage {
+  langId: number;
+  langIso: string;
+  langName: string;
+  isRtl: boolean;
+}
+
+export class LokaliseApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly responseBody: unknown,
+  ) {
+    super(message);
+    this.name = "LokaliseApiError";
+  }
+}
+
+export class LokaliseApiClient {
+  private readonly token: string;
+  private readonly baseUrl: string;
+  private readonly fetchFn: typeof fetch;
+
+  constructor(options: LokaliseApiClientOptions) {
+    this.token = options.token;
+    this.baseUrl = (options.baseUrl ?? LOKALISE_DEFAULT_BASE_URL).replace(/\/+$/g, "");
+    this.fetchFn = options.fetchFn ?? fetch;
+  }
+
+  get resolvedBaseUrl() {
+    return this.baseUrl;
+  }
+
+  async listProjects(): Promise<LokaliseProject[]> {
+    const projects: LokaliseProject[] = [];
+    let page = 1;
+    const limit = 100;
+
+    while (true) {
+      const response = await this.get<LokaliseProjectsListResponse>(
+        `/projects?page=${page}&limit=${limit}`,
+      );
+      const pageItems = (response.projects ?? []).map(normalizeLokaliseProject);
+      projects.push(...pageItems);
+
+      if (pageItems.length < limit) {
+        break;
+      }
+
+      page += 1;
+    }
+
+    return projects;
+  }
+
+  async listProjectLanguages(projectId: string): Promise<LokaliseLanguage[]> {
+    const languages: LokaliseLanguage[] = [];
+    let page = 1;
+    const limit = 100;
+
+    while (true) {
+      const response = await this.get<LokaliseLanguagesListResponse>(
+        `/projects/${encodeURIComponent(projectId)}/languages?page=${page}&limit=${limit}`,
+      );
+      const pageItems = (response.languages ?? []).map(normalizeLokaliseLanguage);
+      languages.push(...pageItems);
+
+      if (pageItems.length < limit) {
+        break;
+      }
+
+      page += 1;
+    }
+
+    return languages;
+  }
+
+  private authHeaders(): Record<string, string> {
+    return {
+      "X-Api-Token": this.token,
+    };
+  }
+
+  private async get<T>(path: string): Promise<T> {
+    return this.request<T>(path, {
+      method: "GET",
+      headers: this.authHeaders(),
+    });
+  }
+
+  private async request<T>(path: string, init: RequestInit): Promise<T> {
+    const url = `${this.baseUrl}${path}`;
+    const response = await this.fetchFn(url, init);
+
+    if (!response.ok) {
+      let body: unknown;
+      try {
+        body = await response.json();
+      } catch {
+        body = await response.text().catch(() => null);
+      }
+
+      throw new LokaliseApiError(
+        `Lokalise API returned HTTP ${response.status} for ${path}`,
+        response.status,
+        body,
+      );
+    }
+
+    return response.json() as Promise<T>;
+  }
+}
+
+type LokaliseProjectsListResponse = {
+  projects?: LokaliseProjectApiRecord[];
+};
+
+type LokaliseLanguagesListResponse = {
+  project_id?: string;
+  languages?: LokaliseLanguageApiRecord[];
+};
+
+type LokaliseProjectApiRecord = {
+  project_id: string;
+  name: string;
+  description?: string | null;
+  project_type?: string | null;
+  team_id?: number | null;
+  base_language_id?: number | null;
+  base_language_iso?: string | null;
+  created_at?: string | null;
+};
+
+type LokaliseLanguageApiRecord = {
+  lang_id: number;
+  lang_iso: string;
+  lang_name: string;
+  is_rtl?: boolean;
+};
+
+function normalizeLokaliseProject(record: LokaliseProjectApiRecord): LokaliseProject {
+  return {
+    projectId: record.project_id,
+    name: record.name,
+    description: record.description ?? null,
+    projectType: record.project_type ?? null,
+    teamId: record.team_id ?? null,
+    baseLanguageId: record.base_language_id ?? null,
+    baseLanguageIso: record.base_language_iso ?? null,
+    createdAt: record.created_at ?? null,
+  };
+}
+
+function normalizeLokaliseLanguage(record: LokaliseLanguageApiRecord): LokaliseLanguage {
+  return {
+    langId: record.lang_id,
+    langIso: record.lang_iso,
+    langName: record.lang_name,
+    isRtl: record.is_rtl ?? false,
+  };
+}
+
+export function partitionLokaliseLocales(
+  project: Pick<LokaliseProject, "baseLanguageId" | "baseLanguageIso">,
+  languages: LokaliseLanguage[],
+) {
+  const sourceLocale = project.baseLanguageIso?.trim() || null;
+  const targetLocales = languages
+    .filter((language) => {
+      if (project.baseLanguageId != null) {
+        return language.langId !== project.baseLanguageId;
+      }
+      if (sourceLocale) {
+        return language.langIso !== sourceLocale;
+      }
+      return true;
+    })
+    .map((language) => language.langIso.trim())
+    .filter((locale): locale is string => Boolean(locale));
+
+  return { sourceLocale, targetLocales };
+}
+
+export function buildLokaliseProjectUrl(projectId: string) {
+  return `https://app.lokalise.com/project/${encodeURIComponent(projectId)}/`;
+}

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-api.ts
@@ -196,7 +196,7 @@ export function partitionLokaliseLocales(
       if (sourceLocale) {
         return language.langIso !== sourceLocale;
       }
-      return true;
+      return false;
     })
     .map((language) => language.langIso.trim())
     .filter((locale): locale is string => Boolean(locale));

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-project-fetcher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-project-fetcher.test.ts
@@ -93,6 +93,58 @@ describe("fetchLokaliseProjects", () => {
     });
   });
 
+  it("stops locale fetches after an auth failure during concurrent project mapping", async () => {
+    const projects = Array.from({ length: 20 }, (_, index) => ({
+      project_id: `proj.${index}`,
+      name: `Project ${index}`,
+      project_type: "localization_files",
+      team_id: 42,
+      base_language_id: 640,
+      base_language_iso: "en",
+    }));
+
+    const fetchMock = vi.fn(async (url) => {
+      if (String(url).includes("/projects?page=1")) {
+        return new Response(JSON.stringify({ projects }), { status: 200 });
+      }
+
+      if (String(url).includes("/projects/proj.0/languages")) {
+        return new Response(JSON.stringify({ error: { message: "Invalid token" } }), {
+          status: 401,
+        });
+      }
+
+      if (String(url).includes("/projects/") && String(url).includes("/languages")) {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        return new Response(
+          JSON.stringify({
+            project_id: "proj.1",
+            languages: [{ lang_id: 640, lang_iso: "en", lang_name: "English", is_rtl: false }],
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify({ projects: [], languages: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      fetchLokaliseProjects({
+        organizationId: "org-1",
+        providerKind: "lokalise",
+        credential,
+        secretMaterial: "invalid-token",
+      }),
+    ).rejects.toThrow("lokalise_auth_invalid");
+
+    const languageFetches = vi
+      .mocked(fetchMock)
+      .mock.calls.filter((call) => String(call[0]).includes("/languages"));
+    expect(languageFetches.length).toBeLessThan(20);
+  });
+
   it("throws lokalise_auth_invalid when authentication fails", async () => {
     const fetchMock = vi.fn(async () => {
       return new Response(JSON.stringify({ error: { message: "Invalid token" } }), {

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-project-fetcher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-project-fetcher.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { fetchLokaliseProjects } from "./lokalise-project-fetcher";
+
+describe("fetchLokaliseProjects", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  const credential = {
+    id: "cred-1",
+    organizationId: "org-1",
+    providerKind: "lokalise" as const,
+    displayName: "Lokalise",
+    region: null,
+    baseUrl: null,
+    validationStatus: "connected",
+    validationMessage: null,
+    lastValidatedAt: null,
+    encryptionAlgorithm: "aes-256-gcm",
+    keyVersion: 1,
+    ciphertext: "cipher",
+    iv: "iv",
+    authTag: "tag",
+    maskedSecretSuffix: "cret",
+    createdByUserId: "user-1",
+    updatedByUserId: "user-1",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  it("normalizes projects and locales into the shared provider model", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      if (String(url).includes("/projects?page=1")) {
+        return new Response(
+          JSON.stringify({
+            projects: [
+              {
+                project_id: "proj.123",
+                name: "Marketing Website",
+                project_type: "localization_files",
+                team_id: 42,
+                base_language_id: 640,
+                base_language_iso: "en",
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (String(url).includes("/projects/proj.123/languages")) {
+        return new Response(
+          JSON.stringify({
+            project_id: "proj.123",
+            languages: [
+              { lang_id: 640, lang_iso: "en", lang_name: "English", is_rtl: false },
+              { lang_id: 673, lang_iso: "fr", lang_name: "French", is_rtl: false },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify({ projects: [], languages: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const projects = await fetchLokaliseProjects({
+      organizationId: "org-1",
+      providerKind: "lokalise",
+      credential,
+      secretMaterial: "lokalise-token",
+    });
+
+    expect(projects).toHaveLength(1);
+    expect(projects[0]).toEqual({
+      externalProjectId: "proj.123",
+      name: "Marketing Website",
+      sourceLocale: "en",
+      targetLocales: ["fr"],
+      externalProjectUrl: "https://app.lokalise.com/project/proj.123/",
+      isActive: true,
+      metadata: {
+        projectType: "localization_files",
+        teamId: 42,
+        description: null,
+        baseLanguageId: 640,
+        languages: [
+          { id: 640, iso: "en", name: "English", isRtl: false },
+          { id: 673, iso: "fr", name: "French", isRtl: false },
+        ],
+      },
+    });
+  });
+
+  it("throws lokalise_auth_invalid when authentication fails", async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(JSON.stringify({ error: { message: "Invalid token" } }), {
+        status: 401,
+      });
+    }) as unknown as typeof fetch;
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      fetchLokaliseProjects({
+        organizationId: "org-1",
+        providerKind: "lokalise",
+        credential,
+        secretMaterial: "invalid-token",
+      }),
+    ).rejects.toThrow("lokalise_auth_invalid");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-project-fetcher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-project-fetcher.ts
@@ -1,0 +1,104 @@
+import type { ExternalTmsProjectFetcher } from "@/lib/providers/external-tms-project-sync";
+
+import {
+  buildLokaliseProjectUrl,
+  LokaliseApiClient,
+  LokaliseApiError,
+  LOKALISE_DEFAULT_BASE_URL,
+  partitionLokaliseLocales,
+} from "./lokalise-api";
+
+const LOCALE_FETCH_CONCURRENCY = 15;
+
+export const fetchLokaliseProjects: ExternalTmsProjectFetcher = async ({
+  credential,
+  secretMaterial,
+}) => {
+  const client = new LokaliseApiClient({
+    token: secretMaterial,
+    baseUrl: credential.baseUrl ?? LOKALISE_DEFAULT_BASE_URL,
+  });
+
+  let projects;
+  try {
+    projects = await client.listProjects();
+  } catch (error) {
+    if (error instanceof LokaliseApiError && (error.status === 401 || error.status === 403)) {
+      throw new Error("lokalise_auth_invalid");
+    }
+    throw error;
+  }
+
+  return mapWithConcurrency(projects, LOCALE_FETCH_CONCURRENCY, async (project) => {
+    try {
+      const languages = await client.listProjectLanguages(project.projectId);
+      const { sourceLocale, targetLocales } = partitionLokaliseLocales(project, languages);
+
+      return {
+        externalProjectId: project.projectId,
+        name: project.name,
+        sourceLocale,
+        targetLocales,
+        externalProjectUrl: buildLokaliseProjectUrl(project.projectId),
+        isActive: true,
+        metadata: {
+          projectType: project.projectType,
+          teamId: project.teamId,
+          description: project.description,
+          baseLanguageId: project.baseLanguageId,
+          languages: languages.map((language) => ({
+            id: language.langId,
+            iso: language.langIso,
+            name: language.langName,
+            isRtl: language.isRtl,
+          })),
+        },
+      };
+    } catch (error) {
+      if (error instanceof LokaliseApiError && (error.status === 401 || error.status === 403)) {
+        throw new Error("lokalise_auth_invalid");
+      }
+
+      return {
+        externalProjectId: project.projectId,
+        name: project.name,
+        sourceLocale: project.baseLanguageIso,
+        targetLocales: [],
+        externalProjectUrl: buildLokaliseProjectUrl(project.projectId),
+        isActive: true,
+        metadata: {
+          projectType: project.projectType,
+          teamId: project.teamId,
+          description: project.description,
+          baseLanguageId: project.baseLanguageId,
+          syncWarning: error instanceof Error ? error.message : "locale_fetch_failed",
+        },
+      };
+    }
+  });
+};
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T) => Promise<R>,
+) {
+  const results: R[] = Array.from({ length: items.length });
+  let nextIndex = 0;
+
+  async function worker() {
+    while (true) {
+      const currentIndex = nextIndex;
+      nextIndex += 1;
+      if (currentIndex >= items.length) {
+        return;
+      }
+
+      results[currentIndex] = await mapper(items[currentIndex] as T);
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, () => worker());
+  await Promise.all(workers);
+  return results;
+}

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-project-fetcher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-project-fetcher.ts
@@ -1,3 +1,4 @@
+import { mapWithConcurrency } from "@/lib/async/map-with-concurrency";
 import type { ExternalTmsProjectFetcher } from "@/lib/providers/external-tms-project-sync";
 
 import {
@@ -77,28 +78,3 @@ export const fetchLokaliseProjects: ExternalTmsProjectFetcher = async ({
     }
   });
 };
-
-async function mapWithConcurrency<T, R>(
-  items: T[],
-  concurrency: number,
-  mapper: (item: T) => Promise<R>,
-) {
-  const results: R[] = Array.from({ length: items.length });
-  let nextIndex = 0;
-
-  async function worker() {
-    while (true) {
-      const currentIndex = nextIndex;
-      nextIndex += 1;
-      if (currentIndex >= items.length) {
-        return;
-      }
-
-      results[currentIndex] = await mapper(items[currentIndex] as T);
-    }
-  }
-
-  const workers = Array.from({ length: Math.min(concurrency, items.length) }, () => worker());
-  await Promise.all(workers);
-  return results;
-}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the first Lokalise TMS connector slice for credential validation and project discovery (HL-358).

- Adds a thin Lokalise API v2 client (`listProjects`, `listProjectLanguages`) using `X-Api-Token` auth
- Adds `fetchLokaliseProjects` to normalize projects/locales into connected external TMS project records
- Wires Lokalise into `POST .../external-tms-provider-credential/:providerKind/sync-projects` (replacing the previous 501)
- Health check continues to use the existing `/me` validation path in `external-tms-health-check.ts`

## Testing

- `pnpm exec vp test src/lib/providers/lokalise/` — 7 tests passed
- `pnpm exec vp check --fix` — passed
- Route integration tests require Postgres (not run in this environment)

## Acceptance criteria

- [x] Lokalise credentials validate through the provider health check API (`/me`)
- [x] Lokalise projects/locales can be scanned idempotently via `upsertOrganizationExternalTmsProject`
- [x] Tests cover auth failure and project normalization
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-358](https://linear.app/hyperlocalise/issue/HL-358/implement-lokalise-credential-validation-and-project-listing)

<div><a href="https://cursor.com/agents/bc-c3759225-2b1d-4404-b90c-771cb34c5a02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c3759225-2b1d-4404-b90c-771cb34c5a02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

