### PR TITLE
🎨 Palette: Standardize TooltipTrigger pattern and improve Artifact accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-05-13 - [Accessible Icon Buttons with Dynamic Feedback]
 **Learning:** For icon-only buttons that trigger an action (like copying text), providing dynamic feedback in both the tooltip and `aria-label` (e.g., changing from "Copy" to "Copied!") is essential for a great UX. When using `@base-ui/react` tooltips, use the `render` prop on `TooltipTrigger` to avoid rendering a nested `<button>` inside a `<button>`, which is invalid HTML and breaks screen reader behavior.
 **Action:** Always use `<TooltipTrigger render={<Button ... />}>` for accessible icon buttons and synchronize the dynamic feedback between the tooltip content and the button's `aria-label`.
+
+## 2026-05-24 - [Tooltip Content and Prop Forwarding]
+**Learning:** Tooltip content in this design system should avoid block-level typography components (like `TypographyP`) to prevent excessive line-height; plain text or inline elements are preferred for compact tooltips. Additionally, when using the `render` prop on `TooltipTrigger` for icon-only buttons, the icons and screen-reader only text must be nested *inside* the component being rendered (e.g., `<TooltipTrigger render={<Button>...</Button>} />`) to ensure proper event delegation and accessibility prop forwarding.
+**Action:** Use plain text for tooltips and ensure all button children are placed inside the `render` prop's component when wrapping with a `TooltipTrigger`.

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/chat/_components/chat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/chat/_components/chat-page-content.tsx
@@ -260,13 +260,13 @@ export function ChatPageContent({ organizationSlug }: { organizationSlug: string
                             size="icon-sm"
                             className="rounded-full text-muted-foreground hover:bg-accent/20 hover:text-foreground"
                             aria-label="Add translation context"
-                          />
+                          >
+                            <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} className="size-4" />
+                          </Button>
                         }
                       />
                     }
-                  >
-                    <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} className="size-4" />
-                  </TooltipTrigger>
+                  />
                   <TooltipContent>Add translation context</TooltipContent>
                 </Tooltip>
                 <DropdownMenuContent className="min-w-52" align="start">
