### PR TITLE
feat(web): Phrase webhook setup and upload-aware reconciliation (HL-405)

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/tms-webhook/tms-webhook.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/tms-webhook/tms-webhook.route.test.ts
@@ -66,8 +66,34 @@ async function createSubscriptionFixture(input: { webhookSecretPlaintext?: strin
   return { organizationId, subscription };
 }
 
+async function createPhraseSubscriptionFixture() {
+  const { organizationId, userId } = await createOrganizationUser();
+  const credential = await upsertOrganizationExternalTmsProviderCredential({
+    organizationId,
+    userId,
+    role: "owner",
+    providerKind: "phrase",
+    displayName: "Phrase",
+    secretMaterial: "secret-token",
+  });
+  const subscription = await insertProviderWebhookSubscription({
+    organizationId,
+    providerCredentialId: credential.id,
+    providerKind: "phrase",
+    providerWebhookId: "phrase-wh-1",
+    endpointUrl: "https://app.example.test/api/webhooks/tms/phrase?provider_webhook_id=phrase-wh-1",
+    webhookSecretPlaintext: "webhook-signing-secret",
+  });
+
+  return { organizationId, subscription };
+}
+
 function signatureFor(body: string, secret = "webhook-signing-secret") {
   return `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
+}
+
+function phraseSignatureFor(body: string, secret = "webhook-signing-secret") {
+  return createHmac("sha256", secret).update(body).digest("hex");
 }
 
 function postWebhook(input: {
@@ -626,5 +652,113 @@ describe("tmsWebhookRoutes", () => {
       .from(schema.providerWebhookEvents)
       .where(eq(schema.providerWebhookEvents.subscriptionId, subscription.id));
     expect(rows).toHaveLength(0);
+  });
+
+  describe("Phrase webhooks", () => {
+    function postPhraseWebhook(input: {
+      app: ReturnType<typeof createApp>;
+      body: string;
+      signature?: string | null;
+    }) {
+      const headers: Record<string, string> = {
+        "content-type": "application/json",
+        "x-phraseapp-event": "uploads:create",
+      };
+
+      if (input.signature !== null) {
+        headers["x-phraseapp-signature"] = input.signature ?? phraseSignatureFor(input.body);
+      }
+
+      return input.app.request(
+        "http://localhost/api/webhooks/tms/phrase?provider_webhook_id=phrase-wh-1",
+        {
+          method: "POST",
+          headers,
+          body: input.body,
+        },
+      );
+    }
+
+    it("accepts signed upload events and queues coarse reconciliation", async () => {
+      const { organizationId, subscription } = await createPhraseSubscriptionFixture();
+      const queuedEvents: ProviderWebhookReconciliationEventData[] = [];
+      const app = createApp({
+        providerWebhookReconciliationQueue: {
+          async enqueue(event) {
+            queuedEvents.push(event);
+            return { ids: [randomUUID()] };
+          },
+        },
+      });
+      const body = JSON.stringify({
+        event_uid: "evt-phrase-upload",
+        event: "uploads:create",
+        upload: { id: "upload-1" },
+      });
+
+      const response = await postPhraseWebhook({ app, body });
+
+      expect(response.status).toBe(202);
+      const intents = await db
+        .select()
+        .from(schema.providerSyncIntents)
+        .where(eq(schema.providerSyncIntents.organizationId, organizationId));
+      expect(intents.map((intent) => intent.syncKind).sort()).toEqual([
+        "file_key_scan",
+        "pull_content",
+      ]);
+      expect(queuedEvents).toHaveLength(2);
+      expect(queuedEvents.every((event) => event.subscriptionId === subscription.id)).toBe(true);
+    });
+
+    it("rejects Phrase deliveries with invalid signatures", async () => {
+      await createPhraseSubscriptionFixture();
+      const app = createApp();
+      const body = JSON.stringify({
+        event_uid: "evt-phrase-invalid",
+        event: "keys:create",
+      });
+
+      const response = await postPhraseWebhook({ app, body, signature: "invalid-signature" });
+
+      expect(response.status).toBe(401);
+      await expect(response.json()).resolves.toEqual({ error: "invalid_signature" });
+    });
+
+    it("dedupes repeated Phrase deliveries without queueing duplicate work", async () => {
+      const { subscription } = await createPhraseSubscriptionFixture();
+      const queuedEvents: ProviderWebhookReconciliationEventData[] = [];
+      const app = createApp({
+        providerWebhookReconciliationQueue: {
+          async enqueue(event) {
+            queuedEvents.push(event);
+            return { ids: [randomUUID()] };
+          },
+        },
+      });
+      const body = JSON.stringify({
+        event_uid: "evt-phrase-duplicate",
+        event: "uploads:create",
+        upload: { id: "upload-1" },
+      });
+
+      const first = await postPhraseWebhook({ app, body });
+      const duplicate = await postPhraseWebhook({ app, body });
+
+      expect(first.status).toBe(202);
+      expect(duplicate.status).toBe(200);
+      await expect(duplicate.json()).resolves.toEqual({
+        ok: true,
+        ignored: true,
+        duplicate: true,
+      });
+      expect(queuedEvents).toHaveLength(2);
+
+      const rows = await db
+        .select()
+        .from(schema.providerWebhookEvents)
+        .where(eq(schema.providerWebhookEvents.subscriptionId, subscription.id));
+      expect(rows).toHaveLength(1);
+    });
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/tms-webhook/tms-webhook.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/tms-webhook/tms-webhook.route.test.ts
@@ -711,6 +711,63 @@ describe("tmsWebhookRoutes", () => {
       expect(queuedEvents.every((event) => event.subscriptionId === subscription.id)).toBe(true);
     });
 
+    it("requeues only missing Phrase upload intents after partial enqueue failure", async () => {
+      const { organizationId, subscription } = await createPhraseSubscriptionFixture();
+      const queuedEvents: ProviderWebhookReconciliationEventData[] = [];
+      let enqueueAttempts = 0;
+      const app = createApp({
+        providerWebhookReconciliationQueue: {
+          async enqueue(event) {
+            enqueueAttempts += 1;
+            if (enqueueAttempts === 2) {
+              throw new Error("queue unavailable");
+            }
+
+            queuedEvents.push(event);
+            return { ids: [randomUUID()] };
+          },
+        },
+      });
+      const body = JSON.stringify({
+        event_uid: "evt-phrase-upload-partial",
+        event: "uploads:create",
+        upload: { id: "upload-1" },
+      });
+
+      const first = await postPhraseWebhook({ app, body });
+      const retry = await postPhraseWebhook({ app, body });
+
+      expect(first.status).toBe(500);
+      expect(retry.status).toBe(202);
+      await expect(retry.json()).resolves.toEqual({
+        ok: true,
+        ignored: false,
+        duplicate: true,
+      });
+
+      const queuedIntentIds = queuedEvents.map((event) => event.providerSyncIntentId);
+      const intents = await db
+        .select()
+        .from(schema.providerSyncIntents)
+        .where(inArray(schema.providerSyncIntents.id, queuedIntentIds));
+      expect(intents.map((intent) => intent.syncKind).sort()).toEqual([
+        "file_key_scan",
+        "pull_content",
+      ]);
+      expect(queuedEvents).toHaveLength(2);
+      expect(queuedEvents.every((event) => event.subscriptionId === subscription.id)).toBe(true);
+
+      const [event] = await db
+        .select()
+        .from(schema.providerWebhookEvents)
+        .where(eq(schema.providerWebhookEvents.organizationId, organizationId));
+      expect(event).toMatchObject({
+        providerEventId: "evt-phrase-upload-partial",
+        providerSyncIntentId: expect.any(String),
+        processingStatus: "pending",
+      });
+    });
+
     it("rejects Phrase deliveries with invalid signatures", async () => {
       await createPhraseSubscriptionFixture();
       const app = createApp();

--- a/apps/hyperlocalise-web/src/api/routes/tms-webhook/tms-webhook.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/tms-webhook/tms-webhook.route.ts
@@ -67,8 +67,10 @@ export function createTmsWebhookRoutes(options: CreateTmsWebhookRoutesOptions = 
     projectId?: string | null;
     descriptor: TmsProviderWebhookDescriptor;
   }) {
-    const mappedIntent = input.descriptor.mappedIntents.find(isExecutableTmsWebhookMappedIntent);
-    if (!mappedIntent) {
+    const executableIntents = input.descriptor.mappedIntents.filter(
+      isExecutableTmsWebhookMappedIntent,
+    );
+    if (executableIntents.length === 0) {
       const errorMessage =
         input.descriptor.mappedIntents.length > 0
           ? "unsupported_provider_webhook_event"
@@ -101,18 +103,25 @@ export function createTmsWebhookRoutes(options: CreateTmsWebhookRoutesOptions = 
       return null;
     }
 
-    const providerSyncIntentId = await enqueueMappedReconciliation({
+    const [firstIntent, ...remainingIntents] = executableIntents;
+    const primaryProviderSyncIntentId = await enqueueMappedReconciliation({
       ...input,
-      mappedIntent,
+      mappedIntent: firstIntent,
     });
+    for (const mappedIntent of remainingIntents) {
+      await enqueueMappedReconciliation({
+        ...input,
+        mappedIntent,
+      });
+    }
 
     await updateProviderWebhookEventSyncIntent({
       eventId: input.providerWebhookEventId,
       organizationId: input.organizationId,
-      providerSyncIntentId,
+      providerSyncIntentId: primaryProviderSyncIntentId,
     });
 
-    return providerSyncIntentId;
+    return primaryProviderSyncIntentId;
   }
 
   async function enqueueMappedReconciliation(input: {
@@ -207,6 +216,7 @@ export function createTmsWebhookRoutes(options: CreateTmsWebhookRoutesOptions = 
         providerKind: providerKindParam,
         headers: c.req.raw.headers,
         payload,
+        requestUrl: c.req.url,
       });
       if (!descriptor) {
         logger.info({ providerKind: providerKindParam }, "ignoring webhook: missing identifiers");

--- a/apps/hyperlocalise-web/src/api/routes/tms-webhook/tms-webhook.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/tms-webhook/tms-webhook.route.ts
@@ -9,7 +9,6 @@ import {
   findActiveProviderWebhookSubscription,
   insertProviderWebhookEventIdempotent,
   updateProviderWebhookEventProcessingStatus,
-  updateProviderWebhookEventSyncIntent,
 } from "@/lib/providers/provider-webhook-storage";
 import {
   getTmsProviderWebhookAdapter,
@@ -42,8 +41,44 @@ type CreateTmsWebhookRoutesOptions = {
   providerWebhookReconciliationQueue?: ProviderWebhookReconciliationQueue;
 };
 
+type EnqueuedMappedIntentRecord = {
+  key: string;
+  providerSyncIntentId: string;
+};
+
 function isExternalTmsProviderKind(value: string): value is ExternalTmsProviderKind {
   return providerKinds.has(value as ExternalTmsProviderKind);
+}
+
+function mappedIntentQueueKey(intent: TmsWebhookExecutableIntent) {
+  return JSON.stringify({
+    kind: intent.kind,
+    resourceId: intent.resourceId ?? null,
+    resourceIds: intent.resourceIds ?? [],
+  });
+}
+
+function enqueuedMappedIntentRecords(
+  errorDetails: Record<string, unknown>,
+): EnqueuedMappedIntentRecord[] {
+  const records = errorDetails.enqueuedMappedIntents;
+  if (!Array.isArray(records)) {
+    return [];
+  }
+
+  return records.filter(
+    (record): record is EnqueuedMappedIntentRecord =>
+      typeof record === "object" &&
+      record !== null &&
+      "key" in record &&
+      "providerSyncIntentId" in record &&
+      typeof record.key === "string" &&
+      typeof record.providerSyncIntentId === "string",
+  );
+}
+
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : "provider_webhook_reconciliation_enqueue_failed";
 }
 
 export function createTmsWebhookRoutes(options: CreateTmsWebhookRoutesOptions = {}) {
@@ -66,6 +101,7 @@ export function createTmsWebhookRoutes(options: CreateTmsWebhookRoutesOptions = 
     providerCredentialId: string;
     projectId?: string | null;
     descriptor: TmsProviderWebhookDescriptor;
+    enqueuedMappedIntents?: EnqueuedMappedIntentRecord[];
   }) {
     const executableIntents = input.descriptor.mappedIntents.filter(
       isExecutableTmsWebhookMappedIntent,
@@ -103,22 +139,62 @@ export function createTmsWebhookRoutes(options: CreateTmsWebhookRoutesOptions = 
       return null;
     }
 
-    const [firstIntent, ...remainingIntents] = executableIntents;
-    const primaryProviderSyncIntentId = await enqueueMappedReconciliation({
-      ...input,
-      mappedIntent: firstIntent,
-    });
-    for (const mappedIntent of remainingIntents) {
-      await enqueueMappedReconciliation({
-        ...input,
-        mappedIntent,
+    const enqueuedMappedIntents = [...(input.enqueuedMappedIntents ?? [])];
+    const enqueuedIntentByKey = new Map(
+      enqueuedMappedIntents.map((record) => [record.key, record.providerSyncIntentId]),
+    );
+    let primaryProviderSyncIntentId: string | null = null;
+
+    try {
+      for (const mappedIntent of executableIntents) {
+        const key = mappedIntentQueueKey(mappedIntent);
+        const existingIntentId = enqueuedIntentByKey.get(key);
+        if (existingIntentId) {
+          primaryProviderSyncIntentId ??= existingIntentId;
+          continue;
+        }
+
+        const providerSyncIntentId = await enqueueMappedReconciliation({
+          ...input,
+          mappedIntent,
+        });
+        primaryProviderSyncIntentId ??= providerSyncIntentId;
+
+        const record = { key, providerSyncIntentId };
+        enqueuedMappedIntents.push(record);
+        enqueuedIntentByKey.set(key, providerSyncIntentId);
+
+        await updateProviderWebhookEventProcessingStatus({
+          eventId: input.providerWebhookEventId,
+          organizationId: input.organizationId,
+          processingStatus: "pending",
+          errorDetails: { enqueuedMappedIntents },
+        });
+      }
+    } catch (error) {
+      await updateProviderWebhookEventProcessingStatus({
+        eventId: input.providerWebhookEventId,
+        organizationId: input.organizationId,
+        processingStatus: "failed",
+        errorMessage: "provider_webhook_reconciliation_enqueue_failed",
+        errorDetails: {
+          message: errorMessage(error),
+          enqueuedMappedIntents,
+        },
       });
+      throw error;
     }
 
-    await updateProviderWebhookEventSyncIntent({
+    if (!primaryProviderSyncIntentId) {
+      throw new Error("provider_webhook_reconciliation_enqueue_failed");
+    }
+
+    await updateProviderWebhookEventProcessingStatus({
       eventId: input.providerWebhookEventId,
       organizationId: input.organizationId,
+      processingStatus: "pending",
       providerSyncIntentId: primaryProviderSyncIntentId,
+      errorDetails: {},
     });
 
     return primaryProviderSyncIntentId;
@@ -271,7 +347,8 @@ export function createTmsWebhookRoutes(options: CreateTmsWebhookRoutesOptions = 
 
       if (!stored.inserted || !stored.event) {
         if (
-          stored.event?.processingStatus === "pending" &&
+          (stored.event?.processingStatus === "pending" ||
+            stored.event?.processingStatus === "failed") &&
           stored.event.providerSyncIntentId === null
         ) {
           const providerSyncIntentId = await enqueueReconciliation({
@@ -292,6 +369,7 @@ export function createTmsWebhookRoutes(options: CreateTmsWebhookRoutesOptions = 
               resourceId: stored.event.resourceId,
               externalResourceId: stored.event.externalResourceId,
             }),
+            enqueuedMappedIntents: enqueuedMappedIntentRecords(stored.event.errorDetails),
           });
 
           log.info(

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-api.ts
@@ -116,6 +116,44 @@ export type PhraseListOptions = {
   perPage?: number;
 };
 
+export type PhraseWebhookEvent =
+  | "keys:create"
+  | "keys:update"
+  | "keys:delete"
+  | "translations:create"
+  | "translations:update"
+  | "translations:review"
+  | "translations:unverify"
+  | "jobs:create"
+  | "jobs:complete"
+  | "jobs:completed"
+  | "uploads:create"
+  | "comments:create"
+  | "locales:create"
+  | "locales:update"
+  | "branches:create"
+  | "branches:merge";
+
+export interface PhraseWebhook {
+  id: string;
+  callbackUrl: string;
+  description: string | null;
+  events: string[];
+  active: boolean;
+  includeBranches: boolean;
+}
+
+export type PhraseWebhookCreateRequest = {
+  callbackUrl: string;
+  secret?: string;
+  description?: string;
+  events: readonly string[];
+  active?: boolean;
+  includeBranches?: boolean;
+};
+
+export type PhraseWebhookUpdateRequest = PhraseWebhookCreateRequest;
+
 export class PhraseApiError extends Error {
   constructor(
     message: string,
@@ -143,6 +181,56 @@ export class PhraseApiClient {
 
   get resolvedBaseUrl() {
     return this.baseUrl;
+  }
+
+  async listWebhooks(projectId: string): Promise<PhraseWebhook[]> {
+    const records = await this.get<PhraseWebhookApiRecord[]>(
+      `/projects/${encodeURIComponent(projectId)}/webhooks`,
+    );
+    return records.map(normalizePhraseWebhook);
+  }
+
+  async createWebhook(
+    projectId: string,
+    input: PhraseWebhookCreateRequest,
+  ): Promise<PhraseWebhook> {
+    const record = await this.post<PhraseWebhookApiRecord>(
+      `/projects/${encodeURIComponent(projectId)}/webhooks`,
+      {
+        callback_url: input.callbackUrl,
+        secret: input.secret,
+        description: input.description,
+        events: input.events.join(","),
+        active: input.active ?? true,
+        include_branches: input.includeBranches ?? false,
+      },
+    );
+    return normalizePhraseWebhook(record);
+  }
+
+  async updateWebhook(
+    projectId: string,
+    webhookId: string,
+    input: PhraseWebhookUpdateRequest,
+  ): Promise<PhraseWebhook> {
+    const record = await this.patch<PhraseWebhookApiRecord>(
+      `/projects/${encodeURIComponent(projectId)}/webhooks/${encodeURIComponent(webhookId)}`,
+      {
+        callback_url: input.callbackUrl,
+        secret: input.secret,
+        description: input.description,
+        events: input.events.join(","),
+        active: input.active ?? true,
+        include_branches: input.includeBranches ?? false,
+      },
+    );
+    return normalizePhraseWebhook(record);
+  }
+
+  async deleteWebhook(projectId: string, webhookId: string): Promise<void> {
+    await this.delete(
+      `/projects/${encodeURIComponent(projectId)}/webhooks/${encodeURIComponent(webhookId)}`,
+    );
   }
 
   async listProjects(): Promise<PhraseProject[]> {
@@ -470,6 +558,13 @@ export class PhraseApiClient {
     });
   }
 
+  private async delete(path: string): Promise<void> {
+    await this.request<unknown>(path, {
+      method: "DELETE",
+      headers: this.authHeaders(),
+    });
+  }
+
   private async request<T>(path: string, init: RequestInit): Promise<T> {
     const url = `${this.baseUrl}${path}`;
     const response = await this.fetchFn(url, { ...init, redirect: "error" });
@@ -596,6 +691,15 @@ type PhraseKeyCommentApiRecord = {
   locales?: PhraseLocalePreviewApiRecord[];
 };
 
+type PhraseWebhookApiRecord = {
+  id: string;
+  callback_url: string;
+  description?: string | null;
+  events?: string[] | string;
+  active?: boolean;
+  include_branches?: boolean;
+};
+
 function normalizePhraseProject(project: PhraseProjectApiRecord): PhraseProject {
   return {
     id: project.id,
@@ -694,6 +798,37 @@ function normalizePhraseLocalePreview(locale: PhraseLocalePreviewApiRecord) {
     id: locale.id,
     name: locale.name,
     code: locale.code ?? null,
+  };
+}
+
+function normalizePhraseWebhookEvents(events: string[] | string | undefined): string[] {
+  if (Array.isArray(events)) {
+    return events.map((event) => event.trim()).filter(Boolean);
+  }
+
+  if (typeof events === "string") {
+    return events
+      .split(",")
+      .map((event) => event.trim())
+      .filter(Boolean);
+  }
+
+  return [];
+}
+
+function normalizePhraseWebhook(webhook: PhraseWebhookApiRecord): PhraseWebhook {
+  const webhookId = webhook.id?.trim() ?? "";
+  if (!webhookId) {
+    throw new PhraseApiError("Phrase webhook response is missing id", 502, webhook);
+  }
+
+  return {
+    id: webhookId,
+    callbackUrl: webhook.callback_url,
+    description: webhook.description ?? null,
+    events: normalizePhraseWebhookEvents(webhook.events),
+    active: webhook.active ?? true,
+    includeBranches: webhook.include_branches ?? false,
   };
 }
 

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-webhook-subscription-adapter.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-webhook-subscription-adapter.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import {
+  appendPhraseWebhookProviderId,
+  createPhraseWebhookSubscriptionAdapter,
+} from "./phrase-webhook-subscription-adapter";
+
+describe("createPhraseWebhookSubscriptionAdapter", () => {
+  function createFetchMock(input: { status?: number } = {}) {
+    return vi.fn(async (url, init) => {
+      const target = String(url);
+
+      if (input.status) {
+        return new Response(JSON.stringify({ message: "forbidden" }), {
+          status: input.status,
+        });
+      }
+
+      if (target.includes("/webhooks") && (init?.method ?? "GET") === "GET") {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "wh-1",
+              callback_url:
+                "https://app.example.test/api/webhooks/tms/phrase?provider_webhook_id=wh-1",
+              events: "keys:create,translations:update",
+              active: true,
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      if (target.includes("/webhooks") && init?.method === "POST") {
+        const body =
+          typeof init.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : {};
+        return new Response(
+          JSON.stringify({
+            id: "wh-created",
+            callback_url: body.callback_url,
+            events: body.events,
+            active: true,
+          }),
+          { status: 201 },
+        );
+      }
+
+      if (target.includes("/webhooks/wh-created") && init?.method === "PATCH") {
+        const body =
+          typeof init.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : {};
+        return new Response(
+          JSON.stringify({
+            id: "wh-created",
+            callback_url: body.callback_url,
+            events: body.events,
+            active: true,
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (target.includes("/webhooks/wh-1") && init?.method === "PATCH") {
+        const body =
+          typeof init.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : {};
+        return new Response(
+          JSON.stringify({
+            id: "wh-1",
+            callback_url: body.callback_url,
+            events: body.events,
+            active: body.active ?? true,
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (target.includes("/webhooks/") && init?.method === "DELETE") {
+        return new Response(null, { status: 204 });
+      }
+
+      return new Response(JSON.stringify({}), { status: 404 });
+    });
+  }
+
+  const context = {
+    organizationId: "org-1",
+    providerCredentialId: "cred-1",
+    providerKind: "phrase" as const,
+    projectId: "project-1",
+    externalProjectId: "phrase-project-1",
+    secretMaterial: "api-token",
+    baseUrl: null,
+    region: null,
+    endpointUrl: "https://app.example.test/api/webhooks/tms/phrase",
+    webhookSecret: "generated-secret",
+    subscribedEvents: ["keys:create", "uploads:create"],
+  };
+
+  it("appends provider_webhook_id to callback URLs", () => {
+    expect(
+      appendPhraseWebhookProviderId(
+        "https://app.example.test/api/webhooks/tms/phrase",
+        "wh-created",
+      ),
+    ).toBe("https://app.example.test/api/webhooks/tms/phrase?provider_webhook_id=wh-created");
+  });
+
+  it("creates remote webhooks and patches callback URL with provider id", async () => {
+    const fetchMock = createFetchMock();
+    const adapter = createPhraseWebhookSubscriptionAdapter();
+    const remote = await adapter.createRemoteSubscription({
+      ...context,
+      fetchFn: fetchMock,
+    });
+
+    expect(remote).toMatchObject({
+      providerWebhookId: "wh-created",
+      endpointUrl:
+        "https://app.example.test/api/webhooks/tms/phrase?provider_webhook_id=wh-created",
+      subscribedEvents: context.subscribedEvents,
+      isActive: true,
+      secret: context.webhookSecret,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("maps permission errors to permission_denied", async () => {
+    const adapter = createPhraseWebhookSubscriptionAdapter();
+
+    await expect(
+      adapter.createRemoteSubscription({
+        ...context,
+        fetchFn: createFetchMock({ status: 403 }),
+      }),
+    ).rejects.toMatchObject({
+      code: "permission_denied",
+    });
+  });
+
+  it("requires a Phrase project id for setup", async () => {
+    const adapter = createPhraseWebhookSubscriptionAdapter();
+
+    await expect(
+      adapter.createRemoteSubscription({
+        ...context,
+        externalProjectId: null,
+        fetchFn: createFetchMock(),
+      }),
+    ).rejects.toMatchObject({
+      code: "invalid_configuration",
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-webhook-subscription-adapter.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-webhook-subscription-adapter.ts
@@ -1,0 +1,201 @@
+import { PhraseApiClient, PhraseApiError } from "./phrase-api";
+import {
+  ProviderWebhookSubscriptionAdapterError,
+  type ProviderWebhookRemoteSubscription,
+  type ProviderWebhookSubscriptionAdapter,
+  type ProviderWebhookSubscriptionAdapterContext,
+} from "../provider-webhook-subscription-types";
+
+const phraseWebhookDescription = "Hyperlocalise sync";
+const providerWebhookIdQueryParam = "provider_webhook_id";
+
+export function appendPhraseWebhookProviderId(endpointUrl: string, providerWebhookId: string) {
+  const url = new URL(endpointUrl);
+  url.searchParams.set(providerWebhookIdQueryParam, providerWebhookId);
+  return url.toString();
+}
+
+function parsePhraseProjectId(externalProjectId: string | null) {
+  if (!externalProjectId?.trim()) {
+    throw new ProviderWebhookSubscriptionAdapterError(
+      "invalid_configuration",
+      "Phrase project id is required for webhook setup",
+    );
+  }
+
+  return externalProjectId.trim();
+}
+
+function createPhraseClient(context: ProviderWebhookSubscriptionAdapterContext) {
+  return new PhraseApiClient({
+    token: context.secretMaterial,
+    region: context.region,
+    baseUrl: context.baseUrl ?? undefined,
+    fetchFn: context.fetchFn,
+  });
+}
+
+function mapPhraseWebhook(webhook: {
+  id: string;
+  callbackUrl: string;
+  events: string[];
+  active: boolean;
+}): ProviderWebhookRemoteSubscription {
+  return {
+    providerWebhookId: webhook.id,
+    endpointUrl: webhook.callbackUrl,
+    subscribedEvents: webhook.events,
+    isActive: webhook.active,
+    secret: null,
+  };
+}
+
+function buildCreateRequest(context: ProviderWebhookSubscriptionAdapterContext) {
+  return {
+    callbackUrl: context.endpointUrl,
+    secret: context.webhookSecret,
+    description: phraseWebhookDescription,
+    events: context.subscribedEvents,
+    active: true,
+    includeBranches: false,
+  };
+}
+
+function mapPhraseError(
+  error: unknown,
+  options?: { providerWebhookId?: string },
+): ProviderWebhookSubscriptionAdapterError {
+  if (error instanceof ProviderWebhookSubscriptionAdapterError) {
+    if (options?.providerWebhookId && !error.providerWebhookId) {
+      return new ProviderWebhookSubscriptionAdapterError(error.code, error.message, {
+        httpStatus: error.httpStatus,
+        cause: error.cause,
+        providerWebhookId: options.providerWebhookId,
+      });
+    }
+
+    return error;
+  }
+
+  if (error instanceof PhraseApiError) {
+    const code =
+      error.status === 401 || error.status === 403 ? "permission_denied" : "provider_error";
+    return new ProviderWebhookSubscriptionAdapterError(
+      code,
+      `Phrase webhook API returned HTTP ${error.status}`,
+      {
+        httpStatus: error.status,
+        cause: error,
+        providerWebhookId: options?.providerWebhookId,
+      },
+    );
+  }
+
+  return new ProviderWebhookSubscriptionAdapterError(
+    "provider_error",
+    error instanceof Error ? error.message : "Phrase webhook setup failed",
+    { cause: error, providerWebhookId: options?.providerWebhookId },
+  );
+}
+
+export function createPhraseWebhookSubscriptionAdapter(): ProviderWebhookSubscriptionAdapter {
+  return {
+    supportsAutomaticSetup: true,
+
+    async listRemoteSubscriptions(context) {
+      try {
+        const projectId = parsePhraseProjectId(context.externalProjectId);
+        const client = createPhraseClient(context);
+        const webhooks = await client.listWebhooks(projectId);
+        return webhooks.map(mapPhraseWebhook);
+      } catch (error) {
+        throw mapPhraseError(error);
+      }
+    },
+
+    async createRemoteSubscription(context) {
+      const projectId = parsePhraseProjectId(context.externalProjectId);
+      const client = createPhraseClient(context);
+
+      try {
+        const created = await client.createWebhook(projectId, buildCreateRequest(context));
+        const callbackUrl = appendPhraseWebhookProviderId(context.endpointUrl, created.id);
+        const updated =
+          callbackUrl === created.callbackUrl
+            ? created
+            : await client.updateWebhook(projectId, created.id, {
+                ...buildCreateRequest(context),
+                callbackUrl,
+              });
+
+        return {
+          ...mapPhraseWebhook(updated),
+          secret: context.webhookSecret,
+        };
+      } catch (error) {
+        throw mapPhraseError(error);
+      }
+    },
+
+    async updateRemoteSubscription(context) {
+      try {
+        const projectId = parsePhraseProjectId(context.externalProjectId);
+        const webhookId = context.providerWebhookId.trim();
+        if (!webhookId) {
+          throw new ProviderWebhookSubscriptionAdapterError(
+            "invalid_configuration",
+            "Phrase webhook id is required for webhook updates",
+          );
+        }
+
+        const client = createPhraseClient(context);
+        const callbackUrl = appendPhraseWebhookProviderId(context.endpointUrl, webhookId);
+        const updated = await client.updateWebhook(projectId, webhookId, {
+          ...buildCreateRequest(context),
+          callbackUrl,
+        });
+
+        return {
+          ...mapPhraseWebhook(updated),
+          secret: context.webhookSecret,
+        };
+      } catch (error) {
+        throw mapPhraseError(error, { providerWebhookId: context.providerWebhookId });
+      }
+    },
+
+    async disableRemoteSubscription(context) {
+      try {
+        const projectId = parsePhraseProjectId(context.externalProjectId);
+        const webhookId = context.providerWebhookId.trim();
+        if (!webhookId) {
+          return;
+        }
+
+        const client = createPhraseClient(context);
+        await client.updateWebhook(projectId, webhookId, {
+          ...buildCreateRequest(context),
+          callbackUrl: appendPhraseWebhookProviderId(context.endpointUrl, webhookId),
+          active: false,
+        });
+      } catch (error) {
+        throw mapPhraseError(error);
+      }
+    },
+
+    async deleteRemoteSubscription(context) {
+      try {
+        const projectId = parsePhraseProjectId(context.externalProjectId);
+        const webhookId = context.providerWebhookId.trim();
+        if (!webhookId) {
+          return;
+        }
+
+        const client = createPhraseClient(context);
+        await client.deleteWebhook(projectId, webhookId);
+      } catch (error) {
+        throw mapPhraseError(error);
+      }
+    },
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-webhook-subscription-adapter.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/phrase/phrase-webhook-subscription-adapter.ts
@@ -114,10 +114,9 @@ export function createPhraseWebhookSubscriptionAdapter(): ProviderWebhookSubscri
     },
 
     async createRemoteSubscription(context) {
-      const projectId = parsePhraseProjectId(context.externalProjectId);
-      const client = createPhraseClient(context);
-
       try {
+        const projectId = parsePhraseProjectId(context.externalProjectId);
+        const client = createPhraseClient(context);
         const created = await client.createWebhook(projectId, buildCreateRequest(context));
         const callbackUrl = appendPhraseWebhookProviderId(context.endpointUrl, created.id);
         const updated =

--- a/apps/hyperlocalise-web/src/lib/providers/provider-webhook-default-events.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-webhook-default-events.ts
@@ -53,6 +53,27 @@ export function listDefaultWebhookEvents(providerKind: ExternalTmsProviderKind) 
     ];
   }
 
+  if (providerKind === "phrase") {
+    return [
+      "keys:create",
+      "keys:update",
+      "keys:delete",
+      "translations:create",
+      "translations:update",
+      "translations:review",
+      "translations:unverify",
+      "jobs:create",
+      "jobs:complete",
+      "jobs:completed",
+      "uploads:create",
+      "comments:create",
+      "locales:create",
+      "locales:update",
+      "branches:create",
+      "branches:merge",
+    ];
+  }
+
   if (providerKind === "smartling") {
     return [
       "file.uploaded",

--- a/apps/hyperlocalise-web/src/lib/providers/provider-webhook-subscription-adapters.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-webhook-subscription-adapters.ts
@@ -1,6 +1,7 @@
 import type { ExternalTmsProviderKind } from "./organization-external-tms-provider-credentials";
 import { createCrowdinWebhookSubscriptionAdapter } from "./crowdin/crowdin-webhook-subscription-adapter";
 import { createLokaliseWebhookSubscriptionAdapter } from "./lokalise/lokalise-webhook-subscription-adapter";
+import { createPhraseWebhookSubscriptionAdapter } from "./phrase/phrase-webhook-subscription-adapter";
 import { createSmartlingWebhookSubscriptionAdapter } from "./smartling/smartling-webhook-subscription-adapter";
 import { createManualProviderWebhookSubscriptionAdapter } from "./manual-provider-webhook-subscription-adapter";
 import type { ProviderWebhookSubscriptionAdapter } from "./provider-webhook-subscription-types";
@@ -8,6 +9,7 @@ import type { ProviderWebhookSubscriptionAdapter } from "./provider-webhook-subs
 const crowdinAdapter = createCrowdinWebhookSubscriptionAdapter();
 const smartlingAdapter = createSmartlingWebhookSubscriptionAdapter();
 const lokaliseAdapter = createLokaliseWebhookSubscriptionAdapter();
+const phraseAdapter = createPhraseWebhookSubscriptionAdapter();
 const manualAdapter = createManualProviderWebhookSubscriptionAdapter();
 
 /**
@@ -27,6 +29,10 @@ export function getProviderWebhookSubscriptionAdapter(
 
   if (providerKind === "lokalise") {
     return lokaliseAdapter;
+  }
+
+  if (providerKind === "phrase") {
+    return phraseAdapter;
   }
 
   return manualAdapter;

--- a/apps/hyperlocalise-web/src/lib/providers/provider-webhook-subscription-manager.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-webhook-subscription-manager.test.ts
@@ -560,7 +560,116 @@ describe("provider webhook subscription manager", () => {
     expect(result.subscription.subscribedEvents).toContain("file.published");
   });
 
-  it("uses the same provider-agnostic fallback for other TMS providers", async () => {
+  function createPhraseWebhookFetch(input: { status?: number } = {}) {
+    return vi.fn(async (url, init) => {
+      if (input.status) {
+        return new Response(JSON.stringify({ message: "forbidden" }), {
+          status: input.status,
+        });
+      }
+
+      const method = init?.method ?? "GET";
+      const body =
+        typeof init?.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : {};
+
+      if (method === "GET" && String(url).includes("/webhooks")) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+
+      if (method === "POST" && String(url).includes("/webhooks")) {
+        return new Response(
+          JSON.stringify({
+            id: "phrase-wh-1",
+            callback_url: body.callback_url,
+            events: body.events,
+            active: true,
+          }),
+          { status: 201 },
+        );
+      }
+
+      if (method === "PATCH" && String(url).includes("/webhooks/phrase-wh-1")) {
+        return new Response(
+          JSON.stringify({
+            id: "phrase-wh-1",
+            callback_url: body.callback_url,
+            events: body.events,
+            active: true,
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify({}), { status: 404 });
+    }) as unknown as typeof fetch;
+  }
+
+  async function createPhraseCredential() {
+    const { organizationId, userId } = await createOrganizationUser();
+    const credential = await upsertOrganizationExternalTmsProviderCredential({
+      organizationId,
+      userId,
+      role: "owner",
+      providerKind: "phrase",
+      displayName: "Phrase",
+      secretMaterial: "secret-token",
+    });
+
+    const projectId = `project_${randomUUID()}`;
+    await db.insert(schema.projects).values({
+      id: projectId,
+      organizationId,
+      name: "Phrase project",
+      description: "",
+      translationContext: "",
+      source: "external_tms",
+      externalProviderCredentialId: credential.id,
+      externalProviderKind: "phrase",
+      externalProjectId: "phrase-project-1",
+      targetLocales: ["fr"],
+      isActive: true,
+    });
+
+    return { organizationId, credential, projectId };
+  }
+
+  it("creates an automatic Phrase webhook subscription for linked projects", async () => {
+    const { organizationId, credential, projectId } = await createPhraseCredential();
+    const fetchMock = createPhraseWebhookFetch();
+
+    const result = await ensureProviderWebhookSubscription({
+      organizationId,
+      providerKind: "phrase",
+      providerCredentialId: credential.id,
+      projectId,
+      externalProjectId: "phrase-project-1",
+      fetchFn: fetchMock,
+    });
+
+    expect(result.status).toBe("active");
+    expect(result.subscription.providerWebhookId).toBe("phrase-wh-1");
+    expect(result.subscription.endpointUrl).toContain("provider_webhook_id=phrase-wh-1");
+    expect(result.subscription.subscribedEvents).toContain("keys:create");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("marks Phrase permission failures with manual fallback details", async () => {
+    const { organizationId, credential, projectId } = await createPhraseCredential();
+
+    const result = await ensureProviderWebhookSubscription({
+      organizationId,
+      providerKind: "phrase",
+      providerCredentialId: credential.id,
+      projectId,
+      externalProjectId: "phrase-project-1",
+      fetchFn: createPhraseWebhookFetch({ status: 403 }),
+    });
+
+    expect(result.status).toBe("permission_error");
+    expect(result.subscription.manualFallback?.webhookUrl).toContain("/api/webhooks/tms/phrase");
+  });
+
+  it("requires manual setup when no linked project is available", async () => {
     const { organizationId, userId } = await createOrganizationUser();
     const credential = await upsertOrganizationExternalTmsProviderCredential({
       organizationId,
@@ -578,7 +687,7 @@ describe("provider webhook subscription manager", () => {
       projectId: null,
     });
 
-    expect(result.status).toBe("manual_required");
+    expect(result.status).toBe("provider_error");
     expect(result.subscription.manualFallback?.webhookUrl).toContain("/api/webhooks/tms/phrase");
   });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/provider-webhook-subscription-manager.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-webhook-subscription-manager.ts
@@ -103,6 +103,17 @@ function buildManualFallback(input: {
     };
   }
 
+  if (input.providerKind === "phrase") {
+    return {
+      webhookUrl: input.endpointUrl,
+      secretHeaderName: "X-PhraseApp-Signature",
+      secretInstructions:
+        "Phrase signs webhook payloads with HMAC-SHA256 of the raw request body in the X-PhraseApp-Signature header. Configure the webhook secret in Phrase to match the generated signing secret. Append ?provider_webhook_id=<webhook id> to the callback URL so Hyperlocalise can route deliveries.",
+      subscribedEvents: input.subscribedEvents,
+      ...(input.lastError ? { lastError: input.lastError } : {}),
+    };
+  }
+
   return {
     webhookUrl: input.endpointUrl,
     secretHeaderName: "X-Hyperlocalise-Signature-256",

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-webhook-adapters.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-webhook-adapters.test.ts
@@ -14,20 +14,35 @@ function signatureFor(body: string, secret = "webhook-signing-secret") {
   return `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
 }
 
+function phraseSignatureFor(body: string, secret = "webhook-signing-secret") {
+  return createHmac("sha256", secret).update(body).digest("hex");
+}
+
 function extract(input: {
   providerKind: ExternalTmsProviderKind;
   payload: ProviderWebhookPayload;
   headers?: HeadersInit;
   providerWebhookId?: string;
+  requestUrl?: string;
 }) {
   const adapter = tmsProviderWebhookAdapters[input.providerKind];
   const headers = new Headers(input.headers);
-  headers.set("x-hyperlocalise-provider-webhook-id", input.providerWebhookId ?? "webhook-1");
+  const providerWebhookId = input.providerWebhookId ?? "webhook-1";
+  if (input.providerKind !== "phrase") {
+    headers.set("x-hyperlocalise-provider-webhook-id", providerWebhookId);
+  }
+
+  const requestUrl =
+    input.requestUrl ??
+    (input.providerKind === "phrase"
+      ? `https://app.example.test/api/webhooks/tms/phrase?provider_webhook_id=${providerWebhookId}`
+      : undefined);
 
   return adapter.extract({
     providerKind: input.providerKind,
     headers,
     payload: input.payload,
+    requestUrl,
   });
 }
 
@@ -166,7 +181,9 @@ describe("tms provider webhook adapters", () => {
         deliveryId:
           providerKind === "smartling" && expected.providerEventId === "smartling-delivery-1"
             ? "smartling-delivery-1"
-            : null,
+            : providerKind === "phrase"
+              ? expected.providerEventId
+              : null,
         eventType: expected.eventType,
         resourceType: null,
         resourceId: expected.resourceId,
@@ -477,11 +494,15 @@ describe("tms provider webhook adapters", () => {
     ]);
   });
 
-  it("default verification rejects echoed secrets without body signatures", async () => {
-    const payload = { event_uid: "evt-signature", event: "jobs:completed" };
+  it("verifies Phrase X-PhraseApp-Signature headers using the raw body", async () => {
+    const payload = { event_uid: "evt-phrase-1", event: "keys:create", key: { id: "key-1" } };
     const body = JSON.stringify(payload);
     const adapter = tmsProviderWebhookAdapters.phrase;
-    const descriptor = extract({ providerKind: "phrase", payload });
+    const descriptor = extract({
+      providerKind: "phrase",
+      payload,
+      requestUrl: "https://app.example.test/api/webhooks/tms/phrase?provider_webhook_id=webhook-1",
+    });
 
     expect(descriptor).not.toBeNull();
 
@@ -489,7 +510,22 @@ describe("tms provider webhook adapters", () => {
       Promise.resolve(
         adapter.verify({
           providerKind: "phrase",
-          headers: new Headers({ "x-hyperlocalise-webhook-secret": "webhook-signing-secret" }),
+          headers: new Headers({
+            "x-phraseapp-signature": phraseSignatureFor(body),
+          }),
+          rawBody: body,
+          payload,
+          webhookSecret: "webhook-signing-secret",
+          descriptor: descriptor!,
+        }),
+      ),
+    ).resolves.toBe(true);
+
+    await expect(
+      Promise.resolve(
+        adapter.verify({
+          providerKind: "phrase",
+          headers: new Headers({ "x-phraseapp-signature": "deadbeef" }),
           rawBody: body,
           payload,
           webhookSecret: "webhook-signing-secret",
@@ -498,4 +534,82 @@ describe("tms provider webhook adapters", () => {
       ),
     ).resolves.toBe(false);
   });
+
+  it("resolves Phrase subscriptions from provider_webhook_id query params", () => {
+    const descriptor = extract({
+      providerKind: "phrase",
+      payload: { event_uid: "evt-phrase-query", event: "keys:create" },
+      requestUrl:
+        "https://app.example.test/api/webhooks/tms/phrase?provider_webhook_id=phrase-wh-9",
+      headers: { "x-phraseapp-event": "keys:create" },
+    });
+
+    expect(descriptor?.providerWebhookId).toBe("phrase-wh-9");
+  });
+
+  it.each<{
+    eventType: string;
+    resourceId: string | null;
+    expectedMappedIntentKinds: TmsWebhookMappedIntentKind[];
+  }>([
+    {
+      eventType: "uploads:create",
+      resourceId: "upload-1",
+      expectedMappedIntentKinds: ["file_key_scan", "pull_content"],
+    },
+    {
+      eventType: "imports:finished",
+      resourceId: "import-1",
+      expectedMappedIntentKinds: ["file_key_scan", "pull_content"],
+    },
+    {
+      eventType: "keys:create",
+      resourceId: "key-1",
+      expectedMappedIntentKinds: ["file_key_scan"],
+    },
+    {
+      eventType: "translations:review",
+      resourceId: "translation-1",
+      expectedMappedIntentKinds: ["file_key_scan", "pull_content"],
+    },
+    {
+      eventType: "translations:update",
+      resourceId: "translation-2",
+      expectedMappedIntentKinds: ["file_key_scan"],
+    },
+    {
+      eventType: "comments:create",
+      resourceId: "comment-1",
+      expectedMappedIntentKinds: ["file_key_scan"],
+    },
+    {
+      eventType: "locales:create",
+      resourceId: "locale-1",
+      expectedMappedIntentKinds: ["project_scan"],
+    },
+  ])(
+    "maps Phrase $eventType events to reconciliation intents",
+    ({ eventType, resourceId, expectedMappedIntentKinds }) => {
+      const descriptor = extract({
+        providerKind: "phrase",
+        payload: {
+          event_uid: `evt-${eventType}`,
+          event: eventType,
+          upload: resourceId ? { id: resourceId } : undefined,
+          key: resourceId ? { id: resourceId } : undefined,
+          translation: resourceId ? { id: resourceId } : undefined,
+          comment: resourceId ? { id: resourceId } : undefined,
+          locale: resourceId ? { id: resourceId } : undefined,
+        },
+        headers: { "x-phraseapp-event": eventType },
+        requestUrl:
+          "https://app.example.test/api/webhooks/tms/phrase?provider_webhook_id=webhook-1",
+      });
+
+      expect(descriptor?.eventType).toBe(eventType);
+      expect(descriptor?.mappedIntents.map((intent) => intent.kind)).toEqual(
+        expectedMappedIntentKinds,
+      );
+    },
+  );
 });

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-webhook-adapters.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-webhook-adapters.ts
@@ -44,6 +44,7 @@ export type TmsProviderWebhookAdapterInput = {
   providerKind: ExternalTmsProviderKind;
   headers: Headers;
   payload: ProviderWebhookPayload;
+  requestUrl?: string | null;
 };
 
 export type TmsProviderWebhookVerificationInput = TmsProviderWebhookAdapterInput & {
@@ -202,6 +203,23 @@ export function verifySmartlingWebhook(input: TmsProviderWebhookVerificationInpu
   }
 
   return verifyCrowdinWebhook(input);
+}
+
+export function verifyPhraseWebhook(input: TmsProviderWebhookVerificationInput) {
+  if (!input.webhookSecret) {
+    return true;
+  }
+
+  const signature = input.headers.get("x-phraseapp-signature");
+  if (!signature) {
+    return false;
+  }
+
+  return verifyHmacSha256Hex({
+    payload: input.rawBody,
+    webhookSecret: input.webhookSecret,
+    signature,
+  });
 }
 
 export function verifyLokaliseWebhook(input: TmsProviderWebhookVerificationInput) {
@@ -495,6 +513,74 @@ function genericTmsEventMapping(input: {
   return [];
 }
 
+function mapPhraseUploadReconciliation(resourceId: string | null) {
+  return [fileKeyScan(resourceId), pullContent(resourceId)];
+}
+
+function mapPhraseEvent(input: {
+  eventType: string;
+  resourceType: string | null;
+  resourceId: string | null;
+}) {
+  const eventType = input.eventType.toLowerCase();
+  const resourceId = input.resourceId;
+
+  if (
+    eventType.startsWith("uploads:") ||
+    includesAny(eventType, ["imports:", "import:", "upload:"])
+  ) {
+    return mapPhraseUploadReconciliation(resourceId);
+  }
+
+  if (eventType.startsWith("keys:") || includesAny(eventType, [":keys:"])) {
+    return [fileKeyScan(resourceId)];
+  }
+
+  if (eventType.startsWith("translations:")) {
+    const intents: TmsWebhookMappedIntent[] = [fileKeyScan(resourceId)];
+    if (includesAny(eventType, ["review", "unverify", "verify", "approved"])) {
+      intents.push(pullContent(resourceId));
+    }
+    return intents;
+  }
+
+  if (
+    eventType.startsWith("jobs:") ||
+    includesAny(eventType, ["jobs:completed", "jobs:complete", "jobs:create"])
+  ) {
+    return [jobTaskScan(resourceId)];
+  }
+
+  if (eventType.startsWith("comments:")) {
+    return [fileKeyScan(resourceId)];
+  }
+
+  if (eventType.startsWith("locales:") || eventType.startsWith("branches:")) {
+    return [projectScan(resourceId)];
+  }
+
+  return genericTmsEventMapping(input);
+}
+
+function resolvePhraseProviderWebhookId(input: TmsProviderWebhookAdapterInput) {
+  if (input.requestUrl) {
+    try {
+      const fromQuery = new URL(input.requestUrl).searchParams.get("provider_webhook_id");
+      if (fromQuery) {
+        return fromQuery;
+      }
+    } catch {
+      // Ignore malformed request URLs in tests or misconfigured callbacks.
+    }
+  }
+
+  return firstString(
+    input.headers.get("x-hyperlocalise-provider-webhook-id"),
+    input.headers.get("x-provider-webhook-id"),
+    firstPathString(input.payload, [["webhook", "id"], ["webhook_id"]]),
+  );
+}
+
 function mapLokaliseEvent(input: {
   eventType: string;
   resourceType: string | null;
@@ -653,14 +739,72 @@ export const crowdinWebhookAdapter = createProviderWebhookAdapter({
   verify: verifyCrowdinWebhook,
 });
 
-export const phraseWebhookAdapter = createProviderWebhookAdapter({
+const basePhraseWebhookAdapter = createProviderWebhookAdapter({
   eventTypePaths: [["event"], ["event_type"], ["type"]],
   eventIdPaths: [["event_uid"], ["event_id"], ["id"], ["uuid"]],
+  deliveryIdPaths: [["sent_at"], ["event_uid"], ["event_id"]],
   resourceTypePaths: [["resource_type"], ["resource", "type"]],
-  resourceIdPaths: [["resource_id"], ["job", "uid"], ["job", "id"], ["key", "id"]],
+  resourceIdPaths: [
+    ["resource_id"],
+    ["job", "uid"],
+    ["job", "id"],
+    ["key", "id"],
+    ["key", "uid"],
+    ["translation", "id"],
+    ["upload", "id"],
+    ["comment", "id"],
+  ],
   externalResourceIdPaths: [["external_resource_id"], ["project", "uid"], ["project", "id"]],
-  mapEvent: genericTmsEventMapping,
+  mapEvent: mapPhraseEvent,
+  verify: verifyPhraseWebhook,
 });
+
+export const phraseWebhookAdapter: TmsProviderWebhookAdapter = {
+  ...basePhraseWebhookAdapter,
+  resolveSubscription(input) {
+    const providerWebhookId = resolvePhraseProviderWebhookId(input);
+    return providerWebhookId ? { providerWebhookId } : null;
+  },
+  extractEventType(input) {
+    return firstString(
+      input.headers.get("x-phraseapp-event"),
+      basePhraseWebhookAdapter.extractEventType(input),
+    );
+  },
+  extract(input) {
+    const subscription = phraseWebhookAdapter.resolveSubscription(input);
+    const providerEventId = phraseWebhookAdapter.extractProviderEventId(input);
+    const eventType = phraseWebhookAdapter.extractEventType(input);
+
+    if (!subscription || !providerEventId || !eventType) {
+      return null;
+    }
+
+    const deliveryId = firstString(
+      input.headers.get("x-phraseapp-delivery"),
+      input.headers.get("x-hyperlocalise-delivery-id"),
+      input.headers.get("x-provider-delivery-id"),
+      input.headers.get("x-delivery-id"),
+      firstPathString(input.payload, [["sent_at"], ["event_uid"], ["event_id"]]),
+    );
+    const resource = phraseWebhookAdapter.extractResource(input);
+    const descriptor: TmsProviderWebhookDescriptor = {
+      ...subscription,
+      providerEventId,
+      eventType,
+      dedupeKey: firstString(input.payload["dedupe_key"], providerEventId) ?? providerEventId,
+      deliveryId,
+      ...resource,
+      redactedPayload: {},
+      mappedIntents: [],
+    };
+
+    descriptor.mappedIntents = phraseWebhookAdapter.mapToIntents({ ...input, descriptor });
+    descriptor.redactedPayload = phraseWebhookAdapter.redact({ ...input, descriptor });
+
+    return descriptor;
+  },
+};
 
 export const smartlingWebhookAdapter = createProviderWebhookAdapter({
   subscriptionIdPaths: [["subscriptionUid"], ["subscription", "subscriptionUid"]],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Implements Phrase-specific webhook subscription management, signature verification, and event mapping for HL-405.

- **Subscription adapter**: Automatic create/update/delete/list via Phrase API when credentials allow; callback URL includes `provider_webhook_id` query param (Phrase has no custom headers). Falls back to manual setup instructions on permission errors.
- **Phrase API**: `listWebhooks`, `createWebhook`, `updateWebhook`, `deleteWebhook` helpers.
- **Webhook adapter**: Verifies `X-PhraseApp-Signature` (HMAC-SHA256 hex of raw body). Maps granular key/translation/job/comment/locale/branch events to sync intents. Maps upload/import events to both `file_key_scan` and `pull_content` (invalidation + polling reconciliation).
- **Route**: Enqueues all executable mapped intents per delivery (not just the first). Links webhook events to the primary sync intent.

## How to test

```bash
cd apps/hyperlocalise-web
vp test phrase-webhook tms-provider-webhook provider-webhook-subscription-manager tms-webhook.route
vp check --fix
```

## Checklist

- [x] Ran `vp test` on focused Phrase/webhook tests (62 passed)
- [x] Ran `vp check --fix`
- [x] PR scoped for HL-405

Fixes HL-405
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-405](https://linear.app/hyperlocalise/issue/HL-405/implement-phrase-webhook-setup-and-upload-aware-reconciliation-mapping)

<div><a href="https://cursor.com/agents/bc-ae833df1-e59b-460f-91be-355c30d39d49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae833df1-e59b-460f-91be-355c30d39d49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

