### PR TITLE
fix(crowdin): improve machine translation engines API v2 parity

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -131,3 +131,9 @@
 **Learning:** The Crowdin Translations API v2 supports several parameters that were missing from the Go SDK, specifically filtering by labels during project and directory builds, and the 'soft match' option for pre-translations. Additionally, uploading translations supports marking them as done immediately.
 
 **Action:** Added `TranslateWithSoftMatchOnly` (*bool) to `PreTranslationRequest` and `PreTranslationAttributes`. Added `LabelIDs` ([]int) to `BuildProjectRequest`, `BuildProjectDirectoryTranslationRequest`, and `BuildAttributes`, and updated `MarshalJSON` to include them. Added `MarkAddedAsDone` (*bool) to `UploadTranslationsRequest`. Verified with comprehensive unit tests in `translations_test.go` and `model/translations_test.go`.
+
+## 2026-09-05 - Improve Machine Translation Engines model parity and flexibility
+
+**Learning:** The Crowdin MT Engines API v2 uses different credential structures depending on the engine type (e.g., Google, DeepL, etc.), but the SDK was using a hardcoded struct. Additionally, the list response was missing pagination, and the resource model was missing standard fields like `createdAt` and `updatedAt`.
+
+**Action:** Updated `MachineTranslation.Credentials` to `map[string]any` and `MTAddRequest.Credentials` to `any` to support all engine types. Added `Pagination` to `MachineTranslationsListResponse`. Added `CreatedAt` and `UpdatedAt` fields to the `MachineTranslation` model. Fixed and unskipped `TestMachineTranslationEnginesService_AddMT` by aligning expectations and correcting mock JSON data.

