### PR TITLE
fix(crowdin): improve reports model parity and add missing fields

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -101,3 +101,9 @@
 **Learning:** The Crowdin Label response model was missing the `projectId` field, which is standard for most Crowdin resources. Additionally, `ScreenshotListOptions` used `[]string` for `StringIDs`, `LabelIDs`, and `ExcludeLabelIDs`, which is inconsistent with other models that use `[]int` for numeric identifiers and with the official API contract.
 
 **Action:** Added `ProjectID` to the `Label` struct in `model/labels.go`. Updated `ScreenshotListOptions` in `model/screenshot.go` to use `[]int` for `StringIDs`, `LabelIDs`, and `ExcludeLabelIDs`. Updated corresponding contract tests in `labels_test.go`, `screenshot_test.go`, and `screenshots_test.go` to reflect these changes and ensure correct query parameter encoding.
+
+## 2026-08-08 - Improve Reports model parity for AI Match and ProjectIDs
+
+**Learning:** Crowdin API v2 Reports have evolved to include AI-specific matching in net rate schemes and more granular metadata in report status attributes. Specifically, `aiMatch` was missing from `ReportNetRateSchemes`, and `projectIds` was missing from `ReportStatusAttributes` for group/organization reports. Additionally, several new report names and the `status` filter in `GroupTaskUsageSchema` were absent.
+
+**Action:** Added `AIMatch` to `ReportNetRateSchemes`, `ProjectIDs` to `ReportStatusAttributes`, and `Status` to `GroupTaskUsageSchema` in `model/reports.go`. Added missing `ReportName` constants for project and group reports (including TM-specific and comprehensive summaries). Updated comprehensive contract tests in `reports_test.go` to verify correct parsing and serialization of these new fields.

