### PR TITLE
fix(crowdin): improve Translations API parity for labels and soft match

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -113,3 +113,15 @@
 **Learning:** The `JoinSlice` utility in the Go SDK was using `fmt.Sprintf` for every element, causing unnecessary reflection and allocations in hot paths like query parameter encoding. Additionally, `BundleAddRequest` was missing `omitempty` tags for optional label fields, which could lead to sending empty arrays to the Crowdin API.
 
 **Action:** Optimized `model.JoinSlice` in `utils.go` by using `strings.Builder` and type switches for `int` and `string` to significantly reduce allocations. Added `omitempty` to `LabelIDs` and `ExcludeLabelIDs` in `BundleAddRequest` and corrected the documentation comment for `ExcludeLabelIDs`. Verified with focused unit tests and the full test suite.
+
+## 2026-08-22 - Improve Translations API parity for labels and soft match
+
+**Learning:** The Crowdin Translations API v2 supports several parameters that were missing from the Go SDK, specifically filtering by labels during project and directory builds, and the 'soft match' option for pre-translations. Additionally, uploading translations supports marking them as done immediately.
+
+**Action:** Added  (*bool) to  and . Added  ([]int) to , , and , and updated  to include them. Added  (*bool) to . Verified with comprehensive unit tests in  and .
+
+## 2026-08-22 - Improve Translations API parity for labels and soft match
+
+**Learning:** The Crowdin Translations API v2 supports several parameters that were missing from the Go SDK, specifically filtering by labels during project and directory builds, and the 'soft match' option for pre-translations. Additionally, uploading translations supports marking them as done immediately.
+
+**Action:** Added `TranslateWithSoftMatchOnly` (*bool) to `PreTranslationRequest` and `PreTranslationAttributes`. Added `LabelIDs` ([]int) to `BuildProjectRequest`, `BuildProjectDirectoryTranslationRequest`, and `BuildAttributes`, and updated `MarshalJSON` to include them. Added `MarkAddedAsDone` (*bool) to `UploadTranslationsRequest`. Verified with comprehensive unit tests in `translations_test.go` and `model/translations_test.go`.

--- a/third_party/crowdin-api-client-go/crowdin/model/translations.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/translations.go
@@ -35,6 +35,7 @@ type (
 		SkipApprovedTranslations      *bool               `json:"skipApprovedTranslations,omitempty"`
 		TranslateUntranslatedOnly     *bool               `json:"translateUntranslatedOnly,omitempty"`
 		TranslateWithPerfectMatchOnly *bool               `json:"translateWithPerfectMatchOnly,omitempty"`
+		TranslateWithSoftMatchOnly    *bool               `json:"translateWithSoftMatchOnly,omitempty"`
 		FallbackLanguages             map[string][]string `json:"fallbackLanguages,omitempty"`
 		LabelIDs                      []int               `json:"labelIds,omitempty"`
 		ExcludeLabelIDs               []int               `json:"excludeLabelIds,omitempty"`
@@ -133,6 +134,9 @@ type PreTranslationRequest struct {
 	// (source text and contextual information are identical). Default is false.
 	// Note: Works only with TM pre-translation method.
 	TranslateWithPerfectMatchOnly *bool `json:"translateWithPerfectMatchOnly,omitempty"`
+	// Applies pre-translation only for the strings with soft match. Default is false.
+	// Note: Works only with TM pre-translation method.
+	TranslateWithSoftMatchOnly *bool `json:"translateWithSoftMatchOnly,omitempty"`
 	// Defines fallback languages mapping. The passed value should contain a map of
 	// languageID as a key and an array of fallback language IDs as a value.
 	//  - languageID – Crowdin ID for the specified language.
@@ -182,6 +186,8 @@ type BuildProjectDirectoryTranslationRequest struct {
 	ExportApprovedOnly *bool `json:"exportApprovedOnly,omitempty"`
 	// Preserve folder hierarchy. Default: false.
 	PreserveFolderHierarchy *bool `json:"preserveFolderHierarchy,omitempty"`
+	// Label Identifiers.
+	LabelIDs []int `json:"labelIds,omitempty"`
 
 	// Defines whether to export only approved strings.
 	// Note: value greater than 0 can't be used with `exportStringsThatPassedWorkflow=true`
@@ -200,6 +206,7 @@ func (r *BuildProjectDirectoryTranslationRequest) MarshalJSON() ([]byte, error) 
 		SkipUntranslatedStrings         *bool    `json:"skipUntranslatedStrings,omitempty"`
 		SkipUntranslatedFiles           *bool    `json:"skipUntranslatedFiles,omitempty"`
 		PreserveFolderHierarchy         *bool    `json:"preserveFolderHierarchy,omitempty"`
+		LabelIDs                        []int    `json:"labelIds,omitempty"`
 		ExportWithMinApprovalsCount     *int     `json:"exportWithMinApprovalsCount,omitempty"`
 		ExportStringsThatPassedWorkflow *bool    `json:"exportStringsThatPassedWorkflow,omitempty"`
 	}
@@ -215,6 +222,7 @@ func (r *BuildProjectDirectoryTranslationRequest) MarshalJSON() ([]byte, error) 
 		SkipUntranslatedStrings:         r.SkipUntranslatedStrings,
 		SkipUntranslatedFiles:           r.SkipUntranslatedFiles,
 		PreserveFolderHierarchy:         r.PreserveFolderHierarchy,
+		LabelIDs:                        r.LabelIDs,
 		ExportWithMinApprovalsCount:     exportWithMinApprovalsCount,
 		ExportStringsThatPassedWorkflow: r.ExportStringsThatPassedWorkflow,
 	})
