### PR TITLE
feat(web): show synced provider translation memories on TM page (HL-378)

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/memory/memory.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/memory/memory.route.ts
@@ -1,4 +1,4 @@
-import { desc, eq } from "drizzle-orm";
+import { count, desc, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { validator } from "hono/validator";
 
@@ -25,8 +25,13 @@ import {
   memoryNotFoundResponse,
 } from "./memory.shared";
 
+type MemoryListResult = {
+  memories: Memory[];
+  total: number;
+};
+
 type MemoryStore = {
-  list(auth: ApiAuthContext, query?: ListMemoryQuery): Promise<Memory[]>;
+  list(auth: ApiAuthContext, query?: ListMemoryQuery): Promise<MemoryListResult>;
   create(auth: ApiAuthContext, payload: CreateMemoryBody): Promise<Memory>;
   getById(auth: ApiAuthContext, memoryId: string): Promise<Memory | null>;
   update(auth: ApiAuthContext, memoryId: string, payload: UpdateMemoryBody): Promise<Memory | null>;
@@ -37,13 +42,20 @@ const memoryStore: MemoryStore = {
   async list(auth, query) {
     const limit = query?.limit ?? 50;
     const offset = query?.offset ?? 0;
-    return db
-      .select()
-      .from(schema.memories)
-      .where(eq(schema.memories.organizationId, auth.organization.localOrganizationId))
-      .orderBy(desc(schema.memories.createdAt))
-      .limit(limit)
-      .offset(offset);
+    const where = eq(schema.memories.organizationId, auth.organization.localOrganizationId);
+
+    const [memories, totalRow] = await Promise.all([
+      db
+        .select()
+        .from(schema.memories)
+        .where(where)
+        .orderBy(desc(schema.memories.createdAt))
+        .limit(limit)
+        .offset(offset),
+      db.select({ value: count() }).from(schema.memories).where(where),
+    ]);
+
+    return { memories, total: totalRow[0]?.value ?? 0 };
   },
   async create(auth, payload) {
     const [memory] = await db
@@ -131,8 +143,8 @@ export function createMemoryRoutes() {
     .use("*", workosAuthMiddleware)
     .get("/", validateListMemoryQuery, async (c) => {
       const query = c.req.valid("query");
-      const memories = await memoryStore.list(c.var.auth, query);
-      return c.json({ memories: memories.map(toMemoryRecord) }, 200);
+      const { memories, total } = await memoryStore.list(c.var.auth, query);
+      return c.json({ memories: memories.map(toMemoryRecord), total }, 200);
     })
     .post("/", validateCreateMemoryBody, async (c) => {
       if (!isMemoryMutationAllowed(c.var.auth.membership.role)) {

--- a/apps/hyperlocalise-web/src/api/routes/memory/memory.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/memory/memory.schema.ts
@@ -57,6 +57,7 @@ export const memoryResponseSchema = z.object({
 
 export const memoriesResponseSchema = z.object({
   memories: z.array(memoryRecordSchema),
+  total: z.number().int().nonnegative(),
 });
 
 export type MemoryIdParams = z.infer<typeof memoryIdParamsSchema>;

--- a/apps/hyperlocalise-web/src/api/routes/memory/memory.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/memory/memory.test.ts
@@ -64,6 +64,7 @@ describe("memoryRoutes", () => {
     expect(legacyResponse.status).toBe(200);
     await expect(legacyResponse.json()).resolves.toMatchObject({
       memories: [expect.objectContaining({ name: "Mounted TM" })],
+      total: 1,
     });
 
     const orgScopedResponse = await client.api.orgs[":organizationSlug"][
@@ -79,6 +80,7 @@ describe("memoryRoutes", () => {
     expect(orgScopedResponse.status).toBe(200);
     await expect(orgScopedResponse.json()).resolves.toMatchObject({
       memories: [expect.objectContaining({ name: "Mounted TM" })],
+      total: 1,
     });
   });
 
@@ -122,6 +124,7 @@ describe("memoryRoutes", () => {
     if ("error" in body) throw new Error(String(body.error));
 
     expect(body.memories).toHaveLength(2);
+    expect(body.total).toBe(2);
     expect(body.memories).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ name: "Native TM", source: "native" }),

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/translation-memories/_components/memory-list.test.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/translation-memories/_components/memory-list.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  buildProjectIdByExternalKey,
+  externalProjectLookupKey,
+  mapMemoryToListRow,
+} from "./memory-list";
+
+describe("memory-list", () => {
+  it("maps native and provider memories with project links", () => {
+    const projectMap = buildProjectIdByExternalKey([
+      {
+        id: "project-1",
+        externalProviderKind: "phrase",
+        externalProjectId: "phrase-project-9",
+      },
+    ]);
+
+    const native = mapMemoryToListRow(
+      {
+        id: "mem-native",
+        organizationId: "org-1",
+        createdByUserId: null,
+        name: "Product UI",
+        description: "",
+        status: "active",
+        source: "native",
+        externalProviderKind: null,
+        externalProjectId: null,
+        externalMemoryId: null,
+        localeCoverage: ["en", "de"],
+        segmentCount: 1200,
+        syncState: null,
+        capabilityMode: null,
+        segmentCapabilities: {},
+        externalUrl: null,
+        lastSyncedAt: null,
+        lastSyncErrorAt: null,
+        lastSyncErrorMessage: null,
+        createdAt: "2026-05-01T00:00:00.000Z",
+        updatedAt: "2026-05-01T00:00:00.000Z",
+      },
+      projectMap,
+    );
+
+    const provider = mapMemoryToListRow(
+      {
+        id: "mem-provider",
+        organizationId: "org-1",
+        createdByUserId: null,
+        name: "Phrase TM",
+        description: "Marketing",
+        status: "active",
+        source: "external_tms",
+        externalProviderKind: "phrase",
+        externalProjectId: "phrase-project-9",
+        externalMemoryId: "tm-42",
+        localeCoverage: ["en", "fr", "de", "es"],
+        segmentCount: 50_000,
+        syncState: "synced",
+        capabilityMode: "live_search",
+        segmentCapabilities: { search: true },
+        externalUrl: "https://phrase.com/tm/42",
+        lastSyncedAt: "2026-05-20T12:00:00.000Z",
+        lastSyncErrorAt: null,
+        lastSyncErrorMessage: null,
+        createdAt: "2026-05-01T00:00:00.000Z",
+        updatedAt: "2026-05-20T12:00:00.000Z",
+      },
+      projectMap,
+    );
+
+    expect(native.capabilityLabel).toBe("Workspace managed");
+    expect(native.localeSummary).toBe("en, de");
+    expect(native.segmentCountLabel).toBe("1.2k");
+    expect(provider.capabilityLabel).toBe("Live search");
+    expect(provider.localeSummary).toBe("en, fr, de +1");
+    expect(provider.segmentCountLabel).toBe("50.0k");
+    expect(provider.projectLinkId).toBe("project-1");
+    expect(externalProjectLookupKey("phrase", "phrase-project-9")).toBe("phrase:phrase-project-9");
+  });
+});

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/translation-memories/_components/memory-list.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/translation-memories/_components/memory-list.ts
@@ -1,0 +1,140 @@
+import type { MemoryRecord } from "@/api/routes/memory/memory.schema";
+
+export type ApiMemory = MemoryRecord;
+
+export type MemoryListRow = {
+  id: string;
+  name: string;
+  description: string;
+  source: "native" | "external_tms";
+  externalProviderKind: ApiMemory["externalProviderKind"];
+  externalProjectId: string | null;
+  externalMemoryId: string | null;
+  localeCoverage: string[];
+  localeSummary: string;
+  segmentCount: number | null;
+  segmentCountLabel: string;
+  syncState: string | null;
+  capabilityMode: ApiMemory["capabilityMode"];
+  capabilityLabel: string;
+  externalUrl: string | null;
+  lastSyncedAt: string | null;
+  lastSyncErrorAt: string | null;
+  lastSyncErrorMessage: string | null;
+  updatedAt: string;
+  projectLinkId: string | null;
+};
+
+const CAPABILITY_LABELS: Record<NonNullable<ApiMemory["capabilityMode"]>, string> = {
+  live_search: "Live search",
+  synced_import: "Synced import",
+  reference_only: "Reference only",
+};
+
+const PROVIDER_LABELS: Record<string, string> = {
+  crowdin: "Crowdin",
+  smartling: "Smartling",
+  phrase: "Phrase",
+  lokalise: "Lokalise",
+};
+
+const RELATIVE_TIME_FORMATTER = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
+
+export function providerLabel(kind: string) {
+  return PROVIDER_LABELS[kind] ?? kind;
+}
+
+export function formatRelativeTimestamp(value: string | null) {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  const deltaSeconds = Math.round((date.getTime() - Date.now()) / 1000);
+  const absoluteSeconds = Math.abs(deltaSeconds);
+  if (absoluteSeconds < 60) return RELATIVE_TIME_FORMATTER.format(deltaSeconds, "second");
+  if (absoluteSeconds < 3_600)
+    return RELATIVE_TIME_FORMATTER.format(Math.round(deltaSeconds / 60), "minute");
+  if (absoluteSeconds < 86_400)
+    return RELATIVE_TIME_FORMATTER.format(Math.round(deltaSeconds / 3_600), "hour");
+  if (absoluteSeconds < 2_592_000)
+    return RELATIVE_TIME_FORMATTER.format(Math.round(deltaSeconds / 86_400), "day");
+  return date.toLocaleDateString();
+}
+
+function formatSegmentCount(count: number | null) {
+  if (count === null) return "Unknown";
+  if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
+  if (count >= 1_000) return `${(count / 1_000).toFixed(1)}k`;
+  return `${count}`;
+}
+
+function formatLocaleCoverage(locales: string[]) {
+  if (locales.length === 0) return "No locales listed";
+  if (locales.length <= 3) return locales.join(", ");
+  return `${locales.slice(0, 3).join(", ")} +${locales.length - 3}`;
+}
+
+function capabilityLabelFor(memory: ApiMemory) {
+  if (memory.capabilityMode) {
+    return CAPABILITY_LABELS[memory.capabilityMode];
+  }
+
+  return memory.source === "native" ? "Workspace managed" : "Provider managed";
+}
+
+export function externalProjectLookupKey(
+  providerKind: string | null | undefined,
+  externalProjectId: string | null | undefined,
+) {
+  if (!providerKind || !externalProjectId) return null;
+  return `${providerKind}:${externalProjectId}`;
+}
+
+export function mapMemoryToListRow(
+  memory: ApiMemory,
+  projectIdByExternalKey: ReadonlyMap<string, string>,
+): MemoryListRow {
+  const lookupKey = externalProjectLookupKey(memory.externalProviderKind, memory.externalProjectId);
+
+  return {
+    id: memory.id,
+    name: memory.name,
+    description: memory.description.trim() || "No description",
+    source: memory.source,
+    externalProviderKind: memory.externalProviderKind,
+    externalProjectId: memory.externalProjectId,
+    externalMemoryId: memory.externalMemoryId,
+    localeCoverage: memory.localeCoverage,
+    localeSummary: formatLocaleCoverage(memory.localeCoverage),
+    segmentCount: memory.segmentCount,
+    segmentCountLabel: formatSegmentCount(memory.segmentCount),
+    syncState: memory.syncState,
+    capabilityMode: memory.capabilityMode,
+    capabilityLabel: capabilityLabelFor(memory),
+    externalUrl: memory.externalUrl,
+    lastSyncedAt: formatRelativeTimestamp(memory.lastSyncedAt),
+    lastSyncErrorAt: formatRelativeTimestamp(memory.lastSyncErrorAt),
+    lastSyncErrorMessage: memory.lastSyncErrorMessage,
+    updatedAt: formatRelativeTimestamp(memory.updatedAt) ?? "—",
+    projectLinkId: lookupKey ? (projectIdByExternalKey.get(lookupKey) ?? null) : null,
+  };
+}
+
+export function buildProjectIdByExternalKey(
+  projects: readonly {
+    id: string;
+    source?: string;
+    externalProviderKind?: string | null;
+    externalProjectId?: string | null;
+  }[],
+) {
+  const map = new Map<string, string>();
+
+  for (const project of projects) {
+    const key = externalProjectLookupKey(project.externalProviderKind, project.externalProjectId);
+    if (key && !map.has(key)) {
+      map.set(key, project.id);
+    }
+  }
+
+  return map;
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-page-content.tsx
@@ -1,116 +1,361 @@
 "use client";
 
+import { useMemo, useState } from "react";
 import Link from "next/link";
-import {
-  ArrowRight01Icon,
-  DatabaseSyncIcon,
-  FileSyncIcon,
-  LanguageSquareIcon,
-} from "@hugeicons/core-free-icons";
+import { ArrowRight01Icon, DatabaseSyncIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { useQuery } from "@tanstack/react-query";
 
-import { Badge } from "@/components/ui/badge";
-import { Separator } from "@/components/ui/separator";
+import { Input } from "@/components/ui/input";
 import {
-  MetricsGrid,
-  PageHeader,
-  ResourceCard,
-  toneClass,
-} from "../../_components/workspace-resource-shared";
-import { TypographyP } from "@/components/ui/typography";
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { apiClient } from "@/lib/api-client-instance";
 
-const memoryMetrics = [
-  { label: "Segments", value: "284k", detail: "92% reusable", tone: "safe" },
-  { label: "Locales", value: "18", detail: "6 synced", tone: "info" },
-  { label: "Conflicts", value: "12", detail: "needs review", tone: "watch" },
-] as const;
+import { MetricsGrid, PageHeader } from "../../_components/workspace-resource-shared";
+import {
+  buildProjectIdByExternalKey,
+  mapMemoryToListRow,
+  type ApiMemory,
+  type MemoryListRow,
+} from "./memory-list";
+import {
+  TranslationMemoriesEmptyAction,
+  TranslationMemoriesTable,
+} from "./translation-memories-table";
 
-const memories = [
-  {
-    name: "Product UI memory",
-    source: "GitHub strings",
-    locales: "12 locales",
-    match: "94% match rate",
-    updated: "8m ago",
-    tone: "safe",
-  },
-  {
-    name: "Marketing campaigns",
-    source: "Phrase",
-    locales: "8 locales",
-    match: "81% match rate",
-    updated: "42m ago",
-    tone: "watch",
-  },
-  {
-    name: "Help center archive",
-    source: "Crowdin",
-    locales: "14 locales",
-    match: "88% match rate",
-    updated: "2h ago",
-    tone: "info",
-  },
-] as const;
+const memoriesQueryKey = (organizationSlug: string) => ["translation-memories", organizationSlug];
+const projectsQueryKey = (organizationSlug: string) => [
+  "translation-memory-projects",
+  organizationSlug,
+];
+const credentialsQueryKey = (organizationSlug: string) => [
+  "translation-memory-credentials",
+  organizationSlug,
+];
+
+function useMemoryFilters(memories: MemoryListRow[]) {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [sourceFilter, setSourceFilter] = useState<string>("all");
+  const [providerFilter, setProviderFilter] = useState<string>("all");
+  const [syncFilter, setSyncFilter] = useState<string>("all");
+
+  const filteredMemories = useMemo(() => {
+    return memories.filter((memory) => {
+      if (searchQuery.trim()) {
+        const query = searchQuery.toLowerCase();
+        const matchesName = memory.name.toLowerCase().includes(query);
+        const matchesProject = memory.externalProjectId?.toLowerCase().includes(query);
+        const matchesMemoryId = memory.externalMemoryId?.toLowerCase().includes(query);
+        if (!matchesName && !matchesProject && !matchesMemoryId) return false;
+      }
+
+      if (sourceFilter !== "all" && memory.source !== sourceFilter) return false;
+
+      if (providerFilter !== "all") {
+        if (memory.externalProviderKind !== providerFilter) return false;
+      }
+
+      if (syncFilter !== "all") {
+        if (syncFilter === "error") {
+          if (!memory.lastSyncErrorAt) return false;
+        } else if (memory.syncState !== syncFilter) {
+          return false;
+        }
+      }
+
+      return true;
+    });
+  }, [memories, searchQuery, sourceFilter, providerFilter, syncFilter]);
+
+  const activeFilterCount = [sourceFilter, providerFilter, syncFilter].filter(
+    (f) => f !== "all",
+  ).length;
+
+  return {
+    searchQuery,
+    setSearchQuery,
+    sourceFilter,
+    setSourceFilter,
+    providerFilter,
+    setProviderFilter,
+    syncFilter,
+    setSyncFilter,
+    filteredMemories,
+    activeFilterCount,
+  };
+}
+
+function TranslationMemoriesMetrics({ memories }: { memories: MemoryListRow[] }) {
+  const metrics = useMemo(() => {
+    const providerMemories = memories.filter((memory) => memory.source === "external_tms");
+    const syncedCount = providerMemories.filter(
+      (memory) => memory.syncState === "synced" && !memory.lastSyncErrorAt,
+    ).length;
+    const errorCount = providerMemories.filter((memory) => memory.lastSyncErrorAt).length;
+    const localeCount = new Set(memories.flatMap((memory) => memory.localeCoverage)).size;
+    const segmentTotal = memories.reduce((sum, memory) => sum + (memory.segmentCount ?? 0), 0);
+    const segmentLabel =
+      segmentTotal >= 1_000_000
+        ? `${(segmentTotal / 1_000_000).toFixed(1)}M`
+        : segmentTotal >= 1_000
+          ? `${(segmentTotal / 1_000).toFixed(1)}k`
+          : `${segmentTotal}`;
+
+    return [
+      {
+        label: "Memory stores",
+        value: `${memories.length}`,
+        detail: `${providerMemories.length} provider`,
+        tone: "info" as const,
+      },
+      {
+        label: "Locales covered",
+        value: `${localeCount}`,
+        detail: `${segmentLabel} segments`,
+        tone: "safe" as const,
+      },
+      {
+        label: "Sync health",
+        value: `${syncedCount}`,
+        detail: errorCount > 0 ? `${errorCount} errors` : "healthy",
+        tone: errorCount > 0 ? ("watch" as const) : ("safe" as const),
+      },
+    ] as const;
+  }, [memories]);
+
+  return <MetricsGrid metrics={metrics} />;
+}
 
 export function TranslationMemoriesPageContent({ organizationSlug }: { organizationSlug: string }) {
+  const projectsQuery = useQuery({
+    queryKey: projectsQueryKey(organizationSlug),
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"].projects.$get({
+        param: { organizationSlug },
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to load projects (${response.status})`);
+      }
+
+      const body = await response.json();
+      return body.projects;
+    },
+  });
+
+  const credentialsQuery = useQuery({
+    queryKey: credentialsQueryKey(organizationSlug),
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"][
+        "external-tms-provider-credential"
+      ].$get({
+        param: { organizationSlug },
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to load provider credentials (${response.status})`);
+      }
+
+      const body = await response.json();
+      return body.externalTmsProviderCredentials;
+    },
+  });
+
+  const memoriesQuery = useQuery({
+    queryKey: memoriesQueryKey(organizationSlug),
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"]["translation-memories"].$get({
+        param: { organizationSlug },
+        query: { limit: "100", offset: "0" },
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to load translation memories (${response.status})`);
+      }
+
+      const body = await response.json();
+      return body.memories as ApiMemory[];
+    },
+  });
+
+  const projectIdByExternalKey = useMemo(
+    () => buildProjectIdByExternalKey(projectsQuery.data ?? []),
+    [projectsQuery.data],
+  );
+
+  const memories = useMemo(
+    () =>
+      (memoriesQuery.data ?? []).map((memory) =>
+        mapMemoryToListRow(memory, projectIdByExternalKey),
+      ),
+    [memoriesQuery.data, projectIdByExternalKey],
+  );
+
+  const {
+    searchQuery,
+    setSearchQuery,
+    sourceFilter,
+    setSourceFilter,
+    providerFilter,
+    setProviderFilter,
+    syncFilter,
+    setSyncFilter,
+    filteredMemories,
+    activeFilterCount,
+  } = useMemoryFilters(memories);
+
+  const hasExternalMemories = memories.some((memory) => memory.source === "external_tms");
+  const connectedCredentials = (credentialsQuery.data ?? []).filter(
+    (credential) => credential.validationStatus === "connected",
+  );
+  const hasConnectedProvider = credentialsQuery.isSuccess && connectedCredentials.length > 0;
+
+  const emptyTitle = hasConnectedProvider
+    ? "No translation memories yet"
+    : "Connect a TMS provider";
+  const emptyDescription = hasConnectedProvider
+    ? "Provider translation memories appear here after sync. Native workspace memories can also be created from this page once creation is enabled."
+    : "Connect Crowdin, Phrase, Smartling, or Lokalise from Integrations to sync translation memories into this workspace.";
+
   return (
-    <main className="space-y-5">
+    <main className="mx-auto flex w-full max-w-6xl flex-col gap-5">
       <PageHeader
         icon={DatabaseSyncIcon}
         label="Manage"
         title="Translation Memories"
-        description="Manage reusable translated segments, source matching, and synchronization state for future localization work."
-        statusLabel="Mock data"
+        description="Browse native workspace memories and synced provider translation memories with locale coverage, capabilities, and sync health in one place."
       />
 
-      <MetricsGrid metrics={memoryMetrics} />
+      {memoriesQuery.isSuccess ? <TranslationMemoriesMetrics memories={memories} /> : null}
+
+      {memoriesQuery.isSuccess && memories.length > 0 ? (
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <div className="flex-1">
+            <Input
+              placeholder="Search by name, project, or external ID..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="w-full sm:max-w-xs"
+            />
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Select
+              value={sourceFilter}
+              onValueChange={(value) => {
+                setSourceFilter(value ?? "all");
+                if (value === "native") {
+                  setProviderFilter("all");
+                  setSyncFilter("all");
+                }
+              }}
+            >
+              <SelectTrigger className="w-fit min-w-[8rem]">
+                <SelectValue placeholder="Source" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All sources</SelectItem>
+                <SelectItem value="native">Workspace</SelectItem>
+                <SelectItem value="external_tms">Provider</SelectItem>
+              </SelectContent>
+            </Select>
+
+            {hasExternalMemories && sourceFilter !== "native" ? (
+              <Select
+                value={providerFilter}
+                onValueChange={(value) => setProviderFilter(value ?? "all")}
+              >
+                <SelectTrigger className="w-fit min-w-[8rem]">
+                  <SelectValue placeholder="Provider" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All providers</SelectItem>
+                  <SelectItem value="phrase">Phrase</SelectItem>
+                  <SelectItem value="crowdin">Crowdin</SelectItem>
+                  <SelectItem value="smartling">Smartling</SelectItem>
+                  <SelectItem value="lokalise">Lokalise</SelectItem>
+                </SelectContent>
+              </Select>
+            ) : null}
+
+            {hasExternalMemories && sourceFilter !== "native" ? (
+              <Select value={syncFilter} onValueChange={(value) => setSyncFilter(value ?? "all")}>
+                <SelectTrigger className="w-fit min-w-[8rem]">
+                  <SelectValue placeholder="Sync" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All sync states</SelectItem>
+                  <SelectItem value="synced">Synced</SelectItem>
+                  <SelectItem value="stale">Stale</SelectItem>
+                  <SelectItem value="syncing">Syncing</SelectItem>
+                  <SelectItem value="error">Sync error</SelectItem>
+                </SelectContent>
+              </Select>
+            ) : null}
+
+            {activeFilterCount > 0 ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  setSearchQuery("");
+                  setSourceFilter("all");
+                  setProviderFilter("all");
+                  setSyncFilter("all");
+                }}
+              >
+                Clear filters
+              </Button>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+
+      {memoriesQuery.isSuccess && memories.length > 0 && filteredMemories.length === 0 ? (
+        <div className="text-sm text-foreground/52">
+          No translation memories match your filters.{" "}
+          <button
+            type="button"
+            onClick={() => {
+              setSearchQuery("");
+              setSourceFilter("all");
+              setProviderFilter("all");
+              setSyncFilter("all");
+            }}
+            className="text-foreground/72 underline hover:text-foreground"
+          >
+            Clear filters
+          </button>
+        </div>
+      ) : null}
 
       <div className="flex items-center gap-2 text-sm text-foreground/54">
         <span>
-          Synced provider translation memories will appear here alongside workspace memories.
+          Provider memories stay read-only here. Connect or manage credentials from Integrations.
         </span>
         <Link
           href={`/org/${organizationSlug}/integrations`}
           className="inline-flex items-center gap-1 hover:text-foreground"
         >
-          <span>Connect a provider</span>
+          <span>Integrations</span>
           <HugeiconsIcon icon={ArrowRight01Icon} strokeWidth={1.7} className="size-4" />
         </Link>
       </div>
 
-      <ResourceCard
-        title="Memory stores"
-        description="Mock translation memory sources grouped by workflow and sync health."
-        icon={FileSyncIcon}
-      >
-        {memories.map((memory, index) => (
-          <div key={memory.name}>
-            <div className="grid gap-3 px-5 py-4 md:grid-cols-[1.4fr_1fr_1fr_auto] md:items-center">
-              <div className="min-w-0">
-                <div className="flex items-center gap-2">
-                  <HugeiconsIcon
-                    icon={LanguageSquareIcon}
-                    strokeWidth={1.7}
-                    className="size-4 text-foreground/42"
-                  />
-                  <TypographyP className="truncate text-sm font-medium text-foreground">
-                    {memory.name}
-                  </TypographyP>
-                </div>
-                <TypographyP className="mt-1 text-xs text-foreground/42">
-                  {memory.source} · Updated {memory.updated}
-                </TypographyP>
-              </div>
-              <TypographyP className="text-sm text-foreground/58">{memory.locales}</TypographyP>
-              <TypographyP className="text-sm text-foreground/58">{memory.match}</TypographyP>
-              <Badge variant="outline" className={toneClass(memory.tone)}>
-                Synced
-              </Badge>
-            </div>
-            {index < memories.length - 1 ? <Separator className="bg-foreground/8" /> : null}
-          </div>
-        ))}
-      </ResourceCard>
+      <TranslationMemoriesTable
+        memories={filteredMemories}
+        memoriesQuery={memoriesQuery}
+        organizationSlug={organizationSlug}
+        emptyTitle={emptyTitle}
+        emptyDescription={emptyDescription}
+        emptyAction={<TranslationMemoriesEmptyAction organizationSlug={organizationSlug} />}
+      />
     </main>
   );
 }

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-page-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { ArrowRight01Icon, DatabaseSyncIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -21,6 +21,7 @@ import { MetricsGrid, PageHeader } from "../../_components/workspace-resource-sh
 import {
   buildProjectIdByExternalKey,
   mapMemoryToListRow,
+  providerLabel,
   type ApiMemory,
   type MemoryListRow,
 } from "./memory-list";
@@ -29,7 +30,13 @@ import {
   TranslationMemoriesTable,
 } from "./translation-memories-table";
 
-const memoriesQueryKey = (organizationSlug: string) => ["translation-memories", organizationSlug];
+const MEMORIES_PAGE_SIZE = 100;
+
+const memoriesQueryKey = (organizationSlug: string, page: number) => [
+  "translation-memories",
+  organizationSlug,
+  page,
+];
 const projectsQueryKey = (organizationSlug: string) => [
   "translation-memory-projects",
   organizationSlug,
@@ -91,7 +98,13 @@ function useMemoryFilters(memories: MemoryListRow[]) {
   };
 }
 
-function TranslationMemoriesMetrics({ memories }: { memories: MemoryListRow[] }) {
+function TranslationMemoriesMetrics({
+  memories,
+  total,
+}: {
+  memories: MemoryListRow[];
+  total: number;
+}) {
   const metrics = useMemo(() => {
     const providerMemories = memories.filter((memory) => memory.source === "external_tms");
     const syncedCount = providerMemories.filter(
@@ -106,12 +119,17 @@ function TranslationMemoriesMetrics({ memories }: { memories: MemoryListRow[] })
         : segmentTotal >= 1_000
           ? `${(segmentTotal / 1_000).toFixed(1)}k`
           : `${segmentTotal}`;
+    const providerCountOnPage = providerMemories.length;
+    const providerDetail =
+      total > memories.length
+        ? `${providerCountOnPage} provider on this page`
+        : `${providerCountOnPage} provider`;
 
     return [
       {
         label: "Memory stores",
-        value: `${memories.length}`,
-        detail: `${providerMemories.length} provider`,
+        value: `${total}`,
+        detail: providerDetail,
         tone: "info" as const,
       },
       {
@@ -127,12 +145,13 @@ function TranslationMemoriesMetrics({ memories }: { memories: MemoryListRow[] })
         tone: errorCount > 0 ? ("watch" as const) : ("safe" as const),
       },
     ] as const;
-  }, [memories]);
+  }, [memories, total]);
 
   return <MetricsGrid metrics={metrics} />;
 }
 
 export function TranslationMemoriesPageContent({ organizationSlug }: { organizationSlug: string }) {
+  const [page, setPage] = useState(1);
   const projectsQuery = useQuery({
     queryKey: projectsQueryKey(organizationSlug),
     queryFn: async () => {
@@ -168,11 +187,14 @@ export function TranslationMemoriesPageContent({ organizationSlug }: { organizat
   });
 
   const memoriesQuery = useQuery({
-    queryKey: memoriesQueryKey(organizationSlug),
+    queryKey: memoriesQueryKey(organizationSlug, page),
     queryFn: async () => {
       const response = await apiClient.api.orgs[":organizationSlug"]["translation-memories"].$get({
         param: { organizationSlug },
-        query: { limit: "100", offset: "0" },
+        query: {
+          limit: String(MEMORIES_PAGE_SIZE),
+          offset: String((page - 1) * MEMORIES_PAGE_SIZE),
+        },
       });
 
       if (!response.ok) {
@@ -180,7 +202,10 @@ export function TranslationMemoriesPageContent({ organizationSlug }: { organizat
       }
 
       const body = await response.json();
-      return body.memories as ApiMemory[];
+      return {
+        memories: body.memories as ApiMemory[],
+        total: body.total as number,
+      };
     },
   });
 
@@ -191,11 +216,26 @@ export function TranslationMemoriesPageContent({ organizationSlug }: { organizat
 
   const memories = useMemo(
     () =>
-      (memoriesQuery.data ?? []).map((memory) =>
+      (memoriesQuery.data?.memories ?? []).map((memory) =>
         mapMemoryToListRow(memory, projectIdByExternalKey),
       ),
-    [memoriesQuery.data, projectIdByExternalKey],
+    [memoriesQuery.data?.memories, projectIdByExternalKey],
   );
+
+  const memoryTotal = memoriesQuery.data?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(memoryTotal / MEMORIES_PAGE_SIZE));
+  const pageStart = memoryTotal === 0 ? 0 : (page - 1) * MEMORIES_PAGE_SIZE + 1;
+  const pageEnd = Math.min(page * MEMORIES_PAGE_SIZE, memoryTotal);
+
+  const providerKinds = useMemo(() => {
+    const kinds = new Set<string>();
+    for (const memory of memories) {
+      if (memory.externalProviderKind) {
+        kinds.add(memory.externalProviderKind);
+      }
+    }
+    return [...kinds].sort((a, b) => providerLabel(a).localeCompare(providerLabel(b)));
+  }, [memories]);
 
   const {
     searchQuery,
@@ -209,6 +249,16 @@ export function TranslationMemoriesPageContent({ organizationSlug }: { organizat
     filteredMemories,
     activeFilterCount,
   } = useMemoryFilters(memories);
+
+  useEffect(() => {
+    setPage(1);
+  }, [organizationSlug, searchQuery, sourceFilter, providerFilter, syncFilter]);
+
+  useEffect(() => {
+    if (memoriesQuery.isSuccess && page > totalPages) {
+      setPage(totalPages);
+    }
+  }, [memoriesQuery.isSuccess, page, totalPages]);
 
   const hasExternalMemories = memories.some((memory) => memory.source === "external_tms");
   const connectedCredentials = (credentialsQuery.data ?? []).filter(
@@ -232,7 +282,9 @@ export function TranslationMemoriesPageContent({ organizationSlug }: { organizat
         description="Browse native workspace memories and synced provider translation memories with locale coverage, capabilities, and sync health in one place."
       />
 
-      {memoriesQuery.isSuccess ? <TranslationMemoriesMetrics memories={memories} /> : null}
+      {memoriesQuery.isSuccess ? (
+        <TranslationMemoriesMetrics memories={memories} total={memoryTotal} />
+      ) : null}
 
       {memoriesQuery.isSuccess && memories.length > 0 ? (
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
@@ -275,10 +327,11 @@ export function TranslationMemoriesPageContent({ organizationSlug }: { organizat
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="all">All providers</SelectItem>
-                  <SelectItem value="phrase">Phrase</SelectItem>
-                  <SelectItem value="crowdin">Crowdin</SelectItem>
-                  <SelectItem value="smartling">Smartling</SelectItem>
-                  <SelectItem value="lokalise">Lokalise</SelectItem>
+                  {providerKinds.map((kind) => (
+                    <SelectItem key={kind} value={kind}>
+                      {providerLabel(kind)}
+                    </SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
             ) : null}
@@ -356,6 +409,37 @@ export function TranslationMemoriesPageContent({ organizationSlug }: { organizat
         emptyDescription={emptyDescription}
         emptyAction={<TranslationMemoriesEmptyAction organizationSlug={organizationSlug} />}
       />
+
+      {memoriesQuery.isSuccess && memoryTotal > MEMORIES_PAGE_SIZE ? (
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <p className="text-sm text-foreground/52">
+            Showing {pageStart}–{pageEnd} of {memoryTotal} translation memories
+          </p>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              disabled={page <= 1}
+              onClick={() => setPage((current) => Math.max(1, current - 1))}
+            >
+              Previous
+            </Button>
+            <p className="text-sm text-foreground/52">
+              Page {page} of {totalPages}
+            </p>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              disabled={page >= totalPages}
+              onClick={() => setPage((current) => current + 1)}
+            >
+              Next
+            </Button>
+          </div>
+        </div>
+      ) : null}
     </main>
   );
 }

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-table.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-table.tsx
@@ -173,7 +173,7 @@ export function TranslationMemoriesTable({
 }: {
   memories: MemoryListRow[];
   memoriesQuery: Pick<
-    UseQueryResult<MemoryListRow[], Error>,
+    UseQueryResult<unknown, Error>,
     "isLoading" | "isError" | "isSuccess" | "error"
   >;
   organizationSlug: string;

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-table.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-table.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+import type { ReactNode } from "react";
+import Link from "next/link";
+import {
+  Alert02Icon,
+  ArrowUpRight01Icon,
+  DatabaseSyncIcon,
+  LanguageSquareIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import type { UseQueryResult } from "@tanstack/react-query";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { TypographyP } from "@/components/ui/typography";
+
+import { ProviderKindBadge, SyncStateBadge } from "../../_components/workspace-files-shared";
+import { ResourceCard, toneClass } from "../../_components/workspace-resource-shared";
+import type { MemoryListRow } from "./memory-list";
+import { providerLabel } from "./memory-list";
+
+function SourceLabel({ memory }: { memory: MemoryListRow }) {
+  if (memory.source === "native") {
+    return <span className="text-xs text-foreground/48">Workspace</span>;
+  }
+
+  if (memory.externalProviderKind) {
+    return <ProviderKindBadge kind={memory.externalProviderKind} />;
+  }
+
+  return <span className="text-xs text-foreground/48">External TMS</span>;
+}
+
+function SyncHealthBadge({ memory }: { memory: MemoryListRow }) {
+  if (memory.source === "native") {
+    return (
+      <Badge variant="outline" className={toneClass("info")}>
+        Active
+      </Badge>
+    );
+  }
+
+  if (memory.lastSyncErrorAt) {
+    return (
+      <Badge variant="destructive" className="text-[10px]">
+        <HugeiconsIcon icon={Alert02Icon} strokeWidth={1.8} className="size-3" />
+        Sync error
+      </Badge>
+    );
+  }
+
+  if (memory.syncState) {
+    return <SyncStateBadge syncState={memory.syncState} />;
+  }
+
+  return (
+    <Badge variant="outline" className="text-[10px] text-foreground/58">
+      Not synced
+    </Badge>
+  );
+}
+
+function CapabilityBadge({ memory }: { memory: MemoryListRow }) {
+  const tone =
+    memory.capabilityMode === "reference_only"
+      ? "watch"
+      : memory.capabilityMode === "live_search"
+        ? "info"
+        : "safe";
+
+  return (
+    <Badge variant="outline" className={toneClass(tone)}>
+      {memory.capabilityLabel}
+    </Badge>
+  );
+}
+
+function MemoryRow({
+  memory,
+  organizationSlug,
+}: {
+  memory: MemoryListRow;
+  organizationSlug: string;
+}) {
+  const sourceDetail =
+    memory.source === "native"
+      ? `Updated ${memory.updatedAt}`
+      : [
+          memory.externalProviderKind ? providerLabel(memory.externalProviderKind) : "Provider",
+          memory.externalProjectId ? `Project ${memory.externalProjectId}` : null,
+          memory.lastSyncedAt ? `Synced ${memory.lastSyncedAt}` : "Not synced yet",
+        ]
+          .filter(Boolean)
+          .join(" · ");
+
+  return (
+    <div className="grid gap-3 px-5 py-4 md:grid-cols-[1.4fr_1fr_0.9fr_0.9fr_auto] md:items-center">
+      <div className="min-w-0">
+        <div className="flex flex-wrap items-center gap-2">
+          <HugeiconsIcon
+            icon={LanguageSquareIcon}
+            strokeWidth={1.7}
+            className="size-4 shrink-0 text-foreground/42"
+          />
+          <TypographyP className="truncate text-sm font-medium text-foreground">
+            {memory.name}
+          </TypographyP>
+          <SourceLabel memory={memory} />
+        </div>
+        <TypographyP className="mt-1 text-xs text-foreground/42">{sourceDetail}</TypographyP>
+        {memory.lastSyncErrorAt ? (
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <span className="mt-1 block text-xs text-destructive">
+                  Last sync failed {memory.lastSyncErrorAt}
+                </span>
+              }
+            />
+            <TooltipContent side="bottom" align="start" className="max-w-xs">
+              <p className="text-xs">{memory.lastSyncErrorMessage ?? "Unknown error"}</p>
+            </TooltipContent>
+          </Tooltip>
+        ) : null}
+        <div className="mt-2 flex flex-wrap items-center gap-2">
+          {memory.projectLinkId ? (
+            <Link
+              href={`/org/${organizationSlug}/projects/${memory.projectLinkId}`}
+              className="text-xs text-foreground/58 underline-offset-2 hover:text-foreground hover:underline"
+            >
+              View linked project
+            </Link>
+          ) : memory.externalProjectId ? (
+            <span className="text-xs text-foreground/42">
+              External project {memory.externalProjectId}
+            </span>
+          ) : null}
+          {memory.externalUrl ? (
+            <a
+              href={memory.externalUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1 text-xs text-foreground/58 hover:text-foreground"
+            >
+              Open in provider
+              <HugeiconsIcon icon={ArrowUpRight01Icon} strokeWidth={1.7} className="size-3.5" />
+            </a>
+          ) : null}
+        </div>
+      </div>
+      <TypographyP className="text-sm text-foreground/58">{memory.localeSummary}</TypographyP>
+      <TypographyP className="text-sm text-foreground/58">
+        {memory.segmentCountLabel} segments
+      </TypographyP>
+      <div className="flex flex-wrap gap-2">
+        <CapabilityBadge memory={memory} />
+      </div>
+      <SyncHealthBadge memory={memory} />
+    </div>
+  );
+}
+
+export function TranslationMemoriesTable({
+  memories,
+  memoriesQuery,
+  organizationSlug,
+  emptyTitle,
+  emptyDescription,
+  emptyAction,
+}: {
+  memories: MemoryListRow[];
+  memoriesQuery: Pick<
+    UseQueryResult<MemoryListRow[], Error>,
+    "isLoading" | "isError" | "isSuccess" | "error"
+  >;
+  organizationSlug: string;
+  emptyTitle: string;
+  emptyDescription: string;
+  emptyAction?: ReactNode;
+}) {
+  return (
+    <ResourceCard
+      title="Memory stores"
+      description="Native workspace memories and synced provider translation memories in one list."
+      icon={DatabaseSyncIcon}
+    >
+      {memoriesQuery.isLoading ? (
+        <div className="px-5 py-8 text-sm text-foreground/52">Loading translation memories...</div>
+      ) : null}
+
+      {memoriesQuery.isError ? (
+        <div className="px-5 py-8">
+          <TypographyP className="text-sm font-medium text-flame-100">
+            Translation memories failed to load.
+          </TypographyP>
+          <TypographyP className="mt-1 text-xs text-foreground/42">
+            {memoriesQuery.error instanceof Error
+              ? memoriesQuery.error.message
+              : "Try refreshing the page."}
+          </TypographyP>
+        </div>
+      ) : null}
+
+      {memoriesQuery.isSuccess && memories.length === 0 ? (
+        <div className="space-y-3 px-5 py-8">
+          <TypographyP className="text-sm font-medium text-foreground">{emptyTitle}</TypographyP>
+          <TypographyP className="text-sm text-foreground/52">{emptyDescription}</TypographyP>
+          {emptyAction}
+        </div>
+      ) : null}
+
+      {memoriesQuery.isSuccess && memories.length > 0
+        ? memories.map((memory, index) => (
+            <div key={memory.id}>
+              <MemoryRow memory={memory} organizationSlug={organizationSlug} />
+              {index < memories.length - 1 ? <Separator className="bg-foreground/8" /> : null}
+            </div>
+          ))
+        : null}
+    </ResourceCard>
+  );
+}
+
+export function TranslationMemoriesEmptyAction({
+  organizationSlug,
+  label = "Connect a provider",
+}: {
+  organizationSlug: string;
+  label?: string;
+}) {
+  return (
+    <Button
+      nativeButton={false}
+      render={<Link href={`/org/${organizationSlug}/integrations`} />}
+      variant="outline"
+      size="sm"
+    >
+      {label}
+    </Button>
+  );
+}


### PR DESCRIPTION
Wire the Translation Memories page to the unified memories API with provider-aware filters, capability labels, sync health, and project links.

## What changed

<!-- Describe the change and why it is needed. -->

## How to test

<!-- List manual checks or commands used to verify this change. -->

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review
