### PR TITLE
fix(crowdin): improve Translation Status parity for progress filtering

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -83,3 +83,9 @@
 **Learning:** The Crowdin Tasks API v2 supports filtering by `labelIds` and `excludeLabelIds`, and Enterprise task creation supports `branchIds`. These were missing from the SDK models. Additionally, some comments in the AI model were inaccurate, and redundant fields like `Languages` in `ProjectsAddRequest` (replaced by `TargetLanguageIDs`) should be removed to avoid confusion.
 
 **Action:** Added `LabelIDs` and `ExcludeLabelIDs` to `TasksListOptions` and updated `Values()` for correct query parameter encoding. Added `BranchIDs` to Enterprise task creation forms and updated `ValidateRequest` to include them. Corrected documentation comments and fixed a loop typo in the AI service. Removed redundant `Languages` field from `ProjectsAddRequest`. Verified with new unit tests and full test suite passing.
+
+## 2026-07-17 - Improve Translation Status parity for progress filtering
+
+**Learning:** Several "Get Progress" endpoints in Crowdin API v2 support optional query parameters for granular filtering that were missing from the Go SDK. Specifically, branch, directory, and file progress can be filtered by `languageIds`, and language progress can be filtered by `fileIds`, `branchIds`, and `directoryIds`.
+
+**Action:** Defined `TranslationProgressListOptions` (with `LanguageIDs`) and `LanguageProgressListOptions` (with `FileIDs`, `BranchIDs`, `DirectoryIDs`) in `model/translation_status.go`. Updated `TranslationStatusService` methods to use these specific option structs. Maintained backward compatibility for `GetProjectProgress` by aliasing `ProjectProgressListOptions` to the new `TranslationProgressListOptions`. Verified correct query parameter encoding with new functional tests in `translation_status_test.go`.

--- a/third_party/crowdin-api-client-go/crowdin/model/translation_status.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/translation_status.go
@@ -23,18 +23,18 @@ type TranslationProgressResponse struct {
 	} `json:"data"`
 }
 
