### PR TITLE
fix(web): preserve GitHub connect errors on agent redirect

### DIFF
--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/agent/_components/github-agent-card.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/agent/_components/github-agent-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { GitBranchIcon, GithubIcon, Refresh01Icon, Search01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -14,6 +14,14 @@ import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { createApiClient } from "@/lib/api-client";
 import { TypographyP } from "@/components/ui/typography";
+
+import {
+  isGithubConnectedCallback,
+  resolveGithubConnectErrorCode,
+  shouldHandleGithubConnectedSuccess,
+  shouldShowGithubConnectErrorToast,
+  stripGithubConnectCallbackParamsFromUrl,
+} from "./github-connect-callback-params";
 
 const api = createApiClient();
 
@@ -215,37 +223,37 @@ export function GitHubAgentCard({ organizationSlug }: GitHubAgentCardProps) {
     refetch: refetchInstallation,
   } = useGitHubInstallation(organizationSlug);
 
-  const handledGithubConnectedRef = useRef(false);
-  const handledGithubErrorRef = useRef(false);
+  const [connectErrorCode, setConnectErrorCode] = useState<string | null>(null);
 
   useEffect(() => {
-    const errorCode = searchParams.get("error");
-    if (!errorCode || handledGithubErrorRef.current) {
+    const errorCode = resolveGithubConnectErrorCode(searchParams);
+    if (!errorCode) {
       return;
     }
 
-    handledGithubErrorRef.current = true;
+    setConnectErrorCode(errorCode);
+    stripGithubConnectCallbackParamsFromUrl();
 
-    const url = new URL(window.location.href);
-    url.searchParams.delete("error");
-    window.history.replaceState(null, "", url.toString());
+    if (!shouldShowGithubConnectErrorToast(organizationSlug, errorCode)) {
+      return;
+    }
 
     const message =
       GITHUB_CONNECT_ERROR_MESSAGES[errorCode] ??
       "GitHub App connection failed. Try connecting again.";
     toast.error(message);
-  }, [searchParams]);
+  }, [organizationSlug, searchParams]);
 
   useEffect(() => {
-    if (searchParams.get("github_connected") !== "1" || handledGithubConnectedRef.current) {
+    if (!isGithubConnectedCallback(searchParams)) {
       return;
     }
 
-    handledGithubConnectedRef.current = true;
+    stripGithubConnectCallbackParamsFromUrl();
 
-    const url = new URL(window.location.href);
-    url.searchParams.delete("github_connected");
-    window.history.replaceState(null, "", url.toString());
+    if (!shouldHandleGithubConnectedSuccess(organizationSlug)) {
+      return;
+    }
 
     void (async () => {
       await refetchInstallation();
@@ -253,6 +261,7 @@ export function GitHubAgentCard({ organizationSlug }: GitHubAgentCardProps) {
         queryKey: ["github-installation-repositories", organizationSlug],
       });
       toast.success("GitHub App connected");
+      setConnectErrorCode(null);
     })();
   }, [organizationSlug, queryClient, refetchInstallation, searchParams]);
   const { data: repositories = [], isLoading: isLoadingRepositories } = useGitHubRepositories(
@@ -290,6 +299,7 @@ export function GitHubAgentCard({ organizationSlug }: GitHubAgentCardProps) {
   }, [query, repositories]);
 
   const handleConnect = useCallback(async () => {
+    setConnectErrorCode(null);
     const { data: url } = await getInstallUrl();
     if (url) {
       window.location.href = url;
@@ -297,6 +307,11 @@ export function GitHubAgentCard({ organizationSlug }: GitHubAgentCardProps) {
       toast.error("Failed to generate GitHub install URL");
     }
   }, [getInstallUrl]);
+
+  const connectErrorMessage = connectErrorCode
+    ? (GITHUB_CONNECT_ERROR_MESSAGES[connectErrorCode] ??
+      "GitHub App connection failed. Try connecting again.")
+    : null;
 
   const toggleRepository = useCallback(
     (repositoryId: string) => {
@@ -356,6 +371,11 @@ export function GitHubAgentCard({ organizationSlug }: GitHubAgentCardProps) {
       </CardHeader>
       <Separator className="bg-foreground/8" />
       <CardContent className="px-5 py-5 lg:px-6">
+        {connectErrorMessage ? (
+          <div className="mb-4 rounded-lg border border-red-500/20 bg-red-500/10 px-4 py-3">
+            <TypographyP className="text-sm text-red-300">{connectErrorMessage}</TypographyP>
+          </div>
+        ) : null}
         {isLoading ? (
           <Skeleton className="h-10 bg-foreground/5" />
         ) : isError ? (

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/agent/_components/github-connect-callback-params.test.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/agent/_components/github-connect-callback-params.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it } from "vite-plus/test";
+
+import {
+  isGithubConnectedCallback,
+  resetGithubConnectCallbackParamsForTests,
+  resolveGithubConnectErrorCode,
+  shouldShowGithubConnectErrorToast,
+} from "./github-connect-callback-params";
+
+describe("github connect callback params", () => {
+  afterEach(() => {
+    resetGithubConnectCallbackParamsForTests();
+  });
+
+  it("caches error codes after search params are cleared", () => {
+    expect(resolveGithubConnectErrorCode(new URLSearchParams("error=invalid_state"))).toBe(
+      "invalid_state",
+    );
+    expect(resolveGithubConnectErrorCode(new URLSearchParams())).toBe("invalid_state");
+  });
+
+  it("caches github_connected after search params are cleared", () => {
+    expect(isGithubConnectedCallback(new URLSearchParams("github_connected=1"))).toBe(true);
+    expect(isGithubConnectedCallback(new URLSearchParams())).toBe(true);
+  });
+
+  it("dedupes connect error toasts per organization and error code", () => {
+    expect(shouldShowGithubConnectErrorToast("acme", "invalid_state")).toBe(true);
+    expect(shouldShowGithubConnectErrorToast("acme", "invalid_state")).toBe(false);
+    expect(shouldShowGithubConnectErrorToast("other", "invalid_state")).toBe(true);
+  });
+});

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/agent/_components/github-connect-callback-params.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/agent/_components/github-connect-callback-params.ts
@@ -1,0 +1,94 @@
+/** Survives React Strict Mode remounts after the URL is cleaned with replaceState. */
+let cachedGithubConnectError: string | null = null;
+let cachedGithubConnected = false;
+
+const acknowledgedGithubConnectErrors = new Set<string>();
+const acknowledgedGithubConnectedSuccess = new Set<string>();
+
+export function resolveGithubConnectErrorCode(searchParams: URLSearchParams): string | null {
+  const fromSearchParams = searchParams.get("error");
+  if (fromSearchParams) {
+    cachedGithubConnectError = fromSearchParams;
+    return fromSearchParams;
+  }
+
+  if (typeof window !== "undefined") {
+    const fromLocation = new URLSearchParams(window.location.search).get("error");
+    if (fromLocation) {
+      cachedGithubConnectError = fromLocation;
+      return fromLocation;
+    }
+  }
+
+  return cachedGithubConnectError;
+}
+
+export function isGithubConnectedCallback(searchParams: URLSearchParams): boolean {
+  if (searchParams.get("github_connected") === "1") {
+    cachedGithubConnected = true;
+    return true;
+  }
+
+  if (typeof window !== "undefined") {
+    const fromLocation = new URLSearchParams(window.location.search).get("github_connected");
+    if (fromLocation === "1") {
+      cachedGithubConnected = true;
+      return true;
+    }
+  }
+
+  return cachedGithubConnected;
+}
+
+export function shouldShowGithubConnectErrorToast(
+  organizationSlug: string,
+  errorCode: string,
+): boolean {
+  const key = `${organizationSlug}:${errorCode}`;
+  if (acknowledgedGithubConnectErrors.has(key)) {
+    return false;
+  }
+
+  acknowledgedGithubConnectErrors.add(key);
+  return true;
+}
+
+export function shouldHandleGithubConnectedSuccess(organizationSlug: string): boolean {
+  if (acknowledgedGithubConnectedSuccess.has(organizationSlug)) {
+    return false;
+  }
+
+  acknowledgedGithubConnectedSuccess.add(organizationSlug);
+  return true;
+}
+
+export function stripGithubConnectCallbackParamsFromUrl(): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  const url = new URL(window.location.href);
+  let changed = false;
+
+  if (url.searchParams.has("error")) {
+    url.searchParams.delete("error");
+    changed = true;
+  }
+
+  if (url.searchParams.has("github_connected")) {
+    url.searchParams.delete("github_connected");
+    changed = true;
+  }
+
+  if (changed) {
+    window.history.replaceState(null, "", url.toString());
+  }
+}
+
+/** Test-only reset for module-level callback caches. */
+export function resetGithubConnectCallbackParamsForTests(): void {
+  cachedGithubConnectError = null;
+  cachedGithubConnected = false;
+  acknowledgedGithubConnectErrors.clear();
+  acknowledgedGithubConnectedSuccess.clear();
+}


### PR DESCRIPTION
Cache OAuth callback query params before URL cleanup so React Strict Mode remounts still show the error toast and inline banner on /agent.

## What changed

<!-- Describe the change and why it is needed. -->

## How to test

<!-- List manual checks or commands used to verify this change. -->

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review
