### PR TITLE
🛡️ Sentinel: Add string length limits to QA and automation schemas

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/job-qa.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job-qa.schema.ts
@@ -6,16 +6,16 @@ import {
 } from "@/lib/providers/provider-job-qa/types";
 
 export const providerQaItemReferenceSchema = z.object({
-  externalStringId: z.string().max(128),
-  key: z.string().max(512),
-  locale: z.string().max(32).optional(),
+  externalStringId: z.string().trim().min(1).max(128),
+  key: z.string().trim().min(1).max(512),
+  locale: z.string().trim().min(1).max(32).optional(),
   field: z.enum(["source", "target"]).optional(),
 });
 
 export const providerQaFindingSchema = z.object({
   checkType: z.enum(providerQaCheckTypes),
   severity: z.enum(providerQaSeverityLevels),
-  message: z.string().max(2048),
+  message: z.string().trim().min(1).max(2048),
   suggestedFix: z.string().max(100_000).optional(),
   confidence: z.number().min(0).max(1).optional(),
   item: providerQaItemReferenceSchema,

--- a/apps/hyperlocalise-web/src/api/routes/project/job-qa.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job-qa.schema.ts
@@ -6,17 +6,17 @@ import {
 } from "@/lib/providers/provider-job-qa/types";
 
 export const providerQaItemReferenceSchema = z.object({
-  externalStringId: z.string(),
-  key: z.string(),
-  locale: z.string().optional(),
+  externalStringId: z.string().max(128),
+  key: z.string().max(512),
+  locale: z.string().max(32).optional(),
   field: z.enum(["source", "target"]).optional(),
 });
 
 export const providerQaFindingSchema = z.object({
   checkType: z.enum(providerQaCheckTypes),
   severity: z.enum(providerQaSeverityLevels),
-  message: z.string(),
-  suggestedFix: z.string().optional(),
+  message: z.string().max(2048),
+  suggestedFix: z.string().max(100_000).optional(),
   confidence: z.number().min(0).max(1).optional(),
   item: providerQaItemReferenceSchema,
 });

--- a/apps/hyperlocalise-web/src/api/routes/security-limits-identifiers.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/security-limits-identifiers.test.ts
@@ -142,10 +142,14 @@ describe("Identifier Schema length limits", () => {
     const item = { externalStringId: "v", key: "v" };
     const findings = (message: string, key = "v") => ({
       action: "run_qa_checks",
-      selectedFindings: [{ checkType: "glossary", severity: "error", message, item: { ...item, key } }],
+      selectedFindings: [
+        { checkType: "glossary", severity: "error", message, item: { ...item, key } },
+      ],
     });
     expect(createJobAgentRunBodySchema.safeParse(findings("a".repeat(2049))).success).toBe(false);
-    expect(createJobAgentRunBodySchema.safeParse(findings("v", "a".repeat(513))).success).toBe(false);
+    expect(createJobAgentRunBodySchema.safeParse(findings("v", "a".repeat(513))).success).toBe(
+      false,
+    );
     expect(createJobAgentRunBodySchema.safeParse(findings("")).success).toBe(false);
     expect(
       upsertTmsAgentAutomationSettingsBodySchema.safeParse({

--- a/apps/hyperlocalise-web/src/api/routes/security-limits-identifiers.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/security-limits-identifiers.test.ts
@@ -3,6 +3,8 @@ import {
   projectIdParamsSchema,
   externalTmsTranslationPushBodySchema,
 } from "./project/project.schema";
+import { createJobAgentRunBodySchema } from "./project/agent-run.schema";
+import { upsertTmsAgentAutomationSettingsBodySchema } from "./tms-agent-automation/tms-agent-automation.schema";
 import {
   jobProjectParamsSchema,
   jobParamsSchema,
@@ -134,5 +136,12 @@ describe("Identifier Schema length limits", () => {
         translations: [{ key: "k", locale: "en", text: "a".repeat(100_001) }],
       }).success,
     ).toBe(false);
+  });
+
+  it("should enforce max length on findings and locales", () => {
+    const item = { externalStringId: "v", key: "v" };
+    expect(createJobAgentRunBodySchema.safeParse({ action: "run_qa_checks", selectedFindings: [{ checkType: "glossary", severity: "error", message: "a".repeat(2049), item }] }).success).toBe(false);
+    expect(createJobAgentRunBodySchema.safeParse({ action: "run_qa_checks", selectedFindings: [{ checkType: "glossary", severity: "error", message: "v", item: { ...item, key: "a".repeat(513) } }] }).success).toBe(false);
+    expect(upsertTmsAgentAutomationSettingsBodySchema.safeParse({ settings: { autoDraftTranslations: { enabled: true, locales: ["a".repeat(33)] } } }).success).toBe(false);
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/security-limits-identifiers.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/security-limits-identifiers.test.ts
@@ -140,8 +140,31 @@ describe("Identifier Schema length limits", () => {
 
   it("should enforce max length on findings and locales", () => {
     const item = { externalStringId: "v", key: "v" };
-    expect(createJobAgentRunBodySchema.safeParse({ action: "run_qa_checks", selectedFindings: [{ checkType: "glossary", severity: "error", message: "a".repeat(2049), item }] }).success).toBe(false);
-    expect(createJobAgentRunBodySchema.safeParse({ action: "run_qa_checks", selectedFindings: [{ checkType: "glossary", severity: "error", message: "v", item: { ...item, key: "a".repeat(513) } }] }).success).toBe(false);
-    expect(upsertTmsAgentAutomationSettingsBodySchema.safeParse({ settings: { autoDraftTranslations: { enabled: true, locales: ["a".repeat(33)] } } }).success).toBe(false);
+    expect(
+      createJobAgentRunBodySchema.safeParse({
+        action: "run_qa_checks",
+        selectedFindings: [
+          { checkType: "glossary", severity: "error", message: "a".repeat(2049), item },
+        ],
+      }).success,
+    ).toBe(false);
+    expect(
+      createJobAgentRunBodySchema.safeParse({
+        action: "run_qa_checks",
+        selectedFindings: [
+          {
+            checkType: "glossary",
+            severity: "error",
+            message: "v",
+            item: { ...item, key: "a".repeat(513) },
+          },
+        ],
+      }).success,
+    ).toBe(false);
+    expect(
+      upsertTmsAgentAutomationSettingsBodySchema.safeParse({
+        settings: { autoDraftTranslations: { enabled: true, locales: ["a".repeat(33)] } },
+      }).success,
+    ).toBe(false);
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/security-limits-identifiers.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/security-limits-identifiers.test.ts
@@ -138,29 +138,15 @@ describe("Identifier Schema length limits", () => {
     ).toBe(false);
   });
 
-  it("should enforce max length on findings and locales", () => {
+  it("should enforce length limits on findings and locales", () => {
     const item = { externalStringId: "v", key: "v" };
-    expect(
-      createJobAgentRunBodySchema.safeParse({
-        action: "run_qa_checks",
-        selectedFindings: [
-          { checkType: "glossary", severity: "error", message: "a".repeat(2049), item },
-        ],
-      }).success,
-    ).toBe(false);
-    expect(
-      createJobAgentRunBodySchema.safeParse({
-        action: "run_qa_checks",
-        selectedFindings: [
-          {
-            checkType: "glossary",
-            severity: "error",
-            message: "v",
-            item: { ...item, key: "a".repeat(513) },
-          },
-        ],
-      }).success,
-    ).toBe(false);
+    const findings = (message: string, key = "v") => ({
+      action: "run_qa_checks",
+      selectedFindings: [{ checkType: "glossary", severity: "error", message, item: { ...item, key } }],
+    });
+    expect(createJobAgentRunBodySchema.safeParse(findings("a".repeat(2049))).success).toBe(false);
+    expect(createJobAgentRunBodySchema.safeParse(findings("v", "a".repeat(513))).success).toBe(false);
+    expect(createJobAgentRunBodySchema.safeParse(findings("")).success).toBe(false);
     expect(
       upsertTmsAgentAutomationSettingsBodySchema.safeParse({
         settings: { autoDraftTranslations: { enabled: true, locales: ["a".repeat(33)] } },

--- a/apps/hyperlocalise-web/src/api/routes/tms-agent-automation/tms-agent-automation.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/tms-agent-automation/tms-agent-automation.schema.ts
@@ -18,7 +18,7 @@ export const upsertTmsAgentAutomationSettingsBodySchema = z.object({
     autoDraftTranslations: z
       .object({
         enabled: z.boolean().optional(),
-        locales: z.array(z.string().max(32)).optional(),
+        locales: z.array(z.string().trim().min(1).max(32)).optional(),
       })
       .optional(),
     writeBack: z

--- a/apps/hyperlocalise-web/src/api/routes/tms-agent-automation/tms-agent-automation.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/tms-agent-automation/tms-agent-automation.schema.ts
@@ -18,7 +18,7 @@ export const upsertTmsAgentAutomationSettingsBodySchema = z.object({
     autoDraftTranslations: z
       .object({
         enabled: z.boolean().optional(),
-        locales: z.array(z.string()).optional(),
+        locales: z.array(z.string().max(32)).optional(),
       })
       .optional(),
     writeBack: z

--- a/apps/hyperlocalise-web/src/lib/providers/tms-agent-automation-settings.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-agent-automation-settings.ts
@@ -8,7 +8,7 @@ export const tmsAgentAutomationSettingsSchema = z.object({
   autoDraftTranslations: z
     .object({
       enabled: z.boolean().default(false),
-      locales: z.array(z.string().max(32)).default([]),
+      locales: z.array(z.string().trim().min(1).max(32)).default([]),
     })
     .default({ enabled: false, locales: [] }),
   writeBack: z
@@ -29,7 +29,7 @@ const tmsAgentAutomationSettingsPartialSchema = z.object({
   autoDraftTranslations: z
     .object({
       enabled: z.boolean().optional(),
-      locales: z.array(z.string().max(32)).optional(),
+      locales: z.array(z.string().trim().min(1).max(32)).optional(),
     })
     .optional(),
   writeBack: z

--- a/apps/hyperlocalise-web/src/lib/providers/tms-agent-automation-settings.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-agent-automation-settings.ts
@@ -8,7 +8,7 @@ export const tmsAgentAutomationSettingsSchema = z.object({
   autoDraftTranslations: z
     .object({
       enabled: z.boolean().default(false),
-      locales: z.array(z.string()).default([]),
+      locales: z.array(z.string().max(32)).default([]),
     })
     .default({ enabled: false, locales: [] }),
   writeBack: z
@@ -29,7 +29,7 @@ const tmsAgentAutomationSettingsPartialSchema = z.object({
   autoDraftTranslations: z
     .object({
       enabled: z.boolean().optional(),
-      locales: z.array(z.string()).optional(),
+      locales: z.array(z.string().max(32)).optional(),
     })
     .optional(),
   writeBack: z


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing string length limits in several API and configuration schemas.
🎯 Impact: Potential Denial of Service (DoS) or memory exhaustion if an attacker sends excessively large string payloads (e.g., in QA findings or locale lists).
🔧 Fix: Added `.max()` constraints to `providerQaItemReferenceSchema`, `providerQaFindingSchema`, and TMS automation settings schemas.
✅ Verification: Added unit tests in `security-limits-identifiers.test.ts` to ensure overly long inputs are rejected. Verified with `tsc` and existing tests.

---
*PR created automatically by Jules for task [8595593449005390307](https://jules.google.com/task/8595593449005390307) started by @cungminh2710*