### PR TITLE
fix(crowdin): optimize JoinSlice and improve Bundle model parity

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -107,3 +107,9 @@
 **Learning:** Crowdin API v2 Reports have evolved to include AI-specific matching in net rate schemes and more granular metadata in report status attributes. Specifically, `aiMatch` was missing from `ReportNetRateSchemes`, and `projectIds` was missing from `ReportStatusAttributes` for group/organization reports. Additionally, several new report names and the `status` filter in `GroupTaskUsageSchema` were absent.
 
 **Action:** Added `AIMatch` to `ReportNetRateSchemes`, `ProjectIDs` to `ReportStatusAttributes`, and `Status` to `GroupTaskUsageSchema` in `model/reports.go`. Added missing `ReportName` constants for project and group reports (including TM-specific and comprehensive summaries). Updated comprehensive contract tests in `reports_test.go` to verify correct parsing and serialization of these new fields.
+
+## 2026-08-15 - Optimize JoinSlice and improve Bundle model parity
+
+**Learning:** The `JoinSlice` utility in the Go SDK was using `fmt.Sprintf` for every element, causing unnecessary reflection and allocations in hot paths like query parameter encoding. Additionally, `BundleAddRequest` was missing `omitempty` tags for optional label fields, which could lead to sending empty arrays to the Crowdin API.
+
+**Action:** Optimized `model.JoinSlice` in `utils.go` by using `strings.Builder` and type switches for `int` and `string` to significantly reduce allocations. Added `omitempty` to `LabelIDs` and `ExcludeLabelIDs` in `BundleAddRequest` and corrected the documentation comment for `ExcludeLabelIDs`. Verified with focused unit tests and the full test suite.

--- a/third_party/crowdin-api-client-go/crowdin/model/bundles.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/bundles.go
@@ -53,9 +53,9 @@ type BundleAddRequest struct {
 	// Default: false.
 	IncludeProjectSourceLanguage *bool `json:"includeProjectSourceLanguage"`
 	// Label Identifiers.
-	LabelIDs []int `json:"labelIds"`
-	// Label Identifiers.
-	ExcludeLabelIDs []int `json:"excludeLabelIds"`
+	LabelIDs []int `json:"labelIds,omitempty"`
+	// Exclude Label Identifiers.
+	ExcludeLabelIDs []int `json:"excludeLabelIds,omitempty"`
 }
 
 // Validate checks if the request is valid.

--- a/third_party/crowdin-api-client-go/crowdin/model/utils.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/utils.go
@@ -13,20 +13,29 @@ func JoinSlice[T any](s []T) string {
 		return ""
 	}
 
+	// Optimization: switch on the slice type to avoid per-element
+	// interface conversion and type switching.
+	switch val := any(s).(type) {
+	case []int:
+		var b strings.Builder
+		for i, v := range val {
+			if i > 0 {
+				b.WriteByte(',')
+			}
+			b.WriteString(strconv.Itoa(v))
+		}
+		return b.String()
+
+	case []string:
+		return strings.Join(val, ",")
+	}
+
 	var b strings.Builder
 	for i, v := range s {
 		if i > 0 {
 			b.WriteByte(',')
 		}
-
-		switch val := any(v).(type) {
-		case int:
-			b.WriteString(strconv.Itoa(val))
-		case string:
-			b.WriteString(val)
-		default:
-			fmt.Fprintf(&b, "%v", val)
-		}
+		fmt.Fprintf(&b, "%v", v)
 	}
 
 	return b.String()

--- a/third_party/crowdin-api-client-go/crowdin/model/utils.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/utils.go
@@ -2,18 +2,34 @@ package model
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
 // JoinSlice is a helper function that joins the elements
 // of the slice into a single comma-separated string.
 func JoinSlice[T any](s []T) string {
-	res := make([]string, len(s))
-	for i, v := range s {
-		res[i] = fmt.Sprintf("%v", v)
+	if len(s) == 0 {
+		return ""
 	}
 
-	return strings.Join(res, ",")
+	var b strings.Builder
+	for i, v := range s {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+
+		switch val := any(v).(type) {
+		case int:
+			b.WriteString(strconv.Itoa(val))
+		case string:
+			b.WriteString(val)
+		default:
+			fmt.Fprintf(&b, "%v", val)
+		}
+	}
+
+	return b.String()
 }
 
 // Helper used in model tests.


### PR DESCRIPTION
- What: Optimized the `JoinSlice` utility used for query parameter encoding and updated `BundleAddRequest` for API parity.
- Why: `JoinSlice` was inefficient due to `fmt.Sprintf` and reflection. `BundleAddRequest` was missing `omitempty` tags for optional label fields.
- Docs: https://developer.crowdin.com/api/v2/#operation/api.projects.bundles.post
- Scope: `third_party/crowdin-api-client-go/crowdin/model/utils.go`, `third_party/crowdin-api-client-go/crowdin/model/bundles.go`
- Tests: Ran focused `TestJoinSlice` and full suite with `GOWORK=off go test ./...`.
- Confidence: All tests passed, and the optimization preserves original behavior for all types while speeding up common cases.

---
*PR created automatically by Jules for task [17973353075513112449](https://jules.google.com/task/17973353075513112449) started by @cungminh2710*