### PR TITLE
fix(slack): resolve GitHub repo context for copy search requests

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/conversation/chat-stream.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/chat-stream.route.ts
@@ -4,11 +4,12 @@ import { Hono } from "hono";
 import type { AuthVariables } from "@/api/auth/workos";
 import { workosAuthMiddleware } from "@/api/auth/workos";
 import {
+  buildTranslationAttachmentRequiredMessage,
   createConversationToolLoopAgent,
   loadInteractionModelMessages,
 } from "@/lib/agents/hyperlocalise-agent";
 import { db, schema } from "@/lib/database";
-import { addInteractionMessage } from "@/lib/interactions";
+import { addInteractionMessage, interactionHasTranslationAttachments } from "@/lib/interactions";
 
 import { conversationIdParamsSchema } from "./conversation.schema";
 
@@ -45,6 +46,17 @@ export function createChatStreamRoutes() {
 
       if (conversation.source !== "chat_ui") {
         return c.json({ error: "conversation_not_replyable" }, 400);
+      }
+
+      const hasTranslationAttachments = await interactionHasTranslationAttachments(conversationId);
+      if (!hasTranslationAttachments) {
+        return c.json(
+          {
+            error: "translation_requires_attachment",
+            message: buildTranslationAttachmentRequiredMessage("web"),
+          },
+          400,
+        );
       }
 
       const chatMessages = await loadInteractionModelMessages(conversationId);

--- a/apps/hyperlocalise-web/src/lib/agents/hyperlocalise-agent.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/hyperlocalise-agent.test.ts
@@ -128,6 +128,24 @@ describe("hyperlocalise agent core", () => {
     ).toEqual({ kind: "repo_tms", githubContextRequirement: "repository" });
   });
 
