### PR TITLE
feat(web): TMS sync observability, retries, and webhook e2e validation (HL-408)

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/external-tms-provider-credential/external-tms-provider-credential.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/external-tms-provider-credential/external-tms-provider-credential.route.ts
@@ -3,7 +3,7 @@ import { validator } from "hono/validator";
 
 import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
 import { hasCapability } from "@/api/auth/policy";
-import { notFoundResponse } from "@/api/response.schema";
+import { badRequestResponse, notFoundResponse } from "@/api/response.schema";
 import { fetchCrowdinProjects } from "@/lib/providers/crowdin/crowdin-project-fetcher";
 import { fetchLokaliseProjects } from "@/lib/providers/lokalise/lokalise-project-fetcher";
 import { fetchPhraseProjects } from "@/lib/providers/phrase/phrase-project-fetcher";
@@ -29,9 +29,16 @@ import {
   ensureProviderWebhookSubscriptionsForCredential,
   listProviderWebhookSubscriptionSummaries,
 } from "@/lib/providers/provider-webhook-subscription-manager";
+import {
+  getProviderSyncObservability,
+  ProviderSyncIntentNotFoundError,
+  ProviderSyncIntentNotRetryableError,
+  retryProviderSyncIntent,
+} from "@/lib/providers/provider-sync-observability";
 
 import {
   externalTmsProviderKindSchema,
+  providerSyncObservabilityQuerySchema,
   revealExternalTmsProviderCredentialBodySchema,
   upsertExternalTmsProviderCredentialBodySchema,
 } from "./external-tms-provider-credential.schema";
@@ -211,6 +218,82 @@ export function createExternalTmsProviderCredentialRoutes() {
       });
 
       return c.json({ providerWebhookSubscriptions }, 200);
