### PR TITLE
feat(lokalise): implement webhook setup and reconciliation mapping

### DIFF
--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-api.ts
@@ -142,6 +142,38 @@ export interface LokaliseComment {
   addedAtTimestamp: number | null;
 }
 
+export type LokaliseWebhookEvent =
+  | "project.branch.added"
+  | "project.branch.deleted"
+  | "project.branch.merged"
+  | "project.imported"
+  | "project.exported"
+  | "project.key.added"
+  | "project.key.modified"
+  | "project.keys.deleted"
+  | "project.languages.added"
+  | "project.language.settings_changed"
+  | "project.task.created"
+  | "project.task.closed"
+  | "project.task.deleted"
+  | "project.task.language.closed"
+  | "project.translation.updated"
+  | "project.translation.proofread";
+
+export interface LokaliseWebhook {
+  webhookId: string;
+  url: string;
+  branch: string | null;
+  secret: string;
+  events: string[];
+}
+
+export interface LokaliseWebhookRequest {
+  url: string;
+  events: string[];
+  branch?: string | null;
+}
+
 export interface LokaliseKey {
   keyId: number;
   keyName: LokalisePlatformStrings;
@@ -525,6 +557,79 @@ export class LokaliseApiClient {
     return (response.comments ?? []).map(normalizeLokaliseComment);
   }
 
+  async listWebhooks(projectId: string): Promise<LokaliseWebhook[]> {
+    const response = await this.get<LokaliseWebhooksListResponse>(
+      `/projects/${encodeURIComponent(projectId)}/webhooks`,
+    );
+    return (response.webhooks ?? []).map(normalizeLokaliseWebhook);
+  }
+
+  async createWebhook(projectId: string, input: LokaliseWebhookRequest): Promise<LokaliseWebhook> {
+    const response = await this.post<LokaliseWebhookCreateResponse>(
+      `/projects/${encodeURIComponent(projectId)}/webhooks`,
+      {
+        url: input.url,
+        events: input.events,
+        ...(input.branch != null ? { branch: input.branch } : {}),
+      },
+    );
+    if (!response.webhook) {
+      throw new LokaliseApiError(
+        `Lokalise webhook create for project ${projectId} did not return a webhook`,
+        502,
+        response,
+      );
+    }
+
+    return normalizeLokaliseWebhook(response.webhook);
+  }
+
+  async updateWebhook(
+    projectId: string,
+    webhookId: string,
+    input: LokaliseWebhookRequest,
+  ): Promise<LokaliseWebhook> {
+    const response = await this.put<LokaliseWebhookUpdateResponse>(
+      `/projects/${encodeURIComponent(projectId)}/webhooks/${encodeURIComponent(webhookId)}`,
+      {
+        url: input.url,
+        events: input.events,
+        ...(input.branch != null ? { branch: input.branch } : {}),
+      },
+    );
+    if (!response.webhook) {
+      throw new LokaliseApiError(
+        `Lokalise webhook update for project ${projectId} did not return a webhook`,
+        502,
+        response,
+      );
+    }
+
+    return normalizeLokaliseWebhook(response.webhook);
+  }
+
+  async deleteWebhook(projectId: string, webhookId: string): Promise<void> {
+    await this.delete(
+      `/projects/${encodeURIComponent(projectId)}/webhooks/${encodeURIComponent(webhookId)}`,
+    );
+  }
+
+  async regenerateWebhookSecret(projectId: string, webhookId: string): Promise<LokaliseWebhook> {
+    const response = await this.patch<LokaliseWebhookRegenerateSecretResponse>(
+      `/projects/${encodeURIComponent(projectId)}/webhooks/${encodeURIComponent(webhookId)}/secret/regenerate`,
+      {},
+    );
+    if (!response.webhook) {
+      throw new LokaliseApiError(
+        `Lokalise webhook secret regenerate for project ${projectId} did not return a webhook`,
+        502,
+        response,
+      );
+    }
+
+    return normalizeLokaliseWebhook(response.webhook);
+  }
+
   private authHeaders(): Record<string, string> {
     return {
       "X-Api-Token": this.token,
@@ -595,6 +700,64 @@ export class LokaliseApiClient {
     });
     return body;
   }
+
+  private async patch<T>(path: string, payload: unknown): Promise<T> {
+    const { body } = await this.request<T>(path, {
+      method: "PATCH",
+      headers: {
+        ...this.authHeaders(),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+    return body;
+  }
+
+  private async delete(path: string): Promise<void> {
+    await this.request<Record<string, never>>(path, {
+      method: "DELETE",
+      headers: this.authHeaders(),
+    });
+  }
+}
+
+type LokaliseWebhookApiRecord = {
+  webhook_id?: string;
+  url?: string;
+  branch?: string | null;
+  secret?: string;
+  events?: string[];
+};
+
+type LokaliseWebhooksListResponse = {
+  webhooks?: LokaliseWebhookApiRecord[];
+};
+
+type LokaliseWebhookCreateResponse = {
+  webhook?: LokaliseWebhookApiRecord;
+};
+
+type LokaliseWebhookUpdateResponse = {
+  webhook?: LokaliseWebhookApiRecord;
+};
+
+type LokaliseWebhookRegenerateSecretResponse = {
+  webhook?: LokaliseWebhookApiRecord;
+};
+
+function normalizeLokaliseWebhook(record: LokaliseWebhookApiRecord): LokaliseWebhook {
+  const webhookId = record.webhook_id?.trim() ?? "";
+  if (!webhookId) {
+    throw new LokaliseApiError("Lokalise webhook response is missing webhook_id", 502, record);
+  }
+
+  return {
+    webhookId,
+    url: record.url?.trim() ?? "",
+    branch: record.branch ?? null,
+    secret: record.secret?.trim() ?? "",
+    events: record.events ?? [],
+  };
 }
 
 type LokaliseGlossaryTermTranslationApiRecord = {

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-webhook-subscription-adapter.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-webhook-subscription-adapter.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { createLokaliseWebhookSubscriptionAdapter } from "./lokalise-webhook-subscription-adapter";
+
+describe("createLokaliseWebhookSubscriptionAdapter", () => {
+  function createFetchMock(input: { status?: number } = {}) {
+    return vi.fn(async (url, init) => {
+      const target = String(url);
+
+      if (input.status) {
+        return new Response(JSON.stringify({ error: { message: "forbidden" } }), {
+          status: input.status,
+        });
+      }
+
+      if (target.includes("/webhooks") && (init?.method ?? "GET") === "GET") {
+        return new Response(
+          JSON.stringify({
+            webhooks: [
+              {
+                webhook_id: "wh-1",
+                url: "https://app.example.com/api/webhooks/tms/lokalise",
+                secret: "remote-secret",
+                events: ["project.key.added"],
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (target.includes("/webhooks") && init?.method === "POST") {
+        const body =
+          typeof init.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : {};
+        return new Response(
+          JSON.stringify({
+            webhook: {
+              webhook_id: "wh-created",
+              url: body.url,
+              secret: "provider-generated-secret",
+              events: body.events,
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (target.includes("/webhooks/wh-1") && init?.method === "PUT") {
+        const body =
+          typeof init.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : {};
+        return new Response(
+          JSON.stringify({
+            webhook: {
+              webhook_id: "wh-1",
+              url: body.url,
+              secret: "remote-secret",
+              events: body.events,
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (target.includes("/webhooks/") && init?.method === "DELETE") {
+        return new Response(JSON.stringify({ webhook_deleted: true }), { status: 200 });
+      }
+
+      return new Response(JSON.stringify({}), { status: 404 });
+    });
+  }
+
+  const context = {
+    organizationId: "org-1",
+    providerCredentialId: "cred-1",
+    providerKind: "lokalise" as const,
+    projectId: "project-1",
+    externalProjectId: "lokalise-project-1",
+    secretMaterial: "api-token",
+    baseUrl: null,
+    region: null,
+    endpointUrl: "https://app.example.com/api/webhooks/tms/lokalise",
+    webhookSecret: "generated-secret",
+    subscribedEvents: ["project.key.added", "project.task.created"],
+  };
+
+  it("creates remote webhooks and returns the provider-generated secret", async () => {
+    const adapter = createLokaliseWebhookSubscriptionAdapter();
+    const remote = await adapter.createRemoteSubscription({
+      ...context,
+      fetchFn: createFetchMock(),
+    });
+
+    expect(remote).toEqual({
+      providerWebhookId: "wh-created",
+      endpointUrl: context.endpointUrl,
+      subscribedEvents: context.subscribedEvents,
+      isActive: true,
+      secret: "provider-generated-secret",
+    });
+  });
+
+  it("maps permission errors to permission_denied", async () => {
+    const adapter = createLokaliseWebhookSubscriptionAdapter();
+
+    await expect(
+      adapter.createRemoteSubscription({
+        ...context,
+        fetchFn: createFetchMock({ status: 403 }),
+      }),
+    ).rejects.toMatchObject({
+      code: "permission_denied",
+    });
+  });
+
+  it("requires a Lokalise project id for setup", async () => {
+    const adapter = createLokaliseWebhookSubscriptionAdapter();
+
+    await expect(
+      adapter.createRemoteSubscription({
+        ...context,
+        externalProjectId: null,
+        fetchFn: createFetchMock(),
+      }),
+    ).rejects.toMatchObject({
+      code: "invalid_configuration",
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-webhook-subscription-adapter.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/lokalise/lokalise-webhook-subscription-adapter.ts
@@ -1,0 +1,167 @@
+import { LokaliseApiClient, LokaliseApiError, type LokaliseWebhookEvent } from "./lokalise-api";
+import {
+  ProviderWebhookSubscriptionAdapterError,
+  type ProviderWebhookRemoteSubscription,
+  type ProviderWebhookSubscriptionAdapter,
+  type ProviderWebhookSubscriptionAdapterContext,
+} from "../provider-webhook-subscription-types";
+
+function parseLokaliseProjectId(externalProjectId: string | null) {
+  if (!externalProjectId?.trim()) {
+    throw new ProviderWebhookSubscriptionAdapterError(
+      "invalid_configuration",
+      "Lokalise project id is required for webhook setup",
+    );
+  }
+
+  return externalProjectId.trim();
+}
+
+function createLokaliseClient(context: ProviderWebhookSubscriptionAdapterContext) {
+  return new LokaliseApiClient({
+    token: context.secretMaterial,
+    baseUrl: context.baseUrl ?? undefined,
+    fetchFn: context.fetchFn,
+  });
+}
+
+function mapLokaliseWebhook(webhook: {
+  webhookId: string;
+  url: string;
+  events: string[];
+  secret: string;
+}): ProviderWebhookRemoteSubscription {
+  return {
+    providerWebhookId: webhook.webhookId,
+    endpointUrl: webhook.url,
+    subscribedEvents: webhook.events,
+    isActive: true,
+    secret: webhook.secret,
+  };
+}
+
+function buildCreateRequest(context: ProviderWebhookSubscriptionAdapterContext) {
+  return {
+    url: context.endpointUrl,
+    events: context.subscribedEvents as LokaliseWebhookEvent[],
+  };
+}
+
+function mapLokaliseError(
+  error: unknown,
+  options?: { providerWebhookId?: string },
+): ProviderWebhookSubscriptionAdapterError {
+  if (error instanceof ProviderWebhookSubscriptionAdapterError) {
+    if (options?.providerWebhookId && !error.providerWebhookId) {
+      return new ProviderWebhookSubscriptionAdapterError(error.code, error.message, {
+        httpStatus: error.httpStatus,
+        cause: error.cause,
+        providerWebhookId: options.providerWebhookId,
+      });
+    }
+
+    return error;
+  }
+
+  if (error instanceof LokaliseApiError) {
+    const code =
+      error.status === 401 || error.status === 403 ? "permission_denied" : "provider_error";
+    return new ProviderWebhookSubscriptionAdapterError(
+      code,
+      `Lokalise webhook API returned HTTP ${error.status}`,
+      {
+        httpStatus: error.status,
+        cause: error,
+        providerWebhookId: options?.providerWebhookId,
+      },
+    );
+  }
+
+  return new ProviderWebhookSubscriptionAdapterError(
+    "provider_error",
+    error instanceof Error ? error.message : "Lokalise webhook setup failed",
+    { cause: error, providerWebhookId: options?.providerWebhookId },
+  );
+}
+
+export function createLokaliseWebhookSubscriptionAdapter(): ProviderWebhookSubscriptionAdapter {
+  return {
+    supportsAutomaticSetup: true,
+
+    async listRemoteSubscriptions(context) {
+      try {
+        const projectId = parseLokaliseProjectId(context.externalProjectId);
+        const client = createLokaliseClient(context);
+        const webhooks = await client.listWebhooks(projectId);
+        return webhooks.map(mapLokaliseWebhook);
+      } catch (error) {
+        throw mapLokaliseError(error);
+      }
+    },
+
+    async createRemoteSubscription(context) {
+      const projectId = parseLokaliseProjectId(context.externalProjectId);
+      const client = createLokaliseClient(context);
+
+      try {
+        const created = await client.createWebhook(projectId, buildCreateRequest(context));
+        return mapLokaliseWebhook(created);
+      } catch (error) {
+        throw mapLokaliseError(error);
+      }
+    },
+
+    async updateRemoteSubscription(context) {
+      try {
+        const projectId = parseLokaliseProjectId(context.externalProjectId);
+        const webhookId = context.providerWebhookId.trim();
+        if (!webhookId) {
+          throw new ProviderWebhookSubscriptionAdapterError(
+            "invalid_configuration",
+            "Lokalise webhook id is required for webhook updates",
+          );
+        }
+
+        const client = createLokaliseClient(context);
+        const updated = await client.updateWebhook(
+          projectId,
+          webhookId,
+          buildCreateRequest(context),
+        );
+        return mapLokaliseWebhook(updated);
+      } catch (error) {
+        throw mapLokaliseError(error, { providerWebhookId: context.providerWebhookId });
+      }
+    },
+
+    async disableRemoteSubscription(context) {
+      try {
+        const projectId = parseLokaliseProjectId(context.externalProjectId);
+        const webhookId = context.providerWebhookId.trim();
+        if (!webhookId) {
+          return;
+        }
+
+        const client = createLokaliseClient(context);
+        await client.deleteWebhook(projectId, webhookId);
+      } catch (error) {
+        throw mapLokaliseError(error);
+      }
+    },
+
+    async deleteRemoteSubscription(context) {
+      try {
+        const projectId = parseLokaliseProjectId(context.externalProjectId);
+        const webhookId = context.providerWebhookId.trim();
+        if (!webhookId) {
+          return;
+        }
+
+        const client = createLokaliseClient(context);
+        await client.deleteWebhook(projectId, webhookId);
+      } catch (error) {
+        throw mapLokaliseError(error);
+      }
+    },
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/providers/provider-webhook-default-events.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-webhook-default-events.ts
@@ -32,6 +32,27 @@ export function listDefaultWebhookEvents(providerKind: ExternalTmsProviderKind) 
     ];
   }
 
+  if (providerKind === "lokalise") {
+    return [
+      "project.key.added",
+      "project.key.modified",
+      "project.keys.deleted",
+      "project.translation.updated",
+      "project.translation.proofread",
+      "project.task.created",
+      "project.task.closed",
+      "project.task.deleted",
+      "project.task.language.closed",
+      "project.imported",
+      "project.exported",
+      "project.languages.added",
+      "project.language.settings_changed",
+      "project.branch.added",
+      "project.branch.deleted",
+      "project.branch.merged",
+    ];
+  }
+
   if (providerKind === "smartling") {
     return [
       "file.uploaded",

--- a/apps/hyperlocalise-web/src/lib/providers/provider-webhook-subscription-adapters.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-webhook-subscription-adapters.ts
@@ -1,11 +1,13 @@
 import type { ExternalTmsProviderKind } from "./organization-external-tms-provider-credentials";
 import { createCrowdinWebhookSubscriptionAdapter } from "./crowdin/crowdin-webhook-subscription-adapter";
+import { createLokaliseWebhookSubscriptionAdapter } from "./lokalise/lokalise-webhook-subscription-adapter";
 import { createSmartlingWebhookSubscriptionAdapter } from "./smartling/smartling-webhook-subscription-adapter";
 import { createManualProviderWebhookSubscriptionAdapter } from "./manual-provider-webhook-subscription-adapter";
 import type { ProviderWebhookSubscriptionAdapter } from "./provider-webhook-subscription-types";
 
 const crowdinAdapter = createCrowdinWebhookSubscriptionAdapter();
 const smartlingAdapter = createSmartlingWebhookSubscriptionAdapter();
+const lokaliseAdapter = createLokaliseWebhookSubscriptionAdapter();
 const manualAdapter = createManualProviderWebhookSubscriptionAdapter();
 
 /**
@@ -21,6 +23,10 @@ export function getProviderWebhookSubscriptionAdapter(
 
   if (providerKind === "smartling") {
     return smartlingAdapter;
+  }
+
+  if (providerKind === "lokalise") {
+    return lokaliseAdapter;
   }
 
   return manualAdapter;

--- a/apps/hyperlocalise-web/src/lib/providers/provider-webhook-subscription-manager.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-webhook-subscription-manager.ts
@@ -92,6 +92,17 @@ function buildManualFallback(input: {
   subscribedEvents: string[];
   lastError?: string;
 }): ProviderWebhookManualFallback {
+  if (input.providerKind === "lokalise") {
+    return {
+      webhookUrl: input.endpointUrl,
+      secretHeaderName: "X-Secret",
+      secretInstructions:
+        "Lokalise sends the webhook secret in the X-Secret header. Copy the secret from the Lokalise webhook settings after creating the webhook.",
+      subscribedEvents: input.subscribedEvents,
+      ...(input.lastError ? { lastError: input.lastError } : {}),
+    };
+  }
+
   return {
     webhookUrl: input.endpointUrl,
     secretHeaderName: "X-Hyperlocalise-Signature-256",
@@ -331,6 +342,8 @@ export async function ensureProviderWebhookSubscription(input: {
           })
         : await adapter.createRemoteSubscription(adapterContext);
 
+    const storedWebhookSecret = remote.secret?.trim() || webhookSecret;
+
     subscription = await updateProviderWebhookSubscription({
       subscriptionId: subscription.id,
       organizationId: input.organizationId,
@@ -340,9 +353,9 @@ export async function ensureProviderWebhookSubscription(input: {
       subscribedEvents: remote.subscribedEvents,
       manualFallback: emptyManualFallback,
       lastError: null,
-      webhookSecretPlaintext: webhookSecret,
+      webhookSecretPlaintext: storedWebhookSecret,
       secretMetadata: {
-        maskedSecretSuffix: maskProviderCredentialSuffix(webhookSecret),
+        maskedSecretSuffix: maskProviderCredentialSuffix(storedWebhookSecret),
       },
     });
   } catch (error) {
@@ -372,6 +385,8 @@ export async function ensureProviderWebhookSubscription(input: {
       lastError: message,
     });
 
+    const storedWebhookSecret = webhookSecret;
+
     subscription = await updateProviderWebhookSubscription({
       subscriptionId: subscription.id,
       organizationId: input.organizationId,
@@ -380,9 +395,9 @@ export async function ensureProviderWebhookSubscription(input: {
       manualFallback,
       lastError: message,
       subscribedEvents,
-      webhookSecretPlaintext: webhookSecret,
+      webhookSecretPlaintext: storedWebhookSecret,
       secretMetadata: {
-        maskedSecretSuffix: maskProviderCredentialSuffix(webhookSecret),
+        maskedSecretSuffix: maskProviderCredentialSuffix(storedWebhookSecret),
       },
     });
   }

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-webhook-adapters.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-webhook-adapters.test.ts
@@ -119,7 +119,23 @@ describe("tms provider webhook adapters", () => {
         eventType: "project.translation.updated",
         resourceId: "789",
         externalResourceId: "lokalise-project-1",
-        mappedIntentKinds: ["project_scan"],
+        mappedIntentKinds: ["file_key_scan"],
+      },
+    },
+    {
+      providerKind: "lokalise",
+      payload: {
+        uuid: "lokalise-task-1",
+        event: "project.task.closed",
+        task: { id: 42 },
+        project: { id: "lokalise-project-1" },
+      },
+      expected: {
+        providerEventId: "lokalise-task-1",
+        eventType: "project.task.closed",
+        resourceId: "42",
+        externalResourceId: "lokalise-project-1",
+        mappedIntentKinds: ["job_task_scan"],
       },
     },
   ])(
@@ -384,6 +400,81 @@ describe("tms provider webhook adapters", () => {
         }),
       ),
     ).resolves.toBe(false);
+  });
+
+  it("verifies Lokalise X-Secret headers", async () => {
+    const payload = {
+      uuid: "evt-lokalise-1",
+      event: "project.key.added",
+      key: { id: 1 },
+    };
+    const body = JSON.stringify(payload);
+    const adapter = tmsProviderWebhookAdapters.lokalise;
+    const descriptor = extract({ providerKind: "lokalise", payload });
+
+    expect(descriptor).not.toBeNull();
+
+    await expect(
+      Promise.resolve(
+        adapter.verify({
+          providerKind: "lokalise",
+          headers: new Headers({ "x-secret": "webhook-signing-secret" }),
+          rawBody: body,
+          payload,
+          webhookSecret: "webhook-signing-secret",
+          descriptor: descriptor!,
+        }),
+      ),
+    ).resolves.toBe(true);
+
+    await expect(
+      Promise.resolve(
+        adapter.verify({
+          providerKind: "lokalise",
+          headers: new Headers({ "x-secret": "wrong-secret" }),
+          rawBody: body,
+          payload,
+          webhookSecret: "webhook-signing-secret",
+          descriptor: descriptor!,
+        }),
+      ),
+    ).resolves.toBe(false);
+  });
+
+  it("extracts Lokalise ping payloads from Webhook-Id headers", () => {
+    const descriptor = tmsProviderWebhookAdapters.lokalise.extract({
+      providerKind: "lokalise",
+      headers: new Headers({
+        "webhook-id": "wh-ping",
+        "project-id": "lokalise-project-1",
+        "x-secret": "secret",
+      }),
+      payload: ["ping"] as unknown as ProviderWebhookPayload,
+    });
+
+    expect(descriptor).toMatchObject({
+      providerWebhookId: "wh-ping",
+      providerEventId: "ping:wh-ping",
+      eventType: "ping",
+      externalResourceId: "lokalise-project-1",
+      mappedIntents: [],
+    });
+  });
+
+  it("maps Lokalise proofread events to file and content reconciliation", () => {
+    const descriptor = extract({
+      providerKind: "lokalise",
+      payload: {
+        uuid: "evt-proofread",
+        event: "project.translation.proofread",
+        key: { id: 99 },
+      },
+    });
+
+    expect(descriptor?.mappedIntents.map((intent) => intent.kind)).toEqual([
+      "file_key_scan",
+      "pull_content",
+    ]);
   });
 
   it("default verification rejects echoed secrets without body signatures", async () => {

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-webhook-adapters.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-webhook-adapters.ts
@@ -204,6 +204,19 @@ export function verifySmartlingWebhook(input: TmsProviderWebhookVerificationInpu
   return verifyCrowdinWebhook(input);
 }
 
+export function verifyLokaliseWebhook(input: TmsProviderWebhookVerificationInput) {
+  if (!input.webhookSecret) {
+    return true;
+  }
+
+  const secret = input.headers.get("x-secret");
+  if (!secret) {
+    return false;
+  }
+
+  return constantTimeEqual(secret, input.webhookSecret);
+}
+
 function verifyCrowdinWebhook(input: TmsProviderWebhookVerificationInput) {
   if (!input.webhookSecret) {
     return true;
@@ -482,6 +495,154 @@ function genericTmsEventMapping(input: {
   return [];
 }
 
+function mapLokaliseEvent(input: {
+  eventType: string;
+  resourceType: string | null;
+  resourceId: string | null;
+}) {
+  const eventType = input.eventType.toLowerCase();
+  const resourceId = input.resourceId;
+
+  if (eventType === "ping") {
+    return [];
+  }
+
+  if (
+    includesAny(eventType, ["write_back", "writeback"]) ||
+    (eventType.includes("translation") && eventType.includes("push"))
+  ) {
+    return [postWriteBackConfirmation(resourceId)];
+  }
+
+  if (
+    includesAny(eventType, ["project.key.added", "project.key.modified", "project.keys.deleted"])
+  ) {
+    return [fileKeyScan(resourceId)];
+  }
+
+  if (includesAny(eventType, ["project.translation.updated", "project.translation.proofread"])) {
+    const intents: TmsWebhookMappedIntent[] = [fileKeyScan(resourceId)];
+    if (eventType.includes("proofread")) {
+      intents.push(pullContent(resourceId));
+    }
+    return intents;
+  }
+
+  if (
+    includesAny(eventType, [
+      "project.task.created",
+      "project.task.closed",
+      "project.task.deleted",
+      "project.task.language.closed",
+    ])
+  ) {
+    return [jobTaskScan(resourceId)];
+  }
+
+  if (
+    includesAny(eventType, [
+      "project.imported",
+      "project.exported",
+      "project.languages.added",
+      "project.language.settings_changed",
+      "project.branch.added",
+      "project.branch.deleted",
+      "project.branch.merged",
+    ])
+  ) {
+    return [projectScan(resourceId)];
+  }
+
+  return genericTmsEventMapping(input);
+}
+
+function isLokalisePingPayload(payload: ProviderWebhookPayload) {
+  return Array.isArray(payload) && payload.length === 1 && payload[0] === "ping";
+}
+
+const baseLokaliseWebhookAdapter = createProviderWebhookAdapter({
+  subscriptionIdPaths: [["webhook_id"], ["webhook", "id"]],
+  eventIdHeaders: ["x-event-id"],
+  deliveryIdHeaders: ["x-event-id"],
+  eventTypePaths: [["event"], ["event_type"], ["type"]],
+  eventIdPaths: [["uuid"], ["event_id"], ["id"]],
+  resourceTypePaths: [["resource_type"], ["object_type"]],
+  resourceIdPaths: [
+    ["resource_id"],
+    ["file", "id"],
+    ["key", "id"],
+    ["task", "id"],
+    ["task", "task_id"],
+  ],
+  externalResourceIdPaths: [["external_resource_id"], ["project", "id"], ["project_id"]],
+  mapEvent: mapLokaliseEvent,
+  verify: verifyLokaliseWebhook,
+});
+
+export const lokaliseWebhookAdapter: TmsProviderWebhookAdapter = {
+  ...baseLokaliseWebhookAdapter,
+  resolveSubscription(input) {
+    const providerWebhookId = firstString(
+      input.headers.get("webhook-id"),
+      input.headers.get("x-hyperlocalise-provider-webhook-id"),
+      input.headers.get("x-provider-webhook-id"),
+      firstPathString(input.payload, [["webhook_id"], ["webhook", "id"]]),
+    );
+
+    return providerWebhookId ? { providerWebhookId } : null;
+  },
+  extractEventType(input) {
+    return firstString(
+      input.headers.get("x-event"),
+      input.headers.get("x-provider-event-type"),
+      firstPathString(input.payload, [["event"], ["event_type"], ["type"]]),
+      isLokalisePingPayload(input.payload) ? "ping" : null,
+    );
+  },
+  extractResource(input) {
+    const resource = baseLokaliseWebhookAdapter.extractResource(input);
+    const externalResourceId = firstString(
+      resource.externalResourceId,
+      input.headers.get("project-id"),
+    );
+
+    return {
+      ...resource,
+      externalResourceId,
+    };
+  },
+  extract(input) {
+    if (!isLokalisePingPayload(input.payload)) {
+      return baseLokaliseWebhookAdapter.extract(input);
+    }
+
+    const subscription = lokaliseWebhookAdapter.resolveSubscription(input);
+    if (!subscription) {
+      return null;
+    }
+
+    const providerEventId = `ping:${subscription.providerWebhookId}`;
+    const externalResourceId = firstString(input.headers.get("project-id"));
+    const descriptor: TmsProviderWebhookDescriptor = {
+      ...subscription,
+      providerEventId,
+      eventType: "ping",
+      dedupeKey: providerEventId,
+      deliveryId: null,
+      resourceType: null,
+      resourceId: null,
+      externalResourceId,
+      redactedPayload: {},
+      mappedIntents: [],
+    };
+
+    descriptor.mappedIntents = lokaliseWebhookAdapter.mapToIntents({ ...input, descriptor });
+    descriptor.redactedPayload = lokaliseWebhookAdapter.redact({ ...input, descriptor });
+
+    return descriptor;
+  },
+};
+
 export const crowdinWebhookAdapter = createProviderWebhookAdapter({
   eventTypePaths: [["event"], ["event_type"], ["type"]],
   eventIdPaths: [["event_id"], ["id"], ["uuid"]],
@@ -533,15 +694,6 @@ export const smartlingWebhookAdapter = createProviderWebhookAdapter({
   ],
   mapEvent: genericTmsEventMapping,
   verify: verifySmartlingWebhook,
-});
-
-export const lokaliseWebhookAdapter = createProviderWebhookAdapter({
-  eventTypePaths: [["event"], ["event_type"], ["type"]],
-  eventIdPaths: [["uuid"], ["event_id"], ["id"]],
-  resourceTypePaths: [["resource_type"], ["object_type"]],
-  resourceIdPaths: [["resource_id"], ["file", "id"], ["key", "id"], ["task", "id"]],
-  externalResourceIdPaths: [["external_resource_id"], ["project", "id"], ["project_id"]],
-  mapEvent: genericTmsEventMapping,
 });
 
 export const tmsProviderWebhookAdapters = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements HL-406 by adding automatic Lokalise webhook subscription management and provider-specific intake mapping for reconciliation intents.

## Changes

- **Lokalise API client**: `listWebhooks`, `createWebhook`, `updateWebhook`, `deleteWebhook`, and `regenerateWebhookSecret`
- **Subscription adapter**: project-scoped automatic setup with permission-denied fallback; stores Lokalise-generated secrets from create responses
- **Intake adapter**: verifies `X-Secret`, resolves `Webhook-Id` / `X-Event` / `Project-Id` headers, handles `["ping"]` payloads
- **Event mapping**:
  - Keys & translations → `file_key_scan` (proofread also triggers `pull_content`)
  - Tasks → `job_task_scan`
  - Import/export, language, and branch events → `project_scan`
- **Default subscribed events**: 16 Lokalise project events for new subscriptions
- **Manual fallback copy**: documents `X-Secret` for Lokalise when automatic setup is unavailable

## Testing

- `vp test src/lib/providers/lokalise/lokalise-webhook-subscription-adapter.test.ts`
- `vp test src/lib/providers/tms-provider-webhook-adapters.test.ts`
- `vp test src/lib/providers/lokalise/lokalise-api.test.ts`
- `vp check --fix`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-406](https://linear.app/hyperlocalise/issue/HL-406/implement-lokalise-webhook-setup-and-reconciliation-mapping)

<div><a href="https://cursor.com/agents/bc-82f7e6df-6ffe-4fae-94c3-5a03992f95cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-82f7e6df-6ffe-4fae-94c3-5a03992f95cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

