### PR TITLE
🎨 Palette: improve app shell navigation and search UX

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -14,6 +14,10 @@
 **Learning:** In , several components were found to have children (icons, accessible text) placed outside the component passed to the `render` prop of `TooltipTrigger`. This pattern can lead to empty interactive elements or broken event delegation. Consistently nesting all content within the rendered component ensures that accessibility properties (like ARIA labels or screen-reader text) are correctly associated with the interactive trigger.
 **Action:** When using `<TooltipTrigger render={<Component ... />} >`, always place the component's children inside `<Component>` rather than as children of `TooltipTrigger`.
 
+## 2026-05-26 - [Sidebar Navigation Accessibility & Keyboard Shortcuts]
+**Learning:** In `apps/hyperlocalise-web`, sidebar components that collapse into an icon-only view must provide a `Tooltip` for the trigger to maintain accessibility. Additionally, common utility components like `InputGroupInput` must support `React.forwardRef` to enable programmatic focus management, which is essential for implementing keyboard shortcuts (e.g., 'f' for search) that enhance power-user productivity.
+**Action:** Always wrap collapsed sidebar items in `Tooltip` and ensure input primitives in the design system forward refs to support focus-based interactions.
+
 ## 2026-05-25 - [TooltipTrigger Structural Consistency]
 **Learning:** In `apps/hyperlocalise-web`, several components were found to have children (icons, accessible text) placed outside the component passed to the `render` prop of `TooltipTrigger`. This pattern can lead to empty interactive elements or broken event delegation. Consistently nesting all content within the rendered component ensures that accessibility properties (like ARIA labels or screen-reader text) are correctly associated with the interactive trigger.
 **Action:** When using `<TooltipTrigger render={<Component ... />} >`, always place the component's children inside `<Component>` rather than as children of `TooltipTrigger`.

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import * as React from "react";
 import type { CSSProperties, ReactNode } from "react";
 import Image from "next/image";
 import { usePathname } from "next/navigation";
