### PR TITLE
🧪 Scout: support triple mustache placeholders

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -43,3 +43,11 @@
 ## 2025-06-12 - [PO msgid Significance of Whitespace]
 **Learning:** In gettext/PO files, `msgid` keys are the source of truth for translation lookups, and leading/trailing whitespace is significant. Over-eagerly trimming spaces from these keys during parsing causes lookup failures in downstream systems.
 **Action:** Always preserve the exact literal string for `msgid` keys, except for the header entry (`msgid ""`) which is standardly skipped in message maps.
+
+## 2026-06-03 - [Triple Mustache Placeholder Normalization]
+**Learning:**  uses a  fallback to handle non-ICU formats. Many mustache-based systems use triple braces `{{{key}}}` for unescaped content. Failing to account for this leads to validation errors when these keys are used in translations.
+**Action:** Update `normalizeMustachePlaceholders` to detect and strip both double and triple braces, converting them to standard ICU `{key}` format for invariant extraction.
+
+## 2026-06-03 - [Triple Mustache Placeholder Normalization]
+**Learning:** ParseInvariant uses a normalizeMustachePlaceholders fallback to handle non-ICU formats. Many mustache-based systems use triple braces {{{key}}} for unescaped content. Failing to account for this leads to validation errors when these keys are used in translations.
+**Action:** Update normalizeMustachePlaceholders to detect and strip both double and triple braces, converting them to standard ICU {key} format for invariant extraction.

--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -45,9 +45,5 @@
 **Action:** Always preserve the exact literal string for `msgid` keys, except for the header entry (`msgid ""`) which is standardly skipped in message maps.
 
 ## 2026-06-03 - [Triple Mustache Placeholder Normalization]
-**Learning:**  uses a  fallback to handle non-ICU formats. Many mustache-based systems use triple braces `{{{key}}}` for unescaped content. Failing to account for this leads to validation errors when these keys are used in translations.
+**Learning:** `ParseInvariant` uses a `normalizeMustachePlaceholders` fallback to handle non-ICU formats. Many mustache-based systems use triple braces `{{{key}}}` for unescaped content. Failing to account for this leads to validation errors when these keys are used in translations.
 **Action:** Update `normalizeMustachePlaceholders` to detect and strip both double and triple braces, converting them to standard ICU `{key}` format for invariant extraction.
-
-## 2026-06-03 - [Triple Mustache Placeholder Normalization]
-**Learning:** ParseInvariant uses a normalizeMustachePlaceholders fallback to handle non-ICU formats. Many mustache-based systems use triple braces {{{key}}} for unescaped content. Failing to account for this leads to validation errors when these keys are used in translations.
-**Action:** Update normalizeMustachePlaceholders to detect and strip both double and triple braces, converting them to standard ICU {key} format for invariant extraction.

--- a/internal/i18n/icuparser/invariant.go
+++ b/internal/i18n/icuparser/invariant.go
@@ -138,27 +138,28 @@ func normalizeMustachePlaceholders(s string) string {
 				j++
 			}
 
