### PR TITLE
feat(lokalise): sync task status into unified jobs model

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -22,6 +22,7 @@ import type { ExternalTmsProviderKind } from "@/lib/providers/organization-exter
 import { getProviderContentPuller } from "@/lib/providers/provider-content-pullers";
 import { getProviderTranslationPusher } from "@/lib/providers/provider-translation-pushers";
 import { fetchLokaliseFileKeys } from "@/lib/providers/lokalise/lokalise-file-fetcher";
+import { fetchLokaliseJobTasks } from "@/lib/providers/lokalise/lokalise-job-task-fetcher";
 import { fetchPhraseFileKeys } from "@/lib/providers/phrase/phrase-file-fetcher";
 import { fetchPhraseJobTasks } from "@/lib/providers/phrase/phrase-job-task-fetcher";
 import { fetchSmartlingFileKeys } from "@/lib/providers/smartling/smartling-file-fetcher";
@@ -223,6 +224,7 @@ const jobTaskFetchersByProvider: Partial<
   Record<ExternalTmsProviderKind, ExternalTmsJobTaskFetcher>
 > = {
   crowdin: fetchCrowdinJobTasks,
+  lokalise: fetchLokaliseJobTasks,
   phrase: fetchPhraseJobTasks,
   smartling: fetchSmartlingJobTasks,
 };

