### PR TITLE
fix(web): persist GitHub install and refresh agent card

### DIFF
--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/agent/_components/github-agent-card.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/agent/_components/github-agent-card.tsx
@@ -205,14 +205,15 @@ export function GitHubAgentCard({ organizationSlug }: GitHubAgentCardProps) {
 
     handledGithubConnectedRef.current = true;
 
+    const url = new URL(window.location.href);
+    url.searchParams.delete("github_connected");
+    window.history.replaceState(null, "", url.toString());
+
     void (async () => {
-      await queryClient.invalidateQueries({
-        queryKey: ["github-installation", organizationSlug],
-      });
+      await refetchInstallation();
       await queryClient.invalidateQueries({
         queryKey: ["github-installation-repositories", organizationSlug],
       });
-      await refetchInstallation();
       toast.success("GitHub App connected");
     })();
   }, [organizationSlug, queryClient, refetchInstallation, searchParams]);

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/agent/_components/github-agent-card.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/agent/_components/github-agent-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import { GitBranchIcon, GithubIcon, Refresh01Icon, Search01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -185,7 +186,36 @@ function useDisconnectInstallation(organizationSlug: string) {
 }
 
 export function GitHubAgentCard({ organizationSlug }: GitHubAgentCardProps) {
-  const { data: installation, isLoading } = useGitHubInstallation(organizationSlug);
+  const searchParams = useSearchParams();
+  const queryClient = useQueryClient();
+  const {
+    data: installation,
+    isLoading,
+    isError,
+    error,
+    refetch: refetchInstallation,
+  } = useGitHubInstallation(organizationSlug);
+
+  const handledGithubConnectedRef = useRef(false);
+
+  useEffect(() => {
+    if (searchParams.get("github_connected") !== "1" || handledGithubConnectedRef.current) {
+      return;
+    }
+
+    handledGithubConnectedRef.current = true;
+
+    void (async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ["github-installation", organizationSlug],
+      });
+      await queryClient.invalidateQueries({
+        queryKey: ["github-installation-repositories", organizationSlug],
+      });
+      await refetchInstallation();
+      toast.success("GitHub App connected");
+    })();
+  }, [organizationSlug, queryClient, refetchInstallation, searchParams]);
   const { data: repositories = [], isLoading: isLoadingRepositories } = useGitHubRepositories(
     organizationSlug,
     Boolean(installation),
@@ -289,6 +319,21 @@ export function GitHubAgentCard({ organizationSlug }: GitHubAgentCardProps) {
       <CardContent className="px-5 py-5 lg:px-6">
         {isLoading ? (
           <Skeleton className="h-10 bg-foreground/5" />
+        ) : isError ? (
+          <div className="flex flex-col gap-4">
+            <TypographyP className="text-sm text-red-300">
+              {error instanceof Error
+                ? error.message
+                : "Unable to load GitHub installation status right now."}
+            </TypographyP>
+            <Button
+              variant="outline"
+              className="w-fit border-foreground/10 bg-transparent text-foreground hover:bg-foreground/8"
+              onClick={() => void refetchInstallation()}
+            >
+              Retry
+            </Button>
+          </div>
         ) : installation ? (
           <div className="flex flex-col gap-5">
             <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">

--- a/apps/hyperlocalise-web/src/app/auth/github/callback/page.test.ts
+++ b/apps/hyperlocalise-web/src/app/auth/github/callback/page.test.ts
@@ -217,6 +217,40 @@ describe("GitHubCallbackPage", () => {
     expect(getGitHubAppMock).not.toHaveBeenCalled();
   });
 
+  it("rejects linking a GitHub installation already linked to another organization", async () => {
+    const { organization: linkedOrg } = await fixture.createStoredProjectFixture();
+    await db.insert(schema.githubInstallations).values({
+      organizationId: linkedOrg.id,
+      githubInstallationId: "123456",
+      githubAppId: "123",
+      accountLogin: "other-org",
+      accountType: "Organization",
+    });
+
+    const { auth, state } = await createCallbackState({ role: "admin" });
+
+    await expect(runCallback(state)).rejects.toThrow(
+      "redirect:/dashboard?error=github_installation_already_linked",
+    );
+
+    const [linkedInstallation] = await db
+      .select()
+      .from(schema.githubInstallations)
+      .where(eq(schema.githubInstallations.organizationId, linkedOrg.id))
+      .limit(1);
+    expect(linkedInstallation).toMatchObject({
+      githubInstallationId: "123456",
+      accountLogin: "other-org",
+    });
+
+    const conflictingInstallations = await db
+      .select()
+      .from(schema.githubInstallations)
+      .where(eq(schema.githubInstallations.organizationId, auth.organization.localOrganizationId));
+    expect(conflictingInstallations).toHaveLength(0);
+    expect(syncInstallationRepositoriesMock).not.toHaveBeenCalled();
+  });
+
   it("allows another org admin to complete an installation started by someone else", async () => {
     const { auth, state, slug } = await createCallbackState({ role: "owner" });
     const organization = globalThis.__testApiAuthContext?.organization;

--- a/apps/hyperlocalise-web/src/app/auth/github/callback/page.test.ts
+++ b/apps/hyperlocalise-web/src/app/auth/github/callback/page.test.ts
@@ -141,7 +141,7 @@ describe("GitHubCallbackPage", () => {
     const { auth, nonce, slug, state } = await createCallbackState({ role: "admin" });
 
     await expect(runCallback(state)).rejects.toThrow(
-      `redirect:/org/${slug}/settings?github_connected=1`,
+      `redirect:/org/${slug}/agent?github_connected=1`,
     );
 
     const [installation] = await db
@@ -217,21 +217,32 @@ describe("GitHubCallbackPage", () => {
     expect(getGitHubAppMock).not.toHaveBeenCalled();
   });
 
-  it("rejects a state completed by a different authenticated user", async () => {
-    const { state, slug } = await createCallbackState({ role: "owner" });
+  it("allows another org admin to complete an installation started by someone else", async () => {
+    const { auth, state, slug } = await createCallbackState({ role: "owner" });
     const organization = globalThis.__testApiAuthContext?.organization;
-    const replayIdentity = fixture.createWorkosIdentityForOrganization(
+    const otherAdminIdentity = fixture.createWorkosIdentityForOrganization(
       {
         workosOrganizationId: organization?.workosOrganizationId ?? "",
         name: organization?.name ?? "Example Org",
         slug,
       },
-      "owner",
+      "admin",
     );
-    await fixture.authHeadersFor(replayIdentity);
+    await fixture.authHeadersFor(otherAdminIdentity);
 
-    await expect(runCallback(state)).rejects.toThrow("redirect:/dashboard?error=invalid_state");
-    expect(getGitHubAppMock).not.toHaveBeenCalled();
+    await expect(runCallback(state)).rejects.toThrow(
+      `redirect:/org/${slug}/agent?github_connected=1`,
+    );
+
+    const [installation] = await db
+      .select()
+      .from(schema.githubInstallations)
+      .where(eq(schema.githubInstallations.organizationId, auth.organization.localOrganizationId))
+      .limit(1);
+    expect(installation).toMatchObject({
+      githubInstallationId: "123456",
+    });
+    expect(getGitHubAppMock).toHaveBeenCalled();
   });
 
   it("rejects a non-admin member before consuming state", async () => {

--- a/apps/hyperlocalise-web/src/app/auth/github/callback/page.tsx
+++ b/apps/hyperlocalise-web/src/app/auth/github/callback/page.tsx
@@ -19,6 +19,19 @@ type GitHubCallbackPageProps = {
 
 const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
+function isUniqueViolation(error: unknown) {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  if ("code" in error && error.code === "23505") {
+    return true;
+  }
+
+  const cause = "cause" in error ? error.cause : undefined;
+  return typeof cause === "object" && cause !== null && "code" in cause && cause.code === "23505";
+}
+
 export default async function GitHubCallbackPage({ searchParams }: GitHubCallbackPageProps) {
   const params = await searchParams;
   const installationId = params.installation_id;
@@ -124,25 +137,33 @@ export default async function GitHubCallbackPage({ searchParams }: GitHubCallbac
     .where(eq(schema.githubInstallations.organizationId, org.id))
     .limit(1);
 
-  if (existing[0]) {
-    await db
-      .update(schema.githubInstallations)
-      .set({
+  try {
+    if (existing[0]) {
+      await db
+        .update(schema.githubInstallations)
+        .set({
+          githubInstallationId,
+          githubAppId,
+          accountLogin,
+          accountType,
+          updatedAt: new Date(),
+        })
+        .where(eq(schema.githubInstallations.id, existing[0].id));
+    } else {
+      await db.insert(schema.githubInstallations).values({
+        organizationId: org.id,
         githubInstallationId,
         githubAppId,
         accountLogin,
         accountType,
-        updatedAt: new Date(),
-      })
-      .where(eq(schema.githubInstallations.id, existing[0].id));
-  } else {
-    await db.insert(schema.githubInstallations).values({
-      organizationId: org.id,
-      githubInstallationId,
-      githubAppId,
-      accountLogin,
-      accountType,
-    });
+      });
+    }
+  } catch (error) {
+    if (isUniqueViolation(error)) {
+      redirect("/dashboard?error=github_installation_already_linked");
+    }
+
+    throw error;
   }
 
   try {

--- a/apps/hyperlocalise-web/src/app/auth/github/callback/page.tsx
+++ b/apps/hyperlocalise-web/src/app/auth/github/callback/page.tsx
@@ -114,10 +114,7 @@ export default async function GitHubCallbackPage({ searchParams }: GitHubCallbac
     .where(eq(schema.githubInstallations.githubInstallationId, githubInstallationId))
     .limit(1);
 
-  if (
-    installationLinkedElsewhere &&
-    installationLinkedElsewhere.organizationId !== org.id
-  ) {
+  if (installationLinkedElsewhere && installationLinkedElsewhere.organizationId !== org.id) {
     redirect("/dashboard?error=github_installation_already_linked");
   }
 

--- a/apps/hyperlocalise-web/src/app/auth/github/callback/page.tsx
+++ b/apps/hyperlocalise-web/src/app/auth/github/callback/page.tsx
@@ -80,7 +80,6 @@ export default async function GitHubCallbackPage({ searchParams }: GitHubCallbac
       and(
         eq(schema.githubInstallationStates.nonce, verified.nonce),
         eq(schema.githubInstallationStates.organizationId, org.id),
-        eq(schema.githubInstallationStates.userId, auth.user.localUserId),
         gt(schema.githubInstallationStates.expiresAt, now),
         isNull(schema.githubInstallationStates.consumedAt),
       ),
@@ -108,6 +107,19 @@ export default async function GitHubCallbackPage({ searchParams }: GitHubCallbac
 
   const githubInstallationId = installationId;
   const githubAppId = env.GITHUB_APP_ID;
+
+  const [installationLinkedElsewhere] = await db
+    .select({ organizationId: schema.githubInstallations.organizationId })
+    .from(schema.githubInstallations)
+    .where(eq(schema.githubInstallations.githubInstallationId, githubInstallationId))
+    .limit(1);
+
+  if (
+    installationLinkedElsewhere &&
+    installationLinkedElsewhere.organizationId !== org.id
+  ) {
+    redirect("/dashboard?error=github_installation_already_linked");
+  }
 
   const existing = await db
     .select()
@@ -147,7 +159,7 @@ export default async function GitHubCallbackPage({ searchParams }: GitHubCallbac
   }
 
   const redirectPath = org.slug
-    ? `/org/${org.slug}/settings?github_connected=1`
+    ? `/org/${org.slug}/agent?github_connected=1`
     : "/dashboard?github_connected=1";
 
   redirect(redirectPath);


### PR DESCRIPTION
## What changed

GitHub App installs could complete on GitHub but the Agent page still showed “No GitHub App installation is linked to this organization yet.” This change fixes the end-to-end link flow:

- Allow any org admin to consume a valid install state on callback (not only the user who clicked Connect), so org admins can finish installs started by another member.
- Redirect successful installs to `/org/{slug}/agent?github_connected=1` instead of Settings, where the GitHub agent card actually lives.
- Refetch installation data and show a success toast when `github_connected=1` is present.
- Surface API load failures with a retry action instead of looking like a missing installation.
- Reject linking a GitHub installation that is already tied to a different Hyperlocalise workspace (`github_installation_already_linked`).

## How to test

1. As an org admin, open `/org/{slug}/agent` and click **Connect GitHub**.
2. Complete the GitHub install flow and confirm you land on the Agent page with a “GitHub App connected” toast.
3. Confirm the GitHub agent card shows **Connected** with installation metadata.
4. Optional: start Connect as user A, finish install while logged in as another org admin B on the same workspace — install should still persist.
5. Run `vp test src/app/auth/github/callback/page.test.ts` in `apps/hyperlocalise-web`.

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)