### PR TITLE
feat(glossaries): show synced provider terminology in unified UI

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary-list-filters.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary-list-filters.ts
@@ -37,6 +37,9 @@ export function buildGlossaryListWhere(
   if (query?.sync) {
     if (query.sync === "error") {
       conditions.push(isNotNull(schema.glossaries.lastSyncErrorAt));
+    } else if (query.sync === "synced") {
+      conditions.push(eq(schema.glossaries.syncState, query.sync));
+      conditions.push(isNull(schema.glossaries.lastSyncErrorAt));
     } else {
       conditions.push(eq(schema.glossaries.syncState, query.sync));
     }

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary-list-filters.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary-list-filters.ts
@@ -1,4 +1,4 @@
-import { and, eq, ilike, isNotNull, or, type SQL } from "drizzle-orm";
+import { and, eq, ilike, isNotNull, isNull, or, type SQL } from "drizzle-orm";
 
 import { schema } from "@/lib/database";
 

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary-list-filters.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary-list-filters.ts
@@ -1,0 +1,46 @@
+import { and, eq, ilike, isNotNull, or, type SQL } from "drizzle-orm";
+
+import { schema } from "@/lib/database";
+
+import type { ListGlossaryQuery } from "./glossary.schema";
+
+export function buildGlossaryListWhere(
+  organizationId: string,
+  query?: ListGlossaryQuery,
+): SQL | undefined {
+  const conditions: SQL[] = [eq(schema.glossaries.organizationId, organizationId)];
+
+  const search = query?.search?.trim();
+  if (search) {
+    const pattern = `%${search}%`;
+    conditions.push(
+      or(
+        ilike(schema.glossaries.name, pattern),
+        ilike(schema.glossaries.externalProjectId, pattern),
+        ilike(schema.glossaries.externalGlossaryId, pattern),
+      )!,
+    );
+  }
+
+  if (query?.source) {
+    conditions.push(eq(schema.glossaries.source, query.source));
+  }
+
+  if (query?.provider) {
+    conditions.push(eq(schema.glossaries.externalProviderKind, query.provider));
+  }
+
+  if (query?.resourceType) {
+    conditions.push(eq(schema.glossaries.externalResourceType, query.resourceType));
+  }
+
+  if (query?.sync) {
+    if (query.sync === "error") {
+      conditions.push(isNotNull(schema.glossaries.lastSyncErrorAt));
+    } else {
+      conditions.push(eq(schema.glossaries.syncState, query.sync));
+    }
+  }
+
+  return and(...conditions);
+}

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary.route.ts
@@ -1,4 +1,4 @@
-import { desc, eq } from "drizzle-orm";
+import { count, desc, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { validator } from "hono/validator";
 
@@ -18,6 +18,7 @@ import {
   type UpdateGlossaryBody,
 } from "./glossary.schema";
 import {
+  externalTmsGlossaryImmutableResponse,
   forbiddenResponse,
   invalidGlossaryPayloadResponse,
   isGlossaryMutationAllowed,
@@ -25,8 +26,13 @@ import {
   glossaryNotFoundResponse,
 } from "./glossary.shared";
 
+type GlossaryListResult = {
+  glossaries: Glossary[];
+  total: number;
+};
+
 type GlossaryStore = {
-  list(auth: ApiAuthContext, query?: ListGlossaryQuery): Promise<Glossary[]>;
+  list(auth: ApiAuthContext, query?: ListGlossaryQuery): Promise<GlossaryListResult>;
   create(auth: ApiAuthContext, payload: CreateGlossaryBody): Promise<Glossary>;
   getById(auth: ApiAuthContext, glossaryId: string): Promise<Glossary | null>;
   update(
@@ -41,13 +47,20 @@ const glossaryStore: GlossaryStore = {
   async list(auth, query) {
     const limit = query?.limit ?? 50;
     const offset = query?.offset ?? 0;
-    return db
-      .select()
-      .from(schema.glossaries)
-      .where(eq(schema.glossaries.organizationId, auth.organization.localOrganizationId))
-      .orderBy(desc(schema.glossaries.createdAt))
-      .limit(limit)
-      .offset(offset);
+    const where = eq(schema.glossaries.organizationId, auth.organization.localOrganizationId);
+
+    const [glossaries, totalRow] = await Promise.all([
+      db
+        .select()
+        .from(schema.glossaries)
+        .where(where)
+        .orderBy(desc(schema.glossaries.createdAt))
+        .limit(limit)
+        .offset(offset),
+      db.select({ value: count() }).from(schema.glossaries).where(where),
+    ]);
+
+    return { glossaries, total: totalRow[0]?.value ?? 0 };
   },
   async create(auth, payload) {
     const [glossary] = await db
@@ -137,8 +150,8 @@ export function createGlossaryRoutes() {
     .use("*", workosAuthMiddleware)
     .get("/", validateListGlossaryQuery, async (c) => {
       const query = c.req.valid("query");
-      const glossaries = await glossaryStore.list(c.var.auth, query);
-      return c.json({ glossaries: glossaries.map(toGlossaryRecord) }, 200);
+      const { glossaries, total } = await glossaryStore.list(c.var.auth, query);
+      return c.json({ glossaries: glossaries.map(toGlossaryRecord), total }, 200);
     })
     .post("/", validateCreateGlossaryBody, async (c) => {
       if (!isGlossaryMutationAllowed(c.var.auth.membership.role)) {
@@ -181,13 +194,23 @@ export function createGlossaryRoutes() {
 
       const params = c.req.valid("param");
       const payload = c.req.valid("json");
-      const glossary = await glossaryStore.update(c.var.auth, params.glossaryId, payload);
+      const glossary = await glossaryStore.getById(c.var.auth, params.glossaryId);
 
       if (!glossary) {
         return glossaryNotFoundResponse(c);
       }
 
-      return c.json({ glossary: toGlossaryRecord(glossary) }, 200);
+      if (glossary.source === "external_tms") {
+        return externalTmsGlossaryImmutableResponse(c);
+      }
+
+      const updated = await glossaryStore.update(c.var.auth, params.glossaryId, payload);
+
+      if (!updated) {
+        return glossaryNotFoundResponse(c);
+      }
+
+      return c.json({ glossary: toGlossaryRecord(updated) }, 200);
     })
     .delete("/:glossaryId", validateGlossaryParams, async (c) => {
       if (!isGlossaryMutationAllowed(c.var.auth.membership.role)) {
@@ -195,6 +218,16 @@ export function createGlossaryRoutes() {
       }
 
       const params = c.req.valid("param");
+      const glossary = await glossaryStore.getById(c.var.auth, params.glossaryId);
+
+      if (!glossary) {
+        return glossaryNotFoundResponse(c);
+      }
+
+      if (glossary.source === "external_tms") {
+        return externalTmsGlossaryImmutableResponse(c);
+      }
+
       const deleted = await glossaryStore.delete(c.var.auth, params.glossaryId);
 
       if (!deleted) {

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary.route.ts
@@ -1,4 +1,4 @@
-import { count, desc, eq } from "drizzle-orm";
+import { count, desc } from "drizzle-orm";
 import { Hono } from "hono";
 import { validator } from "hono/validator";
 
@@ -8,6 +8,7 @@ import type { Glossary } from "@/lib/database/types";
 import { toGlossaryRecord } from "@/lib/glossary/glossary-records";
 import { listGlossaryTermsByGlossaryId } from "@/lib/glossary/query-glossary-terms";
 
+import { buildGlossaryListWhere } from "./glossary-list-filters";
 import {
   createGlossaryBodySchema,
   glossaryIdParamsSchema,
@@ -47,7 +48,7 @@ const glossaryStore: GlossaryStore = {
   async list(auth, query) {
     const limit = query?.limit ?? 50;
     const offset = query?.offset ?? 0;
-    const where = eq(schema.glossaries.organizationId, auth.organization.localOrganizationId);
+    const where = buildGlossaryListWhere(auth.organization.localOrganizationId, query);
 
     const [glossaries, totalRow] = await Promise.all([
       db

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary.schema.ts
@@ -10,6 +10,11 @@ export const listGlossaryQuerySchema = z
   .object({
     limit: z.coerce.number().int().min(1).max(100).default(50),
     offset: z.coerce.number().int().min(0).default(0),
+    search: z.string().trim().max(200).optional(),
+    source: z.enum(["native", "external_tms"]).optional(),
+    provider: z.enum(["crowdin", "smartling", "phrase", "lokalise"]).optional(),
+    resourceType: z.enum(["glossary", "term_base"]).optional(),
+    sync: z.enum(["synced", "stale", "syncing", "error"]).optional(),
   })
   .optional();
 

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary.schema.ts
@@ -107,6 +107,7 @@ export const glossaryResponseSchema = z.object({
 
 export const glossariesResponseSchema = z.object({
   glossaries: z.array(glossaryRecordSchema),
+  total: z.number().int().nonnegative(),
 });
 
 export const glossaryTermsResponseSchema = z.object({

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary.shared.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary.shared.ts
@@ -23,6 +23,14 @@ export function forbiddenResponse(c: { json: JsonContext["json"] }) {
   return sharedForbiddenResponse(c, "forbidden", "Insufficient permissions");
 }
 
+export function externalTmsGlossaryImmutableResponse(c: { json: JsonContext["json"] }) {
+  return sharedForbiddenResponse(
+    c,
+    "external_tms_glossary_immutable",
+    "This glossary is managed by an external TMS and cannot be edited directly",
+  );
+}
+
 export function isGlossaryMutationAllowed(role: ApiAuthContext["membership"]["role"]) {
   return allowedMutationRoles.has(role);
 }

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary.test.ts
@@ -538,6 +538,7 @@ describe("glossaryRoutes", () => {
     if ("error" in body) throw new Error(String(body.error));
 
     expect(body.glossaries).toHaveLength(2);
+    expect(body.total).toBe(2);
     expect(body.glossaries).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ name: "Native Glossary", source: "native" }),
@@ -551,5 +552,55 @@ describe("glossaryRoutes", () => {
         }),
       ]),
     );
+  });
+
+  it("forbids mutating provider-backed glossaries", async () => {
+    const identity = createWorkosIdentity();
+    const { organization, user } = await glossaryFixture.createLocalWorkosIdentity(identity);
+    const credential = await upsertOrganizationExternalTmsProviderCredential({
+      organizationId: organization.id,
+      userId: user.id,
+      role: "owner",
+      providerKind: "crowdin",
+      displayName: "Crowdin",
+      secretMaterial: "crowdin-token",
+    });
+
+    const externalGlossary = await upsertOrganizationExternalTmsGlossary({
+      organizationId: organization.id,
+      providerCredentialId: credential.id,
+      providerKind: "crowdin",
+      externalProjectId: "crowdin-project-1",
+      externalResourceType: "glossary",
+      externalGlossaryId: "glossary-99",
+      name: "Crowdin Glossary",
+      sourceLocale: "en",
+      targetLocale: "fr",
+    });
+
+    const headers = await authHeadersFor(identity);
+
+    const patchResponse = await client.api.glossary[":glossaryId"].$patch(
+      {
+        param: { glossaryId: externalGlossary.id },
+        json: { name: "Renamed" },
+      },
+      { headers },
+    );
+    expect(patchResponse.status).toBe(403);
+    await expect(patchResponse.json()).resolves.toMatchObject({
+      error: "external_tms_glossary_immutable",
+    });
+
+    const deleteResponse = await client.api.glossary[":glossaryId"].$delete(
+      {
+        param: { glossaryId: externalGlossary.id },
+      },
+      { headers },
+    );
+    expect(deleteResponse.status).toBe(403);
+    await expect(deleteResponse.json()).resolves.toMatchObject({
+      error: "external_tms_glossary_immutable",
+    });
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary.test.ts
@@ -554,6 +554,59 @@ describe("glossaryRoutes", () => {
     );
   });
 
+  it("filters glossaries by search and source on the server", async () => {
+    const identity = createWorkosIdentity();
+    const { organization, user } = await glossaryFixture.createLocalWorkosIdentity(identity);
+    await createGlossaryViaApi(identity, { name: "Workspace Marketing Terms" });
+
+    const credential = await upsertOrganizationExternalTmsProviderCredential({
+      organizationId: organization.id,
+      userId: user.id,
+      role: "owner",
+      providerKind: "crowdin",
+      displayName: "Crowdin",
+      secretMaterial: "crowdin-token",
+    });
+
+    await upsertOrganizationExternalTmsGlossary({
+      organizationId: organization.id,
+      providerCredentialId: credential.id,
+      providerKind: "crowdin",
+      externalProjectId: "crowdin-project-9",
+      externalResourceType: "glossary",
+      externalGlossaryId: "glossary-9",
+      name: "Crowdin Product Glossary",
+      sourceLocale: "en",
+      targetLocale: "de",
+    });
+
+    const headers = await authHeadersFor(identity);
+
+    const searchResponse = await client.api.glossary.$get(
+      { query: { limit: "50", offset: "0", search: "marketing" } },
+      { headers },
+    );
+    expect(searchResponse.status).toBe(200);
+    const searchBody = await searchResponse.json();
+    if ("error" in searchBody) throw new Error(String(searchBody.error));
+    expect(searchBody.total).toBe(1);
+    expect(searchBody.glossaries).toEqual([
+      expect.objectContaining({ name: "Workspace Marketing Terms" }),
+    ]);
+
+    const providerResponse = await client.api.glossary.$get(
+      { query: { limit: "50", offset: "0", source: "external_tms" } },
+      { headers },
+    );
+    expect(providerResponse.status).toBe(200);
+    const providerBody = await providerResponse.json();
+    if ("error" in providerBody) throw new Error(String(providerBody.error));
+    expect(providerBody.total).toBe(1);
+    expect(providerBody.glossaries).toEqual([
+      expect.objectContaining({ name: "Crowdin Product Glossary", source: "external_tms" }),
+    ]);
+  });
+
   it("forbids mutating provider-backed glossaries", async () => {
     const identity = createWorkosIdentity();
     const { organization, user } = await glossaryFixture.createLocalWorkosIdentity(identity);

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-page-content.tsx
@@ -29,61 +29,99 @@ import { GlossariesEmptyAction, GlossariesTable } from "./glossaries-table";
 
 const GLOSSARIES_PAGE_SIZE = 100;
 
-const glossariesQueryKey = (organizationSlug: string, page: number) => [
-  "glossaries",
-  organizationSlug,
-  page,
-];
+type GlossaryListFilters = {
+  searchQuery: string;
+  sourceFilter: string;
+  providerFilter: string;
+  resourceTypeFilter: string;
+  syncFilter: string;
+};
+
+const glossariesQueryKey = (
+  organizationSlug: string,
+  page: number,
+  filters: GlossaryListFilters,
+) => ["glossaries", organizationSlug, page, filters];
+
+function buildGlossaryListQuery(page: number, filters: GlossaryListFilters) {
+  const query: {
+    limit: string;
+    offset: string;
+    search?: string;
+    source?: "native" | "external_tms";
+    provider?: "crowdin" | "smartling" | "phrase" | "lokalise";
+    resourceType?: "glossary" | "term_base";
+    sync?: "synced" | "stale" | "syncing" | "error";
+  } = {
+    limit: String(GLOSSARIES_PAGE_SIZE),
+    offset: String((page - 1) * GLOSSARIES_PAGE_SIZE),
+  };
+
+  const search = filters.searchQuery.trim();
+  if (search) {
+    query.search = search;
+  }
+  if (filters.sourceFilter === "native" || filters.sourceFilter === "external_tms") {
+    query.source = filters.sourceFilter;
+  }
+  if (
+    filters.providerFilter === "crowdin" ||
+    filters.providerFilter === "smartling" ||
+    filters.providerFilter === "phrase" ||
+    filters.providerFilter === "lokalise"
+  ) {
+    query.provider = filters.providerFilter;
+  }
+  if (filters.resourceTypeFilter === "glossary" || filters.resourceTypeFilter === "term_base") {
+    query.resourceType = filters.resourceTypeFilter;
+  }
+  if (
+    filters.syncFilter === "synced" ||
+    filters.syncFilter === "stale" ||
+    filters.syncFilter === "syncing" ||
+    filters.syncFilter === "error"
+  ) {
+    query.sync = filters.syncFilter;
+  }
+
+  return query;
+}
 const projectsQueryKey = (organizationSlug: string) => ["glossary-projects", organizationSlug];
 const credentialsQueryKey = (organizationSlug: string) => [
   "glossary-credentials",
   organizationSlug,
 ];
 
-function useGlossaryFilters(glossaries: GlossaryListRow[]) {
+function useGlossaryFilters() {
   const [searchQuery, setSearchQuery] = useState("");
   const [sourceFilter, setSourceFilter] = useState<string>("all");
   const [providerFilter, setProviderFilter] = useState<string>("all");
   const [resourceTypeFilter, setResourceTypeFilter] = useState<string>("all");
   const [syncFilter, setSyncFilter] = useState<string>("all");
 
-  const filteredGlossaries = useMemo(() => {
-    return glossaries.filter((glossary) => {
-      if (searchQuery.trim()) {
-        const query = searchQuery.toLowerCase();
-        const matchesName = glossary.name.toLowerCase().includes(query);
-        const matchesProject = glossary.externalProjectId?.toLowerCase().includes(query);
-        const matchesGlossaryId = glossary.externalGlossaryId?.toLowerCase().includes(query);
-        if (!matchesName && !matchesProject && !matchesGlossaryId) return false;
-      }
+  const filters = useMemo(
+    () => ({
+      searchQuery,
+      sourceFilter,
+      providerFilter,
+      resourceTypeFilter,
+      syncFilter,
+    }),
+    [searchQuery, sourceFilter, providerFilter, resourceTypeFilter, syncFilter],
+  );
 
-      if (sourceFilter !== "all" && glossary.source !== sourceFilter) return false;
+  const activeFilterCount = [
+    searchQuery.trim() ? "search" : null,
+    sourceFilter,
+    providerFilter,
+    resourceTypeFilter,
+    syncFilter,
+  ].filter((value) => value && value !== "all").length;
 
-      if (providerFilter !== "all") {
-        if (glossary.externalProviderKind !== providerFilter) return false;
-      }
-
-      if (resourceTypeFilter !== "all") {
-        if (glossary.externalResourceType !== resourceTypeFilter) return false;
-      }
-
-      if (syncFilter !== "all") {
-        if (syncFilter === "error") {
-          if (!glossary.lastSyncErrorAt) return false;
-        } else if (glossary.syncState !== syncFilter) {
-          return false;
-        }
-      }
-
-      return true;
-    });
-  }, [glossaries, searchQuery, sourceFilter, providerFilter, resourceTypeFilter, syncFilter]);
-
-  const activeFilterCount = [sourceFilter, providerFilter, resourceTypeFilter, syncFilter].filter(
-    (f) => f !== "all",
-  ).length;
+  const hasActiveFilters = activeFilterCount > 0;
 
   return {
+    filters,
     searchQuery,
     setSearchQuery,
     sourceFilter,
@@ -94,8 +132,8 @@ function useGlossaryFilters(glossaries: GlossaryListRow[]) {
     setResourceTypeFilter,
     syncFilter,
     setSyncFilter,
-    filteredGlossaries,
     activeFilterCount,
+    hasActiveFilters,
   };
 }
 
@@ -121,10 +159,11 @@ function GlossariesMetrics({
           ? `${(termTotal / 1_000).toFixed(1)}k`
           : `${termTotal}`;
     const providerCountOnPage = providerGlossaries.length;
+    const providerNoun = providerCountOnPage === 1 ? "provider" : "providers";
     const providerDetail =
       total > glossaries.length
-        ? `${providerCountOnPage} provider on this page`
-        : `${providerCountOnPage} provider`;
+        ? `${providerCountOnPage} ${providerNoun} on this page`
+        : `${providerCountOnPage} ${providerNoun}`;
 
     return [
       {
@@ -136,7 +175,7 @@ function GlossariesMetrics({
       {
         label: "Locales covered",
         value: `${localeCount}`,
-        detail: `${termLabel} terms on page`,
+        detail: `${termLabel} terms on page (this page)`,
         tone: "safe" as const,
       },
       {
@@ -153,6 +192,21 @@ function GlossariesMetrics({
 
 export function GlossariesPageContent({ organizationSlug }: { organizationSlug: string }) {
   const [page, setPage] = useState(1);
+  const {
+    filters,
+    searchQuery,
+    setSearchQuery,
+    sourceFilter,
+    setSourceFilter,
+    providerFilter,
+    setProviderFilter,
+    resourceTypeFilter,
+    setResourceTypeFilter,
+    syncFilter,
+    setSyncFilter,
+    activeFilterCount,
+    hasActiveFilters,
+  } = useGlossaryFilters();
 
   const projectsQuery = useQuery({
     queryKey: projectsQueryKey(organizationSlug),
@@ -189,14 +243,11 @@ export function GlossariesPageContent({ organizationSlug }: { organizationSlug: 
   });
 
   const glossariesQuery = useQuery({
-    queryKey: glossariesQueryKey(organizationSlug, page),
+    queryKey: glossariesQueryKey(organizationSlug, page, filters),
     queryFn: async () => {
       const response = await apiClient.api.orgs[":organizationSlug"].glossaries.$get({
         param: { organizationSlug },
-        query: {
-          limit: String(GLOSSARIES_PAGE_SIZE),
-          offset: String((page - 1) * GLOSSARIES_PAGE_SIZE),
-        },
+        query: buildGlossaryListQuery(page, filters),
       });
 
       if (!response.ok) {
@@ -241,24 +292,9 @@ export function GlossariesPageContent({ organizationSlug }: { organizationSlug: 
 
   const hasResourceTypes = glossaries.some((glossary) => glossary.externalResourceType);
 
-  const {
-    searchQuery,
-    setSearchQuery,
-    sourceFilter,
-    setSourceFilter,
-    providerFilter,
-    setProviderFilter,
-    resourceTypeFilter,
-    setResourceTypeFilter,
-    syncFilter,
-    setSyncFilter,
-    filteredGlossaries,
-    activeFilterCount,
-  } = useGlossaryFilters(glossaries);
-
   useEffect(() => {
     setPage(1);
-  }, [organizationSlug, searchQuery, sourceFilter, providerFilter, resourceTypeFilter, syncFilter]);
+  }, [organizationSlug, filters]);
 
   useEffect(() => {
     if (glossariesQuery.isSuccess && page > totalPages) {
@@ -290,7 +326,7 @@ export function GlossariesPageContent({ organizationSlug }: { organizationSlug: 
         <GlossariesMetrics glossaries={glossaries} total={glossaryTotal} />
       ) : null}
 
-      {glossariesQuery.isSuccess && glossaries.length > 0 ? (
+      {glossariesQuery.isSuccess && (glossaryTotal > 0 || hasActiveFilters) ? (
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
           <div className="flex-1">
             <Input
@@ -392,7 +428,7 @@ export function GlossariesPageContent({ organizationSlug }: { organizationSlug: 
         </div>
       ) : null}
 
-      {glossariesQuery.isSuccess && glossaries.length > 0 && filteredGlossaries.length === 0 ? (
+      {glossariesQuery.isSuccess && hasActiveFilters && glossaryTotal === 0 ? (
         <div className="text-sm text-foreground/52">
           No glossaries match your filters.{" "}
           <button
@@ -426,7 +462,7 @@ export function GlossariesPageContent({ organizationSlug }: { organizationSlug: 
       </div>
 
       <GlossariesTable
-        glossaries={filteredGlossaries}
+        glossaries={glossaries}
         glossariesQuery={glossariesQuery}
         organizationSlug={organizationSlug}
         emptyTitle={emptyTitle}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-page-content.tsx
@@ -1,202 +1,469 @@
 "use client";
 
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { ArrowRight01Icon, BookOpenTextIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { useQuery } from "@tanstack/react-query";
 
-import { Badge } from "@/components/ui/badge";
-import { Separator } from "@/components/ui/separator";
-import { cn } from "@/lib/utils";
-
+import { Input } from "@/components/ui/input";
 import {
-  MetricsGrid,
-  PageHeader,
-  ProgressBar,
-  ResourceCard,
-  toneClass,
-} from "../../_components/workspace-resource-shared";
-import { TypographyP } from "@/components/ui/typography";
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { apiClient } from "@/lib/api-client-instance";
 
-const glossaries = [
-  {
-    name: "Product names",
-    terms: "284",
-    locales: "12",
-    coverage: 91,
-    owner: "Yuki Tanaka",
-    updated: "12m ago",
-    status: "Reviewing",
-    tone: "watch",
-  },
-  {
-    name: "Legal disclaimers",
-    terms: "143",
-    locales: "8",
-    coverage: 98,
-    owner: "Amelia Stone",
-    updated: "37m ago",
-    status: "Approved",
-    tone: "safe",
-  },
-  {
-    name: "Payments vocabulary",
-    terms: "96",
-    locales: "10",
-    coverage: 84,
-    owner: "Jon Bell",
-    updated: "2h ago",
-    status: "Needs work",
-    tone: "risk",
-  },
-] as const;
+import { MetricsGrid, PageHeader } from "../../_components/workspace-resource-shared";
+import {
+  buildProjectIdByExternalKey,
+  mapGlossaryToListRow,
+  providerLabel,
+  type ApiGlossary,
+  type GlossaryListRow,
+} from "./glossary-list";
+import { GlossariesEmptyAction, GlossariesTable } from "./glossaries-table";
 
-const glossaryTerms = [
-  {
-    source: "checkout session",
-    approved: "session de paiement",
-    locale: "fr-FR",
-    usage: "Payments flow",
-    status: "Approved",
-    tone: "safe",
-  },
-  {
-    source: "workspace",
-    approved: "espacio de trabajo",
-    locale: "es-ES",
-    usage: "Navigation",
-    status: "Approved",
-    tone: "safe",
-  },
-  {
-    source: "usage cap",
-    approved: "Nutzungslimit",
-    locale: "de-DE",
-    usage: "Billing",
-    status: "Review",
-    tone: "watch",
-  },
-  {
-    source: "smart routing",
-    approved: "smart routing",
-    locale: "ja-JP",
-    usage: "Feature copy",
-    status: "Conflict",
-    tone: "risk",
-  },
-] as const;
+const GLOSSARIES_PAGE_SIZE = 100;
 
-const glossaryMetrics = [
-  { label: "Glossaries", value: "9", detail: "3 connected to TMS", tone: "info" },
-  { label: "Approved terms", value: "4,820", detail: "92% coverage", tone: "safe" },
-  { label: "Conflicts", value: "11", detail: "need reviewer input", tone: "watch" },
-] as const;
+const glossariesQueryKey = (organizationSlug: string, page: number) => [
+  "glossaries",
+  organizationSlug,
+  page,
+];
+const projectsQueryKey = (organizationSlug: string) => ["glossary-projects", organizationSlug];
+const credentialsQueryKey = (organizationSlug: string) => [
+  "glossary-credentials",
+  organizationSlug,
+];
+
+function useGlossaryFilters(glossaries: GlossaryListRow[]) {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [sourceFilter, setSourceFilter] = useState<string>("all");
+  const [providerFilter, setProviderFilter] = useState<string>("all");
+  const [resourceTypeFilter, setResourceTypeFilter] = useState<string>("all");
+  const [syncFilter, setSyncFilter] = useState<string>("all");
+
+  const filteredGlossaries = useMemo(() => {
+    return glossaries.filter((glossary) => {
+      if (searchQuery.trim()) {
+        const query = searchQuery.toLowerCase();
+        const matchesName = glossary.name.toLowerCase().includes(query);
+        const matchesProject = glossary.externalProjectId?.toLowerCase().includes(query);
+        const matchesGlossaryId = glossary.externalGlossaryId?.toLowerCase().includes(query);
+        if (!matchesName && !matchesProject && !matchesGlossaryId) return false;
+      }
+
+      if (sourceFilter !== "all" && glossary.source !== sourceFilter) return false;
+
+      if (providerFilter !== "all") {
+        if (glossary.externalProviderKind !== providerFilter) return false;
+      }
+
+      if (resourceTypeFilter !== "all") {
+        if (glossary.externalResourceType !== resourceTypeFilter) return false;
+      }
+
+      if (syncFilter !== "all") {
+        if (syncFilter === "error") {
+          if (!glossary.lastSyncErrorAt) return false;
+        } else if (glossary.syncState !== syncFilter) {
+          return false;
+        }
+      }
+
+      return true;
+    });
+  }, [glossaries, searchQuery, sourceFilter, providerFilter, resourceTypeFilter, syncFilter]);
+
+  const activeFilterCount = [sourceFilter, providerFilter, resourceTypeFilter, syncFilter].filter(
+    (f) => f !== "all",
+  ).length;
+
+  return {
+    searchQuery,
+    setSearchQuery,
+    sourceFilter,
+    setSourceFilter,
+    providerFilter,
+    setProviderFilter,
+    resourceTypeFilter,
+    setResourceTypeFilter,
+    syncFilter,
+    setSyncFilter,
+    filteredGlossaries,
+    activeFilterCount,
+  };
+}
+
+function GlossariesMetrics({
+  glossaries,
+  total,
+}: {
+  glossaries: GlossaryListRow[];
+  total: number;
+}) {
+  const metrics = useMemo(() => {
+    const providerGlossaries = glossaries.filter((glossary) => glossary.source === "external_tms");
+    const syncedCount = providerGlossaries.filter(
+      (glossary) => glossary.syncState === "synced" && !glossary.lastSyncErrorAt,
+    ).length;
+    const errorCount = providerGlossaries.filter((glossary) => glossary.lastSyncErrorAt).length;
+    const localeCount = new Set(glossaries.flatMap((glossary) => glossary.localeCoverage)).size;
+    const termTotal = glossaries.reduce((sum, glossary) => sum + (glossary.termCount ?? 0), 0);
+    const termLabel =
+      termTotal >= 1_000_000
+        ? `${(termTotal / 1_000_000).toFixed(1)}M`
+        : termTotal >= 1_000
+          ? `${(termTotal / 1_000).toFixed(1)}k`
+          : `${termTotal}`;
+    const providerCountOnPage = providerGlossaries.length;
+    const providerDetail =
+      total > glossaries.length
+        ? `${providerCountOnPage} provider on this page`
+        : `${providerCountOnPage} provider`;
+
+    return [
+      {
+        label: "Terminology resources",
+        value: `${total}`,
+        detail: providerDetail,
+        tone: "info" as const,
+      },
+      {
+        label: "Locales covered",
+        value: `${localeCount}`,
+        detail: `${termLabel} terms on page`,
+        tone: "safe" as const,
+      },
+      {
+        label: "Sync health",
+        value: `${syncedCount}`,
+        detail: errorCount > 0 ? `${errorCount} errors` : "healthy",
+        tone: errorCount > 0 ? ("watch" as const) : ("safe" as const),
+      },
+    ] as const;
+  }, [glossaries, total]);
+
+  return <MetricsGrid metrics={metrics} />;
+}
 
 export function GlossariesPageContent({ organizationSlug }: { organizationSlug: string }) {
+  const [page, setPage] = useState(1);
+
+  const projectsQuery = useQuery({
+    queryKey: projectsQueryKey(organizationSlug),
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"].projects.$get({
+        param: { organizationSlug },
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to load projects (${response.status})`);
+      }
+
+      const body = await response.json();
+      return body.projects;
+    },
+  });
+
+  const credentialsQuery = useQuery({
+    queryKey: credentialsQueryKey(organizationSlug),
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"][
+        "external-tms-provider-credential"
+      ].$get({
+        param: { organizationSlug },
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to load provider credentials (${response.status})`);
+      }
+
+      const body = await response.json();
+      return body.externalTmsProviderCredentials;
+    },
+  });
+
+  const glossariesQuery = useQuery({
+    queryKey: glossariesQueryKey(organizationSlug, page),
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"].glossaries.$get({
+        param: { organizationSlug },
+        query: {
+          limit: String(GLOSSARIES_PAGE_SIZE),
+          offset: String((page - 1) * GLOSSARIES_PAGE_SIZE),
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to load glossaries (${response.status})`);
+      }
+
+      const body = await response.json();
+      return {
+        glossaries: body.glossaries as ApiGlossary[],
+        total: body.total as number,
+      };
+    },
+  });
+
+  const projectIdByExternalKey = useMemo(
+    () => buildProjectIdByExternalKey(projectsQuery.data ?? []),
+    [projectsQuery.data],
+  );
+
+  const glossaries = useMemo(
+    () =>
+      (glossariesQuery.data?.glossaries ?? []).map((glossary) =>
+        mapGlossaryToListRow(glossary, projectIdByExternalKey),
+      ),
+    [glossariesQuery.data?.glossaries, projectIdByExternalKey],
+  );
+
+  const glossaryTotal = glossariesQuery.data?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(glossaryTotal / GLOSSARIES_PAGE_SIZE));
+  const pageStart = glossaryTotal === 0 ? 0 : (page - 1) * GLOSSARIES_PAGE_SIZE + 1;
+  const pageEnd = Math.min(page * GLOSSARIES_PAGE_SIZE, glossaryTotal);
+
+  const providerKinds = useMemo(() => {
+    const kinds = new Set<string>();
+    for (const glossary of glossaries) {
+      if (glossary.externalProviderKind) {
+        kinds.add(glossary.externalProviderKind);
+      }
+    }
+    return [...kinds].sort((a, b) => providerLabel(a).localeCompare(providerLabel(b)));
+  }, [glossaries]);
+
+  const hasResourceTypes = glossaries.some((glossary) => glossary.externalResourceType);
+
+  const {
+    searchQuery,
+    setSearchQuery,
+    sourceFilter,
+    setSourceFilter,
+    providerFilter,
+    setProviderFilter,
+    resourceTypeFilter,
+    setResourceTypeFilter,
+    syncFilter,
+    setSyncFilter,
+    filteredGlossaries,
+    activeFilterCount,
+  } = useGlossaryFilters(glossaries);
+
+  useEffect(() => {
+    setPage(1);
+  }, [organizationSlug, searchQuery, sourceFilter, providerFilter, resourceTypeFilter, syncFilter]);
+
+  useEffect(() => {
+    if (glossariesQuery.isSuccess && page > totalPages) {
+      setPage(totalPages);
+    }
+  }, [glossariesQuery.isSuccess, page, totalPages]);
+
+  const hasExternalGlossaries = glossaries.some((glossary) => glossary.source === "external_tms");
+  const connectedCredentials = (credentialsQuery.data ?? []).filter(
+    (credential) => credential.validationStatus === "connected",
+  );
+  const hasConnectedProvider = credentialsQuery.isSuccess && connectedCredentials.length > 0;
+
+  const emptyTitle = hasConnectedProvider ? "No glossaries yet" : "Connect a TMS provider";
+  const emptyDescription = hasConnectedProvider
+    ? "Provider glossaries and term bases appear here after sync. Native workspace glossaries are listed alongside synced resources."
+    : "Connect Crowdin, Phrase, Smartling, or Lokalise from Integrations to sync terminology into this workspace.";
+
   return (
-    <main className="space-y-5">
+    <main className="mx-auto flex w-full max-w-6xl flex-col gap-5">
       <PageHeader
         icon={BookOpenTextIcon}
         label="Term library"
         title="Glossaries"
-        description="Manage approved product terms, legal wording, and locale-specific vocabulary that guides every translation run."
-        statusLabel="9 mocked"
+        description="Browse native workspace glossaries and synced provider glossaries or term bases with locale coverage, term capabilities, and sync health in one place."
       />
-      <MetricsGrid metrics={glossaryMetrics} />
+
+      {glossariesQuery.isSuccess ? (
+        <GlossariesMetrics glossaries={glossaries} total={glossaryTotal} />
+      ) : null}
+
+      {glossariesQuery.isSuccess && glossaries.length > 0 ? (
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <div className="flex-1">
+            <Input
+              placeholder="Search by name, project, or external ID..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="w-full sm:max-w-xs"
+            />
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Select
+              value={sourceFilter}
+              onValueChange={(value) => {
+                setSourceFilter(value ?? "all");
+                if (value === "native") {
+                  setProviderFilter("all");
+                  setResourceTypeFilter("all");
+                  setSyncFilter("all");
+                }
+              }}
+            >
+              <SelectTrigger className="w-fit min-w-[8rem]">
+                <SelectValue placeholder="Source" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All sources</SelectItem>
+                <SelectItem value="native">Workspace</SelectItem>
+                <SelectItem value="external_tms">Provider</SelectItem>
+              </SelectContent>
+            </Select>
+
+            {hasExternalGlossaries && sourceFilter !== "native" ? (
+              <Select
+                value={providerFilter}
+                onValueChange={(value) => setProviderFilter(value ?? "all")}
+              >
+                <SelectTrigger className="w-fit min-w-[8rem]">
+                  <SelectValue placeholder="Provider" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All providers</SelectItem>
+                  {providerKinds.map((kind) => (
+                    <SelectItem key={kind} value={kind}>
+                      {providerLabel(kind)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            ) : null}
+
+            {hasResourceTypes && sourceFilter !== "native" ? (
+              <Select
+                value={resourceTypeFilter}
+                onValueChange={(value) => setResourceTypeFilter(value ?? "all")}
+              >
+                <SelectTrigger className="w-fit min-w-[8rem]">
+                  <SelectValue placeholder="Resource" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All resource types</SelectItem>
+                  <SelectItem value="glossary">Glossary</SelectItem>
+                  <SelectItem value="term_base">Term base</SelectItem>
+                </SelectContent>
+              </Select>
+            ) : null}
+
+            {hasExternalGlossaries && sourceFilter !== "native" ? (
+              <Select value={syncFilter} onValueChange={(value) => setSyncFilter(value ?? "all")}>
+                <SelectTrigger className="w-fit min-w-[8rem]">
+                  <SelectValue placeholder="Sync" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All sync states</SelectItem>
+                  <SelectItem value="synced">Synced</SelectItem>
+                  <SelectItem value="stale">Stale</SelectItem>
+                  <SelectItem value="syncing">Syncing</SelectItem>
+                  <SelectItem value="error">Sync error</SelectItem>
+                </SelectContent>
+              </Select>
+            ) : null}
+
+            {activeFilterCount > 0 ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  setSearchQuery("");
+                  setSourceFilter("all");
+                  setProviderFilter("all");
+                  setResourceTypeFilter("all");
+                  setSyncFilter("all");
+                }}
+              >
+                Clear filters
+              </Button>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+
+      {glossariesQuery.isSuccess && glossaries.length > 0 && filteredGlossaries.length === 0 ? (
+        <div className="text-sm text-foreground/52">
+          No glossaries match your filters.{" "}
+          <button
+            type="button"
+            onClick={() => {
+              setSearchQuery("");
+              setSourceFilter("all");
+              setProviderFilter("all");
+              setResourceTypeFilter("all");
+              setSyncFilter("all");
+            }}
+            className="text-foreground/72 underline hover:text-foreground"
+          >
+            Clear filters
+          </button>
+        </div>
+      ) : null}
+
       <div className="flex items-center gap-2 text-sm text-foreground/54">
-        <span>Synced provider glossaries will appear here alongside workspace glossaries.</span>
+        <span>
+          Provider terminology stays read-only here. Connect or manage credentials from
+          Integrations.
+        </span>
         <Link
           href={`/org/${organizationSlug}/integrations`}
           className="inline-flex items-center gap-1 hover:text-foreground"
         >
-          <span>Connect a provider</span>
+          <span>Integrations</span>
           <HugeiconsIcon icon={ArrowRight01Icon} strokeWidth={1.7} className="size-4" />
         </Link>
       </div>
-      <section className="grid gap-4 xl:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]">
-        <ResourceCard
-          title="Glossary sets"
-          description="Mock glossary coverage by domain, locale count, and reviewer state."
-          icon={BookOpenTextIcon}
-        >
-          <div className="px-5 pb-2">
-            {glossaries.map((glossary, index) => (
-              <div key={glossary.name}>
-                <div className="grid gap-4 py-4 md:grid-cols-[minmax(0,1fr)_7rem_8rem_8rem] md:items-center">
-                  <div className="min-w-0">
-                    <div className="flex items-center gap-2">
-                      <TypographyP className="truncate text-sm font-medium text-foreground">
-                        {glossary.name}
-                      </TypographyP>
-                      <Badge
-                        variant="outline"
-                        className={cn("rounded-full", toneClass(glossary.tone))}
-                      >
-                        {glossary.status}
-                      </Badge>
-                    </div>
-                    <TypographyP className="mt-1 text-xs text-foreground/42">
-                      Owner: {glossary.owner} · Updated {glossary.updated}
-                    </TypographyP>
-                  </div>
-                  <TypographyP className="text-sm text-foreground/58">
-                    {glossary.terms} terms
-                  </TypographyP>
-                  <TypographyP className="text-sm text-foreground/58">
-                    {glossary.locales} locales
-                  </TypographyP>
-                  <div className="flex flex-col gap-2">
-                    <ProgressBar value={glossary.coverage} tone={glossary.tone} />
-                    <TypographyP className="text-xs text-foreground/42">
-                      {glossary.coverage}% coverage
-                    </TypographyP>
-                  </div>
-                </div>
-                {index < glossaries.length - 1 ? <Separator className="bg-foreground/8" /> : null}
-              </div>
-            ))}
+
+      <GlossariesTable
+        glossaries={filteredGlossaries}
+        glossariesQuery={glossariesQuery}
+        organizationSlug={organizationSlug}
+        emptyTitle={emptyTitle}
+        emptyDescription={emptyDescription}
+        emptyAction={<GlossariesEmptyAction organizationSlug={organizationSlug} />}
+      />
+
+      {glossariesQuery.isSuccess && glossaryTotal > GLOSSARIES_PAGE_SIZE ? (
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <p className="text-sm text-foreground/52">
+            Showing {pageStart}–{pageEnd} of {glossaryTotal} glossaries
+          </p>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              disabled={page <= 1}
+              onClick={() => setPage((current) => Math.max(1, current - 1))}
+            >
+              Previous
+            </Button>
+            <p className="text-sm text-foreground/52">
+              Page {page} of {totalPages}
+            </p>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              disabled={page >= totalPages}
+              onClick={() => setPage((current) => current + 1)}
+            >
+              Next
+            </Button>
           </div>
-        </ResourceCard>
-        <ResourceCard
-          title="Term review"
-          description="Representative terms that localization jobs can enforce during drafting and evals."
-          icon={BookOpenTextIcon}
-        >
-          <div className="overflow-x-auto">
-            <div className="min-w-176">
-              <div className="grid grid-cols-[minmax(10rem,1fr)_minmax(10rem,1fr)_6rem_minmax(8rem,1fr)_7rem] gap-3 px-5 py-2 text-xs font-medium tracking-[0.08em] text-foreground/38 uppercase">
-                <TypographyP>Source</TypographyP>
-                <TypographyP>Approved term</TypographyP>
-                <TypographyP>Locale</TypographyP>
-                <TypographyP>Usage</TypographyP>
-                <TypographyP>Status</TypographyP>
-              </div>
-              <Separator className="bg-foreground/8" />
-              {glossaryTerms.map((term, index) => (
-                <div key={`${term.locale}-${term.source}`}>
-                  <div className="grid grid-cols-[minmax(10rem,1fr)_minmax(10rem,1fr)_6rem_minmax(8rem,1fr)_7rem] items-center gap-3 px-5 py-4">
-                    <TypographyP className="truncate text-sm text-foreground">
-                      {term.source}
-                    </TypographyP>
-                    <TypographyP className="truncate text-sm text-foreground/72">
-                      {term.approved}
-                    </TypographyP>
-                    <TypographyP className="text-sm text-foreground/48">{term.locale}</TypographyP>
-                    <TypographyP className="truncate text-sm text-foreground/58">
-                      {term.usage}
-                    </TypographyP>
-                    <Badge variant="outline" className={cn("rounded-full", toneClass(term.tone))}>
-                      {term.status}
-                    </Badge>
-                  </div>
-                  {index < glossaryTerms.length - 1 ? (
-                    <Separator className="bg-foreground/8" />
-                  ) : null}
-                </div>
-              ))}
-            </div>
-          </div>
-        </ResourceCard>
-      </section>
+        </div>
+      ) : null}
     </main>
   );
 }

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-table.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-table.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+import type { ReactNode } from "react";
+import Link from "next/link";
+import { Alert02Icon, ArrowUpRight01Icon, BookOpenTextIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import type { UseQueryResult } from "@tanstack/react-query";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { TypographyP } from "@/components/ui/typography";
+
+import { ProviderKindBadge, SyncStateBadge } from "../../_components/workspace-files-shared";
+import { ResourceCard, toneClass } from "../../_components/workspace-resource-shared";
+import type { GlossaryListRow } from "./glossary-list";
+import { providerLabel } from "./glossary-list";
+
+function SourceLabel({ glossary }: { glossary: GlossaryListRow }) {
+  if (glossary.source === "native") {
+    return <span className="text-xs text-foreground/48">Workspace</span>;
+  }
+
+  if (glossary.externalProviderKind) {
+    return <ProviderKindBadge kind={glossary.externalProviderKind} />;
+  }
+
+  return <span className="text-xs text-foreground/48">External TMS</span>;
+}
+
+function SyncHealthBadge({ glossary }: { glossary: GlossaryListRow }) {
+  if (glossary.source === "native") {
+    return (
+      <Badge variant="outline" className={toneClass("info")}>
+        Active
+      </Badge>
+    );
+  }
+
+  if (glossary.lastSyncErrorAt) {
+    return (
+      <Badge variant="destructive" className="text-[10px]">
+        <HugeiconsIcon icon={Alert02Icon} strokeWidth={1.8} className="size-3" />
+        Sync error
+      </Badge>
+    );
+  }
+
+  if (glossary.syncState) {
+    return <SyncStateBadge syncState={glossary.syncState} />;
+  }
+
+  return (
+    <Badge variant="outline" className="text-[10px] text-foreground/58">
+      Not synced
+    </Badge>
+  );
+}
+
+function ResourceTypeBadge({ glossary }: { glossary: GlossaryListRow }) {
+  const tone = glossary.externalResourceType === "term_base" ? "info" : "safe";
+
+  return (
+    <Badge variant="outline" className={toneClass(tone)}>
+      {glossary.resourceTypeLabel}
+    </Badge>
+  );
+}
+
+function TermCapabilityBadge({ glossary }: { glossary: GlossaryListRow }) {
+  const tone =
+    glossary.termCapabilityLabel === "Capabilities unknown"
+      ? "watch"
+      : glossary.termCapabilityLabel.includes("No ")
+        ? "watch"
+        : "safe";
+
+  return (
+    <Badge variant="outline" className={toneClass(tone)}>
+      {glossary.termCapabilityLabel}
+    </Badge>
+  );
+}
+
+function GlossaryRow({
+  glossary,
+  organizationSlug,
+}: {
+  glossary: GlossaryListRow;
+  organizationSlug: string;
+}) {
+  const sourceDetail =
+    glossary.source === "native"
+      ? `${glossary.localePairLabel} · Updated ${glossary.updatedAt}`
+      : [
+          glossary.externalProviderKind ? providerLabel(glossary.externalProviderKind) : "Provider",
+          glossary.externalProjectId ? `Project ${glossary.externalProjectId}` : null,
+          glossary.lastSyncedAt ? `Synced ${glossary.lastSyncedAt}` : "Not synced yet",
+        ]
+          .filter(Boolean)
+          .join(" · ");
+
+  return (
+    <div className="grid gap-3 px-5 py-4 md:grid-cols-[1.35fr_0.95fr_0.75fr_1fr_auto] md:items-center">
+      <div className="min-w-0">
+        <div className="flex flex-wrap items-center gap-2">
+          <HugeiconsIcon
+            icon={BookOpenTextIcon}
+            strokeWidth={1.7}
+            className="size-4 shrink-0 text-foreground/42"
+          />
+          <TypographyP className="truncate text-sm font-medium text-foreground">
+            {glossary.name}
+          </TypographyP>
+          <SourceLabel glossary={glossary} />
+          <ResourceTypeBadge glossary={glossary} />
+        </div>
+        <TypographyP className="mt-1 text-xs text-foreground/42">{sourceDetail}</TypographyP>
+        {glossary.lastSyncErrorAt ? (
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <span className="mt-1 block text-xs text-destructive">
+                  Last sync failed {glossary.lastSyncErrorAt}
+                </span>
+              }
+            />
+            <TooltipContent side="bottom" align="start" className="max-w-xs">
+              <p className="text-xs">{glossary.lastSyncErrorMessage ?? "Unknown error"}</p>
+            </TooltipContent>
+          </Tooltip>
+        ) : null}
+        <div className="mt-2 flex flex-wrap items-center gap-2">
+          {glossary.projectLinkId ? (
+            <>
+              <Link
+                href={`/org/${organizationSlug}/projects/${glossary.projectLinkId}`}
+                className="text-xs text-foreground/58 underline-offset-2 hover:text-foreground hover:underline"
+              >
+                View linked project
+              </Link>
+              <Link
+                href={`/org/${organizationSlug}/jobs`}
+                className="text-xs text-foreground/58 underline-offset-2 hover:text-foreground hover:underline"
+              >
+                View jobs
+              </Link>
+            </>
+          ) : glossary.externalProjectId ? (
+            <span className="text-xs text-foreground/42">
+              External project {glossary.externalProjectId}
+            </span>
+          ) : null}
+          {glossary.externalUrl ? (
+            <a
+              href={glossary.externalUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1 text-xs text-foreground/58 hover:text-foreground"
+            >
+              Open in provider
+              <HugeiconsIcon icon={ArrowUpRight01Icon} strokeWidth={1.7} className="size-3.5" />
+            </a>
+          ) : null}
+        </div>
+      </div>
+      <TypographyP className="text-sm text-foreground/58">{glossary.localeSummary}</TypographyP>
+      <TypographyP className="text-sm text-foreground/58">
+        {glossary.termCountLabel} terms
+      </TypographyP>
+      <div className="flex flex-wrap gap-2">
+        <TermCapabilityBadge glossary={glossary} />
+      </div>
+      <SyncHealthBadge glossary={glossary} />
+    </div>
+  );
+}
+
+export function GlossariesTable({
+  glossaries,
+  glossariesQuery,
+  organizationSlug,
+  emptyTitle,
+  emptyDescription,
+  emptyAction,
+}: {
+  glossaries: GlossaryListRow[];
+  glossariesQuery: Pick<
+    UseQueryResult<unknown, Error>,
+    "isLoading" | "isError" | "isSuccess" | "error"
+  >;
+  organizationSlug: string;
+  emptyTitle: string;
+  emptyDescription: string;
+  emptyAction?: ReactNode;
+}) {
+  return (
+    <ResourceCard
+      title="Terminology resources"
+      description="Native workspace glossaries and synced provider glossaries or term bases in one list."
+      icon={BookOpenTextIcon}
+    >
+      {glossariesQuery.isLoading ? (
+        <div className="px-5 py-8 text-sm text-foreground/52">Loading glossaries...</div>
+      ) : null}
+
+      {glossariesQuery.isError ? (
+        <div className="px-5 py-8">
+          <TypographyP className="text-sm font-medium text-flame-100">
+            Glossaries failed to load.
+          </TypographyP>
+          <TypographyP className="mt-1 text-xs text-foreground/42">
+            {glossariesQuery.error instanceof Error
+              ? glossariesQuery.error.message
+              : "Try refreshing the page."}
+          </TypographyP>
+        </div>
+      ) : null}
+
+      {glossariesQuery.isSuccess && glossaries.length === 0 ? (
+        <div className="space-y-3 px-5 py-8">
+          <TypographyP className="text-sm font-medium text-foreground">{emptyTitle}</TypographyP>
+          <TypographyP className="text-sm text-foreground/52">{emptyDescription}</TypographyP>
+          {emptyAction}
+        </div>
+      ) : null}
+
+      {glossariesQuery.isSuccess && glossaries.length > 0
+        ? glossaries.map((glossary, index) => (
+            <div key={glossary.id}>
+              <GlossaryRow glossary={glossary} organizationSlug={organizationSlug} />
+              {index < glossaries.length - 1 ? <Separator className="bg-foreground/8" /> : null}
+            </div>
+          ))
+        : null}
+    </ResourceCard>
+  );
+}
+
+export function GlossariesEmptyAction({
+  organizationSlug,
+  label = "Connect a provider",
+}: {
+  organizationSlug: string;
+  label?: string;
+}) {
+  return (
+    <Button
+      nativeButton={false}
+      render={<Link href={`/org/${organizationSlug}/integrations`} />}
+      variant="outline"
+      size="sm"
+    >
+      {label}
+    </Button>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/glossaries/_components/glossary-list.test.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/glossaries/_components/glossary-list.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  buildProjectIdByExternalKey,
+  externalProjectLookupKey,
+  mapGlossaryToListRow,
+} from "./glossary-list";
+
+describe("glossary-list", () => {
+  it("maps native and provider glossaries with project links", () => {
+    const projectMap = buildProjectIdByExternalKey([
+      {
+        id: "project-1",
+        externalProviderKind: "phrase",
+        externalProjectId: "phrase-project-9",
+      },
+    ]);
+
+    const native = mapGlossaryToListRow(
+      {
+        id: "glossary-native",
+        organizationId: "org-1",
+        createdByUserId: null,
+        name: "Product UI",
+        description: "",
+        sourceLocale: "en",
+        targetLocale: "de",
+        status: "active",
+        source: "native",
+        externalProviderKind: null,
+        externalProjectId: null,
+        externalResourceType: null,
+        externalGlossaryId: null,
+        localeCoverage: ["en", "de"],
+        termCount: 120,
+        syncState: null,
+        termCapabilities: {},
+        externalUrl: null,
+        lastSyncedAt: null,
+        lastSyncErrorAt: null,
+        lastSyncErrorMessage: null,
+        createdAt: "2026-05-01T00:00:00.000Z",
+        updatedAt: "2026-05-01T00:00:00.000Z",
+      },
+      projectMap,
+    );
+
+    const provider = mapGlossaryToListRow(
+      {
+        id: "glossary-provider",
+        organizationId: "org-1",
+        createdByUserId: null,
+        name: "Phrase Term Base",
+        description: "Marketing",
+        sourceLocale: "en",
+        targetLocale: "fr",
+        status: "active",
+        source: "external_tms",
+        externalProviderKind: "phrase",
+        externalProjectId: "phrase-project-9",
+        externalResourceType: "term_base",
+        externalGlossaryId: "tb-42",
+        localeCoverage: ["en", "fr", "de", "es"],
+        termCount: 4_200,
+        syncState: "synced",
+        termCapabilities: { preferredTerms: true, forbiddenTerms: true },
+        externalUrl: "https://phrase.com/tb/42",
+        lastSyncedAt: "2026-05-20T12:00:00.000Z",
+        lastSyncErrorAt: null,
+        lastSyncErrorMessage: null,
+        createdAt: "2026-05-01T00:00:00.000Z",
+        updatedAt: "2026-05-20T12:00:00.000Z",
+      },
+      projectMap,
+    );
+
+    expect(native.resourceTypeLabel).toBe("Workspace glossary");
+    expect(native.termCapabilityLabel).toBe("Preferred · Forbidden");
+    expect(native.localeSummary).toBe("en, de");
+    expect(native.termCountLabel).toBe("120");
+    expect(provider.resourceTypeLabel).toBe("Term base");
+    expect(provider.localeSummary).toBe("en, fr, de +1");
+    expect(provider.termCountLabel).toBe("4.2k");
+    expect(provider.projectLinkId).toBe("project-1");
+    expect(externalProjectLookupKey("phrase", "phrase-project-9")).toBe("phrase:phrase-project-9");
+  });
+});

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/glossaries/_components/glossary-list.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/glossaries/_components/glossary-list.ts
@@ -1,0 +1,166 @@
+import type { GlossaryRecord } from "@/api/routes/glossary/glossary.schema";
+import {
+  formatTermCapabilityLabel,
+  parseTermCapabilitySupport,
+} from "@/lib/glossary/term-capabilities";
+
+export type ApiGlossary = GlossaryRecord;
+
+export type GlossaryListRow = {
+  id: string;
+  name: string;
+  description: string;
+  source: "native" | "external_tms";
+  externalProviderKind: ApiGlossary["externalProviderKind"];
+  externalProjectId: string | null;
+  externalGlossaryId: string | null;
+  externalResourceType: ApiGlossary["externalResourceType"];
+  resourceTypeLabel: string;
+  sourceLocale: string;
+  targetLocale: string;
+  localePairLabel: string;
+  localeCoverage: string[];
+  localeSummary: string;
+  termCount: number | null;
+  termCountLabel: string;
+  syncState: string | null;
+  termCapabilityLabel: string;
+  externalUrl: string | null;
+  lastSyncedAt: string | null;
+  lastSyncErrorAt: string | null;
+  lastSyncErrorMessage: string | null;
+  updatedAt: string;
+  projectLinkId: string | null;
+};
+
+const PROVIDER_LABELS: Record<string, string> = {
+  crowdin: "Crowdin",
+  smartling: "Smartling",
+  phrase: "Phrase",
+  lokalise: "Lokalise",
+};
+
+const RESOURCE_TYPE_LABELS: Record<NonNullable<ApiGlossary["externalResourceType"]>, string> = {
+  glossary: "Glossary",
+  term_base: "Term base",
+};
+
+const RELATIVE_TIME_FORMATTER = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
+
+export function providerLabel(kind: string) {
+  return PROVIDER_LABELS[kind] ?? kind;
+}
+
+export function formatRelativeTimestamp(value: string | null) {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  const deltaSeconds = Math.round((date.getTime() - Date.now()) / 1000);
+  const absoluteSeconds = Math.abs(deltaSeconds);
+  if (absoluteSeconds < 60) return RELATIVE_TIME_FORMATTER.format(deltaSeconds, "second");
+  if (absoluteSeconds < 3_600)
+    return RELATIVE_TIME_FORMATTER.format(Math.round(deltaSeconds / 60), "minute");
+  if (absoluteSeconds < 86_400)
+    return RELATIVE_TIME_FORMATTER.format(Math.round(deltaSeconds / 3_600), "hour");
+  if (absoluteSeconds < 2_592_000)
+    return RELATIVE_TIME_FORMATTER.format(Math.round(deltaSeconds / 86_400), "day");
+  return date.toLocaleDateString();
+}
+
+function formatTermCount(count: number | null) {
+  if (count === null) return "Unknown";
+  if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
+  if (count >= 1_000) return `${(count / 1_000).toFixed(1)}k`;
+  return `${count}`;
+}
+
+function formatLocaleCoverage(locales: string[], sourceLocale: string, targetLocale: string) {
+  const coverage = locales.length > 0 ? locales : [sourceLocale, targetLocale].filter(Boolean);
+  if (coverage.length === 0) return "No locales listed";
+  if (coverage.length <= 3) return coverage.join(", ");
+  return `${coverage.slice(0, 3).join(", ")} +${coverage.length - 3}`;
+}
+
+function resourceTypeLabelFor(glossary: ApiGlossary) {
+  if (glossary.source === "native") {
+    return "Workspace glossary";
+  }
+
+  if (glossary.externalResourceType) {
+    return RESOURCE_TYPE_LABELS[glossary.externalResourceType];
+  }
+
+  return "Terminology";
+}
+
+export function externalProjectLookupKey(
+  providerKind: string | null | undefined,
+  externalProjectId: string | null | undefined,
+) {
+  if (!providerKind || !externalProjectId) return null;
+  return `${providerKind}:${externalProjectId}`;
+}
+
+export function mapGlossaryToListRow(
+  glossary: ApiGlossary,
+  projectIdByExternalKey: ReadonlyMap<string, string>,
+): GlossaryListRow {
+  const lookupKey = externalProjectLookupKey(
+    glossary.externalProviderKind,
+    glossary.externalProjectId,
+  );
+  const termCapabilitySupport = parseTermCapabilitySupport(
+    glossary.termCapabilities,
+    glossary.source,
+  );
+
+  return {
+    id: glossary.id,
+    name: glossary.name,
+    description: glossary.description.trim() || "No description",
+    source: glossary.source,
+    externalProviderKind: glossary.externalProviderKind,
+    externalProjectId: glossary.externalProjectId,
+    externalGlossaryId: glossary.externalGlossaryId,
+    externalResourceType: glossary.externalResourceType,
+    resourceTypeLabel: resourceTypeLabelFor(glossary),
+    sourceLocale: glossary.sourceLocale,
+    targetLocale: glossary.targetLocale,
+    localePairLabel: `${glossary.sourceLocale} → ${glossary.targetLocale}`,
+    localeCoverage: glossary.localeCoverage,
+    localeSummary: formatLocaleCoverage(
+      glossary.localeCoverage,
+      glossary.sourceLocale,
+      glossary.targetLocale,
+    ),
+    termCount: glossary.termCount,
+    termCountLabel: formatTermCount(glossary.termCount),
+    syncState: glossary.syncState,
+    termCapabilityLabel: formatTermCapabilityLabel(termCapabilitySupport),
+    externalUrl: glossary.externalUrl,
+    lastSyncedAt: formatRelativeTimestamp(glossary.lastSyncedAt),
+    lastSyncErrorAt: formatRelativeTimestamp(glossary.lastSyncErrorAt),
+    lastSyncErrorMessage: glossary.lastSyncErrorMessage,
+    updatedAt: formatRelativeTimestamp(glossary.updatedAt) ?? "—",
+    projectLinkId: lookupKey ? (projectIdByExternalKey.get(lookupKey) ?? null) : null,
+  };
+}
+
+export function buildProjectIdByExternalKey(
+  projects: readonly {
+    id: string;
+    externalProviderKind?: string | null;
+    externalProjectId?: string | null;
+  }[],
+) {
+  const map = new Map<string, string>();
+
+  for (const project of projects) {
+    const key = externalProjectLookupKey(project.externalProviderKind, project.externalProjectId);
+    if (key && !map.has(key)) {
+      map.set(key, project.id);
+    }
+  }
+
+  return map;
+}

--- a/apps/hyperlocalise-web/src/lib/glossary/term-capabilities.test.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/term-capabilities.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { formatTermCapabilityLabel, parseTermCapabilitySupport } from "./term-capabilities";
+
+describe("term-capabilities", () => {
+  it("returns full support for native glossaries", () => {
+    expect(parseTermCapabilitySupport({}, "native")).toEqual({
+      preferred: true,
+      forbidden: true,
+    });
+    expect(formatTermCapabilityLabel(parseTermCapabilitySupport({}, "native"))).toBe(
+      "Preferred · Forbidden",
+    );
+  });
+
+  it("reads provider capability flags from termCapabilities", () => {
+    const support = parseTermCapabilitySupport(
+      { preferredTerms: true, forbiddenTerms: false },
+      "external_tms",
+    );
+
+    expect(support).toEqual({ preferred: true, forbidden: false });
+    expect(formatTermCapabilityLabel(support)).toBe("Preferred · No forbidden");
+  });
+
+  it("reports unknown capabilities when provider metadata is empty", () => {
+    expect(formatTermCapabilityLabel(parseTermCapabilitySupport({}, "external_tms"))).toBe(
+      "Capabilities unknown",
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/glossary/term-capabilities.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/term-capabilities.ts
@@ -1,0 +1,62 @@
+export type TermCapabilitySupport = {
+  preferred: boolean | null;
+  forbidden: boolean | null;
+};
+
+function readCapabilityFlag(
+  capabilities: Record<string, unknown>,
+  keys: readonly string[],
+): boolean | null {
+  for (const key of keys) {
+    const value = capabilities[key];
+    if (typeof value === "boolean") {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+export function parseTermCapabilitySupport(
+  termCapabilities: Record<string, unknown>,
+  source: "native" | "external_tms",
+): TermCapabilitySupport {
+  if (source === "native") {
+    return { preferred: true, forbidden: true };
+  }
+
+  return {
+    preferred: readCapabilityFlag(termCapabilities, [
+      "preferredTerms",
+      "preferred_terms",
+      "supportsPreferredTerms",
+    ]),
+    forbidden: readCapabilityFlag(termCapabilities, [
+      "forbiddenTerms",
+      "forbidden_terms",
+      "supportsForbiddenTerms",
+    ]),
+  };
+}
+
+export function formatTermCapabilityLabel(support: TermCapabilitySupport) {
+  const parts: string[] = [];
+
+  if (support.preferred === true) {
+    parts.push("Preferred");
+  } else if (support.preferred === false) {
+    parts.push("No preferred");
+  }
+
+  if (support.forbidden === true) {
+    parts.push("Forbidden");
+  } else if (support.forbidden === false) {
+    parts.push("No forbidden");
+  }
+
+  if (parts.length === 0) {
+    return "Capabilities unknown";
+  }
+
+  return parts.join(" · ");
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves HL-380 by replacing the mocked Glossaries page with a live, unified terminology list that shows native workspace glossaries alongside synced provider glossaries and term bases.

## Changes

### Glossaries UI (mirrors Translation Memories)
- Fetches glossaries, projects, and provider credentials via React Query
- Table shows source/provider, resource type (glossary vs term base), locale coverage, term counts, term capabilities (preferred/forbidden support), sync health, and last sync
- Filters: search, source, provider, resource type, sync state
- Server-side pagination (100 per page) with total count
- Loading, error, and empty states (including Integrations CTA when no provider is connected)
- Links to linked projects and jobs when a provider project maps to a workspace project

### API hardening
- `GET /glossaries` now returns `{ glossaries, total }` for pagination
- PATCH/DELETE on `external_tms` glossaries returns `external_tms_glossary_immutable`

### Shared helpers
- `term-capabilities.ts` parses provider `termCapabilities` flags into unified labels without provider-specific UI branches

## Testing

- `pnpm exec vp check --fix` — pass
- `pnpm exec vp test` on `glossary-list.test.ts` and `term-capabilities.test.ts` — pass
- Glossary route integration tests require PostgreSQL (not run in this environment)

## Follow-ups (out of scope)

- `glossary_scan` sync orchestration to populate provider glossaries automatically
- Glossary detail / term review page
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-380](https://linear.app/hyperlocalise/issue/HL-380/show-synced-provider-glossaries-in-existing-glossaries-page)

<div><a href="https://cursor.com/agents/bc-ed9bf178-b341-4479-be23-c45e4669537d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed9bf178-b341-4479-be23-c45e4669537d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