@@ -7,12 +8,8 @@ import { ArrowRight01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 
 import { TeamSwitcher } from "@/components/team-switcher";
-import {
-  InputGroup,
-  InputGroupAddon,
-  InputGroupInput,
-  InputGroupText,
-} from "@/components/ui/input-group";
+import { Kbd } from "@/components/ui/kbd";
+import { InputGroup, InputGroupAddon, InputGroupInput } from "@/components/ui/input-group";
 import {
   Sidebar,
   SidebarContent,
@@ -57,6 +54,24 @@ export function AppShellClient({
 }: AppShellClientProps) {
   const pathname = usePathname();
   const pageTitle = getAppShellTitle(pathname);
+  const searchInputRef = React.useRef<HTMLInputElement>(null);
+
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.key === "f" &&
+        !["INPUT", "TEXTAREA"].includes((event.target as HTMLElement).tagName) &&
+        !event.metaKey &&
+        !event.ctrlKey
+      ) {
+        event.preventDefault();
+        searchInputRef.current?.focus();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
 
   return (
     <SidebarProvider
@@ -102,12 +117,13 @@ export function AppShellClient({
           <div className="flex items-center gap-2 group-data-[collapsible=icon]:hidden">
             <InputGroup className="h-9 rounded-xl border-sidebar-border bg-sidebar-accent text-sidebar-foreground">
               <InputGroupInput
+                ref={searchInputRef}
                 aria-label="Find"
                 placeholder="Find…"
                 className="text-sm text-sidebar-foreground placeholder:text-sidebar-foreground/28"
               />
               <InputGroupAddon align="inline-end">
-                <InputGroupText className="text-xs text-sidebar-foreground/50">F</InputGroupText>
+                <Kbd className="bg-sidebar-foreground/10 text-sidebar-foreground/50">F</Kbd>
               </InputGroupAddon>
             </InputGroup>
           </div>

--- a/apps/hyperlocalise-web/src/components/app-shell/nav-user.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/nav-user.tsx
@@ -11,6 +11,7 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -41,7 +42,7 @@ export function NavUser({
     avatar: string;
   };
 }) {
-  const { isMobile } = useSidebar();
+  const { isMobile, state } = useSidebar();
   const initials =
     user.name
       .split(" ")
@@ -54,28 +55,39 @@ export function NavUser({
     <SidebarMenu>
       <SidebarMenuItem>
         <DropdownMenu>
-          <DropdownMenuTrigger
-            render={
-              <SidebarMenuButton
-                size="lg"
-                className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
-              />
-            }
-          >
-            <Avatar className="h-8 w-8 rounded-lg grayscale">
-              <AvatarImage src={user.avatar} alt={user.name} />
-              <AvatarFallback className="rounded-lg">{initials}</AvatarFallback>
-            </Avatar>
-            <div className="grid flex-1 text-left text-sm leading-tight">
-              <span className="truncate font-medium">{user.name}</span>
-              <span className="truncate text-xs text-muted-foreground">{organizationName}</span>
-            </div>
-            <HugeiconsIcon
-              icon={MoreVerticalCircle01Icon}
-              strokeWidth={2}
-              className="ml-auto size-4"
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <DropdownMenuTrigger
+                  render={
+                    <SidebarMenuButton
+                      size="lg"
+                      className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+                    />
+                  }
+                >
+                  <Avatar className="h-8 w-8 rounded-lg grayscale">
+                    <AvatarImage src={user.avatar} alt={user.name} />
+                    <AvatarFallback className="rounded-lg">{initials}</AvatarFallback>
+                  </Avatar>
+                  <div className="grid flex-1 text-left text-sm leading-tight group-data-[collapsible=icon]:hidden">
+                    <span className="truncate font-medium">{user.name}</span>
+                    <span className="truncate text-xs text-muted-foreground">
+                      {organizationName}
+                    </span>
+                  </div>
+                  <HugeiconsIcon
+                    icon={MoreVerticalCircle01Icon}
+                    strokeWidth={2}
+                    className="ml-auto size-4 group-data-[collapsible=icon]:hidden"
+                  />
+                </DropdownMenuTrigger>
+              }
             />
-          </DropdownMenuTrigger>
+            <TooltipContent side="right" align="center" hidden={state !== "collapsed" || isMobile}>
+              {user.name}
+            </TooltipContent>
+          </Tooltip>
           <DropdownMenuContent
             className="w-(--anchor-width) min-w-56 rounded-lg"
             side={isMobile ? "bottom" : "right"}

--- a/apps/hyperlocalise-web/src/components/ui/input-group.tsx
+++ b/apps/hyperlocalise-web/src/components/ui/input-group.tsx
@@ -110,31 +110,39 @@ function InputGroupText({ className, ...props }: React.ComponentProps<"span">) {
   );
 }
 
-function InputGroupInput({ className, ...props }: React.ComponentProps<"input">) {
-  return (
-    <Input
-      data-slot="input-group-control"
-      className={cn(
-        "flex-1 rounded-none border-0 bg-transparent shadow-none ring-0 focus-visible:ring-0 aria-invalid:ring-0 dark:bg-transparent",
-        className,
-      )}
-      {...props}
-    />
-  );
-}
+const InputGroupInput = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
+  ({ className, ...props }, ref) => {
+    return (
+      <Input
+        ref={ref}
+        data-slot="input-group-control"
+        className={cn(
+          "flex-1 rounded-none border-0 bg-transparent shadow-none ring-0 focus-visible:ring-0 aria-invalid:ring-0 dark:bg-transparent",
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+InputGroupInput.displayName = "InputGroupInput";
 
-function InputGroupTextarea({ className, ...props }: React.ComponentProps<"textarea">) {
-  return (
-    <Textarea
-      data-slot="input-group-control"
-      className={cn(
-        "flex-1 resize-none rounded-none border-0 bg-transparent py-2 shadow-none ring-0 focus-visible:ring-0 aria-invalid:ring-0 dark:bg-transparent",
-        className,
-      )}
-      {...props}
-    />
-  );
-}
+const InputGroupTextarea = React.forwardRef<HTMLTextAreaElement, React.ComponentProps<"textarea">>(
+  ({ className, ...props }, ref) => {
+    return (
+      <Textarea
+        ref={ref}
+        data-slot="input-group-control"
+        className={cn(
+          "flex-1 resize-none rounded-none border-0 bg-transparent py-2 shadow-none ring-0 focus-visible:ring-0 aria-invalid:ring-0 dark:bg-transparent",
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+InputGroupTextarea.displayName = "InputGroupTextarea";
 
 export {
   InputGroup,


### PR DESCRIPTION
### 💡 What
This PR adds three micro-UX improvements to the app shell:
1. **Search Focus Shortcut**: Users can now press the 'f' key to quickly focus the search bar. The visual hint was also upgraded to a `Kbd` component.
2. **Sidebar User Tooltip**: When the sidebar is collapsed, the user profile now shows a tooltip with the user's name on hover/focus.
3. **Ref Forwarding**: `InputGroupInput` and `InputGroupTextarea` now support `forwardRef`, enabling the search shortcut and future programmatic focus needs.

### 🎯 Why
These changes make the interface feel more professional and accessible:
- Shortcuts improve productivity for power users.
- Tooltips on collapsed items are essential for understanding icon-only navigation.
- Consistent ref forwarding is a requirement for a robust component library.

### ♿ Accessibility
- Added `Tooltip` to the user profile button in the collapsed sidebar state.
- Ensured user name and organization name are correctly hidden from screen readers/visuals when in icon-only mode to avoid clutter and ensure the tooltip remains the primary label.
- Used `aria-label` on the search input.

---
*PR created automatically by Jules for task [15550019650562026149](https://jules.google.com/task/15550019650562026149) started by @cungminh2710*