### PR TITLE
🎨 Palette: Add tooltips to message branch navigation

### DIFF
--- a/apps/hyperlocalise-web/src/components/ai-elements/message.test.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/message.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MessageBranch, MessageBranchPrevious, MessageBranchNext } from "./message";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+describe("MessageBranch Navigation Tooltips", () => {
+  it("MessageBranchPrevious renders with tooltip trigger", () => {
+    const markup = renderToStaticMarkup(
+      <TooltipProvider>
+        <MessageBranch>
+          <MessageBranchPrevious />
+        </MessageBranch>
+      </TooltipProvider>
+    );
+
+    expect(markup).toContain('data-slot="tooltip-trigger"');
+    expect(markup).toContain('aria-label="Previous branch"');
+
+    // Ensure no nested buttons
+    const buttonCount = (markup.match(/<button/g) || []).length;
+    expect(buttonCount).toBe(1);
+  });
+
+  it("MessageBranchNext renders with tooltip trigger", () => {
+    const markup = renderToStaticMarkup(
+      <TooltipProvider>
+        <MessageBranch>
+          <MessageBranchNext />
+        </MessageBranch>
+      </TooltipProvider>
+    );
+
+    expect(markup).toContain('data-slot="tooltip-trigger"');
+    expect(markup).toContain('aria-label="Next branch"');
+
+    // Ensure no nested buttons
+    const buttonCount = (markup.match(/<button/g) || []).length;
+    expect(buttonCount).toBe(1);
+  });
+});

--- a/apps/hyperlocalise-web/src/components/ai-elements/message.test.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/message.test.tsx
@@ -11,7 +11,7 @@ describe("MessageBranch Navigation Tooltips", () => {
         <MessageBranch>
           <MessageBranchPrevious />
         </MessageBranch>
-      </TooltipProvider>
+      </TooltipProvider>,
     );
 
     expect(markup).toContain('data-slot="tooltip-trigger"');
@@ -28,7 +28,7 @@ describe("MessageBranch Navigation Tooltips", () => {
         <MessageBranch>
           <MessageBranchNext />
         </MessageBranch>
-      </TooltipProvider>
+      </TooltipProvider>,
     );
 
     expect(markup).toContain('data-slot="tooltip-trigger"');

--- a/apps/hyperlocalise-web/src/components/ai-elements/message.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/message.tsx
@@ -220,17 +220,24 @@ export const MessageBranchPrevious = ({ children, ...props }: MessageBranchPrevi
   const { goToPrevious, totalBranches } = useMessageBranch();
 
   return (
-    <Button
-      aria-label="Previous branch"
-      disabled={totalBranches <= 1}
-      onClick={goToPrevious}
-      size="icon-sm"
-      type="button"
-      variant="ghost"
-      {...props}
-    >
-      {children ?? <ChevronLeftIcon size={14} />}
-    </Button>
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Button
+            aria-label="Previous branch"
+            disabled={totalBranches <= 1}
+            onClick={goToPrevious}
+            size="icon-sm"
+            type="button"
+            variant="ghost"
+            {...props}
+          >
+            {children ?? <ChevronLeftIcon size={14} />}
+          </Button>
+        }
+      />
+      <TooltipContent side="bottom">Previous branch</TooltipContent>
+    </Tooltip>
   );
 };
 
@@ -240,17 +247,24 @@ export const MessageBranchNext = ({ children, ...props }: MessageBranchNextProps
   const { goToNext, totalBranches } = useMessageBranch();
 
   return (
-    <Button
-      aria-label="Next branch"
-      disabled={totalBranches <= 1}
-      onClick={goToNext}
-      size="icon-sm"
-      type="button"
-      variant="ghost"
-      {...props}
-    >
-      {children ?? <ChevronRightIcon size={14} />}
-    </Button>
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Button
+            aria-label="Next branch"
+            disabled={totalBranches <= 1}
+            onClick={goToNext}
+            size="icon-sm"
+            type="button"
+            variant="ghost"
+            {...props}
+          >
+            {children ?? <ChevronRightIcon size={14} />}
+          </Button>
+        }
+      />
+      <TooltipContent side="bottom">Next branch</TooltipContent>
+    </Tooltip>
   );
 };
 


### PR DESCRIPTION
Add tooltips to the message branch navigation buttons to improve accessibility and discoverability. Includes unit tests for the new functionality.

---
*PR created automatically by Jules for task [13855804824030503634](https://jules.google.com/task/13855804824030503634) started by @cungminh2710*