### PR TITLE
fix(crowdin): improve task model parity and clean up ai/project models

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -77,3 +77,9 @@
 **Learning:** Using `fmt.Sprintf("%d", id)` in `Values()` methods for query parameter serialization causes unnecessary allocations in hot paths. Replacing it with `strconv.Itoa(id)` is more efficient. Additionally, several typos (e.g., `AIPromtsListOptions`, `configuraion`) and duplicate fields (`MaxExamplesCount`) were identified in the AI model.
 
 **Action:** Optimized `Values()` methods across all model files using `strconv.Itoa`. Fixed typos and removed duplicate fields in `model/ai.go`, propagating the corrected `AIPromptsListOptions` name throughout the fork. Corrected `ProjectsListResponse` documentation comment and removed redundant `Languages` field from `ProjectsAddRequest`. Verified with full test suite passing in the fork.
+
+## 2026-07-10 - Improve Task model parity and fix AI model comments/typos
+
+**Learning:** The Crowdin Tasks API v2 supports filtering by `labelIds` and `excludeLabelIds`, and Enterprise task creation supports `branchIds`. These were missing from the SDK models. Additionally, some comments in the AI model were inaccurate, and redundant fields like `Languages` in `ProjectsAddRequest` (replaced by `TargetLanguageIDs`) should be removed to avoid confusion.
+
+**Action:** Added `LabelIDs` and `ExcludeLabelIDs` to `TasksListOptions` and updated `Values()` for correct query parameter encoding. Added `BranchIDs` to Enterprise task creation forms and updated `ValidateRequest` to include them. Corrected documentation comments and fixed a loop typo in the AI service. Removed redundant `Languages` field from `ProjectsAddRequest`. Verified with new unit tests and full test suite passing.

--- a/third_party/crowdin-api-client-go/crowdin/ai.go
+++ b/third_party/crowdin-api-client-go/crowdin/ai.go
@@ -126,8 +126,8 @@ func (s *AIService) ListPrompts(ctx context.Context, userID int, opt *model.AIPr
 	}
 
 	list := make([]*model.Prompt, 0, len(res.Data))
