### PR TITLE
fix(crowdin): improve Label and Screenshot model parity and consistency

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -95,3 +95,9 @@
 **Learning:** In Crowdin API v2, `groupId` is an optional field that can be set to `0` to indicate the root group. The Go SDK used an `int` which, when combined with `omitempty`, would drop the field if set to `0`. Additionally, the `tmPenalties` field in the `Project` response was untyped (`any`), making it difficult to use correctly in Go.
 
 **Action:** Updated `ProjectsAddRequest.GroupID` to `*int` in `model/projects.go` to allow explicit `0` values. Changed `Project.TMPenalties` from `any` to `*ProjectTMPenalties` for better type safety. Fixed a documentation typo in `ProjectsListResponse`. Updated unit tests in `projects_test.go` to verify correct serialization and parsing with the new types.
+
+## 2026-08-01 - Improve Label and Screenshot model parity and type consistency
+
+**Learning:** The Crowdin Label response model was missing the `projectId` field, which is standard for most Crowdin resources. Additionally, `ScreenshotListOptions` used `[]string` for `StringIDs`, `LabelIDs`, and `ExcludeLabelIDs`, which is inconsistent with other models that use `[]int` for numeric identifiers and with the official API contract.
+
+**Action:** Added `ProjectID` to the `Label` struct in `model/labels.go`. Updated `ScreenshotListOptions` in `model/screenshot.go` to use `[]int` for `StringIDs`, `LabelIDs`, and `ExcludeLabelIDs`. Updated corresponding contract tests in `labels_test.go`, `screenshot_test.go`, and `screenshots_test.go` to reflect these changes and ensure correct query parameter encoding.

