### PR TITLE
fix(crowdin): preview source strings when file download fails

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/project.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.test.ts
@@ -991,6 +991,186 @@ describe("projectRoutes", () => {
     expect(listFiles).toHaveBeenCalledWith(organizationId, "902807", { limit: 500 });
   });
 
+  it("falls back to Crowdin source strings for live file detail preview", async () => {
+    const originalFetch = globalThis.fetch;
+    const baseIdentity = createWorkosIdentity();
+    const identity = {
+      ...baseIdentity,
+      organization: {
+        ...baseIdentity.organization,
+        slug: "hyperlocalise",
+      },
+    };
+    const headers = await authHeadersFor(identity);
+    const organizationId = globalThis.__testApiAuthContext!.organization.localOrganizationId;
+
+    await upsertOrganizationExternalTmsProviderCredential({
+      organizationId,
+      userId: globalThis.__testApiAuthContext!.user.localUserId,
+      role: "admin",
+      providerKind: "crowdin",
+      displayName: "Crowdin",
+      secretMaterial: "crowdin-secret",
+    });
+
+    const fetchMock = vi.fn(async (url) => {
+      const path = String(url);
+
+      if (path.includes("/projects?")) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  id: 902807,
+                  name: "HL-Test",
+                  identifier: "hl-test",
+                  sourceLanguageId: "en",
+                  targetLanguageIds: ["fr"],
+                  webUrl: "https://crowdin.test/project/hl-test",
+                  isSuspended: false,
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/branches?")) {
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }
+
+      if (path.includes("/directories?")) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  id: 1,
+                  branchId: null,
+                  directoryId: null,
+                  name: "Test nested",
+                  title: null,
+                  exportPattern: null,
+                  path: "/Test nested",
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/files?")) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  id: 101,
+                  branchId: null,
+                  directoryId: 1,
+                  name: "en-US.stringsdict",
+                  title: null,
+                  type: "stringsdict",
+                  path: "/Test nested/en-US.stringsdict",
+                  status: "active",
+                  revisionId: 5,
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/revisions?")) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  id: 77,
+                  fileId: 101,
+                  projectId: 902807,
+                  info: {
+                    sourceLanguageId: "en",
+                    addedStrings: 2,
+                    removedStrings: 0,
+                    updatedStrings: 0,
+                  },
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.endsWith("/projects/902807/files/101/download")) {
+        return new Response(JSON.stringify({ error: { message: "No source export" } }), {
+          status: 503,
+        });
+      }
+
+      if (path.includes("/strings?")) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  id: 1001,
+                  projectId: 902807,
+                  fileId: 101,
+                  branchId: null,
+                  directoryId: 1,
+                  identifier: "items.count",
+                  text: { one: "%d item", other: "%d items" },
+                  type: "text",
+                  context: "Pluralized item count",
+                  labelIds: null,
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    globalThis.fetch = fetchMock;
+    try {
+      const response = await app.request(
+        "/api/orgs/hyperlocalise/projects/ext%253Acrowdin%253A902807/files/detail?sourcePath=Test%20nested%2Fen-US.stringsdict",
+        { headers },
+      );
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as ProjectFileDetailResponse;
+      expect(body.file.versions[0]).toMatchObject({
+        origin: "provider",
+        revision: "77",
+        contentType: "application/json",
+      });
+      expect(body.file.versions[0]?.content?.text).toContain('"resource": "source_strings"');
+      expect(body.file.versions[0]?.content?.text).toContain('"key": "items.count"');
+      expect(body.file.versions[0]?.content?.text).toContain('"%d items"');
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining("/projects/902807/files/101/download"),
+        expect.anything(),
+      );
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining("/projects/902807/strings?limit=500&offset=0&fileId=101"),
+        expect.anything(),
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("combines repository and provider records for the same source path", async () => {
     const identity = createWorkosIdentity();
     const createdResponse = await createProjectViaApi(identity);

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
@@ -544,14 +544,23 @@ export class CrowdinApiClient {
     projectId: number,
     fileId?: number,
     stringIds?: number[],
+    options?: { maxItems?: number },
   ): Promise<CrowdinSourceString[]> {
     const strings: CrowdinSourceString[] = [];
     let offset = 0;
     const limit = 500;
 
     while (true) {
+      const pageLimit =
+        options?.maxItems !== undefined
+          ? Math.min(limit, Math.max(options.maxItems - strings.length, 0))
+          : limit;
+      if (pageLimit === 0) {
+        break;
+      }
+
       const params = new URLSearchParams({
-        limit: String(limit),
+        limit: String(pageLimit),
         offset: String(offset),
       });
       if (fileId !== undefined) {
@@ -567,11 +576,11 @@ export class CrowdinApiClient {
       const page = response.data.map((item) => item.data);
       strings.push(...page);
 
-      if (page.length < limit) {
+      if (page.length < pageLimit || strings.length === options?.maxItems) {
         break;
       }
 
-      offset += limit;
+      offset += pageLimit;
     }
 
     return strings;

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
@@ -436,10 +436,6 @@ function mapLiveFile(input: {
 }
 
 function crowdinSourceTextValue(text: CrowdinSourceString["text"]) {
-  if (typeof text === "string") {
-    return text;
-  }
-
   return text;
 }
 

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
@@ -1,7 +1,11 @@
 import { createLogger } from "@/lib/log";
 import { schema } from "@/lib/database";
 import type { ProjectFileDetailResponse } from "@/api/routes/project/project.schema";
-import { CrowdinApiClient, CrowdinApiError } from "@/lib/providers/adapters/crowdin/crowdin-api";
+import {
+  CrowdinApiClient,
+  CrowdinApiError,
+  type CrowdinSourceString,
+} from "@/lib/providers/adapters/crowdin/crowdin-api";
 import { sourceContentType } from "@/lib/file-storage/source-file-metadata";
 import { mapWithConcurrency } from "@/lib/primitives/map-with-concurrency/map-with-concurrency";
 import {
@@ -39,6 +43,7 @@ const logger = createLogger("tms-provider-live");
 const LIVE_PROJECT_JOB_FANOUT_CONCURRENCY = 5;
 const LIVE_GLOSSARY_TM_FANOUT_CONCURRENCY = 5;
 const maxLiveProviderInlineTextBytes = 512 * 1024;
+const maxLiveProviderStringPreviewItems = 1_000;
 
 type ExternalTmsProject = typeof schema.projects.$inferSelect;
 
@@ -430,6 +435,69 @@ function mapLiveFile(input: {
   };
 }
 
+function crowdinSourceTextValue(text: CrowdinSourceString["text"]) {
+  if (typeof text === "string") {
+    return text;
+  }
+
+  return text;
+}
+
+function serializeCrowdinSourceStringsPreview(input: {
+  strings: CrowdinSourceString[];
+  truncated: boolean;
+}) {
+  if (input.strings.length === 0) {
+    return null;
+  }
+
+  return `${JSON.stringify(
+    {
+      provider: "crowdin",
+      resource: "source_strings",
+      note: "Raw source file download was unavailable; this preview is generated from Crowdin source string metadata.",
+      truncated: input.truncated,
+      strings: input.strings.map((sourceString) => ({
+        id: sourceString.id,
+        key: sourceString.identifier,
+        text: crowdinSourceTextValue(sourceString.text),
+        type: sourceString.type,
+        context: sourceString.context,
+      })),
+    },
+    null,
+    2,
+  )}\n`;
+}
+
+async function downloadCrowdinSourceStringPreview(input: {
+  client: CrowdinApiClient;
+  projectId: number;
+  fileId: number;
+}): Promise<{
+  byteSize: number | null;
+  content: { text: string } | null;
+  contentType: string | null;
+} | null> {
+  const strings = await input.client.listSourceStrings(input.projectId, input.fileId, undefined, {
+    maxItems: maxLiveProviderStringPreviewItems + 1,
+  });
+  const previewText = serializeCrowdinSourceStringsPreview({
+    strings: strings.slice(0, maxLiveProviderStringPreviewItems),
+    truncated: strings.length > maxLiveProviderStringPreviewItems,
+  });
+  if (!previewText) {
+    return null;
+  }
+
+  const byteSize = new TextEncoder().encode(previewText).byteLength;
+  return {
+    byteSize,
+    content: byteSize <= maxLiveProviderInlineTextBytes ? { text: previewText } : null,
+    contentType: "application/json",
+  };
+}
+
 async function downloadLiveProviderFileContent(input: {
   context: ActiveTmsProviderContext;
   externalProjectId: string;
@@ -475,6 +543,27 @@ async function downloadLiveProviderFileContent(input: {
   } catch (error) {
     if (error instanceof CrowdinApiError && error.status === 401) {
       throw new TmsProviderLiveError("crowdin_auth_invalid", "Crowdin credentials are invalid.");
+    }
+
+    try {
+      const preview = await downloadCrowdinSourceStringPreview({ client, projectId, fileId });
+      if (preview) {
+        return preview;
+      }
+    } catch (previewError) {
+      if (previewError instanceof CrowdinApiError && previewError.status === 401) {
+        throw new TmsProviderLiveError("crowdin_auth_invalid", "Crowdin credentials are invalid.");
+      }
+
+      logger.warn("tms_provider_live_file_content_failed", {
+        organizationId: input.context.organizationId,
+        providerKind: input.context.providerKind,
+        externalProjectId: input.externalProjectId,
+        externalResourceId: input.externalResourceId,
+        downloadError: error instanceof Error ? error.message : String(error),
+        previewError: previewError instanceof Error ? previewError.message : String(previewError),
+      });
+      return { byteSize: null, content: null, contentType: null };
     }
 
     logger.warn("tms_provider_live_file_content_failed", {


### PR DESCRIPTION
## What changed

- Add a bounded Crowdin source-string fallback for live file detail previews when raw source file download is unavailable.
- Allow Crowdin source string listing to stop after a maximum item count for preview use cases.
- Cover the encoded external project file detail route with a `.stringsdict` fallback preview regression test.

## How to test

- `vp test`
- `vp check --fix`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)