-// ProjectProgressListOptions specifies the optional parameters to the
-// TranslationStatusService.GetProjectProgress method.
-type ProjectProgressListOptions struct {
+// TranslationProgressListOptions specifies the optional parameters for progress
+// methods that filter by language identifiers.
+type TranslationProgressListOptions struct {
 	// Filter progress by Language Identifier.
 	LanguageIDs []string `json:"languageIds,omitempty"`
 
 	ListOptions
 }
 
-// Values returns the url.Values representation of ProjectProgressListOptions.
+// Values returns the url.Values representation of TranslationProgressListOptions.
 // It implements the crowdin.ListOptionsProvider interface.
-func (o *ProjectProgressListOptions) Values() (url.Values, bool) {
+func (o *TranslationProgressListOptions) Values() (url.Values, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -42,6 +42,43 @@ func (o *ProjectProgressListOptions) Values() (url.Values, bool) {
 	v, _ := o.ListOptions.Values()
 	if len(o.LanguageIDs) > 0 {
 		v.Add("languageIds", JoinSlice(o.LanguageIDs))
+	}
+
+	return v, len(v) > 0
+}
+
+// ProjectProgressListOptions is an alias for TranslationProgressListOptions.
+// Deprecated: Use TranslationProgressListOptions instead.
+type ProjectProgressListOptions = TranslationProgressListOptions
+
+// LanguageProgressListOptions specifies the optional parameters to the
+// TranslationStatusService.GetLanguageProgress method.
+type LanguageProgressListOptions struct {
+	// Filter progress by File Identifiers.
+	FileIDs []int `json:"fileIds,omitempty"`
+	// Filter progress by Branch Identifiers.
+	BranchIDs []int `json:"branchIds,omitempty"`
+	// Filter progress by Directory Identifiers.
+	DirectoryIDs []int `json:"directoryIds,omitempty"`
+
+	ListOptions
+}
+
+// Values returns the url.Values representation of LanguageProgressListOptions.
+func (o *LanguageProgressListOptions) Values() (url.Values, bool) {
+	if o == nil {
+		return nil, false
+	}
+
+	v, _ := o.ListOptions.Values()
+	if len(o.FileIDs) > 0 {
+		v.Add("fileIds", JoinSlice(o.FileIDs))
+	}
+	if len(o.BranchIDs) > 0 {
+		v.Add("branchIds", JoinSlice(o.BranchIDs))
+	}
+	if len(o.DirectoryIDs) > 0 {
+		v.Add("directoryIds", JoinSlice(o.DirectoryIDs))
 	}
 
 	return v, len(v) > 0

--- a/third_party/crowdin-api-client-go/crowdin/model/translation_status.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/translation_status.go
@@ -65,6 +65,7 @@ type LanguageProgressListOptions struct {
 }
 
 // Values returns the url.Values representation of LanguageProgressListOptions.
+// It implements the crowdin.ListOptionsProvider interface.
 func (o *LanguageProgressListOptions) Values() (url.Values, bool) {
 	if o == nil {
 		return nil, false

--- a/third_party/crowdin-api-client-go/crowdin/translation_status.go
+++ b/third_party/crowdin-api-client-go/crowdin/translation_status.go
@@ -18,7 +18,7 @@ type TranslationStatusService struct {
 // GetBranchProgress returns the translation and proofreading progress on a branch level.
 //
 // https://developer.crowdin.com/api/v2/#operation/api.projects.branches.languages.progress.getMany
-func (s *TranslationStatusService) GetBranchProgress(ctx context.Context, projectID, branchID int, opts *model.ListOptions) (
+func (s *TranslationStatusService) GetBranchProgress(ctx context.Context, projectID, branchID int, opts *model.TranslationProgressListOptions) (
 	[]*model.TranslationProgress, *Response, error,
 ) {
 	return s.progress(ctx, fmt.Sprintf("/api/v2/projects/%d/branches/%d/languages/progress", projectID, branchID), opts)
@@ -27,7 +27,7 @@ func (s *TranslationStatusService) GetBranchProgress(ctx context.Context, projec
 // GetDirectoryProgress returns the translation and proofreading progress on a directory level.
 //
 // https://developer.crowdin.com/api/v2/#operation/api.projects.directories.languages.progress.getMany
-func (s *TranslationStatusService) GetDirectoryProgress(ctx context.Context, projectID, directoryID int, opts *model.ListOptions) (
+func (s *TranslationStatusService) GetDirectoryProgress(ctx context.Context, projectID, directoryID int, opts *model.TranslationProgressListOptions) (
 	[]*model.TranslationProgress, *Response, error,
 ) {
 	return s.progress(ctx, fmt.Sprintf("/api/v2/projects/%d/directories/%d/languages/progress", projectID, directoryID), opts)
@@ -36,7 +36,7 @@ func (s *TranslationStatusService) GetDirectoryProgress(ctx context.Context, pro
 // GetFileProgress returns the translation and proofreading progress on a file level.
 //
 // https://developer.crowdin.com/api/v2/#operation/api.projects.files.languages.progress.getMany
-func (s *TranslationStatusService) GetFileProgress(ctx context.Context, projectID, fileID int, opts *model.ListOptions) (
+func (s *TranslationStatusService) GetFileProgress(ctx context.Context, projectID, fileID int, opts *model.TranslationProgressListOptions) (
 	[]*model.TranslationProgress, *Response, error,
 ) {
 	return s.progress(ctx, fmt.Sprintf("/api/v2/projects/%d/files/%d/languages/progress", projectID, fileID), opts)
@@ -45,7 +45,7 @@ func (s *TranslationStatusService) GetFileProgress(ctx context.Context, projectI
 // GetLanguageProgress returns the translation and proofreading progress on a language level.
 //
 // https://developer.crowdin.com/api/v2/#operation/api.projects.languages.files.progress.getMany
-func (s *TranslationStatusService) GetLanguageProgress(ctx context.Context, projectID int, languageID string, opts *model.ListOptions) (
+func (s *TranslationStatusService) GetLanguageProgress(ctx context.Context, projectID int, languageID string, opts *model.LanguageProgressListOptions) (
 	[]*model.TranslationProgress, *Response, error,
 ) {
 	return s.progress(ctx, fmt.Sprintf("/api/v2/projects/%d/languages/%s/progress", projectID, languageID), opts)
@@ -54,7 +54,7 @@ func (s *TranslationStatusService) GetLanguageProgress(ctx context.Context, proj
 // GetProjectProgress returns the translation and proofreading progress on a project level.
 //
 // https://developer.crowdin.com/api/v2/#operation/api.projects.languages.progress.getMany
-func (s *TranslationStatusService) GetProjectProgress(ctx context.Context, projectID int, opts *model.ProjectProgressListOptions) (
+func (s *TranslationStatusService) GetProjectProgress(ctx context.Context, projectID int, opts *model.TranslationProgressListOptions) (
 	[]*model.TranslationProgress, *Response, error,
 ) {
 	return s.progress(ctx, fmt.Sprintf("/api/v2/projects/%d/languages/progress", projectID), opts)

--- a/third_party/crowdin-api-client-go/crowdin/translation_status_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/translation_status_test.go
@@ -23,9 +23,11 @@ func TestTranslationStatusService_GetBranchProgress(t *testing.T) {
 		fmt.Fprint(w, getJSONResponseMock())
 	})
 
-	opts := &model.ListOptions{
-		Limit:  25,
-		Offset: 1,
+	opts := &model.TranslationProgressListOptions{
+		ListOptions: model.ListOptions{
+			Limit:  25,
+			Offset: 1,
+		},
 	}
 	branchProgress, resp, err := client.TranslationStatus.GetBranchProgress(context.Background(), 1, 2, opts)
 	if err != nil {
@@ -88,9 +90,11 @@ func TestTranslationStatusService_GetDirectoryProgress(t *testing.T) {
 		fmt.Fprint(w, getJSONResponseMock())
 	})
 
-	opts := &model.ListOptions{
-		Limit:  25,
-		Offset: 1,
+	opts := &model.TranslationProgressListOptions{
+		ListOptions: model.ListOptions{
+			Limit:  25,
+			Offset: 1,
+		},
 	}
 	dirProgress, resp, err := client.TranslationStatus.GetDirectoryProgress(context.Background(), 1, 2, opts)
 	if err != nil {
@@ -153,9 +157,11 @@ func TestTranslationStatusService_GetFileProgress(t *testing.T) {
 		fmt.Fprint(w, getJSONResponseMock())
 	})
 
-	opts := &model.ListOptions{
-		Limit:  25,
-		Offset: 1,
+	opts := &model.TranslationProgressListOptions{
+		ListOptions: model.ListOptions{
+			Limit:  25,
+			Offset: 1,
+		},
 	}
 	fileProgress, resp, err := client.TranslationStatus.GetFileProgress(context.Background(), 1, 2, opts)
 	if err != nil {
@@ -245,9 +251,11 @@ func TestTranslationStatusService_GetLanguageProgress(t *testing.T) {
 		}`)
 	})
 
-	opts := &model.ListOptions{
-		Limit:  25,
-		Offset: 1,
+	opts := &model.LanguageProgressListOptions{
+		ListOptions: model.ListOptions{
+			Limit:  25,
+			Offset: 1,
+		},
 	}
 	langProgress, resp, err := client.TranslationStatus.GetLanguageProgress(context.Background(), 1, "es", opts)
 	if err != nil {
@@ -295,7 +303,7 @@ func TestTranslationStatusService_GetProjectProgress(t *testing.T) {
 		fmt.Fprint(w, getJSONResponseMock())
 	})
 
-	opts := &model.ProjectProgressListOptions{
+	opts := &model.TranslationProgressListOptions{
 		ListOptions: model.ListOptions{
 			Limit:  25,
 			Offset: 1,
@@ -492,4 +500,42 @@ func getJSONResponseMock() string {
 			"limit": 25
 		}
 	}`
+}
+
+func TestTranslationStatusService_GetLanguageProgress_WithFilters(t *testing.T) {
+	client, mux, teardown := setupClient()
+	defer teardown()
+
+	mux.HandleFunc("/api/v2/projects/1/languages/es/progress", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		testURL(t, r, "/api/v2/projects/1/languages/es/progress?branchIds=1%2C2&directoryIds=3%2C4&fileIds=5%2C6")
+
+		fmt.Fprint(w, `{"data": []}`)
+	})
+
+	opts := &model.LanguageProgressListOptions{
+		FileIDs:      []int{5, 6},
+		BranchIDs:    []int{1, 2},
+		DirectoryIDs: []int{3, 4},
+	}
+	_, _, err := client.TranslationStatus.GetLanguageProgress(context.Background(), 1, "es", opts)
+	require.NoError(t, err)
+}
+
+func TestTranslationStatusService_GetBranchProgress_WithLanguageIDs(t *testing.T) {
+	client, mux, teardown := setupClient()
+	defer teardown()
+
+	mux.HandleFunc("/api/v2/projects/1/branches/2/languages/progress", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		testURL(t, r, "/api/v2/projects/1/branches/2/languages/progress?languageIds=en%2Cde")
+
+		fmt.Fprint(w, `{"data": []}`)
+	})
+
+	opts := &model.TranslationProgressListOptions{
+		LanguageIDs: []string{"en", "de"},
+	}
+	_, _, err := client.TranslationStatus.GetBranchProgress(context.Background(), 1, 2, opts)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
Improved Crowdin API v2 parity for Translation Status progress endpoints by adding missing filtering parameters (languageIds, fileIds, branchIds, directoryIds). Updated the service methods and added contract tests to verify correct request encoding.

---
*PR created automatically by Jules for task [16696770201831174715](https://jules.google.com/task/16696770201831174715) started by @cungminh2710*