### PR TITLE
fix(web): route provider project pages through live TMS APIs

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
@@ -49,8 +49,8 @@ import {
   forbiddenResponse,
   getOwnedProject,
   getOwnedProjectRecord,
-  logProjectNotFound,
   projectNotFoundResponse,
+  scheduleProjectNotFoundDiagnostics,
 } from "./project.shared";
 import {
   applyAgentRunProposalReviewUpdates,
@@ -366,7 +366,7 @@ export function createJobRoutes(options: CreateJobRoutesOptions) {
       const project = await getOwnedProject(c.var.auth, params.projectId);
 
       if (!project) {
-        await logProjectNotFound({
+        scheduleProjectNotFoundDiagnostics({
           auth: c.var.auth,
           projectId: params.projectId,
           route: "project.jobs.list",
@@ -413,7 +413,7 @@ export function createJobRoutes(options: CreateJobRoutesOptions) {
       const project = await getOwnedProjectRecord(c.var.auth, params.projectId);
 
       if (!project) {
-        await logProjectNotFound({
+        scheduleProjectNotFoundDiagnostics({
           auth: c.var.auth,
           projectId: params.projectId,
           route: "project.jobs.create",
@@ -551,7 +551,7 @@ export function createJobRoutes(options: CreateJobRoutesOptions) {
       const project = await getOwnedProject(c.var.auth, params.projectId);
 
       if (!project) {
-        await logProjectNotFound({
+        scheduleProjectNotFoundDiagnostics({
           auth: c.var.auth,
           projectId: params.projectId,
           route: "project.jobs.detail",
@@ -572,7 +572,7 @@ export function createJobRoutes(options: CreateJobRoutesOptions) {
       const project = await getOwnedProject(c.var.auth, params.projectId);
 
       if (!project) {
-        await logProjectNotFound({
+        scheduleProjectNotFoundDiagnostics({
           auth: c.var.auth,
           projectId: params.projectId,
           route: "project.jobs.status",

--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
@@ -49,6 +49,7 @@ import {
   forbiddenResponse,
   getOwnedProject,
   getOwnedProjectRecord,
+  logProjectNotFound,
   projectNotFoundResponse,
 } from "./project.shared";
 import {
@@ -365,6 +366,11 @@ export function createJobRoutes(options: CreateJobRoutesOptions) {
       const project = await getOwnedProject(c.var.auth, params.projectId);
 
       if (!project) {
+        await logProjectNotFound({
+          auth: c.var.auth,
+          projectId: params.projectId,
+          route: "project.jobs.list",
+        });
         return projectNotFoundResponse(c);
       }
 
@@ -407,6 +413,11 @@ export function createJobRoutes(options: CreateJobRoutesOptions) {
       const project = await getOwnedProjectRecord(c.var.auth, params.projectId);
 
       if (!project) {
+        await logProjectNotFound({
+          auth: c.var.auth,
+          projectId: params.projectId,
+          route: "project.jobs.create",
+        });
         return projectNotFoundResponse(c);
       }
 
@@ -540,6 +551,11 @@ export function createJobRoutes(options: CreateJobRoutesOptions) {
       const project = await getOwnedProject(c.var.auth, params.projectId);
 
       if (!project) {
+        await logProjectNotFound({
+          auth: c.var.auth,
+          projectId: params.projectId,
+          route: "project.jobs.detail",
+        });
         return projectNotFoundResponse(c);
       }
 
@@ -556,6 +572,11 @@ export function createJobRoutes(options: CreateJobRoutesOptions) {
       const project = await getOwnedProject(c.var.auth, params.projectId);
 
       if (!project) {
+        await logProjectNotFound({
+          auth: c.var.auth,
+          projectId: params.projectId,
+          route: "project.jobs.status",
+        });
         return projectNotFoundResponse(c);
       }
 

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -87,6 +87,7 @@ import {
   invalidProjectPayloadResponse,
   isProjectCreateAllowed,
   isProjectMutationAllowed,
+  logProjectNotFound,
   ownedProjectWhere,
   projectNotFoundResponse,
   unsupportedProjectFileResponse,
@@ -475,6 +476,11 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
         const project = await getOwnedProject(c.var.auth, params.projectId);
 
         if (!project) {
+          await logProjectNotFound({
+            auth: c.var.auth,
+            projectId: params.projectId,
+            route: "project.files.detail",
+          });
           return projectNotFoundResponse(c);
         }
 
@@ -502,6 +508,11 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
       const project = await getOwnedProject(c.var.auth, params.projectId);
 
       if (!project) {
+        await logProjectNotFound({
+          auth: c.var.auth,
+          projectId: params.projectId,
+          route: "project.files.list",
+        });
         return projectNotFoundResponse(c);
       }
 
@@ -542,6 +553,11 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
         const project = await getOwnedProject(c.var.auth, params.projectId);
 
         if (!project) {
+          await logProjectNotFound({
+            auth: c.var.auth,
+            projectId: params.projectId,
+            route: "project.files.upload",
+          });
           return projectNotFoundResponse(c);
         }
 
@@ -631,6 +647,11 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
       const project = await projectStore.getById(c.var.auth, params.projectId);
 
       if (!project) {
+        await logProjectNotFound({
+          auth: c.var.auth,
+          projectId: params.projectId,
+          route: "project.detail",
+        });
         return projectNotFoundResponse(c);
       }
 

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -87,9 +87,9 @@ import {
   invalidProjectPayloadResponse,
   isProjectCreateAllowed,
   isProjectMutationAllowed,
-  logProjectNotFound,
   ownedProjectWhere,
   projectNotFoundResponse,
+  scheduleProjectNotFoundDiagnostics,
   unsupportedProjectFileResponse,
 } from "./project.shared";
 import { createJobRoutes } from "./job.route";
@@ -476,7 +476,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
         const project = await getOwnedProject(c.var.auth, params.projectId);
 
         if (!project) {
-          await logProjectNotFound({
+          scheduleProjectNotFoundDiagnostics({
             auth: c.var.auth,
             projectId: params.projectId,
             route: "project.files.detail",
@@ -508,7 +508,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
       const project = await getOwnedProject(c.var.auth, params.projectId);
 
       if (!project) {
-        await logProjectNotFound({
+        scheduleProjectNotFoundDiagnostics({
           auth: c.var.auth,
           projectId: params.projectId,
           route: "project.files.list",
@@ -553,7 +553,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
         const project = await getOwnedProject(c.var.auth, params.projectId);
 
         if (!project) {
-          await logProjectNotFound({
+          scheduleProjectNotFoundDiagnostics({
             auth: c.var.auth,
             projectId: params.projectId,
             route: "project.files.upload",
@@ -647,7 +647,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
       const project = await projectStore.getById(c.var.auth, params.projectId);
 
       if (!project) {
-        await logProjectNotFound({
+        scheduleProjectNotFoundDiagnostics({
           auth: c.var.auth,
           projectId: params.projectId,
           route: "project.detail",

--- a/apps/hyperlocalise-web/src/api/routes/project/project.shared.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.shared.ts
@@ -1,7 +1,10 @@
 import {
   buildAccessibleProjectsWhere,
+  getVisibleTeamIds,
+  hasOrganizationWideProjectAccess,
   ownedProjectWhere as teamOwnedProjectWhere,
 } from "@/api/auth/team-access";
+import { and, eq } from "drizzle-orm";
 import {
   badRequestResponse,
   forbiddenResponse as sharedForbiddenResponse,
@@ -11,6 +14,27 @@ import {
 } from "@/api/errors";
 import type { ApiAuthContext } from "@/api/auth/workos";
 import { db, schema } from "@/lib/database";
+import { createLogger, serializeErrorForLog } from "@/lib/log";
+
+const logger = createLogger("project-routes");
+const externalTmsProviderKinds = new Set<string>(schema.externalTmsProviderKindEnum.enumValues);
+
+function parseExternalProjectId(projectId: string) {
+  const match = /^ext:([^:]+):(.+)$/.exec(projectId);
+  if (!match) {
+    return null;
+  }
+
+  const providerKind = match[1];
+  if (!externalTmsProviderKinds.has(providerKind)) {
+    return null;
+  }
+
+  return {
+    providerKind: providerKind as (typeof schema.externalTmsProviderKindEnum.enumValues)[number],
+    externalProjectId: match[2],
+  };
+}
 
 export { buildAccessibleProjectsWhere };
 
@@ -30,6 +54,90 @@ export function unsupportedProjectFileResponse(c: { json: JsonContext["json"] },
 
 export function forbiddenResponse(c: { json: JsonContext["json"] }) {
   return sharedForbiddenResponse(c, "forbidden", "Insufficient permissions");
+}
+
+export async function logProjectNotFound(input: {
+  auth: ApiAuthContext;
+  projectId: string;
+  route: string;
+}) {
+  const { auth, projectId, route } = input;
+  const organizationId = auth.organization.localOrganizationId;
+  const externalProject = parseExternalProjectId(projectId);
+
+  try {
+    const [projectInOrganization] = await db
+      .select({
+        id: schema.projects.id,
+        teamId: schema.projects.teamId,
+        source: schema.projects.source,
+        externalProviderKind: schema.projects.externalProviderKind,
+        externalProjectId: schema.projects.externalProjectId,
+        isActive: schema.projects.isActive,
+      })
+      .from(schema.projects)
+      .where(
+        and(eq(schema.projects.organizationId, organizationId), eq(schema.projects.id, projectId)),
+      )
+      .limit(1);
+
+    const [externalProjectInOrganization] = externalProject
+      ? await db
+          .select({
+            id: schema.projects.id,
+            teamId: schema.projects.teamId,
+            source: schema.projects.source,
+            isActive: schema.projects.isActive,
+          })
+          .from(schema.projects)
+          .where(
+            and(
+              eq(schema.projects.organizationId, organizationId),
+              eq(schema.projects.externalProviderKind, externalProject.providerKind),
+              eq(schema.projects.externalProjectId, externalProject.externalProjectId),
+            ),
+          )
+          .limit(1)
+      : [];
+
+    const hasOrganizationWideAccess = hasOrganizationWideProjectAccess(auth);
+    const visibleTeamIds = hasOrganizationWideAccess ? [] : await getVisibleTeamIds(auth);
+
+    logger.warn(
+      {
+        route,
+        organizationId,
+        activeTeamId: auth.activeTeam?.id ?? null,
+        hasOrganizationWideAccess,
+        visibleTeamCount: visibleTeamIds.length,
+        projectId,
+        externalProviderKind: externalProject?.providerKind ?? null,
+        externalProjectId: externalProject?.externalProjectId ?? null,
+        projectExistsInOrganization: Boolean(projectInOrganization),
+        projectTeamId: projectInOrganization?.teamId ?? null,
+        projectSource: projectInOrganization?.source ?? null,
+        projectExternalProviderKind: projectInOrganization?.externalProviderKind ?? null,
+        projectExternalProjectId: projectInOrganization?.externalProjectId ?? null,
+        projectIsActive: projectInOrganization?.isActive ?? null,
+        externalProjectExistsInOrganization: Boolean(externalProjectInOrganization),
+        externalProjectRecordId: externalProjectInOrganization?.id ?? null,
+        externalProjectTeamId: externalProjectInOrganization?.teamId ?? null,
+        externalProjectSource: externalProjectInOrganization?.source ?? null,
+        externalProjectIsActive: externalProjectInOrganization?.isActive ?? null,
+      },
+      "project lookup returned not found",
+    );
+  } catch (error) {
+    logger.warn(
+      {
+        route,
+        organizationId,
+        projectId,
+        err: serializeErrorForLog(error),
+      },
+      "project lookup diagnostics failed",
+    );
+  }
 }
 
 export {

--- a/apps/hyperlocalise-web/src/api/routes/project/project.shared.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.shared.ts
@@ -140,6 +140,24 @@ export async function logProjectNotFound(input: {
   }
 }
 
+export function scheduleProjectNotFoundDiagnostics(input: {
+  auth: ApiAuthContext;
+  projectId: string;
+  route: string;
+}) {
+  void logProjectNotFound(input).catch((error) => {
+    logger.warn(
+      {
+        route: input.route,
+        organizationId: input.auth.organization.localOrganizationId,
+        projectId: input.projectId,
+        err: serializeErrorForLog(error),
+      },
+      "project lookup diagnostics failed",
+    );
+  });
+}
+
 export {
   isProjectCreateAllowed,
   isProjectMutationAllowed,

--- a/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.test.ts
@@ -164,6 +164,62 @@ describe("tmsProviderRoutes", () => {
     });
   });
 
+  it("returns live files for a provider project", async () => {
+    const identity = fixture.createWorkosIdentityWithRole("admin");
+    const headers = await fixture.authHeadersFor(identity);
+    const organizationId = globalThis.__testApiAuthContext!.organization.localOrganizationId;
+
+    const listFiles = vi
+      .spyOn(tmsProviderLive, "listTmsProviderLiveFilesForProject")
+      .mockResolvedValue([
+        {
+          origin: "provider",
+          sourcePath: "keys/home.title",
+          sourceHash: null,
+          commitSha: null,
+          workflowRunId: null,
+          uploadedAt: new Date().toISOString(),
+          storedFileId: null,
+          metadata: {},
+          filename: "home.title",
+          byteSize: null,
+          provider: {
+            kind: "crowdin",
+            resourceType: "key",
+            externalProjectId: "902807",
+            externalResourceId: "key-1",
+            externalUrl: null,
+            syncState: "synced",
+            sourceLocale: "en",
+            targetLocales: ["fr"],
+            localeReadiness: {},
+            revision: null,
+            format: "icu",
+            lastSyncedAt: new Date().toISOString(),
+          },
+          latestJob: null,
+        },
+      ]);
+
+    const response = await client.api.orgs[":organizationSlug"]["tms-provider"].projects[
+      ":externalProjectId"
+    ].files.$get(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing",
+          externalProjectId: "902807",
+        },
+        query: { limit: "500" },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { files: unknown[] };
+    expect(body.files).toHaveLength(1);
+    expect(listFiles).toHaveBeenCalledWith(organizationId, "902807", { limit: 500 });
+  });
+
   it("returns 401 when the stored Crowdin OAuth token bundle is invalid", async () => {
     const identity = fixture.createWorkosIdentityWithRole("admin");
     const headers = await fixture.authHeadersFor(identity);

--- a/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.ts
@@ -8,6 +8,7 @@ import {
   getTmsProviderConnection,
   getTmsProviderLiveJobDetail,
   getTmsProviderLiveProject,
+  listTmsProviderLiveFilesForProject,
   listTmsProviderLiveGlossaries,
   listTmsProviderLiveJobs,
   listTmsProviderLiveJobsForProject,
@@ -27,6 +28,10 @@ const externalProjectIdQuerySchema = z.object({
   externalProjectId: z.string().min(1).optional(),
 });
 
+const projectFilesQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(1_000).optional().default(500),
+});
+
 const validateMineQuery = validator("query", (value, c) => {
   const parsed = mineQuerySchema.safeParse(value);
   if (!parsed.success) {
@@ -38,6 +43,15 @@ const validateMineQuery = validator("query", (value, c) => {
 
 const validateExternalProjectIdQuery = validator("query", (value, c) => {
   const parsed = externalProjectIdQuerySchema.safeParse(value);
+  if (!parsed.success) {
+    return c.json({ error: "invalid_query" }, 400);
+  }
+
+  return parsed.data;
+});
+
+const validateProjectFilesQuery = validator("query", (value, c) => {
+  const parsed = projectFilesQuerySchema.safeParse(value);
   if (!parsed.success) {
     return c.json({ error: "invalid_query" }, 400);
   }
@@ -138,6 +152,24 @@ export function createTmsProviderRoutes() {
           },
         );
         return c.json({ jobs }, 200);
+      } catch (error) {
+        return mapTmsProviderLiveError(c, error);
+      }
+    })
+    .get("/projects/:externalProjectId/files", validateProjectFilesQuery, async (c) => {
+      if (!hasCapability(c.var.auth.membership.role, "projects:read")) {
+        return c.json({ error: "forbidden" }, 403);
+      }
+
+      const query = c.req.valid("query");
+
+      try {
+        const files = await listTmsProviderLiveFilesForProject(
+          c.var.auth.organization.localOrganizationId,
+          c.req.param("externalProjectId"),
+          { limit: query.limit },
+        );
+        return c.json({ files }, 200);
       } catch (error) {
         return mapTmsProviderLiveError(c, error);
       }

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/[jobId]/_components/job-detail-page-content.tsx
@@ -22,8 +22,10 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { TypographyH1, TypographyH2 } from "@/components/ui/typography";
 import { apiClient } from "@/lib/api-client-instance";
 import { cn } from "@/lib/primitives/cn";
+import { isTmsProviderShellModeEnabled } from "@/lib/providers/tms-provider-shell-mode";
 
 import { toneClass } from "../../../_components/workspace-resource-shared";
+import { useActiveTmsProvider } from "../../../_hooks/use-active-tms-provider";
 
 import { parseProviderJobId } from "@/lib/providers/tms-provider-resource-id";
 
@@ -180,7 +182,25 @@ export function JobDetailPageContent({
   jobId: string;
   organizationSlug: string;
 }) {
-  if (parseProviderJobId(jobId)) {
+  const activeTmsProviderQuery = useActiveTmsProvider(organizationSlug);
+  const encodedProviderJob = parseProviderJobId(jobId);
+  const useLiveProviderJob =
+    isTmsProviderShellModeEnabled() &&
+    Boolean(activeTmsProviderQuery.data) &&
+    encodedProviderJob?.providerKind === activeTmsProviderQuery.data?.providerKind;
+
+  if (encodedProviderJob && activeTmsProviderQuery.isLoading) {
+    return (
+      <main className="mx-auto flex w-full max-w-6xl flex-col gap-5">
+        <div className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
+          <Skeleton className="h-5 w-48 bg-foreground/8" />
+          <Skeleton className="mt-4 h-40 w-full bg-foreground/8" />
+        </div>
+      </main>
+    );
+  }
+
+  if (useLiveProviderJob) {
     return <ProviderLiveJobDetailContent jobId={jobId} organizationSlug={organizationSlug} />;
   }
 

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.tsx
@@ -332,9 +332,14 @@ export function JobsPageContent({
     return source === "native" || source === "provider" ? source : "all";
   });
   const [agentReadyFilter, setAgentReadyFilter] = useState<"all" | "ready" | "not_ready">("all");
-  const { data: activeTmsProvider } = useActiveTmsProvider(organizationSlug);
+  const activeTmsProviderQuery = useActiveTmsProvider(organizationSlug);
+  const activeTmsProvider = activeTmsProviderQuery.data;
   const encodedProviderProject = projectId ? parseProviderProjectId(projectId) : null;
-  const useLiveProviderJobs = isTmsProviderShellModeEnabled() && Boolean(activeTmsProvider);
+  const tmsProviderShellMode = isTmsProviderShellModeEnabled();
+  const useLiveProviderJobs =
+    tmsProviderShellMode &&
+    Boolean(activeTmsProvider) &&
+    (!projectId || encodedProviderProject?.providerKind === activeTmsProvider?.providerKind);
 
   const jobsQuery = useQuery({
     queryKey: [
@@ -344,7 +349,9 @@ export function JobsPageContent({
       statusFilter,
       projectId ?? "workspace",
       useLiveProviderJobs ? "live" : "native",
+      activeTmsProvider?.providerKind ?? null,
     ],
+    enabled: !tmsProviderShellMode || activeTmsProviderQuery.isFetched,
     queryFn: async () => {
       if (useLiveProviderJobs) {
         const mine = scope === "mine" ? "true" : "false";

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-page-shell.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-page-shell.tsx
@@ -5,6 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 
 import { cn } from "@/lib/primitives/cn";
 import { apiClient } from "@/lib/api-client-instance";
+import { isTmsProviderShellModeEnabled } from "@/lib/providers/tms-provider-shell-mode";
 
 import {
   PageHeader,
@@ -12,15 +13,29 @@ import {
   type Icon,
 } from "../../../_components/workspace-resource-shared";
 import { parseProviderProjectId } from "@/lib/providers/tms-provider-resource-id";
+import { useActiveTmsProvider } from "../../../_hooks/use-active-tms-provider";
 
 import { mapProjectToListRow } from "../../_components/project-list";
 
 export function useProjectPageQuery(organizationSlug: string, projectId: string) {
+  const activeTmsProviderQuery = useActiveTmsProvider(organizationSlug);
+  const encodedProject = parseProviderProjectId(projectId);
+  const useLiveProviderProject =
+    isTmsProviderShellModeEnabled() &&
+    Boolean(activeTmsProviderQuery.data) &&
+    encodedProject?.providerKind === activeTmsProviderQuery.data?.providerKind;
+
   return useQuery({
-    queryKey: ["translation-project", organizationSlug, projectId],
+    queryKey: [
+      "translation-project",
+      organizationSlug,
+      projectId,
+      useLiveProviderProject ? "live" : "native",
+      activeTmsProviderQuery.data?.providerKind ?? null,
+    ],
+    enabled: !encodedProject || activeTmsProviderQuery.isFetched,
     queryFn: async () => {
-      const encodedProject = parseProviderProjectId(projectId);
-      if (encodedProject) {
+      if (useLiveProviderProject && encodedProject) {
         const response = await apiClient.api.orgs[":organizationSlug"]["tms-provider"].projects[
           ":externalProjectId"
         ].$get({

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
@@ -13,7 +13,10 @@ import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Spinner } from "@/components/ui/spinner";
 import { TypographyP } from "@/components/ui/typography";
+import { apiClient } from "@/lib/api-client-instance";
 import { cn } from "@/lib/primitives/cn";
+import { isTmsProviderShellModeEnabled } from "@/lib/providers/tms-provider-shell-mode";
+import { parseProviderProjectId } from "@/lib/providers/tms-provider-resource-id";
 
 import {
   ProjectPageShell,
@@ -21,6 +24,7 @@ import {
   ProjectSectionTitle,
 } from "../../_components/project-page-shell";
 import { ProjectFileDetailPanel } from "./project-file-detail-panel";
+import { useActiveTmsProvider } from "../../../../_hooks/use-active-tms-provider";
 
 const FILE_ACCEPT =
   ".json,.jsonc,.yaml,.yml,.arb,.xlf,.xlif,.xliff,.po,.html,.md,.mdx,.strings,.stringsdict,.xcstrings,.csv";
@@ -107,6 +111,12 @@ export function ProjectFilesPageContent({
   const inputRef = useRef<HTMLInputElement>(null);
   const queryClient = useQueryClient();
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+  const activeTmsProviderQuery = useActiveTmsProvider(organizationSlug);
+  const encodedProviderProject = parseProviderProjectId(projectId);
+  const useLiveProviderFiles =
+    isTmsProviderShellModeEnabled() &&
+    Boolean(activeTmsProviderQuery.data) &&
+    encodedProviderProject?.providerKind === activeTmsProviderQuery.data?.providerKind;
 
   const selectedSourcePath = searchParams.get("sourcePath");
   const highlightLocale = searchParams.get("locale");
@@ -126,8 +136,32 @@ export function ProjectFilesPageContent({
   );
 
   const filesQuery = useQuery({
-    queryKey: projectFilesQueryKey(organizationSlug, projectId),
+    queryKey: [
+      ...projectFilesQueryKey(organizationSlug, projectId),
+      useLiveProviderFiles ? "live" : "native",
+      activeTmsProviderQuery.data?.providerKind ?? null,
+    ],
+    enabled: !encodedProviderProject || activeTmsProviderQuery.isFetched,
     queryFn: async () => {
+      if (useLiveProviderFiles && encodedProviderProject) {
+        const response = await apiClient.api.orgs[":organizationSlug"]["tms-provider"].projects[
+          ":externalProjectId"
+        ].files.$get({
+          param: {
+            organizationSlug,
+            externalProjectId: encodedProviderProject.externalProjectId,
+          },
+          query: { limit: "500" },
+        });
+
+        if (!response.ok) {
+          throw new Error(`Failed to load provider files (${response.status})`);
+        }
+
+        const body = (await response.json()) as { files: ProjectFileRecord[] };
+        return body.files;
+      }
+
       const response = await fetch(`${apiPath(organizationSlug, projectId)}?limit=500`, {
         method: "GET",
       });
@@ -182,46 +216,55 @@ export function ProjectFilesPageContent({
     [files, selectedSourcePath],
   );
   const isUploading = uploadFiles.isPending;
+  const canUploadFiles = !useLiveProviderFiles;
 
   return (
     <ProjectPageShell className="gap-8">
       <ProjectSectionHeader
         icon={File01Icon}
         section="Files"
-        description="Upload source files, then select one to inspect content and related translation jobs."
+        description={
+          useLiveProviderFiles
+            ? "Browse source files and keys from the connected TMS provider."
+            : "Upload source files, then select one to inspect content and related translation jobs."
+        }
         actions={
-          <Button
-            type="button"
-            onClick={() => inputRef.current?.click()}
-            disabled={isUploading}
-            className="w-full sm:w-fit"
-          >
-            <HugeiconsIcon icon={Upload01Icon} strokeWidth={1.8} />
-            Add files
-          </Button>
+          canUploadFiles ? (
+            <Button
+              type="button"
+              onClick={() => inputRef.current?.click()}
+              disabled={isUploading}
+              className="w-full sm:w-fit"
+            >
+              <HugeiconsIcon icon={Upload01Icon} strokeWidth={1.8} />
+              Add files
+            </Button>
+          ) : null
         }
       />
 
-      <input
-        ref={inputRef}
-        type="file"
-        multiple
-        accept={FILE_ACCEPT}
-        className="sr-only"
-        onChange={(event) => {
-          const nextFiles = Array.from(event.target.files ?? []);
-          setSelectedFiles((currentFiles) => {
-            const existing = new Set(currentFiles.map(fileKey));
-            return [
-              ...currentFiles,
-              ...nextFiles.filter((file) => !existing.has(fileKey(file))),
-            ].slice(0, MAX_UPLOAD_FILES);
-          });
-          event.currentTarget.value = "";
-        }}
-      />
+      {canUploadFiles ? (
+        <input
+          ref={inputRef}
+          type="file"
+          multiple
+          accept={FILE_ACCEPT}
+          className="sr-only"
+          onChange={(event) => {
+            const nextFiles = Array.from(event.target.files ?? []);
+            setSelectedFiles((currentFiles) => {
+              const existing = new Set(currentFiles.map(fileKey));
+              return [
+                ...currentFiles,
+                ...nextFiles.filter((file) => !existing.has(fileKey(file))),
+              ].slice(0, MAX_UPLOAD_FILES);
+            });
+            event.currentTarget.value = "";
+          }}
+        />
+      ) : null}
 
-      {selectedFiles.length > 0 ? (
+      {canUploadFiles && selectedFiles.length > 0 ? (
         <section className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-4">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div>
@@ -300,7 +343,9 @@ export function ProjectFilesPageContent({
                   No files yet
                 </TypographyP>
                 <TypographyP className="text-sm text-foreground/52">
-                  Use Add files above to upload JSON, YAML, XLIFF, PO, and other supported formats.
+                  {useLiveProviderFiles
+                    ? "No provider files or keys were found for this project."
+                    : "Use Add files above to upload JSON, YAML, XLIFF, PO, and other supported formats."}
                 </TypographyP>
               </div>
             ) : (
@@ -343,13 +388,25 @@ export function ProjectFilesPageContent({
           </aside>
 
           <main className="min-h-0 overflow-y-auto bg-background/40">
-            <ProjectFileDetailPanel
-              organizationSlug={organizationSlug}
-              projectId={projectId}
-              file={selectedFile}
-              requestedSourcePath={selectedSourcePath}
-              highlightLocale={highlightLocale}
-            />
+            {useLiveProviderFiles ? (
+              <div className="p-4">
+                <ProjectSectionTitle>
+                  {selectedFile ? selectedFile.sourcePath : "Select a file"}
+                </ProjectSectionTitle>
+                <TypographyP className="mt-2 text-sm text-foreground/52">
+                  Provider file content and related job details are read live from the connected
+                  TMS. Select Jobs to inspect provider tasks for this project.
+                </TypographyP>
+              </div>
+            ) : (
+              <ProjectFileDetailPanel
+                organizationSlug={organizationSlug}
+                projectId={projectId}
+                file={selectedFile}
+                requestedSourcePath={selectedSourcePath}
+                highlightLocale={highlightLocale}
+              />
+            )}
           </main>
         </div>
       </section>

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-settings-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/settings/_components/project-settings-page-content.tsx
@@ -212,18 +212,25 @@ export function ProjectSettingsPageContent({
 
   const isSaving = updateProject.isPending;
   const localesEditable = project.source === "native";
+  const settingsEditable = project.source === "native";
 
   return (
     <ProjectPageShell>
       <ProjectSectionHeader
         icon={Settings01Icon}
         section="Settings"
-        description="Edit project metadata, translation guidance, locales, and source connection details."
+        description={
+          settingsEditable
+            ? "Edit project metadata, translation guidance, locales, and source connection details."
+            : "View provider-managed project metadata, locales, and source connection details."
+        }
         actions={
-          <Button type="submit" form="project-settings-form" disabled={isSaving}>
-            {isSaving ? <Spinner /> : <SaveIcon className="size-4" strokeWidth={2} />}
-            {isSaving ? "Saving..." : "Save settings"}
-          </Button>
+          settingsEditable ? (
+            <Button type="submit" form="project-settings-form" disabled={isSaving}>
+              {isSaving ? <Spinner /> : <SaveIcon className="size-4" strokeWidth={2} />}
+              {isSaving ? "Saving..." : "Save settings"}
+            </Button>
+          ) : null
         }
       />
 
@@ -240,7 +247,7 @@ export function ProjectSettingsPageContent({
             <Input
               id="project-name"
               value={values.name}
-              disabled={isSaving}
+              disabled={isSaving || !settingsEditable}
               onChange={(event) =>
                 setValues((current) =>
                   current ? { ...current, name: event.target.value } : current,
@@ -255,7 +262,7 @@ export function ProjectSettingsPageContent({
             <Textarea
               id="project-description"
               value={values.description}
-              disabled={isSaving}
+              disabled={isSaving || !settingsEditable}
               onChange={(event) =>
                 setValues((current) =>
                   current ? { ...current, description: event.target.value } : current,
@@ -285,7 +292,7 @@ export function ProjectSettingsPageContent({
             <Textarea
               id="translation-context"
               value={values.translationContext}
-              disabled={isSaving}
+              disabled={isSaving || !settingsEditable}
               onChange={(event) =>
                 setValues((current) =>
                   current ? { ...current, translationContext: event.target.value } : current,

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
@@ -398,7 +398,7 @@ function mapLiveFile(input: {
       localeReadiness: input.file.localeReadiness ?? {},
       revision: input.file.revision ?? null,
       format: input.file.format ?? null,
-      lastSyncedAt: timestamp,
+      lastSyncedAt: null,
     },
     latestJob: null,
   };

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
@@ -10,6 +10,7 @@ import {
 } from "@/lib/providers/organization-external-tms-provider-credentials";
 import {
   tmsProviderGlossaryFetchers,
+  tmsProviderFileKeyFetchers,
   tmsProviderJobTaskFetchers,
   tmsProviderProjectFetchers,
   tmsProviderTranslationMemoryFetchers,
@@ -23,6 +24,7 @@ import {
 } from "@/lib/providers/tms-provider-resource-id";
 import { mapProviderStatusToNormalized } from "@/lib/providers/sync/external-tms-status-mapper";
 import type { ExternalTmsGlossaryMetadata } from "@/lib/providers/sync/external-tms-glossary-sync";
+import type { ExternalTmsFileKeyMetadata } from "@/lib/providers/sync/external-tms-file-sync";
 import type { ExternalTmsJobTaskMetadata } from "@/lib/providers/sync/external-tms-job-sync";
 import type { ExternalTmsProjectMetadata } from "@/lib/providers/sync/external-tms-project-sync";
 import type { ExternalTmsTranslationMemoryMetadata } from "@/lib/providers/sync/external-tms-tm-sync";
@@ -104,6 +106,34 @@ export type TmsProviderLiveJobDetail = TmsProviderLiveJob & {
   externalJobId: string;
   externalUrl: string | null;
   externalProviderPayload: Record<string, unknown>;
+};
+
+export type TmsProviderLiveFile = {
+  origin: "provider";
+  sourcePath: string;
+  sourceHash: string | null;
+  commitSha: null;
+  workflowRunId: null;
+  uploadedAt: string;
+  storedFileId: null;
+  metadata: Record<string, unknown>;
+  filename: string;
+  byteSize: null;
+  provider: {
+    kind: ExternalTmsProviderKind;
+    resourceType: "file" | "key";
+    externalProjectId: string;
+    externalResourceId: string;
+    externalUrl: string | null;
+    syncState: string;
+    sourceLocale: string | null;
+    targetLocales: string[];
+    localeReadiness: Record<string, unknown>;
+    revision: string | null;
+    format: string | null;
+    lastSyncedAt: string | null;
+  };
+  latestJob: null;
 };
 
 export type TmsProviderLiveGlossary = {
@@ -336,6 +366,44 @@ function mapLiveJob(input: {
   };
 }
 
+function mapLiveFile(input: {
+  providerKind: ExternalTmsProviderKind;
+  externalProjectId: string;
+  file: ExternalTmsFileKeyMetadata;
+}): TmsProviderLiveFile {
+  const timestamp = new Date().toISOString();
+  const sourcePath = input.file.sourcePath;
+  const filename = input.file.displayName?.trim() || sourcePath.split("/").filter(Boolean).at(-1);
+
+  return {
+    origin: "provider",
+    sourcePath,
+    sourceHash: input.file.sourceHash ?? null,
+    commitSha: null,
+    workflowRunId: null,
+    uploadedAt: timestamp,
+    storedFileId: null,
+    metadata: input.file.providerPayload ?? {},
+    filename: filename || sourcePath,
+    byteSize: null,
+    provider: {
+      kind: input.providerKind,
+      resourceType: input.file.resourceType,
+      externalProjectId: input.externalProjectId,
+      externalResourceId: input.file.externalResourceId,
+      externalUrl: input.file.externalUrl ?? null,
+      syncState: input.file.syncState ?? "synced",
+      sourceLocale: input.file.sourceLocale ?? null,
+      targetLocales: input.file.targetLocales ?? [],
+      localeReadiness: input.file.localeReadiness ?? {},
+      revision: input.file.revision ?? null,
+      format: input.file.format ?? null,
+      lastSyncedAt: timestamp,
+    },
+    latestJob: null,
+  };
+}
+
 async function fetchLiveProjects(context: ActiveTmsProviderContext) {
   const fetcher = tmsProviderProjectFetchers[context.providerKind];
   if (!fetcher) {
@@ -460,6 +528,62 @@ export async function listTmsProviderLiveJobsForProject(
       task,
     }),
   );
+}
+
+export async function listTmsProviderLiveFilesForProject(
+  organizationId: string,
+  externalProjectId: string,
+  options?: {
+    limit?: number;
+    context?: ActiveTmsProviderContext;
+    projects?: ExternalTmsProjectMetadata[];
+  },
+): Promise<TmsProviderLiveFile[]> {
+  const context = options?.context ?? (await loadActiveTmsProviderContext(organizationId));
+  const fetcher = tmsProviderFileKeyFetchers[context.providerKind];
+  if (!fetcher) {
+    throw new TmsProviderLiveError(
+      "provider_fetcher_unavailable",
+      `Live file fetch is not available for ${context.providerKind}.`,
+    );
+  }
+
+  const projects = options?.projects ?? (await fetchLiveProjects(context));
+  const project = projects.find((item) => item.externalProjectId === externalProjectId);
+  if (!project) {
+    return [];
+  }
+
+  const liveProject = buildLiveProviderProject({
+    organizationId: context.organizationId,
+    credentialId: context.credential.id,
+    providerKind: context.providerKind,
+    externalProjectId: project.externalProjectId,
+    name: project.name,
+    sourceLocale: project.sourceLocale ?? "en",
+    targetLocales: project.targetLocales ?? [],
+    externalProjectUrl: project.externalProjectUrl,
+    isActive: project.isActive,
+  });
+
+  let files;
+  try {
+    files = await fetcher({
+      organizationId: context.organizationId,
+      projectId: liveProject.id,
+      providerKind: context.providerKind,
+      externalProjectId,
+      credential: context.credential,
+      project: liveProject,
+      secretMaterial: context.secretMaterial,
+    });
+  } catch (error) {
+    rethrowProviderFetcherError(error);
+  }
+
+  return files
+    .slice(0, options?.limit ?? 500)
+    .map((file) => mapLiveFile({ providerKind: context.providerKind, externalProjectId, file }));
 }
 
 export async function listTmsProviderLiveJobs(


### PR DESCRIPTION
## What changed

- Route shell-mode provider project pages through the live `tms-provider` APIs when an active provider matches the encoded `ext:<provider>:...` project or job ID.
- Add live provider files support with `GET /api/orgs/:organizationSlug/tms-provider/projects/:externalProjectId/files`.
- Update project Files, Settings, Jobs, My Jobs, and Job Detail views to avoid native project/job/file APIs for live provider resources.
- Keep provider-managed settings read-only and hide native file upload controls for provider projects.
- Add safe diagnostics for native project `project_not_found` responses to distinguish missing rows from access/scope mismatches.

## How to test

- `vp test src/api/routes/tms-provider/tms-provider.route.test.ts src/api/routes/project/project.test.ts src/api/routes/project/job.test.ts`
- `vp check --fix`
- `vp test`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review