### PR TITLE
feat(web): use synced provider TM matches in agent translation and review

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/agent-run.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/agent-run.schema.ts
@@ -34,6 +34,27 @@ export const agentRunProposalWarningsSchema = z.object({
   confidence: z.boolean().optional(),
 });
 
+export const translationMemoryMatchSourceSchema = z.enum(["synced_database", "live_provider"]);
+
+export const agentRunTranslationMemoryMatchUsageSchema = z.object({
+  memoryId: z.string(),
+  memoryName: z.string(),
+  sourceText: z.string(),
+  targetText: z.string(),
+  targetLocale: z.string(),
+  matchScore: z.number().nullable(),
+  matchSource: translationMemoryMatchSourceSchema,
+  providerKind: z.enum(schema.externalTmsProviderKindEnum.enumValues).nullable(),
+  resourceId: z.string(),
+  externalResourceId: z.string().nullable(),
+});
+
+export const agentRunTranslationMemoryUsageEntrySchema = z.object({
+  externalStringId: z.string(),
+  key: z.string(),
+  matches: z.array(agentRunTranslationMemoryMatchUsageSchema),
+});
+
 export const agentRunProposalItemSchema = z.object({
   itemId: z.string(),
   externalStringId: z.string(),
@@ -45,6 +66,7 @@ export const agentRunProposalItemSchema = z.object({
   reviewState: agentRunProposalReviewStateSchema,
   changedFields: z.array(z.string()),
   warnings: agentRunProposalWarningsSchema,
+  translationMemoryMatchesUsed: z.array(agentRunTranslationMemoryMatchUsageSchema).optional(),
 });
 
 export const workspaceAgentRunParamsSchema = z.object({

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-agent-run-diff-review-section.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-agent-run-diff-review-section.tsx
@@ -32,6 +32,10 @@ import { cn } from "@/lib/utils";
 
 import { toneClass, type Tone } from "../../../_components/workspace-resource-shared";
 
+import {
+  TranslationMemoryMatchBadges,
+  TranslationMemoryMatchesDetail,
+} from "./job-agent-run-translation-memory";
 import type { AgentRunRecord } from "./job-provider-detail-section";
 import {
   activeWarningKinds,
@@ -131,6 +135,7 @@ function ProposalDiffRow({
             ) : null}
           </div>
           <WarningBadges item={item} />
+          <TranslationMemoryMatchBadges matches={item.translationMemoryMatchesUsed ?? []} />
           <div className="grid gap-3 lg:grid-cols-3">
             <div className="space-y-1 rounded-md border border-foreground/8 bg-foreground/2 p-3">
               <p className="text-xs font-medium uppercase tracking-wide text-foreground/42">
@@ -151,6 +156,7 @@ function ProposalDiffRow({
               <p className="text-sm whitespace-pre-wrap text-foreground/86">{item.to}</p>
             </div>
           </div>
+          <TranslationMemoryMatchesDetail matches={item.translationMemoryMatchesUsed ?? []} />
           <div className="flex flex-wrap gap-2">
             <Button
               size="sm"

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-agent-run-translation-memory.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-agent-run-translation-memory.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import type { AgentRunTranslationMemoryMatchUsage } from "@/lib/translation/translation-memory-match";
+import {
+  formatTranslationMemoryMatchSourceLabel,
+  formatTranslationMemoryResourceLabel,
+} from "@/lib/translation/agent-run-translation-memory";
+import { cn } from "@/lib/utils";
+
+import { toneClass } from "../../../_components/workspace-resource-shared";
+
+function matchSourceTone(matchSource: AgentRunTranslationMemoryMatchUsage["matchSource"]) {
+  return matchSource === "synced_database" ? "safe" : "info";
+}
+
+export function TranslationMemoryMatchBadges({
+  matches,
+  className,
+}: {
+  matches: AgentRunTranslationMemoryMatchUsage[];
+  className?: string;
+}) {
+  if (matches.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={cn("flex flex-wrap gap-1.5", className)}>
+      {matches.map((match, index) => (
+        <Badge
+          key={`${match.memoryId}:${match.targetLocale}:${index}`}
+          variant="outline"
+          className={cn("rounded-full", toneClass(matchSourceTone(match.matchSource)))}
+          title={`${match.memoryName} · ${match.sourceText} → ${match.targetText}${
+            match.matchScore !== null ? ` (${match.matchScore}%)` : ""
+          }`}
+        >
+          {formatTranslationMemoryMatchSourceLabel(match)} · {match.memoryName}
+          {match.matchScore !== null ? ` · ${match.matchScore}%` : ""}
+        </Badge>
+      ))}
+    </div>
+  );
+}
+
+export function TranslationMemoryMatchesDetail({
+  matches,
+}: {
+  matches: AgentRunTranslationMemoryMatchUsage[];
+}) {
+  if (matches.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-2 rounded-md border border-foreground/8 bg-foreground/2 p-3">
+      <p className="text-xs font-medium uppercase tracking-wide text-foreground/42">
+        Translation memory used
+      </p>
+      <ul className="space-y-2">
+        {matches.map((match, index) => (
+          <li
+            key={`${match.memoryId}:${match.targetLocale}:${index}`}
+            className="space-y-1 text-sm text-foreground/74"
+          >
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="font-medium text-foreground/86">{match.memoryName}</span>
+              <Badge
+                variant="outline"
+                className={cn("rounded-full", toneClass(matchSourceTone(match.matchSource)))}
+              >
+                {formatTranslationMemoryResourceLabel(match)}
+              </Badge>
+              {match.matchScore !== null ? (
+                <span className="text-xs text-foreground/48">{match.matchScore}% match</span>
+              ) : null}
+            </div>
+            <p className="text-xs whitespace-pre-wrap text-foreground/58">
+              {match.sourceText} → {match.targetText}
+            </p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-provider-detail-section.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-provider-detail-section.tsx
@@ -18,6 +18,11 @@ import { cn } from "@/lib/utils";
 
 import { toneClass } from "../../../_components/workspace-resource-shared";
 
+import {
+  countTranslationMemoryMatchesInUsage,
+  parseTranslationMemoryUsageFromOutputSummary,
+} from "@/lib/translation/agent-run-translation-memory";
+
 import { JobAgentRunDiffReviewSection } from "./job-agent-run-diff-review-section";
 import { JobQaFindingsSection } from "./job-qa-findings-section";
 
@@ -352,6 +357,11 @@ export function JobProviderDetailSection({
                 typeof run.outputSummary.proposedCount === "number"
                   ? run.outputSummary.proposedCount
                   : run.changedItems.length;
+              const translationMemoryUsage = parseTranslationMemoryUsageFromOutputSummary(
+                run.outputSummary,
+              );
+              const translationMemoryMatchCount =
+                countTranslationMemoryMatchesInUsage(translationMemoryUsage);
 
               return (
                 <li
@@ -365,6 +375,9 @@ export function JobProviderDetailSection({
                     <p className="text-xs text-foreground/48">
                       Started {formatDate(run.createdAt)}
                       {hasProposals ? ` · ${proposedCount} proposals` : null}
+                      {translationMemoryMatchCount > 0
+                        ? ` · ${translationMemoryMatchCount} TM match${translationMemoryMatchCount === 1 ? "" : "es"}`
+                        : null}
                     </p>
                   </div>
                   <div className="flex flex-wrap items-center gap-2">

--- a/apps/hyperlocalise-web/src/lib/providers/agent-run-proposals.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-run-proposals.ts
@@ -3,6 +3,7 @@ import {
   translationUnitHasGlossaryViolations,
   validateGlossaryForTranslationUnits,
 } from "@/lib/glossary/validate-glossary-terms-in-translation";
+import type { AgentRunTranslationMemoryMatchUsage } from "@/lib/translation/translation-memory-match";
 
 export type AgentRunProposalReviewState = "pending" | "accepted" | "rejected";
 
@@ -21,6 +22,7 @@ export type AgentRunProposalItem = {
   reviewState: AgentRunProposalReviewState;
   changedFields: string[];
   warnings: AgentRunProposalWarnings;
+  translationMemoryMatchesUsed?: AgentRunTranslationMemoryMatchUsage[];
 };
 
 type AgentRunProposalGlossaryTermInput = {
@@ -240,6 +242,16 @@ export function enrichAgentRunProposalItem(
     ? raw.changedFields.filter((field): field is string => typeof field === "string")
     : deriveChangedFields(from, to);
 
+  const translationMemoryMatchesUsed = Array.isArray(raw.translationMemoryMatchesUsed)
+    ? raw.translationMemoryMatchesUsed.filter(
+        (match): match is AgentRunTranslationMemoryMatchUsage =>
+          typeof match === "object" &&
+          match !== null &&
+          typeof (match as AgentRunTranslationMemoryMatchUsage).memoryId === "string" &&
+          typeof (match as AgentRunTranslationMemoryMatchUsage).targetLocale === "string",
+      )
+    : undefined;
+
   const warnings =
     raw.warnings && typeof raw.warnings === "object" && !Array.isArray(raw.warnings)
       ? (raw.warnings as AgentRunProposalWarnings)
@@ -271,6 +283,7 @@ export function enrichAgentRunProposalItem(
     reviewState,
     changedFields: changedFields.length > 0 ? changedFields : deriveChangedFields(from, to),
     warnings,
+    translationMemoryMatchesUsed,
   };
 }
 
@@ -324,6 +337,9 @@ export function serializeAgentRunProposalItem(item: AgentRunProposalItem) {
     reviewState: item.reviewState,
     changedFields: item.changedFields,
     warnings: item.warnings,
+    ...(item.translationMemoryMatchesUsed?.length
+      ? { translationMemoryMatchesUsed: item.translationMemoryMatchesUsed }
+      : {}),
   };
 }
 

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-api.ts
@@ -163,6 +163,27 @@ export interface CrowdinDownloadLink {
   expireIn?: string;
 }
 
+export interface CrowdinTmConcordanceSearchRequest {
+  sourceLanguageId: string;
+  targetLanguageId: string;
+  autoSubstitution: boolean;
+  minRelevant: number;
+  expressions: string[];
+}
+
+export interface CrowdinTmConcordanceSearchResult {
+  tm: {
+    id: number;
+    name: string;
+  };
+  recordId: number;
+  source: string;
+  target: string;
+  relevant: number;
+  substituted: string;
+  updatedAt: string;
+}
+
 interface CrowdinListResponse<T> {
   data: Array<{ data: T }>;
   pagination?: {
@@ -415,6 +436,27 @@ export class CrowdinApiClient {
       `/projects/${projectId}/tasks/${taskId}`,
     );
     return response.data;
+  }
+
+  /**
+   * Search translation memory concordance for source expressions.
+   */
+  async concordanceSearch(
+    projectId: number,
+    input: CrowdinTmConcordanceSearchRequest,
+  ): Promise<CrowdinTmConcordanceSearchResult[]> {
+    const response = await this.post<CrowdinListResponse<CrowdinTmConcordanceSearchResult>>(
+      `/projects/${projectId}/tms/concordance`,
+      {
+        sourceLanguageId: input.sourceLanguageId,
+        targetLanguageId: input.targetLanguageId,
+        autoSubstitution: input.autoSubstitution,
+        minRelevant: input.minRelevant,
+        expressions: input.expressions,
+      },
+    );
+
+    return response.data.map((item) => item.data);
   }
 
   /**

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-tm-matcher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-tm-matcher.ts
@@ -1,0 +1,62 @@
+import type { ExternalTmsTranslationMemoryMatcher } from "@/lib/providers/provider-translation-memory-matchers";
+import { normalizeProviderTranslationMemoryMatch } from "@/lib/translation/translation-memory-match";
+
+import { CrowdinApiClient, CrowdinApiError } from "./crowdin-api";
+
+export const searchCrowdinTranslationMemoryMatches: ExternalTmsTranslationMemoryMatcher = async ({
+  credential,
+  secretMaterial,
+  externalProjectId,
+  memory,
+  sourceLocale,
+  targetLocale,
+  sourceText,
+  limit,
+}) => {
+  const projectId = Number(externalProjectId);
+  if (Number.isNaN(projectId)) {
+    return [];
+  }
+
+  const client = new CrowdinApiClient({
+    token: secretMaterial,
+    baseUrl: credential.baseUrl ?? undefined,
+  });
+
+  let results: Awaited<ReturnType<CrowdinApiClient["concordanceSearch"]>>;
+  try {
+    results = await client.concordanceSearch(projectId, {
+      sourceLanguageId: sourceLocale,
+      targetLanguageId: targetLocale,
+      expressions: [sourceText],
+      minRelevant: 50,
+      autoSubstitution: false,
+    });
+  } catch (error) {
+    if (error instanceof CrowdinApiError && error.status === 401) {
+      throw new Error("crowdin_auth_invalid");
+    }
+    throw error;
+  }
+
+  const externalMemoryId = memory.externalMemoryId ? Number(memory.externalMemoryId) : null;
+
+  return results
+    .filter((result) => externalMemoryId === null || result.tm.id === externalMemoryId)
+    .slice(0, limit)
+    .map((result, index) =>
+      normalizeProviderTranslationMemoryMatch({
+        sourceText: result.source,
+        targetText: result.target,
+        sourceLocale,
+        targetLocale,
+        matchScore: result.relevant,
+        providerKind: "crowdin",
+        resourceId: memory.id,
+        externalResourceId: String(result.tm.id),
+        externalSegmentId: String(result.recordId),
+        memoryName: memory.name,
+        rank: 1 - index * 0.01,
+      }),
+    );
+};

--- a/apps/hyperlocalise-web/src/lib/providers/provider-agent-qa.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-agent-qa.ts
@@ -10,6 +10,7 @@ import {
   type ExternalTmsTaskContent,
 } from "@/lib/providers/external-tms-content-sync";
 import type { ExternalTmsProviderKind } from "@/lib/providers/organization-external-tms-provider-credentials";
+import { collectTranslationMemoryUsageForUnits } from "@/lib/translation/load-translation-memory-matches";
 import { getProviderContentPuller } from "@/lib/providers/provider-content-pullers";
 import { loadProjectGlossaryTerms } from "@/lib/providers/provider-job-qa/load-glossary-terms";
 import {
@@ -133,6 +134,7 @@ export type PreparedProviderAgentQaRun =
   | {
       ok: true;
       projectId: string;
+      providerKind: ExternalTmsProviderKind;
       pullRunId: string;
       content: ExternalTmsTaskContent;
       pullFailures: ExternalTmsContentSyncFailure[];
@@ -262,6 +264,7 @@ export async function prepareProviderAgentQaRun(input: {
     return {
       ok: true,
       projectId,
+      providerKind: run.providerKind,
       pullRunId: pullResult.runId,
       content: pullResult.content,
       pullFailures: pullResult.failures,
@@ -289,6 +292,7 @@ export async function completeProviderAgentQaRun(input: {
   agentRunId: string;
   organizationId: string;
   projectId: string;
+  providerKind: ExternalTmsProviderKind;
   pullRunId: string;
   content: ExternalTmsTaskContent;
   pullFailures: ExternalTmsContentSyncFailure[];
@@ -296,6 +300,18 @@ export async function completeProviderAgentQaRun(input: {
   hlResult: RunHlCheckResult;
 }): Promise<ProviderAgentQaResult> {
   const glossaryTerms = await loadProjectGlossaryTerms(input.projectId);
+  const translationMemoryUsage = await collectTranslationMemoryUsageForUnits({
+    projectId: input.projectId,
+    organizationId: input.organizationId,
+    providerKind: input.providerKind,
+    sourceLocale: input.content.sourceLocale ?? "en",
+    targetLocales: input.content.targetLocales,
+    units: input.content.units.map((unit) => ({
+      externalStringId: unit.externalStringId,
+      key: unit.key,
+      sourceText: unit.sourceText,
+    })),
+  });
   const report = await buildProviderJobQaReport(
     input.content,
     {
@@ -317,6 +333,7 @@ export async function completeProviderAgentQaRun(input: {
       summary: report.summary,
       targetLocales: input.content.targetLocales,
       sourceLocale: input.content.sourceLocale ?? null,
+      translationMemoryUsage,
     },
     changedItems: [],
     warnings: input.pullFailures.map((failure) => failure.message),
@@ -353,10 +370,25 @@ export async function executeProviderAgentQa(input: {
     targetLocales: prepared.content.targetLocales,
   });
 
+  const run = await getAgentRun({
+    runId: input.agentRunId,
+    organizationId: input.organizationId,
+  });
+
+  if (!run) {
+    return {
+      ok: false,
+      agentRunId: input.agentRunId,
+      code: "agent_run_not_found",
+      message: "Agent run not found",
+    };
+  }
+
   return completeProviderAgentQaRun({
     agentRunId: input.agentRunId,
     organizationId: input.organizationId,
     projectId: prepared.projectId,
+    providerKind: run.providerKind,
     pullRunId: prepared.pullRunId,
     content: prepared.content,
     pullFailures: prepared.pullFailures,

--- a/apps/hyperlocalise-web/src/lib/providers/provider-agent-qa.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-agent-qa.ts
@@ -370,25 +370,11 @@ export async function executeProviderAgentQa(input: {
     targetLocales: prepared.content.targetLocales,
   });
 
-  const run = await getAgentRun({
-    runId: input.agentRunId,
-    organizationId: input.organizationId,
-  });
-
-  if (!run) {
-    return {
-      ok: false,
-      agentRunId: input.agentRunId,
-      code: "agent_run_not_found",
-      message: "Agent run not found",
-    };
-  }
-
   return completeProviderAgentQaRun({
     agentRunId: input.agentRunId,
     organizationId: input.organizationId,
     projectId: prepared.projectId,
-    providerKind: run.providerKind,
+    providerKind: prepared.providerKind,
     pullRunId: prepared.pullRunId,
     content: prepared.content,
     pullFailures: prepared.pullFailures,

--- a/apps/hyperlocalise-web/src/lib/providers/provider-agent-translate.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-agent-translate.ts
@@ -21,7 +21,9 @@ import {
   assembleStringTranslationContextSnapshot,
   loadTranslationContextProject,
 } from "@/lib/translation/assemble-translation-context";
+import type { AgentRunTranslationMemoryMatchUsage } from "@/lib/translation/translation-memory-match";
 import { loadOrganizationOpenAITranslationGenerator } from "@/lib/translation/load-organization-translation-generator";
+import type { ExternalTmsProviderKind } from "@/lib/providers/organization-external-tms-provider-credentials";
 import type { StringTranslationGenerator } from "@/lib/translation/string-job-executor";
 
 export type ProviderAgentTranslationChangedItem = AgentRunProposalItem;
@@ -91,6 +93,7 @@ function buildJobInputForUnit(input: {
 }
 
 async function translateProviderUnits(input: {
+  organizationId: string;
   projectId: string;
   providerKind: string;
   content: ExternalTmsTaskContent;
@@ -101,6 +104,11 @@ async function translateProviderUnits(input: {
   const sourceLocale = input.content.sourceLocale ?? defaultSourceLocale;
   const changedItems: ProviderAgentTranslationChangedItem[] = [];
   const warnings: string[] = [];
+  const translationMemoryUsageByUnit: Array<{
+    externalStringId: string;
+    key: string;
+    matches: AgentRunTranslationMemoryMatchUsage[];
+  }> = [];
   let unitsProcessed = 0;
   let skippedApprovedLocales = 0;
 
@@ -112,6 +120,7 @@ async function translateProviderUnits(input: {
       warnings: [`Translation project ${input.projectId} was not found`],
       unitsProcessed: 0,
       skippedApprovedLocales: 0,
+      translationMemoryUsageByUnit: [],
     };
   }
 
@@ -145,10 +154,33 @@ async function translateProviderUnits(input: {
       input.projectId,
       jobInput,
       project,
+      {
+        organizationId: input.organizationId,
+        providerKind: input.providerKind as ExternalTmsProviderKind,
+      },
     );
     if (!contextSnapshot.ok) {
       warnings.push(`Skipped ${unit.key}: ${contextSnapshot.message}`);
       continue;
+    }
+
+    if (contextSnapshot.snapshot.translationMemoryMatches.length > 0) {
+      translationMemoryUsageByUnit.push({
+        externalStringId: unit.externalStringId,
+        key: unit.key,
+        matches: contextSnapshot.snapshot.translationMemoryMatches.map((match) => ({
+          memoryId: match.memoryId,
+          memoryName: match.memoryName,
+          sourceText: match.sourceText,
+          targetText: match.targetText,
+          targetLocale: match.targetLocale,
+          matchScore: match.matchScore,
+          matchSource: match.matchSource,
+          providerKind: match.providerKind,
+          resourceId: match.resourceId,
+          externalResourceId: match.externalResourceId,
+        })),
+      });
     }
 
     try {
@@ -184,6 +216,21 @@ async function translateProviderUnits(input: {
             })),
         });
 
+        const localeMatches = contextSnapshot.snapshot.translationMemoryMatches
+          .filter((match) => match.targetLocale === translation.locale)
+          .map((match) => ({
+            memoryId: match.memoryId,
+            memoryName: match.memoryName,
+            sourceText: match.sourceText,
+            targetText: match.targetText,
+            targetLocale: match.targetLocale,
+            matchScore: match.matchScore,
+            matchSource: match.matchSource,
+            providerKind: match.providerKind,
+            resourceId: match.resourceId,
+            externalResourceId: match.externalResourceId,
+          }));
+
         changedItems.push(
           serializeAgentRunProposalItem({
             itemId: buildAgentRunProposalItemId({
@@ -199,6 +246,7 @@ async function translateProviderUnits(input: {
             reviewState: "pending",
             changedFields: deriveChangedFields(from, translation.text),
             warnings: proposalWarnings,
+            translationMemoryMatchesUsed: localeMatches.length > 0 ? localeMatches : undefined,
           }),
         );
       }
@@ -213,6 +261,7 @@ async function translateProviderUnits(input: {
     warnings,
     unitsProcessed,
     skippedApprovedLocales,
+    translationMemoryUsageByUnit,
   };
 }
 
@@ -398,6 +447,7 @@ export async function executeProviderAgentTranslation(input: {
   }
 
   const translationResult = await translateProviderUnits({
+    organizationId: input.organizationId,
     projectId,
     providerKind: run.providerKind,
     content: pullResult.content,
@@ -441,6 +491,7 @@ export async function executeProviderAgentTranslation(input: {
       skippedApprovedLocales: translationResult.skippedApprovedLocales,
       targetLocales: pullResult.content.targetLocales,
       sourceLocale: pullResult.content.sourceLocale ?? defaultSourceLocale,
+      translationMemoryUsage: translationResult.translationMemoryUsageByUnit,
     },
     changedItems: translationResult.changedItems,
     warnings: translationResult.warnings,

--- a/apps/hyperlocalise-web/src/lib/providers/provider-translation-memory-matchers.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-translation-memory-matchers.ts
@@ -1,0 +1,40 @@
+import type { ExternalTmsProviderKind } from "@/lib/providers/organization-external-tms-provider-credentials";
+import { searchCrowdinTranslationMemoryMatches } from "@/lib/providers/crowdin/crowdin-tm-matcher";
+import type { NormalizedTranslationMemoryMatch } from "@/lib/translation/translation-memory-match";
+
+type ExternalTmsCredential =
+  typeof import("@/lib/database/schema").organizationExternalTmsProviderCredentials.$inferSelect;
+
+export type ExternalTmsTranslationMemoryMatcherInput = {
+  organizationId: string;
+  projectId: string;
+  providerKind: ExternalTmsProviderKind;
+  externalProjectId: string;
+  credential: ExternalTmsCredential;
+  secretMaterial: string;
+  memory: {
+    id: string;
+    name: string;
+    externalMemoryId: string | null;
+    capabilityMode: string | null;
+  };
+  sourceLocale: string;
+  targetLocale: string;
+  sourceText: string;
+  limit: number;
+};
+
+export type ExternalTmsTranslationMemoryMatcher = (
+  input: ExternalTmsTranslationMemoryMatcherInput,
+) => Promise<NormalizedTranslationMemoryMatch[]>;
+
+export function getProviderTranslationMemoryMatcher(
+  providerKind: ExternalTmsProviderKind,
+): ExternalTmsTranslationMemoryMatcher | null {
+  switch (providerKind) {
+    case "crowdin":
+      return searchCrowdinTranslationMemoryMatches;
+    default:
+      return null;
+  }
+}

--- a/apps/hyperlocalise-web/src/lib/translation/agent-run-translation-memory.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/agent-run-translation-memory.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  countTranslationMemoryMatchesInUsage,
+  formatTranslationMemoryMatchSourceLabel,
+  formatTranslationMemoryResourceLabel,
+  parseTranslationMemoryUsageFromOutputSummary,
+} from "./agent-run-translation-memory";
+
+describe("parseTranslationMemoryUsageFromOutputSummary", () => {
+  it("parses run-level translation memory usage", () => {
+    const usage = parseTranslationMemoryUsageFromOutputSummary({
+      translationMemoryUsage: [
+        {
+          externalStringId: "s1",
+          key: "welcome.title",
+          matches: [
+            {
+              memoryId: "mem-1",
+              memoryName: "Product TM",
+              sourceText: "Hello",
+              targetText: "Bonjour",
+              targetLocale: "fr",
+              matchScore: 100,
+              matchSource: "synced_database",
+              providerKind: "crowdin",
+              resourceId: "mem-1",
+              externalResourceId: "42",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(usage).toHaveLength(1);
+    expect(countTranslationMemoryMatchesInUsage(usage)).toBe(1);
+  });
+
+  it("returns null when usage is missing or empty", () => {
+    expect(parseTranslationMemoryUsageFromOutputSummary(undefined)).toBeNull();
+    expect(parseTranslationMemoryUsageFromOutputSummary({})).toBeNull();
+    expect(parseTranslationMemoryUsageFromOutputSummary({ translationMemoryUsage: [] })).toBeNull();
+  });
+});
+
+describe("formatTranslationMemoryMatchSourceLabel", () => {
+  it("labels synced and live provider sources", () => {
+    expect(
+      formatTranslationMemoryMatchSourceLabel({
+        matchSource: "synced_database",
+        providerKind: "crowdin",
+      }),
+    ).toBe("Synced database");
+
+    expect(
+      formatTranslationMemoryMatchSourceLabel({
+        matchSource: "live_provider",
+        providerKind: "crowdin",
+      }),
+    ).toBe("Live crowdin");
+  });
+
+  it("includes external resource id in resource label when present", () => {
+    expect(
+      formatTranslationMemoryResourceLabel({
+        memoryId: "mem-1",
+        memoryName: "TM",
+        sourceText: "A",
+        targetText: "B",
+        targetLocale: "fr",
+        matchScore: 90,
+        matchSource: "live_provider",
+        providerKind: "crowdin",
+        resourceId: "mem-1",
+        externalResourceId: "99",
+      }),
+    ).toContain("TM 99");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/translation/agent-run-translation-memory.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/agent-run-translation-memory.ts
@@ -1,0 +1,85 @@
+import type { ExternalTmsProviderKind } from "@/lib/providers/organization-external-tms-provider-credentials";
+import type {
+  AgentRunTranslationMemoryMatchUsage,
+  TranslationMemoryMatchSource,
+} from "@/lib/translation/translation-memory-match";
+
+export type AgentRunTranslationMemoryUsageEntry = {
+  externalStringId: string;
+  key: string;
+  matches: AgentRunTranslationMemoryMatchUsage[];
+};
+
+function isMatchUsage(value: unknown): value is AgentRunTranslationMemoryMatchUsage {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const match = value as AgentRunTranslationMemoryMatchUsage;
+  return (
+    typeof match.memoryId === "string" &&
+    typeof match.memoryName === "string" &&
+    typeof match.targetLocale === "string" &&
+    (match.matchSource === "synced_database" || match.matchSource === "live_provider")
+  );
+}
+
+function isUsageEntry(value: unknown): value is AgentRunTranslationMemoryUsageEntry {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const entry = value as AgentRunTranslationMemoryUsageEntry;
+  return (
+    typeof entry.externalStringId === "string" &&
+    typeof entry.key === "string" &&
+    Array.isArray(entry.matches) &&
+    entry.matches.every(isMatchUsage)
+  );
+}
+
+export function parseTranslationMemoryUsageFromOutputSummary(
+  outputSummary: Record<string, unknown> | undefined,
+): AgentRunTranslationMemoryUsageEntry[] | null {
+  if (!outputSummary || !Array.isArray(outputSummary.translationMemoryUsage)) {
+    return null;
+  }
+
+  const entries = outputSummary.translationMemoryUsage.filter(isUsageEntry);
+  return entries.length > 0 ? entries : null;
+}
+
+export function countTranslationMemoryMatchesInUsage(
+  usage: AgentRunTranslationMemoryUsageEntry[] | null,
+) {
+  if (!usage) {
+    return 0;
+  }
+
+  return usage.reduce((total, entry) => total + entry.matches.length, 0);
+}
+
+export function formatTranslationMemoryMatchSourceLabel(input: {
+  matchSource: TranslationMemoryMatchSource;
+  providerKind: ExternalTmsProviderKind | null;
+}) {
+  if (input.matchSource === "synced_database") {
+    return "Synced database";
+  }
+
+  if (input.providerKind) {
+    return `Live ${input.providerKind}`;
+  }
+
+  return "Live provider";
+}
+
+export function formatTranslationMemoryResourceLabel(match: AgentRunTranslationMemoryMatchUsage) {
+  const source = formatTranslationMemoryMatchSourceLabel(match);
+  const resource =
+    match.externalResourceId && match.externalResourceId !== match.resourceId
+      ? ` · TM ${match.externalResourceId}`
+      : "";
+
+  return `${source}${resource}`;
+}

--- a/apps/hyperlocalise-web/src/lib/translation/assemble-translation-context.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/assemble-translation-context.ts
@@ -2,7 +2,12 @@ import { and, desc, eq, inArray, sql } from "drizzle-orm";
 
 import type { StringTranslationJobInput } from "@/api/routes/project/job.schema";
 import { db, schema } from "@/lib/database";
-import { normalizeTranslationMemorySourceText } from "@/lib/translation/normalizeTranslationMemorySourceText";
+import type { ExternalTmsProviderKind } from "@/lib/providers/organization-external-tms-provider-credentials";
+import { loadTranslationMemoryMatchesForContext } from "@/lib/translation/load-translation-memory-matches";
+import {
+  toContextTranslationMemoryMatch,
+  type ContextTranslationMemoryMatch,
+} from "@/lib/translation/translation-memory-match";
 
 const maxContextSearchTerms = 50;
 
@@ -13,14 +18,7 @@ export type StringTranslationContextSnapshot = {
     name: string;
     translationContext: string;
   };
-  job: {
-    sourceLocale: string;
-    targetLocales: string[];
-    sourceText: string;
-    context?: string;
-    metadata?: Record<string, string>;
-    maxLength?: number;
-  };
+  job: StringTranslationJobInput;
   glossaryTerms: Array<{
     id: string;
     glossaryId: string;
@@ -32,16 +30,7 @@ export type StringTranslationContextSnapshot = {
     forbidden: boolean | null;
     rank: number;
   }>;
-  translationMemoryMatches: Array<{
-    id: string;
-    memoryId: string;
-    sourceText: string;
-    targetText: string;
-    targetLocale: string;
-    provenance: string | null;
-    matchScore: number | null;
-    rank: number;
-  }>;
+  translationMemoryMatches: ContextTranslationMemoryMatch[];
 };
 
 function buildTsQuery(input: string): string {
@@ -124,81 +113,6 @@ async function loadGlossaryTermsForContext(input: {
     .limit(20);
 }
 
-async function loadMemoryMatchesForContext(input: {
-  projectId: string;
-  sourceLocale: string;
-  targetLocales: string[];
-  sourceText: string;
-}) {
-  const attached = await db
-    .select({ memoryId: schema.projectMemories.memoryId })
-    .from(schema.projectMemories)
-    .where(eq(schema.projectMemories.projectId, input.projectId));
-  const memoryIds = attached.map((item) => item.memoryId);
-  if (memoryIds.length === 0) {
-    return [];
-  }
-
-  const normalized = normalizeTranslationMemorySourceText(input.sourceText);
-  const exactMatches = await db
-    .select({
-      id: schema.memoryEntries.id,
-      memoryId: schema.memoryEntries.memoryId,
-      sourceText: schema.memoryEntries.sourceText,
-      targetText: schema.memoryEntries.targetText,
-      targetLocale: schema.memoryEntries.targetLocale,
-      provenance: schema.memoryEntries.provenance,
-      matchScore: schema.memoryEntries.matchScore,
-      rank: sql<number>`1`.as("rank"),
-    })
-    .from(schema.memoryEntries)
-    .where(
-      and(
-        inArray(schema.memoryEntries.memoryId, memoryIds),
-        eq(schema.memoryEntries.normalizedSourceText, normalized),
-        eq(schema.memoryEntries.sourceLocale, input.sourceLocale),
-        inArray(schema.memoryEntries.targetLocale, input.targetLocales),
-        eq(schema.memoryEntries.reviewStatus, "approved"),
-      ),
-    )
-    .limit(10);
-
-  if (exactMatches.length > 0) {
-    return exactMatches;
-  }
-
-  const tsQuery = buildTsQuery(input.sourceText);
-  if (!tsQuery) {
-    return [];
-  }
-
-  return db
-    .select({
-      id: schema.memoryEntries.id,
-      memoryId: schema.memoryEntries.memoryId,
-      sourceText: schema.memoryEntries.sourceText,
-      targetText: schema.memoryEntries.targetText,
-      targetLocale: schema.memoryEntries.targetLocale,
-      provenance: schema.memoryEntries.provenance,
-      matchScore: schema.memoryEntries.matchScore,
-      rank: sql<number>`ts_rank(${schema.memoryEntries.searchVector}, to_tsquery('simple', ${tsQuery}))`.as(
-        "rank",
-      ),
-    })
-    .from(schema.memoryEntries)
-    .where(
-      and(
-        inArray(schema.memoryEntries.memoryId, memoryIds),
-        eq(schema.memoryEntries.sourceLocale, input.sourceLocale),
-        inArray(schema.memoryEntries.targetLocale, input.targetLocales),
-        eq(schema.memoryEntries.reviewStatus, "approved"),
-        sql`${schema.memoryEntries.searchVector} @@ to_tsquery('simple', ${tsQuery})`,
-      ),
-    )
-    .orderBy(desc(sql`rank`))
-    .limit(10);
-}
-
 export async function loadTranslationContextProject(projectId: string) {
   return loadProjectForContext(projectId);
 }
@@ -207,6 +121,10 @@ export async function assembleStringTranslationContextSnapshot(
   projectId: string,
   jobInput: StringTranslationJobInput,
   projectOverride?: TranslationContextProject | null,
+  options?: {
+    organizationId?: string;
+    providerKind?: ExternalTmsProviderKind;
+  },
 ) {
   const project =
     projectOverride === undefined ? await loadProjectForContext(projectId) : projectOverride;
@@ -225,12 +143,14 @@ export async function assembleStringTranslationContextSnapshot(
       targetLocales: jobInput.targetLocales,
       sourceText: jobInput.sourceText,
     }),
-    loadMemoryMatchesForContext({
+    loadTranslationMemoryMatchesForContext({
       projectId,
+      organizationId: options?.organizationId,
+      providerKind: options?.providerKind,
       sourceLocale: jobInput.sourceLocale,
       targetLocales: jobInput.targetLocales,
       sourceText: jobInput.sourceText,
-    }),
+    }).then((matches) => matches.map(toContextTranslationMemoryMatch)),
   ]);
 
   return {

--- a/apps/hyperlocalise-web/src/lib/translation/load-synced-translation-memory-matches.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/load-synced-translation-memory-matches.ts
@@ -1,0 +1,135 @@
+import { and, desc, eq, inArray, sql } from "drizzle-orm";
+
+import { db, schema } from "@/lib/database";
+import type { ExternalTmsProviderKind } from "@/lib/providers/organization-external-tms-provider-credentials";
+import {
+  normalizeSyncedDatabaseTranslationMemoryMatch,
+  type NormalizedTranslationMemoryMatch,
+} from "@/lib/translation/translation-memory-match";
+import { normalizeTranslationMemorySourceText } from "@/lib/translation/normalizeTranslationMemorySourceText";
+import { buildTranslationMemoryTsQuery } from "@/lib/translation/translation-memory-search-query";
+
+type AttachedMemory = {
+  memoryId: string;
+  memoryName: string;
+  source: (typeof schema.projectSourceEnum.enumValues)[number];
+  externalProviderKind: ExternalTmsProviderKind | null;
+  externalMemoryId: string | null;
+};
+
+async function loadAttachedMemories(projectId: string): Promise<AttachedMemory[]> {
+  const rows = await db
+    .select({
+      memoryId: schema.projectMemories.memoryId,
+      memoryName: schema.memories.name,
+      source: schema.memories.source,
+      externalProviderKind: schema.memories.externalProviderKind,
+      externalMemoryId: schema.memories.externalMemoryId,
+    })
+    .from(schema.projectMemories)
+    .innerJoin(schema.memories, eq(schema.projectMemories.memoryId, schema.memories.id))
+    .where(eq(schema.projectMemories.projectId, projectId));
+
+  return rows;
+}
+
+export async function loadSyncedTranslationMemoryMatchesForContext(input: {
+  projectId: string;
+  memoryIds?: string[];
+  sourceLocale: string;
+  targetLocales: string[];
+  sourceText: string;
+  limit?: number;
+}): Promise<NormalizedTranslationMemoryMatch[]> {
+  const attached = await loadAttachedMemories(input.projectId);
+  const memoryIds = input.memoryIds ?? attached.map((item) => item.memoryId);
+  if (memoryIds.length === 0) {
+    return [];
+  }
+
+  const memoryById = new Map(attached.map((memory) => [memory.memoryId, memory]));
+  const normalized = normalizeTranslationMemorySourceText(input.sourceText);
+  const limit = input.limit ?? 10;
+
+  const exactMatches = await db
+    .select({
+      id: schema.memoryEntries.id,
+      memoryId: schema.memoryEntries.memoryId,
+      sourceText: schema.memoryEntries.sourceText,
+      targetText: schema.memoryEntries.targetText,
+      sourceLocale: schema.memoryEntries.sourceLocale,
+      targetLocale: schema.memoryEntries.targetLocale,
+      provenance: schema.memoryEntries.provenance,
+      matchScore: schema.memoryEntries.matchScore,
+      externalKey: schema.memoryEntries.externalKey,
+      rank: sql<number>`1`.as("rank"),
+    })
+    .from(schema.memoryEntries)
+    .where(
+      and(
+        inArray(schema.memoryEntries.memoryId, memoryIds),
+        eq(schema.memoryEntries.normalizedSourceText, normalized),
+        eq(schema.memoryEntries.sourceLocale, input.sourceLocale),
+        inArray(schema.memoryEntries.targetLocale, input.targetLocales),
+        eq(schema.memoryEntries.reviewStatus, "approved"),
+      ),
+    )
+    .limit(limit);
+
+  const dbMatches =
+    exactMatches.length > 0
+      ? exactMatches
+      : await (async () => {
+          const tsQuery = buildTranslationMemoryTsQuery(input.sourceText);
+          if (!tsQuery) {
+            return [];
+          }
+
+          return db
+            .select({
+              id: schema.memoryEntries.id,
+              memoryId: schema.memoryEntries.memoryId,
+              sourceText: schema.memoryEntries.sourceText,
+              targetText: schema.memoryEntries.targetText,
+              sourceLocale: schema.memoryEntries.sourceLocale,
+              targetLocale: schema.memoryEntries.targetLocale,
+              provenance: schema.memoryEntries.provenance,
+              matchScore: schema.memoryEntries.matchScore,
+              externalKey: schema.memoryEntries.externalKey,
+              rank: sql<number>`ts_rank(${schema.memoryEntries.searchVector}, to_tsquery('simple', ${tsQuery}))`.as(
+                "rank",
+              ),
+            })
+            .from(schema.memoryEntries)
+            .where(
+              and(
+                inArray(schema.memoryEntries.memoryId, memoryIds),
+                eq(schema.memoryEntries.sourceLocale, input.sourceLocale),
+                inArray(schema.memoryEntries.targetLocale, input.targetLocales),
+                eq(schema.memoryEntries.reviewStatus, "approved"),
+                sql`${schema.memoryEntries.searchVector} @@ to_tsquery('simple', ${tsQuery})`,
+              ),
+            )
+            .orderBy(desc(sql`rank`))
+            .limit(limit);
+        })();
+
+  return dbMatches.map((entry) => {
+    const memory = memoryById.get(entry.memoryId);
+    return normalizeSyncedDatabaseTranslationMemoryMatch({
+      id: entry.id,
+      memoryId: entry.memoryId,
+      memoryName: memory?.memoryName ?? "Translation memory",
+      sourceText: entry.sourceText,
+      targetText: entry.targetText,
+      sourceLocale: entry.sourceLocale,
+      targetLocale: entry.targetLocale,
+      matchScore: entry.matchScore,
+      provenance: entry.provenance,
+      rank: entry.rank,
+      providerKind: memory?.externalProviderKind ?? null,
+      externalResourceId: memory?.externalMemoryId ?? null,
+      externalSegmentId: entry.externalKey,
+    });
+  });
+}

--- a/apps/hyperlocalise-web/src/lib/translation/load-translation-memory-matches.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/load-translation-memory-matches.ts
@@ -1,6 +1,7 @@
 import { and, eq } from "drizzle-orm";
 
 import { db, schema } from "@/lib/database";
+import { createLogger } from "@/lib/log";
 import { decryptProviderCredential } from "@/lib/security/provider-credential-crypto";
 import type { ExternalTmsProviderKind } from "@/lib/providers/organization-external-tms-provider-credentials";
 import { getProviderTranslationMemoryMatcher } from "@/lib/providers/provider-translation-memory-matchers";
@@ -11,6 +12,12 @@ import {
   type AgentRunTranslationMemoryMatchUsage,
   type NormalizedTranslationMemoryMatch,
 } from "@/lib/translation/translation-memory-match";
+
+const logger = createLogger("translation-memory-matches");
+
+function syncedCoverageKey(memoryId: string, targetLocale: string) {
+  return `${memoryId}:${targetLocale}`;
+}
 
 type AttachedMemoryRecord = {
   id: string;
@@ -94,6 +101,7 @@ async function searchLiveProviderMatches(input: {
   externalProjectId: string;
   credentialId: string;
   memories: AttachedMemoryRecord[];
+  syncedCoveredKeys: Set<string>;
   sourceLocale: string;
   targetLocales: string[];
   sourceText: string;
@@ -129,6 +137,10 @@ async function searchLiveProviderMatches(input: {
     }
 
     for (const targetLocale of input.targetLocales) {
+      if (input.syncedCoveredKeys.has(syncedCoverageKey(memory.id, targetLocale))) {
+        continue;
+      }
+
       const matches = await matcher({
         organizationId: input.organizationId,
         projectId: input.projectId,
@@ -207,12 +219,16 @@ export async function loadTranslationMemoryMatchesForContext(input: {
     limit,
   });
 
-  const syncedMemoryIds = new Set(syncedMatches.map((match) => match.memoryId));
+  const syncedCoveredKeys = new Set(
+    syncedMatches.map((match) => syncedCoverageKey(match.memoryId, match.targetLocale)),
+  );
   const liveSearchMemories = attachedMemories.filter(
     (memory) =>
       memory.capabilityMode === "live_search" &&
       memory.externalProviderKind &&
-      !syncedMemoryIds.has(memory.id),
+      input.targetLocales.some(
+        (locale) => !syncedCoveredKeys.has(syncedCoverageKey(memory.id, locale)),
+      ),
   );
 
   if (liveSearchMemories.length === 0 || !organizationId || !providerKind) {
@@ -242,12 +258,22 @@ export async function loadTranslationMemoryMatchesForContext(input: {
       externalProjectId,
       credentialId,
       memories: liveSearchMemories,
+      syncedCoveredKeys,
       sourceLocale: input.sourceLocale,
       targetLocales: input.targetLocales,
       sourceText: input.sourceText,
       limit,
     });
-  } catch {
+  } catch (error) {
+    logger.error(
+      {
+        err: error,
+        projectId: input.projectId,
+        organizationId,
+        providerKind,
+      },
+      "Live translation memory search failed; returning synced matches only",
+    );
     return mergeTranslationMemoryMatches(syncedMatches, limit);
   }
 

--- a/apps/hyperlocalise-web/src/lib/translation/load-translation-memory-matches.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/load-translation-memory-matches.ts
@@ -1,0 +1,298 @@
+import { and, eq } from "drizzle-orm";
+
+import { db, schema } from "@/lib/database";
+import { decryptProviderCredential } from "@/lib/security/provider-credential-crypto";
+import type { ExternalTmsProviderKind } from "@/lib/providers/organization-external-tms-provider-credentials";
+import { getProviderTranslationMemoryMatcher } from "@/lib/providers/provider-translation-memory-matchers";
+import { loadSyncedTranslationMemoryMatchesForContext } from "@/lib/translation/load-synced-translation-memory-matches";
+import {
+  mergeTranslationMemoryMatches,
+  toAgentRunTranslationMemoryMatchUsage,
+  type AgentRunTranslationMemoryMatchUsage,
+  type NormalizedTranslationMemoryMatch,
+} from "@/lib/translation/translation-memory-match";
+
+type AttachedMemoryRecord = {
+  id: string;
+  name: string;
+  source: (typeof schema.projectSourceEnum.enumValues)[number];
+  capabilityMode: (typeof schema.externalTmsMemoryCapabilityModeEnum.enumValues)[number] | null;
+  externalProviderKind: ExternalTmsProviderKind | null;
+  externalMemoryId: string | null;
+  externalProviderCredentialId: string | null;
+  externalProjectId: string | null;
+};
+
+async function loadAttachedMemoriesForProject(projectId: string): Promise<AttachedMemoryRecord[]> {
+  return db
+    .select({
+      id: schema.memories.id,
+      name: schema.memories.name,
+      source: schema.memories.source,
+      capabilityMode: schema.memories.capabilityMode,
+      externalProviderKind: schema.memories.externalProviderKind,
+      externalMemoryId: schema.memories.externalMemoryId,
+      externalProviderCredentialId: schema.memories.externalProviderCredentialId,
+      externalProjectId: schema.memories.externalProjectId,
+    })
+    .from(schema.projectMemories)
+    .innerJoin(schema.memories, eq(schema.projectMemories.memoryId, schema.memories.id))
+    .where(eq(schema.projectMemories.projectId, projectId));
+}
+
+async function loadExternalTmsProject(input: {
+  organizationId: string;
+  projectId: string;
+  providerKind: ExternalTmsProviderKind;
+}) {
+  const [project] = await db
+    .select({
+      id: schema.projects.id,
+      organizationId: schema.projects.organizationId,
+      externalProjectId: schema.projects.externalProjectId,
+      externalProviderCredentialId: schema.projects.externalProviderCredentialId,
+      externalProviderKind: schema.projects.externalProviderKind,
+    })
+    .from(schema.projects)
+    .where(
+      and(
+        eq(schema.projects.id, input.projectId),
+        eq(schema.projects.organizationId, input.organizationId),
+        eq(schema.projects.externalProviderKind, input.providerKind),
+        eq(schema.projects.source, "external_tms"),
+      ),
+    )
+    .limit(1);
+
+  return project ?? null;
+}
+
+async function loadProviderCredential(input: {
+  organizationId: string;
+  providerKind: ExternalTmsProviderKind;
+  credentialId: string;
+}) {
+  const [credential] = await db
+    .select()
+    .from(schema.organizationExternalTmsProviderCredentials)
+    .where(
+      and(
+        eq(schema.organizationExternalTmsProviderCredentials.organizationId, input.organizationId),
+        eq(schema.organizationExternalTmsProviderCredentials.providerKind, input.providerKind),
+        eq(schema.organizationExternalTmsProviderCredentials.id, input.credentialId),
+      ),
+    )
+    .limit(1);
+
+  return credential ?? null;
+}
+
+async function searchLiveProviderMatches(input: {
+  organizationId: string;
+  projectId: string;
+  providerKind: ExternalTmsProviderKind;
+  externalProjectId: string;
+  credentialId: string;
+  memories: AttachedMemoryRecord[];
+  sourceLocale: string;
+  targetLocales: string[];
+  sourceText: string;
+  limit: number;
+}): Promise<NormalizedTranslationMemoryMatch[]> {
+  const matcher = getProviderTranslationMemoryMatcher(input.providerKind);
+  if (!matcher) {
+    return [];
+  }
+
+  const credential = await loadProviderCredential({
+    organizationId: input.organizationId,
+    providerKind: input.providerKind,
+    credentialId: input.credentialId,
+  });
+  if (!credential) {
+    return [];
+  }
+
+  const secretMaterial = decryptProviderCredential({
+    algorithm: credential.encryptionAlgorithm,
+    keyVersion: credential.keyVersion,
+    ciphertext: credential.ciphertext,
+    iv: credential.iv,
+    authTag: credential.authTag,
+  });
+
+  const liveMatches: NormalizedTranslationMemoryMatch[] = [];
+
+  for (const memory of input.memories) {
+    if (memory.capabilityMode !== "live_search") {
+      continue;
+    }
+
+    for (const targetLocale of input.targetLocales) {
+      const matches = await matcher({
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        providerKind: input.providerKind,
+        externalProjectId: input.externalProjectId,
+        credential,
+        secretMaterial,
+        memory: {
+          id: memory.id,
+          name: memory.name,
+          externalMemoryId: memory.externalMemoryId,
+          capabilityMode: memory.capabilityMode,
+        },
+        sourceLocale: input.sourceLocale,
+        targetLocale,
+        sourceText: input.sourceText,
+        limit: input.limit,
+      });
+
+      liveMatches.push(...matches.filter((match) => match.targetLocale === targetLocale));
+    }
+  }
+
+  return liveMatches;
+}
+
+async function resolveProjectOrganizationId(projectId: string) {
+  const [project] = await db
+    .select({
+      organizationId: schema.projects.organizationId,
+      externalProviderKind: schema.projects.externalProviderKind,
+    })
+    .from(schema.projects)
+    .where(eq(schema.projects.id, projectId))
+    .limit(1);
+
+  return project ?? null;
+}
+
+export async function loadTranslationMemoryMatchesForContext(input: {
+  projectId: string;
+  organizationId?: string;
+  providerKind?: ExternalTmsProviderKind;
+  sourceLocale: string;
+  targetLocales: string[];
+  sourceText: string;
+  limit?: number;
+}): Promise<NormalizedTranslationMemoryMatch[]> {
+  const limit = input.limit ?? 10;
+  const projectContext =
+    input.organizationId && input.providerKind
+      ? null
+      : await resolveProjectOrganizationId(input.projectId);
+  const organizationId = input.organizationId ?? projectContext?.organizationId;
+  const providerKind = input.providerKind ?? projectContext?.externalProviderKind ?? undefined;
+
+  const attachedMemories = await loadAttachedMemoriesForProject(input.projectId);
+  if (attachedMemories.length === 0) {
+    return [];
+  }
+
+  const searchableMemoryIds = attachedMemories
+    .filter((memory) => memory.capabilityMode !== "reference_only")
+    .map((memory) => memory.id);
+
+  if (searchableMemoryIds.length === 0) {
+    return [];
+  }
+
+  const syncedMatches = await loadSyncedTranslationMemoryMatchesForContext({
+    projectId: input.projectId,
+    memoryIds: searchableMemoryIds,
+    sourceLocale: input.sourceLocale,
+    targetLocales: input.targetLocales,
+    sourceText: input.sourceText,
+    limit,
+  });
+
+  const syncedMemoryIds = new Set(syncedMatches.map((match) => match.memoryId));
+  const liveSearchMemories = attachedMemories.filter(
+    (memory) =>
+      memory.capabilityMode === "live_search" &&
+      memory.externalProviderKind &&
+      !syncedMemoryIds.has(memory.id),
+  );
+
+  if (liveSearchMemories.length === 0 || !organizationId || !providerKind) {
+    return mergeTranslationMemoryMatches(syncedMatches, limit);
+  }
+
+  const project = await loadExternalTmsProject({
+    organizationId,
+    projectId: input.projectId,
+    providerKind,
+  });
+
+  const credentialId =
+    project?.externalProviderCredentialId ?? liveSearchMemories[0]?.externalProviderCredentialId;
+  const externalProjectId = project?.externalProjectId ?? liveSearchMemories[0]?.externalProjectId;
+
+  if (!credentialId || !externalProjectId) {
+    return mergeTranslationMemoryMatches(syncedMatches, limit);
+  }
+
+  let liveMatches: NormalizedTranslationMemoryMatch[] = [];
+  try {
+    liveMatches = await searchLiveProviderMatches({
+      organizationId,
+      projectId: input.projectId,
+      providerKind,
+      externalProjectId,
+      credentialId,
+      memories: liveSearchMemories,
+      sourceLocale: input.sourceLocale,
+      targetLocales: input.targetLocales,
+      sourceText: input.sourceText,
+      limit,
+    });
+  } catch {
+    return mergeTranslationMemoryMatches(syncedMatches, limit);
+  }
+
+  return mergeTranslationMemoryMatches([...syncedMatches, ...liveMatches], limit);
+}
+
+export async function collectTranslationMemoryUsageForUnits(input: {
+  projectId: string;
+  organizationId: string;
+  providerKind?: ExternalTmsProviderKind;
+  sourceLocale: string;
+  targetLocales: string[];
+  units: Array<{ externalStringId: string; key: string; sourceText: string }>;
+  maxUnits?: number;
+}) {
+  const sample = input.units
+    .filter((unit) => unit.sourceText.trim().length > 0)
+    .slice(0, input.maxUnits ?? 5);
+
+  const usage: Array<{
+    externalStringId: string;
+    key: string;
+    matches: AgentRunTranslationMemoryMatchUsage[];
+  }> = [];
+
+  for (const unit of sample) {
+    const matches = await loadTranslationMemoryMatchesForContext({
+      projectId: input.projectId,
+      organizationId: input.organizationId,
+      providerKind: input.providerKind,
+      sourceLocale: input.sourceLocale,
+      targetLocales: input.targetLocales,
+      sourceText: unit.sourceText,
+    });
+
+    if (matches.length === 0) {
+      continue;
+    }
+
+    usage.push({
+      externalStringId: unit.externalStringId,
+      key: unit.key,
+      matches: matches.map(toAgentRunTranslationMemoryMatchUsage),
+    });
+  }
+
+  return usage;
+}

--- a/apps/hyperlocalise-web/src/lib/translation/translation-memory-match.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/translation-memory-match.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  mergeTranslationMemoryMatches,
+  normalizeProviderTranslationMemoryMatch,
+  normalizeSyncedDatabaseTranslationMemoryMatch,
+  toAgentRunTranslationMemoryMatchUsage,
+  toContextTranslationMemoryMatch,
+} from "./translation-memory-match";
+
+describe("normalizeProviderTranslationMemoryMatch", () => {
+  it("normalizes Crowdin concordance fields into a provider-neutral match", () => {
+    const match = normalizeProviderTranslationMemoryMatch({
+      sourceText: "Hello",
+      targetText: "Bonjour",
+      sourceLocale: "en",
+      targetLocale: "fr",
+      matchScore: 92,
+      providerKind: "crowdin",
+      resourceId: "memory-1",
+      externalResourceId: "42",
+      externalSegmentId: "99",
+      memoryName: "Product TM",
+      rank: 0.95,
+    });
+
+    expect(match).toMatchObject({
+      memoryId: "memory-1",
+      memoryName: "Product TM",
+      sourceText: "Hello",
+      targetText: "Bonjour",
+      sourceLocale: "en",
+      targetLocale: "fr",
+      matchScore: 92,
+      matchSource: "live_provider",
+      providerKind: "crowdin",
+      resourceId: "memory-1",
+      externalResourceId: "42",
+      externalSegmentId: "99",
+      rank: 0.95,
+    });
+  });
+
+  it("clamps match scores to 0-100", () => {
+    const match = normalizeProviderTranslationMemoryMatch({
+      sourceText: "A",
+      targetText: "B",
+      sourceLocale: "en",
+      targetLocale: "fr",
+      matchScore: 150,
+      providerKind: "crowdin",
+      resourceId: "memory-1",
+      memoryName: "TM",
+    });
+
+    expect(match.matchScore).toBe(100);
+  });
+});
+
+describe("normalizeSyncedDatabaseTranslationMemoryMatch", () => {
+  it("marks synced database entries with resource metadata", () => {
+    const match = normalizeSyncedDatabaseTranslationMemoryMatch({
+      id: "entry-1",
+      memoryId: "memory-1",
+      memoryName: "Synced TM",
+      sourceText: "Save",
+      targetText: "Enregistrer",
+      sourceLocale: "en",
+      targetLocale: "fr",
+      matchScore: 100,
+      provenance: "sync",
+      rank: 1,
+      providerKind: "phrase",
+      externalResourceId: "tm-phrase-1",
+      externalSegmentId: "seg-1",
+    });
+
+    expect(match.matchSource).toBe("synced_database");
+    expect(match.resourceId).toBe("memory-1");
+    expect(match.externalResourceId).toBe("tm-phrase-1");
+  });
+});
+
+describe("mergeTranslationMemoryMatches", () => {
+  it("prefers synced database matches over live provider duplicates", () => {
+    const synced = normalizeSyncedDatabaseTranslationMemoryMatch({
+      id: "entry-1",
+      memoryId: "memory-1",
+      memoryName: "Synced TM",
+      sourceText: "Hello",
+      targetText: "Bonjour",
+      sourceLocale: "en",
+      targetLocale: "fr",
+      matchScore: 100,
+      provenance: "sync",
+      rank: 1,
+      providerKind: "crowdin",
+      externalResourceId: "42",
+      externalSegmentId: "1",
+    });
+
+    const live = normalizeProviderTranslationMemoryMatch({
+      sourceText: "Hello",
+      targetText: "Bonjour",
+      sourceLocale: "en",
+      targetLocale: "fr",
+      matchScore: 80,
+      providerKind: "crowdin",
+      resourceId: "memory-1",
+      externalResourceId: "42",
+      memoryName: "Synced TM",
+    });
+
+    const merged = mergeTranslationMemoryMatches([live, synced], 5);
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.matchSource).toBe("synced_database");
+  });
+});
+
+describe("context and agent run projections", () => {
+  it("projects normalized matches for prompts and run output", () => {
+    const normalized = normalizeSyncedDatabaseTranslationMemoryMatch({
+      id: "entry-1",
+      memoryId: "memory-1",
+      memoryName: "Synced TM",
+      sourceText: "Hello",
+      targetText: "Bonjour",
+      sourceLocale: "en",
+      targetLocale: "fr",
+      matchScore: 100,
+      provenance: "sync",
+      rank: 1,
+      providerKind: "crowdin",
+      externalResourceId: "42",
+      externalSegmentId: "1",
+    });
+
+    expect(toContextTranslationMemoryMatch(normalized)).toMatchObject({
+      matchSource: "synced_database",
+      resourceId: "memory-1",
+      externalResourceId: "42",
+    });
+
+    expect(toAgentRunTranslationMemoryMatchUsage(normalized)).toMatchObject({
+      matchSource: "synced_database",
+      resourceId: "memory-1",
+      memoryName: "Synced TM",
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/translation/translation-memory-match.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/translation-memory-match.ts
@@ -187,6 +187,11 @@ export function mergeTranslationMemoryMatches(
       continue;
     }
 
+    // Never let a live_provider result overwrite an already-stored synced_database entry.
+    if (existing.matchSource === "synced_database" && match.matchSource === "live_provider") {
+      continue;
+    }
+
     if (match.rank > existing.rank || (match.matchScore ?? 0) > (existing.matchScore ?? 0)) {
       byKey.set(key, match);
     }

--- a/apps/hyperlocalise-web/src/lib/translation/translation-memory-match.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/translation-memory-match.ts
@@ -1,0 +1,203 @@
+import type { ExternalTmsProviderKind } from "@/lib/providers/organization-external-tms-provider-credentials";
+
+export type TranslationMemoryMatchSource = "synced_database" | "live_provider";
+
+export type NormalizedTranslationMemoryMatch = {
+  id: string;
+  memoryId: string;
+  memoryName: string;
+  sourceText: string;
+  targetText: string;
+  sourceLocale: string;
+  targetLocale: string;
+  matchScore: number | null;
+  provenance: string | null;
+  rank: number;
+  matchSource: TranslationMemoryMatchSource;
+  providerKind: ExternalTmsProviderKind | null;
+  resourceId: string;
+  externalResourceId: string | null;
+  externalSegmentId: string | null;
+};
+
+export type ContextTranslationMemoryMatch = {
+  id: string;
+  memoryId: string;
+  memoryName: string;
+  sourceText: string;
+  targetText: string;
+  targetLocale: string;
+  provenance: string | null;
+  matchScore: number | null;
+  rank: number;
+  matchSource: TranslationMemoryMatchSource;
+  providerKind: ExternalTmsProviderKind | null;
+  resourceId: string;
+  externalResourceId: string | null;
+};
+
+export type AgentRunTranslationMemoryMatchUsage = {
+  memoryId: string;
+  memoryName: string;
+  sourceText: string;
+  targetText: string;
+  targetLocale: string;
+  matchScore: number | null;
+  matchSource: TranslationMemoryMatchSource;
+  providerKind: ExternalTmsProviderKind | null;
+  resourceId: string;
+  externalResourceId: string | null;
+};
+
+export type ProviderTranslationMemoryMatchInput = {
+  sourceText: string;
+  targetText: string;
+  sourceLocale: string;
+  targetLocale: string;
+  matchScore?: number | null;
+  providerKind: ExternalTmsProviderKind;
+  resourceId: string;
+  externalResourceId?: string | null;
+  externalSegmentId?: string | null;
+  memoryName: string;
+  rank?: number;
+};
+
+function clampMatchScore(score: number | null | undefined): number | null {
+  if (score === null || score === undefined || !Number.isFinite(score)) {
+    return null;
+  }
+
+  return Math.max(0, Math.min(100, Math.round(score)));
+}
+
+export function normalizeProviderTranslationMemoryMatch(
+  input: ProviderTranslationMemoryMatchInput,
+): NormalizedTranslationMemoryMatch {
+  const externalResourceId = input.externalResourceId ?? null;
+  const externalSegmentId = input.externalSegmentId ?? null;
+  const rank = input.rank ?? 1;
+
+  return {
+    id: `live:${input.providerKind}:${externalResourceId ?? input.resourceId}:${externalSegmentId ?? input.sourceText}:${input.targetLocale}`,
+    memoryId: input.resourceId,
+    memoryName: input.memoryName,
+    sourceText: input.sourceText,
+    targetText: input.targetText,
+    sourceLocale: input.sourceLocale,
+    targetLocale: input.targetLocale,
+    matchScore: clampMatchScore(input.matchScore),
+    provenance: "live_provider",
+    rank,
+    matchSource: "live_provider",
+    providerKind: input.providerKind,
+    resourceId: input.resourceId,
+    externalResourceId,
+    externalSegmentId,
+  };
+}
+
+export function normalizeSyncedDatabaseTranslationMemoryMatch(input: {
+  id: string;
+  memoryId: string;
+  memoryName: string;
+  sourceText: string;
+  targetText: string;
+  sourceLocale: string;
+  targetLocale: string;
+  matchScore: number | null;
+  provenance: string | null;
+  rank: number;
+  providerKind: ExternalTmsProviderKind | null;
+  externalResourceId: string | null;
+  externalSegmentId: string | null;
+}): NormalizedTranslationMemoryMatch {
+  return {
+    id: input.id,
+    memoryId: input.memoryId,
+    memoryName: input.memoryName,
+    sourceText: input.sourceText,
+    targetText: input.targetText,
+    sourceLocale: input.sourceLocale,
+    targetLocale: input.targetLocale,
+    matchScore: clampMatchScore(input.matchScore),
+    provenance: input.provenance,
+    rank: input.rank,
+    matchSource: "synced_database",
+    providerKind: input.providerKind,
+    resourceId: input.memoryId,
+    externalResourceId: input.externalResourceId,
+    externalSegmentId: input.externalSegmentId,
+  };
+}
+
+export function toContextTranslationMemoryMatch(
+  match: NormalizedTranslationMemoryMatch,
+): ContextTranslationMemoryMatch {
+  return {
+    id: match.id,
+    memoryId: match.memoryId,
+    memoryName: match.memoryName,
+    sourceText: match.sourceText,
+    targetText: match.targetText,
+    targetLocale: match.targetLocale,
+    provenance: match.provenance,
+    matchScore: match.matchScore,
+    rank: match.rank,
+    matchSource: match.matchSource,
+    providerKind: match.providerKind,
+    resourceId: match.resourceId,
+    externalResourceId: match.externalResourceId,
+  };
+}
+
+export function toAgentRunTranslationMemoryMatchUsage(
+  match: NormalizedTranslationMemoryMatch,
+): AgentRunTranslationMemoryMatchUsage {
+  return {
+    memoryId: match.memoryId,
+    memoryName: match.memoryName,
+    sourceText: match.sourceText,
+    targetText: match.targetText,
+    targetLocale: match.targetLocale,
+    matchScore: match.matchScore,
+    matchSource: match.matchSource,
+    providerKind: match.providerKind,
+    resourceId: match.resourceId,
+    externalResourceId: match.externalResourceId,
+  };
+}
+
+export function mergeTranslationMemoryMatches(
+  matches: NormalizedTranslationMemoryMatch[],
+  limit = 10,
+): NormalizedTranslationMemoryMatch[] {
+  const byKey = new Map<string, NormalizedTranslationMemoryMatch>();
+
+  for (const match of matches) {
+    const key = `${match.memoryId}:${match.targetLocale}:${match.sourceText}:${match.targetText}`;
+    const existing = byKey.get(key);
+    if (!existing) {
+      byKey.set(key, match);
+      continue;
+    }
+
+    if (existing.matchSource === "live_provider" && match.matchSource === "synced_database") {
+      byKey.set(key, match);
+      continue;
+    }
+
+    if (match.rank > existing.rank || (match.matchScore ?? 0) > (existing.matchScore ?? 0)) {
+      byKey.set(key, match);
+    }
+  }
+
+  return [...byKey.values()]
+    .toSorted((left, right) => {
+      if (right.rank !== left.rank) {
+        return right.rank - left.rank;
+      }
+      return (right.matchScore ?? 0) - (left.matchScore ?? 0);
+    })
+    .slice(0, limit);
+}

--- a/apps/hyperlocalise-web/src/lib/translation/translation-memory-search-query.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/translation-memory-search-query.ts
@@ -1,0 +1,12 @@
+const maxContextSearchTerms = 50;
+
+export function buildTranslationMemoryTsQuery(input: string): string {
+  return input
+    .replace(/[&|!():*<>'"-]/g, " ")
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, maxContextSearchTerms)
+    .map((word) => `${word}:*`)
+    .join(" & ");
+}

--- a/apps/hyperlocalise-web/src/workflows/provider-agent-qa.ts
+++ b/apps/hyperlocalise-web/src/workflows/provider-agent-qa.ts
@@ -46,6 +46,7 @@ export async function providerAgentQaWorkflow(event: ProviderAgentQaEventData) {
       agentRunId: event.agentRunId,
       organizationId: event.organizationId,
       projectId: prepared.projectId,
+      providerKind: prepared.providerKind,
       pullRunId: prepared.pullRunId,
       content: prepared.content,
       pullFailures: prepared.pullFailures,

--- a/apps/hyperlocalise-web/src/workflows/steps/provider-agent-qa.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/provider-agent-qa.ts
@@ -3,6 +3,7 @@ import type {
   ExternalTmsContentSyncFailure,
   ExternalTmsTaskContent,
 } from "@/lib/providers/external-tms-content-sync";
+import type { ExternalTmsProviderKind } from "@/lib/providers/organization-external-tms-provider-credentials";
 import {
   completeProviderAgentQaRun,
   prepareProviderAgentQaRun,
@@ -21,6 +22,7 @@ export async function completeProviderAgentQaStep(input: {
   agentRunId: string;
   organizationId: string;
   projectId: string;
+  providerKind: ExternalTmsProviderKind;
   pullRunId: string;
   content: ExternalTmsTaskContent;
   pullFailures: ExternalTmsContentSyncFailure[];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Implements HL-379 by feeding translation memory matches from synced database entries and live provider APIs into provider agent translate/review workflows.

- **Provider-neutral TM layer**: `NormalizedTranslationMemoryMatch` with score, locale pair, provider, resource ID, and `matchSource` (`synced_database` | `live_provider`). Merge prefers synced hits over live duplicates.
- **Unified loader**: `loadTranslationMemoryMatchesForContext` searches attached project memories (synced import / live search), with Crowdin concordance as the first live matcher.
- **Agent context**: `assembleStringTranslationContextSnapshot` uses the unified loader and passes org/provider for live search.
- **Run output**: Translate runs store per-proposal `translationMemoryMatchesUsed` and run-level `translationMemoryUsage`; QA/review runs store sampled `translationMemoryUsage` in `outputSummary`.
- **UI**: Job agent activity shows TM match counts; proposal review shows badges and detail for each match (synced vs live provider + external TM id).

## How to test

```bash
cd apps/hyperlocalise-web
pnpm install
./node_modules/.bin/vp check --fix
./node_modules/.bin/vp test src/lib/translation/ src/lib/providers/agent-run-proposals.test.ts
```

With Postgres and a Crowdin project with `live_search` TM memories attached, run a provider **Translate** agent action and confirm proposals list TM usage; run **Review/QA** and confirm `outputSummary.translationMemoryUsage` in agent activity.

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, targeted `vp test`)
- [x] This PR is scoped and ready for review

Resolves HL-379
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-379](https://linear.app/hyperlocalise/issue/HL-379/use-synced-provider-tm-matches-in-agent-translation-and-review)

<div><a href="https://cursor.com/agents/bc-795fe4f6-24db-4f3e-bd10-61b2873acfae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-795fe4f6-24db-4f3e-bd10-61b2873acfae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

