### PR TITLE
🎨 Palette: Micro-UX and accessibility improvements for tooltips and buttons

### DIFF
--- a/apps/hyperlocalise-web/src/components/ai-elements/message.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/message.tsx
@@ -13,7 +13,6 @@ import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
 import type { ComponentProps, HTMLAttributes, ReactElement } from "react";
 import { createContext, memo, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { Streamdown } from "streamdown";
-import { TypographyP } from "@/components/ui/typography";
 
 export type MessageProps = HTMLAttributes<HTMLDivElement> & {
   from: UIMessage["role"];
@@ -83,9 +82,7 @@ export const MessageAction = ({
     return (
       <Tooltip>
         <TooltipTrigger render={button} />
-        <TooltipContent>
-          <TypographyP>{tooltip}</TypographyP>
-        </TooltipContent>
+        <TooltipContent>{tooltip}</TooltipContent>
       </Tooltip>
     );
   }

--- a/apps/hyperlocalise-web/src/components/ai-elements/tooltip-provider.test.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/tooltip-provider.test.ts
@@ -54,6 +54,7 @@ describe("Tooltip Redundancy Optimization", () => {
     );
     expect(markup).toContain("Web");
     expect(markup).toContain('data-slot="tooltip-trigger"');
+    expect(markup).toContain('aria-label="Web Tooltip"');
   });
 
   it("CodeBlockCopyButton renders correctly within a TooltipProvider", () => {

--- a/apps/hyperlocalise-web/src/components/ai-elements/web-preview.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/web-preview.tsx
@@ -104,20 +104,19 @@ export const WebPreviewNavigationButton = ({
     <TooltipTrigger
       render={
         <Button
+          aria-label={tooltip}
           className="h-8 w-8 p-0 hover:text-foreground"
           disabled={disabled}
           onClick={onClick}
           size="sm"
           variant="ghost"
           {...props}
-        />
+        >
+          {children}
+        </Button>
       }
-    >
-      {children}
-    </TooltipTrigger>
-    <TooltipContent>
-      <TypographyP>{tooltip}</TypographyP>
-    </TooltipContent>
+    />
+    <TooltipContent>{tooltip}</TooltipContent>
   </Tooltip>
 );
 


### PR DESCRIPTION
💡 What: This PR implements several micro-UX and accessibility improvements for tooltips and icon-only buttons in the AI elements components.

🎯 Why: 
- Using block-level elements like TypographyP inside tooltips creates excessive line-height and unwanted margins.
- Icon-only buttons without aria-labels are not accessible to screen readers.
- Correct prop forwarding in TooltipTrigger requires children to be nested inside the rendered component.

♿ Accessibility:
- Added aria-label to WebPreviewNavigationButton.
- Fixed button nesting and prop forwarding for icon-only navigation buttons.

---
*PR created automatically by Jules for task [11399421141330928695](https://jules.google.com/task/11399421141330928695) started by @cungminh2710*