### PR TITLE
🧪 Scout: improve glossary matching for non-word characters

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -31,3 +31,7 @@
 ## 2025-05-28 - [Cross-platform Path Testing]
 **Learning:** Hardcoded absolute Unix paths (e.g., /tmp/root) in tests are not portable and will fail on non-Unix environments like Windows. Security-sensitive path guarding logic often involves complex interactions with symlinks and canonicalization.
 **Action:** Use t.TempDir() and filepath.Join to construct portable paths for testing. When testing symlink-aware logic, evaluate symlinks on the base temporary directory to ensure consistent behavior across environments where the temporary directory itself might be a symlink (e.g., /var -> /private/var on macOS).
+
+## 2025-05-30 - [Robust Glossary Boundary Matching]
+**Learning:** Standard regex word boundaries (`\b`) fail for glossary terms that start or end with non-word characters (e.g., "C#", ".NET", "Go!"). `\b` requires a transition between a word character (`\w`) and a non-word character or string boundary. If a term like "C#" is followed by a space, there is no `\b` after the "#" because both "#" and " " are non-word characters.
+**Action:** Use negative lookarounds `(?<![a-zA-Z0-9_])` and `(?![a-zA-Z0-9_])` to implement "word boundaries" that correctly handle terms containing symbols while still preventing partial matches within larger alphanumeric words.

--- a/apps/hyperlocalise-web/src/lib/providers/provider-job-qa/supplemental-checks.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-job-qa/supplemental-checks.test.ts
@@ -59,7 +59,6 @@ describe("supplemental-checks glossary matching", () => {
       },
     );
 
-    // This is expected to fail with current implementation because \b doesn't match after # if followed by space or end of string
     expect(findings.some((f) => f.checkType === "glossary_violation")).toBe(true);
   });
 

