### PR TITLE
feat(phrase): implement translation pull and write-back (HL-351)

### DIFF
--- a/apps/hyperlocalise-web/src/lib/providers/fetch-mock-helpers.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/fetch-mock-helpers.ts
@@ -1,0 +1,20 @@
+export function requestUrlString(url: Parameters<typeof fetch>[0]): string {
+  if (typeof url === "string") {
+    return url;
+  }
+  if (url instanceof URL) {
+    return url.toString();
+  }
+  return url.url;
+}
+
+export function requestBodyString(body: BodyInit | null | undefined): string {
+  if (typeof body === "string") {
+    return body;
+  }
+  throw new Error(
+    body == null
+      ? "Expected fetch mock request body"
+      : `Unsupported fetch mock body type: ${typeof body}`,
+  );
+}

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-file-fetcher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-file-fetcher.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
+import { requestUrlString } from "../fetch-mock-helpers";
 import { fetchLokaliseFileKeys } from "./lokalise-file-fetcher";
 
 describe("fetchLokaliseFileKeys", () => {
@@ -373,13 +374,3 @@ describe("fetchLokaliseFileKeys", () => {
     ).rejects.toThrow("lokalise_auth_invalid");
   });
 });
-
-function requestUrlString(url: Parameters<typeof fetch>[0]) {
-  if (typeof url === "string") {
-    return url;
-  }
-  if (url instanceof URL) {
-    return url.toString();
-  }
-  return url.url;
-}

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-project-fetcher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-project-fetcher.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
+import { requestUrlString } from "../fetch-mock-helpers";
 import { fetchLokaliseProjects } from "./lokalise-project-fetcher";
 
 describe("fetchLokaliseProjects", () => {
@@ -141,7 +142,7 @@ describe("fetchLokaliseProjects", () => {
 
     const languageFetches = vi
       .mocked(fetchMock)
-      .mock.calls.filter((call) => String(call[0]).includes("/languages"));
+      .mock.calls.filter((call) => requestUrlString(call[0]).includes("/languages"));
     expect(languageFetches.length).toBeLessThan(20);
   });
 

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-api.test.ts
@@ -153,6 +153,65 @@ describe("PhraseApiClient", () => {
     expect(typeof keysRequestUrl === "string" ? keysRequestUrl : "").toContain("branch=feature");
   });
 
+  it("updates an existing translation when POST conflicts", async () => {
+    const fetchMock = vi.fn(async (url, init) => {
+      const path = String(url);
+      const method = init?.method ?? "GET";
+
+      if (path.includes("/translations") && method === "POST") {
+        return new Response(JSON.stringify({ message: "already exists" }), { status: 422 });
+      }
+
+      if (path.includes("/translations") && method === "GET") {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "tr-existing",
+              key_id: "key-1",
+              locale_name: "fr",
+              content: "Ancien",
+              state: "translated",
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/translations/tr-existing") && method === "PATCH") {
+        return new Response(
+          JSON.stringify({
+            id: "tr-existing",
+            key_id: "key-1",
+            locale_name: "fr",
+            content: "Bonjour",
+            state: "translated",
+            unverified: false,
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify([]), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    const translation = await client.upsertTranslation("proj-1", {
+      keyId: "key-1",
+      localeName: "fr",
+      content: "Bonjour",
+    });
+
+    expect(translation).toMatchObject({
+      id: "tr-existing",
+      keyId: "key-1",
+      localeName: "fr",
+      content: "Bonjour",
+    });
+
+    const methods = vi.mocked(fetchMock).mock.calls.map(([, requestInit]) => requestInit?.method);
+    expect(methods).toEqual(expect.arrayContaining(["POST", "GET", "PATCH"]));
+  });
+
   it("throws PhraseApiError for non-success responses", async () => {
     const fetchMock = vi.fn(async () => {
       return new Response(JSON.stringify({ message: "Unauthorized" }), { status: 401 });

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-api.test.ts
@@ -212,6 +212,36 @@ describe("PhraseApiClient", () => {
     expect(methods).toEqual(expect.arrayContaining(["POST", "GET", "PATCH"]));
   });
 
+  it("rethrows non-conflict 422 responses from translation POST", async () => {
+    const fetchMock = vi.fn(async (url, init) => {
+      const path = String(url);
+      const method = init?.method ?? "GET";
+
+      if (path.includes("/translations") && method === "POST") {
+        return new Response(JSON.stringify({ message: "Invalid content encoding" }), {
+          status: 422,
+        });
+      }
+
+      return new Response(JSON.stringify([]), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+
+    await expect(
+      client.upsertTranslation("proj-1", {
+        keyId: "key-1",
+        localeName: "fr",
+        content: "Bonjour",
+      }),
+    ).rejects.toMatchObject({
+      status: 422,
+    });
+
+    const methods = vi.mocked(fetchMock).mock.calls.map(([, requestInit]) => requestInit?.method);
+    expect(methods).not.toContain("PATCH");
+  });
+
   it("throws PhraseApiError for non-success responses", async () => {
     const fetchMock = vi.fn(async () => {
       return new Response(JSON.stringify({ message: "Unauthorized" }), { status: 401 });

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-api.ts
@@ -208,6 +208,56 @@ export class PhraseApiClient {
     });
   }
 
+  async createKey(
+    projectId: string,
+    input: {
+      name: string;
+      description?: string | null;
+      tags?: string[];
+      branch?: string | null;
+    },
+  ): Promise<PhraseKey> {
+    const payload: Record<string, unknown> = {
+      name: input.name,
+      description: input.description ?? null,
+      tags: input.tags ?? [],
+    };
+
+    const record = await this.post<PhraseKeyApiRecord>(
+      `/projects/${encodeURIComponent(projectId)}/keys`,
+      payload,
+      { branch: input.branch },
+    );
+
+    return normalizePhraseKey(record);
+  }
+
+  async upsertTranslation(
+    projectId: string,
+    input: {
+      keyId: string;
+      localeName: string;
+      content: string;
+      branch?: string | null;
+      unverified?: boolean;
+    },
+  ): Promise<PhraseTranslation> {
+    const payload: Record<string, unknown> = {
+      key_id: input.keyId,
+      locale_name: input.localeName,
+      content: input.content,
+      unverified: input.unverified ?? false,
+    };
+
+    const record = await this.post<PhraseTranslationApiRecord>(
+      `/projects/${encodeURIComponent(projectId)}/translations`,
+      payload,
+      { branch: input.branch },
+    );
+
+    return normalizePhraseTranslation(record);
+  }
+
   buildLocaleDownloadMetadata(input: {
     projectId: string;
     locale: PhraseLocale;
@@ -283,6 +333,21 @@ export class PhraseApiClient {
     return this.request<T>(path, {
       method: "GET",
       headers: this.authHeaders(),
+    });
+  }
+
+  private async post<T>(
+    path: string,
+    payload: Record<string, unknown>,
+    query: Record<string, string | null | undefined> = {},
+  ): Promise<T> {
+    return this.request<T>(this.buildPath(path, query), {
+      method: "POST",
+      headers: {
+        ...this.authHeaders(),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
     });
   }
 

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-api.ts
@@ -431,7 +431,13 @@ export class PhraseApiClient {
 }
 
 function isPhraseTranslationConflict(error: unknown): boolean {
-  return error instanceof PhraseApiError && (error.status === 409 || error.status === 422);
+  if (!(error instanceof PhraseApiError)) return false;
+  if (error.status === 409) return true;
+  if (error.status === 422) {
+    const body = error.responseBody as { message?: string } | null;
+    return typeof body?.message === "string" && /already exist/i.test(body.message);
+  }
+  return false;
 }
 
 type PhraseProjectApiRecord = {

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-api.ts
@@ -242,20 +242,61 @@ export class PhraseApiClient {
       unverified?: boolean;
     },
   ): Promise<PhraseTranslation> {
-    const payload: Record<string, unknown> = {
-      key_id: input.keyId,
-      locale_name: input.localeName,
+    const listOptions = input.branch ? { branch: input.branch } : {};
+    const updatePayload = {
       content: input.content,
       unverified: input.unverified ?? false,
     };
 
-    const record = await this.post<PhraseTranslationApiRecord>(
-      `/projects/${encodeURIComponent(projectId)}/translations`,
-      payload,
+    try {
+      const record = await this.post<PhraseTranslationApiRecord>(
+        `/projects/${encodeURIComponent(projectId)}/translations`,
+        {
+          key_id: input.keyId,
+          locale_name: input.localeName,
+          ...updatePayload,
+        },
+        { branch: input.branch },
+      );
+
+      return normalizePhraseTranslation(record);
+    } catch (error) {
+      if (!isPhraseTranslationConflict(error)) {
+        throw error;
+      }
+    }
+
+    const existing = await this.findTranslationForKey(
+      projectId,
+      input.keyId,
+      input.localeName,
+      listOptions,
+    );
+    if (!existing) {
+      throw new PhraseApiError(
+        `Phrase translation already exists for key ${input.keyId} in locale ${input.localeName}, but it could not be resolved for update`,
+        409,
+        null,
+      );
+    }
+
+    const record = await this.patch<PhraseTranslationApiRecord>(
+      `/projects/${encodeURIComponent(projectId)}/translations/${encodeURIComponent(existing.id)}`,
+      updatePayload,
       { branch: input.branch },
     );
 
     return normalizePhraseTranslation(record);
+  }
+
+  private async findTranslationForKey(
+    projectId: string,
+    keyId: string,
+    localeName: string,
+    options: PhraseListOptions,
+  ): Promise<PhraseTranslation | null> {
+    const translations = await this.listTranslations(projectId, localeName, options);
+    return translations.find((translation) => translation.keyId === keyId) ?? null;
   }
 
   buildLocaleDownloadMetadata(input: {
@@ -351,6 +392,21 @@ export class PhraseApiClient {
     });
   }
 
+  private async patch<T>(
+    path: string,
+    payload: Record<string, unknown>,
+    query: Record<string, string | null | undefined> = {},
+  ): Promise<T> {
+    return this.request<T>(this.buildPath(path, query), {
+      method: "PATCH",
+      headers: {
+        ...this.authHeaders(),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+  }
+
   private async request<T>(path: string, init: RequestInit): Promise<T> {
     const url = `${this.baseUrl}${path}`;
     const response = await this.fetchFn(url, init);
@@ -372,6 +428,10 @@ export class PhraseApiClient {
 
     return response.json() as Promise<T>;
   }
+}
+
+function isPhraseTranslationConflict(error: unknown): boolean {
+  return error instanceof PhraseApiError && (error.status === 409 || error.status === 422);
 }
 
 type PhraseProjectApiRecord = {

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-content-puller.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-content-puller.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { pullPhraseTaskContent } from "./phrase-content-puller";
+
+describe("pullPhraseTaskContent", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("pulls scoped keys and translations for a Phrase TMS job", async () => {
+    const fetchMock = vi.fn(async (url, init) => {
+      const path = String(url);
+
+      if (path.includes("cloud.memsource.com") && path.includes("/jobs")) {
+        const workflowLevel = Number(new URL(path).searchParams.get("workflowLevel") ?? "0");
+        if (workflowLevel === 1) {
+          return new Response(
+            JSON.stringify({
+              content: [
+                {
+                  uid: "task-fr",
+                  innerId: "phrase-job-1",
+                  status: "NEW",
+                  targetLang: "fr-FR",
+                  filename: "Homepage French",
+                },
+              ],
+              totalPages: 1,
+            }),
+            { status: 200 },
+          );
+        }
+
+        return new Response(JSON.stringify({ content: [], totalPages: 0 }), { status: 200 });
+      }
+
+      if (path.includes("api.phrase.com") && path.includes("/locales")) {
+        return new Response(
+          JSON.stringify([
+            { id: "loc-en", name: "en", code: "en-US", default: true },
+            { id: "loc-fr", name: "fr", code: "fr-FR", default: false },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("api.phrase.com") && path.includes("/keys") && init?.method !== "POST") {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "key-1",
+              name: "hello",
+              description: "Greeting",
+              tags: ["hyperlocalise:job:phrase-job-1"],
+            },
+            {
+              id: "key-2",
+              name: "world",
+              description: null,
+              tags: ["other"],
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/translations?") && path.includes("locale_name=en")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "tr-en-1",
+              key_id: "key-1",
+              locale_name: "en",
+              content: "Hello",
+              state: "translated",
+              unverified: false,
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/translations?") && path.includes("locale_name=fr")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "tr-fr-1",
+              key_id: "key-1",
+              locale_name: "fr",
+              content: "Bonjour",
+              state: "translated",
+              unverified: false,
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify([]), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    globalThis.fetch = fetchMock;
+
+    const result = await pullPhraseTaskContent({
+      organizationId: "org_1",
+      projectId: "proj_1",
+      providerKind: "phrase",
+      externalProjectId: "strings-project-1",
+      externalJobId: "phrase-job-1-task-fr-fr",
+      credential: {
+        id: "cred_1",
+        region: null,
+        baseUrl: "https://cloud.memsource.com/web",
+      } as never,
+      project: {
+        providerMetadata: {
+          tmsProjectUid: "tms-project-1",
+          defaultBranch: "main",
+        },
+      } as never,
+      secretMaterial: "token",
+    });
+
+    expect(result).toMatchObject({
+      externalJobId: "phrase-job-1-task-fr-fr",
+      externalTaskId: "task-fr",
+      sourceLocale: "en-US",
+      targetLocales: ["fr-FR"],
+      providerPayload: {
+        branch: "main",
+        jobTag: "hyperlocalise:job:phrase-job-1",
+      },
+    });
+    expect(result.units).toHaveLength(1);
+    expect(result.units[0]).toMatchObject({
+      externalStringId: "key-1",
+      key: "hello",
+      sourceText: "Hello",
+      translations: [
+        {
+          locale: "fr-FR",
+          text: "Bonjour",
+          externalTranslationId: "tr-fr-1",
+          isApproved: true,
+        },
+      ],
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-content-puller.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-content-puller.test.ts
@@ -15,10 +15,10 @@ describe("pullPhraseTaskContent", () => {
 
   it("pulls scoped keys and translations for a Phrase TMS job", async () => {
     const fetchMock = vi.fn(async (url, init) => {
-      const path = String(url);
+      const requestUrl = new URL(String(url));
 
-      if (path.includes("cloud.memsource.com") && path.includes("/jobs")) {
-        const workflowLevel = Number(new URL(path).searchParams.get("workflowLevel") ?? "0");
+      if (requestUrl.hostname === "cloud.memsource.com" && requestUrl.pathname.includes("/jobs")) {
+        const workflowLevel = Number(requestUrl.searchParams.get("workflowLevel") ?? "0");
         if (workflowLevel === 1) {
           return new Response(
             JSON.stringify({
@@ -40,7 +40,7 @@ describe("pullPhraseTaskContent", () => {
         return new Response(JSON.stringify({ content: [], totalPages: 0 }), { status: 200 });
       }
 
-      if (path.includes("api.phrase.com") && path.includes("/locales")) {
+      if (requestUrl.hostname === "api.phrase.com" && requestUrl.pathname.includes("/locales")) {
         return new Response(
           JSON.stringify([
             { id: "loc-en", name: "en", code: "en-US", default: true },
@@ -50,7 +50,11 @@ describe("pullPhraseTaskContent", () => {
         );
       }
 
-      if (path.includes("api.phrase.com") && path.includes("/keys") && init?.method !== "POST") {
+      if (
+        requestUrl.hostname === "api.phrase.com" &&
+        requestUrl.pathname.includes("/keys") &&
+        init?.method !== "POST"
+      ) {
         return new Response(
           JSON.stringify([
             {
@@ -70,7 +74,7 @@ describe("pullPhraseTaskContent", () => {
         );
       }
 
-      if (path.includes("/translations?") && path.includes("locale_name=en")) {
+      if (requestUrl.pathname.includes("/translations") && requestUrl.searchParams.get("locale_name") === "en") {
         return new Response(
           JSON.stringify([
             {
@@ -86,7 +90,7 @@ describe("pullPhraseTaskContent", () => {
         );
       }
 
-      if (path.includes("/translations?") && path.includes("locale_name=fr")) {
+      if (requestUrl.pathname.includes("/translations") && requestUrl.searchParams.get("locale_name") === "fr") {
         return new Response(
           JSON.stringify([
             {

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-content-puller.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-content-puller.test.ts
@@ -74,7 +74,10 @@ describe("pullPhraseTaskContent", () => {
         );
       }
 
-      if (requestUrl.pathname.includes("/translations") && requestUrl.searchParams.get("locale_name") === "en") {
+      if (
+        requestUrl.pathname.includes("/translations") &&
+        requestUrl.searchParams.get("locale_name") === "en"
+      ) {
         return new Response(
           JSON.stringify([
             {
@@ -90,7 +93,10 @@ describe("pullPhraseTaskContent", () => {
         );
       }
 
-      if (requestUrl.pathname.includes("/translations") && requestUrl.searchParams.get("locale_name") === "fr") {
+      if (
+        requestUrl.pathname.includes("/translations") &&
+        requestUrl.searchParams.get("locale_name") === "fr"
+      ) {
         return new Response(
           JSON.stringify([
             {

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-content-puller.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-content-puller.test.ts
@@ -162,4 +162,50 @@ describe("pullPhraseTaskContent", () => {
       ],
     });
   });
+
+  it("throws when the job target locale cannot be resolved", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      const requestUrl = new URL(String(url));
+
+      if (requestUrl.hostname === "api.phrase.com" && requestUrl.pathname.includes("/locales")) {
+        return new Response(
+          JSON.stringify([
+            { id: "loc-en", name: "en", code: "en-US", default: true },
+            { id: "loc-de", name: "de", code: "de-DE", default: false },
+            { id: "loc-es", name: "es", code: "es-ES", default: false },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      if (requestUrl.hostname === "api.phrase.com" && requestUrl.pathname.includes("/keys")) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+
+      return new Response(JSON.stringify([]), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      pullPhraseTaskContent({
+        organizationId: "org_1",
+        projectId: "proj_1",
+        providerKind: "phrase",
+        externalProjectId: "strings-project-1",
+        externalJobId: "phrase-job-1-task-fr-fr",
+        credential: {
+          id: "cred_1",
+          region: null,
+          baseUrl: "https://cloud.memsource.com/web",
+        } as never,
+        project: {
+          providerMetadata: {
+            stringsProjectId: "strings-project-1",
+          },
+        } as never,
+        secretMaterial: "token",
+      }),
+    ).rejects.toThrow("phrase_task_missing_target_language");
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-content-puller.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-content-puller.ts
@@ -61,7 +61,7 @@ export const pullPhraseTaskContent: ExternalTmsContentPuller = async ({
   }
 
   let jobPart = null;
-  const tmsProjectUid = resolvePhraseTmsProjectUid(project);
+  const tmsProjectUid = resolvePhraseTmsProjectUid(project, externalProjectId);
   if (tmsProjectUid) {
     const tmsClient = new PhraseTmsApiClient({
       token: secretMaterial,

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-content-puller.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-content-puller.ts
@@ -1,0 +1,238 @@
+import type { ExternalTmsContentPuller } from "@/lib/providers/external-tms-content-sync";
+
+import {
+  PhraseApiError,
+  type PhraseKey,
+  type PhraseLocale,
+  type PhraseTranslation,
+} from "./phrase-api";
+import { createPhraseStringsApiClient } from "./phrase-strings-client";
+import {
+  buildPhraseJobScopeTag,
+  filterPhraseKeysForJobScope,
+  findPhraseTmsJobPart,
+  matchPhraseTargetLocale,
+  normalizePhraseTaskLocaleSuffix,
+  parsePhraseExternalJobId,
+  resolvePhraseBranch,
+  resolvePhraseStringsProjectId,
+  resolvePhraseTmsProjectUid,
+} from "./phrase-job-context";
+import { mapPhraseTranslationReadiness } from "./phrase-locale-readiness";
+import { PhraseTmsApiClient, mapPhraseTmsFetcherError } from "./phrase-tms-api";
+
+const LOCALE_FETCH_CONCURRENCY = 8;
+
+export const pullPhraseTaskContent: ExternalTmsContentPuller = async ({
+  credential,
+  externalProjectId,
+  externalJobId,
+  project,
+  secretMaterial,
+}) => {
+  const stringsProjectId = resolvePhraseStringsProjectId(project, externalProjectId);
+  if (!stringsProjectId) {
+    throw new Error("invalid_phrase_project_id");
+  }
+
+  const stringsClient = createPhraseStringsApiClient({
+    token: secretMaterial,
+    region: credential.region,
+    baseUrl: credential.baseUrl,
+  });
+
+  const branch = resolvePhraseBranch(project);
+  const listOptions = branch ? { branch } : {};
+
+  let locales: PhraseLocale[];
+  let keys: PhraseKey[];
+  try {
+    [locales, keys] = await Promise.all([
+      stringsClient.listLocales(stringsProjectId, listOptions),
+      stringsClient.listKeys(stringsProjectId, listOptions),
+    ]);
+  } catch (error) {
+    throw mapPhraseStringsError(error);
+  }
+
+  const parsedJobId = parsePhraseExternalJobId(externalJobId);
+  if (!parsedJobId) {
+    throw new Error("invalid_phrase_job_id");
+  }
+
+  let jobPart = null;
+  const tmsProjectUid = resolvePhraseTmsProjectUid(project, externalProjectId);
+  if (tmsProjectUid) {
+    const tmsClient = new PhraseTmsApiClient({
+      token: secretMaterial,
+      baseUrl: credential.baseUrl,
+    });
+
+    try {
+      const jobParts = await tmsClient.listAllJobParts(tmsProjectUid);
+      jobPart = findPhraseTmsJobPart({ externalJobId, jobParts });
+    } catch (error) {
+      throw mapPhraseTmsFetcherError(error);
+    }
+  }
+
+  const targetLocale =
+    (jobPart ? matchPhraseTargetLocale(jobPart.targetLang, locales) : null) ??
+    locales.find(
+      (locale) =>
+        !locale.default &&
+        normalizePhraseTaskLocaleSuffix(locale.code ?? locale.name) ===
+          parsedJobId.taskLocaleSuffix,
+    ) ??
+    locales.find((locale) => !locale.default);
+  if (!targetLocale) {
+    throw new Error("phrase_task_missing_target_language");
+  }
+
+  const sourceLocaleRef = locales.find((locale) => locale.default) ?? null;
+  const jobTag = buildPhraseJobScopeTag(parsedJobId.innerId);
+  const scopedKeys = filterPhraseKeysForJobScope({ keys, jobTag });
+
+  const localesToLoad = [sourceLocaleRef, targetLocale].filter(
+    (locale): locale is PhraseLocale => locale != null,
+  );
+
+  const translationsByKeyId = await loadTranslationsByKeyId({
+    client: stringsClient,
+    projectId: stringsProjectId,
+    locales: localesToLoad,
+    branch,
+    keyIds: scopedKeys.map((key) => key.id),
+  });
+
+  const units: Awaited<ReturnType<ExternalTmsContentPuller>>["units"] = scopedKeys.map((key) => {
+    const translationsByLocale = translationsByKeyId.get(key.id);
+    const sourceTranslation = sourceLocaleRef
+      ? translationsByLocale?.get(sourceLocaleRef.name)
+      : null;
+    const targetTranslation = translationsByLocale?.get(targetLocale.name);
+
+    const sourceText = sourceTranslation?.content?.trim() || key.name;
+    const targetEntries = [];
+
+    if (targetTranslation?.content?.trim()) {
+      const readiness = mapPhraseTranslationReadiness({
+        content: targetTranslation.content,
+        state: targetTranslation.state,
+        unverified: targetTranslation.unverified,
+        excluded: targetTranslation.excluded,
+      });
+
+      targetEntries.push({
+        locale: targetLocale.code?.trim() || targetLocale.name,
+        text: targetTranslation.content.trim(),
+        externalTranslationId: targetTranslation.id,
+        isApproved: readiness === "ready",
+      });
+    }
+
+    return {
+      externalStringId: key.id,
+      key: key.name,
+      sourceText,
+      context: key.description,
+      fileId: null,
+      translations: targetEntries,
+      providerPayload: {
+        branch,
+        jobTag,
+        tags: key.tags,
+        dataType: key.dataType,
+        customMetadata: key.customMetadata,
+      },
+    };
+  });
+
+  return {
+    externalJobId,
+    externalTaskId: jobPart?.uid ?? null,
+    sourceLocale: sourceLocaleRef?.code?.trim() || sourceLocaleRef?.name || null,
+    targetLocales: [targetLocale.code?.trim() || targetLocale.name],
+    units,
+    exportArtifact: null,
+    providerPayload: {
+      stringsProjectId,
+      tmsProjectUid,
+      branch,
+      jobTag,
+      innerId: parsedJobId.innerId,
+      filename: jobPart?.filename ?? null,
+      targetLang: jobPart?.targetLang ?? targetLocale.name,
+      workflowStep: jobPart?.workflowStep?.name ?? null,
+    },
+  };
+};
+
+async function loadTranslationsByKeyId(input: {
+  client: ReturnType<typeof createPhraseStringsApiClient>;
+  projectId: string;
+  locales: PhraseLocale[];
+  branch: string | null;
+  keyIds: string[];
+}) {
+  const keyIdSet = new Set(input.keyIds);
+  const translationsByKeyId = new Map<string, Map<string, PhraseTranslation>>();
+  const listOptions = input.branch ? { branch: input.branch } : {};
+  const localesToFetch = input.locales.filter((locale) => keyIdSet.size > 0);
+
+  await mapWithConcurrency(localesToFetch, LOCALE_FETCH_CONCURRENCY, async (locale) => {
+    try {
+      const translations = await input.client.listTranslations(
+        input.projectId,
+        locale.name,
+        listOptions,
+      );
+
+      for (const translation of translations) {
+        if (!translation.keyId || !keyIdSet.has(translation.keyId)) {
+          continue;
+        }
+
+        const byLocale =
+          translationsByKeyId.get(translation.keyId) ?? new Map<string, PhraseTranslation>();
+        byLocale.set(locale.name, translation);
+        translationsByKeyId.set(translation.keyId, byLocale);
+      }
+    } catch (error) {
+      throw mapPhraseStringsError(error);
+    }
+  });
+
+  return translationsByKeyId;
+}
+
+function mapPhraseStringsError(error: unknown) {
+  if (error instanceof PhraseApiError && error.status === 401) {
+    return new Error("phrase_auth_invalid");
+  }
+
+  return error instanceof Error ? error : new Error("phrase_fetch_failed");
+}
+
+async function mapWithConcurrency<T>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T) => Promise<void>,
+) {
+  let nextIndex = 0;
+
+  async function worker() {
+    while (true) {
+      const currentIndex = nextIndex;
+      nextIndex += 1;
+      if (currentIndex >= items.length) {
+        return;
+      }
+
+      await mapper(items[currentIndex] as T);
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, () => worker());
+  await Promise.all(workers);
+}

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-content-puller.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-content-puller.ts
@@ -61,7 +61,7 @@ export const pullPhraseTaskContent: ExternalTmsContentPuller = async ({
   }
 
   let jobPart = null;
-  const tmsProjectUid = resolvePhraseTmsProjectUid(project, externalProjectId);
+  const tmsProjectUid = resolvePhraseTmsProjectUid(project);
   if (tmsProjectUid) {
     const tmsClient = new PhraseTmsApiClient({
       token: secretMaterial,
@@ -83,8 +83,7 @@ export const pullPhraseTaskContent: ExternalTmsContentPuller = async ({
         !locale.default &&
         normalizePhraseTaskLocaleSuffix(locale.code ?? locale.name) ===
           parsedJobId.taskLocaleSuffix,
-    ) ??
-    locales.find((locale) => !locale.default);
+    );
   if (!targetLocale) {
     throw new Error("phrase_task_missing_target_language");
   }

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-content-puller.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-content-puller.ts
@@ -178,7 +178,9 @@ async function loadTranslationsByKeyId(input: {
   const keyIdSet = new Set(input.keyIds);
   const translationsByKeyId = new Map<string, Map<string, PhraseTranslation>>();
   const listOptions = input.branch ? { branch: input.branch } : {};
-  const localesToFetch = input.locales.filter((locale) => keyIdSet.size > 0);
+  if (keyIdSet.size === 0) return translationsByKeyId;
+
+  const localesToFetch = input.locales;
 
   await mapWithConcurrency(localesToFetch, LOCALE_FETCH_CONCURRENCY, async (locale) => {
     try {

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-job-context.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-job-context.test.ts
@@ -7,6 +7,7 @@ import {
   findPhraseTmsJobPart,
   normalizePhraseTaskLocaleSuffix,
   parsePhraseExternalJobId,
+  resolvePhraseTmsProjectUid,
 } from "./phrase-job-context";
 
 describe("phrase job context", () => {
@@ -43,6 +44,19 @@ describe("phrase job context", () => {
     });
 
     expect(jobPart?.uid).toBe("task-fr");
+  });
+
+  it("returns null when TMS project uid is absent from metadata", () => {
+    expect(
+      resolvePhraseTmsProjectUid({
+        providerMetadata: {},
+      }),
+    ).toBeNull();
+    expect(
+      resolvePhraseTmsProjectUid({
+        providerMetadata: { tmsProjectUid: "tms-project-1" },
+      }),
+    ).toBe("tms-project-1");
   });
 
   it("filters keys by job tag with fallback to all keys", () => {

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-job-context.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-job-context.test.ts
@@ -46,25 +46,48 @@ describe("phrase job context", () => {
     expect(jobPart?.uid).toBe("task-fr");
   });
 
-  it("returns null when TMS project uid is absent from metadata", () => {
+  it("prefers tmsProjectUid from metadata and falls back to externalProjectId", () => {
     expect(
-      resolvePhraseTmsProjectUid({
-        providerMetadata: {},
-      }),
+      resolvePhraseTmsProjectUid(
+        {
+          providerMetadata: { tmsProjectUid: "tms-project-1" },
+        },
+        "legacy-project-id",
+      ),
+    ).toBe("tms-project-1");
+    expect(
+      resolvePhraseTmsProjectUid(
+        {
+          providerMetadata: {},
+        },
+        "legacy-project-id",
+      ),
+    ).toBe("legacy-project-id");
+    expect(
+      resolvePhraseTmsProjectUid(
+        {
+          providerMetadata: {},
+        },
+        "",
+      ),
     ).toBeNull();
     expect(
-      resolvePhraseTmsProjectUid({
-        providerMetadata: { tmsProjectUid: "tms-project-1" },
-      }),
-    ).toBe("tms-project-1");
+      resolvePhraseTmsProjectUid(
+        {
+          providerMetadata: { stringsProjectId: "strings-project-1" },
+        },
+        "strings-project-1",
+      ),
+    ).toBeNull();
   });
 
-  it("filters keys by job tag with fallback to all keys", () => {
+  it("filters keys by job tag and returns none when no keys match", () => {
     const keys = [{ tags: ["hyperlocalise:job:job-1"] }, { tags: ["other"] }];
 
     expect(filterPhraseKeysForJobScope({ keys, jobTag: "hyperlocalise:job:job-1" })).toHaveLength(
       1,
     );
-    expect(filterPhraseKeysForJobScope({ keys, jobTag: "missing" })).toHaveLength(2);
+    expect(filterPhraseKeysForJobScope({ keys, jobTag: "missing" })).toHaveLength(0);
+    expect(filterPhraseKeysForJobScope({ keys, jobTag: null })).toHaveLength(2);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-job-context.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-job-context.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  buildPhraseExternalJobId,
+  buildPhraseJobScopeTag,
+  filterPhraseKeysForJobScope,
+  findPhraseTmsJobPart,
+  normalizePhraseTaskLocaleSuffix,
+  parsePhraseExternalJobId,
+} from "./phrase-job-context";
+
+describe("phrase job context", () => {
+  it("parses and builds external job ids", () => {
+    expect(parsePhraseExternalJobId("phrase-job-1-task-fr-fr")).toEqual({
+      innerId: "phrase-job-1",
+      taskLocaleSuffix: "fr-fr",
+    });
+    expect(buildPhraseExternalJobId("phrase-job-1", "fr-FR")).toBe("phrase-job-1-task-fr-fr");
+    expect(normalizePhraseTaskLocaleSuffix("fr_FR")).toBe("fr-fr");
+  });
+
+  it("builds stable job scope tags", () => {
+    expect(buildPhraseJobScopeTag("phrase-job-1")).toBe("hyperlocalise:job:phrase-job-1");
+  });
+
+  it("finds TMS job parts by external job id", () => {
+    const jobPart = findPhraseTmsJobPart({
+      externalJobId: "phrase-job-1-task-fr-fr",
+      jobParts: [
+        {
+          uid: "task-fr",
+          innerId: "phrase-job-1",
+          status: "NEW",
+          targetLang: "fr-FR",
+          filename: "Homepage",
+          dateDue: null,
+          dateCreated: null,
+          workflowStep: null,
+          owner: null,
+          importStatus: null,
+        },
+      ],
+    });
+
+    expect(jobPart?.uid).toBe("task-fr");
+  });
+
+  it("filters keys by job tag with fallback to all keys", () => {
+    const keys = [{ tags: ["hyperlocalise:job:job-1"] }, { tags: ["other"] }];
+
+    expect(filterPhraseKeysForJobScope({ keys, jobTag: "hyperlocalise:job:job-1" })).toHaveLength(
+      1,
+    );
+    expect(filterPhraseKeysForJobScope({ keys, jobTag: "missing" })).toHaveLength(2);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-job-context.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-job-context.ts
@@ -46,10 +46,9 @@ export function resolvePhraseStringsProjectId(
   return externalProjectId.trim();
 }
 
-export function resolvePhraseTmsProjectUid(
-  project: { providerMetadata: Record<string, unknown> },
-  externalProjectId: string,
-) {
+export function resolvePhraseTmsProjectUid(project: {
+  providerMetadata: Record<string, unknown>;
+}): string | null {
   const metadata = project.providerMetadata ?? {};
   const tmsProjectUid =
     typeof metadata.tmsProjectUid === "string" ? metadata.tmsProjectUid.trim() : "";
@@ -57,7 +56,7 @@ export function resolvePhraseTmsProjectUid(
     return tmsProjectUid;
   }
 
-  return externalProjectId.trim();
+  return null;
 }
 
 export function resolvePhraseBranch(project: { providerMetadata: Record<string, unknown> }) {

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-job-context.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-job-context.ts
@@ -46,9 +46,10 @@ export function resolvePhraseStringsProjectId(
   return externalProjectId.trim();
 }
 
-export function resolvePhraseTmsProjectUid(project: {
-  providerMetadata: Record<string, unknown>;
-}): string | null {
+export function resolvePhraseTmsProjectUid(
+  project: { providerMetadata: Record<string, unknown> },
+  externalProjectId: string,
+): string | null {
   const metadata = project.providerMetadata ?? {};
   const tmsProjectUid =
     typeof metadata.tmsProjectUid === "string" ? metadata.tmsProjectUid.trim() : "";
@@ -56,7 +57,14 @@ export function resolvePhraseTmsProjectUid(project: {
     return tmsProjectUid;
   }
 
-  return null;
+  const stringsProjectId =
+    typeof metadata.stringsProjectId === "string" ? metadata.stringsProjectId.trim() : "";
+  if (stringsProjectId) {
+    return null;
+  }
+
+  const fallback = externalProjectId.trim();
+  return fallback || null;
 }
 
 export function resolvePhraseBranch(project: { providerMetadata: Record<string, unknown> }) {
@@ -122,6 +130,5 @@ export function filterPhraseKeysForJobScope<T extends { tags: string[] }>(input:
     return input.keys;
   }
 
-  const scoped = input.keys.filter((key) => key.tags.includes(input.jobTag as string));
-  return scoped.length > 0 ? scoped : input.keys;
+  return input.keys.filter((key) => key.tags.includes(input.jobTag as string));
 }

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-job-context.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-job-context.ts
@@ -1,0 +1,128 @@
+import type { PhraseLocale } from "./phrase-api";
+import type { PhraseTmsJobPart } from "./phrase-tms-api";
+
+const PHRASE_EXTERNAL_JOB_ID_PATTERN = /^(.+)-task-([a-z0-9]+(?:-[a-z0-9]+)*)$/;
+
+export function parsePhraseExternalJobId(externalJobId: string) {
+  const match = externalJobId.trim().match(PHRASE_EXTERNAL_JOB_ID_PATTERN);
+  if (!match) {
+    return null;
+  }
+
+  return {
+    innerId: match[1],
+    taskLocaleSuffix: match[2],
+  };
+}
+
+export function normalizePhraseTaskLocaleSuffix(targetLang: string) {
+  const normalized = targetLang.trim().toLowerCase();
+  if (!normalized) {
+    return "unknown";
+  }
+
+  return normalized.replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+export function buildPhraseExternalJobId(innerId: string, targetLang: string) {
+  return `${innerId.trim()}-task-${normalizePhraseTaskLocaleSuffix(targetLang)}`;
+}
+
+export function buildPhraseJobScopeTag(innerId: string) {
+  return `hyperlocalise:job:${innerId.trim()}`;
+}
+
+export function resolvePhraseStringsProjectId(
+  project: { providerMetadata: Record<string, unknown> },
+  externalProjectId: string,
+) {
+  const metadata = project.providerMetadata ?? {};
+  const stringsProjectId =
+    typeof metadata.stringsProjectId === "string" ? metadata.stringsProjectId.trim() : "";
+  if (stringsProjectId) {
+    return stringsProjectId;
+  }
+
+  return externalProjectId.trim();
+}
+
+export function resolvePhraseTmsProjectUid(
+  project: { providerMetadata: Record<string, unknown> },
+  externalProjectId: string,
+) {
+  const metadata = project.providerMetadata ?? {};
+  const tmsProjectUid =
+    typeof metadata.tmsProjectUid === "string" ? metadata.tmsProjectUid.trim() : "";
+  if (tmsProjectUid) {
+    return tmsProjectUid;
+  }
+
+  return externalProjectId.trim();
+}
+
+export function resolvePhraseBranch(project: { providerMetadata: Record<string, unknown> }) {
+  const metadata = project.providerMetadata ?? {};
+  if (typeof metadata.defaultBranch === "string" && metadata.defaultBranch.trim()) {
+    return metadata.defaultBranch.trim();
+  }
+  if (typeof metadata.branch === "string" && metadata.branch.trim()) {
+    return metadata.branch.trim();
+  }
+
+  return null;
+}
+
+export function matchPhraseTargetLocale(targetLang: string, locales: PhraseLocale[]) {
+  const normalized = targetLang.trim().toLowerCase();
+  if (!normalized) {
+    return null;
+  }
+
+  for (const locale of locales) {
+    if (locale.name.trim().toLowerCase() === normalized) {
+      return locale;
+    }
+    if (locale.code?.trim().toLowerCase() === normalized) {
+      return locale;
+    }
+  }
+
+  const suffix = normalizePhraseTaskLocaleSuffix(targetLang);
+  for (const locale of locales) {
+    if (normalizePhraseTaskLocaleSuffix(locale.code ?? locale.name) === suffix) {
+      return locale;
+    }
+  }
+
+  return null;
+}
+
+export function findPhraseTmsJobPart(input: {
+  externalJobId: string;
+  jobParts: PhraseTmsJobPart[];
+}) {
+  const parsed = parsePhraseExternalJobId(input.externalJobId);
+  if (!parsed) {
+    return null;
+  }
+
+  return (
+    input.jobParts.find(
+      (jobPart) =>
+        jobPart.innerId === parsed.innerId &&
+        normalizePhraseTaskLocaleSuffix(jobPart.targetLang) === parsed.taskLocaleSuffix,
+    ) ?? null
+  );
+}
+
+export function filterPhraseKeysForJobScope<T extends { tags: string[] }>(input: {
+  keys: T[];
+  jobTag: string | null;
+}) {
+  if (!input.jobTag) {
+    return input.keys;
+  }
+
+  const scoped = input.keys.filter((key) => key.tags.includes(input.jobTag as string));
+  return scoped.length > 0 ? scoped : input.keys;
+}

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-job-task-fetcher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-job-task-fetcher.test.ts
@@ -5,6 +5,10 @@ import { fetchPhraseJobTasks } from "./phrase-job-task-fetcher";
 describe("fetchPhraseJobTasks", () => {
   let originalFetch: typeof fetch;
 
+  const tmsProject = {
+    providerMetadata: { tmsProjectUid: "phrase-project-1" },
+  } as never;
+
   const credential = {
     id: "cred-1",
     organizationId: "org-1",
@@ -94,9 +98,7 @@ describe("fetchPhraseJobTasks", () => {
       providerKind: "phrase",
       externalProjectId: "phrase-project-1",
       credential,
-      project: {
-        providerMetadata: {},
-      } as never,
+      project: tmsProject,
       secretMaterial: "secret-token",
     });
 
@@ -158,7 +160,7 @@ describe("fetchPhraseJobTasks", () => {
       providerKind: "phrase",
       externalProjectId: "phrase-project-1",
       credential,
-      project: { providerMetadata: {} } as never,
+      project: tmsProject,
       secretMaterial: "secret-token",
     });
 
@@ -210,7 +212,7 @@ describe("fetchPhraseJobTasks", () => {
       providerKind: "phrase",
       externalProjectId: "phrase-project-1",
       credential,
-      project: { providerMetadata: {} } as never,
+      project: tmsProject,
       secretMaterial: "secret-token",
     });
 
@@ -260,9 +262,11 @@ describe("fetchPhraseJobTasks", () => {
       organizationId: "org-1",
       projectId: "project-1",
       providerKind: "phrase",
-      externalProjectId: "phrase-project-eu",
+      externalProjectId: "strings-project-eu",
       credential: euCredential,
-      project: { providerMetadata: {} } as never,
+      project: {
+        providerMetadata: { tmsProjectUid: "phrase-project-eu" },
+      } as never,
       secretMaterial: "secret-token",
     });
 
@@ -325,7 +329,7 @@ describe("fetchPhraseJobTasks", () => {
         providerKind: "phrase",
         externalProjectId: "phrase-project-1",
         credential,
-        project: { providerMetadata: {} } as never,
+        project: tmsProject,
         secretMaterial: "secret-token",
       }),
     ).rejects.toThrow("phrase_auth_invalid");

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-job-task-fetcher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-job-task-fetcher.ts
@@ -1,5 +1,6 @@
 import type { ExternalTmsJobTaskFetcher } from "@/lib/providers/external-tms-job-sync";
 
+import { buildPhraseExternalJobId } from "./phrase-job-context";
 import {
   mapPhraseTmsFetcherError,
   PhraseTmsApiClient,
@@ -48,8 +49,7 @@ export const fetchPhraseJobTasks: ExternalTmsJobTaskFetcher = async ({
       });
 
       const targetLocale = jobPart.targetLang;
-      const taskSuffix = normalizeTaskLocaleSuffix(targetLocale);
-      const externalJobId = `${jobPart.innerId}-task-${taskSuffix}`;
+      const externalJobId = buildPhraseExternalJobId(jobPart.innerId, targetLocale);
       const assignedUsers = [jobPart.owner?.userName?.trim(), jobPart.owner?.email?.trim()].filter(
         (value): value is string => Boolean(value),
       );
@@ -152,15 +152,6 @@ function buildPhraseJobTitle(jobPart: PhraseTmsJobPart) {
   }
 
   return `${filename} (${jobPart.targetLang})`;
-}
-
-function normalizeTaskLocaleSuffix(targetLang: string) {
-  const normalized = targetLang.trim().toLowerCase();
-  if (!normalized) {
-    return "unknown";
-  }
-
-  return normalized.replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
 }
 
 function buildPhraseTmsJobUrl(baseUrl: string, projectUid: string, jobUid: string) {

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-job-task-fetcher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-job-task-fetcher.ts
@@ -10,11 +10,11 @@ import {
 
 export const fetchPhraseJobTasks: ExternalTmsJobTaskFetcher = async ({
   credential,
-  externalProjectId: _externalProjectId,
+  externalProjectId,
   project,
   secretMaterial,
 }) => {
-  const tmsProjectUid = resolvePhraseTmsProjectUid(project);
+  const tmsProjectUid = resolvePhraseTmsProjectUid(project, externalProjectId);
 
   if (!tmsProjectUid) {
     throw new Error("invalid_phrase_project_id");

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-job-task-fetcher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-job-task-fetcher.ts
@@ -1,6 +1,6 @@
 import type { ExternalTmsJobTaskFetcher } from "@/lib/providers/external-tms-job-sync";
 
-import { buildPhraseExternalJobId } from "./phrase-job-context";
+import { buildPhraseExternalJobId, resolvePhraseTmsProjectUid } from "./phrase-job-context";
 import {
   mapPhraseTmsFetcherError,
   PhraseTmsApiClient,
@@ -10,16 +10,13 @@ import {
 
 export const fetchPhraseJobTasks: ExternalTmsJobTaskFetcher = async ({
   credential,
-  externalProjectId,
+  externalProjectId: _externalProjectId,
   project,
   secretMaterial,
 }) => {
-  const tmsProjectUid = resolvePhraseTmsProjectUid({
-    externalProjectId,
-    providerMetadata: project.providerMetadata,
-  });
+  const tmsProjectUid = resolvePhraseTmsProjectUid(project);
 
-  if (!tmsProjectUid.trim()) {
+  if (!tmsProjectUid) {
     throw new Error("invalid_phrase_project_id");
   }
 
@@ -84,21 +81,6 @@ type JobResourceBundle = {
   translationMemories: PhraseTmsResourceReference[];
   termBases: PhraseTmsResourceReference[];
 };
-
-function resolvePhraseTmsProjectUid(input: {
-  externalProjectId: string;
-  providerMetadata: Record<string, unknown>;
-}) {
-  const metadataUid =
-    typeof input.providerMetadata.tmsProjectUid === "string"
-      ? input.providerMetadata.tmsProjectUid.trim()
-      : "";
-  if (metadataUid) {
-    return metadataUid;
-  }
-
-  return input.externalProjectId.trim();
-}
 
 async function loadProjectTermBases(client: PhraseTmsApiClient, projectUid: string) {
   try {

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-strings-client.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-strings-client.ts
@@ -23,8 +23,15 @@ function resolvePhraseStringsApiBaseUrl(baseUrl?: string | null) {
     return trimmed;
   }
 
-  if (trimmed.includes("api.phrase.com") || trimmed.includes("api.us.app.phrase.com")) {
-    return trimmed.replace(/\/+$/, "");
+  try {
+    const parsed = new URL(trimmed);
+    const allowedHosts = new Set(["api.phrase.com", "api.us.app.phrase.com"]);
+
+    if (parsed.protocol === "https:" && allowedHosts.has(parsed.hostname)) {
+      return trimmed.replace(/\/+$/, "");
+    }
+  } catch {
+    return null;
   }
 
   return null;

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-strings-client.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-strings-client.ts
@@ -1,0 +1,31 @@
+import { PHRASE_EU_BASE_URL, PHRASE_US_BASE_URL } from "./phrase-base-url";
+import { PhraseApiClient } from "./phrase-api";
+
+export function createPhraseStringsApiClient(input: {
+  token: string;
+  region?: string | null;
+  baseUrl?: string | null;
+}) {
+  return new PhraseApiClient({
+    token: input.token,
+    region: input.region,
+    baseUrl: resolvePhraseStringsApiBaseUrl(input.baseUrl),
+  });
+}
+
+function resolvePhraseStringsApiBaseUrl(baseUrl?: string | null) {
+  const trimmed = baseUrl?.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  if (trimmed === PHRASE_EU_BASE_URL || trimmed === PHRASE_US_BASE_URL) {
+    return trimmed;
+  }
+
+  if (trimmed.includes("api.phrase.com") || trimmed.includes("api.us.app.phrase.com")) {
+    return trimmed.replace(/\/+$/, "");
+  }
+
+  return null;
+}

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-translation-pusher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-translation-pusher.test.ts
@@ -161,4 +161,76 @@ describe("pushPhraseTranslations", () => {
       name: "world",
     });
   });
+
+  it("skips TMS lookups when tmsProjectUid is absent from metadata", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      const parsedUrl = new URL(String(url));
+
+      if (parsedUrl.hostname === "cloud.memsource.com") {
+        throw new Error("TMS API should not be called for Strings-only projects");
+      }
+
+      if (parsedUrl.hostname === "api.phrase.com" && parsedUrl.pathname.includes("/keys")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "key-1",
+              name: "hello",
+              description: null,
+              tags: [],
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      if (parsedUrl.hostname === "api.phrase.com" && parsedUrl.pathname.includes("/translations")) {
+        return new Response(
+          JSON.stringify({
+            id: "tr-fr-1",
+            key_id: "key-1",
+            locale_name: "fr-FR",
+            content: "Bonjour",
+            state: "translated",
+            unverified: false,
+          }),
+          { status: 201 },
+        );
+      }
+
+      return new Response(JSON.stringify([]), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    globalThis.fetch = fetchMock;
+
+    const result = await pushPhraseTranslations({
+      organizationId: "org_1",
+      projectId: "proj_1",
+      providerKind: "phrase",
+      externalProjectId: "strings-project-1",
+      externalJobId: "phrase-job-1-task-fr-fr",
+      credential: {
+        id: "cred_1",
+        region: null,
+        baseUrl: "https://cloud.memsource.com/web",
+      } as never,
+      project: {
+        providerMetadata: {
+          stringsProjectId: "strings-project-1",
+          defaultBranch: "main",
+        },
+      } as never,
+      secretMaterial: "token",
+      translations: [{ locale: "fr-FR", key: "hello", text: "Bonjour" }],
+    });
+
+    expect(result.uploaded).toBe(1);
+    expect(
+      vi
+        .mocked(fetchMock)
+        .mock.calls.some(([requestUrl]) =>
+          requestUrlString(requestUrl).includes("cloud.memsource.com"),
+        ),
+    ).toBe(false);
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-translation-pusher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-translation-pusher.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
+import { requestBodyString, requestUrlString } from "../fetch-mock-helpers";
 import { pushPhraseTranslations } from "./phrase-translation-pusher";
 
 describe("pushPhraseTranslations", () => {
@@ -48,7 +49,7 @@ describe("pushPhraseTranslations", () => {
             {
               id: "key-1",
               name: "hello",
-              description: null,
+              description: "Greeting",
               tags: ["hyperlocalise:job:phrase-job-1"],
             },
           ]),
@@ -106,7 +107,7 @@ describe("pushPhraseTranslations", () => {
       } as never,
       secretMaterial: "token",
       translations: [
-        { locale: "fr-FR", key: "hello", externalStringId: "key-1", text: "Bonjour" },
+        { locale: "fr-FR", key: "hello", text: "Bonjour" },
         { locale: "fr-FR", key: "world", text: "Monde" },
       ],
     });
@@ -136,16 +137,28 @@ describe("pushPhraseTranslations", () => {
     const translationRequests = vi
       .mocked(fetchMock)
       .mock.calls.filter(([requestUrl, requestInit]) => {
-        return String(requestUrl).includes("/translations") && requestInit?.method === "POST";
+        return (
+          requestUrlString(requestUrl).includes("/translations") && requestInit?.method === "POST"
+        );
       });
 
     expect(translationRequests).toHaveLength(2);
-    expect(String(translationRequests[0]?.[0])).toContain("branch=main");
-    expect(JSON.parse(String(translationRequests[0]?.[1]?.body))).toMatchObject({
+    expect(requestUrlString(translationRequests[0]![0])).toContain("branch=main");
+    expect(JSON.parse(requestBodyString(translationRequests[0]?.[1]?.body))).toMatchObject({
       key_id: "key-1",
       locale_name: "fr-FR",
       content: "Bonjour",
       unverified: false,
+    });
+
+    const createKeyRequests = vi
+      .mocked(fetchMock)
+      .mock.calls.filter(([requestUrl, requestInit]) => {
+        return requestUrlString(requestUrl).includes("/keys") && requestInit?.method === "POST";
+      });
+    expect(createKeyRequests).toHaveLength(1);
+    expect(JSON.parse(requestBodyString(createKeyRequests[0]?.[1]?.body))).toMatchObject({
+      name: "world",
     });
   });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-translation-pusher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-translation-pusher.test.ts
@@ -228,8 +228,9 @@ describe("pushPhraseTranslations", () => {
     expect(
       vi
         .mocked(fetchMock)
-        .mock.calls.some(([requestUrl]) =>
-          new URL(requestUrlString(requestUrl)).hostname === "cloud.memsource.com",
+        .mock.calls.some(
+          ([requestUrl]) =>
+            new URL(requestUrlString(requestUrl)).hostname === "cloud.memsource.com",
         ),
     ).toBe(false);
   });

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-translation-pusher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-translation-pusher.test.ts
@@ -229,7 +229,7 @@ describe("pushPhraseTranslations", () => {
       vi
         .mocked(fetchMock)
         .mock.calls.some(([requestUrl]) =>
-          requestUrlString(requestUrl).includes("cloud.memsource.com"),
+          new URL(requestUrlString(requestUrl)).hostname === "cloud.memsource.com",
         ),
     ).toBe(false);
   });

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-translation-pusher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-translation-pusher.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { pushPhraseTranslations } from "./phrase-translation-pusher";
+
+describe("pushPhraseTranslations", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("upserts approved translations with branch and job tag context", async () => {
+    const fetchMock = vi.fn(async (url, init) => {
+      const path = String(url);
+
+      if (path.includes("cloud.memsource.com") && path.includes("/jobs")) {
+        const workflowLevel = Number(new URL(path).searchParams.get("workflowLevel") ?? "0");
+        if (workflowLevel === 1) {
+          return new Response(
+            JSON.stringify({
+              content: [
+                {
+                  uid: "task-fr",
+                  innerId: "phrase-job-1",
+                  status: "NEW",
+                  targetLang: "fr-FR",
+                  filename: "Homepage French",
+                },
+              ],
+              totalPages: 1,
+            }),
+            { status: 200 },
+          );
+        }
+
+        return new Response(JSON.stringify({ content: [], totalPages: 0 }), { status: 200 });
+      }
+
+      if (path.includes("api.phrase.com") && path.includes("/keys") && init?.method !== "POST") {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "key-1",
+              name: "hello",
+              description: null,
+              tags: ["hyperlocalise:job:phrase-job-1"],
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("api.phrase.com") && path.includes("/keys") && init?.method === "POST") {
+        return new Response(
+          JSON.stringify({
+            id: "key-2",
+            name: "world",
+            description: null,
+            tags: ["hyperlocalise:job:phrase-job-1"],
+          }),
+          { status: 201 },
+        );
+      }
+
+      if (path.includes("api.phrase.com") && path.includes("/translations")) {
+        return new Response(
+          JSON.stringify({
+            id: "tr-fr-2",
+            key_id: "key-2",
+            locale_name: "fr-FR",
+            content: "Monde",
+            state: "translated",
+            unverified: false,
+          }),
+          { status: 201 },
+        );
+      }
+
+      return new Response(JSON.stringify([]), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    globalThis.fetch = fetchMock;
+
+    const result = await pushPhraseTranslations({
+      organizationId: "org_1",
+      projectId: "proj_1",
+      providerKind: "phrase",
+      externalProjectId: "strings-project-1",
+      externalJobId: "phrase-job-1-task-fr-fr",
+      credential: {
+        id: "cred_1",
+        region: null,
+        baseUrl: "https://cloud.memsource.com/web",
+      } as never,
+      project: {
+        providerMetadata: {
+          tmsProjectUid: "tms-project-1",
+          defaultBranch: "main",
+        },
+      } as never,
+      secretMaterial: "token",
+      translations: [
+        { locale: "fr-FR", key: "hello", externalStringId: "key-1", text: "Bonjour" },
+        { locale: "fr-FR", key: "world", text: "Monde" },
+      ],
+    });
+
+    expect(result.uploaded).toBe(2);
+    expect(result.failed).toBe(0);
+    expect(result.asyncOperations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "phrase_upsert_translation",
+          keyId: "key-1",
+          locale: "fr-FR",
+          branch: "main",
+          jobTag: "hyperlocalise:job:phrase-job-1",
+          status: "succeeded",
+        }),
+        expect.objectContaining({
+          type: "phrase_upsert_translation",
+          keyId: "key-2",
+          locale: "fr-FR",
+          branch: "main",
+          status: "succeeded",
+        }),
+      ]),
+    );
+
+    const translationRequests = vi
+      .mocked(fetchMock)
+      .mock.calls.filter(([requestUrl, requestInit]) => {
+        return String(requestUrl).includes("/translations") && requestInit?.method === "POST";
+      });
+
+    expect(translationRequests).toHaveLength(2);
+    expect(String(translationRequests[0]?.[0])).toContain("branch=main");
+    expect(JSON.parse(String(translationRequests[0]?.[1]?.body))).toMatchObject({
+      key_id: "key-1",
+      locale_name: "fr-FR",
+      content: "Bonjour",
+      unverified: false,
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-translation-pusher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-translation-pusher.test.ts
@@ -15,10 +15,12 @@ describe("pushPhraseTranslations", () => {
 
   it("upserts approved translations with branch and job tag context", async () => {
     const fetchMock = vi.fn(async (url, init) => {
-      const path = String(url);
+      const parsedUrl = new URL(String(url));
+      const host = parsedUrl.hostname;
+      const pathname = parsedUrl.pathname;
 
-      if (path.includes("cloud.memsource.com") && path.includes("/jobs")) {
-        const workflowLevel = Number(new URL(path).searchParams.get("workflowLevel") ?? "0");
+      if (host === "cloud.memsource.com" && pathname.includes("/jobs")) {
+        const workflowLevel = Number(parsedUrl.searchParams.get("workflowLevel") ?? "0");
         if (workflowLevel === 1) {
           return new Response(
             JSON.stringify({
@@ -40,7 +42,7 @@ describe("pushPhraseTranslations", () => {
         return new Response(JSON.stringify({ content: [], totalPages: 0 }), { status: 200 });
       }
 
-      if (path.includes("api.phrase.com") && path.includes("/keys") && init?.method !== "POST") {
+      if (host === "api.phrase.com" && pathname.includes("/keys") && init?.method !== "POST") {
         return new Response(
           JSON.stringify([
             {
@@ -54,7 +56,7 @@ describe("pushPhraseTranslations", () => {
         );
       }
 
-      if (path.includes("api.phrase.com") && path.includes("/keys") && init?.method === "POST") {
+      if (host === "api.phrase.com" && pathname.includes("/keys") && init?.method === "POST") {
         return new Response(
           JSON.stringify({
             id: "key-2",
@@ -66,7 +68,7 @@ describe("pushPhraseTranslations", () => {
         );
       }
 
-      if (path.includes("api.phrase.com") && path.includes("/translations")) {
+      if (host === "api.phrase.com" && pathname.includes("/translations")) {
         return new Response(
           JSON.stringify({
             id: "tr-fr-2",

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-translation-pusher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-translation-pusher.ts
@@ -137,7 +137,7 @@ async function loadKeysByName(
   const keysByName = new Map<string, { id: string; tags: string[] }>();
 
   for (const key of keys) {
-    keysByName.set(buildKeyLookup(key.name, key.description), {
+    keysByName.set(buildKeyLookup(key.name), {
       id: key.id,
       tags: key.tags,
     });
@@ -161,7 +161,7 @@ async function resolvePhraseKeyId(input: {
     return input.entry.keyId;
   }
 
-  const lookup = buildKeyLookup(input.entry.key, null);
+  const lookup = buildKeyLookup(input.entry.key);
   const existing = input.keysByName.get(lookup);
   if (existing) {
     return existing.id;
@@ -178,8 +178,8 @@ async function resolvePhraseKeyId(input: {
   return created.id;
 }
 
-function buildKeyLookup(name: string, description: string | null) {
-  return `${name.trim()}\x00${description?.trim() ?? ""}`;
+function buildKeyLookup(name: string) {
+  return name.trim();
 }
 
 function mapPhraseStringsError(error: unknown) {

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-translation-pusher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-translation-pusher.ts
@@ -1,0 +1,191 @@
+import type { ExternalTmsTranslationPusher } from "@/lib/providers/external-tms-content-sync";
+
+import { PhraseApiError } from "./phrase-api";
+import { createPhraseStringsApiClient } from "./phrase-strings-client";
+import {
+  buildPhraseJobScopeTag,
+  findPhraseTmsJobPart,
+  parsePhraseExternalJobId,
+  resolvePhraseBranch,
+  resolvePhraseStringsProjectId,
+  resolvePhraseTmsProjectUid,
+} from "./phrase-job-context";
+import { PhraseTmsApiClient, mapPhraseTmsFetcherError } from "./phrase-tms-api";
+import { buildPhraseTranslationWriteBackGroups } from "./phrase-write-back";
+
+export const pushPhraseTranslations: ExternalTmsTranslationPusher = async ({
+  credential,
+  externalProjectId,
+  externalJobId,
+  project,
+  secretMaterial,
+  translations,
+}) => {
+  const stringsProjectId = resolvePhraseStringsProjectId(project, externalProjectId);
+  if (!stringsProjectId) {
+    throw new Error("invalid_phrase_project_id");
+  }
+
+  const parsedJobId = parsePhraseExternalJobId(externalJobId);
+  if (!parsedJobId) {
+    throw new Error("invalid_phrase_job_id");
+  }
+
+  const branch = resolvePhraseBranch(project);
+  let defaultTargetLocale: string | null = null;
+
+  const tmsProjectUid = resolvePhraseTmsProjectUid(project, externalProjectId);
+  if (tmsProjectUid) {
+    const tmsClient = new PhraseTmsApiClient({
+      token: secretMaterial,
+      baseUrl: credential.baseUrl,
+    });
+
+    try {
+      const jobParts = await tmsClient.listAllJobParts(tmsProjectUid);
+      const jobPart = findPhraseTmsJobPart({ externalJobId, jobParts });
+      defaultTargetLocale = jobPart?.targetLang?.trim() || null;
+    } catch (error) {
+      throw mapPhraseTmsFetcherError(error);
+    }
+  }
+
+  const jobTag = buildPhraseJobScopeTag(parsedJobId.innerId);
+  const { groups, failures: payloadFailures } = buildPhraseTranslationWriteBackGroups({
+    translations,
+    branch,
+    jobTag,
+    defaultTargetLocale,
+  });
+
+  const client = createPhraseStringsApiClient({
+    token: secretMaterial,
+    region: credential.region,
+    baseUrl: credential.baseUrl,
+  });
+
+  let uploaded = 0;
+  let failed = payloadFailures.length;
+  const failures = [...payloadFailures];
+  const asyncOperations: Array<Record<string, unknown>> = [];
+
+  let keysByName: KeysByName;
+  try {
+    keysByName = await loadKeysByName(client, stringsProjectId, branch);
+  } catch (error) {
+    throw mapPhraseStringsError(error);
+  }
+
+  for (const group of groups) {
+    for (const entry of group.entries) {
+      try {
+        const resolvedKeyId = await resolvePhraseKeyId({
+          client,
+          projectId: stringsProjectId,
+          keysByName,
+          entry,
+        });
+
+        await client.upsertTranslation(stringsProjectId, {
+          keyId: resolvedKeyId,
+          localeName: entry.locale,
+          content: entry.text,
+          branch: entry.branch,
+          unverified: false,
+        });
+
+        uploaded += 1;
+        asyncOperations.push({
+          type: "phrase_upsert_translation",
+          keyId: resolvedKeyId,
+          locale: entry.locale,
+          branch: entry.branch,
+          jobTag: entry.jobTag,
+          status: "succeeded",
+        });
+      } catch (error) {
+        failed += 1;
+        failures.push({
+          locale: entry.locale,
+          fileId: null,
+          message: error instanceof Error ? error.message : "phrase translation upload failed",
+        });
+        asyncOperations.push({
+          type: "phrase_upsert_translation",
+          locale: entry.locale,
+          branch: entry.branch,
+          jobTag: entry.jobTag,
+          status: "failed",
+          error: error instanceof Error ? error.message : "phrase translation upload failed",
+        });
+      }
+    }
+  }
+
+  return { uploaded, failed, failures, asyncOperations };
+};
+
+type KeysByName = Map<string, { id: string; tags: string[] }>;
+
+async function loadKeysByName(
+  client: ReturnType<typeof createPhraseStringsApiClient>,
+  projectId: string,
+  branch: string | null,
+) {
+  const listOptions = branch ? { branch } : {};
+  const keys = await client.listKeys(projectId, listOptions);
+  const keysByName = new Map<string, { id: string; tags: string[] }>();
+
+  for (const key of keys) {
+    keysByName.set(buildKeyLookup(key.name, key.description), {
+      id: key.id,
+      tags: key.tags,
+    });
+  }
+
+  return keysByName;
+}
+
+async function resolvePhraseKeyId(input: {
+  client: ReturnType<typeof createPhraseStringsApiClient>;
+  projectId: string;
+  keysByName: KeysByName;
+  entry: {
+    key: string;
+    keyId: string | null;
+    branch: string | null;
+    jobTag: string | null;
+  };
+}) {
+  if (input.entry.keyId) {
+    return input.entry.keyId;
+  }
+
+  const lookup = buildKeyLookup(input.entry.key, null);
+  const existing = input.keysByName.get(lookup);
+  if (existing) {
+    return existing.id;
+  }
+
+  const tags = input.entry.jobTag ? [input.entry.jobTag] : [];
+  const created = await input.client.createKey(input.projectId, {
+    name: input.entry.key,
+    tags,
+    branch: input.entry.branch,
+  });
+
+  input.keysByName.set(lookup, { id: created.id, tags: created.tags });
+  return created.id;
+}
+
+function buildKeyLookup(name: string, description: string | null) {
+  return `${name.trim()}\x00${description?.trim() ?? ""}`;
+}
+
+function mapPhraseStringsError(error: unknown) {
+  if (error instanceof PhraseApiError && error.status === 401) {
+    return new Error("phrase_auth_invalid");
+  }
+
+  return error instanceof Error ? error : new Error("phrase_fetch_failed");
+}

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-translation-pusher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-translation-pusher.ts
@@ -34,7 +34,7 @@ export const pushPhraseTranslations: ExternalTmsTranslationPusher = async ({
   const branch = resolvePhraseBranch(project);
   let defaultTargetLocale: string | null = null;
 
-  const tmsProjectUid = resolvePhraseTmsProjectUid(project, externalProjectId);
+  const tmsProjectUid = resolvePhraseTmsProjectUid(project);
   if (tmsProjectUid) {
     const tmsClient = new PhraseTmsApiClient({
       token: secretMaterial,

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-translation-pusher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-translation-pusher.ts
@@ -34,7 +34,7 @@ export const pushPhraseTranslations: ExternalTmsTranslationPusher = async ({
   const branch = resolvePhraseBranch(project);
   let defaultTargetLocale: string | null = null;
 
-  const tmsProjectUid = resolvePhraseTmsProjectUid(project);
+  const tmsProjectUid = resolvePhraseTmsProjectUid(project, externalProjectId);
   if (tmsProjectUid) {
     const tmsClient = new PhraseTmsApiClient({
       token: secretMaterial,

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-write-back.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-write-back.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { buildPhraseTranslationWriteBackGroups } from "./phrase-write-back";
+
+describe("buildPhraseTranslationWriteBackGroups", () => {
+  it("groups translations by locale and preserves branch and job tag context", () => {
+    const result = buildPhraseTranslationWriteBackGroups({
+      branch: "main",
+      jobTag: "hyperlocalise:job:phrase-job-1",
+      defaultTargetLocale: "fr-FR",
+      translations: [
+        { locale: "fr-FR", key: "hello", text: "Bonjour" },
+        { locale: "fr-FR", externalStringId: "key-2", text: "Monde" },
+      ],
+    });
+
+    expect(result.failures).toEqual([]);
+    expect(result.groups).toEqual([
+      {
+        locale: "fr-FR",
+        branch: "main",
+        jobTag: "hyperlocalise:job:phrase-job-1",
+        entries: [
+          {
+            key: "hello",
+            keyId: null,
+            locale: "fr-FR",
+            text: "Bonjour",
+            branch: "main",
+            jobTag: "hyperlocalise:job:phrase-job-1",
+          },
+          {
+            key: "key-2",
+            keyId: "key-2",
+            locale: "fr-FR",
+            text: "Monde",
+            branch: "main",
+            jobTag: "hyperlocalise:job:phrase-job-1",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("records validation failures for incomplete uploads", () => {
+    const result = buildPhraseTranslationWriteBackGroups({
+      branch: null,
+      jobTag: null,
+      defaultTargetLocale: null,
+      translations: [
+        { locale: "", key: "hello", text: "Bonjour" },
+        { locale: "fr-FR", key: "", text: "Monde" },
+        { locale: "fr-FR", key: "world", text: "   " },
+      ],
+    });
+
+    expect(result.groups).toEqual([]);
+    expect(result.failures).toEqual([
+      { locale: "", fileId: null, message: "phrase_translation_missing_locale" },
+      { locale: "fr-FR", fileId: null, message: "phrase_translation_missing_key" },
+      { locale: "fr-FR", fileId: null, message: "phrase_translation_missing_text" },
+    ]);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-write-back.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-write-back.ts
@@ -1,0 +1,86 @@
+import type { ExternalTmsApprovedTranslationUpload } from "@/lib/providers/external-tms-content-sync";
+
+export type PhraseTranslationWriteBackEntry = {
+  key: string;
+  keyId: string | null;
+  locale: string;
+  text: string;
+  branch: string | null;
+  jobTag: string | null;
+};
+
+export type PhraseTranslationWriteBackGroup = {
+  locale: string;
+  branch: string | null;
+  jobTag: string | null;
+  entries: PhraseTranslationWriteBackEntry[];
+};
+
+export function buildPhraseTranslationWriteBackGroups(input: {
+  translations: ExternalTmsApprovedTranslationUpload[];
+  branch: string | null;
+  jobTag: string | null;
+  defaultTargetLocale: string | null;
+}): {
+  groups: PhraseTranslationWriteBackGroup[];
+  failures: Array<{ locale: string; message: string; fileId?: string | null }>;
+} {
+  const groups = new Map<string, PhraseTranslationWriteBackGroup>();
+  const failures: Array<{ locale: string; message: string; fileId?: string | null }> = [];
+
+  for (const translation of input.translations) {
+    const locale = translation.locale.trim() || input.defaultTargetLocale?.trim() || "";
+    const key = translation.key?.trim() || translation.externalStringId?.trim() || "";
+    const text = translation.text.trim();
+
+    if (!locale) {
+      failures.push({
+        locale: translation.locale,
+        fileId: translation.fileId ?? null,
+        message: "phrase_translation_missing_locale",
+      });
+      continue;
+    }
+
+    if (!key) {
+      failures.push({
+        locale,
+        fileId: translation.fileId ?? null,
+        message: "phrase_translation_missing_key",
+      });
+      continue;
+    }
+
+    if (!text) {
+      failures.push({
+        locale,
+        fileId: translation.fileId ?? null,
+        message: "phrase_translation_missing_text",
+      });
+      continue;
+    }
+
+    const groupKey = `${locale}::${input.branch ?? ""}`;
+    const existing = groups.get(groupKey) ?? {
+      locale,
+      branch: input.branch,
+      jobTag: input.jobTag,
+      entries: [],
+    };
+
+    existing.entries.push({
+      key,
+      keyId: translation.externalStringId?.trim() || null,
+      locale,
+      text,
+      branch: input.branch,
+      jobTag: input.jobTag,
+    });
+    groups.set(groupKey, existing);
+  }
+
+  return {
+    groups: [...groups.values()],
+    failures,
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/providers/provider-agent-qa.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-agent-qa.test.ts
@@ -160,8 +160,8 @@ describe("executeProviderAgentQa", () => {
 
     const run = await createAgentRun({
       organizationId: project.organizationId,
-      providerKind: "phrase",
-      externalJobId: "phrase-job-qa-1",
+      providerKind: "lokalise",
+      externalJobId: "lokalise-job-qa-1",
       kind: "review",
       inputSnapshot: { projectId: project.id, action: "run_qa_checks" },
     });

--- a/apps/hyperlocalise-web/src/lib/providers/provider-agent-translate.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-agent-translate.test.ts
@@ -141,8 +141,8 @@ describe("executeProviderAgentTranslation", () => {
 
     const run = await createAgentRun({
       organizationId: project.organizationId,
-      providerKind: "phrase",
-      externalJobId: "phrase-job-1",
+      providerKind: "lokalise",
+      externalJobId: "lokalise-job-1",
       kind: "translate",
       inputSnapshot: { projectId: project.id, action: "translate_with_agent" },
     });

--- a/apps/hyperlocalise-web/src/lib/providers/provider-content-pullers.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-content-pullers.ts
@@ -1,5 +1,6 @@
 import { pullCrowdinTaskContent } from "@/lib/providers/crowdin/crowdin-content-puller";
 import type { ExternalTmsContentPuller } from "@/lib/providers/external-tms-content-sync";
+import { pullPhraseTaskContent } from "@/lib/providers/phrase/phrase-content-puller";
 import { pullSmartlingTaskContent } from "@/lib/providers/smartling/smartling-content-puller";
 
 import type { ExternalTmsProviderKind } from "./organization-external-tms-provider-credentials";
@@ -10,6 +11,8 @@ export function getProviderContentPuller(
   switch (providerKind) {
     case "crowdin":
       return pullCrowdinTaskContent;
+    case "phrase":
+      return pullPhraseTaskContent;
     case "smartling":
       return pullSmartlingTaskContent;
     default:

--- a/apps/hyperlocalise-web/src/lib/providers/provider-translation-pushers.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-translation-pushers.ts
@@ -1,5 +1,6 @@
 import { pushCrowdinTranslations } from "@/lib/providers/crowdin/crowdin-translation-pusher";
 import type { ExternalTmsTranslationPusher } from "@/lib/providers/external-tms-content-sync";
+import { pushPhraseTranslations } from "@/lib/providers/phrase/phrase-translation-pusher";
 import { pushSmartlingTranslations } from "@/lib/providers/smartling/smartling-translation-pusher";
 
 import type { ExternalTmsProviderKind } from "./organization-external-tms-provider-credentials";
@@ -10,6 +11,8 @@ export function getProviderTranslationPusher(
   switch (providerKind) {
     case "crowdin":
       return pushCrowdinTranslations;
+    case "phrase":
+      return pushPhraseTranslations;
     case "smartling":
       return pushSmartlingTranslations;
     default:


### PR DESCRIPTION
Add provider-neutral content pull and translation push for Phrase jobs, preserving branch and job tag context when writing to the Strings API.

## What changed

<!-- Describe the change and why it is needed. -->

## How to test

<!-- List manual checks or commands used to verify this change. -->

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review
