### PR TITLE
feat(phrase): sync and search Phrase TM and term bases (HL-352)

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -15,15 +15,25 @@ import {
   type ExternalTmsFileKeyFetcher,
 } from "@/lib/providers/external-tms-file-sync";
 import {
+  syncExternalTmsGlossaries,
+  type ExternalTmsGlossaryFetcher,
+} from "@/lib/providers/external-tms-glossary-sync";
+import {
   syncExternalTmsJobTasks,
   type ExternalTmsJobTaskFetcher,
 } from "@/lib/providers/external-tms-job-sync";
+import {
+  syncExternalTmsTranslationMemories,
+  type ExternalTmsTranslationMemoryFetcher,
+} from "@/lib/providers/external-tms-tm-sync";
 import type { ExternalTmsProviderKind } from "@/lib/providers/organization-external-tms-provider-credentials";
 import { getProviderContentPuller } from "@/lib/providers/provider-content-pullers";
 import { getProviderTranslationPusher } from "@/lib/providers/provider-translation-pushers";
 import { fetchLokaliseFileKeys } from "@/lib/providers/lokalise/lokalise-file-fetcher";
+import { fetchPhraseGlossaries } from "@/lib/providers/phrase/phrase-glossary-fetcher";
 import { fetchPhraseFileKeys } from "@/lib/providers/phrase/phrase-file-fetcher";
 import { fetchPhraseJobTasks } from "@/lib/providers/phrase/phrase-job-task-fetcher";
+import { fetchPhraseTranslationMemories } from "@/lib/providers/phrase/phrase-translation-memory-fetcher";
 import { fetchSmartlingFileKeys } from "@/lib/providers/smartling/smartling-file-fetcher";
 import { fetchSmartlingJobTasks } from "@/lib/providers/smartling/smartling-job-fetcher";
 import {
@@ -227,6 +237,18 @@ const jobTaskFetchersByProvider: Partial<
   smartling: fetchSmartlingJobTasks,
 };
 
+const glossaryFetchersByProvider: Partial<
+  Record<ExternalTmsProviderKind, ExternalTmsGlossaryFetcher>
+> = {
+  phrase: fetchPhraseGlossaries,
+};
+
+const translationMemoryFetchersByProvider: Partial<
+  Record<ExternalTmsProviderKind, ExternalTmsTranslationMemoryFetcher>
+> = {
+  phrase: fetchPhraseTranslationMemories,
+};
+
 export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
   const jobQueue = options.jobQueue ?? createTranslationJobEventQueue();
 
@@ -422,6 +444,70 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
       });
 
       return c.json({ externalTmsJobTaskSync: result }, result.status === "failed" ? 207 : 200);
