### PR TITLE
feat(web): sync and search Crowdin TM and glossary resources (HL-357)

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -9,7 +9,9 @@ import { db, schema } from "@/lib/database";
 import type { Project } from "@/lib/database/types";
 import { getFileStorageAdapter, type FileStorageAdapter } from "@/lib/file-storage";
 import { fetchCrowdinFileKeys } from "@/lib/providers/crowdin/crowdin-file-fetcher";
+import { fetchCrowdinGlossaries } from "@/lib/providers/crowdin/crowdin-glossary-fetcher";
 import { fetchCrowdinJobTasks } from "@/lib/providers/crowdin/crowdin-job-task-fetcher";
+import { fetchCrowdinTranslationMemories } from "@/lib/providers/crowdin/crowdin-tm-fetcher";
 import {
   syncExternalTmsFileKeys,
   type ExternalTmsFileKeyFetcher,
@@ -242,12 +244,14 @@ const jobTaskFetchersByProvider: Partial<
 const glossaryFetchersByProvider: Partial<
   Record<ExternalTmsProviderKind, ExternalTmsGlossaryFetcher>
 > = {
+  crowdin: fetchCrowdinGlossaries,
   phrase: fetchPhraseGlossaries,
 };
 
 const translationMemoryFetchersByProvider: Partial<
   Record<ExternalTmsProviderKind, ExternalTmsTranslationMemoryFetcher>
 > = {
+  crowdin: fetchCrowdinTranslationMemories,
   phrase: fetchPhraseTranslationMemories,
 };
 

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-api.test.ts
@@ -441,6 +441,69 @@ describe("CrowdinApiClient", () => {
     expect(upload.fileId).toBe(101);
   });
 
+  it("lists glossaries and translation memories with pagination", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      const path = String(url);
+
+      if (path.includes("/glossaries?")) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  id: 7,
+                  name: "Product glossary",
+                  description: null,
+                  languageId: "en",
+                  languageIds: ["en", "fr"],
+                  terms: 12,
+                  projectIds: [42],
+                  defaultProjectIds: [],
+                  webUrl: "https://crowdin.com/glossary/7",
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/tms?")) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  id: 9,
+                  name: "Product TM",
+                  description: null,
+                  languageId: "en",
+                  languageIds: ["en", "fr"],
+                  segmentsCount: 100,
+                  projectIds: [42],
+                  defaultProjectIds: [],
+                  webUrl: "https://crowdin.com/tm/9",
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    const glossaries = await client.listGlossaries();
+    const memories = await client.listTranslationMemories();
+
+    expect(glossaries).toHaveLength(1);
+    expect(glossaries[0]?.projectIds).toEqual([42]);
+    expect(memories).toHaveLength(1);
+    expect(memories[0]?.segmentsCount).toBe(100);
+  });
+
   it("lists project language progress", async () => {
     const fetchMock = vi.fn(async () => {
       return new Response(

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-api.ts
@@ -163,6 +163,53 @@ export interface CrowdinDownloadLink {
   expireIn?: string;
 }
 
+export interface CrowdinGlossary {
+  id: number;
+  name: string;
+  description: string | null;
+  languageId: string;
+  languageIds: string[];
+  terms: number;
+  projectIds: number[];
+  defaultProjectIds: number[];
+  webUrl: string;
+}
+
+export interface CrowdinGlossaryTerm {
+  id: number;
+  glossaryId: number;
+  languageId: string;
+  text: string;
+  description: string;
+  partOfSpeech: string;
+  status: string;
+  conceptId: number;
+  note: string;
+}
+
+export interface CrowdinTranslationMemory {
+  id: number;
+  name: string;
+  description: string | null;
+  languageId: string;
+  languageIds: string[];
+  segmentsCount: number;
+  projectIds: number[];
+  defaultProjectIds: number[];
+  webUrl: string;
+}
+
+export interface CrowdinTranslationMemorySegmentRecord {
+  id: number;
+  languageId: string;
+  text: string;
+}
+
+export interface CrowdinTranslationMemorySegment {
+  id: number;
+  records: CrowdinTranslationMemorySegmentRecord[];
+}
+
 export interface CrowdinTmConcordanceSearchRequest {
   sourceLanguageId: string;
   targetLanguageId: string;
@@ -820,6 +867,53 @@ export class CrowdinApiClient {
     }
 
     return progress;
+  }
+
+  async listGlossaries(): Promise<CrowdinGlossary[]> {
+    return this.listPaginated<CrowdinGlossary>("/glossaries");
+  }
+
+  async listGlossaryTerms(glossaryId: number): Promise<CrowdinGlossaryTerm[]> {
+    return this.listPaginated<CrowdinGlossaryTerm>(`/glossaries/${glossaryId}/terms`);
+  }
+
+  async listTranslationMemories(): Promise<CrowdinTranslationMemory[]> {
+    return this.listPaginated<CrowdinTranslationMemory>("/tms");
+  }
+
+  async listTranslationMemorySegments(
+    tmId: number,
+    options?: {
+      shouldStop?: (segments: CrowdinTranslationMemorySegment[]) => boolean;
+    },
+  ): Promise<CrowdinTranslationMemorySegment[]> {
+    return this.listPaginated<CrowdinTranslationMemorySegment>(`/tms/${tmId}/segments`, options);
+  }
+
+  private async listPaginated<T>(
+    path: string,
+    options?: { shouldStop?: (items: T[]) => boolean },
+  ): Promise<T[]> {
+    const items: T[] = [];
+    let offset = 0;
+    const limit = 500;
+
+    while (true) {
+      const separator = path.includes("?") ? "&" : "?";
+      const response = await this.get<CrowdinListResponse<T>>(
+        `${path}${separator}limit=${limit}&offset=${offset}`,
+      );
+      const page = response.data.map((item) => item.data);
+      items.push(...page);
+
+      if (options?.shouldStop?.(items) || page.length < limit) {
+        break;
+      }
+
+      offset += limit;
+    }
+
+    return items;
   }
 
   private authHeaders(contentType = "application/json"): Record<string, string> {

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-glossary-fetcher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-glossary-fetcher.ts
@@ -15,7 +15,7 @@ export const fetchCrowdinGlossaries: ExternalTmsGlossaryFetcher = async ({
   });
 
   const crowdinProjectId = Number(externalProjectId);
-  if (!Number.isFinite(crowdinProjectId)) {
+  if (!Number.isFinite(crowdinProjectId) || crowdinProjectId <= 0) {
     throw new Error("invalid_crowdin_project_id");
   }
 
@@ -160,9 +160,7 @@ function buildGlossaryTermRows(input: {
   for (const [conceptId, sourceTerm] of sourceTermsByConcept) {
     const targets = targetTermsByConcept.get(conceptId) ?? [];
     for (const targetLocale of input.targetLocales) {
-      const targetTerm =
-        targets.find((term) => term.languageId === targetLocale) ??
-        targets.find((term) => term.text.trim().length > 0);
+      const targetTerm = targets.find((term) => term.languageId === targetLocale);
 
       if (!targetTerm?.text.trim()) {
         continue;

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-glossary-fetcher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-glossary-fetcher.ts
@@ -1,0 +1,206 @@
+import type { ExternalTmsGlossaryFetcher } from "@/lib/providers/external-tms-glossary-sync";
+
+import { CrowdinApiClient, CrowdinApiError } from "./crowdin-api";
+import { isCrowdinResourceLinkedToProject } from "./crowdin-resource-scope";
+
+export const fetchCrowdinGlossaries: ExternalTmsGlossaryFetcher = async ({
+  credential,
+  secretMaterial,
+  externalProjectId,
+  project,
+}) => {
+  const client = new CrowdinApiClient({
+    token: secretMaterial,
+    baseUrl: credential.baseUrl ?? undefined,
+  });
+
+  const crowdinProjectId = Number(externalProjectId);
+  if (!Number.isFinite(crowdinProjectId)) {
+    throw new Error("invalid_crowdin_project_id");
+  }
+
+  let glossaries;
+  try {
+    glossaries = await client.listGlossaries();
+  } catch (error) {
+    if (error instanceof CrowdinApiError && error.status === 401) {
+      throw new Error("crowdin_auth_invalid");
+    }
+    throw error;
+  }
+
+  const sourceLocale = project.sourceLocale ?? "en";
+  const targetLocales = project.targetLocales ?? [];
+
+  const scoped = glossaries.filter((glossary) =>
+    isCrowdinResourceLinkedToProject({
+      projectId: crowdinProjectId,
+      projectIds: glossary.projectIds,
+      defaultProjectIds: glossary.defaultProjectIds,
+    }),
+  );
+
+  const results = await Promise.all(
+    scoped.map(async (glossary) => {
+      try {
+        const terms = await client.listGlossaryTerms(glossary.id);
+        const glossaryTargetLocales = uniqueLocales([
+          ...targetLocales,
+          ...glossary.languageIds.filter((locale) => locale !== glossary.languageId),
+        ]);
+
+        const termRows = buildGlossaryTermRows({
+          glossaryId: glossary.id,
+          sourceLanguageId: glossary.languageId,
+          terms,
+          targetLocales: glossaryTargetLocales.length > 0 ? glossaryTargetLocales : [sourceLocale],
+        });
+
+        return glossaryTargetLocales.map((targetLocale) => ({
+          externalGlossaryId: String(glossary.id),
+          name: glossary.name,
+          description: glossary.description ?? "",
+          sourceLocale: glossary.languageId,
+          targetLocale,
+          localeCoverage: uniqueLocales([glossary.languageId, ...glossary.languageIds]),
+          termCount: glossary.terms,
+          externalUrl: glossary.webUrl,
+          metadata: {
+            crowdinGlossaryId: glossary.id,
+            crowdinProjectId,
+          },
+          terms: termRows
+            .filter((term) => term.targetLocale === targetLocale)
+            .map((term) => ({
+              externalKey: term.externalKey,
+              sourceTerm: term.sourceTerm,
+              targetTerm: term.targetTerm,
+              description: term.description,
+              partOfSpeech: term.partOfSpeech,
+              status: term.status,
+              forbidden: term.forbidden,
+              notes: term.notes,
+              metadata: term.metadata,
+            })),
+        }));
+      } catch (error) {
+        if (error instanceof CrowdinApiError && error.status === 401) {
+          throw new Error("crowdin_auth_invalid");
+        }
+
+        return [
+          {
+            externalGlossaryId: String(glossary.id),
+            name: glossary.name,
+            description: glossary.description ?? "",
+            sourceLocale: glossary.languageId,
+            targetLocale: targetLocales[0] ?? glossary.languageIds[0] ?? sourceLocale,
+            localeCoverage: uniqueLocales([glossary.languageId, ...glossary.languageIds]),
+            termCount: glossary.terms,
+            externalUrl: glossary.webUrl,
+            syncErrorMessage: error instanceof Error ? error.message : "glossary_term_fetch_failed",
+            metadata: {
+              crowdinGlossaryId: glossary.id,
+              crowdinProjectId,
+            },
+            terms: [],
+          },
+        ];
+      }
+    }),
+  );
+
+  return results.flat();
+};
+
+function buildGlossaryTermRows(input: {
+  glossaryId: number;
+  sourceLanguageId: string;
+  terms: Array<{
+    id: number;
+    conceptId: number;
+    languageId: string;
+    text: string;
+    description: string;
+    partOfSpeech: string;
+    status: string;
+    note: string;
+  }>;
+  targetLocales: string[];
+}) {
+  const sourceTermsByConcept = new Map<number, (typeof input.terms)[number]>();
+  const targetTermsByConcept = new Map<number, Array<(typeof input.terms)[number]>>();
+
+  for (const term of input.terms) {
+    if (term.languageId === input.sourceLanguageId) {
+      if (!sourceTermsByConcept.has(term.conceptId)) {
+        sourceTermsByConcept.set(term.conceptId, term);
+      }
+      continue;
+    }
+
+    const bucket = targetTermsByConcept.get(term.conceptId) ?? [];
+    bucket.push(term);
+    targetTermsByConcept.set(term.conceptId, bucket);
+  }
+
+  const rows: Array<{
+    externalKey: string;
+    sourceTerm: string;
+    targetTerm: string;
+    targetLocale: string;
+    description: string;
+    partOfSpeech: string;
+    status: string;
+    forbidden: boolean | null;
+    notes: string | null;
+    metadata: Record<string, unknown>;
+  }> = [];
+
+  for (const [conceptId, sourceTerm] of sourceTermsByConcept) {
+    const targets = targetTermsByConcept.get(conceptId) ?? [];
+    for (const targetLocale of input.targetLocales) {
+      const targetTerm =
+        targets.find((term) => term.languageId === targetLocale) ??
+        targets.find((term) => term.text.trim().length > 0);
+
+      if (!targetTerm?.text.trim()) {
+        continue;
+      }
+
+      rows.push({
+        externalKey: `${input.glossaryId}:${conceptId}:${targetLocale}`,
+        sourceTerm: sourceTerm.text,
+        targetTerm: targetTerm.text,
+        targetLocale,
+        description: sourceTerm.description || targetTerm.description,
+        partOfSpeech: sourceTerm.partOfSpeech || targetTerm.partOfSpeech,
+        status: targetTerm.status || sourceTerm.status,
+        forbidden: null,
+        notes: targetTerm.note || sourceTerm.note || null,
+        metadata: {
+          crowdinTermId: targetTerm.id,
+          crowdinConceptId: conceptId,
+        },
+      });
+    }
+  }
+
+  return rows;
+}
+
+function uniqueLocales(locales: string[]): string[] {
+  const seen = new Set<string>();
+  const unique: string[] = [];
+
+  for (const locale of locales) {
+    const trimmed = locale.trim();
+    if (!trimmed || seen.has(trimmed)) {
+      continue;
+    }
+    seen.add(trimmed);
+    unique.push(trimmed);
+  }
+
+  return unique;
+}

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-glossary-matcher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-glossary-matcher.test.ts
@@ -3,11 +3,13 @@ import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 const glossaryConcordanceSearch = vi.fn();
 
 vi.mock("./crowdin-api", () => ({
-  CrowdinApiClient: vi.fn(function CrowdinApiClientMock(this: {
-    glossaryConcordanceSearch: typeof glossaryConcordanceSearch;
-  }) {
-    this.glossaryConcordanceSearch = glossaryConcordanceSearch;
-  }),
+  CrowdinApiClient: vi.fn(
+    function CrowdinApiClientMock(this: {
+      glossaryConcordanceSearch: typeof glossaryConcordanceSearch;
+    }) {
+      this.glossaryConcordanceSearch = glossaryConcordanceSearch;
+    },
+  ),
   CrowdinApiError: class CrowdinApiError extends Error {
     constructor(
       message: string,

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-glossary-matcher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-glossary-matcher.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const glossaryConcordanceSearch = vi.fn();
+
+vi.mock("./crowdin-api", () => ({
+  CrowdinApiClient: vi.fn(function CrowdinApiClientMock(this: {
+    glossaryConcordanceSearch: typeof glossaryConcordanceSearch;
+  }) {
+    this.glossaryConcordanceSearch = glossaryConcordanceSearch;
+  }),
+  CrowdinApiError: class CrowdinApiError extends Error {
+    constructor(
+      message: string,
+      readonly status: number,
+    ) {
+      super(message);
+      this.name = "CrowdinApiError";
+    }
+  },
+}));
+
+import { searchCrowdinGlossaryMatches } from "./crowdin-glossary-matcher";
+
+describe("searchCrowdinGlossaryMatches", () => {
+  beforeEach(() => {
+    glossaryConcordanceSearch.mockReset();
+  });
+
+  it("skips concordance hits for glossaries that are not attached to the project", async () => {
+    glossaryConcordanceSearch.mockResolvedValue([
+      {
+        glossary: { id: 99, name: "Unlinked glossary" },
+        sourceTerms: [{ id: 1, languageId: "en", text: "Save" }],
+        targetTerms: [{ id: 2, languageId: "fr", text: "Enregistrer" }],
+      },
+    ]);
+
+    const matches = await searchCrowdinGlossaryMatches({
+      organizationId: "org-1",
+      projectId: "project-1",
+      providerKind: "crowdin",
+      externalProjectId: "42",
+      credential: {
+        baseUrl: "https://api.crowdin.test/api/v2",
+      } as never,
+      secretMaterial: "token",
+      glossaries: [
+        {
+          id: "glossary-local-1",
+          name: "Product glossary",
+          externalGlossaryId: "77",
+          termCapabilities: {},
+        },
+      ],
+      sourceLocale: "en",
+      targetLocale: "fr",
+      sourceText: "Save",
+      limit: 5,
+    });
+
+    expect(matches).toEqual([]);
+  });
+
+  it("normalizes concordance hits for attached glossaries", async () => {
+    glossaryConcordanceSearch.mockResolvedValue([
+      {
+        glossary: { id: 77, name: "Product glossary" },
+        sourceTerms: [{ id: 1, languageId: "en", text: "Save", status: "preferred" }],
+        targetTerms: [{ id: 2, languageId: "fr", text: "Enregistrer", status: "preferred" }],
+      },
+    ]);
+
+    const matches = await searchCrowdinGlossaryMatches({
+      organizationId: "org-1",
+      projectId: "project-1",
+      providerKind: "crowdin",
+      externalProjectId: "42",
+      credential: {
+        baseUrl: "https://api.crowdin.test/api/v2",
+      } as never,
+      secretMaterial: "token",
+      glossaries: [
+        {
+          id: "glossary-local-1",
+          name: "Product glossary",
+          externalGlossaryId: "77",
+          termCapabilities: {},
+        },
+      ],
+      sourceLocale: "en",
+      targetLocale: "fr",
+      sourceText: "Save",
+      limit: 5,
+    });
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0]).toMatchObject({
+      glossaryId: "glossary-local-1",
+      glossaryName: "Product glossary",
+      sourceTerm: "Save",
+      targetTerm: "Enregistrer",
+      targetLocale: "fr",
+      providerKind: "crowdin",
+      externalResourceId: "77",
+      matchSource: "live_provider",
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-resource-scope.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-resource-scope.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { isCrowdinResourceLinkedToProject } from "./crowdin-resource-scope";
+
+describe("isCrowdinResourceLinkedToProject", () => {
+  it("returns false when no project links are present", () => {
+    expect(
+      isCrowdinResourceLinkedToProject({
+        projectId: 42,
+        projectIds: [],
+        defaultProjectIds: [],
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true when the project is explicitly linked", () => {
+    expect(
+      isCrowdinResourceLinkedToProject({
+        projectId: 42,
+        projectIds: [7, 42],
+        defaultProjectIds: [],
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true when the project is listed as a default project", () => {
+    expect(
+      isCrowdinResourceLinkedToProject({
+        projectId: 42,
+        projectIds: [],
+        defaultProjectIds: [42],
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-resource-scope.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-resource-scope.ts
@@ -1,0 +1,13 @@
+export function isCrowdinResourceLinkedToProject(input: {
+  projectId: number;
+  projectIds?: number[];
+  defaultProjectIds?: number[];
+}): boolean {
+  const linkedProjectIds = [...(input.projectIds ?? []), ...(input.defaultProjectIds ?? [])];
+  if (linkedProjectIds.length === 0) {
+    // Crowdin returns empty projectIds when a TM/glossary is not assigned to any project.
+    return false;
+  }
+
+  return linkedProjectIds.includes(input.projectId);
+}

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-tm-fetcher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-tm-fetcher.ts
@@ -1,0 +1,184 @@
+import type { ExternalTmsTranslationMemoryFetcher } from "@/lib/providers/external-tms-tm-sync";
+
+import { CrowdinApiClient, CrowdinApiError } from "./crowdin-api";
+import { isCrowdinResourceLinkedToProject } from "./crowdin-resource-scope";
+
+const maxSegmentsPerMemory = 2_000;
+
+export const fetchCrowdinTranslationMemories: ExternalTmsTranslationMemoryFetcher = async ({
+  credential,
+  secretMaterial,
+  externalProjectId,
+  project,
+}) => {
+  const client = new CrowdinApiClient({
+    token: secretMaterial,
+    baseUrl: credential.baseUrl ?? undefined,
+  });
+
+  const crowdinProjectId = Number(externalProjectId);
+  if (!Number.isFinite(crowdinProjectId)) {
+    throw new Error("invalid_crowdin_project_id");
+  }
+
+  let memories;
+  try {
+    memories = await client.listTranslationMemories();
+  } catch (error) {
+    if (error instanceof CrowdinApiError && error.status === 401) {
+      throw new Error("crowdin_auth_invalid");
+    }
+    throw error;
+  }
+
+  const sourceLocale = project.sourceLocale ?? "en";
+  const targetLocales = project.targetLocales ?? [];
+
+  const scoped = memories.filter((memory) =>
+    isCrowdinResourceLinkedToProject({
+      projectId: crowdinProjectId,
+      projectIds: memory.projectIds,
+      defaultProjectIds: memory.defaultProjectIds,
+    }),
+  );
+
+  const results = await Promise.all(
+    scoped.map(async (memory) => {
+      try {
+        const entryTargetLocales = uniqueLocales([
+          ...targetLocales,
+          ...memory.languageIds.filter((locale) => locale !== memory.languageId),
+        ]);
+        const sourceLanguageId = memory.languageId || sourceLocale;
+        let fetchedSegmentCount = 0;
+        const entries: ReturnType<typeof buildTranslationMemoryEntries> = [];
+        await client.listTranslationMemorySegments(memory.id, {
+          shouldStop: (fetchedSegments) => {
+            const newSegments = fetchedSegments.slice(fetchedSegmentCount);
+            fetchedSegmentCount = fetchedSegments.length;
+            entries.push(
+              ...buildTranslationMemoryEntries({
+                memoryId: memory.id,
+                sourceLanguageId,
+                targetLocales: entryTargetLocales,
+                segments: newSegments,
+              }),
+            );
+
+            return entries.length >= maxSegmentsPerMemory;
+          },
+        });
+        const syncedEntries = entries.slice(0, maxSegmentsPerMemory);
+
+        return {
+          externalMemoryId: String(memory.id),
+          name: memory.name,
+          description: memory.description ?? "",
+          sourceLocale: memory.languageId || sourceLocale,
+          localeCoverage: uniqueLocales([memory.languageId, ...memory.languageIds]),
+          segmentCount: memory.segmentsCount,
+          externalUrl: memory.webUrl,
+          metadata: {
+            crowdinTranslationMemoryId: memory.id,
+            crowdinProjectId,
+            importedSegmentCount: syncedEntries.length,
+          },
+          entries: syncedEntries,
+        };
+      } catch (error) {
+        if (error instanceof CrowdinApiError && error.status === 401) {
+          throw new Error("crowdin_auth_invalid");
+        }
+
+        return {
+          externalMemoryId: String(memory.id),
+          name: memory.name,
+          description: memory.description ?? "",
+          sourceLocale: memory.languageId || sourceLocale,
+          localeCoverage: uniqueLocales([memory.languageId, ...memory.languageIds]),
+          segmentCount: memory.segmentsCount,
+          externalUrl: memory.webUrl,
+          syncErrorMessage:
+            error instanceof Error ? error.message : "translation_memory_sync_failed",
+          metadata: {
+            crowdinTranslationMemoryId: memory.id,
+            crowdinProjectId,
+          },
+          entries: [],
+        };
+      }
+    }),
+  );
+
+  return results;
+};
+
+function buildTranslationMemoryEntries(input: {
+  memoryId: number;
+  sourceLanguageId: string;
+  targetLocales: string[];
+  segments: Array<{
+    id: number;
+    records: Array<{ id: number; languageId: string; text: string }>;
+  }>;
+}) {
+  const entries: Array<{
+    externalKey: string;
+    sourceLocale: string;
+    targetLocale: string;
+    sourceText: string;
+    targetText: string;
+    matchScore: number;
+    metadata: Record<string, unknown>;
+  }> = [];
+
+  for (const segment of input.segments) {
+    const sourceRecord = segment.records.find(
+      (record) => record.languageId === input.sourceLanguageId && record.text.trim(),
+    );
+    if (!sourceRecord) {
+      continue;
+    }
+
+    for (const targetLocale of input.targetLocales) {
+      const targetRecord = segment.records.find(
+        (record) => record.languageId === targetLocale && record.text.trim(),
+      );
+      if (!targetRecord) {
+        continue;
+      }
+
+      entries.push({
+        externalKey: `${input.memoryId}:${segment.id}:${targetLocale}`,
+        sourceLocale: input.sourceLanguageId,
+        targetLocale,
+        sourceText: sourceRecord.text,
+        targetText: targetRecord.text,
+        matchScore: 100,
+        metadata: {
+          crowdinSegmentId: segment.id,
+          crowdinSourceRecordId: sourceRecord.id,
+          crowdinTargetRecordId: targetRecord.id,
+        },
+      });
+    }
+  }
+
+  return entries;
+}
+
+function uniqueLocales(locales: string[]): string[] {
+  const seen = new Set<string>();
+  const unique: string[] = [];
+
+  for (const locale of locales) {
+    const trimmed = locale.trim();
+    if (!trimmed || seen.has(trimmed)) {
+      continue;
+    }
+    seen.add(trimmed);
+    unique.push(trimmed);
+  }
+
+  return unique;
+}

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-tm-fetcher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-tm-fetcher.ts
@@ -17,7 +17,7 @@ export const fetchCrowdinTranslationMemories: ExternalTmsTranslationMemoryFetche
   });
 
   const crowdinProjectId = Number(externalProjectId);
-  if (!Number.isFinite(crowdinProjectId)) {
+  if (!Number.isFinite(crowdinProjectId) || crowdinProjectId <= 0) {
     throw new Error("invalid_crowdin_project_id");
   }
 
@@ -50,25 +50,21 @@ export const fetchCrowdinTranslationMemories: ExternalTmsTranslationMemoryFetche
           ...memory.languageIds.filter((locale) => locale !== memory.languageId),
         ]);
         const sourceLanguageId = memory.languageId || sourceLocale;
-        let fetchedSegmentCount = 0;
-        const entries: ReturnType<typeof buildTranslationMemoryEntries> = [];
-        await client.listTranslationMemorySegments(memory.id, {
-          shouldStop: (fetchedSegments) => {
-            const newSegments = fetchedSegments.slice(fetchedSegmentCount);
-            fetchedSegmentCount = fetchedSegments.length;
-            entries.push(
-              ...buildTranslationMemoryEntries({
-                memoryId: memory.id,
-                sourceLanguageId,
-                targetLocales: entryTargetLocales,
-                segments: newSegments,
-              }),
-            );
+        const buildEntries = (
+          segments: Parameters<typeof buildTranslationMemoryEntries>[0]["segments"],
+        ) =>
+          buildTranslationMemoryEntries({
+            memoryId: memory.id,
+            sourceLanguageId,
+            targetLocales: entryTargetLocales,
+            segments,
+          });
 
-            return entries.length >= maxSegmentsPerMemory;
-          },
+        const segments = await client.listTranslationMemorySegments(memory.id, {
+          shouldStop: (fetchedSegments) =>
+            buildEntries(fetchedSegments).length >= maxSegmentsPerMemory,
         });
-        const syncedEntries = entries.slice(0, maxSegmentsPerMemory);
+        const syncedEntries = buildEntries(segments).slice(0, maxSegmentsPerMemory);
 
         return {
           externalMemoryId: String(memory.id),

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-tm-matcher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-tm-matcher.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const concordanceSearch = vi.fn();
+
+vi.mock("./crowdin-api", () => ({
+  CrowdinApiClient: vi.fn(function CrowdinApiClientMock(this: {
+    concordanceSearch: typeof concordanceSearch;
+  }) {
+    this.concordanceSearch = concordanceSearch;
+  }),
+  CrowdinApiError: class CrowdinApiError extends Error {
+    constructor(
+      message: string,
+      readonly status: number,
+    ) {
+      super(message);
+      this.name = "CrowdinApiError";
+    }
+  },
+}));
+
+import { searchCrowdinTranslationMemoryMatches } from "./crowdin-tm-matcher";
+
+describe("searchCrowdinTranslationMemoryMatches", () => {
+  beforeEach(() => {
+    concordanceSearch.mockReset();
+  });
+
+  it("filters concordance hits to the attached memory when externalMemoryId is set", async () => {
+    concordanceSearch.mockResolvedValue([
+      {
+        tm: { id: 10, name: "Product TM" },
+        recordId: 501,
+        source: "Save file",
+        target: "Enregistrer le fichier",
+        relevant: 90,
+        substituted: "Enregistrer le fichier",
+        updatedAt: "2026-05-23T00:00:00Z",
+      },
+      {
+        tm: { id: 11, name: "Other TM" },
+        recordId: 502,
+        source: "Save file",
+        target: "Guardar archivo",
+        relevant: 80,
+        substituted: "Guardar archivo",
+        updatedAt: "2026-05-23T00:00:00Z",
+      },
+    ]);
+
+    const matches = await searchCrowdinTranslationMemoryMatches({
+      organizationId: "org-1",
+      projectId: "project-1",
+      providerKind: "crowdin",
+      externalProjectId: "42",
+      credential: {
+        baseUrl: "https://api.crowdin.test/api/v2",
+      } as never,
+      secretMaterial: "token",
+      memory: {
+        id: "memory-local-1",
+        name: "Product TM",
+        externalMemoryId: "10",
+        capabilityMode: "live_search",
+      },
+      sourceLocale: "en",
+      targetLocale: "fr",
+      sourceText: "Save file",
+      limit: 5,
+    });
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0]).toMatchObject({
+      memoryId: "memory-local-1",
+      memoryName: "Product TM",
+      sourceText: "Save file",
+      targetText: "Enregistrer le fichier",
+      externalResourceId: "10",
+      matchSource: "live_provider",
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-tm-matcher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-tm-matcher.test.ts
@@ -3,11 +3,11 @@ import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 const concordanceSearch = vi.fn();
 
 vi.mock("./crowdin-api", () => ({
-  CrowdinApiClient: vi.fn(function CrowdinApiClientMock(this: {
-    concordanceSearch: typeof concordanceSearch;
-  }) {
-    this.concordanceSearch = concordanceSearch;
-  }),
+  CrowdinApiClient: vi.fn(
+    function CrowdinApiClientMock(this: { concordanceSearch: typeof concordanceSearch }) {
+      this.concordanceSearch = concordanceSearch;
+    },
+  ),
   CrowdinApiError: class CrowdinApiError extends Error {
     constructor(
       message: string,


### PR DESCRIPTION
## Summary

- Add Crowdin glossary and translation memory fetchers that sync linked resources into the database via existing `glossary_scan` / `tm_scan` jobs.
- Extend `CrowdinApiClient` with paginated list endpoints for glossaries, glossary terms, and translation memory segments.
- Wire Crowdin into `POST .../sync-glossaries` and `POST .../sync-translation-memories` project routes.
- Add tests for project resource scoping and live concordance match normalization/filtering.

Agent translation context already merges synced DB matches with live Crowdin concordance on external Crowdin projects; this change makes the sync path work end-to-end.

Linear: [HL-357](https://linear.app/hyperlocalise/issue/HL-357/sync-and-search-crowdin-tm-and-glossary-resources)

## Test plan

- [x] `vp check --fix`
- [x] `vp test crowdin-resource-scope crowdin-glossary-matcher crowdin-tm-matcher crowdin-api`
- [ ] Sync glossaries/TMs on a Crowdin-linked project and confirm resources appear on org Glossaries / Translation Memories pages
- [ ] Run agent translation on a Crowdin project and confirm glossary + TM matches in context (synced and/or live concordance)


Made with [Cursor](https://cursor.com)