--- a/apps/hyperlocalise-web/src/lib/providers/provider-job-qa/supplemental-checks.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-job-qa/supplemental-checks.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vite-plus/test";
+import { collectSupplementalQaFindings } from "./supplemental-checks";
+import type { ExternalTmsTranslationUnit } from "@/lib/providers/external-tms-content-sync";
+
+function unit(overrides: Partial<ExternalTmsTranslationUnit> = {}): ExternalTmsTranslationUnit {
+  return {
+    externalStringId: "1",
+    key: "test",
+    sourceText: "source",
+    translations: [],
+    ...overrides,
+  };
+}
+
+const baseOptions = {
+  targetLocales: ["fr"],
+  sourceLocale: "en",
+};
+
+describe("supplemental-checks glossary matching", () => {
+  it("should match basic word terms", () => {
+    const findings = collectSupplementalQaFindings(
+      unit({
+        sourceText: "Save your work",
+        translations: [{ locale: "fr", text: "Sauvegarder" }],
+      }),
+      {
+        ...baseOptions,
+        glossaryTerms: [
+          {
+            sourceTerm: "Save",
+            targetTerm: "Enregistrer",
+            forbidden: false,
+            caseSensitive: false,
+          },
+        ],
+      },
+    );
+
+    expect(findings.some((f) => f.checkType === "glossary_violation")).toBe(true);
+  });
+
+  it("should match terms with non-word characters at the end (e.g., C#)", () => {
+    const findings = collectSupplementalQaFindings(
+      unit({
+        sourceText: "Learning C# today",
+        translations: [{ locale: "fr", text: "Apprendre C#" }],
+      }),
+      {
+        ...baseOptions,
+        glossaryTerms: [
+          {
+            sourceTerm: "C#",
+            targetTerm: "C# (langage)",
+            forbidden: false,
+            caseSensitive: false,
+          },
+        ],
+      },
+    );
+
+    // This is expected to fail with current implementation because \b doesn't match after # if followed by space or end of string
+    expect(findings.some((f) => f.checkType === "glossary_violation")).toBe(true);
+  });
+
+  it("should match terms with non-word characters at the start (e.g., .NET)", () => {
+    const findings = collectSupplementalQaFindings(
+      unit({
+        sourceText: "Using .NET framework",
+        translations: [{ locale: "fr", text: "Utilisation de .NET" }],
+      }),
+      {
+        ...baseOptions,
+        glossaryTerms: [
+          {
+            sourceTerm: ".NET",
+            targetTerm: ".NET Framework",
+            forbidden: false,
+            caseSensitive: false,
+          },
+        ],
+      },
+    );
+
+    expect(findings.some((f) => f.checkType === "glossary_violation")).toBe(true);
+  });
+
+  it("should match terms with punctuation (e.g., Go!)", () => {
+    const findings = collectSupplementalQaFindings(
+      unit({
+        sourceText: "Let's Go!",
+        translations: [{ locale: "fr", text: "Allons-y !" }],
+      }),
+      {
+        ...baseOptions,
+        glossaryTerms: [
+          {
+            sourceTerm: "Go!",
+            targetTerm: "En avant !",
+            forbidden: false,
+            caseSensitive: false,
+          },
+        ],
+      },
+    );
+
+    expect(findings.some((f) => f.checkType === "glossary_violation")).toBe(true);
+  });
+
+  it("should NOT match if the term is part of a larger word", () => {
+    const findings = collectSupplementalQaFindings(
+      unit({
+        sourceText: "Scabbard",
+        translations: [{ locale: "fr", text: "Fourreau" }],
+      }),
+      {
+        ...baseOptions,
+        glossaryTerms: [
+          {
+            sourceTerm: "cab",
+            targetTerm: "taxi",
+            forbidden: false,
+            caseSensitive: false,
+          },
+        ],
+      },
+    );
+
+    expect(findings.some((f) => f.checkType === "glossary_violation")).toBe(false);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/provider-job-qa/supplemental-checks.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-job-qa/supplemental-checks.ts
@@ -37,9 +37,10 @@ function escapeRegExp(value: string) {
 }
 
 function findGlossaryMatches(text: string, term: ProviderQaGlossaryTerm) {
-  const pattern = term.caseSensitive
-    ? new RegExp(`\\b${escapeRegExp(term.sourceTerm)}\\b`)
-    : new RegExp(`\\b${escapeRegExp(term.sourceTerm)}\\b`, "i");
+  // Use a more robust approach for word boundaries that handles non-word characters at the start or end of a term.
+  // Specifically, ensure that a match is only valid if it's not preceded or followed by a word character ([a-zA-Z0-9_]).
+  const patternStr = `(?<![a-zA-Z0-9_])${escapeRegExp(term.sourceTerm)}(?![a-zA-Z0-9_])`;
+  const pattern = term.caseSensitive ? new RegExp(patternStr) : new RegExp(patternStr, "i");
 
   return pattern.test(text);
 }
@@ -138,9 +139,8 @@ function checkGlossaryViolations(
       continue;
     }
 
-    const pattern = term.caseSensitive
-      ? new RegExp(`\\b${escapeRegExp(expected)}\\b`)
-      : new RegExp(`\\b${escapeRegExp(expected)}\\b`, "i");
+    const patternStr = `(?<![a-zA-Z0-9_])${escapeRegExp(expected)}(?![a-zA-Z0-9_])`;
+    const pattern = term.caseSensitive ? new RegExp(patternStr) : new RegExp(patternStr, "i");
 
     if (!pattern.test(targetText)) {
       findings.push(


### PR DESCRIPTION
💡 What: Improved glossary matching logic to correctly handle terms with non-word characters (symbols) and added comprehensive unit tests.
🎯 Why: Standard \b boundaries fail for terms like "C#" when followed by spaces, leading to false negatives in QA checks.
🧩 Scope: `apps/hyperlocalise-web/src/lib/providers/provider-job-qa/supplemental-checks.ts` and new test file.
✅ Verification: Ran `pnpm exec vp test src/lib/providers/provider-job-qa/supplemental-checks.test.ts` and `provider-job-qa.test.ts`.
🛡️ Confidence: Protects glossary enforcement for technical terms and languages that often contain symbols.

---
*PR created automatically by Jules for task [11316014708963517828](https://jules.google.com/task/11316014708963517828) started by @cungminh2710*