+			braceCount := 2
 			if isTriple {
-				if j+2 < len(s) && s[j] == '}' && s[j+1] == '}' && s[j+2] == '}' {
-					name := strings.TrimSpace(s[i+3 : j])
-					if isPlaceholderName(name) {
-						b.WriteByte('{')
-						b.WriteString(name)
-						b.WriteByte('}')
-						i = j + 3
-						continue
-					}
+				braceCount = 3
+			}
+
+			match := true
+			for k := 0; k < braceCount; k++ {
+				if j+k >= len(s) || s[j+k] != '}' {
+					match = false
+					break
 				}
-			} else {
-				if j+1 < len(s) && s[j] == '}' && s[j+1] == '}' {
-					name := strings.TrimSpace(s[i+2 : j])
-					if isPlaceholderName(name) {
-						b.WriteByte('{')
-						b.WriteString(name)
-						b.WriteByte('}')
-						i = j + 2
-						continue
-					}
+			}
+
+			if match {
+				name := strings.TrimSpace(s[i+braceCount : j])
+				if isPlaceholderName(name) {
+					// Convert moustache placeholders to ICU-style arguments for fallback parsing.
+					b.WriteByte('{')
+					b.WriteString(name)
+					b.WriteByte('}')
+					i = j + braceCount
+					continue
 				}
 			}
 		}

--- a/internal/i18n/icuparser/invariant.go
+++ b/internal/i18n/icuparser/invariant.go
@@ -127,19 +127,38 @@ func normalizeMustachePlaceholders(s string) string {
 
 	for i := 0; i < len(s); {
 		if i+3 < len(s) && s[i] == '{' && s[i+1] == '{' {
-			j := i + 2
+			isTriple := i+2 < len(s) && s[i+2] == '{'
+			startOffset := 2
+			if isTriple {
+				startOffset = 3
+			}
+
+			j := i + startOffset
 			for j < len(s) && s[j] != '}' {
 				j++
 			}
-			if j+1 < len(s) && s[j] == '}' && s[j+1] == '}' {
-				name := strings.TrimSpace(s[i+2 : j])
-				if isPlaceholderName(name) {
-					// Convert moustache placeholders to ICU-style arguments for fallback parsing.
-					b.WriteByte('{')
-					b.WriteString(name)
-					b.WriteByte('}')
-					i = j + 2
-					continue
+
+			if isTriple {
+				if j+2 < len(s) && s[j] == '}' && s[j+1] == '}' && s[j+2] == '}' {
+					name := strings.TrimSpace(s[i+3 : j])
+					if isPlaceholderName(name) {
+						b.WriteByte('{')
+						b.WriteString(name)
+						b.WriteByte('}')
+						i = j + 3
+						continue
+					}
+				}
+			} else {
+				if j+1 < len(s) && s[j] == '}' && s[j+1] == '}' {
+					name := strings.TrimSpace(s[i+2 : j])
+					if isPlaceholderName(name) {
+						b.WriteByte('{')
+						b.WriteString(name)
+						b.WriteByte('}')
+						i = j + 2
+						continue
+					}
 				}
 			}
 		}

--- a/internal/i18n/icuparser/invariant_test.go
+++ b/internal/i18n/icuparser/invariant_test.go
@@ -122,6 +122,11 @@ func TestParseInvariantMustacheNormalization(t *testing.T) {
 			want: []string{"name"},
 		},
 		{
+			name: "triple mustache",
+			msg:  "Hello {{{name}}}",
+			want: []string{"name"},
+		},
+		{
 			name: "mustache with dots and dollars",
 			msg:  "Price for {{user.id}} is {{$amount}}",
 			want: []string{"$amount", "user.id"},

--- a/internal/i18n/icuparser/invariant_test.go
+++ b/internal/i18n/icuparser/invariant_test.go
@@ -127,6 +127,16 @@ func TestParseInvariantMustacheNormalization(t *testing.T) {
 			want: []string{"name"},
 		},
 		{
+			name:    "invalid triple mustache identifier (spaces)",
+			msg:     "Hello {{{not a valid id}}}",
+			wantErr: true,
+		},
+		{
+			name: "mixed double and triple mustache",
+			msg:  "{{name}} and {{{title}}}",
+			want: []string{"name", "title"},
+		},
+		{
 			name: "mustache with dots and dollars",
 			msg:  "Price for {{user.id}} is {{$amount}}",
 			want: []string{"$amount", "user.id"},


### PR DESCRIPTION
💡 What: Added support and unit tests for triple mustache placeholders in the ICU invariant parser.
🎯 Why: Mustache-based systems often use `{{{key}}}` for unescaped content. Supporting this syntax prevents validation failures in translations that use it.
🧩 Scope: `internal/i18n/icuparser/invariant.go`, `internal/i18n/icuparser/invariant_test.go`
✅ Verification: Ran `go test -v ./internal/i18n/icuparser/...`. All tests passed.
🛡️ Confidence: Prevents false-positive validation errors for projects using triple-mustache placeholders.

---
*PR created automatically by Jules for task [3470624262101809011](https://jules.google.com/task/3470624262101809011) started by @cungminh2710*