### PR TITLE
feat(web): agent review findings for provider jobs (HL-372)

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/job-qa.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job-qa.schema.ts
@@ -17,6 +17,7 @@ export const providerQaFindingSchema = z.object({
   severity: z.enum(providerQaSeverityLevels),
   message: z.string(),
   suggestedFix: z.string().optional(),
+  confidence: z.number().min(0).max(1).optional(),
   item: providerQaItemReferenceSchema,
 });
 

--- a/apps/hyperlocalise-web/src/api/routes/project/job.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.test.ts
@@ -1385,6 +1385,54 @@ describe("jobRoutes", () => {
     });
   });
 
+  it("creates review agent runs for review_with_agent", async () => {
+    const identity = createWorkosIdentity();
+    const projectResponse = await createProjectViaApi(identity);
+    const project = ((await projectResponse.json()) as ProjectResponse).project;
+    const [organization] = await db
+      .select({ id: schema.organizations.id })
+      .from(schema.projects)
+      .innerJoin(schema.organizations, eq(schema.projects.organizationId, schema.organizations.id))
+      .where(eq(schema.projects.id, project.id))
+      .limit(1);
+
+    const externalJob = await upsertExternalJob({
+      organizationId: organization!.id,
+      projectId: project.id,
+      providerKind: "crowdin",
+      externalJobId: "crowdin-job-review-agent",
+      externalStatus: "todo",
+      title: "Review copy",
+    });
+
+    const response = await client.api.orgs[":organizationSlug"].jobs[":jobId"]["agent-runs"].$post(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          jobId: externalJob.id,
+        },
+        json: { action: "review_with_agent" },
+      },
+      { headers: await authHeadersFor(identity) },
+    );
+
+    expect(response.status).toBe(201);
+    const body = (await response.json()) as {
+      agentRun: {
+        kind: string;
+        status: string;
+        externalJobId: string;
+        inputSnapshot: Record<string, unknown>;
+      };
+    };
+    expect(body.agentRun).toMatchObject({
+      kind: "review",
+      status: "queued",
+      externalJobId: "crowdin-job-review-agent",
+      inputSnapshot: expect.objectContaining({ action: "review_with_agent" }),
+    });
+  });
+
   it("marks the agent run failed when provider translation queueing fails", async () => {
     const failingClient = testClient(
       createApp({

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-qa-findings-model.test.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-qa-findings-model.test.ts
@@ -1,101 +1,25 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import {
-  attachFindingIds,
-  buildFindingId,
-  buildProjectFilesHref,
-  filterFindings,
-  groupFindings,
-  parseQaReportFromOutputSummary,
+  isProviderReviewFindingsAgentRun,
+  isQaChecksAgentRun,
+  isReviewWithAgentRun,
 } from "./job-qa-findings-model";
 
-const sampleFinding = {
-  checkType: "placeholder_mismatch" as const,
-  severity: "error" as const,
-  message: "Placeholder mismatch",
-  item: {
-    externalStringId: "1001",
-    key: "locales/en.json",
-    locale: "fr",
-    field: "target" as const,
-  },
-};
-
-describe("job-qa-findings-model", () => {
-  it("parses QA reports from agent run output summaries", () => {
-    const report = parseQaReportFromOutputSummary({
-      findings: [sampleFinding],
-      summary: { total: 1, byCheckType: {}, bySeverity: { error: 1 } },
-    });
-
-    expect(report?.findings).toHaveLength(1);
-    expect(report?.summary.total).toBe(1);
+describe("provider review findings agent run helpers", () => {
+  it("identifies QA check runs", () => {
+    expect(isQaChecksAgentRun({ action: "run_qa_checks" })).toBe(true);
+    expect(isQaChecksAgentRun({ action: "review_with_agent" })).toBe(false);
   });
 
-  it("rejects malformed QA reports in output summaries", () => {
-    expect(
-      parseQaReportFromOutputSummary({
-        findings: [{ ...sampleFinding, severity: 42 }],
-        summary: { total: 1, byCheckType: {}, bySeverity: { error: 1 } },
-      }),
-    ).toBeNull();
+  it("identifies review_with_agent runs", () => {
+    expect(isReviewWithAgentRun({ action: "review_with_agent" })).toBe(true);
+    expect(isReviewWithAgentRun({ action: "run_qa_checks" })).toBe(false);
   });
 
-  it("assigns distinct ids when the same check fires twice on one item", () => {
-    const first = buildFindingId(sampleFinding);
-    const second = buildFindingId({
-      ...sampleFinding,
-      message: "Different placeholder detail",
-    });
-
-    expect(first).not.toBe(second);
-
-    const withIds = attachFindingIds([
-      sampleFinding,
-      { ...sampleFinding, message: "Different placeholder detail" },
-    ]);
-
-    expect(new Set(withIds.map((finding) => finding.id)).size).toBe(2);
-  });
-
-  it("filters findings by severity and search query", () => {
-    const findings = attachFindingIds([
-      sampleFinding,
-      {
-        ...sampleFinding,
-        severity: "warning",
-        message: "Length expansion warning",
-        item: { ...sampleFinding.item, key: "other.key" },
-      },
-    ]);
-
-    const filtered = filterFindings(findings, {
-      severity: "error",
-      locale: "all",
-      checkType: "all",
-      search: "placeholder",
-    });
-
-    expect(filtered).toHaveLength(1);
-    expect(filtered[0]?.severity).toBe("error");
-  });
-
-  it("groups findings by locale", () => {
-    const findings = attachFindingIds([sampleFinding]);
-    const groups = groupFindings(findings, "locale");
-
-    expect(groups).toHaveLength(1);
-    expect(groups[0]?.label).toBe("fr");
-  });
-
-  it("builds project file links with locale and inferred source path", () => {
-    const href = buildProjectFilesHref({
-      organizationSlug: "acme",
-      projectId: "project-1",
-      key: "locales/en.json",
-      locale: "fr",
-    });
-
-    expect(href).toBe("/org/acme/projects/project-1/files?sourcePath=locales%2Fen.json&locale=fr");
+  it("treats both review and QA actions as findings-producing runs", () => {
+    expect(isProviderReviewFindingsAgentRun({ action: "review_with_agent" })).toBe(true);
+    expect(isProviderReviewFindingsAgentRun({ action: "run_qa_checks" })).toBe(true);
+    expect(isProviderReviewFindingsAgentRun({ action: "translate_with_agent" })).toBe(false);
   });
 });

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-qa-findings-model.test.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-qa-findings-model.test.ts
@@ -1,10 +1,107 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  attachFindingIds,
+  buildFindingId,
+  buildProjectFilesHref,
+  filterFindings,
+  groupFindings,
   isProviderReviewFindingsAgentRun,
   isQaChecksAgentRun,
   isReviewWithAgentRun,
+  parseQaReportFromOutputSummary,
 } from "./job-qa-findings-model";
+
+const sampleFinding = {
+  checkType: "placeholder_mismatch" as const,
+  severity: "error" as const,
+  message: "Placeholder mismatch",
+  item: {
+    externalStringId: "1001",
+    key: "locales/en.json",
+    locale: "fr",
+    field: "target" as const,
+  },
+};
+
+describe("job-qa-findings-model", () => {
+  it("parses QA reports from agent run output summaries", () => {
+    const report = parseQaReportFromOutputSummary({
+      findings: [sampleFinding],
+      summary: { total: 1, byCheckType: {}, bySeverity: { error: 1 } },
+    });
+
+    expect(report?.findings).toHaveLength(1);
+    expect(report?.summary.total).toBe(1);
+  });
+
+  it("rejects malformed QA reports in output summaries", () => {
+    expect(
+      parseQaReportFromOutputSummary({
+        findings: [{ ...sampleFinding, severity: 42 }],
+        summary: { total: 1, byCheckType: {}, bySeverity: { error: 1 } },
+      }),
+    ).toBeNull();
+  });
+
+  it("assigns distinct ids when the same check fires twice on one item", () => {
+    const first = buildFindingId(sampleFinding);
+    const second = buildFindingId({
+      ...sampleFinding,
+      message: "Different placeholder detail",
+    });
+
+    expect(first).not.toBe(second);
+
+    const withIds = attachFindingIds([
+      sampleFinding,
+      { ...sampleFinding, message: "Different placeholder detail" },
+    ]);
+
+    expect(new Set(withIds.map((finding) => finding.id)).size).toBe(2);
+  });
+
+  it("filters findings by severity and search query", () => {
+    const findings = attachFindingIds([
+      sampleFinding,
+      {
+        ...sampleFinding,
+        severity: "warning",
+        message: "Length expansion warning",
+        item: { ...sampleFinding.item, key: "other.key" },
+      },
+    ]);
+
+    const filtered = filterFindings(findings, {
+      severity: "error",
+      locale: "all",
+      checkType: "all",
+      search: "placeholder",
+    });
+
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0]?.severity).toBe("error");
+  });
+
+  it("groups findings by locale", () => {
+    const findings = attachFindingIds([sampleFinding]);
+    const groups = groupFindings(findings, "locale");
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.label).toBe("fr");
+  });
+
+  it("builds project file links with locale and inferred source path", () => {
+    const href = buildProjectFilesHref({
+      organizationSlug: "acme",
+      projectId: "project-1",
+      key: "locales/en.json",
+      locale: "fr",
+    });
+
+    expect(href).toBe("/org/acme/projects/project-1/files?sourcePath=locales%2Fen.json&locale=fr");
+  });
+});
 
 describe("provider review findings agent run helpers", () => {
   it("identifies QA check runs", () => {

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-qa-findings-model.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-qa-findings-model.ts
@@ -60,6 +60,18 @@ export function isQaChecksAgentRun(inputSnapshot: Record<string, unknown> | unde
   return inputSnapshot?.action === "run_qa_checks";
 }
 
+export function isReviewWithAgentRun(inputSnapshot: Record<string, unknown> | undefined) {
+  return inputSnapshot?.action === "review_with_agent";
+}
+
+/** Agent runs that produce inspectable QA/review findings (hl check + supplemental checks). */
+export function isProviderReviewFindingsAgentRun(
+  inputSnapshot: Record<string, unknown> | undefined,
+) {
+  const action = inputSnapshot?.action;
+  return action === "review_with_agent" || action === "run_qa_checks";
+}
+
 export function formatCheckTypeLabel(checkType: ProviderQaCheckType) {
   return checkType.replaceAll("_", " ");
 }

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-qa-findings-section.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-qa-findings-section.tsx
@@ -47,7 +47,7 @@ import {
   filterFindings,
   formatCheckTypeLabel,
   groupFindings,
-  isQaChecksAgentRun,
+  isProviderReviewFindingsAgentRun,
   parseQaReportFromOutputSummary,
   type QaFindingGroupBy,
   type QaFindingWithId,
@@ -167,6 +167,11 @@ function FindingRow({
                 {finding.item.field}
               </Badge>
             ) : null}
+            {typeof finding.confidence === "number" ? (
+              <Badge variant="outline" className="rounded-full text-foreground/62">
+                {Math.round(finding.confidence * 100)}% confidence
+              </Badge>
+            ) : null}
           </div>
           <p className="text-sm text-foreground/82">{finding.message}</p>
           {finding.suggestedFix ? (
@@ -237,7 +242,7 @@ export function JobQaFindingsSection({
 
     return (
       agentRuns.find(
-        (run) => isQaChecksAgentRun(run.inputSnapshot) && run.status === "succeeded",
+        (run) => isProviderReviewFindingsAgentRun(run.inputSnapshot) && run.status === "succeeded",
       ) ?? null
     );
   }, [agentRuns]);
@@ -250,7 +255,7 @@ export function JobQaFindingsSection({
     return (
       agentRuns.find(
         (run) =>
-          isQaChecksAgentRun(run.inputSnapshot) &&
+          isProviderReviewFindingsAgentRun(run.inputSnapshot) &&
           (run.status === "queued" || run.status === "running"),
       ) ?? null
     );
@@ -414,11 +419,11 @@ export function JobQaFindingsSection({
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
           <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
-            QA Findings
+            Review findings
           </TypographyH2>
           <p className="mt-1 text-sm text-foreground/48">
-            Review issues from the latest QA run, filter by locale or check type, and act on
-            selected findings.
+            Inspect issues from agent review or QA checks before writing back to the TMS. Filter by
+            locale or check type, then act on selected findings.
           </p>
         </div>
         <div className="flex flex-wrap gap-2">

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-qa-findings-section.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-qa-findings-section.tsx
@@ -494,7 +494,9 @@ export function JobQaFindingsSection({
 
       {activeQaRun ? (
         <p className="mt-4 rounded-md border border-bud-500/20 bg-bud-500/8 px-3 py-2 text-sm text-bud-300">
-          QA checks are running. Results will refresh when the agent run completes.
+          {activeQaRun.inputSnapshot?.action === "review_with_agent"
+            ? "Agent review is running. Results will refresh when the run completes."
+            : "QA checks are running. Results will refresh when the agent run completes."}
         </p>
       ) : null}
 
@@ -657,8 +659,9 @@ export function JobQaFindingsSection({
             </EmptyMedia>
             <EmptyTitle>No QA findings yet</EmptyTitle>
             <EmptyDescription>
-              Run QA checks on this TMS job to surface placeholder, ICU, glossary, and translation
-              issues here. When checks pass, this section will show a clear no-issues state.
+              Run QA checks or an agent review on this TMS job to surface placeholder, ICU,
+              glossary, and translation issues here. When checks pass, this section will show a
+              clear no-issues state.
             </EmptyDescription>
           </EmptyHeader>
           {runQaChecksAction?.visible && runQaChecksAction.enabled ? (

--- a/apps/hyperlocalise-web/src/lib/providers/provider-job-qa/map-hl-findings.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-job-qa/map-hl-findings.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  mapHlFindingToProviderFinding,
+  mapHlCheckReportToProviderFindings,
+} from "./map-hl-findings";
+
+const manifest = {
+  greeting: { externalStringId: "ext-1", key: "greeting" },
+};
+
+describe("mapHlFindingToProviderFinding", () => {
+  it("maps placeholder_mismatch with full confidence", () => {
+    const finding = mapHlFindingToProviderFinding(
+      {
+        type: "placeholder_mismatch",
+        severity: "error",
+        locale: "fr",
+        sourceFile: "content/en/strings.json",
+        targetFile: "content/fr/strings.json",
+        key: "greeting",
+        message: "Placeholder mismatch",
+      },
+      manifest,
+      "en",
+    );
+
+    expect(finding).toMatchObject({
+      checkType: "placeholder_mismatch",
+      severity: "error",
+      confidence: 1,
+      suggestedFix: expect.stringContaining("placeholders"),
+      item: {
+        externalStringId: "ext-1",
+        key: "greeting",
+        locale: "fr",
+        field: "target",
+      },
+    });
+  });
+
+  it("maps same_as_source to tone_style_issue with slightly lower confidence", () => {
+    const finding = mapHlFindingToProviderFinding(
+      {
+        type: "same_as_source",
+        severity: "warning",
+        locale: "fr",
+        sourceFile: "content/en/strings.json",
+        targetFile: "content/fr/strings.json",
+        key: "greeting",
+        message: "Target matches source",
+      },
+      manifest,
+      "en",
+    );
+
+    expect(finding).toMatchObject({
+      checkType: "tone_style_issue",
+      severity: "warning",
+      confidence: 0.95,
+    });
+  });
+
+  it("maps whitespace_only to whitespace_only_translation", () => {
+    const finding = mapHlFindingToProviderFinding(
+      {
+        type: "whitespace_only",
+        severity: "info",
+        locale: "fr",
+        sourceFile: "content/en/strings.json",
+        targetFile: "content/fr/strings.json",
+        key: "greeting",
+        message: "Whitespace only",
+      },
+      manifest,
+      "en",
+    );
+
+    expect(finding?.checkType).toBe("whitespace_only_translation");
+    expect(finding?.confidence).toBe(1);
+  });
+
+  it("returns null for unmapped hl check types", () => {
+    const finding = mapHlFindingToProviderFinding(
+      {
+        type: "orphaned_key",
+        severity: "error",
+        sourceFile: "content/en/strings.json",
+        key: "greeting",
+      },
+      manifest,
+      "en",
+    );
+
+    expect(finding).toBeNull();
+  });
+
+  it("returns null when manifest entry is missing", () => {
+    const finding = mapHlFindingToProviderFinding(
+      {
+        type: "not_localized",
+        severity: "error",
+        locale: "fr",
+        sourceFile: "content/en/strings.json",
+        targetFile: "content/fr/strings.json",
+        key: "missing-key",
+        message: "Missing",
+      },
+      manifest,
+      "en",
+    );
+
+    expect(finding).toBeNull();
+  });
+});
+
+describe("mapHlCheckReportToProviderFindings", () => {
+  it("normalizes all mapped findings in a report", () => {
+    const findings = mapHlCheckReportToProviderFindings({
+      report: {
+        checks: ["not_localized", "same_as_source"],
+        findings: [
+          {
+            type: "not_localized",
+            severity: "error",
+            locale: "fr",
+            sourceFile: "content/en/strings.json",
+            targetFile: "content/fr/strings.json",
+            key: "greeting",
+            message: "Missing translation",
+          },
+          {
+            type: "same_as_source",
+            severity: "warning",
+            locale: "fr",
+            sourceFile: "content/en/strings.json",
+            targetFile: "content/fr/strings.json",
+            key: "greeting",
+            message: "Same as source",
+          },
+        ],
+        summary: { total: 2 },
+      },
+      manifest,
+      sourceLocale: "en",
+    });
+
+    expect(findings).toHaveLength(2);
+    expect(findings[0]?.checkType).toBe("missing_translation");
+    expect(findings[0]?.confidence).toBe(1);
+    expect(findings[1]?.checkType).toBe("tone_style_issue");
+    expect(findings[1]?.confidence).toBe(0.95);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/provider-job-qa/map-hl-findings.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-job-qa/map-hl-findings.ts
@@ -1,9 +1,6 @@
 import type { HlCheckFinding, HlCheckReport } from "./hl-check-types";
 import type { HlCheckKeyManifest } from "./materialize-hl-check-workspace";
-import {
-  confidenceForHlCheckType,
-  normalizeProviderQaFinding,
-} from "./normalize-provider-findings";
+import { confidenceForHlCheckType } from "./normalize-provider-findings";
 import type { ProviderQaCheckType, ProviderQaFinding, ProviderQaSeverity } from "./types";
 
 const hlCheckTypeMap: Partial<Record<string, ProviderQaCheckType>> = {
@@ -68,22 +65,19 @@ export function mapHlFindingToProviderFinding(
   const field: "source" | "target" =
     finding.type === "markdown_ast_mismatch" && !finding.locale ? "source" : "target";
 
-  return normalizeProviderQaFinding(
-    {
-      checkType,
-      severity: mapSeverity(finding.severity),
-      message: finding.message?.trim() || `hl check reported ${finding.type}`,
-      suggestedFix: hlSuggestedFixes[checkType],
-      confidence: confidenceForHlCheckType(finding.type),
-      item: {
-        externalStringId: entry.externalStringId,
-        key: entry.key,
-        locale,
-        field,
-      },
+  return {
+    checkType,
+    severity: mapSeverity(finding.severity),
+    message: finding.message?.trim() || `hl check reported ${finding.type}`,
+    suggestedFix: hlSuggestedFixes[checkType],
+    confidence: confidenceForHlCheckType(finding.type),
+    item: {
+      externalStringId: entry.externalStringId,
+      key: entry.key,
+      locale,
+      field,
     },
-    { hlSourceType: finding.type },
-  );
+  };
 }
 
 export function mapHlCheckReportToProviderFindings(input: {

--- a/apps/hyperlocalise-web/src/lib/providers/provider-job-qa/map-hl-findings.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-job-qa/map-hl-findings.ts
@@ -1,5 +1,9 @@
 import type { HlCheckFinding, HlCheckReport } from "./hl-check-types";
 import type { HlCheckKeyManifest } from "./materialize-hl-check-workspace";
+import {
+  confidenceForHlCheckType,
+  normalizeProviderQaFinding,
+} from "./normalize-provider-findings";
 import type { ProviderQaCheckType, ProviderQaFinding, ProviderQaSeverity } from "./types";
 
 const hlCheckTypeMap: Partial<Record<string, ProviderQaCheckType>> = {
@@ -8,6 +12,8 @@ const hlCheckTypeMap: Partial<Record<string, ProviderQaCheckType>> = {
   icu_shape_mismatch: "icu_shape_mismatch",
   markdown_ast_mismatch: "markdown_link",
   html_tag_mismatch: "html_tag_mismatch",
+  same_as_source: "tone_style_issue",
+  whitespace_only: "whitespace_only_translation",
 };
 
 const hlSuggestedFixes: Partial<Record<ProviderQaCheckType, string>> = {
@@ -17,6 +23,10 @@ const hlSuggestedFixes: Partial<Record<ProviderQaCheckType, string>> = {
     "Mirror plural, select, and selectordinal blocks from the source in the target.",
   markdown_link: "Preserve markdown link structure and destinations from the source.",
   html_tag_mismatch: "Mirror HTML tags from the source in the target translation.",
+  tone_style_issue:
+    "Translate the string instead of copying the source text, unless the source should remain untranslated.",
+  whitespace_only_translation:
+    "Replace whitespace-only content with a meaningful translation or remove the entry.",
 };
 
 function mapSeverity(severity: string): ProviderQaSeverity {
@@ -58,18 +68,22 @@ export function mapHlFindingToProviderFinding(
   const field: "source" | "target" =
     finding.type === "markdown_ast_mismatch" && !finding.locale ? "source" : "target";
 
-  return {
-    checkType,
-    severity: mapSeverity(finding.severity),
-    message: finding.message?.trim() || `hl check reported ${finding.type}`,
-    suggestedFix: hlSuggestedFixes[checkType],
-    item: {
-      externalStringId: entry.externalStringId,
-      key: entry.key,
-      locale,
-      field,
+  return normalizeProviderQaFinding(
+    {
+      checkType,
+      severity: mapSeverity(finding.severity),
+      message: finding.message?.trim() || `hl check reported ${finding.type}`,
+      suggestedFix: hlSuggestedFixes[checkType],
+      confidence: confidenceForHlCheckType(finding.type),
+      item: {
+        externalStringId: entry.externalStringId,
+        key: entry.key,
+        locale,
+        field,
+      },
     },
-  };
+    { hlSourceType: finding.type },
+  );
 }
 
 export function mapHlCheckReportToProviderFindings(input: {

--- a/apps/hyperlocalise-web/src/lib/providers/provider-job-qa/normalize-provider-findings.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-job-qa/normalize-provider-findings.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  confidenceForHlCheckType,
+  confidenceForProviderCheckType,
+  normalizeProviderQaFinding,
+  normalizeProviderQaFindings,
+} from "./normalize-provider-findings";
+import type { ProviderQaFinding } from "./types";
+
+const baseFinding: ProviderQaFinding = {
+  checkType: "placeholder_mismatch",
+  severity: "error",
+  message: "Placeholder mismatch",
+  item: {
+    externalStringId: "1",
+    key: "hello",
+    locale: "fr",
+    field: "target",
+  },
+};
+
+describe("normalizeProviderQaFinding", () => {
+  it("preserves an existing confidence value", () => {
+    const normalized = normalizeProviderQaFinding({
+      ...baseFinding,
+      confidence: 0.42,
+    });
+
+    expect(normalized.confidence).toBe(0.42);
+  });
+
+  it("assigns hl check confidence when hl source type is provided", () => {
+    const normalized = normalizeProviderQaFinding(baseFinding, {
+      hlSourceType: "same_as_source",
+    });
+
+    expect(normalized.confidence).toBe(0.95);
+  });
+
+  it("assigns supplemental check confidence by check type", () => {
+    const normalized = normalizeProviderQaFinding({
+      ...baseFinding,
+      checkType: "length_expansion",
+      severity: "warning",
+    });
+
+    expect(normalized.confidence).toBe(0.75);
+  });
+});
+
+describe("normalizeProviderQaFindings", () => {
+  it("normalizes every finding in a list", () => {
+    const findings = normalizeProviderQaFindings([
+      baseFinding,
+      {
+        ...baseFinding,
+        checkType: "glossary_violation",
+        confidence: 0.88,
+      },
+    ]);
+
+    expect(findings[0]?.confidence).toBe(0.9);
+    expect(findings[1]?.confidence).toBe(0.88);
+  });
+});
+
+describe("confidence helpers", () => {
+  it("returns deterministic confidence for structural hl checks", () => {
+    expect(confidenceForHlCheckType("placeholder_mismatch")).toBe(1);
+    expect(confidenceForHlCheckType("icu_shape_mismatch")).toBe(1);
+  });
+
+  it("returns heuristic confidence for supplemental checks", () => {
+    expect(confidenceForProviderCheckType("stale_unchanged_target")).toBe(0.85);
+    expect(confidenceForProviderCheckType("length_expansion")).toBe(0.75);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/provider-job-qa/normalize-provider-findings.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-job-qa/normalize-provider-findings.ts
@@ -1,0 +1,48 @@
+import type { ProviderQaCheckType, ProviderQaFinding } from "./types";
+
+const hlCheckConfidence: Partial<Record<string, number>> = {
+  not_localized: 1,
+  placeholder_mismatch: 1,
+  icu_shape_mismatch: 1,
+  markdown_ast_mismatch: 1,
+  html_tag_mismatch: 1,
+  same_as_source: 0.95,
+  whitespace_only: 1,
+};
+
+const supplementalCheckConfidence: Partial<Record<ProviderQaCheckType, number>> = {
+  stale_unchanged_target: 0.85,
+  length_expansion: 0.75,
+  glossary_violation: 0.9,
+};
+
+export function confidenceForHlCheckType(hlType: string): number {
+  return hlCheckConfidence[hlType] ?? 1;
+}
+
+export function confidenceForProviderCheckType(checkType: ProviderQaCheckType): number {
+  return supplementalCheckConfidence[checkType] ?? 0.9;
+}
+
+export function normalizeProviderQaFinding(
+  finding: ProviderQaFinding,
+  options?: { hlSourceType?: string },
+): ProviderQaFinding {
+  if (typeof finding.confidence === "number" && Number.isFinite(finding.confidence)) {
+    return finding;
+  }
+
+  const confidence =
+    options?.hlSourceType !== undefined
+      ? confidenceForHlCheckType(options.hlSourceType)
+      : confidenceForProviderCheckType(finding.checkType);
+
+  return {
+    ...finding,
+    confidence,
+  };
+}
+
+export function normalizeProviderQaFindings(findings: ProviderQaFinding[]): ProviderQaFinding[] {
+  return findings.map((finding) => normalizeProviderQaFinding(finding));
+}

--- a/apps/hyperlocalise-web/src/lib/providers/provider-job-qa/provider-job-qa.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-job-qa/provider-job-qa.test.ts
@@ -263,6 +263,7 @@ describe("runProviderJobQa summary", () => {
     expect(report.findings[0]).toMatchObject({
       severity: expect.any(String),
       message: expect.any(String),
+      confidence: 1,
       item: expect.objectContaining({ key: "greeting" }),
     });
   });

--- a/apps/hyperlocalise-web/src/lib/providers/provider-job-qa/supplemental-checks.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-job-qa/supplemental-checks.ts
@@ -1,5 +1,9 @@
 import type { ExternalTmsTranslationUnit } from "@/lib/providers/external-tms-content-sync";
 
+import {
+  confidenceForProviderCheckType,
+  normalizeProviderQaFinding,
+} from "./normalize-provider-findings";
 import type {
   ProviderQaFinding,
   ProviderQaGlossaryTerm,
@@ -58,13 +62,14 @@ function checkStaleUnchangedTarget(
     return null;
   }
 
-  return {
+  return normalizeProviderQaFinding({
     checkType: "stale_unchanged_target",
     severity: "warning",
     message: "Target was not updated after the source string changed",
     suggestedFix: "Re-translate this string so the target reflects the updated source.",
+    confidence: confidenceForProviderCheckType("stale_unchanged_target"),
     item: itemRef(unit, { locale, field: "target" }),
-  };
+  });
 }
 
 function checkLengthExpansion(
@@ -90,13 +95,14 @@ function checkLengthExpansion(
 
   const severity = ratio >= errorRatio ? "error" : "warning";
 
-  return {
+  return normalizeProviderQaFinding({
     checkType: "length_expansion",
     severity,
     message: `Target is ${Math.round(ratio * 100)}% of source length (${targetLength} vs ${sourceLength} characters)`,
     suggestedFix: "Shorten the translation or confirm the extra length is intentional.",
+    confidence: confidenceForProviderCheckType("length_expansion"),
     item: itemRef(unit, { locale, field: "target" }),
-  };
+  });
 }
 
 function checkGlossaryViolations(
@@ -110,13 +116,16 @@ function checkGlossaryViolations(
 
   for (const term of glossaryTerms) {
     if (term.forbidden && findGlossaryMatches(targetText, term)) {
-      findings.push({
-        checkType: "glossary_violation",
-        severity: "error",
-        message: `Forbidden term "${term.sourceTerm}" appears in the target`,
-        suggestedFix: `Remove or replace "${term.sourceTerm}" in the target translation.`,
-        item: itemRef(unit, { locale, field: "target" }),
-      });
+      findings.push(
+        normalizeProviderQaFinding({
+          checkType: "glossary_violation",
+          severity: "error",
+          message: `Forbidden term "${term.sourceTerm}" appears in the target`,
+          suggestedFix: `Remove or replace "${term.sourceTerm}" in the target translation.`,
+          confidence: confidenceForProviderCheckType("glossary_violation"),
+          item: itemRef(unit, { locale, field: "target" }),
+        }),
+      );
       continue;
     }
 
@@ -134,13 +143,16 @@ function checkGlossaryViolations(
       : new RegExp(`\\b${escapeRegExp(expected)}\\b`, "i");
 
     if (!pattern.test(targetText)) {
-      findings.push({
-        checkType: "glossary_violation",
-        severity: "warning",
-        message: `Glossary term "${term.sourceTerm}" requires target rendering "${term.targetTerm}"`,
-        suggestedFix: `Use "${term.targetTerm}" when translating "${term.sourceTerm}".`,
-        item: itemRef(unit, { locale, field: "target" }),
-      });
+      findings.push(
+        normalizeProviderQaFinding({
+          checkType: "glossary_violation",
+          severity: "warning",
+          message: `Glossary term "${term.sourceTerm}" requires target rendering "${term.targetTerm}"`,
+          suggestedFix: `Use "${term.targetTerm}" when translating "${term.sourceTerm}".`,
+          confidence: confidenceForProviderCheckType("glossary_violation"),
+          item: itemRef(unit, { locale, field: "target" }),
+        }),
+      );
     }
   }
 

--- a/apps/hyperlocalise-web/src/lib/providers/provider-job-qa/types.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-job-qa/types.ts
@@ -7,6 +7,8 @@ export const providerQaCheckTypes = [
   "markdown_link",
   "html_tag_mismatch",
   "glossary_violation",
+  "tone_style_issue",
+  "whitespace_only_translation",
 ] as const;
 
 export type ProviderQaCheckType = (typeof providerQaCheckTypes)[number];
@@ -27,6 +29,7 @@ export type ProviderQaFinding = {
   severity: ProviderQaSeverity;
   message: string;
   suggestedFix?: string;
+  confidence?: number;
   item: ProviderQaItemReference;
 };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes HL-372 by making **Review with agent** findings visible and fully normalized in the provider job review flow.

The backend already pulled TMS content and ran `hl check` in a sandbox for both `review_with_agent` and `run_qa_checks`, but the job UI only surfaced findings from `run_qa_checks`. This change fixes that gap and strengthens the finding model.

## Changes

- **UI:** QA findings section now reads the latest succeeded agent run for either `review_with_agent` or `run_qa_checks`, so review findings are inspectable before TMS write-back.
- **Finding normalization:** Added `normalize-provider-findings` with confidence scoring; extended `hl check` mappings for `same_as_source` → `tone_style_issue` and `whitespace_only` → `whitespace_only_translation`.
- **Schema:** `ProviderQaFinding` and API schema now include optional `confidence` (0–1); findings show a confidence badge in the UI.
- **Tests:** Dedicated tests for hl finding mapping, normalization helpers, review agent-run detection, and API route coverage for `review_with_agent`.

## How it works

1. User starts **Review with agent** on a supported provider job.
2. Workflow pulls source/target via provider adapters, runs `hl check` in sandbox, merges supplemental checks (glossary, stale source, length).
3. Findings (severity, item refs, suggested fix, confidence) are stored on the agent run `outputSummary`.
4. Job detail **Review findings** section displays them for inspection; fix/comment actions remain separate.

## Testing

- `pnpm exec vp test src/lib/providers/provider-job-qa/`
- `pnpm exec vp test src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-qa-findings-model.test.ts`
- `pnpm exec vp check --fix`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-372](https://linear.app/hyperlocalise/issue/HL-372/implement-agent-review-for-provider-jobs)

<div><a href="https://cursor.com/agents/bc-409e3fa6-55b4-498c-b7f6-ed552adb2713"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-409e3fa6-55b4-498c-b7f6-ed552adb2713"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

