### PR TITLE
feat(crowdin): bridge review issues and comments into provider QA (HL-389)

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/job-qa.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job-qa.schema.ts
@@ -32,6 +32,57 @@ export const providerQaReportSchema = z.object({
   summary: providerQaSummarySchema,
 });
 
+export const providerReviewAuthorSchema = z.object({
+  externalUserId: z.string().nullable().optional(),
+  username: z.string().nullable().optional(),
+  displayName: z.string().nullable().optional(),
+});
+
+export const providerReviewCommentSchema = z.object({
+  externalCommentId: z.string(),
+  body: z.string(),
+  author: providerReviewAuthorSchema.nullable().optional(),
+  createdAt: z.string().nullable().optional(),
+  updatedAt: z.string().nullable().optional(),
+});
+
+export const providerReviewContextSchema = z.object({
+  externalProjectId: z.string(),
+  externalJobId: z.string(),
+  externalThreadId: z.string(),
+  externalCommentId: z.string().nullable().optional(),
+  providerUrl: z.string().nullable().optional(),
+});
+
+export const providerReviewThreadSchema = z.object({
+  threadId: z.string(),
+  kind: z.enum(["issue", "comment", "task_comment"]),
+  state: z.enum(["open", "resolved", "unknown"]),
+  subject: z.string().nullable().optional(),
+  issueType: z.string().nullable().optional(),
+  item: providerQaItemReferenceSchema.nullable().optional(),
+  locale: z.string().nullable().optional(),
+  comments: z.array(providerReviewCommentSchema),
+  author: providerReviewAuthorSchema.nullable().optional(),
+  resolver: providerReviewAuthorSchema.nullable().optional(),
+  createdAt: z.string().nullable().optional(),
+  updatedAt: z.string().nullable().optional(),
+  resolvedAt: z.string().nullable().optional(),
+  providerContext: providerReviewContextSchema,
+});
+
+export const providerReviewSummarySchema = z.object({
+  total: z.number().int().nonnegative(),
+  open: z.number().int().nonnegative(),
+  resolved: z.number().int().nonnegative(),
+  byKind: z.record(z.string(), z.number().int().nonnegative()),
+});
+
+export const providerReviewReportSchema = z.object({
+  threads: z.array(providerReviewThreadSchema),
+  summary: providerReviewSummarySchema,
+});
+
 export const providerQaReportResponseSchema = z.object({
   qaReport: providerQaReportSchema.extend({
     pullRunId: z.string(),

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-qa-findings-model.test.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-qa-findings-model.test.ts
@@ -9,6 +9,7 @@ import {
   isProviderReviewFindingsAgentRun,
   isQaChecksAgentRun,
   isReviewWithAgentRun,
+  parseProviderReviewReportFromOutputSummary,
   parseQaReportFromOutputSummary,
 } from "./job-qa-findings-model";
 
@@ -32,6 +33,29 @@ describe("job-qa-findings-model", () => {
     });
 
     expect(report?.findings).toHaveLength(1);
+    expect(report?.summary.total).toBe(1);
+  });
+
+  it("parses provider review reports from agent run output summaries", () => {
+    const report = parseProviderReviewReportFromOutputSummary({
+      reviewThreads: [
+        {
+          threadId: "crowdin:1:9:issue:42",
+          kind: "issue",
+          state: "open",
+          comments: [{ externalCommentId: "42", body: "Wrong tense" }],
+          providerContext: {
+            externalProjectId: "1",
+            externalJobId: "9",
+            externalThreadId: "42",
+            providerUrl: "https://crowdin.com/project/demo",
+          },
+        },
+      ],
+      reviewSummary: { total: 1, open: 1, resolved: 0, byKind: { issue: 1 } },
+    });
+
+    expect(report?.threads).toHaveLength(1);
     expect(report?.summary.total).toBe(1);
   });
 

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-qa-findings-model.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-qa-findings-model.ts
@@ -1,4 +1,7 @@
-import { providerQaReportSchema } from "@/api/routes/project/job-qa.schema";
+import {
+  providerQaReportSchema,
+  providerReviewReportSchema,
+} from "@/api/routes/project/job-qa.schema";
 import { buildFindingId } from "@/lib/providers/provider-job-qa/build-finding-id";
 import type {
   ProviderQaCheckType,
@@ -6,10 +9,23 @@ import type {
   ProviderQaReport,
   ProviderQaSeverity,
 } from "@/lib/providers/provider-job-qa/types";
+import type {
+  ProviderReviewReport,
+  ProviderReviewThread,
+  ProviderReviewThreadKind,
+  ProviderReviewThreadState,
+} from "@/lib/providers/provider-job-review/types";
 
 export { buildFindingId };
 
-export type { ProviderQaFinding, ProviderQaReport, ProviderQaCheckType, ProviderQaSeverity };
+export type {
+  ProviderQaFinding,
+  ProviderQaReport,
+  ProviderQaCheckType,
+  ProviderQaSeverity,
+  ProviderReviewReport,
+  ProviderReviewThread,
+};
 
 export type QaFindingGroupBy = "severity" | "locale" | "checkType" | "key";
 
@@ -45,6 +61,43 @@ export function parseQaReportFromOutputSummary(
   }
 
   return parsed.data;
+}
+
+export function parseProviderReviewReportFromOutputSummary(
+  outputSummary: Record<string, unknown> | undefined,
+): ProviderReviewReport | null {
+  if (!outputSummary) {
+    return null;
+  }
+
+  const parsed = providerReviewReportSchema.safeParse({
+    threads: outputSummary.reviewThreads,
+    summary: outputSummary.reviewSummary,
+  });
+
+  if (!parsed.success) {
+    return null;
+  }
+
+  return parsed.data;
+}
+
+export function formatReviewThreadKindLabel(kind: ProviderReviewThreadKind) {
+  return kind.replaceAll("_", " ");
+}
+
+export function formatReviewThreadStateLabel(state: ProviderReviewThreadState) {
+  return state;
+}
+
+export function formatReviewAuthorLabel(
+  author: ProviderReviewThread["author"] | undefined | null,
+): string | null {
+  if (!author) {
+    return null;
+  }
+
+  return author.displayName?.trim() || author.username?.trim() || author.externalUserId || null;
 }
 
 export function isQaChecksAgentRun(inputSnapshot: Record<string, unknown> | undefined) {

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-qa-findings-section.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-qa-findings-section.tsx
@@ -35,6 +35,7 @@ import { TypographyH2 } from "@/components/ui/typography";
 import { apiClient } from "@/lib/api-client-instance";
 import type { JobProviderActionId } from "@/lib/providers/job-provider-actions";
 import type { ProviderQaFinding, ProviderQaSeverity } from "@/lib/providers/provider-job-qa/types";
+import type { ProviderReviewThread } from "@/lib/providers/provider-job-review/types";
 import { cn } from "@/lib/utils";
 
 import { toneClass, type Tone } from "../../../_components/workspace-resource-shared";
@@ -47,11 +48,27 @@ import {
   filterFindings,
   formatCheckTypeLabel,
   groupFindings,
+  formatReviewAuthorLabel,
+  formatReviewThreadKindLabel,
+  formatReviewThreadStateLabel,
   isProviderReviewFindingsAgentRun,
+  isReviewWithAgentRun,
+  parseProviderReviewReportFromOutputSummary,
   parseQaReportFromOutputSummary,
   type QaFindingGroupBy,
   type QaFindingWithId,
 } from "./job-qa-findings-model";
+
+function reviewThreadStateTone(state: ProviderReviewThread["state"]): Tone {
+  switch (state) {
+    case "open":
+      return "watch";
+    case "resolved":
+      return "safe";
+    default:
+      return "info";
+  }
+}
 
 function severityTone(severity: ProviderQaSeverity): Tone {
   switch (severity) {
@@ -70,6 +87,116 @@ function parseActionError(response: Response, fallback: string) {
     .then((body: { error?: string; message?: string }) => body.message ?? body.error)
     .catch(() => null)
     .then((error) => (error ? `${fallback}: ${error}` : `${fallback} (${response.status})`));
+}
+
+function ProviderReviewSummaryChips({
+  summary,
+}: {
+  summary: { total: number; open: number; resolved: number };
+}) {
+  const entries: Array<{ label: string; count: number; tone: Tone }> = [
+    { label: "Threads", count: summary.total, tone: "info" },
+    { label: "Open", count: summary.open, tone: "watch" },
+    { label: "Resolved", count: summary.resolved, tone: "safe" },
+  ];
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {entries.map((entry) => (
+        <Badge
+          key={entry.label}
+          variant="outline"
+          className={cn("rounded-full capitalize", toneClass(entry.tone))}
+        >
+          {entry.label}: {entry.count}
+        </Badge>
+      ))}
+    </div>
+  );
+}
+
+function ProviderReviewThreadRow({
+  thread,
+  organizationSlug,
+  projectId,
+}: {
+  thread: ProviderReviewThread;
+  organizationSlug: string;
+  projectId: string | null;
+}) {
+  const primaryComment = thread.comments[0];
+  const body = primaryComment?.body ?? thread.subject ?? "";
+  const authorLabel = formatReviewAuthorLabel(thread.author ?? primaryComment?.author);
+  const contentHref =
+    projectId && thread.item
+      ? buildProjectFilesHref({
+          organizationSlug,
+          projectId,
+          key: thread.item.key,
+          locale: thread.item.locale ?? thread.locale ?? undefined,
+        })
+      : null;
+  const providerUrl = thread.providerContext.providerUrl;
+
+  return (
+    <li className="rounded-md border border-foreground/8 bg-foreground/3.5 px-3 py-3">
+      <div className="space-y-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge
+            variant="outline"
+            className={cn(
+              "rounded-full capitalize",
+              toneClass(reviewThreadStateTone(thread.state)),
+            )}
+          >
+            {formatReviewThreadStateLabel(thread.state)}
+          </Badge>
+          <Badge variant="outline" className="rounded-full capitalize text-foreground/62">
+            {formatReviewThreadKindLabel(thread.kind)}
+          </Badge>
+          {thread.locale ? (
+            <Badge variant="outline" className="rounded-full text-foreground/62">
+              {thread.locale}
+            </Badge>
+          ) : null}
+          {thread.issueType ? (
+            <Badge variant="outline" className="rounded-full text-foreground/62">
+              {thread.issueType.replaceAll("_", " ")}
+            </Badge>
+          ) : null}
+        </div>
+        {body ? <p className="text-sm text-foreground/82">{body}</p> : null}
+        {thread.comments.length > 1 ? (
+          <p className="text-xs text-foreground/48">
+            {thread.comments.length} comments in this thread
+          </p>
+        ) : null}
+        <div className="flex flex-wrap items-center gap-3 text-xs text-foreground/54">
+          {authorLabel ? <span>{authorLabel}</span> : null}
+          {thread.createdAt ? <span>{thread.createdAt}</span> : null}
+          {thread.item?.key ? <span className="font-mono">{thread.item.key}</span> : null}
+          {contentHref ? (
+            <Link
+              href={contentHref}
+              className="text-foreground underline decoration-foreground/24 underline-offset-4 hover:decoration-foreground/48"
+            >
+              View in project files
+            </Link>
+          ) : null}
+          {providerUrl ? (
+            <Link
+              href={providerUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="text-foreground underline decoration-foreground/24 underline-offset-4 hover:decoration-foreground/48"
+            >
+              Open in TMS
+            </Link>
+          ) : null}
+        </div>
+      </div>
+    </li>
+  );
 }
 
 function QaSummaryChips({
@@ -246,6 +373,23 @@ export function JobQaFindingsSection({
       ) ?? null
     );
   }, [agentRuns]);
+
+  const latestReviewAgentRun = useMemo(() => {
+    if (!agentRuns) {
+      return null;
+    }
+
+    return (
+      agentRuns.find(
+        (run) => isReviewWithAgentRun(run.inputSnapshot) && run.status === "succeeded",
+      ) ?? null
+    );
+  }, [agentRuns]);
+
+  const providerReviewReport = useMemo(
+    () => parseProviderReviewReportFromOutputSummary(latestReviewAgentRun?.outputSummary),
+    [latestReviewAgentRun],
+  );
 
   const activeQaRun = useMemo(() => {
     if (!agentRuns) {
@@ -498,6 +642,28 @@ export function JobQaFindingsSection({
             ? "Agent review is running. Results will refresh when the run completes."
             : "QA checks are running. Results will refresh when the agent run completes."}
         </p>
+      ) : null}
+
+      {providerReviewReport && providerReviewReport.summary.total > 0 ? (
+        <div className="mt-4 space-y-3 rounded-md border border-foreground/8 bg-foreground/2 px-4 py-4">
+          <div>
+            <h3 className="text-sm font-medium text-foreground/82">Provider review threads</h3>
+            <p className="mt-1 text-sm text-foreground/48">
+              Issues and comments synced from the TMS for this job.
+            </p>
+          </div>
+          <ProviderReviewSummaryChips summary={providerReviewReport.summary} />
+          <ul className="space-y-2">
+            {providerReviewReport.threads.map((thread) => (
+              <ProviderReviewThreadRow
+                key={thread.threadId}
+                thread={thread}
+                organizationSlug={organizationSlug}
+                projectId={projectId}
+              />
+            ))}
+          </ul>
+        </div>
       ) : null}
 
       {report && report.summary.total > 0 ? (

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-api.ts
@@ -136,6 +136,39 @@ export interface CrowdinTranslationApproval {
   languageId: string;
 }
 
+export interface CrowdinShortUser {
+  id: number;
+  username: string;
+  fullName?: string | null;
+}
+
+export interface CrowdinStringComment {
+  id: number;
+  text: string;
+  userId: number;
+  stringId: number;
+  languageId: string;
+  type: string;
+  issueType?: string | null;
+  issueStatus?: string | null;
+  resolverId?: number | null;
+  resolver?: CrowdinShortUser | null;
+  user?: CrowdinShortUser | null;
+  resolvedAt?: string | null;
+  createdAt: string;
+  projectId: number;
+}
+
+export interface CrowdinTaskComment {
+  id: number;
+  userId: number;
+  taskId: number;
+  text: string;
+  timeSpent?: number | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface CrowdinStorage {
   id: number;
   fileName: string;
@@ -504,6 +537,56 @@ export class CrowdinApiClient {
   async getTask(projectId: number, taskId: number): Promise<CrowdinTaskDetails> {
     const response = await this.get<CrowdinGetResponse<CrowdinTaskDetails>>(
       `/projects/${projectId}/tasks/${taskId}`,
+    );
+    return response.data;
+  }
+
+  async listTaskComments(projectId: number, taskId: number): Promise<CrowdinTaskComment[]> {
+    return this.listPaginated<CrowdinTaskComment>(
+      `/projects/${projectId}/tasks/${taskId}/comments`,
+    );
+  }
+
+  async listStringComments(
+    projectId: number,
+    options?: {
+      stringId?: number;
+      type?: "comment" | "issue";
+      issueStatus?: "resolved" | "unresolved";
+    },
+  ): Promise<CrowdinStringComment[]> {
+    const params = new URLSearchParams();
+    if (options?.stringId) {
+      params.set("stringId", String(options.stringId));
+    }
+    if (options?.type) {
+      params.set("type", options.type);
+    }
+    if (options?.issueStatus) {
+      params.set("issueStatus", options.issueStatus);
+    }
+
+    const query = params.toString();
+    const path = query
+      ? `/projects/${projectId}/comments?${query}`
+      : `/projects/${projectId}/comments`;
+
+    return this.listPaginated<CrowdinStringComment>(path);
+  }
+
+  async addStringComment(
+    projectId: number,
+    request: {
+      text: string;
+      stringId: number;
+      targetLanguageId: string;
+      type: "comment" | "issue";
+      issueType?: string;
+    },
+  ): Promise<CrowdinStringComment> {
+    const response = await this.post<CrowdinGetResponse<CrowdinStringComment>>(
+      `/projects/${projectId}/comments`,
+      request,
     );
     return response.data;
   }

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-comment-pusher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-comment-pusher.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { buildFindingId } from "@/lib/providers/provider-job-qa/build-finding-id";
+import type { ProviderQaFinding } from "@/lib/providers/provider-job-qa/types";
+
+import { buildHyperlocaliseFindingMarker } from "../smartling/smartling-comment-write-back";
+import { pushCrowdinProviderComments } from "./crowdin-comment-pusher";
+
+function sampleFinding(overrides?: Partial<ProviderQaFinding>): ProviderQaFinding {
+  return {
+    checkType: "glossary_violation",
+    severity: "error",
+    message: "Forbidden term",
+    item: {
+      externalStringId: "100",
+      key: "welcome.title",
+      locale: "fr",
+      field: "target",
+    },
+    ...overrides,
+  };
+}
+
+function crowdinListResponse<T>(items: T[]) {
+  return new Response(
+    JSON.stringify({
+      data: items.map((item) => ({ data: item })),
+    }),
+    { status: 200 },
+  );
+}
+
+function crowdinItemResponse<T>(data: T) {
+  return new Response(JSON.stringify({ data }), { status: 200 });
+}
+
+describe("pushCrowdinProviderComments", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("creates Crowdin string issues for new findings", async () => {
+    const finding = sampleFinding();
+    const findingId = buildFindingId(finding);
+    let createCommentCalls = 0;
+
+    const fetchMock = vi.fn(async (url, init) => {
+      const path = String(url);
+      const method = init?.method ?? "GET";
+
+      if (path.includes("/projects/1/comments") && method === "GET") {
+        return crowdinListResponse([]);
+      }
+
+      if (path.endsWith("/projects/1/comments") && method === "POST") {
+        createCommentCalls += 1;
+        return crowdinItemResponse({
+          id: 55,
+          text: buildHyperlocaliseFindingMarker(findingId),
+          userId: 1,
+          stringId: 100,
+          languageId: "fr",
+          type: "issue",
+          projectId: 1,
+          createdAt: "2026-05-01T10:00:00Z",
+        });
+      }
+
+      return new Response("Not Found", { status: 404 });
+    });
+
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await pushCrowdinProviderComments({
+      organizationId: "org_1",
+      projectId: "proj_1",
+      providerKind: "crowdin",
+      externalProjectId: "1",
+      externalJobId: "9",
+      secretMaterial: "token",
+      feedback: [{ findingId, finding }],
+      knownExternalIds: new Map(),
+    });
+
+    expect(createCommentCalls).toBe(1);
+    expect(result.posted).toBe(1);
+    expect(result.skipped).toBe(0);
+    expect(result.changedItems[0]).toMatchObject({
+      status: "posted",
+      externalCommentUid: "55",
+      providerReviewContext: {
+        externalProjectId: "1",
+        externalJobId: "9",
+        externalThreadId: "55",
+        externalCommentId: "55",
+      },
+    });
+  });
+
+  it("skips findings when a matching remote issue already exists", async () => {
+    const finding = sampleFinding();
+    const findingId = buildFindingId(finding);
+    let createCommentCalls = 0;
+
+    const fetchMock = vi.fn(async (url, init) => {
+      const path = String(url);
+      const method = init?.method ?? "GET";
+
+      if (path.includes("/projects/1/comments") && method === "GET") {
+        return crowdinListResponse([
+          {
+            id: 77,
+            text: buildHyperlocaliseFindingMarker(findingId),
+            userId: 1,
+            stringId: 100,
+            languageId: "fr",
+            type: "issue",
+            projectId: 1,
+            createdAt: "2026-05-01T10:00:00Z",
+          },
+        ]);
+      }
+
+      if (path.endsWith("/projects/1/comments") && method === "POST") {
+        createCommentCalls += 1;
+        return crowdinItemResponse({ id: 99 });
+      }
+
+      return new Response("Not Found", { status: 404 });
+    });
+
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await pushCrowdinProviderComments({
+      organizationId: "org_1",
+      projectId: "proj_1",
+      providerKind: "crowdin",
+      externalProjectId: "1",
+      externalJobId: "9",
+      secretMaterial: "token",
+      feedback: [{ findingId, finding }],
+      knownExternalIds: new Map(),
+    });
+
+    expect(createCommentCalls).toBe(0);
+    expect(result.posted).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.changedItems[0]?.status).toBe("skipped");
+    expect(result.changedItems[0]?.externalCommentUid).toBe("77");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-comment-pusher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-comment-pusher.ts
@@ -14,7 +14,7 @@ export const pushCrowdinProviderComments: ExternalTmsCommentPusher = async ({
 }) => {
   const client = new CrowdinApiClient({ token: secretMaterial });
   const projectId = Number(externalProjectId.trim());
-  if (Number.isNaN(projectId)) {
+  if (!externalProjectId.trim() || Number.isNaN(projectId)) {
     throw new Error("invalid_crowdin_project_id");
   }
 

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-comment-pusher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-comment-pusher.ts
@@ -1,0 +1,139 @@
+import type { ExternalTmsCommentPusher } from "@/lib/providers/provider-feedback-types";
+import { buildFindingId } from "@/lib/providers/provider-job-qa/build-finding-id";
+import { parseHyperlocaliseFindingMarker } from "@/lib/providers/smartling/smartling-comment-write-back";
+
+import { CrowdinApiClient, CrowdinApiError } from "./crowdin-api";
+import { buildCrowdinCommentWriteBackEntries } from "./crowdin-comment-write-back";
+
+export const pushCrowdinProviderComments: ExternalTmsCommentPusher = async ({
+  externalProjectId,
+  externalJobId,
+  secretMaterial,
+  feedback,
+  knownExternalIds,
+}) => {
+  const client = new CrowdinApiClient({ token: secretMaterial });
+  const projectId = Number(externalProjectId.trim());
+  if (Number.isNaN(projectId)) {
+    throw new Error("invalid_crowdin_project_id");
+  }
+
+  const locales = new Set(feedback.map((item) => item.finding.item.locale?.trim()).filter(Boolean));
+  const defaultLocaleId = locales.size === 1 ? ([...locales][0] ?? null) : null;
+
+  const { entries, failures: validationFailures } = buildCrowdinCommentWriteBackEntries({
+    findings: feedback.map((item) => item.finding),
+    defaultLocaleId,
+  });
+
+  const entryByFindingId = new Map(entries.map((entry) => [entry.findingId, entry]));
+  const changedItems: Awaited<ReturnType<ExternalTmsCommentPusher>>["changedItems"] = [];
+  const failures = [...validationFailures];
+  let posted = 0;
+  let skipped = 0;
+  let failed = validationFailures.length;
+
+  const stringIds = [...new Set(entries.map((entry) => entry.request.stringId))];
+  const remoteCommentIdsByFindingId = new Map<string, string>();
+
+  if (stringIds.length > 0) {
+    try {
+      const remoteIssues = await client.listStringComments(projectId, {
+        type: "issue",
+        issueStatus: "unresolved",
+      });
+
+      for (const comment of remoteIssues) {
+        if (!stringIds.includes(comment.stringId)) {
+          continue;
+        }
+
+        const findingId = parseHyperlocaliseFindingMarker(comment.text);
+        if (findingId) {
+          remoteCommentIdsByFindingId.set(findingId, String(comment.id));
+        }
+      }
+    } catch (error) {
+      if (error instanceof CrowdinApiError && error.status === 401) {
+        throw new Error("crowdin_auth_invalid");
+      }
+      throw error;
+    }
+  }
+
+  for (const item of feedback) {
+    const findingId = item.findingId || buildFindingId(item.finding);
+    const entry = entryByFindingId.get(findingId);
+    if (!entry) {
+      continue;
+    }
+
+    const known = knownExternalIds.get(findingId) ?? null;
+    const remoteCommentId = remoteCommentIdsByFindingId.get(findingId) ?? null;
+    const existingCommentId = known?.commentUid ?? known?.issueUid ?? remoteCommentId;
+
+    if (existingCommentId) {
+      skipped += 1;
+      changedItems.push({
+        type: "provider_comment",
+        findingId,
+        status: "skipped",
+        externalIssueUid: existingCommentId,
+        externalCommentUid: existingCommentId,
+        hashcode: String(entry.request.stringId),
+        locale: entry.request.targetLanguageId,
+        message: "provider_comment_already_exists",
+        providerReviewContext: item.providerReviewContext ?? {
+          externalProjectId,
+          externalJobId,
+          externalThreadId: existingCommentId,
+          externalCommentId: existingCommentId,
+        },
+      });
+      continue;
+    }
+
+    try {
+      const created = await client.addStringComment(projectId, entry.request);
+      const commentId = String(created.id);
+      posted += 1;
+      changedItems.push({
+        type: "provider_comment",
+        findingId,
+        status: "posted",
+        externalIssueUid: commentId,
+        externalCommentUid: commentId,
+        hashcode: String(entry.request.stringId),
+        locale: entry.request.targetLanguageId,
+        providerReviewContext: item.providerReviewContext ?? {
+          externalProjectId,
+          externalJobId,
+          externalThreadId: commentId,
+          externalCommentId: commentId,
+        },
+      });
+    } catch (error) {
+      failed += 1;
+      const message =
+        error instanceof Error ? error.message : "crowdin_provider_comment_create_failed";
+      failures.push({ findingId, message });
+      changedItems.push({
+        type: "provider_comment",
+        findingId,
+        status: "failed",
+        hashcode: String(entry.request.stringId),
+        locale: entry.request.targetLanguageId,
+        message,
+        providerReviewContext: item.providerReviewContext,
+      });
+    }
+  }
+
+  return {
+    posted,
+    skipped,
+    failed,
+    changedItems,
+    failures,
+  };
+};

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-comment-write-back.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-comment-write-back.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { buildFindingId } from "@/lib/providers/provider-job-qa/build-finding-id";
+import type { ProviderQaFinding } from "@/lib/providers/provider-job-qa/types";
+import { buildHyperlocaliseFindingMarker } from "@/lib/providers/smartling/smartling-comment-write-back";
+
+import {
+  buildCrowdinCommentWriteBackEntries,
+  mapProviderSeverityToCrowdinIssueType,
+} from "./crowdin-comment-write-back";
+
+function sampleFinding(overrides?: Partial<ProviderQaFinding>): ProviderQaFinding {
+  return {
+    checkType: "glossary_violation",
+    severity: "warning",
+    message: "Term mismatch",
+    suggestedFix: "Use approved glossary term",
+    confidence: 0.92,
+    item: {
+      externalStringId: "100",
+      key: "welcome.title",
+      locale: "fr",
+      field: "target",
+    },
+    ...overrides,
+  };
+}
+
+describe("crowdin-comment-write-back", () => {
+  it("maps provider severities to Crowdin issue types", () => {
+    expect(mapProviderSeverityToCrowdinIssueType("error")).toBe("translation_mistake");
+    expect(mapProviderSeverityToCrowdinIssueType("warning")).toBe("general_question");
+    expect(mapProviderSeverityToCrowdinIssueType("info")).toBe("context_request");
+  });
+
+  it("builds issue requests with markers and metadata", () => {
+    const finding = sampleFinding();
+    const { entries, failures } = buildCrowdinCommentWriteBackEntries({
+      findings: [finding],
+      defaultLocaleId: null,
+    });
+
+    expect(failures).toEqual([]);
+    expect(entries).toHaveLength(1);
+
+    const findingId = buildFindingId(finding);
+    expect(entries[0]?.findingId).toBe(findingId);
+    expect(entries[0]?.request).toMatchObject({
+      stringId: 100,
+      targetLanguageId: "fr",
+      type: "issue",
+      issueType: "general_question",
+    });
+    expect(entries[0]?.request.text).toContain(buildHyperlocaliseFindingMarker(findingId));
+    expect(entries[0]?.request.text).toContain("[glossary_violation] Term mismatch");
+    expect(entries[0]?.request.text).toContain("Suggested fix:");
+    expect(entries[0]?.request.text).toContain("Confidence: 0.92");
+  });
+
+  it("records validation failures for missing string id or locale", () => {
+    const missingStringId = sampleFinding({
+      item: { externalStringId: "  ", key: "k1", locale: "fr" },
+    });
+    const missingLocale = sampleFinding({
+      item: { externalStringId: "100", key: "k2" },
+    });
+
+    const { entries, failures } = buildCrowdinCommentWriteBackEntries({
+      findings: [missingStringId, missingLocale],
+      defaultLocaleId: null,
+    });
+
+    expect(entries).toEqual([]);
+    expect(failures).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ message: "crowdin_comment_missing_string_id" }),
+        expect.objectContaining({ message: "crowdin_comment_missing_locale" }),
+      ]),
+    );
+  });
+
+  it("falls back to default locale when finding locale is absent", () => {
+    const finding = sampleFinding({
+      item: { externalStringId: "100", key: "k1" },
+    });
+
+    const { entries, failures } = buildCrowdinCommentWriteBackEntries({
+      findings: [finding],
+      defaultLocaleId: "de",
+    });
+
+    expect(failures).toEqual([]);
+    expect(entries[0]?.request.targetLanguageId).toBe("de");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-comment-write-back.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-comment-write-back.ts
@@ -1,0 +1,92 @@
+import { buildFindingId } from "@/lib/providers/provider-job-qa/build-finding-id";
+import type { ProviderQaFinding } from "@/lib/providers/provider-job-qa/types";
+import { buildHyperlocaliseFindingMarker } from "@/lib/providers/smartling/smartling-comment-write-back";
+
+export type CrowdinCommentWriteBackEntry = {
+  findingId: string;
+  finding: ProviderQaFinding;
+  request: {
+    stringId: number;
+    targetLanguageId: string;
+    text: string;
+    type: "issue";
+    issueType: string;
+  };
+};
+
+export function mapProviderSeverityToCrowdinIssueType(severity: ProviderQaFinding["severity"]) {
+  switch (severity) {
+    case "error":
+      return "translation_mistake";
+    case "warning":
+      return "general_question";
+    case "info":
+    default:
+      return "context_request";
+  }
+}
+
+function formatIssueText(finding: ProviderQaFinding, findingId: string) {
+  const lines = [
+    buildHyperlocaliseFindingMarker(findingId),
+    `[${finding.checkType}] ${finding.message}`,
+  ];
+
+  if (finding.suggestedFix) {
+    lines.push(`Suggested fix: ${finding.suggestedFix}`);
+  }
+
+  if (typeof finding.confidence === "number") {
+    lines.push(`Confidence: ${finding.confidence}`);
+  }
+
+  return lines.join("\n");
+}
+
+export function buildCrowdinCommentWriteBackEntries(input: {
+  findings: ProviderQaFinding[];
+  defaultLocaleId: string | null;
+}): {
+  entries: CrowdinCommentWriteBackEntry[];
+  failures: Array<{ findingId: string; message: string }>;
+} {
+  const entries: CrowdinCommentWriteBackEntry[] = [];
+  const failures: Array<{ findingId: string; message: string }> = [];
+
+  for (const finding of input.findings) {
+    const findingId = buildFindingId(finding);
+    const rawStringId = finding.item.externalStringId.trim();
+    const stringId = Number(rawStringId);
+    const targetLanguageId = finding.item.locale?.trim() || input.defaultLocaleId?.trim() || "";
+
+    if (!rawStringId || Number.isNaN(stringId)) {
+      failures.push({
+        findingId,
+        message: "crowdin_comment_missing_string_id",
+      });
+      continue;
+    }
+
+    if (!targetLanguageId) {
+      failures.push({
+        findingId,
+        message: "crowdin_comment_missing_locale",
+      });
+      continue;
+    }
+
+    entries.push({
+      findingId,
+      finding,
+      request: {
+        stringId,
+        targetLanguageId,
+        text: formatIssueText(finding, findingId),
+        type: "issue",
+        issueType: mapProviderSeverityToCrowdinIssueType(finding.severity),
+      },
+    });
+  }
+
+  return { entries, failures };
+}

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-review-normalize.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-review-normalize.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import type { CrowdinStringComment, CrowdinTaskComment } from "./crowdin-api";
+import {
+  buildCrowdinStringCommentProviderUrl,
+  buildCrowdinTaskCommentProviderUrl,
+  normalizeCrowdinStringCommentToThread,
+  normalizeCrowdinTaskCommentToThread,
+} from "./crowdin-review-normalize";
+
+describe("crowdin review normalization", () => {
+  it("maps string issues with resolution state and provider links", () => {
+    const comment: CrowdinStringComment = {
+      id: 42,
+      text: "Wrong tense",
+      userId: 7,
+      stringId: 100,
+      languageId: "de",
+      type: "issue",
+      issueType: "translation_mistake",
+      issueStatus: "unresolved",
+      resolverId: null,
+      resolver: null,
+      user: {
+        id: 7,
+        username: "reviewer",
+        fullName: "Reviewer",
+      },
+      resolvedAt: null,
+      createdAt: "2026-05-01T10:00:00Z",
+      projectId: 1,
+    };
+
+    const thread = normalizeCrowdinStringCommentToThread({
+      comment,
+      externalProjectId: "1",
+      externalJobId: "9",
+      projectWebUrl: "https://crowdin.com/project/demo",
+      stringKeyById: new Map([["100", "welcome.title"]]),
+    });
+
+    expect(thread.kind).toBe("issue");
+    expect(thread.state).toBe("open");
+    expect(thread.item).toEqual({
+      externalStringId: "100",
+      key: "welcome.title",
+      locale: "de",
+      field: "target",
+    });
+    expect(thread.providerContext.providerUrl).toBe(
+      buildCrowdinStringCommentProviderUrl({
+        projectWebUrl: "https://crowdin.com/project/demo",
+        stringId: 100,
+        commentId: 42,
+      }),
+    );
+  });
+
+  it("maps resolved issues and plain comments", () => {
+    const resolved: CrowdinStringComment = {
+      id: 43,
+      text: "Resolved issue",
+      userId: 1,
+      stringId: 101,
+      languageId: "fr",
+      type: "issue",
+      issueStatus: "resolved",
+      createdAt: "2026-05-01T10:00:00Z",
+      projectId: 1,
+      resolvedAt: "2026-05-02T10:00:00Z",
+    };
+
+    const plainComment: CrowdinStringComment = {
+      id: 44,
+      text: "FYI",
+      userId: 2,
+      stringId: 102,
+      languageId: "fr",
+      type: "comment",
+      createdAt: "2026-05-03T10:00:00Z",
+      projectId: 1,
+    };
+
+    const resolvedThread = normalizeCrowdinStringCommentToThread({
+      comment: resolved,
+      externalProjectId: "1",
+      externalJobId: "9",
+      projectWebUrl: "https://crowdin.com/project/demo",
+      stringKeyById: new Map(),
+    });
+
+    const commentThread = normalizeCrowdinStringCommentToThread({
+      comment: plainComment,
+      externalProjectId: "1",
+      externalJobId: "9",
+      projectWebUrl: "https://crowdin.com/project/demo",
+      stringKeyById: new Map([["102", "cta.label"]]),
+    });
+
+    expect(resolvedThread.state).toBe("resolved");
+    expect(commentThread.kind).toBe("comment");
+    expect(commentThread.state).toBe("unknown");
+    expect(commentThread.item?.key).toBe("cta.label");
+  });
+
+  it("maps task comments with task web urls", () => {
+    const comment: CrowdinTaskComment = {
+      id: 5,
+      userId: 3,
+      taskId: 9,
+      text: "Please finish review",
+      createdAt: "2026-05-04T10:00:00Z",
+      updatedAt: "2026-05-04T11:00:00Z",
+    };
+
+    const thread = normalizeCrowdinTaskCommentToThread({
+      comment,
+      externalProjectId: "1",
+      externalJobId: "9",
+      taskWebUrl: "https://crowdin.com/project/demo/tasks/9",
+    });
+
+    expect(thread.kind).toBe("task_comment");
+    expect(thread.providerContext.providerUrl).toBe(
+      buildCrowdinTaskCommentProviderUrl({
+        taskWebUrl: "https://crowdin.com/project/demo/tasks/9",
+        commentId: 5,
+      }),
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-review-normalize.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-review-normalize.ts
@@ -84,7 +84,7 @@ export function normalizeCrowdinStringCommentToThread(input: {
         body: input.comment.text,
         author: mapCrowdinUser(input.comment.user),
         createdAt: input.comment.createdAt ?? null,
-        updatedAt: input.comment.resolvedAt ?? null,
+        updatedAt: input.comment.resolvedAt ?? input.comment.createdAt ?? null,
       },
     ],
     author: mapCrowdinUser(input.comment.user),

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-review-normalize.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-review-normalize.ts
@@ -1,0 +1,155 @@
+import { buildProviderReviewThreadId } from "@/lib/providers/provider-job-review/build-thread-id";
+import type {
+  ProviderReviewAuthor,
+  ProviderReviewThread,
+  ProviderReviewThreadKind,
+  ProviderReviewThreadState,
+} from "@/lib/providers/provider-job-review/types";
+
+import type { CrowdinShortUser, CrowdinStringComment, CrowdinTaskComment } from "./crowdin-api";
+
+function mapCrowdinUser(user: CrowdinShortUser | null | undefined): ProviderReviewAuthor | null {
+  if (!user) {
+    return null;
+  }
+
+  return {
+    externalUserId: String(user.id),
+    username: user.username ?? null,
+    displayName: user.fullName?.trim() || user.username || null,
+  };
+}
+
+function mapIssueState(issueStatus: string | null | undefined): ProviderReviewThreadState {
+  if (issueStatus === "resolved") {
+    return "resolved";
+  }
+  if (issueStatus === "unresolved") {
+    return "open";
+  }
+  return "unknown";
+}
+
+export function buildCrowdinStringCommentProviderUrl(input: {
+  projectWebUrl: string;
+  stringId: number;
+  commentId: number;
+}) {
+  const base = input.projectWebUrl.replace(/\/+$/g, "");
+  return `${base}/comments?commentId=${input.commentId}&stringId=${input.stringId}`;
+}
+
+export function buildCrowdinTaskCommentProviderUrl(input: {
+  taskWebUrl: string;
+  commentId: number;
+}) {
+  const base = input.taskWebUrl.replace(/\/+$/g, "");
+  return `${base}#comment-${input.commentId}`;
+}
+
+export function normalizeCrowdinStringCommentToThread(input: {
+  comment: CrowdinStringComment;
+  externalProjectId: string;
+  externalJobId: string;
+  projectWebUrl: string;
+  stringKeyById: Map<string, string>;
+}): ProviderReviewThread {
+  const kind: ProviderReviewThreadKind = input.comment.type === "issue" ? "issue" : "comment";
+  const externalThreadId = String(input.comment.id);
+  const stringKey =
+    input.stringKeyById.get(String(input.comment.stringId)) ?? String(input.comment.stringId);
+
+  return {
+    threadId: buildProviderReviewThreadId({
+      providerKind: "crowdin",
+      externalProjectId: input.externalProjectId,
+      externalJobId: input.externalJobId,
+      kind,
+      externalThreadId,
+    }),
+    kind,
+    state: kind === "issue" ? mapIssueState(input.comment.issueStatus) : "unknown",
+    subject: input.comment.text,
+    issueType: input.comment.issueType ?? null,
+    item: {
+      externalStringId: String(input.comment.stringId),
+      key: stringKey,
+      locale: input.comment.languageId || undefined,
+      field: "target",
+    },
+    locale: input.comment.languageId || null,
+    comments: [
+      {
+        externalCommentId: externalThreadId,
+        body: input.comment.text,
+        author: mapCrowdinUser(input.comment.user),
+        createdAt: input.comment.createdAt ?? null,
+        updatedAt: input.comment.resolvedAt ?? null,
+      },
+    ],
+    author: mapCrowdinUser(input.comment.user),
+    resolver: mapCrowdinUser(input.comment.resolver),
+    createdAt: input.comment.createdAt ?? null,
+    updatedAt: input.comment.resolvedAt ?? input.comment.createdAt ?? null,
+    resolvedAt: input.comment.resolvedAt ?? null,
+    providerContext: {
+      externalProjectId: input.externalProjectId,
+      externalJobId: input.externalJobId,
+      externalThreadId,
+      externalCommentId: externalThreadId,
+      providerUrl: buildCrowdinStringCommentProviderUrl({
+        projectWebUrl: input.projectWebUrl,
+        stringId: input.comment.stringId,
+        commentId: input.comment.id,
+      }),
+    },
+  };
+}
+
+export function normalizeCrowdinTaskCommentToThread(input: {
+  comment: CrowdinTaskComment;
+  externalProjectId: string;
+  externalJobId: string;
+  taskWebUrl: string;
+}): ProviderReviewThread {
+  const externalThreadId = String(input.comment.id);
+
+  return {
+    threadId: buildProviderReviewThreadId({
+      providerKind: "crowdin",
+      externalProjectId: input.externalProjectId,
+      externalJobId: input.externalJobId,
+      kind: "task_comment",
+      externalThreadId,
+    }),
+    kind: "task_comment",
+    state: "unknown",
+    subject: input.comment.text,
+    comments: [
+      {
+        externalCommentId: externalThreadId,
+        body: input.comment.text,
+        author: {
+          externalUserId: String(input.comment.userId),
+        },
+        createdAt: input.comment.createdAt ?? null,
+        updatedAt: input.comment.updatedAt ?? null,
+      },
+    ],
+    author: {
+      externalUserId: String(input.comment.userId),
+    },
+    createdAt: input.comment.createdAt ?? null,
+    updatedAt: input.comment.updatedAt ?? null,
+    providerContext: {
+      externalProjectId: input.externalProjectId,
+      externalJobId: input.externalJobId,
+      externalThreadId,
+      externalCommentId: externalThreadId,
+      providerUrl: buildCrowdinTaskCommentProviderUrl({
+        taskWebUrl: input.taskWebUrl,
+        commentId: input.comment.id,
+      }),
+    },
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-review-puller.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-review-puller.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { pullCrowdinProviderReview } from "./crowdin-review-puller";
+
+describe("pullCrowdinProviderReview", () => {
+  it("deduplicates string and task comments for repeated sync", async () => {
+    const fetchFn = vi.fn(async (url: string) => {
+      if (url.includes("/projects/1/tasks/9/comments")) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  id: 5,
+                  userId: 3,
+                  taskId: 9,
+                  text: "Task note",
+                  createdAt: "2026-05-04T10:00:00Z",
+                  updatedAt: "2026-05-04T10:00:00Z",
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (url.includes("/projects/1/tasks/9") && !url.includes("/comments")) {
+        return new Response(
+          JSON.stringify({
+            data: {
+              id: 9,
+              projectId: 1,
+              type: 0,
+              status: "in_progress",
+              title: "Review",
+              description: null,
+              languageId: "de",
+              fileIds: [],
+              assignees: null,
+              deadline: null,
+              webUrl: "https://crowdin.com/project/demo/tasks/9",
+              stringIds: [100],
+              targetLanguageId: "de",
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (url.includes("/projects/1") && !url.includes("/tasks/") && !url.includes("/comments")) {
+        return new Response(
+          JSON.stringify({
+            data: {
+              id: 1,
+              name: "Demo",
+              identifier: "demo",
+              sourceLanguageId: "en",
+              targetLanguageIds: ["de"],
+              webUrl: "https://crowdin.com/project/demo",
+              isSuspended: false,
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (url.includes("/projects/1/comments")) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  id: 42,
+                  text: "Issue text",
+                  userId: 7,
+                  stringId: 100,
+                  languageId: "de",
+                  type: "issue",
+                  issueType: "translation_mistake",
+                  issueStatus: "unresolved",
+                  createdAt: "2026-05-01T10:00:00Z",
+                  projectId: 1,
+                },
+              },
+              {
+                data: {
+                  id: 42,
+                  text: "Issue text duplicate",
+                  userId: 7,
+                  stringId: 100,
+                  languageId: "de",
+                  type: "issue",
+                  issueType: "translation_mistake",
+                  issueStatus: "unresolved",
+                  createdAt: "2026-05-01T10:00:00Z",
+                  projectId: 1,
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response("not found", { status: 404 });
+    });
+
+    const report = await pullCrowdinProviderReview({
+      credential: {},
+      secretMaterial: "token",
+      fetchFn: fetchFn as typeof fetch,
+      externalProjectId: "1",
+      externalJobId: "9",
+      content: {
+        externalJobId: "9",
+        targetLocales: ["de"],
+        units: [
+          {
+            externalStringId: "100",
+            key: "welcome.title",
+            sourceText: "Hello",
+            translations: [{ locale: "de", text: "Hallo" }],
+          },
+        ],
+      },
+    });
+
+    expect(report.summary.total).toBe(2);
+    expect(report.summary.byKind.issue).toBe(1);
+    expect(report.summary.byKind.task_comment).toBe(1);
+    expect(report.threads.some((thread) => thread.item?.key === "welcome.title")).toBe(true);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-review-puller.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-review-puller.ts
@@ -79,8 +79,11 @@ export async function pullCrowdinProviderReview(
     stringComments.push(...(await client.listStringComments(projectId)));
   } else {
     for (const chunk of chunkArray(stringIdList, 25)) {
-      for (const stringId of chunk) {
-        stringComments.push(...(await client.listStringComments(projectId, { stringId })));
+      const chunkResults = await Promise.all(
+        chunk.map((stringId) => client.listStringComments(projectId, { stringId })),
+      );
+      for (const comments of chunkResults) {
+        stringComments.push(...comments);
       }
     }
   }

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-review-puller.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-review-puller.ts
@@ -1,0 +1,113 @@
+import type { ExternalTmsTaskContent } from "@/lib/providers/external-tms-content-sync";
+import { buildProviderReviewReport } from "@/lib/providers/provider-job-review/normalize-provider-review";
+import type { ProviderReviewReport } from "@/lib/providers/provider-job-review/types";
+
+import { CrowdinApiClient, CrowdinApiError } from "./crowdin-api";
+import {
+  normalizeCrowdinStringCommentToThread,
+  normalizeCrowdinTaskCommentToThread,
+} from "./crowdin-review-normalize";
+
+function chunkArray<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
+}
+
+export type CrowdinReviewPullInput = {
+  credential: { baseUrl?: string | null };
+  secretMaterial: string;
+  externalProjectId: string;
+  externalJobId: string;
+  content: ExternalTmsTaskContent;
+  fetchFn?: typeof fetch;
+};
+
+export async function pullCrowdinProviderReview(
+  input: CrowdinReviewPullInput,
+): Promise<ProviderReviewReport> {
+  const client = new CrowdinApiClient({
+    token: input.secretMaterial,
+    baseUrl: input.credential.baseUrl ?? undefined,
+    fetchFn: input.fetchFn,
+  });
+
+  const projectId = Number(input.externalProjectId);
+  const taskId = Number(input.externalJobId);
+  if (Number.isNaN(projectId) || Number.isNaN(taskId)) {
+    throw new Error("invalid_crowdin_project_or_task_id");
+  }
+
+  let task: Awaited<ReturnType<typeof client.getTask>>;
+  let project: Awaited<ReturnType<typeof client.getProject>>;
+  try {
+    [task, project] = await Promise.all([
+      client.getTask(projectId, taskId),
+      client.getProject(projectId),
+    ]);
+  } catch (error) {
+    if (error instanceof CrowdinApiError && error.status === 401) {
+      throw new Error("crowdin_auth_invalid");
+    }
+    throw error;
+  }
+
+  const stringKeyById = new Map(
+    input.content.units.map((unit) => [unit.externalStringId, unit.key] as const),
+  );
+
+  const stringIds = new Set<number>();
+  for (const unit of input.content.units) {
+    const stringId = Number(unit.externalStringId);
+    if (!Number.isNaN(stringId)) {
+      stringIds.add(stringId);
+    }
+  }
+
+  if (task.stringIds) {
+    for (const stringId of task.stringIds) {
+      stringIds.add(stringId);
+    }
+  }
+
+  const stringComments: Awaited<ReturnType<typeof client.listStringComments>> = [];
+  const stringIdList = [...stringIds];
+
+  if (stringIdList.length === 0) {
+    stringComments.push(...(await client.listStringComments(projectId)));
+  } else {
+    for (const chunk of chunkArray(stringIdList, 25)) {
+      for (const stringId of chunk) {
+        stringComments.push(...(await client.listStringComments(projectId, { stringId })));
+      }
+    }
+  }
+
+  const taskComments = await client.listTaskComments(projectId, taskId);
+
+  const threads = [
+    ...stringComments.map((comment) =>
+      normalizeCrowdinStringCommentToThread({
+        comment,
+        externalProjectId: input.externalProjectId,
+        externalJobId: input.externalJobId,
+        projectWebUrl: project.webUrl,
+        stringKeyById,
+      }),
+    ),
+    ...taskComments.map((comment) =>
+      normalizeCrowdinTaskCommentToThread({
+        comment,
+        externalProjectId: input.externalProjectId,
+        externalJobId: input.externalJobId,
+        taskWebUrl: task.webUrl,
+      }),
+    ),
+  ];
+
+  const deduped = new Map(threads.map((thread) => [thread.threadId, thread] as const));
+
+  return buildProviderReviewReport([...deduped.values()]);
+}

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-review-puller.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-review-puller.ts
@@ -81,7 +81,8 @@ export async function pullCrowdinProviderReview(
   const stringIdList = [...stringIds];
 
   if (stringIdList.length === 0) {
-    stringComments.push(...(await client.listStringComments(projectId)));
+    // No job-specific string IDs available — skip string comment fetch to avoid
+    // pulling in comments from unrelated jobs in the same project.
   } else {
     for (const chunk of chunkArray(stringIdList, 25)) {
       const chunkResults = await Promise.all(

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-review-puller.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-review-puller.ts
@@ -36,7 +36,12 @@ export async function pullCrowdinProviderReview(
 
   const projectId = Number(input.externalProjectId);
   const taskId = Number(input.externalJobId);
-  if (Number.isNaN(projectId) || Number.isNaN(taskId)) {
+  if (
+    !input.externalProjectId.trim() ||
+    !input.externalJobId.trim() ||
+    Number.isNaN(projectId) ||
+    Number.isNaN(taskId)
+  ) {
     throw new Error("invalid_crowdin_project_or_task_id");
   }
 

--- a/apps/hyperlocalise-web/src/lib/providers/provider-agent-qa.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-agent-qa.test.ts
@@ -14,6 +14,11 @@ import { executeProviderAgentQa } from "./provider-agent-qa";
 const projectFixture = createProjectTestFixture();
 const pullExternalTmsTaskContentMock = vi.fn();
 const runHlCheckOnProviderContentMock = vi.fn();
+const pullProviderReviewForJobMock = vi.fn();
+
+vi.mock("@/lib/providers/sync-provider-review", () => ({
+  pullProviderReviewForJob: (...args: unknown[]) => pullProviderReviewForJobMock(...args),
+}));
 
 const providerContentPullerMocks = vi.hoisted(() => {
   type GetProviderContentPuller = (
@@ -63,6 +68,7 @@ afterEach(async () => {
   await projectFixture.cleanup();
   pullExternalTmsTaskContentMock.mockReset();
   runHlCheckOnProviderContentMock.mockReset();
+  pullProviderReviewForJobMock.mockReset();
   providerContentPullerMocks.getProviderContentPullerMock.mockImplementation(
     providerContentPullerMocks.state.actual,
   );
@@ -237,6 +243,68 @@ describe("executeProviderAgentQa", () => {
     expect(result).toMatchObject({
       ok: false,
       code: "missing_project_id",
+    });
+  });
+
+  it("syncs provider review threads for review_with_agent runs", async () => {
+    const project = await createExternalTmsProject();
+
+    pullExternalTmsTaskContentMock.mockResolvedValue({
+      runId: "pull-run-review-1",
+      counts: { unitsDiscovered: 1, translationsDiscovered: 1, approvedTranslations: 0 },
+      content: pulledContent,
+      failures: [],
+    });
+    runHlCheckOnProviderContentMock.mockResolvedValue({
+      report: { checks: [], findings: [], summary: { total: 0 } },
+      keyManifest: {
+        hello: { externalStringId: "1", key: "hello" },
+      },
+      workspaceRoot: "/tmp/hl-provider-review",
+    });
+    pullProviderReviewForJobMock.mockResolvedValue({
+      threads: [
+        {
+          threadId: "crowdin:123:task-qa-1:issue:42",
+          kind: "issue",
+          state: "open",
+          comments: [{ externalCommentId: "42", body: "Needs review" }],
+          providerContext: {
+            externalProjectId: "123",
+            externalJobId: "task-qa-1",
+            externalThreadId: "42",
+            providerUrl: "https://crowdin.com/project/demo",
+          },
+        },
+      ],
+      summary: { total: 1, open: 1, resolved: 0, byKind: { issue: 1 } },
+    });
+
+    const run = await createAgentRun({
+      organizationId: project.organizationId,
+      providerKind: "crowdin",
+      externalJobId: "task-qa-1",
+      kind: "review",
+      inputSnapshot: { projectId: project.id, action: "review_with_agent" },
+    });
+
+    const result = await executeProviderAgentQa({
+      agentRunId: run.id,
+      organizationId: project.organizationId,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(pullProviderReviewForJobMock).toHaveBeenCalled();
+
+    const completed = await getAgentRun({
+      runId: run.id,
+      organizationId: project.organizationId,
+    });
+
+    expect(completed?.outputSummary?.reviewThreads).toHaveLength(1);
+    expect(completed?.outputSummary?.reviewSummary).toMatchObject({
+      total: 1,
+      open: 1,
     });
   });
 

--- a/apps/hyperlocalise-web/src/lib/providers/provider-agent-qa.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-agent-qa.ts
@@ -30,6 +30,7 @@ import {
 } from "@/lib/providers/provider-job-review/normalize-provider-review";
 import type { ProviderReviewReport } from "@/lib/providers/provider-job-review/types";
 import { providerReviewReportSchema } from "@/api/routes/project/job-qa.schema";
+import { readInputSnapshotAction } from "@/lib/providers/read-input-snapshot-action";
 import { pullProviderReviewForJob } from "@/lib/providers/sync-provider-review";
 
 export type ProviderAgentQaResult =
@@ -55,11 +56,6 @@ function readProjectIdFromInputSnapshot(inputSnapshot: Record<string, unknown>):
 function readOutputSummaryString(outputSummary: Record<string, unknown>, key: string): string {
   const value = outputSummary[key];
   return typeof value === "string" ? value : "";
-}
-
-function readInputSnapshotAction(inputSnapshot: Record<string, unknown>): string | null {
-  const action = inputSnapshot.action;
-  return typeof action === "string" ? action : null;
 }
 
 function readStoredReviewReport(

--- a/apps/hyperlocalise-web/src/lib/providers/provider-agent-qa.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-agent-qa.ts
@@ -407,13 +407,13 @@ export async function completeProviderAgentQaRun(input: {
   let reviewReport: ProviderReviewReport = buildProviderReviewReport([]);
 
   if (input.syncProviderReview) {
-    try {
-      const previousReport = await loadPreviousProviderReviewReport({
-        organizationId: input.organizationId,
-        hyperlocaliseJobId: input.hyperlocaliseJobId ?? null,
-        currentRunId: input.agentRunId,
-      });
+    const previousReport = await loadPreviousProviderReviewReport({
+      organizationId: input.organizationId,
+      hyperlocaliseJobId: input.hyperlocaliseJobId ?? null,
+      currentRunId: input.agentRunId,
+    });
 
+    try {
       reviewReport =
         (await pullProviderReviewForJob({
           organizationId: input.organizationId,
@@ -427,14 +427,7 @@ export async function completeProviderAgentQaRun(input: {
       const message =
         error instanceof Error ? error.message : "Provider review comment sync failed";
       reviewWarnings.push(message);
-      reviewReport = mergeProviderReviewReports(
-        await loadPreviousProviderReviewReport({
-          organizationId: input.organizationId,
-          hyperlocaliseJobId: input.hyperlocaliseJobId ?? null,
-          currentRunId: input.agentRunId,
-        }),
-        buildProviderReviewReport([]),
-      );
+      reviewReport = mergeProviderReviewReports(previousReport, buildProviderReviewReport([]));
     }
   }
 

--- a/apps/hyperlocalise-web/src/lib/providers/provider-agent-qa.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-agent-qa.ts
@@ -2,6 +2,7 @@ import {
   completeAgentRun,
   failAgentRun,
   getAgentRun,
+  listAgentRuns,
   startAgentRun,
 } from "@/lib/providers/agent-runs";
 import {
@@ -23,6 +24,13 @@ import {
   type RunHlCheckResult,
 } from "@/lib/providers/provider-job-qa/run-hl-check";
 import type { ProviderQaReport } from "@/lib/providers/provider-job-qa/types";
+import {
+  buildProviderReviewReport,
+  mergeProviderReviewReports,
+} from "@/lib/providers/provider-job-review/normalize-provider-review";
+import type { ProviderReviewReport } from "@/lib/providers/provider-job-review/types";
+import { providerReviewReportSchema } from "@/api/routes/project/job-qa.schema";
+import { pullProviderReviewForJob } from "@/lib/providers/sync-provider-review";
 
 export type ProviderAgentQaResult =
   | {
@@ -47,6 +55,61 @@ function readProjectIdFromInputSnapshot(inputSnapshot: Record<string, unknown>):
 function readOutputSummaryString(outputSummary: Record<string, unknown>, key: string): string {
   const value = outputSummary[key];
   return typeof value === "string" ? value : "";
+}
+
+function readInputSnapshotAction(inputSnapshot: Record<string, unknown>): string | null {
+  const action = inputSnapshot.action;
+  return typeof action === "string" ? action : null;
+}
+
+function readStoredReviewReport(
+  outputSummary: Record<string, unknown>,
+): ProviderReviewReport | null {
+  const parsed = providerReviewReportSchema.safeParse({
+    threads: outputSummary.reviewThreads,
+    summary: outputSummary.reviewSummary,
+  });
+
+  if (!parsed.success) {
+    return null;
+  }
+
+  return parsed.data;
+}
+
+async function loadPreviousProviderReviewReport(input: {
+  organizationId: string;
+  hyperlocaliseJobId: string | null;
+  currentRunId: string;
+}): Promise<ProviderReviewReport | null> {
+  if (!input.hyperlocaliseJobId) {
+    return null;
+  }
+
+  const priorRuns = await listAgentRuns({
+    organizationId: input.organizationId,
+    hyperlocaliseJobId: input.hyperlocaliseJobId,
+    kind: "review",
+    status: "succeeded",
+    limit: 25,
+  });
+
+  for (const run of priorRuns) {
+    if (run.id === input.currentRunId) {
+      continue;
+    }
+
+    if (readInputSnapshotAction(run.inputSnapshot ?? {}) !== "review_with_agent") {
+      continue;
+    }
+
+    const report = readStoredReviewReport(run.outputSummary ?? {});
+    if (report) {
+      return report;
+    }
+  }
+
+  return null;
 }
 
 function readStoredReport(outputSummary: Record<string, unknown>): ProviderQaReport | null {
@@ -294,11 +357,14 @@ export async function completeProviderAgentQaRun(input: {
   organizationId: string;
   projectId: string;
   providerKind: ExternalTmsProviderKind;
+  externalJobId: string;
   pullRunId: string;
   content: ExternalTmsTaskContent;
   pullFailures: ExternalTmsContentSyncFailure[];
   unitsDiscovered: number;
   hlResult: RunHlCheckResult;
+  syncProviderReview?: boolean;
+  hyperlocaliseJobId?: string | null;
 }): Promise<ProviderAgentQaResult> {
   const glossaryTerms = await loadProjectGlossaryTerms(input.projectId);
   const [translationMemoryUsage, glossaryUsage] = await Promise.all([
@@ -337,6 +403,41 @@ export async function completeProviderAgentQaRun(input: {
     input.hlResult,
   );
 
+  const reviewWarnings: string[] = [];
+  let reviewReport: ProviderReviewReport = buildProviderReviewReport([]);
+
+  if (input.syncProviderReview) {
+    try {
+      const previousReport = await loadPreviousProviderReviewReport({
+        organizationId: input.organizationId,
+        hyperlocaliseJobId: input.hyperlocaliseJobId ?? null,
+        currentRunId: input.agentRunId,
+      });
+
+      reviewReport =
+        (await pullProviderReviewForJob({
+          organizationId: input.organizationId,
+          projectId: input.projectId,
+          providerKind: input.providerKind,
+          externalJobId: input.externalJobId,
+          content: input.content,
+          previousReport,
+        })) ?? buildProviderReviewReport([]);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Provider review comment sync failed";
+      reviewWarnings.push(message);
+      reviewReport = mergeProviderReviewReports(
+        await loadPreviousProviderReviewReport({
+          organizationId: input.organizationId,
+          hyperlocaliseJobId: input.hyperlocaliseJobId ?? null,
+          currentRunId: input.agentRunId,
+        }),
+        buildProviderReviewReport([]),
+      );
+    }
+  }
+
   await completeAgentRun({
     runId: input.agentRunId,
     organizationId: input.organizationId,
@@ -346,13 +447,15 @@ export async function completeProviderAgentQaRun(input: {
       findingCount: report.summary.total,
       findings: report.findings,
       summary: report.summary,
+      reviewThreads: reviewReport.threads,
+      reviewSummary: reviewReport.summary,
       targetLocales: input.content.targetLocales,
       sourceLocale: input.content.sourceLocale ?? null,
       translationMemoryUsage,
       glossaryUsage,
     },
     changedItems: [],
-    warnings: input.pullFailures.map((failure) => failure.message),
+    warnings: [...input.pullFailures.map((failure) => failure.message), ...reviewWarnings],
   });
 
   return {
@@ -386,15 +489,23 @@ export async function executeProviderAgentQa(input: {
     targetLocales: prepared.content.targetLocales,
   });
 
+  const run = await getAgentRun({
+    runId: input.agentRunId,
+    organizationId: input.organizationId,
+  });
+
   return completeProviderAgentQaRun({
     agentRunId: input.agentRunId,
     organizationId: input.organizationId,
     projectId: prepared.projectId,
     providerKind: prepared.providerKind,
+    externalJobId: run?.externalJobId ?? "",
     pullRunId: prepared.pullRunId,
     content: prepared.content,
     pullFailures: prepared.pullFailures,
     unitsDiscovered: prepared.unitsDiscovered,
     hlResult,
+    syncProviderReview: readInputSnapshotAction(run?.inputSnapshot ?? {}) === "review_with_agent",
+    hyperlocaliseJobId: run?.hyperlocaliseJobId ?? null,
   });
 }

--- a/apps/hyperlocalise-web/src/lib/providers/provider-comment-pushers.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-comment-pushers.ts
@@ -1,4 +1,5 @@
 import type { ExternalTmsCommentPusher } from "@/lib/providers/provider-feedback-types";
+import { pushCrowdinProviderComments } from "@/lib/providers/crowdin/crowdin-comment-pusher";
 import { pushSmartlingProviderComments } from "@/lib/providers/smartling/smartling-comment-pusher";
 
 import type { ExternalTmsProviderKind } from "./organization-external-tms-provider-credentials";
@@ -9,6 +10,8 @@ export function getProviderCommentPusher(
   switch (providerKind) {
     case "smartling":
       return pushSmartlingProviderComments;
+    case "crowdin":
+      return pushCrowdinProviderComments;
     default:
       return null;
   }

--- a/apps/hyperlocalise-web/src/lib/providers/provider-feedback-types.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-feedback-types.ts
@@ -1,9 +1,11 @@
+import type { ProviderReviewContext } from "@/lib/providers/provider-job-review/types";
 import type { ProviderQaFinding } from "@/lib/providers/provider-job-qa/types";
 import type { ExternalTmsProviderKind } from "@/lib/providers/organization-external-tms-provider-credentials";
 
 export type ProviderQaFeedbackUpload = {
   findingId: string;
   finding: ProviderQaFinding;
+  providerReviewContext?: ProviderReviewContext | null;
 };
 
 export type ProviderCommentChangedItem = {
@@ -15,6 +17,7 @@ export type ProviderCommentChangedItem = {
   hashcode?: string | null;
   locale?: string | null;
   message?: string | null;
+  providerReviewContext?: ProviderReviewContext | null;
 };
 
 export type ExternalTmsCommentPusher = (input: {

--- a/apps/hyperlocalise-web/src/lib/providers/provider-job-review/build-thread-id.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-job-review/build-thread-id.ts
@@ -1,0 +1,17 @@
+import type { ProviderReviewThreadKind } from "./types";
+
+export function buildProviderReviewThreadId(input: {
+  providerKind: string;
+  externalProjectId: string;
+  externalJobId: string;
+  kind: ProviderReviewThreadKind;
+  externalThreadId: string;
+}) {
+  return [
+    input.providerKind,
+    input.externalProjectId,
+    input.externalJobId,
+    input.kind,
+    input.externalThreadId,
+  ].join(":");
+}

--- a/apps/hyperlocalise-web/src/lib/providers/provider-job-review/normalize-provider-review.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-job-review/normalize-provider-review.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  buildProviderReviewReport,
+  mergeProviderReviewReports,
+  normalizeProviderReviewThread,
+} from "./normalize-provider-review";
+import type { ProviderReviewThread } from "./types";
+
+function sampleThread(overrides: Partial<ProviderReviewThread> = {}): ProviderReviewThread {
+  return {
+    threadId: "crowdin:1:9:issue:42",
+    kind: "issue",
+    state: "open",
+    subject: "  Fix translation  ",
+    issueType: "translation_mistake",
+    item: {
+      externalStringId: "100",
+      key: "welcome.title",
+      locale: "de",
+    },
+    locale: "de",
+    comments: [
+      {
+        externalCommentId: "42",
+        body: "  Please review  ",
+        author: {
+          externalUserId: "7",
+          username: " reviewer ",
+          displayName: null,
+        },
+        createdAt: "2026-05-01T10:00:00Z",
+        updatedAt: null,
+      },
+    ],
+    author: {
+      externalUserId: "7",
+      username: "reviewer",
+      displayName: "Reviewer",
+    },
+    resolver: null,
+    createdAt: "2026-05-01T10:00:00Z",
+    updatedAt: "2026-05-01T10:00:00Z",
+    resolvedAt: null,
+    providerContext: {
+      externalProjectId: "1",
+      externalJobId: "9",
+      externalThreadId: "42",
+      externalCommentId: "42",
+      providerUrl: " https://crowdin.com/project/demo/comments/42 ",
+    },
+    ...overrides,
+  };
+}
+
+describe("normalizeProviderReviewThread", () => {
+  it("trims text fields and preserves nullable metadata", () => {
+    const normalized = normalizeProviderReviewThread(sampleThread());
+
+    expect(normalized.subject).toBe("Fix translation");
+    expect(normalized.comments[0]?.body).toBe("Please review");
+    expect(normalized.comments[0]?.author?.username).toBe("reviewer");
+    expect(normalized.providerContext.providerUrl).toBe(
+      "https://crowdin.com/project/demo/comments/42",
+    );
+  });
+
+  it("handles missing optional author and resolver fields", () => {
+    const normalized = normalizeProviderReviewThread(
+      sampleThread({
+        author: undefined,
+        resolver: undefined,
+        issueType: undefined,
+        item: undefined,
+        locale: undefined,
+      }),
+    );
+
+    expect(normalized.author).toBeNull();
+    expect(normalized.resolver).toBeNull();
+    expect(normalized.issueType).toBeNull();
+    expect(normalized.item).toBeUndefined();
+    expect(normalized.locale).toBeNull();
+  });
+});
+
+describe("buildProviderReviewReport", () => {
+  it("builds summary counts by kind and state", () => {
+    const report = buildProviderReviewReport([
+      sampleThread({ state: "open", kind: "issue" }),
+      sampleThread({
+        threadId: "crowdin:1:9:comment:99",
+        kind: "comment",
+        state: "resolved",
+        providerContext: {
+          externalProjectId: "1",
+          externalJobId: "9",
+          externalThreadId: "99",
+        },
+      }),
+    ]);
+
+    expect(report.summary).toEqual({
+      total: 2,
+      open: 1,
+      resolved: 1,
+      byKind: {
+        issue: 1,
+        comment: 1,
+      },
+    });
+  });
+});
+
+describe("mergeProviderReviewReports", () => {
+  it("replaces threads with the same id and sorts by updated time", () => {
+    const previous = buildProviderReviewReport([
+      sampleThread({
+        updatedAt: "2026-05-01T09:00:00Z",
+        state: "open",
+      }),
+    ]);
+
+    const incoming = buildProviderReviewReport([
+      sampleThread({
+        state: "resolved",
+        resolvedAt: "2026-05-02T12:00:00Z",
+        updatedAt: "2026-05-02T12:00:00Z",
+      }),
+      sampleThread({
+        threadId: "crowdin:1:9:task_comment:5",
+        kind: "task_comment",
+        state: "open",
+        updatedAt: "2026-05-03T08:00:00Z",
+        providerContext: {
+          externalProjectId: "1",
+          externalJobId: "9",
+          externalThreadId: "5",
+        },
+      }),
+    ]);
+
+    const merged = mergeProviderReviewReports(previous, incoming);
+
+    expect(merged.threads).toHaveLength(2);
+    expect(merged.threads[0]?.threadId).toBe("crowdin:1:9:task_comment:5");
+    expect(merged.threads[1]?.state).toBe("resolved");
+    expect(merged.summary.resolved).toBe(1);
+  });
+
+  it("returns incoming report when previous is empty", () => {
+    const incoming = buildProviderReviewReport([sampleThread()]);
+    const merged = mergeProviderReviewReports(null, incoming);
+    expect(merged).toEqual(incoming);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/provider-job-review/normalize-provider-review.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-job-review/normalize-provider-review.ts
@@ -1,0 +1,100 @@
+import type { ProviderReviewReport, ProviderReviewSummary, ProviderReviewThread } from "./types";
+
+function buildSummary(threads: ProviderReviewThread[]): ProviderReviewSummary {
+  const summary: ProviderReviewSummary = {
+    total: threads.length,
+    open: 0,
+    resolved: 0,
+    byKind: {},
+  };
+
+  for (const thread of threads) {
+    if (thread.state === "resolved") {
+      summary.resolved += 1;
+    } else if (thread.state === "open") {
+      summary.open += 1;
+    }
+
+    summary.byKind[thread.kind] = (summary.byKind[thread.kind] ?? 0) + 1;
+  }
+
+  return summary;
+}
+
+export function normalizeProviderReviewThread(thread: ProviderReviewThread): ProviderReviewThread {
+  return {
+    ...thread,
+    subject: thread.subject?.trim() || null,
+    issueType: thread.issueType?.trim() || null,
+    locale: thread.locale?.trim() || null,
+    comments: thread.comments.map((comment) => ({
+      ...comment,
+      body: comment.body.trim(),
+      author: comment.author
+        ? {
+            externalUserId: comment.author.externalUserId ?? null,
+            username: comment.author.username?.trim() || null,
+            displayName: comment.author.displayName?.trim() || null,
+          }
+        : null,
+      createdAt: comment.createdAt ?? null,
+      updatedAt: comment.updatedAt ?? null,
+    })),
+    author: thread.author
+      ? {
+          externalUserId: thread.author.externalUserId ?? null,
+          username: thread.author.username?.trim() || null,
+          displayName: thread.author.displayName?.trim() || null,
+        }
+      : null,
+    resolver: thread.resolver
+      ? {
+          externalUserId: thread.resolver.externalUserId ?? null,
+          username: thread.resolver.username?.trim() || null,
+          displayName: thread.resolver.displayName?.trim() || null,
+        }
+      : null,
+    providerContext: {
+      ...thread.providerContext,
+      providerUrl: thread.providerContext.providerUrl?.trim() || null,
+      externalCommentId: thread.providerContext.externalCommentId ?? null,
+    },
+  };
+}
+
+export function normalizeProviderReviewThreads(
+  threads: ProviderReviewThread[],
+): ProviderReviewThread[] {
+  return threads.map((thread) => normalizeProviderReviewThread(thread));
+}
+
+export function buildProviderReviewReport(threads: ProviderReviewThread[]): ProviderReviewReport {
+  const normalized = normalizeProviderReviewThreads(threads);
+  return {
+    threads: normalized,
+    summary: buildSummary(normalized),
+  };
+}
+
+export function mergeProviderReviewReports(
+  previous: ProviderReviewReport | null | undefined,
+  incoming: ProviderReviewReport,
+): ProviderReviewReport {
+  const byThreadId = new Map<string, ProviderReviewThread>();
+
+  for (const thread of previous?.threads ?? []) {
+    byThreadId.set(thread.threadId, thread);
+  }
+
+  for (const thread of incoming.threads) {
+    byThreadId.set(thread.threadId, normalizeProviderReviewThread(thread));
+  }
+
+  const threads = [...byThreadId.values()].sort((left, right) => {
+    const leftTime = left.updatedAt ?? left.createdAt ?? "";
+    const rightTime = right.updatedAt ?? right.createdAt ?? "";
+    return rightTime.localeCompare(leftTime);
+  });
+
+  return buildProviderReviewReport(threads);
+}

--- a/apps/hyperlocalise-web/src/lib/providers/provider-job-review/types.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-job-review/types.ts
@@ -1,0 +1,60 @@
+import type { ProviderQaItemReference } from "@/lib/providers/provider-job-qa/types";
+
+export const providerReviewThreadKinds = ["issue", "comment", "task_comment"] as const;
+
+export type ProviderReviewThreadKind = (typeof providerReviewThreadKinds)[number];
+
+export const providerReviewThreadStates = ["open", "resolved", "unknown"] as const;
+
+export type ProviderReviewThreadState = (typeof providerReviewThreadStates)[number];
+
+export type ProviderReviewAuthor = {
+  externalUserId?: string | null;
+  username?: string | null;
+  displayName?: string | null;
+};
+
+export type ProviderReviewComment = {
+  externalCommentId: string;
+  body: string;
+  author?: ProviderReviewAuthor | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+};
+
+export type ProviderReviewContext = {
+  externalProjectId: string;
+  externalJobId: string;
+  externalThreadId: string;
+  externalCommentId?: string | null;
+  providerUrl?: string | null;
+};
+
+export type ProviderReviewThread = {
+  threadId: string;
+  kind: ProviderReviewThreadKind;
+  state: ProviderReviewThreadState;
+  subject?: string | null;
+  issueType?: string | null;
+  item?: ProviderQaItemReference | null;
+  locale?: string | null;
+  comments: ProviderReviewComment[];
+  author?: ProviderReviewAuthor | null;
+  resolver?: ProviderReviewAuthor | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  resolvedAt?: string | null;
+  providerContext: ProviderReviewContext;
+};
+
+export type ProviderReviewSummary = {
+  total: number;
+  open: number;
+  resolved: number;
+  byKind: Partial<Record<ProviderReviewThreadKind, number>>;
+};
+
+export type ProviderReviewReport = {
+  threads: ProviderReviewThread[];
+  summary: ProviderReviewSummary;
+};

--- a/apps/hyperlocalise-web/src/lib/providers/provider-review-pullers.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-review-pullers.ts
@@ -1,0 +1,34 @@
+import { pullCrowdinProviderReview } from "@/lib/providers/crowdin/crowdin-review-puller";
+import type { ExternalTmsTaskContent } from "@/lib/providers/external-tms-content-sync";
+import type { ProviderReviewReport } from "@/lib/providers/provider-job-review/types";
+
+import type { ExternalTmsProviderKind } from "./organization-external-tms-provider-credentials";
+
+export type ExternalTmsReviewPuller = (input: {
+  organizationId: string;
+  projectId: string;
+  providerKind: ExternalTmsProviderKind;
+  externalProjectId: string;
+  externalJobId: string;
+  credential: { baseUrl?: string | null };
+  secretMaterial: string;
+  content: ExternalTmsTaskContent;
+}) => Promise<ProviderReviewReport>;
+
+export function getProviderReviewPuller(
+  providerKind: ExternalTmsProviderKind,
+): ExternalTmsReviewPuller | null {
+  switch (providerKind) {
+    case "crowdin":
+      return async (input) =>
+        pullCrowdinProviderReview({
+          credential: input.credential,
+          secretMaterial: input.secretMaterial,
+          externalProjectId: input.externalProjectId,
+          externalJobId: input.externalJobId,
+          content: input.content,
+        });
+    default:
+      return null;
+  }
+}

--- a/apps/hyperlocalise-web/src/lib/providers/read-input-snapshot-action.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/read-input-snapshot-action.ts
@@ -1,0 +1,6 @@
+export function readInputSnapshotAction(
+  inputSnapshot: Record<string, unknown> | undefined,
+): string | null {
+  const action = inputSnapshot?.action;
+  return typeof action === "string" ? action : null;
+}

--- a/apps/hyperlocalise-web/src/lib/providers/sync-provider-review.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/sync-provider-review.ts
@@ -1,0 +1,85 @@
+import { and, eq } from "drizzle-orm";
+
+import { db, schema } from "@/lib/database";
+import { decryptProviderCredential } from "@/lib/security/provider-credential-crypto";
+
+import type { ExternalTmsTaskContent } from "./external-tms-content-sync";
+import type { ExternalTmsProviderKind } from "./organization-external-tms-provider-credentials";
+import { mergeProviderReviewReports } from "./provider-job-review/normalize-provider-review";
+import type { ProviderReviewReport } from "./provider-job-review/types";
+import { getProviderReviewPuller } from "./provider-review-pullers";
+
+export async function pullProviderReviewForJob(input: {
+  organizationId: string;
+  projectId: string;
+  providerKind: ExternalTmsProviderKind;
+  externalJobId: string;
+  content: ExternalTmsTaskContent;
+  previousReport?: ProviderReviewReport | null;
+}): Promise<ProviderReviewReport | null> {
+  const pullReview = getProviderReviewPuller(input.providerKind);
+  if (!pullReview) {
+    return null;
+  }
+
+  const [project] = await db
+    .select()
+    .from(schema.projects)
+    .where(
+      and(
+        eq(schema.projects.id, input.projectId),
+        eq(schema.projects.organizationId, input.organizationId),
+        eq(schema.projects.externalProviderKind, input.providerKind),
+        eq(schema.projects.source, "external_tms"),
+      ),
+    )
+    .limit(1);
+
+  if (!project?.externalProjectId) {
+    throw new Error("external_tms_project_not_found");
+  }
+
+  if (!project.externalProviderCredentialId) {
+    throw new Error("provider_credential_not_found");
+  }
+
+  const [credential] = await db
+    .select()
+    .from(schema.organizationExternalTmsProviderCredentials)
+    .where(
+      and(
+        eq(
+          schema.organizationExternalTmsProviderCredentials.id,
+          project.externalProviderCredentialId,
+        ),
+        eq(schema.organizationExternalTmsProviderCredentials.organizationId, input.organizationId),
+        eq(schema.organizationExternalTmsProviderCredentials.providerKind, input.providerKind),
+      ),
+    )
+    .limit(1);
+
+  if (!credential) {
+    throw new Error("provider_credential_not_found");
+  }
+
+  const secretMaterial = decryptProviderCredential({
+    algorithm: credential.encryptionAlgorithm,
+    keyVersion: credential.keyVersion,
+    ciphertext: credential.ciphertext,
+    iv: credential.iv,
+    authTag: credential.authTag,
+  });
+
+  const incoming = await pullReview({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    providerKind: input.providerKind,
+    externalProjectId: project.externalProjectId,
+    externalJobId: input.externalJobId,
+    credential,
+    secretMaterial,
+    content: input.content,
+  });
+
+  return mergeProviderReviewReports(input.previousReport, incoming);
+}

--- a/apps/hyperlocalise-web/src/workflows/steps/provider-agent-qa.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/provider-agent-qa.ts
@@ -4,6 +4,7 @@ import type {
   ExternalTmsTaskContent,
 } from "@/lib/providers/external-tms-content-sync";
 import type { ExternalTmsProviderKind } from "@/lib/providers/organization-external-tms-provider-credentials";
+import { readInputSnapshotAction } from "@/lib/providers/read-input-snapshot-action";
 import {
   completeProviderAgentQaRun,
   prepareProviderAgentQaRun,
@@ -16,11 +17,6 @@ export async function prepareProviderAgentQaStep(input: {
 }) {
   "use step";
   return prepareProviderAgentQaRun(input);
-}
-
-function readInputSnapshotAction(inputSnapshot: Record<string, unknown> | undefined) {
-  const action = inputSnapshot?.action;
-  return typeof action === "string" ? action : null;
 }
 
 export async function completeProviderAgentQaStep(input: {

--- a/apps/hyperlocalise-web/src/workflows/steps/provider-agent-qa.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/provider-agent-qa.ts
@@ -1,4 +1,4 @@
-import { failAgentRun } from "@/lib/providers/agent-runs";
+import { failAgentRun, getAgentRun } from "@/lib/providers/agent-runs";
 import type {
   ExternalTmsContentSyncFailure,
   ExternalTmsTaskContent,
@@ -18,6 +18,11 @@ export async function prepareProviderAgentQaStep(input: {
   return prepareProviderAgentQaRun(input);
 }
 
+function readInputSnapshotAction(inputSnapshot: Record<string, unknown> | undefined) {
+  const action = inputSnapshot?.action;
+  return typeof action === "string" ? action : null;
+}
+
 export async function completeProviderAgentQaStep(input: {
   agentRunId: string;
   organizationId: string;
@@ -30,7 +35,18 @@ export async function completeProviderAgentQaStep(input: {
   hlResult: RunHlCheckResult;
 }) {
   "use step";
-  return completeProviderAgentQaRun(input);
+
+  const run = await getAgentRun({
+    runId: input.agentRunId,
+    organizationId: input.organizationId,
+  });
+
+  return completeProviderAgentQaRun({
+    ...input,
+    externalJobId: run?.externalJobId ?? "",
+    syncProviderReview: readInputSnapshotAction(run?.inputSnapshot ?? {}) === "review_with_agent",
+    hyperlocaliseJobId: run?.hyperlocaliseJobId ?? null,
+  });
 }
 
 export async function failProviderAgentQaStep(input: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Implements HL-389 by syncing Crowdin review issues and comments into Hyperlocalise's provider review workflow.

- **Provider review model** (`provider-job-review/`): normalized threads, comments, provider context (links, IDs, state), summary counts, and merge-on-repeated-sync by stable `threadId`.
- **Crowdin pull**: extends Crowdin API client for string/task comments; `pullCrowdinProviderReview` fetches task context, string comments, and task comments, then normalizes into the shared report shape.
- **QA workflow**: `review_with_agent` runs pull via `pullProviderReviewForJob`, merges with prior agent-run output, and stores `reviewThreads` / `reviewSummary` on the agent run.
- **UI**: job QA findings section shows provider review threads with state, kind, locale, TMS links, and summary chips.
- **Write-back**: Crowdin comment pusher registered next to Smartling; maps QA findings to Crowdin string issues with provider review context on changed items.

## How to test

```bash
cd apps/hyperlocalise-web
vp check --fix
vp test src/lib/providers/crowdin src/lib/providers/provider-job-review src/lib/providers/provider-agent-qa.test.ts
```

With Postgres (e.g. `docker compose up -d` + `vp run db:migrate`), run the full web test suite including `provider-agent-qa.test.ts`.

## Checklist

- [x] `vp check --fix` passes locally
- [x] Unit tests for normalization, puller, write-back, and UI parsing
- [x] Integration test for `review_with_agent` review sync (requires Postgres in CI)

Fixes HL-389
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-389](https://linear.app/hyperlocalise/issue/HL-389/implement-crowdin-issues-and-comments-bridge)

<div><a href="https://cursor.com/agents/bc-91f19cd4-cebc-4ecb-b64b-1683e77db951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91f19cd4-cebc-4ecb-b64b-1683e77db951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

