### PR TITLE
refactor(security): use Result pattern in lib/security modules

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/job.workflow.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.workflow.test.ts
@@ -12,7 +12,10 @@ import {
   usageFeatureIds,
 } from "@/lib/billing/usage-control";
 import { isErr } from "@/lib/primitives/result/results";
-import { encryptProviderCredential } from "@/lib/security/provider-credential-crypto";
+import {
+  encryptProviderCredential,
+  unwrapProviderCredentialCrypto,
+} from "@/lib/security/provider-credential-crypto";
 import {
   claimTranslationJob,
   completeTranslationJob,
@@ -32,7 +35,9 @@ async function insertProviderCredential(input: {
   provider: "openai" | "anthropic" | "gemini" | "groq" | "mistral";
   defaultModel: string;
 }) {
-  const encrypted = encryptProviderCredential("test-provider-api-key");
+  const encrypted = unwrapProviderCredentialCrypto(
+    encryptProviderCredential("test-provider-api-key"),
+  );
 
   await db.insert(schema.organizationLlmProviderCredentials).values({
     organizationId: input.organizationId,

--- a/apps/hyperlocalise-web/src/lib/providers/external-tms-content-sync.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/external-tms-content-sync.ts
@@ -2,7 +2,10 @@ import { and, eq } from "drizzle-orm";
 
 import { db, schema } from "@/lib/database";
 import type { ProviderSyncRunStatus } from "@/lib/database/types";
-import { decryptProviderCredential } from "@/lib/security/provider-credential-crypto";
+import {
+  decryptProviderCredential,
+  unwrapProviderCredentialCrypto,
+} from "@/lib/security/provider-credential-crypto";
 
 import type { ExternalTmsProviderKind } from "./organization-external-tms-provider-credentials";
 import {
@@ -155,13 +158,15 @@ export async function pullExternalTmsTaskContent(input: {
   });
 
   try {
-    const secretMaterial = decryptProviderCredential({
-      algorithm: credential.encryptionAlgorithm,
-      keyVersion: credential.keyVersion,
-      ciphertext: credential.ciphertext,
-      iv: credential.iv,
-      authTag: credential.authTag,
-    });
+    const secretMaterial = unwrapProviderCredentialCrypto(
+      decryptProviderCredential({
+        algorithm: credential.encryptionAlgorithm,
+        keyVersion: credential.keyVersion,
+        ciphertext: credential.ciphertext,
+        iv: credential.iv,
+        authTag: credential.authTag,
+      }),
+    );
 
     const content = await input.pullContent({
       organizationId: input.organizationId,
@@ -269,13 +274,15 @@ export async function pushExternalTmsTranslations(input: {
   const failures: ExternalTmsContentSyncFailure[] = [];
 
   try {
-    const secretMaterial = decryptProviderCredential({
-      algorithm: credential.encryptionAlgorithm,
-      keyVersion: credential.keyVersion,
-      ciphertext: credential.ciphertext,
-      iv: credential.iv,
-      authTag: credential.authTag,
-    });
+    const secretMaterial = unwrapProviderCredentialCrypto(
+      decryptProviderCredential({
+        algorithm: credential.encryptionAlgorithm,
+        keyVersion: credential.keyVersion,
+        ciphertext: credential.ciphertext,
+        iv: credential.iv,
+        authTag: credential.authTag,
+      }),
+    );
 
     const pushResult = await input.pushTranslations({
       organizationId: input.organizationId,

--- a/apps/hyperlocalise-web/src/lib/providers/external-tms-file-sync.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/external-tms-file-sync.ts
@@ -2,7 +2,10 @@ import { and, eq } from "drizzle-orm";
 
 import { db, schema } from "@/lib/database";
 import type { ProviderSyncRunStatus } from "@/lib/database/types";
-import { decryptProviderCredential } from "@/lib/security/provider-credential-crypto";
+import {
+  decryptProviderCredential,
+  unwrapProviderCredentialCrypto,
+} from "@/lib/security/provider-credential-crypto";
 
 import type { ExternalTmsProviderKind } from "./organization-external-tms-provider-credentials";
 import { upsertExternalTmsFile } from "./organization-external-tms-files";
@@ -103,13 +106,15 @@ export async function syncExternalTmsFileKeys(input: {
   const failures: ExternalTmsFileKeySyncFailure[] = [];
 
   try {
-    const secretMaterial = decryptProviderCredential({
-      algorithm: credential.encryptionAlgorithm,
-      keyVersion: credential.keyVersion,
-      ciphertext: credential.ciphertext,
-      iv: credential.iv,
-      authTag: credential.authTag,
-    });
+    const secretMaterial = unwrapProviderCredentialCrypto(
+      decryptProviderCredential({
+        algorithm: credential.encryptionAlgorithm,
+        keyVersion: credential.keyVersion,
+        ciphertext: credential.ciphertext,
+        iv: credential.iv,
+        authTag: credential.authTag,
+      }),
+    );
     const fileKeys = await input.fetchFileKeys({
       organizationId: input.organizationId,
       projectId: project.id,

--- a/apps/hyperlocalise-web/src/lib/providers/external-tms-glossary-sync.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/external-tms-glossary-sync.ts
@@ -2,7 +2,10 @@ import { and, eq } from "drizzle-orm";
 
 import { db, schema } from "@/lib/database";
 import type { ProviderSyncRunStatus } from "@/lib/database/types";
-import { decryptProviderCredential } from "@/lib/security/provider-credential-crypto";
+import {
+  decryptProviderCredential,
+  unwrapProviderCredentialCrypto,
+} from "@/lib/security/provider-credential-crypto";
 
 import {
   upsertOrganizationExternalTmsGlossary,
@@ -120,13 +123,15 @@ export async function syncExternalTmsGlossaries(input: {
   const failures: ExternalTmsGlossarySyncFailure[] = [];
 
   try {
-    const secretMaterial = decryptProviderCredential({
-      algorithm: credential.encryptionAlgorithm,
-      keyVersion: credential.keyVersion,
-      ciphertext: credential.ciphertext,
-      iv: credential.iv,
-      authTag: credential.authTag,
-    });
+    const secretMaterial = unwrapProviderCredentialCrypto(
+      decryptProviderCredential({
+        algorithm: credential.encryptionAlgorithm,
+        keyVersion: credential.keyVersion,
+        ciphertext: credential.ciphertext,
+        iv: credential.iv,
+        authTag: credential.authTag,
+      }),
+    );
 
     const glossaries = await input.fetchGlossaries({
       organizationId: input.organizationId,

--- a/apps/hyperlocalise-web/src/lib/providers/external-tms-health-check.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/external-tms-health-check.ts
@@ -1,7 +1,10 @@
 import { and, desc, eq, ne } from "drizzle-orm";
 
 import { db, schema } from "@/lib/database";
-import { decryptProviderCredential } from "@/lib/security/provider-credential-crypto";
+import {
+  decryptProviderCredential,
+  unwrapProviderCredentialCrypto,
+} from "@/lib/security/provider-credential-crypto";
 
 import type { ExternalTmsProviderKind } from "./organization-external-tms-provider-credentials";
 import { resolvePhraseBaseUrl } from "./phrase/phrase-base-url";
@@ -73,13 +76,15 @@ export async function checkExternalTmsProviderHealth(input: {
     organizationId: input.organizationId,
     providerKind: input.providerKind,
   });
-  const secretMaterial = decryptProviderCredential({
-    algorithm: credential.encryptionAlgorithm,
-    keyVersion: credential.keyVersion,
-    ciphertext: credential.ciphertext,
-    iv: credential.iv,
-    authTag: credential.authTag,
-  });
+  const secretMaterial = unwrapProviderCredentialCrypto(
+    decryptProviderCredential({
+      algorithm: credential.encryptionAlgorithm,
+      keyVersion: credential.keyVersion,
+      ciphertext: credential.ciphertext,
+      iv: credential.iv,
+      authTag: credential.authTag,
+    }),
+  );
   const response = await validateExternalTmsCredential({
     providerKind: input.providerKind,
     secretMaterial,

--- a/apps/hyperlocalise-web/src/lib/providers/external-tms-job-sync.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/external-tms-job-sync.ts
@@ -2,7 +2,10 @@ import { and, eq, inArray } from "drizzle-orm";
 
 import { db, schema } from "@/lib/database";
 import type { JobKind, ProviderSyncRunStatus } from "@/lib/database/types";
-import { decryptProviderCredential } from "@/lib/security/provider-credential-crypto";
+import {
+  decryptProviderCredential,
+  unwrapProviderCredentialCrypto,
+} from "@/lib/security/provider-credential-crypto";
 
 import type { ExternalTmsProviderKind } from "./organization-external-tms-provider-credentials";
 import { upsertExternalJob } from "./organization-external-tms-jobs";
@@ -107,13 +110,15 @@ export async function syncExternalTmsJobTasks(input: {
   const failures: ExternalTmsJobTaskSyncFailure[] = [];
 
   try {
-    const secretMaterial = decryptProviderCredential({
-      algorithm: credential.encryptionAlgorithm,
-      keyVersion: credential.keyVersion,
-      ciphertext: credential.ciphertext,
-      iv: credential.iv,
-      authTag: credential.authTag,
-    });
+    const secretMaterial = unwrapProviderCredentialCrypto(
+      decryptProviderCredential({
+        algorithm: credential.encryptionAlgorithm,
+        keyVersion: credential.keyVersion,
+        ciphertext: credential.ciphertext,
+        iv: credential.iv,
+        authTag: credential.authTag,
+      }),
+    );
     const jobTasks = await input.fetchJobTasks({
       organizationId: input.organizationId,
       projectId: project.id,

--- a/apps/hyperlocalise-web/src/lib/providers/external-tms-project-sync.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/external-tms-project-sync.ts
@@ -2,7 +2,10 @@ import { and, eq } from "drizzle-orm";
 
 import { db, schema } from "@/lib/database";
 import type { ProviderSyncRunStatus } from "@/lib/database/types";
-import { decryptProviderCredential } from "@/lib/security/provider-credential-crypto";
+import {
+  decryptProviderCredential,
+  unwrapProviderCredentialCrypto,
+} from "@/lib/security/provider-credential-crypto";
 
 import type { ExternalTmsProviderKind } from "./organization-external-tms-provider-credentials";
 import { upsertOrganizationExternalTmsProject } from "./organization-external-tms-projects";
@@ -84,13 +87,15 @@ export async function syncExternalTmsProjects(input: {
   const failures: ExternalTmsProjectSyncFailure[] = [];
 
   try {
-    const secretMaterial = decryptProviderCredential({
-      algorithm: credential.encryptionAlgorithm,
-      keyVersion: credential.keyVersion,
-      ciphertext: credential.ciphertext,
-      iv: credential.iv,
-      authTag: credential.authTag,
-    });
+    const secretMaterial = unwrapProviderCredentialCrypto(
+      decryptProviderCredential({
+        algorithm: credential.encryptionAlgorithm,
+        keyVersion: credential.keyVersion,
+        ciphertext: credential.ciphertext,
+        iv: credential.iv,
+        authTag: credential.authTag,
+      }),
+    );
     const projects = await input.fetchProjects({
       organizationId: input.organizationId,
       providerKind: input.providerKind,

--- a/apps/hyperlocalise-web/src/lib/providers/external-tms-tm-sync.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/external-tms-tm-sync.ts
@@ -2,7 +2,10 @@ import { and, eq } from "drizzle-orm";
 
 import { db, schema } from "@/lib/database";
 import type { ProviderSyncRunStatus } from "@/lib/database/types";
-import { decryptProviderCredential } from "@/lib/security/provider-credential-crypto";
+import {
+  decryptProviderCredential,
+  unwrapProviderCredentialCrypto,
+} from "@/lib/security/provider-credential-crypto";
 
 import {
   upsertOrganizationExternalTmsMemory,
@@ -114,13 +117,15 @@ export async function syncExternalTmsTranslationMemories(input: {
   const failures: ExternalTmsTranslationMemorySyncFailure[] = [];
 
   try {
-    const secretMaterial = decryptProviderCredential({
-      algorithm: credential.encryptionAlgorithm,
-      keyVersion: credential.keyVersion,
-      ciphertext: credential.ciphertext,
-      iv: credential.iv,
-      authTag: credential.authTag,
-    });
+    const secretMaterial = unwrapProviderCredentialCrypto(
+      decryptProviderCredential({
+        algorithm: credential.encryptionAlgorithm,
+        keyVersion: credential.keyVersion,
+        ciphertext: credential.ciphertext,
+        iv: credential.iv,
+        authTag: credential.authTag,
+      }),
+    );
 
     const memories = await input.fetchTranslationMemories({
       organizationId: input.organizationId,

--- a/apps/hyperlocalise-web/src/lib/providers/organization-external-tms-provider-credentials.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/organization-external-tms-provider-credentials.ts
@@ -7,6 +7,7 @@ import {
   decryptProviderCredential,
   encryptProviderCredential,
   maskProviderCredentialSuffix,
+  unwrapProviderCredentialCrypto,
 } from "@/lib/security/provider-credential-crypto";
 import {
   getTmsProviderCapability,
@@ -194,7 +195,7 @@ export async function upsertOrganizationExternalTmsProviderCredential(input: {
   assertExternalTmsCredentialAdmin(input.role);
 
   const now = new Date();
-  const encrypted = encryptProviderCredential(input.secretMaterial);
+  const encrypted = unwrapProviderCredentialCrypto(encryptProviderCredential(input.secretMaterial));
   const baseUrl = await normalizeExternalTmsCredentialBaseUrl({
     providerKind: input.providerKind,
     region: input.region ?? null,
@@ -300,13 +301,15 @@ export async function revealOrganizationExternalTmsProviderCredential(input: {
 
   return {
     summary: credential,
-    secretMaterial: decryptProviderCredential({
-      algorithm: credential.encryptionAlgorithm,
-      keyVersion: credential.keyVersion,
-      ciphertext: credential.ciphertext,
-      iv: credential.iv,
-      authTag: credential.authTag,
-    }),
+    secretMaterial: unwrapProviderCredentialCrypto(
+      decryptProviderCredential({
+        algorithm: credential.encryptionAlgorithm,
+        keyVersion: credential.keyVersion,
+        ciphertext: credential.ciphertext,
+        iv: credential.iv,
+        authTag: credential.authTag,
+      }),
+    ),
   };
 }
 

--- a/apps/hyperlocalise-web/src/lib/providers/organization-provider-credentials.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/organization-provider-credentials.ts
@@ -13,6 +13,7 @@ import {
   decryptProviderCredential,
   encryptProviderCredential,
   maskProviderCredentialSuffix,
+  unwrapProviderCredentialCrypto,
 } from "@/lib/security/provider-credential-crypto";
 
 export type OrganizationProviderCredentialSummary = {
@@ -83,7 +84,7 @@ export async function upsertOrganizationProviderCredential(input: {
   });
 
   const now = new Date();
-  const encrypted = encryptProviderCredential(input.apiKey);
+  const encrypted = unwrapProviderCredentialCrypto(encryptProviderCredential(input.apiKey));
   const [credential] = await db
     .insert(schema.organizationLlmProviderCredentials)
     .values({
@@ -137,13 +138,15 @@ export async function revealOrganizationProviderCredential(input: {
 
   return {
     summary: summarizeCredential(credential),
-    apiKey: decryptProviderCredential({
-      algorithm: credential.encryptionAlgorithm,
-      keyVersion: credential.keyVersion,
-      ciphertext: credential.ciphertext,
-      iv: credential.iv,
-      authTag: credential.authTag,
-    }),
+    apiKey: unwrapProviderCredentialCrypto(
+      decryptProviderCredential({
+        algorithm: credential.encryptionAlgorithm,
+        keyVersion: credential.keyVersion,
+        ciphertext: credential.ciphertext,
+        iv: credential.iv,
+        authTag: credential.authTag,
+      }),
+    ),
   };
 }
 

--- a/apps/hyperlocalise-web/src/lib/providers/provider-agent-comment.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-agent-comment.ts
@@ -1,7 +1,10 @@
 import { and, eq } from "drizzle-orm";
 
 import { db, schema } from "@/lib/database";
-import { decryptProviderCredential } from "@/lib/security/provider-credential-crypto";
+import {
+  decryptProviderCredential,
+  unwrapProviderCredentialCrypto,
+} from "@/lib/security/provider-credential-crypto";
 
 import {
   completeAgentRun,
@@ -366,13 +369,15 @@ export async function executeProviderAgentComment(input: {
   }));
 
   try {
-    const secretMaterial = decryptProviderCredential({
-      algorithm: credential.encryptionAlgorithm,
-      keyVersion: credential.keyVersion,
-      ciphertext: credential.ciphertext,
-      iv: credential.iv,
-      authTag: credential.authTag,
-    });
+    const secretMaterial = unwrapProviderCredentialCrypto(
+      decryptProviderCredential({
+        algorithm: credential.encryptionAlgorithm,
+        keyVersion: credential.keyVersion,
+        ciphertext: credential.ciphertext,
+        iv: credential.iv,
+        authTag: credential.authTag,
+      }),
+    );
 
     const pushResult = await pushComments({
       organizationId: input.organizationId,

--- a/apps/hyperlocalise-web/src/lib/providers/provider-safe-fetch.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-safe-fetch.ts
@@ -1,6 +1,7 @@
 import { Agent, fetch as undiciFetch, type RequestInit as UndiciRequestInit } from "undici";
 
-import { isPublicHttpUrl } from "@/lib/security/ssrf-guard";
+import { isErr } from "@/lib/primitives/result/results";
+import { formatSsrfGuardError } from "@/lib/security/ssrf-guard";
 import { resolvePinnedHttpConnectTarget } from "@/lib/security/ssrf-guard-dns";
 
 const isTestEnv = process.env.VITEST === "true" || process.env.NODE_ENV === "test";
@@ -10,8 +11,9 @@ export async function providerSafeFetch(
   init?: RequestInit,
 ): Promise<Response> {
   const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
-  if (!isPublicHttpUrl(url)) {
-    throw new Error("URL is not an allowed public HTTP(S) endpoint.");
+  const pinnedTargetResult = await resolvePinnedHttpConnectTarget(url);
+  if (isErr(pinnedTargetResult)) {
+    throw new Error(formatSsrfGuardError(pinnedTargetResult.error));
   }
 
   // Vitest stubs global.fetch; use it in tests so provider health-check route tests can mock responses.
@@ -19,7 +21,7 @@ export async function providerSafeFetch(
     return fetch(input, { ...init, redirect: "error" });
   }
 
-  const { requestUrl, connect } = await resolvePinnedHttpConnectTarget(url);
+  const { requestUrl, connect } = pinnedTargetResult.value;
   const dispatcher = new Agent({ connect });
 
   const response = await undiciFetch(requestUrl, {

--- a/apps/hyperlocalise-web/src/lib/providers/provider-url-resolve.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-url-resolve.ts
@@ -1,5 +1,6 @@
-import { normalizeHostname } from "@/lib/security/ssrf-guard";
-import { assertResolvablePublicHost } from "@/lib/security/ssrf-guard-dns";
+import { isErr } from "@/lib/primitives/result/results";
+import { formatSsrfGuardError, normalizeHostname } from "@/lib/security/ssrf-guard";
+import { resolveResolvablePublicHost } from "@/lib/security/ssrf-guard-dns";
 
 import { isSafeProviderUrl } from "./provider-url-safety";
 
@@ -14,5 +15,8 @@ export async function assertProviderUrlResolvable(url: string): Promise<void> {
     return;
   }
 
-  await assertResolvablePublicHost(hostname);
+  const hostResult = await resolveResolvablePublicHost(hostname);
+  if (isErr(hostResult)) {
+    throw new Error(formatSsrfGuardError(hostResult.error));
+  }
 }

--- a/apps/hyperlocalise-web/src/lib/providers/provider-webhook-storage.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-webhook-storage.ts
@@ -7,9 +7,11 @@ import type {
   ProviderWebhookEventProcessingStatus,
   ProviderWebhookSubscriptionStatus,
 } from "@/lib/database/types";
+import { isErr } from "@/lib/primitives/result/results";
 import {
   decryptProviderCredential,
   encryptProviderCredential,
+  unwrapProviderCredentialCrypto,
 } from "@/lib/security/provider-credential-crypto";
 
 import type { ExternalTmsProviderKind } from "./organization-external-tms-provider-credentials";
@@ -54,7 +56,7 @@ export async function insertProviderWebhookSubscription(input: {
 }) {
   const encrypted =
     input.webhookSecretPlaintext != null && input.webhookSecretPlaintext.length > 0
-      ? encryptProviderCredential(input.webhookSecretPlaintext)
+      ? unwrapProviderCredentialCrypto(encryptProviderCredential(input.webhookSecretPlaintext))
       : null;
   const secretMetadata: ProviderWebhookSecretMetadata = {
     ...input.secretMetadata,
@@ -129,7 +131,7 @@ export async function updateProviderWebhookSubscription(input: {
   const now = new Date();
   const encrypted =
     input.webhookSecretPlaintext != null && input.webhookSecretPlaintext.length > 0
-      ? encryptProviderCredential(input.webhookSecretPlaintext)
+      ? unwrapProviderCredentialCrypto(encryptProviderCredential(input.webhookSecretPlaintext))
       : null;
 
   const [subscription] = await db
@@ -275,17 +277,18 @@ export function decryptWebhookSecret(subscription: ProviderWebhookSubscription):
     return null;
   }
 
-  try {
-    return decryptProviderCredential({
-      algorithm: subscription.secretMetadata.encryptionAlgorithm ?? "aes-256-gcm",
-      keyVersion: subscription.webhookSecretKeyVersion,
-      ciphertext: subscription.webhookSecretCiphertext,
-      iv: subscription.webhookSecretIv,
-      authTag: subscription.webhookSecretAuthTag,
-    });
-  } catch {
+  const decrypted = decryptProviderCredential({
+    algorithm: subscription.secretMetadata.encryptionAlgorithm ?? "aes-256-gcm",
+    keyVersion: subscription.webhookSecretKeyVersion,
+    ciphertext: subscription.webhookSecretCiphertext,
+    iv: subscription.webhookSecretIv,
+    authTag: subscription.webhookSecretAuthTag,
+  });
+  if (isErr(decrypted)) {
     return null;
   }
+
+  return decrypted.value;
 }
 
 /**

--- a/apps/hyperlocalise-web/src/lib/providers/provider-webhook-subscription-manager.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-webhook-subscription-manager.ts
@@ -7,6 +7,7 @@ import type { ProviderWebhookSubscription } from "@/lib/database/types";
 import {
   decryptProviderCredential,
   maskProviderCredentialSuffix,
+  unwrapProviderCredentialCrypto,
 } from "@/lib/security/provider-credential-crypto";
 import { providerSupportsTmsAction } from "@/lib/providers/tms-capabilities";
 
@@ -156,13 +157,15 @@ async function loadCredentialContext(input: {
 
   return {
     credential,
-    secretMaterial: decryptProviderCredential({
-      algorithm: credential.encryptionAlgorithm,
-      keyVersion: credential.keyVersion,
-      ciphertext: credential.ciphertext,
-      iv: credential.iv,
-      authTag: credential.authTag,
-    }),
+    secretMaterial: unwrapProviderCredentialCrypto(
+      decryptProviderCredential({
+        algorithm: credential.encryptionAlgorithm,
+        keyVersion: credential.keyVersion,
+        ciphertext: credential.ciphertext,
+        iv: credential.iv,
+        authTag: credential.authTag,
+      }),
+    ),
   };
 }
 
@@ -564,13 +567,15 @@ export async function auditProviderWebhookSubscriptions(input: {
       continue;
     }
 
-    const secretMaterial = decryptProviderCredential({
-      algorithm: credentialRow.encryptionAlgorithm,
-      keyVersion: credentialRow.keyVersion,
-      ciphertext: credentialRow.ciphertext,
-      iv: credentialRow.iv,
-      authTag: credentialRow.authTag,
-    });
+    const secretMaterial = unwrapProviderCredentialCrypto(
+      decryptProviderCredential({
+        algorithm: credentialRow.encryptionAlgorithm,
+        keyVersion: credentialRow.keyVersion,
+        ciphertext: credentialRow.ciphertext,
+        iv: credentialRow.iv,
+        authTag: credentialRow.authTag,
+      }),
+    );
     const webhookSecret = decryptWebhookSecret(subscription) ?? "";
 
     let remoteWebhooks: Awaited<ReturnType<typeof adapter.listRemoteSubscriptions>> = [];

--- a/apps/hyperlocalise-web/src/lib/providers/sync-provider-review.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/sync-provider-review.ts
@@ -1,7 +1,10 @@
 import { and, eq } from "drizzle-orm";
 
 import { db, schema } from "@/lib/database";
-import { decryptProviderCredential } from "@/lib/security/provider-credential-crypto";
+import {
+  decryptProviderCredential,
+  unwrapProviderCredentialCrypto,
+} from "@/lib/security/provider-credential-crypto";
 
 import type { ExternalTmsTaskContent } from "./external-tms-content-sync";
 import type { ExternalTmsProviderKind } from "./organization-external-tms-provider-credentials";
@@ -62,13 +65,15 @@ export async function pullProviderReviewForJob(input: {
     throw new Error("provider_credential_not_found");
   }
 
-  const secretMaterial = decryptProviderCredential({
-    algorithm: credential.encryptionAlgorithm,
-    keyVersion: credential.keyVersion,
-    ciphertext: credential.ciphertext,
-    iv: credential.iv,
-    authTag: credential.authTag,
-  });
+  const secretMaterial = unwrapProviderCredentialCrypto(
+    decryptProviderCredential({
+      algorithm: credential.encryptionAlgorithm,
+      keyVersion: credential.keyVersion,
+      ciphertext: credential.ciphertext,
+      iv: credential.iv,
+      authTag: credential.authTag,
+    }),
+  );
 
   const incoming = await pullReview({
     organizationId: input.organizationId,

--- a/apps/hyperlocalise-web/src/lib/security/provider-credential-crypto.test.ts
+++ b/apps/hyperlocalise-web/src/lib/security/provider-credential-crypto.test.ts
@@ -1,6 +1,8 @@
 import "dotenv/config";
 
 import { describe, expect, it } from "vite-plus/test";
+import { isErr } from "@/lib/primitives/result/results";
+
 import {
   decryptProviderCredential,
   encryptProviderCredential,
@@ -27,64 +29,110 @@ describe("provider-credential-crypto", () => {
   describe("encryption/decryption round-trip", () => {
     it("successfully decrypts an encrypted credential", () => {
       const plaintext = "sk-proj-test-secret-key-12345";
-      const encrypted = encryptProviderCredential(plaintext);
+      const encryptedResult = encryptProviderCredential(plaintext);
+      expect(encryptedResult.ok).toBe(true);
+      if (isErr(encryptedResult)) {
+        throw new Error("expected encryption to succeed");
+      }
 
+      const encrypted = encryptedResult.value;
       expect(encrypted.ciphertext).not.toBe(plaintext);
       expect(encrypted.algorithm).toBe("aes-256-gcm");
 
-      const decrypted = decryptProviderCredential(encrypted);
-      expect(decrypted).toBe(plaintext);
+      const decryptedResult = decryptProviderCredential(encrypted);
+      expect(decryptedResult.ok).toBe(true);
+      if (isErr(decryptedResult)) {
+        throw new Error("expected decryption to succeed");
+      }
+      expect(decryptedResult.value).toBe(plaintext);
     });
 
     it("produces different ciphertexts for the same plaintext (random IV)", () => {
       const plaintext = "sk-proj-test-secret-key-12345";
-      const encrypted1 = encryptProviderCredential(plaintext);
-      const encrypted2 = encryptProviderCredential(plaintext);
+      const encrypted1Result = encryptProviderCredential(plaintext);
+      const encrypted2Result = encryptProviderCredential(plaintext);
+      if (isErr(encrypted1Result) || isErr(encrypted2Result)) {
+        throw new Error("expected encryption to succeed");
+      }
 
-      expect(encrypted1.ciphertext).not.toBe(encrypted2.ciphertext);
-      expect(encrypted1.iv).not.toBe(encrypted2.iv);
+      expect(encrypted1Result.value.ciphertext).not.toBe(encrypted2Result.value.ciphertext);
+      expect(encrypted1Result.value.iv).not.toBe(encrypted2Result.value.iv);
 
-      expect(decryptProviderCredential(encrypted1)).toBe(plaintext);
-      expect(decryptProviderCredential(encrypted2)).toBe(plaintext);
+      const decrypted1 = decryptProviderCredential(encrypted1Result.value);
+      const decrypted2 = decryptProviderCredential(encrypted2Result.value);
+      if (isErr(decrypted1) || isErr(decrypted2)) {
+        throw new Error("expected decryption to succeed");
+      }
+      expect(decrypted1.value).toBe(plaintext);
+      expect(decrypted2.value).toBe(plaintext);
     });
 
-    it("throws an error for unsupported algorithm", () => {
-      const encrypted = encryptProviderCredential("test");
-      const invalidEncrypted = { ...encrypted, algorithm: "unsupported-algo" };
+    it("returns an error for unsupported algorithm", () => {
+      const encryptedResult = encryptProviderCredential("test");
+      if (isErr(encryptedResult)) {
+        throw new Error("expected encryption to succeed");
+      }
+      const invalidEncrypted = { ...encryptedResult.value, algorithm: "unsupported-algo" };
 
-      expect(() => decryptProviderCredential(invalidEncrypted)).toThrow(
-        "unsupported_provider_credential_algorithm",
+      const decryptedResult = decryptProviderCredential(invalidEncrypted);
+      expect(decryptedResult.ok).toBe(false);
+      if (!isErr(decryptedResult)) {
+        throw new Error("expected decryption to fail");
+      }
+      expect(decryptedResult.error.code).toBe("unsupported_provider_credential_algorithm");
+    });
+
+    it("returns an error for unsupported key version", () => {
+      const encryptedResult = encryptProviderCredential("test");
+      if (isErr(encryptedResult)) {
+        throw new Error("expected encryption to succeed");
+      }
+      const invalidEncrypted = { ...encryptedResult.value, keyVersion: 999 };
+
+      const decryptedResult = decryptProviderCredential(invalidEncrypted);
+      expect(decryptedResult.ok).toBe(false);
+      if (!isErr(decryptedResult)) {
+        throw new Error("expected decryption to fail");
+      }
+      expect(decryptedResult.error.code).toBe("unsupported_provider_credential_key_version");
+    });
+
+    it("returns an error when ciphertext is tampered with", () => {
+      const encryptedResult = encryptProviderCredential("sensitive-data");
+      if (isErr(encryptedResult)) {
+        throw new Error("expected encryption to succeed");
+      }
+
+      const tamperedCiphertext = encryptedResult.value.ciphertext.replace(/./, (c) =>
+        c === "A" ? "B" : "A",
       );
+      const tamperedEncrypted = { ...encryptedResult.value, ciphertext: tamperedCiphertext };
+
+      const decryptedResult = decryptProviderCredential(tamperedEncrypted);
+      expect(decryptedResult.ok).toBe(false);
+      if (!isErr(decryptedResult)) {
+        throw new Error("expected decryption to fail");
+      }
+      expect(decryptedResult.error.code).toBe("provider_credential_decryption_failed");
     });
 
-    it("throws an error for unsupported key version", () => {
-      const encrypted = encryptProviderCredential("test");
-      const invalidEncrypted = { ...encrypted, keyVersion: 999 };
+    it("returns an error when auth tag is tampered with", () => {
+      const encryptedResult = encryptProviderCredential("sensitive-data");
+      if (isErr(encryptedResult)) {
+        throw new Error("expected encryption to succeed");
+      }
 
-      expect(() => decryptProviderCredential(invalidEncrypted)).toThrow(
-        "unsupported_provider_credential_key_version",
+      const tamperedAuthTag = encryptedResult.value.authTag.replace(/./, (c) =>
+        c === "A" ? "B" : "A",
       );
-    });
+      const tamperedEncrypted = { ...encryptedResult.value, authTag: tamperedAuthTag };
 
-    it("throws an error when ciphertext is tampered with", () => {
-      const encrypted = encryptProviderCredential("sensitive-data");
-
-      // Corrupt the ciphertext by changing characters in the base64 string
-      // We use a regex that matches any character to ensure we actually change something
-      const tamperedCiphertext = encrypted.ciphertext.replace(/./, (c) => (c === "A" ? "B" : "A"));
-      const tamperedEncrypted = { ...encrypted, ciphertext: tamperedCiphertext };
-
-      // AES-GCM should detect tampering via the auth tag
-      expect(() => decryptProviderCredential(tamperedEncrypted)).toThrow();
-    });
-
-    it("throws an error when auth tag is tampered with", () => {
-      const encrypted = encryptProviderCredential("sensitive-data");
-
-      const tamperedAuthTag = encrypted.authTag.replace(/./, (c) => (c === "A" ? "B" : "A"));
-      const tamperedEncrypted = { ...encrypted, authTag: tamperedAuthTag };
-
-      expect(() => decryptProviderCredential(tamperedEncrypted)).toThrow();
+      const decryptedResult = decryptProviderCredential(tamperedEncrypted);
+      expect(decryptedResult.ok).toBe(false);
+      if (!isErr(decryptedResult)) {
+        throw new Error("expected decryption to fail");
+      }
+      expect(decryptedResult.error.code).toBe("provider_credential_decryption_failed");
     });
   });
 });

--- a/apps/hyperlocalise-web/src/lib/security/provider-credential-crypto.ts
+++ b/apps/hyperlocalise-web/src/lib/security/provider-credential-crypto.ts
@@ -1,51 +1,95 @@
 import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
 
 import { env } from "@/lib/env";
+import { assertNever } from "@/lib/primitives/assert-never/assert-never";
+import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
 
 const encryptionAlgorithm = "aes-256-gcm";
 const currentKeyVersion = 1;
 
-function parseMasterKey(input: string) {
+export type EncryptedProviderCredential = {
+  algorithm: string;
+  keyVersion: number;
+  ciphertext: string;
+  iv: string;
+  authTag: string;
+};
+
+export type ProviderCredentialCryptoError =
+  | { code: "invalid_provider_credentials_master_key" }
+  | { code: "unsupported_provider_credential_key_version" }
+  | { code: "unsupported_provider_credential_algorithm" }
+  | { code: "provider_credential_decryption_failed" };
+
+export function formatProviderCredentialCryptoError(error: ProviderCredentialCryptoError): string {
+  switch (error.code) {
+    case "invalid_provider_credentials_master_key":
+      return "invalid_provider_credentials_master_key";
+    case "unsupported_provider_credential_key_version":
+      return "unsupported_provider_credential_key_version";
+    case "unsupported_provider_credential_algorithm":
+      return "unsupported_provider_credential_algorithm";
+    case "provider_credential_decryption_failed":
+      return "provider_credential_decryption_failed";
+    default:
+      return assertNever(error);
+  }
+}
+
+function parseMasterKey(input: string): Result<Buffer, ProviderCredentialCryptoError> {
   const trimmed = input.trim();
 
   if (/^[0-9a-fA-F]{64}$/.test(trimmed)) {
-    return Buffer.from(trimmed, "hex");
+    return ok(Buffer.from(trimmed, "hex"));
   }
 
   const base64Buffer = Buffer.from(trimmed, "base64");
   if (base64Buffer.length === 32 && base64Buffer.toString("base64") === trimmed) {
-    return base64Buffer;
+    return ok(base64Buffer);
   }
 
-  throw new Error("invalid_provider_credentials_master_key");
+  return err({ code: "invalid_provider_credentials_master_key" });
 }
 
-function getMasterKey(keyVersion = currentKeyVersion) {
+function getMasterKey(
+  keyVersion = currentKeyVersion,
+): Result<Buffer, ProviderCredentialCryptoError> {
   if (keyVersion !== currentKeyVersion) {
-    throw new Error("unsupported_provider_credential_key_version");
+    return err({ code: "unsupported_provider_credential_key_version" });
   }
 
-  const key = parseMasterKey(env.PROVIDER_CREDENTIALS_MASTER_KEY);
-  if (key.length !== 32) {
-    throw new Error("invalid_provider_credentials_master_key");
+  const keyResult = parseMasterKey(env.PROVIDER_CREDENTIALS_MASTER_KEY);
+  if (isErr(keyResult)) {
+    return keyResult;
   }
 
-  return key;
+  if (keyResult.value.length !== 32) {
+    return err({ code: "invalid_provider_credentials_master_key" });
+  }
+
+  return ok(keyResult.value);
 }
 
-export function encryptProviderCredential(plaintext: string) {
+export function encryptProviderCredential(
+  plaintext: string,
+): Result<EncryptedProviderCredential, ProviderCredentialCryptoError> {
+  const keyResult = getMasterKey();
+  if (isErr(keyResult)) {
+    return keyResult;
+  }
+
   const iv = randomBytes(12);
-  const cipher = createCipheriv(encryptionAlgorithm, getMasterKey(), iv);
+  const cipher = createCipheriv(encryptionAlgorithm, keyResult.value, iv);
   const ciphertext = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
   const authTag = cipher.getAuthTag();
 
-  return {
+  return ok({
     algorithm: encryptionAlgorithm,
     keyVersion: currentKeyVersion,
     ciphertext: ciphertext.toString("base64"),
     iv: iv.toString("base64"),
     authTag: authTag.toString("base64"),
-  };
+  });
 }
 
 export function decryptProviderCredential(input: {
@@ -54,24 +98,44 @@ export function decryptProviderCredential(input: {
   ciphertext: string;
   iv: string;
   authTag: string;
-}) {
+}): Result<string, ProviderCredentialCryptoError> {
   if (input.algorithm !== encryptionAlgorithm) {
-    throw new Error("unsupported_provider_credential_algorithm");
+    return err({ code: "unsupported_provider_credential_algorithm" });
   }
 
-  const decipher = createDecipheriv(
-    input.algorithm,
-    getMasterKey(input.keyVersion),
-    Buffer.from(input.iv, "base64"),
-  );
-  decipher.setAuthTag(Buffer.from(input.authTag, "base64"));
+  const keyResult = getMasterKey(input.keyVersion);
+  if (isErr(keyResult)) {
+    return keyResult;
+  }
 
-  return Buffer.concat([
-    decipher.update(Buffer.from(input.ciphertext, "base64")),
-    decipher.final(),
-  ]).toString("utf8");
+  try {
+    const decipher = createDecipheriv(
+      input.algorithm,
+      keyResult.value,
+      Buffer.from(input.iv, "base64"),
+    );
+    decipher.setAuthTag(Buffer.from(input.authTag, "base64"));
+
+    return ok(
+      Buffer.concat([
+        decipher.update(Buffer.from(input.ciphertext, "base64")),
+        decipher.final(),
+      ]).toString("utf8"),
+    );
+  } catch {
+    return err({ code: "provider_credential_decryption_failed" });
+  }
 }
 
 export function maskProviderCredentialSuffix(secret: string) {
   return secret.slice(-4).padStart(8, "•");
+}
+
+export function unwrapProviderCredentialCrypto<T>(
+  result: Result<T, ProviderCredentialCryptoError>,
+): T {
+  if (isErr(result)) {
+    throw new Error(formatProviderCredentialCryptoError(result.error));
+  }
+  return result.value;
 }

--- a/apps/hyperlocalise-web/src/lib/security/ssrf-guard-dns.ts
+++ b/apps/hyperlocalise-web/src/lib/security/ssrf-guard-dns.ts
@@ -1,6 +1,13 @@
 import dns from "node:dns/promises";
 
-import { isBlockedHost, isPublicHttpUrl, normalizeHostname } from "./ssrf-guard";
+import { err, fromThrowableAsync, isErr, ok, type Result } from "@/lib/primitives/result/results";
+
+import {
+  isBlockedHost,
+  normalizeHostname,
+  type SsrfGuardError,
+  validatePublicHttpUrl,
+} from "./ssrf-guard";
 
 export type PinnedHttpConnectTarget = {
   requestUrl: string;
@@ -13,35 +20,43 @@ export type PinnedHttpConnectTarget = {
 
 export async function resolvePinnedHttpConnectTarget(
   url: string,
-): Promise<PinnedHttpConnectTarget> {
-  if (!isPublicHttpUrl(url)) {
-    throw new Error("URL is not an allowed public HTTP(S) endpoint.");
+): Promise<Result<PinnedHttpConnectTarget, SsrfGuardError>> {
+  const urlResult = validatePublicHttpUrl(url);
+  if (isErr(urlResult)) {
+    return urlResult;
   }
 
-  const parsed = new URL(url);
+  const parsed = urlResult.value;
   const hostname = normalizeHostname(parsed.hostname);
   const port = parsed.port ? Number(parsed.port) : parsed.protocol === "https:" ? 443 : 80;
   const servername = parsed.protocol === "https:" ? hostname : undefined;
 
   if (looksLikeIpAddress(hostname)) {
     if (isBlockedHost(hostname)) {
-      throw new Error("URL host is not allowed.");
+      return err({ code: "host_not_allowed" });
     }
 
-    return {
+    return ok({
       requestUrl: parsed.toString(),
       connect: { host: hostname, port, servername },
-    };
+    });
   }
 
-  const results = await dns.lookup(hostname, { all: true, verbatim: true });
+  const lookupResult = await fromThrowableAsync(
+    dns.lookup(hostname, { all: true, verbatim: true }),
+  );
+  if (isErr(lookupResult)) {
+    return err({ code: "host_unresolvable" });
+  }
+
+  const results = lookupResult.value;
   if (!results.length) {
-    throw new Error("URL host could not be resolved.");
+    return err({ code: "host_unresolvable" });
   }
 
   for (const result of results) {
     if (isBlockedHost(result.address)) {
-      throw new Error("URL host resolves to a private or restricted address.");
+      return err({ code: "host_resolves_to_restricted_address" });
     }
   }
 
@@ -50,40 +65,53 @@ export async function resolvePinnedHttpConnectTarget(
     results.find((result) => result.family === 6) ??
     results[0];
 
-  return {
+  return ok({
     requestUrl: parsed.toString(),
     connect: {
       host: preferred.address,
       port,
       servername,
     },
-  };
+  });
 }
 
-export async function assertResolvablePublicHost(hostname: string): Promise<void> {
+export async function resolveResolvablePublicHost(
+  hostname: string,
+): Promise<Result<void, SsrfGuardError>> {
   const normalized = normalizeHostname(hostname);
   if (!normalized || isBlockedHost(normalized)) {
-    throw new Error("URL host is not allowed.");
+    return err({ code: "host_not_allowed" });
   }
 
   if (looksLikeIpAddress(normalized)) {
-    return;
+    return ok(undefined);
   }
 
-  const results = await dns.lookup(normalized, { all: true, verbatim: true });
+  const lookupResult = await fromThrowableAsync(
+    dns.lookup(normalized, { all: true, verbatim: true }),
+  );
+  if (isErr(lookupResult)) {
+    return err({ code: "host_unresolvable" });
+  }
+
+  const results = lookupResult.value;
   if (!results.length) {
-    throw new Error("URL host could not be resolved.");
+    return err({ code: "host_unresolvable" });
   }
 
   for (const result of results) {
     if (isBlockedHost(result.address)) {
-      throw new Error("URL host resolves to a private or restricted address.");
+      return err({ code: "host_resolves_to_restricted_address" });
     }
   }
+
+  return ok(undefined);
 }
 
-export async function assertPublicHttpUrlResolvable(url: string): Promise<void> {
-  await resolvePinnedHttpConnectTarget(url);
+export async function resolvePublicHttpUrl(
+  url: string,
+): Promise<Result<PinnedHttpConnectTarget, SsrfGuardError>> {
+  return resolvePinnedHttpConnectTarget(url);
 }
 
 function looksLikeIpAddress(hostname: string): boolean {

--- a/apps/hyperlocalise-web/src/lib/security/ssrf-guard.ts
+++ b/apps/hyperlocalise-web/src/lib/security/ssrf-guard.ts
@@ -1,3 +1,36 @@
+import { assertNever } from "@/lib/primitives/assert-never/assert-never";
+import { err, ok, type Result } from "@/lib/primitives/result/results";
+
+export type SsrfGuardError =
+  | { code: "invalid_url" }
+  | { code: "unsupported_protocol" }
+  | { code: "credentials_in_url" }
+  | { code: "blocked_host" }
+  | { code: "host_not_allowed" }
+  | { code: "host_unresolvable" }
+  | { code: "host_resolves_to_restricted_address" };
+
+export function formatSsrfGuardError(error: SsrfGuardError): string {
+  switch (error.code) {
+    case "invalid_url":
+      return "URL is invalid.";
+    case "unsupported_protocol":
+      return "URL must use http or https.";
+    case "credentials_in_url":
+      return "URL must not include credentials.";
+    case "blocked_host":
+      return "URL host is not allowed.";
+    case "host_not_allowed":
+      return "URL host is not allowed.";
+    case "host_unresolvable":
+      return "URL host could not be resolved.";
+    case "host_resolves_to_restricted_address":
+      return "URL host resolves to a private or restricted address.";
+    default:
+      return assertNever(error);
+  }
+}
+
 export function normalizeHostname(hostname: string): string {
   const lowerHostname = hostname.toLowerCase();
   if (lowerHostname.startsWith("[") && lowerHostname.endsWith("]")) {
@@ -111,21 +144,29 @@ export function isBlockedHost(hostname: string): boolean {
   return false;
 }
 
-export function isPublicHttpUrl(value: string): boolean {
+export function validatePublicHttpUrl(value: string): Result<URL, SsrfGuardError> {
   let parsed: URL;
   try {
     parsed = new URL(value);
   } catch {
-    return false;
+    return err({ code: "invalid_url" });
   }
 
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-    return false;
+    return err({ code: "unsupported_protocol" });
   }
 
   if (parsed.username || parsed.password) {
-    return false;
+    return err({ code: "credentials_in_url" });
   }
 
-  return !isBlockedHost(parsed.hostname);
+  if (isBlockedHost(parsed.hostname)) {
+    return err({ code: "blocked_host" });
+  }
+
+  return ok(parsed);
+}
+
+export function isPublicHttpUrl(value: string): boolean {
+  return validatePublicHttpUrl(value).ok;
 }

--- a/apps/hyperlocalise-web/src/lib/translation/load-glossary-matches.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/load-glossary-matches.ts
@@ -2,7 +2,10 @@ import { and, eq } from "drizzle-orm";
 
 import { db, schema } from "@/lib/database";
 import { createLogger } from "@/lib/log";
-import { decryptProviderCredential } from "@/lib/security/provider-credential-crypto";
+import {
+  decryptProviderCredential,
+  unwrapProviderCredentialCrypto,
+} from "@/lib/security/provider-credential-crypto";
 import type { ExternalTmsProviderKind } from "@/lib/providers/organization-external-tms-provider-credentials";
 import { getProviderGlossaryMatcher } from "@/lib/providers/provider-glossary-matchers";
 import { loadSyncedGlossaryMatchesForContext } from "@/lib/translation/load-synced-glossary-matches";
@@ -145,13 +148,15 @@ async function searchLiveProviderMatches(input: {
     return [];
   }
 
-  const secretMaterial = decryptProviderCredential({
-    algorithm: credential.encryptionAlgorithm,
-    keyVersion: credential.keyVersion,
-    ciphertext: credential.ciphertext,
-    iv: credential.iv,
-    authTag: credential.authTag,
-  });
+  const secretMaterial = unwrapProviderCredentialCrypto(
+    decryptProviderCredential({
+      algorithm: credential.encryptionAlgorithm,
+      keyVersion: credential.keyVersion,
+      ciphertext: credential.ciphertext,
+      iv: credential.iv,
+      authTag: credential.authTag,
+    }),
+  );
 
   const searchableGlossaries = input.glossaries.filter(supportsLiveGlossarySearch);
   if (searchableGlossaries.length === 0) {

--- a/apps/hyperlocalise-web/src/lib/translation/load-organization-translation-generator.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/load-organization-translation-generator.ts
@@ -1,7 +1,10 @@
 import { and, eq } from "drizzle-orm";
 
 import { db, schema } from "@/lib/database";
-import { decryptProviderCredential } from "@/lib/security/provider-credential-crypto";
+import {
+  decryptProviderCredential,
+  unwrapProviderCredentialCrypto,
+} from "@/lib/security/provider-credential-crypto";
 import { createOpenAIStringTranslationGenerator } from "@/lib/translation/string-job-executor";
 
 export async function loadOrganizationOpenAITranslationGenerator(projectId: string) {
@@ -87,13 +90,15 @@ export async function loadOrganizationOpenAITranslationGenerator(projectId: stri
     } as const;
   }
 
-  const apiKey = decryptProviderCredential({
-    algorithm: project.encryptionAlgorithm,
-    keyVersion: project.keyVersion,
-    ciphertext: project.ciphertext,
-    iv: project.iv,
-    authTag: project.authTag,
-  });
+  const apiKey = unwrapProviderCredentialCrypto(
+    decryptProviderCredential({
+      algorithm: project.encryptionAlgorithm,
+      keyVersion: project.keyVersion,
+      ciphertext: project.ciphertext,
+      iv: project.iv,
+      authTag: project.authTag,
+    }),
+  );
 
   return {
     ok: true,

--- a/apps/hyperlocalise-web/src/lib/translation/load-translation-memory-matches.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/load-translation-memory-matches.ts
@@ -2,7 +2,10 @@ import { and, eq } from "drizzle-orm";
 
 import { db, schema } from "@/lib/database";
 import { createLogger } from "@/lib/log";
-import { decryptProviderCredential } from "@/lib/security/provider-credential-crypto";
+import {
+  decryptProviderCredential,
+  unwrapProviderCredentialCrypto,
+} from "@/lib/security/provider-credential-crypto";
 import type { ExternalTmsProviderKind } from "@/lib/providers/organization-external-tms-provider-credentials";
 import { memorySupportsLiveSearch } from "@/lib/providers/lokalise/lokalise-tm-matcher";
 import { getProviderTranslationMemoryMatcher } from "@/lib/providers/provider-translation-memory-matchers";
@@ -125,13 +128,15 @@ async function searchLiveProviderMatches(input: {
     return [];
   }
 
-  const secretMaterial = decryptProviderCredential({
-    algorithm: credential.encryptionAlgorithm,
-    keyVersion: credential.keyVersion,
-    ciphertext: credential.ciphertext,
-    iv: credential.iv,
-    authTag: credential.authTag,
-  });
+  const secretMaterial = unwrapProviderCredentialCrypto(
+    decryptProviderCredential({
+      algorithm: credential.encryptionAlgorithm,
+      keyVersion: credential.keyVersion,
+      ciphertext: credential.ciphertext,
+      iv: credential.iv,
+      authTag: credential.authTag,
+    }),
+  );
 
   const liveMatches: NormalizedTranslationMemoryMatch[] = [];
 

--- a/apps/hyperlocalise-web/src/lib/translation/translation-job-queued-function.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/translation-job-queued-function.ts
@@ -3,7 +3,10 @@ import { and, eq, isNull, or } from "drizzle-orm";
 import { stringTranslationJobInputSchema } from "@/api/routes/project/job.schema";
 import { db, schema } from "@/lib/database";
 import type { TranslationJobEventData } from "@/lib/workflow/types";
-import { decryptProviderCredential } from "@/lib/security/provider-credential-crypto";
+import {
+  decryptProviderCredential,
+  unwrapProviderCredentialCrypto,
+} from "@/lib/security/provider-credential-crypto";
 import {
   formatUsageControlError,
   markUsageEventSucceededByOperationKey,
@@ -295,13 +298,15 @@ async function loadOrganizationOpenAITranslationGenerator(projectId: string) {
     } as const;
   }
 
-  const apiKey = decryptProviderCredential({
-    algorithm: project.encryptionAlgorithm,
-    keyVersion: project.keyVersion,
-    ciphertext: project.ciphertext,
-    iv: project.iv,
-    authTag: project.authTag,
-  });
+  const apiKey = unwrapProviderCredentialCrypto(
+    decryptProviderCredential({
+      algorithm: project.encryptionAlgorithm,
+      keyVersion: project.keyVersion,
+      ciphertext: project.ciphertext,
+      iv: project.iv,
+      authTag: project.authTag,
+    }),
+  );
 
   return {
     ok: true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Refactored `apps/hyperlocalise-web/src/lib/security` to use the Go-like `Result<T, E>` pattern instead of throwing for expected failures.

**`provider-credential-crypto.ts`**
- `encryptProviderCredential` and `decryptProviderCredential` now return `Result` with a `ProviderCredentialCryptoError` discriminated union
- Added `formatProviderCredentialCryptoError` and `unwrapProviderCredentialCrypto` for boundary callers that still need throw semantics
- Crypto/decryption failures map to stable `code` values instead of opaque exceptions

**`ssrf-guard.ts`**
- Added `validatePublicHttpUrl` returning `Result<URL, SsrfGuardError>`
- Added `formatSsrfGuardError` and kept `isPublicHttpUrl` as a convenience wrapper

**`ssrf-guard-dns.ts`**
- `resolvePinnedHttpConnectTarget`, `resolveResolvablePublicHost`, and `resolvePublicHttpUrl` return `Promise<Result<...>>`
- Removed throw-based `assertResolvablePublicHost` / `assertPublicHttpUrlResolvable` APIs

**Callers**
- Provider credential consumers use `unwrapProviderCredentialCrypto` where throw-on-failure is acceptable
- `decryptWebhookSecret` uses `isErr` and returns `null` on failure (fail-closed webhook intake)
- SSRF callers use `isErr` + `formatSsrfGuardError` at fetch/URL validation boundaries

## How to test

```bash
cd apps/hyperlocalise-web
vp check --fix
vp test src/lib/security/
```

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, `vp test src/lib/security/`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-877bf861-5f0b-453f-b7cf-8991a4b064f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-877bf861-5f0b-453f-b7cf-8991a4b064f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