@@ -366,6 +374,7 @@ type BuildAttributes struct {
 	ExportApprovedOnly              *bool    `json:"exportApprovedOnly,omitempty"`
 	ExportWithMinApprovalsCount     *int     `json:"exportWithMinApprovalsCount,omitempty"`
 	ExportStringsThatPassedWorkflow *bool    `json:"exportStringsThatPassedWorkflow,omitempty"`
+	LabelIDs                        []int    `json:"labelIds,omitempty"`
 
 	Pseudo               *bool   `json:"pseudo,omitempty"`
 	Prefix               *string `json:"prefix,omitempty"`
@@ -408,6 +417,8 @@ type (
 		SkipUntranslatedFiles *bool `json:"skipUntranslatedFiles,omitempty"`
 		// Defines whether to export only approved strings.
 		ExportApprovedOnly *bool `json:"exportApprovedOnly,omitempty"`
+		// Label Identifiers.
+		LabelIDs []int `json:"labelIds,omitempty"`
 
 		// Defines whether to export only approved strings.
 		// Note: value greater than 0 can't be used with `exportStringsThatPassedWorkflow=true`
@@ -452,6 +463,7 @@ func (r *BuildProjectRequest) MarshalJSON() ([]byte, error) {
 		TargetLanguageIDs               []string `json:"targetLanguageIds,omitempty"`
 		SkipUntranslatedStrings         *bool    `json:"skipUntranslatedStrings,omitempty"`
 		SkipUntranslatedFiles           *bool    `json:"skipUntranslatedFiles,omitempty"`
+		LabelIDs                        []int    `json:"labelIds,omitempty"`
 		ExportWithMinApprovalsCount     *int     `json:"exportWithMinApprovalsCount,omitempty"`
 		ExportStringsThatPassedWorkflow *bool    `json:"exportStringsThatPassedWorkflow,omitempty"`
 	}
@@ -467,6 +479,7 @@ func (r *BuildProjectRequest) MarshalJSON() ([]byte, error) {
 		TargetLanguageIDs:               r.TargetLanguageIDs,
 		SkipUntranslatedStrings:         r.SkipUntranslatedStrings,
 		SkipUntranslatedFiles:           r.SkipUntranslatedFiles,
+		LabelIDs:                        r.LabelIDs,
 		ExportWithMinApprovalsCount:     exportWithMinApprovalsCount,
 		ExportStringsThatPassedWorkflow: r.ExportStringsThatPassedWorkflow,
 	})
@@ -535,6 +548,8 @@ type UploadTranslationsRequest struct {
 	TranslateHidden *bool `json:"translateHidden,omitempty"`
 	// Defines whether to add translation to TM. Default: true.
 	AddToTM *bool `json:"addToTm,omitempty"`
+	// Mark added translations as done. Default: false.
+	MarkAddedAsDone *bool `json:"markAddedAsDone,omitempty"`
 }
 
 // Validate checks if the upload translations request is valid.

--- a/third_party/crowdin-api-client-go/crowdin/model/translations_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/translations_test.go
@@ -33,6 +33,7 @@ func TestPreTranslationRequestValidate(t *testing.T) {
 			req: &PreTranslationRequest{
 				LanguageIDs: []string{"uk"}, FileIDs: []int{1, 2},
 				Method: "tm", EngineID: toPtr(1), AutoApproveOption: "all", DuplicateTranslations: toPtr(false),
+				TranslateWithSoftMatchOnly: toPtr(true),
 			},
 			valid: true,
 		},
@@ -135,6 +136,7 @@ func TestBuildProjectDirectoryTranslationRequestValidate(t *testing.T) {
 			req: &BuildProjectDirectoryTranslationRequest{
 				TargetLanguageIDs:       []string{"en"},
 				SkipUntranslatedStrings: toPtr(true), ExportApprovedOnly: toPtr(true),
+				LabelIDs: []int{1, 2},
 			},
 			valid: true,
 		},
@@ -271,7 +273,7 @@ func TestBuildProjectRequestValidate(t *testing.T) {
 			name: "valid request",
 			req: &BuildProjectRequest{
 				BranchID: 1, TargetLanguageIDs: []string{"en"}, SkipUntranslatedStrings: toPtr(true),
-				ExportApprovedOnly: toPtr(true),
+				ExportApprovedOnly: toPtr(true), LabelIDs: []int{1, 2},
 			},
 			valid: true,
 		},
@@ -358,7 +360,7 @@ func TestUploadTranslationsRequestValidate(t *testing.T) {
 			req: &UploadTranslationsRequest{
 				StorageID: 1, FileID: 2, BranchID: 0,
 				ImportEqSuggestions: toPtr(true), AutoApproveImported: toPtr(true), TranslateHidden: toPtr(true),
-				AddToTM: toPtr(false),
+				AddToTM: toPtr(false), MarkAddedAsDone: toPtr(true),
 			},
 			valid: true,
 		},

--- a/third_party/crowdin-api-client-go/crowdin/translations_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/translations_test.go
@@ -36,6 +36,7 @@ func TestTranslationsService_PreTranslationStatus(t *testing.T) {
 					"skipApprovedTranslations": true,
 					"translateUntranslatedOnly": true,
 					"translateWithPerfectMatchOnly": true,
+					"translateWithSoftMatchOnly": true,
 					"fallbackLanguages": {
 						"es": ["en"]
 					},
@@ -69,6 +70,7 @@ func TestTranslationsService_PreTranslationStatus(t *testing.T) {
 			SkipApprovedTranslations:      ToPtr(true),
 			TranslateUntranslatedOnly:     ToPtr(true),
 			TranslateWithPerfectMatchOnly: ToPtr(true),
+			TranslateWithSoftMatchOnly:    ToPtr(true),
 			FallbackLanguages: map[string][]string{
 				"es": {"en"},
 			},
@@ -353,6 +355,7 @@ func TestTranslationsService_ApplyPreTranslation(t *testing.T) {
 			"skipApprovedTranslations": true,
 			"translateUntranslatedOnly": false,
 			"translateWithPerfectMatchOnly": true,
+			"translateWithSoftMatchOnly": true,
 			"fallbackLanguages": {
 			  	"languageId": ["uk"]
 			},
@@ -377,6 +380,7 @@ func TestTranslationsService_ApplyPreTranslation(t *testing.T) {
 					"skipApprovedTranslations": true,
 					"translateUntranslatedOnly": false,
 					"translateWithPerfectMatchOnly": true,
+					"translateWithSoftMatchOnly": true,
 					"fallbackLanguages": {
 						"languageId": ["uk"]
 					},
@@ -401,6 +405,7 @@ func TestTranslationsService_ApplyPreTranslation(t *testing.T) {
 		SkipApprovedTranslations:      ToPtr(true),
 		TranslateUntranslatedOnly:     ToPtr(false),
 		TranslateWithPerfectMatchOnly: ToPtr(true),
+		TranslateWithSoftMatchOnly:    ToPtr(true),
 		FallbackLanguages: map[string][]string{
 			"languageId": {"uk"},
 		},
@@ -425,6 +430,7 @@ func TestTranslationsService_ApplyPreTranslation(t *testing.T) {
 			SkipApprovedTranslations:      ToPtr(true),
 			TranslateUntranslatedOnly:     ToPtr(false),
 			TranslateWithPerfectMatchOnly: ToPtr(true),
+			TranslateWithSoftMatchOnly:    ToPtr(true),
 			FallbackLanguages: map[string][]string{
 				"languageId": {"uk"},
 			},
@@ -470,9 +476,10 @@ func TestTranslationsService_BuildProjectDirectoryTranslation(t *testing.T) {
 			"targetLanguageIds": ["uk"],
 			"skipUntranslatedStrings": false,
 			"skipUntranslatedFiles": false,
+			"preserveFolderHierarchy": false,
+			"labelIds": [10],
 			"exportWithMinApprovalsCount": 0,
-			"exportStringsThatPassedWorkflow": true,
-			"preserveFolderHierarchy": false
+			"exportStringsThatPassedWorkflow": true
 		}`
 		testJSONBody(t, r, expectedReqBody)
 
@@ -498,6 +505,7 @@ func TestTranslationsService_BuildProjectDirectoryTranslation(t *testing.T) {
 		ExportWithMinApprovalsCount:     ToPtr(0),
 		ExportStringsThatPassedWorkflow: ToPtr(true),
 		PreserveFolderHierarchy:         ToPtr(false),
+		LabelIDs:                        []int{10},
 	}
 	buildTranslation, resp, err := client.Translations.BuildProjectDirectoryTranslation(context.Background(), 1, 2, req)
 	require.NoError(t, err)
@@ -636,7 +644,8 @@ func TestTranslationsService_ListProjectBuilds(t *testing.T) {
 								"skipUntranslatedStrings": false,
 								"skipUntranslatedFiles": false,
 								"exportWithMinApprovalsCount": 0,
-								"exportStringsThatPassedWorkflow": true
+								"exportStringsThatPassedWorkflow": true,
+								"labelIds": [30]
 							}
 						}
 					}
@@ -667,6 +676,7 @@ func TestTranslationsService_ListProjectBuilds(t *testing.T) {
 						SkipUntranslatedFiles:           ToPtr(false),
 						ExportWithMinApprovalsCount:     ToPtr(0),
 						ExportStringsThatPassedWorkflow: ToPtr(true),
+						LabelIDs:                        []int{30},
 					},
 				},
 			}
@@ -708,6 +718,7 @@ func TestTranslationsService_BuildProjectTranslation(t *testing.T) {
 				SkipUntranslatedStrings: ToPtr(true),
 				SkipUntranslatedFiles:   ToPtr(false),
 				ExportApprovedOnly:      ToPtr(true),
+				LabelIDs:                []int{20},
 
 				ExportStringsThatPassedWorkflow: ToPtr(false),
 			},
@@ -717,7 +728,8 @@ func TestTranslationsService_BuildProjectTranslation(t *testing.T) {
 				"skipUntranslatedStrings": true,
 				"skipUntranslatedFiles": false,
 				"exportWithMinApprovalsCount": 1,
-				"exportStringsThatPassedWorkflow": false
+				"exportStringsThatPassedWorkflow": false,
+				"labelIds": [20]
 			}`,
 		},
 		{
@@ -765,7 +777,8 @@ func TestTranslationsService_BuildProjectTranslation(t *testing.T) {
 							"skipUntranslatedStrings": false,
 							"skipUntranslatedFiles": false,
 							"exportWithMinApprovalsCount": 0,
-							"exportStringsThatPassedWorkflow": true
+							"exportStringsThatPassedWorkflow": true,
+							"labelIds": [30]
 						}
 					}
 				}`)
@@ -790,6 +803,7 @@ func TestTranslationsService_BuildProjectTranslation(t *testing.T) {
 					SkipUntranslatedFiles:           ToPtr(false),
 					ExportWithMinApprovalsCount:     ToPtr(0),
 					ExportStringsThatPassedWorkflow: ToPtr(true),
+					LabelIDs:                        []int{30},
 				},
 			}
 			assert.Equal(t, expected, build)
@@ -864,7 +878,8 @@ func TestTranslationsService_UploadTranslations(t *testing.T) {
 			"importEqSuggestions": true,
 			"autoApproveImported": false,
 			"translateHidden": false,
-			"addToTm": false
+			"addToTm": false,
+			"markAddedAsDone": true
 		}`)
 
 		fmt.Fprint(w, `{
@@ -884,6 +899,7 @@ func TestTranslationsService_UploadTranslations(t *testing.T) {
 		AutoApproveImported: ToPtr(false),
 		TranslateHidden:     ToPtr(false),
 		AddToTM:             ToPtr(false),
+		MarkAddedAsDone:     ToPtr(true),
 	}
 	uploadTranslations, resp, err := client.Translations.UploadTranslations(context.Background(), 1, "uk", req)
 	require.NoError(t, err)
@@ -950,7 +966,8 @@ func TestTranslationsService_CheckBuildStatus(t *testing.T) {
 					"skipUntranslatedStrings": false,
 					"skipUntranslatedFiles": false,
 					"exportWithMinApprovalsCount": 0,
-					"exportStringsThatPassedWorkflow": true
+					"exportStringsThatPassedWorkflow": true,
+					"labelIds": [30]
 				}
 			}
 		}`)
@@ -974,6 +991,7 @@ func TestTranslationsService_CheckBuildStatus(t *testing.T) {
 			SkipUntranslatedFiles:           ToPtr(false),
 			ExportWithMinApprovalsCount:     ToPtr(0),
 			ExportStringsThatPassedWorkflow: ToPtr(true),
+			LabelIDs:                        []int{30},
 		},
 	}
 	assert.Equal(t, expected, build)


### PR DESCRIPTION
Improved Crowdin Translations API v2 parity by adding missing fields for label filtering, soft match in pre-translations, and 'mark as done' in uploads. Updated custom marshaling logic and verified with comprehensive unit tests.

---
*PR created automatically by Jules for task [11221391992885622017](https://jules.google.com/task/11221391992885622017) started by @cungminh2710*