### PR TITLE
feat(web): GitHub repository automation settings UI (HL-455)

### DIFF
--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/github-integration-row.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/github-integration-row.tsx
@@ -9,6 +9,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
 import { IntegrationRow } from "./integration-row";
+import { RepositoryAutomationSettingsAction } from "./repository-automation-settings-action";
 import { RepositoryI18nSetupAction } from "./repository-i18n-setup-action";
 import { SimpleBrandIcon } from "./simple-brand-icon";
 import { Badge } from "@/components/ui/badge";
@@ -140,7 +141,7 @@ function useSyncRepositories(organizationSlug: string) {
           queryKey: ["github-installation-repositories", organizationSlug],
         }),
       ]);
-      toast.success("GitHub repositories synced");
+      toast.success("GitHub repository list refreshed");
     },
     onError: (error) => {
       toast.error(error.message);
@@ -412,9 +413,10 @@ export function GitHubIntegrationRow({
               size="sm"
               onClick={() => syncRepositories.mutate()}
               disabled={syncRepositories.isPending}
+              title="Refresh the repository list and metadata from GitHub. This does not push or pull translations."
             >
               <HugeiconsIcon icon={Refresh01Icon} strokeWidth={1.8} className="size-4" />
-              {syncRepositories.isPending ? "Syncing..." : "Sync repositories"}
+              {syncRepositories.isPending ? "Refreshing..." : "Refresh repo list"}
             </Button>
             <Button
               variant="outline"
@@ -464,12 +466,13 @@ export function GitHubIntegrationRow({
               </Button>
             </div>
             <div className="overflow-hidden rounded-lg border border-border bg-card">
-              <div className="grid grid-cols-[48px_minmax(0,1fr)_140px_180px] border-b border-border bg-secondary/60 text-xs font-medium tracking-wide text-secondary-foreground uppercase">
+              <div className="grid grid-cols-[48px_minmax(0,1fr)_120px_140px_140px] border-b border-border bg-secondary/60 text-xs font-medium tracking-wide text-secondary-foreground uppercase">
                 <div className="px-4 py-3">
                   <span className="sr-only">Enabled</span>
                 </div>
                 <div className="px-4 py-3">Repositories</div>
                 <div className="px-4 py-3">Branch</div>
+                <div className="px-4 py-3 text-right">Automation</div>
                 <div className="px-4 py-3 text-right">i18n setup</div>
               </div>
               {isLoadingRepositories ? (
@@ -483,7 +486,7 @@ export function GitHubIntegrationRow({
                     <label
                       key={repository.githubRepositoryId}
                       className={cn(
-                        "grid min-h-12 cursor-pointer grid-cols-[48px_minmax(0,1fr)_140px_180px] items-center border-b border-border text-sm transition-colors last:border-b-0 hover:bg-accent/50",
+                        "grid min-h-12 cursor-pointer grid-cols-[48px_minmax(0,1fr)_120px_140px_140px] items-center border-b border-border text-sm transition-colors last:border-b-0 hover:bg-accent/50",
                         checked && "bg-primary/5",
                       )}
                     >
@@ -525,6 +528,22 @@ export function GitHubIntegrationRow({
                       <div className="flex min-w-0 items-center gap-2 px-4 text-muted-foreground">
                         <HugeiconsIcon icon={GitBranchIcon} strokeWidth={1.8} className="size-4" />
                         <span className="truncate">{repository.defaultBranch ?? "default"}</span>
+                      </div>
+                      <div
+                        className="px-4"
+                        onClick={(event) => event.preventDefault()}
+                        onKeyDown={(event) => event.stopPropagation()}
+                      >
+                        <div className="flex flex-col items-end gap-1">
+                          <RepositoryAutomationSettingsAction
+                            organizationSlug={organizationSlug}
+                            githubRepositoryId={repository.githubRepositoryId}
+                            repositoryFullName={repository.fullName}
+                            enabled={checked}
+                            archived={repository.archived}
+                            userCanManage={userCanManage}
+                          />
+                        </div>
                       </div>
                       <div
                         className="px-4"

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/github-repository-automation-view-model.test.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/github-repository-automation-view-model.test.ts
@@ -83,4 +83,17 @@ describe("github-repository-automation-view-model", () => {
     expect(first.branches).toEqual(["main"]);
     expect(duplicate.error).toMatch(/already listed/i);
   });
+
+  it("rejects invalid weekly day-of-week values", () => {
+    const errors = validateAutomationFormState({
+      ...createAutomationFormStateFromSettings(DEFAULT_GITHUB_REPOSITORY_AUTOMATION_SETTINGS),
+      pushSourceEnabled: true,
+      pushSourceProjectId: "project-1",
+      triggerMode: "scheduled",
+      scheduledCadence: "weekly",
+      scheduledDayOfWeek: 7,
+    });
+
+    expect(errors.scheduledDayOfWeek).toBeTruthy();
+  });
 });

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/github-repository-automation-view-model.test.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/github-repository-automation-view-model.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  addBranchPattern,
+  createAutomationFormStateFromSettings,
+  formStateToAutomationSettings,
+  mapAutomationApiErrorToFieldErrors,
+  validateAutomationFormState,
+} from "./github-repository-automation-view-model";
+import { DEFAULT_GITHUB_REPOSITORY_AUTOMATION_SETTINGS } from "@/lib/agents/github/github-repository-automation-settings";
+
+describe("github-repository-automation-view-model", () => {
+  it("maps stored settings into form state", () => {
+    const form = createAutomationFormStateFromSettings({
+      ...DEFAULT_GITHUB_REPOSITORY_AUTOMATION_SETTINGS,
+      workflows: {
+        pushSource: { enabled: true, projectId: "project-1" },
+        pullTranslations: { enabled: false },
+        validation: { enabled: true, blockOnFailure: false },
+      },
+      trigger: {
+        mode: "push",
+        branches: ["main", "release/*"],
+      },
+      statusCheck: { enabled: true, mode: "advisory" },
+    });
+
+    expect(form).toMatchObject({
+      pushSourceEnabled: true,
+      pushSourceProjectId: "project-1",
+      validationEnabled: true,
+      triggerMode: "push",
+      pushBranches: ["main", "release/*"],
+      statusCheckEnabled: true,
+      statusCheckMode: "advisory",
+    });
+  });
+
+  it("requires a trigger when workflows are enabled", () => {
+    const errors = validateAutomationFormState({
+      ...createAutomationFormStateFromSettings(DEFAULT_GITHUB_REPOSITORY_AUTOMATION_SETTINGS),
+      pushSourceEnabled: true,
+      pushSourceProjectId: "project-1",
+      triggerMode: "none",
+    });
+
+    expect(errors.trigger).toBeTruthy();
+  });
+
+  it("serializes push trigger settings for save", () => {
+    const settings = formStateToAutomationSettings({
+      ...createAutomationFormStateFromSettings(DEFAULT_GITHUB_REPOSITORY_AUTOMATION_SETTINGS),
+      pullTranslationsEnabled: true,
+      pullTranslationsProjectId: "project-2",
+      triggerMode: "push",
+      pushBranches: ["main"],
+      statusCheckEnabled: true,
+      statusCheckMode: "blocking",
+    });
+
+    expect(settings).toMatchObject({
+      workflows: {
+        pullTranslations: { enabled: true, projectId: "project-2" },
+      },
+      trigger: {
+        mode: "push",
+        branches: ["main"],
+      },
+      statusCheck: { enabled: true, mode: "blocking" },
+    });
+  });
+
+  it("maps API validation codes to field errors", () => {
+    expect(mapAutomationApiErrorToFieldErrors("push_trigger_requires_branches")).toEqual({
+      pushBranches: expect.stringContaining("branch pattern"),
+    });
+  });
+
+  it("deduplicates branch patterns and enforces limits", () => {
+    const first = addBranchPattern([], "main");
+    const duplicate = addBranchPattern(first.branches, "main");
+
+    expect(first.branches).toEqual(["main"]);
+    expect(duplicate.error).toMatch(/already listed/i);
+  });
+});

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/github-repository-automation-view-model.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/github-repository-automation-view-model.ts
@@ -223,7 +223,10 @@ export function validateAutomationFormState(
   }
 
   if (form.triggerMode === "scheduled") {
-    if (form.scheduledCadence === "weekly" && form.scheduledDayOfWeek === undefined) {
+    if (
+      form.scheduledCadence === "weekly" &&
+      (form.scheduledDayOfWeek < 0 || form.scheduledDayOfWeek > 6)
+    ) {
       errors.scheduledDayOfWeek =
         AUTOMATION_API_ERROR_MESSAGES.weekly_schedule_requires_day_of_week;
     }

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/github-repository-automation-view-model.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/github-repository-automation-view-model.ts
@@ -1,0 +1,321 @@
+import {
+  DEFAULT_GITHUB_REPOSITORY_AUTOMATION_SETTINGS,
+  type GithubRepositoryAutomationSettings,
+  type GithubRepositoryAutomationSettingsPartial,
+  hasEnabledGithubRepoAutomationWorkflow,
+  validateGithubRepositoryAutomationSettings,
+} from "@/lib/agents/github/github-repository-automation-settings";
+
+export type GithubAutomationTriggerMode = "none" | "push" | "scheduled";
+
+export type GithubRepositoryAutomationFormState = {
+  pushSourceEnabled: boolean;
+  pushSourceProjectId: string;
+  pullTranslationsEnabled: boolean;
+  pullTranslationsProjectId: string;
+  validationEnabled: boolean;
+  validationBlockOnFailure: boolean;
+  triggerMode: GithubAutomationTriggerMode;
+  pushBranches: string[];
+  scheduledCadence: "hourly" | "daily" | "weekly";
+  scheduledHourUtc: number;
+  scheduledDayOfWeek: number;
+  scheduledTimezone: string;
+  statusCheckEnabled: boolean;
+  statusCheckMode: "advisory" | "blocking";
+};
+
+export type GithubRepositoryAutomationFieldErrors = Partial<
+  Record<
+    | "pushSourceProjectId"
+    | "pullTranslationsProjectId"
+    | "trigger"
+    | "pushBranches"
+    | "scheduledDayOfWeek"
+    | "scheduledTimezone"
+    | "form",
+    string
+  >
+>;
+
+export const MAX_AUTOMATION_BRANCH_PATTERNS = 32;
+
+const BRANCH_PATTERN_REGEX = /^[A-Za-z0-9._\-/*?]+$/;
+
+export const AUTOMATION_WEEKDAY_OPTIONS = [
+  { value: 0, label: "Sunday" },
+  { value: 1, label: "Monday" },
+  { value: 2, label: "Tuesday" },
+  { value: 3, label: "Wednesday" },
+  { value: 4, label: "Thursday" },
+  { value: 5, label: "Friday" },
+  { value: 6, label: "Saturday" },
+] as const;
+
+export const AUTOMATION_API_ERROR_MESSAGES: Record<string, string> = {
+  automation_trigger_required:
+    "Enable at least one workflow and choose when automation should run.",
+  push_trigger_requires_branches: "Add at least one branch pattern for push triggers.",
+  weekly_schedule_requires_day_of_week: "Choose a day of the week for weekly schedules.",
+  invalid_automation_timezone: "Enter a valid IANA timezone such as UTC or America/New_York.",
+  github_repository_not_enabled: "Enable this repository before configuring automation.",
+  github_repository_archived: "Archived repositories cannot use translation automation.",
+  invalid_branch_pattern: "Branch patterns may only use letters, numbers, ., _, -, /, *, and ?.",
+};
+
+export function createDefaultAutomationFormState(): GithubRepositoryAutomationFormState {
+  const defaults = DEFAULT_GITHUB_REPOSITORY_AUTOMATION_SETTINGS;
+
+  return {
+    pushSourceEnabled: defaults.workflows.pushSource.enabled,
+    pushSourceProjectId: defaults.workflows.pushSource.projectId ?? "",
+    pullTranslationsEnabled: defaults.workflows.pullTranslations.enabled,
+    pullTranslationsProjectId: defaults.workflows.pullTranslations.projectId ?? "",
+    validationEnabled: defaults.workflows.validation.enabled,
+    validationBlockOnFailure: defaults.workflows.validation.blockOnFailure,
+    triggerMode: "none",
+    pushBranches: ["main"],
+    scheduledCadence: "daily",
+    scheduledHourUtc: 2,
+    scheduledDayOfWeek: 1,
+    scheduledTimezone: "UTC",
+    statusCheckEnabled: defaults.statusCheck.enabled,
+    statusCheckMode: defaults.statusCheck.mode,
+  };
+}
+
+export function createAutomationFormStateFromSettings(
+  settings: GithubRepositoryAutomationSettings,
+): GithubRepositoryAutomationFormState {
+  const base = createDefaultAutomationFormState();
+  const hasWorkflow = hasEnabledGithubRepoAutomationWorkflow(settings);
+
+  let triggerMode: GithubAutomationTriggerMode = "none";
+  if (hasWorkflow && settings.trigger?.mode === "push") {
+    triggerMode = "push";
+  } else if (hasWorkflow && settings.trigger?.mode === "scheduled") {
+    triggerMode = "scheduled";
+  }
+
+  return {
+    pushSourceEnabled: settings.workflows.pushSource.enabled,
+    pushSourceProjectId: settings.workflows.pushSource.projectId ?? "",
+    pullTranslationsEnabled: settings.workflows.pullTranslations.enabled,
+    pullTranslationsProjectId: settings.workflows.pullTranslations.projectId ?? "",
+    validationEnabled: settings.workflows.validation.enabled,
+    validationBlockOnFailure: settings.workflows.validation.blockOnFailure,
+    triggerMode,
+    pushBranches:
+      settings.trigger?.mode === "push" && settings.trigger.branches.length > 0
+        ? [...settings.trigger.branches]
+        : base.pushBranches,
+    scheduledCadence:
+      settings.trigger?.mode === "scheduled" ? settings.trigger.cadence : base.scheduledCadence,
+    scheduledHourUtc:
+      settings.trigger?.mode === "scheduled" ? settings.trigger.hourUtc : base.scheduledHourUtc,
+    scheduledDayOfWeek:
+      settings.trigger?.mode === "scheduled"
+        ? (settings.trigger.dayOfWeek ?? base.scheduledDayOfWeek)
+        : base.scheduledDayOfWeek,
+    scheduledTimezone:
+      settings.trigger?.mode === "scheduled" ? settings.trigger.timezone : base.scheduledTimezone,
+    statusCheckEnabled: settings.statusCheck.enabled,
+    statusCheckMode: settings.statusCheck.mode,
+  };
+}
+
+export function hasAnyAutomationWorkflowEnabled(form: GithubRepositoryAutomationFormState) {
+  return form.pushSourceEnabled || form.pullTranslationsEnabled || form.validationEnabled;
+}
+
+export function formStateToAutomationSettings(
+  form: GithubRepositoryAutomationFormState,
+): GithubRepositoryAutomationSettings {
+  const hasWorkflow = hasAnyAutomationWorkflowEnabled(form);
+
+  const trigger =
+    !hasWorkflow || form.triggerMode === "none"
+      ? null
+      : form.triggerMode === "push"
+        ? {
+            mode: "push" as const,
+            branches: form.pushBranches,
+          }
+        : {
+            mode: "scheduled" as const,
+            cadence: form.scheduledCadence,
+            hourUtc: form.scheduledHourUtc,
+            dayOfWeek: form.scheduledCadence === "weekly" ? form.scheduledDayOfWeek : undefined,
+            timezone: form.scheduledTimezone.trim() || "UTC",
+          };
+
+  return {
+    workflows: {
+      pushSource: {
+        enabled: form.pushSourceEnabled,
+        ...(form.pushSourceProjectId.trim() ? { projectId: form.pushSourceProjectId.trim() } : {}),
+      },
+      pullTranslations: {
+        enabled: form.pullTranslationsEnabled,
+        ...(form.pullTranslationsProjectId.trim()
+          ? { projectId: form.pullTranslationsProjectId.trim() }
+          : {}),
+      },
+      validation: {
+        enabled: form.validationEnabled,
+        blockOnFailure: form.validationBlockOnFailure,
+      },
+    },
+    trigger,
+    statusCheck: {
+      enabled: form.statusCheckEnabled,
+      mode: form.statusCheckMode,
+    },
+  };
+}
+
+export function formStateToAutomationSettingsPayload(
+  form: GithubRepositoryAutomationFormState,
+): GithubRepositoryAutomationSettingsPartial {
+  const settings = formStateToAutomationSettings(form);
+
+  return {
+    workflows: settings.workflows,
+    trigger: settings.trigger,
+    statusCheck: settings.statusCheck,
+  };
+}
+
+export function validateAutomationFormState(
+  form: GithubRepositoryAutomationFormState,
+): GithubRepositoryAutomationFieldErrors {
+  const errors: GithubRepositoryAutomationFieldErrors = {};
+  const hasWorkflow = hasAnyAutomationWorkflowEnabled(form);
+
+  if (form.pushSourceEnabled && !form.pushSourceProjectId.trim()) {
+    errors.pushSourceProjectId = "Choose a Hyperlocalise project for push source.";
+  }
+
+  if (form.pullTranslationsEnabled && !form.pullTranslationsProjectId.trim()) {
+    errors.pullTranslationsProjectId = "Choose a Hyperlocalise project for pull translations.";
+  }
+
+  if (!hasWorkflow) {
+    return errors;
+  }
+
+  if (form.triggerMode === "none") {
+    errors.trigger = "Choose push or scheduled triggers when workflows are enabled.";
+    return errors;
+  }
+
+  if (form.triggerMode === "push") {
+    if (form.pushBranches.length === 0) {
+      errors.pushBranches = AUTOMATION_API_ERROR_MESSAGES.push_trigger_requires_branches;
+    } else {
+      const invalidPattern = form.pushBranches.find(
+        (branch) => !BRANCH_PATTERN_REGEX.test(branch.trim()),
+      );
+      if (invalidPattern) {
+        errors.pushBranches = AUTOMATION_API_ERROR_MESSAGES.invalid_branch_pattern;
+      }
+    }
+  }
+
+  if (form.triggerMode === "scheduled") {
+    if (form.scheduledCadence === "weekly" && form.scheduledDayOfWeek === undefined) {
+      errors.scheduledDayOfWeek =
+        AUTOMATION_API_ERROR_MESSAGES.weekly_schedule_requires_day_of_week;
+    }
+
+    const timezone = form.scheduledTimezone.trim() || "UTC";
+    try {
+      Intl.DateTimeFormat("en-US", { timeZone: timezone });
+    } catch {
+      errors.scheduledTimezone = AUTOMATION_API_ERROR_MESSAGES.invalid_automation_timezone;
+    }
+  }
+
+  const validationError = validateGithubRepositoryAutomationSettings(
+    formStateToAutomationSettings(form),
+  );
+  if (validationError) {
+    const mapped = mapAutomationApiErrorToFieldErrors(validationError);
+    return { ...errors, ...mapped };
+  }
+
+  return errors;
+}
+
+export function mapAutomationApiErrorToFieldErrors(
+  errorCode: string,
+  message?: string,
+): GithubRepositoryAutomationFieldErrors {
+  const fallbackMessage = message ?? AUTOMATION_API_ERROR_MESSAGES[errorCode];
+
+  switch (errorCode) {
+    case "automation_trigger_required":
+      return { trigger: fallbackMessage };
+    case "push_trigger_requires_branches":
+      return { pushBranches: fallbackMessage };
+    case "weekly_schedule_requires_day_of_week":
+      return { scheduledDayOfWeek: fallbackMessage };
+    case "invalid_automation_timezone":
+      return { scheduledTimezone: fallbackMessage };
+    case "github_repository_not_enabled":
+    case "github_repository_archived":
+      return { form: fallbackMessage };
+    default:
+      return { form: fallbackMessage ?? "Could not save automation settings." };
+  }
+}
+
+export function normalizeBranchPatternInput(value: string) {
+  return value.trim();
+}
+
+export function addBranchPattern(
+  branches: string[],
+  rawPattern: string,
+): { branches: string[]; error?: string } {
+  const pattern = normalizeBranchPatternInput(rawPattern);
+
+  if (!pattern) {
+    return { branches, error: "Enter a branch pattern." };
+  }
+
+  if (!BRANCH_PATTERN_REGEX.test(pattern)) {
+    return { branches, error: AUTOMATION_API_ERROR_MESSAGES.invalid_branch_pattern };
+  }
+
+  if (branches.includes(pattern)) {
+    return { branches, error: "That branch pattern is already listed." };
+  }
+
+  if (branches.length >= MAX_AUTOMATION_BRANCH_PATTERNS) {
+    return {
+      branches,
+      error: `You can add up to ${MAX_AUTOMATION_BRANCH_PATTERNS} branch patterns.`,
+    };
+  }
+
+  return { branches: [...branches, pattern] };
+}
+
+export function formatAutomationNextRunAt(nextRunAt: string | null) {
+  if (!nextRunAt) {
+    return null;
+  }
+
+  const date = new Date(nextRunAt);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: "UTC",
+    timeZoneName: "short",
+  }).format(date);
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/repository-automation-settings-action.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/repository-automation-settings-action.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import Link from "next/link";
 
 import { RepositoryAutomationSettingsPanel } from "./repository-automation-settings-panel";
 import { Button } from "@/components/ui/button";
@@ -32,7 +31,6 @@ export function RepositoryAutomationSettingsAction({
   userCanManage,
 }: RepositoryAutomationSettingsActionProps) {
   const [open, setOpen] = useState(false);
-  const automationPath = `/org/${organizationSlug}/integrations/github/repositories/${githubRepositoryId}/automation`;
 
   if (!userCanManage || !enabled || archived) {
     return null;
@@ -63,14 +61,6 @@ export function RepositoryAutomationSettingsAction({
             showFullPageLink
             onSaved={() => setOpen(false)}
           />
-          <div className="mt-4 border-t border-border pt-4">
-            <Link
-              href={automationPath}
-              className="text-xs text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
-            >
-              Open dedicated settings page
-            </Link>
-          </div>
         </div>
       </SheetContent>
     </Sheet>

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/repository-automation-settings-action.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/repository-automation-settings-action.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+
+import { RepositoryAutomationSettingsPanel } from "./repository-automation-settings-panel";
+import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+
+type RepositoryAutomationSettingsActionProps = {
+  organizationSlug: string;
+  githubRepositoryId: string;
+  repositoryFullName: string;
+  enabled: boolean;
+  archived: boolean;
+  userCanManage: boolean;
+};
+
+export function RepositoryAutomationSettingsAction({
+  organizationSlug,
+  githubRepositoryId,
+  repositoryFullName,
+  enabled,
+  archived,
+  userCanManage,
+}: RepositoryAutomationSettingsActionProps) {
+  const [open, setOpen] = useState(false);
+  const automationPath = `/org/${organizationSlug}/integrations/github/repositories/${githubRepositoryId}/automation`;
+
+  if (!userCanManage || !enabled || archived) {
+    return null;
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger
+        render={<Button type="button" variant="outline" size="sm" className="whitespace-nowrap" />}
+      >
+        Automation
+      </SheetTrigger>
+      <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-xl">
+        <SheetHeader>
+          <SheetTitle>Repository automation</SheetTitle>
+          <SheetDescription>
+            Push source, pull translations, and publish localization checks for this repository.
+          </SheetDescription>
+        </SheetHeader>
+        <div className="px-6 pb-6">
+          <RepositoryAutomationSettingsPanel
+            organizationSlug={organizationSlug}
+            githubRepositoryId={githubRepositoryId}
+            repositoryFullName={repositoryFullName}
+            repositoryEnabled={enabled}
+            repositoryArchived={archived}
+            userCanManage={userCanManage}
+            showFullPageLink
+            onSaved={() => setOpen(false)}
+          />
+          <div className="mt-4 border-t border-border pt-4">
+            <Link
+              href={automationPath}
+              className="text-xs text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+            >
+              Open dedicated settings page
+            </Link>
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/repository-automation-settings-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/repository-automation-settings-panel.tsx
@@ -202,15 +202,22 @@ export function RepositoryAutomationSettingsPanel({
       return;
     }
 
-    setForm(createAutomationFormStateFromSettings(settingsQuery.data.settings));
     setMetadata({
       configVersion: settingsQuery.data.configVersion,
       nextRunAt: settingsQuery.data.nextRunAt,
     });
+  }, [settingsQuery.data]);
+
+  useEffect(() => {
+    if (!settingsQuery.data || form !== null) {
+      return;
+    }
+
+    setForm(createAutomationFormStateFromSettings(settingsQuery.data.settings));
     setFieldErrors({});
     setBranchInput("");
     setBranchInputError(undefined);
-  }, [settingsQuery.data]);
+  }, [settingsQuery.data, form]);
 
   const saveSettings = useMutation({
     mutationFn: async (nextForm: GithubRepositoryAutomationFormState) => {
@@ -250,9 +257,10 @@ export function RepositoryAutomationSettingsPanel({
         nextRunAt: result.record.nextRunAt,
       });
       setFieldErrors({});
-      void queryClient.invalidateQueries({
-        queryKey: ["github-repository-automation-settings", organizationSlug, githubRepositoryId],
-      });
+      queryClient.setQueryData(
+        ["github-repository-automation-settings", organizationSlug, githubRepositoryId],
+        result.record,
+      );
       toast.success("Automation settings saved");
       onSaved?.();
     },
@@ -287,9 +295,10 @@ export function RepositoryAutomationSettingsPanel({
       });
       setFieldErrors({});
       setResetDialogOpen(false);
-      void queryClient.invalidateQueries({
-        queryKey: ["github-repository-automation-settings", organizationSlug, githubRepositoryId],
-      });
+      queryClient.setQueryData(
+        ["github-repository-automation-settings", organizationSlug, githubRepositoryId],
+        record,
+      );
       toast.success("Automation settings reset");
       onSaved?.();
     },
@@ -316,7 +325,13 @@ export function RepositoryAutomationSettingsPanel({
 
   function updateForm(patch: Partial<GithubRepositoryAutomationFormState>) {
     setForm((current) => (current ? { ...current, ...patch } : current));
-    setFieldErrors({});
+    setFieldErrors((current) => {
+      const next = { ...current };
+      for (const key of Object.keys(patch)) {
+        delete next[key as keyof GithubRepositoryAutomationFieldErrors];
+      }
+      return next;
+    });
   }
 
   function handleSave() {

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/repository-automation-settings-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/repository-automation-settings-panel.tsx
@@ -1,0 +1,803 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import {
+  addBranchPattern,
+  AUTOMATION_WEEKDAY_OPTIONS,
+  createAutomationFormStateFromSettings,
+  type GithubRepositoryAutomationFieldErrors,
+  type GithubRepositoryAutomationFormState,
+  formStateToAutomationSettingsPayload,
+  formatAutomationNextRunAt,
+  hasAnyAutomationWorkflowEnabled,
+  mapAutomationApiErrorToFieldErrors,
+  validateAutomationFormState,
+} from "./github-repository-automation-view-model";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Switch } from "@/components/ui/switch";
+import { createApiClient } from "@/lib/api-client";
+import type { GithubRepositoryAutomationSettings } from "@/lib/agents/github/github-repository-automation-settings";
+import { cn } from "@/lib/primitives/cn";
+
+const api = createApiClient();
+
+type ProjectOption = {
+  id: string;
+  name: string;
+};
+
+type GithubRepositoryAutomationRecord = {
+  githubRepositoryId: string;
+  settings: GithubRepositoryAutomationSettings;
+  configVersion: number;
+  nextRunAt: string | null;
+};
+
+type RepositoryAutomationSettingsPanelProps = {
+  organizationSlug: string;
+  githubRepositoryId: string;
+  repositoryFullName: string;
+  repositoryEnabled: boolean;
+  repositoryArchived: boolean;
+  userCanManage: boolean;
+  showFullPageLink?: boolean;
+  onSaved?: () => void;
+};
+
+function FieldError({ message }: { message?: string }) {
+  if (!message) {
+    return null;
+  }
+
+  return <p className="text-xs text-destructive">{message}</p>;
+}
+
+function SectionHeading({ title, description }: { title: string; description: string }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <h3 className="text-sm font-medium text-foreground">{title}</h3>
+      <p className="text-xs leading-5 text-muted-foreground">{description}</p>
+    </div>
+  );
+}
+
+function ProjectSelectField({
+  id,
+  label,
+  description,
+  value,
+  projects,
+  disabled,
+  error,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  description: string;
+  value: string;
+  projects: ProjectOption[];
+  disabled: boolean;
+  error?: string;
+  onChange: (projectId: string) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <Label htmlFor={id}>{label}</Label>
+      <p className="text-xs text-muted-foreground">{description}</p>
+      <Select
+        value={value || undefined}
+        onValueChange={(nextValue) => {
+          if (nextValue) {
+            onChange(nextValue);
+          }
+        }}
+        disabled={disabled}
+      >
+        <SelectTrigger id={id} className="w-full">
+          <SelectValue placeholder="Select a project" />
+        </SelectTrigger>
+        <SelectContent>
+          {projects.map((project) => (
+            <SelectItem key={project.id} value={project.id}>
+              {project.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <FieldError message={error} />
+    </div>
+  );
+}
+
+export function RepositoryAutomationSettingsPanel({
+  organizationSlug,
+  githubRepositoryId,
+  repositoryFullName,
+  repositoryEnabled,
+  repositoryArchived,
+  userCanManage,
+  showFullPageLink = false,
+  onSaved,
+}: RepositoryAutomationSettingsPanelProps) {
+  const queryClient = useQueryClient();
+  const [form, setForm] = useState<GithubRepositoryAutomationFormState | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<GithubRepositoryAutomationFieldErrors>({});
+  const [branchInput, setBranchInput] = useState("");
+  const [branchInputError, setBranchInputError] = useState<string | undefined>();
+  const [resetDialogOpen, setResetDialogOpen] = useState(false);
+  const [metadata, setMetadata] = useState<{ configVersion: number; nextRunAt: string | null }>({
+    configVersion: 0,
+    nextRunAt: null,
+  });
+
+  const automationPath = `/org/${organizationSlug}/integrations/github/repositories/${githubRepositoryId}/automation`;
+
+  const settingsQuery = useQuery({
+    queryKey: ["github-repository-automation-settings", organizationSlug, githubRepositoryId],
+    queryFn: async () => {
+      const res = await api.api.orgs[":organizationSlug"]["github-installation"].repositories[
+        ":githubRepositoryId"
+      ]["automation-settings"].$get({
+        param: { organizationSlug, githubRepositoryId },
+      });
+
+      if (!res.ok) {
+        const error = await res.json().catch(() => ({ error: "load_failed" }));
+        throw new Error(
+          "error" in error ? String(error.error) : "Failed to load automation settings",
+        );
+      }
+
+      const data = await res.json();
+      return data.githubRepositoryAutomationSettings as GithubRepositoryAutomationRecord;
+    },
+    enabled: userCanManage && repositoryEnabled && !repositoryArchived,
+  });
+
+  const projectsQuery = useQuery({
+    queryKey: ["org-projects", organizationSlug],
+    queryFn: async () => {
+      const res = await api.api.orgs[":organizationSlug"].projects.$get({
+        param: { organizationSlug },
+      });
+
+      if (!res.ok) {
+        throw new Error("Failed to load projects");
+      }
+
+      const data = await res.json();
+      return (data.projects as ProjectOption[]).map((project) => ({
+        id: project.id,
+        name: project.name,
+      }));
+    },
+    enabled: userCanManage,
+  });
+
+  useEffect(() => {
+    if (!settingsQuery.data) {
+      return;
+    }
+
+    setForm(createAutomationFormStateFromSettings(settingsQuery.data.settings));
+    setMetadata({
+      configVersion: settingsQuery.data.configVersion,
+      nextRunAt: settingsQuery.data.nextRunAt,
+    });
+    setFieldErrors({});
+    setBranchInput("");
+    setBranchInputError(undefined);
+  }, [settingsQuery.data]);
+
+  const saveSettings = useMutation({
+    mutationFn: async (nextForm: GithubRepositoryAutomationFormState) => {
+      const res = await api.api.orgs[":organizationSlug"]["github-installation"].repositories[
+        ":githubRepositoryId"
+      ]["automation-settings"].$put({
+        param: { organizationSlug, githubRepositoryId },
+        json: {
+          settings: formStateToAutomationSettingsPayload(nextForm),
+        },
+      });
+
+      if (!res.ok) {
+        const error = await res.json().catch(() => ({ error: "save_failed" }));
+        const code = "error" in error ? String(error.error) : "save_failed";
+        const message =
+          "message" in error && typeof error.message === "string" ? error.message : undefined;
+        return { ok: false as const, code, message };
+      }
+
+      const data = await res.json();
+      return {
+        ok: true as const,
+        record: data.githubRepositoryAutomationSettings as GithubRepositoryAutomationRecord,
+      };
+    },
+    onSuccess: (result) => {
+      if (!result.ok) {
+        setFieldErrors(mapAutomationApiErrorToFieldErrors(result.code, result.message));
+        toast.error(result.message ?? "Could not save automation settings");
+        return;
+      }
+
+      setForm(createAutomationFormStateFromSettings(result.record.settings));
+      setMetadata({
+        configVersion: result.record.configVersion,
+        nextRunAt: result.record.nextRunAt,
+      });
+      setFieldErrors({});
+      void queryClient.invalidateQueries({
+        queryKey: ["github-repository-automation-settings", organizationSlug, githubRepositoryId],
+      });
+      toast.success("Automation settings saved");
+      onSaved?.();
+    },
+    onError: (error) => {
+      toast.error(error.message);
+    },
+  });
+
+  const resetSettings = useMutation({
+    mutationFn: async () => {
+      const res = await api.api.orgs[":organizationSlug"]["github-installation"].repositories[
+        ":githubRepositoryId"
+      ]["automation-settings"].$delete({
+        param: { organizationSlug, githubRepositoryId },
+      });
+
+      if (!res.ok) {
+        const error = await res.json().catch(() => ({ error: "reset_failed" }));
+        throw new Error(
+          "error" in error ? String(error.error) : "Failed to reset automation settings",
+        );
+      }
+
+      const data = await res.json();
+      return data.githubRepositoryAutomationSettings as GithubRepositoryAutomationRecord;
+    },
+    onSuccess: (record) => {
+      setForm(createAutomationFormStateFromSettings(record.settings));
+      setMetadata({
+        configVersion: record.configVersion,
+        nextRunAt: record.nextRunAt,
+      });
+      setFieldErrors({});
+      setResetDialogOpen(false);
+      void queryClient.invalidateQueries({
+        queryKey: ["github-repository-automation-settings", organizationSlug, githubRepositoryId],
+      });
+      toast.success("Automation settings reset");
+      onSaved?.();
+    },
+    onError: (error) => {
+      toast.error(error.message);
+    },
+  });
+
+  const projects = projectsQuery.data ?? [];
+  const readOnly = !userCanManage;
+  const formDisabled =
+    readOnly || !repositoryEnabled || repositoryArchived || saveSettings.isPending;
+  const workflowsEnabled = form ? hasAnyAutomationWorkflowEnabled(form) : false;
+  const formattedNextRun = formatAutomationNextRunAt(metadata.nextRunAt);
+
+  const triggerChoices = useMemo(
+    () => [
+      { value: "none", label: "Off" },
+      { value: "push", label: "On push" },
+      { value: "scheduled", label: "Scheduled" },
+    ],
+    [],
+  );
+
+  function updateForm(patch: Partial<GithubRepositoryAutomationFormState>) {
+    setForm((current) => (current ? { ...current, ...patch } : current));
+    setFieldErrors({});
+  }
+
+  function handleSave() {
+    if (!form) {
+      return;
+    }
+
+    const errors = validateAutomationFormState(form);
+    if (Object.keys(errors).length > 0) {
+      setFieldErrors(errors);
+      return;
+    }
+
+    saveSettings.mutate(form);
+  }
+
+  function handleAddBranchPattern() {
+    if (!form) {
+      return;
+    }
+
+    const result = addBranchPattern(form.pushBranches, branchInput);
+    if (result.error) {
+      setBranchInputError(result.error);
+      return;
+    }
+
+    updateForm({ pushBranches: result.branches });
+    setBranchInput("");
+    setBranchInputError(undefined);
+  }
+
+  if (!userCanManage) {
+    return null;
+  }
+
+  if (!repositoryEnabled) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Enable this repository to configure translation automation.
+      </p>
+    );
+  }
+
+  if (repositoryArchived) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Archived repositories cannot use translation automation.
+      </p>
+    );
+  }
+
+  if (settingsQuery.isLoading || !form) {
+    return (
+      <div className="flex flex-col gap-3">
+        <Skeleton className="h-8 w-2/3" />
+        <Skeleton className="h-24 w-full" />
+        <Skeleton className="h-24 w-full" />
+      </div>
+    );
+  }
+
+  if (settingsQuery.isError) {
+    return (
+      <div className="flex flex-col gap-3">
+        <p className="text-sm text-destructive">
+          {settingsQuery.error instanceof Error
+            ? settingsQuery.error.message
+            : "Unable to load automation settings."}
+        </p>
+        <Button variant="outline" size="sm" onClick={() => void settingsQuery.refetch()}>
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-2">
+          <p className="text-sm text-muted-foreground">
+            Configure how Hyperlocalise syncs source strings and translations for{" "}
+            <span className="font-medium text-foreground">{repositoryFullName}</span>.
+          </p>
+          {showFullPageLink ? (
+            <Link
+              href={automationPath}
+              className="text-xs text-primary underline-offset-4 hover:underline"
+            >
+              Open full-page editor
+            </Link>
+          ) : null}
+          {fieldErrors.form ? <FieldError message={fieldErrors.form} /> : null}
+        </div>
+
+        <section className="flex flex-col gap-4 rounded-lg border border-border p-4">
+          <SectionHeading
+            title="Workflows"
+            description="Choose which automation jobs run for this repository."
+          />
+
+          <div className="flex flex-col gap-4">
+            <div className="flex items-start justify-between gap-4">
+              <div className="flex flex-col gap-1">
+                <Label htmlFor="push-source-enabled">Push source to Hyperlocalise</Label>
+                <p className="text-xs text-muted-foreground">
+                  Import source strings from GitHub into your TMS project.
+                </p>
+              </div>
+              <Switch
+                id="push-source-enabled"
+                checked={form.pushSourceEnabled}
+                disabled={formDisabled}
+                onCheckedChange={(checked) => updateForm({ pushSourceEnabled: checked })}
+              />
+            </div>
+            {form.pushSourceEnabled ? (
+              <ProjectSelectField
+                id="push-source-project"
+                label="Hyperlocalise project"
+                description="Source strings are pushed into this project."
+                value={form.pushSourceProjectId}
+                projects={projects}
+                disabled={formDisabled || projectsQuery.isLoading}
+                error={fieldErrors.pushSourceProjectId}
+                onChange={(projectId) => updateForm({ pushSourceProjectId: projectId })}
+              />
+            ) : null}
+
+            <div className="flex items-start justify-between gap-4">
+              <div className="flex flex-col gap-1">
+                <Label htmlFor="pull-translations-enabled">Pull translations to GitHub</Label>
+                <p className="text-xs text-muted-foreground">
+                  Opens a pull request with updated translation files when sync succeeds.
+                </p>
+              </div>
+              <Switch
+                id="pull-translations-enabled"
+                checked={form.pullTranslationsEnabled}
+                disabled={formDisabled}
+                onCheckedChange={(checked) => updateForm({ pullTranslationsEnabled: checked })}
+              />
+            </div>
+            {form.pullTranslationsEnabled ? (
+              <ProjectSelectField
+                id="pull-translations-project"
+                label="Hyperlocalise project"
+                description="Translations are read from this project before opening the pull request."
+                value={form.pullTranslationsProjectId}
+                projects={projects}
+                disabled={formDisabled || projectsQuery.isLoading}
+                error={fieldErrors.pullTranslationsProjectId}
+                onChange={(projectId) => updateForm({ pullTranslationsProjectId: projectId })}
+              />
+            ) : null}
+
+            <div className="flex items-start justify-between gap-4">
+              <div className="flex flex-col gap-1">
+                <Label htmlFor="validation-enabled">Localization check</Label>
+                <p className="text-xs text-muted-foreground">
+                  Runs <code className="text-xs">hl check</code> against repository translation
+                  files.
+                </p>
+              </div>
+              <Switch
+                id="validation-enabled"
+                checked={form.validationEnabled}
+                disabled={formDisabled}
+                onCheckedChange={(checked) => updateForm({ validationEnabled: checked })}
+              />
+            </div>
+            {form.validationEnabled ? (
+              <div className="flex items-start justify-between gap-4 ps-2">
+                <div className="flex flex-col gap-1">
+                  <Label htmlFor="validation-block">Block on failure</Label>
+                  <p className="text-xs text-muted-foreground">
+                    Fail the automation run when the localization check reports errors.
+                  </p>
+                </div>
+                <Switch
+                  id="validation-block"
+                  checked={form.validationBlockOnFailure}
+                  disabled={formDisabled}
+                  onCheckedChange={(checked) => updateForm({ validationBlockOnFailure: checked })}
+                />
+              </div>
+            ) : null}
+          </div>
+        </section>
+
+        <section className="flex flex-col gap-4 rounded-lg border border-border p-4">
+          <SectionHeading
+            title="Trigger"
+            description="Push and scheduled triggers are mutually exclusive."
+          />
+
+          <div className="flex flex-wrap gap-2">
+            {triggerChoices.map((choice) => (
+              <Button
+                key={choice.value}
+                type="button"
+                size="sm"
+                variant={form.triggerMode === choice.value ? "default" : "outline"}
+                disabled={formDisabled || (!workflowsEnabled && choice.value !== "none")}
+                onClick={() =>
+                  updateForm({
+                    triggerMode: choice.value as GithubRepositoryAutomationFormState["triggerMode"],
+                  })
+                }
+              >
+                {choice.label}
+              </Button>
+            ))}
+          </div>
+          <FieldError message={fieldErrors.trigger} />
+
+          {form.triggerMode === "push" ? (
+            <div className="flex flex-col gap-3">
+              <Label htmlFor="branch-pattern-input">Branch patterns</Label>
+              <p className="text-xs text-muted-foreground">
+                Use glob patterns such as <code className="text-xs">main</code> or{" "}
+                <code className="text-xs">release/*</code>. Up to 32 patterns.
+              </p>
+              <div className="flex gap-2">
+                <input
+                  id="branch-pattern-input"
+                  value={branchInput}
+                  onChange={(event) => {
+                    setBranchInput(event.target.value);
+                    setBranchInputError(undefined);
+                  }}
+                  disabled={formDisabled}
+                  placeholder="main"
+                  className="h-9 min-w-0 flex-1 rounded-lg border border-border bg-background px-3 text-sm outline-none focus:border-primary/40 focus:ring-[3px] focus:ring-primary/20"
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") {
+                      event.preventDefault();
+                      handleAddBranchPattern();
+                    }
+                  }}
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  disabled={formDisabled}
+                  onClick={handleAddBranchPattern}
+                >
+                  Add
+                </Button>
+              </div>
+              <FieldError message={branchInputError ?? fieldErrors.pushBranches} />
+              {form.pushBranches.length > 0 ? (
+                <div className="flex flex-wrap gap-2">
+                  {form.pushBranches.map((branch) => (
+                    <Badge key={branch} variant="secondary" className="gap-1 pe-1">
+                      {branch}
+                      <button
+                        type="button"
+                        className="rounded-full px-1 text-muted-foreground hover:text-foreground"
+                        disabled={formDisabled}
+                        aria-label={`Remove ${branch}`}
+                        onClick={() =>
+                          updateForm({
+                            pushBranches: form.pushBranches.filter((value) => value !== branch),
+                          })
+                        }
+                      >
+                        ×
+                      </button>
+                    </Badge>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+
+          {form.triggerMode === "scheduled" ? (
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="scheduled-cadence">Cadence</Label>
+                <Select
+                  value={form.scheduledCadence}
+                  onValueChange={(value) =>
+                    updateForm({
+                      scheduledCadence:
+                        value as GithubRepositoryAutomationFormState["scheduledCadence"],
+                    })
+                  }
+                  disabled={formDisabled}
+                >
+                  <SelectTrigger id="scheduled-cadence">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="hourly">Hourly</SelectItem>
+                    <SelectItem value="daily">Daily</SelectItem>
+                    <SelectItem value="weekly">Weekly</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {form.scheduledCadence !== "hourly" ? (
+                <div className="flex flex-col gap-2">
+                  <Label htmlFor="scheduled-hour">Hour (UTC)</Label>
+                  <Select
+                    value={String(form.scheduledHourUtc)}
+                    onValueChange={(value) => updateForm({ scheduledHourUtc: Number(value) })}
+                    disabled={formDisabled}
+                  >
+                    <SelectTrigger id="scheduled-hour">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {Array.from({ length: 24 }, (_, hour) => (
+                        <SelectItem key={hour} value={String(hour)}>
+                          {String(hour).padStart(2, "0")}:00 UTC
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              ) : null}
+
+              {form.scheduledCadence === "weekly" ? (
+                <div className="flex flex-col gap-2 sm:col-span-2">
+                  <Label htmlFor="scheduled-day">Day of week</Label>
+                  <Select
+                    value={String(form.scheduledDayOfWeek)}
+                    onValueChange={(value) => updateForm({ scheduledDayOfWeek: Number(value) })}
+                    disabled={formDisabled}
+                  >
+                    <SelectTrigger id="scheduled-day">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {AUTOMATION_WEEKDAY_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={String(option.value)}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FieldError message={fieldErrors.scheduledDayOfWeek} />
+                </div>
+              ) : null}
+
+              <div className="flex flex-col gap-2 sm:col-span-2">
+                <Label htmlFor="scheduled-timezone">Timezone</Label>
+                <input
+                  id="scheduled-timezone"
+                  value={form.scheduledTimezone}
+                  onChange={(event) => updateForm({ scheduledTimezone: event.target.value })}
+                  disabled={formDisabled}
+                  placeholder="UTC"
+                  className="h-9 rounded-lg border border-border bg-background px-3 text-sm outline-none focus:border-primary/40 focus:ring-[3px] focus:ring-primary/20"
+                />
+                <FieldError message={fieldErrors.scheduledTimezone} />
+              </div>
+            </div>
+          ) : null}
+        </section>
+
+        <section className="flex flex-col gap-4 rounded-lg border border-border p-4">
+          <SectionHeading
+            title="GitHub status check"
+            description="Publish a check run so teams can see localization results on commits and pull requests."
+          />
+
+          <div className="flex items-start justify-between gap-4">
+            <div className="flex flex-col gap-1">
+              <Label htmlFor="status-check-enabled">Enable check run</Label>
+              <p className="text-xs text-muted-foreground">
+                Shows localization automation status in GitHub Checks.
+              </p>
+            </div>
+            <Switch
+              id="status-check-enabled"
+              checked={form.statusCheckEnabled}
+              disabled={formDisabled}
+              onCheckedChange={(checked) => updateForm({ statusCheckEnabled: checked })}
+            />
+          </div>
+
+          {form.statusCheckEnabled ? (
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="status-check-mode">Check mode</Label>
+              <Select
+                value={form.statusCheckMode}
+                onValueChange={(value) =>
+                  updateForm({
+                    statusCheckMode:
+                      value as GithubRepositoryAutomationFormState["statusCheckMode"],
+                  })
+                }
+                disabled={formDisabled}
+              >
+                <SelectTrigger id="status-check-mode">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="advisory">Advisory</SelectItem>
+                  <SelectItem value="blocking">Blocking</SelectItem>
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground">
+                Blocking checks can fail pull requests when combined with{" "}
+                <a
+                  href="https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-status-checks"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary underline-offset-4 hover:underline"
+                >
+                  branch protection rules
+                </a>
+                .
+              </p>
+            </div>
+          ) : null}
+        </section>
+
+        {(metadata.configVersion > 0 || formattedNextRun) && (
+          <div className="rounded-lg border border-dashed border-border bg-muted/30 px-4 py-3 text-xs text-muted-foreground">
+            {metadata.configVersion > 0 ? (
+              <p>
+                Config version:{" "}
+                <span className="font-medium text-foreground">{metadata.configVersion}</span>
+              </p>
+            ) : null}
+            {formattedNextRun ? (
+              <p className={cn(metadata.configVersion > 0 && "mt-1")}>
+                Next scheduled run:{" "}
+                <span className="font-medium text-foreground">{formattedNextRun}</span>
+              </p>
+            ) : null}
+          </div>
+        )}
+
+        <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border pt-4">
+          <Button
+            type="button"
+            variant="outline"
+            disabled={formDisabled || resetSettings.isPending}
+            onClick={() => setResetDialogOpen(true)}
+          >
+            Reset settings
+          </Button>
+          <Button
+            type="button"
+            disabled={formDisabled}
+            onClick={handleSave}
+            className="bg-primary text-primary-foreground hover:bg-primary/80"
+          >
+            {saveSettings.isPending ? "Saving..." : "Save settings"}
+          </Button>
+        </div>
+      </div>
+
+      <AlertDialog open={resetDialogOpen} onOpenChange={setResetDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Reset automation settings?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This clears saved workflows, triggers, and status check settings for this repository.
+              GitHub metadata sync is not affected.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={resetSettings.isPending}>Cancel</AlertDialogCancel>
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={resetSettings.isPending}
+              onClick={() => resetSettings.mutate()}
+            >
+              {resetSettings.isPending ? "Resetting..." : "Reset settings"}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/github/repositories/[githubRepositoryId]/automation/page.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/github/repositories/[githubRepositoryId]/automation/page.tsx
@@ -1,0 +1,77 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { and, eq } from "drizzle-orm";
+
+import { RepositoryAutomationSettingsPanel } from "../../../../_components/repository-automation-settings-panel";
+import { hasCapability } from "@/api/auth/policy";
+import { Button } from "@/components/ui/button";
+import { TypographyH1, TypographyP } from "@/components/ui/typography";
+import { db, schema } from "@/lib/database";
+import { requireAppAuthContext } from "@/lib/workos/app-auth";
+
+export default async function GithubRepositoryAutomationPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string; githubRepositoryId: string }>;
+}) {
+  const { organizationSlug, githubRepositoryId } = await params;
+  const auth = await requireAppAuthContext({ organizationSlug });
+
+  if (!hasCapability(auth.membership.role, "integrations:write")) {
+    notFound();
+  }
+
+  const [repo] = await db
+    .select({
+      fullName: schema.githubInstallationRepositories.fullName,
+      enabled: schema.githubInstallationRepositories.enabled,
+      archived: schema.githubInstallationRepositories.archived,
+    })
+    .from(schema.githubInstallationRepositories)
+    .where(
+      and(
+        eq(
+          schema.githubInstallationRepositories.organizationId,
+          auth.organization.localOrganizationId,
+        ),
+        eq(schema.githubInstallationRepositories.githubRepositoryId, githubRepositoryId),
+      ),
+    )
+    .limit(1);
+
+  if (!repo) {
+    notFound();
+  }
+
+  const integrationsHref = `/org/${organizationSlug}/integrations`;
+
+  return (
+    <main className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-6 py-8">
+      <div className="flex flex-col gap-3">
+        <Button
+          variant="outline"
+          size="sm"
+          className="w-fit"
+          render={<Link href={integrationsHref} />}
+        >
+          Back to integrations
+        </Button>
+        <TypographyH1>Repository automation</TypographyH1>
+        <TypographyP className="text-muted-foreground">
+          Configure translation automation for{" "}
+          <span className="text-foreground">{repo.fullName}</span>. This is separate from refreshing
+          repository metadata from GitHub.
+        </TypographyP>
+      </div>
+
+      <RepositoryAutomationSettingsPanel
+        organizationSlug={organizationSlug}
+        githubRepositoryId={githubRepositoryId}
+        repositoryFullName={repo.fullName}
+        repositoryEnabled={repo.enabled}
+        repositoryArchived={repo.archived}
+        userCanManage
+      />
+    </main>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Resolves HL-455.

## Summary

Adds product UI for GitHub repository automation (push source, pull translations, localization check, triggers, and GitHub status checks). Backend API and workers already exist; this wires the integrations surface to `GET` / `PUT` / `DELETE` automation-settings.

## Changes

- **Integrations table**: per-repo **Automation** action (sheet) for enabled repos when the user can manage integrations; **Sync repositories** renamed to **Refresh repo list** with tooltip clarifying metadata-only sync.
- **Dedicated route**: `/org/:slug/integrations/github/repositories/:githubRepositoryId/automation` (requires `integrations:write`).
- **Form**: workflows, push vs scheduled trigger, branch patterns, status check (advisory vs blocking), reset via confirm dialog; shows `configVersion` and `nextRunAt` after save.
- **View model**: `github-repository-automation-view-model.ts` with client validation, API error → field mapping, and unit tests.

## Manual test plan

1. Sign in as org **admin** (or localization manager with `integrations:write`).
2. Open **Org → Integrations → GitHub** with a connected installation and at least one **enabled** repository.
3. Confirm **Refresh repo list** label/tooltip (not translation sync).
4. Click **Automation** on an enabled repo → sheet opens with empty or existing settings.
5. Enable **Push source to Hyperlocalise**, pick a project, set trigger **On push** with branch `main`, save → success toast; reload sheet → settings persist.
6. Enable **Pull translations to GitHub** and **Localization check** with **Block on failure**; save again.
7. Switch trigger to **Scheduled** (daily), save → note **Next run** / `nextRunAt` if returned.
8. Enable **GitHub status check**, set **Blocking**, save.
9. **Reset automation** → confirm → settings cleared (DELETE).
10. Open **Open dedicated settings page** link → full-page form matches sheet.
11. Sign in as non-admin → **Automation** button hidden; direct URL to automation page returns 404.
12. Disable repo or use archived repo → Automation hidden / form shows enable-repo message.

## Tests

- `vp check --fix` — pass
- `vp test github-repository-automation-view-model` — 5/5 pass

## Out of scope

- Automation job run history (follow-up)
- Empty state linking to i18n setup when no `i18n.yml`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-455](https://linear.app/hyperlocalise/issue/HL-455/add-integrations-ui-for-github-repo-automation-push-source-pull)

<div><a href="https://cursor.com/agents/bc-e494dd7f-9d6e-47a2-ae64-2b1f9bdc07fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e494dd7f-9d6e-47a2-ae64-2b1f9bdc07fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

