### PR TITLE
fix(workos): migrate signed-in user first with richer error logs

### DIFF
--- a/apps/hyperlocalise-web/src/lib/organizations/migrate-local-org-to-workos.test.ts
+++ b/apps/hyperlocalise-web/src/lib/organizations/migrate-local-org-to-workos.test.ts
@@ -9,8 +9,8 @@ import { createAuthTestFixture } from "@/api/test-auth.fixture";
 import { LOCAL_ORG_WORKOS_ID_PREFIX } from "@/lib/billing/autumn-customer";
 import { db, schema } from "@/lib/database";
 
-const { provisionWorkspaceInWorkosMock } = vi.hoisted(() => ({
-  provisionWorkspaceInWorkosMock: vi.fn(),
+const { promoteLocalOrganizationForWorkosUserMock } = vi.hoisted(() => ({
+  promoteLocalOrganizationForWorkosUserMock: vi.fn(),
 }));
 
 vi.mock("@/lib/env", async (importOriginal) => {
@@ -33,7 +33,7 @@ vi.mock("@/lib/workos/server-client", () => ({
 }));
 
 vi.mock("@/lib/workos/provision-workspace-in-workos", () => ({
-  provisionWorkspaceInWorkos: provisionWorkspaceInWorkosMock,
+  promoteLocalOrganizationForWorkosUser: promoteLocalOrganizationForWorkosUserMock,
 }));
 
 const { createWorkosIdentity, cleanup } = createAuthTestFixture();
@@ -43,7 +43,7 @@ beforeAll(async () => {
 });
 
 afterEach(async () => {
-  provisionWorkspaceInWorkosMock.mockReset();
+  promoteLocalOrganizationForWorkosUserMock.mockReset();
   await cleanup();
 });
 
@@ -63,15 +63,10 @@ describe("migrateLocalOrgWorkspaceToWorkos", () => {
     const promotedWorkosOrganizationId = `org_workos_promoted_${randomUUID()}`;
     const promotedWorkosMembershipId = `om_workos_promoted_${randomUUID()}`;
 
-    provisionWorkspaceInWorkosMock.mockResolvedValue({
+    promoteLocalOrganizationForWorkosUserMock.mockResolvedValue({
       workosOrganizationId: promotedWorkosOrganizationId,
-      members: [
-        {
-          workosUserId: identity.user.workosUserId,
-          workosMembershipId: promotedWorkosMembershipId,
-          role: identity.membership.role,
-        },
-      ],
+      workosMembershipId: promotedWorkosMembershipId,
+      role: identity.membership.role,
     });
 
     const { migrateLocalOrgWorkspaceToWorkos } = await import("./migrate-local-org-to-workos");
@@ -82,17 +77,13 @@ describe("migrateLocalOrgWorkspaceToWorkos", () => {
       identity.user.workosUserId,
     );
 
-    expect(provisionWorkspaceInWorkosMock).toHaveBeenCalledOnce();
-    expect(provisionWorkspaceInWorkosMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        members: [
-          {
-            workosUserId: identity.user.workosUserId,
-            role: identity.membership.role,
-          },
-        ],
-      }),
-    );
+    expect(promoteLocalOrganizationForWorkosUserMock).toHaveBeenCalledOnce();
+    expect(promoteLocalOrganizationForWorkosUserMock).toHaveBeenCalledWith({
+      localWorkspaceId: organization.id,
+      organizationName: synced.organization.name,
+      workosUserId: identity.user.workosUserId,
+      role: identity.membership.role,
+    });
     expect(result).toEqual({
       status: "migrated",
       workosOrganizationId: promotedWorkosOrganizationId,
@@ -152,15 +143,10 @@ describe("migrateLocalOrgWorkspaceToWorkos", () => {
     const promotedWorkosOrganizationId = `org_workos_promoted_${randomUUID()}`;
     const promotedWorkosMembershipId = `om_workos_promoted_${randomUUID()}`;
 
-    provisionWorkspaceInWorkosMock.mockResolvedValue({
+    promoteLocalOrganizationForWorkosUserMock.mockResolvedValue({
       workosOrganizationId: promotedWorkosOrganizationId,
-      members: [
-        {
-          workosUserId: identity.user.workosUserId,
-          workosMembershipId: promotedWorkosMembershipId,
-          role: identity.membership.role,
-        },
-      ],
+      workosMembershipId: promotedWorkosMembershipId,
+      role: identity.membership.role,
     });
 
     const { migrateLocalOrgWorkspaceToWorkos } = await import("./migrate-local-org-to-workos");
@@ -172,16 +158,20 @@ describe("migrateLocalOrgWorkspaceToWorkos", () => {
     );
 
     expect(result.status).toBe("migrated");
-    expect(provisionWorkspaceInWorkosMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        members: [
-          {
-            workosUserId: identity.user.workosUserId,
-            role: identity.membership.role,
-          },
-        ],
-      }),
-    );
+    expect(promoteLocalOrganizationForWorkosUserMock).toHaveBeenCalledWith({
+      localWorkspaceId: synced.organization.id,
+      organizationName: synced.organization.name,
+      workosUserId: identity.user.workosUserId,
+      role: identity.membership.role,
+    });
+
+    const [otherMembership] = await db
+      .select({ workosMembershipId: schema.organizationMemberships.workosMembershipId })
+      .from(schema.organizationMemberships)
+      .where(eq(schema.organizationMemberships.userId, otherUser.id))
+      .limit(1);
+
+    expect(otherMembership?.workosMembershipId).toMatch(/^om_local_/);
   });
 
   it("skips organizations that already use real WorkOS ids", async () => {
@@ -197,6 +187,6 @@ describe("migrateLocalOrgWorkspaceToWorkos", () => {
     );
 
     expect(result).toEqual({ status: "skipped", reason: "not_local_org" });
-    expect(provisionWorkspaceInWorkosMock).not.toHaveBeenCalled();
+    expect(promoteLocalOrganizationForWorkosUserMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/hyperlocalise-web/src/lib/organizations/migrate-local-org-to-workos.test.ts
+++ b/apps/hyperlocalise-web/src/lib/organizations/migrate-local-org-to-workos.test.ts
@@ -76,9 +76,23 @@ describe("migrateLocalOrgWorkspaceToWorkos", () => {
 
     const { migrateLocalOrgWorkspaceToWorkos } = await import("./migrate-local-org-to-workos");
 
-    const result = await migrateLocalOrgWorkspaceToWorkos(db, organization.id);
+    const result = await migrateLocalOrgWorkspaceToWorkos(
+      db,
+      organization.id,
+      identity.user.workosUserId,
+    );
 
     expect(provisionWorkspaceInWorkosMock).toHaveBeenCalledOnce();
+    expect(provisionWorkspaceInWorkosMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        members: [
+          {
+            workosUserId: identity.user.workosUserId,
+            role: identity.membership.role,
+          },
+        ],
+      }),
+    );
     expect(result).toEqual({
       status: "migrated",
       workosOrganizationId: promotedWorkosOrganizationId,
@@ -109,13 +123,78 @@ describe("migrateLocalOrgWorkspaceToWorkos", () => {
     expect(updatedMembership?.workosMembershipId).toBe(promotedWorkosMembershipId);
   });
 
+  it("provisions only the signed-in user when the workspace has other eligible members", async () => {
+    const identity = createWorkosIdentity();
+    const synced = await syncWorkosIdentity(db, identity);
+    const localOrgId = `${LOCAL_ORG_WORKOS_ID_PREFIX}${synced.organization.id}`;
+
+    await db
+      .update(schema.organizations)
+      .set({ workosOrganizationId: localOrgId, lifecycleStatus: "deprecated" })
+      .where(eq(schema.organizations.id, synced.organization.id));
+
+    const otherWorkosUserId = `user_other_${randomUUID()}`;
+    const [otherUser] = await db
+      .insert(schema.users)
+      .values({
+        workosUserId: otherWorkosUserId,
+        email: `other-${randomUUID()}@example.com`,
+      })
+      .returning({ id: schema.users.id });
+
+    await db.insert(schema.organizationMemberships).values({
+      organizationId: synced.organization.id,
+      userId: otherUser.id,
+      role: "admin",
+      workosMembershipId: `om_local_${randomUUID()}`,
+    });
+
+    const promotedWorkosOrganizationId = `org_workos_promoted_${randomUUID()}`;
+    const promotedWorkosMembershipId = `om_workos_promoted_${randomUUID()}`;
+
+    provisionWorkspaceInWorkosMock.mockResolvedValue({
+      workosOrganizationId: promotedWorkosOrganizationId,
+      members: [
+        {
+          workosUserId: identity.user.workosUserId,
+          workosMembershipId: promotedWorkosMembershipId,
+          role: identity.membership.role,
+        },
+      ],
+    });
+
+    const { migrateLocalOrgWorkspaceToWorkos } = await import("./migrate-local-org-to-workos");
+
+    const result = await migrateLocalOrgWorkspaceToWorkos(
+      db,
+      synced.organization.id,
+      identity.user.workosUserId,
+    );
+
+    expect(result.status).toBe("migrated");
+    expect(provisionWorkspaceInWorkosMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        members: [
+          {
+            workosUserId: identity.user.workosUserId,
+            role: identity.membership.role,
+          },
+        ],
+      }),
+    );
+  });
+
   it("skips organizations that already use real WorkOS ids", async () => {
     const identity = createWorkosIdentity();
     const synced = await syncWorkosIdentity(db, identity);
 
     const { migrateLocalOrgWorkspaceToWorkos } = await import("./migrate-local-org-to-workos");
 
-    const result = await migrateLocalOrgWorkspaceToWorkos(db, synced.organization.id);
+    const result = await migrateLocalOrgWorkspaceToWorkos(
+      db,
+      synced.organization.id,
+      identity.user.workosUserId,
+    );
 
     expect(result).toEqual({ status: "skipped", reason: "not_local_org" });
     expect(provisionWorkspaceInWorkosMock).not.toHaveBeenCalled();

--- a/apps/hyperlocalise-web/src/lib/organizations/migrate-local-org-to-workos.ts
+++ b/apps/hyperlocalise-web/src/lib/organizations/migrate-local-org-to-workos.ts
@@ -2,12 +2,12 @@ import { and, eq, inArray, like } from "drizzle-orm";
 
 import type { DatabaseClient } from "@/lib/database";
 import { schema } from "@/lib/database";
-import type { OrganizationMembershipRole } from "@/lib/database/types";
 import { isDeprecatedLocalOrgWorkosId } from "@/lib/billing/autumn-customer";
 import { createLogger } from "@/lib/log";
 import { env } from "@/lib/env";
 import { isInvitedPlaceholderWorkosUserId } from "@/lib/workos/constants";
 import { promoteLocalOrganizationForWorkosUser } from "@/lib/workos/provision-workspace-in-workos";
+import type { PromoteLocalOrganizationForWorkosUserResult } from "@/lib/workos/provision-workspace-in-workos";
 import { serializeWorkosErrorForLog } from "@/lib/workos/serialize-workos-error-for-log";
 import { getWorkosServerClient } from "@/lib/workos/server-client";
 
@@ -33,14 +33,6 @@ function isWorkosMigrationApiEnabled() {
   }
 
   return getWorkosServerClient() !== null;
-}
-
-function workosRoleSlugForMembershipRole(role: OrganizationMembershipRole) {
-  if (role === "owner" || role === "admin") {
-    return role;
-  }
-
-  return "member";
 }
 
 export async function migrateLocalOrgWorkspaceToWorkos(
@@ -74,7 +66,6 @@ export async function migrateLocalOrgWorkspaceToWorkos(
     .select({
       membershipId: schema.organizationMemberships.id,
       role: schema.organizationMemberships.role,
-      localWorkosUserId: schema.users.workosUserId,
     })
     .from(schema.organizationMemberships)
     .innerJoin(schema.users, eq(schema.organizationMemberships.userId, schema.users.id))
@@ -96,14 +87,20 @@ export async function migrateLocalOrgWorkspaceToWorkos(
     return { status: "skipped", reason: "no_members" };
   }
 
+  let promoted: PromoteLocalOrganizationForWorkosUserResult;
   try {
-    const promoted = await promoteLocalOrganizationForWorkosUser({
+    promoted = await promoteLocalOrganizationForWorkosUser({
       localWorkspaceId: organization.id,
       organizationName: organization.name,
       workosUserId: actingWorkosUserId,
       role: actingMembership.role,
     });
+  } catch {
+    // WorkOS failures are logged in promoteLocalOrganizationForWorkosUser.
+    return { status: "failed", organizationId };
+  }
 
+  try {
     await database.transaction(async (tx) => {
       await tx
         .update(schema.organizations)
@@ -123,23 +120,23 @@ export async function migrateLocalOrgWorkspaceToWorkos(
         })
         .where(eq(schema.organizationMemberships.id, actingMembership.membershipId));
     });
-
-    return {
-      status: "migrated",
-      workosOrganizationId: promoted.workosOrganizationId,
-      membershipsUpdated: 1,
-    };
   } catch (error) {
     logger.warn("local_org_workspace_migration_failed", {
       organizationId,
       actingWorkosUserId,
-      localWorkosUserId: actingMembership.localWorkosUserId,
-      roleSlug: workosRoleSlugForMembershipRole(actingMembership.role),
+      failurePhase: "database",
+      workosOrganizationId: promoted.workosOrganizationId,
       ...serializeWorkosErrorForLog(error),
     });
 
     return { status: "failed", organizationId };
   }
+
+  return {
+    status: "migrated",
+    workosOrganizationId: promoted.workosOrganizationId,
+    membershipsUpdated: 1,
+  };
 }
 
 /**

--- a/apps/hyperlocalise-web/src/lib/organizations/migrate-local-org-to-workos.ts
+++ b/apps/hyperlocalise-web/src/lib/organizations/migrate-local-org-to-workos.ts
@@ -9,8 +9,10 @@ import {
   isReplacingWorkosMembership,
 } from "@/lib/workos/constants";
 import { provisionWorkspaceInWorkos } from "@/lib/workos/provision-workspace-in-workos";
+import { serializeWorkosErrorForLog } from "@/lib/workos/serialize-workos-error-for-log";
 import { getWorkosServerClient } from "@/lib/workos/server-client";
 import { env } from "@/lib/env";
+import type { OrganizationMembershipRole } from "@/lib/database/types";
 
 const logger = createLogger("migrate-local-org-to-workos");
 
@@ -67,9 +69,18 @@ function isWorkosMigrationApiEnabled() {
   return getWorkosServerClient() !== null;
 }
 
+function workosRoleSlugForMembershipRole(role: OrganizationMembershipRole) {
+  if (role === "owner" || role === "admin") {
+    return role;
+  }
+
+  return "member";
+}
+
 export async function migrateLocalOrgWorkspaceToWorkos(
   database: DatabaseClient,
   organizationId: string,
+  actingWorkosUserId: string,
 ): Promise<MigrateLocalOrgWorkspaceResult> {
   if (!isWorkosMigrationApiEnabled()) {
     return { status: "skipped", reason: "workos_disabled" };
@@ -100,20 +111,32 @@ export async function migrateLocalOrgWorkspaceToWorkos(
     .innerJoin(schema.users, eq(schema.organizationMemberships.userId, schema.users.id))
     .where(eq(schema.organizationMemberships.organizationId, organizationId));
 
-  const provisionMembers = localMembers
-    .filter(
-      (member) =>
-        !isInvitedPlaceholderWorkosUserId(member.workosUserId) &&
-        !isReplacingWorkosMembership(member.workosMembershipId),
-    )
-    .map((member) => ({
-      workosUserId: member.workosUserId,
-      role: member.role,
-    }));
+  const eligibleMembers = localMembers.filter(
+    (member) =>
+      !isInvitedPlaceholderWorkosUserId(member.workosUserId) &&
+      !isReplacingWorkosMembership(member.workosMembershipId),
+  );
 
-  if (provisionMembers.length === 0) {
+  const actingMember = eligibleMembers.find((member) => member.workosUserId === actingWorkosUserId);
+
+  if (!actingMember) {
+    logger.warn("local_org_workspace_migration_skipped", {
+      organizationId,
+      reason: "acting_user_not_eligible",
+      localMemberCount: localMembers.length,
+      eligibleMemberCount: eligibleMembers.length,
+    });
+
     return { status: "skipped", reason: "no_members" };
   }
+
+  const provisionMembers = [
+    {
+      workosUserId: actingMember.workosUserId,
+      role: actingMember.role,
+    },
+  ];
+  const deferredMemberCount = eligibleMembers.length - provisionMembers.length;
 
   try {
     const provisioned = await provisionWorkspaceInWorkos({
@@ -161,7 +184,12 @@ export async function migrateLocalOrgWorkspaceToWorkos(
   } catch (error) {
     logger.warn("local_org_workspace_migration_failed", {
       organizationId,
-      errorName: error instanceof Error ? error.name : "unknown_error",
+      actingWorkosUserId,
+      localMemberCount: localMembers.length,
+      eligibleMemberCount: eligibleMembers.length,
+      deferredMemberCount,
+      roleSlug: workosRoleSlugForMembershipRole(actingMember.role),
+      ...serializeWorkosErrorForLog(error),
     });
 
     return { status: "failed", organizationId };
@@ -187,7 +215,7 @@ export async function migrateLocalOrgWorkspacesForUser(
   let skipped = 0;
 
   for (const { organizationId } of organizations) {
-    const result = await migrateLocalOrgWorkspaceToWorkos(database, organizationId);
+    const result = await migrateLocalOrgWorkspaceToWorkos(database, organizationId, workosUserId);
     if (result.status === "migrated") {
       migrated += 1;
       continue;

--- a/apps/hyperlocalise-web/src/lib/organizations/migrate-local-org-to-workos.ts
+++ b/apps/hyperlocalise-web/src/lib/organizations/migrate-local-org-to-workos.ts
@@ -2,17 +2,14 @@ import { and, eq, inArray, like } from "drizzle-orm";
 
 import type { DatabaseClient } from "@/lib/database";
 import { schema } from "@/lib/database";
+import type { OrganizationMembershipRole } from "@/lib/database/types";
 import { isDeprecatedLocalOrgWorkosId } from "@/lib/billing/autumn-customer";
 import { createLogger } from "@/lib/log";
-import {
-  isInvitedPlaceholderWorkosUserId,
-  isReplacingWorkosMembership,
-} from "@/lib/workos/constants";
-import { provisionWorkspaceInWorkos } from "@/lib/workos/provision-workspace-in-workos";
+import { env } from "@/lib/env";
+import { isInvitedPlaceholderWorkosUserId } from "@/lib/workos/constants";
+import { promoteLocalOrganizationForWorkosUser } from "@/lib/workos/provision-workspace-in-workos";
 import { serializeWorkosErrorForLog } from "@/lib/workos/serialize-workos-error-for-log";
 import { getWorkosServerClient } from "@/lib/workos/server-client";
-import { env } from "@/lib/env";
-import type { OrganizationMembershipRole } from "@/lib/database/types";
 
 const logger = createLogger("migrate-local-org-to-workos");
 
@@ -24,37 +21,6 @@ export type LocalOrgWorkspaceSummary = {
   slug: string | null;
   lifecycleStatus: "active" | "archived" | "deprecated";
 };
-
-export async function listLocalOrgWorkspacesForUser(
-  database: DatabaseClient,
-  workosUserId: string,
-): Promise<LocalOrgWorkspaceSummary[]> {
-  if (isInvitedPlaceholderWorkosUserId(workosUserId)) {
-    return [];
-  }
-
-  return database
-    .select({
-      organizationId: schema.organizations.id,
-      name: schema.organizations.name,
-      slug: schema.organizations.slug,
-      lifecycleStatus: schema.organizations.lifecycleStatus,
-    })
-    .from(schema.organizationMemberships)
-    .innerJoin(schema.users, eq(schema.organizationMemberships.userId, schema.users.id))
-    .innerJoin(
-      schema.organizations,
-      eq(schema.organizationMemberships.organizationId, schema.organizations.id),
-    )
-    .where(
-      and(
-        eq(schema.users.workosUserId, workosUserId),
-        like(schema.organizations.workosOrganizationId, LOCAL_ORG_WORKOS_ID_PATTERN),
-        inArray(schema.organizations.lifecycleStatus, ["active", "deprecated"]),
-      ),
-    )
-    .orderBy(schema.organizations.name);
-}
 
 export type MigrateLocalOrgWorkspaceResult =
   | { status: "skipped"; reason: "not_local_org" | "workos_disabled" | "no_members" }
@@ -86,6 +52,10 @@ export async function migrateLocalOrgWorkspaceToWorkos(
     return { status: "skipped", reason: "workos_disabled" };
   }
 
+  if (isInvitedPlaceholderWorkosUserId(actingWorkosUserId)) {
+    return { status: "skipped", reason: "no_members" };
+  }
+
   const [organization] = await database
     .select({
       id: schema.organizations.id,
@@ -100,95 +70,71 @@ export async function migrateLocalOrgWorkspaceToWorkos(
     return { status: "skipped", reason: "not_local_org" };
   }
 
-  const localMembers = await database
+  const [actingMembership] = await database
     .select({
       membershipId: schema.organizationMemberships.id,
       role: schema.organizationMemberships.role,
-      workosMembershipId: schema.organizationMemberships.workosMembershipId,
-      workosUserId: schema.users.workosUserId,
+      localWorkosUserId: schema.users.workosUserId,
     })
     .from(schema.organizationMemberships)
     .innerJoin(schema.users, eq(schema.organizationMemberships.userId, schema.users.id))
-    .where(eq(schema.organizationMemberships.organizationId, organizationId));
+    .where(
+      and(
+        eq(schema.organizationMemberships.organizationId, organizationId),
+        eq(schema.users.workosUserId, actingWorkosUserId),
+      ),
+    )
+    .limit(1);
 
-  const eligibleMembers = localMembers.filter(
-    (member) =>
-      !isInvitedPlaceholderWorkosUserId(member.workosUserId) &&
-      !isReplacingWorkosMembership(member.workosMembershipId),
-  );
-
-  const actingMember = eligibleMembers.find((member) => member.workosUserId === actingWorkosUserId);
-
-  if (!actingMember) {
+  if (!actingMembership) {
     logger.warn("local_org_workspace_migration_skipped", {
       organizationId,
-      reason: "acting_user_not_eligible",
-      localMemberCount: localMembers.length,
-      eligibleMemberCount: eligibleMembers.length,
+      reason: "acting_user_not_member",
+      actingWorkosUserId,
     });
 
     return { status: "skipped", reason: "no_members" };
   }
 
-  const provisionMembers = [
-    {
-      workosUserId: actingMember.workosUserId,
-      role: actingMember.role,
-    },
-  ];
-  const deferredMemberCount = eligibleMembers.length - provisionMembers.length;
-
   try {
-    const provisioned = await provisionWorkspaceInWorkos({
+    const promoted = await promoteLocalOrganizationForWorkosUser({
       localWorkspaceId: organization.id,
       organizationName: organization.name,
-      members: provisionMembers,
+      workosUserId: actingWorkosUserId,
+      role: actingMembership.role,
     });
-
-    const membershipByUserId = new Map(
-      provisioned.members.map((member) => [member.workosUserId, member]),
-    );
 
     await database.transaction(async (tx) => {
       await tx
         .update(schema.organizations)
         .set({
-          workosOrganizationId: provisioned.workosOrganizationId,
+          workosOrganizationId: promoted.workosOrganizationId,
           lifecycleStatus: "active",
           updatedAt: new Date(),
         })
         .where(eq(schema.organizations.id, organizationId));
 
-      for (const member of localMembers) {
-        const remote = membershipByUserId.get(member.workosUserId);
-        if (!remote) {
-          continue;
-        }
-
-        await tx
-          .update(schema.organizationMemberships)
-          .set({
-            workosMembershipId: remote.workosMembershipId,
-            role: remote.role,
-            updatedAt: new Date(),
-          })
-          .where(eq(schema.organizationMemberships.id, member.membershipId));
-      }
+      await tx
+        .update(schema.organizationMemberships)
+        .set({
+          workosMembershipId: promoted.workosMembershipId,
+          role: promoted.role,
+          updatedAt: new Date(),
+        })
+        .where(eq(schema.organizationMemberships.id, actingMembership.membershipId));
     });
 
     return {
       status: "migrated",
-      workosOrganizationId: provisioned.workosOrganizationId,
-      membershipsUpdated: provisioned.members.length,
+      workosOrganizationId: promoted.workosOrganizationId,
+      membershipsUpdated: 1,
     };
   } catch (error) {
     logger.warn("local_org_workspace_migration_failed", {
       organizationId,
       actingWorkosUserId,
-      localMemberCount: localMembers.length,
-      eligibleMemberCount: eligibleMembers.length,
-      deferredMemberCount,
-      roleSlug: workosRoleSlugForMembershipRole(actingMember.role),
+      localWorkosUserId: actingMembership.localWorkosUserId,
+      roleSlug: workosRoleSlugForMembershipRole(actingMembership.role),
       ...serializeWorkosErrorForLog(error),
     });
 
@@ -230,4 +176,35 @@ export async function migrateLocalOrgWorkspacesForUser(
   }
 
   return { migrated, failed, skipped };
+}
+
+export async function listLocalOrgWorkspacesForUser(
+  database: DatabaseClient,
+  workosUserId: string,
+): Promise<LocalOrgWorkspaceSummary[]> {
+  if (isInvitedPlaceholderWorkosUserId(workosUserId)) {
+    return [];
+  }
+
+  return database
+    .select({
+      organizationId: schema.organizations.id,
+      name: schema.organizations.name,
+      slug: schema.organizations.slug,
+      lifecycleStatus: schema.organizations.lifecycleStatus,
+    })
+    .from(schema.organizationMemberships)
+    .innerJoin(schema.users, eq(schema.organizationMemberships.userId, schema.users.id))
+    .innerJoin(
+      schema.organizations,
+      eq(schema.organizationMemberships.organizationId, schema.organizations.id),
+    )
+    .where(
+      and(
+        eq(schema.users.workosUserId, workosUserId),
+        like(schema.organizations.workosOrganizationId, LOCAL_ORG_WORKOS_ID_PATTERN),
+        inArray(schema.organizations.lifecycleStatus, ["active", "deprecated"]),
+      ),
+    )
+    .orderBy(schema.organizations.name);
 }

--- a/apps/hyperlocalise-web/src/lib/workos/membership-role.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/membership-role.ts
@@ -1,5 +1,13 @@
 import type { OrganizationMembershipRole } from "@/lib/database/types";
 
+export function membershipRoleToWorkosRoleSlug(role: OrganizationMembershipRole) {
+  if (role === "owner" || role === "admin") {
+    return role;
+  }
+
+  return "member";
+}
+
 export function workosRoleSlugToMembershipRole(
   roleSlug: string | undefined,
 ): OrganizationMembershipRole {

--- a/apps/hyperlocalise-web/src/lib/workos/provision-workspace-in-workos.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/provision-workspace-in-workos.ts
@@ -1,5 +1,9 @@
 import type { OrganizationMembershipRole } from "@/lib/database/types";
 import { createLogger } from "@/lib/log";
+import {
+  membershipRoleFromUnknownRoleField,
+  membershipRoleToWorkosRoleSlug,
+} from "@/lib/workos/membership-role";
 import { getWorkosServerClient } from "@/lib/workos/server-client";
 import { serializeWorkosErrorForLog } from "@/lib/workos/serialize-workos-error-for-log";
 
@@ -26,14 +30,6 @@ export type ProvisionWorkspaceInWorkosResult = {
   workosOrganizationId: string;
   members: ProvisionedWorkspaceMember[];
 };
-
-function membershipRoleToWorkosRoleSlug(role: OrganizationMembershipRole) {
-  if (role === "owner" || role === "admin") {
-    return role;
-  }
-
-  return "member";
-}
 
 export async function deleteProvisionedWorkosOrganization(workosOrganizationId: string) {
   const workos = getWorkosServerClient();
@@ -102,7 +98,7 @@ export async function promoteLocalOrganizationForWorkosUser(
       return {
         workosOrganizationId: organization.id,
         workosMembershipId: existingMembership.id,
-        role: input.role,
+        role: membershipRoleFromUnknownRoleField(existingMembership.role),
       };
     }
 
@@ -186,7 +182,7 @@ export async function provisionWorkspaceInWorkos(
         provisionedMembers.push({
           workosUserId: member.workosUserId,
           workosMembershipId: existing.id,
-          role: member.role,
+          role: membershipRoleFromUnknownRoleField(existing.role),
         });
         continue;
       }

--- a/apps/hyperlocalise-web/src/lib/workos/provision-workspace-in-workos.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/provision-workspace-in-workos.ts
@@ -1,5 +1,9 @@
 import type { OrganizationMembershipRole } from "@/lib/database/types";
+import { createLogger } from "@/lib/log";
 import { getWorkosServerClient } from "@/lib/workos/server-client";
+import { serializeWorkosErrorForLog } from "@/lib/workos/serialize-workos-error-for-log";
+
+const logger = createLogger("provision-workspace-in-workos");
 
 export type ProvisionWorkspaceMember = {
   workosUserId: string;
@@ -58,6 +62,12 @@ export async function provisionWorkspaceInWorkos(
   }
 
   let workosOrganizationId: string | undefined;
+  let lastAttemptedMember:
+    | {
+        workosUserId: string;
+        roleSlug: string;
+      }
+    | undefined;
 
   try {
     const organization = await workos.organizations.createOrganization(
@@ -94,10 +104,16 @@ export async function provisionWorkspaceInWorkos(
         continue;
       }
 
+      const roleSlug = membershipRoleToWorkosRoleSlug(member.role);
+      lastAttemptedMember = {
+        workosUserId: member.workosUserId,
+        roleSlug,
+      };
+
       const created = await workos.userManagement.createOrganizationMembership({
         organizationId: organization.id,
         userId: member.workosUserId,
-        roleSlug: membershipRoleToWorkosRoleSlug(member.role),
+        roleSlug,
       });
 
       provisionedMembers.push({
@@ -115,6 +131,15 @@ export async function provisionWorkspaceInWorkos(
     if (workosOrganizationId) {
       await deleteProvisionedWorkosOrganization(workosOrganizationId);
     }
+
+    logger.warn("workos_workspace_provision_failed", {
+      localWorkspaceId: input.localWorkspaceId,
+      workosOrganizationId,
+      memberCount: input.members.length,
+      lastAttemptedWorkosUserId: lastAttemptedMember?.workosUserId,
+      lastAttemptedRoleSlug: lastAttemptedMember?.roleSlug,
+      ...serializeWorkosErrorForLog(error),
+    });
 
     throw error;
   }

--- a/apps/hyperlocalise-web/src/lib/workos/provision-workspace-in-workos.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/provision-workspace-in-workos.ts
@@ -48,6 +48,93 @@ export async function deleteProvisionedWorkosOrganization(workosOrganizationId: 
   }
 }
 
+export type PromoteLocalOrganizationForWorkosUserInput = {
+  localWorkspaceId: string;
+  organizationName: string;
+  workosUserId: string;
+  role: OrganizationMembershipRole;
+};
+
+export type PromoteLocalOrganizationForWorkosUserResult = {
+  workosOrganizationId: string;
+  workosMembershipId: string;
+  role: OrganizationMembershipRole;
+};
+
+/**
+ * Promotes a legacy local workspace by creating a WorkOS organization and assigning
+ * an existing WorkOS user. Does not create users or touch other members.
+ */
+export async function promoteLocalOrganizationForWorkosUser(
+  input: PromoteLocalOrganizationForWorkosUserInput,
+): Promise<PromoteLocalOrganizationForWorkosUserResult> {
+  const workos = getWorkosServerClient();
+
+  if (!workos) {
+    throw new Error("workos_organization_required");
+  }
+
+  let workosOrganizationId: string | undefined;
+  let roleSlug: string | undefined;
+
+  try {
+    const organization = await workos.organizations.createOrganization(
+      {
+        name: input.organizationName,
+        externalId: input.localWorkspaceId,
+        metadata: {
+          hyperlocalise_local_organization_id: input.localWorkspaceId,
+        },
+      },
+      { idempotencyKey: `workspace:${input.localWorkspaceId}` },
+    );
+    workosOrganizationId = organization.id;
+
+    const existingMembershipsPage = await workos.userManagement.listOrganizationMemberships({
+      organizationId: organization.id,
+      userId: input.workosUserId,
+      statuses: ["active"],
+    });
+    const existingMemberships = await existingMembershipsPage.autoPagination();
+    const existingMembership = existingMemberships[0];
+
+    if (existingMembership) {
+      return {
+        workosOrganizationId: organization.id,
+        workosMembershipId: existingMembership.id,
+        role: input.role,
+      };
+    }
+
+    roleSlug = membershipRoleToWorkosRoleSlug(input.role);
+    const createdMembership = await workos.userManagement.createOrganizationMembership({
+      organizationId: organization.id,
+      userId: input.workosUserId,
+      roleSlug,
+    });
+
+    return {
+      workosOrganizationId: organization.id,
+      workosMembershipId: createdMembership.id,
+      role: input.role,
+    };
+  } catch (error) {
+    if (workosOrganizationId) {
+      await deleteProvisionedWorkosOrganization(workosOrganizationId);
+    }
+
+    logger.warn("workos_local_org_promotion_failed", {
+      localWorkspaceId: input.localWorkspaceId,
+      workosOrganizationId,
+      workosUserId: input.workosUserId,
+      roleSlug,
+      ...serializeWorkosErrorForLog(error),
+    });
+
+    throw error;
+  }
+}
+
 /**
  * Creates (or idempotently reuses) a WorkOS organization and active memberships.
  * Uses `externalId = localWorkspaceId` so legacy local workspaces can be promoted safely.

--- a/apps/hyperlocalise-web/src/lib/workos/serialize-workos-error-for-log.test.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/serialize-workos-error-for-log.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { serializeWorkosErrorForLog } from "./serialize-workos-error-for-log";
+
+describe("serializeWorkosErrorForLog", () => {
+  it("captures WorkOS request exception fields", () => {
+    const error = new Error("The role is invalid");
+    error.name = "UnprocessableEntityException";
+    Object.assign(error, {
+      code: "invalid_role",
+      requestID: "req_123",
+    });
+
+    expect(serializeWorkosErrorForLog(error)).toEqual({
+      errorName: "UnprocessableEntityException",
+      errorMessage: "The role is invalid",
+      workosErrorCode: "invalid_role",
+      workosRequestId: "req_123",
+    });
+  });
+
+  it("returns unknown_error for non-error values", () => {
+    expect(serializeWorkosErrorForLog("boom")).toEqual({ errorName: "unknown_error" });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/workos/serialize-workos-error-for-log.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/serialize-workos-error-for-log.ts
@@ -1,0 +1,27 @@
+export type WorkosErrorLogContext = {
+  errorName: string;
+  errorMessage?: string;
+  workosErrorCode?: string;
+  workosRequestId?: string;
+};
+
+export function serializeWorkosErrorForLog(error: unknown): WorkosErrorLogContext {
+  if (!(error instanceof Error)) {
+    return { errorName: "unknown_error" };
+  }
+
+  const context: WorkosErrorLogContext = {
+    errorName: error.name,
+    errorMessage: error.message,
+  };
+
+  if ("code" in error && typeof error.code === "string") {
+    context.workosErrorCode = error.code;
+  }
+
+  if ("requestID" in error && typeof error.requestID === "string") {
+    context.workosRequestId = error.requestID;
+  }
+
+  return context;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses four code review items on the local org → WorkOS migration path.

### Changes

1. **Redundant log field** — Removed `localWorkosUserId` from the acting-membership select and failure log (it always matched `actingWorkosUserId`).

2. **Duplicate role-slug helper** — Moved `membershipRoleToWorkosRoleSlug` into `membership-role.ts` alongside the inverse `workosRoleSlugToMembershipRole`, and reused it from `provision-workspace-in-workos.ts`.

3. **Idempotent role sync** — When an existing WorkOS membership is found during promotion/provisioning, the returned role now comes from WorkOS via `membershipRoleFromUnknownRoleField` instead of the local input role.

4. **Double logging** — Split WorkOS promotion from the DB transaction in `migrateLocalOrgWorkspaceToWorkos`. WorkOS failures rely on `workos_local_org_promotion_failed` only; `local_org_workspace_migration_failed` is emitted for database transaction failures with `failurePhase: "database"`.

### Testing

- `vp check --fix`
- `vp test src/lib/organizations/migrate-local-org-to-workos.test.ts src/lib/workos/serialize-workos-error-for-log.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34b84ba1-e11d-4a73-9498-1f18a478c018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34b84ba1-e11d-4a73-9498-1f18a478c018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

