### PR TITLE
🧪 Scout: improve HTML tag parity coverage with formatting edge cases

### DIFF
--- a/internal/i18n/htmltagparity/htmltagparity_test.go
+++ b/internal/i18n/htmltagparity/htmltagparity_test.go
@@ -47,3 +47,63 @@ func TestMismatchIgnoresAngleBracketPathTokens(t *testing.T) {
 		t.Fatalf("expected <name> in paths not to count as HTML tags")
 	}
 }
+
+func TestMismatchFormattingAndKnownTags(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		tgt  string
+		want bool
+	}{
+		{
+			name: "multiline tag and attributes",
+			src:  "Hello <strong\n  class=\"foo\">world</strong>",
+			tgt:  "Bonjour <strong class=\"foo\">monde</strong>",
+			want: false,
+		},
+		{
+			name: "case-insensitive matching",
+			src:  "Hello <STRONG>world</STRONG>",
+			tgt:  "Bonjour <strong>monde</strong>",
+			want: false,
+		},
+		{
+			name: "self-closing variations",
+			src:  "Hello <br/> world <br>",
+			tgt:  "Bonjour <br> monde <br />",
+			want: false,
+		},
+		{
+			name: "heading tags",
+			src:  "<h1>Title</h1>",
+			tgt:  "<h1>Titre</h1>",
+			want: false,
+		},
+		{
+			name: "whitespace in closing tags",
+			src:  "Hello <strong>world</strong >",
+			tgt:  "Bonjour <strong>monde</strong>",
+			want: false,
+		},
+		{
+			name: "unknown tags are ignored in both",
+			src:  "Hello <not-a-tag>world</not-a-tag>",
+			tgt:  "Bonjour world",
+			want: false,
+		},
+		{
+			name: "img tags with different attributes",
+			src:  "<img src=\"/a.png\">",
+			tgt:  "<img src=\"/b.png\" alt=\"image\">",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Mismatch(tt.src, tt.tgt); got != tt.want {
+				t.Errorf("Mismatch() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/i18n/htmltagparity/htmltagparity_test.go
+++ b/internal/i18n/htmltagparity/htmltagparity_test.go
@@ -97,12 +97,18 @@ func TestMismatchFormattingAndKnownTags(t *testing.T) {
 			tgt:  "<img src=\"/b.png\" alt=\"image\">",
 			want: false,
 		},
+		{
+			name: "ignores path-like tokens that are known atoms",
+			src:  "Path <id> and <name>",
+			tgt:  "Path <id> and <name>",
+			want: false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := Mismatch(tt.src, tt.tgt); got != tt.want {
-				t.Errorf("Mismatch() = %v, want %v", got, tt.want)
+				t.Errorf("%s: Mismatch() = %v, want %v", tt.name, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
- 💡 What: Added \`TestMismatchFormattingAndKnownTags\` to \`internal/i18n/htmltagparity/htmltagparity_test.go\`.
- 🎯 Why: To ensure the HTML tag parity checker correctly handles formatting variations (multiline, casing, self-closing tags) without false positives.
- 🧩 Scope: \`internal/i18n/htmltagparity/htmltagparity_test.go\`
- ✅ Verification: Ran \`go test -v ./internal/i18n/htmltagparity/...\` and \`go test ./...\`.
- 🛡️ Confidence: High. The tests specifically target and confirm normalization behavior for common HTML formatting noise.

---
*PR created automatically by Jules for task [9530407401342898027](https://jules.google.com/task/9530407401342898027) started by @cungminh2710*