--- a/third_party/crowdin-api-client-go/crowdin/machine_translation_engines_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/machine_translation_engines_test.go
@@ -52,12 +52,9 @@ func TestMachineTranslationEnginesService_GetMT(t *testing.T) {
 		ID:   2,
 		Name: "Crowdin Translate",
 		Type: "crowdin",
-		Credentials: struct {
-			CrowdinNMT                  string `json:"crowdin_nmt"`
-			CrowdinNMTMultiTranslations string `json:"crowdin_nmt_multi_translations"`
-		}{
-			CrowdinNMT:                  "1",
-			CrowdinNMTMultiTranslations: "1",
+		Credentials: map[string]any{
+			"crowdin_nmt":                    "1",
+			"crowdin_nmt_multi_translations": "1",
 		},
 		SupportedLanguageIDs: []string{"en", "es", "pl"},
 		SupportedLanguagePairs: map[string][]string{
@@ -212,8 +209,6 @@ func TestMachineTranslationEnginesService_ListMT_invalidJSON(t *testing.T) {
 }
 
 func TestMachineTranslationEnginesService_AddMT(t *testing.T) {
-	t.Skip("Not implemented correctly")
-
 	client, mux, teardown := setupClient()
 	defer teardown()
 
@@ -230,7 +225,7 @@ func TestMachineTranslationEnginesService_AddMT(t *testing.T) {
 			"groupId": 0,
 			"enabledLanguageIds": ["uk"],
 			"enabledProjectIds": [ 22],
-			"isEnabled": "true"
+			"isEnabled": true
 		}`)
 
 		fmt.Fprint(w, `{
@@ -240,8 +235,8 @@ func TestMachineTranslationEnginesService_AddMT(t *testing.T) {
 				"name": "Crowdin Translate",
 				"type": "crowdin",
 				"credentials": {
-					"crowdin_nmt": 1,
-					"crowdin_nmt_multi_translations": 1
+					"crowdin_nmt": "1",
+					"crowdin_nmt_multi_translations": "1"
 				},
 				"supportedLanguageIds": ["en","es","pl"],
 				"supportedLanguagePairs": {
@@ -276,12 +271,9 @@ func TestMachineTranslationEnginesService_AddMT(t *testing.T) {
 		ID:   2,
 		Name: "Crowdin Translate",
 		Type: "crowdin",
-		Credentials: struct {
-			CrowdinNMT                  string `json:"crowdin_nmt"`
-			CrowdinNMTMultiTranslations string `json:"crowdin_nmt_multi_translations"`
-		}{
-			CrowdinNMT:                  "1",
-			CrowdinNMTMultiTranslations: "1",
+		Credentials: map[string]any{
+			"crowdin_nmt":                    "1",
+			"crowdin_nmt_multi_translations": "1",
 		},
 		SupportedLanguageIDs: []string{"en", "es", "pl"},
 		SupportedLanguagePairs: map[string][]string{

--- a/third_party/crowdin-api-client-go/crowdin/model/machine_translation_engines.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/machine_translation_engines.go
@@ -3,6 +3,7 @@ package model
 import (
 	"errors"
 	"net/url"
+	"reflect"
 	"strconv"
 )
 
@@ -146,7 +147,7 @@ func (r *MTAddRequest) Validate() error {
 	if r.Type == "" {
 		return errors.New("type is required")
 	}
-	if r.Credentials == nil {
+	if r.Credentials == nil || (reflect.ValueOf(r.Credentials).Kind() == reflect.Ptr && reflect.ValueOf(r.Credentials).IsNil()) {
 		return errors.New("credentials are required")
 	}
 

--- a/third_party/crowdin-api-client-go/crowdin/model/machine_translation_engines.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/machine_translation_engines.go
@@ -147,7 +147,11 @@ func (r *MTAddRequest) Validate() error {
 	if r.Type == "" {
 		return errors.New("type is required")
 	}
-	if r.Credentials == nil || (reflect.ValueOf(r.Credentials).Kind() == reflect.Ptr && reflect.ValueOf(r.Credentials).IsNil()) {
+	if r.Credentials == nil {
+		return errors.New("credentials are required")
+	}
+	if v := reflect.ValueOf(r.Credentials); (v.Kind() == reflect.Ptr || v.Kind() == reflect.Map ||
+		v.Kind() == reflect.Slice || v.Kind() == reflect.Chan || v.Kind() == reflect.Func) && v.IsNil() {
 		return errors.New("credentials are required")
 	}
 

--- a/third_party/crowdin-api-client-go/crowdin/model/machine_translation_engines.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/machine_translation_engines.go
@@ -8,13 +8,10 @@ import (
 
 // MachineTranslation represents a machine translation engine (MTE).
 type MachineTranslation struct {
-	ID          int    `json:"id"`
-	Name        string `json:"name"`
-	Type        string `json:"type"`
-	Credentials struct {
-		CrowdinNMT                  string `json:"crowdin_nmt"`
-		CrowdinNMTMultiTranslations string `json:"crowdin_nmt_multi_translations"`
-	} `json:"credentials"`
+	ID                     int                 `json:"id"`
+	Name                   string              `json:"name"`
+	Type                   string              `json:"type"`
+	Credentials            map[string]any      `json:"credentials"`
 	SupportedLanguageIDs   []string            `json:"supportedLanguageIds"`
 	SupportedLanguagePairs map[string][]string `json:"supportedLanguagePairs"`
 
@@ -23,6 +20,8 @@ type MachineTranslation struct {
 	EnabledProjectIDs  []int    `json:"enabledProjectIds,omitempty"`
 	ProjectIDs         []int    `json:"projectIds,omitempty"`
 	IsEnabled          *bool    `json:"isEnabled,omitempty"`
+	CreatedAt          string   `json:"createdAt,omitempty"`
+	UpdatedAt          string   `json:"updatedAt,omitempty"`
 }
 
 // MachineTranslationsResponse defines the structure of
@@ -34,7 +33,8 @@ type MachineTranslationsResponse struct {
 // MachineTranslationsListResponse defines the structure of
 // a response to list machine translation engines.
 type MachineTranslationsListResponse struct {
-	Data []*MachineTranslationsResponse `json:"data"`
+	Data       []*MachineTranslationsResponse `json:"data"`
+	Pagination *Pagination                    `json:"pagination"`
 }
 
 // MTListOptions specifies the optional parameters
@@ -72,7 +72,7 @@ type MTAddRequest struct {
 	//       amazon, modernmt, custom_mt.
 	Type string `json:"type"`
 	// MT engine credentials.
-	Credentials *MTECredentials `json:"credentials"`
+	Credentials any `json:"credentials"`
 	// Group Identifier that defines the group to which the MT is added.
 	// If `0`, the MT will be available for all projects and groups
 	// in your workspace.

--- a/third_party/crowdin-api-client-go/crowdin/model/machine_translation_engines_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/machine_translation_engines_test.go
@@ -79,6 +79,14 @@ func TestMTAddRequestValidate(t *testing.T) {
 			err:  "credentials are required",
 		},
 		{
+			name: "typed nil credentials",
+			req: func() *MTAddRequest {
+				var creds *MTECredentials = nil
+				return &MTAddRequest{Name: "Crowdin Translate", Type: "crowdin", Credentials: creds}
+			}(),
+			err: "credentials are required",
+		},
+		{
 			name: "valid request",
 			req: &MTAddRequest{
 				Name: "Crowdin Translate", Type: "crowdin",


### PR DESCRIPTION
This PR improves the Machine Translation Engines (MTE) API v2 parity in the Crowdin fork. 

Key changes:
- **Credential Flexibility:** Changed `MachineTranslation.Credentials` to `map[string]any` and `MTAddRequest.Credentials` to `any`. This allows the SDK to support various MT engines (Google, DeepL, Microsoft, etc.) which have different credential structures, moving away from a hardcoded struct that only supported Crowdin's own NMT.
- **API Parity:** Added missing standard fields `CreatedAt` and `UpdatedAt` to the `MachineTranslation` model and included `Pagination` in the `MachineTranslationsListResponse`.
- **Test Fixes:** Fixed and unskipped `TestMachineTranslationEnginesService_AddMT` by correcting mock JSON data (changing `isEnabled` from string to boolean) and aligning expectations with the new flexible credential type.

Docs: https://developer.crowdin.com/api/v2/#tag/Machine-Translation-Engines

---
*PR created automatically by Jules for task [12819748868877514136](https://jules.google.com/task/12819748868877514136) started by @cungminh2710*