### PR TITLE
feat(smartling): bridge QA findings to Smartling issues API (HL-347)

### DIFF
--- a/apps/hyperlocalise-web/src/api/app.ts
+++ b/apps/hyperlocalise-web/src/api/app.ts
@@ -6,6 +6,7 @@ import type {
   EmailAgentTaskQueue,
   GitHubFixQueue,
   JobQueue,
+  ProviderAgentCommentQueue,
   ProviderAgentQaQueue,
   ProviderAgentTranslationQueue,
   TranslationJobEventData,
@@ -38,6 +39,7 @@ import { createTeamRoutes } from "./routes/team/team.route";
 import { workosWebhookRoutes } from "./routes/workos-webhook/workos-webhook.route";
 import {
   createTranslationJobEventQueue,
+  createProviderAgentCommentQueue,
   createProviderAgentQaQueue,
   createProviderAgentTranslationQueue,
 } from "@/workflows/adapters";
@@ -49,6 +51,7 @@ type CreateAppOptions = {
   jobQueue?: JobQueue<TranslationJobEventData>;
   providerAgentTranslationQueue?: ProviderAgentTranslationQueue;
   providerAgentQaQueue?: ProviderAgentQaQueue;
+  providerAgentCommentQueue?: ProviderAgentCommentQueue;
   fileStorageAdapter?: FileStorageAdapter;
 };
 
@@ -57,6 +60,8 @@ export function createApp(options: CreateAppOptions = {}) {
   const providerAgentTranslationQueue =
     options.providerAgentTranslationQueue ?? createProviderAgentTranslationQueue();
   const providerAgentQaQueue = options.providerAgentQaQueue ?? createProviderAgentQaQueue();
+  const providerAgentCommentQueue =
+    options.providerAgentCommentQueue ?? createProviderAgentCommentQueue();
 
   return new Hono()
     .use("*", secureHeaders())
@@ -72,6 +77,7 @@ export function createApp(options: CreateAppOptions = {}) {
         jobQueue,
         providerAgentTranslationQueue,
         providerAgentQaQueue,
+        providerAgentCommentQueue,
       }),
     )
     .route(
@@ -81,6 +87,7 @@ export function createApp(options: CreateAppOptions = {}) {
         jobQueue,
         providerAgentTranslationQueue,
         providerAgentQaQueue,
+        providerAgentCommentQueue,
       }),
     )
     .route("/v1", createPublicApiRoutes({ ...options, jobQueue }))
@@ -113,6 +120,7 @@ function createOrgScopedAppRoutes(
     jobQueue: JobQueue<TranslationJobEventData>;
     providerAgentTranslationQueue: ProviderAgentTranslationQueue;
     providerAgentQaQueue: ProviderAgentQaQueue;
+    providerAgentCommentQueue: ProviderAgentCommentQueue;
   },
 ) {
   return new Hono()
@@ -125,6 +133,7 @@ function createOrgScopedAppRoutes(
         jobQueue: options.jobQueue,
         providerAgentTranslationQueue: options.providerAgentTranslationQueue,
         providerAgentQaQueue: options.providerAgentQaQueue,
+        providerAgentCommentQueue: options.providerAgentCommentQueue,
       }),
     )
     .route("/provider-credential", createProviderCredentialRoutes())

--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
@@ -21,6 +21,7 @@ import {
 import { inferSupportedFileTranslationFileFormat } from "@/lib/translation/file-formats";
 import type {
   JobQueue,
+  ProviderAgentCommentQueue,
   ProviderAgentQaQueue,
   ProviderAgentTranslationQueue,
   TranslationJobEventData,
@@ -76,6 +77,7 @@ type CreateWorkspaceJobRoutesOptions = {
   jobQueue: JobQueue<TranslationJobEventData>;
   providerAgentTranslationQueue: ProviderAgentTranslationQueue;
   providerAgentQaQueue: ProviderAgentQaQueue;
+  providerAgentCommentQueue: ProviderAgentCommentQueue;
 };
 
 const providerQaAgentActions = new Set(["review_with_agent", "run_qa_checks"]);
@@ -894,6 +896,30 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
               c,
               "agent_run_queue_unavailable",
               "Agent QA queue is unavailable",
+            );
+          }
+        }
+
+        if (payload.action === "leave_provider_comment") {
+          try {
+            await options.providerAgentCommentQueue.enqueue({
+              agentRunId: agentRun.id,
+              organizationId,
+            });
+          } catch (error) {
+            await failAgentRun({
+              runId: agentRun.id,
+              organizationId,
+              outputSummary: { code: "agent_run_queue_unavailable" },
+              warnings: [
+                error instanceof Error ? error.message : "agent comment queue unavailable",
+              ],
+            });
+
+            return serviceUnavailableResponse(
+              c,
+              "agent_run_queue_unavailable",
+              "Agent comment queue is unavailable",
             );
           }
         }

--- a/apps/hyperlocalise-web/src/api/routes/project/job.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.test.ts
@@ -10,6 +10,7 @@ import { createApp } from "@/api/app";
 import { db, schema } from "@/lib/database";
 import type {
   JobQueue,
+  ProviderAgentCommentQueue,
   ProviderAgentQaQueue,
   ProviderAgentTranslationQueue,
   TranslationJobEventData,
@@ -67,11 +68,20 @@ function createInlineTestProviderAgentQaQueue(): ProviderAgentQaQueue {
   };
 }
 
+function createInlineTestProviderAgentCommentQueue(): ProviderAgentCommentQueue {
+  return {
+    async enqueue(event) {
+      return { ids: [event.agentRunId] };
+    },
+  };
+}
+
 const client = testClient(
   createApp({
     jobQueue: createInlineTestJobQueue(),
     providerAgentTranslationQueue: createInlineTestProviderAgentTranslationQueue(),
     providerAgentQaQueue: createInlineTestProviderAgentQaQueue(),
+    providerAgentCommentQueue: createInlineTestProviderAgentCommentQueue(),
   }),
 );
 const appClient = client;
@@ -1567,6 +1577,156 @@ describe("jobRoutes", () => {
         status: "failed",
         outputSummary: { code: "agent_run_queue_unavailable" },
         warnings: ["qa queue down"],
+      }),
+    ]);
+  });
+
+  it("creates comment_only agent runs for leave_provider_comment", async () => {
+    const identity = createWorkosIdentity();
+    const projectResponse = await createProjectViaApi(identity);
+    const project = ((await projectResponse.json()) as ProjectResponse).project;
+    const [organization] = await db
+      .select({ id: schema.organizations.id })
+      .from(schema.projects)
+      .innerJoin(schema.organizations, eq(schema.projects.organizationId, schema.organizations.id))
+      .where(eq(schema.projects.id, project.id))
+      .limit(1);
+
+    const externalJob = await upsertExternalJob({
+      organizationId: organization!.id,
+      projectId: project.id,
+      providerKind: "crowdin",
+      externalJobId: "crowdin-job-comment-agent",
+      externalStatus: "todo",
+      title: "Comment write-back copy",
+    });
+
+    const selectedFindings = [
+      {
+        checkType: "glossary_violation" as const,
+        severity: "warning" as const,
+        message: "Use approved term",
+        item: {
+          externalStringId: "hash-1",
+          key: "cta.label",
+          locale: "fr-FR",
+          field: "target" as const,
+        },
+      },
+    ];
+
+    const response = await client.api.orgs[":organizationSlug"].jobs[":jobId"]["agent-runs"].$post(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          jobId: externalJob.id,
+        },
+        json: {
+          action: "leave_provider_comment",
+          selectedFindings,
+        },
+      },
+      { headers: await authHeadersFor(identity) },
+    );
+
+    expect(response.status).toBe(201);
+    const body = (await response.json()) as {
+      agentRun: {
+        kind: string;
+        status: string;
+        inputSnapshot: Record<string, unknown>;
+      };
+    };
+    expect(body.agentRun).toMatchObject({
+      kind: "comment_only",
+      status: "queued",
+      inputSnapshot: expect.objectContaining({
+        action: "leave_provider_comment",
+        selectedFindings,
+      }),
+    });
+  });
+
+  it("marks the agent run failed when provider comment queueing fails", async () => {
+    const failingClient = testClient(
+      createApp({
+        jobQueue: createInlineTestJobQueue(),
+        providerAgentTranslationQueue: createInlineTestProviderAgentTranslationQueue(),
+        providerAgentQaQueue: createInlineTestProviderAgentQaQueue(),
+        providerAgentCommentQueue: {
+          async enqueue() {
+            throw new Error("comment queue down");
+          },
+        },
+      }),
+    );
+    const identity = createWorkosIdentity();
+    const projectResponse = await createProjectViaApi(identity);
+    const project = ((await projectResponse.json()) as ProjectResponse).project;
+    const [organization] = await db
+      .select({ id: schema.organizations.id })
+      .from(schema.projects)
+      .innerJoin(schema.organizations, eq(schema.projects.organizationId, schema.organizations.id))
+      .where(eq(schema.projects.id, project.id))
+      .limit(1);
+
+    const externalJob = await upsertExternalJob({
+      organizationId: organization!.id,
+      projectId: project.id,
+      providerKind: "crowdin",
+      externalJobId: "crowdin-job-comment-queue-fail",
+      externalStatus: "todo",
+      title: "Comment queue failure copy",
+    });
+
+    const response = await failingClient.api.orgs[":organizationSlug"].jobs[":jobId"][
+      "agent-runs"
+    ].$post(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          jobId: externalJob.id,
+        },
+        json: {
+          action: "leave_provider_comment",
+          selectedFindings: [
+            {
+              checkType: "glossary_violation",
+              severity: "warning",
+              message: "Use approved term",
+              item: {
+                externalStringId: "hash-1",
+                key: "cta.label",
+                locale: "fr-FR",
+                field: "target",
+              },
+            },
+          ],
+        },
+      },
+      { headers: await authHeadersFor(identity) },
+    );
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "agent_run_queue_unavailable",
+      message: expect.any(String),
+    });
+
+    const agentRuns = await db
+      .select({
+        status: schema.agentRuns.status,
+        outputSummary: schema.agentRuns.outputSummary,
+        warnings: schema.agentRuns.warnings,
+      })
+      .from(schema.agentRuns)
+      .where(eq(schema.agentRuns.hyperlocaliseJobId, externalJob.id));
+
+    expect(agentRuns).toEqual([
+      expect.objectContaining({
+        status: "failed",
+        outputSummary: { code: "agent_run_queue_unavailable" },
+        warnings: ["comment queue down"],
       }),
     ]);
   });

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-qa-findings-model.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-qa-findings-model.ts
@@ -1,10 +1,13 @@
 import { providerQaReportSchema } from "@/api/routes/project/job-qa.schema";
