### PR TITLE
fix(web): classify GitHub JWT decode failures as app credential errors

### DIFF
--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/agent/_components/github-agent-card.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/agent/_components/github-agent-card.tsx
@@ -26,7 +26,7 @@ const GITHUB_CONNECT_ERROR_MESSAGES: Record<string, string> = {
     "GitHub is waiting for an org owner to approve this app install. Approve it on GitHub, then connect again.",
   github_app_not_configured: "GitHub App integration is not configured for this environment.",
   github_app_private_key_invalid:
-    "The GitHub App private key in this environment is invalid or malformed. Re-save GITHUB_APP_PRIVATE_KEY as the PEM from GitHub (use literal \\n line breaks or base64-encode the whole file).",
+    "GitHub rejected the app credentials in this environment. Set GITHUB_APP_ID to the App ID from GitHub App settings and GITHUB_APP_PRIVATE_KEY to the matching PEM (use literal \\n line breaks or base64-encode the whole file).",
   github_installation_invalid:
     "GitHub rejected the installation ID. Confirm the app is installed on the expected account.",
   github_installation_already_linked:

--- a/apps/hyperlocalise-web/src/app/auth/github/callback/page.test.ts
+++ b/apps/hyperlocalise-web/src/app/auth/github/callback/page.test.ts
@@ -332,6 +332,28 @@ describe("GitHubCallbackPage", () => {
     expect(getGitHubAppMock).not.toHaveBeenCalled();
   });
 
+  it("redirects when GitHub rejects app JWT credentials", async () => {
+    const { slug, state } = await createCallbackState({ role: "admin" });
+    getGitHubAppMock.mockReturnValueOnce({
+      octokit: {
+        rest: {
+          apps: {
+            getInstallation: vi.fn(async () => {
+              throw new Error(
+                "A JSON web token could not be decoded - https://docs.github.com/rest",
+              );
+            }),
+          },
+        },
+      },
+    });
+
+    await expect(runCallback(state)).rejects.toThrow(
+      `redirect:/org/${slug}/agent?error=github_app_private_key_invalid`,
+    );
+    expect(syncInstallationRepositoriesMock).not.toHaveBeenCalled();
+  });
+
   it("rejects missing GitHub app configuration before consuming state", async () => {
     envOverrides.GITHUB_APP_ID = undefined;
     const { nonce, state } = await createCallbackState({ role: "admin" });

--- a/apps/hyperlocalise-web/src/lib/agents/github/app.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/app.ts
@@ -1,3 +1,5 @@
+import { createPrivateKey } from "node:crypto";
+
 import { App, type Octokit } from "octokit";
 
 import { env } from "@/lib/env";
@@ -17,6 +19,7 @@ export function getGitHubAppPrivateKey(): string {
   if (!cachedPrivateKey) {
     const normalized = normalizeGitHubAppPrivateKey(env.GITHUB_APP_PRIVATE_KEY);
     assertGitHubAppPrivateKeyParsable(normalized);
+    createPrivateKey({ key: normalized });
     cachedPrivateKey = normalized;
   }
 

--- a/apps/hyperlocalise-web/src/lib/agents/github/app.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/app.ts
@@ -19,7 +19,11 @@ export function getGitHubAppPrivateKey(): string {
   if (!cachedPrivateKey) {
     const normalized = normalizeGitHubAppPrivateKey(env.GITHUB_APP_PRIVATE_KEY);
     assertGitHubAppPrivateKeyParsable(normalized);
-    createPrivateKey({ key: normalized });
+    try {
+      createPrivateKey({ key: normalized });
+    } catch {
+      throw new Error("invalid GitHub App private key PEM format");
+    }
     cachedPrivateKey = normalized;
   }
 

--- a/apps/hyperlocalise-web/src/lib/agents/github/private-key.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/private-key.test.ts
@@ -78,6 +78,25 @@ describe("isGitHubAppPrivateKeyDecoderError", () => {
     ).toBe(true);
   });
 
+  it("detects GitHub JWT decode failures from app authentication", () => {
+    expect(
+      isGitHubAppPrivateKeyDecoderError(
+        new Error("A JSON web token could not be decoded - https://docs.github.com/rest"),
+      ),
+    ).toBe(true);
+  });
+
+  it("detects JWT decode failures nested in GitHub API response payloads", () => {
+    const error = new Error("Bad credentials") as Error & {
+      response: { data: { message: string } };
+    };
+    error.response = {
+      data: { message: "A JSON web token could not be decoded" },
+    };
+
+    expect(isGitHubAppPrivateKeyDecoderError(error)).toBe(true);
+  });
+
   it("ignores unrelated errors", () => {
     expect(isGitHubAppPrivateKeyDecoderError(new Error("Not Found"))).toBe(false);
   });

--- a/apps/hyperlocalise-web/src/lib/agents/github/private-key.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/private-key.ts
@@ -50,17 +50,34 @@ export function assertGitHubAppPrivateKeyParsable(privateKey: string): void {
   }
 }
 
-export function isGitHubAppPrivateKeyDecoderError(error: unknown): boolean {
+function githubApiErrorText(error: unknown): string {
   if (!(error instanceof Error)) {
-    return false;
+    return String(error).toLowerCase();
   }
 
-  const message = error.message.toLowerCase();
+  const parts = [error.message];
+  if ("response" in error && error.response && typeof error.response === "object") {
+    const response = error.response as { data?: unknown };
+    if (response.data && typeof response.data === "object" && response.data !== null) {
+      const data = response.data as { message?: string };
+      if (typeof data.message === "string") {
+        parts.push(data.message);
+      }
+    }
+  }
+
+  return parts.join(" ").toLowerCase();
+}
+
+/** Local PEM/OpenSSL failures and GitHub JWT auth rejections for app credentials. */
+export function isGitHubAppPrivateKeyDecoderError(error: unknown): boolean {
+  const message = githubApiErrorText(error);
   return (
     message.includes("decoder routines") ||
     message.includes("no start line") ||
     message.includes("bad decrypt") ||
     message.includes("error:1e08010c") ||
-    message.includes("invalid github app private key pem format")
+    message.includes("invalid github app private key pem format") ||
+    message.includes("json web token could not be decoded")
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When GitHub rejects the app authentication JWT during install callback (`apps.getInstallation`), the API returns:

> A JSON web token could not be decoded

Previously this was logged with `privateKeyMisconfigured: false` and users were redirected to `github_installation_invalid`, which points at the installation ID rather than server credentials.

This change:

- Treats GitHub JWT decode failures as app credential misconfiguration (same redirect as OpenSSL/PEM errors: `github_app_private_key_invalid`)
- Validates the normalized PEM with `createPrivateKey` before caching in `getGitHubAppPrivateKey()`
- Updates agent card copy to mention both `GITHUB_APP_ID` and `GITHUB_APP_PRIVATE_KEY`

## Root cause (ops)

This error almost always means the deployed **App ID** and **private key** do not belong to the same GitHub App, or the PEM was truncated/corrupted when copied into the secret store. PEM normalization from #734 fixes escaped newlines; this PR improves detection when GitHub still rejects the signed JWT.

## Testing

- `vp test src/lib/agents/github/private-key.test.ts` (passes)
- Added unit coverage for JWT decode message detection and callback redirect behavior
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8b0c87f-1b17-4390-9640-b6ae1ece4784"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8b0c87f-1b17-4390-9640-b6ae1ece4784"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

