### PR TITLE
feat(web): native project locale setup and TMS job validation

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/file/file.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/file/file.route.test.ts
@@ -147,6 +147,8 @@ describe("file download route", () => {
         json: {
           name: "Beta Project",
           teamId: teamBetaBody.team.id,
+          sourceLocale: "en-US",
+          targetLocales: ["fr-FR"],
         },
       },
       { headers: await authHeadersFor(admin) },
@@ -210,6 +212,8 @@ describe("file download route", () => {
         json: {
           name: "Team Files Project",
           teamId: teamBody.team.id,
+          sourceLocale: "en-US",
+          targetLocales: ["fr-FR"],
         },
       },
       { headers: await authHeadersFor(admin) },

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary.schema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-const localePattern = /^[a-z]{2,3}(-[A-Z]{2,3})?$/;
+import { localeInputSchema } from "@/lib/i18n/locales";
 
 export const glossaryIdParamsSchema = z.object({
   glossaryId: z.string().trim().min(1).max(128),
@@ -21,38 +21,16 @@ export const listGlossaryQuerySchema = z
 export const createGlossaryBodySchema = z.object({
   name: z.string().trim().min(1).max(200),
   description: z.string().max(10_000).optional(),
-  sourceLocale: z
-    .string()
-    .trim()
-    .min(1)
-    .max(50)
-    .regex(localePattern, "invalid locale format (e.g., en, en-US, fr-FR)"),
-  targetLocale: z
-    .string()
-    .trim()
-    .min(1)
-    .max(50)
-    .regex(localePattern, "invalid locale format (e.g., en, en-US, fr-FR)"),
+  sourceLocale: localeInputSchema,
+  targetLocale: localeInputSchema,
 });
 
 export const updateGlossaryBodySchema = z
   .object({
     name: z.string().trim().min(1).max(200).optional(),
     description: z.string().max(10_000).optional(),
-    sourceLocale: z
-      .string()
-      .trim()
-      .min(1)
-      .max(50)
-      .regex(localePattern, "invalid locale format (e.g., en, en-US, fr-FR)")
-      .optional(),
-    targetLocale: z
-      .string()
-      .trim()
-      .min(1)
-      .max(50)
-      .regex(localePattern, "invalid locale format (e.g., en, en-US, fr-FR)")
-      .optional(),
+    sourceLocale: localeInputSchema.optional(),
+    targetLocale: localeInputSchema.optional(),
   })
   .refine(
     (value) =>

--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
@@ -415,8 +415,8 @@ export function createJobRoutes(options: CreateJobRoutesOptions) {
         sourceLocale: inputPayload.sourceLocale,
         targetLocales: inputPayload.targetLocales,
       });
-      if (!localeValidation.ok) {
-        return badRequestResponse(c, localeValidation.code, localeValidation.message);
+      if (isErr(localeValidation)) {
+        return badRequestResponse(c, localeValidation.error.code, localeValidation.error.message);
       }
 
       if (payload.type === "file") {

--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
@@ -42,7 +42,14 @@ import type {
   TranslationJobEventData,
 } from "@/lib/workflow/types";
 
-import { forbiddenResponse, getOwnedProject, projectNotFoundResponse } from "./project.shared";
+import { validateJobLocalesAgainstProject } from "@/lib/i18n/project-job-locales";
+
+import {
+  forbiddenResponse,
+  getOwnedProject,
+  getOwnedProjectRecord,
+  projectNotFoundResponse,
+} from "./project.shared";
 import {
   applyAgentRunProposalReviewUpdates,
   applyBulkAgentRunProposalReview,
@@ -396,13 +403,21 @@ export function createJobRoutes(options: CreateJobRoutesOptions) {
 
       const params = c.req.valid("param");
       const payload = c.req.valid("json");
-      const project = await getOwnedProject(c.var.auth, params.projectId);
+      const project = await getOwnedProjectRecord(c.var.auth, params.projectId);
 
       if (!project) {
         return projectNotFoundResponse(c);
       }
 
       const inputPayload = payload.type === "string" ? payload.stringInput : payload.fileInput;
+
+      const localeValidation = validateJobLocalesAgainstProject(project, {
+        sourceLocale: inputPayload.sourceLocale,
+        targetLocales: inputPayload.targetLocales,
+      });
+      if (!localeValidation.ok) {
+        return badRequestResponse(c, localeValidation.code, localeValidation.message);
+      }
 
       if (payload.type === "file") {
         const sourceFile = await getStoredFileForJobScope({

--- a/apps/hyperlocalise-web/src/api/routes/project/job.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.test.ts
@@ -370,6 +370,39 @@ describe("jobRoutes", () => {
     });
   });
 
+  it("rejects job target locales outside the project scope", async () => {
+    const identity = createWorkosIdentity();
+    const projectResponse = await createProjectViaApi(identity, {
+      targetLocales: ["fr-FR"],
+    });
+    const project = ((await projectResponse.json()) as ProjectResponse).project;
+
+    const response = await client.api.orgs[":organizationSlug"].projects[":projectId"].jobs.$post(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: project.id,
+        },
+        json: {
+          type: "string",
+          stringInput: {
+            sourceText: "Hello world",
+            sourceLocale: "en-US",
+            targetLocales: ["ja-JP"],
+          },
+        },
+      },
+      {
+        headers: await authHeadersFor(identity),
+      },
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "job_target_locale_not_in_project",
+    });
+  });
+
   it("lists project jobs and applies type and status filters", async () => {
     const identity = createWorkosIdentity();
     const projectResponse = await createProjectViaApi(identity);
@@ -1131,6 +1164,8 @@ describe("jobRoutes", () => {
           name: "Marketing Site",
           description: "Primary website strings",
           translationContext: "Use a concise product-marketing tone.",
+          sourceLocale: "en-US",
+          targetLocales: ["fr-FR", "de-DE"],
         },
       },
       {

--- a/apps/hyperlocalise-web/src/api/routes/project/project-team-access.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project-team-access.test.ts
@@ -79,6 +79,8 @@ describe("team-scoped project access", () => {
         json: {
           name: "Alpha Project",
           teamId: teamAlphaBody.team.id,
+          sourceLocale: "en-US",
+          targetLocales: ["fr-FR"],
         },
       },
       { headers: await authHeadersFor(admin) },
@@ -92,6 +94,8 @@ describe("team-scoped project access", () => {
         json: {
           name: "Beta Project",
           teamId: teamBetaBody.team.id,
+          sourceLocale: "en-US",
+          targetLocales: ["de-DE"],
         },
       },
       { headers: await authHeadersFor(admin) },
@@ -137,6 +141,8 @@ describe("team-scoped project access", () => {
         json: {
           name: "Ops Project",
           teamId: teamBody.team.id,
+          sourceLocale: "en-US",
+          targetLocales: ["fr-FR"],
         },
       },
       { headers: await authHeadersFor(admin) },

--- a/apps/hyperlocalise-web/src/api/routes/project/project.fixture.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.fixture.ts
@@ -11,6 +11,8 @@ type CreateProjectInput = Partial<{
   name: string;
   description: string;
   translationContext: string;
+  sourceLocale: string;
+  targetLocales: string[];
 }>;
 
 type Client = ReturnType<typeof testClient<AppType>>;
@@ -30,6 +32,8 @@ export function createProjectTestFixture(client?: Client) {
           name: input?.name ?? "Marketing Site",
           description: input?.description ?? "Primary website strings",
           translationContext: input?.translationContext ?? "Use a concise product-marketing tone.",
+          sourceLocale: input?.sourceLocale ?? "en-US",
+          targetLocales: input?.targetLocales ?? ["fr-FR", "de-DE"],
         },
       },
       {
@@ -52,6 +56,8 @@ export function createProjectTestFixture(client?: Client) {
         name: "Docs",
         description: "",
         translationContext: "",
+        sourceLocale: "en-US",
+        targetLocales: ["fr-FR"],
       })
       .returning();
 

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -5,6 +5,7 @@ import { Hono } from "hono";
 import { validator } from "hono/validator";
 
 import { workosAuthMiddleware, type ApiAuthContext, type AuthVariables } from "@/api/auth/workos";
+import { badRequestResponse } from "@/api/errors";
 import { db, schema } from "@/lib/database";
 import type { Project } from "@/lib/database/types";
 import { getFileStorageAdapter, type FileStorageAdapter } from "@/lib/file-storage";
@@ -70,7 +71,8 @@ import {
   type UpdateProjectBody,
 } from "./project.schema";
 import { getVisibleTeamIds, hasOrganizationWideProjectAccess } from "@/api/auth/team-access";
-import { normalizeProjectLocalePatch } from "@/lib/i18n/locales";
+import { normalizeProjectLocalePatch, type ProjectLocalePatchError } from "@/lib/i18n/locales";
+import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
 import { ensureDefaultWorkspaceTeam } from "@/lib/teams/default-workspace-team";
 
 import {
@@ -85,6 +87,28 @@ import {
 } from "./project.shared";
 import { createJobRoutes } from "./job.route";
 
+type ProjectUpdateErrorCode =
+  | "invalid_project_team"
+  | "external_project_locales_readonly"
+  | ProjectLocalePatchError;
+
+type ProjectUpdateError = {
+  code: ProjectUpdateErrorCode;
+  message?: string;
+};
+
+type ProjectUpdateResult = Result<Project | null, ProjectUpdateError>;
+
+const projectLocalePatchErrorMessages: Record<
+  Exclude<ProjectUpdateErrorCode, "invalid_project_team">,
+  string
+> = {
+  external_project_locales_readonly: "External TMS project locales are read-only",
+  invalid_source_locale: "Invalid source locale",
+  invalid_target_locales: "Invalid target locales",
+  source_in_targets: "Source locale cannot also be a target locale",
+};
+
 type ProjectStore = {
   list(auth: ApiAuthContext): Promise<Project[]>;
   create(auth: ApiAuthContext, payload: CreateProjectBody): Promise<Project>;
@@ -93,7 +117,7 @@ type ProjectStore = {
     auth: ApiAuthContext,
     projectId: string,
     payload: UpdateProjectBody,
-  ): Promise<Project | null>;
+  ): Promise<ProjectUpdateResult>;
   delete(auth: ApiAuthContext, projectId: string): Promise<boolean>;
 };
 
@@ -183,10 +207,10 @@ const projectStore: ProjectStore = {
 
     return project ?? null;
   },
-  async update(auth, projectId, payload) {
+  async update(auth, projectId, payload): Promise<ProjectUpdateResult> {
     const existing = await this.getById(auth, projectId);
     if (!existing) {
-      return null;
+      return ok(null);
     }
 
     const { teamId, sourceLocale, targetLocales, ...updates } = payload;
@@ -199,7 +223,7 @@ const projectStore: ProjectStore = {
     if (teamId !== undefined) {
       const resolvedTeamId = await resolveProjectTeamId(auth, teamId);
       if (!resolvedTeamId) {
-        throw new Error("invalid_project_team");
+        return err({ code: "invalid_project_team" });
       }
 
       updateValues.teamId = resolvedTeamId;
@@ -209,7 +233,10 @@ const projectStore: ProjectStore = {
       existing.source === "external_tms" &&
       (sourceLocale !== undefined || targetLocales !== undefined)
     ) {
-      throw new Error("external_project_locales_readonly");
+      return err({
+        code: "external_project_locales_readonly",
+        message: projectLocalePatchErrorMessages.external_project_locales_readonly,
+      });
     }
 
     if (sourceLocale !== undefined || targetLocales !== undefined) {
@@ -221,7 +248,10 @@ const projectStore: ProjectStore = {
       });
 
       if ("error" in normalized) {
-        throw new Error(normalized.error);
+        return err({
+          code: normalized.error,
+          message: projectLocalePatchErrorMessages[normalized.error],
+        });
       }
 
       if (normalized.sourceLocale !== undefined) {
@@ -238,7 +268,7 @@ const projectStore: ProjectStore = {
       .where(await ownedProjectWhere(auth, projectId))
       .returning();
 
-    return project ?? null;
+    return ok(project ?? null);
   },
   async delete(auth, projectId) {
     const deletedProjects = await db
@@ -498,28 +528,16 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
 
       const params = c.req.valid("param");
       const payload = c.req.valid("json");
-      let project;
-      try {
-        project = await projectStore.update(c.var.auth, params.projectId, payload);
-      } catch (error) {
-        if (error instanceof Error) {
-          if (error.message === "invalid_project_team") {
-            return invalidProjectPayloadResponse(c);
-          }
-
-          if (
-            error.message === "external_project_locales_readonly" ||
-            error.message === "invalid_source_locale" ||
-            error.message === "invalid_target_locales" ||
-            error.message === "source_in_targets"
-          ) {
-            return invalidProjectPayloadResponse(c);
-          }
+      const updateResult = await projectStore.update(c.var.auth, params.projectId, payload);
+      if (isErr(updateResult)) {
+        if (updateResult.error.code === "invalid_project_team") {
+          return invalidProjectPayloadResponse(c);
         }
 
-        throw error;
+        return badRequestResponse(c, updateResult.error.code, updateResult.error.message);
       }
 
+      const project = updateResult.value;
       if (!project) {
         return projectNotFoundResponse(c);
       }

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -70,7 +70,7 @@ import {
   type UpdateProjectBody,
 } from "./project.schema";
 import { getVisibleTeamIds, hasOrganizationWideProjectAccess } from "@/api/auth/team-access";
-import { normalizeProjectLocales } from "@/lib/i18n/locales";
+import { normalizeProjectLocalePatch } from "@/lib/i18n/locales";
 import { ensureDefaultWorkspaceTeam } from "@/lib/teams/default-workspace-team";
 
 import {
@@ -213,17 +213,23 @@ const projectStore: ProjectStore = {
     }
 
     if (sourceLocale !== undefined || targetLocales !== undefined) {
-      const normalized = normalizeProjectLocales({
-        sourceLocale: sourceLocale ?? existing.sourceLocale ?? "",
-        targetLocales: targetLocales ?? existing.targetLocales ?? [],
+      const normalized = normalizeProjectLocalePatch({
+        existingSourceLocale: existing.sourceLocale,
+        existingTargetLocales: existing.targetLocales,
+        sourceLocale,
+        targetLocales,
       });
 
       if ("error" in normalized) {
         throw new Error(normalized.error);
       }
 
-      updateValues.sourceLocale = normalized.sourceLocale;
-      updateValues.targetLocales = normalized.targetLocales;
+      if (normalized.sourceLocale !== undefined) {
+        updateValues.sourceLocale = normalized.sourceLocale;
+      }
+      if (normalized.targetLocales !== undefined) {
+        updateValues.targetLocales = normalized.targetLocales;
+      }
     }
 
     const [project] = await db

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -70,6 +70,7 @@ import {
   type UpdateProjectBody,
 } from "./project.schema";
 import { getVisibleTeamIds, hasOrganizationWideProjectAccess } from "@/api/auth/team-access";
+import { normalizeProjectLocales } from "@/lib/i18n/locales";
 import { ensureDefaultWorkspaceTeam } from "@/lib/teams/default-workspace-team";
 
 import {
@@ -166,6 +167,8 @@ const projectStore: ProjectStore = {
         description: payload.description ?? "",
         translationContext: payload.translationContext ?? "",
         source: "native",
+        sourceLocale: payload.sourceLocale,
+        targetLocales: payload.targetLocales,
       })
       .returning();
 
@@ -181,8 +184,17 @@ const projectStore: ProjectStore = {
     return project ?? null;
   },
   async update(auth, projectId, payload) {
-    const { teamId, ...updates } = payload;
-    const updateValues: typeof updates & { teamId?: string } = { ...updates };
+    const existing = await this.getById(auth, projectId);
+    if (!existing) {
+      return null;
+    }
+
+    const { teamId, sourceLocale, targetLocales, ...updates } = payload;
+    const updateValues: typeof updates & {
+      teamId?: string;
+      sourceLocale?: string;
+      targetLocales?: string[];
+    } = { ...updates };
 
     if (teamId !== undefined) {
       const resolvedTeamId = await resolveProjectTeamId(auth, teamId);
@@ -191,6 +203,27 @@ const projectStore: ProjectStore = {
       }
 
       updateValues.teamId = resolvedTeamId;
+    }
+
+    if (
+      existing.source === "external_tms" &&
+      (sourceLocale !== undefined || targetLocales !== undefined)
+    ) {
+      throw new Error("external_project_locales_readonly");
+    }
+
+    if (sourceLocale !== undefined || targetLocales !== undefined) {
+      const normalized = normalizeProjectLocales({
+        sourceLocale: sourceLocale ?? existing.sourceLocale ?? "",
+        targetLocales: targetLocales ?? existing.targetLocales ?? [],
+      });
+
+      if ("error" in normalized) {
+        throw new Error(normalized.error);
+      }
+
+      updateValues.sourceLocale = normalized.sourceLocale;
+      updateValues.targetLocales = normalized.targetLocales;
     }
 
     const [project] = await db
@@ -463,8 +496,19 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
       try {
         project = await projectStore.update(c.var.auth, params.projectId, payload);
       } catch (error) {
-        if (error instanceof Error && error.message === "invalid_project_team") {
-          return invalidProjectPayloadResponse(c);
+        if (error instanceof Error) {
+          if (error.message === "invalid_project_team") {
+            return invalidProjectPayloadResponse(c);
+          }
+
+          if (
+            error.message === "external_project_locales_readonly" ||
+            error.message === "invalid_source_locale" ||
+            error.message === "invalid_target_locales" ||
+            error.message === "source_in_targets"
+          ) {
+            return invalidProjectPayloadResponse(c);
+          }
         }
 
         throw error;

--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -1,5 +1,11 @@
 import { z } from "zod";
 
+import {
+  localeInputSchema,
+  maxProjectTargetLocales,
+  projectTargetLocalesSchema,
+} from "@/lib/i18n/locales";
+
 export const projectIdParamsSchema = z.object({
   projectId: z.string().trim().min(1).max(128),
 });
@@ -31,12 +37,25 @@ export const externalTmsTranslationPushBodySchema = z.object({
     .max(1000),
 });
 
-export const createProjectBodySchema = z.object({
-  name: z.string().trim().min(1).max(200),
-  description: z.string().max(10_000).optional(),
-  translationContext: z.string().max(20_000).optional(),
-  teamId: z.string().uuid().optional(),
-});
+export const createProjectBodySchema = z
+  .object({
+    name: z.string().trim().min(1).max(200),
+    description: z.string().max(10_000).optional(),
+    translationContext: z.string().max(20_000).optional(),
+    teamId: z.string().uuid().optional(),
+    sourceLocale: localeInputSchema,
+    targetLocales: projectTargetLocalesSchema,
+  })
+  .superRefine((value, ctx) => {
+    const sourceKey = value.sourceLocale.toLowerCase();
+    if (value.targetLocales.some((locale) => locale.toLowerCase() === sourceKey)) {
+      ctx.addIssue({
+        code: "custom",
+        message: "source locale cannot appear in target locales",
+        path: ["targetLocales"],
+      });
+    }
+  });
 
 export const updateProjectBodySchema = z
   .object({
@@ -44,17 +63,40 @@ export const updateProjectBodySchema = z
     description: z.string().max(10_000).optional(),
     translationContext: z.string().max(20_000).optional(),
     teamId: z.string().uuid().optional(),
+    sourceLocale: localeInputSchema.optional(),
+    targetLocales: projectTargetLocalesSchema.optional(),
   })
   .refine(
     (value) =>
       value.name !== undefined ||
       value.description !== undefined ||
       value.translationContext !== undefined ||
-      value.teamId !== undefined,
+      value.teamId !== undefined ||
+      value.sourceLocale !== undefined ||
+      value.targetLocales !== undefined,
     {
       message: "at least one field must be provided",
     },
-  );
+  )
+  .superRefine((value, ctx) => {
+    if (value.sourceLocale === undefined || value.targetLocales === undefined) {
+      return;
+    }
+
+    if (
+      value.targetLocales.some(
+        (locale) => locale.toLowerCase() === value.sourceLocale!.toLowerCase(),
+      )
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message: "source locale cannot appear in target locales",
+        path: ["targetLocales"],
+      });
+    }
+  });
+
+export { maxProjectTargetLocales };
 
 export const projectRecordSchema = z.object({
   id: z.string(),

--- a/apps/hyperlocalise-web/src/api/routes/project/project.shared.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.shared.ts
@@ -44,3 +44,13 @@ export async function getOwnedProject(auth: ApiAuthContext, projectId: string) {
 
   return project ?? null;
 }
+
+export async function getOwnedProjectRecord(auth: ApiAuthContext, projectId: string) {
+  const [project] = await db
+    .select()
+    .from(schema.projects)
+    .where(await ownedProjectWhere(auth, projectId))
+    .limit(1);
+
+  return project ?? null;
+}

--- a/apps/hyperlocalise-web/src/api/routes/project/project.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.test.ts
@@ -165,6 +165,60 @@ describe("projectRoutes", () => {
     expect(response.status).toBe(400);
   });
 
+  it("allows partial locale patch on legacy native projects", async () => {
+    const { identity, project } = await projectFixture.createStoredProjectFixture();
+
+    await db
+      .update(schema.projects)
+      .set({ sourceLocale: null, targetLocales: [] })
+      .where(eq(schema.projects.id, project.id));
+
+    const targetsOnlyResponse = await client.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].$patch(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: project.id,
+        },
+        json: { targetLocales: ["fr-FR", "de-DE"] },
+      },
+      {
+        headers: await authHeadersFor(identity),
+      },
+    );
+
+    expect(targetsOnlyResponse.status).toBe(200);
+    const targetsOnlyBody = (await targetsOnlyResponse.json()) as ProjectResponse;
+    expect(targetsOnlyBody.project.sourceLocale).toBeNull();
+    expect(targetsOnlyBody.project.targetLocales).toEqual(["fr-FR", "de-DE"]);
+
+    await db
+      .update(schema.projects)
+      .set({ sourceLocale: null, targetLocales: [] })
+      .where(eq(schema.projects.id, project.id));
+
+    const sourceOnlyResponse = await client.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].$patch(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: project.id,
+        },
+        json: { sourceLocale: "en-GB" },
+      },
+      {
+        headers: await authHeadersFor(identity),
+      },
+    );
+
+    expect(sourceOnlyResponse.status).toBe(200);
+    const sourceOnlyBody = (await sourceOnlyResponse.json()) as ProjectResponse;
+    expect(sourceOnlyBody.project.sourceLocale).toBe("en-GB");
+    expect(sourceOnlyBody.project.targetLocales).toEqual([]);
+  });
+
   it("updates native project locales", async () => {
     const identity = createWorkosIdentity();
     const createdResponse = await createProjectViaApi(identity);

--- a/apps/hyperlocalise-web/src/api/routes/project/project.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.test.ts
@@ -246,6 +246,57 @@ describe("projectRoutes", () => {
     expect(body.project.targetLocales).toEqual(["es-ES", "it-IT"]);
   });
 
+  it("returns a specific error when patching external TMS project locales", async () => {
+    const { identity, project } = await projectFixture.createStoredProjectFixture();
+
+    await db
+      .update(schema.projects)
+      .set({ source: "external_tms" })
+      .where(eq(schema.projects.id, project.id));
+
+    const response = await client.api.orgs[":organizationSlug"].projects[":projectId"].$patch(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: project.id,
+        },
+        json: { sourceLocale: "en-GB" },
+      },
+      {
+        headers: await authHeadersFor(identity),
+      },
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "external_project_locales_readonly",
+      message: expect.any(String),
+    });
+  });
+
+  it("returns a specific error when a partial locale patch puts source in targets", async () => {
+    const { identity, project } = await projectFixture.createStoredProjectFixture();
+
+    const response = await client.api.orgs[":organizationSlug"].projects[":projectId"].$patch(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: project.id,
+        },
+        json: { sourceLocale: "fr-FR" },
+      },
+      {
+        headers: await authHeadersFor(identity),
+      },
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "source_in_targets",
+      message: expect.any(String),
+    });
+  });
+
   it("returns 400 for invalid create payloads", async () => {
     const identity = createWorkosIdentity();
     const response = await client.api.orgs[":organizationSlug"].projects.$post(

--- a/apps/hyperlocalise-web/src/api/routes/project/project.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.test.ts
@@ -112,6 +112,8 @@ describe("projectRoutes", () => {
       name: "Docs",
       description: "Documentation content",
       translationContext: "Keep terminology consistent.",
+      sourceLocale: "en-US",
+      targetLocales: ["fr-FR", "de-DE"],
     });
 
     expect(response.status).toBe(201);
@@ -121,15 +123,38 @@ describe("projectRoutes", () => {
     expect(body.project.name).toBe("Docs");
     expect(body.project.description).toBe("Documentation content");
     expect(body.project.translationContext).toBe("Keep terminology consistent.");
+    expect(body.project.sourceLocale).toBe("en-US");
+    expect(body.project.targetLocales).toEqual(["fr-FR", "de-DE"]);
   });
 
-  it("fills default values for optional create fields", async () => {
+  it("returns 400 when create payload omits locales", async () => {
     const identity = createWorkosIdentity();
     const response = await client.api.orgs[":organizationSlug"].projects.$post(
       {
         param: { organizationSlug: identity.organization.slug ?? "missing-slug" },
         json: {
           name: "Docs",
+        } as Parameters<
+          (typeof client.api.orgs)[":organizationSlug"]["projects"]["$post"]
+        >[0]["json"],
+      },
+      {
+        headers: await authHeadersFor(identity),
+      },
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 when source locale appears in target locales", async () => {
+    const identity = createWorkosIdentity();
+    const response = await client.api.orgs[":organizationSlug"].projects.$post(
+      {
+        param: { organizationSlug: identity.organization.slug ?? "missing-slug" },
+        json: {
+          name: "Docs",
+          sourceLocale: "en-US",
+          targetLocales: ["fr-FR", "en-us"],
         },
       },
       {
@@ -137,12 +162,34 @@ describe("projectRoutes", () => {
       },
     );
 
-    expect(response.status).toBe(201);
+    expect(response.status).toBe(400);
+  });
 
+  it("updates native project locales", async () => {
+    const identity = createWorkosIdentity();
+    const createdResponse = await createProjectViaApi(identity);
+    const createdBody = (await createdResponse.json()) as ProjectResponse;
+
+    const response = await client.api.orgs[":organizationSlug"].projects[":projectId"].$patch(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: createdBody.project.id,
+        },
+        json: {
+          sourceLocale: "en-GB",
+          targetLocales: ["es-ES", "it-IT"],
+        },
+      },
+      {
+        headers: await authHeadersFor(identity),
+      },
+    );
+
+    expect(response.status).toBe(200);
     const body = (await response.json()) as ProjectResponse;
-    expect(body.project.name).toBe("Docs");
-    expect(body.project.description).toBe("");
-    expect(body.project.translationContext).toBe("");
+    expect(body.project.sourceLocale).toBe("en-GB");
+    expect(body.project.targetLocales).toEqual(["es-ES", "it-IT"]);
   });
 
   it("returns 400 for invalid create payloads", async () => {
@@ -152,7 +199,9 @@ describe("projectRoutes", () => {
         param: { organizationSlug: identity.organization.slug ?? "missing-slug" },
         json: {
           name: "   ",
-        },
+        } as Parameters<
+          (typeof client.api.orgs)[":organizationSlug"]["projects"]["$post"]
+        >[0]["json"],
       },
       {
         headers: await authHeadersFor(identity),
@@ -176,6 +225,8 @@ describe("projectRoutes", () => {
           name: "Docs",
           description: "Documentation content",
           translationContext: "Keep terminology consistent.",
+          sourceLocale: "en-US",
+          targetLocales: ["fr-FR"],
         },
       },
       {

--- a/apps/hyperlocalise-web/src/api/routes/public-jobs/public-jobs.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/public-jobs/public-jobs.route.ts
@@ -10,6 +10,7 @@ import {
   requireApiKeyPermission,
   type ApiKeyAuthVariables,
 } from "@/api/auth/api-key";
+import { badRequestResponse } from "@/api/errors";
 import { db, schema } from "@/lib/database";
 import {
   formatUsageControlError,
@@ -152,8 +153,8 @@ export function createPublicJobRoutes(options: CreatePublicJobRoutesOptions = {}
           sourceLocale: inputPayload.sourceLocale,
           targetLocales: inputPayload.targetLocales,
         });
-        if (!localeValidation.ok) {
-          return c.json({ error: localeValidation.code, message: localeValidation.message }, 400);
+        if (isErr(localeValidation)) {
+          return badRequestResponse(c, localeValidation.error.code, localeValidation.error.message);
         }
 
         if (payload.type === "file") {

--- a/apps/hyperlocalise-web/src/api/routes/public-jobs/public-jobs.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/public-jobs/public-jobs.route.ts
@@ -16,6 +16,7 @@ import {
   reserveUsageEvent,
   usageFeatureIds,
 } from "@/lib/billing/usage-control";
+import { validateJobLocalesAgainstProject } from "@/lib/i18n/project-job-locales";
 import {
   ensureRepositorySourceFileVersionForStoredFile,
   getStoredFileForJobScope,
@@ -114,7 +115,7 @@ function publicJobOutputFiles(input: {
 
 async function getProjectForOrganization(organizationId: string, projectId: string) {
   const [project] = await db
-    .select({ id: schema.projects.id })
+    .select()
     .from(schema.projects)
     .where(
       and(eq(schema.projects.id, projectId), eq(schema.projects.organizationId, organizationId)),
@@ -146,6 +147,14 @@ export function createPublicJobRoutes(options: CreatePublicJobRoutesOptions = {}
         }
 
         const inputPayload = payload.type === "string" ? payload.stringInput : payload.fileInput;
+
+        const localeValidation = validateJobLocalesAgainstProject(project, {
+          sourceLocale: inputPayload.sourceLocale,
+          targetLocales: inputPayload.targetLocales,
+        });
+        if (!localeValidation.ok) {
+          return c.json({ error: localeValidation.code, message: localeValidation.message }, 400);
+        }
 
         if (payload.type === "file") {
           const sourceFile = await getStoredFileForJobScope({

--- a/apps/hyperlocalise-web/src/api/routes/team/team.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/team/team.test.ts
@@ -460,6 +460,8 @@ describe("teamRoutes", () => {
         json: {
           name: "Scoped Project",
           teamId: projectTeamBody.team.id,
+          sourceLocale: "en-US",
+          targetLocales: ["fr-FR"],
         },
       },
       {

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/locales/_components/project-locales-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/locales/_components/project-locales-page-content.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import Link from "next/link";
+import { useQuery } from "@tanstack/react-query";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { TypographyH1, TypographyP } from "@/components/ui/typography";
+import { apiClient } from "@/lib/api-client-instance";
+import { getLocaleLabel, isRtlLocale } from "@/lib/i18n/locales";
+
+import { formatProjectLocaleSummary } from "../../../_components/project-form";
+import { mapProjectToListRow } from "../../../_components/project-list";
+
+export function ProjectLocalesPageContent({
+  organizationSlug,
+  projectId,
+}: {
+  organizationSlug: string;
+  projectId: string;
+}) {
+  const projectQuery = useQuery({
+    queryKey: ["translation-project", organizationSlug, projectId],
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"].projects[":projectId"].$get({
+        param: { organizationSlug, projectId },
+      });
+      if (!response.ok) {
+        throw new Error(`Failed to load project (${response.status})`);
+      }
+      const body = await response.json();
+      return mapProjectToListRow(body.project);
+    },
+  });
+
+  const project = projectQuery.data;
+
+  return (
+    <div className="mx-auto flex w-full max-w-4xl flex-col gap-8">
+      <div className="space-y-3">
+        {projectQuery.isLoading ? (
+          <Skeleton className="h-10 w-72" />
+        ) : (
+          <TypographyH1 className="font-heading text-3xl font-semibold text-foreground md:text-4xl">
+            Locales
+          </TypographyH1>
+        )}
+        <TypographyP className="max-w-2xl text-sm leading-6 text-foreground/58">
+          Source and target locales configured for this project. Native projects can edit locales in
+          project settings; external TMS projects inherit locales from the connected provider.
+        </TypographyP>
+        {project ? (
+          <div className="flex flex-wrap gap-2">
+            <Badge variant="outline" className="border-foreground/12 text-foreground/62">
+              {project.source === "external_tms" ? "Provider-managed" : "Native project"}
+            </Badge>
+            {project.externalProviderKind ? (
+              <Badge variant="outline" className="border-foreground/12 text-foreground/62">
+                {project.externalProviderKind}
+              </Badge>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+
+      {projectQuery.isLoading ? (
+        <Skeleton className="h-40 w-full" />
+      ) : project ? (
+        <section className="grid gap-6 rounded-xl border border-foreground/8 bg-foreground/2.5 p-6">
+          <div>
+            <p className="text-xs font-medium uppercase tracking-wide text-foreground/44">
+              Summary
+            </p>
+            <p className="mt-2 text-sm text-foreground">
+              {formatProjectLocaleSummary(project.sourceLocale, project.targetLocales)}
+            </p>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="rounded-lg border border-foreground/8 p-4">
+              <p className="text-xs font-medium text-foreground/48">Source locale</p>
+              <p className="mt-2 text-lg font-medium text-foreground">
+                {project.sourceLocale ?? "Not configured"}
+              </p>
+              {project.sourceLocale ? (
+                <p className="mt-1 text-sm text-foreground/56">
+                  {getLocaleLabel(project.sourceLocale)}
+                </p>
+              ) : null}
+            </div>
+
+            <div className="rounded-lg border border-foreground/8 p-4 sm:col-span-1">
+              <p className="text-xs font-medium text-foreground/48">
+                Target locales ({project.targetLocales.length})
+              </p>
+              {project.targetLocales.length > 0 ? (
+                <ul className="mt-3 space-y-2">
+                  {project.targetLocales.map((locale) => (
+                    <li
+                      key={locale}
+                      className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-foreground/6 bg-background/40 px-3 py-2 text-sm"
+                    >
+                      <span className="font-medium text-foreground">{locale}</span>
+                      <span className="text-foreground/56">{getLocaleLabel(locale)}</span>
+                      {isRtlLocale(locale) ? (
+                        <Badge variant="secondary" className="text-[10px]">
+                          RTL
+                        </Badge>
+                      ) : null}
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="mt-2 text-sm text-foreground/56">No target locales configured yet.</p>
+              )}
+            </div>
+          </div>
+
+          {project.source === "external_tms" && project.lastSyncedAt ? (
+            <p className="text-xs text-foreground/48">
+              Last synced from provider: {project.lastSyncedAt}
+            </p>
+          ) : null}
+        </section>
+      ) : null}
+
+      <div className="flex flex-wrap gap-2">
+        <Button
+          variant="outline"
+          render={<Link href={`/org/${organizationSlug}/projects/${projectId}/settings`} />}
+        >
+          Project settings
+        </Button>
+        <Button
+          variant="outline"
+          render={<Link href={`/org/${organizationSlug}/projects/${projectId}/jobs`} />}
+        >
+          View jobs
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/locales/page.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/locales/page.tsx
@@ -1,4 +1,4 @@
-import { ProjectSectionPlaceholder } from "../_components/project-section-placeholder";
+import { ProjectLocalesPageContent } from "./_components/project-locales-page-content";
 
 export default async function ProjectLocalesPage({
   params,
@@ -7,12 +7,5 @@ export default async function ProjectLocalesPage({
 }) {
   const { organizationSlug, projectId } = await params;
 
-  return (
-    <ProjectSectionPlaceholder
-      organizationSlug={organizationSlug}
-      projectId={projectId}
-      title="Locales"
-      description="Track language and market readiness for this project — coverage, blockers, and launch status by locale."
-    />
-  );
+  return <ProjectLocalesPageContent organizationSlug={organizationSlug} projectId={projectId} />;
 }

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/_components/project-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/_components/project-dialog.tsx
@@ -18,17 +18,22 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Field, FieldError, FieldLabel } from "@/components/ui/field";
 
+import { ProjectSourceLocalePicker, ProjectTargetLocalesPicker } from "./project-locale-picker";
 import {
   projectFormHasErrors,
+  projectFormRequiresLocales,
   validateProjectForm,
   type ProjectFormErrors,
   type ProjectFormValues,
 } from "./project-form";
+import type { ProjectListRow } from "./project-list";
 
 export function ProjectDialog({
   open,
   title,
   description,
+  mode,
+  projectSource = "native",
   initialValues,
   isSaving,
   onOpenChange,
@@ -37,6 +42,8 @@ export function ProjectDialog({
   open: boolean;
   title: string;
   description: string;
+  mode: "create" | "edit";
+  projectSource?: ProjectListRow["source"];
   initialValues: ProjectFormValues;
   isSaving: boolean;
   onOpenChange: (open: boolean) => void;
@@ -58,10 +65,12 @@ export function ProjectDialog({
     }
   }, [initialValues, open]);
 
+  const showLocaleFields = projectFormRequiresLocales(mode, projectSource);
+
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
-    const nextErrors = validateProjectForm(values);
+    const nextErrors = validateProjectForm(values, { requireLocales: showLocaleFields });
     setErrors(nextErrors);
 
     if (projectFormHasErrors(nextErrors)) {
@@ -140,6 +149,28 @@ export function ProjectDialog({
                 </span>
               </div>
             </Field>
+
+            {showLocaleFields ? (
+              <>
+                <ProjectSourceLocalePicker
+                  value={values.sourceLocale}
+                  onChange={(sourceLocale) => {
+                    setValues((current) => ({ ...current, sourceLocale }));
+                  }}
+                  disabled={isSaving}
+                  error={errors.sourceLocale}
+                />
+                <ProjectTargetLocalesPicker
+                  value={values.targetLocales}
+                  sourceLocale={values.sourceLocale}
+                  onChange={(targetLocales) => {
+                    setValues((current) => ({ ...current, targetLocales }));
+                  }}
+                  disabled={isSaving}
+                  error={errors.targetLocales}
+                />
+              </>
+            ) : null}
 
             <Field className="gap-1.5">
               <FieldLabel htmlFor={contextId}>Translation context</FieldLabel>

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/_components/project-form.test.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/_components/project-form.test.ts
@@ -14,6 +14,8 @@ function createProject(overrides: Partial<ApiProject> = {}): ApiProject {
     name: "Website Launch",
     description: "Marketing site refresh",
     translationContext: "Use a concise launch voice.",
+    sourceLocale: "en-US",
+    targetLocales: ["fr-FR", "de-DE"],
     createdAt: "2026-04-29T00:00:00.000Z",
     updatedAt: "2026-04-30T03:20:00.000Z",
     ...overrides,
@@ -28,6 +30,8 @@ describe("project form helpers", () => {
       name: "Website Launch",
       description: "Marketing site refresh",
       translationContext: "Use a concise launch voice.",
+      sourceLocale: "en-US",
+      targetLocales: ["fr-FR", "de-DE"],
     });
   });
 
@@ -36,6 +40,8 @@ describe("project form helpers", () => {
       name: "   ",
       description: "x".repeat(10_001),
       translationContext: "x".repeat(20_001),
+      sourceLocale: "en-US",
+      targetLocales: ["fr-FR"],
     });
 
     expect(projectFormHasErrors(errors)).toBe(true);
@@ -46,17 +52,55 @@ describe("project form helpers", () => {
     });
   });
 
-  it("trims payload fields before sending them to the project API", () => {
+  it("rejects source locale in target locales", () => {
+    const errors = validateProjectForm({
+      name: "Docs",
+      description: "",
+      translationContext: "",
+      sourceLocale: "en-US",
+      targetLocales: ["fr-FR", "en-us"],
+    });
+
+    expect(errors.targetLocales).toBe("Remove the source locale from target locales.");
+  });
+
+  it("trims payload fields and canonicalizes locales before sending them to the API", () => {
     expect(
-      toProjectPayload({
-        name: "  Docs  ",
-        description: "  Product docs  ",
-        translationContext: "  Keep it crisp.  ",
-      }),
+      toProjectPayload(
+        {
+          name: "  Docs  ",
+          description: "  Product docs  ",
+          translationContext: "  Keep it crisp.  ",
+          sourceLocale: "en",
+          targetLocales: ["fr-fr", "de-DE"],
+        },
+        { mode: "create" },
+      ),
     ).toEqual({
       name: "Docs",
       description: "Product docs",
       translationContext: "Keep it crisp.",
+      sourceLocale: "en",
+      targetLocales: ["fr-FR", "de-DE"],
+    });
+  });
+
+  it("omits locales for external TMS edits", () => {
+    expect(
+      toProjectPayload(
+        {
+          name: "Docs",
+          description: "",
+          translationContext: "",
+          sourceLocale: "en-US",
+          targetLocales: ["fr-FR"],
+        },
+        { mode: "edit", includeLocales: false },
+      ),
+    ).toEqual({
+      name: "Docs",
+      description: "",
+      translationContext: "",
     });
   });
 });

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/_components/project-form.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/_components/project-form.ts
@@ -1,18 +1,30 @@
+import { canonicalizeLocale, normalizeProjectLocales } from "@/lib/i18n/locales";
+
 import type { ProjectListRow } from "./project-list";
 
 export type ProjectFormValues = {
   name: string;
   description: string;
   translationContext: string;
+  sourceLocale: string;
+  targetLocales: string[];
 };
 
-export type ProjectFormErrors = Partial<Record<keyof ProjectFormValues, string>>;
+export type ProjectFormErrors = Partial<Record<keyof ProjectFormValues, string>> & {
+  targetLocales?: string;
+};
+
+export const defaultNativeProjectSourceLocale = "en-US";
+
+export const defaultNativeProjectTargetLocales = ["fr-FR", "de-DE"];
 
 export function createEmptyProjectForm(): ProjectFormValues {
   return {
     name: "",
     description: "",
     translationContext: "",
+    sourceLocale: defaultNativeProjectSourceLocale,
+    targetLocales: [...defaultNativeProjectTargetLocales],
   };
 }
 
@@ -21,12 +33,21 @@ export function createProjectFormFromRow(project: ProjectListRow): ProjectFormVa
     name: project.name,
     description: project.descriptionValue,
     translationContext: project.translationContextValue,
+    sourceLocale: project.sourceLocale ?? defaultNativeProjectSourceLocale,
+    targetLocales:
+      project.targetLocales.length > 0
+        ? project.targetLocales
+        : [...defaultNativeProjectTargetLocales],
   };
 }
 
-export function validateProjectForm(values: ProjectFormValues): ProjectFormErrors {
+export function validateProjectForm(
+  values: ProjectFormValues,
+  options?: { requireLocales?: boolean },
+): ProjectFormErrors {
   const errors: ProjectFormErrors = {};
   const name = values.name.trim();
+  const requireLocales = options?.requireLocales ?? true;
 
   if (!name) {
     errors.name = "Project name is required.";
@@ -42,6 +63,23 @@ export function validateProjectForm(values: ProjectFormValues): ProjectFormError
     errors.translationContext = "Translation context must be 20,000 characters or fewer.";
   }
 
+  if (requireLocales) {
+    const normalized = normalizeProjectLocales({
+      sourceLocale: values.sourceLocale,
+      targetLocales: values.targetLocales,
+    });
+
+    if ("error" in normalized) {
+      if (normalized.error === "invalid_source_locale") {
+        errors.sourceLocale = "Select a valid source locale.";
+      } else if (normalized.error === "source_in_targets") {
+        errors.targetLocales = "Remove the source locale from target locales.";
+      } else {
+        errors.targetLocales = "Select at least one valid target locale.";
+      }
+    }
+  }
+
   return errors;
 }
 
@@ -49,10 +87,88 @@ export function projectFormHasErrors(errors: ProjectFormErrors) {
   return Object.keys(errors).length > 0;
 }
 
-export function toProjectPayload(values: ProjectFormValues) {
+export type ProjectMetadataPayload = {
+  name: string;
+  description: string;
+  translationContext: string;
+};
+
+export type ProjectCreatePayload = ProjectMetadataPayload & {
+  sourceLocale: string;
+  targetLocales: string[];
+};
+
+export type ProjectUpdatePayload = ProjectMetadataPayload & {
+  sourceLocale?: string;
+  targetLocales?: string[];
+};
+
+function buildMetadataPayload(values: ProjectFormValues): ProjectMetadataPayload {
   return {
     name: values.name.trim(),
     description: values.description.trim(),
     translationContext: values.translationContext.trim(),
   };
+}
+
+function buildLocalePayload(values: ProjectFormValues) {
+  const normalized = normalizeProjectLocales({
+    sourceLocale: values.sourceLocale,
+    targetLocales: values.targetLocales,
+  });
+
+  if ("error" in normalized) {
+    throw new Error(normalized.error);
+  }
+
+  return {
+    sourceLocale: normalized.sourceLocale,
+    targetLocales: normalized.targetLocales,
+  };
+}
+
+export function toProjectPayload(
+  values: ProjectFormValues,
+  options: { mode: "create" },
+): ProjectCreatePayload;
+export function toProjectPayload(
+  values: ProjectFormValues,
+  options: { mode: "edit"; includeLocales?: boolean },
+): ProjectUpdatePayload;
+export function toProjectPayload(
+  values: ProjectFormValues,
+  options: { mode: "create" | "edit"; includeLocales?: boolean },
+): ProjectCreatePayload | ProjectUpdatePayload {
+  const payload = buildMetadataPayload(values);
+  const includeLocales = options.includeLocales ?? options.mode === "create";
+
+  if (!includeLocales) {
+    return payload;
+  }
+
+  return {
+    ...payload,
+    ...buildLocalePayload(values),
+  };
+}
+
+export function projectFormRequiresLocales(
+  mode: "create" | "edit",
+  source: ProjectListRow["source"],
+) {
+  return mode === "create" || source === "native";
+}
+
+export function formatProjectLocaleSummary(sourceLocale: string | null, targetLocales: string[]) {
+  if (!sourceLocale && targetLocales.length === 0) {
+    return "No locales configured";
+  }
+
+  const source = sourceLocale ? (canonicalizeLocale(sourceLocale) ?? sourceLocale) : "—";
+  const targets =
+    targetLocales.length > 0
+      ? targetLocales.map((locale) => canonicalizeLocale(locale) ?? locale).join(", ")
+      : "—";
+
+  return `${source} → ${targets}`;
 }

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/_components/project-locale-picker.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/_components/project-locale-picker.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import { useId, useMemo, useState } from "react";
+import { Add01Icon, Cancel01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Field, FieldError, FieldLabel } from "@/components/ui/field";
+import {
+  canonicalizeLocale,
+  COMMON_LOCALES,
+  getLocaleLabel,
+  isValidLocaleInput,
+} from "@/lib/i18n/locales";
+
+function sortLocales(locales: string[]) {
+  return [...locales].toSorted((a, b) => getLocaleLabel(a).localeCompare(getLocaleLabel(b)));
+}
+
+export function ProjectSourceLocalePicker({
+  value,
+  onChange,
+  disabled,
+  error,
+}: {
+  value: string;
+  onChange: (locale: string) => void;
+  disabled?: boolean;
+  error?: string;
+}) {
+  const fieldId = useId();
+  const customId = useId();
+  const [customLocale, setCustomLocale] = useState("");
+  const [customError, setCustomError] = useState<string | undefined>();
+
+  const options = useMemo(() => {
+    const merged = new Set<string>(COMMON_LOCALES);
+    if (value) {
+      merged.add(value);
+    }
+    return sortLocales([...merged]);
+  }, [value]);
+
+  function applyCustomLocale() {
+    if (!isValidLocaleInput(customLocale)) {
+      setCustomError("Enter a valid BCP-47 locale (e.g. en-US, zh-Hant-TW).");
+      return;
+    }
+
+    onChange(canonicalizeLocale(customLocale) as string);
+    setCustomLocale("");
+    setCustomError(undefined);
+  }
+
+  return (
+    <Field className="gap-1.5">
+      <FieldLabel htmlFor={fieldId}>Source locale</FieldLabel>
+      <Select
+        value={value || undefined}
+        onValueChange={(next) => {
+          if (next) {
+            onChange(next);
+          }
+        }}
+        disabled={disabled}
+      >
+        <SelectTrigger
+          id={fieldId}
+          className="border-foreground/10 bg-foreground/6 text-foreground"
+        >
+          <SelectValue placeholder="Select source locale" />
+        </SelectTrigger>
+        <SelectContent>
+          {options.map((locale) => (
+            <SelectItem key={locale} value={locale}>
+              {getLocaleLabel(locale)} ({locale})
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <div className="flex gap-2">
+        <Input
+          id={customId}
+          value={customLocale}
+          onChange={(event) => {
+            setCustomLocale(event.target.value);
+            setCustomError(undefined);
+          }}
+          disabled={disabled}
+          placeholder="Custom locale, e.g. en-GB"
+          className="border-foreground/10 bg-foreground/6 text-foreground placeholder:text-foreground/32"
+        />
+        <Button type="button" variant="outline" disabled={disabled} onClick={applyCustomLocale}>
+          <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
+          Use
+        </Button>
+      </div>
+      <FieldError errors={error || customError ? [{ message: error ?? customError }] : undefined} />
+    </Field>
+  );
+}
+
+export function ProjectTargetLocalesPicker({
+  value,
+  onChange,
+  sourceLocale,
+  disabled,
+  error,
+}: {
+  value: string[];
+  onChange: (locales: string[]) => void;
+  sourceLocale: string;
+  disabled?: boolean;
+  error?: string;
+}) {
+  const fieldId = useId();
+  const customId = useId();
+  const [customLocale, setCustomLocale] = useState("");
+  const [customError, setCustomError] = useState<string | undefined>();
+
+  const selected = useMemo(() => new Set(value.map((locale) => locale.toLowerCase())), [value]);
+  const sourceKey = sourceLocale.trim().toLowerCase();
+
+  function toggleLocale(locale: string) {
+    const key = locale.toLowerCase();
+    if (key === sourceKey) {
+      return;
+    }
+
+    if (selected.has(key)) {
+      onChange(value.filter((entry) => entry.toLowerCase() !== key));
+      return;
+    }
+
+    onChange(sortLocales([...value, locale]));
+  }
+
+  function removeLocale(locale: string) {
+    onChange(value.filter((entry) => entry !== locale));
+  }
+
+  function applyCustomLocale() {
+    if (!isValidLocaleInput(customLocale)) {
+      setCustomError("Enter a valid BCP-47 locale (e.g. fr-FR, zh-Hant-TW).");
+      return;
+    }
+
+    const canonical = canonicalizeLocale(customLocale) as string;
+    if (canonical.toLowerCase() === sourceKey) {
+      setCustomError("Target locale cannot match the source locale.");
+      return;
+    }
+
+    toggleLocale(canonical);
+    setCustomLocale("");
+    setCustomError(undefined);
+  }
+
+  return (
+    <Field className="gap-2">
+      <FieldLabel id={fieldId}>Target locales</FieldLabel>
+      <p className="text-xs text-foreground/48">
+        Pick from common markets or add a custom BCP-47 locale tag.
+      </p>
+      <div className="flex flex-wrap gap-2" role="group" aria-labelledby={fieldId}>
+        {COMMON_LOCALES.map((locale) => {
+          const isSource = locale.toLowerCase() === sourceKey;
+          const isSelected = selected.has(locale.toLowerCase());
+
+          return (
+            <Button
+              key={locale}
+              type="button"
+              size="sm"
+              variant={isSelected ? "default" : "outline"}
+              disabled={disabled || isSource}
+              onClick={() => toggleLocale(locale)}
+              className="h-8"
+            >
+              {locale}
+            </Button>
+          );
+        })}
+      </div>
+      {value.length > 0 ? (
+        <div className="flex flex-wrap gap-2">
+          {value.map((locale) => (
+            <Badge key={locale} variant="secondary" className="gap-1 pr-1">
+              <span>
+                {locale} · {getLocaleLabel(locale)}
+              </span>
+              <button
+                type="button"
+                className="rounded-sm p-0.5 text-foreground/56 hover:text-foreground"
+                disabled={disabled}
+                onClick={() => removeLocale(locale)}
+                aria-label={`Remove ${locale}`}
+              >
+                <HugeiconsIcon icon={Cancel01Icon} strokeWidth={1.8} className="size-3.5" />
+              </button>
+            </Badge>
+          ))}
+        </div>
+      ) : null}
+      <div className="flex gap-2">
+        <Input
+          id={customId}
+          value={customLocale}
+          onChange={(event) => {
+            setCustomLocale(event.target.value);
+            setCustomError(undefined);
+          }}
+          disabled={disabled}
+          placeholder="Custom target locale"
+          className="border-foreground/10 bg-foreground/6 text-foreground placeholder:text-foreground/32"
+        />
+        <Button type="button" variant="outline" disabled={disabled} onClick={applyCustomLocale}>
+          <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
+          Add
+        </Button>
+      </div>
+      <FieldError errors={error || customError ? [{ message: error ?? customError }] : undefined} />
+    </Field>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
@@ -128,7 +128,7 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
     mutationFn: async (values: ProjectFormValues) => {
       const response = await apiClient.api.orgs[":organizationSlug"].projects.$post({
         param: { organizationSlug },
-        json: toProjectPayload(values),
+        json: toProjectPayload(values, { mode: "create" }),
       });
 
       if (!response.ok) {
@@ -150,7 +150,10 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
     mutationFn: async ({ projectId, values }: { projectId: string; values: ProjectFormValues }) => {
       const response = await apiClient.api.orgs[":organizationSlug"].projects[":projectId"].$patch({
         param: { organizationSlug, projectId },
-        json: toProjectPayload(values),
+        json: toProjectPayload(values, {
+          mode: "edit",
+          includeLocales: editingProject?.source === "native",
+        }),
       });
 
       if (!response.ok) {
@@ -387,6 +390,8 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
         open={projectDialogMode !== null}
         title={projectDialogTitle}
         description={projectDialogDescription}
+        mode={projectDialogMode === "edit" ? "edit" : "create"}
+        projectSource={editingProject?.source ?? "native"}
         initialValues={initialProjectValues}
         isSaving={isSavingProject}
         onOpenChange={closeProjectDialog}

--- a/apps/hyperlocalise-web/src/lib/i18n/locales.test.ts
+++ b/apps/hyperlocalise-web/src/lib/i18n/locales.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  canonicalizeLocale,
+  COMMON_LOCALES,
+  getLocaleLabel,
+  isRtlLocale,
+  normalizeProjectLocales,
+  normalizeTargetLocales,
+} from "./locales";
+
+describe("locales", () => {
+  it("exposes 40 common locales", () => {
+    expect(COMMON_LOCALES).toHaveLength(40);
+    expect(COMMON_LOCALES).toContain("en-US");
+    expect(COMMON_LOCALES).toContain("zh-TW");
+  });
+
+  it("canonicalizes BCP-47 tags", () => {
+    expect(canonicalizeLocale("en-us")).toBe("en-US");
+    expect(canonicalizeLocale("zh-hant-tw")).toBe("zh-Hant-TW");
+    expect(canonicalizeLocale("")).toBeNull();
+    expect(canonicalizeLocale("not-a-locale!!!")).toBeNull();
+  });
+
+  it("dedupes and sorts target locales by canonical form", () => {
+    expect(normalizeTargetLocales(["fr-fr", "de-DE", "fr-FR"])).toEqual(["fr-FR", "de-DE"]);
+  });
+
+  it("rejects source locale in targets", () => {
+    expect(
+      normalizeProjectLocales({
+        sourceLocale: "en-US",
+        targetLocales: ["fr-FR", "en-us"],
+      }),
+    ).toEqual({ error: "source_in_targets" });
+  });
+
+  it("normalizes valid project locale pairs", () => {
+    expect(
+      normalizeProjectLocales({
+        sourceLocale: "en",
+        targetLocales: ["fr-FR", "de-DE"],
+      }),
+    ).toEqual({
+      sourceLocale: "en",
+      targetLocales: ["fr-FR", "de-DE"],
+    });
+  });
+
+  it("builds human-readable labels", () => {
+    expect(getLocaleLabel("fr-FR")).toContain("French");
+  });
+
+  it("detects rtl locales", () => {
+    expect(isRtlLocale("ar-SA")).toBe(true);
+    expect(isRtlLocale("en-US")).toBe(false);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/i18n/locales.test.ts
+++ b/apps/hyperlocalise-web/src/lib/i18n/locales.test.ts
@@ -5,6 +5,7 @@ import {
   COMMON_LOCALES,
   getLocaleLabel,
   isRtlLocale,
+  normalizeProjectLocalePatch,
   normalizeProjectLocales,
   normalizeTargetLocales,
 } from "./locales";
@@ -23,8 +24,36 @@ describe("locales", () => {
     expect(canonicalizeLocale("not-a-locale!!!")).toBeNull();
   });
 
-  it("dedupes and sorts target locales by canonical form", () => {
+  it("dedupes target locales by canonical form while preserving insertion order", () => {
     expect(normalizeTargetLocales(["fr-fr", "de-DE", "fr-FR"])).toEqual(["fr-FR", "de-DE"]);
+  });
+
+  it("allows partial locale patch when the other side is unset on legacy projects", () => {
+    expect(
+      normalizeProjectLocalePatch({
+        existingSourceLocale: null,
+        existingTargetLocales: [],
+        targetLocales: ["fr-FR"],
+      }),
+    ).toEqual({ targetLocales: ["fr-FR"] });
+
+    expect(
+      normalizeProjectLocalePatch({
+        existingSourceLocale: null,
+        existingTargetLocales: [],
+        sourceLocale: "en-US",
+      }),
+    ).toEqual({ sourceLocale: "en-US" });
+  });
+
+  it("runs cross-field checks when both sides are configured after merge", () => {
+    expect(
+      normalizeProjectLocalePatch({
+        existingSourceLocale: "en-US",
+        existingTargetLocales: [],
+        targetLocales: ["en-us"],
+      }),
+    ).toEqual({ error: "source_in_targets" });
   });
 
   it("rejects source locale in targets", () => {

--- a/apps/hyperlocalise-web/src/lib/i18n/locales.ts
+++ b/apps/hyperlocalise-web/src/lib/i18n/locales.ts
@@ -180,6 +180,73 @@ export function normalizeProjectLocales(input: {
   return { sourceLocale, targetLocales };
 }
 
+export type ProjectLocalePatchError =
+  | "invalid_source_locale"
+  | "invalid_target_locales"
+  | "source_in_targets";
+
+/**
+ * Normalizes a partial project locale PATCH without fabricating empty fallbacks.
+ * Cross-field checks run only when both source and targets are configured after merge.
+ */
+export function normalizeProjectLocalePatch(input: {
+  existingSourceLocale: string | null;
+  existingTargetLocales: string[];
+  sourceLocale?: string;
+  targetLocales?: string[];
+  maxTargets?: number;
+}): { sourceLocale?: string; targetLocales?: string[] } | { error: ProjectLocalePatchError } {
+  const patchingSource = input.sourceLocale !== undefined;
+  const patchingTargets = input.targetLocales !== undefined;
+
+  if (patchingSource && patchingTargets) {
+    const full = normalizeProjectLocales({
+      sourceLocale: input.sourceLocale!,
+      targetLocales: input.targetLocales!,
+      maxTargets: input.maxTargets,
+    });
+    if ("error" in full) {
+      return { error: full.error };
+    }
+    return {
+      sourceLocale: full.sourceLocale,
+      targetLocales: full.targetLocales,
+    };
+  }
+
+  let resolvedSource = input.existingSourceLocale;
+  let resolvedTargets = input.existingTargetLocales;
+  const updates: { sourceLocale?: string; targetLocales?: string[] } = {};
+
+  if (patchingSource) {
+    const canonical = canonicalizeLocale(input.sourceLocale!);
+    if (!canonical) {
+      return { error: "invalid_source_locale" };
+    }
+    resolvedSource = canonical;
+    updates.sourceLocale = canonical;
+  }
+
+  if (patchingTargets) {
+    const normalized = normalizeTargetLocales(input.targetLocales!, {
+      max: input.maxTargets ?? maxProjectTargetLocales,
+    });
+    if (!normalized || normalized.length === 0) {
+      return { error: "invalid_target_locales" };
+    }
+    resolvedTargets = normalized;
+    updates.targetLocales = normalized;
+  }
+
+  if (resolvedSource && resolvedTargets.length > 0) {
+    if (resolvedTargets.some((locale) => locale.toLowerCase() === resolvedSource!.toLowerCase())) {
+      return { error: "source_in_targets" };
+    }
+  }
+
+  return updates;
+}
+
 export const localeInputSchema = z
   .string()
   .trim()

--- a/apps/hyperlocalise-web/src/lib/i18n/locales.ts
+++ b/apps/hyperlocalise-web/src/lib/i18n/locales.ts
@@ -1,0 +1,197 @@
+import { z } from "zod";
+
+/** Curated locales for fast project setup; any valid BCP-47 tag is still accepted. */
+export const COMMON_LOCALES = [
+  "en-US",
+  "en-GB",
+  "en-AU",
+  "en-IN",
+  "es-ES",
+  "es-MX",
+  "fr-FR",
+  "fr-CA",
+  "de-DE",
+  "it-IT",
+  "pt-BR",
+  "pt-PT",
+  "nl-NL",
+  "sv-SE",
+  "da-DK",
+  "nb-NO",
+  "fi-FI",
+  "pl-PL",
+  "cs-CZ",
+  "hu-HU",
+  "ro-RO",
+  "tr-TR",
+  "el-GR",
+  "ru-RU",
+  "uk-UA",
+  "ar-SA",
+  "he-IL",
+  "fa-IR",
+  "hi-IN",
+  "bn-BD",
+  "id-ID",
+  "ms-MY",
+  "vi-VN",
+  "th-TH",
+  "fil-PH",
+  "ja-JP",
+  "ko-KR",
+  "zh-CN",
+  "zh-TW",
+  "zh-HK",
+] as const;
+
+export type CommonLocale = (typeof COMMON_LOCALES)[number];
+
+export const maxProjectTargetLocales = 50;
+
+const RTL_LANGUAGE_PREFIXES = new Set(["ar", "fa", "he", "ur", "ps", "sd", "yi"]);
+
+const localeLabelFormatter =
+  typeof Intl !== "undefined" && "DisplayNames" in Intl
+    ? new Intl.DisplayNames(["en"], { type: "language" })
+    : null;
+
+const regionLabelFormatter =
+  typeof Intl !== "undefined" && "DisplayNames" in Intl
+    ? new Intl.DisplayNames(["en"], { type: "region" })
+    : null;
+
+/**
+ * Canonicalizes a user or provider locale tag when the runtime accepts it.
+ * Returns null for empty or invalid input.
+ */
+export function canonicalizeLocale(input: string): string | null {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  if (typeof Intl === "undefined" || typeof Intl.getCanonicalLocales !== "function") {
+    return trimmed;
+  }
+
+  try {
+    const [canonical] = Intl.getCanonicalLocales(trimmed);
+    return canonical ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function isValidLocaleInput(input: string): boolean {
+  return canonicalizeLocale(input) !== null;
+}
+
+export function getLocaleLabel(locale: string): string {
+  const canonical = canonicalizeLocale(locale) ?? locale;
+
+  try {
+    const parsed = new Intl.Locale(canonical);
+    const languageLabel = localeLabelFormatter?.of(parsed.language) ?? parsed.language;
+    const region = parsed.region;
+
+    if (region) {
+      const regionLabel = regionLabelFormatter?.of(region) ?? region;
+      return `${languageLabel} (${regionLabel})`;
+    }
+
+    return languageLabel;
+  } catch {
+    return canonical;
+  }
+}
+
+export function isRtlLocale(locale: string): boolean {
+  const canonical = canonicalizeLocale(locale);
+  if (!canonical) {
+    return false;
+  }
+
+  try {
+    const parsed = new Intl.Locale(canonical);
+    if (parsed.getTextInfo) {
+      return parsed.getTextInfo().direction === "rtl";
+    }
+  } catch {
+    // Fall through to language-prefix heuristic.
+  }
+
+  const language = canonical.split("-")[0]?.toLowerCase();
+  return language ? RTL_LANGUAGE_PREFIXES.has(language) : false;
+}
+
+export function normalizeTargetLocales(
+  locales: string[],
+  options?: { max?: number },
+): string[] | null {
+  const max = options?.max ?? maxProjectTargetLocales;
+  const normalized: string[] = [];
+  const seen = new Set<string>();
+
+  for (const raw of locales) {
+    const canonical = canonicalizeLocale(raw);
+    if (!canonical) {
+      return null;
+    }
+
+    const key = canonical.toLowerCase();
+    if (seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    normalized.push(canonical);
+
+    if (normalized.length > max) {
+      return null;
+    }
+  }
+
+  return normalized;
+}
+
+export function normalizeProjectLocales(input: {
+  sourceLocale: string;
+  targetLocales: string[];
+  maxTargets?: number;
+}):
+  | { sourceLocale: string; targetLocales: string[] }
+  | { error: "invalid_source_locale" | "invalid_target_locales" | "source_in_targets" } {
+  const sourceLocale = canonicalizeLocale(input.sourceLocale);
+  if (!sourceLocale) {
+    return { error: "invalid_source_locale" };
+  }
+
+  const targetLocales = normalizeTargetLocales(input.targetLocales, {
+    max: input.maxTargets ?? maxProjectTargetLocales,
+  });
+  if (!targetLocales || targetLocales.length === 0) {
+    return { error: "invalid_target_locales" };
+  }
+
+  if (targetLocales.some((locale) => locale.toLowerCase() === sourceLocale.toLowerCase())) {
+    return { error: "source_in_targets" };
+  }
+
+  return { sourceLocale, targetLocales };
+}
+
+export const localeInputSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(50)
+  .refine((value) => isValidLocaleInput(value), {
+    message: "invalid locale format (e.g. en, en-US, fr-FR, zh-Hant-TW)",
+  })
+  .transform((value) => canonicalizeLocale(value) as string);
+
+export const projectTargetLocalesSchema = z
+  .array(localeInputSchema)
+  .min(1, "at least one target locale is required")
+  .max(maxProjectTargetLocales)
+  .transform((locales) => normalizeTargetLocales(locales) as string[]);

--- a/apps/hyperlocalise-web/src/lib/i18n/project-job-locales.test.ts
+++ b/apps/hyperlocalise-web/src/lib/i18n/project-job-locales.test.ts
@@ -1,19 +1,21 @@
 import { describe, expect, it } from "vite-plus/test";
 
+import { isErr, isOk } from "@/lib/primitives/result/results";
+
 import { validateJobLocalesAgainstProject } from "./project-job-locales";
 
 describe("validateJobLocalesAgainstProject", () => {
   it("accepts canonical native job locales within project scope", () => {
-    expect(
-      validateJobLocalesAgainstProject(
-        {
-          source: "native",
-          sourceLocale: "en-US",
-          targetLocales: ["fr-FR", "de-DE"],
-        },
-        { sourceLocale: "en-us", targetLocales: ["fr-fr"] },
-      ),
-    ).toEqual({ ok: true });
+    const result = validateJobLocalesAgainstProject(
+      {
+        source: "native",
+        sourceLocale: "en-US",
+        targetLocales: ["fr-FR", "de-DE"],
+      },
+      { sourceLocale: "en-us", targetLocales: ["fr-fr"] },
+    );
+
+    expect(isOk(result)).toBe(true);
   });
 
   it("rejects native job target outside project scope", () => {
@@ -26,23 +28,23 @@ describe("validateJobLocalesAgainstProject", () => {
       { sourceLocale: "en-US", targetLocales: ["ja-JP"] },
     );
 
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.code).toBe("job_target_locale_not_in_project");
+    expect(isErr(result)).toBe(true);
+    if (isErr(result)) {
+      expect(result.error.code).toBe("job_target_locale_not_in_project");
     }
   });
 
   it("uses exact provider locale IDs for external TMS projects", () => {
-    expect(
-      validateJobLocalesAgainstProject(
-        {
-          source: "external_tms",
-          sourceLocale: "en-US",
-          targetLocales: ["fr-FR"],
-        },
-        { sourceLocale: "en-US", targetLocales: ["fr-FR"] },
-      ),
-    ).toEqual({ ok: true });
+    const valid = validateJobLocalesAgainstProject(
+      {
+        source: "external_tms",
+        sourceLocale: "en-US",
+        targetLocales: ["fr-FR"],
+      },
+      { sourceLocale: "en-US", targetLocales: ["fr-FR"] },
+    );
+
+    expect(isOk(valid)).toBe(true);
 
     const mismatch = validateJobLocalesAgainstProject(
       {
@@ -53,6 +55,6 @@ describe("validateJobLocalesAgainstProject", () => {
       { sourceLocale: "en", targetLocales: ["fr-FR"] },
     );
 
-    expect(mismatch.ok).toBe(false);
+    expect(isErr(mismatch)).toBe(true);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/i18n/project-job-locales.test.ts
+++ b/apps/hyperlocalise-web/src/lib/i18n/project-job-locales.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { validateJobLocalesAgainstProject } from "./project-job-locales";
+
+describe("validateJobLocalesAgainstProject", () => {
+  it("accepts canonical native job locales within project scope", () => {
+    expect(
+      validateJobLocalesAgainstProject(
+        {
+          source: "native",
+          sourceLocale: "en-US",
+          targetLocales: ["fr-FR", "de-DE"],
+        },
+        { sourceLocale: "en-us", targetLocales: ["fr-fr"] },
+      ),
+    ).toEqual({ ok: true });
+  });
+
+  it("rejects native job target outside project scope", () => {
+    const result = validateJobLocalesAgainstProject(
+      {
+        source: "native",
+        sourceLocale: "en-US",
+        targetLocales: ["fr-FR"],
+      },
+      { sourceLocale: "en-US", targetLocales: ["ja-JP"] },
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("job_target_locale_not_in_project");
+    }
+  });
+
+  it("uses exact provider locale IDs for external TMS projects", () => {
+    expect(
+      validateJobLocalesAgainstProject(
+        {
+          source: "external_tms",
+          sourceLocale: "en-US",
+          targetLocales: ["fr-FR"],
+        },
+        { sourceLocale: "en-US", targetLocales: ["fr-FR"] },
+      ),
+    ).toEqual({ ok: true });
+
+    const mismatch = validateJobLocalesAgainstProject(
+      {
+        source: "external_tms",
+        sourceLocale: "en-US",
+        targetLocales: ["fr-FR"],
+      },
+      { sourceLocale: "en", targetLocales: ["fr-FR"] },
+    );
+
+    expect(mismatch.ok).toBe(false);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/i18n/project-job-locales.ts
+++ b/apps/hyperlocalise-web/src/lib/i18n/project-job-locales.ts
@@ -1,0 +1,130 @@
+import { canonicalizeLocale } from "./locales";
+
+type ProjectLocaleScope = {
+  source: "native" | "external_tms";
+  sourceLocale: string | null;
+  targetLocales: string[];
+};
+
+type JobLocaleInput = {
+  sourceLocale: string;
+  targetLocales: string[];
+};
+
+function localeKey(locale: string) {
+  return locale.trim().toLowerCase();
+}
+
+function projectAllowsLocale(
+  project: ProjectLocaleScope,
+  locale: string,
+  role: "source" | "target",
+) {
+  if (project.source === "external_tms") {
+    const allowed =
+      role === "source"
+        ? project.sourceLocale
+          ? [project.sourceLocale]
+          : []
+        : project.targetLocales;
+    return allowed.some((entry) => entry === locale);
+  }
+
+  const canonical = canonicalizeLocale(locale);
+  if (!canonical) {
+    return false;
+  }
+
+  if (role === "source") {
+    return project.sourceLocale ? localeKey(project.sourceLocale) === localeKey(canonical) : true;
+  }
+
+  if (project.targetLocales.length === 0) {
+    return true;
+  }
+
+  return project.targetLocales.some((entry) => localeKey(entry) === localeKey(canonical));
+}
+
+/**
+ * Validates translation job locales against a project's configured locale scope.
+ * External TMS projects use exact provider locale IDs; native projects use canonical BCP-47.
+ */
+export function validateJobLocalesAgainstProject(
+  project: ProjectLocaleScope,
+  input: JobLocaleInput,
+): { ok: true } | { ok: false; code: string; message: string } {
+  if (project.source === "external_tms") {
+    if (project.sourceLocale && input.sourceLocale !== project.sourceLocale) {
+      return {
+        ok: false,
+        code: "job_source_locale_not_in_project",
+        message: "Source locale must match the synced TMS project source locale",
+      };
+    }
+
+    if (project.targetLocales.length > 0) {
+      const invalidTargets = input.targetLocales.filter(
+        (locale) => !project.targetLocales.includes(locale),
+      );
+      if (invalidTargets.length > 0) {
+        return {
+          ok: false,
+          code: "job_target_locale_not_in_project",
+          message: `Target locales must be configured on the project: ${invalidTargets.join(", ")}`,
+        };
+      }
+    }
+
+    return { ok: true };
+  }
+
+  const sourceLocale = canonicalizeLocale(input.sourceLocale);
+  if (!sourceLocale) {
+    return {
+      ok: false,
+      code: "invalid_job_source_locale",
+      message: "Invalid source locale",
+    };
+  }
+
+  if (!projectAllowsLocale(project, sourceLocale, "source")) {
+    return {
+      ok: false,
+      code: "job_source_locale_not_in_project",
+      message: "Source locale must match the project source locale",
+    };
+  }
+
+  const normalizedTargets: string[] = [];
+  for (const raw of input.targetLocales) {
+    const canonical = canonicalizeLocale(raw);
+    if (!canonical) {
+      return {
+        ok: false,
+        code: "invalid_job_target_locale",
+        message: `Invalid target locale: ${raw}`,
+      };
+    }
+
+    if (!projectAllowsLocale(project, canonical, "target")) {
+      return {
+        ok: false,
+        code: "job_target_locale_not_in_project",
+        message: `Target locale is not enabled on this project: ${canonical}`,
+      };
+    }
+
+    normalizedTargets.push(canonical);
+  }
+
+  if (normalizedTargets.some((locale) => localeKey(locale) === localeKey(sourceLocale))) {
+    return {
+      ok: false,
+      code: "job_source_in_targets",
+      message: "Source locale cannot appear in target locales",
+    };
+  }
+
+  return { ok: true };
+}

--- a/apps/hyperlocalise-web/src/lib/i18n/project-job-locales.ts
+++ b/apps/hyperlocalise-web/src/lib/i18n/project-job-locales.ts
@@ -1,4 +1,11 @@
+import { err, ok, type Result } from "@/lib/primitives/result/results";
+
 import { canonicalizeLocale } from "./locales";
+
+export type JobLocaleValidationError = {
+  code: string;
+  message: string;
+};
 
 type ProjectLocaleScope = {
   source: "native" | "external_tms";
@@ -53,14 +60,13 @@ function projectAllowsLocale(
 export function validateJobLocalesAgainstProject(
   project: ProjectLocaleScope,
   input: JobLocaleInput,
-): { ok: true } | { ok: false; code: string; message: string } {
+): Result<void, JobLocaleValidationError> {
   if (project.source === "external_tms") {
     if (project.sourceLocale && input.sourceLocale !== project.sourceLocale) {
-      return {
-        ok: false,
+      return err({
         code: "job_source_locale_not_in_project",
         message: "Source locale must match the synced TMS project source locale",
-      };
+      });
     }
 
     if (project.targetLocales.length > 0) {
@@ -68,63 +74,57 @@ export function validateJobLocalesAgainstProject(
         (locale) => !project.targetLocales.includes(locale),
       );
       if (invalidTargets.length > 0) {
-        return {
-          ok: false,
+        return err({
           code: "job_target_locale_not_in_project",
           message: `Target locales must be configured on the project: ${invalidTargets.join(", ")}`,
-        };
+        });
       }
     }
 
-    return { ok: true };
+    return ok(undefined);
   }
 
   const sourceLocale = canonicalizeLocale(input.sourceLocale);
   if (!sourceLocale) {
-    return {
-      ok: false,
+    return err({
       code: "invalid_job_source_locale",
       message: "Invalid source locale",
-    };
+    });
   }
 
   if (!projectAllowsLocale(project, sourceLocale, "source")) {
-    return {
-      ok: false,
+    return err({
       code: "job_source_locale_not_in_project",
       message: "Source locale must match the project source locale",
-    };
+    });
   }
 
   const normalizedTargets: string[] = [];
   for (const raw of input.targetLocales) {
     const canonical = canonicalizeLocale(raw);
     if (!canonical) {
-      return {
-        ok: false,
+      return err({
         code: "invalid_job_target_locale",
         message: `Invalid target locale: ${raw}`,
-      };
+      });
     }
 
     if (!projectAllowsLocale(project, canonical, "target")) {
-      return {
-        ok: false,
+      return err({
         code: "job_target_locale_not_in_project",
         message: `Target locale is not enabled on this project: ${canonical}`,
-      };
+      });
     }
 
     normalizedTargets.push(canonical);
   }
 
   if (normalizedTargets.some((locale) => localeKey(locale) === localeKey(sourceLocale))) {
-    return {
-      ok: false,
+    return err({
       code: "job_source_in_targets",
       message: "Source locale cannot appear in target locales",
-    };
+    });
   }
 
-  return { ok: true };
+  return ok(undefined);
 }


### PR DESCRIPTION
## What changed

- Added shared BCP-47 locale utilities with a curated list of 40 common locales for quick project setup.
- Native projects now require `sourceLocale` and `targetLocales` on create/update; external TMS projects keep provider-synced locales read-only.
- Translation jobs (project API and public API) validate job locales against the project scope, using canonical BCP-47 for native projects and exact provider IDs for TMS projects.
- Project create/edit UI includes locale pickers; the project Locales page shows configured source/target locales.

## How to test

- `cd apps/hyperlocalise-web && vp check --fix`
- `cd apps/hyperlocalise-web && vp test src/lib/i18n src/api/routes/project/project.test.ts src/api/routes/project/job.test.ts`
- In the app: create a native project with source + target locales, confirm the Locales page, and verify a job with an out-of-scope target locale is rejected.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)