### PR TITLE
feat(web): expand automation templates gallery and editor

### DIFF
--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/automations/_components/automation-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/automations/_components/automation-detail-page-content.tsx
@@ -2,23 +2,19 @@
 
 import Link from "next/link";
 import { useEffect, useState } from "react";
-import { SparklesIcon } from "@hugeicons/core-free-icons";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { apiClient } from "@/lib/api-client-instance";
-import type { WorkspaceAutomationRunRecord } from "@/lib/agents/workspace-automations";
 import {
   createWorkspaceAutomationFormStateFromRecord,
   formStateToWorkspaceAutomationPayload,
   mapWorkspaceAutomationApiErrorToFieldErrors,
   validateWorkspaceAutomationFormState,
 } from "@/lib/agents/workspace-automation-view-model";
-import { PageHeader, WorkspacePageShell } from "../../_components/workspace-resource-shared";
-import { WorkspaceAutomationForm } from "./workspace-automation-form";
+import { WorkspacePageShell } from "../../_components/workspace-resource-shared";
+import { WorkspaceAutomationEditor } from "./workspace-automation-form";
 
 export function AutomationDetailPageContent({
   organizationSlug,
@@ -28,7 +24,6 @@ export function AutomationDetailPageContent({
   automationId: string;
 }) {
   const queryClient = useQueryClient();
-  const [activeTab, setActiveTab] = useState<"settings" | "history">("settings");
 
   const automationQuery = useQuery({
     queryKey: ["workspace-automation", organizationSlug, automationId],
@@ -142,12 +137,14 @@ export function AutomationDetailPageContent({
   }
 
   return (
-    <WorkspacePageShell>
-      <PageHeader
-        icon={SparklesIcon}
-        title={automation.name}
-        description="Configure deterministic workflows, notifications, and inspect run history."
-        statusLabel={automation.status}
+    <WorkspacePageShell className="max-w-5xl">
+      <WorkspaceAutomationEditor
+        mode="detail"
+        organizationSlug={organizationSlug}
+        form={form}
+        errors={errors}
+        onChange={setForm}
+        runHistory={recentRuns}
         actions={
           <div className="flex gap-2">
             <Button
@@ -164,61 +161,11 @@ export function AutomationDetailPageContent({
         }
       />
 
-      <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as typeof activeTab)}>
-        <TabsList>
-          <TabsTrigger value="settings">Settings</TabsTrigger>
-          <TabsTrigger value="history">Run history</TabsTrigger>
-        </TabsList>
-        <TabsContent value="settings" className="mt-6">
-          <WorkspaceAutomationForm
-            organizationSlug={organizationSlug}
-            form={form}
-            errors={errors}
-            onChange={setForm}
-          />
-        </TabsContent>
-        <TabsContent value="history" className="mt-6">
-          <RunHistoryTable runs={recentRuns} />
-        </TabsContent>
-      </Tabs>
-
       <div className="pt-4">
         <Button variant="outline" render={<Link href={`/org/${organizationSlug}/automations`} />}>
           Back to automations
         </Button>
       </div>
     </WorkspacePageShell>
-  );
-}
-
-function RunHistoryTable({ runs }: { runs: WorkspaceAutomationRunRecord[] }) {
-  if (runs.length === 0) {
-    return <p className="text-sm text-muted-foreground">No runs yet.</p>;
-  }
-
-  return (
-    <div className="overflow-hidden rounded-xl border border-foreground/10">
-      <div className="grid grid-cols-[minmax(0,0.8fr)_minmax(0,0.8fr)_minmax(0,1fr)_minmax(0,0.8fr)] gap-4 border-b border-foreground/10 px-4 py-3 text-xs font-medium text-muted-foreground">
-        <span>Status</span>
-        <span>Trigger</span>
-        <span>Summary</span>
-        <span>Completed</span>
-      </div>
-      {runs.map((run) => (
-        <div
-          key={run.id}
-          className="grid grid-cols-[minmax(0,0.8fr)_minmax(0,0.8fr)_minmax(0,1fr)_minmax(0,0.8fr)] gap-4 border-b border-foreground/10 px-4 py-4 text-sm last:border-b-0"
-        >
-          <Badge variant="outline">{run.status}</Badge>
-          <span>{run.triggerSource}</span>
-          <span className="truncate text-muted-foreground">
-            {Object.keys(run.outputSummary).length > 0 ? JSON.stringify(run.outputSummary) : "—"}
-          </span>
-          <span className="text-muted-foreground">
-            {run.completedAt ? new Date(run.completedAt).toLocaleString() : "—"}
-          </span>
-        </div>
-      ))}
-    </div>
   );
 }

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/automations/_components/automation-template-flow.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/automations/_components/automation-template-flow.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { SlackIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { ClockIcon, MailIcon } from "lucide-react";
+import { siGithub } from "simple-icons";
+
+import {
+  getWorkspaceAutomationTemplateFlow,
+  type WorkspaceAutomationTemplate,
+  type WorkspaceAutomationTemplateFlowNode,
+} from "@/lib/agents/workspace-automation-templates";
+import { cn } from "@/lib/primitives/cn";
+import { SimpleBrandIcon } from "../../integrations/_components/simple-brand-icon";
+
+type IconBucket = "schedule" | "github" | "slack" | "email";
+
+function iconBucketForNode(node: WorkspaceAutomationTemplateFlowNode): IconBucket {
+  switch (node.id) {
+    case "github-push":
+    case "github":
+    case "push-source":
+    case "pull-translations":
+    case "validation":
+      return "github";
+    case "slack":
+      return "slack";
+    case "email":
+      return "email";
+    case "scheduled":
+    case "manual":
+    default:
+      return "schedule";
+  }
+}
+
+function FlowIcon({ bucket }: { bucket: IconBucket }) {
+  switch (bucket) {
+    case "github":
+      return <SimpleBrandIcon icon={siGithub} colored className="size-4" />;
+    case "slack":
+      return <HugeiconsIcon icon={SlackIcon} strokeWidth={1.8} className="size-4" />;
+    case "email":
+      return <MailIcon className="size-4" />;
+    case "schedule":
+      return <ClockIcon className="size-4" strokeWidth={1.8} />;
+  }
+}
+
+function uniqueToolBuckets(
+  trigger: WorkspaceAutomationTemplateFlowNode,
+  tools: WorkspaceAutomationTemplateFlowNode[],
+) {
+  const triggerBucket = iconBucketForNode(trigger);
+  const buckets: IconBucket[] = [];
+
+  for (const tool of tools) {
+    const bucket = iconBucketForNode(tool);
+    if (bucket === triggerBucket || buckets.includes(bucket)) {
+      continue;
+    }
+    buckets.push(bucket);
+  }
+
+  return buckets;
+}
+
+export function AutomationTemplateFlow({
+  className,
+  template,
+}: {
+  className?: string;
+  template: WorkspaceAutomationTemplate;
+}) {
+  const flow = getWorkspaceAutomationTemplateFlow(template);
+  const triggerBucket = iconBucketForNode(flow.trigger);
+  const toolBuckets = uniqueToolBuckets(flow.trigger, flow.tools);
+  const summary = [flow.trigger.label, ...flow.tools.map((tool) => tool.label)].join(" → ");
+
+  return (
+    <div
+      className={cn("flex items-center gap-2 text-muted-foreground", className)}
+      title={summary}
+      aria-label={summary}
+    >
+      <FlowIcon bucket={triggerBucket} />
+      {toolBuckets.length > 0 ? (
+        <>
+          <span className="h-px w-3 shrink-0 bg-foreground/25" aria-hidden />
+          {toolBuckets.map((bucket) => (
+            <FlowIcon key={bucket} bucket={bucket} />
+          ))}
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/automations/_components/automations-new-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/automations/_components/automations-new-page-content.tsx
@@ -3,12 +3,10 @@
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
-import { SparklesIcon } from "@hugeicons/core-free-icons";
 import { useMutation } from "@tanstack/react-query";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
-import { TypographyH1, TypographyP } from "@/components/ui/typography";
 import { apiClient } from "@/lib/api-client-instance";
 import {
   createDefaultWorkspaceAutomationFormState,
@@ -17,8 +15,8 @@ import {
   mapWorkspaceAutomationApiErrorToFieldErrors,
   validateWorkspaceAutomationFormState,
 } from "@/lib/agents/workspace-automation-view-model";
-import { PageHeader, WorkspacePageShell } from "../../_components/workspace-resource-shared";
-import { WorkspaceAutomationForm } from "./workspace-automation-form";
+import { WorkspacePageShell } from "../../_components/workspace-resource-shared";
+import { WorkspaceAutomationEditor } from "./workspace-automation-form";
 
 export function AutomationsNewPageContent({
   organizationSlug,
@@ -81,36 +79,27 @@ export function AutomationsNewPageContent({
   });
 
   return (
-    <WorkspacePageShell>
-      <PageHeader
-        icon={SparklesIcon}
-        title="New automation"
-        description="Configure triggers, deterministic GitHub workflows, and terminal notifications."
-      />
-      <div className="mb-4">
-        <TypographyH1 className="text-2xl">Create automation</TypographyH1>
-        <TypographyP className="text-muted-foreground">
-          {templateId
-            ? "Template defaults are prefilled below. Review repository, project, and notification settings before saving."
-            : "Start from scratch or return to the templates gallery."}
-        </TypographyP>
-      </div>
-
-      <WorkspaceAutomationForm
+    <WorkspacePageShell className="max-w-5xl">
+      <WorkspaceAutomationEditor
+        mode="create"
         organizationSlug={organizationSlug}
         form={form}
         errors={errors}
         onChange={setForm}
+        actions={
+          <>
+            <Button
+              variant="outline"
+              render={<Link href={`/org/${organizationSlug}/automations`} />}
+            >
+              Cancel
+            </Button>
+            <Button onClick={() => createMutation.mutate()} disabled={createMutation.isPending}>
+              {createMutation.isPending ? "Creating..." : "Create automation"}
+            </Button>
+          </>
+        }
       />
-
-      <div className="flex items-center justify-end gap-3 border-t border-foreground/10 pt-6">
-        <Button variant="outline" render={<Link href={`/org/${organizationSlug}/automations`} />}>
-          Cancel
-        </Button>
-        <Button onClick={() => createMutation.mutate()} disabled={createMutation.isPending}>
-          {createMutation.isPending ? "Creating..." : "Create automation"}
-        </Button>
-      </div>
     </WorkspacePageShell>
   );
 }

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-content.tsx
@@ -8,16 +8,18 @@ import { useQuery } from "@tanstack/react-query";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { TypographyH1, TypographyP } from "@/components/ui/typography";
+import { TypographyP } from "@/components/ui/typography";
 import { apiClient } from "@/lib/api-client-instance";
 import {
   WORKSPACE_AUTOMATION_TEMPLATE_CATEGORIES,
+  getWorkspaceAutomationTemplateCategoryLabel,
   listWorkspaceAutomationTemplates,
 } from "@/lib/agents/workspace-automation-templates";
 import type { WorkspaceAutomationRecord } from "@/lib/agents/workspace-automations";
 import { PageHeader, WorkspacePageShell } from "../../_components/workspace-resource-shared";
+import { AutomationTemplateFlow } from "./automation-template-flow";
 
 function formatRelativeTimestamp(value: string) {
   const date = new Date(value);
@@ -62,9 +64,6 @@ export function AutomationsPageContent({
   currentUserId: string;
 }) {
   const [scope, setScope] = useState<"mine" | "team">("mine");
-  const [templateCategory, setTemplateCategory] = useState(
-    WORKSPACE_AUTOMATION_TEMPLATE_CATEGORIES[0]?.id ?? "popular",
-  );
 
   const automationsQuery = useQuery({
     queryKey: ["workspace-automations", organizationSlug],
@@ -101,7 +100,19 @@ export function AutomationsPageContent({
     };
   }, [visibleAutomations]);
 
-  const templates = listWorkspaceAutomationTemplates(templateCategory);
+  const templates = useMemo(() => {
+    const categoryOrder = WORKSPACE_AUTOMATION_TEMPLATE_CATEGORIES.map((category) => category.id);
+
+    return listWorkspaceAutomationTemplates().toSorted((left, right) => {
+      const leftIndex = categoryOrder.indexOf(left.category);
+      const rightIndex = categoryOrder.indexOf(right.category);
+      if (leftIndex !== rightIndex) {
+        return leftIndex - rightIndex;
+      }
+
+      return left.name.localeCompare(right.name);
+    });
+  }, []);
 
   return (
     <WorkspacePageShell>
@@ -192,41 +203,32 @@ export function AutomationsPageContent({
 
       <section className="flex flex-col gap-4">
         <div>
-          <TypographyH1 className="text-xl">Templates</TypographyH1>
+          <h2 className="font-sans text-base font-medium text-balance text-foreground">
+            Templates
+          </h2>
           <TypographyP className="text-muted-foreground">
             Start from a curated workflow. Templates prefill the creation form with instructions,
             triggers, and tools.
           </TypographyP>
         </div>
-        <Tabs
-          value={templateCategory}
-          onValueChange={(value) => setTemplateCategory(value as typeof templateCategory)}
-        >
-          <TabsList className="flex h-auto flex-wrap justify-start gap-2 bg-transparent p-0">
-            {WORKSPACE_AUTOMATION_TEMPLATE_CATEGORIES.map((category) => (
-              <TabsTrigger key={category.id} value={category.id} className="rounded-full">
-                {category.label}
-              </TabsTrigger>
-            ))}
-          </TabsList>
-        </Tabs>
-        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
           {templates.map((template) => (
-            <Card key={template.id} className="flex flex-col">
-              <CardHeader>
-                <CardTitle className="text-base">{template.name}</CardTitle>
-                <CardDescription>{template.description}</CardDescription>
-              </CardHeader>
-              <CardContent className="mt-auto flex items-center justify-between gap-3">
-                {!template.activatable ? (
-                  <Badge variant="secondary">Coming soon</Badge>
-                ) : (
-                  <span className="text-xs text-muted-foreground">Deterministic V1</span>
-                )}
+            <Card key={template.id} size="sm" className="gap-4 px-5 py-5">
+              <div className="flex items-start justify-between gap-2">
+                <AutomationTemplateFlow template={template} />
+                <Badge variant="outline" className="shrink-0 rounded-full text-[10px]">
+                  {getWorkspaceAutomationTemplateCategoryLabel(template.category)}
+                </Badge>
+              </div>
+              <div className="space-y-1.5">
+                <h3 className="text-sm font-medium text-foreground">{template.name}</h3>
+                <p className="text-sm text-pretty text-muted-foreground">{template.description}</p>
+              </div>
+              <div className="mt-auto flex items-center gap-2">
                 {template.activatable ? (
                   <Button
                     size="sm"
-                    variant="outline"
+                    className="rounded-full"
                     render={
                       <Link
                         href={`/org/${organizationSlug}/automations/new?template=${template.id}`}
@@ -236,11 +238,11 @@ export function AutomationsPageContent({
                     Add
                   </Button>
                 ) : (
-                  <Button size="sm" variant="outline" disabled>
-                    Add
+                  <Button size="sm" variant="outline" className="rounded-full" disabled>
+                    Coming soon
                   </Button>
                 )}
-              </CardContent>
+              </div>
             </Card>
           ))}
         </div>

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/automations/_components/workspace-automation-form.tsx
@@ -1,11 +1,30 @@
 "use client";
 
 import Link from "next/link";
-import { useMemo, useState } from "react";
+import { useMemo, useState, type ReactNode } from "react";
+import {
+  Add01Icon,
+  ArrowDown01Icon,
+  FolderLibraryIcon,
+  GitBranchIcon,
+  SlackIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { useQuery } from "@tanstack/react-query";
+import { ClockIcon, MailIcon, Trash2Icon } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -15,7 +34,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import { createApiClient } from "@/lib/api-client";
 import {
@@ -24,6 +45,8 @@ import {
 } from "@/app/(authenticated)/org/[organizationSlug]/integrations/_components/github-repository-automation-view-model";
 import type { WorkspaceAutomationFormState } from "@/lib/agents/workspace-automation-view-model";
 import { workspaceAutomationFormCanActivate } from "@/lib/agents/workspace-automation-view-model";
+import type { WorkspaceAutomationRunRecord } from "@/lib/agents/workspace-automations";
+import { cn } from "@/lib/primitives/cn";
 
 const api = createApiClient();
 
@@ -36,6 +59,8 @@ type GithubRepositoryOption = {
   defaultBranch: string | null;
 };
 
+type AutomationEditorTab = "settings" | "history";
+
 function FieldError({ message }: { message?: string }) {
   if (!message) {
     return null;
@@ -44,20 +69,960 @@ function FieldError({ message }: { message?: string }) {
   return <p className="text-xs text-destructive">{message}</p>;
 }
 
-export function WorkspaceAutomationForm({
-  organizationSlug,
-  form,
-  errors,
+function EditorSection({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section className="flex flex-col gap-2">
+      <h2 className="px-2 text-xs font-medium text-muted-foreground">{title}</h2>
+      {children}
+    </section>
+  );
+}
+
+function EditorPanel({ children, className }: { children: ReactNode; className?: string }) {
+  return (
+    <div
+      className={cn(
+        "overflow-hidden rounded-xl border border-foreground/10 bg-foreground/2.5",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+function EditorRow({
+  icon,
+  title,
+  description,
+  children,
+  action,
+  className,
+}: {
+  icon: ReactNode;
+  title: ReactNode;
+  description?: ReactNode;
+  children?: ReactNode;
+  action?: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex min-h-12 flex-col gap-3 border-b border-foreground/8 px-3 py-3 last:border-b-0 md:flex-row md:items-center",
+        className,
+      )}
+    >
+      <div className="flex min-w-0 flex-1 items-start gap-3 md:items-center">
+        <span className="mt-0.5 flex size-5 shrink-0 items-center justify-center text-muted-foreground md:mt-0">
+          {icon}
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 flex-wrap items-center gap-2 text-sm text-foreground">
+            {title}
+          </div>
+          {description ? (
+            <div className="mt-1 text-xs text-pretty text-muted-foreground">{description}</div>
+          ) : null}
+        </div>
+      </div>
+      {children ? <div className="min-w-0 md:max-w-xl md:flex-1">{children}</div> : null}
+      {action ? <div className="flex shrink-0 items-center justify-end gap-2">{action}</div> : null}
+    </div>
+  );
+}
+
+function DeleteToolButton({
   disabled,
+  label,
+  onClick,
+}: {
+  disabled?: boolean;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon-sm"
+      aria-label={label}
+      disabled={disabled}
+      onClick={onClick}
+      className="size-8 rounded-lg text-muted-foreground hover:text-foreground"
+    >
+      <Trash2Icon className="size-4" />
+    </Button>
+  );
+}
+
+function formatHour(hourUtc: number) {
+  return `${String(hourUtc).padStart(2, "0")}:00`;
+}
+
+function triggerSummary(
+  form: WorkspaceAutomationFormState,
+  repositories: GithubRepositoryOption[] = [],
+) {
+  if (form.triggerMode === "scheduled") {
+    if (form.scheduledCadence === "hourly") {
+      return `Every hour · ${form.scheduledTimezone}`;
+    }
+
+    if (form.scheduledCadence === "weekly") {
+      const weekday =
+        AUTOMATION_WEEKDAY_OPTIONS.find((option) => option.value === form.scheduledDayOfWeek)
+          ?.label ?? "Monday";
+      return `Every ${weekday} at ${formatHour(form.scheduledHourUtc)} · ${form.scheduledTimezone}`;
+    }
+
+    return `Every day at ${formatHour(form.scheduledHourUtc)} · ${form.scheduledTimezone}`;
+  }
+
+  if (form.triggerMode === "github") {
+    const repository = repositories.find(
+      (entry) => entry.id === form.githubInstallationRepositoryId,
+    );
+    const repositoryLabel = repository?.fullName ?? "repository required";
+    const branchLabel = form.pushBranches.join(", ") || "branches required";
+    return `GitHub push · ${repositoryLabel} · ${branchLabel}`;
+  }
+
+  return "";
+}
+
+function toolCount(form: WorkspaceAutomationFormState) {
+  return Number(form.githubEnabled) + Number(form.slackEnabled) + Number(form.emailEnabled);
+}
+
+function HeaderProjectSelector({
+  disabled,
+  form,
+  isError,
+  isLoading,
+  onChange,
+  projects,
+}: {
+  disabled?: boolean;
+  form: WorkspaceAutomationFormState;
+  isError: boolean;
+  isLoading: boolean;
+  onChange: (next: WorkspaceAutomationFormState) => void;
+  projects: ProjectOption[];
+}) {
+  const selectedProject = projects.find((project) => project.id === form.githubProjectId);
+  const triggerLabel =
+    selectedProject?.name ?? (form.githubProjectId ? "Unknown project" : "Select project");
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        disabled={disabled || isLoading}
+        render={
+          <Button
+            type="button"
+            variant="ghost"
+            className="h-auto gap-1 px-0 py-0 text-sm font-normal text-muted-foreground hover:bg-transparent hover:text-foreground disabled:opacity-50"
+          />
+        }
+      >
+        <HugeiconsIcon icon={FolderLibraryIcon} strokeWidth={1.8} className="size-4" />
+        {isLoading ? (
+          <Skeleton className="h-3.5 w-20 rounded-full bg-muted-foreground/20" />
+        ) : (
+          triggerLabel
+        )}
+        <HugeiconsIcon icon={ArrowDown01Icon} strokeWidth={1.8} className="size-3.5" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="min-w-56" align="start">
+        <DropdownMenuGroup>
+          <DropdownMenuLabel>Projects</DropdownMenuLabel>
+          {isError ? <DropdownMenuItem disabled>Unable to load projects</DropdownMenuItem> : null}
+          {!isLoading && projects.length === 0 ? (
+            <DropdownMenuItem disabled>No projects found</DropdownMenuItem>
+          ) : null}
+          {projects.map((project) => (
+            <DropdownMenuItem
+              key={project.id}
+              onClick={() => onChange({ ...form, githubProjectId: project.id })}
+            >
+              <HugeiconsIcon icon={FolderLibraryIcon} strokeWidth={1.8} className="size-4" />
+              {project.name}
+              {form.githubProjectId === project.id ? (
+                <DropdownMenuShortcut>Selected</DropdownMenuShortcut>
+              ) : null}
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function formatBranchPatternLabel(branches: string[]) {
+  if (branches.length === 0) {
+    return "Branches";
+  }
+
+  if (branches.length === 1) {
+    return branches[0]!;
+  }
+
+  if (branches.length === 2) {
+    return branches.join(", ");
+  }
+
+  return `${branches[0]!} +${branches.length - 1}`;
+}
+
+function BranchPatternSelector({
+  branches,
+  disabled,
+  error,
   onChange,
 }: {
-  organizationSlug: string;
-  form: WorkspaceAutomationFormState;
-  errors: Record<string, string | undefined>;
+  branches: string[];
   disabled?: boolean;
-  onChange: (next: WorkspaceAutomationFormState) => void;
+  error?: string;
+  onChange: (branches: string[]) => void;
 }) {
   const [branchInput, setBranchInput] = useState("");
+  const [inputError, setInputError] = useState<string | undefined>();
+
+  function handleAdd() {
+    const result = addBranchPattern(branches, branchInput);
+    if (result.error) {
+      setInputError(result.error);
+      return;
+    }
+
+    onChange(result.branches);
+    setBranchInput("");
+    setInputError(undefined);
+  }
+
+  return (
+    <div className="min-w-0 md:min-w-36 md:max-w-xs md:flex-1">
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          disabled={disabled}
+          render={
+            <Button
+              type="button"
+              variant="outline"
+              className="h-8 w-full justify-between gap-2 rounded-lg border border-input bg-input/30 px-3 text-sm font-normal text-foreground hover:bg-input/50 disabled:opacity-50"
+            />
+          }
+        >
+          <span className="truncate">{formatBranchPatternLabel(branches)}</span>
+          <HugeiconsIcon
+            icon={ArrowDown01Icon}
+            strokeWidth={1.8}
+            className="size-3.5 shrink-0 opacity-60"
+          />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent className="min-w-56" align="start">
+          <DropdownMenuGroup>
+            <DropdownMenuLabel>Branch patterns</DropdownMenuLabel>
+            {branches.length === 0 ? (
+              <DropdownMenuItem disabled>No branches added</DropdownMenuItem>
+            ) : (
+              branches.map((branch) => (
+                <DropdownMenuItem
+                  key={branch}
+                  onClick={() => onChange(branches.filter((value) => value !== branch))}
+                >
+                  <span className="min-w-0 flex-1 truncate">{branch}</span>
+                  <DropdownMenuShortcut>Remove</DropdownMenuShortcut>
+                </DropdownMenuItem>
+              ))
+            )}
+          </DropdownMenuGroup>
+          <DropdownMenuSeparator />
+          <div
+            className="flex gap-2 p-2"
+            onPointerDown={(event) => event.stopPropagation()}
+            onClick={(event) => event.stopPropagation()}
+          >
+            <Input
+              aria-label="Branch pattern"
+              value={branchInput}
+              disabled={disabled}
+              placeholder="main"
+              className="h-8 min-w-0 flex-1 rounded-lg"
+              onChange={(event) => {
+                setBranchInput(event.target.value);
+                setInputError(undefined);
+              }}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  event.preventDefault();
+                  handleAdd();
+                }
+              }}
+            />
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              disabled={disabled}
+              className="h-8 shrink-0"
+              onClick={handleAdd}
+            >
+              Add
+            </Button>
+          </div>
+          {inputError ? <p className="px-2 pb-2 text-xs text-destructive">{inputError}</p> : null}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <FieldError message={error} />
+    </div>
+  );
+}
+
+function AddTriggerMenu({
+  disabled,
+  form,
+  githubConnected,
+  onChange,
+  repositories,
+}: {
+  disabled?: boolean;
+  form: WorkspaceAutomationFormState;
+  githubConnected: boolean;
+  onChange: (next: WorkspaceAutomationFormState) => void;
+  repositories: GithubRepositoryOption[];
+}) {
+  return (
+    <div className="w-full">
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          className="w-full"
+          render={
+            <Button
+              type="button"
+              variant="ghost"
+              disabled={disabled}
+              className="flex h-10 w-full shrink justify-start rounded-none px-3 text-muted-foreground hover:bg-foreground/5 hover:text-foreground"
+            />
+          }
+        >
+          <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} className="size-4" />
+          Add Trigger
+        </DropdownMenuTrigger>
+        <DropdownMenuContent className="w-72" align="start" sideOffset={2}>
+          <DropdownMenuGroup>
+            <DropdownMenuLabel>Supported triggers</DropdownMenuLabel>
+            <DropdownMenuItem
+              disabled={form.triggerMode === "manual"}
+              onClick={() => onChange({ ...form, triggerMode: "manual" })}
+            >
+              <ClockIcon className="size-4" />
+              Manual run
+              {form.triggerMode === "manual" ? (
+                <DropdownMenuShortcut>Added</DropdownMenuShortcut>
+              ) : null}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              disabled={form.triggerMode === "scheduled"}
+              onClick={() => onChange({ ...form, triggerMode: "scheduled" })}
+            >
+              <ClockIcon className="size-4" />
+              Scheduled
+              {form.triggerMode === "scheduled" ? (
+                <DropdownMenuShortcut>Added</DropdownMenuShortcut>
+              ) : null}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              disabled={form.triggerMode === "github" || !githubConnected}
+              onClick={() => {
+                const defaultRepositoryId =
+                  form.githubInstallationRepositoryId ||
+                  repositories.find((repository) => repository.enabled)?.id ||
+                  repositories[0]?.id ||
+                  "";
+
+                onChange({
+                  ...form,
+                  triggerMode: "github",
+                  githubEnabled: true,
+                  repositoryTargetKind: "github",
+                  githubInstallationRepositoryId: defaultRepositoryId,
+                  validationEnabled:
+                    form.pushSourceEnabled || form.pullTranslationsEnabled
+                      ? form.validationEnabled
+                      : true,
+                });
+              }}
+            >
+              <HugeiconsIcon icon={GitBranchIcon} strokeWidth={1.8} className="size-4" />
+              GitHub push
+              {form.triggerMode === "github" ? (
+                <DropdownMenuShortcut>Added</DropdownMenuShortcut>
+              ) : !githubConnected ? (
+                <DropdownMenuShortcut>Connect first</DropdownMenuShortcut>
+              ) : null}
+            </DropdownMenuItem>
+          </DropdownMenuGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
+
+function TriggerSettings({
+  disabled,
+  errors,
+  form,
+  githubConnected,
+  onChange,
+  repositories,
+}: {
+  disabled?: boolean;
+  errors: Record<string, string | undefined>;
+  form: WorkspaceAutomationFormState;
+  githubConnected: boolean;
+  onChange: (next: WorkspaceAutomationFormState) => void;
+  repositories: GithubRepositoryOption[];
+}) {
+  return (
+    <EditorSection title="Triggers">
+      <EditorPanel>
+        {form.triggerMode === "scheduled" ? (
+          <EditorRow
+            icon={<ClockIcon className="size-4" />}
+            title={
+              <>
+                <span>Every</span>
+                <Select
+                  value={form.scheduledCadence}
+                  onValueChange={(value) =>
+                    onChange({
+                      ...form,
+                      scheduledCadence: value as typeof form.scheduledCadence,
+                    })
+                  }
+                  disabled={disabled}
+                >
+                  <SelectTrigger size="sm" className="h-8 min-w-28">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="hourly">Hour</SelectItem>
+                    <SelectItem value="daily">Day</SelectItem>
+                    <SelectItem value="weekly">Week</SelectItem>
+                  </SelectContent>
+                </Select>
+                {form.scheduledCadence === "weekly" ? (
+                  <Select
+                    value={String(form.scheduledDayOfWeek)}
+                    onValueChange={(value) =>
+                      onChange({
+                        ...form,
+                        scheduledDayOfWeek: Number(value),
+                      })
+                    }
+                    disabled={disabled}
+                  >
+                    <SelectTrigger size="sm" className="h-8 min-w-32">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {AUTOMATION_WEEKDAY_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={String(option.value)}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                ) : null}
+                {form.scheduledCadence !== "hourly" ? (
+                  <>
+                    <span>at</span>
+                    <Select
+                      value={String(form.scheduledHourUtc)}
+                      onValueChange={(value) =>
+                        onChange({
+                          ...form,
+                          scheduledHourUtc: Number(value),
+                        })
+                      }
+                      disabled={disabled}
+                    >
+                      <SelectTrigger size="sm" className="h-8 min-w-24">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent className="max-h-72">
+                        {Array.from({ length: 24 }, (_, hour) => (
+                          <SelectItem key={hour} value={String(hour)}>
+                            {formatHour(hour)}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </>
+                ) : null}
+                <Input
+                  aria-label="Schedule timezone"
+                  value={form.scheduledTimezone}
+                  disabled={disabled}
+                  className="h-8 w-32 rounded-lg px-2 text-sm"
+                  onChange={(event) =>
+                    onChange({
+                      ...form,
+                      scheduledTimezone: event.target.value,
+                    })
+                  }
+                />
+              </>
+            }
+          />
+        ) : null}
+
+        {form.triggerMode === "github" ? (
+          <EditorRow
+            icon={<HugeiconsIcon icon={GitBranchIcon} strokeWidth={1.8} className="size-4" />}
+            title="GitHub push"
+            className="md:items-center"
+          >
+            <div className="flex w-full min-w-0 flex-col gap-1.5">
+              <div className="flex flex-col gap-2 md:flex-row md:items-center md:gap-2">
+                <Select
+                  value={form.githubInstallationRepositoryId || undefined}
+                  onValueChange={(value) => {
+                    if (!value) {
+                      return;
+                    }
+                    onChange({
+                      ...form,
+                      triggerMode: "github",
+                      githubEnabled: true,
+                      repositoryTargetKind: "github",
+                      githubInstallationRepositoryId: value,
+                    });
+                  }}
+                  disabled={disabled}
+                >
+                  <SelectTrigger className="h-8 w-full rounded-lg md:min-w-44 md:max-w-xs">
+                    <SelectValue placeholder="Repository" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {repositories.map((repository) => (
+                      <SelectItem key={repository.id} value={repository.id}>
+                        {repository.fullName}
+                        {!repository.enabled ? " (disabled)" : ""}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <BranchPatternSelector
+                  branches={form.pushBranches}
+                  disabled={disabled}
+                  error={errors.pushBranches}
+                  onChange={(pushBranches) => onChange({ ...form, pushBranches })}
+                />
+              </div>
+              <FieldError message={errors.githubRepository} />
+            </div>
+          </EditorRow>
+        ) : null}
+
+        {form.triggerMode === "manual" ? (
+          <EditorRow
+            icon={<ClockIcon className="size-4" />}
+            title="Manual only"
+            description="Runs only start when a teammate queues one from this automation."
+          />
+        ) : null}
+
+        <AddTriggerMenu
+          disabled={disabled}
+          form={form}
+          githubConnected={githubConnected}
+          onChange={onChange}
+          repositories={repositories}
+        />
+      </EditorPanel>
+      <FieldError message={errors.trigger} />
+    </EditorSection>
+  );
+}
+
+function AddToolMenu({
+  disabled,
+  emailConnected,
+  form,
+  githubConnected,
+  onChange,
+  slackConnected,
+}: {
+  disabled?: boolean;
+  emailConnected: boolean;
+  form: WorkspaceAutomationFormState;
+  githubConnected: boolean;
+  onChange: (next: WorkspaceAutomationFormState) => void;
+  slackConnected: boolean;
+}) {
+  return (
+    <div className="w-full">
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          className="w-full"
+          render={
+            <Button
+              type="button"
+              variant="ghost"
+              disabled={disabled}
+              className="flex h-10 w-full shrink justify-start rounded-none px-3 text-muted-foreground hover:bg-foreground/5 hover:text-foreground"
+            />
+          }
+        >
+          <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} className="size-4" />
+          Add Tool
+        </DropdownMenuTrigger>
+        <DropdownMenuContent className="w-80" align="start" sideOffset={2}>
+          <DropdownMenuGroup>
+            <DropdownMenuLabel>Supported tools</DropdownMenuLabel>
+            <DropdownMenuItem
+              disabled={form.githubEnabled || !githubConnected}
+              onClick={() =>
+                onChange({
+                  ...form,
+                  githubEnabled: true,
+                  repositoryTargetKind: "github",
+                  validationEnabled:
+                    form.pushSourceEnabled || form.pullTranslationsEnabled
+                      ? form.validationEnabled
+                      : true,
+                })
+              }
+            >
+              <HugeiconsIcon icon={GitBranchIcon} strokeWidth={1.8} className="size-4" />
+              GitHub workflows
+              {form.githubEnabled ? (
+                <DropdownMenuShortcut>Added</DropdownMenuShortcut>
+              ) : !githubConnected ? (
+                <DropdownMenuShortcut>Connect first</DropdownMenuShortcut>
+              ) : null}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              disabled={form.slackEnabled || !slackConnected}
+              onClick={() => onChange({ ...form, slackEnabled: true })}
+            >
+              <HugeiconsIcon icon={SlackIcon} strokeWidth={1.8} className="size-4" />
+              Send to Slack
+              {form.slackEnabled ? (
+                <DropdownMenuShortcut>Added</DropdownMenuShortcut>
+              ) : !slackConnected ? (
+                <DropdownMenuShortcut>Connect first</DropdownMenuShortcut>
+              ) : null}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              disabled={form.emailEnabled || !emailConnected}
+              onClick={() => onChange({ ...form, emailEnabled: true })}
+            >
+              <MailIcon className="size-4" />
+              Send email
+              {form.emailEnabled ? (
+                <DropdownMenuShortcut>Added</DropdownMenuShortcut>
+              ) : !emailConnected ? (
+                <DropdownMenuShortcut>Enable first</DropdownMenuShortcut>
+              ) : null}
+            </DropdownMenuItem>
+          </DropdownMenuGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
+
+function ToolsSettings({
+  disabled,
+  emailConnected,
+  errors,
+  form,
+  githubConnected,
+  onChange,
+  organizationSlug,
+  repositories,
+  slackConnected,
+}: {
+  disabled?: boolean;
+  emailConnected: boolean;
+  errors: Record<string, string | undefined>;
+  form: WorkspaceAutomationFormState;
+  githubConnected: boolean;
+  onChange: (next: WorkspaceAutomationFormState) => void;
+  organizationSlug: string;
+  repositories: GithubRepositoryOption[];
+  slackConnected: boolean;
+}) {
+  return (
+    <EditorSection title="Tools">
+      <EditorPanel>
+        {form.githubEnabled ? (
+          <EditorRow
+            icon={<HugeiconsIcon icon={GitBranchIcon} strokeWidth={1.8} className="size-4" />}
+            title="GitHub workflows"
+            description="Push source, pull translations, and validation checks."
+            action={
+              <DeleteToolButton
+                disabled={disabled}
+                label="Remove GitHub workflows"
+                onClick={() =>
+                  onChange({
+                    ...form,
+                    githubEnabled: false,
+                    repositoryTargetKind: "none",
+                    pushSourceEnabled: false,
+                    pullTranslationsEnabled: false,
+                    validationEnabled: false,
+                  })
+                }
+              />
+            }
+          >
+            <div className="grid gap-3">
+              <div className="grid gap-1.5">
+                <Label className="text-xs text-muted-foreground">Repository</Label>
+                <Select
+                  value={form.githubInstallationRepositoryId || undefined}
+                  onValueChange={(value) => {
+                    if (!value) {
+                      return;
+                    }
+                    onChange({
+                      ...form,
+                      githubInstallationRepositoryId: value,
+                    });
+                  }}
+                  disabled={disabled}
+                >
+                  <SelectTrigger className="h-8 w-full rounded-lg">
+                    <SelectValue placeholder="Select repository" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {repositories.map((repository) => (
+                      <SelectItem key={repository.id} value={repository.id}>
+                        {repository.fullName}
+                        {!repository.enabled ? " (disabled)" : ""}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FieldError message={errors.githubRepository} />
+              </div>
+              <div className="grid gap-2 md:grid-cols-3">
+                <label className="flex items-center justify-between gap-3 rounded-lg border border-foreground/8 px-3 py-2">
+                  <span className="text-xs text-foreground">Push source</span>
+                  <Switch
+                    size="sm"
+                    checked={form.pushSourceEnabled}
+                    disabled={disabled}
+                    onCheckedChange={(checked) => onChange({ ...form, pushSourceEnabled: checked })}
+                  />
+                </label>
+                <label className="flex items-center justify-between gap-3 rounded-lg border border-foreground/8 px-3 py-2">
+                  <span className="text-xs text-foreground">Pull translations</span>
+                  <Switch
+                    size="sm"
+                    checked={form.pullTranslationsEnabled}
+                    disabled={disabled}
+                    onCheckedChange={(checked) =>
+                      onChange({
+                        ...form,
+                        pullTranslationsEnabled: checked,
+                      })
+                    }
+                  />
+                </label>
+                <label className="flex items-center justify-between gap-3 rounded-lg border border-foreground/8 px-3 py-2">
+                  <span className="text-xs text-foreground">Validation</span>
+                  <Switch
+                    size="sm"
+                    checked={form.validationEnabled}
+                    disabled={disabled}
+                    onCheckedChange={(checked) => onChange({ ...form, validationEnabled: checked })}
+                  />
+                </label>
+              </div>
+            </div>
+          </EditorRow>
+        ) : null}
+
+        {form.slackEnabled ? (
+          <EditorRow
+            icon={<HugeiconsIcon icon={SlackIcon} strokeWidth={1.8} className="size-4" />}
+            title={
+              <>
+                <span>Send to Slack</span>
+                {!slackConnected ? <Badge variant="secondary">Connect first</Badge> : null}
+              </>
+            }
+            description={
+              slackConnected ? (
+                "Notify a channel when runs reach a terminal state."
+              ) : (
+                <>
+                  Connect Slack in{" "}
+                  <Link href={`/org/${organizationSlug}/integrations`} className="underline">
+                    Integrations
+                  </Link>{" "}
+                  to use this tool.
+                </>
+              )
+            }
+            action={
+              <DeleteToolButton
+                disabled={disabled}
+                label="Remove Slack notifications"
+                onClick={() => onChange({ ...form, slackEnabled: false, slackChannelId: "" })}
+              />
+            }
+          >
+            <div className="grid gap-1.5">
+              <Label htmlFor="slack-channel" className="text-xs text-muted-foreground">
+                Channel ID
+              </Label>
+              <Input
+                id="slack-channel"
+                value={form.slackChannelId}
+                disabled={disabled || !slackConnected}
+                placeholder="C0123456789"
+                className="h-8 rounded-lg"
+                onChange={(event) => onChange({ ...form, slackChannelId: event.target.value })}
+              />
+              <FieldError message={errors.slackChannelId} />
+            </div>
+          </EditorRow>
+        ) : null}
+
+        {form.emailEnabled ? (
+          <EditorRow
+            icon={<MailIcon className="size-4" />}
+            title={
+              <>
+                <span>Send email</span>
+                {!emailConnected ? <Badge variant="secondary">Enable first</Badge> : null}
+              </>
+            }
+            description={
+              emailConnected ? (
+                "Send terminal run summaries to specific recipients."
+              ) : (
+                <>
+                  Enable the email agent in{" "}
+                  <Link href={`/org/${organizationSlug}/integrations`} className="underline">
+                    Integrations
+                  </Link>{" "}
+                  to use email notifications.
+                </>
+              )
+            }
+            action={
+              <DeleteToolButton
+                disabled={disabled}
+                label="Remove email notifications"
+                onClick={() => onChange({ ...form, emailEnabled: false, emailRecipients: [] })}
+              />
+            }
+          >
+            <div className="grid gap-1.5">
+              <Label htmlFor="email-recipients" className="text-xs text-muted-foreground">
+                Recipients
+              </Label>
+              <Textarea
+                id="email-recipients"
+                value={form.emailRecipients.join("\n")}
+                disabled={disabled || !emailConnected}
+                className="min-h-20 rounded-lg text-sm"
+                placeholder={"ops@company.com\ndev@company.com"}
+                onChange={(event) =>
+                  onChange({
+                    ...form,
+                    emailRecipients: event.target.value
+                      .split(/\n|,/)
+                      .map((value) => value.trim())
+                      .filter(Boolean),
+                  })
+                }
+              />
+              <FieldError message={errors.emailRecipients} />
+            </div>
+          </EditorRow>
+        ) : null}
+
+        <AddToolMenu
+          disabled={disabled}
+          emailConnected={emailConnected}
+          form={form}
+          githubConnected={githubConnected}
+          onChange={onChange}
+          slackConnected={slackConnected}
+        />
+      </EditorPanel>
+    </EditorSection>
+  );
+}
+
+function RunHistoryTable({ runs }: { runs: WorkspaceAutomationRunRecord[] }) {
+  if (runs.length === 0) {
+    return (
+      <EditorPanel className="px-4 py-10">
+        <p className="text-sm text-muted-foreground">No runs yet.</p>
+      </EditorPanel>
+    );
+  }
+
+  return (
+    <EditorPanel>
+      <div className="grid grid-cols-[minmax(0,0.8fr)_minmax(0,0.8fr)_minmax(0,1fr)_minmax(0,0.8fr)] gap-4 border-b border-foreground/10 px-4 py-3 text-xs font-medium text-muted-foreground">
+        <span>Status</span>
+        <span>Trigger</span>
+        <span>Summary</span>
+        <span>Completed</span>
+      </div>
+      {runs.map((run) => (
+        <div
+          key={run.id}
+          className="grid grid-cols-[minmax(0,0.8fr)_minmax(0,0.8fr)_minmax(0,1fr)_minmax(0,0.8fr)] gap-4 border-b border-foreground/10 px-4 py-4 text-sm last:border-b-0"
+        >
+          <Badge variant="outline" className="w-fit">
+            {run.status}
+          </Badge>
+          <span>{run.triggerSource}</span>
+          <span className="truncate text-muted-foreground">
+            {Object.keys(run.outputSummary).length > 0 ? JSON.stringify(run.outputSummary) : "—"}
+          </span>
+          <span className="text-muted-foreground">
+            {run.completedAt ? new Date(run.completedAt).toLocaleString() : "—"}
+          </span>
+        </div>
+      ))}
+    </EditorPanel>
+  );
+}
+
+export function WorkspaceAutomationEditor({
+  actions,
+  disabled,
+  errors,
+  form,
+  mode,
+  onChange,
+  organizationSlug,
+  runHistory,
+}: {
+  actions?: ReactNode;
+  disabled?: boolean;
+  errors: Record<string, string | undefined>;
+  form: WorkspaceAutomationFormState;
+  mode: "create" | "detail";
+  onChange: (next: WorkspaceAutomationFormState) => void;
+  organizationSlug: string;
+  runHistory?: WorkspaceAutomationRunRecord[];
+}) {
+  const [activeTab, setActiveTab] = useState<AutomationEditorTab>("settings");
 
   const projectsQuery = useQuery({
     queryKey: ["projects", organizationSlug],
@@ -72,6 +1037,22 @@ export function WorkspaceAutomationForm({
       return body.projects as ProjectOption[];
     },
   });
+
+  const githubInstallationQuery = useQuery({
+    queryKey: ["github-installation", organizationSlug],
+    queryFn: async () => {
+      const response = await api.api.orgs[":organizationSlug"]["github-installation"].$get({
+        param: { organizationSlug },
+      });
+      if (!response.ok) {
+        throw new Error("Failed to load GitHub installation");
+      }
+      const body = await response.json();
+      return body.installation as { githubInstallationId: string } | null;
+    },
+  });
+
+  const githubConnected = Boolean(githubInstallationQuery.data);
 
   const repositoriesQuery = useQuery({
     queryKey: ["github-installation-repositories", organizationSlug],
@@ -88,6 +1069,7 @@ export function WorkspaceAutomationForm({
       const body = await response.json();
       return body.repositories as GithubRepositoryOption[];
     },
+    enabled: githubConnected,
   });
 
   const slackQuery = useQuery({
@@ -122,50 +1104,36 @@ export function WorkspaceAutomationForm({
     () => (repositoriesQuery.data ?? []).filter((repository) => !repository.archived),
     [repositoriesQuery.data],
   );
-
   const canActivate = workspaceAutomationFormCanActivate(form);
   const slackConnected = Boolean(slackQuery.data?.enabled);
   const emailConnected = Boolean(emailQuery.data?.enabled);
+  const hasHistory = mode === "detail";
 
   return (
-    <div className="flex flex-col gap-8">
-      <section className="flex flex-col gap-4">
-        <div className="flex flex-col gap-1">
-          <h2 className="text-sm font-medium text-foreground">Basics</h2>
-          <p className="text-xs text-muted-foreground">
-            Instructions are stored for operators and copied into run metadata. They do not execute
-            a free-form agent in V1.
-          </p>
-        </div>
-        <div className="grid gap-4">
-          <div className="grid gap-2">
-            <Label htmlFor="automation-name">Name</Label>
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-6">
+      <section className="flex flex-col gap-3">
+        <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+          <div className="min-w-0 flex-1">
+            <Label htmlFor="automation-name" className="sr-only">
+              Automation name
+            </Label>
             <Input
               id="automation-name"
               value={form.name}
               disabled={disabled}
+              placeholder="Untitled automation"
+              className="h-auto rounded-none border-0 bg-transparent px-0 py-0 text-2xl font-medium shadow-none ring-0 focus-visible:ring-0 md:text-2xl"
               onChange={(event) => onChange({ ...form, name: event.target.value })}
             />
             <FieldError message={errors.name} />
           </div>
-          <div className="grid gap-2">
-            <Label htmlFor="automation-instructions">Agent instructions</Label>
-            <Textarea
-              id="automation-instructions"
-              value={form.instructions}
-              disabled={disabled}
-              className="min-h-48 font-mono text-sm"
-              onChange={(event) => onChange({ ...form, instructions: event.target.value })}
-            />
-            <FieldError message={errors.instructions} />
-          </div>
-          <div className="flex items-center justify-between rounded-lg border border-foreground/10 px-4 py-3">
-            <div>
-              <p className="text-sm font-medium">Active</p>
-              <p className="text-xs text-muted-foreground">
-                Paused automations keep their configuration but will not dispatch.
-              </p>
-            </div>
+          {actions ? (
+            <div className="flex shrink-0 flex-wrap items-center gap-2">{actions}</div>
+          ) : null}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-2 text-sm text-muted-foreground">
+          <label className="flex items-center gap-2 text-foreground">
             <Switch
               checked={form.status === "active"}
               disabled={disabled || !canActivate}
@@ -176,381 +1144,100 @@ export function WorkspaceAutomationForm({
                 })
               }
             />
-          </div>
-          {!canActivate ? (
-            <p className="text-xs text-muted-foreground">
-              Enable at least one deterministic GitHub workflow or notification tool to activate
-              this automation.
-            </p>
+            <span>{form.status === "active" ? "Active" : "Paused"}</span>
+          </label>
+          <span className="text-foreground/20">|</span>
+          <HeaderProjectSelector
+            disabled={disabled}
+            form={form}
+            isError={projectsQuery.isError}
+            isLoading={projectsQuery.isLoading}
+            onChange={onChange}
+            projects={projectsQuery.data ?? []}
+          />
+          {form.triggerMode !== "manual" ? (
+            <>
+              <span className="text-foreground/20">|</span>
+              <span>{triggerSummary(form, repositories)}</span>
+            </>
           ) : null}
-          <FieldError message={errors.form} />
+          <span className="text-foreground/20">|</span>
+          <span>
+            {toolCount(form)} tool{toolCount(form) === 1 ? "" : "s"}
+          </span>
         </div>
+        <FieldError message={errors.githubProjectId} />
+        {!canActivate ? (
+          <p className="text-xs text-muted-foreground">
+            Add at least one supported tool to activate this automation.
+          </p>
+        ) : null}
+        <FieldError message={errors.form} />
       </section>
 
-      <section className="flex flex-col gap-4">
-        <div className="flex flex-col gap-1">
-          <h2 className="text-sm font-medium text-foreground">Triggers</h2>
-          <p className="text-xs text-muted-foreground">
-            V1 supports manual runs, schedules, and GitHub push triggers.
-          </p>
-        </div>
-        <div className="grid gap-4 rounded-lg border border-foreground/10 p-4">
-          <div className="grid gap-2">
-            <Label>Trigger</Label>
-            <Select
-              value={form.triggerMode}
-              onValueChange={(value) =>
-                onChange({
-                  ...form,
-                  triggerMode: value as WorkspaceAutomationFormState["triggerMode"],
-                })
-              }
-              disabled={disabled}
-            >
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="manual">Manual only</SelectItem>
-                <SelectItem value="scheduled">Scheduled</SelectItem>
-                <SelectItem value="github">GitHub push</SelectItem>
-              </SelectContent>
-            </Select>
-            <FieldError message={errors.trigger} />
-          </div>
+      <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as AutomationEditorTab)}>
+        <TabsList>
+          <TabsTrigger value="settings">Settings</TabsTrigger>
+          {hasHistory ? <TabsTrigger value="history">Run History</TabsTrigger> : null}
+        </TabsList>
 
-          {form.triggerMode === "scheduled" ? (
-            <div className="grid gap-3 md:grid-cols-3">
-              <div className="grid gap-2">
-                <Label>Cadence</Label>
-                <Select
-                  value={form.scheduledCadence}
-                  onValueChange={(value) =>
-                    onChange({
-                      ...form,
-                      scheduledCadence: value as typeof form.scheduledCadence,
-                    })
-                  }
-                  disabled={disabled}
-                >
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="hourly">Hourly</SelectItem>
-                    <SelectItem value="daily">Daily</SelectItem>
-                    <SelectItem value="weekly">Weekly</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-              <div className="grid gap-2">
-                <Label>Hour (UTC)</Label>
-                <Input
-                  type="number"
-                  min={0}
-                  max={23}
-                  value={form.scheduledHourUtc}
-                  disabled={disabled || form.scheduledCadence === "hourly"}
-                  onChange={(event) =>
-                    onChange({
-                      ...form,
-                      scheduledHourUtc: Number(event.target.value),
-                    })
-                  }
-                />
-              </div>
-              <div className="grid gap-2">
-                <Label>Timezone</Label>
-                <Input
-                  value={form.scheduledTimezone}
-                  disabled={disabled}
-                  onChange={(event) =>
-                    onChange({
-                      ...form,
-                      scheduledTimezone: event.target.value,
-                    })
-                  }
-                />
-              </div>
-              {form.scheduledCadence === "weekly" ? (
-                <div className="grid gap-2 md:col-span-3">
-                  <Label>Day of week</Label>
-                  <Select
-                    value={String(form.scheduledDayOfWeek)}
-                    onValueChange={(value) =>
-                      onChange({
-                        ...form,
-                        scheduledDayOfWeek: Number(value),
-                      })
-                    }
-                    disabled={disabled}
-                  >
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {AUTOMATION_WEEKDAY_OPTIONS.map((option) => (
-                        <SelectItem key={option.value} value={String(option.value)}>
-                          {option.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              ) : null}
-            </div>
-          ) : null}
+        <TabsContent value="settings" className="mt-4 flex flex-col gap-6">
+          <TriggerSettings
+            disabled={disabled}
+            errors={errors}
+            form={form}
+            githubConnected={githubConnected}
+            onChange={onChange}
+            repositories={repositories}
+          />
 
-          {form.triggerMode === "github" ? (
-            <div className="grid gap-2">
-              <Label>Branch patterns</Label>
-              <div className="flex flex-wrap gap-2">
-                {form.pushBranches.map((branch) => (
-                  <Badge key={branch} variant="secondary">
-                    {branch}
-                  </Badge>
-                ))}
-              </div>
-              <div className="flex gap-2">
-                <Input
-                  value={branchInput}
-                  disabled={disabled}
-                  placeholder="main"
-                  onChange={(event) => setBranchInput(event.target.value)}
-                />
-                <Button
-                  type="button"
-                  variant="outline"
-                  disabled={disabled}
-                  onClick={() => {
-                    const result = addBranchPattern(form.pushBranches, branchInput);
-                    if (result.error) {
-                      return;
-                    }
-                    onChange({ ...form, pushBranches: result.branches });
-                    setBranchInput("");
-                  }}
-                >
-                  Add
-                </Button>
-              </div>
-              <FieldError message={errors.pushBranches} />
-            </div>
-          ) : null}
-        </div>
-      </section>
-
-      <section className="flex flex-col gap-4">
-        <div className="flex flex-col gap-1">
-          <h2 className="text-sm font-medium text-foreground">Tools</h2>
-          <p className="text-xs text-muted-foreground">
-            GitHub workflows run through the existing deterministic repository automation path.
-          </p>
-        </div>
-
-        <div className="grid gap-4">
-          <div className="rounded-lg border border-foreground/10 p-4">
-            <div className="flex items-center justify-between gap-4">
-              <div>
-                <p className="text-sm font-medium">GitHub workflows</p>
-                <p className="text-xs text-muted-foreground">
-                  Push source, pull translations, and validation/check.
-                </p>
-              </div>
-              <Switch
-                checked={form.githubEnabled}
+          <EditorSection title="Agent Instructions">
+            <div className="relative rounded-xl">
+              <Textarea
+                id="automation-instructions"
+                value={form.instructions}
                 disabled={disabled}
-                onCheckedChange={(checked) =>
-                  onChange({
-                    ...form,
-                    githubEnabled: checked,
-                    repositoryTargetKind: checked ? "github" : "none",
-                  })
-                }
+                className="relative z-0 min-h-80 resize-y rounded-xl border-foreground/10 bg-foreground/[0.025] pb-10 font-sans text-sm leading-6"
+                placeholder="Tell the automation what to do, what to inspect, and what to ignore."
+                onChange={(event) => onChange({ ...form, instructions: event.target.value })}
+              />
+              <div
+                aria-hidden
+                className="pointer-events-none absolute inset-x-px bottom-px z-10 h-11 rounded-b-[calc(0.75rem-1px)] bg-linear-to-t from-foreground/[0.06] via-foreground/[0.02] to-transparent backdrop-blur-sm"
               />
             </div>
+            <FieldError message={errors.instructions} />
+          </EditorSection>
 
-            {form.githubEnabled ? (
-              <div className="mt-4 grid gap-4">
-                <div className="grid gap-2">
-                  <Label>Repository</Label>
-                  <Select
-                    value={form.githubInstallationRepositoryId || undefined}
-                    onValueChange={(value) => {
-                      if (!value) {
-                        return;
-                      }
-                      onChange({
-                        ...form,
-                        githubInstallationRepositoryId: value,
-                      });
-                    }}
-                    disabled={disabled}
-                  >
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select repository" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {repositories.map((repository) => (
-                        <SelectItem key={repository.id} value={repository.id}>
-                          {repository.fullName}
-                          {!repository.enabled ? " (disabled)" : ""}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <FieldError message={errors.githubRepository} />
-                </div>
-                <div className="grid gap-2">
-                  <Label>Project</Label>
-                  <Select
-                    value={form.githubProjectId || undefined}
-                    onValueChange={(value) => {
-                      if (!value) {
-                        return;
-                      }
-                      onChange({ ...form, githubProjectId: value });
-                    }}
-                    disabled={disabled}
-                  >
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select project" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {(projectsQuery.data ?? []).map((project) => (
-                        <SelectItem key={project.id} value={project.id}>
-                          {project.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <FieldError message={errors.githubProjectId} />
-                </div>
-                <div className="grid gap-3">
-                  <label className="flex items-center justify-between gap-4">
-                    <span className="text-sm">Push source</span>
-                    <Switch
-                      checked={form.pushSourceEnabled}
-                      disabled={disabled}
-                      onCheckedChange={(checked) =>
-                        onChange({ ...form, pushSourceEnabled: checked })
-                      }
-                    />
-                  </label>
-                  <label className="flex items-center justify-between gap-4">
-                    <span className="text-sm">Pull translations</span>
-                    <Switch
-                      checked={form.pullTranslationsEnabled}
-                      disabled={disabled}
-                      onCheckedChange={(checked) =>
-                        onChange({
-                          ...form,
-                          pullTranslationsEnabled: checked,
-                        })
-                      }
-                    />
-                  </label>
-                  <label className="flex items-center justify-between gap-4">
-                    <span className="text-sm">Validation / check</span>
-                    <Switch
-                      checked={form.validationEnabled}
-                      disabled={disabled}
-                      onCheckedChange={(checked) =>
-                        onChange({ ...form, validationEnabled: checked })
-                      }
-                    />
-                  </label>
-                </div>
-              </div>
-            ) : null}
-          </div>
+          <ToolsSettings
+            disabled={disabled}
+            emailConnected={emailConnected}
+            errors={errors}
+            form={form}
+            githubConnected={githubConnected}
+            onChange={onChange}
+            organizationSlug={organizationSlug}
+            repositories={repositories}
+            slackConnected={slackConnected}
+          />
+        </TabsContent>
 
-          <div className="rounded-lg border border-foreground/10 p-4">
-            <div className="flex items-center justify-between gap-4">
-              <div>
-                <p className="text-sm font-medium">Slack notifications</p>
-                <p className="text-xs text-muted-foreground">
-                  Notify a channel when runs reach a terminal state.
-                </p>
-              </div>
-              <Switch
-                checked={form.slackEnabled}
-                disabled={disabled || !slackConnected}
-                onCheckedChange={(checked) => onChange({ ...form, slackEnabled: checked })}
-              />
-            </div>
-            {!slackConnected ? (
-              <p className="mt-2 text-xs text-muted-foreground">
-                Connect Slack in{" "}
-                <Link href={`/org/${organizationSlug}/integrations`} className="underline">
-                  Integrations
-                </Link>{" "}
-                to enable this tool.
-              </p>
-            ) : null}
-            {form.slackEnabled ? (
-              <div className="mt-4 grid gap-2">
-                <Label htmlFor="slack-channel">Channel ID</Label>
-                <Input
-                  id="slack-channel"
-                  value={form.slackChannelId}
-                  disabled={disabled}
-                  placeholder="C0123456789"
-                  onChange={(event) => onChange({ ...form, slackChannelId: event.target.value })}
-                />
-                <FieldError message={errors.slackChannelId} />
-              </div>
-            ) : null}
-          </div>
-
-          <div className="rounded-lg border border-foreground/10 p-4">
-            <div className="flex items-center justify-between gap-4">
-              <div>
-                <p className="text-sm font-medium">Email notifications</p>
-                <p className="text-xs text-muted-foreground">
-                  Send terminal run summaries to specific recipients.
-                </p>
-              </div>
-              <Switch
-                checked={form.emailEnabled}
-                disabled={disabled || !emailConnected}
-                onCheckedChange={(checked) => onChange({ ...form, emailEnabled: checked })}
-              />
-            </div>
-            {!emailConnected ? (
-              <p className="mt-2 text-xs text-muted-foreground">
-                Enable the email agent in{" "}
-                <Link href={`/org/${organizationSlug}/integrations`} className="underline">
-                  Integrations
-                </Link>{" "}
-                to use email notifications.
-              </p>
-            ) : null}
-            {form.emailEnabled ? (
-              <div className="mt-4 grid gap-2">
-                <Label htmlFor="email-recipients">Recipients</Label>
-                <Textarea
-                  id="email-recipients"
-                  value={form.emailRecipients.join("\n")}
-                  disabled={disabled}
-                  className="min-h-24"
-                  placeholder={"ops@company.com\ndev@company.com"}
-                  onChange={(event) =>
-                    onChange({
-                      ...form,
-                      emailRecipients: event.target.value
-                        .split(/\n|,/)
-                        .map((value) => value.trim())
-                        .filter(Boolean),
-                    })
-                  }
-                />
-                <FieldError message={errors.emailRecipients} />
-              </div>
-            ) : null}
-          </div>
-        </div>
-      </section>
+        {hasHistory ? (
+          <TabsContent value="history" className="mt-4">
+            <RunHistoryTable runs={runHistory ?? []} />
+          </TabsContent>
+        ) : null}
+      </Tabs>
     </div>
   );
+}
+
+export function WorkspaceAutomationForm(props: {
+  organizationSlug: string;
+  form: WorkspaceAutomationFormState;
+  errors: Record<string, string | undefined>;
+  disabled?: boolean;
+  onChange: (next: WorkspaceAutomationFormState) => void;
+}) {
+  return <WorkspaceAutomationEditor mode="create" {...props} />;
 }

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/simple-brand-icon.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/simple-brand-icon.tsx
@@ -11,13 +11,16 @@ type SimpleBrandIconProps = SVGProps<SVGSVGElement> & {
 };
 
 export function SimpleBrandIcon({ icon, colored, className, ...props }: SimpleBrandIconProps) {
+  // GitHub's brand hex is near-black and disappears on dark surfaces.
+  const useThemeForeground = colored && icon.slug === "github";
+
   return (
     <svg
       aria-hidden="true"
       focusable="false"
       viewBox="0 0 24 24"
-      className={cn("size-5", className)}
-      fill={colored ? `#${icon.hex}` : "currentColor"}
+      className={cn("size-5", useThemeForeground && "fill-foreground", className)}
+      fill={useThemeForeground ? undefined : colored ? `#${icon.hex}` : "currentColor"}
       opacity={colored ? 1 : 0.72}
       {...props}
     >

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-navigation.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-navigation.tsx
@@ -80,7 +80,7 @@ function GlobalNavigation({
         }
 
         return (
-          <Collapsible key={group.label} defaultOpen>
+          <Collapsible key={group.label} defaultOpen className={cn(groupIndex > 0 && "mt-2")}>
             <SidebarGroup className="p-0">
               <CollapsibleTrigger className="group/collapsible-trigger flex h-7 w-full items-center gap-2 rounded-md px-3 text-left text-xs font-medium tracking-wide text-muted-foreground uppercase outline-hidden transition-[margin,opacity,color] duration-200 hover:text-sidebar-foreground focus-visible:text-sidebar-foreground group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0">
                 <span className="min-w-0 flex-1 truncate">{group.label}</span>

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
@@ -70,15 +70,22 @@ export function buildGlobalNavigationGroups(organizationSlug: string): readonly 
           icon: DashboardSquare01Icon,
         },
         {
-          label: "Projects",
-          href: org("projects"),
-          icon: FolderKanbanIcon,
+          label: "Automations",
+          href: org("automations"),
+          icon: Task01Icon,
+          description: "Scheduled and GitHub-triggered deterministic workflows",
+          badge: "Beta",
         },
       ],
     },
     {
       label: "Workspace",
       items: [
+        {
+          label: "Projects",
+          href: org("projects"),
+          icon: FolderKanbanIcon,
+        },
         {
           label: "Knowledge",
           href: org("knowledge"),
@@ -100,12 +107,6 @@ export function buildGlobalNavigationGroups(organizationSlug: string): readonly 
           label: "Integrations",
           href: org("integrations"),
           icon: LinkSquare02Icon,
-        },
-        {
-          label: "Automations",
-          href: org("automations"),
-          icon: Task01Icon,
-          description: "Scheduled and GitHub-triggered deterministic workflows",
         },
         {
           label: "Team",

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-templates.ts
@@ -2,10 +2,10 @@ import type { WorkspaceAutomationFormState } from "./workspace-automation-view-m
 
 export type WorkspaceAutomationTemplateCategory =
   | "popular"
-  | "code-review"
-  | "security"
-  | "incidents"
-  | "data";
+  | "source-content"
+  | "translation-delivery"
+  | "quality"
+  | "release";
 
 export type WorkspaceAutomationTemplate = {
   id: string;
@@ -22,158 +22,160 @@ export const WORKSPACE_AUTOMATION_TEMPLATE_CATEGORIES: Array<{
   label: string;
 }> = [
   { id: "popular", label: "Popular" },
-  { id: "code-review", label: "Code Review" },
-  { id: "security", label: "Security" },
-  { id: "incidents", label: "Incidents & Triage" },
-  { id: "data", label: "Data & Research" },
+  { id: "source-content", label: "Source Content" },
+  { id: "translation-delivery", label: "Translation Delivery" },
+  { id: "quality", label: "Quality" },
+  { id: "release", label: "Release Readiness" },
 ];
 
 export const WORKSPACE_AUTOMATION_TEMPLATES: WorkspaceAutomationTemplate[] = [
   {
-    id: "find-critical-bugs",
+    id: "validate-localisation-on-push",
     category: "popular",
-    name: "Find critical bugs",
+    name: "Validate localisation on push",
     description:
-      "Inspect recent commits for high-severity behavioral regressions and open a pull request when a fix is ready.",
+      "Check localisation changes on every push and notify the team when blockers are found.",
     instructions: [
-      "You are a deep bug-finding automation.",
+      "You are a localisation quality automation.",
       "",
-      "Goal: inspect recent commits for critical bugs before they reach production.",
+      "Goal: validate source string and translation changes before they reach production.",
       "",
-      "Investigation strategy:",
-      "- Focus on behavioral changes, data corruption, auth regressions, and race conditions.",
-      "- Ignore style-only diffs and low-risk refactors.",
+      "Review strategy:",
+      "- Check changed source strings for missing context, unstable copy, and accidental key churn.",
+      "- Flag missing translations, broken ICU syntax, mismatched placeholders, and unsafe HTML.",
+      "- Treat locale coverage regressions and release-blocking translation issues as blocking findings.",
+      "- Ignore style-only code changes that do not affect localisation files or user-facing strings.",
     ].join("\n"),
     activatable: true,
     defaultForm: {
-      name: "Find critical bugs",
-      triggerMode: "scheduled",
-      scheduledCadence: "daily",
-      scheduledHourUtc: 22,
-      scheduledTimezone: "UTC",
+      name: "Validate localisation on push",
+      triggerMode: "github",
+      pushBranches: ["main"],
       githubEnabled: true,
       validationEnabled: true,
       slackEnabled: true,
     },
   },
   {
-    id: "summarize-changes-daily",
+    id: "full-localisation-sync",
     category: "popular",
-    name: "Summarize changes daily",
-    description: "Post a concise summary of repository changes to Slack every day.",
-    instructions:
-      "Summarize the most important repository changes from the last day, grouped by risk and user impact. Keep the update concise and actionable.",
+    name: "Full localisation sync",
+    description: "Run a daily source push, translation pull, and validation pass for the project.",
+    instructions: [
+      "Run the full localisation sync loop for this repository.",
+      "",
+      "Expected outcome:",
+      "- Push new or changed source strings to the translation system.",
+      "- Pull completed translations back into the repository.",
+      "- Validate locale coverage, placeholders, ICU syntax, and release-blocking translation issues.",
+      "- Notify the configured channel with a concise summary of completed sync work and blockers.",
+    ].join("\n"),
     activatable: true,
     defaultForm: {
-      name: "Summarize changes daily",
+      name: "Full localisation sync",
       triggerMode: "scheduled",
       scheduledCadence: "daily",
       scheduledHourUtc: 22,
       scheduledTimezone: "UTC",
       githubEnabled: true,
+      pushSourceEnabled: true,
+      pullTranslationsEnabled: true,
       validationEnabled: true,
       slackEnabled: true,
     },
   },
   {
-    id: "add-test-coverage",
-    category: "code-review",
-    name: "Add test coverage",
-    description: "Review recent changes and propose tests for under-covered critical paths.",
-    instructions:
-      "Review recent changes and identify critical paths missing automated tests. Open a pull request only when tests are clearly justified.",
-    activatable: true,
-    defaultForm: {
-      name: "Add test coverage",
-      triggerMode: "scheduled",
-      scheduledCadence: "weekly",
-      scheduledDayOfWeek: 1,
-      scheduledHourUtc: 22,
-      scheduledTimezone: "UTC",
-      githubEnabled: true,
-      validationEnabled: true,
-    },
-  },
-  {
-    id: "assign-pr-reviewers",
-    category: "code-review",
-    name: "Assign PR reviewers",
-    description: "Assign reviewers based on touched areas and auto-approve low-risk pull requests.",
-    instructions:
-      "Review open pull requests, assign reviewers based on code ownership, and auto-approve only low-risk changes.",
-    activatable: false,
-    defaultForm: {
-      name: "Assign PR reviewers",
-      triggerMode: "github",
-      pushBranches: ["main"],
-      instructions:
-        "Review open pull requests, assign reviewers based on code ownership, and auto-approve only low-risk changes.",
-    },
-  },
-  {
-    id: "find-vulnerabilities",
-    category: "security",
-    name: "Find vulnerabilities",
+    id: "push-source-strings",
+    category: "source-content",
+    name: "Push source strings",
     description:
-      "Review pull requests for exploitable security issues and flag only validated findings before merge.",
-    instructions:
-      "Review pull requests for exploitable security issues. Flag only validated findings with clear reproduction steps.",
+      "Send changed source strings to the translation system whenever localisation files change.",
+    instructions: [
+      "Push changed source strings from the repository to the translation system.",
+      "",
+      "Focus on source content hygiene:",
+      "- Include new and updated user-facing strings.",
+      "- Preserve stable translation keys where possible.",
+      "- Highlight source strings that lack product context or contain hard-coded locale assumptions.",
+      "- Avoid changing translated files unless the push workflow requires it.",
+    ].join("\n"),
     activatable: true,
     defaultForm: {
-      name: "Find vulnerabilities",
+      name: "Push source strings",
       triggerMode: "github",
       pushBranches: ["main"],
       githubEnabled: true,
-      validationEnabled: true,
-      slackEnabled: true,
+      pushSourceEnabled: true,
     },
   },
   {
-    id: "scan-codebase-vulnerabilities",
-    category: "security",
-    name: "Scan codebase for vulnerabilities",
-    description:
-      "Run a scheduled security scan across the default branch and report validated findings.",
-    instructions:
-      "Scan the repository for high-confidence security issues. Report only validated findings with remediation guidance.",
+    id: "pull-translations-daily",
+    category: "translation-delivery",
+    name: "Pull translations daily",
+    description: "Bring completed translations back into the repository on a daily schedule.",
+    instructions: [
+      "Pull completed translations from the translation system into the repository.",
+      "",
+      "Delivery criteria:",
+      "- Keep generated translation changes scoped to locale resources.",
+      "- Preserve formatting, placeholders, ICU syntax, and file ordering conventions.",
+      "- Summarize newly completed locales and any languages still below release coverage.",
+      "- Avoid broad rewrites that make translation diffs hard to review.",
+    ].join("\n"),
     activatable: true,
     defaultForm: {
-      name: "Scan codebase for vulnerabilities",
+      name: "Pull translations daily",
       triggerMode: "scheduled",
       scheduledCadence: "daily",
       scheduledHourUtc: 22,
       scheduledTimezone: "UTC",
       githubEnabled: true,
+      pullTranslationsEnabled: true,
+    },
+  },
+  {
+    id: "release-localisation-check",
+    category: "release",
+    name: "Release localisation check",
+    description:
+      "Validate release branches for localisation coverage, placeholder safety, and blocking translation gaps.",
+    instructions: [
+      "Review release-bound localisation changes for blocking issues.",
+      "",
+      "Release criteria:",
+      "- Confirm required locales meet coverage expectations.",
+      "- Flag missing translations in release-critical user journeys.",
+      "- Verify placeholders, ICU syntax, punctuation, and embedded markup remain safe.",
+      "- Notify the team with clear release blockers and non-blocking follow-ups.",
+    ].join("\n"),
+    activatable: true,
+    defaultForm: {
+      name: "Release localisation check",
+      triggerMode: "github",
+      pushBranches: ["main", "release/*"],
+      githubEnabled: true,
       validationEnabled: true,
       slackEnabled: true,
     },
   },
   {
-    id: "fix-slack-bugs",
-    category: "incidents",
-    name: "Fix bugs reported in Slack",
+    id: "weekly-localisation-summary",
+    category: "release",
+    name: "Weekly localisation summary",
     description:
-      "Monitor a Slack channel for bug reports, investigate the codebase, and fix with a pull request.",
-    instructions:
-      "Monitor the configured Slack channel for bug reports, investigate the repository, and open a pull request when a fix is clear.",
-    activatable: false,
-    defaultForm: {
-      name: "Fix bugs reported in Slack",
-      triggerMode: "manual",
-      slackEnabled: true,
-    },
-  },
-  {
-    id: "generate-docs",
-    category: "data",
-    name: "Generate docs",
-    description:
-      "Create and update developer documentation for recently changed or under-documented code.",
-    instructions:
-      "Create or update developer documentation for recently changed or under-documented code. Prefer concise, accurate docs over broad rewrites.",
+      "Post a weekly summary of localisation progress, outstanding gaps, and release risks.",
+    instructions: [
+      "Summarize localisation progress for the week.",
+      "",
+      "Include:",
+      "- Source strings changed and translations pulled.",
+      "- Locales that are complete, in progress, or blocked.",
+      "- Placeholder, ICU, or formatting issues that need attention.",
+      "- Release risks and the next recommended action for each blocker.",
+    ].join("\n"),
     activatable: true,
     defaultForm: {
-      name: "Generate docs",
+      name: "Weekly localisation summary",
       triggerMode: "scheduled",
       scheduledCadence: "weekly",
       scheduledDayOfWeek: 1,
@@ -181,12 +183,418 @@ export const WORKSPACE_AUTOMATION_TEMPLATES: WorkspaceAutomationTemplate[] = [
       scheduledTimezone: "UTC",
       githubEnabled: true,
       pullTranslationsEnabled: true,
+      slackEnabled: true,
+    },
+  },
+  {
+    id: "icu-placeholder-audit",
+    category: "quality",
+    name: "ICU and placeholder audit",
+    description: "Flag ICU syntax errors and unsafe placeholders on every push to main.",
+    instructions: [
+      "Audit localisation changes for ICU and placeholder safety.",
+      "",
+      "Focus on:",
+      "- Broken ICU plural/select syntax and invalid message format strings.",
+      "- Placeholder name mismatches between source and translated strings.",
+      "- Unsafe HTML or markup embedded in translated copy.",
+      "- Notify the team only when findings are release-blocking.",
+    ].join("\n"),
+    activatable: true,
+    defaultForm: {
+      name: "ICU and placeholder audit",
+      triggerMode: "github",
+      pushBranches: ["main"],
+      githubEnabled: true,
+      validationEnabled: true,
+      slackEnabled: true,
+    },
+  },
+  {
+    id: "missing-translation-gate",
+    category: "quality",
+    name: "Missing translation gate",
+    description: "Block merges when required locales drop below coverage on protected branches.",
+    instructions: [
+      "Treat missing translations in required locales as release blockers.",
+      "",
+      "Check for:",
+      "- Locale coverage regressions on user-facing keys.",
+      "- New source strings without completed translations in required languages.",
+      "- Stale or empty values in locale resource files.",
+      "- Summarize blockers with locale, file, and key context for fast fixes.",
+    ].join("\n"),
+    activatable: true,
+    defaultForm: {
+      name: "Missing translation gate",
+      triggerMode: "github",
+      pushBranches: ["main", "release/*"],
+      githubEnabled: true,
+      validationEnabled: true,
+      slackEnabled: true,
+    },
+  },
+  {
+    id: "locale-coverage-daily",
+    category: "quality",
+    name: "Daily locale coverage check",
+    description: "Run a daily validation pass and post coverage gaps to Slack.",
+    instructions: [
+      "Report daily locale coverage and translation health for the project.",
+      "",
+      "Include:",
+      "- Locales below required coverage thresholds.",
+      "- Keys added in the last day without translations.",
+      "- Non-blocking formatting issues worth fixing before release.",
+    ].join("\n"),
+    activatable: true,
+    defaultForm: {
+      name: "Daily locale coverage check",
+      triggerMode: "scheduled",
+      scheduledCadence: "daily",
+      scheduledHourUtc: 8,
+      scheduledTimezone: "UTC",
+      githubEnabled: true,
+      validationEnabled: true,
+      slackEnabled: true,
+    },
+  },
+  {
+    id: "push-source-on-feature-branches",
+    category: "source-content",
+    name: "Push source on feature branches",
+    description: "Send updated source strings when feature branches change localisation files.",
+    instructions: [
+      "Push source string changes from feature branches to the translation system.",
+      "",
+      "Prioritize:",
+      "- New user-facing copy introduced on active feature work.",
+      "- Stable keys and clear product context for translators.",
+      "- Skipping translated locale files unless the workflow requires updates.",
+    ].join("\n"),
+    activatable: true,
+    defaultForm: {
+      name: "Push source on feature branches",
+      triggerMode: "github",
+      pushBranches: ["feature/*", "main"],
+      githubEnabled: true,
+      pushSourceEnabled: true,
+    },
+  },
+  {
+    id: "pull-translations-on-merge",
+    category: "translation-delivery",
+    name: "Pull translations on merge",
+    description: "Pull completed translations when changes land on main.",
+    instructions: [
+      "Pull completed translations into the repository after merges to main.",
+      "",
+      "Delivery rules:",
+      "- Limit diffs to locale resource files.",
+      "- Preserve placeholders, ICU syntax, and repository formatting conventions.",
+      "- Summarize locales updated and languages still pending review.",
+    ].join("\n"),
+    activatable: true,
+    defaultForm: {
+      name: "Pull translations on merge",
+      triggerMode: "github",
+      pushBranches: ["main"],
+      githubEnabled: true,
+      pullTranslationsEnabled: true,
+      slackEnabled: true,
+    },
+  },
+  {
+    id: "hourly-translation-pull",
+    category: "translation-delivery",
+    name: "Hourly translation pull",
+    description: "Keep the repository in sync with completed translations throughout the day.",
+    instructions: [
+      "Pull newly completed translations from the translation system on an hourly cadence.",
+      "",
+      "Keep updates small and reviewable:",
+      "- Prefer incremental locale file updates over large batch rewrites.",
+      "- Flag conflicts between in-flight repo edits and pulled translations.",
+    ].join("\n"),
+    activatable: true,
+    defaultForm: {
+      name: "Hourly translation pull",
+      triggerMode: "scheduled",
+      scheduledCadence: "hourly",
+      scheduledTimezone: "UTC",
+      githubEnabled: true,
+      pullTranslationsEnabled: true,
+    },
+  },
+  {
+    id: "email-release-digest",
+    category: "translation-delivery",
+    name: "Email release digest",
+    description: "Email a weekly digest of translation delivery status to stakeholders.",
+    instructions: [
+      "Send a weekly email digest of translation delivery progress.",
+      "",
+      "Cover:",
+      "- Locales completed since the last digest.",
+      "- Languages still below release coverage.",
+      "- Pull requests or branches waiting on translations.",
+    ].join("\n"),
+    activatable: true,
+    defaultForm: {
+      name: "Email release digest",
+      triggerMode: "scheduled",
+      scheduledCadence: "weekly",
+      scheduledDayOfWeek: 5,
+      scheduledHourUtc: 16,
+      scheduledTimezone: "UTC",
+      githubEnabled: true,
+      pullTranslationsEnabled: true,
+      emailEnabled: true,
+    },
+  },
+  {
+    id: "pre-release-validation",
+    category: "release",
+    name: "Pre-release validation",
+    description: "Validate release branches every hour during release week.",
+    instructions: [
+      "Run pre-release localisation validation on active release branches.",
+      "",
+      "Escalate:",
+      "- Missing translations in release-critical flows.",
+      "- Placeholder or ICU regressions introduced during stabilization.",
+      "- Locale files that drift from approved source copy.",
+    ].join("\n"),
+    activatable: true,
+    defaultForm: {
+      name: "Pre-release validation",
+      triggerMode: "scheduled",
+      scheduledCadence: "hourly",
+      scheduledTimezone: "UTC",
+      githubEnabled: true,
+      validationEnabled: true,
+      slackEnabled: true,
+    },
+  },
+  {
+    id: "notify-on-push-blockers",
+    category: "popular",
+    name: "Notify on push blockers",
+    description: "Validate every push and ping Slack when localisation blockers are found.",
+    instructions: [
+      "Validate localisation changes on push and notify the team about blockers.",
+      "",
+      "Notify when:",
+      "- Required locales lose coverage.",
+      "- Placeholders, ICU syntax, or unsafe markup fail validation.",
+      "- Skip notifications for clean runs unless configured otherwise.",
+    ].join("\n"),
+    activatable: true,
+    defaultForm: {
+      name: "Notify on push blockers",
+      triggerMode: "github",
+      pushBranches: ["main"],
+      githubEnabled: true,
+      validationEnabled: true,
+      slackEnabled: true,
+    },
+  },
+  {
+    id: "create-localisation-job-brief",
+    category: "source-content",
+    name: "Create localisation job brief",
+    description:
+      "Generate a translator-ready brief from PRs, tickets, assets, or TMS jobs with context, screenshots, glossary terms, tone, priority, and deadlines.",
+    instructions: [
+      "Create a translator-ready localisation job brief from linked work items.",
+      "",
+      "Include:",
+      "- Product context from PRs, tickets, and linked assets.",
+      "- Screenshots, glossary terms, tone guidance, priority, and deadlines.",
+      "- Open questions or risks that could block translation quality.",
+    ].join("\n"),
+    activatable: false,
+    defaultForm: {
+      name: "Create localisation job brief",
+      triggerMode: "manual",
+      githubEnabled: true,
+      slackEnabled: true,
+    },
+  },
+  {
+    id: "add-context-to-tms-strings",
+    category: "source-content",
+    name: "Add context to TMS strings",
+    description:
+      "Attach PRs, tickets, screenshots, Figma frames, and usage notes to new source strings before translation starts.",
+    instructions: [
+      "Enrich new TMS source strings with product and design context before translation starts.",
+      "",
+      "Attach:",
+      "- Linked PRs, tickets, screenshots, and Figma frames.",
+      "- Usage notes, glossary references, and locale-sensitive constraints.",
+      "- Flags when context is missing or likely to cause rework.",
+    ].join("\n"),
+    activatable: false,
+    defaultForm: {
+      name: "Add context to TMS strings",
+      triggerMode: "github",
+      pushBranches: ["main"],
+      githubEnabled: true,
+      pushSourceEnabled: true,
+    },
+  },
+  {
+    id: "review-tms-translations",
+    category: "quality",
+    name: "Review TMS translations",
+    description:
+      "Check pending translations against glossary, placeholders, formatting, brand tone, and market-specific style rules.",
+    instructions: [
+      "Review pending TMS translations before they are approved for delivery.",
+      "",
+      "Check:",
+      "- Glossary adherence, placeholders, ICU syntax, and formatting.",
+      "- Brand tone and market-specific style rules.",
+      "- Non-blocking suggestions versus release-blocking issues.",
+    ].join("\n"),
+    activatable: false,
+    defaultForm: {
+      name: "Review TMS translations",
+      triggerMode: "scheduled",
+      scheduledCadence: "daily",
+      scheduledHourUtc: 9,
+      scheduledTimezone: "UTC",
+      githubEnabled: true,
+      validationEnabled: true,
+      slackEnabled: true,
+    },
+  },
+  {
+    id: "hyperlocalise-campaign-assets",
+    category: "translation-delivery",
+    name: "Hyperlocalise campaign assets",
+    description:
+      "Adapt campaign copy, CTA, tone, and visual direction for each market, then route approved copy into the TMS.",
+    instructions: [
+      "Hyperlocalise campaign assets for each target market.",
+      "",
+      "Adapt:",
+      "- Campaign copy, CTAs, tone, and visual direction per locale.",
+      "- Market-specific constraints from glossary and brand guidelines.",
+      "- Route approved copy into the TMS for translation and delivery.",
+    ].join("\n"),
+    activatable: false,
+    defaultForm: {
+      name: "Hyperlocalise campaign assets",
+      triggerMode: "manual",
+      githubEnabled: true,
+      pushSourceEnabled: true,
+      slackEnabled: true,
+    },
+  },
+  {
+    id: "publish-approved-translations",
+    category: "translation-delivery",
+    name: "Publish approved translations",
+    description:
+      "Pull reviewed translations from the TMS and deliver them into GitHub, CMS, app store metadata, or release workflows.",
+    instructions: [
+      "Publish approved translations from the TMS into downstream delivery targets.",
+      "",
+      "Deliver to:",
+      "- GitHub locale files, CMS content, app store metadata, or release workflows.",
+      "- Preserve placeholders, ICU syntax, and repository formatting conventions.",
+      "- Summarize locales published and any delivery blockers.",
+    ].join("\n"),
+    activatable: false,
+    defaultForm: {
+      name: "Publish approved translations",
+      triggerMode: "scheduled",
+      scheduledCadence: "daily",
+      scheduledHourUtc: 22,
+      scheduledTimezone: "UTC",
+      githubEnabled: true,
+      pullTranslationsEnabled: true,
+      slackEnabled: true,
     },
   },
 ];
 
+export type WorkspaceAutomationTemplateFlowNode = {
+  id: string;
+  label: string;
+};
+
+export type WorkspaceAutomationTemplateFlow = {
+  trigger: WorkspaceAutomationTemplateFlowNode;
+  tools: WorkspaceAutomationTemplateFlowNode[];
+};
+
+function scheduledTriggerLabel(form: Partial<WorkspaceAutomationFormState>) {
+  if (form.scheduledCadence === "hourly") {
+    return "Hourly";
+  }
+
+  if (form.scheduledCadence === "weekly") {
+    return "Weekly";
+  }
+
+  return "Daily";
+}
+
+export function getWorkspaceAutomationTemplateFlow(
+  template: WorkspaceAutomationTemplate,
+): WorkspaceAutomationTemplateFlow {
+  const form = template.defaultForm;
+  const triggerMode = form.triggerMode ?? "manual";
+
+  const trigger: WorkspaceAutomationTemplateFlowNode =
+    triggerMode === "github"
+      ? { id: "github-push", label: "GitHub push" }
+      : triggerMode === "scheduled"
+        ? { id: "scheduled", label: scheduledTriggerLabel(form) }
+        : { id: "manual", label: "Manual" };
+
+  const tools: WorkspaceAutomationTemplateFlowNode[] = [];
+
+  if (form.githubEnabled) {
+    if (form.pushSourceEnabled) {
+      tools.push({ id: "push-source", label: "Push source" });
+    }
+    if (form.pullTranslationsEnabled) {
+      tools.push({ id: "pull-translations", label: "Pull translations" });
+    }
+    if (form.validationEnabled) {
+      tools.push({ id: "validation", label: "Validation" });
+    }
+    if (!form.pushSourceEnabled && !form.pullTranslationsEnabled && !form.validationEnabled) {
+      tools.push({ id: "github", label: "GitHub" });
+    }
+  }
+
+  if (form.slackEnabled) {
+    tools.push({ id: "slack", label: "Slack" });
+  }
+
+  if (form.emailEnabled) {
+    tools.push({ id: "email", label: "Email" });
+  }
+
+  return { trigger, tools };
+}
+
 export function getWorkspaceAutomationTemplate(templateId: string) {
   return WORKSPACE_AUTOMATION_TEMPLATES.find((template) => template.id === templateId) ?? null;
+}
+
+export function getWorkspaceAutomationTemplateCategoryLabel(
+  category: WorkspaceAutomationTemplateCategory,
+) {
+  return (
+    WORKSPACE_AUTOMATION_TEMPLATE_CATEGORIES.find((entry) => entry.id === category)?.label ??
+    category
+  );
 }
 
 export function listWorkspaceAutomationTemplates(category?: WorkspaceAutomationTemplateCategory) {

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.test.ts
@@ -10,18 +10,28 @@ import {
 
 describe("workspace automation view model", () => {
   it("prefills the form from a template", () => {
-    const template = getWorkspaceAutomationTemplate("find-critical-bugs");
+    const template = getWorkspaceAutomationTemplate("validate-localisation-on-push");
     expect(template).not.toBeNull();
 
-    const form = createWorkspaceAutomationFormStateFromTemplate("find-critical-bugs");
+    const form = createWorkspaceAutomationFormStateFromTemplate("validate-localisation-on-push");
     expect(form).toMatchObject({
-      name: "Find critical bugs",
-      triggerMode: "scheduled",
+      name: "Validate localisation on push",
+      triggerMode: "github",
+      pushBranches: ["main"],
       githubEnabled: true,
       validationEnabled: true,
       slackEnabled: true,
     });
-    expect(form?.instructions).toContain("deep bug-finding automation");
+    expect(form?.instructions).toContain("localisation quality automation");
+  });
+
+  it("does not prefill coming-soon templates", () => {
+    expect(getWorkspaceAutomationTemplate("create-localisation-job-brief")?.activatable).toBe(
+      false,
+    );
+    expect(createWorkspaceAutomationFormStateFromTemplate("create-localisation-job-brief")).toBe(
+      null,
+    );
   });
 
   it("maps form state to API payload", () => {

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automation-view-model.ts
@@ -140,7 +140,7 @@ export function createWorkspaceAutomationFormStateFromTemplate(
   templateId: string,
 ): WorkspaceAutomationFormState | null {
   const template = getWorkspaceAutomationTemplate(templateId);
-  if (!template) {
+  if (!template?.activatable) {
     return null;
   }
 


### PR DESCRIPTION
## What changed

- Expanded the automations templates gallery: all templates in one grid with outline category badges, primary **Add** for activatable templates, and disabled **Coming soon** for roadmap workflows.
- Added five coming-soon workflow templates (job brief, TMS context, translation review, campaign hyperlocalisation, publish approved translations).
- Introduced template flow icons on cards and blocked prefilling from non-activatable templates.
- Refined automation create/detail editor layout and added Automations to workspace navigation.

## How to test

- Open `/org/{slug}/automations` and confirm templates render in a single grid with category badges and correct Add / Coming soon buttons.
- Click **Add** on an activatable template and confirm the new automation form prefills from the template.
- Open create/detail automation pages and confirm the editor layout and save flows still work.
- In apps/hyperlocalise-web: `vp test src/lib/agents/workspace-automation-view-model.test.ts` and `vp check --fix`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)