### PR TITLE
🛡️ Sentinel: [HIGH] Fix Broken Project Level Authorization in Workspace Job Routes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -32,3 +32,8 @@
 **Vulnerability:** Webhook verification logic (Slack, WorkOS) converted request headers directly into Buffers for comparison. While `timingSafeEqual` prevents timing attacks, extremely large signature headers could cause excessive memory allocation or unexpected behavior during Buffer conversion before the equality check.
 **Learning:** Defensive signature verification should include an early-exit length check against the expected hash length. This prevents unnecessary work and potential resource exhaustion from malformed or malicious headers.
 **Prevention:** Always verify that the provided signature string matches the expected hex/base64 length before allocating Buffers for constant-time comparison.
+
+## 2026-05-28 - [High] Broken Project Level Authorization in Workspace Job Routes
+**Vulnerability:** Several workspace-scoped job endpoints (agent-runs, provider-actions, QA, retry, mark-failed) only verified that a job belonged to the user's organization, but did not check if the user had access to the specific project containing that job. This allowed users to access or modify jobs in projects they were not members of within the same organization (BOLA).
+**Learning:** Checking for organization ownership is a baseline but often insufficient in multi-tenant apps with nested resource hierarchies (e.g., Teams/Projects). Direct lookups by ID must always incorporate the full accessibility context of the current user.
+**Prevention:** Centralize resource accessibility logic into shared helpers (like `buildAccessibleJobsWhere`) and ensure these are used in every endpoint that performs a direct object lookup or modification, even when a `jobId` is provided.

--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
@@ -5,7 +5,7 @@ import { Hono } from "hono";
 import { validator } from "hono/validator";
 
 import { buildAccessibleJobsWhere } from "@/api/auth/team-access";
-import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
+import { workosAuthMiddleware, type ApiAuthContext, type AuthVariables } from "@/api/auth/workos";
 import {
   badRequestResponse,
   conflictResponse,
@@ -189,19 +189,19 @@ function jobListFilters(input: {
   return filters;
 }
 
-function retryableJobWhere(input: { organizationId: string; jobId: string }) {
+async function retryableJobWhere(auth: ApiAuthContext, jobId: string) {
   return and(
-    eq(schema.jobs.id, input.jobId),
-    eq(schema.jobs.organizationId, input.organizationId),
+    eq(schema.jobs.id, jobId),
+    await buildAccessibleJobsWhere(auth),
     eq(schema.jobs.kind, "translation"),
     or(eq(schema.jobs.status, "queued"), eq(schema.jobs.status, "failed")),
   );
 }
 
-function activeJobWhere(input: { organizationId: string; jobId: string }) {
+async function activeJobWhere(auth: ApiAuthContext, jobId: string) {
   return and(
-    eq(schema.jobs.id, input.jobId),
-    eq(schema.jobs.organizationId, input.organizationId),
+    eq(schema.jobs.id, jobId),
+    await buildAccessibleJobsWhere(auth),
     or(eq(schema.jobs.status, "queued"), eq(schema.jobs.status, "running")),
   );
 }
@@ -630,9 +630,7 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
         })
         .from(schema.jobs)
         .leftJoin(schema.externalJobDetails, eq(schema.externalJobDetails.jobId, schema.jobs.id))
-        .where(
-          and(eq(schema.jobs.id, params.jobId), eq(schema.jobs.organizationId, organizationId)),
-        )
+        .where(and(eq(schema.jobs.id, params.jobId), await buildAccessibleJobsWhere(c.var.auth)))
         .limit(1);
 
       if (!job) {
@@ -675,9 +673,7 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
           })
           .from(schema.jobs)
           .leftJoin(schema.externalJobDetails, eq(schema.externalJobDetails.jobId, schema.jobs.id))
-          .where(
-            and(eq(schema.jobs.id, params.jobId), eq(schema.jobs.organizationId, organizationId)),
-          )
+          .where(and(eq(schema.jobs.id, params.jobId), await buildAccessibleJobsWhere(c.var.auth)))
           .limit(1);
 
         if (!job) {
@@ -809,7 +805,6 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
     )
     .get("/:jobId/provider-actions", validateWorkspaceJobParams, async (c) => {
       const params = c.req.valid("param");
-      const organizationId = c.var.auth.organization.localOrganizationId;
 
       const [job] = await db
         .select({
@@ -817,9 +812,7 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
         })
         .from(schema.jobs)
         .leftJoin(schema.externalJobDetails, eq(schema.externalJobDetails.jobId, schema.jobs.id))
-        .where(
-          and(eq(schema.jobs.id, params.jobId), eq(schema.jobs.organizationId, organizationId)),
-        )
+        .where(and(eq(schema.jobs.id, params.jobId), await buildAccessibleJobsWhere(c.var.auth)))
         .limit(1);
 
       if (!job) {
@@ -855,9 +848,7 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
           })
           .from(schema.jobs)
           .leftJoin(schema.externalJobDetails, eq(schema.externalJobDetails.jobId, schema.jobs.id))
-          .where(
-            and(eq(schema.jobs.id, params.jobId), eq(schema.jobs.organizationId, organizationId)),
-          )
+          .where(and(eq(schema.jobs.id, params.jobId), await buildAccessibleJobsWhere(c.var.auth)))
           .limit(1);
 
         if (!job) {
@@ -1017,9 +1008,7 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
         })
         .from(schema.jobs)
         .leftJoin(schema.externalJobDetails, eq(schema.externalJobDetails.jobId, schema.jobs.id))
-        .where(
-          and(eq(schema.jobs.id, params.jobId), eq(schema.jobs.organizationId, organizationId)),
-        )
+        .where(and(eq(schema.jobs.id, params.jobId), await buildAccessibleJobsWhere(c.var.auth)))
         .limit(1);
 
       if (!job) {
@@ -1106,24 +1095,14 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
           schema.translationJobDetails,
           eq(schema.translationJobDetails.jobId, schema.jobs.id),
         )
-        .where(
-          retryableJobWhere({
-            organizationId: c.var.auth.organization.localOrganizationId,
-            jobId: params.jobId,
-          }),
-        )
+        .where(await retryableJobWhere(c.var.auth, params.jobId))
         .limit(1);
 
       if (!job) {
         const [existingJob] = await db
           .select({ id: schema.jobs.id })
           .from(schema.jobs)
-          .where(
-            and(
-              eq(schema.jobs.id, params.jobId),
-              eq(schema.jobs.organizationId, c.var.auth.organization.localOrganizationId),
-            ),
-          )
+          .where(and(eq(schema.jobs.id, params.jobId), await buildAccessibleJobsWhere(c.var.auth)))
           .limit(1);
 
         return existingJob
@@ -1148,12 +1127,7 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
             outcomePayload: null,
             completedAt: null,
           })
