### PR TITLE
🎨 Palette: Fix SidebarTrigger accessibility pattern

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -9,3 +9,11 @@
 ## 2026-05-24 - [Tooltip Content and Prop Forwarding]
 **Learning:** Tooltip content in this design system should avoid block-level typography components (like `TypographyP`) to prevent excessive line-height; plain text or inline elements are preferred for compact tooltips. Additionally, when using the `render` prop on `TooltipTrigger` for icon-only buttons, the icons and screen-reader only text must be nested *inside* the component being rendered (e.g., `<TooltipTrigger render={<Button>...</Button>} />`) to ensure proper event delegation and accessibility prop forwarding.
 **Action:** Use plain text for tooltips and ensure all button children are placed inside the `render` prop's component when wrapping with a `TooltipTrigger`.
+
+## 2026-05-25 - [TooltipTrigger Structural Consistency]
+**Learning:** In , several components were found to have children (icons, accessible text) placed outside the component passed to the `render` prop of `TooltipTrigger`. This pattern can lead to empty interactive elements or broken event delegation. Consistently nesting all content within the rendered component ensures that accessibility properties (like ARIA labels or screen-reader text) are correctly associated with the interactive trigger.
+**Action:** When using `<TooltipTrigger render={<Component ... />} >`, always place the component's children inside `<Component>` rather than as children of `TooltipTrigger`.
+
+## 2026-05-25 - [TooltipTrigger Structural Consistency]
+**Learning:** In `apps/hyperlocalise-web`, several components were found to have children (icons, accessible text) placed outside the component passed to the `render` prop of `TooltipTrigger`. This pattern can lead to empty interactive elements or broken event delegation. Consistently nesting all content within the rendered component ensures that accessibility properties (like ARIA labels or screen-reader text) are correctly associated with the interactive trigger.
+**Action:** When using `<TooltipTrigger render={<Component ... />} >`, always place the component's children inside `<Component>` rather than as children of `TooltipTrigger`.

--- a/apps/hyperlocalise-web/src/components/ui/sidebar.test.tsx
+++ b/apps/hyperlocalise-web/src/components/ui/sidebar.test.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { SidebarTrigger, SidebarProvider } from "./sidebar";
+import { TooltipProvider } from "./tooltip";
+
+describe("SidebarTrigger Accessibility", () => {
+  it("SidebarTrigger renders with icons inside the button", () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(
+        SidebarProvider,
+        {},
+        React.createElement(
+          TooltipProvider,
+          {},
+          React.createElement(SidebarTrigger, {})
+        )
+      )
+    );
+
+    // Check that the button is present
+    expect(markup).toContain('<button');
+    // Check that the icon and sr-only text are present
+    expect(markup).toContain('Toggle Sidebar');
+
+    // The key part: verify no nested buttons and that the content is inside the button
+    const buttonCount = (markup.match(/<button/g) || []).length;
+    expect(buttonCount).toBe(1);
+
+    // Verify the icon is inside the button
+    // A simple way is to check that the button tag is NOT self-closing before the icon
+    const buttonOpenIndex = markup.indexOf('<button');
+    const iconIndex = markup.indexOf('<svg');
+    const buttonCloseIndex = markup.indexOf('</button>');
+
+    expect(buttonOpenIndex).toBeLessThan(iconIndex);
+    expect(iconIndex).toBeLessThan(buttonCloseIndex);
+  });
+});

--- a/apps/hyperlocalise-web/src/components/ui/sidebar.test.tsx
+++ b/apps/hyperlocalise-web/src/components/ui/sidebar.test.tsx
@@ -10,18 +10,14 @@ describe("SidebarTrigger Accessibility", () => {
       React.createElement(
         SidebarProvider,
         {},
-        React.createElement(
-          TooltipProvider,
-          {},
-          React.createElement(SidebarTrigger, {})
-        )
-      )
+        React.createElement(TooltipProvider, {}, React.createElement(SidebarTrigger, {})),
+      ),
     );
 
     // Check that the button is present
-    expect(markup).toContain('<button');
+    expect(markup).toContain("<button");
     // Check that the icon and sr-only text are present
-    expect(markup).toContain('Toggle Sidebar');
+    expect(markup).toContain("Toggle Sidebar");
 
     // The key part: verify no nested buttons and that the content is inside the button
     const buttonCount = (markup.match(/<button/g) || []).length;
@@ -29,9 +25,9 @@ describe("SidebarTrigger Accessibility", () => {
 
     // Verify the icon is inside the button
     // A simple way is to check that the button tag is NOT self-closing before the icon
-    const buttonOpenIndex = markup.indexOf('<button');
-    const iconIndex = markup.indexOf('<svg');
-    const buttonCloseIndex = markup.indexOf('</button>');
+    const buttonOpenIndex = markup.indexOf("<button");
+    const iconIndex = markup.indexOf("<svg");
+    const buttonCloseIndex = markup.indexOf("</button>");
 
     expect(buttonOpenIndex).toBeLessThan(iconIndex);
     expect(iconIndex).toBeLessThan(buttonCloseIndex);

--- a/apps/hyperlocalise-web/src/components/ui/sidebar.tsx
+++ b/apps/hyperlocalise-web/src/components/ui/sidebar.tsx
@@ -266,12 +266,12 @@ function SidebarTrigger({ className, onClick, ...props }: React.ComponentProps<t
               toggleSidebar();
             }}
             {...props}
-          />
+          >
+            <HugeiconsIcon icon={SidebarLeftIcon} strokeWidth={2} className="rtl:rotate-180" />
+            <span className="sr-only">Toggle Sidebar</span>
+          </Button>
         }
-      >
-        <HugeiconsIcon icon={SidebarLeftIcon} strokeWidth={2} className="rtl:rotate-180" />
-        <span className="sr-only">Toggle Sidebar</span>
-      </TooltipTrigger>
+      />
       <TooltipContent side="bottom" align="start">
         Toggle Sidebar
         <Kbd className="ms-2">{isMac ? "⌘B" : "Ctrl+B"}</Kbd>


### PR DESCRIPTION
💡 What: Fixed a structural accessibility issue in the SidebarTrigger component.
🎯 Why: TooltipTrigger with a `render` prop expects the content to be nested inside the component being rendered to ensure proper accessibility and event delegation. Previously, the icons and sr-only text were siblings to the Button, potentially resulting in an empty interactive element.
♿ Accessibility: Ensures the SidebarTrigger button has a proper accessible name and visual content for screen readers and other assistive technologies.
🧪 Testing: Added `apps/hyperlocalise-web/src/components/ui/sidebar.test.tsx` to verify the HTML structure via `renderToStaticMarkup`.

---
*PR created automatically by Jules for task [4254653849119293307](https://jules.google.com/task/4254653849119293307) started by @cungminh2710*