### PR TITLE
feat(web): agent run diff review screen (HL-373)

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/agent-run.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/agent-run.schema.ts
@@ -18,6 +18,64 @@ export const createJobAgentRunBodySchema = z.object({
   selectedFindings: z.array(providerQaFindingSchema).max(500).optional(),
 });
 
+export const agentRunProposalReviewStateSchema = z.enum(["pending", "accepted", "rejected"]);
+
+export const agentRunProposalWarningKindSchema = z.enum([
+  "glossary",
+  "placeholder",
+  "format",
+  "confidence",
+]);
+
+export const agentRunProposalWarningsSchema = z.object({
+  glossary: z.boolean().optional(),
+  placeholder: z.boolean().optional(),
+  format: z.boolean().optional(),
+  confidence: z.boolean().optional(),
+});
+
+export const agentRunProposalItemSchema = z.object({
+  itemId: z.string(),
+  externalStringId: z.string(),
+  key: z.string(),
+  locale: z.string(),
+  sourceText: z.string(),
+  from: z.string(),
+  to: z.string(),
+  reviewState: agentRunProposalReviewStateSchema,
+  changedFields: z.array(z.string()),
+  warnings: agentRunProposalWarningsSchema,
+});
+
+export const workspaceAgentRunParamsSchema = z.object({
+  jobId: z.string().trim().min(1).max(128),
+  agentRunId: z.string().uuid(),
+});
+
+export const updateAgentRunProposalReviewBodySchema = z
+  .object({
+    updates: z
+      .array(
+        z.object({
+          itemId: z.string().trim().min(1).max(256),
+          reviewState: z.enum(["accepted", "rejected"]),
+        }),
+      )
+      .max(500)
+      .optional(),
+    bulk: z
+      .object({
+        reviewState: z.enum(["accepted", "rejected"]),
+        itemIds: z.array(z.string().trim().min(1).max(256)).max(500).optional(),
+        scope: z.enum(["pending", "all", "filtered"]).optional(),
+        itemIdsFilter: z.array(z.string().trim().min(1).max(256)).max(500).optional(),
+      })
+      .optional(),
+  })
+  .refine((body) => (body.updates?.length ?? 0) > 0 || body.bulk, {
+    message: "Provide updates or bulk review instructions",
+  });
+
 export const agentRunRecordSchema = z.object({
   id: z.string().uuid(),
   organizationId: z.string().uuid(),
@@ -29,7 +87,7 @@ export const agentRunRecordSchema = z.object({
   actorUserId: z.string().uuid().nullable(),
   inputSnapshot: z.record(z.string(), z.unknown()),
   outputSummary: z.record(z.string(), z.unknown()),
-  changedItems: z.array(z.record(z.string(), z.unknown())),
+  changedItems: z.array(agentRunProposalItemSchema.or(z.record(z.string(), z.unknown()))),
   warnings: z.array(z.string()),
   hyperlocaliseJobId: z.string().nullable(),
   startedAt: z.string().nullable(),

--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
@@ -32,7 +32,18 @@ import {
   isProjectMutationAllowed,
   projectNotFoundResponse,
 } from "./project.shared";
-import { createAgentRun, failAgentRun, listAgentRuns } from "@/lib/providers/agent-runs";
+import {
+  applyAgentRunProposalReviewUpdates,
+  applyBulkAgentRunProposalReview,
+  parseAgentRunProposalItems,
+} from "@/lib/providers/agent-run-proposals";
+import {
+  createAgentRun,
+  failAgentRun,
+  getAgentRun,
+  listAgentRuns,
+  updateAgentRunChangedItems,
+} from "@/lib/providers/agent-runs";
 import {
   getJobProviderActionAvailability,
   getJobProviderActionDefinition,
@@ -43,7 +54,11 @@ import { mapProviderQaErrorToHttpStatus } from "@/lib/providers/map-provider-qa-
 import { runProviderJobQaForJob } from "@/lib/providers/provider-agent-qa";
 import { getProviderContentPuller } from "@/lib/providers/provider-content-pullers";
 
-import { createJobAgentRunBodySchema } from "./agent-run.schema";
+import {
+  createJobAgentRunBodySchema,
+  updateAgentRunProposalReviewBodySchema,
+  workspaceAgentRunParamsSchema,
+} from "./agent-run.schema";
 import { providerQaReportResponseSchema } from "./job-qa.schema";
 import {
   createJobBodySchema,
@@ -223,6 +238,31 @@ const validateCreateJobAgentRunBody = validator("json", (value, c) => {
       c,
       "invalid_agent_run_payload",
       "Invalid agent run payload",
+      parsed.error.issues,
+    );
+  }
+
+  return parsed.data;
+});
+
+const validateWorkspaceAgentRunParams = validator("param", (value, c) => {
+  const parsed = workspaceAgentRunParamsSchema.safeParse(value);
+
+  if (!parsed.success) {
+    return notFoundResponse(c, "agent_run_not_found", "Agent run not found");
+  }
+
+  return parsed.data;
+});
+
+const validateUpdateAgentRunProposalReviewBody = validator("json", (value, c) => {
+  const parsed = updateAgentRunProposalReviewBodySchema.safeParse(value);
+
+  if (!parsed.success) {
+    return validationErrorResponse(
+      c,
+      "invalid_agent_run_review_payload",
+      "Invalid agent run review payload",
       parsed.error.issues,
     );
   }
@@ -609,6 +649,111 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
 
       return c.json({ agentRuns: agentRuns.map(serializeAgentRun) }, 200);
     })
+    .patch(
+      "/:jobId/agent-runs/:agentRunId/review",
+      validateWorkspaceAgentRunParams,
+      validateUpdateAgentRunProposalReviewBody,
+      async (c) => {
+        if (!isProjectMutationAllowed(c.var.auth.membership.role)) {
+          return forbiddenResponse(c);
+        }
+
+        const params = c.req.valid("param");
+        const payload = c.req.valid("json");
+        const organizationId = c.var.auth.organization.localOrganizationId;
+
+        const [job] = await db
+          .select({
+            id: schema.jobs.id,
+            externalProviderKind: schema.externalJobDetails.providerKind,
+            externalJobId: schema.externalJobDetails.externalJobId,
+          })
+          .from(schema.jobs)
+          .leftJoin(schema.externalJobDetails, eq(schema.externalJobDetails.jobId, schema.jobs.id))
+          .where(
+            and(eq(schema.jobs.id, params.jobId), eq(schema.jobs.organizationId, organizationId)),
+          )
+          .limit(1);
+
+        if (!job) {
+          return notFoundResponse(c, "job_not_found", "Job not found");
+        }
+
+        if (!job.externalProviderKind || !job.externalJobId) {
+          return conflictResponse(
+            c,
+            "provider_job_required",
+            "Agent run review is only available for provider-backed jobs",
+          );
+        }
+
+        const agentRun = await getAgentRun({
+          runId: params.agentRunId,
+          organizationId,
+        });
+
+        if (!agentRun || agentRun.hyperlocaliseJobId !== job.id) {
+          return notFoundResponse(c, "agent_run_not_found", "Agent run not found");
+        }
+
+        if (agentRun.status !== "succeeded") {
+          return conflictResponse(
+            c,
+            "agent_run_not_reviewable",
+            "Only completed agent runs can be reviewed",
+          );
+        }
+
+        if (agentRun.kind !== "translate" && agentRun.kind !== "qa_fix") {
+          return conflictResponse(
+            c,
+            "agent_run_not_reviewable",
+            "This agent run does not contain reviewable proposals",
+          );
+        }
+
+        const existingItems = parseAgentRunProposalItems(agentRun.changedItems);
+        if (existingItems.length === 0) {
+          return conflictResponse(
+            c,
+            "agent_run_not_reviewable",
+            "This agent run does not contain proposals to review",
+          );
+        }
+
+        let nextChangedItems = agentRun.changedItems;
+
+        if (payload.updates && payload.updates.length > 0) {
+          nextChangedItems = applyAgentRunProposalReviewUpdates({
+            changedItems: agentRun.changedItems,
+            updates: payload.updates,
+          });
+        } else if (payload.bulk) {
+          const scope = payload.bulk.scope ?? "pending";
+          const itemIds =
+            scope === "filtered"
+              ? payload.bulk.itemIdsFilter
+              : scope === "all"
+                ? undefined
+                : payload.bulk.itemIds;
+
+          nextChangedItems = applyBulkAgentRunProposalReview({
+            changedItems: agentRun.changedItems,
+            reviewState: payload.bulk.reviewState,
+            itemIds,
+            filter: scope === "all" ? "all" : "pending",
+          });
+        }
+
+        const updatedRun = await updateAgentRunChangedItems({
+          runId: agentRun.id,
+          organizationId,
+          changedItems: nextChangedItems,
+        });
+
+        return c.json({ agentRun: serializeAgentRun(updatedRun) }, 200);
+      },
+    )
     .get("/:jobId/provider-actions", validateWorkspaceJobParams, async (c) => {
       const params = c.req.valid("param");
       const organizationId = c.var.auth.organization.localOrganizationId;

--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
@@ -712,8 +712,7 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
           );
         }
 
-        const existingItems = parseAgentRunProposalItems(agentRun.changedItems);
-        if (existingItems.length === 0) {
+        if (parseAgentRunProposalItems(agentRun.changedItems).length === 0) {
           return conflictResponse(
             c,
             "agent_run_not_reviewable",
@@ -721,34 +720,36 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
           );
         }
 
-        let nextChangedItems = agentRun.changedItems;
-
-        if (payload.updates && payload.updates.length > 0) {
-          nextChangedItems = applyAgentRunProposalReviewUpdates({
-            changedItems: agentRun.changedItems,
-            updates: payload.updates,
-          });
-        } else if (payload.bulk) {
-          const scope = payload.bulk.scope ?? "pending";
-          const itemIds =
-            scope === "filtered"
-              ? payload.bulk.itemIdsFilter
-              : scope === "all"
-                ? undefined
-                : payload.bulk.itemIds;
-
-          nextChangedItems = applyBulkAgentRunProposalReview({
-            changedItems: agentRun.changedItems,
-            reviewState: payload.bulk.reviewState,
-            itemIds,
-            filter: scope === "all" ? "all" : "pending",
-          });
-        }
-
         const updatedRun = await updateAgentRunChangedItems({
           runId: agentRun.id,
           organizationId,
-          changedItems: nextChangedItems,
+          changedItems: (currentRun) => {
+            if (payload.updates && payload.updates.length > 0) {
+              return applyAgentRunProposalReviewUpdates({
+                changedItems: currentRun.changedItems,
+                updates: payload.updates,
+              });
+            }
+
+            if (payload.bulk) {
+              const scope = payload.bulk.scope ?? "pending";
+              const itemIds =
+                scope === "filtered"
+                  ? (payload.bulk.itemIdsFilter ?? [])
+                  : scope === "all"
+                    ? undefined
+                    : payload.bulk.itemIds;
+
+              return applyBulkAgentRunProposalReview({
+                changedItems: currentRun.changedItems,
+                reviewState: payload.bulk.reviewState,
+                itemIds,
+                filter: scope === "all" ? "all" : "pending",
+              });
+            }
+
+            return currentRun.changedItems;
+          },
         });
 
         return c.json({ agentRun: serializeAgentRun(updatedRun) }, 200);

--- a/apps/hyperlocalise-web/src/api/routes/project/job.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.test.ts
@@ -17,6 +17,8 @@ import type {
 import { createProjectTestFixture } from "./project.fixture";
 import type { JobRecord, WorkspaceJobRecord } from "./job.schema";
 import type { ProjectResponse } from "./project.schema";
+import { completeAgentRun, createAgentRun } from "@/lib/providers/agent-runs";
+import { serializeAgentRunProposalItem } from "@/lib/providers/agent-run-proposals";
 import { upsertExternalJob } from "@/lib/providers/organization-external-tms-jobs";
 
 const { resolveApiAuthContextFromSessionMock, runProviderJobQaForJobMock } = vi.hoisted(() => ({
@@ -1601,5 +1603,121 @@ describe("jobRoutes", () => {
     await expect(response.json()).resolves.toMatchObject({
       error: "provider_job_required",
     });
+  });
+
+  it("persists accept and reject decisions for agent run proposals", async () => {
+    const identity = createWorkosIdentity();
+    const projectResponse = await createProjectViaApi(identity);
+    const project = ((await projectResponse.json()) as ProjectResponse).project;
+    const [organization] = await db
+      .select({ id: schema.organizations.id })
+      .from(schema.projects)
+      .innerJoin(schema.organizations, eq(schema.projects.organizationId, schema.organizations.id))
+      .where(eq(schema.projects.id, project.id))
+      .limit(1);
+
+    const externalJob = await upsertExternalJob({
+      organizationId: organization!.id,
+      projectId: project.id,
+      providerKind: "crowdin",
+      externalJobId: "crowdin-job-review-1",
+      externalStatus: "todo",
+      title: "Review copy",
+    });
+
+    const agentRun = await createAgentRun({
+      organizationId: organization!.id,
+      providerKind: "crowdin",
+      externalJobId: "crowdin-job-review-1",
+      kind: "translate",
+      hyperlocaliseJobId: externalJob.id,
+      inputSnapshot: { action: "translate_with_agent", projectId: project.id },
+    });
+
+    await completeAgentRun({
+      runId: agentRun.id,
+      organizationId: organization!.id,
+      outputSummary: { proposedCount: 2 },
+      changedItems: [
+        serializeAgentRunProposalItem({
+          itemId: "1:fr",
+          externalStringId: "1",
+          key: "hello",
+          locale: "fr",
+          sourceText: "Hello {name}",
+          from: "",
+          to: "Bonjour",
+          reviewState: "pending",
+          changedFields: ["target"],
+          warnings: { placeholder: true },
+        }),
+        serializeAgentRunProposalItem({
+          itemId: "2:fr",
+          externalStringId: "2",
+          key: "world",
+          locale: "fr",
+          sourceText: "World",
+          from: "Monde",
+          to: "Le monde",
+          reviewState: "pending",
+          changedFields: ["target"],
+          warnings: {},
+        }),
+      ],
+    });
+
+    const acceptResponse = await client.api.orgs[":organizationSlug"].jobs[":jobId"]["agent-runs"][
+      ":agentRunId"
+    ].review.$patch(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          jobId: externalJob.id,
+          agentRunId: agentRun.id,
+        },
+        json: {
+          updates: [{ itemId: "1:fr", reviewState: "accepted" }],
+        },
+      },
+      { headers: await authHeadersFor(identity) },
+    );
+
+    expect(acceptResponse.status).toBe(200);
+    const acceptBody = (await acceptResponse.json()) as {
+      agentRun: { changedItems: Array<{ itemId: string; reviewState: string }> };
+    };
+    expect(acceptBody.agentRun.changedItems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ itemId: "1:fr", reviewState: "accepted" }),
+        expect.objectContaining({ itemId: "2:fr", reviewState: "pending" }),
+      ]),
+    );
+
+    const rejectResponse = await client.api.orgs[":organizationSlug"].jobs[":jobId"]["agent-runs"][
+      ":agentRunId"
+    ].review.$patch(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          jobId: externalJob.id,
+          agentRunId: agentRun.id,
+        },
+        json: {
+          bulk: { reviewState: "rejected", scope: "pending" },
+        },
+      },
+      { headers: await authHeadersFor(identity) },
+    );
+
+    expect(rejectResponse.status).toBe(200);
+    const rejectBody = (await rejectResponse.json()) as {
+      agentRun: { changedItems: Array<{ itemId: string; reviewState: string }> };
+    };
+    expect(rejectBody.agentRun.changedItems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ itemId: "1:fr", reviewState: "accepted" }),
+        expect.objectContaining({ itemId: "2:fr", reviewState: "rejected" }),
+      ]),
+    );
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/project/job.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.test.ts
@@ -17,7 +17,7 @@ import type {
 import { createProjectTestFixture } from "./project.fixture";
 import type { JobRecord, WorkspaceJobRecord } from "./job.schema";
 import type { ProjectResponse } from "./project.schema";
-import { completeAgentRun, createAgentRun } from "@/lib/providers/agent-runs";
+import { completeAgentRun, createAgentRun, startAgentRun } from "@/lib/providers/agent-runs";
 import { serializeAgentRunProposalItem } from "@/lib/providers/agent-run-proposals";
 import { upsertExternalJob } from "@/lib/providers/organization-external-tms-jobs";
 
@@ -1632,6 +1632,11 @@ describe("jobRoutes", () => {
       kind: "translate",
       hyperlocaliseJobId: externalJob.id,
       inputSnapshot: { action: "translate_with_agent", projectId: project.id },
+    });
+
+    await startAgentRun({
+      runId: agentRun.id,
+      organizationId: organization!.id,
     });
 
     await completeAgentRun({

--- a/apps/hyperlocalise-web/src/api/routes/project/job.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.test.ts
@@ -1698,6 +1698,33 @@ describe("jobRoutes", () => {
       ]),
     );
 
+    const emptyFilteredResponse = await client.api.orgs[":organizationSlug"].jobs[":jobId"][
+      "agent-runs"
+    ][":agentRunId"].review.$patch(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          jobId: externalJob.id,
+          agentRunId: agentRun.id,
+        },
+        json: {
+          bulk: { reviewState: "accepted", scope: "filtered" },
+        },
+      },
+      { headers: await authHeadersFor(identity) },
+    );
+
+    expect(emptyFilteredResponse.status).toBe(200);
+    const emptyFilteredBody = (await emptyFilteredResponse.json()) as {
+      agentRun: { changedItems: Array<{ itemId: string; reviewState: string }> };
+    };
+    expect(emptyFilteredBody.agentRun.changedItems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ itemId: "1:fr", reviewState: "accepted" }),
+        expect.objectContaining({ itemId: "2:fr", reviewState: "pending" }),
+      ]),
+    );
+
     const rejectResponse = await client.api.orgs[":organizationSlug"].jobs[":jobId"]["agent-runs"][
       ":agentRunId"
     ].review.$patch(

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-agent-run-diff-review-model.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-agent-run-diff-review-model.ts
@@ -1,0 +1,106 @@
+import type {
+  AgentRunProposalItem,
+  AgentRunProposalReviewState,
+  AgentRunProposalWarningKind,
+} from "@/lib/providers/agent-run-proposals";
+import {
+  agentRunHasReviewableProposals,
+  countAgentRunProposalReviewStates,
+  parseAgentRunProposalItems,
+} from "@/lib/providers/agent-run-proposals";
+
+import type { AgentRunRecord } from "./job-provider-detail-section";
+
+export type ProposalReviewFilter = "all" | AgentRunProposalReviewState | "has_warnings";
+
+export const proposalReviewPageSize = 25;
+
+export const warningLabels: Record<AgentRunProposalWarningKind, string> = {
+  glossary: "Glossary",
+  placeholder: "Placeholder",
+  format: "Format",
+  confidence: "Confidence",
+};
+
+export function listReviewableAgentRuns(agentRuns: AgentRunRecord[] | undefined) {
+  return (agentRuns ?? []).filter((run) =>
+    agentRunHasReviewableProposals({
+      kind: run.kind,
+      status: run.status,
+      changedItems: run.changedItems,
+    }),
+  );
+}
+
+export function parseProposalItemsForRun(run: AgentRunRecord) {
+  return parseAgentRunProposalItems(run.changedItems);
+}
+
+export function summarizeProposalReview(items: AgentRunProposalItem[]) {
+  return countAgentRunProposalReviewStates(items);
+}
+
+export function filterProposalItems(
+  items: AgentRunProposalItem[],
+  input: {
+    search: string;
+    locale: string;
+    reviewFilter: ProposalReviewFilter;
+    warningFilter: AgentRunProposalWarningKind | "all";
+  },
+) {
+  const search = input.search.trim().toLowerCase();
+
+  return items.filter((item) => {
+    if (input.locale !== "all" && item.locale !== input.locale) {
+      return false;
+    }
+
+    if (input.reviewFilter === "has_warnings") {
+      if (!Object.values(item.warnings).some(Boolean)) {
+        return false;
+      }
+    } else if (input.reviewFilter !== "all" && item.reviewState !== input.reviewFilter) {
+      return false;
+    }
+
+    if (input.warningFilter !== "all" && !item.warnings[input.warningFilter]) {
+      return false;
+    }
+
+    if (!search) {
+      return true;
+    }
+
+    return (
+      item.key.toLowerCase().includes(search) ||
+      item.locale.toLowerCase().includes(search) ||
+      item.sourceText.toLowerCase().includes(search) ||
+      item.from.toLowerCase().includes(search) ||
+      item.to.toLowerCase().includes(search)
+    );
+  });
+}
+
+export function paginateProposalItems<T>(items: T[], page: number, pageSize: number) {
+  const totalPages = Math.max(1, Math.ceil(items.length / pageSize));
+  const currentPage = Math.min(Math.max(page, 1), totalPages);
+  const start = (currentPage - 1) * pageSize;
+
+  return {
+    currentPage,
+    totalPages,
+    pageItems: items.slice(start, start + pageSize),
+    totalCount: items.length,
+  };
+}
+
+export function collectProposalLocales(items: AgentRunProposalItem[]) {
+  return [...new Set(items.map((item) => item.locale))].sort();
+}
+
+export function activeWarningKinds(item: AgentRunProposalItem) {
+  return (Object.keys(item.warnings) as AgentRunProposalWarningKind[]).filter(
+    (kind) => item.warnings[kind],
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-agent-run-diff-review-section.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-agent-run-diff-review-section.tsx
@@ -1,0 +1,532 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  Cancel01Icon,
+  CheckmarkCircle02Icon,
+  Search01Icon,
+  Tick02Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { TypographyH2 } from "@/components/ui/typography";
+import { apiClient } from "@/lib/api-client-instance";
+import type {
+  AgentRunProposalItem,
+  AgentRunProposalReviewState,
+  AgentRunProposalWarningKind,
+} from "@/lib/providers/agent-run-proposals";
+import { cn } from "@/lib/utils";
+
+import { toneClass, type Tone } from "../../../_components/workspace-resource-shared";
+
+import type { AgentRunRecord } from "./job-provider-detail-section";
+import {
+  activeWarningKinds,
+  collectProposalLocales,
+  filterProposalItems,
+  listReviewableAgentRuns,
+  paginateProposalItems,
+  parseProposalItemsForRun,
+  proposalReviewPageSize,
+  summarizeProposalReview,
+  warningLabels,
+  type ProposalReviewFilter,
+} from "./job-agent-run-diff-review-model";
+
+function reviewStateTone(state: AgentRunProposalReviewState): Tone {
+  switch (state) {
+    case "accepted":
+      return "safe";
+    case "rejected":
+      return "risk";
+    default:
+      return "watch";
+  }
+}
+
+function parseActionError(response: Response, fallback: string) {
+  return response
+    .json()
+    .then((body: { error?: string; message?: string }) => body.message ?? body.error)
+    .catch(() => null)
+    .then((error) => (error ? `${fallback}: ${error}` : `${fallback} (${response.status})`));
+}
+
+function WarningBadges({ item }: { item: AgentRunProposalItem }) {
+  const kinds = activeWarningKinds(item);
+  if (kinds.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {kinds.map((kind) => (
+        <Badge key={kind} variant="outline" className={cn("rounded-full", toneClass("watch"))}>
+          {warningLabels[kind]}
+        </Badge>
+      ))}
+    </div>
+  );
+}
+
+function ProposalDiffRow({
+  item,
+  selected,
+  onToggle,
+  onAccept,
+  onReject,
+  disabled,
+}: {
+  item: AgentRunProposalItem;
+  selected: boolean;
+  onToggle: (itemId: string, checked: boolean) => void;
+  onAccept: (itemId: string) => void;
+  onReject: (itemId: string) => void;
+  disabled: boolean;
+}) {
+  return (
+    <li className="rounded-md border border-foreground/8 bg-foreground/3.5 px-3 py-3">
+      <div className="flex flex-wrap items-start gap-3">
+        <label className="mt-0.5 flex cursor-pointer items-center gap-2">
+          <input
+            type="checkbox"
+            className="size-4 rounded border-foreground/20 accent-foreground"
+            checked={selected}
+            disabled={disabled}
+            onChange={(event) => onToggle(item.itemId, event.currentTarget.checked)}
+          />
+        </label>
+        <div className="min-w-0 flex-1 space-y-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="font-mono text-sm font-medium text-foreground/86">{item.key}</p>
+            <Badge variant="outline" className="rounded-full uppercase">
+              {item.locale}
+            </Badge>
+            <Badge
+              variant="outline"
+              className={cn(
+                "rounded-full capitalize",
+                toneClass(reviewStateTone(item.reviewState)),
+              )}
+            >
+              {item.reviewState}
+            </Badge>
+            {item.changedFields.length > 0 ? (
+              <Badge variant="outline" className="rounded-full">
+                Changed: {item.changedFields.join(", ")}
+              </Badge>
+            ) : null}
+          </div>
+          <WarningBadges item={item} />
+          <div className="grid gap-3 lg:grid-cols-3">
+            <div className="space-y-1 rounded-md border border-foreground/8 bg-foreground/2 p-3">
+              <p className="text-xs font-medium uppercase tracking-wide text-foreground/42">
+                Source
+              </p>
+              <p className="text-sm whitespace-pre-wrap text-foreground/78">{item.sourceText}</p>
+            </div>
+            <div className="space-y-1 rounded-md border border-foreground/8 bg-foreground/2 p-3">
+              <p className="text-xs font-medium uppercase tracking-wide text-foreground/42">
+                Current provider target
+              </p>
+              <p className="text-sm whitespace-pre-wrap text-foreground/78">{item.from || "—"}</p>
+            </div>
+            <div className="space-y-1 rounded-md border border-flame-100/20 bg-flame-100/5 p-3">
+              <p className="text-xs font-medium uppercase tracking-wide text-foreground/42">
+                Agent proposal
+              </p>
+              <p className="text-sm whitespace-pre-wrap text-foreground/86">{item.to}</p>
+            </div>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={disabled || item.reviewState === "accepted"}
+              onClick={() => onAccept(item.itemId)}
+            >
+              <HugeiconsIcon icon={Tick02Icon} strokeWidth={1.8} />
+              Accept
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={disabled || item.reviewState === "rejected"}
+              onClick={() => onReject(item.itemId)}
+            >
+              <HugeiconsIcon icon={Cancel01Icon} strokeWidth={1.8} />
+              Reject
+            </Button>
+          </div>
+        </div>
+      </div>
+    </li>
+  );
+}
+
+export function JobAgentRunDiffReviewSection({
+  jobId,
+  organizationSlug,
+  agentRuns,
+  agentRunsLoading,
+}: {
+  jobId: string;
+  organizationSlug: string;
+  agentRuns: AgentRunRecord[] | undefined;
+  agentRunsLoading: boolean;
+}) {
+  const queryClient = useQueryClient();
+  const agentRunsQueryKey = ["job-agent-runs", organizationSlug, jobId] as const;
+
+  const reviewableRuns = useMemo(() => listReviewableAgentRuns(agentRuns), [agentRuns]);
+  const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const [localeFilter, setLocaleFilter] = useState("all");
+  const [reviewFilter, setReviewFilter] = useState<ProposalReviewFilter>("pending");
+  const [warningFilter, setWarningFilter] = useState<AgentRunProposalWarningKind | "all">("all");
+  const [page, setPage] = useState(1);
+  const [selectedItemIds, setSelectedItemIds] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!selectedRunId && reviewableRuns.length > 0) {
+      setSelectedRunId(reviewableRuns[0]!.id);
+    }
+  }, [reviewableRuns, selectedRunId]);
+
+  useEffect(() => {
+    setPage(1);
+    setSelectedItemIds(new Set());
+  }, [selectedRunId, search, localeFilter, reviewFilter, warningFilter]);
+
+  const selectedRun =
+    reviewableRuns.find((run) => run.id === selectedRunId) ?? reviewableRuns[0] ?? null;
+  const allItems = useMemo(
+    () => (selectedRun ? parseProposalItemsForRun(selectedRun) : []),
+    [selectedRun],
+  );
+  const filteredItems = useMemo(
+    () =>
+      filterProposalItems(allItems, {
+        search,
+        locale: localeFilter,
+        reviewFilter,
+        warningFilter,
+      }),
+    [allItems, localeFilter, reviewFilter, search, warningFilter],
+  );
+  const pagination = useMemo(
+    () => paginateProposalItems(filteredItems, page, proposalReviewPageSize),
+    [filteredItems, page],
+  );
+  const reviewSummary = useMemo(() => summarizeProposalReview(allItems), [allItems]);
+  const locales = useMemo(() => collectProposalLocales(allItems), [allItems]);
+
+  const reviewMutation = useMutation({
+    mutationFn: async (body: {
+      updates?: Array<{ itemId: string; reviewState: "accepted" | "rejected" }>;
+      bulk?: {
+        reviewState: "accepted" | "rejected";
+        itemIds?: string[];
+        scope?: "pending" | "all" | "filtered";
+        itemIdsFilter?: string[];
+      };
+    }) => {
+      if (!selectedRun) {
+        throw new Error("No agent run selected");
+      }
+
+      const response = await apiClient.api.orgs[":organizationSlug"].jobs[":jobId"]["agent-runs"][
+        ":agentRunId"
+      ].review.$patch({
+        param: {
+          organizationSlug,
+          jobId,
+          agentRunId: selectedRun.id,
+        },
+        json: body,
+      });
+
+      if (!response.ok) {
+        throw new Error(await parseActionError(response, "Failed to update proposal review"));
+      }
+
+      return (await response.json()) as { agentRun: AgentRunRecord };
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: agentRunsQueryKey });
+      setSelectedItemIds(new Set());
+      toast.success("Proposal review saved");
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Failed to update proposal review");
+    },
+  });
+
+  const toggleItem = (itemId: string, checked: boolean) => {
+    setSelectedItemIds((current) => {
+      const next = new Set(current);
+      if (checked) {
+        next.add(itemId);
+      } else {
+        next.delete(itemId);
+      }
+      return next;
+    });
+  };
+
+  const togglePageSelection = (checked: boolean) => {
+    setSelectedItemIds((current) => {
+      const next = new Set(current);
+      for (const item of pagination.pageItems) {
+        if (checked) {
+          next.add(item.itemId);
+        } else {
+          next.delete(item.itemId);
+        }
+      }
+      return next;
+    });
+  };
+
+  const applyUpdates = (
+    updates: Array<{ itemId: string; reviewState: "accepted" | "rejected" }>,
+  ) => {
+    if (updates.length === 0) {
+      return;
+    }
+    reviewMutation.mutate({ updates });
+  };
+
+  const applyBulk = (
+    reviewState: "accepted" | "rejected",
+    scope: "pending" | "all" | "filtered",
+  ) => {
+    reviewMutation.mutate({
+      bulk: {
+        reviewState,
+        scope,
+        ...(scope === "filtered" ? { itemIdsFilter: [...selectedItemIds] } : {}),
+      },
+    });
+  };
+
+  if (agentRunsLoading) {
+    return null;
+  }
+
+  if (reviewableRuns.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
+          Agent Proposal Review
+        </TypographyH2>
+        <div className="flex flex-wrap gap-2">
+          <Badge variant="outline" className={cn("rounded-full", toneClass("watch"))}>
+            Pending: {reviewSummary.pending}
+          </Badge>
+          <Badge variant="outline" className={cn("rounded-full", toneClass("safe"))}>
+            Accepted: {reviewSummary.accepted}
+          </Badge>
+          <Badge variant="outline" className={cn("rounded-full", toneClass("risk"))}>
+            Rejected: {reviewSummary.rejected}
+          </Badge>
+        </div>
+      </div>
+
+      <p className="mt-2 text-sm text-foreground/52">
+        Inspect agent-proposed translations before pushing approved changes back to the provider.
+      </p>
+
+      {reviewableRuns.length > 1 ? (
+        <div className="mt-4 max-w-sm">
+          <Select value={selectedRun?.id ?? ""} onValueChange={(value) => setSelectedRunId(value)}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select agent run" />
+            </SelectTrigger>
+            <SelectContent>
+              {reviewableRuns.map((run) => (
+                <SelectItem key={run.id} value={run.id}>
+                  {run.kind.replaceAll("_", " ")} · {new Date(run.createdAt).toLocaleString()}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      ) : null}
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        <div className="relative min-w-[12rem] flex-1">
+          <HugeiconsIcon
+            icon={Search01Icon}
+            strokeWidth={1.8}
+            className="pointer-events-none absolute top-2.5 left-2.5 size-4 text-foreground/42"
+          />
+          <Input
+            value={search}
+            onChange={(event) => setSearch(event.currentTarget.value)}
+            placeholder="Search key, locale, or text"
+            className="pl-9"
+          />
+        </div>
+        <Select value={localeFilter} onValueChange={(value) => setLocaleFilter(value ?? "all")}>
+          <SelectTrigger className="w-[8rem]">
+            <SelectValue placeholder="Locale" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All locales</SelectItem>
+            {locales.map((locale) => (
+              <SelectItem key={locale} value={locale}>
+                {locale}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select
+          value={reviewFilter}
+          onValueChange={(value) => value && setReviewFilter(value as ProposalReviewFilter)}
+        >
+          <SelectTrigger className="w-[10rem]">
+            <SelectValue placeholder="Review state" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All states</SelectItem>
+            <SelectItem value="pending">Pending</SelectItem>
+            <SelectItem value="accepted">Accepted</SelectItem>
+            <SelectItem value="rejected">Rejected</SelectItem>
+            <SelectItem value="has_warnings">Has warnings</SelectItem>
+          </SelectContent>
+        </Select>
+        <Select
+          value={warningFilter}
+          onValueChange={(value) =>
+            value && setWarningFilter(value as AgentRunProposalWarningKind | "all")
+          }
+        >
+          <SelectTrigger className="w-[11rem]">
+            <SelectValue placeholder="Warning type" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All warnings</SelectItem>
+            <SelectItem value="glossary">Glossary</SelectItem>
+            <SelectItem value="placeholder">Placeholder</SelectItem>
+            <SelectItem value="format">Format</SelectItem>
+            <SelectItem value="confidence">Confidence</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        <Button
+          size="sm"
+          disabled={reviewMutation.isPending}
+          onClick={() => applyBulk("accepted", "pending")}
+        >
+          <HugeiconsIcon icon={CheckmarkCircle02Icon} strokeWidth={1.8} />
+          Accept all pending
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={reviewMutation.isPending}
+          onClick={() => applyBulk("rejected", "pending")}
+        >
+          Reject all pending
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={reviewMutation.isPending || selectedItemIds.size === 0}
+          onClick={() => applyBulk("accepted", "filtered")}
+        >
+          Accept selected
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={reviewMutation.isPending || selectedItemIds.size === 0}
+          onClick={() => applyBulk("rejected", "filtered")}
+        >
+          Reject selected
+        </Button>
+      </div>
+
+      <div className="mt-4 flex flex-wrap items-center justify-between gap-2 text-sm text-foreground/52">
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            className="size-4 rounded border-foreground/20 accent-foreground"
+            checked={
+              pagination.pageItems.length > 0 &&
+              pagination.pageItems.every((item) => selectedItemIds.has(item.itemId))
+            }
+            onChange={(event) => togglePageSelection(event.currentTarget.checked)}
+          />
+          Select page
+        </label>
+        <p>
+          Showing {pagination.pageItems.length} of {pagination.totalCount} filtered ·{" "}
+          {allItems.length} total
+        </p>
+      </div>
+
+      {pagination.pageItems.length > 0 ? (
+        <ul className="mt-3 space-y-2">
+          {pagination.pageItems.map((item) => (
+            <ProposalDiffRow
+              key={item.itemId}
+              item={item}
+              selected={selectedItemIds.has(item.itemId)}
+              disabled={reviewMutation.isPending}
+              onToggle={toggleItem}
+              onAccept={(itemId) => applyUpdates([{ itemId, reviewState: "accepted" }])}
+              onReject={(itemId) => applyUpdates([{ itemId, reviewState: "rejected" }])}
+            />
+          ))}
+        </ul>
+      ) : (
+        <p className="mt-4 text-sm text-foreground/48">No proposals match the current filters.</p>
+      )}
+
+      {pagination.totalPages > 1 ? (
+        <div className="mt-4 flex flex-wrap items-center justify-between gap-2">
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={pagination.currentPage <= 1}
+            onClick={() => setPage((current) => Math.max(1, current - 1))}
+          >
+            Previous
+          </Button>
+          <p className="text-sm text-foreground/52">
+            Page {pagination.currentPage} of {pagination.totalPages}
+          </p>
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={pagination.currentPage >= pagination.totalPages}
+            onClick={() => setPage((current) => current + 1)}
+          >
+            Next
+          </Button>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-provider-detail-section.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-provider-detail-section.tsx
@@ -12,11 +12,13 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { TypographyH2 } from "@/components/ui/typography";
 import { apiClient } from "@/lib/api-client-instance";
+import { agentRunHasReviewableProposals } from "@/lib/providers/agent-run-proposals";
 import type { JobProviderActionId } from "@/lib/providers/job-provider-actions";
 import { cn } from "@/lib/utils";
 
 import { toneClass } from "../../../_components/workspace-resource-shared";
 
+import { JobAgentRunDiffReviewSection } from "./job-agent-run-diff-review-section";
 import { JobQaFindingsSection } from "./job-qa-findings-section";
 
 export type ProviderSourceFile = {
@@ -60,6 +62,8 @@ export type AgentRunRecord = {
   status: "queued" | "running" | "succeeded" | "failed" | "cancelled";
   inputSnapshot: Record<string, unknown>;
   outputSummary: Record<string, unknown>;
+  changedItems: Record<string, unknown>[];
+  warnings: string[];
   createdAt: string;
   completedAt: string | null;
 };
@@ -315,6 +319,13 @@ export function JobProviderDetailSection({
         }}
       />
 
+      <JobAgentRunDiffReviewSection
+        jobId={jobId}
+        organizationSlug={organizationSlug}
+        agentRuns={agentRunsQuery.data}
+        agentRunsLoading={agentRunsQuery.isLoading}
+      />
+
       <section className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
         <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
           Agent Activity
@@ -331,25 +342,47 @@ export function JobProviderDetailSection({
         ) : null}
         {agentRunsQuery.data && agentRunsQuery.data.length > 0 ? (
           <ul className="mt-4 space-y-2">
-            {agentRunsQuery.data.map((run) => (
-              <li
-                key={run.id}
-                className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-foreground/8 bg-foreground/3.5 px-3 py-2"
-              >
-                <div className="min-w-0">
-                  <p className="text-sm font-medium capitalize text-foreground/82">
-                    {run.kind.replaceAll("_", " ")}
-                  </p>
-                  <p className="text-xs text-foreground/48">Started {formatDate(run.createdAt)}</p>
-                </div>
-                <Badge
-                  variant="outline"
-                  className={cn("rounded-full capitalize", toneClass(agentRunTone(run.status)))}
+            {agentRunsQuery.data.map((run) => {
+              const hasProposals = agentRunHasReviewableProposals({
+                kind: run.kind,
+                status: run.status,
+                changedItems: run.changedItems,
+              });
+              const proposedCount =
+                typeof run.outputSummary.proposedCount === "number"
+                  ? run.outputSummary.proposedCount
+                  : run.changedItems.length;
+
+              return (
+                <li
+                  key={run.id}
+                  className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-foreground/8 bg-foreground/3.5 px-3 py-2"
                 >
-                  {run.status}
-                </Badge>
-              </li>
-            ))}
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium capitalize text-foreground/82">
+                      {run.kind.replaceAll("_", " ")}
+                    </p>
+                    <p className="text-xs text-foreground/48">
+                      Started {formatDate(run.createdAt)}
+                      {hasProposals ? ` · ${proposedCount} proposals` : null}
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    {hasProposals ? (
+                      <Badge variant="outline" className="rounded-full">
+                        Review proposals
+                      </Badge>
+                    ) : null}
+                    <Badge
+                      variant="outline"
+                      className={cn("rounded-full capitalize", toneClass(agentRunTone(run.status)))}
+                    >
+                      {run.status}
+                    </Badge>
+                  </div>
+                </li>
+              );
+            })}
           </ul>
         ) : null}
         {agentRunsQuery.data && agentRunsQuery.data.length === 0 ? (

--- a/apps/hyperlocalise-web/src/lib/glossary/validate-glossary-terms-in-translation.test.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/validate-glossary-terms-in-translation.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { validateGlossaryTermsInTranslation } from "./file-translation-job";
+import {
+  validateGlossaryForTranslationUnits,
+  validateGlossaryTermsInTranslation,
+} from "./validate-glossary-terms-in-translation";
 
 describe("validateGlossaryTermsInTranslation", () => {
   it("includes approved preferred terms only when source term appears", () => {
@@ -91,5 +94,52 @@ describe("validateGlossaryTermsInTranslation", () => {
         reason: "missing_preferred_term",
       },
     ]);
+  });
+});
+
+describe("validateGlossaryForTranslationUnits", () => {
+  it("validates each translation unit with locale-scoped glossary terms", () => {
+    const failuresByUnit = validateGlossaryForTranslationUnits(
+      [
+        {
+          externalStringId: "1",
+          key: "hello",
+          sourceText: "Hello {name}",
+          locale: "fr",
+          translatedText: "Bonjour",
+        },
+        {
+          externalStringId: "2",
+          key: "save",
+          sourceText: "Save",
+          locale: "de",
+          translatedText: "Speichern",
+        },
+      ],
+      [
+        {
+          sourceTerm: "Hello",
+          targetTerm: "Salut",
+          targetLocale: "fr",
+          forbidden: false,
+        },
+        {
+          sourceTerm: "Save",
+          targetTerm: "Speichern",
+          targetLocale: "de",
+          forbidden: false,
+        },
+      ],
+    );
+
+    expect(failuresByUnit.get("1:fr")).toEqual([
+      {
+        sourceTerm: "Hello",
+        targetTerm: "Salut",
+        forbidden: false,
+        reason: "missing_preferred_term",
+      },
+    ]);
+    expect(failuresByUnit.has("2:de")).toBe(false);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/glossary/validate-glossary-terms-in-translation.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/validate-glossary-terms-in-translation.ts
@@ -1,0 +1,119 @@
+export type GlossaryTermConstraint = {
+  sourceTerm: string;
+  targetTerm: string;
+  targetLocale: string;
+  forbidden: boolean | null;
+  caseSensitive?: boolean | null;
+};
+
+export type GlossaryValidationFailure = {
+  sourceTerm: string;
+  targetTerm: string;
+  forbidden: boolean;
+  reason: "missing_preferred_term" | "contains_forbidden_term";
+};
+
+export type GlossaryTranslationUnit = {
+  externalStringId: string;
+  key: string;
+  sourceText: string;
+  locale: string;
+  translatedText: string;
+};
+
+export function sourceContainsTerm(
+  sourceText: string,
+  term: { sourceTerm: string; caseSensitive: boolean },
+) {
+  if (term.caseSensitive) {
+    return sourceText.includes(term.sourceTerm);
+  }
+
+  return sourceText.toLocaleLowerCase().includes(term.sourceTerm.toLocaleLowerCase());
+}
+
+function translationContainsTerm(text: string, term: string, caseSensitive: boolean) {
+  return caseSensitive
+    ? text.includes(term)
+    : text.toLocaleLowerCase().includes(term.toLocaleLowerCase());
+}
+
+export function validateGlossaryTermsInTranslation(input: {
+  sourceText: string;
+  translatedText: string;
+  terms: GlossaryTermConstraint[];
+}) {
+  const failures: GlossaryValidationFailure[] = [];
+
+  for (const term of input.terms) {
+    const caseSensitive = term.caseSensitive === true;
+    if (!sourceContainsTerm(input.sourceText, { sourceTerm: term.sourceTerm, caseSensitive })) {
+      continue;
+    }
+
+    const hasTarget = translationContainsTerm(input.translatedText, term.targetTerm, caseSensitive);
+    if (term.forbidden === true) {
+      if (hasTarget) {
+        failures.push({
+          sourceTerm: term.sourceTerm,
+          targetTerm: term.targetTerm,
+          forbidden: true,
+          reason: "contains_forbidden_term",
+        });
+      }
+      continue;
+    }
+
+    if (term.forbidden === false && !hasTarget) {
+      failures.push({
+        sourceTerm: term.sourceTerm,
+        targetTerm: term.targetTerm,
+        forbidden: false,
+        reason: "missing_preferred_term",
+      });
+    }
+  }
+
+  return failures;
+}
+
+function translationUnitKey(unit: Pick<GlossaryTranslationUnit, "externalStringId" | "locale">) {
+  return `${unit.externalStringId}:${unit.locale}`;
+}
+
+function glossaryTermsForLocale(terms: GlossaryTermConstraint[], locale: string) {
+  return terms.filter((term) => term.targetLocale === locale);
+}
+
+export function validateGlossaryForTranslationUnits(
+  units: GlossaryTranslationUnit[],
+  terms: GlossaryTermConstraint[],
+) {
+  const failuresByUnitKey = new Map<string, GlossaryValidationFailure[]>();
+
+  for (const unit of units) {
+    const localeTerms = glossaryTermsForLocale(terms, unit.locale);
+    if (localeTerms.length === 0) {
+      continue;
+    }
+
+    const failures = validateGlossaryTermsInTranslation({
+      sourceText: unit.sourceText,
+      translatedText: unit.translatedText,
+      terms: localeTerms,
+    });
+
+    if (failures.length > 0) {
+      failuresByUnitKey.set(translationUnitKey(unit), failures);
+    }
+  }
+
+  return failuresByUnitKey;
+}
+
+export function translationUnitHasGlossaryViolations(
+  unit: GlossaryTranslationUnit,
+  terms: GlossaryTermConstraint[],
+) {
+  return validateGlossaryForTranslationUnits([unit], terms).size > 0;
+}

--- a/apps/hyperlocalise-web/src/lib/providers/agent-run-proposals.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-run-proposals.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  applyAgentRunProposalReviewUpdates,
+  applyBulkAgentRunProposalReview,
+  buildAgentRunProposalItemId,
+  detectAgentRunProposalWarnings,
+  enrichAgentRunProposalItem,
+  parseAgentRunProposalItems,
+} from "./agent-run-proposals";
+
+describe("agent-run-proposals", () => {
+  it("builds stable item ids", () => {
+    expect(buildAgentRunProposalItemId({ externalStringId: "1", locale: "fr" })).toBe("1:fr");
+  });
+
+  it("detects placeholder and glossary warnings", () => {
+    const warnings = detectAgentRunProposalWarnings({
+      sourceText: "Hello {name}",
+      from: "",
+      to: "Bonjour",
+      locale: "fr",
+      glossaryTerms: [
+        {
+          sourceTerm: "Hello",
+          targetTerm: "Salut",
+          targetLocale: "fr",
+          forbidden: false,
+        },
+      ],
+    });
+
+    expect(warnings.placeholder).toBe(true);
+    expect(warnings.glossary).toBe(true);
+  });
+
+  it("enriches raw changed items with review metadata", () => {
+    const item = enrichAgentRunProposalItem({
+      externalStringId: "1",
+      key: "hello",
+      locale: "fr",
+      sourceText: "Hello",
+      from: "",
+      to: "Bonjour",
+    });
+
+    expect(item).toMatchObject({
+      itemId: "1:fr",
+      reviewState: "pending",
+      changedFields: ["target"],
+    });
+  });
+
+  it("applies per-item and bulk review updates", () => {
+    const changedItems = [
+      {
+        externalStringId: "1",
+        key: "hello",
+        locale: "fr",
+        sourceText: "Hello",
+        from: "",
+        to: "Bonjour",
+      },
+      {
+        externalStringId: "2",
+        key: "world",
+        locale: "fr",
+        sourceText: "World",
+        from: "Monde",
+        to: "Le monde",
+      },
+    ];
+
+    const parsed = parseAgentRunProposalItems(changedItems);
+    expect(parsed).toHaveLength(2);
+
+    const individuallyUpdated = applyAgentRunProposalReviewUpdates({
+      changedItems,
+      updates: [{ itemId: parsed[0]!.itemId, reviewState: "accepted" }],
+    });
+
+    expect(enrichAgentRunProposalItem(individuallyUpdated[0]!)?.reviewState).toBe("accepted");
+    expect(enrichAgentRunProposalItem(individuallyUpdated[1]!)?.reviewState).toBe("pending");
+
+    const bulkRejected = applyBulkAgentRunProposalReview({
+      changedItems: individuallyUpdated,
+      reviewState: "rejected",
+      filter: "pending",
+    });
+
+    expect(enrichAgentRunProposalItem(bulkRejected[0]!)?.reviewState).toBe("accepted");
+    expect(enrichAgentRunProposalItem(bulkRejected[1]!)?.reviewState).toBe("rejected");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/agent-run-proposals.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-run-proposals.ts
@@ -1,4 +1,8 @@
-import { validateGlossaryTermsInTranslation } from "@/workflows/file-translation-job";
+import {
+  type GlossaryTermConstraint,
+  translationUnitHasGlossaryViolations,
+  validateGlossaryForTranslationUnits,
+} from "@/lib/glossary/validate-glossary-terms-in-translation";
 
 export type AgentRunProposalReviewState = "pending" | "accepted" | "rejected";
 
@@ -19,9 +23,13 @@ export type AgentRunProposalItem = {
   warnings: AgentRunProposalWarnings;
 };
 
-type GlossaryTermConstraint = Parameters<
-  typeof validateGlossaryTermsInTranslation
->[0]["terms"][number];
+type AgentRunProposalGlossaryTermInput = {
+  sourceTerm: string;
+  targetTerm: string;
+  targetLocale?: string;
+  forbidden?: boolean | null;
+  caseSensitive?: boolean | null;
+};
 
 const placeholderPattern = /\{[^}]+\}|%\d*\$?[sdif]|%\([^)]+\)[sdif]|\{\{[^}]+\}\}|%\w+/g;
 
@@ -47,22 +55,70 @@ function extractHtmlTagNames(text: string) {
   return tags.sort();
 }
 
-function hasGlossaryWarning(input: {
+function normalizeGlossaryTerms(
+  glossaryTerms: AgentRunProposalGlossaryTermInput[] | undefined,
+  locale: string,
+): GlossaryTermConstraint[] {
+  return (glossaryTerms ?? []).map((term) => ({
+    sourceTerm: term.sourceTerm,
+    targetTerm: term.targetTerm,
+    targetLocale: term.targetLocale ?? locale,
+    forbidden: term.forbidden ?? null,
+    caseSensitive: term.caseSensitive ?? null,
+  }));
+}
+
+function toProposalTranslationUnit(input: {
+  externalStringId: string;
+  key: string;
+  locale: string;
   sourceText: string;
   translatedText: string;
-  glossaryTerms: GlossaryTermConstraint[];
 }) {
-  if (input.glossaryTerms.length === 0) {
-    return false;
+  return {
+    externalStringId: input.externalStringId,
+    key: input.key,
+    locale: input.locale,
+    sourceText: input.sourceText,
+    translatedText: input.translatedText,
+  };
+}
+
+function collectGlossaryWarningsForProposalUnits(
+  units: ReturnType<typeof toProposalTranslationUnit>[],
+  glossaryTerms: GlossaryTermConstraint[],
+) {
+  const failuresByUnitKey = validateGlossaryForTranslationUnits(units, glossaryTerms);
+  const warnedUnitKeys = new Set<string>();
+
+  for (const unit of units) {
+    const unitKey = buildAgentRunProposalItemId({
+      externalStringId: unit.externalStringId,
+      locale: unit.locale,
+    });
+    if (failuresByUnitKey.has(`${unit.externalStringId}:${unit.locale}`)) {
+      warnedUnitKeys.add(unitKey);
+    }
   }
 
-  return (
-    validateGlossaryTermsInTranslation({
-      sourceText: input.sourceText,
-      translatedText: input.translatedText,
-      terms: input.glossaryTerms,
-    }).length > 0
-  );
+  return warnedUnitKeys;
+}
+
+function toGlossaryTermConstraints(
+  glossaryTerms: AgentRunProposalGlossaryTermInput[] | undefined,
+): GlossaryTermConstraint[] {
+  return (glossaryTerms ?? [])
+    .filter(
+      (term): term is AgentRunProposalGlossaryTermInput & { targetLocale: string } =>
+        typeof term.targetLocale === "string" && term.targetLocale.length > 0,
+    )
+    .map((term) => ({
+      sourceTerm: term.sourceTerm,
+      targetTerm: term.targetTerm,
+      targetLocale: term.targetLocale,
+      forbidden: term.forbidden ?? null,
+      caseSensitive: term.caseSensitive ?? null,
+    }));
 }
 
 function hasPlaceholderWarning(sourceText: string, translatedText: string) {
@@ -110,26 +166,27 @@ export function detectAgentRunProposalWarnings(input: {
   from: string;
   to: string;
   locale: string;
-  glossaryTerms?: Array<{
-    sourceTerm: string;
-    targetTerm: string;
-    targetLocale?: string;
-    forbidden?: boolean | null;
-    caseSensitive?: boolean | null;
-  }>;
+  externalStringId?: string;
+  key?: string;
+  glossaryTerms?: AgentRunProposalGlossaryTermInput[];
 }): AgentRunProposalWarnings {
-  const glossaryTerms: GlossaryTermConstraint[] = (input.glossaryTerms ?? []).map((term) => ({
-    sourceTerm: term.sourceTerm,
-    targetTerm: term.targetTerm,
-    targetLocale: term.targetLocale ?? input.locale,
-    forbidden: term.forbidden ?? null,
-    caseSensitive: term.caseSensitive ?? null,
-  }));
+  const glossaryTerms = normalizeGlossaryTerms(input.glossaryTerms, input.locale);
   const warnings: AgentRunProposalWarnings = {};
 
-  if (hasGlossaryWarning({ ...input, translatedText: input.to, glossaryTerms })) {
-    warnings.glossary = true;
+  if (glossaryTerms.length > 0) {
+    const unit = toProposalTranslationUnit({
+      externalStringId: input.externalStringId ?? "proposal",
+      key: input.key ?? "proposal",
+      locale: input.locale,
+      sourceText: input.sourceText,
+      translatedText: input.to,
+    });
+
+    if (translationUnitHasGlossaryViolations(unit, glossaryTerms)) {
+      warnings.glossary = true;
+    }
   }
+
   if (hasPlaceholderWarning(input.sourceText, input.to)) {
     warnings.placeholder = true;
   }
@@ -153,7 +210,8 @@ export function deriveChangedFields(from: string, to: string) {
 
 export function enrichAgentRunProposalItem(
   raw: Record<string, unknown>,
-  glossaryTerms?: Parameters<typeof detectAgentRunProposalWarnings>[0]["glossaryTerms"],
+  glossaryTerms?: AgentRunProposalGlossaryTermInput[],
+  glossaryWarningsByUnitKey?: Set<string>,
 ): AgentRunProposalItem | null {
   const externalStringId = typeof raw.externalStringId === "string" ? raw.externalStringId : null;
   const key = typeof raw.key === "string" ? raw.key : null;
@@ -185,13 +243,22 @@ export function enrichAgentRunProposalItem(
   const warnings =
     raw.warnings && typeof raw.warnings === "object" && !Array.isArray(raw.warnings)
       ? (raw.warnings as AgentRunProposalWarnings)
-      : detectAgentRunProposalWarnings({
-          sourceText,
-          from,
-          to,
-          locale,
-          glossaryTerms,
-        });
+      : {
+          ...detectAgentRunProposalWarnings({
+            sourceText,
+            from,
+            to,
+            locale,
+            externalStringId,
+            key,
+            glossaryTerms: glossaryWarningsByUnitKey ? undefined : glossaryTerms,
+          }),
+          ...(glossaryWarningsByUnitKey?.has(
+            buildAgentRunProposalItemId({ externalStringId, locale }),
+          )
+            ? { glossary: true }
+            : {}),
+        };
 
   return {
     itemId,
@@ -209,10 +276,39 @@ export function enrichAgentRunProposalItem(
 
 export function parseAgentRunProposalItems(
   changedItems: Record<string, unknown>[],
-  glossaryTerms?: Parameters<typeof detectAgentRunProposalWarnings>[0]["glossaryTerms"],
+  glossaryTerms?: AgentRunProposalGlossaryTermInput[],
 ) {
+  const glossaryConstraintTerms = toGlossaryTermConstraints(glossaryTerms);
+  const proposalUnits = changedItems
+    .map((raw) => {
+      const externalStringId =
+        typeof raw.externalStringId === "string" ? raw.externalStringId : null;
+      const key = typeof raw.key === "string" ? raw.key : null;
+      const locale = typeof raw.locale === "string" ? raw.locale : null;
+      const sourceText = typeof raw.sourceText === "string" ? raw.sourceText : "";
+      const to = typeof raw.to === "string" ? raw.to : "";
+
+      if (!externalStringId || !key || !locale) {
+        return null;
+      }
+
+      return toProposalTranslationUnit({
+        externalStringId,
+        key,
+        locale,
+        sourceText,
+        translatedText: to,
+      });
+    })
+    .filter((unit): unit is NonNullable<typeof unit> => unit !== null);
+
+  const glossaryWarningsByUnitKey =
+    glossaryConstraintTerms.length > 0
+      ? collectGlossaryWarningsForProposalUnits(proposalUnits, glossaryConstraintTerms)
+      : undefined;
+
   return changedItems
-    .map((item) => enrichAgentRunProposalItem(item, glossaryTerms))
+    .map((item) => enrichAgentRunProposalItem(item, glossaryTerms, glossaryWarningsByUnitKey))
     .filter((item): item is AgentRunProposalItem => item !== null);
 }
 

--- a/apps/hyperlocalise-web/src/lib/providers/agent-run-proposals.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-run-proposals.ts
@@ -1,0 +1,305 @@
+import { validateGlossaryTermsInTranslation } from "@/workflows/file-translation-job";
+
+export type AgentRunProposalReviewState = "pending" | "accepted" | "rejected";
+
+export type AgentRunProposalWarningKind = "glossary" | "placeholder" | "format" | "confidence";
+
+export type AgentRunProposalWarnings = Partial<Record<AgentRunProposalWarningKind, boolean>>;
+
+export type AgentRunProposalItem = {
+  itemId: string;
+  externalStringId: string;
+  key: string;
+  locale: string;
+  sourceText: string;
+  from: string;
+  to: string;
+  reviewState: AgentRunProposalReviewState;
+  changedFields: string[];
+  warnings: AgentRunProposalWarnings;
+};
+
+type GlossaryTermConstraint = Parameters<
+  typeof validateGlossaryTermsInTranslation
+>[0]["terms"][number];
+
+const placeholderPattern = /\{[^}]+\}|%\d*\$?[sdif]|%\([^)]+\)[sdif]|\{\{[^}]+\}\}|%\w+/g;
+
+const htmlTagPattern = /<\/?([a-zA-Z][a-zA-Z0-9]*)\b[^>]*>/g;
+
+export function buildAgentRunProposalItemId(input: { externalStringId: string; locale: string }) {
+  return `${input.externalStringId}:${input.locale}`;
+}
+
+export function extractPlaceholderTokens(text: string) {
+  const matches = text.match(placeholderPattern) ?? [];
+  return [...new Set(matches)].sort();
+}
+
+function extractHtmlTagNames(text: string) {
+  const tags: string[] = [];
+  for (const match of text.matchAll(htmlTagPattern)) {
+    const tag = match[1]?.toLowerCase();
+    if (tag) {
+      tags.push(tag);
+    }
+  }
+  return tags.sort();
+}
+
+function hasGlossaryWarning(input: {
+  sourceText: string;
+  translatedText: string;
+  glossaryTerms: GlossaryTermConstraint[];
+}) {
+  if (input.glossaryTerms.length === 0) {
+    return false;
+  }
+
+  return (
+    validateGlossaryTermsInTranslation({
+      sourceText: input.sourceText,
+      translatedText: input.translatedText,
+      terms: input.glossaryTerms,
+    }).length > 0
+  );
+}
+
+function hasPlaceholderWarning(sourceText: string, translatedText: string) {
+  const sourcePlaceholders = extractPlaceholderTokens(sourceText);
+  if (sourcePlaceholders.length === 0) {
+    return false;
+  }
+
+  const targetPlaceholders = new Set(extractPlaceholderTokens(translatedText));
+  return sourcePlaceholders.some((token) => !targetPlaceholders.has(token));
+}
+
+function hasFormatWarning(sourceText: string, translatedText: string) {
+  const sourceTags = extractHtmlTagNames(sourceText);
+  if (sourceTags.length === 0) {
+    return false;
+  }
+
+  const targetTags = extractHtmlTagNames(translatedText);
+  if (sourceTags.length !== targetTags.length) {
+    return true;
+  }
+
+  return sourceTags.some((tag, index) => tag !== targetTags[index]);
+}
+
+function hasConfidenceWarning(sourceText: string, translatedText: string) {
+  const sourceLength = sourceText.trim().length;
+  const targetLength = translatedText.trim().length;
+
+  if (sourceLength >= 12 && targetLength === 0) {
+    return true;
+  }
+
+  if (sourceLength === 0) {
+    return false;
+  }
+
+  const ratio = targetLength / sourceLength;
+  return ratio < 0.15 || ratio > 6;
+}
+
+export function detectAgentRunProposalWarnings(input: {
+  sourceText: string;
+  from: string;
+  to: string;
+  locale: string;
+  glossaryTerms?: Array<{
+    sourceTerm: string;
+    targetTerm: string;
+    targetLocale?: string;
+    forbidden?: boolean | null;
+    caseSensitive?: boolean | null;
+  }>;
+}): AgentRunProposalWarnings {
+  const glossaryTerms: GlossaryTermConstraint[] = (input.glossaryTerms ?? []).map((term) => ({
+    sourceTerm: term.sourceTerm,
+    targetTerm: term.targetTerm,
+    targetLocale: term.targetLocale ?? input.locale,
+    forbidden: term.forbidden ?? null,
+    caseSensitive: term.caseSensitive ?? null,
+  }));
+  const warnings: AgentRunProposalWarnings = {};
+
+  if (hasGlossaryWarning({ ...input, translatedText: input.to, glossaryTerms })) {
+    warnings.glossary = true;
+  }
+  if (hasPlaceholderWarning(input.sourceText, input.to)) {
+    warnings.placeholder = true;
+  }
+  if (hasFormatWarning(input.sourceText, input.to)) {
+    warnings.format = true;
+  }
+  if (hasConfidenceWarning(input.sourceText, input.to)) {
+    warnings.confidence = true;
+  }
+
+  return warnings;
+}
+
+export function deriveChangedFields(from: string, to: string) {
+  const fields: string[] = [];
+  if (from !== to) {
+    fields.push("target");
+  }
+  return fields;
+}
+
+export function enrichAgentRunProposalItem(
+  raw: Record<string, unknown>,
+  glossaryTerms?: Parameters<typeof detectAgentRunProposalWarnings>[0]["glossaryTerms"],
+): AgentRunProposalItem | null {
+  const externalStringId = typeof raw.externalStringId === "string" ? raw.externalStringId : null;
+  const key = typeof raw.key === "string" ? raw.key : null;
+  const locale = typeof raw.locale === "string" ? raw.locale : null;
+  const sourceText = typeof raw.sourceText === "string" ? raw.sourceText : "";
+  const from = typeof raw.from === "string" ? raw.from : "";
+  const to = typeof raw.to === "string" ? raw.to : "";
+
+  if (!externalStringId || !key || !locale) {
+    return null;
+  }
+
+  const itemId =
+    typeof raw.itemId === "string"
+      ? raw.itemId
+      : buildAgentRunProposalItemId({ externalStringId, locale });
+
+  const reviewState =
+    raw.reviewState === "accepted" ||
+    raw.reviewState === "rejected" ||
+    raw.reviewState === "pending"
+      ? raw.reviewState
+      : "pending";
+
+  const changedFields = Array.isArray(raw.changedFields)
+    ? raw.changedFields.filter((field): field is string => typeof field === "string")
+    : deriveChangedFields(from, to);
+
+  const warnings =
+    raw.warnings && typeof raw.warnings === "object" && !Array.isArray(raw.warnings)
+      ? (raw.warnings as AgentRunProposalWarnings)
+      : detectAgentRunProposalWarnings({
+          sourceText,
+          from,
+          to,
+          locale,
+          glossaryTerms,
+        });
+
+  return {
+    itemId,
+    externalStringId,
+    key,
+    locale,
+    sourceText,
+    from,
+    to,
+    reviewState,
+    changedFields: changedFields.length > 0 ? changedFields : deriveChangedFields(from, to),
+    warnings,
+  };
+}
+
+export function parseAgentRunProposalItems(
+  changedItems: Record<string, unknown>[],
+  glossaryTerms?: Parameters<typeof detectAgentRunProposalWarnings>[0]["glossaryTerms"],
+) {
+  return changedItems
+    .map((item) => enrichAgentRunProposalItem(item, glossaryTerms))
+    .filter((item): item is AgentRunProposalItem => item !== null);
+}
+
+export function serializeAgentRunProposalItem(item: AgentRunProposalItem) {
+  return {
+    itemId: item.itemId,
+    externalStringId: item.externalStringId,
+    key: item.key,
+    locale: item.locale,
+    sourceText: item.sourceText,
+    from: item.from,
+    to: item.to,
+    reviewState: item.reviewState,
+    changedFields: item.changedFields,
+    warnings: item.warnings,
+  };
+}
+
+export function applyAgentRunProposalReviewUpdates(input: {
+  changedItems: Record<string, unknown>[];
+  updates: Array<{ itemId: string; reviewState: AgentRunProposalReviewState }>;
+}) {
+  const updatesById = new Map(input.updates.map((update) => [update.itemId, update.reviewState]));
+
+  return input.changedItems.map((raw) => {
+    const item = enrichAgentRunProposalItem(raw);
+    if (!item) {
+      return raw;
+    }
+
+    const nextState = updatesById.get(item.itemId);
+    if (!nextState) {
+      return serializeAgentRunProposalItem(item);
+    }
+
+    return serializeAgentRunProposalItem({ ...item, reviewState: nextState });
+  });
+}
+
+export function applyBulkAgentRunProposalReview(input: {
+  changedItems: Record<string, unknown>[];
+  reviewState: Extract<AgentRunProposalReviewState, "accepted" | "rejected">;
+  itemIds?: string[];
+  filter?: "pending" | "all";
+}) {
+  const itemIdSet = input.itemIds ? new Set(input.itemIds) : null;
+
+  return input.changedItems.map((raw) => {
+    const item = enrichAgentRunProposalItem(raw);
+    if (!item) {
+      return raw;
+    }
+
+    if (itemIdSet && !itemIdSet.has(item.itemId)) {
+      return serializeAgentRunProposalItem(item);
+    }
+
+    if (!itemIdSet && input.filter === "pending" && item.reviewState !== "pending") {
+      return serializeAgentRunProposalItem(item);
+    }
+
+    return serializeAgentRunProposalItem({ ...item, reviewState: input.reviewState });
+  });
+}
+
+export function countAgentRunProposalReviewStates(items: AgentRunProposalItem[]) {
+  return items.reduce(
+    (counts, item) => {
+      counts[item.reviewState] += 1;
+      return counts;
+    },
+    { pending: 0, accepted: 0, rejected: 0 },
+  );
+}
+
+export function agentRunHasReviewableProposals(input: {
+  kind: string;
+  status: string;
+  changedItems: Record<string, unknown>[];
+}) {
+  if (input.status !== "succeeded") {
+    return false;
+  }
+
+  if (input.kind !== "translate" && input.kind !== "qa_fix") {
+    return false;
+  }
+
+  return parseAgentRunProposalItems(input.changedItems).length > 0;
+}

--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs.test.ts
@@ -15,6 +15,7 @@ import {
   listAgentRuns,
   startAgentRun,
   updateAgentRun,
+  updateAgentRunChangedItems,
 } from "./agent-runs";
 
 const projectFixture = createProjectTestFixture();
@@ -279,6 +280,48 @@ describe("agent runs", () => {
     expect(updated.warnings).toEqual(["spelling mismatch"]);
     expect(updated.hyperlocaliseJobId).toBe(job.id);
     expect(updated.status).toBe("queued");
+  });
+
+  it("updates changed items from the current persisted run state", async () => {
+    const { project } = await createTestProject();
+
+    const created = await createAgentRun({
+      organizationId: project.organizationId,
+      providerKind: "crowdin",
+      externalJobId: "crowdin-job-review-callback",
+      kind: "translate",
+    });
+
+    await startAgentRun({
+      runId: created.id,
+      organizationId: project.organizationId,
+    });
+
+    await completeAgentRun({
+      runId: created.id,
+      organizationId: project.organizationId,
+      changedItems: [{ itemId: "a", reviewState: "pending" }],
+    });
+
+    await updateAgentRunChangedItems({
+      runId: created.id,
+      organizationId: project.organizationId,
+      changedItems: [{ itemId: "a", reviewState: "accepted" }],
+    });
+
+    const updated = await updateAgentRunChangedItems({
+      runId: created.id,
+      organizationId: project.organizationId,
+      changedItems: (run) => [
+        ...run.changedItems,
+        { itemId: "b", reviewState: "rejected" },
+      ],
+    });
+
+    expect(updated.changedItems).toEqual([
+      { itemId: "a", reviewState: "accepted" },
+      { itemId: "b", reviewState: "rejected" },
+    ]);
   });
 
   it("does not update a terminal run", async () => {

--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs.test.ts
@@ -312,10 +312,7 @@ describe("agent runs", () => {
     const updated = await updateAgentRunChangedItems({
       runId: created.id,
       organizationId: project.organizationId,
-      changedItems: (run) => [
-        ...run.changedItems,
-        { itemId: "b", reviewState: "rejected" },
-      ],
+      changedItems: (run) => [...run.changedItems, { itemId: "b", reviewState: "rejected" }],
     });
 
     expect(updated.changedItems).toEqual([

--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs.ts
@@ -258,29 +258,52 @@ export async function listAgentRuns(input: {
 export async function updateAgentRunChangedItems(input: {
   runId: string;
   organizationId: string;
-  changedItems: AgentRunChangedItem[];
+  changedItems:
+    | AgentRunChangedItem[]
+    | ((run: typeof schema.agentRuns.$inferSelect) => AgentRunChangedItem[]);
 }) {
-  const now = new Date();
-  const [run] = await db
-    .update(schema.agentRuns)
-    .set({
-      changedItems: input.changedItems,
-      updatedAt: now,
-    })
-    .where(
-      and(
-        eq(schema.agentRuns.id, input.runId),
-        eq(schema.agentRuns.organizationId, input.organizationId),
-        eq(schema.agentRuns.status, "succeeded"),
-      ),
-    )
-    .returning();
+  return db.transaction(async (tx) => {
+    const [currentRun] = await tx
+      .select()
+      .from(schema.agentRuns)
+      .where(
+        and(
+          eq(schema.agentRuns.id, input.runId),
+          eq(schema.agentRuns.organizationId, input.organizationId),
+          eq(schema.agentRuns.status, "succeeded"),
+        ),
+      )
+      .limit(1)
+      .for("update");
 
-  if (!run) {
-    throw new Error("Agent run not found or not in reviewable state");
-  }
+    if (!currentRun) {
+      throw new Error("Agent run not found or not in reviewable state");
+    }
 
-  return run;
+    const changedItems =
+      typeof input.changedItems === "function" ? input.changedItems(currentRun) : input.changedItems;
+    const now = new Date();
+    const [run] = await tx
+      .update(schema.agentRuns)
+      .set({
+        changedItems,
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(schema.agentRuns.id, input.runId),
+          eq(schema.agentRuns.organizationId, input.organizationId),
+          eq(schema.agentRuns.status, "succeeded"),
+        ),
+      )
+      .returning();
+
+    if (!run) {
+      throw new Error("Agent run not found or not in reviewable state");
+    }
+
+    return run;
+  });
 }
 
 export async function getAgentRunsByExternalJob(input: {

--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs.ts
@@ -255,6 +255,34 @@ export async function listAgentRuns(input: {
     .limit(input.limit ?? 50);
 }
 
+export async function updateAgentRunChangedItems(input: {
+  runId: string;
+  organizationId: string;
+  changedItems: AgentRunChangedItem[];
+}) {
+  const now = new Date();
+  const [run] = await db
+    .update(schema.agentRuns)
+    .set({
+      changedItems: input.changedItems,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(schema.agentRuns.id, input.runId),
+        eq(schema.agentRuns.organizationId, input.organizationId),
+        eq(schema.agentRuns.status, "succeeded"),
+      ),
+    )
+    .returning();
+
+  if (!run) {
+    throw new Error("Agent run not found or not in reviewable state");
+  }
+
+  return run;
+}
+
 export async function getAgentRunsByExternalJob(input: {
   organizationId: string;
   providerKind: ExternalTmsProviderKind;

--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs.ts
@@ -281,7 +281,9 @@ export async function updateAgentRunChangedItems(input: {
     }
 
     const changedItems =
-      typeof input.changedItems === "function" ? input.changedItems(currentRun) : input.changedItems;
+      typeof input.changedItems === "function"
+        ? input.changedItems(currentRun)
+        : input.changedItems;
     const now = new Date();
     const [run] = await tx
       .update(schema.agentRuns)

--- a/apps/hyperlocalise-web/src/lib/providers/organization-external-tms-glossaries.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/organization-external-tms-glossaries.test.ts
@@ -6,7 +6,7 @@ import { eq, inArray } from "drizzle-orm";
 import { afterEach, beforeAll, describe, expect, it } from "vite-plus/test";
 
 import { db, schema } from "@/lib/database";
-import { validateGlossaryTermsInTranslation } from "@/workflows/file-translation-job";
+import { validateGlossaryTermsInTranslation } from "@/lib/glossary/validate-glossary-terms-in-translation";
 
 import {
   listOrganizationExternalTmsGlossaries,

--- a/apps/hyperlocalise-web/src/lib/providers/provider-agent-translate.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-agent-translate.test.ts
@@ -119,14 +119,17 @@ describe("executeProviderAgentTranslation", () => {
 
     expect(completed?.status).toBe("succeeded");
     expect(completed?.changedItems).toEqual([
-      {
+      expect.objectContaining({
+        itemId: "1:fr",
         externalStringId: "1",
         key: "hello",
         locale: "fr",
         sourceText: "Hello",
         from: "",
         to: "Bonjour",
-      },
+        reviewState: "pending",
+        changedFields: ["target"],
+      }),
     ]);
     expect(completed?.outputSummary).toMatchObject({
       pullRunId: "pull-run-1",

--- a/apps/hyperlocalise-web/src/lib/providers/provider-agent-translate.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-agent-translate.ts
@@ -172,6 +172,8 @@ async function translateProviderUnits(input: {
           from,
           to: translation.text,
           locale: translation.locale,
+          externalStringId: unit.externalStringId,
+          key: unit.key,
           glossaryTerms: contextSnapshot.snapshot.glossaryTerms
             .filter((term) => term.targetLocale === translation.locale)
             .map((term) => ({

--- a/apps/hyperlocalise-web/src/lib/providers/provider-agent-translate.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-agent-translate.ts
@@ -1,4 +1,11 @@
 import {
+  detectAgentRunProposalWarnings,
+  deriveChangedFields,
+  buildAgentRunProposalItemId,
+  serializeAgentRunProposalItem,
+  type AgentRunProposalItem,
+} from "@/lib/providers/agent-run-proposals";
+import {
   completeAgentRun,
   failAgentRun,
   getAgentRun,
@@ -17,14 +24,7 @@ import {
 import { loadOrganizationOpenAITranslationGenerator } from "@/lib/translation/load-organization-translation-generator";
 import type { StringTranslationGenerator } from "@/lib/translation/string-job-executor";
 
-export type ProviderAgentTranslationChangedItem = {
-  externalStringId: string;
-  key: string;
-  locale: string;
-  sourceText: string;
-  from: string;
-  to: string;
-};
+export type ProviderAgentTranslationChangedItem = AgentRunProposalItem;
 
 export type ProviderAgentTranslationResult =
   | {
@@ -167,14 +167,38 @@ async function translateProviderUnits(input: {
           continue;
         }
 
-        changedItems.push({
-          externalStringId: unit.externalStringId,
-          key: unit.key,
-          locale: translation.locale,
+        const proposalWarnings = detectAgentRunProposalWarnings({
           sourceText: unit.sourceText,
           from,
           to: translation.text,
+          locale: translation.locale,
+          glossaryTerms: contextSnapshot.snapshot.glossaryTerms
+            .filter((term) => term.targetLocale === translation.locale)
+            .map((term) => ({
+              sourceTerm: term.sourceTerm,
+              targetTerm: term.targetTerm,
+              targetLocale: term.targetLocale,
+              forbidden: term.forbidden,
+            })),
         });
+
+        changedItems.push(
+          serializeAgentRunProposalItem({
+            itemId: buildAgentRunProposalItemId({
+              externalStringId: unit.externalStringId,
+              locale: translation.locale,
+            }),
+            externalStringId: unit.externalStringId,
+            key: unit.key,
+            locale: translation.locale,
+            sourceText: unit.sourceText,
+            from,
+            to: translation.text,
+            reviewState: "pending",
+            changedFields: deriveChangedFields(from, translation.text),
+            warnings: proposalWarnings,
+          }),
+        );
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : "translation failed";

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -22,6 +22,10 @@ import {
   writeFileToSandbox,
   writeTempConfig,
 } from "@/lib/translation/sandbox-translation";
+import {
+  sourceContainsTerm,
+  validateGlossaryTermsInTranslation,
+} from "@/lib/glossary/validate-glossary-terms-in-translation";
 import type { TranslationJobEventData } from "@/lib/workflow/types";
 import {
   claimTranslationJobStep,
@@ -140,77 +144,6 @@ async function logDiagnosticsStep(
     content,
     outputFilename,
   );
-}
-
-function sourceContainsTerm(
-  sourceText: string,
-  term: { sourceTerm: string; caseSensitive: boolean },
-) {
-  if (term.caseSensitive) {
-    return sourceText.includes(term.sourceTerm);
-  }
-
-  return sourceText.toLocaleLowerCase().includes(term.sourceTerm.toLocaleLowerCase());
-}
-
-type GlossaryTermConstraint = {
-  sourceTerm: string;
-  targetTerm: string;
-  targetLocale: string;
-  forbidden: boolean | null;
-  caseSensitive?: boolean | null;
-};
-
-type GlossaryValidationFailure = {
-  sourceTerm: string;
-  targetTerm: string;
-  forbidden: boolean;
-  reason: "missing_preferred_term" | "contains_forbidden_term";
-};
-
-function translationContainsTerm(text: string, term: string, caseSensitive: boolean) {
-  return caseSensitive
-    ? text.includes(term)
-    : text.toLocaleLowerCase().includes(term.toLocaleLowerCase());
-}
-
-export function validateGlossaryTermsInTranslation(input: {
-  sourceText: string;
-  translatedText: string;
-  terms: GlossaryTermConstraint[];
-}) {
-  const failures: GlossaryValidationFailure[] = [];
-
-  for (const term of input.terms) {
-    const caseSensitive = term.caseSensitive === true;
-    if (!sourceContainsTerm(input.sourceText, { sourceTerm: term.sourceTerm, caseSensitive })) {
-      continue;
-    }
-
-    const hasTarget = translationContainsTerm(input.translatedText, term.targetTerm, caseSensitive);
-    if (term.forbidden === true) {
-      if (hasTarget) {
-        failures.push({
-          sourceTerm: term.sourceTerm,
-          targetTerm: term.targetTerm,
-          forbidden: true,
-          reason: "contains_forbidden_term",
-        });
-      }
-      continue;
-    }
-
-    if (term.forbidden === false && !hasTarget) {
-      failures.push({
-        sourceTerm: term.sourceTerm,
-        targetTerm: term.targetTerm,
-        forbidden: false,
-        reason: "missing_preferred_term",
-      });
-    }
-  }
-
-  return failures;
 }
 
 async function assembleFileTranslationContextStep(input: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Adds an **Agent Proposal Review** panel on provider-backed job detail pages so reviewers can inspect translation agent output before provider write-back.

- Shows **source**, **current provider target**, and **agent proposal** side by side, plus changed fields and review state
- **Accept / reject** per proposal, with bulk actions (all pending, selected)
- **Warning badges** for glossary, placeholder, format, and confidence issues (computed when proposals are created)
- **Search, locale, review-state, and warning filters** with **pagination** (25 items per page) for large runs
- Persists decisions on the `agent_runs.changed_items` JSON via `PATCH /api/orgs/:slug/jobs/:jobId/agent-runs/:agentRunId/review`

## How to test

1. Open a provider-backed job that has a succeeded `translate` agent run with proposals.
2. Confirm the **Agent Proposal Review** section lists proposals with warning badges where applicable.
3. Accept/reject individual rows and use bulk actions; refresh and verify state persists.
4. Exercise filters and pagination on a run with many proposals.

```bash
cd apps/hyperlocalise-web
vp check --fix
vp test src/lib/providers/agent-run-proposals.test.ts
```

(DB-backed route tests require Postgres.)

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, unit tests)
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-373](https://linear.app/hyperlocalise/issue/HL-373/build-agent-run-diff-review-screen)

<div><a href="https://cursor.com/agents/bc-04aab898-ab4f-4585-9f1b-348ceb11086e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04aab898-ab4f-4585-9f1b-348ceb11086e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

