### PR TITLE
refactor(web): use Result for billing errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,3 +75,64 @@ Install `vp` via `curl -fsSL https://vite.plus | bash`, then run `vp env setup` 
 
 - Standard commands per `AGENTS.md`: `make bootstrap`, `make fmt`, `make lint`, `make test`.
 - Run the CLI with `go run ./apps/cli <command>`.
+
+### TypeScript Error Handling with Result
+
+For predictable error handling in the web app, prefer the Go-like `Result<T, E>` pattern for expected failures in shared business logic and provider integrations.
+
+```typescript
+import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
+
+type ProviderCredentialError =
+    | { code: "unsupported_provider_model" }
+    | { code: "provider_validation_failed"; message: string };
+
+async function validateCredential(input: CredentialInput): Promise<Result<void, ProviderCredentialError>> {
+    if (!isSupportedModel(input.provider, input.model)) {
+        return err({ code: "unsupported_provider_model" });
+    }
+
+    const response = await validateWithProvider(input);
+    if (!response.ok) {
+        return err({ code: "provider_validation_failed", message: response.message });
+    }
+
+    return ok(undefined);
+}
+
+const result = await validateCredential(input);
+if (isErr(result)) {
+    return mapCredentialErrorToResponse(result.error);
+}
+```
+
+Use `Result` when the failure is expected and part of normal control flow:
+
+- Provider credential validation, provider API calls, billing/usage tracking, URL/SSRF validation, encryption/decryption checks, and other integration boundaries.
+- Domain rules that callers should branch on, such as unsupported models, missing provider credentials, rate limits, invalid external IDs, or unsafe URLs.
+- Shared library functions with multiple callers. Let routes, server actions, workers, or UI handlers decide how to present the error.
+- Parsing helpers. Use `safeJsonParse`, Zod `safeParse`, or `fromThrowable` wrappers instead of open-coded `try`/`catch` for recoverable parsing failures.
+
+Model errors as small discriminated unions with stable `code` values. Avoid string-matching `error.message` for known errors.
+
+Keep `throw`/`try`/`catch` where exceptions are the right contract:
+
+- Framework boundaries and control flow, such as Next.js `redirect()` and Hono/Next request handlers that catch unknown errors.
+- Drizzle transaction rollback paths, unless the transaction is explicitly aborted another way.
+- Best-effort cleanup and logging, where the original failure must still propagate.
+- Truly unexpected programmer errors or invariant violations.
+- Third-party APIs that throw before they reach a local adapter. Wrap them once at the adapter boundary and return `Result` from our code.
+
+At HTTP and server-action boundaries, convert `Result` errors into the existing response conventions. For Hono JSON routes, return the standard `{ error, message, details }` envelope from `apps/hyperlocalise-web/src/api/response.schema.ts`. For server actions, return action state with field or form errors. Re-throw unknown failures so global error handling still catches bugs.
+
+## Code Style & Conventions
+
+Use 4 spaces indentation
+
+### Naming Conventions
+
+- **Classes**: PascalCase
+- **Variables/Functions/Methods**: camelCase
+- **Files/Directories**: kebab-case
+- **Environment Variables**: UPPERCASE
+- **Constants**: UPPERCASE (avoid magic numbers)

--- a/apps/hyperlocalise-web/src/api/routes/autumn/autumn.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/autumn/autumn.route.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { createMiddleware } from "hono/factory";
+import type { ResolvedIdentity } from "autumn-js/backend";
 import { autumnHandler } from "autumn-js/hono";
 
 import { forbiddenResponse } from "@/api/errors";
@@ -15,6 +16,7 @@ import {
   AUTUMN_BILLING_WRITE_ROUTE_NAMES,
   getAutumnRouteNameFromPath,
 } from "@/lib/billing/autumn-route-access";
