### PR TITLE
feat(web): support multi-intent Slack agent routing

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/conversation/chat-stream.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/chat-stream.route.ts
@@ -11,7 +11,9 @@ import { workosAuthMiddleware } from "@/api/auth/workos";
 import { resolveApiAuthContextFromSession } from "@/api/auth/workos-session";
 import {
   buildTranslationAttachmentRequiredMessage,
+  classifyConversation,
   createConversationToolLoopAgent,
+  getRecentUserConversationText,
   loadInteractionModelMessages,
 } from "@/lib/agent-runtime/loops/hyperlocalise-agent";
 import { db } from "@/lib/database";
@@ -114,8 +116,17 @@ export function createChatStreamRoutes() {
         }
 
         const chatMessages = await loadInteractionModelMessages(conversationId);
+        const conversationText = getRecentUserConversationText(chatMessages, message.text);
+        const classification = await classifyConversation({
+          currentMessage: message.text,
+          conversationText,
+          hasFileAttachments: hasTranslationAttachments,
+          hasStoredRepositoryContext: false,
+          surface: "web",
+        });
         const agent = createConversationToolLoopAgent({
           surface: "web",
+          suggestedIntents: classification.intents,
           toolContext: {
             conversationId,
             organizationId: orgId,
@@ -125,7 +136,6 @@ export function createChatStreamRoutes() {
             db,
           },
           hasFileAttachments: hasTranslationAttachments,
-          userMessageText: message.text,
         });
 
         const result = await agent.stream({ messages: chatMessages });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/context.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/context.ts
@@ -1,5 +1,8 @@
 import type { HyperlocaliseAgentSurface } from "@/lib/agent-runtime/loops/hyperlocalise-agent";
-import type { HyperlocaliseConversationMode } from "@/lib/agent-runtime/loops/conversation-mode";
+import type {
+  HyperlocaliseConversationIntent,
+  HyperlocaliseConversationMode,
+} from "@/lib/agent-runtime/loops/conversation-mode";
 import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
 import type { ToolContext } from "@/lib/agent-contracts/tool-context";
 
@@ -10,6 +13,9 @@ import type { ToolContext } from "@/lib/agent-contracts/tool-context";
 export type HyperlocaliseAgentRuntimeContext = {
   surface: HyperlocaliseAgentSurface;
   toolContext: ToolContext;
+  /** Active intents for this turn (translation and repository may both apply). */
+  suggestedIntents: HyperlocaliseConversationIntent[];
+  /** Primary orchestrator hint derived from suggestedIntents. */
   suggestedMode: HyperlocaliseConversationMode;
   hasFileAttachments: boolean;
   additionalInstructions?: string;
@@ -38,13 +44,20 @@ export function resolveAgentRuntimeContext(
   }
 
   const context = experimentalContext as Partial<HyperlocaliseAgentRuntimeContext>;
-  if (!context.toolContext || !context.surface || !context.suggestedMode) {
+  if (
+    !context.toolContext ||
+    !context.surface ||
+    !context.suggestedMode ||
+    !context.suggestedIntents ||
+    context.suggestedIntents.length === 0
+  ) {
     return err({ code: "runtime_context_incomplete" });
   }
 
   return ok({
     surface: context.surface,
     toolContext: context.toolContext,
+    suggestedIntents: context.suggestedIntents,
     suggestedMode: context.suggestedMode,
     hasFileAttachments: context.hasFileAttachments ?? false,
     additionalInstructions: context.additionalInstructions,

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-classifier.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-classifier.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const { generateTextMock } = vi.hoisted(() => ({
+  generateTextMock: vi.fn(),
+}));
+
+vi.mock("ai", async () => {
+  const actual = await vi.importActual<typeof import("ai")>("ai");
+
+  return {
+    ...actual,
+    generateText: generateTextMock,
+  };
+});
+
+vi.mock("@/lib/agent-runtime/loops/model", () => ({
+  getHyperlocaliseAgentModel: vi.fn(() => "mock-model"),
+}));
+
+import {
+  classifyConversation,
+  classificationHasIntent,
+  getPrimarySuggestedMode,
+  getRecentUserConversationText,
+  normalizeConversationIntents,
+  shouldAttemptRepositoryContextResolution,
+  shouldRequireRepositoryContextClarification,
+} from "./conversation-classifier";
+
+function repositoryClassification(
+  overrides: Partial<{
+    intents: Array<"translation" | "repository" | "general">;
+    needsRepositoryTools: boolean;
+    continuesRepositoryThread: boolean;
+    currentMessageSpecifiesRepository: boolean;
+    shouldAskForRepositoryClarification: boolean;
+    requiresPullRequest: boolean;
+  }> = {},
+) {
+  return {
+    intents: ["repository"] as const,
+    needsRepositoryTools: true,
+    requiresPullRequest: false,
+    shouldAskForRepositoryClarification: false,
+    continuesRepositoryThread: false,
+    currentMessageSpecifiesRepository: false,
+    confidence: 0.95,
+    ...overrides,
+  };
+}
+
+describe("conversation classifier routing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("normalizes multi-intent output and drops general when specific intents exist", () => {
+    expect(normalizeConversationIntents(["translation", "repository", "general"])).toEqual([
+      "translation",
+      "repository",
+    ]);
+  });
+
+  it("uses general orchestrator mode when translation and repository are both active", () => {
+    expect(getPrimarySuggestedMode(["translation", "repository"])).toBe("general");
+  });
+
+  it("enables repository resolution when repository is among intents", () => {
+    expect(
+      shouldAttemptRepositoryContextResolution({
+        classification: repositoryClassification(),
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps repository tools on thread follow-ups when context was stored", () => {
+    expect(
+      shouldAttemptRepositoryContextResolution({
+        classification: repositoryClassification({
+          intents: ["repository"],
+          needsRepositoryTools: false,
+          continuesRepositoryThread: true,
+        }),
+        storedRepositoryContext: {
+          resolved: true,
+          installationId: 1,
+          repositoryFullName: "acme/web",
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("detects translation intent in multi-intent classification", () => {
+    const classification = repositoryClassification({
+      intents: ["translation", "repository"],
+    });
+    expect(classificationHasIntent(classification, "translation")).toBe(true);
+    expect(classificationHasIntent(classification, "repository")).toBe(true);
+  });
+
+  it("uses model output for repository clarification", () => {
+    expect(
+      shouldRequireRepositoryContextClarification(
+        repositoryClassification({ shouldAskForRepositoryClarification: true }),
+      ),
+    ).toBe(true);
+  });
+
+  it("builds recent user conversation text for classification", () => {
+    expect(
+      getRecentUserConversationText(
+        [{ role: "user", content: "what's the context of Providers" }],
+        "Github repo",
+      ),
+    ).toBe("what's the context of Providers\nGithub repo");
+  });
+
+  it("classifies conversations through the AI SDK", async () => {
+    generateTextMock.mockResolvedValueOnce({
+      output: repositoryClassification({
+        intents: ["repository"],
+        continuesRepositoryThread: true,
+      }),
+    });
+
+    await expect(
+      classifyConversation({
+        currentMessage: "What are the words nearby?",
+        conversationText: "what's the context of Providers\nWhat are the words nearby?",
+        hasFileAttachments: false,
+        hasStoredRepositoryContext: true,
+        surface: "slack",
+      }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        intents: ["repository"],
+        continuesRepositoryThread: true,
+      }),
+    );
+
+    expect(generateTextMock).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-classifier.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-classifier.test.ts
@@ -20,6 +20,7 @@ vi.mock("@/lib/agent-runtime/loops/model", () => ({
 import {
   classifyConversation,
   classificationHasIntent,
+  fallbackConversationClassification,
   getPrimarySuggestedMode,
   getRecentUserConversationText,
   normalizeConversationIntents,
@@ -57,6 +58,12 @@ describe("conversation classifier routing", () => {
 
   it("uses general orchestrator mode when translation and repository are both active", () => {
     expect(getPrimarySuggestedMode(["translation", "repository"])).toBe("general");
+  });
+
+  it("accepts readonly intent arrays when normalizing", () => {
+    const intents = ["translation", "repository"] as const;
+
+    expect(normalizeConversationIntents(intents)).toEqual(["translation", "repository"]);
   });
 
   it("enables repository resolution when repository is among intents", () => {
@@ -133,5 +140,38 @@ describe("conversation classifier routing", () => {
     );
 
     expect(generateTextMock).toHaveBeenCalledOnce();
+  });
+
+  it("falls back when AI classification fails", async () => {
+    generateTextMock.mockRejectedValueOnce(new Error("model unavailable"));
+
+    await expect(
+      classifyConversation({
+        currentMessage: "Hello",
+        conversationText: "Hello",
+        hasFileAttachments: false,
+        hasStoredRepositoryContext: false,
+        surface: "web",
+      }),
+    ).resolves.toEqual(
+      fallbackConversationClassification({
+        hasFileAttachments: false,
+        hasStoredRepositoryContext: false,
+      }),
+    );
+  });
+
+  it("falls back to translation intent when attachments are present", () => {
+    expect(
+      fallbackConversationClassification({
+        hasFileAttachments: true,
+        hasStoredRepositoryContext: false,
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        intents: ["translation"],
+        confidence: 0,
+      }),
+    );
   });
 });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-classifier.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-classifier.test.ts
@@ -25,20 +25,14 @@ import {
   normalizeConversationIntents,
   shouldAttemptRepositoryContextResolution,
   shouldRequireRepositoryContextClarification,
+  type ConversationClassification,
 } from "./conversation-classifier";
 
 function repositoryClassification(
-  overrides: Partial<{
-    intents: Array<"translation" | "repository" | "general">;
-    needsRepositoryTools: boolean;
-    continuesRepositoryThread: boolean;
-    currentMessageSpecifiesRepository: boolean;
-    shouldAskForRepositoryClarification: boolean;
-    requiresPullRequest: boolean;
-  }> = {},
-) {
+  overrides: Partial<ConversationClassification> = {},
+): ConversationClassification {
   return {
-    intents: ["repository"] as const,
+    intents: ["repository"],
     needsRepositoryTools: true,
     requiresPullRequest: false,
     shouldAskForRepositoryClarification: false,

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-classifier.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-classifier.ts
@@ -1,0 +1,223 @@
+import { generateText, Output, type LanguageModel, type ModelMessage } from "ai";
+import { z } from "zod";
+
+import type { RepositoryAgentGitHubContext } from "@/lib/agent-contracts/repository-task";
+
+import { getHyperlocaliseAgentModel } from "./model";
+import type {
+  HyperlocaliseConversationIntent,
+  HyperlocaliseConversationMode,
+} from "./conversation-mode";
+
+export const conversationIntentSchema = z.enum(["translation", "repository", "general"]);
+
+export const conversationClassificationSchema = z.object({
+  intents: z.array(conversationIntentSchema).min(1),
+  needsRepositoryTools: z.boolean(),
+  requiresPullRequest: z.boolean(),
+  shouldAskForRepositoryClarification: z.boolean(),
+  continuesRepositoryThread: z.boolean(),
+  currentMessageSpecifiesRepository: z.boolean(),
+  confidence: z.number().min(0).max(1),
+});
+
+export type ConversationClassification = z.infer<typeof conversationClassificationSchema>;
+
+type ConversationClassifierSurface = "slack" | "web" | "github";
+
+type ClassifyConversationInput = {
+  currentMessage: string;
+  conversationText: string;
+  hasFileAttachments: boolean;
+  hasStoredRepositoryContext: boolean;
+  surface: ConversationClassifierSurface;
+};
+
+type CreateConversationClassifierOptions = {
+  model: LanguageModel;
+};
+
+const maxConversationClassificationChars = 12_000;
+
+function truncateForClassification(value: string) {
+  if (value.length <= maxConversationClassificationChars) {
+    return value;
+  }
+
+  return `${value.slice(0, maxConversationClassificationChars)}\n[truncated]`;
+}
+
+function buildConversationClassificationPrompt(input: ClassifyConversationInput) {
+  return [
+    "Classify this Hyperlocalise agent conversation for routing and GitHub repository tooling.",
+    "",
+    "Intent rules (return one or more in `intents`):",
+    '- "translation": translate or localize uploaded files/images, create translation jobs, or set locales for attached sources.',
+    '- "repository": read-only localization context from a connected GitHub repo (where a string/key/copy appears, surrounding text, product context, nearby words).',
+    '- "general": greetings, product questions, job status, glossary, or requests outside translation/repo lookup.',
+    "",
+    "Multi-intent:",
+    "- Include every intent the user needs in this turn. Translation and repository can both appear when the user wants file jobs and repo context in the same request.",
+    "- When both translation and repository apply, include both intents (do not collapse to one).",
+    '- Use "general" only when no translation or repository work is needed. Do not combine "general" with other intents.',
+    "",
+    "Repository tooling flags:",
+    "- needsRepositoryTools: true when the assistant should connect to GitHub and use read-only repo search tools for this turn.",
+    "- continuesRepositoryThread: true when the latest message continues an in-thread repo lookup (for example nearby words, surrounding copy, which file, show more) even if the latest message is short.",
+    "- currentMessageSpecifiesRepository: true only when the latest user message explicitly names a repo (owner/name), GitHub URL, or pull request.",
+    "- requiresPullRequest: true only when the user is asking for PR-scoped work such as fixing, reviewing, or checking a specific pull request.",
+    "- shouldAskForRepositoryClarification: true when the user clearly wants repo-based localization context but the conversation does not yet identify which repository or PR to use.",
+    "",
+    "Use the full recent conversation, not only the latest message.",
+    "If a repository was already established earlier in the thread, treat short follow-ups as continuesRepositoryThread and keep needsRepositoryTools true when repository intent applies.",
+    "",
+    `Surface: ${input.surface}`,
+    `Has file attachments in this turn: ${input.hasFileAttachments ? "yes" : "no"}`,
+    `Thread already has resolved repository context: ${input.hasStoredRepositoryContext ? "yes" : "no"}`,
+    "",
+    "Recent conversation:",
+    truncateForClassification(input.conversationText.trim() || "(none)"),
+    "",
+    "Latest user message:",
+    truncateForClassification(input.currentMessage.trim() || "(none)"),
+  ].join("\n");
+}
+
+export function normalizeConversationIntents(
+  intents: HyperlocaliseConversationIntent[],
+): HyperlocaliseConversationIntent[] {
+  const unique = [...new Set(intents)];
+  const specific = unique.filter((intent) => intent !== "general");
+
+  if (specific.length > 0) {
+    return specific;
+  }
+
+  return ["general"];
+}
+
+export function normalizeConversationClassification(
+  classification: ConversationClassification,
+): ConversationClassification {
+  const intents = normalizeConversationIntents(classification.intents ?? ["general"]);
+
+  return {
+    intents,
+    needsRepositoryTools: classification.needsRepositoryTools || intents.includes("repository"),
+    requiresPullRequest: classification.requiresPullRequest,
+    shouldAskForRepositoryClarification: classification.shouldAskForRepositoryClarification,
+    continuesRepositoryThread: classification.continuesRepositoryThread,
+    currentMessageSpecifiesRepository: classification.currentMessageSpecifiesRepository,
+    confidence: classification.confidence,
+  };
+}
+
+export function classificationHasIntent(
+  classification: ConversationClassification,
+  intent: HyperlocaliseConversationIntent,
+): boolean {
+  return classification.intents.includes(intent);
+}
+
+export function getPrimarySuggestedMode(
+  intents: HyperlocaliseConversationIntent[],
+): HyperlocaliseConversationMode {
+  const normalized = normalizeConversationIntents(intents);
+
+  if (normalized.includes("translation") && normalized.includes("repository")) {
+    return "general";
+  }
+
+  if (normalized.includes("repository")) {
+    return "repository";
+  }
+
+  if (normalized.includes("translation")) {
+    return "translation";
+  }
+
+  return "general";
+}
+
+export function createConversationClassifier({ model }: CreateConversationClassifierOptions) {
+  return async (input: ClassifyConversationInput): Promise<ConversationClassification> => {
+    const { output } = await generateText({
+      model,
+      output: Output.object({
+        schema: conversationClassificationSchema,
+      }),
+      system:
+        "You are a precise conversation router for a localization agent. Return only structured classification data.",
+      prompt: buildConversationClassificationPrompt(input),
+      temperature: 0,
+    });
+
+    return normalizeConversationClassification(output);
+  };
+}
+
+export async function classifyConversation(
+  input: ClassifyConversationInput,
+): Promise<ConversationClassification> {
+  const classify = createConversationClassifier({
+    model: getHyperlocaliseAgentModel(),
+  });
+
+  return classify(input);
+}
+
+export function getRecentUserConversationText(
+  messages: ModelMessage[],
+  latestText: string,
+  limit = 5,
+): string {
+  const userLines = messages.flatMap((chatMessage) => {
+    if (chatMessage.role !== "user" || typeof chatMessage.content !== "string") {
+      return [];
+    }
+
+    const text = chatMessage.content.trim();
+    return text ? [text] : [];
+  });
+
+  const trimmedLatest = latestText.trim();
+  if (trimmedLatest && userLines.at(-1) !== trimmedLatest) {
+    userLines.push(trimmedLatest);
+  }
+
+  return userLines.slice(-limit).join("\n");
+}
+
+export function shouldAttemptRepositoryContextResolution(input: {
+  classification: ConversationClassification;
+  storedRepositoryContext?: RepositoryAgentGitHubContext | null;
+}): boolean {
+  if (
+    input.classification.needsRepositoryTools ||
+    classificationHasIntent(input.classification, "repository")
+  ) {
+    return true;
+  }
+
+  if (!input.storedRepositoryContext) {
+    return false;
+  }
+
+  return (
+    input.classification.continuesRepositoryThread ||
+    classificationHasIntent(input.classification, "repository")
+  );
+}
+
+export function shouldRequireRepositoryContextClarification(
+  classification: ConversationClassification,
+): boolean {
+  return classification.shouldAskForRepositoryClarification;
+}
+
+/** @deprecated Use classification.intents or getPrimarySuggestedMode instead. */
+export function getClassificationMode(
+  classification: ConversationClassification,
+): HyperlocaliseConversationMode {
+  return getPrimarySuggestedMode(classification.intents);
+}

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-classifier.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-classifier.ts
@@ -84,7 +84,7 @@ function buildConversationClassificationPrompt(input: ClassifyConversationInput)
 }
 
 export function normalizeConversationIntents(
-  intents: HyperlocaliseConversationIntent[],
+  intents: readonly HyperlocaliseConversationIntent[],
 ): HyperlocaliseConversationIntent[] {
   const unique = [...new Set(intents)];
   const specific = unique.filter((intent) => intent !== "general");
@@ -120,7 +120,7 @@ export function classificationHasIntent(
 }
 
 export function getPrimarySuggestedMode(
-  intents: HyperlocaliseConversationIntent[],
+  intents: readonly HyperlocaliseConversationIntent[],
 ): HyperlocaliseConversationMode {
   const normalized = normalizeConversationIntents(intents);
 
@@ -156,6 +156,24 @@ export function createConversationClassifier({ model }: CreateConversationClassi
   };
 }
 
+export function fallbackConversationClassification(
+  input: Pick<ClassifyConversationInput, "hasFileAttachments" | "hasStoredRepositoryContext">,
+): ConversationClassification {
+  const intents: HyperlocaliseConversationIntent[] = input.hasFileAttachments
+    ? ["translation"]
+    : ["general"];
+
+  return {
+    intents,
+    needsRepositoryTools: false,
+    requiresPullRequest: false,
+    shouldAskForRepositoryClarification: false,
+    continuesRepositoryThread: input.hasStoredRepositoryContext,
+    currentMessageSpecifiesRepository: false,
+    confidence: 0,
+  };
+}
+
 export async function classifyConversation(
   input: ClassifyConversationInput,
 ): Promise<ConversationClassification> {
@@ -163,7 +181,11 @@ export async function classifyConversation(
     model: getHyperlocaliseAgentModel(),
   });
 
-  return classify(input);
+  try {
+    return await classify(input);
+  } catch {
+    return fallbackConversationClassification(input);
+  }
 }
 
 export function getRecentUserConversationText(
@@ -203,10 +225,7 @@ export function shouldAttemptRepositoryContextResolution(input: {
     return false;
   }
 
-  return (
-    input.classification.continuesRepositoryThread ||
-    classificationHasIntent(input.classification, "repository")
-  );
+  return input.classification.continuesRepositoryThread;
 }
 
 export function shouldRequireRepositoryContextClarification(

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-mode.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-mode.test.ts
@@ -1,38 +1,14 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import {
-  buildConversationModeInstructions,
-  classifyConversationMode,
-  conversationModeRequiresPullRequestContext,
-} from "./conversation-mode";
+import { buildConversationModeInstructions } from "./conversation-mode";
 
-describe("conversation mode", () => {
-  it("classifies find-context requests as repository mode", () => {
-    expect(
-      classifyConversationMode("Can you find the context of the text 'Email agent' in our github"),
-    ).toBe("repository");
+describe("conversation mode instructions", () => {
+  it("describes repository lookup behavior", () => {
     expect(buildConversationModeInstructions("repository")).toContain("find localization context");
     expect(buildConversationModeInstructions("repository")).toContain("placeholder");
   });
 
-  it("classifies translation requests as translation mode", () => {
-    expect(classifyConversationMode("Translate this JSON file to French")).toBe("translation");
+  it("describes file translation behavior", () => {
     expect(buildConversationModeInstructions("translation")).toContain("createTranslationJob");
-  });
-
-  it("classifies pull request URLs as repository mode", () => {
-    expect(classifyConversationMode("Can you check https://github.com/acme/web/pull/42")).toBe(
-      "repository",
-    );
-    expect(
-      conversationModeRequiresPullRequestContext(
-        "Can you check https://github.com/acme/web/pull/42",
-        "repository",
-      ),
-    ).toBe(true);
-  });
-
-  it("does not treat standalone run plus hl as repository mode", () => {
-    expect(classifyConversationMode("Run a translation job in HL")).toBe("translation");
   });
 });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-mode.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-mode.ts
@@ -1,79 +1,8 @@
-import {
-  classifyAgentRequestText,
-  type AgentPlannerIntent,
-} from "@/lib/agent-runtime/requests/planner";
-import {
-  extractGitHubRepositoryFullNameReferences,
-  githubPullRequestUrlPatternSource,
-} from "@/lib/agent-contracts/github-text-patterns";
-import { escapeRegExp } from "@/lib/primitives/escapeRegExp/escapeRegExp";
+/** Agent intents the conversation router can activate (one or more per turn). */
+export type HyperlocaliseConversationIntent = "translation" | "repository" | "general";
 
-/** Conversation routing modes — maps to focused tool loops, not a single translation default. */
-export type HyperlocaliseConversationMode = "translation" | "repository" | "general";
-
-const githubPullRequestUrlPattern = new RegExp(githubPullRequestUrlPatternSource, "i");
-
-/**
- * Classifies the latest user message into a conversation mode.
- * Uses the shared planner heuristics plus GitHub-specific patterns for PR/repo lookup.
- */
-export function classifyConversationMode(text: string): HyperlocaliseConversationMode {
-  const plannerIntent = classifyAgentRequestText(text);
-  if (plannerIntent === "translation" || plannerIntent === "repository") {
-    return plannerIntent;
-  }
-
-  if (isRepositoryConversationRequest(text)) {
-    return "repository";
-  }
-
-  return "general";
-}
-
-export function isRepositoryConversationRequest(text: string): boolean {
-  const trimmed = text.trim();
-  if (!trimmed) {
-    return false;
-  }
-
-  if (githubPullRequestUrlPattern.test(trimmed)) {
-    return true;
-  }
-
-  if (/\b(?:pull request|pr)\s*#?\d+\b/i.test(trimmed) || /\bgithub\s+#?\d+\b/i.test(trimmed)) {
-    return true;
-  }
-
-  if (isExplicitGitHubRepositoryMessage(trimmed)) {
-    return true;
-  }
-
-  const repoSubject = /\b(?:repo|repository|github|hl|hyperlocalise)\b/i.test(trimmed);
-  const repoAction =
-    /\b(?:checks?|fix|review|scan|inspect|sync|extract|analy[sz]e|search|find(?:ing)?|locate|lookup)\b/i.test(
-      trimmed,
-    );
-  const repoRunAction = /\brun\s+(?:the\s+)?(?:repo|repository|github|hl|hyperlocalise)\b/i.test(
-    trimmed,
-  );
-
-  return repoSubject && (repoAction || repoRunAction);
-}
-
-export function conversationModeRequiresPullRequestContext(
-  text: string,
-  mode: HyperlocaliseConversationMode,
-): boolean {
-  if (mode !== "repository") {
-    return false;
-  }
-
-  return (
-    githubPullRequestUrlPattern.test(text) ||
-    /\b(?:pull request|pr)\s*#?\d+\b/i.test(text) ||
-    /\bgithub\s+#?\d+\b/i.test(text)
-  );
-}
+/** Primary routing label derived from intents (orchestrator hint when a single intent dominates). */
+export type HyperlocaliseConversationMode = HyperlocaliseConversationIntent;
 
 export function buildConversationModeInstructions(
   mode: HyperlocaliseConversationMode,
@@ -96,32 +25,6 @@ export function buildConversationModeInstructions(
       "Ask for targetLocales (and sourceLocale when missing) before creating a translation job.",
       "Do not invent sourceFileId values; use only IDs provided in the conversation.",
     ].join("\n");
-  }
-
-  return null;
-}
-
-function isExplicitGitHubRepositoryMessage(text: string): boolean {
-  const references = extractGitHubRepositoryFullNameReferences(text);
-  if (references.length !== 1) {
-    return false;
-  }
-
-  const repositoryFullName = references[0]!;
-  const remainder = text
-    .replace(new RegExp(escapeRegExp(repositoryFullName), "gi"), "")
-    .replace(/https?:\/\/(?:www\.)?github\.com\/[^\s]+/gi, "")
-    .trim();
-
-  return remainder.length <= 40;
-}
-
-/** @internal Exported for tests that assert planner alignment. */
-export function plannerIntentToConversationMode(
-  intent: AgentPlannerIntent,
-): HyperlocaliseConversationMode | null {
-  if (intent === "translation" || intent === "repository") {
-    return intent;
   }
 
   return null;

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/hyperlocalise-agent.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/hyperlocalise-agent.test.ts
@@ -117,7 +117,7 @@ describe("hyperlocalise agent core", () => {
         model: "mock-model",
         tools,
         activeTools: ["example"],
-        stopWhen: { stepLimit: 5 },
+        stopWhen: { stepLimit: hyperlocaliseAgentStepLimit },
       }),
     );
   });
@@ -125,6 +125,7 @@ describe("hyperlocalise agent core", () => {
   it("creates an orchestrator runtime for translation mode", () => {
     createConversationToolLoopAgent({
       surface: "web",
+      suggestedIntents: ["translation"],
       toolContext: {
         conversationId: "conv_123",
         organizationId: "org_123",
@@ -134,7 +135,6 @@ describe("hyperlocalise agent core", () => {
         db: {} as never,
       },
       hasFileAttachments: true,
-      userMessageText: "Translate this file to French",
     });
 
     expect(createConversationOrchestratorAgent).toHaveBeenCalledWith(
@@ -150,6 +150,7 @@ describe("hyperlocalise agent core", () => {
   it("creates an orchestrator runtime for repository mode", () => {
     createConversationToolLoopAgent({
       surface: "slack",
+      suggestedIntents: ["repository"],
       toolContext: {
         conversationId: "conv_123",
         organizationId: "org_123",
@@ -159,7 +160,6 @@ describe("hyperlocalise agent core", () => {
         db: {} as never,
         sandboxId: "sbx_123",
       },
-      userMessageText: "Find 'Email agent' in our GitHub repo",
     });
 
     expect(createConversationOrchestratorAgent).toHaveBeenCalledWith(

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/hyperlocalise-agent.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/hyperlocalise-agent.ts
@@ -15,21 +15,28 @@ import { getHyperlocaliseAgentModel } from "./model";
 export { getHyperlocaliseAgentModel, hyperlocaliseAgentModelId } from "./model";
 import type { ToolContext } from "@/lib/agent-contracts/tool-context";
 
-import { classifyConversationMode } from "./conversation-mode";
+import type { HyperlocaliseConversationIntent } from "./conversation-mode";
+import { getPrimarySuggestedMode, normalizeConversationIntents } from "./conversation-classifier";
 import {
   createConversationOrchestratorAgent,
   type ConversationOrchestratorOnFinish,
 } from "./orchestrator";
 
 export type { HyperlocaliseConversationMode } from "./conversation-mode";
+export { buildConversationModeInstructions } from "./conversation-mode";
 export {
-  buildConversationModeInstructions,
-  classifyConversationMode,
-  conversationModeRequiresPullRequestContext,
-  isRepositoryConversationRequest,
-} from "./conversation-mode";
+  classifyConversation,
+  createConversationClassifier,
+  getPrimarySuggestedMode,
+  getRecentUserConversationText,
+  normalizeConversationIntents,
+  shouldAttemptRepositoryContextResolution,
+  shouldRequireRepositoryContextClarification,
+  type ConversationClassification,
+} from "./conversation-classifier";
+export type { HyperlocaliseConversationIntent } from "./conversation-mode";
 
-export const hyperlocaliseAgentStepLimit = 5;
+export const hyperlocaliseAgentStepLimit = 40;
 export const hyperlocaliseAgentMaxOutputTokens = 4_000;
 
 export type HyperlocaliseAgentSurface = "web" | "slack" | "github";
@@ -54,6 +61,7 @@ type CreateHyperlocaliseAgentInput<TOOLS extends ToolSet> = {
 type CreateConversationAgentInput = {
   surface: HyperlocaliseAgentSurface;
   toolContext: ToolContext;
+  suggestedIntents: HyperlocaliseConversationIntent[];
   additionalInstructions?: string;
   onFinish?: ConversationOrchestratorOnFinish;
 };
@@ -180,19 +188,19 @@ export function createHyperlocaliseAgent<TOOLS extends ToolSet>({
 export function createConversationToolLoopAgent({
   surface,
   toolContext,
+  suggestedIntents,
   additionalInstructions,
   onFinish,
   hasFileAttachments = false,
-  userMessageText = "",
-}: Omit<CreateConversationAgentInput, "intent"> & {
+}: CreateConversationAgentInput & {
   hasFileAttachments?: boolean;
-  userMessageText?: string;
 }) {
-  const suggestedMode = classifyConversationMode(userMessageText);
+  const normalizedIntents = normalizeConversationIntents(suggestedIntents);
   const runtime: HyperlocaliseAgentRuntimeContext = {
     surface,
     toolContext,
-    suggestedMode,
+    suggestedIntents: normalizedIntents,
+    suggestedMode: getPrimarySuggestedMode(normalizedIntents),
     hasFileAttachments,
     additionalInstructions: additionalInstructions?.trim() || undefined,
   };

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/orchestrator.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/orchestrator.test.ts
@@ -17,9 +17,10 @@ describe("conversation orchestrator", () => {
     const instructions = buildOrchestratorInstructions({
       surface: "web",
       projectId: null,
+      suggestedIntents: ["repository"],
       suggestedMode: "repository",
       availableSubagents: ["repository"],
-      preferredSubagent: "repository",
+      preferredSubagents: ["repository"],
     });
 
     expect(instructions).toContain("Repository context handoff");
@@ -27,5 +28,23 @@ describe("conversation orchestrator", () => {
     expect(instructions).toContain("source text");
     expect(instructions).toContain("placeholder meanings");
     expect(instructions).toContain("Do not use repository context for broad architecture");
+  });
+
+  it("instructs sequential delegation when multiple intents are active", () => {
+    const instructions = buildOrchestratorInstructions({
+      surface: "slack",
+      projectId: null,
+      suggestedIntents: ["translation", "repository"],
+      suggestedMode: "general",
+      availableSubagents: ["repository", "translation"],
+      preferredSubagents: ["repository", "translation"],
+    });
+
+    expect(instructions).toContain("Active intents");
+    expect(instructions).toContain("`translation`");
+    expect(instructions).toContain("`repository`");
+    expect(instructions).toContain("`repository` → `translation`");
+    expect(instructions).toContain("Run every agent");
+    expect(instructions).toContain("complete repository context collection before translation");
   });
 });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/orchestrator.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/orchestrator.ts
@@ -1,10 +1,12 @@
 import { stepCountIs, ToolLoopAgent, type ToolLoopAgentSettings } from "ai";
 import type { HyperlocaliseAgentRuntimeContext } from "@/lib/agent-runtime/context";
+import type { HyperlocaliseConversationIntent } from "@/lib/agent-runtime/loops/conversation-mode";
 import {
   buildSubagentSummaryLines,
   listAvailableSubagentTypes,
-  resolveSubagentTypeForMode,
+  resolvePreferredSubagentOrder,
 } from "@/lib/agent-runtime/subagents/registry";
+import type { HyperlocaliseSubagentType } from "@/lib/agent-runtime/subagents/definitions";
 import { createTaskTool } from "@/lib/agent-runtime/tools/task-tool";
 import { ORCHESTRATOR_STEP_LIMIT } from "@/lib/agent-runtime/subagents/constants";
 
@@ -26,9 +28,10 @@ export type ConversationOrchestratorOnFinish = ToolLoopAgentSettings<
 export function buildOrchestratorInstructions(input: {
   surface: HyperlocaliseAgentSurface;
   projectId: string | null;
+  suggestedIntents: HyperlocaliseConversationIntent[];
   suggestedMode: HyperlocaliseConversationMode;
   availableSubagents: string[];
-  preferredSubagent: string | null;
+  preferredSubagents: HyperlocaliseSubagentType[];
   additionalInstructions?: string;
 }) {
   const base = buildHyperlocaliseAgentInstructions({
@@ -41,33 +44,43 @@ export function buildOrchestratorInstructions(input: {
     base,
     "",
     "## Orchestration",
-    "You coordinate specialists via the `task` tool. Do not call translation or repository tools directly.",
-    "Your job is to choose the right specialist, provide a precise handoff, then synthesize the result for the user.",
+    "You coordinate agents via the `task` tool. Do not call translation or repository tools directly.",
+    "Your job is to choose the right agent, provide a precise handoff, then synthesize the result for the user.",
     "",
-    "Available specialists:",
+    "Available agents:",
     buildSubagentSummaryLines(),
   ];
 
   if (input.availableSubagents.length === 0) {
     lines.push(
       "",
-      "No specialists are available for this request. Explain what the user should provide (file attachment or GitHub repo access).",
+      "No agents are available for this request. Explain what the user should provide (file attachment or GitHub repo access).",
     );
   } else {
     lines.push(
       "",
-      `Specialists available now: ${input.availableSubagents.map((name) => `\`${name}\``).join(", ")}.`,
+      `Agents available now: ${input.availableSubagents.map((name) => `\`${name}\``).join(", ")}.`,
     );
   }
 
-  if (input.preferredSubagent) {
+  lines.push(
+    "",
+    `Active intents for this message: ${input.suggestedIntents.map((intent) => `\`${intent}\``).join(", ")}.`,
+  );
+
+  if (input.preferredSubagents.length === 1) {
     lines.push(
-      `Suggested specialist for this message: \`${input.preferredSubagent}\` (mode: ${input.suggestedMode}).`,
-      "Delegate to that specialist unless the user clearly needs a different one.",
+      `Delegate to \`${input.preferredSubagents[0]}\` for this turn unless the user clearly needs a different agent.`,
+    );
+  } else if (input.preferredSubagents.length > 1) {
+    lines.push(
+      `Delegate to each required agent in order: ${input.preferredSubagents.map((name) => `\`${name}\``).join(" → ")}.`,
+      "Run every agent that matches an active intent before sending the final reply.",
+      "Pass repository findings into the translation task when both intents apply.",
     );
   } else if (input.suggestedMode !== "general") {
     lines.push(
-      `Conversation mode hint: ${input.suggestedMode}. Pick the matching specialist when available.`,
+      `Conversation mode hint: ${input.suggestedMode}. Pick the matching agent when available.`,
     );
   }
 
@@ -82,9 +95,9 @@ export function buildOrchestratorInstructions(input: {
     "",
     "Translation handoff:",
     "- Use `translation` for uploaded-file translation jobs when sourceFileId values and locales are available.",
-    "- If repository context is needed for a translation and the repository specialist is available, collect that context first, then pass the relevant summary into the translation task.",
+    "- When both repository and translation intents are active, complete repository context collection before translation jobs.",
     "",
-    "After a specialist returns, synthesize a clear user-facing reply from their summary.",
+    "After each agent returns, synthesize one clear user-facing reply that covers every intent addressed.",
   );
 
   return lines.join("\n");
@@ -95,7 +108,7 @@ export function createConversationOrchestratorAgent(
   onFinish?: ConversationOrchestratorOnFinish,
 ) {
   const available = listAvailableSubagentTypes(runtime);
-  const preferredSubagent = resolveSubagentTypeForMode(runtime);
+  const preferredSubagents = resolvePreferredSubagentOrder(runtime);
   const taskTool = createTaskTool();
 
   return new ToolLoopAgent<never, { task: typeof taskTool }>({
@@ -103,9 +116,10 @@ export function createConversationOrchestratorAgent(
     instructions: buildOrchestratorInstructions({
       surface: runtime.surface,
       projectId: runtime.toolContext.projectId,
+      suggestedIntents: runtime.suggestedIntents,
       suggestedMode: runtime.suggestedMode,
       availableSubagents: available,
-      preferredSubagent,
+      preferredSubagents,
       additionalInstructions: runtime.additionalInstructions,
     }),
     tools: {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/runs/agent-run-events.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/runs/agent-run-events.test.ts
@@ -5,7 +5,7 @@ vi.mock("@/lib/conversations/interactions", () => ({
   addInteractionMessage: vi.fn(),
 }));
 
-import { wrapThreadPostForInteraction } from "./agent-run-events";
+import { postThreadMessageWithoutTracking, wrapThreadPostForInteraction } from "./agent-run-events";
 
 function createThread() {
   const posts: unknown[] = [];
@@ -74,6 +74,16 @@ describe("wrapThreadPostForInteraction", () => {
       senderType: "agent",
       text: "Agent reply",
     });
+  });
+
+  it("posts without persisting when tracking is enabled", async () => {
+    const addMessage = vi.fn(async () => ({ id: "msg_123" }));
+    const { thread } = createThread();
+
+    wrapThreadPostForInteraction(thread, "interaction_123", addMessage);
+    await postThreadMessageWithoutTracking(thread, { markdown: "Processing ack" });
+
+    expect(addMessage).not.toHaveBeenCalled();
   });
 
   it("updates the tracked interaction without double wrapping", async () => {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/runs/agent-run-events.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/runs/agent-run-events.ts
@@ -11,6 +11,7 @@ type AddAgentMessage = (input: {
 type TrackedPostState = {
   addMessage: AddAgentMessage;
   interactionId: string;
+  originalPost: Thread<unknown>["post"];
 };
 
 const trackedThreadPosts = new WeakMap<object, TrackedPostState>();
@@ -50,10 +51,10 @@ export function wrapThreadPostForInteraction<TState>(
     return;
   }
 
-  const trackedState: TrackedPostState = { interactionId, addMessage };
+  const originalPost = thread.post.bind(thread);
+  const trackedState: TrackedPostState = { interactionId, addMessage, originalPost };
   trackedThreadPosts.set(thread, trackedState);
 
-  const originalPost = thread.post.bind(thread);
   thread.post = async (...args: Parameters<typeof originalPost>) => {
     const result = await originalPost(...args);
 
@@ -72,4 +73,17 @@ export function wrapThreadPostForInteraction<TState>(
 
     return result;
   };
+}
+
+/** Posts to Slack (or other chat surfaces) without persisting to the interaction message store. */
+export async function postThreadMessageWithoutTracking<TState>(
+  thread: Thread<TState>,
+  ...args: Parameters<Thread<TState>["post"]>
+) {
+  const tracked = trackedThreadPosts.get(thread);
+  if (tracked) {
+    return tracked.originalPost(...args);
+  }
+
+  return thread.post(...args);
 }

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/subagents/constants.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/subagents/constants.ts
@@ -1,8 +1,8 @@
-/** Tool steps allowed inside a specialist subagent loop. */
-export const SUBAGENT_STEP_LIMIT = 5;
+/** Tool steps allowed inside a subagent loop. */
+export const SUBAGENT_STEP_LIMIT = 20;
 
 /** Steps for the parent orchestrator (delegate + synthesize). */
-export const ORCHESTRATOR_STEP_LIMIT = 3;
+export const ORCHESTRATOR_STEP_LIMIT = 5;
 
 export const SUBAGENT_NO_QUESTIONS_RULES = [
   "You cannot ask follow-up questions — no one will respond in this loop.",

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/subagents/constants.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/subagents/constants.ts
@@ -1,8 +1,8 @@
 /** Tool steps allowed inside a subagent loop. */
-export const SUBAGENT_STEP_LIMIT = 20;
+export const SUBAGENT_STEP_LIMIT = 10;
 
 /** Steps for the parent orchestrator (delegate + synthesize). */
-export const ORCHESTRATOR_STEP_LIMIT = 5;
+export const ORCHESTRATOR_STEP_LIMIT = 3;
 
 export const SUBAGENT_NO_QUESTIONS_RULES = [
   "You cannot ask follow-up questions — no one will respond in this loop.",

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/subagents/definitions.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/subagents/definitions.ts
@@ -16,7 +16,7 @@ export const SUBAGENT_REGISTRY = {
       "Translate uploaded localization files and queue translation jobs when sourceFileId values are available",
     agent: translationSubagent,
     isAvailable: (runtime: HyperlocaliseAgentRuntimeContext) =>
-      runtime.hasFileAttachments || runtime.suggestedMode === "translation",
+      runtime.hasFileAttachments || runtime.suggestedIntents.includes("translation"),
     unavailableMessage: (_runtime) =>
       "Translation requires an attached localization file with a target language.",
   },

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/subagents/registry.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/subagents/registry.test.ts
@@ -53,6 +53,19 @@ describe("subagent registry", () => {
     expect(resolveSubagentTypeForMode(runtime)).toBe("repository");
   });
 
+  it("returns no preferred subagents for general intent even when agents are available", () => {
+    const runtime = createRuntime({
+      hasFileAttachments: true,
+      toolContext: {
+        ...createRuntime().toolContext,
+        sandboxId: "sbx_1",
+      },
+    });
+    expect(listAvailableSubagentTypes(runtime)).toEqual(["translation", "repository"]);
+    expect(resolvePreferredSubagentOrder(runtime)).toEqual([]);
+    expect(resolveSubagentTypeForMode(runtime)).toBeNull();
+  });
+
   it("orders repository before translation when both intents are active", () => {
     const runtime = createRuntime({
       suggestedIntents: ["translation", "repository"],

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/subagents/registry.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/subagents/registry.test.ts
@@ -4,6 +4,7 @@ import type { HyperlocaliseAgentRuntimeContext } from "@/lib/agent-runtime/conte
 
 import {
   listAvailableSubagentTypes,
+  resolvePreferredSubagentOrder,
   resolveSubagentTypeForMode,
   SUBAGENT_REGISTRY,
 } from "./registry";
@@ -13,6 +14,7 @@ function createRuntime(
 ): HyperlocaliseAgentRuntimeContext {
   return {
     surface: "slack",
+    suggestedIntents: ["general"],
     suggestedMode: "general",
     hasFileAttachments: false,
     toolContext: {
@@ -29,13 +31,18 @@ function createRuntime(
 
 describe("subagent registry", () => {
   it("lists translation when files are attached", () => {
-    const runtime = createRuntime({ hasFileAttachments: true, suggestedMode: "translation" });
+    const runtime = createRuntime({
+      hasFileAttachments: true,
+      suggestedIntents: ["translation"],
+      suggestedMode: "translation",
+    });
     expect(listAvailableSubagentTypes(runtime)).toContain("translation");
     expect(SUBAGENT_REGISTRY.translation.isAvailable(runtime)).toBe(true);
   });
 
   it("lists repository when a sandbox is available", () => {
     const runtime = createRuntime({
+      suggestedIntents: ["repository"],
       suggestedMode: "repository",
       toolContext: {
         ...createRuntime().toolContext,
@@ -46,15 +53,17 @@ describe("subagent registry", () => {
     expect(resolveSubagentTypeForMode(runtime)).toBe("repository");
   });
 
-  it("prefers translation mode when both specialists are available", () => {
+  it("orders repository before translation when both intents are active", () => {
     const runtime = createRuntime({
-      suggestedMode: "translation",
+      suggestedIntents: ["translation", "repository"],
+      suggestedMode: "general",
       hasFileAttachments: true,
       toolContext: {
         ...createRuntime().toolContext,
         sandboxId: "sbx_1",
       },
     });
-    expect(resolveSubagentTypeForMode(runtime)).toBe("translation");
+    expect(resolvePreferredSubagentOrder(runtime)).toEqual(["repository", "translation"]);
+    expect(resolveSubagentTypeForMode(runtime)).toBe("repository");
   });
 });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/subagents/registry.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/subagents/registry.ts
@@ -20,24 +20,30 @@ export function listAvailableSubagentTypes(
   return SUBAGENT_TYPES.filter((type) => SUBAGENT_REGISTRY[type].isAvailable(runtime));
 }
 
+/** Preferred delegation order when multiple intents are active (repository context before translation). */
+export function resolvePreferredSubagentOrder(
+  runtime: HyperlocaliseAgentRuntimeContext,
+): HyperlocaliseSubagentType[] {
+  const available = new Set(listAvailableSubagentTypes(runtime));
+  const order: HyperlocaliseSubagentType[] = [];
+
+  if (runtime.suggestedIntents.includes("repository") && available.has("repository")) {
+    order.push("repository");
+  }
+
+  if (runtime.suggestedIntents.includes("translation") && available.has("translation")) {
+    order.push("translation");
+  }
+
+  if (order.length > 0) {
+    return order;
+  }
+
+  return listAvailableSubagentTypes(runtime);
+}
+
 export function resolveSubagentTypeForMode(
   runtime: HyperlocaliseAgentRuntimeContext,
 ): HyperlocaliseSubagentType | null {
-  if (
-    runtime.suggestedMode === "translation" &&
-    SUBAGENT_REGISTRY.translation.isAvailable(runtime)
-  ) {
-    return "translation";
-  }
-
-  if (runtime.suggestedMode === "repository" && SUBAGENT_REGISTRY.repository.isAvailable(runtime)) {
-    return "repository";
-  }
-
-  const available = listAvailableSubagentTypes(runtime);
-  if (available.length === 1) {
-    return available[0]!;
-  }
-
-  return null;
+  return resolvePreferredSubagentOrder(runtime)[0] ?? null;
 }

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/subagents/registry.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/subagents/registry.ts
@@ -39,7 +39,7 @@ export function resolvePreferredSubagentOrder(
     return order;
   }
 
-  return listAvailableSubagentTypes(runtime);
+  return [];
 }
 
 export function resolveSubagentTypeForMode(

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/subagents/translation.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/subagents/translation.ts
@@ -11,7 +11,7 @@ import {
 } from "./constants";
 import type { SubagentCallOptions } from "./types";
 
-const TRANSLATION_SYSTEM_PROMPT = `You are the Hyperlocalise translation specialist.
+const TRANSLATION_SYSTEM_PROMPT = `You are the Hyperlocalise translation agent.
 
 ## Role
 Create and queue file translation jobs from source files already attached to the conversation.

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/task-tool.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/task-tool.test.ts
@@ -57,6 +57,7 @@ describe("task tool", () => {
       },
       createToolExecutionOptions({
         surface: "web",
+        suggestedIntents: ["translation"],
         suggestedMode: "translation",
         hasFileAttachments: true,
         toolContext: {
@@ -95,6 +96,7 @@ describe("task tool", () => {
       },
       createToolExecutionOptions({
         surface: "web",
+        suggestedIntents: ["translation"],
         suggestedMode: "translation",
         hasFileAttachments: true,
         toolContext: {
@@ -111,7 +113,7 @@ describe("task tool", () => {
     expect(result).toMatchObject({
       success: false,
       subagentType: "translation",
-      summary: "Specialist encountered an error.",
+      summary: "Agent encountered an error.",
       error: "rate limit exceeded",
     });
   });
@@ -126,6 +128,7 @@ describe("task tool", () => {
       },
       createToolExecutionOptions({
         surface: "slack",
+        suggestedIntents: ["repository"],
         suggestedMode: "repository",
         hasFileAttachments: false,
         toolContext: {
@@ -161,12 +164,12 @@ describe("task tool", () => {
     expect(result).toMatchObject({
       success: false,
       subagentType: "translation",
-      summary: "Specialist cannot run without request context.",
+      summary: "Agent cannot run without request context.",
       error: "Hyperlocalise agent runtime context is incomplete.",
     });
   });
 
-  it("adds localization-context handoff requirements for repository specialists", async () => {
+  it("adds localization-context handoff requirements for the repository agent", async () => {
     runSubagentMock.mockResolvedValueOnce({ text: "Found context in src/messages.ts:12." });
 
     const taskTool = createTaskTool();
@@ -178,6 +181,7 @@ describe("task tool", () => {
       },
       createToolExecutionOptions({
         surface: "slack",
+        suggestedIntents: ["repository"],
         suggestedMode: "repository",
         hasFileAttachments: false,
         toolContext: {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/task-tool.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/task-tool.ts
@@ -32,11 +32,11 @@ export function createTaskTool() {
   const subagentSummaryLines = buildSubagentSummaryLines();
   const taskInputSchema = z.object({
     subagentType: subagentTypeSchema.describe(
-      `Specialist to run. Available options:\n${subagentSummaryLines}`,
+      `Agent to run. Available options:\n${subagentSummaryLines}`,
     ),
     task: z.string().describe("Short description of the work (shown to operators)"),
     instructions: z.string().describe(
-      `Detailed instructions for the specialist. Include:
+      `Detailed instructions for the agent. Include:
 - Goal and deliverables
 - Constraints (locales, file IDs, quoted strings to search)
 - How to verify success`,
@@ -44,25 +44,25 @@ export function createTaskTool() {
   });
 
   return tool({
-    description: `Delegate work to a Hyperlocalise specialist subagent.
+    description: `Delegate work to a Hyperlocalise subagent.
 
-AVAILABLE SPECIALISTS:
+AVAILABLE AGENTS:
 ${subagentSummaryLines}
 
 WHEN TO USE:
 - Translation requests with attached files → \`translation\`
 - Finding localization context for source strings, messages, keys, or uploaded-file segments in GitHub → \`repository\`
-- Any work that matches a specialist description above
+- Any work that matches an agent description above
 
 WHEN NOT TO USE:
 - Simple questions you can answer without tools
-- Requests that need a specialist that is unavailable (explain what is missing instead)
-- General repository architecture summaries, PR fixes, code review, or checks unless a specialist explicitly supports them
+- Requests that need an agent that is unavailable (explain what is missing instead)
+- General repository architecture summaries, PR fixes, code review, or checks unless an agent explicitly supports them
 
 BEHAVIOR:
-- Specialists run autonomously for up to ${SUBAGENT_STEP_LIMIT} tool steps
+- Agents run autonomously for up to ${SUBAGENT_STEP_LIMIT} tool steps
 - They return only a summary — relay that summary to the user
-- Be explicit in instructions; specialists cannot ask clarifying questions`,
+- Be explicit in instructions; agents cannot ask clarifying questions`,
     inputSchema: taskInputSchema,
     outputSchema: taskOutputSchema,
     execute: async ({ subagentType, task, instructions }, { experimental_context }) => {
@@ -71,7 +71,7 @@ BEHAVIOR:
         return {
           success: false,
           subagentType,
-          summary: "Specialist cannot run without request context.",
+          summary: "Agent cannot run without request context.",
           error: formatAgentRuntimeContextError(runtimeResult.error),
         };
       }
@@ -97,7 +97,7 @@ BEHAVIOR:
               ? [
                   instructions,
                   "",
-                  "Repository specialist handoff requirements:",
+                  "Repository agent handoff requirements:",
                   "- Include the exact source text, key, file path, surrounding text, source locale, target locale, and repo hint when known.",
                   "- Return localization context only: product surface, user intent, tone/register, placeholders, nearby copy, existing translations, and ambiguities.",
                   "- Do not ask for code changes, PR review, checks, or broad architecture analysis.",
@@ -111,7 +111,7 @@ BEHAVIOR:
         return {
           success: true,
           subagentType,
-          summary: result.text.trim() || "Specialist completed the task.",
+          summary: result.text.trim() || "Agent completed the task.",
         };
       }
 
@@ -122,7 +122,7 @@ BEHAVIOR:
       return {
         success: false,
         subagentType,
-        summary: "Specialist encountered an error.",
+        summary: "Agent encountered an error.",
         error: message,
       };
     },

--- a/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
@@ -47,6 +47,21 @@ const { enqueueRepositoryTaskMock } = vi.hoisted(() => ({
   enqueueRepositoryTaskMock: vi.fn(async () => ({ ids: ["run-123"] })),
 }));
 
+const { chatLoggerMock, loggerChildMock } = vi.hoisted(() => ({
+  chatLoggerMock: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+  loggerChildMock: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
 vi.mock("@/workflows/adapters", () => ({
   createRepositoryAgentTaskQueue: vi.fn(() => ({ enqueue: enqueueRepositoryTaskMock })),
 }));
@@ -153,19 +168,9 @@ vi.mock("@/lib/agents/runtime/state", () => ({
 }));
 
 vi.mock("@/lib/log", () => ({
-  createChatLogger: vi.fn(() => ({
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  })),
+  createChatLogger: vi.fn(() => chatLoggerMock),
   createLogger: vi.fn(() => ({
-    child: vi.fn(() => ({
-      debug: vi.fn(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    })),
+    child: vi.fn(() => loggerChildMock),
     debug: vi.fn(),
     info: vi.fn(),
     warn: vi.fn(),
@@ -403,6 +408,7 @@ describe("handleNewConversation", () => {
     agentGenerateMock.mockResolvedValue({ text: "AI response" });
     loadMessagesMock.mockResolvedValue([]);
     interactionHasTranslationAttachmentsMock.mockResolvedValue(false);
+    loggerChildMock.info.mockClear();
     resolveSlackRepositoryGitHubContextMock.mockResolvedValue({ status: "not_applicable" });
     classifyConversationMock.mockImplementation(async () => createMockClassification());
   });
@@ -622,6 +628,13 @@ describe("handleNewConversation", () => {
     await handleSubscribedMessage(thread, message);
 
     expect(resolveSlackRepositoryGitHubContextMock).not.toHaveBeenCalled();
+    const reuseLog = loggerChildMock.info.mock.calls.find(
+      ([, message]) => message === "reusing stored slack thread repository context",
+    );
+    expect(reuseLog?.[0]).toEqual({
+      installationId: 12345,
+      hasPullRequestNumber: false,
+    });
     expect(createConversationToolLoopAgentMock).toHaveBeenCalledWith(
       expect.objectContaining({
         toolContext: expect.objectContaining({
@@ -1110,6 +1123,7 @@ describe("handleSubscribedMessage", () => {
       role: "admin",
       localUserId: "user-123",
     } as never);
+    interactionHasTranslationAttachmentsMock.mockResolvedValueOnce(true);
     vi.mocked(findInteractionBySourceThreadId).mockResolvedValue({
       id: "interaction-123",
       title: "Existing",
@@ -1154,6 +1168,15 @@ describe("handleSubscribedMessage", () => {
         },
       ],
     });
+    expect(interactionHasTranslationAttachmentsMock).toHaveBeenCalledWith("interaction-123");
+    expect(vi.mocked(updateInteractionMessage).mock.invocationCallOrder[0]).toBeLessThan(
+      interactionHasTranslationAttachmentsMock.mock.invocationCallOrder[0] ?? 0,
+    );
+    expect(classifyConversationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hasFileAttachments: true,
+      }),
+    );
     expect(createConversationToolLoopAgentMock).toHaveBeenCalledWith(
       expect.objectContaining({
         additionalInstructions: expect.stringContaining('Use sourceLocale "auto"'),

--- a/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
@@ -489,6 +489,12 @@ describe("handleNewConversation", () => {
     expect(createConversationToolLoopAgentMock).toHaveBeenCalled();
     expect(agentGenerateMock).toHaveBeenCalled();
     expect(posts).toEqual([SLACK_PROCESSING_ACK_POST, { markdown: "AI response" }]);
+    expect(addInteractionMessage).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        senderType: "agent",
+        text: "On it — I'll reply here shortly.",
+      }),
+    );
   });
 
   it("skips GitHub context discovery for ordinary chat without attachments", async () => {

--- a/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { emoji } from "chat";
 import type { Message, Thread } from "chat";
 
+import type { ConversationClassification } from "@/lib/agent-runtime/loops/conversation-classifier";
+
 import {
   extractTeamId,
   getOrCreateInteraction,
@@ -9,13 +11,31 @@ import {
   handleSubscribedMessage,
   wrapThreadPost,
 } from "./bot";
+
+function createMockClassification(
+  overrides: Partial<ConversationClassification> = {},
+): ConversationClassification {
+  return {
+    intents: ["general"],
+    needsRepositoryTools: false,
+    requiresPullRequest: false,
+    shouldAskForRepositoryClarification: false,
+    continuesRepositoryThread: false,
+    currentMessageSpecifiesRepository: false,
+    confidence: 0.9,
+    ...overrides,
+  };
+}
+
 const {
   agentGenerateMock,
+  classifyConversationMock,
   createConversationToolLoopAgentMock,
   loadMessagesMock,
   resolveSlackRepositoryGitHubContextMock,
 } = vi.hoisted(() => ({
   agentGenerateMock: vi.fn(),
+  classifyConversationMock: vi.fn(async () => createMockClassification()),
   createConversationToolLoopAgentMock: vi.fn(() => ({
     generate: agentGenerateMock,
   })),
@@ -45,6 +65,7 @@ vi.mock("@/lib/agent-runtime/loops/hyperlocalise-agent", () => {
     )
     .then((actual) => ({
       ...actual,
+      classifyConversation: classifyConversationMock,
       createConversationToolLoopAgent: createConversationToolLoopAgentMock,
       loadInteractionModelMessages: loadMessagesMock,
       replaceLastUserMessage: (
@@ -113,12 +134,19 @@ vi.mock("@/lib/agents/slack/helpers", () => ({
   lookupMembership: vi.fn(),
 }));
 
+const interactionHasTranslationAttachmentsMock = vi.hoisted(() => vi.fn(async () => false));
+
 vi.mock("@/lib/conversations/interactions", () => ({
   addInteractionMessage: vi.fn(async () => ({ id: "msg-123" })),
   createInteraction: vi.fn(),
   findInteractionBySourceThreadId: vi.fn(),
+  interactionHasTranslationAttachments: interactionHasTranslationAttachmentsMock,
   updateInteractionMessage: vi.fn(),
 }));
+
+const SLACK_PROCESSING_ACK_POST = {
+  markdown: "On it — I'll reply here shortly.",
+};
 
 vi.mock("@/lib/agents/runtime/state", () => ({
   createChatStateAdapter: vi.fn(),
@@ -374,7 +402,9 @@ describe("handleNewConversation", () => {
     vi.clearAllMocks();
     agentGenerateMock.mockResolvedValue({ text: "AI response" });
     loadMessagesMock.mockResolvedValue([]);
+    interactionHasTranslationAttachmentsMock.mockResolvedValue(false);
     resolveSlackRepositoryGitHubContextMock.mockResolvedValue({ status: "not_applicable" });
+    classifyConversationMock.mockImplementation(async () => createMockClassification());
   });
 
   it("ignores bot messages", async () => {
@@ -452,7 +482,7 @@ describe("handleNewConversation", () => {
     expect(getSubscribed()).toBe(true);
     expect(createConversationToolLoopAgentMock).toHaveBeenCalled();
     expect(agentGenerateMock).toHaveBeenCalled();
-    expect(posts).toEqual([{ markdown: "AI response" }]);
+    expect(posts).toEqual([SLACK_PROCESSING_ACK_POST, { markdown: "AI response" }]);
   });
 
   it("skips GitHub context discovery for ordinary chat without attachments", async () => {
@@ -488,6 +518,14 @@ describe("handleNewConversation", () => {
       raw: { team_id: "T123", channel: "C123" },
     });
 
+    classifyConversationMock.mockResolvedValueOnce(
+      createMockClassification({
+        intents: ["repository"],
+        needsRepositoryTools: true,
+        currentMessageSpecifiesRepository: true,
+        confidence: 0.95,
+      }),
+    );
     resolveSlackRepositoryGitHubContextMock.mockResolvedValueOnce({
       status: "resolved",
       source: "slack_pr_url",
@@ -539,7 +577,63 @@ describe("handleNewConversation", () => {
     expect(posts).toEqual([{ markdown: "AI response" }]);
   });
 
-  it("resolves GitHub context from the current Slack message only", async () => {
+  it("reuses stored repository context for thread follow-ups without re-resolving", async () => {
+    const { thread, posts } = createThread({
+      repositoryGitHubContext: {
+        resolved: true,
+        installationId: 12345,
+        repositoryFullName: "acme/web",
+      },
+    });
+    const message = createMessage({
+      text: "What are the words nearby?",
+      raw: { team_id: "T123", channel: "C123" },
+    });
+
+    classifyConversationMock.mockResolvedValueOnce(
+      createMockClassification({
+        intents: ["repository"],
+        needsRepositoryTools: true,
+        continuesRepositoryThread: true,
+        confidence: 0.95,
+      }),
+    );
+    loadMessagesMock.mockResolvedValueOnce([
+      { role: "user", content: "what's the context of Providers" },
+      { role: "assistant", content: "Providers is on the landing page." },
+    ] as never);
+    vi.mocked(findSlackConnector).mockResolvedValue({
+      id: "connector-123",
+      organizationId: "org-123",
+      enabled: true,
+      config: {},
+    } as never);
+    vi.mocked(lookupMembership).mockResolvedValue({
+      role: "member",
+      localUserId: "user-123",
+    } as never);
+    vi.mocked(findInteractionBySourceThreadId).mockResolvedValue({
+      id: "interaction-123",
+      title: "Existing",
+      projectId: null,
+    } as never);
+    vi.mocked(addInteractionMessage).mockResolvedValue({ id: "msg-123" } as never);
+
+    await handleSubscribedMessage(thread, message);
+
+    expect(resolveSlackRepositoryGitHubContextMock).not.toHaveBeenCalled();
+    expect(createConversationToolLoopAgentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolContext: expect.objectContaining({
+          sandboxId: "sbx_test",
+          githubContext: expect.objectContaining({ repositoryFullName: "acme/web" }),
+        }),
+      }),
+    );
+    expect(posts).toEqual([{ markdown: "AI response" }]);
+  });
+
+  it("resolves GitHub context using recent conversation text", async () => {
     const { thread } = createThread();
     const message = createMessage({
       text: "Find 'Email agent' in org/new-repo",
@@ -550,6 +644,14 @@ describe("handleNewConversation", () => {
       { role: "user", content: "Find 'Email agent' in org/old-repo" },
       { role: "assistant", content: "I searched org/old-repo." },
     ] as never);
+    classifyConversationMock.mockResolvedValueOnce(
+      createMockClassification({
+        intents: ["repository"],
+        needsRepositoryTools: true,
+        currentMessageSpecifiesRepository: true,
+        confidence: 0.95,
+      }),
+    );
     resolveSlackRepositoryGitHubContextMock.mockResolvedValueOnce({
       status: "resolved",
       source: "slack_repo_reference",
@@ -580,7 +682,7 @@ describe("handleNewConversation", () => {
 
     expect(resolveSlackRepositoryGitHubContextMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        text: "Find 'Email agent' in org/new-repo",
+        text: expect.stringContaining("org/new-repo"),
         requirePullRequest: false,
       }),
     );
@@ -603,6 +705,15 @@ describe("handleNewConversation", () => {
       raw: { team_id: "T123", channel: "C123" },
     });
 
+    classifyConversationMock.mockResolvedValueOnce(
+      createMockClassification({
+        intents: ["repository"],
+        needsRepositoryTools: true,
+        requiresPullRequest: true,
+        currentMessageSpecifiesRepository: true,
+        confidence: 0.95,
+      }),
+    );
     vi.mocked(findSlackConnector).mockResolvedValue({
       id: "connector-123",
       organizationId: "org-123",
@@ -640,6 +751,14 @@ describe("handleNewConversation", () => {
       raw: { team_id: "T123", channel: "C123" },
     });
 
+    classifyConversationMock.mockResolvedValueOnce(
+      createMockClassification({
+        intents: ["repository"],
+        needsRepositoryTools: true,
+        shouldAskForRepositoryClarification: true,
+        confidence: 0.95,
+      }),
+    );
     resolveSlackRepositoryGitHubContextMock.mockResolvedValueOnce({
       status: "unresolved",
       context: {
@@ -677,6 +796,14 @@ describe("handleNewConversation", () => {
       raw: { team_id: "T123", channel: "C123" },
     });
 
+    classifyConversationMock.mockResolvedValueOnce(
+      createMockClassification({
+        intents: ["repository"],
+        needsRepositoryTools: true,
+        shouldAskForRepositoryClarification: true,
+        confidence: 0.95,
+      }),
+    );
     resolveSlackRepositoryGitHubContextMock.mockResolvedValueOnce({
       status: "unresolved",
       context: {
@@ -749,7 +876,7 @@ describe("handleNewConversation", () => {
     expect(getSubscribed()).toBe(false);
     expect(createConversationToolLoopAgentMock).toHaveBeenCalled();
     expect(agentGenerateMock).toHaveBeenCalled();
-    expect(posts).toEqual([{ markdown: "AI response" }]);
+    expect(posts).toEqual([SLACK_PROCESSING_ACK_POST, { markdown: "AI response" }]);
   });
 
   it("adds an eyes reaction while processing a message and removes it on reply", async () => {
@@ -842,6 +969,9 @@ describe("handleSubscribedMessage", () => {
     vi.clearAllMocks();
     agentGenerateMock.mockResolvedValue({ text: "AI response" });
     loadMessagesMock.mockResolvedValue([]);
+    interactionHasTranslationAttachmentsMock.mockResolvedValue(false);
+    resolveSlackRepositoryGitHubContextMock.mockResolvedValue({ status: "not_applicable" });
+    classifyConversationMock.mockImplementation(async () => createMockClassification());
   });
 
   it("ignores bot messages", async () => {
@@ -893,7 +1023,7 @@ describe("handleSubscribedMessage", () => {
     });
     expect(createConversationToolLoopAgentMock).toHaveBeenCalled();
     expect(agentGenerateMock).toHaveBeenCalled();
-    expect(posts).toEqual([{ markdown: "AI response" }]);
+    expect(posts).toEqual([SLACK_PROCESSING_ACK_POST, { markdown: "AI response" }]);
 
     // Agent reply should also be persisted
     expect(addInteractionMessage).toHaveBeenLastCalledWith({
@@ -901,6 +1031,58 @@ describe("handleSubscribedMessage", () => {
       senderType: "agent",
       text: "AI response",
     });
+  });
+
+  it("treats prior thread file uploads as attachments on follow-up messages", async () => {
+    const { thread, posts } = createThread();
+    const message = createMessage({ text: "Translate to French" });
+
+    interactionHasTranslationAttachmentsMock.mockResolvedValue(true);
+    loadMessagesMock.mockResolvedValueOnce([
+      {
+        role: "user",
+        content:
+          "Please translate the attached source file.\n\nAttached translation source files are already stored and ready for file translation jobs:\n- en-US.json: sourceFileId=file_123, fileFormat=json, contentType=application/json",
+      },
+      { role: "assistant", content: "Which locales should I use?" },
+    ] as never);
+    classifyConversationMock.mockResolvedValueOnce(
+      createMockClassification({
+        intents: ["translation"],
+        confidence: 0.95,
+      }),
+    );
+
+    vi.mocked(findSlackConnector).mockResolvedValue({
+      id: "connector-123",
+      organizationId: "org-123",
+      enabled: true,
+    } as never);
+    vi.mocked(lookupMembership).mockResolvedValue({
+      role: "member",
+      localUserId: "user-123",
+    } as never);
+    vi.mocked(findInteractionBySourceThreadId).mockResolvedValue({
+      id: "interaction-123",
+      title: "Existing",
+      projectId: "project-123",
+    } as never);
+    vi.mocked(addInteractionMessage).mockResolvedValue({ id: "msg-456" } as never);
+
+    await handleSubscribedMessage(thread, message);
+
+    expect(interactionHasTranslationAttachmentsMock).toHaveBeenCalledWith("interaction-123");
+    expect(classifyConversationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hasFileAttachments: true,
+      }),
+    );
+    expect(createConversationToolLoopAgentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hasFileAttachments: true,
+      }),
+    );
+    expect(posts[0]).toEqual(SLACK_PROCESSING_ACK_POST);
   });
 
   it("stores supported Slack file attachments for file translation jobs", async () => {
@@ -986,7 +1168,7 @@ describe("handleSubscribedMessage", () => {
       ],
     });
     expect(agentGenerateMock.mock.calls[0]?.[0]?.messages[0]?.content).toContain("fileFormat=json");
-    expect(posts).toEqual([{ markdown: "AI response" }]);
+    expect(posts).toEqual([SLACK_PROCESSING_ACK_POST, { markdown: "AI response" }]);
   });
 
   it("localizes images and creates file translation jobs when both are attached", async () => {
@@ -1068,6 +1250,7 @@ describe("handleSubscribedMessage", () => {
       ],
     });
     expect(posts).toEqual([
+      SLACK_PROCESSING_ACK_POST,
       {
         raw: expect.stringContaining("localized version of banner.png for fr"),
         files: [
@@ -1179,6 +1362,7 @@ describe("handleSubscribedMessage", () => {
     expect(agentGenerateMock).not.toHaveBeenCalled();
     expect(posts).toEqual([
       { markdown: expect.stringContaining("brief.pdf") },
+      SLACK_PROCESSING_ACK_POST,
       {
         raw: expect.stringContaining("localized version of banner.png for fr"),
         files: [
@@ -1258,6 +1442,7 @@ describe("handleSubscribedMessage", () => {
       expect.stringContaining("User instructions: Use refined campaign copy."),
     );
     expect(posts).toEqual([
+      SLACK_PROCESSING_ACK_POST,
       {
         raw: expect.stringContaining("localized version of banner.png for fr"),
         files: [
@@ -1318,7 +1503,10 @@ describe("handleSubscribedMessage", () => {
 
     expect(generateText).toHaveBeenCalledOnce();
     expect(regenerateImageFromAttachment).not.toHaveBeenCalled();
-    expect(posts).toEqual([expect.stringContaining("I need the target language")]);
+    expect(posts).toEqual([
+      SLACK_PROCESSING_ACK_POST,
+      expect.stringContaining("I need the target language"),
+    ]);
   });
 
   it("logs image localization failures while posting the fallback message", async () => {
@@ -1371,6 +1559,7 @@ describe("handleSubscribedMessage", () => {
         targetLocale: "fr",
       });
       expect(posts).toEqual([
+        SLACK_PROCESSING_ACK_POST,
         "Sorry, I couldn't localize banner.png right now. Please try again with the image and target language.",
       ]);
     } finally {

--- a/apps/hyperlocalise-web/src/lib/agents/slack/bot.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/bot.ts
@@ -319,7 +319,8 @@ async function processSlackMessage(
           buildResolvedRepositoryContextInstructions(resolvedRepositoryContext);
         log.info(
           {
-            repositoryFullName: resolvedRepositoryContext.repositoryFullName,
+            installationId: resolvedRepositoryContext.installationId,
+            hasPullRequestNumber: resolvedRepositoryContext.pullRequestNumber !== undefined,
           },
           "reusing stored slack thread repository context",
         );

--- a/apps/hyperlocalise-web/src/lib/agents/slack/bot.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/bot.ts
@@ -3,11 +3,13 @@ import { createSlackAdapter } from "@chat-adapter/slack";
 import type { Message, Thread, UserInfo } from "chat";
 
 import {
-  classifyConversationMode,
-  conversationModeRequiresPullRequestContext,
+  classifyConversation,
   createConversationToolLoopAgent,
+  getRecentUserConversationText,
   loadInteractionModelMessages,
   replaceLastUserMessage,
+  shouldAttemptRepositoryContextResolution,
+  shouldRequireRepositoryContextClarification,
 } from "@/lib/agent-runtime/loops/hyperlocalise-agent";
 import {
   buildRepositoryGitHubContextInstructions,
@@ -28,6 +30,7 @@ import {
   addInteractionMessage,
   createInteraction,
   findInteractionBySourceThreadId,
+  interactionHasTranslationAttachments,
   updateInteractionMessage,
 } from "@/lib/conversations/interactions";
 
@@ -40,10 +43,13 @@ import {
   storeSlackFileAttachments,
 } from "./file-attachments";
 import { getSlackImageAttachments, handleSlackImageAttachments } from "./image-attachments";
+import { type SlackBotThreadState } from "./repository-session";
 
-type SlackBotState = Record<string, unknown>;
+type SlackBotState = SlackBotThreadState;
 
 const logger = createLogger("slack-bot");
+
+const SLACK_PROCESSING_ACK_MESSAGE = "On it — I'll reply here shortly.";
 
 let botInstance: Chat<{ slack: ReturnType<typeof createSlackAdapter> }, SlackBotState> | null =
   null;
@@ -99,31 +105,6 @@ function buildSlackFileTranslationInstructions() {
   return `When a Slack message includes stored source file IDs, create file translation jobs with type "file", the provided sourceFileId and fileFormat, targetLocales, and sourceLocale. Use sourceLocale "auto" if the user did not specify a source locale. Supported file job formats: ${supportedFileTranslationFileFormats.join(", ")}.`;
 }
 
-function buildSlackRepositoryInstructions(
-  messages: Awaited<ReturnType<typeof loadInteractionModelMessages>>,
-  latestText: string,
-): string {
-  const userLines = messages.flatMap((chatMessage) => {
-    if (chatMessage.role !== "user" || typeof chatMessage.content !== "string") {
-      return [];
-    }
-
-    const text = chatMessage.content.trim();
-    return text ? [text] : [];
-  });
-
-  const trimmedLatest = latestText.trim();
-  if (trimmedLatest && userLines.at(-1) !== trimmedLatest) {
-    userLines.push(trimmedLatest);
-  }
-
-  if (userLines.length === 0) {
-    return trimmedLatest;
-  }
-
-  return userLines.slice(-5).join("\n");
-}
-
 function getSlackChannelId(thread: Thread<SlackBotState>, message: Message): string | null {
   const channelId = thread.channelId;
   if (typeof channelId === "string" && channelId.length > 0) {
@@ -132,44 +113,6 @@ function getSlackChannelId(thread: Thread<SlackBotState>, message: Message): str
 
   const raw = message.raw as { channel?: string } | undefined;
   return raw?.channel ?? null;
-}
-
-const githubReferencePattern =
-  /https?:\/\/(?:www\.)?github\.com\/[^\s]+|\b(?:github|repo|repository)\b|(?:^|[\s(<])[\w.-]+\/[\w.-]+(?=[\s>|)\].,;:!?]|$)/i;
-const repositoryContextQuestionPattern =
-  /\b(?:context|search|find(?:ing)?|locate|lookup|where|usage|surrounding|nearby)\b/i;
-const repositoryStringSubjectPattern =
-  /\b(?:locali[sz]ed|translated|message|messages|string|strings|copy|text)\b/i;
-
-function shouldAttemptRepositoryContextResolution(input: {
-  text: string;
-  hasStoredFileAttachments: boolean;
-  mode: ReturnType<typeof classifyConversationMode>;
-}) {
-  if (input.mode === "repository") {
-    return true;
-  }
-
-  if (githubReferencePattern.test(input.text)) {
-    return true;
-  }
-
-  if (
-    repositoryContextQuestionPattern.test(input.text) &&
-    (repositoryStringSubjectPattern.test(input.text) || /["'`][^"'`]+["'`]/.test(input.text))
-  ) {
-    return true;
-  }
-
-  return false;
-}
-
-function shouldRequireRepositoryContextClarification(text: string) {
-  return (
-    githubReferencePattern.test(text) ||
-    (repositoryContextQuestionPattern.test(text) &&
-      (repositoryStringSubjectPattern.test(text) || /["'`][^"'`]+["'`]/.test(text)))
-  );
 }
 
 function buildMissingRepositoryContextInstructions(followUp: string) {
@@ -196,6 +139,15 @@ async function removeEyesReaction(thread: Thread<SlackBotState>, message: Messag
   });
 }
 
+type ProcessSlackMessageOptions = {
+  isNewInteraction?: boolean;
+};
+
+async function postSlackProcessingAck(thread: Thread<SlackBotState>, interactionId: string) {
+  wrapThreadPost(thread, interactionId);
+  await thread.post({ markdown: SLACK_PROCESSING_ACK_MESSAGE });
+}
+
 async function processSlackMessage(
   thread: Thread<SlackBotState>,
   message: Message,
@@ -203,6 +155,7 @@ async function processSlackMessage(
   organizationId: string,
   projectId: string | null,
   connectorConfig: Record<string, unknown> | null,
+  options: ProcessSlackMessageOptions = {},
 ) {
   const channelId = getSlackChannelId(thread, message);
   const log = logger.child({
@@ -316,79 +269,123 @@ async function processSlackMessage(
       }
     }
 
-    const conversationMode = classifyConversationMode(message.text);
+    const hasTranslationAttachments = await interactionHasTranslationAttachments(interactionId);
+    const shouldPostProcessingAck =
+      options.isNewInteraction === true ||
+      storedFileAttachments.length > 0 ||
+      imageAttachments.length > 0 ||
+      hasTranslationAttachments;
+
+    if (shouldPostProcessingAck) {
+      await postSlackProcessingAck(thread, interactionId);
+    }
+
+    const loadedMessages = await loadInteractionModelMessages(interactionId);
+    const conversationText = getRecentUserConversationText(loadedMessages, persistedUserText);
+    const threadState = (await thread.state) as SlackBotThreadState | null;
+    const storedRepositoryContext = threadState?.repositoryGitHubContext ?? null;
+    const classification = await classifyConversation({
+      currentMessage: message.text,
+      conversationText,
+      hasFileAttachments: hasTranslationAttachments,
+      hasStoredRepositoryContext: Boolean(storedRepositoryContext),
+      surface: "slack",
+    });
     const shouldResolveRepositoryContext = shouldAttemptRepositoryContextResolution({
-      text: message.text,
-      hasStoredFileAttachments: storedFileAttachments.length > 0,
-      mode: conversationMode,
+      classification,
+      storedRepositoryContext,
     });
     log.info(
       {
-        conversationMode,
+        conversationIntents: classification.intents,
         shouldResolveRepositoryContext,
+        needsRepositoryTools: classification.needsRepositoryTools,
+        continuesRepositoryThread: classification.continuesRepositoryThread,
+        hasStoredRepositoryContext: Boolean(storedRepositoryContext),
         hasConnectorConfig: Boolean(connectorConfig),
       },
-      "slack agent conversation mode classified",
+      "slack agent conversation classified",
     );
 
     let resolvedRepositoryContext: RepositoryAgentGitHubContext | null = null;
     let repositoryContextInstructions: string | null = null;
     if (shouldResolveRepositoryContext) {
-      const githubContextResolution = await resolveSlackRepositoryGitHubContext({
-        organizationId,
-        text: message.text,
-        connectorConfig,
-        projectId,
-        channelId,
-        requirePullRequest: conversationModeRequiresPullRequestContext(
-          message.text,
-          conversationMode,
-        ),
-      });
-      log.info(
-        {
-          status: githubContextResolution.status,
-          source:
-            githubContextResolution.status === "resolved" ? githubContextResolution.source : null,
-          repositoryFullName:
-            githubContextResolution.status === "resolved"
-              ? githubContextResolution.context.repositoryFullName
-              : null,
-          installationId:
-            githubContextResolution.status === "resolved"
-              ? githubContextResolution.context.installationId
-              : null,
-          unresolvedReason:
-            githubContextResolution.status === "unresolved"
-              ? githubContextResolution.context.reason
-              : null,
-        },
-        "slack agent repository context resolved",
-      );
+      const canReuseStoredRepositoryContext =
+        storedRepositoryContext !== null && !classification.currentMessageSpecifiesRepository;
 
-      if (githubContextResolution.status === "resolved") {
-        resolvedRepositoryContext = githubContextResolution.context;
+      if (canReuseStoredRepositoryContext) {
+        resolvedRepositoryContext = storedRepositoryContext;
         repositoryContextInstructions =
           buildResolvedRepositoryContextInstructions(resolvedRepositoryContext);
-      } else if (githubContextResolution.status === "unresolved") {
-        repositoryContextInstructions = buildMissingRepositoryContextInstructions(
-          githubContextResolution.followUp,
+        log.info(
+          {
+            repositoryFullName: resolvedRepositoryContext.repositoryFullName,
+          },
+          "reusing stored slack thread repository context",
+        );
+      } else {
+        const githubContextResolution = await resolveSlackRepositoryGitHubContext({
+          organizationId,
+          text: conversationText,
+          connectorConfig,
+          projectId,
+          channelId,
+          requirePullRequest: classification.requiresPullRequest,
+        });
+        log.info(
+          {
+            status: githubContextResolution.status,
+            source:
+              githubContextResolution.status === "resolved" ? githubContextResolution.source : null,
+            repositoryFullName:
+              githubContextResolution.status === "resolved"
+                ? githubContextResolution.context.repositoryFullName
+                : null,
+            installationId:
+              githubContextResolution.status === "resolved"
+                ? githubContextResolution.context.installationId
+                : null,
+            unresolvedReason:
+              githubContextResolution.status === "unresolved"
+                ? githubContextResolution.context.reason
+                : null,
+          },
+          "slack agent repository context resolved",
         );
 
-        if (shouldRequireRepositoryContextClarification(message.text)) {
-          await removeEyesReaction(thread, message);
-          wrapThreadPost(thread, interactionId);
-          await thread.post({ markdown: githubContextResolution.followUp });
-          return;
+        if (githubContextResolution.status === "resolved") {
+          resolvedRepositoryContext = githubContextResolution.context;
+          repositoryContextInstructions =
+            buildResolvedRepositoryContextInstructions(resolvedRepositoryContext);
+          await thread.setState({
+            ...threadState,
+            repositoryGitHubContext: resolvedRepositoryContext,
+          });
+        } else if (githubContextResolution.status === "unresolved") {
+          if (storedRepositoryContext && !classification.currentMessageSpecifiesRepository) {
+            resolvedRepositoryContext = storedRepositoryContext;
+            repositoryContextInstructions =
+              buildResolvedRepositoryContextInstructions(resolvedRepositoryContext);
+          } else {
+            repositoryContextInstructions = buildMissingRepositoryContextInstructions(
+              githubContextResolution.followUp,
+            );
+
+            if (shouldRequireRepositoryContextClarification(classification)) {
+              await removeEyesReaction(thread, message);
+              wrapThreadPost(thread, interactionId);
+              await thread.post({ markdown: githubContextResolution.followUp });
+              return;
+            }
+          }
         }
       }
     }
 
-    const loadedMessages = await loadInteractionModelMessages(interactionId);
     const chatMessages = replaceLastUserMessage(
       loadedMessages,
       resolvedRepositoryContext
-        ? buildSlackRepositoryInstructions(loadedMessages, persistedUserText)
+        ? getRecentUserConversationText(loadedMessages, persistedUserText)
         : persistedUserText,
     );
 
@@ -436,7 +433,7 @@ async function processSlackMessage(
 
       const agent = createConversationToolLoopAgent({
         surface: "slack",
-        userMessageText: persistedUserText,
+        suggestedIntents: classification.intents,
         toolContext: {
           conversationId: interactionId,
           organizationId,
@@ -458,7 +455,7 @@ async function processSlackMessage(
               }
             : {}),
         },
-        hasFileAttachments: storedFileAttachments.length > 0,
+        hasFileAttachments: hasTranslationAttachments,
         additionalInstructions: [
           buildSlackFileTranslationInstructions(),
           repositoryContextInstructions,
@@ -470,7 +467,7 @@ async function processSlackMessage(
         {
           hasRepositoryContext: Boolean(resolvedRepositoryContext),
           hasSandbox: Boolean(sandboxId),
-          hasFileAttachments: storedFileAttachments.length > 0,
+          hasFileAttachments: hasTranslationAttachments,
         },
         "running slack conversation agent",
       );
@@ -539,6 +536,7 @@ export async function handleNewConversation(thread: Thread<SlackBotState>, messa
     connector.organizationId,
     interaction.projectId,
     (connector.config ?? null) as Record<string, unknown> | null,
+    { isNewInteraction: isNew },
   );
 }
 
@@ -570,6 +568,7 @@ export async function handleSubscribedMessage(thread: Thread<SlackBotState>, mes
     connector.organizationId,
     interaction.projectId,
     (connector.config ?? null) as Record<string, unknown> | null,
+    { isNewInteraction: false },
   );
 }
 

--- a/apps/hyperlocalise-web/src/lib/agents/slack/bot.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/bot.ts
@@ -21,7 +21,10 @@ import {
 } from "@/lib/agent-runtime/workspaces/repository-sandbox";
 import { type RepositoryAgentGitHubContext } from "@/lib/agents/repository-agent-task";
 import { createChatStateAdapter } from "@/lib/agents/runtime/state";
-import { wrapThreadPostForInteraction } from "@/lib/agent-runtime/runs/agent-run-events";
+import {
+  postThreadMessageWithoutTracking,
+  wrapThreadPostForInteraction,
+} from "@/lib/agent-runtime/runs/agent-run-events";
 import { db } from "@/lib/database";
 import { env } from "@/lib/env";
 import { createChatLogger, createLogger, serializeErrorForLog } from "@/lib/log";
@@ -143,9 +146,10 @@ type ProcessSlackMessageOptions = {
   isNewInteraction?: boolean;
 };
 
-async function postSlackProcessingAck(thread: Thread<SlackBotState>, interactionId: string) {
-  wrapThreadPost(thread, interactionId);
-  await thread.post({ markdown: SLACK_PROCESSING_ACK_MESSAGE });
+async function postSlackProcessingAck(thread: Thread<SlackBotState>) {
+  await postThreadMessageWithoutTracking(thread, {
+    markdown: SLACK_PROCESSING_ACK_MESSAGE,
+  });
 }
 
 async function processSlackMessage(
@@ -277,7 +281,7 @@ async function processSlackMessage(
       hasTranslationAttachments;
 
     if (shouldPostProcessingAck) {
-      await postSlackProcessingAck(thread, interactionId);
+      await postSlackProcessingAck(thread);
     }
 
     const loadedMessages = await loadInteractionModelMessages(interactionId);
@@ -421,7 +425,6 @@ async function processSlackMessage(
       if (resolvedRepositoryContext) {
         log.info(
           {
-            repositoryFullName: resolvedRepositoryContext.repositoryFullName,
             installationId: resolvedRepositoryContext.installationId,
             branch: resolvedRepositoryContext.branch ?? null,
             commitSha: resolvedRepositoryContext.commitSha ?? null,

--- a/apps/hyperlocalise-web/src/lib/agents/slack/repository-session.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/repository-session.ts
@@ -1,0 +1,8 @@
+import type { RepositoryAgentGitHubContext } from "@/lib/agent-contracts/repository-task";
+
+export type { RepositoryAgentGitHubContext };
+
+export type SlackBotThreadState = {
+  warnedNonMemberUsers?: string[];
+  repositoryGitHubContext?: RepositoryAgentGitHubContext;
+};

--- a/apps/hyperlocalise-web/src/lib/conversations/interactions.test.ts
+++ b/apps/hyperlocalise-web/src/lib/conversations/interactions.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const { interactionMessagesMock } = vi.hoisted(() => ({
+  interactionMessagesMock: vi.fn(),
+}));
+
+vi.mock("@/lib/database", () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: interactionMessagesMock,
+      })),
+    })),
+  },
+  schema: {
+    interactionMessages: {
+      interactionId: "interaction_id",
+      text: "text",
+      attachments: "attachments",
+    },
+  },
+}));
+
+import { interactionHasTranslationAttachments } from "./interactions";
+
+describe("interactionHasTranslationAttachments", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("counts attachments persisted on the current interaction message", async () => {
+    interactionMessagesMock.mockResolvedValueOnce([
+      {
+        text: "Translate this to French",
+        attachments: [
+          {
+            id: "file_123",
+            filename: "en-US.json",
+            contentType: "application/json",
+            url: "https://files.example/file_123",
+          },
+        ],
+      },
+    ]);
+
+    await expect(interactionHasTranslationAttachments("interaction-123")).resolves.toBe(true);
+  });
+
+  it("counts stored source file markers in message text", async () => {
+    interactionMessagesMock.mockResolvedValueOnce([
+      {
+        text: "Attached file: sourceFileId=file_123",
+        attachments: null,
+      },
+    ]);
+
+    await expect(interactionHasTranslationAttachments("interaction-123")).resolves.toBe(true);
+  });
+});


### PR DESCRIPTION
## What changed

- Add structured conversation classification for translation, repository, and multi-intent Slack agent requests.
- Route multi-intent conversations through repository context before translation work, and pass active intents into the orchestrator.
- Reuse stored Slack thread repository context for follow-up messages instead of re-resolving when the user does not name a new repo.
- Treat prior Slack translation attachments as active context on follow-up messages and post a short processing acknowledgement for longer-running Slack work.

## How to test

- `vp test` - fails in `src/api/auth/identity-access-regression.test.ts` with duplicate `organization_memberships_workos_membership_id_key` for `workos_membership_id = replacing`.
- `vp check --fix` - fails with TypeScript errors in `src/lib/agent-runtime/loops/conversation-classifier.test.ts` because `repositoryClassification()` returns readonly `intents`.

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review