-          .where(
-            retryableJobWhere({
-              organizationId: c.var.auth.organization.localOrganizationId,
-              jobId: params.jobId,
-            }),
-          )
+          .where(await retryableJobWhere(c.var.auth, params.jobId))
           .returning({ id: schema.jobs.id, projectId: schema.jobs.projectId });
 
         if (!updatedJob) {
@@ -1189,12 +1163,7 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
                 error instanceof Error ? error.message : "translation job queue unavailable",
               completedAt: new Date(),
             })
-            .where(
-              and(
-                eq(schema.jobs.id, params.jobId),
-                eq(schema.jobs.organizationId, c.var.auth.organization.localOrganizationId),
-              ),
-            );
+            .where(and(eq(schema.jobs.id, params.jobId), await buildAccessibleJobsWhere(c.var.auth)));
 
           await tx
             .update(schema.translationJobDetails)
@@ -1226,12 +1195,7 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
             eq(schema.projects.organizationId, schema.jobs.organizationId),
           ),
         )
-        .where(
-          and(
-            eq(schema.jobs.id, params.jobId),
-            eq(schema.jobs.organizationId, c.var.auth.organization.localOrganizationId),
-          ),
-        )
+        .where(and(eq(schema.jobs.id, params.jobId), await buildAccessibleJobsWhere(c.var.auth)))
         .limit(1);
 
       return c.json({ job: updatedJob }, 200);
@@ -1255,12 +1219,7 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
             },
             completedAt: new Date(),
           })
-          .where(
-            activeJobWhere({
-              organizationId: c.var.auth.organization.localOrganizationId,
-              jobId: params.jobId,
-            }),
-          )
+          .where(await activeJobWhere(c.var.auth, params.jobId))
           .returning({ id: schema.jobs.id, kind: schema.jobs.kind });
 
         if (job?.kind === "translation") {
@@ -1277,12 +1236,7 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
         const [existingJob] = await db
           .select({ id: schema.jobs.id })
           .from(schema.jobs)
-          .where(
-            and(
-              eq(schema.jobs.id, params.jobId),
-              eq(schema.jobs.organizationId, c.var.auth.organization.localOrganizationId),
-            ),
-          )
+          .where(and(eq(schema.jobs.id, params.jobId), await buildAccessibleJobsWhere(c.var.auth)))
           .limit(1);
 
         return existingJob
@@ -1311,12 +1265,7 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
             eq(schema.projects.organizationId, schema.jobs.organizationId),
           ),
         )
-        .where(
-          and(
-            eq(schema.jobs.id, params.jobId),
-            eq(schema.jobs.organizationId, c.var.auth.organization.localOrganizationId),
-          ),
-        )
+        .where(and(eq(schema.jobs.id, params.jobId), await buildAccessibleJobsWhere(c.var.auth)))
         .limit(1);
 
       return c.json({ job }, 200);

--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
@@ -1163,7 +1163,9 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
                 error instanceof Error ? error.message : "translation job queue unavailable",
               completedAt: new Date(),
             })
-            .where(and(eq(schema.jobs.id, params.jobId), await buildAccessibleJobsWhere(c.var.auth)));
+            .where(
+              and(eq(schema.jobs.id, params.jobId), await buildAccessibleJobsWhere(c.var.auth)),
+            );
 
           await tx
             .update(schema.translationJobDetails)


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Several workspace-scoped job endpoints (agent-runs, provider-actions, QA, retry, mark-failed) were missing project-level authorization checks.
🎯 Impact: Users could view or modify jobs in projects they were not members of, provided they knew the Job ID, within the same organization.
🔧 Fix: Standardized authorization by incorporating `buildAccessibleJobsWhere` into all affected workspace job lookups and refactored local authorization helpers to be asynchronous and context-aware.
✅ Verification: Verified code changes via manual inspection and static type checking (`npx tsc --noEmit`). Recorded findings in Sentinel journal.

---
*PR created automatically by Jules for task [1720166035374261058](https://jules.google.com/task/1720166035374261058) started by @cungminh2710*