--- a/third_party/crowdin-api-client-go/crowdin/labels_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/labels_test.go
@@ -24,6 +24,7 @@ func TestLabelsService_Get(t *testing.T) {
 		fmt.Fprint(w, `{
 			"data": {
 				"id": 34,
+				"projectId": 1,
 				"title": "main"
 			}
 		}`)
@@ -35,6 +36,7 @@ func TestLabelsService_Get(t *testing.T) {
 
 	assert.Equal(t, "main", label.Title)
 	assert.Equal(t, 34, label.ID)
+	assert.Equal(t, 1, label.ProjectID)
 }
 
 func TestLabelsService_Get_NotFound(t *testing.T) {
@@ -98,12 +100,14 @@ func TestLabelsService_List(t *testing.T) {
 					{
 						"data": {
 							"id": 34,
+							"projectId": 1,
 							"title": "main"
 						}
 					},
 					{
 						"data": {
 							"id": 36,
+							"projectId": 1,
 							"title": "test"
 						}
 					}
@@ -120,12 +124,14 @@ func TestLabelsService_List(t *testing.T) {
 
 		expected := []*model.Label{
 			{
-				ID:    34,
-				Title: "main",
+				ID:        34,
+				ProjectID: 1,
+				Title:     "main",
 			},
 			{
-				ID:    36,
-				Title: "test",
+				ID:        36,
+				ProjectID: 1,
+				Title:     "test",
 			},
 		}
 		assert.Equal(t, expected, labels)
@@ -163,6 +169,7 @@ func TestLabelsService_Add(t *testing.T) {
 		fmt.Fprint(w, `{
 			"data": {
 				"id": 34,
+				"projectId": 1,
 				"title": "main"
 			}
 		}`)
@@ -174,6 +181,7 @@ func TestLabelsService_Add(t *testing.T) {
 
 	assert.Equal(t, "main", label.Title)
 	assert.Equal(t, 34, label.ID)
+	assert.Equal(t, 1, label.ProjectID)
 }
 
 func TestLabelsService_Edit(t *testing.T) {
@@ -189,6 +197,7 @@ func TestLabelsService_Edit(t *testing.T) {
 		fmt.Fprint(w, `{
 			"data": {
 				"id": 34,
+				"projectId": 1,
 				"title": "main"
 			}
 		}`)
@@ -207,6 +216,7 @@ func TestLabelsService_Edit(t *testing.T) {
 
 	assert.Equal(t, "main", label.Title)
 	assert.Equal(t, 34, label.ID)
+	assert.Equal(t, 1, label.ProjectID)
 }
 
 func TestLabelsService_Delete(t *testing.T) {

--- a/third_party/crowdin-api-client-go/crowdin/model/labels.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/labels.go
@@ -7,8 +7,9 @@ import (
 
 // Label represents a Crowdin label.
 type Label struct {
-	ID    int    `json:"id"`
-	Title string `json:"title"`
+	ID        int    `json:"id"`
+	ProjectID int    `json:"projectId"`
+	Title     string `json:"title"`
 }
 
 // LabelResponse defines the structure of a response when

--- a/third_party/crowdin-api-client-go/crowdin/model/screenshot.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/screenshot.go
@@ -75,13 +75,13 @@ type ScreenshotListOptions struct {
 	// String Identifiers.
 	// Example: stringIds=1,2,3,4,5
 	// Note: Cannot be used with stringId in the same request.
-	StringIDs []string `json:"stringIds,omitempty"`
+	StringIDs []int `json:"stringIds,omitempty"`
 	// Label Identifiers.
 	// Example: labelIds=1,2,3
-	LabelIDs []string `json:"labelIds,omitempty"`
+	LabelIDs []int `json:"labelIds,omitempty"`
 	// Label Identifiers to exclude.
 	// Example: excludeLabelIds=1,2,3
-	ExcludeLabelIDs []string `json:"excludeLabelIds,omitempty"`
+	ExcludeLabelIDs []int `json:"excludeLabelIds,omitempty"`
 
 	ListOptions
 }

--- a/third_party/crowdin-api-client-go/crowdin/model/screenshot_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/screenshot_test.go
@@ -24,7 +24,7 @@ func TestScreenshotListOptionsValues(t *testing.T) {
 			name: "with all options",
 			opts: &ScreenshotListOptions{
 				OrderBy: "createdAt desc,name,tagsCount", StringID: 1, // TODO: StringID is deprecated
-				LabelIDs: []string{"1", "2", "3"}, ExcludeLabelIDs: []string{"4", "5", "6"},
+				LabelIDs: []int{1, 2, 3}, ExcludeLabelIDs: []int{4, 5, 6},
 				ListOptions: ListOptions{Offset: 1, Limit: 10},
 			},
 			out: "excludeLabelIds=4%2C5%2C6&labelIds=1%2C2%2C3&limit=10&offset=1&orderBy=createdAt+desc%2Cname%2CtagsCount&stringId=1",
@@ -32,8 +32,8 @@ func TestScreenshotListOptionsValues(t *testing.T) {
 		{
 			name: "with all options",
 			opts: &ScreenshotListOptions{
-				OrderBy: "createdAt desc,name,tagsCount", StringIDs: []string{"1", "2", "3"},
-				LabelIDs: []string{"1", "2", "3"}, ExcludeLabelIDs: []string{"4", "5", "6"},
+				OrderBy: "createdAt desc,name,tagsCount", StringIDs: []int{1, 2, 3},
+				LabelIDs: []int{1, 2, 3}, ExcludeLabelIDs: []int{4, 5, 6},
 				ListOptions: ListOptions{Offset: 1, Limit: 10},
 			},
 			out: "excludeLabelIds=4%2C5%2C6&labelIds=1%2C2%2C3&limit=10&offset=1&orderBy=createdAt+desc%2Cname%2CtagsCount&stringIds=1%2C2%2C3",
@@ -64,8 +64,8 @@ func TestScreenshotListOptionsValidate(t *testing.T) {
 		{
 			name: "invalid case - using both stringId and stringIds in the same request",
 			req: &ScreenshotListOptions{
-				OrderBy: "createdAt desc,name,tagsCount", StringID: 1, StringIDs: []string{"1", "2", "3"}, // TODO: StringID is deprecated
-				LabelIDs: []string{"1", "2", "3"}, ExcludeLabelIDs: []string{"4", "5", "6"},
+				OrderBy: "createdAt desc,name,tagsCount", StringID: 1, StringIDs: []int{1, 2, 3}, // TODO: StringID is deprecated
+				LabelIDs: []int{1, 2, 3}, ExcludeLabelIDs: []int{4, 5, 6},
 				ListOptions: ListOptions{Offset: 1, Limit: 10},
 			},
 			err: "stringId and stringIds cannot be used in the same request",

--- a/third_party/crowdin-api-client-go/crowdin/screenshots_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/screenshots_test.go
@@ -137,8 +137,8 @@ func TestScreenshotsService_ListScreenshot(t *testing.T) {
 			opts: &model.ScreenshotListOptions{
 				OrderBy:         "createdAt desc,name,tagsCount",
 				StringID:        1, // TODO: StringID is deprecated
-				LabelIDs:        []string{"1", "2", "3"},
-				ExcludeLabelIDs: []string{"1", "2", "3"},
+				LabelIDs:        []int{1, 2, 3},
+				ExcludeLabelIDs: []int{1, 2, 3},
 				ListOptions: model.ListOptions{
 					Limit:  10,
 					Offset: 20,


### PR DESCRIPTION
This PR improves the parity and consistency of the Crowdin Go client fork by addressing two specific areas in the Labels and Screenshots APIs.

### Changes:
1. **Labels Model:** Added the missing `projectId` field to the `Label` struct. This field is standard in Crowdin API v2 responses for labels and was previously missing.
2. **Screenshots API:** Updated the types for `StringIDs`, `LabelIDs`, and `ExcludeLabelIDs` in `ScreenshotListOptions` from `[]string` to `[]int`. This aligns the client with the official Crowdin API documentation where these are defined as arrays of integers, and ensures consistency with other models in the SDK.

### Impact:
- Better documentation parity with Crowdin API v2.
- Type-safe numeric identifiers in screenshot listing options.
- No regressions introduced; all relevant contract tests have been updated and verified.

### Verification:
Ran the following tests in the Crowdin fork:
`cd third_party/crowdin-api-client-go && GOWORK=off go test ./...`
All tests passed.

---
*PR created automatically by Jules for task [8011237904512931465](https://jules.google.com/task/8011237904512931465) started by @cungminh2710*