### PR TITLE
feat(web): implement approved translation write-back (HL-374)

### DIFF
--- a/apps/hyperlocalise-web/src/api/app.ts
+++ b/apps/hyperlocalise-web/src/api/app.ts
@@ -9,6 +9,7 @@ import type {
   ProviderAgentCommentQueue,
   ProviderAgentQaQueue,
   ProviderAgentTranslationQueue,
+  ProviderAgentWritebackQueue,
   TranslationJobEventData,
 } from "@/lib/workflow/types";
 import { handleUnexpectedError, notFoundHandler } from "./errors";
@@ -42,6 +43,7 @@ import {
   createProviderAgentCommentQueue,
   createProviderAgentQaQueue,
   createProviderAgentTranslationQueue,
+  createProviderAgentWritebackQueue,
 } from "@/workflows/adapters";
 
 type CreateAppOptions = {
@@ -52,6 +54,7 @@ type CreateAppOptions = {
   providerAgentTranslationQueue?: ProviderAgentTranslationQueue;
   providerAgentQaQueue?: ProviderAgentQaQueue;
   providerAgentCommentQueue?: ProviderAgentCommentQueue;
+  providerAgentWritebackQueue?: ProviderAgentWritebackQueue;
   fileStorageAdapter?: FileStorageAdapter;
 };
 
@@ -62,6 +65,8 @@ export function createApp(options: CreateAppOptions = {}) {
   const providerAgentQaQueue = options.providerAgentQaQueue ?? createProviderAgentQaQueue();
   const providerAgentCommentQueue =
     options.providerAgentCommentQueue ?? createProviderAgentCommentQueue();
+  const providerAgentWritebackQueue =
+    options.providerAgentWritebackQueue ?? createProviderAgentWritebackQueue();
 
   return new Hono()
     .use("*", secureHeaders())
@@ -78,6 +83,7 @@ export function createApp(options: CreateAppOptions = {}) {
         providerAgentTranslationQueue,
         providerAgentQaQueue,
         providerAgentCommentQueue,
+        providerAgentWritebackQueue,
       }),
     )
     .route(
@@ -88,6 +94,7 @@ export function createApp(options: CreateAppOptions = {}) {
         providerAgentTranslationQueue,
         providerAgentQaQueue,
         providerAgentCommentQueue,
+        providerAgentWritebackQueue,
       }),
     )
     .route("/v1", createPublicApiRoutes({ ...options, jobQueue }))
@@ -121,6 +128,7 @@ function createOrgScopedAppRoutes(
     providerAgentTranslationQueue: ProviderAgentTranslationQueue;
     providerAgentQaQueue: ProviderAgentQaQueue;
     providerAgentCommentQueue: ProviderAgentCommentQueue;
+    providerAgentWritebackQueue: ProviderAgentWritebackQueue;
   },
 ) {
   return new Hono()
@@ -134,6 +142,7 @@ function createOrgScopedAppRoutes(
         providerAgentTranslationQueue: options.providerAgentTranslationQueue,
         providerAgentQaQueue: options.providerAgentQaQueue,
         providerAgentCommentQueue: options.providerAgentCommentQueue,
+        providerAgentWritebackQueue: options.providerAgentWritebackQueue,
       }),
     )
     .route("/provider-credential", createProviderCredentialRoutes())

--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
@@ -24,6 +24,7 @@ import type {
   ProviderAgentCommentQueue,
   ProviderAgentQaQueue,
   ProviderAgentTranslationQueue,
+  ProviderAgentWritebackQueue,
   TranslationJobEventData,
 } from "@/lib/workflow/types";
 
@@ -78,6 +79,7 @@ type CreateWorkspaceJobRoutesOptions = {
   providerAgentTranslationQueue: ProviderAgentTranslationQueue;
   providerAgentQaQueue: ProviderAgentQaQueue;
   providerAgentCommentQueue: ProviderAgentCommentQueue;
+  providerAgentWritebackQueue: ProviderAgentWritebackQueue;
 };
 
 const providerQaAgentActions = new Set(["review_with_agent", "run_qa_checks"]);
@@ -920,6 +922,30 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
               c,
               "agent_run_queue_unavailable",
               "Agent comment queue is unavailable",
+            );
+          }
+        }
+
+        if (payload.action === "push_approved_changes") {
+          try {
+            await options.providerAgentWritebackQueue.enqueue({
+              agentRunId: agentRun.id,
+              organizationId,
+            });
+          } catch (error) {
+            await failAgentRun({
+              runId: agentRun.id,
+              organizationId,
+              outputSummary: { code: "agent_run_queue_unavailable" },
+              warnings: [
+                error instanceof Error ? error.message : "agent write-back queue unavailable",
+              ],
+            });
+
+            return serviceUnavailableResponse(
+              c,
+              "agent_run_queue_unavailable",
+              "Agent write-back queue is unavailable",
             );
           }
         }

--- a/apps/hyperlocalise-web/src/api/routes/project/job.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.test.ts
@@ -13,6 +13,7 @@ import type {
   ProviderAgentCommentQueue,
   ProviderAgentQaQueue,
   ProviderAgentTranslationQueue,
+  ProviderAgentWritebackQueue,
   TranslationJobEventData,
 } from "@/lib/workflow/types";
 import { createProjectTestFixture } from "./project.fixture";
@@ -76,12 +77,21 @@ function createInlineTestProviderAgentCommentQueue(): ProviderAgentCommentQueue 
   };
 }
 
+function createInlineTestProviderAgentWritebackQueue(): ProviderAgentWritebackQueue {
+  return {
+    async enqueue(event) {
+      return { ids: [event.agentRunId] };
+    },
+  };
+}
+
 const client = testClient(
   createApp({
     jobQueue: createInlineTestJobQueue(),
     providerAgentTranslationQueue: createInlineTestProviderAgentTranslationQueue(),
     providerAgentQaQueue: createInlineTestProviderAgentQaQueue(),
     providerAgentCommentQueue: createInlineTestProviderAgentCommentQueue(),
+    providerAgentWritebackQueue: createInlineTestProviderAgentWritebackQueue(),
   }),
 );
 const appClient = client;
@@ -1647,6 +1657,128 @@ describe("jobRoutes", () => {
     });
   });
 