@@ -367,16 +367,16 @@ export function ChatPageContent({ organizationSlug }: { organizationSlug: string
                       disabled={!canSubmit}
                       className="rounded-full bg-primary text-primary-foreground hover:bg-primary/90"
                       aria-label="Send translation request"
-                    />
+                    >
+                      {chatRequestMutation.isPending ? (
+                        <Spinner className="text-primary-foreground" />
+                      ) : (
+                        <HugeiconsIcon icon={SentIcon} strokeWidth={2} />
+                      )}
+                      Send
+                    </Button>
                   }
-                >
-                  {chatRequestMutation.isPending ? (
-                    <Spinner className="text-primary-foreground" />
-                  ) : (
-                    <HugeiconsIcon icon={SentIcon} strokeWidth={2} />
-                  )}
-                  Send
-                </TooltipTrigger>
+                />
                 <TooltipContent side="top" align="end">
                   Send request
                   <Kbd className="ms-2 bg-background/15 text-background">Enter</Kbd>

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-list.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-list.tsx
@@ -56,11 +56,11 @@ export const InboxList = memo(function InboxList({
                   size="icon-sm"
                   className="text-muted-foreground hover:bg-accent hover:text-foreground"
                   aria-label="Filter inbox"
-                />
+                >
+                  <HugeiconsIcon icon={FilterMailIcon} strokeWidth={1.8} className="size-4" />
+                </Button>
               }
-            >
-              <HugeiconsIcon icon={FilterMailIcon} strokeWidth={1.8} className="size-4" />
-            </TooltipTrigger>
+            />
             <TooltipContent side="bottom">Filter inbox</TooltipContent>
           </Tooltip>
           <Tooltip>
@@ -72,11 +72,15 @@ export const InboxList = memo(function InboxList({
                   size="icon-sm"
                   className="text-muted-foreground hover:bg-accent hover:text-foreground"
                   aria-label="Inbox display settings"
-                />
+                >
+                  <HugeiconsIcon
+                    icon={PreferenceHorizontalIcon}
+                    strokeWidth={1.8}
+                    className="size-4"
+                  />
+                </Button>
               }
-            >
-              <HugeiconsIcon icon={PreferenceHorizontalIcon} strokeWidth={1.8} className="size-4" />
-            </TooltipTrigger>
+            />
             <TooltipContent side="bottom">Inbox display settings</TooltipContent>
           </Tooltip>
         </div>

--- a/apps/hyperlocalise-web/src/components/ai-elements/artifact.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/artifact.tsx
@@ -47,12 +47,12 @@ export const ArtifactClose = ({
           type="button"
           variant={variant}
           {...props}
-        />
+        >
+          {children ?? <XIcon className="size-4" />}
+          <span className="sr-only">Close</span>
+        </Button>
       }
-    >
-      {children ?? <XIcon className="size-4" />}
-      <span className="sr-only">Close</span>
-    </TooltipTrigger>
+    />
     <TooltipContent>Close</TooltipContent>
   </Tooltip>
 );
@@ -107,12 +107,12 @@ export const ArtifactAction = ({
               type="button"
               variant={variant}
               {...props}
-            />
+            >
+              {Icon ? <Icon className="size-4" /> : children}
+              <span className="sr-only">{label || tooltip}</span>
+            </Button>
           }
-        >
-          {Icon ? <Icon className="size-4" /> : children}
-          <span className="sr-only">{label || tooltip}</span>
-        </TooltipTrigger>
+        />
         <TooltipContent>{tooltip}</TooltipContent>
       </Tooltip>
     );

--- a/apps/hyperlocalise-web/src/components/ai-elements/artifact.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/artifact.tsx
@@ -38,16 +38,23 @@ export const ArtifactClose = ({
   variant = "ghost",
   ...props
 }: ArtifactCloseProps) => (
-  <Button
-    className={cn("size-8 p-0 text-muted-foreground hover:text-foreground", className)}
-    size={size}
-    type="button"
-    variant={variant}
-    {...props}
-  >
-    {children ?? <XIcon className="size-4" />}
-    <span className="sr-only">Close</span>
-  </Button>
+  <Tooltip>
+    <TooltipTrigger
+      render={
+        <Button
+          className={cn("size-8 p-0 text-muted-foreground hover:text-foreground", className)}
+          size={size}
+          type="button"
+          variant={variant}
+          {...props}
+        />
+      }
+    >
+      {children ?? <XIcon className="size-4" />}
+      <span className="sr-only">Close</span>
+    </TooltipTrigger>
+    <TooltipContent>Close</TooltipContent>
+  </Tooltip>
 );
 
 export type ArtifactTitleProps = HTMLAttributes<HTMLParagraphElement>;
@@ -89,7 +96,29 @@ export const ArtifactAction = ({
    * RootLayout already provides a TooltipProvider. Local providers add
    * unnecessary React context overhead and can lead to desynced timers.
    */
-  const button = (
+  if (tooltip) {
+    return (
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <Button
+              className={cn("size-8 p-0 text-muted-foreground hover:text-foreground", className)}
+              size={size}
+              type="button"
+              variant={variant}
+              {...props}
+            />
+          }
+        >
+          {Icon ? <Icon className="size-4" /> : children}
+          <span className="sr-only">{label || tooltip}</span>
+        </TooltipTrigger>
+        <TooltipContent>{tooltip}</TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  return (
     <Button
       className={cn("size-8 p-0 text-muted-foreground hover:text-foreground", className)}
       size={size}
@@ -101,19 +130,6 @@ export const ArtifactAction = ({
       <span className="sr-only">{label || tooltip}</span>
     </Button>
   );
-
-  if (tooltip) {
-    return (
-      <Tooltip>
-        <TooltipTrigger>{button}</TooltipTrigger>
-        <TooltipContent>
-          <TypographyP>{tooltip}</TypographyP>
-        </TooltipContent>
-      </Tooltip>
-    );
-  }
-
-  return button;
 };
 
 export type ArtifactContentProps = HTMLAttributes<HTMLDivElement>;

--- a/apps/hyperlocalise-web/src/components/ai-elements/environment-variables.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/environment-variables.tsx
@@ -297,11 +297,11 @@ export const EnvironmentVariableCopyButton = ({
             size="icon"
             variant="ghost"
             {...props}
-          />
+          >
+            {children ?? <Icon size={12} />}
+          </Button>
         }
-      >
-        {children ?? <Icon size={12} />}
-      </TooltipTrigger>
+      />
       <TooltipContent>{tooltipText}</TooltipContent>
     </Tooltip>
   );

--- a/apps/hyperlocalise-web/src/components/ai-elements/stack-trace.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/stack-trace.tsx
@@ -340,11 +340,11 @@ export const StackTraceCopyButton = memo(
               size="icon"
               variant="ghost"
               {...props}
-            />
+            >
+              {children ?? <Icon size={14} />}
+            </Button>
           }
-        >
-          {children ?? <Icon size={14} />}
-        </TooltipTrigger>
+        />
         <TooltipContent>{tooltipText}</TooltipContent>
       </Tooltip>
     );

--- a/apps/hyperlocalise-web/src/components/theme-toggle.tsx
+++ b/apps/hyperlocalise-web/src/components/theme-toggle.tsx
@@ -52,13 +52,15 @@ export function ThemeToggle() {
         <TooltipTrigger
           render={
             <DropdownMenuTrigger
-              render={<Button variant="outline" size="icon-sm" className="rounded-full" />}
+              render={
+                <Button variant="outline" size="icon-sm" className="rounded-full">
+                  <ThemeToggleIcon theme={triggerTheme} />
+                  <span className="sr-only">Change theme</span>
+                </Button>
+              }
             />
           }
-        >
-          <ThemeToggleIcon theme={triggerTheme} />
-          <span className="sr-only">Change theme</span>
-        </TooltipTrigger>
+        />
         <TooltipContent side="bottom" align="center">
           Change theme
         </TooltipContent>


### PR DESCRIPTION
💡 What: Standardized the `TooltipTrigger` pattern across several core UI components and added missing accessibility features.

🎯 Why: To ensure proper accessibility (a11y) relationships and event delegation, and to provide better discoverability for icon-only actions.

♿ Accessibility:
- Fixed `TooltipTrigger` usage to avoid double-wrapping of buttons.
- Ensured icons and `sr-only` text are nested within the interactive button.
- Added a "Close" tooltip to the Artifact close button.
- Improved tooltip styling by removing excessive line-height from paragraph tags.

---
*PR created automatically by Jules for task [2475359199670488174](https://jules.google.com/task/2475359199670488174) started by @cungminh2710*