### PR TITLE
feat(lokalise): implement task content pull and translation write-back

### DIFF
--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-api.test.ts
@@ -4,6 +4,7 @@ import {
   buildLokaliseProjectUrl,
   buildLokaliseTaskUrl,
   collectLokaliseTaskAssignees,
+  collectLokaliseTaskKeyIds,
   collectLokaliseTaskTargetLocales,
   extractLokaliseKeyName,
   getLokaliseTaskCompletionMs,
@@ -14,6 +15,7 @@ import {
   LokaliseApiError,
   parseLokaliseTaskDueDate,
   partitionLokaliseLocales,
+  summarizeLokaliseBulkUpdateChunkResult,
 } from "./lokalise-api";
 
 describe("LokaliseApiClient", () => {
@@ -305,6 +307,31 @@ describe("LokaliseApiClient", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it("preserves per-language key ids from detailed task responses", async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          task: {
+            task_id: 42,
+            title: "Homepage",
+            status: "in_progress",
+            languages: [
+              { language_iso: "fr", keys: [100, 200] },
+              { language_iso: "de", keys: [200, 300] },
+            ],
+          },
+        }),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    const task = await client.getTask("proj.123", 42);
+
+    expect(collectLokaliseTaskKeyIds(task).sort((a, b) => a - b)).toEqual([100, 200, 300]);
+    expect(task.languages[0]?.keyIds).toEqual([100, 200]);
+  });
+
   it("throws LokaliseApiError on auth failure", async () => {
     const fetchMock = vi.fn(async () => {
       return new Response(JSON.stringify({ error: { message: "Invalid token" } }), {
@@ -316,6 +343,33 @@ describe("LokaliseApiClient", () => {
 
     await expect(client.listProjects()).rejects.toBeInstanceOf(LokaliseApiError);
     await expect(client.listProjects()).rejects.toMatchObject({ status: 401 });
+  });
+});
+
+describe("summarizeLokaliseBulkUpdateChunkResult", () => {
+  it("counts only successful keys when the bulk response reports per-key errors", () => {
+    const chunk = [
+      {
+        keyId: 4242,
+        translations: [{ languageIso: "fr", translation: "Bonjour" }],
+      },
+      {
+        keyId: 9999,
+        translations: [{ languageIso: "fr", translation: "Échec" }],
+      },
+    ];
+
+    const result = summarizeLokaliseBulkUpdateChunkResult(chunk, {
+      keys: [{ key_id: 4242 }],
+      errors: [{ message: "Key not found", key: { key_id: 9999 } }],
+    });
+
+    expect(result).toMatchObject({
+      uploaded: 1,
+      failed: 1,
+      failedKeyCount: 1,
+      failures: [{ locale: "fr", message: "Key not found" }],
+    });
   });
 });
 

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-api.ts
@@ -299,9 +299,15 @@ export class LokaliseApiClient {
     return normalizeLokaliseDetailedTask(response.task);
   }
 
-  async bulkUpdateKeys(projectId: string, keys: LokaliseBulkUpdateKey[]) {
+  async bulkUpdateKeys(
+    projectId: string,
+    keys: LokaliseBulkUpdateKey[],
+  ): Promise<LokaliseBulkUpdateKeysResponse> {
     if (keys.length === 0) {
-      return { keys: [] as LokaliseKey[], errors: {} as Record<string, unknown> };
+      return {
+        keys: [] as LokaliseKeyApiRecord[],
+        errors: [] as LokaliseBulkUpdateKeyErrorRecord[],
+      };
     }
 
     const body = {
@@ -481,10 +487,17 @@ type LokaliseDetailedTaskLanguageApiRecord = LokaliseTaskLanguageApiRecord & {
   keys?: number[];
 };
 
+type LokaliseBulkUpdateKeyErrorRecord = {
+  message?: string;
+  code?: number | string;
+  key?: { key_id?: number; key_name?: unknown };
+  key_id?: number;
+};
+
 type LokaliseBulkUpdateKeysResponse = {
   project_id?: string;
   keys?: LokaliseKeyApiRecord[];
-  errors?: Record<string, unknown>;
+  errors?: LokaliseBulkUpdateKeyErrorRecord[] | Record<string, unknown>;
 };
 
 type LokaliseFileDownloadResponse = {
@@ -596,7 +609,7 @@ function normalizeLokaliseDetailedTask(
   const task = normalizeLokaliseTask(record);
   return {
     ...task,
-    languages: (record.languages ?? task.languages).map(normalizeLokaliseDetailedTaskLanguage),
+    languages: (record.languages ?? []).map(normalizeLokaliseDetailedTaskLanguage),
   };
 }
 
@@ -853,6 +866,120 @@ export function collectLokaliseTaskKeyIds(task: Pick<LokaliseDetailedTask, "lang
     }
   }
   return [...keyIds];
+}
+
+export function summarizeLokaliseBulkUpdateChunkResult(
+  chunk: LokaliseBulkUpdateKey[],
+  response: {
+    keys?: Array<{ key_id?: number }>;
+    errors?: LokaliseBulkUpdateKeysResponse["errors"];
+  },
+): {
+  uploaded: number;
+  failed: number;
+  failedKeyCount: number;
+  failures: Array<{ locale: string; fileId: string | null; message: string }>;
+} {
+  const failedKeyIds = collectLokaliseBulkUpdateFailedKeyIds({
+    requestedKeyIds: chunk.map((batch) => batch.keyId),
+    responseKeys: response.keys,
+    errors: response.errors,
+  });
+  const errorMessageByKeyId = buildLokaliseBulkUpdateErrorMessages(response.errors);
+
+  let uploaded = 0;
+  let failed = 0;
+  let failedKeyCount = 0;
+  const failures: Array<{ locale: string; fileId: string | null; message: string }> = [];
+
+  for (const batch of chunk) {
+    if (!failedKeyIds.has(batch.keyId)) {
+      uploaded += batch.translations.length;
+      continue;
+    }
+
+    failedKeyCount += 1;
+    const message = errorMessageByKeyId.get(batch.keyId) ?? "lokalise_bulk_update_key_failed";
+    failed += batch.translations.length;
+    for (const translation of batch.translations) {
+      failures.push({
+        locale: translation.languageIso,
+        fileId: null,
+        message,
+      });
+    }
+  }
+
+  return { uploaded, failed, failedKeyCount, failures };
+}
+
+function collectLokaliseBulkUpdateFailedKeyIds(input: {
+  requestedKeyIds: number[];
+  responseKeys?: Array<{ key_id?: number }>;
+  errors?: LokaliseBulkUpdateKeysResponse["errors"];
+}) {
+  const failed = new Set<number>();
+
+  for (const entry of listLokaliseBulkUpdateErrors(input.errors)) {
+    const keyId = extractLokaliseBulkUpdateErrorKeyId(entry);
+    if (keyId != null) {
+      failed.add(keyId);
+    }
+  }
+
+  const updatedKeyIds = new Set(
+    (input.responseKeys ?? [])
+      .map((key) => key.key_id)
+      .filter((keyId): keyId is number => typeof keyId === "number" && Number.isFinite(keyId)),
+  );
+
+  const errorEntries = listLokaliseBulkUpdateErrors(input.errors);
+  const shouldInferMissingKeysAsFailed = errorEntries.length > 0 || input.responseKeys != null;
+
+  if (shouldInferMissingKeysAsFailed) {
+    for (const keyId of input.requestedKeyIds) {
+      if (!updatedKeyIds.has(keyId)) {
+        failed.add(keyId);
+      }
+    }
+  }
+
+  return failed;
+}
+
+function buildLokaliseBulkUpdateErrorMessages(errors: LokaliseBulkUpdateKeysResponse["errors"]) {
+  const messages = new Map<number, string>();
+  for (const entry of listLokaliseBulkUpdateErrors(errors)) {
+    const keyId = extractLokaliseBulkUpdateErrorKeyId(entry);
+    const message = entry.message?.trim();
+    if (keyId != null && message) {
+      messages.set(keyId, message);
+    }
+  }
+  return messages;
+}
+
+function listLokaliseBulkUpdateErrors(
+  errors: LokaliseBulkUpdateKeysResponse["errors"],
+): LokaliseBulkUpdateKeyErrorRecord[] {
+  if (!errors) {
+    return [];
+  }
+  if (Array.isArray(errors)) {
+    return errors;
+  }
+  return Object.values(errors).filter(
+    (entry): entry is LokaliseBulkUpdateKeyErrorRecord =>
+      entry != null && typeof entry === "object",
+  );
+}
+
+function extractLokaliseBulkUpdateErrorKeyId(entry: LokaliseBulkUpdateKeyErrorRecord) {
+  const keyId = entry.key?.key_id ?? entry.key_id;
+  if (typeof keyId !== "number" || !Number.isFinite(keyId)) {
+    return null;
+  }
+  return keyId;
 }
 
 export function parseLokaliseExternalJobId(externalJobId: string) {

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-api.ts
@@ -94,6 +94,39 @@ export interface LokaliseTask {
   completedAtTimestamp: number | null;
 }
 
+export interface LokaliseDetailedTaskLanguage extends LokaliseTaskLanguage {
+  keyIds: number[];
+}
+
+export interface LokaliseDetailedTask extends LokaliseTask {
+  languages: LokaliseDetailedTaskLanguage[];
+}
+
+export type LokaliseBulkUpdateTranslation = {
+  languageIso: string;
+  translation: string;
+  isUnverified?: boolean;
+  isReviewed?: boolean;
+};
+
+export type LokaliseBulkUpdateKey = {
+  keyId: number;
+  translations: LokaliseBulkUpdateTranslation[];
+};
+
+export type LokaliseFileDownloadRequest = {
+  format: string;
+  originalFilenames?: boolean;
+  bundleStructure?: string;
+  filterLangs?: string[];
+  filterFilenames?: string[];
+};
+
+export type LokaliseFileDownloadResult = {
+  bundleUrl: string;
+  warning: string | null;
+};
+
 export interface LokaliseKey {
   keyId: number;
   keyName: LokalisePlatformStrings;
@@ -163,12 +196,20 @@ export class LokaliseApiClient {
 
   async listKeys(
     projectId: string,
-    options?: { includeTranslations?: boolean },
+    options?: {
+      includeTranslations?: boolean;
+      filterKeyIds?: number[];
+      filterTranslationLangIds?: number[];
+    },
   ): Promise<LokaliseKey[]> {
     const keys: LokaliseKey[] = [];
     let cursor = "";
     const limit = 500;
     const includeTranslations = options?.includeTranslations ?? true;
+    const filterKeyIds = options?.filterKeyIds?.length ? options.filterKeyIds.join(",") : null;
+    const filterTranslationLangIds = options?.filterTranslationLangIds?.length
+      ? options.filterTranslationLangIds.join(",")
+      : null;
 
     while (true) {
       const params = new URLSearchParams({
@@ -178,6 +219,12 @@ export class LokaliseApiClient {
       });
       if (cursor) {
         params.set("cursor", cursor);
+      }
+      if (filterKeyIds) {
+        params.set("filter_key_ids", filterKeyIds);
+      }
+      if (filterTranslationLangIds) {
+        params.set("filter_translation_lang_ids", filterTranslationLangIds);
       }
 
       const { body, nextCursor } = await this.getWithPagination<LokaliseKeysListResponse>(
@@ -235,6 +282,87 @@ export class LokaliseApiClient {
     }
 
     return tasks;
+  }
+
+  async getTask(projectId: string, taskId: number): Promise<LokaliseDetailedTask> {
+    const response = await this.get<LokaliseTaskGetResponse>(
+      `/projects/${encodeURIComponent(projectId)}/tasks/${encodeURIComponent(String(taskId))}`,
+    );
+    if (!response.task) {
+      throw new LokaliseApiError(
+        `Lokalise task ${taskId} was not found in project ${projectId}`,
+        404,
+        response,
+      );
+    }
+
+    return normalizeLokaliseDetailedTask(response.task);
+  }
+
+  async bulkUpdateKeys(projectId: string, keys: LokaliseBulkUpdateKey[]) {
+    if (keys.length === 0) {
+      return { keys: [] as LokaliseKey[], errors: {} as Record<string, unknown> };
+    }
+
+    const body = {
+      keys: keys.map((key) => ({
+        key_id: key.keyId,
+        translations: key.translations.map((translation) => ({
+          language_iso: translation.languageIso,
+          translation: translation.translation,
+          ...(translation.isUnverified != null ? { is_unverified: translation.isUnverified } : {}),
+          ...(translation.isReviewed != null ? { is_reviewed: translation.isReviewed } : {}),
+        })),
+      })),
+    };
+
+    return this.put<LokaliseBulkUpdateKeysResponse>(
+      `/projects/${encodeURIComponent(projectId)}/keys`,
+      body,
+    );
+  }
+
+  async requestFileDownload(
+    projectId: string,
+    request: LokaliseFileDownloadRequest,
+  ): Promise<LokaliseFileDownloadResult> {
+    const response = await this.post<LokaliseFileDownloadResponse>(
+      `/projects/${encodeURIComponent(projectId)}/files/download`,
+      {
+        format: request.format,
+        original_filenames: request.originalFilenames ?? false,
+        bundle_structure: request.bundleStructure ?? LOKALISE_DEFAULT_BUNDLE_STRUCTURE,
+        ...(request.filterLangs?.length ? { filter_langs: request.filterLangs } : {}),
+        ...(request.filterFilenames?.length ? { filter_filenames: request.filterFilenames } : {}),
+      },
+    );
+
+    const bundleUrl = response.bundle_url?.trim() ?? "";
+    if (!bundleUrl) {
+      throw new LokaliseApiError(
+        `Lokalise file download for project ${projectId} did not return a bundle URL`,
+        502,
+        response,
+      );
+    }
+
+    return {
+      bundleUrl,
+      warning: response.warning?.trim() || null,
+    };
+  }
+
+  async downloadUrl(url: string): Promise<ArrayBuffer> {
+    const response = await this.fetchFn(url, { method: "GET" });
+    if (!response.ok) {
+      throw new LokaliseApiError(
+        `Failed to download Lokalise bundle from ${url}`,
+        response.status,
+        null,
+      );
+    }
+
+    return response.arrayBuffer();
   }
 
   async listProjectLanguages(projectId: string): Promise<LokaliseLanguage[]> {
@@ -305,6 +433,30 @@ export class LokaliseApiClient {
     const nextCursor = response.headers.get("X-Pagination-Next-Cursor")?.trim() || null;
     return { body, nextCursor };
   }
+
+  private async post<T>(path: string, payload: unknown): Promise<T> {
+    const { body } = await this.request<T>(path, {
+      method: "POST",
+      headers: {
+        ...this.authHeaders(),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+    return body;
+  }
+
+  private async put<T>(path: string, payload: unknown): Promise<T> {
+    const { body } = await this.request<T>(path, {
+      method: "PUT",
+      headers: {
+        ...this.authHeaders(),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+    return body;
+  }
 }
 
 type LokaliseProjectsListResponse = {
@@ -314,6 +466,31 @@ type LokaliseProjectsListResponse = {
 type LokaliseTasksListResponse = {
   project_id?: string;
   tasks?: LokaliseTaskApiRecord[];
+};
+
+type LokaliseTaskGetResponse = {
+  project_id?: string;
+  task?: LokaliseDetailedTaskApiRecord;
+};
+
+type LokaliseDetailedTaskApiRecord = LokaliseTaskApiRecord & {
+  languages?: LokaliseDetailedTaskLanguageApiRecord[];
+};
+
+type LokaliseDetailedTaskLanguageApiRecord = LokaliseTaskLanguageApiRecord & {
+  keys?: number[];
+};
+
+type LokaliseBulkUpdateKeysResponse = {
+  project_id?: string;
+  keys?: LokaliseKeyApiRecord[];
+  errors?: Record<string, unknown>;
+};
+
+type LokaliseFileDownloadResponse = {
+  project_id?: string;
+  bundle_url?: string;
+  warning?: string | null;
 };
 
 type LokaliseTaskLanguageUserApiRecord = {
@@ -412,6 +589,25 @@ type LokaliseLanguageApiRecord = {
   lang_name: string;
   is_rtl?: boolean;
 };
+
+function normalizeLokaliseDetailedTask(
+  record: LokaliseDetailedTaskApiRecord,
+): LokaliseDetailedTask {
+  const task = normalizeLokaliseTask(record);
+  return {
+    ...task,
+    languages: (record.languages ?? task.languages).map(normalizeLokaliseDetailedTaskLanguage),
+  };
+}
+
+function normalizeLokaliseDetailedTaskLanguage(
+  record: LokaliseDetailedTaskLanguageApiRecord,
+): LokaliseDetailedTaskLanguage {
+  return {
+    ...normalizeLokaliseTaskLanguage(record),
+    keyIds: record.keys ?? [],
+  };
+}
 
 function normalizeLokaliseTask(record: LokaliseTaskApiRecord): LokaliseTask {
   return {
@@ -645,6 +841,32 @@ export function collectLokaliseTaskTargetLocales(task: LokaliseTask) {
   return task.languages
     .map((language) => language.languageIso.trim())
     .filter((locale): locale is string => Boolean(locale));
+}
+
+export function collectLokaliseTaskKeyIds(task: Pick<LokaliseDetailedTask, "languages">) {
+  const keyIds = new Set<number>();
+  for (const language of task.languages) {
+    for (const keyId of language.keyIds) {
+      if (keyId > 0) {
+        keyIds.add(keyId);
+      }
+    }
+  }
+  return [...keyIds];
+}
+
+export function parseLokaliseExternalJobId(externalJobId: string) {
+  const trimmed = externalJobId.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const taskId = Number(trimmed);
+  if (!Number.isInteger(taskId) || taskId <= 0) {
+    return null;
+  }
+
+  return { taskId };
 }
 
 export function parseLokaliseTaskDueDate(task: LokaliseTask) {

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-content-puller.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-content-puller.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { pullLokaliseTaskContent } from "./lokalise-content-puller";
+
+describe("pullLokaliseTaskContent", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("pulls task-scoped keys and translations through the provider-neutral shape", async () => {
+    const fetchMock = vi.fn(async (url, init) => {
+      const path = String(url);
+
+      if (path.endsWith("/tasks/42")) {
+        return new Response(
+          JSON.stringify({
+            task: {
+              task_id: 42,
+              title: "Homepage",
+              status: "in_progress",
+              task_type: "translation",
+              source_language_iso: "en",
+              languages: [
+                {
+                  language_iso: "fr",
+                  language_id: 673,
+                  language_name: "French",
+                  keys: [4242],
+                },
+              ],
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/keys?") && init?.method !== "PUT") {
+        return new Response(
+          JSON.stringify({
+            keys: [
+              {
+                key_id: 4242,
+                key_name: { web: "hello", ios: "", android: "", other: "" },
+                filenames: { web: "locales/en/home.json", ios: "", android: "", other: "" },
+                platforms: ["web"],
+                translations: [
+                  {
+                    translation_id: 1,
+                    key_id: 4242,
+                    language_iso: "en",
+                    translation: "Hello",
+                    is_reviewed: true,
+                    is_unverified: false,
+                  },
+                  {
+                    translation_id: 2,
+                    key_id: 4242,
+                    language_iso: "fr",
+                    translation: "Bonjour",
+                    is_reviewed: true,
+                    is_unverified: false,
+                  },
+                ],
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.endsWith("/files/download") && init?.method === "POST") {
+        return new Response(
+          JSON.stringify({
+            bundle_url: "https://downloads.lokalise.test/bundle.zip",
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path === "https://downloads.lokalise.test/bundle.zip") {
+        return new Response(new Uint8Array([1, 2, 3]), { status: 200 });
+      }
+
+      return new Response(JSON.stringify({}), { status: 404 });
+    }) as unknown as typeof fetch;
+
+    globalThis.fetch = fetchMock;
+
+    const content = await pullLokaliseTaskContent({
+      organizationId: "org-1",
+      projectId: "project-1",
+      providerKind: "lokalise",
+      externalProjectId: "proj.123",
+      externalJobId: "42",
+      credential: {
+        id: "cred-1",
+        baseUrl: "https://api.lokalise.test/api2",
+      } as never,
+      project: {
+        sourceLocale: "en",
+        targetLocales: ["fr"],
+        providerMetadata: {},
+      } as never,
+      secretMaterial: "token",
+    });
+
+    expect(content).toMatchObject({
+      externalJobId: "42",
+      externalTaskId: "42",
+      sourceLocale: "en",
+      targetLocales: ["fr"],
+      units: [
+        {
+          externalStringId: "4242",
+          key: "hello",
+          sourceText: "Hello",
+          translations: [
+            {
+              locale: "fr",
+              text: "Bonjour",
+              externalTranslationId: "2",
+              isApproved: true,
+            },
+          ],
+        },
+      ],
+      exportArtifact: {
+        url: "https://downloads.lokalise.test/bundle.zip",
+        format: "json",
+        byteLength: 3,
+      },
+    });
+    const keyListRequest = vi
+      .mocked(fetchMock)
+      .mock.calls.map(([requestUrl]) => String(requestUrl))
+      .find((requestUrl) => requestUrl.includes("/keys?"));
+    expect(keyListRequest).toContain("filter_key_ids=4242");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-content-puller.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-content-puller.ts
@@ -1,0 +1,219 @@
+import type { ExternalTmsContentPuller } from "@/lib/providers/external-tms-content-sync";
+
+import {
+  collectLokaliseTaskKeyIds,
+  collectLokaliseTaskTargetLocales,
+  extractLokaliseKeyName,
+  inferFormatFromFilename,
+  listLokaliseFilenameEntries,
+  LOKALISE_DEFAULT_BASE_URL,
+  LOKALISE_DEFAULT_BUNDLE_STRUCTURE,
+  LokaliseApiClient,
+  LokaliseApiError,
+  type LokaliseKey,
+  parseLokaliseExternalJobId,
+} from "./lokalise-api";
+import { mapLokaliseTranslationReadiness } from "./lokalise-locale-readiness";
+
+const KEY_ID_CHUNK_SIZE = 100;
+
+export const pullLokaliseTaskContent: ExternalTmsContentPuller = async ({
+  credential,
+  externalProjectId,
+  externalJobId,
+  project,
+  secretMaterial,
+}) => {
+  const projectId = externalProjectId.trim();
+  if (!projectId) {
+    throw new Error("invalid_lokalise_project_id");
+  }
+
+  const parsedJobId = parseLokaliseExternalJobId(externalJobId);
+  if (!parsedJobId) {
+    throw new Error("invalid_lokalise_job_id");
+  }
+
+  const client = new LokaliseApiClient({
+    token: secretMaterial,
+    baseUrl: credential.baseUrl ?? LOKALISE_DEFAULT_BASE_URL,
+  });
+
+  let task;
+  try {
+    task = await client.getTask(projectId, parsedJobId.taskId);
+  } catch (error) {
+    throw mapLokaliseFetcherError(error);
+  }
+
+  const sourceLocale = task.sourceLanguageIso?.trim() || project.sourceLocale?.trim() || null;
+  const targetLocales = collectLokaliseTaskTargetLocales(task);
+  if (targetLocales.length === 0) {
+    throw new Error("lokalise_task_missing_target_language");
+  }
+
+  const taskKeyIds = collectLokaliseTaskKeyIds(task);
+  let keys: LokaliseKey[];
+  try {
+    keys =
+      taskKeyIds.length > 0
+        ? await listKeysByIds(client, projectId, taskKeyIds)
+        : await client.listKeys(projectId, { includeTranslations: true });
+  } catch (error) {
+    throw mapLokaliseFetcherError(error);
+  }
+
+  const units: Awaited<ReturnType<ExternalTmsContentPuller>>["units"] = keys.map((key) => {
+    const keyName = extractLokaliseKeyName(key.keyName);
+    const translationsByLocale = new Map(
+      key.translations.map((translation) => [translation.languageIso, translation]),
+    );
+    const sourceTranslation = sourceLocale ? translationsByLocale.get(sourceLocale) : null;
+    const sourceText = sourceTranslation?.translation?.trim() || keyName;
+    const primaryFilename = pickPrimaryFilename(key);
+
+    const targetEntries = targetLocales.flatMap((locale) => {
+      const translation = translationsByLocale.get(locale);
+      if (!translation?.translation?.trim()) {
+        return [];
+      }
+
+      const readiness = mapLokaliseTranslationReadiness({
+        content: translation.translation,
+        isUnverified: translation.isUnverified,
+        isReviewed: translation.isReviewed,
+        isArchived: key.isArchived,
+        isHidden: key.isHidden,
+      });
+
+      return [
+        {
+          locale,
+          text: translation.translation.trim(),
+          externalTranslationId: String(translation.translationId),
+          isApproved: readiness === "ready",
+        },
+      ];
+    });
+
+    return {
+      externalStringId: String(key.keyId),
+      key: keyName,
+      sourceText,
+      context: key.context ?? key.description,
+      fileId: primaryFilename,
+      translations: targetEntries,
+      providerPayload: {
+        tags: key.tags,
+        platforms: key.platforms,
+        filenames: buildNonEmptyFilenamesPayload(key.filenames),
+        isPlural: key.isPlural,
+        isHidden: key.isHidden,
+        isArchived: key.isArchived,
+      },
+    };
+  });
+
+  let exportArtifact: Awaited<ReturnType<ExternalTmsContentPuller>>["exportArtifact"] = null;
+  try {
+    const format = inferPrimaryFormat(keys) ?? "json";
+    const download = await client.requestFileDownload(projectId, {
+      format,
+      originalFilenames: false,
+      bundleStructure: LOKALISE_DEFAULT_BUNDLE_STRUCTURE,
+      filterLangs: [...new Set([...(sourceLocale ? [sourceLocale] : []), ...targetLocales])],
+    });
+    const bytes = await client.downloadUrl(download.bundleUrl);
+    exportArtifact = {
+      url: download.bundleUrl,
+      format,
+      byteLength: bytes.byteLength,
+    };
+  } catch {
+    // File export is best-effort for agent workflows.
+  }
+
+  return {
+    externalJobId,
+    externalTaskId: String(task.taskId),
+    sourceLocale,
+    targetLocales,
+    units,
+    exportArtifact,
+    providerPayload: {
+      taskId: task.taskId,
+      status: task.status,
+      title: task.title,
+      taskType: task.taskType,
+      keysCount: task.keysCount,
+      wordsCount: task.wordsCount,
+      keyIds: taskKeyIds,
+    },
+  };
+};
+
+async function listKeysByIds(client: LokaliseApiClient, projectId: string, keyIds: number[]) {
+  const keysById = new Map<number, LokaliseKey>();
+  for (let index = 0; index < keyIds.length; index += KEY_ID_CHUNK_SIZE) {
+    const chunk = keyIds.slice(index, index + KEY_ID_CHUNK_SIZE);
+    const page = await client.listKeys(projectId, {
+      includeTranslations: true,
+      filterKeyIds: chunk,
+    });
+    for (const key of page) {
+      keysById.set(key.keyId, key);
+    }
+  }
+
+  return [...keysById.values()];
+}
+
+function pickPrimaryFilename(key: LokaliseKey) {
+  for (const platform of key.platforms) {
+    const normalizedPlatform = platform.trim().toLowerCase();
+    if (normalizedPlatform === "web" && key.filenames.web.trim()) {
+      return key.filenames.web;
+    }
+    if (normalizedPlatform === "ios" && key.filenames.ios.trim()) {
+      return key.filenames.ios;
+    }
+    if (normalizedPlatform === "android" && key.filenames.android.trim()) {
+      return key.filenames.android;
+    }
+    if (normalizedPlatform === "other" && key.filenames.other.trim()) {
+      return key.filenames.other;
+    }
+  }
+
+  return listLokaliseFilenameEntries(key.filenames)[0]?.filename ?? null;
+}
+
+function buildNonEmptyFilenamesPayload(filenames: LokaliseKey["filenames"]) {
+  return Object.fromEntries(
+    listLokaliseFilenameEntries(filenames).map((entry) => [entry.platform, entry.filename]),
+  );
+}
+
+function inferPrimaryFormat(keys: LokaliseKey[]) {
+  for (const key of keys) {
+    const filename = pickPrimaryFilename(key);
+    if (!filename) {
+      continue;
+    }
+
+    const format = inferFormatFromFilename(filename);
+    if (format) {
+      return format;
+    }
+  }
+
+  return null;
+}
+
+function mapLokaliseFetcherError(error: unknown) {
+  if (error instanceof LokaliseApiError && (error.status === 401 || error.status === 403)) {
+    return new Error("lokalise_auth_invalid");
+  }
+
+  return error instanceof Error ? error : new Error("lokalise_fetch_failed");
+}

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-translation-pusher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-translation-pusher.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { pushLokaliseTranslations } from "./lokalise-translation-pusher";
+
+describe("pushLokaliseTranslations", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("bulk updates approved translations with stable key ids", async () => {
+    const fetchMock = vi.fn(async (url, init) => {
+      const path = String(url);
+
+      if (path.endsWith("/tasks/42")) {
+        return new Response(
+          JSON.stringify({
+            task: {
+              task_id: 42,
+              title: "Homepage",
+              status: "in_progress",
+              task_type: "translation",
+              languages: [{ language_iso: "fr", keys: [4242] }],
+              source_language_iso: "en",
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.endsWith("/keys") && init?.method === "PUT") {
+        const body = JSON.parse(String(init.body));
+        expect(body).toEqual({
+          keys: [
+            {
+              key_id: 4242,
+              translations: [
+                {
+                  language_iso: "fr",
+                  translation: "Bonjour",
+                  is_unverified: false,
+                  is_reviewed: true,
+                },
+              ],
+            },
+          ],
+        });
+        return new Response(JSON.stringify({ keys: [{ key_id: 4242 }] }), { status: 200 });
+      }
+
+      return new Response(JSON.stringify({}), { status: 404 });
+    }) as unknown as typeof fetch;
+
+    globalThis.fetch = fetchMock;
+
+    const result = await pushLokaliseTranslations({
+      organizationId: "org-1",
+      projectId: "project-1",
+      providerKind: "lokalise",
+      externalProjectId: "proj.123",
+      externalJobId: "42",
+      credential: {
+        id: "cred-1",
+        baseUrl: "https://api.lokalise.test/api2",
+      } as never,
+      project: {} as never,
+      secretMaterial: "token",
+      translations: [{ locale: "fr", externalStringId: "4242", key: "hello", text: "Bonjour" }],
+    });
+
+    expect(result.uploaded).toBe(1);
+    expect(result.failed).toBe(0);
+    expect(result.failures).toEqual([]);
+    expect(result.asyncOperations).toEqual([
+      expect.objectContaining({
+        type: "lokalise_bulk_update_keys",
+        status: "succeeded",
+      }),
+    ]);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-translation-pusher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-translation-pusher.test.ts
@@ -83,4 +83,73 @@ describe("pushLokaliseTranslations", () => {
       }),
     ]);
   });
+
+  it("records partial bulk update failures from response errors", async () => {
+    const fetchMock = vi.fn(async (url, init) => {
+      const path = String(url);
+
+      if (path.endsWith("/tasks/42")) {
+        return new Response(
+          JSON.stringify({
+            task: {
+              task_id: 42,
+              title: "Homepage",
+              status: "in_progress",
+              languages: [{ language_iso: "fr", keys: [4242, 9999] }],
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.endsWith("/keys") && init?.method === "PUT") {
+        return new Response(
+          JSON.stringify({
+            keys: [{ key_id: 4242 }],
+            errors: [{ message: "Key not found", key: { key_id: 9999 } }],
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify({}), { status: 404 });
+    }) as unknown as typeof fetch;
+
+    globalThis.fetch = fetchMock;
+
+    const result = await pushLokaliseTranslations({
+      organizationId: "org-1",
+      projectId: "project-1",
+      providerKind: "lokalise",
+      externalProjectId: "proj.123",
+      externalJobId: "42",
+      credential: {
+        id: "cred-1",
+        baseUrl: "https://api.lokalise.test/api2",
+      } as never,
+      project: {} as never,
+      secretMaterial: "token",
+      translations: [
+        { locale: "fr", externalStringId: "4242", key: "hello", text: "Bonjour" },
+        { locale: "fr", externalStringId: "9999", key: "missing", text: "Échec" },
+      ],
+    });
+
+    expect(result.uploaded).toBe(1);
+    expect(result.failed).toBe(1);
+    expect(result.failures).toEqual([
+      expect.objectContaining({
+        locale: "fr",
+        message: "Key not found",
+      }),
+    ]);
+    expect(result.asyncOperations).toEqual([
+      expect.objectContaining({
+        type: "lokalise_bulk_update_keys",
+        status: "partial",
+        keysUpdated: 1,
+        keysFailed: 1,
+      }),
+    ]);
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-translation-pusher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-translation-pusher.ts
@@ -1,0 +1,96 @@
+import type { ExternalTmsTranslationPusher } from "@/lib/providers/external-tms-content-sync";
+
+import {
+  collectLokaliseTaskTargetLocales,
+  LOKALISE_DEFAULT_BASE_URL,
+  LokaliseApiClient,
+  LokaliseApiError,
+  parseLokaliseExternalJobId,
+} from "./lokalise-api";
+import { buildLokaliseTranslationWriteBackBatches } from "./lokalise-write-back";
+
+const BULK_UPDATE_CHUNK_SIZE = 50;
+
+export const pushLokaliseTranslations: ExternalTmsTranslationPusher = async ({
+  credential,
+  externalProjectId,
+  externalJobId,
+  secretMaterial,
+  translations,
+}) => {
+  const projectId = externalProjectId.trim();
+  if (!projectId) {
+    throw new Error("invalid_lokalise_project_id");
+  }
+
+  const parsedJobId = parseLokaliseExternalJobId(externalJobId);
+  if (!parsedJobId) {
+    throw new Error("invalid_lokalise_job_id");
+  }
+
+  const client = new LokaliseApiClient({
+    token: secretMaterial,
+    baseUrl: credential.baseUrl ?? LOKALISE_DEFAULT_BASE_URL,
+  });
+
+  let defaultTargetLocale: string | null = null;
+  try {
+    const task = await client.getTask(projectId, parsedJobId.taskId);
+    const targetLocales = collectLokaliseTaskTargetLocales(task);
+    defaultTargetLocale = targetLocales[0] ?? null;
+  } catch (error) {
+    throw mapLokaliseFetcherError(error);
+  }
+
+  const { batches, failures: payloadFailures } = buildLokaliseTranslationWriteBackBatches({
+    translations,
+    defaultTargetLocale,
+  });
+
+  let uploaded = 0;
+  let failed = payloadFailures.length;
+  const failures = [...payloadFailures];
+  const asyncOperations: Array<Record<string, unknown>> = [];
+
+  for (let index = 0; index < batches.length; index += BULK_UPDATE_CHUNK_SIZE) {
+    const chunk = batches.slice(index, index + BULK_UPDATE_CHUNK_SIZE);
+    try {
+      const response = await client.bulkUpdateKeys(projectId, chunk);
+      uploaded += chunk.reduce((count, batch) => count + batch.translations.length, 0);
+      asyncOperations.push({
+        type: "lokalise_bulk_update_keys",
+        keysRequested: chunk.length,
+        keysUpdated: response.keys?.length ?? chunk.length,
+        status: "succeeded",
+      });
+    } catch (error) {
+      failed += chunk.reduce((count, batch) => count + batch.translations.length, 0);
+      const message = error instanceof Error ? error.message : "lokalise_translation_upload_failed";
+      for (const batch of chunk) {
+        for (const translation of batch.translations) {
+          failures.push({
+            locale: translation.languageIso,
+            fileId: null,
+            message,
+          });
+        }
+      }
+      asyncOperations.push({
+        type: "lokalise_bulk_update_keys",
+        keysRequested: chunk.length,
+        status: "failed",
+        error: message,
+      });
+    }
+  }
+
+  return { uploaded, failed, failures, asyncOperations };
+};
+
+function mapLokaliseFetcherError(error: unknown) {
+  if (error instanceof LokaliseApiError && (error.status === 401 || error.status === 403)) {
+    return new Error("lokalise_auth_invalid");
+  }
+
+  return error instanceof Error ? error : new Error("lokalise_fetch_failed");
+}

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-translation-pusher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-translation-pusher.ts
@@ -6,6 +6,7 @@ import {
   LokaliseApiClient,
   LokaliseApiError,
   parseLokaliseExternalJobId,
+  summarizeLokaliseBulkUpdateChunkResult,
 } from "./lokalise-api";
 import { buildLokaliseTranslationWriteBackBatches } from "./lokalise-write-back";
 
@@ -56,12 +57,18 @@ export const pushLokaliseTranslations: ExternalTmsTranslationPusher = async ({
     const chunk = batches.slice(index, index + BULK_UPDATE_CHUNK_SIZE);
     try {
       const response = await client.bulkUpdateKeys(projectId, chunk);
-      uploaded += chunk.reduce((count, batch) => count + batch.translations.length, 0);
+      const chunkResult = summarizeLokaliseBulkUpdateChunkResult(chunk, response);
+      uploaded += chunkResult.uploaded;
+      failed += chunkResult.failed;
+      failures.push(...chunkResult.failures);
+
       asyncOperations.push({
         type: "lokalise_bulk_update_keys",
         keysRequested: chunk.length,
-        keysUpdated: response.keys?.length ?? chunk.length,
-        status: "succeeded",
+        keysUpdated: response.keys?.length ?? 0,
+        keysFailed: chunkResult.failedKeyCount,
+        status:
+          chunkResult.failed > 0 ? (chunkResult.uploaded > 0 ? "partial" : "failed") : "succeeded",
       });
     } catch (error) {
       failed += chunk.reduce((count, batch) => count + batch.translations.length, 0);

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-write-back.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-write-back.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { buildLokaliseTranslationWriteBackBatches } from "./lokalise-write-back";
+
+describe("buildLokaliseTranslationWriteBackBatches", () => {
+  it("groups translations by key id and marks approved uploads as reviewed", () => {
+    const result = buildLokaliseTranslationWriteBackBatches({
+      defaultTargetLocale: "fr",
+      translations: [
+        { locale: "fr", externalStringId: "4242", key: "hello", text: "Bonjour" },
+        { locale: "de", externalStringId: "4242", text: "Hallo" },
+        { locale: "", externalStringId: "7777", key: "world", text: "Monde" },
+      ],
+    });
+
+    expect(result.failures).toEqual([]);
+    expect(result.batches).toEqual([
+      {
+        keyId: 4242,
+        translations: [
+          {
+            languageIso: "fr",
+            translation: "Bonjour",
+            isUnverified: false,
+            isReviewed: true,
+          },
+          {
+            languageIso: "de",
+            translation: "Hallo",
+            isUnverified: false,
+            isReviewed: true,
+          },
+        ],
+      },
+      {
+        keyId: 7777,
+        translations: [
+          {
+            languageIso: "fr",
+            translation: "Monde",
+            isUnverified: false,
+            isReviewed: true,
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("records validation failures for incomplete uploads", () => {
+    const result = buildLokaliseTranslationWriteBackBatches({
+      defaultTargetLocale: null,
+      translations: [
+        { locale: "", key: "hello", text: "Bonjour" },
+        { locale: "fr-FR", externalStringId: "4242", text: "   " },
+        { locale: "fr-FR", key: "world", text: "Salut" },
+      ],
+    });
+
+    expect(result.batches).toEqual([]);
+    expect(result.failures).toEqual([
+      { locale: "", fileId: null, message: "lokalise_translation_missing_locale" },
+      { locale: "fr-FR", fileId: null, message: "lokalise_translation_missing_text" },
+      { locale: "fr-FR", fileId: null, message: "lokalise_translation_missing_key_id" },
+    ]);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-write-back.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-write-back.ts
@@ -1,0 +1,88 @@
+import type { ExternalTmsApprovedTranslationUpload } from "@/lib/providers/external-tms-content-sync";
+
+import type { LokaliseBulkUpdateKey } from "./lokalise-api";
+
+export type LokaliseTranslationWriteBackEntry = {
+  keyId: number;
+  keyName: string | null;
+  locale: string;
+  text: string;
+};
+
+export function buildLokaliseTranslationWriteBackBatches(input: {
+  translations: ExternalTmsApprovedTranslationUpload[];
+  defaultTargetLocale: string | null;
+}): {
+  batches: LokaliseBulkUpdateKey[];
+  failures: Array<{ locale: string; message: string; fileId?: string | null }>;
+} {
+  const entriesByKeyId = new Map<number, LokaliseTranslationWriteBackEntry[]>();
+  const failures: Array<{ locale: string; message: string; fileId?: string | null }> = [];
+
+  for (const translation of input.translations) {
+    const locale = translation.locale.trim() || input.defaultTargetLocale?.trim() || "";
+    const text = translation.text.trim();
+    const keyId = parseLokaliseKeyId(translation.externalStringId);
+    const keyName = translation.key?.trim() || null;
+
+    if (!locale) {
+      failures.push({
+        locale: translation.locale,
+        fileId: translation.fileId ?? null,
+        message: "lokalise_translation_missing_locale",
+      });
+      continue;
+    }
+
+    if (keyId == null) {
+      failures.push({
+        locale,
+        fileId: translation.fileId ?? null,
+        message: "lokalise_translation_missing_key_id",
+      });
+      continue;
+    }
+
+    if (!text) {
+      failures.push({
+        locale,
+        fileId: translation.fileId ?? null,
+        message: "lokalise_translation_missing_text",
+      });
+      continue;
+    }
+
+    const existing = entriesByKeyId.get(keyId) ?? [];
+    existing.push({ keyId, keyName, locale, text });
+    entriesByKeyId.set(keyId, existing);
+  }
+
+  const batches: LokaliseBulkUpdateKey[] = [];
+  for (const entries of entriesByKeyId.values()) {
+    batches.push({
+      keyId: entries[0]!.keyId,
+      translations: entries.map((entry) => ({
+        languageIso: entry.locale,
+        translation: entry.text,
+        isUnverified: false,
+        isReviewed: true,
+      })),
+    });
+  }
+
+  return { batches, failures };
+}
+
+function parseLokaliseKeyId(externalStringId: string | null | undefined) {
+  const trimmed = externalStringId?.trim() ?? "";
+  if (!trimmed) {
+    return null;
+  }
+
+  const keyId = Number(trimmed);
+  if (!Number.isInteger(keyId) || keyId <= 0) {
+    return null;
+  }
+
+  return keyId;
+}

--- a/apps/hyperlocalise-web/src/lib/providers/provider-agent-qa.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-agent-qa.test.ts
@@ -15,6 +15,34 @@ const projectFixture = createProjectTestFixture();
 const pullExternalTmsTaskContentMock = vi.fn();
 const runHlCheckOnProviderContentMock = vi.fn();
 
+const providerContentPullerMocks = vi.hoisted(() => {
+  type GetProviderContentPuller = (
+    providerKind: import("./organization-external-tms-provider-credentials").ExternalTmsProviderKind,
+  ) => import("@/lib/providers/external-tms-content-sync").ExternalTmsContentPuller | null;
+
+  const state: { actual: GetProviderContentPuller } = {
+    actual: () => null,
+  };
+  const getProviderContentPullerMock = vi.fn((...args: Parameters<GetProviderContentPuller>) =>
+    state.actual(...args),
+  );
+
+  return { state, getProviderContentPullerMock };
+});
+
+vi.mock("@/lib/providers/provider-content-pullers", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/providers/provider-content-pullers")>();
+  providerContentPullerMocks.state.actual = actual.getProviderContentPuller;
+  providerContentPullerMocks.getProviderContentPullerMock.mockImplementation(
+    actual.getProviderContentPuller,
+  );
+  return {
+    ...actual,
+    getProviderContentPuller: (...args: Parameters<typeof actual.getProviderContentPuller>) =>
+      providerContentPullerMocks.getProviderContentPullerMock(...args),
+  };
+});
+
 vi.mock("@/lib/providers/provider-job-qa/run-hl-check", () => ({
   runHlCheckOnProviderContent: (...args: unknown[]) => runHlCheckOnProviderContentMock(...args),
 }));
@@ -35,6 +63,9 @@ afterEach(async () => {
   await projectFixture.cleanup();
   pullExternalTmsTaskContentMock.mockReset();
   runHlCheckOnProviderContentMock.mockReset();
+  providerContentPullerMocks.getProviderContentPullerMock.mockImplementation(
+    providerContentPullerMocks.state.actual,
+  );
 });
 
 async function createExternalTmsProject() {
@@ -156,6 +187,8 @@ describe("executeProviderAgentQa", () => {
   });
 
   it("fails when the provider does not support content pull", async () => {
+    providerContentPullerMocks.getProviderContentPullerMock.mockReturnValue(null);
+
     const project = await createExternalTmsProject();
 
     const run = await createAgentRun({

--- a/apps/hyperlocalise-web/src/lib/providers/provider-agent-translate.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-agent-translate.test.ts
@@ -15,6 +15,34 @@ const projectFixture = createProjectTestFixture();
 const pullExternalTmsTaskContentMock = vi.fn();
 const loadOrganizationOpenAITranslationGeneratorMock = vi.fn();
 
+const providerContentPullerMocks = vi.hoisted(() => {
+  type GetProviderContentPuller = (
+    providerKind: import("./organization-external-tms-provider-credentials").ExternalTmsProviderKind,
+  ) => import("@/lib/providers/external-tms-content-sync").ExternalTmsContentPuller | null;
+
+  const state: { actual: GetProviderContentPuller } = {
+    actual: () => null,
+  };
+  const getProviderContentPullerMock = vi.fn((...args: Parameters<GetProviderContentPuller>) =>
+    state.actual(...args),
+  );
+
+  return { state, getProviderContentPullerMock };
+});
+
+vi.mock("@/lib/providers/provider-content-pullers", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/providers/provider-content-pullers")>();
+  providerContentPullerMocks.state.actual = actual.getProviderContentPuller;
+  providerContentPullerMocks.getProviderContentPullerMock.mockImplementation(
+    actual.getProviderContentPuller,
+  );
+  return {
+    ...actual,
+    getProviderContentPuller: (...args: Parameters<typeof actual.getProviderContentPuller>) =>
+      providerContentPullerMocks.getProviderContentPullerMock(...args),
+  };
+});
+
 vi.mock("@/lib/providers/external-tms-content-sync", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/providers/external-tms-content-sync")>();
   return {
@@ -36,6 +64,9 @@ afterEach(async () => {
   await projectFixture.cleanup();
   pullExternalTmsTaskContentMock.mockReset();
   loadOrganizationOpenAITranslationGeneratorMock.mockReset();
+  providerContentPullerMocks.getProviderContentPullerMock.mockImplementation(
+    providerContentPullerMocks.state.actual,
+  );
 });
 
 async function createExternalTmsProject() {
@@ -140,6 +171,8 @@ describe("executeProviderAgentTranslation", () => {
   });
 
   it("fails when the provider does not support content pull", async () => {
+    providerContentPullerMocks.getProviderContentPullerMock.mockReturnValue(null);
+
     const project = await createExternalTmsProject();
 
     const run = await createAgentRun({

--- a/apps/hyperlocalise-web/src/lib/providers/provider-content-pullers.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-content-pullers.ts
@@ -1,5 +1,6 @@
 import { pullCrowdinTaskContent } from "@/lib/providers/crowdin/crowdin-content-puller";
 import type { ExternalTmsContentPuller } from "@/lib/providers/external-tms-content-sync";
+import { pullLokaliseTaskContent } from "@/lib/providers/lokalise/lokalise-content-puller";
 import { pullPhraseTaskContent } from "@/lib/providers/phrase/phrase-content-puller";
 import { pullSmartlingTaskContent } from "@/lib/providers/smartling/smartling-content-puller";
 
@@ -15,6 +16,8 @@ export function getProviderContentPuller(
       return pullPhraseTaskContent;
     case "smartling":
       return pullSmartlingTaskContent;
+    case "lokalise":
+      return pullLokaliseTaskContent;
     default:
       return null;
   }

--- a/apps/hyperlocalise-web/src/lib/providers/provider-translation-pushers.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-translation-pushers.ts
@@ -1,5 +1,6 @@
 import { pushCrowdinTranslations } from "@/lib/providers/crowdin/crowdin-translation-pusher";
 import type { ExternalTmsTranslationPusher } from "@/lib/providers/external-tms-content-sync";
+import { pushLokaliseTranslations } from "@/lib/providers/lokalise/lokalise-translation-pusher";
 import { pushPhraseTranslations } from "@/lib/providers/phrase/phrase-translation-pusher";
 import { pushSmartlingTranslations } from "@/lib/providers/smartling/smartling-translation-pusher";
 
@@ -15,6 +16,8 @@ export function getProviderTranslationPusher(
       return pushPhraseTranslations;
     case "smartling":
       return pushSmartlingTranslations;
+    case "lokalise":
+      return pushLokaliseTranslations;
     default:
       return null;
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements HL-361 by wiring Lokalise into the provider-neutral TMS content sync layer used by agent translate/QA and manual sync routes.

## Changes

- **Pull** (`pullLokaliseTaskContent`): loads a Lokalise task by `externalJobId`, fetches task-scoped keys via `filter_key_ids`, maps translations into `ExternalTmsTaskContent`, and best-effort requests an async file bundle export for `exportArtifact`.
- **Write-back** (`pushLokaliseTranslations`): validates approved uploads, groups them by stable Lokalise `key_id` (`externalStringId`), and bulk-updates translations as reviewed/unverified=false.
- **API client**: adds `getTask`, filtered `listKeys`, `bulkUpdateKeys`, `requestFileDownload`, and `downloadUrl`.
- **Registries**: registers Lokalise in `getProviderContentPuller` and `getProviderTranslationPusher` so `pullExternalTmsTaskContent` / `pushExternalTmsTranslations` record `provider_sync_runs` like other providers.

## Testing

- `vp test src/lib/providers/lokalise`
- `vp check --fix`

## Acceptance criteria

- [x] Agent run code can pull Lokalise task content through the provider-neutral interface
- [x] Approved translations can be written back with stable key identity (`externalStringId` = Lokalise key ID)
- [x] Tests cover write-back payload construction (`lokalise-write-back.test.ts`)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-361](https://linear.app/hyperlocalise/issue/HL-361/implement-lokalise-translation-pull-and-write-back)

<div><a href="https://cursor.com/agents/bc-c6e2f6cd-8597-446f-9ccd-597f344458e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c6e2f6cd-8597-446f-9ccd-597f344458e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

