### PR TITLE
feat(phrase): sync review issues and comments into provider workflow

### DIFF
--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-api.ts
@@ -79,6 +79,28 @@ export interface PhraseUpload {
   updatedAt: string | null;
 }
 
+export interface PhraseUserPreview {
+  id: string;
+  username: string | null;
+  name: string | null;
+}
+
+export interface PhraseLocalePreview {
+  id: string;
+  name: string;
+  code: string | null;
+}
+
+export interface PhraseKeyComment {
+  id: string;
+  message: string;
+  hasReplies: boolean;
+  user: PhraseUserPreview | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+  locales: PhraseLocalePreview[];
+}
+
 export interface PhraseLocaleDownloadMetadata {
   localeId: string;
   localeName: string;
@@ -176,6 +198,47 @@ export class PhraseApiClient {
           branch: options.branch,
         }),
       normalize: (record) => normalizePhraseKey(record as PhraseKeyApiRecord),
+    });
+  }
+
+  async listKeyComments(
+    projectId: string,
+    keyId: string,
+    options: PhraseListOptions = {},
+  ): Promise<PhraseKeyComment[]> {
+    return this.paginate({
+      buildPath: (page, perPage) =>
+        this.buildPath(
+          `/projects/${encodeURIComponent(projectId)}/keys/${encodeURIComponent(keyId)}/comments`,
+          {
+            page,
+            per_page: perPage,
+            branch: options.branch,
+            order: "desc",
+          },
+        ),
+      normalize: (record) => normalizePhraseKeyComment(record as PhraseKeyCommentApiRecord),
+    });
+  }
+
+  async listCommentReplies(
+    projectId: string,
+    keyId: string,
+    commentId: string,
+    options: PhraseListOptions = {},
+  ): Promise<PhraseKeyComment[]> {
+    return this.paginate({
+      buildPath: (page, perPage) =>
+        this.buildPath(
+          `/projects/${encodeURIComponent(projectId)}/keys/${encodeURIComponent(keyId)}/comments/${encodeURIComponent(commentId)}/replies`,
+          {
+            page,
+            per_page: perPage,
+            branch: options.branch,
+            order: "asc",
+          },
+        ),
+      normalize: (record) => normalizePhraseKeyComment(record as PhraseKeyCommentApiRecord),
     });
   }
 
@@ -511,6 +574,28 @@ type PhraseUploadApiRecord = {
   updated_at?: string | null;
 };
 
