### PR TITLE
fix(crowdin): improve AI Prompts model parity and filtering

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -120,6 +120,12 @@
 
 **Action:** Added  (*bool) to  and . Added  ([]int) to , , and , and updated  to include them. Added  (*bool) to . Verified with comprehensive unit tests in  and .
 
+## 2026-08-29 - Improve AI Prompts parity for provider and model filtering
+
+**Learning:** The Crowdin AI Prompts API v2 supports filtering prompts by `aiProviderId` and `aiModelId`, but these options were missing from the SDK's `AIPromptsListOptions`. Additionally, the `Prompt` response model was using a generic `string` for the `action` field instead of the existing `PromptAction` enum.
+
+**Action:** Added `AIProviderID` and `AIModelID` to `AIPromptsListOptions` and updated its `Values()` method for correct query parameter encoding. Updated `Prompt.Action` to use the `PromptAction` type. Cleaned up redundant client access in AI service tests. Verified with updated unit tests in `model/ai_test.go` and full suite passing.
+
 ## 2026-08-22 - Improve Translations API parity for labels and soft match
 
 **Learning:** The Crowdin Translations API v2 supports several parameters that were missing from the Go SDK, specifically filtering by labels during project and directory builds, and the 'soft match' option for pre-translations. Additionally, uploading translations supports marking them as done immediately.

--- a/third_party/crowdin-api-client-go/crowdin/ai_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/ai_test.go
@@ -419,7 +419,7 @@ func TestAIService_CreateFineTuningJob(t *testing.T) {
 			NEpochs:                10,
 		},
 	}
-	job, resp, err := client.AI.client.AI.CreateFineTuningJob(context.Background(), 2, 1, req)
+	job, resp, err := client.AI.CreateFineTuningJob(context.Background(), 2, 1, req)
 	require.NoError(t, err)
 	assert.NotNil(t, resp)
 

--- a/third_party/crowdin-api-client-go/crowdin/model/ai.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/ai.go
@@ -251,7 +251,7 @@ const (
 type Prompt struct {
 	ID                int          `json:"id"`
 	Name              string       `json:"name"`
-	Action            string       `json:"action"`
+	Action            PromptAction `json:"action"`
 	AIProviderID      int          `json:"aiProviderId"`
 	AIModelID         string       `json:"aiModelId"`
 	IsEnabled         bool         `json:"isEnabled"`
@@ -305,6 +305,10 @@ type AIPromptsListOptions struct {
 	// Allows to filter the prompts available for the specific action.
 	// Enum: pre_translate, assist.
 	Action PromptAction `json:"action,omitempty"`
+	// Filter the prompts available for the specific AI provider.
+	AIProviderID int `json:"aiProviderId,omitempty"`
+	// Filter the prompts available for the specific AI model.
+	AIModelID string `json:"aiModelId,omitempty"`
 
 	ListOptions
 }
@@ -323,6 +327,12 @@ func (o *AIPromptsListOptions) Values() (url.Values, bool) {
 	}
 	if o.Action != "" {
 		v.Add("action", string(o.Action))
+	}
+	if o.AIProviderID > 0 {
+		v.Add("aiProviderId", strconv.Itoa(o.AIProviderID))
+	}
+	if o.AIModelID != "" {
+		v.Add("aiModelId", o.AIModelID)
 	}
 
 	return v, len(v) > 0

--- a/third_party/crowdin-api-client-go/crowdin/model/ai_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/ai_test.go
@@ -165,9 +165,22 @@ func TestAIPromptsListOptionsValues(t *testing.T) {
 			out:  "action=assist",
 		},
 		{
+			name: "with AI provider ID",
+			opt:  &AIPromptsListOptions{AIProviderID: 3},
+			out:  "aiProviderId=3",
+		},
+		{
+			name: "with AI model ID",
+			opt:  &AIPromptsListOptions{AIModelID: "gpt-4"},
+			out:  "aiModelId=gpt-4",
+		},
+		{
 			name: "with all options",
-			opt:  &AIPromptsListOptions{ProjectID: 2, Action: ActionPreTranslate},
-			out:  "action=pre_translate&projectId=2",
+			opt: &AIPromptsListOptions{
+				ProjectID: 2, Action: ActionPreTranslate,
+				AIProviderID: 3, AIModelID: "gpt-4",
+			},
+			out: "action=pre_translate&aiModelId=gpt-4&aiProviderId=3&projectId=2",
 		},
 	}
 


### PR DESCRIPTION
### 💡 What
Improved AI Prompts API implementation in the Go SDK by aligning models and filtering options with Crowdin API v2.

### 🎯 Why
The official API supports filtering prompts by `aiProviderId` and `aiModelId`, which were missing from the SDK. Additionally, using the specific `PromptAction` type instead of a raw `string` in the response model improves type safety and consistency.

### 📄 Docs
- [List AI Prompts](https://developer.crowdin.com/api/v2/#operation/api.users.ai.prompts.getMany)

### 🧩 Scope
- `third_party/crowdin-api-client-go/crowdin/model/ai.go`: Added filter fields and updated response model.
- `third_party/crowdin-api-client-go/crowdin/ai_test.go`: Fixed redundant service access.
- `third_party/crowdin-api-client-go/crowdin/model/ai_test.go`: Added test coverage for new filters.
- `.jules/crowdin-steward.md`: Recorded learning.

### ✅ Verification
- Ran focused unit tests for AI models and service.
- Ran full test suite in `third_party/crowdin-api-client-go` using `GOWORK=off go test ./...`.
- Verified formatting and static analysis with `go fmt` and `go vet`.

### 🛡️ Confidence
High. The changes follow established patterns in the SDK and match documented API behavior.

---
*PR created automatically by Jules for task [14440432954128386345](https://jules.google.com/task/14440432954128386345) started by @cungminh2710*