### PR TITLE
refactor(api): remove legacy non-org-scoped app route mounting

### DIFF
--- a/apps/hyperlocalise-web/src/api/app.ts
+++ b/apps/hyperlocalise-web/src/api/app.ts
@@ -79,17 +79,6 @@ export function createApp(options: CreateAppOptions = {}) {
     .route("/", createInternalRoutes())
     .route("/auth", createAuthRoutes())
     .route(
-      "/",
-      createLegacyAppRoutes({
-        ...options,
-        jobQueue,
-        providerAgentTranslationQueue,
-        providerAgentQaQueue,
-        providerAgentCommentQueue,
-        providerAgentWritebackQueue,
-      }),
-    )
-    .route(
       "/orgs/:organizationSlug",
       createOrgScopedAppRoutes({
         ...options,
@@ -114,15 +103,6 @@ function createInternalRoutes() {
 
 function createAuthRoutes() {
   return new Hono().route("/", authRoutes).route("/slack", createSlackOAuthRoutes());
-}
-
-function createLegacyAppRoutes(
-  options: CreateAppOptions & { jobQueue: JobQueue<TranslationJobEventData> },
-) {
-  return new Hono()
-    .route("/glossary", createGlossaryRoutes())
-    .route("/memory", createMemoryRoutes())
-    .route("/project", createProjectRoutes(options));
 }
 
 function createOrgScopedAppRoutes(

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary.fixture.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary.fixture.ts
@@ -21,8 +21,9 @@ export function createGlossaryTestFixture(client?: Client) {
       throw new Error("createGlossaryViaApi requires a test client");
     }
 
-    return client.api.glossary.$post(
+    return client.api.orgs[":organizationSlug"].glossaries.$post(
       {
+        param: { organizationSlug: identity.organization.slug ?? "missing-slug" },
         json: {
           name: input?.name ?? "Marketing Glossary",
           description: input?.description ?? "Marketing terminology",

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary.test.ts
@@ -45,26 +45,20 @@ afterEach(async () => {
 
 describe("glossaryRoutes", () => {
   it("returns 401 when auth context is missing", async () => {
-    const response = await client.api.glossary.$get({ query: { limit: "50", offset: "0" } });
+    const response = await client.api.orgs[":organizationSlug"].glossaries.$get({
+      param: { organizationSlug: "missing-slug" },
+      query: { limit: "50", offset: "0" },
+    });
 
     expect(response.status).toBe(401);
     const responseBody = await response.json();
     expect(responseBody).toMatchObject({ error: "unauthorized", message: expect.any(String) });
   });
 
-  it("keeps glossary routes mounted at legacy and org-scoped app paths", async () => {
+  it("keeps glossary routes mounted at the org-scoped app path", async () => {
     const identity = createWorkosIdentity();
     await createGlossaryViaApi(identity, { name: "Mounted Glossary" });
     const headers = await authHeadersFor(identity);
-
-    const legacyResponse = await client.api.glossary.$get(
-      { query: { limit: "50", offset: "0" } },
-      { headers },
-    );
-    expect(legacyResponse.status).toBe(200);
-    await expect(legacyResponse.json()).resolves.toMatchObject({
-      glossaries: [expect.objectContaining({ name: "Mounted Glossary" })],
-    });
 
     const orgScopedResponse = await client.api.orgs[":organizationSlug"].glossaries.$get(
       {
@@ -88,8 +82,11 @@ describe("glossaryRoutes", () => {
     const otherIdentity = createWorkosIdentity();
     await createGlossaryViaApi(otherIdentity, { name: "Other Org Glossary" });
 
-    const response = await client.api.glossary.$get(
-      { query: { limit: "50", offset: "0" } },
+    const response = await client.api.orgs[":organizationSlug"].glossaries.$get(
+      {
+        param: { organizationSlug: identity.organization.slug ?? "missing-slug" },
+        query: { limit: "50", offset: "0" },
+      },
       {
         headers: await authHeadersFor(identity),
       },
@@ -130,8 +127,9 @@ describe("glossaryRoutes", () => {
 
   it("fills default values for optional create fields", async () => {
     const identity = createWorkosIdentity();
-    const response = await client.api.glossary.$post(
+    const response = await client.api.orgs[":organizationSlug"].glossaries.$post(
       {
+        param: { organizationSlug: identity.organization.slug ?? "missing-slug" },
         json: {
           name: "Test Glossary",
           sourceLocale: "en",
@@ -153,8 +151,9 @@ describe("glossaryRoutes", () => {
 
   it("returns 400 for invalid create payloads", async () => {
     const identity = createWorkosIdentity();
-    const response = await client.api.glossary.$post(
+    const response = await client.api.orgs[":organizationSlug"].glossaries.$post(
       {
+        param: { organizationSlug: identity.organization.slug ?? "missing-slug" },
         json: {
           name: "   ",
           sourceLocale: "en",
@@ -176,8 +175,9 @@ describe("glossaryRoutes", () => {
 
   it("returns 403 when a member creates a glossary", async () => {
     const identity = createWorkosIdentityWithRole("member");
-    const response = await client.api.glossary.$post(
+    const response = await client.api.orgs[":organizationSlug"].glossaries.$post(
       {
+        param: { organizationSlug: identity.organization.slug ?? "missing-slug" },
         json: {
           name: "Test Glossary",
           sourceLocale: "en",
@@ -213,9 +213,12 @@ describe("glossaryRoutes", () => {
     const createdBody = await createdResponse.json();
     if ("error" in createdBody) throw new Error(String(createdBody.error));
 
-    const response = await client.api.glossary[":glossaryId"].$get(
+    const response = await client.api.orgs[":organizationSlug"].glossaries[":glossaryId"].$get(
       {
-        param: { glossaryId: createdBody.glossary.id },
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          glossaryId: createdBody.glossary.id,
+        },
       },
       {
         headers: await authHeadersFor(identity),
@@ -236,9 +239,12 @@ describe("glossaryRoutes", () => {
     const createdBody = await createdResponse.json();
     if ("error" in createdBody) throw new Error(String(createdBody.error));
 
-    const response = await client.api.glossary[":glossaryId"].$patch(
+    const response = await client.api.orgs[":organizationSlug"].glossaries[":glossaryId"].$patch(
       {
-        param: { glossaryId: createdBody.glossary.id },
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          glossaryId: createdBody.glossary.id,
+        },
         json: {
           name: "Updated Glossary Name",
         },
@@ -262,9 +268,14 @@ describe("glossaryRoutes", () => {
     const createdBody = await createdResponse.json();
     if ("error" in createdBody) throw new Error(String(createdBody.error));
 
-    const emptyResponse = await client.api.glossary[":glossaryId"].$patch(
+    const emptyResponse = await client.api.orgs[":organizationSlug"].glossaries[
+      ":glossaryId"
+    ].$patch(
       {
-        param: { glossaryId: createdBody.glossary.id },
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          glossaryId: createdBody.glossary.id,
+        },
         json: {},
       },
       {
@@ -279,9 +290,14 @@ describe("glossaryRoutes", () => {
       message: expect.any(String),
     });
 
-    const invalidNameResponse = await client.api.glossary[":glossaryId"].$patch(
+    const invalidNameResponse = await client.api.orgs[":organizationSlug"].glossaries[
+      ":glossaryId"
+    ].$patch(
       {
-        param: { glossaryId: createdBody.glossary.id },
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          glossaryId: createdBody.glossary.id,
+        },
         json: {
           name: "   ",
         },
@@ -306,9 +322,12 @@ describe("glossaryRoutes", () => {
     if ("error" in createdBody) throw new Error(String(createdBody.error));
 
     const otherIdentity = createWorkosIdentity();
-    const response = await client.api.glossary[":glossaryId"].$get(
+    const response = await client.api.orgs[":organizationSlug"].glossaries[":glossaryId"].$get(
       {
-        param: { glossaryId: createdBody.glossary.id },
+        param: {
+          organizationSlug: ownerIdentity.organization.slug ?? "missing-slug",
+          glossaryId: createdBody.glossary.id,
+        },
       },
       {
         headers: await authHeadersFor(otherIdentity),
@@ -330,9 +349,12 @@ describe("glossaryRoutes", () => {
     if ("error" in createdBody) throw new Error(String(createdBody.error));
 
     const otherIdentity = createWorkosIdentity();
-    const response = await client.api.glossary[":glossaryId"].$patch(
+    const response = await client.api.orgs[":organizationSlug"].glossaries[":glossaryId"].$patch(
       {
-        param: { glossaryId: createdBody.glossary.id },
+        param: {
+          organizationSlug: ownerIdentity.organization.slug ?? "missing-slug",
+          glossaryId: createdBody.glossary.id,
+        },
         json: {
           name: "Should Not Apply",
         },
@@ -357,9 +379,12 @@ describe("glossaryRoutes", () => {
     if ("error" in createdBody) throw new Error(String(createdBody.error));
 
     const memberIdentity = createWorkosIdentityWithRole("member");
-    const response = await client.api.glossary[":glossaryId"].$patch(
+    const response = await client.api.orgs[":organizationSlug"].glossaries[":glossaryId"].$patch(
       {
-        param: { glossaryId: createdBody.glossary.id },
+        param: {
+          organizationSlug: ownerIdentity.organization.slug ?? "missing-slug",
+          glossaryId: createdBody.glossary.id,
+        },
         json: {
           name: "Should Not Apply",
         },
@@ -376,9 +401,12 @@ describe("glossaryRoutes", () => {
 
   it("returns 404 when a glossary does not exist", async () => {
     const identity = createWorkosIdentity();
-    const response = await client.api.glossary[":glossaryId"].$get(
+    const response = await client.api.orgs[":organizationSlug"].glossaries[":glossaryId"].$get(
       {
-        param: { glossaryId: generateNonExistentUuid() },
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          glossaryId: generateNonExistentUuid(),
+        },
       },
       {
         headers: await authHeadersFor(identity),
@@ -399,9 +427,12 @@ describe("glossaryRoutes", () => {
     const createdBody = await createdResponse.json();
     if ("error" in createdBody) throw new Error(String(createdBody.error));
 
-    const response = await client.api.glossary[":glossaryId"].$delete(
+    const response = await client.api.orgs[":organizationSlug"].glossaries[":glossaryId"].$delete(
       {
-        param: { glossaryId: createdBody.glossary.id },
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          glossaryId: createdBody.glossary.id,
+        },
       },
       {
         headers: await authHeadersFor(identity),
@@ -410,9 +441,12 @@ describe("glossaryRoutes", () => {
 
     expect(response.status).toBe(204);
 
-    const fetchResponse = await client.api.glossary[":glossaryId"].$get(
+    const fetchResponse = await client.api.orgs[":organizationSlug"].glossaries[":glossaryId"].$get(
       {
-        param: { glossaryId: createdBody.glossary.id },
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          glossaryId: createdBody.glossary.id,
+        },
       },
       {
         headers: await authHeadersFor(identity),
@@ -429,9 +463,12 @@ describe("glossaryRoutes", () => {
     if ("error" in createdBody) throw new Error(String(createdBody.error));
 
     const otherIdentity = createWorkosIdentity();
-    const response = await client.api.glossary[":glossaryId"].$delete(
+    const response = await client.api.orgs[":organizationSlug"].glossaries[":glossaryId"].$delete(
       {
-        param: { glossaryId: createdBody.glossary.id },
+        param: {
+          organizationSlug: ownerIdentity.organization.slug ?? "missing-slug",
+          glossaryId: createdBody.glossary.id,
+        },
       },
       {
         headers: await authHeadersFor(otherIdentity),
@@ -445,9 +482,12 @@ describe("glossaryRoutes", () => {
       message: expect.any(String),
     });
 
-    const fetchResponse = await client.api.glossary[":glossaryId"].$get(
+    const fetchResponse = await client.api.orgs[":organizationSlug"].glossaries[":glossaryId"].$get(
       {
-        param: { glossaryId: createdBody.glossary.id },
+        param: {
+          organizationSlug: ownerIdentity.organization.slug ?? "missing-slug",
+          glossaryId: createdBody.glossary.id,
+        },
       },
       {
         headers: await authHeadersFor(ownerIdentity),
@@ -459,9 +499,12 @@ describe("glossaryRoutes", () => {
 
   it("returns 404 when deleting a glossary that does not exist", async () => {
     const identity = createWorkosIdentity();
-    const response = await client.api.glossary[":glossaryId"].$delete(
+    const response = await client.api.orgs[":organizationSlug"].glossaries[":glossaryId"].$delete(
       {
-        param: { glossaryId: generateNonExistentUuid() },
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          glossaryId: generateNonExistentUuid(),
+        },
       },
       {
         headers: await authHeadersFor(identity),
@@ -483,9 +526,12 @@ describe("glossaryRoutes", () => {
     if ("error" in createdBody) throw new Error(String(createdBody.error));
 
     const memberIdentity = createWorkosIdentityWithRole("member");
-    const response = await client.api.glossary[":glossaryId"].$delete(
+    const response = await client.api.orgs[":organizationSlug"].glossaries[":glossaryId"].$delete(
       {
-        param: { glossaryId: createdBody.glossary.id },
+        param: {
+          organizationSlug: ownerIdentity.organization.slug ?? "missing-slug",
+          glossaryId: createdBody.glossary.id,
+        },
       },
       {
         headers: await authHeadersFor(memberIdentity),
@@ -526,8 +572,11 @@ describe("glossaryRoutes", () => {
       externalUrl: "https://phrase.com/term-bases/tb-42",
     });
 
-    const response = await client.api.glossary.$get(
-      { query: { limit: "50", offset: "0" } },
+    const response = await client.api.orgs[":organizationSlug"].glossaries.$get(
+      {
+        param: { organizationSlug: identity.organization.slug ?? "missing-slug" },
+        query: { limit: "50", offset: "0" },
+      },
       {
         headers: await authHeadersFor(identity),
       },
@@ -582,8 +631,11 @@ describe("glossaryRoutes", () => {
 
     const headers = await authHeadersFor(identity);
 
-    const searchResponse = await client.api.glossary.$get(
-      { query: { limit: "50", offset: "0", search: "marketing" } },
+    const searchResponse = await client.api.orgs[":organizationSlug"].glossaries.$get(
+      {
+        param: { organizationSlug: identity.organization.slug ?? "missing-slug" },
+        query: { limit: "50", offset: "0", search: "marketing" },
+      },
       { headers },
     );
     expect(searchResponse.status).toBe(200);
@@ -594,8 +646,11 @@ describe("glossaryRoutes", () => {
       expect.objectContaining({ name: "Workspace Marketing Terms" }),
     ]);
 
-    const providerResponse = await client.api.glossary.$get(
-      { query: { limit: "50", offset: "0", source: "external_tms" } },
+    const providerResponse = await client.api.orgs[":organizationSlug"].glossaries.$get(
+      {
+        param: { organizationSlug: identity.organization.slug ?? "missing-slug" },
+        query: { limit: "50", offset: "0", source: "external_tms" },
+      },
       { headers },
     );
     expect(providerResponse.status).toBe(200);
@@ -633,9 +688,14 @@ describe("glossaryRoutes", () => {
 
     const headers = await authHeadersFor(identity);
 
-    const patchResponse = await client.api.glossary[":glossaryId"].$patch(
+    const patchResponse = await client.api.orgs[":organizationSlug"].glossaries[
+      ":glossaryId"
+    ].$patch(
       {
-        param: { glossaryId: externalGlossary.id },
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          glossaryId: externalGlossary.id,
+        },
         json: { name: "Renamed" },
       },
       { headers },
@@ -645,9 +705,14 @@ describe("glossaryRoutes", () => {
       error: "external_tms_glossary_immutable",
     });
 
-    const deleteResponse = await client.api.glossary[":glossaryId"].$delete(
+    const deleteResponse = await client.api.orgs[":organizationSlug"].glossaries[
+      ":glossaryId"
+    ].$delete(
       {
-        param: { glossaryId: externalGlossary.id },
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          glossaryId: externalGlossary.id,
+        },
       },
       { headers },
     );

--- a/apps/hyperlocalise-web/src/api/routes/memory/memory.fixture.ts
+++ b/apps/hyperlocalise-web/src/api/routes/memory/memory.fixture.ts
@@ -19,8 +19,9 @@ export function createMemoryTestFixture(client?: Client) {
       throw new Error("createMemoryViaApi requires a test client");
     }
 
-    return client.api.memory.$post(
+    return client.api.orgs[":organizationSlug"]["translation-memories"].$post(
       {
+        param: { organizationSlug: identity.organization.slug ?? "missing-slug" },
         json: {
           name: input?.name ?? "Product TM",
           description: input?.description ?? "Product translation memory",

--- a/apps/hyperlocalise-web/src/api/routes/memory/memory.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/memory/memory.test.ts
@@ -45,27 +45,20 @@ afterEach(async () => {
 
 describe("memoryRoutes", () => {
   it("returns 401 when auth context is missing", async () => {
-    const response = await client.api.memory.$get({ query: { limit: "50", offset: "0" } });
+    const response = await client.api.orgs[":organizationSlug"]["translation-memories"].$get({
+      param: { organizationSlug: "missing-slug" },
+      query: { limit: "50", offset: "0" },
+    });
 
     expect(response.status).toBe(401);
     const responseBody = await response.json();
     expect(responseBody).toMatchObject({ error: "unauthorized", message: expect.any(String) });
   });
 
-  it("keeps memory routes mounted at legacy and org-scoped app paths", async () => {
+  it("keeps memory routes mounted at the org-scoped app path", async () => {
     const identity = createWorkosIdentity();
     await createMemoryViaApi(identity, { name: "Mounted TM" });
     const headers = await authHeadersFor(identity);
-
-    const legacyResponse = await client.api.memory.$get(
-      { query: { limit: "50", offset: "0" } },
-      { headers },
-    );
-    expect(legacyResponse.status).toBe(200);
-    await expect(legacyResponse.json()).resolves.toMatchObject({
-      memories: [expect.objectContaining({ name: "Mounted TM" })],
-      total: 1,
-    });
 
     const orgScopedResponse = await client.api.orgs[":organizationSlug"][
       "translation-memories"
@@ -112,8 +105,11 @@ describe("memoryRoutes", () => {
       externalUrl: "https://crowdin.com/tm/77",
     });
 
-    const response = await client.api.memory.$get(
-      { query: { limit: "50", offset: "0" } },
+    const response = await client.api.orgs[":organizationSlug"]["translation-memories"].$get(
+      {
+        param: { organizationSlug: identity.organization.slug ?? "missing-slug" },
+        query: { limit: "50", offset: "0" },
+      },
       {
         headers: await authHeadersFor(identity),
       },
@@ -163,9 +159,14 @@ describe("memoryRoutes", () => {
 
   it("returns memory_not_found for unknown ids", async () => {
     const identity = createWorkosIdentity();
-    const response = await client.api.memory[":memoryId"].$get(
+    const response = await client.api.orgs[":organizationSlug"]["translation-memories"][
+      ":memoryId"
+    ].$get(
       {
-        param: { memoryId: generateNonExistentUuid() },
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          memoryId: generateNonExistentUuid(),
+        },
       },
       {
         headers: await authHeadersFor(identity),
@@ -200,9 +201,14 @@ describe("memoryRoutes", () => {
 
     const headers = await authHeadersFor(identity);
 
-    const patchResponse = await client.api.memory[":memoryId"].$patch(
+    const patchResponse = await client.api.orgs[":organizationSlug"]["translation-memories"][
+      ":memoryId"
+    ].$patch(
       {
-        param: { memoryId: externalMemory.id },
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          memoryId: externalMemory.id,
+        },
         json: { name: "Renamed" },
       },
       { headers },
@@ -212,9 +218,14 @@ describe("memoryRoutes", () => {
       error: "external_tms_memory_immutable",
     });
 
-    const deleteResponse = await client.api.memory[":memoryId"].$delete(
+    const deleteResponse = await client.api.orgs[":organizationSlug"]["translation-memories"][
+      ":memoryId"
+    ].$delete(
       {
-        param: { memoryId: externalMemory.id },
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          memoryId: externalMemory.id,
+        },
       },
       { headers },
     );

--- a/apps/hyperlocalise-web/src/api/routes/project/job.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.test.ts
@@ -261,9 +261,15 @@ describe("jobRoutes", () => {
     });
     const headers = await authHeadersFor(identity);
 
-    const nestedResponse = await appClient.api.project[":projectId"].jobs[":jobId"].$get(
+    const nestedResponse = await appClient.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].jobs[":jobId"].$get(
       {
-        param: { projectId: project.id, jobId: job.id },
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: project.id,
+          jobId: job.id,
+        },
       },
       { headers },
     );
@@ -294,9 +300,12 @@ describe("jobRoutes", () => {
     const projectResponse = await createProjectViaApi(identity);
     const project = ((await projectResponse.json()) as ProjectResponse).project;
 
-    const response = await client.api.project[":projectId"].jobs.$post(
+    const response = await client.api.orgs[":organizationSlug"].projects[":projectId"].jobs.$post(
       {
-        param: { projectId: project.id },
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: project.id,
+        },
         json: {
           type: "string",
           stringInput: {
@@ -389,9 +398,12 @@ describe("jobRoutes", () => {
       },
     });
 
-    const allResponse = await client.api.project[":projectId"].jobs.$get(
+    const allResponse = await client.api.orgs[":organizationSlug"].projects[":projectId"].jobs.$get(
       {
-        param: { projectId: project.id },
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: project.id,
+        },
         query: { mine: "false", limit: "50" },
       },
       { headers: authHeader },
@@ -406,9 +418,14 @@ describe("jobRoutes", () => {
       ]),
     });
 
-    const mineResponse = await client.api.project[":projectId"].jobs.$get(
+    const mineResponse = await client.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].jobs.$get(
       {
-        param: { projectId: project.id },
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: project.id,
+        },
         query: { mine: "true", limit: "50" },
       },
       { headers: authHeader },
@@ -425,9 +442,14 @@ describe("jobRoutes", () => {
     expect(mineBody.jobs).toHaveLength(2);
     expect(mineBody.jobs.every((job) => job.createdByUserId === localUserId)).toBe(true);
 
-    const filteredResponse = await client.api.project[":projectId"].jobs.$get(
+    const filteredResponse = await client.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].jobs.$get(
       {
-        param: { projectId: project.id },
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: project.id,
+        },
         query: { type: "file", status: "failed", mine: "false", limit: "50" },
       },
       { headers: authHeader },
@@ -438,9 +460,14 @@ describe("jobRoutes", () => {
       jobs: [expect.objectContaining({ type: "file", status: "failed" })],
     });
 
-    const limitedResponse = await client.api.project[":projectId"].jobs.$get(
+    const limitedResponse = await client.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].jobs.$get(
       {
-        param: { projectId: project.id },
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: project.id,
+        },
         query: { mine: "false", limit: "1" },
       },
       { headers: authHeader },
@@ -516,9 +543,14 @@ describe("jobRoutes", () => {
       },
     });
 
-    const projectJobsResponse = await client.api.project[":projectId"].jobs.$get(
+    const projectJobsResponse = await client.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].jobs.$get(
       {
-        param: { projectId: project.id },
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: project.id,
+        },
         query: { kind: "research", mine: "false", limit: "50" },
       },
       { headers: authHeader },
@@ -581,9 +613,15 @@ describe("jobRoutes", () => {
 
     const authHeader = await authHeadersFor(identity);
 
-    const getResponse = await client.api.project[":projectId"].jobs[":jobId"].$get(
+    const getResponse = await client.api.orgs[":organizationSlug"].projects[":projectId"].jobs[
+      ":jobId"
+    ].$get(
       {
-        param: { projectId: project.id, jobId: job.id },
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: project.id,
+          jobId: job.id,
+        },
       },
       { headers: authHeader },
     );
@@ -597,9 +635,15 @@ describe("jobRoutes", () => {
       }),
     });
 
-    const statusResponse = await client.api.project[":projectId"].jobs[":jobId"].status.$get(
+    const statusResponse = await client.api.orgs[":organizationSlug"].projects[":projectId"].jobs[
+      ":jobId"
+    ].status.$get(
       {
-        param: { projectId: project.id, jobId: job.id },
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: project.id,
+          jobId: job.id,
+        },
       },
       { headers: authHeader },
     );
@@ -826,9 +870,12 @@ describe("jobRoutes", () => {
       ownerIdentity.organization,
       "member",
     );
-    const response = await client.api.project[":projectId"].jobs.$post(
+    const response = await client.api.orgs[":organizationSlug"].projects[":projectId"].jobs.$post(
       {
-        param: { projectId: project.id },
+        param: {
+          organizationSlug: ownerIdentity.organization.slug ?? "missing-slug",
+          projectId: project.id,
+        },
         json: {
           type: "string",
           stringInput: {
@@ -867,9 +914,15 @@ describe("jobRoutes", () => {
     });
 
     const otherIdentity = createWorkosIdentity();
-    const response = await client.api.project[":projectId"].jobs[":jobId"].$get(
+    const response = await client.api.orgs[":organizationSlug"].projects[":projectId"].jobs[
+      ":jobId"
+    ].$get(
       {
-        param: { projectId: project.id, jobId: job.id },
+        param: {
+          organizationSlug: ownerIdentity.organization.slug ?? "missing-slug",
+          projectId: project.id,
+          jobId: job.id,
+        },
       },
       {
         headers: await authHeadersFor(otherIdentity),
@@ -886,9 +939,12 @@ describe("jobRoutes", () => {
     const projectResponse = await createProjectViaApi(identity);
     const project = ((await projectResponse.json()) as ProjectResponse).project;
 
-    const response = await client.api.project[":projectId"].jobs.$post(
+    const response = await client.api.orgs[":organizationSlug"].projects[":projectId"].jobs.$post(
       {
-        param: { projectId: project.id },
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: project.id,
+        },
         json: {
           type: "string",
           stringInput: {
@@ -921,9 +977,12 @@ describe("jobRoutes", () => {
       contentType: "application/xliff+xml",
     });
 
-    const response = await client.api.project[":projectId"].jobs.$post(
+    const response = await client.api.orgs[":organizationSlug"].projects[":projectId"].jobs.$post(
       {
-        param: { projectId: project.id },
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: project.id,
+        },
         json: {
           type: "file",
           fileInput: {
@@ -964,9 +1023,12 @@ describe("jobRoutes", () => {
       contentType: "image/png",
     });
 
-    const response = await client.api.project[":projectId"].jobs.$post(
+    const response = await client.api.orgs[":organizationSlug"].projects[":projectId"].jobs.$post(
       {
-        param: { projectId: project.id },
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: project.id,
+        },
         json: {
           type: "file",
           fileInput: {
@@ -995,9 +1057,12 @@ describe("jobRoutes", () => {
     const projectResponse = await createProjectViaApi(identity);
     const project = ((await projectResponse.json()) as ProjectResponse).project;
 
-    const response = await client.api.project[":projectId"].jobs.$post(
+    const response = await client.api.orgs[":organizationSlug"].projects[":projectId"].jobs.$post(
       {
-        param: { projectId: project.id },
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: project.id,
+        },
         json: {
           type: "file",
           fileInput: {
@@ -1032,8 +1097,9 @@ describe("jobRoutes", () => {
       }),
     );
     const identity = createWorkosIdentity();
-    const projectResponse = await failingClient.api.project.$post(
+    const projectResponse = await failingClient.api.orgs[":organizationSlug"].projects.$post(
       {
+        param: { organizationSlug: identity.organization.slug ?? "missing-slug" },
         json: {
           name: "Marketing Site",
           description: "Primary website strings",
@@ -1046,9 +1112,14 @@ describe("jobRoutes", () => {
     );
     const project = ((await projectResponse.json()) as ProjectResponse).project;
 
-    const response = await failingClient.api.project[":projectId"].jobs.$post(
+    const response = await failingClient.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].jobs.$post(
       {
-        param: { projectId: project.id },
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: project.id,
+        },
         json: {
           type: "string",
           stringInput: {

--- a/apps/hyperlocalise-web/src/api/routes/project/project.fixture.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.fixture.ts
@@ -23,8 +23,9 @@ export function createProjectTestFixture(client?: Client) {
       throw new Error("createProjectViaApi requires a test client");
     }
 
-    return client.api.project.$post(
+    return client.api.orgs[":organizationSlug"].projects.$post(
       {
+        param: { organizationSlug: identity.organization.slug ?? "missing-slug" },
         json: {
           name: input?.name ?? "Marketing Site",
           description: input?.description ?? "Primary website strings",

--- a/apps/hyperlocalise-web/src/api/routes/project/project.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.test.ts
@@ -53,23 +53,19 @@ afterEach(async () => {
 
 describe("projectRoutes", () => {
   it("returns 401 when auth context is missing", async () => {
-    const response = await client.api.project.$get();
+    const response = await client.api.orgs[":organizationSlug"].projects.$get({
+      param: { organizationSlug: "missing-slug" },
+    });
 
     expect(response.status).toBe(401);
     const responseBody = await response.json();
     expect(responseBody).toMatchObject({ error: "unauthorized", message: expect.any(String) });
   });
 
-  it("keeps project routes mounted at legacy and org-scoped app paths", async () => {
+  it("keeps project routes mounted at the org-scoped app path", async () => {
     const identity = createWorkosIdentity();
     await createProjectViaApi(identity, { name: "Mounted Project" });
     const headers = await authHeadersFor(identity);
-
-    const legacyResponse = await appClient.api.project.$get({}, { headers });
-    expect(legacyResponse.status).toBe(200);
-    await expect(legacyResponse.json()).resolves.toMatchObject({
-      projects: [expect.objectContaining({ name: "Mounted Project" })],
-    });
 
     const orgScopedResponse = await appClient.api.orgs[":organizationSlug"].projects.$get(
       {
@@ -92,8 +88,8 @@ describe("projectRoutes", () => {
     const otherIdentity = createWorkosIdentity();
     await createProjectViaApi(otherIdentity, { name: "Other Org Project" });
 
-    const response = await client.api.project.$get(
-      {},
+    const response = await client.api.orgs[":organizationSlug"].projects.$get(
+      { param: { organizationSlug: identity.organization.slug ?? "missing-slug" } },
       {
         headers: await authHeadersFor(identity),
       },
@@ -125,8 +121,9 @@ describe("projectRoutes", () => {
 
   it("fills default values for optional create fields", async () => {
     const identity = createWorkosIdentity();
-    const response = await client.api.project.$post(
+    const response = await client.api.orgs[":organizationSlug"].projects.$post(
       {
+        param: { organizationSlug: identity.organization.slug ?? "missing-slug" },
         json: {
           name: "Docs",
         },
@@ -146,8 +143,9 @@ describe("projectRoutes", () => {
 
   it("returns 400 for invalid create payloads", async () => {
     const identity = createWorkosIdentity();
-    const response = await client.api.project.$post(
+    const response = await client.api.orgs[":organizationSlug"].projects.$post(
       {
+        param: { organizationSlug: identity.organization.slug ?? "missing-slug" },
         json: {
           name: "   ",
         },
@@ -167,8 +165,9 @@ describe("projectRoutes", () => {
 
   it("returns 403 when a member creates a project", async () => {
     const identity = createWorkosIdentityWithRole("member");
-    const response = await client.api.project.$post(
+    const response = await client.api.orgs[":organizationSlug"].projects.$post(
       {
+        param: { organizationSlug: identity.organization.slug ?? "missing-slug" },
         json: {
           name: "Docs",
           description: "Documentation content",
@@ -190,9 +189,12 @@ describe("projectRoutes", () => {
     const createdResponse = await createProjectViaApi(identity);
     const createdBody = (await createdResponse.json()) as ProjectResponse;
 
-    const response = await client.api.project[":projectId"].$get(
+    const response = await client.api.orgs[":organizationSlug"].projects[":projectId"].$get(
       {
-        param: { projectId: createdBody.project.id },
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: createdBody.project.id,
+        },
       },
       {
         headers: await authHeadersFor(identity),
@@ -211,9 +213,12 @@ describe("projectRoutes", () => {
     const createdResponse = await createProjectViaApi(identity);
     const createdBody = (await createdResponse.json()) as ProjectResponse;
 
-    const response = await client.api.project[":projectId"].$patch(
+    const response = await client.api.orgs[":organizationSlug"].projects[":projectId"].$patch(
       {
-        param: { projectId: createdBody.project.id },
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: createdBody.project.id,
+        },
         json: {
           name: "Docs v2",
         },
@@ -235,9 +240,12 @@ describe("projectRoutes", () => {
     const createdResponse = await createProjectViaApi(identity);
     const createdBody = (await createdResponse.json()) as ProjectResponse;
 
-    const emptyResponse = await client.api.project[":projectId"].$patch(
+    const emptyResponse = await client.api.orgs[":organizationSlug"].projects[":projectId"].$patch(
       {
-        param: { projectId: createdBody.project.id },
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: createdBody.project.id,
+        },
         json: {},
       },
       {
@@ -252,9 +260,14 @@ describe("projectRoutes", () => {
       message: expect.any(String),
     });
 
-    const invalidNameResponse = await client.api.project[":projectId"].$patch(
+    const invalidNameResponse = await client.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].$patch(
       {
-        param: { projectId: createdBody.project.id },
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: createdBody.project.id,
+        },
         json: {
           name: "   ",
         },
@@ -278,9 +291,12 @@ describe("projectRoutes", () => {
     const createdBody = (await createdResponse.json()) as ProjectResponse;
 
     const otherIdentity = createWorkosIdentity();
-    const response = await client.api.project[":projectId"].$get(
+    const response = await client.api.orgs[":organizationSlug"].projects[":projectId"].$get(
       {
-        param: { projectId: createdBody.project.id },
+        param: {
+          organizationSlug: ownerIdentity.organization.slug ?? "missing-slug",
+          projectId: createdBody.project.id,
+        },
       },
       {
         headers: await authHeadersFor(otherIdentity),
@@ -298,9 +314,12 @@ describe("projectRoutes", () => {
     const createdBody = (await createdResponse.json()) as ProjectResponse;
 
     const otherIdentity = createWorkosIdentity();
-    const response = await client.api.project[":projectId"].$patch(
+    const response = await client.api.orgs[":organizationSlug"].projects[":projectId"].$patch(
       {
-        param: { projectId: createdBody.project.id },
+        param: {
+          organizationSlug: ownerIdentity.organization.slug ?? "missing-slug",
+          projectId: createdBody.project.id,
+        },
         json: {
           name: "Should Not Apply",
         },
@@ -321,9 +340,12 @@ describe("projectRoutes", () => {
     const createdBody = (await createdResponse.json()) as ProjectResponse;
 
     const memberIdentity = createWorkosIdentityWithRole("member");
-    const response = await client.api.project[":projectId"].$patch(
+    const response = await client.api.orgs[":organizationSlug"].projects[":projectId"].$patch(
       {
-        param: { projectId: createdBody.project.id },
+        param: {
+          organizationSlug: ownerIdentity.organization.slug ?? "missing-slug",
+          projectId: createdBody.project.id,
+        },
         json: {
           name: "Should Not Apply",
         },
@@ -340,9 +362,12 @@ describe("projectRoutes", () => {
 
   it("returns 404 when a project does not exist", async () => {
     const identity = createWorkosIdentity();
-    const response = await client.api.project[":projectId"].$get(
+    const response = await client.api.orgs[":organizationSlug"].projects[":projectId"].$get(
       {
-        param: { projectId: `project_missing_${randomUUID()}` },
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: `project_missing_${randomUUID()}`,
+        },
       },
       {
         headers: await authHeadersFor(identity),
@@ -359,9 +384,12 @@ describe("projectRoutes", () => {
     const createdResponse = await createProjectViaApi(identity);
     const createdBody = (await createdResponse.json()) as ProjectResponse;
 
-    const response = await client.api.project[":projectId"].$delete(
+    const response = await client.api.orgs[":organizationSlug"].projects[":projectId"].$delete(
       {
-        param: { projectId: createdBody.project.id },
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: createdBody.project.id,
+        },
       },
       {
         headers: await authHeadersFor(identity),
@@ -370,9 +398,12 @@ describe("projectRoutes", () => {
 
     expect(response.status).toBe(204);
 
-    const fetchResponse = await client.api.project[":projectId"].$get(
+    const fetchResponse = await client.api.orgs[":organizationSlug"].projects[":projectId"].$get(
       {
-        param: { projectId: createdBody.project.id },
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: createdBody.project.id,
+        },
       },
       {
         headers: await authHeadersFor(identity),
@@ -388,9 +419,12 @@ describe("projectRoutes", () => {
     const createdBody = (await createdResponse.json()) as ProjectResponse;
 
     const otherIdentity = createWorkosIdentity();
-    const response = await client.api.project[":projectId"].$delete(
+    const response = await client.api.orgs[":organizationSlug"].projects[":projectId"].$delete(
       {
-        param: { projectId: createdBody.project.id },
+        param: {
+          organizationSlug: ownerIdentity.organization.slug ?? "missing-slug",
+          projectId: createdBody.project.id,
+        },
       },
       {
         headers: await authHeadersFor(otherIdentity),
@@ -401,9 +435,12 @@ describe("projectRoutes", () => {
     const responseBody = await response.json();
     expect(responseBody).toMatchObject({ error: "project_not_found", message: expect.any(String) });
 
-    const fetchResponse = await client.api.project[":projectId"].$get(
+    const fetchResponse = await client.api.orgs[":organizationSlug"].projects[":projectId"].$get(
       {
-        param: { projectId: createdBody.project.id },
+        param: {
+          organizationSlug: ownerIdentity.organization.slug ?? "missing-slug",
+          projectId: createdBody.project.id,
+        },
       },
       {
         headers: await authHeadersFor(ownerIdentity),
@@ -415,9 +452,12 @@ describe("projectRoutes", () => {
 
   it("returns 404 when deleting a project that does not exist", async () => {
     const identity = createWorkosIdentity();
-    const response = await client.api.project[":projectId"].$delete(
+    const response = await client.api.orgs[":organizationSlug"].projects[":projectId"].$delete(
       {
-        param: { projectId: `project_missing_${randomUUID()}` },
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: `project_missing_${randomUUID()}`,
+        },
       },
       {
         headers: await authHeadersFor(identity),
@@ -435,9 +475,12 @@ describe("projectRoutes", () => {
     const createdBody = (await createdResponse.json()) as ProjectResponse;
 
     const memberIdentity = createWorkosIdentityWithRole("member");
-    const response = await client.api.project[":projectId"].$delete(
+    const response = await client.api.orgs[":organizationSlug"].projects[":projectId"].$delete(
       {
-        param: { projectId: createdBody.project.id },
+        param: {
+          organizationSlug: ownerIdentity.organization.slug ?? "missing-slug",
+          projectId: createdBody.project.id,
+        },
       },
       {
         headers: await authHeadersFor(memberIdentity),


### PR DESCRIPTION
### Motivation
- The legacy unauthenticated app routes mounted at `/api/glossary`, `/api/memory`, and `/api/project` created ambiguous default-organization behavior and made org access boundaries implicit instead of explicit.
- The API should use org-scoped routes under `/api/orgs/:organizationSlug/*` as the canonical authenticated workspace surface to prevent accidental cross-org access.

### Description
- Removed mounting of legacy non-org-scoped app routes from `apps/hyperlocalise-web/src/api/app.ts` (deleted the legacy route group and stopped mounting `/glossary`, `/memory`, and `/project` at the root API path). 
- Kept and retained the org-scoped route group under `/api/orgs/:organizationSlug` as the canonical authenticated API surface. 
- Updated test fixtures to create resources via org-scoped endpoints by switching calls to `client.api.orgs[":organizationSlug"].glossaries`, `client.api.orgs[":organizationSlug"]["translation-memories"]`, and `client.api.orgs[":organizationSlug"].projects` in:
  - `apps/hyperlocalise-web/src/api/routes/glossary/glossary.fixture.ts`
  - `apps/hyperlocalise-web/src/api/routes/memory/memory.fixture.ts`
  - `apps/hyperlocalise-web/src/api/routes/project/project.fixture.ts`

### Testing
- Attempted `make bootstrap`, which failed in this environment due to Go module verification against `proxy.golang.org` returning `Forbidden` so dependencies were not installed. 
- Attempted `vp check --fix` and `vp test` but the `vp` CLI is not available in this environment so frontend checks/tests could not be run. 
- Code changes were committed locally (`refactor(api): drop legacy non-org app route mounting`) and a PR record was created; no automated test suite ran to completion in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12b58c954c832c86c007e7e123f604)