### PR TITLE
feat(auth): enforce WorkOS RBAC across org, project, job, and provider APIs

### DIFF
--- a/apps/hyperlocalise-web/src/api/auth/LOCALIZATION_ROLES.md
+++ b/apps/hyperlocalise-web/src/api/auth/LOCALIZATION_ROLES.md
@@ -27,9 +27,9 @@ environment roles in your WorkOS project (see `src/lib/workos/IDENTITY.md`).
 
 ## Capability map (organization-wide)
 
-Capabilities are checked after the WorkOS access gate. Resource-scoped checks
-(project, team, locale, assignment) are added in HL-427; this table is the
-org-wide ceiling.
+Capabilities are checked after the WorkOS access gate via `policy.ts` and route
+helpers in `capability-guards.ts`. This table is the org-wide ceiling; team
+membership further limits which projects appear in listings.
 
 | Capability                   | admin | localization_manager | developer | reviewer | translator | member |
 | ---------------------------- | ----- | -------------------- | --------- | -------- | ---------- | ------ |
@@ -75,13 +75,16 @@ with admins except billing write.
 These roles are **organization-wide** in WorkOS and in `organization_memberships`.
 They define the maximum access a user may have anywhere in the workspace.
 
-Finer boundaries are layered separately (HL-427+):
+Finer boundaries are layered separately:
 
 - **Team membership** (`team_memberships.role`: `manager` | `member`) limits
   which projects and resources appear in listings.
 - **Project / job / locale assignment** (future) further restricts translators
   and contractors to assigned work even when org capabilities would allow broader
   reads.
+
+`bun run workos:setup` also syncs WorkOS environment permissions (additive) so
+role slugs in the WorkOS dashboard mirror the capability slugs below.
 
 Authorization helpers should treat org capabilities as necessary but not
 sufficient where resource scope applies.

