### PR TITLE
feat(lokalise): bridge comments and task feedback for review workflows (HL-362)

### DIFF
--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-api.test.ts
@@ -344,6 +344,64 @@ describe("LokaliseApiClient", () => {
     await expect(client.listProjects()).rejects.toBeInstanceOf(LokaliseApiError);
     await expect(client.listProjects()).rejects.toMatchObject({ status: 401 });
   });
+
+  it("lists and creates key comments", async () => {
+    let createCalls = 0;
+    const fetchMock = vi.fn(async (url, init) => {
+      const path = String(url);
+      const method = init?.method ?? "GET";
+
+      if (path.includes("/keys/4242/comments") && method === "GET") {
+        return new Response(
+          JSON.stringify({
+            comments: [
+              {
+                comment_id: 10,
+                key_id: 4242,
+                comment: "Existing note",
+                added_by: 1,
+                added_by_email: "reviewer@example.com",
+                added_at: "2026-05-01T10:00:00Z",
+                added_at_timestamp: 1746093600,
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/keys/4242/comments") && method === "POST") {
+        createCalls += 1;
+        return new Response(
+          JSON.stringify({
+            comments: [
+              {
+                comment_id: 11,
+                key_id: 4242,
+                comment: "New note",
+                added_by: 2,
+                added_by_email: "agent@example.com",
+                added_at: "2026-05-02T10:00:00Z",
+                added_at_timestamp: 1746180000,
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify({ comments: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    const listed = await client.listKeyComments("proj.123", 4242);
+    const created = await client.createKeyComments("proj.123", 4242, [{ comment: "New note" }]);
+
+    expect(listed).toHaveLength(1);
+    expect(listed[0]).toMatchObject({ commentId: 10, comment: "Existing note" });
+    expect(createCalls).toBe(1);
+    expect(created[0]).toMatchObject({ commentId: 11, comment: "New note" });
+  });
 });
 
 describe("summarizeLokaliseBulkUpdateChunkResult", () => {

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-api.ts
@@ -1084,8 +1084,7 @@ export function buildLokaliseKeyCommentProviderUrl(input: {
   commentId: number;
 }) {
   const taskUrl = buildLokaliseTaskUrl(input.projectId, input.taskId);
-  const separator = taskUrl.includes("?") ? "&" : "?";
-  return `${taskUrl}${separator}key=${encodeURIComponent(String(input.keyId))}&comment=${encodeURIComponent(String(input.commentId))}`;
+  return `${taskUrl}&key=${encodeURIComponent(String(input.keyId))}&comment=${encodeURIComponent(String(input.commentId))}`;
 }
 
 export function collectLokaliseTaskAssignees(task: LokaliseTask) {

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-api.ts
@@ -127,6 +127,16 @@ export type LokaliseFileDownloadResult = {
   warning: string | null;
 };
 
+export interface LokaliseComment {
+  commentId: number;
+  keyId: number;
+  comment: string;
+  addedBy: number | null;
+  addedByEmail: string | null;
+  addedAt: string | null;
+  addedAtTimestamp: number | null;
+}
+
 export interface LokaliseKey {
   keyId: number;
   keyName: LokalisePlatformStrings;
@@ -466,6 +476,45 @@ export class LokaliseApiClient {
     return languages;
   }
 
+  async listKeyComments(projectId: string, keyId: number): Promise<LokaliseComment[]> {
+    const comments: LokaliseComment[] = [];
+    let page = 1;
+    const limit = 500;
+
+    while (true) {
+      const response = await this.get<LokaliseKeyCommentsListResponse>(
+        `/projects/${encodeURIComponent(projectId)}/keys/${encodeURIComponent(String(keyId))}/comments?page=${page}&limit=${limit}`,
+      );
+      const pageItems = (response.comments ?? []).map(normalizeLokaliseComment);
+      comments.push(...pageItems);
+
+      if (pageItems.length < limit) {
+        break;
+      }
+
+      page += 1;
+    }
+
+    return comments;
+  }
+
+  async createKeyComments(
+    projectId: string,
+    keyId: number,
+    comments: Array<{ comment: string }>,
+  ): Promise<LokaliseComment[]> {
+    if (comments.length === 0) {
+      return [];
+    }
+
+    const response = await this.post<LokaliseKeyCommentsCreateResponse>(
+      `/projects/${encodeURIComponent(projectId)}/keys/${encodeURIComponent(String(keyId))}/comments`,
+      { comments },
+    );
+
+    return (response.comments ?? []).map(normalizeLokaliseComment);
+  }
+
   private authHeaders(): Record<string, string> {
     return {
       "X-Api-Token": this.token,
@@ -646,6 +695,28 @@ type LokaliseTaskApiRecord = {
   completed_at_timestamp?: number | null;
 };
 
+type LokaliseCommentApiRecord = {
+  comment_id?: number;
+  key_id?: number;
+  comment?: string;
+  added_by?: number;
+  added_by_email?: string;
+  added_at?: string | null;
+  added_at_timestamp?: number | null;
+};
+
+type LokaliseKeyCommentsListResponse = {
+  project_id?: string;
+  key_id?: number;
+  comments?: LokaliseCommentApiRecord[];
+};
+
+type LokaliseKeyCommentsCreateResponse = {
+  project_id?: string;
+  key_id?: number;
+  comments?: LokaliseCommentApiRecord[];
+};
+
 type LokaliseLanguagesListResponse = {
   project_id?: string;
   languages?: LokaliseLanguageApiRecord[];
@@ -708,6 +779,18 @@ type LokaliseLanguageApiRecord = {
   lang_name: string;
   is_rtl?: boolean;
 };
+
+function normalizeLokaliseComment(record: LokaliseCommentApiRecord): LokaliseComment {
+  return {
+    commentId: record.comment_id ?? 0,
+    keyId: record.key_id ?? 0,
+    comment: record.comment?.trim() ?? "",
+    addedBy: record.added_by ?? null,
+    addedByEmail: record.added_by_email?.trim() || null,
+    addedAt: record.added_at ?? null,
+    addedAtTimestamp: record.added_at_timestamp ?? null,
+  };
+}
 
 function normalizeLokaliseDetailedTask(
   record: LokaliseDetailedTaskApiRecord,
@@ -992,6 +1075,17 @@ export function buildLokaliseProjectUrl(projectId: string) {
 
 export function buildLokaliseTaskUrl(projectId: string, taskId: number | string) {
   return `https://app.lokalise.com/project/${encodeURIComponent(projectId)}/?task=${encodeURIComponent(String(taskId))}`;
+}
+
+export function buildLokaliseKeyCommentProviderUrl(input: {
+  projectId: string;
+  taskId: number | string;
+  keyId: number;
+  commentId: number;
+}) {
+  const taskUrl = buildLokaliseTaskUrl(input.projectId, input.taskId);
+  const separator = taskUrl.includes("?") ? "&" : "?";
+  return `${taskUrl}${separator}key=${encodeURIComponent(String(input.keyId))}&comment=${encodeURIComponent(String(input.commentId))}`;
 }
 
 export function collectLokaliseTaskAssignees(task: LokaliseTask) {

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-comment-pusher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-comment-pusher.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { buildFindingId } from "@/lib/providers/provider-job-qa/build-finding-id";
+import type { ProviderQaFinding } from "@/lib/providers/provider-job-qa/types";
+
+import { buildHyperlocaliseFindingMarker } from "../smartling/smartling-comment-write-back";
+import { pushLokaliseProviderComments } from "./lokalise-comment-pusher";
+
+function sampleFinding(overrides?: Partial<ProviderQaFinding>): ProviderQaFinding {
+  return {
+    checkType: "glossary_violation",
+    severity: "error",
+    message: "Forbidden term",
+    item: {
+      externalStringId: "4242",
+      key: "welcome.title",
+      locale: "fr",
+      field: "target",
+    },
+    ...overrides,
+  };
+}
+
+describe("pushLokaliseProviderComments", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("creates Lokalise key comments for new findings", async () => {
+    const finding = sampleFinding();
+    const findingId = buildFindingId(finding);
+    let createCommentCalls = 0;
+
+    const fetchMock = vi.fn(async (url, init) => {
+      const path = String(url);
+      const method = init?.method ?? "GET";
+
+      if (path.includes("/keys/4242/comments") && method === "GET") {
+        return new Response(JSON.stringify({ comments: [] }), { status: 200 });
+      }
+
+      if (path.includes("/keys/4242/comments") && method === "POST") {
+        createCommentCalls += 1;
+        return new Response(
+          JSON.stringify({
+            comments: [
+              {
+                comment_id: 55,
+                key_id: 4242,
+                comment: buildHyperlocaliseFindingMarker(findingId),
+                added_by: 1,
+                added_by_email: "reviewer@example.com",
+                added_at: "2026-05-01T10:00:00Z",
+                added_at_timestamp: 1746093600,
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response("Not Found", { status: 404 });
+    });
+
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await pushLokaliseProviderComments({
+      organizationId: "org_1",
+      projectId: "proj_1",
+      providerKind: "lokalise",
+      externalProjectId: "proj.123",
+      externalJobId: "55392",
+      secretMaterial: "token",
+      feedback: [{ findingId, finding }],
+      knownExternalIds: new Map(),
+    });
+
+    expect(createCommentCalls).toBe(1);
+    expect(result.posted).toBe(1);
+    expect(result.skipped).toBe(0);
+    expect(result.changedItems[0]).toMatchObject({
+      status: "posted",
+      externalCommentUid: "55",
+      providerReviewContext: {
+        externalProjectId: "proj.123",
+        externalJobId: "55392",
+        externalThreadId: "55",
+        externalCommentId: "55",
+      },
+    });
+  });
+
+  it("skips findings when a matching remote comment already exists", async () => {
+    const finding = sampleFinding();
+    const findingId = buildFindingId(finding);
+    let createCommentCalls = 0;
+
+    const fetchMock = vi.fn(async (url, init) => {
+      const path = String(url);
+      const method = init?.method ?? "GET";
+
+      if (path.includes("/keys/4242/comments") && method === "GET") {
+        return new Response(
+          JSON.stringify({
+            comments: [
+              {
+                comment_id: 77,
+                key_id: 4242,
+                comment: `${buildHyperlocaliseFindingMarker(findingId)}\n[glossary_violation] Forbidden term`,
+                added_by: 1,
+                added_by_email: "reviewer@example.com",
+                added_at: "2026-05-01T10:00:00Z",
+                added_at_timestamp: 1746093600,
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/keys/4242/comments") && method === "POST") {
+        createCommentCalls += 1;
+        return new Response(JSON.stringify({ comments: [{ comment_id: 99 }] }), {
+          status: 200,
+        });
+      }
+
+      return new Response("Not Found", { status: 404 });
+    });
+
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await pushLokaliseProviderComments({
+      organizationId: "org_1",
+      projectId: "proj_1",
+      providerKind: "lokalise",
+      externalProjectId: "proj.123",
+      externalJobId: "55392",
+      secretMaterial: "token",
+      feedback: [{ findingId, finding }],
+      knownExternalIds: new Map(),
+    });
+
+    expect(createCommentCalls).toBe(0);
+    expect(result.posted).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.changedItems[0]?.status).toBe("skipped");
+    expect(result.changedItems[0]?.externalCommentUid).toBe("77");
+  });
+
+  it("skips findings when known external ids were stored from a prior run", async () => {
+    const finding = sampleFinding();
+    const findingId = buildFindingId(finding);
+    let createCommentCalls = 0;
+
+    const fetchMock = vi.fn(async (url, init) => {
+      const path = String(url);
+      const method = init?.method ?? "GET";
+
+      if (path.includes("/keys/4242/comments") && method === "GET") {
+        return new Response(JSON.stringify({ comments: [] }), { status: 200 });
+      }
+
+      if (path.includes("/keys/4242/comments") && method === "POST") {
+        createCommentCalls += 1;
+        return new Response(JSON.stringify({ comments: [{ comment_id: 99 }] }), {
+          status: 200,
+        });
+      }
+
+      return new Response("Not Found", { status: 404 });
+    });
+
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const knownExternalIds = new Map([[findingId, { issueUid: "88", commentUid: "88" }]]);
+
+    const result = await pushLokaliseProviderComments({
+      organizationId: "org_1",
+      projectId: "proj_1",
+      providerKind: "lokalise",
+      externalProjectId: "proj.123",
+      externalJobId: "55392",
+      secretMaterial: "token",
+      feedback: [{ findingId, finding }],
+      knownExternalIds,
+    });
+
+    expect(createCommentCalls).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.changedItems[0]?.externalCommentUid).toBe("88");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-comment-pusher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-comment-pusher.test.ts
@@ -154,6 +154,49 @@ describe("pushLokaliseProviderComments", () => {
     expect(result.changedItems[0]?.externalCommentUid).toBe("77");
   });
 
+  it("fails when the API returns a missing or zero comment id", async () => {
+    const finding = sampleFinding();
+    const findingId = buildFindingId(finding);
+
+    const fetchMock = vi.fn(async (url, init) => {
+      const path = String(url);
+      const method = init?.method ?? "GET";
+
+      if (path.includes("/keys/4242/comments") && method === "GET") {
+        return new Response(JSON.stringify({ comments: [] }), { status: 200 });
+      }
+
+      if (path.includes("/keys/4242/comments") && method === "POST") {
+        return new Response(JSON.stringify({ comments: [{ key_id: 4242, comment: "x" }] }), {
+          status: 200,
+        });
+      }
+
+      return new Response("Not Found", { status: 404 });
+    });
+
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await pushLokaliseProviderComments({
+      organizationId: "org_1",
+      projectId: "proj_1",
+      providerKind: "lokalise",
+      externalProjectId: "proj.123",
+      externalJobId: "55392",
+      secretMaterial: "token",
+      feedback: [{ findingId, finding }],
+      knownExternalIds: new Map(),
+    });
+
+    expect(result.posted).toBe(0);
+    expect(result.failed).toBe(1);
+    expect(result.changedItems[0]).toMatchObject({
+      status: "failed",
+      message: "lokalise_provider_comment_create_failed",
+    });
+    expect(result.changedItems[0]?.externalCommentUid).toBeUndefined();
+  });
+
   it("skips findings when known external ids were stored from a prior run", async () => {
     const finding = sampleFinding();
     const findingId = buildFindingId(finding);

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-comment-pusher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-comment-pusher.ts
@@ -100,10 +100,11 @@ export const pushLokaliseProviderComments: ExternalTmsCommentPusher = async ({
       const created = await client.createKeyComments(projectId, entry.request.keyId, [
         { comment: entry.request.comment },
       ]);
-      const commentId = String(created[0]?.commentId ?? "");
-      if (!commentId) {
+      const rawCommentId = created[0]?.commentId;
+      if (rawCommentId == null || rawCommentId <= 0) {
         throw new Error("lokalise_provider_comment_create_failed");
       }
+      const commentId = String(rawCommentId);
 
       posted += 1;
       changedItems.push({

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-comment-pusher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-comment-pusher.ts
@@ -1,0 +1,154 @@
+import type { ExternalTmsCommentPusher } from "@/lib/providers/provider-feedback-types";
+import { buildFindingId } from "@/lib/providers/provider-job-qa/build-finding-id";
+import { parseHyperlocaliseFindingMarker } from "@/lib/providers/smartling/smartling-comment-write-back";
+
+import {
+  buildLokaliseKeyCommentProviderUrl,
+  LOKALISE_DEFAULT_BASE_URL,
+  LokaliseApiClient,
+  LokaliseApiError,
+} from "./lokalise-api";
+import { buildLokaliseCommentWriteBackEntries } from "./lokalise-comment-write-back";
+
+export const pushLokaliseProviderComments: ExternalTmsCommentPusher = async ({
+  externalProjectId,
+  externalJobId,
+  secretMaterial,
+  feedback,
+  knownExternalIds,
+}) => {
+  const projectId = externalProjectId.trim();
+  if (!projectId) {
+    throw new Error("invalid_lokalise_project_id");
+  }
+
+  const client = new LokaliseApiClient({
+    token: secretMaterial,
+    baseUrl: LOKALISE_DEFAULT_BASE_URL,
+  });
+
+  const locales = new Set(feedback.map((item) => item.finding.item.locale?.trim()).filter(Boolean));
+  const defaultLocaleId = locales.size === 1 ? ([...locales][0] ?? null) : null;
+
+  const { entries, failures: validationFailures } = buildLokaliseCommentWriteBackEntries({
+    findings: feedback.map((item) => item.finding),
+    defaultLocaleId,
+  });
+
+  const entryByFindingId = new Map(entries.map((entry) => [entry.findingId, entry]));
+  const changedItems: Awaited<ReturnType<ExternalTmsCommentPusher>>["changedItems"] = [];
+  const failures = [...validationFailures];
+  let posted = 0;
+  let skipped = 0;
+  let failed = validationFailures.length;
+
+  const keyIds = [...new Set(entries.map((entry) => entry.request.keyId))];
+  const remoteCommentIdsByFindingId = new Map<string, string>();
+
+  if (keyIds.length > 0) {
+    try {
+      for (const keyId of keyIds) {
+        const remoteComments = await client.listKeyComments(projectId, keyId);
+        for (const remoteComment of remoteComments) {
+          const findingId = parseHyperlocaliseFindingMarker(remoteComment.comment);
+          if (findingId) {
+            remoteCommentIdsByFindingId.set(findingId, String(remoteComment.commentId));
+          }
+        }
+      }
+    } catch (error) {
+      if (error instanceof LokaliseApiError && error.status === 401) {
+        throw new Error("lokalise_auth_invalid");
+      }
+      throw error;
+    }
+  }
+
+  for (const item of feedback) {
+    const findingId = item.findingId || buildFindingId(item.finding);
+    const entry = entryByFindingId.get(findingId);
+    if (!entry) {
+      continue;
+    }
+
+    const known = knownExternalIds.get(findingId) ?? null;
+    const remoteCommentId = remoteCommentIdsByFindingId.get(findingId) ?? null;
+    const existingCommentId = known?.commentUid ?? known?.issueUid ?? remoteCommentId;
+
+    if (existingCommentId) {
+      skipped += 1;
+      changedItems.push({
+        type: "provider_comment",
+        findingId,
+        status: "skipped",
+        externalIssueUid: existingCommentId,
+        externalCommentUid: existingCommentId,
+        hashcode: String(entry.request.keyId),
+        locale: entry.request.locale ?? undefined,
+        message: "provider_comment_already_exists",
+        providerReviewContext: item.providerReviewContext ?? {
+          externalProjectId: projectId,
+          externalJobId,
+          externalThreadId: existingCommentId,
+          externalCommentId: existingCommentId,
+        },
+      });
+      continue;
+    }
+
+    try {
+      const created = await client.createKeyComments(projectId, entry.request.keyId, [
+        { comment: entry.request.comment },
+      ]);
+      const commentId = String(created[0]?.commentId ?? "");
+      if (!commentId) {
+        throw new Error("lokalise_provider_comment_create_failed");
+      }
+
+      posted += 1;
+      changedItems.push({
+        type: "provider_comment",
+        findingId,
+        status: "posted",
+        externalIssueUid: commentId,
+        externalCommentUid: commentId,
+        hashcode: String(entry.request.keyId),
+        locale: entry.request.locale ?? undefined,
+        providerReviewContext: item.providerReviewContext ?? {
+          externalProjectId: projectId,
+          externalJobId,
+          externalThreadId: commentId,
+          externalCommentId: commentId,
+          providerUrl: buildLokaliseKeyCommentProviderUrl({
+            projectId,
+            taskId: externalJobId,
+            keyId: entry.request.keyId,
+            commentId: Number(commentId),
+          }),
+        },
+      });
+    } catch (error) {
+      failed += 1;
+      const message =
+        error instanceof Error ? error.message : "lokalise_provider_comment_create_failed";
+      failures.push({ findingId, message });
+      changedItems.push({
+        type: "provider_comment",
+        findingId,
+        status: "failed",
+        hashcode: String(entry.request.keyId),
+        locale: entry.request.locale ?? undefined,
+        message,
+        providerReviewContext: item.providerReviewContext,
+      });
+    }
+  }
+
+  return {
+    posted,
+    skipped,
+    failed,
+    changedItems,
+    failures,
+  };
+};

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-comment-write-back.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-comment-write-back.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { buildFindingId } from "@/lib/providers/provider-job-qa/build-finding-id";
+import type { ProviderQaFinding } from "@/lib/providers/provider-job-qa/types";
+import { buildHyperlocaliseFindingMarker } from "@/lib/providers/smartling/smartling-comment-write-back";
+
+import { buildLokaliseCommentWriteBackEntries } from "./lokalise-comment-write-back";
+
+function sampleFinding(overrides?: Partial<ProviderQaFinding>): ProviderQaFinding {
+  return {
+    checkType: "glossary_violation",
+    severity: "error",
+    message: "Forbidden term",
+    item: {
+      externalStringId: "4242",
+      key: "welcome.title",
+      locale: "fr",
+      field: "target",
+    },
+    ...overrides,
+  };
+}
+
+describe("buildLokaliseCommentWriteBackEntries", () => {
+  it("builds comment payloads with finding markers", () => {
+    const finding = sampleFinding();
+    const findingId = buildFindingId(finding);
+
+    const result = buildLokaliseCommentWriteBackEntries({
+      findings: [finding],
+      defaultLocaleId: null,
+    });
+
+    expect(result.failures).toEqual([]);
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0]).toMatchObject({
+      findingId,
+      request: {
+        keyId: 4242,
+        locale: "fr",
+        comment: expect.stringContaining(buildHyperlocaliseFindingMarker(findingId)),
+      },
+    });
+  });
+
+  it("records validation failures for missing key ids", () => {
+    const finding = sampleFinding({
+      item: {
+        externalStringId: "",
+        key: "welcome.title",
+        locale: "fr",
+        field: "target",
+      },
+    });
+
+    const result = buildLokaliseCommentWriteBackEntries({
+      findings: [finding],
+      defaultLocaleId: "fr",
+    });
+
+    expect(result.entries).toEqual([]);
+    expect(result.failures[0]?.message).toBe("lokalise_comment_missing_key_id");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-comment-write-back.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-comment-write-back.ts
@@ -1,0 +1,69 @@
+import { buildFindingId } from "@/lib/providers/provider-job-qa/build-finding-id";
+import type { ProviderQaFinding } from "@/lib/providers/provider-job-qa/types";
+import { buildHyperlocaliseFindingMarker } from "@/lib/providers/smartling/smartling-comment-write-back";
+
+import { parseLokaliseKeyId } from "./lokalise-write-back";
+
+export type LokaliseCommentWriteBackEntry = {
+  findingId: string;
+  finding: ProviderQaFinding;
+  request: {
+    keyId: number;
+    locale: string | null;
+    comment: string;
+  };
+};
+
+function formatCommentText(finding: ProviderQaFinding, findingId: string) {
+  const lines = [
+    buildHyperlocaliseFindingMarker(findingId),
+    `[${finding.checkType}] ${finding.message}`,
+  ];
+
+  if (finding.suggestedFix) {
+    lines.push(`Suggested fix: ${finding.suggestedFix}`);
+  }
+
+  if (typeof finding.confidence === "number") {
+    lines.push(`Confidence: ${finding.confidence}`);
+  }
+
+  return lines.join("\n");
+}
+
+export function buildLokaliseCommentWriteBackEntries(input: {
+  findings: ProviderQaFinding[];
+  defaultLocaleId: string | null;
+}): {
+  entries: LokaliseCommentWriteBackEntry[];
+  failures: Array<{ findingId: string; message: string }>;
+} {
+  const entries: LokaliseCommentWriteBackEntry[] = [];
+  const failures: Array<{ findingId: string; message: string }> = [];
+
+  for (const finding of input.findings) {
+    const findingId = buildFindingId(finding);
+    const keyId = parseLokaliseKeyId(finding.item.externalStringId);
+    const locale = finding.item.locale?.trim() || input.defaultLocaleId?.trim() || null;
+
+    if (keyId == null) {
+      failures.push({
+        findingId,
+        message: "lokalise_comment_missing_key_id",
+      });
+      continue;
+    }
+
+    entries.push({
+      findingId,
+      finding,
+      request: {
+        keyId,
+        locale,
+        comment: formatCommentText(finding, findingId),
+      },
+    });
+  }
+
+  return { entries, failures };
+}

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-review-normalize.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-review-normalize.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { normalizeLokaliseKeyCommentToThread } from "./lokalise-review-normalize";
+
+describe("normalizeLokaliseKeyCommentToThread", () => {
+  it("maps key comments into provider review threads", () => {
+    const thread = normalizeLokaliseKeyCommentToThread({
+      comment: {
+        commentId: 42,
+        keyId: 4242,
+        comment: "Please review this translation",
+        addedBy: 7,
+        addedByEmail: "reviewer@example.com",
+        addedAt: "2026-05-01T10:00:00Z",
+        addedAtTimestamp: 1746093600,
+      },
+      externalProjectId: "proj.123",
+      externalJobId: "55392",
+      stringKeyById: new Map([["4242", "welcome.title"]]),
+    });
+
+    expect(thread.kind).toBe("comment");
+    expect(thread.item).toMatchObject({
+      externalStringId: "4242",
+      key: "welcome.title",
+    });
+    expect(thread.providerContext).toMatchObject({
+      externalProjectId: "proj.123",
+      externalJobId: "55392",
+      externalCommentId: "42",
+      externalThreadId: "42",
+    });
+    expect(thread.comments[0]?.body).toBe("Please review this translation");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-review-normalize.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-review-normalize.ts
@@ -1,0 +1,72 @@
+import { buildProviderReviewThreadId } from "@/lib/providers/provider-job-review/build-thread-id";
+import type {
+  ProviderReviewAuthor,
+  ProviderReviewThread,
+} from "@/lib/providers/provider-job-review/types";
+
+import { buildLokaliseKeyCommentProviderUrl, type LokaliseComment } from "./lokalise-api";
+
+function mapLokaliseCommentAuthor(comment: LokaliseComment): ProviderReviewAuthor | null {
+  if (comment.addedBy == null && !comment.addedByEmail) {
+    return null;
+  }
+
+  return {
+    externalUserId: comment.addedBy != null ? String(comment.addedBy) : null,
+    displayName: comment.addedByEmail,
+    username: comment.addedByEmail,
+  };
+}
+
+export function normalizeLokaliseKeyCommentToThread(input: {
+  comment: LokaliseComment;
+  externalProjectId: string;
+  externalJobId: string;
+  stringKeyById: Map<string, string>;
+}): ProviderReviewThread {
+  const externalThreadId = String(input.comment.commentId);
+  const stringKey =
+    input.stringKeyById.get(String(input.comment.keyId)) ?? String(input.comment.keyId);
+
+  return {
+    threadId: buildProviderReviewThreadId({
+      providerKind: "lokalise",
+      externalProjectId: input.externalProjectId,
+      externalJobId: input.externalJobId,
+      kind: "comment",
+      externalThreadId,
+    }),
+    kind: "comment",
+    state: "unknown",
+    subject: input.comment.comment,
+    item: {
+      externalStringId: String(input.comment.keyId),
+      key: stringKey,
+      field: "target",
+    },
+    comments: [
+      {
+        externalCommentId: externalThreadId,
+        body: input.comment.comment,
+        author: mapLokaliseCommentAuthor(input.comment),
+        createdAt: input.comment.addedAt,
+        updatedAt: input.comment.addedAt,
+      },
+    ],
+    author: mapLokaliseCommentAuthor(input.comment),
+    createdAt: input.comment.addedAt,
+    updatedAt: input.comment.addedAt,
+    providerContext: {
+      externalProjectId: input.externalProjectId,
+      externalJobId: input.externalJobId,
+      externalThreadId,
+      externalCommentId: externalThreadId,
+      providerUrl: buildLokaliseKeyCommentProviderUrl({
+        projectId: input.externalProjectId,
+        taskId: input.externalJobId,
+        keyId: input.comment.keyId,
+        commentId: input.comment.commentId,
+      }),
+    },
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-review-puller.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-review-puller.test.ts
@@ -83,4 +83,62 @@ describe("pullLokaliseProviderReview", () => {
       },
     });
   });
+
+  it("throws lokalise_auth_invalid when listKeyComments returns 401", async () => {
+    const fetchFn = vi.fn(async (url: string) => {
+      if (url.includes("/tasks/55392") && !url.includes("/comments")) {
+        return new Response(
+          JSON.stringify({
+            task: {
+              task_id: 55392,
+              title: "Review",
+              status: "in_progress",
+              languages: [
+                {
+                  language_iso: "fr",
+                  language_id: 673,
+                  language_name: "French",
+                  status: "created",
+                  progress: 0,
+                  users: [],
+                  keys: [4242],
+                },
+              ],
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (url.includes("/keys/4242/comments")) {
+        return new Response(JSON.stringify({ error: { message: "Invalid token" } }), {
+          status: 401,
+        });
+      }
+
+      return new Response("Not Found", { status: 404 });
+    });
+
+    await expect(
+      pullLokaliseProviderReview({
+        credential: { baseUrl: "https://api.lokalise.test/api2" },
+        secretMaterial: "token",
+        externalProjectId: "proj.123",
+        externalJobId: "55392",
+        content: {
+          externalJobId: "55392",
+          targetLocales: ["fr"],
+          units: [
+            {
+              externalStringId: "4242",
+              key: "welcome.title",
+              sourceText: "Hello",
+              translations: [{ locale: "fr", text: "Bonjour" }],
+            },
+          ],
+        },
+        fetchFn: fetchFn as typeof fetch,
+      }),
+    ).rejects.toThrow("lokalise_auth_invalid");
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-review-puller.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-review-puller.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { pullLokaliseProviderReview } from "./lokalise-review-puller";
+
+describe("pullLokaliseProviderReview", () => {
+  it("pulls task-scoped key comments into a review report", async () => {
+    const fetchFn = vi.fn(async (url: string) => {
+      if (url.includes("/tasks/55392") && !url.includes("/comments")) {
+        return new Response(
+          JSON.stringify({
+            task: {
+              task_id: 55392,
+              title: "Review",
+              status: "in_progress",
+              languages: [
+                {
+                  language_iso: "fr",
+                  language_id: 673,
+                  language_name: "French",
+                  status: "created",
+                  progress: 0,
+                  users: [],
+                  keys: [4242],
+                },
+              ],
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (url.includes("/keys/4242/comments")) {
+        return new Response(
+          JSON.stringify({
+            comments: [
+              {
+                comment_id: 42,
+                key_id: 4242,
+                comment: "Needs review",
+                added_by: 7,
+                added_by_email: "reviewer@example.com",
+                added_at: "2026-05-01T10:00:00Z",
+                added_at_timestamp: 1746093600,
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response("Not Found", { status: 404 });
+    });
+
+    const report = await pullLokaliseProviderReview({
+      credential: { baseUrl: "https://api.lokalise.test/api2" },
+      secretMaterial: "token",
+      externalProjectId: "proj.123",
+      externalJobId: "55392",
+      content: {
+        externalJobId: "55392",
+        targetLocales: ["fr"],
+        units: [
+          {
+            externalStringId: "4242",
+            key: "welcome.title",
+            sourceText: "Hello",
+            translations: [{ locale: "fr", text: "Bonjour" }],
+          },
+        ],
+      },
+      fetchFn: fetchFn as typeof fetch,
+    });
+
+    expect(report.threads).toHaveLength(1);
+    expect(report.threads[0]).toMatchObject({
+      kind: "comment",
+      item: {
+        externalStringId: "4242",
+        key: "welcome.title",
+      },
+      providerContext: {
+        externalCommentId: "42",
+      },
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-review-puller.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-review-puller.ts
@@ -11,6 +11,13 @@ import {
 } from "./lokalise-api";
 import { normalizeLokaliseKeyCommentToThread } from "./lokalise-review-normalize";
 
+function rethrowLokaliseAuthError(error: unknown): never {
+  if (error instanceof LokaliseApiError && error.status === 401) {
+    throw new Error("lokalise_auth_invalid");
+  }
+  throw error;
+}
+
 function chunkArray<T>(items: T[], size: number): T[][] {
   const chunks: T[][] = [];
   for (let index = 0; index < items.length; index += size) {
@@ -47,10 +54,7 @@ export async function pullLokaliseProviderReview(
   try {
     task = await client.getTask(projectId, parsedJobId.taskId);
   } catch (error) {
-    if (error instanceof LokaliseApiError && error.status === 401) {
-      throw new Error("lokalise_auth_invalid");
-    }
-    throw error;
+    rethrowLokaliseAuthError(error);
   }
 
   const stringKeyById = new Map(
@@ -76,13 +80,17 @@ export async function pullLokaliseProviderReview(
     return buildProviderReviewReport([]);
   }
 
-  for (const chunk of chunkArray(keyIdList, 25)) {
-    const chunkResults = await Promise.all(
-      chunk.map((keyId) => client.listKeyComments(projectId, keyId)),
-    );
-    for (const keyComments of chunkResults) {
-      comments.push(...keyComments);
+  try {
+    for (const chunk of chunkArray(keyIdList, 25)) {
+      const chunkResults = await Promise.all(
+        chunk.map((keyId) => client.listKeyComments(projectId, keyId)),
+      );
+      for (const keyComments of chunkResults) {
+        comments.push(...keyComments);
+      }
     }
+  } catch (error) {
+    rethrowLokaliseAuthError(error);
   }
 
   const threads = comments.map((comment) =>

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-review-puller.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-review-puller.ts
@@ -1,0 +1,100 @@
+import type { ExternalTmsTaskContent } from "@/lib/providers/external-tms-content-sync";
+import { buildProviderReviewReport } from "@/lib/providers/provider-job-review/normalize-provider-review";
+import type { ProviderReviewReport } from "@/lib/providers/provider-job-review/types";
+
+import {
+  collectLokaliseTaskKeyIds,
+  LOKALISE_DEFAULT_BASE_URL,
+  LokaliseApiClient,
+  LokaliseApiError,
+  parseLokaliseExternalJobId,
+} from "./lokalise-api";
+import { normalizeLokaliseKeyCommentToThread } from "./lokalise-review-normalize";
+
+function chunkArray<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
+}
+
+export type LokaliseReviewPullInput = {
+  credential: { baseUrl?: string | null };
+  secretMaterial: string;
+  externalProjectId: string;
+  externalJobId: string;
+  content: ExternalTmsTaskContent;
+  fetchFn?: typeof fetch;
+};
+
+export async function pullLokaliseProviderReview(
+  input: LokaliseReviewPullInput,
+): Promise<ProviderReviewReport> {
+  const projectId = input.externalProjectId.trim();
+  const parsedJobId = parseLokaliseExternalJobId(input.externalJobId);
+  if (!projectId || !parsedJobId) {
+    throw new Error("invalid_lokalise_project_or_task_id");
+  }
+
+  const client = new LokaliseApiClient({
+    token: input.secretMaterial,
+    baseUrl: input.credential.baseUrl ?? LOKALISE_DEFAULT_BASE_URL,
+    fetchFn: input.fetchFn,
+  });
+
+  let task: Awaited<ReturnType<typeof client.getTask>>;
+  try {
+    task = await client.getTask(projectId, parsedJobId.taskId);
+  } catch (error) {
+    if (error instanceof LokaliseApiError && error.status === 401) {
+      throw new Error("lokalise_auth_invalid");
+    }
+    throw error;
+  }
+
+  const stringKeyById = new Map(
+    input.content.units.map((unit) => [unit.externalStringId, unit.key] as const),
+  );
+
+  const keyIds = new Set<number>();
+  for (const unit of input.content.units) {
+    const keyId = Number(unit.externalStringId);
+    if (!Number.isNaN(keyId) && keyId > 0) {
+      keyIds.add(keyId);
+    }
+  }
+
+  for (const keyId of collectLokaliseTaskKeyIds(task)) {
+    keyIds.add(keyId);
+  }
+
+  const keyIdList = [...keyIds];
+  const comments: Awaited<ReturnType<typeof client.listKeyComments>> = [];
+
+  if (keyIdList.length === 0) {
+    return buildProviderReviewReport([]);
+  }
+
+  for (const chunk of chunkArray(keyIdList, 25)) {
+    const chunkResults = await Promise.all(
+      chunk.map((keyId) => client.listKeyComments(projectId, keyId)),
+    );
+    for (const keyComments of chunkResults) {
+      comments.push(...keyComments);
+    }
+  }
+
+  const threads = comments.map((comment) =>
+    normalizeLokaliseKeyCommentToThread({
+      comment,
+      externalProjectId: input.externalProjectId,
+      externalJobId: input.externalJobId,
+      stringKeyById,
+    }),
+  );
+
+  const deduped = new Map(threads.map((thread) => [thread.threadId, thread] as const));
+
+  return buildProviderReviewReport([...deduped.values()]);
+}

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-write-back.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-write-back.ts
@@ -99,7 +99,7 @@ export function buildLokaliseTranslationWriteBackBatches(input: {
   return { batches, failures };
 }
 
-function parseLokaliseKeyId(externalStringId: string | null | undefined) {
+export function parseLokaliseKeyId(externalStringId: string | null | undefined) {
   const trimmed = externalStringId?.trim() ?? "";
   if (!trimmed) {
     return null;

--- a/apps/hyperlocalise-web/src/lib/providers/provider-comment-pushers.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-comment-pushers.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { getTmsProviderActionCapability, providerSupportsTmsAction } from "./tms-capabilities";
+
+import { getProviderCommentPusher } from "./provider-comment-pushers";
+
+describe("getProviderCommentPusher", () => {
+  it.each([
+    ["smartling", true],
+    ["crowdin", true],
+    ["lokalise", true],
+    ["phrase", false],
+  ] as const)("returns whether %s has a comment pusher implementation", (provider, supported) => {
+    const pusher = getProviderCommentPusher(provider);
+    if (supported) {
+      expect(pusher).toBeTypeOf("function");
+    } else {
+      expect(pusher).toBeNull();
+    }
+  });
+});
+
+describe("unsupported comment capability behavior", () => {
+  it("advertises comment write support for Lokalise while Phrase remains read-only at runtime", () => {
+    expect(providerSupportsTmsAction("lokalise", "comments.write")).toBe(true);
+    expect(getProviderCommentPusher("lokalise")).not.toBeNull();
+
+    expect(providerSupportsTmsAction("phrase", "comments.write")).toBe(true);
+    expect(getProviderCommentPusher("phrase")).toBeNull();
+    expect(getTmsProviderActionCapability("phrase", "comments.write")).toMatchObject({
+      supported: true,
+      ui: { state: "enabled" },
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/provider-comment-pushers.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-comment-pushers.ts
@@ -1,5 +1,6 @@
 import type { ExternalTmsCommentPusher } from "@/lib/providers/provider-feedback-types";
 import { pushCrowdinProviderComments } from "@/lib/providers/crowdin/crowdin-comment-pusher";
+import { pushLokaliseProviderComments } from "@/lib/providers/lokalise/lokalise-comment-pusher";
 import { pushSmartlingProviderComments } from "@/lib/providers/smartling/smartling-comment-pusher";
 
 import type { ExternalTmsProviderKind } from "./organization-external-tms-provider-credentials";
@@ -12,6 +13,8 @@ export function getProviderCommentPusher(
       return pushSmartlingProviderComments;
     case "crowdin":
       return pushCrowdinProviderComments;
+    case "lokalise":
+      return pushLokaliseProviderComments;
     default:
       return null;
   }

--- a/apps/hyperlocalise-web/src/lib/providers/provider-review-pullers.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-review-pullers.ts
@@ -1,5 +1,6 @@
 import { pullCrowdinProviderReview } from "@/lib/providers/crowdin/crowdin-review-puller";
 import type { ExternalTmsTaskContent } from "@/lib/providers/external-tms-content-sync";
+import { pullLokaliseProviderReview } from "@/lib/providers/lokalise/lokalise-review-puller";
 import type { ProviderReviewReport } from "@/lib/providers/provider-job-review/types";
 import { pullPhraseProviderReview } from "@/lib/providers/phrase/phrase-review-puller";
 
@@ -42,6 +43,15 @@ export function getProviderReviewPuller(
           externalProjectId: input.externalProjectId,
           externalJobId: input.externalJobId,
           project: input.project,
+          content: input.content,
+        });
+    case "lokalise":
+      return async (input) =>
+        pullLokaliseProviderReview({
+          credential: input.credential,
+          secretMaterial: input.secretMaterial,
+          externalProjectId: input.externalProjectId,
+          externalJobId: input.externalJobId,
           content: input.content,
         });
     default:

--- a/apps/hyperlocalise-web/src/lib/providers/tms-capabilities.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-capabilities.test.ts
@@ -100,6 +100,8 @@ describe("tmsProviderCapabilityRegistry", () => {
     ["lokalise", "glossary.export", true],
     ["lokalise", "translation_memory.export", true],
     ["lokalise", "translation_memory.import", true],
+    ["lokalise", "comments.read", true],
+    ["lokalise", "comments.write", true],
   ] as const)("answers whether %s supports %s", (provider, action, supported) => {
     expect(providerSupportsTmsAction(provider, action)).toBe(supported);
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Implements the Lokalise comments and task feedback bridge for Hyperlocalise review workflows (HL-362), following the same patterns as Crowdin and Smartling.

- **Read path:** `pullLokaliseProviderReview` loads task keys from the Lokalise task API, lists key comments per key, and normalizes them into `ProviderReviewThread` entries.
- **Write path:** `pushLokaliseProviderComments` creates key comments from agent review findings via `buildLokaliseCommentWriteEntries`, with idempotency via stored external comment IDs and Hyperlocalise finding markers in comment text.
- **API:** `LokaliseApiClient` gains `listKeyComments` and `createKeyComments`.
- **Registry:** Lokalise is wired into `provider-comment-pushers` and `provider-review-pullers`.

## How to test

From `apps/hyperlocalise-web`:

```bash
pnpm exec vp install
pnpm exec vp check --fix
pnpm exec vp test src/lib/providers/lokalise/lokalise-comment src/lib/providers/lokalise/lokalise-review src/lib/providers/provider-comment-pushers.test.ts
```

Key behaviors covered by tests:

- Review findings are written as Lokalise key comments with provider URLs.
- Re-running write-back skips comments when `knownExternalIds` or remote markers already exist.
- Phrase advertises `comments.write` but has no pusher (unsupported capability behavior documented in `provider-comment-pushers.test.ts`).

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, `vp test` on affected files)
- [x] This PR is scoped and ready for review

Resolves HL-362
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-362](https://linear.app/hyperlocalise/issue/HL-362/implement-lokalise-comments-and-task-feedback-bridge)

<div><a href="https://cursor.com/agents/bc-50976f81-de3f-45b9-8e94-10b0fa4959de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50976f81-de3f-45b9-8e94-10b0fa4959de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

