### PR TITLE
test(auth): add enterprise identity access regression tests and invariants

### DIFF
--- a/apps/hyperlocalise-web/src/api/auth/AUTH_INVARIANTS.md
+++ b/apps/hyperlocalise-web/src/api/auth/AUTH_INVARIANTS.md
@@ -1,0 +1,82 @@
+# Organization access invariants
+
+These contracts protect enterprise identity. Regression coverage lives in
+`identity-access-regression.test.ts`. Extend this list when adding roles, teams,
+or collaboration features — do not weaken an invariant without an explicit
+security review.
+
+See also [`src/lib/workos/IDENTITY.md`](../../lib/workos/IDENTITY.md) for the
+full WorkOS identity model.
+
+## Access gate (session bootstrap)
+
+1. **WorkOS is authoritative.** Session and API access require a local
+   membership row with a real, non-`replacing` `workos_membership_id` that
+   WorkOS still reports as active after reconcile.
+2. **Local membership alone never grants access.** A row in
+   `organization_memberships` without WorkOS confirmation (pending invite,
+   replacing sentinel, or stale authoritative id) must not appear in
+   `resolveApiAuthContextFromSession` results.
+3. **Pending invites never grant access.** `workos_membership_id IS NULL` is
+   member-list UI state only (`accessSource: pending_invite`).
+4. **Replacing sentinel never grants access.** `workos_membership_id = replacing`
+   blocks access while an invite replacement is in flight
+   (`accessSource: replacing_invite`).
+5. **Placeholder users never bootstrap access.** Users with
+   `workos_user_id` prefixed `invited_user_` skip WorkOS membership reconcile
+   and cannot receive `workos_authoritative` session context.
+6. **Reconcile runs before membership load.** Every
+   `resolveApiAuthContextFromSession` call reconciles (subject to TTL) before
+   querying active memberships.
+7. **Fail closed on stale WorkOS.** If membership lookup fails and
+   `users.workos_memberships_reconciled_at` is older than five minutes, deny
+   with `workos_membership_lookup_failed`.
+8. **Removed WorkOS members lose access on reconcile.** Local authoritative
+   memberships absent from WorkOS active membership listing are revoked during
+   reconcile (and via webhooks).
+
+## Route authorization
+
+9. **Session cookie is the only API auth channel.** Forged
+   `x-hyperlocalise-auth` headers or other client-supplied identity must not
+   bypass `workosAuthMiddleware`.
+10. **Org slug must match an active membership.** Requested
+    `organizationSlug` must resolve to a membership returned after the access
+    gate; otherwise return `organization_access_denied` or picker/unresolvable
+    errors — never silently fall back to another org.
+11. **Archived organizations are excluded.** Only organizations with
+    `lifecycle_status = active` participate in session membership queries.
+
+## Member management mutations
+
+12. **Mutations sync to WorkOS before granting new access.** Invites, role
+    changes, and removals call WorkOS first; local changes roll back when WorkOS
+    rejects the operation.
+13. **Admin mutations cannot create WorkOS-denied access.** Pending local rows
+    and placeholder users remain non-authoritative until WorkOS confirms
+    membership; admin PATCH/POST must not set a real `workos_membership_id`
+    without a corresponding WorkOS membership.
+14. **Admin cannot elevate to or manage owners.** Capability and hierarchy
+    checks in `member.shared.ts` enforce owner protection.
+15. **At least one owner required.** Owner demotion/removal is blocked when
+    the locked owner count would drop below one.
+
+## Capability layer (`policy.ts`)
+
+16. **Capabilities derive from reconciled role only.** `hasCapability` runs
+    after the access gate; roles on pending or revoked rows must never reach
+    capability checks.
+17. **Member role is read-only for admin capabilities.** Members receive
+    baseline read capabilities only; `members:invite` and other admin writes
+    require owner/admin roles.
+
+## Future extension points
+
+When adding team-scoped roles or contractor access:
+
+- Keep the access gate in `workos-session.ts` — team policy in `team-access.ts`
+  runs only after WorkOS-authoritative membership is established.
+- Never treat local-only membership as sufficient for org or team resource
+  access.
+- Add a regression test in `identity-access-regression.test.ts` for each new
+  access path.

