### PR TITLE
🧪 Scout: Improved ICU invariant extraction for typed elements

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -35,3 +35,7 @@
 ## 2025-05-30 - [Robust Glossary Boundary Matching]
 **Learning:** Standard regex word boundaries (`\b`) fail for glossary terms that start or end with non-word characters (e.g., "C#", ".NET", "Go!"). `\b` requires a transition between a word character (`\w`) and a non-word character or string boundary. If a term like "C#" is followed by a space, there is no `\b` after the "#" because both "#" and " " are non-word characters.
 **Action:** Use negative lookarounds `(?<![a-zA-Z0-9_])` and `(?![a-zA-Z0-9_])` to implement "word boundaries" that correctly handle terms containing symbols while still preventing partial matches within larger alphanumeric words.
+
+## 2025-06-05 - [Typed ICU Block Invariants]
+**Learning:** ICU elements for `number`, `date`, and `time` were previously excluded from `ICUBlocks` metadata, which is used for structural parity checks. While their arguments were extracted as placeholders, their specific types were missing from the structural signature. This could allow a translation to change the type (e.g., from `date` to `number`) without triggering a structural mismatch.
+**Action:** Ensure all "typed" ICU elements (`NumberElement`, `DateElement`, `TimeElement`) are appended to `ICUBlocks` during invariant collection to protect the structural integrity of complex messages.

--- a/internal/i18n/icuparser/invariant.go
+++ b/internal/i18n/icuparser/invariant.go
@@ -162,10 +162,22 @@ func collectInvariantFromElement(el Element, inv *Invariant, pluralArg string) {
 		appendPlaceholder(inv, v.Value)
 	case NumberElement:
 		appendPlaceholder(inv, v.Value)
+		inv.ICUBlocks = append(inv.ICUBlocks, BlockSignature{
+			Arg:  v.Value,
+			Type: "number",
+		})
 	case DateElement:
 		appendPlaceholder(inv, v.Value)
+		inv.ICUBlocks = append(inv.ICUBlocks, BlockSignature{
+			Arg:  v.Value,
+			Type: "date",
+		})
 	case TimeElement:
 		appendPlaceholder(inv, v.Value)
+		inv.ICUBlocks = append(inv.ICUBlocks, BlockSignature{
+			Arg:  v.Value,
+			Type: "time",
+		})
 	case SelectElement:
 		appendSelectBlockInvariant(inv, v, pluralArg)
 	case PluralElement:

--- a/internal/i18n/icuparser/invariant_test.go
+++ b/internal/i18n/icuparser/invariant_test.go
@@ -375,7 +375,6 @@ func TestHasDuplicatePounds(t *testing.T) {
 	}
 }
 
-
 func TestParseInvariantIncludesTypedBlocks(t *testing.T) {
 	tests := []struct {
 		msg  string

--- a/internal/i18n/icuparser/invariant_test.go
+++ b/internal/i18n/icuparser/invariant_test.go
@@ -375,32 +375,47 @@ func TestHasDuplicatePounds(t *testing.T) {
 	}
 }
 
+
 func TestParseInvariantIncludesTypedBlocks(t *testing.T) {
 	tests := []struct {
-		name string
 		msg  string
-		kind string
+		want []BlockSignature
 	}{
-		{"number", "{n, number}", "number"},
-		{"date", "{d, date}", "date"},
-		{"time", "{t, time}", "time"},
+		{
+			msg: "{n, number}",
+			want: []BlockSignature{
+				{Arg: "n", Type: "number"},
+			},
+		},
+		{
+			msg: "{d, date}",
+			want: []BlockSignature{
+				{Arg: "d", Type: "date"},
+			},
+		},
+		{
+			msg: "{t, time}",
+			want: []BlockSignature{
+				{Arg: "t", Type: "time"},
+			},
+		},
+		{
+			msg: "{p, plural, other {{n, number}}}",
+			want: []BlockSignature{
+				{Arg: "n", Type: "number"},
+				{Arg: "p", Type: "plural", Options: []string{"other"}},
+			},
+		},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.msg, func(t *testing.T) {
 			inv, err := ParseInvariant(tt.msg)
 			if err != nil {
 				t.Fatalf("ParseInvariant failed: %v", err)
 			}
-			found := false
-			for _, b := range inv.ICUBlocks {
-				if b.Arg == tt.msg[1:2] && b.Type == tt.kind {
-					found = true
-					break
-				}
-			}
-			if !found {
-				t.Errorf("expected ICUBlock of type %q for message %q, but got none", tt.kind, tt.msg)
+			if !SameICUBlocks(inv.ICUBlocks, tt.want) {
+				t.Errorf("ParseInvariant(%q) ICUBlocks = %s, want %s", tt.msg, FormatICUBlocks(inv.ICUBlocks), FormatICUBlocks(tt.want))
 			}
 		})
 	}

--- a/internal/i18n/icuparser/invariant_test.go
+++ b/internal/i18n/icuparser/invariant_test.go
@@ -374,3 +374,34 @@ func TestHasDuplicatePounds(t *testing.T) {
 		})
 	}
 }
+
+func TestParseInvariantIncludesTypedBlocks(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  string
+		kind string
+	}{
+		{"number", "{n, number}", "number"},
+		{"date", "{d, date}", "date"},
+		{"time", "{t, time}", "time"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inv, err := ParseInvariant(tt.msg)
+			if err != nil {
+				t.Fatalf("ParseInvariant failed: %v", err)
+			}
+			found := false
+			for _, b := range inv.ICUBlocks {
+				if b.Arg == tt.msg[1:2] && b.Type == tt.kind {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("expected ICUBlock of type %q for message %q, but got none", tt.kind, tt.msg)
+			}
+		})
+	}
+}

--- a/internal/i18n/icuparser/parser_test.go
+++ b/internal/i18n/icuparser/parser_test.go
@@ -22,6 +22,10 @@ func TestParserFeatureParitySubset(t *testing.T) {
 			name:             "simple formatter argument is preserved for parity",
 			msg:              "Date {ts, date, ::yyyyMMdd}",
 			wantPlaceholders: []string{"ts"},
+			wantICU: []BlockSignature{{
+				Arg:  "ts",
+				Type: "date",
+			}},
 		},
 		{
 			name:             "plural with selectors and nested placeholders",


### PR DESCRIPTION
Improved `ParseInvariant` to include `number`, `date`, and `time` ICU elements in the `ICUBlocks` metadata. This ensures structural parity checks protect typed elements, preventing translations from accidentally changing the expected data type.

---
*PR created automatically by Jules for task [10199598735403308873](https://jules.google.com/task/10199598735403308873) started by @cungminh2710*