+  it("classifies GitHub copy lookup requests as repo/TMS repository intent", () => {
+    expect(
+      classifyHyperlocaliseAgentIntent({
+        surface: "slack",
+        text: "Can you help me find the context of the text 'Email agent' in our github",
+      }),
+    ).toEqual({ kind: "repo_tms", githubContextRequirement: "repository" });
+  });
+
+  it("classifies owner/repository-only Slack replies as repo/TMS repository intent", () => {
+    expect(
+      classifyHyperlocaliseAgentIntent({
+        surface: "slack",
+        text: "hyperlocalise/hyperlocalise",
+      }),
+    ).toEqual({ kind: "repo_tms", githubContextRequirement: "repository" });
+  });
+
   it("converts interaction rows to model messages", () => {
     expect(
       toModelMessages([

--- a/apps/hyperlocalise-web/src/lib/agents/hyperlocalise-agent.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/hyperlocalise-agent.test.ts
@@ -72,7 +72,7 @@ describe("hyperlocalise agent core", () => {
     expect(instructions).toContain("bold labels");
     expect(instructions).toContain("relevant emoji");
     expect(instructions).toContain("This conversation is attached to project proj_123.");
-    expect(instructions).toContain("Call getProjectContext");
+    expect(instructions).toContain("createTranslationJob");
   });
 
   it("builds missing-project guidance for web conversations", () => {
@@ -81,8 +81,7 @@ describe("hyperlocalise agent core", () => {
       projectId: null,
     });
 
-    expect(instructions).toContain("This conversation is NOT attached to a project yet.");
-    expect(instructions).toContain("call listProjects");
+    expect(instructions).toContain("searchRepoFiles");
   });
 
   it("classifies GitHub pull request URLs as repo/TMS pull request intent", () => {
@@ -95,7 +94,7 @@ describe("hyperlocalise agent core", () => {
       kind: "repo_tms",
       githubContextRequirement: "pull_request",
     });
-    expect(getActiveToolsForHyperlocaliseAgentIntent(intent)).toContain("createSyncJob");
+    expect(getActiveToolsForHyperlocaliseAgentIntent(intent)).toContain("searchRepoFiles");
     expect(buildHyperlocaliseAgentIntentInstructions(intent)).toContain(
       "Intent: repository/TMS work.",
     );
@@ -208,14 +207,14 @@ describe("hyperlocalise agent core", () => {
     createConversationToolLoopAgent({
       surface: "web",
       toolContext,
-      intent: { kind: "repo_tms", githubContextRequirement: "repository" },
+      hasFileAttachments: true,
     });
 
     expect(buildToolsMock).toHaveBeenCalledWith(toolContext);
     expect(toolLoopAgentMock).toHaveBeenCalledWith(
       expect.objectContaining({
         tools: { listProjects: { description: "mock tool" } },
-        activeTools: expect.arrayContaining(["createSyncJob"]),
+        activeTools: ["createTranslationJob"],
       }),
     );
   });

--- a/apps/hyperlocalise-web/src/lib/agents/hyperlocalise-agent.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/hyperlocalise-agent.ts
@@ -14,7 +14,10 @@ import { env } from "@/lib/env";
 import { buildTools } from "@/lib/tools/registry";
 import type { ToolContext } from "@/lib/tools/types";
 
-import { githubPullRequestUrlPatternSource } from "./repo-tms-context";
+import {
+  extractGitHubRepositoryFullNameReferences,
+  githubPullRequestUrlPatternSource,
+} from "./repo-tms-context";
 
 export const hyperlocaliseAgentModelId = "gpt-5.4-mini";
 export const hyperlocaliseAgentStepLimit = 5;
@@ -76,6 +79,8 @@ const intentToolsets = {
     "listProjects",
     "getProjectContext",
     "updateInteractionProject",
+    "searchRepoFiles",
+    "readRepoFile",
     "createSyncJob",
     "resolveInteraction",
   ],
@@ -155,6 +160,8 @@ export function buildHyperlocaliseAgentIntentInstructions(intent: HyperlocaliseA
     return [
       "Intent: repository/TMS work.",
       "Use only the repository context provided by the source adapter.",
+      "Strings in owner/repository format (for example hyperlocalise/hyperlocalise) are GitHub repositories, not Hyperlocalise projects. Do not call listProjects to resolve them.",
+      "When the user asks to find or locate text in GitHub, use searchRepoFiles with the quoted string as the pattern, then readRepoFile for surrounding context when needed.",
       "Do not infer or invent a GitHub repository, pull request, branch, or installation ID.",
       "If repository/TMS execution is unavailable, say that clearly and keep the response tied to the resolved context.",
     ].join("\n");
@@ -172,12 +179,38 @@ function isRepoTmsPullRequestIntent(text: string) {
 }
 
 function isRepoTmsRepositoryIntent(text: string) {
+  if (isExplicitGitHubRepositoryMessage(text)) {
+    return true;
+  }
+
   const repoSubject = /\b(?:repo|repository|github|hl|hyperlocalise)\b/i.test(text);
-  const repoAction = /\b(?:checks?|fix|review|scan|inspect|sync|extract|analy[sz]e)\b/i.test(text);
+  const repoAction =
+    /\b(?:checks?|fix|review|scan|inspect|sync|extract|analy[sz]e|search|find(?:ing)?|locate|lookup)\b/i.test(
+      text,
+    );
   const repoRunAction = /\brun\s+(?:the\s+)?(?:repo|repository|github|hl|hyperlocalise)\b/i.test(
     text,
   );
   return repoSubject && (repoAction || repoRunAction);
+}
+
+function isExplicitGitHubRepositoryMessage(text: string) {
+  const references = extractGitHubRepositoryFullNameReferences(text);
+  if (references.length !== 1) {
+    return false;
+  }
+
+  const repositoryFullName = references[0]!;
+  const remainder = text
+    .replace(new RegExp(escapeRegExp(repositoryFullName), "gi"), "")
+    .replace(/https?:\/\/(?:www\.)?github\.com\/[^\s]+/gi, "")
+    .trim();
+
+  return remainder.length <= 40;
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 export function getHyperlocaliseAgentModel() {
@@ -230,8 +263,15 @@ export function buildHyperlocaliseAgentInstructions(input: {
     lines.push(
       "- This conversation is NOT attached to a project yet.",
       "- If the user mentions a project by name, call listProjects to find it, then call updateInteractionProject to attach it.",
+      "- If the user gives owner/repository (for example hyperlocalise/hyperlocalise), that is a GitHub repository name — not a Hyperlocalise project. Do not call listProjects for it.",
       "- If the user asks about translation without mentioning a project, you can still call queryGlossary and queryTranslationMemory org-wide.",
       "- If a project would help (e.g. the user says 'for the mobile app'), always attach it before translating.",
+    );
+  }
+
+  if (input.surface === "slack") {
+    lines.push(
+      "- When the user asks to find text or copy in GitHub, the Slack integration will queue a repository workflow when a GitHub repo is enabled — do not ask them to pick a Hyperlocalise project for that.",
     );
   }
 

--- a/apps/hyperlocalise-web/src/lib/agents/hyperlocalise-agent.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/hyperlocalise-agent.ts
@@ -11,6 +11,8 @@ import {
 
 import { db, schema } from "@/lib/database";
 import { env } from "@/lib/env";
+import { escapeRegExp } from "@/lib/primitives/escapeRegExp/escapeRegExp";
+import { getConversationActiveTools } from "@/lib/tools/conversation-tools";
 import { buildTools } from "@/lib/tools/registry";
 import type { ToolContext } from "@/lib/tools/types";
 
@@ -66,48 +68,21 @@ type CreateConversationAgentInput = {
 };
 
 const intentToolsets = {
-  translation: [
-    "listProjects",
-    "getProjectContext",
-    "updateInteractionProject",
-    "queryGlossary",
-    "queryTranslationMemory",
-    "createTranslationJob",
-    "readStoredFile",
-  ],
+  translation: ["createTranslationJob", "searchRepoFiles", "readRepoFile"],
   repo_tms: [
-    "listProjects",
-    "getProjectContext",
-    "updateInteractionProject",
     "searchRepoFiles",
     "readRepoFile",
-    "createSyncJob",
-    "resolveInteraction",
+    "detectRepoConfig",
+    "applyHyperlocaliseFixes",
+    "commitChanges",
+    "pushToBranch",
+    "uploadSources",
   ],
-  job_status: ["listJobs", "getJobStatus", "resolveInteraction"],
-  glossary_memory: [
-    "queryGlossary",
-    "queryTranslationMemory",
-    "listGlossaries",
-    "createGlossary",
-    "updateGlossary",
-    "deleteGlossary",
-    "listGlossaryTerms",
-    "createGlossaryTerm",
-    "updateGlossaryTerm",
-    "deleteGlossaryTerm",
-    "listTranslationMemories",
-    "createTranslationMemory",
-    "updateTranslationMemory",
-    "deleteTranslationMemory",
-    "listMemoryEntries",
-    "createMemoryEntry",
-    "updateMemoryEntry",
-    "deleteMemoryEntry",
-  ],
-  project: ["listProjects", "getProjectContext", "updateInteractionProject"],
-  general: undefined,
-} satisfies Record<HyperlocaliseAgentIntentKind, string[] | undefined>;
+  job_status: [],
+  glossary_memory: [],
+  project: [],
+  general: [],
+} satisfies Record<HyperlocaliseAgentIntentKind, string[]>;
 
 const githubPullRequestUrlPattern = new RegExp(githubPullRequestUrlPatternSource, "i");
 
@@ -151,8 +126,21 @@ export function classifyHyperlocaliseAgentIntent(input: {
 
 export function getActiveToolsForHyperlocaliseAgentIntent(
   intent: HyperlocaliseAgentIntent,
-): ToolLoopAgentSettings<never, ToolSet>["activeTools"] | undefined {
+): ToolLoopAgentSettings<never, ToolSet>["activeTools"] {
   return intentToolsets[intent.kind];
+}
+
+export function buildTranslationAttachmentRequiredMessage(surface: HyperlocaliseAgentSurface) {
+  const lines = [
+    "I can translate supported files, localize images, or search your connected GitHub repository.",
+    "Attach a file or image with a target language, or ask me to find text in a repo you have enabled in Agent → GitHub.",
+  ];
+
+  if (surface === "slack") {
+    lines.push("Supported file types include JSON, CSV, XLIFF, and other localization formats.");
+  }
+
+  return lines.join(" ");
 }
 
 export function buildHyperlocaliseAgentIntentInstructions(intent: HyperlocaliseAgentIntent) {
@@ -209,10 +197,6 @@ function isExplicitGitHubRepositoryMessage(text: string) {
   return remainder.length <= 40;
 }
 
-function escapeRegExp(value: string) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
 export function getHyperlocaliseAgentModel() {
   if (!env.OPENAI_API_KEY) {
     throw new Error("OPENAI_API_KEY is not configured");
@@ -227,8 +211,8 @@ export function buildHyperlocaliseAgentInstructions(input: {
   additionalInstructions?: string;
 }) {
   const lines = [
-    "You are Hyperlocalise, an expert localization and translation assistant.",
-    "You help teams translate content, manage glossaries, review translations, and organize localization projects.",
+    "You are Hyperlocalise, a localization assistant focused on file translation and GitHub repository lookup.",
+    "Use the tools you are given; do not guess repository paths or file contents.",
   ];
 
   if (input.surface === "slack") {
@@ -241,50 +225,24 @@ export function buildHyperlocaliseAgentInstructions(input: {
     );
   }
 
-  lines.push(
-    "",
-    "You can answer questions about:",
-    "- Translation strategies and best practices",
-    "- Locale-specific formatting, cultural adaptation, and regional conventions",
-    "- Managing translation workflows, jobs, and project organization",
-    "- Using glossaries and translation memories effectively",
-    "- Quality assurance and review processes for localized content",
-    "",
-    "Project context:",
-  );
-
   if (input.projectId) {
     lines.push(
+      "",
+      "Project context:",
       `- This conversation is attached to project ${input.projectId}.`,
-      "- Call getProjectContext when you need the project's name, description, translation rules, or attached glossaries and memories.",
-      "- Call updateInteractionProject only if the user explicitly says they want to switch to a different project.",
-    );
-  } else {
-    lines.push(
-      "- This conversation is NOT attached to a project yet.",
-      "- If the user mentions a project by name, call listProjects to find it, then call updateInteractionProject to attach it.",
-      "- If the user gives owner/repository (for example hyperlocalise/hyperlocalise), that is a GitHub repository name — not a Hyperlocalise project. Do not call listProjects for it.",
-      "- If the user asks about translation without mentioning a project, you can still call queryGlossary and queryTranslationMemory org-wide.",
-      "- If a project would help (e.g. the user says 'for the mobile app'), always attach it before translating.",
-    );
-  }
-
-  if (input.surface === "slack") {
-    lines.push(
-      "- When the user asks to find text or copy in GitHub, the Slack integration will queue a repository workflow when a GitHub repo is enabled — do not ask them to pick a Hyperlocalise project for that.",
     );
   }
 
   lines.push(
     "",
     "Guidelines:",
+    '- Use createTranslationJob with type "file" when sourceFileId values are present in the message.',
+    "- Use searchRepoFiles with the user's quoted string as the pattern, then readRepoFile for surrounding context.",
+    "- Ask for targetLocales (and sourceLocale when missing) before creating a translation job.",
+    "- Do not invent sourceFileId values; use only IDs provided in the conversation.",
+    "- If the user asks to find copy in GitHub but repo search tools are unavailable, say the repository context is missing.",
     "- Be concise but thorough. Responses should be scannable.",
-    "- When suggesting translations, consider context, tone, and target audience.",
-    "- If you need more information to provide a good answer, ask clarifying questions.",
-    "- You can create translation jobs, suggest glossary terms, and inspect existing jobs.",
-    "- Review, research, sync, and asset-management jobs are not runnable yet; use the matching unavailable-job tool if a user asks to queue one.",
     "- Always maintain a professional, helpful tone.",
-    "- If a request is outside your capabilities, give a clear fallback response explaining what you can do instead.",
   );
 
   if (input.additionalInstructions?.trim()) {
@@ -360,16 +318,17 @@ export function createConversationToolLoopAgent({
   surface,
   toolContext,
   additionalInstructions,
-  intent,
   onFinish,
-}: CreateConversationAgentInput) {
+  hasFileAttachments = false,
+}: Omit<CreateConversationAgentInput, "intent"> & { hasFileAttachments?: boolean }) {
   const tools = buildTools(toolContext);
+  const activeTools = getConversationActiveTools(toolContext, { hasFileAttachments });
   return createHyperlocaliseAgent({
     surface,
     projectId: toolContext.projectId,
     tools,
     additionalInstructions,
-    activeTools: intent ? getActiveToolsForHyperlocaliseAgentIntent(intent) : undefined,
+    activeTools,
     onFinish,
   });
 }

--- a/apps/hyperlocalise-web/src/lib/agents/repo-tms-context.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/repo-tms-context.test.ts
@@ -261,6 +261,58 @@ describe("resolveSlackRepoTmsGitHubContext", () => {
     });
   });
 
+  it("lists enabled repositories once when resolving an explicit owner/repo reference", async () => {
+    const listEnabledRepositories = vi.fn(async () => [
+      {
+        installationId: 12345,
+        repositoryFullName: "org/enabled-repo",
+        defaultBranch: "main",
+      },
+    ]);
+
+    await resolveSlackRepoTmsGitHubContext({
+      organizationId: "org_123",
+      text: "Find the text 'Email agent' in org/disabled-repo",
+      requirePullRequest: false,
+      dependencies: createDependencies({
+        findEnabledRepository: vi.fn(async () => null),
+        listEnabledRepositories,
+      }),
+    });
+
+    expect(listEnabledRepositories).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not substitute a different enabled repository when an explicit owner/repo is unavailable", async () => {
+    const resolution = await resolveSlackRepoTmsGitHubContext({
+      organizationId: "org_123",
+      text: "Find the text 'Email agent' in org/disabled-repo",
+      requirePullRequest: false,
+      dependencies: createDependencies({
+        findEnabledRepository: vi.fn(async () => null),
+        listEnabledRepositories: vi.fn(async () => [
+          {
+            installationId: 12345,
+            repositoryFullName: "org/enabled-repo",
+            defaultBranch: "main",
+          },
+        ]),
+      }),
+    });
+
+    expect(resolution).toMatchObject({
+      status: "unresolved",
+      context: {
+        resolved: false,
+        reason: "The GitHub repository is not enabled for this workspace.",
+      },
+      followUp: expect.stringContaining("org/disabled-repo"),
+    });
+    expect(resolution).toMatchObject({
+      followUp: expect.stringContaining("enabled for this workspace"),
+    });
+  });
+
   it("falls back to the only enabled repository when an explicit owner/repo is not enabled", async () => {
     const resolution = await resolveSlackRepoTmsGitHubContext({
       organizationId: "org_123",

--- a/apps/hyperlocalise-web/src/lib/agents/repo-tms-context.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/repo-tms-context.test.ts
@@ -257,7 +257,34 @@ describe("resolveSlackRepoTmsGitHubContext", () => {
         resolved: false,
         reason: "The GitHub repository is not enabled for this workspace.",
       },
-      followUp: expect.stringContaining("can't access that pull request"),
+      followUp: expect.stringContaining("enabled for this workspace"),
+    });
+  });
+
+  it("falls back to the only enabled repository when an explicit owner/repo is not enabled", async () => {
+    const resolution = await resolveSlackRepoTmsGitHubContext({
+      organizationId: "org_123",
+      text: "Find the text 'Email agent' in hyperlocalise/hyperlocalise",
+      requirePullRequest: false,
+      dependencies: createDependencies({
+        findEnabledRepository: vi.fn(async () => null),
+        listEnabledRepositories: vi.fn(async () => [
+          {
+            installationId: 12345,
+            repositoryFullName: "hyperlocalise/hyperlocalise",
+            defaultBranch: "main",
+          },
+        ]),
+      }),
+    });
+
+    expect(resolution).toMatchObject({
+      status: "resolved",
+      source: "single_installed_repository",
+      context: {
+        resolved: true,
+        repositoryFullName: "hyperlocalise/hyperlocalise",
+      },
     });
   });
 

--- a/apps/hyperlocalise-web/src/lib/agents/repo-tms-context.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/repo-tms-context.ts
@@ -1,5 +1,5 @@
 import type { GitHubRawMessage } from "@chat-adapter/github";
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 
 import { db, schema } from "@/lib/database";
 
@@ -330,10 +330,24 @@ async function resolveInstalledGitHubContext(input: {
     repositoryFullName,
   });
   if (!repository) {
+    const enabledRepositories = await input.dependencies.listEnabledRepositories({
+      organizationId: input.organizationId,
+    });
+    const singleRepository = getSingleInstalledRepository(enabledRepositories);
+    if (singleRepository?.enabledRepository) {
+      return resolveEnabledGitHubRepositoryContext({
+        repository: singleRepository.enabledRepository,
+        pullRequestNumber: input.pullRequestNumber,
+        source: singleRepository.source,
+        accessFailureFollowUp: input.accessFailureFollowUp,
+        dependencies: input.dependencies,
+      });
+    }
+
     return unresolved(
       "The GitHub repository is not enabled for this workspace.",
-      "Install the GitHub App for the repository and enable it in Hyperlocalise.",
-      input.accessFailureFollowUp,
+      "Install the GitHub App for the repository and enable it in Agent → GitHub.",
+      `I couldn't find \`${repositoryFullName}\` among the GitHub repositories enabled for this workspace. Open Agent → GitHub, enable the repository, or ask again without naming the repo when only one is enabled.`,
     );
   }
 
@@ -615,7 +629,7 @@ export const defaultRepoTmsGitHubContextDependencies: RepoTmsGitHubContextDepend
       .where(
         and(
           eq(schema.githubInstallationRepositories.organizationId, input.organizationId),
-          eq(schema.githubInstallationRepositories.fullName, input.repositoryFullName),
+          sql`lower(${schema.githubInstallationRepositories.fullName}) = lower(${input.repositoryFullName})`,
           eq(schema.githubInstallationRepositories.enabled, true),
         ),
       )

--- a/apps/hyperlocalise-web/src/lib/agents/repo-tms-context.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/repo-tms-context.ts
@@ -3,6 +3,8 @@ import { and, eq, sql } from "drizzle-orm";
 
 import { db, schema } from "@/lib/database";
 
+import { escapeRegExp } from "@/lib/primitives/escapeRegExp/escapeRegExp";
+
 import { getInstallationOctokit } from "./github/app";
 import type {
   RepoTmsAgentGitHubContext,
@@ -235,6 +237,7 @@ export async function resolveSlackRepoTmsGitHubContext(input: {
     pullRequestNumber: pullRequestNumber ?? undefined,
     source: fallback.source,
     accessFailureFollowUp: `I found repository context for ${fallback.repositoryFullName}, but I can't access it with the GitHub App installation. Please check the app is installed and the repository is enabled for this workspace.`,
+    installedRepositories,
     dependencies,
   });
 }
@@ -314,6 +317,7 @@ async function resolveInstalledGitHubContext(input: {
   pullRequestNumber?: number;
   source: ResolvedContextSource;
   accessFailureFollowUp: string;
+  installedRepositories?: EnabledGitHubRepository[];
   dependencies: RepoTmsGitHubContextDependencies;
 }): Promise<RepoTmsGitHubContextResolution> {
   const repositoryFullName = normalizeRepositoryFullName(input.repositoryFullName);
@@ -330,11 +334,16 @@ async function resolveInstalledGitHubContext(input: {
     repositoryFullName,
   });
   if (!repository) {
-    const enabledRepositories = await input.dependencies.listEnabledRepositories({
-      organizationId: input.organizationId,
-    });
+    const enabledRepositories =
+      input.installedRepositories ??
+      (await input.dependencies.listEnabledRepositories({
+        organizationId: input.organizationId,
+      }));
     const singleRepository = getSingleInstalledRepository(enabledRepositories);
-    if (singleRepository?.enabledRepository) {
+    if (
+      singleRepository?.enabledRepository &&
+      repositoryFullName.toLowerCase() === singleRepository.repositoryFullName.toLowerCase()
+    ) {
       return resolveEnabledGitHubRepositoryContext({
         repository: singleRepository.enabledRepository,
         pullRequestNumber: input.pullRequestNumber,
@@ -548,10 +557,6 @@ function slackTextContainsRepositoryName(text: string, repositoryFullName: strin
     `(^|[^A-Za-z0-9_.-])${escapeRegExp(repositoryName)}($|[^A-Za-z0-9_.-])`,
     "i",
   ).test(text);
-}
-
-function escapeRegExp(value: string) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function repositoryFullNameFromConfigValue(value: unknown): string | null {

--- a/apps/hyperlocalise-web/src/lib/agents/repo-tms-sandbox.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/repo-tms-sandbox.ts
@@ -1,0 +1,37 @@
+import { Sandbox } from "@vercel/sandbox";
+
+import { getInstallationOctokit } from "@/lib/agents/github/app";
+import type { RepoTmsAgentGitHubContext } from "@/lib/agents/repo-tms-task";
+
+const sandboxTimeoutMs = 10 * 60 * 1000;
+
+type InstallationAuth = {
+  token: string;
+};
+
+type ResolvedRepoTmsGitHubContext = Extract<RepoTmsAgentGitHubContext, { resolved: true }>;
+
+export async function createRepoTmsSandbox(
+  githubContext: ResolvedRepoTmsGitHubContext,
+): Promise<string> {
+  const octokit = await getInstallationOctokit(githubContext.installationId);
+  const { token } = (await octokit.auth({ type: "installation" })) as InstallationAuth;
+  const sandbox = await Sandbox.create({
+    source: {
+      type: "git",
+      url: `https://github.com/${githubContext.repositoryFullName}.git`,
+      revision: githubContext.commitSha ?? githubContext.branch ?? "HEAD",
+      depth: 1,
+      username: "x-access-token",
+      password: token,
+    },
+    timeout: sandboxTimeoutMs,
+  });
+
+  return sandbox.sandboxId;
+}
+
+export async function stopRepoTmsSandbox(sandboxId: string): Promise<void> {
+  const sandbox = await Sandbox.get({ sandboxId });
+  await sandbox.stop();
+}

--- a/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
@@ -9,8 +9,6 @@ import {
   handleSubscribedMessage,
   wrapThreadPost,
 } from "./bot";
-import { buildRepoTmsTaskIdempotencyKey } from "@/lib/agents/repo-tms-task";
-
 const {
   agentGenerateMock,
   createConversationToolLoopAgentMock,
@@ -93,6 +91,11 @@ vi.mock("@/lib/tools/registry", () => ({
 
 vi.mock("@/lib/image-generation", () => ({
   regenerateImageFromAttachment: vi.fn(),
+}));
+
+vi.mock("@/lib/agents/repo-tms-sandbox", () => ({
+  createRepoTmsSandbox: vi.fn(async () => "sbx_test"),
+  stopRepoTmsSandbox: vi.fn(async () => undefined),
 }));
 
 vi.mock("@/lib/file-storage/records", () => ({
@@ -434,22 +437,11 @@ describe("handleNewConversation", () => {
       senderEmail: "alice@example.com",
     });
     expect(getSubscribed()).toBe(true);
-    expect(createConversationToolLoopAgentMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        surface: "slack",
-        toolContext: expect.objectContaining({
-          conversationId: "interaction-123",
-          organizationId: "org-123",
-          localUserId: "user-123",
-          membershipRole: "member",
-          projectId: null,
-        }),
-      }),
-    );
-    expect(agentGenerateMock).toHaveBeenCalledWith({
-      messages: [{ role: "user", content: "Help me translate" }],
-    });
-    expect(posts).toEqual([{ markdown: "AI response" }]);
+    expect(createConversationToolLoopAgentMock).not.toHaveBeenCalled();
+    expect(agentGenerateMock).not.toHaveBeenCalled();
+    expect(posts).toEqual([
+      expect.objectContaining({ markdown: expect.stringContaining("Attach") }),
+    ]);
   });
 
   it("does not resolve GitHub context for ordinary translation chat", async () => {
@@ -521,49 +513,75 @@ describe("handleNewConversation", () => {
       channelId: "C123",
       requirePullRequest: true,
     });
-    expect(createConversationToolLoopAgentMock).not.toHaveBeenCalled();
-    expect(enqueueRepoTmsTaskMock).toHaveBeenCalledTimes(1);
-    expect(enqueueRepoTmsTaskMock).toHaveBeenCalledWith(
+    expect(enqueueRepoTmsTaskMock).not.toHaveBeenCalled();
+    expect(createConversationToolLoopAgentMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        source: "slack",
-        sourceThreadId: thread.id,
-        actor: {
-          sourceUserId: message.author.userId,
-          userId: "user-123",
-          email: "alice@example.com",
-          displayName: "Alice",
-          role: "member",
-        },
-        organizationId: "org-123",
-        projectId: "project-123",
-        workMode: "read_only",
-        instructions: "Can you check https://github.com/acme/web/pull/42",
-        githubContext: {
-          resolved: true,
-          installationId: 12345,
-          repositoryFullName: "acme/web",
-          pullRequestNumber: 42,
-        },
-        idempotencyKey: buildRepoTmsTaskIdempotencyKey({
-          source: "slack",
-          sourceThreadId: thread.id,
-          organizationId: "org-123",
-          instructions: "Can you check https://github.com/acme/web/pull/42",
-          githubContext: {
-            resolved: true,
-            installationId: 12345,
-            repositoryFullName: "acme/web",
-            pullRequestNumber: 42,
-          },
+        surface: "slack",
+        toolContext: expect.objectContaining({
+          sandboxId: "sbx_test",
+          workMode: "read_only",
         }),
       }),
     );
-    expect(posts).toEqual([
-      {
-        markdown:
-          "Queued your read-only repo/TMS workflow. I'll gather context and post results in this thread.",
+    expect(agentGenerateMock).toHaveBeenCalled();
+    expect(posts).toEqual([{ markdown: "AI response" }]);
+  });
+
+  it("resolves GitHub context from the current Slack message only", async () => {
+    const { thread } = createThread();
+    const message = createMessage({
+      text: "Find 'Email agent' in org/new-repo",
+      raw: { team_id: "T123", channel: "C123" },
+    });
+
+    loadMessagesMock.mockResolvedValueOnce([
+      { role: "user", content: "Find 'Email agent' in org/old-repo" },
+      { role: "assistant", content: "I searched org/old-repo." },
+    ] as never);
+    resolveSlackRepoTmsGitHubContextMock.mockResolvedValueOnce({
+      status: "resolved",
+      source: "slack_repo_reference",
+      context: {
+        resolved: true,
+        installationId: 12345,
+        repositoryFullName: "org/new-repo",
       },
-    ]);
+    });
+    vi.mocked(findSlackConnector).mockResolvedValue({
+      id: "connector-123",
+      organizationId: "org-123",
+      enabled: true,
+      config: {},
+    } as never);
+    vi.mocked(lookupMembership).mockResolvedValue({
+      role: "member",
+      localUserId: "user-123",
+    } as never);
+    vi.mocked(findInteractionBySourceThreadId).mockResolvedValue({
+      id: "interaction-123",
+      title: "Existing",
+      projectId: "project-123",
+    } as never);
+    vi.mocked(addInteractionMessage).mockResolvedValue({ id: "msg-123" } as never);
+
+    await handleNewConversation(thread, message);
+
+    expect(resolveSlackRepoTmsGitHubContextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "Find 'Email agent' in org/new-repo",
+        requirePullRequest: false,
+      }),
+    );
+    expect(enqueueRepoTmsTaskMock).not.toHaveBeenCalled();
+    expect(createConversationToolLoopAgentMock).toHaveBeenCalled();
+    expect(agentGenerateMock).toHaveBeenCalledWith({
+      messages: expect.arrayContaining([
+        expect.objectContaining({
+          role: "user",
+          content: expect.stringContaining("org/old-repo"),
+        }),
+      ]),
+    });
   });
 
   it("queues write-mode repo/TMS Slack tasks for workspace admins", async () => {
@@ -655,7 +673,17 @@ describe("handleNewConversation", () => {
 
   it("resumes existing interaction and posts AI response", async () => {
     const { thread, posts, getSubscribed } = createThread();
-    const message = createMessage({ text: "Follow up" });
+    const message = createMessage({
+      text: "Translate to French",
+      attachments: [
+        {
+          type: "file",
+          name: "copy.json",
+          mimeType: "application/json",
+          fetchData: vi.fn(async () => Buffer.from("{}")),
+        },
+      ],
+    });
 
     vi.mocked(findSlackConnector).mockResolvedValue({
       id: "connector-123",
@@ -679,10 +707,11 @@ describe("handleNewConversation", () => {
     expect(addInteractionMessage).toHaveBeenCalledWith({
       interactionId: "interaction-123",
       senderType: "user",
-      text: "Follow up",
+      text: "Translate to French",
       senderEmail: "alice@example.com",
     });
     expect(getSubscribed()).toBe(false);
+    expect(createConversationToolLoopAgentMock).toHaveBeenCalled();
     expect(agentGenerateMock).toHaveBeenCalled();
     expect(posts).toEqual([{ markdown: "AI response" }]);
   });
@@ -790,7 +819,17 @@ describe("handleSubscribedMessage", () => {
 
   it("creates or resumes interaction and posts AI response", async () => {
     const { thread, posts } = createThread();
-    const message = createMessage({ text: "Second message" });
+    const message = createMessage({
+      text: "Translate to German",
+      attachments: [
+        {
+          type: "file",
+          name: "copy.json",
+          mimeType: "application/json",
+          fetchData: vi.fn(async () => Buffer.from("{}")),
+        },
+      ],
+    });
 
     vi.mocked(findSlackConnector).mockResolvedValue({
       id: "connector-123",
@@ -813,9 +852,10 @@ describe("handleSubscribedMessage", () => {
     expect(addInteractionMessage).toHaveBeenCalledWith({
       interactionId: "interaction-123",
       senderType: "user",
-      text: "Second message",
+      text: expect.stringContaining("Translate to German"),
       senderEmail: "alice@example.com",
     });
+    expect(createConversationToolLoopAgentMock).toHaveBeenCalled();
     expect(agentGenerateMock).toHaveBeenCalled();
     expect(posts).toEqual([{ markdown: "AI response" }]);
 

--- a/apps/hyperlocalise-web/src/lib/agents/slack/bot.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/bot.ts
@@ -6,11 +6,16 @@ import type { Message, Thread, UserInfo } from "chat";
 import {
   buildHyperlocaliseAgentIntentInstructions,
   classifyHyperlocaliseAgentIntent,
+  buildTranslationAttachmentRequiredMessage,
   createConversationToolLoopAgent,
   loadInteractionModelMessages,
   replaceLastUserMessage,
 } from "@/lib/agents/hyperlocalise-agent";
-import { resolveSlackRepoTmsGitHubContext } from "@/lib/agents/repo-tms-context";
+import {
+  buildRepoTmsGitHubContextInstructions,
+  resolveSlackRepoTmsGitHubContext,
+} from "@/lib/agents/repo-tms-context";
+import { createRepoTmsSandbox, stopRepoTmsSandbox } from "@/lib/agents/repo-tms-sandbox";
 import {
   buildRepoTmsTaskIdempotencyKey,
   type RepoTmsAgentGitHubContext,
@@ -200,7 +205,7 @@ async function processSlackMessage(
     if (intent.kind === "repo_tms") {
       const githubContextResolution = await resolveSlackRepoTmsGitHubContext({
         organizationId,
-        text: repoTmsInstructions,
+        text: message.text,
         connectorConfig,
         projectId,
         channelId: getSlackChannelId(thread, message),
@@ -223,41 +228,103 @@ async function processSlackMessage(
       const repoTmsWorkMode = hasCapability(membership.role, "integrations:write")
         ? "write"
         : "read_only";
-      const repoTmsTask: RepoTmsAgentTask = {
-        id: randomUUID(),
-        source: "slack",
-        sourceThreadId: thread.id,
-        actor: {
-          sourceUserId: message.author.userId,
-          userId: membership.localUserId,
-          email: slackUser?.email,
-          displayName: message.author.fullName ?? message.author.userName,
-          role: membership.role,
-        },
-        organizationId,
-        projectId,
-        workMode: repoTmsWorkMode,
-        instructions: repoTmsInstructions,
-        githubContext: resolvedRepoTmsContext,
-        createdAt: new Date().toISOString(),
-        idempotencyKey: buildRepoTmsTaskIdempotencyKey({
+
+      if (repoTmsWorkMode === "write") {
+        const repoTmsTask: RepoTmsAgentTask = {
+          id: randomUUID(),
           source: "slack",
           sourceThreadId: thread.id,
+          actor: {
+            sourceUserId: message.author.userId,
+            userId: membership.localUserId,
+            email: slackUser?.email,
+            displayName: message.author.fullName ?? message.author.userName,
+            role: membership.role,
+          },
           organizationId,
+          projectId,
+          workMode: repoTmsWorkMode,
           instructions: repoTmsInstructions,
           githubContext: resolvedRepoTmsContext,
-        }),
-      };
-      await createRepoTmsAgentTaskQueue().enqueue(repoTmsTask);
+          createdAt: new Date().toISOString(),
+          idempotencyKey: buildRepoTmsTaskIdempotencyKey({
+            source: "slack",
+            sourceThreadId: thread.id,
+            organizationId,
+            instructions: repoTmsInstructions,
+            githubContext: resolvedRepoTmsContext,
+          }),
+        };
+        await createRepoTmsAgentTaskQueue().enqueue(repoTmsTask);
 
-      await removeEyesReaction(thread, message);
-      wrapThreadPost(thread, interactionId);
-      await thread.post({
-        markdown:
-          repoTmsWorkMode === "write"
-            ? "Queued your repo/TMS workflow. I'll post progress and final results in this thread."
-            : "Queued your read-only repo/TMS workflow. I'll gather context and post results in this thread.",
-      });
+        await removeEyesReaction(thread, message);
+        wrapThreadPost(thread, interactionId);
+        await thread.post({
+          markdown:
+            "Queued your repo/TMS workflow. I'll post progress and final results in this thread.",
+        });
+        return;
+      }
+
+      if (!resolvedRepoTmsContext) {
+        await removeEyesReaction(thread, message);
+        wrapThreadPost(thread, interactionId);
+        await thread.post({
+          markdown: buildTranslationAttachmentRequiredMessage("slack"),
+        });
+        return;
+      }
+
+      let sandboxId: string | null = null;
+      try {
+        sandboxId = await createRepoTmsSandbox(resolvedRepoTmsContext);
+        const chatMessages = replaceLastUserMessage(
+          await loadInteractionModelMessages(interactionId),
+          repoTmsInstructions,
+        );
+        const agent = createConversationToolLoopAgent({
+          surface: "slack",
+          toolContext: {
+            conversationId: interactionId,
+            organizationId,
+            localUserId: membership.localUserId,
+            membershipRole: membership.role,
+            projectId,
+            db,
+            sandboxId,
+            githubContext: resolvedRepoTmsContext,
+            workMode: "read_only",
+            repoTmsSource: "slack",
+            actor: {
+              sourceUserId: message.author.userId,
+              userId: membership.localUserId,
+              role: membership.role,
+            },
+          },
+          additionalInstructions: [
+            buildSlackFileTranslationInstructions(),
+            intentInstructions,
+            buildRepoTmsGitHubContextInstructions(resolvedRepoTmsContext),
+            "Use searchRepoFiles with the user's quoted string, then readRepoFile for surrounding lines.",
+          ]
+            .filter((instruction): instruction is string => instruction !== null)
+            .join("\n\n"),
+        });
+        const result = await agent.generate({ messages: chatMessages });
+
+        await removeEyesReaction(thread, message);
+        wrapThreadPost(thread, interactionId);
+        const replyText = result.text.trim();
+        if (replyText) {
+          await thread.post({ markdown: replyText });
+        }
+      } finally {
+        if (sandboxId) {
+          await stopRepoTmsSandbox(sandboxId).catch(() => {
+            // Best-effort cleanup
+          });
+        }
+      }
       return;
     }
 
@@ -332,6 +399,15 @@ async function processSlackMessage(
       }
     }
 
+    if (storedFileAttachments.length === 0) {
+      await removeEyesReaction(thread, message);
+      wrapThreadPost(thread, interactionId);
+      await thread.post({
+        markdown: buildTranslationAttachmentRequiredMessage("slack"),
+      });
+      return;
+    }
+
     const agent = createConversationToolLoopAgent({
       surface: "slack",
       toolContext: {
@@ -342,7 +418,7 @@ async function processSlackMessage(
         projectId,
         db,
       },
-      intent,
+      hasFileAttachments: true,
       additionalInstructions: additionalInstructions
         .filter((instruction): instruction is string => instruction !== null)
         .join("\n\n"),
@@ -360,7 +436,7 @@ async function processSlackMessage(
     wrapThreadPost(thread, interactionId);
     await thread.post({
       markdown:
-        "I'm having trouble processing that right now. I can help with translation jobs, project questions, glossary lookups, and job status checks. How can I assist you?",
+        "I'm having trouble processing that right now. Attach a supported file or image with a target language and I can help translate it.",
     });
   }
 }

--- a/apps/hyperlocalise-web/src/lib/agents/slack/bot.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/bot.ts
@@ -97,6 +97,32 @@ function buildSlackFileTranslationInstructions() {
   return `When a Slack message includes stored source file IDs, create file translation jobs with type "file", the provided sourceFileId and fileFormat, targetLocales, and sourceLocale. Use sourceLocale "auto" if the user did not specify a source locale. Supported file job formats: ${supportedFileTranslationFileFormats.join(", ")}.`;
 }
 
+async function buildSlackRepoTmsInstructions(
+  interactionId: string,
+  latestText: string,
+): Promise<string> {
+  const messages = await loadInteractionModelMessages(interactionId);
+  const userLines = messages.flatMap((chatMessage) => {
+    if (chatMessage.role !== "user" || typeof chatMessage.content !== "string") {
+      return [];
+    }
+
+    const text = chatMessage.content.trim();
+    return text ? [text] : [];
+  });
+
+  const trimmedLatest = latestText.trim();
+  if (trimmedLatest && userLines.at(-1) !== trimmedLatest) {
+    userLines.push(trimmedLatest);
+  }
+
+  if (userLines.length === 0) {
+    return trimmedLatest;
+  }
+
+  return userLines.slice(-5).join("\n");
+}
+
 function getSlackChannelId(thread: Thread<SlackBotState>, message: Message): string | null {
   const channelId = thread.channelId;
   if (typeof channelId === "string" && channelId.length > 0) {
@@ -166,11 +192,15 @@ async function processSlackMessage(
     const intentInstructions = buildHyperlocaliseAgentIntentInstructions(intent);
     const additionalInstructions = [buildSlackFileTranslationInstructions(), intentInstructions];
     let resolvedRepoTmsContext: RepoTmsAgentGitHubContext | undefined;
+    const repoTmsInstructions =
+      intent.kind === "repo_tms"
+        ? await buildSlackRepoTmsInstructions(interactionId, message.text)
+        : message.text;
 
     if (intent.kind === "repo_tms") {
       const githubContextResolution = await resolveSlackRepoTmsGitHubContext({
         organizationId,
-        text: message.text,
+        text: repoTmsInstructions,
         connectorConfig,
         projectId,
         channelId: getSlackChannelId(thread, message),
@@ -207,14 +237,14 @@ async function processSlackMessage(
         organizationId,
         projectId,
         workMode: repoTmsWorkMode,
-        instructions: message.text,
+        instructions: repoTmsInstructions,
         githubContext: resolvedRepoTmsContext,
         createdAt: new Date().toISOString(),
         idempotencyKey: buildRepoTmsTaskIdempotencyKey({
           source: "slack",
           sourceThreadId: thread.id,
           organizationId,
-          instructions: message.text,
+          instructions: repoTmsInstructions,
           githubContext: resolvedRepoTmsContext,
         }),
       };

--- a/apps/hyperlocalise-web/src/lib/interactions.ts
+++ b/apps/hyperlocalise-web/src/lib/interactions.ts
@@ -2,6 +2,8 @@ import { and, eq } from "drizzle-orm";
 
 import { db, schema } from "@/lib/database";
 
+const sourceFileIdPattern = /\bsourceFileId=/;
+
 type CreateInteractionInput = {
   organizationId: string;
   source: "chat_ui" | "email_agent" | "github_agent" | "slack_agent";
@@ -74,6 +76,25 @@ export async function addInteractionMessage(input: AddMessageInput) {
     .where(eq(schema.inboxItems.interactionId, input.interactionId));
 
   return message;
+}
+
+export async function interactionHasTranslationAttachments(interactionId: string) {
+  const messages = await db
+    .select({
+      text: schema.interactionMessages.text,
+      attachments: schema.interactionMessages.attachments,
+    })
+    .from(schema.interactionMessages)
+    .where(eq(schema.interactionMessages.interactionId, interactionId));
+
+  return messages.some((message) => {
+    if (sourceFileIdPattern.test(message.text)) {
+      return true;
+    }
+
+    const attachments = message.attachments;
+    return Array.isArray(attachments) && attachments.length > 0;
+  });
 }
 
 export async function updateInteractionMessage(

--- a/apps/hyperlocalise-web/src/lib/primitives/escapeRegExp/escapeRegExp.ts
+++ b/apps/hyperlocalise-web/src/lib/primitives/escapeRegExp/escapeRegExp.ts
@@ -1,0 +1,3 @@
+export function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/apps/hyperlocalise-web/src/lib/tools/conversation-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/conversation-tools.ts
@@ -1,0 +1,22 @@
+import type { ToolContext } from "./types";
+
+export const conversationFileTranslationToolNames = ["createTranslationJob"] as const;
+
+export const conversationRepoSearchToolNames = ["searchRepoFiles", "readRepoFile"] as const;
+
+export function getConversationActiveTools(
+  ctx: ToolContext,
+  input: { hasFileAttachments?: boolean } = {},
+): string[] {
+  const tools: string[] = [];
+
+  if (input.hasFileAttachments) {
+    tools.push(...conversationFileTranslationToolNames);
+  }
+
+  if (ctx.sandboxId) {
+    tools.push(...conversationRepoSearchToolNames);
+  }
+
+  return tools;
+}

--- a/apps/hyperlocalise-web/src/lib/tools/registry.test.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/registry.test.ts
@@ -26,6 +26,14 @@ describe("buildTools", () => {
     expect(tools.listProjects).toBeDefined();
   });
 
+  it("includes repository search tools when a sandbox is available", () => {
+    const tools = buildTools(createToolContext({ sandboxId: "sbx_1" }));
+
+    expect(tools.searchRepoFiles).toBeDefined();
+    expect(tools.readRepoFile).toBeDefined();
+    expect(tools.detectRepoConfig).toBeDefined();
+  });
+
   it("includes repo/TMS write tools outside read-only mode", () => {
     const tools = buildTools(
       createToolContext({

--- a/apps/hyperlocalise-web/src/lib/tools/registry.test.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/registry.test.ts
@@ -16,14 +16,25 @@ function createToolContext(overrides: Partial<ToolContext> = {}): ToolContext {
 }
 
 describe("buildTools", () => {
+  it("exposes only file translation tools for ordinary conversations", () => {
+    const tools = buildTools(createToolContext());
+
+    expect(tools.createTranslationJob).toBeDefined();
+    expect(tools.searchRepoFiles).toBeUndefined();
+    expect(tools.readRepoFile).toBeUndefined();
+    expect(tools.listProjects).toBeUndefined();
+    expect(tools.queryGlossary).toBeUndefined();
+    expect(tools.listJobs).toBeUndefined();
+  });
+
   it("omits repo/TMS write tools in read-only mode", () => {
-    const tools = buildTools(createToolContext({ workMode: "read_only" }));
+    const tools = buildTools(createToolContext({ workMode: "read_only", sandboxId: "sbx_1" }));
 
     expect(tools.applyHyperlocaliseFixes).toBeUndefined();
     expect(tools.commitChanges).toBeUndefined();
     expect(tools.pushToBranch).toBeUndefined();
     expect(tools.uploadSources).toBeUndefined();
-    expect(tools.listProjects).toBeDefined();
+    expect(tools.searchRepoFiles).toBeDefined();
   });
 
   it("includes repository search tools when a sandbox is available", () => {
@@ -38,6 +49,7 @@ describe("buildTools", () => {
     const tools = buildTools(
       createToolContext({
         workMode: "approval_required",
+        sandboxId: "sbx_1",
         repoTmsSource: "slack",
         actor: { sourceUserId: "U1", role: "admin" },
       }),

--- a/apps/hyperlocalise-web/src/lib/tools/registry.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/registry.ts
@@ -1,40 +1,39 @@
 import type { ToolSet } from "ai";
 import type { Bash } from "just-bash";
 
-import { createQueryGlossaryTool, createQueryTranslationMemoryTool } from "./asset-tools";
+// import { createQueryGlossaryTool, createQueryTranslationMemoryTool } from "./asset-tools";
+// import {
+//   createCreateGlossaryTermTool,
+//   createCreateGlossaryTool,
+//   createDeleteGlossaryTermTool,
+//   createDeleteGlossaryTool,
+//   createListGlossariesTool,
+//   createListGlossaryTermsTool,
+//   createUpdateGlossaryTermTool,
+//   createUpdateGlossaryTool,
+// } from "./glossary-tools";
 import {
-  createCreateGlossaryTermTool,
-  createCreateGlossaryTool,
-  createDeleteGlossaryTermTool,
-  createDeleteGlossaryTool,
-  createListGlossariesTool,
-  createListGlossaryTermsTool,
-  createUpdateGlossaryTermTool,
-  createUpdateGlossaryTool,
-} from "./glossary-tools";
-import { createReadStoredFileTool } from "./file-tools";
-import {
-  createGetJobStatusTool,
-  createListJobsTool,
+  // createGetJobStatusTool,
+  // createListJobsTool,
   createTranslationJobTool,
-  createUnavailableJobKindTool,
+  // createUnavailableJobKindTool,
 } from "./job-tools";
-import { createResolveInteractionTool } from "./interaction-tools";
-import {
-  createCreateMemoryEntryTool,
-  createCreateTranslationMemoryTool,
-  createDeleteMemoryEntryTool,
-  createDeleteTranslationMemoryTool,
-  createListMemoryEntriesTool,
-  createListTranslationMemoriesTool,
-  createUpdateMemoryEntryTool,
-  createUpdateTranslationMemoryTool,
-} from "./memory-tools";
-import {
-  createGetProjectContextTool,
-  createListProjectsTool,
-  createUpdateInteractionProjectTool,
-} from "./project-tools";
+// import { createResolveInteractionTool } from "./interaction-tools";
+// import {
+//   createCreateMemoryEntryTool,
+//   createCreateTranslationMemoryTool,
+//   createDeleteMemoryEntryTool,
+//   createDeleteTranslationMemoryTool,
+//   createListMemoryEntriesTool,
+//   createListTranslationMemoriesTool,
+//   createUpdateMemoryEntryTool,
+//   createUpdateTranslationMemoryTool,
+// } from "./memory-tools";
+// import {
+//   createGetProjectContextTool,
+//   createListProjectsTool,
+//   createUpdateInteractionProjectTool,
+// } from "./project-tools";
 import type { ToolContext } from "./types";
 import {
   createDetectRepoConfigTool,
@@ -50,56 +49,45 @@ import {
 import { createSandboxRepoBash } from "./sandbox-repo-bash";
 
 /**
- * Builds the full agent toolset for a specific request context.
+ * Builds the agent toolset for a specific request context.
  *
- * Each tool factory receives the same `ToolContext` so that database queries
- * and side effects are consistently scoped to the current organization,
- * conversation, and project.
+ * Conversation agents receive file-translation tools plus GitHub repo search
+ * when a sandbox is available. Repo/TMS write workflows add mutation tools.
  */
 export function buildTools(ctx: ToolContext): ToolSet {
   const tools: ToolSet = {
-    listProjects: createListProjectsTool(ctx),
-    getProjectContext: createGetProjectContextTool(ctx),
-    updateInteractionProject: createUpdateInteractionProjectTool(ctx),
-
-    queryGlossary: createQueryGlossaryTool(ctx),
-    queryTranslationMemory: createQueryTranslationMemoryTool(ctx),
-
-    listGlossaries: createListGlossariesTool(ctx),
-    createGlossary: createCreateGlossaryTool(ctx),
-    updateGlossary: createUpdateGlossaryTool(ctx),
-    deleteGlossary: createDeleteGlossaryTool(ctx),
-    listGlossaryTerms: createListGlossaryTermsTool(ctx),
-    createGlossaryTerm: createCreateGlossaryTermTool(ctx),
-    updateGlossaryTerm: createUpdateGlossaryTermTool(ctx),
-    deleteGlossaryTerm: createDeleteGlossaryTermTool(ctx),
-
-    listTranslationMemories: createListTranslationMemoriesTool(ctx),
-    createTranslationMemory: createCreateTranslationMemoryTool(ctx),
-    updateTranslationMemory: createUpdateTranslationMemoryTool(ctx),
-    deleteTranslationMemory: createDeleteTranslationMemoryTool(ctx),
-    listMemoryEntries: createListMemoryEntriesTool(ctx),
-    createMemoryEntry: createCreateMemoryEntryTool(ctx),
-    updateMemoryEntry: createUpdateMemoryEntryTool(ctx),
-    deleteMemoryEntry: createDeleteMemoryEntryTool(ctx),
-
     createTranslationJob: createTranslationJobTool(ctx),
-    readStoredFile: createReadStoredFileTool(ctx),
-    createReviewJob: createUnavailableJobKindTool("Review"),
-    createResearchJob: createUnavailableJobKindTool("Research"),
-    createSyncJob: createUnavailableJobKindTool("Sync"),
-    createAssetManagementJob: createUnavailableJobKindTool("Asset-management"),
-    listJobs: createListJobsTool(ctx),
-    getJobStatus: createGetJobStatusTool(ctx),
-    resolveInteraction: createResolveInteractionTool(ctx),
   };
 
-  if (ctx.workMode !== "read_only") {
-    tools.applyHyperlocaliseFixes = createApplyHyperlocaliseFixesTool(ctx);
-    tools.commitChanges = createCommitChangesTool(ctx);
-    tools.pushToBranch = createPushToBranchTool(ctx);
-    tools.uploadSources = createUploadSourcesTool(ctx);
-  }
+  // Disabled for now — re-enable when expanding beyond file/image translation.
+  // listProjects: createListProjectsTool(ctx),
+  // getProjectContext: createGetProjectContextTool(ctx),
+  // updateInteractionProject: createUpdateInteractionProjectTool(ctx),
+  // queryGlossary: createQueryGlossaryTool(ctx),
+  // queryTranslationMemory: createQueryTranslationMemoryTool(ctx),
+  // listGlossaries: createListGlossariesTool(ctx),
+  // createGlossary: createCreateGlossaryTool(ctx),
+  // updateGlossary: createUpdateGlossaryTool(ctx),
+  // deleteGlossary: createDeleteGlossaryTool(ctx),
+  // listGlossaryTerms: createListGlossaryTermsTool(ctx),
+  // createGlossaryTerm: createCreateGlossaryTermTool(ctx),
+  // updateGlossaryTerm: createUpdateGlossaryTermTool(ctx),
+  // deleteGlossaryTerm: createDeleteGlossaryTermTool(ctx),
+  // listTranslationMemories: createListTranslationMemoriesTool(ctx),
+  // createTranslationMemory: createCreateTranslationMemoryTool(ctx),
+  // updateTranslationMemory: createUpdateTranslationMemoryTool(ctx),
+  // deleteTranslationMemory: createDeleteTranslationMemoryTool(ctx),
+  // listMemoryEntries: createListMemoryEntriesTool(ctx),
+  // createMemoryEntry: createCreateMemoryEntryTool(ctx),
+  // updateMemoryEntry: createUpdateMemoryEntryTool(ctx),
+  // deleteMemoryEntry: createDeleteMemoryEntryTool(ctx),
+  // createReviewJob: createUnavailableJobKindTool("Review"),
+  // createResearchJob: createUnavailableJobKindTool("Research"),
+  // createSyncJob: createUnavailableJobKindTool("Sync"),
+  // createAssetManagementJob: createUnavailableJobKindTool("Asset-management"),
+  // listJobs: createListJobsTool(ctx),
+  // getJobStatus: createGetJobStatusTool(ctx),
+  // resolveInteraction: createResolveInteractionTool(ctx),
 
   if (ctx.sandboxId) {
     const repoBash = createSandboxRepoBash(ctx.sandboxId) as Bash;
@@ -107,6 +95,13 @@ export function buildTools(ctx: ToolContext): ToolSet {
     tools.searchRepoFiles = createSearchRepoFilesTool(repoToolContext);
     tools.readRepoFile = createReadRepoFileTool(repoToolContext);
     tools.detectRepoConfig = createDetectRepoConfigTool(repoToolContext);
+
+    if (ctx.workMode !== "read_only") {
+      tools.applyHyperlocaliseFixes = createApplyHyperlocaliseFixesTool(ctx);
+      tools.commitChanges = createCommitChangesTool(ctx);
+      tools.pushToBranch = createPushToBranchTool(ctx);
+      tools.uploadSources = createUploadSourcesTool(ctx);
+    }
   }
 
   return tools;

--- a/apps/hyperlocalise-web/src/lib/tools/registry.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/registry.ts
@@ -1,4 +1,5 @@
 import type { ToolSet } from "ai";
+import type { Bash } from "just-bash";
 
 import { createQueryGlossaryTool, createQueryTranslationMemoryTool } from "./asset-tools";
 import {
@@ -36,11 +37,17 @@ import {
 } from "./project-tools";
 import type { ToolContext } from "./types";
 import {
+  createDetectRepoConfigTool,
+  createReadRepoFileTool,
+  createSearchRepoFilesTool,
+} from "./repo-tools";
+import {
   createApplyHyperlocaliseFixesTool,
   createCommitChangesTool,
   createPushToBranchTool,
   createUploadSourcesTool,
 } from "./repo-tms-write-tools";
+import { createSandboxRepoBash } from "./sandbox-repo-bash";
 
 /**
  * Builds the full agent toolset for a specific request context.
@@ -92,6 +99,14 @@ export function buildTools(ctx: ToolContext): ToolSet {
     tools.commitChanges = createCommitChangesTool(ctx);
     tools.pushToBranch = createPushToBranchTool(ctx);
     tools.uploadSources = createUploadSourcesTool(ctx);
+  }
+
+  if (ctx.sandboxId) {
+    const repoBash = createSandboxRepoBash(ctx.sandboxId) as Bash;
+    const repoToolContext = { bash: repoBash };
+    tools.searchRepoFiles = createSearchRepoFilesTool(repoToolContext);
+    tools.readRepoFile = createReadRepoFileTool(repoToolContext);
+    tools.detectRepoConfig = createDetectRepoConfigTool(repoToolContext);
   }
 
   return tools;

--- a/apps/hyperlocalise-web/src/lib/tools/sandbox-repo-bash.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/sandbox-repo-bash.ts
@@ -1,0 +1,28 @@
+import type { Bash } from "just-bash";
+
+import { runSandboxCommand } from "@/lib/translation/sandbox-translation";
+
+/**
+ * Minimal Bash adapter backed by a Vercel sandbox for repo read/search tools.
+ */
+export function createSandboxRepoBash(sandboxId: string): Pick<Bash, "exec" | "readFile"> {
+  return {
+    async exec(command, options) {
+      const args = options?.args ?? [];
+      const result = await runSandboxCommand(sandboxId, command, args);
+      return {
+        exitCode: result.exitCode,
+        stdout: result.output,
+        stderr: "",
+        env: {},
+      };
+    },
+    async readFile(path) {
+      const result = await runSandboxCommand(sandboxId, "cat", [path], { output: "stdout" });
+      if (result.exitCode !== 0) {
+        throw new Error(result.output || `Failed to read ${path}`);
+      }
+      return result.output;
+    },
+  };
+}

--- a/apps/hyperlocalise-web/src/workflows/repo-tms-agent.ts
+++ b/apps/hyperlocalise-web/src/workflows/repo-tms-agent.ts
@@ -1,9 +1,11 @@
 import { ToolLoopAgent, type ModelMessage, type ToolSet } from "ai";
-import { Sandbox } from "@vercel/sandbox";
 import { getWorkflowMetadata } from "workflow";
 
-import type { RepoTmsAgentTask } from "@/lib/agents/repo-tms-task";
-import { getInstallationOctokit } from "@/lib/agents/github/app";
+import type { RepoTmsAgentGitHubContext, RepoTmsAgentTask } from "@/lib/agents/repo-tms-task";
+import {
+  createRepoTmsSandbox as createRepoTmsSandboxImpl,
+  stopRepoTmsSandbox as stopRepoTmsSandboxImpl,
+} from "@/lib/agents/repo-tms-sandbox";
 import {
   buildHyperlocaliseAgentInstructions,
   getHyperlocaliseAgentModel,
@@ -21,45 +23,22 @@ export type RepoTmsWorkflowResult = {
   error?: string;
 };
 
-const sandboxTimeoutMs = 10 * 60 * 1000;
 const agentStepLimit = 20;
 const readOnlyRepoInstructions =
   "This workflow is read-only. Gather repository and TMS context, but do not modify files, upload sources, commit, push, or create TMS-side effects.";
 
-type InstallationAuth = {
-  token: string;
-};
+type ResolvedRepoTmsGitHubContext = Extract<RepoTmsAgentGitHubContext, { resolved: true }>;
 
-type ResolvedRepoTmsGitHubContext = Extract<
-  NonNullable<RepoTmsAgentTask["githubContext"]>,
-  { resolved: true }
->;
-
-async function createRepoTmsSandbox(githubContext: ResolvedRepoTmsGitHubContext): Promise<string> {
+async function createRepoTmsSandboxStep(
+  githubContext: ResolvedRepoTmsGitHubContext,
+): Promise<string> {
   "use step";
-
-  const octokit = await getInstallationOctokit(githubContext.installationId);
-  const { token } = (await octokit.auth({ type: "installation" })) as InstallationAuth;
-  const sandbox = await Sandbox.create({
-    source: {
-      type: "git",
-      url: `https://github.com/${githubContext.repositoryFullName}.git`,
-      revision: githubContext.commitSha ?? githubContext.branch ?? "HEAD",
-      depth: 1,
-      username: "x-access-token",
-      password: token,
-    },
-    timeout: sandboxTimeoutMs,
-  });
-
-  return sandbox.sandboxId;
+  return createRepoTmsSandboxImpl(githubContext);
 }
 
-async function stopRepoTmsSandbox(sandboxId: string): Promise<void> {
+async function stopRepoTmsSandboxStep(sandboxId: string): Promise<void> {
   "use step";
-
-  const sandbox = await Sandbox.get({ sandboxId });
-  await sandbox.stop();
+  return stopRepoTmsSandboxImpl(sandboxId);
 }
 
 export async function repoTmsAgentWorkflow(task: RepoTmsAgentTask): Promise<RepoTmsWorkflowResult> {
@@ -87,7 +66,7 @@ export async function repoTmsAgentWorkflow(task: RepoTmsAgentTask): Promise<Repo
 
   try {
     if (task.githubContext?.resolved) {
-      sandboxId = await createRepoTmsSandbox(task.githubContext);
+      sandboxId = await createRepoTmsSandboxStep(task.githubContext);
     }
 
     const toolContext: ToolContext = {
@@ -153,7 +132,7 @@ export async function repoTmsAgentWorkflow(task: RepoTmsAgentTask): Promise<Repo
   } finally {
     if (sandboxId) {
       try {
-        await stopRepoTmsSandbox(sandboxId);
+        await stopRepoTmsSandboxStep(sandboxId);
       } catch {
         // Best-effort cleanup; preserve the structured workflow result.
       }

--- a/apps/hyperlocalise-web/src/workflows/repo-tms-agent.ts
+++ b/apps/hyperlocalise-web/src/workflows/repo-tms-agent.ts
@@ -8,6 +8,7 @@ import {
   buildHyperlocaliseAgentInstructions,
   getHyperlocaliseAgentModel,
 } from "@/lib/agents/hyperlocalise-agent";
+import { buildRepoTmsGitHubContextInstructions } from "@/lib/agents/repo-tms-context";
 import type { ToolContext } from "@/lib/tools/types";
 import { buildTools } from "@/lib/tools/registry";
 import { db } from "@/lib/database";
@@ -116,6 +117,12 @@ export async function repoTmsAgentWorkflow(task: RepoTmsAgentTask): Promise<Repo
           sandboxId
             ? `Sandbox id available to tools: ${sandboxId}. Access repo only via tools.`
             : "No repository sandbox required for this task.",
+          task.githubContext?.resolved
+            ? buildRepoTmsGitHubContextInstructions(task.githubContext)
+            : null,
+          sandboxId
+            ? "Use searchRepoFiles to locate literal strings in the repository. Use readRepoFile to inspect surrounding lines and explain where copy appears."
+            : null,
           task.workMode === "read_only" ? readOnlyRepoInstructions : null,
         ]
           .filter((instruction): instruction is string => instruction !== null)


### PR DESCRIPTION
Route Slack GitHub lookup intents through enabled-repo resolution with single-repo auto-select, wire sandbox search tools, and treat owner/repo names as repositories instead of Hyperlocalise projects.

## What changed

<!-- Describe the change and why it is needed. -->

## How to test

<!-- List manual checks or commands used to verify this change. -->

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review
