### PR TITLE
feat(smartling): sync and search TM and glossary resources (HL-386)

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -40,7 +40,9 @@ import { fetchPhraseFileKeys } from "@/lib/providers/phrase/phrase-file-fetcher"
 import { fetchPhraseJobTasks } from "@/lib/providers/phrase/phrase-job-task-fetcher";
 import { fetchPhraseTranslationMemories } from "@/lib/providers/phrase/phrase-translation-memory-fetcher";
 import { fetchSmartlingFileKeys } from "@/lib/providers/smartling/smartling-file-fetcher";
+import { fetchSmartlingGlossaries } from "@/lib/providers/smartling/smartling-glossary-fetcher";
 import { fetchSmartlingJobTasks } from "@/lib/providers/smartling/smartling-job-fetcher";
+import { fetchSmartlingTranslationMemories } from "@/lib/providers/smartling/smartling-translation-memory-fetcher";
 import {
   pullExternalTmsTaskContent,
   pushExternalTmsTranslations,
@@ -249,6 +251,7 @@ const glossaryFetchersByProvider: Partial<
   lokalise: fetchLokaliseGlossaries,
   crowdin: fetchCrowdinGlossaries,
   phrase: fetchPhraseGlossaries,
+  smartling: fetchSmartlingGlossaries,
 };
 
 const translationMemoryFetchersByProvider: Partial<
@@ -257,6 +260,7 @@ const translationMemoryFetchersByProvider: Partial<
   lokalise: fetchLokaliseTranslationMemories,
   crowdin: fetchCrowdinTranslationMemories,
   phrase: fetchPhraseTranslationMemories,
+  smartling: fetchSmartlingTranslationMemories,
 };
 
 export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-tm-matcher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-tm-matcher.test.ts
@@ -15,6 +15,15 @@ describe("memorySupportsLiveSearch", () => {
     ).toBe(true);
   });
 