+type PhraseUserPreviewApiRecord = {
+  id: string;
+  username?: string | null;
+  name?: string | null;
+};
+
+type PhraseLocalePreviewApiRecord = {
+  id: string;
+  name: string;
+  code?: string | null;
+};
+
+type PhraseKeyCommentApiRecord = {
+  id: string;
+  message?: string;
+  has_replies?: boolean;
+  user?: PhraseUserPreviewApiRecord | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+  locales?: PhraseLocalePreviewApiRecord[];
+};
+
 function normalizePhraseProject(project: PhraseProjectApiRecord): PhraseProject {
   return {
     id: project.id,
@@ -589,5 +674,37 @@ function normalizePhraseUpload(upload: PhraseUploadApiRecord): PhraseUpload {
     url: upload.url ?? null,
     createdAt: upload.created_at ?? null,
     updatedAt: upload.updated_at ?? null,
+  };
+}
+
+function normalizePhraseUserPreview(user: PhraseUserPreviewApiRecord | null | undefined) {
+  if (!user?.id) {
+    return null;
+  }
+
+  return {
+    id: user.id,
+    username: user.username ?? null,
+    name: user.name ?? null,
+  };
+}
+
+function normalizePhraseLocalePreview(locale: PhraseLocalePreviewApiRecord) {
+  return {
+    id: locale.id,
+    name: locale.name,
+    code: locale.code ?? null,
+  };
+}
+
+function normalizePhraseKeyComment(comment: PhraseKeyCommentApiRecord): PhraseKeyComment {
+  return {
+    id: comment.id,
+    message: comment.message?.trim() || "",
+    hasReplies: comment.has_replies ?? false,
+    user: normalizePhraseUserPreview(comment.user),
+    createdAt: comment.created_at ?? null,
+    updatedAt: comment.updated_at ?? null,
+    locales: (comment.locales ?? []).map(normalizePhraseLocalePreview),
   };
 }

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-review-normalize.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-review-normalize.test.ts
@@ -89,6 +89,27 @@ describe("phrase review normalization", () => {
       lqaReference: null,
     };
 
+    const withSegment: PhraseTmsConversation = {
+      id: "plain-segment",
+      type: "plain",
+      description: "Note on this segment",
+      deleted: false,
+      createdAt: "2026-05-06T10:00:00Z",
+      updatedAt: null,
+      resolvedAt: null,
+      state: "open",
+      author: null,
+      resolver: null,
+      comments: [],
+      lqaReference: {
+        segmentId: "segment-99",
+        commentedText: "Bonjour",
+        errorCategoryId: null,
+        severityId: null,
+        repeated: null,
+      },
+    };
+
     const resolved: PhraseTmsConversation = {
       id: "plain-1",
       type: "plain",
@@ -132,6 +153,21 @@ describe("phrase review normalization", () => {
         jobProviderUrl: null,
       }),
     ).toBeNull();
+
+    const segmentThread = normalizePhrasePlainConversationToThread({
+      conversation: withSegment,
+      externalProjectId: "project-1",
+      externalJobId: "phrase-job-1-task-fr-fr",
+      jobProviderUrl: null,
+      targetLocale: "fr-FR",
+    });
+
+    expect(segmentThread?.item).toEqual({
+      externalStringId: "segment-99",
+      key: "segment-99",
+      locale: "fr-FR",
+      field: "target",
+    });
 
     const thread = normalizePhrasePlainConversationToThread({
       conversation: resolved,

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-review-normalize.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-review-normalize.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import type { PhraseKeyComment } from "./phrase-api";
+import type { PhraseTmsConversation } from "./phrase-tms-api";
+import {
+  buildPhraseStringsKeyProviderUrl,
+  buildPhraseTmsJobProviderUrl,
+  normalizePhraseKeyCommentToThread,
+  normalizePhraseLqaConversationToThread,
+  normalizePhrasePlainConversationToThread,
+} from "./phrase-review-normalize";
+
+describe("phrase review normalization", () => {
+  it("maps LQA issues with resolution state, segment refs, and provider links", () => {
+    const conversation: PhraseTmsConversation = {
+      id: "lqa-1",
+      type: "lqa",
+      description: "Wrong terminology",
+      deleted: false,
+      createdAt: "2026-05-01T10:00:00Z",
+      updatedAt: "2026-05-02T10:00:00Z",
+      resolvedAt: null,
+      state: "open",
+      author: {
+        uid: "user-1",
+        userName: "reviewer",
+        firstName: "Review",
+        lastName: "Er",
+        email: null,
+      },
+      resolver: null,
+      comments: [
+        {
+          id: "comment-1",
+          text: "Please fix",
+          createdAt: "2026-05-01T10:00:00Z",
+          updatedAt: null,
+          author: null,
+        },
+      ],
+      lqaReference: {
+        segmentId: "segment-42",
+        commentedText: "Hallo",
+        errorCategoryId: 3,
+        severityId: 2,
+        repeated: "no",
+      },
+    };
+
+    const thread = normalizePhraseLqaConversationToThread({
+      conversation,
+      externalProjectId: "project-1",
+      externalJobId: "phrase-job-1-task-fr-fr",
+      jobProviderUrl: buildPhraseTmsJobProviderUrl({
+        tmsBaseUrl: "https://cloud.memsource.com/web",
+        projectUid: "tms-project-1",
+        jobUid: "job-fr",
+      }),
+      targetLocale: "fr-FR",
+    });
+
+    expect(thread?.kind).toBe("issue");
+    expect(thread?.state).toBe("open");
+    expect(thread?.issueType).toBe("category:3,severity:2,repeated:no");
+    expect(thread?.item).toEqual({
+      externalStringId: "segment-42",
+      key: "segment-42",
+      locale: "fr-FR",
+      field: "target",
+    });
+    expect(thread?.providerContext.providerUrl).toBe(
+      "https://cloud.memsource.com/web/project2/translate/tms-project-1/job/job-fr",
+    );
+  });
+
+  it("skips deleted conversations and maps resolved plain comments", () => {
+    const deleted: PhraseTmsConversation = {
+      id: "plain-deleted",
+      type: "plain",
+      description: "gone",
+      deleted: true,
+      createdAt: null,
+      updatedAt: null,
+      resolvedAt: null,
+      state: "unknown",
+      author: null,
+      resolver: null,
+      comments: [],
+      lqaReference: null,
+    };
+
+    const resolved: PhraseTmsConversation = {
+      id: "plain-1",
+      type: "plain",
+      description: null,
+      deleted: false,
+      createdAt: "2026-05-03T10:00:00Z",
+      updatedAt: "2026-05-04T10:00:00Z",
+      resolvedAt: "2026-05-04T10:00:00Z",
+      state: "resolved",
+      author: {
+        uid: "user-2",
+        userName: "pm",
+        firstName: null,
+        lastName: null,
+        email: null,
+      },
+      resolver: {
+        uid: "user-3",
+        userName: "lead",
+        firstName: "Team",
+        lastName: "Lead",
+        email: null,
+      },
+      comments: [
+        {
+          id: "comment-2",
+          text: "Looks good now",
+          createdAt: "2026-05-03T10:00:00Z",
+          updatedAt: "2026-05-04T10:00:00Z",
+          author: null,
+        },
+      ],
+      lqaReference: null,
+    };
+
+    expect(
+      normalizePhrasePlainConversationToThread({
+        conversation: deleted,
+        externalProjectId: "project-1",
+        externalJobId: "phrase-job-1-task-fr-fr",
+        jobProviderUrl: null,
+      }),
+    ).toBeNull();
+
+    const thread = normalizePhrasePlainConversationToThread({
+      conversation: resolved,
+      externalProjectId: "project-1",
+      externalJobId: "phrase-job-1-task-fr-fr",
+      jobProviderUrl: null,
+    });
+
+    expect(thread?.kind).toBe("comment");
+    expect(thread?.state).toBe("resolved");
+    expect(thread?.resolver?.displayName).toBe("Team Lead");
+    expect(thread?.subject).toBe("Looks good now");
+  });
+
+  it("maps strings key comments with replies and tolerates missing author metadata", () => {
+    const comment: PhraseKeyComment = {
+      id: "comment-root",
+      message: "Check pluralization",
+      hasReplies: true,
+      user: null,
+      createdAt: "2026-05-05T10:00:00Z",
+      updatedAt: null,
+      locales: [{ id: "locale-1", name: "German", code: "de" }],
+    };
+
+    const reply: PhraseKeyComment = {
+      id: "comment-reply",
+      message: "Updated",
+      hasReplies: false,
+      user: {
+        id: "user-9",
+        username: "translator",
+        name: "Translator",
+      },
+      createdAt: "2026-05-05T11:00:00Z",
+      updatedAt: null,
+      locales: [],
+    };
+
+    const thread = normalizePhraseKeyCommentToThread({
+      comment,
+      replies: [reply],
+      keyId: "key-1",
+      externalProjectId: "project-1",
+      externalJobId: "phrase-job-1-task-de-de",
+      stringKeyById: new Map([["key-1", "welcome.title"]]),
+      keyProviderUrl: buildPhraseStringsKeyProviderUrl({
+        accountSlug: "acme",
+        projectSlug: "demo",
+        keyId: "key-1",
+      }),
+    });
+
+    expect(thread?.item?.key).toBe("welcome.title");
+    expect(thread?.locale).toBe("de");
+    expect(thread?.comments).toHaveLength(2);
+    expect(thread?.author).toBeNull();
+    expect(thread?.providerContext.providerUrl).toBe(
+      "https://app.phrase.com/accounts/acme/projects/demo/keys/key-1",
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-review-normalize.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-review-normalize.ts
@@ -133,6 +133,22 @@ function pickLatestTimestamp(conversation: PhraseTmsConversation): string | null
   return timestamps.sort().at(-1) ?? null;
 }
 
+function buildTmsSegmentItemReference(input: {
+  segmentId: string | null;
+  targetLocale?: string | null;
+}) {
+  if (!input.segmentId) {
+    return null;
+  }
+
+  return {
+    externalStringId: input.segmentId,
+    key: input.segmentId,
+    locale: input.targetLocale ?? undefined,
+    field: "target" as const,
+  };
+}
+
 export function normalizePhraseLqaConversationToThread(input: {
   conversation: PhraseTmsConversation;
   externalProjectId: string;
@@ -161,14 +177,10 @@ export function normalizePhraseLqaConversationToThread(input: {
     state: mapTmsConversationState(input.conversation.state),
     subject: pickConversationSubject(input.conversation),
     issueType: buildLqaIssueType(input.conversation),
-    item: segmentId
-      ? {
-          externalStringId: segmentId,
-          key: segmentId,
-          locale: input.targetLocale ?? undefined,
-          field: "target",
-        }
-      : null,
+    item: buildTmsSegmentItemReference({
+      segmentId,
+      targetLocale: input.targetLocale,
+    }),
     locale: input.targetLocale ?? null,
     comments,
     author: mapPhraseTmsUser(input.conversation.author),
@@ -191,12 +203,14 @@ export function normalizePhrasePlainConversationToThread(input: {
   externalProjectId: string;
   externalJobId: string;
   jobProviderUrl: string | null;
+  targetLocale?: string | null;
 }): ProviderReviewThread | null {
   if (input.conversation.deleted || !input.conversation.id.trim()) {
     return null;
   }
 
   const externalThreadId = `tms-plain:${input.conversation.id}`;
+  const segmentId = input.conversation.lqaReference?.segmentId?.trim() || null;
   const comments = buildTmsConversationComments(input.conversation);
   const firstCommentId = comments[0]?.externalCommentId ?? input.conversation.id;
 
@@ -211,6 +225,11 @@ export function normalizePhrasePlainConversationToThread(input: {
     kind: "comment",
     state: mapTmsConversationState(input.conversation.state),
     subject: pickConversationSubject(input.conversation),
+    item: buildTmsSegmentItemReference({
+      segmentId,
+      targetLocale: input.targetLocale,
+    }),
+    locale: segmentId ? (input.targetLocale ?? null) : null,
     comments,
     author: mapPhraseTmsUser(input.conversation.author),
     resolver: mapPhraseTmsUser(input.conversation.resolver),

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-review-normalize.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-review-normalize.ts
@@ -1,0 +1,297 @@
+import { buildProviderReviewThreadId } from "@/lib/providers/provider-job-review/build-thread-id";
+import type {
+  ProviderReviewAuthor,
+  ProviderReviewComment,
+  ProviderReviewThread,
+  ProviderReviewThreadState,
+} from "@/lib/providers/provider-job-review/types";
+
+import type { PhraseKeyComment, PhraseUserPreview } from "./phrase-api";
+import type { PhraseTmsConversation, PhraseTmsConversationUser } from "./phrase-tms-api";
+
+export function buildPhraseTmsJobProviderUrl(input: {
+  tmsBaseUrl: string;
+  projectUid: string;
+  jobUid: string;
+}) {
+  const base = input.tmsBaseUrl.replace(/\/+$/g, "");
+  return `${base}/project2/translate/${encodeURIComponent(input.projectUid)}/job/${encodeURIComponent(input.jobUid)}`;
+}
+
+export function buildPhraseStringsKeyProviderUrl(input: {
+  accountSlug: string | null;
+  projectSlug: string | null;
+  keyId: string;
+}) {
+  if (!input.accountSlug || !input.projectSlug) {
+    return null;
+  }
+
+  return `https://app.phrase.com/accounts/${input.accountSlug}/projects/${input.projectSlug}/keys/${encodeURIComponent(input.keyId)}`;
+}
+
+function mapPhraseTmsUser(
+  user: PhraseTmsConversationUser | null | undefined,
+): ProviderReviewAuthor | null {
+  if (!user) {
+    return null;
+  }
+
+  const externalUserId = user.uid?.trim() || user.userName?.trim() || null;
+  if (!externalUserId) {
+    return null;
+  }
+
+  const displayName = [user.firstName, user.lastName]
+    .map((part) => part?.trim())
+    .filter((part): part is string => Boolean(part))
+    .join(" ");
+
+  return {
+    externalUserId,
+    username: user.userName?.trim() || null,
+    displayName: displayName || user.userName?.trim() || null,
+  };
+}
+
+function mapPhraseStringsUser(
+  user: PhraseUserPreview | null | undefined,
+): ProviderReviewAuthor | null {
+  if (!user?.id) {
+    return null;
+  }
+
+  return {
+    externalUserId: user.id,
+    username: user.username?.trim() || null,
+    displayName: user.name?.trim() || user.username?.trim() || null,
+  };
+}
+
+function mapTmsConversationState(state: PhraseTmsConversation["state"]): ProviderReviewThreadState {
+  if (state === "resolved") {
+    return "resolved";
+  }
+  if (state === "open") {
+    return "open";
+  }
+  return "unknown";
+}
+
+function buildTmsConversationComments(
+  conversation: PhraseTmsConversation,
+): ProviderReviewComment[] {
+  return conversation.comments.map((comment) => ({
+    externalCommentId: comment.id,
+    body: comment.text,
+    author: mapPhraseTmsUser(comment.author),
+    createdAt: comment.createdAt ?? null,
+    updatedAt: comment.updatedAt ?? comment.createdAt ?? null,
+  }));
+}
+
+function buildLqaIssueType(conversation: PhraseTmsConversation): string | null {
+  const lqa = conversation.lqaReference;
+  if (!lqa) {
+    return null;
+  }
+
+  const parts: string[] = [];
+  if (lqa.errorCategoryId != null) {
+    parts.push(`category:${lqa.errorCategoryId}`);
+  }
+  if (lqa.severityId != null) {
+    parts.push(`severity:${lqa.severityId}`);
+  }
+  if (lqa.repeated) {
+    parts.push(`repeated:${lqa.repeated}`);
+  }
+
+  return parts.length > 0 ? parts.join(",") : null;
+}
+
+function pickConversationSubject(conversation: PhraseTmsConversation): string | null {
+  if (conversation.description?.trim()) {
+    return conversation.description.trim();
+  }
+
+  return conversation.comments[0]?.text ?? null;
+}
+
+function pickLatestTimestamp(conversation: PhraseTmsConversation): string | null {
+  const timestamps = [
+    conversation.updatedAt,
+    conversation.resolvedAt,
+    conversation.createdAt,
+    ...conversation.comments.flatMap((comment) => [comment.updatedAt, comment.createdAt]),
+  ].filter((value): value is string => Boolean(value?.trim()));
+
+  if (timestamps.length === 0) {
+    return null;
+  }
+
+  return timestamps.sort().at(-1) ?? null;
+}
+
+export function normalizePhraseLqaConversationToThread(input: {
+  conversation: PhraseTmsConversation;
+  externalProjectId: string;
+  externalJobId: string;
+  jobProviderUrl: string | null;
+  targetLocale?: string | null;
+}): ProviderReviewThread | null {
+  if (input.conversation.deleted || !input.conversation.id.trim()) {
+    return null;
+  }
+
+  const externalThreadId = `tms-lqa:${input.conversation.id}`;
+  const segmentId = input.conversation.lqaReference?.segmentId?.trim() || null;
+  const comments = buildTmsConversationComments(input.conversation);
+  const firstCommentId = comments[0]?.externalCommentId ?? input.conversation.id;
+
+  return {
+    threadId: buildProviderReviewThreadId({
+      providerKind: "phrase",
+      externalProjectId: input.externalProjectId,
+      externalJobId: input.externalJobId,
+      kind: "issue",
+      externalThreadId,
+    }),
+    kind: "issue",
+    state: mapTmsConversationState(input.conversation.state),
+    subject: pickConversationSubject(input.conversation),
+    issueType: buildLqaIssueType(input.conversation),
+    item: segmentId
+      ? {
+          externalStringId: segmentId,
+          key: segmentId,
+          locale: input.targetLocale ?? undefined,
+          field: "target",
+        }
+      : null,
+    locale: input.targetLocale ?? null,
+    comments,
+    author: mapPhraseTmsUser(input.conversation.author),
+    resolver: mapPhraseTmsUser(input.conversation.resolver),
+    createdAt: input.conversation.createdAt ?? null,
+    updatedAt: pickLatestTimestamp(input.conversation),
+    resolvedAt: input.conversation.resolvedAt ?? null,
+    providerContext: {
+      externalProjectId: input.externalProjectId,
+      externalJobId: input.externalJobId,
+      externalThreadId,
+      externalCommentId: firstCommentId,
+      providerUrl: input.jobProviderUrl,
+    },
+  };
+}
+
+export function normalizePhrasePlainConversationToThread(input: {
+  conversation: PhraseTmsConversation;
+  externalProjectId: string;
+  externalJobId: string;
+  jobProviderUrl: string | null;
+}): ProviderReviewThread | null {
+  if (input.conversation.deleted || !input.conversation.id.trim()) {
+    return null;
+  }
+
+  const externalThreadId = `tms-plain:${input.conversation.id}`;
+  const comments = buildTmsConversationComments(input.conversation);
+  const firstCommentId = comments[0]?.externalCommentId ?? input.conversation.id;
+
+  return {
+    threadId: buildProviderReviewThreadId({
+      providerKind: "phrase",
+      externalProjectId: input.externalProjectId,
+      externalJobId: input.externalJobId,
+      kind: "comment",
+      externalThreadId,
+    }),
+    kind: "comment",
+    state: mapTmsConversationState(input.conversation.state),
+    subject: pickConversationSubject(input.conversation),
+    comments,
+    author: mapPhraseTmsUser(input.conversation.author),
+    resolver: mapPhraseTmsUser(input.conversation.resolver),
+    createdAt: input.conversation.createdAt ?? null,
+    updatedAt: pickLatestTimestamp(input.conversation),
+    resolvedAt: input.conversation.resolvedAt ?? null,
+    providerContext: {
+      externalProjectId: input.externalProjectId,
+      externalJobId: input.externalJobId,
+      externalThreadId,
+      externalCommentId: firstCommentId,
+      providerUrl: input.jobProviderUrl,
+    },
+  };
+}
+
+export function normalizePhraseKeyCommentToThread(input: {
+  comment: PhraseKeyComment;
+  replies: PhraseKeyComment[];
+  keyId: string;
+  externalProjectId: string;
+  externalJobId: string;
+  stringKeyById: Map<string, string>;
+  keyProviderUrl: string | null;
+}): ProviderReviewThread | null {
+  if (!input.comment.id.trim() || !input.comment.message.trim()) {
+    return null;
+  }
+
+  const externalThreadId = `strings-key:${input.keyId}:${input.comment.id}`;
+  const stringKey = input.stringKeyById.get(input.keyId) ?? input.keyId;
+  const locale =
+    input.comment.locales[0]?.code?.trim() || input.comment.locales[0]?.name?.trim() || null;
+
+  const comments: ProviderReviewComment[] = [
+    {
+      externalCommentId: input.comment.id,
+      body: input.comment.message,
+      author: mapPhraseStringsUser(input.comment.user),
+      createdAt: input.comment.createdAt ?? null,
+      updatedAt: input.comment.updatedAt ?? input.comment.createdAt ?? null,
+    },
+    ...input.replies
+      .filter((reply) => reply.id.trim() && reply.message.trim())
+      .map((reply) => ({
+        externalCommentId: reply.id,
+        body: reply.message,
+        author: mapPhraseStringsUser(reply.user),
+        createdAt: reply.createdAt ?? null,
+        updatedAt: reply.updatedAt ?? reply.createdAt ?? null,
+      })),
+  ];
+
+  return {
+    threadId: buildProviderReviewThreadId({
+      providerKind: "phrase",
+      externalProjectId: input.externalProjectId,
+      externalJobId: input.externalJobId,
+      kind: "comment",
+      externalThreadId,
+    }),
+    kind: "comment",
+    state: "unknown",
+    subject: input.comment.message,
+    item: {
+      externalStringId: input.keyId,
+      key: stringKey,
+      locale: locale ?? undefined,
+      field: "target",
+    },
+    locale,
+    comments,
+    author: mapPhraseStringsUser(input.comment.user),
+    createdAt: input.comment.createdAt ?? null,
+    updatedAt: input.comment.updatedAt ?? input.comment.createdAt ?? null,
+    providerContext: {
+      externalProjectId: input.externalProjectId,
+      externalJobId: input.externalJobId,
+      externalThreadId,
+      externalCommentId: input.comment.id,
+      providerUrl: input.keyProviderUrl,
+    },
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-review-puller.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-review-puller.test.ts
@@ -118,4 +118,48 @@ describe("pullPhraseProviderReview", () => {
     expect(report.summary.byKind.comment).toBe(1);
     expect(report.threads.some((thread) => thread.item?.key === "welcome.title")).toBe(true);
   });
+
+  it("maps Phrase API rate limits to phrase_rate_limited", async () => {
+    const fetchFn = vi.fn(async (url: string) => {
+      const path = String(url);
+
+      if (path.includes("/api2/v2/projects/") && path.includes("/jobs")) {
+        return new Response(JSON.stringify({ content: [], totalPages: 0 }), { status: 200 });
+      }
+
+      if (path.includes("/keys/")) {
+        return new Response("Too Many Requests", { status: 429 });
+      }
+
+      return new Response("not found", { status: 404 });
+    });
+
+    await expect(
+      pullPhraseProviderReview({
+        credential: { region: "eu" },
+        secretMaterial: "token",
+        fetchFn: fetchFn as typeof fetch,
+        externalProjectId: "strings-project-1",
+        externalJobId: "phrase-job-1-task-fr-fr",
+        project: {
+          providerMetadata: {
+            stringsProjectId: "strings-project-1",
+            tmsProjectUid: "tms-project-1",
+          },
+        } as never,
+        content: {
+          externalJobId: "phrase-job-1-task-fr-fr",
+          targetLocales: ["fr-FR"],
+          units: [
+            {
+              externalStringId: "key-1",
+              key: "welcome.title",
+              sourceText: "Hello",
+              translations: [{ locale: "fr-FR", text: "Bonjour" }],
+            },
+          ],
+        },
+      }),
+    ).rejects.toThrow("phrase_rate_limited");
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-review-puller.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-review-puller.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { pullPhraseProviderReview } from "./phrase-review-puller";
+
+describe("pullPhraseProviderReview", () => {
+  it("deduplicates threads across repeated sync pulls", async () => {
+    const fetchFn = vi.fn(async (url: string) => {
+      const path = String(url);
+
+      if (path.includes("/api2/v2/projects/") && path.includes("/jobs")) {
+        const workflowLevel = Number(new URL(path).searchParams.get("workflowLevel"));
+        if (workflowLevel === 1) {
+          return new Response(
+            JSON.stringify({
+              content: [
+                {
+                  uid: "job-fr",
+                  innerId: "phrase-job-1",
+                  status: "NEW",
+                  targetLang: "fr-FR",
+                  filename: "Homepage",
+                },
+              ],
+              totalPages: 1,
+            }),
+            { status: 200 },
+          );
+        }
+
+        return new Response(JSON.stringify({ content: [], totalPages: 0 }), { status: 200 });
+      }
+
+      if (path.includes("/conversations/lqas")) {
+        return new Response(
+          JSON.stringify({
+            conversations: [
+              {
+                id: "lqa-1",
+                lqaDescription: "Wrong tense",
+                deleted: false,
+                dateCreated: "2026-05-01T10:00:00Z",
+                status: { name: "unresolved" },
+                comments: [
+                  {
+                    id: "lqa-comment-1",
+                    text: "Please fix",
+                    dateCreated: "2026-05-01T10:00:00Z",
+                  },
+                  {
+                    id: "lqa-comment-1",
+                    text: "Please fix duplicate",
+                    dateCreated: "2026-05-01T10:00:00Z",
+                  },
+                ],
+                references: {
+                  segmentId: "segment-1",
+                  lqa: [{ errorCategoryId: 1, severityId: 2 }],
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/conversations/plains")) {
+        return new Response(JSON.stringify({ conversations: [] }), { status: 200 });
+      }
+
+      if (path.includes("/keys/key-1/comments") && !path.includes("/replies")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "strings-comment-1",
+              message: "FYI",
+              has_replies: false,
+              created_at: "2026-05-02T10:00:00Z",
+              locales: [{ id: "locale-fr", name: "French", code: "fr" }],
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      return new Response("not found", { status: 404 });
+    });
+
+    const report = await pullPhraseProviderReview({
+      credential: { region: "eu" },
+      secretMaterial: "token",
+      fetchFn: fetchFn as typeof fetch,
+      externalProjectId: "strings-project-1",
+      externalJobId: "phrase-job-1-task-fr-fr",
+      project: {
+        providerMetadata: {
+          stringsProjectId: "strings-project-1",
+          tmsProjectUid: "tms-project-1",
+          accountSlug: "acme",
+          slug: "demo",
+        },
+      } as never,
+      content: {
+        externalJobId: "phrase-job-1-task-fr-fr",
+        targetLocales: ["fr-FR"],
+        units: [
+          {
+            externalStringId: "key-1",
+            key: "welcome.title",
+            sourceText: "Hello",
+            translations: [{ locale: "fr-FR", text: "Bonjour" }],
+          },
+        ],
+      },
+    });
+
+    expect(report.summary.total).toBe(2);
+    expect(report.summary.byKind.issue).toBe(1);
+    expect(report.summary.byKind.comment).toBe(1);
+    expect(report.threads.some((thread) => thread.item?.key === "welcome.title")).toBe(true);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-review-puller.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-review-puller.ts
@@ -1,0 +1,218 @@
+import type { ExternalTmsTaskContent } from "@/lib/providers/external-tms-content-sync";
+import { buildProviderReviewReport } from "@/lib/providers/provider-job-review/normalize-provider-review";
+import type { ProviderReviewReport } from "@/lib/providers/provider-job-review/types";
+
+import { schema } from "@/lib/database";
+
+import { PhraseApiClient, PhraseApiError } from "./phrase-api";
+import {
+  findPhraseTmsJobPart,
+  parsePhraseExternalJobId,
+  resolvePhraseBranch,
+  resolvePhraseStringsProjectId,
+  resolvePhraseTmsProjectUid,
+} from "./phrase-job-context";
+import {
+  buildPhraseStringsKeyProviderUrl,
+  buildPhraseTmsJobProviderUrl,
+  normalizePhraseKeyCommentToThread,
+  normalizePhraseLqaConversationToThread,
+  normalizePhrasePlainConversationToThread,
+} from "./phrase-review-normalize";
+import { PhraseTmsApiClient, PhraseTmsApiError } from "./phrase-tms-api";
+
+type ExternalTmsProject = typeof schema.projects.$inferSelect;
+
+function chunkArray<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
+}
+
+function resolvePhraseProjectSlugs(project: ExternalTmsProject) {
+  const metadata = project.providerMetadata ?? {};
+  const accountSlug = typeof metadata.accountSlug === "string" ? metadata.accountSlug.trim() : null;
+  const projectSlug = typeof metadata.slug === "string" ? metadata.slug.trim() : null;
+
+  return { accountSlug: accountSlug || null, projectSlug: projectSlug || null };
+}
+
+export type PhraseReviewPullInput = {
+  credential: { baseUrl?: string | null; region?: string | null };
+  secretMaterial: string;
+  externalProjectId: string;
+  externalJobId: string;
+  project: ExternalTmsProject;
+  content: ExternalTmsTaskContent;
+  fetchFn?: typeof fetch;
+};
+
+export async function pullPhraseProviderReview(
+  input: PhraseReviewPullInput,
+): Promise<ProviderReviewReport> {
+  if (!input.externalProjectId.trim() || !input.externalJobId.trim()) {
+    throw new Error("invalid_phrase_project_or_job_id");
+  }
+
+  if (!parsePhraseExternalJobId(input.externalJobId)) {
+    throw new Error("invalid_phrase_external_job_id");
+  }
+
+  const stringsProjectId = resolvePhraseStringsProjectId(input.project, input.externalProjectId);
+  const tmsProjectUid = resolvePhraseTmsProjectUid(input.project, input.externalProjectId);
+  const branch = resolvePhraseBranch(input.project);
+  const { accountSlug, projectSlug } = resolvePhraseProjectSlugs(input.project);
+
+  const stringsClient = new PhraseApiClient({
+    token: input.secretMaterial,
+    region: input.credential.region,
+    baseUrl: input.credential.baseUrl,
+    fetchFn: input.fetchFn,
+  });
+
+  const tmsClient = new PhraseTmsApiClient({
+    token: input.secretMaterial,
+    baseUrl: input.credential.baseUrl,
+    fetchFn: input.fetchFn,
+  });
+
+  const stringKeyById = new Map(
+    input.content.units.map((unit) => [unit.externalStringId, unit.key] as const),
+  );
+
+  const keyIds = new Set<string>();
+  for (const unit of input.content.units) {
+    const keyId = unit.externalStringId.trim();
+    if (keyId) {
+      keyIds.add(keyId);
+    }
+  }
+
+  let jobProviderUrl: string | null = null;
+  let targetLocale: string | null = input.content.targetLocales[0]?.trim() || null;
+
+  const tmsThreads: ReturnType<typeof normalizePhraseLqaConversationToThread>[] = [];
+
+  if (tmsProjectUid) {
+    try {
+      const jobParts = await tmsClient.listAllJobParts(tmsProjectUid);
+      const jobPart = findPhraseTmsJobPart({
+        externalJobId: input.externalJobId,
+        jobParts,
+      });
+
+      if (jobPart) {
+        targetLocale = jobPart.targetLang.trim() || targetLocale;
+        jobProviderUrl = buildPhraseTmsJobProviderUrl({
+          tmsBaseUrl: tmsClient.resolvedBaseUrl,
+          projectUid: tmsProjectUid,
+          jobUid: jobPart.uid,
+        });
+
+        const [lqaConversations, plainConversations] = await Promise.all([
+          tmsClient.listLqaConversations(jobPart.uid),
+          tmsClient.listPlainConversations(jobPart.uid),
+        ]);
+
+        for (const conversation of lqaConversations) {
+          tmsThreads.push(
+            normalizePhraseLqaConversationToThread({
+              conversation,
+              externalProjectId: input.externalProjectId,
+              externalJobId: input.externalJobId,
+              jobProviderUrl,
+              targetLocale,
+            }),
+          );
+        }
+
+        for (const conversation of plainConversations) {
+          tmsThreads.push(
+            normalizePhrasePlainConversationToThread({
+              conversation,
+              externalProjectId: input.externalProjectId,
+              externalJobId: input.externalJobId,
+              jobProviderUrl,
+            }),
+          );
+        }
+      }
+    } catch (error) {
+      if (error instanceof PhraseTmsApiError && error.status === 401) {
+        throw new Error("phrase_auth_invalid");
+      }
+      throw error;
+    }
+  }
+
+  const keyCommentThreads: ReturnType<typeof normalizePhraseKeyCommentToThread>[] = [];
+  const keyIdList = [...keyIds];
+
+  if (keyIdList.length > 0 && stringsProjectId) {
+    try {
+      const listOptions = { branch };
+
+      for (const chunk of chunkArray(keyIdList, 10)) {
+        const chunkResults = await Promise.all(
+          chunk.map(async (keyId) => {
+            const comments = await stringsClient.listKeyComments(
+              stringsProjectId,
+              keyId,
+              listOptions,
+            );
+            const keyProviderUrl = buildPhraseStringsKeyProviderUrl({
+              accountSlug,
+              projectSlug,
+              keyId,
+            });
+
+            const threadsForKey = await Promise.all(
+              comments.map(async (comment) => {
+                const replies =
+                  comment.hasReplies && comment.id.trim()
+                    ? await stringsClient.listCommentReplies(
+                        stringsProjectId,
+                        keyId,
+                        comment.id,
+                        listOptions,
+                      )
+                    : [];
+
+                return normalizePhraseKeyCommentToThread({
+                  comment,
+                  replies,
+                  keyId,
+                  externalProjectId: input.externalProjectId,
+                  externalJobId: input.externalJobId,
+                  stringKeyById,
+                  keyProviderUrl,
+                });
+              }),
+            );
+
+            return threadsForKey;
+          }),
+        );
+
+        for (const threads of chunkResults) {
+          keyCommentThreads.push(...threads);
+        }
+      }
+    } catch (error) {
+      if (error instanceof PhraseApiError && error.status === 401) {
+        throw new Error("phrase_auth_invalid");
+      }
+      throw error;
+    }
+  }
+
+  const threads = [...tmsThreads, ...keyCommentThreads].filter(
+    (thread): thread is NonNullable<typeof thread> => thread != null,
+  );
+
+  const deduped = new Map(threads.map((thread) => [thread.threadId, thread] as const));
+
+  return buildProviderReviewReport([...deduped.values()]);
+}

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-review-puller.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-review-puller.ts
@@ -31,6 +31,19 @@ function chunkArray<T>(items: T[], size: number): T[][] {
   return chunks;
 }
 
+function rethrowPhraseReviewPullError(error: unknown): never {
+  if (error instanceof PhraseTmsApiError || error instanceof PhraseApiError) {
+    if (error.status === 401) {
+      throw new Error("phrase_auth_invalid");
+    }
+    if (error.status === 429) {
+      throw new Error("phrase_rate_limited");
+    }
+  }
+
+  throw error;
+}
+
 function resolvePhraseProjectSlugs(project: ExternalTmsProject) {
   const metadata = project.providerMetadata ?? {};
   const accountSlug = typeof metadata.accountSlug === "string" ? metadata.accountSlug.trim() : null;
@@ -135,15 +148,13 @@ export async function pullPhraseProviderReview(
               externalProjectId: input.externalProjectId,
               externalJobId: input.externalJobId,
               jobProviderUrl,
+              targetLocale,
             }),
           );
         }
       }
     } catch (error) {
-      if (error instanceof PhraseTmsApiError && error.status === 401) {
-        throw new Error("phrase_auth_invalid");
-      }
-      throw error;
+      rethrowPhraseReviewPullError(error);
     }
   }
 
@@ -201,10 +212,7 @@ export async function pullPhraseProviderReview(
         }
       }
     } catch (error) {
-      if (error instanceof PhraseApiError && error.status === 401) {
-        throw new Error("phrase_auth_invalid");
-      }
-      throw error;
+      rethrowPhraseReviewPullError(error);
     }
   }
 

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-tms-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-tms-api.ts
@@ -50,6 +50,45 @@ export interface PhraseTmsSearchSegmentResult {
   transMemoryName: string | null;
 }
 
+export interface PhraseTmsConversationUser {
+  uid: string | null;
+  userName: string | null;
+  firstName: string | null;
+  lastName: string | null;
+  email: string | null;
+}
+
+export interface PhraseTmsConversationComment {
+  id: string;
+  text: string;
+  createdAt: string | null;
+  updatedAt: string | null;
+  author: PhraseTmsConversationUser | null;
+}
+
+export interface PhraseTmsLqaConversationReference {
+  segmentId: string | null;
+  commentedText: string | null;
+  errorCategoryId: number | null;
+  severityId: number | null;
+  repeated: string | null;
+}
+
+export interface PhraseTmsConversation {
+  id: string;
+  type: "lqa" | "plain";
+  description: string | null;
+  deleted: boolean;
+  createdAt: string | null;
+  updatedAt: string | null;
+  resolvedAt: string | null;
+  state: "open" | "resolved" | "unknown";
+  author: PhraseTmsConversationUser | null;
+  resolver: PhraseTmsConversationUser | null;
+  comments: PhraseTmsConversationComment[];
+  lqaReference: PhraseTmsLqaConversationReference | null;
+}
+
 export class PhraseTmsApiError extends Error {
   constructor(
     message: string,
@@ -138,6 +177,22 @@ export class PhraseTmsApiClient {
     const path = `/api2/v1/projects/${encodeURIComponent(projectUid)}/termBases`;
     const response = await this.get<PhraseTmsTermBasesApiRecord>(path);
     return normalizePhraseTmsResourceList(response.termBases);
+  }
+
+  async listLqaConversations(jobUid: string): Promise<PhraseTmsConversation[]> {
+    const path = `/api2/v1/jobs/${encodeURIComponent(jobUid)}/conversations/lqas`;
+    const response = await this.get<PhraseTmsLqaConversationsApiRecord>(path);
+    return (response.conversations ?? []).map((conversation) =>
+      normalizePhraseTmsConversation(conversation, "lqa"),
+    );
+  }
+
+  async listPlainConversations(jobUid: string): Promise<PhraseTmsConversation[]> {
+    const path = `/api2/v1/jobs/${encodeURIComponent(jobUid)}/conversations/plains`;
+    const response = await this.get<PhraseTmsPlainConversationsApiRecord>(path);
+    return (response.conversations ?? []).map((conversation) =>
+      normalizePhraseTmsConversation(conversation, "plain"),
+    );
   }
 
   async searchJobTranslationMemorySegment(input: {
@@ -293,6 +348,56 @@ type PhraseTmsSearchSegmentApiRecord = {
   transMemory?: { uid?: string; name?: string };
 };
 
+type PhraseTmsLqaConversationsApiRecord = {
+  conversations?: PhraseTmsConversationApiRecord[];
+};
+
+type PhraseTmsPlainConversationsApiRecord = {
+  conversations?: PhraseTmsConversationApiRecord[];
+};
+
+type PhraseTmsConversationApiRecord = {
+  id?: string;
+  type?: string;
+  lqaDescription?: string;
+  deleted?: boolean;
+  dateCreated?: string | null;
+  dateModified?: string | null;
+  dateEdited?: string | null;
+  createdBy?: PhraseTmsUserApiRecord | null;
+  status?: {
+    name?: string;
+    date?: string | null;
+    by?: PhraseTmsUserApiRecord | null;
+  } | null;
+  comments?: PhraseTmsCommentApiRecord[];
+  references?: {
+    segmentId?: string;
+    commentedText?: string;
+    lqa?: Array<{
+      errorCategoryId?: number;
+      severityId?: number;
+      repeated?: string;
+    }>;
+  } | null;
+};
+
+type PhraseTmsUserApiRecord = {
+  uid?: string;
+  userName?: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
+  email?: string | null;
+};
+
+type PhraseTmsCommentApiRecord = {
+  id?: string;
+  text?: string;
+  dateCreated?: string | null;
+  dateModified?: string | null;
+  createdBy?: PhraseTmsUserApiRecord | null;
+};
+
 function normalizePhraseTmsSearchSegmentResults(
   results: PhraseTmsSearchSegmentApiRecord[] | undefined,
 ): PhraseTmsSearchSegmentResult[] {
@@ -356,6 +461,93 @@ function normalizePhraseTmsJobPart(job: PhraseTmsJobPartApiRecord): PhraseTmsJob
       ? {
           status: job.importStatus.status ?? null,
           errorMessage: job.importStatus.errorMessage ?? null,
+        }
+      : null,
+  };
+}
+
+function normalizePhraseTmsConversationUser(
+  user: PhraseTmsUserApiRecord | null | undefined,
+): PhraseTmsConversationUser | null {
+  if (!user) {
+    return null;
+  }
+
+  const externalUserId = user.uid?.trim() || user.userName?.trim() || null;
+  if (!externalUserId) {
+    return null;
+  }
+
+  return {
+    uid: user.uid?.trim() || null,
+    userName: user.userName?.trim() || null,
+    firstName: user.firstName?.trim() || null,
+    lastName: user.lastName?.trim() || null,
+    email: user.email?.trim() || null,
+  };
+}
+
+function mapPhraseTmsConversationState(
+  statusName: string | null | undefined,
+): PhraseTmsConversation["state"] {
+  if (statusName === "resolved") {
+    return "resolved";
+  }
+  if (statusName === "unresolved") {
+    return "open";
+  }
+  return "unknown";
+}
+
+function normalizePhraseTmsConversationComment(
+  comment: PhraseTmsCommentApiRecord,
+): PhraseTmsConversationComment | null {
+  const id = comment.id?.trim();
+  const text = comment.text?.trim();
+  if (!id || !text) {
+    return null;
+  }
+
+  return {
+    id,
+    text,
+    createdAt: comment.dateCreated ?? null,
+    updatedAt: comment.dateModified ?? null,
+    author: normalizePhraseTmsConversationUser(comment.createdBy),
+  };
+}
+
+function normalizePhraseTmsConversation(
+  conversation: PhraseTmsConversationApiRecord,
+  type: PhraseTmsConversation["type"],
+): PhraseTmsConversation {
+  const lqa = conversation.references?.lqa?.[0];
+  const statusName = conversation.status?.name ?? null;
+
+  return {
+    id: conversation.id?.trim() || "",
+    type,
+    description: conversation.lqaDescription?.trim() || null,
+    deleted: conversation.deleted ?? false,
+    createdAt: conversation.dateCreated ?? null,
+    updatedAt: conversation.dateModified ?? conversation.dateEdited ?? null,
+    resolvedAt: statusName === "resolved" ? (conversation.status?.date ?? null) : null,
+    state: mapPhraseTmsConversationState(statusName),
+    author: normalizePhraseTmsConversationUser(conversation.createdBy),
+    resolver:
+      statusName === "resolved"
+        ? normalizePhraseTmsConversationUser(conversation.status?.by)
+        : null,
+    comments: (conversation.comments ?? [])
+      .map((comment) => normalizePhraseTmsConversationComment(comment))
+      .filter((comment): comment is PhraseTmsConversationComment => comment != null),
+    lqaReference: lqa
+      ? {
+          segmentId: conversation.references?.segmentId?.trim() || null,
+          commentedText: conversation.references?.commentedText?.trim() || null,
+          errorCategoryId: lqa.errorCategoryId ?? null,
+          severityId: lqa.severityId ?? null,
+          repeated: lqa.repeated ?? null,
         }
       : null,
   };

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-tms-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-tms-api.ts
@@ -517,11 +517,30 @@ function normalizePhraseTmsConversationComment(
   };
 }
 
+function normalizePhraseTmsConversationReference(
+  references: PhraseTmsConversationApiRecord["references"],
+): PhraseTmsLqaConversationReference | null {
+  const lqa = references?.lqa?.[0];
+  const segmentId = references?.segmentId?.trim() || null;
+  const commentedText = references?.commentedText?.trim() || null;
+
+  if (!lqa && !segmentId && !commentedText) {
+    return null;
+  }
+
+  return {
+    segmentId,
+    commentedText,
+    errorCategoryId: lqa?.errorCategoryId ?? null,
+    severityId: lqa?.severityId ?? null,
+    repeated: lqa?.repeated ?? null,
+  };
+}
+
 function normalizePhraseTmsConversation(
   conversation: PhraseTmsConversationApiRecord,
   type: PhraseTmsConversation["type"],
 ): PhraseTmsConversation {
-  const lqa = conversation.references?.lqa?.[0];
   const statusName = conversation.status?.name ?? null;
 
   return {
@@ -541,15 +560,7 @@ function normalizePhraseTmsConversation(
     comments: (conversation.comments ?? [])
       .map((comment) => normalizePhraseTmsConversationComment(comment))
       .filter((comment): comment is PhraseTmsConversationComment => comment != null),
-    lqaReference: lqa
-      ? {
-          segmentId: conversation.references?.segmentId?.trim() || null,
-          commentedText: conversation.references?.commentedText?.trim() || null,
-          errorCategoryId: lqa.errorCategoryId ?? null,
-          severityId: lqa.severityId ?? null,
-          repeated: lqa.repeated ?? null,
-        }
-      : null,
+    lqaReference: normalizePhraseTmsConversationReference(conversation.references),
   };
 }
 

--- a/apps/hyperlocalise-web/src/lib/providers/provider-review-pullers.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-review-pullers.ts
@@ -1,8 +1,13 @@
 import { pullCrowdinProviderReview } from "@/lib/providers/crowdin/crowdin-review-puller";
 import type { ExternalTmsTaskContent } from "@/lib/providers/external-tms-content-sync";
 import type { ProviderReviewReport } from "@/lib/providers/provider-job-review/types";
+import { pullPhraseProviderReview } from "@/lib/providers/phrase/phrase-review-puller";
+
+import { schema } from "@/lib/database";
 
 import type { ExternalTmsProviderKind } from "./organization-external-tms-provider-credentials";
+
+type ExternalTmsProject = typeof schema.projects.$inferSelect;
 
 export type ExternalTmsReviewPuller = (input: {
   organizationId: string;
@@ -10,8 +15,9 @@ export type ExternalTmsReviewPuller = (input: {
   providerKind: ExternalTmsProviderKind;
   externalProjectId: string;
   externalJobId: string;
-  credential: { baseUrl?: string | null };
+  credential: { baseUrl?: string | null; region?: string | null };
   secretMaterial: string;
+  project: ExternalTmsProject;
   content: ExternalTmsTaskContent;
 }) => Promise<ProviderReviewReport>;
 
@@ -26,6 +32,16 @@ export function getProviderReviewPuller(
           secretMaterial: input.secretMaterial,
           externalProjectId: input.externalProjectId,
           externalJobId: input.externalJobId,
+          content: input.content,
+        });
+    case "phrase":
+      return async (input) =>
+        pullPhraseProviderReview({
+          credential: input.credential,
+          secretMaterial: input.secretMaterial,
+          externalProjectId: input.externalProjectId,
+          externalJobId: input.externalJobId,
+          project: input.project,
           content: input.content,
         });
     default:

--- a/apps/hyperlocalise-web/src/lib/providers/sync-provider-review.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/sync-provider-review.ts
@@ -78,6 +78,7 @@ export async function pullProviderReviewForJob(input: {
     externalJobId: input.externalJobId,
     credential,
     secretMaterial,
+    project,
     content: input.content,
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements HL-388 by bridging Phrase review data into Hyperlocalise's existing provider review workflow (same pattern as Crowdin).

## Changes

- **Phrase TMS**: fetch LQA and plain job conversations; normalize to `issue` / `comment` threads with resolution state, segment references, and TMS job URLs.
- **Phrase Strings**: fetch key comments (and replies) scoped to job content units; normalize with key/locale mapping and Strings app URLs.
- **Puller**: `pullPhraseProviderReview` orchestrates TMS + Strings APIs, deduplicates by `threadId`, and returns a `ProviderReviewReport`.
- **Wiring**: register the Phrase puller in `getProviderReviewPuller` and pass project metadata through `sync-provider-review`.

## Testing

- `phrase-review-normalize.test.ts` — LQA/plain/key comment mapping, deleted threads, missing author fields, provider URLs
- `phrase-review-puller.test.ts` — end-to-end mocked fetch with deduplicated threads
- `vp check --fix` and targeted `vp test` pass locally

## Linear

Closes HL-388
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-388](https://linear.app/hyperlocalise/issue/HL-388/implement-phrase-issues-and-comments-bridge)

<div><a href="https://cursor.com/agents/bc-7bce01ab-3036-444d-8c9f-dec74ecf729c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7bce01ab-3036-444d-8c9f-dec74ecf729c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

