### PR TITLE
🧪 Scout: protect significant whitespace in PO msgid keys

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -39,3 +39,7 @@
 ## 2025-06-05 - [Typed ICU Block Invariants]
 **Learning:** ICU elements for `number`, `date`, and `time` were previously excluded from `ICUBlocks` metadata, which is used for structural parity checks. While their arguments were extracted as placeholders, their specific types were missing from the structural signature. This could allow a translation to change the type (e.g., from `date` to `number`) without triggering a structural mismatch.
 **Action:** Ensure all "typed" ICU elements (`NumberElement`, `DateElement`, `TimeElement`) are appended to `ICUBlocks` during invariant collection to protect the structural integrity of complex messages.
+
+## 2025-06-12 - [PO msgid Significance of Whitespace]
+**Learning:** In gettext/PO files, `msgid` keys are the source of truth for translation lookups, and leading/trailing whitespace is significant. Over-eagerly trimming spaces from these keys during parsing causes lookup failures in downstream systems.
+**Action:** Always preserve the exact literal string for `msgid` keys, except for the header entry (`msgid ""`) which is standardly skipped in message maps.

--- a/internal/i18n/translationfileparser/po_parser.go
+++ b/internal/i18n/translationfileparser/po_parser.go
@@ -22,7 +22,7 @@ func (p POFileParser) Parse(content []byte) (map[string]string, error) {
 		if !seenMsgID || !seenMsgStr {
 			return
 		}
-		key := strings.TrimSpace(currentMsgID.String())
+		key := currentMsgID.String()
 		if key == "" {
 			return // skip header entry (msgid "")
 		}

--- a/internal/i18n/translationfileparser/po_parser_test.go
+++ b/internal/i18n/translationfileparser/po_parser_test.go
@@ -177,3 +177,34 @@ msgstr "Hello "
 		t.Errorf("expected indented cleared continuation lines, got:\n%s", content)
 	}
 }
+
+func TestPOParserPreservesSpacesInMsgID(t *testing.T) {
+	content := []byte(`msgid ""
+msgstr ""
+"Language: en-US\n"
+
+msgid " leading"
+msgstr "val1"
+
+msgid "trailing "
+msgstr "val2"
+
+msgid " "
+msgstr "val3"
+`)
+
+	got, err := (POFileParser{}).Parse(content)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	expected := map[string]string{
+		" leading":  "val1",
+		"trailing ": "val2",
+		" ":         "val3",
+	}
+
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("got %v, want %v", got, expected)
+	}
+}


### PR DESCRIPTION
- 💡 What: Removed `strings.TrimSpace` from `msgid` extraction in `POFileParser.Parse` and added a regression test.
- 🎯 Why: In PO files, leading and trailing spaces in `msgid` are significant for translation lookups. Trimming them causes mismatches.
- 🧩 Scope: `internal/i18n/translationfileparser/po_parser.go` and `internal/i18n/translationfileparser/po_parser_test.go`.
- ✅ Verification: Ran `go test -v ./internal/i18n/translationfileparser` and `make lint`.
- 🛡️ Confidence: Prevents regression where source messages with intentional padding (common in some UI layouts) fail to find their translations.

---
*PR created automatically by Jules for task [5766891890295835789](https://jules.google.com/task/5766891890295835789) started by @cungminh2710*