### PR TITLE
fix(cli): discover translation files in pack auto-discovery

### DIFF
--- a/.hyperlocalise.lock.json
+++ b/.hyperlocalise.lock.json
@@ -1243,9 +1243,17 @@
         "s": "f0f21c1c7d2e861a6742ac9de31b9c33",
         "t": "25158174a045a04ee53c23d51c6b2c9c"
       },
+      "md.1fa721a9f54bc75e": {
+        "s": "4268fe5223350e7fb56a460222a146e8",
+        "t": "4770d70e47eb2a4946979bf9d15b7d11"
+      },
       "md.23b314b748d49934": {
         "s": "4b1113b9a64129316d2f2430301280d0",
         "t": "69da8a8c8de3094c08e8e0c952cd26d6"
+      },
+      "md.29c9cf5777f9020e": {
+        "s": "dd8d8bc7191fe39e5c92e3ef6c0c261c",
+        "t": "ca5870a8936680ee7229c4a1edf7569c"
       },
       "md.2f9f7cbbe84ede4e": {
         "s": "a8413356c2e1c99c3020a0aa5603002f",
@@ -1270,6 +1278,10 @@
       "md.4862f447f2c7f272": {
         "s": "8bc0dec4fca7ee0ed72b7a4293430955",
         "t": "3e2e3dad8e81d0f08fdb9c4ac7f8b382"
+      },
+      "md.4f875cc57b06e2fe": {
+        "s": "a9e75f907339a92a1d5e91cdf20379fa",
+        "t": "9ddf942875c1cc235a63fc14bbf9b77d"
       },
       "md.58ce84db325f4b5e": {
         "s": "3267d19e5512324b964546b118c0e666",
@@ -1314,6 +1326,10 @@
       "md.afdc92150a18e311": {
         "s": "143c289a03b3367215faa5857eb261d7",
         "t": "ee2a2a01221949fbd647e6261aacde29"
+      },
+      "md.c7a3b8ae96f7fec3": {
+        "s": "cf6f4f007e8aa64d0fe1a67999309380",
+        "t": "8821d0579d2cdbcaf8689dbb135a4902"
       },
       "md.d7cb13a51e8ed48d": {
         "s": "7f7deea2eb501c55056db2f89dc2a22a",
@@ -12458,9 +12474,17 @@
         "s": "f0f21c1c7d2e861a6742ac9de31b9c33",
         "t": "73b88b65bdc8c3c781d2a5d90cf20025"
       },
+      "md.1fa721a9f54bc75e": {
+        "s": "4268fe5223350e7fb56a460222a146e8",
+        "t": "e240ca8c63a06d0e1d69a4cffb74ae57"
+      },
       "md.23b314b748d49934": {
         "s": "4b1113b9a64129316d2f2430301280d0",
         "t": "d6a8ca38bf9c65d9e051e8bf41911c92"
+      },
+      "md.29c9cf5777f9020e": {
+        "s": "dd8d8bc7191fe39e5c92e3ef6c0c261c",
+        "t": "734fd33ec40a99c6431b40dbd024b432"
       },
       "md.2f9f7cbbe84ede4e": {
         "s": "a8413356c2e1c99c3020a0aa5603002f",
@@ -12485,6 +12509,10 @@
       "md.4862f447f2c7f272": {
         "s": "8bc0dec4fca7ee0ed72b7a4293430955",
         "t": "29cf2d49c0b684dccf99b92fa0f4fd89"
+      },
+      "md.4f875cc57b06e2fe": {
+        "s": "a9e75f907339a92a1d5e91cdf20379fa",
+        "t": "197374e4874fd51e69efc4e379bf3741"
       },
       "md.58ce84db325f4b5e": {
         "s": "3267d19e5512324b964546b118c0e666",
@@ -12529,6 +12557,10 @@
       "md.afdc92150a18e311": {
         "s": "143c289a03b3367215faa5857eb261d7",
         "t": "2cd73f29049932fc043a554a56a1b0d8"
+      },
+      "md.c7a3b8ae96f7fec3": {
+        "s": "cf6f4f007e8aa64d0fe1a67999309380",
+        "t": "6adf4e0a55c8e1588f06e1e9e3d3b598"
       },
       "md.d7cb13a51e8ed48d": {
         "s": "7f7deea2eb501c55056db2f89dc2a22a",

--- a/apps/cli/cmd/pack.go
+++ b/apps/cli/cmd/pack.go
@@ -115,6 +115,14 @@ func collectPackLocaleFilesFromConfig(options packOptions) ([]string, error) {
 		return nil, fmt.Errorf("load config: %w", err)
 	}
 
+	locales, err := resolveStatusLocales(cfg, nil, options.group)
+	if err != nil {
+		return nil, err
+	}
+	if len(locales) == 0 {
+		return nil, fmt.Errorf("pack: no locales selected")
+	}
+
 	buckets, err := selectedStatusBuckets(cfg, options.group, options.bucket)
 	if err != nil {
 		return nil, err
@@ -134,22 +142,29 @@ func collectPackLocaleFilesFromConfig(options packOptions) ([]string, error) {
 				if shouldIgnoreSourcePathForStatus(sourcePath, cfg.Locales.Targets) {
 					continue
 				}
-				cleaned := filepath.Clean(sourcePath)
-				if _, ok := seen[cleaned]; ok {
-					continue
-				}
-				formatJS, err := isPackFormatJSFile(cleaned)
-				if err != nil {
-					if os.IsNotExist(err) {
+				for _, locale := range locales {
+					targetPattern := pathresolver.ResolveTargetPath(file.To, cfg.Locales.Source, locale)
+					targetPath, err := resolveTargetPathForStatus(sourcePattern, targetPattern, sourcePath)
+					if err != nil {
+						return nil, fmt.Errorf("resolve target path for source %q: %w", sourcePath, err)
+					}
+					cleaned := filepath.Clean(targetPath)
+					if _, ok := seen[cleaned]; ok {
 						continue
 					}
-					return nil, fmt.Errorf("inspect %q: %w", cleaned, err)
+					formatJS, err := isPackFormatJSFile(cleaned)
+					if err != nil {
+						if os.IsNotExist(err) {
+							continue
+						}
+						return nil, fmt.Errorf("inspect %q: %w", cleaned, err)
+					}
+					if !formatJS {
+						continue
+					}
+					seen[cleaned] = struct{}{}
+					paths = append(paths, cleaned)
 				}
-				if !formatJS {
-					continue
-				}
-				seen[cleaned] = struct{}{}
-				paths = append(paths, cleaned)
 			}
 		}
 	}

--- a/apps/cli/cmd/pack_test.go
+++ b/apps/cli/cmd/pack_test.go
@@ -447,9 +447,16 @@ func TestPackCommandDiscoversLocaleFilesFromConfig(t *testing.T) {
 	t.Chdir(dir)
 
 	langDir := filepath.Join(dir, "lang")
+	distDir := filepath.Join(dir, "dist")
 	writePackTestFile(t, filepath.Join(langDir, "en-US.json"), `{
   "home.title": {
     "defaultMessage": "Dashboard",
+    "description": "Home heading"
+  }
+}`)
+	writePackTestFile(t, filepath.Join(distDir, "es-ES.json"), `{
+  "home.title": {
+    "defaultMessage": "Panel",
     "description": "Home heading"
   }
 }`)
@@ -472,20 +479,23 @@ func TestPackCommandDiscoversLocaleFilesFromConfig(t *testing.T) {
 	if out.Len() != 0 {
 		t.Fatalf("expected batch pack to keep stdout empty, got %q", out.String())
 	}
-	if !strings.Contains(errOut.String(), "lang/en-US.packed.json") {
+	if !strings.Contains(errOut.String(), "dist/es-ES.packed.json") {
 		t.Fatalf("expected status output for packed file, got %q", errOut.String())
 	}
 
-	content, err := os.ReadFile(filepath.Join(langDir, "en-US.packed.json"))
+	content, err := os.ReadFile(filepath.Join(distDir, "es-ES.packed.json"))
 	if err != nil {
 		t.Fatalf("read packed output file: %v", err)
 	}
 	got := decodePackCatalogOutput(t, content)
 	want := map[string]extractCatalogMessage{
-		"home.title": {DefaultMessage: "Dashboard"},
+		"home.title": {DefaultMessage: "Panel"},
 	}
 	assertPackCatalogOutput(t, got, want)
 
+	if _, err := os.Stat(filepath.Join(langDir, "en-US.packed.json")); err == nil {
+		t.Fatalf("expected source locale file to be skipped during auto discovery")
+	}
 	if _, err := os.Stat(filepath.Join(langDir, "plain.packed.json")); err == nil {
 		t.Fatalf("expected plain JSON file to be skipped during auto discovery")
 	}
@@ -496,16 +506,22 @@ func TestPackCommandSkipsNonJSONFilesDuringDiscovery(t *testing.T) {
 	t.Chdir(dir)
 
 	langDir := filepath.Join(dir, "lang")
+	distDir := filepath.Join(dir, "dist")
 	writePackTestFile(t, filepath.Join(langDir, "en-US.json"), `{
   "home.title": {
     "defaultMessage": "Dashboard"
   }
 }`)
-	writePackTestFile(t, filepath.Join(langDir, "en-US.yaml"), `home.title: Dashboard`)
+	writePackTestFile(t, filepath.Join(distDir, "es-ES.json"), `{
+  "home.title": {
+    "defaultMessage": "Panel"
+  }
+}`)
+	writePackTestFile(t, filepath.Join(distDir, "es-ES.yaml"), `home.title: Panel`)
 
 	writePackConfigWithFiles(t, filepath.Join(dir, "i18n.jsonc"), []packConfigFileMapping{
-		{from: filepath.Join(langDir, "{{source}}.json"), to: "dist/{{target}}.json"},
-		{from: filepath.Join(langDir, "{{source}}.yaml"), to: "dist/{{target}}.yaml"},
+		{from: filepath.Join(langDir, "{{source}}.json"), to: filepath.Join(distDir, "{{target}}.json")},
+		{from: filepath.Join(langDir, "{{source}}.yaml"), to: filepath.Join(distDir, "{{target}}.yaml")},
 	})
 
 	cmd := newPackCmd()
@@ -518,13 +534,13 @@ func TestPackCommandSkipsNonJSONFilesDuringDiscovery(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("execute pack command: %v", err)
 	}
-	if !strings.Contains(errOut.String(), "lang/en-US.packed.json") {
+	if !strings.Contains(errOut.String(), "dist/es-ES.packed.json") {
 		t.Fatalf("expected status output for packed JSON file, got %q", errOut.String())
 	}
-	if _, err := os.Stat(filepath.Join(langDir, "en-US.packed.json")); err != nil {
+	if _, err := os.Stat(filepath.Join(distDir, "es-ES.packed.json")); err != nil {
 		t.Fatalf("expected packed JSON output file: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(langDir, "en-US.yaml.packed.json")); err == nil {
+	if _, err := os.Stat(filepath.Join(distDir, "es-ES.yaml.packed.json")); err == nil {
 		t.Fatalf("expected YAML locale file to be skipped during auto discovery")
 	}
 }

--- a/docs/commands/pack.mdx
+++ b/docs/commands/pack.mdx
@@ -47,9 +47,9 @@ Use `--group-by-value` to invert the shape and group ids that share the same tra
 
 ### Automatic discovery
 
-When no translation file is passed, `pack` loads your i18n config (`i18n.yml` or `i18n.jsonc` in the working directory by default) and packs every react-intl source locale file referenced by bucket `from` paths. Only JSON files in strict FormatJS shape (`defaultMessage` per id) are packed; plain nested JSON, non-JSON files, and missing files are skipped.
+When no translation file is passed, `pack` loads your i18n config (`i18n.yml` or `i18n.jsonc` in the working directory by default) and packs every react-intl translation file referenced by bucket `to` paths for the selected target locales. Only JSON files in strict FormatJS shape (`defaultMessage` per id) are packed; plain nested JSON, non-JSON files, and missing files are skipped.
 
-Batch discovery writes one output file per input, using `--out-suffix` (default `.packed`). For example, `lang/en-US.json` becomes `lang/en-US.packed.json`. Progress is printed to stderr.
+Batch discovery writes one output file per input, using `--out-suffix` (default `.packed`). For example, `lang/es-ES.json` becomes `lang/es-ES.packed.json`. Progress is printed to stderr.
 
 ## Flags
 
@@ -69,7 +69,7 @@ Strip descriptions from an extracted catalog:
 hyperlocalise pack lang/en.json --out-file lang/en.packed.json
 ```
 
-Pack every react-intl source locale file from the default i18n config:
+Pack every react-intl translation file from the default i18n config:
 
 ```bash
 hyperlocalise pack

--- a/docs/vi-VN/commands/pack.mdx
+++ b/docs/vi-VN/commands/pack.mdx
@@ -47,13 +47,13 @@ Sử dụng `--group-by-value` để đảo ngược hình dạng và nhóm các
 
 ### Khám phá tự động
 
-Khi không có tệp dịch nào được truyền vào, `pack` sẽ tải cấu hình i18n của bạn (`i18n.yml` hoặc `i18n.jsonc` trong thư mục làm việc theo mặc định) và đóng gói mọi tệp ngôn ngữ nguồn react-intl được tham chiếu bởi các đường dẫn của bucket `from`. Chỉ các tệp JSON có định dạng FormatJS nghiêm ngặt (`defaultMessage` cho mỗi id) mới được đóng gói; JSON lồng nhau thông thường và các tệp bị thiếu sẽ bị bỏ qua.
+Khi không có tệp dịch nào được truyền vào, `pack` sẽ tải cấu hình i18n của bạn (mặc định là `i18n.yml` hoặc `i18n.jsonc` trong thư mục làm việc) và đóng gói mọi tệp dịch react-intl được tham chiếu bởi các đường dẫn bucket `to` cho các locale mục tiêu đã chọn. Chỉ các tệp JSON có định dạng FormatJS nghiêm ngặt (`defaultMessage` cho mỗi id) mới được đóng gói; JSON lồng thuần túy, các tệp không phải JSON và các tệp bị thiếu sẽ bị bỏ qua.
 
-Batch discovery ghi một tệp đầu ra cho mỗi đầu vào, sử dụng `--out-suffix` (mặc định `.packed`). Ví dụ, `lang/en-US.json` trở thành `lang/en-US.packed.json`. Tiến độ được in ra stderr.
+Khám phá hàng loạt sẽ ghi một tệp đầu ra cho mỗi đầu vào, sử dụng `--out-suffix` (mặc định `.packed`). Ví dụ, `lang/es-ES.json` trở thành `lang/es-ES.packed.json`. Tiến trình được in ra stderr.
 
 ## Các cờ
 
-- `--group-by-value`: nhóm các ID theo chuỗi bản dịch dùng chung thay vì giữ nguyên đầu ra được ánh xạ theo ID.
+- `--group-by-value`: nhóm các id theo chuỗi dịch dùng chung thay vì giữ đầu ra được khóa theo id. Chỉ sử dụng với một tệp đầu vào duy nhất.
 - `--out-file <path>`: ghi JSON đã đóng gói vào một tệp thay vì stdout. Chỉ dùng với một tệp đầu vào duy nhất.
 - `--prefix-id`: loại bỏ tiền tố tên tệp `extract --prefix-id` khỏi các id. Ví dụ, `src.components.app-header.title` sẽ trở thành `title`.
 - `--config <path>`: đường dẫn tùy chọn đến cấu hình i18n khi phát hiện các tệp ngôn ngữ (mặc định: `i18n.yml` hoặc `i18n.jsonc`).
@@ -69,7 +69,7 @@ Xóa mô tả khỏi một catalog đã trích xuất:
 hyperlocalise pack lang/en.json --out-file lang/en.packed.json
 ```
 
-Đóng gói mọi tệp ngôn ngữ nguồn react-intl từ cấu hình i18n mặc định:
+Đóng gói mọi tệp dịch react-intl từ cấu hình i18n mặc định:
 
 ```bash
 hyperlocalise pack

--- a/docs/zh-CN/commands/pack.mdx
+++ b/docs/zh-CN/commands/pack.mdx
@@ -47,13 +47,13 @@ hyperlocalise pack [translation-file] [flags]
 
 ### 自动发现
 
-当未传入翻译文件时，`pack` 会加载你的 i18n 配置（默认情况下为工作目录中的 `i18n.yml` 或 `i18n.jsonc`），并打包 bucket `from` 路径所引用的每个 react-intl 源语言环境文件。仅会打包严格符合 FormatJS 结构（每个 id 对应 `defaultMessage`）的 JSON 文件；普通的嵌套 JSON 和缺失的文件会被跳过。
+当未传入翻译文件时，`pack` 会加载你的 i18n 配置（默认情况下为工作目录中的 `i18n.yml` 或 `i18n.jsonc`），并打包桶 `to` 路径所引用的每个 react-intl 翻译文件，供所选目标区域设置使用。只有严格符合 FormatJS 结构的 JSON 文件（每个 id 对应 `defaultMessage`）会被打包；普通的嵌套 JSON、非 JSON 文件以及缺失文件都会被跳过。
 
-批量发现会为每个输入写入一个输出文件，使用`--out-suffix`（默认`.packed`）。例如，`lang/en-US.json`会变为`lang/en-US.packed.json`。进度会打印到 stderr。
+批量发现会为每个输入写入一个输出文件，使用 `--out-suffix`（默认 `.packed`）。例如，`lang/es-ES.json` 会变为 `lang/es-ES.packed.json`。进度会打印到 stderr。
 
 ## 标志
 
-- `--group-by-value`：按共享的译文字符串对组 ID 进行分组，而不是保留按 ID 键控的输出。
+- `--group-by-value`：按共享的译文字符串对组 ID，而不是保留按 ID 键控的输出。仅与单个输入文件一起使用。
 - `--out-file <path>`：将打包后的 JSON 写入文件，而不是标准输出。仅与单个输入文件一起使用。
 - `--prefix-id`：从 ids 中去除 `extract --prefix-id` 文件名前缀。例如，`src.components.app-header.title` 会变成 `title`。
 - `--config <path>`：在发现区域设置文件时，i18n 配置的可选路径（默认：`i18n.yml` 或 `i18n.jsonc`）。
@@ -69,7 +69,7 @@ hyperlocalise pack [translation-file] [flags]
 hyperlocalise pack lang/en.json --out-file lang/en.packed.json
 ```
 
-打包默认 i18n 配置中的每个 react-intl 源语言环境文件：
+打包默认 i18n 配置中的每个 react-intl 翻译文件：
 
 ```bash
 hyperlocalise pack


### PR DESCRIPTION
Resolve bucket to paths for target locales instead of packing source locale files from from paths.

## What changed

<!-- Describe the change and why it is needed. -->

## How to test

<!-- List manual checks or commands used to verify this change. -->

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review
