### PR TITLE
feat(github-automation): pull translation write-back to GitHub (HL-447)

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/github-installation/github-installation.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/github-installation/github-installation.schema.ts
@@ -27,7 +27,12 @@ const githubRepositoryAutomationSettingsPartialSchema = z.object({
           projectId: z.string().trim().min(1).optional(),
         })
         .optional(),
-      pullTranslations: z.object({ enabled: z.boolean().optional() }).optional(),
+      pullTranslations: z
+        .object({
+          enabled: z.boolean().optional(),
+          projectId: z.string().trim().min(1).optional(),
+        })
+        .optional(),
       validation: z.object({ enabled: z.boolean().optional() }).optional(),
     })
     .optional(),

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-localisation-paths.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-localisation-paths.ts
@@ -111,7 +111,7 @@ function globPatternToRegExp(pattern: string): RegExp {
   return new RegExp(regexSource);
 }
 
-function pathMatchesPattern(path: string, pattern: string): boolean {
+export function pathMatchesPattern(path: string, pattern: string): boolean {
   const normalizedPath = path.replaceAll("\\", "/");
   const normalizedPattern = pattern.replaceAll("\\", "/");
   return globPatternToRegExp(normalizedPattern).test(normalizedPath);

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-pull-translations-branch.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-pull-translations-branch.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { buildPullTranslationsBranchName } from "./github-repository-automation-pull-translations-branch";
+
+describe("buildPullTranslationsBranchName", () => {
+  it("uses a stable branch name per automation job", () => {
+    expect(buildPullTranslationsBranchName("job-abc-123")).toBe(
+      "hyperlocalise/translations-job-abc-123",
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-pull-translations-branch.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-pull-translations-branch.ts
@@ -1,0 +1,3 @@
+export function buildPullTranslationsBranchName(jobId: string): string {
+  return `hyperlocalise/translations-${jobId}`;
+}

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-pull-translations-export.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-pull-translations-export.ts
@@ -1,0 +1,336 @@
+import { and, eq, inArray, sql } from "drizzle-orm";
+
+import { db, schema } from "@/lib/database";
+import { getFileStorageAdapter } from "@/lib/file-storage";
+import { resolveSourcePath, resolveTargetPath } from "@/lib/i18n/i18n-pathresolver";
+import { bufferFromStream } from "@/lib/streams";
+import { mapWithConcurrency } from "@/lib/primitives/map-with-concurrency/map-with-concurrency";
+
+import {
+  extractI18nBucketFilePatternsFromConfigJson,
+  pathMatchesPattern,
+} from "./github-repository-automation-localisation-paths";
+
+export type PullTranslationExportCandidate = {
+  sourcePath: string;
+  targetPath: string;
+  locale: string;
+  translationJobId: string;
+  outputFileId: string;
+  content: Buffer;
+};
+
+type FileJobOutputFile = {
+  fileId: string;
+  locale: string;
+  filename: string;
+};
+
+function hasValue(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function parseFileJobOutputFiles(input: {
+  outcomeKind: string | null;
+  outcomePayload: unknown;
+}): FileJobOutputFile[] {
+  if (input.outcomeKind !== "file_result") {
+    return [];
+  }
+
+  if (!input.outcomePayload || typeof input.outcomePayload !== "object") {
+    return [];
+  }
+
+  const outputFiles = (input.outcomePayload as Record<string, unknown>).outputFiles;
+  if (!Array.isArray(outputFiles)) {
+    return [];
+  }
+
+  const parsed: FileJobOutputFile[] = [];
+  for (const item of outputFiles) {
+    if (!item || typeof item !== "object") {
+      continue;
+    }
+    const record = item as Record<string, unknown>;
+    if (!hasValue(record.fileId) || !hasValue(record.locale) || !hasValue(record.filename)) {
+      continue;
+    }
+    parsed.push({
+      fileId: record.fileId,
+      locale: record.locale,
+      filename: record.filename,
+    });
+  }
+
+  return parsed;
+}
+
+function parseI18nLocales(config: Record<string, unknown>): {
+  sourceLocale: string;
+  targetLocales: string[];
+} | null {
+  const locales = config.locales;
+  if (!locales || typeof locales !== "object") {
+    return null;
+  }
+
+  const record = locales as Record<string, unknown>;
+  if (!hasValue(record.source)) {
+    return null;
+  }
+
+  const targets = record.targets;
+  if (!Array.isArray(targets)) {
+    return null;
+  }
+
+  const targetLocales = targets.filter((locale): locale is string => hasValue(locale));
+  if (targetLocales.length === 0) {
+    return null;
+  }
+
+  return {
+    sourceLocale: record.source,
+    targetLocales,
+  };
+}
+
+type BucketFileMapping = {
+  fromPattern: string;
+  toPattern: string;
+};
+
+function collectBucketFileMappings(config: Record<string, unknown>): BucketFileMapping[] {
+  const buckets = config.buckets;
+  if (!buckets || typeof buckets !== "object") {
+    return [];
+  }
+
+  const mappings: BucketFileMapping[] = [];
+  for (const bucket of Object.values(buckets)) {
+    if (!bucket || typeof bucket !== "object") {
+      continue;
+    }
+
+    const files = (bucket as Record<string, unknown>).files;
+    if (!Array.isArray(files)) {
+      continue;
+    }
+
+    for (const file of files) {
+      if (!file || typeof file !== "object") {
+        continue;
+      }
+      const entry = file as Record<string, unknown>;
+      if (!hasValue(entry.from) || !hasValue(entry.to)) {
+        continue;
+      }
+      mappings.push({ fromPattern: entry.from, toPattern: entry.to });
+    }
+  }
+
+  return mappings;
+}
+
+function findBucketMappingForSourcePath(
+  sourcePath: string,
+  mappings: BucketFileMapping[],
+  sourceLocale: string,
+): BucketFileMapping | null {
+  for (const mapping of mappings) {
+    const resolvedSource = resolveSourcePath(mapping.fromPattern, sourceLocale);
+    if (
+      sourcePath === resolvedSource ||
+      pathMatchesPattern(sourcePath, mapping.fromPattern) ||
+      pathMatchesPattern(sourcePath, resolvedSource)
+    ) {
+      return mapping;
+    }
+  }
+
+  return null;
+}
+
+export async function listPullTranslationExportCandidates(input: {
+  organizationId: string;
+  projectId: string;
+  configJson: Record<string, unknown>;
+}): Promise<PullTranslationExportCandidate[]> {
+  const locales = parseI18nLocales(input.configJson);
+  if (!locales) {
+    return [];
+  }
+
+  const patterns = extractI18nBucketFilePatternsFromConfigJson(input.configJson);
+  if (patterns.targetPatterns.length === 0) {
+    return [];
+  }
+
+  const mappings = collectBucketFileMappings(input.configJson);
+  if (mappings.length === 0) {
+    return [];
+  }
+
+  const versionsSubquery = db
+    .select({
+      versionId: schema.repositorySourceFileVersions.id,
+      sourcePath: schema.repositorySourceFileVersions.sourcePath,
+      rowNumber:
+        sql<number>`ROW_NUMBER() OVER (PARTITION BY ${schema.repositorySourceFileVersions.sourcePath} ORDER BY ${schema.repositorySourceFileVersions.createdAt} DESC)`.as(
+          "rn",
+        ),
+    })
+    .from(schema.repositorySourceFileVersions)
+    .innerJoin(
+      schema.storedFiles,
+      eq(schema.storedFiles.id, schema.repositorySourceFileVersions.storedFileId),
+    )
+    .where(
+      and(
+        eq(schema.repositorySourceFileVersions.organizationId, input.organizationId),
+        eq(schema.repositorySourceFileVersions.projectId, input.projectId),
+        eq(schema.storedFiles.role, "source"),
+        eq(schema.storedFiles.sourceKind, "repository_file"),
+      ),
+    )
+    .as("versions_sq");
+
+  const versions = await db
+    .select({
+      versionId: versionsSubquery.versionId,
+      sourcePath: versionsSubquery.sourcePath,
+    })
+    .from(versionsSubquery)
+    .where(eq(versionsSubquery.rowNumber, 1));
+
+  if (versions.length === 0) {
+    return [];
+  }
+
+  const versionIds = versions.map((version) => version.versionId);
+  const jobsSubquery = db
+    .select({
+      versionId: schema.translationJobDetails.sourceFileVersionId,
+      jobId: schema.jobs.id,
+      jobStatus: schema.jobs.status,
+      outcomeKind: schema.translationJobDetails.outcomeKind,
+      outcomePayload: schema.jobs.outcomePayload,
+      rowNumber:
+        sql<number>`ROW_NUMBER() OVER (PARTITION BY ${schema.translationJobDetails.sourceFileVersionId} ORDER BY ${schema.jobs.createdAt} DESC)`.as(
+          "rn",
+        ),
+    })
+    .from(schema.jobs)
+    .innerJoin(schema.translationJobDetails, eq(schema.translationJobDetails.jobId, schema.jobs.id))
+    .where(
+      and(
+        eq(schema.jobs.projectId, input.projectId),
+        eq(schema.jobs.organizationId, input.organizationId),
+        eq(schema.translationJobDetails.type, "file"),
+        eq(schema.jobs.status, "succeeded"),
+        inArray(schema.translationJobDetails.sourceFileVersionId, versionIds),
+      ),
+    )
+    .as("jobs_sq");
+
+  const jobRows = await db
+    .select({
+      versionId: jobsSubquery.versionId,
+      jobId: jobsSubquery.jobId,
+      outcomeKind: jobsSubquery.outcomeKind,
+      outcomePayload: jobsSubquery.outcomePayload,
+    })
+    .from(jobsSubquery)
+    .where(eq(jobsSubquery.rowNumber, 1));
+
+  const versionById = new Map(versions.map((version) => [version.versionId, version.sourcePath]));
+  const planned: Array<{
+    sourcePath: string;
+    targetPath: string;
+    locale: string;
+    translationJobId: string;
+    outputFileId: string;
+  }> = [];
+
+  for (const job of jobRows) {
+    if (!job.versionId) {
+      continue;
+    }
+
+    const sourcePath = versionById.get(job.versionId);
+    if (!sourcePath) {
+      continue;
+    }
+
+    const mapping = findBucketMappingForSourcePath(sourcePath, mappings, locales.sourceLocale);
+    if (!mapping) {
+      continue;
+    }
+
+    const outputs = parseFileJobOutputFiles({
+      outcomeKind: job.outcomeKind,
+      outcomePayload: job.outcomePayload,
+    });
+    for (const output of outputs) {
+      if (!locales.targetLocales.includes(output.locale)) {
+        continue;
+      }
+
+      const targetPath = resolveTargetPath(mapping.toPattern, locales.sourceLocale, output.locale);
+
+      planned.push({
+        sourcePath,
+        targetPath,
+        locale: output.locale,
+        translationJobId: job.jobId,
+        outputFileId: output.fileId,
+      });
+    }
+  }
+
+  if (planned.length === 0) {
+    return [];
+  }
+
+  const outputFileIds = [...new Set(planned.map((item) => item.outputFileId))];
+  const storedFiles = await db
+    .select({
+      id: schema.storedFiles.id,
+      storageKey: schema.storedFiles.storageKey,
+    })
+    .from(schema.storedFiles)
+    .where(
+      and(
+        eq(schema.storedFiles.organizationId, input.organizationId),
+        eq(schema.storedFiles.projectId, input.projectId),
+        eq(schema.storedFiles.role, "output"),
+        inArray(schema.storedFiles.id, outputFileIds),
+      ),
+    );
+
+  const storageKeyById = new Map(storedFiles.map((file) => [file.id, file.storageKey]));
+  const adapter = getFileStorageAdapter();
+
+  const candidates = await mapWithConcurrency(planned, 5, async (item) => {
+    const storageKey = storageKeyById.get(item.outputFileId);
+    if (!storageKey) {
+      return null;
+    }
+
+    const object = await adapter.get({ keyOrUrl: storageKey });
+    if (!object) {
+      return null;
+    }
+
+    const content = await bufferFromStream(object.body);
+    return {
+      ...item,
+      content,
+    } satisfies PullTranslationExportCandidate;
+  });
+
+  return candidates.filter(
+    (candidate): candidate is PullTranslationExportCandidate => candidate !== null,
+  );
+}

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-pull-translations-pr.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-pull-translations-pr.ts
@@ -60,27 +60,6 @@ export async function writePullTranslationCandidatesToSandbox(input: {
   return { written: input.candidates.length, skipped: 0 };
 }
 
-export async function listChangedRepositoryPaths(sandboxId: string): Promise<string[]> {
-  const status = await runSandboxCommand(sandboxId, "git", ["status", "--porcelain"]);
-  if (status.exitCode !== 0) {
-    throw new Error(`git status failed: ${status.output}`);
-  }
-
-  const paths = new Set<string>();
-  for (const line of status.output.split("\n")) {
-    const trimmed = line.trimEnd();
-    if (trimmed.length < 4) {
-      continue;
-    }
-    const path = trimmed.slice(3).trim();
-    if (path) {
-      paths.add(path.replaceAll("\\", "/"));
-    }
-  }
-
-  return [...paths].sort();
-}
-
 export async function commitPushAndCreatePullTranslationsPullRequest(input: {
   sandboxId: string;
   installationId: string;
@@ -112,16 +91,18 @@ export async function commitPushAndCreatePullTranslationsPullRequest(input: {
     per_page: 1,
   });
 
-  const checkoutArgs =
-    existingPull.data.length > 0
-      ? ["checkout", input.branchName]
-      : ["checkout", "-b", input.branchName];
+  const isUpdatingExistingPull = existingPull.data.length > 0;
+  const remoteBranchHeadSha = isUpdatingExistingPull ? existingPull.data[0]?.head.sha : undefined;
+
+  const checkoutArgs = isUpdatingExistingPull
+    ? ["checkout", "-f", input.branchName]
+    : ["checkout", "-b", input.branchName];
   const checkout = await runSandboxCommand(input.sandboxId, "git", checkoutArgs);
   if (checkout.exitCode !== 0) {
     throw new Error(`git checkout failed: ${checkout.output}`);
   }
 
-  if (existingPull.data.length > 0) {
+  if (isUpdatingExistingPull) {
     const reset = await runSandboxCommand(input.sandboxId, "git", [
       "reset",
       "--hard",
@@ -150,12 +131,17 @@ export async function commitPushAndCreatePullTranslationsPullRequest(input: {
     throw new Error(`git commit failed: ${commit.output}`);
   }
 
-  const push = await runSandboxCommand(input.sandboxId, "git", [
-    "push",
-    "-u",
-    "origin",
-    input.branchName,
-  ]);
+  const pushArgs =
+    isUpdatingExistingPull && remoteBranchHeadSha
+      ? [
+          "push",
+          "-u",
+          "origin",
+          input.branchName,
+          `--force-with-lease=refs/heads/${input.branchName}:${remoteBranchHeadSha}`,
+        ]
+      : ["push", "-u", "origin", input.branchName];
+  const push = await runSandboxCommand(input.sandboxId, "git", pushArgs);
   if (push.exitCode !== 0) {
     throw new Error(`git push failed: ${push.output}`);
   }
@@ -182,7 +168,7 @@ export async function commitPushAndCreatePullTranslationsPullRequest(input: {
     "Please review locale file changes before merging.",
   ].filter((line): line is string => line !== null);
 
-  if (existingPull.data.length > 0) {
+  if (isUpdatingExistingPull) {
     const pullRequest = existingPull.data[0];
     await octokit.rest.pulls.update({
       owner,

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-pull-translations-pr.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-pull-translations-pr.ts
@@ -215,8 +215,16 @@ export async function hasDiffAgainstBase(input: {
     candidates: input.candidates,
   });
 
+  for (const path of input.paths) {
+    const add = await runSandboxCommand(input.sandboxId, "git", ["add", "--", path]);
+    if (add.exitCode !== 0) {
+      throw new Error(`git add failed for ${path}: ${add.output}`);
+    }
+  }
+
   const diff = await runGitDiffInSandbox(input.sandboxId, [
     "diff",
+    "--cached",
     "--quiet",
     input.baseSha,
     "--",

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-pull-translations-pr.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-pull-translations-pr.ts
@@ -1,0 +1,241 @@
+import { getInstallationOctokit } from "@/lib/agents/github/app";
+import { buildGithubRepositoryAutomationJobDetailsUrl } from "@/lib/agents/github/github-repository-automation-check-run";
+import {
+  prepareGithubRepositoryAutomationSandboxForPush,
+  runGitDiffInSandbox,
+} from "@/lib/agents/github/github-repository-automation-sandbox";
+import { runSandboxCommand, writeFilesToSandbox } from "@/lib/translation/sandbox-translation";
+
+import { buildPullTranslationsBranchName } from "./github-repository-automation-pull-translations-branch";
+import type { PullTranslationExportCandidate } from "./github-repository-automation-pull-translations-export";
+
+export { buildPullTranslationsBranchName };
+
+function parseRepositoryOwnerRepo(fullName: string): { owner: string; repo: string } {
+  const [owner, repo] = fullName.split("/");
+  if (!owner || !repo) {
+    throw new Error("invalid repository full name");
+  }
+  return { owner, repo };
+}
+
+export async function verifyExpectedBaseBranchHead(input: {
+  installationId: string;
+  repositoryFullName: string;
+  baseBranch: string;
+  expectedBaseSha: string;
+}): Promise<{ ok: true } | { ok: false; actualBaseSha: string }> {
+  const octokit = await getInstallationOctokit(input.installationId);
+  const { owner, repo } = parseRepositoryOwnerRepo(input.repositoryFullName);
+  const ref = await octokit.rest.git.getRef({
+    owner,
+    repo,
+    ref: `heads/${input.baseBranch}`,
+  });
+
+  const actualBaseSha = ref.data.object.sha;
+  if (actualBaseSha !== input.expectedBaseSha) {
+    return { ok: false, actualBaseSha };
+  }
+
+  return { ok: true };
+}
+
+export async function writePullTranslationCandidatesToSandbox(input: {
+  sandboxId: string;
+  candidates: PullTranslationExportCandidate[];
+}): Promise<{ written: number; skipped: number }> {
+  if (input.candidates.length === 0) {
+    return { written: 0, skipped: 0 };
+  }
+
+  await writeFilesToSandbox(
+    input.sandboxId,
+    input.candidates.map((candidate) => ({
+      path: candidate.targetPath,
+      content: candidate.content,
+    })),
+  );
+
+  return { written: input.candidates.length, skipped: 0 };
+}
+
+export async function listChangedRepositoryPaths(sandboxId: string): Promise<string[]> {
+  const status = await runSandboxCommand(sandboxId, "git", ["status", "--porcelain"]);
+  if (status.exitCode !== 0) {
+    throw new Error(`git status failed: ${status.output}`);
+  }
+
+  const paths = new Set<string>();
+  for (const line of status.output.split("\n")) {
+    const trimmed = line.trimEnd();
+    if (trimmed.length < 4) {
+      continue;
+    }
+    const path = trimmed.slice(3).trim();
+    if (path) {
+      paths.add(path.replaceAll("\\", "/"));
+    }
+  }
+
+  return [...paths].sort();
+}
+
+export async function commitPushAndCreatePullTranslationsPullRequest(input: {
+  sandboxId: string;
+  installationId: string;
+  repositoryFullName: string;
+  automationJobId: string;
+  organizationSlug: string | null;
+  githubRepositoryId: string;
+  baseBranch: string;
+  baseSha: string;
+  branchName: string;
+  paths: string[];
+  candidates: PullTranslationExportCandidate[];
+  linkedTranslationJobIds: string[];
+}): Promise<{ pullRequestUrl: string; pullRequestNumber: number; updated: boolean }> {
+  const { owner, repo } = parseRepositoryOwnerRepo(input.repositoryFullName);
+  const octokit = await getInstallationOctokit(input.installationId);
+
+  await prepareGithubRepositoryAutomationSandboxForPush({
+    sandboxId: input.sandboxId,
+    installationId: input.installationId,
+    repositoryFullName: input.repositoryFullName,
+  });
+
+  const existingPull = await octokit.rest.pulls.list({
+    owner,
+    repo,
+    state: "open",
+    head: `${owner}:${input.branchName}`,
+    per_page: 1,
+  });
+
+  const checkoutArgs =
+    existingPull.data.length > 0
+      ? ["checkout", input.branchName]
+      : ["checkout", "-b", input.branchName];
+  const checkout = await runSandboxCommand(input.sandboxId, "git", checkoutArgs);
+  if (checkout.exitCode !== 0) {
+    throw new Error(`git checkout failed: ${checkout.output}`);
+  }
+
+  if (existingPull.data.length > 0) {
+    const reset = await runSandboxCommand(input.sandboxId, "git", [
+      "reset",
+      "--hard",
+      input.baseSha,
+    ]);
+    if (reset.exitCode !== 0) {
+      throw new Error(`git reset failed: ${reset.output}`);
+    }
+  }
+
+  await writePullTranslationCandidatesToSandbox({
+    sandboxId: input.sandboxId,
+    candidates: input.candidates,
+  });
+
+  for (const path of input.paths) {
+    const add = await runSandboxCommand(input.sandboxId, "git", ["add", "--", path]);
+    if (add.exitCode !== 0) {
+      throw new Error(`git add failed for ${path}: ${add.output}`);
+    }
+  }
+
+  const commitMessage = `chore(i18n): update translations (${input.automationJobId.slice(0, 8)})`;
+  const commit = await runSandboxCommand(input.sandboxId, "git", ["commit", "-m", commitMessage]);
+  if (commit.exitCode !== 0) {
+    throw new Error(`git commit failed: ${commit.output}`);
+  }
+
+  const push = await runSandboxCommand(input.sandboxId, "git", [
+    "push",
+    "-u",
+    "origin",
+    input.branchName,
+  ]);
+  if (push.exitCode !== 0) {
+    throw new Error(`git push failed: ${push.output}`);
+  }
+
+  const jobDetailsUrl = buildGithubRepositoryAutomationJobDetailsUrl({
+    organizationSlug: input.organizationSlug,
+    githubRepositoryId: input.githubRepositoryId,
+    jobId: input.automationJobId,
+  });
+
+  const bodyLines = [
+    "## Hyperlocalise translation sync",
+    "",
+    "This pull request writes completed Hyperlocalise file translations back to the repository.",
+    "",
+    `- Automation job: \`${input.automationJobId}\``,
+    `- Base commit: \`${input.baseSha}\``,
+    `- Updated paths: ${input.paths.length}`,
+    jobDetailsUrl ? `- [View automation run](${jobDetailsUrl})` : null,
+    input.linkedTranslationJobIds.length > 0
+      ? `- Linked translation jobs: ${input.linkedTranslationJobIds.map((id) => `\`${id}\``).join(", ")}`
+      : null,
+    "",
+    "Please review locale file changes before merging.",
+  ].filter((line): line is string => line !== null);
+
+  if (existingPull.data.length > 0) {
+    const pullRequest = existingPull.data[0];
+    await octokit.rest.pulls.update({
+      owner,
+      repo,
+      pull_number: pullRequest.number,
+      body: bodyLines.join("\n"),
+    });
+
+    return {
+      pullRequestUrl: pullRequest.html_url,
+      pullRequestNumber: pullRequest.number,
+      updated: true,
+    };
+  }
+
+  const { data: pullRequest } = await octokit.rest.pulls.create({
+    owner,
+    repo,
+    title: commitMessage,
+    head: input.branchName,
+    base: input.baseBranch,
+    body: bodyLines.join("\n"),
+  });
+
+  return {
+    pullRequestUrl: pullRequest.html_url,
+    pullRequestNumber: pullRequest.number,
+    updated: false,
+  };
+}
+
+export async function hasDiffAgainstBase(input: {
+  sandboxId: string;
+  baseSha: string;
+  paths: string[];
+  candidates: PullTranslationExportCandidate[];
+}): Promise<boolean> {
+  if (input.paths.length === 0) {
+    return false;
+  }
+
+  await writePullTranslationCandidatesToSandbox({
+    sandboxId: input.sandboxId,
+    candidates: input.candidates,
+  });
+
+  const diff = await runGitDiffInSandbox(input.sandboxId, [
+    "diff",
+    "--quiet",
+    input.baseSha,
+    "--",
+    ...input.paths,
+  ]);
+
+  return diff.exitCode !== 0;
+}

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-pull-translations.errors.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-pull-translations.errors.ts
@@ -1,0 +1,92 @@
+import { updateGithubRepositoryAutomationJobStatus } from "./github-repository-automation-jobs";
+
+import type { GithubRepositoryAutomationPullTranslationsSummary } from "./github-repository-automation-pull-translations.types";
+
+export type GithubRepositoryAutomationPullTranslationsError =
+  | { code: "pull_translations_workflow_disabled" }
+  | { code: "project_not_linked" }
+  | { code: "i18n_config_not_found" }
+  | { code: "target_patterns_not_configured" }
+  | {
+      code: "no_translation_exports_available";
+      summary: GithubRepositoryAutomationPullTranslationsSummary;
+    }
+  | {
+      code: "no_repository_changes";
+      summary: GithubRepositoryAutomationPullTranslationsSummary;
+    }
+  | { code: "base_branch_advanced"; expectedBaseSha: string; actualBaseSha: string }
+  | { code: "protected_branch"; branch: string; reason: string }
+  | { code: "cannot_push_to_repository"; reason: string }
+  | {
+      code: "pull_translations_failed";
+      summary: GithubRepositoryAutomationPullTranslationsSummary;
+    }
+  | { code: "infrastructure"; message: string };
+
+export function isPullTranslationsSkipError(
+  error: GithubRepositoryAutomationPullTranslationsError,
+): boolean {
+  return (
+    error.code === "pull_translations_workflow_disabled" ||
+    error.code === "project_not_linked" ||
+    error.code === "i18n_config_not_found" ||
+    error.code === "target_patterns_not_configured" ||
+    error.code === "no_translation_exports_available" ||
+    error.code === "no_repository_changes"
+  );
+}
+
+export async function persistPullTranslationsSkippedJob(input: {
+  jobId: string;
+  error: GithubRepositoryAutomationPullTranslationsError;
+}): Promise<void> {
+  const resultSummary =
+    input.error.code === "no_translation_exports_available" ||
+    input.error.code === "no_repository_changes"
+      ? input.error.summary
+      : null;
+
+  await updateGithubRepositoryAutomationJobStatus({
+    jobId: input.jobId,
+    status: "skipped",
+    skipReason: input.error.code,
+    resultSummary,
+  });
+}
+
+export async function persistPullTranslationsFailedJob(input: {
+  jobId: string;
+  error: GithubRepositoryAutomationPullTranslationsError;
+  lastError?: string | null;
+  resultSummary?: Record<string, unknown> | null;
+}): Promise<void> {
+  const summaryFromError =
+    input.error.code === "pull_translations_failed" ||
+    input.error.code === "no_translation_exports_available" ||
+    input.error.code === "no_repository_changes"
+      ? input.error.summary
+      : null;
+
+  const lastError =
+    input.lastError ??
+    (input.error.code === "infrastructure"
+      ? input.error.message
+      : input.error.code === "base_branch_advanced"
+        ? `base_branch_advanced:${input.error.actualBaseSha}`
+        : input.error.code === "protected_branch"
+          ? input.error.reason
+          : input.error.code === "cannot_push_to_repository"
+            ? input.error.reason
+            : input.error.code === "pull_translations_failed"
+              ? "pull_translations_failed"
+              : input.error.code);
+
+  await updateGithubRepositoryAutomationJobStatus({
+    jobId: input.jobId,
+    status: "failed",
+    skipReason: null,
+    resultSummary: input.resultSummary ?? summaryFromError,
+    lastError,
+  });
+}

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-pull-translations.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-pull-translations.ts
@@ -1,0 +1,344 @@
+import { createLogger } from "@/lib/log";
+import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
+import { canPushToGitHubRepository } from "@/lib/agents/repository-write-gate";
+
+import {
+  resolveGithubRepositoryAutomationCommitRange,
+  type GithubRepositoryAutomationCommitRange,
+} from "./github-repository-automation-commit-range";
+import {
+  discoverI18nConfigInSandbox,
+  loadI18nConfigJsonFromSandbox,
+} from "./github-repository-automation-i18n-config";
+import type { GithubRepositoryAutomationJobWithRepository } from "./github-repository-automation-jobs";
+import { updateGithubRepositoryAutomationJobStatus } from "./github-repository-automation-jobs";
+import {
+  listPullTranslationExportCandidates,
+  type PullTranslationExportCandidate,
+} from "./github-repository-automation-pull-translations-export";
+import {
+  type GithubRepositoryAutomationPullTranslationsError,
+  persistPullTranslationsFailedJob,
+  persistPullTranslationsSkippedJob,
+} from "./github-repository-automation-pull-translations.errors";
+import { buildPullTranslationsBranchName } from "./github-repository-automation-pull-translations-branch";
+import {
+  commitPushAndCreatePullTranslationsPullRequest,
+  hasDiffAgainstBase,
+  verifyExpectedBaseBranchHead,
+} from "./github-repository-automation-pull-translations-pr";
+import { resolveGithubRepositoryAutomationProjectId } from "./github-repository-automation-project";
+import { getGithubRepositoryAutomationSettings } from "./github-repository-automation-settings-store";
+import {
+  createGithubRepositoryAutomationSandbox,
+  stopGithubRepositoryAutomationSandbox,
+} from "./github-repository-automation-sandbox";
+
+import type { GithubRepositoryAutomationPullTranslationsSummary } from "./github-repository-automation-pull-translations.types";
+
+const logger = createLogger("github-repo-automation-pull-translations");
+
+export type { GithubRepositoryAutomationPullTranslationsError } from "./github-repository-automation-pull-translations.errors";
+export type { GithubRepositoryAutomationPullTranslationsSummary } from "./github-repository-automation-pull-translations.types";
+
+function parseInstallationId(installationId: string): number {
+  return Number.parseInt(installationId, 10);
+}
+
+function buildPullTranslationsSummary(input: {
+  baseSha: string;
+  baseBranch: string;
+  branchName: string;
+  candidates: PullTranslationExportCandidate[];
+  written: number;
+  skipped: number;
+  pullRequestUrl?: string;
+  pullRequestNumber?: number;
+}): GithubRepositoryAutomationPullTranslationsSummary {
+  const linkedTranslationJobIds = [
+    ...new Set(input.candidates.map((candidate) => candidate.translationJobId)),
+  ];
+
+  return {
+    baseSha: input.baseSha,
+    baseBranch: input.baseBranch,
+    branchName: input.branchName,
+    pullRequestUrl: input.pullRequestUrl,
+    pullRequestNumber: input.pullRequestNumber,
+    counts: {
+      planned: input.candidates.length,
+      written: input.written,
+      skipped: input.skipped,
+      failed: 0,
+    },
+    linkedTranslationJobIds,
+  };
+}
+
+async function returnPullTranslationsSkipped(
+  jobId: string,
+  error: GithubRepositoryAutomationPullTranslationsError,
+): Promise<Result<never, GithubRepositoryAutomationPullTranslationsError>> {
+  await persistPullTranslationsSkippedJob({ jobId, error });
+  return err(error);
+}
+
+async function returnPullTranslationsFailed(
+  jobId: string,
+  error: GithubRepositoryAutomationPullTranslationsError,
+  lastError?: string | null,
+): Promise<Result<never, GithubRepositoryAutomationPullTranslationsError>> {
+  await persistPullTranslationsFailedJob({ jobId, error, lastError });
+  return err(error);
+}
+
+export async function runGithubRepositoryAutomationPullTranslations(input: {
+  job: GithubRepositoryAutomationJobWithRepository;
+  commitRange?: GithubRepositoryAutomationCommitRange;
+}): Promise<
+  Result<
+    GithubRepositoryAutomationPullTranslationsSummary,
+    GithubRepositoryAutomationPullTranslationsError
+  >
+> {
+  const job = input.job;
+
+  if (!job.workflows.pullTranslations) {
+    return returnPullTranslationsSkipped(job.id, { code: "pull_translations_workflow_disabled" });
+  }
+
+  const settingsRecord = await getGithubRepositoryAutomationSettings({
+    githubInstallationRepositoryId: job.githubInstallationRepositoryId,
+    githubRepositoryId: job.githubRepositoryId,
+  });
+
+  const projectId = await resolveGithubRepositoryAutomationProjectId({
+    organizationId: job.organizationId,
+    repositoryFullName: job.repositoryFullName,
+    configuredProjectId: settingsRecord.settings.workflows.pullTranslations.projectId,
+  });
+
+  if (!projectId) {
+    return returnPullTranslationsSkipped(job.id, { code: "project_not_linked" });
+  }
+
+  const installationId = parseInstallationId(job.githubInstallationId);
+
+  const repositoryPush = await canPushToGitHubRepository({
+    installationId,
+    repositoryFullName: job.repositoryFullName,
+  });
+  if (!repositoryPush.canPush) {
+    return returnPullTranslationsFailed(job.id, {
+      code: "cannot_push_to_repository",
+      reason: repositoryPush.reason ?? "Cannot push to repository.",
+    });
+  }
+
+  const commitRangeResult: Result<
+    GithubRepositoryAutomationCommitRange,
+    GithubRepositoryAutomationPullTranslationsError
+  > = input.commitRange ? ok(input.commitRange) : await resolveCommitRangeForPullTranslations(job);
+
+  if (isErr(commitRangeResult)) {
+    return returnPullTranslationsFailed(job.id, commitRangeResult.error);
+  }
+
+  const { commitAfter } = commitRangeResult.value;
+  const baseBranch = job.triggerBranch ?? job.defaultBranch;
+  if (!baseBranch) {
+    return returnPullTranslationsFailed(job.id, {
+      code: "infrastructure",
+      message: "github_repository_automation_branch_not_resolved",
+    });
+  }
+
+  const baseHead = await verifyExpectedBaseBranchHead({
+    installationId: job.githubInstallationId,
+    repositoryFullName: job.repositoryFullName,
+    baseBranch,
+    expectedBaseSha: commitAfter,
+  });
+  if (!baseHead.ok) {
+    return returnPullTranslationsFailed(job.id, {
+      code: "base_branch_advanced",
+      expectedBaseSha: commitAfter,
+      actualBaseSha: baseHead.actualBaseSha,
+    });
+  }
+
+  if (!input.commitRange && !job.commitAfter) {
+    await updateGithubRepositoryAutomationJobStatus({
+      jobId: job.id,
+      status: "running",
+      commitBefore: commitRangeResult.value.commitBefore,
+      commitAfter,
+    });
+  }
+
+  let sandboxId: string | null = null;
+
+  try {
+    sandboxId = await createGithubRepositoryAutomationSandbox({
+      installationId: job.githubInstallationId,
+      repositoryFullName: job.repositoryFullName,
+      revision: commitAfter,
+      cloneDepth: 50,
+    });
+
+    const i18nConfig = await discoverI18nConfigInSandbox(sandboxId);
+    if (!i18nConfig) {
+      return returnPullTranslationsSkipped(job.id, { code: "i18n_config_not_found" });
+    }
+
+    if (i18nConfig.patterns.targetPatterns.length === 0) {
+      return returnPullTranslationsSkipped(job.id, { code: "target_patterns_not_configured" });
+    }
+
+    const configJson = await loadI18nConfigJsonFromSandbox(sandboxId, i18nConfig.configPath);
+    if (!configJson) {
+      return returnPullTranslationsSkipped(job.id, { code: "i18n_config_not_found" });
+    }
+
+    const candidates = await listPullTranslationExportCandidates({
+      organizationId: job.organizationId,
+      projectId,
+      configJson,
+    });
+
+    const branchNameForSummary = buildPullTranslationsBranchName(job.id);
+
+    if (candidates.length === 0) {
+      const summary = buildPullTranslationsSummary({
+        baseSha: commitAfter,
+        baseBranch,
+        branchName: branchNameForSummary,
+        candidates: [],
+        written: 0,
+        skipped: 0,
+      });
+
+      return returnPullTranslationsSkipped(job.id, {
+        code: "no_translation_exports_available",
+        summary,
+      });
+    }
+
+    const targetPaths = [...new Set(candidates.map((candidate) => candidate.targetPath))].sort();
+    const hasChanges = await hasDiffAgainstBase({
+      sandboxId,
+      baseSha: commitAfter,
+      paths: targetPaths,
+      candidates,
+    });
+
+    if (!hasChanges) {
+      const summary = buildPullTranslationsSummary({
+        baseSha: commitAfter,
+        baseBranch,
+        branchName: branchNameForSummary,
+        candidates,
+        written: 0,
+        skipped: candidates.length,
+      });
+
+      return returnPullTranslationsSkipped(job.id, {
+        code: "no_repository_changes",
+        summary,
+      });
+    }
+
+    const pullRequest = await commitPushAndCreatePullTranslationsPullRequest({
+      sandboxId,
+      installationId: job.githubInstallationId,
+      repositoryFullName: job.repositoryFullName,
+      automationJobId: job.id,
+      organizationSlug: job.organizationSlug,
+      githubRepositoryId: job.githubRepositoryId,
+      baseBranch,
+      baseSha: commitAfter,
+      branchName: branchNameForSummary,
+      paths: targetPaths,
+      candidates,
+      linkedTranslationJobIds: [
+        ...new Set(candidates.map((candidate) => candidate.translationJobId)),
+      ],
+    });
+
+    const summary = buildPullTranslationsSummary({
+      baseSha: commitAfter,
+      baseBranch,
+      branchName: branchNameForSummary,
+      candidates,
+      written: candidates.length,
+      skipped: 0,
+      pullRequestUrl: pullRequest.pullRequestUrl,
+      pullRequestNumber: pullRequest.pullRequestNumber,
+    });
+
+    await updateGithubRepositoryAutomationJobStatus({
+      jobId: job.id,
+      status: "succeeded",
+      resultSummary: summary,
+      lastError: null,
+    });
+
+    logger.info(
+      {
+        jobId: job.id,
+        pullRequestNumber: pullRequest.pullRequestNumber,
+        pathCount: targetPaths.length,
+      },
+      "github repository automation pull translations completed",
+    );
+
+    return ok(summary);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "pull_translations_automation_failed";
+
+    logger.error(
+      {
+        jobId: job.id,
+        err: error,
+      },
+      "github repository automation pull translations failed",
+    );
+
+    const partialSummary = buildPullTranslationsSummary({
+      baseSha: commitAfter,
+      baseBranch,
+      branchName: buildPullTranslationsBranchName(job.id),
+      candidates: [],
+      written: 0,
+      skipped: 0,
+    });
+
+    return returnPullTranslationsFailed(
+      job.id,
+      { code: "pull_translations_failed", summary: partialSummary },
+      message,
+    );
+  } finally {
+    if (sandboxId) {
+      await stopGithubRepositoryAutomationSandbox(sandboxId).catch(() => undefined);
+    }
+  }
+}
+
+async function resolveCommitRangeForPullTranslations(
+  job: GithubRepositoryAutomationJobWithRepository,
+): Promise<
+  Result<GithubRepositoryAutomationCommitRange, GithubRepositoryAutomationPullTranslationsError>
+> {
+  try {
+    const commitRange = await resolveGithubRepositoryAutomationCommitRange(job);
+    return ok(commitRange);
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : "failed_to_resolve_commit_range_for_pull_translations";
+
+    return err({ code: "infrastructure", message });
+  }
+}

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-pull-translations.types.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-pull-translations.types.ts
@@ -1,0 +1,14 @@
+export type GithubRepositoryAutomationPullTranslationsSummary = {
+  baseSha: string;
+  baseBranch: string;
+  branchName: string;
+  pullRequestUrl?: string;
+  pullRequestNumber?: number;
+  counts: {
+    planned: number;
+    written: number;
+    skipped: number;
+    failed: number;
+  };
+  linkedTranslationJobIds: string[];
+};

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-sandbox.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-sandbox.ts
@@ -61,6 +61,36 @@ export async function runGitDiffInSandbox(
   return runSandboxCommand(sandboxId, "git", args, { output: "stdout" });
 }
 
+export async function prepareGithubRepositoryAutomationSandboxForPush(input: {
+  sandboxId: string;
+  installationId: string;
+  repositoryFullName: string;
+}): Promise<void> {
+  const octokit = await getInstallationOctokit(input.installationId);
+  const { token } = (await octokit.auth({ type: "installation" })) as InstallationAuth;
+  const remote = `https://github.com/${input.repositoryFullName}.git`;
+
+  for (const [command, args, options] of [
+    ["git", ["config", "user.name", "hyperlocalise[bot]"]],
+    ["git", ["config", "user.email", "hyperlocalise[bot]@users.noreply.github.com"]],
+    ["git", ["config", "credential.helper", "store"]],
+    [
+      "bash",
+      [
+        "-lc",
+        `printf '%s\\n' "https://x-access-token:$GITHUB_TOKEN@github.com" > ~/.git-credentials`,
+      ],
+      { env: { GITHUB_TOKEN: token } },
+    ],
+    ["git", ["remote", "set-url", "origin", remote]],
+  ] satisfies Array<[string, string[], { env?: Record<string, string> }?]>) {
+    const result = await runSandboxCommand(input.sandboxId, command, args, options);
+    if (result.exitCode !== 0) {
+      throw new Error(`sandbox git setup failed: ${result.output}`);
+    }
+  }
+}
+
 export async function resolveDefaultBranchHeadSha(input: {
   installationId: string;
   owner: string;

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-settings-store.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-settings-store.ts
@@ -32,6 +32,7 @@ function parseStoredSettings(
     merged.workflows.pushSource.enabled !== defaults.workflows.pushSource.enabled ||
     merged.workflows.pushSource.projectId !== defaults.workflows.pushSource.projectId ||
     merged.workflows.pullTranslations.enabled !== defaults.workflows.pullTranslations.enabled ||
+    merged.workflows.pullTranslations.projectId !== defaults.workflows.pullTranslations.projectId ||
     merged.workflows.validation.enabled !== defaults.workflows.validation.enabled
   ) {
     stored.workflows = merged.workflows;

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-settings.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-settings.ts
@@ -43,7 +43,12 @@ export const githubRepoAutomationWorkflowsSchema = z.object({
       projectId: z.string().trim().min(1).optional(),
     })
     .default({ enabled: false }),
-  pullTranslations: z.object({ enabled: z.boolean().default(false) }).default({ enabled: false }),
+  pullTranslations: z
+    .object({
+      enabled: z.boolean().default(false),
+      projectId: z.string().trim().min(1).optional(),
+    })
+    .default({ enabled: false }),
   validation: githubRepoAutomationValidationWorkflowSchema,
 });
 
@@ -62,7 +67,7 @@ export type GithubRepositoryAutomationSettings = z.infer<
 export type GithubRepositoryAutomationSettingsPartial = {
   workflows?: {
     pushSource?: { enabled?: boolean; projectId?: string };
-    pullTranslations?: { enabled?: boolean };
+    pullTranslations?: { enabled?: boolean; projectId?: string };
     validation?: { enabled?: boolean; blockOnFailure?: boolean };
   };
   trigger?: z.infer<typeof githubRepoAutomationTriggerSchema> | null;
@@ -80,7 +85,12 @@ const githubRepositoryAutomationSettingsPartialSchema = z.object({
           projectId: z.string().trim().min(1).optional(),
         })
         .optional(),
-      pullTranslations: z.object({ enabled: z.boolean().optional() }).optional(),
+      pullTranslations: z
+        .object({
+          enabled: z.boolean().optional(),
+          projectId: z.string().trim().min(1).optional(),
+        })
+        .optional(),
       validation: z
         .object({
           enabled: z.boolean().optional(),
@@ -127,6 +137,9 @@ export function mergeGithubRepositoryAutomationSettings(
       pullTranslations: {
         enabled:
           override.workflows?.pullTranslations?.enabled ?? base.workflows.pullTranslations.enabled,
+        projectId:
+          override.workflows?.pullTranslations?.projectId ??
+          base.workflows.pullTranslations.projectId,
       },
       validation: {
         enabled: override.workflows?.validation?.enabled ?? base.workflows.validation.enabled,

--- a/apps/hyperlocalise-web/src/lib/i18n/i18n-pathresolver.test.ts
+++ b/apps/hyperlocalise-web/src/lib/i18n/i18n-pathresolver.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { resolveSourcePath, resolveTargetPath } from "./i18n-pathresolver";
+
+describe("i18n-pathresolver", () => {
+  it("resolves source paths with locale tokens", () => {
+    expect(resolveSourcePath("locales/{{source}}.json", "en")).toBe("locales/en.json");
+  });
+
+  it("resolves target paths with locale directory tokens", () => {
+    expect(resolveTargetPath("locales/{{localeDir}}/messages.json", "en", "fr")).toBe(
+      "locales/fr/messages.json",
+    );
+  });
+
+  it("resolves legacy [locale] placeholders", () => {
+    expect(resolveTargetPath("locales/[locale]/messages.json", "en", "de")).toBe(
+      "locales/de/messages.json",
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/i18n/i18n-pathresolver.ts
+++ b/apps/hyperlocalise-web/src/lib/i18n/i18n-pathresolver.ts
@@ -1,0 +1,31 @@
+const TOKEN_SOURCE = "{{source}}";
+const TOKEN_TARGET = "{{target}}";
+const TOKEN_LOCALE_DIR = "{{localeDir}}";
+const LEGACY_LOCALE = "[locale]";
+
+function resolve(pattern: string, sourceLocale: string, targetLocale: string): string {
+  const localeDir = sourceLocale === targetLocale ? "" : targetLocale;
+
+  let path = pattern.replaceAll(TOKEN_SOURCE, sourceLocale);
+  path = path.replaceAll(TOKEN_TARGET, targetLocale);
+  path = path.replaceAll(TOKEN_LOCALE_DIR, localeDir);
+  path = path.replaceAll(LEGACY_LOCALE, targetLocale);
+
+  while (path.includes("//")) {
+    path = path.replaceAll("//", "/");
+  }
+
+  return path;
+}
+
+export function resolveSourcePath(pattern: string, sourceLocale: string): string {
+  return resolve(pattern, sourceLocale, sourceLocale);
+}
+
+export function resolveTargetPath(
+  pattern: string,
+  sourceLocale: string,
+  targetLocale: string,
+): string {
+  return resolve(pattern, sourceLocale, targetLocale);
+}

--- a/apps/hyperlocalise-web/src/workflows/github-repository-automation.ts
+++ b/apps/hyperlocalise-web/src/workflows/github-repository-automation.ts
@@ -12,6 +12,7 @@ import {
 } from "@/lib/agents/github/github-repository-automation-commit-range";
 import { isErr } from "@/lib/primitives/result/results";
 
+import { runGithubRepositoryAutomationPullTranslations } from "@/lib/agents/github/github-repository-automation-pull-translations";
 import { runGithubRepositoryAutomationPushSource } from "@/lib/agents/github/github-repository-automation-push-source";
 import { runGithubRepositoryAutomationValidation } from "@/lib/agents/github/github-repository-automation-validation";
 
@@ -62,17 +63,9 @@ async function runAutomationJobStep(input: { jobId: string; workflowRunId: strin
     return { skipped: true, reason: "no_runnable_workflows" };
   }
 
-  if (!job.workflows.pushSource && !job.workflows.validation) {
-    await updateGithubRepositoryAutomationJobStatus({
-      jobId: job.id,
-      status: "skipped",
-      skipReason: "pull_translations_not_implemented",
-    });
-    return { skipped: true, reason: "pull_translations_not_implemented" };
-  }
-
   const results: Record<string, unknown> = {};
-  const needsCommitRange = job.workflows.pushSource || job.workflows.validation;
+  const needsCommitRange =
+    job.workflows.pushSource || job.workflows.validation || job.workflows.pullTranslations;
   let commitRange: GithubRepositoryAutomationCommitRange | undefined;
 
   if (needsCommitRange) {
@@ -120,6 +113,22 @@ async function runAutomationJobStep(input: { jobId: string; workflowRunId: strin
       workflowRunId: input.workflowRunId,
       commitRange,
     });
+  }
+
+  if (job.workflows.pullTranslations) {
+    const pullTranslationsResult = await runGithubRepositoryAutomationPullTranslations({
+      job,
+      commitRange,
+    });
+
+    if (isErr(pullTranslationsResult)) {
+      results.pullTranslations = pullTranslationsResult.error;
+      if (pullTranslationsResult.error.code === "infrastructure") {
+        throw new Error(pullTranslationsResult.error.message);
+      }
+    } else {
+      results.pullTranslations = pullTranslationsResult.value;
+    }
   }
 
   return results;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Addresses HL-447: automatic write-back of Hyperlocalise translation updates to GitHub via pull request.

## Latest fix

**New locale file detection** — `hasDiffAgainstBase` now stages candidate paths and uses `git diff --cached --quiet <baseSha>` so first-time (untracked) locale files are detected instead of incorrectly skipping with `no_repository_changes`.

## Prior review fixes

- `--force-with-lease` when updating an existing PR branch after reset/commit
- `git checkout -f` on re-run so dirty working tree from the diff check does not block checkout
- Removed unused `listChangedRepositoryPaths` export
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-447](https://linear.app/hyperlocalise/issue/HL-447/implement-pull-translation-automation-back-to-github)

<div><a href="https://cursor.com/agents/bc-4b62a9f2-940b-43f5-ae24-23c9dc18ddcd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b62a9f2-940b-43f5-ae24-23c9dc18ddcd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

