### PR TITLE
feat(web): centralize RBAC into capability policy layer (HL-392)

### DIFF
--- a/apps/hyperlocalise-web/src/api/auth/policy.test.ts
+++ b/apps/hyperlocalise-web/src/api/auth/policy.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  getCapabilitiesForRole,
+  hasCapability,
+  ORGANIZATION_CAPABILITIES,
+  type OrganizationCapability,
+} from "./policy";
+
+const ADMIN_ONLY_CAPABILITIES: OrganizationCapability[] = [
+  "workspace:update",
+  "members:invite",
+  "teams:write",
+  "projects:create",
+  "projects:write",
+  "glossaries:write",
+  "memories:write",
+  "provider_credentials:write",
+  "api_keys:write",
+  "integrations:write",
+  "agent_write:approve",
+];
+
+describe("organization capability policy", () => {
+  it("defines every expected capability", () => {
+    expect([...ORGANIZATION_CAPABILITIES].sort()).toEqual([...ADMIN_ONLY_CAPABILITIES].sort());
+  });
+
+  describe.each(["owner", "admin"] as const)("%s role", (role) => {
+    it("grants every defined capability", () => {
+      for (const capability of ORGANIZATION_CAPABILITIES) {
+        expect(hasCapability(role, capability)).toBe(true);
+      }
+
+      expect(getCapabilitiesForRole(role).sort()).toEqual([...ORGANIZATION_CAPABILITIES].sort());
+    });
+  });
+
+  describe("member role", () => {
+    it("denies every defined capability", () => {
+      for (const capability of ORGANIZATION_CAPABILITIES) {
+        expect(hasCapability("member", capability)).toBe(false);
+      }
+
+      expect(getCapabilitiesForRole("member")).toEqual([]);
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/api/auth/policy.test.ts
+++ b/apps/hyperlocalise-web/src/api/auth/policy.test.ts
@@ -7,6 +7,7 @@ import {
   ORGANIZATION_CAPABILITIES,
   type OrganizationCapability,
 } from "./policy";
+import type { OrganizationMembershipRole } from "@/lib/database/types";
 
 const MEMBER_READ_CAPABILITIES: OrganizationCapability[] = [
   "workspace:read",
@@ -71,6 +72,20 @@ describe("organization capability policy", () => {
     it("returns false for unrecognized role strings", () => {
       expect(isAdminRole("guest")).toBe(false);
       expect(isAdminRole("")).toBe(false);
+    });
+  });
+
+  describe("unrecognized roles", () => {
+    const unknownRole = "guest" as OrganizationMembershipRole;
+
+    it("returns no capabilities", () => {
+      expect(getCapabilitiesForRole(unknownRole)).toEqual([]);
+    });
+
+    it("denies every capability", () => {
+      for (const capability of ORGANIZATION_CAPABILITIES) {
+        expect(hasCapability(unknownRole, capability)).toBe(false);
+      }
     });
   });
 });

--- a/apps/hyperlocalise-web/src/api/auth/policy.test.ts
+++ b/apps/hyperlocalise-web/src/api/auth/policy.test.ts
@@ -7,7 +7,19 @@ import {
   type OrganizationCapability,
 } from "./policy";
 
+const MEMBER_READ_CAPABILITIES: OrganizationCapability[] = [
+  "workspace:read",
+  "projects:read",
+  "teams:read",
+  "glossaries:read",
+  "memories:read",
+];
+
 const ADMIN_ONLY_CAPABILITIES: OrganizationCapability[] = [
+  "billing:read",
+  "api_keys:read",
+  "provider_credentials:read",
+  "integrations:read",
   "workspace:update",
   "members:invite",
   "teams:write",
@@ -23,7 +35,9 @@ const ADMIN_ONLY_CAPABILITIES: OrganizationCapability[] = [
 
 describe("organization capability policy", () => {
   it("defines every expected capability", () => {
-    expect([...ORGANIZATION_CAPABILITIES].sort()).toEqual([...ADMIN_ONLY_CAPABILITIES].sort());
+    expect([...ORGANIZATION_CAPABILITIES].sort()).toEqual(
+      [...MEMBER_READ_CAPABILITIES, ...ADMIN_ONLY_CAPABILITIES].sort(),
+    );
   });
 
   describe.each(["owner", "admin"] as const)("%s role", (role) => {
@@ -37,12 +51,18 @@ describe("organization capability policy", () => {
   });
 
   describe("member role", () => {
-    it("denies every defined capability", () => {
-      for (const capability of ORGANIZATION_CAPABILITIES) {
-        expect(hasCapability("member", capability)).toBe(false);
+    it("grants baseline read capabilities", () => {
+      for (const capability of MEMBER_READ_CAPABILITIES) {
+        expect(hasCapability("member", capability)).toBe(true);
       }
 
-      expect(getCapabilitiesForRole("member")).toEqual([]);
+      expect(getCapabilitiesForRole("member").sort()).toEqual([...MEMBER_READ_CAPABILITIES].sort());
+    });
+
+    it("denies admin-only read and write capabilities", () => {
+      for (const capability of ADMIN_ONLY_CAPABILITIES) {
+        expect(hasCapability("member", capability)).toBe(false);
+      }
     });
   });
 });

--- a/apps/hyperlocalise-web/src/api/auth/policy.test.ts
+++ b/apps/hyperlocalise-web/src/api/auth/policy.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   getCapabilitiesForRole,
   hasCapability,
+  isAdminRole,
   ORGANIZATION_CAPABILITIES,
   type OrganizationCapability,
 } from "./policy";
@@ -63,6 +64,13 @@ describe("organization capability policy", () => {
       for (const capability of ADMIN_ONLY_CAPABILITIES) {
         expect(hasCapability("member", capability)).toBe(false);
       }
+    });
+  });
+
+  describe("isAdminRole", () => {
+    it("returns false for unrecognized role strings", () => {
+      expect(isAdminRole("guest")).toBe(false);
+      expect(isAdminRole("")).toBe(false);
     });
   });
 });

--- a/apps/hyperlocalise-web/src/api/auth/policy.ts
+++ b/apps/hyperlocalise-web/src/api/auth/policy.ts
@@ -1,6 +1,14 @@
 import type { OrganizationMembershipRole } from "@/lib/database/types";
 
-export const ORGANIZATION_CAPABILITIES = [
+const MEMBER_READ_CAPABILITIES = [
+  "workspace:read",
+  "projects:read",
+  "teams:read",
+  "glossaries:read",
+  "memories:read",
+] as const;
+
+const ADMIN_WRITE_CAPABILITIES = [
   "workspace:update",
   "members:invite",
   "teams:write",
@@ -14,14 +22,33 @@ export const ORGANIZATION_CAPABILITIES = [
   "agent_write:approve",
 ] as const;
 
+const ADMIN_READ_CAPABILITIES = [
+  "billing:read",
+  "api_keys:read",
+  "provider_credentials:read",
+  "integrations:read",
+] as const;
+
+export const ORGANIZATION_CAPABILITIES = [
+  ...MEMBER_READ_CAPABILITIES,
+  ...ADMIN_READ_CAPABILITIES,
+  ...ADMIN_WRITE_CAPABILITIES,
+] as const;
+
 export type OrganizationCapability = (typeof ORGANIZATION_CAPABILITIES)[number];
 
-const ADMIN_CAPABILITIES = new Set<OrganizationCapability>(ORGANIZATION_CAPABILITIES);
+const ADMIN_CAPABILITIES = new Set<OrganizationCapability>([
+  ...MEMBER_READ_CAPABILITIES,
+  ...ADMIN_READ_CAPABILITIES,
+  ...ADMIN_WRITE_CAPABILITIES,
+]);
+
+const MEMBER_CAPABILITIES = new Set<OrganizationCapability>(MEMBER_READ_CAPABILITIES);
 
 const ROLE_CAPABILITIES: Record<OrganizationMembershipRole, ReadonlySet<OrganizationCapability>> = {
   owner: ADMIN_CAPABILITIES,
   admin: ADMIN_CAPABILITIES,
-  member: new Set<OrganizationCapability>(),
+  member: MEMBER_CAPABILITIES,
 };
 
 export function getCapabilitiesForRole(role: OrganizationMembershipRole): OrganizationCapability[] {

--- a/apps/hyperlocalise-web/src/api/auth/policy.ts
+++ b/apps/hyperlocalise-web/src/api/auth/policy.ts
@@ -72,7 +72,8 @@ export function assertCapability(
 }
 
 export function isAdminRole(role: string): boolean {
-  return hasCapability(role as OrganizationMembershipRole, "integrations:write");
+  const capabilities = ROLE_CAPABILITIES[role as OrganizationMembershipRole];
+  return capabilities?.has("integrations:write") ?? false;
 }
 
 export function enrichAuthContextWithCapabilities<

--- a/apps/hyperlocalise-web/src/api/auth/policy.ts
+++ b/apps/hyperlocalise-web/src/api/auth/policy.ts
@@ -1,0 +1,58 @@
+import type { OrganizationMembershipRole } from "@/lib/database/types";
+
+export const ORGANIZATION_CAPABILITIES = [
+  "workspace:update",
+  "members:invite",
+  "teams:write",
+  "projects:create",
+  "projects:write",
+  "glossaries:write",
+  "memories:write",
+  "provider_credentials:write",
+  "api_keys:write",
+  "integrations:write",
+  "agent_write:approve",
+] as const;
+
+export type OrganizationCapability = (typeof ORGANIZATION_CAPABILITIES)[number];
+
+const ADMIN_CAPABILITIES = new Set<OrganizationCapability>(ORGANIZATION_CAPABILITIES);
+
+const ROLE_CAPABILITIES: Record<OrganizationMembershipRole, ReadonlySet<OrganizationCapability>> = {
+  owner: ADMIN_CAPABILITIES,
+  admin: ADMIN_CAPABILITIES,
+  member: new Set<OrganizationCapability>(),
+};
+
+export function getCapabilitiesForRole(role: OrganizationMembershipRole): OrganizationCapability[] {
+  return [...ROLE_CAPABILITIES[role]];
+}
+
+export function hasCapability(
+  role: OrganizationMembershipRole,
+  capability: OrganizationCapability,
+): boolean {
+  return ROLE_CAPABILITIES[role].has(capability);
+}
+
+export function assertCapability(
+  role: OrganizationMembershipRole,
+  capability: OrganizationCapability,
+) {
+  if (!hasCapability(role, capability)) {
+    throw new Error("forbidden");
+  }
+}
+
+export function isAdminRole(role: string): boolean {
+  return hasCapability(role as OrganizationMembershipRole, "integrations:write");
+}
+
+export function enrichAuthContextWithCapabilities<
+  T extends { membership: { role: OrganizationMembershipRole } },
+>(auth: T): T & { capabilities: OrganizationCapability[] } {
+  return {
+    ...auth,
+    capabilities: getCapabilitiesForRole(auth.membership.role),
+  };
+}

--- a/apps/hyperlocalise-web/src/api/auth/policy.ts
+++ b/apps/hyperlocalise-web/src/api/auth/policy.ts
@@ -52,14 +52,14 @@ const ROLE_CAPABILITIES: Record<OrganizationMembershipRole, ReadonlySet<Organiza
 };
 
 export function getCapabilitiesForRole(role: OrganizationMembershipRole): OrganizationCapability[] {
-  return [...ROLE_CAPABILITIES[role]];
+  return [...(ROLE_CAPABILITIES[role] ?? [])];
 }
 
 export function hasCapability(
   role: OrganizationMembershipRole,
   capability: OrganizationCapability,
 ): boolean {
-  return ROLE_CAPABILITIES[role].has(capability);
+  return ROLE_CAPABILITIES[role]?.has(capability) ?? false;
 }
 
 export function assertCapability(

--- a/apps/hyperlocalise-web/src/api/auth/roles.ts
+++ b/apps/hyperlocalise-web/src/api/auth/roles.ts
@@ -1,3 +1,1 @@
-export function isAdminRole(role: string): boolean {
-  return role === "owner" || role === "admin";
-}
+export { isAdminRole } from "@/api/auth/policy";

--- a/apps/hyperlocalise-web/src/api/auth/workos-session.ts
+++ b/apps/hyperlocalise-web/src/api/auth/workos-session.ts
@@ -1,6 +1,7 @@
 import { eq } from "drizzle-orm";
 import { withAuth } from "@workos-inc/authkit-nextjs";
 
+import { enrichAuthContextWithCapabilities } from "@/api/auth/policy";
 import type { ApiAuthContext } from "@/api/auth/workos";
 import { db, schema } from "@/lib/database";
 
@@ -114,7 +115,7 @@ export async function resolveApiAuthContextFromSession(
     return null;
   }
 
-  return {
+  return enrichAuthContextWithCapabilities({
     user: {
       workosUserId: membership.workosUserId,
       localUserId: membership.localUserId,
@@ -128,5 +129,5 @@ export async function resolveApiAuthContextFromSession(
       role: activeOrganization.membership.role,
     },
     activeTeam: null,
-  };
+  });
 }

--- a/apps/hyperlocalise-web/src/api/auth/workos.ts
+++ b/apps/hyperlocalise-web/src/api/auth/workos.ts
@@ -1,6 +1,7 @@
 import { createMiddleware } from "hono/factory";
 
 import { forbiddenResponse, unauthorizedResponse } from "@/api/errors";
+import { enrichAuthContextWithCapabilities, type OrganizationCapability } from "@/api/auth/policy";
 import type { OrganizationMembershipRole, TeamMembershipRole } from "@/lib/database/types";
 import { resolveApiAuthContextFromSession } from "@/api/auth/workos-session";
 
@@ -75,7 +76,10 @@ export type ApiAuthContext = {
     name: string;
     role: TeamMembershipRole;
   } | null;
+  capabilities: OrganizationCapability[];
 };
+
+export { enrichAuthContextWithCapabilities } from "@/api/auth/policy";
 
 export interface AuthVariables {
   auth: ApiAuthContext;
@@ -103,7 +107,7 @@ export function createWorkosAuthMiddleware() {
         throw new Error("missing_auth_context");
       }
 
-      c.set("auth", authFromSession);
+      c.set("auth", enrichAuthContextWithCapabilities(authFromSession));
     } catch (error) {
       const message = error instanceof Error ? error.message : "unauthorized";
 

--- a/apps/hyperlocalise-web/src/api/auth/workos.ts
+++ b/apps/hyperlocalise-web/src/api/auth/workos.ts
@@ -1,7 +1,7 @@
 import { createMiddleware } from "hono/factory";
 
 import { forbiddenResponse, unauthorizedResponse } from "@/api/errors";
-import { enrichAuthContextWithCapabilities, type OrganizationCapability } from "@/api/auth/policy";
+import { type OrganizationCapability } from "@/api/auth/policy";
 import type { OrganizationMembershipRole, TeamMembershipRole } from "@/lib/database/types";
 import { resolveApiAuthContextFromSession } from "@/api/auth/workos-session";
 
@@ -107,7 +107,7 @@ export function createWorkosAuthMiddleware() {
         throw new Error("missing_auth_context");
       }
 
-      c.set("auth", enrichAuthContextWithCapabilities(authFromSession));
+      c.set("auth", authFromSession);
     } catch (error) {
       const message = error instanceof Error ? error.message : "unauthorized";
 

--- a/apps/hyperlocalise-web/src/api/routes/api-key/api-key.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/api-key/api-key.route.ts
@@ -15,7 +15,8 @@ import {
   apiKeyNotFoundResponse,
   forbiddenResponse,
   invalidApiKeyPayloadResponse,
-  isApiKeyAdminActionAllowed,
+  isApiKeyReadAllowed,
+  isApiKeyWriteAllowed,
   ownedApiKeyWhere,
 } from "./api-key.shared";
 
@@ -39,7 +40,7 @@ export function createApiKeyRoutes() {
   return new Hono<{ Variables: AuthVariables }>()
     .use("*", workosAuthMiddleware)
     .get("/", async (c) => {
-      if (!isApiKeyAdminActionAllowed(c.var.auth.membership.role)) {
+      if (!isApiKeyReadAllowed(c.var.auth.membership.role)) {
         return forbiddenResponse(c);
       }
 
@@ -65,7 +66,7 @@ export function createApiKeyRoutes() {
       return c.json({ apiKeys: keys }, 200);
     })
     .post("/", validateCreateApiKeyBody, async (c) => {
-      if (!isApiKeyAdminActionAllowed(c.var.auth.membership.role)) {
+      if (!isApiKeyWriteAllowed(c.var.auth.membership.role)) {
         return forbiddenResponse(c);
       }
 
@@ -95,7 +96,7 @@ export function createApiKeyRoutes() {
       return c.json({ apiKey: { ...apiKey, key: plainKey } }, 201);
     })
     .delete("/:apiKeyId", validateApiKeyIdParams, async (c) => {
-      if (!isApiKeyAdminActionAllowed(c.var.auth.membership.role)) {
+      if (!isApiKeyWriteAllowed(c.var.auth.membership.role)) {
         return forbiddenResponse(c);
       }
 

--- a/apps/hyperlocalise-web/src/api/routes/api-key/api-key.shared.ts
+++ b/apps/hyperlocalise-web/src/api/routes/api-key/api-key.shared.ts
@@ -2,6 +2,7 @@ import { and, eq } from "drizzle-orm";
 import type { z } from "zod";
 
 import type { ApiAuthContext } from "@/api/auth/workos";
+import { hasCapability } from "@/api/auth/policy";
 import {
   forbiddenResponse as sharedForbiddenResponse,
   notFoundResponse,
@@ -9,8 +10,6 @@ import {
   type JsonContext,
 } from "@/api/errors";
 import { schema } from "@/lib/database";
-
-const allowedAdminActionRoles = new Set<string>(["owner", "admin"]);
 
 export function invalidApiKeyPayloadResponse(
   c: { json: JsonContext["json"] },
@@ -28,7 +27,7 @@ export function forbiddenResponse(c: { json: JsonContext["json"] }) {
 }
 
 export function isApiKeyAdminActionAllowed(role: ApiAuthContext["membership"]["role"]) {
-  return allowedAdminActionRoles.has(role);
+  return hasCapability(role, "api_keys:write");
 }
 
 export function ownedApiKeyWhere(auth: ApiAuthContext, apiKeyId: string) {

--- a/apps/hyperlocalise-web/src/api/routes/api-key/api-key.shared.ts
+++ b/apps/hyperlocalise-web/src/api/routes/api-key/api-key.shared.ts
@@ -26,7 +26,11 @@ export function forbiddenResponse(c: { json: JsonContext["json"] }) {
   return sharedForbiddenResponse(c, "forbidden", "Insufficient permissions");
 }
 
-export function isApiKeyAdminActionAllowed(role: ApiAuthContext["membership"]["role"]) {
+export function isApiKeyReadAllowed(role: ApiAuthContext["membership"]["role"]) {
+  return hasCapability(role, "api_keys:read");
+}
+
+export function isApiKeyWriteAllowed(role: ApiAuthContext["membership"]["role"]) {
   return hasCapability(role, "api_keys:write");
 }
 

--- a/apps/hyperlocalise-web/src/api/routes/auth/auth.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/auth/auth.route.test.ts
@@ -6,6 +6,9 @@ import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { createWorkosAuthMiddleware } from "../../auth/workos";
 import type { ApiAuthContext } from "../../auth/workos";
+import { enrichAuthContextWithCapabilities, getCapabilitiesForRole } from "../../auth/policy";
+
+type SessionAuthContextInput = Omit<ApiAuthContext, "capabilities">;
 
 const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
   resolveApiAuthContextFromSessionMock: vi.fn(),
@@ -13,7 +16,7 @@ const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
 
 async function createClient(
   options: {
-    sessionAuthContext?: ApiAuthContext | null;
+    sessionAuthContext?: SessionAuthContextInput | null;
     mockProjectRoutes?: boolean;
   } = {},
 ) {
@@ -39,7 +42,11 @@ async function createClient(
     });
   }
 
-  resolveApiAuthContextFromSessionMock.mockResolvedValue(options.sessionAuthContext ?? null);
+  resolveApiAuthContextFromSessionMock.mockResolvedValue(
+    options.sessionAuthContext
+      ? enrichAuthContextWithCapabilities(options.sessionAuthContext)
+      : null,
+  );
 
   vi.doMock("@/api/auth/workos-session", () => ({
     resolveApiAuthContextFromSession: resolveApiAuthContextFromSessionMock,
@@ -171,6 +178,7 @@ describe("authRoutes", () => {
           role: "owner",
         },
         activeTeam: null,
+        capabilities: getCapabilitiesForRole("owner"),
       },
     });
   });
@@ -187,7 +195,7 @@ describe("authRoutes", () => {
       },
     };
 
-    const authContext: ApiAuthContext = {
+    const authContext = enrichAuthContextWithCapabilities({
       user: {
         workosUserId: "user_123",
         localUserId: "local_user_123",
@@ -201,7 +209,7 @@ describe("authRoutes", () => {
         role: "owner",
       },
       activeTeam: null,
-    };
+    });
 
     const client = await createClient({ sessionAuthContext: authContext, mockProjectRoutes: true });
 
@@ -246,21 +254,23 @@ describe("authRoutes", () => {
       },
     };
     vi.resetModules();
-    resolveApiAuthContextFromSessionMock.mockResolvedValue({
-      user: {
-        workosUserId: "user_123",
-        localUserId: "local_user_123",
-        email: "user@example.com",
-      },
-      organizations: [activeOrganization],
-      organization: activeOrganization,
-      activeOrganization,
-      membership: {
-        workosMembershipId: "membership_123",
-        role: "owner",
-      },
-      activeTeam: null,
-    });
+    resolveApiAuthContextFromSessionMock.mockResolvedValue(
+      enrichAuthContextWithCapabilities({
+        user: {
+          workosUserId: "user_123",
+          localUserId: "local_user_123",
+          email: "user@example.com",
+        },
+        organizations: [activeOrganization],
+        organization: activeOrganization,
+        activeOrganization,
+        membership: {
+          workosMembershipId: "membership_123",
+          role: "owner",
+        },
+        activeTeam: null,
+      }),
+    );
     vi.doMock("@/api/auth/workos-session", () => ({
       resolveApiAuthContextFromSession: resolveApiAuthContextFromSessionMock,
     }));

--- a/apps/hyperlocalise-web/src/api/routes/external-tms-provider-credential/external-tms-provider-credential.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/external-tms-provider-credential/external-tms-provider-credential.route.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { validator } from "hono/validator";
 
 import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
+import { hasCapability } from "@/api/auth/policy";
 import { notFoundResponse } from "@/api/response.schema";
 import { fetchCrowdinProjects } from "@/lib/providers/crowdin/crowdin-project-fetcher";
 import { fetchLokaliseProjects } from "@/lib/providers/lokalise/lokalise-project-fetcher";
@@ -49,6 +50,10 @@ export function createExternalTmsProviderCredentialRoutes() {
   return new Hono<{ Variables: AuthVariables }>()
     .use("*", workosAuthMiddleware)
     .get("/", async (c) => {
+      if (!hasCapability(c.var.auth.membership.role, "provider_credentials:read")) {
+        return c.json({ error: "forbidden" }, 403);
+      }
+
       const providerCredentials = await listOrganizationExternalTmsProviderCredentialDetails(
         c.var.auth.organization.localOrganizationId,
       );

--- a/apps/hyperlocalise-web/src/api/routes/external-tms-provider-credential/external-tms-provider-credential.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/external-tms-provider-credential/external-tms-provider-credential.test.ts
@@ -276,7 +276,7 @@ describe("externalTmsProviderCredentialRoutes", () => {
     });
   });
 
-  it("allows non-admins to list external TMS credentials", async () => {
+  it("blocks org members from listing external TMS credentials", async () => {
     const identity = fixture.createWorkosIdentityWithRole("member");
     const headers = await fixture.authHeadersFor(identity);
     const authContext = globalThis.__testApiAuthContext!;
@@ -299,13 +299,8 @@ describe("externalTmsProviderCredentialRoutes", () => {
       { headers },
     );
 
-    expect(response.status).toBe(200);
-    const data = (await response.json()) as {
-      externalTmsProviderCredentials: Array<{ providerKind: string; displayName: string }>;
-    };
-    expect(data.externalTmsProviderCredentials).toHaveLength(1);
-    expect(data.externalTmsProviderCredentials[0].providerKind).toBe("lokalise");
-    expect(data.externalTmsProviderCredentials[0].displayName).toBe("Lokalise");
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: "forbidden" });
   });
 
   it("returns connected provider health and records a health check sync run", async () => {

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary.shared.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary.shared.ts
@@ -7,9 +7,8 @@ import {
   type JsonContext,
 } from "@/api/errors";
 import type { ApiAuthContext } from "@/api/auth/workos";
+import { hasCapability } from "@/api/auth/policy";
 import { schema } from "@/lib/database";
-
-const allowedMutationRoles = new Set<string>(["owner", "admin"]);
 
 export function invalidGlossaryPayloadResponse(c: { json: JsonContext["json"] }) {
   return validationErrorResponse(c, "invalid_glossary_payload", "Invalid glossary payload");
@@ -32,7 +31,7 @@ export function externalTmsGlossaryImmutableResponse(c: { json: JsonContext["jso
 }
 
 export function isGlossaryMutationAllowed(role: ApiAuthContext["membership"]["role"]) {
-  return allowedMutationRoles.has(role);
+  return hasCapability(role, "glossaries:write");
 }
 
 export function ownedGlossaryWhere(auth: ApiAuthContext, glossaryId: string) {

--- a/apps/hyperlocalise-web/src/api/routes/memory/memory.shared.ts
+++ b/apps/hyperlocalise-web/src/api/routes/memory/memory.shared.ts
@@ -7,9 +7,8 @@ import {
   type JsonContext,
 } from "@/api/errors";
 import type { ApiAuthContext } from "@/api/auth/workos";
+import { hasCapability } from "@/api/auth/policy";
 import { schema } from "@/lib/database";
-
-const allowedMutationRoles = new Set<string>(["owner", "admin"]);
 
 export function invalidMemoryPayloadResponse(c: { json: JsonContext["json"] }) {
   return validationErrorResponse(c, "invalid_memory_payload", "Invalid translation memory payload");
@@ -32,7 +31,7 @@ export function externalTmsMemoryImmutableResponse(c: { json: JsonContext["json"
 }
 
 export function isMemoryMutationAllowed(role: ApiAuthContext["membership"]["role"]) {
-  return allowedMutationRoles.has(role);
+  return hasCapability(role, "memories:write");
 }
 
 export function ownedMemoryWhere(auth: ApiAuthContext, memoryId: string) {

--- a/apps/hyperlocalise-web/src/api/routes/project/project.shared.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.shared.ts
@@ -6,10 +6,9 @@ import {
   validationErrorResponse,
   type JsonContext,
 } from "@/api/errors";
+import { hasCapability } from "@/api/auth/policy";
 import type { ApiAuthContext } from "@/api/auth/workos";
 import { db, schema } from "@/lib/database";
-
-const allowedMutationRoles = new Set<string>(["owner", "admin"]);
 
 export function invalidProjectPayloadResponse(c: { json: JsonContext["json"] }) {
   return validationErrorResponse(c, "invalid_project_payload", "Invalid project payload");
@@ -24,7 +23,7 @@ export function forbiddenResponse(c: { json: JsonContext["json"] }) {
 }
 
 export function isProjectMutationAllowed(role: ApiAuthContext["membership"]["role"]) {
-  return allowedMutationRoles.has(role);
+  return hasCapability(role, "projects:write");
 }
 
 export function ownedProjectWhere(auth: ApiAuthContext, projectId: string) {

--- a/apps/hyperlocalise-web/src/api/routes/provider-credential/provider-credential.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/provider-credential/provider-credential.route.ts
@@ -18,6 +18,7 @@ import {
   invalidProviderCredentialPayloadResponse,
   invalidProviderModelResponse,
   isProviderCredentialMutationAllowed,
+  isProviderCredentialReadAllowed,
   providerCredentialNotFoundResponse,
   providerValidationFailedResponse,
 } from "./provider-credential.shared";
@@ -44,6 +45,10 @@ export function createProviderCredentialRoutes() {
   return new Hono<{ Variables: AuthVariables }>()
     .use("*", workosAuthMiddleware)
     .get("/", async (c) => {
+      if (!isProviderCredentialReadAllowed(c.var.auth.membership.role)) {
+        return forbiddenResponse(c);
+      }
+
       const providerCredential = await getOrganizationProviderCredentialSummary(
         c.var.auth.organization.localOrganizationId,
       );

--- a/apps/hyperlocalise-web/src/api/routes/provider-credential/provider-credential.shared.ts
+++ b/apps/hyperlocalise-web/src/api/routes/provider-credential/provider-credential.shared.ts
@@ -1,7 +1,6 @@
 import type { ApiAuthContext } from "@/api/auth/workos";
+import { hasCapability } from "@/api/auth/policy";
 import type { JsonContext } from "@/api/errors";
-
-const allowedMutationRoles = new Set<string>(["owner", "admin"]);
 
 export function invalidProviderCredentialPayloadResponse(c: { json: JsonContext["json"] }) {
   return c.json({ error: "invalid_provider_credential_payload" }, 400);
@@ -33,5 +32,5 @@ export function providerValidationFailedResponse(
 }
 
 export function isProviderCredentialMutationAllowed(role: ApiAuthContext["membership"]["role"]) {
-  return allowedMutationRoles.has(role);
+  return hasCapability(role, "provider_credentials:write");
 }

--- a/apps/hyperlocalise-web/src/api/routes/provider-credential/provider-credential.shared.ts
+++ b/apps/hyperlocalise-web/src/api/routes/provider-credential/provider-credential.shared.ts
@@ -31,6 +31,10 @@ export function providerValidationFailedResponse(
   );
 }
 
+export function isProviderCredentialReadAllowed(role: ApiAuthContext["membership"]["role"]) {
+  return hasCapability(role, "provider_credentials:read");
+}
+
 export function isProviderCredentialMutationAllowed(role: ApiAuthContext["membership"]["role"]) {
   return hasCapability(role, "provider_credentials:write");
 }

--- a/apps/hyperlocalise-web/src/api/routes/provider-credential/provider-credential.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/provider-credential/provider-credential.test.ts
@@ -87,6 +87,36 @@ describe("providerCredentialRoutes", () => {
     });
   });
 
+  it("blocks org members from reading provider credential summaries", async () => {
+    const ownerIdentity = fixture.createWorkosIdentity();
+    const memberIdentity = fixture.createWorkosIdentityForOrganization(
+      ownerIdentity.organization,
+      "member",
+    );
+    const organizationSlug = ownerIdentity.organization.slug ?? "missing-slug";
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(JSON.stringify({ ok: true }), { status: 200 })),
+    );
+
+    await fixture.upsertProviderCredentialViaApi(ownerIdentity, {
+      provider: "openai",
+      apiKey: "sk-owner-key",
+      defaultModel: "gpt-4.1-mini",
+    });
+
+    const response = await client.api.orgs[":organizationSlug"]["provider-credential"].$get(
+      {
+        param: { organizationSlug },
+      },
+      { headers: await fixture.authHeadersFor(memberIdentity) },
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: "forbidden" });
+  });
+
   it("reveals a stored provider credential only after explicit confirmation", async () => {
     vi.stubGlobal(
       "fetch",

--- a/apps/hyperlocalise-web/src/api/routes/team/team.shared.ts
+++ b/apps/hyperlocalise-web/src/api/routes/team/team.shared.ts
@@ -1,4 +1,5 @@
 import type { ApiAuthContext } from "@/api/auth/workos";
+import { hasCapability } from "@/api/auth/policy";
 import type { JsonContext } from "@/api/errors";
 
 export function slugifyTeamName(name: string) {
@@ -47,5 +48,5 @@ export function isUniqueViolation(error: unknown) {
 }
 
 export function isOrganizationAdmin(auth: ApiAuthContext) {
-  return auth.membership.role === "owner" || auth.membership.role === "admin";
+  return hasCapability(auth.membership.role, "teams:write");
 }

--- a/apps/hyperlocalise-web/src/api/test-auth.fixture.ts
+++ b/apps/hyperlocalise-web/src/api/test-auth.fixture.ts
@@ -4,6 +4,7 @@ import { eq } from "drizzle-orm";
 import { expect } from "vite-plus/test";
 
 import type { ApiAuthContext, WorkosAuthIdentity } from "@/api/auth/workos";
+import { enrichAuthContextWithCapabilities } from "@/api/auth/policy";
 import { syncWorkosIdentity } from "@/api/auth/workos-sync";
 import { db, schema } from "@/lib/database";
 import { cleanupWorkosTestRecords } from "./test-cleanup";
@@ -165,7 +166,7 @@ export function createAuthTestFixture() {
       },
     };
 
-    const authContext: ApiAuthContext = {
+    const authContext = enrichAuthContextWithCapabilities({
       user: {
         workosUserId: user.workosUserId,
         localUserId: user.id,
@@ -179,7 +180,7 @@ export function createAuthTestFixture() {
         role: membership.role,
       },
       activeTeam: null,
-    };
+    });
     const sessionToken = `test_${randomUUID()}`;
     const records = currentTestRecords();
 

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-page-content.tsx
@@ -16,6 +16,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
 import type { LlmProvider } from "@/lib/database/types";
+import { hasCapability } from "@/api/auth/policy";
 import { defaultModelByProvider, llmProviderCatalog } from "@/lib/providers/catalog";
 
 import type { OrganizationMembershipRole } from "@/lib/database/types";
@@ -61,8 +62,8 @@ type IntegrationsPageContentProps = {
   membershipRole: OrganizationMembershipRole;
 };
 
-function isAdmin(role: OrganizationMembershipRole) {
-  return role === "owner" || role === "admin";
+function canManageIntegrations(role: OrganizationMembershipRole) {
+  return hasCapability(role, "integrations:write");
 }
 
 function tmsHealthTone(status: string): Parameters<typeof toneClass>[0] {
@@ -497,7 +498,7 @@ export function IntegrationsPageContent({
   const tmsSecretFieldId = useId();
   const tmsRegionFieldId = useId();
   const tmsBaseUrlFieldId = useId();
-  const userIsAdmin = isAdmin(membershipRole);
+  const userIsAdmin = canManageIntegrations(membershipRole);
 
   useEffect(() => {
     if (!credential || selectedProvider !== credential.provider) {

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/page.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/page.tsx
@@ -1,4 +1,4 @@
-import { requireAppAuthContext } from "@/lib/workos/app-auth";
+import { requireAppCapability } from "@/lib/workos/app-auth";
 import { IntegrationsPageContent } from "./_components/integrations-page-content";
 
 export default async function IntegrationsPage({
@@ -7,7 +7,7 @@ export default async function IntegrationsPage({
   params: Promise<{ organizationSlug: string }>;
 }) {
   const { organizationSlug } = await params;
-  const auth = await requireAppAuthContext({ organizationSlug });
+  const auth = await requireAppCapability("integrations:read", { organizationSlug });
 
   return (
     <IntegrationsPageContent

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/settings/_components/settings-pages.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/settings/_components/settings-pages.tsx
@@ -27,12 +27,16 @@ import { Separator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
 import { TypographyH1, TypographyP } from "@/components/ui/typography";
 
+import type { OrganizationCapability } from "@/api/auth/policy";
+
 type SettingsPageProps = {
   organizationSlug: string;
+  capabilities: OrganizationCapability[];
 };
 
-type AccountPageProps = SettingsPageProps & {
+type AccountPageProps = {
   organizationName: string;
+  organizationSlug: string;
   userEmail: string;
   userName: string;
 };
@@ -59,6 +63,7 @@ const settingsCards = [
     href: "api-keys",
     icon: Key01Icon,
     status: "Manage",
+    requiredCapability: "api_keys:read" as const,
   },
   {
     label: "Billing",
@@ -66,6 +71,7 @@ const settingsCards = [
     href: "billing",
     icon: CreditCardIcon,
     status: "Enterprise",
+    requiredCapability: "billing:read" as const,
   },
   {
     label: "Notifications",
@@ -188,8 +194,11 @@ function ReadonlyField({ label, value }: { label: string; value: string }) {
   );
 }
 
-export function SettingsPageContent({ organizationSlug }: SettingsPageProps) {
+export function SettingsPageContent({ organizationSlug, capabilities }: SettingsPageProps) {
   const baseHref = `/org/${organizationSlug}/settings`;
+  const visibleCards = settingsCards.filter(
+    (card) => !("requiredCapability" in card) || capabilities.includes(card.requiredCapability),
+  );
 
   return (
     <main className="space-y-5">
@@ -201,7 +210,7 @@ export function SettingsPageContent({ organizationSlug }: SettingsPageProps) {
       />
 
       <section className="grid gap-3 md:grid-cols-3">
-        {settingsCards.map((card) => (
+        {visibleCards.map((card) => (
           <SettingsCard key={card.label} {...card} href={`${baseHref}/${card.href}`} />
         ))}
       </section>

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/settings/api-keys/page.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/settings/api-keys/page.tsx
@@ -1,3 +1,4 @@
+import { requireAppCapability } from "@/lib/workos/app-auth";
 import { ApiKeySettingsPageContent } from "../_components/api-keys-page-content";
 
 export default async function ApiKeySettingsPage({
@@ -6,5 +7,7 @@ export default async function ApiKeySettingsPage({
   params: Promise<{ organizationSlug: string }>;
 }) {
   const { organizationSlug } = await params;
+  await requireAppCapability("api_keys:read", { organizationSlug });
+
   return <ApiKeySettingsPageContent organizationSlug={organizationSlug} />;
 }

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/settings/billing/page.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/settings/billing/page.tsx
@@ -1,5 +1,13 @@
+import { requireAppCapability } from "@/lib/workos/app-auth";
 import { BillingSettingsPageContent } from "../_components/settings-pages";
 
-export default function BillingSettingsPage() {
+export default async function BillingSettingsPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string }>;
+}) {
+  const { organizationSlug } = await params;
+  await requireAppCapability("billing:read", { organizationSlug });
+
   return <BillingSettingsPageContent />;
 }

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/settings/page.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/settings/page.tsx
@@ -1,3 +1,4 @@
+import { requireAppAuthContext } from "@/lib/workos/app-auth";
 import { SettingsPageContent } from "./_components/settings-pages";
 
 export default async function SettingsPage({
@@ -6,6 +7,9 @@ export default async function SettingsPage({
   params: Promise<{ organizationSlug: string }>;
 }) {
   const { organizationSlug } = await params;
+  const auth = await requireAppAuthContext({ organizationSlug });
 
-  return <SettingsPageContent organizationSlug={organizationSlug} />;
+  return (
+    <SettingsPageContent organizationSlug={organizationSlug} capabilities={auth.capabilities} />
+  );
 }

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.tsx
@@ -41,6 +41,7 @@ type AppShellClientProps = {
     name: string;
     slug?: string | null;
   }>;
+  showBillingLink?: boolean;
   user: {
     name: string;
     avatarUrl?: string;
@@ -52,6 +53,7 @@ export function AppShellClient({
   navigation,
   activeOrganization,
   organizations,
+  showBillingLink = false,
   user,
 }: AppShellClientProps) {
   const pathname = usePathname();
@@ -123,29 +125,31 @@ export function AppShellClient({
         <SidebarContent className="gap-0 px-2 py-2">
           {navigation}
 
-          <div className="mt-auto px-1 pb-2 group-data-[collapsible=icon]:hidden">
-            <div className="rounded-lg border border-sidebar-border bg-sidebar-accent px-3 py-3">
-              <TypographyP className="text-xs font-medium text-sidebar-foreground">
-                Plan usage
-              </TypographyP>
-              <TypographyP className="mt-3 text-xs text-sidebar-foreground/80">
-                Enterprise
-              </TypographyP>
-              <TypographyP className="mt-1 text-xs text-sidebar-foreground/70">
-                Renews on Aug 24, 2027
-              </TypographyP>
-              <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-sidebar-foreground/10">
-                <div className="h-full w-[60%] rounded-full bg-bud-500" />
-              </div>
-              <TypographyP className="mt-3 text-xs text-sidebar-foreground/68">
-                1.2M / 2M words used
-              </TypographyP>
-              <div className="mt-3 flex items-center gap-2 text-xs text-sidebar-foreground/58">
-                <span>View usage</span>
-                <HugeiconsIcon icon={ArrowRight01Icon} strokeWidth={1.7} className="size-3.5" />
+          {showBillingLink ? (
+            <div className="mt-auto px-1 pb-2 group-data-[collapsible=icon]:hidden">
+              <div className="rounded-lg border border-sidebar-border bg-sidebar-accent px-3 py-3">
+                <TypographyP className="text-xs font-medium text-sidebar-foreground">
+                  Plan usage
+                </TypographyP>
+                <TypographyP className="mt-3 text-xs text-sidebar-foreground/80">
+                  Enterprise
+                </TypographyP>
+                <TypographyP className="mt-1 text-xs text-sidebar-foreground/70">
+                  Renews on Aug 24, 2027
+                </TypographyP>
+                <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-sidebar-foreground/10">
+                  <div className="h-full w-[60%] rounded-full bg-bud-500" />
+                </div>
+                <TypographyP className="mt-3 text-xs text-sidebar-foreground/68">
+                  1.2M / 2M words used
+                </TypographyP>
+                <div className="mt-3 flex items-center gap-2 text-xs text-sidebar-foreground/58">
+                  <span>View usage</span>
+                  <HugeiconsIcon icon={ArrowRight01Icon} strokeWidth={1.7} className="size-3.5" />
+                </div>
               </div>
             </div>
-          </div>
+          ) : null}
         </SidebarContent>
 
         <SidebarSeparator className="bg-sidebar-border" />
@@ -154,6 +158,7 @@ export function AppShellClient({
           <NavUser
             organizationName={activeOrganization.name}
             organizationSlug={activeOrganization.slug ?? ""}
+            showBillingLink={showBillingLink}
             user={{ name: user.name, avatar: user.avatarUrl ?? "" }}
           />
         </SidebarFooter>

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell.tsx
@@ -15,6 +15,7 @@ import {
   WorkHistoryIcon,
 } from "@hugeicons/core-free-icons";
 
+import { hasCapability } from "@/api/auth/policy";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 import { AppShellClient } from "@/components/app-shell/app-shell-client";
 import { AppShellNavigation } from "@/components/app-shell/app-shell-navigation";
@@ -99,11 +100,15 @@ export async function AppShell({ children, organizationSlug }: AppShellProps) {
           href: `/org/${activeOrganizationSlug}/translation-memories`,
           icon: DatabaseSyncIcon,
         },
-        {
-          label: "Integrations",
-          href: `/org/${activeOrganizationSlug}/integrations`,
-          icon: LinkSquare02Icon,
-        },
+        ...(hasCapability(auth.membership.role, "integrations:read")
+          ? [
+              {
+                label: "Integrations",
+                href: `/org/${activeOrganizationSlug}/integrations`,
+                icon: LinkSquare02Icon,
+              },
+            ]
+          : []),
         {
           label: "Settings",
           href: `/org/${activeOrganizationSlug}/settings`,
@@ -117,6 +122,7 @@ export async function AppShell({ children, organizationSlug }: AppShellProps) {
     <AppShellClient
       activeOrganization={auth.activeOrganization}
       organizations={auth.organizations}
+      showBillingLink={hasCapability(auth.membership.role, "billing:read")}
       user={{
         name: displayName,
         avatarUrl: auth.sessionUser.profilePictureUrl ?? undefined,

--- a/apps/hyperlocalise-web/src/components/app-shell/nav-user.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/nav-user.tsx
@@ -30,10 +30,12 @@ import {
 export function NavUser({
   organizationName,
   organizationSlug,
+  showBillingLink = false,
   user,
 }: {
   organizationName: string;
   organizationSlug: string;
+  showBillingLink?: boolean;
   user: {
     name: string;
     avatar: string;
@@ -104,12 +106,14 @@ export function NavUser({
                 <HugeiconsIcon icon={AiUserIcon} strokeWidth={2} className="size-4" />
                 Account
               </DropdownMenuItem>
-              <DropdownMenuItem
-                render={<Link href={`/org/${organizationSlug}/settings/billing`} />}
-              >
-                <HugeiconsIcon icon={CreditCardIcon} strokeWidth={2} className="size-4" />
-                Billing
-              </DropdownMenuItem>
+              {showBillingLink ? (
+                <DropdownMenuItem
+                  render={<Link href={`/org/${organizationSlug}/settings/billing`} />}
+                >
+                  <HugeiconsIcon icon={CreditCardIcon} strokeWidth={2} className="size-4" />
+                  Billing
+                </DropdownMenuItem>
+              ) : null}
               <DropdownMenuItem
                 render={<Link href={`/org/${organizationSlug}/settings/notifications`} />}
               >

--- a/apps/hyperlocalise-web/src/lib/agents/repo-tms-write-gate.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/repo-tms-write-gate.ts
@@ -3,6 +3,8 @@ import type {
   RepoTmsAgentTaskSource,
   RepoTmsAgentWorkMode,
 } from "./repo-tms-task";
+import { hasCapability } from "@/api/auth/policy";
+import type { OrganizationMembershipRole } from "@/lib/database/types";
 
 export type WriteAction =
   | "upload_sources"
@@ -13,7 +15,13 @@ export type WriteAction =
 
 export type WriteGateResult = { allowed: true } | { allowed: false; reason: string };
 
-const adminRoles = new Set(["owner", "admin"]);
+function hasAdminCapability(role: OrganizationMembershipRole | null | undefined) {
+  return role ? hasCapability(role, "integrations:write") : false;
+}
+
+function canApproveAgentWrite(role: OrganizationMembershipRole | null | undefined) {
+  return role ? hasCapability(role, "agent_write:approve") : false;
+}
 
 /**
  * Determine whether a repo/TMS write action is allowed for the current task.
@@ -57,7 +65,7 @@ function checkSlackWriteGate(
   _workMode: RepoTmsAgentWorkMode,
   actor: RepoTmsAgentActor,
 ): WriteGateResult {
-  if (actor.role && adminRoles.has(actor.role)) {
+  if (actor.role && hasAdminCapability(actor.role)) {
     return { allowed: true };
   }
 
@@ -84,7 +92,7 @@ function checkGitHubWriteGate(
   workMode: RepoTmsAgentWorkMode,
   actor: RepoTmsAgentActor,
 ): WriteGateResult {
-  const isAdmin = actor.role && adminRoles.has(actor.role);
+  const isAdmin = canApproveAgentWrite(actor.role);
 
   if (workMode === "write") {
     // GitHub write mode is allowed if the requester passed the bot permission

--- a/apps/hyperlocalise-web/src/lib/agents/slack/bot.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/bot.ts
@@ -17,6 +17,7 @@ import {
   type RepoTmsAgentTask,
 } from "@/lib/agents/repo-tms-task";
 import { createRepoTmsAgentTaskQueue } from "@/workflows/adapters";
+import { hasCapability } from "@/api/auth/policy";
 import { createChatStateAdapter } from "@/lib/agents/runtime/state";
 import { wrapThreadPostForInteraction } from "@/lib/agents/runtime/tracking";
 import { db } from "@/lib/database";
@@ -189,8 +190,9 @@ async function processSlackMessage(
     }
 
     if (intent.kind === "repo_tms") {
-      const repoTmsWorkMode =
-        membership.role === "owner" || membership.role === "admin" ? "write" : "read_only";
+      const repoTmsWorkMode = hasCapability(membership.role, "integrations:write")
+        ? "write"
+        : "read_only";
       const repoTmsTask: RepoTmsAgentTask = {
         id: randomUUID(),
         source: "slack",

--- a/apps/hyperlocalise-web/src/lib/providers/organization-external-tms-provider-credentials.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/organization-external-tms-provider-credentials.ts
@@ -1,5 +1,6 @@
 import { and, eq, inArray, ne, sql } from "drizzle-orm";
 
+import { assertCapability } from "@/api/auth/policy";
 import { db, schema } from "@/lib/database";
 import type { OrganizationMembershipRole } from "@/lib/database/types";
 import {
@@ -16,9 +17,7 @@ import {
 export type ExternalTmsProviderKind = "crowdin" | "smartling" | "phrase" | "lokalise";
 
 export function assertExternalTmsCredentialAdmin(role: OrganizationMembershipRole) {
-  if (role !== "owner" && role !== "admin") {
-    throw new Error("forbidden");
-  }
+  assertCapability(role, "provider_credentials:write");
 }
 
 export type ExternalTmsProviderCredentialSummary = {

--- a/apps/hyperlocalise-web/src/lib/providers/organization-provider-credentials.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/organization-provider-credentials.ts
@@ -1,5 +1,6 @@
 import { and, eq } from "drizzle-orm";
 
+import { assertCapability } from "@/api/auth/policy";
 import { db, schema } from "@/lib/database";
 import type {
   LlmProvider,
@@ -24,14 +25,8 @@ export type OrganizationProviderCredentialSummary = {
   updatedAt: Date;
 };
 
-function isProviderCredentialAdmin(role: OrganizationMembershipRole) {
-  return role === "owner" || role === "admin";
-}
-
 export function assertProviderCredentialAdmin(role: OrganizationMembershipRole) {
-  if (!isProviderCredentialAdmin(role)) {
-    throw new Error("forbidden");
-  }
+  assertCapability(role, "provider_credentials:write");
 }
 
 async function getCredentialByOrganizationId(organizationId: string, provider?: LlmProvider) {

--- a/apps/hyperlocalise-web/src/lib/tools/glossary-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/glossary-tools.ts
@@ -3,6 +3,7 @@ import { tool } from "ai";
 import { z } from "zod";
 
 import { schema } from "@/lib/database";
+import { hasCapability } from "@/api/auth/policy";
 
 import { localePattern } from "./locale";
 import type { ToolContext } from "./types";
@@ -80,7 +81,7 @@ export function createCreateGlossaryTool(ctx: ToolContext) {
         .describe("BCP-47 target locale tag."),
     }),
     execute: async ({ name, description, sourceLocale, targetLocale }) => {
-      if (ctx.membershipRole !== "owner" && ctx.membershipRole !== "admin") {
+      if (!hasCapability(ctx.membershipRole, "glossaries:write")) {
         return {
           success: false,
           error:
@@ -130,7 +131,7 @@ export function createUpdateGlossaryTool(ctx: ToolContext) {
       status: z.enum(["draft", "active", "archived"]).optional().describe("New status."),
     }),
     execute: async (input) => {
-      if (ctx.membershipRole !== "owner" && ctx.membershipRole !== "admin") {
+      if (!hasCapability(ctx.membershipRole, "glossaries:write")) {
         return {
           success: false,
           error:
@@ -172,7 +173,7 @@ export function createDeleteGlossaryTool(ctx: ToolContext) {
       glossaryId: z.string().describe("The glossary ID to delete."),
     }),
     execute: async ({ glossaryId }) => {
-      if (ctx.membershipRole !== "owner" && ctx.membershipRole !== "admin") {
+      if (!hasCapability(ctx.membershipRole, "glossaries:write")) {
         return {
           success: false,
           error:
@@ -253,7 +254,7 @@ export function createCreateGlossaryTermTool(ctx: ToolContext) {
       forbidden: z.boolean().default(false).describe("Whether this translation is forbidden."),
     }),
     execute: async (input) => {
-      if (ctx.membershipRole !== "owner" && ctx.membershipRole !== "admin") {
+      if (!hasCapability(ctx.membershipRole, "glossaries:write")) {
         return {
           success: false,
           error:
@@ -329,7 +330,7 @@ export function createUpdateGlossaryTermTool(ctx: ToolContext) {
         .describe("New review status."),
     }),
     execute: async (input) => {
-      if (ctx.membershipRole !== "owner" && ctx.membershipRole !== "admin") {
+      if (!hasCapability(ctx.membershipRole, "glossaries:write")) {
         return {
           success: false,
           error:
@@ -374,7 +375,7 @@ export function createDeleteGlossaryTermTool(ctx: ToolContext) {
       termId: z.string().describe("The term ID to delete."),
     }),
     execute: async ({ termId }) => {
-      if (ctx.membershipRole !== "owner" && ctx.membershipRole !== "admin") {
+      if (!hasCapability(ctx.membershipRole, "glossaries:write")) {
         return {
           success: false,
           error:

--- a/apps/hyperlocalise-web/src/lib/tools/job-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/job-tools.ts
@@ -5,6 +5,7 @@ import { tool } from "ai";
 import { z } from "zod";
 
 import { schema } from "@/lib/database";
+import { hasCapability } from "@/api/auth/policy";
 import {
   ensureRepositorySourceFileVersionForStoredFile,
   getStoredFileForJobScope,
@@ -218,7 +219,7 @@ export function createTranslationJobTool(ctx: ToolContext) {
         .describe("Optional maximum string length for string jobs."),
     }),
     execute: async (input) => {
-      if (ctx.membershipRole !== "owner" && ctx.membershipRole !== "admin") {
+      if (!hasCapability(ctx.membershipRole, "projects:write")) {
         return {
           success: false,
           error:

--- a/apps/hyperlocalise-web/src/lib/tools/memory-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/memory-tools.ts
@@ -3,6 +3,7 @@ import { tool } from "ai";
 import { z } from "zod";
 
 import { schema } from "@/lib/database";
+import { hasCapability } from "@/api/auth/policy";
 import { normalizeTranslationMemorySourceText } from "@/lib/translation/normalizeTranslationMemorySourceText";
 
 import { localePattern } from "./locale";
@@ -62,7 +63,7 @@ export function createCreateTranslationMemoryTool(ctx: ToolContext) {
       description: z.string().max(10_000).optional().describe("Optional description."),
     }),
     execute: async ({ name, description }) => {
-      if (ctx.membershipRole !== "owner" && ctx.membershipRole !== "admin") {
+      if (!hasCapability(ctx.membershipRole, "memories:write")) {
         return {
           success: false,
           error:
@@ -94,7 +95,7 @@ export function createUpdateTranslationMemoryTool(ctx: ToolContext) {
       status: z.enum(["draft", "active", "archived"]).optional().describe("New status."),
     }),
     execute: async (input) => {
-      if (ctx.membershipRole !== "owner" && ctx.membershipRole !== "admin") {
+      if (!hasCapability(ctx.membershipRole, "memories:write")) {
         return {
           success: false,
           error:
@@ -136,7 +137,7 @@ export function createDeleteTranslationMemoryTool(ctx: ToolContext) {
       memoryId: z.string().describe("The memory ID to delete."),
     }),
     execute: async ({ memoryId }) => {
-      if (ctx.membershipRole !== "owner" && ctx.membershipRole !== "admin") {
+      if (!hasCapability(ctx.membershipRole, "memories:write")) {
         return {
           success: false,
           error:
@@ -245,7 +246,7 @@ export function createCreateMemoryEntryTool(ctx: ToolContext) {
       externalKey: z.string().optional().describe("Optional external identifier."),
     }),
     execute: async (input) => {
-      if (ctx.membershipRole !== "owner" && ctx.membershipRole !== "admin") {
+      if (!hasCapability(ctx.membershipRole, "memories:write")) {
         return {
           success: false,
           error:
@@ -343,7 +344,7 @@ export function createUpdateMemoryEntryTool(ctx: ToolContext) {
         .describe("New review status."),
     }),
     execute: async (input) => {
-      if (ctx.membershipRole !== "owner" && ctx.membershipRole !== "admin") {
+      if (!hasCapability(ctx.membershipRole, "memories:write")) {
         return {
           success: false,
           error:
@@ -395,7 +396,7 @@ export function createDeleteMemoryEntryTool(ctx: ToolContext) {
       entryId: z.string().describe("The entry ID to delete."),
     }),
     execute: async ({ entryId }) => {
-      if (ctx.membershipRole !== "owner" && ctx.membershipRole !== "admin") {
+      if (!hasCapability(ctx.membershipRole, "memories:write")) {
         return {
           success: false,
           error:

--- a/apps/hyperlocalise-web/src/lib/workos/app-auth.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/app-auth.ts
@@ -1,6 +1,8 @@
 import { redirect } from "next/navigation";
 import { withAuth } from "@workos-inc/authkit-nextjs";
 
+import type { OrganizationCapability } from "@/api/auth/policy";
+import { hasCapability } from "@/api/auth/policy";
 import type { ApiAuthContext } from "@/api/auth/workos";
 import { resolveApiAuthContextFromSession } from "@/api/auth/workos-session";
 import { getStoredActiveOrganizationSlug } from "@/lib/workos/active-organization";
@@ -42,6 +44,19 @@ export async function requireAppAuthContext(
     ...auth,
     sessionUser: session.user,
   } satisfies AppAuthContext;
+}
+
+export async function requireAppCapability(
+  capability: OrganizationCapability,
+  options: { organizationSlug?: string; ignoreStoredActiveOrganization?: boolean } = {},
+) {
+  const auth = await requireAppAuthContext(options);
+
+  if (!hasCapability(auth.membership.role, capability)) {
+    redirect("/auth/access-denied?reason=insufficient-permissions");
+  }
+
+  return auth;
 }
 
 export async function getDefaultOrganizationDashboardPath() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Centralizes organization RBAC into a typed capability policy layer and adds explicit **read** capabilities to restrict admin-only surfaces (billing, API keys, provider credentials, integrations).

### Policy layer (`src/api/auth/policy.ts`)

- **Member baseline reads**: `workspace:read`, `projects:read`, `teams:read`, `glossaries:read`, `memories:read`
- **Admin-only reads**: `billing:read`, `api_keys:read`, `provider_credentials:read`, `integrations:read`
- **Admin-only writes**: existing write capabilities unchanged (`*:write`, `members:invite`, etc.)
- Owner/admin receive all capabilities; members receive baseline reads only

### API enforcement

- API keys: GET requires `api_keys:read`; POST/DELETE require `api_keys:write`
- Provider credentials: GET requires `provider_credentials:read`; mutations require `provider_credentials:write`
- External TMS credentials: GET blocked for members (403)

### UI enforcement

- Settings index filters Billing/API Keys cards by read capability
- Billing, API Keys, and Integrations pages redirect members via `requireAppCapability`
- App shell hides Integrations nav, billing sidebar widget, and billing user-menu link for members

### Helpers

- `requireAppCapability()` in `app-auth.ts` for server-side page guards
- `capabilities` enriched on auth context for client-side gating

## Test plan

- [x] `vp check --fix`
- [x] `vp test` (1137 tests passing)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-392](https://linear.app/hyperlocalise/issue/HL-392/centralize-rbac-permissions-into-a-capability-policy-layer)

<div><a href="https://cursor.com/agents/bc-1690010f-2e39-4130-85c4-a31540e17837"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1690010f-2e39-4130-85c4-a31540e17837"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