--- a/apps/hyperlocalise-web/src/api/auth/identity-access-regression.test.ts
+++ b/apps/hyperlocalise-web/src/api/auth/identity-access-regression.test.ts
@@ -1,0 +1,410 @@
+import "dotenv/config";
+
+import { randomUUID } from "node:crypto";
+
+import { eq } from "drizzle-orm";
+import { testClient } from "hono/testing";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
+
+import { createApp } from "@/api/app";
+import {
+  promoteInvitedPlaceholderUser,
+  revokeOrganizationMembershipAccess,
+  syncWorkosIdentity,
+} from "@/api/auth/workos-sync";
+import { createAuthTestFixture } from "@/api/test-auth.fixture";
+import { db, schema } from "@/lib/database";
+import {
+  INVITED_WORKOS_USER_ID_PREFIX,
+  REPLACING_WORKOS_MEMBERSHIP_ID,
+} from "@/lib/workos/constants";
+
+const { withAuthMock, listMembershipsMock, getOrganizationMock } = vi.hoisted(() => ({
+  withAuthMock: vi.fn(),
+  listMembershipsMock: vi.fn(),
+  getOrganizationMock: vi.fn(),
+}));
+
+vi.mock("@workos-inc/authkit-nextjs", () => ({
+  withAuth: withAuthMock,
+}));
+
+vi.mock("@/lib/env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/env")>();
+  return {
+    env: new Proxy(actual.env, {
+      get(target, property, receiver) {
+        if (property === "WORKOS_API_KEY") {
+          return "sk_test_identity_regression";
+        }
+
+        return Reflect.get(target, property, receiver);
+      },
+    }),
+  };
+});
+
+vi.mock("@/lib/workos/server-client", () => ({
+  getWorkosServerClient: () => ({
+    userManagement: {
+      listOrganizationMemberships: listMembershipsMock,
+    },
+    organizations: {
+      getOrganization: getOrganizationMock,
+    },
+  }),
+}));
+
+const { createWorkosIdentity, cleanup } = createAuthTestFixture();
+const client = testClient(createApp());
+const sessionHeaders = { headers: { cookie: "wos-session=identity-regression" } };
+
+function mockWorkosSessionForIdentity(identity: ReturnType<typeof createWorkosIdentity>) {
+  withAuthMock.mockResolvedValue({
+    user: {
+      id: identity.user.workosUserId,
+      email: identity.user.email,
+      firstName: null,
+      lastName: null,
+      profilePictureUrl: null,
+    },
+    organizationId: identity.organization.workosOrganizationId,
+  });
+}
+
+function mockWorkosActiveMembership(identity: ReturnType<typeof createWorkosIdentity>) {
+  listMembershipsMock.mockResolvedValue({
+    autoPagination: async () => [
+      {
+        id: identity.membership.workosMembershipId,
+        organizationId: identity.organization.workosOrganizationId,
+        status: "active",
+        role: { slug: identity.membership.role },
+      },
+    ],
+  });
+  getOrganizationMock.mockResolvedValue({
+    id: identity.organization.workosOrganizationId,
+    name: identity.organization.name,
+  });
+}
+
+async function requestOrgProjects(organizationSlug: string) {
+  return client.api.orgs[":organizationSlug"].projects.$get(
+    { param: { organizationSlug } },
+    sessionHeaders,
+  );
+}
+
+beforeAll(async () => {
+  await db.$client.query("select 1");
+});
+
+afterEach(async () => {
+  withAuthMock.mockReset();
+  listMembershipsMock.mockReset();
+  getOrganizationMock.mockReset();
+  await cleanup();
+});
+
+describe("enterprise identity access regression", () => {
+  describe("session bootstrap access gate", () => {
+    it("grants access for accepted WorkOS members with authoritative membership", async () => {
+      const identity = createWorkosIdentity();
+      await syncWorkosIdentity(db, identity);
+      mockWorkosActiveMembership(identity);
+      mockWorkosSessionForIdentity(identity);
+
+      const { resolveApiAuthContextFromSession } = await import("./workos-session");
+      const auth = await resolveApiAuthContextFromSession();
+
+      expect(auth?.membership.accessSource).toBe("workos_authoritative");
+      expect(auth?.activeOrganization.slug).toBe(identity.organization.slug);
+
+      const response = await requestOrgProjects(identity.organization.slug!);
+      expect(response.status).toBe(200);
+    });
+
+    it("denies access for pending invites without WorkOS membership confirmation", async () => {
+      const ownerIdentity = createWorkosIdentity();
+      await syncWorkosIdentity(db, ownerIdentity);
+
+      const pendingEmail = `pending-${randomUUID()}@example.com`;
+      const placeholderUserId = `${INVITED_WORKOS_USER_ID_PREFIX}${randomUUID()}`;
+      await syncWorkosIdentity(db, {
+        user: {
+          workosUserId: placeholderUserId,
+          email: pendingEmail,
+        },
+        organization: ownerIdentity.organization,
+        membership: {
+          role: "member",
+        },
+      });
+
+      listMembershipsMock.mockResolvedValue({ autoPagination: async () => [] });
+      withAuthMock.mockResolvedValue({
+        user: {
+          id: placeholderUserId,
+          email: pendingEmail,
+          firstName: null,
+          lastName: null,
+          profilePictureUrl: null,
+        },
+        organizationId: null,
+      });
+
+      const { resolveApiAuthContextFromSession } = await import("./workos-session");
+
+      await expect(
+        resolveApiAuthContextFromSession({
+          organizationSlug: ownerIdentity.organization.slug,
+        }),
+      ).rejects.toThrow("organization_access_denied");
+
+      await expect(resolveApiAuthContextFromSession()).resolves.toBeNull();
+    });
+
+    it("denies access for existing local users invited but not yet accepted in WorkOS", async () => {
+      const ownerIdentity = createWorkosIdentity();
+      const existingUserIdentity = createWorkosIdentity();
+      const ownerSynced = await syncWorkosIdentity(db, ownerIdentity);
+      const existingSynced = await syncWorkosIdentity(db, existingUserIdentity);
+
+      await db.insert(schema.organizationMemberships).values({
+        organizationId: ownerSynced.organization.id,
+        userId: existingSynced.user.id,
+        role: "member",
+        workosMembershipId: null,
+      });
+
+      listMembershipsMock.mockResolvedValue({ autoPagination: async () => [] });
+      withAuthMock.mockResolvedValue({
+        user: {
+          id: existingUserIdentity.user.workosUserId,
+          email: existingUserIdentity.user.email,
+          firstName: null,
+          lastName: null,
+          profilePictureUrl: null,
+        },
+        organizationId: null,
+      });
+
+      const { resolveApiAuthContextFromSession } = await import("./workos-session");
+
+      await expect(
+        resolveApiAuthContextFromSession({
+          organizationSlug: ownerIdentity.organization.slug,
+        }),
+      ).rejects.toThrow("organization_access_denied");
+    });
+
+    it("denies access while invite replacement sentinel is set", async () => {
+      const identity = createWorkosIdentity();
+      const synced = await syncWorkosIdentity(db, identity);
+
+      await db
+        .update(schema.organizationMemberships)
+        .set({ workosMembershipId: REPLACING_WORKOS_MEMBERSHIP_ID })
+        .where(eq(schema.organizationMemberships.organizationId, synced.organization.id));
+
+      listMembershipsMock.mockResolvedValue({ autoPagination: async () => [] });
+      mockWorkosSessionForIdentity(identity);
+
+      const { resolveApiAuthContextFromSession } = await import("./workos-session");
+
+      await expect(
+        resolveApiAuthContextFromSession({
+          organizationSlug: identity.organization.slug,
+        }),
+      ).rejects.toThrow("organization_access_denied");
+    });
+
+    it("does not grant access from local membership alone when WorkOS no longer lists the member", async () => {
+      const identity = createWorkosIdentity();
+      await syncWorkosIdentity(db, identity);
+
+      listMembershipsMock.mockResolvedValue({ autoPagination: async () => [] });
+      mockWorkosSessionForIdentity(identity);
+
+      const { resolveApiAuthContextFromSession } = await import("./workos-session");
+
+      await expect(
+        resolveApiAuthContextFromSession({
+          organizationSlug: identity.organization.slug,
+        }),
+      ).rejects.toThrow("organization_access_denied");
+
+      const response = await requestOrgProjects(identity.organization.slug!);
+      expect(response.status).toBe(403);
+      await expect(response.json()).resolves.toMatchObject({
+        error: "organization_access_denied",
+      });
+    });
+  });
+
+  describe("membership reconciliation during login", () => {
+    it("revokes removed WorkOS members during session bootstrap", async () => {
+      const identity = createWorkosIdentity();
+      await syncWorkosIdentity(db, identity);
+
+      listMembershipsMock.mockResolvedValue({ autoPagination: async () => [] });
+      mockWorkosSessionForIdentity(identity);
+
+      const { reconcileWorkosMembershipsForUser } = await import("./workos-membership-reconcile");
+      const result = await reconcileWorkosMembershipsForUser(db, {
+        workosUserId: identity.user.workosUserId,
+        email: identity.user.email,
+        force: true,
+      });
+
+      expect(result).toMatchObject({ status: "reconciled", revoked: 1 });
+
+      const memberships = await db
+        .select({ id: schema.organizationMemberships.id })
+        .from(schema.organizationMemberships)
+        .innerJoin(schema.users, eq(schema.organizationMemberships.userId, schema.users.id))
+        .where(eq(schema.users.workosUserId, identity.user.workosUserId));
+
+      expect(memberships).toEqual([]);
+
+      const { resolveApiAuthContextFromSession } = await import("./workos-session");
+      await expect(
+        resolveApiAuthContextFromSession({
+          organizationSlug: identity.organization.slug,
+        }),
+      ).rejects.toThrow("organization_access_denied");
+    });
+
+    it("skips reconcile for placeholder invited users", async () => {
+      const placeholderUserId = `${INVITED_WORKOS_USER_ID_PREFIX}${randomUUID()}`;
+
+      const { reconcileWorkosMembershipsForUser } = await import("./workos-membership-reconcile");
+      const result = await reconcileWorkosMembershipsForUser(db, {
+        workosUserId: placeholderUserId,
+        email: "placeholder@example.com",
+        force: true,
+      });
+
+      expect(result).toEqual({ status: "skipped" });
+      expect(listMembershipsMock).not.toHaveBeenCalled();
+    });
+
+    it("respects reconcile TTL unless force is set", async () => {
+      const identity = createWorkosIdentity();
+      await syncWorkosIdentity(db, identity);
+
+      await db
+        .update(schema.users)
+        .set({ workosMembershipsReconciledAt: new Date() })
+        .where(eq(schema.users.workosUserId, identity.user.workosUserId));
+
+      const { reconcileWorkosMembershipsForUser } = await import("./workos-membership-reconcile");
+
+      const skipped = await reconcileWorkosMembershipsForUser(db, {
+        workosUserId: identity.user.workosUserId,
+        email: identity.user.email,
+      });
+      expect(skipped).toEqual({ status: "skipped" });
+      expect(listMembershipsMock).not.toHaveBeenCalled();
+
+      listMembershipsMock.mockResolvedValue({ autoPagination: async () => [] });
+      const forced = await reconcileWorkosMembershipsForUser(db, {
+        workosUserId: identity.user.workosUserId,
+        email: identity.user.email,
+        force: true,
+      });
+      expect(forced.status).toBe("reconciled");
+      expect(listMembershipsMock).toHaveBeenCalled();
+    });
+  });
+
+  describe("revocation and placeholder promotion", () => {
+    it("revokes local access when WorkOS membership is deleted", async () => {
+      const identity = createWorkosIdentity();
+      const synced = await syncWorkosIdentity(db, identity);
+
+      const result = await revokeOrganizationMembershipAccess(db, {
+        workosMembershipId: identity.membership.workosMembershipId,
+        workosOrganizationId: identity.organization.workosOrganizationId,
+        workosUserId: identity.user.workosUserId,
+      });
+
+      expect(result.organizationMembershipsDeleted).toBe(1);
+
+      const remaining = await db
+        .select({ id: schema.organizationMemberships.id })
+        .from(schema.organizationMemberships)
+        .where(eq(schema.organizationMemberships.organizationId, synced.organization.id));
+
+      expect(remaining).toEqual([]);
+    });
+
+    it("promotes placeholder users on WorkOS user.created", async () => {
+      const ownerIdentity = createWorkosIdentity();
+      await syncWorkosIdentity(db, ownerIdentity);
+
+      const pendingEmail = `promote-${randomUUID()}@example.com`;
+      const placeholderUserId = `${INVITED_WORKOS_USER_ID_PREFIX}${randomUUID()}`;
+      const realWorkosUserId = `user_${randomUUID()}`;
+
+      await syncWorkosIdentity(db, {
+        user: {
+          workosUserId: placeholderUserId,
+          email: pendingEmail,
+        },
+        organization: ownerIdentity.organization,
+        membership: {
+          role: "member",
+        },
+      });
+
+      const promoted = await promoteInvitedPlaceholderUser(db, {
+        email: pendingEmail,
+        workosUserId: realWorkosUserId,
+      });
+
+      expect(promoted).toBe(true);
+
+      const [user] = await db
+        .select({ workosUserId: schema.users.workosUserId })
+        .from(schema.users)
+        .where(eq(schema.users.email, pendingEmail))
+        .limit(1);
+
+      expect(user?.workosUserId).toBe(realWorkosUserId);
+    });
+  });
+
+  describe("route authorization for membership states", () => {
+    it("returns 403 for removed members on org-scoped routes after reconcile", async () => {
+      const identity = createWorkosIdentity();
+      await syncWorkosIdentity(db, identity);
+
+      listMembershipsMock.mockResolvedValue({ autoPagination: async () => [] });
+      mockWorkosSessionForIdentity(identity);
+
+      const response = await requestOrgProjects(identity.organization.slug!);
+
+      expect(response.status).toBe(403);
+      await expect(response.json()).resolves.toMatchObject({
+        error: "organization_access_denied",
+      });
+    });
+
+    it("returns workos_membership_lookup_failed when reconcile cannot verify membership", async () => {
+      const identity = createWorkosIdentity();
+      await syncWorkosIdentity(db, identity);
+
+      listMembershipsMock.mockRejectedValue(new Error("workos_unavailable"));
+      mockWorkosSessionForIdentity(identity);
+
+      const response = await requestOrgProjects(identity.organization.slug!);
+
+      expect(response.status).toBe(403);
+      await expect(response.json()).resolves.toMatchObject({
+        error: "workos_membership_lookup_failed",
+      });
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/api/auth/identity-access-regression.test.ts
+++ b/apps/hyperlocalise-web/src/api/auth/identity-access-regression.test.ts
@@ -55,7 +55,7 @@ vi.mock("@/lib/workos/server-client", () => ({
   }),
 }));
 
-const { createWorkosIdentity, cleanup } = createAuthTestFixture();
+const { createWorkosIdentity, cleanup, trackWorkosUserId } = createAuthTestFixture();
 const client = testClient(createApp());
 const sessionHeaders = { headers: { cookie: "wos-session=identity-regression" } };
 
@@ -131,6 +131,7 @@ describe("enterprise identity access regression", () => {
 
       const pendingEmail = `pending-${randomUUID()}@example.com`;
       const placeholderUserId = `${INVITED_WORKOS_USER_ID_PREFIX}${randomUUID()}`;
+      trackWorkosUserId(placeholderUserId);
       await syncWorkosIdentity(db, {
         user: {
           workosUserId: placeholderUserId,
@@ -348,6 +349,8 @@ describe("enterprise identity access regression", () => {
       const placeholderUserId = `${INVITED_WORKOS_USER_ID_PREFIX}${randomUUID()}`;
       const realWorkosUserId = `user_${randomUUID()}`;
 
+      trackWorkosUserId(placeholderUserId);
+
       await syncWorkosIdentity(db, {
         user: {
           workosUserId: placeholderUserId,
@@ -365,6 +368,7 @@ describe("enterprise identity access regression", () => {
       });
 
       expect(promoted).toBe(true);
+      trackWorkosUserId(realWorkosUserId);
 
       const [user] = await db
         .select({ workosUserId: schema.users.workosUserId })

--- a/apps/hyperlocalise-web/src/api/auth/policy.test.ts
+++ b/apps/hyperlocalise-web/src/api/auth/policy.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  assertCapability,
   getCapabilitiesForRole,
   hasCapability,
   isAdminRole,
@@ -87,6 +88,16 @@ describe("organization capability policy", () => {
       for (const capability of ORGANIZATION_CAPABILITIES) {
         expect(hasCapability(unknownRole, capability)).toBe(false);
       }
+    });
+  });
+
+  describe("assertCapability", () => {
+    it("throws when the role lacks the requested capability", () => {
+      expect(() => assertCapability("member", "members:invite")).toThrow("forbidden");
+    });
+
+    it("does not throw when the role has the requested capability", () => {
+      expect(() => assertCapability("admin", "members:invite")).not.toThrow();
     });
   });
 });

--- a/apps/hyperlocalise-web/src/api/auth/policy.ts
+++ b/apps/hyperlocalise-web/src/api/auth/policy.ts
@@ -1,5 +1,12 @@
 import type { OrganizationMembershipRole } from "@/lib/database/types";
 
+/**
+ * Organization capability matrix. Authorization runs only after WorkOS-
+ * authoritative membership is established in `workos-session.ts`.
+ *
+ * Security invariants for access gates, member mutations, and future role work:
+ * see `./AUTH_INVARIANTS.md`.
+ */
 const MEMBER_READ_CAPABILITIES = [
   "workspace:read",
   "projects:read",

--- a/apps/hyperlocalise-web/src/api/auth/workos-sync.test.ts
+++ b/apps/hyperlocalise-web/src/api/auth/workos-sync.test.ts
@@ -1,22 +1,33 @@
 import "dotenv/config";
 
+import { randomUUID } from "node:crypto";
+
 import { eq } from "drizzle-orm";
-import { beforeAll, describe, expect, it } from "vite-plus/test";
+import { afterEach, beforeAll, describe, expect, it } from "vite-plus/test";
 
 import {
   clearPendingMembershipReplacingInvitation,
   markPendingMembershipReplacingInvitation,
+  promoteInvitedPlaceholderUser,
   removePendingOrganizationMembershipForInvite,
+  revokeOrganizationMembershipAccess,
   syncWorkosIdentity,
 } from "@/api/auth/workos-sync";
 import { createAuthTestFixture } from "@/api/test-auth.fixture";
 import { db, schema } from "@/lib/database";
-import { REPLACING_WORKOS_MEMBERSHIP_ID } from "@/lib/workos/constants";
+import {
+  INVITED_WORKOS_USER_ID_PREFIX,
+  REPLACING_WORKOS_MEMBERSHIP_ID,
+} from "@/lib/workos/constants";
 
-const { createWorkosIdentity } = createAuthTestFixture();
+const { createWorkosIdentity, cleanup } = createAuthTestFixture();
 
 beforeAll(async () => {
   await db.$client.query("select 1");
+});
+
+afterEach(async () => {
+  await cleanup();
 });
 
 describe("removePendingOrganizationMembershipForInvite", () => {
@@ -77,5 +88,56 @@ describe("removePendingOrganizationMembershipForInvite", () => {
     await db
       .delete(schema.organizationMemberships)
       .where(eq(schema.organizationMemberships.id, membership.id));
+  });
+});
+
+describe("promoteInvitedPlaceholderUser", () => {
+  it("returns false when no placeholder user exists for the email", async () => {
+    const promoted = await promoteInvitedPlaceholderUser(db, {
+      email: "missing@example.com",
+      workosUserId: "user_real",
+    });
+
+    expect(promoted).toBe(false);
+  });
+});
+
+describe("revokeOrganizationMembershipAccess", () => {
+  it("is a no-op when the membership id is unknown", async () => {
+    const result = await revokeOrganizationMembershipAccess(db, {
+      workosMembershipId: "membership_missing",
+    });
+
+    expect(result).toEqual({
+      organizationMembershipsDeleted: 0,
+      teamMembershipsDeleted: 0,
+      mcpSessionsDeleted: 0,
+    });
+  });
+
+  it("removes pending invite rows for revoked invitations", async () => {
+    const ownerIdentity = createWorkosIdentity();
+    await syncWorkosIdentity(db, ownerIdentity);
+
+    const pendingEmail = `revoked-${randomUUID()}@example.com`;
+    const placeholderUserId = `${INVITED_WORKOS_USER_ID_PREFIX}${randomUUID()}`;
+
+    await syncWorkosIdentity(db, {
+      user: {
+        workosUserId: placeholderUserId,
+        email: pendingEmail,
+      },
+      organization: ownerIdentity.organization,
+      membership: {
+        role: "member",
+      },
+    });
+
+    const deleted = await removePendingOrganizationMembershipForInvite(db, {
+      workosOrganizationId: ownerIdentity.organization.workosOrganizationId,
+      email: pendingEmail,
+    });
+
+    expect(deleted).toBe(1);
   });
 });

--- a/apps/hyperlocalise-web/src/api/auth/workos-sync.test.ts
+++ b/apps/hyperlocalise-web/src/api/auth/workos-sync.test.ts
@@ -20,7 +20,7 @@ import {
   REPLACING_WORKOS_MEMBERSHIP_ID,
 } from "@/lib/workos/constants";
 
-const { createWorkosIdentity, cleanup } = createAuthTestFixture();
+const { createWorkosIdentity, cleanup, trackWorkosUserId } = createAuthTestFixture();
 
 beforeAll(async () => {
   await db.$client.query("select 1");
@@ -89,6 +89,34 @@ describe("removePendingOrganizationMembershipForInvite", () => {
       .delete(schema.organizationMemberships)
       .where(eq(schema.organizationMemberships.id, membership.id));
   });
+
+  it("removes pending invite rows for revoked invitations", async () => {
+    const ownerIdentity = createWorkosIdentity();
+    await syncWorkosIdentity(db, ownerIdentity);
+
+    const pendingEmail = `revoked-${randomUUID()}@example.com`;
+    const placeholderUserId = `${INVITED_WORKOS_USER_ID_PREFIX}${randomUUID()}`;
+
+    trackWorkosUserId(placeholderUserId);
+
+    await syncWorkosIdentity(db, {
+      user: {
+        workosUserId: placeholderUserId,
+        email: pendingEmail,
+      },
+      organization: ownerIdentity.organization,
+      membership: {
+        role: "member",
+      },
+    });
+
+    const deleted = await removePendingOrganizationMembershipForInvite(db, {
+      workosOrganizationId: ownerIdentity.organization.workosOrganizationId,
+      email: pendingEmail,
+    });
+
+    expect(deleted).toBe(1);
+  });
 });
 
 describe("promoteInvitedPlaceholderUser", () => {
@@ -113,31 +141,5 @@ describe("revokeOrganizationMembershipAccess", () => {
       teamMembershipsDeleted: 0,
       mcpSessionsDeleted: 0,
     });
-  });
-
-  it("removes pending invite rows for revoked invitations", async () => {
-    const ownerIdentity = createWorkosIdentity();
-    await syncWorkosIdentity(db, ownerIdentity);
-
-    const pendingEmail = `revoked-${randomUUID()}@example.com`;
-    const placeholderUserId = `${INVITED_WORKOS_USER_ID_PREFIX}${randomUUID()}`;
-
-    await syncWorkosIdentity(db, {
-      user: {
-        workosUserId: placeholderUserId,
-        email: pendingEmail,
-      },
-      organization: ownerIdentity.organization,
-      membership: {
-        role: "member",
-      },
-    });
-
-    const deleted = await removePendingOrganizationMembershipForInvite(db, {
-      workosOrganizationId: ownerIdentity.organization.workosOrganizationId,
-      email: pendingEmail,
-    });
-
-    expect(deleted).toBe(1);
   });
 });

--- a/apps/hyperlocalise-web/src/api/auth/workos.test.ts
+++ b/apps/hyperlocalise-web/src/api/auth/workos.test.ts
@@ -1,0 +1,150 @@
+import "dotenv/config";
+
+import { Hono } from "hono";
+import { evlog } from "evlog/hono";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { createWorkosAuthMiddleware, enrichAuthContextWithCapabilities } from "@/api/auth/workos";
+import {
+  OrganizationSlugUnresolvableError,
+  StaleOrganizationSlugError,
+} from "@/api/auth/workos-session";
+
+const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
+  resolveApiAuthContextFromSessionMock: vi.fn(),
+}));
+
+vi.mock("@/api/auth/workos-session", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/auth/workos-session")>();
+  return {
+    ...actual,
+    resolveApiAuthContextFromSession: resolveApiAuthContextFromSessionMock,
+  };
+});
+
+function createTestApp() {
+  return new Hono().use("*", evlog()).route(
+    "/orgs/:organizationSlug",
+    new Hono()
+      .use("*", createWorkosAuthMiddleware())
+      .get("/projects", (c) => c.json({ projects: [] }, 200)),
+  );
+}
+
+const sessionHeaders = { headers: { cookie: "wos-session=test" } };
+
+afterEach(() => {
+  resolveApiAuthContextFromSessionMock.mockReset();
+});
+
+describe("workosAuthMiddleware", () => {
+  it("returns 401 when the session cookie is missing", async () => {
+    const response = await createTestApp().request("http://localhost/orgs/example/projects");
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({ error: "unauthorized" });
+  });
+
+  it("returns stale_organization_slug with redirect details", async () => {
+    resolveApiAuthContextFromSessionMock.mockRejectedValueOnce(
+      new StaleOrganizationSlugError("old-slug", "new-slug"),
+    );
+
+    const response = await createTestApp().request("http://localhost/orgs/old-slug/projects", {
+      ...sessionHeaders,
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "stale_organization_slug",
+      details: {
+        requestedSlug: "old-slug",
+        currentSlug: "new-slug",
+        redirectTo: "/org/new-slug/dashboard",
+      },
+    });
+  });
+
+  it("returns organization_slug_unresolvable for unknown multi-org slugs", async () => {
+    resolveApiAuthContextFromSessionMock.mockRejectedValueOnce(
+      new OrganizationSlugUnresolvableError("missing-slug"),
+    );
+
+    const response = await createTestApp().request("http://localhost/orgs/missing-slug/projects", {
+      ...sessionHeaders,
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "organization_slug_unresolvable",
+    });
+  });
+
+  it("returns workspace_archived for archived-only access", async () => {
+    resolveApiAuthContextFromSessionMock.mockRejectedValueOnce(
+      new Error("archived_organization_access"),
+    );
+
+    const response = await createTestApp().request("http://localhost/orgs/archived/projects", {
+      ...sessionHeaders,
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "workspace_archived",
+    });
+  });
+
+  it("returns workos_membership_lookup_failed when reconcile verification fails", async () => {
+    resolveApiAuthContextFromSessionMock.mockRejectedValueOnce(
+      new Error("workos_membership_lookup_failed"),
+    );
+
+    const response = await createTestApp().request("http://localhost/orgs/example/projects", {
+      ...sessionHeaders,
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "workos_membership_lookup_failed",
+    });
+  });
+
+  it("allows org-scoped requests for authoritative members", async () => {
+    const activeOrganization = {
+      workosOrganizationId: "org_123",
+      localOrganizationId: "org_local_123",
+      name: "Example Org",
+      slug: "example-org",
+      membership: {
+        workosMembershipId: "membership_123",
+        role: "owner" as const,
+        accessSource: "workos_authoritative" as const,
+      },
+    };
+
+    resolveApiAuthContextFromSessionMock.mockResolvedValueOnce(
+      enrichAuthContextWithCapabilities({
+        user: {
+          workosUserId: "user_123",
+          localUserId: "user_local_123",
+          email: "user@example.com",
+        },
+        organizations: [activeOrganization],
+        organization: activeOrganization,
+        activeOrganization,
+        membership: activeOrganization.membership,
+        activeTeam: null,
+      }),
+    );
+
+    const response = await createTestApp().request("http://localhost/orgs/example-org/projects", {
+      ...sessionHeaders,
+    });
+
+    expect(response.status).toBe(200);
+    expect(resolveApiAuthContextFromSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ organizationSlug: "example-org" }),
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/api/routes/member/member.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/member/member.test.ts
@@ -740,4 +740,35 @@ describe("memberRoutes", () => {
 
     expect(response.status).toBe(409);
   });
+
+  it("forbids members from inviting or managing workspace membership", async () => {
+    const ownerIdentity = createWorkosIdentity();
+    const memberIdentity = createWorkosIdentityForOrganization(
+      ownerIdentity.organization,
+      "member",
+    );
+    const memberHeaders = await authHeadersFor(memberIdentity);
+
+    const inviteResponse = await inviteMemberViaApi(
+      ownerIdentity,
+      { email: "blocked-by-member@example.com", role: "member" },
+      memberHeaders,
+    );
+    expect(inviteResponse.status).toBe(403);
+
+    const updateResponse = await updateMemberRoleViaApi(
+      ownerIdentity,
+      ownerIdentity.user.workosUserId,
+      "admin",
+      memberHeaders,
+    );
+    expect(updateResponse.status).toBe(403);
+
+    const deleteResponse = await removeMemberViaApi(
+      ownerIdentity,
+      ownerIdentity.user.workosUserId,
+      memberHeaders,
+    );
+    expect(deleteResponse.status).toBe(403);
+  });
 });

--- a/apps/hyperlocalise-web/src/api/test-auth.fixture.ts
+++ b/apps/hyperlocalise-web/src/api/test-auth.fixture.ts
@@ -313,6 +313,10 @@ export function createAuthTestFixture() {
     createdRecordsByTest.delete(testKey);
   }
 
+  function trackWorkosUserId(workosUserId: string) {
+    currentTestRecords().workosUserIds.add(workosUserId);
+  }
+
   return {
     authHeadersFor,
     authHeadersForOrganizations,
@@ -322,5 +326,6 @@ export function createAuthTestFixture() {
     createWorkosIdentityForOrganization,
     createWorkosIdentityWithRole,
     getLocalUserId,
+    trackWorkosUserId,
   };
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Resolves HL-425 by adding automated regression coverage and documented invariants for WorkOS invite and membership access control.

- Added `AUTH_INVARIANTS.md` near the auth policy layer documenting 17 security invariants (access gate, reconciliation, route auth, member mutations).
- Added `identity-access-regression.test.ts` exercising real session resolution against DB fixtures for accepted, pending, revoked, removed, placeholder, and local-only membership states.
- Added `workos.test.ts` for middleware error mapping (401/403 paths: stale slug, unresolvable slug, archived workspace, lookup failure, success).
- Extended `workos-sync.test.ts` with revocation, placeholder promotion, and pending invite removal coverage.
- Extended `policy.test.ts` with `assertCapability` tests and `member.test.ts` with a test forbidding non-admin member mutations.

## How to test

```bash
cd apps/hyperlocalise-web
vp test src/api/auth/identity-access-regression.test.ts src/api/auth/workos.test.ts src/api/auth/workos-sync.test.ts src/api/auth/policy.test.ts src/api/routes/member/member.test.ts
vp check --fix
```

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, `vp test` on auth suite — 53 tests passing)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-425](https://linear.app/hyperlocalise/issue/HL-425/add-enterprise-identity-access-regression-tests-and-auth-invariants)

<div><a href="https://cursor.com/agents/bc-c752f058-c07c-45ad-977a-85198ee76b92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c752f058-c07c-45ad-977a-85198ee76b92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

