### PR TITLE
🧪 Scout: support namespaced tags in HTML tag parity check

### DIFF
--- a/internal/i18n/htmltagparity/htmltagparity.go
+++ b/internal/i18n/htmltagparity/htmltagparity.go
@@ -57,7 +57,7 @@ func isLikelyMarkupTag(raw, normalized string) bool {
 	if tag == "" {
 		return false
 	}
-	if atom.Lookup([]byte(tag)) != 0 || strings.Contains(tag, "-") {
+	if atom.Lookup([]byte(tag)) != 0 || strings.Contains(tag, "-") || strings.Contains(tag, ":") {
 		return true
 	}
 	rawName := rawTagName(raw)

--- a/internal/i18n/htmltagparity/htmltagparity_test.go
+++ b/internal/i18n/htmltagparity/htmltagparity_test.go
@@ -104,6 +104,12 @@ func TestMismatchFormattingAndKnownTags(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "namespaced tags are treated as markup",
+			src:  "Hello <ui:button>world</ui:button>",
+			tgt:  "Bonjour world",
+			want: true,
+		},
+		{
 			name: "ignores path-like tokens that are known atoms",
 			src:  "Path <id> and <name>",
 			tgt:  "Path <id> and <name>",


### PR DESCRIPTION
💡 What: Support for namespaced tags in HTML tag parity check.
🎯 Why: Namespaced tags (e.g. `<ui:button>`) are common in some markup formats and should be treated as markup to ensure structural parity during translation.
🧩 Scope: `internal/i18n/htmltagparity/htmltagparity.go`, `internal/i18n/htmltagparity/htmltagparity_test.go`
✅ Verification: `go test -v ./internal/i18n/htmltagparity/...`
🛡️ Confidence: Prevents accidental removal or addition of namespaced tags in translations.

---
*PR created automatically by Jules for task [4408055849840062522](https://jules.google.com/task/4408055849840062522) started by @cungminh2710*