### PR TITLE
🛡️ Sentinel: prevent CSV formula injection in exports

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -42,3 +42,8 @@
 **Vulnerability:** Conversation and chat-request routes only verified organization ownership, but did not check for project-level access. This allowed users to access or create interactions for projects they were not members of within the same organization (BOLA).
 **Learning:** Interactions linked to projects must inherit the same authorization constraints as the projects themselves. Any route that performs a lookup or mutation on a sub-resource must verify the user's path through the hierarchy.
 **Prevention:** Implement and enforce specialized accessibility helpers (like `buildAccessibleInteractionsWhere` and `canAccessInteraction`) that explicitly account for both project-less (organization-global) and project-scoped resources.
+
+## 2026-05-31 - [Enhancement] Preventing CSV Formula Injection in Exports
+**Vulnerability:** Glossary and translation memory CSV exports were vulnerable to formula injection. If a translation string started with characters like '=', '+', '-', or '@', spreadsheet applications could execute them as formulas.
+**Learning:** Even though the application uses a local-first CLI and trusted TMS providers, the exported data is ultimately user-controlled and can be opened in insecure environments like Excel.
+**Prevention:** Use a centralized helper like `csvsafe.EscapeRow` to sanitize all CSV exports. This ensures consistent protection across all storage adapters.

--- a/internal/i18n/storage/crowdin/BUILD.bazel
+++ b/internal/i18n/storage/crowdin/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/hyperlocalise/hyperlocalise/internal/i18n/storage/crowdin",
     visibility = ["//visibility:public"],
     deps = [
+        "//internal/csvsafe",
         "//internal/pathguard",
         "//internal/i18n/storage",
         "@com_github_crowdin_crowdin_api_client_go//crowdin",

--- a/internal/i18n/storage/crowdin/glossary.go
+++ b/internal/i18n/storage/crowdin/glossary.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/crowdin/crowdin-api-client-go/crowdin/model"
+	"github.com/hyperlocalise/hyperlocalise/internal/csvsafe"
 )
 
 const glossaryCSVPageLimit = 500
@@ -85,7 +86,7 @@ func (c *HTTPClient) WriteGlossaryCSV(ctx context.Context, req GlossaryDownloadR
 		return GlossaryDownloadResult{}, fmt.Errorf("write glossary csv header: %w", err)
 	}
 	for _, row := range rows {
-		if err := writer.Write(row); err != nil {
+		if err := writer.Write(csvsafe.EscapeRow(row)); err != nil {
 			return GlossaryDownloadResult{}, fmt.Errorf("write glossary csv row: %w", err)
 		}
 	}

--- a/internal/i18n/storage/crowdin/glossary_test.go
+++ b/internal/i18n/storage/crowdin/glossary_test.go
@@ -122,6 +122,41 @@ func TestWriteGlossaryCSVWritesStableRows(t *testing.T) {
 	}
 }
 
+func TestWriteGlossaryCSVEscapesFormulaPrefixes(t *testing.T) {
+	client, mux, teardown := newCrowdinHTTPClientForTest(t)
+	defer teardown()
+
+	mux.HandleFunc("/api/v2/glossaries/77", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, map[string]any{"data": map[string]any{"id": 77, "languageId": "en"}})
+	})
+	mux.HandleFunc("/api/v2/glossaries/77/concepts", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, map[string]any{
+			"data": []any{
+				map[string]any{"data": map[string]any{"id": 9, "subject": "=subject"}},
+			},
+			"pagination": map[string]any{"offset": 0, "limit": 500},
+		})
+	})
+	mux.HandleFunc("/api/v2/glossaries/77/terms", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, map[string]any{
+			"data": []any{
+				map[string]any{"data": map[string]any{"id": 3, "languageId": "en", "text": "Checkout", "conceptId": 9}},
+				map[string]any{"data": map[string]any{"id": 4, "languageId": "fr", "text": "=cmd", "conceptId": 9}},
+			},
+			"pagination": map[string]any{"offset": 0, "limit": 500},
+		})
+	})
+
+	var out bytes.Buffer
+	if _, err := client.WriteGlossaryCSV(context.Background(), GlossaryDownloadRequest{GlossaryID: 77}, &out); err != nil {
+		t.Fatalf("write glossary csv: %v", err)
+	}
+
+	if !strings.Contains(out.String(), "'=cmd") || !strings.Contains(out.String(), "'=subject") {
+		t.Fatalf("expected formula-prefixed cells to be escaped, got: %s", out.String())
+	}
+}
+
 func TestWriteGlossaryCSVPaginatesTerms(t *testing.T) {
 	client, mux, teardown := newCrowdinHTTPClientForTest(t)
 	defer teardown()

--- a/internal/i18n/storage/crowdin/translation_memory.go
+++ b/internal/i18n/storage/crowdin/translation_memory.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/crowdin/crowdin-api-client-go/crowdin/model"
+	"github.com/hyperlocalise/hyperlocalise/internal/csvsafe"
 )
 
 const translationMemoryCSVPageLimit = 500
