### PR TITLE
feat(github): publish automation check runs

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/github-installation/github-installation.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/github-installation/github-installation.schema.ts
@@ -28,7 +28,9 @@ const githubRepositoryAutomationSettingsPartialSchema = z.object({
         })
         .optional(),
       pullTranslations: z.object({ enabled: z.boolean().optional() }).optional(),
-      validation: z.object({ enabled: z.boolean().optional() }).optional(),
+      validation: z
+        .object({ enabled: z.boolean().optional(), blockOnFailure: z.boolean().optional() })
+        .optional(),
     })
     .optional(),
   trigger: z
@@ -56,6 +58,12 @@ const githubRepositoryAutomationSettingsPartialSchema = z.object({
       }),
     ])
     .nullable()
+    .optional(),
+  statusCheck: z
+    .object({
+      enabled: z.boolean().optional(),
+      mode: z.enum(["advisory", "blocking"]).optional(),
+    })
     .optional(),
 });
 

--- a/apps/hyperlocalise-web/src/api/routes/github-installation/github-installation.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/github-installation/github-installation.test.ts
@@ -452,6 +452,7 @@ describe("githubInstallationRoutes", () => {
             validation: { enabled: false },
           },
           trigger: null,
+          statusCheck: { enabled: false, mode: "blocking" },
         },
       },
     });
