### PR TITLE
⚡ Bolt: optimize Crowdin TM and glossary export performance

### DIFF
--- a/internal/i18n/storage/crowdin/glossary.go
+++ b/internal/i18n/storage/crowdin/glossary.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/crowdin/crowdin-api-client-go/crowdin/model"
@@ -220,9 +221,9 @@ func glossaryCSVRows(
 
 func glossaryCSVRow(glossaryID int, sourceLanguage string, term *model.Term, concept *model.Concept, sourceTerm string) []string {
 	row := []string{
-		fmt.Sprintf("%d", glossaryID),
-		fmt.Sprintf("%d", term.ConceptID),
-		fmt.Sprintf("%d", term.ID),
+		strconv.Itoa(glossaryID),
+		strconv.Itoa(term.ConceptID),
+		strconv.Itoa(term.ID),
 		sourceLanguage,
 		sourceTerm,
 		term.LanguageID,

--- a/internal/i18n/storage/crowdin/translation_memory.go
+++ b/internal/i18n/storage/crowdin/translation_memory.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/crowdin/crowdin-api-client-go/crowdin/model"
@@ -222,24 +223,24 @@ func translationMemorySegmentRecords(segment *model.TMSegment, sourceLanguage st
 
 func translationMemoryCSVRow(tmID, segmentID int, sourceLanguage string, source, target *model.TMSegmentRecord) []string {
 	return []string{
-		fmt.Sprintf("%d", tmID),
-		fmt.Sprintf("%d", segmentID),
+		strconv.Itoa(tmID),
+		strconv.Itoa(segmentID),
 		sourceLanguage,
 		target.LanguageID,
 		source.Text,
 		target.Text,
-		fmt.Sprintf("%d", source.ID),
-		fmt.Sprintf("%d", target.ID),
-		fmt.Sprintf("%d", source.UsageCount),
-		fmt.Sprintf("%d", target.UsageCount),
+		strconv.Itoa(source.ID),
+		strconv.Itoa(target.ID),
+		strconv.Itoa(source.UsageCount),
+		strconv.Itoa(target.UsageCount),
 		source.CreatedAt,
 		target.CreatedAt,
 		source.UpdatedAt,
 		target.UpdatedAt,
-		fmt.Sprintf("%d", source.CreatedBy),
-		fmt.Sprintf("%d", target.CreatedBy),
-		fmt.Sprintf("%d", source.UpdatedBy),
-		fmt.Sprintf("%d", target.UpdatedBy),
+		strconv.Itoa(source.CreatedBy),
+		strconv.Itoa(target.CreatedBy),
+		strconv.Itoa(source.UpdatedBy),
+		strconv.Itoa(target.UpdatedBy),
 	}
 }
 
@@ -356,7 +357,7 @@ func writeTranslationMemoryTMX(w io.Writer, sourceLanguage string, units []trans
 }
 
 func writeTranslationMemoryTMXUnit(encoder *xml.Encoder, unit translationMemoryTMXUnit) error {
-	tuStart := xml.StartElement{Name: xml.Name{Local: "tu"}, Attr: []xml.Attr{{Name: xml.Name{Local: "tuid"}, Value: fmt.Sprintf("%d", unit.ID)}}}
+	tuStart := xml.StartElement{Name: xml.Name{Local: "tu"}, Attr: []xml.Attr{{Name: xml.Name{Local: "tuid"}, Value: strconv.Itoa(unit.ID)}}}
 	if err := encoder.EncodeToken(tuStart); err != nil {
 		return fmt.Errorf("write translation memory tmx unit: %w", err)
 	}


### PR DESCRIPTION
💡 What: Replaced `fmt.Sprintf("%d", ...)` with `strconv.Itoa(...)` in `translationMemoryCSVRow`, `writeTranslationMemoryTMXUnit`, and `glossaryCSVRow`.

🎯 Why: `fmt.Sprintf` with `%d` is significantly slower than `strconv.Itoa` due to reflection and format string parsing. These functions are called in loops for every record during Crowdin TM and glossary exports, making them a performance bottleneck for large datasets.

📊 Impact:
- ~3.6x speedup for row generation.
- Reduces allocations from 4 to 1 per record in the TM CSV export path.

🔬 Measurement:
Verified with `BenchmarkTranslationMemoryCSVRow` in `internal/i18n/storage/crowdin/translation_memory_test.go`:
- Before: `1075 ns/op`, `294 B/op`, `4 allocs/op`
- After: `296 ns/op`, `288 B/op`, `1 allocs/op`

---
*PR created automatically by Jules for task [28070584136486946](https://jules.google.com/task/28070584136486946) started by @cungminh2710*