### PR TITLE
feat(cli): improve pack for react-intl locale JSON prep

### DIFF
--- a/apps/cli/cmd/pack.go
+++ b/apps/cli/cmd/pack.go
@@ -81,6 +81,12 @@ func runPackDefault(path string, options packOptions) (any, error) {
 		if formatJS {
 			return buildPackCatalog(payload, options)
 		}
+
+		out := make(map[string]string)
+		if err := translationfileparser.FlattenJSON(out, "", payload); err != nil {
+			return nil, err
+		}
+		return buildPackFlat(out, options), nil
 	}
 
 	values, err := translationfileparser.NewDefaultStrategy().Parse(trimmedPath, content)
@@ -196,10 +202,7 @@ func writePackOutput(cmd *cobra.Command, payload any, options packOptions) error
 	}
 
 	outFile := strings.TrimSpace(options.outFile)
-	if options.outFile != "" {
-		if outFile == "" {
-			return fmt.Errorf("pack out-file cannot be empty")
-		}
+	if outFile != "" {
 		if err := os.MkdirAll(filepath.Dir(outFile), 0o755); err != nil {
 			return fmt.Errorf("create pack output directory: %w", err)
 		}

--- a/apps/cli/cmd/pack.go
+++ b/apps/cli/cmd/pack.go
@@ -86,7 +86,7 @@ func runPackDefault(path string, options packOptions) (any, error) {
 		if err := translationfileparser.FlattenJSON(out, "", payload); err != nil {
 			return nil, err
 		}
-		return buildPackFlat(out, options), nil
+		return buildPackFlat(out, options)
 	}
 
 	values, err := translationfileparser.NewDefaultStrategy().Parse(trimmedPath, content)
@@ -94,7 +94,7 @@ func runPackDefault(path string, options packOptions) (any, error) {
 		return nil, err
 	}
 
-	return buildPackFlat(values, options), nil
+	return buildPackFlat(values, options)
 }
 
 func buildPackCatalog(payload map[string]any, options packOptions) (map[string]extractCatalogMessage, error) {
@@ -136,22 +136,39 @@ func buildPackCatalog(payload map[string]any, options packOptions) (map[string]e
 	return catalog, nil
 }
 
-func buildPackFlat(values map[string]string, options packOptions) map[string]string {
+func buildPackFlat(values map[string]string, options packOptions) (map[string]string, error) {
 	prefixIndex := packPrefixIndex{}
 	if options.prefixID {
 		prefixIndex = collectPackPrefixIndex()
 	}
 
 	out := make(map[string]string, len(values))
-	for id, translation := range values {
+	sourceByPackedID := make(map[string]string, len(values))
+	ids := make([]string, 0, len(values))
+	for id := range values {
+		ids = append(ids, id)
+	}
+	slices.Sort(ids)
+
+	for _, id := range ids {
+		translation := values[id]
 		packedID := id
 		if options.prefixID {
 			packedID = stripPackPrefixID(id, prefixIndex)
 		}
+		if existingSourceID, ok := sourceByPackedID[packedID]; ok {
+			return nil, fmt.Errorf(
+				"pack --prefix-id: ids %q and %q both strip to %q",
+				existingSourceID,
+				id,
+				packedID,
+			)
+		}
+		sourceByPackedID[packedID] = id
 		out[packedID] = translation
 	}
 
-	return out
+	return out, nil
 }
 
 func runPackGrouped(path string, options packOptions) (map[string][]string, error) {

--- a/apps/cli/cmd/pack.go
+++ b/apps/cli/cmd/pack.go
@@ -15,8 +15,9 @@ import (
 )
 
 type packOptions struct {
-	outFile  string
-	prefixID bool
+	groupByValue bool
+	outFile      string
+	prefixID     bool
 }
 
 func newPackCmd() *cobra.Command {
@@ -24,26 +25,130 @@ func newPackCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:          "pack <translation-file>",
-		Short:        "group translation ids by shared string value",
+		Short:        "prepare translation JSON by stripping metadata or grouping duplicates",
 		Args:         cobra.ExactArgs(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			packed, err := runPack(args[0], o)
+			payload, err := runPack(args[0], o)
 			if err != nil {
 				return err
 			}
 
-			return writePackOutput(cmd, packed, o)
+			return writePackOutput(cmd, payload, o)
 		},
 	}
 
+	cmd.Flags().BoolVar(&o.groupByValue, "group-by-value", false, "group ids by shared translation string instead of preserving id-keyed output")
 	cmd.Flags().StringVar(&o.outFile, "out-file", "", "write packed translations to a JSON file")
 	cmd.Flags().BoolVar(&o.prefixID, "prefix-id", false, "strip extract --prefix-id filename prefixes from packed ids")
 
 	return cmd
 }
 
-func runPack(path string, options packOptions) (map[string][]string, error) {
+func runPack(path string, options packOptions) (any, error) {
+	if options.groupByValue {
+		return runPackGrouped(path, options)
+	}
+
+	return runPackDefault(path, options)
+}
+
+func runPackDefault(path string, options packOptions) (any, error) {
+	trimmedPath := strings.TrimSpace(path)
+	if trimmedPath == "" {
+		return nil, fmt.Errorf("pack translation file path cannot be empty")
+	}
+
+	content, err := os.ReadFile(trimmedPath)
+	if err != nil {
+		return nil, fmt.Errorf("read pack input %q: %w", trimmedPath, err)
+	}
+
+	switch strings.ToLower(filepath.Ext(trimmedPath)) {
+	case ".json":
+		var payload map[string]any
+		if err := json.Unmarshal(content, &payload); err != nil {
+			return nil, fmt.Errorf("json decode: %w", err)
+		}
+		if payload == nil {
+			payload = map[string]any{}
+		}
+
+		formatJS, err := translationfileparser.IsStrictFormatJSRoot(payload)
+		if err != nil {
+			return nil, err
+		}
+		if formatJS {
+			return buildPackCatalog(payload, options)
+		}
+	}
+
+	values, err := translationfileparser.NewDefaultStrategy().Parse(trimmedPath, content)
+	if err != nil {
+		return nil, err
+	}
+
+	return buildPackFlat(values, options), nil
+}
+
+func buildPackCatalog(payload map[string]any, options packOptions) (map[string]extractCatalogMessage, error) {
+	prefixIndex := packPrefixIndex{}
+	if options.prefixID {
+		prefixIndex = collectPackPrefixIndex()
+	}
+
+	keys := make([]string, 0, len(payload))
+	for key := range payload {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+
+	catalog := make(map[string]extractCatalogMessage, len(keys))
+	for _, key := range keys {
+		message, ok := payload[key].(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("json key %q must be object", key)
+		}
+		raw, ok := message["defaultMessage"]
+		if !ok {
+			return nil, fmt.Errorf("json key %q missing field %q", key, "defaultMessage")
+		}
+		defaultMessage, ok := raw.(string)
+		if !ok {
+			return nil, fmt.Errorf("json key %q field %q must be string, got %T", key, "defaultMessage", raw)
+		}
+
+		packedID := key
+		if options.prefixID {
+			packedID = stripPackPrefixID(key, prefixIndex)
+		}
+		catalog[packedID] = extractCatalogMessage{
+			DefaultMessage: defaultMessage,
+		}
+	}
+
+	return catalog, nil
+}
+
+func buildPackFlat(values map[string]string, options packOptions) map[string]string {
+	prefixIndex := packPrefixIndex{}
+	if options.prefixID {
+		prefixIndex = collectPackPrefixIndex()
+	}
+
+	out := make(map[string]string, len(values))
+	for id, translation := range values {
+		packedID := id
+		if options.prefixID {
+			packedID = stripPackPrefixID(id, prefixIndex)
+		}
+		out[packedID] = translation
+	}
+
+	return out
+}
+
+func runPackGrouped(path string, options packOptions) (map[string][]string, error) {
 	trimmedPath := strings.TrimSpace(path)
 	if trimmedPath == "" {
 		return nil, fmt.Errorf("pack translation file path cannot be empty")
@@ -81,12 +186,12 @@ func runPack(path string, options packOptions) (map[string][]string, error) {
 	return packed, nil
 }
 
-func writePackOutput(cmd *cobra.Command, packed map[string][]string, options packOptions) error {
+func writePackOutput(cmd *cobra.Command, payload any, options packOptions) error {
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf)
 	enc.SetIndent("", "  ")
 	enc.SetEscapeHTML(false)
-	if err := enc.Encode(packed); err != nil {
+	if err := enc.Encode(payload); err != nil {
 		return fmt.Errorf("encode pack output: %w", err)
 	}
 

--- a/apps/cli/cmd/pack.go
+++ b/apps/cli/cmd/pack.go
@@ -15,6 +15,7 @@ import (
 )
 
 type packOptions struct {
+	outFile  string
 	prefixID bool
 }
 
@@ -32,10 +33,11 @@ func newPackCmd() *cobra.Command {
 				return err
 			}
 
-			return writePackOutput(cmd, packed)
+			return writePackOutput(cmd, packed, o)
 		},
 	}
 
+	cmd.Flags().StringVar(&o.outFile, "out-file", "", "write packed translations to a JSON file")
 	cmd.Flags().BoolVar(&o.prefixID, "prefix-id", false, "strip extract --prefix-id filename prefixes from packed ids")
 
 	return cmd
@@ -79,13 +81,27 @@ func runPack(path string, options packOptions) (map[string][]string, error) {
 	return packed, nil
 }
 
-func writePackOutput(cmd *cobra.Command, packed map[string][]string) error {
+func writePackOutput(cmd *cobra.Command, packed map[string][]string, options packOptions) error {
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf)
 	enc.SetIndent("", "  ")
 	enc.SetEscapeHTML(false)
 	if err := enc.Encode(packed); err != nil {
 		return fmt.Errorf("encode pack output: %w", err)
+	}
+
+	outFile := strings.TrimSpace(options.outFile)
+	if options.outFile != "" {
+		if outFile == "" {
+			return fmt.Errorf("pack out-file cannot be empty")
+		}
+		if err := os.MkdirAll(filepath.Dir(outFile), 0o755); err != nil {
+			return fmt.Errorf("create pack output directory: %w", err)
+		}
+		if err := os.WriteFile(outFile, buf.Bytes(), 0o644); err != nil {
+			return fmt.Errorf("write pack output file %q: %w", outFile, err)
+		}
+		return nil
 	}
 
 	if _, err := cmd.OutOrStdout().Write(buf.Bytes()); err != nil {

--- a/apps/cli/cmd/pack_test.go
+++ b/apps/cli/cmd/pack_test.go
@@ -299,6 +299,53 @@ export function Bar() {
 	assertPackGroupedOutput(t, got, want)
 }
 
+func TestPackCommandStripsPrefixIDInPlainJSONFlatOutput(t *testing.T) {
+	dir := t.TempDir()
+	inputPath := filepath.Join(dir, "messages.json")
+	writePackTestFile(t, inputPath, `{
+  "src.components.app-header.button.label": "Save settings",
+  "src.components.app-header.cta": "Create project"
+}`)
+
+	cmd := newPackCmd()
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{inputPath, "--prefix-id"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute pack command: %v", err)
+	}
+
+	got := decodePackFlatOutput(t, out.Bytes())
+	want := map[string]string{
+		"button.label": "Save settings",
+		"cta":          "Create project",
+	}
+	assertPackFlatOutput(t, got, want)
+}
+
+func TestPackCommandRejectsPrefixIDCollisionsInPlainJSONFlatOutput(t *testing.T) {
+	dir := t.TempDir()
+	inputPath := filepath.Join(dir, "messages.json")
+	writePackTestFile(t, inputPath, `{
+  "src.foo.button.label": "Save settings",
+  "src.bar.button.label": "Start trial"
+}`)
+
+	cmd := newPackCmd()
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{inputPath, "--prefix-id"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected pack command to fail on prefix-id collision")
+	}
+	if !strings.Contains(err.Error(), `ids "src.bar.button.label" and "src.foo.button.label" both strip to "label"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestPackCommandSupportsPlainJSONTranslations(t *testing.T) {
 	dir := t.TempDir()
 	inputPath := filepath.Join(dir, "messages.json")

--- a/apps/cli/cmd/pack_test.go
+++ b/apps/cli/cmd/pack_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-func TestPackCommandGroupsFormatJSMessagesAndDropsDescriptions(t *testing.T) {
+func TestPackCommandStripsDescriptionsByDefault(t *testing.T) {
 	dir := t.TempDir()
 	inputPath := filepath.Join(dir, "messages.json")
 	writePackTestFile(t, inputPath, `{
@@ -35,7 +35,52 @@ func TestPackCommandGroupsFormatJSMessagesAndDropsDescriptions(t *testing.T) {
 		t.Fatalf("execute pack command: %v", err)
 	}
 
-	got := decodePackTestOutput(t, out.Bytes())
+	got := decodePackCatalogOutput(t, out.Bytes())
+	want := map[string]extractCatalogMessage{
+		"src.components.app-header.cta": {
+			DefaultMessage: "Create project",
+		},
+		"src.components.app-header.title": {
+			DefaultMessage: "Dashboard",
+		},
+		"src.components.hero.title": {
+			DefaultMessage: "Dashboard",
+		},
+	}
+	assertPackCatalogOutput(t, got, want)
+
+	if strings.Contains(out.String(), "description") {
+		t.Fatalf("pack output should omit description metadata: %s", out.String())
+	}
+}
+
+func TestPackCommandGroupsByValue(t *testing.T) {
+	dir := t.TempDir()
+	inputPath := filepath.Join(dir, "messages.json")
+	writePackTestFile(t, inputPath, `{
+  "src.components.app-header.title": {
+    "defaultMessage": "Dashboard",
+    "description": "Main dashboard heading"
+  },
+  "src.components.hero.title": {
+    "defaultMessage": "Dashboard",
+    "description": "Hero heading"
+  },
+  "src.components.app-header.cta": {
+    "defaultMessage": "Create project"
+  }
+}`)
+
+	cmd := newPackCmd()
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{inputPath, "--group-by-value"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute pack command: %v", err)
+	}
+
+	got := decodePackGroupedOutput(t, out.Bytes())
 	want := map[string][]string{
 		"Create project": {"src.components.app-header.cta"},
 		"Dashboard": {
@@ -43,10 +88,10 @@ func TestPackCommandGroupsFormatJSMessagesAndDropsDescriptions(t *testing.T) {
 			"src.components.hero.title",
 		},
 	}
-	assertPackOutput(t, got, want)
+	assertPackGroupedOutput(t, got, want)
 
 	if strings.Contains(out.String(), "description") || strings.Contains(out.String(), "defaultMessage") {
-		t.Fatalf("pack output should only contain translation values and id arrays: %s", out.String())
+		t.Fatalf("grouped pack output should only contain translation values and id arrays: %s", out.String())
 	}
 }
 
@@ -76,20 +121,20 @@ func TestPackCommandStripsPrefixID(t *testing.T) {
 	cmd := newPackCmd()
 	out := bytes.NewBuffer(nil)
 	cmd.SetOut(out)
-	cmd.SetArgs([]string{inputPath, "--prefix-id"})
+	cmd.SetArgs([]string{inputPath, "--prefix-id", "--group-by-value"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("execute pack command: %v", err)
 	}
 
-	got := decodePackTestOutput(t, out.Bytes())
+	got := decodePackGroupedOutput(t, out.Bytes())
 	want := map[string][]string{
 		"Create project":    {"cta"},
 		"Dashboard":         {"title"},
 		"Save button label": {"my-button.label"},
 		"Save settings":     {"button.label"},
 	}
-	assertPackOutput(t, got, want)
+	assertPackGroupedOutput(t, got, want)
 }
 
 func TestPackCommandStripsPrefixIDAtFilenameBoundary(t *testing.T) {
@@ -149,20 +194,20 @@ export function Bar() {
 	cmd := newPackCmd()
 	out := bytes.NewBuffer(nil)
 	cmd.SetOut(out)
-	cmd.SetArgs([]string{inputPath, "--prefix-id"})
+	cmd.SetArgs([]string{inputPath, "--prefix-id", "--group-by-value"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("execute pack command: %v", err)
 	}
 
-	got := decodePackTestOutput(t, out.Bytes())
+	got := decodePackGroupedOutput(t, out.Bytes())
 	want := map[string][]string{
 		"Ambiguous":     {"bar.baz"},
 		"Dashboard":     {"title"},
 		"Save settings": {"button.label"},
 		"Start trial":   {"button.label"},
 	}
-	assertPackOutput(t, got, want)
+	assertPackGroupedOutput(t, got, want)
 }
 
 func TestPackCommandSupportsPlainJSONTranslations(t *testing.T) {
@@ -186,11 +231,40 @@ func TestPackCommandSupportsPlainJSONTranslations(t *testing.T) {
 		t.Fatalf("execute pack command: %v", err)
 	}
 
-	got := decodePackTestOutput(t, out.Bytes())
+	got := decodePackFlatOutput(t, out.Bytes())
+	want := map[string]string{
+		"home.title": "Dashboard",
+		"nav.title":  "Dashboard",
+	}
+	assertPackFlatOutput(t, got, want)
+}
+
+func TestPackCommandGroupsPlainJSONTranslationsByValue(t *testing.T) {
+	dir := t.TempDir()
+	inputPath := filepath.Join(dir, "messages.json")
+	writePackTestFile(t, inputPath, `{
+  "home": {
+    "title": "Dashboard"
+  },
+  "nav": {
+    "title": "Dashboard"
+  }
+}`)
+
+	cmd := newPackCmd()
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{inputPath, "--group-by-value"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute pack command: %v", err)
+	}
+
+	got := decodePackGroupedOutput(t, out.Bytes())
 	want := map[string][]string{
 		"Dashboard": {"home.title", "nav.title"},
 	}
-	assertPackOutput(t, got, want)
+	assertPackGroupedOutput(t, got, want)
 }
 
 func TestPackCommandWritesOutFile(t *testing.T) {
@@ -223,11 +297,12 @@ func TestPackCommandWritesOutFile(t *testing.T) {
 		t.Fatalf("read pack output file: %v", err)
 	}
 
-	got := decodePackTestOutput(t, content)
-	want := map[string][]string{
-		"Dashboard": {"home.title", "nav.title"},
+	got := decodePackCatalogOutput(t, content)
+	want := map[string]extractCatalogMessage{
+		"home.title": {DefaultMessage: "Dashboard"},
+		"nav.title":  {DefaultMessage: "Dashboard"},
 	}
-	assertPackOutput(t, got, want)
+	assertPackCatalogOutput(t, got, want)
 }
 
 func TestRootHelpIncludesPackCommand(t *testing.T) {
@@ -257,18 +332,74 @@ func writePackTestFile(t *testing.T, path, content string) {
 	}
 }
 
-func decodePackTestOutput(t *testing.T, content []byte) map[string][]string {
+func decodePackCatalogOutput(t *testing.T, content []byte) map[string]extractCatalogMessage {
 	t.Helper()
 
-	var out map[string][]string
+	var out map[string]extractCatalogMessage
 	if err := json.Unmarshal(content, &out); err != nil {
-		t.Fatalf("decode pack output: %v\noutput=%s", err, string(content))
+		t.Fatalf("decode pack catalog output: %v\noutput=%s", err, string(content))
 	}
 
 	return out
 }
 
-func assertPackOutput(t *testing.T, got, want map[string][]string) {
+func decodePackFlatOutput(t *testing.T, content []byte) map[string]string {
+	t.Helper()
+
+	var out map[string]string
+	if err := json.Unmarshal(content, &out); err != nil {
+		t.Fatalf("decode pack flat output: %v\noutput=%s", err, string(content))
+	}
+
+	return out
+}
+
+func decodePackGroupedOutput(t *testing.T, content []byte) map[string][]string {
+	t.Helper()
+
+	var out map[string][]string
+	if err := json.Unmarshal(content, &out); err != nil {
+		t.Fatalf("decode pack grouped output: %v\noutput=%s", err, string(content))
+	}
+
+	return out
+}
+
+func assertPackCatalogOutput(t *testing.T, got, want map[string]extractCatalogMessage) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("packed catalog count = %d, want %d; output=%#v", len(got), len(want), got)
+	}
+	for id, wantMessage := range want {
+		gotMessage, ok := got[id]
+		if !ok {
+			t.Fatalf("missing id %q in output=%#v", id, got)
+		}
+		if gotMessage != wantMessage {
+			t.Fatalf("id %q message = %#v, want %#v", id, gotMessage, wantMessage)
+		}
+	}
+}
+
+func assertPackFlatOutput(t *testing.T, got, want map[string]string) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("packed flat count = %d, want %d; output=%#v", len(got), len(want), got)
+	}
+	for id, wantValue := range want {
+		gotValue, ok := got[id]
+		if !ok {
+			t.Fatalf("missing id %q in output=%#v", id, got)
+		}
+		if gotValue != wantValue {
+			t.Fatalf("id %q value = %q, want %q", id, gotValue, wantValue)
+		}
+	}
+}
+
+func assertPackGroupedOutput(t *testing.T, got, want map[string][]string) {
 	t.Helper()
 
 	if len(got) != len(want) {

--- a/apps/cli/cmd/pack_test.go
+++ b/apps/cli/cmd/pack_test.go
@@ -193,6 +193,43 @@ func TestPackCommandSupportsPlainJSONTranslations(t *testing.T) {
 	assertPackOutput(t, got, want)
 }
 
+func TestPackCommandWritesOutFile(t *testing.T) {
+	dir := t.TempDir()
+	inputPath := filepath.Join(dir, "messages.json")
+	writePackTestFile(t, inputPath, `{
+  "home.title": {
+    "defaultMessage": "Dashboard"
+  },
+  "nav.title": {
+    "defaultMessage": "Dashboard"
+  }
+}`)
+
+	outPath := filepath.Join(dir, "packed.json")
+	cmd := newPackCmd()
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{inputPath, "--out-file", outPath})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute pack command: %v", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("expected out-file mode to keep stdout empty, got %q", out.String())
+	}
+
+	content, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read pack output file: %v", err)
+	}
+
+	got := decodePackTestOutput(t, content)
+	want := map[string][]string{
+		"Dashboard": {"home.title", "nav.title"},
+	}
+	assertPackOutput(t, got, want)
+}
+
 func TestRootHelpIncludesPackCommand(t *testing.T) {
 	cmd := newRootCmd("")
 	b := bytes.NewBufferString("")

--- a/apps/cli/cmd/pack_test.go
+++ b/apps/cli/cmd/pack_test.go
@@ -137,6 +137,95 @@ func TestPackCommandStripsPrefixID(t *testing.T) {
 	assertPackGroupedOutput(t, got, want)
 }
 
+func TestPackCommandStripsPrefixIDInDefaultCatalog(t *testing.T) {
+	dir := t.TempDir()
+	inputPath := filepath.Join(dir, "messages.json")
+	writePackTestFile(t, inputPath, `{
+  "src.components.app-header.button.label": {
+    "defaultMessage": "Save settings"
+  },
+  "src.components.app-header.my-button.label": {
+    "defaultMessage": "Save button label"
+  },
+  "src.components.app-header.cta": {
+    "defaultMessage": "Create project"
+  }
+}`)
+
+	cmd := newPackCmd()
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{inputPath, "--prefix-id"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute pack command: %v", err)
+	}
+
+	got := decodePackCatalogOutput(t, out.Bytes())
+	want := map[string]extractCatalogMessage{
+		"button.label": {
+			DefaultMessage: "Save settings",
+		},
+		"cta": {
+			DefaultMessage: "Create project",
+		},
+		"my-button.label": {
+			DefaultMessage: "Save button label",
+		},
+	}
+	assertPackCatalogOutput(t, got, want)
+}
+
+func TestPackCommandStripsPrefixIDAtFilenameBoundaryInDefaultCatalog(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	writePackTestFile(t, filepath.Join(dir, "src", "components", "AppHeader.tsx"), `
+import { FormattedMessage } from "react-intl";
+
+export function AppHeader() {
+  return <FormattedMessage id="title" defaultMessage="Dashboard" />;
+}
+`)
+	writePackTestFile(t, filepath.Join(dir, "src", "foo.tsx"), `
+import { FormattedMessage } from "react-intl";
+
+export function Foo() {
+  return <FormattedMessage id="bar.baz" defaultMessage="Ambiguous" />;
+}
+`)
+
+	inputPath := filepath.Join(dir, "messages.json")
+	writePackTestFile(t, inputPath, `{
+  "src.components.app-header.title": {
+    "defaultMessage": "Dashboard"
+  },
+  "src.foo.bar.baz": {
+    "defaultMessage": "Ambiguous"
+  }
+}`)
+
+	cmd := newPackCmd()
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{inputPath, "--prefix-id"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute pack command: %v", err)
+	}
+
+	got := decodePackCatalogOutput(t, out.Bytes())
+	want := map[string]extractCatalogMessage{
+		"bar.baz": {
+			DefaultMessage: "Ambiguous",
+		},
+		"title": {
+			DefaultMessage: "Dashboard",
+		},
+	}
+	assertPackCatalogOutput(t, got, want)
+}
+
 func TestPackCommandStripsPrefixIDAtFilenameBoundary(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)

--- a/docs/commands/overview.mdx
+++ b/docs/commands/overview.mdx
@@ -31,7 +31,7 @@ Main commands:
 - Crowdin file workflow: [crowdin](/commands/crowdin)
 - Local draft generation: [run](/commands/run)
 - Extract React Intl catalogs: [extract](/commands/extract)
-- Group duplicate strings: [pack](/commands/pack)
+- Prepare translation JSON: [pack](/commands/pack)
 - Translation integrity checks: [check](/commands/check)
 - Quality experiments and gating: [eval](/commands/eval)
 - Reporting progress: [status](/commands/status)

--- a/docs/commands/pack.mdx
+++ b/docs/commands/pack.mdx
@@ -1,6 +1,6 @@
 ---
 title: "pack"
-description: "Group translation ids by shared string value."
+description: "Prepare translation JSON by stripping metadata or grouping duplicate strings."
 ---
 
 ## Usage
@@ -11,9 +11,31 @@ hyperlocalise pack <translation-file> [flags]
 
 ## Behavior
 
-`pack` reads a translation file, groups identical translated strings together, and writes JSON where each key is the string value and each value is an array of ids that use that string.
+By default, `pack` prepares a translation file for downstream workflows by removing `description` metadata while preserving id-keyed output.
 
-For FormatJS message JSON, `pack` uses `defaultMessage` as the string value and omits `description` metadata from output.
+For FormatJS message JSON, the default output keeps each message id and its `defaultMessage`:
+
+```json
+{
+  "src.components.app-header.title": {
+    "defaultMessage": "Dashboard"
+  },
+  "src.components.hero.title": {
+    "defaultMessage": "Dashboard"
+  }
+}
+```
+
+For plain nested JSON, the default output is a flat id-to-string map:
+
+```json
+{
+  "home.title": "Dashboard",
+  "nav.title": "Dashboard"
+}
+```
+
+Use `--group-by-value` to invert the shape and group ids that share the same translation string:
 
 ```json
 {
@@ -23,15 +45,26 @@ For FormatJS message JSON, `pack` uses `defaultMessage` as the string value and 
 
 ## Flags
 
+- `--group-by-value`: group ids by shared translation string instead of preserving id-keyed output.
 - `--out-file <path>`: write the packed JSON to a file instead of stdout.
 - `--prefix-id`: strip `extract --prefix-id` filename prefixes from ids. For example, `src.components.app-header.title` becomes `title`.
 
 ## Examples
 
-```bash
-hyperlocalise pack lang/en.json --out-file lang/packed.json
-```
+Strip descriptions from an extracted catalog:
 
 ```bash
-hyperlocalise pack lang/en.json --prefix-id --out-file lang/packed.json
+hyperlocalise pack lang/en.json --out-file lang/en.packed.json
+```
+
+Group duplicate strings for review:
+
+```bash
+hyperlocalise pack lang/en.json --group-by-value --out-file lang/duplicates.json
+```
+
+Strip prefixed ids while grouping:
+
+```bash
+hyperlocalise pack lang/en.json --group-by-value --prefix-id --out-file lang/packed.json
 ```

--- a/docs/commands/pack.mdx
+++ b/docs/commands/pack.mdx
@@ -6,7 +6,7 @@ description: "Group translation ids by shared string value."
 ## Usage
 
 ```bash
-hyperlocalise pack <translation-file> [--prefix-id]
+hyperlocalise pack <translation-file> [flags]
 ```
 
 ## Behavior
@@ -23,4 +23,15 @@ For FormatJS message JSON, `pack` uses `defaultMessage` as the string value and 
 
 ## Flags
 
+- `--out-file <path>`: write the packed JSON to a file instead of stdout.
 - `--prefix-id`: strip `extract --prefix-id` filename prefixes from ids. For example, `src.components.app-header.title` becomes `title`.
+
+## Examples
+
+```bash
+hyperlocalise pack lang/en.json --out-file lang/packed.json
+```
+
+```bash
+hyperlocalise pack lang/en.json --prefix-id --out-file lang/packed.json
+```

--- a/internal/i18n/translationfileparser/json_parser.go
+++ b/internal/i18n/translationfileparser/json_parser.go
@@ -122,6 +122,11 @@ func IsStrictFormatJSRoot(payload map[string]any) (bool, error) {
 	return isStrictFormatJSRoot(payload)
 }
 
+// FlattenJSON flattens nested JSON objects into dotted string keys.
+func FlattenJSON(out map[string]string, prefix string, input map[string]any) error {
+	return flattenJSON(out, prefix, input)
+}
+
 func flattenJSON(out map[string]string, prefix string, input map[string]any) error {
 	keys := make([]string, 0, len(input))
 	for key := range input {

--- a/internal/i18n/translationfileparser/json_parser.go
+++ b/internal/i18n/translationfileparser/json_parser.go
@@ -117,6 +117,11 @@ func isStrictFormatJSRoot(payload map[string]any) (bool, error) {
 	return true, nil
 }
 
+// IsStrictFormatJSRoot reports whether payload is a FormatJS message catalog.
+func IsStrictFormatJSRoot(payload map[string]any) (bool, error) {
+	return isStrictFormatJSRoot(payload)
+}
+
 func flattenJSON(out map[string]string, prefix string, input map[string]any) error {
 	keys := make([]string, 0, len(input))
 	for key := range input {


### PR DESCRIPTION
## What changed

Updates `hyperlocalise pack` to better match react-intl locale JSON workflows:

- **Default behavior** now strips `description` metadata while preserving id-keyed FormatJS output (`id → { defaultMessage }`), which is the shape `IntlProvider` expects.
- **Duplicate grouping** moves behind `--group-by-value` (translation → ids), for optional audit/review rather than runtime consumption.
- Adds **`--out-file`** to write packed JSON to a file instead of stdout, matching `extract`.
- Exports `IsStrictFormatJSRoot` from the JSON parser so pack can detect FormatJS catalogs reliably.

Docs updated in `docs/commands/pack.mdx` and the commands overview.

## How to test

```bash
make fmt
make lint
go test ./apps/cli/cmd/... -run Pack -v
```

Manual checks:

```bash
hyperlocalise pack lang/en.json
hyperlocalise pack lang/en.json --group-by-value
hyperlocalise pack lang/en.json --out-file lang/en.packed.json
```

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
