### PR TITLE
🛡️ Sentinel: Restricting additional internal redirect targets

### DIFF
--- a/apps/hyperlocalise-web/src/lib/workos/return-to.test.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/return-to.test.ts
@@ -29,6 +29,9 @@ describe("sanitizeReturnTo", () => {
     expect(sanitizeReturnTo("/auth/sign-out")).toBe("/dashboard");
     expect(sanitizeReturnTo("/auth/callback")).toBe("/dashboard");
     expect(sanitizeReturnTo("/auth/github/callback")).toBe("/dashboard");
+    expect(sanitizeReturnTo("/auth/select-organization")).toBe("/dashboard");
+    expect(sanitizeReturnTo("/auth/onboarding")).toBe("/dashboard");
+    expect(sanitizeReturnTo("/auth/access-denied")).toBe("/dashboard");
   });
 
   it("should return the fallback if the value starts with a restricted auth path followed by ?, #, or /", () => {

--- a/apps/hyperlocalise-web/src/lib/workos/return-to.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/return-to.ts
@@ -3,6 +3,9 @@ const RESTRICTED_PATHS = [
   "/auth/sign-out",
   "/auth/callback",
   "/auth/github/callback",
+  "/auth/select-organization",
+  "/auth/onboarding",
+  "/auth/access-denied",
 ];
 
 export function sanitizeReturnTo(value: string | null | undefined, fallback = "/dashboard") {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `sanitizeReturnTo` utility allowed redirecting back to certain sensitive internal authentication and onboarding routes (e.g., `/auth/select-organization`, `/auth/onboarding`, `/auth/access-denied`).
🎯 Impact: This could be exploited to create redirect loops or send users to confusing/incorrect states during the authentication flow.
🔧 Fix: Added these sensitive paths to the `RESTRICTED_PATHS` list in the redirect sanitizer.
✅ Verification: Added unit tests to `return-to.test.ts` covering the new paths and verified they all pass.

---
*PR created automatically by Jules for task [10708249761479497053](https://jules.google.com/task/10708249761479497053) started by @cungminh2710*