@@ -472,6 +473,7 @@ describe("githubInstallationRoutes", () => {
               pullTranslations: { enabled: false },
               validation: { enabled: false },
             },
+            statusCheck: { enabled: true, mode: "blocking" },
             trigger: {
               mode: "push",
               branches: ["main", "release/*"],
@@ -491,6 +493,7 @@ describe("githubInstallationRoutes", () => {
           workflows: {
             pushSource: { enabled: true },
           },
+          statusCheck: { enabled: true, mode: "blocking" },
           trigger: {
             mode: "push",
             branches: ["main", "release/*"],

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-check-run.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-check-run.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vite-plus/test";
 
 import { buildGithubRepositoryAutomationJobDetailsUrl } from "./github-repository-automation-check-run";
 
-describe("buildGithubRepositoryAutomationJobDetailsUrl", () => {
+describe("github repository automation check runs", () => {
   it("returns the org integrations page with job context", async () => {
     vi.resetModules();
     vi.doMock("@/lib/env", () => ({
@@ -33,5 +33,43 @@ describe("buildGithubRepositoryAutomationJobDetailsUrl", () => {
         jobId: "job-uuid",
       }),
     ).toBeUndefined();
+  });
+});
+
+describe("check run constants", () => {
+  it("uses a localization automation context suitable for branch protection", async () => {
+    vi.resetModules();
+    const checksCreate = vi.fn().mockResolvedValue({ data: { id: 123 } });
+    vi.doMock("@/lib/agents/github/app", () => ({
+      getInstallationOctokit: vi.fn().mockResolvedValue({
+        rest: { checks: { create: checksCreate } },
+      }),
+    }));
+    vi.doMock("@/lib/env", () => ({
+      env: { HYPERLOCALISE_PUBLIC_APP_URL: "https://app.example.com" },
+    }));
+
+    const { createGithubRepositoryAutomationCheckRun } =
+      await import("./github-repository-automation-check-run");
+
+    await expect(
+      createGithubRepositoryAutomationCheckRun({
+        installationId: "987",
+        repositoryFullName: "acme/repo",
+        headSha: "abc123",
+        organizationSlug: "acme",
+        githubRepositoryId: "101",
+        jobId: "job-uuid",
+      }),
+    ).resolves.toBe("123");
+
+    expect(checksCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "Hyperlocalise localization automation",
+        head_sha: "abc123",
+        status: "in_progress",
+        external_id: "job-uuid",
+      }),
+    );
   });
 });

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-check-run.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-check-run.ts
@@ -1,7 +1,13 @@
 import { getInstallationOctokit } from "@/lib/agents/github/app";
 import { env } from "@/lib/env";
 
-const CHECK_RUN_NAME = "Hyperlocalise localization validation";
+const CHECK_RUN_NAME = "Hyperlocalise localization automation";
+
+export type GithubRepositoryAutomationCheckConclusion =
+  | "success"
+  | "failure"
+  | "neutral"
+  | "skipped";
 
 function parseRepositoryFullName(fullName: string): { owner: string; repo: string } {
   const [owner, repo] = fullName.split("/");
@@ -36,6 +42,7 @@ export async function createGithubRepositoryAutomationCheckRun(input: {
   jobId: string;
   organizationSlug: string | null;
   githubRepositoryId: string;
+  summary?: string;
 }): Promise<string | null> {
   const octokit = await getInstallationOctokit(input.installationId);
   const { owner, repo } = parseRepositoryFullName(input.repositoryFullName);
@@ -46,14 +53,17 @@ export async function createGithubRepositoryAutomationCheckRun(input: {
     name: CHECK_RUN_NAME,
     head_sha: input.headSha,
     status: "in_progress",
+    external_id: input.jobId,
     details_url: buildGithubRepositoryAutomationJobDetailsUrl({
       organizationSlug: input.organizationSlug,
       githubRepositoryId: input.githubRepositoryId,
       jobId: input.jobId,
     }),
     output: {
-      title: "Validating localization commits",
-      summary: "Running per-commit hl check and repository localization review.",
+      title: CHECK_RUN_NAME,
+      summary:
+        input.summary ??
+        "Running Hyperlocalise repository automation for source upload, translation pull, and localization validation.",
     },
   });
 
@@ -64,7 +74,7 @@ export async function completeGithubRepositoryAutomationCheckRun(input: {
   installationId: string;
   repositoryFullName: string;
   checkRunId: string;
-  conclusion: "success" | "failure" | "neutral";
+  conclusion: GithubRepositoryAutomationCheckConclusion;
   summary: string;
   jobId: string;
   organizationSlug: string | null;

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-dispatcher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-dispatcher.test.ts
@@ -197,6 +197,7 @@ describe("github repository automation dispatch", () => {
       pullTranslations: true,
       validation: false,
       validationBlockOnFailure: true,
+      statusCheck: { enabled: false, mode: "blocking" },
     });
   });
 

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-dispatcher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-dispatcher.test.ts
@@ -235,11 +235,13 @@ describe("github repository automation dispatch", () => {
       githubRepositoryId: repository.githubRepositoryId,
       githubInstallationId: "54321",
       triggerMode: "scheduled" as const,
+      statusCheck: { enabled: false, mode: "blocking" as const },
       workflows: {
         pushSource: false,
         pullTranslations: false,
         validation: true,
         validationBlockOnFailure: true,
+        statusCheck: { enabled: false, mode: "blocking" as const },
       },
     };
 

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-dispatcher.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-dispatcher.ts
@@ -108,7 +108,10 @@ export async function dispatchGithubRepositoryAutomationForPush(
     triggerBranch: input.branch,
     commitBefore: input.commitBefore,
     commitAfter: input.commitAfter,
-    workflows: dispatchPayload.workflows,
+    workflows: {
+      ...dispatchPayload.workflows,
+      statusCheck: dispatchPayload.statusCheck,
+    },
     githubDeliveryId: input.deliveryId,
   });
 
@@ -205,7 +208,10 @@ export async function dispatchGithubRepositoryAutomationForSchedule(
     githubRepositoryId: input.githubRepositoryId,
     configVersion: input.dispatchPayload.configVersion,
     triggerMode: "scheduled",
-    workflows: input.dispatchPayload.workflows,
+    workflows: {
+      ...input.dispatchPayload.workflows,
+      statusCheck: input.dispatchPayload.statusCheck,
+    },
     scheduledRunAt: input.scheduledRunAt,
   });
 

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-jobs.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-jobs.ts
@@ -53,6 +53,12 @@ function normalizeJobWorkflows(
     pullTranslations: workflows.pullTranslations,
     validation: workflows.validation,
     validationBlockOnFailure: workflows.validationBlockOnFailure ?? true,
+    statusCheck: {
+      enabled: workflows.statusCheck?.enabled ?? workflows.validation,
+      mode:
+        workflows.statusCheck?.mode ??
+        ((workflows.validationBlockOnFailure ?? true) ? "blocking" : "advisory"),
+    },
   };
 }
 

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-settings-store.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-settings-store.ts
@@ -42,6 +42,13 @@ function parseStoredSettings(
     stored.trigger = merged.trigger;
   }
 
+  if (
+    merged.statusCheck.enabled !== defaults.statusCheck.enabled ||
+    merged.statusCheck.mode !== defaults.statusCheck.mode
+  ) {
+    stored.statusCheck = merged.statusCheck;
+  }
+
   return stored;
 }
 

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-settings.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-settings.test.ts
@@ -20,6 +20,7 @@ describe("github repository automation settings", () => {
         validation: { enabled: false, blockOnFailure: true },
       },
       trigger: null,
+      statusCheck: { enabled: false, mode: "blocking" },
     });
   });
 
@@ -32,6 +33,7 @@ describe("github repository automation settings", () => {
           validation: { enabled: false, blockOnFailure: true },
         },
         trigger: null,
+        statusCheck: { enabled: false, mode: "blocking" },
       }),
     ).toBe("automation_trigger_required");
   });
