### PR TITLE
feat(web): add Smartling webhook subscriptions and verification (HL-407)

### DIFF
--- a/apps/hyperlocalise-web/src/lib/providers/provider-webhook-default-events.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-webhook-default-events.ts
@@ -32,5 +32,25 @@ export function listDefaultWebhookEvents(providerKind: ExternalTmsProviderKind) 
     ];
   }
 
+  if (providerKind === "smartling") {
+    return [
+      "file.uploaded",
+      "file.published",
+      "file.deleted",
+      "file.translation.completed",
+      "job.created",
+      "job.completed",
+      "job.cancelled",
+      "translation.published",
+      "translation.updated",
+      "sourceIssue.created",
+      "sourceIssue.comment.created",
+      "glossary.entry.created",
+      "glossary.entry.updated",
+      "translationMemory.entry.created",
+      "translationMemory.entry.updated",
+    ];
+  }
+
   return [];
 }

--- a/apps/hyperlocalise-web/src/lib/providers/provider-webhook-subscription-adapters.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-webhook-subscription-adapters.ts
@@ -1,9 +1,11 @@
 import type { ExternalTmsProviderKind } from "./organization-external-tms-provider-credentials";
 import { createCrowdinWebhookSubscriptionAdapter } from "./crowdin/crowdin-webhook-subscription-adapter";
+import { createSmartlingWebhookSubscriptionAdapter } from "./smartling/smartling-webhook-subscription-adapter";
 import { createManualProviderWebhookSubscriptionAdapter } from "./manual-provider-webhook-subscription-adapter";
 import type { ProviderWebhookSubscriptionAdapter } from "./provider-webhook-subscription-types";
 
 const crowdinAdapter = createCrowdinWebhookSubscriptionAdapter();
