### PR TITLE
🧪 Scout: fix po parser multiline leak

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -19,3 +19,7 @@
 ## 2025-05-22 - [Unicode Placeholder Support]
 **Learning:** ICU and mustache-style placeholders were restricted to ASCII letters, causing validation failures for non-Latin scripts or mathematical symbols (e.g., {π}).
 **Action:** Use `unicode.IsLetter` in placeholder validation helpers to ensure broad script support while maintaining structural integrity.
+
+## 2025-05-23 - [PO Parser Multiline State Management]
+**Learning:** The PO file parser's state management using `activeField` can lead to data leakage if not explicitly reset when encountering ignored fields (like `msgid_plural` or non-zero `msgstr[N]`). Continuation lines (quoted strings on new lines) rely on `activeField` to determine which buffer to append to; if `activeField` remains set to a previous valid field (e.g., `msgid`), the continuation from an ignored field will be incorrectly appended to it.
+**Action:** Always reset `activeField` to an empty string when skipping fields that may have multiline continuations to ensure subsequent lines are correctly ignored.

--- a/internal/i18n/translationfileparser/po_parser.go
+++ b/internal/i18n/translationfileparser/po_parser.go
@@ -75,6 +75,9 @@ func consumePOLine(
 		return handlePOMsgStr(lineNumber, strings.TrimPrefix(line, "msgstr "), currentMsgStr, activeField, seenMsgStr)
 	case strings.HasPrefix(line, "msgstr["):
 		return handlePOIndexedMsgStr(lineNumber, line, currentMsgStr, activeField, seenMsgStr)
+	case strings.HasPrefix(line, "msgid_plural "):
+		*activeField = ""
+		return nil
 	case strings.HasPrefix(line, "msgctxt "):
 		// Context is currently ignored by the map[string]string strategy output.
 		*activeField = ""
@@ -112,6 +115,7 @@ func handlePOMsgStr(lineNumber int, raw string, currentMsgStr *strings.Builder, 
 
 func handlePOIndexedMsgStr(lineNumber int, line string, currentMsgStr *strings.Builder, activeField *string, seenMsgStr *bool) error {
 	if !strings.HasPrefix(line, "msgstr[0]") {
+		*activeField = ""
 		return nil
 	}
 	idx := strings.Index(line, "]")

--- a/internal/i18n/translationfileparser/po_parser_test.go
+++ b/internal/i18n/translationfileparser/po_parser_test.go
@@ -61,3 +61,55 @@ msgstr "Accueil hero"
 		t.Fatalf("expected last msgid variant to win, got %+v", got)
 	}
 }
+
+func TestPOParserIndexedMsgStrContinuation(t *testing.T) {
+	content := []byte(`msgid "plural"
+msgid_plural "plurals"
+msgstr[0] "singular"
+" continuation"
+msgstr[1] "plural"
+" should be ignored"
+`)
+
+	got, err := (POFileParser{}).Parse(content)
+	if err != nil {
+		t.Fatalf("parse po: %v", err)
+	}
+
+	val, ok := got["plural"]
+	if !ok {
+		t.Fatalf("expected key 'plural' to exist")
+	}
+
+	expected := "singular continuation"
+	if val != expected {
+		t.Errorf("expected %q, got %q. If it contains 'should be ignored', then msgstr[1] continuation leaked into msgstr[0]", expected, val)
+	}
+}
+
+func TestPOParserMsgidPluralContinuation(t *testing.T) {
+	content := []byte(`msgid "singular"
+msgid_plural "plural"
+" continuation"
+msgstr "singular value"
+`)
+
+	got, err := (POFileParser{}).Parse(content)
+	if err != nil {
+		t.Fatalf("parse po: %v", err)
+	}
+
+	val, ok := got["singular"]
+	if !ok {
+		for k := range got {
+			if k == "singular continuation" {
+				t.Errorf("bug: msgid_plural continuation was appended to msgid")
+				return
+			}
+		}
+		t.Fatalf("expected key 'singular' to exist, got %v", got)
+	}
+	if val != "singular value" {
+		t.Errorf("expected 'singular value', got %q", val)
+	}
+}

--- a/internal/i18n/translationfileparser/po_parser_test.go
+++ b/internal/i18n/translationfileparser/po_parser_test.go
@@ -1,6 +1,7 @@
 package translationfileparser
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -39,6 +40,67 @@ msgstr[1] "items"
 	}
 }
 
