### PR TITLE
🎨 Palette: improve tooltip accessibility and add member removal tooltip

### DIFF
--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.tsx
@@ -223,12 +223,12 @@ export function ProjectsTable({
                               }}
                               disabled={isSavingProject}
                               className="text-foreground/54 hover:text-foreground"
-                            />
+                            >
+                              <HugeiconsIcon icon={Edit02Icon} strokeWidth={1.8} />
+                              <span className="sr-only">Edit {project.name}</span>
+                            </Button>
                           }
-                        >
-                          <HugeiconsIcon icon={Edit02Icon} strokeWidth={1.8} />
-                          <span className="sr-only">Edit {project.name}</span>
-                        </TooltipTrigger>
+                        />
                         <TooltipContent side="bottom" align="center">
                           Edit project
                         </TooltipContent>
@@ -245,12 +245,12 @@ export function ProjectsTable({
                               }}
                               disabled={isDeletingProject || isSavingProject}
                               className="text-foreground/54 hover:text-foreground"
-                            />
+                            >
+                              <HugeiconsIcon icon={Delete02Icon} strokeWidth={1.8} />
+                              <span className="sr-only">Delete {project.name}</span>
+                            </Button>
                           }
-                        >
-                          <HugeiconsIcon icon={Delete02Icon} strokeWidth={1.8} />
-                          <span className="sr-only">Delete {project.name}</span>
-                        </TooltipTrigger>
+                        />
                         <TooltipContent side="bottom" align="center">
                           Delete project
                         </TooltipContent>

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/settings/_components/members-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/settings/_components/members-page-content.tsx
@@ -8,6 +8,7 @@ import { toast } from "sonner";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   Dialog,
@@ -317,21 +318,30 @@ export function MembersSettingsPageContent({
                       )}
 
                       {canRemoveMember ? (
-                        <Button
-                          type="button"
-                          variant="outline"
-                          size="icon"
-                          className="border-foreground/10 bg-transparent text-foreground/52 hover:bg-destructive/10 hover:text-destructive"
-                          onClick={() => setRemovingMember(member)}
-                          disabled={removeMember.isPending}
-                          aria-label={
-                            isInvited
-                              ? `Cancel invitation for ${member.displayName}`
-                              : `Remove ${member.displayName}`
-                          }
-                        >
-                          <HugeiconsIcon icon={Delete01Icon} strokeWidth={1.8} />
-                        </Button>
+                        <Tooltip>
+                          <TooltipTrigger
+                            render={
+                              <Button
+                                type="button"
+                                variant="outline"
+                                size="icon"
+                                className="border-foreground/10 bg-transparent text-foreground/52 hover:bg-destructive/10 hover:text-destructive"
+                                onClick={() => setRemovingMember(member)}
+                                disabled={removeMember.isPending}
+                                aria-label={
+                                  isInvited
+                                    ? `Cancel invitation for ${member.displayName}`
+                                    : `Remove ${member.displayName}`
+                                }
+                              >
+                                <HugeiconsIcon icon={Delete01Icon} strokeWidth={1.8} />
+                              </Button>
+                            }
+                          />
+                          <TooltipContent side="bottom" align="end">
+                            {isInvited ? "Cancel invitation" : "Remove member"}
+                          </TooltipContent>
+                        </Tooltip>
                       ) : null}
                     </div>
                   </div>


### PR DESCRIPTION
💡 What: 
This PR implements two micro-UX improvements focused on accessibility and discoverability:
1. **Restructured `TooltipTrigger` usage** in the projects table. Previously, some children were placed outside the component passed to the `render` prop, which could lead to accessibility properties not being correctly associated with the interactive trigger.
2. **Added a tooltip to the member removal button** in the workspace members settings page. Since this is an icon-only button, a tooltip provides essential clarity for the action.

🎯 Why: 
- To adhere to established accessibility best practices in the codebase (as documented in `.jules/palette.md`).
- To make icon-only actions more discoverable and intuitive for users.

♿ Accessibility: 
- Fixed `TooltipTrigger` structure ensures ARIA labels and screen-reader text are correctly associated with buttons.
- Added tooltip content matches existing ARIA labels for consistency.

---
*PR created automatically by Jules for task [4180939367185392359](https://jules.google.com/task/4180939367185392359) started by @cungminh2710*