### PR TITLE
docs: add vp CLI and workflow plugin caveats to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,14 @@ go build -o $(go env GOPATH)/bin/golangci-lint github.com/golangci/golangci-lint
 - Run `vp run db:migrate` after starting Postgres to apply Drizzle migrations.
 - The `make test` target uses coverage flags that may warn about a missing `covdata` tool — all actual tests still pass. Use `go test ./...` if you want a clean exit code without coverage.
 
+### Web app dev server caveat
+
+The `withWorkflow` plugin in `next.config.ts` may crash `vp run dev` and `vp run build` with a `workflow-node-module-error` about `node:crypto` in `src/lib/agents/github/app.ts`. This does not affect `vp test` or `vp check`. If you only need to run tests or lint, proceed normally. CI builds pass because the workflow bundler behaves differently in that environment.
+
+### vp (Vite+) CLI
+
+Install `vp` via `curl -fsSL https://vite.plus | bash`, then run `vp env setup` to create Node.js shims. If `nvm` is active, ensure `$HOME/.vite-plus/bin` is before the nvm path so the vp-managed Node.js is used.
+
 ### CLI (Go)
 
 - Standard commands per `AGENTS.md`: `make bootstrap`, `make fmt`, `make lint`, `make test`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Added two non-obvious caveats to the `## Cursor Cloud specific instructions` section of `AGENTS.md`:

1. **Workflow plugin dev server crash**: Documents that `vp run dev` and `vp run build` may crash due to the `withWorkflow` plugin detecting `node:crypto` usage in `src/lib/agents/github/app.ts`. Tests and checks (`vp test`, `vp check`) are unaffected.

2. **vp (Vite+) CLI setup**: Documents installation via `curl -fsSL https://vite.plus | bash` and the need to run `vp env setup` for shims, plus nvm PATH ordering caveat.

These were discovered during full development environment setup.

## How to test

- Verify `AGENTS.md` content is accurate
- No code changes

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d29ec74-de75-4c56-b633-7f8adb7def95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d29ec74-de75-4c56-b633-7f8adb7def95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

