### PR TITLE
feat(smartling): implement job content pull and translation write-back

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -9,10 +9,8 @@ import { db, schema } from "@/lib/database";
 import type { Project } from "@/lib/database/types";
 import { getFileStorageAdapter, type FileStorageAdapter } from "@/lib/file-storage";
 import { normalizeSourcePath } from "@/lib/file-storage/records";
-import { pullCrowdinTaskContent } from "@/lib/providers/crowdin/crowdin-content-puller";
 import { fetchCrowdinFileKeys } from "@/lib/providers/crowdin/crowdin-file-fetcher";
 import { fetchCrowdinJobTasks } from "@/lib/providers/crowdin/crowdin-job-task-fetcher";
-import { pushCrowdinTranslations } from "@/lib/providers/crowdin/crowdin-translation-pusher";
 import {
   syncExternalTmsFileKeys,
   type ExternalTmsFileKeyFetcher,
@@ -22,6 +20,8 @@ import {
   type ExternalTmsJobTaskFetcher,
 } from "@/lib/providers/external-tms-job-sync";
 import type { ExternalTmsProviderKind } from "@/lib/providers/organization-external-tms-provider-credentials";
+import { getProviderContentPuller } from "@/lib/providers/provider-content-pullers";
+import { getProviderTranslationPusher } from "@/lib/providers/provider-translation-pushers";
 import { fetchPhraseFileKeys } from "@/lib/providers/phrase/phrase-file-fetcher";
 import { fetchSmartlingFileKeys } from "@/lib/providers/smartling/smartling-file-fetcher";
 import { fetchSmartlingJobTasks } from "@/lib/providers/smartling/smartling-job-fetcher";
@@ -723,16 +723,21 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
           return projectNotFoundResponse(c);
         }
 
-        if (project.externalProviderKind !== "crowdin") {
+        if (!project.externalProviderKind) {
+          return c.json({ error: "provider_sync_not_implemented" }, 501);
+        }
+
+        const pullContent = getProviderContentPuller(project.externalProviderKind);
+        if (!pullContent) {
           return c.json({ error: "provider_sync_not_implemented" }, 501);
         }
 
         const result = await pullExternalTmsTaskContent({
           organizationId: c.var.auth.organization.localOrganizationId,
           projectId: project.id,
-          providerKind: "crowdin",
+          providerKind: project.externalProviderKind,
           externalJobId: payload.externalJobId,
-          pullContent: pullCrowdinTaskContent,
+          pullContent,
         });
 
         return c.json({ externalTmsContentPull: result }, result.status === "failed" ? 207 : 200);
@@ -755,17 +760,22 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
           return projectNotFoundResponse(c);
         }
 