+const smartlingAdapter = createSmartlingWebhookSubscriptionAdapter();
 const manualAdapter = createManualProviderWebhookSubscriptionAdapter();
 
 /**
@@ -15,6 +17,10 @@ export function getProviderWebhookSubscriptionAdapter(
 ): ProviderWebhookSubscriptionAdapter {
   if (providerKind === "crowdin") {
     return crowdinAdapter;
+  }
+
+  if (providerKind === "smartling") {
+    return smartlingAdapter;
   }
 
   return manualAdapter;

--- a/apps/hyperlocalise-web/src/lib/providers/provider-webhook-subscription-manager.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-webhook-subscription-manager.test.ts
@@ -419,6 +419,147 @@ describe("provider webhook subscription manager", () => {
     expect(retried.subscription.id).toBe(first.subscription.id);
   });
 
+  async function createSmartlingCredential() {
+    const { organizationId, userId } = await createOrganizationUser();
+    const credential = await upsertOrganizationExternalTmsProviderCredential({
+      organizationId,
+      userId,
+      role: "owner",
+      providerKind: "smartling",
+      displayName: "Smartling",
+      secretMaterial: "user-1:secret-1:acct-smartling-1",
+    });
+
+    const projectId = `project_${randomUUID()}`;
+    await db.insert(schema.projects).values({
+      id: projectId,
+      organizationId,
+      name: "Smartling project",
+      description: "",
+      translationContext: "",
+      source: "external_tms",
+      externalProviderCredentialId: credential.id,
+      externalProviderKind: "smartling",
+      externalProjectId: "smartling-project-1",
+      targetLocales: ["fr-FR"],
+      isActive: true,
+    });
+
+    return { organizationId, credential, projectId };
+  }
+
+  function createSmartlingWebhookFetch(input: { updateFails?: boolean; status?: number } = {}) {
+    return vi.fn(async (url, init) => {
+      const target = String(url);
+
+      if (input.status) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "VALIDATION_ERROR",
+              errors: [{ message: "maximum subscriptions reached" }],
+            },
+          }),
+          { status: input.status },
+        );
+      }
+
+      if (target.endsWith("/authenticate")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: { accessToken: "access-token", expiresIn: 3600 },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (target.includes("/subscriptions") && (init?.method ?? "GET") === "GET") {
+        return new Response(
+          JSON.stringify({
+            response: { code: "SUCCESS", data: { items: [], totalCount: 0 } },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (
+        target.includes("/subscriptions") &&
+        init?.method === "POST" &&
+        !target.endsWith("/disable")
+      ) {
+        const body =
+          typeof init.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : {};
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: {
+                subscriptionUid: "sub-smartling-1",
+                subscriptionName: body.subscriptionName,
+                subscriptionUrl: body.subscriptionUrl,
+                payloadSecret: body.payloadSecret,
+                requestHeaders: body.requestHeaders ?? [],
+                events: body.events ?? [],
+                projectUids: body.projectUids ?? [],
+                isActive: true,
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (target.includes("/subscriptions/sub-smartling-1") && init?.method === "PUT") {
+        if (input.updateFails) {
+          return new Response(JSON.stringify({ response: { code: "ERROR" } }), { status: 500 });
+        }
+
+        const body =
+          typeof init.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : {};
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: {
+                subscriptionUid: "sub-smartling-1",
+                subscriptionName: body.subscriptionName,
+                subscriptionUrl: body.subscriptionUrl,
+                payloadSecret: body.payloadSecret,
+                requestHeaders: body.requestHeaders ?? [],
+                events: body.events ?? [],
+                projectUids: body.projectUids ?? [],
+                isActive: true,
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response("Not Found", { status: 404 });
+    }) as unknown as typeof fetch;
+  }
+
+  it("creates an active Smartling webhook subscription when automatic setup is available", async () => {
+    const { organizationId, credential, projectId } = await createSmartlingCredential();
+
+    const result = await ensureProviderWebhookSubscription({
+      organizationId,
+      providerKind: "smartling",
+      providerCredentialId: credential.id,
+      projectId,
+      externalProjectId: "smartling-project-1",
+      fetchFn: createSmartlingWebhookFetch(),
+    });
+
+    expect(result.status).toBe("active");
+    expect(result.subscription.providerWebhookId).toBe("sub-smartling-1");
+    expect(result.subscription.subscribedEvents).toContain("file.published");
+  });
+
   it("uses the same provider-agnostic fallback for other TMS providers", async () => {
     const { organizationId, userId } = await createOrganizationUser();
     const credential = await upsertOrganizationExternalTmsProviderCredential({

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-api.ts
@@ -18,6 +18,7 @@ const DEFAULT_GLOSSARY_BASE_URL = "https://api.smartling.com/glossary-api/v2";
 const DEFAULT_GLOSSARY_V3_BASE_URL = "https://api.smartling.com/glossary-api/v3";
 const DEFAULT_TM_BASE_URL = "https://api.smartling.com/translation-memory-api/v2";
 const DEFAULT_ISSUES_BASE_URL = "https://api.smartling.com/issues-api/v2";
+const DEFAULT_WEBHOOKS_BASE_URL = "https://api.smartling.com/webhooks-api/v2";
 const TOKEN_REFRESH_SKEW_MS = 60_000;
 const DEFAULT_PAGE_SIZE = 500;
 
@@ -35,8 +36,43 @@ export interface SmartlingApiClientOptions {
   glossaryV3BaseUrl?: string;
   tmBaseUrl?: string;
   issuesBaseUrl?: string;
+  webhooksBaseUrl?: string;
   fetchFn?: typeof fetch;
 }
+
+export interface SmartlingWebhookEventSpec {
+  type: string;
+  schemaVersion: string;
+}
+
+export interface SmartlingWebhookRequestHeader {
+  headerName: string;
+  headerValue: string;
+}
+
+export interface SmartlingWebhookSubscription {
+  subscriptionUid: string;
+  subscriptionName: string;
+  subscriptionUrl: string;
+  description?: string | null;
+  payloadSecret?: string | null;
+  requestHeaders?: SmartlingWebhookRequestHeader[];
+  events: SmartlingWebhookEventSpec[];
+  projectUids: string[];
+  isActive?: boolean;
+}
+
+export type SmartlingWebhookSubscriptionCreateRequest = {
+  subscriptionName: string;
+  subscriptionUrl: string;
+  description?: string;
+  payloadSecret?: string;
+  requestHeaders?: SmartlingWebhookRequestHeader[];
+  events: SmartlingWebhookEventSpec[];
+  projectUids: string[];
+};
+
+export type SmartlingWebhookSubscriptionUpdateRequest = SmartlingWebhookSubscriptionCreateRequest;
 
 export interface SmartlingGlossarySummary {
   glossaryUid: string;
@@ -276,6 +312,7 @@ export class SmartlingApiClient {
   private readonly glossaryV3BaseUrl: string;
   private readonly tmBaseUrl: string;
   private readonly issuesBaseUrl: string;
+  private readonly webhooksBaseUrl: string;
   private readonly fetchFn: typeof fetch;
   private tokens: SmartlingAuthTokens | null = null;
 
@@ -320,6 +357,10 @@ export class SmartlingApiClient {
     this.issuesBaseUrl = normalizeServiceBaseUrl(
       options.issuesBaseUrl ?? deriveServiceBaseUrl(this.authBaseUrl, "issues"),
       DEFAULT_ISSUES_BASE_URL,
+    );
+    this.webhooksBaseUrl = normalizeServiceBaseUrl(
+      options.webhooksBaseUrl ?? deriveServiceBaseUrl(this.authBaseUrl, "webhooks"),
+      DEFAULT_WEBHOOKS_BASE_URL,
     );
     this.fetchFn = options.fetchFn ?? fetch;
   }
@@ -919,6 +960,85 @@ export class SmartlingApiClient {
     );
   }
 
+  async listWebhookSubscriptions(accountUid: string): Promise<SmartlingWebhookSubscription[]> {
+    const token = await this.getAccessToken();
+    const subscriptions: SmartlingWebhookSubscription[] = [];
+    let offset = 0;
+
+    while (true) {
+      const params = new URLSearchParams({
+        limit: String(DEFAULT_PAGE_SIZE),
+        offset: String(offset),
+      });
+      const data = await this.get<{ items: SmartlingWebhookSubscription[]; totalCount?: number }>(
+        `${this.webhooksBaseUrl}/accounts/${encodeURIComponent(accountUid)}/subscriptions?${params}`,
+        token,
+      );
+
+      const page = (data.items ?? []).map(normalizeSmartlingWebhookSubscription);
+      subscriptions.push(...page);
+      offset += page.length;
+
+      if (page.length === 0) {
+        break;
+      }
+
+      if (typeof data.totalCount === "number") {
+        if (offset >= data.totalCount) {
+          break;
+        }
+      } else if (page.length < DEFAULT_PAGE_SIZE) {
+        break;
+      }
+    }
+
+    return subscriptions;
+  }
+
+  async createWebhookSubscription(
+    accountUid: string,
+    request: SmartlingWebhookSubscriptionCreateRequest,
+  ): Promise<SmartlingWebhookSubscription> {
+    const token = await this.getAccessToken();
+    const created = await this.post<SmartlingWebhookSubscription>(
+      `${this.webhooksBaseUrl}/accounts/${encodeURIComponent(accountUid)}/subscriptions`,
+      token,
+      request,
+    );
+    return normalizeSmartlingWebhookSubscription(created);
+  }
+
+  async updateWebhookSubscription(
+    accountUid: string,
+    subscriptionUid: string,
+    request: SmartlingWebhookSubscriptionUpdateRequest,
+  ): Promise<SmartlingWebhookSubscription> {
+    const token = await this.getAccessToken();
+    const updated = await this.put<SmartlingWebhookSubscription>(
+      `${this.webhooksBaseUrl}/accounts/${encodeURIComponent(accountUid)}/subscriptions/${encodeURIComponent(subscriptionUid)}`,
+      token,
+      request,
+    );
+    return normalizeSmartlingWebhookSubscription(updated);
+  }
+
+  async disableWebhookSubscription(accountUid: string, subscriptionUid: string): Promise<void> {
+    const token = await this.getAccessToken();
+    await this.post<Record<string, never>>(
+      `${this.webhooksBaseUrl}/accounts/${encodeURIComponent(accountUid)}/subscriptions/${encodeURIComponent(subscriptionUid)}/disable`,
+      token,
+      {},
+    );
+  }
+
+  async deleteWebhookSubscription(accountUid: string, subscriptionUid: string): Promise<void> {
+    const token = await this.getAccessToken();
+    await this.delete(
+      `${this.webhooksBaseUrl}/accounts/${encodeURIComponent(accountUid)}/subscriptions/${encodeURIComponent(subscriptionUid)}`,
+      token,
+    );
+  }
+
   private async get<T>(url: string, token: string): Promise<T> {
     const response = await this.fetchFn(url, {
       method: "GET",
@@ -956,6 +1076,34 @@ export class SmartlingApiClient {
 
     return parseSmartlingResponse<T>(response, url);
   }
+
+  private async delete(url: string, token: string): Promise<void> {
+    const response = await this.fetchFn(url, {
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+    });
+
+    await parseSmartlingResponse<Record<string, never>>(response, url);
+  }
+}
+
+function normalizeSmartlingWebhookSubscription(
+  item: SmartlingWebhookSubscription,
+): SmartlingWebhookSubscription {
+  return {
+    subscriptionUid: item.subscriptionUid,
+    subscriptionName: item.subscriptionName,
+    subscriptionUrl: item.subscriptionUrl,
+    description: item.description ?? null,
+    payloadSecret: item.payloadSecret ?? null,
+    requestHeaders: item.requestHeaders ?? [],
+    events: item.events ?? [],
+    projectUids: item.projectUids ?? [],
+    isActive: item.isActive ?? true,
+  };
 }
 
 export function deriveServiceBaseUrl(
@@ -969,11 +1117,13 @@ export function deriveServiceBaseUrl(
     | "glossary"
     | "glossary-v3"
     | "translation-memory"
-    | "issues",
+    | "issues"
+    | "webhooks",
 ) {
   const normalized = normalizeServiceBaseUrl(authBaseUrl, authBaseUrl);
   if (normalized.includes("/auth-api/")) {
-    const version = service === "jobs" || service === "glossary-v3" ? "v3" : "v2";
+    const version =
+      service === "jobs" || service === "glossary-v3" ? "v3" : service === "webhooks" ? "v2" : "v2";
     const apiName =
       service === "glossary"
         ? "glossary"
@@ -1004,6 +1154,8 @@ export function deriveServiceBaseUrl(
       return DEFAULT_TM_BASE_URL;
     case "issues":
       return DEFAULT_ISSUES_BASE_URL;
+    case "webhooks":
+      return DEFAULT_WEBHOOKS_BASE_URL;
   }
 }
 

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-api.ts
@@ -1122,8 +1122,7 @@ export function deriveServiceBaseUrl(
 ) {
   const normalized = normalizeServiceBaseUrl(authBaseUrl, authBaseUrl);
   if (normalized.includes("/auth-api/")) {
-    const version =
-      service === "jobs" || service === "glossary-v3" ? "v3" : service === "webhooks" ? "v2" : "v2";
+    const version = service === "jobs" || service === "glossary-v3" ? "v3" : "v2";
     const apiName =
       service === "glossary"
         ? "glossary"

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-webhook-subscription-adapter.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-webhook-subscription-adapter.test.ts
@@ -161,9 +161,7 @@ describe("createSmartlingWebhookSubscriptionAdapter", () => {
     const putCall = fetchMock.mock.calls.find(([, init]) => init?.method === "PUT");
     expect(putCall).toBeDefined();
     const putInit = putCall?.[1];
-    const putBody = JSON.parse(
-      typeof putInit?.body === "string" ? putInit.body : "{}",
-    ) as {
+    const putBody = JSON.parse(typeof putInit?.body === "string" ? putInit.body : "{}") as {
       requestHeaders: Array<{ headerName: string; headerValue: string }>;
     };
     expect(putBody.requestHeaders).toEqual(

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-webhook-subscription-adapter.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-webhook-subscription-adapter.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { createSmartlingWebhookSubscriptionAdapter } from "./smartling-webhook-subscription-adapter";
+
+describe("createSmartlingWebhookSubscriptionAdapter", () => {
+  function createFetchMock(input: { updateFails?: boolean; status?: number } = {}) {
+    return vi.fn(async (url, init) => {
+      const target = String(url);
+
+      if (input.status) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "VALIDATION_ERROR",
+              errors: [{ message: "subscription limit reached" }],
+            },
+          }),
+          { status: input.status },
+        );
+      }
+
+      if (target.endsWith("/authenticate")) {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: { accessToken: "access-token", expiresIn: 3600 },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (target.includes("/subscriptions") && (init?.method ?? "GET") === "GET") {
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: { items: [], totalCount: 0 },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (
+        target.includes("/subscriptions") &&
+        init?.method === "POST" &&
+        !target.endsWith("/disable")
+      ) {
+        const body =
+          typeof init.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : {};
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: {
+                subscriptionUid: "sub-smartling-1",
+                subscriptionName: body.subscriptionName,
+                subscriptionUrl: body.subscriptionUrl,
+                payloadSecret: body.payloadSecret,
+                requestHeaders: body.requestHeaders ?? [],
+                events: body.events ?? [],
+                projectUids: body.projectUids ?? [],
+                isActive: true,
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (target.includes("/subscriptions/sub-smartling-1") && init?.method === "PUT") {
+        if (input.updateFails) {
+          return new Response(
+            JSON.stringify({
+              response: {
+                code: "ERROR",
+                errors: [{ message: "update failed" }],
+              },
+            }),
+            { status: 500 },
+          );
+        }
+
+        const body =
+          typeof init.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : {};
+        return new Response(
+          JSON.stringify({
+            response: {
+              code: "SUCCESS",
+              data: {
+                subscriptionUid: "sub-smartling-1",
+                subscriptionName: body.subscriptionName,
+                subscriptionUrl: body.subscriptionUrl,
+                payloadSecret: body.payloadSecret,
+                requestHeaders: body.requestHeaders ?? [],
+                events: body.events ?? [],
+                projectUids: body.projectUids ?? [],
+                isActive: true,
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (target.endsWith("/disable") && init?.method === "POST") {
+        return new Response(
+          JSON.stringify({
+            response: { code: "SUCCESS", data: {} },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (target.includes("/subscriptions/sub-smartling-1") && init?.method === "DELETE") {
+        return new Response(
+          JSON.stringify({
+            response: { code: "SUCCESS", data: {} },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response("Not Found", { status: 404 });
+    }) as unknown as typeof fetch;
+  }
+
+  const baseContext = {
+    organizationId: "org-1",
+    providerCredentialId: "cred-1",
+    providerKind: "smartling" as const,
+    projectId: "project-1",
+    externalProjectId: "smartling-project-1",
+    secretMaterial: "user-1:secret-1:acct-smartling-1",
+    baseUrl: null,
+    region: null,
+    endpointUrl: "https://app.example.test/api/webhooks/tms/smartling",
+    webhookSecret: "webhook-signing-secret",
+    subscribedEvents: ["file.published", "job.completed"],
+  };
+
+  it("creates a remote subscription and patches provider webhook headers", async () => {
+    const adapter = createSmartlingWebhookSubscriptionAdapter();
+    const fetchFn = createFetchMock();
+
+    const remote = await adapter.createRemoteSubscription({
+      ...baseContext,
+      fetchFn,
+    });
+
+    expect(remote).toMatchObject({
+      providerWebhookId: "sub-smartling-1",
+      endpointUrl: baseContext.endpointUrl,
+      subscribedEvents: ["file.published", "job.completed"],
+      isActive: true,
+    });
+
+    const fetchMock = vi.mocked(fetchFn);
+    const putCall = fetchMock.mock.calls.find(([, init]) => init?.method === "PUT");
+    expect(putCall).toBeDefined();
+    const putInit = putCall?.[1];
+    const putBody = JSON.parse(
+      typeof putInit?.body === "string" ? putInit.body : "{}",
+    ) as {
+      requestHeaders: Array<{ headerName: string; headerValue: string }>;
+    };
+    expect(putBody.requestHeaders).toEqual(
+      expect.arrayContaining([
+        {
+          headerName: "X-Hyperlocalise-Webhook-Secret",
+          headerValue: "webhook-signing-secret",
+        },
+        {
+          headerName: "X-Hyperlocalise-Provider-Webhook-Id",
+          headerValue: "sub-smartling-1",
+        },
+      ]),
+    );
+  });
+
+  it("maps subscription limit failures to not_supported", async () => {
+    const adapter = createSmartlingWebhookSubscriptionAdapter();
+
+    await expect(
+      adapter.createRemoteSubscription({
+        ...baseContext,
+        fetchFn: createFetchMock({ status: 400 }),
+      }),
+    ).rejects.toMatchObject({
+      code: "not_supported",
+    });
+  });
+
+  it("returns provider webhook id when header activation fails after create", async () => {
+    const adapter = createSmartlingWebhookSubscriptionAdapter();
+
+    await expect(
+      adapter.createRemoteSubscription({
+        ...baseContext,
+        fetchFn: createFetchMock({ updateFails: true }),
+      }),
+    ).rejects.toMatchObject({
+      code: "provider_error",
+      providerWebhookId: "sub-smartling-1",
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-webhook-subscription-adapter.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-webhook-subscription-adapter.ts
@@ -230,21 +230,16 @@ export function createSmartlingWebhookSubscriptionAdapter(): ProviderWebhookSubs
     },
 
     async createRemoteSubscription(context) {
-      const accountUid = await resolveAccountUid(context);
-      const client = createSmartlingClient(context);
+      let providerWebhookId: string | undefined;
 
-      let created: SmartlingWebhookSubscription;
       try {
-        created = await client.createWebhookSubscription(
+        const accountUid = await resolveAccountUid(context);
+        const client = createSmartlingClient(context);
+        const created = await client.createWebhookSubscription(
           accountUid,
           buildSubscriptionRequest(context),
         );
-      } catch (error) {
-        throw mapSmartlingError(error);
-      }
-
-      const providerWebhookId = created.subscriptionUid;
-      try {
+        providerWebhookId = created.subscriptionUid;
         const updated = await client.updateWebhookSubscription(
           accountUid,
           providerWebhookId,
@@ -252,7 +247,7 @@ export function createSmartlingWebhookSubscriptionAdapter(): ProviderWebhookSubs
         );
         return mapSmartlingWebhook(updated);
       } catch (error) {
-        throw mapSmartlingError(error, { providerWebhookId });
+        throw mapSmartlingError(error, providerWebhookId ? { providerWebhookId } : undefined);
       }
     },
 

--- a/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-webhook-subscription-adapter.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/smartling/smartling-webhook-subscription-adapter.ts
@@ -1,0 +1,294 @@
+import { parseSmartlingCredentials } from "./smartling-credentials";
+import {
+  SmartlingApiClient,
+  SmartlingApiError,
+  type SmartlingWebhookEventSpec,
+  type SmartlingWebhookSubscription,
+} from "./smartling-api";
+import { resolveSmartlingAccountUid } from "./smartling-account-context";
+import {
+  ProviderWebhookSubscriptionAdapterError,
+  type ProviderWebhookRemoteSubscription,
+  type ProviderWebhookSubscriptionAdapter,
+  type ProviderWebhookSubscriptionAdapterContext,
+} from "../provider-webhook-subscription-types";
+
+const smartlingWebhookName = "Hyperlocalise sync";
+const webhookIdHeaderName = "X-Hyperlocalise-Provider-Webhook-Id";
+const webhookSecretHeaderName = "X-Hyperlocalise-Webhook-Secret";
+const defaultSchemaVersion = "1.0";
+const maxProjectUidsPerSubscription = 10;
+
+function createSmartlingClient(context: ProviderWebhookSubscriptionAdapterContext) {
+  return new SmartlingApiClient({
+    credentials: context.secretMaterial,
+    fetchFn: context.fetchFn,
+  });
+}
+
+function toSmartlingEvents(subscribedEvents: string[]): SmartlingWebhookEventSpec[] {
+  return subscribedEvents.map((type) => ({
+    type,
+    schemaVersion: defaultSchemaVersion,
+  }));
+}
+
+function fromSmartlingEvents(events: SmartlingWebhookEventSpec[]) {
+  return events.map((event) => event.type);
+}
+
+function buildRequestHeaders(input: { webhookSecret: string; providerWebhookId?: string }) {
+  return [
+    {
+      headerName: webhookSecretHeaderName,
+      headerValue: input.webhookSecret,
+    },
+    ...(input.providerWebhookId
+      ? [
+          {
+            headerName: webhookIdHeaderName,
+            headerValue: input.providerWebhookId,
+          },
+        ]
+      : []),
+  ];
+}
+
+function mapSmartlingWebhook(
+  subscription: SmartlingWebhookSubscription,
+): ProviderWebhookRemoteSubscription {
+  return {
+    providerWebhookId: subscription.subscriptionUid,
+    endpointUrl: subscription.subscriptionUrl,
+    subscribedEvents: fromSmartlingEvents(subscription.events),
+    isActive: subscription.isActive ?? true,
+    secret: subscription.payloadSecret ?? null,
+  };
+}
+
+async function resolveAccountUid(context: ProviderWebhookSubscriptionAdapterContext) {
+  const credentials = parseSmartlingCredentials(context.secretMaterial);
+  if (credentials.accountUid?.trim()) {
+    return credentials.accountUid.trim();
+  }
+
+  const projectId = context.externalProjectId?.trim() || credentials.projectId?.trim();
+  if (!projectId) {
+    throw new ProviderWebhookSubscriptionAdapterError(
+      "invalid_configuration",
+      "Smartling account UID or project id is required for webhook setup",
+    );
+  }
+
+  const accountUid = await resolveSmartlingAccountUid({
+    secretMaterial: context.secretMaterial,
+    externalProjectId: projectId,
+  });
+
+  if (!accountUid) {
+    throw new ProviderWebhookSubscriptionAdapterError(
+      "invalid_configuration",
+      "Unable to resolve Smartling account UID for webhook setup",
+    );
+  }
+
+  return accountUid;
+}
+
+function resolveProjectUids(context: ProviderWebhookSubscriptionAdapterContext) {
+  const credentials = parseSmartlingCredentials(context.secretMaterial);
+  const projectId = context.externalProjectId?.trim() || credentials.projectId?.trim();
+
+  if (!projectId) {
+    throw new ProviderWebhookSubscriptionAdapterError(
+      "invalid_configuration",
+      "Smartling project id is required for webhook setup",
+    );
+  }
+
+  return [projectId];
+}
+
+function buildSubscriptionRequest(
+  context: ProviderWebhookSubscriptionAdapterContext & { providerWebhookId?: string },
+) {
+  const projectUids = resolveProjectUids(context);
+  if (projectUids.length > maxProjectUidsPerSubscription) {
+    throw new ProviderWebhookSubscriptionAdapterError(
+      "not_supported",
+      `Smartling allows at most ${maxProjectUidsPerSubscription} projects per webhook subscription`,
+    );
+  }
+
+  return {
+    subscriptionName: smartlingWebhookName,
+    subscriptionUrl: context.endpointUrl,
+    description: "Hyperlocalise TMS reconciliation webhook",
+    payloadSecret: context.webhookSecret,
+    requestHeaders: buildRequestHeaders({
+      webhookSecret: context.webhookSecret,
+      providerWebhookId: context.providerWebhookId,
+    }),
+    events: toSmartlingEvents(context.subscribedEvents),
+    projectUids,
+  };
+}
+
+function mapSmartlingError(
+  error: unknown,
+  options?: { providerWebhookId?: string },
+): ProviderWebhookSubscriptionAdapterError {
+  if (error instanceof ProviderWebhookSubscriptionAdapterError) {
+    if (options?.providerWebhookId && !error.providerWebhookId) {
+      return new ProviderWebhookSubscriptionAdapterError(error.code, error.message, {
+        httpStatus: error.httpStatus,
+        cause: error.cause,
+        providerWebhookId: options.providerWebhookId,
+      });
+    }
+
+    return error;
+  }
+
+  if (error instanceof SmartlingApiError) {
+    const combinedMessage =
+      `${error.message} ${collectSmartlingWebhookErrorDetail(error)}`.toLowerCase();
+
+    if (error.status === 401 || error.status === 403) {
+      return new ProviderWebhookSubscriptionAdapterError(
+        "permission_denied",
+        `Smartling webhook API returned HTTP ${error.status}`,
+        {
+          httpStatus: error.status,
+          cause: error,
+          providerWebhookId: options?.providerWebhookId,
+        },
+      );
+    }
+
+    if (
+      combinedMessage.includes("limit") ||
+      combinedMessage.includes("maximum") ||
+      combinedMessage.includes("too many")
+    ) {
+      return new ProviderWebhookSubscriptionAdapterError(
+        "not_supported",
+        "Smartling webhook subscription limit reached. Configure the webhook manually in Smartling.",
+        {
+          httpStatus: error.status,
+          cause: error,
+          providerWebhookId: options?.providerWebhookId,
+        },
+      );
+    }
+
+    return new ProviderWebhookSubscriptionAdapterError(
+      "provider_error",
+      `Smartling webhook API returned HTTP ${error.status}`,
+      {
+        httpStatus: error.status,
+        cause: error,
+        providerWebhookId: options?.providerWebhookId,
+      },
+    );
+  }
+
+  return new ProviderWebhookSubscriptionAdapterError(
+    "provider_error",
+    error instanceof Error ? error.message : "Smartling webhook setup failed",
+    { cause: error, providerWebhookId: options?.providerWebhookId },
+  );
+}
+
+function collectSmartlingWebhookErrorDetail(error: SmartlingApiError) {
+  if (!error.responseBody || typeof error.responseBody !== "object") {
+    return "";
+  }
+
+  const response = (error.responseBody as { response?: { errors?: Array<{ message?: string }> } })
+    .response;
+  const errors = Array.isArray(response?.errors) ? response.errors : [];
+  return errors
+    .map((entry) => (typeof entry?.message === "string" ? entry.message : ""))
+    .filter(Boolean)
+    .join(" ");
+}
+
+export function createSmartlingWebhookSubscriptionAdapter(): ProviderWebhookSubscriptionAdapter {
+  return {
+    supportsAutomaticSetup: true,
+
+    async listRemoteSubscriptions(context) {
+      try {
+        const accountUid = await resolveAccountUid(context);
+        const client = createSmartlingClient(context);
+        const subscriptions = await client.listWebhookSubscriptions(accountUid);
+        return subscriptions.map(mapSmartlingWebhook);
+      } catch (error) {
+        throw mapSmartlingError(error);
+      }
+    },
+
+    async createRemoteSubscription(context) {
+      const accountUid = await resolveAccountUid(context);
+      const client = createSmartlingClient(context);
+
+      let created: SmartlingWebhookSubscription;
+      try {
+        created = await client.createWebhookSubscription(
+          accountUid,
+          buildSubscriptionRequest(context),
+        );
+      } catch (error) {
+        throw mapSmartlingError(error);
+      }
+
+      const providerWebhookId = created.subscriptionUid;
+      try {
+        const updated = await client.updateWebhookSubscription(
+          accountUid,
+          providerWebhookId,
+          buildSubscriptionRequest({ ...context, providerWebhookId }),
+        );
+        return mapSmartlingWebhook(updated);
+      } catch (error) {
+        throw mapSmartlingError(error, { providerWebhookId });
+      }
+    },
+
+    async updateRemoteSubscription(context) {
+      try {
+        const accountUid = await resolveAccountUid(context);
+        const client = createSmartlingClient(context);
+        const updated = await client.updateWebhookSubscription(
+          accountUid,
+          context.providerWebhookId,
+          buildSubscriptionRequest({ ...context, providerWebhookId: context.providerWebhookId }),
+        );
+        return mapSmartlingWebhook(updated);
+      } catch (error) {
+        throw mapSmartlingError(error, { providerWebhookId: context.providerWebhookId });
+      }
+    },
+
+    async disableRemoteSubscription(context) {
+      try {
+        const accountUid = await resolveAccountUid(context);
+        const client = createSmartlingClient(context);
+        await client.disableWebhookSubscription(accountUid, context.providerWebhookId);
+      } catch (error) {
+        throw mapSmartlingError(error, { providerWebhookId: context.providerWebhookId });
+      }
+    },
+
+    async deleteRemoteSubscription(context) {
+      try {
+        const accountUid = await resolveAccountUid(context);
+        const client = createSmartlingClient(context);
+        await client.deleteWebhookSubscription(accountUid, context.providerWebhookId);
+      } catch (error) {
+        throw mapSmartlingError(error, { providerWebhookId: context.providerWebhookId });
+      }
+    },
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-webhook-adapters.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-webhook-adapters.test.ts
@@ -18,10 +18,11 @@ function extract(input: {
   providerKind: ExternalTmsProviderKind;
   payload: ProviderWebhookPayload;
   headers?: HeadersInit;
+  providerWebhookId?: string;
 }) {
   const adapter = tmsProviderWebhookAdapters[input.providerKind];
   const headers = new Headers(input.headers);
-  headers.set("x-hyperlocalise-provider-webhook-id", "webhook-1");
+  headers.set("x-hyperlocalise-provider-webhook-id", input.providerWebhookId ?? "webhook-1");
 
   return adapter.extract({
     providerKind: input.providerKind,
@@ -91,6 +92,21 @@ describe("tms provider webhook adapters", () => {
       },
     },
     {
+      providerKind: "smartling",
+      payload: {
+        type: "file.published",
+        file: { fileUri: "/locales/en.json" },
+        project: { projectUid: "smartling-project-1" },
+      },
+      expected: {
+        providerEventId: "smartling-delivery-1",
+        eventType: "file.published",
+        resourceId: "/locales/en.json",
+        externalResourceId: "smartling-project-1",
+        mappedIntentKinds: ["file_key_scan"],
+      },
+    },
+    {
       providerKind: "lokalise",
       payload: {
         uuid: "lokalise-event-1",
@@ -109,7 +125,11 @@ describe("tms provider webhook adapters", () => {
   ])(
     "maps representative $providerKind payloads to reconciliation intents",
     ({ providerKind, payload, expected }) => {
-      const descriptor = extract({ providerKind, payload });
+      const headers =
+        providerKind === "smartling" && expected.providerEventId === "smartling-delivery-1"
+          ? { "event-id": "smartling-delivery-1" }
+          : undefined;
+      const descriptor = extract({ providerKind, payload, headers });
 
       expect(descriptor).toMatchObject({
         providerWebhookId: "webhook-1",
@@ -118,13 +138,19 @@ describe("tms provider webhook adapters", () => {
         dedupeKey: expected.providerEventId,
         resourceId: expected.resourceId,
         externalResourceId: expected.externalResourceId,
+        ...(providerKind === "smartling" && expected.providerEventId === "smartling-delivery-1"
+          ? { deliveryId: "smartling-delivery-1" }
+          : {}),
       });
       expect(descriptor?.mappedIntents.map((intent) => intent.kind)).toEqual(
         expected.mappedIntentKinds,
       );
       expect(descriptor?.redactedPayload).toEqual({
         providerEventId: expected.providerEventId,
-        deliveryId: null,
+        deliveryId:
+          providerKind === "smartling" && expected.providerEventId === "smartling-delivery-1"
+            ? "smartling-delivery-1"
+            : null,
         eventType: expected.eventType,
         resourceType: null,
         resourceId: expected.resourceId,
@@ -216,6 +242,67 @@ describe("tms provider webhook adapters", () => {
     });
 
     expect(descriptor?.mappedIntents).toEqual([]);
+  });
+
+  it("verifies Smartling Event-Signature headers using the raw body", async () => {
+    const payload = {
+      type: "file.published",
+      file: { fileUri: "/locales/en.json" },
+      project: { projectUid: "smartling-project-1" },
+    };
+    const body = JSON.stringify(payload);
+    const eventId = "evt-smartling-1";
+    const eventTimestamp = "1710000000";
+    const signedPayload = `${eventId}.${eventTimestamp}.${body}`;
+    const signature = createHmac("sha256", "webhook-signing-secret")
+      .update(signedPayload)
+      .digest("hex");
+    const adapter = tmsProviderWebhookAdapters.smartling;
+    const descriptor = extract({
+      providerKind: "smartling",
+      payload,
+      headers: {
+        "event-id": eventId,
+        "event-timestamp": eventTimestamp,
+        "event-signature": signature,
+      },
+    });
+
+    expect(descriptor).not.toBeNull();
+
+    await expect(
+      Promise.resolve(
+        adapter.verify({
+          providerKind: "smartling",
+          headers: new Headers({
+            "event-id": eventId,
+            "event-timestamp": eventTimestamp,
+            "event-signature": signature,
+          }),
+          rawBody: body,
+          payload,
+          webhookSecret: "webhook-signing-secret",
+          descriptor: descriptor!,
+        }),
+      ),
+    ).resolves.toBe(true);
+
+    await expect(
+      Promise.resolve(
+        adapter.verify({
+          providerKind: "smartling",
+          headers: new Headers({
+            "event-id": eventId,
+            "event-timestamp": eventTimestamp,
+            "event-signature": "deadbeef",
+          }),
+          rawBody: body,
+          payload,
+          webhookSecret: "webhook-signing-secret",
+          descriptor: descriptor!,
+        }),
+      ),
+    ).resolves.toBe(false);
   });
 
   it("verifies Crowdin configured secret headers and body signatures", async () => {

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-webhook-adapters.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-webhook-adapters.test.ts
@@ -252,7 +252,7 @@ describe("tms provider webhook adapters", () => {
     };
     const body = JSON.stringify(payload);
     const eventId = "evt-smartling-1";
-    const eventTimestamp = "1710000000";
+    const eventTimestamp = String(Math.floor(Date.now() / 1000));
     const signedPayload = `${eventId}.${eventTimestamp}.${body}`;
     const signature = createHmac("sha256", "webhook-signing-secret")
       .update(signedPayload)
@@ -300,6 +300,39 @@ describe("tms provider webhook adapters", () => {
           payload,
           webhookSecret: "webhook-signing-secret",
           descriptor: descriptor!,
+        }),
+      ),
+    ).resolves.toBe(false);
+  });
+
+  it("rejects stale Smartling event timestamps before verifying signatures", async () => {
+    const payload = {
+      type: "file.published",
+      file: { fileUri: "/locales/en.json" },
+      project: { projectUid: "smartling-project-1" },
+    };
+    const body = JSON.stringify(payload);
+    const eventId = "evt-smartling-stale";
+    const eventTimestamp = String(Math.floor(Date.now() / 1000) - 301);
+    const signedPayload = `${eventId}.${eventTimestamp}.${body}`;
+    const signature = createHmac("sha256", "webhook-signing-secret")
+      .update(signedPayload)
+      .digest("hex");
+    const adapter = tmsProviderWebhookAdapters.smartling;
+
+    await expect(
+      Promise.resolve(
+        adapter.verify({
+          providerKind: "smartling",
+          headers: new Headers({
+            "event-id": eventId,
+            "event-timestamp": eventTimestamp,
+            "event-signature": signature,
+          }),
+          rawBody: body,
+          payload,
+          webhookSecret: "webhook-signing-secret",
+          descriptor: extract({ providerKind: "smartling", payload })!,
         }),
       ),
     ).resolves.toBe(false);

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-webhook-adapters.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-webhook-adapters.ts
@@ -136,6 +136,18 @@ function verifyHmacSha256(input: { rawBody: string; webhookSecret: string; signa
   }
 }
 
+const SMARTLING_WEBHOOK_TIMESTAMP_TOLERANCE_SECONDS = 300;
+
+function isSmartlingEventTimestampFresh(eventTimestamp: string) {
+  const requestTime = Number.parseInt(eventTimestamp, 10);
+  if (!Number.isFinite(requestTime)) {
+    return false;
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  return Math.abs(now - requestTime) <= SMARTLING_WEBHOOK_TIMESTAMP_TOLERANCE_SECONDS;
+}
+
 function verifyHmacSha256Hex(input: { payload: string; webhookSecret: string; signature: string }) {
   const expected = createHmac("sha256", input.webhookSecret).update(input.payload).digest("hex");
 
@@ -173,6 +185,10 @@ export function verifySmartlingWebhook(input: TmsProviderWebhookVerificationInpu
   const eventSignature = input.headers.get("event-signature");
 
   if (eventId && eventTimestamp && eventSignature) {
+    if (!isSmartlingEventTimestampFresh(eventTimestamp)) {
+      return false;
+    }
+
     const signedPayload = `${eventId}.${eventTimestamp}.${input.rawBody}`;
     const signatures = eventSignature.trim().split(/\s+/);
 

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-webhook-adapters.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-webhook-adapters.ts
@@ -136,6 +136,20 @@ function verifyHmacSha256(input: { rawBody: string; webhookSecret: string; signa
   }
 }
 
+function verifyHmacSha256Hex(input: { payload: string; webhookSecret: string; signature: string }) {
+  const expected = createHmac("sha256", input.webhookSecret).update(input.payload).digest("hex");
+
+  if (input.signature.length !== expected.length) {
+    return false;
+  }
+
+  try {
+    return timingSafeEqual(Buffer.from(input.signature, "hex"), Buffer.from(expected, "hex"));
+  } catch {
+    return false;
+  }
+}
+
 function defaultVerify({ headers, rawBody, webhookSecret }: TmsProviderWebhookVerificationInput) {
   if (!webhookSecret) {
     return true;
@@ -147,6 +161,31 @@ function defaultVerify({ headers, rawBody, webhookSecret }: TmsProviderWebhookVe
   }
 
   return verifyHmacSha256({ rawBody, webhookSecret, signature });
+}
+
+export function verifySmartlingWebhook(input: TmsProviderWebhookVerificationInput) {
+  if (!input.webhookSecret) {
+    return true;
+  }
+
+  const eventId = input.headers.get("event-id");
+  const eventTimestamp = input.headers.get("event-timestamp");
+  const eventSignature = input.headers.get("event-signature");
+
+  if (eventId && eventTimestamp && eventSignature) {
+    const signedPayload = `${eventId}.${eventTimestamp}.${input.rawBody}`;
+    const signatures = eventSignature.trim().split(/\s+/);
+
+    return signatures.some((signature) =>
+      verifyHmacSha256Hex({
+        payload: signedPayload,
+        webhookSecret: input.webhookSecret!,
+        signature,
+      }),
+    );
+  }
+
+  return verifyCrowdinWebhook(input);
 }
 
 function verifyCrowdinWebhook(input: TmsProviderWebhookVerificationInput) {
@@ -206,7 +245,9 @@ function baseRedactedPayload(descriptor: TmsProviderWebhookDescriptor) {
 
 export type ProviderWebhookAdapterConfig = {
   subscriptionIdPaths?: readonly (readonly string[])[];
+  eventIdHeaders?: readonly string[];
   eventIdPaths?: readonly (readonly string[])[];
+  deliveryIdHeaders?: readonly string[];
   deliveryIdPaths?: readonly (readonly string[])[];
   eventTypePaths?: readonly (readonly string[])[];
   resourceTypePaths?: readonly (readonly string[])[];
@@ -249,6 +290,7 @@ export function createProviderWebhookAdapter(
     },
     extractProviderEventId({ headers, payload }) {
       return firstString(
+        ...(config.eventIdHeaders ?? []).map((headerName) => headers.get(headerName)),
         headers.get("x-hyperlocalise-provider-event-id"),
         headers.get("x-provider-event-id"),
         headers.get("x-webhook-event-id"),
@@ -300,6 +342,7 @@ export function createProviderWebhookAdapter(
       }
 
       const deliveryId = firstString(
+        ...(config.deliveryIdHeaders ?? []).map((headerName) => input.headers.get(headerName)),
         input.headers.get("x-hyperlocalise-delivery-id"),
         input.headers.get("x-provider-delivery-id"),
         input.headers.get("x-delivery-id"),
@@ -443,12 +486,37 @@ export const phraseWebhookAdapter = createProviderWebhookAdapter({
 });
 
 export const smartlingWebhookAdapter = createProviderWebhookAdapter({
-  eventTypePaths: [["eventType"], ["event_type"], ["event"], ["type"]],
+  subscriptionIdPaths: [["subscriptionUid"], ["subscription", "subscriptionUid"]],
+  eventIdHeaders: ["event-id"],
+  deliveryIdHeaders: ["event-id"],
+  eventTypePaths: [["type"], ["eventType"], ["event_type"], ["event"]],
   eventIdPaths: [["eventId"], ["event_id"], ["id"]],
-  resourceTypePaths: [["resource_type"], ["resourceType"], ["entityType"]],
-  resourceIdPaths: [["resource_id"], ["fileUri"], ["file", "uri"], ["jobUid"], ["job", "uid"]],
-  externalResourceIdPaths: [["external_resource_id"], ["projectId"], ["project", "id"]],
+  resourceTypePaths: [
+    ["resource_type"],
+    ["resourceType"],
+    ["entityType"],
+    ["file", "type"],
+    ["job", "type"],
+  ],
+  resourceIdPaths: [
+    ["resource_id"],
+    ["fileUri"],
+    ["file", "fileUri"],
+    ["file", "uri"],
+    ["translationJobUid"],
+    ["jobUid"],
+    ["job", "uid"],
+    ["job", "translationJobUid"],
+  ],
+  externalResourceIdPaths: [
+    ["external_resource_id"],
+    ["projectId"],
+    ["projectUid"],
+    ["project", "projectUid"],
+    ["project", "id"],
+  ],
   mapEvent: genericTmsEventMapping,
+  verify: verifySmartlingWebhook,
 });
 
 export const lokaliseWebhookAdapter = createProviderWebhookAdapter({


### PR DESCRIPTION
Automate Smartling webhook setup via the Webhooks API, verify Event-Signature deliveries, and map webhook events into the shared TMS reconciliation pipeline.

## What changed

<!-- Describe the change and why it is needed. -->

## How to test

<!-- List manual checks or commands used to verify this change. -->

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review
