### PR TITLE
feat(web): add WorkOS sync recovery for stuck organization access

### DIFF
--- a/apps/hyperlocalise-web/src/app/auth/access-denied/_components/sync-workos-membership-action.tsx
+++ b/apps/hyperlocalise-web/src/app/auth/access-denied/_components/sync-workos-membership-action.tsx
@@ -79,7 +79,6 @@ export function SyncWorkosMembershipAction() {
       }
 
       router.replace(redirectTo);
-      router.refresh();
     },
     onError: (mutationError) => {
       setError(

--- a/apps/hyperlocalise-web/src/app/auth/access-denied/_components/sync-workos-membership-action.tsx
+++ b/apps/hyperlocalise-web/src/app/auth/access-denied/_components/sync-workos-membership-action.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useMutation } from "@tanstack/react-query";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import { TypographyP } from "@/components/ui/typography";
+import { apiClient } from "@/lib/api-client-instance";
+
+function readUpgradeErrorMessage(body: unknown, fallback: string) {
+  if (body && typeof body === "object" && "message" in body) {
+    const message = body.message;
+    if (typeof message === "string" && message.length > 0) {
+      return message;
+    }
+  }
+
+  return fallback;
+}
+
+function readUpgradeRedirectTo(body: unknown) {
+  if (
+    body &&
+    typeof body === "object" &&
+    "workspaceUpgrade" in body &&
+    body.workspaceUpgrade &&
+    typeof body.workspaceUpgrade === "object" &&
+    "redirectTo" in body.workspaceUpgrade &&
+    typeof body.workspaceUpgrade.redirectTo === "string"
+  ) {
+    return body.workspaceUpgrade.redirectTo;
+  }
+
+  return null;
+}
+
+/**
+ * Temporary self-service recovery for users whose local workspace exists but WorkOS
+ * membership is out of sync. Remove once automatic migration/reconcile covers all cases.
+ */
+export function SyncWorkosMembershipAction() {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+
+  const syncMembership = useMutation({
+    mutationFn: async () => {
+      const response = await apiClient.api.auth["upgrade-workspace"].$post();
+      const body: unknown = await response.json().catch(() => null);
+
+      if (response.status === 401) {
+        router.replace(
+          "/auth/sign-in?returnTo=/auth/access-denied?reason=organization-access-denied",
+        );
+        return null;
+      }
+
+      if (!response.ok) {
+        throw new Error(
+          readUpgradeErrorMessage(
+            body,
+            "We could not sync your workspace membership with WorkOS. Try again in a moment or contact support if this continues.",
+          ),
+        );
+      }
+
+      const redirectTo = readUpgradeRedirectTo(body);
+      if (!redirectTo) {
+        throw new Error("Sync finished without a redirect destination.");
+      }
+
+      return redirectTo;
+    },
+    onSuccess: (redirectTo) => {
+      if (!redirectTo) {
+        return;
+      }
+
+      router.replace(redirectTo);
+      router.refresh();
+    },
+    onError: (mutationError) => {
+      setError(
+        mutationError instanceof Error
+          ? mutationError.message
+          : "We could not sync your workspace membership with WorkOS. Try again in a moment or contact support if this continues.",
+      );
+    },
+  });
+
+  return (
+    <div className="flex flex-col gap-3 rounded-lg border border-border/70 bg-muted/20 px-4 py-4">
+      <TypographyP className="text-sm leading-6 text-muted-foreground">
+        If you already have a workspace here, you can retry syncing your membership with WorkOS.
+      </TypographyP>
+
+      {error ? (
+        <Alert variant="destructive">
+          <AlertTitle>Sync failed</AlertTitle>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      <Button
+        type="button"
+        disabled={syncMembership.isPending}
+        onClick={() => {
+          setError(null);
+          syncMembership.mutate();
+        }}
+      >
+        {syncMembership.isPending ? (
+          <>
+            <Spinner className="size-4" />
+            Syncing with WorkOS…
+          </>
+        ) : (
+          "Sync workspace with WorkOS"
+        )}
+      </Button>
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/auth/access-denied/_components/sync-workos-membership-action.tsx
+++ b/apps/hyperlocalise-web/src/app/auth/access-denied/_components/sync-workos-membership-action.tsx
@@ -52,7 +52,7 @@ export function SyncWorkosMembershipAction() {
 
       if (response.status === 401) {
         router.replace(
-          "/auth/sign-in?returnTo=/auth/access-denied?reason=organization-access-denied",
+          `/auth/sign-in?returnTo=${encodeURIComponent("/auth/access-denied?reason=organization-access-denied")}`,
         );
         return null;
       }

--- a/apps/hyperlocalise-web/src/app/auth/access-denied/page.tsx
+++ b/apps/hyperlocalise-web/src/app/auth/access-denied/page.tsx
@@ -1,25 +1,94 @@
 import Link from "next/link";
 
+import { SyncWorkosMembershipAction } from "@/app/auth/access-denied/_components/sync-workos-membership-action";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { TypographyP } from "@/components/ui/typography";
 
-export default function AccessDeniedPage() {
+type AccessDeniedReason =
+  | "organization-access-denied"
+  | "workos-membership-lookup-failed"
+  | "workspace-archived"
+  | "insufficient-permissions"
+  | "missing-org-slug"
+  | "callback";
+
+function shouldOfferWorkosMembershipSync(reason: AccessDeniedReason | undefined) {
+  return reason === "organization-access-denied" || reason === "workos-membership-lookup-failed";
+}
+
+function getAccessDeniedCopy(reason: AccessDeniedReason | undefined) {
+  switch (reason) {
+    case "organization-access-denied":
+      return {
+        title: "Organization access unavailable",
+        description:
+          "Your account is signed in, but we could not match this workspace to an active WorkOS membership.",
+        body: "This can happen when a legacy workspace has not finished syncing to WorkOS yet. Try syncing below, choose another organization, or ask an admin to confirm your membership.",
+      };
+    case "workos-membership-lookup-failed":
+      return {
+        title: "Could not verify membership",
+        description:
+          "Your account is signed in, but we could not reach WorkOS to confirm your organization membership.",
+        body: "Try syncing again in a moment. If the problem continues, contact support or choose another organization.",
+      };
+    case "workspace-archived":
+      return {
+        title: "Workspace archived",
+        description: "This workspace is archived and can no longer be opened.",
+        body: "Choose another organization or sign out and retry with another account.",
+      };
+    case "insufficient-permissions":
+      return {
+        title: "Insufficient permissions",
+        description: "Your account does not have permission to open this page.",
+        body: "Ask an organization admin to update your role, or choose another organization.",
+      };
+    case "missing-org-slug":
+      return {
+        title: "Workspace unavailable",
+        description: "We could not determine which organization to open.",
+        body: "Choose an organization from your account or contact support if this continues.",
+      };
+    case "callback":
+      return {
+        title: "Sign-in could not be completed",
+        description: "Something went wrong while finishing sign-in.",
+        body: "Try signing in again or contact support if this continues.",
+      };
+    default:
+      return {
+        title: "Access denied",
+        description:
+          "Your account is signed in, but this workspace does not have an active organization context you can use.",
+        body: "Ask your organization admin to confirm your WorkOS membership, choose another organization, or sign out and retry with another account.",
+      };
+  }
+}
+
+type AccessDeniedPageProps = {
+  searchParams: Promise<{ reason?: string }>;
+};
+
+export default async function AccessDeniedPage({ searchParams }: AccessDeniedPageProps) {
+  const { reason: rawReason } = await searchParams;
+  const reason = rawReason as AccessDeniedReason | undefined;
+  const copy = getAccessDeniedCopy(reason);
+  const showWorkosSync = shouldOfferWorkosMembershipSync(reason);
+
   return (
     <main className="flex min-h-svh items-center justify-center bg-background px-4 py-10 text-foreground">
       <Card className="w-full max-w-lg border-border/70 bg-background shadow-2xl shadow-foreground/12">
         <CardHeader>
-          <CardTitle className="font-heading text-2xl">Access denied</CardTitle>
-          <CardDescription className="text-muted-foreground">
-            Your account is signed in, but this workspace does not have an active organization
-            context you can use.
-          </CardDescription>
+          <CardTitle className="font-heading text-2xl">{copy.title}</CardTitle>
+          <CardDescription className="text-muted-foreground">{copy.description}</CardDescription>
         </CardHeader>
-        <CardContent className="flex flex-col gap-3">
-          <TypographyP className="text-sm leading-6 text-muted-foreground">
-            Ask your organization admin to confirm your WorkOS membership, choose another
-            organization, or sign out and retry with another account.
-          </TypographyP>
+        <CardContent className="flex flex-col gap-4">
+          <TypographyP className="text-sm leading-6 text-muted-foreground">{copy.body}</TypographyP>
+
+          {showWorkosSync ? <SyncWorkosMembershipAction /> : null}
+
           <div className="flex flex-wrap gap-3">
             <Button
               variant="outline"

--- a/apps/hyperlocalise-web/src/app/auth/access-denied/page.tsx
+++ b/apps/hyperlocalise-web/src/app/auth/access-denied/page.tsx
@@ -14,7 +14,7 @@ type AccessDeniedReason =
   | "callback";
 
 function shouldOfferWorkosMembershipSync(reason: AccessDeniedReason | undefined) {
-  return reason === "organization-access-denied" || reason === "workos-membership-lookup-failed";
+  return reason === "organization-access-denied";
 }
 
 function getAccessDeniedCopy(reason: AccessDeniedReason | undefined) {
@@ -31,7 +31,7 @@ function getAccessDeniedCopy(reason: AccessDeniedReason | undefined) {
         title: "Could not verify membership",
         description:
           "Your account is signed in, but we could not reach WorkOS to confirm your organization membership.",
-        body: "Try syncing again in a moment. If the problem continues, contact support or choose another organization.",
+        body: "Try again in a moment. If the problem continues, contact support or choose another organization.",
       };
     case "workspace-archived":
       return {

--- a/apps/hyperlocalise-web/src/lib/workos/app-auth.test.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/app-auth.test.ts
@@ -89,6 +89,26 @@ describe("requireAppAuthContext", () => {
     expect(listLocalOrgWorkspacesForUserMock).toHaveBeenCalledWith(expect.anything(), "user_123");
   });
 
+  it("redirects to access denied when legacy workspace lookup fails", async () => {
+    const session = {
+      user: { id: "user_123", email: "person@example.com" },
+      organizationId: null,
+    };
+    withAuthMock.mockResolvedValue(session);
+    getStoredActiveOrganizationSlugMock.mockResolvedValue(null);
+    resolveApiAuthContextFromSessionMock.mockRejectedValue(new Error("organization_access_denied"));
+    listLocalOrgWorkspacesForUserMock.mockRejectedValue(new Error("database_unavailable"));
+
+    const { requireAppAuthContext } = await import("./app-auth");
+
+    await expect(requireAppAuthContext({ organizationSlug: "stale-slug" })).rejects.toThrow(
+      "redirect:/auth/access-denied?reason=organization-access-denied",
+    );
+    expect(redirectMock).toHaveBeenCalledWith(
+      "/auth/access-denied?reason=organization-access-denied",
+    );
+  });
+
   it("redirects to the org access-denied page when the requested org is not accessible", async () => {
     const session = {
       user: { id: "user_123", email: "person@example.com" },

--- a/apps/hyperlocalise-web/src/lib/workos/app-auth.test.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/app-auth.test.ts
@@ -68,6 +68,27 @@ describe("requireAppAuthContext", () => {
     expect(redirectMock).toHaveBeenCalledWith("/auth/select-organization");
   });
 
+  it("redirects to workspace upgrade when org access is denied but legacy workspaces exist", async () => {
+    const session = {
+      user: { id: "user_123", email: "person@example.com" },
+      organizationId: null,
+    };
+    withAuthMock.mockResolvedValue(session);
+    getStoredActiveOrganizationSlugMock.mockResolvedValue(null);
+    resolveApiAuthContextFromSessionMock.mockRejectedValue(new Error("organization_access_denied"));
+    listLocalOrgWorkspacesForUserMock.mockResolvedValue([
+      { organizationId: "org_1", name: "Legacy Workspace", slug: "legacy" },
+    ]);
+
+    const { requireAppAuthContext } = await import("./app-auth");
+
+    await expect(requireAppAuthContext({ organizationSlug: "stale-slug" })).rejects.toThrow(
+      "redirect:/auth/upgrade-workspace",
+    );
+    expect(redirectMock).toHaveBeenCalledWith("/auth/upgrade-workspace");
+    expect(listLocalOrgWorkspacesForUserMock).toHaveBeenCalledWith(expect.anything(), "user_123");
+  });
+
   it("redirects to the org access-denied page when the requested org is not accessible", async () => {
     const session = {
       user: { id: "user_123", email: "person@example.com" },
@@ -76,6 +97,7 @@ describe("requireAppAuthContext", () => {
     withAuthMock.mockResolvedValue(session);
     getStoredActiveOrganizationSlugMock.mockResolvedValue(null);
     resolveApiAuthContextFromSessionMock.mockRejectedValue(new Error("organization_access_denied"));
+    listLocalOrgWorkspacesForUserMock.mockResolvedValue([]);
 
     const { requireAppAuthContext } = await import("./app-auth");
 

--- a/apps/hyperlocalise-web/src/lib/workos/app-auth.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/app-auth.ts
@@ -53,7 +53,14 @@ export async function requireAppAuthContext(
 
     if (error instanceof Error && error.message === "organization_access_denied") {
       // Temporary: legacy local workspaces can exist while WorkOS membership is still empty.
-      const pendingLocalOrgWorkspaces = await listLocalOrgWorkspacesForUser(db, session.user.id);
+      let pendingLocalOrgWorkspaces: Awaited<ReturnType<typeof listLocalOrgWorkspacesForUser>> = [];
+
+      try {
+        pendingLocalOrgWorkspaces = await listLocalOrgWorkspacesForUser(db, session.user.id);
+      } catch {
+        // Fall through to access denied if the legacy workspace lookup fails.
+      }
+
       if (pendingLocalOrgWorkspaces.length > 0) {
         redirect("/auth/upgrade-workspace");
       }

--- a/apps/hyperlocalise-web/src/lib/workos/app-auth.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/app-auth.ts
@@ -52,6 +52,12 @@ export async function requireAppAuthContext(
     }
 
     if (error instanceof Error && error.message === "organization_access_denied") {
+      // Temporary: legacy local workspaces can exist while WorkOS membership is still empty.
+      const pendingLocalOrgWorkspaces = await listLocalOrgWorkspacesForUser(db, session.user.id);
+      if (pendingLocalOrgWorkspaces.length > 0) {
+        redirect("/auth/upgrade-workspace");
+      }
+
       redirect("/auth/access-denied?reason=organization-access-denied");
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Users with a local workspace but no active WorkOS membership could land on `organization-access-denied` even though their org exists in the database. This adds a temporary self-service recovery path.

## Changes

- **Auth redirect fix:** When `organization_access_denied` is thrown and the signed-in user still has legacy `local_org_*` workspaces, redirect to `/auth/upgrade-workspace` instead of access denied (matches onboarding behavior).
- **Access denied UI:** Reason-specific copy on `/auth/access-denied`, including clearer messaging for `organization-access-denied` and `workos-membership-lookup-failed`.
- **Temporary sync action:** A "Sync workspace with WorkOS" button calls the existing `POST /api/auth/upgrade-workspace` endpoint to migrate legacy workspaces and force membership reconcile.

## Notes

The sync UI is intentionally marked as temporary in code comments — it should be removed once automatic migration/reconcile covers all stuck-user cases.

## Testing

- `CI=true vp test src/lib/workos/app-auth.test.ts`
- `CI=true vp check --fix`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55025fd6-67e3-4efa-afa2-0c6d50c5d181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55025fd6-67e3-4efa-afa2-0c6d50c5d181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

