### PR TITLE
feat(web): integrate Autumn org-scoped billing (HL-419)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,8 +57,9 @@ go build -o $(go env GOPATH)/bin/golangci-lint github.com/golangci/golangci-lint
   WORKOS_CLIENT_ID=client_placeholder
   WORKOS_REDIRECT_URI=http://localhost:3000/auth/callback
   NEXT_PUBLIC_WORKOS_REDIRECT_URI=http://localhost:3000/auth/callback
-  WORKOS_COOKIE_PASSWORD=this-is-a-test-cookie-password-at-least-32-characters
-  ```
+ WORKOS_COOKIE_PASSWORD=this-is-a-test-cookie-password-at-least-32-characters
+ AUTUMN_API_KEY=am_sk_test_placeholder
+ ```
 - Run `vp run db:migrate` after starting Postgres to apply Drizzle migrations.
 - The `make test` target uses coverage flags that may warn about a missing `covdata` tool — all actual tests still pass. Use `go test ./...` if you want a clean exit code without coverage.
 

--- a/apps/hyperlocalise-web/package.json
+++ b/apps/hyperlocalise-web/package.json
@@ -41,6 +41,7 @@
     "@xyflow/react": "^12.10.2",
     "ai": "6.0.191",
     "ansi-to-react": "^6.2.6",
+    "autumn-js": "^1.2.27",
     "chat": "4.29.0",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",

--- a/apps/hyperlocalise-web/pnpm-lock.yaml
+++ b/apps/hyperlocalise-web/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       ansi-to-react:
         specifier: ^6.2.6
         version: 6.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      autumn-js:
+        specifier: ^1.2.27
+        version: 1.2.27(express@5.2.1)(hono@4.12.22)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       chat:
         specifier: 4.29.0
         version: 4.29.0(ai@6.0.191(zod@4.4.3))(zod@4.4.3)
@@ -3690,6 +3693,29 @@ packages:
     resolution: {integrity: sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  autumn-js@1.2.27:
+    resolution: {integrity: sha512-2tbO0gGtoyQ+upz4dPTIaORYQVQNztZb5pZ4B+QWNJZdmsvJfuZ2o6Fmh1rD9qh0aVqgVwRcxXxcwsQJ9RcNrA==}
+    peerDependencies:
+      better-auth: ^1.6.0
+      better-call: ^1.0.12
+      express: ^5.2.1
+      hono: ^4.0.0
+      next: ^14.0.0 || ^15.0.0 || ^16.0.0
+      react: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      better-auth:
+        optional: true
+      better-call:
+        optional: true
+      express:
+        optional: true
+      hono:
+        optional: true
+      next:
+        optional: true
+      react:
+        optional: true
+
   axios@1.16.0:
     resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
 
@@ -4276,6 +4302,10 @@ packages:
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
+  decode-uri-component@0.4.1:
+    resolution: {integrity: sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==}
+    engines: {node: '>=14.16'}
+
   decompress-response@10.0.0:
     resolution: {integrity: sha512-oj7KWToJuuxlPr7VV0vabvxEIiqNMo+q0NueIiL3XhtwC6FVOX7Hr1c0C4eD0bmf7Zr+S/dSf2xvkH3Ad6sU3Q==}
     engines: {node: '>=20'}
@@ -4821,6 +4851,10 @@ packages:
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
+
+  filter-obj@5.1.0:
+    resolution: {integrity: sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==}
+    engines: {node: '>=14.16'}
 
   finalhandler@1.3.2:
     resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
@@ -6341,6 +6375,10 @@ packages:
     resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
     engines: {node: '>=0.6'}
 
+  query-string@9.3.1:
+    resolution: {integrity: sha512-5fBfMOcDi5SA9qj5jZhWAcTtDfKF5WFdd2uD9nVNlbxVv1baq65aALy6qofpNEGELHvisjjasxQp7BlM9gvMzw==}
+    engines: {node: '>=18'}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -6629,6 +6667,9 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  rou3@0.6.3:
+    resolution: {integrity: sha512-1HSG1ENTj7Kkm5muMnXuzzfdDOf7CFnbSYFA+H3Fp/rB9lOCxCPgy1jlZxTKyFoC5jJay8Mmc+VbPLYRjzYLrA==}
+
   roughjs@4.6.6:
     resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
 
@@ -6820,6 +6861,10 @@ packages:
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  split-on-first@3.0.0:
+    resolution: {integrity: sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==}
+    engines: {node: '>=12'}
 
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
@@ -10914,6 +10959,17 @@ snapshots:
 
   auto-bind@5.0.1: {}
 
+  autumn-js@1.2.27(express@5.2.1)(hono@4.12.22)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6):
+    dependencies:
+      query-string: 9.3.1
+      rou3: 0.6.3
+      zod: 4.4.3
+    optionalDependencies:
+      express: 5.2.1
+      hono: 4.12.22
+      next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
+
   axios@1.16.0:
     dependencies:
       follow-redirects: 1.16.0
@@ -11516,6 +11572,8 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
+  decode-uri-component@0.4.1: {}
+
   decompress-response@10.0.0:
     dependencies:
       mimic-response: 4.0.0
@@ -12047,6 +12105,8 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  filter-obj@5.1.0: {}
 
   finalhandler@1.3.2:
     dependencies:
@@ -13808,6 +13868,12 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
+  query-string@9.3.1:
+    dependencies:
+      decode-uri-component: 0.4.1
+      filter-obj: 5.1.0
+      split-on-first: 3.0.0
+
   queue-microtask@1.2.3: {}
 
   quick-lru@5.1.1: {}
@@ -14143,6 +14209,8 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.2
       '@rolldown/binding-win32-x64-msvc': 1.0.2
 
+  rou3@0.6.3: {}
+
   roughjs@4.6.6:
     dependencies:
       hachure-fill: 0.5.2
@@ -14449,6 +14517,8 @@ snapshots:
   source-map@0.7.6: {}
 
   space-separated-tokens@2.0.2: {}
+
+  split-on-first@3.0.0: {}
 
   split2@4.2.0: {}
 

--- a/apps/hyperlocalise-web/src/api/app.ts
+++ b/apps/hyperlocalise-web/src/api/app.ts
@@ -48,6 +48,7 @@ import { createMemberRoutes } from "./routes/member/member.route";
 import { createTeamRoutes } from "./routes/team/team.route";
 import { createWorkspaceRoutes } from "./routes/workspace/workspace.route";
 import { workosWebhookRoutes } from "./routes/workos-webhook/workos-webhook.route";