+  it("allows synced Smartling memories to fall back to live entry scans", () => {
+    expect(
+      memorySupportsLiveSearch({
+        capabilityMode: "synced_import",
+        externalProviderKind: "smartling",
+      }),
+    ).toBe(true);
+  });
+
   it("keeps other providers on live_search only", () => {
     expect(
       memorySupportsLiveSearch({

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-tm-matcher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-tm-matcher.ts
@@ -71,9 +71,9 @@ export function memorySupportsLiveSearch(memory: {
   capabilityMode: string | null;
   externalProviderKind: string | null;
 }) {
-  if (memory.externalProviderKind !== "lokalise") {
-    return memory.capabilityMode === "live_search";
+  if (memory.externalProviderKind === "lokalise" || memory.externalProviderKind === "smartling") {
+    return memory.capabilityMode === "live_search" || memory.capabilityMode === "synced_import";
   }
 
-  return memory.capabilityMode === "live_search" || memory.capabilityMode === "synced_import";
+  return memory.capabilityMode === "live_search";
 }

--- a/apps/hyperlocalise-web/src/lib/providers/provider-glossary-matchers.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-glossary-matchers.ts
@@ -1,6 +1,7 @@
 import type { ExternalTmsProviderKind } from "@/lib/providers/organization-external-tms-provider-credentials";
 import { searchCrowdinGlossaryMatches } from "@/lib/providers/crowdin/crowdin-glossary-matcher";
 import { searchLokaliseGlossaryMatches } from "@/lib/providers/lokalise/lokalise-glossary-matcher";
+import { searchSmartlingGlossaryMatches } from "@/lib/providers/smartling/smartling-glossary-matcher";
 import type { NormalizedGlossaryMatch } from "@/lib/translation/glossary-match";
 
 type ExternalTmsCredential =
@@ -38,6 +39,8 @@ export function getProviderGlossaryMatcher(
       return searchCrowdinGlossaryMatches;
     case "lokalise":
       return searchLokaliseGlossaryMatches;
+    case "smartling":
+      return searchSmartlingGlossaryMatches;
     default:
       return null;
   }

--- a/apps/hyperlocalise-web/src/lib/providers/provider-translation-memory-matchers.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-translation-memory-matchers.ts
@@ -2,6 +2,7 @@ import type { ExternalTmsProviderKind } from "@/lib/providers/organization-exter
 import { searchCrowdinTranslationMemoryMatches } from "@/lib/providers/crowdin/crowdin-tm-matcher";
 import { searchLokaliseTranslationMemoryMatches } from "@/lib/providers/lokalise/lokalise-tm-matcher";
 import { searchPhraseTranslationMemoryMatches } from "@/lib/providers/phrase/phrase-tm-matcher";
+import { searchSmartlingTranslationMemoryMatches } from "@/lib/providers/smartling/smartling-tm-matcher";
 import type { NormalizedTranslationMemoryMatch } from "@/lib/translation/translation-memory-match";
 
 type ExternalTmsCredential =
@@ -45,6 +46,8 @@ export function getProviderTranslationMemoryMatcher(
       return searchPhraseTranslationMemoryMatches;
     case "lokalise":
       return searchLokaliseTranslationMemoryMatches;
+    case "smartling":
+      return searchSmartlingTranslationMemoryMatches;
     default:
       return null;
   }

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/normalize-smartling-context-matches.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/normalize-smartling-context-matches.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  buildSmartlingTranslationMemoryCandidates,
+  matchesSmartlingGlossaryEntry,
+} from "./normalize-smartling-context-matches";
+import { pickSmartlingGlossaryTranslation, scoreSmartlingTextMatch } from "./smartling-api";
+
+describe("scoreSmartlingTextMatch", () => {
+  it("scores exact matches highest", () => {
+    expect(scoreSmartlingTextMatch("Hello world", "Hello world")).toBe(100);
+  });
+
+  it("returns zero for empty candidates", () => {
+    expect(scoreSmartlingTextMatch("Hello", "")).toBe(0);
+  });
+});
+
+describe("matchesSmartlingGlossaryEntry", () => {
+  it("matches glossary terms that overlap with the source text", () => {
+    expect(
+      matchesSmartlingGlossaryEntry("Save your work", {
+        entryUid: "entry-1",
+        term: "Save",
+        definition: null,
+        partOfSpeech: null,
+        translations: [],
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("pickSmartlingGlossaryTranslation", () => {
+  it("returns the translation for the requested locale", () => {
+    expect(
+      pickSmartlingGlossaryTranslation(
+        {
+          entryUid: "entry-1",
+          term: "Save",
+          definition: null,
+          partOfSpeech: null,
+          translations: [{ localeId: "fr-FR", term: "Enregistrer", notes: null, definition: null }],
+        },
+        "fr-FR",
+      ),
+    ).toBe("Enregistrer");
+  });
+});
+
+describe("buildSmartlingTranslationMemoryCandidates", () => {
+  it("builds scored TM candidates for the target locale", () => {
+    const candidates = buildSmartlingTranslationMemoryCandidates(
+      [
+        {
+          entryUid: "entry-1",
+          sourceText: "Hello",
+          sourceLocaleId: "en-US",
+          translations: [{ targetLocaleId: "fr-FR", translationText: "Bonjour" }],
+        },
+      ],
+      {
+        sourceLocale: "en-US",
+        targetLocale: "fr-FR",
+        sourceText: "Hello",
+        limit: 5,
+      },
+    );
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]).toMatchObject({
+      entryUid: "entry-1",
+      sourceText: "Hello",
+      targetText: "Bonjour",
+      matchScore: 100,
+    });
+  });
+
+  it("returns no candidates when the target locale is missing", () => {
+    const candidates = buildSmartlingTranslationMemoryCandidates(
+      [
+        {
+          entryUid: "entry-1",
+          sourceText: "Hello",
+          sourceLocaleId: "en-US",
+          translations: [{ targetLocaleId: "de-DE", translationText: "Hallo" }],
+        },
+      ],
+      {
+        sourceLocale: "en-US",
+        targetLocale: "fr-FR",
+        sourceText: "Hello",
+        limit: 5,
+      },
+    );
+
+    expect(candidates).toEqual([]);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/normalize-smartling-context-matches.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/normalize-smartling-context-matches.ts
@@ -1,0 +1,56 @@
+import type { SmartlingGlossaryEntry, SmartlingTranslationMemoryEntry } from "./smartling-api";
+import { pickSmartlingGlossaryTranslation, scoreSmartlingTextMatch } from "./smartling-api";
+
+export function matchesSmartlingGlossaryEntry(sourceText: string, entry: SmartlingGlossaryEntry) {
+  return scoreSmartlingTextMatch(sourceText, entry.term) >= 55;
+}
+
+export function buildSmartlingTranslationMemoryCandidates(
+  entries: SmartlingTranslationMemoryEntry[],
+  input: {
+    sourceLocale: string;
+    targetLocale: string;
+    sourceText: string;
+    limit: number;
+  },
+) {
+  const candidates: Array<{
+    entryUid: string;
+    sourceText: string;
+    targetText: string;
+    matchScore: number;
+  }> = [];
+
+  for (const entry of entries) {
+    const sourceText = entry.sourceText.trim();
+    if (!sourceText) {
+      continue;
+    }
+
+    const matchScore = scoreSmartlingTextMatch(input.sourceText, sourceText);
+    if (matchScore < 55) {
+      continue;
+    }
+
+    const translation = entry.translations.find(
+      (item) => item.targetLocaleId.trim() === input.targetLocale.trim(),
+    );
+    const targetText = translation?.translationText.trim();
+    if (!targetText) {
+      continue;
+    }
+
+    candidates.push({
+      entryUid: entry.entryUid,
+      sourceText,
+      targetText,
+      matchScore,
+    });
+  }
+
+  return candidates
+    .toSorted((left, right) => right.matchScore - left.matchScore)
+    .slice(0, input.limit);
+}
+
+export { pickSmartlingGlossaryTranslation, scoreSmartlingTextMatch };

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-account-context.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-account-context.ts
@@ -1,0 +1,58 @@
+import { parseSmartlingCredentials } from "./smartling-credentials";
+import { SmartlingApiClient } from "./smartling-api";
+
+type SmartlingProjectLike = {
+  sourceLocale?: string | null;
+  targetLocales?: string[] | null;
+  providerMetadata?: Record<string, unknown> | null;
+};
+
+export async function resolveSmartlingAccountUid(input: {
+  secretMaterial: string;
+  externalProjectId: string;
+  project?: SmartlingProjectLike;
+}): Promise<string | null> {
+  const credentials = parseSmartlingCredentials(input.secretMaterial);
+  if (credentials.accountUid?.trim()) {
+    return credentials.accountUid.trim();
+  }
+
+  const metadataAccountUid = readMetadataAccountUid(input.project?.providerMetadata);
+  if (metadataAccountUid) {
+    return metadataAccountUid;
+  }
+
+  const projectId = input.externalProjectId.trim() || credentials.projectId?.trim();
+  if (!projectId) {
+    return null;
+  }
+
+  const client = new SmartlingApiClient({ credentials });
+  try {
+    const details = await client.getProjectDetails(projectId);
+    return details.accountUid?.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+function readMetadataAccountUid(metadata: Record<string, unknown> | null | undefined) {
+  const accountUid = metadata?.accountUid;
+  return typeof accountUid === "string" && accountUid.trim() ? accountUid.trim() : null;
+}
+
+export function uniqueLocales(locales: string[]): string[] {
+  const seen = new Set<string>();
+  const unique: string[] = [];
+
+  for (const locale of locales) {
+    const trimmed = locale.trim();
+    if (!trimmed || seen.has(trimmed)) {
+      continue;
+    }
+    seen.add(trimmed);
+    unique.push(trimmed);
+  }
+
+  return unique;
+}

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-account-context.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-account-context.ts
@@ -1,6 +1,8 @@
 import { parseSmartlingCredentials } from "./smartling-credentials";
 import { SmartlingApiClient } from "./smartling-api";
 
+export { uniqueLocales } from "./smartling-locales";
+
 type SmartlingProjectLike = {
   sourceLocale?: string | null;
   targetLocales?: string[] | null;
@@ -39,20 +41,4 @@ export async function resolveSmartlingAccountUid(input: {
 function readMetadataAccountUid(metadata: Record<string, unknown> | null | undefined) {
   const accountUid = metadata?.accountUid;
   return typeof accountUid === "string" && accountUid.trim() ? accountUid.trim() : null;
-}
-
-export function uniqueLocales(locales: string[]): string[] {
-  const seen = new Set<string>();
-  const unique: string[] = [];
-
-  for (const locale of locales) {
-    const trimmed = locale.trim();
-    if (!trimmed || seen.has(trimmed)) {
-      continue;
-    }
-    seen.add(trimmed);
-    unique.push(trimmed);
-  }
-
-  return unique;
 }

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-api.ts
@@ -6,6 +6,7 @@
  */
 
 import { parseSmartlingCredentials, type SmartlingCredentials } from "./smartling-credentials";
+import { uniqueLocales } from "./smartling-locales";
 
 const DEFAULT_AUTH_BASE_URL = "https://api.smartling.com/auth-api/v2";
 const DEFAULT_ACCOUNTS_BASE_URL = "https://api.smartling.com/accounts-api/v2";
@@ -704,7 +705,10 @@ export class SmartlingApiClient {
           limit: String(limit),
           offset: String(offset),
         });
-        const data = await this.get<{ items?: SmartlingGlossaryEntry[]; totalCount?: number }>(
+        const data = await this.get<{
+          items?: Array<Record<string, unknown>>;
+          totalCount?: number;
+        }>(
           `${this.glossaryBaseUrl}/accounts/${encodeURIComponent(accountUid)}/glossaries/${encodeURIComponent(glossaryUid)}/entries?${params.toString()}`,
           token,
         );
@@ -731,7 +735,7 @@ export class SmartlingApiClient {
 
     const token = await this.getAccessToken();
     try {
-      const data = await this.post<{ items?: SmartlingGlossaryEntry[] }>(
+      const data = await this.post<{ items?: Array<Record<string, unknown>> }>(
         `${this.glossaryV3BaseUrl}/accounts/${encodeURIComponent(input.accountUid)}/glossaries/${encodeURIComponent(input.glossaryUid)}/entries/search`,
         token,
         { query },
@@ -783,11 +787,11 @@ export class SmartlingApiClient {
     options: {
       sourceLocaleId: string;
       targetLocaleIds: string[];
-      shouldStop?: (entries: SmartlingTranslationMemoryEntry[]) => boolean;
+      shouldStop?: (page: SmartlingTranslationMemoryEntry[]) => boolean;
     },
   ): Promise<SmartlingTranslationMemoryEntry[]> {
     const entries: SmartlingTranslationMemoryEntry[] = [];
-    const targetLocaleIds = uniqueSmartlingLocales(options.targetLocaleIds);
+    const targetLocaleIds = uniqueLocales(options.targetLocaleIds);
     const targetLocaleParam = targetLocaleIds.length > 0 ? targetLocaleIds.join(",") : "";
 
     await paginateSmartlingList({
@@ -802,7 +806,7 @@ export class SmartlingApiClient {
           params.set("targetLocaleIds", targetLocaleParam);
         }
         const data = await this.get<{
-          items?: SmartlingTranslationMemoryEntry[];
+          items?: Array<Record<string, unknown>>;
           totalCount?: number;
         }>(
           `${this.tmBaseUrl}/accounts/${encodeURIComponent(accountUid)}/translation-memories/${encodeURIComponent(translationMemoryUid)}/entries?${params.toString()}`,
@@ -815,7 +819,7 @@ export class SmartlingApiClient {
       },
       onPage: (page) => {
         entries.push(...page);
-        if (options.shouldStop?.(entries)) {
+        if (options.shouldStop?.(page)) {
           return true;
         }
         return false;
@@ -1084,9 +1088,7 @@ function readSmartlingLocaleIds(item: Record<string, unknown>) {
     return [];
   }
 
-  return uniqueSmartlingLocales(
-    localeIds.filter((locale): locale is string => typeof locale === "string"),
-  );
+  return uniqueLocales(localeIds.filter((locale): locale is string => typeof locale === "string"));
 }
 
 function normalizeSmartlingGlossarySummary(
@@ -1102,18 +1104,34 @@ function normalizeSmartlingGlossarySummary(
   };
 }
 
-function normalizeSmartlingGlossaryEntry(item: SmartlingGlossaryEntry): SmartlingGlossaryEntry {
+function normalizeSmartlingGlossaryEntry(item: Record<string, unknown>): SmartlingGlossaryEntry {
+  const translationsRaw = item.translations;
+  const translations = Array.isArray(translationsRaw)
+    ? translationsRaw
+        .filter(
+          (translation): translation is Record<string, unknown> =>
+            typeof translation === "object" && translation !== null,
+        )
+        .map(normalizeSmartlingGlossaryTranslation)
+    : [];
+
   return {
-    entryUid: item.entryUid,
-    term: item.term ?? "",
-    definition: item.definition ?? null,
-    partOfSpeech: item.partOfSpeech ?? null,
-    translations: (item.translations ?? []).map((translation) => ({
-      localeId: translation.localeId,
-      term: translation.term ?? "",
-      notes: translation.notes ?? null,
-      definition: translation.definition ?? null,
-    })),
+    entryUid: readSmartlingUid(item, "entryUid", "entryUID", "uid"),
+    term: readSmartlingString(item, "term") ?? "",
+    definition: readSmartlingString(item, "definition"),
+    partOfSpeech: readSmartlingString(item, "partOfSpeech"),
+    translations,
+  };
+}
+
+function normalizeSmartlingGlossaryTranslation(
+  item: Record<string, unknown>,
+): SmartlingGlossaryTranslation {
+  return {
+    localeId: readSmartlingString(item, "localeId") ?? "",
+    term: readSmartlingString(item, "term") ?? "",
+    notes: readSmartlingString(item, "notes"),
+    definition: readSmartlingString(item, "definition"),
   };
 }
 
@@ -1137,33 +1155,34 @@ function normalizeSmartlingTranslationMemorySummary(
 }
 
 function normalizeSmartlingTranslationMemoryEntry(
-  item: SmartlingTranslationMemoryEntry,
+  item: Record<string, unknown>,
 ): SmartlingTranslationMemoryEntry {
+  const translationsRaw = item.translations;
+  const translations = Array.isArray(translationsRaw)
+    ? translationsRaw
+        .filter(
+          (translation): translation is Record<string, unknown> =>
+            typeof translation === "object" && translation !== null,
+        )
+        .map(normalizeSmartlingTranslationMemoryTranslation)
+    : [];
+
   return {
-    entryUid: item.entryUid,
-    sourceText: item.sourceText ?? "",
-    sourceLocaleId: item.sourceLocaleId,
-    translations: (item.translations ?? []).map((translation) => ({
-      targetLocaleId: translation.targetLocaleId,
-      translationText: translation.translationText ?? "",
-    })),
+    entryUid: readSmartlingUid(item, "entryUid", "entryUID", "uid"),
+    sourceText: readSmartlingString(item, "sourceText") ?? "",
+    sourceLocaleId: readSmartlingString(item, "sourceLocaleId") ?? "",
+    translations,
   };
 }
 
-export function uniqueSmartlingLocales(locales: string[]): string[] {
-  const seen = new Set<string>();
-  const unique: string[] = [];
-
-  for (const locale of locales) {
-    const trimmed = locale.trim();
-    if (!trimmed || seen.has(trimmed)) {
-      continue;
-    }
-    seen.add(trimmed);
-    unique.push(trimmed);
-  }
-
-  return unique;
+function normalizeSmartlingTranslationMemoryTranslation(
+  item: Record<string, unknown>,
+): SmartlingTranslationMemoryTranslation {
+  return {
+    targetLocaleId:
+      readSmartlingString(item, "targetLocaleId") ?? readSmartlingString(item, "localeId") ?? "",
+    translationText: readSmartlingString(item, "translationText") ?? "",
+  };
 }
 
 export function scoreSmartlingTextMatch(sourceText: string, candidateText: string) {

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-api.ts
@@ -2,7 +2,7 @@
  * Smartling API client for authentication and project discovery.
  *
  * This module intentionally implements only the endpoints required for
- * credential validation, TMS connector scans, and job-scoped content pull/write-back.
+ * credential validation, TMS connector scans, terminology resources, and job-scoped content pull/write-back.
  */
 
 import { parseSmartlingCredentials, type SmartlingCredentials } from "./smartling-credentials";
@@ -13,8 +13,13 @@ const DEFAULT_PROJECTS_BASE_URL = "https://api.smartling.com/projects-api/v2";
 const DEFAULT_FILES_BASE_URL = "https://api.smartling.com/files-api/v2";
 const DEFAULT_STRINGS_BASE_URL = "https://api.smartling.com/strings-api/v2";
 const DEFAULT_JOBS_BASE_URL = "https://api.smartling.com/jobs-api/v3";
+const DEFAULT_GLOSSARY_BASE_URL = "https://api.smartling.com/glossary-api/v2";
+const DEFAULT_GLOSSARY_V3_BASE_URL = "https://api.smartling.com/glossary-api/v3";
+const DEFAULT_TM_BASE_URL = "https://api.smartling.com/translation-memory-api/v2";
 const TOKEN_REFRESH_SKEW_MS = 60_000;
 const DEFAULT_PAGE_SIZE = 500;
+
+export const SMARTLING_TM_SYNC_MAX_ENTRIES = 2_000;
 
 export interface SmartlingApiClientOptions {
   credentials: SmartlingCredentials | string;
@@ -24,7 +29,52 @@ export interface SmartlingApiClientOptions {
   filesBaseUrl?: string;
   stringsBaseUrl?: string;
   jobsBaseUrl?: string;
+  glossaryBaseUrl?: string;
+  glossaryV3BaseUrl?: string;
+  tmBaseUrl?: string;
   fetchFn?: typeof fetch;
+}
+
+export interface SmartlingGlossarySummary {
+  glossaryUid: string;
+  name: string;
+  description: string | null;
+  localeIds: string[];
+}
+
+export interface SmartlingGlossaryEntry {
+  entryUid: string;
+  term: string;
+  definition: string | null;
+  partOfSpeech: string | null;
+  translations: SmartlingGlossaryTranslation[];
+}
+
+export interface SmartlingGlossaryTranslation {
+  localeId: string;
+  term: string;
+  notes: string | null;
+  definition: string | null;
+}
+
+export interface SmartlingTranslationMemorySummary {
+  translationMemoryUid: string;
+  name: string;
+  description: string | null;
+  sourceLocaleId: string | null;
+  localeIds: string[];
+}
+
+export interface SmartlingTranslationMemoryEntry {
+  entryUid: string;
+  sourceText: string;
+  sourceLocaleId: string;
+  translations: SmartlingTranslationMemoryTranslation[];
+}
+
+export interface SmartlingTranslationMemoryTranslation {
+  targetLocaleId: string;
+  translationText: string;
 }
 
 export interface SmartlingAuthTokens {
@@ -186,6 +236,9 @@ export class SmartlingApiClient {
   private readonly filesBaseUrl: string;
   private readonly stringsBaseUrl: string;
   private readonly jobsBaseUrl: string;
+  private readonly glossaryBaseUrl: string;
+  private readonly glossaryV3BaseUrl: string;
+  private readonly tmBaseUrl: string;
   private readonly fetchFn: typeof fetch;
   private tokens: SmartlingAuthTokens | null = null;
 
@@ -214,6 +267,18 @@ export class SmartlingApiClient {
     this.jobsBaseUrl = normalizeServiceBaseUrl(
       options.jobsBaseUrl ?? deriveServiceBaseUrl(this.authBaseUrl, "jobs"),
       DEFAULT_JOBS_BASE_URL,
+    );
+    this.glossaryBaseUrl = normalizeServiceBaseUrl(
+      options.glossaryBaseUrl ?? deriveServiceBaseUrl(this.authBaseUrl, "glossary"),
+      DEFAULT_GLOSSARY_BASE_URL,
+    );
+    this.glossaryV3BaseUrl = normalizeServiceBaseUrl(
+      options.glossaryV3BaseUrl ?? deriveServiceBaseUrl(this.authBaseUrl, "glossary-v3"),
+      DEFAULT_GLOSSARY_V3_BASE_URL,
+    );
+    this.tmBaseUrl = normalizeServiceBaseUrl(
+      options.tmBaseUrl ?? deriveServiceBaseUrl(this.authBaseUrl, "translation-memory"),
+      DEFAULT_TM_BASE_URL,
     );
     this.fetchFn = options.fetchFn ?? fetch;
   }
@@ -598,6 +663,168 @@ export class SmartlingApiClient {
     );
   }
 
+  async listAccountGlossaries(accountUid: string): Promise<SmartlingGlossarySummary[]> {
+    const glossaries: SmartlingGlossarySummary[] = [];
+
+    await paginateSmartlingList({
+      fetchPage: async (offset, limit) => {
+        const token = await this.getAccessToken();
+        const params = new URLSearchParams({
+          limit: String(limit),
+          offset: String(offset),
+        });
+        const data = await this.get<{
+          items?: Array<Record<string, unknown>>;
+          totalCount?: number;
+        }>(
+          `${this.glossaryBaseUrl}/accounts/${encodeURIComponent(accountUid)}/glossaries?${params.toString()}`,
+          token,
+        );
+        return {
+          items: (data.items ?? []).map(normalizeSmartlingGlossarySummary),
+          totalCount: data.totalCount,
+        };
+      },
+      onPage: (page) => glossaries.push(...page),
+    });
+
+    return glossaries;
+  }
+
+  async listGlossaryEntries(
+    accountUid: string,
+    glossaryUid: string,
+  ): Promise<SmartlingGlossaryEntry[]> {
+    const entries: SmartlingGlossaryEntry[] = [];
+
+    await paginateSmartlingList({
+      fetchPage: async (offset, limit) => {
+        const token = await this.getAccessToken();
+        const params = new URLSearchParams({
+          limit: String(limit),
+          offset: String(offset),
+        });
+        const data = await this.get<{ items?: SmartlingGlossaryEntry[]; totalCount?: number }>(
+          `${this.glossaryBaseUrl}/accounts/${encodeURIComponent(accountUid)}/glossaries/${encodeURIComponent(glossaryUid)}/entries?${params.toString()}`,
+          token,
+        );
+        return {
+          items: (data.items ?? []).map(normalizeSmartlingGlossaryEntry),
+          totalCount: data.totalCount,
+        };
+      },
+      onPage: (page) => entries.push(...page),
+    });
+
+    return entries;
+  }
+
+  async searchGlossaryEntries(input: {
+    accountUid: string;
+    glossaryUid: string;
+    query: string;
+  }): Promise<SmartlingGlossaryEntry[]> {
+    const query = input.query.trim();
+    if (!query) {
+      return [];
+    }
+
+    const token = await this.getAccessToken();
+    try {
+      const data = await this.post<{ items?: SmartlingGlossaryEntry[] }>(
+        `${this.glossaryV3BaseUrl}/accounts/${encodeURIComponent(input.accountUid)}/glossaries/${encodeURIComponent(input.glossaryUid)}/entries/search`,
+        token,
+        { query },
+      );
+      return (data.items ?? []).map(normalizeSmartlingGlossaryEntry);
+    } catch (error) {
+      if (!(error instanceof SmartlingApiError) || (error.status !== 404 && error.status !== 405)) {
+        throw error;
+      }
+    }
+
+    const entries = await this.listGlossaryEntries(input.accountUid, input.glossaryUid);
+    return entries.filter((entry) => matchesSmartlingGlossaryQuery(query, entry));
+  }
+
+  async listAccountTranslationMemories(
+    accountUid: string,
+  ): Promise<SmartlingTranslationMemorySummary[]> {
+    const memories: SmartlingTranslationMemorySummary[] = [];
+
+    await paginateSmartlingList({
+      fetchPage: async (offset, limit) => {
+        const token = await this.getAccessToken();
+        const params = new URLSearchParams({
+          limit: String(limit),
+          offset: String(offset),
+        });
+        const data = await this.get<{
+          items?: Array<Record<string, unknown>>;
+          totalCount?: number;
+        }>(
+          `${this.tmBaseUrl}/accounts/${encodeURIComponent(accountUid)}/translation-memories?${params.toString()}`,
+          token,
+        );
+        return {
+          items: (data.items ?? []).map(normalizeSmartlingTranslationMemorySummary),
+          totalCount: data.totalCount,
+        };
+      },
+      onPage: (page) => memories.push(...page),
+    });
+
+    return memories;
+  }
+
+  async listTranslationMemoryEntries(
+    accountUid: string,
+    translationMemoryUid: string,
+    options: {
+      sourceLocaleId: string;
+      targetLocaleIds: string[];
+      shouldStop?: (entries: SmartlingTranslationMemoryEntry[]) => boolean;
+    },
+  ): Promise<SmartlingTranslationMemoryEntry[]> {
+    const entries: SmartlingTranslationMemoryEntry[] = [];
+    const targetLocaleIds = uniqueSmartlingLocales(options.targetLocaleIds);
+    const targetLocaleParam = targetLocaleIds.length > 0 ? targetLocaleIds.join(",") : "";
+
+    await paginateSmartlingList({
+      fetchPage: async (offset, limit) => {
+        const token = await this.getAccessToken();
+        const params = new URLSearchParams({
+          sourceLocaleId: options.sourceLocaleId,
+          limit: String(limit),
+          offset: String(offset),
+        });
+        if (targetLocaleParam) {
+          params.set("targetLocaleIds", targetLocaleParam);
+        }
+        const data = await this.get<{
+          items?: SmartlingTranslationMemoryEntry[];
+          totalCount?: number;
+        }>(
+          `${this.tmBaseUrl}/accounts/${encodeURIComponent(accountUid)}/translation-memories/${encodeURIComponent(translationMemoryUid)}/entries?${params.toString()}`,
+          token,
+        );
+        return {
+          items: (data.items ?? []).map(normalizeSmartlingTranslationMemoryEntry),
+          totalCount: data.totalCount,
+        };
+      },
+      onPage: (page) => {
+        entries.push(...page);
+        if (options.shouldStop?.(entries)) {
+          return true;
+        }
+        return false;
+      },
+    });
+
+    return entries;
+  }
+
   private async get<T>(url: string, token: string): Promise<T> {
     const response = await this.fetchFn(url, {
       method: "GET",
@@ -639,12 +866,28 @@ export class SmartlingApiClient {
 
 export function deriveServiceBaseUrl(
   authBaseUrl: string,
-  service: "accounts" | "projects" | "files" | "strings" | "jobs",
+  service:
+    | "accounts"
+    | "projects"
+    | "files"
+    | "strings"
+    | "jobs"
+    | "glossary"
+    | "glossary-v3"
+    | "translation-memory",
 ) {
   const normalized = normalizeServiceBaseUrl(authBaseUrl, authBaseUrl);
   if (normalized.includes("/auth-api/")) {
-    const version = service === "jobs" ? "v3" : "v2";
-    return normalized.replace(/\/auth-api\/v\d+/, `/${service}-api/${version}`);
+    const version = service === "jobs" || service === "glossary-v3" ? "v3" : "v2";
+    const apiName =
+      service === "glossary"
+        ? "glossary"
+        : service === "glossary-v3"
+          ? "glossary"
+          : service === "translation-memory"
+            ? "translation-memory"
+            : service;
+    return normalized.replace(/\/auth-api\/v\d+/, `/${apiName}-api/${version}`);
   }
 
   switch (service) {
@@ -658,6 +901,12 @@ export function deriveServiceBaseUrl(
       return DEFAULT_STRINGS_BASE_URL;
     case "jobs":
       return DEFAULT_JOBS_BASE_URL;
+    case "glossary":
+      return DEFAULT_GLOSSARY_BASE_URL;
+    case "glossary-v3":
+      return DEFAULT_GLOSSARY_V3_BASE_URL;
+    case "translation-memory":
+      return DEFAULT_TM_BASE_URL;
   }
 }
 
@@ -787,14 +1036,18 @@ function collectSmartlingErrorMessage(responseBody: unknown) {
 
 async function paginateSmartlingList<T>(input: {
   fetchPage: (offset: number, limit: number) => Promise<{ items: T[]; totalCount?: number }>;
-  onPage: (items: T[]) => void;
+  onPage: (items: T[]) => unknown;
 }) {
   let offset = 0;
 
   while (true) {
     const page = await input.fetchPage(offset, DEFAULT_PAGE_SIZE);
-    input.onPage(page.items);
+    const shouldStop = input.onPage(page.items);
     offset += page.items.length;
+
+    if (shouldStop === true) {
+      break;
+    }
 
     if (page.items.length === 0) {
       break;
@@ -808,6 +1061,174 @@ async function paginateSmartlingList<T>(input: {
       break;
     }
   }
+}
+
+function readSmartlingUid(item: Record<string, unknown>, ...keys: string[]) {
+  for (const key of keys) {
+    const value = item[key];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return "";
+}
+
+function readSmartlingString(item: Record<string, unknown>, key: string) {
+  const value = item[key];
+  return typeof value === "string" ? value : null;
+}
+
+function readSmartlingLocaleIds(item: Record<string, unknown>) {
+  const localeIds = item.localeIds;
+  if (!Array.isArray(localeIds)) {
+    return [];
+  }
+
+  return uniqueSmartlingLocales(
+    localeIds.filter((locale): locale is string => typeof locale === "string"),
+  );
+}
+
+function normalizeSmartlingGlossarySummary(
+  item: Record<string, unknown>,
+): SmartlingGlossarySummary {
+  const glossaryUid = readSmartlingUid(item, "glossaryUid", "uid", "glossaryUID");
+  const name = readSmartlingString(item, "name") ?? glossaryUid;
+  return {
+    glossaryUid,
+    name,
+    description: readSmartlingString(item, "description"),
+    localeIds: readSmartlingLocaleIds(item),
+  };
+}
+
+function normalizeSmartlingGlossaryEntry(item: SmartlingGlossaryEntry): SmartlingGlossaryEntry {
+  return {
+    entryUid: item.entryUid,
+    term: item.term ?? "",
+    definition: item.definition ?? null,
+    partOfSpeech: item.partOfSpeech ?? null,
+    translations: (item.translations ?? []).map((translation) => ({
+      localeId: translation.localeId,
+      term: translation.term ?? "",
+      notes: translation.notes ?? null,
+      definition: translation.definition ?? null,
+    })),
+  };
+}
+
+function normalizeSmartlingTranslationMemorySummary(
+  item: Record<string, unknown>,
+): SmartlingTranslationMemorySummary {
+  const translationMemoryUid = readSmartlingUid(
+    item,
+    "translationMemoryUid",
+    "uid",
+    "translationMemoryUID",
+  );
+  const name = readSmartlingString(item, "name") ?? translationMemoryUid;
+  return {
+    translationMemoryUid,
+    name,
+    description: readSmartlingString(item, "description"),
+    sourceLocaleId: readSmartlingString(item, "sourceLocaleId"),
+    localeIds: readSmartlingLocaleIds(item),
+  };
+}
+
+function normalizeSmartlingTranslationMemoryEntry(
+  item: SmartlingTranslationMemoryEntry,
+): SmartlingTranslationMemoryEntry {
+  return {
+    entryUid: item.entryUid,
+    sourceText: item.sourceText ?? "",
+    sourceLocaleId: item.sourceLocaleId,
+    translations: (item.translations ?? []).map((translation) => ({
+      targetLocaleId: translation.targetLocaleId,
+      translationText: translation.translationText ?? "",
+    })),
+  };
+}
+
+export function uniqueSmartlingLocales(locales: string[]): string[] {
+  const seen = new Set<string>();
+  const unique: string[] = [];
+
+  for (const locale of locales) {
+    const trimmed = locale.trim();
+    if (!trimmed || seen.has(trimmed)) {
+      continue;
+    }
+    seen.add(trimmed);
+    unique.push(trimmed);
+  }
+
+  return unique;
+}
+
+export function scoreSmartlingTextMatch(sourceText: string, candidateText: string) {
+  const source = sourceText.trim();
+  const candidate = candidateText.trim();
+  if (!source || !candidate) {
+    return 0;
+  }
+
+  if (source === candidate) {
+    return 100;
+  }
+
+  const sourceLower = source.toLowerCase();
+  const candidateLower = candidate.toLowerCase();
+  if (sourceLower === candidateLower) {
+    return 98;
+  }
+
+  if (candidateLower.includes(sourceLower) || sourceLower.includes(candidateLower)) {
+    const ratio =
+      Math.min(source.length, candidate.length) / Math.max(source.length, candidate.length);
+    return Math.round(70 + ratio * 25);
+  }
+
+  const sourceTokens = tokenizeSmartlingText(sourceLower);
+  const candidateTokens = tokenizeSmartlingText(candidateLower);
+  if (sourceTokens.length === 0 || candidateTokens.length === 0) {
+    return 0;
+  }
+
+  const overlap = sourceTokens.filter((token) => candidateTokens.includes(token)).length;
+  if (overlap === 0) {
+    return 0;
+  }
+
+  const coverage = overlap / Math.max(sourceTokens.length, candidateTokens.length);
+  return Math.round(50 + coverage * 40);
+}
+
+function tokenizeSmartlingText(value: string) {
+  return value.split(/\s+/).filter(Boolean);
+}
+
+function matchesSmartlingGlossaryQuery(query: string, entry: SmartlingGlossaryEntry) {
+  return scoreSmartlingTextMatch(query, entry.term) >= 55;
+}
+
+export function pickSmartlingGlossaryTranslation(
+  entry: SmartlingGlossaryEntry,
+  targetLocale: string,
+) {
+  const normalizedTarget = targetLocale.trim().toLowerCase();
+  for (const translation of entry.translations) {
+    if (translation.localeId.trim().toLowerCase() !== normalizedTarget) {
+      continue;
+    }
+
+    const targetTerm = translation.term.trim();
+    if (targetTerm) {
+      return targetTerm;
+    }
+  }
+
+  return null;
 }
 
 function normalizeSmartlingFileSummary(item: SmartlingFileSummary): SmartlingFileSummary {

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-glossary-fetcher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-glossary-fetcher.ts
@@ -1,0 +1,57 @@
+import type { ExternalTmsGlossaryFetcher } from "@/lib/providers/external-tms-glossary-sync";
+
+import { resolveSmartlingAccountUid, uniqueLocales } from "./smartling-account-context";
+import { SmartlingApiClient, SmartlingApiError } from "./smartling-api";
+
+export const fetchSmartlingGlossaries: ExternalTmsGlossaryFetcher = async ({
+  secretMaterial,
+  externalProjectId,
+  project,
+}) => {
+  const accountUid = await resolveSmartlingAccountUid({
+    secretMaterial,
+    externalProjectId,
+    project,
+  });
+  if (!accountUid) {
+    throw new Error("smartling_account_uid_required");
+  }
+
+  const client = new SmartlingApiClient({ credentials: secretMaterial });
+
+  let glossaries;
+  try {
+    glossaries = await client.listAccountGlossaries(accountUid);
+  } catch (error) {
+    if (error instanceof SmartlingApiError && error.status === 401) {
+      throw new Error("smartling_auth_invalid");
+    }
+    throw error;
+  }
+
+  const sourceLocale = project.sourceLocale ?? "en";
+  const targetLocales = project.targetLocales ?? [];
+  const glossaryTargetLocales =
+    targetLocales.length > 0 ? uniqueLocales(targetLocales) : [sourceLocale];
+
+  return glossaries
+    .filter((glossary) => glossary.glossaryUid)
+    .flatMap((glossary) =>
+      glossaryTargetLocales.map((targetLocale) => ({
+        externalGlossaryId: glossary.glossaryUid,
+        name: glossary.name || glossary.glossaryUid,
+        description: glossary.description ?? "",
+        sourceLocale,
+        targetLocale,
+        externalResourceType: "glossary" as const,
+        localeCoverage: uniqueLocales([sourceLocale, targetLocale, ...glossary.localeIds]),
+        termCount: null,
+        termCapabilities: { mode: "live_search" },
+        metadata: {
+          smartlingGlossaryUid: glossary.glossaryUid,
+          smartlingAccountUid: accountUid,
+        },
+        terms: [],
+      })),
+    );
+};

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-glossary-fetcher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-glossary-fetcher.ts
@@ -31,8 +31,10 @@ export const fetchSmartlingGlossaries: ExternalTmsGlossaryFetcher = async ({
 
   const sourceLocale = project.sourceLocale ?? "en";
   const targetLocales = project.targetLocales ?? [];
-  const glossaryTargetLocales =
-    targetLocales.length > 0 ? uniqueLocales(targetLocales) : [sourceLocale];
+  if (targetLocales.length === 0) {
+    return [];
+  }
+  const glossaryTargetLocales = uniqueLocales(targetLocales);
 
   return glossaries
     .filter((glossary) => glossary.glossaryUid)

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-glossary-matcher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-glossary-matcher.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { searchSmartlingGlossaryMatches } from "./smartling-glossary-matcher";
+
+describe("searchSmartlingGlossaryMatches", () => {
+  it("normalizes live glossary matches for attached glossaries", async () => {
+    const fetchMock = vi.fn(async (url, init) => {
+      if (String(url).endsWith("/authenticate") && init?.method === "POST") {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: { accessToken: "token", expiresIn: 3600 },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (String(url).includes("/entries/search")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: {
+                items: [
+                  {
+                    entryUid: "entry-1",
+                    term: "Save",
+                    translations: [{ localeId: "fr-FR", term: "Enregistrer" }],
+                  },
+                ],
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response("Not Found", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const matches = await searchSmartlingGlossaryMatches({
+      organizationId: "org_1",
+      projectId: "project_1",
+      providerKind: "smartling",
+      externalProjectId: "project-smartling",
+      credential: { baseUrl: null } as never,
+      secretMaterial: JSON.stringify({
+        userIdentifier: "user",
+        userSecret: "secret",
+        accountUid: "acct-1",
+      }),
+      glossaries: [
+        {
+          id: "glossary_local_1",
+          name: "Product glossary",
+          externalGlossaryId: "glossary-uid-1",
+          targetLocale: "fr-FR",
+          termCapabilities: { mode: "live_search" },
+        },
+      ],
+      sourceLocale: "en-US",
+      targetLocale: "fr-FR",
+      sourceText: "Save your work",
+      limit: 5,
+    });
+
+    vi.unstubAllGlobals();
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0]).toMatchObject({
+      glossaryId: "glossary_local_1",
+      sourceTerm: "Save",
+      targetTerm: "Enregistrer",
+      providerKind: "smartling",
+      matchSource: "live_provider",
+      externalResourceId: "glossary-uid-1",
+      externalTermId: "entry-1",
+    });
+  });
+
+  it("returns no matches when the glossary is not attached", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const matches = await searchSmartlingGlossaryMatches({
+      organizationId: "org_1",
+      projectId: "project_1",
+      providerKind: "smartling",
+      externalProjectId: "project-smartling",
+      credential: { baseUrl: null } as never,
+      secretMaterial: JSON.stringify({
+        userIdentifier: "user",
+        userSecret: "secret",
+        accountUid: "acct-1",
+      }),
+      glossaries: [
+        {
+          id: "glossary_local_1",
+          name: "Product glossary",
+          externalGlossaryId: null,
+          targetLocale: "fr-FR",
+          termCapabilities: { mode: "live_search" },
+        },
+      ],
+      sourceLocale: "en-US",
+      targetLocale: "fr-FR",
+      sourceText: "Save your work",
+      limit: 5,
+    });
+
+    vi.unstubAllGlobals();
+
+    expect(matches).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-glossary-matcher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-glossary-matcher.ts
@@ -1,0 +1,91 @@
+import type { ExternalTmsGlossaryMatcher } from "@/lib/providers/provider-glossary-matchers";
+import { normalizeProviderGlossaryMatch } from "@/lib/translation/glossary-match";
+
+import { resolveSmartlingAccountUid } from "./smartling-account-context";
+import {
+  matchesSmartlingGlossaryEntry,
+  pickSmartlingGlossaryTranslation,
+} from "./normalize-smartling-context-matches";
+import { SmartlingApiClient, SmartlingApiError } from "./smartling-api";
+
+export const searchSmartlingGlossaryMatches: ExternalTmsGlossaryMatcher = async ({
+  secretMaterial,
+  externalProjectId,
+  glossaries,
+  sourceLocale,
+  targetLocale,
+  sourceText,
+  limit,
+}) => {
+  const accountUid = await resolveSmartlingAccountUid({
+    secretMaterial,
+    externalProjectId,
+  });
+  if (!accountUid) {
+    return [];
+  }
+
+  const searchableGlossaries = glossaries.filter((glossary) => glossary.externalGlossaryId);
+  if (searchableGlossaries.length === 0) {
+    return [];
+  }
+
+  const client = new SmartlingApiClient({ credentials: secretMaterial });
+  const normalizedTargetLocale = targetLocale.trim();
+  const liveMatches = [];
+
+  for (const glossary of searchableGlossaries) {
+    const glossaryUid = glossary.externalGlossaryId;
+    if (!glossaryUid) {
+      continue;
+    }
+
+    if (glossary.targetLocale?.trim() && glossary.targetLocale.trim() !== normalizedTargetLocale) {
+      continue;
+    }
+
+    let entries;
+    try {
+      entries = await client.searchGlossaryEntries({
+        accountUid,
+        glossaryUid,
+        query: sourceText,
+      });
+    } catch (error) {
+      if (error instanceof SmartlingApiError && error.status === 401) {
+        throw new Error("smartling_auth_invalid");
+      }
+      continue;
+    }
+
+    for (const [index, entry] of entries.entries()) {
+      if (!matchesSmartlingGlossaryEntry(sourceText, entry)) {
+        continue;
+      }
+
+      const sourceTerm = entry.term.trim();
+      const targetTerm = pickSmartlingGlossaryTranslation(entry, normalizedTargetLocale);
+      if (!sourceTerm || !targetTerm) {
+        continue;
+      }
+
+      liveMatches.push(
+        normalizeProviderGlossaryMatch({
+          sourceTerm,
+          targetTerm,
+          sourceLocale,
+          targetLocale: normalizedTargetLocale,
+          description: entry.definition,
+          providerKind: "smartling",
+          resourceId: glossary.id,
+          externalResourceId: glossaryUid,
+          externalTermId: entry.entryUid,
+          glossaryName: glossary.name,
+          rank: Math.max(0, 1 - index * 0.01),
+        }),
+      );
+    }
+  }
+
+  return liveMatches.toSorted((left, right) => right.rank - left.rank).slice(0, limit);
+};

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-locales.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-locales.ts
@@ -1,0 +1,15 @@
+export function uniqueLocales(locales: string[]): string[] {
+  const seen = new Set<string>();
+  const unique: string[] = [];
+
+  for (const locale of locales) {
+    const trimmed = locale.trim();
+    if (!trimmed || seen.has(trimmed)) {
+      continue;
+    }
+    seen.add(trimmed);
+    unique.push(trimmed);
+  }
+
+  return unique;
+}

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-tm-matcher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-tm-matcher.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { searchSmartlingTranslationMemoryMatches } from "./smartling-tm-matcher";
+
+describe("searchSmartlingTranslationMemoryMatches", () => {
+  it("normalizes TM entry matches for attached memories", async () => {
+    const fetchMock = vi.fn(async (url, init) => {
+      if (String(url).endsWith("/authenticate") && init?.method === "POST") {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: { accessToken: "token", expiresIn: 3600 },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (String(url).includes("/translation-memories/tm-uid-1/entries")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: {
+                items: [
+                  {
+                    entryUid: "entry-1",
+                    sourceText: "Hello",
+                    sourceLocaleId: "en-US",
+                    translations: [{ targetLocaleId: "fr-FR", translationText: "Bonjour" }],
+                  },
+                ],
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response("Not Found", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const matches = await searchSmartlingTranslationMemoryMatches({
+      organizationId: "org_1",
+      projectId: "project_1",
+      providerKind: "smartling",
+      externalProjectId: "project-smartling",
+      credential: { baseUrl: null } as never,
+      secretMaterial: JSON.stringify({
+        userIdentifier: "user",
+        userSecret: "secret",
+        accountUid: "acct-1",
+      }),
+      memory: {
+        id: "memory_local_1",
+        name: "Product TM",
+        externalMemoryId: "tm-uid-1",
+        capabilityMode: "synced_import",
+      },
+      sourceLocale: "en-US",
+      targetLocale: "fr-FR",
+      sourceText: "Hello",
+      limit: 5,
+    });
+
+    vi.unstubAllGlobals();
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0]).toMatchObject({
+      memoryId: "memory_local_1",
+      sourceText: "Hello",
+      targetText: "Bonjour",
+      providerKind: "smartling",
+      matchSource: "live_provider",
+      externalResourceId: "tm-uid-1",
+      externalSegmentId: "entry-1",
+    });
+  });
+
+  it("returns no matches when external memory id is missing", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const matches = await searchSmartlingTranslationMemoryMatches({
+      organizationId: "org_1",
+      projectId: "project_1",
+      providerKind: "smartling",
+      externalProjectId: "project-smartling",
+      credential: { baseUrl: null } as never,
+      secretMaterial: JSON.stringify({
+        userIdentifier: "user",
+        userSecret: "secret",
+        accountUid: "acct-1",
+      }),
+      memory: {
+        id: "memory_local_1",
+        name: "Product TM",
+        externalMemoryId: null,
+        capabilityMode: "synced_import",
+      },
+      sourceLocale: "en-US",
+      targetLocale: "fr-FR",
+      sourceText: "Hello",
+      limit: 5,
+    });
+
+    vi.unstubAllGlobals();
+
+    expect(matches).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-tm-matcher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-tm-matcher.ts
@@ -3,7 +3,11 @@ import { normalizeProviderTranslationMemoryMatch } from "@/lib/translation/trans
 
 import { resolveSmartlingAccountUid } from "./smartling-account-context";
 import { buildSmartlingTranslationMemoryCandidates } from "./normalize-smartling-context-matches";
-import { SmartlingApiClient, SmartlingApiError } from "./smartling-api";
+import {
+  SmartlingApiClient,
+  SmartlingApiError,
+  SMARTLING_TM_SYNC_MAX_ENTRIES,
+} from "./smartling-api";
 
 export const searchSmartlingTranslationMemoryMatches: ExternalTmsTranslationMemoryMatcher = async ({
   secretMaterial,
@@ -33,9 +37,15 @@ export const searchSmartlingTranslationMemoryMatches: ExternalTmsTranslationMemo
 
   let entries;
   try {
+    let fetchedSegmentCount = 0;
+
     entries = await client.listTranslationMemoryEntries(accountUid, externalMemoryId, {
       sourceLocaleId: sourceLocale,
       targetLocaleIds: [targetLocale],
+      shouldStop: (page) => {
+        fetchedSegmentCount += page.length;
+        return fetchedSegmentCount >= SMARTLING_TM_SYNC_MAX_ENTRIES;
+      },
     });
   } catch (error) {
     if (error instanceof SmartlingApiError && error.status === 401) {

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-tm-matcher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-tm-matcher.ts
@@ -1,0 +1,69 @@
+import type { ExternalTmsTranslationMemoryMatcher } from "@/lib/providers/provider-translation-memory-matchers";
+import { normalizeProviderTranslationMemoryMatch } from "@/lib/translation/translation-memory-match";
+
+import { resolveSmartlingAccountUid } from "./smartling-account-context";
+import { buildSmartlingTranslationMemoryCandidates } from "./normalize-smartling-context-matches";
+import { SmartlingApiClient, SmartlingApiError } from "./smartling-api";
+
+export const searchSmartlingTranslationMemoryMatches: ExternalTmsTranslationMemoryMatcher = async ({
+  secretMaterial,
+  externalProjectId,
+  project,
+  memory,
+  sourceLocale,
+  targetLocale,
+  sourceText,
+  limit,
+}) => {
+  const externalMemoryId = memory.externalMemoryId?.trim();
+  if (!externalMemoryId) {
+    return [];
+  }
+
+  const accountUid = await resolveSmartlingAccountUid({
+    secretMaterial,
+    externalProjectId,
+    project: project ?? undefined,
+  });
+  if (!accountUid) {
+    return [];
+  }
+
+  const client = new SmartlingApiClient({ credentials: secretMaterial });
+
+  let entries;
+  try {
+    entries = await client.listTranslationMemoryEntries(accountUid, externalMemoryId, {
+      sourceLocaleId: sourceLocale,
+      targetLocaleIds: [targetLocale],
+    });
+  } catch (error) {
+    if (error instanceof SmartlingApiError && error.status === 401) {
+      throw new Error("smartling_auth_invalid");
+    }
+    return [];
+  }
+
+  const candidates = buildSmartlingTranslationMemoryCandidates(entries, {
+    sourceLocale,
+    targetLocale,
+    sourceText,
+    limit,
+  });
+
+  return candidates.map((candidate, index) =>
+    normalizeProviderTranslationMemoryMatch({
+      sourceText: candidate.sourceText,
+      targetText: candidate.targetText,
+      sourceLocale,
+      targetLocale,
+      matchScore: candidate.matchScore,
+      providerKind: "smartling",
+      resourceId: memory.id,
+      externalResourceId: externalMemoryId,
+      externalSegmentId: candidate.entryUid,
+      memoryName: memory.name,
+      rank: Math.max(0, 1 - index * 0.01),
+    }),
+  );
+};

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-translation-memory-fetcher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-translation-memory-fetcher.ts
@@ -1,0 +1,165 @@
+import type { ExternalTmsTranslationMemoryFetcher } from "@/lib/providers/external-tms-tm-sync";
+
+import { resolveSmartlingAccountUid, uniqueLocales } from "./smartling-account-context";
+import {
+  SmartlingApiClient,
+  SmartlingApiError,
+  SMARTLING_TM_SYNC_MAX_ENTRIES,
+  uniqueSmartlingLocales,
+} from "./smartling-api";
+
+export const fetchSmartlingTranslationMemories: ExternalTmsTranslationMemoryFetcher = async ({
+  secretMaterial,
+  externalProjectId,
+  project,
+}) => {
+  const accountUid = await resolveSmartlingAccountUid({
+    secretMaterial,
+    externalProjectId,
+    project,
+  });
+  if (!accountUid) {
+    throw new Error("smartling_account_uid_required");
+  }
+
+  const client = new SmartlingApiClient({ credentials: secretMaterial });
+
+  let memories;
+  try {
+    memories = await client.listAccountTranslationMemories(accountUid);
+  } catch (error) {
+    if (error instanceof SmartlingApiError && error.status === 401) {
+      throw new Error("smartling_auth_invalid");
+    }
+    throw error;
+  }
+
+  const sourceLocale = project.sourceLocale ?? "en";
+  const targetLocales = uniqueLocales(project.targetLocales ?? []);
+
+  const results = await Promise.all(
+    memories
+      .filter((memory) => memory.translationMemoryUid)
+      .map(async (memory) => {
+        const memorySourceLocale = memory.sourceLocaleId || sourceLocale;
+        const entryTargetLocales = uniqueSmartlingLocales([
+          ...targetLocales,
+          ...memory.localeIds.filter((locale) => locale !== memorySourceLocale),
+        ]);
+
+        try {
+          const buildEntries = (
+            segments: Awaited<ReturnType<SmartlingApiClient["listTranslationMemoryEntries"]>>,
+          ) =>
+            buildTranslationMemoryEntries({
+              translationMemoryUid: memory.translationMemoryUid,
+              sourceLanguageId: memorySourceLocale,
+              targetLocales: entryTargetLocales,
+              segments,
+            });
+
+          const segments = await client.listTranslationMemoryEntries(
+            accountUid,
+            memory.translationMemoryUid,
+            {
+              sourceLocaleId: memorySourceLocale,
+              targetLocaleIds: entryTargetLocales,
+              shouldStop: (fetchedSegments) =>
+                buildEntries(fetchedSegments).length >= SMARTLING_TM_SYNC_MAX_ENTRIES,
+            },
+          );
+          const syncedEntries = buildEntries(segments).slice(0, SMARTLING_TM_SYNC_MAX_ENTRIES);
+
+          return {
+            externalMemoryId: memory.translationMemoryUid,
+            name: memory.name,
+            description: memory.description ?? "",
+            sourceLocale: memorySourceLocale,
+            localeCoverage: uniqueSmartlingLocales([memorySourceLocale, ...memory.localeIds]),
+            segmentCount: syncedEntries.length,
+            metadata: {
+              smartlingTranslationMemoryUid: memory.translationMemoryUid,
+              smartlingAccountUid: accountUid,
+              importedSegmentCount: syncedEntries.length,
+            },
+            entries: syncedEntries,
+          };
+        } catch (error) {
+          if (error instanceof SmartlingApiError && error.status === 401) {
+            throw new Error("smartling_auth_invalid");
+          }
+
+          return {
+            externalMemoryId: memory.translationMemoryUid,
+            name: memory.name,
+            description: memory.description ?? "",
+            sourceLocale: memorySourceLocale,
+            localeCoverage: uniqueSmartlingLocales([memorySourceLocale, ...memory.localeIds]),
+            segmentCount: null,
+            syncErrorMessage:
+              error instanceof Error ? error.message : "translation_memory_sync_failed",
+            metadata: {
+              smartlingTranslationMemoryUid: memory.translationMemoryUid,
+              smartlingAccountUid: accountUid,
+            },
+            entries: [],
+          };
+        }
+      }),
+  );
+
+  return results;
+};
+
+function buildTranslationMemoryEntries(input: {
+  translationMemoryUid: string;
+  sourceLanguageId: string;
+  targetLocales: string[];
+  segments: Array<{
+    entryUid: string;
+    sourceText: string;
+    sourceLocaleId: string;
+    translations: Array<{ targetLocaleId: string; translationText: string }>;
+  }>;
+}) {
+  const entries: Array<{
+    externalKey: string;
+    sourceLocale: string;
+    targetLocale: string;
+    sourceText: string;
+    targetText: string;
+    matchScore: number;
+    metadata: Record<string, unknown>;
+  }> = [];
+
+  for (const segment of input.segments) {
+    const sourceText = segment.sourceText.trim();
+    if (!sourceText) {
+      continue;
+    }
+
+    for (const targetLocale of input.targetLocales) {
+      const targetTranslation = segment.translations.find(
+        (translation) =>
+          translation.targetLocaleId === targetLocale && translation.translationText.trim(),
+      );
+      if (!targetTranslation) {
+        continue;
+      }
+
+      entries.push({
+        externalKey: `${input.translationMemoryUid}:${segment.entryUid}:${targetLocale}`,
+        sourceLocale: input.sourceLanguageId,
+        targetLocale,
+        sourceText,
+        targetText: targetTranslation.translationText.trim(),
+        matchScore: 100,
+        metadata: {
+          smartlingEntryUid: segment.entryUid,
+        },
+      });
+    }
+  }
+
+  return entries;
+}

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-translation-memory-fetcher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-translation-memory-fetcher.ts
@@ -5,8 +5,9 @@ import {
   SmartlingApiClient,
   SmartlingApiError,
   SMARTLING_TM_SYNC_MAX_ENTRIES,
-  uniqueSmartlingLocales,
 } from "./smartling-api";
+
+const TRANSLATION_MEMORY_FETCH_CONCURRENCY = 5;
 
 export const fetchSmartlingTranslationMemories: ExternalTmsTranslationMemoryFetcher = async ({
   secretMaterial,
@@ -37,79 +38,126 @@ export const fetchSmartlingTranslationMemories: ExternalTmsTranslationMemoryFetc
   const sourceLocale = project.sourceLocale ?? "en";
   const targetLocales = uniqueLocales(project.targetLocales ?? []);
 
-  const results = await Promise.all(
-    memories
-      .filter((memory) => memory.translationMemoryUid)
-      .map(async (memory) => {
-        const memorySourceLocale = memory.sourceLocaleId || sourceLocale;
-        const entryTargetLocales = uniqueSmartlingLocales([
-          ...targetLocales,
-          ...memory.localeIds.filter((locale) => locale !== memorySourceLocale),
-        ]);
+  const results = await mapInBatches(
+    memories.filter((memory) => memory.translationMemoryUid),
+    TRANSLATION_MEMORY_FETCH_CONCURRENCY,
+    async (memory) => {
+      const memorySourceLocale = memory.sourceLocaleId || sourceLocale;
+      const entryTargetLocales = uniqueLocales([
+        ...targetLocales,
+        ...memory.localeIds.filter((locale) => locale !== memorySourceLocale),
+      ]);
 
-        try {
-          const buildEntries = (
-            segments: Awaited<ReturnType<SmartlingApiClient["listTranslationMemoryEntries"]>>,
-          ) =>
-            buildTranslationMemoryEntries({
-              translationMemoryUid: memory.translationMemoryUid,
-              sourceLanguageId: memorySourceLocale,
-              targetLocales: entryTargetLocales,
-              segments,
-            });
-
-          const segments = await client.listTranslationMemoryEntries(
-            accountUid,
-            memory.translationMemoryUid,
-            {
-              sourceLocaleId: memorySourceLocale,
-              targetLocaleIds: entryTargetLocales,
-              shouldStop: (fetchedSegments) =>
-                buildEntries(fetchedSegments).length >= SMARTLING_TM_SYNC_MAX_ENTRIES,
+      try {
+        let syncedEntryCount = 0;
+        const segments = await client.listTranslationMemoryEntries(
+          accountUid,
+          memory.translationMemoryUid,
+          {
+            sourceLocaleId: memorySourceLocale,
+            targetLocaleIds: entryTargetLocales,
+            shouldStop: (page) => {
+              syncedEntryCount += countTranslationMemoryEntries({
+                segments: page,
+                targetLocales: entryTargetLocales,
+              });
+              return syncedEntryCount >= SMARTLING_TM_SYNC_MAX_ENTRIES;
             },
-          );
-          const syncedEntries = buildEntries(segments).slice(0, SMARTLING_TM_SYNC_MAX_ENTRIES);
+          },
+        );
+        const syncedEntries = buildTranslationMemoryEntries({
+          translationMemoryUid: memory.translationMemoryUid,
+          sourceLanguageId: memorySourceLocale,
+          targetLocales: entryTargetLocales,
+          segments,
+        }).slice(0, SMARTLING_TM_SYNC_MAX_ENTRIES);
 
-          return {
-            externalMemoryId: memory.translationMemoryUid,
-            name: memory.name,
-            description: memory.description ?? "",
-            sourceLocale: memorySourceLocale,
-            localeCoverage: uniqueSmartlingLocales([memorySourceLocale, ...memory.localeIds]),
-            segmentCount: syncedEntries.length,
-            metadata: {
-              smartlingTranslationMemoryUid: memory.translationMemoryUid,
-              smartlingAccountUid: accountUid,
-              importedSegmentCount: syncedEntries.length,
-            },
-            entries: syncedEntries,
-          };
-        } catch (error) {
-          if (error instanceof SmartlingApiError && error.status === 401) {
-            throw new Error("smartling_auth_invalid");
-          }
-
-          return {
-            externalMemoryId: memory.translationMemoryUid,
-            name: memory.name,
-            description: memory.description ?? "",
-            sourceLocale: memorySourceLocale,
-            localeCoverage: uniqueSmartlingLocales([memorySourceLocale, ...memory.localeIds]),
-            segmentCount: null,
-            syncErrorMessage:
-              error instanceof Error ? error.message : "translation_memory_sync_failed",
-            metadata: {
-              smartlingTranslationMemoryUid: memory.translationMemoryUid,
-              smartlingAccountUid: accountUid,
-            },
-            entries: [],
-          };
+        return {
+          externalMemoryId: memory.translationMemoryUid,
+          name: memory.name,
+          description: memory.description ?? "",
+          sourceLocale: memorySourceLocale,
+          localeCoverage: uniqueLocales([memorySourceLocale, ...memory.localeIds]),
+          segmentCount: syncedEntries.length,
+          metadata: {
+            smartlingTranslationMemoryUid: memory.translationMemoryUid,
+            smartlingAccountUid: accountUid,
+            importedSegmentCount: syncedEntries.length,
+          },
+          entries: syncedEntries,
+        };
+      } catch (error) {
+        if (error instanceof SmartlingApiError && error.status === 401) {
+          throw new Error("smartling_auth_invalid");
         }
-      }),
+
+        return {
+          externalMemoryId: memory.translationMemoryUid,
+          name: memory.name,
+          description: memory.description ?? "",
+          sourceLocale: memorySourceLocale,
+          localeCoverage: uniqueLocales([memorySourceLocale, ...memory.localeIds]),
+          segmentCount: null,
+          syncErrorMessage:
+            error instanceof Error ? error.message : "translation_memory_sync_failed",
+          metadata: {
+            smartlingTranslationMemoryUid: memory.translationMemoryUid,
+            smartlingAccountUid: accountUid,
+          },
+          entries: [],
+        };
+      }
+    },
   );
 
   return results;
 };
+
+async function mapInBatches<T, R>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = [];
+  const batchSize = Math.max(1, concurrency);
+
+  for (let index = 0; index < items.length; index += batchSize) {
+    const batch = items.slice(index, index + batchSize);
+    const batchResults = await Promise.all(batch.map((item) => mapper(item)));
+    results.push(...batchResults);
+  }
+
+  return results;
+}
+
+function countTranslationMemoryEntries(input: {
+  targetLocales: string[];
+  segments: Array<{
+    sourceText: string;
+    translations: Array<{ targetLocaleId: string; translationText: string }>;
+  }>;
+}) {
+  let count = 0;
+
+  for (const segment of input.segments) {
+    const sourceText = segment.sourceText.trim();
+    if (!sourceText) {
+      continue;
+    }
+
+    for (const targetLocale of input.targetLocales) {
+      const targetTranslation = segment.translations.find(
+        (translation) =>
+          translation.targetLocaleId === targetLocale && translation.translationText.trim(),
+      );
+      if (targetTranslation) {
+        count += 1;
+      }
+    }
+  }
+
+  return count;
+}
 
 function buildTranslationMemoryEntries(input: {
   translationMemoryUid: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **HL-386** by bridging Smartling account-level glossaries and translation memories into Hyperlocalise’s synced resources and agent context.

## Changes

- **Smartling API client** — glossary list, v3 entry search, TM list, and paginated TM entry import (capped at 2,000 segments per memory)
- **Sync fetchers** — `fetchSmartlingGlossaries` (metadata + `live_search`) and `fetchSmartlingTranslationMemories` (metadata + optional entry import)
- **Live matchers** — glossary search via v3 `entries/search` (v2 list fallback) and TM matching via imported/live entry scans
- **Wiring** — registered on project sync routes and provider glossary/TM matcher maps
- **Tests** — match normalization, missing external IDs, and Smartling-specific live-search capability handling

## How to verify

1. Connect a Smartling external TMS project with a credential that includes `accountUid` (or project metadata that resolves it).
2. Run **Sync glossaries** and **Sync translation memories** on the project — resources should appear on the Glossaries and Translation Memories pages with Smartling badges.
3. Attach synced resources to a project and run agent translate/review — TM and glossary matches should appear in context when live lookup is needed.

## Notes

- Glossaries use `termCapabilities: { mode: "live_search" }` (metadata-only sync, terms fetched on demand).
- TMs with imported segments use `synced_import`; empty imports fall back to `live_search`.
- Smartling `synced_import` memories can still use live entry scans when synced DB matches miss (same pattern as Lokalise).
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-386](https://linear.app/hyperlocalise/issue/HL-386/sync-and-search-smartling-tm-and-glossary-resources)

<div><a href="https://cursor.com/agents/bc-d076e9cc-2b11-43f0-a9a0-0b215d82194b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d076e9cc-2b11-43f0-a9a0-0b215d82194b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