--- a/apps/hyperlocalise-web/src/api/auth/capability-guards.test.ts
+++ b/apps/hyperlocalise-web/src/api/auth/capability-guards.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import type { OrganizationMembershipRole } from "@/lib/database/types";
+
+import {
+  isAiActionAllowed,
+  isIntegrationsReadAllowed,
+  isJobCreateAllowed,
+  isJobMutationAllowed,
+  isJobProviderActionAllowed,
+  isProjectCreateAllowed,
+  isProjectWriteAllowed,
+  isProviderCredentialReadAllowed,
+  isReviewApproveAllowed,
+  isWriteBackApproveAllowed,
+} from "./capability-guards";
+
+const LOCALIZATION_ROLES = [
+  "admin",
+  "localization_manager",
+  "developer",
+  "reviewer",
+  "translator",
+  "member",
+] as const satisfies readonly OrganizationMembershipRole[];
+
+type Guard = (role: OrganizationMembershipRole) => boolean;
+
+function expectRoles(guard: Guard, allowed: OrganizationMembershipRole[]) {
+  const allowedSet = new Set(allowed);
+
+  for (const role of LOCALIZATION_ROLES) {
+    expect(guard(role)).toBe(allowedSet.has(role));
+  }
+}
+
+describe("capability guards", () => {
+  it("scopes project create to operators and developers", () => {
+    expectRoles(isProjectCreateAllowed, ["admin", "localization_manager", "developer"]);
+  });
+
+  it("scopes project write to operators and developers", () => {
+    expectRoles(isProjectWriteAllowed, ["admin", "localization_manager", "developer"]);
+  });
+
+  it("scopes job create to contributor roles", () => {
+    expectRoles(isJobCreateAllowed, [
+      "admin",
+      "localization_manager",
+      "developer",
+      "reviewer",
+      "translator",
+    ]);
+  });
+
+  it("scopes job mutation to contributor roles", () => {
+    expectRoles(isJobMutationAllowed, [
+      "admin",
+      "localization_manager",
+      "developer",
+      "reviewer",
+      "translator",
+    ]);
+  });
+
+  it("scopes AI actions to contributor roles", () => {
+    expectRoles(isAiActionAllowed, [
+      "admin",
+      "localization_manager",
+      "developer",
+      "reviewer",
+      "translator",
+    ]);
+  });
+
+  it("scopes review approval to reviewers and operators", () => {
+    expectRoles(isReviewApproveAllowed, ["admin", "localization_manager", "reviewer"]);
+  });
+
+  it("scopes write-back approval to reviewers and operators", () => {
+    expectRoles(isWriteBackApproveAllowed, ["admin", "localization_manager", "reviewer"]);
+  });
+
+  it("scopes integrations read to operators and developers", () => {
+    expectRoles(isIntegrationsReadAllowed, ["admin", "localization_manager", "developer"]);
+  });
+
+  it("scopes provider credential read to operators only", () => {
+    expectRoles(isProviderCredentialReadAllowed, ["admin", "localization_manager"]);
+  });
+
+  describe("isJobProviderActionAllowed", () => {
+    it("requires write-back approval for push_approved_changes", () => {
+      expect(isJobProviderActionAllowed("translator", "push_approved_changes")).toBe(false);
+      expect(isJobProviderActionAllowed("reviewer", "push_approved_changes")).toBe(true);
+      expect(isJobProviderActionAllowed("developer", "push_approved_changes")).toBe(false);
+    });
+
+    it("requires AI execution for other provider actions", () => {
+      expect(isJobProviderActionAllowed("translator", "qa_check")).toBe(true);
+      expect(isJobProviderActionAllowed("member", "qa_check")).toBe(false);
+      expect(isJobProviderActionAllowed("reviewer", "review_with_agent")).toBe(true);
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/api/auth/capability-guards.test.ts
+++ b/apps/hyperlocalise-web/src/api/auth/capability-guards.test.ts
@@ -97,9 +97,14 @@ describe("capability guards", () => {
     });
 
     it("requires AI execution for other provider actions", () => {
-      expect(isJobProviderActionAllowed("translator", "qa_check")).toBe(true);
-      expect(isJobProviderActionAllowed("member", "qa_check")).toBe(false);
+      expect(isJobProviderActionAllowed("translator", "run_qa_checks")).toBe(true);
+      expect(isJobProviderActionAllowed("member", "run_qa_checks")).toBe(false);
       expect(isJobProviderActionAllowed("reviewer", "review_with_agent")).toBe(true);
+    });
+
+    it("denies unrecognised provider action ids", () => {
+      expect(isJobProviderActionAllowed("translator", "qa_check")).toBe(false);
+      expect(isJobProviderActionAllowed("admin", "unknown_action")).toBe(false);
     });
   });
 });

--- a/apps/hyperlocalise-web/src/api/auth/capability-guards.ts
+++ b/apps/hyperlocalise-web/src/api/auth/capability-guards.ts
@@ -1,0 +1,67 @@
+import { hasCapability, type OrganizationCapability } from "@/api/auth/policy";
+import type { OrganizationMembershipRole } from "@/lib/database/types";
+
+export function roleHasCapability(
+  role: OrganizationMembershipRole,
+  capability: OrganizationCapability,
+): boolean {
+  return hasCapability(role, capability);
+}
+
+export function isProjectCreateAllowed(role: OrganizationMembershipRole): boolean {
+  return hasCapability(role, "projects:create");
+}
+
+export function isProjectWriteAllowed(role: OrganizationMembershipRole): boolean {
+  return hasCapability(role, "projects:write");
+}
+
+/** Project metadata mutations (update, delete, sync settings). */
+export function isProjectMutationAllowed(role: OrganizationMembershipRole): boolean {
+  return isProjectWriteAllowed(role);
+}
+
+export function isJobCreateAllowed(role: OrganizationMembershipRole): boolean {
+  return hasCapability(role, "jobs:create");
+}
+
+export function isJobWriteAllowed(role: OrganizationMembershipRole): boolean {
+  return hasCapability(role, "jobs:write");
+}
+
+/** Job lifecycle mutations (retry, cancel, update). */
+export function isJobMutationAllowed(role: OrganizationMembershipRole): boolean {
+  return isJobWriteAllowed(role);
+}
+
+export function isAiActionAllowed(role: OrganizationMembershipRole): boolean {
+  return hasCapability(role, "ai_actions:run");
+}
+
+export function isReviewApproveAllowed(role: OrganizationMembershipRole): boolean {
+  return hasCapability(role, "reviews:approve");
+}
+
+export function isWriteBackApproveAllowed(role: OrganizationMembershipRole): boolean {
+  return hasCapability(role, "write_back:approve");
+}
+
+export function isIntegrationsReadAllowed(role: OrganizationMembershipRole): boolean {
+  return hasCapability(role, "integrations:read");
+}
+
+export function isProviderCredentialReadAllowed(role: OrganizationMembershipRole): boolean {
+  return hasCapability(role, "provider_credentials:read");
+}
+
+/** Provider job agent actions: write-back approval vs AI execution. */
+export function isJobProviderActionAllowed(
+  role: OrganizationMembershipRole,
+  action: string,
+): boolean {
+  if (action === "push_approved_changes") {
+    return isWriteBackApproveAllowed(role);
+  }
+
+  return isAiActionAllowed(role);
+}

--- a/apps/hyperlocalise-web/src/api/auth/capability-guards.ts
+++ b/apps/hyperlocalise-web/src/api/auth/capability-guards.ts
@@ -4,7 +4,7 @@ import { assertNever } from "@/lib/primitives/assert-never/assert-never";
 import {
   isJobProviderActionId,
   type JobProviderActionId,
-} from "@/lib/providers/job-provider-actions";
+} from "@/lib/providers/job-provider-action-ids";
 
 export function roleHasCapability(
   role: OrganizationMembershipRole,

--- a/apps/hyperlocalise-web/src/api/auth/capability-guards.ts
+++ b/apps/hyperlocalise-web/src/api/auth/capability-guards.ts
@@ -1,5 +1,10 @@
 import { hasCapability, type OrganizationCapability } from "@/api/auth/policy";
 import type { OrganizationMembershipRole } from "@/lib/database/types";
+import { assertNever } from "@/lib/primitives/assert-never/assert-never";
+import {
+  isJobProviderActionId,
+  type JobProviderActionId,
+} from "@/lib/providers/job-provider-actions";
 
 export function roleHasCapability(
   role: OrganizationMembershipRole,
@@ -54,14 +59,32 @@ export function isProviderCredentialReadAllowed(role: OrganizationMembershipRole
   return hasCapability(role, "provider_credentials:read");
 }
 
+function isKnownJobProviderActionAllowed(
+  role: OrganizationMembershipRole,
+  action: JobProviderActionId,
+): boolean {
+  switch (action) {
+    case "push_approved_changes":
+      return isWriteBackApproveAllowed(role);
+    case "translate_with_agent":
+    case "review_with_agent":
+    case "run_qa_checks":
+    case "fix_qa_issues":
+    case "leave_provider_comment":
+      return isAiActionAllowed(role);
+    default:
+      return assertNever(action);
+  }
+}
+
 /** Provider job agent actions: write-back approval vs AI execution. */
 export function isJobProviderActionAllowed(
   role: OrganizationMembershipRole,
   action: string,
 ): boolean {
-  if (action === "push_approved_changes") {
-    return isWriteBackApproveAllowed(role);
+  if (!isJobProviderActionId(action)) {
+    return false;
   }
 
-  return isAiActionAllowed(role);
+  return isKnownJobProviderActionAllowed(role, action);
 }

--- a/apps/hyperlocalise-web/src/api/auth/roles.ts
+++ b/apps/hyperlocalise-web/src/api/auth/roles.ts
@@ -1,4 +1,17 @@
 export {
+  isAiActionAllowed,
+  isIntegrationsReadAllowed,
+  isJobCreateAllowed,
+  isJobMutationAllowed,
+  isJobProviderActionAllowed,
+  isProjectCreateAllowed,
+  isProjectMutationAllowed,
+  isProjectWriteAllowed,
+  isProviderCredentialReadAllowed,
+  isReviewApproveAllowed,
+  isWriteBackApproveAllowed,
+} from "@/api/auth/capability-guards";
+export {
   getCapabilitiesForRole,
   hasCapability,
   isAdminRole,

--- a/apps/hyperlocalise-web/src/api/routes/agent-email/agent-email.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/agent-email/agent-email.route.ts
@@ -4,7 +4,9 @@ import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { validator } from "hono/validator";
 
+import { isIntegrationsReadAllowed } from "@/api/auth/capability-guards";
 import { type AuthVariables, workosAuthMiddleware } from "@/api/auth/workos";
+import { forbiddenResponse } from "@/api/response.schema";
 import { db, schema } from "@/lib/database";
 import { assertProviderCredentialAdmin } from "@/lib/providers/organization-provider-credentials";
 
@@ -121,6 +123,10 @@ export function createAgentEmailRoutes() {
   return new Hono<{ Variables: AuthVariables }>()
     .use("*", workosAuthMiddleware)
     .get("/", async (c) => {
+      if (!isIntegrationsReadAllowed(c.var.auth.membership.role)) {
+        return forbiddenResponse(c);
+      }
+
       const organizationId = c.var.auth.organization.localOrganizationId;
       let connector = await getEmailConnector(organizationId);
 

--- a/apps/hyperlocalise-web/src/api/routes/agent-email/agent-email.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/agent-email/agent-email.test.ts
@@ -159,6 +159,9 @@ describe("agentEmailRoutes", () => {
 
     expect(response.status).toBe(200);
     const body = await response.json();
+    if ("error" in body) {
+      throw new Error(String(body.error));
+    }
     expect(body.emailAgent.enabled).toBe(true);
     expect(body.emailAgent.inboundEmailAddress).toMatch(
       /^example-org-[a-f0-9-]+-[a-f0-9]{32}@inbox\.hyperlocalise\.com$/,
@@ -223,6 +226,22 @@ describe("agentEmailRoutes", () => {
     expect((connector?.config as { inboundEmailAlias?: string })?.inboundEmailAlias).toMatch(
       /^example-org-[a-f0-9-]+-[a-f0-9]{32}$/,
     );
+  });
+
+  it("blocks translators from reading the email agent configuration", async () => {
+    const identity = fixture.createWorkosIdentityWithRole("translator");
+    const organizationSlug = identity.organization.slug ?? "missing-slug";
+
+    const response = await client.api.orgs[":organizationSlug"]["agent-email"].$get(
+      {
+        param: { organizationSlug },
+      },
+      {
+        headers: await fixture.authHeadersFor(identity),
+      },
+    );
+
+    expect(response.status).toBe(403);
   });
 
   it("blocks org members from updating the email agent", async () => {

--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
@@ -4,6 +4,13 @@ import { and, desc, eq, or } from "drizzle-orm";
 import { Hono } from "hono";
 import { validator } from "hono/validator";
 
+import {
+  isAiActionAllowed,
+  isJobCreateAllowed,
+  isJobMutationAllowed,
+  isJobProviderActionAllowed,
+  isReviewApproveAllowed,
+} from "@/api/auth/capability-guards";
 import { buildAccessibleJobsWhere } from "@/api/auth/team-access";
 import { workosAuthMiddleware, type ApiAuthContext, type AuthVariables } from "@/api/auth/workos";
 import {
@@ -35,12 +42,7 @@ import type {
   TranslationJobEventData,
 } from "@/lib/workflow/types";
 
-import {
-  forbiddenResponse,
-  getOwnedProject,
-  isProjectMutationAllowed,
-  projectNotFoundResponse,
-} from "./project.shared";
+import { forbiddenResponse, getOwnedProject, projectNotFoundResponse } from "./project.shared";
 import {
   applyAgentRunProposalReviewUpdates,
   applyBulkAgentRunProposalReview,
@@ -388,7 +390,7 @@ export function createJobRoutes(options: CreateJobRoutesOptions) {
       return c.json({ jobs }, 200);
     })
     .post("/", validateProjectParams, validateCreateJobBody, async (c) => {
-      if (!isProjectMutationAllowed(c.var.auth.membership.role)) {
+      if (!isJobCreateAllowed(c.var.auth.membership.role)) {
         return forbiddenResponse(c);
       }
 
@@ -674,7 +676,7 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
       validateWorkspaceAgentRunParams,
       validateUpdateAgentRunProposalReviewBody,
       async (c) => {
-        if (!isProjectMutationAllowed(c.var.auth.membership.role)) {
+        if (!isReviewApproveAllowed(c.var.auth.membership.role)) {
           return forbiddenResponse(c);
         }
 
@@ -849,12 +851,13 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
       validateWorkspaceJobParams,
       validateCreateJobAgentRunBody,
       async (c) => {
-        if (!isProjectMutationAllowed(c.var.auth.membership.role)) {
+        const params = c.req.valid("param");
+        const payload = c.req.valid("json");
+
+        if (!isJobProviderActionAllowed(c.var.auth.membership.role, payload.action)) {
           return forbiddenResponse(c);
         }
 
-        const params = c.req.valid("param");
-        const payload = c.req.valid("json");
         const organizationId = c.var.auth.organization.localOrganizationId;
 
         const [job] = await db
@@ -1012,7 +1015,7 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
       },
     )
     .post("/:jobId/qa", validateWorkspaceJobParams, async (c) => {
-      if (!isProjectMutationAllowed(c.var.auth.membership.role)) {
+      if (!isAiActionAllowed(c.var.auth.membership.role)) {
         return forbiddenResponse(c);
       }
 
@@ -1098,7 +1101,7 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
       }
     })
     .post("/:jobId/retry", validateWorkspaceJobParams, async (c) => {
-      if (!isProjectMutationAllowed(c.var.auth.membership.role)) {
+      if (!isJobMutationAllowed(c.var.auth.membership.role)) {
         return forbiddenResponse(c);
       }
 
@@ -1222,7 +1225,7 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
       return c.json({ job: updatedJob }, 200);
     })
     .post("/:jobId/mark-failed", validateWorkspaceJobParams, async (c) => {
-      if (!isProjectMutationAllowed(c.var.auth.membership.role)) {
+      if (!isJobMutationAllowed(c.var.auth.membership.role)) {
         return forbiddenResponse(c);
       }
 

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -77,6 +77,7 @@ import {
   forbiddenResponse,
   getOwnedProject,
   invalidProjectPayloadResponse,
+  isProjectCreateAllowed,
   isProjectMutationAllowed,
   ownedProjectWhere,
   projectNotFoundResponse,
@@ -362,7 +363,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
       return c.json({ projects: projectsWithJobCounts }, 200);
     })
     .post("/", validateCreateProjectBody, async (c) => {
-      if (!isProjectMutationAllowed(c.var.auth.membership.role)) {
+      if (!isProjectCreateAllowed(c.var.auth.membership.role)) {
         return forbiddenResponse(c);
       }
 

--- a/apps/hyperlocalise-web/src/api/routes/project/project.shared.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.shared.ts
@@ -8,7 +8,6 @@ import {
   validationErrorResponse,
   type JsonContext,
 } from "@/api/errors";
-import { hasCapability } from "@/api/auth/policy";
 import type { ApiAuthContext } from "@/api/auth/workos";
 import { db, schema } from "@/lib/database";
 
@@ -26,9 +25,11 @@ export function forbiddenResponse(c: { json: JsonContext["json"] }) {
   return sharedForbiddenResponse(c, "forbidden", "Insufficient permissions");
 }
 
-export function isProjectMutationAllowed(role: ApiAuthContext["membership"]["role"]) {
-  return hasCapability(role, "projects:write");
-}
+export {
+  isProjectCreateAllowed,
+  isProjectMutationAllowed,
+  isProjectWriteAllowed,
+} from "@/api/auth/capability-guards";
 
 export async function ownedProjectWhere(auth: ApiAuthContext, projectId: string) {
   return teamOwnedProjectWhere(auth, projectId);

--- a/apps/hyperlocalise-web/src/api/routes/provider-credential/provider-credential.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/provider-credential/provider-credential.test.ts
@@ -91,6 +91,36 @@ describe("providerCredentialRoutes", () => {
     });
   });
 
+  it("allows localization managers to manage provider credentials", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(JSON.stringify({ ok: true }), { status: 200 })),
+    );
+
+    const identity = fixture.createWorkosIdentityWithRole("localization_manager");
+    const response = await fixture.upsertProviderCredentialViaApi(identity, {
+      provider: "openai",
+      apiKey: "sk-manager-key",
+      defaultModel: "gpt-4.1-mini",
+    });
+
+    expect(response.status).toBe(200);
+  });
+
+  it("blocks translators from managing provider credentials", async () => {
+    const identity = fixture.createWorkosIdentityWithRole("translator");
+    const response = await fixture.upsertProviderCredentialViaApi(identity, {
+      provider: "openai",
+      apiKey: "sk-translator-key",
+      defaultModel: "gpt-4.1-mini",
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: "forbidden",
+    });
+  });
+
   it("blocks org members from reading provider credential summaries", async () => {
     const ownerIdentity = fixture.createWorkosIdentity();
     const memberIdentity = fixture.createWorkosIdentityForOrganization(

--- a/apps/hyperlocalise-web/src/api/routes/tms-agent-automation/tms-agent-automation.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/tms-agent-automation/tms-agent-automation.route.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { validator } from "hono/validator";
 
+import { isIntegrationsReadAllowed } from "@/api/auth/capability-guards";
 import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
 import { badRequestResponse, forbiddenResponse } from "@/api/response.schema";
 import {
@@ -79,6 +80,10 @@ export function createTmsAgentAutomationRoutes() {
   return new Hono<{ Variables: AuthVariables }>()
     .use("*", workosAuthMiddleware)
     .get("/organization", async (c) => {
+      if (!isIntegrationsReadAllowed(c.var.auth.membership.role)) {
+        return forbiddenResponse(c);
+      }
+
       const record = await getTmsAgentAutomationSettingsForScope({
         organizationId: c.var.auth.organization.localOrganizationId,
         scope: "organization",

--- a/apps/hyperlocalise-web/src/api/routes/tms-dashboard-summary/tms-dashboard-summary.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/tms-dashboard-summary/tms-dashboard-summary.route.ts
@@ -1,13 +1,18 @@
 import { Hono } from "hono";
 
+import { isIntegrationsReadAllowed } from "@/api/auth/capability-guards";
 import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
-import { internalErrorResponse } from "@/api/response.schema";
+import { forbiddenResponse, internalErrorResponse } from "@/api/response.schema";
 import { getOrganizationTmsDashboardSummary } from "@/lib/providers/organization-tms-dashboard-summary";
 
 export function createTmsDashboardSummaryRoutes() {
   return new Hono<{ Variables: AuthVariables }>()
     .use("*", workosAuthMiddleware)
     .get("/", async (c) => {
+      if (!isIntegrationsReadAllowed(c.var.auth.membership.role)) {
+        return forbiddenResponse(c);
+      }
+
       try {
         const tmsDashboardSummary = await getOrganizationTmsDashboardSummary(
           c.var.auth.organization.localOrganizationId,

--- a/apps/hyperlocalise-web/src/api/routes/tms-dashboard-summary/tms-dashboard-summary.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/tms-dashboard-summary/tms-dashboard-summary.test.ts
@@ -86,4 +86,32 @@ describe("tmsDashboardSummaryRoutes", () => {
     expect(body.tmsDashboardSummary.providers).toHaveLength(1);
     expect(body.tmsDashboardSummary.providers[0]?.providerKind).toBe("crowdin");
   });
+
+  it("allows developers to read the TMS dashboard summary", async () => {
+    const identity = fixture.createWorkosIdentityWithRole("developer");
+    const headers = await fixture.authHeadersFor(identity);
+
+    const response = await client.api.orgs[":organizationSlug"]["tms-dashboard-summary"].$get(
+      {
+        param: { organizationSlug: identity.organization.slug ?? "missing" },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(200);
+  });
+
+  it("blocks translators from reading the TMS dashboard summary", async () => {
+    const identity = fixture.createWorkosIdentityWithRole("translator");
+    const headers = await fixture.authHeadersFor(identity);
+
+    const response = await client.api.orgs[":organizationSlug"]["tms-dashboard-summary"].$get(
+      {
+        param: { organizationSlug: identity.organization.slug ?? "missing" },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(403);
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/agent-contracts/write-gate.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-contracts/write-gate.ts
@@ -62,14 +62,16 @@ function checkSlackWriteGate(
 }
 
 function checkVerifiedMemberWriteGate(actor: RepositoryAgentActor): WriteGateResult {
-  const isMember = actor.role === "admin" || actor.role === "member";
-  if (isMember) {
+  if (
+    actor.role &&
+    (hasCapability(actor.role, "jobs:write") || hasCapability(actor.role, "write_back:translation"))
+  ) {
     return { allowed: true };
   }
 
   return {
     allowed: false,
-    reason: "Write actions require a verified workspace member.",
+    reason: "Write actions require a verified workspace member with job access.",
   };
 }
 

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/translation-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/translation-tools.ts
@@ -5,7 +5,7 @@ import { tool } from "ai";
 import { z } from "zod";
 
 import { schema } from "@/lib/database";
-import { hasCapability } from "@/api/auth/policy";
+import { isJobCreateAllowed } from "@/api/auth/capability-guards";
 import {
   ensureRepositorySourceFileVersionForStoredFile,
   getStoredFileForJobScope,
@@ -335,11 +335,10 @@ async function prepareTranslationJobInput(
   ctx: ToolContext,
   input: CreateTranslationJobInput,
 ): Promise<Result<PreparedTranslationJobInput, CreateTranslationJobToolError>> {
-  if (!hasCapability(ctx.membershipRole, "projects:write")) {
+  if (!isJobCreateAllowed(ctx.membershipRole)) {
     return err({
       code: "translation_job_permission_denied",
-      message:
-        "You do not have permission to create translation jobs. Only organization admins can perform this action.",
+      message: "You do not have permission to create translation jobs.",
     });
   }
 

--- a/apps/hyperlocalise-web/src/lib/agents/repository-write-gate.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/repository-write-gate.test.ts
@@ -134,15 +134,25 @@ describe("checkRepositoryWriteGate", () => {
     expect(result.allowed).toBe(true);
   });
 
-  it("treats chat_ui like Slack for permission checks", () => {
-    const result = checkRepositoryWriteGate({
+  it("uses contributor capabilities for chat_ui instead of Slack admin checks", () => {
+    const denied = checkRepositoryWriteGate({
       workMode: "write",
       source: "chat_ui",
       actor: { sourceUserId: "user_1", role: "member" },
       action: "apply_fixes",
     });
 
-    expect(result.allowed).toBe(true);
+    expect(denied.allowed).toBe(false);
+    expect(deniedReason(denied)).toContain("job access");
+
+    const allowed = checkRepositoryWriteGate({
+      workMode: "write",
+      source: "chat_ui",
+      actor: { sourceUserId: "user_1", role: "translator" },
+      action: "apply_fixes",
+    });
+
+    expect(allowed.allowed).toBe(true);
   });
 });
 

--- a/apps/hyperlocalise-web/src/lib/providers/job-provider-action-ids.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/job-provider-action-ids.ts
@@ -1,0 +1,21 @@
+/** Known provider job agent action ids (workflow-safe; no provider adapter imports). */
+export type JobProviderActionId =
+  | "translate_with_agent"
+  | "review_with_agent"
+  | "run_qa_checks"
+  | "fix_qa_issues"
+  | "leave_provider_comment"
+  | "push_approved_changes";
+
+const jobProviderActionIds = new Set<JobProviderActionId>([
+  "translate_with_agent",
+  "review_with_agent",
+  "run_qa_checks",
+  "fix_qa_issues",
+  "leave_provider_comment",
+  "push_approved_changes",
+]);
+
+export function isJobProviderActionId(value: string): value is JobProviderActionId {
+  return jobProviderActionIds.has(value as JobProviderActionId);
+}

--- a/apps/hyperlocalise-web/src/lib/providers/job-provider-actions.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/job-provider-actions.ts
@@ -146,6 +146,14 @@ export function getJobProviderActionAvailability(providerKind: string) {
   );
 }
 
+const jobProviderActionIds = new Set(
+  jobProviderActionDefinitions.map((definition) => definition.id),
+);
+
+export function isJobProviderActionId(value: string): value is JobProviderActionId {
+  return jobProviderActionIds.has(value as JobProviderActionId);
+}
+
 export function getJobProviderActionDefinition(actionId: JobProviderActionId) {
   return jobProviderActionDefinitions.find((action) => action.id === actionId) ?? null;
 }

--- a/apps/hyperlocalise-web/src/lib/providers/job-provider-actions.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/job-provider-actions.ts
@@ -6,14 +6,10 @@ import {
   type TmsProviderCapabilityAction,
 } from "./tms-capabilities";
 import type { ExternalTmsProviderKind } from "./organization-external-tms-provider-credentials";
+import type { JobProviderActionId } from "./job-provider-action-ids";
 
-export type JobProviderActionId =
-  | "translate_with_agent"
-  | "review_with_agent"
-  | "run_qa_checks"
-  | "fix_qa_issues"
-  | "leave_provider_comment"
-  | "push_approved_changes";
+export type { JobProviderActionId } from "./job-provider-action-ids";
+export { isJobProviderActionId } from "./job-provider-action-ids";
 
 export type JobProviderActionDefinition = {
   id: JobProviderActionId;
@@ -144,14 +140,6 @@ export function getJobProviderActionAvailability(providerKind: string) {
   return jobProviderActionDefinitions.map((action) =>
     resolveActionAvailability(providerKind, action),
   );
-}
-
-const jobProviderActionIds = new Set(
-  jobProviderActionDefinitions.map((definition) => definition.id),
-);
-
-export function isJobProviderActionId(value: string): value is JobProviderActionId {
-  return jobProviderActionIds.has(value as JobProviderActionId);
 }
 
 export function getJobProviderActionDefinition(actionId: JobProviderActionId) {

--- a/apps/hyperlocalise-web/src/lib/workos/IDENTITY.md
+++ b/apps/hyperlocalise-web/src/lib/workos/IDENTITY.md
@@ -24,8 +24,9 @@ Hyperlocalise treats WorkOS as the authoritative source for organization members
 Role slugs and the product capability matrix:
 [`src/api/auth/LOCALIZATION_ROLES.md`](../../api/auth/LOCALIZATION_ROLES.md).
 
-Provision WorkOS environment roles (idempotent — creates missing slugs only; never
-updates name, description, or permissions on roles that already exist):
+Provision WorkOS environment roles and capability permissions (idempotent — creates
+missing slugs and permission assignments only; never removes or replaces existing
+WorkOS role configuration):
 
 ```bash
 bun run workos:setup

--- a/apps/hyperlocalise-web/src/lib/workos/run-workos-setup.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/run-workos-setup.ts
@@ -30,6 +30,21 @@ async function main() {
         `Added ${permissionResult.rolePermissionsAdded.length} missing role permission assignments`,
       );
     }
+
+    if (
+      permissionResult.permissionsCreated.length === 0 &&
+      permissionResult.rolePermissionsAdded.length === 0
+    ) {
+      console.log(
+        `WorkOS permissions unchanged (${permissionResult.permissionsUnchanged.length}): ${permissionResult.permissionsUnchanged.join(", ")}`,
+      );
+    }
+
+    if (permissionResult.rolesSkipped.length > 0) {
+      console.log(
+        `Skipped WorkOS role permission sync for missing environment roles: ${permissionResult.rolesSkipped.join(", ")}`,
+      );
+    }
   }
 }
 

--- a/apps/hyperlocalise-web/src/lib/workos/run-workos-setup.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/run-workos-setup.ts
@@ -1,26 +1,35 @@
+import { setupWorkosLocalizationPermissions } from "@/lib/workos/setup-workos-localization-permissions";
 import { setupWorkosLocalizationRoles } from "@/lib/workos/setup-workos-localization-roles";
 
 async function main() {
-  const result = await setupWorkosLocalizationRoles();
+  const roleResult = await setupWorkosLocalizationRoles();
+  const permissionResult = await setupWorkosLocalizationPermissions();
 
-  if (result.skipped) {
+  if (roleResult.skipped && permissionResult.skipped) {
     console.log(
       "Skipped WorkOS setup: WORKOS_API_KEY is missing or set to the test placeholder. Configure a real API key in .env and retry.",
     );
     return;
   }
 
-  if (result.created.length === 0) {
+  if (roleResult.created.length > 0) {
+    console.log(`Created WorkOS environment roles: ${roleResult.created.join(", ")}`);
+  } else if (!roleResult.skipped) {
     console.log(
-      `WorkOS localization roles unchanged (${result.unchanged.length}): ${result.unchanged.join(", ")}`,
+      `WorkOS localization roles unchanged (${roleResult.unchanged.length}): ${roleResult.unchanged.join(", ")}`,
     );
-    return;
   }
 
-  console.log(`Created WorkOS environment roles: ${result.created.join(", ")}`);
+  if (!permissionResult.skipped) {
+    if (permissionResult.permissionsCreated.length > 0) {
+      console.log(`Created WorkOS permissions: ${permissionResult.permissionsCreated.join(", ")}`);
+    }
 
-  if (result.unchanged.length > 0) {
-    console.log(`Left unchanged: ${result.unchanged.join(", ")}`);
+    if (permissionResult.rolePermissionsAdded.length > 0) {
+      console.log(
+        `Added ${permissionResult.rolePermissionsAdded.length} missing role permission assignments`,
+      );
+    }
   }
 }
 

--- a/apps/hyperlocalise-web/src/lib/workos/setup-workos-localization-permissions.test.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/setup-workos-localization-permissions.test.ts
@@ -1,0 +1,153 @@
+import { ConflictException, NotFoundException } from "@workos-inc/node";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const {
+  getPermissionMock,
+  createPermissionMock,
+  getEnvironmentRoleMock,
+  addEnvironmentRolePermissionMock,
+  getWorkosServerClientMock,
+} = vi.hoisted(() => ({
+  getPermissionMock: vi.fn(),
+  createPermissionMock: vi.fn(),
+  getEnvironmentRoleMock: vi.fn(),
+  addEnvironmentRolePermissionMock: vi.fn(),
+  getWorkosServerClientMock: vi.fn(),
+}));
+
+vi.mock("@/lib/workos/server-client", () => ({
+  getWorkosServerClient: getWorkosServerClientMock,
+}));
+
+import { ORGANIZATION_CAPABILITIES } from "@/api/auth/policy";
+import { getWorkosPermissionSlugsForRole } from "@/lib/workos/workos-localization-permission-definitions";
+import { setupWorkosLocalizationPermissions } from "./setup-workos-localization-permissions";
+
+function workosNotFound() {
+  return new NotFoundException({
+    path: "/authorization/permissions/missing",
+    requestID: "req_test_not_found",
+    message: "not found",
+  });
+}
+
+function workosConflict() {
+  return new ConflictException({
+    requestID: "req_test_conflict",
+    message: "already exists",
+  });
+}
+
+describe("setupWorkosLocalizationPermissions", () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+    getPermissionMock.mockReset();
+    createPermissionMock.mockReset();
+    getEnvironmentRoleMock.mockReset();
+    addEnvironmentRolePermissionMock.mockReset();
+    getWorkosServerClientMock.mockReset();
+  });
+
+  it("skips when WorkOS is not configured", async () => {
+    vi.stubEnv("WORKOS_API_KEY", "test-workos-api-key");
+    getWorkosServerClientMock.mockReturnValue({ authorization: {} });
+
+    await expect(setupWorkosLocalizationPermissions()).resolves.toEqual({
+      permissionsCreated: [],
+      permissionsUnchanged: [],
+      rolePermissionsAdded: [],
+      skipped: true,
+    });
+
+    expect(getPermissionMock).not.toHaveBeenCalled();
+  });
+
+  it("creates only missing permissions and adds missing role assignments", async () => {
+    vi.stubEnv("WORKOS_API_KEY", "sk_test_real");
+    const existingPermissions = new Set(["workspace:read", "projects:read"]);
+    getPermissionMock.mockImplementation(async (slug: string) => {
+      if (existingPermissions.has(slug)) {
+        return { slug };
+      }
+
+      throw workosNotFound();
+    });
+    createPermissionMock.mockResolvedValue({});
+    getEnvironmentRoleMock.mockImplementation(async (slug: string) => ({
+      slug,
+      permissions: slug === "translator" ? ["workspace:read", "jobs:read"] : ["workspace:read"],
+    }));
+    addEnvironmentRolePermissionMock.mockResolvedValue({});
+    getWorkosServerClientMock.mockReturnValue({
+      authorization: {
+        getPermission: getPermissionMock,
+        createPermission: createPermissionMock,
+        getEnvironmentRole: getEnvironmentRoleMock,
+        addEnvironmentRolePermission: addEnvironmentRolePermissionMock,
+      },
+    });
+
+    const result = await setupWorkosLocalizationPermissions();
+
+    expect(result.skipped).toBe(false);
+    expect(result.permissionsCreated.length).toBe(
+      ORGANIZATION_CAPABILITIES.length - existingPermissions.size,
+    );
+    expect(result.permissionsUnchanged).toEqual(expect.arrayContaining([...existingPermissions]));
+    expect(addEnvironmentRolePermissionMock).toHaveBeenCalled();
+    expect(
+      addEnvironmentRolePermissionMock.mock.calls.some(
+        (call) =>
+          call[0] === "translator" &&
+          (call[1] as { permissionSlug: string }).permissionSlug === "jobs:create",
+      ),
+    ).toBe(true);
+  });
+
+  it("is idempotent when permissions and role assignments already exist", async () => {
+    vi.stubEnv("WORKOS_API_KEY", "sk_test_real");
+    getPermissionMock.mockResolvedValue({ slug: "workspace:read" });
+    getEnvironmentRoleMock.mockImplementation(async (slug: string) => ({
+      slug,
+      permissions: getWorkosPermissionSlugsForRole(
+        slug as Parameters<typeof getWorkosPermissionSlugsForRole>[0],
+      ),
+    }));
+    getWorkosServerClientMock.mockReturnValue({
+      authorization: {
+        getPermission: getPermissionMock,
+        createPermission: createPermissionMock,
+        getEnvironmentRole: getEnvironmentRoleMock,
+        addEnvironmentRolePermission: addEnvironmentRolePermissionMock,
+      },
+    });
+
+    const result = await setupWorkosLocalizationPermissions();
+
+    expect(result.permissionsCreated).toEqual([]);
+    expect(result.rolePermissionsAdded).toEqual([]);
+    expect(createPermissionMock).not.toHaveBeenCalled();
+    expect(addEnvironmentRolePermissionMock).not.toHaveBeenCalled();
+  });
+
+  it("treats create permission conflicts as unchanged", async () => {
+    vi.stubEnv("WORKOS_API_KEY", "sk_test_real");
+    getPermissionMock.mockRejectedValue(workosNotFound());
+    createPermissionMock.mockRejectedValue(workosConflict());
+    getEnvironmentRoleMock.mockResolvedValue({ slug: "member", permissions: [] });
+    addEnvironmentRolePermissionMock.mockResolvedValue({});
+    getWorkosServerClientMock.mockReturnValue({
+      authorization: {
+        getPermission: getPermissionMock,
+        createPermission: createPermissionMock,
+        getEnvironmentRole: getEnvironmentRoleMock,
+        addEnvironmentRolePermission: addEnvironmentRolePermissionMock,
+      },
+    });
+
+    const result = await setupWorkosLocalizationPermissions();
+
+    expect(result.permissionsCreated).toEqual([]);
+    expect(result.permissionsUnchanged).toEqual([...ORGANIZATION_CAPABILITIES]);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/workos/setup-workos-localization-permissions.test.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/setup-workos-localization-permissions.test.ts
@@ -56,6 +56,7 @@ describe("setupWorkosLocalizationPermissions", () => {
       permissionsCreated: [],
       permissionsUnchanged: [],
       rolePermissionsAdded: [],
+      rolesSkipped: [],
       skipped: true,
     });
 
@@ -126,8 +127,39 @@ describe("setupWorkosLocalizationPermissions", () => {
 
     expect(result.permissionsCreated).toEqual([]);
     expect(result.rolePermissionsAdded).toEqual([]);
+    expect(result.rolesSkipped).toEqual([]);
     expect(createPermissionMock).not.toHaveBeenCalled();
     expect(addEnvironmentRolePermissionMock).not.toHaveBeenCalled();
+  });
+
+  it("skips missing environment roles and continues syncing other roles", async () => {
+    vi.stubEnv("WORKOS_API_KEY", "sk_test_real");
+    getPermissionMock.mockResolvedValue({ slug: "workspace:read" });
+    getEnvironmentRoleMock.mockImplementation(async (slug: string) => {
+      if (slug === "translator") {
+        throw workosNotFound();
+      }
+
+      return { slug, permissions: ["workspace:read"] };
+    });
+    addEnvironmentRolePermissionMock.mockResolvedValue({});
+    getWorkosServerClientMock.mockReturnValue({
+      authorization: {
+        getPermission: getPermissionMock,
+        createPermission: createPermissionMock,
+        getEnvironmentRole: getEnvironmentRoleMock,
+        addEnvironmentRolePermission: addEnvironmentRolePermissionMock,
+      },
+    });
+
+    const result = await setupWorkosLocalizationPermissions();
+
+    expect(result.rolesSkipped).toEqual(["translator"]);
+    expect(addEnvironmentRolePermissionMock).not.toHaveBeenCalledWith(
+      "translator",
+      expect.anything(),
+    );
+    expect(addEnvironmentRolePermissionMock).toHaveBeenCalled();
   });
 
   it("treats create permission conflicts as unchanged", async () => {

--- a/apps/hyperlocalise-web/src/lib/workos/setup-workos-localization-permissions.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/setup-workos-localization-permissions.ts
@@ -13,6 +13,8 @@ export type SetupWorkosLocalizationPermissionsResult = {
   permissionsCreated: string[];
   permissionsUnchanged: string[];
   rolePermissionsAdded: Array<{ roleSlug: string; permissionSlug: string }>;
+  /** Environment roles missing in WorkOS; permission sync was skipped for these slugs. */
+  rolesSkipped: string[];
   skipped: boolean;
 };
 
@@ -70,11 +72,31 @@ async function ensurePermissions(workos: NonNullable<ReturnType<typeof getWorkos
   return { permissionsCreated, permissionsUnchanged };
 }
 
+async function environmentRoleExists(
+  workos: NonNullable<ReturnType<typeof getWorkosServerClient>>,
+  slug: string,
+) {
+  try {
+    await workos.authorization.getEnvironmentRole(slug);
+    return true;
+  } catch (error) {
+    if (error instanceof NotFoundException) {
+      return false;
+    }
+
+    throw error;
+  }
+}
+
 async function syncRolePermissions(
   workos: NonNullable<ReturnType<typeof getWorkosServerClient>>,
   role: OrganizationMembershipRole,
 ) {
   const roleSlug = WORKOS_ROLE_SLUG_BY_MEMBERSHIP_ROLE[role];
+  if (!(await environmentRoleExists(workos, roleSlug))) {
+    return { rolePermissionsAdded: [], roleSkipped: roleSlug };
+  }
+
   const environmentRole = await workos.authorization.getEnvironmentRole(roleSlug);
   const assigned = new Set(environmentRole.permissions ?? []);
   const expected = getWorkosPermissionSlugsForRole(role);
@@ -91,7 +113,7 @@ async function syncRolePermissions(
     rolePermissionsAdded.push({ roleSlug, permissionSlug });
   }
 
-  return rolePermissionsAdded;
+  return { rolePermissionsAdded, roleSkipped: null as string | null };
 }
 
 /**
@@ -107,22 +129,31 @@ export async function setupWorkosLocalizationPermissions(): Promise<SetupWorkosL
       permissionsCreated: [],
       permissionsUnchanged: [],
       rolePermissionsAdded: [],
+      rolesSkipped: [],
       skipped: true,
     };
   }
 
   const { permissionsCreated, permissionsUnchanged } = await ensurePermissions(workos);
   const rolePermissionsAdded: Array<{ roleSlug: string; permissionSlug: string }> = [];
+  const rolesSkipped: string[] = [];
 
   for (const definition of WORKOS_LOCALIZATION_ROLE_DEFINITIONS) {
-    const added = await syncRolePermissions(workos, definition.slug as OrganizationMembershipRole);
+    const { rolePermissionsAdded: added, roleSkipped } = await syncRolePermissions(
+      workos,
+      definition.slug as OrganizationMembershipRole,
+    );
     rolePermissionsAdded.push(...added);
+    if (roleSkipped) {
+      rolesSkipped.push(roleSkipped);
+    }
   }
 
   return {
     permissionsCreated,
     permissionsUnchanged,
     rolePermissionsAdded,
+    rolesSkipped,
     skipped: false,
   };
 }

--- a/apps/hyperlocalise-web/src/lib/workos/setup-workos-localization-permissions.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/setup-workos-localization-permissions.ts
@@ -1,0 +1,128 @@
+import { ConflictException, NotFoundException } from "@workos-inc/node";
+
+import type { OrganizationMembershipRole } from "@/lib/database/types";
+import { WORKOS_ROLE_SLUG_BY_MEMBERSHIP_ROLE } from "@/lib/workos/localization-role-slugs";
+import { getWorkosServerClient } from "@/lib/workos/server-client";
+import {
+  getWorkosPermissionSlugsForRole,
+  WORKOS_LOCALIZATION_PERMISSION_DEFINITIONS,
+} from "@/lib/workos/workos-localization-permission-definitions";
+import { WORKOS_LOCALIZATION_ROLE_DEFINITIONS } from "@/lib/workos/workos-localization-role-definitions";
+
+export type SetupWorkosLocalizationPermissionsResult = {
+  permissionsCreated: string[];
+  permissionsUnchanged: string[];
+  rolePermissionsAdded: Array<{ roleSlug: string; permissionSlug: string }>;
+  skipped: boolean;
+};
+
+function isWorkosSetupEnabled(apiKey: string | undefined) {
+  if (!apiKey || apiKey === "test-workos-api-key") {
+    return false;
+  }
+
+  return !apiKey.includes("placeholder");
+}
+
+async function permissionExists(
+  workos: NonNullable<ReturnType<typeof getWorkosServerClient>>,
+  slug: string,
+) {
+  try {
+    await workos.authorization.getPermission(slug);
+    return true;
+  } catch (error) {
+    if (error instanceof NotFoundException) {
+      return false;
+    }
+
+    throw error;
+  }
+}
+
+async function ensurePermissions(workos: NonNullable<ReturnType<typeof getWorkosServerClient>>) {
+  const permissionsCreated: string[] = [];
+  const permissionsUnchanged: string[] = [];
+
+  for (const definition of WORKOS_LOCALIZATION_PERMISSION_DEFINITIONS) {
+    if (await permissionExists(workos, definition.slug)) {
+      permissionsUnchanged.push(definition.slug);
+      continue;
+    }
+
+    try {
+      await workos.authorization.createPermission({
+        slug: definition.slug,
+        name: definition.name,
+        description: definition.description,
+      });
+      permissionsCreated.push(definition.slug);
+    } catch (error) {
+      if (error instanceof ConflictException) {
+        permissionsUnchanged.push(definition.slug);
+        continue;
+      }
+
+      throw error;
+    }
+  }
+
+  return { permissionsCreated, permissionsUnchanged };
+}
+
+async function syncRolePermissions(
+  workos: NonNullable<ReturnType<typeof getWorkosServerClient>>,
+  role: OrganizationMembershipRole,
+) {
+  const roleSlug = WORKOS_ROLE_SLUG_BY_MEMBERSHIP_ROLE[role];
+  const environmentRole = await workos.authorization.getEnvironmentRole(roleSlug);
+  const assigned = new Set(environmentRole.permissions ?? []);
+  const expected = getWorkosPermissionSlugsForRole(role);
+  const rolePermissionsAdded: Array<{ roleSlug: string; permissionSlug: string }> = [];
+
+  for (const permissionSlug of expected) {
+    if (assigned.has(permissionSlug)) {
+      continue;
+    }
+
+    await workos.authorization.addEnvironmentRolePermission(roleSlug, {
+      permissionSlug,
+    });
+    rolePermissionsAdded.push({ roleSlug, permissionSlug });
+  }
+
+  return rolePermissionsAdded;
+}
+
+/**
+ * Ensures Hyperlocalise capability permissions exist in WorkOS and attaches any
+ * missing permissions to localization environment roles (additive only).
+ */
+export async function setupWorkosLocalizationPermissions(): Promise<SetupWorkosLocalizationPermissionsResult> {
+  const workos = getWorkosServerClient();
+  const apiKey = process.env.WORKOS_API_KEY;
+
+  if (!workos || !isWorkosSetupEnabled(apiKey)) {
+    return {
+      permissionsCreated: [],
+      permissionsUnchanged: [],
+      rolePermissionsAdded: [],
+      skipped: true,
+    };
+  }
+
+  const { permissionsCreated, permissionsUnchanged } = await ensurePermissions(workos);
+  const rolePermissionsAdded: Array<{ roleSlug: string; permissionSlug: string }> = [];
+
+  for (const definition of WORKOS_LOCALIZATION_ROLE_DEFINITIONS) {
+    const added = await syncRolePermissions(workos, definition.slug as OrganizationMembershipRole);
+    rolePermissionsAdded.push(...added);
+  }
+
+  return {
+    permissionsCreated,
+    permissionsUnchanged,
+    rolePermissionsAdded,
+    skipped: false,
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/workos/workos-localization-permission-definitions.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/workos-localization-permission-definitions.ts
@@ -1,0 +1,38 @@
+import {
+  getCapabilitiesForRole,
+  ORGANIZATION_CAPABILITIES,
+  type OrganizationCapability,
+} from "@/api/auth/policy";
+import type { OrganizationMembershipRole } from "@/lib/database/types";
+
+export type WorkosLocalizationPermissionDefinition = {
+  slug: OrganizationCapability;
+  name: string;
+  description: string;
+};
+
+function humanizeCapabilitySlug(slug: OrganizationCapability): string {
+  return slug
+    .split(":")
+    .map((segment) =>
+      segment
+        .split("_")
+        .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(" "),
+    )
+    .join(" — ");
+}
+
+/** WorkOS permission slugs mirror `OrganizationCapability` values in policy.ts. */
+export const WORKOS_LOCALIZATION_PERMISSION_DEFINITIONS: WorkosLocalizationPermissionDefinition[] =
+  ORGANIZATION_CAPABILITIES.map((slug) => ({
+    slug,
+    name: humanizeCapabilitySlug(slug),
+    description: `Hyperlocalise capability: ${slug}`,
+  }));
+
+export function getWorkosPermissionSlugsForRole(
+  role: OrganizationMembershipRole,
+): OrganizationCapability[] {
+  return getCapabilitiesForRole(role);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements HL-427 server-side enforcement of the WorkOS-backed capability matrix across organization, project, job, and integration APIs.

## Changes

- **Capability guards** (`capability-guards.ts`): granular helpers for project/job mutations, review approval, write-back approval, integrations read, and provider job actions.
- **API routes**: job routes use `jobs:*`, `reviews:approve`, and `write_back:approve` instead of `projects:write`; TMS dashboard, agent email GET, and TMS agent automation org endpoints require `integrations:read`.
- **WorkOS setup**: `setupWorkosLocalizationPermissions()` creates capability permissions in WorkOS and additively attaches missing permissions to localization environment roles; invoked from `workos:setup` after role provisioning.
- **Agent write gate**: repository/chat UI writes require `jobs:write` or `write_back:translation` (contributor roles), not read-only `member`.
- **Tests**: capability guard matrix tests, WorkOS permission setup tests, and route-level deny/allow coverage for translator vs admin/manager on credentials, integrations, and email agent.

## Acceptance criteria

| Criterion | Status |
|-----------|--------|
| Contractor/translator users cannot access admin APIs | Enforced via capability checks on credentials, integrations, members (existing + extended tests) |
| Provider credential and webhook management require admin/localization-manager | `provider_credentials:write` unchanged; tests added for manager allow / translator deny |
| Job review and write-back enforce reviewer/manager policy | `reviews:approve` and `write_back:approve` on job routes |
| Tests cover allowed/denied paths for localization roles | `capability-guards.test.ts` + route tests |
| Existing owner/admin flows via mapped capabilities | Admin/localization_manager unchanged in policy |

## Not in scope

- UI disabled/hidden capability metadata (deferred per issue until server enforcement landed)
- Runtime reads of WorkOS permission APIs (enforcement remains in-app via `policy.ts`)

## Verification

- `vp check --fix`
- `vp test` (1612 tests passed)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HL-427](https://linear.app/hyperlocalise/issue/HL-427/enforce-scoped-workos-rbac-across-org-project-job-and-provider-apis)

<div><a href="https://cursor.com/agents/bc-d34aaf13-bcd7-4e91-8777-694bdca80541"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d34aaf13-bcd7-4e91-8777-694bdca80541"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

