### PR TITLE
🎨 Palette: Add tooltips to Dialog and Sheet close buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -21,3 +21,7 @@
 ## 2026-06-01 - [Dynamic Sidebar Labels & Structural Consistency]
 **Learning:** In `apps/hyperlocalise-web`, toggle controls like `SidebarTrigger` should use dynamic ARIA labels and tooltips (e.g., 'Expand Sidebar' / 'Collapse Sidebar') to reflect the interface state. Additionally, when using `@base-ui/react` primitives with a `render` prop, nesting children inside the rendered component is necessary for correct accessibility prop forwarding and event delegation.
 **Action:** Always synchronize toggle labels with state and ensure children of `render` prop components are nested within those components.
+
+## 2026-06-03 - [Tooltip Coverage for Portaled Close Buttons]
+**Learning:** In `apps/hyperlocalise-web`, icon-only close buttons within `Dialog` and `Sheet` components were missing tooltips. Standardizing these with `Tooltip` components improves discoverability. When testing these components with `renderToStaticMarkup`, note that content rendered inside Portals (like `DialogContent` or `SheetContent`) will not be captured in the output as they are teleported out of the static tree.
+**Action:** Consistently wrap icon-only close buttons in `Tooltip` using the `render` prop pattern and use E2E tests (Playwright) or full DOM rendering for verification of portaled content.

--- a/apps/hyperlocalise-web/src/components/ui/dialog.tsx
+++ b/apps/hyperlocalise-web/src/components/ui/dialog.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/primitives/cn";
 import { Button } from "@/components/ui/button";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Cancel01Icon } from "@hugeicons/core-free-icons";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 function Dialog({ ...props }: DialogPrimitive.Root.Props) {
   return <DialogPrimitive.Root data-slot="dialog" {...props} />;
@@ -58,15 +59,24 @@ function DialogContent({
       >
         {children}
         {showCloseButton && (
-          <DialogPrimitive.Close
-            data-slot="dialog-close"
-            render={
-              <Button variant="ghost" className="absolute top-4 end-4" size="icon-sm">
-                <HugeiconsIcon icon={Cancel01Icon} strokeWidth={2} />
-                <span className="sr-only">Close</span>
-              </Button>
-            }
-          />
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <DialogPrimitive.Close
+                  data-slot="dialog-close"
+                  render={
+                    <Button variant="ghost" className="absolute top-4 end-4" size="icon-sm">
+                      <HugeiconsIcon icon={Cancel01Icon} strokeWidth={2} />
+                      <span className="sr-only">Close</span>
+                    </Button>
+                  }
+                />
+              }
+            />
+            <TooltipContent side="bottom" align="center">
+              Close
+            </TooltipContent>
+          </Tooltip>
         )}
       </DialogPrimitive.Popup>
     </DialogPortal>

--- a/apps/hyperlocalise-web/src/components/ui/dialog.tsx
+++ b/apps/hyperlocalise-web/src/components/ui/dialog.tsx
@@ -73,7 +73,7 @@ function DialogContent({
                 />
               }
             />
-            <TooltipContent side="bottom" align="center">
+            <TooltipContent side="bottom" align="end">
               Close
             </TooltipContent>
           </Tooltip>

--- a/apps/hyperlocalise-web/src/components/ui/sheet.tsx
+++ b/apps/hyperlocalise-web/src/components/ui/sheet.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/primitives/cn";
 import { Button } from "@/components/ui/button";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Cancel01Icon } from "@hugeicons/core-free-icons";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 function Sheet({ ...props }: SheetPrimitive.Root.Props) {
   return <SheetPrimitive.Root data-slot="sheet" {...props} />;
@@ -61,15 +62,24 @@ function SheetContent({
       >
         {children}
         {showCloseButton && (
-          <SheetPrimitive.Close
-            data-slot="sheet-close"
-            render={
-              <Button variant="ghost" className="absolute top-4 end-4" size="icon-sm">
-                <HugeiconsIcon icon={Cancel01Icon} strokeWidth={2} />
-                <span className="sr-only">Close</span>
-              </Button>
-            }
-          />
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <SheetPrimitive.Close
+                  data-slot="sheet-close"
+                  render={
+                    <Button variant="ghost" className="absolute top-4 end-4" size="icon-sm">
+                      <HugeiconsIcon icon={Cancel01Icon} strokeWidth={2} />
+                      <span className="sr-only">Close</span>
+                    </Button>
+                  }
+                />
+              }
+            />
+            <TooltipContent side="bottom" align="center">
+              Close
+            </TooltipContent>
+          </Tooltip>
         )}
       </SheetPrimitive.Popup>
     </SheetPortal>

--- a/apps/hyperlocalise-web/src/components/ui/sheet.tsx
+++ b/apps/hyperlocalise-web/src/components/ui/sheet.tsx
@@ -76,7 +76,7 @@ function SheetContent({
                 />
               }
             />
-            <TooltipContent side="bottom" align="center">
+            <TooltipContent side="bottom" align="end">
               Close
             </TooltipContent>
           </Tooltip>


### PR DESCRIPTION
### 💡 What: The UX enhancement added
Added visual tooltips to the icon-only "Close" buttons in the `Dialog` and `Sheet` UI components.

### 🎯 Why: The user problem it solves
Icon-only buttons can sometimes be ambiguous for users. While the "X" icon is a common convention for "Close", providing a tooltip confirms the action on hover, improving discoverability and bringing these components in line with the rest of the application's accessible icon button pattern.

### ♿ Accessibility: Any a11y improvements made
- Improved visual discoverability for hover users.
- Maintained existing screen-reader support via `sr-only` text.
- Followed the `@base-ui/react` `render` prop pattern to ensure proper ARIA attribute forwarding without invalid HTML nesting (no nested buttons).

---
*PR created automatically by Jules for task [13006873851044837377](https://jules.google.com/task/13006873851044837377) started by @cungminh2710*