@@ -81,7 +82,7 @@ func (c *HTTPClient) WriteTranslationMemoryCSV(ctx context.Context, req Translat
 		return TranslationMemoryDownloadResult{}, fmt.Errorf("write translation memory csv header: %w", err)
 	}
 	for _, row := range rows {
-		if err := writer.Write(row); err != nil {
+		if err := writer.Write(csvsafe.EscapeRow(row)); err != nil {
 			return TranslationMemoryDownloadResult{}, fmt.Errorf("write translation memory csv row: %w", err)
 		}
 	}

--- a/internal/i18n/storage/crowdin/translation_memory_test.go
+++ b/internal/i18n/storage/crowdin/translation_memory_test.go
@@ -64,6 +64,39 @@ func TestWriteTranslationMemoryCSVWritesStableRows(t *testing.T) {
 	}
 }
 
+func TestWriteTranslationMemoryCSVEscapesFormulaPrefixes(t *testing.T) {
+	client, mux, teardown := newCrowdinHTTPClientForTest(t)
+	defer teardown()
+
+	mux.HandleFunc("/api/v2/tms/77/segments", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, map[string]any{
+			"data": []any{
+				map[string]any{"data": map[string]any{
+					"id": 9,
+					"records": []any{
+						map[string]any{"id": 1, "languageId": "en", "text": "Checkout"},
+						map[string]any{"id": 2, "languageId": "fr", "text": "=cmd"},
+					},
+				}},
+			},
+			"pagination": map[string]any{"offset": 0, "limit": 500},
+		})
+	})
+
+	var out bytes.Buffer
+	if _, err := client.WriteTranslationMemoryCSV(context.Background(), TranslationMemoryDownloadRequest{
+		TranslationMemoryID: 77,
+		SourceLanguage:      "en",
+		TargetLanguages:     []string{"fr"},
+	}, &out); err != nil {
+		t.Fatalf("write translation memory csv: %v", err)
+	}
+
+	if !strings.Contains(out.String(), "'=cmd") {
+		t.Fatalf("expected formula-prefixed cells to be escaped, got: %s", out.String())
+	}
+}
+
 func TestWriteTranslationMemoryCSVPaginatesSegments(t *testing.T) {
 	client, mux, teardown := newCrowdinHTTPClientForTest(t)
 	defer teardown()

--- a/internal/i18n/storage/phrase/BUILD.bazel
+++ b/internal/i18n/storage/phrase/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/hyperlocalise/hyperlocalise/internal/i18n/storage/phrase",
     visibility = ["//visibility:public"],
     deps = [
+        "//internal/csvsafe",
         "//internal/i18n/locales",
         "//internal/i18n/storage",
         "@com_github_antihax_optional//:optional",

--- a/internal/i18n/storage/phrase/glossary.go
+++ b/internal/i18n/storage/phrase/glossary.go
@@ -10,6 +10,8 @@ import (
 	"net/url"
 	"slices"
 	"strings"
+
+	"github.com/hyperlocalise/hyperlocalise/internal/csvsafe"
 )
 
 var glossaryCSVHeader = []string{
@@ -88,7 +90,7 @@ func (c *HTTPClient) WriteGlossaryCSV(ctx context.Context, in GlossaryDownloadIn
 		return GlossaryDownloadResult{}, fmt.Errorf("write phrase glossary csv header: %w", err)
 	}
 	for _, row := range rows {
-		if err := writer.Write(row); err != nil {
+		if err := writer.Write(csvsafe.EscapeRow(row)); err != nil {
 			return GlossaryDownloadResult{}, fmt.Errorf("write phrase glossary csv row: %w", err)
 		}
 	}

--- a/internal/i18n/storage/phrase/http_client_test.go
+++ b/internal/i18n/storage/phrase/http_client_test.go
@@ -239,6 +239,64 @@ func TestHTTPClientDownloadSourceFileAPIError(t *testing.T) {
 	}
 }
 
+func TestWriteGlossaryCSVEscapesFormulaPrefixes(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/accounts/acc-1/glossaries/glo-1/terms", func(w http.ResponseWriter, _ *http.Request) {
+		writePhraseJSON(t, w, []any{
+			map[string]any{
+				"id": "term-1", "term": "=cmd", "description": "+note",
+				"translations": []any{},
+			},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client := newHTTPClient(srv.URL, srv.Client())
+	out := bytes.NewBuffer(nil)
+	if _, err := client.WriteGlossaryCSV(context.Background(), GlossaryDownloadInput{
+		AccountID: "acc-1", GlossaryID: "glo-1", APIToken: "token",
+	}, out); err != nil {
+		t.Fatalf("write glossary csv: %v", err)
+	}
+	if !strings.Contains(out.String(), "'=cmd") || !strings.Contains(out.String(), "'+note") {
+		t.Fatalf("expected formula-prefixed cells to be escaped, got: %s", out.String())
+	}
+}
+
+func TestWriteTranslationMemoryCSVEscapesFormulaPrefixes(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/transMemories/tm-1/export", func(w http.ResponseWriter, _ *http.Request) {
+		writePhraseJSON(t, w, map[string]any{"asyncRequest": map[string]any{"id": "async-1"}})
+	})
+	mux.HandleFunc("/v1/transMemories/downloadExport/async-1", func(w http.ResponseWriter, _ *http.Request) {
+		tmx := `<?xml version="1.0" encoding="UTF-8"?>
+<tmx version="1.4">
+  <body>
+    <tu tuid="1">
+      <tuv lang="en"><seg>Checkout</seg></tuv>
+      <tuv lang="fr"><seg>=cmd</seg></tuv>
+    </tu>
+  </body>
+</tmx>`
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(tmx))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client := newHTTPClient(srv.URL, srv.Client())
+	out := bytes.NewBuffer(nil)
+	if _, err := client.WriteTranslationMemoryCSV(context.Background(), TranslationMemoryDownloadInput{
+		TranslationMemoryID: "tm-1", APIToken: "token", SourceLanguage: "en", TargetLanguages: []string{"fr"},
+	}, out); err != nil {
+		t.Fatalf("write translation memory csv: %v", err)
+	}
+	if !strings.Contains(out.String(), "'=cmd") {
+		t.Fatalf("expected formula-prefixed cells to be escaped, got: %s", out.String())
+	}
+}
+
 func TestHTTPClientDownloadTranslationFile(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/projects/p/locales/fr/download", func(w http.ResponseWriter, r *http.Request) {
@@ -305,6 +363,14 @@ func TestRetryDelayUsesExponentialBackoff(t *testing.T) {
 	d2 := retryDelay(1, nil)
 	if d2 <= d1 || d1 < 200*time.Millisecond {
 		t.Fatalf("unexpected delays: %s %s", d1, d2)
+	}
+}
+
+func writePhraseJSON(t *testing.T, w http.ResponseWriter, value any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(value); err != nil {
+		t.Fatalf("write json: %v", err)
 	}
 }
 

--- a/internal/i18n/storage/phrase/translation_memory.go
+++ b/internal/i18n/storage/phrase/translation_memory.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hyperlocalise/hyperlocalise/internal/csvsafe"
 	"github.com/hyperlocalise/hyperlocalise/internal/i18n/locales"
 )
 
@@ -113,7 +114,7 @@ func (c *HTTPClient) WriteTranslationMemoryCSV(ctx context.Context, in Translati
 		return TranslationMemoryDownloadResult{}, fmt.Errorf("write phrase translation memory csv header: %w", err)
 	}
 	for _, row := range rows {
-		if err := writer.Write(row); err != nil {
+		if err := writer.Write(csvsafe.EscapeRow(row)); err != nil {
 			return TranslationMemoryDownloadResult{}, fmt.Errorf("write phrase translation memory csv row: %w", err)
 		}
 	}


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix CSV Formula Injection in Exports

🚨 Severity: MEDIUM
💡 Vulnerability: Glossary and translation memory CSV exports from Crowdin and Phrase were missing formula escaping.
🎯 Impact: User-controlled translation strings starting with `=`, `+`, `-`, or `@` could be executed as formulas when exported CSV files are opened in applications like Excel or Google Sheets.
🔧 Fix: Applied the existing `csvsafe.EscapeRow` helper to all rows in Crowdin and Phrase CSV export paths.
✅ Verification: Added new test cases to `internal/i18n/storage/crowdin/glossary_test.go`, `internal/i18n/storage/crowdin/translation_memory_test.go`, and `internal/i18n/storage/phrase/http_client_test.go` that specifically assert formula-prefixed values are escaped with a single quote.

---
*PR created automatically by Jules for task [13050811013464559900](https://jules.google.com/task/13050811013464559900) started by @cungminh2710*