--- a/apps/hyperlocalise-web/src/lib/providers/external-tms-status-mapper.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/external-tms-status-mapper.test.ts
@@ -52,7 +52,10 @@ const cases: ProviderCase[] = [
   { provider: "phrase", status: "cancelled", expected: "cancelled" },
 
   // Lokalise
+  { provider: "lokalise", status: "created", expected: "queued" },
+  { provider: "lokalise", status: "queued", expected: "queued" },
   { provider: "lokalise", status: "unassigned", expected: "queued" },
+  { provider: "lokalise", status: "in_progress", expected: "running" },
   { provider: "lokalise", status: "in_translation", expected: "running" },
   { provider: "lokalise", status: "completed", expected: "succeeded" },
   { provider: "lokalise", status: "failed", expected: "failed" },

--- a/apps/hyperlocalise-web/src/lib/providers/external-tms-status-mapper.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/external-tms-status-mapper.test.ts
@@ -54,6 +54,8 @@ const cases: ProviderCase[] = [
   // Lokalise
   { provider: "lokalise", status: "created", expected: "queued" },
   { provider: "lokalise", status: "queued", expected: "queued" },
+  { provider: "lokalise", status: "not_started", expected: "queued" },
+  { provider: "lokalise", status: "not-started", expected: "queued" },
   { provider: "lokalise", status: "unassigned", expected: "queued" },
   { provider: "lokalise", status: "in_progress", expected: "running" },
   { provider: "lokalise", status: "in_translation", expected: "running" },

--- a/apps/hyperlocalise-web/src/lib/providers/external-tms-status-mapper.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/external-tms-status-mapper.ts
@@ -152,7 +152,18 @@ function mapLokaliseStatus(status: string): NormalizedJobStatus {
     ].includes(status)
   )
     return "running";
-  if (["new", "pending", "created", "draft", "queued", "unassigned"].includes(status))
+  if (
+    [
+      "new",
+      "pending",
+      "created",
+      "draft",
+      "queued",
+      "unassigned",
+      "not_started",
+      "not-started",
+    ].includes(status)
+  )
     return "queued";
   if (["failed", "rejected", "error"].includes(status)) return "failed";
   if (

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-api.test.ts
@@ -6,6 +6,8 @@ import {
   collectLokaliseTaskAssignees,
   collectLokaliseTaskTargetLocales,
   extractLokaliseKeyName,
+  getLokaliseTaskCompletionMs,
+  isLokaliseTaskCompletedAfter,
   inferFormatFromFilename,
   listLokaliseFilenameEntries,
   LokaliseApiClient,
@@ -205,6 +207,53 @@ describe("LokaliseApiClient", () => {
     );
   });
 
+  it("filters completed tasks by completion time and caps pagination", async () => {
+    const recentCompletedAt = Math.floor(Date.now() / 1000) - 60;
+    const staleCompletedAt = Math.floor(Date.now() / 1000) - 60 * 60 * 24 * 60;
+
+    const fetchMock = vi.fn(async (url) => {
+      const path = String(url);
+      if (!path.includes("filter_statuses=completed")) {
+        return new Response(JSON.stringify({ tasks: [] }), { status: 200 });
+      }
+
+      if (path.includes("page=1")) {
+        return new Response(
+          JSON.stringify({
+            tasks: [
+              {
+                task_id: 1,
+                title: "Recent",
+                status: "completed",
+                completed_at_timestamp: recentCompletedAt,
+              },
+              {
+                task_id: 2,
+                title: "Stale",
+                status: "completed",
+                completed_at_timestamp: staleCompletedAt,
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify({ tasks: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    const cutoffMs = Date.now() - 30 * 24 * 60 * 60 * 1000;
+    const tasks = await client.listTasks("proj.123", {
+      filterStatuses: ["completed"],
+      maxPages: 1,
+      completedAfterMs: cutoffMs,
+    });
+
+    expect(tasks.map((task) => task.taskId)).toEqual([1]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("throws LokaliseApiError on auth failure", async () => {
     const fetchMock = vi.fn(async () => {
       return new Response(JSON.stringify({ error: { message: "Invalid token" } }), {
@@ -258,6 +307,33 @@ describe("buildLokaliseTaskUrl", () => {
     expect(buildLokaliseTaskUrl("proj.123", 55392)).toBe(
       "https://app.lokalise.com/project/proj.123/?task=55392",
     );
+  });
+});
+
+describe("isLokaliseTaskCompletedAfter", () => {
+  it("uses completed_at_timestamp when available", () => {
+    const task = {
+      taskId: 1,
+      title: "Done",
+      description: null,
+      status: "completed",
+      progress: 100,
+      taskType: "translation",
+      dueDate: null,
+      dueDateTimestamp: null,
+      sourceLanguageIso: null,
+      languages: [],
+      keysCount: 0,
+      wordsCount: 0,
+      createdAt: null,
+      createdAtTimestamp: null,
+      completedAt: null,
+      completedAtTimestamp: 1_700_000_000,
+    };
+
+    expect(isLokaliseTaskCompletedAfter(task, 1_699_000_000_000)).toBe(true);
+    expect(isLokaliseTaskCompletedAfter(task, 1_701_000_000_000)).toBe(false);
+    expect(getLokaliseTaskCompletionMs(task)).toBe(1_700_000_000_000);
   });
 });
 

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-api.test.ts
@@ -2,11 +2,15 @@ import { describe, expect, it, vi } from "vite-plus/test";
 
 import {
   buildLokaliseProjectUrl,
+  buildLokaliseTaskUrl,
+  collectLokaliseTaskAssignees,
+  collectLokaliseTaskTargetLocales,
   extractLokaliseKeyName,
   inferFormatFromFilename,
   listLokaliseFilenameEntries,
   LokaliseApiClient,
   LokaliseApiError,
+  parseLokaliseTaskDueDate,
   partitionLokaliseLocales,
 } from "./lokalise-api";
 
@@ -149,6 +153,58 @@ describe("LokaliseApiClient", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it("lists tasks with pagination and status filters", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      if (String(url).includes("/projects/proj.123/tasks?page=1")) {
+        return new Response(
+          JSON.stringify({
+            project_id: "proj.123",
+            tasks: [
+              {
+                task_id: 42,
+                title: "Homepage",
+                status: "queued",
+                task_type: "translation",
+                languages: [
+                  {
+                    language_iso: "de",
+                    language_id: 666,
+                    language_name: "German",
+                    users: [{ user_id: 1, email: "de@example.com", fullname: "DE User" }],
+                  },
+                ],
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify({ tasks: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    const tasks = await client.listTasks("proj.123", {
+      filterStatuses: ["created", "queued", "in_progress"],
+    });
+
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]).toMatchObject({
+      taskId: 42,
+      title: "Homepage",
+      status: "queued",
+      taskType: "translation",
+    });
+    expect(collectLokaliseTaskTargetLocales(tasks[0]!)).toEqual(["de"]);
+    expect(collectLokaliseTaskAssignees(tasks[0]!)).toEqual(["DE User"]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.lokalise.test/api2/projects/proj.123/tasks?page=1&limit=500&filter_statuses=created%2Cqueued%2Cin_progress",
+      expect.objectContaining({
+        headers: { "X-Api-Token": "test-token" },
+      }),
+    );
+  });
+
   it("throws LokaliseApiError on auth failure", async () => {
     const fetchMock = vi.fn(async () => {
       return new Response(JSON.stringify({ error: { message: "Invalid token" } }), {
@@ -194,6 +250,39 @@ describe("partitionLokaliseLocales", () => {
 describe("buildLokaliseProjectUrl", () => {
   it("builds the app URL for a project", () => {
     expect(buildLokaliseProjectUrl("proj.123")).toBe("https://app.lokalise.com/project/proj.123/");
+  });
+});
+
+describe("buildLokaliseTaskUrl", () => {
+  it("builds the app URL for a task", () => {
+    expect(buildLokaliseTaskUrl("proj.123", 55392)).toBe(
+      "https://app.lokalise.com/project/proj.123/?task=55392",
+    );
+  });
+});
+
+describe("parseLokaliseTaskDueDate", () => {
+  it("prefers due_date_timestamp when present", () => {
+    const dueDate = parseLokaliseTaskDueDate({
+      taskId: 1,
+      title: "Task",
+      description: null,
+      status: "queued",
+      progress: 0,
+      taskType: "translation",
+      dueDate: null,
+      dueDateTimestamp: 1_700_000_000,
+      sourceLanguageIso: null,
+      languages: [],
+      keysCount: 0,
+      wordsCount: 0,
+      createdAt: null,
+      createdAtTimestamp: null,
+      completedAt: null,
+      completedAtTimestamp: null,
+    });
+
+    expect(dueDate).toEqual(new Date(1_700_000_000 * 1000));
   });
 });
 

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-api.test.ts
@@ -254,6 +254,57 @@ describe("LokaliseApiClient", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("fetches the next page when a full page has only stale completed tasks", async () => {
+    const recentCompletedAt = Math.floor(Date.now() / 1000) - 60;
+    const staleCompletedAt = Math.floor(Date.now() / 1000) - 60 * 60 * 24 * 60;
+    const stalePage = Array.from({ length: 500 }, (_, index) => ({
+      task_id: index + 100,
+      title: `Stale ${index}`,
+      status: "completed",
+      completed_at_timestamp: staleCompletedAt,
+    }));
+
+    const fetchMock = vi.fn(async (url) => {
+      const path = String(url);
+      if (!path.includes("filter_statuses=completed")) {
+        return new Response(JSON.stringify({ tasks: [] }), { status: 200 });
+      }
+
+      if (path.includes("page=1")) {
+        return new Response(JSON.stringify({ tasks: stalePage }), { status: 200 });
+      }
+
+      if (path.includes("page=2")) {
+        return new Response(
+          JSON.stringify({
+            tasks: [
+              {
+                task_id: 99,
+                title: "Recent on page two",
+                status: "completed",
+                completed_at_timestamp: recentCompletedAt,
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify({ tasks: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    const cutoffMs = Date.now() - 30 * 24 * 60 * 60 * 1000;
+    const tasks = await client.listTasks("proj.123", {
+      filterStatuses: ["completed"],
+      maxPages: 2,
+      completedAfterMs: cutoffMs,
+    });
+
+    expect(tasks.map((task) => task.taskId)).toEqual([99]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it("throws LokaliseApiError on auth failure", async () => {
     const fetchMock = vi.fn(async () => {
       return new Response(JSON.stringify({ error: { message: "Invalid token" } }), {

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-api.ts
@@ -4,6 +4,23 @@
 
 export const LOKALISE_DEFAULT_BASE_URL = "https://api.lokalise.com/api2";
 
+/** How far back completed tasks are included in job sync. */
+export const LOKALISE_RECENT_COMPLETED_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** Caps completed-task API pagination when no server-side recency filter exists. */
+export const LOKALISE_COMPLETED_TASK_MAX_PAGES = 2;
+
+export type LokaliseListTasksOptions = {
+  filterStatuses?: string[];
+  /** Stops pagination after this many pages (inclusive). */
+  maxPages?: number;
+  /**
+   * When set, only returns completed tasks completed at or after this Unix ms.
+   * Stops paging early when an entire page is older than the cutoff (newest-first).
+   */
+  completedAfterMs?: number;
+};
+
 export interface LokaliseApiClientOptions {
   token: string;
   baseUrl?: string | null;
@@ -182,14 +199,13 @@ export class LokaliseApiClient {
     return keys;
   }
 
-  async listTasks(
-    projectId: string,
-    options?: { filterStatuses?: string[] },
-  ): Promise<LokaliseTask[]> {
+  async listTasks(projectId: string, options?: LokaliseListTasksOptions): Promise<LokaliseTask[]> {
     const tasks: LokaliseTask[] = [];
     let page = 1;
     const limit = 500;
     const filterStatuses = options?.filterStatuses?.join(",") ?? null;
+    const maxPages = options?.maxPages;
+    const completedAfterMs = options?.completedAfterMs;
 
     while (true) {
       const params = new URLSearchParams({
@@ -204,9 +220,25 @@ export class LokaliseApiClient {
         `/projects/${encodeURIComponent(projectId)}/tasks?${params.toString()}`,
       );
       const pageItems = (response.tasks ?? []).map(normalizeLokaliseTask);
-      tasks.push(...pageItems);
+      const acceptedItems =
+        completedAfterMs == null
+          ? pageItems
+          : pageItems.filter((task) => isLokaliseTaskCompletedAfter(task, completedAfterMs));
+      tasks.push(...acceptedItems);
 
       if (pageItems.length < limit) {
+        break;
+      }
+
+      if (maxPages != null && page >= maxPages) {
+        break;
+      }
+
+      if (
+        completedAfterMs != null &&
+        pageItems.length > 0 &&
+        pageItems.every((task) => !isLokaliseTaskCompletedAfter(task, completedAfterMs))
+      ) {
         break;
       }
 
@@ -579,6 +611,24 @@ export function partitionLokaliseLocales(
     .filter((locale): locale is string => Boolean(locale));
 
   return { sourceLocale, targetLocales };
+}
+
+export function getLokaliseTaskCompletionMs(task: LokaliseTask) {
+  if (task.completedAtTimestamp != null && task.completedAtTimestamp > 0) {
+    return task.completedAtTimestamp * 1000;
+  }
+
+  if (!task.completedAt) {
+    return null;
+  }
+
+  const parsed = Date.parse(task.completedAt);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+export function isLokaliseTaskCompletedAfter(task: LokaliseTask, afterMs: number) {
+  const completedMs = getLokaliseTaskCompletionMs(task);
+  return completedMs != null && completedMs >= afterMs;
 }
 
 export function buildLokaliseProjectUrl(projectId: string) {

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-api.ts
@@ -46,6 +46,40 @@ export interface LokaliseTranslation {
   isUnverified: boolean;
 }
 
+export interface LokaliseTaskLanguageUser {
+  userId: number;
+  email: string;
+  fullname: string;
+}
+
+export interface LokaliseTaskLanguage {
+  languageIso: string;
+  languageId: number;
+  languageName: string;
+  status: string;
+  progress: number;
+  users: LokaliseTaskLanguageUser[];
+}
+
+export interface LokaliseTask {
+  taskId: number;
+  title: string;
+  description: string | null;
+  status: string;
+  progress: number;
+  taskType: string;
+  dueDate: string | null;
+  dueDateTimestamp: number | null;
+  sourceLanguageIso: string | null;
+  languages: LokaliseTaskLanguage[];
+  keysCount: number;
+  wordsCount: number;
+  createdAt: string | null;
+  createdAtTimestamp: number | null;
+  completedAt: string | null;
+  completedAtTimestamp: number | null;
+}
+
 export interface LokaliseKey {
   keyId: number;
   keyName: LokalisePlatformStrings;
@@ -148,6 +182,40 @@ export class LokaliseApiClient {
     return keys;
   }
 
+  async listTasks(
+    projectId: string,
+    options?: { filterStatuses?: string[] },
+  ): Promise<LokaliseTask[]> {
+    const tasks: LokaliseTask[] = [];
+    let page = 1;
+    const limit = 500;
+    const filterStatuses = options?.filterStatuses?.join(",") ?? null;
+
+    while (true) {
+      const params = new URLSearchParams({
+        page: String(page),
+        limit: String(limit),
+      });
+      if (filterStatuses) {
+        params.set("filter_statuses", filterStatuses);
+      }
+
+      const response = await this.get<LokaliseTasksListResponse>(
+        `/projects/${encodeURIComponent(projectId)}/tasks?${params.toString()}`,
+      );
+      const pageItems = (response.tasks ?? []).map(normalizeLokaliseTask);
+      tasks.push(...pageItems);
+
+      if (pageItems.length < limit) {
+        break;
+      }
+
+      page += 1;
+    }
+
+    return tasks;
+  }
+
   async listProjectLanguages(projectId: string): Promise<LokaliseLanguage[]> {
     const languages: LokaliseLanguage[] = [];
     let page = 1;
@@ -222,6 +290,45 @@ type LokaliseProjectsListResponse = {
   projects?: LokaliseProjectApiRecord[];
 };
 
+type LokaliseTasksListResponse = {
+  project_id?: string;
+  tasks?: LokaliseTaskApiRecord[];
+};
+
+type LokaliseTaskLanguageUserApiRecord = {
+  user_id?: number;
+  email?: string;
+  fullname?: string;
+};
+
+type LokaliseTaskLanguageApiRecord = {
+  language_iso?: string;
+  language_id?: number;
+  language_name?: string;
+  status?: string;
+  progress?: number;
+  users?: LokaliseTaskLanguageUserApiRecord[];
+};
+
+type LokaliseTaskApiRecord = {
+  task_id: number;
+  title: string;
+  description?: string | null;
+  status: string;
+  progress?: number;
+  task_type?: string;
+  due_date?: string | null;
+  due_date_timestamp?: number | null;
+  source_language_iso?: string | null;
+  languages?: LokaliseTaskLanguageApiRecord[];
+  keys_count?: number;
+  words_count?: number;
+  created_at?: string | null;
+  created_at_timestamp?: number | null;
+  completed_at?: string | null;
+  completed_at_timestamp?: number | null;
+};
+
 type LokaliseLanguagesListResponse = {
   project_id?: string;
   languages?: LokaliseLanguageApiRecord[];
@@ -284,6 +391,50 @@ type LokaliseLanguageApiRecord = {
   lang_name: string;
   is_rtl?: boolean;
 };
+
+function normalizeLokaliseTask(record: LokaliseTaskApiRecord): LokaliseTask {
+  return {
+    taskId: record.task_id,
+    title: record.title,
+    description: record.description ?? null,
+    status: record.status,
+    progress: record.progress ?? 0,
+    taskType: record.task_type ?? "translation",
+    dueDate: record.due_date ?? null,
+    dueDateTimestamp: record.due_date_timestamp ?? null,
+    sourceLanguageIso: record.source_language_iso ?? null,
+    languages: (record.languages ?? []).map(normalizeLokaliseTaskLanguage),
+    keysCount: record.keys_count ?? 0,
+    wordsCount: record.words_count ?? 0,
+    createdAt: record.created_at ?? null,
+    createdAtTimestamp: record.created_at_timestamp ?? null,
+    completedAt: record.completed_at ?? null,
+    completedAtTimestamp: record.completed_at_timestamp ?? null,
+  };
+}
+
+function normalizeLokaliseTaskLanguage(
+  record: LokaliseTaskLanguageApiRecord,
+): LokaliseTaskLanguage {
+  return {
+    languageIso: record.language_iso?.trim() ?? "",
+    languageId: record.language_id ?? 0,
+    languageName: record.language_name?.trim() ?? "",
+    status: record.status?.trim() ?? "",
+    progress: record.progress ?? 0,
+    users: (record.users ?? []).map(normalizeLokaliseTaskLanguageUser),
+  };
+}
+
+function normalizeLokaliseTaskLanguageUser(
+  record: LokaliseTaskLanguageUserApiRecord,
+): LokaliseTaskLanguageUser {
+  return {
+    userId: record.user_id ?? 0,
+    email: record.email?.trim() ?? "",
+    fullname: record.fullname?.trim() ?? "",
+  };
+}
 
 function normalizeLokaliseProject(record: LokaliseProjectApiRecord): LokaliseProject {
   return {
@@ -432,4 +583,40 @@ export function partitionLokaliseLocales(
 
 export function buildLokaliseProjectUrl(projectId: string) {
   return `https://app.lokalise.com/project/${encodeURIComponent(projectId)}/`;
+}
+
+export function buildLokaliseTaskUrl(projectId: string, taskId: number | string) {
+  return `https://app.lokalise.com/project/${encodeURIComponent(projectId)}/?task=${encodeURIComponent(String(taskId))}`;
+}
+
+export function collectLokaliseTaskAssignees(task: LokaliseTask) {
+  const assignees = new Set<string>();
+  for (const language of task.languages) {
+    for (const user of language.users) {
+      const label = user.fullname || user.email;
+      if (label) {
+        assignees.add(label);
+      }
+    }
+  }
+  return [...assignees];
+}
+
+export function collectLokaliseTaskTargetLocales(task: LokaliseTask) {
+  return task.languages
+    .map((language) => language.languageIso.trim())
+    .filter((locale): locale is string => Boolean(locale));
+}
+
+export function parseLokaliseTaskDueDate(task: LokaliseTask) {
+  if (task.dueDateTimestamp != null && task.dueDateTimestamp > 0) {
+    return new Date(task.dueDateTimestamp * 1000);
+  }
+
+  if (!task.dueDate) {
+    return null;
+  }
+
+  const parsed = new Date(task.dueDate);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
 }

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-api.ts
@@ -14,10 +14,7 @@ export type LokaliseListTasksOptions = {
   filterStatuses?: string[];
   /** Stops pagination after this many pages (inclusive). */
   maxPages?: number;
-  /**
-   * When set, only returns completed tasks completed at or after this Unix ms.
-   * Stops paging early when an entire page is older than the cutoff (newest-first).
-   */
+  /** When set, only returns completed tasks completed at or after this Unix ms. */
   completedAfterMs?: number;
 };
 
@@ -231,14 +228,6 @@ export class LokaliseApiClient {
       }
 
       if (maxPages != null && page >= maxPages) {
-        break;
-      }
-
-      if (
-        completedAfterMs != null &&
-        pageItems.length > 0 &&
-        pageItems.every((task) => !isLokaliseTaskCompletedAfter(task, completedAfterMs))
-      ) {
         break;
       }
 

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-job-task-fetcher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-job-task-fetcher.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { fetchLokaliseJobTasks } from "./lokalise-job-task-fetcher";
+
+describe("fetchLokaliseJobTasks", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("returns normalized job/task metadata from Lokalise", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      const path = String(url);
+
+      if (path.includes("/projects/proj.123/tasks?")) {
+        return new Response(
+          JSON.stringify({
+            project_id: "proj.123",
+            tasks: [
+              {
+                task_id: 55392,
+                title: "French homepage",
+                description: "Translate homepage keys",
+                status: "in_progress",
+                progress: 25,
+                task_type: "translation",
+                due_date: "2026-06-01 00:00:00 (Etc/UTC)",
+                due_date_timestamp: 1780272000,
+                source_language_iso: "en",
+                keys_count: 3,
+                words_count: 91,
+                languages: [
+                  {
+                    language_iso: "fr",
+                    language_id: 673,
+                    language_name: "French",
+                    status: "in progress",
+                    progress: 80,
+                    users: [
+                      {
+                        user_id: 421,
+                        email: "translator@example.com",
+                        fullname: "Jean Translator",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify({ tasks: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    globalThis.fetch = fetchMock;
+
+    const result = await fetchLokaliseJobTasks({
+      organizationId: "org-1",
+      projectId: "project-1",
+      providerKind: "lokalise",
+      externalProjectId: "proj.123",
+      credential: { baseUrl: "https://api.lokalise.test/api2" } as never,
+      project: {} as never,
+      secretMaterial: "test-token",
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      externalJobId: "55392",
+      externalStatus: "in_progress",
+      title: "French homepage",
+      targetLocales: ["fr"],
+      assignedUsers: ["Jean Translator"],
+      kind: "translation",
+      externalUrl: "https://app.lokalise.com/project/proj.123/?task=55392",
+    });
+    expect(result[0]?.dueDate).toEqual(new Date(1780272000 * 1000));
+    expect(result[0]?.providerPayload).toMatchObject({
+      taskType: "translation",
+      progress: 25,
+      sourceLanguageIso: "en",
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.lokalise.test/api2/projects/proj.123/tasks?page=1&limit=500&filter_statuses=created%2Cqueued%2Cin_progress%2Ccompleted",
+      expect.objectContaining({
+        method: "GET",
+        headers: { "X-Api-Token": "test-token" },
+      }),
+    );
+  });
+
+  it("maps review tasks to review kind", async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          tasks: [
+            {
+              task_id: 99,
+              title: "QA pass",
+              status: "queued",
+              task_type: "review",
+              languages: [],
+            },
+          ],
+        }),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+
+    globalThis.fetch = fetchMock;
+
+    const result = await fetchLokaliseJobTasks({
+      organizationId: "org-1",
+      projectId: "project-1",
+      providerKind: "lokalise",
+      externalProjectId: "proj.123",
+      credential: {} as never,
+      project: {} as never,
+      secretMaterial: "token",
+    });
+
+    expect(result[0]?.kind).toBe("review");
+  });
+
+  it("throws lokalise_auth_invalid on 401", async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(JSON.stringify({ error: { message: "Invalid token" } }), {
+        status: 401,
+      });
+    }) as unknown as typeof fetch;
+
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      fetchLokaliseJobTasks({
+        organizationId: "org-1",
+        projectId: "project-1",
+        providerKind: "lokalise",
+        externalProjectId: "proj.123",
+        credential: {} as never,
+        project: {} as never,
+        secretMaterial: "bad-token",
+      }),
+    ).rejects.toThrow("lokalise_auth_invalid");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-job-task-fetcher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-job-task-fetcher.test.ts
@@ -17,7 +17,7 @@ describe("fetchLokaliseJobTasks", () => {
     const fetchMock = vi.fn(async (url) => {
       const path = String(url);
 
-      if (path.includes("/projects/proj.123/tasks?")) {
+      if (path.includes("filter_statuses=created%2Cqueued%2Cin_progress")) {
         return new Response(
           JSON.stringify({
             project_id: "proj.123",
@@ -57,6 +57,10 @@ describe("fetchLokaliseJobTasks", () => {
         );
       }
 
+      if (path.includes("filter_statuses=completed")) {
+        return new Response(JSON.stringify({ tasks: [] }), { status: 200 });
+      }
+
       return new Response(JSON.stringify({ tasks: [] }), { status: 200 });
     }) as unknown as typeof fetch;
 
@@ -88,8 +92,16 @@ describe("fetchLokaliseJobTasks", () => {
       progress: 25,
       sourceLanguageIso: "en",
     });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://api.lokalise.test/api2/projects/proj.123/tasks?page=1&limit=500&filter_statuses=created%2Cqueued%2Cin_progress%2Ccompleted",
+      "https://api.lokalise.test/api2/projects/proj.123/tasks?page=1&limit=500&filter_statuses=created%2Cqueued%2Cin_progress",
+      expect.objectContaining({
+        method: "GET",
+        headers: { "X-Api-Token": "test-token" },
+      }),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.lokalise.test/api2/projects/proj.123/tasks?page=1&limit=500&filter_statuses=completed",
       expect.objectContaining({
         method: "GET",
         headers: { "X-Api-Token": "test-token" },

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-job-task-fetcher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-job-task-fetcher.ts
@@ -4,18 +4,15 @@ import {
   buildLokaliseTaskUrl,
   collectLokaliseTaskAssignees,
   collectLokaliseTaskTargetLocales,
+  LOKALISE_COMPLETED_TASK_MAX_PAGES,
+  LOKALISE_RECENT_COMPLETED_WINDOW_MS,
   LokaliseApiClient,
   LokaliseApiError,
+  type LokaliseTask,
   parseLokaliseTaskDueDate,
 } from "./lokalise-api";
 
-/** Lokalise task statuses for open and recently completed work. */
-const LOKALISE_OPEN_AND_RECENT_TASK_STATUSES = [
-  "created",
-  "queued",
-  "in_progress",
-  "completed",
-] as const;
+const LOKALISE_OPEN_TASK_STATUSES = ["created", "queued", "in_progress"] as const;
 
 export const fetchLokaliseJobTasks: ExternalTmsJobTaskFetcher = async ({
   credential,
@@ -27,11 +24,9 @@ export const fetchLokaliseJobTasks: ExternalTmsJobTaskFetcher = async ({
     baseUrl: credential.baseUrl ?? undefined,
   });
 
-  let tasks: Awaited<ReturnType<typeof client.listTasks>>;
+  let tasks: LokaliseTask[];
   try {
-    tasks = await client.listTasks(externalProjectId, {
-      filterStatuses: [...LOKALISE_OPEN_AND_RECENT_TASK_STATUSES],
-    });
+    tasks = await listOpenAndRecentLokaliseTasks(client, externalProjectId);
   } catch (error) {
     if (error instanceof LokaliseApiError && error.status === 401) {
       throw new Error("lokalise_auth_invalid");
@@ -67,6 +62,26 @@ export const fetchLokaliseJobTasks: ExternalTmsJobTaskFetcher = async ({
     kind: mapLokaliseTaskKind(task.taskType),
   }));
 };
+
+async function listOpenAndRecentLokaliseTasks(client: LokaliseApiClient, projectId: string) {
+  const completedAfterMs = Date.now() - LOKALISE_RECENT_COMPLETED_WINDOW_MS;
+
+  const [openTasks, recentCompletedTasks] = await Promise.all([
+    client.listTasks(projectId, { filterStatuses: [...LOKALISE_OPEN_TASK_STATUSES] }),
+    client.listTasks(projectId, {
+      filterStatuses: ["completed"],
+      maxPages: LOKALISE_COMPLETED_TASK_MAX_PAGES,
+      completedAfterMs,
+    }),
+  ]);
+
+  const tasksById = new Map<number, LokaliseTask>();
+  for (const task of [...openTasks, ...recentCompletedTasks]) {
+    tasksById.set(task.taskId, task);
+  }
+
+  return [...tasksById.values()];
+}
 
 function mapLokaliseTaskKind(
   taskType: string,

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-job-task-fetcher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-job-task-fetcher.ts
@@ -1,0 +1,84 @@
+import type { ExternalTmsJobTaskFetcher } from "@/lib/providers/external-tms-job-sync";
+
+import {
+  buildLokaliseTaskUrl,
+  collectLokaliseTaskAssignees,
+  collectLokaliseTaskTargetLocales,
+  LokaliseApiClient,
+  LokaliseApiError,
+  parseLokaliseTaskDueDate,
+} from "./lokalise-api";
+
+/** Lokalise task statuses for open and recently completed work. */
+const LOKALISE_OPEN_AND_RECENT_TASK_STATUSES = [
+  "created",
+  "queued",
+  "in_progress",
+  "completed",
+] as const;
+
+export const fetchLokaliseJobTasks: ExternalTmsJobTaskFetcher = async ({
+  credential,
+  externalProjectId,
+  secretMaterial,
+}) => {
+  const client = new LokaliseApiClient({
+    token: secretMaterial,
+    baseUrl: credential.baseUrl ?? undefined,
+  });
+
+  let tasks: Awaited<ReturnType<typeof client.listTasks>>;
+  try {
+    tasks = await client.listTasks(externalProjectId, {
+      filterStatuses: [...LOKALISE_OPEN_AND_RECENT_TASK_STATUSES],
+    });
+  } catch (error) {
+    if (error instanceof LokaliseApiError && error.status === 401) {
+      throw new Error("lokalise_auth_invalid");
+    }
+    throw error;
+  }
+
+  return tasks.map((task) => ({
+    externalJobId: String(task.taskId),
+    externalTaskId: null,
+    externalStatus: task.status,
+    title: task.title,
+    dueDate: parseLokaliseTaskDueDate(task),
+    targetLocales: collectLokaliseTaskTargetLocales(task),
+    assignedUsers: collectLokaliseTaskAssignees(task),
+    externalUrl: buildLokaliseTaskUrl(externalProjectId, task.taskId),
+    providerPayload: {
+      taskType: task.taskType,
+      description: task.description,
+      progress: task.progress,
+      sourceLanguageIso: task.sourceLanguageIso,
+      keysCount: task.keysCount,
+      wordsCount: task.wordsCount,
+      languages: task.languages.map((language) => ({
+        languageIso: language.languageIso,
+        languageName: language.languageName,
+        status: language.status,
+        progress: language.progress,
+      })),
+      createdAt: task.createdAt,
+      completedAt: task.completedAt,
+    },
+    kind: mapLokaliseTaskKind(task.taskType),
+  }));
+};
+
+function mapLokaliseTaskKind(
+  taskType: string,
+): "translation" | "research" | "review" | "sync" | "asset_management" {
+  switch (taskType) {
+    case "review":
+    case "lqa_by_ai":
+      return "review";
+    case "automatic_translation":
+      return "sync";
+    case "translation":
+    default:
+      return "translation";
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements HL-360 by syncing Lokalise tasks into the unified external TMS jobs model.

- Adds `LokaliseApiClient.listTasks()` with pagination and status filters for open/recent tasks (`created`, `queued`, `in_progress`, `completed`)
- Introduces `fetchLokaliseJobTasks` to map task title, assignees, target locales, status, due date, provider URL, and metadata into `ExternalTmsJobTaskMetadata`
- Registers the fetcher on `POST /projects/:projectId/sync-jobs` (replacing the previous 501 for Lokalise)
- Extends Lokalise status mapping tests for API-native statuses (`created`, `queued`, `in_progress`)

## Testing

- `vp test src/lib/providers/lokalise/`
- `vp test src/lib/providers/external-tms-status-mapper.test.ts`
- `vp check --fix`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-360](https://linear.app/hyperlocalise/issue/HL-360/implement-lokalise-task-status-sync)

<div><a href="https://cursor.com/agents/bc-b56ddbf1-5c69-4d31-a79d-436a8cbc8703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b56ddbf1-5c69-4d31-a79d-436a8cbc8703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