+  it("creates translate agent runs for push_approved_changes", async () => {
+    const identity = createWorkosIdentity();
+    const projectResponse = await createProjectViaApi(identity);
+    const project = ((await projectResponse.json()) as ProjectResponse).project;
+    const [organization] = await db
+      .select({ id: schema.organizations.id })
+      .from(schema.projects)
+      .innerJoin(schema.organizations, eq(schema.projects.organizationId, schema.organizations.id))
+      .where(eq(schema.projects.id, project.id))
+      .limit(1);
+
+    const externalJob = await upsertExternalJob({
+      organizationId: organization!.id,
+      projectId: project.id,
+      providerKind: "crowdin",
+      externalJobId: "crowdin-job-writeback-agent",
+      externalStatus: "todo",
+      title: "Write-back copy",
+    });
+
+    const response = await client.api.orgs[":organizationSlug"].jobs[":jobId"]["agent-runs"].$post(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          jobId: externalJob.id,
+        },
+        json: {
+          action: "push_approved_changes",
+        },
+      },
+      { headers: await authHeadersFor(identity) },
+    );
+
+    expect(response.status).toBe(201);
+    const body = (await response.json()) as {
+      agentRun: {
+        kind: string;
+        status: string;
+        inputSnapshot: Record<string, unknown>;
+      };
+    };
+    expect(body.agentRun).toMatchObject({
+      kind: "translate",
+      status: "queued",
+      inputSnapshot: expect.objectContaining({
+        action: "push_approved_changes",
+      }),
+    });
+  });
+
+  it("marks the agent run failed when provider write-back queueing fails", async () => {
+    const failingClient = testClient(
+      createApp({
+        jobQueue: createInlineTestJobQueue(),
+        providerAgentTranslationQueue: createInlineTestProviderAgentTranslationQueue(),
+        providerAgentQaQueue: createInlineTestProviderAgentQaQueue(),
+        providerAgentCommentQueue: createInlineTestProviderAgentCommentQueue(),
+        providerAgentWritebackQueue: {
+          async enqueue() {
+            throw new Error("write-back queue down");
+          },
+        },
+      }),
+    );
+    const identity = createWorkosIdentity();
+    const projectResponse = await createProjectViaApi(identity);
+    const project = ((await projectResponse.json()) as ProjectResponse).project;
+    const [organization] = await db
+      .select({ id: schema.organizations.id })
+      .from(schema.projects)
+      .innerJoin(schema.organizations, eq(schema.projects.organizationId, schema.organizations.id))
+      .where(eq(schema.projects.id, project.id))
+      .limit(1);
+
+    const externalJob = await upsertExternalJob({
+      organizationId: organization!.id,
+      projectId: project.id,
+      providerKind: "crowdin",
+      externalJobId: "crowdin-job-writeback-queue-fail",
+      externalStatus: "todo",
+      title: "Write-back queue failure copy",
+    });
+
+    const response = await failingClient.api.orgs[":organizationSlug"].jobs[":jobId"][
+      "agent-runs"
+    ].$post(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          jobId: externalJob.id,
+        },
+        json: {
+          action: "push_approved_changes",
+        },
+      },
+      { headers: await authHeadersFor(identity) },
+    );
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "agent_run_queue_unavailable",
+      message: expect.any(String),
+    });
+
+    const agentRuns = await db
+      .select({
+        status: schema.agentRuns.status,
+        outputSummary: schema.agentRuns.outputSummary,
+        warnings: schema.agentRuns.warnings,
+      })
+      .from(schema.agentRuns)
+      .where(eq(schema.agentRuns.hyperlocaliseJobId, externalJob.id));
+
+    expect(agentRuns).toEqual([
+      expect.objectContaining({
+        status: "failed",
+        outputSummary: { code: "agent_run_queue_unavailable" },
+        warnings: ["write-back queue down"],
+      }),
+    ]);
+  });
+
   it("marks the agent run failed when provider comment queueing fails", async () => {
     const failingClient = testClient(
       createApp({
@@ -1658,6 +1790,7 @@ describe("jobRoutes", () => {
             throw new Error("comment queue down");
           },
         },
+        providerAgentWritebackQueue: createInlineTestProviderAgentWritebackQueue(),
       }),
     );
     const identity = createWorkosIdentity();

--- a/apps/hyperlocalise-web/src/lib/providers/agent-run-proposals.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-run-proposals.test.ts
@@ -4,6 +4,7 @@ import {
   applyAgentRunProposalReviewUpdates,
   applyBulkAgentRunProposalReview,
   buildAgentRunProposalItemId,
+  collectAcceptedAgentRunProposalsForJob,
   detectAgentRunProposalWarnings,
   enrichAgentRunProposalItem,
   parseAgentRunProposalItems,
@@ -90,5 +91,76 @@ describe("agent-run-proposals", () => {
 
     expect(enrichAgentRunProposalItem(bulkRejected[0]!)?.reviewState).toBe("accepted");
     expect(enrichAgentRunProposalItem(bulkRejected[1]!)?.reviewState).toBe("rejected");
+  });
+
+  it("collects accepted proposals across translate and qa_fix runs", () => {
+    const olderRunId = "run-older";
+    const newerRunId = "run-newer";
+
+    const accepted = collectAcceptedAgentRunProposalsForJob({
+      runs: [
+        {
+          id: newerRunId,
+          kind: "qa_fix",
+          status: "succeeded",
+          inputSnapshot: {},
+          createdAt: new Date("2026-01-02T00:00:00.000Z"),
+          changedItems: [
+            {
+              externalStringId: "1",
+              key: "hello",
+              locale: "fr",
+              sourceText: "Hello",
+              from: "",
+              to: "Bonjour",
+              reviewState: "accepted",
+            },
+            {
+              externalStringId: "2",
+              key: "world",
+              locale: "fr",
+              sourceText: "World",
+              from: "",
+              to: "Le monde",
+              reviewState: "pending",
+            },
+          ],
+        },
+        {
+          id: olderRunId,
+          kind: "translate",
+          status: "succeeded",
+          inputSnapshot: {},
+          createdAt: new Date("2026-01-01T00:00:00.000Z"),
+          changedItems: [
+            {
+              externalStringId: "1",
+              key: "hello",
+              locale: "fr",
+              sourceText: "Hello",
+              from: "",
+              to: "Salut",
+              reviewState: "accepted",
+            },
+          ],
+        },
+        {
+          id: "writeback-run",
+          kind: "translate",
+          status: "succeeded",
+          inputSnapshot: { action: "push_approved_changes" },
+          createdAt: new Date("2026-01-03T00:00:00.000Z"),
+          changedItems: [],
+        },
+      ],
+    });
+
+    expect(accepted).toEqual([
+      expect.objectContaining({
+        itemId: "1:fr",
+        to: "Bonjour",
+        sourceAgentRunId: newerRunId,
+      }),
+    ]);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/agent-run-proposals.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-run-proposals.ts
@@ -414,6 +414,54 @@ export function countAgentRunProposalReviewStates(items: AgentRunProposalItem[])
   );
 }
 
+export type AcceptedAgentRunProposal = AgentRunProposalItem & {
+  sourceAgentRunId: string;
+};
+
+export function isPushApprovedWritebackAgentRun(inputSnapshot: Record<string, unknown>) {
+  return inputSnapshot.action === "push_approved_changes";
+}
+
+export function collectAcceptedAgentRunProposalsForJob(input: {
+  runs: Array<{
+    id: string;
+    kind: string;
+    status: string;
+    inputSnapshot: Record<string, unknown>;
+    changedItems: Record<string, unknown>[];
+    createdAt: Date;
+  }>;
+}) {
+  const proposalRuns = input.runs
+    .filter(
+      (run) =>
+        run.status === "succeeded" &&
+        (run.kind === "translate" || run.kind === "qa_fix") &&
+        !isPushApprovedWritebackAgentRun(run.inputSnapshot),
+    )
+    .sort((left, right) => right.createdAt.getTime() - left.createdAt.getTime());
+
+  const acceptedByItemId = new Map<string, AcceptedAgentRunProposal>();
+
+  for (const run of proposalRuns) {
+    const proposals = parseAgentRunProposalItems(run.changedItems);
+    for (const proposal of proposals) {
+      if (proposal.reviewState !== "accepted") {
+        continue;
+      }
+
+      if (!acceptedByItemId.has(proposal.itemId)) {
+        acceptedByItemId.set(proposal.itemId, {
+          ...proposal,
+          sourceAgentRunId: run.id,
+        });
+      }
+    }
+  }
+
+  return [...acceptedByItemId.values()];
+}
+
 export function agentRunHasReviewableProposals(input: {
   kind: string;
   status: string;

--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs.ts
@@ -87,6 +87,7 @@ export async function failAgentRun(input: {
   runId: string;
   organizationId: string;
   outputSummary?: AgentRunOutputSummary;
+  changedItems?: AgentRunChangedItem[];
   warnings?: string[];
 }) {
   return finishAgentRun({
@@ -94,6 +95,7 @@ export async function failAgentRun(input: {
     organizationId: input.organizationId,
     status: "failed",
     outputSummary: input.outputSummary,
+    changedItems: input.changedItems,
     warnings: input.warnings,
     sourceStatuses: ["queued", "running"],
   });

--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs.ts
@@ -224,6 +224,7 @@ export async function listAgentRuns(input: {
   actorUserId?: string;
   hyperlocaliseJobId?: string;
   limit?: number;
+  offset?: number;
 }) {
   const filters: SQL[] = [eq(schema.agentRuns.organizationId, input.organizationId)];
 
@@ -254,7 +255,8 @@ export async function listAgentRuns(input: {
     .from(schema.agentRuns)
     .where(and(...filters))
     .orderBy(desc(schema.agentRuns.createdAt))
-    .limit(input.limit ?? 50);
+    .limit(input.limit ?? 50)
+    .offset(input.offset ?? 0);
 }
 
 export async function updateAgentRunChangedItems(input: {

--- a/apps/hyperlocalise-web/src/lib/providers/provider-agent-writeback.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-agent-writeback.test.ts
@@ -21,13 +21,28 @@ vi.mock("./external-tms-content-sync", async (importOriginal) => {
   };
 });
 
+async function createTestJob(input: { organizationId: string; projectId: string }) {
+  const [job] = await db
+    .insert(schema.jobs)
+    .values({
+      id: `job_test_${randomUUID()}`,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      kind: "translation",
+      status: "queued",
+      inputPayload: {},
+    })
+    .returning();
+
+  return job!;
+}
+
 describe("provider-agent-writeback", () => {
   afterEach(() => {
     pushExternalTmsTranslationsMock.mockReset();
   });
 
   it("pushes accepted proposals and records per-item write-back results", async () => {
-    const hyperlocaliseJobId = randomUUID();
     const projectId = randomUUID();
     const orgSuffix = randomUUID();
 
@@ -50,12 +65,14 @@ describe("provider-agent-writeback", () => {
       externalProjectId: "123",
     });
 
+    const job = await createTestJob({ organizationId, projectId });
+
     const sourceRun = await createAgentRun({
       organizationId,
       providerKind: "crowdin",
       externalJobId: "task-1",
       kind: "translate",
-      hyperlocaliseJobId,
+      hyperlocaliseJobId: job.id,
       inputSnapshot: { projectId },
     });
 
@@ -84,11 +101,11 @@ describe("provider-agent-writeback", () => {
       providerKind: "crowdin",
       externalJobId: "task-1",
       kind: "translate",
-      hyperlocaliseJobId,
+      hyperlocaliseJobId: job.id,
       inputSnapshot: {
         action: "push_approved_changes",
         projectId,
-        hyperlocaliseJobId,
+        hyperlocaliseJobId: job.id,
       },
     });
 
@@ -159,7 +176,6 @@ describe("provider-agent-writeback", () => {
   });
 
   it("completes with partial success when some locales fail", async () => {
-    const hyperlocaliseJobId = randomUUID();
     const projectId = randomUUID();
     const orgSuffix = randomUUID();
 
@@ -182,12 +198,14 @@ describe("provider-agent-writeback", () => {
       externalProjectId: "123",
     });
 
+    const job = await createTestJob({ organizationId, projectId });
+
     const sourceRun = await createAgentRun({
       organizationId,
       providerKind: "crowdin",
       externalJobId: "task-2",
       kind: "translate",
-      hyperlocaliseJobId,
+      hyperlocaliseJobId: job.id,
       inputSnapshot: { projectId },
     });
 
@@ -228,11 +246,11 @@ describe("provider-agent-writeback", () => {
       providerKind: "crowdin",
       externalJobId: "task-2",
       kind: "translate",
-      hyperlocaliseJobId,
+      hyperlocaliseJobId: job.id,
       inputSnapshot: {
         action: "push_approved_changes",
         projectId,
-        hyperlocaliseJobId,
+        hyperlocaliseJobId: job.id,
       },
     });
 

--- a/apps/hyperlocalise-web/src/lib/providers/provider-agent-writeback.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-agent-writeback.test.ts
@@ -272,7 +272,7 @@ describe("provider-agent-writeback", () => {
         translationsFailed: 1,
         asyncOperations: 0,
       },
-      failures: [{ externalStringId: null, locale: "de-DE", message: "upload failed" }],
+      failures: [{ externalStringId: "hash-2", locale: "de-DE", message: "upload failed" }],
       asyncOperations: [],
     });
 

--- a/apps/hyperlocalise-web/src/lib/providers/provider-agent-writeback.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-agent-writeback.test.ts
@@ -1,0 +1,290 @@
+import "dotenv/config";
+
+import { randomUUID } from "node:crypto";
+
+import { eq } from "drizzle-orm";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { db, schema } from "@/lib/database";
+
+import { completeAgentRun, createAgentRun, startAgentRun } from "./agent-runs";
+import { serializeAgentRunProposalItem } from "./agent-run-proposals";
+import { executeProviderAgentWriteback } from "./provider-agent-writeback";
+
+const pushExternalTmsTranslationsMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./external-tms-content-sync", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./external-tms-content-sync")>();
+  return {
+    ...actual,
+    pushExternalTmsTranslations: (...args: unknown[]) => pushExternalTmsTranslationsMock(...args),
+  };
+});
+
+describe("provider-agent-writeback", () => {
+  afterEach(() => {
+    pushExternalTmsTranslationsMock.mockReset();
+  });
+
+  it("pushes accepted proposals and records per-item write-back results", async () => {
+    const hyperlocaliseJobId = randomUUID();
+    const projectId = randomUUID();
+    const orgSuffix = randomUUID();
+
+    const [organization] = await db
+      .insert(schema.organizations)
+      .values({
+        workosOrganizationId: `org_${orgSuffix}`,
+        name: "Write-back Org",
+        slug: `writeback-${orgSuffix.slice(0, 8)}`,
+      })
+      .returning();
+    const organizationId = organization!.id;
+
+    await db.insert(schema.projects).values({
+      id: projectId,
+      organizationId,
+      name: "External TMS Project",
+      source: "external_tms",
+      externalProviderKind: "crowdin",
+      externalProjectId: "123",
+    });
+
+    const sourceRun = await createAgentRun({
+      organizationId,
+      providerKind: "crowdin",
+      externalJobId: "task-1",
+      kind: "translate",
+      hyperlocaliseJobId,
+      inputSnapshot: { projectId },
+    });
+
+    await completeAgentRun({
+      runId: sourceRun.id,
+      organizationId,
+      outputSummary: { proposals: 1 },
+      changedItems: [
+        serializeAgentRunProposalItem({
+          itemId: "hash-1:fr-FR",
+          externalStringId: "hash-1",
+          key: "cta.label",
+          locale: "fr-FR",
+          sourceText: "Buy now",
+          from: "",
+          to: "Acheter",
+          reviewState: "accepted",
+          changedFields: ["target"],
+          warnings: {},
+        }),
+      ],
+    });
+
+    const writebackRun = await createAgentRun({
+      organizationId,
+      providerKind: "crowdin",
+      externalJobId: "task-1",
+      kind: "translate",
+      hyperlocaliseJobId,
+      inputSnapshot: {
+        action: "push_approved_changes",
+        projectId,
+        hyperlocaliseJobId,
+      },
+    });
+
+    pushExternalTmsTranslationsMock.mockResolvedValue({
+      runId: "sync-run-1",
+      status: "succeeded",
+      providerKind: "crowdin",
+      providerCredentialId: "cred-1",
+      projectId,
+      counts: {
+        translationsRequested: 1,
+        translationsUploaded: 1,
+        translationsFailed: 0,
+        asyncOperations: 0,
+      },
+      failures: [],
+      asyncOperations: [],
+    });
+
+    const result = await executeProviderAgentWriteback({
+      agentRunId: writebackRun.id,
+      organizationId,
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      uploaded: 1,
+      skipped: 0,
+      failed: 0,
+      pushRunId: "sync-run-1",
+    });
+
+    expect(pushExternalTmsTranslationsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId,
+        externalJobId: "task-1",
+        translations: [
+          expect.objectContaining({
+            externalStringId: "hash-1",
+            key: "cta.label",
+            locale: "fr-FR",
+            text: "Acheter",
+          }),
+        ],
+      }),
+    );
+
+    const [storedRun] = await db
+      .select()
+      .from(schema.agentRuns)
+      .where(eq(schema.agentRuns.id, writebackRun.id))
+      .limit(1);
+
+    expect(storedRun?.status).toBe("succeeded");
+    expect(storedRun?.outputSummary).toMatchObject({
+      pushRunId: "sync-run-1",
+      uploaded: 1,
+      failed: 0,
+    });
+    expect(storedRun?.changedItems).toEqual([
+      expect.objectContaining({
+        type: "provider_translation_writeback",
+        itemId: "hash-1:fr-FR",
+        status: "uploaded",
+        sourceAgentRunId: sourceRun.id,
+      }),
+    ]);
+  });
+
+  it("completes with partial success when some locales fail", async () => {
+    const hyperlocaliseJobId = randomUUID();
+    const projectId = randomUUID();
+    const orgSuffix = randomUUID();
+
+    const [organization] = await db
+      .insert(schema.organizations)
+      .values({
+        workosOrganizationId: `org_${orgSuffix}`,
+        name: "Partial Write-back Org",
+        slug: `partial-writeback-${orgSuffix.slice(0, 8)}`,
+      })
+      .returning();
+    const organizationId = organization!.id;
+
+    await db.insert(schema.projects).values({
+      id: projectId,
+      organizationId,
+      name: "External TMS Project",
+      source: "external_tms",
+      externalProviderKind: "crowdin",
+      externalProjectId: "123",
+    });
+
+    const sourceRun = await createAgentRun({
+      organizationId,
+      providerKind: "crowdin",
+      externalJobId: "task-2",
+      kind: "translate",
+      hyperlocaliseJobId,
+      inputSnapshot: { projectId },
+    });
+
+    await completeAgentRun({
+      runId: sourceRun.id,
+      organizationId,
+      outputSummary: { proposals: 2 },
+      changedItems: [
+        serializeAgentRunProposalItem({
+          itemId: "hash-1:fr-FR",
+          externalStringId: "hash-1",
+          key: "cta.label",
+          locale: "fr-FR",
+          sourceText: "Buy now",
+          from: "",
+          to: "Acheter",
+          reviewState: "accepted",
+          changedFields: ["target"],
+          warnings: {},
+        }),
+        serializeAgentRunProposalItem({
+          itemId: "hash-2:de-DE",
+          externalStringId: "hash-2",
+          key: "cta.label",
+          locale: "de-DE",
+          sourceText: "Buy now",
+          from: "",
+          to: "Kaufen",
+          reviewState: "accepted",
+          changedFields: ["target"],
+          warnings: {},
+        }),
+      ],
+    });
+
+    const writebackRun = await createAgentRun({
+      organizationId,
+      providerKind: "crowdin",
+      externalJobId: "task-2",
+      kind: "translate",
+      hyperlocaliseJobId,
+      inputSnapshot: {
+        action: "push_approved_changes",
+        projectId,
+        hyperlocaliseJobId,
+      },
+    });
+
+    await startAgentRun({ runId: writebackRun.id, organizationId });
+
+    pushExternalTmsTranslationsMock.mockResolvedValue({
+      runId: "sync-run-2",
+      status: "failed",
+      providerKind: "crowdin",
+      providerCredentialId: "cred-1",
+      projectId,
+      counts: {
+        translationsRequested: 2,
+        translationsUploaded: 1,
+        translationsFailed: 1,
+        asyncOperations: 0,
+      },
+      failures: [{ externalStringId: null, locale: "de-DE", message: "upload failed" }],
+      asyncOperations: [],
+    });
+
+    const result = await executeProviderAgentWriteback({
+      agentRunId: writebackRun.id,
+      organizationId,
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      uploaded: 1,
+      failed: 1,
+      pushRunId: "sync-run-2",
+    });
+
+    const [storedRun] = await db
+      .select()
+      .from(schema.agentRuns)
+      .where(eq(schema.agentRuns.id, writebackRun.id))
+      .limit(1);
+
+    expect(storedRun?.status).toBe("succeeded");
+    expect(storedRun?.changedItems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          itemId: "hash-1:fr-FR",
+          status: "uploaded",
+        }),
+        expect.objectContaining({
+          itemId: "hash-2:de-DE",
+          status: "failed",
+          message: "upload failed",
+        }),
+      ]),
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/provider-agent-writeback.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-agent-writeback.test.ts
@@ -76,6 +76,8 @@ describe("provider-agent-writeback", () => {
       inputSnapshot: { projectId },
     });
 
+    await startAgentRun({ runId: sourceRun.id, organizationId });
+
     await completeAgentRun({
       runId: sourceRun.id,
       organizationId,
@@ -208,6 +210,8 @@ describe("provider-agent-writeback", () => {
       hyperlocaliseJobId: job.id,
       inputSnapshot: { projectId },
     });
+
+    await startAgentRun({ runId: sourceRun.id, organizationId });
 
     await completeAgentRun({
       runId: sourceRun.id,

--- a/apps/hyperlocalise-web/src/lib/providers/provider-agent-writeback.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-agent-writeback.ts
@@ -1,0 +1,451 @@
+import {
+  collectAcceptedAgentRunProposalsForJob,
+  isPushApprovedWritebackAgentRun,
+  type AcceptedAgentRunProposal,
+} from "./agent-run-proposals";
+import {
+  completeAgentRun,
+  failAgentRun,
+  getAgentRun,
+  listAgentRuns,
+  startAgentRun,
+} from "./agent-runs";
+import {
+  pushExternalTmsTranslations,
+  type ExternalTmsApprovedTranslationUpload,
+} from "./external-tms-content-sync";
+import type { ProviderTranslationWritebackChangedItem } from "./provider-feedback-types";
+import { getProviderTranslationPusher } from "./provider-translation-pushers";
+
+export type ProviderAgentWritebackResult =
+  | {
+      ok: true;
+      agentRunId: string;
+      uploaded: number;
+      skipped: number;
+      failed: number;
+      pushRunId?: string;
+      alreadyCompleted?: boolean;
+    }
+  | {
+      ok: false;
+      agentRunId: string;
+      code: string;
+      message: string;
+    };
+
+function readProjectIdFromInputSnapshot(inputSnapshot: Record<string, unknown>): string | null {
+  const projectId = inputSnapshot.projectId;
+  return typeof projectId === "string" && projectId.length > 0 ? projectId : null;
+}
+
+function readOutputSummaryNumber(outputSummary: Record<string, unknown>, key: string): number {
+  const value = outputSummary[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function readOutputSummaryString(
+  outputSummary: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const value = outputSummary[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function isProviderTranslationWritebackChangedItem(
+  item: Record<string, unknown>,
+): item is ProviderTranslationWritebackChangedItem {
+  return item.type === "provider_translation_writeback" && typeof item.itemId === "string";
+}
+
+function loadPreviouslyUploadedItemIds(input: {
+  runs: Array<{
+    id: string;
+    inputSnapshot: Record<string, unknown>;
+    changedItems: Record<string, unknown>[];
+  }>;
+  currentRunId: string;
+}) {
+  const uploaded = new Set<string>();
+
+  for (const run of input.runs) {
+    if (run.id === input.currentRunId) {
+      continue;
+    }
+
+    if (!isPushApprovedWritebackAgentRun(run.inputSnapshot)) {
+      continue;
+    }
+
+    const changedItems = Array.isArray(run.changedItems)
+      ? (run.changedItems as Record<string, unknown>[])
+      : [];
+
+    for (const item of changedItems) {
+      if (!isProviderTranslationWritebackChangedItem(item)) {
+        continue;
+      }
+
+      if (item.status === "uploaded" || item.status === "skipped") {
+        uploaded.add(item.itemId);
+      }
+    }
+  }
+
+  return uploaded;
+}
+
+function buildWritebackChangedItems(input: {
+  proposals: AcceptedAgentRunProposal[];
+  skippedItemIds: Set<string>;
+  uploaded: number;
+  failed: number;
+  failures: Array<{ locale: string | null; message: string }>;
+}): ProviderTranslationWritebackChangedItem[] {
+  const changedItems: ProviderTranslationWritebackChangedItem[] = [];
+  const failedLocales = new Set(
+    input.failures.map((failure) => failure.locale).filter((locale): locale is string => !!locale),
+  );
+  const failureMessage =
+    input.failures[0]?.message ?? "One or more provider translation uploads failed";
+
+  for (const proposal of input.proposals) {
+    if (input.skippedItemIds.has(proposal.itemId)) {
+      changedItems.push({
+        type: "provider_translation_writeback",
+        itemId: proposal.itemId,
+        externalStringId: proposal.externalStringId,
+        key: proposal.key,
+        locale: proposal.locale,
+        status: "skipped",
+        sourceAgentRunId: proposal.sourceAgentRunId,
+        message: "already_uploaded",
+      });
+      continue;
+    }
+
+    let status: ProviderTranslationWritebackChangedItem["status"] = "uploaded";
+    let message: string | null = null;
+
+    if (input.failed > 0 && input.uploaded === 0) {
+      status = "failed";
+      message = failureMessage;
+    } else if (input.failed > 0 && failedLocales.has(proposal.locale)) {
+      status = "failed";
+      message =
+        input.failures.find((failure) => failure.locale === proposal.locale)?.message ??
+        failureMessage;
+    }
+
+    changedItems.push({
+      type: "provider_translation_writeback",
+      itemId: proposal.itemId,
+      externalStringId: proposal.externalStringId,
+      key: proposal.key,
+      locale: proposal.locale,
+      status,
+      sourceAgentRunId: proposal.sourceAgentRunId,
+      message,
+    });
+  }
+
+  return changedItems;
+}
+
+export async function executeProviderAgentWriteback(input: {
+  agentRunId: string;
+  organizationId: string;
+}): Promise<ProviderAgentWritebackResult> {
+  const run = await getAgentRun({
+    runId: input.agentRunId,
+    organizationId: input.organizationId,
+  });
+
+  if (!run) {
+    return {
+      ok: false,
+      agentRunId: input.agentRunId,
+      code: "agent_run_not_found",
+      message: "Agent run not found",
+    };
+  }
+
+  if (!isPushApprovedWritebackAgentRun(run.inputSnapshot)) {
+    return {
+      ok: false,
+      agentRunId: input.agentRunId,
+      code: "unsupported_agent_run_action",
+      message: "Agent run is not a push approved changes write-back action",
+    };
+  }
+
+  if (run.status === "succeeded") {
+    const outputSummary = run.outputSummary ?? {};
+    return {
+      ok: true,
+      agentRunId: input.agentRunId,
+      uploaded: readOutputSummaryNumber(outputSummary, "uploaded"),
+      skipped: readOutputSummaryNumber(outputSummary, "skipped"),
+      failed: readOutputSummaryNumber(outputSummary, "failed"),
+      pushRunId: readOutputSummaryString(outputSummary, "pushRunId"),
+      alreadyCompleted: true,
+    };
+  }
+
+  if (run.status === "failed" || run.status === "cancelled") {
+    return {
+      ok: false,
+      agentRunId: input.agentRunId,
+      code: run.status === "failed" ? "agent_run_already_failed" : "agent_run_already_cancelled",
+      message: `Agent run is ${run.status}, expected queued or running`,
+    };
+  }
+
+  const projectId = readProjectIdFromInputSnapshot(run.inputSnapshot);
+  if (!projectId) {
+    await failAgentRun({
+      runId: run.id,
+      organizationId: input.organizationId,
+      outputSummary: { code: "missing_project_id" },
+      warnings: ["Agent run input snapshot is missing projectId"],
+    });
+
+    return {
+      ok: false,
+      agentRunId: input.agentRunId,
+      code: "missing_project_id",
+      message: "Agent run input snapshot is missing projectId",
+    };
+  }
+
+  if (!run.hyperlocaliseJobId) {
+    await failAgentRun({
+      runId: run.id,
+      organizationId: input.organizationId,
+      outputSummary: { code: "missing_hyperlocalise_job_id" },
+      warnings: ["Agent run is missing hyperlocaliseJobId"],
+    });
+
+    return {
+      ok: false,
+      agentRunId: input.agentRunId,
+      code: "missing_hyperlocalise_job_id",
+      message: "Agent run is missing hyperlocaliseJobId",
+    };
+  }
+
+  const pushTranslations = getProviderTranslationPusher(run.providerKind);
+  if (!pushTranslations) {
+    await failAgentRun({
+      runId: run.id,
+      organizationId: input.organizationId,
+      outputSummary: {
+        code: "unsupported_provider_translation_push",
+        providerKind: run.providerKind,
+      },
+      warnings: [`Provider ${run.providerKind} does not support translation write-back yet`],
+    });
+
+    return {
+      ok: false,
+      agentRunId: input.agentRunId,
+      code: "unsupported_provider_translation_push",
+      message: `Provider ${run.providerKind} does not support translation write-back yet`,
+    };
+  }
+
+  if (run.status === "queued") {
+    try {
+      await startAgentRun({
+        runId: run.id,
+        organizationId: input.organizationId,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to start agent run";
+      await failAgentRun({
+        runId: run.id,
+        organizationId: input.organizationId,
+        outputSummary: { code: "agent_run_start_failed" },
+        warnings: [message],
+      });
+      return {
+        ok: false,
+        agentRunId: input.agentRunId,
+        code: "agent_run_start_failed",
+        message,
+      };
+    }
+  }
+
+  const jobRuns = await listAgentRuns({
+    organizationId: input.organizationId,
+    hyperlocaliseJobId: run.hyperlocaliseJobId,
+    limit: 200,
+  });
+
+  const acceptedProposals = collectAcceptedAgentRunProposalsForJob({ runs: jobRuns });
+  const previouslyUploadedItemIds = loadPreviouslyUploadedItemIds({
+    runs: jobRuns,
+    currentRunId: run.id,
+  });
+
+  const proposalsToPush = acceptedProposals.filter(
+    (proposal) => !previouslyUploadedItemIds.has(proposal.itemId),
+  );
+  const skippedCount = acceptedProposals.length - proposalsToPush.length;
+
+  if (acceptedProposals.length === 0) {
+    await failAgentRun({
+      runId: run.id,
+      organizationId: input.organizationId,
+      outputSummary: { code: "no_accepted_proposals" },
+      warnings: ["No accepted agent proposals were found for translation write-back"],
+    });
+
+    return {
+      ok: false,
+      agentRunId: input.agentRunId,
+      code: "no_accepted_proposals",
+      message: "No accepted agent proposals were found for translation write-back",
+    };
+  }
+
+  if (proposalsToPush.length === 0) {
+    const changedItems = buildWritebackChangedItems({
+      proposals: acceptedProposals,
+      skippedItemIds: previouslyUploadedItemIds,
+      uploaded: 0,
+      failed: 0,
+      failures: [],
+    });
+
+    await completeAgentRun({
+      runId: run.id,
+      organizationId: input.organizationId,
+      outputSummary: {
+        uploaded: 0,
+        skipped: skippedCount,
+        failed: 0,
+        translationsRequested: 0,
+        acceptedProposals: acceptedProposals.length,
+      },
+      changedItems,
+      warnings: [],
+    });
+
+    return {
+      ok: true,
+      agentRunId: input.agentRunId,
+      uploaded: 0,
+      skipped: skippedCount,
+      failed: 0,
+    };
+  }
+
+  const translations: ExternalTmsApprovedTranslationUpload[] = proposalsToPush.map((proposal) => ({
+    externalStringId: proposal.externalStringId,
+    key: proposal.key,
+    locale: proposal.locale,
+    text: proposal.to,
+  }));
+
+  try {
+    const pushResult = await pushExternalTmsTranslations({
+      organizationId: input.organizationId,
+      projectId,
+      providerKind: run.providerKind,
+      externalJobId: run.externalJobId,
+      translations,
+      pushTranslations,
+    });
+
+    const changedItems = buildWritebackChangedItems({
+      proposals: acceptedProposals,
+      skippedItemIds: previouslyUploadedItemIds,
+      uploaded: pushResult.counts.translationsUploaded,
+      failed: pushResult.counts.translationsFailed,
+      failures: pushResult.failures,
+    });
+
+    const uploaded = changedItems.filter((item) => item.status === "uploaded").length;
+    const failed = changedItems.filter((item) => item.status === "failed").length;
+    const warnings = pushResult.failures.map(
+      (failure) => `${failure.locale ?? "unknown"}: ${failure.message}`,
+    );
+
+    const outputSummary = {
+      pushRunId: pushResult.runId,
+      uploaded,
+      skipped: skippedCount,
+      failed,
+      translationsRequested: translations.length,
+      acceptedProposals: acceptedProposals.length,
+      providerSyncStatus: pushResult.status,
+    };
+
+    if (uploaded === 0 && failed > 0) {
+      await failAgentRun({
+        runId: run.id,
+        organizationId: input.organizationId,
+        outputSummary: { ...outputSummary, code: "provider_translation_push_failed" },
+        warnings,
+      });
+
+      return {
+        ok: false,
+        agentRunId: input.agentRunId,
+        code: "provider_translation_push_failed",
+        message: warnings[0] ?? "Provider translation write-back failed",
+      };
+    }
+
+    await completeAgentRun({
+      runId: run.id,
+      organizationId: input.organizationId,
+      outputSummary,
+      changedItems,
+      warnings,
+    });
+
+    return {
+      ok: true,
+      agentRunId: input.agentRunId,
+      uploaded,
+      skipped: skippedCount,
+      failed,
+      pushRunId: pushResult.runId,
+    };
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Provider translation write-back failed";
+
+    const changedItems = buildWritebackChangedItems({
+      proposals: acceptedProposals,
+      skippedItemIds: previouslyUploadedItemIds,
+      uploaded: 0,
+      failed: proposalsToPush.length,
+      failures: [{ locale: null, message }],
+    });
+
+    await failAgentRun({
+      runId: run.id,
+      organizationId: input.organizationId,
+      outputSummary: {
+        code: "provider_translation_push_failed",
+        uploaded: 0,
+        skipped: skippedCount,
+        failed: proposalsToPush.length,
+        translationsRequested: translations.length,
+      },
+      changedItems,
+      warnings: [message],
+    });
+
+    return {
+      ok: false,
+      agentRunId: input.agentRunId,
+      code: "provider_translation_push_failed",
+      message,
+    };
+  }
+}

--- a/apps/hyperlocalise-web/src/lib/providers/provider-agent-writeback.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-agent-writeback.ts
@@ -13,6 +13,7 @@ import {
 import {
   pushExternalTmsTranslations,
   type ExternalTmsApprovedTranslationUpload,
+  type ExternalTmsContentSyncFailure,
 } from "./external-tms-content-sync";
 import type { ProviderTranslationWritebackChangedItem } from "./provider-feedback-types";
 import { getProviderTranslationPusher } from "./provider-translation-pushers";
@@ -95,18 +96,89 @@ function loadPreviouslyUploadedItemIds(input: {
   return uploaded;
 }
 
+const JOB_AGENT_RUNS_PAGE_SIZE = 200;
+
+async function listAllAgentRunsForJob(input: {
+  organizationId: string;
+  hyperlocaliseJobId: string;
+}) {
+  const runs: Awaited<ReturnType<typeof listAgentRuns>> = [];
+  let offset = 0;
+
+  while (true) {
+    const page = await listAgentRuns({
+      organizationId: input.organizationId,
+      hyperlocaliseJobId: input.hyperlocaliseJobId,
+      limit: JOB_AGENT_RUNS_PAGE_SIZE,
+      offset,
+    });
+
+    runs.push(...page);
+
+    if (page.length < JOB_AGENT_RUNS_PAGE_SIZE) {
+      break;
+    }
+
+    offset += JOB_AGENT_RUNS_PAGE_SIZE;
+  }
+
+  return runs;
+}
+
+function resolveWritebackItemStatus(input: {
+  proposal: AcceptedAgentRunProposal;
+  uploaded: number;
+  failed: number;
+  failures: ExternalTmsContentSyncFailure[];
+  failureByExternalStringId: Map<string, ExternalTmsContentSyncFailure>;
+  localeOnlyFailedLocales: Set<string>;
+  defaultFailureMessage: string;
+}): Pick<ProviderTranslationWritebackChangedItem, "status" | "message"> {
+  if (input.failed > 0 && input.uploaded === 0) {
+    return { status: "failed", message: input.defaultFailureMessage };
+  }
+
+  const stringFailure = input.failureByExternalStringId.get(input.proposal.externalStringId);
+  if (stringFailure) {
+    return { status: "failed", message: stringFailure.message };
+  }
+
+  if (input.failed > 0 && input.localeOnlyFailedLocales.has(input.proposal.locale)) {
+    const localeFailure = input.failures.find(
+      (failure) => !failure.externalStringId && failure.locale === input.proposal.locale,
+    );
+    return {
+      status: "failed",
+      message: localeFailure?.message ?? input.defaultFailureMessage,
+    };
+  }
+
+  return { status: "uploaded", message: null };
+}
+
 function buildWritebackChangedItems(input: {
   proposals: AcceptedAgentRunProposal[];
   skippedItemIds: Set<string>;
   uploaded: number;
   failed: number;
-  failures: Array<{ locale: string | null; message: string }>;
+  failures: ExternalTmsContentSyncFailure[];
 }): ProviderTranslationWritebackChangedItem[] {
   const changedItems: ProviderTranslationWritebackChangedItem[] = [];
-  const failedLocales = new Set(
-    input.failures.map((failure) => failure.locale).filter((locale): locale is string => !!locale),
-  );
-  const failureMessage =
+  const failureByExternalStringId = new Map<string, ExternalTmsContentSyncFailure>();
+  const localeOnlyFailedLocales = new Set<string>();
+
+  for (const failure of input.failures) {
+    if (failure.externalStringId) {
+      failureByExternalStringId.set(failure.externalStringId, failure);
+      continue;
+    }
+
+    if (failure.locale) {
+      localeOnlyFailedLocales.add(failure.locale);
+    }
+  }
+
+  const defaultFailureMessage =
     input.failures[0]?.message ?? "One or more provider translation uploads failed";
 
   for (const proposal of input.proposals) {
@@ -124,18 +196,15 @@ function buildWritebackChangedItems(input: {
       continue;
     }
 
-    let status: ProviderTranslationWritebackChangedItem["status"] = "uploaded";
-    let message: string | null = null;
-
-    if (input.failed > 0 && input.uploaded === 0) {
-      status = "failed";
-      message = failureMessage;
-    } else if (input.failed > 0 && failedLocales.has(proposal.locale)) {
-      status = "failed";
-      message =
-        input.failures.find((failure) => failure.locale === proposal.locale)?.message ??
-        failureMessage;
-    }
+    const { status, message } = resolveWritebackItemStatus({
+      proposal,
+      uploaded: input.uploaded,
+      failed: input.failed,
+      failures: input.failures,
+      failureByExternalStringId,
+      localeOnlyFailedLocales,
+      defaultFailureMessage,
+    });
 
     changedItems.push({
       type: "provider_translation_writeback",
@@ -277,10 +346,9 @@ export async function executeProviderAgentWriteback(input: {
     }
   }
 
-  const jobRuns = await listAgentRuns({
+  const jobRuns = await listAllAgentRunsForJob({
     organizationId: input.organizationId,
     hyperlocaliseJobId: run.hyperlocaliseJobId,
-    limit: 200,
   });
 
   const acceptedProposals = collectAcceptedAgentRunProposalsForJob({ runs: jobRuns });
@@ -388,6 +456,7 @@ export async function executeProviderAgentWriteback(input: {
         runId: run.id,
         organizationId: input.organizationId,
         outputSummary: { ...outputSummary, code: "provider_translation_push_failed" },
+        changedItems,
         warnings,
       });
 
@@ -424,7 +493,7 @@ export async function executeProviderAgentWriteback(input: {
       skippedItemIds: previouslyUploadedItemIds,
       uploaded: 0,
       failed: proposalsToPush.length,
-      failures: [{ locale: null, message }],
+      failures: [{ externalStringId: null, locale: null, message }],
     });
 
     await failAgentRun({

--- a/apps/hyperlocalise-web/src/lib/providers/provider-feedback-types.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-feedback-types.ts
@@ -17,6 +17,17 @@ export type ProviderCommentChangedItem = {
   message?: string | null;
 };
 
+export type ProviderTranslationWritebackChangedItem = {
+  type: "provider_translation_writeback";
+  itemId: string;
+  externalStringId: string;
+  key: string;
+  locale: string;
+  status: "uploaded" | "skipped" | "failed";
+  sourceAgentRunId?: string | null;
+  message?: string | null;
+};
+
 export type ExternalTmsCommentPusher = (input: {
   organizationId: string;
   projectId: string;

--- a/apps/hyperlocalise-web/src/lib/workflow/types.ts
+++ b/apps/hyperlocalise-web/src/lib/workflow/types.ts
@@ -118,3 +118,10 @@ export type ProviderAgentCommentEventData = {
 };
 
 export type ProviderAgentCommentQueue = JobQueue<ProviderAgentCommentEventData>;
+
+export type ProviderAgentWritebackEventData = {
+  agentRunId: string;
+  organizationId: string;
+};
+
+export type ProviderAgentWritebackQueue = JobQueue<ProviderAgentWritebackEventData>;

--- a/apps/hyperlocalise-web/src/workflows/adapters.ts
+++ b/apps/hyperlocalise-web/src/workflows/adapters.ts
@@ -6,6 +6,7 @@ import { githubFixWorkflow } from "./github-fix";
 import { providerAgentCommentWorkflow } from "./provider-agent-comment";
 import { providerAgentQaWorkflow } from "./provider-agent-qa";
 import { providerAgentTranslationWorkflow } from "./provider-agent-translation";
+import { providerAgentWritebackWorkflow } from "./provider-agent-writeback";
 import { repoTmsAgentWorkflow } from "./repo-tms-agent";
 import { translationJobWorkflow } from "./translation-job";
 import type {
@@ -15,6 +16,7 @@ import type {
   ProviderAgentCommentQueue,
   ProviderAgentQaQueue,
   ProviderAgentTranslationQueue,
+  ProviderAgentWritebackQueue,
   RepoTmsAgentTaskQueue,
   TranslationJobEventData,
 } from "@/lib/workflow/types";
@@ -87,6 +89,15 @@ export function createProviderAgentCommentQueue(): ProviderAgentCommentQueue {
   return {
     async enqueue(event) {
       const run = await start(providerAgentCommentWorkflow, [event]);
+      return { ids: [run.runId] };
+    },
+  };
+}
+
+export function createProviderAgentWritebackQueue(): ProviderAgentWritebackQueue {
+  return {
+    async enqueue(event) {
+      const run = await start(providerAgentWritebackWorkflow, [event]);
       return { ids: [run.runId] };
     },
   };

--- a/apps/hyperlocalise-web/src/workflows/provider-agent-writeback.ts
+++ b/apps/hyperlocalise-web/src/workflows/provider-agent-writeback.ts
@@ -1,0 +1,39 @@
+import { getWorkflowMetadata } from "workflow";
+
+import type { ProviderAgentWritebackEventData } from "@/lib/workflow/types";
+
+import {
+  executeProviderAgentWritebackStep,
+  failProviderAgentWritebackStep,
+} from "./steps/provider-agent-writeback";
+
+function formatExecutionError(error: unknown) {
+  return error instanceof Error ? error.message : "provider agent write-back failed";
+}
+
+export async function providerAgentWritebackWorkflow(event: ProviderAgentWritebackEventData) {
+  "use workflow";
+
+  const { workflowRunId } = getWorkflowMetadata();
+
+  try {
+    const result = await executeProviderAgentWritebackStep(event);
+
+    return {
+      ...result,
+      workflowRunId,
+    };
+  } catch (error) {
+    const failure = await failProviderAgentWritebackStep({
+      agentRunId: event.agentRunId,
+      organizationId: event.organizationId,
+      code: "provider_agent_writeback_failed",
+      message: formatExecutionError(error),
+    });
+
+    return {
+      ...failure,
+      workflowRunId,
+    };
+  }
+}

--- a/apps/hyperlocalise-web/src/workflows/steps/provider-agent-writeback.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/provider-agent-writeback.ts
@@ -1,0 +1,33 @@
+import { failAgentRun } from "@/lib/providers/agent-runs";
+import { executeProviderAgentWriteback } from "@/lib/providers/provider-agent-writeback";
+
+export async function executeProviderAgentWritebackStep(input: {
+  agentRunId: string;
+  organizationId: string;
+}) {
+  "use step";
+  return executeProviderAgentWriteback(input);
+}
+
+export async function failProviderAgentWritebackStep(input: {
+  agentRunId: string;
+  organizationId: string;
+  code: string;
+  message: string;
+}) {
+  "use step";
+
+  await failAgentRun({
+    runId: input.agentRunId,
+    organizationId: input.organizationId,
+    outputSummary: { code: input.code },
+    warnings: [input.message],
+  });
+
+  return {
+    ok: false as const,
+    agentRunId: input.agentRunId,
+    code: input.code,
+    message: input.message,
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **HL-374**: explicit push of user-approved agent translations back to supported TMS providers (Crowdin, Phrase, Smartling, Lokalise).

The `push_approved_changes` action already existed in the UI/API but agent runs stayed `queued` because nothing executed them. This change adds the full write-back pipeline.

## Changes

- **`executeProviderAgentWriteback`**: Provider-neutral service that:
  - Validates write-back runs (`inputSnapshot.action === "push_approved_changes"`)
  - Collects accepted proposals from prior succeeded `translate` / `qa_fix` runs on the same job
  - Skips items already uploaded in prior succeeded write-back runs (idempotent)
  - Calls `pushExternalTmsTranslations` via `getProviderTranslationPusher`
  - Records per-item `provider_translation_writeback` results in `changedItems`
  - Syncs run summary (`pushRunId`, `uploaded`, `skipped`, `failed`)
  - Supports partial success (succeeds when any upload succeeds; fails only when all fail)

- **`collectAcceptedAgentRunProposalsForJob`**: Gathers accepted proposals, dedupes by `itemId` (newer wins), excludes write-back runs.

- **Workflow wiring**: `providerAgentWritebackWorkflow` + queue, enqueued from job route only for `push_approved_changes` (never from translate/QA flows).

- **`failAgentRun`**: Now accepts `changedItems` so catastrophic failures still persist per-item results.

## Acceptance criteria

| Criterion | Status |
|-----------|--------|
| User can push approved agent translations to a supported provider | ✅ Explicit `push_approved_changes` action enqueues write-back workflow |
| Write-back never triggered implicitly by translate/review runs | ✅ Only dedicated queue on `push_approved_changes` |
| Item-level successes and failures visible after completion | ✅ `changedItems` with `uploaded` / `skipped` / `failed` per item |

## Testing

- `vp check --fix` passes
- `agent-run-proposals.test.ts` passes locally
- DB integration tests (`provider-agent-writeback.test.ts`, `job.test.ts` write-back cases) require Postgres (CI)

Resolves HL-374
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-374](https://linear.app/hyperlocalise/issue/HL-374/implement-approved-translation-write-back-action)

<div><a href="https://cursor.com/agents/bc-d8cbf5de-ee09-4b45-8916-c2ec9451a4e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8cbf5de-ee09-4b45-8916-c2ec9451a4e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