+    })
+    .post("/:projectId/sync-glossaries", validateProjectParams, async (c) => {
+      if (!isProjectMutationAllowed(c.var.auth.membership.role)) {
+        return forbiddenResponse(c);
+      }
+
+      const params = c.req.valid("param");
+      const project = await projectStore.getById(c.var.auth, params.projectId);
+
+      if (!project) {
+        return projectNotFoundResponse(c);
+      }
+
+      if (!project.externalProviderKind) {
+        return c.json({ error: "provider_sync_not_implemented" }, 501);
+      }
+
+      const fetchGlossaries = glossaryFetchersByProvider[project.externalProviderKind];
+      if (!fetchGlossaries) {
+        return c.json({ error: "provider_sync_not_implemented" }, 501);
+      }
+
+      const result = await syncExternalTmsGlossaries({
+        organizationId: c.var.auth.organization.localOrganizationId,
+        projectId: project.id,
+        providerKind: project.externalProviderKind,
+        fetchGlossaries,
+      });
+
+      return c.json({ externalTmsGlossarySync: result }, result.status === "failed" ? 207 : 200);
+    })
+    .post("/:projectId/sync-translation-memories", validateProjectParams, async (c) => {
+      if (!isProjectMutationAllowed(c.var.auth.membership.role)) {
+        return forbiddenResponse(c);
+      }
+
+      const params = c.req.valid("param");
+      const project = await projectStore.getById(c.var.auth, params.projectId);
+
+      if (!project) {
+        return projectNotFoundResponse(c);
+      }
+
+      if (!project.externalProviderKind) {
+        return c.json({ error: "provider_sync_not_implemented" }, 501);
+      }
+
+      const fetchTranslationMemories =
+        translationMemoryFetchersByProvider[project.externalProviderKind];
+      if (!fetchTranslationMemories) {
+        return c.json({ error: "provider_sync_not_implemented" }, 501);
+      }
+
+      const result = await syncExternalTmsTranslationMemories({
+        organizationId: c.var.auth.organization.localOrganizationId,
+        projectId: project.id,
+        providerKind: project.externalProviderKind,
+        fetchTranslationMemories,
+      });
+
+      return c.json(
+        { externalTmsTranslationMemorySync: result },
+        result.status === "failed" ? 207 : 200,
+      );
     })
     .post(
       "/:projectId/sync-pull-content",

--- a/apps/hyperlocalise-web/src/lib/providers/external-tms-glossary-sync.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/external-tms-glossary-sync.ts
@@ -1,0 +1,321 @@
+import { and, eq } from "drizzle-orm";
+
+import { db, schema } from "@/lib/database";
+import type { ProviderSyncRunStatus } from "@/lib/database/types";
+import { decryptProviderCredential } from "@/lib/security/provider-credential-crypto";
+
+import {
+  upsertOrganizationExternalTmsGlossary,
+  upsertOrganizationExternalTmsGlossaryTerms,
+  type ExternalTmsTerminologyResourceType,
+} from "./organization-external-tms-glossaries";
+import type { ExternalTmsProviderKind } from "./organization-external-tms-provider-credentials";
+import {
+  completeProviderSyncRun,
+  failProviderSyncRun,
+  startProviderSyncRun,
+} from "./provider-sync-runs";
+
+type ExternalTmsCredential = typeof schema.organizationExternalTmsProviderCredentials.$inferSelect;
+type ExternalTmsProject = typeof schema.projects.$inferSelect;
+
+export type ExternalTmsGlossaryTermMetadata = {
+  externalKey: string;
+  sourceTerm: string;
+  targetTerm: string;
+  description?: string;
+  partOfSpeech?: string;
+  status?: string | null;
+  forbidden?: boolean | null;
+  notes?: string | null;
+  metadata?: Record<string, unknown>;
+};
+
+export type ExternalTmsGlossaryMetadata = {
+  externalGlossaryId: string;
+  name: string;
+  description?: string;
+  sourceLocale: string;
+  targetLocale: string;
+  externalResourceType?: ExternalTmsTerminologyResourceType;
+  localeCoverage?: string[];
+  termCount?: number | null;
+  externalUrl?: string | null;
+  termCapabilities?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+  syncErrorMessage?: string | null;
+  terms?: ExternalTmsGlossaryTermMetadata[];
+};
+
+export type ExternalTmsGlossaryFetcher = (input: {
+  organizationId: string;
+  projectId: string;
+  providerKind: ExternalTmsProviderKind;
+  externalProjectId: string;
+  credential: ExternalTmsCredential;
+  project: ExternalTmsProject;
+  secretMaterial: string;
+}) => Promise<ExternalTmsGlossaryMetadata[]>;
+
+export type ExternalTmsGlossarySyncFailure = {
+  externalGlossaryId: string | null;
+  name: string | null;
+  message: string;
+};
+
+export type ExternalTmsGlossarySyncResult = {
+  runId: string;
+  status: Extract<ProviderSyncRunStatus, "succeeded" | "failed">;
+  providerKind: ExternalTmsProviderKind;
+  providerCredentialId: string;
+  projectId: string;
+  counts: {
+    glossariesDiscovered: number;
+    glossariesSynced: number;
+    glossariesFailed: number;
+    termsSynced: number;
+  };
+  failures: ExternalTmsGlossarySyncFailure[];
+};
+
+export async function syncExternalTmsGlossaries(input: {
+  organizationId: string;
+  projectId: string;
+  providerKind: ExternalTmsProviderKind;
+  fetchGlossaries: ExternalTmsGlossaryFetcher;
+}): Promise<ExternalTmsGlossarySyncResult> {
+  const project = await getExternalTmsProject(input);
+
+  if (!project?.externalProjectId) {
+    throw new Error("external_tms_project_not_found");
+  }
+
+  const credential = await getExternalTmsCredential({
+    organizationId: input.organizationId,
+    providerKind: input.providerKind,
+    credentialId: project.externalProviderCredentialId,
+  });
+
+  if (!credential) {
+    throw new Error("provider_credential_not_found");
+  }
+
+  const run = await startProviderSyncRun({
+    organizationId: input.organizationId,
+    providerKind: input.providerKind,
+    providerCredentialId: credential.id,
+    kind: "glossary_scan",
+    projectId: project.id,
+    externalProjectId: project.externalProjectId,
+    resourceType: "glossary",
+    providerMetadata: { credentialId: credential.id },
+  });
+
+  const counts: ExternalTmsGlossarySyncResult["counts"] = {
+    glossariesDiscovered: 0,
+    glossariesSynced: 0,
+    glossariesFailed: 0,
+    termsSynced: 0,
+  };
+  const failures: ExternalTmsGlossarySyncFailure[] = [];
+
+  try {
+    const secretMaterial = decryptProviderCredential({
+      algorithm: credential.encryptionAlgorithm,
+      keyVersion: credential.keyVersion,
+      ciphertext: credential.ciphertext,
+      iv: credential.iv,
+      authTag: credential.authTag,
+    });
+
+    const glossaries = await input.fetchGlossaries({
+      organizationId: input.organizationId,
+      projectId: project.id,
+      providerKind: input.providerKind,
+      externalProjectId: project.externalProjectId,
+      credential,
+      project,
+      secretMaterial,
+    });
+
+    counts.glossariesDiscovered = glossaries.length;
+
+    for (const glossary of glossaries) {
+      try {
+        if (glossary.syncErrorMessage) {
+          counts.glossariesFailed += 1;
+          failures.push({
+            externalGlossaryId: glossary.externalGlossaryId,
+            name: glossary.name,
+            message: glossary.syncErrorMessage,
+          });
+          continue;
+        }
+
+        const importedTermCount = glossary.terms?.length ?? 0;
+        const termCapabilities =
+          glossary.termCapabilities ??
+          (importedTermCount === 0 ? { mode: "live_search" } : { mode: "synced_import" });
+
+        const record = await upsertOrganizationExternalTmsGlossary({
+          organizationId: input.organizationId,
+          providerCredentialId: credential.id,
+          providerKind: input.providerKind,
+          externalProjectId: project.externalProjectId,
+          externalResourceType: glossary.externalResourceType ?? "glossary",
+          externalGlossaryId: glossary.externalGlossaryId,
+          name: glossary.name,
+          description: glossary.description,
+          sourceLocale: glossary.sourceLocale,
+          targetLocale: glossary.targetLocale,
+          localeCoverage: glossary.localeCoverage,
+          termCount: glossary.termCount,
+          termCapabilities,
+          externalUrl: glossary.externalUrl,
+          metadata: glossary.metadata,
+        });
+
+        await ensureProjectGlossaryAttachment({
+          organizationId: input.organizationId,
+          projectId: project.id,
+          glossaryId: record.id,
+        });
+
+        const terms = glossary.terms ?? [];
+        if (terms.length > 0) {
+          await upsertOrganizationExternalTmsGlossaryTerms(
+            terms.map((term) => ({
+              glossaryId: record.id,
+              externalKey: term.externalKey,
+              sourceTerm: term.sourceTerm,
+              targetTerm: term.targetTerm,
+              description: term.description,
+              partOfSpeech: term.partOfSpeech,
+              status: term.status,
+              forbidden: term.forbidden,
+              notes: term.notes,
+              metadata: term.metadata,
+            })),
+          );
+          counts.termsSynced += terms.length;
+        }
+
+        counts.glossariesSynced += 1;
+      } catch (error) {
+        counts.glossariesFailed += 1;
+        failures.push({
+          externalGlossaryId: glossary.externalGlossaryId,
+          name: glossary.name,
+          message: error instanceof Error ? error.message : "glossary sync failed",
+        });
+      }
+    }
+
+    const status = failures.length > 0 ? "failed" : "succeeded";
+    const finishInput = {
+      runId: run.id,
+      organizationId: run.organizationId,
+      counts,
+      providerMetadata: {
+        credentialId: credential.id,
+        failures,
+      },
+    };
+
+    if (status === "failed") {
+      await failProviderSyncRun({
+        ...finishInput,
+        errorMessage: "One or more provider glossaries failed to sync",
+        errorDetails: { failures },
+      });
+    } else {
+      await completeProviderSyncRun(finishInput);
+    }
+
+    return {
+      runId: run.id,
+      status,
+      providerKind: input.providerKind,
+      providerCredentialId: credential.id,
+      projectId: project.id,
+      counts,
+      failures,
+    };
+  } catch (error) {
+    await failProviderSyncRun({
+      runId: run.id,
+      organizationId: run.organizationId,
+      errorMessage: error instanceof Error ? error.message : "provider glossary sync failed",
+      errorDetails: {
+        name: error instanceof Error ? error.name : "UnknownError",
+        stack: error instanceof Error ? error.stack : undefined,
+      },
+      counts,
+      providerMetadata: { credentialId: credential.id },
+    });
+    throw error;
+  }
+}
+
+async function ensureProjectGlossaryAttachment(input: {
+  organizationId: string;
+  projectId: string;
+  glossaryId: string;
+}) {
+  await db
+    .insert(schema.projectGlossaries)
+    .values({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      glossaryId: input.glossaryId,
+      priority: 0,
+    })
+    .onConflictDoNothing({
+      target: [schema.projectGlossaries.projectId, schema.projectGlossaries.glossaryId],
+    });
+}
+
+async function getExternalTmsProject(input: {
+  organizationId: string;
+  projectId: string;
+  providerKind: ExternalTmsProviderKind;
+}) {
+  const [project] = await db
+    .select()
+    .from(schema.projects)
+    .where(
+      and(
+        eq(schema.projects.id, input.projectId),
+        eq(schema.projects.organizationId, input.organizationId),
+        eq(schema.projects.externalProviderKind, input.providerKind),
+        eq(schema.projects.source, "external_tms"),
+      ),
+    )
+    .limit(1);
+
+  return project ?? null;
+}
+
+async function getExternalTmsCredential(input: {
+  organizationId: string;
+  providerKind: ExternalTmsProviderKind;
+  credentialId: string | null;
+}) {
+  if (!input.credentialId) {
+    return null;
+  }
+
+  const [credential] = await db
+    .select()
+    .from(schema.organizationExternalTmsProviderCredentials)
+    .where(
+      and(
+        eq(schema.organizationExternalTmsProviderCredentials.organizationId, input.organizationId),
+        eq(schema.organizationExternalTmsProviderCredentials.providerKind, input.providerKind),
+        eq(schema.organizationExternalTmsProviderCredentials.id, input.credentialId),
+      ),
+    )
+    .limit(1);
+
+  return credential ?? null;
+}

--- a/apps/hyperlocalise-web/src/lib/providers/external-tms-tm-sync.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/external-tms-tm-sync.ts
@@ -1,0 +1,313 @@
+import { and, eq } from "drizzle-orm";
+
+import { db, schema } from "@/lib/database";
+import type { ProviderSyncRunStatus } from "@/lib/database/types";
+import { decryptProviderCredential } from "@/lib/security/provider-credential-crypto";
+
+import {
+  upsertOrganizationExternalTmsMemory,
+  upsertOrganizationExternalTmsMemoryEntries,
+} from "./organization-external-tms-memories";
+import type { ExternalTmsProviderKind } from "./organization-external-tms-provider-credentials";
+import {
+  completeProviderSyncRun,
+  failProviderSyncRun,
+  startProviderSyncRun,
+} from "./provider-sync-runs";
+
+type ExternalTmsCredential = typeof schema.organizationExternalTmsProviderCredentials.$inferSelect;
+type ExternalTmsProject = typeof schema.projects.$inferSelect;
+
+export type ExternalTmsTranslationMemoryEntryMetadata = {
+  externalKey: string;
+  sourceLocale: string;
+  targetLocale: string;
+  sourceText: string;
+  targetText: string;
+  matchScore?: number;
+  metadata?: Record<string, unknown>;
+};
+
+export type ExternalTmsTranslationMemoryMetadata = {
+  externalMemoryId: string;
+  name: string;
+  description?: string;
+  sourceLocale: string;
+  localeCoverage?: string[];
+  segmentCount?: number | null;
+  externalUrl?: string | null;
+  metadata?: Record<string, unknown>;
+  syncErrorMessage?: string | null;
+  entries?: ExternalTmsTranslationMemoryEntryMetadata[];
+};
+
+export type ExternalTmsTranslationMemoryFetcher = (input: {
+  organizationId: string;
+  projectId: string;
+  providerKind: ExternalTmsProviderKind;
+  externalProjectId: string;
+  credential: ExternalTmsCredential;
+  project: ExternalTmsProject;
+  secretMaterial: string;
+}) => Promise<ExternalTmsTranslationMemoryMetadata[]>;
+
+export type ExternalTmsTranslationMemorySyncFailure = {
+  externalMemoryId: string | null;
+  name: string | null;
+  message: string;
+};
+
+export type ExternalTmsTranslationMemorySyncResult = {
+  runId: string;
+  status: Extract<ProviderSyncRunStatus, "succeeded" | "failed">;
+  providerKind: ExternalTmsProviderKind;
+  providerCredentialId: string;
+  projectId: string;
+  counts: {
+    memoriesDiscovered: number;
+    memoriesSynced: number;
+    memoriesFailed: number;
+    entriesSynced: number;
+  };
+  failures: ExternalTmsTranslationMemorySyncFailure[];
+};
+
+export async function syncExternalTmsTranslationMemories(input: {
+  organizationId: string;
+  projectId: string;
+  providerKind: ExternalTmsProviderKind;
+  fetchTranslationMemories: ExternalTmsTranslationMemoryFetcher;
+}): Promise<ExternalTmsTranslationMemorySyncResult> {
+  const project = await getExternalTmsProject(input);
+
+  if (!project?.externalProjectId) {
+    throw new Error("external_tms_project_not_found");
+  }
+
+  const credential = await getExternalTmsCredential({
+    organizationId: input.organizationId,
+    providerKind: input.providerKind,
+    credentialId: project.externalProviderCredentialId,
+  });
+
+  if (!credential) {
+    throw new Error("provider_credential_not_found");
+  }
+
+  const run = await startProviderSyncRun({
+    organizationId: input.organizationId,
+    providerKind: input.providerKind,
+    providerCredentialId: credential.id,
+    kind: "tm_scan",
+    projectId: project.id,
+    externalProjectId: project.externalProjectId,
+    resourceType: "translation_memory",
+    providerMetadata: { credentialId: credential.id },
+  });
+
+  const counts: ExternalTmsTranslationMemorySyncResult["counts"] = {
+    memoriesDiscovered: 0,
+    memoriesSynced: 0,
+    memoriesFailed: 0,
+    entriesSynced: 0,
+  };
+  const failures: ExternalTmsTranslationMemorySyncFailure[] = [];
+
+  try {
+    const secretMaterial = decryptProviderCredential({
+      algorithm: credential.encryptionAlgorithm,
+      keyVersion: credential.keyVersion,
+      ciphertext: credential.ciphertext,
+      iv: credential.iv,
+      authTag: credential.authTag,
+    });
+
+    const memories = await input.fetchTranslationMemories({
+      organizationId: input.organizationId,
+      projectId: project.id,
+      providerKind: input.providerKind,
+      externalProjectId: project.externalProjectId,
+      credential,
+      project,
+      secretMaterial,
+    });
+
+    counts.memoriesDiscovered = memories.length;
+
+    for (const memory of memories) {
+      try {
+        if (memory.syncErrorMessage) {
+          counts.memoriesFailed += 1;
+          failures.push({
+            externalMemoryId: memory.externalMemoryId,
+            name: memory.name,
+            message: memory.syncErrorMessage,
+          });
+          continue;
+        }
+
+        const importedEntryCount = memory.entries?.length ?? 0;
+        const capabilityMode =
+          importedEntryCount > 0 ? ("synced_import" as const) : ("live_search" as const);
+
+        const record = await upsertOrganizationExternalTmsMemory({
+          organizationId: input.organizationId,
+          providerCredentialId: credential.id,
+          providerKind: input.providerKind,
+          externalProjectId: project.externalProjectId,
+          externalMemoryId: memory.externalMemoryId,
+          name: memory.name,
+          description: memory.description,
+          localeCoverage:
+            memory.localeCoverage && memory.localeCoverage.length > 0
+              ? memory.localeCoverage
+              : [memory.sourceLocale],
+          segmentCount: memory.segmentCount,
+          capabilityMode,
+          externalUrl: memory.externalUrl,
+          metadata: memory.metadata,
+        });
+
+        await ensureProjectMemoryAttachment({
+          organizationId: input.organizationId,
+          projectId: project.id,
+          memoryId: record.id,
+        });
+
+        const entries = memory.entries ?? [];
+        if (entries.length > 0) {
+          await upsertOrganizationExternalTmsMemoryEntries(
+            entries.map((entry) => ({
+              memoryId: record.id,
+              externalKey: entry.externalKey,
+              sourceLocale: entry.sourceLocale,
+              targetLocale: entry.targetLocale,
+              sourceText: entry.sourceText,
+              targetText: entry.targetText,
+              matchScore: entry.matchScore,
+              metadata: entry.metadata,
+            })),
+          );
+          counts.entriesSynced += entries.length;
+        }
+
+        counts.memoriesSynced += 1;
+      } catch (error) {
+        counts.memoriesFailed += 1;
+        failures.push({
+          externalMemoryId: memory.externalMemoryId,
+          name: memory.name,
+          message: error instanceof Error ? error.message : "translation memory sync failed",
+        });
+      }
+    }
+
+    const status = failures.length > 0 ? "failed" : "succeeded";
+    const finishInput = {
+      runId: run.id,
+      organizationId: run.organizationId,
+      counts,
+      providerMetadata: {
+        credentialId: credential.id,
+        failures,
+      },
+    };
+
+    if (status === "failed") {
+      await failProviderSyncRun({
+        ...finishInput,
+        errorMessage: "One or more provider translation memories failed to sync",
+        errorDetails: { failures },
+      });
+    } else {
+      await completeProviderSyncRun(finishInput);
+    }
+
+    return {
+      runId: run.id,
+      status,
+      providerKind: input.providerKind,
+      providerCredentialId: credential.id,
+      projectId: project.id,
+      counts,
+      failures,
+    };
+  } catch (error) {
+    await failProviderSyncRun({
+      runId: run.id,
+      organizationId: run.organizationId,
+      errorMessage:
+        error instanceof Error ? error.message : "provider translation memory sync failed",
+      errorDetails: {
+        name: error instanceof Error ? error.name : "UnknownError",
+        stack: error instanceof Error ? error.stack : undefined,
+      },
+      counts,
+      providerMetadata: { credentialId: credential.id },
+    });
+    throw error;
+  }
+}
+
+async function ensureProjectMemoryAttachment(input: {
+  organizationId: string;
+  projectId: string;
+  memoryId: string;
+}) {
+  await db
+    .insert(schema.projectMemories)
+    .values({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      memoryId: input.memoryId,
+      priority: 0,
+    })
+    .onConflictDoNothing({
+      target: [schema.projectMemories.projectId, schema.projectMemories.memoryId],
+    });
+}
+
+async function getExternalTmsProject(input: {
+  organizationId: string;
+  projectId: string;
+  providerKind: ExternalTmsProviderKind;
+}) {
+  const [project] = await db
+    .select()
+    .from(schema.projects)
+    .where(
+      and(
+        eq(schema.projects.id, input.projectId),
+        eq(schema.projects.organizationId, input.organizationId),
+        eq(schema.projects.externalProviderKind, input.providerKind),
+        eq(schema.projects.source, "external_tms"),
+      ),
+    )
+    .limit(1);
+
+  return project ?? null;
+}
+
+async function getExternalTmsCredential(input: {
+  organizationId: string;
+  providerKind: ExternalTmsProviderKind;
+  credentialId: string | null;
+}) {
+  if (!input.credentialId) {
+    return null;
+  }
+
+  const [credential] = await db
+    .select()
+    .from(schema.organizationExternalTmsProviderCredentials)
+    .where(
+      and(
+        eq(schema.organizationExternalTmsProviderCredentials.organizationId, input.organizationId),
+        eq(schema.organizationExternalTmsProviderCredentials.providerKind, input.providerKind),
+        eq(schema.organizationExternalTmsProviderCredentials.id, input.credentialId),
+      ),
+    )
+    .limit(1);
+
+  return credential ?? null;
+}

--- a/apps/hyperlocalise-web/src/lib/providers/organization-external-tms-glossaries.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/organization-external-tms-glossaries.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, notInArray, sql } from "drizzle-orm";
 
 import { db, schema } from "@/lib/database";
 