@@ -45,6 +47,7 @@ describe("github repository automation settings", () => {
           validation: { enabled: false, blockOnFailure: true },
         },
         trigger: { mode: "push", branches: [] },
+        statusCheck: { enabled: false, mode: "blocking" },
       }),
     ).toBe("push_trigger_requires_branches");
   });
@@ -88,38 +91,43 @@ describe("github repository automation settings", () => {
       githubRepositoryId: "101",
       githubInstallationId: "987654",
       triggerMode: "push",
+      statusCheck: { enabled: false, mode: "blocking" },
       workflows: {
         pushSource: true,
         pullTranslations: true,
         validation: false,
         validationBlockOnFailure: true,
+        statusCheck: { enabled: false, mode: "blocking" },
       },
       pushBranch: "release/2.0",
     });
   });
 
-  it("includes validationBlockOnFailure when validation is enabled", () => {
+  it("includes validation and status check behavior when enabled", () => {
     const settings = mergeGithubRepositoryAutomationSettings(
       DEFAULT_GITHUB_REPOSITORY_AUTOMATION_SETTINGS,
       {
         workflows: {
           validation: { enabled: true, blockOnFailure: false },
         },
+        statusCheck: { enabled: true, mode: "advisory" },
         trigger: { mode: "push", branches: ["main"] },
       },
     );
 
-    expect(
-      buildGithubRepoAutomationDispatchPayload({
-        configVersion: 1,
-        githubInstallationRepositoryId: "repo-row-id",
-        organizationId: "org-id",
-        githubRepositoryId: "101",
-        githubInstallationId: "987654",
-        settings,
-        pushBranch: "main",
-      })?.workflows.validationBlockOnFailure,
-    ).toBe(false);
+    const payload = buildGithubRepoAutomationDispatchPayload({
+      configVersion: 1,
+      githubInstallationRepositoryId: "repo-row-id",
+      organizationId: "org-id",
+      githubRepositoryId: "101",
+      githubInstallationId: "987654",
+      settings,
+      pushBranch: "main",
+    });
+
+    expect(payload?.workflows.validationBlockOnFailure).toBe(false);
+    expect(payload?.statusCheck).toEqual({ enabled: true, mode: "advisory" });
+    expect(payload?.workflows.statusCheck).toEqual({ enabled: true, mode: "advisory" });
   });
 
   it("computes the next scheduled run in the future", () => {

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-settings.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-settings.ts
@@ -36,6 +36,13 @@ export const githubRepoAutomationValidationWorkflowSchema = z
   })
   .default({ enabled: false, blockOnFailure: true });
 
+export const githubRepoAutomationStatusCheckSchema = z
+  .object({
+    enabled: z.boolean().default(false),
+    mode: z.enum(["advisory", "blocking"]).default("blocking"),
+  })
+  .default({ enabled: false, mode: "blocking" });
+
 export const githubRepoAutomationWorkflowsSchema = z.object({
   pushSource: z
     .object({
@@ -54,6 +61,7 @@ export const githubRepositoryAutomationSettingsSchema = z.object({
     validation: { enabled: false, blockOnFailure: true },
   }),
   trigger: githubRepoAutomationTriggerSchema.nullable().default(null),
+  statusCheck: githubRepoAutomationStatusCheckSchema,
 });
 
 export type GithubRepositoryAutomationSettings = z.infer<
@@ -66,6 +74,7 @@ export type GithubRepositoryAutomationSettingsPartial = {
     validation?: { enabled?: boolean; blockOnFailure?: boolean };
   };
   trigger?: z.infer<typeof githubRepoAutomationTriggerSchema> | null;
+  statusCheck?: { enabled?: boolean; mode?: "advisory" | "blocking" };
 };
 
 export const DEFAULT_GITHUB_REPOSITORY_AUTOMATION_SETTINGS: GithubRepositoryAutomationSettings =
@@ -90,6 +99,12 @@ const githubRepositoryAutomationSettingsPartialSchema = z.object({
     })
     .optional(),
   trigger: githubRepoAutomationTriggerSchema.nullable().optional(),
+  statusCheck: z
+    .object({
+      enabled: z.boolean().optional(),
+      mode: z.enum(["advisory", "blocking"]).optional(),
+    })
+    .optional(),
 });
 
 export function parseGithubRepositoryAutomationSettingsPartial(
@@ -136,6 +151,10 @@ export function mergeGithubRepositoryAutomationSettings(
       },
     },
     trigger,
+    statusCheck: {
+      enabled: override.statusCheck?.enabled ?? base.statusCheck.enabled,
+      mode: override.statusCheck?.mode ?? base.statusCheck.mode,
+    },
   });
 }
 
