### PR TITLE
fix(web): gate org access on WorkOS membership activation (HL-423)

### DIFF
--- a/apps/hyperlocalise-web/src/api/auth/workos-session.test.ts
+++ b/apps/hyperlocalise-web/src/api/auth/workos-session.test.ts
@@ -207,6 +207,31 @@ describe("resolveApiAuthContextFromSession", () => {
     ).rejects.toThrow("organization_access_denied");
   });
 
+  it("does not grant access for pending invitations without WorkOS membership confirmation", async () => {
+    const pendingOnlyIdentity = fixture.createWorkosIdentity();
+    const synced = await syncWorkosIdentity(db, pendingOnlyIdentity);
+
+    await db
+      .update(schema.organizationMemberships)
+      .set({ workosMembershipId: null })
+      .where(eq(schema.organizationMemberships.organizationId, synced.organization.id));
+
+    withAuthMock.mockResolvedValue({
+      user: { id: synced.user.workosUserId },
+      organizationId: null,
+    });
+
+    const { resolveApiAuthContextFromSession } = await import("./workos-session");
+
+    await expect(
+      resolveApiAuthContextFromSession({
+        organizationSlug: pendingOnlyIdentity.organization.slug,
+      }),
+    ).rejects.toThrow("organization_access_denied");
+
+    await expect(resolveApiAuthContextFromSession()).resolves.toBeNull();
+  });
+
   it("uses the injected session without performing another withAuth lookup", async () => {
     const identity = fixture.createWorkosIdentity();
     await syncWorkosIdentity(db, identity);

--- a/apps/hyperlocalise-web/src/api/auth/workos-session.test.ts
+++ b/apps/hyperlocalise-web/src/api/auth/workos-session.test.ts
@@ -7,6 +7,7 @@ import { db, schema } from "@/lib/database";
 import { eq } from "drizzle-orm";
 import type { WorkosAuthIdentity } from "@/api/auth/workos";
 import { createProjectTestFixture } from "@/api/routes/project/project.fixture";
+import { REPLACING_WORKOS_MEMBERSHIP_ID } from "@/lib/workos/constants";
 
 const { withAuthMock } = vi.hoisted(() => ({
   withAuthMock: vi.fn(),
@@ -205,6 +206,31 @@ describe("resolveApiAuthContextFromSession", () => {
         organizationSlug: "not-a-real-membership",
       }),
     ).rejects.toThrow("organization_access_denied");
+  });
+
+  it("does not grant access while invite replacement sentinel is set on membership", async () => {
+    const identity = fixture.createWorkosIdentity();
+    const synced = await syncWorkosIdentity(db, identity);
+
+    await db
+      .update(schema.organizationMemberships)
+      .set({ workosMembershipId: REPLACING_WORKOS_MEMBERSHIP_ID })
+      .where(eq(schema.organizationMemberships.organizationId, synced.organization.id));
+
+    withAuthMock.mockResolvedValue({
+      user: { id: synced.user.workosUserId },
+      organizationId: null,
+    });
+
+    const { resolveApiAuthContextFromSession } = await import("./workos-session");
+
+    await expect(
+      resolveApiAuthContextFromSession({
+        organizationSlug: identity.organization.slug,
+      }),
+    ).rejects.toThrow("organization_access_denied");
+
+    await expect(resolveApiAuthContextFromSession()).resolves.toBeNull();
   });
 
   it("does not grant access for pending invitations without WorkOS membership confirmation", async () => {

--- a/apps/hyperlocalise-web/src/api/auth/workos-session.ts
+++ b/apps/hyperlocalise-web/src/api/auth/workos-session.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, isNotNull } from "drizzle-orm";
 import { withAuth } from "@workos-inc/authkit-nextjs";
 
 import { getVisibleTeamIds, hasOrganizationWideProjectAccess } from "@/api/auth/team-access";
@@ -252,6 +252,7 @@ export async function resolveApiAuthContextFromSession(
       and(
         eq(schema.users.workosUserId, session.user.id),
         eq(schema.organizations.lifecycleStatus, "active"),
+        isNotNull(schema.organizationMemberships.workosMembershipId),
       ),
     )
     .orderBy(schema.organizations.name);

--- a/apps/hyperlocalise-web/src/api/auth/workos-session.ts
+++ b/apps/hyperlocalise-web/src/api/auth/workos-session.ts
@@ -1,10 +1,11 @@
-import { and, eq, inArray, isNotNull } from "drizzle-orm";
+import { and, eq, inArray, isNotNull, ne } from "drizzle-orm";
 import { withAuth } from "@workos-inc/authkit-nextjs";
 
 import { getVisibleTeamIds, hasOrganizationWideProjectAccess } from "@/api/auth/team-access";
 import { enrichAuthContextWithCapabilities } from "@/api/auth/policy";
 import type { ApiAuthContext } from "@/api/auth/workos";
 import { db, schema } from "@/lib/database";
+import { REPLACING_WORKOS_MEMBERSHIP_ID } from "@/lib/workos/constants";
 
 type ResolveApiAuthContextOptions = {
   cookie?: string;
@@ -253,6 +254,7 @@ export async function resolveApiAuthContextFromSession(
         eq(schema.users.workosUserId, session.user.id),
         eq(schema.organizations.lifecycleStatus, "active"),
         isNotNull(schema.organizationMemberships.workosMembershipId),
+        ne(schema.organizationMemberships.workosMembershipId, REPLACING_WORKOS_MEMBERSHIP_ID),
       ),
     )
     .orderBy(schema.organizations.name);

--- a/apps/hyperlocalise-web/src/api/auth/workos-sync.test.ts
+++ b/apps/hyperlocalise-web/src/api/auth/workos-sync.test.ts
@@ -1,0 +1,81 @@
+import "dotenv/config";
+
+import { eq } from "drizzle-orm";
+import { beforeAll, describe, expect, it } from "vite-plus/test";
+
+import {
+  clearPendingMembershipReplacingInvitation,
+  markPendingMembershipReplacingInvitation,
+  removePendingOrganizationMembershipForInvite,
+  syncWorkosIdentity,
+} from "@/api/auth/workos-sync";
+import { createAuthTestFixture } from "@/api/test-auth.fixture";
+import { db, schema } from "@/lib/database";
+import { REPLACING_WORKOS_MEMBERSHIP_ID } from "@/lib/workos/constants";
+
+const { createWorkosIdentity } = createAuthTestFixture();
+
+beforeAll(async () => {
+  await db.$client.query("select 1");
+});
+
+describe("removePendingOrganizationMembershipForInvite", () => {
+  it("does not delete memberships marked as replacing an invitation", async () => {
+    const ownerIdentity = createWorkosIdentity();
+    const invitedIdentity = createWorkosIdentity();
+    await syncWorkosIdentity(db, ownerIdentity);
+    await syncWorkosIdentity(db, invitedIdentity);
+
+    const [organization] = await db
+      .select({ id: schema.organizations.id })
+      .from(schema.organizations)
+      .where(
+        eq(
+          schema.organizations.workosOrganizationId,
+          ownerIdentity.organization.workosOrganizationId,
+        ),
+      )
+      .limit(1);
+
+    const [invitedUser] = await db
+      .select({ id: schema.users.id })
+      .from(schema.users)
+      .where(eq(schema.users.workosUserId, invitedIdentity.user.workosUserId))
+      .limit(1);
+
+    expect(organization).toBeDefined();
+    expect(invitedUser).toBeDefined();
+
+    const [membership] = await db
+      .insert(schema.organizationMemberships)
+      .values({
+        organizationId: organization!.id,
+        userId: invitedUser!.id,
+        role: "member",
+        workosMembershipId: null,
+      })
+      .returning({ id: schema.organizationMemberships.id });
+
+    const marked = await markPendingMembershipReplacingInvitation(db, membership.id);
+    expect(marked).toBe(true);
+
+    const deleted = await removePendingOrganizationMembershipForInvite(db, {
+      workosOrganizationId: ownerIdentity.organization.workosOrganizationId,
+      email: invitedIdentity.user.email,
+    });
+    expect(deleted).toBe(0);
+
+    const [remaining] = await db
+      .select({ workosMembershipId: schema.organizationMemberships.workosMembershipId })
+      .from(schema.organizationMemberships)
+      .where(eq(schema.organizationMemberships.id, membership.id))
+      .limit(1);
+
+    expect(remaining?.workosMembershipId).toBe(REPLACING_WORKOS_MEMBERSHIP_ID);
+
+    await clearPendingMembershipReplacingInvitation(db, membership.id);
+    await db
+      .delete(schema.organizationMemberships)
+      .where(eq(schema.organizationMemberships.id, membership.id));
+  });
+});

--- a/apps/hyperlocalise-web/src/api/auth/workos-sync.ts
+++ b/apps/hyperlocalise-web/src/api/auth/workos-sync.ts
@@ -7,6 +7,7 @@ import type { DatabaseClient } from "@/lib/database";
 import {
   INVITED_WORKOS_USER_ID_PREFIX,
   isInvitedPlaceholderWorkosUserId,
+  REPLACING_WORKOS_MEMBERSHIP_ID,
 } from "@/lib/workos/constants";
 
 export type WorkosUserSync = {
@@ -244,6 +245,38 @@ export type RemoveWorkosMembershipResult = {
   organizationMembershipsDeleted: number;
   target: RevocationTarget | null;
 };
+
+export async function markPendingMembershipReplacingInvitation(
+  database: DatabaseClient,
+  membershipId: string,
+): Promise<boolean> {
+  const result = await database
+    .update(schema.organizationMemberships)
+    .set({ workosMembershipId: REPLACING_WORKOS_MEMBERSHIP_ID })
+    .where(
+      and(
+        eq(schema.organizationMemberships.id, membershipId),
+        isNull(schema.organizationMemberships.workosMembershipId),
+      ),
+    );
+
+  return Number(result.rowCount ?? 0) > 0;
+}
+
+export async function clearPendingMembershipReplacingInvitation(
+  database: DatabaseClient,
+  membershipId: string,
+): Promise<void> {
+  await database
+    .update(schema.organizationMemberships)
+    .set({ workosMembershipId: null })
+    .where(
+      and(
+        eq(schema.organizationMemberships.id, membershipId),
+        eq(schema.organizationMemberships.workosMembershipId, REPLACING_WORKOS_MEMBERSHIP_ID),
+      ),
+    );
+}
 
 export async function removePendingOrganizationMembershipForInvite(
   database: DatabaseClient,

--- a/apps/hyperlocalise-web/src/api/auth/workos-sync.ts
+++ b/apps/hyperlocalise-web/src/api/auth/workos-sync.ts
@@ -1,10 +1,13 @@
-import { and, eq, like } from "drizzle-orm";
+import { and, eq, isNull, like, sql } from "drizzle-orm";
 
 import * as schema from "@/lib/database/schema";
 import type { OrganizationMembershipRole } from "@/lib/database/types";
 
 import type { DatabaseClient } from "@/lib/database";
-import { INVITED_WORKOS_USER_ID_PREFIX } from "@/lib/workos/constants";
+import {
+  INVITED_WORKOS_USER_ID_PREFIX,
+  isInvitedPlaceholderWorkosUserId,
+} from "@/lib/workos/constants";
 
 export type WorkosUserSync = {
   workosUserId: string;
@@ -230,6 +233,61 @@ export async function syncWorkosOrganization(
     });
 
   return createdOrganization;
+}
+
+export async function removePendingOrganizationMembershipForInvite(
+  database: DatabaseClient,
+  input: { workosOrganizationId: string; email: string },
+): Promise<number> {
+  const normalizedEmail = input.email.trim().toLowerCase();
+
+  const [organization] = await database
+    .select({ id: schema.organizations.id })
+    .from(schema.organizations)
+    .where(eq(schema.organizations.workosOrganizationId, input.workosOrganizationId))
+    .limit(1);
+
+  if (!organization) {
+    return 0;
+  }
+
+  const [user] = await database
+    .select({
+      id: schema.users.id,
+      workosUserId: schema.users.workosUserId,
+    })
+    .from(schema.users)
+    .where(eq(schema.users.email, normalizedEmail))
+    .limit(1);
+
+  if (!user) {
+    return 0;
+  }
+
+  const result = await database
+    .delete(schema.organizationMemberships)
+    .where(
+      and(
+        eq(schema.organizationMemberships.organizationId, organization.id),
+        eq(schema.organizationMemberships.userId, user.id),
+        isNull(schema.organizationMemberships.workosMembershipId),
+      ),
+    );
+
+  if (isInvitedPlaceholderWorkosUserId(user.workosUserId) && Number(result.rowCount ?? 0) > 0) {
+    await database.delete(schema.users).where(
+      and(
+        eq(schema.users.id, user.id),
+        sql`not exists (
+          select 1
+          from ${schema.organizationMemberships}
+          where ${schema.organizationMemberships.userId} = ${schema.users.id}
+        )`,
+      ),
+    );
+  }
+
+  return Number(result.rowCount ?? 0);
 }
 
 export async function removeWorkosMembership(

--- a/apps/hyperlocalise-web/src/api/auth/workos-sync.ts
+++ b/apps/hyperlocalise-web/src/api/auth/workos-sync.ts
@@ -288,6 +288,7 @@ export async function removePendingOrganizationMembershipForInvite(
     await database.delete(schema.users).where(
       and(
         eq(schema.users.id, user.id),
+        like(schema.users.workosUserId, `${INVITED_WORKOS_USER_ID_PREFIX}%`),
         sql`not exists (
           select 1
           from ${schema.organizationMemberships}

--- a/apps/hyperlocalise-web/src/api/routes/member/member.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/member/member.route.ts
@@ -372,7 +372,7 @@ export function createMemberRoutes() {
           inviterUserId: c.var.auth.user.workosUserId,
           roleSlug: payload.role,
           replacePendingInvitation:
-            isResend && "roleChanged" in pendingInvite && pendingInvite.roleChanged,
+            !isResend || ("roleChanged" in pendingInvite && pendingInvite.roleChanged),
         });
       } catch {
         if (!isResend) {

--- a/apps/hyperlocalise-web/src/api/routes/member/member.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/member/member.route.ts
@@ -456,6 +456,9 @@ export function createMemberRoutes() {
       }
 
       const { updated } = updateResult;
+      const roleChanged = previousRole !== payload.role;
+      const isPendingInvite = isPendingOrganizationMembership(member.workosMembershipId);
+      const workosOrganizationId = c.var.auth.organization.workosOrganizationId;
 
       if (
         shouldSyncMembershipToWorkos({
@@ -465,6 +468,40 @@ export function createMemberRoutes() {
         try {
           await workos!.userManagement.updateOrganizationMembership(member.workosMembershipId!, {
             roleSlug: payload.role,
+          });
+        } catch {
+          await db
+            .update(schema.organizationMemberships)
+            .set({ role: previousRole })
+            .where(eq(schema.organizationMemberships.id, member.membershipId));
+
+          return internalErrorResponse(
+            c,
+            "member_sync_failed",
+            "Failed to sync member role with identity provider",
+          );
+        }
+      } else if (isPendingInvite && roleChanged) {
+        if (!workos) {
+          await db
+            .update(schema.organizationMemberships)
+            .set({ role: previousRole })
+            .where(eq(schema.organizationMemberships.id, member.membershipId));
+
+          return serviceUnavailableResponse(
+            c,
+            "workos_server_not_configured",
+            "WorkOS server integration is not configured",
+          );
+        }
+
+        try {
+          await deliverWorkosInvitation({
+            workosOrganizationId,
+            email: member.email,
+            inviterUserId: c.var.auth.user.workosUserId,
+            roleSlug: payload.role,
+            replacePendingInvitation: true,
           });
         } catch {
           await db

--- a/apps/hyperlocalise-web/src/api/routes/member/member.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/member/member.route.ts
@@ -245,6 +245,38 @@ async function revokePendingWorkosInvitation(input: {
   await workos.userManagement.revokeInvitation(pendingInvitation.id);
 }
 
+class WorkosInvitationRevokedNotDeliveredError extends Error {
+  readonly code = "member_invite_revoked_not_delivered" as const;
+
+  constructor() {
+    super("WorkOS invitation was revoked but a replacement could not be sent");
+    this.name = "WorkosInvitationRevokedNotDeliveredError";
+  }
+}
+
+function isWorkosInvitationRevokedNotDeliveredError(
+  error: unknown,
+): error is WorkosInvitationRevokedNotDeliveredError {
+  return error instanceof WorkosInvitationRevokedNotDeliveredError;
+}
+
+async function sendWorkosInvitation(
+  workos: NonNullable<ReturnType<typeof getWorkosServerClient>>,
+  input: {
+    workosOrganizationId: string;
+    email: string;
+    inviterUserId: string;
+    roleSlug: OrganizationMembershipRole;
+  },
+) {
+  await workos.userManagement.sendInvitation({
+    email: input.email.trim().toLowerCase(),
+    organizationId: input.workosOrganizationId,
+    inviterUserId: input.inviterUserId,
+    roleSlug: input.roleSlug,
+  });
+}
+
 async function deliverWorkosInvitation(input: {
   workosOrganizationId: string;
   email: string;
@@ -262,19 +294,33 @@ async function deliverWorkosInvitation(input: {
     email: input.email,
   });
 
+  const invitationPayload = {
+    workosOrganizationId: input.workosOrganizationId,
+    email: input.email,
+    inviterUserId: input.inviterUserId,
+    roleSlug: input.roleSlug,
+  };
+
   if (pendingInvitation && input.replacePendingInvitation) {
     await workos.userManagement.revokeInvitation(pendingInvitation.id);
-  } else if (pendingInvitation) {
+    try {
+      await sendWorkosInvitation(workos, invitationPayload);
+    } catch {
+      try {
+        await sendWorkosInvitation(workos, invitationPayload);
+      } catch {
+        throw new WorkosInvitationRevokedNotDeliveredError();
+      }
+    }
+    return;
+  }
+
+  if (pendingInvitation) {
     await workos.userManagement.resendInvitation(pendingInvitation.id);
     return;
   }
 
-  await workos.userManagement.sendInvitation({
-    email: input.email.trim().toLowerCase(),
-    organizationId: input.workosOrganizationId,
-    inviterUserId: input.inviterUserId,
-    roleSlug: input.roleSlug,
-  });
+  await sendWorkosInvitation(workos, invitationPayload);
 }
 
 async function rollbackPendingInvite(input: {
@@ -374,7 +420,7 @@ export function createMemberRoutes() {
           replacePendingInvitation:
             !isResend || ("roleChanged" in pendingInvite && pendingInvite.roleChanged),
         });
-      } catch {
+      } catch (error) {
         if (!isResend) {
           await rollbackPendingInvite({
             membershipId: pendingInvite.membershipId,
@@ -390,6 +436,14 @@ export function createMemberRoutes() {
             .update(schema.organizationMemberships)
             .set({ role: pendingInvite.previousRole })
             .where(eq(schema.organizationMemberships.id, pendingInvite.membershipId));
+        }
+
+        if (isWorkosInvitationRevokedNotDeliveredError(error)) {
+          return internalErrorResponse(
+            c,
+            error.code,
+            "The previous invitation was revoked but a new one could not be sent. Invite this member again.",
+          );
         }
 
         return internalErrorResponse(
@@ -503,11 +557,19 @@ export function createMemberRoutes() {
             roleSlug: payload.role,
             replacePendingInvitation: true,
           });
-        } catch {
+        } catch (error) {
           await db
             .update(schema.organizationMemberships)
             .set({ role: previousRole })
             .where(eq(schema.organizationMemberships.id, member.membershipId));
+
+          if (isWorkosInvitationRevokedNotDeliveredError(error)) {
+            return internalErrorResponse(
+              c,
+              error.code,
+              "The previous invitation was revoked but a new one could not be sent. Invite this member again.",
+            );
+          }
 
           return internalErrorResponse(
             c,

--- a/apps/hyperlocalise-web/src/api/routes/member/member.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/member/member.route.ts
@@ -23,8 +23,9 @@ import {
   getOrganizationMember,
   invalidMemberPayloadResponse,
   INVITED_WORKOS_USER_ID_PREFIX,
-  isInvitedPlaceholderWorkosUserId,
+  isActiveOrganizationMembership,
   isMemberListAllowed,
+  isPendingOrganizationMembership,
   shouldCleanupPlaceholderUserOnMemberRemoval,
   isMemberManageAllowed,
   lastOwnerProtectedResponse,
@@ -82,8 +83,18 @@ async function inviteOrganizationMember(input: {
 }) {
   const normalizedEmail = input.email.trim().toLowerCase();
 
-  const existingMember = await db
-    .select({ id: schema.users.id })
+  const [existingMembership] = await db
+    .select({
+      membershipId: schema.organizationMemberships.id,
+      workosMembershipId: schema.organizationMemberships.workosMembershipId,
+      role: schema.organizationMemberships.role,
+      createdAt: schema.organizationMemberships.createdAt,
+      localUserId: schema.users.id,
+      workosUserId: schema.users.workosUserId,
+      email: schema.users.email,
+      firstName: schema.users.firstName,
+      lastName: schema.users.lastName,
+    })
     .from(schema.users)
     .innerJoin(
       schema.organizationMemberships,
@@ -97,8 +108,36 @@ async function inviteOrganizationMember(input: {
     )
     .limit(1);
 
-  if (existingMember[0]) {
-    return { error: "member_already_exists" as const };
+  if (existingMembership) {
+    if (isActiveOrganizationMembership(existingMembership.workosMembershipId)) {
+      return { error: "member_already_exists" as const };
+    }
+
+    if (existingMembership.role !== input.role) {
+      await db
+        .update(schema.organizationMemberships)
+        .set({ role: input.role })
+        .where(eq(schema.organizationMemberships.id, existingMembership.membershipId));
+    }
+
+    return {
+      resend: true as const,
+      membershipId: existingMembership.membershipId,
+      localUserId: existingMembership.localUserId,
+      isNewUser: false,
+      member: toMemberSummary(
+        {
+          workosUserId: existingMembership.workosUserId,
+          email: existingMembership.email,
+          firstName: existingMembership.firstName,
+          lastName: existingMembership.lastName,
+          role: input.role,
+          createdAt: existingMembership.createdAt,
+          workosMembershipId: existingMembership.workosMembershipId,
+        },
+        "",
+      ),
+    };
   }
 
   const [existingUser] = await db
@@ -159,6 +198,7 @@ async function inviteOrganizationMember(input: {
         lastName: user.lastName,
         role: membership.role,
         createdAt: membership.createdAt,
+        workosMembershipId: null,
       },
       "",
     ),
@@ -178,13 +218,10 @@ async function cleanupInvitedPlaceholderUser(localUserId: string) {
   );
 }
 
-async function revokePendingWorkosInvitation(input: {
-  workosOrganizationId: string;
-  email: string;
-}) {
+async function findPendingWorkosInvitation(input: { workosOrganizationId: string; email: string }) {
   const workos = getWorkosServerClient();
   if (!workos) {
-    return;
+    return null;
   }
 
   const normalizedEmail = input.email.trim().toLowerCase();
@@ -194,12 +231,53 @@ async function revokePendingWorkosInvitation(input: {
     limit: 10,
   });
 
-  const pendingInvitation = invitations.data.find((invitation) => invitation.state === "pending");
+  return invitations.data.find((invitation) => invitation.state === "pending") ?? null;
+}
+
+async function revokePendingWorkosInvitation(input: {
+  workosOrganizationId: string;
+  email: string;
+}) {
+  const pendingInvitation = await findPendingWorkosInvitation(input);
   if (!pendingInvitation) {
     return;
   }
 
+  const workos = getWorkosServerClient();
+  if (!workos) {
+    return;
+  }
+
   await workos.userManagement.revokeInvitation(pendingInvitation.id);
+}
+
+async function deliverWorkosInvitation(input: {
+  workosOrganizationId: string;
+  email: string;
+  inviterUserId: string;
+  roleSlug: OrganizationMembershipRole;
+}) {
+  const workos = getWorkosServerClient();
+  if (!workos) {
+    throw new Error("workos_not_configured");
+  }
+
+  const pendingInvitation = await findPendingWorkosInvitation({
+    workosOrganizationId: input.workosOrganizationId,
+    email: input.email,
+  });
+
+  if (pendingInvitation) {
+    await workos.userManagement.resendInvitation(pendingInvitation.id);
+    return;
+  }
+
+  await workos.userManagement.sendInvitation({
+    email: input.email.trim().toLowerCase(),
+    organizationId: input.workosOrganizationId,
+    inviterUserId: input.inviterUserId,
+    roleSlug: input.roleSlug,
+  });
 }
 
 async function rollbackPendingInvite(input: {
@@ -234,6 +312,7 @@ export function createMemberRoutes() {
           lastName: schema.users.lastName,
           role: schema.organizationMemberships.role,
           createdAt: schema.organizationMemberships.createdAt,
+          workosMembershipId: schema.organizationMemberships.workosMembershipId,
         })
         .from(schema.organizationMemberships)
         .innerJoin(schema.users, eq(schema.organizationMemberships.userId, schema.users.id))
@@ -287,19 +366,23 @@ export function createMemberRoutes() {
         return memberAlreadyExistsResponse(c);
       }
 
+      const isResend = "resend" in pendingInvite && pendingInvite.resend;
+
       try {
-        await workos.userManagement.sendInvitation({
+        await deliverWorkosInvitation({
+          workosOrganizationId,
           email: normalizedEmail,
-          organizationId: workosOrganizationId,
           inviterUserId: c.var.auth.user.workosUserId,
           roleSlug: payload.role,
         });
       } catch {
-        await rollbackPendingInvite({
-          membershipId: pendingInvite.membershipId,
-          localUserId: pendingInvite.localUserId,
-          isNewUser: pendingInvite.isNewUser,
-        });
+        if (!isResend) {
+          await rollbackPendingInvite({
+            membershipId: pendingInvite.membershipId,
+            localUserId: pendingInvite.localUserId,
+            isNewUser: pendingInvite.isNewUser,
+          });
+        }
 
         return internalErrorResponse(
           c,
@@ -315,7 +398,7 @@ export function createMemberRoutes() {
             isCurrentUser: false,
           },
         },
-        201,
+        isResend ? 200 : 201,
       );
     })
     .patch("/:workosUserId", validateMemberParams, validateUpdateMemberBody, async (c) => {
@@ -399,6 +482,7 @@ export function createMemberRoutes() {
               lastName: member.lastName,
               role: updated.role,
               createdAt: updated.createdAt,
+              workosMembershipId: member.workosMembershipId,
             },
             c.var.auth.user.workosUserId,
           ),
@@ -448,7 +532,7 @@ export function createMemberRoutes() {
         return lastOwnerProtectedResponse(c);
       }
 
-      const isPendingInvite = isInvitedPlaceholderWorkosUserId(member.workosUserId);
+      const isPendingInvite = isPendingOrganizationMembership(member.workosMembershipId);
 
       if (
         shouldSyncMembershipToWorkos({
@@ -471,7 +555,7 @@ export function createMemberRoutes() {
             "Failed to sync member removal with identity provider",
           );
         }
-      } else if (isPendingInvite) {
+      } else if (isPendingInvite && workos) {
         try {
           await revokePendingWorkosInvitation({
             workosOrganizationId,

--- a/apps/hyperlocalise-web/src/api/routes/member/member.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/member/member.route.ts
@@ -5,7 +5,11 @@ import { Hono } from "hono";
 import { validator } from "hono/validator";
 
 import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
-import { revokeOrganizationMembershipAccess } from "@/api/auth/workos-sync";
+import {
+  clearPendingMembershipReplacingInvitation,
+  markPendingMembershipReplacingInvitation,
+  revokeOrganizationMembershipAccess,
+} from "@/api/auth/workos-sync";
 import { internalErrorResponse, serviceUnavailableResponse } from "@/api/response.schema";
 import { db, schema } from "@/lib/database";
 import type { OrganizationMembershipRole } from "@/lib/database/types";
@@ -61,7 +65,7 @@ const validateMemberParams = validator("param", (value, c) => {
 
 function shouldSyncMembershipToWorkos(input: { workosMembershipId: string | null }) {
   const workos = getWorkosServerClient();
-  return Boolean(input.workosMembershipId) && workos !== null;
+  return isActiveOrganizationMembership(input.workosMembershipId) && workos !== null;
 }
 
 async function inviteOrganizationMember(input: {
@@ -283,6 +287,7 @@ async function deliverWorkosInvitation(input: {
   inviterUserId: string;
   roleSlug: OrganizationMembershipRole;
   replacePendingInvitation?: boolean;
+  localMembershipId?: string;
 }) {
   const workos = getWorkosServerClient();
   if (!workos) {
@@ -302,14 +307,24 @@ async function deliverWorkosInvitation(input: {
   };
 
   if (pendingInvitation && input.replacePendingInvitation) {
-    await workos.userManagement.revokeInvitation(pendingInvitation.id);
+    const markedReplacing = input.localMembershipId
+      ? await markPendingMembershipReplacingInvitation(db, input.localMembershipId)
+      : false;
+
     try {
-      await sendWorkosInvitation(workos, invitationPayload);
-    } catch {
+      await workos.userManagement.revokeInvitation(pendingInvitation.id);
       try {
         await sendWorkosInvitation(workos, invitationPayload);
       } catch {
-        throw new WorkosInvitationRevokedNotDeliveredError();
+        try {
+          await sendWorkosInvitation(workos, invitationPayload);
+        } catch {
+          throw new WorkosInvitationRevokedNotDeliveredError();
+        }
+      }
+    } finally {
+      if (markedReplacing && input.localMembershipId) {
+        await clearPendingMembershipReplacingInvitation(db, input.localMembershipId);
       }
     }
     return;
@@ -417,6 +432,7 @@ export function createMemberRoutes() {
           email: normalizedEmail,
           inviterUserId: c.var.auth.user.workosUserId,
           roleSlug: payload.role,
+          localMembershipId: pendingInvite.membershipId,
           replacePendingInvitation:
             !isResend || ("roleChanged" in pendingInvite && pendingInvite.roleChanged),
         });
@@ -555,6 +571,7 @@ export function createMemberRoutes() {
             email: member.email,
             inviterUserId: c.var.auth.user.workosUserId,
             roleSlug: payload.role,
+            localMembershipId: member.membershipId,
             replacePendingInvitation: true,
           });
         } catch (error) {

--- a/apps/hyperlocalise-web/src/api/routes/member/member.shared.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/member/member.shared.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 
+import { REPLACING_WORKOS_MEMBERSHIP_ID } from "@/lib/workos/constants";
+
 import { resolveMemberStatus } from "./member.shared";
 
 describe("resolveMemberStatus", () => {
@@ -9,5 +11,11 @@ describe("resolveMemberStatus", () => {
 
   it("marks memberships with WorkOS confirmation as active", () => {
     expect(resolveMemberStatus({ workosMembershipId: "om_123" })).toBe("active");
+  });
+
+  it("marks in-flight invite replacement as invited", () => {
+    expect(resolveMemberStatus({ workosMembershipId: REPLACING_WORKOS_MEMBERSHIP_ID })).toBe(
+      "invited",
+    );
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/member/member.shared.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/member/member.shared.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { resolveMemberStatus } from "./member.shared";
+
+describe("resolveMemberStatus", () => {
+  it("marks memberships without WorkOS confirmation as invited", () => {
+    expect(resolveMemberStatus({ workosMembershipId: null })).toBe("invited");
+  });
+
+  it("marks memberships with WorkOS confirmation as active", () => {
+    expect(resolveMemberStatus({ workosMembershipId: "om_123" })).toBe("active");
+  });
+});

--- a/apps/hyperlocalise-web/src/api/routes/member/member.shared.ts
+++ b/apps/hyperlocalise-web/src/api/routes/member/member.shared.ts
@@ -14,7 +14,9 @@ import type { OrganizationMembershipRole } from "@/lib/database/types";
 
 import {
   INVITED_WORKOS_USER_ID_PREFIX,
+  isActiveOrganizationMembership,
   isInvitedPlaceholderWorkosUserId,
+  isPendingOrganizationMembership,
   shouldCleanupPlaceholderUserOnMemberRemoval,
 } from "@/lib/workos/constants";
 
@@ -22,12 +24,16 @@ import type { z } from "zod";
 
 export {
   INVITED_WORKOS_USER_ID_PREFIX,
+  isActiveOrganizationMembership,
   isInvitedPlaceholderWorkosUserId,
+  isPendingOrganizationMembership,
   shouldCleanupPlaceholderUserOnMemberRemoval,
 };
 
-export function resolveMemberStatus(workosUserId: string): "active" | "invited" {
-  return isInvitedPlaceholderWorkosUserId(workosUserId) ? "invited" : "active";
+export function resolveMemberStatus(input: {
+  workosMembershipId: string | null;
+}): "active" | "invited" {
+  return isPendingOrganizationMembership(input.workosMembershipId) ? "invited" : "active";
 }
 
 export function forbiddenResponse(c: JsonContext) {
@@ -155,6 +161,7 @@ export function toMemberSummary(
     lastName: string | null;
     role: OrganizationMembershipRole;
     createdAt: Date;
+    workosMembershipId: string | null;
   },
   currentWorkosUserId: string,
 ): {
@@ -177,6 +184,6 @@ export function toMemberSummary(
     role: row.role,
     isCurrentUser: row.workosUserId === currentWorkosUserId,
     createdAt: row.createdAt.toISOString(),
-    status: resolveMemberStatus(row.workosUserId),
+    status: resolveMemberStatus({ workosMembershipId: row.workosMembershipId }),
   };
 }

--- a/apps/hyperlocalise-web/src/api/routes/member/member.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/member/member.test.ts
@@ -8,6 +8,7 @@ const {
   deleteOrganizationMembershipMock,
   getWorkosServerClientMock,
   listInvitationsMock,
+  resendInvitationMock,
   resolveApiAuthContextFromSessionMock,
   revokeInvitationMock,
   sendInvitationMock,
@@ -20,9 +21,8 @@ const {
       null,
   ),
   sendInvitationMock: vi.fn(async () => ({ id: "invitation_mock" })),
-  listInvitationsMock: vi.fn(async () => ({
-    data: [{ id: "invitation_mock", state: "pending" }],
-  })),
+  resendInvitationMock: vi.fn(async () => ({ id: "invitation_mock" })),
+  listInvitationsMock: vi.fn(async () => ({ data: [] as { id: string; state: string }[] })),
   revokeInvitationMock: vi.fn(async () => undefined),
   deleteOrganizationMembershipMock: vi.fn(async () => undefined),
   updateOrganizationMembershipMock: vi.fn(async () => undefined),
@@ -47,6 +47,7 @@ vi.mock("@/lib/workos/server-client", () => ({
     return {
       userManagement: {
         sendInvitation: sendInvitationMock,
+        resendInvitation: resendInvitationMock,
         listInvitations: listInvitationsMock,
         revokeInvitation: revokeInvitationMock,
         deleteOrganizationMembership: deleteOrganizationMembershipMock,
@@ -57,6 +58,7 @@ vi.mock("@/lib/workos/server-client", () => ({
 }));
 
 import { createApp } from "@/api/app";
+import { syncWorkosIdentity } from "@/api/auth/workos-sync";
 import { db, schema } from "@/lib/database";
 import type { JobQueue, TranslationJobEventData } from "@/lib/workflow/types";
 
@@ -218,6 +220,7 @@ describe("memberRoutes", () => {
   });
 
   it("rolls back pending invite when WorkOS invitation fails", async () => {
+    listInvitationsMock.mockResolvedValue({ data: [] });
     sendInvitationMock.mockRejectedValueOnce(new Error("boom"));
     const ownerIdentity = createWorkosIdentity();
     const headers = await authHeadersFor(ownerIdentity);
@@ -272,6 +275,87 @@ describe("memberRoutes", () => {
     );
 
     expect(response.status).toBe(403);
+  });
+
+  it("resends a pending invitation instead of creating a duplicate membership", async () => {
+    listInvitationsMock
+      .mockResolvedValueOnce({ data: [] })
+      .mockResolvedValueOnce({ data: [{ id: "invitation_mock", state: "pending" }] });
+
+    const ownerIdentity = createWorkosIdentity();
+    const headers = await authHeadersFor(ownerIdentity);
+
+    const firstResponse = await inviteMemberViaApi(
+      ownerIdentity,
+      { email: "resend-me@example.com", role: "member" },
+      headers,
+    );
+    expect(firstResponse.status).toBe(201);
+    expect(sendInvitationMock).toHaveBeenCalledTimes(1);
+
+    const secondResponse = await inviteMemberViaApi(
+      ownerIdentity,
+      { email: "resend-me@example.com", role: "member" },
+      headers,
+    );
+    expect(secondResponse.status).toBe(200);
+    expect(sendInvitationMock).toHaveBeenCalledTimes(1);
+    expect(resendInvitationMock).toHaveBeenCalledTimes(1);
+
+    const listBody = (await (
+      await listMembersViaApi(ownerIdentity, headers)
+    ).json()) as MembersResponse;
+    expect(
+      listBody.members.filter((member) => member.email === "resend-me@example.com"),
+    ).toHaveLength(1);
+  });
+
+  it("shows existing users as invited until WorkOS confirms membership", async () => {
+    const ownerIdentity = createWorkosIdentity();
+    const existingUserIdentity = createWorkosIdentity();
+    await syncWorkosIdentity(db, existingUserIdentity);
+
+    const headers = await authHeadersFor(ownerIdentity);
+    const response = await inviteMemberViaApi(
+      ownerIdentity,
+      { email: existingUserIdentity.user.email, role: "member" },
+      headers,
+    );
+    expect(response.status).toBe(201);
+
+    const listBody = (await (
+      await listMembersViaApi(ownerIdentity, headers)
+    ).json()) as MembersResponse;
+    const invited = listBody.members.find(
+      (member) => member.email === existingUserIdentity.user.email,
+    );
+    expect(invited?.status).toBe("invited");
+    expect(invited?.workosUserId).toBe(existingUserIdentity.user.workosUserId);
+  });
+
+  it("revokes WorkOS invitations when removing a pending existing user", async () => {
+    listInvitationsMock.mockResolvedValue({
+      data: [{ id: "invitation_mock", state: "pending" }],
+    });
+
+    const ownerIdentity = createWorkosIdentity();
+    const existingUserIdentity = createWorkosIdentity();
+    await syncWorkosIdentity(db, existingUserIdentity);
+
+    const headers = await authHeadersFor(ownerIdentity);
+    await inviteMemberViaApi(
+      ownerIdentity,
+      { email: existingUserIdentity.user.email, role: "member" },
+      headers,
+    );
+
+    const deleteResponse = await removeMemberViaApi(
+      ownerIdentity,
+      existingUserIdentity.user.workosUserId,
+      headers,
+    );
+    expect(deleteResponse.status).toBe(204);
+    expect(revokeInvitationMock).toHaveBeenCalled();
   });
 
   it("returns 409 when removing the last owner", async () => {

--- a/apps/hyperlocalise-web/src/api/routes/member/member.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/member/member.test.ts
@@ -456,6 +456,28 @@ describe("memberRoutes", () => {
     expect(response.status).toBe(403);
   });
 
+  it("returns member_invite_revoked_not_delivered when replace revokes but send fails", async () => {
+    listInvitationsMock.mockResolvedValue({
+      data: [{ id: "stale_invitation", state: "pending" }],
+    });
+    sendInvitationMock.mockRejectedValue(new Error("workos unavailable"));
+
+    const ownerIdentity = createWorkosIdentity();
+    const headers = await authHeadersFor(ownerIdentity);
+
+    const response = await inviteMemberViaApi(
+      ownerIdentity,
+      { email: "revoked-not-sent@example.com", role: "admin" },
+      headers,
+    );
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "member_invite_revoked_not_delivered",
+    });
+    expect(revokeInvitationMock).toHaveBeenCalledWith("stale_invitation");
+    expect(sendInvitationMock).toHaveBeenCalledTimes(2);
+  });
+
   it("replaces a stale WorkOS invitation when inviting with no local pending membership", async () => {
     listInvitationsMock.mockResolvedValue({
       data: [{ id: "stale_invitation", state: "pending" }],

--- a/apps/hyperlocalise-web/src/api/routes/member/member.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/member/member.test.ts
@@ -568,6 +568,72 @@ describe("memberRoutes", () => {
     expect(member?.role).toBe("member");
   });
 
+  it("replaces a pending WorkOS invitation when PATCH changes an existing user's role", async () => {
+    listInvitationsMock.mockResolvedValue({
+      data: [{ id: "invitation_mock", state: "pending" }],
+    });
+
+    const ownerIdentity = createWorkosIdentity();
+    const existingUserIdentity = createWorkosIdentity();
+    await syncWorkosIdentity(db, existingUserIdentity);
+
+    const headers = await authHeadersFor(ownerIdentity);
+    await inviteMemberViaApi(
+      ownerIdentity,
+      { email: existingUserIdentity.user.email, role: "member" },
+      headers,
+    );
+
+    const updateResponse = await updateMemberRoleViaApi(
+      ownerIdentity,
+      existingUserIdentity.user.workosUserId,
+      "admin",
+      headers,
+    );
+    expect(updateResponse.status).toBe(200);
+    expect(revokeInvitationMock).toHaveBeenCalledWith("invitation_mock");
+    expect(sendInvitationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: existingUserIdentity.user.email,
+        roleSlug: "admin",
+      }),
+    );
+    expect(updateOrganizationMembershipMock).not.toHaveBeenCalled();
+  });
+
+  it("rolls back PATCH role changes for pending members when invitation sync fails", async () => {
+    listInvitationsMock.mockResolvedValue({
+      data: [{ id: "invitation_mock", state: "pending" }],
+    });
+    revokeInvitationMock.mockRejectedValueOnce(new Error("workos unavailable"));
+
+    const ownerIdentity = createWorkosIdentity();
+    const existingUserIdentity = createWorkosIdentity();
+    await syncWorkosIdentity(db, existingUserIdentity);
+
+    const headers = await authHeadersFor(ownerIdentity);
+    await inviteMemberViaApi(
+      ownerIdentity,
+      { email: existingUserIdentity.user.email, role: "member" },
+      headers,
+    );
+
+    const updateResponse = await updateMemberRoleViaApi(
+      ownerIdentity,
+      existingUserIdentity.user.workosUserId,
+      "admin",
+      headers,
+    );
+    expect(updateResponse.status).toBe(500);
+
+    const listBody = (await (
+      await listMembersViaApi(ownerIdentity, headers)
+    ).json()) as MembersResponse;
+    expect(
+      listBody.members.find((row) => row.email === existingUserIdentity.user.email)?.role,
+    ).toBe("member");
+  });
+
   it("shows existing users as invited until WorkOS confirms membership", async () => {
     const ownerIdentity = createWorkosIdentity();
     const existingUserIdentity = createWorkosIdentity();

--- a/apps/hyperlocalise-web/src/api/routes/member/member.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/member/member.test.ts
@@ -456,6 +456,30 @@ describe("memberRoutes", () => {
     expect(response.status).toBe(403);
   });
 
+  it("replaces a stale WorkOS invitation when inviting with no local pending membership", async () => {
+    listInvitationsMock.mockResolvedValue({
+      data: [{ id: "stale_invitation", state: "pending" }],
+    });
+
+    const ownerIdentity = createWorkosIdentity();
+    const headers = await authHeadersFor(ownerIdentity);
+
+    const response = await inviteMemberViaApi(
+      ownerIdentity,
+      { email: "stale-workos@example.com", role: "admin" },
+      headers,
+    );
+    expect(response.status).toBe(201);
+    expect(revokeInvitationMock).toHaveBeenCalledWith("stale_invitation");
+    expect(sendInvitationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: "stale-workos@example.com",
+        roleSlug: "admin",
+      }),
+    );
+    expect(resendInvitationMock).not.toHaveBeenCalled();
+  });
+
   it("resends a pending invitation instead of creating a duplicate membership", async () => {
     listInvitationsMock
       .mockResolvedValueOnce({ data: [] })
@@ -602,9 +626,9 @@ describe("memberRoutes", () => {
   });
 
   it("rolls back PATCH role changes for pending members when invitation sync fails", async () => {
-    listInvitationsMock.mockResolvedValue({
-      data: [{ id: "invitation_mock", state: "pending" }],
-    });
+    listInvitationsMock
+      .mockResolvedValueOnce({ data: [] })
+      .mockResolvedValueOnce({ data: [{ id: "invitation_mock", state: "pending" }] });
     revokeInvitationMock.mockRejectedValueOnce(new Error("workos unavailable"));
 
     const ownerIdentity = createWorkosIdentity();

--- a/apps/hyperlocalise-web/src/api/routes/workos-webhook/workos-webhook.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/workos-webhook/workos-webhook.route.test.ts
@@ -6,7 +6,11 @@ import { testClient } from "hono/testing";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { app } from "@/api/app";
-import { promoteInvitedPlaceholderUser, syncWorkosUser } from "@/api/auth/workos-sync";
+import {
+  promoteInvitedPlaceholderUser,
+  removePendingOrganizationMembershipForInvite,
+  syncWorkosUser,
+} from "@/api/auth/workos-sync";
 import { env } from "@/lib/env";
 
 const secret = env.WORKOS_WEBHOOK_SECRET ?? "test-workos-webhook-secret";
@@ -24,6 +28,7 @@ vi.mock("@/api/auth/workos-sync", () => ({
   syncWorkosOrganization: vi.fn().mockResolvedValue(undefined),
   syncWorkosIdentity: vi.fn().mockResolvedValue(undefined),
   removeWorkosMembership: vi.fn().mockResolvedValue(undefined),
+  removePendingOrganizationMembershipForInvite: vi.fn().mockResolvedValue(1),
 }));
 
 vi.mock("@/lib/database", async (importOriginal) => {
@@ -98,5 +103,34 @@ describe("workosWebhookRoutes", () => {
       workosUserId: "user_123",
     });
     expect(syncWorkosUser).toHaveBeenCalled();
+  });
+
+  it("removes pending local membership when an invitation is revoked", async () => {
+    const client = testClient(app);
+
+    const payload = JSON.stringify({
+      event: "invitation.revoked",
+      data: {
+        organization_id: "org_123",
+        email: "revoked@example.com",
+      },
+    });
+
+    const response = await client.api.webhooks.workos.$post(
+      {
+        json: JSON.parse(payload) as unknown as never,
+      },
+      {
+        headers: {
+          "workos-signature": sign(payload),
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(removePendingOrganizationMembershipForInvite).toHaveBeenCalledWith(expect.anything(), {
+      workosOrganizationId: "org_123",
+      email: "revoked@example.com",
+    });
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/workos-webhook/workos-webhook.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/workos-webhook/workos-webhook.route.ts
@@ -6,6 +6,7 @@ import { bodyLimit } from "hono/body-limit";
 
 import {
   promoteInvitedPlaceholderUser,
+  removePendingOrganizationMembershipForInvite,
   removeWorkosMembership,
   syncWorkosIdentity,
   syncWorkosOrganization,
@@ -101,6 +102,22 @@ function toMembershipRole(data: Record<string, unknown>): OrganizationMembership
 async function handleWorkosEvent(event: WorkosWebhookEvent): Promise<void> {
   const { db } = await import("@/lib/database");
   const data = event.data;
+
+  if (event.event === "invitation.revoked") {
+    const workosOrganizationId = readString(data, "organization_id");
+    const email = readString(data, "email");
+
+    if (!workosOrganizationId || !email) {
+      return;
+    }
+
+    await removePendingOrganizationMembershipForInvite(db, {
+      workosOrganizationId,
+      email,
+    });
+
+    return;
+  }
 
   if (event.event === "user.created" || event.event === "user.updated") {
     const workosUserId = readString(data, "id", "user_id");
@@ -213,6 +230,10 @@ async function handleWorkosEvent(event: WorkosWebhookEvent): Promise<void> {
     }
 
     if (!existingUser) {
+      return;
+    }
+
+    if (!workosMembershipId) {
       return;
     }
 

--- a/apps/hyperlocalise-web/src/lib/workos/constants.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/constants.ts
@@ -1,5 +1,15 @@
 export const INVITED_WORKOS_USER_ID_PREFIX = "invited_user_";
 
+/** WorkOS has confirmed organization membership (invite accepted). */
+export function isActiveOrganizationMembership(workosMembershipId: string | null | undefined) {
+  return workosMembershipId != null && workosMembershipId.length > 0;
+}
+
+/** Local membership row exists but WorkOS has not confirmed acceptance yet. */
+export function isPendingOrganizationMembership(workosMembershipId: string | null | undefined) {
+  return !isActiveOrganizationMembership(workosMembershipId);
+}
+
 export function isInvitedPlaceholderWorkosUserId(workosUserId: string) {
   return workosUserId.startsWith(INVITED_WORKOS_USER_ID_PREFIX);
 }

--- a/apps/hyperlocalise-web/src/lib/workos/constants.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/constants.ts
@@ -1,8 +1,19 @@
 export const INVITED_WORKOS_USER_ID_PREFIX = "invited_user_";
 
+/** Local-only marker while an in-flight invite replace revokes the prior WorkOS invitation. */
+export const REPLACING_WORKOS_MEMBERSHIP_ID = "replacing";
+
+export function isReplacingWorkosMembership(workosMembershipId: string | null | undefined) {
+  return workosMembershipId === REPLACING_WORKOS_MEMBERSHIP_ID;
+}
+
 /** WorkOS has confirmed organization membership (invite accepted). */
 export function isActiveOrganizationMembership(workosMembershipId: string | null | undefined) {
-  return workosMembershipId != null && workosMembershipId.length > 0;
+  return (
+    workosMembershipId != null &&
+    workosMembershipId.length > 0 &&
+    !isReplacingWorkosMembership(workosMembershipId)
+  );
 }
 
 /** Local membership row exists but WorkOS has not confirmed acceptance yet. */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

WorkOS invitation acceptance is now the source of truth for usable organization access. Membership rows with a null `workosMembershipId` are treated as pending invites: they appear in the members list as `invited`, but are excluded from API and app auth until WorkOS confirms membership.

- Auth (`workos-session`) only considers memberships with a non-null `workosMembershipId`.
- Member status UI uses `workosMembershipId`, not placeholder user IDs, so existing users show as invited until acceptance.
- Re-inviting a pending member resends the WorkOS invitation (200) instead of returning 409.
- Cancelling a pending member revokes the WorkOS invitation for both placeholder and existing users.
- `invitation.revoked` webhooks remove pending local membership rows.
- `organization_membership.created` webhooks require a WorkOS membership id before activating access.

Fixes HL-423.

## How to test

```bash
cd apps/hyperlocalise-web
vp check --fix
vp test
```

Manual checks:
1. Invite an existing user to a workspace — they should see `invited` in members but cannot access org routes/APIs until accepting.
2. Re-invite the same pending email — should succeed with 200 and resend, not 409.
3. Cancel a pending invite — local membership removed and WorkOS invitation revoked.
4. Accept invite in WorkOS — `organization_membership.created` webhook sets `workosMembershipId` and grants access.

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, `vp test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-423](https://linear.app/hyperlocalise/issue/HL-423/fix-workos-invite-acceptance-and-membership-activation-semantics)

<div><a href="https://cursor.com/agents/bc-0371f53f-5006-4bbb-a749-2e166122dbb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0371f53f-5006-4bbb-a749-2e166122dbb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