+    })
+    .get("/:providerKind/sync-observability", async (c) => {
+      if (!hasCapability(c.var.auth.membership.role, "provider_credentials:read")) {
+        return c.json({ error: "forbidden" }, 403);
+      }
+
+      const providerKind = externalTmsProviderKindSchema.safeParse(c.req.param("providerKind"));
+      if (!providerKind.success) {
+        return c.json({ error: "invalid_external_tms_provider_kind" }, 400);
+      }
+
+      const query = providerSyncObservabilityQuerySchema.safeParse({
+        projectId: c.req.query("projectId") || undefined,
+      });
+      if (!query.success) {
+        return badRequestResponse(c, "invalid_sync_observability_query");
+      }
+
+      const providerCredentialSummary = await getOrganizationExternalTmsProviderCredentialSummary(
+        c.var.auth.organization.localOrganizationId,
+        providerKind.data,
+      );
+      if (!providerCredentialSummary) {
+        return c.json({ error: "provider_credential_not_found" }, 404);
+      }
+
+      const providerSyncObservability = await getProviderSyncObservability({
+        organizationId: c.var.auth.organization.localOrganizationId,
+        providerKind: providerKind.data,
+        providerCredentialId: providerCredentialSummary.id,
+        projectId: query.data.projectId,
+      });
+
+      return c.json({ providerSyncObservability }, 200);
+    })
+    .post("/:providerKind/sync-intents/:intentId/retry", async (c) => {
+      try {
+        assertExternalTmsCredentialAdmin(c.var.auth.membership.role);
+
+        const providerKind = externalTmsProviderKindSchema.safeParse(c.req.param("providerKind"));
+        if (!providerKind.success) {
+          return c.json({ error: "invalid_external_tms_provider_kind" }, 400);
+        }
+
+        const intentId = c.req.param("intentId");
+        if (!intentId) {
+          return badRequestResponse(c, "invalid_provider_sync_intent_id");
+        }
+
+        const providerCredentialSummary = await getOrganizationExternalTmsProviderCredentialSummary(
+          c.var.auth.organization.localOrganizationId,
+          providerKind.data,
+        );
+        if (!providerCredentialSummary) {
+          return c.json({ error: "provider_credential_not_found" }, 404);
+        }
+
+        const result = await retryProviderSyncIntent({
+          organizationId: c.var.auth.organization.localOrganizationId,
+          providerKind: providerKind.data,
+          intentId,
+        });
+
+        return c.json(result, 200);
+      } catch (error) {
+        if (error instanceof Error && error.message === "forbidden") {
+          return c.json({ error: "forbidden" }, 403);
+        }
+        if (error instanceof ProviderSyncIntentNotFoundError) {
+          return notFoundResponse(c, "provider_sync_intent_not_found");
+        }
+        if (error instanceof ProviderSyncIntentNotRetryableError) {
+          return badRequestResponse(c, "provider_sync_intent_not_retryable");
+        }
+        throw error;
+      }
     })
     .post("/:providerKind/webhook-subscriptions/retry", async (c) => {
       try {

--- a/apps/hyperlocalise-web/src/api/routes/external-tms-provider-credential/external-tms-provider-credential.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/external-tms-provider-credential/external-tms-provider-credential.schema.ts
@@ -15,6 +15,10 @@ export const revealExternalTmsProviderCredentialBodySchema = z.object({
   confirmed: z.literal(true),
 });
 
+export const providerSyncObservabilityQuerySchema = z.object({
+  projectId: z.string().trim().min(1).optional(),
+});
+
 export const externalTmsProviderHealthResponseSchema = z.object({
   externalTmsProviderHealth: z.object({
     providerKind: externalTmsProviderKindSchema,

--- a/apps/hyperlocalise-web/src/api/routes/tms-webhook/tms-webhook.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/tms-webhook/tms-webhook.route.test.ts
@@ -654,6 +654,213 @@ describe("tmsWebhookRoutes", () => {
     expect(rows).toHaveLength(0);
   });
 
+  describe("Lokalise webhooks", () => {
+    async function createLokaliseSubscriptionFixture() {
+      const { organizationId, userId } = await createOrganizationUser();
+      const credential = await upsertOrganizationExternalTmsProviderCredential({
+        organizationId,
+        userId,
+        role: "owner",
+        providerKind: "lokalise",
+        displayName: "Lokalise",
+        secretMaterial: "secret-token",
+      });
+      const subscription = await insertProviderWebhookSubscription({
+        organizationId,
+        providerCredentialId: credential.id,
+        providerKind: "lokalise",
+        providerWebhookId: "lokalise-wh-1",
+        endpointUrl: "https://app.example.test/api/webhooks/tms/lokalise",
+        webhookSecretPlaintext: "webhook-signing-secret",
+      });
+
+      return { organizationId, subscription };
+    }
+
+    function postLokaliseWebhook(input: {
+      app: ReturnType<typeof createApp>;
+      body: string;
+      secret?: string | null;
+      webhookId?: string;
+    }) {
+      const headers: Record<string, string> = {
+        "content-type": "application/json",
+        "webhook-id": input.webhookId ?? "lokalise-wh-1",
+      };
+
+      if (input.secret !== null) {
+        headers["x-secret"] = input.secret ?? "webhook-signing-secret";
+      }
+
+      return input.app.request("http://localhost/api/webhooks/tms/lokalise", {
+        method: "POST",
+        headers,
+        body: input.body,
+      });
+    }
+
+    it("accepts signed translation events and queues reconciliation", async () => {
+      const { organizationId, subscription } = await createLokaliseSubscriptionFixture();
+      const queuedEvents: ProviderWebhookReconciliationEventData[] = [];
+      const app = createApp({
+        providerWebhookReconciliationQueue: {
+          async enqueue(event) {
+            queuedEvents.push(event);
+            return { ids: [randomUUID()] };
+          },
+        },
+      });
+      const body = JSON.stringify({
+        uuid: "evt-lokalise-translation",
+        event: "project.translation.updated",
+        key: { id: 789 },
+        project: { id: "lokalise-project-1" },
+      });
+
+      const response = await postLokaliseWebhook({ app, body });
+
+      expect(response.status).toBe(202);
+      const [intent] = await db
+        .select()
+        .from(schema.providerSyncIntents)
+        .where(eq(schema.providerSyncIntents.organizationId, organizationId));
+      expect(intent).toMatchObject({
+        organizationId,
+        providerKind: "lokalise",
+        syncKind: "file_key_scan",
+        cause: "webhook",
+        status: "pending",
+      });
+      expect(queuedEvents).toHaveLength(1);
+      expect(queuedEvents[0]?.subscriptionId).toBe(subscription.id);
+    });
+
+    it("rejects Lokalise deliveries with invalid secrets", async () => {
+      await createLokaliseSubscriptionFixture();
+      const app = createApp();
+      const body = JSON.stringify({
+        uuid: "evt-lokalise-invalid",
+        event: "project.translation.updated",
+        key: { id: 1 },
+      });
+
+      const response = await postLokaliseWebhook({ app, body, secret: "wrong-secret" });
+
+      expect(response.status).toBe(401);
+      await expect(response.json()).resolves.toEqual({ error: "invalid_signature" });
+    });
+  });
+
+  describe("Smartling webhooks", () => {
+    async function createSmartlingSubscriptionFixture() {
+      const { organizationId, userId } = await createOrganizationUser();
+      const credential = await upsertOrganizationExternalTmsProviderCredential({
+        organizationId,
+        userId,
+        role: "owner",
+        providerKind: "smartling",
+        displayName: "Smartling",
+        secretMaterial: "secret-token",
+      });
+      const subscription = await insertProviderWebhookSubscription({
+        organizationId,
+        providerCredentialId: credential.id,
+        providerKind: "smartling",
+        providerWebhookId: "smartling-wh-1",
+        endpointUrl: "https://app.example.test/api/webhooks/tms/smartling",
+        webhookSecretPlaintext: "webhook-signing-secret",
+      });
+
+      return { organizationId, subscription };
+    }
+
+    function smartlingSignatureFor(body: string, eventId: string, eventTimestamp: string) {
+      const signedPayload = `${eventId}.${eventTimestamp}.${body}`;
+      return createHmac("sha256", "webhook-signing-secret").update(signedPayload).digest("hex");
+    }
+
+    function postSmartlingWebhook(input: {
+      app: ReturnType<typeof createApp>;
+      body: string;
+      eventId?: string;
+      eventTimestamp?: string;
+      signature?: string | null;
+    }) {
+      const eventId = input.eventId ?? "evt-smartling-1";
+      const eventTimestamp = input.eventTimestamp ?? String(Math.floor(Date.now() / 1000));
+      const headers: Record<string, string> = {
+        "content-type": "application/json",
+        "event-id": eventId,
+        "event-timestamp": eventTimestamp,
+        "x-hyperlocalise-provider-webhook-id": "smartling-wh-1",
+      };
+
+      if (input.signature !== null) {
+        headers["event-signature"] =
+          input.signature ?? smartlingSignatureFor(input.body, eventId, eventTimestamp);
+      }
+
+      return input.app.request("http://localhost/api/webhooks/tms/smartling", {
+        method: "POST",
+        headers,
+        body: input.body,
+      });
+    }
+
+    it("accepts signed file events and queues reconciliation", async () => {
+      const { organizationId, subscription } = await createSmartlingSubscriptionFixture();
+      const queuedEvents: ProviderWebhookReconciliationEventData[] = [];
+      const app = createApp({
+        providerWebhookReconciliationQueue: {
+          async enqueue(event) {
+            queuedEvents.push(event);
+            return { ids: [randomUUID()] };
+          },
+        },
+      });
+      const body = JSON.stringify({
+        type: "file.published",
+        file: { fileUri: "/locales/en.json" },
+        project: { projectUid: "smartling-project-1" },
+      });
+
+      const response = await postSmartlingWebhook({ app, body, eventId: "evt-smartling-file" });
+
+      expect(response.status).toBe(202);
+      const [intent] = await db
+        .select()
+        .from(schema.providerSyncIntents)
+        .where(eq(schema.providerSyncIntents.organizationId, organizationId));
+      expect(intent).toMatchObject({
+        organizationId,
+        providerKind: "smartling",
+        syncKind: "file_key_scan",
+        cause: "webhook",
+        status: "pending",
+      });
+      expect(queuedEvents).toHaveLength(1);
+      expect(queuedEvents[0]?.subscriptionId).toBe(subscription.id);
+    });
+
+    it("rejects Smartling deliveries with invalid signatures", async () => {
+      await createSmartlingSubscriptionFixture();
+      const app = createApp();
+      const body = JSON.stringify({
+        type: "file.published",
+        file: { fileUri: "/locales/en.json" },
+      });
+
+      const response = await postSmartlingWebhook({
+        app,
+        body,
+        signature: "invalid-signature",
+      });
+
+      expect(response.status).toBe(401);
+      await expect(response.json()).resolves.toEqual({ error: "invalid_signature" });
+    });
+  });
+
   describe("Phrase webhooks", () => {
     function postPhraseWebhook(input: {
       app: ReturnType<typeof createApp>;

--- a/apps/hyperlocalise-web/src/api/routes/tms-webhook/tms-webhook.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/tms-webhook/tms-webhook.route.ts
@@ -328,8 +328,6 @@ export function createTmsWebhookRoutes(options: CreateTmsWebhookRoutesOptions = 
       if (!subscription) {
         logWebhookIgnored({
           providerKind: providerKindParam,
-          providerEventId: descriptor.providerEventId,
-          deliveryId: descriptor.deliveryId,
           reason: "subscription_not_found",
         });
         return c.json({ ok: true, ignored: true }, 202);

--- a/apps/hyperlocalise-web/src/api/routes/tms-webhook/tms-webhook.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/tms-webhook/tms-webhook.route.ts
@@ -352,8 +352,6 @@ export function createTmsWebhookRoutes(options: CreateTmsWebhookRoutesOptions = 
           providerKind: providerKindParam,
           organizationId: subscription.organizationId,
           subscriptionId: subscription.id,
-          providerEventId: descriptor.providerEventId,
-          deliveryId: descriptor.deliveryId,
         });
         return c.json({ error: "invalid_signature" }, 401);
       }

--- a/apps/hyperlocalise-web/src/api/routes/tms-webhook/tms-webhook.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/tms-webhook/tms-webhook.route.ts
@@ -3,6 +3,13 @@ import { bodyLimit } from "hono/body-limit";
 
 import { createLogger } from "@/lib/log";
 import { safeJsonParse } from "@/lib/primitives/safeJsonParse/safeJsonParse";
+import {
+  logIntentEnqueued,
+  logWebhookAccepted,
+  logWebhookDuplicate,
+  logWebhookIgnored,
+  logWebhookVerificationFailed,
+} from "@/lib/providers/provider-tms-sync-telemetry";
 import type { ExternalTmsProviderKind } from "@/lib/providers/organization-external-tms-provider-credentials";
 import { enqueueProviderSyncIntentFromWebhookEvent } from "@/lib/providers/provider-sync-intent-worker";
 import {
@@ -112,17 +119,14 @@ export function createTmsWebhookRoutes(options: CreateTmsWebhookRoutesOptions = 
           ? "unsupported_provider_webhook_event"
           : "unrecognized_provider_webhook_event";
 
-      logger.warn(
-        {
-          providerKind: input.providerKind,
-          subscriptionId: input.subscriptionId,
-          providerWebhookEventId: input.providerWebhookEventId,
-          eventType: input.descriptor.eventType,
-          resourceType: input.descriptor.resourceType ?? null,
-          mappedIntentKinds: input.descriptor.mappedIntents.map((intent) => intent.kind),
-        },
-        "ignoring webhook: unsupported provider event",
-      );
+      logWebhookIgnored({
+        providerKind: input.providerKind,
+        organizationId: input.organizationId,
+        subscriptionId: input.subscriptionId,
+        providerWebhookEventId: input.providerWebhookEventId,
+        eventType: input.descriptor.eventType,
+        reason: errorMessage,
+      });
 
       await updateProviderWebhookEventProcessingStatus({
         eventId: input.providerWebhookEventId,
@@ -159,6 +163,15 @@ export function createTmsWebhookRoutes(options: CreateTmsWebhookRoutesOptions = 
           mappedIntent,
         });
         primaryProviderSyncIntentId ??= providerSyncIntentId;
+
+        logIntentEnqueued({
+          providerKind: input.providerKind,
+          organizationId: input.organizationId,
+          subscriptionId: input.subscriptionId,
+          providerWebhookEventId: input.providerWebhookEventId,
+          providerSyncIntentId,
+          syncKind: mappedIntent.kind,
+        });
 
         const record = { key, providerSyncIntentId };
         enqueuedMappedIntents.push(record);
@@ -295,7 +308,10 @@ export function createTmsWebhookRoutes(options: CreateTmsWebhookRoutesOptions = 
         requestUrl: c.req.url,
       });
       if (!descriptor) {
-        logger.info({ providerKind: providerKindParam }, "ignoring webhook: missing identifiers");
+        logWebhookIgnored({
+          providerKind: providerKindParam,
+          reason: "missing_identifiers",
+        });
         return c.json({ ok: true, ignored: true }, 202);
       }
 
@@ -310,7 +326,12 @@ export function createTmsWebhookRoutes(options: CreateTmsWebhookRoutesOptions = 
         providerWebhookId: descriptor.providerWebhookId,
       });
       if (!subscription) {
-        log.info("ignoring webhook: subscription not found");
+        logWebhookIgnored({
+          providerKind: providerKindParam,
+          providerEventId: descriptor.providerEventId,
+          deliveryId: descriptor.deliveryId,
+          reason: "subscription_not_found",
+        });
         return c.json({ ok: true, ignored: true }, 202);
       }
       if (!subscription.webhookSecretPlaintext) {
@@ -327,7 +348,13 @@ export function createTmsWebhookRoutes(options: CreateTmsWebhookRoutesOptions = 
         descriptor,
       });
       if (!verified) {
-        log.warn({ subscriptionId: subscription.id }, "invalid webhook signature");
+        logWebhookVerificationFailed({
+          providerKind: providerKindParam,
+          organizationId: subscription.organizationId,
+          subscriptionId: subscription.id,
+          providerEventId: descriptor.providerEventId,
+          deliveryId: descriptor.deliveryId,
+        });
         return c.json({ error: "invalid_signature" }, 401);
       }
 
@@ -372,21 +399,40 @@ export function createTmsWebhookRoutes(options: CreateTmsWebhookRoutesOptions = 
             enqueuedMappedIntents: enqueuedMappedIntentRecords(stored.event.errorDetails),
           });
 
-          log.info(
-            {
+          if (providerSyncIntentId) {
+            logWebhookDuplicate({
+              providerKind: providerKindParam,
+              organizationId: subscription.organizationId,
               subscriptionId: subscription.id,
-              providerSyncIntentId,
               providerWebhookEventId: stored.event.id,
-            },
-            providerSyncIntentId
-              ? "webhook reconciliation requeued for pending duplicate"
-              : "webhook duplicate ignored for unrecognized provider event",
-          );
+              providerSyncIntentId,
+              providerEventId: descriptor.providerEventId,
+              deliveryId: descriptor.deliveryId,
+              reason: "requeued_pending_duplicate",
+            });
+          } else {
+            logWebhookIgnored({
+              providerKind: providerKindParam,
+              organizationId: subscription.organizationId,
+              subscriptionId: subscription.id,
+              providerWebhookEventId: stored.event.id,
+              providerEventId: descriptor.providerEventId,
+              deliveryId: descriptor.deliveryId,
+              reason: "duplicate_unrecognized_event",
+            });
+          }
 
           return c.json({ ok: true, ignored: providerSyncIntentId === null, duplicate: true }, 202);
         }
 
-        log.info({ subscriptionId: subscription.id }, "ignoring duplicate webhook delivery");
+        logWebhookDuplicate({
+          providerKind: providerKindParam,
+          organizationId: subscription.organizationId,
+          subscriptionId: subscription.id,
+          providerWebhookEventId: stored.event?.id,
+          providerEventId: descriptor.providerEventId,
+          deliveryId: descriptor.deliveryId,
+        });
         return c.json({ ok: true, ignored: true, duplicate: true }, 200);
       }
 
@@ -400,16 +446,29 @@ export function createTmsWebhookRoutes(options: CreateTmsWebhookRoutesOptions = 
         descriptor,
       });
 
-      log.info(
-        {
+      if (providerSyncIntentId) {
+        logWebhookAccepted({
+          providerKind: providerKindParam,
+          organizationId: subscription.organizationId,
           subscriptionId: subscription.id,
-          providerSyncIntentId,
           providerWebhookEventId: stored.event.id,
-        },
-        providerSyncIntentId
-          ? "webhook accepted"
-          : "webhook ignored for unrecognized provider event",
-      );
+          providerSyncIntentId,
+          providerEventId: descriptor.providerEventId,
+          deliveryId: descriptor.deliveryId,
+          eventType: descriptor.eventType,
+        });
+      } else {
+        logWebhookIgnored({
+          providerKind: providerKindParam,
+          organizationId: subscription.organizationId,
+          subscriptionId: subscription.id,
+          providerWebhookEventId: stored.event.id,
+          providerEventId: descriptor.providerEventId,
+          deliveryId: descriptor.deliveryId,
+          eventType: descriptor.eventType,
+          reason: "unrecognized_provider_event",
+        });
+      }
 
       return c.json({ ok: true, ignored: providerSyncIntentId === null }, 202);
     },

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-page-content.tsx
@@ -24,6 +24,7 @@ import { createApiClient } from "@/lib/api-client";
 import type { ExternalTmsProviderCredentialListItem } from "@/lib/providers/organization-external-tms-provider-credentials";
 import type { ProviderWebhookSubscriptionSummary } from "@/lib/providers/provider-webhook-subscription-types";
 import { toneClass } from "../../_components/workspace-resource-shared";
+import { TmsSyncObservabilityPanel } from "./tms-sync-observability-panel";
 import {
   AlertDialog,
   AlertDialogCancel,
@@ -1099,6 +1100,15 @@ export function IntegrationsPageContent({
                     <div className="rounded-lg border border-dashed border-border px-4 py-3 text-sm text-muted-foreground">
                       Webhook subscriptions appear after projects are synced for this provider.
                     </div>
+                  ) : null}
+
+                  {selectedTmsProvider ? (
+                    <TmsSyncObservabilityPanel
+                      organizationSlug={organizationSlug}
+                      providerKind={selectedTmsProvider}
+                      membershipRole={membershipRole}
+                      enabled={Boolean(selectedTmsCredential)}
+                    />
                   ) : null}
 
                   <DialogFooter className="gap-2 sm:justify-between">

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/tms-sync-observability-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/tms-sync-observability-panel.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { hasCapability } from "@/api/auth/policy";
+import type { OrganizationMembershipRole } from "@/lib/database/types";
+import { createApiClient } from "@/lib/api-client";
+import type { ExternalTmsProviderKind } from "@/lib/providers/organization-external-tms-provider-credentials";
+import type { ProviderSyncObservabilityEntry } from "@/lib/providers/provider-sync-observability-types";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { toneClass } from "../../_components/workspace-resource-shared";
+
+const api = createApiClient();
+
+function syncStatusTone(active: boolean) {
+  return active ? ("safe" as const) : ("watch" as const);
+}
+
+function processingStatusLabel(status: string) {
+  return status.replaceAll("_", " ");
+}
+
+function ObservabilityEntryCard({
+  entry,
+  canRetry,
+  onRetryIntent,
+  retryingIntentId,
+}: {
+  entry: ProviderSyncObservabilityEntry;
+  canRetry: boolean;
+  onRetryIntent: (intentId: string) => void;
+  retryingIntentId: string | null;
+}) {
+  return (
+    <div className="space-y-3 rounded-md border border-border bg-card p-3 text-sm">
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge variant="outline" className={toneClass(syncStatusTone(entry.automaticSyncActive))}>
+          {entry.automaticSyncActive ? "Automatic sync active" : "Automatic sync inactive"}
+        </Badge>
+        {entry.projectId ? (
+          <span className="text-xs text-muted-foreground">Project {entry.projectId}</span>
+        ) : (
+          <span className="text-xs text-muted-foreground">Organization scope</span>
+        )}
+      </div>
+
+      <dl className="grid gap-2 text-muted-foreground">
+        <div>
+          <dt className="font-medium text-foreground">Latest webhook event</dt>
+          <dd className="mt-0.5">
+            {entry.latestWebhookEvent ? (
+              <>
+                <span className="capitalize">
+                  {processingStatusLabel(entry.latestWebhookEvent.processingStatus)}
+                </span>
+                <span className="text-xs"> · {entry.latestWebhookEvent.eventType}</span>
+                <p className="mt-1 font-mono text-xs">{entry.latestWebhookEvent.id}</p>
+              </>
+            ) : (
+              "No events received yet"
+            )}
+          </dd>
+        </div>
+
+        <div>
+          <dt className="font-medium text-foreground">Latest sync intent</dt>
+          <dd className="mt-0.5">
+            {entry.latestSyncIntent ? (
+              <>
+                <span className="capitalize">
+                  {processingStatusLabel(entry.latestSyncIntent.status)} ·{" "}
+                  {entry.latestSyncIntent.syncKind}
+                </span>
+                <p className="mt-1 font-mono text-xs">{entry.latestSyncIntent.id}</p>
+                {entry.latestSyncIntent.lastError ? (
+                  <p className="mt-1 text-destructive">{entry.latestSyncIntent.lastError}</p>
+                ) : null}
+                {canRetry && entry.latestSyncIntent.canRetry ? (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="mt-2"
+                    disabled={retryingIntentId === entry.latestSyncIntent.id}
+                    onClick={() => onRetryIntent(entry.latestSyncIntent!.id)}
+                  >
+                    {retryingIntentId === entry.latestSyncIntent.id
+                      ? "Retrying..."
+                      : "Retry sync intent"}
+                  </Button>
+                ) : null}
+              </>
+            ) : (
+              "No sync intents yet"
+            )}
+          </dd>
+        </div>
+
+        <div>
+          <dt className="font-medium text-foreground">Latest provider sync run</dt>
+          <dd className="mt-0.5">
+            {entry.latestSyncRun ? (
+              <>
+                <span className="capitalize">
+                  {processingStatusLabel(entry.latestSyncRun.status)} · {entry.latestSyncRun.kind}
+                </span>
+                <p className="mt-1 font-mono text-xs">{entry.latestSyncRun.id}</p>
+              </>
+            ) : (
+              "No sync runs yet"
+            )}
+          </dd>
+        </div>
+      </dl>
+    </div>
+  );
+}
+
+export function TmsSyncObservabilityPanel({
+  organizationSlug,
+  providerKind,
+  membershipRole,
+  enabled,
+}: {
+  organizationSlug: string;
+  providerKind: ExternalTmsProviderKind;
+  membershipRole: OrganizationMembershipRole;
+  enabled: boolean;
+}) {
+  const queryClient = useQueryClient();
+  const userIsAdmin = hasCapability(membershipRole, "provider_credentials:write");
+
+  const observabilityQuery = useQuery({
+    queryKey: ["provider-sync-observability", organizationSlug, providerKind],
+    enabled,
+    queryFn: async () => {
+      const res = await api.api.orgs[":organizationSlug"]["external-tms-provider-credential"][
+        ":providerKind"
+      ]["sync-observability"].$get({
+        param: { organizationSlug, providerKind },
+      });
+
+      if (!res.ok) {
+        throw new Error("Unable to load sync observability");
+      }
+
+      return res.json();
+    },
+  });
+
+  const retryIntent = useMutation({
+    mutationFn: async (intentId: string) => {
+      const res = await api.api.orgs[":organizationSlug"]["external-tms-provider-credential"][
+        ":providerKind"
+      ]["sync-intents"][":intentId"].retry.$post({
+        param: { organizationSlug, providerKind, intentId },
+      });
+
+      if (!res.ok) {
+        const error = await res.json().catch(() => ({ error: "sync_intent_retry_failed" }));
+        throw new Error("message" in error ? String(error.message) : "Unable to retry sync intent");
+      }
+
+      return res.json();
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ["provider-sync-observability", organizationSlug, providerKind],
+      });
+      toast.success("Sync intent requeued");
+    },
+    onError: (error) => {
+      toast.error(error.message);
+    },
+  });
+
+  if (!enabled) {
+    return null;
+  }
+
+  if (observabilityQuery.isLoading) {
+    return (
+      <div className="space-y-2 rounded-lg border border-dashed border-border px-4 py-3">
+        <Skeleton className="h-4 w-40" />
+        <Skeleton className="h-16 w-full" />
+      </div>
+    );
+  }
+
+  if (observabilityQuery.isError) {
+    return (
+      <div className="rounded-lg border border-dashed border-border px-4 py-3 text-sm text-destructive">
+        Unable to load sync activity for this provider.
+      </div>
+    );
+  }
+
+  const entries = observabilityQuery.data?.providerSyncObservability.entries ?? [];
+  if (entries.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed border-border px-4 py-3 text-sm text-muted-foreground">
+        Sync activity appears after webhook subscriptions are created for synced projects.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3 rounded-lg border border-border bg-muted/20 p-4">
+      <div>
+        <p className="text-sm font-medium text-foreground">Sync activity</p>
+        <p className="mt-0.5 text-sm text-muted-foreground">
+          Trace the latest webhook delivery, queued sync intent, and provider sync run. IDs are safe
+          for support debugging and do not include customer content.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        {entries.map((entry) => (
+          <ObservabilityEntryCard
+            key={entry.subscription.id}
+            entry={entry}
+            canRetry={userIsAdmin}
+            onRetryIntent={(intentId) => retryIntent.mutate(intentId)}
+            retryingIntentId={retryIntent.isPending ? (retryIntent.variables ?? null) : null}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/lib/providers/provider-sync-intent-worker.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-sync-intent-worker.ts
@@ -13,6 +13,7 @@ import {
   ProviderWebhookEventNotFoundError,
   updateProviderWebhookEventProcessingStatus,
 } from "./provider-webhook-storage";
+import { logReconciliationFailed, logReconciliationSucceeded } from "./provider-tms-sync-telemetry";
 import type { ProviderWebhookEventProcessingStatus } from "@/lib/database/types";
 
 type WebhookEventStatusUpdate = {
@@ -203,6 +204,15 @@ export async function processProviderSyncIntent(
         { requireAll: false },
       );
 
+      logReconciliationFailed({
+        providerKind: claimed.providerKind,
+        organizationId: input.organizationId,
+        providerSyncIntentId: claimed.id,
+        providerSyncRunId: dispatchResult.runId,
+        processingStatus: failedIntent.status,
+        reason: "provider_sync_run_failed",
+      });
+
       return {
         ok: false,
         intentId: claimed.id,
@@ -238,6 +248,14 @@ export async function processProviderSyncIntent(
       },
       { requireAll: false },
     );
+
+    logReconciliationSucceeded({
+      providerKind: claimed.providerKind,
+      organizationId: input.organizationId,
+      providerSyncIntentId: claimed.id,
+      providerSyncRunId: dispatchResult.runId,
+      syncKind: claimed.syncKind,
+    });
 
     return {
       ok: true,
@@ -280,6 +298,14 @@ export async function processProviderSyncIntent(
       },
       { requireAll: false },
     );
+
+    logReconciliationFailed({
+      providerKind: claimed.providerKind,
+      organizationId: input.organizationId,
+      providerSyncIntentId: claimed.id,
+      processingStatus: failedIntent.status,
+      reason: message,
+    });
 
     return {
       ok: false,

--- a/apps/hyperlocalise-web/src/lib/providers/provider-sync-observability-types.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-sync-observability-types.ts
@@ -1,0 +1,62 @@
+import type {
+  ProviderSyncIntentStatus,
+  ProviderSyncRunStatus,
+  ProviderWebhookEventProcessingStatus,
+  ProviderWebhookSubscriptionStatus,
+} from "@/lib/database/types";
+
+import type { ExternalTmsProviderKind } from "./organization-external-tms-provider-credentials";
+import type { ProviderWebhookSubscriptionSummary } from "./provider-webhook-subscription-types";
+
+export type ProviderSyncObservabilityWebhookEventSummary = {
+  id: string;
+  eventType: string;
+  processingStatus: ProviderWebhookEventProcessingStatus;
+  providerSyncIntentId: string | null;
+  providerSyncRunId: string | null;
+  receivedAt: string;
+  processedAt: string | null;
+  errorMessage: string | null;
+};
+
+export type ProviderSyncObservabilityIntentSummary = {
+  id: string;
+  syncKind: string;
+  status: ProviderSyncIntentStatus;
+  cause: string;
+  attempts: number;
+  maxAttempts: number;
+  lastError: string | null;
+  providerSyncRunId: string | null;
+  createdAt: string;
+  updatedAt: string;
+  completedAt: string | null;
+  canRetry: boolean;
+};
+
+export type ProviderSyncObservabilityRunSummary = {
+  id: string;
+  kind: string;
+  status: ProviderSyncRunStatus;
+  startedAt: string;
+  completedAt: string | null;
+  errorMessage: string | null;
+};
+
+export type ProviderSyncObservabilityEntry = {
+  projectId: string | null;
+  subscription: ProviderWebhookSubscriptionSummary;
+  automaticSyncActive: boolean;
+  latestWebhookEvent: ProviderSyncObservabilityWebhookEventSummary | null;
+  latestSyncIntent: ProviderSyncObservabilityIntentSummary | null;
+  latestSyncRun: ProviderSyncObservabilityRunSummary | null;
+};
+
+export type ProviderSyncObservability = {
+  providerKind: ExternalTmsProviderKind;
+  entries: ProviderSyncObservabilityEntry[];
+};
+
+export function isAutomaticSyncActive(status: ProviderWebhookSubscriptionStatus) {
+  return status === "active";
+}

--- a/apps/hyperlocalise-web/src/lib/providers/provider-sync-observability.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-sync-observability.test.ts
@@ -175,6 +175,111 @@ describe("provider sync observability", () => {
     });
   });
 
+  it("keeps global observability scoped to global intents and runs", async () => {
+    const { organizationId, userId } = await createOrganizationUser();
+    const credential = await upsertOrganizationExternalTmsProviderCredential({
+      organizationId,
+      userId,
+      role: "owner",
+      providerKind: "crowdin",
+      displayName: "Crowdin",
+      secretMaterial: "secret-token",
+    });
+
+    const projectId = `project_${randomUUID()}`;
+    await db.insert(schema.projects).values({
+      id: projectId,
+      organizationId,
+      name: "Crowdin project",
+      description: "",
+      translationContext: "",
+      source: "external_tms",
+      externalProviderCredentialId: credential.id,
+      externalProviderKind: "crowdin",
+      externalProjectId: "crowdin-project-1",
+      targetLocales: ["fr"],
+      isActive: true,
+    });
+
+    await insertProviderWebhookSubscription({
+      organizationId,
+      providerCredentialId: credential.id,
+      providerKind: "crowdin",
+      providerWebhookId: "webhook-global",
+      endpointUrl: "https://app.example.test/api/webhooks/tms/crowdin",
+      webhookSecretPlaintext: "webhook-signing-secret",
+      status: "active",
+    });
+    await insertProviderWebhookSubscription({
+      organizationId,
+      providerCredentialId: credential.id,
+      providerKind: "crowdin",
+      providerWebhookId: "webhook-project",
+      endpointUrl: "https://app.example.test/api/webhooks/tms/crowdin",
+      webhookSecretPlaintext: "webhook-signing-secret",
+      status: "active",
+      projectId,
+    });
+
+    const [globalIntent] = await db
+      .insert(schema.providerSyncIntents)
+      .values({
+        organizationId,
+        providerCredentialId: credential.id,
+        providerKind: "crowdin",
+        syncKind: "file_key_scan",
+        cause: "webhook",
+        status: "succeeded",
+        leaseKey: `global-${randomUUID()}`,
+        createdAt: new Date("2026-01-01T00:00:00Z"),
+        updatedAt: new Date("2026-01-01T00:00:00Z"),
+      })
+      .returning();
+
+    const [projectRun] = await db
+      .insert(schema.providerSyncRuns)
+      .values({
+        organizationId,
+        providerKind: "crowdin",
+        kind: "file_key_scan",
+        status: "succeeded",
+        projectId,
+        startedAt: new Date("2026-01-02T00:00:00Z"),
+      })
+      .returning();
+
+    const [projectIntent] = await db
+      .insert(schema.providerSyncIntents)
+      .values({
+        organizationId,
+        providerCredentialId: credential.id,
+        providerKind: "crowdin",
+        projectId,
+        syncKind: "file_key_scan",
+        cause: "webhook",
+        status: "succeeded",
+        providerSyncRunId: projectRun!.id,
+        leaseKey: `project-${randomUUID()}`,
+        createdAt: new Date("2026-01-02T00:00:00Z"),
+        updatedAt: new Date("2026-01-02T00:00:00Z"),
+      })
+      .returning();
+
+    const observability = await getProviderSyncObservability({
+      organizationId,
+      providerKind: "crowdin",
+      providerCredentialId: credential.id,
+    });
+
+    const globalEntry = observability.entries.find((entry) => entry.projectId === null);
+    const projectEntry = observability.entries.find((entry) => entry.projectId === projectId);
+
+    expect(globalEntry?.latestSyncIntent?.id).toBe(globalIntent!.id);
+    expect(globalEntry?.latestSyncRun).toBeNull();
+    expect(projectEntry?.latestSyncIntent?.id).toBe(projectIntent!.id);
+    expect(projectEntry?.latestSyncRun?.id).toBe(projectRun!.id);
+  });
+
   it("requeues a failed intent without creating a duplicate intent row", async () => {
     const { organizationId, userId } = await createOrganizationUser();
     const credential = await upsertOrganizationExternalTmsProviderCredential({

--- a/apps/hyperlocalise-web/src/lib/providers/provider-sync-observability.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-sync-observability.test.ts
@@ -13,7 +13,6 @@ import type { ProviderWebhookReconciliationEventData } from "@/lib/workflow/type
 
 import {
   getProviderSyncObservability,
-  ProviderSyncIntentNotFoundError,
   ProviderSyncIntentNotRetryableError,
   retryProviderSyncIntent,
 } from "./provider-sync-observability";
@@ -252,6 +251,87 @@ describe("provider sync observability", () => {
     });
   });
 
+  it("restores retryable state when manual retry enqueue fails", async () => {
+    const { organizationId, userId } = await createOrganizationUser();
+    const credential = await upsertOrganizationExternalTmsProviderCredential({
+      organizationId,
+      userId,
+      role: "owner",
+      providerKind: "phrase",
+      displayName: "Phrase",
+      secretMaterial: "secret-token",
+    });
+    const subscription = await insertProviderWebhookSubscription({
+      organizationId,
+      providerCredentialId: credential.id,
+      providerKind: "phrase",
+      providerWebhookId: "phrase-obs-enqueue-fails",
+      endpointUrl: "https://app.example.test/api/webhooks/tms/phrase",
+      webhookSecretPlaintext: "webhook-signing-secret",
+      status: "active",
+    });
+
+    const [webhookEvent] = await db
+      .insert(schema.providerWebhookEvents)
+      .values({
+        organizationId,
+        subscriptionId: subscription.id,
+        providerKind: "phrase",
+        providerEventId: "evt-phrase-retry-enqueue-fails",
+        eventType: "uploads:create",
+        dedupeKey: "evt-phrase-retry-enqueue-fails",
+        processingStatus: "failed",
+        errorMessage: "provider_sync_run_failed",
+      })
+      .returning();
+
+    const { intent } = await enqueueProviderSyncIntentFromWebhookEvent({
+      organizationId,
+      providerKind: "phrase",
+      providerCredentialId: credential.id,
+      syncKind: "file_key_scan",
+      providerWebhookEventId: webhookEvent!.id,
+    });
+
+    await db
+      .update(schema.providerSyncIntents)
+      .set({ status: "failed", lastError: "provider_sync_run_failed" })
+      .where(eq(schema.providerSyncIntents.id, intent.id));
+
+    await expect(
+      retryProviderSyncIntent({
+        organizationId,
+        providerKind: "phrase",
+        intentId: intent.id,
+        providerWebhookReconciliationQueue: {
+          async enqueue() {
+            throw new Error("queue unavailable");
+          },
+        },
+      }),
+    ).rejects.toThrow("queue unavailable");
+
+    const [storedIntent] = await db
+      .select()
+      .from(schema.providerSyncIntents)
+      .where(eq(schema.providerSyncIntents.id, intent.id));
+    expect(storedIntent).toMatchObject({
+      status: "failed",
+      lastError: "queue unavailable",
+      errorDetails: { message: "queue unavailable" },
+    });
+
+    const [storedEvent] = await db
+      .select()
+      .from(schema.providerWebhookEvents)
+      .where(eq(schema.providerWebhookEvents.id, webhookEvent!.id));
+    expect(storedEvent).toMatchObject({
+      processingStatus: "failed",
+      errorMessage: "queue unavailable",
+      errorDetails: { message: "queue unavailable" },
+    });
+  });
+
   it("rejects retry for non-retryable intents", async () => {
     const { organizationId, userId } = await createOrganizationUser();
     const credential = await upsertOrganizationExternalTmsProviderCredential({
@@ -394,7 +474,7 @@ describe("provider sync observability", () => {
           },
         },
       }),
-    ).rejects.toBeInstanceOf(ProviderSyncIntentNotFoundError);
+    ).rejects.toBeInstanceOf(ProviderSyncIntentNotRetryableError);
 
     const [storedIntent] = await db
       .select()

--- a/apps/hyperlocalise-web/src/lib/providers/provider-sync-observability.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-sync-observability.test.ts
@@ -13,6 +13,7 @@ import type { ProviderWebhookReconciliationEventData } from "@/lib/workflow/type
 
 import {
   getProviderSyncObservability,
+  ProviderSyncIntentNotFoundError,
   ProviderSyncIntentNotRetryableError,
   retryProviderSyncIntent,
 } from "./provider-sync-observability";
@@ -305,5 +306,103 @@ describe("provider sync observability", () => {
         },
       }),
     ).rejects.toBeInstanceOf(ProviderSyncIntentNotRetryableError);
+  });
+
+  it("does not mutate a failed intent when retry event references are missing", async () => {
+    const { organizationId, userId } = await createOrganizationUser();
+    const credential = await upsertOrganizationExternalTmsProviderCredential({
+      organizationId,
+      userId,
+      role: "owner",
+      providerKind: "crowdin",
+      displayName: "Crowdin",
+      secretMaterial: "secret-token",
+    });
+
+    const [intent] = await db
+      .insert(schema.providerSyncIntents)
+      .values({
+        organizationId,
+        providerCredentialId: credential.id,
+        providerKind: "crowdin",
+        syncKind: "file_key_scan",
+        cause: "webhook",
+        eventReferences: [],
+        leaseKey: `missing-event-${randomUUID()}`,
+        status: "failed",
+        lastError: "provider_sync_run_failed",
+      })
+      .returning();
+
+    await expect(
+      retryProviderSyncIntent({
+        organizationId,
+        providerKind: "crowdin",
+        intentId: intent!.id,
+        providerWebhookReconciliationQueue: {
+          async enqueue() {
+            return { ids: [randomUUID()] };
+          },
+        },
+      }),
+    ).rejects.toBeInstanceOf(ProviderSyncIntentNotRetryableError);
+
+    const [storedIntent] = await db
+      .select()
+      .from(schema.providerSyncIntents)
+      .where(eq(schema.providerSyncIntents.id, intent!.id));
+    expect(storedIntent).toMatchObject({
+      status: "failed",
+      lastError: "provider_sync_run_failed",
+    });
+  });
+
+  it("does not mutate a failed intent when retry webhook event is missing", async () => {
+    const { organizationId, userId } = await createOrganizationUser();
+    const credential = await upsertOrganizationExternalTmsProviderCredential({
+      organizationId,
+      userId,
+      role: "owner",
+      providerKind: "crowdin",
+      displayName: "Crowdin",
+      secretMaterial: "secret-token",
+    });
+
+    const [intent] = await db
+      .insert(schema.providerSyncIntents)
+      .values({
+        organizationId,
+        providerCredentialId: credential.id,
+        providerKind: "crowdin",
+        syncKind: "file_key_scan",
+        cause: "webhook",
+        eventReferences: [randomUUID()],
+        leaseKey: `deleted-event-${randomUUID()}`,
+        status: "failed",
+        lastError: "provider_sync_run_failed",
+      })
+      .returning();
+
+    await expect(
+      retryProviderSyncIntent({
+        organizationId,
+        providerKind: "crowdin",
+        intentId: intent!.id,
+        providerWebhookReconciliationQueue: {
+          async enqueue() {
+            return { ids: [randomUUID()] };
+          },
+        },
+      }),
+    ).rejects.toBeInstanceOf(ProviderSyncIntentNotFoundError);
+
+    const [storedIntent] = await db
+      .select()
+      .from(schema.providerSyncIntents)
+      .where(eq(schema.providerSyncIntents.id, intent!.id));
+    expect(storedIntent).toMatchObject({
+      status: "failed",
+      lastError: "provider_sync_run_failed",
+    });
   });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/provider-sync-observability.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-sync-observability.test.ts
@@ -1,0 +1,309 @@
+import "dotenv/config";
+
+import { randomUUID } from "node:crypto";
+
+import { eq, inArray } from "drizzle-orm";
+import { afterEach, beforeAll, describe, expect, it } from "vite-plus/test";
+
+import { db, schema } from "@/lib/database";
+import { upsertOrganizationExternalTmsProviderCredential } from "@/lib/providers/organization-external-tms-provider-credentials";
+import { enqueueProviderSyncIntentFromWebhookEvent } from "@/lib/providers/provider-sync-intent-worker";
+import { insertProviderWebhookSubscription } from "@/lib/providers/provider-webhook-storage";
+import type { ProviderWebhookReconciliationEventData } from "@/lib/workflow/types";
+
+import {
+  getProviderSyncObservability,
+  ProviderSyncIntentNotRetryableError,
+  retryProviderSyncIntent,
+} from "./provider-sync-observability";
+
+const createdOrganizationIds = new Set<string>();
+const createdUserIds = new Set<string>();
+
+async function createOrganizationUser() {
+  const userId = randomUUID();
+  const organizationId = randomUUID();
+
+  createdUserIds.add(userId);
+  createdOrganizationIds.add(organizationId);
+
+  await db.insert(schema.users).values({
+    id: userId,
+    workosUserId: `user_${randomUUID()}`,
+    email: `test-${userId}@example.com`,
+  });
+  await db.insert(schema.organizations).values({
+    id: organizationId,
+    workosOrganizationId: `org_${randomUUID()}`,
+    slug: `org-${randomUUID().slice(0, 8)}`,
+    name: "Acme",
+  });
+  await db.insert(schema.organizationMemberships).values({
+    organizationId,
+    userId,
+    role: "owner",
+  });
+
+  return { organizationId, userId };
+}
+
+beforeAll(async () => {
+  await db.$client.query("select 1");
+});
+
+afterEach(async () => {
+  const organizationIds = [...createdOrganizationIds];
+  const userIds = [...createdUserIds];
+
+  if (organizationIds.length > 0) {
+    await db
+      .delete(schema.providerSyncRuns)
+      .where(inArray(schema.providerSyncRuns.organizationId, organizationIds));
+    await db
+      .delete(schema.providerSyncIntents)
+      .where(inArray(schema.providerSyncIntents.organizationId, organizationIds));
+    await db
+      .delete(schema.providerWebhookEvents)
+      .where(inArray(schema.providerWebhookEvents.organizationId, organizationIds));
+    await db
+      .delete(schema.providerWebhookSubscriptions)
+      .where(inArray(schema.providerWebhookSubscriptions.organizationId, organizationIds));
+    await db
+      .delete(schema.organizationExternalTmsProviderCredentials)
+      .where(
+        inArray(schema.organizationExternalTmsProviderCredentials.organizationId, organizationIds),
+      );
+    await db
+      .delete(schema.organizationMemberships)
+      .where(inArray(schema.organizationMemberships.organizationId, organizationIds));
+    await db.delete(schema.organizations).where(inArray(schema.organizations.id, organizationIds));
+  }
+
+  if (userIds.length > 0) {
+    await db.delete(schema.users).where(inArray(schema.users.id, userIds));
+  }
+
+  createdOrganizationIds.clear();
+  createdUserIds.clear();
+});
+
+describe("provider sync observability", () => {
+  it("returns latest subscription, webhook event, intent, and run summaries", async () => {
+    const { organizationId, userId } = await createOrganizationUser();
+    const credential = await upsertOrganizationExternalTmsProviderCredential({
+      organizationId,
+      userId,
+      role: "owner",
+      providerKind: "crowdin",
+      displayName: "Crowdin",
+      secretMaterial: "secret-token",
+    });
+    const subscription = await insertProviderWebhookSubscription({
+      organizationId,
+      providerCredentialId: credential.id,
+      providerKind: "crowdin",
+      providerWebhookId: "webhook-obs-1",
+      endpointUrl: "https://app.example.test/api/webhooks/tms/crowdin",
+      webhookSecretPlaintext: "webhook-signing-secret",
+      status: "active",
+    });
+
+    const [webhookEvent] = await db
+      .insert(schema.providerWebhookEvents)
+      .values({
+        organizationId,
+        subscriptionId: subscription.id,
+        providerKind: "crowdin",
+        providerEventId: "evt-obs-1",
+        eventType: "file.updated",
+        dedupeKey: "evt-obs-1",
+        processingStatus: "failed",
+        errorMessage: "provider_sync_run_failed",
+      })
+      .returning();
+
+    const { intent } = await enqueueProviderSyncIntentFromWebhookEvent({
+      organizationId,
+      providerKind: "crowdin",
+      providerCredentialId: credential.id,
+      syncKind: "file_key_scan",
+      providerWebhookEventId: webhookEvent!.id,
+    });
+
+    const [run] = await db
+      .insert(schema.providerSyncRuns)
+      .values({
+        organizationId,
+        providerKind: "crowdin",
+        kind: "file_key_scan",
+        status: "failed",
+        errorMessage: "provider_sync_run_failed",
+      })
+      .returning();
+
+    await db
+      .update(schema.providerSyncIntents)
+      .set({
+        status: "failed",
+        providerSyncRunId: run!.id,
+        lastError: "provider_sync_run_failed",
+      })
+      .where(eq(schema.providerSyncIntents.id, intent.id));
+
+    const observability = await getProviderSyncObservability({
+      organizationId,
+      providerKind: "crowdin",
+      providerCredentialId: credential.id,
+    });
+
+    expect(observability.entries).toHaveLength(1);
+    expect(observability.entries[0]).toMatchObject({
+      automaticSyncActive: true,
+      latestWebhookEvent: {
+        id: webhookEvent!.id,
+        processingStatus: "failed",
+      },
+      latestSyncIntent: {
+        id: intent.id,
+        status: "failed",
+        canRetry: true,
+      },
+      latestSyncRun: {
+        id: run!.id,
+        status: "failed",
+      },
+    });
+  });
+
+  it("requeues a failed intent without creating a duplicate intent row", async () => {
+    const { organizationId, userId } = await createOrganizationUser();
+    const credential = await upsertOrganizationExternalTmsProviderCredential({
+      organizationId,
+      userId,
+      role: "owner",
+      providerKind: "phrase",
+      displayName: "Phrase",
+      secretMaterial: "secret-token",
+    });
+    const subscription = await insertProviderWebhookSubscription({
+      organizationId,
+      providerCredentialId: credential.id,
+      providerKind: "phrase",
+      providerWebhookId: "phrase-obs-1",
+      endpointUrl: "https://app.example.test/api/webhooks/tms/phrase",
+      webhookSecretPlaintext: "webhook-signing-secret",
+      status: "active",
+    });
+
+    const [webhookEvent] = await db
+      .insert(schema.providerWebhookEvents)
+      .values({
+        organizationId,
+        subscriptionId: subscription.id,
+        providerKind: "phrase",
+        providerEventId: "evt-phrase-retry",
+        eventType: "uploads:create",
+        dedupeKey: "evt-phrase-retry",
+        processingStatus: "failed",
+      })
+      .returning();
+
+    const { intent } = await enqueueProviderSyncIntentFromWebhookEvent({
+      organizationId,
+      providerKind: "phrase",
+      providerCredentialId: credential.id,
+      syncKind: "file_key_scan",
+      providerWebhookEventId: webhookEvent!.id,
+    });
+
+    await db
+      .update(schema.providerSyncIntents)
+      .set({ status: "failed", lastError: "provider_sync_run_failed" })
+      .where(eq(schema.providerSyncIntents.id, intent.id));
+
+    const queuedEvents: ProviderWebhookReconciliationEventData[] = [];
+    await retryProviderSyncIntent({
+      organizationId,
+      providerKind: "phrase",
+      intentId: intent.id,
+      providerWebhookReconciliationQueue: {
+        async enqueue(event) {
+          queuedEvents.push(event);
+          return { ids: [randomUUID()] };
+        },
+      },
+    });
+
+    const intents = await db
+      .select()
+      .from(schema.providerSyncIntents)
+      .where(eq(schema.providerSyncIntents.organizationId, organizationId));
+
+    expect(intents).toHaveLength(1);
+    expect(intents[0]).toMatchObject({
+      id: intent.id,
+      status: "pending",
+    });
+    expect(queuedEvents).toHaveLength(1);
+    expect(queuedEvents[0]).toMatchObject({
+      providerSyncIntentId: intent.id,
+      providerWebhookEventId: webhookEvent!.id,
+    });
+  });
+
+  it("rejects retry for non-retryable intents", async () => {
+    const { organizationId, userId } = await createOrganizationUser();
+    const credential = await upsertOrganizationExternalTmsProviderCredential({
+      organizationId,
+      userId,
+      role: "owner",
+      providerKind: "crowdin",
+      displayName: "Crowdin",
+      secretMaterial: "secret-token",
+    });
+
+    const subscription = await insertProviderWebhookSubscription({
+      organizationId,
+      providerCredentialId: credential.id,
+      providerKind: "crowdin",
+      providerWebhookId: "webhook-retry-guard",
+      endpointUrl: "https://app.example.test/api/webhooks/tms/crowdin",
+      webhookSecretPlaintext: "webhook-signing-secret",
+      status: "active",
+    });
+
+    const [webhookEvent] = await db
+      .insert(schema.providerWebhookEvents)
+      .values({
+        organizationId,
+        subscriptionId: subscription.id,
+        providerKind: "crowdin",
+        providerEventId: "evt-retry-guard",
+        eventType: "file.updated",
+        dedupeKey: "evt-retry-guard",
+        processingStatus: "pending",
+      })
+      .returning();
+
+    const { intent } = await enqueueProviderSyncIntentFromWebhookEvent({
+      organizationId,
+      providerKind: "crowdin",
+      providerCredentialId: credential.id,
+      syncKind: "file_key_scan",
+      providerWebhookEventId: webhookEvent!.id,
+    });
+
+    await expect(
+      retryProviderSyncIntent({
+        organizationId,
+        providerKind: "crowdin",
+        intentId: intent.id,
+        providerWebhookReconciliationQueue: {
+          async enqueue() {
+            return { ids: [randomUUID()] };
+          },
+        },
+      }),
+    ).rejects.toBeInstanceOf(ProviderSyncIntentNotRetryableError);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/provider-sync-observability.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-sync-observability.ts
@@ -1,0 +1,362 @@
+import { and, desc, eq, inArray, or, sql } from "drizzle-orm";
+
+import { db, schema } from "@/lib/database";
+import type { ProviderSyncIntent } from "@/lib/database/types";
+
+import type { ExternalTmsProviderKind } from "./organization-external-tms-provider-credentials";
+import {
+  isAutomaticSyncActive,
+  type ProviderSyncObservability,
+  type ProviderSyncObservabilityEntry,
+  type ProviderSyncObservabilityIntentSummary,
+  type ProviderSyncObservabilityRunSummary,
+  type ProviderSyncObservabilityWebhookEventSummary,
+} from "./provider-sync-observability-types";
+import { getProviderSyncIntentById } from "./provider-sync-intents";
+import { logIntentEnqueued } from "./provider-tms-sync-telemetry";
+import { listProviderWebhookSubscriptionSummaries } from "./provider-webhook-subscription-manager";
+import type { ProviderWebhookSubscriptionSummary } from "./provider-webhook-subscription-types";
+import { updateProviderWebhookEventProcessingStatus } from "./provider-webhook-storage";
+import { createProviderWebhookReconciliationQueue } from "@/workflows/adapters";
+
+export class ProviderSyncIntentNotRetryableError extends Error {
+  constructor() {
+    super("provider_sync_intent_not_retryable");
+    this.name = "ProviderSyncIntentNotRetryableError";
+  }
+}
+
+export class ProviderSyncIntentNotFoundError extends Error {
+  constructor() {
+    super("provider_sync_intent_not_found");
+    this.name = "ProviderSyncIntentNotFoundError";
+  }
+}
+
+function canRetrySyncIntent(intent: Pick<ProviderSyncIntent, "status">) {
+  return intent.status === "failed" || intent.status === "retryable";
+}
+
+function toWebhookEventSummary(
+  row: typeof schema.providerWebhookEvents.$inferSelect,
+): ProviderSyncObservabilityWebhookEventSummary {
+  return {
+    id: row.id,
+    eventType: row.eventType,
+    processingStatus: row.processingStatus,
+    providerSyncIntentId: row.providerSyncIntentId,
+    providerSyncRunId: row.providerSyncRunId,
+    receivedAt: row.receivedAt.toISOString(),
+    processedAt: row.processedAt?.toISOString() ?? null,
+    errorMessage: row.errorMessage,
+  };
+}
+
+function toIntentSummary(intent: ProviderSyncIntent): ProviderSyncObservabilityIntentSummary {
+  return {
+    id: intent.id,
+    syncKind: intent.syncKind,
+    status: intent.status,
+    cause: intent.cause,
+    attempts: intent.attempts,
+    maxAttempts: intent.maxAttempts,
+    lastError: intent.lastError,
+    providerSyncRunId: intent.providerSyncRunId,
+    createdAt: intent.createdAt.toISOString(),
+    updatedAt: intent.updatedAt.toISOString(),
+    completedAt: intent.completedAt?.toISOString() ?? null,
+    canRetry: canRetrySyncIntent(intent),
+  };
+}
+
+function toRunSummary(
+  row: typeof schema.providerSyncRuns.$inferSelect,
+): ProviderSyncObservabilityRunSummary {
+  return {
+    id: row.id,
+    kind: row.kind,
+    status: row.status,
+    startedAt: row.startedAt.toISOString(),
+    completedAt: row.completedAt?.toISOString() ?? null,
+    errorMessage: row.errorMessage,
+  };
+}
+
+async function latestWebhookEventForSubscription(input: {
+  organizationId: string;
+  subscriptionId: string;
+  projectId?: string | null;
+}) {
+  const filters = [
+    eq(schema.providerWebhookEvents.organizationId, input.organizationId),
+    eq(schema.providerWebhookEvents.subscriptionId, input.subscriptionId),
+  ];
+
+  if (input.projectId) {
+    filters.push(eq(schema.providerWebhookEvents.projectId, input.projectId));
+  }
+
+  const [row] = await db
+    .select()
+    .from(schema.providerWebhookEvents)
+    .where(and(...filters))
+    .orderBy(desc(schema.providerWebhookEvents.receivedAt))
+    .limit(1);
+
+  return row ? toWebhookEventSummary(row) : null;
+}
+
+async function latestSyncIntentForScope(input: {
+  organizationId: string;
+  providerKind: ExternalTmsProviderKind;
+  providerCredentialId: string;
+  projectId?: string | null;
+}) {
+  const filters = [
+    eq(schema.providerSyncIntents.organizationId, input.organizationId),
+    eq(schema.providerSyncIntents.providerKind, input.providerKind),
+    eq(schema.providerSyncIntents.providerCredentialId, input.providerCredentialId),
+  ];
+
+  if (input.projectId) {
+    filters.push(eq(schema.providerSyncIntents.projectId, input.projectId));
+  }
+
+  const [row] = await db
+    .select()
+    .from(schema.providerSyncIntents)
+    .where(and(...filters))
+    .orderBy(desc(schema.providerSyncIntents.createdAt))
+    .limit(1);
+
+  return row ? toIntentSummary(row) : null;
+}
+
+async function latestSyncRunForScope(input: {
+  organizationId: string;
+  providerKind: ExternalTmsProviderKind;
+  projectId?: string | null;
+  providerSyncRunId?: string | null;
+}) {
+  if (input.providerSyncRunId) {
+    const [row] = await db
+      .select()
+      .from(schema.providerSyncRuns)
+      .where(
+        and(
+          eq(schema.providerSyncRuns.id, input.providerSyncRunId),
+          eq(schema.providerSyncRuns.organizationId, input.organizationId),
+        ),
+      )
+      .limit(1);
+
+    return row ? toRunSummary(row) : null;
+  }
+
+  const filters = [
+    eq(schema.providerSyncRuns.organizationId, input.organizationId),
+    eq(schema.providerSyncRuns.providerKind, input.providerKind),
+  ];
+
+  if (input.projectId) {
+    filters.push(eq(schema.providerSyncRuns.projectId, input.projectId));
+  }
+
+  const [row] = await db
+    .select()
+    .from(schema.providerSyncRuns)
+    .where(and(...filters))
+    .orderBy(desc(schema.providerSyncRuns.startedAt))
+    .limit(1);
+
+  return row ? toRunSummary(row) : null;
+}
+
+function buildEntry(input: {
+  subscription: ProviderWebhookSubscriptionSummary;
+  latestWebhookEvent: ProviderSyncObservabilityWebhookEventSummary | null;
+  latestSyncIntent: ProviderSyncObservabilityIntentSummary | null;
+  latestSyncRun: ProviderSyncObservabilityRunSummary | null;
+}): ProviderSyncObservabilityEntry {
+  return {
+    projectId: input.subscription.projectId,
+    subscription: input.subscription,
+    automaticSyncActive: isAutomaticSyncActive(input.subscription.status),
+    latestWebhookEvent: input.latestWebhookEvent,
+    latestSyncIntent: input.latestSyncIntent,
+    latestSyncRun: input.latestSyncRun,
+  };
+}
+
+export async function getProviderSyncObservability(input: {
+  organizationId: string;
+  providerKind: ExternalTmsProviderKind;
+  providerCredentialId: string;
+  projectId?: string | null;
+}): Promise<ProviderSyncObservability> {
+  const subscriptions = await listProviderWebhookSubscriptionSummaries({
+    organizationId: input.organizationId,
+    providerCredentialId: input.providerCredentialId,
+  });
+
+  const scopedSubscriptions = subscriptions.filter((subscription) => {
+    if (subscription.providerKind !== input.providerKind) {
+      return false;
+    }
+
+    if (input.projectId === undefined) {
+      return true;
+    }
+
+    if (input.projectId === null) {
+      return subscription.projectId === null;
+    }
+
+    return subscription.projectId === input.projectId;
+  });
+
+  const entries = await Promise.all(
+    scopedSubscriptions.map(async (subscription) => {
+      const latestWebhookEvent = await latestWebhookEventForSubscription({
+        organizationId: input.organizationId,
+        subscriptionId: subscription.id,
+        projectId: subscription.projectId,
+      });
+
+      const latestSyncIntent = await latestSyncIntentForScope({
+        organizationId: input.organizationId,
+        providerKind: input.providerKind,
+        providerCredentialId: input.providerCredentialId,
+        projectId: subscription.projectId,
+      });
+
+      const latestSyncRun = await latestSyncRunForScope({
+        organizationId: input.organizationId,
+        providerKind: input.providerKind,
+        projectId: subscription.projectId,
+        providerSyncRunId:
+          latestWebhookEvent?.providerSyncRunId ?? latestSyncIntent?.providerSyncRunId ?? null,
+      });
+
+      return buildEntry({
+        subscription,
+        latestWebhookEvent,
+        latestSyncIntent,
+        latestSyncRun,
+      });
+    }),
+  );
+
+  return {
+    providerKind: input.providerKind,
+    entries,
+  };
+}
+
+export async function retryProviderSyncIntent(input: {
+  organizationId: string;
+  providerKind: ExternalTmsProviderKind;
+  intentId: string;
+  providerWebhookReconciliationQueue?: ReturnType<typeof createProviderWebhookReconciliationQueue>;
+}) {
+  const intent = await getProviderSyncIntentById({
+    intentId: input.intentId,
+    organizationId: input.organizationId,
+  });
+
+  if (!intent) {
+    throw new ProviderSyncIntentNotFoundError();
+  }
+
+  if (intent.providerKind !== input.providerKind) {
+    throw new ProviderSyncIntentNotFoundError();
+  }
+
+  if (!canRetrySyncIntent(intent)) {
+    throw new ProviderSyncIntentNotRetryableError();
+  }
+
+  const now = new Date();
+  const [requeued] = await db
+    .update(schema.providerSyncIntents)
+    .set({
+      status: "pending",
+      leasedUntil: null,
+      leasedBy: null,
+      nextAttemptAt: now,
+      completedAt: null,
+      lastError: null,
+      errorDetails: {},
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(schema.providerSyncIntents.id, intent.id),
+        eq(schema.providerSyncIntents.organizationId, input.organizationId),
+        inArray(schema.providerSyncIntents.status, ["failed", "retryable"]),
+        or(
+          sql`${schema.providerSyncIntents.leasedUntil} IS NULL`,
+          sql`${schema.providerSyncIntents.leasedUntil} < ${now}`,
+        ),
+      ),
+    )
+    .returning();
+
+  if (!requeued) {
+    throw new ProviderSyncIntentNotRetryableError();
+  }
+
+  const webhookEventId = requeued.eventReferences[0];
+  if (!webhookEventId) {
+    throw new ProviderSyncIntentNotRetryableError();
+  }
+
+  const [webhookEvent] = await db
+    .select()
+    .from(schema.providerWebhookEvents)
+    .where(
+      and(
+        eq(schema.providerWebhookEvents.id, webhookEventId),
+        eq(schema.providerWebhookEvents.organizationId, input.organizationId),
+      ),
+    )
+    .limit(1);
+
+  if (!webhookEvent) {
+    throw new ProviderSyncIntentNotFoundError();
+  }
+
+  await updateProviderWebhookEventProcessingStatus({
+    eventId: webhookEvent.id,
+    organizationId: input.organizationId,
+    processingStatus: "pending",
+    providerSyncIntentId: requeued.id,
+    errorMessage: null,
+    errorDetails: {},
+    nextRetryAt: null,
+  });
+
+  const queue =
+    input.providerWebhookReconciliationQueue ?? createProviderWebhookReconciliationQueue();
+
+  await queue.enqueue({
+    providerWebhookEventId: webhookEvent.id,
+    providerSyncIntentId: requeued.id,
+    organizationId: input.organizationId,
+    subscriptionId: webhookEvent.subscriptionId,
+    providerKind: input.providerKind,
+  });
+
+  logIntentEnqueued({
+    providerKind: input.providerKind,
+    organizationId: input.organizationId,
+    subscriptionId: webhookEvent.subscriptionId,
+    providerWebhookEventId: webhookEvent.id,
+    providerSyncIntentId: requeued.id,
+    reason: "manual_retry",
+  });
+
+  return {
+    providerSyncIntent: toIntentSummary(requeued),
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/providers/provider-sync-observability.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-sync-observability.ts
@@ -144,7 +144,7 @@ async function latestSyncIntentsForScopes(input: {
 
   const latestByScope = new Map<string, ProviderSyncObservabilityIntentSummary>();
   for (const row of rows) {
-    if (!latestByScope.has(projectScopeKey(null))) {
+    if (row.projectId === null && !latestByScope.has(projectScopeKey(null))) {
       latestByScope.set(projectScopeKey(null), toIntentSummary(row));
     }
 
@@ -207,7 +207,7 @@ async function latestSyncRunsForScopes(input: {
     const summary = toRunSummary(row);
     byId.set(row.id, summary);
 
-    if (!byScope.has(projectScopeKey(null))) {
+    if (row.projectId === null && !byScope.has(projectScopeKey(null))) {
       byScope.set(projectScopeKey(null), summary);
     }
 

--- a/apps/hyperlocalise-web/src/lib/providers/provider-sync-observability.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-sync-observability.ts
@@ -37,6 +37,10 @@ function canRetrySyncIntent(intent: Pick<ProviderSyncIntent, "status">) {
   return intent.status === "failed" || intent.status === "retryable";
 }
 
+function retryErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : "provider_webhook_reconciliation_enqueue_failed";
+}
+
 function toWebhookEventSummary(
   row: typeof schema.providerWebhookEvents.$inferSelect,
 ): ProviderSyncObservabilityWebhookEventSummary {
@@ -369,7 +373,7 @@ export async function retryProviderSyncIntent(input: {
     .limit(1);
 
   if (!webhookEvent) {
-    throw new ProviderSyncIntentNotFoundError();
+    throw new ProviderSyncIntentNotRetryableError();
   }
 
   const now = new Date();
@@ -402,26 +406,66 @@ export async function retryProviderSyncIntent(input: {
     throw new ProviderSyncIntentNotRetryableError();
   }
 
-  await updateProviderWebhookEventProcessingStatus({
-    eventId: webhookEvent.id,
-    organizationId: input.organizationId,
-    processingStatus: "pending",
-    providerSyncIntentId: requeued.id,
-    errorMessage: null,
-    errorDetails: {},
-    nextRetryAt: null,
-  });
-
   const queue =
     input.providerWebhookReconciliationQueue ?? createProviderWebhookReconciliationQueue();
 
-  await queue.enqueue({
-    providerWebhookEventId: webhookEvent.id,
-    providerSyncIntentId: requeued.id,
-    organizationId: input.organizationId,
-    subscriptionId: webhookEvent.subscriptionId,
-    providerKind: input.providerKind,
-  });
+  try {
+    await updateProviderWebhookEventProcessingStatus({
+      eventId: webhookEvent.id,
+      organizationId: input.organizationId,
+      processingStatus: "pending",
+      providerSyncIntentId: requeued.id,
+      errorMessage: null,
+      errorDetails: {},
+      nextRetryAt: null,
+    });
+
+    await queue.enqueue({
+      providerWebhookEventId: webhookEvent.id,
+      providerSyncIntentId: requeued.id,
+      organizationId: input.organizationId,
+      subscriptionId: webhookEvent.subscriptionId,
+      providerKind: input.providerKind,
+    });
+  } catch (error) {
+    const retryFailureMessage = retryErrorMessage(error);
+    const rollbackAt = new Date();
+
+    await db
+      .update(schema.providerSyncIntents)
+      .set({
+        status: "failed",
+        leasedUntil: null,
+        leasedBy: null,
+        nextAttemptAt: null,
+        completedAt: null,
+        lastError: retryFailureMessage,
+        errorDetails: { message: retryFailureMessage },
+        updatedAt: rollbackAt,
+      })
+      .where(
+        and(
+          eq(schema.providerSyncIntents.id, requeued.id),
+          eq(schema.providerSyncIntents.organizationId, input.organizationId),
+        ),
+      );
+
+    try {
+      await updateProviderWebhookEventProcessingStatus({
+        eventId: webhookEvent.id,
+        organizationId: input.organizationId,
+        processingStatus: "failed",
+        providerSyncIntentId: requeued.id,
+        errorMessage: retryFailureMessage,
+        errorDetails: { message: retryFailureMessage },
+        nextRetryAt: null,
+      });
+    } catch {
+      // Preserve the original enqueue/update failure after restoring retryability.
+    }
+
+    throw error;
+  }
 
   logIntentEnqueued({
     providerKind: input.providerKind,

--- a/apps/hyperlocalise-web/src/lib/providers/provider-sync-observability.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-sync-observability.ts
@@ -82,35 +82,41 @@ function toRunSummary(
   };
 }
 
-async function latestWebhookEventForSubscription(input: {
-  organizationId: string;
-  subscriptionId: string;
-  projectId?: string | null;
-}) {
-  const filters = [
-    eq(schema.providerWebhookEvents.organizationId, input.organizationId),
-    eq(schema.providerWebhookEvents.subscriptionId, input.subscriptionId),
-  ];
-
-  if (input.projectId) {
-    filters.push(eq(schema.providerWebhookEvents.projectId, input.projectId));
-  }
-
-  const [row] = await db
-    .select()
-    .from(schema.providerWebhookEvents)
-    .where(and(...filters))
-    .orderBy(desc(schema.providerWebhookEvents.receivedAt))
-    .limit(1);
-
-  return row ? toWebhookEventSummary(row) : null;
+function projectScopeKey(projectId: string | null | undefined) {
+  return projectId ?? "__all_projects__";
 }
 
-async function latestSyncIntentForScope(input: {
+async function latestWebhookEventsForSubscriptions(input: {
+  organizationId: string;
+  subscriptionIds: string[];
+}) {
+  if (input.subscriptionIds.length === 0) {
+    return new Map<string, ProviderSyncObservabilityWebhookEventSummary>();
+  }
+
+  const rows = await db
+    .selectDistinctOn([schema.providerWebhookEvents.subscriptionId])
+    .from(schema.providerWebhookEvents)
+    .where(
+      and(
+        eq(schema.providerWebhookEvents.organizationId, input.organizationId),
+        inArray(schema.providerWebhookEvents.subscriptionId, input.subscriptionIds),
+      ),
+    )
+    .orderBy(
+      schema.providerWebhookEvents.subscriptionId,
+      desc(schema.providerWebhookEvents.receivedAt),
+    );
+
+  return new Map(rows.map((row) => [row.subscriptionId, toWebhookEventSummary(row)]));
+}
+
+async function latestSyncIntentsForScopes(input: {
   organizationId: string;
   providerKind: ExternalTmsProviderKind;
   providerCredentialId: string;
-  projectId?: string | null;
+  projectIds: string[];
+  includeGlobalScope: boolean;
 }) {
   const filters = [
     eq(schema.providerSyncIntents.organizationId, input.organizationId),
@@ -118,58 +124,98 @@ async function latestSyncIntentForScope(input: {
     eq(schema.providerSyncIntents.providerCredentialId, input.providerCredentialId),
   ];
 
-  if (input.projectId) {
-    filters.push(eq(schema.providerSyncIntents.projectId, input.projectId));
+  if (!input.includeGlobalScope) {
+    if (input.projectIds.length === 0) {
+      return new Map<string, ProviderSyncObservabilityIntentSummary>();
+    }
+
+    filters.push(inArray(schema.providerSyncIntents.projectId, input.projectIds));
   }
 
-  const [row] = await db
+  const rows = await db
     .select()
     .from(schema.providerSyncIntents)
     .where(and(...filters))
-    .orderBy(desc(schema.providerSyncIntents.createdAt))
-    .limit(1);
+    .orderBy(desc(schema.providerSyncIntents.createdAt));
 
-  return row ? toIntentSummary(row) : null;
-}
+  const latestByScope = new Map<string, ProviderSyncObservabilityIntentSummary>();
+  for (const row of rows) {
+    if (!latestByScope.has(projectScopeKey(null))) {
+      latestByScope.set(projectScopeKey(null), toIntentSummary(row));
+    }
 
-async function latestSyncRunForScope(input: {
-  organizationId: string;
-  providerKind: ExternalTmsProviderKind;
-  projectId?: string | null;
-  providerSyncRunId?: string | null;
-}) {
-  if (input.providerSyncRunId) {
-    const [row] = await db
-      .select()
-      .from(schema.providerSyncRuns)
-      .where(
-        and(
-          eq(schema.providerSyncRuns.id, input.providerSyncRunId),
-          eq(schema.providerSyncRuns.organizationId, input.organizationId),
-        ),
-      )
-      .limit(1);
-
-    return row ? toRunSummary(row) : null;
+    if (row.projectId && input.projectIds.includes(row.projectId)) {
+      const key = projectScopeKey(row.projectId);
+      if (!latestByScope.has(key)) {
+        latestByScope.set(key, toIntentSummary(row));
+      }
+    }
   }
 
-  const filters = [
+  return latestByScope;
+}
+
+async function latestSyncRunsForScopes(input: {
+  organizationId: string;
+  providerKind: ExternalTmsProviderKind;
+  projectIds: string[];
+  providerSyncRunIds: string[];
+  includeGlobalScope: boolean;
+}) {
+  if (
+    input.providerSyncRunIds.length === 0 &&
+    input.projectIds.length === 0 &&
+    !input.includeGlobalScope
+  ) {
+    return {
+      byId: new Map<string, ProviderSyncObservabilityRunSummary>(),
+      byScope: new Map<string, ProviderSyncObservabilityRunSummary>(),
+    };
+  }
+
+  const scopedRunFilters = [
     eq(schema.providerSyncRuns.organizationId, input.organizationId),
     eq(schema.providerSyncRuns.providerKind, input.providerKind),
   ];
-
-  if (input.projectId) {
-    filters.push(eq(schema.providerSyncRuns.projectId, input.projectId));
+  if (!input.includeGlobalScope) {
+    scopedRunFilters.push(inArray(schema.providerSyncRuns.projectId, input.projectIds));
   }
 
-  const [row] = await db
+  const rows = await db
     .select()
     .from(schema.providerSyncRuns)
-    .where(and(...filters))
-    .orderBy(desc(schema.providerSyncRuns.startedAt))
-    .limit(1);
+    .where(
+      and(
+        eq(schema.providerSyncRuns.organizationId, input.organizationId),
+        or(
+          input.providerSyncRunIds.length > 0
+            ? inArray(schema.providerSyncRuns.id, input.providerSyncRunIds)
+            : undefined,
+          and(...scopedRunFilters),
+        ),
+      ),
+    )
+    .orderBy(desc(schema.providerSyncRuns.startedAt));
 
-  return row ? toRunSummary(row) : null;
+  const byId = new Map<string, ProviderSyncObservabilityRunSummary>();
+  const byScope = new Map<string, ProviderSyncObservabilityRunSummary>();
+  for (const row of rows) {
+    const summary = toRunSummary(row);
+    byId.set(row.id, summary);
+
+    if (!byScope.has(projectScopeKey(null))) {
+      byScope.set(projectScopeKey(null), summary);
+    }
+
+    if (row.projectId && input.projectIds.includes(row.projectId)) {
+      const key = projectScopeKey(row.projectId);
+      if (!byScope.has(key)) {
+        byScope.set(key, summary);
+      }
+    }
+  }
+
+  return { byId, byScope };
 }
 
 function buildEntry(input: {
@@ -215,37 +261,67 @@ export async function getProviderSyncObservability(input: {
     return subscription.projectId === input.projectId;
   });
 
-  const entries = await Promise.all(
-    scopedSubscriptions.map(async (subscription) => {
-      const latestWebhookEvent = await latestWebhookEventForSubscription({
-        organizationId: input.organizationId,
-        subscriptionId: subscription.id,
-        projectId: subscription.projectId,
-      });
+  const subscriptionIds = scopedSubscriptions.map((subscription) => subscription.id);
+  const projectIds = [
+    ...new Set(
+      scopedSubscriptions
+        .map((subscription) => subscription.projectId)
+        .filter((projectId): projectId is string => Boolean(projectId)),
+    ),
+  ];
+  const includeGlobalScope = scopedSubscriptions.some((subscription) => !subscription.projectId);
 
-      const latestSyncIntent = await latestSyncIntentForScope({
-        organizationId: input.organizationId,
-        providerKind: input.providerKind,
-        providerCredentialId: input.providerCredentialId,
-        projectId: subscription.projectId,
-      });
+  const latestWebhookEvents = await latestWebhookEventsForSubscriptions({
+    organizationId: input.organizationId,
+    subscriptionIds,
+  });
 
-      const latestSyncRun = await latestSyncRunForScope({
-        organizationId: input.organizationId,
-        providerKind: input.providerKind,
-        projectId: subscription.projectId,
-        providerSyncRunId:
-          latestWebhookEvent?.providerSyncRunId ?? latestSyncIntent?.providerSyncRunId ?? null,
-      });
+  const latestSyncIntents = await latestSyncIntentsForScopes({
+    organizationId: input.organizationId,
+    providerKind: input.providerKind,
+    providerCredentialId: input.providerCredentialId,
+    projectIds,
+    includeGlobalScope,
+  });
 
-      return buildEntry({
-        subscription,
-        latestWebhookEvent,
-        latestSyncIntent,
-        latestSyncRun,
-      });
-    }),
-  );
+  const providerSyncRunIds = [
+    ...new Set(
+      scopedSubscriptions
+        .map((subscription) => {
+          const latestWebhookEvent = latestWebhookEvents.get(subscription.id) ?? null;
+          const latestSyncIntent =
+            latestSyncIntents.get(projectScopeKey(subscription.projectId)) ?? null;
+
+          return latestWebhookEvent?.providerSyncRunId ?? latestSyncIntent?.providerSyncRunId;
+        })
+        .filter((providerSyncRunId): providerSyncRunId is string => Boolean(providerSyncRunId)),
+    ),
+  ];
+
+  const latestSyncRuns = await latestSyncRunsForScopes({
+    organizationId: input.organizationId,
+    providerKind: input.providerKind,
+    projectIds,
+    providerSyncRunIds,
+    includeGlobalScope,
+  });
+
+  const entries = scopedSubscriptions.map((subscription) => {
+    const latestWebhookEvent = latestWebhookEvents.get(subscription.id) ?? null;
+    const latestSyncIntent = latestSyncIntents.get(projectScopeKey(subscription.projectId)) ?? null;
+    const providerSyncRunId =
+      latestWebhookEvent?.providerSyncRunId ?? latestSyncIntent?.providerSyncRunId ?? null;
+    const latestSyncRun = providerSyncRunId
+      ? (latestSyncRuns.byId.get(providerSyncRunId) ?? null)
+      : (latestSyncRuns.byScope.get(projectScopeKey(subscription.projectId)) ?? null);
+
+    return buildEntry({
+      subscription,
+      latestWebhookEvent,
+      latestSyncIntent,
+      latestSyncRun,
+    });
+  });
 
   return {
     providerKind: input.providerKind,
@@ -276,6 +352,26 @@ export async function retryProviderSyncIntent(input: {
     throw new ProviderSyncIntentNotRetryableError();
   }
 
+  const webhookEventId = intent.eventReferences[0];
+  if (!webhookEventId) {
+    throw new ProviderSyncIntentNotRetryableError();
+  }
+
+  const [webhookEvent] = await db
+    .select()
+    .from(schema.providerWebhookEvents)
+    .where(
+      and(
+        eq(schema.providerWebhookEvents.id, webhookEventId),
+        eq(schema.providerWebhookEvents.organizationId, input.organizationId),
+      ),
+    )
+    .limit(1);
+
+  if (!webhookEvent) {
+    throw new ProviderSyncIntentNotFoundError();
+  }
+
   const now = new Date();
   const [requeued] = await db
     .update(schema.providerSyncIntents)
@@ -304,26 +400,6 @@ export async function retryProviderSyncIntent(input: {
 
   if (!requeued) {
     throw new ProviderSyncIntentNotRetryableError();
-  }
-
-  const webhookEventId = requeued.eventReferences[0];
-  if (!webhookEventId) {
-    throw new ProviderSyncIntentNotRetryableError();
-  }
-
-  const [webhookEvent] = await db
-    .select()
-    .from(schema.providerWebhookEvents)
-    .where(
-      and(
-        eq(schema.providerWebhookEvents.id, webhookEventId),
-        eq(schema.providerWebhookEvents.organizationId, input.organizationId),
-      ),
-    )
-    .limit(1);
-
-  if (!webhookEvent) {
-    throw new ProviderSyncIntentNotFoundError();
   }
 
   await updateProviderWebhookEventProcessingStatus({

--- a/apps/hyperlocalise-web/src/lib/providers/provider-tms-sync-telemetry.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-tms-sync-telemetry.ts
@@ -1,0 +1,65 @@
+import { createLogger } from "@/lib/log";
+
+import type { ExternalTmsProviderKind } from "./organization-external-tms-provider-credentials";
+
+export const TMS_SYNC_TELEMETRY_EVENTS = {
+  webhookAccepted: "webhook_accepted",
+  webhookDuplicate: "duplicate",
+  webhookIgnored: "ignored",
+  webhookVerificationFailed: "verification_failed",
+  intentEnqueued: "intent_enqueued",
+  reconciliationSucceeded: "reconciliation_succeeded",
+  reconciliationFailed: "reconciliation_failed",
+} as const;
+
+export type TmsSyncTelemetryEvent =
+  (typeof TMS_SYNC_TELEMETRY_EVENTS)[keyof typeof TMS_SYNC_TELEMETRY_EVENTS];
+
+type TmsSyncTelemetryContext = {
+  providerKind: ExternalTmsProviderKind;
+  organizationId?: string;
+  subscriptionId?: string;
+  providerWebhookEventId?: string;
+  providerSyncIntentId?: string;
+  providerSyncRunId?: string;
+  providerEventId?: string;
+  deliveryId?: string | null;
+  eventType?: string;
+  processingStatus?: string;
+  syncKind?: string;
+  reason?: string;
+};
+
+const logger = createLogger("tms-sync-telemetry");
+
+function logTelemetry(event: TmsSyncTelemetryEvent, context: TmsSyncTelemetryContext) {
+  logger.info({ event, ...context }, event);
+}
+
+export function logWebhookAccepted(context: TmsSyncTelemetryContext) {
+  logTelemetry(TMS_SYNC_TELEMETRY_EVENTS.webhookAccepted, context);
+}
+
+export function logWebhookDuplicate(context: TmsSyncTelemetryContext) {
+  logTelemetry(TMS_SYNC_TELEMETRY_EVENTS.webhookDuplicate, context);
+}
+
+export function logWebhookIgnored(context: TmsSyncTelemetryContext) {
+  logTelemetry(TMS_SYNC_TELEMETRY_EVENTS.webhookIgnored, context);
+}
+
+export function logWebhookVerificationFailed(context: TmsSyncTelemetryContext) {
+  logTelemetry(TMS_SYNC_TELEMETRY_EVENTS.webhookVerificationFailed, context);
+}
+
+export function logIntentEnqueued(context: TmsSyncTelemetryContext) {
+  logTelemetry(TMS_SYNC_TELEMETRY_EVENTS.intentEnqueued, context);
+}
+
+export function logReconciliationSucceeded(context: TmsSyncTelemetryContext) {
+  logTelemetry(TMS_SYNC_TELEMETRY_EVENTS.reconciliationSucceeded, context);
+}
+
+export function logReconciliationFailed(context: TmsSyncTelemetryContext) {
+  logTelemetry(TMS_SYNC_TELEMETRY_EVENTS.reconciliationFailed, context);
+}

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-webhook-adapters.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-webhook-adapters.test.ts
@@ -181,7 +181,7 @@ describe("tms provider webhook adapters", () => {
         deliveryId:
           providerKind === "smartling" && expected.providerEventId === "smartling-delivery-1"
             ? "smartling-delivery-1"
-            : providerKind === "phrase"
+            : providerKind === "phrase" || providerKind === "lokalise"
               ? expected.providerEventId
               : null,
         eventType: expected.eventType,

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-webhook-adapters.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-webhook-adapters.ts
@@ -698,26 +698,56 @@ export const lokaliseWebhookAdapter: TmsProviderWebhookAdapter = {
     };
   },
   extract(input) {
-    if (!isLokalisePingPayload(input.payload)) {
-      return baseLokaliseWebhookAdapter.extract(input);
+    if (isLokalisePingPayload(input.payload)) {
+      const subscription = lokaliseWebhookAdapter.resolveSubscription(input);
+      if (!subscription) {
+        return null;
+      }
+
+      const providerEventId = `ping:${subscription.providerWebhookId}`;
+      const externalResourceId = firstString(input.headers.get("project-id"));
+      const descriptor: TmsProviderWebhookDescriptor = {
+        ...subscription,
+        providerEventId,
+        eventType: "ping",
+        dedupeKey: providerEventId,
+        deliveryId: null,
+        resourceType: null,
+        resourceId: null,
+        externalResourceId,
+        redactedPayload: {},
+        mappedIntents: [],
+      };
+
+      descriptor.mappedIntents = lokaliseWebhookAdapter.mapToIntents({ ...input, descriptor });
+      descriptor.redactedPayload = lokaliseWebhookAdapter.redact({ ...input, descriptor });
+
+      return descriptor;
     }
 
     const subscription = lokaliseWebhookAdapter.resolveSubscription(input);
-    if (!subscription) {
+    const providerEventId = lokaliseWebhookAdapter.extractProviderEventId(input);
+    const eventType = lokaliseWebhookAdapter.extractEventType(input);
+
+    if (!subscription || !providerEventId || !eventType) {
       return null;
     }
 
-    const providerEventId = `ping:${subscription.providerWebhookId}`;
-    const externalResourceId = firstString(input.headers.get("project-id"));
+    const deliveryId = firstString(
+      input.headers.get("x-event-id"),
+      input.headers.get("x-hyperlocalise-delivery-id"),
+      input.headers.get("x-provider-delivery-id"),
+      input.headers.get("x-delivery-id"),
+      firstPathString(input.payload, [["uuid"], ["event_id"], ["id"]]),
+    );
+    const resource = lokaliseWebhookAdapter.extractResource(input);
     const descriptor: TmsProviderWebhookDescriptor = {
       ...subscription,
       providerEventId,
-      eventType: "ping",
-      dedupeKey: providerEventId,
-      deliveryId: null,
-      resourceType: null,
-      resourceId: null,
-      externalResourceId,
+      eventType,
+      dedupeKey: firstString(input.payload["dedupe_key"], providerEventId) ?? providerEventId,
+      deliveryId,
+      ...resource,
       redactedPayload: {},
       mappedIntents: [],
     };

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -93,6 +93,7 @@
             "group": "TMS Adapters",
             "pages": [
               "storage/overview",
+              "storage/tms-webhook-sync",
               "storage/crowdin",
               "storage/lilt",
               "storage/lokalise",

--- a/docs/storage/tms-webhook-sync.mdx
+++ b/docs/storage/tms-webhook-sync.mdx
@@ -1,0 +1,61 @@
+---
+title: "TMS webhook automatic sync"
+description: "How Hyperlocalise registers inbound TMS webhooks, reconciles remote changes, and falls back to manual setup."
+---
+
+## Overview
+
+Hyperlocalise can keep synced TMS projects up to date by receiving provider webhooks, enqueueing sync intents, and running provider sync runs in the background. Write-back to the source TMS remains approval-gated; webhooks and schedulers only confirm remote state after an approved write-back.
+
+## Hosted automatic setup
+
+When `HYPERLOCALISE_PUBLIC_APP_URL` is configured, Hyperlocalise registers a single inbound route per provider:
+
+`/api/webhooks/tms/{provider}`
+
+After you connect a TMS credential and sync projects, webhook subscriptions are created automatically when the provider API supports it.
+
+| Provider | Automatic API setup | Manual fallback |
+| --- | --- | --- |
+| Crowdin | Yes | Shown if API setup fails or automatic setup is disabled |
+| Phrase | Yes | Shown if API setup fails or automatic setup is disabled |
+| Lokalise | Yes | Shown if API setup fails or automatic setup is disabled |
+| Smartling | Yes | Shown if API setup fails or automatic setup is disabled |
+
+Use **Integrations → TMS provider → Retry setup** to re-run automatic registration without creating duplicate provider webhooks.
+
+## Manual fallback
+
+If automatic setup cannot complete, the integrations UI shows:
+
+- the webhook URL to paste into the provider console
+- the secret header name (when applicable)
+- subscribed event types
+- the last setup error
+
+Configure the provider webhook manually using those values. Hyperlocalise deduplicates deliveries by provider event ID, so retries and duplicate notifications do not create duplicate sync work.
+
+## Observability in the app
+
+For each webhook subscription, the TMS connection dialog shows:
+
+- whether automatic sync is active
+- the latest webhook event (processing status and internal event ID)
+- the latest sync intent (status, sync kind, internal intent ID)
+- the latest provider sync run (status and internal run ID)
+
+Admins can retry failed webhook setup and failed sync intents from the same dialog when it is safe to do so.
+
+## Support debugging
+
+Server logs emit stable telemetry event names without customer content:
+
+- `webhook_accepted`
+- `duplicate`
+- `ignored`
+- `verification_failed`
+- `intent_enqueued`
+- `reconciliation_succeeded`
+- `reconciliation_failed`
+
+Correlate support tickets using internal IDs surfaced in the UI (subscription, webhook event, sync intent, and sync run IDs).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Adds cross-provider TMS sync observability and safe retry paths for HL-408:

- **UI**: `TmsSyncObservabilityPanel` in the TMS integrations dialog shows latest subscription status, webhook event, sync intent, and provider sync run per linked project.
- **API**: `GET /api/organizations/:orgId/external-tms-provider-credentials/:providerKind/sync-observability?projectId=` and `POST .../sync-intents/:intentId/retry` for failed/retryable intents (reuses the same intent row and workflow enqueue — no duplicate work).
- **Telemetry**: Structured logs via `provider-tms-sync-telemetry` for `webhook_accepted`, `duplicate`, `ignored`, `verification_failed`, `intent_enqueued`, `reconciliation_succeeded`, and `reconciliation_failed` (opaque IDs only).
- **E2E tests**: Route tests for Lokalise and Smartling webhooks (Crowdin/Phrase already covered); unit tests for observability + retry.
- **Lokalise fix**: Custom `extract()` resolves `webhook-id` header subscriptions (mirrors Phrase) so non-ping events are not ignored.
- **Docs**: [TMS webhook sync](docs/storage/tms-webhook-sync.mdx) — hosted automatic setup vs manual fallback per provider; write-back remains approval-gated.

## How to test

```bash
cd apps/hyperlocalise-web
vp test src/api/routes/tms-webhook/tms-webhook.route.test.ts src/lib/providers/provider-sync-observability.test.ts
vp test
vp check --fix
```

Manual: open org **Integrations** → TMS provider dialog → confirm sync activity panel and retry buttons for failed setup/intents.

## Checklist

- [x] `vp test` (1384 tests)
- [x] `vp check --fix`
- [x] Docs updated

Resolves HL-408
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-408](https://linear.app/hyperlocalise/issue/HL-408/add-tms-sync-observability-retries-and-end-to-end-webhook-validation)

<div><a href="https://cursor.com/agents/bc-81848d7e-a023-4283-8019-2cf0bc1c146f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81848d7e-a023-4283-8019-2cf0bc1c146f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

