### PR TITLE
feat(web): implement Crowdin webhook setup and reconciliation mapping (HL-404)

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/tms-webhook/tms-webhook.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/tms-webhook/tms-webhook.route.test.ts
@@ -565,12 +565,14 @@ describe("tmsWebhookRoutes", () => {
     expect(rows).toHaveLength(0);
   });
 
-  it("rejects echoed webhook secrets without a body signature", async () => {
+  it("accepts Crowdin webhook secret headers", async () => {
     const { subscription } = await createSubscriptionFixture();
+    let enqueueCount = 0;
     const app = createApp({
       providerWebhookReconciliationQueue: {
         async enqueue() {
-          throw new Error("unexpected enqueue");
+          enqueueCount += 1;
+          return { ids: [randomUUID()] };
         },
       },
     });
@@ -586,14 +588,18 @@ describe("tmsWebhookRoutes", () => {
       webhookSecretHeader: "webhook-signing-secret",
     });
 
-    expect(response.status).toBe(401);
-    await expect(response.json()).resolves.toEqual({ error: "invalid_signature" });
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      ignored: false,
+    });
+    expect(enqueueCount).toBe(1);
 
     const rows = await db
       .select()
       .from(schema.providerWebhookEvents)
       .where(eq(schema.providerWebhookEvents.subscriptionId, subscription.id));
-    expect(rows).toHaveLength(0);
+    expect(rows).toHaveLength(1);
   });
 
   it("rejects active subscriptions when the webhook secret is unavailable", async () => {

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-api.test.ts
@@ -202,6 +202,130 @@ describe("CrowdinApiClient", () => {
     );
   });
 
+  it("manages project webhooks", async () => {
+    const fetchMock = vi.fn(async (url, init) => {
+      const method = init?.method;
+      if (method === "GET") {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  id: 9,
+                  projectId: 42,
+                  name: "Hyperlocalise sync",
+                  url: "https://app.example.test/api/webhooks/tms/crowdin",
+                  events: ["file.updated"],
+                  headers: { "X-Hyperlocalise-Provider-Webhook-Id": "9" },
+                  payload: {},
+                  isActive: true,
+                  requestType: "POST",
+                  contentType: "application/json",
+                  batchingEnabled: false,
+                  createdAt: "2026-05-28T00:00:00Z",
+                  updatedAt: "2026-05-28T00:00:00Z",
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (method === "POST") {
+        return new Response(
+          JSON.stringify({
+            data: {
+              id: 10,
+              projectId: 42,
+              name: "Hyperlocalise sync",
+              url: "https://app.example.test/api/webhooks/tms/crowdin",
+              events: ["file.updated"],
+              headers: {},
+              payload: {},
+              isActive: true,
+              requestType: "POST",
+              contentType: "application/json",
+              batchingEnabled: false,
+              createdAt: "2026-05-28T00:00:00Z",
+              updatedAt: "2026-05-28T00:00:00Z",
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (method === "PATCH") {
+        return new Response(
+          JSON.stringify({
+            data: {
+              id: 10,
+              projectId: 42,
+              name: "Hyperlocalise sync",
+              url: "https://app.example.test/api/webhooks/tms/crowdin",
+              events: ["file.updated", "task.statusChanged"],
+              headers: { "X-Hyperlocalise-Provider-Webhook-Id": "10" },
+              payload: {},
+              isActive: true,
+              requestType: "POST",
+              contentType: "application/json",
+              batchingEnabled: false,
+              createdAt: "2026-05-28T00:00:00Z",
+              updatedAt: "2026-05-28T00:00:00Z",
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(null, { status: 204 });
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+
+    await expect(client.listWebhooks(42)).resolves.toMatchObject([{ id: 9 }]);
+    await expect(
+      client.createWebhook(42, {
+        name: "Hyperlocalise sync",
+        url: "https://app.example.test/api/webhooks/tms/crowdin",
+        events: ["file.updated"],
+        requestType: "POST",
+        contentType: "application/json",
+        isActive: true,
+      }),
+    ).resolves.toMatchObject({ id: 10 });
+    await expect(
+      client.updateWebhook(42, 10, [
+        { op: "replace", path: "/events", value: ["file.updated", "task.statusChanged"] },
+      ]),
+    ).resolves.toMatchObject({
+      id: 10,
+      events: ["file.updated", "task.statusChanged"],
+    });
+    await expect(client.deleteWebhook(42, 10)).resolves.toBeUndefined();
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://api.crowdin.test/api/v2/projects/42/webhooks?limit=500&offset=0",
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://api.crowdin.test/api/v2/projects/42/webhooks",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      "https://api.crowdin.test/api/v2/projects/42/webhooks/10",
+      expect.objectContaining({ method: "PATCH" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      4,
+      "https://api.crowdin.test/api/v2/projects/42/webhooks/10",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+
   it("lists directories for a project", async () => {
     const fetchMock = vi.fn(async () => {
       return new Response(

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-api.ts
@@ -243,6 +243,67 @@ export interface CrowdinTranslationMemorySegment {
   records: CrowdinTranslationMemorySegmentRecord[];
 }
 
+export type CrowdinWebhookEvent =
+  | "file.added"
+  | "file.updated"
+  | "file.reverted"
+  | "file.deleted"
+  | "file.translated"
+  | "file.approved"
+  | "project.translated"
+  | "project.approved"
+  | "project.built"
+  | "translation.updated"
+  | "string.added"
+  | "string.updated"
+  | "string.deleted"
+  | "stringComment.created"
+  | "stringComment.updated"
+  | "stringComment.deleted"
+  | "stringComment.restored"
+  | "suggestion.added"
+  | "suggestion.updated"
+  | "suggestion.deleted"
+  | "suggestion.approved"
+  | "suggestion.disapproved"
+  | "task.added"
+  | "task.statusChanged"
+  | "task.deleted";
+
+export interface CrowdinWebhook {
+  id: number;
+  projectId: number;
+  name: string;
+  url: string;
+  events: CrowdinWebhookEvent[];
+  headers: Record<string, string>;
+  payload: Record<string, unknown>;
+  isActive: boolean;
+  requestType: "POST" | "GET";
+  contentType: string;
+  batchingEnabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CrowdinWebhookRequest {
+  name: string;
+  url: string;
+  events: CrowdinWebhookEvent[];
+  requestType: "POST";
+  contentType?: "application/json";
+  headers?: Record<string, string>;
+  payload?: Record<string, unknown>;
+  isActive?: boolean;
+  batchingEnabled?: boolean;
+}
+
+export type CrowdinPatchOperation = {
+  op: "replace" | "add" | "remove";
+  path: string;
+  value?: unknown;
+};
+
 export interface CrowdinTmConcordanceSearchRequest {
   sourceLanguageId: string;
   targetLanguageId: string;
@@ -973,6 +1034,34 @@ export class CrowdinApiClient {
     return this.listPaginated<CrowdinTranslationMemorySegment>(`/tms/${tmId}/segments`, options);
   }
 
+  async listWebhooks(projectId: number): Promise<CrowdinWebhook[]> {
+    return this.listPaginated<CrowdinWebhook>(`/projects/${projectId}/webhooks`);
+  }
+
+  async createWebhook(projectId: number, input: CrowdinWebhookRequest): Promise<CrowdinWebhook> {
+    const response = await this.post<CrowdinGetResponse<CrowdinWebhook>>(
+      `/projects/${projectId}/webhooks`,
+      input,
+    );
+    return response.data;
+  }
+
+  async updateWebhook(
+    projectId: number,
+    webhookId: number,
+    operations: CrowdinPatchOperation[],
+  ): Promise<CrowdinWebhook> {
+    const response = await this.patch<CrowdinGetResponse<CrowdinWebhook>>(
+      `/projects/${projectId}/webhooks/${webhookId}`,
+      operations,
+    );
+    return response.data;
+  }
+
+  async deleteWebhook(projectId: number, webhookId: number): Promise<void> {
+    await this.delete(`/projects/${projectId}/webhooks/${webhookId}`);
+  }
+
   private async listPaginated<T>(
     path: string,
     options?: { shouldStop?: (items: T[]) => boolean },
@@ -1021,6 +1110,21 @@ export class CrowdinApiClient {
     });
   }
 
+  private async patch<T>(path: string, body: unknown): Promise<T> {
+    return this.request<T>(path, {
+      method: "PATCH",
+      headers: this.authHeaders(),
+      body: JSON.stringify(body),
+    });
+  }
+
+  private async delete(path: string): Promise<void> {
+    await this.request<void>(path, {
+      method: "DELETE",
+      headers: this.authHeaders(),
+    });
+  }
+
   private async request<T>(path: string, init: RequestInit): Promise<T> {
     const url = `${this.baseUrl}${path}`;
     const response = await this.fetchFn(url, init);
@@ -1038,6 +1142,10 @@ export class CrowdinApiClient {
         response.status,
         body,
       );
+    }
+
+    if (response.status === 204) {
+      return undefined as T;
     }
 
     return response.json() as Promise<T>;

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-webhook-subscription-adapter.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-webhook-subscription-adapter.ts
@@ -95,8 +95,19 @@ function buildReplaceOperations(
   ];
 }
 
-function mapCrowdinError(error: unknown): ProviderWebhookSubscriptionAdapterError {
+function mapCrowdinError(
+  error: unknown,
+  options?: { providerWebhookId?: string },
+): ProviderWebhookSubscriptionAdapterError {
   if (error instanceof ProviderWebhookSubscriptionAdapterError) {
+    if (options?.providerWebhookId && !error.providerWebhookId) {
+      return new ProviderWebhookSubscriptionAdapterError(error.code, error.message, {
+        httpStatus: error.httpStatus,
+        cause: error.cause,
+        providerWebhookId: options.providerWebhookId,
+      });
+    }
+
     return error;
   }
 
@@ -106,14 +117,18 @@ function mapCrowdinError(error: unknown): ProviderWebhookSubscriptionAdapterErro
     return new ProviderWebhookSubscriptionAdapterError(
       code,
       `Crowdin webhook API returned HTTP ${error.status}`,
-      { httpStatus: error.status, cause: error },
+      {
+        httpStatus: error.status,
+        cause: error,
+        providerWebhookId: options?.providerWebhookId,
+      },
     );
   }
 
   return new ProviderWebhookSubscriptionAdapterError(
     "provider_error",
     error instanceof Error ? error.message : "Crowdin webhook setup failed",
-    { cause: error },
+    { cause: error, providerWebhookId: options?.providerWebhookId },
   );
 }
 
@@ -133,11 +148,18 @@ export function createCrowdinWebhookSubscriptionAdapter(): ProviderWebhookSubscr
     },
 
     async createRemoteSubscription(context) {
+      const projectId = parseCrowdinProjectId(context.externalProjectId);
+      const client = createCrowdinClient(context);
+
+      let created: CrowdinWebhook;
       try {
-        const projectId = parseCrowdinProjectId(context.externalProjectId);
-        const client = createCrowdinClient(context);
-        const created = await client.createWebhook(projectId, buildCreateRequest(context));
-        const providerWebhookId = String(created.id);
+        created = await client.createWebhook(projectId, buildCreateRequest(context));
+      } catch (error) {
+        throw mapCrowdinError(error);
+      }
+
+      const providerWebhookId = String(created.id);
+      try {
         const updated = await client.updateWebhook(projectId, created.id, [
           {
             op: "replace",
@@ -150,7 +172,7 @@ export function createCrowdinWebhookSubscriptionAdapter(): ProviderWebhookSubscr
         ]);
         return mapCrowdinWebhook(updated);
       } catch (error) {
-        throw mapCrowdinError(error);
+        throw mapCrowdinError(error, { providerWebhookId });
       }
     },
 

--- a/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-webhook-subscription-adapter.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/crowdin/crowdin-webhook-subscription-adapter.ts
@@ -1,0 +1,212 @@
+import {
+  CrowdinApiClient,
+  CrowdinApiError,
+  type CrowdinPatchOperation,
+  type CrowdinWebhook,
+  type CrowdinWebhookEvent,
+} from "./crowdin-api";
+import {
+  ProviderWebhookSubscriptionAdapterError,
+  type ProviderWebhookRemoteSubscription,
+  type ProviderWebhookSubscriptionAdapter,
+  type ProviderWebhookSubscriptionAdapterContext,
+} from "../provider-webhook-subscription-types";
+
+const crowdinWebhookName = "Hyperlocalise sync";
+const webhookIdHeaderName = "X-Hyperlocalise-Provider-Webhook-Id";
+const webhookSecretHeaderName = "X-Hyperlocalise-Webhook-Secret";
+
+function parseCrowdinProjectId(externalProjectId: string | null) {
+  if (!externalProjectId) {
+    throw new ProviderWebhookSubscriptionAdapterError(
+      "invalid_configuration",
+      "Crowdin project id is required for webhook setup",
+    );
+  }
+
+  const projectId = Number(externalProjectId);
+  if (!Number.isInteger(projectId) || projectId <= 0) {
+    throw new ProviderWebhookSubscriptionAdapterError(
+      "invalid_configuration",
+      "Crowdin project id must be numeric for webhook setup",
+    );
+  }
+
+  return projectId;
+}
+
+function createCrowdinClient(context: ProviderWebhookSubscriptionAdapterContext) {
+  return new CrowdinApiClient({
+    token: context.secretMaterial,
+    baseUrl: context.baseUrl ?? undefined,
+    fetchFn: context.fetchFn,
+  });
+}
+
+function mapCrowdinWebhook(webhook: CrowdinWebhook): ProviderWebhookRemoteSubscription {
+  return {
+    providerWebhookId: String(webhook.id),
+    endpointUrl: webhook.url,
+    subscribedEvents: webhook.events,
+    isActive: webhook.isActive,
+    secret: webhook.headers?.[webhookSecretHeaderName] ?? null,
+  };
+}
+
+function buildHeaders(input: { webhookSecret: string; providerWebhookId?: string }) {
+  return {
+    [webhookSecretHeaderName]: input.webhookSecret,
+    ...(input.providerWebhookId ? { [webhookIdHeaderName]: input.providerWebhookId } : {}),
+  };
+}
+
+function buildCreateRequest(context: ProviderWebhookSubscriptionAdapterContext) {
+  return {
+    name: crowdinWebhookName,
+    url: context.endpointUrl,
+    events: context.subscribedEvents as CrowdinWebhookEvent[],
+    requestType: "POST" as const,
+    contentType: "application/json" as const,
+    isActive: true,
+    batchingEnabled: false,
+    headers: buildHeaders({ webhookSecret: context.webhookSecret }),
+  };
+}
+
+function buildReplaceOperations(
+  context: ProviderWebhookSubscriptionAdapterContext & { providerWebhookId: string },
+): CrowdinPatchOperation[] {
+  return [
+    { op: "replace", path: "/name", value: crowdinWebhookName },
+    { op: "replace", path: "/url", value: context.endpointUrl },
+    { op: "replace", path: "/events", value: context.subscribedEvents },
+    { op: "replace", path: "/requestType", value: "POST" },
+    { op: "replace", path: "/contentType", value: "application/json" },
+    { op: "replace", path: "/isActive", value: true },
+    { op: "replace", path: "/batchingEnabled", value: false },
+    {
+      op: "replace",
+      path: "/headers",
+      value: buildHeaders({
+        webhookSecret: context.webhookSecret,
+        providerWebhookId: context.providerWebhookId,
+      }),
+    },
+  ];
+}
+
+function mapCrowdinError(error: unknown): ProviderWebhookSubscriptionAdapterError {
+  if (error instanceof ProviderWebhookSubscriptionAdapterError) {
+    return error;
+  }
+
+  if (error instanceof CrowdinApiError) {
+    const code =
+      error.status === 401 || error.status === 403 ? "permission_denied" : "provider_error";
+    return new ProviderWebhookSubscriptionAdapterError(
+      code,
+      `Crowdin webhook API returned HTTP ${error.status}`,
+      { httpStatus: error.status, cause: error },
+    );
+  }
+
+  return new ProviderWebhookSubscriptionAdapterError(
+    "provider_error",
+    error instanceof Error ? error.message : "Crowdin webhook setup failed",
+    { cause: error },
+  );
+}
+
+export function createCrowdinWebhookSubscriptionAdapter(): ProviderWebhookSubscriptionAdapter {
+  return {
+    supportsAutomaticSetup: true,
+
+    async listRemoteSubscriptions(context) {
+      try {
+        const projectId = parseCrowdinProjectId(context.externalProjectId);
+        const client = createCrowdinClient(context);
+        const webhooks = await client.listWebhooks(projectId);
+        return webhooks.map(mapCrowdinWebhook);
+      } catch (error) {
+        throw mapCrowdinError(error);
+      }
+    },
+
+    async createRemoteSubscription(context) {
+      try {
+        const projectId = parseCrowdinProjectId(context.externalProjectId);
+        const client = createCrowdinClient(context);
+        const created = await client.createWebhook(projectId, buildCreateRequest(context));
+        const providerWebhookId = String(created.id);
+        const updated = await client.updateWebhook(projectId, created.id, [
+          {
+            op: "replace",
+            path: "/headers",
+            value: buildHeaders({
+              webhookSecret: context.webhookSecret,
+              providerWebhookId,
+            }),
+          },
+        ]);
+        return mapCrowdinWebhook(updated);
+      } catch (error) {
+        throw mapCrowdinError(error);
+      }
+    },
+
+    async updateRemoteSubscription(context) {
+      try {
+        const projectId = parseCrowdinProjectId(context.externalProjectId);
+        const webhookId = Number(context.providerWebhookId);
+        if (!Number.isInteger(webhookId) || webhookId <= 0) {
+          throw new ProviderWebhookSubscriptionAdapterError(
+            "invalid_configuration",
+            "Crowdin webhook id must be numeric",
+          );
+        }
+
+        const client = createCrowdinClient(context);
+        const updated = await client.updateWebhook(
+          projectId,
+          webhookId,
+          buildReplaceOperations(context),
+        );
+        return mapCrowdinWebhook(updated);
+      } catch (error) {
+        throw mapCrowdinError(error);
+      }
+    },
+
+    async disableRemoteSubscription(context) {
+      try {
+        const projectId = parseCrowdinProjectId(context.externalProjectId);
+        const webhookId = Number(context.providerWebhookId);
+        if (!Number.isInteger(webhookId) || webhookId <= 0) {
+          return;
+        }
+
+        const client = createCrowdinClient(context);
+        await client.updateWebhook(projectId, webhookId, [
+          { op: "replace", path: "/isActive", value: false },
+        ]);
+      } catch (error) {
+        throw mapCrowdinError(error);
+      }
+    },
+
+    async deleteRemoteSubscription(context) {
+      try {
+        const projectId = parseCrowdinProjectId(context.externalProjectId);
+        const webhookId = Number(context.providerWebhookId);
+        if (!Number.isInteger(webhookId) || webhookId <= 0) {
+          return;
+        }
+
+        const client = createCrowdinClient(context);
+        await client.deleteWebhook(projectId, webhookId);
+      } catch (error) {
+        throw mapCrowdinError(error);
+      }
+    },
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/providers/provider-webhook-default-events.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-webhook-default-events.ts
@@ -1,10 +1,36 @@
 import type { ExternalTmsProviderKind } from "./organization-external-tms-provider-credentials";
 
-/**
- * Returns the default event list stored on new subscriptions. HL-402 does not
- * define provider event semantics, so this stays empty until the provider event
- * mapping contract and concrete provider setup tickets choose event names.
- */
-export function listDefaultWebhookEvents(_providerKind: ExternalTmsProviderKind) {
+/** Returns the default provider event list stored on new subscriptions. */
+export function listDefaultWebhookEvents(providerKind: ExternalTmsProviderKind) {
+  if (providerKind === "crowdin") {
+    return [
+      "file.added",
+      "file.updated",
+      "file.reverted",
+      "file.deleted",
+      "file.translated",
+      "file.approved",
+      "project.translated",
+      "project.approved",
+      "project.built",
+      "translation.updated",
+      "string.added",
+      "string.updated",
+      "string.deleted",
+      "stringComment.created",
+      "stringComment.updated",
+      "stringComment.deleted",
+      "stringComment.restored",
+      "suggestion.added",
+      "suggestion.updated",
+      "suggestion.deleted",
+      "suggestion.approved",
+      "suggestion.disapproved",
+      "task.added",
+      "task.statusChanged",
+      "task.deleted",
+    ];
+  }
+
   return [];
 }

--- a/apps/hyperlocalise-web/src/lib/providers/provider-webhook-subscription-adapters.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-webhook-subscription-adapters.ts
@@ -1,16 +1,21 @@
 import type { ExternalTmsProviderKind } from "./organization-external-tms-provider-credentials";
+import { createCrowdinWebhookSubscriptionAdapter } from "./crowdin/crowdin-webhook-subscription-adapter";
 import { createManualProviderWebhookSubscriptionAdapter } from "./manual-provider-webhook-subscription-adapter";
 import type { ProviderWebhookSubscriptionAdapter } from "./provider-webhook-subscription-types";
 
+const crowdinAdapter = createCrowdinWebhookSubscriptionAdapter();
 const manualAdapter = createManualProviderWebhookSubscriptionAdapter();
 
 /**
- * Returns the subscription adapter for a provider. HL-402 keeps all providers on
- * the manual adapter; HL-404 and later provider tickets should register concrete
- * adapters here.
+ * Returns the subscription adapter for a provider. Providers without automatic
+ * setup stay on the manual adapter until their concrete setup ticket lands.
  */
 export function getProviderWebhookSubscriptionAdapter(
-  _providerKind: ExternalTmsProviderKind,
+  providerKind: ExternalTmsProviderKind,
 ): ProviderWebhookSubscriptionAdapter {
+  if (providerKind === "crowdin") {
+    return crowdinAdapter;
+  }
+
   return manualAdapter;
 }

--- a/apps/hyperlocalise-web/src/lib/providers/provider-webhook-subscription-manager.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-webhook-subscription-manager.test.ts
@@ -3,7 +3,7 @@ import "dotenv/config";
 import { randomUUID } from "node:crypto";
 
 import { inArray } from "drizzle-orm";
-import { afterEach, beforeAll, describe, expect, it } from "vite-plus/test";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
 
 import { db, schema } from "@/lib/database";
 
@@ -97,6 +97,98 @@ describe("provider webhook subscription manager", () => {
     return { organizationId, credential, projectId };
   }
 
+  function createCrowdinWebhookFetch(input: { status?: number } = {}) {
+    return vi.fn(async (_url, init) => {
+      if (input.status) {
+        return new Response(JSON.stringify({ error: "provider failure" }), {
+          status: input.status,
+        });
+      }
+
+      const method = init?.method ?? "GET";
+      const body =
+        typeof init?.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : {};
+
+      if (method === "POST") {
+        return new Response(
+          JSON.stringify({
+            data: {
+              id: 77,
+              projectId: 12345,
+              name: body.name,
+              url: body.url,
+              events: body.events,
+              headers: body.headers ?? {},
+              payload: {},
+              isActive: true,
+              requestType: "POST",
+              contentType: "application/json",
+              batchingEnabled: false,
+              createdAt: "2026-05-28T00:00:00Z",
+              updatedAt: "2026-05-28T00:00:00Z",
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (method === "PATCH") {
+        const operations = Array.isArray(body) ? body : [];
+        const headers = operations.find((operation) => operation.path === "/headers")?.value as
+          | Record<string, string>
+          | undefined;
+        return new Response(
+          JSON.stringify({
+            data: {
+              id: 77,
+              projectId: 12345,
+              name: "Hyperlocalise sync",
+              url: "https://app.example.test/api/webhooks/tms/crowdin",
+              events: [
+                "file.added",
+                "file.updated",
+                "file.reverted",
+                "file.deleted",
+                "file.translated",
+                "file.approved",
+                "project.translated",
+                "project.approved",
+                "project.built",
+                "translation.updated",
+                "string.added",
+                "string.updated",
+                "string.deleted",
+                "stringComment.created",
+                "stringComment.updated",
+                "stringComment.deleted",
+                "stringComment.restored",
+                "suggestion.added",
+                "suggestion.updated",
+                "suggestion.deleted",
+                "suggestion.approved",
+                "suggestion.disapproved",
+                "task.added",
+                "task.statusChanged",
+                "task.deleted",
+              ],
+              headers: headers ?? {},
+              payload: {},
+              isActive: true,
+              requestType: "POST",
+              contentType: "application/json",
+              batchingEnabled: false,
+              createdAt: "2026-05-28T00:00:00Z",
+              updatedAt: "2026-05-28T00:00:00Z",
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+  }
+
   beforeAll(async () => {
     await db.$client.query("select 1");
   });
@@ -144,8 +236,9 @@ describe("provider webhook subscription manager", () => {
     createdRecordsByTest.delete(testKey);
   });
 
-  it("creates a manual-required subscription until provider adapters are implemented", async () => {
+  it("creates an automatic Crowdin webhook subscription", async () => {
     const { organizationId, credential, projectId } = await createCrowdinCredential();
+    const fetchMock = createCrowdinWebhookFetch();
 
     const result = await ensureProviderWebhookSubscription({
       organizationId,
@@ -153,17 +246,22 @@ describe("provider webhook subscription manager", () => {
       providerCredentialId: credential.id,
       projectId,
       externalProjectId: "12345",
+      fetchFn: fetchMock,
     });
 
-    expect(result.status).toBe("manual_required");
-    expect(result.subscription.providerWebhookId).toMatch(/^pending-/);
-    expect(result.subscription.manualFallback?.webhookUrl).toContain("/api/webhooks/tms/crowdin");
-    expect(result.subscription.manualFallback?.subscribedEvents).toEqual([]);
-    expect(result.subscription.canRetry).toBe(true);
+    expect(result.status).toBe("active");
+    expect(result.subscription.providerWebhookId).toBe("77");
+    expect(result.subscription.manualFallback).toBeNull();
+    expect(result.subscription.endpointUrl).toBe(
+      "https://app.example.test/api/webhooks/tms/crowdin",
+    );
+    expect(result.subscription.subscribedEvents).toContain("file.updated");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
-  it("reuses an existing manual subscription for the same credential and project", async () => {
+  it("reuses an existing active subscription for the same credential and project", async () => {
     const { organizationId, credential, projectId } = await createCrowdinCredential();
+    const fetchMock = createCrowdinWebhookFetch();
 
     const first = await ensureProviderWebhookSubscription({
       organizationId,
@@ -171,6 +269,7 @@ describe("provider webhook subscription manager", () => {
       providerCredentialId: credential.id,
       projectId,
       externalProjectId: "12345",
+      fetchFn: fetchMock,
     });
 
     const second = await ensureProviderWebhookSubscription({
@@ -181,7 +280,7 @@ describe("provider webhook subscription manager", () => {
       externalProjectId: "12345",
     });
 
-    expect(second.status).toBe("manual_required");
+    expect(second.status).toBe("active");
     expect(second.subscription.id).toBe(first.subscription.id);
     expect(second.subscription.providerWebhookId).toBe(first.subscription.providerWebhookId);
   });
@@ -208,6 +307,7 @@ describe("provider webhook subscription manager", () => {
       organizationId,
       providerKind: "crowdin",
       providerCredentialId: credential.id,
+      fetchFn: createCrowdinWebhookFetch(),
     });
 
     expect(results).toHaveLength(1);
@@ -238,17 +338,19 @@ describe("provider webhook subscription manager", () => {
       providerCredentialId: credential.id,
       projectId,
       externalProjectId: "12345",
+      fetchFn: createCrowdinWebhookFetch(),
     });
 
     const disabled = await disableProviderWebhookSubscription({
       organizationId,
       subscriptionId: created.subscription.id,
+      fetchFn: createCrowdinWebhookFetch(),
     });
 
     expect(disabled.status).toBe("disabled");
   });
 
-  it("retries by refreshing the manual fallback subscription", async () => {
+  it("marks Crowdin permission failures without blocking manual sync", async () => {
     const { organizationId, credential, projectId } = await createCrowdinCredential();
 
     const first = await ensureProviderWebhookSubscription({
@@ -257,17 +359,20 @@ describe("provider webhook subscription manager", () => {
       providerCredentialId: credential.id,
       projectId,
       externalProjectId: "12345",
+      fetchFn: createCrowdinWebhookFetch({ status: 403 }),
     });
-    expect(first.status).toBe("manual_required");
+    expect(first.status).toBe("permission_error");
+    expect(first.subscription.manualFallback?.webhookUrl).toContain("/api/webhooks/tms/crowdin");
 
     const retried = await retryProviderWebhookSubscriptionSetup({
       organizationId,
       providerKind: "crowdin",
       providerCredentialId: credential.id,
       projectId,
+      fetchFn: createCrowdinWebhookFetch(),
     });
 
-    expect(retried.status).toBe("manual_required");
+    expect(retried.status).toBe("active");
     expect(retried.subscription.id).toBe(first.subscription.id);
   });
 

--- a/apps/hyperlocalise-web/src/lib/providers/provider-webhook-subscription-manager.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-webhook-subscription-manager.test.ts
@@ -97,7 +97,7 @@ describe("provider webhook subscription manager", () => {
     return { organizationId, credential, projectId };
   }
 
-  function createCrowdinWebhookFetch(input: { status?: number } = {}) {
+  function createCrowdinWebhookFetch(input: { status?: number; patchFails?: boolean } = {}) {
     return vi.fn(async (_url, init) => {
       if (input.status) {
         return new Response(JSON.stringify({ error: "provider failure" }), {
@@ -133,6 +133,12 @@ describe("provider webhook subscription manager", () => {
       }
 
       if (method === "PATCH") {
+        if (input.patchFails) {
+          return new Response(JSON.stringify({ error: "provider failure" }), {
+            status: 500,
+          });
+        }
+
         const operations = Array.isArray(body) ? body : [];
         const headers = operations.find((operation) => operation.path === "/headers")?.value as
           | Record<string, string>
@@ -234,6 +240,43 @@ describe("provider webhook subscription manager", () => {
     }
 
     createdRecordsByTest.delete(testKey);
+  });
+
+  it("resumes Crowdin webhook setup after header activation fails", async () => {
+    const { organizationId, credential, projectId } = await createCrowdinCredential();
+    const failingFetch = createCrowdinWebhookFetch({ patchFails: true });
+
+    const failed = await ensureProviderWebhookSubscription({
+      organizationId,
+      providerKind: "crowdin",
+      providerCredentialId: credential.id,
+      projectId,
+      externalProjectId: "12345",
+      fetchFn: failingFetch,
+    });
+
+    expect(failed.status).toBe("provider_error");
+    expect(failed.subscription.providerWebhookId).toBe("77");
+
+    const resumeFetch = createCrowdinWebhookFetch();
+    const resumed = await ensureProviderWebhookSubscription({
+      organizationId,
+      providerKind: "crowdin",
+      providerCredentialId: credential.id,
+      projectId,
+      externalProjectId: "12345",
+      fetchFn: resumeFetch,
+    });
+
+    expect(resumed.status).toBe("active");
+    expect(resumed.subscription.providerWebhookId).toBe("77");
+    expect(resumed.subscription.id).toBe(failed.subscription.id);
+    expect(failingFetch).toHaveBeenCalledTimes(2);
+    expect(resumeFetch).toHaveBeenCalledTimes(1);
+    expect(resumeFetch).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ method: "PATCH" }),
+    );
   });
 
   it("creates an automatic Crowdin webhook subscription", async () => {

--- a/apps/hyperlocalise-web/src/lib/providers/provider-webhook-subscription-manager.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-webhook-subscription-manager.ts
@@ -320,8 +320,11 @@ export async function ensureProviderWebhookSubscription(input: {
       fetchFn: input.fetchFn,
     };
 
+    const hasAllocatedRemoteWebhookId =
+      Boolean(existing?.providerWebhookId) && !existing!.providerWebhookId.startsWith("pending-");
+
     const remote =
-      existing && existing.status === "active"
+      existing && (existing.status === "active" || hasAllocatedRemoteWebhookId)
         ? await adapter.updateRemoteSubscription({
             ...adapterContext,
             providerWebhookId: existing.providerWebhookId,
@@ -357,6 +360,11 @@ export async function ensureProviderWebhookSubscription(input: {
           ? "manual_required"
           : "provider_error";
 
+    const partialProviderWebhookId =
+      error instanceof ProviderWebhookSubscriptionAdapterError
+        ? error.providerWebhookId
+        : undefined;
+
     const manualFallback = buildManualFallback({
       providerKind: input.providerKind,
       endpointUrl,
@@ -368,6 +376,7 @@ export async function ensureProviderWebhookSubscription(input: {
       subscriptionId: subscription.id,
       organizationId: input.organizationId,
       status,
+      ...(partialProviderWebhookId ? { providerWebhookId: partialProviderWebhookId } : {}),
       manualFallback,
       lastError: message,
       subscribedEvents,

--- a/apps/hyperlocalise-web/src/lib/providers/provider-webhook-subscription-types.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-webhook-subscription-types.ts
@@ -64,16 +64,19 @@ export type ProviderWebhookSubscriptionAdapterErrorCode =
 export class ProviderWebhookSubscriptionAdapterError extends Error {
   readonly code: ProviderWebhookSubscriptionAdapterErrorCode;
   readonly httpStatus?: number;
+  /** Set when a remote webhook was created but final activation failed. */
+  readonly providerWebhookId?: string;
 
   constructor(
     code: ProviderWebhookSubscriptionAdapterErrorCode,
     message: string,
-    options?: { httpStatus?: number; cause?: unknown },
+    options?: { httpStatus?: number; cause?: unknown; providerWebhookId?: string },
   ) {
     super(message, { cause: options?.cause });
     this.name = "ProviderWebhookSubscriptionAdapterError";
     this.code = code;
     this.httpStatus = options?.httpStatus;
+    this.providerWebhookId = options?.providerWebhookId;
   }
 }
 

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-webhook-adapters.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-webhook-adapters.test.ts
@@ -218,7 +218,7 @@ describe("tms provider webhook adapters", () => {
     expect(descriptor?.mappedIntents).toEqual([]);
   });
 
-  it("verifies body signatures without accepting echoed secrets", async () => {
+  it("verifies Crowdin configured secret headers and body signatures", async () => {
     const payload = { event_id: "evt-signature", event: "file.updated" };
     const body = JSON.stringify(payload);
     const adapter = tmsProviderWebhookAdapters.crowdin;
@@ -243,6 +243,28 @@ describe("tms provider webhook adapters", () => {
       Promise.resolve(
         adapter.verify({
           providerKind: "crowdin",
+          headers: new Headers({ "x-hyperlocalise-webhook-secret": "webhook-signing-secret" }),
+          rawBody: body,
+          payload,
+          webhookSecret: "webhook-signing-secret",
+          descriptor: descriptor!,
+        }),
+      ),
+    ).resolves.toBe(true);
+  });
+
+  it("default verification rejects echoed secrets without body signatures", async () => {
+    const payload = { event_uid: "evt-signature", event: "jobs:completed" };
+    const body = JSON.stringify(payload);
+    const adapter = tmsProviderWebhookAdapters.phrase;
+    const descriptor = extract({ providerKind: "phrase", payload });
+
+    expect(descriptor).not.toBeNull();
+
+    await expect(
+      Promise.resolve(
+        adapter.verify({
+          providerKind: "phrase",
           headers: new Headers({ "x-hyperlocalise-webhook-secret": "webhook-signing-secret" }),
           rawBody: body,
           payload,

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-webhook-adapters.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-webhook-adapters.test.ts
@@ -251,6 +251,19 @@ describe("tms provider webhook adapters", () => {
         }),
       ),
     ).resolves.toBe(true);
+
+    await expect(
+      Promise.resolve(
+        adapter.verify({
+          providerKind: "crowdin",
+          headers: new Headers({ "x-hyperlocalise-webhook-secret": "wrong-secret" }),
+          rawBody: body,
+          payload,
+          webhookSecret: "webhook-signing-secret",
+          descriptor: descriptor!,
+        }),
+      ),
+    ).resolves.toBe(false);
   });
 
   it("default verification rejects echoed secrets without body signatures", async () => {

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-webhook-adapters.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-webhook-adapters.ts
@@ -197,6 +197,7 @@ export type ProviderWebhookAdapterConfig = {
   resourceTypePaths?: readonly (readonly string[])[];
   resourceIdPaths?: readonly (readonly string[])[];
   externalResourceIdPaths?: readonly (readonly string[])[];
+  verify?: TmsProviderWebhookAdapter["verify"];
   mapEvent: (input: {
     eventType: string;
     resourceType: string | null;
@@ -261,7 +262,7 @@ export function createProviderWebhookAdapter(
 
       return { resourceType, resourceId, externalResourceId };
     },
-    verify: defaultVerify,
+    verify: config.verify ?? defaultVerify,
     redact({ descriptor }) {
       return baseRedactedPayload(descriptor);
     },
@@ -414,8 +415,8 @@ export const crowdinWebhookAdapter = createProviderWebhookAdapter({
   resourceIdPaths: [["resource_id"], ["file", "id"], ["string", "id"], ["task", "id"]],
   externalResourceIdPaths: [["external_resource_id"], ["project", "id"]],
   mapEvent: genericTmsEventMapping,
+  verify: verifyCrowdinWebhook,
 });
-crowdinWebhookAdapter.verify = verifyCrowdinWebhook;
 
 export const phraseWebhookAdapter = createProviderWebhookAdapter({
   eventTypePaths: [["event"], ["event_type"], ["type"]],

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-webhook-adapters.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-webhook-adapters.ts
@@ -111,6 +111,17 @@ function readSignature(headers: Headers) {
   return signature.startsWith("sha256=") ? signature.slice("sha256=".length) : signature;
 }
 
+function constantTimeEqual(left: string, right: string) {
+  const leftBuffer = Buffer.from(left);
+  const rightBuffer = Buffer.from(right);
+
+  if (leftBuffer.length !== rightBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(leftBuffer, rightBuffer);
+}
+
 function verifyHmacSha256(input: { rawBody: string; webhookSecret: string; signature: string }) {
   const expected = createHmac("sha256", input.webhookSecret).update(input.rawBody).digest("hex");
 
@@ -153,7 +164,11 @@ function verifyCrowdinWebhook(input: TmsProviderWebhookVerificationInput) {
   }
 
   const echoedSecret = input.headers.get("x-hyperlocalise-webhook-secret");
-  return echoedSecret === input.webhookSecret;
+  if (!echoedSecret) {
+    return false;
+  }
+
+  return constantTimeEqual(echoedSecret, input.webhookSecret);
 }
 
 function dedupeIntents(intents: TmsWebhookMappedIntent[]) {

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-webhook-adapters.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-webhook-adapters.ts
@@ -138,6 +138,24 @@ function defaultVerify({ headers, rawBody, webhookSecret }: TmsProviderWebhookVe
   return verifyHmacSha256({ rawBody, webhookSecret, signature });
 }
 
+function verifyCrowdinWebhook(input: TmsProviderWebhookVerificationInput) {
+  if (!input.webhookSecret) {
+    return true;
+  }
+
+  const signature = readSignature(input.headers);
+  if (signature) {
+    return verifyHmacSha256({
+      rawBody: input.rawBody,
+      webhookSecret: input.webhookSecret,
+      signature,
+    });
+  }
+
+  const echoedSecret = input.headers.get("x-hyperlocalise-webhook-secret");
+  return echoedSecret === input.webhookSecret;
+}
+
 function dedupeIntents(intents: TmsWebhookMappedIntent[]) {
   const seen = new Set<string>();
   const deduped: TmsWebhookMappedIntent[] = [];
@@ -397,6 +415,7 @@ export const crowdinWebhookAdapter = createProviderWebhookAdapter({
   externalResourceIdPaths: [["external_resource_id"], ["project", "id"]],
   mapEvent: genericTmsEventMapping,
 });
+crowdinWebhookAdapter.verify = verifyCrowdinWebhook;
 
 export const phraseWebhookAdapter = createProviderWebhookAdapter({
   eventTypePaths: [["event"], ["event_type"], ["type"]],


### PR DESCRIPTION
## What changed

Adds Crowdin support to the provider webhook pipeline introduced in HL-402/HL-403:

- **Crowdin API client** — webhook CRUD (`listWebhooks`, `createWebhook`, `updateWebhook`, `deleteWebhook`) plus PATCH/DELETE helpers and typed webhook/event models.
- **Webhook subscription adapter** — automatic Crowdin webhook provisioning per connected project, including `X-Hyperlocalise-Webhook-Secret` and `X-Hyperlocalise-Provider-Webhook-Id` headers for inbound verification and subscription lookup.
- **Default event list** — subscribes Crowdin projects to file, string, translation, suggestion, task, and project lifecycle events used for reconciliation.
- **Inbound verification** — Crowdin webhooks accept either HMAC body signatures or the configured secret echoed via `X-Hyperlocalise-Webhook-Secret` (Crowdin does not sign payloads natively).
- **Reconciliation mapping** — wires Crowdin into the existing generic TMS webhook adapter for event extraction and sync-intent mapping.

## How to test

- [ ] `cd apps/hyperlocalise-web && vp test src/lib/providers/crowdin/crowdin-api.test.ts`
- [ ] `cd apps/hyperlocalise-web && vp test src/lib/providers/provider-webhook-subscription-manager.test.ts`
- [ ] `cd apps/hyperlocalise-web && vp test src/lib/providers/tms-provider-webhook-adapters.test.ts`
- [ ] `cd apps/hyperlocalise-web && vp test src/api/routes/tms-webhook/tms-webhook.route.test.ts`
- [ ] `cd apps/hyperlocalise-web && vp check`
- [ ] Connect a Crowdin project with webhook auto-setup enabled and confirm a webhook is created in Crowdin pointing at `/api/webhooks/tms/crowdin`
- [ ] Trigger a Crowdin file/string event and confirm the webhook is accepted (202), stored, and queued for reconciliation

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review