### PR TITLE
refactor(web): extract agent runtime contracts (HL-449)

### DIFF
--- a/apps/hyperlocalise-web/src/lib/agent-contracts/github-text-patterns.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-contracts/github-text-patterns.ts
@@ -1,0 +1,103 @@
+export type GitHubPullRequestReference = {
+  repositoryFullName: string;
+  pullRequestNumber: number;
+  sourceUrl: string;
+};
+
+export const githubPullRequestUrlPatternSource = String.raw`https?:\/\/(?:www\.)?github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)\/pull\/(\d+)(?=[/?#\s>|)\].,;:!?]|$)`;
+
+const githubPullRequestUrlPattern = new RegExp(githubPullRequestUrlPatternSource, "gi");
+const githubRepositoryUrlPattern =
+  /https?:\/\/(?:www\.)?github\.com\/([A-Za-z0-9-]+)\/([A-Za-z0-9_.-]+)(?=[/?#\s>|)\].,;:!?]|$)/gi;
+const githubRepositoryFullNamePattern =
+  /(?:^|[\s(<])([A-Za-z0-9-]+\/[A-Za-z0-9_.-]+)(?=[\s>|)\].,;:!?]|$)/gi;
+
+export function extractGitHubPullRequestReferences(text: string): GitHubPullRequestReference[] {
+  const references = new Map<string, GitHubPullRequestReference>();
+
+  for (const match of text.matchAll(githubPullRequestUrlPattern)) {
+    const owner = match[1];
+    const repo = match[2];
+    const pullRequestNumber = Number.parseInt(match[3] ?? "", 10);
+    if (!owner || !repo || !Number.isSafeInteger(pullRequestNumber)) {
+      continue;
+    }
+
+    const repositoryFullName = `${owner}/${repo}`;
+    references.set(`${repositoryFullName.toLowerCase()}#${pullRequestNumber}`, {
+      repositoryFullName,
+      pullRequestNumber,
+      sourceUrl: match[0],
+    });
+  }
+
+  return [...references.values()];
+}
+
+export function extractGitHubPullRequestNumber(text: string): "ambiguous" | number | null {
+  const numbers = new Set<number>();
+
+  for (const pattern of [/\b(?:pr|pull request)\s*#?(\d+)\b/gi, /\bgithub\s+#?(\d+)\b/gi]) {
+    for (const match of text.matchAll(pattern)) {
+      const pullRequestNumber = Number.parseInt(match[1] ?? "", 10);
+      if (Number.isSafeInteger(pullRequestNumber)) {
+        numbers.add(pullRequestNumber);
+      }
+    }
+  }
+
+  if (numbers.size > 1) {
+    return "ambiguous";
+  }
+
+  return numbers.values().next().value ?? null;
+}
+
+export function extractGitHubRepositoryFullNameReferences(text: string): string[] {
+  const references = new Map<string, string>();
+
+  for (const match of text.matchAll(githubRepositoryUrlPattern)) {
+    const owner = match[1];
+    const repo = match[2];
+    if (!owner || !repo) {
+      continue;
+    }
+
+    const repositoryFullName = normalizeRepositoryFullName(
+      trimTrailingRepositoryReferencePunctuation(`${owner}/${repo}`),
+    );
+    if (repositoryFullName) {
+      references.set(repositoryFullName.toLowerCase(), repositoryFullName);
+    }
+  }
+
+  for (const match of text.matchAll(githubRepositoryFullNamePattern)) {
+    const repositoryFullName = normalizeRepositoryFullName(
+      trimTrailingRepositoryReferencePunctuation(match[1] ?? ""),
+    );
+    if (repositoryFullName) {
+      references.set(repositoryFullName.toLowerCase(), repositoryFullName);
+    }
+  }
+
+  return [...references.values()];
+}
+
+function normalizeRepositoryFullName(value: string): string | null {
+  const trimmed = value.trim();
+  const parts = trimmed.split("/");
+  if (parts.length !== 2) {
+    return null;
+  }
+
+  const [owner, repo] = parts;
+  if (!owner || !repo || /\s/.test(owner) || /\s/.test(repo)) {
+    return null;
+  }
+
+  return `${owner}/${repo}`;
+}
+
+function trimTrailingRepositoryReferencePunctuation(value: string) {
+  return value.replace(/[.,;:!?]+$/g, "");
+}

--- a/apps/hyperlocalise-web/src/lib/agent-contracts/repository-task.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-contracts/repository-task.ts
@@ -1,0 +1,190 @@
+import { createHash } from "node:crypto";
+import { z } from "zod";
+
+/**
+ * The mode of operation for a repository agent task.
+ *
+ * - read_only: The agent may inspect, query, and report but must not mutate
+ *              repository state and create external effects.
+ * - approval_required/write: Reserved for dormant write-tool scaffolding; source
+ *              adapters should keep repository-agent tasks read_only for now.
+ */
+export const repositoryAgentWorkModeSchema = z.enum(["read_only", "approval_required", "write"]);
+
+export type RepositoryAgentWorkMode = z.infer<typeof repositoryAgentWorkModeSchema>;
+
+/**
+ * Supported sources that can trigger a repository agent task.
+ *
+ * Kept as a string union so future adapters (e.g. CLI, webhook) can be added
+ * without changing downstream workflow code.
+ */
+export const repositoryAgentTaskSourceSchema = z.enum(["slack", "github", "chat_ui"]);
+
+export type RepositoryAgentTaskSource = z.infer<typeof repositoryAgentTaskSourceSchema>;
+
+/**
+ * The actor who triggered the task, captured from the source adapter.
+ */
+export const repositoryAgentActorSchema = z.object({
+  /** Source-specific user identifier (e.g. Slack user ID, GitHub login). */
+  sourceUserId: z.string(),
+  /** Optional internal Hyperlocalise user ID when the actor is a known member. */
+  userId: z.string().optional(),
+  /** Email address from the source adapter, used for membership lookup. */
+  email: z.string().optional(),
+  /** Human-readable display name from the source. */
+  displayName: z.string().optional(),
+  /** Organization membership role when the actor is a known member. */
+  role: z.enum(["admin", "member"]).optional(),
+});
+
+export type RepositoryAgentActor = z.infer<typeof repositoryAgentActorSchema>;
+
+/**
+ * Resolved GitHub repository context for repository tasks.
+ */
+export const repositoryAgentGitHubContextSchema = z.object({
+  resolved: z.literal(true),
+  /** GitHub App installation identifier. */
+  installationId: z.number(),
+  /** Full repository name (owner/name). */
+  repositoryFullName: z.string(),
+  /** Optional pull request number when the task is PR-scoped. */
+  pullRequestNumber: z.number().optional(),
+  /** Optional commit SHA when the task targets a specific revision. */
+  commitSha: z.string().optional(),
+  /** Optional branch name when the task targets a specific branch. */
+  branch: z.string().optional(),
+  /** Optional comment ID that triggered the task. */
+  commentId: z.number().optional(),
+});
+
+export type RepositoryAgentGitHubContext = z.infer<typeof repositoryAgentGitHubContextSchema>;
+
+/**
+ * Unresolved GitHub context signals that the source adapter could not
+ * determine the repository or PR to work on. The agent should ask a
+ * follow-up question instead of failing.
+ */
+export const unresolvedRepositoryAgentGitHubContextSchema = z.object({
+  resolved: z.literal(false),
+  /** Human-readable reason the context could not be resolved. */
+  reason: z.string(),
+  /** Optional hint the agent can include in its follow-up question. */
+  hint: z.string().optional(),
+});
+
+export type UnresolvedRepositoryAgentGitHubContext = z.infer<
+  typeof unresolvedRepositoryAgentGitHubContextSchema
+>;
+
+/**
+ * Union of resolved and unresolved GitHub context.
+ */
+export const repositoryAgentGitHubContextUnionSchema = z.union([
+  repositoryAgentGitHubContextSchema,
+  unresolvedRepositoryAgentGitHubContextSchema,
+]);
+
+export type RepositoryAgentGitHubContextUnion = z.infer<
+  typeof repositoryAgentGitHubContextUnionSchema
+>;
+
+/**
+ * Durable task contract for repository agent workflows.
+ *
+ * This payload is source-neutral: the same workflow runner can handle tasks
+ * originating from Slack, GitHub, or the chat UI without source-specific
+ * branching. Source adapters are responsible for assembling this shape before
+ * enqueueing.
+ */
+export const repositoryAgentTaskSchema = z.object({
+  /** Stable task identifier. */
+  id: z.string(),
+  /** Where the task originated. */
+  source: repositoryAgentTaskSourceSchema,
+  /** Source-specific thread or conversation identifier. */
+  sourceThreadId: z.string(),
+  /** The user who triggered the task. */
+  actor: repositoryAgentActorSchema,
+  /** Organization that owns the task. */
+  organizationId: z.string(),
+  /** Optional project context; null for workspace-level tasks. */
+  projectId: z.string().nullable(),
+  /** How the agent is allowed to mutate state. */
+  workMode: repositoryAgentWorkModeSchema,
+  /** Natural-language instructions from the user. */
+  instructions: z.string(),
+  /**
+   * Optional GitHub repository context. Present when the task is repo-scoped.
+   * May be unresolved so the agent can ask clarifying questions.
+   */
+  githubContext: repositoryAgentGitHubContextUnionSchema.optional(),
+  /** ISO-8601 creation timestamp. */
+  createdAt: z.string().datetime(),
+  /** Deterministic idempotency key for deduplicating repeated triggers. */
+  idempotencyKey: z.string(),
+});
+
+export type RepositoryAgentTask = z.infer<typeof repositoryAgentTaskSchema>;
+
+/**
+ * Build a deterministic idempotency key for a repository agent task.
+ */
+export function buildRepositoryTaskIdempotencyKey(input: {
+  source: RepositoryAgentTaskSource;
+  sourceThreadId: string;
+  organizationId: string;
+  instructions: string;
+  githubContext?: RepositoryAgentGitHubContext;
+}): string {
+  const parts = [input.source, input.sourceThreadId, input.organizationId, input.instructions];
+
+  if (input.githubContext) {
+    parts.push(
+      String(input.githubContext.installationId),
+      input.githubContext.repositoryFullName,
+      input.githubContext.pullRequestNumber !== undefined
+        ? String(input.githubContext.pullRequestNumber)
+        : "",
+      input.githubContext.commitSha ?? "",
+    );
+  }
+
+  const raw = parts.join("\0");
+  return createHash("sha256").update(raw).digest("hex");
+}
+
+/**
+ * Serialize a repository agent task to a JSON string.
+ */
+export function serializeRepositoryAgentTask(task: RepositoryAgentTask): string {
+  return JSON.stringify(task);
+}
+
+/**
+ * Deserialize and validate a repository agent task from a JSON string.
+ */
+export function deserializeRepositoryAgentTask(json: string): RepositoryAgentTask {
+  const parsed = JSON.parse(json);
+  return repositoryAgentTaskSchema.parse(parsed);
+}
+
+/**
+ * Type guard for unresolved GitHub context.
+ */
+export function isUnresolvedGitHubContext(
+  context: RepositoryAgentGitHubContextUnion | undefined,
+): context is UnresolvedRepositoryAgentGitHubContext {
+  return context !== undefined && "resolved" in context && context.resolved === false;
+}
+
+/**
+ * Type guard for resolved GitHub context.
+ */
+export function isResolvedGitHubContext(
+  context: RepositoryAgentGitHubContextUnion | undefined,
+): context is RepositoryAgentGitHubContext {
+  return context !== undefined && "resolved" in context && context.resolved === true;
+}

--- a/apps/hyperlocalise-web/src/lib/agent-contracts/tool-context.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-contracts/tool-context.ts
@@ -1,0 +1,50 @@
+import type { db } from "@/lib/database";
+import type { OrganizationMembershipRole } from "@/lib/database/types";
+import type {
+  RepositoryAgentActor,
+  RepositoryAgentGitHubContext,
+  RepositoryAgentTaskSource,
+  RepositoryAgentWorkMode,
+} from "@/lib/agent-contracts/repository-task";
+
+export type AgentTodoItem = {
+  id: string;
+  content: string;
+  status: "todo" | "in-progress" | "completed";
+};
+
+export type AgentSessionState = {
+  todos: AgentTodoItem[];
+};
+
+export function ensureAgentSession(ctx: { agentSession?: AgentSessionState }): AgentSessionState {
+  if (!ctx.agentSession) {
+    ctx.agentSession = { todos: [] };
+  }
+  return ctx.agentSession;
+}
+
+/**
+ * Request-scoped context passed to every chat tool.
+ *
+ * Tools use this object to scope database queries and side effects
+ * to the current organization, conversation, and project.
+ */
+export type ToolContext = {
+  conversationId: string;
+  workflowRunId?: string | null;
+  organizationId: string;
+  /** Hyperlocalise user id for team-scoped project and asset access. */
+  localUserId: string;
+  membershipRole: OrganizationMembershipRole;
+  projectId: string | null;
+  db: typeof db;
+  /** Repository agent context (optional, populated for repository workflows). */
+  workMode?: RepositoryAgentWorkMode;
+  repositorySource?: RepositoryAgentTaskSource;
+  actor?: RepositoryAgentActor;
+  sandboxId?: string | null;
+  githubContext?: RepositoryAgentGitHubContext | null;
+  /** Mutable per-run session state (todos, etc.). */
+  agentSession?: AgentSessionState;
+};

--- a/apps/hyperlocalise-web/src/lib/agent-contracts/write-gate.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-contracts/write-gate.ts
@@ -1,0 +1,95 @@
+import { hasCapability } from "@/api/auth/policy";
+import type { OrganizationMembershipRole } from "@/lib/database/types";
+
+import type {
+  RepositoryAgentActor,
+  RepositoryAgentTaskSource,
+  RepositoryAgentWorkMode,
+} from "@/lib/agent-contracts/repository-task";
+
+export type WriteAction = "upload_sources" | "apply_fixes" | "commit_changes" | "push_to_branch";
+
+export type WriteGateResult = { allowed: true } | { allowed: false; reason: string };
+
+function hasAdminCapability(role: OrganizationMembershipRole | null | undefined) {
+  return role ? hasCapability(role, "integrations:write") : false;
+}
+
+function canApproveAgentWrite(role: OrganizationMembershipRole | null | undefined) {
+  return role ? hasCapability(role, "agent_write:approve") : false;
+}
+
+/**
+ * Determine whether a repository write action is allowed for the current task.
+ */
+export function checkRepositoryWriteGate(input: {
+  workMode: RepositoryAgentWorkMode;
+  source: RepositoryAgentTaskSource;
+  actor: RepositoryAgentActor;
+  action: WriteAction;
+}): WriteGateResult {
+  if (input.workMode === "read_only") {
+    return {
+      allowed: false,
+      reason: "This workflow is running in read-only mode. Write actions are not permitted.",
+    };
+  }
+
+  if (input.source === "slack") {
+    return checkSlackWriteGate(input.workMode, input.actor);
+  }
+
+  if (input.source === "github") {
+    return checkGitHubWriteGate(input.workMode, input.actor);
+  }
+
+  return checkVerifiedMemberWriteGate(input.actor);
+}
+
+function checkSlackWriteGate(
+  _workMode: RepositoryAgentWorkMode,
+  actor: RepositoryAgentActor,
+): WriteGateResult {
+  if (actor.role && hasAdminCapability(actor.role)) {
+    return { allowed: true };
+  }
+
+  return {
+    allowed: false,
+    reason:
+      "Slack-triggered write actions require admin privileges. Regular members run in read-only mode.",
+  };
+}
+
+function checkVerifiedMemberWriteGate(actor: RepositoryAgentActor): WriteGateResult {
+  const isMember = actor.role === "admin" || actor.role === "member";
+  if (isMember) {
+    return { allowed: true };
+  }
+
+  return {
+    allowed: false,
+    reason: "Write actions require a verified workspace member.",
+  };
+}
+
+function checkGitHubWriteGate(
+  workMode: RepositoryAgentWorkMode,
+  actor: RepositoryAgentActor,
+): WriteGateResult {
+  const isAdmin = canApproveAgentWrite(actor.role);
+
+  if (workMode === "write") {
+    return { allowed: true };
+  }
+
+  if (isAdmin) {
+    return { allowed: true };
+  }
+
+  return {
+    allowed: false,
+    reason:
+      "Write actions in this workflow require admin privileges. Please contact a workspace admin.",
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/context.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/context.ts
@@ -1,7 +1,7 @@
 import type { HyperlocaliseAgentSurface } from "@/lib/agent-runtime/loops/hyperlocalise-agent";
 import type { HyperlocaliseConversationMode } from "@/lib/agent-runtime/loops/conversation-mode";
 import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
-import type { ToolContext } from "@/lib/tools/types";
+import type { ToolContext } from "@/lib/agent-contracts/tool-context";
 
 /**
  * Request-scoped runtime state shared by the orchestrator and task tool.

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-mode.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-mode.ts
@@ -5,7 +5,7 @@ import {
 import {
   extractGitHubRepositoryFullNameReferences,
   githubPullRequestUrlPatternSource,
-} from "@/lib/agents/repository-context";
+} from "@/lib/agent-contracts/github-text-patterns";
 import { escapeRegExp } from "@/lib/primitives/escapeRegExp/escapeRegExp";
 
 /** Conversation routing modes — maps to focused tool loops, not a single translation default. */

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/hyperlocalise-agent.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/hyperlocalise-agent.ts
@@ -13,7 +13,7 @@ import type { HyperlocaliseAgentRuntimeContext } from "@/lib/agent-runtime/conte
 import { getHyperlocaliseAgentModel } from "./model";
 
 export { getHyperlocaliseAgentModel, hyperlocaliseAgentModelId } from "./model";
-import type { ToolContext } from "@/lib/tools/types";
+import type { ToolContext } from "@/lib/agent-contracts/tool-context";
 
 import { classifyConversationMode } from "./conversation-mode";
 import {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/subagents/build-subagent-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/subagents/build-subagent-tools.ts
@@ -5,7 +5,7 @@ import {
   repositoryWorkspaceToolNames,
 } from "@/lib/agent-runtime/tools/manifest";
 import { buildTools } from "@/lib/agent-runtime/tools/registry";
-import type { ToolContext } from "@/lib/tools/types";
+import type { ToolContext } from "@/lib/agent-contracts/tool-context";
 
 import type { HyperlocaliseSubagentType } from "./types";
 

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/subagents/types.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/subagents/types.ts
@@ -1,5 +1,5 @@
 import type { HyperlocaliseAgentRuntimeContext } from "@/lib/agent-runtime/context";
-import type { ToolContext } from "@/lib/tools/types";
+import type { ToolContext } from "@/lib/agent-contracts/tool-context";
 
 import type { repositorySubagent } from "./repository";
 import type { translationSubagent } from "./translation";

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/audit.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/audit.ts
@@ -1,6 +1,6 @@
 import { schema } from "@/lib/database";
-import type { ToolContext } from "@/lib/tools/types";
-import type { WriteAction } from "@/lib/agents/repository-write-gate";
+import type { ToolContext } from "@/lib/agent-contracts/tool-context";
+import type { WriteAction } from "@/lib/agent-contracts/write-gate";
 
 export async function auditRepositoryMutation(
   ctx: ToolContext,

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/i18n-setup-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/i18n-setup-tools.ts
@@ -3,7 +3,7 @@ import { Sandbox } from "@vercel/sandbox";
 import { z } from "zod";
 
 import { assertRepositoryWriteAllowed } from "@/lib/agent-runtime/tools/policy";
-import type { ToolContext } from "@/lib/tools/types";
+import type { ToolContext } from "@/lib/agent-contracts/tool-context";
 
 type WriteI18nConfigToolOptions = {
   allowUpdate?: boolean;

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/manifest.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/manifest.ts
@@ -1,6 +1,6 @@
 import type { ToolSet } from "ai";
 
-import type { RepositoryAgentTaskSource } from "@/lib/agents/repository-agent-task";
+import type { RepositoryAgentTaskSource } from "@/lib/agent-contracts/repository-task";
 
 export type AgentToolSideEffect = "none" | "workspace_write" | "external_write";
 export type AgentToolDomain = "translation" | "repo" | "tms" | "project" | "session" | "web";

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/policy.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/policy.ts
@@ -1,15 +1,15 @@
 import type { OrganizationMembershipRole } from "@/lib/database/types";
-import {
-  checkRepositoryWriteGate,
-  type WriteAction,
-  type WriteGateResult,
-} from "@/lib/agents/repository-write-gate";
 import type {
   RepositoryAgentActor,
   RepositoryAgentTaskSource,
   RepositoryAgentWorkMode,
-} from "@/lib/agents/repository-agent-task";
-import type { ToolContext } from "@/lib/tools/types";
+} from "@/lib/agent-contracts/repository-task";
+import type { ToolContext } from "@/lib/agent-contracts/tool-context";
+import {
+  checkRepositoryWriteGate,
+  type WriteAction,
+  type WriteGateResult,
+} from "@/lib/agent-contracts/write-gate";
 
 export type ToolPolicyEffect = "allow" | "deny" | "require_approval";
 

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/registry.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/registry.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import { buildTools } from "./registry";
-import type { ToolContext } from "@/lib/tools/types";
+import type { ToolContext } from "@/lib/agent-contracts/tool-context";
 
 function createToolContext(overrides: Partial<ToolContext> = {}): ToolContext {
   return {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/registry.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/registry.ts
@@ -2,8 +2,7 @@ import type { ToolSet } from "ai";
 import type { Bash } from "just-bash";
 
 import { createSandboxRepoBash } from "@/lib/agent-runtime/workspaces/sandbox-repo-bash";
-import { ensureAgentSession } from "@/lib/tools/types";
-import type { ToolContext } from "@/lib/tools/types";
+import { ensureAgentSession, type ToolContext } from "@/lib/agent-contracts/tool-context";
 
 import {
   createDetectRepoConfigTool,

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-write-tools.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-write-tools.test.ts
@@ -15,8 +15,11 @@ const { checkRepositoryWriteGateMock, canPushToGitHubBranchMock } = vi.hoisted((
   canPushToGitHubBranchMock: vi.fn(),
 }));
 
-vi.mock("@/lib/agents/repository-write-gate", () => ({
+vi.mock("@/lib/agent-contracts/write-gate", () => ({
   checkRepositoryWriteGate: checkRepositoryWriteGateMock,
+}));
+
+vi.mock("@/lib/agents/repository-write-gate", () => ({
   canPushToGitHubBranch: canPushToGitHubBranchMock,
 }));
 
@@ -50,7 +53,7 @@ import {
   createUploadSourcesTool,
   getCommittableChangedPaths,
 } from "./repo-write-tools";
-import type { ToolContext } from "@/lib/tools/types";
+import type { ToolContext } from "@/lib/agent-contracts/tool-context";
 
 function createBaseCtx(overrides: Partial<ToolContext> = {}): ToolContext {
   const db = {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-write-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/repo-write-tools.ts
@@ -12,8 +12,9 @@ import {
   normalizeSourcePath,
 } from "@/lib/file-storage/records";
 import { inferSupportedFileTranslationFileFormat } from "@/lib/translation/file-formats";
-import type { ToolContext } from "@/lib/tools/types";
-import { canPushToGitHubBranch, type WriteAction } from "@/lib/agents/repository-write-gate";
+import type { ToolContext } from "@/lib/agent-contracts/tool-context";
+import type { WriteAction } from "@/lib/agent-contracts/write-gate";
+import { canPushToGitHubBranch } from "@/lib/agents/repository-write-gate";
 
 async function logMutation(
   ctx: ToolContext,

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/translation-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/translation-tools.ts
@@ -27,7 +27,7 @@ import {
 import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
 
 import { toolAccessibleJobsWhere, toolCanAccessProject } from "@/lib/tools/tool-access";
-import type { ToolContext } from "@/lib/tools/types";
+import type { ToolContext } from "@/lib/agent-contracts/tool-context";
 
 const jobKinds = ["translation", "research", "review", "sync", "asset_management"] as const;
 type JobKind = (typeof jobKinds)[number];

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/todo.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/todo.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { ensureAgentSession } from "@/lib/tools/types";
+import { ensureAgentSession } from "@/lib/agent-contracts/tool-context";
 
 import { createTodoWriteTool } from "./todo";
 

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/todo.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/workspace/todo.ts
@@ -1,7 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 
-import { ensureAgentSession, type AgentTodoItem } from "@/lib/tools/types";
+import { ensureAgentSession, type AgentTodoItem } from "@/lib/agent-contracts/tool-context";
 
 const todoItemSchema = z.object({
   id: z.string(),

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/workspaces/repository-sandbox.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/workspaces/repository-sandbox.ts
@@ -2,8 +2,7 @@ import {
   createVercelSandboxWorkspace,
   stopWorkspace,
 } from "@/lib/agent-runtime/workspaces/vercel-sandbox-runtime";
-import { getInstallationOctokit } from "@/lib/agents/github/app";
-import type { RepositoryAgentGitHubContext } from "@/lib/agents/repository-agent-task";
+import type { RepositoryAgentGitHubContext } from "@/lib/agent-contracts/repository-task";
 import { createLogger, serializeErrorForLog } from "@/lib/log";
 
 type ResolvedRepositoryGitHubContext = Extract<RepositoryAgentGitHubContext, { resolved: true }>;
@@ -23,6 +22,7 @@ export async function createRepositorySandbox(
     commitSha: githubContext.commitSha ?? null,
   });
   log.info("minting github installation token for repository sandbox");
+  const { getInstallationOctokit } = await import("@/lib/agents/github/app");
   const octokit = await getInstallationOctokit(githubContext.installationId);
   const { token } = (await octokit.auth({ type: "installation" })) as InstallationAuth;
   const revision = githubContext.commitSha ?? githubContext.branch ?? "HEAD";

--- a/apps/hyperlocalise-web/src/lib/agents/repository-agent-task.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/repository-agent-task.ts
@@ -1,200 +1,21 @@
-import { createHash } from "node:crypto";
-import { z } from "zod";
-
-/**
- * The mode of operation for a repository agent task.
- *
- * - read_only: The agent may inspect, query, and report but must not mutate
- *              repository state or create external effects.
- * - approval_required/write: Reserved for dormant write-tool scaffolding; source
- *              adapters should keep repository-agent tasks read_only for now.
- */
-export const repositoryAgentWorkModeSchema = z.enum(["read_only", "approval_required", "write"]);
-
-export type RepositoryAgentWorkMode = z.infer<typeof repositoryAgentWorkModeSchema>;
-
-/**
- * Supported sources that can trigger a repository agent task.
- *
- * Kept as a string union so future adapters (e.g. CLI, webhook) can be added
- * without changing downstream workflow code.
- */
-export const repositoryAgentTaskSourceSchema = z.enum(["slack", "github", "chat_ui"]);
-
-export type RepositoryAgentTaskSource = z.infer<typeof repositoryAgentTaskSourceSchema>;
-
-/**
- * The actor who triggered the task, captured from the source adapter.
- */
-export const repositoryAgentActorSchema = z.object({
-  /** Source-specific user identifier (e.g. Slack user ID, GitHub login). */
-  sourceUserId: z.string(),
-  /** Optional internal Hyperlocalise user ID when the actor is a known member. */
-  userId: z.string().optional(),
-  /** Email address from the source adapter, used for membership lookup. */
-  email: z.string().optional(),
-  /** Human-readable display name from the source. */
-  displayName: z.string().optional(),
-  /** Organization membership role when the actor is a known member. */
-  role: z.enum(["admin", "member"]).optional(),
-});
-
-export type RepositoryAgentActor = z.infer<typeof repositoryAgentActorSchema>;
-
-/**
- * Resolved GitHub repository context for repository tasks.
- */
-export const repositoryAgentGitHubContextSchema = z.object({
-  resolved: z.literal(true),
-  /** GitHub App installation identifier. */
-  installationId: z.number(),
-  /** Full repository name (owner/name). */
-  repositoryFullName: z.string(),
-  /** Optional pull request number when the task is PR-scoped. */
-  pullRequestNumber: z.number().optional(),
-  /** Optional commit SHA when the task targets a specific revision. */
-  commitSha: z.string().optional(),
-  /** Optional branch name when the task targets a specific branch. */
-  branch: z.string().optional(),
-  /** Optional comment ID that triggered the task. */
-  commentId: z.number().optional(),
-});
-
-export type RepositoryAgentGitHubContext = z.infer<typeof repositoryAgentGitHubContextSchema>;
-
-/**
- * Unresolved GitHub context signals that the source adapter could not
- * determine the repository or PR to work on. The agent should ask a
- * follow-up question instead of failing.
- */
-export const unresolvedRepositoryAgentGitHubContextSchema = z.object({
-  resolved: z.literal(false),
-  /** Human-readable reason the context could not be resolved. */
-  reason: z.string(),
-  /** Optional hint the agent can include in its follow-up question. */
-  hint: z.string().optional(),
-});
-
-export type UnresolvedRepositoryAgentGitHubContext = z.infer<
-  typeof unresolvedRepositoryAgentGitHubContextSchema
->;
-
-/**
- * Union of resolved and unresolved GitHub context.
- */
-export const repositoryAgentGitHubContextUnionSchema = z.union([
+export {
+  buildRepositoryTaskIdempotencyKey,
+  deserializeRepositoryAgentTask,
+  isResolvedGitHubContext,
+  isUnresolvedGitHubContext,
+  repositoryAgentActorSchema,
   repositoryAgentGitHubContextSchema,
+  repositoryAgentGitHubContextUnionSchema,
+  repositoryAgentTaskSchema,
+  repositoryAgentTaskSourceSchema,
+  repositoryAgentWorkModeSchema,
+  serializeRepositoryAgentTask,
   unresolvedRepositoryAgentGitHubContextSchema,
-]);
-
-export type RepositoryAgentGitHubContextUnion = z.infer<
-  typeof repositoryAgentGitHubContextUnionSchema
->;
-
-/**
- * Durable task contract for repository agent workflows.
- *
- * This payload is source-neutral: the same workflow runner can handle tasks
- * originating from Slack, GitHub, or the chat UI without source-specific
- * branching. Source adapters are responsible for assembling this shape before
- * enqueueing.
- */
-export const repositoryAgentTaskSchema = z.object({
-  /** Stable task identifier. */
-  id: z.string(),
-  /** Where the task originated. */
-  source: repositoryAgentTaskSourceSchema,
-  /** Source-specific thread or conversation identifier. */
-  sourceThreadId: z.string(),
-  /** The user who triggered the task. */
-  actor: repositoryAgentActorSchema,
-  /** Organization that owns the task. */
-  organizationId: z.string(),
-  /** Optional project context; null for workspace-level tasks. */
-  projectId: z.string().nullable(),
-  /** How the agent is allowed to mutate state. */
-  workMode: repositoryAgentWorkModeSchema,
-  /** Natural-language instructions from the user. */
-  instructions: z.string(),
-  /**
-   * Optional GitHub repository context. Present when the task is repo-scoped.
-   * May be unresolved so the agent can ask clarifying questions.
-   */
-  githubContext: repositoryAgentGitHubContextUnionSchema.optional(),
-  /** ISO-8601 creation timestamp. */
-  createdAt: z.string().datetime(),
-  /** Deterministic idempotency key for deduplicating repeated triggers. */
-  idempotencyKey: z.string(),
-});
-
-export type RepositoryAgentTask = z.infer<typeof repositoryAgentTaskSchema>;
-
-/**
- * Build a deterministic idempotency key for a repository agent task.
- *
- * The key is derived from the stable dimensions of the task so that repeated
- * trigger events (e.g. a Slack user clicking a button twice, or a GitHub
- * webhook redelivery) do not create duplicate workflow runs.
- *
- * @param input - The fields that make a task unique. All fields are required
- *   because omitting any dimension weakens deduplication.
- */
-export function buildRepositoryTaskIdempotencyKey(input: {
-  source: RepositoryAgentTaskSource;
-  sourceThreadId: string;
-  organizationId: string;
-  instructions: string;
-  githubContext?: RepositoryAgentGitHubContext;
-}): string {
-  const parts = [input.source, input.sourceThreadId, input.organizationId, input.instructions];
-
-  if (input.githubContext) {
-    parts.push(
-      String(input.githubContext.installationId),
-      input.githubContext.repositoryFullName,
-      input.githubContext.pullRequestNumber !== undefined
-        ? String(input.githubContext.pullRequestNumber)
-        : "",
-      input.githubContext.commitSha ?? "",
-    );
-  }
-
-  const raw = parts.join("\0");
-  return createHash("sha256").update(raw).digest("hex");
-}
-
-/**
- * Serialize a repository agent task to a JSON string.
- */
-export function serializeRepositoryAgentTask(task: RepositoryAgentTask): string {
-  return JSON.stringify(task);
-}
-
-/**
- * Deserialize and validate a repository agent task from a JSON string.
- *
- * @throws {SyntaxError} when `json` is not valid JSON.
- * @throws {z.ZodError} when the parsed value does not match the schema.
- */
-export function deserializeRepositoryAgentTask(json: string): RepositoryAgentTask {
-  const parsed = JSON.parse(json);
-  return repositoryAgentTaskSchema.parse(parsed);
-}
-
-/**
- * Type guard for unresolved GitHub context.
- */
-export function isUnresolvedGitHubContext(
-  context: RepositoryAgentGitHubContextUnion | undefined,
-): context is UnresolvedRepositoryAgentGitHubContext {
-  return context !== undefined && "resolved" in context && context.resolved === false;
-}
-
-/**
- * Type guard for resolved GitHub context.
- */
-export function isResolvedGitHubContext(
-  context: RepositoryAgentGitHubContextUnion | undefined,
-): context is RepositoryAgentGitHubContext {
-  return context !== undefined && "resolved" in context && context.resolved === true;
-}
+  type RepositoryAgentActor,
+  type RepositoryAgentGitHubContext,
+  type RepositoryAgentGitHubContextUnion,
+  type RepositoryAgentTask,
+  type RepositoryAgentTaskSource,
+  type RepositoryAgentWorkMode,
+  type UnresolvedRepositoryAgentGitHubContext,
+} from "@/lib/agent-contracts/repository-task";

--- a/apps/hyperlocalise-web/src/lib/agents/repository-context.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/repository-context.ts
@@ -5,16 +5,26 @@ import { db, schema } from "@/lib/database";
 
 import { escapeRegExp } from "@/lib/primitives/escapeRegExp/escapeRegExp";
 
-import { getInstallationOctokit } from "./github/app";
+import {
+  extractGitHubPullRequestNumber,
+  extractGitHubPullRequestReferences,
+  extractGitHubRepositoryFullNameReferences,
+  githubPullRequestUrlPatternSource,
+  type GitHubPullRequestReference,
+} from "@/lib/agent-contracts/github-text-patterns";
 import type {
   RepositoryAgentGitHubContext,
   UnresolvedRepositoryAgentGitHubContext,
-} from "./repository-agent-task";
+} from "@/lib/agent-contracts/repository-task";
 
-export type GitHubPullRequestReference = {
-  repositoryFullName: string;
-  pullRequestNumber: number;
-  sourceUrl: string;
+import { getInstallationOctokit } from "./github/app";
+
+export type { GitHubPullRequestReference };
+export {
+  extractGitHubPullRequestNumber,
+  extractGitHubPullRequestReferences,
+  extractGitHubRepositoryFullNameReferences,
+  githubPullRequestUrlPatternSource,
 };
 
 type EnabledGitHubRepository = {
@@ -64,85 +74,6 @@ export type RepositoryGitHubContextDependencies = {
     pullRequestNumber: number;
   }) => Promise<PullRequestDetails | null>;
 };
-
-export const githubPullRequestUrlPatternSource = String.raw`https?:\/\/(?:www\.)?github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)\/pull\/(\d+)(?=[/?#\s>|)\].,;:!?]|$)`;
-
-const githubPullRequestUrlPattern = new RegExp(githubPullRequestUrlPatternSource, "gi");
-const githubRepositoryUrlPattern =
-  /https?:\/\/(?:www\.)?github\.com\/([A-Za-z0-9-]+)\/([A-Za-z0-9_.-]+)(?=[/?#\s>|)\].,;:!?]|$)/gi;
-const githubRepositoryFullNamePattern =
-  /(?:^|[\s(<])([A-Za-z0-9-]+\/[A-Za-z0-9_.-]+)(?=[\s>|)\].,;:!?]|$)/gi;
-
-export function extractGitHubPullRequestReferences(text: string): GitHubPullRequestReference[] {
-  const references = new Map<string, GitHubPullRequestReference>();
-
-  for (const match of text.matchAll(githubPullRequestUrlPattern)) {
-    const owner = match[1];
-    const repo = match[2];
-    const pullRequestNumber = Number.parseInt(match[3] ?? "", 10);
-    if (!owner || !repo || !Number.isSafeInteger(pullRequestNumber)) {
-      continue;
-    }
-
-    const repositoryFullName = `${owner}/${repo}`;
-    references.set(`${repositoryFullName.toLowerCase()}#${pullRequestNumber}`, {
-      repositoryFullName,
-      pullRequestNumber,
-      sourceUrl: match[0],
-    });
-  }
-
-  return [...references.values()];
-}
-
-export function extractGitHubPullRequestNumber(text: string): "ambiguous" | number | null {
-  const numbers = new Set<number>();
-
-  for (const pattern of [/\b(?:pr|pull request)\s*#?(\d+)\b/gi, /\bgithub\s+#?(\d+)\b/gi]) {
-    for (const match of text.matchAll(pattern)) {
-      const pullRequestNumber = Number.parseInt(match[1] ?? "", 10);
-      if (Number.isSafeInteger(pullRequestNumber)) {
-        numbers.add(pullRequestNumber);
-      }
-    }
-  }
-
-  if (numbers.size > 1) {
-    return "ambiguous";
-  }
-
-  return numbers.values().next().value ?? null;
-}
-
-export function extractGitHubRepositoryFullNameReferences(text: string): string[] {
-  const references = new Map<string, string>();
-
-  for (const match of text.matchAll(githubRepositoryUrlPattern)) {
-    const owner = match[1];
-    const repo = match[2];
-    if (!owner || !repo) {
-      continue;
-    }
-
-    const repositoryFullName = normalizeRepositoryFullName(
-      trimTrailingRepositoryReferencePunctuation(`${owner}/${repo}`),
-    );
-    if (repositoryFullName) {
-      references.set(repositoryFullName.toLowerCase(), repositoryFullName);
-    }
-  }
-
-  for (const match of text.matchAll(githubRepositoryFullNamePattern)) {
-    const repositoryFullName = normalizeRepositoryFullName(
-      trimTrailingRepositoryReferencePunctuation(match[1] ?? ""),
-    );
-    if (repositoryFullName) {
-      references.set(repositoryFullName.toLowerCase(), repositoryFullName);
-    }
-  }
-
-  return [...references.values()];
-}
 
 export async function resolveSlackRepositoryGitHubContext(input: {
   organizationId: string;
@@ -597,10 +528,6 @@ function normalizeRepositoryFullName(value: string): string | null {
   }
 
   return `${owner}/${repo}`;
-}
-
-function trimTrailingRepositoryReferencePunctuation(value: string) {
-  return value.replace(/[.,;:!?]+$/g, "");
 }
 
 function getGitHubRawCommitSha(raw: GitHubRawMessage): string | null {

--- a/apps/hyperlocalise-web/src/lib/agents/repository-write-gate.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/repository-write-gate.ts
@@ -2,111 +2,13 @@ import type {
   RepositoryAgentActor,
   RepositoryAgentTaskSource,
   RepositoryAgentWorkMode,
-} from "./repository-agent-task";
-import { hasCapability } from "@/api/auth/policy";
-import type { OrganizationMembershipRole } from "@/lib/database/types";
+} from "@/lib/agent-contracts/repository-task";
 
-export type WriteAction = "upload_sources" | "apply_fixes" | "commit_changes" | "push_to_branch";
-
-export type WriteGateResult = { allowed: true } | { allowed: false; reason: string };
-
-function hasAdminCapability(role: OrganizationMembershipRole | null | undefined) {
-  return role ? hasCapability(role, "integrations:write") : false;
-}
-
-function canApproveAgentWrite(role: OrganizationMembershipRole | null | undefined) {
-  return role ? hasCapability(role, "agent_write:approve") : false;
-}
-
-/**
- * Determine whether a repository write action is allowed for the current task.
- *
- * Rules:
- * - read_only: all writes are denied.
- * - slack: allow write actions for workspace admins; regular members
- *   should be enqueued in read_only mode and are denied if a task is malformed.
- * - write: allow GitHub requests that passed adapter-level permission checks.
- * - approval_required: keep GitHub admin-gated.
- *
- * GitHub-sourced write-mode tasks are assumed to have passed bot-level
- * permission checks (requesterCanRunFix) before enqueuing.
- */
-export function checkRepositoryWriteGate(input: {
-  workMode: RepositoryAgentWorkMode;
-  source: RepositoryAgentTaskSource;
-  actor: RepositoryAgentActor;
-  action: WriteAction;
-}): WriteGateResult {
-  if (input.workMode === "read_only") {
-    return {
-      allowed: false,
-      reason: "This workflow is running in read-only mode. Write actions are not permitted.",
-    };
-  }
-
-  if (input.source === "slack") {
-    return checkSlackWriteGate(input.workMode, input.actor);
-  }
-
-  if (input.source === "github") {
-    return checkGitHubWriteGate(input.workMode, input.actor);
-  }
-
-  // chat_ui: require a verified workspace member role.
-  return checkVerifiedMemberWriteGate(input.actor);
-}
-
-function checkSlackWriteGate(
-  _workMode: RepositoryAgentWorkMode,
-  actor: RepositoryAgentActor,
-): WriteGateResult {
-  if (actor.role && hasAdminCapability(actor.role)) {
-    return { allowed: true };
-  }
-
-  return {
-    allowed: false,
-    reason:
-      "Slack-triggered write actions require admin privileges. Regular members run in read-only mode.",
-  };
-}
-
-function checkVerifiedMemberWriteGate(actor: RepositoryAgentActor): WriteGateResult {
-  const isMember = actor.role === "admin" || actor.role === "member";
-  if (isMember) {
-    return { allowed: true };
-  }
-
-  return {
-    allowed: false,
-    reason: "Write actions require a verified workspace member.",
-  };
-}
-
-function checkGitHubWriteGate(
-  workMode: RepositoryAgentWorkMode,
-  actor: RepositoryAgentActor,
-): WriteGateResult {
-  const isAdmin = canApproveAgentWrite(actor.role);
-
-  if (workMode === "write") {
-    // GitHub write mode is allowed if the requester passed the bot permission
-    // check. We additionally auto-approve for Hyperlocalise admins.
-    return { allowed: true };
-  }
-
-  // approval_required: allow admins; deny other roles until a durable approval
-  // flow exists.
-  if (isAdmin) {
-    return { allowed: true };
-  }
-
-  return {
-    allowed: false,
-    reason:
-      "Write actions in this workflow require admin privileges. Please contact a workspace admin.",
-  };
-}
+export {
+  checkRepositoryWriteGate,
+  type WriteAction,
+  type WriteGateResult,
+} from "@/lib/agent-contracts/write-gate";
 
 /**
  * Check whether the GitHub App installation can push to a repository.
@@ -191,3 +93,6 @@ export async function canPushToGitHubBranch(input: {
     };
   }
 }
+
+// Re-exported for adapters that assemble write-gate inputs from task payloads.
+export type { RepositoryAgentActor, RepositoryAgentTaskSource, RepositoryAgentWorkMode };

--- a/apps/hyperlocalise-web/src/lib/tools/types.ts
+++ b/apps/hyperlocalise-web/src/lib/tools/types.ts
@@ -1,50 +1,6 @@
-import type { db } from "@/lib/database";
-import type { OrganizationMembershipRole } from "@/lib/database/types";
-import type {
-  RepositoryAgentActor,
-  RepositoryAgentGitHubContext,
-  RepositoryAgentTaskSource,
-  RepositoryAgentWorkMode,
-} from "@/lib/agents/repository-agent-task";
-
-export type AgentTodoItem = {
-  id: string;
-  content: string;
-  status: "todo" | "in-progress" | "completed";
-};
-
-export type AgentSessionState = {
-  todos: AgentTodoItem[];
-};
-
-export function ensureAgentSession(ctx: { agentSession?: AgentSessionState }): AgentSessionState {
-  if (!ctx.agentSession) {
-    ctx.agentSession = { todos: [] };
-  }
-  return ctx.agentSession;
-}
-
-/**
- * Request-scoped context passed to every chat tool.
- *
- * Tools use this object to scope database queries and side effects
- * to the current organization, conversation, and project.
- */
-export type ToolContext = {
-  conversationId: string;
-  workflowRunId?: string | null;
-  organizationId: string;
-  /** Hyperlocalise user id for team-scoped project and asset access. */
-  localUserId: string;
-  membershipRole: OrganizationMembershipRole;
-  projectId: string | null;
-  db: typeof db;
-  /** Repository agent context (optional, populated for repository workflows). */
-  workMode?: RepositoryAgentWorkMode;
-  repositorySource?: RepositoryAgentTaskSource;
-  actor?: RepositoryAgentActor;
-  sandboxId?: string | null;
-  githubContext?: RepositoryAgentGitHubContext | null;
-  /** Mutable per-run session state (todos, etc.). */
-  agentSession?: AgentSessionState;
-};
+export {
+  ensureAgentSession,
+  type AgentSessionState,
+  type AgentTodoItem,
+  type ToolContext,
+} from "@/lib/agent-contracts/tool-context";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extracts shared agent/repository runtime types and policy into a new `agent-contracts` layer so `agent-runtime` no longer imports `agents/*` for type contracts, and `tools/types.ts` is reduced to re-exports.

Resolves HL-449.

## Changes

- Added `src/lib/agent-contracts/` with:
  - `repository-task.ts` — task source/work mode/actor/GitHub context schemas and helpers
  - `write-gate.ts` — `WriteAction`, `WriteGateResult`, `checkRepositoryWriteGate`
  - `tool-context.ts` — `ToolContext`, session/todo types, `ensureAgentSession`
  - `github-text-patterns.ts` — PR/repo URL parsing helpers (no adapter deps)
- Updated `agent-runtime` to import contracts instead of `agents/*` / cross-layer `tools/types`
- Slimmed `tools/types.ts` to re-export from `agent-contracts` (app-domain tools unchanged)
- Kept `agents/repository-agent-task.ts` and `agents/repository-write-gate.ts` as thin re-exports; GitHub push checks stay in agents with dynamic Octokit import
- `repository-sandbox` uses dynamic import for GitHub App client (avoids static adapter pull-in)

## Verification

- `CI=true vp test src/lib/agent-runtime src/lib/agent-contracts src/lib/agents/repository-write-gate.test.ts src/lib/agents/repository-context.test.ts` — 143 tests passed
- `CI=true vp check --fix` — clean
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-449](https://linear.app/hyperlocalise/issue/HL-449/extract-agent-runtime-contracts-to-break-lib-boundary-cycles)

<div><a href="https://cursor.com/agents/bc-1b714e81-a366-421b-80d2-114a5352c2bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b714e81-a366-421b-80d2-114a5352c2bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