@@ -381,11 +400,19 @@ export type GithubRepoAutomationDispatchPayload = {
   githubRepositoryId: string;
   githubInstallationId: string;
   triggerMode: "scheduled" | "push";
+  statusCheck: {
+    enabled: boolean;
+    mode: "advisory" | "blocking";
+  };
   workflows: {
     pushSource: boolean;
     pullTranslations: boolean;
     validation: boolean;
     validationBlockOnFailure: boolean;
+    statusCheck?: {
+      enabled: boolean;
+      mode: "advisory" | "blocking";
+    };
   };
   pushBranch?: string;
 };
@@ -423,11 +450,13 @@ export function buildGithubRepoAutomationDispatchPayload(input: {
     githubRepositoryId: input.githubRepositoryId,
     githubInstallationId: input.githubInstallationId,
     triggerMode: input.settings.trigger.mode,
+    statusCheck: input.settings.statusCheck,
     workflows: {
       pushSource: input.settings.workflows.pushSource.enabled,
       pullTranslations: input.settings.workflows.pullTranslations.enabled,
       validation: input.settings.workflows.validation.enabled,
       validationBlockOnFailure: input.settings.workflows.validation.blockOnFailure,
+      statusCheck: input.settings.statusCheck,
     },
     pushBranch: input.pushBranch,
   };

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-validation.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-validation.ts
@@ -132,9 +132,10 @@ export async function runGithubRepositoryAutomationValidation(input: {
 
   let sandboxId: string | null = null;
   let checkRunId: string | null = job.githubCheckRunId;
+  const shouldPublishCheckRun = job.workflows.statusCheck?.enabled ?? false;
 
   try {
-    if (!checkRunId) {
+    if (shouldPublishCheckRun && !checkRunId) {
       checkRunId = await createGithubRepositoryAutomationCheckRun({
         installationId: job.githubInstallationId,
         repositoryFullName: job.repositoryFullName,

--- a/apps/hyperlocalise-web/src/lib/database/schema.ts
+++ b/apps/hyperlocalise-web/src/lib/database/schema.ts
@@ -1390,6 +1390,10 @@ export const githubRepositoryAutomationJobs = pgTable(
         pullTranslations: boolean;
         validation: boolean;
         validationBlockOnFailure?: boolean;
+        statusCheck?: {
+          enabled?: boolean;
+          mode?: "advisory" | "blocking";
+        };
       }>()
       .notNull()
       .default(sql`'{"pushSource":false,"pullTranslations":false,"validation":false}'::jsonb`),

--- a/apps/hyperlocalise-web/src/workflows/github-repository-automation.test.ts
+++ b/apps/hyperlocalise-web/src/workflows/github-repository-automation.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { resolveGithubAutomationCheckConclusion } from "./github-repository-automation";
+
+describe("github repository automation workflow check conclusions", () => {
+  const baseJob: {
+    workflows: {
+      pushSource: boolean;
+      pullTranslations: boolean;
+      validation: boolean;
+      validationBlockOnFailure: boolean;
+      statusCheck: { enabled: boolean; mode: "advisory" | "blocking" };
+    };
+  } = {
+    workflows: {
+      pushSource: true,
+      pullTranslations: false,
+      validation: true,
+      validationBlockOnFailure: true,
+      statusCheck: { enabled: true, mode: "blocking" as const },
+    },
+  };
+
+  it("fails blocking checks when automation fails", () => {
+    expect(
+      resolveGithubAutomationCheckConclusion({ job: baseJob as never, status: "failed" }),
+    ).toBe("failure");
+  });
+
+  it("keeps advisory checks neutral when automation fails", () => {
+    expect(
+      resolveGithubAutomationCheckConclusion({
+        job: {
+          ...baseJob,
+          workflows: {
+            ...baseJob.workflows,
+            statusCheck: { enabled: true, mode: "advisory" },
+          },
+        } as never,
+        status: "failed",
+      }),
+    ).toBe("neutral");
+  });
+
+  it("resolves skipped automation explicitly", () => {
+    expect(
+      resolveGithubAutomationCheckConclusion({ job: baseJob as never, status: "skipped" }),
+    ).toBe("skipped");
+  });
+});

--- a/apps/hyperlocalise-web/src/workflows/github-repository-automation.ts
+++ b/apps/hyperlocalise-web/src/workflows/github-repository-automation.ts
@@ -257,19 +257,25 @@ async function runAutomationJobStep(input: { jobId: string; workflowRunId: strin
         workflowRunId: input.workflowRunId,
         commitRange,
       });
+    } else {
+      await completeGithubAutomationCheckRunForJob({
+        jobId: job.id,
+        checkRunId,
+        terminalStatus: "succeeded",
+      });
     }
-
-    await completeGithubAutomationCheckRunForJob({ jobId: job.id, checkRunId });
 
     return results;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    await completeGithubAutomationCheckRunForJob({
-      jobId: job.id,
-      checkRunId,
-      terminalStatus: "failed",
-      lastError: message,
-    }).catch(() => undefined);
+    if (!job.workflows.validation) {
+      await completeGithubAutomationCheckRunForJob({
+        jobId: job.id,
+        checkRunId,
+        terminalStatus: "failed",
+        lastError: message,
+      }).catch(() => undefined);
+    }
     throw error;
   }
 }

--- a/apps/hyperlocalise-web/src/workflows/github-repository-automation.ts
+++ b/apps/hyperlocalise-web/src/workflows/github-repository-automation.ts
@@ -5,6 +5,7 @@ import {
   claimGithubRepositoryAutomationJobForRunning,
   getGithubRepositoryAutomationJobById,
   updateGithubRepositoryAutomationJobStatus,
+  type GithubRepositoryAutomationJobWithRepository,
 } from "@/lib/agents/github/github-repository-automation-jobs";
 import {
   resolveGithubRepositoryAutomationCommitRange,
@@ -12,6 +13,11 @@ import {
 } from "@/lib/agents/github/github-repository-automation-commit-range";
 import { isErr } from "@/lib/primitives/result/results";
 
+import {
+  completeGithubRepositoryAutomationCheckRun,
+  createGithubRepositoryAutomationCheckRun,
+  type GithubRepositoryAutomationCheckConclusion,
+} from "@/lib/agents/github/github-repository-automation-check-run";
 import { runGithubRepositoryAutomationPushSource } from "@/lib/agents/github/github-repository-automation-push-source";
 import { runGithubRepositoryAutomationValidation } from "@/lib/agents/github/github-repository-automation-validation";
 
@@ -45,6 +51,113 @@ async function claimJobStep(input: { jobId: string; workflowRunId: string }) {
   return claimed;
 }
 
+export function shouldPublishGithubAutomationCheckRun(
+  job: GithubRepositoryAutomationJobWithRepository,
+): boolean {
+  return job.workflows.statusCheck?.enabled ?? false;
+}
+
+export function resolveGithubAutomationCheckConclusion(input: {
+  job: GithubRepositoryAutomationJobWithRepository;
+  status: "succeeded" | "failed" | "skipped";
+}): GithubRepositoryAutomationCheckConclusion {
+  if (input.status === "succeeded") {
+    return "success";
+  }
+
+  if (input.status === "skipped") {
+    return "skipped";
+  }
+
+  return input.job.workflows.statusCheck?.mode === "advisory" ? "neutral" : "failure";
+}
+
+function buildGithubAutomationCheckSummary(input: {
+  status: "succeeded" | "failed" | "skipped";
+  skipReason?: string | null;
+  lastError?: string | null;
+  resultSummary?: Record<string, unknown> | null;
+}): string {
+  if (input.status === "skipped") {
+    return `Hyperlocalise automation was skipped: ${input.skipReason ?? "skipped"}.`;
+  }
+
+  if (input.status === "failed") {
+    return `Hyperlocalise automation failed: ${input.lastError ?? "automation_failed"}.`;
+  }
+
+  const resultSummary = input.resultSummary
+    ? ` Result summary: ${JSON.stringify(input.resultSummary)}.`
+    : "";
+  return `Hyperlocalise automation completed successfully.${resultSummary}`;
+}
+
+async function ensureGithubAutomationCheckRun(input: {
+  job: GithubRepositoryAutomationJobWithRepository;
+  headSha: string;
+}): Promise<string | null> {
+  if (!shouldPublishGithubAutomationCheckRun(input.job)) {
+    return null;
+  }
+
+  if (input.job.githubCheckRunId) {
+    return input.job.githubCheckRunId;
+  }
+
+  const checkRunId = await createGithubRepositoryAutomationCheckRun({
+    installationId: input.job.githubInstallationId,
+    repositoryFullName: input.job.repositoryFullName,
+    headSha: input.headSha,
+    organizationSlug: input.job.organizationSlug,
+    githubRepositoryId: input.job.githubRepositoryId,
+    jobId: input.job.id,
+  });
+
+  if (checkRunId) {
+    await updateGithubRepositoryAutomationJobStatus({
+      jobId: input.job.id,
+      status: "running",
+      githubCheckRunId: checkRunId,
+    });
+  }
+
+  return checkRunId;
+}
+
+async function completeGithubAutomationCheckRunForJob(input: {
+  jobId: string;
+  checkRunId: string | null;
+}): Promise<void> {
+  if (!input.checkRunId) {
+    return;
+  }
+
+  const job = await getGithubRepositoryAutomationJobById(input.jobId);
+  if (!job || !shouldPublishGithubAutomationCheckRun(job)) {
+    return;
+  }
+
+  if (job.status !== "succeeded" && job.status !== "failed" && job.status !== "skipped") {
+    return;
+  }
+
+  await completeGithubRepositoryAutomationCheckRun({
+    installationId: job.githubInstallationId,
+    repositoryFullName: job.repositoryFullName,
+    checkRunId: input.checkRunId,
+    conclusion: resolveGithubAutomationCheckConclusion({ job, status: job.status }),
+    summary: buildGithubAutomationCheckSummary({
+      status: job.status,
+      skipReason: job.skipReason,
+      lastError: job.lastError,
+      resultSummary: job.resultSummary,
+    }),
+    organizationSlug: job.organizationSlug,
+    githubRepositoryId: job.githubRepositoryId,
+    jobId: job.id,
+  });
+}
+
 async function runAutomationJobStep(input: { jobId: string; workflowRunId: string }) {
   "use step";
 
@@ -54,26 +167,36 @@ async function runAutomationJobStep(input: { jobId: string; workflowRunId: strin
   }
 
   if (!job.workflows.pushSource && !job.workflows.validation && !job.workflows.pullTranslations) {
+    const checkRunId = job.commitAfter
+      ? await ensureGithubAutomationCheckRun({ job, headSha: job.commitAfter })
+      : null;
     await updateGithubRepositoryAutomationJobStatus({
       jobId: job.id,
       status: "skipped",
       skipReason: "no_runnable_workflows",
     });
+    await completeGithubAutomationCheckRunForJob({ jobId: job.id, checkRunId });
     return { skipped: true, reason: "no_runnable_workflows" };
   }
 
   if (!job.workflows.pushSource && !job.workflows.validation) {
+    const checkRunId = job.commitAfter
+      ? await ensureGithubAutomationCheckRun({ job, headSha: job.commitAfter })
+      : null;
     await updateGithubRepositoryAutomationJobStatus({
       jobId: job.id,
       status: "skipped",
       skipReason: "pull_translations_not_implemented",
     });
+    await completeGithubAutomationCheckRunForJob({ jobId: job.id, checkRunId });
     return { skipped: true, reason: "pull_translations_not_implemented" };
   }
 
   const results: Record<string, unknown> = {};
   const needsCommitRange = job.workflows.pushSource || job.workflows.validation;
   let commitRange: GithubRepositoryAutomationCommitRange | undefined;
+
+  let checkRunId: string | null = job.githubCheckRunId;
 
   if (needsCommitRange) {
     if (job.commitAfter) {
@@ -95,34 +218,48 @@ async function runAutomationJobStep(input: { jobId: string; workflowRunId: strin
         commitAfter: commitRange.commitAfter,
       };
     }
-  }
 
-  if (job.workflows.pushSource) {
-    const pushSourceResult = await runGithubRepositoryAutomationPushSource({
-      job,
-      workflowRunId: input.workflowRunId,
-      commitRange,
-    });
-
-    if (isErr(pushSourceResult)) {
-      results.pushSource = pushSourceResult.error;
-      if (pushSourceResult.error.code === "infrastructure") {
-        throw new Error(pushSourceResult.error.message);
-      }
-    } else {
-      results.pushSource = pushSourceResult.value;
+    checkRunId = await ensureGithubAutomationCheckRun({ job, headSha: commitRange.commitAfter });
+    if (checkRunId) {
+      job = { ...job, githubCheckRunId: checkRunId };
     }
   }
 
-  if (job.workflows.validation) {
-    results.validation = await runGithubRepositoryAutomationValidation({
-      job,
-      workflowRunId: input.workflowRunId,
-      commitRange,
-    });
-  }
+  try {
+    if (job.workflows.pushSource) {
+      const pushSourceResult = await runGithubRepositoryAutomationPushSource({
+        job,
+        workflowRunId: input.workflowRunId,
+        commitRange,
+      });
 
-  return results;
+      if (isErr(pushSourceResult)) {
+        results.pushSource = pushSourceResult.error;
+        if (pushSourceResult.error.code === "infrastructure") {
+          throw new Error(pushSourceResult.error.message);
+        }
+      } else {
+        results.pushSource = pushSourceResult.value;
+      }
+    }
+
+    if (job.workflows.validation) {
+      results.validation = await runGithubRepositoryAutomationValidation({
+        job,
+        workflowRunId: input.workflowRunId,
+        commitRange,
+      });
+    }
+
+    await completeGithubAutomationCheckRunForJob({ jobId: job.id, checkRunId });
+
+    return results;
+  } catch (error) {
+    await completeGithubAutomationCheckRunForJob({ jobId: job.id, checkRunId }).catch(
+      () => undefined,
+    );
+    throw error;
+  }
 }
 
 export async function githubRepositoryAutomationWorkflow(


### PR DESCRIPTION
### Motivation

- Expose repository automation and `hl check` results as a named GitHub check context so teams can opt into advisory or blocking behavior for branch protection and get a visible per‑commit automation link. 

### Description

- Add `statusCheck` to repository automation settings schema with `enabled` and `mode` (`advisory` | `blocking`) and persist it with settings and dispatch payloads.  
- Extend the automation job schema and workflows payload to carry `statusCheck` and normalize it into job records.  
- Implement idempotent GitHub check run helpers (`createGithubRepositoryAutomationCheckRun` / `completeGithubRepositoryAutomationCheckRun`) that publish an `in_progress` check and later resolve to `success`/`failure`/`neutral`/`skipped` and attach the automation run details URL.  
- Wire check-run lifecycle into the automation workflow: ensure a pending check is created before work runs (or reused across retries), complete the check when the job finishes (including skipped paths), and map advisory mode to `neutral` on failures while blocking mode maps to `failure`.  
- Update API schemas, DB schema typing, job dispatch, normalization, and unit tests to cover settings, dispatch payloads, check-run creation metadata, and conclusion mapping.

### Testing

- Ran targeted unit tests: `vp test src/lib/agents/github/github-repository-automation-settings.test.ts src/lib/agents/github/github-repository-automation-check-run.test.ts src/workflows/github-repository-automation.test.ts`, and they passed.  
- Ran repo checks and type/lint: `vp check --fix` (format + lint + types) completed with no errors after fixes.  
- Attempted full test run `vp test` but the environment lacked a running Postgres/Docker instance, causing many DB‑dependent suites to fail with `ECONNREFUSED` (environment issue, not code regressions).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bcc1ff928832cb56a894d9e44ae4a)