+func TestPOParserMultilineContinuations(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected map[string]string
+	}{
+		{
+			name: "msgid_plural continuation does not leak into msgid",
+			content: `msgid "key"
+msgid_plural "plural"
+" continuation"
+msgstr "value"`,
+			expected: map[string]string{"key": "value"},
+		},
+		{
+			name: "msgstr[N] continuation does not leak into msgstr[0]",
+			content: `msgid "key"
+msgid_plural "plural"
+msgstr[0] "value0"
+" continuation0"
+msgstr[1] "value1"
+" continuation1"`,
+			expected: map[string]string{"key": "value0 continuation0"},
+		},
+		{
+			name: "msgctxt continuation does not leak into following fields",
+			content: `msgctxt "context"
+" continuation"
+msgid "key"
+msgstr "value"`,
+			expected: map[string]string{"key": "value"},
+		},
+		{
+			name: "multiple entries with continuations",
+			content: `msgid "key1"
+msgstr "value1"
+" continuation1"
+
+msgid "key2"
+msgstr "value2"
+" continuation2"`,
+			expected: map[string]string{
+				"key1": "value1 continuation1",
+				"key2": "value2 continuation2",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := (POFileParser{}).Parse([]byte(tt.content))
+			if err != nil {
+				t.Fatalf("Parse() error = %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("got %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestPOParserMsgctxtWithDuplicateMsgidCollidesByMsgid(t *testing.T) {
 	content := []byte(`msgctxt "nav"
 msgid "home"
@@ -59,57 +121,5 @@ msgstr "Accueil hero"
 	}
 	if got["home"] != "Accueil hero" {
 		t.Fatalf("expected last msgid variant to win, got %+v", got)
-	}
-}
-
-func TestPOParserIndexedMsgStrContinuation(t *testing.T) {
-	content := []byte(`msgid "plural"
-msgid_plural "plurals"
-msgstr[0] "singular"
-" continuation"
-msgstr[1] "plural"
-" should be ignored"
-`)
-
-	got, err := (POFileParser{}).Parse(content)
-	if err != nil {
-		t.Fatalf("parse po: %v", err)
-	}
-
-	val, ok := got["plural"]
-	if !ok {
-		t.Fatalf("expected key 'plural' to exist")
-	}
-
-	expected := "singular continuation"
-	if val != expected {
-		t.Errorf("expected %q, got %q. If it contains 'should be ignored', then msgstr[1] continuation leaked into msgstr[0]", expected, val)
-	}
-}
-
-func TestPOParserMsgidPluralContinuation(t *testing.T) {
-	content := []byte(`msgid "singular"
-msgid_plural "plural"
-" continuation"
-msgstr "singular value"
-`)
-
-	got, err := (POFileParser{}).Parse(content)
-	if err != nil {
-		t.Fatalf("parse po: %v", err)
-	}
-
-	val, ok := got["singular"]
-	if !ok {
-		for k := range got {
-			if k == "singular continuation" {
-				t.Errorf("bug: msgid_plural continuation was appended to msgid")
-				return
-			}
-		}
-		t.Fatalf("expected key 'singular' to exist, got %v", got)
-	}
-	if val != "singular value" {
-		t.Errorf("expected 'singular value', got %q", val)
 	}
 }


### PR DESCRIPTION
💡 What: Fixed a state management bug in the PO file parser where continuation lines from ignored fields were leaking into previous valid fields.
🎯 Why: To prevent corrupted translation keys or values when parsing PO files with multiline plural definitions.
🧩 Scope: `internal/i18n/translationfileparser/po_parser.go` and its associated tests.
✅ Verification: Ran `go test ./internal/i18n/translationfileparser` and verified that the new regression tests pass.
🛡️ Confidence: High, the fix is targeted and verified with explicit regression tests.

---
*PR created automatically by Jules for task [17971231778299061479](https://jules.google.com/task/17971231778299061479) started by @cungminh2710*