### PR TITLE
feat(cli): auto-discover react-intl locale files in pack

### DIFF
--- a/.hyperlocalise.lock.json
+++ b/.hyperlocalise.lock.json
@@ -1194,6 +1194,10 @@
       "md.8cd5c081a4e6ed25": {
         "s": "ab4185438c82cf158d564beb6004fd67"
       },
+      "md.90d0dc1a755e10fe": {
+        "s": "7421468244ccd5357ee7d1ec6ccfbdea",
+        "t": "1965ec606676b5aaadfa429c92b91691"
+      },
       "md.a320e45b446fcf38": {
         "s": "22709b415d64239e9ad311e361cbefec"
       },
@@ -1223,29 +1227,113 @@
       }
     },
     "docs/vi-VN/commands/pack.mdx": {
+      "md.0216381134408cfd": {
+        "s": "25ab3eb2b6c1cbcab03ff08e06078c1e",
+        "t": "f55227e992073f54ba439887b6fb98a1"
+      },
+      "md.048493cd95fe8520": {
+        "s": "4920914ac1ba20301f85fb249a42af7b",
+        "t": "d6c1eaf4cd574419cfbecc1ca9723621"
+      },
+      "md.054fdb4ee36c4d74": {
+        "s": "b6322cb76d0046753a052f39e1a9117e",
+        "t": "9591f20c310a84e55ea9a6252fa85fd6"
+      },
+      "md.1c52d15655473687": {
+        "s": "f0f21c1c7d2e861a6742ac9de31b9c33",
+        "t": "25158174a045a04ee53c23d51c6b2c9c"
+      },
       "md.23b314b748d49934": {
         "s": "4b1113b9a64129316d2f2430301280d0",
         "t": "69da8a8c8de3094c08e8e0c952cd26d6"
+      },
+      "md.2f9f7cbbe84ede4e": {
+        "s": "a8413356c2e1c99c3020a0aa5603002f",
+        "t": "10ce91fecf9eff7757cdb3b240f851d9"
+      },
+      "md.37af3a94288d54c2": {
+        "s": "be432f73748935c9b53d7902a1876f31",
+        "t": "80fffe94d69070972835ad1947404e96"
+      },
+      "md.3ab7fcafd8568bb7": {
+        "s": "d679a317a35d322b4757f90977703f76",
+        "t": "2588c9094154fc5372744757883ea12a"
+      },
+      "md.4372518678ba8e06": {
+        "s": "ce46f982f55b25f9552cbb5c052afd34",
+        "t": "cb9fb232f50c944d64f7b5b05e8be3e3"
+      },
+      "md.47ea6a9518bc61cd": {
+        "s": "83a72f22f4af2adb3a1d445d50cadb61",
+        "t": "4e87c9b1ad86a03a4bc8ee17c6b5504d"
       },
       "md.4862f447f2c7f272": {
         "s": "8bc0dec4fca7ee0ed72b7a4293430955",
         "t": "3e2e3dad8e81d0f08fdb9c4ac7f8b382"
       },
+      "md.58ce84db325f4b5e": {
+        "s": "3267d19e5512324b964546b118c0e666",
+        "t": "9a096521c2a72c46f1471c861f483174"
+      },
       "md.6190d6b1112f1d41": {
         "s": "59ea04b5594546802c03fdfb7ccda1e0",
         "t": "78402ca26a761dc7b086f0b19b2f374f"
+      },
+      "md.65b61075bc665bd1": {
+        "s": "59c89dd9d5acc8d75e1b7608b13bab25",
+        "t": "e21cd198a13a20fc89f0f9fd59f95dac"
+      },
+      "md.6c2060fa59a13e30": {
+        "s": "1869c2e59e9dcef1affdb5c0d97ba47b",
+        "t": "d073003d7a510bfec6d30ff5d645b5f8"
+      },
+      "md.770dda70d42e898f": {
+        "s": "cf3e132eeadfd9498d346fb0b3a973c2",
+        "t": "4c4ea62de78bb3810690772832f4fe4f"
+      },
+      "md.81fbc93d7ce2bea9": {
+        "s": "c7fb62768e66494f27eceb3445dcb90a",
+        "t": "6a3bde23f52ceca671ad29d5cbef22b4"
       },
       "md.8d59829c1e15afe1": {
         "s": "c1bb2aece7719d5e15e38ba2b95f0353",
         "t": "156ea1d499aa3cb1a47f5c1cc442c8fd"
       },
+      "md.a16d884f83bf621e": {
+        "s": "8390ee3d7d24980f7e17538176c02f47",
+        "t": "392001dd0468d924762bb16275e0e770"
+      },
       "md.a883862f0eda61f8": {
         "s": "73a17b58af7a32001548b09f2f1b29c1",
         "t": "aff798dfad47b391eaeaeabcfbf26c21"
       },
+      "md.abeb32928747dbf6": {
+        "s": "9075be722b1457658c05749ee52c41af",
+        "t": "27e3732e37f0ec803061489a32461df0"
+      },
+      "md.afdc92150a18e311": {
+        "s": "143c289a03b3367215faa5857eb261d7",
+        "t": "ee2a2a01221949fbd647e6261aacde29"
+      },
+      "md.d7cb13a51e8ed48d": {
+        "s": "7f7deea2eb501c55056db2f89dc2a22a",
+        "t": "e5b69314f67173d2af0a5170062b0604"
+      },
+      "md.d95031a5128fc807": {
+        "s": "2b364198dc3cc25410ffd9adf1dac65a",
+        "t": "8e67533fd037f0b89cb826f3aca2e9f6"
+      },
       "md.e252b3e525d9185a": {
         "s": "6b0e1c2019a712b42fce554605156c43",
         "t": "8d65d36faa7af0ccfa56d910a74f8ca0"
+      },
+      "md.e676b605854cadc2": {
+        "s": "3b6da3b3b0d79a6d57ac8ed474598153",
+        "t": "85e700ef88acd734ec163b2e79ff0463"
+      },
+      "md.e68ee04dff59551b": {
+        "s": "dc62c7f9df4f6114a42c35b782cf3503",
+        "t": "5f69b640d8c362909766c169a974ae8c"
       },
       "md.edf8d3f1781f32f0": {
         "s": "ccf5a3658e27d43c093f607a10f731e8",
@@ -12321,6 +12409,10 @@
       "md.8cd5c081a4e6ed25": {
         "s": "ab4185438c82cf158d564beb6004fd67"
       },
+      "md.90d0dc1a755e10fe": {
+        "s": "7421468244ccd5357ee7d1ec6ccfbdea",
+        "t": "5b479f49b7bc4c329a08c180cfe03bc9"
+      },
       "md.a320e45b446fcf38": {
         "s": "22709b415d64239e9ad311e361cbefec"
       },
@@ -12350,29 +12442,113 @@
       }
     },
     "docs/zh-CN/commands/pack.mdx": {
+      "md.0216381134408cfd": {
+        "s": "25ab3eb2b6c1cbcab03ff08e06078c1e",
+        "t": "98bfd72d7ff16e21714c1ba4dd7c30eb"
+      },
+      "md.048493cd95fe8520": {
+        "s": "4920914ac1ba20301f85fb249a42af7b",
+        "t": "b92590aa93dcf70ce226c61dfe5329f0"
+      },
+      "md.054fdb4ee36c4d74": {
+        "s": "b6322cb76d0046753a052f39e1a9117e",
+        "t": "0f731b061d7a015555013a7ebb4b66cc"
+      },
+      "md.1c52d15655473687": {
+        "s": "f0f21c1c7d2e861a6742ac9de31b9c33",
+        "t": "73b88b65bdc8c3c781d2a5d90cf20025"
+      },
       "md.23b314b748d49934": {
         "s": "4b1113b9a64129316d2f2430301280d0",
         "t": "d6a8ca38bf9c65d9e051e8bf41911c92"
+      },
+      "md.2f9f7cbbe84ede4e": {
+        "s": "a8413356c2e1c99c3020a0aa5603002f",
+        "t": "0c3d5aca017b20dbaf156c8695264f20"
+      },
+      "md.37af3a94288d54c2": {
+        "s": "be432f73748935c9b53d7902a1876f31",
+        "t": "c011016324fd1cd54fc28aaa65a007af"
+      },
+      "md.3ab7fcafd8568bb7": {
+        "s": "d679a317a35d322b4757f90977703f76",
+        "t": "2441c39d3904e403f93aafebd1af291c"
+      },
+      "md.4372518678ba8e06": {
+        "s": "ce46f982f55b25f9552cbb5c052afd34",
+        "t": "21e443ecea17311c8da41a2104f01d28"
+      },
+      "md.47ea6a9518bc61cd": {
+        "s": "83a72f22f4af2adb3a1d445d50cadb61",
+        "t": "ffe5ce056cdfae3c5a19bc7da5a54893"
       },
       "md.4862f447f2c7f272": {
         "s": "8bc0dec4fca7ee0ed72b7a4293430955",
         "t": "29cf2d49c0b684dccf99b92fa0f4fd89"
       },
+      "md.58ce84db325f4b5e": {
+        "s": "3267d19e5512324b964546b118c0e666",
+        "t": "647eb79d7a7d29c294b70d575f81cce4"
+      },
       "md.6190d6b1112f1d41": {
         "s": "59ea04b5594546802c03fdfb7ccda1e0",
         "t": "1f4e77920005c324769404200776f599"
+      },
+      "md.65b61075bc665bd1": {
+        "s": "59c89dd9d5acc8d75e1b7608b13bab25",
+        "t": "d6c4d85b4d8e7df64884973989ebcfbc"
+      },
+      "md.6c2060fa59a13e30": {
+        "s": "1869c2e59e9dcef1affdb5c0d97ba47b",
+        "t": "c2c535cdafdcc40f69ca1d036aee6fa3"
+      },
+      "md.770dda70d42e898f": {
+        "s": "cf3e132eeadfd9498d346fb0b3a973c2",
+        "t": "084621a84d6108ee27511820204b5c74"
+      },
+      "md.81fbc93d7ce2bea9": {
+        "s": "c7fb62768e66494f27eceb3445dcb90a",
+        "t": "ee74ed91f565f4e34293d1217f2d4c4d"
       },
       "md.8d59829c1e15afe1": {
         "s": "c1bb2aece7719d5e15e38ba2b95f0353",
         "t": "f8395462947ecdda815a4ce16346b210"
       },
+      "md.a16d884f83bf621e": {
+        "s": "8390ee3d7d24980f7e17538176c02f47",
+        "t": "fb67938e42abe0545f7b4bbe14fbf019"
+      },
       "md.a883862f0eda61f8": {
         "s": "73a17b58af7a32001548b09f2f1b29c1",
         "t": "2acd89bb8a0f96599234a54ca0c6d94a"
       },
+      "md.abeb32928747dbf6": {
+        "s": "9075be722b1457658c05749ee52c41af",
+        "t": "6f53d4238dea1fb82d4440ae7d5c1233"
+      },
+      "md.afdc92150a18e311": {
+        "s": "143c289a03b3367215faa5857eb261d7",
+        "t": "2cd73f29049932fc043a554a56a1b0d8"
+      },
+      "md.d7cb13a51e8ed48d": {
+        "s": "7f7deea2eb501c55056db2f89dc2a22a",
+        "t": "a97edeb033ea1e7d66d3709158f34d30"
+      },
+      "md.d95031a5128fc807": {
+        "s": "2b364198dc3cc25410ffd9adf1dac65a",
+        "t": "cf778de95bfb1e88f41cc0e220c37678"
+      },
       "md.e252b3e525d9185a": {
         "s": "6b0e1c2019a712b42fce554605156c43",
         "t": "10a5749b718f999c64526f12bab69fcb"
+      },
+      "md.e676b605854cadc2": {
+        "s": "3b6da3b3b0d79a6d57ac8ed474598153",
+        "t": "7ac6e80ec58db4fb1757406354856165"
+      },
+      "md.e68ee04dff59551b": {
+        "s": "dc62c7f9df4f6114a42c35b782cf3503",
+        "t": "46e9cf25c45c91c83c74f57bf8d295c0"
       },
       "md.edf8d3f1781f32f0": {
         "s": "ccf5a3658e27d43c093f607a10f731e8",

--- a/apps/cli/cmd/pack.go
+++ b/apps/cli/cmd/pack.go
@@ -102,6 +102,8 @@ func validatePackOptions(args []string, options packOptions) error {
 		return fmt.Errorf("pack --out-file requires a translation file")
 	case !hasFile && strings.TrimSpace(options.outSuffix) == "":
 		return fmt.Errorf("pack --out-suffix cannot be empty")
+	case !hasFile && options.groupByValue:
+		return fmt.Errorf("pack --group-by-value requires a translation file")
 	}
 
 	return nil
@@ -157,6 +159,10 @@ func collectPackLocaleFilesFromConfig(options packOptions) ([]string, error) {
 }
 
 func isPackFormatJSFile(path string) (bool, error) {
+	if strings.ToLower(filepath.Ext(path)) != ".json" {
+		return false, nil
+	}
+
 	content, err := os.ReadFile(path)
 	if err != nil {
 		return false, err

--- a/apps/cli/cmd/pack.go
+++ b/apps/cli/cmd/pack.go
@@ -10,39 +10,192 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/hyperlocalise/hyperlocalise/apps/cli/internal/i18n/pathresolver"
 	"github.com/hyperlocalise/hyperlocalise/internal/i18n/translationfileparser"
+	config "github.com/hyperlocalise/hyperlocalise/pkg/i18nconfig"
 	"github.com/spf13/cobra"
 )
+
+const defaultPackOutSuffix = ".packed"
 
 type packOptions struct {
 	groupByValue bool
 	outFile      string
 	prefixID     bool
+	configPath   string
+	group        string
+	bucket       string
+	outSuffix    string
 }
 
 func newPackCmd() *cobra.Command {
-	o := packOptions{}
+	o := packOptions{
+		outSuffix: defaultPackOutSuffix,
+	}
 
 	cmd := &cobra.Command{
-		Use:          "pack <translation-file>",
-		Short:        "prepare translation JSON by stripping metadata or grouping duplicates",
-		Args:         cobra.ExactArgs(1),
+		Use:   "pack [translation-file]",
+		Short: "prepare translation JSON by stripping metadata or grouping duplicates",
+		Long: `Prepare translation JSON by stripping metadata or grouping duplicate strings.
+
+Pass a translation file, or omit it to discover react-intl (FormatJS) locale JSON
+files from your i18n config (i18n.yml or i18n.jsonc by default).`,
+		Args:         cobra.MaximumNArgs(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			payload, err := runPack(args[0], o)
-			if err != nil {
+			if err := validatePackOptions(args, o); err != nil {
 				return err
 			}
 
-			return writePackOutput(cmd, payload, o)
+			if len(args) == 1 {
+				payload, err := runPack(args[0], o)
+				if err != nil {
+					return err
+				}
+				return writePackOutput(cmd, payload, o)
+			}
+
+			paths, err := collectPackLocaleFilesFromConfig(o)
+			if err != nil {
+				return err
+			}
+			if len(paths) == 0 {
+				return fmt.Errorf("pack: no react-intl locale JSON files found")
+			}
+
+			for _, path := range paths {
+				payload, err := runPack(path, o)
+				if err != nil {
+					return fmt.Errorf("pack %q: %w", path, err)
+				}
+				outPath := packOutputPath(path, o.outSuffix)
+				if err := writePackPayloadToFile(payload, outPath); err != nil {
+					return err
+				}
+				if _, err := fmt.Fprintf(cmd.ErrOrStderr(), "packed %s -> %s\n", path, outPath); err != nil {
+					return fmt.Errorf("write pack status: %w", err)
+				}
+			}
+
+			return nil
 		},
 	}
 
 	cmd.Flags().BoolVar(&o.groupByValue, "group-by-value", false, "group ids by shared translation string instead of preserving id-keyed output")
 	cmd.Flags().StringVar(&o.outFile, "out-file", "", "write packed translations to a JSON file")
 	cmd.Flags().BoolVar(&o.prefixID, "prefix-id", false, "strip extract --prefix-id filename prefixes from packed ids")
+	cmd.Flags().StringVar(&o.configPath, "config", "", "path to i18n config (default: i18n.yml or i18n.jsonc in the working directory)")
+	cmd.Flags().StringVar(&o.group, "group", "", "filter config discovery by group name")
+	cmd.Flags().StringVar(&o.bucket, "bucket", "", "filter config discovery by bucket name")
+	cmd.Flags().StringVar(&o.outSuffix, "out-suffix", o.outSuffix, "output filename suffix when packing multiple files (for example .packed -> en-US.packed.json)")
 
 	return cmd
+}
+
+func validatePackOptions(args []string, options packOptions) error {
+	hasFile := len(args) == 1
+
+	switch {
+	case hasFile && strings.TrimSpace(options.configPath) != "":
+		return fmt.Errorf("pack cannot combine a translation file with --config")
+	case !hasFile && strings.TrimSpace(options.outFile) != "":
+		return fmt.Errorf("pack --out-file requires a translation file")
+	case !hasFile && strings.TrimSpace(options.outSuffix) == "":
+		return fmt.Errorf("pack --out-suffix cannot be empty")
+	}
+
+	return nil
+}
+
+func collectPackLocaleFilesFromConfig(options packOptions) ([]string, error) {
+	cfg, err := config.Load(options.configPath)
+	if err != nil {
+		return nil, fmt.Errorf("load config: %w", err)
+	}
+
+	buckets, err := selectedStatusBuckets(cfg, options.group, options.bucket)
+	if err != nil {
+		return nil, err
+	}
+
+	seen := make(map[string]struct{})
+	paths := make([]string, 0)
+	for _, bucketName := range buckets {
+		bucket := cfg.Buckets[bucketName]
+		for _, file := range bucket.Files {
+			sourcePattern := pathresolver.ResolveSourcePath(file.From, cfg.Locales.Source)
+			sourcePaths, err := resolveSourcePathsForStatus(sourcePattern)
+			if err != nil {
+				return nil, fmt.Errorf("resolve source paths for %q: %w", sourcePattern, err)
+			}
+			for _, sourcePath := range sourcePaths {
+				if shouldIgnoreSourcePathForStatus(sourcePath, cfg.Locales.Targets) {
+					continue
+				}
+				cleaned := filepath.Clean(sourcePath)
+				if _, ok := seen[cleaned]; ok {
+					continue
+				}
+				formatJS, err := isPackFormatJSFile(cleaned)
+				if err != nil {
+					if os.IsNotExist(err) {
+						continue
+					}
+					return nil, fmt.Errorf("inspect %q: %w", cleaned, err)
+				}
+				if !formatJS {
+					continue
+				}
+				seen[cleaned] = struct{}{}
+				paths = append(paths, cleaned)
+			}
+		}
+	}
+
+	slices.Sort(paths)
+	return paths, nil
+}
+
+func isPackFormatJSFile(path string) (bool, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(content, &payload); err != nil {
+		return false, fmt.Errorf("json decode: %w", err)
+	}
+	if payload == nil {
+		return false, nil
+	}
+
+	return translationfileparser.IsStrictFormatJSRoot(payload)
+}
+
+func packOutputPath(inputPath, suffix string) string {
+	ext := filepath.Ext(inputPath)
+	base := strings.TrimSuffix(inputPath, ext)
+	return base + suffix + ext
+}
+
+func writePackPayloadToFile(payload any, outPath string) error {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetIndent("", "  ")
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(payload); err != nil {
+		return fmt.Errorf("encode pack output: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+		return fmt.Errorf("create pack output directory: %w", err)
+	}
+	if err := os.WriteFile(outPath, buf.Bytes(), 0o644); err != nil {
+		return fmt.Errorf("write pack output file %q: %w", outPath, err)
+	}
+
+	return nil
 }
 
 func runPack(path string, options packOptions) (any, error) {
@@ -210,23 +363,17 @@ func runPackGrouped(path string, options packOptions) (map[string][]string, erro
 }
 
 func writePackOutput(cmd *cobra.Command, payload any, options packOptions) error {
+	outFile := strings.TrimSpace(options.outFile)
+	if outFile != "" {
+		return writePackPayloadToFile(payload, outFile)
+	}
+
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf)
 	enc.SetIndent("", "  ")
 	enc.SetEscapeHTML(false)
 	if err := enc.Encode(payload); err != nil {
 		return fmt.Errorf("encode pack output: %w", err)
-	}
-
-	outFile := strings.TrimSpace(options.outFile)
-	if outFile != "" {
-		if err := os.MkdirAll(filepath.Dir(outFile), 0o755); err != nil {
-			return fmt.Errorf("create pack output directory: %w", err)
-		}
-		if err := os.WriteFile(outFile, buf.Bytes(), 0o644); err != nil {
-			return fmt.Errorf("write pack output file %q: %w", outFile, err)
-		}
-		return nil
 	}
 
 	if _, err := cmd.OutOrStdout().Write(buf.Bytes()); err != nil {

--- a/apps/cli/cmd/pack_test.go
+++ b/apps/cli/cmd/pack_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -439,6 +440,108 @@ func TestPackCommandWritesOutFile(t *testing.T) {
 		"nav.title":  {DefaultMessage: "Dashboard"},
 	}
 	assertPackCatalogOutput(t, got, want)
+}
+
+func TestPackCommandDiscoversLocaleFilesFromConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	langDir := filepath.Join(dir, "lang")
+	writePackTestFile(t, filepath.Join(langDir, "en-US.json"), `{
+  "home.title": {
+    "defaultMessage": "Dashboard",
+    "description": "Home heading"
+  }
+}`)
+	writePackTestFile(t, filepath.Join(langDir, "plain.json"), `{
+  "home.title": "Dashboard"
+}`)
+
+	writePackConfig(t, filepath.Join(dir, "i18n.jsonc"), filepath.Join(langDir, "{{source}}.json"))
+
+	cmd := newPackCmd()
+	out := bytes.NewBuffer(nil)
+	errOut := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(errOut)
+	cmd.SetArgs(nil)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute pack command: %v", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("expected batch pack to keep stdout empty, got %q", out.String())
+	}
+	if !strings.Contains(errOut.String(), "lang/en-US.packed.json") {
+		t.Fatalf("expected status output for packed file, got %q", errOut.String())
+	}
+
+	content, err := os.ReadFile(filepath.Join(langDir, "en-US.packed.json"))
+	if err != nil {
+		t.Fatalf("read packed output file: %v", err)
+	}
+	got := decodePackCatalogOutput(t, content)
+	want := map[string]extractCatalogMessage{
+		"home.title": {DefaultMessage: "Dashboard"},
+	}
+	assertPackCatalogOutput(t, got, want)
+
+	if _, err := os.Stat(filepath.Join(langDir, "plain.packed.json")); err == nil {
+		t.Fatalf("expected plain JSON file to be skipped during auto discovery")
+	}
+}
+
+func TestPackCommandRejectsFileWithConfigFlag(t *testing.T) {
+	dir := t.TempDir()
+	inputPath := filepath.Join(dir, "messages.json")
+	writePackTestFile(t, inputPath, `{
+  "home.title": {
+    "defaultMessage": "Dashboard"
+  }
+}`)
+
+	cmd := newPackCmd()
+	cmd.SetArgs([]string{inputPath, "--config", filepath.Join(dir, "i18n.jsonc")})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected pack command to reject file plus --config")
+	}
+	if !strings.Contains(err.Error(), "cannot combine") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func writePackConfig(t *testing.T, configPath, sourcePattern string) {
+	t.Helper()
+
+	content := fmt.Sprintf(`{
+  "locales": {
+    "source": "en-US",
+    "targets": ["es-ES"]
+  },
+  "buckets": {
+    "ui": {
+      "files": [
+        {
+          "from": %q,
+          "to": "dist/{{target}}.json"
+        }
+      ]
+    }
+  },
+  "llm": {
+    "profiles": {
+      "default": {
+        "provider": "openai",
+        "model": "gpt-5.2"
+      }
+    }
+  }
+}`, sourcePattern)
+	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write pack config: %v", err)
+	}
 }
 
 func TestRootHelpIncludesPackCommand(t *testing.T) {

--- a/apps/cli/cmd/pack_test.go
+++ b/apps/cli/cmd/pack_test.go
@@ -491,6 +491,68 @@ func TestPackCommandDiscoversLocaleFilesFromConfig(t *testing.T) {
 	}
 }
 
+func TestPackCommandSkipsNonJSONFilesDuringDiscovery(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	langDir := filepath.Join(dir, "lang")
+	writePackTestFile(t, filepath.Join(langDir, "en-US.json"), `{
+  "home.title": {
+    "defaultMessage": "Dashboard"
+  }
+}`)
+	writePackTestFile(t, filepath.Join(langDir, "en-US.yaml"), `home.title: Dashboard`)
+
+	writePackConfigWithFiles(t, filepath.Join(dir, "i18n.jsonc"), []packConfigFileMapping{
+		{from: filepath.Join(langDir, "{{source}}.json"), to: "dist/{{target}}.json"},
+		{from: filepath.Join(langDir, "{{source}}.yaml"), to: "dist/{{target}}.yaml"},
+	})
+
+	cmd := newPackCmd()
+	out := bytes.NewBuffer(nil)
+	errOut := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(errOut)
+	cmd.SetArgs(nil)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute pack command: %v", err)
+	}
+	if !strings.Contains(errOut.String(), "lang/en-US.packed.json") {
+		t.Fatalf("expected status output for packed JSON file, got %q", errOut.String())
+	}
+	if _, err := os.Stat(filepath.Join(langDir, "en-US.packed.json")); err != nil {
+		t.Fatalf("expected packed JSON output file: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(langDir, "en-US.yaml.packed.json")); err == nil {
+		t.Fatalf("expected YAML locale file to be skipped during auto discovery")
+	}
+}
+
+func TestPackCommandRejectsGroupByValueInBatchMode(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	langDir := filepath.Join(dir, "lang")
+	writePackTestFile(t, filepath.Join(langDir, "en-US.json"), `{
+  "home.title": {
+    "defaultMessage": "Dashboard"
+  }
+}`)
+	writePackConfig(t, filepath.Join(dir, "i18n.jsonc"), filepath.Join(langDir, "{{source}}.json"))
+
+	cmd := newPackCmd()
+	cmd.SetArgs([]string{"--group-by-value"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected pack command to reject --group-by-value in batch mode")
+	}
+	if !strings.Contains(err.Error(), "pack --group-by-value requires a translation file") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestPackCommandRejectsFileWithConfigFlag(t *testing.T) {
 	dir := t.TempDir()
 	inputPath := filepath.Join(dir, "messages.json")
@@ -512,8 +574,24 @@ func TestPackCommandRejectsFileWithConfigFlag(t *testing.T) {
 	}
 }
 
-func writePackConfig(t *testing.T, configPath, sourcePattern string) {
+type packConfigFileMapping struct {
+	from string
+	to   string
+}
+
+func writePackConfigWithFiles(t *testing.T, configPath string, files []packConfigFileMapping) {
 	t.Helper()
+
+	var fileEntries strings.Builder
+	for i, file := range files {
+		if i > 0 {
+			fileEntries.WriteString(",\n")
+		}
+		fmt.Fprintf(&fileEntries, `        {
+          "from": %q,
+          "to": %q
+        }`, file.from, file.to)
+	}
 
 	content := fmt.Sprintf(`{
   "locales": {
@@ -523,10 +601,7 @@ func writePackConfig(t *testing.T, configPath, sourcePattern string) {
   "buckets": {
     "ui": {
       "files": [
-        {
-          "from": %q,
-          "to": "dist/{{target}}.json"
-        }
+%s
       ]
     }
   },
@@ -538,10 +613,18 @@ func writePackConfig(t *testing.T, configPath, sourcePattern string) {
       }
     }
   }
-}`, sourcePattern)
+}`, fileEntries.String())
 	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
 		t.Fatalf("write pack config: %v", err)
 	}
+}
+
+func writePackConfig(t *testing.T, configPath, sourcePattern string) {
+	t.Helper()
+
+	writePackConfigWithFiles(t, configPath, []packConfigFileMapping{
+		{from: sourcePattern, to: "dist/{{target}}.json"},
+	})
 }
 
 func TestRootHelpIncludesPackCommand(t *testing.T) {

--- a/docs/commands/pack.mdx
+++ b/docs/commands/pack.mdx
@@ -6,8 +6,10 @@ description: "Prepare translation JSON by stripping metadata or grouping duplica
 ## Usage
 
 ```bash
-hyperlocalise pack <translation-file> [flags]
+hyperlocalise pack [translation-file] [flags]
 ```
+
+Pass a single translation file, or omit it to discover react-intl locale JSON files from your i18n config.
 
 ## Behavior
 
@@ -43,11 +45,21 @@ Use `--group-by-value` to invert the shape and group ids that share the same tra
 }
 ```
 
+### Automatic discovery
+
+When no translation file is passed, `pack` loads your i18n config (`i18n.yml` or `i18n.jsonc` in the working directory by default) and packs every react-intl source locale file referenced by bucket `from` paths. Only JSON files in strict FormatJS shape (`defaultMessage` per id) are packed; plain nested JSON and missing files are skipped.
+
+Batch discovery writes one output file per input, using `--out-suffix` (default `.packed`). For example, `lang/en-US.json` becomes `lang/en-US.packed.json`. Progress is printed to stderr.
+
 ## Flags
 
 - `--group-by-value`: group ids by shared translation string instead of preserving id-keyed output.
-- `--out-file <path>`: write the packed JSON to a file instead of stdout.
+- `--out-file <path>`: write the packed JSON to a file instead of stdout. Use with a single input file only.
 - `--prefix-id`: strip `extract --prefix-id` filename prefixes from ids. For example, `src.components.app-header.title` becomes `title`.
+- `--config <path>`: optional path to i18n config when discovering locale files (default: `i18n.yml` or `i18n.jsonc`).
+- `--group <name>`: filter config discovery by group name.
+- `--bucket <name>`: filter config discovery by bucket name.
+- `--out-suffix <suffix>`: output filename suffix when packing multiple files (default `.packed`).
 
 ## Examples
 
@@ -55,6 +67,18 @@ Strip descriptions from an extracted catalog:
 
 ```bash
 hyperlocalise pack lang/en.json --out-file lang/en.packed.json
+```
+
+Pack every react-intl source locale file from the default i18n config:
+
+```bash
+hyperlocalise pack
+```
+
+Use a custom config path:
+
+```bash
+hyperlocalise pack --config path/to/i18n.yml
 ```
 
 Group duplicate strings for review:

--- a/docs/commands/pack.mdx
+++ b/docs/commands/pack.mdx
@@ -47,13 +47,13 @@ Use `--group-by-value` to invert the shape and group ids that share the same tra
 
 ### Automatic discovery
 
-When no translation file is passed, `pack` loads your i18n config (`i18n.yml` or `i18n.jsonc` in the working directory by default) and packs every react-intl source locale file referenced by bucket `from` paths. Only JSON files in strict FormatJS shape (`defaultMessage` per id) are packed; plain nested JSON and missing files are skipped.
+When no translation file is passed, `pack` loads your i18n config (`i18n.yml` or `i18n.jsonc` in the working directory by default) and packs every react-intl source locale file referenced by bucket `from` paths. Only JSON files in strict FormatJS shape (`defaultMessage` per id) are packed; plain nested JSON, non-JSON files, and missing files are skipped.
 
 Batch discovery writes one output file per input, using `--out-suffix` (default `.packed`). For example, `lang/en-US.json` becomes `lang/en-US.packed.json`. Progress is printed to stderr.
 
 ## Flags
 
-- `--group-by-value`: group ids by shared translation string instead of preserving id-keyed output.
+- `--group-by-value`: group ids by shared translation string instead of preserving id-keyed output. Use with a single input file only.
 - `--out-file <path>`: write the packed JSON to a file instead of stdout. Use with a single input file only.
 - `--prefix-id`: strip `extract --prefix-id` filename prefixes from ids. For example, `src.components.app-header.title` becomes `title`.
 - `--config <path>`: optional path to i18n config when discovering locale files (default: `i18n.yml` or `i18n.jsonc`).

--- a/docs/vi-VN/commands/overview.mdx
+++ b/docs/vi-VN/commands/overview.mdx
@@ -31,7 +31,7 @@ Các lệnh chính:
 - Quy trình làm việc của tệp Crowdin: [crowdin](/commands/crowdin)
 - Tạo bản nháp cục bộ: [run](/commands/run)
 - Trích xuất các danh mục React Intl: [extract](/commands/extract)
-- Nhóm các chuỗi trùng lặp: [pack](/commands/pack)
+- Chuẩn bị JSON bản dịch: [pack](/commands/pack)
 - Thử nghiệm chất lượng và kiểm soát: [eval](/commands/eval)
 - Đang báo cáo tiến độ: [status](/commands/status)
 - Kéo các bản dịch đã được tuyển chọn: [sync pull](/commands/sync-pull)

--- a/docs/vi-VN/commands/pack.mdx
+++ b/docs/vi-VN/commands/pack.mdx
@@ -1,19 +1,43 @@
 ---
 title: "gói"
-description: "Nhóm các ID dịch theo cùng giá trị chuỗi."
+description: "Chuẩn bị JSON bản dịch bằng cách loại bỏ siêu dữ liệu hoặc nhóm các chuỗi trùng lặp."
 ---
 
 ## Cách sử dụng
 
 ```bash
-hyperlocalise pack <translation-file> [--prefix-id]
+hyperlocalise pack [translation-file] [flags]
 ```
+
+Truyền vào một tệp bản dịch duy nhất, hoặc bỏ qua nó để phát hiện các tệp JSON ngôn ngữ react-intl từ cấu hình i18n của bạn.
 
 ## Hành vi
 
-`pack` đọc một tệp bản dịch, nhóm các chuỗi đã dịch giống nhau lại với nhau, và ghi JSON trong đó mỗi khóa là giá trị chuỗi và mỗi giá trị là một mảng các id sử dụng chuỗi đó.
+Theo mặc định, `pack` chuẩn bị một tệp dịch cho các quy trình làm việc tiếp theo bằng cách loại bỏ siêu dữ liệu `description` trong khi vẫn giữ nguyên đầu ra được gắn khóa theo id.
 
-Đối với JSON thông điệp FormatJS, `pack` sử dụng `defaultMessage` làm giá trị chuỗi và bỏ qua siêu dữ liệu `description` khỏi đầu ra.
+Đối với JSON thông điệp FormatJS, đầu ra mặc định giữ nguyên từng id thông điệp và `defaultMessage`:
+
+```json
+{
+  "src.components.app-header.title": {
+    "defaultMessage": "Dashboard"
+  },
+  "src.components.hero.title": {
+    "defaultMessage": "Dashboard"
+  }
+}
+```
+
+Đối với JSON lồng nhau thông thường, đầu ra mặc định là một ánh xạ phẳng từ id sang chuỗi:
+
+```json
+{
+  "home.title": "Dashboard",
+  "nav.title": "Dashboard"
+}
+```
+
+Sử dụng `--group-by-value` để đảo ngược hình dạng và nhóm các id dùng chung cùng một chuỗi bản dịch:
 
 ```json
 {
@@ -21,6 +45,50 @@ hyperlocalise pack <translation-file> [--prefix-id]
 }
 ```
 
+### Khám phá tự động
+
+Khi không có tệp dịch nào được truyền vào, `pack` sẽ tải cấu hình i18n của bạn (`i18n.yml` hoặc `i18n.jsonc` trong thư mục làm việc theo mặc định) và đóng gói mọi tệp ngôn ngữ nguồn react-intl được tham chiếu bởi các đường dẫn của bucket `from`. Chỉ các tệp JSON có định dạng FormatJS nghiêm ngặt (`defaultMessage` cho mỗi id) mới được đóng gói; JSON lồng nhau thông thường và các tệp bị thiếu sẽ bị bỏ qua.
+
+Batch discovery ghi một tệp đầu ra cho mỗi đầu vào, sử dụng `--out-suffix` (mặc định `.packed`). Ví dụ, `lang/en-US.json` trở thành `lang/en-US.packed.json`. Tiến độ được in ra stderr.
+
 ## Các cờ
 
+- `--group-by-value`: nhóm các ID theo chuỗi bản dịch dùng chung thay vì giữ nguyên đầu ra được ánh xạ theo ID.
+- `--out-file <path>`: ghi JSON đã đóng gói vào một tệp thay vì stdout. Chỉ dùng với một tệp đầu vào duy nhất.
 - `--prefix-id`: loại bỏ tiền tố tên tệp `extract --prefix-id` khỏi các id. Ví dụ, `src.components.app-header.title` sẽ trở thành `title`.
+- `--config <path>`: đường dẫn tùy chọn đến cấu hình i18n khi phát hiện các tệp ngôn ngữ (mặc định: `i18n.yml` hoặc `i18n.jsonc`).
+- `--group <name>`: khám phá cấu hình bộ lọc theo tên nhóm.
+- `--bucket <name>`: phát hiện cấu hình bộ lọc theo tên bucket.
+- `--out-suffix <suffix>`: hậu tố tên tệp đầu ra khi đóng gói nhiều tệp (mặc định `.packed`).
+
+## Ví dụ
+
+Xóa mô tả khỏi một catalog đã trích xuất:
+
+```bash
+hyperlocalise pack lang/en.json --out-file lang/en.packed.json
+```
+
+Đóng gói mọi tệp ngôn ngữ nguồn react-intl từ cấu hình i18n mặc định:
+
+```bash
+hyperlocalise pack
+```
+
+Sử dụng đường dẫn cấu hình tùy chỉnh:
+
+```bash
+hyperlocalise pack --config path/to/i18n.yml
+```
+
+Nhóm các chuỗi trùng lặp để xem xét:
+
+```bash
+hyperlocalise pack lang/en.json --group-by-value --out-file lang/duplicates.json
+```
+
+Loại bỏ các id có tiền tố khi nhóm:
+
+```bash
+hyperlocalise pack lang/en.json --group-by-value --prefix-id --out-file lang/packed.json
+```

--- a/docs/zh-CN/commands/overview.mdx
+++ b/docs/zh-CN/commands/overview.mdx
@@ -31,7 +31,7 @@ hyperlocalise [command]
 - Crowdin 文件工作流：[crowdin](/commands/crowdin)
 - 本地草稿生成：[运行](/commands/run)
 - 提取 React Intl 目录： [extract](/commands/extract)
-- 分组重复字符串：[pack](/commands/pack)
+- 准备翻译 JSON：[pack](/commands/pack)
 - 质量实验与门控：[eval](/commands/eval)
 - 报告进度：[状态](/commands/status)
 - 拉取精选翻译：[同步拉取](/commands/sync-pull)

--- a/docs/zh-CN/commands/pack.mdx
+++ b/docs/zh-CN/commands/pack.mdx
@@ -1,19 +1,43 @@
 ---
 title: "打包"
-description: "按共享的字符串值对翻译 ID 进行分组。"
+description: "通过删除元数据或分组重复字符串来准备翻译 JSON。"
 ---
 
 ## 用法
 
 ```bash
-hyperlocalise pack <translation-file> [--prefix-id]
+hyperlocalise pack [translation-file] [flags]
 ```
+
+传入一个单独的翻译文件，或者省略它，以便从你的 i18n 配置中发现 react-intl 语言环境 JSON 文件。
 
 ## 行为
 
-`pack` 读取翻译文件，将相同的译文分组到一起，并写入 JSON，其中每个键都是字符串值，每个值都是使用该字符串的 id 数组。
+默认情况下，`pack` 会通过移除 `description` 元数据来为下游工作流准备翻译文件，同时保留以 id 为键的输出。
 
-对于 FormatJS 消息 JSON，`pack` 使用 `defaultMessage` 作为字符串值，并在输出中省略 `description` 元数据。
+对于 FormatJS 消息 JSON，默认输出会保留每个消息 id 和其`defaultMessage`：
+
+```json
+{
+  "src.components.app-header.title": {
+    "defaultMessage": "Dashboard"
+  },
+  "src.components.hero.title": {
+    "defaultMessage": "Dashboard"
+  }
+}
+```
+
+对于普通的嵌套 JSON，默认输出是一个扁平的 id 到字符串映射：
+
+```json
+{
+  "home.title": "Dashboard",
+  "nav.title": "Dashboard"
+}
+```
+
+使用 `--group-by-value` 来反转形状和共享相同翻译字符串的组 ID：
 
 ```json
 {
@@ -21,6 +45,50 @@ hyperlocalise pack <translation-file> [--prefix-id]
 }
 ```
 
+### 自动发现
+
+当未传入翻译文件时，`pack` 会加载你的 i18n 配置（默认情况下为工作目录中的 `i18n.yml` 或 `i18n.jsonc`），并打包 bucket `from` 路径所引用的每个 react-intl 源语言环境文件。仅会打包严格符合 FormatJS 结构（每个 id 对应 `defaultMessage`）的 JSON 文件；普通的嵌套 JSON 和缺失的文件会被跳过。
+
+批量发现会为每个输入写入一个输出文件，使用`--out-suffix`（默认`.packed`）。例如，`lang/en-US.json`会变为`lang/en-US.packed.json`。进度会打印到 stderr。
+
 ## 标志
 
+- `--group-by-value`：按共享的译文字符串对组 ID 进行分组，而不是保留按 ID 键控的输出。
+- `--out-file <path>`：将打包后的 JSON 写入文件，而不是标准输出。仅与单个输入文件一起使用。
 - `--prefix-id`：从 ids 中去除 `extract --prefix-id` 文件名前缀。例如，`src.components.app-header.title` 会变成 `title`。
+- `--config <path>`：在发现区域设置文件时，i18n 配置的可选路径（默认：`i18n.yml` 或 `i18n.jsonc`）。
+- `--group <name>`：按组名称筛选配置发现。
+- `--bucket <name>`：按存储桶名称筛选配置发现。
+- `--out-suffix <suffix>`：打包多个文件时的输出文件名后缀（默认 `.packed`）。
+
+## 示例
+
+从提取的目录中删除描述：
+
+```bash
+hyperlocalise pack lang/en.json --out-file lang/en.packed.json
+```
+
+打包默认 i18n 配置中的每个 react-intl 源语言环境文件：
+
+```bash
+hyperlocalise pack
+```
+
+使用自定义配置路径：
+
+```bash
+hyperlocalise pack --config path/to/i18n.yml
+```
+
+将重复字符串分组以供审查：
+
+```bash
+hyperlocalise pack lang/en.json --group-by-value --out-file lang/duplicates.json
+```
+
+分组时去除前缀 ID：
+
+```bash
+hyperlocalise pack lang/en.json --group-by-value --prefix-id --out-file lang/packed.json
+```


### PR DESCRIPTION
# feat(cli): auto-discover react-intl locale files in pack

## What changed

`pack` can now discover and pack react-intl (FormatJS) locale JSON files from your i18n config, so you don't have to pass each file individually.

- Omit the translation file argument to load `i18n.yml` or `i18n.jsonc` from the working directory and pack all matching source locale files from bucket `from` paths
- Optional `--config` overrides the config path; `--group` and `--bucket` filter discovery
- Only strict FormatJS catalogs are packed; plain nested JSON and missing files are skipped
- Batch mode writes one output per input using `--out-suffix` (default `.packed`, e.g. `en-US.json` → `en-US.packed.json`) and prints progress to stderr
- Single-file mode is unchanged

Docs updated in `docs/commands/pack.mdx`.

## How to test

```bash
make fmt
make lint
make test
go test ./apps/cli/cmd/... -run Pack -count=1
```