--- a/third_party/crowdin-api-client-go/crowdin/model/reports.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/reports.go
@@ -61,6 +61,13 @@ const (
 	ReportSavingActivity              ReportName = "saving-activity"
 	ReportTranslationActivity         ReportName = "translation-activity"
 
+	ReportCostsEstimation             ReportName = "costs-estimation"
+	ReportTranslationCosts            ReportName = "translation-costs"
+	ReportUserComprehensiveSummary    ReportName = "user-comprehensive-summary"
+	ReportProjectComprehensiveSummary ReportName = "project-comprehensive-summary"
+	ReportTranslationCostsTM          ReportName = "translation-costs-tm"
+	ReportCostsEstimationTM           ReportName = "costs-estimation-tm"
+
 	// Deprecated: Use ReportPreTranslateAccuracy instead.
 	ReportPreTranslateEfficiency ReportName = "pre-translate-efficiency"
 
@@ -70,6 +77,11 @@ const (
 	ReportGroupTaskUsage                   ReportName = "group-task-usage"
 	ReportGroupQACheckIssues               ReportName = "group-qa-check-issues"
 	ReportGroupTranslationActivity         ReportName = "group-translation-activity"
+
+	ReportGroupTranslationCosts           ReportName = "group-translation-costs"
+	ReportGroupCostsEstimationPostEditing ReportName = "group-costs-estimation-pe"
+	ReportGroupTranslationCostsTM         ReportName = "group-translation-costs-tm"
+	ReportGroupCostsEstimationTM          ReportName = "group-costs-estimation-tm"
 )
 
 // ReportArchive represents a report archive.
@@ -147,6 +159,7 @@ type (
 	ReportStatusAttributes struct {
 		Format     string `json:"format"`
 		ReportName string `json:"reportName"`
+		ProjectIDs []int  `json:"projectIds,omitempty"`
 		Schema     any    `json:"schema"`
 	}
 )
@@ -189,6 +202,8 @@ type (
 		TMMatch []ReportNetRateSchemeMatch `json:"tmMatch,omitempty"`
 		// Match type enum: "100", "99-82", "81-60".
 		MTMatch []ReportNetRateSchemeMatch `json:"mtMatch,omitempty"`
+		// Match type enum: "100", "99-82", "81-60".
+		AIMatch []ReportNetRateSchemeMatch `json:"aiMatch,omitempty"`
 		// Match type enum: "100", "99-82".
 		SuggestionMatch []ReportNetRateSchemeMatch `json:"suggestionMatch,omitempty"`
 	}
@@ -725,6 +740,8 @@ type (
 		CreatorID int `json:"creatorId,omitempty"`
 		// Task assignee identifier filter.
 		AssigneeID int `json:"assigneeId,omitempty"`
+		// Task status filter.
+		Status string `json:"status,omitempty"`
 	}
 
 	// GroupQACheckIssuesSchema defines the schema for the group QA check issues report.

--- a/third_party/crowdin-api-client-go/crowdin/model/reports.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/reports.go
@@ -741,7 +741,7 @@ type (
 		// Task assignee identifier filter.
 		AssigneeID int `json:"assigneeId,omitempty"`
 		// Task status filter.
-		Status string `json:"status,omitempty"`
+		Status TaskStatus `json:"status,omitempty"`
 	}
 
 	// GroupQACheckIssuesSchema defines the schema for the group QA check issues report.

--- a/third_party/crowdin-api-client-go/crowdin/reports_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/reports_test.go
@@ -242,6 +242,7 @@ func TestReportsService_ExportArchive(t *testing.T) {
 				Attributes: model.ReportStatusAttributes{
 					Format:     "xlsx",
 					ReportName: "costs-estimation",
+					ProjectIDs: []int{1, 2},
 					Schema:     map[string]any{},
 				},
 				CreatedAt:  "2023-09-23T11:26:54+00:00",
@@ -294,6 +295,7 @@ func TestReportsService_CheckArchiveExportStatus(t *testing.T) {
 		Attributes: model.ReportStatusAttributes{
 			Format:     "xlsx",
 			ReportName: "costs-estimation",
+			ProjectIDs: []int{1, 2},
 			Schema:     map[string]any{},
 		},
 		CreatedAt:  "2023-09-23T11:26:54+00:00",
@@ -450,6 +452,7 @@ func TestReportsService_CheckStatus(t *testing.T) {
 		Attributes: model.ReportStatusAttributes{
 			Format:     "xlsx",
 			ReportName: "costs-estimation",
+			ProjectIDs: []int{1, 2},
 			Schema:     map[string]any{},
 		},
 		CreatedAt:  "2023-09-23T11:26:54+00:00",
@@ -529,6 +532,12 @@ func TestReportsService_GetSettingsTemplate(t *testing.T) {
 								"price": 0.1
 							}
 						],
+						"aiMatch": [
+							{
+								"matchType": "100",
+								"price": 0.1
+							}
+						],
 						"suggestionMatch": [
 							{
 								"matchType": "100",
@@ -567,6 +576,7 @@ func TestReportsService_GetSettingsTemplate(t *testing.T) {
 			NetRateSchemes: &model.ReportNetRateSchemes{
 				TMMatch:         []model.ReportNetRateSchemeMatch{{MatchType: "perfect", Price: 0.1}},
 				MTMatch:         []model.ReportNetRateSchemeMatch{{MatchType: "100", Price: 0.1}},
+				AIMatch:         []model.ReportNetRateSchemeMatch{{MatchType: "100", Price: 0.1}},
 				SuggestionMatch: []model.ReportNetRateSchemeMatch{{MatchType: "100", Price: 0.1}},
 			},
 		},
@@ -719,6 +729,12 @@ func TestReportsService_AddSettingsTemplate(t *testing.T) {
 							"price":0.1
 						}
 					],
+					"aiMatch": [
+						{
+							"matchType": "100",
+							"price": 0.1
+						}
+					],
 					"suggestionMatch":[
 						{
 							"matchType":"100",
@@ -759,6 +775,7 @@ func TestReportsService_AddSettingsTemplate(t *testing.T) {
 			NetRateSchemes: &model.ReportNetRateSchemes{
 				TMMatch:         []model.ReportNetRateSchemeMatch{{MatchType: "perfect", Price: 0.1}},
 				MTMatch:         []model.ReportNetRateSchemeMatch{{MatchType: "100", Price: 0.1}},
+				AIMatch:         []model.ReportNetRateSchemeMatch{{MatchType: "100", Price: 0.1}},
 				SuggestionMatch: []model.ReportNetRateSchemeMatch{{MatchType: "100", Price: 0.1}},
 			},
 		},
@@ -883,6 +900,7 @@ func TestReportsService_CheckGroupReportStatus(t *testing.T) {
 		Attributes: model.ReportStatusAttributes{
 			Format:     "xlsx",
 			ReportName: "costs-estimation",
+			ProjectIDs: []int{1, 2},
 			Schema:     map[string]any{},
 		},
 		CreatedAt:  "2023-09-23T11:26:54+00:00",
@@ -1202,6 +1220,7 @@ func TestReportsService_CheckOrganizationReportStatus(t *testing.T) {
 		Attributes: model.ReportStatusAttributes{
 			Format:     "xlsx",
 			ReportName: "costs-estimation",
+			ProjectIDs: []int{1, 2},
 			Schema:     map[string]any{},
 		},
 		CreatedAt:  "2023-09-23T11:26:54+00:00",
@@ -1248,6 +1267,7 @@ func jsonReportStatus() string {
 			"attributes": {
 				"format": "xlsx",
 				"reportName": "costs-estimation",
+				"projectIds": [1, 2],
 				"schema": {}
 			},
 			"createdAt": "2023-09-23T11:26:54+00:00",
@@ -1343,6 +1363,7 @@ func TestReportsService_GetUserSettingsTemplate(t *testing.T) {
 			NetRateSchemes: &model.ReportNetRateSchemes{
 				TMMatch:         []model.ReportNetRateSchemeMatch{{MatchType: "perfect", Price: 0.1}},
 				MTMatch:         []model.ReportNetRateSchemeMatch{{MatchType: "100", Price: 0.1}},
+				AIMatch:         []model.ReportNetRateSchemeMatch{{MatchType: "100", Price: 0.1}},
 				SuggestionMatch: []model.ReportNetRateSchemeMatch{{MatchType: "100", Price: 0.1}},
 			},
 		},


### PR DESCRIPTION
This PR improves the Reports module in the Crowdin SDK fork to better align with the official Crowdin API v2 contract. It introduces support for AI matching in net rate schemes, additional metadata in report status responses, and missing report types and filtering options. These changes ensure the client remains correct and functional under real-world workloads, especially in Enterprise environments.

---
*PR created automatically by Jules for task [8458814564181264704](https://jules.google.com/task/8458814564181264704) started by @cungminh2710*