+import { isErr } from "@/lib/primitives/result/results";
 
 const requireBillingReadMiddleware = createMiddleware<{ Variables: AuthVariables }>(
   async (c, next) => {
@@ -34,7 +36,7 @@ const requireBillingReadMiddleware = createMiddleware<{ Variables: AuthVariables
 const requireBillingWriteForRouteMiddleware = createMiddleware<{ Variables: AuthVariables }>(
   async (c, next) => {
     const routeName = getAutumnRouteNameFromPath(new URL(c.req.url).pathname);
-    if (routeName && AUTUMN_BILLING_WRITE_ROUTE_NAMES.has(routeName)) {
+    if (!isErr(routeName) && AUTUMN_BILLING_WRITE_ROUTE_NAMES.has(routeName.value)) {
       const auth = c.get("auth");
       if (!hasCapability(auth.membership.role, "billing:write")) {
         return forbiddenResponse(
@@ -50,21 +52,21 @@ const requireBillingWriteForRouteMiddleware = createMiddleware<{ Variables: Auth
 );
 
 type AutumnVariables = AuthVariables & {
-  autumnCustomerIdentity: NonNullable<ReturnType<typeof resolveAutumnCustomerIdentity>>;
+  autumnCustomerIdentity: ResolvedIdentity;
 };
 
 const requireBillableWorkspaceMiddleware = createMiddleware<{ Variables: AutumnVariables }>(
   async (c, next) => {
     const identity = resolveAutumnCustomerIdentity(c.get("auth"));
-    if (!identity?.customerId) {
+    if (isErr(identity)) {
       return forbiddenResponse(
         c,
-        "billing_customer_unavailable",
+        identity.error.code,
         "Billing is not available for this workspace",
       );
     }
 
-    c.set("autumnCustomerIdentity", identity);
+    c.set("autumnCustomerIdentity", identity.value);
     await next();
   },
 );

--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
@@ -20,7 +20,12 @@ import {
   getStoredFileForJobScope,
 } from "@/lib/file-storage/records";
 import { inferSupportedFileTranslationFileFormat } from "@/lib/translation/file-formats";
-import { reserveUsageEvent, usageFeatureIds } from "@/lib/billing/usage-control";
+import {
+  formatUsageControlError,
+  reserveUsageEvent,
+  usageFeatureIds,
+} from "@/lib/billing/usage-control";
+import { isErr } from "@/lib/primitives/result/results";
 import type {
   JobQueue,
   ProviderAgentCommentQueue,
@@ -463,7 +468,7 @@ export function createJobRoutes(options: CreateJobRoutesOptions) {
           })
           .returning();
 
-        await reserveUsageEvent({
+        const usageEventResult = await reserveUsageEvent({
           db: tx,
           organizationId: c.var.auth.organization.localOrganizationId,
           featureId: usageFeatureIds.translationJobs,
@@ -472,6 +477,9 @@ export function createJobRoutes(options: CreateJobRoutesOptions) {
           jobId,
           quantity: 1,
         });
+        if (isErr(usageEventResult)) {
+          throw new Error(formatUsageControlError(usageEventResult.error));
+        }
 
         return [{ ...createdJob, type: details.type }];
       });

--- a/apps/hyperlocalise-web/src/api/routes/project/job.workflow.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.workflow.test.ts
@@ -6,7 +6,12 @@ import { and, eq } from "drizzle-orm";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
 
 import { db, schema } from "@/lib/database";
-import { reserveUsageEvent, usageFeatureIds } from "@/lib/billing/usage-control";
+import {
+  formatUsageControlError,
+  reserveUsageEvent,
+  usageFeatureIds,
+} from "@/lib/billing/usage-control";
+import { isErr } from "@/lib/primitives/result/results";
 import { encryptProviderCredential } from "@/lib/security/provider-credential-crypto";
 import {
   claimTranslationJob,
@@ -85,7 +90,7 @@ async function insertJob(input: {
       })
       .returning();
 
-    await reserveUsageEvent({
+    const usageEventResult = await reserveUsageEvent({
       db: tx,
       organizationId: input.organizationId,
       featureId: usageFeatureIds.translationJobs,
@@ -94,6 +99,9 @@ async function insertJob(input: {
       jobId: job.id,
       quantity: 1,
     });
+    if (isErr(usageEventResult)) {
+      throw new Error(formatUsageControlError(usageEventResult.error));
+    }
 
     return { ...job, type: details.type };
   });

--- a/apps/hyperlocalise-web/src/api/routes/public-jobs/public-jobs.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/public-jobs/public-jobs.route.ts
@@ -11,12 +11,17 @@ import {
   type ApiKeyAuthVariables,
 } from "@/api/auth/api-key";
 import { db, schema } from "@/lib/database";
-import { reserveUsageEvent, usageFeatureIds } from "@/lib/billing/usage-control";
+import {
+  formatUsageControlError,
+  reserveUsageEvent,
+  usageFeatureIds,
+} from "@/lib/billing/usage-control";
 import {
   ensureRepositorySourceFileVersionForStoredFile,
   getStoredFileForJobScope,
   normalizeSourcePath,
 } from "@/lib/file-storage/records";
+import { isErr } from "@/lib/primitives/result/results";
 import { inferSupportedFileTranslationFileFormat } from "@/lib/translation/file-formats";
 import type { JobQueue, TranslationJobEventData } from "@/lib/workflow/types";
 
@@ -197,7 +202,7 @@ export function createPublicJobRoutes(options: CreatePublicJobRoutesOptions = {}
             })
             .returning();
 
-          await reserveUsageEvent({
+          const usageEventResult = await reserveUsageEvent({
             db: tx,
             organizationId,
             featureId: usageFeatureIds.translationJobs,
@@ -206,6 +211,9 @@ export function createPublicJobRoutes(options: CreatePublicJobRoutesOptions = {}
             jobId,
             quantity: 1,
           });
+          if (isErr(usageEventResult)) {
+            throw new Error(formatUsageControlError(usageEventResult.error));
+          }
 
           return [{ ...createdJob, type: details.type }];
         });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/translation-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/translation-tools.ts
@@ -19,7 +19,12 @@ import {
   supportedFileTranslationFileFormats,
 } from "@/lib/translation/file-formats";
 import { createTranslationJobEventQueue } from "@/workflows/adapters";
-import { reserveUsageEvent, usageFeatureIds } from "@/lib/billing/usage-control";
+import {
+  formatUsageControlError,
+  reserveUsageEvent,
+  usageFeatureIds,
+} from "@/lib/billing/usage-control";
+import { isErr } from "@/lib/primitives/result/results";
 
 import { toolAccessibleJobsWhere, toolCanAccessProject } from "@/lib/tools/tool-access";
 import type { ToolContext } from "@/lib/tools/types";
@@ -192,7 +197,7 @@ async function createQueuedJob(ctx: ToolContext, input: Parameters<typeof queued
 
     const billing = queuedJobUsageBilling(input.kind);
 
-    await reserveUsageEvent({
+    const usageEventResult = await reserveUsageEvent({
       db: tx,
       organizationId: ctx.organizationId,
       featureId: billing.featureId,
@@ -202,6 +207,9 @@ async function createQueuedJob(ctx: ToolContext, input: Parameters<typeof queued
       interactionId: ctx.conversationId ?? undefined,
       quantity: 1,
     });
+    if (isErr(usageEventResult)) {
+      throw new Error(formatUsageControlError(usageEventResult.error));
+    }
 
     return job;
   });
@@ -375,7 +383,7 @@ export function createTranslationJobTool(ctx: ToolContext) {
           sourceFileVersionId: sourceFileVersion?.id ?? null,
         });
 
-        await reserveUsageEvent({
+        const usageEventResult = await reserveUsageEvent({
           db: tx,
           organizationId: ctx.organizationId,
           featureId: usageFeatureIds.translationJobs,
@@ -385,6 +393,9 @@ export function createTranslationJobTool(ctx: ToolContext) {
           interactionId: ctx.conversationId ?? undefined,
           quantity: 1,
         });
+        if (isErr(usageEventResult)) {
+          throw new Error(formatUsageControlError(usageEventResult.error));
+        }
 
         return createdJob;
       });

--- a/apps/hyperlocalise-web/src/lib/billing/autumn-customer.test.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/autumn-customer.test.ts
@@ -6,6 +6,7 @@ import {
   LOCAL_ORG_WORKOS_ID_PREFIX,
   resolveAutumnCustomerIdentity,
 } from "@/lib/billing/autumn-customer";
+import { isErr } from "@/lib/primitives/result/results";
 
 function createAuthContext(
   overrides: Partial<ApiAuthContext["organization"]> = {},
@@ -51,8 +52,14 @@ function createAuthContext(
 describe("autumn customer identity", () => {
   it("maps organizations to stable Autumn customer IDs", () => {
     const auth = createAuthContext();
+    const identity = resolveAutumnCustomerIdentity(auth);
 
-    expect(resolveAutumnCustomerIdentity(auth)).toEqual({
+    expect(isErr(identity)).toBe(false);
+    if (isErr(identity)) {
+      throw new Error("Expected Autumn customer identity to resolve");
+    }
+
+    expect(identity.value).toEqual({
       customerId: "00000000-0000-4000-8000-000000000010",
       customerData: {
         name: "Example Workspace",
@@ -67,6 +74,9 @@ describe("autumn customer identity", () => {
     });
 
     expect(isDeprecatedLocalOrgWorkosId(auth.organization.workosOrganizationId)).toBe(true);
-    expect(resolveAutumnCustomerIdentity(auth)).toBeNull();
+    expect(resolveAutumnCustomerIdentity(auth)).toMatchObject({
+      ok: false,
+      error: { code: "billing_customer_unavailable" },
+    });
   });
 });

--- a/apps/hyperlocalise-web/src/lib/billing/autumn-customer.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/autumn-customer.ts
@@ -1,6 +1,7 @@
 import type { ResolvedIdentity } from "autumn-js/backend";
 
 import type { ApiAuthContext } from "@/api/auth/workos";
+import { err, ok, type Result } from "@/lib/primitives/result/results";
 
 /** Synthetic WorkOS organization IDs for deprecated local-only workspaces. */
 export const LOCAL_ORG_WORKOS_ID_PREFIX = "local_org_";
@@ -18,16 +19,22 @@ export function isDeprecatedLocalOrgWorkosId(workosOrganizationId: string) {
   return workosOrganizationId.startsWith(LOCAL_ORG_WORKOS_ID_PREFIX);
 }
 
-export function resolveAutumnCustomerIdentity(auth: ApiAuthContext): ResolvedIdentity | null {
+export type ResolveAutumnCustomerIdentityError = {
+  code: "billing_customer_unavailable";
+};
+
+export function resolveAutumnCustomerIdentity(
+  auth: ApiAuthContext,
+): Result<ResolvedIdentity, ResolveAutumnCustomerIdentityError> {
   if (isDeprecatedLocalOrgWorkosId(auth.organization.workosOrganizationId)) {
-    return null;
+    return err({ code: "billing_customer_unavailable" });
   }
 
-  return {
+  return ok({
     customerId: auth.organization.localOrganizationId,
     customerData: {
       name: auth.organization.name,
       email: auth.user.email,
     },
-  };
+  });
 }

--- a/apps/hyperlocalise-web/src/lib/billing/autumn-errors.test.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/autumn-errors.test.ts
@@ -22,5 +22,11 @@ describe("formatAutumnBillingError", () => {
         message: "should not leak",
       }),
     ).toBe("Billing is not available for this workspace.");
+
+    expect(
+      formatAutumnBillingError({
+        code: "billing_customer_unavailable",
+      }),
+    ).toBe("Billing is not available for this workspace.");
   });
 });

--- a/apps/hyperlocalise-web/src/lib/billing/autumn-errors.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/autumn-errors.ts
@@ -17,9 +17,9 @@ export function formatAutumnBillingError(error: unknown): string {
     }
   }
 
-  if (error && typeof error === "object" && "error" in error) {
-    const apiError = error as { error?: string; message?: string };
-    switch (apiError.error) {
+  if (error && typeof error === "object" && ("error" in error || "code" in error)) {
+    const apiError = error as { error?: string; code?: string; message?: string };
+    switch (apiError.error ?? apiError.code) {
       case "billing_read_forbidden":
         return "You do not have permission to view billing for this workspace.";
       case "billing_write_forbidden":

--- a/apps/hyperlocalise-web/src/lib/billing/autumn-route-access.test.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/autumn-route-access.test.ts
@@ -4,16 +4,24 @@ import {
   AUTUMN_BILLING_WRITE_ROUTE_NAMES,
   getAutumnRouteNameFromPath,
 } from "@/lib/billing/autumn-route-access";
+import { isErr } from "@/lib/primitives/result/results";
 
 describe("autumn route access", () => {
   it("parses Autumn route names from API paths", () => {
-    expect(getAutumnRouteNameFromPath("/api/autumn/getOrCreateCustomer")).toBe(
-      "getOrCreateCustomer",
-    );
-    expect(getAutumnRouteNameFromPath("/api/autumn/openCustomerPortal/extra")).toBe(
-      "openCustomerPortal",
-    );
-    expect(getAutumnRouteNameFromPath("/api/other")).toBeNull();
+    const readRoute = getAutumnRouteNameFromPath("/api/autumn/getOrCreateCustomer");
+    const writeRoute = getAutumnRouteNameFromPath("/api/autumn/openCustomerPortal/extra");
+    const outsideRoute = getAutumnRouteNameFromPath("/api/other");
+
+    if (isErr(readRoute) || isErr(writeRoute)) {
+      throw new Error("Expected Autumn route names to parse");
+    }
+
+    expect(readRoute.value).toBe("getOrCreateCustomer");
+    expect(writeRoute.value).toBe("openCustomerPortal");
+    expect(outsideRoute).toMatchObject({
+      ok: false,
+      error: { code: "autumn_route_outside_prefix" },
+    });
   });
 
   it("tracks billing write routes", () => {

--- a/apps/hyperlocalise-web/src/lib/billing/autumn-route-access.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/autumn-route-access.ts
@@ -1,3 +1,5 @@
+import { err, ok, type Result } from "@/lib/primitives/result/results";
+
 /** Autumn handler route names that mutate billing state (admin-only). */
 export const AUTUMN_BILLING_WRITE_ROUTE_NAMES = new Set([
   "attach",
@@ -7,18 +9,30 @@ export const AUTUMN_BILLING_WRITE_ROUTE_NAMES = new Set([
   "openCustomerPortal",
 ]);
 
+export type AutumnRouteNameError =
+  | {
+      code: "autumn_route_outside_prefix";
+      pathname: string;
+      pathPrefix: string;
+    }
+  | {
+      code: "autumn_route_name_missing";
+      pathname: string;
+      pathPrefix: string;
+    };
+
 export function getAutumnRouteNameFromPath(
   pathname: string,
   pathPrefix = "/api/autumn",
-): string | null {
+): Result<string, AutumnRouteNameError> {
   if (!pathname.startsWith(pathPrefix)) {
-    return null;
+    return err({ code: "autumn_route_outside_prefix", pathname, pathPrefix });
   }
 
   const suffix = pathname.slice(pathPrefix.length).replace(/^\/+/, "");
   if (!suffix) {
-    return null;
+    return err({ code: "autumn_route_name_missing", pathname, pathPrefix });
   }
 
-  return suffix.split("/")[0] ?? null;
+  return ok(suffix.split("/")[0] ?? suffix);
 }

--- a/apps/hyperlocalise-web/src/lib/billing/usage-control.test.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/usage-control.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
 
 import { createAuthTestFixture } from "@/api/test-auth.fixture";
 import { db, schema } from "@/lib/database";
+import { isErr } from "@/lib/primitives/result/results";
 import {
   markUsageEventSucceededByOperationKey,
   reserveUsageEvent,
@@ -32,15 +33,18 @@ async function createOrganization() {
 
 async function reservedUsageEvent(operationKey = `usage_${randomUUID()}`) {
   const organization = await createOrganization();
-  const event = await reserveUsageEvent({
+  const eventResult = await reserveUsageEvent({
     organizationId: organization.id,
     featureId: usageFeatureIds.translationJobs,
     operationKey,
     source: "translation_job_create",
     quantity: 1,
   });
+  if (isErr(eventResult)) {
+    throw new Error(eventResult.error.code);
+  }
 
-  return { event, operationKey, organization };
+  return { event: eventResult.value, operationKey, organization };
 }
 
 async function getUsageEvent(operationKey: string) {
@@ -78,28 +82,44 @@ describe("usage-control", () => {
       .from(schema.usageEvents)
       .where(eq(schema.usageEvents.operationKey, operationKey));
 
-    expect(second.id).toBe(first.id);
+    if (isErr(first) || isErr(second)) {
+      throw new Error("Expected usage event reservations to succeed");
+    }
+
+    expect(second.value.id).toBe(first.value.id);
     expect(rows).toHaveLength(1);
   });
 
-  it("throws when marking a missing usage event succeeded", async () => {
-    await expect(
-      markUsageEventSucceededByOperationKey({ operationKey: `missing_${randomUUID()}` }),
-    ).rejects.toThrow("usage event not found");
+  it("returns an error when marking a missing usage event succeeded", async () => {
+    const operationKey = `missing_${randomUUID()}`;
+    const result = await markUsageEventSucceededByOperationKey({ operationKey });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "usage_event_not_found",
+        operationKey,
+      },
+    });
   });
 
   it("posts succeeded usage events to Autumn before marking tracking succeeded", async () => {
     const { operationKey, organization } = await reservedUsageEvent();
-    await markUsageEventSucceededByOperationKey({ operationKey });
+    const markResult = await markUsageEventSucceededByOperationKey({ operationKey });
+    expect(isErr(markResult)).toBe(false);
 
     const fetchFn = vi.fn(
       async () => new Response("{}", { status: 200 }),
     ) as unknown as typeof fetch;
 
-    await trackUsageEventInAutumnByOperationKey({
+    const trackResult = await trackUsageEventInAutumnByOperationKey({
       operationKey,
       autumnApiKey: "am_sk_test",
       fetchFn,
+    });
+    expect(trackResult).toMatchObject({
+      ok: true,
+      value: { status: "tracking_succeeded" },
     });
 
     expect(fetchFn).toHaveBeenCalledOnce();
@@ -137,19 +157,28 @@ describe("usage-control", () => {
 
   it("marks tracking failed when Autumn rejects the usage event", async () => {
     const { operationKey } = await reservedUsageEvent();
-    await markUsageEventSucceededByOperationKey({ operationKey });
+    const markResult = await markUsageEventSucceededByOperationKey({ operationKey });
+    expect(isErr(markResult)).toBe(false);
 
     const fetchFn = vi.fn(
       async () => new Response("bad", { status: 500 }),
     ) as unknown as typeof fetch;
 
-    await expect(
-      trackUsageEventInAutumnByOperationKey({
+    const trackResult = await trackUsageEventInAutumnByOperationKey({
+      operationKey,
+      autumnApiKey: "am_sk_test",
+      fetchFn,
+    });
+
+    expect(trackResult).toMatchObject({
+      ok: false,
+      error: {
+        code: "autumn_usage_tracking_failed",
         operationKey,
-        autumnApiKey: "am_sk_test",
-        fetchFn,
-      }),
-    ).rejects.toThrow("Autumn usage tracking failed with HTTP 500");
+        message: "Autumn usage tracking failed with HTTP 500",
+        httpStatus: 500,
+      },
+    });
 
     await expect(getUsageEvent(operationKey)).resolves.toMatchObject({
       status: "tracking_failed",
@@ -163,13 +192,20 @@ describe("usage-control", () => {
       async () => new Response("{}", { status: 200 }),
     ) as unknown as typeof fetch;
 
-    await expect(
-      trackUsageEventInAutumnByOperationKey({
+    const trackResult = await trackUsageEventInAutumnByOperationKey({
+      operationKey,
+      autumnApiKey: "am_sk_test",
+      fetchFn,
+    });
+
+    expect(trackResult).toMatchObject({
+      ok: false,
+      error: {
+        code: "usage_event_not_trackable",
         operationKey,
-        autumnApiKey: "am_sk_test",
-        fetchFn,
-      }),
-    ).rejects.toThrow("must be succeeded before tracking");
+        status: "reserved",
+      },
+    });
 
     expect(fetchFn).not.toHaveBeenCalled();
   });

--- a/apps/hyperlocalise-web/src/lib/billing/usage-control.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/usage-control.ts
@@ -50,7 +50,7 @@ export type UsageControlError =
   | MarkUsageEventSucceededError
   | TrackUsageEventError;
 
-export function formatUsageControlError(error: UsageControlError) {
+export function formatUsageControlError(error: UsageControlError): string {
   switch (error.code) {
     case "usage_event_not_found":
       return `usage event not found for operation key ${error.operationKey}`;

--- a/apps/hyperlocalise-web/src/lib/billing/usage-control.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/usage-control.ts
@@ -1,15 +1,67 @@
 import { eq } from "drizzle-orm";
 
-import { env } from "@/lib/env";
+import { usageFeatureIds, type UsageFeatureId } from "@/lib/billing/autumn-ids";
 import type { DatabaseClient } from "@/lib/database";
 import { db, schema } from "@/lib/database";
+import { env } from "@/lib/env";
+import { err, ok, type Result } from "@/lib/primitives/result/results";
 
 const AUTUMN_API_VERSION = "2.2.0";
 const AUTUMN_TRACK_USAGE_URL = "https://api.useautumn.com/v1/balances.track";
 
-import { usageFeatureIds, type UsageFeatureId } from "@/lib/billing/autumn-ids";
-
 export { usageFeatureIds, type UsageFeatureId };
+
+export type UsageEventReference = {
+  id: string;
+};
+
+export type UsageEventNotFoundError = {
+  code: "usage_event_not_found";
+  operationKey: string;
+};
+
+export type ReserveUsageEventError = {
+  code: "usage_event_reservation_failed";
+  operationKey: string;
+};
+
+export type MarkUsageEventSucceededError = UsageEventNotFoundError;
+
+export type TrackUsageEventError =
+  | UsageEventNotFoundError
+  | {
+      code: "usage_event_not_trackable";
+      operationKey: string;
+      status: (typeof schema.usageEvents.$inferSelect)["status"];
+    }
+  | {
+      code: "autumn_usage_tracking_failed";
+      operationKey: string;
+      message: string;
+      httpStatus?: number;
+    };
+
+export type TrackUsageEventResult = {
+  status: "already_tracked" | "tracking_pending" | "tracking_succeeded";
+};
+
+export type UsageControlError =
+  | ReserveUsageEventError
+  | MarkUsageEventSucceededError
+  | TrackUsageEventError;
+
+export function formatUsageControlError(error: UsageControlError) {
+  switch (error.code) {
+    case "usage_event_not_found":
+      return `usage event not found for operation key ${error.operationKey}`;
+    case "usage_event_reservation_failed":
+      return `failed to reserve usage event for operation key ${error.operationKey}`;
+    case "usage_event_not_trackable":
+      return `usage event ${error.operationKey} must be succeeded before tracking, got ${error.status}`;
+    case "autumn_usage_tracking_failed":
+      return error.message;
+  }
+}
 
 export async function reserveUsageEvent(input: {
   db?: DatabaseClient;
@@ -20,7 +72,7 @@ export async function reserveUsageEvent(input: {
   quantity?: number;
   jobId?: string;
   interactionId?: string;
-}) {
+}): Promise<Result<UsageEventReference, ReserveUsageEventError>> {
   const database = input.db ?? db;
   const [event] = await database
     .insert(schema.usageEvents)
@@ -36,7 +88,7 @@ export async function reserveUsageEvent(input: {
     .onConflictDoNothing({ target: schema.usageEvents.operationKey })
     .returning({ id: schema.usageEvents.id });
 
-  if (event) return event;
+  if (event) return ok(event);
 
   const [existing] = await database
     .select({ id: schema.usageEvents.id })
@@ -44,14 +96,14 @@ export async function reserveUsageEvent(input: {
     .where(eq(schema.usageEvents.operationKey, input.operationKey))
     .limit(1);
 
-  if (existing) return existing;
-  throw new Error("failed to reserve usage event");
+  if (existing) return ok(existing);
+  return err({ code: "usage_event_reservation_failed", operationKey: input.operationKey });
 }
 
 export async function markUsageEventSucceededByOperationKey(input: {
   db?: DatabaseClient;
   operationKey: string;
-}) {
+}): Promise<Result<void, MarkUsageEventSucceededError>> {
   const database = input.db ?? db;
   const [event] = await database
     .update(schema.usageEvents)
@@ -60,8 +112,10 @@ export async function markUsageEventSucceededByOperationKey(input: {
     .returning({ id: schema.usageEvents.id });
 
   if (!event) {
-    throw new Error(`usage event not found for operation key ${input.operationKey}`);
+    return err({ code: "usage_event_not_found", operationKey: input.operationKey });
   }
+
+  return ok(undefined);
 }
 
 function canTrackUsageEventStatus(status: (typeof schema.usageEvents.$inferSelect)["status"]) {
@@ -77,30 +131,45 @@ async function trackUsageEventInAutumn(input: {
   event: typeof schema.usageEvents.$inferSelect;
   apiKey: string;
   fetchFn: typeof fetch;
-}) {
-  const response = await input.fetchFn(AUTUMN_TRACK_USAGE_URL, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${input.apiKey}`,
-      "Content-Type": "application/json",
-      "x-api-version": AUTUMN_API_VERSION,
-    },
-    body: JSON.stringify({
-      customer_id: input.event.organizationId,
-      feature_id: input.event.featureId,
-      value: input.event.quantity,
-      idempotency_key: input.event.operationKey,
-      properties: {
-        operation_key: input.event.operationKey,
-        source: input.event.source,
-        job_id: input.event.jobId,
-        interaction_id: input.event.interactionId,
-      },
-    }),
-  });
+}): Promise<Result<void, Extract<TrackUsageEventError, { code: "autumn_usage_tracking_failed" }>>> {
+  let response: Response;
 
-  if (response.ok || response.status === 409) return;
-  throw new Error(`Autumn usage tracking failed with HTTP ${response.status}`);
+  try {
+    response = await input.fetchFn(AUTUMN_TRACK_USAGE_URL, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${input.apiKey}`,
+        "Content-Type": "application/json",
+        "x-api-version": AUTUMN_API_VERSION,
+      },
+      body: JSON.stringify({
+        customer_id: input.event.organizationId,
+        feature_id: input.event.featureId,
+        value: input.event.quantity,
+        idempotency_key: input.event.operationKey,
+        properties: {
+          operation_key: input.event.operationKey,
+          source: input.event.source,
+          job_id: input.event.jobId,
+          interaction_id: input.event.interactionId,
+        },
+      }),
+    });
+  } catch (error) {
+    return err({
+      code: "autumn_usage_tracking_failed",
+      operationKey: input.event.operationKey,
+      message: autumnTrackErrorMessage(error),
+    });
+  }
+
+  if (response.ok || response.status === 409) return ok(undefined);
+  return err({
+    code: "autumn_usage_tracking_failed",
+    operationKey: input.event.operationKey,
+    message: `Autumn usage tracking failed with HTTP ${response.status}`,
+    httpStatus: response.status,
+  });
 }
 
 export async function trackUsageEventInAutumnByOperationKey(input: {
@@ -108,7 +177,7 @@ export async function trackUsageEventInAutumnByOperationKey(input: {
   operationKey: string;
   autumnApiKey?: string;
   fetchFn?: typeof fetch;
-}) {
+}): Promise<Result<TrackUsageEventResult, TrackUsageEventError>> {
   const database = input.db ?? db;
   const [event] = await database
     .select()
@@ -117,15 +186,17 @@ export async function trackUsageEventInAutumnByOperationKey(input: {
     .limit(1);
 
   if (!event) {
-    throw new Error(`usage event not found for operation key ${input.operationKey}`);
+    return err({ code: "usage_event_not_found", operationKey: input.operationKey });
   }
 
-  if (event.status === "tracking_succeeded") return;
+  if (event.status === "tracking_succeeded") return ok({ status: "already_tracked" });
 
   if (!canTrackUsageEventStatus(event.status)) {
-    throw new Error(
-      `usage event ${input.operationKey} must be succeeded before tracking, got ${event.status}`,
-    );
+    return err({
+      code: "usage_event_not_trackable",
+      operationKey: input.operationKey,
+      status: event.status,
+    });
   }
 
   const autumnApiKey = input.autumnApiKey ?? env.AUTUMN_API_KEY;
@@ -137,9 +208,9 @@ export async function trackUsageEventInAutumnByOperationKey(input: {
       .returning({ id: schema.usageEvents.id });
 
     if (!updatedEvent) {
-      throw new Error(`usage event not found for operation key ${input.operationKey}`);
+      return err({ code: "usage_event_not_found", operationKey: input.operationKey });
     }
-    return;
+    return ok({ status: "tracking_pending" });
   }
 
   const [pendingEvent] = await database
@@ -149,26 +220,26 @@ export async function trackUsageEventInAutumnByOperationKey(input: {
     .returning({ id: schema.usageEvents.id });
 
   if (!pendingEvent) {
-    throw new Error(`usage event not found for operation key ${input.operationKey}`);
+    return err({ code: "usage_event_not_found", operationKey: input.operationKey });
   }
 
-  try {
-    await trackUsageEventInAutumn({
-      event,
-      apiKey: autumnApiKey,
-      fetchFn: input.fetchFn ?? fetch,
-    });
-  } catch (error) {
+  const trackingResult = await trackUsageEventInAutumn({
+    event,
+    apiKey: autumnApiKey,
+    fetchFn: input.fetchFn ?? fetch,
+  });
+
+  if (!trackingResult.ok) {
     const [failedEvent] = await database
       .update(schema.usageEvents)
-      .set({ status: "tracking_failed", autumnTrackError: autumnTrackErrorMessage(error) })
+      .set({ status: "tracking_failed", autumnTrackError: trackingResult.error.message })
       .where(eq(schema.usageEvents.id, event.id))
       .returning({ id: schema.usageEvents.id });
 
     if (!failedEvent) {
-      throw new Error(`usage event not found for operation key ${input.operationKey}`);
+      return err({ code: "usage_event_not_found", operationKey: input.operationKey });
     }
-    throw error;
+    return err(trackingResult.error);
   }
 
   const [trackedEvent] = await database
@@ -178,6 +249,8 @@ export async function trackUsageEventInAutumnByOperationKey(input: {
     .returning({ id: schema.usageEvents.id });
 
   if (!trackedEvent) {
-    throw new Error(`usage event not found for operation key ${input.operationKey}`);
+    return err({ code: "usage_event_not_found", operationKey: input.operationKey });
   }
+
+  return ok({ status: "tracking_succeeded" });
 }

--- a/apps/hyperlocalise-web/src/lib/tools/rbac.test.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/rbac.test.ts
@@ -9,7 +9,7 @@ vi.mock("@/lib/env", () => ({
 }));
 
 vi.mock("@/lib/billing/usage-control", () => ({
-  reserveUsageEvent: vi.fn(async () => ({ id: "usage_123" })),
+  reserveUsageEvent: vi.fn(async () => ({ ok: true, value: { id: "usage_123" } })),
   usageFeatureIds: {
     translationJobs: "translation_jobs",
     agentRuns: "agent_runs",

--- a/apps/hyperlocalise-web/src/lib/translation/translation-job-queued-function.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/translation-job-queued-function.ts
@@ -5,9 +5,11 @@ import { db, schema } from "@/lib/database";
 import type { TranslationJobEventData } from "@/lib/workflow/types";
 import { decryptProviderCredential } from "@/lib/security/provider-credential-crypto";
 import {
+  formatUsageControlError,
   markUsageEventSucceededByOperationKey,
   trackUsageEventInAutumnByOperationKey,
 } from "@/lib/billing/usage-control";
+import { isErr } from "@/lib/primitives/result/results";
 import { assembleStringTranslationContextSnapshot } from "@/lib/translation/assemble-translation-context";
 import {
   createOpenAIStringTranslationGenerator,
@@ -438,14 +440,17 @@ export async function completeTranslationJob(input: {
   }
 
   const operationKey = `job:${input.jobId}:translation_jobs`;
-  await markUsageEventSucceededByOperationKey({ operationKey });
-  try {
-    await trackUsageEventInAutumnByOperationKey({ operationKey });
-  } catch (error) {
+  const markUsageResult = await markUsageEventSucceededByOperationKey({ operationKey });
+  if (isErr(markUsageResult)) {
+    throw new Error(formatUsageControlError(markUsageResult.error));
+  }
+
+  const trackUsageResult = await trackUsageEventInAutumnByOperationKey({ operationKey });
+  if (isErr(trackUsageResult)) {
     console.error("[translation-job] Autumn usage tracking failed after job succeeded", {
       jobId: input.jobId,
       operationKey,
-      error: error instanceof Error ? error.message : "autumn_tracking_failed",
+      error: formatUsageControlError(trackUsageResult.error),
     });
   }
 


### PR DESCRIPTION
## What changed

- Refactors billing helpers to return `Result` for expected customer identity, route parsing, usage reservation, and Autumn tracking failures.
- Updates current billing call sites to branch on `isErr`, while preserving transaction rollback behavior at transactional boundaries.
- Updates billing tests and affected mocks for the new Result-returning contracts.
- Note: this branch also currently includes an existing `AGENTS.md` update commit.

## How to test

- `vp test src/lib/billing`
- `vp check --fix`
- `vp test`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)