### PR TITLE
feat(github): implement push source automation from repositories (HL-446)

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/github-installation/github-installation.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/github-installation/github-installation.schema.ts
@@ -21,7 +21,12 @@ export const i18nSetupRunIdParamSchema = z.object({
 const githubRepositoryAutomationSettingsPartialSchema = z.object({
   workflows: z
     .object({
-      pushSource: z.object({ enabled: z.boolean().optional() }).optional(),
+      pushSource: z
+        .object({
+          enabled: z.boolean().optional(),
+          projectId: z.string().trim().min(1).optional(),
+        })
+        .optional(),
       pullTranslations: z.object({ enabled: z.boolean().optional() }).optional(),
       validation: z.object({ enabled: z.boolean().optional() }).optional(),
     })

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-commit-range.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-commit-range.ts
@@ -10,12 +10,14 @@ function parseRepositoryOwnerRepo(fullName: string): { owner: string; repo: stri
   return { owner, repo };
 }
 
-export async function resolveGithubRepositoryAutomationCommitRange(
-  job: GithubRepositoryAutomationJobWithRepository,
-): Promise<{
+export type GithubRepositoryAutomationCommitRange = {
   commitBefore: string | null;
   commitAfter: string;
-}> {
+};
+
+export async function resolveGithubRepositoryAutomationCommitRange(
+  job: GithubRepositoryAutomationJobWithRepository,
+): Promise<GithubRepositoryAutomationCommitRange> {
   if (job.commitAfter) {
     return {
       commitBefore: job.commitBefore,

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-commit-range.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-commit-range.ts
@@ -1,0 +1,48 @@
+import type { GithubRepositoryAutomationJobWithRepository } from "./github-repository-automation-jobs";
+import { findLatestSucceededCommitAfter } from "./github-repository-automation-jobs";
+import { resolveDefaultBranchHeadSha } from "./github-repository-automation-sandbox";
+
+function parseRepositoryOwnerRepo(fullName: string): { owner: string; repo: string } {
+  const [owner, repo] = fullName.split("/");
+  if (!owner || !repo) {
+    throw new Error("invalid repository full name");
+  }
+  return { owner, repo };
+}
+
+export async function resolveGithubRepositoryAutomationCommitRange(
+  job: GithubRepositoryAutomationJobWithRepository,
+): Promise<{
+  commitBefore: string | null;
+  commitAfter: string;
+}> {
+  if (job.commitAfter) {
+    return {
+      commitBefore: job.commitBefore,
+      commitAfter: job.commitAfter,
+    };
+  }
+
+  const branch = job.triggerBranch ?? job.defaultBranch;
+  if (!branch) {
+    throw new Error("github_repository_automation_branch_not_resolved");
+  }
+
+  const { owner, repo } = parseRepositoryOwnerRepo(job.repositoryFullName);
+  const head = await resolveDefaultBranchHeadSha({
+    installationId: job.githubInstallationId,
+    owner,
+    repo,
+    branch,
+  });
+
+  const previousCommit = await findLatestSucceededCommitAfter({
+    githubInstallationRepositoryId: job.githubInstallationRepositoryId,
+    triggerBranch: branch,
+  });
+
+  return {
+    commitBefore: previousCommit,
+    commitAfter: head.sha,
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-commits.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-commits.test.ts
@@ -3,11 +3,13 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   buildCommitRangeLogArgs,
   buildCommitScopedDiffArgs,
+  buildCommitScopedNameStatusDiffArgs,
   buildCommitScopedPatchArgs,
   classifyHlCheckReport,
   isZeroCommitSha,
   parseCommitLogLines,
   parseNameOnlyDiffPaths,
+  parseNameStatusDiffPathsForUpload,
   shouldSkipCommitForPaths,
   shouldSkipCommitForSourcePaths,
 } from "./github-repository-automation-commits";
@@ -59,12 +61,37 @@ describe("github repository automation commits", () => {
     ).toEqual(["diff", "--name-only", "parent..child", "--", "locales/**"]);
 
     expect(
+      buildCommitScopedNameStatusDiffArgs({
+        parentSha: "parent",
+        commitSha: "child",
+        paths: ["locales/**"],
+      }),
+    ).toEqual(["diff", "--name-status", "parent..child", "--", "locales/**"]);
+
+    expect(
       buildCommitScopedPatchArgs({
         parentSha: null,
         commitSha: "root",
         paths: ["locales/en.json"],
       }),
     ).toEqual(["diff", "root", "--", "locales/en.json"]);
+  });
+
+  it("parses name-status diff paths for upload excluding deletions", () => {
+    const output = [
+      "M\tlocales/en.json",
+      "D\tlocales/removed.json",
+      "A\tlocales/new.json",
+      "R100\tlocales/old.json\tlocales/renamed.json",
+      "C100\tlocales/copy-src.json\tlocales/copy-dst.json",
+    ].join("\n");
+
+    expect(parseNameStatusDiffPathsForUpload(output)).toEqual([
+      "locales/copy-dst.json",
+      "locales/en.json",
+      "locales/new.json",
+      "locales/renamed.json",
+    ]);
   });
 
   it("skips commits without configured localisation path changes", () => {

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-commits.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-commits.test.ts
@@ -9,6 +9,7 @@ import {
   parseCommitLogLines,
   parseNameOnlyDiffPaths,
   shouldSkipCommitForPaths,
+  shouldSkipCommitForSourcePaths,
 } from "./github-repository-automation-commits";
 
 describe("github repository automation commits", () => {
@@ -85,6 +86,33 @@ describe("github repository automation commits", () => {
     expect(
       shouldSkipCommitForPaths({
         changedPaths: ["locales/en.json", "README.md"],
+        patterns,
+      }),
+    ).toEqual({
+      skipped: false,
+      paths: ["locales/en.json"],
+    });
+  });
+
+  it("skips commits without configured source path changes", () => {
+    const patterns = {
+      sourcePatterns: ["locales/en.json"],
+      targetPatterns: ["locales/{{locale}}.json"],
+    };
+
+    expect(
+      shouldSkipCommitForSourcePaths({
+        changedPaths: ["locales/fr.json"],
+        patterns,
+      }),
+    ).toEqual({
+      skipped: true,
+      reason: "no_configured_source_paths_changed",
+    });
+
+    expect(
+      shouldSkipCommitForSourcePaths({
+        changedPaths: ["locales/en.json"],
         patterns,
       }),
     ).toEqual({

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-commits.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-commits.ts
@@ -99,6 +99,61 @@ export function buildCommitScopedDiffArgs(input: {
   return args;
 }
 
+export function buildCommitScopedNameStatusDiffArgs(input: {
+  parentSha: string | null;
+  commitSha: string;
+  paths: string[];
+}): string[] {
+  const range = input.parentSha ? `${input.parentSha}..${input.commitSha}` : input.commitSha;
+  const args = ["diff", "--name-status", range, "--"];
+
+  for (const path of input.paths) {
+    args.push(path);
+  }
+
+  return args;
+}
+
+/**
+ * Paths present at the commit tip that can be read for upload.
+ * Excludes deletions; renames and copies resolve to the post-change path.
+ */
+export function parseNameStatusDiffPathsForUpload(output: string): string[] {
+  const unique = new Set<string>();
+
+  for (const line of output.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+
+    const parts = trimmed.split("\t");
+    if (parts.length < 2) {
+      continue;
+    }
+
+    const status = parts[0] ?? "";
+    const statusCode = status.charAt(0);
+
+    if (statusCode === "D") {
+      continue;
+    }
+
+    const path =
+      statusCode === "R" || statusCode === "C" || statusCode === "T"
+        ? (parts.at(-1) ?? "")
+        : (parts[1] ?? "");
+
+    if (!path) {
+      continue;
+    }
+
+    unique.add(path.replaceAll("\\", "/"));
+  }
+
+  return [...unique].sort();
+}
+
 export function buildCommitScopedPatchArgs(input: {
   parentSha: string | null;
   commitSha: string;

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-commits.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-commits.ts
@@ -2,6 +2,7 @@ import type { HlCheckReport } from "@/lib/providers/provider-job-qa/hl-check-typ
 
 import {
   filterPathsToLocalisationScope,
+  filterPathsToSourceScope,
   type I18nBucketFilePatterns,
 } from "./github-repository-automation-localisation-paths";
 
@@ -130,6 +131,21 @@ export function classifyHlCheckReport(report: HlCheckReport): "passed" | "warnin
   }
 
   return "passed";
+}
+
+export function shouldSkipCommitForSourcePaths(input: {
+  changedPaths: string[];
+  patterns: I18nBucketFilePatterns;
+}): { skipped: true; reason: string } | { skipped: false; paths: string[] } {
+  const scopedPaths = filterPathsToSourceScope(input.changedPaths, input.patterns);
+  if (scopedPaths.length === 0) {
+    return {
+      skipped: true,
+      reason: "no_configured_source_paths_changed",
+    };
+  }
+
+  return { skipped: false, paths: scopedPaths };
 }
 
 export function shouldSkipCommitForPaths(input: {

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-dispatcher.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-dispatcher.ts
@@ -16,7 +16,8 @@ import {
   claimGithubRepositoryAutomationJob,
   type GithubRepositoryAutomationJobRecord,
 } from "./github-repository-automation-jobs";
-import { enqueueGithubRepositoryAutomationValidationJob } from "./github-repository-automation-worker";
+import { enqueueGithubRepositoryAutomationJob } from "./github-repository-automation-worker";
+import { githubRepositoryAutomationJobHasRunnableWorkflow } from "./github-repository-automation-workflows";
 
 const logger = createLogger("github-repo-automation-dispatch");
 
@@ -121,8 +122,11 @@ export async function dispatchGithubRepositoryAutomationForPush(
     "github repository automation job enqueued from push",
   );
 
-  if (dispatchPayload.workflows.validation && claim.job.status === "queued") {
-    await enqueueGithubRepositoryAutomationValidationJob({ jobId: claim.job.id });
+  if (
+    githubRepositoryAutomationJobHasRunnableWorkflow(dispatchPayload.workflows) &&
+    claim.job.status === "queued"
+  ) {
+    await enqueueGithubRepositoryAutomationJob({ jobId: claim.job.id });
   }
 
   return {
@@ -215,8 +219,11 @@ export async function dispatchGithubRepositoryAutomationForSchedule(
     "github repository automation job enqueued from schedule",
   );
 
-  if (input.dispatchPayload.workflows.validation && claim.job.status === "queued") {
-    await enqueueGithubRepositoryAutomationValidationJob({ jobId: claim.job.id });
+  if (
+    githubRepositoryAutomationJobHasRunnableWorkflow(input.dispatchPayload.workflows) &&
+    claim.job.status === "queued"
+  ) {
+    await enqueueGithubRepositoryAutomationJob({ jobId: claim.job.id });
   }
 
   return {

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-localisation-paths.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-localisation-paths.ts
@@ -151,6 +151,16 @@ export function pathMatchesLocalisationPatterns(
   );
 }
 
+export function filterPathsToSourceScope(
+  paths: string[],
+  patterns: I18nBucketFilePatterns,
+): string[] {
+  return filterPathsToLocalisationScope(paths, {
+    sourcePatterns: patterns.sourcePatterns,
+    targetPatterns: [],
+  });
+}
+
 export function filterPathsToLocalisationScope(
   paths: string[],
   patterns: I18nBucketFilePatterns,

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-project.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-project.test.ts
@@ -1,0 +1,137 @@
+import { randomUUID } from "node:crypto";
+
+import { afterEach, describe, expect, it } from "vite-plus/test";
+
+import { createProjectTestFixture } from "@/api/routes/project/project.fixture";
+import { db, schema } from "@/lib/database";
+import { ensureDefaultWorkspaceTeam } from "@/lib/teams/default-workspace-team";
+
+import { resolveGithubRepositoryAutomationProjectId } from "./github-repository-automation-project";
+
+const fixture = createProjectTestFixture();
+
+async function createProjectInOrganization(organizationId: string, name: string) {
+  const team = await ensureDefaultWorkspaceTeam(organizationId);
+  const [project] = await db
+    .insert(schema.projects)
+    .values({
+      id: `project_${randomUUID()}`,
+      organizationId,
+      teamId: team.id,
+      createdByUserId: null,
+      name,
+      description: "",
+      translationContext: "",
+    })
+    .returning();
+
+  return project!;
+}
+
+describe("resolveGithubRepositoryAutomationProjectId", () => {
+  afterEach(async () => {
+    await fixture.cleanup();
+  });
+
+  it("prefers an explicit project configured on push source settings", async () => {
+    const { organization, project } = await fixture.createStoredProjectFixture();
+
+    const resolved = await resolveGithubRepositoryAutomationProjectId({
+      organizationId: organization.id,
+      repositoryFullName: "hyperlocalise/hyperlocalise",
+      configuredProjectId: project.id,
+    });
+
+    expect(resolved).toBe(project.id);
+  });
+
+  it("resolves a unique project from connector repository mappings", async () => {
+    const { organization, project } = await fixture.createStoredProjectFixture();
+
+    await db
+      .insert(schema.connectors)
+      .values({
+        organizationId: organization.id,
+        kind: "slack",
+        enabled: true,
+        config: {
+          repository: {
+            github: {
+              projectRepositories: {
+                [project.id]: "hyperlocalise/hyperlocalise",
+              },
+            },
+          },
+        },
+      })
+      .onConflictDoUpdate({
+        target: [schema.connectors.organizationId, schema.connectors.kind],
+        set: {
+          config: {
+            repository: {
+              github: {
+                projectRepositories: {
+                  [project.id]: "hyperlocalise/hyperlocalise",
+                },
+              },
+            },
+          },
+          updatedAt: new Date(),
+        },
+      });
+
+    const resolved = await resolveGithubRepositoryAutomationProjectId({
+      organizationId: organization.id,
+      repositoryFullName: "hyperlocalise/hyperlocalise",
+    });
+
+    expect(resolved).toBe(project.id);
+  });
+
+  it("returns null when multiple projects map to the same repository", async () => {
+    const { organization } = await fixture.createStoredProjectFixture();
+    const firstProject = await createProjectInOrganization(organization.id, "First Project");
+    const secondProject = await createProjectInOrganization(organization.id, "Second Project");
+
+    await db
+      .insert(schema.connectors)
+      .values({
+        organizationId: organization.id,
+        kind: "slack",
+        enabled: true,
+        config: {
+          repository: {
+            github: {
+              projectRepositories: {
+                [firstProject.id]: "hyperlocalise/hyperlocalise",
+                [secondProject.id]: "hyperlocalise/hyperlocalise",
+              },
+            },
+          },
+        },
+      })
+      .onConflictDoUpdate({
+        target: [schema.connectors.organizationId, schema.connectors.kind],
+        set: {
+          config: {
+            repository: {
+              github: {
+                projectRepositories: {
+                  [firstProject.id]: "hyperlocalise/hyperlocalise",
+                  [secondProject.id]: "hyperlocalise/hyperlocalise",
+                },
+              },
+            },
+          },
+          updatedAt: new Date(),
+        },
+      });
+
+    const resolved = await resolveGithubRepositoryAutomationProjectId({
+      organizationId: organization.id,
+      repositoryFullName: "hyperlocalise/hyperlocalise",
+    });
+
+    expect(resolved).toBeNull();
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-project.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-project.ts
@@ -1,0 +1,108 @@
+import { and, eq } from "drizzle-orm";
+
+import { db, schema } from "@/lib/database";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function repositoryFullNameFromConfigValue(value: unknown): string | null {
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value.trim();
+  }
+
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const fullName = value.repositoryFullName ?? value.fullName;
+  return typeof fullName === "string" && fullName.trim().length > 0 ? fullName.trim() : null;
+}
+
+function findProjectIdsForRepository(
+  projectRepositories: unknown,
+  repositoryFullName: string,
+): string[] {
+  if (!isRecord(projectRepositories)) {
+    return [];
+  }
+
+  const normalizedRepository = repositoryFullName.toLowerCase();
+  const matches: string[] = [];
+
+  for (const [projectId, configuredRepository] of Object.entries(projectRepositories)) {
+    const configuredFullName = repositoryFullNameFromConfigValue(configuredRepository);
+    if (configuredFullName?.toLowerCase() === normalizedRepository) {
+      matches.push(projectId);
+    }
+  }
+
+  return matches;
+}
+
+async function findProjectIdFromConnectorConfigs(input: {
+  organizationId: string;
+  repositoryFullName: string;
+}): Promise<string | null> {
+  const connectors = await db
+    .select({ config: schema.connectors.config })
+    .from(schema.connectors)
+    .where(eq(schema.connectors.organizationId, input.organizationId));
+
+  const matches = new Set<string>();
+
+  for (const connector of connectors) {
+    const root = isRecord(connector.config) ? connector.config : null;
+    const repository = root ? (isRecord(root.repository) ? root.repository : null) : null;
+    const github = repository
+      ? isRecord(repository.github)
+        ? repository.github
+        : null
+      : isRecord(root?.github)
+        ? root.github
+        : null;
+
+    if (!github) {
+      continue;
+    }
+
+    for (const projectId of findProjectIdsForRepository(
+      github.projectRepositories,
+      input.repositoryFullName,
+    )) {
+      matches.add(projectId);
+    }
+  }
+
+  if (matches.size === 1) {
+    return [...matches][0] ?? null;
+  }
+
+  return null;
+}
+
+export async function resolveGithubRepositoryAutomationProjectId(input: {
+  organizationId: string;
+  repositoryFullName: string;
+  configuredProjectId?: string | null;
+}): Promise<string | null> {
+  if (input.configuredProjectId) {
+    const [project] = await db
+      .select({ id: schema.projects.id })
+      .from(schema.projects)
+      .where(
+        and(
+          eq(schema.projects.id, input.configuredProjectId),
+          eq(schema.projects.organizationId, input.organizationId),
+        ),
+      )
+      .limit(1);
+
+    return project?.id ?? null;
+  }
+
+  return findProjectIdFromConnectorConfigs({
+    organizationId: input.organizationId,
+    repositoryFullName: input.repositoryFullName,
+  });
+}

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-project.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-project.ts
@@ -2,6 +2,9 @@ import { and, eq } from "drizzle-orm";
 
 import { db, schema } from "@/lib/database";
 
+/** Slack connector stores project→repository mappings under `repository.github`. */
+const GITHUB_REPOSITORY_PROJECT_CONNECTOR_KIND = "slack" as const;
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
@@ -40,42 +43,43 @@ function findProjectIdsForRepository(
   return matches;
 }
 
-async function findProjectIdFromConnectorConfigs(input: {
+async function findProjectIdFromConnectorConfig(input: {
   organizationId: string;
   repositoryFullName: string;
 }): Promise<string | null> {
-  const connectors = await db
+  const [connector] = await db
     .select({ config: schema.connectors.config })
     .from(schema.connectors)
-    .where(eq(schema.connectors.organizationId, input.organizationId));
+    .where(
+      and(
+        eq(schema.connectors.organizationId, input.organizationId),
+        eq(schema.connectors.kind, GITHUB_REPOSITORY_PROJECT_CONNECTOR_KIND),
+      ),
+    )
+    .limit(1);
 
-  const matches = new Set<string>();
-
-  for (const connector of connectors) {
-    const root = isRecord(connector.config) ? connector.config : null;
-    const repository = root ? (isRecord(root.repository) ? root.repository : null) : null;
-    const github = repository
-      ? isRecord(repository.github)
-        ? repository.github
-        : null
-      : isRecord(root?.github)
-        ? root.github
-        : null;
-
-    if (!github) {
-      continue;
-    }
-
-    for (const projectId of findProjectIdsForRepository(
-      github.projectRepositories,
-      input.repositoryFullName,
-    )) {
-      matches.add(projectId);
-    }
+  if (!connector) {
+    return null;
   }
 
-  if (matches.size === 1) {
-    return [...matches][0] ?? null;
+  const root = isRecord(connector.config) ? connector.config : null;
+  const repository = root ? (isRecord(root.repository) ? root.repository : null) : null;
+  const github = repository
+    ? isRecord(repository.github)
+      ? repository.github
+      : null
+    : isRecord(root?.github)
+      ? root.github
+      : null;
+
+  if (!github) {
+    return null;
+  }
+
+  const matches = findProjectIdsForRepository(github.projectRepositories, input.repositoryFullName);
+
+  if (matches.length === 1) {
+    return matches[0] ?? null;
   }
 
   return null;
@@ -101,7 +105,7 @@ export async function resolveGithubRepositoryAutomationProjectId(input: {
     return project?.id ?? null;
   }
 
-  return findProjectIdFromConnectorConfigs({
+  return findProjectIdFromConnectorConfig({
     organizationId: input.organizationId,
     repositoryFullName: input.repositoryFullName,
   });

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-push-source.errors.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-push-source.errors.ts
@@ -1,0 +1,70 @@
+import { updateGithubRepositoryAutomationJobStatus } from "./github-repository-automation-jobs";
+
+import type { GithubRepositoryAutomationPushSourceSummary } from "./github-repository-automation-push-source.types";
+
+export type GithubRepositoryAutomationPushSourceError =
+  | { code: "push_source_workflow_disabled" }
+  | { code: "project_not_linked" }
+  | { code: "i18n_config_not_found" }
+  | { code: "source_patterns_not_configured" }
+  | {
+      code: "no_relevant_source_file_changes";
+      summary: GithubRepositoryAutomationPushSourceSummary;
+    }
+  | { code: "failed_to_list_commits" }
+  | {
+      code: "push_source_failed";
+      summary: GithubRepositoryAutomationPushSourceSummary;
+    }
+  | { code: "infrastructure"; message: string };
+
+export function isPushSourceSkipError(error: GithubRepositoryAutomationPushSourceError): boolean {
+  return (
+    error.code === "push_source_workflow_disabled" ||
+    error.code === "project_not_linked" ||
+    error.code === "i18n_config_not_found" ||
+    error.code === "source_patterns_not_configured" ||
+    error.code === "no_relevant_source_file_changes"
+  );
+}
+
+export async function persistPushSourceSkippedJob(input: {
+  jobId: string;
+  error: GithubRepositoryAutomationPushSourceError;
+}): Promise<void> {
+  const resultSummary =
+    input.error.code === "no_relevant_source_file_changes" ? input.error.summary : null;
+
+  await updateGithubRepositoryAutomationJobStatus({
+    jobId: input.jobId,
+    status: "skipped",
+    skipReason: input.error.code,
+    resultSummary,
+  });
+}
+
+export async function persistPushSourceFailedJob(input: {
+  jobId: string;
+  error: GithubRepositoryAutomationPushSourceError;
+  lastError?: string | null;
+}): Promise<void> {
+  const resultSummary =
+    input.error.code === "push_source_failed" ||
+    input.error.code === "no_relevant_source_file_changes"
+      ? input.error.summary
+      : null;
+
+  await updateGithubRepositoryAutomationJobStatus({
+    jobId: input.jobId,
+    status: "failed",
+    skipReason: null,
+    resultSummary,
+    lastError:
+      input.lastError ??
+      (input.error.code === "infrastructure"
+        ? input.error.message
+        : input.error.code === "push_source_failed"
+          ? "push_source_failed"
+          : input.error.code),
+  });
+}

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-push-source.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-push-source.ts
@@ -8,9 +8,9 @@ import {
 } from "./github-repository-automation-commit-range";
 import {
   buildCommitRangeLogArgs,
-  buildCommitScopedDiffArgs,
+  buildCommitScopedNameStatusDiffArgs,
   parseCommitLogLines,
-  parseNameOnlyDiffPaths,
+  parseNameStatusDiffPathsForUpload,
   shouldSkipCommitForSourcePaths,
 } from "./github-repository-automation-commits";
 import { discoverI18nConfigInSandbox } from "./github-repository-automation-i18n-config";
@@ -172,17 +172,17 @@ export async function runGithubRepositoryAutomationPushSource(input: {
     const pathsToUpload = new Set<string>();
 
     for (const commit of commits) {
-      const nameOnlyDiff = await runGitDiffInSandbox(
+      const nameStatusDiff = await runGitDiffInSandbox(
         sandboxId,
-        buildCommitScopedDiffArgs({
+        buildCommitScopedNameStatusDiffArgs({
           parentSha: commit.parentSha,
           commitSha: commit.sha,
           paths: i18nConfig.patterns.sourcePatterns,
         }),
       );
 
-      const changedPaths = parseNameOnlyDiffPaths(
-        nameOnlyDiff.exitCode === 0 ? nameOnlyDiff.output : "",
+      const changedPaths = parseNameStatusDiffPathsForUpload(
+        nameStatusDiff.exitCode === 0 ? nameStatusDiff.output : "",
       );
       const skipDecision = shouldSkipCommitForSourcePaths({
         changedPaths,

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-push-source.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-push-source.ts
@@ -18,7 +18,6 @@ import { updateGithubRepositoryAutomationJobStatus } from "./github-repository-a
 import { resolveGithubRepositoryAutomationProjectId } from "./github-repository-automation-project";
 import { getGithubRepositoryAutomationSettings } from "./github-repository-automation-settings-store";
 import {
-  checkoutCommitInSandbox,
   createGithubRepositoryAutomationSandbox,
   runGitDiffInSandbox,
   runGitLogInSandbox,
@@ -29,10 +28,6 @@ const logger = createLogger("github-repo-automation-push-source");
 
 export type GithubRepositoryAutomationPushSourceSummary = {
   totalCommits: number;
-  uploadedFiles: number;
-  skippedFiles: number;
-  failedFiles: number;
-  unchangedFiles: number;
   counts: {
     uploaded: number;
     skipped: number;
@@ -77,15 +72,9 @@ function buildPushSourceSummary(input: {
   totalCommits: number;
   fileResults: Awaited<ReturnType<typeof uploadRepositorySourceFilesFromSandbox>>;
 }): GithubRepositoryAutomationPushSourceSummary {
-  const counts = summarizePushSourceResults(input.fileResults);
-
   return {
     totalCommits: input.totalCommits,
-    uploadedFiles: counts.uploaded,
-    skippedFiles: counts.skipped,
-    failedFiles: counts.failed,
-    unchangedFiles: counts.unchanged,
-    counts,
+    counts: summarizePushSourceResults(input.fileResults),
   };
 }
 
@@ -218,8 +207,6 @@ export async function runGithubRepositoryAutomationPushSource(input: {
       return { skipped: true, reason: "no_relevant_source_file_changes" };
     }
 
-    await checkoutCommitInSandbox(sandboxId, commitAfter);
-
     const fileResults = await uploadRepositorySourceFilesFromSandbox({
       sandboxId,
       organizationId: job.organizationId,
@@ -235,7 +222,7 @@ export async function runGithubRepositoryAutomationPushSource(input: {
       fileResults,
     });
 
-    const finalStatus = summary.failedFiles > 0 ? "failed" : "succeeded";
+    const finalStatus = summary.counts.failed > 0 ? "failed" : "succeeded";
 
     await updateGithubRepositoryAutomationJobStatus({
       jobId: job.id,
@@ -247,9 +234,7 @@ export async function runGithubRepositoryAutomationPushSource(input: {
     logger.info(
       {
         jobId: job.id,
-        uploadedFiles: summary.uploadedFiles,
-        skippedFiles: summary.skippedFiles,
-        failedFiles: summary.failedFiles,
+        counts: summary.counts,
       },
       "github repository automation push source completed",
     );

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-push-source.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-push-source.ts
@@ -1,7 +1,10 @@
 import { createLogger } from "@/lib/log";
 import { uploadRepositorySourceFilesFromSandbox } from "@/lib/file-storage/upload-repository-source-files";
 
-import { resolveGithubRepositoryAutomationCommitRange } from "./github-repository-automation-commit-range";
+import {
+  resolveGithubRepositoryAutomationCommitRange,
+  type GithubRepositoryAutomationCommitRange,
+} from "./github-repository-automation-commit-range";
 import {
   buildCommitRangeLogArgs,
   buildCommitScopedDiffArgs,
@@ -89,6 +92,7 @@ function buildPushSourceSummary(input: {
 export async function runGithubRepositoryAutomationPushSource(input: {
   job: GithubRepositoryAutomationJobWithRepository;
   workflowRunId?: string | null;
+  commitRange?: GithubRepositoryAutomationCommitRange;
 }): Promise<GithubRepositoryAutomationPushSourceSummary | { skipped: true; reason: string }> {
   const job = input.job;
 
@@ -121,9 +125,10 @@ export async function runGithubRepositoryAutomationPushSource(input: {
     return { skipped: true, reason: "project_not_linked" };
   }
 
-  const { commitBefore, commitAfter } = await resolveGithubRepositoryAutomationCommitRange(job);
+  const { commitBefore, commitAfter } =
+    input.commitRange ?? (await resolveGithubRepositoryAutomationCommitRange(job));
 
-  if (!job.commitAfter) {
+  if (!input.commitRange && !job.commitAfter) {
     await updateGithubRepositoryAutomationJobStatus({
       jobId: job.id,
       status: "running",

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-push-source.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-push-source.ts
@@ -1,5 +1,6 @@
 import { createLogger } from "@/lib/log";
 import { uploadRepositorySourceFilesFromSandbox } from "@/lib/file-storage/upload-repository-source-files";
+import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
 
 import {
   resolveGithubRepositoryAutomationCommitRange,
@@ -15,6 +16,11 @@ import {
 import { discoverI18nConfigInSandbox } from "./github-repository-automation-i18n-config";
 import type { GithubRepositoryAutomationJobWithRepository } from "./github-repository-automation-jobs";
 import { updateGithubRepositoryAutomationJobStatus } from "./github-repository-automation-jobs";
+import {
+  type GithubRepositoryAutomationPushSourceError,
+  persistPushSourceFailedJob,
+  persistPushSourceSkippedJob,
+} from "./github-repository-automation-push-source.errors";
 import { resolveGithubRepositoryAutomationProjectId } from "./github-repository-automation-project";
 import { getGithubRepositoryAutomationSettings } from "./github-repository-automation-settings-store";
 import {
@@ -26,15 +32,9 @@ import {
 
 const logger = createLogger("github-repo-automation-push-source");
 
-export type GithubRepositoryAutomationPushSourceSummary = {
-  totalCommits: number;
-  counts: {
-    uploaded: number;
-    skipped: number;
-    failed: number;
-    unchanged: number;
-  };
-};
+export type { GithubRepositoryAutomationPushSourceError } from "./github-repository-automation-push-source.errors";
+export type { GithubRepositoryAutomationPushSourceSummary } from "./github-repository-automation-push-source.types";
+import type { GithubRepositoryAutomationPushSourceSummary } from "./github-repository-automation-push-source.types";
 
 function summarizePushSourceResults(
   fileResults: Awaited<ReturnType<typeof uploadRepositorySourceFilesFromSandbox>>,
@@ -78,20 +78,34 @@ function buildPushSourceSummary(input: {
   };
 }
 
+async function returnPushSourceSkipped(
+  jobId: string,
+  error: GithubRepositoryAutomationPushSourceError,
+): Promise<Result<never, GithubRepositoryAutomationPushSourceError>> {
+  await persistPushSourceSkippedJob({ jobId, error });
+  return err(error);
+}
+
+async function returnPushSourceFailed(
+  jobId: string,
+  error: GithubRepositoryAutomationPushSourceError,
+  lastError?: string | null,
+): Promise<Result<never, GithubRepositoryAutomationPushSourceError>> {
+  await persistPushSourceFailedJob({ jobId, error, lastError });
+  return err(error);
+}
+
 export async function runGithubRepositoryAutomationPushSource(input: {
   job: GithubRepositoryAutomationJobWithRepository;
   workflowRunId?: string | null;
   commitRange?: GithubRepositoryAutomationCommitRange;
-}): Promise<GithubRepositoryAutomationPushSourceSummary | { skipped: true; reason: string }> {
+}): Promise<
+  Result<GithubRepositoryAutomationPushSourceSummary, GithubRepositoryAutomationPushSourceError>
+> {
   const job = input.job;
 
   if (!job.workflows.pushSource) {
-    await updateGithubRepositoryAutomationJobStatus({
-      jobId: job.id,
-      status: "skipped",
-      skipReason: "push_source_workflow_disabled",
-    });
-    return { skipped: true, reason: "push_source_workflow_disabled" };
+    return returnPushSourceSkipped(job.id, { code: "push_source_workflow_disabled" });
   }
 
   const settingsRecord = await getGithubRepositoryAutomationSettings({
@@ -106,16 +120,19 @@ export async function runGithubRepositoryAutomationPushSource(input: {
   });
 
   if (!projectId) {
-    await updateGithubRepositoryAutomationJobStatus({
-      jobId: job.id,
-      status: "skipped",
-      skipReason: "project_not_linked",
-    });
-    return { skipped: true, reason: "project_not_linked" };
+    return returnPushSourceSkipped(job.id, { code: "project_not_linked" });
   }
 
-  const { commitBefore, commitAfter } =
-    input.commitRange ?? (await resolveGithubRepositoryAutomationCommitRange(job));
+  const commitRangeResult: Result<
+    GithubRepositoryAutomationCommitRange,
+    GithubRepositoryAutomationPushSourceError
+  > = input.commitRange ? ok(input.commitRange) : await resolveCommitRangeForPushSource(job);
+
+  if (isErr(commitRangeResult)) {
+    return returnPushSourceFailed(job.id, commitRangeResult.error);
+  }
+
+  const { commitBefore, commitAfter } = commitRangeResult.value;
 
   if (!input.commitRange && !job.commitAfter) {
     await updateGithubRepositoryAutomationJobStatus({
@@ -138,27 +155,17 @@ export async function runGithubRepositoryAutomationPushSource(input: {
 
     const i18nConfig = await discoverI18nConfigInSandbox(sandboxId);
     if (!i18nConfig) {
-      await updateGithubRepositoryAutomationJobStatus({
-        jobId: job.id,
-        status: "skipped",
-        skipReason: "i18n_config_not_found",
-      });
-      return { skipped: true, reason: "i18n_config_not_found" };
+      return returnPushSourceSkipped(job.id, { code: "i18n_config_not_found" });
     }
 
     if (i18nConfig.patterns.sourcePatterns.length === 0) {
-      await updateGithubRepositoryAutomationJobStatus({
-        jobId: job.id,
-        status: "skipped",
-        skipReason: "source_patterns_not_configured",
-      });
-      return { skipped: true, reason: "source_patterns_not_configured" };
+      return returnPushSourceSkipped(job.id, { code: "source_patterns_not_configured" });
     }
 
     const logArgs = buildCommitRangeLogArgs({ commitBefore, commitAfter });
     const logResult = await runGitLogInSandbox(sandboxId, logArgs);
     if (logResult.exitCode !== 0) {
-      throw new Error("failed_to_list_commits_for_push_source");
+      return returnPushSourceFailed(job.id, { code: "failed_to_list_commits" });
     }
 
     const commits = parseCommitLogLines(logResult.output);
@@ -197,14 +204,10 @@ export async function runGithubRepositoryAutomationPushSource(input: {
         fileResults: [],
       });
 
-      await updateGithubRepositoryAutomationJobStatus({
-        jobId: job.id,
-        status: "skipped",
-        skipReason: "no_relevant_source_file_changes",
-        resultSummary: summary,
+      return returnPushSourceSkipped(job.id, {
+        code: "no_relevant_source_file_changes",
+        summary,
       });
-
-      return { skipped: true, reason: "no_relevant_source_file_changes" };
     }
 
     const fileResults = await uploadRepositorySourceFilesFromSandbox({
@@ -222,13 +225,15 @@ export async function runGithubRepositoryAutomationPushSource(input: {
       fileResults,
     });
 
-    const finalStatus = summary.counts.failed > 0 ? "failed" : "succeeded";
+    if (summary.counts.failed > 0) {
+      return returnPushSourceFailed(job.id, { code: "push_source_failed", summary });
+    }
 
     await updateGithubRepositoryAutomationJobStatus({
       jobId: job.id,
-      status: finalStatus,
+      status: "succeeded",
       resultSummary: summary,
-      lastError: finalStatus === "failed" ? "push_source_failed" : null,
+      lastError: null,
     });
 
     logger.info(
@@ -239,20 +244,38 @@ export async function runGithubRepositoryAutomationPushSource(input: {
       "github repository automation push source completed",
     );
 
-    return summary;
+    return ok(summary);
   } catch (error) {
-    const message = error instanceof Error ? error.message : "push source automation failed";
+    const message = error instanceof Error ? error.message : "push_source_automation_failed";
 
-    await updateGithubRepositoryAutomationJobStatus({
-      jobId: job.id,
-      status: "failed",
-      lastError: message,
-    });
+    logger.error(
+      {
+        jobId: job.id,
+        err: error,
+      },
+      "github repository automation push source failed",
+    );
 
-    throw error;
+    return returnPushSourceFailed(job.id, { code: "infrastructure", message }, message);
   } finally {
     if (sandboxId) {
       await stopGithubRepositoryAutomationSandbox(sandboxId).catch(() => undefined);
     }
+  }
+}
+
+async function resolveCommitRangeForPushSource(
+  job: GithubRepositoryAutomationJobWithRepository,
+): Promise<
+  Result<GithubRepositoryAutomationCommitRange, GithubRepositoryAutomationPushSourceError>
+> {
+  try {
+    const commitRange = await resolveGithubRepositoryAutomationCommitRange(job);
+    return ok(commitRange);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "failed_to_resolve_commit_range_for_push_source";
+
+    return err({ code: "infrastructure", message });
   }
 }

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-push-source.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-push-source.ts
@@ -1,0 +1,268 @@
+import { createLogger } from "@/lib/log";
+import { uploadRepositorySourceFilesFromSandbox } from "@/lib/file-storage/upload-repository-source-files";
+
+import { resolveGithubRepositoryAutomationCommitRange } from "./github-repository-automation-commit-range";
+import {
+  buildCommitRangeLogArgs,
+  buildCommitScopedDiffArgs,
+  parseCommitLogLines,
+  parseNameOnlyDiffPaths,
+  shouldSkipCommitForSourcePaths,
+} from "./github-repository-automation-commits";
+import { discoverI18nConfigInSandbox } from "./github-repository-automation-i18n-config";
+import type { GithubRepositoryAutomationJobWithRepository } from "./github-repository-automation-jobs";
+import { updateGithubRepositoryAutomationJobStatus } from "./github-repository-automation-jobs";
+import { resolveGithubRepositoryAutomationProjectId } from "./github-repository-automation-project";
+import { getGithubRepositoryAutomationSettings } from "./github-repository-automation-settings-store";
+import {
+  checkoutCommitInSandbox,
+  createGithubRepositoryAutomationSandbox,
+  runGitDiffInSandbox,
+  runGitLogInSandbox,
+  stopGithubRepositoryAutomationSandbox,
+} from "./github-repository-automation-sandbox";
+
+const logger = createLogger("github-repo-automation-push-source");
+
+export type GithubRepositoryAutomationPushSourceSummary = {
+  totalCommits: number;
+  uploadedFiles: number;
+  skippedFiles: number;
+  failedFiles: number;
+  unchangedFiles: number;
+  counts: {
+    uploaded: number;
+    skipped: number;
+    failed: number;
+    unchanged: number;
+  };
+};
+
+function summarizePushSourceResults(
+  fileResults: Awaited<ReturnType<typeof uploadRepositorySourceFilesFromSandbox>>,
+): GithubRepositoryAutomationPushSourceSummary["counts"] {
+  const counts = {
+    uploaded: 0,
+    skipped: 0,
+    failed: 0,
+    unchanged: 0,
+  };
+
+  for (const result of fileResults) {
+    if (result.outcome === "uploaded") {
+      counts.uploaded += 1;
+      continue;
+    }
+
+    if (result.outcome === "failed") {
+      counts.failed += 1;
+      continue;
+    }
+
+    if (result.reason === "unchanged_for_commit") {
+      counts.unchanged += 1;
+      continue;
+    }
+
+    counts.skipped += 1;
+  }
+
+  return counts;
+}
+
+function buildPushSourceSummary(input: {
+  totalCommits: number;
+  fileResults: Awaited<ReturnType<typeof uploadRepositorySourceFilesFromSandbox>>;
+}): GithubRepositoryAutomationPushSourceSummary {
+  const counts = summarizePushSourceResults(input.fileResults);
+
+  return {
+    totalCommits: input.totalCommits,
+    uploadedFiles: counts.uploaded,
+    skippedFiles: counts.skipped,
+    failedFiles: counts.failed,
+    unchangedFiles: counts.unchanged,
+    counts,
+  };
+}
+
+export async function runGithubRepositoryAutomationPushSource(input: {
+  job: GithubRepositoryAutomationJobWithRepository;
+  workflowRunId?: string | null;
+}): Promise<GithubRepositoryAutomationPushSourceSummary | { skipped: true; reason: string }> {
+  const job = input.job;
+
+  if (!job.workflows.pushSource) {
+    await updateGithubRepositoryAutomationJobStatus({
+      jobId: job.id,
+      status: "skipped",
+      skipReason: "push_source_workflow_disabled",
+    });
+    return { skipped: true, reason: "push_source_workflow_disabled" };
+  }
+
+  const settingsRecord = await getGithubRepositoryAutomationSettings({
+    githubInstallationRepositoryId: job.githubInstallationRepositoryId,
+    githubRepositoryId: job.githubRepositoryId,
+  });
+
+  const projectId = await resolveGithubRepositoryAutomationProjectId({
+    organizationId: job.organizationId,
+    repositoryFullName: job.repositoryFullName,
+    configuredProjectId: settingsRecord.settings.workflows.pushSource.projectId,
+  });
+
+  if (!projectId) {
+    await updateGithubRepositoryAutomationJobStatus({
+      jobId: job.id,
+      status: "skipped",
+      skipReason: "project_not_linked",
+    });
+    return { skipped: true, reason: "project_not_linked" };
+  }
+
+  const { commitBefore, commitAfter } = await resolveGithubRepositoryAutomationCommitRange(job);
+
+  if (!job.commitAfter) {
+    await updateGithubRepositoryAutomationJobStatus({
+      jobId: job.id,
+      status: "running",
+      commitBefore,
+      commitAfter,
+    });
+  }
+
+  let sandboxId: string | null = null;
+
+  try {
+    sandboxId = await createGithubRepositoryAutomationSandbox({
+      installationId: job.githubInstallationId,
+      repositoryFullName: job.repositoryFullName,
+      revision: commitAfter,
+      cloneDepth: 50,
+    });
+
+    const i18nConfig = await discoverI18nConfigInSandbox(sandboxId);
+    if (!i18nConfig) {
+      await updateGithubRepositoryAutomationJobStatus({
+        jobId: job.id,
+        status: "skipped",
+        skipReason: "i18n_config_not_found",
+      });
+      return { skipped: true, reason: "i18n_config_not_found" };
+    }
+
+    if (i18nConfig.patterns.sourcePatterns.length === 0) {
+      await updateGithubRepositoryAutomationJobStatus({
+        jobId: job.id,
+        status: "skipped",
+        skipReason: "source_patterns_not_configured",
+      });
+      return { skipped: true, reason: "source_patterns_not_configured" };
+    }
+
+    const logArgs = buildCommitRangeLogArgs({ commitBefore, commitAfter });
+    const logResult = await runGitLogInSandbox(sandboxId, logArgs);
+    if (logResult.exitCode !== 0) {
+      throw new Error("failed_to_list_commits_for_push_source");
+    }
+
+    const commits = parseCommitLogLines(logResult.output);
+    const pathsToUpload = new Set<string>();
+
+    for (const commit of commits) {
+      const nameOnlyDiff = await runGitDiffInSandbox(
+        sandboxId,
+        buildCommitScopedDiffArgs({
+          parentSha: commit.parentSha,
+          commitSha: commit.sha,
+          paths: i18nConfig.patterns.sourcePatterns,
+        }),
+      );
+
+      const changedPaths = parseNameOnlyDiffPaths(
+        nameOnlyDiff.exitCode === 0 ? nameOnlyDiff.output : "",
+      );
+      const skipDecision = shouldSkipCommitForSourcePaths({
+        changedPaths,
+        patterns: i18nConfig.patterns,
+      });
+
+      if (skipDecision.skipped) {
+        continue;
+      }
+
+      for (const path of skipDecision.paths) {
+        pathsToUpload.add(path);
+      }
+    }
+
+    if (pathsToUpload.size === 0) {
+      const summary = buildPushSourceSummary({
+        totalCommits: commits.length,
+        fileResults: [],
+      });
+
+      await updateGithubRepositoryAutomationJobStatus({
+        jobId: job.id,
+        status: "skipped",
+        skipReason: "no_relevant_source_file_changes",
+        resultSummary: summary,
+      });
+
+      return { skipped: true, reason: "no_relevant_source_file_changes" };
+    }
+
+    await checkoutCommitInSandbox(sandboxId, commitAfter);
+
+    const fileResults = await uploadRepositorySourceFilesFromSandbox({
+      sandboxId,
+      organizationId: job.organizationId,
+      projectId,
+      paths: [...pathsToUpload],
+      commitSha: commitAfter,
+      workflowRunId: input.workflowRunId ?? job.workflowRunId,
+      uploadSurface: "github_automation",
+    });
+
+    const summary = buildPushSourceSummary({
+      totalCommits: commits.length,
+      fileResults,
+    });
+
+    const finalStatus = summary.failedFiles > 0 ? "failed" : "succeeded";
+
+    await updateGithubRepositoryAutomationJobStatus({
+      jobId: job.id,
+      status: finalStatus,
+      resultSummary: summary,
+      lastError: finalStatus === "failed" ? "push_source_failed" : null,
+    });
+
+    logger.info(
+      {
+        jobId: job.id,
+        uploadedFiles: summary.uploadedFiles,
+        skippedFiles: summary.skippedFiles,
+        failedFiles: summary.failedFiles,
+      },
+      "github repository automation push source completed",
+    );
+
+    return summary;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "push source automation failed";
+
+    await updateGithubRepositoryAutomationJobStatus({
+      jobId: job.id,
+      status: "failed",
+      lastError: message,
+    });
+
+    throw error;
+  } finally {
+    if (sandboxId) {
+      await stopGithubRepositoryAutomationSandbox(sandboxId).catch(() => undefined);
+    }
+  }
+}

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-push-source.types.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-push-source.types.ts
@@ -1,0 +1,9 @@
+export type GithubRepositoryAutomationPushSourceSummary = {
+  totalCommits: number;
+  counts: {
+    uploaded: number;
+    skipped: number;
+    failed: number;
+    unchanged: number;
+  };
+};

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-settings-store.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-settings-store.ts
@@ -30,6 +30,7 @@ function parseStoredSettings(
 
   if (
     merged.workflows.pushSource.enabled !== defaults.workflows.pushSource.enabled ||
+    merged.workflows.pushSource.projectId !== defaults.workflows.pushSource.projectId ||
     merged.workflows.pullTranslations.enabled !== defaults.workflows.pullTranslations.enabled ||
     merged.workflows.validation.enabled !== defaults.workflows.validation.enabled
   ) {

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-settings.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-settings.ts
@@ -37,7 +37,12 @@ export const githubRepoAutomationValidationWorkflowSchema = z
   .default({ enabled: false, blockOnFailure: true });
 
 export const githubRepoAutomationWorkflowsSchema = z.object({
-  pushSource: z.object({ enabled: z.boolean().default(false) }).default({ enabled: false }),
+  pushSource: z
+    .object({
+      enabled: z.boolean().default(false),
+      projectId: z.string().trim().min(1).optional(),
+    })
+    .default({ enabled: false }),
   pullTranslations: z.object({ enabled: z.boolean().default(false) }).default({ enabled: false }),
   validation: githubRepoAutomationValidationWorkflowSchema,
 });
@@ -56,7 +61,7 @@ export type GithubRepositoryAutomationSettings = z.infer<
 >;
 export type GithubRepositoryAutomationSettingsPartial = {
   workflows?: {
-    pushSource?: { enabled?: boolean };
+    pushSource?: { enabled?: boolean; projectId?: string };
     pullTranslations?: { enabled?: boolean };
     validation?: { enabled?: boolean; blockOnFailure?: boolean };
   };
@@ -69,7 +74,12 @@ export const DEFAULT_GITHUB_REPOSITORY_AUTOMATION_SETTINGS: GithubRepositoryAuto
 const githubRepositoryAutomationSettingsPartialSchema = z.object({
   workflows: z
     .object({
-      pushSource: z.object({ enabled: z.boolean().optional() }).optional(),
+      pushSource: z
+        .object({
+          enabled: z.boolean().optional(),
+          projectId: z.string().trim().min(1).optional(),
+        })
+        .optional(),
       pullTranslations: z.object({ enabled: z.boolean().optional() }).optional(),
       validation: z
         .object({
@@ -112,6 +122,7 @@ export function mergeGithubRepositoryAutomationSettings(
     workflows: {
       pushSource: {
         enabled: override.workflows?.pushSource?.enabled ?? base.workflows.pushSource.enabled,
+        projectId: override.workflows?.pushSource?.projectId ?? base.workflows.pushSource.projectId,
       },
       pullTranslations: {
         enabled:

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-validation.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-validation.ts
@@ -23,7 +23,10 @@ import {
 import { discoverI18nConfigInSandbox } from "./github-repository-automation-i18n-config";
 import { runHlCheckDiffInSandbox } from "./github-repository-automation-hl-check";
 import type { GithubRepositoryAutomationJobWithRepository } from "./github-repository-automation-jobs";
-import { resolveGithubRepositoryAutomationCommitRange } from "./github-repository-automation-commit-range";
+import {
+  resolveGithubRepositoryAutomationCommitRange,
+  type GithubRepositoryAutomationCommitRange,
+} from "./github-repository-automation-commit-range";
 import { updateGithubRepositoryAutomationJobStatus } from "./github-repository-automation-jobs";
 import {
   checkoutCommitInSandbox,
@@ -94,6 +97,7 @@ function resolveCheckRunConclusion(input: {
 export async function runGithubRepositoryAutomationValidation(input: {
   job: GithubRepositoryAutomationJobWithRepository;
   workflowRunId?: string | null;
+  commitRange?: GithubRepositoryAutomationCommitRange;
 }): Promise<Record<string, unknown>> {
   const job = input.job;
   const workflows = job.workflows;
@@ -108,9 +112,10 @@ export async function runGithubRepositoryAutomationValidation(input: {
   }
 
   const blockOnFailure = workflows.validationBlockOnFailure ?? true;
-  const { commitBefore, commitAfter } = await resolveGithubRepositoryAutomationCommitRange(job);
+  const { commitBefore, commitAfter } =
+    input.commitRange ?? (await resolveGithubRepositoryAutomationCommitRange(job));
 
-  if (!job.commitAfter) {
+  if (!input.commitRange && !job.commitAfter) {
     await updateGithubRepositoryAutomationJobStatus({
       jobId: job.id,
       status: "running",

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-validation.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-validation.ts
@@ -23,14 +23,11 @@ import {
 import { discoverI18nConfigInSandbox } from "./github-repository-automation-i18n-config";
 import { runHlCheckDiffInSandbox } from "./github-repository-automation-hl-check";
 import type { GithubRepositoryAutomationJobWithRepository } from "./github-repository-automation-jobs";
-import {
-  findLatestSucceededCommitAfter,
-  updateGithubRepositoryAutomationJobStatus,
-} from "./github-repository-automation-jobs";
+import { resolveGithubRepositoryAutomationCommitRange } from "./github-repository-automation-commit-range";
+import { updateGithubRepositoryAutomationJobStatus } from "./github-repository-automation-jobs";
 import {
   checkoutCommitInSandbox,
   createGithubRepositoryAutomationSandbox,
-  resolveDefaultBranchHeadSha,
   runGitDiffInSandbox,
   runGitLogInSandbox,
   stopGithubRepositoryAutomationSandbox,
@@ -45,49 +42,6 @@ function truncateDiff(diff: string): string {
     return diff;
   }
   return `${diff.slice(0, MAX_DIFF_EXCERPT_CHARS)}\n\n[diff truncated]`;
-}
-
-function parseRepositoryOwnerRepo(fullName: string): { owner: string; repo: string } {
-  const [owner, repo] = fullName.split("/");
-  if (!owner || !repo) {
-    throw new Error("invalid repository full name");
-  }
-  return { owner, repo };
-}
-
-async function resolveCommitRange(job: GithubRepositoryAutomationJobWithRepository): Promise<{
-  commitBefore: string | null;
-  commitAfter: string;
-}> {
-  if (job.commitAfter) {
-    return {
-      commitBefore: job.commitBefore,
-      commitAfter: job.commitAfter,
-    };
-  }
-
-  const branch = job.triggerBranch ?? job.defaultBranch;
-  if (!branch) {
-    throw new Error("github_repository_automation_branch_not_resolved");
-  }
-
-  const { owner, repo } = parseRepositoryOwnerRepo(job.repositoryFullName);
-  const head = await resolveDefaultBranchHeadSha({
-    installationId: job.githubInstallationId,
-    owner,
-    repo,
-    branch,
-  });
-
-  const previousCommit = await findLatestSucceededCommitAfter({
-    githubInstallationRepositoryId: job.githubInstallationRepositoryId,
-    triggerBranch: branch,
-  });
-
-  return {
-    commitBefore: previousCommit,
-    commitAfter: head.sha,
-  };
 }
 
 function resolveJobFinalStatus(input: {
@@ -154,7 +108,7 @@ export async function runGithubRepositoryAutomationValidation(input: {
   }
 
   const blockOnFailure = workflows.validationBlockOnFailure ?? true;
-  const { commitBefore, commitAfter } = await resolveCommitRange(job);
+  const { commitBefore, commitAfter } = await resolveGithubRepositoryAutomationCommitRange(job);
 
   if (!job.commitAfter) {
     await updateGithubRepositoryAutomationJobStatus({

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-worker.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-worker.ts
@@ -2,13 +2,14 @@ import { createLogger } from "@/lib/log";
 import { createGithubRepositoryAutomationQueue } from "@/workflows/adapters";
 
 import { listQueuedGithubRepositoryAutomationJobs } from "./github-repository-automation-jobs";
+import { githubRepositoryAutomationJobHasRunnableWorkflow } from "./github-repository-automation-workflows";
 
 const logger = createLogger("github-repo-automation-worker");
 
 /** Skip queued jobs younger than this — the dispatcher already enqueues them on create. */
 const WORKER_JOB_MIN_AGE_MS = 30_000;
 
-export async function enqueueGithubRepositoryAutomationValidationJob(input: {
+export async function enqueueGithubRepositoryAutomationJob(input: {
   jobId: string;
 }): Promise<{ enqueued: boolean }> {
   const queue = createGithubRepositoryAutomationQueue();
@@ -42,7 +43,7 @@ export async function runGithubRepositoryAutomationWorker(input?: {
   let skipped = 0;
 
   for (const job of jobs) {
-    if (!job.workflows.validation) {
+    if (!githubRepositoryAutomationJobHasRunnableWorkflow(job.workflows)) {
       skipped += 1;
       continue;
     }

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-workflows.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-workflows.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { githubRepositoryAutomationJobHasRunnableWorkflow } from "./github-repository-automation-workflows";
+
+describe("githubRepositoryAutomationJobHasRunnableWorkflow", () => {
+  it("returns true when any workflow is enabled", () => {
+    expect(
+      githubRepositoryAutomationJobHasRunnableWorkflow({
+        pushSource: true,
+        pullTranslations: false,
+        validation: false,
+        validationBlockOnFailure: true,
+      }),
+    ).toBe(true);
+
+    expect(
+      githubRepositoryAutomationJobHasRunnableWorkflow({
+        pushSource: false,
+        pullTranslations: true,
+        validation: false,
+        validationBlockOnFailure: true,
+      }),
+    ).toBe(true);
+
+    expect(
+      githubRepositoryAutomationJobHasRunnableWorkflow({
+        pushSource: false,
+        pullTranslations: false,
+        validation: true,
+        validationBlockOnFailure: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when no workflows are enabled", () => {
+    expect(
+      githubRepositoryAutomationJobHasRunnableWorkflow({
+        pushSource: false,
+        pullTranslations: false,
+        validation: false,
+        validationBlockOnFailure: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-workflows.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-workflows.ts
@@ -1,0 +1,7 @@
+import type { GithubRepoAutomationDispatchPayload } from "./github-repository-automation-settings";
+
+export function githubRepositoryAutomationJobHasRunnableWorkflow(
+  workflows: GithubRepoAutomationDispatchPayload["workflows"],
+): boolean {
+  return workflows.pushSource || workflows.pullTranslations || workflows.validation;
+}

--- a/apps/hyperlocalise-web/src/lib/file-storage/records.ts
+++ b/apps/hyperlocalise-web/src/lib/file-storage/records.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull, or, type SQL } from "drizzle-orm";
+import { and, desc, eq, isNull, or, type SQL } from "drizzle-orm";
 
 import { db, schema } from "@/lib/database";
 
@@ -259,6 +259,34 @@ async function createRepositorySourceFileVersionWithDb(
   }
 
   return version;
+}
+
+export async function getLatestRepositorySourceFileVersion(input: {
+  organizationId: string;
+  projectId: string;
+  sourcePath: string;
+  db?: DbSelectClient;
+}) {
+  const dbClient = input.db ?? db;
+  const sourcePath = normalizeSourcePath(input.sourcePath);
+
+  const [version] = await dbClient
+    .select()
+    .from(schema.repositorySourceFileVersions)
+    .where(
+      and(
+        eq(schema.repositorySourceFileVersions.organizationId, input.organizationId),
+        eq(schema.repositorySourceFileVersions.projectId, input.projectId),
+        eq(schema.repositorySourceFileVersions.sourcePath, sourcePath),
+      ),
+    )
+    .orderBy(
+      desc(schema.repositorySourceFileVersions.createdAt),
+      desc(schema.repositorySourceFileVersions.id),
+    )
+    .limit(1);
+
+  return version ?? null;
 }
 
 export async function getRepositorySourceFileVersionForStoredFile(input: StoredFileScopeInput) {

--- a/apps/hyperlocalise-web/src/lib/file-storage/source-file-metadata.ts
+++ b/apps/hyperlocalise-web/src/lib/file-storage/source-file-metadata.ts
@@ -1,0 +1,33 @@
+import { inferSupportedFileTranslationFileFormat } from "@/lib/translation/file-formats";
+
+import { normalizeSourcePath } from "./records";
+
+export function sourceFilename(path: string) {
+  const normalizedPath = normalizeSourcePath(path);
+  return normalizedPath.split("/").filter(Boolean).at(-1) ?? normalizedPath;
+}
+
+export function sourceContentType(path: string) {
+  const format = inferSupportedFileTranslationFileFormat(path);
+  switch (format) {
+    case "json":
+    case "jsonc":
+    case "arb":
+      return "application/json";
+    case "xliff":
+      return "application/xliff+xml";
+    case "po":
+    case "strings":
+    case "stringsdict":
+      return "text/plain";
+    case "html":
+      return "text/html";
+    case "markdown":
+    case "mdx":
+      return "text/markdown";
+    case "csv":
+      return "text/csv";
+    default:
+      return "application/octet-stream";
+  }
+}

--- a/apps/hyperlocalise-web/src/lib/file-storage/upload-repository-source-files.ts
+++ b/apps/hyperlocalise-web/src/lib/file-storage/upload-repository-source-files.ts
@@ -1,0 +1,150 @@
+import { db } from "@/lib/database";
+import { getFileStorageAdapter } from "@/lib/file-storage";
+import {
+  createRepositorySourceFileVersion,
+  createStoredFile,
+  getLatestRepositorySourceFileVersion,
+  normalizeSourcePath,
+  sha256Hex,
+} from "@/lib/file-storage/records";
+import { sourceContentType, sourceFilename } from "@/lib/file-storage/source-file-metadata";
+import { runSandboxCommand } from "@/lib/translation/sandbox-translation";
+import { inferSupportedFileTranslationFileFormat } from "@/lib/translation/file-formats";
+
+export type UploadRepositorySourceFileResult =
+  | {
+      path: string;
+      outcome: "uploaded";
+      fileId: string;
+      sourceFileVersionId: string;
+    }
+  | {
+      path: string;
+      outcome: "skipped";
+      reason: string;
+      sourceFileVersionId?: string;
+    }
+  | {
+      path: string;
+      outcome: "failed";
+      reason: string;
+    };
+
+export async function uploadRepositorySourceFilesFromSandbox(input: {
+  sandboxId: string;
+  organizationId: string;
+  projectId: string;
+  paths: string[];
+  commitSha?: string | null;
+  workflowRunId?: string | null;
+  uploadSurface?: string;
+}): Promise<UploadRepositorySourceFileResult[]> {
+  const adapter = getFileStorageAdapter();
+  const results: UploadRepositorySourceFileResult[] = [];
+
+  for (const path of input.paths) {
+    const normalizedPath = normalizeSourcePath(path);
+    if (!inferSupportedFileTranslationFileFormat(normalizedPath)) {
+      results.push({
+        path: normalizedPath,
+        outcome: "failed",
+        reason: "unsupported_source_file_format",
+      });
+      continue;
+    }
+
+    const readResult = await runSandboxCommand(input.sandboxId, "cat", [normalizedPath], {
+      output: "stdout",
+    });
+    if (readResult.exitCode !== 0) {
+      results.push({
+        path: normalizedPath,
+        outcome: "failed",
+        reason: "failed_to_read_source_file",
+      });
+      continue;
+    }
+
+    const content = Buffer.from(readResult.output);
+    const sourceHash = await sha256Hex(content);
+
+    if (input.commitSha) {
+      const latestVersion = await getLatestRepositorySourceFileVersion({
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        sourcePath: normalizedPath,
+      });
+
+      if (
+        latestVersion &&
+        latestVersion.commitSha === input.commitSha &&
+        latestVersion.sourceHash === sourceHash
+      ) {
+        results.push({
+          path: normalizedPath,
+          outcome: "skipped",
+          reason: "unchanged_for_commit",
+          sourceFileVersionId: latestVersion.id,
+        });
+        continue;
+      }
+    }
+
+    let uploadedStorageKey: string | null = null;
+
+    try {
+      const { storedFile, version } = await db.transaction(async (tx) => {
+        const storedFile = await createStoredFile({
+          organizationId: input.organizationId,
+          projectId: input.projectId,
+          createdByUserId: null,
+          role: "source",
+          sourceKind: "repository_file",
+          filename: sourceFilename(normalizedPath),
+          contentType: sourceContentType(normalizedPath),
+          content,
+          metadata: {
+            sourcePath: normalizedPath,
+            commitSha: input.commitSha ?? null,
+            workflowRunId: input.workflowRunId ?? null,
+            uploadSurface: input.uploadSurface ?? "github_automation",
+          },
+          adapter,
+          db: tx,
+        });
+        uploadedStorageKey = storedFile.storageKey;
+
+        const version = await createRepositorySourceFileVersion({
+          storedFile,
+          sourcePath: normalizedPath,
+          sourceHash,
+          commitSha: input.commitSha ?? null,
+          workflowRunId: input.workflowRunId ?? null,
+          uploadSurface: input.uploadSurface ?? "github_automation",
+          db: tx,
+        });
+
+        return { storedFile, version };
+      });
+
+      results.push({
+        path: normalizedPath,
+        outcome: "uploaded",
+        fileId: storedFile.id,
+        sourceFileVersionId: version.id,
+      });
+    } catch {
+      if (uploadedStorageKey) {
+        await adapter.delete({ keyOrUrl: uploadedStorageKey }).catch(() => undefined);
+      }
+
+      results.push({
+        path: normalizedPath,
+        outcome: "failed",
+        reason: "failed_to_store_source_file",
+      });
+    }
+  }
+
+  return results;
+}

--- a/apps/hyperlocalise-web/src/lib/file-storage/upload-repository-source-files.ts
+++ b/apps/hyperlocalise-web/src/lib/file-storage/upload-repository-source-files.ts
@@ -1,5 +1,6 @@
 import { db } from "@/lib/database";
 import { getFileStorageAdapter } from "@/lib/file-storage";
+import { createLogger } from "@/lib/log";
 import {
   createRepositorySourceFileVersion,
   createStoredFile,
@@ -10,6 +11,8 @@ import {
 import { sourceContentType, sourceFilename } from "@/lib/file-storage/source-file-metadata";
 import { runSandboxCommand } from "@/lib/translation/sandbox-translation";
 import { inferSupportedFileTranslationFileFormat } from "@/lib/translation/file-formats";
+
+const logger = createLogger("upload-repository-source-files");
 
 export type UploadRepositorySourceFileResult =
   | {
@@ -47,7 +50,7 @@ export async function uploadRepositorySourceFilesFromSandbox(input: {
     if (!inferSupportedFileTranslationFileFormat(normalizedPath)) {
       results.push({
         path: normalizedPath,
-        outcome: "failed",
+        outcome: "skipped",
         reason: "unsupported_source_file_format",
       });
       continue;
@@ -133,10 +136,20 @@ export async function uploadRepositorySourceFilesFromSandbox(input: {
         fileId: storedFile.id,
         sourceFileVersionId: version.id,
       });
-    } catch {
+    } catch (error) {
       if (uploadedStorageKey) {
         await adapter.delete({ keyOrUrl: uploadedStorageKey }).catch(() => undefined);
       }
+
+      logger.error(
+        {
+          organizationId: input.organizationId,
+          projectId: input.projectId,
+          reason: "failed_to_store_source_file",
+          err: error,
+        },
+        "failed to store repository source file",
+      );
 
       results.push({
         path: normalizedPath,

--- a/apps/hyperlocalise-web/src/workflows/github-repository-automation.ts
+++ b/apps/hyperlocalise-web/src/workflows/github-repository-automation.ts
@@ -6,6 +6,7 @@ import {
   getGithubRepositoryAutomationJobById,
   updateGithubRepositoryAutomationJobStatus,
 } from "@/lib/agents/github/github-repository-automation-jobs";
+import { runGithubRepositoryAutomationPushSource } from "@/lib/agents/github/github-repository-automation-push-source";
 import { runGithubRepositoryAutomationValidation } from "@/lib/agents/github/github-repository-automation-validation";
 
 async function loadJobStep(jobId: string) {
@@ -38,7 +39,7 @@ async function claimJobStep(input: { jobId: string; workflowRunId: string }) {
   return claimed;
 }
 
-async function validateJobStep(input: { jobId: string; workflowRunId: string }) {
+async function runAutomationJobStep(input: { jobId: string; workflowRunId: string }) {
   "use step";
 
   const job = await getGithubRepositoryAutomationJobById(input.jobId);
@@ -46,10 +47,41 @@ async function validateJobStep(input: { jobId: string; workflowRunId: string }) 
     throw new Error("github_repository_automation_job_not_found");
   }
 
-  return runGithubRepositoryAutomationValidation({
-    job,
-    workflowRunId: input.workflowRunId,
-  });
+  const results: Record<string, unknown> = {};
+
+  if (job.workflows.pushSource) {
+    results.pushSource = await runGithubRepositoryAutomationPushSource({
+      job,
+      workflowRunId: input.workflowRunId,
+    });
+  }
+
+  if (job.workflows.validation) {
+    results.validation = await runGithubRepositoryAutomationValidation({
+      job,
+      workflowRunId: input.workflowRunId,
+    });
+  }
+
+  if (!job.workflows.pushSource && !job.workflows.validation && !job.workflows.pullTranslations) {
+    await updateGithubRepositoryAutomationJobStatus({
+      jobId: job.id,
+      status: "skipped",
+      skipReason: "no_runnable_workflows",
+    });
+    return { skipped: true, reason: "no_runnable_workflows" };
+  }
+
+  if (!job.workflows.pushSource && !job.workflows.validation) {
+    await updateGithubRepositoryAutomationJobStatus({
+      jobId: job.id,
+      status: "skipped",
+      skipReason: "pull_translations_not_implemented",
+    });
+    return { skipped: true, reason: "pull_translations_not_implemented" };
+  }
+
+  return results;
 }
 
 export async function githubRepositoryAutomationWorkflow(
@@ -86,5 +118,5 @@ export async function githubRepositoryAutomationWorkflow(
     };
   }
 
-  return validateJobStep({ jobId: event.jobId, workflowRunId });
+  return runAutomationJobStep({ jobId: event.jobId, workflowRunId });
 }

--- a/apps/hyperlocalise-web/src/workflows/github-repository-automation.ts
+++ b/apps/hyperlocalise-web/src/workflows/github-repository-automation.ts
@@ -6,6 +6,10 @@ import {
   getGithubRepositoryAutomationJobById,
   updateGithubRepositoryAutomationJobStatus,
 } from "@/lib/agents/github/github-repository-automation-jobs";
+import {
+  resolveGithubRepositoryAutomationCommitRange,
+  type GithubRepositoryAutomationCommitRange,
+} from "@/lib/agents/github/github-repository-automation-commit-range";
 import { runGithubRepositoryAutomationPushSource } from "@/lib/agents/github/github-repository-automation-push-source";
 import { runGithubRepositoryAutomationValidation } from "@/lib/agents/github/github-repository-automation-validation";
 
@@ -42,17 +46,42 @@ async function claimJobStep(input: { jobId: string; workflowRunId: string }) {
 async function runAutomationJobStep(input: { jobId: string; workflowRunId: string }) {
   "use step";
 
-  const job = await getGithubRepositoryAutomationJobById(input.jobId);
+  let job = await getGithubRepositoryAutomationJobById(input.jobId);
   if (!job) {
     throw new Error("github_repository_automation_job_not_found");
   }
 
   const results: Record<string, unknown> = {};
+  const needsCommitRange = job.workflows.pushSource || job.workflows.validation;
+  let commitRange: GithubRepositoryAutomationCommitRange | undefined;
+
+  if (needsCommitRange) {
+    if (job.commitAfter) {
+      commitRange = {
+        commitBefore: job.commitBefore,
+        commitAfter: job.commitAfter,
+      };
+    } else {
+      commitRange = await resolveGithubRepositoryAutomationCommitRange(job);
+      await updateGithubRepositoryAutomationJobStatus({
+        jobId: job.id,
+        status: "running",
+        commitBefore: commitRange.commitBefore,
+        commitAfter: commitRange.commitAfter,
+      });
+      job = {
+        ...job,
+        commitBefore: commitRange.commitBefore,
+        commitAfter: commitRange.commitAfter,
+      };
+    }
+  }
 
   if (job.workflows.pushSource) {
     results.pushSource = await runGithubRepositoryAutomationPushSource({
       job,
       workflowRunId: input.workflowRunId,
+      commitRange,
     });
   }
 
@@ -60,6 +89,7 @@ async function runAutomationJobStep(input: { jobId: string; workflowRunId: strin
     results.validation = await runGithubRepositoryAutomationValidation({
       job,
       workflowRunId: input.workflowRunId,
+      commitRange,
     });
   }
 

--- a/apps/hyperlocalise-web/src/workflows/github-repository-automation.ts
+++ b/apps/hyperlocalise-web/src/workflows/github-repository-automation.ts
@@ -51,6 +51,24 @@ async function runAutomationJobStep(input: { jobId: string; workflowRunId: strin
     throw new Error("github_repository_automation_job_not_found");
   }
 
+  if (!job.workflows.pushSource && !job.workflows.validation && !job.workflows.pullTranslations) {
+    await updateGithubRepositoryAutomationJobStatus({
+      jobId: job.id,
+      status: "skipped",
+      skipReason: "no_runnable_workflows",
+    });
+    return { skipped: true, reason: "no_runnable_workflows" };
+  }
+
+  if (!job.workflows.pushSource && !job.workflows.validation) {
+    await updateGithubRepositoryAutomationJobStatus({
+      jobId: job.id,
+      status: "skipped",
+      skipReason: "pull_translations_not_implemented",
+    });
+    return { skipped: true, reason: "pull_translations_not_implemented" };
+  }
+
   const results: Record<string, unknown> = {};
   const needsCommitRange = job.workflows.pushSource || job.workflows.validation;
   let commitRange: GithubRepositoryAutomationCommitRange | undefined;
@@ -91,24 +109,6 @@ async function runAutomationJobStep(input: { jobId: string; workflowRunId: strin
       workflowRunId: input.workflowRunId,
       commitRange,
     });
-  }
-
-  if (!job.workflows.pushSource && !job.workflows.validation && !job.workflows.pullTranslations) {
-    await updateGithubRepositoryAutomationJobStatus({
-      jobId: job.id,
-      status: "skipped",
-      skipReason: "no_runnable_workflows",
-    });
-    return { skipped: true, reason: "no_runnable_workflows" };
-  }
-
-  if (!job.workflows.pushSource && !job.workflows.validation) {
-    await updateGithubRepositoryAutomationJobStatus({
-      jobId: job.id,
-      status: "skipped",
-      skipReason: "pull_translations_not_implemented",
-    });
-    return { skipped: true, reason: "pull_translations_not_implemented" };
   }
 
   return results;

--- a/apps/hyperlocalise-web/src/workflows/github-repository-automation.ts
+++ b/apps/hyperlocalise-web/src/workflows/github-repository-automation.ts
@@ -10,6 +10,8 @@ import {
   resolveGithubRepositoryAutomationCommitRange,
   type GithubRepositoryAutomationCommitRange,
 } from "@/lib/agents/github/github-repository-automation-commit-range";
+import { isErr } from "@/lib/primitives/result/results";
+
 import { runGithubRepositoryAutomationPushSource } from "@/lib/agents/github/github-repository-automation-push-source";
 import { runGithubRepositoryAutomationValidation } from "@/lib/agents/github/github-repository-automation-validation";
 
@@ -96,11 +98,20 @@ async function runAutomationJobStep(input: { jobId: string; workflowRunId: strin
   }
 
   if (job.workflows.pushSource) {
-    results.pushSource = await runGithubRepositoryAutomationPushSource({
+    const pushSourceResult = await runGithubRepositoryAutomationPushSource({
       job,
       workflowRunId: input.workflowRunId,
       commitRange,
     });
+
+    if (isErr(pushSourceResult)) {
+      results.pushSource = pushSourceResult.error;
+      if (pushSourceResult.error.code === "infrastructure") {
+        throw new Error(pushSourceResult.error.message);
+      }
+    } else {
+      results.pushSource = pushSourceResult.value;
+    }
   }
 
   if (job.workflows.validation) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Implements **push source automation** for GitHub repository jobs (HL-446). When `workflows.pushSource` is enabled, automation now:

- Resolves the target project from `pushSource.projectId` in settings or a unique connector `projectRepositories` mapping
- Computes changed **source** paths across the job commit range (not translation/locale paths)
- Checks out the post-push commit in the sandbox and uploads file contents via existing `createStoredFile` / `createRepositorySourceFileVersion` primitives
- Stores traceability metadata (`commitSha`, `workflowRunId`, `sourcePath`, `uploadSurface: github_automation`)
- Skips idempotently when the latest version already matches the same commit and content hash

Dispatcher and worker now enqueue jobs when **any** runnable workflow is enabled (`pushSource`, `pullTranslations`, or `validation`), not validation-only. The workflow runs push source before validation when both are configured.

## How to test

- `cd apps/hyperlocalise-web && vp check --fix && vp test`
- Targeted: `vp test src/lib/agents/github/github-repository-automation-{project,commits,workflows,dispatcher}.test.ts`
- With Postgres and GitHub automation settings with `pushSource: true` and a linked project, trigger a push that changes configured source paths and confirm `repository_source_file_versions` rows include the expected `commitSha` and paths

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, `vp test`)
- [x] This PR is scoped and ready for review

## Notes

- `pullTranslations` remains stubbed as not implemented in the workflow
- Combined push + validation jobs: validation’s final job status update may override push source summary (acceptable for MVP)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-446](https://linear.app/hyperlocalise/issue/HL-446/implement-push-source-automation-from-github-repositories)

<div><a href="https://cursor.com/agents/bc-12ceafa3-23c4-4a37-9372-353ec302e231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12ceafa3-23c4-4a37-9372-353ec302e231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

