### PR TITLE
🧪 Scout: ensure unique placeholders in ICU invariants

### DIFF
--- a/internal/i18n/icuparser/invariant.go
+++ b/internal/i18n/icuparser/invariant.go
@@ -34,6 +34,7 @@ func ParseInvariant(s string) (Invariant, error) {
 	collectInvariantFromElements(elems, &inv, "")
 
 	slices.Sort(inv.Placeholders)
+	inv.Placeholders = slices.Compact(inv.Placeholders)
 	slices.SortFunc(inv.ICUBlocks, func(a, b BlockSignature) int {
 		if c := cmp.Compare(a.Arg, b.Arg); c != 0 {
 			return c

--- a/internal/i18n/icuparser/invariant_test.go
+++ b/internal/i18n/icuparser/invariant_test.go
@@ -299,6 +299,49 @@ func TestNumericPlaceholderInPlaceholders(t *testing.T) {
 	}
 }
 
+func TestParseInvariantDeduplicatesPlaceholders(t *testing.T) {
+	// ParseInvariant MUST return a unique set of placeholders, even if an
+	// argument is used multiple times or through different elements (like #).
+	tests := []struct {
+		name string
+		msg  string
+		want []string
+	}{
+		{
+			name: "duplicate arguments",
+			msg:  "Hello {name} {name}",
+			want: []string{"name"},
+		},
+		{
+			name: "plural with multiple pounds",
+			msg:  "{n, plural, one {#} other {# items}}",
+			want: []string{"n"},
+		},
+		{
+			name: "mixed argument and pound",
+			msg:  "{count, plural, other {Value: {count} (#)}}",
+			want: []string{"count"},
+		},
+		{
+			name: "nested duplicates",
+			msg:  "{n, plural, other {{n, plural, other {#}}}}",
+			want: []string{"n"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inv, err := ParseInvariant(tt.msg)
+			if err != nil {
+				t.Fatalf("ParseInvariant(%q) failed: %v", tt.msg, err)
+			}
+			if !slicesEqual(inv.Placeholders, tt.want) {
+				t.Errorf("ParseInvariant(%q) placeholders = %v, want %v", tt.msg, inv.Placeholders, tt.want)
+			}
+		})
+	}
+}
+
 func TestHasDuplicatePounds(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/i18n/icuparser/parser_test.go
+++ b/internal/i18n/icuparser/parser_test.go
@@ -26,7 +26,7 @@ func TestParserFeatureParitySubset(t *testing.T) {
 		{
 			name:             "plural with selectors and nested placeholders",
 			msg:              "Hi {name}. {count, plural, =0 {No items} one {One item for {name}} other {{count} items}}",
-			wantPlaceholders: []string{"count", "count", "name", "name"},
+			wantPlaceholders: []string{"count", "name"},
 			wantICU: []BlockSignature{{
 				Arg:     "count",
 				Type:    "plural",
@@ -36,7 +36,7 @@ func TestParserFeatureParitySubset(t *testing.T) {
 		{
 			name:             "nested select plural",
 			msg:              "{gender, select, male {{count, plural, one {He has one} other {He has #}}} female {{count, plural, one {She has one} other {She has #}}} other {They have {count}}}",
-			wantPlaceholders: []string{"count", "count", "count", "count", "count", "gender"},
+			wantPlaceholders: []string{"count", "gender"},
 			wantICU: []BlockSignature{
 				{Arg: "count", Type: "plural", Options: []string{"one", "other"}, Pounds: []int{0, 1}},
 				{Arg: "count", Type: "plural", Options: []string{"one", "other"}, Pounds: []int{0, 1}},
@@ -46,7 +46,7 @@ func TestParserFeatureParitySubset(t *testing.T) {
 		{
 			name:             "plural offset accepted",
 			msg:              "{count, plural, offset:1 =0 {Nobody} one {{name}} other {{name} and # others}}",
-			wantPlaceholders: []string{"count", "count", "name", "name"},
+			wantPlaceholders: []string{"count", "name"},
 			wantICU: []BlockSignature{{
 				Arg:     "count",
 				Type:    "plural",
@@ -57,7 +57,7 @@ func TestParserFeatureParitySubset(t *testing.T) {
 		{
 			name:             "plural pound and explicit arg normalize the same",
 			msg:              "{count, plural, one {# invite} other {{count} invites}}",
-			wantPlaceholders: []string{"count", "count", "count"},
+			wantPlaceholders: []string{"count"},
 			wantICU: []BlockSignature{{
 				Arg:     "count",
 				Type:    "plural",
@@ -78,7 +78,7 @@ func TestParserFeatureParitySubset(t *testing.T) {
 		{
 			name:             "selectordinal accepted",
 			msg:              "{pos, selectordinal, one {#st} two {#nd} few {#rd} other {#th}}",
-			wantPlaceholders: []string{"pos", "pos", "pos", "pos", "pos"},
+			wantPlaceholders: []string{"pos"},
 			wantICU: []BlockSignature{{
 				Arg:     "pos",
 				Type:    "selectordinal",


### PR DESCRIPTION
💡 What: Added deduplication to ICU invariant placeholder extraction and a corresponding regression test.

🎯 Why: To ensure a clean and predictable API where each placeholder name is only listed once, regardless of how many times it appears in the ICU message (e.g., in multiple plural branches or via '#' signs).

🧩 Scope: `internal/i18n/icuparser/invariant.go`, `internal/i18n/icuparser/invariant_test.go`, `internal/i18n/icuparser/parser_test.go`.

✅ Verification: Ran `go test ./internal/i18n/icuparser/...` (passed) and `go test ./...` (passed after updating existing expectations). Verified with `go tool staticcheck ./...`.

🛡️ Confidence: Prevents redundant entries in placeholder lists which helps maintain consistency in downstream tools that rely on these invariants for validation.

---
*PR created automatically by Jules for task [2065522012083837859](https://jules.google.com/task/2065522012083837859) started by @cungminh2710*