### PR TITLE
feat(web): add scheduled TMS reconciliation cron (HL-401)

### DIFF
--- a/apps/hyperlocalise-web/src/api/app.ts
+++ b/apps/hyperlocalise-web/src/api/app.ts
@@ -49,6 +49,7 @@ import { createTeamRoutes } from "./routes/team/team.route";
 import { createWorkspaceRoutes } from "./routes/workspace/workspace.route";
 import { workosWebhookRoutes } from "./routes/workos-webhook/workos-webhook.route";
 import { createAutumnRoutes } from "./routes/autumn/autumn.route";
+import { createTmsScheduledReconciliationRoutes } from "./routes/cron/tms-scheduled-reconciliation.route";
 import {
   createTranslationJobEventQueue,
   createProviderAgentCommentQueue,
@@ -87,7 +88,7 @@ export function createApp(options: CreateAppOptions = {}) {
     .basePath("/api")
     .onError(handleUnexpectedError)
     .notFound(notFoundHandler)
-    .route("/", createInternalRoutes())
+    .route("/", createInternalRoutes(options))
     .route("/auth", createAuthRoutes())
     .route("/autumn", createAutumnRoutes())
     .route(
@@ -109,8 +110,16 @@ export const app = createApp();
 
 export type AppType = typeof app;
 
-function createInternalRoutes() {
-  return new Hono().route("/", createMcpRoutes()).route("/health", healthRoutes);
+function createInternalRoutes(options: CreateAppOptions = {}) {
+  return new Hono()
+    .route("/", createMcpRoutes())
+    .route("/health", healthRoutes)
+    .route(
+      "/cron/tms-scheduled-reconciliation",
+      createTmsScheduledReconciliationRoutes({
+        providerWebhookReconciliationQueue: options.providerWebhookReconciliationQueue,
+      }),
+    );
 }
 
 function createAuthRoutes() {

--- a/apps/hyperlocalise-web/src/api/routes/cron/tms-scheduled-reconciliation.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/cron/tms-scheduled-reconciliation.route.test.ts
@@ -57,7 +57,7 @@ describe("tms scheduled reconciliation cron route", () => {
   it("rejects requests without the cron secret", async () => {
     const client = await createClient();
 
-    const response = await client.index.$post();
+    const response = await client.index.$get();
 
     expect(response.status).toBe(401);
     await expect(response.json()).resolves.toEqual({ error: "unauthorized" });
@@ -66,7 +66,7 @@ describe("tms scheduled reconciliation cron route", () => {
   it("runs scheduled reconciliation when authorized", async () => {
     const client = await createClient();
 
-    const response = await client.index.$post(
+    const response = await client.index.$get(
       {},
       {
         headers: {
@@ -96,7 +96,7 @@ describe("tms scheduled reconciliation cron route", () => {
   it("returns disabled when scheduled reconciliation is turned off", async () => {
     const client = await createClient({ enabled: false });
 
-    const response = await client.index.$post(
+    const response = await client.index.$get(
       {},
       {
         headers: {

--- a/apps/hyperlocalise-web/src/api/routes/cron/tms-scheduled-reconciliation.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/cron/tms-scheduled-reconciliation.route.test.ts
@@ -1,0 +1,113 @@
+import { testClient } from "hono/testing";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+const runScheduledReconciliationMock = vi.fn(async () => [
+  {
+    schedule: "incremental",
+    intentsEnqueued: 1,
+    intentsCoalesced: 0,
+    intentsSkipped: 0,
+    credentialsSkipped: 0,
+    projectsSkipped: 0,
+    auditsCompleted: 0,
+    healthChecksCompleted: 0,
+  },
+]);
+
+async function createClient(input?: { enabled?: boolean; cronSecret?: string | null }) {
+  vi.resetModules();
+  vi.doMock("@/workflows/adapters", () => ({
+    createProviderWebhookReconciliationQueue: () => ({
+      enqueue: vi.fn(async () => ({ ids: ["workflow-1"] })),
+    }),
+  }));
+  vi.doMock("@/lib/providers/provider-scheduled-reconciliation", () => ({
+    runScheduledReconciliation: runScheduledReconciliationMock,
+  }));
+  vi.doMock("@/lib/env", () => ({
+    env: {
+      TMS_SCHEDULED_RECONCILIATION_ENABLED: input?.enabled ?? true,
+      TMS_SCHEDULED_RECONCILIATION_CRON_SECRET:
+        input?.cronSecret === null ? undefined : (input?.cronSecret ?? "cron-secret"),
+      TMS_SCHEDULED_RECONCILIATION_INCREMENTAL_INTERVAL_MINUTES: 15,
+      TMS_SCHEDULED_RECONCILIATION_TM_GLOSSARY_INTERVAL_MINUTES: 60,
+      TMS_SCHEDULED_RECONCILIATION_FULL_INTERVAL_MINUTES: 24 * 60,
+      TMS_SCHEDULED_RECONCILIATION_AUDIT_INTERVAL_MINUTES: 24 * 60,
+      TMS_SCHEDULED_RECONCILIATION_FULL_HOUR_UTC: 3,
+      TMS_SCHEDULED_RECONCILIATION_AUDIT_HOUR_UTC: 4,
+      TMS_SCHEDULED_RECONCILIATION_MAX_INTENTS_PER_TICK: 500,
+    },
+  }));
+
+  const { createTmsScheduledReconciliationRoutes } =
+    await import("./tms-scheduled-reconciliation.route");
+
+  return testClient(createTmsScheduledReconciliationRoutes());
+}
+
+describe("tms scheduled reconciliation cron route", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock("@/workflows/adapters");
+    vi.doUnmock("@/lib/providers/provider-scheduled-reconciliation");
+    vi.doUnmock("@/lib/env");
+    runScheduledReconciliationMock.mockClear();
+  });
+
+  it("rejects requests without the cron secret", async () => {
+    const client = await createClient();
+
+    const response = await client.index.$post();
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: "unauthorized" });
+  });
+
+  it("runs scheduled reconciliation when authorized", async () => {
+    const client = await createClient();
+
+    const response = await client.index.$post(
+      {},
+      {
+        headers: {
+          authorization: "Bearer cron-secret",
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      results: [
+        {
+          schedule: "incremental",
+          intentsEnqueued: 1,
+          intentsCoalesced: 0,
+          intentsSkipped: 0,
+          credentialsSkipped: 0,
+          projectsSkipped: 0,
+          auditsCompleted: 0,
+          healthChecksCompleted: 0,
+        },
+      ],
+    });
+    expect(runScheduledReconciliationMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns disabled when scheduled reconciliation is turned off", async () => {
+    const client = await createClient({ enabled: false });
+
+    const response = await client.index.$post(
+      {},
+      {
+        headers: {
+          authorization: "Bearer cron-secret",
+        },
+      },
+    );
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      error: "scheduled_reconciliation_disabled",
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/api/routes/cron/tms-scheduled-reconciliation.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/cron/tms-scheduled-reconciliation.route.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { timingSafeEqual } from "node:crypto";
+import { createHmac, timingSafeEqual } from "node:crypto";
 
 import { env } from "@/lib/env";
 import type { ScheduledReconciliationSchedule } from "@/lib/providers/provider-scheduled-reconciliation-config";
@@ -29,15 +29,12 @@ function readCronSecret(request: Request) {
   return request.headers.get("x-cron-secret")?.trim() ?? null;
 }
 
+const HMAC_KEY = Buffer.alloc(32);
+
 function secretsMatch(provided: string, expected: string) {
-  const providedBuffer = Buffer.from(provided);
-  const expectedBuffer = Buffer.from(expected);
-
-  if (providedBuffer.length !== expectedBuffer.length) {
-    return false;
-  }
-
-  return timingSafeEqual(providedBuffer, expectedBuffer);
+  const providedHmac = createHmac("sha256", HMAC_KEY).update(provided).digest();
+  const expectedHmac = createHmac("sha256", HMAC_KEY).update(expected).digest();
+  return timingSafeEqual(providedHmac, expectedHmac);
 }
 
 type CreateTmsScheduledReconciliationRoutesOptions = {
@@ -87,5 +84,3 @@ export function createTmsScheduledReconciliationRoutes(
     return c.json({ results }, 200);
   });
 }
-
-export const tmsScheduledReconciliationRoutes = createTmsScheduledReconciliationRoutes();

--- a/apps/hyperlocalise-web/src/api/routes/cron/tms-scheduled-reconciliation.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/cron/tms-scheduled-reconciliation.route.ts
@@ -47,7 +47,7 @@ export function createTmsScheduledReconciliationRoutes(
   const queue =
     options.providerWebhookReconciliationQueue ?? createProviderWebhookReconciliationQueue();
 
-  return new Hono().post("/", async (c) => {
+  return new Hono().get("/", async (c) => {
     if (!env.TMS_SCHEDULED_RECONCILIATION_ENABLED) {
       return c.json({ error: "scheduled_reconciliation_disabled" }, 503);
     }

--- a/apps/hyperlocalise-web/src/api/routes/cron/tms-scheduled-reconciliation.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/cron/tms-scheduled-reconciliation.route.ts
@@ -1,0 +1,91 @@
+import { Hono } from "hono";
+import { timingSafeEqual } from "node:crypto";
+
+import { env } from "@/lib/env";
+import type { ScheduledReconciliationSchedule } from "@/lib/providers/provider-scheduled-reconciliation-config";
+import { runScheduledReconciliation } from "@/lib/providers/provider-scheduled-reconciliation";
+import type { ProviderWebhookReconciliationQueue } from "@/lib/workflow/types";
+import { createProviderWebhookReconciliationQueue } from "@/workflows/adapters";
+
+const scheduleValues = new Set<ScheduledReconciliationSchedule>([
+  "incremental",
+  "resource_import",
+  "full",
+  "audit",
+]);
+
+function isScheduledReconciliationSchedule(
+  value: string,
+): value is ScheduledReconciliationSchedule {
+  return scheduleValues.has(value as ScheduledReconciliationSchedule);
+}
+
+function readCronSecret(request: Request) {
+  const authorization = request.headers.get("authorization");
+  if (authorization?.startsWith("Bearer ")) {
+    return authorization.slice("Bearer ".length).trim();
+  }
+
+  return request.headers.get("x-cron-secret")?.trim() ?? null;
+}
+
+function secretsMatch(provided: string, expected: string) {
+  const providedBuffer = Buffer.from(provided);
+  const expectedBuffer = Buffer.from(expected);
+
+  if (providedBuffer.length !== expectedBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(providedBuffer, expectedBuffer);
+}
+
+type CreateTmsScheduledReconciliationRoutesOptions = {
+  providerWebhookReconciliationQueue?: ProviderWebhookReconciliationQueue;
+};
+
+export function createTmsScheduledReconciliationRoutes(
+  options: CreateTmsScheduledReconciliationRoutesOptions = {},
+) {
+  const queue =
+    options.providerWebhookReconciliationQueue ?? createProviderWebhookReconciliationQueue();
+
+  return new Hono().post("/", async (c) => {
+    if (!env.TMS_SCHEDULED_RECONCILIATION_ENABLED) {
+      return c.json({ error: "scheduled_reconciliation_disabled" }, 503);
+    }
+
+    const cronSecret = env.TMS_SCHEDULED_RECONCILIATION_CRON_SECRET;
+    if (!cronSecret) {
+      return c.json({ error: "scheduled_reconciliation_misconfigured" }, 503);
+    }
+
+    const providedSecret = readCronSecret(c.req.raw);
+    if (!providedSecret || !secretsMatch(providedSecret, cronSecret)) {
+      return c.json({ error: "unauthorized" }, 401);
+    }
+
+    const scheduleParam = c.req.query("schedule");
+    const forceSchedule =
+      scheduleParam && isScheduledReconciliationSchedule(scheduleParam) ? scheduleParam : undefined;
+
+    const results = await runScheduledReconciliation({
+      queue,
+      forceSchedule,
+      config: {
+        enabled: env.TMS_SCHEDULED_RECONCILIATION_ENABLED,
+        incrementalIntervalMinutes: env.TMS_SCHEDULED_RECONCILIATION_INCREMENTAL_INTERVAL_MINUTES,
+        tmGlossaryIntervalMinutes: env.TMS_SCHEDULED_RECONCILIATION_TM_GLOSSARY_INTERVAL_MINUTES,
+        fullIntervalMinutes: env.TMS_SCHEDULED_RECONCILIATION_FULL_INTERVAL_MINUTES,
+        auditIntervalMinutes: env.TMS_SCHEDULED_RECONCILIATION_AUDIT_INTERVAL_MINUTES,
+        fullReconciliationHourUtc: env.TMS_SCHEDULED_RECONCILIATION_FULL_HOUR_UTC,
+        auditHourUtc: env.TMS_SCHEDULED_RECONCILIATION_AUDIT_HOUR_UTC,
+        maxIntentsPerTick: env.TMS_SCHEDULED_RECONCILIATION_MAX_INTENTS_PER_TICK,
+      },
+    });
+
+    return c.json({ results }, 200);
+  });
+}
+
+export const tmsScheduledReconciliationRoutes = createTmsScheduledReconciliationRoutes();

--- a/apps/hyperlocalise-web/src/lib/env.ts
+++ b/apps/hyperlocalise-web/src/lib/env.ts
@@ -111,6 +111,56 @@ export const env = createEnv({
      * When set, hosted deployments attempt automatic provider webhook registration.
      */
     HYPERLOCALISE_PUBLIC_APP_URL: z.url().optional(),
+
+    /** Enables scheduled TMS reconciliation cron ticks. */
+    TMS_SCHEDULED_RECONCILIATION_ENABLED: z
+      .enum(["true", "false"])
+      .default("false")
+      .transform((value) => value === "true"),
+
+    /** Shared secret for scheduled TMS reconciliation cron requests. */
+    TMS_SCHEDULED_RECONCILIATION_CRON_SECRET: z.string().min(1).optional(),
+
+    /** Interval for lightweight file/job scans in minutes. */
+    TMS_SCHEDULED_RECONCILIATION_INCREMENTAL_INTERVAL_MINUTES: z.coerce
+      .number()
+      .int()
+      .positive()
+      .default(15),
+
+    /** Interval for TM/glossary import scans in minutes. */
+    TMS_SCHEDULED_RECONCILIATION_TM_GLOSSARY_INTERVAL_MINUTES: z.coerce
+      .number()
+      .int()
+      .positive()
+      .default(60),
+
+    /** Interval for full reconciliation in minutes. */
+    TMS_SCHEDULED_RECONCILIATION_FULL_INTERVAL_MINUTES: z.coerce
+      .number()
+      .int()
+      .positive()
+      .default(24 * 60),
+
+    /** Interval for provider health and webhook audits in minutes. */
+    TMS_SCHEDULED_RECONCILIATION_AUDIT_INTERVAL_MINUTES: z.coerce
+      .number()
+      .int()
+      .positive()
+      .default(24 * 60),
+
+    /** UTC hour for nightly full reconciliation. */
+    TMS_SCHEDULED_RECONCILIATION_FULL_HOUR_UTC: z.coerce.number().int().min(0).max(23).default(3),
+
+    /** UTC hour for daily provider health and webhook audits. */
+    TMS_SCHEDULED_RECONCILIATION_AUDIT_HOUR_UTC: z.coerce.number().int().min(0).max(23).default(4),
+
+    /** Maximum sync intents enqueued per cron tick. */
+    TMS_SCHEDULED_RECONCILIATION_MAX_INTENTS_PER_TICK: z.coerce
+      .number()
+      .int()
+      .positive()
+      .default(500),
   },
   client: {
     /** Public URL for the waitlist/sign-up page. Required for client-side redirects. */
@@ -181,6 +231,24 @@ export const env = createEnv({
       process.env.HYPERLOCALISE_PUBLIC_APP_URL ??
       (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : undefined) ??
       (isTestEnv ? "https://app.example.test" : undefined),
+    TMS_SCHEDULED_RECONCILIATION_ENABLED: process.env.TMS_SCHEDULED_RECONCILIATION_ENABLED,
+    TMS_SCHEDULED_RECONCILIATION_CRON_SECRET:
+      process.env.TMS_SCHEDULED_RECONCILIATION_CRON_SECRET ??
+      (isTestEnv ? "test-tms-scheduled-reconciliation-secret" : undefined),
+    TMS_SCHEDULED_RECONCILIATION_INCREMENTAL_INTERVAL_MINUTES:
+      process.env.TMS_SCHEDULED_RECONCILIATION_INCREMENTAL_INTERVAL_MINUTES,
+    TMS_SCHEDULED_RECONCILIATION_TM_GLOSSARY_INTERVAL_MINUTES:
+      process.env.TMS_SCHEDULED_RECONCILIATION_TM_GLOSSARY_INTERVAL_MINUTES,
+    TMS_SCHEDULED_RECONCILIATION_FULL_INTERVAL_MINUTES:
+      process.env.TMS_SCHEDULED_RECONCILIATION_FULL_INTERVAL_MINUTES,
+    TMS_SCHEDULED_RECONCILIATION_AUDIT_INTERVAL_MINUTES:
+      process.env.TMS_SCHEDULED_RECONCILIATION_AUDIT_INTERVAL_MINUTES,
+    TMS_SCHEDULED_RECONCILIATION_FULL_HOUR_UTC:
+      process.env.TMS_SCHEDULED_RECONCILIATION_FULL_HOUR_UTC,
+    TMS_SCHEDULED_RECONCILIATION_AUDIT_HOUR_UTC:
+      process.env.TMS_SCHEDULED_RECONCILIATION_AUDIT_HOUR_UTC,
+    TMS_SCHEDULED_RECONCILIATION_MAX_INTENTS_PER_TICK:
+      process.env.TMS_SCHEDULED_RECONCILIATION_MAX_INTENTS_PER_TICK,
     NEXT_PUBLIC_WAITLIST_URL:
       process.env.NEXT_PUBLIC_WAITLIST_URL ??
       (isTestEnv ? "https://example.com/waitlist" : undefined),

--- a/apps/hyperlocalise-web/src/lib/providers/external-tms-health-check.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/external-tms-health-check.ts
@@ -34,6 +34,7 @@ type ExternalTmsCredential = typeof schema.organizationExternalTmsProviderCreden
 export async function checkExternalTmsProviderHealth(input: {
   organizationId: string;
   providerKind: ExternalTmsProviderKind;
+  credentialId?: string;
   fetchFn?: typeof fetch;
 }): Promise<{
   credential: ExternalTmsCredential | null;
@@ -43,10 +44,22 @@ export async function checkExternalTmsProviderHealth(input: {
     .select()
     .from(schema.organizationExternalTmsProviderCredentials)
     .where(
-      and(
-        eq(schema.organizationExternalTmsProviderCredentials.organizationId, input.organizationId),
-        eq(schema.organizationExternalTmsProviderCredentials.providerKind, input.providerKind),
-      ),
+      input.credentialId
+        ? and(
+            eq(schema.organizationExternalTmsProviderCredentials.id, input.credentialId),
+            eq(
+              schema.organizationExternalTmsProviderCredentials.organizationId,
+              input.organizationId,
+            ),
+            eq(schema.organizationExternalTmsProviderCredentials.providerKind, input.providerKind),
+          )
+        : and(
+            eq(
+              schema.organizationExternalTmsProviderCredentials.organizationId,
+              input.organizationId,
+            ),
+            eq(schema.organizationExternalTmsProviderCredentials.providerKind, input.providerKind),
+          ),
     )
     .limit(1);
 

--- a/apps/hyperlocalise-web/src/lib/providers/provider-scheduled-reconciliation-config.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-scheduled-reconciliation-config.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  DEFAULT_SCHEDULED_RECONCILIATION_CONFIG,
+  resolveDueSchedules,
+} from "./provider-scheduled-reconciliation-config";
+
+describe("resolveDueSchedules", () => {
+  const config = DEFAULT_SCHEDULED_RECONCILIATION_CONFIG;
+
+  it("returns incremental scans every 15 minutes", () => {
+    const schedules = resolveDueSchedules({
+      now: new Date("2026-05-28T10:15:00.000Z"),
+      config,
+    });
+
+    expect(schedules).toEqual(["incremental"]);
+  });
+
+  it("includes resource import scans on hourly boundaries", () => {
+    const schedules = resolveDueSchedules({
+      now: new Date("2026-05-28T11:00:00.000Z"),
+      config,
+    });
+
+    expect(schedules).toEqual(["incremental", "resource_import"]);
+  });
+
+  it("includes full reconciliation at the configured nightly hour", () => {
+    const schedules = resolveDueSchedules({
+      now: new Date("2026-05-28T03:00:00.000Z"),
+      config,
+    });
+
+    expect(schedules).toEqual(["incremental", "resource_import", "full"]);
+  });
+
+  it("includes daily audits at the configured audit hour", () => {
+    const schedules = resolveDueSchedules({
+      now: new Date("2026-05-28T04:00:00.000Z"),
+      config,
+    });
+
+    expect(schedules).toEqual(["incremental", "resource_import", "audit"]);
+  });
+
+  it("honors forced schedule overrides", () => {
+    const schedules = resolveDueSchedules({
+      now: new Date("2026-05-28T10:07:00.000Z"),
+      config,
+      forceSchedule: "full",
+    });
+
+    expect(schedules).toEqual(["full"]);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/provider-scheduled-reconciliation-config.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-scheduled-reconciliation-config.ts
@@ -1,0 +1,77 @@
+export type ScheduledReconciliationSchedule = "incremental" | "resource_import" | "full" | "audit";
+
+export type ScheduledReconciliationConfig = {
+  enabled: boolean;
+  incrementalIntervalMinutes: number;
+  tmGlossaryIntervalMinutes: number;
+  fullIntervalMinutes: number;
+  auditIntervalMinutes: number;
+  fullReconciliationHourUtc: number;
+  auditHourUtc: number;
+  maxIntentsPerTick: number;
+};
+
+export const DEFAULT_SCHEDULED_RECONCILIATION_CONFIG: ScheduledReconciliationConfig = {
+  enabled: false,
+  incrementalIntervalMinutes: 15,
+  tmGlossaryIntervalMinutes: 60,
+  fullIntervalMinutes: 24 * 60,
+  auditIntervalMinutes: 24 * 60,
+  fullReconciliationHourUtc: 3,
+  auditHourUtc: 4,
+  maxIntentsPerTick: 500,
+};
+
+export function resolveDueSchedules(input: {
+  now: Date;
+  config: Pick<
+    ScheduledReconciliationConfig,
+    | "incrementalIntervalMinutes"
+    | "tmGlossaryIntervalMinutes"
+    | "fullIntervalMinutes"
+    | "auditIntervalMinutes"
+    | "fullReconciliationHourUtc"
+    | "auditHourUtc"
+  >;
+  forceSchedule?: ScheduledReconciliationSchedule;
+}): ScheduledReconciliationSchedule[] {
+  if (input.forceSchedule) {
+    return [input.forceSchedule];
+  }
+
+  const minuteOfDay = input.now.getUTCHours() * 60 + input.now.getUTCMinutes();
+  const schedules: ScheduledReconciliationSchedule[] = [];
+
+  if (minuteOfDay % input.config.incrementalIntervalMinutes === 0) {
+    schedules.push("incremental");
+  }
+
+  if (minuteOfDay % input.config.tmGlossaryIntervalMinutes === 0) {
+    schedules.push("resource_import");
+  }
+
+  if (isDailyScheduleInterval(input.config.fullIntervalMinutes)) {
+    if (
+      input.now.getUTCHours() === input.config.fullReconciliationHourUtc &&
+      input.now.getUTCMinutes() === 0
+    ) {
+      schedules.push("full");
+    }
+  } else if (minuteOfDay % input.config.fullIntervalMinutes === 0) {
+    schedules.push("full");
+  }
+
+  if (isDailyScheduleInterval(input.config.auditIntervalMinutes)) {
+    if (input.now.getUTCHours() === input.config.auditHourUtc && input.now.getUTCMinutes() === 0) {
+      schedules.push("audit");
+    }
+  } else if (minuteOfDay % input.config.auditIntervalMinutes === 0) {
+    schedules.push("audit");
+  }
+
+  return schedules;
+}
+
+function isDailyScheduleInterval(intervalMinutes: number) {
+  return intervalMinutes >= 24 * 60;
+}

--- a/apps/hyperlocalise-web/src/lib/providers/provider-scheduled-reconciliation.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-scheduled-reconciliation.test.ts
@@ -1,0 +1,219 @@
+import "dotenv/config";
+
+import { eq } from "drizzle-orm";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
+
+import { db, schema } from "@/lib/database";
+
+import { createProjectTestFixture } from "../../api/routes/project/project.fixture";
+import { upsertOrganizationExternalTmsProviderCredential } from "./organization-external-tms-provider-credentials";
+import {
+  listScheduledReconciliationProjects,
+  runScheduledReconciliation,
+  shouldIncludeCredentialForScheduledReconciliation,
+  syncKindsForSchedule,
+} from "./provider-scheduled-reconciliation";
+import { DEFAULT_SCHEDULED_RECONCILIATION_CONFIG } from "./provider-scheduled-reconciliation-config";
+import type { ProviderWebhookReconciliationEventData } from "@/lib/workflow/types";
+
+const projectFixture = createProjectTestFixture();
+
+beforeAll(async () => {
+  await db.$client.query("select 1");
+});
+
+afterEach(async () => {
+  await projectFixture.cleanup();
+  vi.restoreAllMocks();
+});
+
+async function createExternalTmsProject(input?: { validationStatus?: string; isActive?: boolean }) {
+  const { organization, user, project } = await projectFixture.createStoredProjectFixture();
+  const credential = await upsertOrganizationExternalTmsProviderCredential({
+    organizationId: organization.id,
+    userId: user.id,
+    role: "owner",
+    providerKind: "phrase",
+    displayName: "Phrase",
+    secretMaterial: "secret-token",
+    baseUrl: "https://api.example.test",
+  });
+
+  await db
+    .update(schema.organizationExternalTmsProviderCredentials)
+    .set({
+      validationStatus: input?.validationStatus ?? "connected",
+    })
+    .where(eq(schema.organizationExternalTmsProviderCredentials.id, credential.id));
+
+  const [externalProject] = await db
+    .update(schema.projects)
+    .set({
+      source: "external_tms",
+      externalProviderCredentialId: credential.id,
+      externalProviderKind: "phrase",
+      externalProjectId: "phrase-project-1",
+      isActive: input?.isActive ?? true,
+    })
+    .where(eq(schema.projects.id, project.id))
+    .returning();
+
+  return { organization, credential, project: externalProject };
+}
+
+describe("provider scheduled reconciliation", () => {
+  it("filters eligible credentials and projects", () => {
+    expect(shouldIncludeCredentialForScheduledReconciliation("connected")).toBe(true);
+    expect(shouldIncludeCredentialForScheduledReconciliation("degraded")).toBe(true);
+    expect(shouldIncludeCredentialForScheduledReconciliation("error")).toBe(false);
+    expect(shouldIncludeCredentialForScheduledReconciliation("unvalidated")).toBe(false);
+  });
+
+  it("maps schedules to distinct sync kinds", () => {
+    expect(syncKindsForSchedule("incremental")).toEqual(["file_key_scan", "job_task_scan"]);
+    expect(syncKindsForSchedule("resource_import")).toEqual(["tm_scan", "glossary_scan"]);
+    expect(syncKindsForSchedule("full")).toEqual([
+      "project_scan",
+      "file_key_scan",
+      "job_task_scan",
+      "tm_scan",
+      "glossary_scan",
+    ]);
+    expect(syncKindsForSchedule("audit")).toEqual([]);
+  });
+
+  it("lists only active external TMS projects with connected credentials", async () => {
+    const included = await createExternalTmsProject({ validationStatus: "connected" });
+    await createExternalTmsProject({ validationStatus: "error" });
+    await createExternalTmsProject({ validationStatus: "connected", isActive: false });
+
+    const projects = await listScheduledReconciliationProjects();
+
+    expect(projects).toContainEqual({
+      id: included.project.id,
+      organizationId: included.organization.id,
+      providerKind: "phrase",
+      providerCredentialId: included.credential.id,
+    });
+    expect(
+      projects.some(
+        (project) =>
+          project.organizationId === included.organization.id &&
+          project.id !== included.project.id,
+      ),
+    ).toBe(false);
+  });
+
+  it("enqueues scheduled sync intents and starts reconciliation workflows", async () => {
+    const { organization, credential, project } = await createExternalTmsProject();
+    const enqueue = vi.fn(async (_event: ProviderWebhookReconciliationEventData) => ({
+      ids: ["workflow-1"],
+    }));
+
+    const results = await runScheduledReconciliation({
+      forceSchedule: "incremental",
+      config: {
+        ...DEFAULT_SCHEDULED_RECONCILIATION_CONFIG,
+        maxIntentsPerTick: 10,
+      },
+      queue: { enqueue },
+      listCredentials: async () => [
+        {
+          id: credential.id,
+          organizationId: organization.id,
+          providerKind: "phrase",
+          validationStatus: "connected",
+        },
+      ],
+      listProjects: async () => [
+        {
+          id: project.id,
+          organizationId: organization.id,
+          providerKind: "phrase",
+          providerCredentialId: credential.id,
+        },
+      ],
+    });
+
+    expect(results).toEqual([
+      {
+        schedule: "incremental",
+        intentsEnqueued: 2,
+        intentsCoalesced: 0,
+        intentsSkipped: 0,
+        credentialsSkipped: 0,
+        projectsSkipped: 0,
+        auditsCompleted: 0,
+        healthChecksCompleted: 0,
+      },
+    ]);
+
+    const intents = await db
+      .select()
+      .from(schema.providerSyncIntents)
+      .where(eq(schema.providerSyncIntents.organizationId, organization.id));
+
+    expect(intents).toHaveLength(2);
+    expect(new Set(intents.map((intent) => intent.syncKind))).toEqual(
+      new Set(["file_key_scan", "job_task_scan"]),
+    );
+    expect(intents.every((intent) => intent.cause === "scheduled")).toBe(true);
+    expect(intents.every((intent) => intent.projectId === project.id)).toBe(true);
+    expect(intents.every((intent) => intent.providerCredentialId === credential.id)).toBe(true);
+
+    expect(enqueue).toHaveBeenCalledTimes(2);
+    const firstQueuedEvent = enqueue.mock.calls.at(0)?.[0];
+    expect(firstQueuedEvent).toMatchObject({
+      organizationId: organization.id,
+      providerKind: "phrase",
+      providerWebhookEventId: "",
+      subscriptionId: "",
+    });
+  });
+
+  it("enqueues credential-level project scans during full reconciliation", async () => {
+    const { organization, credential, project } = await createExternalTmsProject();
+    const enqueue = vi.fn(async (_event: ProviderWebhookReconciliationEventData) => ({
+      ids: ["workflow-1"],
+    }));
+
+    await runScheduledReconciliation({
+      forceSchedule: "full",
+      config: {
+        ...DEFAULT_SCHEDULED_RECONCILIATION_CONFIG,
+        maxIntentsPerTick: 20,
+      },
+      queue: { enqueue },
+      listCredentials: async () => [
+        {
+          id: credential.id,
+          organizationId: organization.id,
+          providerKind: "phrase",
+          validationStatus: "connected",
+        },
+      ],
+      listProjects: async () => [
+        {
+          id: project.id,
+          organizationId: organization.id,
+          providerKind: "phrase",
+          providerCredentialId: credential.id,
+        },
+      ],
+    });
+
+    const intents = await db
+      .select()
+      .from(schema.providerSyncIntents)
+      .where(eq(schema.providerSyncIntents.organizationId, organization.id));
+
+    const projectScan = intents.find((intent) => intent.syncKind === "project_scan");
+    expect(projectScan).toMatchObject({
+      organizationId: organization.id,
+      providerCredentialId: credential.id,
+      projectId: null,
+      cause: "scheduled",
+    });
+    expect(intents.some((intent) => intent.syncKind === "tm_scan")).toBe(true);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/provider-scheduled-reconciliation.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-scheduled-reconciliation.test.ts
@@ -98,8 +98,7 @@ describe("provider scheduled reconciliation", () => {
     expect(
       projects.some(
         (project) =>
-          project.organizationId === included.organization.id &&
-          project.id !== included.project.id,
+          project.organizationId === included.organization.id && project.id !== included.project.id,
       ),
     ).toBe(false);
   });

--- a/apps/hyperlocalise-web/src/lib/providers/provider-scheduled-reconciliation.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-scheduled-reconciliation.test.ts
@@ -216,4 +216,57 @@ describe("provider scheduled reconciliation", () => {
     });
     expect(intents.some((intent) => intent.syncKind === "tm_scan")).toBe(true);
   });
+
+  it("counts projects skipped when the intent budget is exhausted", async () => {
+    const { organization, credential, project } = await createExternalTmsProject();
+    const secondProject = await createExternalTmsProject();
+    const enqueue = vi.fn(async (_event: ProviderWebhookReconciliationEventData) => ({
+      ids: ["workflow-1"],
+    }));
+
+    const results = await runScheduledReconciliation({
+      forceSchedule: "incremental",
+      config: {
+        ...DEFAULT_SCHEDULED_RECONCILIATION_CONFIG,
+        maxIntentsPerTick: 1,
+      },
+      queue: { enqueue },
+      listCredentials: async () => [
+        {
+          id: credential.id,
+          organizationId: organization.id,
+          providerKind: "phrase",
+          validationStatus: "connected",
+        },
+      ],
+      listProjects: async () => [
+        {
+          id: project.id,
+          organizationId: organization.id,
+          providerKind: "phrase",
+          providerCredentialId: credential.id,
+        },
+        {
+          id: secondProject.project.id,
+          organizationId: secondProject.organization.id,
+          providerKind: "phrase",
+          providerCredentialId: secondProject.credential.id,
+        },
+      ],
+    });
+
+    expect(results).toEqual([
+      {
+        schedule: "incremental",
+        intentsEnqueued: 1,
+        intentsCoalesced: 0,
+        intentsSkipped: 1,
+        credentialsSkipped: 0,
+        projectsSkipped: 1,
+        auditsCompleted: 0,
+        healthChecksCompleted: 0,
+      },
+    ]);
+    expect(enqueue).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/provider-scheduled-reconciliation.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-scheduled-reconciliation.ts
@@ -1,0 +1,357 @@
+import { and, eq, inArray, isNotNull } from "drizzle-orm";
+
+import { db, schema } from "@/lib/database";
+import { createLogger } from "@/lib/log";
+import type { ProviderWebhookReconciliationQueue } from "@/lib/workflow/types";
+
+import {
+  checkExternalTmsProviderHealth,
+  persistExternalTmsProviderHealth,
+} from "./external-tms-health-check";
+import type { ExternalTmsProviderKind } from "./organization-external-tms-provider-credentials";
+import type { ProviderSyncIntentKind } from "./provider-sync-intent-kinds";
+import { enqueueProviderSyncIntent } from "./provider-sync-intents";
+import {
+  DEFAULT_SCHEDULED_RECONCILIATION_CONFIG,
+  resolveDueSchedules,
+  type ScheduledReconciliationConfig,
+  type ScheduledReconciliationSchedule,
+} from "./provider-scheduled-reconciliation-config";
+import { auditProviderWebhookSubscriptions } from "./provider-webhook-subscription-manager";
+
+const logger = createLogger("tms-scheduled-reconciliation");
+
+const ELIGIBLE_CREDENTIAL_STATUSES = ["connected", "degraded"] as const;
+
+export type ScheduledReconciliationCredential = {
+  id: string;
+  organizationId: string;
+  providerKind: ExternalTmsProviderKind;
+  validationStatus: string;
+};
+
+export type ScheduledReconciliationProject = {
+  id: string;
+  organizationId: string;
+  providerKind: ExternalTmsProviderKind;
+  providerCredentialId: string;
+};
+
+export type ScheduledReconciliationEnqueueResult = {
+  schedule: ScheduledReconciliationSchedule;
+  intentsEnqueued: number;
+  intentsCoalesced: number;
+  intentsSkipped: number;
+  credentialsSkipped: number;
+  projectsSkipped: number;
+  auditsCompleted: number;
+  healthChecksCompleted: number;
+};
+
+export type RunScheduledReconciliationInput = {
+  now?: Date;
+  config?: ScheduledReconciliationConfig;
+  forceSchedule?: ScheduledReconciliationSchedule;
+  queue: ProviderWebhookReconciliationQueue;
+  listCredentials?: () => Promise<ScheduledReconciliationCredential[]>;
+  listProjects?: () => Promise<ScheduledReconciliationProject[]>;
+};
+
+export function shouldIncludeCredentialForScheduledReconciliation(
+  validationStatus: string,
+): validationStatus is (typeof ELIGIBLE_CREDENTIAL_STATUSES)[number] {
+  return (ELIGIBLE_CREDENTIAL_STATUSES as readonly string[]).includes(validationStatus);
+}
+
+export function syncKindsForSchedule(
+  schedule: ScheduledReconciliationSchedule,
+): ProviderSyncIntentKind[] {
+  switch (schedule) {
+    case "incremental":
+      return ["file_key_scan", "job_task_scan"];
+    case "resource_import":
+      return ["tm_scan", "glossary_scan"];
+    case "full":
+      return ["project_scan", "file_key_scan", "job_task_scan", "tm_scan", "glossary_scan"];
+    case "audit":
+      return [];
+  }
+}
+
+export async function listScheduledReconciliationCredentials(): Promise<
+  ScheduledReconciliationCredential[]
+> {
+  const credentials = await db
+    .select({
+      id: schema.organizationExternalTmsProviderCredentials.id,
+      organizationId: schema.organizationExternalTmsProviderCredentials.organizationId,
+      providerKind: schema.organizationExternalTmsProviderCredentials.providerKind,
+      validationStatus: schema.organizationExternalTmsProviderCredentials.validationStatus,
+    })
+    .from(schema.organizationExternalTmsProviderCredentials);
+
+  return credentials.map((credential) => ({
+    id: credential.id,
+    organizationId: credential.organizationId,
+    providerKind: credential.providerKind as ExternalTmsProviderKind,
+    validationStatus: credential.validationStatus,
+  }));
+}
+
+export async function listScheduledReconciliationProjects(): Promise<
+  ScheduledReconciliationProject[]
+> {
+  const projects = await db
+    .select({
+      id: schema.projects.id,
+      organizationId: schema.projects.organizationId,
+      providerKind: schema.projects.externalProviderKind,
+      providerCredentialId: schema.projects.externalProviderCredentialId,
+      validationStatus: schema.organizationExternalTmsProviderCredentials.validationStatus,
+    })
+    .from(schema.projects)
+    .innerJoin(
+      schema.organizationExternalTmsProviderCredentials,
+      eq(
+        schema.projects.externalProviderCredentialId,
+        schema.organizationExternalTmsProviderCredentials.id,
+      ),
+    )
+    .where(
+      and(
+        eq(schema.projects.source, "external_tms"),
+        eq(schema.projects.isActive, true),
+        isNotNull(schema.projects.externalProviderCredentialId),
+        isNotNull(schema.projects.externalProviderKind),
+        inArray(schema.organizationExternalTmsProviderCredentials.validationStatus, [
+          ...ELIGIBLE_CREDENTIAL_STATUSES,
+        ]),
+      ),
+    );
+
+  return projects.flatMap((project) => {
+    if (!project.providerCredentialId || !project.providerKind) {
+      return [];
+    }
+
+    return [
+      {
+        id: project.id,
+        organizationId: project.organizationId,
+        providerKind: project.providerKind as ExternalTmsProviderKind,
+        providerCredentialId: project.providerCredentialId,
+      },
+    ];
+  });
+}
+
+async function enqueueScheduledSyncIntent(input: {
+  organizationId: string;
+  providerKind: ExternalTmsProviderKind;
+  providerCredentialId: string;
+  projectId?: string | null;
+  syncKind: ProviderSyncIntentKind;
+  queue: ProviderWebhookReconciliationQueue;
+}) {
+  const { intent, coalesced } = await enqueueProviderSyncIntent({
+    organizationId: input.organizationId,
+    providerKind: input.providerKind,
+    providerCredentialId: input.providerCredentialId,
+    projectId: input.projectId,
+    syncKind: input.syncKind,
+    cause: "scheduled",
+    eventReferences: [],
+  });
+
+  await input.queue.enqueue({
+    providerWebhookEventId: "",
+    providerSyncIntentId: intent.id,
+    organizationId: input.organizationId,
+    subscriptionId: "",
+    providerKind: input.providerKind,
+  });
+
+  return { coalesced };
+}
+
+async function runAuditSchedule(credentials: ScheduledReconciliationCredential[]) {
+  let auditsCompleted = 0;
+  let healthChecksCompleted = 0;
+
+  for (const credential of credentials) {
+    if (!shouldIncludeCredentialForScheduledReconciliation(credential.validationStatus)) {
+      continue;
+    }
+
+    try {
+      const { credential: credentialRow, health } = await checkExternalTmsProviderHealth({
+        organizationId: credential.organizationId,
+        providerKind: credential.providerKind,
+      });
+
+      if (credentialRow && health) {
+        await persistExternalTmsProviderHealth({
+          credentialId: credentialRow.id,
+          health,
+        });
+        healthChecksCompleted += 1;
+      }
+    } catch (error) {
+      logger.warn(
+        {
+          organizationId: credential.organizationId,
+          providerCredentialId: credential.id,
+          providerKind: credential.providerKind,
+          errorCode:
+            error instanceof Error ? error.message : "scheduled_provider_health_check_failed",
+        },
+        "scheduled provider health check failed",
+      );
+    }
+
+    try {
+      const auditResults = await auditProviderWebhookSubscriptions({
+        organizationId: credential.organizationId,
+      });
+      auditsCompleted += auditResults.length;
+    } catch (error) {
+      logger.warn(
+        {
+          organizationId: credential.organizationId,
+          providerCredentialId: credential.id,
+          providerKind: credential.providerKind,
+          errorCode: error instanceof Error ? error.message : "scheduled_webhook_audit_failed",
+        },
+        "scheduled webhook subscription audit failed",
+      );
+    }
+  }
+
+  return { auditsCompleted, healthChecksCompleted };
+}
+
+export async function runScheduledReconciliation(
+  input: RunScheduledReconciliationInput,
+): Promise<ScheduledReconciliationEnqueueResult[]> {
+  const now = input.now ?? new Date();
+  const config = input.config ?? DEFAULT_SCHEDULED_RECONCILIATION_CONFIG;
+  const schedules = resolveDueSchedules({
+    now,
+    config,
+    forceSchedule: input.forceSchedule,
+  });
+
+  if (schedules.length === 0) {
+    return [];
+  }
+
+  const credentials =
+    (await input.listCredentials?.()) ?? (await listScheduledReconciliationCredentials());
+  const projects = (await input.listProjects?.()) ?? (await listScheduledReconciliationProjects());
+
+  const eligibleCredentials = credentials.filter((credential) =>
+    shouldIncludeCredentialForScheduledReconciliation(credential.validationStatus),
+  );
+  const credentialsSkipped = credentials.length - eligibleCredentials.length;
+
+  const results: ScheduledReconciliationEnqueueResult[] = [];
+
+  for (const schedule of schedules) {
+    if (schedule === "audit") {
+      const auditCounts = await runAuditSchedule(eligibleCredentials);
+      results.push({
+        schedule,
+        intentsEnqueued: 0,
+        intentsCoalesced: 0,
+        intentsSkipped: 0,
+        credentialsSkipped,
+        projectsSkipped: 0,
+        ...auditCounts,
+      });
+      continue;
+    }
+
+    const syncKinds = syncKindsForSchedule(schedule);
+    let intentsEnqueued = 0;
+    let intentsCoalesced = 0;
+    let intentsSkipped = 0;
+    let remainingBudget = config.maxIntentsPerTick;
+
+    if (syncKinds.includes("project_scan")) {
+      for (const credential of eligibleCredentials) {
+        if (remainingBudget <= 0) {
+          intentsSkipped += 1;
+          continue;
+        }
+
+        const result = await enqueueScheduledSyncIntent({
+          organizationId: credential.organizationId,
+          providerKind: credential.providerKind,
+          providerCredentialId: credential.id,
+          syncKind: "project_scan",
+          queue: input.queue,
+        });
+
+        remainingBudget -= 1;
+        if (result.coalesced) {
+          intentsCoalesced += 1;
+        } else {
+          intentsEnqueued += 1;
+        }
+      }
+    }
+
+    const projectSyncKinds = syncKinds.filter((kind) => kind !== "project_scan");
+
+    for (const project of projects) {
+      for (const syncKind of projectSyncKinds) {
+        if (remainingBudget <= 0) {
+          intentsSkipped += 1;
+          continue;
+        }
+
+        const result = await enqueueScheduledSyncIntent({
+          organizationId: project.organizationId,
+          providerKind: project.providerKind,
+          providerCredentialId: project.providerCredentialId,
+          projectId: project.id,
+          syncKind,
+          queue: input.queue,
+        });
+
+        remainingBudget -= 1;
+        if (result.coalesced) {
+          intentsCoalesced += 1;
+        } else {
+          intentsEnqueued += 1;
+        }
+      }
+    }
+
+    logger.info(
+      {
+        schedule,
+        intentsEnqueued,
+        intentsCoalesced,
+        intentsSkipped,
+        credentialsSkipped,
+        eligibleCredentialCount: eligibleCredentials.length,
+        projectCount: projects.length,
+      },
+      "scheduled TMS reconciliation tick completed",
+    );
+
+    results.push({
+      schedule,
+      intentsEnqueued,
+      intentsCoalesced,
+      intentsSkipped,
+      credentialsSkipped,
+      projectsSkipped: 0,
+      auditsCompleted: 0,
+      healthChecksCompleted: 0,
+    });
+  }
+
+  return results;
+}

--- a/apps/hyperlocalise-web/src/lib/providers/provider-scheduled-reconciliation.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-scheduled-reconciliation.ts
@@ -195,6 +195,7 @@ async function enqueueScheduledSyncIntent(input: {
 async function runAuditSchedule(credentials: ScheduledReconciliationCredential[]) {
   let auditsCompleted = 0;
   let healthChecksCompleted = 0;
+  const auditedOrganizationIds = new Set<string>();
 
   for (const credential of credentials) {
     if (!shouldIncludeCredentialForScheduledReconciliation(credential.validationStatus)) {
@@ -228,6 +229,11 @@ async function runAuditSchedule(credentials: ScheduledReconciliationCredential[]
       );
     }
 
+    if (auditedOrganizationIds.has(credential.organizationId)) {
+      continue;
+    }
+    auditedOrganizationIds.add(credential.organizationId);
+
     try {
       const auditResults = await auditProviderWebhookSubscriptions({
         organizationId: credential.organizationId,
@@ -237,8 +243,6 @@ async function runAuditSchedule(credentials: ScheduledReconciliationCredential[]
       logger.warn(
         {
           organizationId: credential.organizationId,
-          providerCredentialId: credential.id,
-          providerKind: credential.providerKind,
           errorCode: error instanceof Error ? error.message : "scheduled_webhook_audit_failed",
         },
         "scheduled webhook subscription audit failed",

--- a/apps/hyperlocalise-web/src/lib/providers/provider-scheduled-reconciliation.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-scheduled-reconciliation.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, isNotNull } from "drizzle-orm";
+import { and, count, eq, inArray, isNotNull, notInArray } from "drizzle-orm";
 
 import { db, schema } from "@/lib/database";
 import { createLogger } from "@/lib/log";
@@ -88,7 +88,12 @@ export async function listScheduledReconciliationCredentials(): Promise<
       providerKind: schema.organizationExternalTmsProviderCredentials.providerKind,
       validationStatus: schema.organizationExternalTmsProviderCredentials.validationStatus,
     })
-    .from(schema.organizationExternalTmsProviderCredentials);
+    .from(schema.organizationExternalTmsProviderCredentials)
+    .where(
+      inArray(schema.organizationExternalTmsProviderCredentials.validationStatus, [
+        ...ELIGIBLE_CREDENTIAL_STATUSES,
+      ]),
+    );
 
   return credentials.map((credential) => ({
     id: credential.id,
@@ -96,6 +101,19 @@ export async function listScheduledReconciliationCredentials(): Promise<
     providerKind: credential.providerKind as ExternalTmsProviderKind,
     validationStatus: credential.validationStatus,
   }));
+}
+
+async function countIneligibleScheduledReconciliationCredentials(): Promise<number> {
+  const [row] = await db
+    .select({ value: count() })
+    .from(schema.organizationExternalTmsProviderCredentials)
+    .where(
+      notInArray(schema.organizationExternalTmsProviderCredentials.validationStatus, [
+        ...ELIGIBLE_CREDENTIAL_STATUSES,
+      ]),
+    );
+
+  return row?.value ?? 0;
 }
 
 export async function listScheduledReconciliationProjects(): Promise<
@@ -187,6 +205,7 @@ async function runAuditSchedule(credentials: ScheduledReconciliationCredential[]
       const { credential: credentialRow, health } = await checkExternalTmsProviderHealth({
         organizationId: credential.organizationId,
         providerKind: credential.providerKind,
+        credentialId: credential.id,
       });
 
       if (credentialRow && health) {
@@ -245,14 +264,23 @@ export async function runScheduledReconciliation(
     return [];
   }
 
-  const credentials =
-    (await input.listCredentials?.()) ?? (await listScheduledReconciliationCredentials());
-  const projects = (await input.listProjects?.()) ?? (await listScheduledReconciliationProjects());
+  let eligibleCredentials: ScheduledReconciliationCredential[];
+  let credentialsSkipped: number;
 
-  const eligibleCredentials = credentials.filter((credential) =>
-    shouldIncludeCredentialForScheduledReconciliation(credential.validationStatus),
-  );
-  const credentialsSkipped = credentials.length - eligibleCredentials.length;
+  if (input.listCredentials) {
+    const credentials = await input.listCredentials();
+    eligibleCredentials = credentials.filter((credential) =>
+      shouldIncludeCredentialForScheduledReconciliation(credential.validationStatus),
+    );
+    credentialsSkipped = credentials.length - eligibleCredentials.length;
+  } else {
+    [eligibleCredentials, credentialsSkipped] = await Promise.all([
+      listScheduledReconciliationCredentials(),
+      countIneligibleScheduledReconciliationCredentials(),
+    ]);
+  }
+
+  const projects = (await input.listProjects?.()) ?? (await listScheduledReconciliationProjects());
 
   const results: ScheduledReconciliationEnqueueResult[] = [];
 
@@ -275,6 +303,7 @@ export async function runScheduledReconciliation(
     let intentsEnqueued = 0;
     let intentsCoalesced = 0;
     let intentsSkipped = 0;
+    let projectsSkipped = 0;
     let remainingBudget = config.maxIntentsPerTick;
 
     if (syncKinds.includes("project_scan")) {
@@ -304,6 +333,11 @@ export async function runScheduledReconciliation(
     const projectSyncKinds = syncKinds.filter((kind) => kind !== "project_scan");
 
     for (const project of projects) {
+      if (remainingBudget <= 0) {
+        projectsSkipped += 1;
+        continue;
+      }
+
       for (const syncKind of projectSyncKinds) {
         if (remainingBudget <= 0) {
           intentsSkipped += 1;
@@ -335,6 +369,7 @@ export async function runScheduledReconciliation(
         intentsCoalesced,
         intentsSkipped,
         credentialsSkipped,
+        projectsSkipped,
         eligibleCredentialCount: eligibleCredentials.length,
         projectCount: projects.length,
       },
@@ -347,7 +382,7 @@ export async function runScheduledReconciliation(
       intentsCoalesced,
       intentsSkipped,
       credentialsSkipped,
-      projectsSkipped: 0,
+      projectsSkipped,
       auditsCompleted: 0,
       healthChecksCompleted: 0,
     });

--- a/apps/hyperlocalise-web/vercel.json
+++ b/apps/hyperlocalise-web/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/tms-scheduled-reconciliation",
+      "schedule": "*/15 * * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## What changed

Adds scheduled reconciliation for connected external TMS projects so missed, delayed, or unsupported webhook events do not leave files, jobs, TM, or glossaries stale.

This introduces a cron-triggered scheduler that:
- Scans active external TMS credentials and active `source = external_tms` projects
- Enqueues sync intents through the shared HL-400 intent queue (`cause: "scheduled"`)
- Reuses the existing webhook reconciliation workflow for processing
- Skips `error` / `unvalidated` credentials and logs safe scheduler decisions

Default schedule tiers:
- **Every 15 min:** `file_key_scan`, `job_task_scan`
- **Hourly:** `tm_scan`, `glossary_scan`
- **Nightly (03:00 UTC):** full reconciliation (`project_scan` + all project scans)
- **Daily (04:00 UTC):** provider health checks + webhook subscription audit

Intervals and enablement are configurable via env vars. A Vercel cron entry runs every 15 minutes against `POST /api/cron/tms-scheduled-reconciliation`, protected by `TMS_SCHEDULED_RECONCILIATION_CRON_SECRET`.

## How to test

- [x] Run focused scheduler tests:
  ```bash
  cd apps/hyperlocalise-web
  vp test src/lib/providers/provider-scheduled-reconciliation-config.test.ts \
           src/lib/providers/provider-scheduled-reconciliation.test.ts \
           src/api/routes/cron/tms-scheduled-reconciliation.route.test.ts
```