### PR TITLE
🧪 Scout: improve sanitizeReturnTo test coverage and security

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -23,3 +23,7 @@
 ## 2025-05-23 - [PO Parser Multiline State Management]
 **Learning:** The PO file parser's state management using `activeField` can lead to data leakage if not explicitly reset when encountering ignored fields (like `msgid_plural` or non-zero `msgstr[N]`). Continuation lines (quoted strings on new lines) rely on `activeField` to determine which buffer to append to; if `activeField` remains set to a previous valid field (e.g., `msgid`), the continuation from an ignored field will be incorrectly appended to it.
 **Action:** Always reset `activeField` to an empty string when skipping fields that may have multiline continuations to ensure subsequent lines are correctly ignored.
+
+## 2025-05-24 - [Auth Redirect Sanitization Bypasses]
+**Learning:** URL sanitization for redirect parameters (e.g., `returnTo`) can be bypassed using URL-encoded characters (e.g., `%73` for `s`) or mixed casing if the validation check is performed on the raw string. This is particularly dangerous for preventing loops to sensitive authentication routes.
+**Action:** Always decode URI components and normalize the path to lowercase before comparing against restricted route lists. Perform validation on the normalized path while preserving the original string for the final redirect to maintain routing integrity.

--- a/apps/hyperlocalise-web/src/lib/workos/return-to.test.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/return-to.test.ts
@@ -52,4 +52,21 @@ describe("sanitizeReturnTo", () => {
     expect(sanitizeReturnTo("/not/auth/sign-in")).toBe("/not/auth/sign-in");
     expect(sanitizeReturnTo("/auth/sign-in-not-really")).toBe("/auth/sign-in-not-really");
   });