+import { createAutumnRoutes } from "./routes/autumn/autumn.route";
 import {
   createTranslationJobEventQueue,
   createProviderAgentCommentQueue,
@@ -88,6 +89,7 @@ export function createApp(options: CreateAppOptions = {}) {
     .notFound(notFoundHandler)
     .route("/", createInternalRoutes())
     .route("/auth", createAuthRoutes())
+    .route("/autumn", createAutumnRoutes())
     .route(
       "/orgs/:organizationSlug",
       createOrgScopedAppRoutes({

--- a/apps/hyperlocalise-web/src/api/auth/policy.test.ts
+++ b/apps/hyperlocalise-web/src/api/auth/policy.test.ts
@@ -19,6 +19,7 @@ const MEMBER_READ_CAPABILITIES: OrganizationCapability[] = [
 
 const ADMIN_ONLY_CAPABILITIES: OrganizationCapability[] = [
   "billing:read",
+  "billing:write",
   "api_keys:read",
   "provider_credentials:read",
   "integrations:read",

--- a/apps/hyperlocalise-web/src/api/auth/policy.ts
+++ b/apps/hyperlocalise-web/src/api/auth/policy.ts
@@ -9,6 +9,7 @@ const MEMBER_READ_CAPABILITIES = [
 ] as const;
 
 const ADMIN_WRITE_CAPABILITIES = [
+  "billing:write",
   "workspace:update",
   "members:invite",
   "teams:write",

--- a/apps/hyperlocalise-web/src/api/routes/autumn/autumn.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/autumn/autumn.route.test.ts
@@ -60,7 +60,7 @@ vi.mock("autumn-js/hono", () => ({
 import { createApp } from "@/api/app";
 import type { WorkosAuthIdentity } from "@/api/auth/workos";
 import { createAuthTestFixture } from "@/api/test-auth.fixture";
-import { ORGANIZATION_SLUG_HEADER } from "@/lib/billing/autumn-config";
+import { ORGANIZATION_SLUG_HEADER } from "@/lib/billing/autumn-public-config";
 import { LOCAL_ORG_WORKOS_ID_PREFIX } from "@/lib/billing/autumn-customer";
 import { db } from "@/lib/database";
 

--- a/apps/hyperlocalise-web/src/api/routes/autumn/autumn.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/autumn/autumn.route.test.ts
@@ -1,0 +1,188 @@
+import "dotenv/config";
+
+import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
+
+const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
+  resolveApiAuthContextFromSessionMock: vi.fn(
+    (options) =>
+      globalThis.__resolveTestApiAuthContextFromSession?.(options) ??
+      globalThis.__testApiAuthContext ??
+      null,
+  ),
+}));
+
+const { autumnHandlerMock, autumnRequestHandlerMock } = vi.hoisted(() => {
+  const autumnRequestHandlerMock = vi.fn(
+    async (
+      _c: { get: (key: string) => unknown },
+      identity: {
+        customerId?: string;
+        customerData?: { name?: string; email?: string };
+      } | null,
+    ) =>
+      new Response(JSON.stringify({ identity }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+  );
+
+  const autumnHandlerMock = vi.fn(
+    ({
+      identify,
+    }: {
+      identify: (c: { get: (key: string) => unknown }) => {
+        customerId?: string;
+        customerData?: { name?: string; email?: string };
+      } | null;
+    }) => {
+      return async (c: { get: (key: string) => unknown }) => {
+        const identity = identify(c);
+        return autumnRequestHandlerMock(c, identity);
+      };
+    },
+  );
+
+  return { autumnHandlerMock, autumnRequestHandlerMock };
+});
+
+vi.mock("@/api/auth/workos-session", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/auth/workos-session")>();
+  return {
+    ...actual,
+    resolveApiAuthContextFromSession: resolveApiAuthContextFromSessionMock,
+  };
+});
+
+vi.mock("autumn-js/hono", () => ({
+  autumnHandler: autumnHandlerMock,
+}));
+
+import { createApp } from "@/api/app";
+import type { WorkosAuthIdentity } from "@/api/auth/workos";
+import { createAuthTestFixture } from "@/api/test-auth.fixture";
+import { ORGANIZATION_SLUG_HEADER } from "@/lib/billing/autumn-config";
+import { LOCAL_ORG_WORKOS_ID_PREFIX } from "@/lib/billing/autumn-customer";
+import { db } from "@/lib/database";
+
+const app = createApp();
+const fixture = createAuthTestFixture();
+
+async function postAutumnRoute(routeName: string, headers: Record<string, string> = {}) {
+  return app.request(`http://localhost/api/autumn/${routeName}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify({}),
+  });
+}
+
+beforeAll(async () => {
+  await db.$client.query("select 1");
+});
+
+afterEach(async () => {
+  resolveApiAuthContextFromSessionMock.mockClear();
+  autumnRequestHandlerMock.mockClear();
+  await fixture.cleanup();
+});
+
+describe("autumnRoutes", () => {
+  it("returns unauthorized without a session cookie", async () => {
+    const response = await postAutumnRoute("getOrCreateCustomer", {
+      [ORGANIZATION_SLUG_HEADER]: "missing-org",
+    });
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "unauthorized",
+    });
+  });
+
+  it("forbids billing routes for members without billing access", async () => {
+    const identity = fixture.createWorkosIdentityWithRole("member");
+    const headers = await fixture.authHeadersFor(identity);
+
+    const response = await postAutumnRoute("openCustomerPortal", {
+      cookie: headers.cookie,
+      [ORGANIZATION_SLUG_HEADER]: identity.organization.slug ?? "missing-slug",
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "billing_read_forbidden",
+    });
+    expect(autumnRequestHandlerMock).not.toHaveBeenCalled();
+  });
+
+  it("allows owners to reach Autumn write routes", async () => {
+    const identity = fixture.createWorkosIdentityWithRole("owner");
+    const headers = await fixture.authHeadersFor(identity);
+
+    const response = await postAutumnRoute("openCustomerPortal", {
+      cookie: headers.cookie,
+      [ORGANIZATION_SLUG_HEADER]: identity.organization.slug ?? "missing-slug",
+    });
+
+    expect(response.status).toBe(200);
+    expect(autumnRequestHandlerMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("forbids deprecated local_org workspaces before Autumn is invoked", async () => {
+    const identity = fixture.createWorkosIdentity();
+    identity.organization.workosOrganizationId = `${LOCAL_ORG_WORKOS_ID_PREFIX}legacy`;
+    const headers = await fixture.authHeadersFor(identity);
+
+    const response = await postAutumnRoute("getOrCreateCustomer", {
+      cookie: headers.cookie,
+      [ORGANIZATION_SLUG_HEADER]: identity.organization.slug ?? "missing-slug",
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "billing_customer_unavailable",
+    });
+    expect(autumnRequestHandlerMock).not.toHaveBeenCalled();
+  });
+
+  it("scopes Autumn identity to the active organization from the slug header", async () => {
+    const primaryIdentity = fixture.createWorkosIdentity();
+    const secondaryIdentity = {
+      ...fixture.createWorkosIdentityForOrganization(
+        {
+          workosOrganizationId: `org_${crypto.randomUUID()}`,
+          name: "Secondary Workspace",
+          slug: `secondary-${crypto.randomUUID()}`,
+        },
+        "owner",
+      ),
+      user: primaryIdentity.user,
+      membership: {
+        workosMembershipId: `${primaryIdentity.membership.workosMembershipId}-secondary`,
+        role: "owner",
+      },
+    } satisfies WorkosAuthIdentity;
+
+    const { cookie, organizations } = await fixture.authHeadersForOrganizations([
+      primaryIdentity,
+      secondaryIdentity,
+    ]);
+    const secondaryOrganization = organizations[1]!;
+
+    const response = await postAutumnRoute("getOrCreateCustomer", {
+      cookie,
+      [ORGANIZATION_SLUG_HEADER]: secondaryOrganization.slug ?? "missing-slug",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      identity: {
+        customerId: secondaryOrganization.localOrganizationId,
+        customerData: {
+          name: "Secondary Workspace",
+        },
+      },
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/api/routes/autumn/autumn.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/autumn/autumn.route.ts
@@ -49,7 +49,11 @@ const requireBillingWriteForRouteMiddleware = createMiddleware<{ Variables: Auth
   },
 );
 
-const requireBillableWorkspaceMiddleware = createMiddleware<{ Variables: AuthVariables }>(
+type AutumnVariables = AuthVariables & {
+  autumnCustomerIdentity: NonNullable<ReturnType<typeof resolveAutumnCustomerIdentity>>;
+};
+
+const requireBillableWorkspaceMiddleware = createMiddleware<{ Variables: AutumnVariables }>(
   async (c, next) => {
     const identity = resolveAutumnCustomerIdentity(c.get("auth"));
     if (!identity?.customerId) {
@@ -60,6 +64,7 @@ const requireBillableWorkspaceMiddleware = createMiddleware<{ Variables: AuthVar
       );
     }
 
+    c.set("autumnCustomerIdentity", identity);
     await next();
   },
 );
@@ -67,7 +72,7 @@ const requireBillableWorkspaceMiddleware = createMiddleware<{ Variables: AuthVar
 export function createAutumnRoutes() {
   const secretKey = getAutumnSecretKey();
 
-  return new Hono<{ Variables: AuthVariables }>()
+  return new Hono<{ Variables: AutumnVariables }>()
     .use("*", createWorkosAuthMiddleware())
     .use("*", requireBillingReadMiddleware)
     .use("*", requireBillingWriteForRouteMiddleware)
@@ -77,7 +82,7 @@ export function createAutumnRoutes() {
       autumnHandler({
         secretKey,
         pathPrefix: AUTUMN_API_PATH_PREFIX,
-        identify: (c) => resolveAutumnCustomerIdentity(c.get("auth")),
+        identify: (c) => c.get("autumnCustomerIdentity"),
       }),
     );
 }

--- a/apps/hyperlocalise-web/src/api/routes/autumn/autumn.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/autumn/autumn.route.ts
@@ -1,0 +1,85 @@
+import { Hono } from "hono";
+import { createMiddleware } from "hono/factory";
+import { autumnHandler } from "autumn-js/hono";
+
+import { forbiddenResponse } from "@/api/errors";
+import { hasCapability } from "@/api/auth/policy";
+import { createWorkosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
+import {
+  AUTUMN_API_PATH_PREFIX,
+  getAutumnSecretKey,
+  ORGANIZATION_SLUG_HEADER,
+} from "@/lib/billing/autumn-config";
+import { resolveAutumnCustomerIdentity } from "@/lib/billing/autumn-customer";
+import {
+  AUTUMN_BILLING_WRITE_ROUTE_NAMES,
+  getAutumnRouteNameFromPath,
+} from "@/lib/billing/autumn-route-access";
+
+const requireBillingReadMiddleware = createMiddleware<{ Variables: AuthVariables }>(
+  async (c, next) => {
+    const auth = c.get("auth");
+    if (!hasCapability(auth.membership.role, "billing:read")) {
+      return forbiddenResponse(
+        c,
+        "billing_read_forbidden",
+        "Billing settings require workspace owner or admin access",
+      );
+    }
+
+    await next();
+  },
+);
+
+const requireBillingWriteForRouteMiddleware = createMiddleware<{ Variables: AuthVariables }>(
+  async (c, next) => {
+    const routeName = getAutumnRouteNameFromPath(new URL(c.req.url).pathname);
+    if (routeName && AUTUMN_BILLING_WRITE_ROUTE_NAMES.has(routeName)) {
+      const auth = c.get("auth");
+      if (!hasCapability(auth.membership.role, "billing:write")) {
+        return forbiddenResponse(
+          c,
+          "billing_write_forbidden",
+          "Only workspace owners and admins can change plans or open the billing portal",
+        );
+      }
+    }
+
+    await next();
+  },
+);
+
+const requireBillableWorkspaceMiddleware = createMiddleware<{ Variables: AuthVariables }>(
+  async (c, next) => {
+    const identity = resolveAutumnCustomerIdentity(c.get("auth"));
+    if (!identity?.customerId) {
+      return forbiddenResponse(
+        c,
+        "billing_customer_unavailable",
+        "Billing is not available for this workspace",
+      );
+    }
+
+    await next();
+  },
+);
+
+export function createAutumnRoutes() {
+  const secretKey = getAutumnSecretKey();
+
+  return new Hono<{ Variables: AuthVariables }>()
+    .use("*", createWorkosAuthMiddleware())
+    .use("*", requireBillingReadMiddleware)
+    .use("*", requireBillingWriteForRouteMiddleware)
+    .use("*", requireBillableWorkspaceMiddleware)
+    .use(
+      "*",
+      autumnHandler({
+        secretKey,
+        pathPrefix: AUTUMN_API_PATH_PREFIX,
+        identify: (c) => resolveAutumnCustomerIdentity(c.get("auth")),
+      }),
+    );
+}
+
+export { ORGANIZATION_SLUG_HEADER };

--- a/apps/hyperlocalise-web/src/api/test-auth.fixture.ts
+++ b/apps/hyperlocalise-web/src/api/test-auth.fixture.ts
@@ -153,9 +153,11 @@ export function createAuthTestFixture() {
     };
   }
 
-  async function authHeadersFor(identity: WorkosAuthIdentity) {
-    const { user, organization, membership } = await syncWorkosIdentity(db, identity);
-    const activeOrganization = {
+  function toAuthOrganization(
+    organization: Awaited<ReturnType<typeof syncWorkosIdentity>>["organization"],
+    membership: Awaited<ReturnType<typeof syncWorkosIdentity>>["membership"],
+  ) {
+    return {
       workosOrganizationId: organization.workosOrganizationId,
       localOrganizationId: organization.id,
       name: organization.name,
@@ -165,6 +167,11 @@ export function createAuthTestFixture() {
         role: membership.role,
       },
     };
+  }
+
+  async function authHeadersFor(identity: WorkosAuthIdentity) {
+    const { user, organization, membership } = await syncWorkosIdentity(db, identity);
+    const activeOrganization = toAuthOrganization(organization, membership);
 
     const authContext = enrichAuthContextWithCapabilities({
       user: {
@@ -190,6 +197,53 @@ export function createAuthTestFixture() {
 
     return {
       cookie: `wos-session=${sessionToken}`,
+    };
+  }
+
+  async function authHeadersForOrganizations(identities: WorkosAuthIdentity[]) {
+    if (identities.length === 0) {
+      throw new Error("expected at least one organization identity");
+    }
+
+    const organizations = [];
+    let user: Awaited<ReturnType<typeof syncWorkosIdentity>>["user"] | null = null;
+
+    for (const identity of identities) {
+      const synced = await syncWorkosIdentity(db, identity);
+      user = synced.user;
+      organizations.push(toAuthOrganization(synced.organization, synced.membership));
+    }
+
+    if (!user) {
+      throw new Error("expected synced user for organization identities");
+    }
+
+    const activeOrganization = organizations[0]!;
+    const authContext = enrichAuthContextWithCapabilities({
+      user: {
+        workosUserId: user.workosUserId,
+        localUserId: user.id,
+        email: user.email,
+      },
+      organizations,
+      organization: activeOrganization,
+      activeOrganization,
+      membership: {
+        workosMembershipId: activeOrganization.membership.workosMembershipId,
+        role: activeOrganization.membership.role,
+      },
+      activeTeam: null,
+    });
+    const sessionToken = `test_${randomUUID()}`;
+    const records = currentTestRecords();
+
+    records.sessionTokens.add(sessionToken);
+    testApiAuthContextsBySession.set(sessionToken, authContext);
+    globalThis.__testApiAuthContext = authContext;
+
+    return {
+      cookie: `wos-session=${sessionToken}`,
+      organizations,
     };
   }
 
@@ -247,6 +301,7 @@ export function createAuthTestFixture() {
 
   return {
     authHeadersFor,
+    authHeadersForOrganizations,
     cleanup,
     createLocalWorkosIdentity,
     createWorkosIdentity,

--- a/apps/hyperlocalise-web/src/api/test-auth.fixture.ts
+++ b/apps/hyperlocalise-web/src/api/test-auth.fixture.ts
@@ -32,6 +32,33 @@ function testSessionTokenFromCookie(cookie: string | undefined) {
     ?.slice("wos-session=".length);
 }
 
+function switchAuthContextOrganization(
+  authContext: ApiAuthContext,
+  organizationSlug: string | undefined,
+) {
+  if (!organizationSlug || authContext.organization.slug == null) {
+    return authContext;
+  }
+
+  const activeOrganization = authContext.organizations.find(
+    (organization) => organization.slug === organizationSlug,
+  );
+
+  if (!activeOrganization) {
+    return authContext;
+  }
+
+  return enrichAuthContextWithCapabilities({
+    ...authContext,
+    organization: activeOrganization,
+    activeOrganization,
+    membership: {
+      workosMembershipId: activeOrganization.membership.workosMembershipId,
+      role: activeOrganization.membership.role,
+    },
+  });
+}
+
 globalThis.__resolveTestApiAuthContextFromSession = (options = {}) => {
   const token = testSessionTokenFromCookie(options.cookie);
   const authContext =
@@ -45,31 +72,7 @@ globalThis.__resolveTestApiAuthContextFromSession = (options = {}) => {
     return null;
   }
 
-  if (!options.organizationSlug) {
-    return authContext;
-  }
-
-  if (authContext.organization.slug == null) {
-    return authContext;
-  }
-
-  const activeOrganization = authContext.organizations.find(
-    (organization) => organization.slug === options.organizationSlug,
-  );
-
-  if (!activeOrganization) {
-    return authContext;
-  }
-
-  return {
-    ...authContext,
-    organization: activeOrganization,
-    activeOrganization,
-    membership: {
-      workosMembershipId: activeOrganization.membership.workosMembershipId,
-      role: activeOrganization.membership.role,
-    },
-  };
+  return switchAuthContextOrganization(authContext, options.organizationSlug);
 };
 
 export function createAuthTestFixture() {

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/settings/_components/settings-pages.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/settings/_components/settings-pages.tsx
@@ -10,12 +10,10 @@ import {
   UserGroupIcon,
   CheckmarkCircle01Icon,
   CreditCardIcon,
-  Invoice03Icon,
   Key01Icon,
   Mail01Icon,
   Notification01Icon,
   Settings01Icon,
-  Wallet03Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 
@@ -314,119 +312,6 @@ export function AccountSettingsPageContent({
         />
       </SurfaceCard>
     </main>
-  );
-}
-
-export function BillingSettingsPageContent() {
-  return (
-    <main className="space-y-5">
-      <SettingsHeader
-        eyebrow="Billing settings"
-        icon={CreditCardIcon}
-        title="Billing"
-        description="Track plan status, usage, and billing records for localization operations."
-      />
-
-      <section className="grid gap-3 lg:grid-cols-[1fr_22rem]">
-        <SurfaceCard>
-          <CardHeader className="px-5 py-5">
-            <div className="flex items-start justify-between gap-4">
-              <div>
-                <CardTitle className="text-lg font-medium text-foreground">
-                  Enterprise plan
-                </CardTitle>
-                <CardDescription className="mt-1 text-foreground/52">
-                  1.2M of 2M translated words used this cycle.
-                </CardDescription>
-              </div>
-              <Badge
-                variant="outline"
-                className="shrink-0 rounded-full border-bud-500/25 bg-bud-500/10 text-bud-100"
-              >
-                Active
-              </Badge>
-            </div>
-          </CardHeader>
-          <Separator className="bg-foreground/8" />
-          <CardContent className="px-5 py-5">
-            <div className="h-2 overflow-hidden rounded-full bg-foreground/10">
-              <div className="h-full w-[60%] rounded-full bg-bud-500" />
-            </div>
-            <div className="mt-4 grid gap-3 text-sm sm:grid-cols-3">
-              <Metric label="Cycle usage" value="60%" />
-              <Metric label="Renewal" value="Aug 24, 2027" />
-              <Metric label="Billing owner" value="Finance" />
-            </div>
-          </CardContent>
-        </SurfaceCard>
-
-        <SurfaceCard>
-          <CardHeader className="px-5 py-5">
-            <div className="flex size-10 items-center justify-center rounded-lg border border-foreground/10 bg-foreground/5">
-              <HugeiconsIcon icon={Wallet03Icon} strokeWidth={1.8} className="size-5" />
-            </div>
-            <CardTitle className="text-base font-medium text-foreground">Payment method</CardTitle>
-            <CardDescription className="leading-6 text-foreground/52">
-              Card and invoice collection will be managed through the billing provider.
-            </CardDescription>
-          </CardHeader>
-          <Separator className="bg-foreground/8" />
-          <CardContent className="px-5 py-4">
-            <Button
-              variant="outline"
-              className="border-foreground/10 bg-transparent text-foreground/40"
-              disabled
-            >
-              Manage billing
-            </Button>
-          </CardContent>
-        </SurfaceCard>
-      </section>
-
-      <SurfaceCard>
-        <CardHeader className="px-5 py-5">
-          <CardTitle className="text-lg font-medium text-foreground">Invoices</CardTitle>
-          <CardDescription className="text-foreground/52">
-            Recent billing documents.
-          </CardDescription>
-        </CardHeader>
-        <Separator className="bg-foreground/8" />
-        <CardContent className="divide-y divide-foreground/8 px-5 py-0">
-          {["Aug 2025", "Jul 2025", "Jun 2025"].map((invoice) => (
-            <div key={invoice} className="flex items-center justify-between gap-4 py-4">
-              <div className="flex items-center gap-3">
-                <div className="flex size-9 items-center justify-center rounded-lg bg-foreground/5">
-                  <HugeiconsIcon icon={Invoice03Icon} strokeWidth={1.8} className="size-4" />
-                </div>
-                <div>
-                  <TypographyP className="text-sm font-medium text-foreground">
-                    {invoice}
-                  </TypographyP>
-                  <TypographyP className="text-xs text-foreground/42">
-                    Enterprise workspace subscription
-                  </TypographyP>
-                </div>
-              </div>
-              <Badge
-                variant="outline"
-                className="rounded-full border-foreground/10 bg-foreground/4 text-foreground/52"
-              >
-                Paid
-              </Badge>
-            </div>
-          ))}
-        </CardContent>
-      </SurfaceCard>
-    </main>
-  );
-}
-
-function Metric({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="rounded-lg border border-foreground/8 bg-foreground/4 px-4 py-3">
-      <TypographyP className="text-xs text-foreground/42">{label}</TypographyP>
-      <TypographyP className="mt-1 text-sm font-medium text-foreground">{value}</TypographyP>
-    </div>
   );
 }
 

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/settings/billing/_components/autumn-billing-provider.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/settings/billing/_components/autumn-billing-provider.tsx
@@ -2,7 +2,10 @@
 
 import { AutumnProvider } from "autumn-js/react";
 
-import { AUTUMN_API_PATH_PREFIX, ORGANIZATION_SLUG_HEADER } from "@/lib/billing/autumn-config";
+import {
+  AUTUMN_API_PATH_PREFIX,
+  ORGANIZATION_SLUG_HEADER,
+} from "@/lib/billing/autumn-public-config";
 
 export function AutumnBillingProvider({
   children,

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/settings/billing/_components/autumn-billing-provider.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/settings/billing/_components/autumn-billing-provider.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { AutumnProvider } from "autumn-js/react";
+
+import { AUTUMN_API_PATH_PREFIX, ORGANIZATION_SLUG_HEADER } from "@/lib/billing/autumn-config";
+
+export function AutumnBillingProvider({
+  children,
+  organizationSlug,
+}: {
+  children: React.ReactNode;
+  organizationSlug: string;
+}) {
+  return (
+    <AutumnProvider
+      pathPrefix={AUTUMN_API_PATH_PREFIX}
+      includeCredentials
+      headers={{
+        [ORGANIZATION_SLUG_HEADER]: organizationSlug,
+      }}
+    >
+      {children}
+    </AutumnProvider>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/settings/billing/_components/billing-settings-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/settings/billing/_components/billing-settings-content.tsx
@@ -1,0 +1,412 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { CreditCardIcon, Wallet03Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useCustomer, useListPlans } from "autumn-js/react";
+import { toast } from "sonner";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { TypographyH1, TypographyP } from "@/components/ui/typography";
+import { formatAutumnBillingError } from "@/lib/billing/autumn-errors";
+import { isAutumnConfigured } from "@/lib/billing/autumn-config";
+import { getUsageFeatureLabel, meteredUsageFeatureIds } from "@/lib/billing/usage-feature-labels";
+
+function SurfaceCard({
+  children,
+  className = "",
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <Card
+      className={`rounded-lg border border-foreground/8 bg-foreground/2.5 py-0 text-foreground ring-0 ${className}`}
+    >
+      {children}
+    </Card>
+  );
+}
+
+function formatUsageValue(value: number) {
+  return new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(value);
+}
+
+function formatResetDate(timestamp: number | null | undefined) {
+  if (!timestamp) {
+    return "—";
+  }
+
+  return new Intl.DateTimeFormat(undefined, { dateStyle: "medium" }).format(new Date(timestamp));
+}
+
+function BillingSettingsHeader() {
+  return (
+    <section className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+      <div className="max-w-2xl">
+        <div className="flex items-center gap-2 text-sm text-foreground/48">
+          <HugeiconsIcon icon={CreditCardIcon} strokeWidth={1.8} className="size-4" />
+          <span>Billing settings</span>
+        </div>
+        <TypographyH1 className="mt-2 font-heading text-2xl font-medium text-foreground md:text-2xl">
+          Billing
+        </TypographyH1>
+        <TypographyP className="mt-2 text-sm leading-6 text-foreground/52">
+          View your workspace plan, metered usage balances, and manage subscription billing through
+          Autumn.
+        </TypographyP>
+      </div>
+    </section>
+  );
+}
+
+function BillingSettingsPanel({
+  canManageBilling,
+  organizationSlug,
+}: {
+  canManageBilling: boolean;
+  organizationSlug: string;
+}) {
+  const [actionPending, setActionPending] = useState<string | null>(null);
+  const {
+    data: customer,
+    isLoading: customerLoading,
+    error: customerError,
+    refetch: refetchCustomer,
+    attach,
+    updateSubscription,
+    openCustomerPortal,
+  } = useCustomer();
+  const { data: plans, isLoading: plansLoading, error: plansError } = useListPlans();
+
+  const activeSubscription = useMemo(() => {
+    if (!customer?.subscriptions?.length) {
+      return null;
+    }
+
+    return (
+      customer.subscriptions.find((subscription) => subscription.status === "active") ??
+      customer.subscriptions[0] ??
+      null
+    );
+  }, [customer?.subscriptions]);
+
+  const activePlanId = activeSubscription?.planId ?? null;
+  const isScheduledForCancel = Boolean(
+    activeSubscription?.canceledAt && activeSubscription.status === "active",
+  );
+  const usageRows = meteredUsageFeatureIds.map((featureId) => {
+    const balance = customer?.balances?.[featureId];
+    return {
+      featureId,
+      label: getUsageFeatureLabel(featureId),
+      usage: balance?.usage ?? 0,
+      remaining: balance?.remaining ?? 0,
+      granted: balance?.granted ?? 0,
+      unlimited: balance?.unlimited ?? false,
+      nextResetAt: balance?.nextResetAt ?? null,
+    };
+  });
+
+  const billingError = customerError ?? plansError;
+  const isLoading = customerLoading || plansLoading;
+
+  async function runBillingAction(actionId: string, action: () => Promise<unknown>) {
+    setActionPending(actionId);
+    try {
+      await action();
+      await refetchCustomer();
+    } catch (error) {
+      toast.error(formatAutumnBillingError(error));
+    } finally {
+      setActionPending(null);
+    }
+  }
+
+  async function handleAttachPlan(planId: string) {
+    await runBillingAction(`attach-${planId}`, () => attach({ planId }));
+  }
+
+  async function handleCancelSubscription() {
+    if (!activePlanId) {
+      return;
+    }
+
+    await runBillingAction("cancel", () =>
+      updateSubscription({
+        planId: activePlanId,
+        cancelAction: "cancel_end_of_cycle",
+      }),
+    );
+  }
+
+  async function handleUncancelSubscription() {
+    if (!activePlanId) {
+      return;
+    }
+
+    await runBillingAction("uncancel", () =>
+      updateSubscription({
+        planId: activePlanId,
+        cancelAction: "uncancel",
+      }),
+    );
+  }
+
+  async function handleOpenPortal() {
+    const returnUrl =
+      typeof window !== "undefined"
+        ? `${window.location.origin}/org/${organizationSlug}/settings/billing`
+        : undefined;
+
+    await runBillingAction("portal", () => openCustomerPortal({ returnUrl }));
+  }
+
+  if (!isAutumnConfigured()) {
+    return (
+      <SurfaceCard>
+        <CardHeader className="px-5 py-5">
+          <CardTitle className="text-lg font-medium text-foreground">Billing unavailable</CardTitle>
+          <CardDescription className="text-foreground/52">
+            Autumn is not configured in this environment. Add a sandbox `AUTUMN_API_KEY` to enable
+            billing for this workspace.
+          </CardDescription>
+        </CardHeader>
+      </SurfaceCard>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <SurfaceCard>
+        <CardHeader className="px-5 py-5">
+          <CardTitle className="text-lg font-medium text-foreground">Loading billing</CardTitle>
+          <CardDescription className="text-foreground/52">
+            Fetching plan and usage details for this workspace.
+          </CardDescription>
+        </CardHeader>
+      </SurfaceCard>
+    );
+  }
+
+  if (billingError) {
+    return (
+      <SurfaceCard>
+        <CardHeader className="px-5 py-5">
+          <CardTitle className="text-lg font-medium text-foreground">
+            Unable to load billing
+          </CardTitle>
+          <CardDescription className="text-foreground/52">
+            {formatAutumnBillingError(billingError)}
+          </CardDescription>
+        </CardHeader>
+        <Separator className="bg-foreground/8" />
+        <CardContent className="px-5 py-4">
+          <Button variant="outline" onClick={() => void refetchCustomer()}>
+            Try again
+          </Button>
+        </CardContent>
+      </SurfaceCard>
+    );
+  }
+
+  return (
+    <>
+      <section className="grid gap-3 lg:grid-cols-[1fr_22rem]">
+        <SurfaceCard>
+          <CardHeader className="px-5 py-5">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <CardTitle className="text-lg font-medium text-foreground">
+                  {activeSubscription?.plan?.name ?? "No active plan"}
+                </CardTitle>
+                <CardDescription className="mt-1 text-foreground/52">
+                  {activeSubscription
+                    ? `Status: ${activeSubscription.status.replaceAll("_", " ")}`
+                    : "Choose a plan below to start a subscription for this workspace."}
+                </CardDescription>
+              </div>
+              {activeSubscription ? (
+                <Badge
+                  variant="outline"
+                  className="shrink-0 rounded-full border-bud-500/25 bg-bud-500/10 text-bud-100"
+                >
+                  {isScheduledForCancel ? "Canceling" : "Active"}
+                </Badge>
+              ) : null}
+            </div>
+          </CardHeader>
+          <Separator className="bg-foreground/8" />
+          <CardContent className="px-5 py-5">
+            {activeSubscription?.currentPeriodEnd ? (
+              <TypographyP className="text-sm text-foreground/52">
+                Current period ends {formatResetDate(activeSubscription.currentPeriodEnd)}
+              </TypographyP>
+            ) : null}
+            {canManageBilling && isScheduledForCancel ? (
+              <div className="mt-4">
+                <Button
+                  variant="outline"
+                  disabled={actionPending !== null}
+                  onClick={() => void handleUncancelSubscription()}
+                >
+                  {actionPending === "uncancel" ? "Restoring…" : "Restore subscription"}
+                </Button>
+              </div>
+            ) : null}
+            {canManageBilling && activeSubscription && !isScheduledForCancel ? (
+              <div className="mt-4">
+                <Button
+                  variant="outline"
+                  disabled={actionPending !== null}
+                  onClick={() => void handleCancelSubscription()}
+                >
+                  {actionPending === "cancel" ? "Scheduling…" : "Cancel at period end"}
+                </Button>
+              </div>
+            ) : null}
+          </CardContent>
+        </SurfaceCard>
+
+        <SurfaceCard>
+          <CardHeader className="px-5 py-5">
+            <div className="flex size-10 items-center justify-center rounded-lg border border-foreground/10 bg-foreground/5">
+              <HugeiconsIcon icon={Wallet03Icon} strokeWidth={1.8} className="size-5" />
+            </div>
+            <CardTitle className="text-base font-medium text-foreground">Stripe portal</CardTitle>
+            <CardDescription className="leading-6 text-foreground/52">
+              Update payment methods, review invoices, and manage subscription details in Stripe.
+            </CardDescription>
+          </CardHeader>
+          <Separator className="bg-foreground/8" />
+          <CardContent className="px-5 py-4">
+            <Button
+              variant="outline"
+              className="border-foreground/10 bg-transparent"
+              disabled={!canManageBilling || actionPending !== null}
+              onClick={() => void handleOpenPortal()}
+            >
+              {actionPending === "portal" ? "Opening…" : "Open billing portal"}
+            </Button>
+            {!canManageBilling ? (
+              <TypographyP className="mt-3 text-xs text-foreground/42">
+                Only workspace owners and admins can open the billing portal.
+              </TypographyP>
+            ) : null}
+          </CardContent>
+        </SurfaceCard>
+      </section>
+
+      <SurfaceCard>
+        <CardHeader className="px-5 py-5">
+          <CardTitle className="text-lg font-medium text-foreground">Usage balances</CardTitle>
+          <CardDescription className="text-foreground/52">
+            Metered usage for this billing cycle. Enforcement happens server-side; this panel is for
+            visibility only.
+          </CardDescription>
+        </CardHeader>
+        <Separator className="bg-foreground/8" />
+        <CardContent className="divide-y divide-foreground/8 px-5 py-0">
+          {usageRows.map((row) => (
+            <div key={row.featureId} className="flex items-center justify-between gap-4 py-4">
+              <div>
+                <TypographyP className="text-sm font-medium text-foreground">
+                  {row.label}
+                </TypographyP>
+                <TypographyP className="text-xs text-foreground/42">
+                  Resets {formatResetDate(row.nextResetAt)}
+                </TypographyP>
+              </div>
+              <div className="text-right">
+                <TypographyP className="text-sm font-medium text-foreground">
+                  {row.unlimited
+                    ? "Unlimited"
+                    : `${formatUsageValue(row.usage)} / ${formatUsageValue(row.granted)} used`}
+                </TypographyP>
+                {!row.unlimited ? (
+                  <TypographyP className="text-xs text-foreground/42">
+                    {formatUsageValue(row.remaining)} remaining
+                  </TypographyP>
+                ) : null}
+              </div>
+            </div>
+          ))}
+        </CardContent>
+      </SurfaceCard>
+
+      <SurfaceCard>
+        <CardHeader className="px-5 py-5">
+          <CardTitle className="text-lg font-medium text-foreground">Available plans</CardTitle>
+          <CardDescription className="text-foreground/52">
+            Plans are configured in Autumn. Pricing changes there do not require app migrations.
+          </CardDescription>
+        </CardHeader>
+        <Separator className="bg-foreground/8" />
+        <CardContent className="divide-y divide-foreground/8 px-5 py-0">
+          {(plans ?? []).map((plan) => {
+            const isCurrentPlan = plan.id === activePlanId;
+            return (
+              <div key={plan.id} className="flex items-start justify-between gap-4 py-4">
+                <div>
+                  <TypographyP className="text-sm font-medium text-foreground">
+                    {plan.name}
+                  </TypographyP>
+                  <TypographyP className="mt-1 max-w-xl text-sm leading-6 text-foreground/48">
+                    {plan.description ?? "Workspace subscription plan"}
+                  </TypographyP>
+                </div>
+                <div className="flex shrink-0 flex-col items-end gap-2">
+                  {isCurrentPlan ? (
+                    <Badge
+                      variant="outline"
+                      className="rounded-full border-foreground/10 bg-foreground/4 text-foreground/52"
+                    >
+                      Current plan
+                    </Badge>
+                  ) : (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      disabled={!canManageBilling || actionPending !== null}
+                      onClick={() => void handleAttachPlan(plan.id)}
+                    >
+                      {actionPending === `attach-${plan.id}` ? "Starting…" : "Select plan"}
+                    </Button>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+          {!plans?.length ? (
+            <div className="py-4">
+              <TypographyP className="text-sm text-foreground/52">
+                No plans are configured in Autumn yet.
+              </TypographyP>
+            </div>
+          ) : null}
+        </CardContent>
+      </SurfaceCard>
+    </>
+  );
+}
+
+export function BillingSettingsPageContent({
+  canManageBilling,
+  organizationSlug,
+}: {
+  canManageBilling: boolean;
+  organizationSlug: string;
+}) {
+  return (
+    <main className="space-y-5">
+      <BillingSettingsHeader />
+      <BillingSettingsPanel
+        canManageBilling={canManageBilling}
+        organizationSlug={organizationSlug}
+      />
+    </main>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/settings/billing/_components/billing-settings-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/settings/billing/_components/billing-settings-content.tsx
@@ -12,7 +12,6 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Separator } from "@/components/ui/separator";
 import { TypographyH1, TypographyP } from "@/components/ui/typography";
 import { formatAutumnBillingError } from "@/lib/billing/autumn-errors";
-import { isAutumnConfigured } from "@/lib/billing/autumn-config";
 import { getUsageFeatureLabel, meteredUsageFeatureIds } from "@/lib/billing/usage-feature-labels";
 
 function SurfaceCard({
@@ -64,9 +63,11 @@ function BillingSettingsHeader() {
 }
 
 function BillingSettingsPanel({
+  autumnConfigured,
   canManageBilling,
   organizationSlug,
 }: {
+  autumnConfigured: boolean;
   canManageBilling: boolean;
   organizationSlug: string;
 }) {
@@ -165,7 +166,7 @@ function BillingSettingsPanel({
     await runBillingAction("portal", () => openCustomerPortal({ returnUrl }));
   }
 
-  if (!isAutumnConfigured()) {
+  if (!autumnConfigured) {
     return (
       <SurfaceCard>
         <CardHeader className="px-5 py-5">
@@ -394,9 +395,11 @@ function BillingSettingsPanel({
 }
 
 export function BillingSettingsPageContent({
+  autumnConfigured,
   canManageBilling,
   organizationSlug,
 }: {
+  autumnConfigured: boolean;
   canManageBilling: boolean;
   organizationSlug: string;
 }) {
@@ -404,6 +407,7 @@ export function BillingSettingsPageContent({
     <main className="space-y-5">
       <BillingSettingsHeader />
       <BillingSettingsPanel
+        autumnConfigured={autumnConfigured}
         canManageBilling={canManageBilling}
         organizationSlug={organizationSlug}
       />

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/settings/billing/page.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/settings/billing/page.tsx
@@ -1,4 +1,5 @@
 import { hasCapability } from "@/api/auth/policy";
+import { isAutumnConfigured } from "@/lib/billing/autumn-config";
 import { requireAppAuthContext, requireAppCapability } from "@/lib/workos/app-auth";
 
 import { AutumnBillingProvider } from "./_components/autumn-billing-provider";
@@ -16,6 +17,7 @@ export default async function BillingSettingsPage({
   return (
     <AutumnBillingProvider organizationSlug={organizationSlug}>
       <BillingSettingsPageContent
+        autumnConfigured={isAutumnConfigured()}
         organizationSlug={organizationSlug}
         canManageBilling={hasCapability(auth.membership.role, "billing:write")}
       />

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/settings/billing/page.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/settings/billing/page.tsx
@@ -1,5 +1,8 @@
-import { requireAppCapability } from "@/lib/workos/app-auth";
-import { BillingSettingsPageContent } from "../_components/settings-pages";
+import { hasCapability } from "@/api/auth/policy";
+import { requireAppAuthContext, requireAppCapability } from "@/lib/workos/app-auth";
+
+import { AutumnBillingProvider } from "./_components/autumn-billing-provider";
+import { BillingSettingsPageContent } from "./_components/billing-settings-content";
 
 export default async function BillingSettingsPage({
   params,
@@ -8,6 +11,14 @@ export default async function BillingSettingsPage({
 }) {
   const { organizationSlug } = await params;
   await requireAppCapability("billing:read", { organizationSlug });
+  const auth = await requireAppAuthContext({ organizationSlug });
 
-  return <BillingSettingsPageContent />;
+  return (
+    <AutumnBillingProvider organizationSlug={organizationSlug}>
+      <BillingSettingsPageContent
+        organizationSlug={organizationSlug}
+        canManageBilling={hasCapability(auth.membership.role, "billing:write")}
+      />
+    </AutumnBillingProvider>
+  );
 }

--- a/apps/hyperlocalise-web/src/lib/billing/autumn-config.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/autumn-config.ts
@@ -1,10 +1,6 @@
 import { env } from "@/lib/env";
 
-/** Header used to scope Autumn billing to the active organization workspace. */
-export const ORGANIZATION_SLUG_HEADER = "x-hyperlocalise-organization-slug";
-
-/** Autumn API route prefix mounted on the Hono app (under `/api`). */
-export const AUTUMN_API_PATH_PREFIX = "/api/autumn";
+export { AUTUMN_API_PATH_PREFIX, ORGANIZATION_SLUG_HEADER } from "./autumn-public-config";
 
 /**
  * Resolves the Autumn secret key. The app stores `AUTUMN_API_KEY`; Autumn's SDK

--- a/apps/hyperlocalise-web/src/lib/billing/autumn-config.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/autumn-config.ts
@@ -1,0 +1,19 @@
+import { env } from "@/lib/env";
+
+/** Header used to scope Autumn billing to the active organization workspace. */
+export const ORGANIZATION_SLUG_HEADER = "x-hyperlocalise-organization-slug";
+
+/** Autumn API route prefix mounted on the Hono app (under `/api`). */
+export const AUTUMN_API_PATH_PREFIX = "/api/autumn";
+
+/**
+ * Resolves the Autumn secret key. The app stores `AUTUMN_API_KEY`; Autumn's SDK
+ * also accepts `AUTUMN_SECRET_KEY`, which we mirror when a key is configured.
+ */
+export function getAutumnSecretKey(): string | undefined {
+  return env.AUTUMN_API_KEY ?? process.env.AUTUMN_SECRET_KEY;
+}
+
+export function isAutumnConfigured(): boolean {
+  return Boolean(getAutumnSecretKey());
+}

--- a/apps/hyperlocalise-web/src/lib/billing/autumn-customer.test.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/autumn-customer.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import type { ApiAuthContext } from "@/api/auth/workos";
+import {
+  isDeprecatedLocalOrgWorkosId,
+  LOCAL_ORG_WORKOS_ID_PREFIX,
+  resolveAutumnCustomerIdentity,
+} from "@/lib/billing/autumn-customer";
+
+function createAuthContext(
+  overrides: Partial<ApiAuthContext["organization"]> = {},
+): ApiAuthContext {
+  return {
+    user: {
+      workosUserId: "user_test",
+      localUserId: "00000000-0000-4000-8000-000000000001",
+      email: "owner@example.com",
+    },
+    organizations: [],
+    organization: {
+      workosOrganizationId: "org_test",
+      localOrganizationId: "00000000-0000-4000-8000-000000000010",
+      name: "Example Workspace",
+      slug: "example-workspace",
+      membership: {
+        workosMembershipId: "membership_test",
+        role: "owner",
+      },
+      ...overrides,
+    },
+    activeOrganization: {
+      workosOrganizationId: "org_test",
+      localOrganizationId: "00000000-0000-4000-8000-000000000010",
+      name: "Example Workspace",
+      slug: "example-workspace",
+      membership: {
+        workosMembershipId: "membership_test",
+        role: "owner",
+      },
+      ...overrides,
+    },
+    membership: {
+      workosMembershipId: "membership_test",
+      role: "owner",
+    },
+    activeTeam: null,
+    capabilities: [],
+  };
+}
+
+describe("autumn customer identity", () => {
+  it("maps organizations to stable Autumn customer IDs", () => {
+    const auth = createAuthContext();
+
+    expect(resolveAutumnCustomerIdentity(auth)).toEqual({
+      customerId: "00000000-0000-4000-8000-000000000010",
+      customerData: {
+        name: "Example Workspace",
+        email: "owner@example.com",
+      },
+    });
+  });
+
+  it("rejects deprecated local_org workspaces", () => {
+    const auth = createAuthContext({
+      workosOrganizationId: `${LOCAL_ORG_WORKOS_ID_PREFIX}legacy`,
+    });
+
+    expect(isDeprecatedLocalOrgWorkosId(auth.organization.workosOrganizationId)).toBe(true);
+    expect(resolveAutumnCustomerIdentity(auth)).toBeNull();
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/billing/autumn-customer.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/autumn-customer.ts
@@ -1,0 +1,33 @@
+import type { ResolvedIdentity } from "autumn-js/backend";
+
+import type { ApiAuthContext } from "@/api/auth/workos";
+
+/** Synthetic WorkOS organization IDs for deprecated local-only workspaces. */
+export const LOCAL_ORG_WORKOS_ID_PREFIX = "local_org_";
+
+/**
+ * Customer identity mapping for Autumn:
+ *
+ * - `customerId` = `organizations.id` (internal UUID) for stable org-scoped billing
+ * - `customerData.name` = organization display name
+ * - `customerData.email` = acting authenticated user email (billing contact hint)
+ *
+ * Deprecated `local_org_*` workspaces are excluded and never become Autumn customers.
+ */
+export function isDeprecatedLocalOrgWorkosId(workosOrganizationId: string) {
+  return workosOrganizationId.startsWith(LOCAL_ORG_WORKOS_ID_PREFIX);
+}
+
+export function resolveAutumnCustomerIdentity(auth: ApiAuthContext): ResolvedIdentity | null {
+  if (isDeprecatedLocalOrgWorkosId(auth.organization.workosOrganizationId)) {
+    return null;
+  }
+
+  return {
+    customerId: auth.organization.localOrganizationId,
+    customerData: {
+      name: auth.organization.name,
+      email: auth.user.email,
+    },
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/billing/autumn-errors.test.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/autumn-errors.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { AutumnClientError } from "autumn-js/react";
+
+import { formatAutumnBillingError } from "@/lib/billing/autumn-errors";
+
+describe("formatAutumnBillingError", () => {
+  it("maps known billing API errors to stable messages", () => {
+    expect(
+      formatAutumnBillingError(
+        new AutumnClientError({
+          message: "raw provider message",
+          code: "billing_write_forbidden",
+          statusCode: 403,
+        }),
+      ),
+    ).toBe("Only workspace owners and admins can change plans or open the billing portal.");
+
+    expect(
+      formatAutumnBillingError({
+        error: "billing_customer_unavailable",
+        message: "should not leak",
+      }),
+    ).toBe("Billing is not available for this workspace.");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/billing/autumn-errors.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/autumn-errors.ts
@@ -1,0 +1,41 @@
+import { AutumnClientError } from "autumn-js/react";
+
+/** Maps Autumn/API billing failures to stable, user-safe messages. */
+export function formatAutumnBillingError(error: unknown): string {
+  if (error instanceof AutumnClientError) {
+    switch (error.code) {
+      case "billing_read_forbidden":
+        return "You do not have permission to view billing for this workspace.";
+      case "billing_write_forbidden":
+        return "Only workspace owners and admins can change plans or open the billing portal.";
+      case "billing_customer_unavailable":
+        return "Billing is not available for this workspace.";
+      case "unauthorized":
+        return "Sign in again to manage billing.";
+      default:
+        return error.message || "Billing request failed. Try again in a moment.";
+    }
+  }
+
+  if (error && typeof error === "object" && "error" in error) {
+    const apiError = error as { error?: string; message?: string };
+    switch (apiError.error) {
+      case "billing_read_forbidden":
+        return "You do not have permission to view billing for this workspace.";
+      case "billing_write_forbidden":
+        return "Only workspace owners and admins can change plans or open the billing portal.";
+      case "billing_customer_unavailable":
+        return "Billing is not available for this workspace.";
+      case "unauthorized":
+        return "Sign in again to manage billing.";
+      default:
+        return apiError.message || "Billing request failed. Try again in a moment.";
+    }
+  }
+
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return "Billing request failed. Try again in a moment.";
+}

--- a/apps/hyperlocalise-web/src/lib/billing/autumn-ids.test.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/autumn-ids.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { autumnPlanIds, meteredUsageFeatureIds, usageFeatureIds } from "@/lib/billing/autumn-ids";
+
+describe("autumn identifiers", () => {
+  it("exposes stable plan and usage feature IDs", () => {
+    expect(autumnPlanIds).toEqual({
+      free: "free",
+      team: "team",
+    });
+
+    expect(usageFeatureIds).toEqual({
+      translationJobs: "translation_jobs",
+      translationUnits: "translation_units",
+      sourceCharacters: "source_characters",
+      aiTokens: "ai_tokens",
+      apiRequests: "api_requests",
+      agentRuns: "agent_runs",
+    });
+
+    expect(meteredUsageFeatureIds).toEqual([
+      usageFeatureIds.translationJobs,
+      usageFeatureIds.translationUnits,
+      usageFeatureIds.sourceCharacters,
+      usageFeatureIds.aiTokens,
+      usageFeatureIds.apiRequests,
+      usageFeatureIds.agentRuns,
+    ]);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/billing/autumn-ids.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/autumn-ids.ts
@@ -1,0 +1,39 @@
+/**
+ * Autumn product and feature identifiers configured in the Autumn dashboard.
+ * Plan IDs can change pricing in Autumn without local schema migrations.
+ */
+
+/** Subscription plan IDs (configure matching products in Autumn). */
+export const autumnPlanIds = {
+  /** Free / dev sandbox plan for onboarding and local testing. */
+  free: "free",
+  /** Paid workspace subscription plan. */
+  team: "team",
+} as const;
+
+export type AutumnPlanId = (typeof autumnPlanIds)[keyof typeof autumnPlanIds];
+
+/**
+ * Metered usage feature IDs aligned with HL-418 usage control.
+ * These must match Autumn feature definitions and `usage_events.feature_id`.
+ */
+export const usageFeatureIds = {
+  translationJobs: "translation_jobs",
+  translationUnits: "translation_units",
+  sourceCharacters: "source_characters",
+  aiTokens: "ai_tokens",
+  apiRequests: "api_requests",
+  agentRuns: "agent_runs",
+} as const;
+
+export type UsageFeatureId = (typeof usageFeatureIds)[keyof typeof usageFeatureIds];
+
+/** Metered features shown on the billing settings usage panel. */
+export const meteredUsageFeatureIds = [
+  usageFeatureIds.translationJobs,
+  usageFeatureIds.translationUnits,
+  usageFeatureIds.sourceCharacters,
+  usageFeatureIds.aiTokens,
+  usageFeatureIds.apiRequests,
+  usageFeatureIds.agentRuns,
+] as const satisfies readonly UsageFeatureId[];

--- a/apps/hyperlocalise-web/src/lib/billing/autumn-public-config.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/autumn-public-config.ts
@@ -1,0 +1,5 @@
+/** Header used to scope Autumn billing to the active organization workspace. */
+export const ORGANIZATION_SLUG_HEADER = "x-hyperlocalise-organization-slug";
+
+/** Autumn API route prefix mounted on the Hono app (under `/api`). */
+export const AUTUMN_API_PATH_PREFIX = "/api/autumn";

--- a/apps/hyperlocalise-web/src/lib/billing/autumn-route-access.test.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/autumn-route-access.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  AUTUMN_BILLING_WRITE_ROUTE_NAMES,
+  getAutumnRouteNameFromPath,
+} from "@/lib/billing/autumn-route-access";
+
+describe("autumn route access", () => {
+  it("parses Autumn route names from API paths", () => {
+    expect(getAutumnRouteNameFromPath("/api/autumn/getOrCreateCustomer")).toBe(
+      "getOrCreateCustomer",
+    );
+    expect(getAutumnRouteNameFromPath("/api/autumn/openCustomerPortal/extra")).toBe(
+      "openCustomerPortal",
+    );
+    expect(getAutumnRouteNameFromPath("/api/other")).toBeNull();
+  });
+
+  it("tracks billing write routes", () => {
+    expect([...AUTUMN_BILLING_WRITE_ROUTE_NAMES].sort()).toEqual(
+      ["attach", "multiAttach", "openCustomerPortal", "setupPayment", "updateSubscription"].sort(),
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/billing/autumn-route-access.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/autumn-route-access.ts
@@ -1,0 +1,24 @@
+/** Autumn handler route names that mutate billing state (admin-only). */
+export const AUTUMN_BILLING_WRITE_ROUTE_NAMES = new Set([
+  "attach",
+  "updateSubscription",
+  "multiAttach",
+  "setupPayment",
+  "openCustomerPortal",
+]);
+
+export function getAutumnRouteNameFromPath(
+  pathname: string,
+  pathPrefix = "/api/autumn",
+): string | null {
+  if (!pathname.startsWith(pathPrefix)) {
+    return null;
+  }
+
+  const suffix = pathname.slice(pathPrefix.length).replace(/^\/+/, "");
+  if (!suffix) {
+    return null;
+  }
+
+  return suffix.split("/")[0] ?? null;
+}

--- a/apps/hyperlocalise-web/src/lib/billing/usage-control.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/usage-control.ts
@@ -7,16 +7,9 @@ import { db, schema } from "@/lib/database";
 const AUTUMN_API_VERSION = "2.2.0";
 const AUTUMN_TRACK_USAGE_URL = "https://api.useautumn.com/v1/balances.track";
 
-export const usageFeatureIds = {
-  translationJobs: "translation_jobs",
-  translationUnits: "translation_units",
-  sourceCharacters: "source_characters",
-  aiTokens: "ai_tokens",
-  apiRequests: "api_requests",
-  agentRuns: "agent_runs",
-} as const;
+import { usageFeatureIds, type UsageFeatureId } from "@/lib/billing/autumn-ids";
 
-type UsageFeatureId = (typeof usageFeatureIds)[keyof typeof usageFeatureIds];
+export { usageFeatureIds, type UsageFeatureId };
 
 export async function reserveUsageEvent(input: {
   db?: DatabaseClient;

--- a/apps/hyperlocalise-web/src/lib/billing/usage-feature-labels.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/usage-feature-labels.ts
@@ -1,0 +1,21 @@
+import { meteredUsageFeatureIds, type UsageFeatureId } from "@/lib/billing/autumn-ids";
+
+/** Display labels for metered usage features shown on billing settings. */
+export const usageFeatureLabels: Record<UsageFeatureId, string> = {
+  translation_jobs: "Translation jobs",
+  translation_units: "Translation units",
+  source_characters: "Source characters",
+  ai_tokens: "AI tokens",
+  api_requests: "API requests",
+  agent_runs: "Agent runs",
+};
+
+export function getUsageFeatureLabel(featureId: string) {
+  if (featureId in usageFeatureLabels) {
+    return usageFeatureLabels[featureId as UsageFeatureId];
+  }
+
+  return featureId.replaceAll("_", " ");
+}
+
+export { meteredUsageFeatureIds };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Integrates [Autumn](https://useautumn.com) for organization-scoped subscription and usage-based billing (HL-419). WorkOS remains the identity/workspace layer; Autumn owns plans, Stripe checkout/portal, entitlements, and metered balances.

## Changes

### Backend
- Add `autumn-js` and optional `AUTUMN_API_KEY` env validation
- Mount `/api/autumn/*` on the Hono app with WorkOS session auth and org scoping via `x-hyperlocalise-organization-slug`
- Map Autumn `customerId` → `organizations.id` (stable UUID); block deprecated `local_org_*` workspaces
- Add `billing:write` capability for plan changes and Stripe portal (owners/admins only)
- Centralize plan/feature IDs in `src/lib/billing/autumn-ids.ts` (`free`, `team`, metered usage features)

### Billing settings UI
- Replace mock billing page with Autumn React hooks (`useCustomer`, `useListPlans`)
- Show current plan, usage balances, available plans, cancel/uncancel, and Stripe portal (admin-only actions)
- `AutumnProvider` sends org slug header + credentials on every Autumn API call

### Tests
- Customer identity, route access, error formatting, and Autumn route auth/org-switching tests
- `authHeadersForOrganizations` test helper for multi-org session scenarios

## Customer identity mapping

| Autumn field | Hyperlocalise source |
|---|---|
| `customerId` | `organizations.id` |
| `customerData.name` | Organization display name |
| `customerData.email` | Acting user email (billing contact hint) |

Deprecated `local_org_*` workspaces return `billing_customer_unavailable` and never become Autumn customers.

## Out of scope (HL-418)

Server-side usage gating/`check`/`track` enforcement remains in the usage-control layer; this PR wires billing UI and Autumn customer setup only.

## How to test locally

1. Set `AUTUMN_API_KEY` to a sandbox key in `apps/hyperlocalise-web/.env`
2. Configure matching `free` and `team` products/features in the Autumn dashboard (see `autumn-ids.ts`)
3. Open **Settings → Billing** as an org owner/admin

## Validation

- `vp check --fix` passes
- Billing-related tests pass (`src/lib/billing/**`, `src/api/routes/autumn/**`)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-419](https://linear.app/hyperlocalise/issue/HL-419/integrate-autumn-for-organization-subscription-and-usage-based-billing)

<div><a href="https://cursor.com/agents/bc-7e7a5b01-bdbf-4fea-9605-5d468c7b6f35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7e7a5b01-bdbf-4fea-9605-5d468c7b6f35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