-        if (project.externalProviderKind !== "crowdin") {
+        if (!project.externalProviderKind) {
+          return c.json({ error: "provider_sync_not_implemented" }, 501);
+        }
+
+        const pushTranslations = getProviderTranslationPusher(project.externalProviderKind);
+        if (!pushTranslations) {
           return c.json({ error: "provider_sync_not_implemented" }, 501);
         }
 
         const result = await pushExternalTmsTranslations({
           organizationId: c.var.auth.organization.localOrganizationId,
           projectId: project.id,
-          providerKind: "crowdin",
+          providerKind: project.externalProviderKind,
           externalJobId: payload.externalJobId,
           translations: payload.translations,
-          pushTranslations: pushCrowdinTranslations,
+          pushTranslations,
         });
 
         return c.json(

--- a/apps/hyperlocalise-web/src/lib/providers/provider-agent-qa.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-agent-qa.test.ts
@@ -160,8 +160,8 @@ describe("executeProviderAgentQa", () => {
 
     const run = await createAgentRun({
       organizationId: project.organizationId,
-      providerKind: "smartling",
-      externalJobId: "smartling-job-qa-1",
+      providerKind: "phrase",
+      externalJobId: "phrase-job-qa-1",
       kind: "review",
       inputSnapshot: { projectId: project.id, action: "run_qa_checks" },
     });

--- a/apps/hyperlocalise-web/src/lib/providers/provider-agent-translate.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-agent-translate.test.ts
@@ -191,8 +191,10 @@ describe("executeProviderAgentTranslation", () => {
     });
 
     loadOrganizationOpenAITranslationGeneratorMock.mockResolvedValue({
+      ok: true,
+      project: { name: project.name, translationContext: project.translationContext },
       translateStringJob: vi.fn(async () => ({
-        translations: [{ key: "hello", locale: "fr", text: "Bonjour" }],
+        translations: [{ locale: "fr", text: "Bonjour" }],
       })),
     });
 

--- a/apps/hyperlocalise-web/src/lib/providers/provider-agent-translate.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-agent-translate.test.ts
@@ -141,8 +141,8 @@ describe("executeProviderAgentTranslation", () => {
 
     const run = await createAgentRun({
       organizationId: project.organizationId,
-      providerKind: "smartling",
-      externalJobId: "smartling-job-1",
+      providerKind: "phrase",
+      externalJobId: "phrase-job-1",
       kind: "translate",
       inputSnapshot: { projectId: project.id, action: "translate_with_agent" },
     });
@@ -164,6 +164,58 @@ describe("executeProviderAgentTranslation", () => {
 
     expect(failed?.status).toBe("failed");
     expect(pullExternalTmsTaskContentMock).not.toHaveBeenCalled();
+  });
+
+  it("pulls Smartling job content through the provider-neutral sync layer", async () => {
+    const project = await createExternalTmsProject();
+    await db
+      .update(schema.projects)
+      .set({
+        externalProviderKind: "smartling",
+      })
+      .where(eq(schema.projects.id, project.id));
+
+    pullExternalTmsTaskContentMock.mockResolvedValue({
+      runId: "pull-run-smartling",
+      status: "succeeded",
+      providerKind: "smartling",
+      providerCredentialId: "cred-smartling",
+      projectId: project.id,
+      content: pulledContent,
+      counts: {
+        unitsDiscovered: 2,
+        translationsDiscovered: 1,
+        approvedTranslations: 1,
+      },
+      failures: [],
+    });
+
+    loadOrganizationOpenAITranslationGeneratorMock.mockResolvedValue({
+      translateStringJob: vi.fn(async () => ({
+        translations: [{ key: "hello", locale: "fr", text: "Bonjour" }],
+      })),
+    });
+
+    const run = await createAgentRun({
+      organizationId: project.organizationId,
+      providerKind: "smartling",
+      externalJobId: "smartling-job-1",
+      kind: "translate",
+      inputSnapshot: { projectId: project.id, action: "translate_with_agent" },
+    });
+
+    const result = await executeProviderAgentTranslation({
+      agentRunId: run.id,
+      organizationId: project.organizationId,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(pullExternalTmsTaskContentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerKind: "smartling",
+        externalJobId: "smartling-job-1",
+      }),
+    );
   });
 
   it("fails when projectId is missing from the input snapshot", async () => {

--- a/apps/hyperlocalise-web/src/lib/providers/provider-content-pullers.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-content-pullers.ts
@@ -1,5 +1,6 @@
 import { pullCrowdinTaskContent } from "@/lib/providers/crowdin/crowdin-content-puller";
 import type { ExternalTmsContentPuller } from "@/lib/providers/external-tms-content-sync";
+import { pullSmartlingTaskContent } from "@/lib/providers/smartling/smartling-content-puller";
 
 import type { ExternalTmsProviderKind } from "./organization-external-tms-provider-credentials";
 
@@ -9,6 +10,8 @@ export function getProviderContentPuller(
   switch (providerKind) {
     case "crowdin":
       return pullCrowdinTaskContent;
+    case "smartling":
+      return pullSmartlingTaskContent;
     default:
       return null;
   }

--- a/apps/hyperlocalise-web/src/lib/providers/provider-translation-pushers.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-translation-pushers.ts
@@ -1,0 +1,18 @@
+import { pushCrowdinTranslations } from "@/lib/providers/crowdin/crowdin-translation-pusher";
+import type { ExternalTmsTranslationPusher } from "@/lib/providers/external-tms-content-sync";
+import { pushSmartlingTranslations } from "@/lib/providers/smartling/smartling-translation-pusher";
+
+import type { ExternalTmsProviderKind } from "./organization-external-tms-provider-credentials";
+
+export function getProviderTranslationPusher(
+  providerKind: ExternalTmsProviderKind,
+): ExternalTmsTranslationPusher | null {
+  switch (providerKind) {
+    case "crowdin":
+      return pushCrowdinTranslations;
+    case "smartling":
+      return pushSmartlingTranslations;
+    default:
+      return null;
+  }
+}

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-api.ts
@@ -2,7 +2,7 @@
  * Smartling API client for authentication and project discovery.
  *
  * This module intentionally implements only the endpoints required for
- * credential validation and the TMS connector project-scan flow.
+ * credential validation, TMS connector scans, and job-scoped content pull/write-back.
  */
 
 import { parseSmartlingCredentials, type SmartlingCredentials } from "./smartling-credentials";
@@ -96,6 +96,46 @@ export interface SmartlingJobSummary {
   modifiedDate?: string | null;
   referenceNumber?: string | null;
   jobNumber?: string | null;
+}
+
+export type SmartlingJobDetails = SmartlingJobSummary;
+
+export interface SmartlingJobFile {
+  fileUri: string;
+  fileName?: string | null;
+}
+
+export interface SmartlingLocaleTranslation {
+  hashcode?: string | null;
+  stringText?: string | null;
+  parsedStringText?: string | null;
+  translation?: string | null;
+  instruction?: string | null;
+  fileUri?: string | null;
+  targetLocaleId?: string | null;
+  authorized?: boolean | null;
+  published?: boolean | null;
+  publishStatus?: string | null;
+}
+
+export interface SmartlingUpsertTranslationItem {
+  hashcode: string;
+  translation: string;
+  stringText?: string | null;
+  instruction?: string | null;
+}
+
+export interface SmartlingJobProgress {
+  totalWordCount?: number;
+  completedWordCount?: number;
+  percentComplete?: number;
+}
+
+export interface SmartlingAsyncProcessStatus {
+  processUid?: string;
+  processState?: string;
+  processStatus?: string;
+  percentComplete?: number;
 }
 
 type SmartlingEnvelope<T> = {
@@ -417,6 +457,143 @@ export class SmartlingApiClient {
     return jobs;
   }
 
+  async getJob(projectId: string, translationJobUid: string): Promise<SmartlingJobDetails> {
+    const token = await this.getAccessToken();
+    const data = await this.get<SmartlingJobDetails>(
+      `${this.jobsBaseUrl}/projects/${encodeURIComponent(projectId)}/jobs/${encodeURIComponent(translationJobUid)}`,
+      token,
+    );
+    return normalizeSmartlingJobSummary(data);
+  }
+
+  async listJobFiles(projectId: string, translationJobUid: string): Promise<SmartlingJobFile[]> {
+    const files: SmartlingJobFile[] = [];
+
+    await paginateSmartlingList({
+      fetchPage: async (offset, limit) => {
+        const token = await this.getAccessToken();
+        const params = new URLSearchParams({
+          limit: String(limit),
+          offset: String(offset),
+        });
+        const data = await this.get<{ items?: SmartlingJobFile[]; totalCount?: number }>(
+          `${this.jobsBaseUrl}/projects/${encodeURIComponent(projectId)}/jobs/${encodeURIComponent(translationJobUid)}/files?${params.toString()}`,
+          token,
+        );
+        return {
+          items: (data.items ?? []).map((item) => ({
+            fileUri: item.fileUri,
+            fileName: item.fileName ?? null,
+          })),
+          totalCount: data.totalCount,
+        };
+      },
+      onPage: (page) => files.push(...page),
+    });
+
+    return files;
+  }
+
+  async listLocaleTranslations(
+    projectId: string,
+    localeId: string,
+  ): Promise<SmartlingLocaleTranslation[]> {
+    const translations: SmartlingLocaleTranslation[] = [];
+
+    await paginateSmartlingList({
+      fetchPage: async (offset, limit) => {
+        const token = await this.getAccessToken();
+        const params = new URLSearchParams({
+          targetLocaleId: localeId,
+          limit: String(limit),
+          offset: String(offset),
+        });
+        const data = await this.get<{ items?: SmartlingLocaleTranslation[]; totalCount?: number }>(
+          `${this.stringsBaseUrl}/projects/${encodeURIComponent(projectId)}/translations?${params.toString()}`,
+          token,
+        );
+        return {
+          items: (data.items ?? []).map(normalizeSmartlingLocaleTranslation),
+          totalCount: data.totalCount,
+        };
+      },
+      onPage: (page) => translations.push(...page),
+    });
+
+    return translations;
+  }
+
+  async upsertLocaleTranslations(
+    projectId: string,
+    localeId: string,
+    items: SmartlingUpsertTranslationItem[],
+  ): Promise<void> {
+    if (items.length === 0) {
+      return;
+    }
+
+    const token = await this.getAccessToken();
+    await this.put(
+      `${this.stringsBaseUrl}/projects/${encodeURIComponent(projectId)}/locales/${encodeURIComponent(localeId)}/translations`,
+      token,
+      { items },
+    );
+  }
+
+  async authorizeJob(
+    projectId: string,
+    translationJobUid: string,
+    targetLocaleIds: string[],
+  ): Promise<Record<string, unknown>> {
+    const token = await this.getAccessToken();
+    return this.post<Record<string, unknown>>(
+      `${this.jobsBaseUrl}/projects/${encodeURIComponent(projectId)}/jobs/${encodeURIComponent(translationJobUid)}/authorize`,
+      token,
+      { targetLocaleIds },
+    );
+  }
+
+  async getJobProgress(
+    projectId: string,
+    translationJobUid: string,
+    targetLocaleId?: string,
+  ): Promise<SmartlingJobProgress> {
+    const token = await this.getAccessToken();
+    const params = new URLSearchParams();
+    if (targetLocaleId) {
+      params.set("targetLocaleId", targetLocaleId);
+    }
+    const query = params.toString();
+    const url = `${this.jobsBaseUrl}/projects/${encodeURIComponent(projectId)}/jobs/${encodeURIComponent(translationJobUid)}/progress${query ? `?${query}` : ""}`;
+    const data = await this.get<{
+      progress?: SmartlingJobProgress;
+      totalWordCount?: number;
+      completedWordCount?: number;
+      percentComplete?: number;
+    }>(url, token);
+
+    if (data.progress) {
+      return data.progress;
+    }
+
+    return {
+      totalWordCount: data.totalWordCount,
+      completedWordCount: data.completedWordCount,
+      percentComplete: data.percentComplete,
+    };
+  }
+
+  async getAsyncProcessStatus(
+    projectId: string,
+    processUid: string,
+  ): Promise<SmartlingAsyncProcessStatus> {
+    const token = await this.getAccessToken();
+    return this.get<SmartlingAsyncProcessStatus>(
+      `${this.filesBaseUrl}/projects/${encodeURIComponent(projectId)}/processes/${encodeURIComponent(processUid)}`,
+      token,
+    );
+  }
+
   private async get<T>(url: string, token: string): Promise<T> {
     const response = await this.fetchFn(url, {
       method: "GET",
@@ -434,6 +611,19 @@ export class SmartlingApiClient {
       method: "POST",
       headers: {
         ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+
+    return parseSmartlingResponse<T>(response, url);
+  }
+
+  private async put<T>(url: string, token: string, payload: unknown): Promise<T> {
+    const response = await this.fetchFn(url, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${token}`,
         "Content-Type": "application/json",
       },
       body: JSON.stringify(payload),
@@ -651,5 +841,22 @@ function normalizeSmartlingJobSummary(item: SmartlingJobSummary): SmartlingJobSu
     modifiedDate: item.modifiedDate ?? null,
     referenceNumber: item.referenceNumber ?? null,
     jobNumber: item.jobNumber ?? null,
+  };
+}
+
+function normalizeSmartlingLocaleTranslation(
+  item: SmartlingLocaleTranslation,
+): SmartlingLocaleTranslation {
+  return {
+    hashcode: item.hashcode ?? null,
+    stringText: item.stringText ?? null,
+    parsedStringText: item.parsedStringText ?? null,
+    translation: item.translation ?? null,
+    instruction: item.instruction ?? null,
+    fileUri: item.fileUri ?? null,
+    targetLocaleId: item.targetLocaleId ?? null,
+    authorized: item.authorized ?? null,
+    published: item.published ?? null,
+    publishStatus: item.publishStatus ?? null,
   };
 }

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-api.ts
@@ -497,6 +497,7 @@ export class SmartlingApiClient {
   async listLocaleTranslations(
     projectId: string,
     localeId: string,
+    options?: { fileUri?: string },
   ): Promise<SmartlingLocaleTranslation[]> {
     const translations: SmartlingLocaleTranslation[] = [];
 
@@ -508,6 +509,9 @@ export class SmartlingApiClient {
           limit: String(limit),
           offset: String(offset),
         });
+        if (options?.fileUri) {
+          params.set("fileUri", options.fileUri);
+        }
         const data = await this.get<{ items?: SmartlingLocaleTranslation[]; totalCount?: number }>(
           `${this.stringsBaseUrl}/projects/${encodeURIComponent(projectId)}/translations?${params.toString()}`,
           token,

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-async-polling.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-async-polling.ts
@@ -1,0 +1,86 @@
+import type { SmartlingApiClient, SmartlingAsyncProcessStatus } from "./smartling-api";
+
+const DEFAULT_POLL_INTERVAL_MS = 1_000;
+const DEFAULT_MAX_ATTEMPTS = 60;
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isTerminalProcessState(status: SmartlingAsyncProcessStatus) {
+  const state = `${status.processState ?? status.processStatus ?? ""}`.toLowerCase();
+  if (!state) {
+    return false;
+  }
+  return ["completed", "complete", "finished", "success", "succeeded", "failed", "cancelled"].some(
+    (terminal) => state.includes(terminal),
+  );
+}
+
+function isFailedProcessState(status: SmartlingAsyncProcessStatus) {
+  const state = `${status.processState ?? status.processStatus ?? ""}`.toLowerCase();
+  return state.includes("fail") || state.includes("cancel");
+}
+
+export async function pollSmartlingAsyncProcess(input: {
+  client: SmartlingApiClient;
+  projectId: string;
+  processUid: string;
+  pollIntervalMs?: number;
+  maxAttempts?: number;
+}): Promise<SmartlingAsyncProcessStatus> {
+  const pollIntervalMs = input.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  const maxAttempts = input.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+
+  let lastStatus: SmartlingAsyncProcessStatus = { processUid: input.processUid };
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    lastStatus = await input.client.getAsyncProcessStatus(input.projectId, input.processUid);
+    if (isTerminalProcessState(lastStatus)) {
+      if (isFailedProcessState(lastStatus)) {
+        throw new Error(
+          `smartling_async_process_failed:${lastStatus.processState ?? lastStatus.processStatus ?? "unknown"}`,
+        );
+      }
+      return lastStatus;
+    }
+    await sleep(pollIntervalMs);
+  }
+
+  throw new Error("smartling_async_process_timeout");
+}
+
+export async function pollSmartlingJobProgress(input: {
+  client: SmartlingApiClient;
+  projectId: string;
+  translationJobUid: string;
+  targetLocaleId?: string;
+  pollIntervalMs?: number;
+  maxAttempts?: number;
+}): Promise<Record<string, unknown>> {
+  const pollIntervalMs = input.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  const maxAttempts = input.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+
+  let lastProgress: Record<string, unknown> = {};
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    const progress = await input.client.getJobProgress(
+      input.projectId,
+      input.translationJobUid,
+      input.targetLocaleId,
+    );
+    lastProgress = progress as Record<string, unknown>;
+    const percent =
+      typeof progress.percentComplete === "number"
+        ? progress.percentComplete
+        : progress.totalWordCount && progress.completedWordCount
+          ? (progress.completedWordCount / progress.totalWordCount) * 100
+          : null;
+
+    if (percent != null && percent >= 100) {
+      return lastProgress;
+    }
+
+    await sleep(pollIntervalMs);
+  }
+
+  throw new Error("smartling_job_progress_timeout");
+}

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-content-puller.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-content-puller.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { pullSmartlingTaskContent } from "./smartling-content-puller";
+
+describe("pullSmartlingTaskContent", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("pulls job-scoped source strings and locale translations", async () => {
+    const fetchMock = vi.fn(async (url, init) => {
+      const path = String(url);
+
+      if (path.endsWith("/authenticate") && init?.method === "POST") {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: { accessToken: "access-token", expiresIn: 3600 },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.endsWith("/projects/proj-1/jobs/job-1") && init?.method !== "POST") {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: {
+                translationJobUid: "job-1",
+                jobName: "French rollout",
+                jobStatus: "in_progress",
+                targetLocaleIds: ["fr-FR"],
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.endsWith("/projects/proj-1") && !path.includes("/jobs/")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: {
+                projectId: "proj-1",
+                projectName: "Demo",
+                sourceLocaleId: "en-US",
+                accountUid: "acct-1",
+                targetLocales: [{ localeId: "fr-FR", enabled: true }],
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/jobs/job-1/files")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: {
+                items: [{ fileUri: "messages.json" }],
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/source-strings")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: {
+                items: [
+                  {
+                    hashcode: "hash-1",
+                    stringText: "Hello",
+                    fileUri: "messages.json",
+                    variant: "hello",
+                  },
+                ],
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/translations?") && path.includes("targetLocaleId=fr-FR")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: {
+                items: [
+                  {
+                    hashcode: "hash-1",
+                    fileUri: "messages.json",
+                    translation: "Bonjour",
+                    targetLocaleId: "fr-FR",
+                    authorized: true,
+                  },
+                ],
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response("Not Found", { status: 404 });
+    });
+
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await pullSmartlingTaskContent({
+      organizationId: "org_1",
+      projectId: "proj_1",
+      providerKind: "smartling",
+      externalProjectId: "proj-1",
+      externalJobId: "job-1",
+      credential: { id: "cred_1" } as never,
+      project: {} as never,
+      secretMaterial: "user:secret:acct-1",
+    });
+
+    expect(result).toMatchObject({
+      externalJobId: "job-1",
+      sourceLocale: "en-US",
+      targetLocales: ["fr-FR"],
+    });
+    expect(result.units).toHaveLength(1);
+    expect(result.units[0]).toMatchObject({
+      externalStringId: "hash-1",
+      key: "hello",
+      sourceText: "Hello",
+      fileId: "messages.json",
+      translations: [{ locale: "fr-FR", text: "Bonjour", isApproved: true }],
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-content-puller.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-content-puller.test.ts
@@ -99,7 +99,11 @@ describe("pullSmartlingTaskContent", () => {
         );
       }
 
-      if (path.includes("/translations?") && path.includes("targetLocaleId=fr-FR")) {
+      if (
+        path.includes("/translations?") &&
+        path.includes("targetLocaleId=fr-FR") &&
+        path.includes("fileUri=messages.json")
+      ) {
         return new Response(
           JSON.stringify({
             response: {

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-content-puller.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-content-puller.ts
@@ -1,0 +1,161 @@
+import type { ExternalTmsContentPuller } from "@/lib/providers/external-tms-content-sync";
+
+import { SmartlingApiClient, SmartlingApiError } from "./smartling-api";
+import { mapSmartlingFetcherError } from "./smartling-errors";
+
+function translationLookupKey(input: {
+  hashcode?: string | null;
+  fileUri?: string | null;
+  stringText?: string | null;
+  parsedStringText?: string | null;
+}) {
+  if (input.hashcode) {
+    return input.fileUri ? `${input.fileUri}::${input.hashcode}` : input.hashcode;
+  }
+  const text = input.parsedStringText ?? input.stringText;
+  if (!text) {
+    return null;
+  }
+  return input.fileUri ? `${input.fileUri}::${text}` : text;
+}
+
+function isApprovedTranslation(translation: {
+  authorized?: boolean | null;
+  published?: boolean | null;
+  publishStatus?: string | null;
+  translation?: string | null;
+}) {
+  if (!translation.translation?.trim()) {
+    return false;
+  }
+  if (translation.authorized === true || translation.published === true) {
+    return true;
+  }
+  const publishStatus = translation.publishStatus?.toLowerCase() ?? "";
+  return publishStatus.includes("publish") || publishStatus.includes("author");
+}
+
+export const pullSmartlingTaskContent: ExternalTmsContentPuller = async ({
+  credential,
+  externalProjectId,
+  externalJobId,
+  secretMaterial,
+}) => {
+  const client = new SmartlingApiClient({
+    credentials: secretMaterial,
+    authBaseUrl: credential.baseUrl ?? undefined,
+  });
+
+  const projectId = externalProjectId.trim();
+  const jobUid = externalJobId.trim();
+  if (!projectId || !jobUid) {
+    throw new Error("invalid_smartling_project_or_job_id");
+  }
+
+  let job;
+  let projectDetails;
+  let jobFiles;
+  try {
+    [job, projectDetails, jobFiles] = await Promise.all([
+      client.getJob(projectId, jobUid),
+      client.getProjectDetails(projectId),
+      client.listJobFiles(projectId, jobUid),
+    ]);
+  } catch (error) {
+    if (error instanceof SmartlingApiError && error.status === 401) {
+      throw new Error("smartling_auth_invalid");
+    }
+    throw mapSmartlingFetcherError(error);
+  }
+
+  const targetLocales = job.targetLocaleIds.length > 0 ? job.targetLocaleIds : [];
+  const fileUris = jobFiles.map((file) => file.fileUri).filter(Boolean);
+
+  const sourceStrings = [];
+  if (fileUris.length > 0) {
+    for (const fileUri of fileUris) {
+      sourceStrings.push(...(await client.listSourceStrings(projectId, { fileUri })));
+    }
+  } else {
+    sourceStrings.push(...(await client.listSourceStrings(projectId)));
+  }
+
+  const translationsByKey = new Map<
+    string,
+    Array<{
+      locale: string;
+      text: string;
+      isApproved: boolean;
+      externalTranslationId: string | null;
+    }>
+  >();
+
+  for (const locale of targetLocales) {
+    const localeTranslations = await client.listLocaleTranslations(projectId, locale);
+    for (const translation of localeTranslations) {
+      const key = translationLookupKey(translation);
+      if (!key || !translation.translation) {
+        continue;
+      }
+
+      const existing = translationsByKey.get(key) ?? [];
+      existing.push({
+        locale,
+        text: translation.translation,
+        isApproved: isApprovedTranslation(translation),
+        externalTranslationId: translation.hashcode ?? null,
+      });
+      translationsByKey.set(key, existing);
+    }
+  }
+
+  const units = sourceStrings.map((sourceString) => {
+    const lookupKeys = [
+      translationLookupKey({
+        hashcode: sourceString.hashcode,
+        fileUri: sourceString.fileUri,
+      }),
+      translationLookupKey({
+        fileUri: sourceString.fileUri,
+        stringText: sourceString.stringText,
+      }),
+    ].filter((key): key is string => Boolean(key));
+
+    const matchedTranslations =
+      lookupKeys.map((key) => translationsByKey.get(key)).find((value) => value != null) ?? [];
+
+    return {
+      externalStringId: sourceString.hashcode,
+      key: sourceString.variant ?? sourceString.hashcode,
+      sourceText: sourceString.stringText ?? "",
+      context:
+        typeof sourceString.metadata?.instruction === "string"
+          ? sourceString.metadata.instruction
+          : null,
+      fileId: sourceString.fileUri ?? null,
+      translations: matchedTranslations,
+      providerPayload: {
+        fileUri: sourceString.fileUri,
+        variant: sourceString.variant,
+        stringVariantUid: sourceString.stringVariantUid,
+      },
+    };
+  });
+
+  return {
+    externalJobId: job.translationJobUid,
+    externalTaskId: null,
+    sourceLocale: projectDetails.sourceLocaleId ?? null,
+    targetLocales,
+    units,
+    exportArtifact: null,
+    providerPayload: {
+      jobName: job.jobName,
+      jobStatus: job.jobStatus,
+      fileUris,
+      description: job.description,
+      referenceNumber: job.referenceNumber,
+      jobNumber: job.jobNumber,
+    },
+  };
+};

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-content-puller.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-content-puller.ts
@@ -32,7 +32,12 @@ function isApprovedTranslation(translation: {
     return true;
   }
   const publishStatus = translation.publishStatus?.toLowerCase() ?? "";
-  return publishStatus.includes("publish") || publishStatus.includes("author");
+  return (
+    publishStatus === "published" ||
+    publishStatus === "authorized" ||
+    (publishStatus.includes("publish") && !publishStatus.startsWith("unpublish")) ||
+    (publishStatus.includes("author") && !publishStatus.startsWith("unauthor"))
+  );
 }
 
 export const pullSmartlingTaskContent: ExternalTmsContentPuller = async ({
@@ -91,21 +96,28 @@ export const pullSmartlingTaskContent: ExternalTmsContentPuller = async ({
   >();
 
   for (const locale of targetLocales) {
-    const localeTranslations = await client.listLocaleTranslations(projectId, locale);
-    for (const translation of localeTranslations) {
-      const key = translationLookupKey(translation);
-      if (!key || !translation.translation) {
-        continue;
-      }
-
-      const existing = translationsByKey.get(key) ?? [];
-      existing.push({
+    const fileScopes = fileUris.length > 0 ? fileUris : [undefined];
+    for (const fileUri of fileScopes) {
+      const localeTranslations = await client.listLocaleTranslations(
+        projectId,
         locale,
-        text: translation.translation,
-        isApproved: isApprovedTranslation(translation),
-        externalTranslationId: translation.hashcode ?? null,
-      });
-      translationsByKey.set(key, existing);
+        fileUri ? { fileUri } : undefined,
+      );
+      for (const translation of localeTranslations) {
+        const key = translationLookupKey(translation);
+        if (!key || !translation.translation) {
+          continue;
+        }
+
+        const existing = translationsByKey.get(key) ?? [];
+        existing.push({
+          locale,
+          text: translation.translation,
+          isApproved: isApprovedTranslation(translation),
+          externalTranslationId: translation.hashcode ?? null,
+        });
+        translationsByKey.set(key, existing);
+      }
     }
   }
 

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-translation-pusher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-translation-pusher.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { pushSmartlingTranslations } from "./smartling-translation-pusher";
+
+describe("pushSmartlingTranslations", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("upserts translations, authorizes the job, and records async progress", async () => {
+    const fetchMock = vi.fn(async (url, init) => {
+      const path = String(url);
+      const method = init?.method ?? "GET";
+
+      if (path.endsWith("/authenticate") && method === "POST") {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: { accessToken: "access-token", expiresIn: 3600 },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.endsWith("/projects/proj-1/jobs/job-1") && method === "GET") {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: {
+                translationJobUid: "job-1",
+                jobName: "French rollout",
+                jobStatus: "in_progress",
+                targetLocaleIds: ["fr-FR"],
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.endsWith("/locales/fr-FR/translations") && method === "PUT") {
+        return new Response(
+          JSON.stringify({
+            response: { code: "SUCCESS", data: {} },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.endsWith("/jobs/job-1/authorize") && method === "POST") {
+        return new Response(
+          JSON.stringify({
+            response: { code: "SUCCESS", data: { authorized: true } },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/jobs/job-1/progress")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: { percentComplete: 100 },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response("Not Found", { status: 404 });
+    });
+
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await pushSmartlingTranslations({
+      organizationId: "org_1",
+      projectId: "proj_1",
+      providerKind: "smartling",
+      externalProjectId: "proj-1",
+      externalJobId: "job-1",
+      credential: { id: "cred_1" } as never,
+      project: {} as never,
+      secretMaterial: "user:secret:acct-1",
+      translations: [{ locale: "fr-FR", text: "Bonjour", externalStringId: "hash-1" }],
+    });
+
+    expect(result.uploaded).toBe(1);
+    expect(result.failed).toBe(0);
+    expect(result.asyncOperations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "smartling_upsert_translations", status: "succeeded" }),
+        expect.objectContaining({ type: "smartling_authorize_job" }),
+        expect.objectContaining({ type: "smartling_job_progress", status: "succeeded" }),
+      ]),
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-translation-pusher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-translation-pusher.ts
@@ -32,9 +32,8 @@ export const pushSmartlingTranslations: ExternalTmsTranslationPusher = async ({
     throw new Error("invalid_smartling_project_or_job_id");
   }
 
-  let job;
   try {
-    job = await client.getJob(projectId, jobUid);
+    await client.getJob(projectId, jobUid);
   } catch (error) {
     if (error instanceof SmartlingApiError && error.status === 401) {
       throw new Error("smartling_auth_invalid");
@@ -76,7 +75,6 @@ export const pushSmartlingTranslations: ExternalTmsTranslationPusher = async ({
       hashcode,
       translation: translation.text,
       stringText: translation.key ?? null,
-      instruction: translation.fileId ?? null,
     });
     groups.set(key, existing);
   }
@@ -161,11 +159,13 @@ export const pushSmartlingTranslations: ExternalTmsTranslationPusher = async ({
         status: "failed",
         error: error instanceof Error ? error.message : "smartling job authorization failed",
       });
-      failures.push({
-        locale: job.targetLocaleIds[0] ?? "unknown",
-        fileId: null,
-        message: error instanceof Error ? error.message : "smartling job authorization failed",
-      });
+      for (const locale of localesToAuthorize) {
+        failures.push({
+          locale,
+          fileId: null,
+          message: error instanceof Error ? error.message : "smartling job authorization failed",
+        });
+      }
     }
   }
 

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-translation-pusher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-translation-pusher.ts
@@ -1,0 +1,173 @@
+import type { ExternalTmsTranslationPusher } from "@/lib/providers/external-tms-content-sync";
+
+import { SmartlingApiClient, SmartlingApiError } from "./smartling-api";
+import { pollSmartlingJobProgress } from "./smartling-async-polling";
+import { mapSmartlingFetcherError } from "./smartling-errors";
+
+type LocaleUploadGroup = {
+  locale: string;
+  entries: Array<{
+    hashcode: string;
+    translation: string;
+    stringText?: string | null;
+    instruction?: string | null;
+  }>;
+};
+
+export const pushSmartlingTranslations: ExternalTmsTranslationPusher = async ({
+  credential,
+  externalProjectId,
+  externalJobId,
+  secretMaterial,
+  translations,
+}) => {
+  const client = new SmartlingApiClient({
+    credentials: secretMaterial,
+    authBaseUrl: credential.baseUrl ?? undefined,
+  });
+
+  const projectId = externalProjectId.trim();
+  const jobUid = externalJobId.trim();
+  if (!projectId || !jobUid) {
+    throw new Error("invalid_smartling_project_or_job_id");
+  }
+
+  let job;
+  try {
+    job = await client.getJob(projectId, jobUid);
+  } catch (error) {
+    if (error instanceof SmartlingApiError && error.status === 401) {
+      throw new Error("smartling_auth_invalid");
+    }
+    throw mapSmartlingFetcherError(error);
+  }
+
+  let uploaded = 0;
+  let failed = 0;
+  const failures: Array<{ locale: string; message: string; fileId?: string | null }> = [];
+  const asyncOperations: Array<Record<string, unknown>> = [];
+
+  const groups = new Map<string, LocaleUploadGroup>();
+  for (const translation of translations) {
+    const locale = translation.locale.trim();
+    const hashcode = translation.externalStringId?.trim();
+    if (!locale) {
+      failed += 1;
+      failures.push({
+        locale: translation.locale,
+        fileId: translation.fileId ?? null,
+        message: "smartling_translation_missing_locale",
+      });
+      continue;
+    }
+    if (!hashcode) {
+      failed += 1;
+      failures.push({
+        locale,
+        fileId: translation.fileId ?? null,
+        message: "smartling_translation_missing_hashcode",
+      });
+      continue;
+    }
+
+    const key = locale;
+    const existing = groups.get(key) ?? { locale, entries: [] };
+    existing.entries.push({
+      hashcode,
+      translation: translation.text,
+      stringText: translation.key ?? null,
+      instruction: translation.fileId ?? null,
+    });
+    groups.set(key, existing);
+  }
+
+  if (groups.size === 0) {
+    return { uploaded, failed, failures, asyncOperations };
+  }
+
+  const localesToAuthorize = new Set<string>();
+  for (const group of groups.values()) {
+    try {
+      await client.upsertLocaleTranslations(projectId, group.locale, group.entries);
+      uploaded += group.entries.length;
+      localesToAuthorize.add(group.locale);
+      asyncOperations.push({
+        type: "smartling_upsert_translations",
+        locale: group.locale,
+        count: group.entries.length,
+        status: "succeeded",
+      });
+    } catch (error) {
+      failed += group.entries.length;
+      failures.push({
+        locale: group.locale,
+        fileId: null,
+        message: error instanceof Error ? error.message : "smartling translation upload failed",
+      });
+      asyncOperations.push({
+        type: "smartling_upsert_translations",
+        locale: group.locale,
+        status: "failed",
+        error: error instanceof Error ? error.message : "smartling translation upload failed",
+      });
+    }
+  }
+
+  if (localesToAuthorize.size > 0) {
+    try {
+      const authorizeResult = await client.authorizeJob(projectId, jobUid, [...localesToAuthorize]);
+      asyncOperations.push({
+        type: "smartling_authorize_job",
+        translationJobUid: jobUid,
+        targetLocaleIds: [...localesToAuthorize],
+        result: authorizeResult,
+      });
+
+      for (const locale of localesToAuthorize) {
+        try {
+          const progress = await pollSmartlingJobProgress({
+            client,
+            projectId,
+            translationJobUid: jobUid,
+            targetLocaleId: locale,
+          });
+          asyncOperations.push({
+            type: "smartling_job_progress",
+            translationJobUid: jobUid,
+            locale,
+            status: "succeeded",
+            progress,
+          });
+        } catch (error) {
+          asyncOperations.push({
+            type: "smartling_job_progress",
+            translationJobUid: jobUid,
+            locale,
+            status: "failed",
+            error: error instanceof Error ? error.message : "smartling job progress polling failed",
+          });
+          failures.push({
+            locale,
+            fileId: null,
+            message:
+              error instanceof Error ? error.message : "smartling job progress polling failed",
+          });
+        }
+      }
+    } catch (error) {
+      asyncOperations.push({
+        type: "smartling_authorize_job",
+        translationJobUid: jobUid,
+        status: "failed",
+        error: error instanceof Error ? error.message : "smartling job authorization failed",
+      });
+      failures.push({
+        locale: job.targetLocaleIds[0] ?? "unknown",
+        fileId: null,
+        message: error instanceof Error ? error.message : "smartling job authorization failed",
+      });
+    }
+  }
+
+  return { uploaded, failed, failures, asyncOperations };
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements HL-346 by adding Smartling support for provider-neutral job content pull and approved translation write-back in the web app.

## Changes

- **Smartling API client** — Job details, job files, locale translations (list/upsert), job authorization, job progress, and async process status endpoints.
- **`pullSmartlingTaskContent`** — Downloads job-scoped source strings and per-locale translations, maps them into `ExternalTmsTaskContent` for agent runs.
- **`pushSmartlingTranslations`** — Upserts approved translations per locale, authorizes the job, polls progress, and records async operation metadata.
- **Provider registries** — `getProviderContentPuller` / `getProviderTranslationPusher` now include Smartling alongside Crowdin.
- **Project routes** — `sync-pull-content` and `sync-push-translations` use registries instead of Crowdin-only guards.

## Sync runs

Pull and push operations continue to flow through `pullExternalTmsTaskContent` / `pushExternalTmsTranslations`, which record `pull_content` and `push_translations` runs in `provider_sync_runs`. Failures (including async polling timeouts) are persisted via `failProviderSyncRun` with `errorMessage` and `errorDetails`.

## Testing

- `vp check` — pass
- `vp test src/lib/providers/smartling/` — 30 tests passed
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-346](https://linear.app/hyperlocalise/issue/HL-346/implement-smartling-translation-pull-and-write-back)

<div><a href="https://cursor.com/agents/bc-210ee34f-cb67-4101-8b6d-055b68806758"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-210ee34f-cb67-4101-8b6d-055b68806758"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