+import { buildFindingId } from "@/lib/providers/provider-job-qa/build-finding-id";
 import type {
   ProviderQaCheckType,
   ProviderQaFinding,
   ProviderQaReport,
   ProviderQaSeverity,
 } from "@/lib/providers/provider-job-qa/types";
+
+export { buildFindingId };
 
 export type { ProviderQaFinding, ProviderQaReport, ProviderQaCheckType, ProviderQaSeverity };
 
@@ -17,18 +20,6 @@ export type QaFindingGroup = {
   label: string;
   findings: QaFindingWithId[];
 };
-
-export function buildFindingId(finding: ProviderQaFinding): string {
-  const { externalStringId, key, locale, field } = finding.item;
-  return [
-    externalStringId,
-    key,
-    locale ?? "",
-    field ?? "",
-    finding.checkType,
-    finding.message,
-  ].join("|");
-}
 
 export function attachFindingIds(findings: ProviderQaFinding[]): QaFindingWithId[] {
   return findings.map((finding) => ({

--- a/apps/hyperlocalise-web/src/lib/providers/provider-agent-comment.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-agent-comment.ts
@@ -1,0 +1,424 @@
+import { and, eq } from "drizzle-orm";
+
+import { db, schema } from "@/lib/database";
+import { decryptProviderCredential } from "@/lib/security/provider-credential-crypto";
+
+import {
+  completeAgentRun,
+  failAgentRun,
+  getAgentRun,
+  listAgentRuns,
+  startAgentRun,
+} from "./agent-runs";
+import { getProviderCommentPusher } from "./provider-comment-pushers";
+import type {
+  ProviderCommentChangedItem,
+  ProviderQaFeedbackUpload,
+} from "./provider-feedback-types";
+import { buildFindingId } from "./provider-job-qa/build-finding-id";
+import type { ProviderQaFinding } from "./provider-job-qa/types";
+import type { ExternalTmsProviderKind } from "./organization-external-tms-provider-credentials";
+
+export type ProviderAgentCommentResult =
+  | {
+      ok: true;
+      agentRunId: string;
+      posted: number;
+      skipped: number;
+      failed: number;
+      alreadyCompleted?: boolean;
+    }
+  | {
+      ok: false;
+      agentRunId: string;
+      code: string;
+      message: string;
+    };
+
+function readProjectIdFromInputSnapshot(inputSnapshot: Record<string, unknown>): string | null {
+  const projectId = inputSnapshot.projectId;
+  return typeof projectId === "string" && projectId.length > 0 ? projectId : null;
+}
+
+function readSelectedFindings(inputSnapshot: Record<string, unknown>): ProviderQaFinding[] {
+  const selectedFindings = inputSnapshot.selectedFindings;
+  if (!Array.isArray(selectedFindings)) {
+    return [];
+  }
+
+  return selectedFindings.filter((finding): finding is ProviderQaFinding => {
+    if (!finding || typeof finding !== "object") {
+      return false;
+    }
+
+    const candidate = finding as ProviderQaFinding;
+    return (
+      typeof candidate.checkType === "string" &&
+      typeof candidate.severity === "string" &&
+      typeof candidate.message === "string" &&
+      typeof candidate.item?.externalStringId === "string" &&
+      typeof candidate.item?.key === "string"
+    );
+  });
+}
+
+function readOutputSummaryNumber(outputSummary: Record<string, unknown>, key: string): number {
+  const value = outputSummary[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function isProviderCommentChangedItem(
+  item: Record<string, unknown>,
+): item is ProviderCommentChangedItem {
+  return item.type === "provider_comment" && typeof item.findingId === "string";
+}
+
+function indexKnownExternalIdsFromChangedItems(
+  changedItems: Record<string, unknown>[],
+): Map<string, { issueUid: string; commentUid?: string | null }> {
+  const map = new Map<string, { issueUid: string; commentUid?: string | null }>();
+
+  for (const item of changedItems) {
+    if (!isProviderCommentChangedItem(item)) {
+      continue;
+    }
+
+    if (!item.externalIssueUid) {
+      continue;
+    }
+
+    map.set(item.findingId, {
+      issueUid: item.externalIssueUid,
+      commentUid: item.externalCommentUid ?? null,
+    });
+  }
+
+  return map;
+}
+
+async function loadKnownProviderCommentExternalIds(input: {
+  organizationId: string;
+  hyperlocaliseJobId: string;
+  currentRunId: string;
+  currentChangedItems: Record<string, unknown>[];
+}) {
+  const known = indexKnownExternalIdsFromChangedItems(input.currentChangedItems);
+
+  const priorRuns = await listAgentRuns({
+    organizationId: input.organizationId,
+    hyperlocaliseJobId: input.hyperlocaliseJobId,
+    kind: "comment_only",
+    status: "succeeded",
+    limit: 100,
+  });
+
+  for (const run of priorRuns) {
+    if (run.id === input.currentRunId) {
+      continue;
+    }
+
+    const items = Array.isArray(run.changedItems)
+      ? (run.changedItems as Record<string, unknown>[])
+      : [];
+
+    for (const [findingId, external] of indexKnownExternalIdsFromChangedItems(items)) {
+      if (!known.has(findingId)) {
+        known.set(findingId, external);
+      }
+    }
+  }
+
+  return known;
+}
+
+async function getExternalTmsProject(input: {
+  organizationId: string;
+  projectId: string;
+  providerKind: ExternalTmsProviderKind;
+}) {
+  const [project] = await db
+    .select()
+    .from(schema.projects)
+    .where(
+      and(
+        eq(schema.projects.id, input.projectId),
+        eq(schema.projects.organizationId, input.organizationId),
+        eq(schema.projects.externalProviderKind, input.providerKind),
+        eq(schema.projects.source, "external_tms"),
+      ),
+    )
+    .limit(1);
+
+  return project ?? null;
+}
+
+async function getExternalTmsCredential(input: {
+  organizationId: string;
+  providerKind: ExternalTmsProviderKind;
+  credentialId: string | null;
+}) {
+  if (!input.credentialId) {
+    return null;
+  }
+
+  const [credential] = await db
+    .select()
+    .from(schema.organizationExternalTmsProviderCredentials)
+    .where(
+      and(
+        eq(schema.organizationExternalTmsProviderCredentials.organizationId, input.organizationId),
+        eq(schema.organizationExternalTmsProviderCredentials.providerKind, input.providerKind),
+        eq(schema.organizationExternalTmsProviderCredentials.id, input.credentialId),
+      ),
+    )
+    .limit(1);
+
+  return credential ?? null;
+}
+
+export async function executeProviderAgentComment(input: {
+  agentRunId: string;
+  organizationId: string;
+}): Promise<ProviderAgentCommentResult> {
+  const run = await getAgentRun({
+    runId: input.agentRunId,
+    organizationId: input.organizationId,
+  });
+
+  if (!run) {
+    return {
+      ok: false,
+      agentRunId: input.agentRunId,
+      code: "agent_run_not_found",
+      message: "Agent run not found",
+    };
+  }
+
+  if (run.kind !== "comment_only") {
+    return {
+      ok: false,
+      agentRunId: input.agentRunId,
+      code: "unsupported_agent_run_kind",
+      message: `Agent run kind ${run.kind} is not supported for provider comments`,
+    };
+  }
+
+  if (run.status === "succeeded") {
+    const outputSummary = run.outputSummary ?? {};
+    return {
+      ok: true,
+      agentRunId: input.agentRunId,
+      posted: readOutputSummaryNumber(outputSummary, "posted"),
+      skipped: readOutputSummaryNumber(outputSummary, "skipped"),
+      failed: readOutputSummaryNumber(outputSummary, "failed"),
+      alreadyCompleted: true,
+    };
+  }
+
+  if (run.status === "failed" || run.status === "cancelled") {
+    return {
+      ok: false,
+      agentRunId: input.agentRunId,
+      code: run.status === "failed" ? "agent_run_already_failed" : "agent_run_already_cancelled",
+      message: `Agent run is ${run.status}, expected queued or running`,
+    };
+  }
+
+  const projectId = readProjectIdFromInputSnapshot(run.inputSnapshot);
+  if (!projectId) {
+    await failAgentRun({
+      runId: run.id,
+      organizationId: input.organizationId,
+      outputSummary: { code: "missing_project_id" },
+      warnings: ["Agent run input snapshot is missing projectId"],
+    });
+
+    return {
+      ok: false,
+      agentRunId: input.agentRunId,
+      code: "missing_project_id",
+      message: "Agent run input snapshot is missing projectId",
+    };
+  }
+
+  const selectedFindings = readSelectedFindings(run.inputSnapshot);
+  if (selectedFindings.length === 0) {
+    await failAgentRun({
+      runId: run.id,
+      organizationId: input.organizationId,
+      outputSummary: { code: "missing_selected_findings" },
+      warnings: ["No QA findings were selected for provider comment write-back"],
+    });
+
+    return {
+      ok: false,
+      agentRunId: input.agentRunId,
+      code: "missing_selected_findings",
+      message: "No QA findings were selected for provider comment write-back",
+    };
+  }
+
+  const pushComments = getProviderCommentPusher(run.providerKind);
+  if (!pushComments) {
+    await failAgentRun({
+      runId: run.id,
+      organizationId: input.organizationId,
+      outputSummary: {
+        code: "unsupported_provider_comment_push",
+        providerKind: run.providerKind,
+      },
+      warnings: [`Provider ${run.providerKind} does not support comment write-back yet`],
+    });
+
+    return {
+      ok: false,
+      agentRunId: input.agentRunId,
+      code: "unsupported_provider_comment_push",
+      message: `Provider ${run.providerKind} does not support comment write-back yet`,
+    };
+  }
+
+  const project = await getExternalTmsProject({
+    organizationId: input.organizationId,
+    projectId,
+    providerKind: run.providerKind,
+  });
+
+  if (!project?.externalProjectId) {
+    await failAgentRun({
+      runId: run.id,
+      organizationId: input.organizationId,
+      outputSummary: { code: "external_tms_project_not_found" },
+      warnings: ["External TMS project was not found for provider comment write-back"],
+    });
+
+    return {
+      ok: false,
+      agentRunId: input.agentRunId,
+      code: "external_tms_project_not_found",
+      message: "External TMS project was not found for provider comment write-back",
+    };
+  }
+
+  const credential = await getExternalTmsCredential({
+    organizationId: input.organizationId,
+    providerKind: run.providerKind,
+    credentialId: project.externalProviderCredentialId,
+  });
+
+  if (!credential) {
+    await failAgentRun({
+      runId: run.id,
+      organizationId: input.organizationId,
+      outputSummary: { code: "provider_credential_not_found" },
+      warnings: ["Provider credential was not found for comment write-back"],
+    });
+
+    return {
+      ok: false,
+      agentRunId: input.agentRunId,
+      code: "provider_credential_not_found",
+      message: "Provider credential was not found for comment write-back",
+    };
+  }
+
+  if (run.status === "queued") {
+    try {
+      await startAgentRun({
+        runId: run.id,
+        organizationId: input.organizationId,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to start agent run";
+      await failAgentRun({
+        runId: run.id,
+        organizationId: input.organizationId,
+        outputSummary: { code: "agent_run_start_failed" },
+        warnings: [message],
+      });
+      return {
+        ok: false,
+        agentRunId: input.agentRunId,
+        code: "agent_run_start_failed",
+        message,
+      };
+    }
+  }
+
+  const currentChangedItems = Array.isArray(run.changedItems)
+    ? (run.changedItems as Record<string, unknown>[])
+    : [];
+
+  const knownExternalIds = await loadKnownProviderCommentExternalIds({
+    organizationId: input.organizationId,
+    hyperlocaliseJobId: run.hyperlocaliseJobId ?? "",
+    currentRunId: run.id,
+    currentChangedItems,
+  });
+
+  const feedback: ProviderQaFeedbackUpload[] = selectedFindings.map((finding) => ({
+    findingId: buildFindingId(finding),
+    finding,
+  }));
+
+  try {
+    const secretMaterial = decryptProviderCredential({
+      algorithm: credential.encryptionAlgorithm,
+      keyVersion: credential.keyVersion,
+      ciphertext: credential.ciphertext,
+      iv: credential.iv,
+      authTag: credential.authTag,
+    });
+
+    const pushResult = await pushComments({
+      organizationId: input.organizationId,
+      projectId: project.id,
+      providerKind: run.providerKind,
+      externalProjectId: project.externalProjectId,
+      externalJobId: run.externalJobId,
+      secretMaterial,
+      feedback,
+      knownExternalIds,
+    });
+
+    const warnings = pushResult.failures.map(
+      (failure) => `${failure.findingId}: ${failure.message}`,
+    );
+
+    await completeAgentRun({
+      runId: run.id,
+      organizationId: input.organizationId,
+      outputSummary: {
+        posted: pushResult.posted,
+        skipped: pushResult.skipped,
+        failed: pushResult.failed,
+        findingsRequested: feedback.length,
+      },
+      changedItems: pushResult.changedItems,
+      warnings,
+    });
+
+    return {
+      ok: true,
+      agentRunId: input.agentRunId,
+      posted: pushResult.posted,
+      skipped: pushResult.skipped,
+      failed: pushResult.failed,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Provider comment write-back failed";
+    await failAgentRun({
+      runId: run.id,
+      organizationId: input.organizationId,
+      outputSummary: { code: "provider_comment_push_failed" },
+      warnings: [message],
+    });
+
+    return {
+      ok: false,
+      agentRunId: input.agentRunId,
+      code: "provider_comment_push_failed",
+      message,
+    };
+  }
+}

--- a/apps/hyperlocalise-web/src/lib/providers/provider-agent-comment.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-agent-comment.ts
@@ -98,11 +98,15 @@ function indexKnownExternalIdsFromChangedItems(
 
 async function loadKnownProviderCommentExternalIds(input: {
   organizationId: string;
-  hyperlocaliseJobId: string;
+  hyperlocaliseJobId: string | null;
   currentRunId: string;
   currentChangedItems: Record<string, unknown>[];
 }) {
   const known = indexKnownExternalIdsFromChangedItems(input.currentChangedItems);
+
+  if (!input.hyperlocaliseJobId) {
+    return known;
+  }
 
   const priorRuns = await listAgentRuns({
     organizationId: input.organizationId,
@@ -351,7 +355,7 @@ export async function executeProviderAgentComment(input: {
 
   const knownExternalIds = await loadKnownProviderCommentExternalIds({
     organizationId: input.organizationId,
-    hyperlocaliseJobId: run.hyperlocaliseJobId ?? "",
+    hyperlocaliseJobId: run.hyperlocaliseJobId,
     currentRunId: run.id,
     currentChangedItems,
   });

--- a/apps/hyperlocalise-web/src/lib/providers/provider-comment-pushers.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-comment-pushers.ts
@@ -1,0 +1,15 @@
+import type { ExternalTmsCommentPusher } from "@/lib/providers/provider-feedback-types";
+import { pushSmartlingProviderComments } from "@/lib/providers/smartling/smartling-comment-pusher";
+
+import type { ExternalTmsProviderKind } from "./organization-external-tms-provider-credentials";
+
+export function getProviderCommentPusher(
+  providerKind: ExternalTmsProviderKind,
+): ExternalTmsCommentPusher | null {
+  switch (providerKind) {
+    case "smartling":
+      return pushSmartlingProviderComments;
+    default:
+      return null;
+  }
+}

--- a/apps/hyperlocalise-web/src/lib/providers/provider-feedback-types.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-feedback-types.ts
@@ -1,0 +1,35 @@
+import type { ProviderQaFinding } from "@/lib/providers/provider-job-qa/types";
+import type { ExternalTmsProviderKind } from "@/lib/providers/organization-external-tms-provider-credentials";
+
+export type ProviderQaFeedbackUpload = {
+  findingId: string;
+  finding: ProviderQaFinding;
+};
+
+export type ProviderCommentChangedItem = {
+  type: "provider_comment";
+  findingId: string;
+  status: "posted" | "skipped" | "failed";
+  externalIssueUid?: string | null;
+  externalCommentUid?: string | null;
+  hashcode?: string | null;
+  locale?: string | null;
+  message?: string | null;
+};
+
+export type ExternalTmsCommentPusher = (input: {
+  organizationId: string;
+  projectId: string;
+  providerKind: ExternalTmsProviderKind;
+  externalProjectId: string;
+  externalJobId: string;
+  secretMaterial: string;
+  feedback: ProviderQaFeedbackUpload[];
+  knownExternalIds: Map<string, { issueUid: string; commentUid?: string | null }>;
+}) => Promise<{
+  posted: number;
+  skipped: number;
+  failed: number;
+  changedItems: ProviderCommentChangedItem[];
+  failures: Array<{ findingId: string; message: string }>;
+}>;

--- a/apps/hyperlocalise-web/src/lib/providers/provider-job-qa/build-finding-id.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-job-qa/build-finding-id.ts
@@ -1,0 +1,13 @@
+import type { ProviderQaFinding } from "./types";
+
+export function buildFindingId(finding: ProviderQaFinding): string {
+  const { externalStringId, key, locale, field } = finding.item;
+  return [
+    externalStringId,
+    key,
+    locale ?? "",
+    field ?? "",
+    finding.checkType,
+    finding.message,
+  ].join("|");
+}

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-api.ts
@@ -13,6 +13,7 @@ const DEFAULT_PROJECTS_BASE_URL = "https://api.smartling.com/projects-api/v2";
 const DEFAULT_FILES_BASE_URL = "https://api.smartling.com/files-api/v2";
 const DEFAULT_STRINGS_BASE_URL = "https://api.smartling.com/strings-api/v2";
 const DEFAULT_JOBS_BASE_URL = "https://api.smartling.com/jobs-api/v3";
+const DEFAULT_ISSUES_BASE_URL = "https://api.smartling.com/issues-api/v2";
 const TOKEN_REFRESH_SKEW_MS = 60_000;
 const DEFAULT_PAGE_SIZE = 500;
 
@@ -24,6 +25,7 @@ export interface SmartlingApiClientOptions {
   filesBaseUrl?: string;
   stringsBaseUrl?: string;
   jobsBaseUrl?: string;
+  issuesBaseUrl?: string;
   fetchFn?: typeof fetch;
 }
 
@@ -138,6 +140,46 @@ export interface SmartlingAsyncProcessStatus {
   percentComplete?: number;
 }
 
+export interface SmartlingIssueStringReference {
+  hashcode: string;
+  localeId: string;
+}
+
+export interface SmartlingIssue {
+  issueUid: string;
+  issueText?: string | null;
+  issueTypeCode?: string | null;
+  issueSubTypeCode?: string | null;
+  issueSeverityLevelCode?: string | null;
+  issueStateCode?: string | null;
+  string?: SmartlingIssueStringReference | null;
+}
+
+export interface SmartlingIssueComment {
+  issueCommentUid: string;
+  commentText?: string | null;
+  createdDate?: string | null;
+  createdByUserUid?: string | null;
+}
+
+export interface SmartlingIssueTemplate {
+  string: SmartlingIssueStringReference;
+  issueTypeCode: string;
+  issueSubTypeCode?: string | null;
+  issueText: string;
+  issueSeverityLevelCode: string;
+}
+
+export interface SmartlingIssuesListFilter {
+  stringFilter?: {
+    hashcodes?: string[];
+    localeIds?: string[];
+  };
+  issueStateCodes?: string[];
+  offset?: number;
+  limit?: number;
+}
+
 type SmartlingEnvelope<T> = {
   response: {
     code: string;
@@ -186,6 +228,7 @@ export class SmartlingApiClient {
   private readonly filesBaseUrl: string;
   private readonly stringsBaseUrl: string;
   private readonly jobsBaseUrl: string;
+  private readonly issuesBaseUrl: string;
   private readonly fetchFn: typeof fetch;
   private tokens: SmartlingAuthTokens | null = null;
 
@@ -214,6 +257,10 @@ export class SmartlingApiClient {
     this.jobsBaseUrl = normalizeServiceBaseUrl(
       options.jobsBaseUrl ?? deriveServiceBaseUrl(this.authBaseUrl, "jobs"),
       DEFAULT_JOBS_BASE_URL,
+    );
+    this.issuesBaseUrl = normalizeServiceBaseUrl(
+      options.issuesBaseUrl ?? deriveServiceBaseUrl(this.authBaseUrl, "issues"),
+      DEFAULT_ISSUES_BASE_URL,
     );
     this.fetchFn = options.fetchFn ?? fetch;
   }
@@ -598,6 +645,79 @@ export class SmartlingApiClient {
     );
   }
 
+  async listIssues(
+    projectId: string,
+    filter: SmartlingIssuesListFilter,
+  ): Promise<SmartlingIssue[]> {
+    const token = await this.getAccessToken();
+    const issues: SmartlingIssue[] = [];
+    let offset = filter.offset ?? 0;
+    const limit = filter.limit ?? DEFAULT_PAGE_SIZE;
+
+    while (true) {
+      const data = await this.post<{ items?: SmartlingIssue[]; totalCount?: number }>(
+        `${this.issuesBaseUrl}/projects/${encodeURIComponent(projectId)}/issues/list`,
+        token,
+        {
+          ...filter,
+          offset,
+          limit,
+        },
+      );
+
+      const page = data.items ?? [];
+      issues.push(...page);
+      offset += page.length;
+
+      if (page.length === 0) {
+        break;
+      }
+
+      const totalCount = data.totalCount;
+      if (typeof totalCount === "number") {
+        if (offset >= totalCount) {
+          break;
+        }
+      } else if (page.length < limit) {
+        break;
+      }
+    }
+
+    return issues;
+  }
+
+  async createIssue(projectId: string, template: SmartlingIssueTemplate): Promise<SmartlingIssue> {
+    const token = await this.getAccessToken();
+    return this.post<SmartlingIssue>(
+      `${this.issuesBaseUrl}/projects/${encodeURIComponent(projectId)}/issues`,
+      token,
+      template,
+    );
+  }
+
+  async createIssueComment(
+    projectId: string,
+    issueUid: string,
+    commentText: string,
+  ): Promise<SmartlingIssueComment> {
+    const token = await this.getAccessToken();
+    return this.post<SmartlingIssueComment>(
+      `${this.issuesBaseUrl}/projects/${encodeURIComponent(projectId)}/issues/${encodeURIComponent(issueUid)}/comments`,
+      token,
+      { commentText },
+    );
+  }
+
+  async listIssueComments(projectId: string, issueUid: string): Promise<SmartlingIssueComment[]> {
+    const token = await this.getAccessToken();
+    const data = await this.get<{ items?: SmartlingIssueComment[] }>(
+      `${this.issuesBaseUrl}/projects/${encodeURIComponent(projectId)}/issues/${encodeURIComponent(issueUid)}/comments`,
+      token,
+    );
+
+    return data.items ?? [];
+  }
+
   private async get<T>(url: string, token: string): Promise<T> {
     const response = await this.fetchFn(url, {
       method: "GET",
@@ -639,7 +759,7 @@ export class SmartlingApiClient {
 
 export function deriveServiceBaseUrl(
   authBaseUrl: string,
-  service: "accounts" | "projects" | "files" | "strings" | "jobs",
+  service: "accounts" | "projects" | "files" | "strings" | "jobs" | "issues",
 ) {
   const normalized = normalizeServiceBaseUrl(authBaseUrl, authBaseUrl);
   if (normalized.includes("/auth-api/")) {
@@ -658,6 +778,8 @@ export function deriveServiceBaseUrl(
       return DEFAULT_STRINGS_BASE_URL;
     case "jobs":
       return DEFAULT_JOBS_BASE_URL;
+    case "issues":
+      return DEFAULT_ISSUES_BASE_URL;
   }
 }
 

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-api.ts
@@ -155,13 +155,6 @@ export interface SmartlingIssue {
   string?: SmartlingIssueStringReference | null;
 }
 
-export interface SmartlingIssueComment {
-  issueCommentUid: string;
-  commentText?: string | null;
-  createdDate?: string | null;
-  createdByUserUid?: string | null;
-}
-
 export interface SmartlingIssueTemplate {
   string: SmartlingIssueStringReference;
   issueTypeCode: string;
@@ -693,29 +686,6 @@ export class SmartlingApiClient {
       token,
       template,
     );
-  }
-
-  async createIssueComment(
-    projectId: string,
-    issueUid: string,
-    commentText: string,
-  ): Promise<SmartlingIssueComment> {
-    const token = await this.getAccessToken();
-    return this.post<SmartlingIssueComment>(
-      `${this.issuesBaseUrl}/projects/${encodeURIComponent(projectId)}/issues/${encodeURIComponent(issueUid)}/comments`,
-      token,
-      { commentText },
-    );
-  }
-
-  async listIssueComments(projectId: string, issueUid: string): Promise<SmartlingIssueComment[]> {
-    const token = await this.getAccessToken();
-    const data = await this.get<{ items?: SmartlingIssueComment[] }>(
-      `${this.issuesBaseUrl}/projects/${encodeURIComponent(projectId)}/issues/${encodeURIComponent(issueUid)}/comments`,
-      token,
-    );
-
-    return data.items ?? [];
   }
 
   private async get<T>(url: string, token: string): Promise<T> {

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-comment-pusher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-comment-pusher.test.ts
@@ -315,4 +315,130 @@ describe("pushSmartlingProviderComments", () => {
       findingId,
     });
   });
+
+  it("records validation failures in changedItems before posting", async () => {
+    const finding = sampleFinding({
+      item: { externalStringId: "  ", key: "k1", locale: "fr-FR" },
+    });
+    const findingId = buildFindingId(finding);
+    const fetchMock = vi.fn();
+
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await pushSmartlingProviderComments({
+      organizationId: "org_1",
+      projectId: "proj_1",
+      providerKind: "smartling",
+      externalProjectId: "proj-1",
+      externalJobId: "job-1",
+      secretMaterial: "user:secret:acct-1",
+      feedback: [{ findingId, finding }],
+      knownExternalIds: new Map(),
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.failed).toBe(1);
+    expect(result.changedItems).toEqual([
+      expect.objectContaining({
+        findingId,
+        status: "failed",
+        message: "smartling_comment_missing_hashcode",
+      }),
+    ]);
+  });
+
+  it("does not infer a default locale when feedback spans multiple locales", async () => {
+    const frFinding = sampleFinding({
+      item: { externalStringId: "hash-fr", key: "k1", locale: "fr-FR" },
+    });
+    const deFinding = sampleFinding({
+      item: { externalStringId: "hash-de", key: "k2", locale: "de-DE" },
+    });
+    const missingLocale = sampleFinding({
+      item: { externalStringId: "hash-missing", key: "k3" },
+    });
+    const missingLocaleId = buildFindingId(missingLocale);
+    let createIssueCalls = 0;
+
+    const fetchMock = vi.fn(async (url, init) => {
+      const path = String(url);
+      const method = init?.method ?? "GET";
+
+      if (path.endsWith("/authenticate") && method === "POST") {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: { accessToken: "access-token", expiresIn: 3600 },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.endsWith("/issues/list") && method === "POST") {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: { items: [], totalCount: 0 },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.endsWith("/issues") && method === "POST" && !path.endsWith("/issues/list")) {
+        createIssueCalls += 1;
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: { issueUid: `issue-${createIssueCalls}` },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response("Not Found", { status: 404 });
+    });
+
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await pushSmartlingProviderComments({
+      organizationId: "org_1",
+      projectId: "proj_1",
+      providerKind: "smartling",
+      externalProjectId: "proj-1",
+      externalJobId: "job-1",
+      secretMaterial: "user:secret:acct-1",
+      feedback: [
+        { findingId: buildFindingId(frFinding), finding: frFinding },
+        { findingId: buildFindingId(deFinding), finding: deFinding },
+        { findingId: missingLocaleId, finding: missingLocale },
+      ],
+      knownExternalIds: new Map(),
+    });
+
+    expect(createIssueCalls).toBe(2);
+    expect(result.posted).toBe(2);
+    expect(result.failures).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          findingId: missingLocaleId,
+          message: "smartling_comment_missing_locale",
+        }),
+      ]),
+    );
+    expect(result.changedItems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          findingId: missingLocaleId,
+          status: "failed",
+          message: "smartling_comment_missing_locale",
+        }),
+      ]),
+    );
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-comment-pusher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-comment-pusher.test.ts
@@ -1,0 +1,318 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { buildFindingId } from "@/lib/providers/provider-job-qa/build-finding-id";
+import type { ProviderQaFinding } from "@/lib/providers/provider-job-qa/types";
+
+import { buildHyperlocaliseFindingMarker } from "./smartling-comment-write-back";
+import { pushSmartlingProviderComments } from "./smartling-comment-pusher";
+
+function sampleFinding(overrides?: Partial<ProviderQaFinding>): ProviderQaFinding {
+  return {
+    checkType: "glossary_violation",
+    severity: "error",
+    message: "Forbidden term",
+    item: {
+      externalStringId: "hash-abc",
+      key: "welcome.title",
+      locale: "fr-FR",
+      field: "target",
+    },
+    ...overrides,
+  };
+}
+
+describe("pushSmartlingProviderComments", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("creates Smartling issues for new findings", async () => {
+    const finding = sampleFinding();
+    const findingId = buildFindingId(finding);
+    let createIssueCalls = 0;
+
+    const fetchMock = vi.fn(async (url, init) => {
+      const path = String(url);
+      const method = init?.method ?? "GET";
+
+      if (path.endsWith("/authenticate") && method === "POST") {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: { accessToken: "access-token", expiresIn: 3600 },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.endsWith("/issues/list") && method === "POST") {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: { items: [], totalCount: 0 },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.endsWith("/issues") && method === "POST" && !path.endsWith("/issues/list")) {
+        createIssueCalls += 1;
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: {
+                issueUid: "issue-new-1",
+                issueText: buildHyperlocaliseFindingMarker(findingId),
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response("Not Found", { status: 404 });
+    });
+
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await pushSmartlingProviderComments({
+      organizationId: "org_1",
+      projectId: "proj_1",
+      providerKind: "smartling",
+      externalProjectId: "proj-1",
+      externalJobId: "job-1",
+      secretMaterial: "user:secret:acct-1",
+      feedback: [{ findingId, finding }],
+      knownExternalIds: new Map(),
+    });
+
+    expect(createIssueCalls).toBe(1);
+    expect(result.posted).toBe(1);
+    expect(result.skipped).toBe(0);
+    expect(result.failed).toBe(0);
+    expect(result.changedItems).toEqual([
+      expect.objectContaining({
+        type: "provider_comment",
+        findingId,
+        status: "posted",
+        externalIssueUid: "issue-new-1",
+      }),
+    ]);
+  });
+
+  it("skips creation when a known external issue id already exists", async () => {
+    const finding = sampleFinding();
+    const findingId = buildFindingId(finding);
+    let createIssueCalls = 0;
+
+    const fetchMock = vi.fn(async (url, init) => {
+      const path = String(url);
+      const method = init?.method ?? "GET";
+
+      if (path.endsWith("/authenticate") && method === "POST") {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: { accessToken: "access-token", expiresIn: 3600 },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.endsWith("/issues/list") && method === "POST") {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: { items: [], totalCount: 0 },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.endsWith("/issues") && method === "POST" && !path.endsWith("/issues/list")) {
+        createIssueCalls += 1;
+        return new Response("unexpected create", { status: 500 });
+      }
+
+      return new Response("Not Found", { status: 404 });
+    });
+
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await pushSmartlingProviderComments({
+      organizationId: "org_1",
+      projectId: "proj_1",
+      providerKind: "smartling",
+      externalProjectId: "proj-1",
+      externalJobId: "job-1",
+      secretMaterial: "user:secret:acct-1",
+      feedback: [{ findingId, finding }],
+      knownExternalIds: new Map([[findingId, { issueUid: "issue-existing-1" }]]),
+    });
+
+    expect(createIssueCalls).toBe(0);
+    expect(result.posted).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.changedItems[0]).toMatchObject({
+      status: "skipped",
+      externalIssueUid: "issue-existing-1",
+      message: "provider_comment_already_exists",
+    });
+  });
+
+  it("skips creation when Smartling already has a matching marker issue", async () => {
+    const finding = sampleFinding();
+    const findingId = buildFindingId(finding);
+    let createIssueCalls = 0;
+
+    const fetchMock = vi.fn(async (url, init) => {
+      const path = String(url);
+      const method = init?.method ?? "GET";
+
+      if (path.endsWith("/authenticate") && method === "POST") {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: { accessToken: "access-token", expiresIn: 3600 },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.endsWith("/issues/list") && method === "POST") {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: {
+                items: [
+                  {
+                    issueUid: "issue-remote-1",
+                    issueText: buildHyperlocaliseFindingMarker(findingId),
+                  },
+                ],
+                totalCount: 1,
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.endsWith("/issues") && method === "POST" && !path.endsWith("/issues/list")) {
+        createIssueCalls += 1;
+        return new Response("unexpected create", { status: 500 });
+      }
+
+      return new Response("Not Found", { status: 404 });
+    });
+
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await pushSmartlingProviderComments({
+      organizationId: "org_1",
+      projectId: "proj_1",
+      providerKind: "smartling",
+      externalProjectId: "proj-1",
+      externalJobId: "job-1",
+      secretMaterial: "user:secret:acct-1",
+      feedback: [{ findingId, finding }],
+      knownExternalIds: new Map(),
+    });
+
+    expect(createIssueCalls).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.changedItems[0]).toMatchObject({
+      status: "skipped",
+      externalIssueUid: "issue-remote-1",
+    });
+  });
+
+  it("records per-finding failures when issue creation fails", async () => {
+    const finding = sampleFinding();
+    const findingId = buildFindingId(finding);
+
+    const fetchMock = vi.fn(async (url, init) => {
+      const path = String(url);
+      const method = init?.method ?? "GET";
+
+      if (path.endsWith("/authenticate") && method === "POST") {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: { accessToken: "access-token", expiresIn: 3600 },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.endsWith("/issues/list") && method === "POST") {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: { items: [], totalCount: 0 },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.endsWith("/issues") && method === "POST" && !path.endsWith("/issues/list")) {
+        return new Response(
+          JSON.stringify({
+            response: { code: "VALIDATION_ERROR", errors: [{ message: "invalid issue type" }] },
+          }),
+          { status: 400 },
+        );
+      }
+
+      return new Response("Not Found", { status: 404 });
+    });
+
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await pushSmartlingProviderComments({
+      organizationId: "org_1",
+      projectId: "proj_1",
+      providerKind: "smartling",
+      externalProjectId: "proj-1",
+      externalJobId: "job-1",
+      secretMaterial: "user:secret:acct-1",
+      feedback: [{ findingId, finding }],
+      knownExternalIds: new Map(),
+    });
+
+    expect(result.posted).toBe(0);
+    expect(result.failed).toBe(1);
+    expect(result.failures).toEqual([
+      expect.objectContaining({
+        findingId,
+        message: expect.any(String),
+      }),
+    ]);
+    expect(result.changedItems[0]).toMatchObject({
+      status: "failed",
+      findingId,
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-comment-pusher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-comment-pusher.test.ts
@@ -175,6 +175,74 @@ describe("pushSmartlingProviderComments", () => {
     });
   });
 
+  it("requests only OPENED issues when checking remote duplicates", async () => {
+    const finding = sampleFinding();
+    const findingId = buildFindingId(finding);
+
+    const fetchMock = vi.fn(async (url, init) => {
+      const path = String(url);
+      const method = init?.method ?? "GET";
+
+      if (path.endsWith("/authenticate") && method === "POST") {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: { accessToken: "access-token", expiresIn: 3600 },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.endsWith("/issues/list") && method === "POST") {
+        const body = JSON.parse(String(init?.body ?? "{}")) as {
+          issueStateCodes?: string[];
+        };
+        expect(body.issueStateCodes).toEqual(["OPENED"]);
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: { items: [], totalCount: 0 },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.endsWith("/issues") && method === "POST" && !path.endsWith("/issues/list")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: { issueUid: "issue-new-1" },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response("Not Found", { status: 404 });
+    });
+
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await pushSmartlingProviderComments({
+      organizationId: "org_1",
+      projectId: "proj_1",
+      providerKind: "smartling",
+      externalProjectId: "proj-1",
+      externalJobId: "job-1",
+      secretMaterial: "user:secret:acct-1",
+      feedback: [{ findingId, finding }],
+      knownExternalIds: new Map(),
+    });
+
+    expect(result.posted).toBe(1);
+    expect(result.skipped).toBe(0);
+  });
+
   it("skips creation when Smartling already has a matching marker issue", async () => {
     const finding = sampleFinding();
     const findingId = buildFindingId(finding);

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-comment-pusher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-comment-pusher.ts
@@ -21,8 +21,10 @@ export const pushSmartlingProviderComments: ExternalTmsCommentPusher = async ({
     throw new Error("invalid_smartling_project_id");
   }
 
-  const defaultLocaleId =
-    feedback.find((item) => item.finding.item.locale?.trim())?.finding.item.locale?.trim() ?? null;
+  const locales = new Set(
+    feedback.map((item) => item.finding.item.locale?.trim()).filter(Boolean),
+  );
+  const defaultLocaleId = locales.size === 1 ? ([...locales][0] ?? null) : null;
 
   const { entries, failures: validationFailures } = buildSmartlingCommentWriteBackEntries({
     findings: feedback.map((item) => item.finding),
@@ -35,6 +37,22 @@ export const pushSmartlingProviderComments: ExternalTmsCommentPusher = async ({
   let posted = 0;
   let skipped = 0;
   let failed = validationFailures.length;
+
+  const feedbackByFindingId = new Map(
+    feedback.map((item) => [item.findingId || buildFindingId(item.finding), item]),
+  );
+
+  for (const failure of validationFailures) {
+    const item = feedbackByFindingId.get(failure.findingId);
+    changedItems.push({
+      type: "provider_comment",
+      findingId: failure.findingId,
+      status: "failed",
+      hashcode: item?.finding.item.externalStringId?.trim() || null,
+      locale: item?.finding.item.locale?.trim() || null,
+      message: failure.message,
+    });
+  }
 
   const hashcodes = [
     ...new Set(

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-comment-pusher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-comment-pusher.ts
@@ -1,0 +1,147 @@
+import type { ExternalTmsCommentPusher } from "@/lib/providers/provider-feedback-types";
+import { buildFindingId } from "@/lib/providers/provider-job-qa/build-finding-id";
+
+import {
+  buildSmartlingCommentWriteBackEntries,
+  parseHyperlocaliseFindingMarker,
+} from "./smartling-comment-write-back";
+import { SmartlingApiClient, SmartlingApiError } from "./smartling-api";
+import { mapSmartlingFetcherError } from "./smartling-errors";
+
+export const pushSmartlingProviderComments: ExternalTmsCommentPusher = async ({
+  externalProjectId,
+  secretMaterial,
+  feedback,
+  knownExternalIds,
+}) => {
+  const client = new SmartlingApiClient({ credentials: secretMaterial });
+  const projectId = externalProjectId.trim();
+
+  if (!projectId) {
+    throw new Error("invalid_smartling_project_id");
+  }
+
+  const defaultLocaleId =
+    feedback.find((item) => item.finding.item.locale?.trim())?.finding.item.locale?.trim() ?? null;
+
+  const { entries, failures: validationFailures } = buildSmartlingCommentWriteBackEntries({
+    findings: feedback.map((item) => item.finding),
+    defaultLocaleId,
+  });
+
+  const entryByFindingId = new Map(entries.map((entry) => [entry.findingId, entry]));
+  const changedItems: Awaited<ReturnType<ExternalTmsCommentPusher>>["changedItems"] = [];
+  const failures = [...validationFailures];
+  let posted = 0;
+  let skipped = 0;
+  let failed = validationFailures.length;
+
+  const hashcodes = [
+    ...new Set(
+      entries
+        .map((entry) => entry.issueTemplate.string.hashcode)
+        .filter((hashcode) => hashcode.length > 0),
+    ),
+  ];
+
+  const remoteIssueIdsByFindingId = new Map<string, string>();
+  if (hashcodes.length > 0) {
+    try {
+      const remoteIssues = await client.listIssues(projectId, {
+        stringFilter: { hashcodes },
+        limit: 500,
+      });
+
+      for (const issue of remoteIssues) {
+        const findingId = parseHyperlocaliseFindingMarker(issue.issueText);
+        if (findingId && issue.issueUid) {
+          remoteIssueIdsByFindingId.set(findingId, issue.issueUid);
+        }
+      }
+    } catch (error) {
+      if (error instanceof SmartlingApiError && error.status === 401) {
+        throw new Error("smartling_auth_invalid");
+      }
+      throw mapSmartlingFetcherError(error);
+    }
+  }
+
+  for (const item of feedback) {
+    const findingId = item.findingId || buildFindingId(item.finding);
+    const entry = entryByFindingId.get(findingId);
+    if (!entry) {
+      continue;
+    }
+
+    const known = knownExternalIds.get(findingId) ?? null;
+    const remoteIssueUid = remoteIssueIdsByFindingId.get(findingId) ?? null;
+    const existingIssueUid = known?.issueUid ?? remoteIssueUid;
+
+    if (existingIssueUid) {
+      skipped += 1;
+      changedItems.push({
+        type: "provider_comment",
+        findingId,
+        status: "skipped",
+        externalIssueUid: existingIssueUid,
+        externalCommentUid: known?.commentUid ?? null,
+        hashcode: entry.issueTemplate.string.hashcode,
+        locale: entry.issueTemplate.string.localeId,
+        message: "provider_comment_already_exists",
+      });
+      continue;
+    }
+
+    try {
+      const issue = await client.createIssue(projectId, entry.issueTemplate);
+      if (!issue.issueUid) {
+        failed += 1;
+        failures.push({
+          findingId,
+          message: "smartling_issue_missing_uid",
+        });
+        changedItems.push({
+          type: "provider_comment",
+          findingId,
+          status: "failed",
+          hashcode: entry.issueTemplate.string.hashcode,
+          locale: entry.issueTemplate.string.localeId,
+          message: "smartling_issue_missing_uid",
+        });
+        continue;
+      }
+
+      posted += 1;
+      changedItems.push({
+        type: "provider_comment",
+        findingId,
+        status: "posted",
+        externalIssueUid: issue.issueUid,
+        externalCommentUid: null,
+        hashcode: entry.issueTemplate.string.hashcode,
+        locale: entry.issueTemplate.string.localeId,
+      });
+    } catch (error) {
+      failed += 1;
+      const message =
+        error instanceof Error ? error.message : "smartling_provider_comment_create_failed";
+      failures.push({ findingId, message });
+      changedItems.push({
+        type: "provider_comment",
+        findingId,
+        status: "failed",
+        hashcode: entry.issueTemplate.string.hashcode,
+        locale: entry.issueTemplate.string.localeId,
+        message,
+      });
+    }
+  }
+
+  return {
+    posted,
+    skipped,
+    failed,
+    changedItems,
+    failures,
+  };
+};

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-comment-pusher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-comment-pusher.ts
@@ -21,9 +21,7 @@ export const pushSmartlingProviderComments: ExternalTmsCommentPusher = async ({
     throw new Error("invalid_smartling_project_id");
   }
 
-  const locales = new Set(
-    feedback.map((item) => item.finding.item.locale?.trim()).filter(Boolean),
-  );
+  const locales = new Set(feedback.map((item) => item.finding.item.locale?.trim()).filter(Boolean));
   const defaultLocaleId = locales.size === 1 ? ([...locales][0] ?? null) : null;
 
   const { entries, failures: validationFailures } = buildSmartlingCommentWriteBackEntries({
@@ -67,6 +65,7 @@ export const pushSmartlingProviderComments: ExternalTmsCommentPusher = async ({
     try {
       const remoteIssues = await client.listIssues(projectId, {
         stringFilter: { hashcodes },
+        issueStateCodes: ["OPENED"],
         limit: 500,
       });
 

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-comment-write-back.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-comment-write-back.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { buildFindingId } from "@/lib/providers/provider-job-qa/build-finding-id";
+import type { ProviderQaFinding } from "@/lib/providers/provider-job-qa/types";
+
+import {
+  buildHyperlocaliseFindingMarker,
+  buildSmartlingCommentWriteBackEntries,
+  mapProviderSeverityToSmartling,
+  parseHyperlocaliseFindingMarker,
+} from "./smartling-comment-write-back";
+
+function sampleFinding(overrides?: Partial<ProviderQaFinding>): ProviderQaFinding {
+  return {
+    checkType: "glossary_violation",
+    severity: "warning",
+    message: "Term mismatch",
+    suggestedFix: "Use approved glossary term",
+    confidence: 0.92,
+    item: {
+      externalStringId: "hash-abc",
+      key: "welcome.title",
+      locale: "fr-FR",
+      field: "target",
+    },
+    ...overrides,
+  };
+}
+
+describe("smartling-comment-write-back", () => {
+  it("round-trips hyperlocalise finding markers in issue text", () => {
+    const findingId = "finding-123";
+    const marker = buildHyperlocaliseFindingMarker(findingId);
+
+    expect(marker).toBe("[hyperlocalise:finding=finding-123]");
+    expect(parseHyperlocaliseFindingMarker(marker)).toBe(findingId);
+    expect(parseHyperlocaliseFindingMarker("no marker here")).toBeNull();
+  });
+
+  it("maps provider severities to Smartling severity codes", () => {
+    expect(mapProviderSeverityToSmartling("error")).toBe("HIGH");
+    expect(mapProviderSeverityToSmartling("warning")).toBe("MEDIUM");
+    expect(mapProviderSeverityToSmartling("info")).toBe("LOW");
+  });
+
+  it("builds issue templates with markers and metadata", () => {
+    const finding = sampleFinding();
+    const { entries, failures } = buildSmartlingCommentWriteBackEntries({
+      findings: [finding],
+      defaultLocaleId: null,
+    });
+
+    expect(failures).toEqual([]);
+    expect(entries).toHaveLength(1);
+
+    const findingId = buildFindingId(finding);
+    expect(entries[0]?.findingId).toBe(findingId);
+    expect(entries[0]?.issueTemplate).toMatchObject({
+      string: { hashcode: "hash-abc", localeId: "fr-FR" },
+      issueTypeCode: "REVIEW",
+      issueSeverityLevelCode: "MEDIUM",
+    });
+    expect(entries[0]?.issueTemplate.issueText).toContain(
+      buildHyperlocaliseFindingMarker(findingId),
+    );
+    expect(entries[0]?.issueTemplate.issueText).toContain("[glossary_violation] Term mismatch");
+    expect(entries[0]?.issueTemplate.issueText).toContain("Suggested fix:");
+    expect(entries[0]?.issueTemplate.issueText).toContain("Confidence: 0.92");
+  });
+
+  it("records validation failures for missing hashcode or locale", () => {
+    const missingHash = sampleFinding({
+      item: { externalStringId: "  ", key: "k1", locale: "fr-FR" },
+    });
+    const missingLocale = sampleFinding({
+      item: { externalStringId: "hash-1", key: "k2" },
+    });
+
+    const { entries, failures } = buildSmartlingCommentWriteBackEntries({
+      findings: [missingHash, missingLocale],
+      defaultLocaleId: null,
+    });
+
+    expect(entries).toEqual([]);
+    expect(failures).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ message: "smartling_comment_missing_hashcode" }),
+        expect.objectContaining({ message: "smartling_comment_missing_locale" }),
+      ]),
+    );
+  });
+
+  it("falls back to default locale when finding locale is absent", () => {
+    const finding = sampleFinding({
+      item: { externalStringId: "hash-1", key: "k1" },
+    });
+
+    const { entries, failures } = buildSmartlingCommentWriteBackEntries({
+      findings: [finding],
+      defaultLocaleId: "de-DE",
+    });
+
+    expect(failures).toEqual([]);
+    expect(entries[0]?.issueTemplate.string.localeId).toBe("de-DE");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-comment-write-back.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-comment-write-back.ts
@@ -1,0 +1,100 @@
+import { buildFindingId } from "@/lib/providers/provider-job-qa/build-finding-id";
+import type { ProviderQaFinding, ProviderQaSeverity } from "@/lib/providers/provider-job-qa/types";
+
+import type { SmartlingIssueTemplate } from "./smartling-api";
+
+export const HYPERLOCALISE_FINDING_MARKER_PREFIX = "[hyperlocalise:finding=";
+
+export type SmartlingCommentWriteBackEntry = {
+  findingId: string;
+  finding: ProviderQaFinding;
+  issueTemplate: SmartlingIssueTemplate;
+};
+
+export function buildHyperlocaliseFindingMarker(findingId: string) {
+  return `${HYPERLOCALISE_FINDING_MARKER_PREFIX}${findingId}]`;
+}
+
+export function parseHyperlocaliseFindingMarker(issueText: string | null | undefined) {
+  if (!issueText) {
+    return null;
+  }
+
+  const match = issueText.match(/\[hyperlocalise:finding=([^\]]+)\]/);
+  return match?.[1] ?? null;
+}
+
+export function mapProviderSeverityToSmartling(severity: ProviderQaSeverity) {
+  switch (severity) {
+    case "error":
+      return "HIGH";
+    case "warning":
+      return "MEDIUM";
+    case "info":
+    default:
+      return "LOW";
+  }
+}
+
+function formatIssueText(finding: ProviderQaFinding, findingId: string) {
+  const lines = [
+    buildHyperlocaliseFindingMarker(findingId),
+    `[${finding.checkType}] ${finding.message}`,
+  ];
+
+  if (finding.suggestedFix) {
+    lines.push(`Suggested fix: ${finding.suggestedFix}`);
+  }
+
+  if (typeof finding.confidence === "number") {
+    lines.push(`Confidence: ${finding.confidence}`);
+  }
+
+  return lines.join("\n");
+}
+
+export function buildSmartlingCommentWriteBackEntries(input: {
+  findings: ProviderQaFinding[];
+  defaultLocaleId: string | null;
+}): {
+  entries: SmartlingCommentWriteBackEntry[];
+  failures: Array<{ findingId: string; message: string }>;
+} {
+  const entries: SmartlingCommentWriteBackEntry[] = [];
+  const failures: Array<{ findingId: string; message: string }> = [];
+
+  for (const finding of input.findings) {
+    const findingId = buildFindingId(finding);
+    const hashcode = finding.item.externalStringId.trim();
+    const localeId = finding.item.locale?.trim() || input.defaultLocaleId?.trim() || "";
+
+    if (!hashcode) {
+      failures.push({
+        findingId,
+        message: "smartling_comment_missing_hashcode",
+      });
+      continue;
+    }
+
+    if (!localeId) {
+      failures.push({
+        findingId,
+        message: "smartling_comment_missing_locale",
+      });
+      continue;
+    }
+
+    entries.push({
+      findingId,
+      finding,
+      issueTemplate: {
+        string: { hashcode, localeId },
+        issueTypeCode: "REVIEW",
+        issueText: formatIssueText(finding, findingId),
+        issueSeverityLevelCode: mapProviderSeverityToSmartling(finding.severity),
+      },
+    });
+  }
+
+  return { entries, failures };
+}

--- a/apps/hyperlocalise-web/src/lib/workflow/types.ts
+++ b/apps/hyperlocalise-web/src/lib/workflow/types.ts
@@ -111,3 +111,10 @@ export type ProviderAgentQaEventData = {
 };
 
 export type ProviderAgentQaQueue = JobQueue<ProviderAgentQaEventData>;
+
+export type ProviderAgentCommentEventData = {
+  agentRunId: string;
+  organizationId: string;
+};
+
+export type ProviderAgentCommentQueue = JobQueue<ProviderAgentCommentEventData>;

--- a/apps/hyperlocalise-web/src/workflows/adapters.ts
+++ b/apps/hyperlocalise-web/src/workflows/adapters.ts
@@ -3,6 +3,7 @@ import { start } from "workflow/api";
 import { emailTranslationWorkflow } from "./email-translation";
 import { fileTranslationJobWorkflow } from "./file-translation-job";
 import { githubFixWorkflow } from "./github-fix";
+import { providerAgentCommentWorkflow } from "./provider-agent-comment";
 import { providerAgentQaWorkflow } from "./provider-agent-qa";
 import { providerAgentTranslationWorkflow } from "./provider-agent-translation";
 import { repoTmsAgentWorkflow } from "./repo-tms-agent";
@@ -11,6 +12,7 @@ import type {
   EmailAgentTaskQueue,
   GitHubFixQueue,
   JobQueue,
+  ProviderAgentCommentQueue,
   ProviderAgentQaQueue,
   ProviderAgentTranslationQueue,
   RepoTmsAgentTaskQueue,
@@ -76,6 +78,15 @@ export function createProviderAgentQaQueue(): ProviderAgentQaQueue {
   return {
     async enqueue(event) {
       const run = await start(providerAgentQaWorkflow, [event]);
+      return { ids: [run.runId] };
+    },
+  };
+}
+
+export function createProviderAgentCommentQueue(): ProviderAgentCommentQueue {
+  return {
+    async enqueue(event) {
+      const run = await start(providerAgentCommentWorkflow, [event]);
       return { ids: [run.runId] };
     },
   };

--- a/apps/hyperlocalise-web/src/workflows/provider-agent-comment.ts
+++ b/apps/hyperlocalise-web/src/workflows/provider-agent-comment.ts
@@ -1,0 +1,39 @@
+import { getWorkflowMetadata } from "workflow";
+
+import type { ProviderAgentCommentEventData } from "@/lib/workflow/types";
+
+import {
+  executeProviderAgentCommentStep,
+  failProviderAgentCommentStep,
+} from "./steps/provider-agent-comment";
+
+function formatExecutionError(error: unknown) {
+  return error instanceof Error ? error.message : "provider agent comment failed";
+}
+
+export async function providerAgentCommentWorkflow(event: ProviderAgentCommentEventData) {
+  "use workflow";
+
+  const { workflowRunId } = getWorkflowMetadata();
+
+  try {
+    const result = await executeProviderAgentCommentStep(event);
+
+    return {
+      ...result,
+      workflowRunId,
+    };
+  } catch (error) {
+    const failure = await failProviderAgentCommentStep({
+      agentRunId: event.agentRunId,
+      organizationId: event.organizationId,
+      code: "provider_agent_comment_failed",
+      message: formatExecutionError(error),
+    });
+
+    return {
+      ...failure,
+      workflowRunId,
+    };
+  }
+}

--- a/apps/hyperlocalise-web/src/workflows/steps/provider-agent-comment.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/provider-agent-comment.ts
@@ -1,0 +1,33 @@
+import { failAgentRun } from "@/lib/providers/agent-runs";
+import { executeProviderAgentComment } from "@/lib/providers/provider-agent-comment";
+
+export async function executeProviderAgentCommentStep(input: {
+  agentRunId: string;
+  organizationId: string;
+}) {
+  "use step";
+  return executeProviderAgentComment(input);
+}
+
+export async function failProviderAgentCommentStep(input: {
+  agentRunId: string;
+  organizationId: string;
+  code: string;
+  message: string;
+}) {
+  "use step";
+
+  await failAgentRun({
+    runId: input.agentRunId,
+    organizationId: input.organizationId,
+    outputSummary: { code: input.code },
+    warnings: [input.message],
+  });
+
+  return {
+    ok: false as const,
+    agentRunId: input.agentRunId,
+    code: input.code,
+    message: input.message,
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Implements **HL-347** by bridging Hyperlocalise QA review findings into Smartling-native feedback via the Issues API v2.

- Extended `SmartlingApiClient` with `listIssues`, `createIssue`, `createIssueComment`, and `listIssueComments`
- Maps `ProviderQaFinding` values to Smartling review issues with `[hyperlocalise:finding=…]` markers for idempotency
- Added `pushSmartlingProviderComments` with dedupe from prior agent-run `changedItems` and remote issue scans
- Wired `comment_only` agent runs through `provider-agent-comment` workflow when users trigger `leave_provider_comment`
- Extracted `buildFindingId` to `provider-job-qa/build-finding-id.ts` for shared server/client use

## How to test

```bash
cd apps/hyperlocalise-web
vp check --fix
vp test src/lib/providers/smartling/smartling-comment-write-back.test.ts
vp test src/lib/providers/smartling/smartling-comment-pusher.test.ts
```

With Postgres running and migrations applied, route tests in `job.test.ts` cover agent-run creation and comment-queue failure handling.

Manual flow: on a Smartling-backed job, run QA, select findings, and use **Leave provider comment** — the agent run should queue, post issues to Smartling, and skip duplicates on re-run when external issue IDs are recorded.

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, targeted `vp test`)
- [x] Tests cover write-back mapping, idempotent skip paths, and comment creation failure handling
- [x] This PR is scoped and ready for review

Closes HL-347
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-347](https://linear.app/hyperlocalise/issue/HL-347/implement-smartling-issues-and-comments-bridge)

<div><a href="https://cursor.com/agents/bc-3e9f13e5-002d-4b07-a64d-5801b22f2211"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e9f13e5-002d-4b07-a64d-5801b22f2211"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