@@ -109,10 +109,9 @@ export async function upsertOrganizationExternalTmsGlossary(input: ExternalTmsGl
   return glossary;
 }
 
-export async function upsertOrganizationExternalTmsGlossaryTerm(
-  input: ExternalTmsGlossaryTermMetadata,
-) {
-  const now = new Date();
+const glossaryTermBatchSize = 200;
+
+function buildGlossaryTermInsertValue(input: ExternalTmsGlossaryTermMetadata) {
   const { forbidden } = normalizeProviderGlossaryTermFlags({
     status: input.status,
     forbidden: input.forbidden,
@@ -123,43 +122,99 @@ export async function upsertOrganizationExternalTmsGlossaryTerm(
     ...(input.status ? { providerStatus: input.status } : {}),
   };
 
+  return {
+    glossaryId: input.glossaryId,
+    sourceTerm: input.sourceTerm,
+    targetTerm: input.targetTerm,
+    description: input.description ?? "",
+    partOfSpeech: input.partOfSpeech ?? "",
+    caseSensitive: input.caseSensitive ?? false,
+    forbidden,
+    externalKey: input.externalKey,
+    provenance: "sync" as const,
+    reviewStatus: "approved" as const,
+    metadata,
+  };
+}
+
+export async function upsertOrganizationExternalTmsGlossaryTerms(
+  terms: ExternalTmsGlossaryTermMetadata[],
+) {
+  if (terms.length === 0) {
+    return;
+  }
+
+  const now = new Date();
+
+  for (let index = 0; index < terms.length; index += glossaryTermBatchSize) {
+    const chunk = terms.slice(index, index + glossaryTermBatchSize);
+    const values = chunk.map(buildGlossaryTermInsertValue);
+
+    await db
+      .insert(schema.glossaryTerms)
+      .values(values)
+      .onConflictDoUpdate({
+        target: [schema.glossaryTerms.glossaryId, schema.glossaryTerms.externalKey],
+        set: {
+          sourceTerm: sql`excluded.source_term`,
+          targetTerm: sql`excluded.target_term`,
+          description: sql`excluded.description`,
+          partOfSpeech: sql`excluded.part_of_speech`,
+          caseSensitive: sql`excluded.case_sensitive`,
+          forbidden: sql`excluded.forbidden`,
+          provenance: sql`excluded.provenance`,
+          reviewStatus: sql`excluded.review_status`,
+          metadata: sql`excluded.metadata`,
+          updatedAt: now,
+        },
+      });
+  }
+}
+
+export async function upsertOrganizationExternalTmsGlossaryTerm(
+  input: ExternalTmsGlossaryTermMetadata,
+) {
+  await upsertOrganizationExternalTmsGlossaryTerms([input]);
+
   const [term] = await db
-    .insert(schema.glossaryTerms)
-    .values({
-      glossaryId: input.glossaryId,
-      sourceTerm: input.sourceTerm,
-      targetTerm: input.targetTerm,
-      description: input.description ?? "",
-      partOfSpeech: input.partOfSpeech ?? "",
-      caseSensitive: input.caseSensitive ?? false,
-      forbidden,
-      externalKey: input.externalKey,
-      provenance: "sync",
-      reviewStatus: "approved",
-      metadata,
-    })
-    .onConflictDoUpdate({
-      target: [schema.glossaryTerms.glossaryId, schema.glossaryTerms.externalKey],
-      set: {
-        sourceTerm: input.sourceTerm,
-        targetTerm: input.targetTerm,
-        description: input.description ?? "",
-        partOfSpeech: input.partOfSpeech ?? "",
-        caseSensitive: input.caseSensitive ?? false,
-        forbidden,
-        provenance: "sync",
-        reviewStatus: "approved",
-        metadata,
-        updatedAt: now,
-      },
-    })
-    .returning();
+    .select()
+    .from(schema.glossaryTerms)
+    .where(
+      and(
+        eq(schema.glossaryTerms.glossaryId, input.glossaryId),
+        eq(schema.glossaryTerms.externalKey, input.externalKey),
+      ),
+    )
+    .limit(1);
 
   if (!term) {
     throw new Error("Failed to upsert external TMS glossary term");
   }
 
   return term;
+}
+
+export async function pruneOrganizationExternalTmsGlossaryTerms(input: {
+  glossaryId: string;
+  externalKeys: string[];
+}) {
+  const uniqueExternalKeys = [...new Set(input.externalKeys)];
+
+  if (uniqueExternalKeys.length === 0) {
+    await db
+      .delete(schema.glossaryTerms)
+      .where(eq(schema.glossaryTerms.glossaryId, input.glossaryId));
+    return;
+  }
+
+  await db
+    .delete(schema.glossaryTerms)
+    .where(
+      and(
+        eq(schema.glossaryTerms.glossaryId, input.glossaryId),
+        notInArray(schema.glossaryTerms.externalKey, uniqueExternalKeys),
+      ),
+    );
 }
 
 export async function listOrganizationExternalTmsGlossaries(input: {

--- a/apps/hyperlocalise-web/src/lib/providers/organization-external-tms-memories.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/organization-external-tms-memories.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, notInArray, sql } from "drizzle-orm";
 
 import { db, schema } from "@/lib/database";
 
@@ -106,49 +106,96 @@ export async function upsertOrganizationExternalTmsMemory(input: ExternalTmsMemo
   return memory;
 }
 
+const memoryEntryBatchSize = 200;
+
+export async function upsertOrganizationExternalTmsMemoryEntries(
+  entries: ExternalTmsMemoryEntryMetadata[],
+) {
+  if (entries.length === 0) {
+    return;
+  }
+
+  const now = new Date();
+
+  for (let index = 0; index < entries.length; index += memoryEntryBatchSize) {
+    const chunk = entries.slice(index, index + memoryEntryBatchSize);
+    const values = chunk.map((entry) => ({
+      memoryId: entry.memoryId,
+      sourceLocale: entry.sourceLocale,
+      targetLocale: entry.targetLocale,
+      sourceText: entry.sourceText,
+      normalizedSourceText: normalizeTranslationMemorySourceText(entry.sourceText),
+      targetText: entry.targetText,
+      matchScore: entry.matchScore ?? 100,
+      provenance: "sync" as const,
+      externalKey: entry.externalKey,
+      reviewStatus: "approved" as const,
+      metadata: entry.metadata ?? {},
+    }));
+
+    await db
+      .insert(schema.memoryEntries)
+      .values(values)
+      .onConflictDoUpdate({
+        target: [schema.memoryEntries.memoryId, schema.memoryEntries.externalKey],
+        set: {
+          sourceLocale: sql`excluded.source_locale`,
+          targetLocale: sql`excluded.target_locale`,
+          sourceText: sql`excluded.source_text`,
+          normalizedSourceText: sql`excluded.normalized_source_text`,
+          targetText: sql`excluded.target_text`,
+          matchScore: sql`excluded.match_score`,
+          provenance: sql`excluded.provenance`,
+          reviewStatus: sql`excluded.review_status`,
+          metadata: sql`excluded.metadata`,
+          updatedAt: now,
+        },
+      });
+  }
+}
+
 export async function upsertOrganizationExternalTmsMemoryEntry(
   input: ExternalTmsMemoryEntryMetadata,
 ) {
-  const now = new Date();
-  const normalizedSourceText = normalizeTranslationMemorySourceText(input.sourceText);
+  await upsertOrganizationExternalTmsMemoryEntries([input]);
 
   const [entry] = await db
-    .insert(schema.memoryEntries)
-    .values({
-      memoryId: input.memoryId,
-      sourceLocale: input.sourceLocale,
-      targetLocale: input.targetLocale,
-      sourceText: input.sourceText,
-      normalizedSourceText,
-      targetText: input.targetText,
-      matchScore: input.matchScore ?? 100,
-      provenance: "sync",
-      externalKey: input.externalKey,
-      reviewStatus: "approved",
-      metadata: input.metadata ?? {},
-    })
-    .onConflictDoUpdate({
-      target: [schema.memoryEntries.memoryId, schema.memoryEntries.externalKey],
-      set: {
-        sourceLocale: input.sourceLocale,
-        targetLocale: input.targetLocale,
-        sourceText: input.sourceText,
-        normalizedSourceText,
-        targetText: input.targetText,
-        matchScore: input.matchScore ?? 100,
-        provenance: "sync",
-        reviewStatus: "approved",
-        metadata: input.metadata ?? {},
-        updatedAt: now,
-      },
-    })
-    .returning();
+    .select()
+    .from(schema.memoryEntries)
+    .where(
+      and(
+        eq(schema.memoryEntries.memoryId, input.memoryId),
+        eq(schema.memoryEntries.externalKey, input.externalKey),
+      ),
+    )
+    .limit(1);
 
   if (!entry) {
     throw new Error("Failed to upsert external TMS translation memory entry");
   }
 
   return entry;
+}
+
+export async function pruneOrganizationExternalTmsMemoryEntries(input: {
+  memoryId: string;
+  externalKeys: string[];
+}) {
+  const uniqueExternalKeys = [...new Set(input.externalKeys)];
+
+  if (uniqueExternalKeys.length === 0) {
+    await db.delete(schema.memoryEntries).where(eq(schema.memoryEntries.memoryId, input.memoryId));
+    return;
+  }
+
+  await db
+    .delete(schema.memoryEntries)
+    .where(
+      and(
+        eq(schema.memoryEntries.memoryId, input.memoryId),
+        notInArray(schema.memoryEntries.externalKey, uniqueExternalKeys),
+      ),
+    );
 }
 
 export async function listOrganizationExternalTmsMemories(input: {

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/load-phrase-translation-context-matches.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/load-phrase-translation-context-matches.test.ts
@@ -6,7 +6,6 @@ const { mockDbSelect, mockDecrypt, mockPhraseClient } = vi.hoisted(() => ({
   mockDbSelect: vi.fn(),
   mockDecrypt: vi.fn(() => "secret-token"),
   mockPhraseClient: {
-    searchJobTranslationMemorySegment: vi.fn(),
     searchJobTermBasesInText: vi.fn(),
   },
 }));
@@ -21,8 +20,6 @@ vi.mock("@/lib/database", () => ({
       organizationId: "organizationId",
       providerKind: "providerKind",
     },
-    projectMemories: { projectId: "projectId", memoryId: "memoryId" },
-    memories: { id: "id", externalMemoryId: "externalMemoryId" },
   },
 }));
 
@@ -32,7 +29,6 @@ vi.mock("@/lib/security/provider-credential-crypto", () => ({
 
 vi.mock("./phrase-tms-api", () => ({
   PhraseTmsApiClient: class {
-    searchJobTranslationMemorySegment = mockPhraseClient.searchJobTranslationMemorySegment;
     searchJobTermBasesInText = mockPhraseClient.searchJobTermBasesInText;
   },
 }));
@@ -61,12 +57,6 @@ function createSelectBuilder(result: unknown) {
     from: vi.fn(() => ({
       where: vi.fn(() => ({
         limit: vi.fn(async () => result),
-        innerJoin: vi.fn(() => ({
-          where: vi.fn(async () => result),
-        })),
-      })),
-      innerJoin: vi.fn(() => ({
-        where: vi.fn(async () => result),
       })),
     })),
   };
@@ -75,11 +65,10 @@ function createSelectBuilder(result: unknown) {
 describe("loadPhraseTranslationContextMatches", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockPhraseClient.searchJobTranslationMemorySegment.mockResolvedValue([]);
     mockPhraseClient.searchJobTermBasesInText.mockResolvedValue([]);
   });
 
-  it("returns empty matches when external job uid is missing", async () => {
+  it("returns empty glossary terms when external job uid is missing", async () => {
     const result = await loadPhraseTranslationContextMatches({
       project: phraseProject(),
       externalJobUid: null,
@@ -88,11 +77,11 @@ describe("loadPhraseTranslationContextMatches", () => {
       sourceText: "Hello",
     });
 
-    expect(result).toEqual({ glossaryTerms: [], translationMemoryMatches: [] });
-    expect(mockPhraseClient.searchJobTranslationMemorySegment).not.toHaveBeenCalled();
+    expect(result).toEqual({ glossaryTerms: [] });
+    expect(mockPhraseClient.searchJobTermBasesInText).not.toHaveBeenCalled();
   });
 
-  it("returns empty matches for non-phrase projects", async () => {
+  it("returns empty glossary terms for non-phrase projects", async () => {
     const result = await loadPhraseTranslationContextMatches({
       project: phraseProject({ externalProviderKind: "crowdin" }),
       externalJobUid: "job-1",
@@ -101,11 +90,11 @@ describe("loadPhraseTranslationContextMatches", () => {
       sourceText: "Hello",
     });
 
-    expect(result).toEqual({ glossaryTerms: [], translationMemoryMatches: [] });
+    expect(result).toEqual({ glossaryTerms: [] });
     expect(mockDbSelect).not.toHaveBeenCalled();
   });
 
-  it("returns empty matches when provider credential is missing", async () => {
+  it("returns empty glossary terms when provider credential is missing", async () => {
     mockDbSelect.mockReturnValueOnce(createSelectBuilder([]));
 
     const result = await loadPhraseTranslationContextMatches({
@@ -116,11 +105,11 @@ describe("loadPhraseTranslationContextMatches", () => {
       sourceText: "Hello",
     });
 
-    expect(result).toEqual({ glossaryTerms: [], translationMemoryMatches: [] });
-    expect(mockPhraseClient.searchJobTranslationMemorySegment).not.toHaveBeenCalled();
+    expect(result).toEqual({ glossaryTerms: [] });
+    expect(mockPhraseClient.searchJobTermBasesInText).not.toHaveBeenCalled();
   });
 
-  it("normalizes live TM and term-base hits for attached memories", async () => {
+  it("normalizes live term-base hits", async () => {
     const credential = {
       id: "cred_1",
       encryptionAlgorithm: "aes-256-gcm",
@@ -131,29 +120,8 @@ describe("loadPhraseTranslationContextMatches", () => {
       baseUrl: "https://cloud.memsource.com/web",
     };
 
-    mockDbSelect
-      .mockReturnValueOnce(createSelectBuilder([credential]))
-      .mockReturnValueOnce(
-        createSelectBuilder([{ id: "memory_local_1", externalMemoryId: "tm-uid-1" }]),
-      );
+    mockDbSelect.mockReturnValueOnce(createSelectBuilder([credential]));
 
-    mockPhraseClient.searchJobTranslationMemorySegment.mockResolvedValue([
-      {
-        transMemoryUid: "tm-uid-1",
-        transMemoryName: "Product TM",
-        sourceText: "Hello",
-        targetText: "Bonjour",
-        targetLocale: "fr-FR",
-        score: 0.9,
-      },
-      {
-        transMemoryUid: "tm-not-synced",
-        sourceText: "Hello",
-        targetText: "Hola",
-        targetLocale: "es-ES",
-        score: 0.7,
-      },
-    ]);
     mockPhraseClient.searchJobTermBasesInText.mockResolvedValue([
       {
         termBaseUid: "tb-1",
@@ -172,13 +140,11 @@ describe("loadPhraseTranslationContextMatches", () => {
       sourceText: "Hello",
     });
 
-    expect(mockPhraseClient.searchJobTranslationMemorySegment).toHaveBeenCalledWith({
+    expect(mockPhraseClient.searchJobTermBasesInText).toHaveBeenCalledWith({
       projectUid: "phrase-project-uid",
       jobUid: "job-1",
-      segment: "Hello",
+      text: "Hello",
     });
-    expect(result.translationMemoryMatches).toHaveLength(1);
-    expect(result.translationMemoryMatches[0]?.memoryId).toBe("memory_local_1");
     expect(result.glossaryTerms).toHaveLength(1);
     expect(result.glossaryTerms[0]?.glossaryId).toBe("phrase:tb-1");
   });

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/load-phrase-translation-context-matches.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/load-phrase-translation-context-matches.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import type { TranslationContextProjectRecord } from "@/lib/translation/assemble-translation-context";
+
+const { mockDbSelect, mockDecrypt, mockPhraseClient } = vi.hoisted(() => ({
+  mockDbSelect: vi.fn(),
+  mockDecrypt: vi.fn(() => "secret-token"),
+  mockPhraseClient: {
+    searchJobTranslationMemorySegment: vi.fn(),
+    searchJobTermBasesInText: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/database", () => ({
+  db: {
+    select: mockDbSelect,
+  },
+  schema: {
+    organizationExternalTmsProviderCredentials: {
+      id: "id",
+      organizationId: "organizationId",
+      providerKind: "providerKind",
+    },
+    projectMemories: { projectId: "projectId", memoryId: "memoryId" },
+    memories: { id: "id", externalMemoryId: "externalMemoryId" },
+  },
+}));
+
+vi.mock("@/lib/security/provider-credential-crypto", () => ({
+  decryptProviderCredential: mockDecrypt,
+}));
+
+vi.mock("./phrase-tms-api", () => ({
+  PhraseTmsApiClient: class {
+    searchJobTranslationMemorySegment = mockPhraseClient.searchJobTranslationMemorySegment;
+    searchJobTermBasesInText = mockPhraseClient.searchJobTermBasesInText;
+  },
+}));
+
+import { loadPhraseTranslationContextMatches } from "./load-phrase-translation-context-matches";
+
+function phraseProject(
+  overrides: Partial<TranslationContextProjectRecord> = {},
+): TranslationContextProjectRecord {
+  return {
+    id: "project_1",
+    name: "Phrase project",
+    translationContext: "",
+    organizationId: "org_1",
+    source: "external_tms",
+    externalProviderKind: "phrase",
+    externalProjectId: "phrase-project-uid",
+    externalProviderCredentialId: "cred_1",
+    providerMetadata: { phraseTmsProjectUid: "phrase-project-uid" },
+    ...overrides,
+  };
+}
+
+function createSelectBuilder(result: unknown) {
+  return {
+    from: vi.fn(() => ({
+      where: vi.fn(() => ({
+        limit: vi.fn(async () => result),
+        innerJoin: vi.fn(() => ({
+          where: vi.fn(async () => result),
+        })),
+      })),
+      innerJoin: vi.fn(() => ({
+        where: vi.fn(async () => result),
+      })),
+    })),
+  };
+}
+
+describe("loadPhraseTranslationContextMatches", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPhraseClient.searchJobTranslationMemorySegment.mockResolvedValue([]);
+    mockPhraseClient.searchJobTermBasesInText.mockResolvedValue([]);
+  });
+
+  it("returns empty matches when external job uid is missing", async () => {
+    const result = await loadPhraseTranslationContextMatches({
+      project: phraseProject(),
+      externalJobUid: null,
+      sourceLocale: "en",
+      targetLocales: ["fr-FR"],
+      sourceText: "Hello",
+    });
+
+    expect(result).toEqual({ glossaryTerms: [], translationMemoryMatches: [] });
+    expect(mockPhraseClient.searchJobTranslationMemorySegment).not.toHaveBeenCalled();
+  });
+
+  it("returns empty matches for non-phrase projects", async () => {
+    const result = await loadPhraseTranslationContextMatches({
+      project: phraseProject({ externalProviderKind: "crowdin" }),
+      externalJobUid: "job-1",
+      sourceLocale: "en",
+      targetLocales: ["fr-FR"],
+      sourceText: "Hello",
+    });
+
+    expect(result).toEqual({ glossaryTerms: [], translationMemoryMatches: [] });
+    expect(mockDbSelect).not.toHaveBeenCalled();
+  });
+
+  it("returns empty matches when provider credential is missing", async () => {
+    mockDbSelect.mockReturnValueOnce(createSelectBuilder([]));
+
+    const result = await loadPhraseTranslationContextMatches({
+      project: phraseProject(),
+      externalJobUid: "job-1",
+      sourceLocale: "en",
+      targetLocales: ["fr-FR"],
+      sourceText: "Hello",
+    });
+
+    expect(result).toEqual({ glossaryTerms: [], translationMemoryMatches: [] });
+    expect(mockPhraseClient.searchJobTranslationMemorySegment).not.toHaveBeenCalled();
+  });
+
+  it("normalizes live TM and term-base hits for attached memories", async () => {
+    const credential = {
+      id: "cred_1",
+      encryptionAlgorithm: "aes-256-gcm",
+      keyVersion: 1,
+      ciphertext: "cipher",
+      iv: "iv",
+      authTag: "tag",
+      baseUrl: "https://cloud.memsource.com/web",
+    };
+
+    mockDbSelect
+      .mockReturnValueOnce(createSelectBuilder([credential]))
+      .mockReturnValueOnce(
+        createSelectBuilder([{ id: "memory_local_1", externalMemoryId: "tm-uid-1" }]),
+      );
+
+    mockPhraseClient.searchJobTranslationMemorySegment.mockResolvedValue([
+      {
+        transMemoryUid: "tm-uid-1",
+        transMemoryName: "Product TM",
+        sourceText: "Hello",
+        targetText: "Bonjour",
+        targetLocale: "fr-FR",
+        score: 0.9,
+      },
+      {
+        transMemoryUid: "tm-not-synced",
+        sourceText: "Hello",
+        targetText: "Hola",
+        targetLocale: "es-ES",
+        score: 0.7,
+      },
+    ]);
+    mockPhraseClient.searchJobTermBasesInText.mockResolvedValue([
+      {
+        termBaseUid: "tb-1",
+        termBaseName: "Brand",
+        sourceTerm: "Hello",
+        targetTerm: "Bonjour",
+        targetLocale: "fr-FR",
+      },
+    ]);
+
+    const result = await loadPhraseTranslationContextMatches({
+      project: phraseProject(),
+      externalJobUid: "job-1",
+      sourceLocale: "en",
+      targetLocales: ["fr-FR"],
+      sourceText: "Hello",
+    });
+
+    expect(mockPhraseClient.searchJobTranslationMemorySegment).toHaveBeenCalledWith({
+      projectUid: "phrase-project-uid",
+      jobUid: "job-1",
+      segment: "Hello",
+    });
+    expect(result.translationMemoryMatches).toHaveLength(1);
+    expect(result.translationMemoryMatches[0]?.memoryId).toBe("memory_local_1");
+    expect(result.glossaryTerms).toHaveLength(1);
+    expect(result.glossaryTerms[0]?.glossaryId).toBe("phrase:tb-1");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/load-phrase-translation-context-matches.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/load-phrase-translation-context-matches.ts
@@ -1,0 +1,145 @@
+import { and, eq } from "drizzle-orm";
+
+import { db, schema } from "@/lib/database";
+import type { TranslationContextProjectRecord } from "@/lib/translation/assemble-translation-context";
+import { decryptProviderCredential } from "@/lib/security/provider-credential-crypto";
+
+import { resolvePhraseTmsProjectUid } from "./phrase-job-context";
+import {
+  mergeTranslationContextMatches,
+  normalizePhraseTermBaseSearchMatches,
+  normalizePhraseTranslationMemorySearchMatches,
+} from "./normalize-phrase-context-matches";
+import { PhraseTmsApiClient } from "./phrase-tms-api";
+
+export async function loadPhraseTranslationContextMatches(input: {
+  project: TranslationContextProjectRecord;
+  externalJobUid?: string | null;
+  sourceLocale: string;
+  targetLocales: string[];
+  sourceText: string;
+}) {
+  const { project } = input;
+
+  if (
+    project.source !== "external_tms" ||
+    project.externalProviderKind !== "phrase" ||
+    !project.externalProjectId ||
+    !project.externalProviderCredentialId
+  ) {
+    return {
+      glossaryTerms: [],
+      translationMemoryMatches: [],
+    };
+  }
+
+  const jobUid = input.externalJobUid?.trim();
+  if (!jobUid) {
+    return {
+      glossaryTerms: [],
+      translationMemoryMatches: [],
+    };
+  }
+
+  const tmsProjectUid = resolvePhraseTmsProjectUid(project, project.externalProjectId);
+  if (!tmsProjectUid) {
+    return {
+      glossaryTerms: [],
+      translationMemoryMatches: [],
+    };
+  }
+
+  const [credential] = await db
+    .select()
+    .from(schema.organizationExternalTmsProviderCredentials)
+    .where(
+      and(
+        eq(
+          schema.organizationExternalTmsProviderCredentials.id,
+          project.externalProviderCredentialId,
+        ),
+        eq(
+          schema.organizationExternalTmsProviderCredentials.organizationId,
+          project.organizationId,
+        ),
+        eq(schema.organizationExternalTmsProviderCredentials.providerKind, "phrase"),
+      ),
+    )
+    .limit(1);
+
+  if (!credential) {
+    return {
+      glossaryTerms: [],
+      translationMemoryMatches: [],
+    };
+  }
+
+  const secretMaterial = decryptProviderCredential({
+    algorithm: credential.encryptionAlgorithm,
+    keyVersion: credential.keyVersion,
+    ciphertext: credential.ciphertext,
+    iv: credential.iv,
+    authTag: credential.authTag,
+  });
+
+  const client = new PhraseTmsApiClient({
+    token: secretMaterial,
+    baseUrl: credential.baseUrl,
+  });
+
+  const segment = input.sourceText.trim();
+  if (!segment) {
+    return {
+      glossaryTerms: [],
+      translationMemoryMatches: [],
+    };
+  }
+
+  const attachedMemories = await db
+    .select({
+      id: schema.memories.id,
+      externalMemoryId: schema.memories.externalMemoryId,
+    })
+    .from(schema.projectMemories)
+    .innerJoin(schema.memories, eq(schema.projectMemories.memoryId, schema.memories.id))
+    .where(eq(schema.projectMemories.projectId, project.id));
+
+  const memoryIdByExternalUid = new Map(
+    attachedMemories
+      .filter((memory) => memory.externalMemoryId)
+      .map((memory) => [memory.externalMemoryId as string, memory.id]),
+  );
+
+  const [tmSearchResults, termBaseSearchResults] = await Promise.all([
+    client
+      .searchJobTranslationMemorySegment({
+        projectUid: tmsProjectUid,
+        jobUid,
+        segment,
+      })
+      .catch(() => []),
+    client
+      .searchJobTermBasesInText({
+        projectUid: tmsProjectUid,
+        jobUid,
+        text: segment,
+      })
+      .catch(() => []),
+  ]);
+
+  const glossaryTerms = input.targetLocales.flatMap((targetLocale) =>
+    normalizePhraseTermBaseSearchMatches(termBaseSearchResults, { targetLocale }),
+  );
+
+  const translationMemoryMatches = input.targetLocales.flatMap((targetLocale) =>
+    normalizePhraseTranslationMemorySearchMatches(tmSearchResults, {
+      targetLocale,
+      memoryIdByExternalUid,
+    }),
+  );
+
+  return {
+    glossaryTerms: mergeTranslationContextMatches([], glossaryTerms, 20),
+    translationMemoryMatches: mergeTranslationContextMatches([], translationMemoryMatches, 10),
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/load-phrase-translation-context-matches.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/load-phrase-translation-context-matches.ts
@@ -8,7 +8,6 @@ import { resolvePhraseTmsProjectUid } from "./phrase-job-context";
 import {
   mergeTranslationContextMatches,
   normalizePhraseTermBaseSearchMatches,
-  normalizePhraseTranslationMemorySearchMatches,
 } from "./normalize-phrase-context-matches";
 import { PhraseTmsApiClient } from "./phrase-tms-api";
 
@@ -27,26 +26,17 @@ export async function loadPhraseTranslationContextMatches(input: {
     !project.externalProjectId ||
     !project.externalProviderCredentialId
   ) {
-    return {
-      glossaryTerms: [],
-      translationMemoryMatches: [],
-    };
+    return { glossaryTerms: [] };
   }
 
   const jobUid = input.externalJobUid?.trim();
   if (!jobUid) {
-    return {
-      glossaryTerms: [],
-      translationMemoryMatches: [],
-    };
+    return { glossaryTerms: [] };
   }
 
   const tmsProjectUid = resolvePhraseTmsProjectUid(project, project.externalProjectId);
   if (!tmsProjectUid) {
-    return {
-      glossaryTerms: [],
-      translationMemoryMatches: [],
-    };
+    return { glossaryTerms: [] };
   }
 
   const [credential] = await db
@@ -68,10 +58,7 @@ export async function loadPhraseTranslationContextMatches(input: {
     .limit(1);
 
   if (!credential) {
-    return {
-      glossaryTerms: [],
-      translationMemoryMatches: [],
-    };
+    return { glossaryTerms: [] };
   }
 
   const secretMaterial = decryptProviderCredential({
@@ -89,57 +76,22 @@ export async function loadPhraseTranslationContextMatches(input: {
 
   const segment = input.sourceText.trim();
   if (!segment) {
-    return {
-      glossaryTerms: [],
-      translationMemoryMatches: [],
-    };
+    return { glossaryTerms: [] };
   }
 
-  const attachedMemories = await db
-    .select({
-      id: schema.memories.id,
-      externalMemoryId: schema.memories.externalMemoryId,
+  const termBaseSearchResults = await client
+    .searchJobTermBasesInText({
+      projectUid: tmsProjectUid,
+      jobUid,
+      text: segment,
     })
-    .from(schema.projectMemories)
-    .innerJoin(schema.memories, eq(schema.projectMemories.memoryId, schema.memories.id))
-    .where(eq(schema.projectMemories.projectId, project.id));
-
-  const memoryIdByExternalUid = new Map(
-    attachedMemories
-      .filter((memory) => memory.externalMemoryId)
-      .map((memory) => [memory.externalMemoryId as string, memory.id]),
-  );
-
-  const [tmSearchResults, termBaseSearchResults] = await Promise.all([
-    client
-      .searchJobTranslationMemorySegment({
-        projectUid: tmsProjectUid,
-        jobUid,
-        segment,
-      })
-      .catch(() => []),
-    client
-      .searchJobTermBasesInText({
-        projectUid: tmsProjectUid,
-        jobUid,
-        text: segment,
-      })
-      .catch(() => []),
-  ]);
+    .catch(() => []);
 
   const glossaryTerms = input.targetLocales.flatMap((targetLocale) =>
     normalizePhraseTermBaseSearchMatches(termBaseSearchResults, { targetLocale }),
   );
 
-  const translationMemoryMatches = input.targetLocales.flatMap((targetLocale) =>
-    normalizePhraseTranslationMemorySearchMatches(tmSearchResults, {
-      targetLocale,
-      memoryIdByExternalUid,
-    }),
-  );
-
   return {
     glossaryTerms: mergeTranslationContextMatches([], glossaryTerms, 20),
-    translationMemoryMatches: mergeTranslationContextMatches([], translationMemoryMatches, 10),
   };
 }

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/normalize-phrase-context-matches.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/normalize-phrase-context-matches.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  mergeTranslationContextMatches,
+  normalizePhraseMatchScore,
+  normalizePhraseTermBaseSearchMatches,
+  normalizePhraseTranslationMemorySearchMatches,
+} from "./normalize-phrase-context-matches";
+
+describe("normalizePhraseMatchScore", () => {
+  it("converts fractional Phrase scores to 0-100", () => {
+    expect(normalizePhraseMatchScore(0.85)).toBe(85);
+    expect(normalizePhraseMatchScore(0)).toBe(0);
+    expect(normalizePhraseMatchScore(1)).toBe(100);
+  });
+
+  it("clamps already-percent scores", () => {
+    expect(normalizePhraseMatchScore(92)).toBe(92);
+    expect(normalizePhraseMatchScore(150)).toBe(100);
+    expect(normalizePhraseMatchScore(-5)).toBe(0);
+  });
+
+  it("returns null for missing or non-finite scores", () => {
+    expect(normalizePhraseMatchScore(null)).toBeNull();
+    expect(normalizePhraseMatchScore(undefined)).toBeNull();
+    expect(normalizePhraseMatchScore(Number.NaN)).toBeNull();
+  });
+});
+
+describe("normalizePhraseTranslationMemorySearchMatches", () => {
+  const memoryIdByExternalUid = new Map([["tm-uid-1", "memory_local_1"]]);
+
+  it("maps attached memories into agent context matches", () => {
+    const matches = normalizePhraseTranslationMemorySearchMatches(
+      [
+        {
+          transMemoryUid: "tm-uid-1",
+          transMemoryName: "Product TM",
+          segmentId: "seg-1",
+          sourceText: "Hello",
+          targetText: "Bonjour",
+          targetLocale: "fr-FR",
+          score: 0.91,
+        },
+      ],
+      { targetLocale: "fr-FR", memoryIdByExternalUid },
+    );
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0]).toMatchObject({
+      memoryId: "memory_local_1",
+      memoryName: "Product TM",
+      sourceText: "Hello",
+      targetText: "Bonjour",
+      matchScore: 91,
+      matchSource: "live_provider",
+      providerKind: "phrase",
+      externalResourceId: "tm-uid-1",
+    });
+  });
+
+  it("skips matches for memories that are not synced locally", () => {
+    const matches = normalizePhraseTranslationMemorySearchMatches(
+      [
+        {
+          transMemoryUid: "unknown-tm",
+          transMemoryName: null,
+          segmentId: null,
+          sourceText: "Hello",
+          targetText: "Bonjour",
+          targetLocale: "fr-FR",
+          score: 0.8,
+        },
+      ],
+      { targetLocale: "fr-FR", memoryIdByExternalUid },
+    );
+
+    expect(matches).toEqual([]);
+  });
+
+  it("filters by target locale when provided on the match", () => {
+    const matches = normalizePhraseTranslationMemorySearchMatches(
+      [
+        {
+          transMemoryUid: "tm-uid-1",
+          transMemoryName: null,
+          segmentId: null,
+          sourceText: "Hello",
+          targetText: "Hola",
+          targetLocale: "es-ES",
+          score: 0.8,
+        },
+      ],
+      { targetLocale: "fr-FR", memoryIdByExternalUid },
+    );
+
+    expect(matches).toEqual([]);
+  });
+});
+
+describe("normalizePhraseTermBaseSearchMatches", () => {
+  it("maps term-base hits into glossary context terms", () => {
+    const terms = normalizePhraseTermBaseSearchMatches(
+      [
+        {
+          termBaseUid: "tb-1",
+          termBaseName: "Brand terms",
+          sourceTerm: "Hyperlocalise",
+          targetTerm: "Hyperlocalise",
+          targetLocale: "fr-FR",
+          description: "Product name",
+          forbidden: false,
+        },
+      ],
+      { targetLocale: "fr-FR" },
+    );
+
+    expect(terms).toHaveLength(1);
+    expect(terms[0]).toMatchObject({
+      glossaryId: "phrase:tb-1",
+      glossaryName: "Brand terms",
+      sourceTerm: "Hyperlocalise",
+      targetTerm: "Hyperlocalise",
+      forbidden: false,
+    });
+  });
+
+  it("returns empty when term base uid is missing", () => {
+    const terms = normalizePhraseTermBaseSearchMatches(
+      [
+        {
+          termBaseUid: null,
+          termBaseName: null,
+          sourceTerm: "a",
+          targetTerm: "b",
+          targetLocale: "fr-FR",
+          description: null,
+          forbidden: null,
+        },
+      ],
+      { targetLocale: "fr-FR" },
+    );
+
+    expect(terms).toEqual([]);
+  });
+});
+
+describe("mergeTranslationContextMatches", () => {
+  it("deduplicates by id and sorts by rank", () => {
+    const merged = mergeTranslationContextMatches(
+      [{ id: "a", rank: 50 }],
+      [
+        { id: "b", rank: 90 },
+        { id: "a", rank: 10 },
+      ],
+      10,
+    );
+
+    expect(merged.map((item) => item.id)).toEqual(["b", "a"]);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/normalize-phrase-context-matches.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/normalize-phrase-context-matches.test.ts
@@ -158,4 +158,16 @@ describe("mergeTranslationContextMatches", () => {
 
     expect(merged.map((item) => item.id)).toEqual(["b", "a"]);
   });
+
+  it("includes high-ranked supplemental items after sorting when primary fills the limit", () => {
+    const primary = Array.from({ length: 3 }, (_, index) => ({
+      id: `db-${index}`,
+      rank: 1,
+    }));
+    const supplemental = [{ id: "phrase-live", rank: 99 }];
+
+    const merged = mergeTranslationContextMatches(primary, supplemental, 3);
+
+    expect(merged.map((item) => item.id)).toEqual(["phrase-live", "db-0", "db-1"]);
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/normalize-phrase-context-matches.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/normalize-phrase-context-matches.ts
@@ -106,12 +106,12 @@ export function mergeTranslationContextMatches<T extends { id: string; rank: num
   const merged: T[] = [];
 
   for (const item of [...primary, ...supplemental]) {
-    if (seen.has(item.id) || merged.length >= limit) {
+    if (seen.has(item.id)) {
       continue;
     }
     seen.add(item.id);
     merged.push(item);
   }
 
-  return merged.sort((left, right) => right.rank - left.rank);
+  return merged.sort((left, right) => right.rank - left.rank).slice(0, limit);
 }

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/normalize-phrase-context-matches.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/normalize-phrase-context-matches.ts
@@ -1,0 +1,117 @@
+import type { StringTranslationContextSnapshot } from "@/lib/translation/assemble-translation-context";
+import type {
+  PhraseTmsSearchSegmentResult,
+  PhraseTmsTermBaseSearchResult,
+} from "@/lib/providers/phrase/phrase-tms-api";
+
+export function normalizePhraseMatchScore(score: number | null | undefined): number | null {
+  if (score == null || !Number.isFinite(score)) {
+    return null;
+  }
+
+  if (score <= 1) {
+    return Math.max(0, Math.min(100, Math.round(score * 100)));
+  }
+
+  return Math.max(0, Math.min(100, Math.round(score)));
+}
+
+export function normalizePhraseTranslationMemorySearchMatches(
+  matches: PhraseTmsSearchSegmentResult[],
+  input: {
+    targetLocale: string;
+    memoryIdByExternalUid: Map<string, string>;
+    rankOffset?: number;
+  },
+): StringTranslationContextSnapshot["translationMemoryMatches"] {
+  const normalized: StringTranslationContextSnapshot["translationMemoryMatches"] = [];
+  let index = input.rankOffset ?? 0;
+
+  for (const match of matches) {
+    if (input.targetLocale && match.targetLocale && match.targetLocale !== input.targetLocale) {
+      continue;
+    }
+
+    const externalMemoryUid = match.transMemoryUid;
+    if (!externalMemoryUid) {
+      continue;
+    }
+
+    const memoryId = input.memoryIdByExternalUid.get(externalMemoryUid);
+    if (!memoryId) {
+      continue;
+    }
+
+    normalized.push({
+      id: `phrase:tm:${externalMemoryUid}:${match.segmentId ?? index}:${input.targetLocale}`,
+      memoryId,
+      memoryName: match.transMemoryName ?? externalMemoryUid,
+      sourceText: match.sourceText,
+      targetText: match.targetText,
+      targetLocale: input.targetLocale,
+      provenance: "phrase_tm_search",
+      matchScore: normalizePhraseMatchScore(match.score),
+      rank: Math.max(1, 100 - index),
+      matchSource: "live_provider",
+      providerKind: "phrase",
+      resourceId: memoryId,
+      externalResourceId: externalMemoryUid,
+    });
+    index += 1;
+  }
+
+  return normalized;
+}
+
+export function normalizePhraseTermBaseSearchMatches(
+  matches: PhraseTmsTermBaseSearchResult[],
+  input: { targetLocale: string; rankOffset?: number },
+): StringTranslationContextSnapshot["glossaryTerms"] {
+  const normalized: StringTranslationContextSnapshot["glossaryTerms"] = [];
+  let index = input.rankOffset ?? 0;
+
+  for (const match of matches) {
+    if (input.targetLocale && match.targetLocale && match.targetLocale !== input.targetLocale) {
+      continue;
+    }
+
+    const termBaseUid = match.termBaseUid;
+    if (!termBaseUid) {
+      continue;
+    }
+
+    normalized.push({
+      id: `phrase:term-base:${termBaseUid}:${match.sourceTerm}:${input.targetLocale}`,
+      glossaryId: `phrase:${termBaseUid}`,
+      glossaryName: match.termBaseName ?? termBaseUid,
+      sourceTerm: match.sourceTerm,
+      targetTerm: match.targetTerm,
+      targetLocale: input.targetLocale,
+      description: match.description,
+      forbidden: match.forbidden,
+      rank: Math.max(1, 100 - index),
+    });
+    index += 1;
+  }
+
+  return normalized;
+}
+
+export function mergeTranslationContextMatches<T extends { id: string; rank: number }>(
+  primary: T[],
+  supplemental: T[],
+  limit: number,
+): T[] {
+  const seen = new Set<string>();
+  const merged: T[] = [];
+
+  for (const item of [...primary, ...supplemental]) {
+    if (seen.has(item.id) || merged.length >= limit) {
+      continue;
+    }
+    seen.add(item.id);
+    merged.push(item);
+  }
+
+  return merged.sort((left, right) => right.rank - left.rank);
+}

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-glossary-fetcher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-glossary-fetcher.ts
@@ -1,0 +1,72 @@
+import type { ExternalTmsGlossaryFetcher } from "@/lib/providers/external-tms-glossary-sync";
+
+import { resolvePhraseTmsProjectUid } from "./phrase-job-context";
+import { PhraseTmsApiClient, PhraseTmsApiError } from "./phrase-tms-api";
+
+export const fetchPhraseGlossaries: ExternalTmsGlossaryFetcher = async ({
+  credential,
+  secretMaterial,
+  externalProjectId,
+  project,
+}) => {
+  const tmsProjectUid = resolvePhraseTmsProjectUid(project, externalProjectId);
+  if (!tmsProjectUid) {
+    throw new Error("invalid_phrase_tms_project_id");
+  }
+
+  const client = new PhraseTmsApiClient({
+    token: secretMaterial,
+    baseUrl: credential.baseUrl,
+  });
+
+  let termBases;
+  try {
+    termBases = await client.getProjectTermBases(tmsProjectUid);
+  } catch (error) {
+    if (error instanceof PhraseTmsApiError && error.status === 401) {
+      throw new Error("phrase_auth_invalid");
+    }
+    throw error;
+  }
+
+  const sourceLocale = project.sourceLocale ?? "en";
+  const targetLocales = project.targetLocales ?? [];
+  const glossaryTargetLocales =
+    targetLocales.length > 0 ? uniqueLocales(targetLocales) : [sourceLocale];
+
+  return termBases.flatMap((termBase) =>
+    glossaryTargetLocales.map((targetLocale) => ({
+      externalGlossaryId: termBase.uid,
+      name: termBase.name || termBase.uid,
+      description: "",
+      sourceLocale,
+      targetLocale,
+      externalResourceType: "term_base" as const,
+      localeCoverage: uniqueLocales([sourceLocale, targetLocale]),
+      termCount: null,
+      termCapabilities: { mode: "live_search" },
+      metadata: {
+        phraseTermBaseUid: termBase.uid,
+        phraseTmsProjectUid: tmsProjectUid,
+        phraseTermBaseId: termBase.id,
+      },
+      terms: [],
+    })),
+  );
+};
+
+function uniqueLocales(locales: string[]): string[] {
+  const seen = new Set<string>();
+  const unique: string[] = [];
+
+  for (const locale of locales) {
+    const trimmed = locale.trim();
+    if (!trimmed || seen.has(trimmed)) {
+      continue;
+    }
+    seen.add(trimmed);
+    unique.push(trimmed);
+  }
+
+  return unique;
+}

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-tm-matcher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-tm-matcher.ts
@@ -1,0 +1,83 @@
+import type { ExternalTmsTranslationMemoryMatcher } from "@/lib/providers/provider-translation-memory-matchers";
+import { normalizeProviderTranslationMemoryMatch } from "@/lib/translation/translation-memory-match";
+
+import { resolvePhraseTmsProjectUid } from "./phrase-job-context";
+import {
+  normalizePhraseMatchScore,
+  normalizePhraseTranslationMemorySearchMatches,
+} from "./normalize-phrase-context-matches";
+import { PhraseTmsApiClient, PhraseTmsApiError } from "./phrase-tms-api";
+
+export const searchPhraseTranslationMemoryMatches: ExternalTmsTranslationMemoryMatcher = async ({
+  secretMaterial,
+  externalProjectId,
+  project,
+  memory,
+  sourceLocale,
+  targetLocale,
+  sourceText,
+  limit,
+  externalJobUid,
+  credential,
+}) => {
+  const jobUid = externalJobUid?.trim();
+  if (!jobUid || !project) {
+    return [];
+  }
+
+  const tmsProjectUid = resolvePhraseTmsProjectUid(project, externalProjectId);
+  if (!tmsProjectUid) {
+    return [];
+  }
+
+  const client = new PhraseTmsApiClient({
+    token: secretMaterial,
+    baseUrl: credential.baseUrl,
+  });
+
+  let results;
+  try {
+    results = await client.searchJobTranslationMemorySegment({
+      projectUid: tmsProjectUid,
+      jobUid,
+      segment: sourceText,
+      maxSegments: Math.min(limit, 5),
+    });
+  } catch (error) {
+    if (error instanceof PhraseTmsApiError && error.status === 401) {
+      throw new Error("phrase_auth_invalid");
+    }
+    return [];
+  }
+
+  const externalMemoryId = memory.externalMemoryId;
+  const filtered = externalMemoryId
+    ? results.filter((result) => result.transMemoryUid === externalMemoryId)
+    : results;
+
+  const memoryIdByExternalUid = new Map<string, string>();
+  if (externalMemoryId) {
+    memoryIdByExternalUid.set(externalMemoryId, memory.id);
+  }
+
+  const normalized = normalizePhraseTranslationMemorySearchMatches(filtered, {
+    targetLocale,
+    memoryIdByExternalUid,
+  });
+
+  return normalized.slice(0, limit).map((match, index) =>
+    normalizeProviderTranslationMemoryMatch({
+      sourceText: match.sourceText,
+      targetText: match.targetText,
+      sourceLocale,
+      targetLocale,
+      matchScore: normalizePhraseMatchScore(match.matchScore),
+      providerKind: "phrase",
+      resourceId: memory.id,
+      externalResourceId: match.externalResourceId,
+      externalSegmentId: match.id,
+      memoryName: memory.name,
+      rank: 1 - index * 0.01,
+    }),
+  );
+};

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-tms-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-tms-api.ts
@@ -40,6 +40,26 @@ export interface PhraseTmsResourceReference {
   id: string | null;
 }
 
+export interface PhraseTmsSearchSegmentResult {
+  score: number | null;
+  segmentId: string | null;
+  sourceText: string;
+  targetText: string;
+  targetLocale: string | null;
+  transMemoryUid: string | null;
+  transMemoryName: string | null;
+}
+
+export interface PhraseTmsTermBaseSearchResult {
+  termBaseUid: string | null;
+  termBaseName: string | null;
+  sourceTerm: string;
+  targetTerm: string;
+  targetLocale: string | null;
+  description: string | null;
+  forbidden: boolean | null;
+}
+
 export class PhraseTmsApiError extends Error {
   constructor(
     message: string,
@@ -130,6 +150,34 @@ export class PhraseTmsApiClient {
     return normalizePhraseTmsResourceList(response.termBases);
   }
 
+  async searchJobTranslationMemorySegment(input: {
+    projectUid: string;
+    jobUid: string;
+    segment: string;
+    maxSegments?: number;
+    scoreThreshold?: number;
+  }): Promise<PhraseTmsSearchSegmentResult[]> {
+    const path = `/api2/v1/projects/${encodeURIComponent(input.projectUid)}/jobs/${encodeURIComponent(input.jobUid)}/transMemories/searchSegment`;
+    const response = await this.post<PhraseTmsSearchSegmentResponseApiRecord>(path, {
+      segment: input.segment,
+      maxSegments: input.maxSegments ?? 5,
+      scoreThreshold: input.scoreThreshold ?? 0.5,
+    });
+    return normalizePhraseTmsSearchSegmentResults(response.searchResults);
+  }
+
+  async searchJobTermBasesInText(input: {
+    projectUid: string;
+    jobUid: string;
+    text: string;
+  }): Promise<PhraseTmsTermBaseSearchResult[]> {
+    const path = `/api2/v1/projects/${encodeURIComponent(input.projectUid)}/jobs/${encodeURIComponent(input.jobUid)}/termBases/searchInTextByJob`;
+    const response = await this.post<PhraseTmsTermBaseSearchResponseApiRecord>(path, {
+      text: input.text,
+    });
+    return normalizePhraseTmsTermBaseSearchResults(response.terms);
+  }
+
   private buildPath(
     path: string,
     query: Record<string, string | number | null | undefined>,
@@ -158,6 +206,17 @@ export class PhraseTmsApiClient {
     return this.request<T>(path, {
       method: "GET",
       headers: this.authHeaders(),
+    });
+  }
+
+  private async post<T>(path: string, body: Record<string, unknown>): Promise<T> {
+    return this.request<T>(path, {
+      method: "POST",
+      headers: {
+        ...this.authHeaders(),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
     });
   }
 
@@ -243,6 +302,101 @@ type PhraseTmsResourceApiRecord = {
   name?: string;
   id?: string | number | null;
 };
+
+type PhraseTmsSearchSegmentResponseApiRecord = {
+  searchResults?: PhraseTmsSearchSegmentApiRecord[];
+};
+
+type PhraseTmsSearchSegmentApiRecord = {
+  score?: number;
+  segmentId?: string;
+  source?: { text?: string; lang?: string };
+  translations?: Array<{ text?: string; lang?: string }>;
+  transMemory?: { uid?: string; name?: string };
+};
+
+type PhraseTmsTermBaseSearchResponseApiRecord = {
+  terms?: PhraseTmsTermBaseSearchApiRecord[];
+};
+
+type PhraseTmsTermBaseSearchApiRecord = {
+  termBase?: { uid?: string; name?: string };
+  sourceTerm?: { text?: string };
+  targetTerms?: Array<{ text?: string; lang?: string; forbidden?: boolean }>;
+  description?: string;
+};
+
+function normalizePhraseTmsSearchSegmentResults(
+  results: PhraseTmsSearchSegmentApiRecord[] | undefined,
+): PhraseTmsSearchSegmentResult[] {
+  if (!results?.length) {
+    return [];
+  }
+
+  const normalized: PhraseTmsSearchSegmentResult[] = [];
+
+  for (const result of results) {
+    const sourceText = result.source?.text?.trim() ?? "";
+    if (!sourceText) {
+      continue;
+    }
+
+    const targetTranslation =
+      result.translations?.find((translation) => translation.text?.trim()) ?? null;
+    const targetText = targetTranslation?.text?.trim() ?? "";
+    if (!targetText) {
+      continue;
+    }
+
+    normalized.push({
+      score: result.score ?? null,
+      segmentId: result.segmentId?.trim() || null,
+      sourceText,
+      targetText,
+      targetLocale: targetTranslation?.lang?.trim() || null,
+      transMemoryUid: result.transMemory?.uid?.trim() || null,
+      transMemoryName: result.transMemory?.name?.trim() || null,
+    });
+  }
+
+  return normalized;
+}
+
+function normalizePhraseTmsTermBaseSearchResults(
+  terms: PhraseTmsTermBaseSearchApiRecord[] | undefined,
+): PhraseTmsTermBaseSearchResult[] {
+  if (!terms?.length) {
+    return [];
+  }
+
+  const normalized: PhraseTmsTermBaseSearchResult[] = [];
+
+  for (const term of terms) {
+    const sourceTerm = term.sourceTerm?.text?.trim() ?? "";
+    if (!sourceTerm) {
+      continue;
+    }
+
+    const targetTermRecord =
+      term.targetTerms?.find((target) => target.text?.trim()) ?? term.targetTerms?.[0];
+    const targetTerm = targetTermRecord?.text?.trim() ?? "";
+    if (!targetTerm) {
+      continue;
+    }
+
+    normalized.push({
+      termBaseUid: term.termBase?.uid?.trim() || null,
+      termBaseName: term.termBase?.name?.trim() || null,
+      sourceTerm,
+      targetTerm,
+      targetLocale: targetTermRecord?.lang?.trim() || null,
+      description: term.description?.trim() || null,
+      forbidden: targetTermRecord?.forbidden ?? null,
+    });
+  }
+
+  return normalized;
+}
 
 function normalizePhraseTmsJobPart(job: PhraseTmsJobPartApiRecord): PhraseTmsJobPart {
   return {

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-translation-memory-fetcher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-translation-memory-fetcher.ts
@@ -1,0 +1,65 @@
+import type { ExternalTmsTranslationMemoryFetcher } from "@/lib/providers/external-tms-tm-sync";
+
+import { resolvePhraseTmsProjectUid } from "./phrase-job-context";
+import { PhraseTmsApiClient, PhraseTmsApiError } from "./phrase-tms-api";
+
+export const fetchPhraseTranslationMemories: ExternalTmsTranslationMemoryFetcher = async ({
+  credential,
+  secretMaterial,
+  externalProjectId,
+  project,
+}) => {
+  const tmsProjectUid = resolvePhraseTmsProjectUid(project, externalProjectId);
+  if (!tmsProjectUid) {
+    throw new Error("invalid_phrase_tms_project_id");
+  }
+
+  const client = new PhraseTmsApiClient({
+    token: secretMaterial,
+    baseUrl: credential.baseUrl,
+  });
+
+  let memories;
+  try {
+    memories = await client.getProjectTranslationMemories({ projectUid: tmsProjectUid });
+  } catch (error) {
+    if (error instanceof PhraseTmsApiError && error.status === 401) {
+      throw new Error("phrase_auth_invalid");
+    }
+    throw error;
+  }
+
+  const sourceLocale = project.sourceLocale ?? "en";
+  const targetLocales = project.targetLocales ?? [];
+
+  return memories.map((memory) => ({
+    externalMemoryId: memory.uid,
+    name: memory.name || memory.uid,
+    description: "",
+    sourceLocale,
+    localeCoverage: uniqueLocales([sourceLocale, ...targetLocales]),
+    segmentCount: null,
+    metadata: {
+      phraseTransMemoryUid: memory.uid,
+      phraseTmsProjectUid: tmsProjectUid,
+      phraseTransMemoryId: memory.id,
+    },
+    entries: [],
+  }));
+};
+
+function uniqueLocales(locales: string[]): string[] {
+  const seen = new Set<string>();
+  const unique: string[] = [];
+
+  for (const locale of locales) {
+    const trimmed = locale.trim();
+    if (!trimmed || seen.has(trimmed)) {
+      continue;
+    }
+    seen.add(trimmed);
+    unique.push(trimmed);
+  }
+
+  return unique;
+}

--- a/apps/hyperlocalise-web/src/lib/providers/provider-agent-translate.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-agent-translate.ts
@@ -157,6 +157,7 @@ async function translateProviderUnits(input: {
       {
         organizationId: input.organizationId,
         providerKind: input.providerKind as ExternalTmsProviderKind,
+        externalJobUid: input.content.externalTaskId,
       },
     );
     if (!contextSnapshot.ok) {

--- a/apps/hyperlocalise-web/src/lib/providers/provider-translation-memory-matchers.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-translation-memory-matchers.ts
@@ -1,5 +1,6 @@
 import type { ExternalTmsProviderKind } from "@/lib/providers/organization-external-tms-provider-credentials";
 import { searchCrowdinTranslationMemoryMatches } from "@/lib/providers/crowdin/crowdin-tm-matcher";
+import { searchPhraseTranslationMemoryMatches } from "@/lib/providers/phrase/phrase-tm-matcher";
 import type { NormalizedTranslationMemoryMatch } from "@/lib/translation/translation-memory-match";
 
 type ExternalTmsCredential =
@@ -22,6 +23,11 @@ export type ExternalTmsTranslationMemoryMatcherInput = {
   targetLocale: string;
   sourceText: string;
   limit: number;
+  externalJobUid?: string | null;
+  project?: {
+    providerMetadata: Record<string, unknown>;
+    externalProjectId: string | null;
+  };
 };
 
 export type ExternalTmsTranslationMemoryMatcher = (
@@ -34,6 +40,8 @@ export function getProviderTranslationMemoryMatcher(
   switch (providerKind) {
     case "crowdin":
       return searchCrowdinTranslationMemoryMatches;
+    case "phrase":
+      return searchPhraseTranslationMemoryMatches;
     default:
       return null;
   }

--- a/apps/hyperlocalise-web/src/lib/translation/assemble-translation-context.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/assemble-translation-context.ts
@@ -3,6 +3,8 @@ import { and, desc, eq, inArray, sql } from "drizzle-orm";
 import type { StringTranslationJobInput } from "@/api/routes/project/job.schema";
 import { db, schema } from "@/lib/database";
 import type { ExternalTmsProviderKind } from "@/lib/providers/organization-external-tms-provider-credentials";
+import { loadPhraseTranslationContextMatches } from "@/lib/providers/phrase/load-phrase-translation-context-matches";
+import { mergeTranslationContextMatches } from "@/lib/providers/phrase/normalize-phrase-context-matches";
 import { loadTranslationMemoryMatchesForContext } from "@/lib/translation/load-translation-memory-matches";
 import {
   toContextTranslationMemoryMatch,
@@ -50,12 +52,31 @@ export type TranslationContextProject = {
   translationContext: string;
 };
 
-async function loadProjectForContext(projectId: string): Promise<TranslationContextProject | null> {
+export type TranslationContextProjectRecord = TranslationContextProject &
+  Pick<
+    typeof schema.projects.$inferSelect,
+    | "organizationId"
+    | "source"
+    | "externalProviderKind"
+    | "externalProjectId"
+    | "externalProviderCredentialId"
+    | "providerMetadata"
+  >;
+
+async function loadProjectForContext(
+  projectId: string,
+): Promise<TranslationContextProjectRecord | null> {
   const [project] = await db
     .select({
       id: schema.projects.id,
       name: schema.projects.name,
       translationContext: schema.projects.translationContext,
+      organizationId: schema.projects.organizationId,
+      source: schema.projects.source,
+      externalProviderKind: schema.projects.externalProviderKind,
+      externalProjectId: schema.projects.externalProjectId,
+      externalProviderCredentialId: schema.projects.externalProviderCredentialId,
+      providerMetadata: schema.projects.providerMetadata,
     })
     .from(schema.projects)
     .where(eq(schema.projects.id, projectId))
@@ -120,10 +141,11 @@ export async function loadTranslationContextProject(projectId: string) {
 export async function assembleStringTranslationContextSnapshot(
   projectId: string,
   jobInput: StringTranslationJobInput,
-  projectOverride?: TranslationContextProject | null,
+  projectOverride?: TranslationContextProjectRecord | null,
   options?: {
     organizationId?: string;
     providerKind?: ExternalTmsProviderKind;
+    externalJobUid?: string | null;
   },
 ) {
   const project =
@@ -136,7 +158,9 @@ export async function assembleStringTranslationContextSnapshot(
     } as const;
   }
 
-  const [glossaryTerms, translationMemoryMatches] = await Promise.all([
+  const providerKind = options?.providerKind ?? project.externalProviderKind ?? undefined;
+
+  const [glossaryTerms, translationMemoryMatches, phraseLiveMatches] = await Promise.all([
     loadGlossaryTermsForContext({
       projectId,
       sourceLocale: jobInput.sourceLocale,
@@ -146,21 +170,47 @@ export async function assembleStringTranslationContextSnapshot(
     loadTranslationMemoryMatchesForContext({
       projectId,
       organizationId: options?.organizationId,
-      providerKind: options?.providerKind,
+      providerKind,
+      externalJobUid: options?.externalJobUid,
       sourceLocale: jobInput.sourceLocale,
       targetLocales: jobInput.targetLocales,
       sourceText: jobInput.sourceText,
     }).then((matches) => matches.map(toContextTranslationMemoryMatch)),
+    providerKind === "phrase"
+      ? loadPhraseTranslationContextMatches({
+          project,
+          externalJobUid: options?.externalJobUid,
+          sourceLocale: jobInput.sourceLocale,
+          targetLocales: jobInput.targetLocales,
+          sourceText: jobInput.sourceText,
+        })
+      : Promise.resolve({ glossaryTerms: [], translationMemoryMatches: [] }),
   ]);
+
+  const mergedGlossaryTerms = mergeTranslationContextMatches(
+    glossaryTerms,
+    phraseLiveMatches.glossaryTerms,
+    20,
+  );
+
+  const mergedTranslationMemoryMatches = mergeTranslationContextMatches(
+    translationMemoryMatches,
+    phraseLiveMatches.translationMemoryMatches,
+    10,
+  );
 
   return {
     ok: true,
     snapshot: {
       assembledAt: new Date().toISOString(),
-      project,
+      project: {
+        id: project.id,
+        name: project.name,
+        translationContext: project.translationContext,
+      },
       job: jobInput,
-      glossaryTerms,
-      translationMemoryMatches,
+      glossaryTerms: mergedGlossaryTerms,
+      translationMemoryMatches: mergedTranslationMemoryMatches,
     } satisfies StringTranslationContextSnapshot,
   } as const;
 }

--- a/apps/hyperlocalise-web/src/lib/translation/assemble-translation-context.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/assemble-translation-context.ts
@@ -160,7 +160,7 @@ export async function assembleStringTranslationContextSnapshot(
 
   const providerKind = options?.providerKind ?? project.externalProviderKind ?? undefined;
 
-  const [glossaryTerms, translationMemoryMatches, phraseLiveMatches] = await Promise.all([
+  const [glossaryTerms, translationMemoryMatches, phraseLiveGlossaryTerms] = await Promise.all([
     loadGlossaryTermsForContext({
       projectId,
       sourceLocale: jobInput.sourceLocale,
@@ -183,20 +183,14 @@ export async function assembleStringTranslationContextSnapshot(
           sourceLocale: jobInput.sourceLocale,
           targetLocales: jobInput.targetLocales,
           sourceText: jobInput.sourceText,
-        })
-      : Promise.resolve({ glossaryTerms: [], translationMemoryMatches: [] }),
+        }).then((result) => result.glossaryTerms)
+      : Promise.resolve([]),
   ]);
 
   const mergedGlossaryTerms = mergeTranslationContextMatches(
     glossaryTerms,
-    phraseLiveMatches.glossaryTerms,
+    phraseLiveGlossaryTerms,
     20,
-  );
-
-  const mergedTranslationMemoryMatches = mergeTranslationContextMatches(
-    translationMemoryMatches,
-    phraseLiveMatches.translationMemoryMatches,
-    10,
   );
 
   return {
@@ -210,7 +204,7 @@ export async function assembleStringTranslationContextSnapshot(
       },
       job: jobInput,
       glossaryTerms: mergedGlossaryTerms,
-      translationMemoryMatches: mergedTranslationMemoryMatches,
+      translationMemoryMatches,
     } satisfies StringTranslationContextSnapshot,
   } as const;
 }

--- a/apps/hyperlocalise-web/src/lib/translation/load-translation-memory-matches.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/load-translation-memory-matches.ts
@@ -59,6 +59,7 @@ async function loadExternalTmsProject(input: {
       externalProjectId: schema.projects.externalProjectId,
       externalProviderCredentialId: schema.projects.externalProviderCredentialId,
       externalProviderKind: schema.projects.externalProviderKind,
+      providerMetadata: schema.projects.providerMetadata,
     })
     .from(schema.projects)
     .where(
@@ -106,6 +107,8 @@ async function searchLiveProviderMatches(input: {
   targetLocales: string[];
   sourceText: string;
   limit: number;
+  externalJobUid?: string | null;
+  projectMetadata?: Record<string, unknown>;
 }): Promise<NormalizedTranslationMemoryMatch[]> {
   const matcher = getProviderTranslationMemoryMatcher(input.providerKind);
   if (!matcher) {
@@ -158,6 +161,13 @@ async function searchLiveProviderMatches(input: {
         targetLocale,
         sourceText: input.sourceText,
         limit: input.limit,
+        externalJobUid: input.externalJobUid,
+        project: input.projectMetadata
+          ? {
+              providerMetadata: input.projectMetadata,
+              externalProjectId: input.externalProjectId,
+            }
+          : undefined,
       });
 
       liveMatches.push(...matches.filter((match) => match.targetLocale === targetLocale));
@@ -184,6 +194,7 @@ export async function loadTranslationMemoryMatchesForContext(input: {
   projectId: string;
   organizationId?: string;
   providerKind?: ExternalTmsProviderKind;
+  externalJobUid?: string | null;
   sourceLocale: string;
   targetLocales: string[];
   sourceText: string;
@@ -251,6 +262,14 @@ export async function loadTranslationMemoryMatchesForContext(input: {
 
   let liveMatches: NormalizedTranslationMemoryMatch[] = [];
   try {
+    const projectRecord =
+      project ??
+      (await loadExternalTmsProject({
+        organizationId,
+        projectId: input.projectId,
+        providerKind,
+      }));
+
     liveMatches = await searchLiveProviderMatches({
       organizationId,
       projectId: input.projectId,
@@ -263,6 +282,8 @@ export async function loadTranslationMemoryMatchesForContext(input: {
       targetLocales: input.targetLocales,
       sourceText: input.sourceText,
       limit,
+      externalJobUid: input.externalJobUid,
+      projectMetadata: projectRecord?.providerMetadata ?? undefined,
     });
   } catch (error) {
     logger.error(

--- a/apps/hyperlocalise-web/src/lib/translation/load-translation-memory-matches.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/load-translation-memory-matches.ts
@@ -262,13 +262,7 @@ export async function loadTranslationMemoryMatchesForContext(input: {
 
   let liveMatches: NormalizedTranslationMemoryMatch[] = [];
   try {
-    const projectRecord =
-      project ??
-      (await loadExternalTmsProject({
-        organizationId,
-        projectId: input.projectId,
-        providerKind,
-      }));
+    const projectRecord = project;
 
     liveMatches = await searchLiveProviderMatches({
       organizationId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements HL-352 by bridging Phrase translation memory and term-base APIs into Hyperlocalise's synced TM/glossary models and agent translation context.

## Changes

- **Sync**: `POST /projects/:projectId/sync-translation-memories` and `POST /projects/:projectId/sync-glossaries` for Phrase projects, persisting TM/term-base metadata with `live_search` capability (no bulk segment import).
- **Live search**: Job-scoped Phrase TM segment search and term-base text search via `PhraseTmsApiClient`, normalized into agent context glossary/TM match shapes.
- **Agent translate**: Provider agent translation passes `externalJobUid` and merges Phrase live matches with DB-backed glossary/TM context.
- **Tests**: Score normalization, missing-resource graceful behavior, and match mapping.

## Acceptance criteria

- [x] TM and Glossaries pages can show Phrase resources from the database (via sync routes + existing list APIs)
- [x] Agent translation/review can receive Phrase TM matches (live job search + matcher registry)
- [x] Agent translation/review can receive Phrase term-base matches (live job search merged into context)
- [x] Tests cover score normalization and missing-resource behavior

## Testing

- `pnpm exec vp check --fix` — pass
- `pnpm exec vp test src/lib/providers/phrase/normalize-phrase-context-matches.test.ts src/lib/providers/phrase/load-phrase-translation-context-matches.test.ts` — pass (13 tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-352](https://linear.app/hyperlocalise/issue/HL-352/sync-and-search-phrase-tm-and-term-base-resources)

<div><a href="https://cursor.com/agents/bc-f9956a7d-821c-4016-b6cc-4e8eba7df66d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9956a7d-821c-4016-b6cc-4e8eba7df66d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

