### PR TITLE
feat(web): add native TM and glossary management

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary.route.ts
@@ -9,7 +9,7 @@ import type { Glossary } from "@/lib/database/types";
 import { toGlossaryRecord } from "@/lib/glossary/glossary-records";
 import { listGlossaryTermsByGlossaryId } from "@/lib/glossary/query-glossary-terms";
 
-import { getOwnedProject } from "../project/project.shared";
+import { getOwnedProject, projectNotFoundResponse } from "../project/project.shared";
 import { buildGlossaryListWhere } from "./glossary-list-filters";
 import {
   attachGlossaryProjectBodySchema,
@@ -276,6 +276,49 @@ async function createGlossaryTerm(
   return term ?? null;
 }
 
+async function createGlossaryTerms(
+  glossary: Glossary,
+  payloads: CreateGlossaryTermBody[],
+): Promise<GlossaryTerm[]> {
+  if (payloads.length === 0) {
+    return [];
+  }
+
+  const existing = await db
+    .select({
+      sourceTerm: schema.glossaryTerms.sourceTerm,
+    })
+    .from(schema.glossaryTerms)
+    .where(eq(schema.glossaryTerms.glossaryId, glossary.id));
+  const seenSourceTerms = new Set(existing.map((term) => term.sourceTerm.toLowerCase()));
+  const values: (typeof schema.glossaryTerms.$inferInsert)[] = [];
+
+  for (const payload of payloads) {
+    const sourceTermKey = payload.caseSensitive
+      ? payload.sourceTerm
+      : payload.sourceTerm.toLowerCase();
+    if (seenSourceTerms.has(sourceTermKey)) {
+      continue;
+    }
+    seenSourceTerms.add(sourceTermKey);
+    values.push({
+      glossaryId: glossary.id,
+      sourceTerm: payload.sourceTerm,
+      targetTerm: payload.targetTerm,
+      description: payload.description ?? "",
+      partOfSpeech: payload.partOfSpeech ?? "",
+      caseSensitive: payload.caseSensitive,
+      forbidden: payload.forbidden,
+    });
+  }
+
+  if (values.length === 0) {
+    return [];
+  }
+
+  return db.insert(schema.glossaryTerms).values(values).onConflictDoNothing().returning();
+}
+
 async function listGlossaryProjects(
   auth: ApiAuthContext,
   glossaryId: string,
@@ -494,19 +537,18 @@ export function createGlossaryRoutes() {
         }
 
         const terms = parseGlossaryImport(payload);
-        const created: GlossaryTermRecord[] = [];
-        let skipped = 0;
+        const limitedTerms = terms.slice(0, 2_000);
+        const created = await createGlossaryTerms(glossary, limitedTerms);
+        const skipped = limitedTerms.length - created.length;
 
-        for (const termPayload of terms.slice(0, 2_000)) {
-          const term = await createGlossaryTerm(glossary, termPayload);
-          if (term) {
-            created.push(toGlossaryTermRecord(term, glossary));
-          } else {
-            skipped++;
-          }
-        }
-
-        return c.json({ glossaryTerms: created, imported: created.length, skipped }, 201);
+        return c.json(
+          {
+            glossaryTerms: created.map((term) => toGlossaryTermRecord(term, glossary)),
+            imported: created.length,
+            skipped,
+          },
+          201,
+        );
       },
     )
     .patch(
@@ -633,7 +675,7 @@ export function createGlossaryRoutes() {
           return glossaryNotFoundResponse(c);
         }
         if (!project) {
-          return glossaryNotFoundResponse(c);
+          return projectNotFoundResponse(c);
         }
 
         await db
@@ -667,7 +709,7 @@ export function createGlossaryRoutes() {
         return glossaryNotFoundResponse(c);
       }
       if (!project) {
-        return glossaryNotFoundResponse(c);
+        return projectNotFoundResponse(c);
       }
 
       await db

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary.route.ts
@@ -1,20 +1,31 @@
-import { count, desc } from "drizzle-orm";
+import { and, count, desc, eq, ne, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { validator } from "hono/validator";
 
 import { workosAuthMiddleware, type ApiAuthContext, type AuthVariables } from "@/api/auth/workos";
+import { conflictResponse } from "@/api/errors";
 import { db, schema } from "@/lib/database";
 import type { Glossary } from "@/lib/database/types";
 import { toGlossaryRecord } from "@/lib/glossary/glossary-records";
 import { listGlossaryTermsByGlossaryId } from "@/lib/glossary/query-glossary-terms";
 
+import { getOwnedProject } from "../project/project.shared";
 import { buildGlossaryListWhere } from "./glossary-list-filters";
 import {
+  attachGlossaryProjectBodySchema,
   createGlossaryBodySchema,
+  createGlossaryTermBodySchema,
   glossaryIdParamsSchema,
+  glossaryProjectParamsSchema,
+  glossaryTermIdParamsSchema,
+  importGlossaryTermsBodySchema,
   listGlossaryQuerySchema,
   updateGlossaryBodySchema,
+  updateGlossaryTermBodySchema,
+  type AttachGlossaryProjectBody,
   type CreateGlossaryBody,
+  type CreateGlossaryTermBody,
+  type ImportGlossaryTermsBody,
   type ListGlossaryQuery,
   type UpdateGlossaryBody,
 } from "./glossary.schema";
@@ -43,6 +54,32 @@ type GlossaryStore = {
     payload: UpdateGlossaryBody,
   ): Promise<Glossary | null>;
   delete(auth: ApiAuthContext, glossaryId: string): Promise<boolean>;
+};
+
+type GlossaryTerm = typeof schema.glossaryTerms.$inferSelect;
+
+type GlossaryTermRecord = {
+  id: string;
+  glossaryId: string;
+  glossaryName: string;
+  sourceTerm: string;
+  targetTerm: string;
+  targetLocale: string;
+  description: string;
+  partOfSpeech: string;
+  forbidden: boolean;
+  caseSensitive: boolean;
+  provenance: string;
+  externalKey: string | null;
+  reviewStatus: string;
+};
+
+type GlossaryProjectRecord = {
+  projectId: string;
+  projectName: string;
+  priority: number;
+  sourceLocale: string | null;
+  targetLocales: string[];
 };
 
 const glossaryStore: GlossaryStore = {
@@ -101,6 +138,167 @@ const glossaryStore: GlossaryStore = {
   },
 };
 
+function toGlossaryTermRecord(term: GlossaryTerm, glossary: Glossary): GlossaryTermRecord {
+  return {
+    id: term.id,
+    glossaryId: term.glossaryId,
+    glossaryName: glossary.name,
+    sourceTerm: term.sourceTerm,
+    targetTerm: term.targetTerm,
+    targetLocale: glossary.targetLocale,
+    description: term.description,
+    partOfSpeech: term.partOfSpeech,
+    forbidden: term.forbidden,
+    caseSensitive: term.caseSensitive,
+    provenance: term.provenance,
+    externalKey: term.externalKey,
+    reviewStatus: term.reviewStatus,
+  };
+}
+
+function parseCsvRows(content: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let cell = "";
+  let quoted = false;
+
+  for (let index = 0; index < content.length; index++) {
+    const char = content[index];
+    const next = content[index + 1];
+
+    if (char === '"' && quoted && next === '"') {
+      cell += '"';
+      index++;
+      continue;
+    }
+    if (char === '"') {
+      quoted = !quoted;
+      continue;
+    }
+    if (char === "," && !quoted) {
+      row.push(cell.trim());
+      cell = "";
+      continue;
+    }
+    if ((char === "\n" || char === "\r") && !quoted) {
+      if (char === "\r" && next === "\n") index++;
+      row.push(cell.trim());
+      if (row.some(Boolean)) rows.push(row);
+      row = [];
+      cell = "";
+      continue;
+    }
+    cell += char;
+  }
+
+  row.push(cell.trim());
+  if (row.some(Boolean)) rows.push(row);
+  return rows;
+}
+
+function parseGlossaryImport(payload: ImportGlossaryTermsBody): CreateGlossaryTermBody[] {
+  if (payload.format === "csv") {
+    const rows = parseCsvRows(payload.content);
+    const [first, ...rest] = rows;
+    const hasHeader = first?.some((cell) => /source|target|term/i.test(cell)) ?? false;
+    const dataRows = hasHeader ? rest : rows;
+
+    return dataRows.flatMap((row) => {
+      const [sourceTerm, targetTerm, description = "", partOfSpeech = ""] = row;
+      return sourceTerm && targetTerm
+        ? [
+            {
+              sourceTerm,
+              targetTerm,
+              description,
+              partOfSpeech,
+              caseSensitive: false,
+              forbidden: false,
+            },
+          ]
+        : [];
+    });
+  }
+
+  const entries = [...payload.content.matchAll(/<termEntry\b[\s\S]*?<\/termEntry>/gi)];
+  return entries.flatMap((entry) => {
+    const terms = [...entry[0].matchAll(/<term\b[^>]*>([\s\S]*?)<\/term>/gi)].map((match) =>
+      match[1]?.replace(/<[^>]*>/g, "").trim(),
+    );
+    const [sourceTerm, targetTerm] = terms.filter(Boolean) as string[];
+    return sourceTerm && targetTerm
+      ? [
+          {
+            sourceTerm,
+            targetTerm,
+            description: "",
+            partOfSpeech: "",
+            caseSensitive: false,
+            forbidden: false,
+          },
+        ]
+      : [];
+  });
+}
+
+async function createGlossaryTerm(
+  glossary: Glossary,
+  payload: CreateGlossaryTermBody,
+): Promise<GlossaryTerm | null> {
+  const duplicateCheck = payload.caseSensitive
+    ? eq(schema.glossaryTerms.sourceTerm, payload.sourceTerm)
+    : sql`lower(${schema.glossaryTerms.sourceTerm}) = lower(${payload.sourceTerm})`;
+
+  const existing = await db
+    .select({ id: schema.glossaryTerms.id })
+    .from(schema.glossaryTerms)
+    .where(and(eq(schema.glossaryTerms.glossaryId, glossary.id), duplicateCheck))
+    .limit(1);
+
+  if (existing.length > 0) {
+    return null;
+  }
+
+  const [term] = await db
+    .insert(schema.glossaryTerms)
+    .values({
+      glossaryId: glossary.id,
+      sourceTerm: payload.sourceTerm,
+      targetTerm: payload.targetTerm,
+      description: payload.description ?? "",
+      partOfSpeech: payload.partOfSpeech ?? "",
+      caseSensitive: payload.caseSensitive,
+      forbidden: payload.forbidden,
+    })
+    .onConflictDoNothing()
+    .returning();
+
+  return term ?? null;
+}
+
+async function listGlossaryProjects(
+  auth: ApiAuthContext,
+  glossaryId: string,
+): Promise<GlossaryProjectRecord[]> {
+  return db
+    .select({
+      projectId: schema.projects.id,
+      projectName: schema.projects.name,
+      priority: schema.projectGlossaries.priority,
+      sourceLocale: schema.projects.sourceLocale,
+      targetLocales: schema.projects.targetLocales,
+    })
+    .from(schema.projectGlossaries)
+    .innerJoin(schema.projects, eq(schema.projectGlossaries.projectId, schema.projects.id))
+    .where(
+      and(
+        eq(schema.projectGlossaries.organizationId, auth.organization.localOrganizationId),
+        eq(schema.projectGlossaries.glossaryId, glossaryId),
+      ),
+    )
+    .orderBy(schema.projectGlossaries.priority, schema.projects.name);
+}
+
 const validateGlossaryParams = validator("param", (value, c) => {
   const parsed = glossaryIdParamsSchema.safeParse(value);
 
@@ -111,8 +309,68 @@ const validateGlossaryParams = validator("param", (value, c) => {
   return parsed.data;
 });
 
+const validateGlossaryTermParams = validator("param", (value, c) => {
+  const parsed = glossaryTermIdParamsSchema.safeParse(value);
+
+  if (!parsed.success) {
+    return glossaryNotFoundResponse(c);
+  }
+
+  return parsed.data;
+});
+
+const validateGlossaryProjectParams = validator("param", (value, c) => {
+  const parsed = glossaryProjectParamsSchema.safeParse(value);
+
+  if (!parsed.success) {
+    return glossaryNotFoundResponse(c);
+  }
+
+  return parsed.data;
+});
+
 const validateCreateGlossaryBody = validator("json", (value, c) => {
   const parsed = createGlossaryBodySchema.safeParse(value);
+
+  if (!parsed.success) {
+    return invalidGlossaryPayloadResponse(c);
+  }
+
+  return parsed.data;
+});
+
+const validateCreateGlossaryTermBody = validator("json", (value, c) => {
+  const parsed = createGlossaryTermBodySchema.safeParse(value);
+
+  if (!parsed.success) {
+    return invalidGlossaryPayloadResponse(c);
+  }
+
+  return parsed.data;
+});
+
+const validateUpdateGlossaryTermBody = validator("json", (value, c) => {
+  const parsed = updateGlossaryTermBodySchema.safeParse(value);
+
+  if (!parsed.success) {
+    return invalidGlossaryPayloadResponse(c);
+  }
+
+  return parsed.data;
+});
+
+const validateImportGlossaryTermsBody = validator("json", (value, c) => {
+  const parsed = importGlossaryTermsBodySchema.safeParse(value);
+
+  if (!parsed.success) {
+    return invalidGlossaryPayloadResponse(c);
+  }
+
+  return parsed.data;
+});
+
+const validateAttachGlossaryProjectBody = validator("json", (value, c) => {
+  const parsed = attachGlossaryProjectBodySchema.safeParse(value);
 
   if (!parsed.success) {
     return invalidGlossaryPayloadResponse(c);
@@ -181,7 +439,251 @@ export function createGlossaryRoutes() {
         glossaryId: params.glossaryId,
       });
 
-      return c.json({ glossaryTerms }, 200);
+      return c.json({ glossaryTerms, total: glossaryTerms.length }, 200);
+    })
+    .post(
+      "/:glossaryId/terms",
+      validateGlossaryParams,
+      validateCreateGlossaryTermBody,
+      async (c) => {
+        if (!isGlossaryMutationAllowed(c.var.auth.membership.role)) {
+          return forbiddenResponse(c);
+        }
+
+        const params = c.req.valid("param");
+        const payload = c.req.valid("json");
+        const glossary = await glossaryStore.getById(c.var.auth, params.glossaryId);
+
+        if (!glossary) {
+          return glossaryNotFoundResponse(c);
+        }
+        if (glossary.source === "external_tms") {
+          return externalTmsGlossaryImmutableResponse(c);
+        }
+
+        const term = await createGlossaryTerm(glossary, payload);
+        if (!term) {
+          return conflictResponse(
+            c,
+            "duplicate_glossary_term",
+            "A term with this source text already exists",
+          );
+        }
+
+        return c.json({ glossaryTerm: toGlossaryTermRecord(term, glossary) }, 201);
+      },
+    )
+    .post(
+      "/:glossaryId/terms/import",
+      validateGlossaryParams,
+      validateImportGlossaryTermsBody,
+      async (c) => {
+        if (!isGlossaryMutationAllowed(c.var.auth.membership.role)) {
+          return forbiddenResponse(c);
+        }
+
+        const params = c.req.valid("param");
+        const payload = c.req.valid("json");
+        const glossary = await glossaryStore.getById(c.var.auth, params.glossaryId);
+
+        if (!glossary) {
+          return glossaryNotFoundResponse(c);
+        }
+        if (glossary.source === "external_tms") {
+          return externalTmsGlossaryImmutableResponse(c);
+        }
+
+        const terms = parseGlossaryImport(payload);
+        const created: GlossaryTermRecord[] = [];
+        let skipped = 0;
+
+        for (const termPayload of terms.slice(0, 2_000)) {
+          const term = await createGlossaryTerm(glossary, termPayload);
+          if (term) {
+            created.push(toGlossaryTermRecord(term, glossary));
+          } else {
+            skipped++;
+          }
+        }
+
+        return c.json({ glossaryTerms: created, imported: created.length, skipped }, 201);
+      },
+    )
+    .patch(
+      "/:glossaryId/terms/:termId",
+      validateGlossaryTermParams,
+      validateUpdateGlossaryTermBody,
+      async (c) => {
+        if (!isGlossaryMutationAllowed(c.var.auth.membership.role)) {
+          return forbiddenResponse(c);
+        }
+
+        const params = c.req.valid("param");
+        const payload = c.req.valid("json");
+        const glossary = await glossaryStore.getById(c.var.auth, params.glossaryId);
+
+        if (!glossary) {
+          return glossaryNotFoundResponse(c);
+        }
+        if (glossary.source === "external_tms") {
+          return externalTmsGlossaryImmutableResponse(c);
+        }
+
+        if (payload.sourceTerm !== undefined) {
+          const duplicateCheck = payload.caseSensitive
+            ? eq(schema.glossaryTerms.sourceTerm, payload.sourceTerm)
+            : sql`lower(${schema.glossaryTerms.sourceTerm}) = lower(${payload.sourceTerm})`;
+          const existing = await db
+            .select({ id: schema.glossaryTerms.id })
+            .from(schema.glossaryTerms)
+            .where(
+              and(
+                eq(schema.glossaryTerms.glossaryId, glossary.id),
+                ne(schema.glossaryTerms.id, params.termId),
+                duplicateCheck,
+              ),
+            )
+            .limit(1);
+
+          if (existing.length > 0) {
+            return conflictResponse(
+              c,
+              "duplicate_glossary_term",
+              "A term with this source text already exists",
+            );
+          }
+        }
+
+        const [term] = await db
+          .update(schema.glossaryTerms)
+          .set(payload)
+          .where(
+            and(
+              eq(schema.glossaryTerms.id, params.termId),
+              eq(schema.glossaryTerms.glossaryId, glossary.id),
+            ),
+          )
+          .returning();
+
+        if (!term) {
+          return glossaryNotFoundResponse(c);
+        }
+
+        return c.json({ glossaryTerm: toGlossaryTermRecord(term, glossary) }, 200);
+      },
+    )
+    .delete("/:glossaryId/terms/:termId", validateGlossaryTermParams, async (c) => {
+      if (!isGlossaryMutationAllowed(c.var.auth.membership.role)) {
+        return forbiddenResponse(c);
+      }
+
+      const params = c.req.valid("param");
+      const glossary = await glossaryStore.getById(c.var.auth, params.glossaryId);
+
+      if (!glossary) {
+        return glossaryNotFoundResponse(c);
+      }
+      if (glossary.source === "external_tms") {
+        return externalTmsGlossaryImmutableResponse(c);
+      }
+
+      const deleted = await db
+        .delete(schema.glossaryTerms)
+        .where(
+          and(
+            eq(schema.glossaryTerms.id, params.termId),
+            eq(schema.glossaryTerms.glossaryId, glossary.id),
+          ),
+        )
+        .returning({ id: schema.glossaryTerms.id });
+
+      if (deleted.length === 0) {
+        return glossaryNotFoundResponse(c);
+      }
+
+      return c.body(null, 204);
+    })
+    .get("/:glossaryId/projects", validateGlossaryParams, async (c) => {
+      const params = c.req.valid("param");
+      const glossary = await glossaryStore.getById(c.var.auth, params.glossaryId);
+
+      if (!glossary) {
+        return glossaryNotFoundResponse(c);
+      }
+
+      return c.json({ projects: await listGlossaryProjects(c.var.auth, params.glossaryId) }, 200);
+    })
+    .post(
+      "/:glossaryId/projects",
+      validateGlossaryParams,
+      validateAttachGlossaryProjectBody,
+      async (c) => {
+        if (!isGlossaryMutationAllowed(c.var.auth.membership.role)) {
+          return forbiddenResponse(c);
+        }
+
+        const params = c.req.valid("param");
+        const payload: AttachGlossaryProjectBody = c.req.valid("json");
+        const [glossary, project] = await Promise.all([
+          glossaryStore.getById(c.var.auth, params.glossaryId),
+          getOwnedProject(c.var.auth, payload.projectId),
+        ]);
+
+        if (!glossary) {
+          return glossaryNotFoundResponse(c);
+        }
+        if (!project) {
+          return glossaryNotFoundResponse(c);
+        }
+
+        await db
+          .insert(schema.projectGlossaries)
+          .values({
+            organizationId: c.var.auth.organization.localOrganizationId,
+            projectId: project.id,
+            glossaryId: glossary.id,
+            priority: payload.priority,
+          })
+          .onConflictDoUpdate({
+            target: [schema.projectGlossaries.projectId, schema.projectGlossaries.glossaryId],
+            set: { priority: payload.priority },
+          });
+
+        return c.json({ projects: await listGlossaryProjects(c.var.auth, params.glossaryId) }, 200);
+      },
+    )
+    .delete("/:glossaryId/projects/:projectId", validateGlossaryProjectParams, async (c) => {
+      if (!isGlossaryMutationAllowed(c.var.auth.membership.role)) {
+        return forbiddenResponse(c);
+      }
+
+      const params = c.req.valid("param");
+      const [glossary, project] = await Promise.all([
+        glossaryStore.getById(c.var.auth, params.glossaryId),
+        getOwnedProject(c.var.auth, params.projectId),
+      ]);
+
+      if (!glossary) {
+        return glossaryNotFoundResponse(c);
+      }
+      if (!project) {
+        return glossaryNotFoundResponse(c);
+      }
+
+      await db
+        .delete(schema.projectGlossaries)
+        .where(
+          and(
+            eq(
+              schema.projectGlossaries.organizationId,
+              c.var.auth.organization.localOrganizationId,
+            ),
+            eq(schema.projectGlossaries.projectId, project.id),
+            eq(schema.projectGlossaries.glossaryId, glossary.id),
+          ),
+        );
+
+      return c.body(null, 204);
     })
     .patch("/:glossaryId", validateGlossaryParams, validateUpdateGlossaryBody, async (c) => {
       if (!isGlossaryMutationAllowed(c.var.auth.membership.role)) {

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary.route.ts
@@ -4,8 +4,10 @@ import { validator } from "hono/validator";
 
 import { workosAuthMiddleware, type ApiAuthContext, type AuthVariables } from "@/api/auth/workos";
 import { conflictResponse } from "@/api/errors";
+import { parseCsvRows } from "@/lib/csv/parse-csv-rows";
 import { db, schema } from "@/lib/database";
 import type { Glossary } from "@/lib/database/types";
+import { createGlossaryTermDuplicateTracker } from "@/lib/glossary/glossary-term-dedupe";
 import { toGlossaryRecord } from "@/lib/glossary/glossary-records";
 import { listGlossaryTermsByGlossaryId } from "@/lib/glossary/query-glossary-terms";
 
@@ -156,46 +158,6 @@ function toGlossaryTermRecord(term: GlossaryTerm, glossary: Glossary): GlossaryT
   };
 }
 
-function parseCsvRows(content: string): string[][] {
-  const rows: string[][] = [];
-  let row: string[] = [];
-  let cell = "";
-  let quoted = false;
-
-  for (let index = 0; index < content.length; index++) {
-    const char = content[index];
-    const next = content[index + 1];
-
-    if (char === '"' && quoted && next === '"') {
-      cell += '"';
-      index++;
-      continue;
-    }
-    if (char === '"') {
-      quoted = !quoted;
-      continue;
-    }
-    if (char === "," && !quoted) {
-      row.push(cell.trim());
-      cell = "";
-      continue;
-    }
-    if ((char === "\n" || char === "\r") && !quoted) {
-      if (char === "\r" && next === "\n") index++;
-      row.push(cell.trim());
-      if (row.some(Boolean)) rows.push(row);
-      row = [];
-      cell = "";
-      continue;
-    }
-    cell += char;
-  }
-
-  row.push(cell.trim());
-  if (row.some(Boolean)) rows.push(row);
-  return rows;
-}
-
 function parseGlossaryImport(payload: ImportGlossaryTermsBody): CreateGlossaryTermBody[] {
   if (payload.format === "csv") {
     const rows = parseCsvRows(payload.content);
@@ -290,17 +252,13 @@ async function createGlossaryTerms(
     })
     .from(schema.glossaryTerms)
     .where(eq(schema.glossaryTerms.glossaryId, glossary.id));
-  const seenSourceTerms = new Set(existing.map((term) => term.sourceTerm.toLowerCase()));
+  const duplicateTracker = createGlossaryTermDuplicateTracker(existing);
   const values: (typeof schema.glossaryTerms.$inferInsert)[] = [];
 
   for (const payload of payloads) {
-    const sourceTermKey = payload.caseSensitive
-      ? payload.sourceTerm
-      : payload.sourceTerm.toLowerCase();
-    if (seenSourceTerms.has(sourceTermKey)) {
+    if (duplicateTracker.hasDuplicateAndTrack(payload)) {
       continue;
     }
-    seenSourceTerms.add(sourceTermKey);
     values.push({
       glossaryId: glossary.id,
       sourceTerm: payload.sourceTerm,

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary.route.ts
@@ -223,7 +223,7 @@ function parseGlossaryImport(payload: ImportGlossaryTermsBody): CreateGlossaryTe
   const entries = [...payload.content.matchAll(/<termEntry\b[\s\S]*?<\/termEntry>/gi)];
   return entries.flatMap((entry) => {
     const terms = [...entry[0].matchAll(/<term\b[^>]*>([\s\S]*?)<\/term>/gi)].map((match) =>
-      match[1]?.replace(/<[^>]*>/g, "").trim(),
+      match[1]?.replace(/[<>]/g, "").trim(),
     );
     const [sourceTerm, targetTerm] = terms.filter(Boolean) as string[];
     return sourceTerm && targetTerm

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary.schema.ts
@@ -6,6 +6,14 @@ export const glossaryIdParamsSchema = z.object({
   glossaryId: z.string().trim().min(1).max(128),
 });
 
+export const glossaryTermIdParamsSchema = glossaryIdParamsSchema.extend({
+  termId: z.string().trim().min(1).max(128),
+});
+
+export const glossaryProjectParamsSchema = glossaryIdParamsSchema.extend({
+  projectId: z.string().trim().min(1).max(128),
+});
+
 export const listGlossaryQuerySchema = z
   .object({
     limit: z.coerce.number().int().min(1).max(100).default(50),
@@ -43,6 +51,47 @@ export const updateGlossaryBodySchema = z
     },
   );
 
+export const createGlossaryTermBodySchema = z.object({
+  sourceTerm: z.string().trim().min(1).max(1_000),
+  targetTerm: z.string().trim().min(1).max(1_000),
+  description: z.string().max(10_000).optional(),
+  partOfSpeech: z.string().max(200).optional(),
+  caseSensitive: z.boolean().optional().default(false),
+  forbidden: z.boolean().optional().default(false),
+});
+
+export const updateGlossaryTermBodySchema = z
+  .object({
+    sourceTerm: z.string().trim().min(1).max(1_000).optional(),
+    targetTerm: z.string().trim().min(1).max(1_000).optional(),
+    description: z.string().max(10_000).optional(),
+    partOfSpeech: z.string().max(200).optional(),
+    caseSensitive: z.boolean().optional(),
+    forbidden: z.boolean().optional(),
+  })
+  .refine(
+    (value) =>
+      value.sourceTerm !== undefined ||
+      value.targetTerm !== undefined ||
+      value.description !== undefined ||
+      value.partOfSpeech !== undefined ||
+      value.caseSensitive !== undefined ||
+      value.forbidden !== undefined,
+    {
+      message: "at least one field must be provided",
+    },
+  );
+
+export const importGlossaryTermsBodySchema = z.object({
+  format: z.enum(["csv", "tbx"]),
+  content: z.string().min(1).max(5_000_000),
+});
+
+export const attachGlossaryProjectBodySchema = z.object({
+  projectId: z.string().trim().min(1).max(128),
+  priority: z.number().int().min(0).max(10_000).optional().default(0),
+});
+
 export const glossaryRecordSchema = z.object({
   id: z.string(),
   organizationId: z.string(),
@@ -77,6 +126,7 @@ export const glossaryTermRecordSchema = z.object({
   targetTerm: z.string(),
   targetLocale: z.string(),
   description: z.string(),
+  partOfSpeech: z.string().optional(),
   forbidden: z.boolean(),
   caseSensitive: z.boolean(),
   provenance: z.string(),
@@ -84,8 +134,20 @@ export const glossaryTermRecordSchema = z.object({
   reviewStatus: z.string(),
 });
 
+export const glossaryProjectRecordSchema = z.object({
+  projectId: z.string(),
+  projectName: z.string(),
+  priority: z.number().int(),
+  sourceLocale: z.string().nullable(),
+  targetLocales: z.array(z.string()),
+});
+
 export const glossaryResponseSchema = z.object({
   glossary: glossaryRecordSchema,
+});
+
+export const glossaryTermResponseSchema = z.object({
+  glossaryTerm: glossaryTermRecordSchema,
 });
 
 export const glossariesResponseSchema = z.object({
@@ -95,14 +157,28 @@ export const glossariesResponseSchema = z.object({
 
 export const glossaryTermsResponseSchema = z.object({
   glossaryTerms: z.array(glossaryTermRecordSchema),
+  total: z.number().int().nonnegative().optional(),
+});
+
+export const glossaryProjectsResponseSchema = z.object({
+  projects: z.array(glossaryProjectRecordSchema),
 });
 
 export type GlossaryIdParams = z.infer<typeof glossaryIdParamsSchema>;
+export type GlossaryTermIdParams = z.infer<typeof glossaryTermIdParamsSchema>;
+export type GlossaryProjectParams = z.infer<typeof glossaryProjectParamsSchema>;
 export type ListGlossaryQuery = z.infer<typeof listGlossaryQuerySchema>;
 export type CreateGlossaryBody = z.infer<typeof createGlossaryBodySchema>;
 export type UpdateGlossaryBody = z.infer<typeof updateGlossaryBodySchema>;
+export type CreateGlossaryTermBody = z.infer<typeof createGlossaryTermBodySchema>;
+export type UpdateGlossaryTermBody = z.infer<typeof updateGlossaryTermBodySchema>;
+export type ImportGlossaryTermsBody = z.infer<typeof importGlossaryTermsBodySchema>;
+export type AttachGlossaryProjectBody = z.infer<typeof attachGlossaryProjectBodySchema>;
 export type GlossaryRecord = z.infer<typeof glossaryRecordSchema>;
 export type GlossaryResponse = z.infer<typeof glossaryResponseSchema>;
+export type GlossaryTermResponse = z.infer<typeof glossaryTermResponseSchema>;
 export type GlossariesResponse = z.infer<typeof glossariesResponseSchema>;
 export type GlossaryTermRecord = z.infer<typeof glossaryTermRecordSchema>;
 export type GlossaryTermsResponse = z.infer<typeof glossaryTermsResponseSchema>;
+export type GlossaryProjectRecord = z.infer<typeof glossaryProjectRecordSchema>;
+export type GlossaryProjectsResponse = z.infer<typeof glossaryProjectsResponseSchema>;

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary.test.ts
@@ -6,7 +6,7 @@ import { testClient } from "hono/testing";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
 
 import { app } from "@/api/app";
-import { db } from "@/lib/database";
+import { db, schema } from "@/lib/database";
 import { upsertOrganizationExternalTmsGlossary } from "@/lib/providers/sync/organization-external-tms-glossaries";
 import { upsertOrganizationExternalTmsProviderCredential } from "@/lib/providers/organization-external-tms-provider-credentials";
 
@@ -723,6 +723,104 @@ describe("glossaryRoutes", () => {
     expect(deleteResponse.status).toBe(403);
     await expect(deleteResponse.json()).resolves.toMatchObject({
       error: "external_tms_glossary_immutable",
+    });
+  });
+
+  it("manages native glossary terms and project assignment", async () => {
+    const { identity, organization, user, glossary } =
+      await glossaryFixture.createStoredGlossaryFixture();
+    const headers = await authHeadersFor(identity);
+
+    const createTermResponse = await client.api.orgs[":organizationSlug"].glossaries[
+      ":glossaryId"
+    ].terms.$post(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          glossaryId: glossary.id,
+        },
+        json: {
+          sourceTerm: "checkout",
+          targetTerm: "paiement",
+          description: "Commerce funnel term",
+          partOfSpeech: "noun",
+          caseSensitive: false,
+          forbidden: false,
+        },
+      },
+      { headers },
+    );
+    expect(createTermResponse.status).toBe(201);
+    const createTermBody = await createTermResponse.json();
+    if ("error" in createTermBody) throw new Error(String(createTermBody.error));
+    expect(createTermBody.glossaryTerm).toMatchObject({
+      sourceTerm: "checkout",
+      targetTerm: "paiement",
+    });
+
+    const updateTermResponse = await client.api.orgs[":organizationSlug"].glossaries[
+      ":glossaryId"
+    ].terms[":termId"].$patch(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          glossaryId: glossary.id,
+          termId: createTermBody.glossaryTerm.id,
+        },
+        json: { targetTerm: "caisse" },
+      },
+      { headers },
+    );
+    expect(updateTermResponse.status).toBe(200);
+    await expect(updateTermResponse.json()).resolves.toMatchObject({
+      glossaryTerm: expect.objectContaining({ targetTerm: "caisse" }),
+    });
+
+    const importResponse = await client.api.orgs[":organizationSlug"].glossaries[
+      ":glossaryId"
+    ].terms["import"].$post(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          glossaryId: glossary.id,
+        },
+        json: {
+          format: "csv",
+          content: "sourceTerm,targetTerm\ncart,panier",
+        },
+      },
+      { headers },
+    );
+    expect(importResponse.status).toBe(201);
+    await expect(importResponse.json()).resolves.toMatchObject({ imported: 1 });
+
+    const [project] = await db
+      .insert(schema.projects)
+      .values({
+        id: `project_${randomUUID()}`,
+        organizationId: organization.id,
+        createdByUserId: user.id,
+        name: "Website",
+        sourceLocale: "en",
+        targetLocales: ["fr"],
+      })
+      .returning();
+
+    const attachResponse = await client.api.orgs[":organizationSlug"].glossaries[
+      ":glossaryId"
+    ].projects.$post(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          glossaryId: glossary.id,
+        },
+        json: { projectId: project.id, priority: 0 },
+      },
+      { headers },
+    );
+    expect(attachResponse.status).toBe(200);
+    await expect(attachResponse.json()).resolves.toMatchObject({
+      projects: [expect.objectContaining({ projectId: project.id, projectName: "Website" })],
     });
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/glossary/glossary.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/glossary/glossary.test.ts
@@ -726,6 +726,39 @@ describe("glossaryRoutes", () => {
     });
   });
 
+  it("returns project_not_found when assigning an unknown project to a glossary", async () => {
+    const { identity, glossary } = await glossaryFixture.createStoredGlossaryFixture();
+    const headers = await authHeadersFor(identity);
+    const param = {
+      organizationSlug: identity.organization.slug ?? "missing-slug",
+      glossaryId: glossary.id,
+    };
+    const projectId = `project_${randomUUID()}`;
+
+    const attachResponse = await client.api.orgs[":organizationSlug"].glossaries[
+      ":glossaryId"
+    ].projects.$post(
+      {
+        param,
+        json: { projectId, priority: 0 },
+      },
+      { headers },
+    );
+    expect(attachResponse.status).toBe(404);
+    await expect(attachResponse.json()).resolves.toMatchObject({ error: "project_not_found" });
+
+    const detachResponse = await client.api.orgs[":organizationSlug"].glossaries[
+      ":glossaryId"
+    ].projects[":projectId"].$delete(
+      {
+        param: { ...param, projectId },
+      },
+      { headers },
+    );
+    expect(detachResponse.status).toBe(404);
+    await expect(detachResponse.json()).resolves.toMatchObject({ error: "project_not_found" });
+  });
+
   it("manages native glossary terms and project assignment", async () => {
     const { identity, organization, user, glossary } =
       await glossaryFixture.createStoredGlossaryFixture();
@@ -786,13 +819,13 @@ describe("glossaryRoutes", () => {
         },
         json: {
           format: "csv",
-          content: "sourceTerm,targetTerm\ncart,panier",
+          content: "sourceTerm,targetTerm\ncart,panier\nCart,chariot",
         },
       },
       { headers },
     );
     expect(importResponse.status).toBe(201);
-    await expect(importResponse.json()).resolves.toMatchObject({ imported: 1 });
+    await expect(importResponse.json()).resolves.toMatchObject({ imported: 1, skipped: 1 });
 
     const [project] = await db
       .insert(schema.projects)

--- a/apps/hyperlocalise-web/src/api/routes/memory/memory.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/memory/memory.route.ts
@@ -6,6 +6,7 @@ import { validator } from "hono/validator";
 
 import { workosAuthMiddleware, type ApiAuthContext, type AuthVariables } from "@/api/auth/workos";
 import { conflictResponse } from "@/api/errors";
+import { parseCsvRows } from "@/lib/csv/parse-csv-rows";
 import { db, schema } from "@/lib/database";
 import type { Memory } from "@/lib/database/types";
 import { toMemoryRecord } from "@/lib/memory/memory-records";
@@ -152,46 +153,6 @@ function toMemoryEntryRecord(entry: MemoryEntry): MemoryEntryRecord {
   };
 }
 
-function parseCsvRows(content: string): string[][] {
-  const rows: string[][] = [];
-  let row: string[] = [];
-  let cell = "";
-  let quoted = false;
-
-  for (let index = 0; index < content.length; index++) {
-    const char = content[index];
-    const next = content[index + 1];
-
-    if (char === '"' && quoted && next === '"') {
-      cell += '"';
-      index++;
-      continue;
-    }
-    if (char === '"') {
-      quoted = !quoted;
-      continue;
-    }
-    if (char === "," && !quoted) {
-      row.push(cell.trim());
-      cell = "";
-      continue;
-    }
-    if ((char === "\n" || char === "\r") && !quoted) {
-      if (char === "\r" && next === "\n") index++;
-      row.push(cell.trim());
-      if (row.some(Boolean)) rows.push(row);
-      row = [];
-      cell = "";
-      continue;
-    }
-    cell += char;
-  }
-
-  row.push(cell.trim());
-  if (row.some(Boolean)) rows.push(row);
-  return rows;
-}
-
 function parseMemoryImport(payload: ImportMemoryEntriesBody): CreateMemoryEntryBody[] {
   if (payload.format === "csv") {
     const rows = parseCsvRows(payload.content);
@@ -201,7 +162,8 @@ function parseMemoryImport(payload: ImportMemoryEntriesBody): CreateMemoryEntryB
 
     return dataRows.flatMap((row) => {
       const [sourceLocale, targetLocale, sourceText, targetText, score] = row;
-      const matchScore = score ? Number.parseInt(score, 10) : 100;
+      const rawScore = score ? Number.parseInt(score, 10) : 100;
+      const matchScore = Number.isFinite(rawScore) ? Math.min(100, Math.max(0, rawScore)) : 100;
       return sourceLocale && targetLocale && sourceText && targetText
         ? [
             {
@@ -209,7 +171,7 @@ function parseMemoryImport(payload: ImportMemoryEntriesBody): CreateMemoryEntryB
               targetLocale,
               sourceText,
               targetText,
-              matchScore: Number.isFinite(matchScore) ? matchScore : 100,
+              matchScore,
             },
           ]
         : [];

--- a/apps/hyperlocalise-web/src/api/routes/memory/memory.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/memory/memory.route.ts
@@ -1,4 +1,4 @@
-import { and, count, desc, eq } from "drizzle-orm";
+import { and, count, desc, eq, ne } from "drizzle-orm";
 
 import { buildProjectLinkedMemoryWhere } from "@/api/auth/team-access";
 import { Hono } from "hono";
@@ -11,7 +11,7 @@ import type { Memory } from "@/lib/database/types";
 import { toMemoryRecord } from "@/lib/memory/memory-records";
 import { normalizeTranslationMemorySourceText } from "@/lib/translation/normalizeTranslationMemorySourceText";
 
-import { getOwnedProject } from "../project/project.shared";
+import { getOwnedProject, projectNotFoundResponse } from "../project/project.shared";
 import {
   attachMemoryProjectBodySchema,
   createMemoryEntryBodySchema,
@@ -313,6 +313,32 @@ async function createMemoryEntry(
   return entry ?? null;
 }
 
+async function createMemoryEntries(
+  memory: Memory,
+  payloads: CreateMemoryEntryBody[],
+): Promise<MemoryEntry[]> {
+  if (payloads.length === 0) {
+    return [];
+  }
+
+  return db
+    .insert(schema.memoryEntries)
+    .values(
+      payloads.map((payload) => ({
+        memoryId: memory.id,
+        sourceLocale: payload.sourceLocale,
+        targetLocale: payload.targetLocale,
+        sourceText: payload.sourceText,
+        normalizedSourceText: normalizeTranslationMemorySourceText(payload.sourceText),
+        targetText: payload.targetText,
+        matchScore: payload.matchScore,
+        provenance: "manual",
+      })),
+    )
+    .onConflictDoNothing()
+    .returning();
+}
+
 async function listMemoryProjects(
   auth: ApiAuthContext,
   memoryId: string,
@@ -533,19 +559,14 @@ export function createMemoryRoutes() {
         }
 
         const entries = parseMemoryImport(payload);
-        const created: MemoryEntryRecord[] = [];
-        let skipped = 0;
+        const limitedEntries = entries.slice(0, 5_000);
+        const created = await createMemoryEntries(memory, limitedEntries);
+        const skipped = limitedEntries.length - created.length;
 
-        for (const entryPayload of entries.slice(0, 5_000)) {
-          const entry = await createMemoryEntry(memory, entryPayload);
-          if (entry) {
-            created.push(toMemoryEntryRecord(entry));
-          } else {
-            skipped++;
-          }
-        }
-
-        return c.json({ memoryEntries: created, imported: created.length, skipped }, 201);
+        return c.json(
+          { memoryEntries: created.map(toMemoryEntryRecord), imported: created.length, skipped },
+          201,
+        );
       },
     )
     .patch(
@@ -568,9 +589,60 @@ export function createMemoryRoutes() {
           return externalTmsMemoryImmutableResponse(c);
         }
 
+        const [existingEntry] = await db
+          .select()
+          .from(schema.memoryEntries)
+          .where(
+            and(
+              eq(schema.memoryEntries.id, params.entryId),
+              eq(schema.memoryEntries.memoryId, memory.id),
+            ),
+          )
+          .limit(1);
+
+        if (!existingEntry) {
+          return memoryNotFoundResponse(c);
+        }
+
         const updates: Partial<typeof schema.memoryEntries.$inferInsert> = { ...payload };
         if (payload.sourceText !== undefined) {
           updates.normalizedSourceText = normalizeTranslationMemorySourceText(payload.sourceText);
+        }
+
+        if (
+          payload.sourceText !== undefined ||
+          payload.sourceLocale !== undefined ||
+          payload.targetLocale !== undefined
+        ) {
+          const normalizedSourceText =
+            updates.normalizedSourceText ?? existingEntry.normalizedSourceText;
+          const duplicate = await db
+            .select({ id: schema.memoryEntries.id })
+            .from(schema.memoryEntries)
+            .where(
+              and(
+                eq(schema.memoryEntries.memoryId, memory.id),
+                eq(
+                  schema.memoryEntries.sourceLocale,
+                  payload.sourceLocale ?? existingEntry.sourceLocale,
+                ),
+                eq(
+                  schema.memoryEntries.targetLocale,
+                  payload.targetLocale ?? existingEntry.targetLocale,
+                ),
+                eq(schema.memoryEntries.normalizedSourceText, normalizedSourceText),
+                ne(schema.memoryEntries.id, params.entryId),
+              ),
+            )
+            .limit(1);
+
+          if (duplicate.length > 0) {
+            return conflictResponse(
+              c,
+              "duplicate_memory_entry",
+              "An entry with this source text and locale pair already exists",
+            );
+          }
         }
 
         const [entry] = await db
@@ -652,7 +724,7 @@ export function createMemoryRoutes() {
           return memoryNotFoundResponse(c);
         }
         if (!project) {
-          return memoryNotFoundResponse(c);
+          return projectNotFoundResponse(c);
         }
 
         await db
@@ -686,7 +758,7 @@ export function createMemoryRoutes() {
         return memoryNotFoundResponse(c);
       }
       if (!project) {
-        return memoryNotFoundResponse(c);
+        return projectNotFoundResponse(c);
       }
 
       await db

--- a/apps/hyperlocalise-web/src/api/routes/memory/memory.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/memory/memory.route.ts
@@ -228,11 +228,11 @@ function parseMemoryImport(payload: ImportMemoryEntriesBody): CreateMemoryEntryB
     const [source, target] = variants;
     const sourceText = source[2]
       ?.match(/<seg\b[^>]*>([\s\S]*?)<\/seg>/i)?.[1]
-      ?.replace(/<[^>]*>/g, "")
+      ?.replace(/[<>]/g, "")
       .trim();
     const targetText = target[2]
       ?.match(/<seg\b[^>]*>([\s\S]*?)<\/seg>/i)?.[1]
-      ?.replace(/<[^>]*>/g, "")
+      ?.replace(/[<>]/g, "")
       .trim();
 
     return source[1] && target[1] && sourceText && targetText

--- a/apps/hyperlocalise-web/src/api/routes/memory/memory.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/memory/memory.route.ts
@@ -1,21 +1,36 @@
-import { count, desc } from "drizzle-orm";
+import { and, count, desc, eq } from "drizzle-orm";
 
 import { buildProjectLinkedMemoryWhere } from "@/api/auth/team-access";
 import { Hono } from "hono";
 import { validator } from "hono/validator";
 
 import { workosAuthMiddleware, type ApiAuthContext, type AuthVariables } from "@/api/auth/workos";
+import { conflictResponse } from "@/api/errors";
 import { db, schema } from "@/lib/database";
 import type { Memory } from "@/lib/database/types";
 import { toMemoryRecord } from "@/lib/memory/memory-records";
+import { normalizeTranslationMemorySourceText } from "@/lib/translation/normalizeTranslationMemorySourceText";
 
+import { getOwnedProject } from "../project/project.shared";
 import {
+  attachMemoryProjectBodySchema,
+  createMemoryEntryBodySchema,
   createMemoryBodySchema,
+  importMemoryEntriesBodySchema,
+  listMemoryEntriesQuerySchema,
   listMemoryQuerySchema,
+  memoryEntryIdParamsSchema,
   memoryIdParamsSchema,
+  memoryProjectParamsSchema,
+  updateMemoryEntryBodySchema,
   updateMemoryBodySchema,
+  type AttachMemoryProjectBody,
+  type CreateMemoryEntryBody,
   type CreateMemoryBody,
+  type ImportMemoryEntriesBody,
+  type ListMemoryEntriesQuery,
   type ListMemoryQuery,
+  type UpdateMemoryEntryBody,
   type UpdateMemoryBody,
 } from "./memory.schema";
 import {
@@ -39,6 +54,31 @@ type MemoryStore = {
   getById(auth: ApiAuthContext, memoryId: string): Promise<Memory | null>;
   update(auth: ApiAuthContext, memoryId: string, payload: UpdateMemoryBody): Promise<Memory | null>;
   delete(auth: ApiAuthContext, memoryId: string): Promise<boolean>;
+};
+
+type MemoryEntry = typeof schema.memoryEntries.$inferSelect;
+
+type MemoryEntryRecord = {
+  id: string;
+  memoryId: string;
+  sourceLocale: string;
+  targetLocale: string;
+  sourceText: string;
+  targetText: string;
+  matchScore: number;
+  provenance: string;
+  reviewStatus: string;
+  externalKey: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type MemoryProjectRecord = {
+  projectId: string;
+  projectName: string;
+  priority: number;
+  sourceLocale: string | null;
+  targetLocales: string[];
 };
 
 const memoryStore: MemoryStore = {
@@ -95,8 +135,229 @@ const memoryStore: MemoryStore = {
   },
 };
 
+function toMemoryEntryRecord(entry: MemoryEntry): MemoryEntryRecord {
+  return {
+    id: entry.id,
+    memoryId: entry.memoryId,
+    sourceLocale: entry.sourceLocale,
+    targetLocale: entry.targetLocale,
+    sourceText: entry.sourceText,
+    targetText: entry.targetText,
+    matchScore: entry.matchScore,
+    provenance: entry.provenance,
+    reviewStatus: entry.reviewStatus,
+    externalKey: entry.externalKey,
+    createdAt: entry.createdAt.toISOString(),
+    updatedAt: entry.updatedAt.toISOString(),
+  };
+}
+
+function parseCsvRows(content: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let cell = "";
+  let quoted = false;
+
+  for (let index = 0; index < content.length; index++) {
+    const char = content[index];
+    const next = content[index + 1];
+
+    if (char === '"' && quoted && next === '"') {
+      cell += '"';
+      index++;
+      continue;
+    }
+    if (char === '"') {
+      quoted = !quoted;
+      continue;
+    }
+    if (char === "," && !quoted) {
+      row.push(cell.trim());
+      cell = "";
+      continue;
+    }
+    if ((char === "\n" || char === "\r") && !quoted) {
+      if (char === "\r" && next === "\n") index++;
+      row.push(cell.trim());
+      if (row.some(Boolean)) rows.push(row);
+      row = [];
+      cell = "";
+      continue;
+    }
+    cell += char;
+  }
+
+  row.push(cell.trim());
+  if (row.some(Boolean)) rows.push(row);
+  return rows;
+}
+
+function parseMemoryImport(payload: ImportMemoryEntriesBody): CreateMemoryEntryBody[] {
+  if (payload.format === "csv") {
+    const rows = parseCsvRows(payload.content);
+    const [first, ...rest] = rows;
+    const hasHeader = first?.some((cell) => /source|target|locale|text/i.test(cell)) ?? false;
+    const dataRows = hasHeader ? rest : rows;
+
+    return dataRows.flatMap((row) => {
+      const [sourceLocale, targetLocale, sourceText, targetText, score] = row;
+      const matchScore = score ? Number.parseInt(score, 10) : 100;
+      return sourceLocale && targetLocale && sourceText && targetText
+        ? [
+            {
+              sourceLocale,
+              targetLocale,
+              sourceText,
+              targetText,
+              matchScore: Number.isFinite(matchScore) ? matchScore : 100,
+            },
+          ]
+        : [];
+    });
+  }
+
+  const units = [...payload.content.matchAll(/<tu\b[\s\S]*?<\/tu>/gi)];
+  return units.flatMap((unit) => {
+    const variants = [
+      ...unit[0].matchAll(/<tuv\b[^>]*?xml:lang=["']([^"']+)["'][^>]*>([\s\S]*?)<\/tuv>/gi),
+    ];
+    if (variants.length < 2) {
+      return [];
+    }
+
+    const [source, target] = variants;
+    const sourceText = source[2]
+      ?.match(/<seg\b[^>]*>([\s\S]*?)<\/seg>/i)?.[1]
+      ?.replace(/<[^>]*>/g, "")
+      .trim();
+    const targetText = target[2]
+      ?.match(/<seg\b[^>]*>([\s\S]*?)<\/seg>/i)?.[1]
+      ?.replace(/<[^>]*>/g, "")
+      .trim();
+
+    return source[1] && target[1] && sourceText && targetText
+      ? [
+          {
+            sourceLocale: source[1],
+            targetLocale: target[1],
+            sourceText,
+            targetText,
+            matchScore: 100,
+          },
+        ]
+      : [];
+  });
+}
+
+async function listMemoryEntries(memoryId: string, query?: ListMemoryEntriesQuery) {
+  const limit = query?.limit ?? 50;
+  const offset = query?.offset ?? 0;
+  const conditions = [eq(schema.memoryEntries.memoryId, memoryId)];
+  if (query?.sourceLocale)
+    conditions.push(eq(schema.memoryEntries.sourceLocale, query.sourceLocale));
+  if (query?.targetLocale)
+    conditions.push(eq(schema.memoryEntries.targetLocale, query.targetLocale));
+  const where = and(...conditions);
+
+  const [entries, totalRow] = await Promise.all([
+    db
+      .select()
+      .from(schema.memoryEntries)
+      .where(where)
+      .orderBy(desc(schema.memoryEntries.createdAt))
+      .limit(limit)
+      .offset(offset),
+    db.select({ value: count() }).from(schema.memoryEntries).where(where),
+  ]);
+
+  return { entries, total: totalRow[0]?.value ?? 0 };
+}
+
+async function createMemoryEntry(
+  memory: Memory,
+  payload: CreateMemoryEntryBody,
+): Promise<MemoryEntry | null> {
+  const normalizedSourceText = normalizeTranslationMemorySourceText(payload.sourceText);
+  const existing = await db
+    .select({ id: schema.memoryEntries.id })
+    .from(schema.memoryEntries)
+    .where(
+      and(
+        eq(schema.memoryEntries.memoryId, memory.id),
+        eq(schema.memoryEntries.sourceLocale, payload.sourceLocale),
+        eq(schema.memoryEntries.targetLocale, payload.targetLocale),
+        eq(schema.memoryEntries.normalizedSourceText, normalizedSourceText),
+      ),
+    )
+    .limit(1);
+
+  if (existing.length > 0) {
+    return null;
+  }
+
+  const [entry] = await db
+    .insert(schema.memoryEntries)
+    .values({
+      memoryId: memory.id,
+      sourceLocale: payload.sourceLocale,
+      targetLocale: payload.targetLocale,
+      sourceText: payload.sourceText,
+      normalizedSourceText,
+      targetText: payload.targetText,
+      matchScore: payload.matchScore,
+      provenance: "manual",
+    })
+    .onConflictDoNothing()
+    .returning();
+
+  return entry ?? null;
+}
+
+async function listMemoryProjects(
+  auth: ApiAuthContext,
+  memoryId: string,
+): Promise<MemoryProjectRecord[]> {
+  return db
+    .select({
+      projectId: schema.projects.id,
+      projectName: schema.projects.name,
+      priority: schema.projectMemories.priority,
+      sourceLocale: schema.projects.sourceLocale,
+      targetLocales: schema.projects.targetLocales,
+    })
+    .from(schema.projectMemories)
+    .innerJoin(schema.projects, eq(schema.projectMemories.projectId, schema.projects.id))
+    .where(
+      and(
+        eq(schema.projectMemories.organizationId, auth.organization.localOrganizationId),
+        eq(schema.projectMemories.memoryId, memoryId),
+      ),
+    )
+    .orderBy(schema.projectMemories.priority, schema.projects.name);
+}
+
 const validateMemoryParams = validator("param", (value, c) => {
   const parsed = memoryIdParamsSchema.safeParse(value);
+
+  if (!parsed.success) {
+    return memoryNotFoundResponse(c);
+  }
+
+  return parsed.data;
+});
+
+const validateMemoryEntryParams = validator("param", (value, c) => {
+  const parsed = memoryEntryIdParamsSchema.safeParse(value);
+
+  if (!parsed.success) {
+    return memoryNotFoundResponse(c);
+  }
+
+  return parsed.data;
+});
+
+const validateMemoryProjectParams = validator("param", (value, c) => {
+  const parsed = memoryProjectParamsSchema.safeParse(value);
 
   if (!parsed.success) {
     return memoryNotFoundResponse(c);
@@ -117,6 +378,56 @@ const validateCreateMemoryBody = validator("json", (value, c) => {
 
 const validateUpdateMemoryBody = validator("json", (value, c) => {
   const parsed = updateMemoryBodySchema.safeParse(value);
+
+  if (!parsed.success) {
+    return invalidMemoryPayloadResponse(c);
+  }
+
+  return parsed.data;
+});
+
+const validateListMemoryEntriesQuery = validator("query", (value, c) => {
+  const parsed = listMemoryEntriesQuerySchema.safeParse(value);
+
+  if (!parsed.success) {
+    return invalidMemoryPayloadResponse(c);
+  }
+
+  return parsed.data;
+});
+
+const validateCreateMemoryEntryBody = validator("json", (value, c) => {
+  const parsed = createMemoryEntryBodySchema.safeParse(value);
+
+  if (!parsed.success) {
+    return invalidMemoryPayloadResponse(c);
+  }
+
+  return parsed.data;
+});
+
+const validateUpdateMemoryEntryBody = validator("json", (value, c) => {
+  const parsed = updateMemoryEntryBodySchema.safeParse(value);
+
+  if (!parsed.success) {
+    return invalidMemoryPayloadResponse(c);
+  }
+
+  return parsed.data;
+});
+
+const validateImportMemoryEntriesBody = validator("json", (value, c) => {
+  const parsed = importMemoryEntriesBodySchema.safeParse(value);
+
+  if (!parsed.success) {
+    return invalidMemoryPayloadResponse(c);
+  }
+
+  return parsed.data;
+});
+
+const validateAttachMemoryProjectBody = validator("json", (value, c) => {
+  const parsed = attachMemoryProjectBodySchema.safeParse(value);
 
   if (!parsed.success) {
     return invalidMemoryPayloadResponse(c);
@@ -161,6 +472,234 @@ export function createMemoryRoutes() {
       }
 
       return c.json({ memory: toMemoryRecord(memory) }, 200);
+    })
+    .get("/:memoryId/entries", validateMemoryParams, validateListMemoryEntriesQuery, async (c) => {
+      const params = c.req.valid("param");
+      const query = c.req.valid("query");
+      const memory = await memoryStore.getById(c.var.auth, params.memoryId);
+
+      if (!memory) {
+        return memoryNotFoundResponse(c);
+      }
+
+      const { entries, total } = await listMemoryEntries(params.memoryId, query);
+      return c.json({ memoryEntries: entries.map(toMemoryEntryRecord), total }, 200);
+    })
+    .post("/:memoryId/entries", validateMemoryParams, validateCreateMemoryEntryBody, async (c) => {
+      if (!isMemoryMutationAllowed(c.var.auth.membership.role)) {
+        return forbiddenResponse(c);
+      }
+
+      const params = c.req.valid("param");
+      const payload = c.req.valid("json");
+      const memory = await memoryStore.getById(c.var.auth, params.memoryId);
+
+      if (!memory) {
+        return memoryNotFoundResponse(c);
+      }
+      if (memory.source === "external_tms") {
+        return externalTmsMemoryImmutableResponse(c);
+      }
+
+      const entry = await createMemoryEntry(memory, payload);
+      if (!entry) {
+        return conflictResponse(
+          c,
+          "duplicate_memory_entry",
+          "An entry with this source text and locale pair already exists",
+        );
+      }
+
+      return c.json({ memoryEntry: toMemoryEntryRecord(entry) }, 201);
+    })
+    .post(
+      "/:memoryId/entries/import",
+      validateMemoryParams,
+      validateImportMemoryEntriesBody,
+      async (c) => {
+        if (!isMemoryMutationAllowed(c.var.auth.membership.role)) {
+          return forbiddenResponse(c);
+        }
+
+        const params = c.req.valid("param");
+        const payload = c.req.valid("json");
+        const memory = await memoryStore.getById(c.var.auth, params.memoryId);
+
+        if (!memory) {
+          return memoryNotFoundResponse(c);
+        }
+        if (memory.source === "external_tms") {
+          return externalTmsMemoryImmutableResponse(c);
+        }
+
+        const entries = parseMemoryImport(payload);
+        const created: MemoryEntryRecord[] = [];
+        let skipped = 0;
+
+        for (const entryPayload of entries.slice(0, 5_000)) {
+          const entry = await createMemoryEntry(memory, entryPayload);
+          if (entry) {
+            created.push(toMemoryEntryRecord(entry));
+          } else {
+            skipped++;
+          }
+        }
+
+        return c.json({ memoryEntries: created, imported: created.length, skipped }, 201);
+      },
+    )
+    .patch(
+      "/:memoryId/entries/:entryId",
+      validateMemoryEntryParams,
+      validateUpdateMemoryEntryBody,
+      async (c) => {
+        if (!isMemoryMutationAllowed(c.var.auth.membership.role)) {
+          return forbiddenResponse(c);
+        }
+
+        const params = c.req.valid("param");
+        const payload: UpdateMemoryEntryBody = c.req.valid("json");
+        const memory = await memoryStore.getById(c.var.auth, params.memoryId);
+
+        if (!memory) {
+          return memoryNotFoundResponse(c);
+        }
+        if (memory.source === "external_tms") {
+          return externalTmsMemoryImmutableResponse(c);
+        }
+
+        const updates: Partial<typeof schema.memoryEntries.$inferInsert> = { ...payload };
+        if (payload.sourceText !== undefined) {
+          updates.normalizedSourceText = normalizeTranslationMemorySourceText(payload.sourceText);
+        }
+
+        const [entry] = await db
+          .update(schema.memoryEntries)
+          .set(updates)
+          .where(
+            and(
+              eq(schema.memoryEntries.id, params.entryId),
+              eq(schema.memoryEntries.memoryId, memory.id),
+            ),
+          )
+          .returning();
+
+        if (!entry) {
+          return memoryNotFoundResponse(c);
+        }
+
+        return c.json({ memoryEntry: toMemoryEntryRecord(entry) }, 200);
+      },
+    )
+    .delete("/:memoryId/entries/:entryId", validateMemoryEntryParams, async (c) => {
+      if (!isMemoryMutationAllowed(c.var.auth.membership.role)) {
+        return forbiddenResponse(c);
+      }
+
+      const params = c.req.valid("param");
+      const memory = await memoryStore.getById(c.var.auth, params.memoryId);
+
+      if (!memory) {
+        return memoryNotFoundResponse(c);
+      }
+      if (memory.source === "external_tms") {
+        return externalTmsMemoryImmutableResponse(c);
+      }
+
+      const deleted = await db
+        .delete(schema.memoryEntries)
+        .where(
+          and(
+            eq(schema.memoryEntries.id, params.entryId),
+            eq(schema.memoryEntries.memoryId, memory.id),
+          ),
+        )
+        .returning({ id: schema.memoryEntries.id });
+
+      if (deleted.length === 0) {
+        return memoryNotFoundResponse(c);
+      }
+
+      return c.body(null, 204);
+    })
+    .get("/:memoryId/projects", validateMemoryParams, async (c) => {
+      const params = c.req.valid("param");
+      const memory = await memoryStore.getById(c.var.auth, params.memoryId);
+
+      if (!memory) {
+        return memoryNotFoundResponse(c);
+      }
+
+      return c.json({ projects: await listMemoryProjects(c.var.auth, params.memoryId) }, 200);
+    })
+    .post(
+      "/:memoryId/projects",
+      validateMemoryParams,
+      validateAttachMemoryProjectBody,
+      async (c) => {
+        if (!isMemoryMutationAllowed(c.var.auth.membership.role)) {
+          return forbiddenResponse(c);
+        }
+
+        const params = c.req.valid("param");
+        const payload: AttachMemoryProjectBody = c.req.valid("json");
+        const [memory, project] = await Promise.all([
+          memoryStore.getById(c.var.auth, params.memoryId),
+          getOwnedProject(c.var.auth, payload.projectId),
+        ]);
+
+        if (!memory) {
+          return memoryNotFoundResponse(c);
+        }
+        if (!project) {
+          return memoryNotFoundResponse(c);
+        }
+
+        await db
+          .insert(schema.projectMemories)
+          .values({
+            organizationId: c.var.auth.organization.localOrganizationId,
+            projectId: project.id,
+            memoryId: memory.id,
+            priority: payload.priority,
+          })
+          .onConflictDoUpdate({
+            target: [schema.projectMemories.projectId, schema.projectMemories.memoryId],
+            set: { priority: payload.priority },
+          });
+
+        return c.json({ projects: await listMemoryProjects(c.var.auth, params.memoryId) }, 200);
+      },
+    )
+    .delete("/:memoryId/projects/:projectId", validateMemoryProjectParams, async (c) => {
+      if (!isMemoryMutationAllowed(c.var.auth.membership.role)) {
+        return forbiddenResponse(c);
+      }
+
+      const params = c.req.valid("param");
+      const [memory, project] = await Promise.all([
+        memoryStore.getById(c.var.auth, params.memoryId),
+        getOwnedProject(c.var.auth, params.projectId),
+      ]);
+
+      if (!memory) {
+        return memoryNotFoundResponse(c);
+      }
+      if (!project) {
+        return memoryNotFoundResponse(c);
+      }
+
+      await db
+        .delete(schema.projectMemories)
+        .where(
+          and(
+            eq(schema.projectMemories.organizationId, c.var.auth.organization.localOrganizationId),
+            eq(schema.projectMemories.projectId, project.id),
+            eq(schema.projectMemories.memoryId, memory.id),
+          ),
+        );
+
+      return c.body(null, 204);
     })
     .patch("/:memoryId", validateMemoryParams, validateUpdateMemoryBody, async (c) => {
       if (!isMemoryMutationAllowed(c.var.auth.membership.role)) {

--- a/apps/hyperlocalise-web/src/api/routes/memory/memory.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/memory/memory.schema.ts
@@ -6,6 +6,14 @@ export const memoryIdParamsSchema = z.object({
   memoryId: z.string().trim().min(1).max(128),
 });
 
+export const memoryEntryIdParamsSchema = memoryIdParamsSchema.extend({
+  entryId: z.string().trim().min(1).max(128),
+});
+
+export const memoryProjectParamsSchema = memoryIdParamsSchema.extend({
+  projectId: z.string().trim().min(1).max(128),
+});
+
 export const listMemoryQuerySchema = z
   .object({
     limit: z.coerce.number().int().min(1).max(100).default(50),
@@ -26,6 +34,51 @@ export const updateMemoryBodySchema = z
   .refine((value) => value.name !== undefined || value.description !== undefined, {
     message: "at least one field must be provided",
   });
+
+export const listMemoryEntriesQuerySchema = z
+  .object({
+    limit: z.coerce.number().int().min(1).max(100).default(50),
+    offset: z.coerce.number().int().min(0).default(0),
+    sourceLocale: z.string().trim().max(50).optional(),
+    targetLocale: z.string().trim().max(50).optional(),
+  })
+  .optional();
+
+export const createMemoryEntryBodySchema = z.object({
+  sourceLocale: z.string().trim().min(1).max(50),
+  targetLocale: z.string().trim().min(1).max(50),
+  sourceText: z.string().trim().min(1).max(100_000),
+  targetText: z.string().trim().min(1).max(100_000),
+  matchScore: z.number().int().min(0).max(100).optional().default(100),
+});
+
+export const updateMemoryEntryBodySchema = z
+  .object({
+    sourceLocale: z.string().trim().min(1).max(50).optional(),
+    targetLocale: z.string().trim().min(1).max(50).optional(),
+    sourceText: z.string().trim().min(1).max(100_000).optional(),
+    targetText: z.string().trim().min(1).max(100_000).optional(),
+    matchScore: z.number().int().min(0).max(100).optional(),
+  })
+  .refine(
+    (value) =>
+      value.sourceLocale !== undefined ||
+      value.targetLocale !== undefined ||
+      value.sourceText !== undefined ||
+      value.targetText !== undefined ||
+      value.matchScore !== undefined,
+    { message: "at least one field must be provided" },
+  );
+
+export const importMemoryEntriesBodySchema = z.object({
+  format: z.enum(["csv", "tmx"]),
+  content: z.string().min(1).max(10_000_000),
+});
+
+export const attachMemoryProjectBodySchema = z.object({
+  projectId: z.string().trim().min(1).max(128),
+  priority: z.number().int().min(0).max(10_000).optional().default(0),
+});
 
 export const memoryRecordSchema = z.object({
   id: z.string(),
@@ -55,15 +108,63 @@ export const memoryResponseSchema = z.object({
   memory: memoryRecordSchema,
 });
 
+export const memoryEntryRecordSchema = z.object({
+  id: z.string(),
+  memoryId: z.string(),
+  sourceLocale: z.string(),
+  targetLocale: z.string(),
+  sourceText: z.string(),
+  targetText: z.string(),
+  matchScore: z.number().int(),
+  provenance: z.string(),
+  reviewStatus: z.string(),
+  externalKey: z.string().nullable(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+
+export const memoryEntryResponseSchema = z.object({
+  memoryEntry: memoryEntryRecordSchema,
+});
+
+export const memoryProjectRecordSchema = z.object({
+  projectId: z.string(),
+  projectName: z.string(),
+  priority: z.number().int(),
+  sourceLocale: z.string().nullable(),
+  targetLocales: z.array(z.string()),
+});
+
 export const memoriesResponseSchema = z.object({
   memories: z.array(memoryRecordSchema),
   total: z.number().int().nonnegative(),
 });
 
+export const memoryEntriesResponseSchema = z.object({
+  memoryEntries: z.array(memoryEntryRecordSchema),
+  total: z.number().int().nonnegative(),
+});
+
+export const memoryProjectsResponseSchema = z.object({
+  projects: z.array(memoryProjectRecordSchema),
+});
+
 export type MemoryIdParams = z.infer<typeof memoryIdParamsSchema>;
+export type MemoryEntryIdParams = z.infer<typeof memoryEntryIdParamsSchema>;
+export type MemoryProjectParams = z.infer<typeof memoryProjectParamsSchema>;
 export type ListMemoryQuery = z.infer<typeof listMemoryQuerySchema>;
+export type ListMemoryEntriesQuery = z.infer<typeof listMemoryEntriesQuerySchema>;
 export type CreateMemoryBody = z.infer<typeof createMemoryBodySchema>;
 export type UpdateMemoryBody = z.infer<typeof updateMemoryBodySchema>;
+export type CreateMemoryEntryBody = z.infer<typeof createMemoryEntryBodySchema>;
+export type UpdateMemoryEntryBody = z.infer<typeof updateMemoryEntryBodySchema>;
+export type ImportMemoryEntriesBody = z.infer<typeof importMemoryEntriesBodySchema>;
+export type AttachMemoryProjectBody = z.infer<typeof attachMemoryProjectBodySchema>;
 export type MemoryRecord = z.infer<typeof memoryRecordSchema>;
 export type MemoryResponse = z.infer<typeof memoryResponseSchema>;
+export type MemoryEntryRecord = z.infer<typeof memoryEntryRecordSchema>;
+export type MemoryEntryResponse = z.infer<typeof memoryEntryResponseSchema>;
 export type MemoriesResponse = z.infer<typeof memoriesResponseSchema>;
+export type MemoryEntriesResponse = z.infer<typeof memoryEntriesResponseSchema>;
+export type MemoryProjectRecord = z.infer<typeof memoryProjectRecordSchema>;
+export type MemoryProjectsResponse = z.infer<typeof memoryProjectsResponseSchema>;

--- a/apps/hyperlocalise-web/src/api/routes/memory/memory.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/memory/memory.test.ts
@@ -437,4 +437,51 @@ describe("memoryRoutes", () => {
       projects: [expect.objectContaining({ projectId: project.id, projectName: "Website" })],
     });
   });
+
+  it("clamps CSV import match scores into the database range", async () => {
+    const { identity, memory } = await memoryFixture.createStoredMemoryFixture();
+    const headers = await authHeadersFor(identity);
+    const param = {
+      organizationSlug: identity.organization.slug ?? "missing-slug",
+      memoryId: memory.id,
+    };
+
+    const importResponse = await client.api.orgs[":organizationSlug"]["translation-memories"][
+      ":memoryId"
+    ].entries["import"].$post(
+      {
+        param,
+        json: {
+          format: "csv",
+          content:
+            "sourceLocale,targetLocale,sourceText,targetText,score\nen,fr,Upgrade,Mettre à niveau,150\nen,fr,Downgrade,Rétrograder,-5\nen,fr,Default,Défaut,not-a-number",
+        },
+      },
+      { headers },
+    );
+
+    expect(importResponse.status).toBe(201);
+    await expect(importResponse.json()).resolves.toMatchObject({ imported: 3, skipped: 0 });
+
+    const entriesResponse = await client.api.orgs[":organizationSlug"]["translation-memories"][
+      ":memoryId"
+    ].entries.$get(
+      {
+        param,
+        query: { limit: "50", offset: "0" },
+      },
+      { headers },
+    );
+
+    expect(entriesResponse.status).toBe(200);
+    const entriesBody = await entriesResponse.json();
+    if ("error" in entriesBody) throw new Error(String(entriesBody.error));
+    expect(entriesBody.memoryEntries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ sourceText: "Upgrade", matchScore: 100 }),
+        expect.objectContaining({ sourceText: "Downgrade", matchScore: 0 }),
+        expect.objectContaining({ sourceText: "Default", matchScore: 100 }),
+      ]),
+    );
+  });
 });

--- a/apps/hyperlocalise-web/src/api/routes/memory/memory.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/memory/memory.test.ts
@@ -6,7 +6,7 @@ import { testClient } from "hono/testing";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
 
 import { app } from "@/api/app";
-import { db } from "@/lib/database";
+import { db, schema } from "@/lib/database";
 import { upsertOrganizationExternalTmsMemory } from "@/lib/providers/sync/organization-external-tms-memories";
 import { upsertOrganizationExternalTmsProviderCredential } from "@/lib/providers/organization-external-tms-provider-credentials";
 
@@ -245,5 +245,102 @@ describe("memoryRoutes", () => {
 
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toMatchObject({ error: "forbidden" });
+  });
+
+  it("manages native memory entries and project assignment", async () => {
+    const { identity, organization, user, memory } =
+      await memoryFixture.createStoredMemoryFixture();
+    const headers = await authHeadersFor(identity);
+
+    const createEntryResponse = await client.api.orgs[":organizationSlug"]["translation-memories"][
+      ":memoryId"
+    ].entries.$post(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          memoryId: memory.id,
+        },
+        json: {
+          sourceLocale: "en",
+          targetLocale: "fr",
+          sourceText: "Start free trial",
+          targetText: "Commencer l'essai gratuit",
+          matchScore: 100,
+        },
+      },
+      { headers },
+    );
+    expect(createEntryResponse.status).toBe(201);
+    const createEntryBody = await createEntryResponse.json();
+    if ("error" in createEntryBody) throw new Error(String(createEntryBody.error));
+    expect(createEntryBody.memoryEntry).toMatchObject({
+      sourceText: "Start free trial",
+      targetText: "Commencer l'essai gratuit",
+    });
+
+    const updateEntryResponse = await client.api.orgs[":organizationSlug"]["translation-memories"][
+      ":memoryId"
+    ].entries[":entryId"].$patch(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          memoryId: memory.id,
+          entryId: createEntryBody.memoryEntry.id,
+        },
+        json: { targetText: "Démarrer l'essai gratuit" },
+      },
+      { headers },
+    );
+    expect(updateEntryResponse.status).toBe(200);
+    await expect(updateEntryResponse.json()).resolves.toMatchObject({
+      memoryEntry: expect.objectContaining({ targetText: "Démarrer l'essai gratuit" }),
+    });
+
+    const importResponse = await client.api.orgs[":organizationSlug"]["translation-memories"][
+      ":memoryId"
+    ].entries["import"].$post(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          memoryId: memory.id,
+        },
+        json: {
+          format: "csv",
+          content: "sourceLocale,targetLocale,sourceText,targetText\nen,fr,Hello,Bonjour",
+        },
+      },
+      { headers },
+    );
+    expect(importResponse.status).toBe(201);
+    await expect(importResponse.json()).resolves.toMatchObject({ imported: 1 });
+
+    const [project] = await db
+      .insert(schema.projects)
+      .values({
+        id: `project_${randomUUID()}`,
+        organizationId: organization.id,
+        createdByUserId: user.id,
+        name: "Website",
+        sourceLocale: "en",
+        targetLocales: ["fr"],
+      })
+      .returning();
+
+    const attachResponse = await client.api.orgs[":organizationSlug"]["translation-memories"][
+      ":memoryId"
+    ].projects.$post(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          memoryId: memory.id,
+        },
+        json: { projectId: project.id, priority: 0 },
+      },
+      { headers },
+    );
+    expect(attachResponse.status).toBe(200);
+    await expect(attachResponse.json()).resolves.toMatchObject({
+      projects: [expect.objectContaining({ projectId: project.id, projectName: "Website" })],
+    });
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/memory/memory.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/memory/memory.test.ts
@@ -247,6 +247,99 @@ describe("memoryRoutes", () => {
     await expect(response.json()).resolves.toMatchObject({ error: "forbidden" });
   });
 
+  it("returns 409 when updating a memory entry to duplicate another entry", async () => {
+    const { identity, memory } = await memoryFixture.createStoredMemoryFixture();
+    const headers = await authHeadersFor(identity);
+    const param = {
+      organizationSlug: identity.organization.slug ?? "missing-slug",
+      memoryId: memory.id,
+    };
+
+    const firstResponse = await client.api.orgs[":organizationSlug"]["translation-memories"][
+      ":memoryId"
+    ].entries.$post(
+      {
+        param,
+        json: {
+          sourceLocale: "en",
+          targetLocale: "fr",
+          sourceText: "Start free trial",
+          targetText: "Commencer l'essai gratuit",
+          matchScore: 100,
+        },
+      },
+      { headers },
+    );
+    expect(firstResponse.status).toBe(201);
+
+    const secondResponse = await client.api.orgs[":organizationSlug"]["translation-memories"][
+      ":memoryId"
+    ].entries.$post(
+      {
+        param,
+        json: {
+          sourceLocale: "en",
+          targetLocale: "fr",
+          sourceText: "Create account",
+          targetText: "Créer un compte",
+          matchScore: 100,
+        },
+      },
+      { headers },
+    );
+    expect(secondResponse.status).toBe(201);
+    const secondBody = await secondResponse.json();
+    if ("error" in secondBody) throw new Error(String(secondBody.error));
+
+    const duplicateResponse = await client.api.orgs[":organizationSlug"]["translation-memories"][
+      ":memoryId"
+    ].entries[":entryId"].$patch(
+      {
+        param: { ...param, entryId: secondBody.memoryEntry.id },
+        json: { sourceText: "start free trial" },
+      },
+      { headers },
+    );
+
+    expect(duplicateResponse.status).toBe(409);
+    await expect(duplicateResponse.json()).resolves.toMatchObject({
+      error: "duplicate_memory_entry",
+    });
+  });
+
+  it("returns project_not_found when assigning an unknown project to a memory", async () => {
+    const { identity, memory } = await memoryFixture.createStoredMemoryFixture();
+    const headers = await authHeadersFor(identity);
+    const param = {
+      organizationSlug: identity.organization.slug ?? "missing-slug",
+      memoryId: memory.id,
+    };
+    const projectId = `project_${randomUUID()}`;
+
+    const attachResponse = await client.api.orgs[":organizationSlug"]["translation-memories"][
+      ":memoryId"
+    ].projects.$post(
+      {
+        param,
+        json: { projectId, priority: 0 },
+      },
+      { headers },
+    );
+    expect(attachResponse.status).toBe(404);
+    await expect(attachResponse.json()).resolves.toMatchObject({ error: "project_not_found" });
+
+    const detachResponse = await client.api.orgs[":organizationSlug"]["translation-memories"][
+      ":memoryId"
+    ].projects[":projectId"].$delete(
+      {
+        param: { ...param, projectId },
+      },
+      { headers },
+    );
+    expect(detachResponse.status).toBe(404);
+    await expect(detachResponse.json()).resolves.toMatchObject({ error: "project_not_found" });
+  });
+
   it("manages native memory entries and project assignment", async () => {
     const { identity, organization, user, memory } =
       await memoryFixture.createStoredMemoryFixture();
@@ -306,13 +399,14 @@ describe("memoryRoutes", () => {
         },
         json: {
           format: "csv",
-          content: "sourceLocale,targetLocale,sourceText,targetText\nen,fr,Hello,Bonjour",
+          content:
+            "sourceLocale,targetLocale,sourceText,targetText\nen,fr,Hello,Bonjour\nen,fr,hello,Salut",
         },
       },
       { headers },
     );
     expect(importResponse.status).toBe(201);
-    await expect(importResponse.json()).resolves.toMatchObject({ imported: 1 });
+    await expect(importResponse.json()).resolves.toMatchObject({ imported: 1, skipped: 1 });
 
     const [project] = await db
       .insert(schema.projects)

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
@@ -25,20 +25,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { TypographyH1, TypographyP } from "@/components/ui/typography";
+import { readApiError } from "@/lib/api-error";
 import { apiClient } from "@/lib/api-client-instance";
-
-function readApiError(response: Response, fallback: string) {
-  return response
-    .json()
-    .then((body) =>
-      body && typeof body === "object" && "message" in body
-        ? String(body.message)
-        : body && typeof body === "object" && "error" in body
-          ? String(body.error)
-          : fallback,
-    )
-    .catch(() => fallback);
-}
 
 type TermForm = {
   sourceTerm: string;

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/_components/glossary-detail-page-content.tsx
@@ -1,0 +1,483 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { ArrowLeft01Icon, BookOpenTextIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import type {
+  GlossaryProjectRecord,
+  GlossaryRecord,
+  GlossaryTermRecord,
+} from "@/api/routes/glossary/glossary.schema";
+import type { ProjectRecord } from "@/api/routes/project/project.schema";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Field, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { TypographyH1, TypographyP } from "@/components/ui/typography";
+import { apiClient } from "@/lib/api-client-instance";
+
+function readApiError(response: Response, fallback: string) {
+  return response
+    .json()
+    .then((body) =>
+      body && typeof body === "object" && "message" in body
+        ? String(body.message)
+        : body && typeof body === "object" && "error" in body
+          ? String(body.error)
+          : fallback,
+    )
+    .catch(() => fallback);
+}
+
+type TermForm = {
+  sourceTerm: string;
+  targetTerm: string;
+  description: string;
+  partOfSpeech: string;
+};
+
+const emptyTermForm: TermForm = {
+  sourceTerm: "",
+  targetTerm: "",
+  description: "",
+  partOfSpeech: "",
+};
+
+export function GlossaryDetailPageContent({
+  organizationSlug,
+  glossaryId,
+  canManageGlossaries,
+}: {
+  organizationSlug: string;
+  glossaryId: string;
+  canManageGlossaries: boolean;
+}) {
+  const queryClient = useQueryClient();
+  const [termForm, setTermForm] = useState<TermForm>(emptyTermForm);
+  const [editingTermId, setEditingTermId] = useState<string | null>(null);
+  const [selectedProjectId, setSelectedProjectId] = useState("");
+
+  const glossaryQuery = useQuery({
+    queryKey: ["glossary", organizationSlug, glossaryId],
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"].glossaries[":glossaryId"].$get(
+        {
+          param: { organizationSlug, glossaryId },
+        },
+      );
+      if (!response.ok) throw new Error(await readApiError(response, "Unable to load glossary"));
+      const body = await response.json();
+      return body.glossary as GlossaryRecord;
+    },
+  });
+
+  const termsQuery = useQuery({
+    queryKey: ["glossary-terms", organizationSlug, glossaryId],
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"].glossaries[
+        ":glossaryId"
+      ].terms.$get({ param: { organizationSlug, glossaryId } });
+      if (!response.ok) throw new Error(await readApiError(response, "Unable to load terms"));
+      const body = await response.json();
+      return body.glossaryTerms as GlossaryTermRecord[];
+    },
+  });
+
+  const attachedProjectsQuery = useQuery({
+    queryKey: ["glossary-projects", organizationSlug, glossaryId],
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"].glossaries[
+        ":glossaryId"
+      ].projects.$get({ param: { organizationSlug, glossaryId } });
+      if (!response.ok) throw new Error(await readApiError(response, "Unable to load projects"));
+      const body = await response.json();
+      return body.projects as GlossaryProjectRecord[];
+    },
+  });
+
+  const projectsQuery = useQuery({
+    queryKey: ["translation-projects", organizationSlug],
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"].projects.$get({
+        param: { organizationSlug },
+      });
+      if (!response.ok) throw new Error(await readApiError(response, "Unable to load projects"));
+      const body = await response.json();
+      return body.projects as ProjectRecord[];
+    },
+  });
+
+  const invalidateTerms = () =>
+    queryClient.invalidateQueries({ queryKey: ["glossary-terms", organizationSlug, glossaryId] });
+  const invalidateProjects = () =>
+    queryClient.invalidateQueries({
+      queryKey: ["glossary-projects", organizationSlug, glossaryId],
+    });
+
+  const saveTerm = useMutation({
+    mutationFn: async (values: TermForm) => {
+      const payload = {
+        sourceTerm: values.sourceTerm.trim(),
+        targetTerm: values.targetTerm.trim(),
+        description: values.description.trim(),
+        partOfSpeech: values.partOfSpeech.trim(),
+        caseSensitive: false,
+        forbidden: false,
+      };
+      const response = editingTermId
+        ? await apiClient.api.orgs[":organizationSlug"].glossaries[":glossaryId"].terms[
+            ":termId"
+          ].$patch({
+            param: { organizationSlug, glossaryId, termId: editingTermId },
+            json: payload,
+          })
+        : await apiClient.api.orgs[":organizationSlug"].glossaries[":glossaryId"].terms.$post({
+            param: { organizationSlug, glossaryId },
+            json: payload,
+          });
+      if (!response.ok) throw new Error(await readApiError(response, "Unable to save term"));
+      return response.json();
+    },
+    onSuccess: async () => {
+      await invalidateTerms();
+      setTermForm(emptyTermForm);
+      setEditingTermId(null);
+      toast.success(editingTermId ? "Term updated" : "Term added");
+    },
+    onError: (error) => toast.error(error.message),
+  });
+
+  const deleteTerm = useMutation({
+    mutationFn: async (termId: string) => {
+      const response = await apiClient.api.orgs[":organizationSlug"].glossaries[
+        ":glossaryId"
+      ].terms[":termId"].$delete({ param: { organizationSlug, glossaryId, termId } });
+      if (!response.ok) throw new Error(await readApiError(response, "Unable to delete term"));
+    },
+    onSuccess: async () => {
+      await invalidateTerms();
+      toast.success("Term deleted");
+    },
+    onError: (error) => toast.error(error.message),
+  });
+
+  const importTerms = useMutation({
+    mutationFn: async (file: File) => {
+      const content = await file.text();
+      const format = file.name.toLowerCase().endsWith(".tbx") ? "tbx" : "csv";
+      const response = await apiClient.api.orgs[":organizationSlug"].glossaries[
+        ":glossaryId"
+      ].terms["import"].$post({
+        param: { organizationSlug, glossaryId },
+        json: { format, content },
+      });
+      if (!response.ok) throw new Error(await readApiError(response, "Unable to import terms"));
+      return response.json();
+    },
+    onSuccess: async (body) => {
+      await invalidateTerms();
+      toast.success(`Imported ${body.imported ?? 0} terms`);
+    },
+    onError: (error) => toast.error(error.message),
+  });
+
+  const attachProject = useMutation({
+    mutationFn: async (projectId: string) => {
+      const response = await apiClient.api.orgs[":organizationSlug"].glossaries[
+        ":glossaryId"
+      ].projects.$post({
+        param: { organizationSlug, glossaryId },
+        json: { projectId, priority: 0 },
+      });
+      if (!response.ok) throw new Error(await readApiError(response, "Unable to assign project"));
+      return response.json();
+    },
+    onSuccess: async () => {
+      await invalidateProjects();
+      setSelectedProjectId("");
+      toast.success("Project assigned");
+    },
+    onError: (error) => toast.error(error.message),
+  });
+
+  const detachProject = useMutation({
+    mutationFn: async (projectId: string) => {
+      const response = await apiClient.api.orgs[":organizationSlug"].glossaries[
+        ":glossaryId"
+      ].projects[":projectId"].$delete({ param: { organizationSlug, glossaryId, projectId } });
+      if (!response.ok) throw new Error(await readApiError(response, "Unable to remove project"));
+    },
+    onSuccess: async () => {
+      await invalidateProjects();
+      toast.success("Project removed");
+    },
+    onError: (error) => toast.error(error.message),
+  });
+
+  const glossary = glossaryQuery.data;
+  const isNative = glossary?.source === "native";
+  const canEdit = canManageGlossaries && isNative;
+  const attachedProjectIds = useMemo(
+    () => new Set((attachedProjectsQuery.data ?? []).map((project) => project.projectId)),
+    [attachedProjectsQuery.data],
+  );
+  const availableProjects = (projectsQuery.data ?? []).filter(
+    (project) => !attachedProjectIds.has(project.id),
+  );
+
+  if (glossaryQuery.isLoading) {
+    return (
+      <TypographyP className="py-8 text-sm text-foreground/52">Loading glossary...</TypographyP>
+    );
+  }
+  if (!glossary) {
+    return (
+      <TypographyP className="py-8 text-sm text-foreground/52">Glossary not found.</TypographyP>
+    );
+  }
+
+  return (
+    <main className="mx-auto flex w-full max-w-6xl flex-col gap-6">
+      <Link
+        href={`/org/${organizationSlug}/glossaries`}
+        className="inline-flex w-fit items-center gap-2 text-sm text-foreground/58 hover:text-foreground"
+      >
+        <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" strokeWidth={1.8} />
+        Glossaries
+      </Link>
+
+      <section className="flex flex-col gap-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <HugeiconsIcon
+            icon={BookOpenTextIcon}
+            className="size-5 text-foreground/48"
+            strokeWidth={1.8}
+          />
+          <Badge variant="outline">{glossary.source === "native" ? "Workspace" : "Provider"}</Badge>
+          <Badge variant="outline">
+            {glossary.sourceLocale} → {glossary.targetLocale}
+          </Badge>
+        </div>
+        <TypographyH1 className="font-sans text-2xl font-medium">{glossary.name}</TypographyH1>
+        <TypographyP className="max-w-2xl text-sm leading-6 text-foreground/58">
+          {glossary.description || "Manage terms and assign this glossary to projects."}
+        </TypographyP>
+      </section>
+
+      <section className="grid gap-4 rounded-lg border border-foreground/8 p-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <TypographyP className="text-sm font-medium text-foreground">Terms</TypographyP>
+            <TypographyP className="text-xs text-foreground/52">
+              Add terms manually or import CSV/TBX files.
+            </TypographyP>
+          </div>
+          {canEdit ? (
+            <Input
+              type="file"
+              accept=".csv,.tbx,text/csv"
+              className="max-w-xs"
+              onChange={(event) => {
+                const file = event.target.files?.[0];
+                if (file) importTerms.mutate(file);
+                event.currentTarget.value = "";
+              }}
+            />
+          ) : null}
+        </div>
+
+        {canEdit ? (
+          <div className="grid gap-3 md:grid-cols-2">
+            <Field className="gap-1.5">
+              <FieldLabel>Source term</FieldLabel>
+              <Input
+                value={termForm.sourceTerm}
+                onChange={(event) =>
+                  setTermForm((current) => ({ ...current, sourceTerm: event.target.value }))
+                }
+              />
+            </Field>
+            <Field className="gap-1.5">
+              <FieldLabel>Target term</FieldLabel>
+              <Input
+                value={termForm.targetTerm}
+                onChange={(event) =>
+                  setTermForm((current) => ({ ...current, targetTerm: event.target.value }))
+                }
+              />
+            </Field>
+            <Field className="gap-1.5">
+              <FieldLabel>Part of speech</FieldLabel>
+              <Input
+                value={termForm.partOfSpeech}
+                onChange={(event) =>
+                  setTermForm((current) => ({ ...current, partOfSpeech: event.target.value }))
+                }
+              />
+            </Field>
+            <Field className="gap-1.5">
+              <FieldLabel>Description</FieldLabel>
+              <Input
+                value={termForm.description}
+                onChange={(event) =>
+                  setTermForm((current) => ({ ...current, description: event.target.value }))
+                }
+              />
+            </Field>
+            <div className="flex gap-2 md:col-span-2">
+              <Button
+                type="button"
+                disabled={
+                  !termForm.sourceTerm.trim() || !termForm.targetTerm.trim() || saveTerm.isPending
+                }
+                onClick={() => saveTerm.mutate(termForm)}
+              >
+                {editingTermId ? "Update term" : "Add term"}
+              </Button>
+              {editingTermId ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => {
+                    setEditingTermId(null);
+                    setTermForm(emptyTermForm);
+                  }}
+                >
+                  Cancel edit
+                </Button>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
+
+        <div className="overflow-hidden rounded-lg border border-foreground/8">
+          {(termsQuery.data ?? []).map((term) => (
+            <div
+              key={term.id}
+              className="grid gap-2 border-b border-foreground/8 px-4 py-3 last:border-b-0 md:grid-cols-[1fr_1fr_auto] md:items-center"
+            >
+              <div>
+                <TypographyP className="text-sm font-medium">{term.sourceTerm}</TypographyP>
+                <TypographyP className="text-xs text-foreground/48">
+                  {term.description || term.partOfSpeech}
+                </TypographyP>
+              </div>
+              <TypographyP className="text-sm text-foreground/72">{term.targetTerm}</TypographyP>
+              {canEdit ? (
+                <div className="flex gap-2">
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    onClick={() => {
+                      setEditingTermId(term.id);
+                      setTermForm({
+                        sourceTerm: term.sourceTerm,
+                        targetTerm: term.targetTerm,
+                        description: term.description,
+                        partOfSpeech: term.partOfSpeech ?? "",
+                      });
+                    }}
+                  >
+                    Edit
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => deleteTerm.mutate(term.id)}
+                  >
+                    Delete
+                  </Button>
+                </div>
+              ) : null}
+            </div>
+          ))}
+          {termsQuery.isSuccess && (termsQuery.data ?? []).length === 0 ? (
+            <TypographyP className="px-4 py-6 text-sm text-foreground/52">
+              No terms yet.
+            </TypographyP>
+          ) : null}
+        </div>
+      </section>
+
+      <section className="grid gap-4 rounded-lg border border-foreground/8 p-4">
+        <div>
+          <TypographyP className="text-sm font-medium text-foreground">
+            Assigned projects
+          </TypographyP>
+          <TypographyP className="text-xs text-foreground/52">
+            This glossary is used only by the projects listed here.
+          </TypographyP>
+        </div>
+        {canEdit ? (
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <Select
+              value={selectedProjectId}
+              onValueChange={(value) => setSelectedProjectId(value ?? "")}
+            >
+              <SelectTrigger className="sm:max-w-sm">
+                <SelectValue placeholder="Select project" />
+              </SelectTrigger>
+              <SelectContent>
+                {availableProjects.map((project) => (
+                  <SelectItem key={project.id} value={project.id}>
+                    {project.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Button
+              type="button"
+              disabled={!selectedProjectId || attachProject.isPending}
+              onClick={() => attachProject.mutate(selectedProjectId)}
+            >
+              Assign to project
+            </Button>
+          </div>
+        ) : null}
+        <div className="grid gap-2">
+          {(attachedProjectsQuery.data ?? []).map((project) => (
+            <div
+              key={project.projectId}
+              className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-foreground/8 px-3 py-2"
+            >
+              <Link
+                href={`/org/${organizationSlug}/projects/${project.projectId}`}
+                className="text-sm font-medium text-foreground hover:underline"
+              >
+                {project.projectName}
+              </Link>
+              {canEdit ? (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => detachProject.mutate(project.projectId)}
+                >
+                  Remove
+                </Button>
+              ) : null}
+            </div>
+          ))}
+          {attachedProjectsQuery.isSuccess && (attachedProjectsQuery.data ?? []).length === 0 ? (
+            <TypographyP className="text-sm text-foreground/52">
+              No projects assigned yet.
+            </TypographyP>
+          ) : null}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/glossaries/[glossaryId]/page.tsx
@@ -1,0 +1,24 @@
+import { Suspense } from "react";
+
+import { hasCapability } from "@/api/auth/policy";
+import { requireAppAuthContext } from "@/lib/workos/app-auth";
+import { GlossaryDetailPageContent } from "./_components/glossary-detail-page-content";
+
+export default async function GlossaryDetailPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string; glossaryId: string }>;
+}) {
+  const { organizationSlug, glossaryId } = await params;
+  const auth = await requireAppAuthContext({ organizationSlug });
+
+  return (
+    <Suspense fallback={null}>
+      <GlossaryDetailPageContent
+        organizationSlug={organizationSlug}
+        glossaryId={glossaryId}
+        canManageGlossaries={hasCapability(auth.membership.role, "glossaries:write")}
+      />
+    </Suspense>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-page-content.tsx
@@ -28,6 +28,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { Textarea } from "@/components/ui/textarea";
+import { readApiError } from "@/lib/api-error";
 import { apiClient } from "@/lib/api-client-instance";
 
 import {
@@ -152,19 +153,6 @@ function createEmptyGlossaryForm(): GlossaryCreateForm {
     sourceLocale: "en-US",
     targetLocales: ["fr-FR"],
   };
-}
-
-function readApiError(response: Response, fallback: string) {
-  return response
-    .json()
-    .then((body) =>
-      body && typeof body === "object" && "message" in body
-        ? String(body.message)
-        : body && typeof body === "object" && "error" in body
-          ? String(body.error)
-          : fallback,
-    )
-    .catch(() => fallback);
 }
 
 function useGlossaryFilters(searchParams: URLSearchParams) {

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-page-content.tsx
@@ -1,11 +1,23 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
 import { useSearchParams } from "next/navigation";
-import { BookOpenTextIcon } from "@hugeicons/core-free-icons";
-import { useQuery } from "@tanstack/react-query";
+import { Add01Icon, BookOpenTextIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 
+import { Field, FieldError, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import {
   Select,
   SelectContent,
@@ -14,6 +26,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import { Textarea } from "@/components/ui/textarea";
 import { apiClient } from "@/lib/api-client-instance";
 
 import {
@@ -34,6 +48,10 @@ import {
   type ApiGlossary,
 } from "./glossary-list";
 import { GlossariesEmptyAction, GlossariesTable } from "./glossaries-table";
+import {
+  ProjectSourceLocalePicker,
+  ProjectTargetLocalesPicker,
+} from "../../projects/_components/project-locale-picker";
 
 const GLOSSARIES_PAGE_SIZE = 100;
 
@@ -120,6 +138,35 @@ const credentialsQueryKey = (organizationSlug: string) => [
   organizationSlug,
 ];
 
+type GlossaryCreateForm = {
+  name: string;
+  description: string;
+  sourceLocale: string;
+  targetLocales: string[];
+};
+
+function createEmptyGlossaryForm(): GlossaryCreateForm {
+  return {
+    name: "",
+    description: "",
+    sourceLocale: "en-US",
+    targetLocales: ["fr-FR"],
+  };
+}
+
+function readApiError(response: Response, fallback: string) {
+  return response
+    .json()
+    .then((body) =>
+      body && typeof body === "object" && "message" in body
+        ? String(body.message)
+        : body && typeof body === "object" && "error" in body
+          ? String(body.error)
+          : fallback,
+    )
+    .catch(() => fallback);
+}
+
 function useGlossaryFilters(searchParams: URLSearchParams) {
   const [searchQuery, setSearchQuery] = useState("");
   const [sourceFilter, setSourceFilter] = useState(() =>
@@ -173,9 +220,20 @@ function useGlossaryFilters(searchParams: URLSearchParams) {
   };
 }
 
-export function GlossariesPageContent({ organizationSlug }: { organizationSlug: string }) {
+export function GlossariesPageContent({
+  organizationSlug,
+  canCreateGlossaries,
+}: {
+  organizationSlug: string;
+  canCreateGlossaries: boolean;
+}) {
+  const router = useRouter();
   const searchParams = useSearchParams();
+  const queryClient = useQueryClient();
   const [page, setPage] = useState(1);
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const [createForm, setCreateForm] = useState<GlossaryCreateForm>(() => createEmptyGlossaryForm());
+  const [createErrors, setCreateErrors] = useState<{ name?: string; targetLocales?: string }>({});
   const {
     filters,
     searchQuery,
@@ -245,6 +303,35 @@ export function GlossariesPageContent({ organizationSlug }: { organizationSlug: 
       };
     },
   });
+  const createGlossary = useMutation({
+    mutationFn: async (values: GlossaryCreateForm) => {
+      const response = await apiClient.api.orgs[":organizationSlug"].glossaries.$post({
+        param: { organizationSlug },
+        json: {
+          name: values.name.trim(),
+          description: values.description.trim(),
+          sourceLocale: values.sourceLocale,
+          targetLocale: values.targetLocales[0] ?? "",
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(await readApiError(response, "Unable to create glossary"));
+      }
+
+      return response.json();
+    },
+    onSuccess: async (body) => {
+      await queryClient.invalidateQueries({ queryKey: ["glossaries", organizationSlug] });
+      setCreateDialogOpen(false);
+      setCreateForm(createEmptyGlossaryForm());
+      toast.success("Glossary created");
+      router.push(`/org/${organizationSlug}/glossaries/${body.glossary.id}`);
+    },
+    onError: (error) => {
+      toast.error(error.message);
+    },
+  });
 
   const projectIdByExternalKey = useMemo(
     () => buildProjectIdByExternalKey(projectsQuery.data ?? []),
@@ -294,7 +381,7 @@ export function GlossariesPageContent({ organizationSlug }: { organizationSlug: 
 
   const emptyTitle = hasConnectedProvider ? "No glossaries yet" : "Connect a TMS provider";
   const emptyDescription = hasConnectedProvider
-    ? "Provider glossaries and term bases appear here after sync. Native workspace glossaries are listed alongside synced resources."
+    ? "Provider glossaries and term bases appear here after sync. Connect or resync a TMS provider from Integrations if you expected to see one."
     : "Connect Crowdin, Phrase, Smartling, or Lokalise from Integrations to sync glossaries into this workspace.";
 
   const glossaryCountLabel =
@@ -302,14 +389,41 @@ export function GlossariesPageContent({ organizationSlug }: { organizationSlug: 
       ? `${glossaryTotal} ${glossaryTotal === 1 ? "glossary" : "glossaries"}`
       : undefined;
 
+  function submitCreateGlossary() {
+    const errors: { name?: string; targetLocales?: string } = {};
+    if (!createForm.name.trim()) {
+      errors.name = "Glossary name is required.";
+    }
+    if (createForm.targetLocales.length === 0) {
+      errors.targetLocales = "Select one target locale.";
+    }
+    setCreateErrors(errors);
+    if (Object.keys(errors).length > 0) {
+      return;
+    }
+    createGlossary.mutate(createForm);
+  }
+
   return (
     <main className="mx-auto flex w-full max-w-6xl flex-col gap-6">
       <PageHeader
         icon={BookOpenTextIcon}
         label="Workspace"
         title="Glossaries"
-        description="Workspace and synced TMS glossaries and term bases. Provider glossaries stay read-only—connect credentials in Integrations."
+        description="Create first-party workspace glossaries or sync provider term bases. Provider glossaries stay read-only."
         statusLabel={glossaryCountLabel}
+        actions={
+          canCreateGlossaries ? (
+            <Button
+              type="button"
+              onClick={() => setCreateDialogOpen(true)}
+              className="w-full sm:w-fit"
+            >
+              <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
+              Create glossary
+            </Button>
+          ) : null
+        }
       />
 
       {glossariesQuery.isSuccess && (glossaryTotal > 0 || hasActiveFilters) ? (
@@ -480,9 +594,21 @@ export function GlossariesPageContent({ organizationSlug }: { organizationSlug: 
         glossaries={glossaries}
         glossariesQuery={glossariesQuery}
         organizationSlug={organizationSlug}
-        emptyTitle={emptyTitle}
-        emptyDescription={emptyDescription}
-        emptyAction={<GlossariesEmptyAction organizationSlug={organizationSlug} />}
+        emptyTitle={canCreateGlossaries ? "No glossaries yet" : emptyTitle}
+        emptyDescription={
+          canCreateGlossaries
+            ? "Create a workspace glossary, import terms, then assign it to the projects that should use it."
+            : emptyDescription
+        }
+        emptyAction={
+          canCreateGlossaries ? (
+            <Button type="button" size="sm" onClick={() => setCreateDialogOpen(true)}>
+              Create glossary
+            </Button>
+          ) : (
+            <GlossariesEmptyAction organizationSlug={organizationSlug} />
+          )
+        }
       />
 
       {glossariesQuery.isSuccess && glossaryTotal > GLOSSARIES_PAGE_SIZE ? (
@@ -515,6 +641,75 @@ export function GlossariesPageContent({ organizationSlug }: { organizationSlug: 
           </div>
         </div>
       ) : null}
+      <Dialog open={createDialogOpen} onOpenChange={setCreateDialogOpen}>
+        <DialogContent className="max-h-[min(85dvh,42rem)] overflow-y-auto sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Create glossary</DialogTitle>
+            <DialogDescription>
+              Add a first-party terminology library. You can import and edit terms after creation.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-4">
+            <Field className="gap-1.5">
+              <FieldLabel>Name</FieldLabel>
+              <Input
+                value={createForm.name}
+                onChange={(event) =>
+                  setCreateForm((current) => ({ ...current, name: event.target.value }))
+                }
+                disabled={createGlossary.isPending}
+                placeholder="Product terminology"
+              />
+              <FieldError
+                errors={createErrors.name ? [{ message: createErrors.name }] : undefined}
+              />
+            </Field>
+            <ProjectSourceLocalePicker
+              value={createForm.sourceLocale}
+              onChange={(sourceLocale) =>
+                setCreateForm((current) => ({ ...current, sourceLocale }))
+              }
+              disabled={createGlossary.isPending}
+            />
+            <ProjectTargetLocalesPicker
+              value={createForm.targetLocales}
+              sourceLocale={createForm.sourceLocale}
+              onChange={(targetLocales) =>
+                setCreateForm((current) => ({
+                  ...current,
+                  targetLocales: targetLocales.slice(0, 1),
+                }))
+              }
+              disabled={createGlossary.isPending}
+              error={createErrors.targetLocales}
+            />
+            <Field className="gap-1.5">
+              <FieldLabel>Description</FieldLabel>
+              <Textarea
+                value={createForm.description}
+                onChange={(event) =>
+                  setCreateForm((current) => ({ ...current, description: event.target.value }))
+                }
+                disabled={createGlossary.isPending}
+                placeholder="Where this glossary should be used"
+              />
+            </Field>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setCreateDialogOpen(false)}
+              disabled={createGlossary.isPending}
+            >
+              Cancel
+            </Button>
+            <Button onClick={submitCreateGlossary} disabled={createGlossary.isPending}>
+              {createGlossary.isPending ? <Spinner /> : null}
+              Create glossary
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </main>
   );
 }

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-table.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-table.tsx
@@ -110,9 +110,12 @@ function GlossaryRow({
             strokeWidth={1.7}
             className="size-4 shrink-0 text-foreground/42"
           />
-          <TypographyP className="truncate text-sm font-medium text-foreground">
+          <Link
+            href={`/org/${organizationSlug}/glossaries/${glossary.id}`}
+            className="truncate text-sm font-medium text-foreground underline-offset-2 hover:underline"
+          >
             {glossary.name}
-          </TypographyP>
+          </Link>
           <SourceLabel glossary={glossary} />
           <ResourceTypeBadge glossary={glossary} />
         </div>

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/glossaries/page.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/glossaries/page.tsx
@@ -1,5 +1,7 @@
 import { Suspense } from "react";
 
+import { hasCapability } from "@/api/auth/policy";
+import { requireAppAuthContext } from "@/lib/workos/app-auth";
 import { GlossariesPageContent } from "./_components/glossaries-page-content";
 
 export default async function GlossariesPage({
@@ -8,10 +10,14 @@ export default async function GlossariesPage({
   params: Promise<{ organizationSlug: string }>;
 }) {
   const { organizationSlug } = await params;
+  const auth = await requireAppAuthContext({ organizationSlug });
 
   return (
     <Suspense fallback={null}>
-      <GlossariesPageContent organizationSlug={organizationSlug} />
+      <GlossariesPageContent
+        organizationSlug={organizationSlug}
+        canCreateGlossaries={hasCapability(auth.membership.role, "glossaries:write")}
+      />
     </Suspense>
   );
 }

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/translation-memory-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/translation-memory-detail-page-content.tsx
@@ -1,0 +1,486 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { ArrowLeft01Icon, DatabaseSyncIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import type {
+  MemoryEntryRecord,
+  MemoryProjectRecord,
+  MemoryRecord,
+} from "@/api/routes/memory/memory.schema";
+import type { ProjectRecord } from "@/api/routes/project/project.schema";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Field, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { TypographyH1, TypographyP } from "@/components/ui/typography";
+import { apiClient } from "@/lib/api-client-instance";
+
+function readApiError(response: Response, fallback: string) {
+  return response
+    .json()
+    .then((body) =>
+      body && typeof body === "object" && "message" in body
+        ? String(body.message)
+        : body && typeof body === "object" && "error" in body
+          ? String(body.error)
+          : fallback,
+    )
+    .catch(() => fallback);
+}
+
+type EntryForm = {
+  sourceLocale: string;
+  targetLocale: string;
+  sourceText: string;
+  targetText: string;
+};
+
+const emptyEntryForm: EntryForm = {
+  sourceLocale: "en-US",
+  targetLocale: "fr-FR",
+  sourceText: "",
+  targetText: "",
+};
+
+export function TranslationMemoryDetailPageContent({
+  organizationSlug,
+  memoryId,
+  canManageMemories,
+}: {
+  organizationSlug: string;
+  memoryId: string;
+  canManageMemories: boolean;
+}) {
+  const queryClient = useQueryClient();
+  const [entryForm, setEntryForm] = useState<EntryForm>(emptyEntryForm);
+  const [editingEntryId, setEditingEntryId] = useState<string | null>(null);
+  const [selectedProjectId, setSelectedProjectId] = useState("");
+
+  const memoryQuery = useQuery({
+    queryKey: ["translation-memory", organizationSlug, memoryId],
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"]["translation-memories"][
+        ":memoryId"
+      ].$get({ param: { organizationSlug, memoryId } });
+      if (!response.ok) throw new Error(await readApiError(response, "Unable to load memory"));
+      const body = await response.json();
+      return body.memory as MemoryRecord;
+    },
+  });
+
+  const entriesQuery = useQuery({
+    queryKey: ["translation-memory-entries", organizationSlug, memoryId],
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"]["translation-memories"][
+        ":memoryId"
+      ].entries.$get({
+        param: { organizationSlug, memoryId },
+        query: { limit: "50", offset: "0" },
+      });
+      if (!response.ok) throw new Error(await readApiError(response, "Unable to load entries"));
+      const body = await response.json();
+      return body.memoryEntries as MemoryEntryRecord[];
+    },
+  });
+
+  const attachedProjectsQuery = useQuery({
+    queryKey: ["translation-memory-projects", organizationSlug, memoryId],
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"]["translation-memories"][
+        ":memoryId"
+      ].projects.$get({ param: { organizationSlug, memoryId } });
+      if (!response.ok) throw new Error(await readApiError(response, "Unable to load projects"));
+      const body = await response.json();
+      return body.projects as MemoryProjectRecord[];
+    },
+  });
+
+  const projectsQuery = useQuery({
+    queryKey: ["translation-projects", organizationSlug],
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"].projects.$get({
+        param: { organizationSlug },
+      });
+      if (!response.ok) throw new Error(await readApiError(response, "Unable to load projects"));
+      const body = await response.json();
+      return body.projects as ProjectRecord[];
+    },
+  });
+
+  const invalidateEntries = () =>
+    queryClient.invalidateQueries({
+      queryKey: ["translation-memory-entries", organizationSlug, memoryId],
+    });
+  const invalidateProjects = () =>
+    queryClient.invalidateQueries({
+      queryKey: ["translation-memory-projects", organizationSlug, memoryId],
+    });
+
+  const saveEntry = useMutation({
+    mutationFn: async (values: EntryForm) => {
+      const payload = {
+        sourceLocale: values.sourceLocale.trim(),
+        targetLocale: values.targetLocale.trim(),
+        sourceText: values.sourceText.trim(),
+        targetText: values.targetText.trim(),
+        matchScore: 100,
+      };
+      const response = editingEntryId
+        ? await apiClient.api.orgs[":organizationSlug"]["translation-memories"][
+            ":memoryId"
+          ].entries[":entryId"].$patch({
+            param: { organizationSlug, memoryId, entryId: editingEntryId },
+            json: payload,
+          })
+        : await apiClient.api.orgs[":organizationSlug"]["translation-memories"][
+            ":memoryId"
+          ].entries.$post({
+            param: { organizationSlug, memoryId },
+            json: payload,
+          });
+      if (!response.ok) throw new Error(await readApiError(response, "Unable to save entry"));
+      return response.json();
+    },
+    onSuccess: async () => {
+      await invalidateEntries();
+      setEntryForm(emptyEntryForm);
+      setEditingEntryId(null);
+      toast.success(editingEntryId ? "Entry updated" : "Entry added");
+    },
+    onError: (error) => toast.error(error.message),
+  });
+
+  const deleteEntry = useMutation({
+    mutationFn: async (entryId: string) => {
+      const response = await apiClient.api.orgs[":organizationSlug"]["translation-memories"][
+        ":memoryId"
+      ].entries[":entryId"].$delete({ param: { organizationSlug, memoryId, entryId } });
+      if (!response.ok) throw new Error(await readApiError(response, "Unable to delete entry"));
+    },
+    onSuccess: async () => {
+      await invalidateEntries();
+      toast.success("Entry deleted");
+    },
+    onError: (error) => toast.error(error.message),
+  });
+
+  const importEntries = useMutation({
+    mutationFn: async (file: File) => {
+      const content = await file.text();
+      const format = file.name.toLowerCase().endsWith(".tmx") ? "tmx" : "csv";
+      const response = await apiClient.api.orgs[":organizationSlug"]["translation-memories"][
+        ":memoryId"
+      ].entries["import"].$post({
+        param: { organizationSlug, memoryId },
+        json: { format, content },
+      });
+      if (!response.ok) throw new Error(await readApiError(response, "Unable to import entries"));
+      return response.json();
+    },
+    onSuccess: async (body) => {
+      await invalidateEntries();
+      toast.success(`Imported ${body.imported ?? 0} entries`);
+    },
+    onError: (error) => toast.error(error.message),
+  });
+
+  const attachProject = useMutation({
+    mutationFn: async (projectId: string) => {
+      const response = await apiClient.api.orgs[":organizationSlug"]["translation-memories"][
+        ":memoryId"
+      ].projects.$post({ param: { organizationSlug, memoryId }, json: { projectId, priority: 0 } });
+      if (!response.ok) throw new Error(await readApiError(response, "Unable to assign project"));
+      return response.json();
+    },
+    onSuccess: async () => {
+      await invalidateProjects();
+      setSelectedProjectId("");
+      toast.success("Project assigned");
+    },
+    onError: (error) => toast.error(error.message),
+  });
+
+  const detachProject = useMutation({
+    mutationFn: async (projectId: string) => {
+      const response = await apiClient.api.orgs[":organizationSlug"]["translation-memories"][
+        ":memoryId"
+      ].projects[":projectId"].$delete({ param: { organizationSlug, memoryId, projectId } });
+      if (!response.ok) throw new Error(await readApiError(response, "Unable to remove project"));
+    },
+    onSuccess: async () => {
+      await invalidateProjects();
+      toast.success("Project removed");
+    },
+    onError: (error) => toast.error(error.message),
+  });
+
+  const memory = memoryQuery.data;
+  const isNative = memory?.source === "native";
+  const canEdit = canManageMemories && isNative;
+  const attachedProjectIds = useMemo(
+    () => new Set((attachedProjectsQuery.data ?? []).map((project) => project.projectId)),
+    [attachedProjectsQuery.data],
+  );
+  const availableProjects = (projectsQuery.data ?? []).filter(
+    (project) => !attachedProjectIds.has(project.id),
+  );
+
+  if (memoryQuery.isLoading) {
+    return <TypographyP className="py-8 text-sm text-foreground/52">Loading memory...</TypographyP>;
+  }
+  if (!memory) {
+    return (
+      <TypographyP className="py-8 text-sm text-foreground/52">
+        Translation memory not found.
+      </TypographyP>
+    );
+  }
+
+  return (
+    <main className="mx-auto flex w-full max-w-6xl flex-col gap-6">
+      <Link
+        href={`/org/${organizationSlug}/translation-memories`}
+        className="inline-flex w-fit items-center gap-2 text-sm text-foreground/58 hover:text-foreground"
+      >
+        <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" strokeWidth={1.8} />
+        Translation memories
+      </Link>
+
+      <section className="flex flex-col gap-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <HugeiconsIcon
+            icon={DatabaseSyncIcon}
+            className="size-5 text-foreground/48"
+            strokeWidth={1.8}
+          />
+          <Badge variant="outline">{memory.source === "native" ? "Workspace" : "Provider"}</Badge>
+        </div>
+        <TypographyH1 className="font-sans text-2xl font-medium">{memory.name}</TypographyH1>
+        <TypographyP className="max-w-2xl text-sm leading-6 text-foreground/58">
+          {memory.description || "Manage translation examples and assign this memory to projects."}
+        </TypographyP>
+      </section>
+
+      <section className="grid gap-4 rounded-lg border border-foreground/8 p-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <TypographyP className="text-sm font-medium text-foreground">Entries</TypographyP>
+            <TypographyP className="text-xs text-foreground/52">
+              Add aligned source and target examples manually or import CSV/TMX files.
+            </TypographyP>
+          </div>
+          {canEdit ? (
+            <Input
+              type="file"
+              accept=".csv,.tmx,text/csv"
+              className="max-w-xs"
+              onChange={(event) => {
+                const file = event.target.files?.[0];
+                if (file) importEntries.mutate(file);
+                event.currentTarget.value = "";
+              }}
+            />
+          ) : null}
+        </div>
+
+        {canEdit ? (
+          <div className="grid gap-3 md:grid-cols-2">
+            <Field className="gap-1.5">
+              <FieldLabel>Source locale</FieldLabel>
+              <Input
+                value={entryForm.sourceLocale}
+                onChange={(event) =>
+                  setEntryForm((current) => ({ ...current, sourceLocale: event.target.value }))
+                }
+              />
+            </Field>
+            <Field className="gap-1.5">
+              <FieldLabel>Target locale</FieldLabel>
+              <Input
+                value={entryForm.targetLocale}
+                onChange={(event) =>
+                  setEntryForm((current) => ({ ...current, targetLocale: event.target.value }))
+                }
+              />
+            </Field>
+            <Field className="gap-1.5">
+              <FieldLabel>Source text</FieldLabel>
+              <Textarea
+                value={entryForm.sourceText}
+                onChange={(event) =>
+                  setEntryForm((current) => ({ ...current, sourceText: event.target.value }))
+                }
+              />
+            </Field>
+            <Field className="gap-1.5">
+              <FieldLabel>Target text</FieldLabel>
+              <Textarea
+                value={entryForm.targetText}
+                onChange={(event) =>
+                  setEntryForm((current) => ({ ...current, targetText: event.target.value }))
+                }
+              />
+            </Field>
+            <div className="flex gap-2 md:col-span-2">
+              <Button
+                type="button"
+                disabled={
+                  !entryForm.sourceText.trim() ||
+                  !entryForm.targetText.trim() ||
+                  !entryForm.sourceLocale.trim() ||
+                  !entryForm.targetLocale.trim() ||
+                  saveEntry.isPending
+                }
+                onClick={() => saveEntry.mutate(entryForm)}
+              >
+                {editingEntryId ? "Update entry" : "Add entry"}
+              </Button>
+              {editingEntryId ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => {
+                    setEditingEntryId(null);
+                    setEntryForm(emptyEntryForm);
+                  }}
+                >
+                  Cancel edit
+                </Button>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
+
+        <div className="overflow-hidden rounded-lg border border-foreground/8">
+          {(entriesQuery.data ?? []).map((entry) => (
+            <div
+              key={entry.id}
+              className="grid gap-2 border-b border-foreground/8 px-4 py-3 last:border-b-0 md:grid-cols-[1fr_1fr_auto] md:items-center"
+            >
+              <div>
+                <TypographyP className="text-sm font-medium">{entry.sourceText}</TypographyP>
+                <TypographyP className="text-xs text-foreground/48">
+                  {entry.sourceLocale} → {entry.targetLocale}
+                </TypographyP>
+              </div>
+              <TypographyP className="text-sm text-foreground/72">{entry.targetText}</TypographyP>
+              {canEdit ? (
+                <div className="flex gap-2">
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    onClick={() => {
+                      setEditingEntryId(entry.id);
+                      setEntryForm({
+                        sourceLocale: entry.sourceLocale,
+                        targetLocale: entry.targetLocale,
+                        sourceText: entry.sourceText,
+                        targetText: entry.targetText,
+                      });
+                    }}
+                  >
+                    Edit
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => deleteEntry.mutate(entry.id)}
+                  >
+                    Delete
+                  </Button>
+                </div>
+              ) : null}
+            </div>
+          ))}
+          {entriesQuery.isSuccess && (entriesQuery.data ?? []).length === 0 ? (
+            <TypographyP className="px-4 py-6 text-sm text-foreground/52">
+              No entries yet.
+            </TypographyP>
+          ) : null}
+        </div>
+      </section>
+
+      <section className="grid gap-4 rounded-lg border border-foreground/8 p-4">
+        <div>
+          <TypographyP className="text-sm font-medium text-foreground">
+            Assigned projects
+          </TypographyP>
+          <TypographyP className="text-xs text-foreground/52">
+            This memory is used only by the projects listed here.
+          </TypographyP>
+        </div>
+        {canEdit ? (
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <Select
+              value={selectedProjectId}
+              onValueChange={(value) => setSelectedProjectId(value ?? "")}
+            >
+              <SelectTrigger className="sm:max-w-sm">
+                <SelectValue placeholder="Select project" />
+              </SelectTrigger>
+              <SelectContent>
+                {availableProjects.map((project) => (
+                  <SelectItem key={project.id} value={project.id}>
+                    {project.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Button
+              type="button"
+              disabled={!selectedProjectId || attachProject.isPending}
+              onClick={() => attachProject.mutate(selectedProjectId)}
+            >
+              Assign to project
+            </Button>
+          </div>
+        ) : null}
+        <div className="grid gap-2">
+          {(attachedProjectsQuery.data ?? []).map((project) => (
+            <div
+              key={project.projectId}
+              className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-foreground/8 px-3 py-2"
+            >
+              <Link
+                href={`/org/${organizationSlug}/projects/${project.projectId}`}
+                className="text-sm font-medium text-foreground hover:underline"
+              >
+                {project.projectName}
+              </Link>
+              {canEdit ? (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => detachProject.mutate(project.projectId)}
+                >
+                  Remove
+                </Button>
+              ) : null}
+            </div>
+          ))}
+          {attachedProjectsQuery.isSuccess && (attachedProjectsQuery.data ?? []).length === 0 ? (
+            <TypographyP className="text-sm text-foreground/52">
+              No projects assigned yet.
+            </TypographyP>
+          ) : null}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/translation-memory-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/_components/translation-memory-detail-page-content.tsx
@@ -26,20 +26,8 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { TypographyH1, TypographyP } from "@/components/ui/typography";
+import { readApiError } from "@/lib/api-error";
 import { apiClient } from "@/lib/api-client-instance";
-
-function readApiError(response: Response, fallback: string) {
-  return response
-    .json()
-    .then((body) =>
-      body && typeof body === "object" && "message" in body
-        ? String(body.message)
-        : body && typeof body === "object" && "error" in body
-          ? String(body.error)
-          : fallback,
-    )
-    .catch(() => fallback);
-}
 
 type EntryForm = {
   sourceLocale: string;

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/translation-memories/[memoryId]/page.tsx
@@ -1,0 +1,24 @@
+import { Suspense } from "react";
+
+import { hasCapability } from "@/api/auth/policy";
+import { requireAppAuthContext } from "@/lib/workos/app-auth";
+import { TranslationMemoryDetailPageContent } from "./_components/translation-memory-detail-page-content";
+
+export default async function TranslationMemoryDetailPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string; memoryId: string }>;
+}) {
+  const { organizationSlug, memoryId } = await params;
+  const auth = await requireAppAuthContext({ organizationSlug });
+
+  return (
+    <Suspense fallback={null}>
+      <TranslationMemoryDetailPageContent
+        organizationSlug={organizationSlug}
+        memoryId={memoryId}
+        canManageMemories={hasCapability(auth.membership.role, "memories:write")}
+      />
+    </Suspense>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-page-content.tsx
@@ -1,10 +1,21 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { useSearchParams } from "next/navigation";
-import { DatabaseSyncIcon } from "@hugeicons/core-free-icons";
-import { useQuery } from "@tanstack/react-query";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Add01Icon, DatabaseSyncIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Field, FieldError, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import {
   Select,
@@ -14,6 +25,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import { Textarea } from "@/components/ui/textarea";
 import { apiClient } from "@/lib/api-client-instance";
 
 import {
@@ -68,6 +81,28 @@ const credentialsQueryKey = (organizationSlug: string) => [
   "translation-memory-credentials",
   organizationSlug,
 ];
+
+type MemoryCreateForm = {
+  name: string;
+  description: string;
+};
+
+function createEmptyMemoryForm(): MemoryCreateForm {
+  return { name: "", description: "" };
+}
+
+function readApiError(response: Response, fallback: string) {
+  return response
+    .json()
+    .then((body) =>
+      body && typeof body === "object" && "message" in body
+        ? String(body.message)
+        : body && typeof body === "object" && "error" in body
+          ? String(body.error)
+          : fallback,
+    )
+    .catch(() => fallback);
+}
 
 function useMemoryFilters(memories: MemoryListRow[], searchParams: URLSearchParams) {
   const [searchQuery, setSearchQuery] = useState("");
@@ -127,9 +162,20 @@ function useMemoryFilters(memories: MemoryListRow[], searchParams: URLSearchPara
   };
 }
 
-export function TranslationMemoriesPageContent({ organizationSlug }: { organizationSlug: string }) {
+export function TranslationMemoriesPageContent({
+  organizationSlug,
+  canCreateMemories,
+}: {
+  organizationSlug: string;
+  canCreateMemories: boolean;
+}) {
+  const router = useRouter();
   const searchParams = useSearchParams();
+  const queryClient = useQueryClient();
   const [page, setPage] = useState(1);
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const [createForm, setCreateForm] = useState<MemoryCreateForm>(() => createEmptyMemoryForm());
+  const [createErrors, setCreateErrors] = useState<{ name?: string }>({});
   const projectsQuery = useQuery({
     queryKey: projectsQueryKey(organizationSlug),
     queryFn: async () => {
@@ -184,6 +230,33 @@ export function TranslationMemoriesPageContent({ organizationSlug }: { organizat
         memories: body.memories as ApiMemory[],
         total: body.total as number,
       };
+    },
+  });
+  const createMemory = useMutation({
+    mutationFn: async (values: MemoryCreateForm) => {
+      const response = await apiClient.api.orgs[":organizationSlug"]["translation-memories"].$post({
+        param: { organizationSlug },
+        json: {
+          name: values.name.trim(),
+          description: values.description.trim(),
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(await readApiError(response, "Unable to create translation memory"));
+      }
+
+      return response.json();
+    },
+    onSuccess: async (body) => {
+      await queryClient.invalidateQueries({ queryKey: ["translation-memories", organizationSlug] });
+      setCreateDialogOpen(false);
+      setCreateForm(createEmptyMemoryForm());
+      toast.success("Translation memory created");
+      router.push(`/org/${organizationSlug}/translation-memories/${body.memory.id}`);
+    },
+    onError: (error) => {
+      toast.error(error.message);
     },
   });
 
@@ -248,7 +321,7 @@ export function TranslationMemoriesPageContent({ organizationSlug }: { organizat
     ? "No translation memories yet"
     : "Connect a TMS provider";
   const emptyDescription = hasConnectedProvider
-    ? "Provider translation memories appear here after sync. Native workspace memories can also be created from this page once creation is enabled."
+    ? "Provider translation memories appear here after sync. Connect or resync a TMS provider from Integrations if you expected to see one."
     : "Connect Crowdin, Phrase, Smartling, or Lokalise from Integrations to sync translation memories into this workspace.";
 
   const memoryCountLabel =
@@ -256,14 +329,38 @@ export function TranslationMemoriesPageContent({ organizationSlug }: { organizat
       ? `${memoryTotal} ${memoryTotal === 1 ? "memory" : "memories"}`
       : undefined;
 
+  function submitCreateMemory() {
+    const errors: { name?: string } = {};
+    if (!createForm.name.trim()) {
+      errors.name = "Translation memory name is required.";
+    }
+    setCreateErrors(errors);
+    if (Object.keys(errors).length > 0) {
+      return;
+    }
+    createMemory.mutate(createForm);
+  }
+
   return (
     <main className="mx-auto flex w-full max-w-6xl flex-col gap-6">
       <PageHeader
         icon={DatabaseSyncIcon}
         label="Workspace"
         title="Translation Memories"
-        description="Workspace and synced TMS translation memories. Provider memories stay read-only—connect credentials in Integrations."
+        description="Create first-party workspace memories or sync provider translation memories. Provider memories stay read-only."
         statusLabel={memoryCountLabel}
+        actions={
+          canCreateMemories ? (
+            <Button
+              type="button"
+              onClick={() => setCreateDialogOpen(true)}
+              className="w-full sm:w-fit"
+            >
+              <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
+              Create memory
+            </Button>
+          ) : null
+        }
       />
 
       {memoriesQuery.isSuccess && memories.length > 0 ? (
@@ -403,9 +500,21 @@ export function TranslationMemoriesPageContent({ organizationSlug }: { organizat
         memories={filteredMemories}
         memoriesQuery={memoriesQuery}
         organizationSlug={organizationSlug}
-        emptyTitle={emptyTitle}
-        emptyDescription={emptyDescription}
-        emptyAction={<TranslationMemoriesEmptyAction organizationSlug={organizationSlug} />}
+        emptyTitle={canCreateMemories ? "No translation memories yet" : emptyTitle}
+        emptyDescription={
+          canCreateMemories
+            ? "Create a workspace memory, import entries, then assign it to the projects that should use it."
+            : emptyDescription
+        }
+        emptyAction={
+          canCreateMemories ? (
+            <Button type="button" size="sm" onClick={() => setCreateDialogOpen(true)}>
+              Create memory
+            </Button>
+          ) : (
+            <TranslationMemoriesEmptyAction organizationSlug={organizationSlug} />
+          )
+        }
       />
 
       {memoriesQuery.isSuccess && memoryTotal > MEMORIES_PAGE_SIZE ? (
@@ -438,6 +547,56 @@ export function TranslationMemoriesPageContent({ organizationSlug }: { organizat
           </div>
         </div>
       ) : null}
+      <Dialog open={createDialogOpen} onOpenChange={setCreateDialogOpen}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Create translation memory</DialogTitle>
+            <DialogDescription>
+              Add a first-party memory library. You can import and edit entries after creation.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-4">
+            <Field className="gap-1.5">
+              <FieldLabel>Name</FieldLabel>
+              <Input
+                value={createForm.name}
+                onChange={(event) =>
+                  setCreateForm((current) => ({ ...current, name: event.target.value }))
+                }
+                disabled={createMemory.isPending}
+                placeholder="Marketing launch memory"
+              />
+              <FieldError
+                errors={createErrors.name ? [{ message: createErrors.name }] : undefined}
+              />
+            </Field>
+            <Field className="gap-1.5">
+              <FieldLabel>Description</FieldLabel>
+              <Textarea
+                value={createForm.description}
+                onChange={(event) =>
+                  setCreateForm((current) => ({ ...current, description: event.target.value }))
+                }
+                disabled={createMemory.isPending}
+                placeholder="When this memory should be used"
+              />
+            </Field>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setCreateDialogOpen(false)}
+              disabled={createMemory.isPending}
+            >
+              Cancel
+            </Button>
+            <Button onClick={submitCreateMemory} disabled={createMemory.isPending}>
+              {createMemory.isPending ? <Spinner /> : null}
+              Create memory
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </main>
   );
 }

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-page-content.tsx
@@ -27,6 +27,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { Textarea } from "@/components/ui/textarea";
+import { readApiError } from "@/lib/api-error";
 import { apiClient } from "@/lib/api-client-instance";
 
 import {
@@ -89,19 +90,6 @@ type MemoryCreateForm = {
 
 function createEmptyMemoryForm(): MemoryCreateForm {
   return { name: "", description: "" };
-}
-
-function readApiError(response: Response, fallback: string) {
-  return response
-    .json()
-    .then((body) =>
-      body && typeof body === "object" && "message" in body
-        ? String(body.message)
-        : body && typeof body === "object" && "error" in body
-          ? String(body.error)
-          : fallback,
-    )
-    .catch(() => fallback);
 }
 
 function useMemoryFilters(memories: MemoryListRow[], searchParams: URLSearchParams) {

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-table.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-table.tsx
@@ -100,9 +100,12 @@ function MemoryRow({
             strokeWidth={1.7}
             className="size-4 shrink-0 text-foreground/42"
           />
-          <TypographyP className="truncate text-sm font-medium text-foreground">
+          <Link
+            href={`/org/${organizationSlug}/translation-memories/${memory.id}`}
+            className="truncate text-sm font-medium text-foreground underline-offset-2 hover:underline"
+          >
             {memory.name}
-          </TypographyP>
+          </Link>
           <SourceLabel memory={memory} />
         </div>
         <TypographyP className="mt-1 text-xs text-foreground/42">{sourceDetail}</TypographyP>

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/translation-memories/page.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/translation-memories/page.tsx
@@ -1,5 +1,7 @@
 import { Suspense } from "react";
 
+import { hasCapability } from "@/api/auth/policy";
+import { requireAppAuthContext } from "@/lib/workos/app-auth";
 import { TranslationMemoriesPageContent } from "./_components/translation-memories-page-content";
 
 export default async function TranslationMemoriesPage({
@@ -8,10 +10,14 @@ export default async function TranslationMemoriesPage({
   params: Promise<{ organizationSlug: string }>;
 }) {
   const { organizationSlug } = await params;
+  const auth = await requireAppAuthContext({ organizationSlug });
 
   return (
     <Suspense fallback={null}>
-      <TranslationMemoriesPageContent organizationSlug={organizationSlug} />
+      <TranslationMemoriesPageContent
+        organizationSlug={organizationSlug}
+        canCreateMemories={hasCapability(auth.membership.role, "memories:write")}
+      />
     </Suspense>
   );
 }

--- a/apps/hyperlocalise-web/src/lib/api-error.ts
+++ b/apps/hyperlocalise-web/src/lib/api-error.ts
@@ -1,0 +1,12 @@
+export function readApiError(response: Response, fallback: string) {
+  return response
+    .json()
+    .then((body) =>
+      body && typeof body === "object" && "message" in body
+        ? String(body.message)
+        : body && typeof body === "object" && "error" in body
+          ? String(body.error)
+          : fallback,
+    )
+    .catch(() => fallback);
+}

--- a/apps/hyperlocalise-web/src/lib/csv/parse-csv-rows.ts
+++ b/apps/hyperlocalise-web/src/lib/csv/parse-csv-rows.ts
@@ -1,0 +1,39 @@
+export function parseCsvRows(content: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let cell = "";
+  let quoted = false;
+
+  for (let index = 0; index < content.length; index++) {
+    const char = content[index];
+    const next = content[index + 1];
+
+    if (char === '"' && quoted && next === '"') {
+      cell += '"';
+      index++;
+      continue;
+    }
+    if (char === '"') {
+      quoted = !quoted;
+      continue;
+    }
+    if (char === "," && !quoted) {
+      row.push(cell.trim());
+      cell = "";
+      continue;
+    }
+    if ((char === "\n" || char === "\r") && !quoted) {
+      if (char === "\r" && next === "\n") index++;
+      row.push(cell.trim());
+      if (row.some(Boolean)) rows.push(row);
+      row = [];
+      cell = "";
+      continue;
+    }
+    cell += char;
+  }
+
+  row.push(cell.trim());
+  if (row.some(Boolean)) rows.push(row);
+  return rows;
+}

--- a/apps/hyperlocalise-web/src/lib/glossary/glossary-term-dedupe.test.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/glossary-term-dedupe.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { createGlossaryTermDuplicateTracker } from "./glossary-term-dedupe";
+
+describe("createGlossaryTermDuplicateTracker", () => {
+  it("uses exact keys for case-sensitive terms", () => {
+    const tracker = createGlossaryTermDuplicateTracker([{ sourceTerm: "Hello" }]);
+
+    expect(tracker.hasDuplicateAndTrack({ sourceTerm: "Hello", caseSensitive: true })).toBe(true);
+    expect(tracker.hasDuplicateAndTrack({ sourceTerm: "hello", caseSensitive: true })).toBe(false);
+  });
+
+  it("uses lowercased keys for case-insensitive terms", () => {
+    const tracker = createGlossaryTermDuplicateTracker([{ sourceTerm: "Hello" }]);
+
+    expect(tracker.hasDuplicateAndTrack({ sourceTerm: "hello", caseSensitive: false })).toBe(true);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/glossary/glossary-term-dedupe.ts
+++ b/apps/hyperlocalise-web/src/lib/glossary/glossary-term-dedupe.ts
@@ -1,0 +1,32 @@
+type GlossaryTermDuplicateInput = {
+  sourceTerm: string;
+  caseSensitive: boolean;
+};
+
+type ExistingGlossaryTerm = {
+  sourceTerm: string;
+};
+
+export function createGlossaryTermDuplicateTracker(existing: ExistingGlossaryTerm[]) {
+  const seenExactSourceTerms = new Set(existing.map((term) => term.sourceTerm));
+  const seenCaseInsensitiveSourceTerms = new Set(
+    existing.map((term) => term.sourceTerm.toLowerCase()),
+  );
+
+  return {
+    hasDuplicateAndTrack(input: GlossaryTermDuplicateInput) {
+      const sourceTermKey = input.sourceTerm;
+      const caseInsensitiveSourceTermKey = input.sourceTerm.toLowerCase();
+      const duplicateExists = input.caseSensitive
+        ? seenExactSourceTerms.has(sourceTermKey)
+        : seenCaseInsensitiveSourceTerms.has(caseInsensitiveSourceTermKey);
+
+      if (!duplicateExists) {
+        seenExactSourceTerms.add(sourceTermKey);
+        seenCaseInsensitiveSourceTerms.add(caseInsensitiveSourceTermKey);
+      }
+
+      return duplicateExists;
+    },
+  };
+}


### PR DESCRIPTION
## What changed

- Added first-party creation flows for workspace glossaries and translation memories.
- Added glossary and translation memory detail pages for manual CRUD, CSV/TBX/TMX imports, and project assignment from the resource page.
- Added org-scoped REST endpoints and focused route coverage for terms, entries, imports, and project attachments while keeping provider-backed resources read-only.

## How to test

- `vp check --fix`
- `vp test`

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, `vp test`)
- [x] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)