### PR TITLE
feat(web): add automations UI with dispatch and notifications

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/cron/github-repository-automation-dispatch.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/cron/github-repository-automation-dispatch.route.test.ts
@@ -14,6 +14,13 @@ const runGithubRepositoryAutomationWorkerMock = vi.fn(async () => ({
   skipped: 0,
 }));
 
+const runWorkspaceAutomationSchedulerMock = vi.fn(async () => ({
+  processed: 1,
+  enqueued: 1,
+  skipped: 0,
+  duplicates: 0,
+}));
+
 async function createClient(input?: { enabled?: boolean; cronSecret?: string | null }) {
   vi.resetModules();
   vi.doMock("@/lib/agents/github/github-repository-automation-scheduler", () => ({
@@ -21,6 +28,9 @@ async function createClient(input?: { enabled?: boolean; cronSecret?: string | n
   }));
   vi.doMock("@/lib/agents/github/github-repository-automation-worker", () => ({
     runGithubRepositoryAutomationWorker: runGithubRepositoryAutomationWorkerMock,
+  }));
+  vi.doMock("@/lib/agents/workspace-automation-scheduler", () => ({
+    runWorkspaceAutomationScheduler: runWorkspaceAutomationSchedulerMock,
   }));
   vi.doMock("@/lib/env", () => ({
     env: {
@@ -42,9 +52,11 @@ describe("github repository automation dispatch cron route", () => {
     vi.resetModules();
     vi.doUnmock("@/lib/agents/github/github-repository-automation-scheduler");
     vi.doUnmock("@/lib/agents/github/github-repository-automation-worker");
+    vi.doUnmock("@/lib/agents/workspace-automation-scheduler");
     vi.doUnmock("@/lib/env");
     runGithubRepositoryAutomationSchedulerMock.mockClear();
     runGithubRepositoryAutomationWorkerMock.mockClear();
+    runWorkspaceAutomationSchedulerMock.mockClear();
   });
 
   it("rejects requests without the cron secret", async () => {
@@ -77,6 +89,12 @@ describe("github repository automation dispatch cron route", () => {
           skipped: 0,
           duplicates: 0,
         },
+        workspaceAutomationScheduler: {
+          processed: 1,
+          enqueued: 1,
+          skipped: 0,
+          duplicates: 0,
+        },
         worker: {
           processed: 1,
           started: 1,
@@ -85,6 +103,7 @@ describe("github repository automation dispatch cron route", () => {
       },
     });
     expect(runGithubRepositoryAutomationSchedulerMock).toHaveBeenCalledTimes(1);
+    expect(runWorkspaceAutomationSchedulerMock).toHaveBeenCalledTimes(1);
     expect(runGithubRepositoryAutomationWorkerMock).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/hyperlocalise-web/src/api/routes/cron/github-repository-automation-dispatch.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/cron/github-repository-automation-dispatch.route.ts
@@ -4,6 +4,7 @@ import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
 import { env } from "@/lib/env";
 import { runGithubRepositoryAutomationScheduler } from "@/lib/agents/github/github-repository-automation-scheduler";
 import { runGithubRepositoryAutomationWorker } from "@/lib/agents/github/github-repository-automation-worker";
+import { runWorkspaceAutomationScheduler } from "@/lib/agents/workspace-automation-scheduler";
 
 function readCronSecret(request: Request) {
   const authorization = request.headers.get("authorization");
@@ -41,11 +42,23 @@ export function createGithubRepositoryAutomationDispatchRoutes() {
     const schedulerResults = await runGithubRepositoryAutomationScheduler({
       limit: env.GITHUB_REPOSITORY_AUTOMATION_DISPATCH_MAX_REPOS_PER_TICK,
     });
+    const workspaceAutomationSchedulerResults = await runWorkspaceAutomationScheduler({
+      limit: env.GITHUB_REPOSITORY_AUTOMATION_DISPATCH_MAX_REPOS_PER_TICK,
+    });
 
     const workerResults = await runGithubRepositoryAutomationWorker({
       limit: env.GITHUB_REPOSITORY_AUTOMATION_DISPATCH_MAX_REPOS_PER_TICK,
     });
 
-    return c.json({ results: { scheduler: schedulerResults, worker: workerResults } }, 200);
+    return c.json(
+      {
+        results: {
+          scheduler: schedulerResults,
+          workspaceAutomationScheduler: workspaceAutomationSchedulerResults,
+          worker: workerResults,
+        },
+      },
+      200,
+    );
   });
 }

--- a/apps/hyperlocalise-web/src/api/routes/workspace-automation/workspace-automation.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/workspace-automation/workspace-automation.route.ts
@@ -12,6 +12,7 @@ import {
   listWorkspaceAutomationRuns,
   listWorkspaceAutomations,
   updateWorkspaceAutomation,
+  validateWorkspaceAutomationIntegrations,
   type WorkspaceAutomationConfigValidationError,
   type WorkspaceAutomationRepositoryTarget,
   type WorkspaceAutomationToolConfig,
@@ -249,6 +250,14 @@ export function createWorkspaceAutomationRoutes() {
         return mapReferenceError(c, referenceError);
       }
 
+      const integrationValidation = await validateWorkspaceAutomationIntegrations({
+        organizationId,
+        toolConfig: payload.toolConfig,
+      });
+      if (isErr(integrationValidation)) {
+        return mapAutomationConfigValidationError(c, integrationValidation.error);
+      }
+
       try {
         const result = await createWorkspaceAutomation({
           organizationId,
@@ -310,6 +319,14 @@ export function createWorkspaceAutomationRoutes() {
       });
       if (referenceError !== "ok") {
         return mapReferenceError(c, referenceError);
+      }
+
+      const integrationValidation = await validateWorkspaceAutomationIntegrations({
+        organizationId,
+        toolConfig: payload.toolConfig ?? existing.toolConfig,
+      });
+      if (isErr(integrationValidation)) {
+        return mapAutomationConfigValidationError(c, integrationValidation.error);
       }
 
       try {

--- a/apps/hyperlocalise-web/src/api/routes/workspace-automation/workspace-automation.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/workspace-automation/workspace-automation.route.ts
@@ -12,7 +12,6 @@ import {
   listWorkspaceAutomationRuns,
   listWorkspaceAutomations,
   updateWorkspaceAutomation,
-  validateWorkspaceAutomationIntegrations,
   type WorkspaceAutomationConfigValidationError,
   type WorkspaceAutomationRepositoryTarget,
   type WorkspaceAutomationToolConfig,
@@ -250,14 +249,6 @@ export function createWorkspaceAutomationRoutes() {
         return mapReferenceError(c, referenceError);
       }
 
-      const integrationValidation = await validateWorkspaceAutomationIntegrations({
-        organizationId,
-        toolConfig: payload.toolConfig,
-      });
-      if (isErr(integrationValidation)) {
-        return mapAutomationConfigValidationError(c, integrationValidation.error);
-      }
-
       try {
         const result = await createWorkspaceAutomation({
           organizationId,
@@ -319,14 +310,6 @@ export function createWorkspaceAutomationRoutes() {
       });
       if (referenceError !== "ok") {
         return mapReferenceError(c, referenceError);
-      }
-
-      const integrationValidation = await validateWorkspaceAutomationIntegrations({
-        organizationId,
-        toolConfig: payload.toolConfig ?? existing.toolConfig,
-      });
-      if (isErr(integrationValidation)) {
-        return mapAutomationConfigValidationError(c, integrationValidation.error);
       }
 
       try {

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/automations/[automationId]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/automations/[automationId]/page.tsx
@@ -1,0 +1,20 @@
+import { Suspense } from "react";
+
+import { AutomationDetailPageContent } from "../_components/automation-detail-page-content";
+
+export default async function AutomationDetailPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string; automationId: string }>;
+}) {
+  const { organizationSlug, automationId } = await params;
+
+  return (
+    <Suspense fallback={null}>
+      <AutomationDetailPageContent
+        organizationSlug={organizationSlug}
+        automationId={automationId}
+      />
+    </Suspense>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/automations/_components/automation-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/automations/_components/automation-detail-page-content.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { SparklesIcon } from "@hugeicons/core-free-icons";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { apiClient } from "@/lib/api-client-instance";
+import type { WorkspaceAutomationRunRecord } from "@/lib/agents/workspace-automations";
+import {
+  createWorkspaceAutomationFormStateFromRecord,
+  formStateToWorkspaceAutomationPayload,
+  mapWorkspaceAutomationApiErrorToFieldErrors,
+  validateWorkspaceAutomationFormState,
+} from "@/lib/agents/workspace-automation-view-model";
+import { PageHeader, WorkspacePageShell } from "../../_components/workspace-resource-shared";
+import { WorkspaceAutomationForm } from "./workspace-automation-form";
+
+export function AutomationDetailPageContent({
+  organizationSlug,
+  automationId,
+}: {
+  organizationSlug: string;
+  automationId: string;
+}) {
+  const queryClient = useQueryClient();
+  const [activeTab, setActiveTab] = useState<"settings" | "history">("settings");
+
+  const automationQuery = useQuery({
+    queryKey: ["workspace-automation", organizationSlug, automationId],
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"].automations[
+        ":automationId"
+      ].$get({
+        param: { organizationSlug, automationId },
+      });
+      if (!response.ok) {
+        throw new Error("Failed to load automation");
+      }
+      return response.json();
+    },
+  });
+
+  const automation = automationQuery.data?.automation;
+  const recentRuns = automationQuery.data?.recentRuns ?? [];
+  const [form, setForm] = useState<ReturnType<
+    typeof createWorkspaceAutomationFormStateFromRecord
+  > | null>(null);
+  const [errors, setErrors] = useState<Record<string, string | undefined>>({});
+
+  useEffect(() => {
+    if (automation) {
+      setForm(createWorkspaceAutomationFormStateFromRecord(automation));
+    }
+  }, [automation]);
+
+  const saveMutation = useMutation({
+    mutationFn: async () => {
+      if (!form) {
+        throw new Error("missing_form");
+      }
+
+      const fieldErrors = validateWorkspaceAutomationFormState(form);
+      if (Object.keys(fieldErrors).length > 0) {
+        setErrors(fieldErrors);
+        throw new Error("validation_failed");
+      }
+
+      const payload = formStateToWorkspaceAutomationPayload(form);
+      const response = await apiClient.api.orgs[":organizationSlug"].automations[
+        ":automationId"
+      ].$patch({
+        param: { organizationSlug, automationId },
+        json: payload,
+      });
+
+      if (!response.ok) {
+        const body = (await response.json().catch(() => null)) as {
+          error?: string;
+        } | null;
+        if (body?.error) {
+          setErrors(mapWorkspaceAutomationApiErrorToFieldErrors(body.error));
+        }
+        throw new Error("Failed to update automation");
+      }
+
+      return response.json();
+    },
+    onSuccess: () => {
+      toast.success("Automation updated");
+      void queryClient.invalidateQueries({
+        queryKey: ["workspace-automation", organizationSlug, automationId],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ["workspace-automations", organizationSlug],
+      });
+    },
+    onError: (error) => {
+      if (error.message === "validation_failed") {
+        return;
+      }
+      toast.error("Unable to save automation right now");
+    },
+  });
+
+  const runMutation = useMutation({
+    mutationFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"].automations[
+        ":automationId"
+      ].runs.$post({
+        param: { organizationSlug, automationId },
+        json: {
+          idempotencyKey: `manual:${automationId}:${Date.now()}`,
+        },
+      });
+      if (!response.ok) {
+        throw new Error("Failed to queue automation run");
+      }
+      return response.json();
+    },
+    onSuccess: () => {
+      toast.success("Manual run queued");
+      void queryClient.invalidateQueries({
+        queryKey: ["workspace-automation", organizationSlug, automationId],
+      });
+    },
+    onError: () => {
+      toast.error("Unable to queue a manual run right now");
+    },
+  });
+
+  if (automationQuery.isLoading || !form || !automation) {
+    return (
+      <WorkspacePageShell>
+        <p className="text-sm text-muted-foreground">Loading automation...</p>
+      </WorkspacePageShell>
+    );
+  }
+
+  return (
+    <WorkspacePageShell>
+      <PageHeader
+        icon={SparklesIcon}
+        title={automation.name}
+        description="Configure deterministic workflows, notifications, and inspect run history."
+        statusLabel={automation.status}
+        actions={
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              onClick={() => runMutation.mutate()}
+              disabled={runMutation.isPending || automation.status !== "active"}
+            >
+              Run now
+            </Button>
+            <Button onClick={() => saveMutation.mutate()} disabled={saveMutation.isPending}>
+              {saveMutation.isPending ? "Saving..." : "Save changes"}
+            </Button>
+          </div>
+        }
+      />
+
+      <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as typeof activeTab)}>
+        <TabsList>
+          <TabsTrigger value="settings">Settings</TabsTrigger>
+          <TabsTrigger value="history">Run history</TabsTrigger>
+        </TabsList>
+        <TabsContent value="settings" className="mt-6">
+          <WorkspaceAutomationForm
+            organizationSlug={organizationSlug}
+            form={form}
+            errors={errors}
+            onChange={setForm}
+          />
+        </TabsContent>
+        <TabsContent value="history" className="mt-6">
+          <RunHistoryTable runs={recentRuns} />
+        </TabsContent>
+      </Tabs>
+
+      <div className="pt-4">
+        <Button variant="outline" render={<Link href={`/org/${organizationSlug}/automations`} />}>
+          Back to automations
+        </Button>
+      </div>
+    </WorkspacePageShell>
+  );
+}
+
+function RunHistoryTable({ runs }: { runs: WorkspaceAutomationRunRecord[] }) {
+  if (runs.length === 0) {
+    return <p className="text-sm text-muted-foreground">No runs yet.</p>;
+  }
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-foreground/10">
+      <div className="grid grid-cols-[minmax(0,0.8fr)_minmax(0,0.8fr)_minmax(0,1fr)_minmax(0,0.8fr)] gap-4 border-b border-foreground/10 px-4 py-3 text-xs font-medium text-muted-foreground">
+        <span>Status</span>
+        <span>Trigger</span>
+        <span>Summary</span>
+        <span>Completed</span>
+      </div>
+      {runs.map((run) => (
+        <div
+          key={run.id}
+          className="grid grid-cols-[minmax(0,0.8fr)_minmax(0,0.8fr)_minmax(0,1fr)_minmax(0,0.8fr)] gap-4 border-b border-foreground/10 px-4 py-4 text-sm last:border-b-0"
+        >
+          <Badge variant="outline">{run.status}</Badge>
+          <span>{run.triggerSource}</span>
+          <span className="truncate text-muted-foreground">
+            {Object.keys(run.outputSummary).length > 0 ? JSON.stringify(run.outputSummary) : "—"}
+          </span>
+          <span className="text-muted-foreground">
+            {run.completedAt ? new Date(run.completedAt).toLocaleString() : "—"}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/automations/_components/automations-new-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/automations/_components/automations-new-page-content.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useMemo, useState } from "react";
+import { SparklesIcon } from "@hugeicons/core-free-icons";
+import { useMutation } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { TypographyH1, TypographyP } from "@/components/ui/typography";
+import { apiClient } from "@/lib/api-client-instance";
+import {
+  createDefaultWorkspaceAutomationFormState,
+  createWorkspaceAutomationFormStateFromTemplate,
+  formStateToWorkspaceAutomationPayload,
+  mapWorkspaceAutomationApiErrorToFieldErrors,
+  validateWorkspaceAutomationFormState,
+} from "@/lib/agents/workspace-automation-view-model";
+import { PageHeader, WorkspacePageShell } from "../../_components/workspace-resource-shared";
+import { WorkspaceAutomationForm } from "./workspace-automation-form";
+
+export function AutomationsNewPageContent({
+  organizationSlug,
+  templateId,
+}: {
+  organizationSlug: string;
+  templateId?: string;
+}) {
+  const router = useRouter();
+  const initialForm = useMemo(() => {
+    if (templateId) {
+      return (
+        createWorkspaceAutomationFormStateFromTemplate(templateId) ??
+        createDefaultWorkspaceAutomationFormState()
+      );
+    }
+
+    return createDefaultWorkspaceAutomationFormState();
+  }, [templateId]);
+  const [form, setForm] = useState(initialForm);
+  const [errors, setErrors] = useState<Record<string, string | undefined>>({});
+
+  const createMutation = useMutation({
+    mutationFn: async () => {
+      const fieldErrors = validateWorkspaceAutomationFormState(form);
+      if (Object.keys(fieldErrors).length > 0) {
+        setErrors(fieldErrors);
+        throw new Error("validation_failed");
+      }
+
+      const payload = formStateToWorkspaceAutomationPayload(form);
+      const response = await apiClient.api.orgs[":organizationSlug"].automations.$post({
+        param: { organizationSlug },
+        json: payload,
+      });
+
+      if (!response.ok) {
+        const body = (await response.json().catch(() => null)) as {
+          error?: string;
+          message?: string;
+        } | null;
+        if (body?.error) {
+          setErrors(mapWorkspaceAutomationApiErrorToFieldErrors(body.error));
+        }
+        throw new Error(body?.message ?? "Failed to create automation");
+      }
+
+      return response.json();
+    },
+    onSuccess: (body) => {
+      toast.success("Automation created");
+      router.push(`/org/${organizationSlug}/automations/${body.automation.id}`);
+    },
+    onError: (error) => {
+      if (error.message === "validation_failed") {
+        return;
+      }
+      toast.error("Unable to create automation right now");
+    },
+  });
+
+  return (
+    <WorkspacePageShell>
+      <PageHeader
+        icon={SparklesIcon}
+        title="New automation"
+        description="Configure triggers, deterministic GitHub workflows, and terminal notifications."
+      />
+      <div className="mb-4">
+        <TypographyH1 className="text-2xl">Create automation</TypographyH1>
+        <TypographyP className="text-muted-foreground">
+          {templateId
+            ? "Template defaults are prefilled below. Review repository, project, and notification settings before saving."
+            : "Start from scratch or return to the templates gallery."}
+        </TypographyP>
+      </div>
+
+      <WorkspaceAutomationForm
+        organizationSlug={organizationSlug}
+        form={form}
+        errors={errors}
+        onChange={setForm}
+      />
+
+      <div className="flex items-center justify-end gap-3 border-t border-foreground/10 pt-6">
+        <Button variant="outline" render={<Link href={`/org/${organizationSlug}/automations`} />}>
+          Cancel
+        </Button>
+        <Button onClick={() => createMutation.mutate()} disabled={createMutation.isPending}>
+          {createMutation.isPending ? "Creating..." : "Create automation"}
+        </Button>
+      </div>
+    </WorkspacePageShell>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-content.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { Add01Icon, SparklesIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useQuery } from "@tanstack/react-query";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { TypographyH1, TypographyP } from "@/components/ui/typography";
+import { apiClient } from "@/lib/api-client-instance";
+import {
+  WORKSPACE_AUTOMATION_TEMPLATE_CATEGORIES,
+  listWorkspaceAutomationTemplates,
+} from "@/lib/agents/workspace-automation-templates";
+import type { WorkspaceAutomationRecord } from "@/lib/agents/workspace-automations";
+import { PageHeader, WorkspacePageShell } from "../../_components/workspace-resource-shared";
+
+function formatRelativeTimestamp(value: string) {
+  const date = new Date(value);
+  const diffMs = Date.now() - date.getTime();
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+  if (diffHours < 24) {
+    return `${Math.max(diffHours, 1)}h`;
+  }
+
+  const diffDays = Math.floor(diffHours / 24);
+  return `${diffDays}d`;
+}
+
+function AutomationToolsSummary({ automation }: { automation: WorkspaceAutomationRecord }) {
+  const tools: string[] = [];
+  if (automation.toolConfig.github?.enabled) {
+    tools.push("GitHub");
+  }
+  if (automation.toolConfig.slack?.enabled) {
+    tools.push("Slack");
+  }
+  if (automation.toolConfig.email?.enabled) {
+    tools.push("Email");
+  }
+
+  return (
+    <div className="flex flex-wrap gap-1">
+      {tools.map((tool) => (
+        <Badge key={tool} variant="outline">
+          {tool}
+        </Badge>
+      ))}
+    </div>
+  );
+}
+
+export function AutomationsPageContent({
+  organizationSlug,
+  currentUserId,
+}: {
+  organizationSlug: string;
+  currentUserId: string;
+}) {
+  const [scope, setScope] = useState<"mine" | "team">("mine");
+  const [templateCategory, setTemplateCategory] = useState(
+    WORKSPACE_AUTOMATION_TEMPLATE_CATEGORIES[0]?.id ?? "popular",
+  );
+
+  const automationsQuery = useQuery({
+    queryKey: ["workspace-automations", organizationSlug],
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"].automations.$get({
+        param: { organizationSlug },
+        query: { limit: "100", offset: "0" },
+      });
+      if (!response.ok) {
+        throw new Error("Failed to load automations");
+      }
+      const body = await response.json();
+      return body.automations as WorkspaceAutomationRecord[];
+    },
+  });
+
+  const automations = automationsQuery.data ?? [];
+  const visibleAutomations = useMemo(() => {
+    const activeAutomations = automations.filter((automation) => automation.status !== "archived");
+    if (scope === "team") {
+      return activeAutomations;
+    }
+
+    return activeAutomations.filter((automation) => automation.authorUserId === currentUserId);
+  }, [automations, currentUserId, scope]);
+
+  const stats = useMemo(() => {
+    const active = visibleAutomations.filter((automation) => automation.status === "active").length;
+    const paused = visibleAutomations.filter((automation) => automation.status === "paused").length;
+    return {
+      total: visibleAutomations.length,
+      active,
+      paused,
+    };
+  }, [visibleAutomations]);
+
+  const templates = listWorkspaceAutomationTemplates(templateCategory);
+
+  return (
+    <WorkspacePageShell>
+      <PageHeader
+        icon={SparklesIcon}
+        label="Workspace"
+        title="Automations"
+        description="Automate repetitive tasks with always-on workflows that respond to schedules and GitHub pushes."
+        actions={
+          <Button render={<Link href={`/org/${organizationSlug}/automations/new`} />}>
+            <HugeiconsIcon icon={Add01Icon} strokeWidth={2} />
+            New Automation
+          </Button>
+        }
+      />
+
+      <section className="grid gap-4 md:grid-cols-3">
+        <Card>
+          <CardHeader>
+            <CardDescription>Total automations</CardDescription>
+            <CardTitle className="text-3xl">{stats.total}</CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardDescription>Active</CardDescription>
+            <CardTitle className="text-3xl">{stats.active}</CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardDescription>Paused</CardDescription>
+            <CardTitle className="text-3xl">{stats.paused}</CardTitle>
+          </CardHeader>
+        </Card>
+      </section>
+
+      <section className="flex flex-col gap-4">
+        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <Tabs value={scope} onValueChange={(value) => setScope(value as "mine" | "team")}>
+            <TabsList>
+              <TabsTrigger value="mine">Mine</TabsTrigger>
+              <TabsTrigger value="team">Team</TabsTrigger>
+            </TabsList>
+          </Tabs>
+        </div>
+
+        <div className="overflow-hidden rounded-xl border border-foreground/10">
+          <div className="grid grid-cols-[minmax(0,1.6fr)_minmax(0,0.8fr)_minmax(0,0.8fr)_minmax(0,0.5fr)] gap-4 border-b border-foreground/10 px-4 py-3 text-xs font-medium text-muted-foreground">
+            <span>Automation</span>
+            <span>Tools</span>
+            <span>Status</span>
+            <span>Created</span>
+          </div>
+          {visibleAutomations.length === 0 ? (
+            <div className="px-4 py-10 text-sm text-muted-foreground">
+              No automations yet. Start from a template below or create a new automation.
+            </div>
+          ) : (
+            visibleAutomations.map((automation) => (
+              <Link
+                key={automation.id}
+                href={`/org/${organizationSlug}/automations/${automation.id}`}
+                className="grid grid-cols-[minmax(0,1.6fr)_minmax(0,0.8fr)_minmax(0,0.8fr)_minmax(0,0.5fr)] gap-4 border-b border-foreground/10 px-4 py-4 transition-colors last:border-b-0 hover:bg-foreground/5"
+              >
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium">{automation.name}</p>
+                  <p className="truncate text-xs text-muted-foreground">
+                    {automation.triggerConfig.mode === "scheduled"
+                      ? "Scheduled"
+                      : automation.triggerConfig.mode === "github"
+                        ? "GitHub push"
+                        : "Manual"}
+                  </p>
+                </div>
+                <AutomationToolsSummary automation={automation} />
+                <Badge variant={automation.status === "active" ? "default" : "secondary"}>
+                  {automation.status}
+                </Badge>
+                <span className="text-sm text-muted-foreground">
+                  {formatRelativeTimestamp(automation.createdAt)}
+                </span>
+              </Link>
+            ))
+          )}
+        </div>
+      </section>
+
+      <section className="flex flex-col gap-4">
+        <div>
+          <TypographyH1 className="text-xl">Templates</TypographyH1>
+          <TypographyP className="text-muted-foreground">
+            Start from a curated workflow. Templates prefill the creation form with instructions,
+            triggers, and tools.
+          </TypographyP>
+        </div>
+        <Tabs
+          value={templateCategory}
+          onValueChange={(value) => setTemplateCategory(value as typeof templateCategory)}
+        >
+          <TabsList className="flex h-auto flex-wrap justify-start gap-2 bg-transparent p-0">
+            {WORKSPACE_AUTOMATION_TEMPLATE_CATEGORIES.map((category) => (
+              <TabsTrigger key={category.id} value={category.id} className="rounded-full">
+                {category.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          {templates.map((template) => (
+            <Card key={template.id} className="flex flex-col">
+              <CardHeader>
+                <CardTitle className="text-base">{template.name}</CardTitle>
+                <CardDescription>{template.description}</CardDescription>
+              </CardHeader>
+              <CardContent className="mt-auto flex items-center justify-between gap-3">
+                {!template.activatable ? (
+                  <Badge variant="secondary">Coming soon</Badge>
+                ) : (
+                  <span className="text-xs text-muted-foreground">Deterministic V1</span>
+                )}
+                {template.activatable ? (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    render={
+                      <Link
+                        href={`/org/${organizationSlug}/automations/new?template=${template.id}`}
+                      />
+                    }
+                  >
+                    Add
+                  </Button>
+                ) : (
+                  <Button size="sm" variant="outline" disabled>
+                    Add
+                  </Button>
+                )}
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </section>
+    </WorkspacePageShell>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
@@ -1,0 +1,556 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+import { createApiClient } from "@/lib/api-client";
+import {
+  AUTOMATION_WEEKDAY_OPTIONS,
+  addBranchPattern,
+} from "@/app/(authenticated)/org/[organizationSlug]/integrations/_components/github-repository-automation-view-model";
+import type { WorkspaceAutomationFormState } from "@/lib/agents/workspace-automation-view-model";
+import { workspaceAutomationFormCanActivate } from "@/lib/agents/workspace-automation-view-model";
+
+const api = createApiClient();
+
+type ProjectOption = { id: string; name: string };
+type GithubRepositoryOption = {
+  id: string;
+  fullName: string;
+  enabled: boolean;
+  archived: boolean;
+  defaultBranch: string | null;
+};
+
+function FieldError({ message }: { message?: string }) {
+  if (!message) {
+    return null;
+  }
+
+  return <p className="text-xs text-destructive">{message}</p>;
+}
+
+export function WorkspaceAutomationForm({
+  organizationSlug,
+  form,
+  errors,
+  disabled,
+  onChange,
+}: {
+  organizationSlug: string;
+  form: WorkspaceAutomationFormState;
+  errors: Record<string, string | undefined>;
+  disabled?: boolean;
+  onChange: (next: WorkspaceAutomationFormState) => void;
+}) {
+  const [branchInput, setBranchInput] = useState("");
+
+  const projectsQuery = useQuery({
+    queryKey: ["projects", organizationSlug],
+    queryFn: async () => {
+      const response = await api.api.orgs[":organizationSlug"].projects.$get({
+        param: { organizationSlug },
+      });
+      if (!response.ok) {
+        throw new Error("Failed to load projects");
+      }
+      const body = await response.json();
+      return body.projects as ProjectOption[];
+    },
+  });
+
+  const repositoriesQuery = useQuery({
+    queryKey: ["github-installation-repositories", organizationSlug],
+    queryFn: async () => {
+      const response = await api.api.orgs[":organizationSlug"][
+        "github-installation"
+      ].repositories.$get({
+        param: { organizationSlug },
+        query: {},
+      });
+      if (!response.ok) {
+        throw new Error("Failed to load GitHub repositories");
+      }
+      const body = await response.json();
+      return body.repositories as GithubRepositoryOption[];
+    },
+  });
+
+  const slackQuery = useQuery({
+    queryKey: ["slack-agent", organizationSlug],
+    queryFn: async () => {
+      const response = await api.api.orgs[":organizationSlug"]["agent-slack"].$get({
+        param: { organizationSlug },
+      });
+      if (!response.ok) {
+        throw new Error("Failed to load Slack settings");
+      }
+      const body = await response.json();
+      return body.slackAgent;
+    },
+  });
+
+  const emailQuery = useQuery({
+    queryKey: ["email-agent", organizationSlug],
+    queryFn: async () => {
+      const response = await api.api.orgs[":organizationSlug"]["agent-email"].$get({
+        param: { organizationSlug },
+      });
+      if (!response.ok) {
+        throw new Error("Failed to load email agent settings");
+      }
+      const body = await response.json();
+      return body.emailAgent;
+    },
+  });
+
+  const repositories = useMemo(
+    () => (repositoriesQuery.data ?? []).filter((repository) => !repository.archived),
+    [repositoriesQuery.data],
+  );
+
+  const canActivate = workspaceAutomationFormCanActivate(form);
+  const slackConnected = Boolean(slackQuery.data?.enabled);
+  const emailConnected = Boolean(emailQuery.data?.enabled);
+
+  return (
+    <div className="flex flex-col gap-8">
+      <section className="flex flex-col gap-4">
+        <div className="flex flex-col gap-1">
+          <h2 className="text-sm font-medium text-foreground">Basics</h2>
+          <p className="text-xs text-muted-foreground">
+            Instructions are stored for operators and copied into run metadata. They do not execute
+            a free-form agent in V1.
+          </p>
+        </div>
+        <div className="grid gap-4">
+          <div className="grid gap-2">
+            <Label htmlFor="automation-name">Name</Label>
+            <Input
+              id="automation-name"
+              value={form.name}
+              disabled={disabled}
+              onChange={(event) => onChange({ ...form, name: event.target.value })}
+            />
+            <FieldError message={errors.name} />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="automation-instructions">Agent instructions</Label>
+            <Textarea
+              id="automation-instructions"
+              value={form.instructions}
+              disabled={disabled}
+              className="min-h-48 font-mono text-sm"
+              onChange={(event) => onChange({ ...form, instructions: event.target.value })}
+            />
+            <FieldError message={errors.instructions} />
+          </div>
+          <div className="flex items-center justify-between rounded-lg border border-foreground/10 px-4 py-3">
+            <div>
+              <p className="text-sm font-medium">Active</p>
+              <p className="text-xs text-muted-foreground">
+                Paused automations keep their configuration but will not dispatch.
+              </p>
+            </div>
+            <Switch
+              checked={form.status === "active"}
+              disabled={disabled || !canActivate}
+              onCheckedChange={(checked) =>
+                onChange({
+                  ...form,
+                  status: checked ? "active" : "paused",
+                })
+              }
+            />
+          </div>
+          {!canActivate ? (
+            <p className="text-xs text-muted-foreground">
+              Enable at least one deterministic GitHub workflow or notification tool to activate
+              this automation.
+            </p>
+          ) : null}
+          <FieldError message={errors.form} />
+        </div>
+      </section>
+
+      <section className="flex flex-col gap-4">
+        <div className="flex flex-col gap-1">
+          <h2 className="text-sm font-medium text-foreground">Triggers</h2>
+          <p className="text-xs text-muted-foreground">
+            V1 supports manual runs, schedules, and GitHub push triggers.
+          </p>
+        </div>
+        <div className="grid gap-4 rounded-lg border border-foreground/10 p-4">
+          <div className="grid gap-2">
+            <Label>Trigger</Label>
+            <Select
+              value={form.triggerMode}
+              onValueChange={(value) =>
+                onChange({
+                  ...form,
+                  triggerMode: value as WorkspaceAutomationFormState["triggerMode"],
+                })
+              }
+              disabled={disabled}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="manual">Manual only</SelectItem>
+                <SelectItem value="scheduled">Scheduled</SelectItem>
+                <SelectItem value="github">GitHub push</SelectItem>
+              </SelectContent>
+            </Select>
+            <FieldError message={errors.trigger} />
+          </div>
+
+          {form.triggerMode === "scheduled" ? (
+            <div className="grid gap-3 md:grid-cols-3">
+              <div className="grid gap-2">
+                <Label>Cadence</Label>
+                <Select
+                  value={form.scheduledCadence}
+                  onValueChange={(value) =>
+                    onChange({
+                      ...form,
+                      scheduledCadence: value as typeof form.scheduledCadence,
+                    })
+                  }
+                  disabled={disabled}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="hourly">Hourly</SelectItem>
+                    <SelectItem value="daily">Daily</SelectItem>
+                    <SelectItem value="weekly">Weekly</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="grid gap-2">
+                <Label>Hour (UTC)</Label>
+                <Input
+                  type="number"
+                  min={0}
+                  max={23}
+                  value={form.scheduledHourUtc}
+                  disabled={disabled || form.scheduledCadence === "hourly"}
+                  onChange={(event) =>
+                    onChange({
+                      ...form,
+                      scheduledHourUtc: Number(event.target.value),
+                    })
+                  }
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label>Timezone</Label>
+                <Input
+                  value={form.scheduledTimezone}
+                  disabled={disabled}
+                  onChange={(event) =>
+                    onChange({
+                      ...form,
+                      scheduledTimezone: event.target.value,
+                    })
+                  }
+                />
+              </div>
+              {form.scheduledCadence === "weekly" ? (
+                <div className="grid gap-2 md:col-span-3">
+                  <Label>Day of week</Label>
+                  <Select
+                    value={String(form.scheduledDayOfWeek)}
+                    onValueChange={(value) =>
+                      onChange({
+                        ...form,
+                        scheduledDayOfWeek: Number(value),
+                      })
+                    }
+                    disabled={disabled}
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {AUTOMATION_WEEKDAY_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={String(option.value)}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+
+          {form.triggerMode === "github" ? (
+            <div className="grid gap-2">
+              <Label>Branch patterns</Label>
+              <div className="flex flex-wrap gap-2">
+                {form.pushBranches.map((branch) => (
+                  <Badge key={branch} variant="secondary">
+                    {branch}
+                  </Badge>
+                ))}
+              </div>
+              <div className="flex gap-2">
+                <Input
+                  value={branchInput}
+                  disabled={disabled}
+                  placeholder="main"
+                  onChange={(event) => setBranchInput(event.target.value)}
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={disabled}
+                  onClick={() => {
+                    const result = addBranchPattern(form.pushBranches, branchInput);
+                    if (result.error) {
+                      return;
+                    }
+                    onChange({ ...form, pushBranches: result.branches });
+                    setBranchInput("");
+                  }}
+                >
+                  Add
+                </Button>
+              </div>
+              <FieldError message={errors.pushBranches} />
+            </div>
+          ) : null}
+        </div>
+      </section>
+
+      <section className="flex flex-col gap-4">
+        <div className="flex flex-col gap-1">
+          <h2 className="text-sm font-medium text-foreground">Tools</h2>
+          <p className="text-xs text-muted-foreground">
+            GitHub workflows run through the existing deterministic repository automation path.
+          </p>
+        </div>
+
+        <div className="grid gap-4">
+          <div className="rounded-lg border border-foreground/10 p-4">
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <p className="text-sm font-medium">GitHub workflows</p>
+                <p className="text-xs text-muted-foreground">
+                  Push source, pull translations, and validation/check.
+                </p>
+              </div>
+              <Switch
+                checked={form.githubEnabled}
+                disabled={disabled}
+                onCheckedChange={(checked) =>
+                  onChange({
+                    ...form,
+                    githubEnabled: checked,
+                    repositoryTargetKind: checked ? "github" : "none",
+                  })
+                }
+              />
+            </div>
+
+            {form.githubEnabled ? (
+              <div className="mt-4 grid gap-4">
+                <div className="grid gap-2">
+                  <Label>Repository</Label>
+                  <Select
+                    value={form.githubInstallationRepositoryId || undefined}
+                    onValueChange={(value) => {
+                      if (!value) {
+                        return;
+                      }
+                      onChange({
+                        ...form,
+                        githubInstallationRepositoryId: value,
+                      });
+                    }}
+                    disabled={disabled}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select repository" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {repositories.map((repository) => (
+                        <SelectItem key={repository.id} value={repository.id}>
+                          {repository.fullName}
+                          {!repository.enabled ? " (disabled)" : ""}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FieldError message={errors.githubRepository} />
+                </div>
+                <div className="grid gap-2">
+                  <Label>Project</Label>
+                  <Select
+                    value={form.githubProjectId || undefined}
+                    onValueChange={(value) => {
+                      if (!value) {
+                        return;
+                      }
+                      onChange({ ...form, githubProjectId: value });
+                    }}
+                    disabled={disabled}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select project" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {(projectsQuery.data ?? []).map((project) => (
+                        <SelectItem key={project.id} value={project.id}>
+                          {project.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FieldError message={errors.githubProjectId} />
+                </div>
+                <div className="grid gap-3">
+                  <label className="flex items-center justify-between gap-4">
+                    <span className="text-sm">Push source</span>
+                    <Switch
+                      checked={form.pushSourceEnabled}
+                      disabled={disabled}
+                      onCheckedChange={(checked) =>
+                        onChange({ ...form, pushSourceEnabled: checked })
+                      }
+                    />
+                  </label>
+                  <label className="flex items-center justify-between gap-4">
+                    <span className="text-sm">Pull translations</span>
+                    <Switch
+                      checked={form.pullTranslationsEnabled}
+                      disabled={disabled}
+                      onCheckedChange={(checked) =>
+                        onChange({
+                          ...form,
+                          pullTranslationsEnabled: checked,
+                        })
+                      }
+                    />
+                  </label>
+                  <label className="flex items-center justify-between gap-4">
+                    <span className="text-sm">Validation / check</span>
+                    <Switch
+                      checked={form.validationEnabled}
+                      disabled={disabled}
+                      onCheckedChange={(checked) =>
+                        onChange({ ...form, validationEnabled: checked })
+                      }
+                    />
+                  </label>
+                </div>
+              </div>
+            ) : null}
+          </div>
+
+          <div className="rounded-lg border border-foreground/10 p-4">
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <p className="text-sm font-medium">Slack notifications</p>
+                <p className="text-xs text-muted-foreground">
+                  Notify a channel when runs reach a terminal state.
+                </p>
+              </div>
+              <Switch
+                checked={form.slackEnabled}
+                disabled={disabled || !slackConnected}
+                onCheckedChange={(checked) => onChange({ ...form, slackEnabled: checked })}
+              />
+            </div>
+            {!slackConnected ? (
+              <p className="mt-2 text-xs text-muted-foreground">
+                Connect Slack in{" "}
+                <Link href={`/org/${organizationSlug}/integrations`} className="underline">
+                  Integrations
+                </Link>{" "}
+                to enable this tool.
+              </p>
+            ) : null}
+            {form.slackEnabled ? (
+              <div className="mt-4 grid gap-2">
+                <Label htmlFor="slack-channel">Channel ID</Label>
+                <Input
+                  id="slack-channel"
+                  value={form.slackChannelId}
+                  disabled={disabled}
+                  placeholder="C0123456789"
+                  onChange={(event) => onChange({ ...form, slackChannelId: event.target.value })}
+                />
+                <FieldError message={errors.slackChannelId} />
+              </div>
+            ) : null}
+          </div>
+
+          <div className="rounded-lg border border-foreground/10 p-4">
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <p className="text-sm font-medium">Email notifications</p>
+                <p className="text-xs text-muted-foreground">
+                  Send terminal run summaries to specific recipients.
+                </p>
+              </div>
+              <Switch
+                checked={form.emailEnabled}
+                disabled={disabled || !emailConnected}
+                onCheckedChange={(checked) => onChange({ ...form, emailEnabled: checked })}
+              />
+            </div>
+            {!emailConnected ? (
+              <p className="mt-2 text-xs text-muted-foreground">
+                Enable the email agent in{" "}
+                <Link href={`/org/${organizationSlug}/integrations`} className="underline">
+                  Integrations
+                </Link>{" "}
+                to use email notifications.
+              </p>
+            ) : null}
+            {form.emailEnabled ? (
+              <div className="mt-4 grid gap-2">
+                <Label htmlFor="email-recipients">Recipients</Label>
+                <Textarea
+                  id="email-recipients"
+                  value={form.emailRecipients.join("\n")}
+                  disabled={disabled}
+                  className="min-h-24"
+                  placeholder={"ops@company.com\ndev@company.com"}
+                  onChange={(event) =>
+                    onChange({
+                      ...form,
+                      emailRecipients: event.target.value
+                        .split(/\n|,/)
+                        .map((value) => value.trim())
+                        .filter(Boolean),
+                    })
+                  }
+                />
+                <FieldError message={errors.emailRecipients} />
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/automations/new/page.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/automations/new/page.tsx
@@ -1,0 +1,20 @@
+import { Suspense } from "react";
+
+import { AutomationsNewPageContent } from "../_components/automations-new-page-content";
+
+export default async function NewAutomationPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ organizationSlug: string }>;
+  searchParams: Promise<{ template?: string }>;
+}) {
+  const { organizationSlug } = await params;
+  const { template } = await searchParams;
+
+  return (
+    <Suspense fallback={null}>
+      <AutomationsNewPageContent organizationSlug={organizationSlug} templateId={template} />
+    </Suspense>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/automations/page.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/automations/page.tsx
@@ -1,0 +1,23 @@
+import { Suspense } from "react";
+
+import { requireAppAuthContext } from "@/lib/workos/app-auth";
+
+import { AutomationsPageContent } from "./_components/automations-page-content";
+
+export default async function AutomationsPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string }>;
+}) {
+  const { organizationSlug } = await params;
+  const auth = await requireAppAuthContext({ organizationSlug });
+
+  return (
+    <Suspense fallback={null}>
+      <AutomationsPageContent
+        organizationSlug={organizationSlug}
+        currentUserId={auth.user.localUserId}
+      />
+    </Suspense>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
@@ -102,6 +102,12 @@ export function buildGlobalNavigationGroups(organizationSlug: string): readonly 
           icon: LinkSquare02Icon,
         },
         {
+          label: "Automations",
+          href: org("automations"),
+          icon: Task01Icon,
+          description: "Scheduled and GitHub-triggered deterministic workflows",
+        },
+        {
           label: "Team",
           href: org("settings/members"),
           icon: UserGroupIcon,

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/translation-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/translation-tools.ts
@@ -18,7 +18,7 @@ import {
   inferSupportedFileTranslationFileFormat,
   supportedFileTranslationFileFormats,
 } from "@/lib/translation/file-formats";
-import { createTranslationJobEventQueue } from "@/workflows/adapters";
+import { createTranslationJobEventQueue } from "@/lib/workflow/queues";
 import {
   formatUsageControlError,
   reserveUsageEvent,

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-push-webhook.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-push-webhook.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const {
+  dispatchGithubRepositoryAutomationForPushMock,
+  dispatchWorkspaceAutomationsForGithubPushMock,
+  loggerErrorMock,
+  loggerInfoMock,
+} = vi.hoisted(() => ({
+  dispatchGithubRepositoryAutomationForPushMock: vi.fn(),
+  dispatchWorkspaceAutomationsForGithubPushMock: vi.fn(),
+  loggerErrorMock: vi.fn(),
+  loggerInfoMock: vi.fn(),
+}));
+
+vi.mock("@/lib/log", () => ({
+  createLogger: vi.fn(() => ({
+    error: loggerErrorMock,
+    info: loggerInfoMock,
+  })),
+}));
+
+vi.mock("./github-repository-automation-dispatcher", () => ({
+  dispatchGithubRepositoryAutomationForPush: dispatchGithubRepositoryAutomationForPushMock,
+}));
+
+vi.mock("../workspace-automation-dispatcher", () => ({
+  dispatchWorkspaceAutomationsForGithubPush: dispatchWorkspaceAutomationsForGithubPushMock,
+}));
+
+import { handleGithubPushWebhook } from "./github-push-webhook";
+
+describe("handleGithubPushWebhook", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dispatchGithubRepositoryAutomationForPushMock.mockResolvedValue({
+      job: { id: "job_123" },
+      outcome: "enqueued",
+    });
+    dispatchWorkspaceAutomationsForGithubPushMock.mockResolvedValue([]);
+  });
+
+  it("does not fail the webhook when workspace automation dispatch fails", async () => {
+    dispatchWorkspaceAutomationsForGithubPushMock.mockRejectedValueOnce(
+      new Error("database unavailable"),
+    );
+
+    await expect(
+      handleGithubPushWebhook({
+        deliveryId: "delivery-1",
+        organizationId: "org_123",
+        githubInstallationId: "installation-123",
+        githubInstallationRepositoryId: "installation-repo-123",
+        githubRepositoryId: "repo-123",
+        payload: {
+          after: "after-sha",
+          before: "before-sha",
+          ref: "refs/heads/main",
+        },
+      }),
+    ).resolves.toEqual({
+      automation: {
+        jobId: "job_123",
+        outcome: "enqueued",
+      },
+      ignored: false,
+    });
+
+    expect(dispatchGithubRepositoryAutomationForPushMock).toHaveBeenCalledOnce();
+    expect(dispatchWorkspaceAutomationsForGithubPushMock).toHaveBeenCalledOnce();
+    expect(loggerErrorMock).toHaveBeenCalledWith(
+      {
+        deliveryId: "delivery-1",
+        error: "database unavailable",
+        repositoryId: "repo-123",
+      },
+      "workspace automations github push dispatch failed",
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-push-webhook.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-push-webhook.ts
@@ -80,18 +80,29 @@ export async function handleGithubPushWebhook(
     commitAfter,
   });
 
-  const { dispatchWorkspaceAutomationsForGithubPush } =
-    await import("../workspace-automation-dispatcher");
-  await dispatchWorkspaceAutomationsForGithubPush({
-    deliveryId: input.deliveryId,
-    organizationId: input.organizationId,
-    githubInstallationId: input.githubInstallationId,
-    githubInstallationRepositoryId: input.githubInstallationRepositoryId,
-    githubRepositoryId: input.githubRepositoryId,
-    branch,
-    commitBefore,
-    commitAfter,
-  });
+  try {
+    const { dispatchWorkspaceAutomationsForGithubPush } =
+      await import("../workspace-automation-dispatcher");
+    await dispatchWorkspaceAutomationsForGithubPush({
+      deliveryId: input.deliveryId,
+      organizationId: input.organizationId,
+      githubInstallationId: input.githubInstallationId,
+      githubInstallationRepositoryId: input.githubInstallationRepositoryId,
+      githubRepositoryId: input.githubRepositoryId,
+      branch,
+      commitBefore,
+      commitAfter,
+    });
+  } catch (error) {
+    logger.error(
+      {
+        deliveryId: input.deliveryId,
+        repositoryId: input.githubRepositoryId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      "workspace automations github push dispatch failed",
+    );
+  }
 
   if (dispatchResult.outcome === "skipped") {
     return {

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-push-webhook.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-push-webhook.ts
@@ -80,6 +80,19 @@ export async function handleGithubPushWebhook(
     commitAfter,
   });
 
+  const { dispatchWorkspaceAutomationsForGithubPush } =
+    await import("../workspace-automation-dispatcher");
+  await dispatchWorkspaceAutomationsForGithubPush({
+    deliveryId: input.deliveryId,
+    organizationId: input.organizationId,
+    githubInstallationId: input.githubInstallationId,
+    githubInstallationRepositoryId: input.githubInstallationRepositoryId,
+    githubRepositoryId: input.githubRepositoryId,
+    branch,
+    commitBefore,
+    commitAfter,
+  });
+
   if (dispatchResult.outcome === "skipped") {
     return {
       ignored: false,

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-jobs.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-jobs.test.ts
@@ -1,7 +1,11 @@
 import "dotenv/config";
 
 import { eq } from "drizzle-orm";
-import { afterEach, beforeAll, describe, expect, it } from "vite-plus/test";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
+
+vi.mock("@/workflows/steps/workspace-automation-run-sync", () => ({
+  syncWorkspaceAutomationRunsForGithubJobStep: vi.fn().mockResolvedValue(undefined),
+}));
 
 import { db, schema } from "@/lib/database";
 

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-jobs.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-jobs.ts
@@ -268,9 +268,9 @@ export async function updateGithubRepositoryAutomationJobStatus(input: {
     .where(eq(schema.githubRepositoryAutomationJobs.id, input.jobId));
 
   if (isTerminal || input.status === "running") {
-    const { syncWorkspaceAutomationRunsForGithubJob } =
-      await import("../workspace-automation-run-sync");
-    await syncWorkspaceAutomationRunsForGithubJob({
+    const { syncWorkspaceAutomationRunsForGithubJobStep } =
+      await import("@/workflows/steps/workspace-automation-run-sync");
+    await syncWorkspaceAutomationRunsForGithubJobStep({
       jobId: input.jobId,
       status: input.status,
       resultSummary: input.resultSummary,

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-jobs.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-jobs.ts
@@ -266,6 +266,19 @@ export async function updateGithubRepositoryAutomationJobStatus(input: {
       updatedAt: new Date(),
     })
     .where(eq(schema.githubRepositoryAutomationJobs.id, input.jobId));
+
+  if (isTerminal || input.status === "running") {
+    const { syncWorkspaceAutomationRunsForGithubJob } =
+      await import("../workspace-automation-run-sync");
+    await syncWorkspaceAutomationRunsForGithubJob({
+      jobId: input.jobId,
+      status: input.status,
+      resultSummary: input.resultSummary,
+      lastError: input.lastError,
+      skipReason: input.skipReason,
+      completedAt: isTerminal ? new Date() : null,
+    });
+  }
 }
 
 export async function findLatestSucceededCommitAfter(input: {

--- a/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-jobs.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/github-repository-automation-jobs.ts
@@ -268,9 +268,9 @@ export async function updateGithubRepositoryAutomationJobStatus(input: {
     .where(eq(schema.githubRepositoryAutomationJobs.id, input.jobId));
 
   if (isTerminal || input.status === "running") {
-    const { syncWorkspaceAutomationRunsForGithubJobStep } =
-      await import("@/workflows/steps/workspace-automation-run-sync");
-    await syncWorkspaceAutomationRunsForGithubJobStep({
+    const { syncWorkspaceAutomationRunsForGithubJob } =
+      await import("@/lib/agents/workspace-automation-run-sync");
+    await syncWorkspaceAutomationRunsForGithubJob({
       jobId: input.jobId,
       status: input.status,
       resultSummary: input.resultSummary,

--- a/apps/hyperlocalise-web/src/lib/agents/slack/post-channel-message.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/post-channel-message.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+const { chatConstructorMock, createSlackAdapterMock, initializeMock, postChannelMessageMock } =
+  vi.hoisted(() => ({
+    chatConstructorMock: vi.fn(),
+    createSlackAdapterMock: vi.fn(() => ({ kind: "slack-adapter" })),
+    initializeMock: vi.fn(),
+    postChannelMessageMock: vi.fn(async () => undefined),
+  }));
+
+vi.mock("@/lib/env", () => ({
+  env: {
+    SLACK_CLIENT_ID: "test-client-id",
+    SLACK_CLIENT_SECRET: "test-client-secret",
+    SLACK_SIGNING_SECRET: "test-signing-secret",
+  },
+}));
+
+vi.mock("@/lib/agents/runtime/state", () => ({
+  createChatStateAdapter: vi.fn(() => ({ kind: "state-adapter" })),
+}));
+
+vi.mock("@chat-adapter/slack", () => ({
+  createSlackAdapter: createSlackAdapterMock,
+}));
+
+vi.mock("chat", () => ({
+  Chat: class MockChat {
+    constructor(config: unknown) {
+      chatConstructorMock(config);
+    }
+
+    initialize() {
+      return initializeMock();
+    }
+
+    getAdapter(adapterName: string) {
+      return {
+        adapterName,
+        postChannelMessage: postChannelMessageMock,
+      };
+    }
+  },
+}));
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return { promise, reject, resolve };
+}
+
+async function waitForInitializeCall() {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    if (initializeMock.mock.calls.length > 0) {
+      return;
+    }
+    await Promise.resolve();
+  }
+
+  throw new Error("expected Slack chat initialization to start");
+}
+
+describe("postSlackChannelMessage", () => {
+  it("shares initialization across concurrent callers before posting messages", async () => {
+    const initialized = createDeferred<void>();
+    initializeMock.mockReturnValueOnce(initialized.promise);
+    const { postSlackChannelMessage } = await import("./post-channel-message");
+
+    const firstPost = postSlackChannelMessage({
+      channelId: "C123",
+      text: "first",
+    });
+    await waitForInitializeCall();
+
+    const secondPost = postSlackChannelMessage({
+      channelId: "C123",
+      text: "second",
+    });
+    await Promise.resolve();
+
+    expect(chatConstructorMock).toHaveBeenCalledOnce();
+    expect(createSlackAdapterMock).toHaveBeenCalledOnce();
+    expect(initializeMock).toHaveBeenCalledOnce();
+    expect(postChannelMessageMock).not.toHaveBeenCalled();
+
+    initialized.resolve();
+    await Promise.all([firstPost, secondPost]);
+
+    expect(postChannelMessageMock).toHaveBeenCalledTimes(2);
+    expect(postChannelMessageMock).toHaveBeenNthCalledWith(1, "C123", "first");
+    expect(postChannelMessageMock).toHaveBeenNthCalledWith(2, "C123", "second");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/agents/slack/post-channel-message.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/post-channel-message.ts
@@ -1,0 +1,47 @@
+import { Chat, type Adapter } from "chat";
+
+import { createChatStateAdapter } from "@/lib/agents/runtime/state";
+import { env } from "@/lib/env";
+
+type SlackChat = Chat<{ slack: Adapter<unknown, unknown> }>;
+
+let slackChat: SlackChat | null = null;
+
+async function getSlackChat(): Promise<SlackChat> {
+  if (slackChat) {
+    return slackChat;
+  }
+
+  if (!env.SLACK_CLIENT_ID || !env.SLACK_CLIENT_SECRET || !env.SLACK_SIGNING_SECRET) {
+    throw new Error("missing Slack bot configuration");
+  }
+
+  const { createSlackAdapter } = await import("@chat-adapter/slack");
+
+  slackChat = new Chat({
+    adapters: {
+      slack: createSlackAdapter({
+        clientId: env.SLACK_CLIENT_ID,
+        clientSecret: env.SLACK_CLIENT_SECRET,
+        signingSecret: env.SLACK_SIGNING_SECRET,
+        userName: "hyperlocalise",
+      }),
+    },
+    state: createChatStateAdapter(),
+    userName: "hyperlocalise",
+  });
+
+  await slackChat.initialize();
+  return slackChat;
+}
+
+export async function postSlackChannelMessage(input: {
+  channelId: string;
+  text: string;
+}): Promise<void> {
+  const chat = await getSlackChat();
+  const adapter = chat.getAdapter("slack") as {
+    postChannelMessage: (channelId: string, message: string) => Promise<unknown>;
+  };
+  await adapter.postChannelMessage(input.channelId, input.text);
+}

--- a/apps/hyperlocalise-web/src/lib/agents/slack/post-channel-message.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/post-channel-message.ts
@@ -5,20 +5,28 @@ import { env } from "@/lib/env";
 
 type SlackChat = Chat<{ slack: Adapter<unknown, unknown> }>;
 
-let slackChat: SlackChat | null = null;
+let slackChatPromise: Promise<SlackChat> | null = null;
 
 async function getSlackChat(): Promise<SlackChat> {
-  if (slackChat) {
-    return slackChat;
+  if (slackChatPromise) {
+    return slackChatPromise;
   }
 
+  slackChatPromise = initializeSlackChat().catch((error: unknown) => {
+    slackChatPromise = null;
+    throw error;
+  });
+  return slackChatPromise;
+}
+
+async function initializeSlackChat(): Promise<SlackChat> {
   if (!env.SLACK_CLIENT_ID || !env.SLACK_CLIENT_SECRET || !env.SLACK_SIGNING_SECRET) {
     throw new Error("missing Slack bot configuration");
   }
 
   const { createSlackAdapter } = await import("@chat-adapter/slack");
 
-  slackChat = new Chat({
+  const slackChat = new Chat({
     adapters: {
       slack: createSlackAdapter({
         clientId: env.SLACK_CLIENT_ID,

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-dispatcher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-dispatcher.test.ts
@@ -1,0 +1,167 @@
+import "dotenv/config";
+
+import { eq } from "drizzle-orm";
+import { afterEach, beforeAll, describe, expect, it } from "vite-plus/test";
+
+import { db, schema } from "@/lib/database";
+import { type Result } from "@/lib/primitives/result/results";
+
+import { createWorkspaceAutomation, listWorkspaceAutomationRuns } from "./workspace-automations";
+
+function expectOk<T, E>(result: Result<T, E>): T {
+  if (!result.ok) {
+    throw new Error("expected ok result");
+  }
+  return result.value;
+}
+import { dispatchWorkspaceAutomationForSchedule } from "./workspace-automation-dispatcher";
+
+const organizationIds: string[] = [];
+
+async function seedDispatchScope() {
+  const organizationId = crypto.randomUUID();
+  const userId = crypto.randomUUID();
+  const numericSuffix = BigInt(`0x${crypto.randomUUID().replaceAll("-", "").slice(0, 12)}`)
+    .toString()
+    .slice(0, 12);
+
+  organizationIds.push(organizationId);
+
+  await db.insert(schema.organizations).values({
+    id: organizationId,
+    workosOrganizationId: `org_${organizationId}`,
+    slug: `workspace-dispatch-${organizationId.slice(0, 8)}`,
+    name: "Workspace Dispatch Test Org",
+  });
+
+  await db.insert(schema.users).values({
+    id: userId,
+    workosUserId: `user_${userId}`,
+    email: `${userId}@example.test`,
+  });
+
+  const projectId = `project-${organizationId.slice(0, 8)}`;
+  await db.insert(schema.projects).values({
+    id: projectId,
+    organizationId,
+    createdByUserId: userId,
+    name: "Website",
+  });
+
+  const githubInstallationId = `7${numericSuffix}`;
+  const githubRepositoryId = `6${numericSuffix}`;
+
+  await db.insert(schema.githubInstallations).values({
+    organizationId,
+    githubInstallationId,
+    githubAppId: "123",
+    accountLogin: "hyperlocalise",
+    accountType: "Organization",
+  });
+
+  const [repository] = await db
+    .insert(schema.githubInstallationRepositories)
+    .values({
+      organizationId,
+      githubInstallationId,
+      githubRepositoryId,
+      owner: "hyperlocalise",
+      name: "web",
+      fullName: "hyperlocalise/web",
+      private: false,
+      archived: false,
+      defaultBranch: "main",
+      enabled: true,
+    })
+    .returning();
+
+  if (!repository) {
+    throw new Error("failed to seed repository");
+  }
+
+  return {
+    organizationId,
+    userId,
+    projectId,
+    repository,
+    githubInstallationId,
+    githubRepositoryId,
+  };
+}
+
+describe("workspace automation dispatcher", () => {
+  beforeAll(async () => {
+    await db.$client.query("select 1");
+  });
+
+  afterEach(async () => {
+    for (const organizationId of organizationIds.splice(0)) {
+      await db.delete(schema.organizations).where(eq(schema.organizations.id, organizationId));
+    }
+  });
+
+  it("creates idempotent scheduled runs linked to github jobs", async () => {
+    const scope = await seedDispatchScope();
+    const scheduledRunAt = new Date("2026-06-01T08:00:00.000Z");
+    const automation = expectOk(
+      await createWorkspaceAutomation({
+        organizationId: scope.organizationId,
+        authorUserId: scope.userId,
+        name: "Scheduled validation",
+        instructions: "Run validation on a schedule.",
+        triggerConfig: {
+          mode: "scheduled",
+          schedule: {
+            cadence: "daily",
+            hourUtc: 8,
+            timezone: "UTC",
+          },
+        },
+        repositoryTarget: {
+          kind: "github",
+          githubInstallationRepositoryId: scope.repository.id,
+        },
+        toolConfig: {
+          github: {
+            enabled: true,
+            projectId: scope.projectId,
+            pushSource: false,
+            pullTranslations: false,
+            validation: true,
+          },
+        },
+        nextRunAt: scheduledRunAt,
+      }),
+    );
+
+    const first = await dispatchWorkspaceAutomationForSchedule({
+      automation,
+      repository: {
+        id: scope.repository.id,
+        githubInstallationId: scope.githubInstallationId,
+        githubRepositoryId: scope.githubRepositoryId,
+      },
+      scheduledRunAt,
+    });
+    const second = await dispatchWorkspaceAutomationForSchedule({
+      automation,
+      repository: {
+        id: scope.repository.id,
+        githubInstallationId: scope.githubInstallationId,
+        githubRepositoryId: scope.githubRepositoryId,
+      },
+      scheduledRunAt,
+    });
+
+    expect(first?.outcome).toBe("enqueued");
+    expect(second?.outcome).toBe("enqueued");
+    expect(second?.inserted).toBe(false);
+
+    const runs = await listWorkspaceAutomationRuns({
+      automationId: automation.id,
+      organizationId: scope.organizationId,
+    });
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.githubRepositoryAutomationJobId).toBeTruthy();
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-dispatcher.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-dispatcher.ts
@@ -1,0 +1,316 @@
+import { createLogger } from "@/lib/log";
+
+import {
+  buildGithubPushAutomationIdempotencyKey,
+  buildGithubScheduledAutomationIdempotencyKey,
+} from "./github/github-repository-automation-idempotency";
+import {
+  buildGithubRepoAutomationDispatchPayload,
+  shouldRunAutomationForPushBranch,
+} from "./github/github-repository-automation-settings";
+import {
+  claimGithubRepositoryAutomationJob,
+  type GithubRepositoryAutomationJobRecord,
+} from "./github/github-repository-automation-jobs";
+import { enqueueGithubRepositoryAutomationJob } from "./github/github-repository-automation-worker";
+import { githubRepositoryAutomationJobHasRunnableWorkflow } from "./github/github-repository-automation-workflows";
+import {
+  buildWorkspaceGithubPushAutomationIdempotencyKey,
+  buildWorkspaceScheduledAutomationIdempotencyKey,
+} from "./workspace-automation-idempotency";
+import {
+  hasWorkspaceAutomationGithubWorkflow,
+  workspaceAutomationMatchesPushBranch,
+  workspaceAutomationToGithubSettings,
+} from "./workspace-automation-github-mapping";
+import {
+  advanceWorkspaceAutomationNextRun,
+  createWorkspaceAutomationRun,
+  listWorkspaceAutomations,
+  updateWorkspaceAutomationRun,
+  type WorkspaceAutomationRecord,
+} from "./workspace-automations";
+
+const logger = createLogger("workspace-automation-dispatch");
+
+export type WorkspaceAutomationDispatchResult =
+  | {
+      outcome: "enqueued";
+      runId: string;
+      job: GithubRepositoryAutomationJobRecord;
+      inserted: boolean;
+    }
+  | {
+      outcome: "skipped";
+      runId: string;
+      job: GithubRepositoryAutomationJobRecord;
+      inserted: boolean;
+      skipReason: string;
+    };
+
+async function linkWorkspaceAutomationRun(input: {
+  organizationId: string;
+  automation: WorkspaceAutomationRecord;
+  triggerSource: "scheduled" | "github";
+  idempotencyKey: string;
+  scheduledRunAt?: Date;
+  githubDeliveryId?: string;
+  pushBranch?: string;
+  commitBefore?: string;
+  commitAfter?: string;
+  dispatchPayload: NonNullable<ReturnType<typeof buildGithubRepoAutomationDispatchPayload>>;
+  repository: {
+    id: string;
+    githubInstallationId: string;
+    githubRepositoryId: string;
+  };
+}): Promise<WorkspaceAutomationDispatchResult> {
+  const run = await createWorkspaceAutomationRun({
+    automationId: input.automation.id,
+    organizationId: input.organizationId,
+    triggerSource: input.triggerSource,
+    status: "queued",
+    idempotencyKey: input.idempotencyKey,
+    inputSnapshot: {
+      automationConfigVersion: input.automation.configVersion,
+      automationName: input.automation.name,
+      instructions: input.automation.instructions,
+      ...(input.scheduledRunAt ? { scheduledRunAt: input.scheduledRunAt.toISOString() } : {}),
+      ...(input.githubDeliveryId ? { githubDeliveryId: input.githubDeliveryId } : {}),
+      ...(input.pushBranch ? { pushBranch: input.pushBranch } : {}),
+      ...(input.commitBefore ? { commitBefore: input.commitBefore } : {}),
+      ...(input.commitAfter ? { commitAfter: input.commitAfter } : {}),
+    },
+  });
+
+  const githubIdempotencyKey =
+    input.triggerSource === "scheduled" && input.scheduledRunAt
+      ? buildGithubScheduledAutomationIdempotencyKey({
+          githubInstallationRepositoryId: input.repository.id,
+          configVersion: input.dispatchPayload.configVersion,
+          scheduledRunAt: input.scheduledRunAt,
+        })
+      : buildGithubPushAutomationIdempotencyKey({
+          githubDeliveryId: input.githubDeliveryId ?? run.id,
+        });
+
+  const claim = await claimGithubRepositoryAutomationJob({
+    idempotencyKey: githubIdempotencyKey,
+    organizationId: input.organizationId,
+    githubInstallationRepositoryId: input.repository.id,
+    githubInstallationId: input.repository.githubInstallationId,
+    githubRepositoryId: input.repository.githubRepositoryId,
+    configVersion: input.dispatchPayload.configVersion,
+    triggerMode: input.triggerSource === "scheduled" ? "scheduled" : "push",
+    triggerBranch: input.pushBranch ?? null,
+    commitBefore: input.commitBefore ?? null,
+    commitAfter: input.commitAfter ?? null,
+    workflows: input.dispatchPayload.workflows,
+    githubDeliveryId: input.githubDeliveryId ?? null,
+    scheduledRunAt: input.scheduledRunAt ?? null,
+  });
+
+  await updateWorkspaceAutomationRun({
+    runId: run.id,
+    organizationId: input.organizationId,
+    githubRepositoryAutomationJobId: claim.job.id,
+    status: claim.job.status === "skipped" ? "skipped" : "queued",
+    outputSummary:
+      claim.job.status === "skipped"
+        ? { skipReason: claim.job.skipReason ?? "automation_skipped" }
+        : {},
+    completedAt: claim.job.status === "skipped" ? new Date() : null,
+  });
+
+  if (
+    claim.job.status !== "skipped" &&
+    githubRepositoryAutomationJobHasRunnableWorkflow(input.dispatchPayload.workflows) &&
+    claim.job.status === "queued"
+  ) {
+    await enqueueGithubRepositoryAutomationJob({ jobId: claim.job.id });
+  }
+
+  if (claim.job.status === "skipped") {
+    return {
+      outcome: "skipped",
+      runId: run.id,
+      job: claim.job,
+      inserted: claim.inserted,
+      skipReason: claim.job.skipReason ?? "automation_skipped",
+    };
+  }
+
+  return {
+    outcome: "enqueued",
+    runId: run.id,
+    job: claim.job,
+    inserted: claim.inserted,
+  };
+}
+
+export async function dispatchWorkspaceAutomationForSchedule(input: {
+  automation: WorkspaceAutomationRecord;
+  repository: {
+    id: string;
+    githubInstallationId: string;
+    githubRepositoryId: string;
+  };
+  scheduledRunAt: Date;
+}): Promise<WorkspaceAutomationDispatchResult | null> {
+  if (input.automation.status !== "active") {
+    return null;
+  }
+
+  if (!hasWorkspaceAutomationGithubWorkflow(input.automation.toolConfig)) {
+    return null;
+  }
+
+  if (input.automation.triggerConfig.mode !== "scheduled") {
+    return null;
+  }
+
+  const githubSettings = workspaceAutomationToGithubSettings(input.automation);
+  if (!githubSettings) {
+    return null;
+  }
+
+  const dispatchPayload = buildGithubRepoAutomationDispatchPayload({
+    configVersion: input.automation.configVersion,
+    githubInstallationRepositoryId: input.repository.id,
+    organizationId: input.automation.organizationId,
+    githubRepositoryId: input.repository.githubRepositoryId,
+    githubInstallationId: input.repository.githubInstallationId,
+    settings: githubSettings,
+  });
+
+  if (!dispatchPayload) {
+    return null;
+  }
+
+  const idempotencyKey = buildWorkspaceScheduledAutomationIdempotencyKey({
+    automationId: input.automation.id,
+    configVersion: input.automation.configVersion,
+    scheduledRunAt: input.scheduledRunAt,
+  });
+
+  return linkWorkspaceAutomationRun({
+    organizationId: input.automation.organizationId,
+    automation: input.automation,
+    triggerSource: "scheduled",
+    idempotencyKey,
+    scheduledRunAt: input.scheduledRunAt,
+    dispatchPayload,
+    repository: input.repository,
+  });
+}
+
+export async function dispatchWorkspaceAutomationsForGithubPush(input: {
+  deliveryId: string;
+  organizationId: string;
+  githubInstallationId: string;
+  githubInstallationRepositoryId: string;
+  githubRepositoryId: string;
+  branch: string;
+  commitBefore: string;
+  commitAfter: string;
+}): Promise<WorkspaceAutomationDispatchResult[]> {
+  const automations = (
+    await listWorkspaceAutomations({
+      organizationId: input.organizationId,
+      status: "active",
+      limit: 100,
+    })
+  ).filter(
+    (automation) =>
+      automation.repositoryTarget.kind === "github" &&
+      automation.repositoryTarget.githubInstallationRepositoryId ===
+        input.githubInstallationRepositoryId &&
+      automation.triggerConfig.mode === "github" &&
+      workspaceAutomationMatchesPushBranch(automation, input.branch),
+  );
+
+  const results: WorkspaceAutomationDispatchResult[] = [];
+
+  for (const automation of automations) {
+    if (!hasWorkspaceAutomationGithubWorkflow(automation.toolConfig)) {
+      continue;
+    }
+
+    const githubSettings = workspaceAutomationToGithubSettings(automation);
+    if (!githubSettings || githubSettings.trigger?.mode !== "push") {
+      continue;
+    }
+
+    if (!shouldRunAutomationForPushBranch(githubSettings, input.branch)) {
+      continue;
+    }
+
+    const dispatchPayload = buildGithubRepoAutomationDispatchPayload({
+      configVersion: automation.configVersion,
+      githubInstallationRepositoryId: input.githubInstallationRepositoryId,
+      organizationId: input.organizationId,
+      githubRepositoryId: input.githubRepositoryId,
+      githubInstallationId: input.githubInstallationId,
+      settings: githubSettings,
+      pushBranch: input.branch,
+    });
+
+    if (!dispatchPayload) {
+      continue;
+    }
+
+    try {
+      const result = await linkWorkspaceAutomationRun({
+        organizationId: input.organizationId,
+        automation,
+        triggerSource: "github",
+        idempotencyKey: buildWorkspaceGithubPushAutomationIdempotencyKey({
+          automationId: automation.id,
+          configVersion: automation.configVersion,
+          githubDeliveryId: input.deliveryId,
+        }),
+        githubDeliveryId: input.deliveryId,
+        pushBranch: input.branch,
+        commitBefore: input.commitBefore,
+        commitAfter: input.commitAfter,
+        dispatchPayload,
+        repository: {
+          id: input.githubInstallationRepositoryId,
+          githubInstallationId: input.githubInstallationId,
+          githubRepositoryId: input.githubRepositoryId,
+        },
+      });
+      results.push(result);
+    } catch (error) {
+      logger.error(
+        {
+          automationId: automation.id,
+          deliveryId: input.deliveryId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "workspace automation github push dispatch failed",
+      );
+    }
+  }
+
+  return results;
+}
+
+export async function dispatchWorkspaceAutomationForScheduleAndAdvance(input: {
+  automation: WorkspaceAutomationRecord;
+  repository: {
+    id: string;
+    githubInstallationId: string;
+    githubRepositoryId: string;
+  };
+  scheduledRunAt: Date;
+  completedAt?: Date;
+}) {
+  const result = await dispatchWorkspaceAutomationForSchedule(input);
+  await advanceWorkspaceAutomationNextRun({
+    automationId: input.automation.id,
+    organizationId: input.automation.organizationId,
+    completedAt: input.completedAt,
+  });
+  return result;
+}

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-github-mapping.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-github-mapping.ts
@@ -1,0 +1,96 @@
+import {
+  branchMatchesAutomationPatterns,
+  type GithubRepositoryAutomationSettings,
+} from "@/lib/agents/github/github-repository-automation-settings";
+
+import type {
+  WorkspaceAutomationRecord,
+  WorkspaceAutomationToolConfig,
+  WorkspaceAutomationTriggerConfig,
+} from "./workspace-automations";
+
+export function hasWorkspaceAutomationGithubWorkflow(
+  toolConfig: WorkspaceAutomationToolConfig,
+): boolean {
+  const github = toolConfig.github;
+  if (!github?.enabled) {
+    return false;
+  }
+
+  return Boolean(github.pushSource || github.pullTranslations || github.validation);
+}
+
+export function workspaceAutomationToGithubSettings(
+  automation: WorkspaceAutomationRecord,
+): GithubRepositoryAutomationSettings | null {
+  const github = automation.toolConfig.github;
+  if (!hasWorkspaceAutomationGithubWorkflow(automation.toolConfig) || !github?.projectId) {
+    return null;
+  }
+
+  const trigger = resolveGithubTriggerFromWorkspaceTrigger(automation.triggerConfig);
+  if (!trigger) {
+    return null;
+  }
+
+  return {
+    workflows: {
+      pushSource: {
+        enabled: github.pushSource,
+        projectId: github.projectId,
+      },
+      pullTranslations: {
+        enabled: github.pullTranslations,
+        projectId: github.projectId,
+      },
+      validation: {
+        enabled: github.validation,
+        blockOnFailure: true,
+      },
+    },
+    trigger,
+    statusCheck: {
+      enabled: false,
+      mode: "blocking",
+    },
+  };
+}
+
+function resolveGithubTriggerFromWorkspaceTrigger(
+  triggerConfig: WorkspaceAutomationTriggerConfig,
+): GithubRepositoryAutomationSettings["trigger"] {
+  if (triggerConfig.mode === "scheduled" && triggerConfig.schedule) {
+    return {
+      mode: "scheduled",
+      cadence: triggerConfig.schedule.cadence,
+      hourUtc: triggerConfig.schedule.hourUtc ?? 0,
+      dayOfWeek: triggerConfig.schedule.dayOfWeek,
+      timezone: triggerConfig.schedule.timezone,
+    };
+  }
+
+  if (
+    triggerConfig.mode === "github" &&
+    triggerConfig.branches &&
+    triggerConfig.branches.length > 0
+  ) {
+    return {
+      mode: "push",
+      branches: triggerConfig.branches,
+    };
+  }
+
+  return null;
+}
+
+export function workspaceAutomationMatchesPushBranch(
+  automation: WorkspaceAutomationRecord,
+  branch: string,
+): boolean {
+  if (automation.triggerConfig.mode !== "github") {
+    return false;
+  }
+
+  const branches = automation.triggerConfig.branches ?? [];
+  return branchMatchesAutomationPatterns(branch, branches);
+}

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-idempotency.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-idempotency.ts
@@ -1,0 +1,25 @@
+export function buildWorkspaceScheduledAutomationIdempotencyKey(input: {
+  automationId: string;
+  configVersion: number;
+  scheduledRunAt: Date;
+}): string {
+  return [
+    "workspace-automation:scheduled",
+    input.automationId,
+    String(input.configVersion),
+    input.scheduledRunAt.toISOString(),
+  ].join(":");
+}
+
+export function buildWorkspaceGithubPushAutomationIdempotencyKey(input: {
+  automationId: string;
+  configVersion: number;
+  githubDeliveryId: string;
+}): string {
+  return [
+    "workspace-automation:github-push",
+    input.automationId,
+    String(input.configVersion),
+    input.githubDeliveryId,
+  ].join(":");
+}

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-notifications.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-notifications.ts
@@ -1,0 +1,165 @@
+import { Resend } from "resend";
+
+import { env } from "@/lib/env";
+import { createLogger } from "@/lib/log";
+import { err, ok, type Result } from "@/lib/primitives/result/results";
+
+import { getSlackBot } from "./slack/bot";
+import type {
+  WorkspaceAutomationRecord,
+  WorkspaceAutomationRunRecord,
+} from "./workspace-automations";
+
+const logger = createLogger("workspace-automation-notifications");
+
+export type WorkspaceAutomationNotificationError = {
+  code: "slack_send_failed" | "email_send_failed" | "notifications_not_configured";
+  message: string;
+};
+
+function buildRunSummaryMessage(input: {
+  automation: WorkspaceAutomationRecord;
+  run: WorkspaceAutomationRunRecord;
+}) {
+  const statusLabel = input.run.status.toUpperCase();
+  const lines = [
+    `Automation "${input.automation.name}" finished with status ${statusLabel}.`,
+    `Trigger: ${input.run.triggerSource}.`,
+  ];
+
+  if (input.run.outputSummary && Object.keys(input.run.outputSummary).length > 0) {
+    lines.push(`Summary: ${JSON.stringify(input.run.outputSummary)}`);
+  }
+
+  if (input.run.error) {
+    lines.push(`Error: ${JSON.stringify(input.run.error)}`);
+  }
+
+  return lines.join("\n");
+}
+
+async function sendSlackNotification(input: {
+  channelId: string;
+  message: string;
+}): Promise<Result<void, WorkspaceAutomationNotificationError>> {
+  if (!env.SLACK_CLIENT_ID || !env.SLACK_CLIENT_SECRET || !env.SLACK_SIGNING_SECRET) {
+    return err({
+      code: "slack_send_failed",
+      message: "Slack is not configured for this environment.",
+    });
+  }
+
+  try {
+    const bot = await getSlackBot();
+    await bot.initialize();
+    const adapter = bot.getAdapter("slack");
+    const postChannelMessage = (
+      adapter as unknown as {
+        postMessage?: (channelId: string, message: string) => Promise<void>;
+      }
+    ).postMessage;
+    if (!postChannelMessage) {
+      return err({
+        code: "slack_send_failed",
+        message: "Slack adapter does not support channel notifications.",
+      });
+    }
+
+    await postChannelMessage(input.channelId, input.message);
+    return ok(undefined);
+  } catch (error) {
+    logger.warn(
+      { error: error instanceof Error ? error.message : String(error) },
+      "workspace automation slack notification failed",
+    );
+    return err({
+      code: "slack_send_failed",
+      message: error instanceof Error ? error.message : "Slack notification failed.",
+    });
+  }
+}
+
+async function sendEmailNotification(input: {
+  recipients: string[];
+  subject: string;
+  message: string;
+}): Promise<Result<void, WorkspaceAutomationNotificationError>> {
+  if (!env.RESEND_API_KEY || !env.RESEND_FROM_ADDRESS) {
+    return err({
+      code: "email_send_failed",
+      message: "Email delivery is not configured for this environment.",
+    });
+  }
+
+  try {
+    const resend = new Resend(env.RESEND_API_KEY);
+    const result = await resend.emails.send({
+      from: env.RESEND_FROM_NAME
+        ? `${env.RESEND_FROM_NAME} <${env.RESEND_FROM_ADDRESS}>`
+        : env.RESEND_FROM_ADDRESS,
+      to: input.recipients,
+      subject: input.subject,
+      text: input.message,
+    });
+
+    if (result.error) {
+      return err({
+        code: "email_send_failed",
+        message: result.error.message,
+      });
+    }
+
+    return ok(undefined);
+  } catch (error) {
+    return err({
+      code: "email_send_failed",
+      message: error instanceof Error ? error.message : "Email notification failed.",
+    });
+  }
+}
+
+export async function notifyWorkspaceAutomationTerminalRun(input: {
+  automation: WorkspaceAutomationRecord;
+  run: WorkspaceAutomationRunRecord;
+}): Promise<Record<string, unknown>> {
+  const terminalStatuses = new Set(["succeeded", "failed", "skipped"]);
+  if (!terminalStatuses.has(input.run.status)) {
+    return {};
+  }
+
+  const message = buildRunSummaryMessage(input);
+  const warnings: Array<{ channel: "slack" | "email"; code: string; message: string }> = [];
+
+  const slack = input.automation.toolConfig.slack;
+  if (slack?.enabled && slack.channelId) {
+    const result = await sendSlackNotification({
+      channelId: slack.channelId,
+      message,
+    });
+    if (!result.ok) {
+      warnings.push({
+        channel: "slack",
+        code: result.error.code,
+        message: result.error.message,
+      });
+    }
+  }
+
+  const email = input.automation.toolConfig.email;
+  if (email?.enabled && email.recipients && email.recipients.length > 0) {
+    const result = await sendEmailNotification({
+      recipients: email.recipients,
+      subject: `Automation run ${input.run.status}: ${input.automation.name}`,
+      message,
+    });
+    if (!result.ok) {
+      warnings.push({
+        channel: "email",
+        code: result.error.code,
+        message: result.error.message,
+      });
+    }
+  }
+
+  return warnings.length > 0 ? { notificationWarnings: warnings } : {};
+}

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-notifications.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-notifications.ts
@@ -1,21 +1,11 @@
-import { Resend } from "resend";
-
-import { env } from "@/lib/env";
-import { createLogger } from "@/lib/log";
-import { err, ok, type Result } from "@/lib/primitives/result/results";
-
-import { getSlackBot } from "./slack/bot";
+import {
+  runWorkspaceAutomationEmailNotificationTool,
+  runWorkspaceAutomationSlackNotificationTool,
+} from "./workspace-automation/notification-tools";
 import type {
   WorkspaceAutomationRecord,
   WorkspaceAutomationRunRecord,
 } from "./workspace-automations";
-
-const logger = createLogger("workspace-automation-notifications");
-
-export type WorkspaceAutomationNotificationError = {
-  code: "slack_send_failed" | "email_send_failed" | "notifications_not_configured";
-  message: string;
-};
 
 function buildRunSummaryMessage(input: {
   automation: WorkspaceAutomationRecord;
@@ -38,86 +28,6 @@ function buildRunSummaryMessage(input: {
   return lines.join("\n");
 }
 
-async function sendSlackNotification(input: {
-  channelId: string;
-  message: string;
-}): Promise<Result<void, WorkspaceAutomationNotificationError>> {
-  if (!env.SLACK_CLIENT_ID || !env.SLACK_CLIENT_SECRET || !env.SLACK_SIGNING_SECRET) {
-    return err({
-      code: "slack_send_failed",
-      message: "Slack is not configured for this environment.",
-    });
-  }
-
-  try {
-    const bot = await getSlackBot();
-    await bot.initialize();
-    const adapter = bot.getAdapter("slack");
-    const postChannelMessage = (
-      adapter as unknown as {
-        postMessage?: (channelId: string, message: string) => Promise<void>;
-      }
-    ).postMessage;
-    if (!postChannelMessage) {
-      return err({
-        code: "slack_send_failed",
-        message: "Slack adapter does not support channel notifications.",
-      });
-    }
-
-    await postChannelMessage(input.channelId, input.message);
-    return ok(undefined);
-  } catch (error) {
-    logger.warn(
-      { error: error instanceof Error ? error.message : String(error) },
-      "workspace automation slack notification failed",
-    );
-    return err({
-      code: "slack_send_failed",
-      message: error instanceof Error ? error.message : "Slack notification failed.",
-    });
-  }
-}
-
-async function sendEmailNotification(input: {
-  recipients: string[];
-  subject: string;
-  message: string;
-}): Promise<Result<void, WorkspaceAutomationNotificationError>> {
-  if (!env.RESEND_API_KEY || !env.RESEND_FROM_ADDRESS) {
-    return err({
-      code: "email_send_failed",
-      message: "Email delivery is not configured for this environment.",
-    });
-  }
-
-  try {
-    const resend = new Resend(env.RESEND_API_KEY);
-    const result = await resend.emails.send({
-      from: env.RESEND_FROM_NAME
-        ? `${env.RESEND_FROM_NAME} <${env.RESEND_FROM_ADDRESS}>`
-        : env.RESEND_FROM_ADDRESS,
-      to: input.recipients,
-      subject: input.subject,
-      text: input.message,
-    });
-
-    if (result.error) {
-      return err({
-        code: "email_send_failed",
-        message: result.error.message,
-      });
-    }
-
-    return ok(undefined);
-  } catch (error) {
-    return err({
-      code: "email_send_failed",
-      message: error instanceof Error ? error.message : "Email notification failed.",
-    });
-  }
-}
-
 export async function notifyWorkspaceAutomationTerminalRun(input: {
   automation: WorkspaceAutomationRecord;
   run: WorkspaceAutomationRunRecord;
@@ -132,7 +42,7 @@ export async function notifyWorkspaceAutomationTerminalRun(input: {
 
   const slack = input.automation.toolConfig.slack;
   if (slack?.enabled && slack.channelId) {
-    const result = await sendSlackNotification({
+    const result = await runWorkspaceAutomationSlackNotificationTool({
       channelId: slack.channelId,
       message,
     });
@@ -147,7 +57,7 @@ export async function notifyWorkspaceAutomationTerminalRun(input: {
 
   const email = input.automation.toolConfig.email;
   if (email?.enabled && email.recipients && email.recipients.length > 0) {
-    const result = await sendEmailNotification({
+    const result = await runWorkspaceAutomationEmailNotificationTool({
       recipients: email.recipients,
       subject: `Automation run ${input.run.status}: ${input.automation.name}`,
       message,

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-run-sync.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-run-sync.test.ts
@@ -1,0 +1,165 @@
+import "dotenv/config";
+
+import { eq } from "drizzle-orm";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const { notifyWorkspaceAutomationTerminalRunMock } = vi.hoisted(() => ({
+  notifyWorkspaceAutomationTerminalRunMock: vi.fn(async () => ({ notificationSent: true })),
+}));
+
+vi.mock("./workspace-automation-notifications", () => ({
+  notifyWorkspaceAutomationTerminalRun: notifyWorkspaceAutomationTerminalRunMock,
+}));
+
+import { db, schema } from "@/lib/database";
+
+import { claimGithubRepositoryAutomationJob } from "./github/github-repository-automation-jobs";
+import { syncWorkspaceAutomationRunsForGithubJob } from "./workspace-automation-run-sync";
+import {
+  createWorkspaceAutomation,
+  createWorkspaceAutomationRun,
+  listWorkspaceAutomationRuns,
+} from "./workspace-automations";
+
+const organizationIds: string[] = [];
+
+function expectOk<T, E>(result: { ok: true; value: T } | { ok: false; error: E }): T {
+  if (!result.ok) {
+    throw new Error("expected ok result");
+  }
+  return result.value;
+}
+
+async function seedRunSyncScope() {
+  const organizationId = crypto.randomUUID();
+  const userId = crypto.randomUUID();
+  const numericSuffix = BigInt(`0x${crypto.randomUUID().replaceAll("-", "").slice(0, 12)}`)
+    .toString()
+    .slice(0, 12);
+  const githubInstallationId = `7${numericSuffix}`;
+  const githubRepositoryId = `6${numericSuffix}`;
+
+  organizationIds.push(organizationId);
+
+  await db.insert(schema.organizations).values({
+    id: organizationId,
+    workosOrganizationId: `org_${organizationId}`,
+    slug: `workspace-run-sync-${organizationId.slice(0, 8)}`,
+    name: "Workspace Run Sync Test Org",
+  });
+
+  await db.insert(schema.users).values({
+    id: userId,
+    workosUserId: `user_${userId}`,
+    email: `${userId}@example.test`,
+  });
+
+  await db.insert(schema.githubInstallations).values({
+    organizationId,
+    githubInstallationId,
+    githubAppId: "123",
+    accountLogin: "hyperlocalise",
+    accountType: "Organization",
+  });
+
+  const [repository] = await db
+    .insert(schema.githubInstallationRepositories)
+    .values({
+      organizationId,
+      githubInstallationId,
+      githubRepositoryId,
+      owner: "hyperlocalise",
+      name: "web",
+      fullName: "hyperlocalise/web",
+      private: false,
+      archived: false,
+      defaultBranch: "main",
+      enabled: true,
+    })
+    .returning();
+
+  if (!repository) {
+    throw new Error("failed to seed github installation repository");
+  }
+
+  return {
+    organizationId,
+    userId,
+    githubInstallationId,
+    githubRepositoryId,
+    githubInstallationRepositoryId: repository.id,
+  };
+}
+
+describe("workspace automation run sync", () => {
+  beforeAll(async () => {
+    await db.$client.query("select 1");
+  });
+
+  beforeEach(() => {
+    notifyWorkspaceAutomationTerminalRunMock.mockClear();
+  });
+
+  afterEach(async () => {
+    for (const organizationId of organizationIds.splice(0)) {
+      await db.delete(schema.organizations).where(eq(schema.organizations.id, organizationId));
+    }
+  });
+
+  it("only sends terminal notifications on the first transition into a terminal state", async () => {
+    const scope = await seedRunSyncScope();
+    const automation = expectOk(
+      await createWorkspaceAutomation({
+        organizationId: scope.organizationId,
+        authorUserId: scope.userId,
+        name: "Repository automation",
+        instructions: "Run repository automation.",
+      }),
+    );
+    const { job } = await claimGithubRepositoryAutomationJob({
+      idempotencyKey: `workspace-automation:${crypto.randomUUID()}`,
+      organizationId: scope.organizationId,
+      githubInstallationRepositoryId: scope.githubInstallationRepositoryId,
+      githubInstallationId: scope.githubInstallationId,
+      githubRepositoryId: scope.githubRepositoryId,
+      configVersion: 1,
+      triggerMode: "scheduled",
+      scheduledRunAt: new Date("2026-06-01T12:00:00.000Z"),
+    });
+
+    await createWorkspaceAutomationRun({
+      automationId: automation.id,
+      organizationId: scope.organizationId,
+      triggerSource: "scheduled",
+      status: "running",
+      githubRepositoryAutomationJobId: job.id,
+      startedAt: new Date("2026-06-01T12:01:00.000Z"),
+    });
+
+    const completedAt = new Date("2026-06-01T12:02:00.000Z");
+    const syncInput = {
+      jobId: job.id,
+      status: "succeeded" as const,
+      resultSummary: { changedFiles: 2 },
+      completedAt,
+    };
+
+    await syncWorkspaceAutomationRunsForGithubJob(syncInput);
+    await syncWorkspaceAutomationRunsForGithubJob(syncInput);
+
+    expect(notifyWorkspaceAutomationTerminalRunMock).toHaveBeenCalledTimes(1);
+
+    const [syncedRun] = await listWorkspaceAutomationRuns({
+      automationId: automation.id,
+      organizationId: scope.organizationId,
+    });
+    expect(syncedRun).toMatchObject({
+      status: "succeeded",
+      outputSummary: {
+        changedFiles: 2,
+        notificationSent: true,
+      },
+      completedAt: completedAt.toISOString(),
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-run-sync.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-run-sync.ts
@@ -29,6 +29,12 @@ function mapGithubJobStatusToRunStatus(
   }
 }
 
+function isTerminalRunStatus(status: WorkspaceAutomationRunStatus) {
+  return (
+    status === "succeeded" || status === "failed" || status === "cancelled" || status === "skipped"
+  );
+}
+
 export async function syncWorkspaceAutomationRunsForGithubJob(input: {
   jobId: string;
   status: GithubRepositoryAutomationJobStatus;
@@ -52,6 +58,8 @@ export async function syncWorkspaceAutomationRunsForGithubJob(input: {
   }
 
   for (const runRow of runRows) {
+    const shouldNotifyTerminalRun =
+      isTerminalRunStatus(mappedStatus) && !isTerminalRunStatus(runRow.status);
     const outputSummary = {
       ...(runRow.outputSummary as Record<string, unknown>),
       ...input.resultSummary,
@@ -76,6 +84,10 @@ export async function syncWorkspaceAutomationRunsForGithubJob(input: {
     });
 
     if (!updatedRun) {
+      continue;
+    }
+
+    if (!shouldNotifyTerminalRun) {
       continue;
     }
 

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-run-sync.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-run-sync.ts
@@ -1,0 +1,105 @@
+import { eq } from "drizzle-orm";
+
+import { db, schema } from "@/lib/database";
+
+import type { GithubRepositoryAutomationJobStatus } from "./github/github-repository-automation-jobs";
+import { notifyWorkspaceAutomationTerminalRun } from "./workspace-automation-notifications";
+import {
+  getWorkspaceAutomationById,
+  updateWorkspaceAutomationRun,
+  type WorkspaceAutomationRunStatus,
+} from "./workspace-automations";
+
+function mapGithubJobStatusToRunStatus(
+  status: GithubRepositoryAutomationJobStatus,
+): WorkspaceAutomationRunStatus | null {
+  switch (status) {
+    case "queued":
+      return "queued";
+    case "running":
+      return "running";
+    case "succeeded":
+      return "succeeded";
+    case "failed":
+      return "failed";
+    case "skipped":
+      return "skipped";
+    default:
+      return null;
+  }
+}
+
+export async function syncWorkspaceAutomationRunsForGithubJob(input: {
+  jobId: string;
+  status: GithubRepositoryAutomationJobStatus;
+  resultSummary?: Record<string, unknown> | null;
+  lastError?: string | null;
+  skipReason?: string | null;
+  completedAt?: Date | null;
+}) {
+  const [runRow] = await db
+    .select()
+    .from(schema.workspaceAutomationRuns)
+    .where(eq(schema.workspaceAutomationRuns.githubRepositoryAutomationJobId, input.jobId))
+    .limit(1);
+
+  if (!runRow) {
+    return;
+  }
+
+  const mappedStatus = mapGithubJobStatusToRunStatus(input.status);
+  if (!mappedStatus) {
+    return;
+  }
+
+  const outputSummary = {
+    ...(runRow.outputSummary as Record<string, unknown>),
+    ...input.resultSummary,
+    ...(input.skipReason ? { skipReason: input.skipReason } : {}),
+  };
+
+  const updatedRun = await updateWorkspaceAutomationRun({
+    runId: runRow.id,
+    organizationId: runRow.organizationId,
+    status: mappedStatus,
+    outputSummary,
+    error: input.lastError ? { message: input.lastError } : null,
+    completedAt:
+      input.completedAt ??
+      (mappedStatus === "succeeded" || mappedStatus === "failed" || mappedStatus === "skipped"
+        ? new Date()
+        : null),
+    startedAt:
+      mappedStatus === "running" && !runRow.startedAt
+        ? new Date()
+        : (runRow.startedAt ?? undefined),
+  });
+
+  if (!updatedRun) {
+    return;
+  }
+
+  const automation = await getWorkspaceAutomationById({
+    automationId: runRow.automationId,
+    organizationId: runRow.organizationId,
+  });
+  if (!automation) {
+    return;
+  }
+
+  const notificationSummary = await notifyWorkspaceAutomationTerminalRun({
+    automation,
+    run: updatedRun,
+  });
+
+  if (Object.keys(notificationSummary).length > 0) {
+    await updateWorkspaceAutomationRun({
+      runId: updatedRun.id,
+      organizationId: updatedRun.organizationId,
+      outputSummary: {
+        ...updatedRun.outputSummary,
+        ...notificationSummary,
+      },
+    });
+  }
+}

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-run-sync.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-run-sync.ts
@@ -37,69 +37,70 @@ export async function syncWorkspaceAutomationRunsForGithubJob(input: {
   skipReason?: string | null;
   completedAt?: Date | null;
 }) {
-  const [runRow] = await db
-    .select()
-    .from(schema.workspaceAutomationRuns)
-    .where(eq(schema.workspaceAutomationRuns.githubRepositoryAutomationJobId, input.jobId))
-    .limit(1);
-
-  if (!runRow) {
-    return;
-  }
-
   const mappedStatus = mapGithubJobStatusToRunStatus(input.status);
   if (!mappedStatus) {
     return;
   }
 
-  const outputSummary = {
-    ...(runRow.outputSummary as Record<string, unknown>),
-    ...input.resultSummary,
-    ...(input.skipReason ? { skipReason: input.skipReason } : {}),
-  };
+  const runRows = await db
+    .select()
+    .from(schema.workspaceAutomationRuns)
+    .where(eq(schema.workspaceAutomationRuns.githubRepositoryAutomationJobId, input.jobId));
 
-  const updatedRun = await updateWorkspaceAutomationRun({
-    runId: runRow.id,
-    organizationId: runRow.organizationId,
-    status: mappedStatus,
-    outputSummary,
-    error: input.lastError ? { message: input.lastError } : null,
-    completedAt:
-      input.completedAt ??
-      (mappedStatus === "succeeded" || mappedStatus === "failed" || mappedStatus === "skipped"
-        ? new Date()
-        : null),
-    startedAt:
-      mappedStatus === "running" && !runRow.startedAt
-        ? new Date()
-        : (runRow.startedAt ?? undefined),
-  });
-
-  if (!updatedRun) {
+  if (runRows.length === 0) {
     return;
   }
 
-  const automation = await getWorkspaceAutomationById({
-    automationId: runRow.automationId,
-    organizationId: runRow.organizationId,
-  });
-  if (!automation) {
-    return;
-  }
+  for (const runRow of runRows) {
+    const outputSummary = {
+      ...(runRow.outputSummary as Record<string, unknown>),
+      ...input.resultSummary,
+      ...(input.skipReason ? { skipReason: input.skipReason } : {}),
+    };
 
-  const notificationSummary = await notifyWorkspaceAutomationTerminalRun({
-    automation,
-    run: updatedRun,
-  });
-
-  if (Object.keys(notificationSummary).length > 0) {
-    await updateWorkspaceAutomationRun({
-      runId: updatedRun.id,
-      organizationId: updatedRun.organizationId,
-      outputSummary: {
-        ...updatedRun.outputSummary,
-        ...notificationSummary,
-      },
+    const updatedRun = await updateWorkspaceAutomationRun({
+      runId: runRow.id,
+      organizationId: runRow.organizationId,
+      status: mappedStatus,
+      outputSummary,
+      error: input.lastError ? { message: input.lastError } : null,
+      completedAt:
+        input.completedAt ??
+        (mappedStatus === "succeeded" || mappedStatus === "failed" || mappedStatus === "skipped"
+          ? new Date()
+          : null),
+      startedAt:
+        mappedStatus === "running" && !runRow.startedAt
+          ? new Date()
+          : (runRow.startedAt ?? undefined),
     });
+
+    if (!updatedRun) {
+      continue;
+    }
+
+    const automation = await getWorkspaceAutomationById({
+      automationId: runRow.automationId,
+      organizationId: runRow.organizationId,
+    });
+    if (!automation) {
+      continue;
+    }
+
+    const notificationSummary = await notifyWorkspaceAutomationTerminalRun({
+      automation,
+      run: updatedRun,
+    });
+
+    if (Object.keys(notificationSummary).length > 0) {
+      await updateWorkspaceAutomationRun({
+        runId: updatedRun.id,
+        organizationId: updatedRun.organizationId,
+        outputSummary: {
+          ...updatedRun.outputSummary,
+          ...notificationSummary,
+        },
+      });
+    }
   }
 }

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-schedule.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-schedule.ts
@@ -1,0 +1,20 @@
+import { resolveNextRunAtForSettings } from "@/lib/agents/github/github-repository-automation-settings";
+
+import { workspaceAutomationToGithubSettings } from "./workspace-automation-github-mapping";
+import type { WorkspaceAutomationRecord } from "./workspace-automations";
+
+export function resolveNextRunAtForWorkspaceAutomation(
+  automation: WorkspaceAutomationRecord,
+  from: Date = new Date(),
+): Date | null {
+  if (automation.status !== "active") {
+    return null;
+  }
+
+  const githubSettings = workspaceAutomationToGithubSettings(automation);
+  if (!githubSettings) {
+    return null;
+  }
+
+  return resolveNextRunAtForSettings(githubSettings, from);
+}

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-scheduler.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-scheduler.ts
@@ -1,0 +1,136 @@
+import { createLogger } from "@/lib/log";
+
+import { dispatchWorkspaceAutomationForScheduleAndAdvance } from "./workspace-automation-dispatcher";
+import { hasWorkspaceAutomationGithubWorkflow } from "./workspace-automation-github-mapping";
+import { listDueWorkspaceAutomations } from "./workspace-automations";
+
+const logger = createLogger("workspace-automation-scheduler");
+
+export type WorkspaceAutomationSchedulerResult = {
+  processed: number;
+  enqueued: number;
+  skipped: number;
+  duplicates: number;
+};
+
+export async function runWorkspaceAutomationScheduler(input?: {
+  now?: Date;
+  limit?: number;
+}): Promise<WorkspaceAutomationSchedulerResult> {
+  const now = input?.now ?? new Date();
+  const dueAutomations = await listDueWorkspaceAutomations({
+    now,
+    limit: input?.limit,
+  });
+
+  let enqueued = 0;
+  let skipped = 0;
+  let duplicates = 0;
+
+  for (const entry of dueAutomations) {
+    try {
+      const scheduledRunAt = entry.automation.nextRunAt
+        ? new Date(entry.automation.nextRunAt)
+        : null;
+      if (!scheduledRunAt) {
+        logger.warn(
+          { automationId: entry.automation.id },
+          "workspace automation missing next_run_at; advancing",
+        );
+        await dispatchWorkspaceAutomationForScheduleAndAdvance({
+          automation: entry.automation,
+          repository: {
+            id: entry.repository.id,
+            githubInstallationId: entry.repository.githubInstallationId,
+            githubRepositoryId: entry.repository.githubRepositoryId,
+          },
+          scheduledRunAt: now,
+          completedAt: now,
+        });
+        skipped += 1;
+        continue;
+      }
+
+      if (!hasWorkspaceAutomationGithubWorkflow(entry.automation.toolConfig)) {
+        await dispatchWorkspaceAutomationForScheduleAndAdvance({
+          automation: entry.automation,
+          repository: {
+            id: entry.repository.id,
+            githubInstallationId: entry.repository.githubInstallationId,
+            githubRepositoryId: entry.repository.githubRepositoryId,
+          },
+          scheduledRunAt,
+          completedAt: now,
+        });
+        skipped += 1;
+        continue;
+      }
+
+      if (entry.automation.triggerConfig.mode !== "scheduled") {
+        await dispatchWorkspaceAutomationForScheduleAndAdvance({
+          automation: entry.automation,
+          repository: {
+            id: entry.repository.id,
+            githubInstallationId: entry.repository.githubInstallationId,
+            githubRepositoryId: entry.repository.githubRepositoryId,
+          },
+          scheduledRunAt,
+          completedAt: now,
+        });
+        skipped += 1;
+        continue;
+      }
+
+      const result = await dispatchWorkspaceAutomationForScheduleAndAdvance({
+        automation: entry.automation,
+        repository: {
+          id: entry.repository.id,
+          githubInstallationId: entry.repository.githubInstallationId,
+          githubRepositoryId: entry.repository.githubRepositoryId,
+        },
+        scheduledRunAt,
+        completedAt: now,
+      });
+
+      if (!result) {
+        skipped += 1;
+        continue;
+      }
+
+      if (result.outcome === "enqueued") {
+        enqueued += 1;
+        if (!result.inserted) {
+          duplicates += 1;
+        }
+      } else {
+        skipped += 1;
+      }
+    } catch (error) {
+      logger.error(
+        {
+          automationId: entry.automation.id,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "workspace automation scheduler entry failed",
+      );
+      skipped += 1;
+    }
+  }
+
+  logger.info(
+    {
+      processed: dueAutomations.length,
+      enqueued,
+      skipped,
+      duplicates,
+    },
+    "workspace automation scheduler tick completed",
+  );
+
+  return {
+    processed: dueAutomations.length,
+    enqueued,
+    skipped,
+    duplicates,
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.ts
@@ -1,0 +1,198 @@
+import type { WorkspaceAutomationFormState } from "./workspace-automation-view-model";
+
+export type WorkspaceAutomationTemplateCategory =
+  | "popular"
+  | "code-review"
+  | "security"
+  | "incidents"
+  | "data";
+
+export type WorkspaceAutomationTemplate = {
+  id: string;
+  category: WorkspaceAutomationTemplateCategory;
+  name: string;
+  description: string;
+  instructions: string;
+  activatable: boolean;
+  defaultForm: Partial<WorkspaceAutomationFormState>;
+};
+
+export const WORKSPACE_AUTOMATION_TEMPLATE_CATEGORIES: Array<{
+  id: WorkspaceAutomationTemplateCategory;
+  label: string;
+}> = [
+  { id: "popular", label: "Popular" },
+  { id: "code-review", label: "Code Review" },
+  { id: "security", label: "Security" },
+  { id: "incidents", label: "Incidents & Triage" },
+  { id: "data", label: "Data & Research" },
+];
+
+export const WORKSPACE_AUTOMATION_TEMPLATES: WorkspaceAutomationTemplate[] = [
+  {
+    id: "find-critical-bugs",
+    category: "popular",
+    name: "Find critical bugs",
+    description:
+      "Inspect recent commits for high-severity behavioral regressions and open a pull request when a fix is ready.",
+    instructions: [
+      "You are a deep bug-finding automation.",
+      "",
+      "Goal: inspect recent commits for critical bugs before they reach production.",
+      "",
+      "Investigation strategy:",
+      "- Focus on behavioral changes, data corruption, auth regressions, and race conditions.",
+      "- Ignore style-only diffs and low-risk refactors.",
+    ].join("\n"),
+    activatable: true,
+    defaultForm: {
+      name: "Find critical bugs",
+      triggerMode: "scheduled",
+      scheduledCadence: "daily",
+      scheduledHourUtc: 22,
+      scheduledTimezone: "UTC",
+      githubEnabled: true,
+      validationEnabled: true,
+      slackEnabled: true,
+    },
+  },
+  {
+    id: "summarize-changes-daily",
+    category: "popular",
+    name: "Summarize changes daily",
+    description: "Post a concise summary of repository changes to Slack every day.",
+    instructions:
+      "Summarize the most important repository changes from the last day, grouped by risk and user impact. Keep the update concise and actionable.",
+    activatable: true,
+    defaultForm: {
+      name: "Summarize changes daily",
+      triggerMode: "scheduled",
+      scheduledCadence: "daily",
+      scheduledHourUtc: 22,
+      scheduledTimezone: "UTC",
+      githubEnabled: true,
+      validationEnabled: true,
+      slackEnabled: true,
+    },
+  },
+  {
+    id: "add-test-coverage",
+    category: "code-review",
+    name: "Add test coverage",
+    description: "Review recent changes and propose tests for under-covered critical paths.",
+    instructions:
+      "Review recent changes and identify critical paths missing automated tests. Open a pull request only when tests are clearly justified.",
+    activatable: true,
+    defaultForm: {
+      name: "Add test coverage",
+      triggerMode: "scheduled",
+      scheduledCadence: "weekly",
+      scheduledDayOfWeek: 1,
+      scheduledHourUtc: 22,
+      scheduledTimezone: "UTC",
+      githubEnabled: true,
+      validationEnabled: true,
+    },
+  },
+  {
+    id: "assign-pr-reviewers",
+    category: "code-review",
+    name: "Assign PR reviewers",
+    description: "Assign reviewers based on touched areas and auto-approve low-risk pull requests.",
+    instructions:
+      "Review open pull requests, assign reviewers based on code ownership, and auto-approve only low-risk changes.",
+    activatable: false,
+    defaultForm: {
+      name: "Assign PR reviewers",
+      triggerMode: "github",
+      pushBranches: ["main"],
+      instructions:
+        "Review open pull requests, assign reviewers based on code ownership, and auto-approve only low-risk changes.",
+    },
+  },
+  {
+    id: "find-vulnerabilities",
+    category: "security",
+    name: "Find vulnerabilities",
+    description:
+      "Review pull requests for exploitable security issues and flag only validated findings before merge.",
+    instructions:
+      "Review pull requests for exploitable security issues. Flag only validated findings with clear reproduction steps.",
+    activatable: true,
+    defaultForm: {
+      name: "Find vulnerabilities",
+      triggerMode: "github",
+      pushBranches: ["main"],
+      githubEnabled: true,
+      validationEnabled: true,
+      slackEnabled: true,
+    },
+  },
+  {
+    id: "scan-codebase-vulnerabilities",
+    category: "security",
+    name: "Scan codebase for vulnerabilities",
+    description:
+      "Run a scheduled security scan across the default branch and report validated findings.",
+    instructions:
+      "Scan the repository for high-confidence security issues. Report only validated findings with remediation guidance.",
+    activatable: true,
+    defaultForm: {
+      name: "Scan codebase for vulnerabilities",
+      triggerMode: "scheduled",
+      scheduledCadence: "daily",
+      scheduledHourUtc: 22,
+      scheduledTimezone: "UTC",
+      githubEnabled: true,
+      validationEnabled: true,
+      slackEnabled: true,
+    },
+  },
+  {
+    id: "fix-slack-bugs",
+    category: "incidents",
+    name: "Fix bugs reported in Slack",
+    description:
+      "Monitor a Slack channel for bug reports, investigate the codebase, and fix with a pull request.",
+    instructions:
+      "Monitor the configured Slack channel for bug reports, investigate the repository, and open a pull request when a fix is clear.",
+    activatable: false,
+    defaultForm: {
+      name: "Fix bugs reported in Slack",
+      triggerMode: "manual",
+      slackEnabled: true,
+    },
+  },
+  {
+    id: "generate-docs",
+    category: "data",
+    name: "Generate docs",
+    description:
+      "Create and update developer documentation for recently changed or under-documented code.",
+    instructions:
+      "Create or update developer documentation for recently changed or under-documented code. Prefer concise, accurate docs over broad rewrites.",
+    activatable: true,
+    defaultForm: {
+      name: "Generate docs",
+      triggerMode: "scheduled",
+      scheduledCadence: "weekly",
+      scheduledDayOfWeek: 1,
+      scheduledHourUtc: 22,
+      scheduledTimezone: "UTC",
+      githubEnabled: true,
+      pullTranslationsEnabled: true,
+    },
+  },
+];
+
+export function getWorkspaceAutomationTemplate(templateId: string) {
+  return WORKSPACE_AUTOMATION_TEMPLATES.find((template) => template.id === templateId) ?? null;
+}
+
+export function listWorkspaceAutomationTemplates(category?: WorkspaceAutomationTemplateCategory) {
+  if (!category) {
+    return WORKSPACE_AUTOMATION_TEMPLATES;
+  }
+
+  return WORKSPACE_AUTOMATION_TEMPLATES.filter((template) => template.category === category);
+}

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { getWorkspaceAutomationTemplate } from "./workspace-automation-templates";
+import {
+  createDefaultWorkspaceAutomationFormState,
+  createWorkspaceAutomationFormStateFromTemplate,
+  formStateToWorkspaceAutomationPayload,
+  validateWorkspaceAutomationFormState,
+} from "./workspace-automation-view-model";
+
+describe("workspace automation view model", () => {
+  it("prefills the form from a template", () => {
+    const template = getWorkspaceAutomationTemplate("find-critical-bugs");
+    expect(template).not.toBeNull();
+
+    const form = createWorkspaceAutomationFormStateFromTemplate("find-critical-bugs");
+    expect(form).toMatchObject({
+      name: "Find critical bugs",
+      triggerMode: "scheduled",
+      githubEnabled: true,
+      validationEnabled: true,
+      slackEnabled: true,
+    });
+    expect(form?.instructions).toContain("deep bug-finding automation");
+  });
+
+  it("maps form state to API payload", () => {
+    const form = {
+      ...createDefaultWorkspaceAutomationFormState(),
+      name: "Nightly validation",
+      instructions: "Validate repository changes.",
+      triggerMode: "scheduled" as const,
+      githubEnabled: true,
+      githubInstallationRepositoryId: "11111111-1111-4111-8111-111111111111",
+      githubProjectId: "project-1",
+      validationEnabled: true,
+      slackEnabled: true,
+      slackChannelId: "C123",
+      emailEnabled: true,
+      emailRecipients: ["ops@example.com"],
+    };
+
+    expect(validateWorkspaceAutomationFormState(form)).toEqual({});
+    const payload = formStateToWorkspaceAutomationPayload(form);
+    expect(payload.triggerConfig.mode).toBe("scheduled");
+    expect(payload.repositoryTarget).toEqual({
+      kind: "github",
+      githubInstallationRepositoryId: "11111111-1111-4111-8111-111111111111",
+    });
+    expect(payload.toolConfig.github).toMatchObject({
+      enabled: true,
+      projectId: "project-1",
+      validation: true,
+    });
+    expect(payload.toolConfig.slack).toEqual({
+      enabled: true,
+      channelId: "C123",
+    });
+    expect(payload.toolConfig.email).toEqual({
+      enabled: true,
+      recipients: ["ops@example.com"],
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.ts
@@ -54,6 +54,7 @@ export const WORKSPACE_AUTOMATION_API_ERROR_MESSAGES: Record<string, string> = {
   github_project_required: "Choose a Hyperlocalise project for GitHub workflows.",
   github_trigger_required: "Choose a schedule or GitHub push trigger for GitHub workflows.",
   github_push_branches_required: "Add at least one branch pattern for GitHub push triggers.",
+  scheduled_github_workflow_required: "Scheduled automations require at least one GitHub workflow.",
   slack_not_connected: "Connect Slack in Integrations before enabling Slack notifications.",
   slack_channel_required: "Choose a Slack channel for notifications.",
   email_not_connected: "Enable the email agent in Integrations before using email notifications.",
@@ -296,6 +297,7 @@ export function mapWorkspaceAutomationApiErrorToFieldErrors(
     case "project_not_found":
       return { githubProjectId: message };
     case "github_trigger_required":
+    case "scheduled_github_workflow_required":
       return { trigger: message };
     case "github_push_branches_required":
       return { pushBranches: message };

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.ts
@@ -1,0 +1,315 @@
+import type {
+  WorkspaceAutomationRecord,
+  WorkspaceAutomationRepositoryTarget,
+  WorkspaceAutomationToolConfig,
+  WorkspaceAutomationTriggerConfig,
+} from "./workspace-automations";
+import {
+  getWorkspaceAutomationTemplate,
+  type WorkspaceAutomationTemplate,
+} from "./workspace-automation-templates";
+
+export type WorkspaceAutomationTriggerMode = "manual" | "scheduled" | "github";
+
+export type WorkspaceAutomationFormState = {
+  name: string;
+  instructions: string;
+  status: "active" | "paused";
+  triggerMode: WorkspaceAutomationTriggerMode;
+  pushBranches: string[];
+  scheduledCadence: "hourly" | "daily" | "weekly";
+  scheduledHourUtc: number;
+  scheduledDayOfWeek: number;
+  scheduledTimezone: string;
+  repositoryTargetKind: "none" | "github";
+  githubInstallationRepositoryId: string;
+  githubEnabled: boolean;
+  githubProjectId: string;
+  pushSourceEnabled: boolean;
+  pullTranslationsEnabled: boolean;
+  validationEnabled: boolean;
+  slackEnabled: boolean;
+  slackChannelId: string;
+  emailEnabled: boolean;
+  emailRecipients: string[];
+};
+
+export type WorkspaceAutomationFieldErrors = Partial<
+  Record<
+    | "name"
+    | "instructions"
+    | "githubProjectId"
+    | "githubRepository"
+    | "trigger"
+    | "pushBranches"
+    | "slackChannelId"
+    | "emailRecipients"
+    | "form",
+    string
+  >
+>;
+
+export const WORKSPACE_AUTOMATION_API_ERROR_MESSAGES: Record<string, string> = {
+  github_repository_target_required: "Choose a GitHub repository before enabling GitHub tools.",
+  github_project_required: "Choose a Hyperlocalise project for GitHub workflows.",
+  github_trigger_required: "Choose a schedule or GitHub push trigger for GitHub workflows.",
+  github_push_branches_required: "Add at least one branch pattern for GitHub push triggers.",
+  slack_not_connected: "Connect Slack in Integrations before enabling Slack notifications.",
+  slack_channel_required: "Choose a Slack channel for notifications.",
+  email_not_connected: "Enable the email agent in Integrations before using email notifications.",
+  email_recipients_required: "Add at least one email recipient.",
+  github_repository_not_enabled: "Enable this repository before configuring automation.",
+  github_repository_archived: "Archived repositories cannot use automations.",
+  project_not_found: "The selected project could not be found.",
+};
+
+export function createDefaultWorkspaceAutomationFormState(): WorkspaceAutomationFormState {
+  return {
+    name: "",
+    instructions: "",
+    status: "active",
+    triggerMode: "manual",
+    pushBranches: ["main"],
+    scheduledCadence: "daily",
+    scheduledHourUtc: 22,
+    scheduledDayOfWeek: 1,
+    scheduledTimezone: "UTC",
+    repositoryTargetKind: "none",
+    githubInstallationRepositoryId: "",
+    githubEnabled: false,
+    githubProjectId: "",
+    pushSourceEnabled: false,
+    pullTranslationsEnabled: false,
+    validationEnabled: false,
+    slackEnabled: false,
+    slackChannelId: "",
+    emailEnabled: false,
+    emailRecipients: [],
+  };
+}
+
+export function createWorkspaceAutomationFormStateFromRecord(
+  automation: WorkspaceAutomationRecord,
+): WorkspaceAutomationFormState {
+  const github = automation.toolConfig.github;
+  const slack = automation.toolConfig.slack;
+  const email = automation.toolConfig.email;
+
+  return {
+    name: automation.name,
+    instructions: automation.instructions,
+    status: automation.status === "paused" ? "paused" : "active",
+    triggerMode: automation.triggerConfig.mode,
+    pushBranches:
+      automation.triggerConfig.mode === "github" && automation.triggerConfig.branches?.length
+        ? [...automation.triggerConfig.branches]
+        : ["main"],
+    scheduledCadence:
+      automation.triggerConfig.mode === "scheduled" && automation.triggerConfig.schedule
+        ? automation.triggerConfig.schedule.cadence
+        : "daily",
+    scheduledHourUtc:
+      automation.triggerConfig.mode === "scheduled" && automation.triggerConfig.schedule
+        ? (automation.triggerConfig.schedule.hourUtc ?? 22)
+        : 22,
+    scheduledDayOfWeek:
+      automation.triggerConfig.mode === "scheduled" && automation.triggerConfig.schedule
+        ? (automation.triggerConfig.schedule.dayOfWeek ?? 1)
+        : 1,
+    scheduledTimezone:
+      automation.triggerConfig.mode === "scheduled" && automation.triggerConfig.schedule
+        ? automation.triggerConfig.schedule.timezone
+        : "UTC",
+    repositoryTargetKind: automation.repositoryTarget.kind,
+    githubInstallationRepositoryId:
+      automation.repositoryTarget.githubInstallationRepositoryId ?? "",
+    githubEnabled: Boolean(github?.enabled),
+    githubProjectId: github?.projectId ?? "",
+    pushSourceEnabled: Boolean(github?.pushSource),
+    pullTranslationsEnabled: Boolean(github?.pullTranslations),
+    validationEnabled: Boolean(github?.validation),
+    slackEnabled: Boolean(slack?.enabled),
+    slackChannelId: slack?.channelId ?? "",
+    emailEnabled: Boolean(email?.enabled),
+    emailRecipients: email?.recipients ? [...email.recipients] : [],
+  };
+}
+
+export function createWorkspaceAutomationFormStateFromTemplate(
+  templateId: string,
+): WorkspaceAutomationFormState | null {
+  const template = getWorkspaceAutomationTemplate(templateId);
+  if (!template) {
+    return null;
+  }
+
+  return applyTemplateToWorkspaceAutomationFormState(
+    createDefaultWorkspaceAutomationFormState(),
+    template,
+  );
+}
+
+export function applyTemplateToWorkspaceAutomationFormState(
+  base: WorkspaceAutomationFormState,
+  template: WorkspaceAutomationTemplate,
+): WorkspaceAutomationFormState {
+  return {
+    ...base,
+    ...template.defaultForm,
+    name: template.defaultForm.name ?? template.name,
+    instructions: template.defaultForm.instructions ?? template.instructions,
+    pushBranches: template.defaultForm.pushBranches ?? base.pushBranches,
+    emailRecipients: template.defaultForm.emailRecipients ?? base.emailRecipients,
+  };
+}
+
+export function formStateToWorkspaceAutomationPayload(form: WorkspaceAutomationFormState): {
+  name: string;
+  instructions: string;
+  status: "active" | "paused";
+  triggerConfig: WorkspaceAutomationTriggerConfig;
+  repositoryTarget: WorkspaceAutomationRepositoryTarget;
+  toolConfig: WorkspaceAutomationToolConfig;
+} {
+  const triggerConfig: WorkspaceAutomationTriggerConfig =
+    form.triggerMode === "scheduled"
+      ? {
+          mode: "scheduled",
+          schedule: {
+            cadence: form.scheduledCadence,
+            hourUtc: form.scheduledHourUtc,
+            dayOfWeek: form.scheduledCadence === "weekly" ? form.scheduledDayOfWeek : undefined,
+            timezone: form.scheduledTimezone.trim() || "UTC",
+          },
+        }
+      : form.triggerMode === "github"
+        ? {
+            mode: "github",
+            branches: form.pushBranches,
+          }
+        : { mode: "manual" };
+
+  const repositoryTarget: WorkspaceAutomationRepositoryTarget =
+    form.githubEnabled && form.githubInstallationRepositoryId
+      ? {
+          kind: "github",
+          githubInstallationRepositoryId: form.githubInstallationRepositoryId,
+        }
+      : { kind: "none" };
+
+  const toolConfig: WorkspaceAutomationToolConfig = {
+    ...(form.githubEnabled
+      ? {
+          github: {
+            enabled: true,
+            projectId: form.githubProjectId.trim() || undefined,
+            pushSource: form.pushSourceEnabled,
+            pullTranslations: form.pullTranslationsEnabled,
+            validation: form.validationEnabled,
+          },
+        }
+      : {}),
+    ...(form.slackEnabled
+      ? {
+          slack: {
+            enabled: true,
+            channelId: form.slackChannelId.trim() || undefined,
+          },
+        }
+      : {}),
+    ...(form.emailEnabled
+      ? {
+          email: {
+            enabled: true,
+            recipients: form.emailRecipients,
+          },
+        }
+      : {}),
+  };
+
+  return {
+    name: form.name.trim(),
+    instructions: form.instructions.trim(),
+    status: form.status,
+    triggerConfig,
+    repositoryTarget,
+    toolConfig,
+  };
+}
+
+export function validateWorkspaceAutomationFormState(
+  form: WorkspaceAutomationFormState,
+): WorkspaceAutomationFieldErrors {
+  const errors: WorkspaceAutomationFieldErrors = {};
+
+  if (!form.name.trim()) {
+    errors.name = "Name is required.";
+  }
+
+  if (!form.instructions.trim()) {
+    errors.instructions = "Instructions are required.";
+  }
+
+  if (form.githubEnabled) {
+    if (!form.githubInstallationRepositoryId) {
+      errors.githubRepository = "Choose a GitHub repository.";
+    }
+    if (!form.githubProjectId.trim()) {
+      errors.githubProjectId = "Choose a Hyperlocalise project.";
+    }
+    if (!form.pushSourceEnabled && !form.pullTranslationsEnabled && !form.validationEnabled) {
+      errors.form = "Enable at least one GitHub workflow.";
+    }
+    if (form.triggerMode === "manual") {
+      errors.trigger = "Choose a schedule or GitHub push trigger.";
+    }
+    if (form.triggerMode === "github" && form.pushBranches.length === 0) {
+      errors.pushBranches = "Add at least one branch pattern.";
+    }
+  }
+
+  if (form.slackEnabled && !form.slackChannelId.trim()) {
+    errors.slackChannelId = "Choose a Slack channel.";
+  }
+
+  if (form.emailEnabled && form.emailRecipients.length === 0) {
+    errors.emailRecipients = "Add at least one email recipient.";
+  }
+
+  return errors;
+}
+
+export function mapWorkspaceAutomationApiErrorToFieldErrors(
+  errorCode: string,
+): WorkspaceAutomationFieldErrors {
+  const message = WORKSPACE_AUTOMATION_API_ERROR_MESSAGES[errorCode];
+  if (!message) {
+    return { form: "Unable to save this automation." };
+  }
+
+  switch (errorCode) {
+    case "github_repository_target_required":
+    case "github_repository_not_enabled":
+    case "github_repository_archived":
+      return { githubRepository: message };
+    case "github_project_required":
+    case "project_not_found":
+      return { githubProjectId: message };
+    case "github_trigger_required":
+      return { trigger: message };
+    case "github_push_branches_required":
+      return { pushBranches: message };
+    case "slack_not_connected":
+    case "slack_channel_required":
+      return { slackChannelId: message };
+    case "email_not_connected":
+    case "email_recipients_required":
+      return { emailRecipients: message };
+    default:
+      return { form: message };
+  }
+}
+
+export function workspaceAutomationFormCanActivate(form: WorkspaceAutomationFormState) {
+  return form.githubEnabled || form.slackEnabled || form.emailEnabled;
+}

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation/notification-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation/notification-tools.ts
@@ -1,0 +1,71 @@
+import { Resend } from "resend";
+
+import { env } from "@/lib/env";
+import { err, ok, type Result } from "@/lib/primitives/result/results";
+
+export type WorkspaceAutomationNotificationError = {
+  code: "slack_send_failed" | "email_send_failed" | "notifications_not_configured";
+  message: string;
+};
+
+export async function runWorkspaceAutomationSlackNotificationTool(input: {
+  channelId: string;
+  message: string;
+}): Promise<Result<void, WorkspaceAutomationNotificationError>> {
+  if (!env.SLACK_CLIENT_ID || !env.SLACK_CLIENT_SECRET || !env.SLACK_SIGNING_SECRET) {
+    return err({
+      code: "slack_send_failed",
+      message: "Slack is not configured for this environment.",
+    });
+  }
+
+  try {
+    const { postSlackChannelMessage } = await import("@/lib/agents/slack/post-channel-message");
+    await postSlackChannelMessage({ channelId: input.channelId, text: input.message });
+    return ok(undefined);
+  } catch (error) {
+    return err({
+      code: "slack_send_failed",
+      message: error instanceof Error ? error.message : "Slack notification failed.",
+    });
+  }
+}
+
+export async function runWorkspaceAutomationEmailNotificationTool(input: {
+  recipients: string[];
+  subject: string;
+  message: string;
+}): Promise<Result<void, WorkspaceAutomationNotificationError>> {
+  if (!env.RESEND_API_KEY || !env.RESEND_FROM_ADDRESS) {
+    return err({
+      code: "email_send_failed",
+      message: "Email delivery is not configured for this environment.",
+    });
+  }
+
+  try {
+    const resend = new Resend(env.RESEND_API_KEY);
+    const result = await resend.emails.send({
+      from: env.RESEND_FROM_NAME
+        ? `${env.RESEND_FROM_NAME} <${env.RESEND_FROM_ADDRESS}>`
+        : env.RESEND_FROM_ADDRESS,
+      to: input.recipients,
+      subject: input.subject,
+      text: input.message,
+    });
+
+    if (result.error) {
+      return err({
+        code: "email_send_failed",
+        message: result.error.message,
+      });
+    }
+
+    return ok(undefined);
+  } catch (error) {
+    return err({
+      code: "email_send_failed",
+      message: error instanceof Error ? error.message : "Email notification failed.",
+    });
+  }
+}

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.test.ts
@@ -185,6 +185,68 @@ describe("workspace automations", () => {
     expect(missingProject.error.code).toBe("github_project_required");
   });
 
+  it("rejects scheduled automations without a GitHub workflow", async () => {
+    const scope = await seedWorkspaceAutomationScope();
+    const triggerConfig = {
+      mode: "scheduled" as const,
+      schedule: {
+        cadence: "daily" as const,
+        hourUtc: 8,
+        timezone: "UTC",
+      },
+    };
+
+    await db.insert(schema.connectors).values({
+      organizationId: scope.organizationId,
+      kind: "slack",
+      enabled: true,
+    });
+
+    const notificationOnlySchedule = await createWorkspaceAutomation({
+      organizationId: scope.organizationId,
+      authorUserId: scope.userId,
+      name: "Notification-only schedule",
+      instructions: "Send a daily reminder.",
+      triggerConfig,
+      toolConfig: {
+        slack: {
+          enabled: true,
+          channelId: "C123",
+        },
+      },
+    });
+    expect(notificationOnlySchedule.ok).toBe(false);
+    if (notificationOnlySchedule.ok) {
+      throw new Error("expected validation error");
+    }
+    expect(notificationOnlySchedule.error.code).toBe("scheduled_github_workflow_required");
+
+    const manualNotification = expectOk(
+      await createWorkspaceAutomation({
+        organizationId: scope.organizationId,
+        authorUserId: scope.userId,
+        name: "Manual notification",
+        instructions: "Send a reminder manually.",
+        toolConfig: {
+          slack: {
+            enabled: true,
+            channelId: "C123",
+          },
+        },
+      }),
+    );
+    const scheduledUpdate = await updateWorkspaceAutomation({
+      automationId: manualNotification.id,
+      organizationId: scope.organizationId,
+      triggerConfig,
+    });
+    expect(scheduledUpdate.ok).toBe(false);
+    if (scheduledUpdate.ok) {
+      throw new Error("expected validation error");
+    }
+    expect(scheduledUpdate.error.code).toBe("scheduled_github_workflow_required");
+  });
+
   it("only versions config-changing automation updates", async () => {
     const scope = await seedWorkspaceAutomationScope();
     const automation = expectOk(

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.test.ts
@@ -197,6 +197,14 @@ describe("workspace automations", () => {
           kind: "github",
           githubInstallationRepositoryId: scope.githubInstallationRepositoryId,
         },
+        triggerConfig: {
+          mode: "scheduled",
+          schedule: {
+            cadence: "daily",
+            hourUtc: 12,
+            timezone: "UTC",
+          },
+        },
         toolConfig: {
           github: {
             enabled: true,

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
@@ -1,8 +1,10 @@
-import { and, desc, eq, sql } from "drizzle-orm";
+import { and, desc, eq, isNotNull, lte, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import { db, schema } from "@/lib/database";
 import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
+
+import { resolveNextRunAtForWorkspaceAutomation } from "./workspace-automation-schedule";
 
 export const workspaceAutomationStatusSchema = z.enum(["active", "paused", "archived"]);
 export const workspaceAutomationRunStatusSchema = z.enum([
@@ -15,6 +17,13 @@ export const workspaceAutomationRunStatusSchema = z.enum([
 ]);
 export const workspaceAutomationRunTriggerSourceSchema = z.enum(["manual", "scheduled", "github"]);
 
+const branchPatternSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(255)
+  .regex(/^[A-Za-z0-9._\-/*?]+$/, "invalid_branch_pattern");
+
 const triggerConfigSchema = z
   .object({
     mode: z.enum(["manual", "scheduled", "github"]).default("manual"),
@@ -26,6 +35,7 @@ const triggerConfigSchema = z
         timezone: z.string().trim().min(1).max(64).default("UTC"),
       })
       .optional(),
+    branches: z.array(branchPatternSchema).min(1).max(32).optional(),
   })
   .default({ mode: "manual" });
 
@@ -46,9 +56,25 @@ const githubToolConfigSchema = z
   })
   .default({ enabled: false, pushSource: false, pullTranslations: false, validation: false });
 
+const slackToolConfigSchema = z
+  .object({
+    enabled: z.boolean().default(false),
+    channelId: z.string().trim().min(1).max(64).optional(),
+  })
+  .default({ enabled: false });
+
+const emailToolConfigSchema = z
+  .object({
+    enabled: z.boolean().default(false),
+    recipients: z.array(z.string().email()).min(1).max(10).optional(),
+  })
+  .default({ enabled: false });
+
 const toolConfigSchema = z
   .object({
     github: githubToolConfigSchema.optional(),
+    slack: slackToolConfigSchema.optional(),
+    email: emailToolConfigSchema.optional(),
   })
   .default({});
 
@@ -65,6 +91,8 @@ export type WorkspaceAutomationRunTriggerSource = z.infer<
 >;
 export type WorkspaceAutomationTriggerConfig = z.infer<typeof triggerConfigSchema>;
 export type WorkspaceAutomationRepositoryTarget = z.infer<typeof repositoryTargetSchema>;
+export type WorkspaceAutomationSlackToolConfig = z.infer<typeof slackToolConfigSchema>;
+export type WorkspaceAutomationEmailToolConfig = z.infer<typeof emailToolConfigSchema>;
 export type WorkspaceAutomationToolConfig = z.infer<typeof toolConfigSchema>;
 
 export type WorkspaceAutomationConfigValidationError =
@@ -72,7 +100,31 @@ export type WorkspaceAutomationConfigValidationError =
       code: "github_repository_target_required";
       message: "Enabled GitHub tools require a GitHub repository target.";
     }
-  | { code: "github_project_required"; message: "Enabled GitHub tools require a project." };
+  | { code: "github_project_required"; message: "Enabled GitHub tools require a project." }
+  | {
+      code: "github_trigger_required";
+      message: "Enabled GitHub tools require a scheduled or GitHub push trigger.";
+    }
+  | {
+      code: "github_push_branches_required";
+      message: "GitHub push triggers require at least one branch pattern.";
+    }
+  | {
+      code: "slack_not_connected";
+      message: "Enable the Slack integration before using Slack notifications.";
+    }
+  | {
+      code: "slack_channel_required";
+      message: "Choose a Slack channel for automation notifications.";
+    }
+  | {
+      code: "email_not_connected";
+      message: "Enable the email agent before using email notifications.";
+    }
+  | {
+      code: "email_recipients_required";
+      message: "Add at least one email recipient for automation notifications.";
+    };
 
 type AutomationRow = typeof schema.workspaceAutomations.$inferSelect;
 type AutomationRunRow = typeof schema.workspaceAutomationRuns.$inferSelect;
@@ -125,29 +177,108 @@ function normalizeToolConfig(value: Record<string, unknown>): WorkspaceAutomatio
 }
 
 function validateWorkspaceAutomationConfig(input: {
+  triggerConfig: WorkspaceAutomationTriggerConfig;
   repositoryTarget: WorkspaceAutomationRepositoryTarget;
   toolConfig: WorkspaceAutomationToolConfig;
 }): Result<void, WorkspaceAutomationConfigValidationError> {
   const githubTools = input.toolConfig.github;
-  if (!githubTools?.enabled) {
-    return ok(undefined);
+  if (githubTools?.enabled) {
+    if (
+      input.repositoryTarget.kind !== "github" ||
+      !input.repositoryTarget.githubInstallationRepositoryId
+    ) {
+      return err({
+        code: "github_repository_target_required",
+        message: "Enabled GitHub tools require a GitHub repository target.",
+      });
+    }
+
+    if (!githubTools.projectId) {
+      return err({
+        code: "github_project_required",
+        message: "Enabled GitHub tools require a project.",
+      });
+    }
+
+    if (input.triggerConfig.mode === "manual") {
+      return err({
+        code: "github_trigger_required",
+        message: "Enabled GitHub tools require a scheduled or GitHub push trigger.",
+      });
+    }
+
+    if (
+      input.triggerConfig.mode === "github" &&
+      (!input.triggerConfig.branches || input.triggerConfig.branches.length === 0)
+    ) {
+      return err({
+        code: "github_push_branches_required",
+        message: "GitHub push triggers require at least one branch pattern.",
+      });
+    }
   }
 
-  if (
-    input.repositoryTarget.kind !== "github" ||
-    !input.repositoryTarget.githubInstallationRepositoryId
-  ) {
+  const slackTools = input.toolConfig.slack;
+  if (slackTools?.enabled && !slackTools.channelId) {
     return err({
-      code: "github_repository_target_required",
-      message: "Enabled GitHub tools require a GitHub repository target.",
+      code: "slack_channel_required",
+      message: "Choose a Slack channel for automation notifications.",
     });
   }
 
-  if (!githubTools.projectId) {
+  const emailTools = input.toolConfig.email;
+  if (emailTools?.enabled && (!emailTools.recipients || emailTools.recipients.length === 0)) {
     return err({
-      code: "github_project_required",
-      message: "Enabled GitHub tools require a project.",
+      code: "email_recipients_required",
+      message: "Add at least one email recipient for automation notifications.",
     });
+  }
+
+  return ok(undefined);
+}
+
+export async function validateWorkspaceAutomationIntegrations(input: {
+  organizationId: string;
+  toolConfig: WorkspaceAutomationToolConfig;
+}): Promise<Result<void, WorkspaceAutomationConfigValidationError>> {
+  if (input.toolConfig.slack?.enabled) {
+    const [connector] = await db
+      .select({ enabled: schema.connectors.enabled })
+      .from(schema.connectors)
+      .where(
+        and(
+          eq(schema.connectors.organizationId, input.organizationId),
+          eq(schema.connectors.kind, "slack"),
+        ),
+      )
+      .limit(1);
+
+    if (!connector?.enabled) {
+      return err({
+        code: "slack_not_connected",
+        message: "Enable the Slack integration before using Slack notifications.",
+      });
+    }
+  }
+
+  if (input.toolConfig.email?.enabled) {
+    const [connector] = await db
+      .select({ enabled: schema.connectors.enabled })
+      .from(schema.connectors)
+      .where(
+        and(
+          eq(schema.connectors.organizationId, input.organizationId),
+          eq(schema.connectors.kind, "email"),
+        ),
+      )
+      .limit(1);
+
+    if (!connector?.enabled) {
+      return err({
+        code: "email_not_connected",
+        message: "Enable the email agent before using email notifications.",
+      });
+    }
   }
 
   return ok(undefined);
@@ -206,10 +337,42 @@ export async function createWorkspaceAutomation(input: {
     repositoryTarget: input.repositoryTarget ?? {},
     toolConfig: input.toolConfig ?? {},
   });
-  const validation = validateWorkspaceAutomationConfig(config);
+  const validation = validateWorkspaceAutomationConfig({
+    triggerConfig: config.triggerConfig,
+    repositoryTarget: config.repositoryTarget,
+    toolConfig: config.toolConfig,
+  });
   if (isErr(validation)) {
     return err(validation.error);
   }
+
+  const integrationValidation = await validateWorkspaceAutomationIntegrations({
+    organizationId: input.organizationId,
+    toolConfig: config.toolConfig,
+  });
+  if (isErr(integrationValidation)) {
+    return err(integrationValidation.error);
+  }
+
+  const draftAutomation: WorkspaceAutomationRecord = {
+    id: crypto.randomUUID(),
+    organizationId: input.organizationId,
+    authorUserId: input.authorUserId ?? null,
+    status: input.status ?? "active",
+    name: input.name,
+    instructions: input.instructions,
+    triggerConfig: config.triggerConfig,
+    repositoryTarget: config.repositoryTarget,
+    toolConfig: config.toolConfig,
+    configVersion: 1,
+    nextRunAt: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+  const resolvedNextRunAt =
+    input.nextRunAt !== undefined
+      ? input.nextRunAt
+      : resolveNextRunAtForWorkspaceAutomation(draftAutomation);
 
   const [row] = await db
     .insert(schema.workspaceAutomations)
@@ -226,7 +389,7 @@ export async function createWorkspaceAutomation(input: {
           : null,
       repositoryTarget: config.repositoryTarget,
       toolConfig: config.toolConfig,
-      nextRunAt: input.nextRunAt ?? null,
+      nextRunAt: resolvedNextRunAt,
     })
     .returning();
 
@@ -266,10 +429,44 @@ export async function updateWorkspaceAutomation(input: {
     repositoryTarget: input.repositoryTarget ?? existing.repositoryTarget,
     toolConfig: input.toolConfig ?? existing.toolConfig,
   });
-  const validation = validateWorkspaceAutomationConfig(config);
+  const validation = validateWorkspaceAutomationConfig({
+    triggerConfig: config.triggerConfig,
+    repositoryTarget: config.repositoryTarget,
+    toolConfig: config.toolConfig,
+  });
   if (isErr(validation)) {
     return err(validation.error);
   }
+
+  const integrationValidation = await validateWorkspaceAutomationIntegrations({
+    organizationId: input.organizationId,
+    toolConfig: config.toolConfig,
+  });
+  if (isErr(integrationValidation)) {
+    return err(integrationValidation.error);
+  }
+
+  const mergedAutomation: WorkspaceAutomationRecord = {
+    ...existing,
+    status: input.status ?? existing.status,
+    name: input.name ?? existing.name,
+    instructions: input.instructions ?? existing.instructions,
+    triggerConfig: config.triggerConfig,
+    repositoryTarget: config.repositoryTarget,
+    toolConfig: config.toolConfig,
+    configVersion: configChanged ? existing.configVersion : existing.configVersion,
+  };
+  const resolvedNextRunAt =
+    input.nextRunAt !== undefined
+      ? input.nextRunAt
+      : configChanged || input.status !== undefined
+        ? resolveNextRunAtForWorkspaceAutomation({
+            ...mergedAutomation,
+            status: input.status ?? existing.status,
+          })
+        : existing.nextRunAt
+          ? new Date(existing.nextRunAt)
+          : null;
 
   const updateConditions = [
     eq(schema.workspaceAutomations.id, input.automationId),
@@ -296,7 +493,9 @@ export async function updateWorkspaceAutomation(input: {
           }
         : {}),
       ...(input.toolConfig !== undefined ? { toolConfig: config.toolConfig } : {}),
-      ...(input.nextRunAt !== undefined ? { nextRunAt: input.nextRunAt } : {}),
+      ...(input.nextRunAt !== undefined || configChanged || input.status !== undefined
+        ? { nextRunAt: resolvedNextRunAt }
+        : {}),
       ...(configChanged
         ? { configVersion: sql`${schema.workspaceAutomations.configVersion} + 1` }
         : {}),
@@ -371,6 +570,81 @@ export async function listWorkspaceAutomations(input: {
     .offset(input.offset ?? 0);
 
   return rows.map(serializeAutomation);
+}
+
+export type DueWorkspaceAutomation = {
+  automation: WorkspaceAutomationRecord;
+  repository: typeof schema.githubInstallationRepositories.$inferSelect;
+};
+
+export async function listDueWorkspaceAutomations(input: {
+  now?: Date;
+  limit?: number;
+}): Promise<DueWorkspaceAutomation[]> {
+  const now = input.now ?? new Date();
+  const limit = input.limit ?? 100;
+
+  const rows = await db
+    .select({
+      automation: schema.workspaceAutomations,
+      repository: schema.githubInstallationRepositories,
+    })
+    .from(schema.workspaceAutomations)
+    .innerJoin(
+      schema.githubInstallationRepositories,
+      eq(
+        schema.workspaceAutomations.githubInstallationRepositoryId,
+        schema.githubInstallationRepositories.id,
+      ),
+    )
+    .where(
+      and(
+        eq(schema.workspaceAutomations.status, "active"),
+        isNotNull(schema.workspaceAutomations.nextRunAt),
+        lte(schema.workspaceAutomations.nextRunAt, now),
+        eq(schema.githubInstallationRepositories.enabled, true),
+        eq(schema.githubInstallationRepositories.archived, false),
+      ),
+    )
+    .orderBy(schema.workspaceAutomations.nextRunAt)
+    .limit(limit);
+
+  return rows.map(({ automation, repository }) => ({
+    automation: serializeAutomation(automation),
+    repository,
+  }));
+}
+
+export async function advanceWorkspaceAutomationNextRun(input: {
+  automationId: string;
+  organizationId: string;
+  completedAt?: Date;
+}) {
+  const automation = await getWorkspaceAutomationById({
+    automationId: input.automationId,
+    organizationId: input.organizationId,
+  });
+  if (!automation) {
+    return;
+  }
+
+  const nextRunAt = resolveNextRunAtForWorkspaceAutomation(
+    automation,
+    input.completedAt ?? new Date(),
+  );
+
+  await db
+    .update(schema.workspaceAutomations)
+    .set({
+      nextRunAt,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(schema.workspaceAutomations.id, input.automationId),
+        eq(schema.workspaceAutomations.organizationId, input.organizationId),
+      ),
+    );
 }
 
 export async function createWorkspaceAutomationRun(input: {

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { db, schema } from "@/lib/database";
 import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
 
+import { hasWorkspaceAutomationGithubWorkflow } from "./workspace-automation-github-mapping";
 import { resolveNextRunAtForWorkspaceAutomation } from "./workspace-automation-schedule";
 
 export const workspaceAutomationStatusSchema = z.enum(["active", "paused", "archived"]);
@@ -108,6 +109,10 @@ export type WorkspaceAutomationConfigValidationError =
   | {
       code: "github_push_branches_required";
       message: "GitHub push triggers require at least one branch pattern.";
+    }
+  | {
+      code: "scheduled_github_workflow_required";
+      message: "Scheduled automations require at least one GitHub workflow.";
     }
   | {
       code: "slack_not_connected";
@@ -216,6 +221,16 @@ function validateWorkspaceAutomationConfig(input: {
         message: "GitHub push triggers require at least one branch pattern.",
       });
     }
+  }
+
+  if (
+    input.triggerConfig.mode === "scheduled" &&
+    !hasWorkspaceAutomationGithubWorkflow(input.toolConfig)
+  ) {
+    return err({
+      code: "scheduled_github_workflow_required",
+      message: "Scheduled automations require at least one GitHub workflow.",
+    });
   }
 
   const slackTools = input.toolConfig.slack;

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
@@ -454,7 +454,7 @@ export async function updateWorkspaceAutomation(input: {
     triggerConfig: config.triggerConfig,
     repositoryTarget: config.repositoryTarget,
     toolConfig: config.toolConfig,
-    configVersion: configChanged ? existing.configVersion : existing.configVersion,
+    configVersion: configChanged ? existing.configVersion + 1 : existing.configVersion,
   };
   const resolvedNextRunAt =
     input.nextRunAt !== undefined

--- a/apps/hyperlocalise-web/src/lib/workflow/queues.ts
+++ b/apps/hyperlocalise-web/src/lib/workflow/queues.ts
@@ -1,0 +1,18 @@
+import { start } from "workflow/api";
+
+import type { TranslationJobEventData, JobQueue } from "@/lib/workflow/types";
+
+export function createTranslationJobEventQueue(): JobQueue<TranslationJobEventData> {
+  return {
+    async enqueue(event) {
+      const { fileTranslationJobWorkflow } = await import("@/workflows/file-translation-job");
+      const { translationJobWorkflow } = await import("@/workflows/translation-job");
+      const workflow = event.type === "file" ? fileTranslationJobWorkflow : translationJobWorkflow;
+      const run = await start(workflow, [event]);
+
+      return {
+        ids: [run.runId],
+      };
+    },
+  };
+}

--- a/apps/hyperlocalise-web/src/workflows/adapters.ts
+++ b/apps/hyperlocalise-web/src/workflows/adapters.ts
@@ -1,17 +1,15 @@
 import { start } from "workflow/api";
 
 import { emailTranslationWorkflow } from "./email-translation";
-import { fileTranslationJobWorkflow } from "./file-translation-job";
 import { githubFixWorkflow } from "./github-fix";
+import { githubRepositoryAutomationWorkflow } from "./github-repository-automation";
+import { i18nSetupWorkflow } from "./i18n-setup";
 import { providerAgentCommentWorkflow } from "./provider-agent-comment";
 import { providerAgentQaWorkflow } from "./provider-agent-qa";
 import { providerAgentTranslationWorkflow } from "./provider-agent-translation";
 import { providerAgentWritebackWorkflow } from "./provider-agent-writeback";
 import { providerWebhookReconciliationWorkflow } from "./provider-webhook-reconciliation";
-import { i18nSetupWorkflow } from "./i18n-setup";
 import { repositoryAgentWorkflow } from "./repository-agent";
-import { githubRepositoryAutomationWorkflow } from "./github-repository-automation";
-import { translationJobWorkflow } from "./translation-job";
 import type {
   EmailAgentTaskQueue,
   GitHubFixQueue,
@@ -23,21 +21,9 @@ import type {
   ProviderWebhookReconciliationQueue,
   I18nSetupQueue,
   RepositoryAgentTaskQueue,
-  TranslationJobEventData,
 } from "@/lib/workflow/types";
 
-export function createTranslationJobEventQueue(): JobQueue<TranslationJobEventData> {
-  return {
-    async enqueue(event) {
-      const workflow = event.type === "file" ? fileTranslationJobWorkflow : translationJobWorkflow;
-      const run = await start(workflow, [event]);
-
-      return {
-        ids: [run.runId],
-      };
-    },
-  };
-}
+export { createTranslationJobEventQueue } from "@/lib/workflow/queues";
 
 export function createGitHubFixQueue(): GitHubFixQueue {
   return {

--- a/apps/hyperlocalise-web/src/workflows/github-repository-automation.ts
+++ b/apps/hyperlocalise-web/src/workflows/github-repository-automation.ts
@@ -18,9 +18,6 @@ import {
   createGithubRepositoryAutomationCheckRun,
   resolveGithubAutomationCheckConclusion as resolveGithubAutomationCheckConclusionFromMode,
 } from "@/lib/agents/github/github-repository-automation-check-run";
-import { runGithubRepositoryAutomationPullTranslations } from "@/lib/agents/github/github-repository-automation-pull-translations";
-import { runGithubRepositoryAutomationPushSource } from "@/lib/agents/github/github-repository-automation-push-source";
-import { runGithubRepositoryAutomationValidation } from "@/lib/agents/github/github-repository-automation-validation";
 
 async function loadJobStep(jobId: string) {
   "use step";
@@ -159,6 +156,13 @@ async function completeGithubAutomationCheckRunForJob(input: {
 
 async function runAutomationJobStep(input: { jobId: string; workflowRunId: string }) {
   "use step";
+
+  const { runGithubRepositoryAutomationPullTranslations } =
+    await import("@/lib/agents/github/github-repository-automation-pull-translations");
+  const { runGithubRepositoryAutomationPushSource } =
+    await import("@/lib/agents/github/github-repository-automation-push-source");
+  const { runGithubRepositoryAutomationValidation } =
+    await import("@/lib/agents/github/github-repository-automation-validation");
 
   let job = await getGithubRepositoryAutomationJobById(input.jobId);
   if (!job) {

--- a/apps/hyperlocalise-web/src/workflows/repository-agent.ts
+++ b/apps/hyperlocalise-web/src/workflows/repository-agent.ts
@@ -6,10 +6,6 @@ import type {
   RepositoryAgentTask,
 } from "@/lib/agents/repository-agent-task";
 import {
-  createRepositorySandbox as createRepositorySandboxImpl,
-  stopRepositorySandbox as stopRepositorySandboxImpl,
-} from "@/lib/agent-runtime/workspaces/repository-sandbox";
-import {
   buildHyperlocaliseAgentInstructions,
   getHyperlocaliseAgentModel,
 } from "@/lib/agent-runtime/loops/hyperlocalise-agent";
@@ -41,12 +37,16 @@ async function createRepositorySandboxStep(
   githubContext: ResolvedRepositoryGitHubContext,
 ): Promise<string> {
   "use step";
-  return createRepositorySandboxImpl(githubContext);
+  const { createRepositorySandbox } =
+    await import("@/lib/agent-runtime/workspaces/repository-sandbox");
+  return createRepositorySandbox(githubContext);
 }
 
 async function stopRepositorySandboxStep(sandboxId: string): Promise<void> {
   "use step";
-  return stopRepositorySandboxImpl(sandboxId);
+  const { stopRepositorySandbox } =
+    await import("@/lib/agent-runtime/workspaces/repository-sandbox");
+  return stopRepositorySandbox(sandboxId);
 }
 
 export async function repositoryAgentWorkflow(

--- a/apps/hyperlocalise-web/src/workflows/steps/workspace-automation-run-sync.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/workspace-automation-run-sync.ts
@@ -1,0 +1,16 @@
+import type { GithubRepositoryAutomationJobStatus } from "@/lib/agents/github/github-repository-automation-jobs";
+
+export async function syncWorkspaceAutomationRunsForGithubJobStep(input: {
+  jobId: string;
+  status: GithubRepositoryAutomationJobStatus;
+  resultSummary?: Record<string, unknown> | null;
+  lastError?: string | null;
+  skipReason?: string | null;
+  completedAt?: Date | null;
+}): Promise<void> {
+  "use step";
+
+  const { syncWorkspaceAutomationRunsForGithubJob } =
+    await import("@/lib/agents/workspace-automation-run-sync");
+  await syncWorkspaceAutomationRunsForGithubJob(input);
+}


### PR DESCRIPTION
## What changed

- Add workspace **Automations** navigation and list page with Mine/Team filtering, summary stats, and template cards that prefill the create form.
- Add **New automation** and **detail** pages for configuring triggers, GitHub workflows, Slack/email notifications, and viewing run history.
- Extend workspace automation config validation for GitHub push branches and notification integrations.
- Wire scheduled/GitHub push dispatch into the existing repository automation job path, sync workspace runs from job status, and send terminal Slack/email notifications.

Closes HL-462. Also covers HL-460 and HL-461 backend/UI integration for this slice.

## How to test

- Run `vp check --fix` and `vp test` in `apps/hyperlocalise-web`.
- Open `/org/{slug}/automations`, create an automation from a template, and confirm the form is prefilled.
- Edit an automation on the detail page, save changes, and verify run history renders.
- With GitHub/Slack/email integrations configured, enable matching tools and confirm validation errors when integrations are missing.
- Apply migration `0038` locally (`vp run db:migrate`) before exercising run creation/dispatch tests.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)