-	for _, promt := range res.Data {
-		list = append(list, promt.Data)
+	for _, prompt := range res.Data {
+		list = append(list, prompt.Data)
 	}
 
 	return list, resp, err

--- a/third_party/crowdin-api-client-go/crowdin/model/ai.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/ai.go
@@ -300,7 +300,7 @@ type PromptsListResponse struct {
 // AIPromptsListOptions specifies the optional parameters to the
 // AIService.ListPrompts method.
 type AIPromptsListOptions struct {
-	// Allows to filter the prompts available for the specific action.
+	// Filter the prompts available for the specific project.
 	ProjectID int `json:"projectId,omitempty"`
 	// Allows to filter the prompts available for the specific action.
 	// Enum: pre_translate, assist.

--- a/third_party/crowdin-api-client-go/crowdin/model/projects.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/projects.go
@@ -341,8 +341,6 @@ type ProjectsAddRequest struct {
 	MTID int `json:"mtId,omitempty"`
 	// Fields.
 	Fields map[string]any `json:"fields,omitempty"`
-	// Target Languages Identifiers.
-	Languages []string `json:"languages,omitempty"`
 }
 
 // LanguageMapping represents a project language mapping.

--- a/third_party/crowdin-api-client-go/crowdin/model/tasks.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/tasks.go
@@ -111,6 +111,10 @@ type TasksListOptions struct {
 	AssigneeID int `json:"assigneeId,omitempty"`
 	// List tasks for specified workflow step.
 	WorkflowStepID int `json:"workflowStepId,omitempty"`
+	// Filter tasks by labelIds.
+	LabelIDs []int `json:"labelIds,omitempty"`
+	// Filter tasks by excludeLabelIds.
+	ExcludeLabelIDs []int `json:"excludeLabelIds,omitempty"`
 
 	ListOptions
 }
@@ -135,6 +139,12 @@ func (o *TasksListOptions) Values() (url.Values, bool) {
 	}
 	if o.WorkflowStepID > 0 {
 		v.Add("workflowStepId", strconv.Itoa(o.WorkflowStepID))
+	}
+	if len(o.LabelIDs) > 0 {
+		v.Add("labelIds", JoinSlice(o.LabelIDs))
+	}
+	if len(o.ExcludeLabelIDs) > 0 {
+		v.Add("excludeLabelIds", JoinSlice(o.ExcludeLabelIDs))
 	}
 
 	return v, len(v) > 0
@@ -499,6 +509,9 @@ type (
 		// Task workflow step id.
 		// Note: Can't be used with `type` in same request.
 		WorkflowStepID int `json:"workflowStepId,omitempty"`
+		// Branch identifiers.
+		// One of branchIds, stringIds or fileIds is required.
+		BranchIDs []int `json:"branchIds,omitempty"`
 		// Task title
 		Title string `json:"title"`
 		// Task language identifier.
@@ -550,6 +563,9 @@ type (
 	EnterpriseVendorTaskCreateForm struct {
 		// Task workflow step id with type `Translate by Vendor` or `Proofread by Vendor`.
 		WorkflowStepID int `json:"workflowStepId"`
+		// Branch identifiers.
+		// One of branchIds, stringIds or fileIds is required.
+		BranchIDs []int `json:"branchIds,omitempty"`
 		// Task title.
 		Title string `json:"title"`
 		// Language identifier.
@@ -855,8 +871,8 @@ func (r *EnterpriseTaskCreateForm) ValidateRequest() error {
 	if r.LanguageID == "" {
 		return errors.New("languageId is required")
 	}
-	if len(r.StringIDs) == 0 && len(r.FileIDs) == 0 {
-		return errors.New("one of stringIds or fileIds is required")
+	if len(r.StringIDs) == 0 && len(r.FileIDs) == 0 && len(r.BranchIDs) == 0 {
+		return errors.New("one of stringIds, fileIds or branchIds is required")
 	}
 
 	return nil
@@ -882,8 +898,8 @@ func (r *EnterpriseVendorTaskCreateForm) ValidateRequest() error {
 	if r.LanguageID == "" {
 		return errors.New("languageId is required")
 	}
-	if len(r.StringIDs) == 0 && len(r.FileIDs) == 0 {
-		return errors.New("one of stringIds or fileIds is required")
+	if len(r.StringIDs) == 0 && len(r.FileIDs) == 0 && len(r.BranchIDs) == 0 {
+		return errors.New("one of stringIds, fileIds or branchIds is required")
 	}
 
 	return nil

--- a/third_party/crowdin-api-client-go/crowdin/model/tasks_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/tasks_test.go
@@ -25,8 +25,9 @@ func TestTasksListOptionsValues(t *testing.T) {
 			opts: &TasksListOptions{
 				OrderBy: "createdAt desc,name", Status: []TaskStatus{TaskStatusTodo, TaskStatusDone},
 				AssigneeID: 1, ListOptions: ListOptions{Limit: 10, Offset: 5},
+				LabelIDs: []int{1, 2}, ExcludeLabelIDs: []int{3, 4},
 			},
-			out: "assigneeId=1&limit=10&offset=5&orderBy=createdAt+desc%2Cname&status=todo%2Cdone",
+			out: "assigneeId=1&excludeLabelIds=3%2C4&labelIds=1%2C2&limit=10&offset=5&orderBy=createdAt+desc%2Cname&status=todo%2Cdone",
 		},
 	}
 
@@ -654,9 +655,19 @@ func TestEnterpriseTaskCreateFormValidate(t *testing.T) {
 			err:  "languageId is required",
 		},
 		{
-			name: "stringIds or fileIds is required",
+			name: "stringIds, fileIds or branchIds is required",
 			req:  &EnterpriseTaskCreateForm{WorkflowStepID: 1, Title: "French", LanguageID: "en"},
-			err:  "one of stringIds or fileIds is required",
+			err:  "one of stringIds, fileIds or branchIds is required",
+		},
+		{
+			name: "valid data validation with branchIds",
+			req: &EnterpriseTaskCreateForm{
+				WorkflowStepID: 1,
+				Title:          "French",
+				LanguageID:     "en",
+				BranchIDs:      []int{1, 2},
+			},
+			valid: true,
 		},
 		{
 			name: "valid data validation",
@@ -715,9 +726,19 @@ func TestEnterpriseVendorTaskCreateFormValidate(t *testing.T) {
 			err:  "languageId is required",
 		},
 		{
-			name: "stringIds or fileIds is required",
+			name: "stringIds, fileIds or branchIds is required",
 			req:  &EnterpriseVendorTaskCreateForm{WorkflowStepID: 1, Title: "French", LanguageID: "en"},
-			err:  "one of stringIds or fileIds is required",
+			err:  "one of stringIds, fileIds or branchIds is required",
+		},
+		{
+			name: "valid data validation with branchIds",
+			req: &EnterpriseVendorTaskCreateForm{
+				WorkflowStepID: 1,
+				Title:          "French",
+				LanguageID:     "en",
+				BranchIDs:      []int{1, 2},
+			},
+			valid: true,
 		},
 		{
 			name: "valid data validation",


### PR DESCRIPTION
- What: Improved Tasks API parity by adding label filters and branch ID support for Enterprise tasks. Cleaned up redundant fields in Projects and minor typos/comments in AI models.
- Why: To align the Crowdin Go SDK more closely with the official API v2 contract and improve developer experience.
- Docs: https://developer.crowdin.com/api/v2/#tag/Tasks
- Scope: `third_party/crowdin-api-client-go/crowdin/model/tasks.go`, `third_party/crowdin-api-client-go/crowdin/model/ai.go`, `third_party/crowdin-api-client-go/crowdin/model/projects.go`, `third_party/crowdin-api-client-go/crowdin/ai.go`
- Tests: Added new unit tests in `tasks_test.go` and verified the full suite passes with `GOWORK=off go test ./crowdin/...`.
- Confidence: High. Changes are well-tested and align with documented API behaviors.

---
*PR created automatically by Jules for task [15985465174490006429](https://jules.google.com/task/15985465174490006429) started by @cungminh2710*