+
+  it("should detect URL-encoded restricted paths", () => {
+    // %73 is 's'
+    expect(sanitizeReturnTo("/auth/%73ign-in")).toBe("/dashboard");
+    // %2f is '/'
+    expect(sanitizeReturnTo("%2fauth/sign-in")).toBe("/dashboard");
+  });
+
+  it("should detect mixed-case restricted paths", () => {
+    expect(sanitizeReturnTo("/AUTH/SIGN-IN")).toBe("/dashboard");
+    expect(sanitizeReturnTo("/Auth/Onboarding")).toBe("/dashboard");
+  });
+
+  it("should handle encoded query separators", () => {
+    expect(sanitizeReturnTo("/auth/sign-in%3Ffoo=bar")).toBe("/dashboard");
+    expect(sanitizeReturnTo("/auth/sign-in%23section")).toBe("/dashboard");
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/workos/return-to.test.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/return-to.test.ts
@@ -69,4 +69,15 @@ describe("sanitizeReturnTo", () => {
     expect(sanitizeReturnTo("/auth/sign-in%3Ffoo=bar")).toBe("/dashboard");
     expect(sanitizeReturnTo("/auth/sign-in%23section")).toBe("/dashboard");
   });
+
+  it("should preserve GitHub install callback URLs with encoded query separator", () => {
+    expect(
+      sanitizeReturnTo("/auth/github/callback%3Finstallation_id=123456&state=abc"),
+    ).toBe("/auth/github/callback%3Finstallation_id=123456&state=abc");
+  });
+
+  it("should reject double-encoded slashes that lead to open redirects", () => {
+    expect(sanitizeReturnTo("/%2fgoogle.com")).toBe("/dashboard");
+    expect(sanitizeReturnTo("/%2f%5cexample.com")).toBe("/dashboard");
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/workos/return-to.test.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/return-to.test.ts
@@ -57,7 +57,7 @@ describe("sanitizeReturnTo", () => {
     // %73 is 's'
     expect(sanitizeReturnTo("/auth/%73ign-in")).toBe("/dashboard");
     // %2f is '/'
-    expect(sanitizeReturnTo("%2fauth/sign-in")).toBe("/dashboard");
+    expect(sanitizeReturnTo("/%2fauth/sign-in")).toBe("/dashboard");
   });
 
   it("should detect mixed-case restricted paths", () => {
@@ -79,5 +79,6 @@ describe("sanitizeReturnTo", () => {
   it("should reject double-encoded slashes that lead to open redirects", () => {
     expect(sanitizeReturnTo("/%2fgoogle.com")).toBe("/dashboard");
     expect(sanitizeReturnTo("/%2f%5cexample.com")).toBe("/dashboard");
+    expect(sanitizeReturnTo("/%5c%5cgoogle.com")).toBe("/dashboard");
   });
 });

--- a/apps/hyperlocalise-web/src/lib/workos/return-to.test.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/return-to.test.ts
@@ -71,9 +71,9 @@ describe("sanitizeReturnTo", () => {
   });
 
   it("should preserve GitHub install callback URLs with encoded query separator", () => {
-    expect(
-      sanitizeReturnTo("/auth/github/callback%3Finstallation_id=123456&state=abc"),
-    ).toBe("/auth/github/callback%3Finstallation_id=123456&state=abc");
+    expect(sanitizeReturnTo("/auth/github/callback%3Finstallation_id=123456&state=abc")).toBe(
+      "/auth/github/callback%3Finstallation_id=123456&state=abc",
+    );
   });
 
   it("should reject double-encoded slashes that lead to open redirects", () => {

--- a/apps/hyperlocalise-web/src/lib/workos/return-to.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/return-to.ts
@@ -9,13 +9,35 @@ const RESTRICTED_PATHS = [
 ];
 
 export function sanitizeReturnTo(value: string | null | undefined, fallback = "/dashboard") {
-  if (!value || !value.startsWith("/") || value.startsWith("//") || value.startsWith("/\\")) {
+  if (!value) {
+    return fallback;
+  }
+
+  // Normalise the value by decoding URI components and lowercasing for consistent checking.
+  let decodedValue: string;
+  try {
+    decodedValue = decodeURIComponent(value);
+  } catch {
+    // If decoding fails, the URI is likely malformed and should be rejected.
+    return fallback;
+  }
+
+  if (
+    !decodedValue.startsWith("/") ||
+    decodedValue.startsWith("//") ||
+    decodedValue.startsWith("/\\")
+  ) {
+    return fallback;
+  }
+
+  // Double check the original value as well to be safe.
+  if (!value.startsWith("/") || value.startsWith("//") || value.startsWith("/\\")) {
     return fallback;
   }
 
   // Prevent redirect loops by avoiding sensitive auth routes.
   // We check the path part of the URL (before ? or #) to avoid bypasses.
-  const urlPath = value.split(/[?#]/)[0];
+  const urlPath = decodedValue.split(/[?#]/)[0].toLowerCase();
   const isRestricted = RESTRICTED_PATHS.some(
     (path) => urlPath === path || urlPath.startsWith(`${path}/`),
   );

--- a/apps/hyperlocalise-web/src/lib/workos/return-to.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/return-to.ts
@@ -14,14 +14,24 @@ export function sanitizeReturnTo(value: string | null | undefined, fallback = "/
   }
 
   try {
-    // Normalize the value by decoding URI components and lowercasing for consistent checking.
+    // Normalize the value by decoding URI components.
     const decodedValue = decodeURIComponent(value);
-    const urlPath = decodedValue.split(/[?#]/)[0].toLowerCase();
 
     // Re-verify it still looks like a safe relative path after decoding.
-    if (urlPath.startsWith("//") || urlPath.startsWith("/\\")) {
+    // We check for // and /\ which can be used for open redirects.
+    if (decodedValue.startsWith("//") || decodedValue.startsWith("/\\")) {
       return fallback;
     }
+
+    // Use URL parser to robustly handle the path and parameters.
+    const url = new URL(decodedValue, "http://localhost");
+
+    // Ensure it didn't decode into an absolute URL.
+    if (url.origin !== "http://localhost") {
+      return fallback;
+    }
+
+    const urlPath = url.pathname.toLowerCase();
 
     // Prevent redirect loops by avoiding sensitive auth routes.
     const isRestricted = RESTRICTED_PATHS.some(
@@ -31,12 +41,8 @@ export function sanitizeReturnTo(value: string | null | undefined, fallback = "/
     if (isRestricted) {
       // Special case for GitHub installation callback which is restricted but needed.
       if (urlPath === "/auth/github/callback") {
-        const queryIndex = decodedValue.indexOf("?");
-        if (queryIndex !== -1) {
-          const params = new URLSearchParams(decodedValue.slice(queryIndex + 1));
-          if (params.has("installation_id") && params.has("state")) {
-            return value;
-          }
+        if (url.searchParams.has("installation_id") && url.searchParams.has("state")) {
+          return value;
         }
       }
 

--- a/apps/hyperlocalise-web/src/lib/workos/return-to.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/return-to.ts
@@ -9,50 +9,41 @@ const RESTRICTED_PATHS = [
 ];
 
 export function sanitizeReturnTo(value: string | null | undefined, fallback = "/dashboard") {
-  if (!value) {
+  if (!value || !value.startsWith("/") || value.startsWith("//") || value.startsWith("/\\")) {
     return fallback;
   }
 
-  // Normalise the value by decoding URI components and lowercasing for consistent checking.
-  let decodedValue: string;
   try {
-    decodedValue = decodeURIComponent(value);
-  } catch {
-    // If decoding fails, the URI is likely malformed and should be rejected.
-    return fallback;
-  }
+    // Normalize the value by decoding URI components and lowercasing for consistent checking.
+    const decodedValue = decodeURIComponent(value);
+    const urlPath = decodedValue.split(/[?#]/)[0].toLowerCase();
 
-  if (
-    !decodedValue.startsWith("/") ||
-    decodedValue.startsWith("//") ||
-    decodedValue.startsWith("/\\")
-  ) {
-    return fallback;
-  }
-
-  // Double check the original value as well to be safe.
-  if (!value.startsWith("/") || value.startsWith("//") || value.startsWith("/\\")) {
-    return fallback;
-  }
-
-  // Prevent redirect loops by avoiding sensitive auth routes.
-  // We check the path part of the URL (before ? or #) to avoid bypasses.
-  const urlPath = decodedValue.split(/[?#]/)[0].toLowerCase();
-  const isRestricted = RESTRICTED_PATHS.some(
-    (path) => urlPath === path || urlPath.startsWith(`${path}/`),
-  );
-
-  if (isRestricted) {
-    if (urlPath === "/auth/github/callback") {
-      const queryIndex = value.indexOf("?");
-      if (queryIndex !== -1) {
-        const params = new URLSearchParams(value.slice(queryIndex + 1));
-        if (params.has("installation_id") && params.has("state")) {
-          return value;
-        }
-      }
+    // Re-verify it still looks like a safe relative path after decoding.
+    if (urlPath.startsWith("//") || urlPath.startsWith("/\\")) {
+      return fallback;
     }
 
+    // Prevent redirect loops by avoiding sensitive auth routes.
+    const isRestricted = RESTRICTED_PATHS.some(
+      (path) => urlPath === path || urlPath.startsWith(`${path}/`),
+    );
+
+    if (isRestricted) {
+      // Special case for GitHub installation callback which is restricted but needed.
+      if (urlPath === "/auth/github/callback") {
+        const queryIndex = decodedValue.indexOf("?");
+        if (queryIndex !== -1) {
+          const params = new URLSearchParams(decodedValue.slice(queryIndex + 1));
+          if (params.has("installation_id") && params.has("state")) {
+            return value;
+          }
+        }
+      }
+
+      return fallback;
+    }
+  } catch {
+    // If decoding fails, the URI is likely malformed and should be rejected.
     return fallback;
   }
 


### PR DESCRIPTION
- 💡 What: Added security edge cases to `sanitizeReturnTo` tests and improved the implementation to handle URL-encoded and mixed-case paths.
- 🎯 Why: The previous implementation could be bypassed using encoding or casing, potentially leading to redirect loops or unauthorized redirects to sensitive auth routes.
- 🧩 Scope: `apps/hyperlocalise-web/src/lib/workos/return-to.ts` and `apps/hyperlocalise-web/src/lib/workos/return-to.test.ts`.
- ✅ Verification: Ran `cd apps/hyperlocalise-web && pnpm exec vp test src/lib/workos/return-to.test.ts`.
- 🛡️ Confidence: Hardens the application against Open Redirect-style bypasses and ensures robust redirection logic for authentication flows.

---
*PR created automatically by Jules for task [11297415136305770187](https://jules.google.com/task/11297415136305770187) started by @cungminh2710*