### PR TITLE
feat(web): source strings table and repo context lookup in file preview

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -59,6 +59,7 @@ import {
   listTmsProviderLiveProjects,
 } from "@/lib/providers/tms-provider-live";
 import { getProjectFileDetail } from "@/lib/projects/project-file-detail";
+import { lookupProjectFileStringRepositoryContext } from "@/lib/projects/project-file-string-context";
 import { listFilteredProjectFiles } from "@/lib/projects/project-files";
 import type { ExternalTmsResourceType } from "@/lib/providers/sync/organization-external-tms-files";
 import type {
@@ -75,6 +76,7 @@ import {
   externalTmsTranslationPushBodySchema,
   maxProjectFileUploadBytes,
   projectFileDetailQuerySchema,
+  projectFileStringContextBodySchema,
   projectFileUploadBodySchema,
   projectFilesQuerySchema,
   projectIdParamsSchema,
@@ -318,6 +320,16 @@ const validateProjectFileDetailQuery = validator("query", (value, c) => {
   return parsed.data;
 });
 
+const validateProjectFileStringContextBody = validator("json", (value, c) => {
+  const parsed = projectFileStringContextBodySchema.safeParse(value);
+
+  if (!parsed.success) {
+    return invalidProjectPayloadResponse(c);
+  }
+
+  return parsed.data;
+});
+
 function asString(value: unknown) {
   return typeof value === "string" ? value : undefined;
 }
@@ -545,6 +557,44 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
         }
 
         return c.json({ file }, 200);
+      },
+    )
+    .post(
+      "/:projectId/files/string-context",
+      validateProjectParams,
+      validateProjectFileStringContextBody,
+      async (c) => {
+        const params = c.req.valid("param");
+        const body = c.req.valid("json");
+
+        if (!isProjectMutationAllowed(c.var.auth.membership.role)) {
+          return forbiddenResponse(c);
+        }
+
+        const target = await resolveProjectResourceTarget(c.var.auth, params.projectId);
+        if (target.kind === "provider_unavailable") {
+          return providerProjectUnavailableResponse(c, target);
+        }
+
+        const result = await lookupProjectFileStringRepositoryContext({
+          organizationId: c.var.auth.organization.localOrganizationId,
+          projectId: params.projectId,
+          repositoryFullName: body.repositoryFullName,
+          sourcePath: body.sourcePath,
+          key: body.key,
+          text: body.text,
+          context: body.context ?? null,
+          localUserId: c.var.auth.user.localUserId,
+          membershipRole: c.var.auth.membership.role,
+          displayName: null,
+          email: c.var.auth.user.email,
+        });
+
+        if (isErr(result)) {
+          return badRequestResponse(c, result.error.code, result.error.message);
+        }
+
+        return c.json({ stringContext: result.value }, 200);
       },
     )
     .get("/:projectId/files", validateProjectParams, validateProjectFilesQuery, async (c) => {

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -89,6 +89,7 @@ import { normalizeProjectLocalePatch, type ProjectLocalePatchError } from "@/lib
 import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
 import { ensureDefaultWorkspaceTeam } from "@/lib/teams/default-workspace-team";
 
+import { isAiActionAllowed } from "@/api/auth/capability-guards";
 import {
   buildAccessibleProjectsWhere,
   forbiddenResponse,
@@ -567,7 +568,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
         const params = c.req.valid("param");
         const body = c.req.valid("json");
 
-        if (!isProjectMutationAllowed(c.var.auth.membership.role)) {
+        if (!isAiActionAllowed(c.var.auth.membership.role)) {
           return forbiddenResponse(c);
         }
 

--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -241,7 +241,7 @@ export const projectFileStringContextBodySchema = z.object({
   repositoryFullName: z.string().trim().min(1).max(256),
   sourcePath: z.string().trim().min(1).max(2048),
   key: z.string().trim().min(1).max(2048),
-  text: z.string().trim().min(1).max(16_384),
+  text: z.string().trim().max(16_384),
   context: z.string().trim().max(16_384).nullable().optional(),
 });
 

--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -218,8 +218,37 @@ export const projectFileUploadBodySchema = z.object({
   workflowRunId: z.string().trim().min(1).max(256).optional(),
 });
 
-export const projectFileContentSchema = z.object({
+export const projectSourceStringEntrySchema = z.object({
+  key: z.string(),
   text: z.string(),
+  context: z.string().nullable(),
+  type: z.string().optional(),
+  id: z.number().optional(),
+});
+
+export const projectSourceStringsPreviewSchema = z.object({
+  truncated: z.boolean(),
+  note: z.string().optional(),
+  entries: z.array(projectSourceStringEntrySchema),
+});
+
+export const projectFileContentSchema = z.object({
+  text: z.string().optional(),
+  sourceStrings: projectSourceStringsPreviewSchema.optional(),
+});
+
+export const projectFileStringContextBodySchema = z.object({
+  repositoryFullName: z.string().trim().min(1).max(256),
+  sourcePath: z.string().trim().min(1).max(2048),
+  key: z.string().trim().min(1).max(2048),
+  text: z.string().trim().min(1).max(16_384),
+  context: z.string().trim().max(16_384).nullable().optional(),
+});
+
+export const projectFileStringContextResponseSchema = z.object({
+  stringContext: z.object({
+    summary: z.string(),
+  }),
 });
 
 export const projectFileVersionRecordSchema = z.object({
@@ -309,7 +338,13 @@ export type ProjectFileRecord = z.infer<typeof projectFileRecordSchema>;
 export type ProjectFilesResponse = z.infer<typeof projectFilesResponseSchema>;
 export type ProjectFilesQuery = z.infer<typeof projectFilesQuerySchema>;
 export type ProjectFileDetailQuery = z.infer<typeof projectFileDetailQuerySchema>;
+export type ProjectSourceStringEntry = z.infer<typeof projectSourceStringEntrySchema>;
+export type ProjectSourceStringsPreview = z.infer<typeof projectSourceStringsPreviewSchema>;
 export type ProjectFileContent = z.infer<typeof projectFileContentSchema>;
+export type ProjectFileStringContextBody = z.infer<typeof projectFileStringContextBodySchema>;
+export type ProjectFileStringContextResponse = z.infer<
+  typeof projectFileStringContextResponseSchema
+>;
 export type ProjectFileVersionRecord = z.infer<typeof projectFileVersionRecordSchema>;
 export type ProjectFileOutputRecord = z.infer<typeof projectFileOutputRecordSchema>;
 export type ProjectFileJobRecord = z.infer<typeof projectFileJobRecordSchema>;

--- a/apps/hyperlocalise-web/src/api/routes/project/project.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.test.ts
@@ -1155,9 +1155,16 @@ describe("projectRoutes", () => {
         revision: "77",
         contentType: "application/json",
       });
-      expect(body.file.versions[0]?.content?.text).toContain('"resource": "source_strings"');
-      expect(body.file.versions[0]?.content?.text).toContain('"key": "items.count"');
-      expect(body.file.versions[0]?.content?.text).toContain('"%d items"');
+      expect(body.file.versions[0]?.content?.sourceStrings?.entries).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            key: "items.count",
+            text: JSON.stringify({ one: "%d item", other: "%d items" }),
+            context: "Pluralized item count",
+          }),
+        ]),
+      );
+      expect(body.file.versions[0]?.content?.text).toBeUndefined();
       expect(fetchMock).toHaveBeenCalledWith(
         expect.stringContaining("/projects/902807/files/101/download"),
         expect.anything(),

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-detail-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-detail-panel.tsx
@@ -72,12 +72,14 @@ export function ProjectFileDetailPanel({
   file,
   requestedSourcePath,
   highlightLocale,
+  canFindInRepo,
 }: {
   organizationSlug: string;
   projectId: string;
   file: ProjectFileRecord | null;
   requestedSourcePath: string | null;
   highlightLocale: string | null;
+  canFindInRepo: boolean;
 }) {
   const sourcePath = file?.sourcePath ?? null;
 
@@ -205,7 +207,8 @@ export function ProjectFileDetailPanel({
             organizationSlug={organizationSlug}
             projectId={projectId}
             sourcePath={sourcePath}
-            content={latestContent}
+            sourceStrings={sourceStringsPreview}
+            canFindInRepo={canFindInRepo}
           />
         ) : textPreview ? (
           <div className="overflow-hidden rounded-md border border-foreground/8 bg-background">

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-detail-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-detail-panel.tsx
@@ -10,8 +10,10 @@ import type {
 import { Badge } from "@/components/ui/badge";
 import { Spinner } from "@/components/ui/spinner";
 import { TypographyP } from "@/components/ui/typography";
+import { ProjectFileSourceStringsPreview } from "./project-file-source-strings-preview";
 import { readApiError } from "@/lib/api-error";
 import { apiClient } from "@/lib/api-client-instance";
+import { parseSourceStringsFromFileContent } from "@/lib/projects/project-file-source-strings";
 import { cn } from "@/lib/primitives/cn";
 
 const DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
@@ -148,7 +150,10 @@ export function ProjectFileDetailPanel({
 
   const detail = detailQuery.data;
   const latestVersion = detail?.versions[0];
-  const preview = latestVersion?.content?.text ? truncatePreview(latestVersion.content.text) : null;
+  const latestContent = latestVersion?.content ?? null;
+  const sourceStringsPreview = parseSourceStringsFromFileContent(latestContent);
+  const textPreview =
+    latestContent?.text && !sourceStringsPreview ? truncatePreview(latestContent.text) : null;
   const displayByteSize = latestVersion?.byteSize ?? file.byteSize;
 
   const jobsByLocale = detail?.jobsByLocale ?? [];
@@ -195,12 +200,19 @@ export function ProjectFileDetailPanel({
         <TypographyP className="text-xs font-medium tracking-wide text-foreground/52 uppercase">
           Source preview
         </TypographyP>
-        {preview ? (
+        {sourceStringsPreview ? (
+          <ProjectFileSourceStringsPreview
+            organizationSlug={organizationSlug}
+            projectId={projectId}
+            sourcePath={sourcePath}
+            content={latestContent}
+          />
+        ) : textPreview ? (
           <div className="overflow-hidden rounded-md border border-foreground/8 bg-background">
             <pre className="max-h-[min(24rem,50vh)] overflow-auto p-3 font-mono text-xs leading-relaxed text-foreground/82 whitespace-pre-wrap wrap-break-word">
-              {preview.text}
+              {textPreview.text}
             </pre>
-            {preview.truncated ? (
+            {textPreview.truncated ? (
               <TypographyP className="border-t border-foreground/8 px-3 py-2 text-xs text-foreground/42">
                 Preview truncated. Download the full file from a completed job output when
                 available.

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-source-strings-preview.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-source-strings-preview.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 
 import type {
-  ProjectFileContent,
   ProjectSourceStringEntry,
   ProjectSourceStringsPreview,
 } from "@/api/routes/project/project.schema";
@@ -21,7 +20,6 @@ import { Spinner } from "@/components/ui/spinner";
 import { TypographyP } from "@/components/ui/typography";
 import { readApiError } from "@/lib/api-error";
 import { apiClient } from "@/lib/api-client-instance";
-import { parseSourceStringsFromFileContent } from "@/lib/projects/project-file-source-strings";
 import { cn } from "@/lib/primitives/cn";
 
 type GitHubRepositoryOption = {
@@ -54,15 +52,15 @@ export function ProjectFileSourceStringsPreview({
   organizationSlug,
   projectId,
   sourcePath,
-  content,
+  sourceStrings,
+  canFindInRepo,
 }: {
   organizationSlug: string;
   projectId: string;
   sourcePath: string;
-  content: ProjectFileContent | null | undefined;
+  sourceStrings: ProjectSourceStringsPreview;
+  canFindInRepo: boolean;
 }) {
-  const sourceStrings = useMemo(() => parseSourceStringsFromFileContent(content), [content]);
-
   const repositoriesQuery = useEnabledGitHubRepositories(organizationSlug);
   const enabledRepositories = repositoriesQuery.data ?? [];
 
@@ -110,7 +108,7 @@ export function ProjectFileSourceStringsPreview({
     },
   });
 
-  if (!sourceStrings || sourceStrings.entries.length === 0) {
+  if (sourceStrings.entries.length === 0) {
     return null;
   }
 
@@ -122,8 +120,9 @@ export function ProjectFileSourceStringsPreview({
         repositories={enabledRepositories}
         repositoriesLoading={repositoriesQuery.isLoading}
         onRepositoryChange={setRepositoryFullName}
+        canFindInRepo={canFindInRepo}
         onFindInRepo={(entry) => {
-          if (!repositoryFullName) {
+          if (!repositoryFullName || !canFindInRepo) {
             return;
           }
           lookupMutation.mutate(entry);
@@ -150,6 +149,7 @@ function SourceStringsTable({
   repositories,
   repositoriesLoading,
   onRepositoryChange,
+  canFindInRepo,
   onFindInRepo,
   findInRepoPending,
 }: {
@@ -158,10 +158,12 @@ function SourceStringsTable({
   repositories: GitHubRepositoryOption[];
   repositoriesLoading: boolean;
   onRepositoryChange: (fullName: string) => void;
+  canFindInRepo: boolean;
   onFindInRepo: (entry: ProjectSourceStringEntry) => void;
   findInRepoPending: boolean;
 }) {
   const repoReady = Boolean(repositoryFullName);
+  const findInRepoEnabled = canFindInRepo && repoReady && !findInRepoPending;
 
   return (
     <div className="space-y-3">
@@ -234,7 +236,7 @@ function SourceStringsTable({
                       variant="outline"
                       size="sm"
                       className="h-7 text-[10px]"
-                      disabled={!repoReady || findInRepoPending}
+                      disabled={!findInRepoEnabled}
                       onClick={() => onFindInRepo(entry)}
                     >
                       Find in repo
@@ -247,7 +249,12 @@ function SourceStringsTable({
         </div>
       </div>
 
-      {!repoReady && repositories.length > 0 ? (
+      {!canFindInRepo ? (
+        <TypographyP className={cn("text-xs text-foreground/42")}>
+          Repository context lookup requires a role that can run AI actions (for example translator
+          or developer).
+        </TypographyP>
+      ) : !repoReady && repositories.length > 0 ? (
         <TypographyP className={cn("text-xs text-foreground/42")}>
           Select a repository, then use Find in repo on a string to run the same repository agent as
           Slack.

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-source-strings-preview.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-source-strings-preview.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+
+import type {
+  ProjectFileContent,
+  ProjectSourceStringEntry,
+  ProjectSourceStringsPreview,
+} from "@/api/routes/project/project.schema";
+import { ProjectFileStringContextDialog } from "./project-file-string-context-dialog";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Spinner } from "@/components/ui/spinner";
+import { TypographyP } from "@/components/ui/typography";
+import { readApiError } from "@/lib/api-error";
+import { apiClient } from "@/lib/api-client-instance";
+import { parseSourceStringsFromFileContent } from "@/lib/projects/project-file-source-strings";
+import { cn } from "@/lib/primitives/cn";
+
+type GitHubRepositoryOption = {
+  fullName: string;
+  enabled: boolean;
+};
+
+function useEnabledGitHubRepositories(organizationSlug: string) {
+  return useQuery({
+    queryKey: ["github-installation-repositories", organizationSlug, "enabled-only"],
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"]["github-installation"][
+        "repositories"
+      ].$get({
+        param: { organizationSlug },
+        query: {},
+      });
+
+      if (!response.ok) {
+        throw new Error("Failed to load GitHub repositories");
+      }
+
+      const body = (await response.json()) as { repositories: GitHubRepositoryOption[] };
+      return body.repositories.filter((repository) => repository.enabled);
+    },
+  });
+}
+
+export function ProjectFileSourceStringsPreview({
+  organizationSlug,
+  projectId,
+  sourcePath,
+  content,
+}: {
+  organizationSlug: string;
+  projectId: string;
+  sourcePath: string;
+  content: ProjectFileContent | null | undefined;
+}) {
+  const sourceStrings = useMemo(() => parseSourceStringsFromFileContent(content), [content]);
+
+  const repositoriesQuery = useEnabledGitHubRepositories(organizationSlug);
+  const enabledRepositories = repositoriesQuery.data ?? [];
+
+  const [repositoryFullName, setRepositoryFullName] = useState<string>("");
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [activeEntry, setActiveEntry] = useState<ProjectSourceStringEntry | null>(null);
+  const [contextSummary, setContextSummary] = useState<string | null>(null);
+  const [contextError, setContextError] = useState<string | null>(null);
+
+  const lookupMutation = useMutation({
+    mutationFn: async (entry: ProjectSourceStringEntry) => {
+      const response = await apiClient.api.orgs[":organizationSlug"].projects[":projectId"].files[
+        "string-context"
+      ].$post({
+        param: { organizationSlug, projectId },
+        json: {
+          repositoryFullName,
+          sourcePath,
+          key: entry.key,
+          text: entry.text,
+          context: entry.context,
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(await readApiError(response, "Failed to look up repository context"));
+      }
+
+      const body = (await response.json()) as { stringContext: { summary: string } };
+      return body.stringContext.summary;
+    },
+    onMutate: (entry) => {
+      setActiveEntry(entry);
+      setContextSummary(null);
+      setContextError(null);
+      setDialogOpen(true);
+    },
+    onSuccess: (summary) => {
+      setContextSummary(summary);
+    },
+    onError: (error) => {
+      setContextError(
+        error instanceof Error ? error.message : "Failed to look up repository context.",
+      );
+    },
+  });
+
+  if (!sourceStrings || sourceStrings.entries.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <SourceStringsTable
+        preview={sourceStrings}
+        repositoryFullName={repositoryFullName}
+        repositories={enabledRepositories}
+        repositoriesLoading={repositoriesQuery.isLoading}
+        onRepositoryChange={setRepositoryFullName}
+        onFindInRepo={(entry) => {
+          if (!repositoryFullName) {
+            return;
+          }
+          lookupMutation.mutate(entry);
+        }}
+        findInRepoPending={lookupMutation.isPending}
+      />
+
+      <ProjectFileStringContextDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        entry={activeEntry}
+        repositoryFullName={repositoryFullName || null}
+        isLoading={lookupMutation.isPending}
+        summary={contextSummary}
+        errorMessage={contextError}
+      />
+    </>
+  );
+}
+
+function SourceStringsTable({
+  preview,
+  repositoryFullName,
+  repositories,
+  repositoriesLoading,
+  onRepositoryChange,
+  onFindInRepo,
+  findInRepoPending,
+}: {
+  preview: ProjectSourceStringsPreview;
+  repositoryFullName: string;
+  repositories: GitHubRepositoryOption[];
+  repositoriesLoading: boolean;
+  onRepositoryChange: (fullName: string) => void;
+  onFindInRepo: (entry: ProjectSourceStringEntry) => void;
+  findInRepoPending: boolean;
+}) {
+  const repoReady = Boolean(repositoryFullName);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <TypographyP className="text-xs text-foreground/52">
+          {preview.entries.length} string{preview.entries.length === 1 ? "" : "s"}
+          {preview.truncated ? " (preview truncated)" : ""}
+        </TypographyP>
+        <div className="flex w-full flex-col gap-1.5 sm:max-w-xs">
+          <TypographyP className="text-[10px] font-medium tracking-wide text-foreground/42 uppercase">
+            Repository for context lookup
+          </TypographyP>
+          {repositoriesLoading ? (
+            <div className="flex h-9 items-center gap-2 px-1">
+              <Spinner className="size-4" />
+              <TypographyP className="text-xs text-foreground/42">Loading repos…</TypographyP>
+            </div>
+          ) : repositories.length === 0 ? (
+            <TypographyP className="text-xs text-foreground/42">
+              Enable a repository under Integrations → GitHub to search for context.
+            </TypographyP>
+          ) : (
+            <Select
+              value={repositoryFullName}
+              onValueChange={(value) => onRepositoryChange(value ?? "")}
+            >
+              <SelectTrigger className="h-9 w-full font-mono text-xs">
+                <SelectValue placeholder="Select repository" />
+              </SelectTrigger>
+              <SelectContent>
+                {repositories.map((repository) => (
+                  <SelectItem key={repository.fullName} value={repository.fullName}>
+                    {repository.fullName}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+        </div>
+      </div>
+
+      {preview.note ? (
+        <TypographyP className="text-xs text-foreground/42">{preview.note}</TypographyP>
+      ) : null}
+
+      <div className="overflow-hidden rounded-md border border-foreground/8 bg-background">
+        <div className="max-h-[min(24rem,50vh)] overflow-auto">
+          <table className="w-full min-w-[32rem] border-collapse text-left text-xs">
+            <thead className="sticky top-0 z-10 border-b border-foreground/8 bg-background/95 backdrop-blur-sm">
+              <tr>
+                <th className="px-3 py-2 font-medium text-foreground/52">Key</th>
+                <th className="px-3 py-2 font-medium text-foreground/52">Text</th>
+                <th className="px-3 py-2 font-medium text-foreground/52">Context</th>
+                <th className="w-28 px-3 py-2 font-medium text-foreground/52" />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-foreground/8">
+              {preview.entries.map((entry) => (
+                <tr key={entry.id ?? entry.key} className="align-top">
+                  <td className="px-3 py-2 font-mono text-foreground/82">{entry.key}</td>
+                  <td className="max-w-[14rem] px-3 py-2 whitespace-pre-wrap text-foreground/78">
+                    {entry.text}
+                  </td>
+                  <td className="max-w-[12rem] px-3 py-2 whitespace-pre-wrap text-foreground/52">
+                    {entry.context?.trim() ? entry.context : "—"}
+                  </td>
+                  <td className="px-3 py-2">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="h-7 text-[10px]"
+                      disabled={!repoReady || findInRepoPending}
+                      onClick={() => onFindInRepo(entry)}
+                    >
+                      Find in repo
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {!repoReady && repositories.length > 0 ? (
+        <TypographyP className={cn("text-xs text-foreground/42")}>
+          Select a repository, then use Find in repo on a string to run the same repository agent as
+          Slack.
+        </TypographyP>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-string-context-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-string-context-dialog.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { MessageResponse } from "@/components/ai-elements/message";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Spinner } from "@/components/ui/spinner";
+import { TypographyP } from "@/components/ui/typography";
+import type { ProjectSourceStringEntry } from "@/api/routes/project/project.schema";
+
+export function ProjectFileStringContextDialog({
+  open,
+  onOpenChange,
+  entry,
+  repositoryFullName,
+  isLoading,
+  summary,
+  errorMessage,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  entry: ProjectSourceStringEntry | null;
+  repositoryFullName: string | null;
+  isLoading: boolean;
+  summary: string | null;
+  errorMessage: string | null;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex max-h-[min(32rem,85vh)] flex-col gap-4 sm:max-w-xl">
+        <DialogHeader>
+          <DialogTitle>Repository context</DialogTitle>
+          <DialogDescription>
+            {entry ? (
+              <>
+                <span className="font-mono text-foreground/72">{entry.key}</span>
+                {repositoryFullName ? (
+                  <>
+                    {" "}
+                    in <span className="font-mono text-foreground/72">{repositoryFullName}</span>
+                  </>
+                ) : null}
+              </>
+            ) : (
+              "Localization context from your connected repository."
+            )}
+          </DialogDescription>
+        </DialogHeader>
+
+        {isLoading ? (
+          <div className="flex items-center gap-2 py-6">
+            <Spinner />
+            <TypographyP className="text-sm text-foreground/52">
+              Searching the repository…
+            </TypographyP>
+          </div>
+        ) : errorMessage ? (
+          <TypographyP className="text-sm text-flame-100">{errorMessage}</TypographyP>
+        ) : summary ? (
+          <div className="min-h-0 overflow-auto rounded-md border border-foreground/8 bg-background/60 p-3">
+            <MessageResponse>{summary}</MessageResponse>
+          </div>
+        ) : (
+          <TypographyP className="text-sm text-foreground/52">No context returned.</TypographyP>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
@@ -185,9 +185,11 @@ function ProjectFilesTree({
 export function ProjectFilesPageContent({
   organizationSlug,
   projectId,
+  canFindInRepo,
 }: {
   organizationSlug: string;
   projectId: string;
+  canFindInRepo: boolean;
 }) {
   const router = useRouter();
   const pathname = usePathname();
@@ -422,6 +424,7 @@ export function ProjectFilesPageContent({
               file={selectedFile}
               requestedSourcePath={selectedSourcePath}
               highlightLocale={highlightLocale}
+              canFindInRepo={canFindInRepo}
             />
           </main>
         </div>

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/page.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/page.tsx
@@ -1,6 +1,8 @@
 import { Suspense } from "react";
 
+import { hasCapability } from "@/api/auth/policy";
 import { TypographyP } from "@/components/ui/typography";
+import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
 import { ProjectFilesPageContent } from "./_components/project-files-page-content";
 
@@ -10,12 +12,17 @@ export default async function ProjectFilesPage({
   params: Promise<{ organizationSlug: string; projectId: string }>;
 }) {
   const { organizationSlug, projectId } = await params;
+  const auth = await requireAppAuthContext({ organizationSlug });
 
   return (
     <Suspense
       fallback={<TypographyP className="text-sm text-foreground/52">Loading files...</TypographyP>}
     >
-      <ProjectFilesPageContent organizationSlug={organizationSlug} projectId={projectId} />
+      <ProjectFilesPageContent
+        organizationSlug={organizationSlug}
+        projectId={projectId}
+        canFindInRepo={hasCapability(auth.membership.role, "ai_actions:run")}
+      />
     </Suspense>
   );
 }

--- a/apps/hyperlocalise-web/src/lib/agents/repository-context.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/repository-context.ts
@@ -75,6 +75,23 @@ export type RepositoryGitHubContextDependencies = {
   }) => Promise<PullRequestDetails | null>;
 };
 
+export async function resolveWebProjectRepositoryGitHubContext(input: {
+  organizationId: string;
+  repositoryFullName: string;
+  dependencies?: RepositoryGitHubContextDependencies;
+}): Promise<RepositoryGitHubContextResolution> {
+  const dependencies = input.dependencies ?? defaultRepositoryGitHubContextDependencies;
+
+  return resolveInstalledGitHubContext({
+    organizationId: input.organizationId,
+    repositoryFullName: input.repositoryFullName,
+    source: "workspace_config",
+    accessFailureFollowUp:
+      "The GitHub App could not access this repository. Check that it is installed and enabled in Agent → GitHub.",
+    dependencies,
+  });
+}
+
 export async function resolveSlackRepositoryGitHubContext(input: {
   organizationId: string;
   text: string;

--- a/apps/hyperlocalise-web/src/lib/projects/project-file-detail.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/project-file-detail.ts
@@ -15,6 +15,7 @@ import { listExternalTmsFileVersionsForFile } from "@/lib/providers/sync/organiz
 import { resolveProviderJobsForFile } from "@/lib/providers/job-provider-source-files";
 import { bufferFromStream } from "@/lib/primitives/streams";
 import { sanitizeExternalUrl } from "@/lib/security/safe-external-url";
+import { normalizeProjectFileContent } from "@/lib/projects/project-file-source-strings";
 import { inferSupportedFileTranslationFileFormat } from "@/lib/translation/file-formats";
 
 const maxInlineTextBytes = 512 * 1024;
@@ -100,9 +101,8 @@ export async function inlineProjectFileTextContent(input: {
   }
 
   const buffer = await bufferFromStream(object.body);
-  return {
-    text: new TextDecoder("utf-8", { fatal: false }).decode(buffer),
-  };
+  const text = new TextDecoder("utf-8", { fatal: false }).decode(buffer);
+  return normalizeProjectFileContent({ text });
 }
 
 function toProviderRecord(file: typeof schema.externalTmsFiles.$inferSelect) {

--- a/apps/hyperlocalise-web/src/lib/projects/project-file-source-strings.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/project-file-source-strings.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  normalizeProjectFileContent,
+  parseSourceStringsFromFileContent,
+} from "./project-file-source-strings";
+
+describe("project-file-source-strings", () => {
+  it("parses structured sourceStrings from stored JSON text", () => {
+    const content = {
+      text: JSON.stringify({
+        sourceStrings: {
+          truncated: false,
+          entries: [{ key: "app.title", text: "Hello", context: null }],
+        },
+      }),
+    };
+
+    expect(parseSourceStringsFromFileContent(content)?.entries[0]?.key).toBe("app.title");
+    expect(normalizeProjectFileContent(content)).toEqual({
+      sourceStrings: {
+        truncated: false,
+        entries: [{ key: "app.title", text: "Hello", context: null }],
+      },
+    });
+  });
+
+  it("parses legacy Crowdin preview JSON with strings array", () => {
+    const content = {
+      text: JSON.stringify({
+        provider: "crowdin",
+        resource: "source_strings",
+        strings: [{ key: "legacy.key", text: "Legacy", context: "Note" }],
+      }),
+    };
+
+    expect(parseSourceStringsFromFileContent(content)?.entries[0]?.key).toBe("legacy.key");
+    expect(normalizeProjectFileContent(content)?.sourceStrings?.entries[0]?.key).toBe("legacy.key");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/projects/project-file-source-strings.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/project-file-source-strings.ts
@@ -1,0 +1,144 @@
+import type {
+  ProjectFileContent,
+  ProjectSourceStringEntry,
+  ProjectSourceStringsPreview,
+} from "@/api/routes/project/project.schema";
+
+type StoredSourceStringsPreviewPayload = {
+  sourceStrings?: ProjectSourceStringsPreview;
+};
+
+type LegacyCrowdinPreviewPayload = {
+  strings?: Array<{
+    id?: number;
+    key?: string;
+    text?: unknown;
+    type?: string;
+    context?: string | null;
+  }>;
+  truncated?: boolean;
+  note?: string;
+};
+
+function formatSourceStringText(text: unknown): string {
+  if (typeof text === "string") {
+    return text;
+  }
+
+  if (text === null || text === undefined) {
+    return "";
+  }
+
+  if (typeof text === "object") {
+    return JSON.stringify(text);
+  }
+
+  return JSON.stringify(text);
+}
+
+export function buildSourceStringsPreviewContent(input: {
+  entries: ProjectSourceStringEntry[];
+  truncated: boolean;
+  note?: string;
+}): ProjectFileContent {
+  if (input.entries.length === 0) {
+    return {};
+  }
+
+  const sourceStrings: ProjectSourceStringsPreview = {
+    truncated: input.truncated,
+    note: input.note,
+    entries: input.entries,
+  };
+
+  return { sourceStrings };
+}
+
+export function parseSourceStringsFromFileContent(
+  content: ProjectFileContent | null | undefined,
+): ProjectSourceStringsPreview | null {
+  if (!content) {
+    return null;
+  }
+
+  if (content.sourceStrings) {
+    return content.sourceStrings;
+  }
+
+  if (!content.text) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(content.text) as StoredSourceStringsPreviewPayload &
+      LegacyCrowdinPreviewPayload;
+
+    if (parsed.sourceStrings?.entries?.length) {
+      return parsed.sourceStrings;
+    }
+
+    if (!Array.isArray(parsed.strings) || parsed.strings.length === 0) {
+      return null;
+    }
+
+    const entries: ProjectSourceStringEntry[] = [];
+    for (const entry of parsed.strings) {
+      const key = typeof entry.key === "string" ? entry.key.trim() : "";
+      if (!key) {
+        continue;
+      }
+
+      entries.push({
+        key,
+        text: formatSourceStringText(entry.text),
+        context: typeof entry.context === "string" ? entry.context : null,
+        type: typeof entry.type === "string" ? entry.type : undefined,
+        id: typeof entry.id === "number" ? entry.id : undefined,
+      });
+    }
+
+    if (entries.length === 0) {
+      return null;
+    }
+
+    return {
+      truncated: parsed.truncated === true,
+      note: typeof parsed.note === "string" ? parsed.note : undefined,
+      entries,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function normalizeProjectFileContent(
+  content: ProjectFileContent | null | undefined,
+): ProjectFileContent | null {
+  if (!content) {
+    return null;
+  }
+
+  const sourceStrings = parseSourceStringsFromFileContent(content);
+  if (sourceStrings) {
+    return { sourceStrings };
+  }
+
+  if (content.text?.trim()) {
+    return { text: content.text };
+  }
+
+  return Object.keys(content).length > 0 ? content : null;
+}
+
+export function hasRenderableFilePreview(content: ProjectFileContent | null | undefined) {
+  if (!content) {
+    return false;
+  }
+
+  if (content.text?.trim()) {
+    return true;
+  }
+
+  const sourceStrings = parseSourceStringsFromFileContent(content);
+  return Boolean(sourceStrings && sourceStrings.entries.length > 0);
+}

--- a/apps/hyperlocalise-web/src/lib/projects/project-file-string-context.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/project-file-string-context.ts
@@ -1,0 +1,128 @@
+import { randomUUID } from "node:crypto";
+
+import {
+  buildRepositoryGitHubContextInstructions,
+  resolveWebProjectRepositoryGitHubContext,
+} from "@/lib/agents/repository-context";
+import { runSubagent } from "@/lib/agent-runtime/subagents/run-subagent";
+import { createRepositorySandbox } from "@/lib/agent-runtime/workspaces/repository-sandbox";
+import { stopRepositorySandbox } from "@/lib/agent-runtime/workspaces/repository-sandbox";
+import { ensureAgentSession } from "@/lib/tools/types";
+import type { ToolContext } from "@/lib/tools/types";
+import { db } from "@/lib/database";
+import type { OrganizationMembershipRole } from "@/lib/database/types";
+import { err, ok, type Result } from "@/lib/primitives/result/results";
+
+export type ProjectFileStringContextError =
+  | { code: "repository_not_enabled"; message: string }
+  | { code: "repository_access_failed"; message: string }
+  | { code: "agent_failed"; message: string };
+
+export async function lookupProjectFileStringRepositoryContext(input: {
+  organizationId: string;
+  projectId: string;
+  repositoryFullName: string;
+  sourcePath: string;
+  key: string;
+  text: string;
+  context: string | null;
+  localUserId: string;
+  membershipRole: OrganizationMembershipRole;
+  displayName: string | null;
+  email: string | null;
+}): Promise<Result<{ summary: string }, ProjectFileStringContextError>> {
+  const resolution = await resolveWebProjectRepositoryGitHubContext({
+    organizationId: input.organizationId,
+    repositoryFullName: input.repositoryFullName,
+  });
+
+  if (resolution.status === "unresolved") {
+    return err({
+      code: "repository_not_enabled",
+      message: resolution.followUp,
+    });
+  }
+
+  if (resolution.status !== "resolved" || !resolution.context.resolved) {
+    return err({
+      code: "repository_not_enabled",
+      message:
+        "Connect and enable a GitHub repository in Agent → GitHub before looking up string context.",
+    });
+  }
+
+  const githubContext = resolution.context;
+  let sandboxId: string | null = null;
+
+  try {
+    sandboxId = await createRepositorySandbox(githubContext);
+  } catch {
+    return err({
+      code: "repository_access_failed",
+      message:
+        "The GitHub App could not access this repository. Check that it is installed and enabled for this workspace.",
+    });
+  }
+
+  const conversationId = `project-file-context:${randomUUID()}`;
+  const toolContext: ToolContext = {
+    conversationId,
+    agentSession: { todos: [] },
+    organizationId: input.organizationId,
+    localUserId: input.localUserId,
+    membershipRole: input.membershipRole,
+    projectId: input.projectId,
+    db,
+    workMode: "read_only",
+    repositorySource: "chat_ui",
+    actor: {
+      sourceUserId: input.localUserId,
+      userId: input.localUserId,
+      email: input.email ?? undefined,
+      displayName: input.displayName ?? undefined,
+      role: input.membershipRole,
+    },
+    sandboxId,
+    githubContext,
+  };
+
+  ensureAgentSession(toolContext);
+
+  const instructions = [
+    buildRepositoryGitHubContextInstructions(githubContext),
+    `Source file path in the TMS project: ${input.sourcePath}`,
+    `String key: ${input.key}`,
+    `Source text: ${input.text}`,
+    input.context ? `Crowdin/context note: ${input.context}` : null,
+    "Find where this string appears in the connected repository and explain localization-relevant context for translators.",
+  ]
+    .filter((line): line is string => line !== null)
+    .join("\n\n");
+
+  try {
+    const result = await runSubagent("repository", {
+      toolContext,
+      task: `Find repository context for localization key "${input.key}".`,
+      instructions,
+    });
+
+    const summary = result.text.trim();
+    if (!summary) {
+      return err({
+        code: "agent_failed",
+        message: "The repository agent did not return any context for this string.",
+      });
+    }
+
+    return ok({ summary });
+  } catch {
+    return err({
+      code: "agent_failed",
+      message: "Failed to look up repository context. Try again in a moment.",
+    });
+  } finally {
+    if (sandboxId) {
+      await stopRepositorySandbox(sandboxId).catch(() => undefined);
+    }
+  }
+}

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
@@ -1,6 +1,13 @@
 import { createLogger } from "@/lib/log";
 import { schema } from "@/lib/database";
-import type { ProjectFileDetailResponse } from "@/api/routes/project/project.schema";
+import type {
+  ProjectFileContent,
+  ProjectFileDetailResponse,
+} from "@/api/routes/project/project.schema";
+import {
+  buildSourceStringsPreviewContent,
+  normalizeProjectFileContent,
+} from "@/lib/projects/project-file-source-strings";
 import {
   CrowdinApiClient,
   CrowdinApiError,
@@ -439,31 +446,30 @@ function crowdinSourceTextValue(text: CrowdinSourceString["text"]) {
   return text;
 }
 
-function serializeCrowdinSourceStringsPreview(input: {
+function buildCrowdinSourceStringsPreviewContent(input: {
   strings: CrowdinSourceString[];
   truncated: boolean;
-}) {
+}): ProjectFileContent | null {
   if (input.strings.length === 0) {
     return null;
   }
 
-  return `${JSON.stringify(
-    {
-      provider: "crowdin",
-      resource: "source_strings",
-      note: "Raw source file download was unavailable; this preview is generated from Crowdin source string metadata.",
-      truncated: input.truncated,
-      strings: input.strings.map((sourceString) => ({
-        id: sourceString.id,
-        key: sourceString.identifier,
-        text: crowdinSourceTextValue(sourceString.text),
-        type: sourceString.type,
-        context: sourceString.context,
-      })),
-    },
-    null,
-    2,
-  )}\n`;
+  const entries = input.strings.map((sourceString) => ({
+    id: sourceString.id,
+    key: sourceString.identifier,
+    text:
+      typeof sourceString.text === "string"
+        ? sourceString.text
+        : JSON.stringify(crowdinSourceTextValue(sourceString.text)),
+    type: sourceString.type,
+    context: sourceString.context,
+  }));
+
+  return buildSourceStringsPreviewContent({
+    entries,
+    truncated: input.truncated,
+    note: "Raw source file download was unavailable; this preview is generated from Crowdin source string metadata.",
+  });
 }
 
 async function downloadCrowdinSourceStringPreview(input: {
@@ -472,24 +478,25 @@ async function downloadCrowdinSourceStringPreview(input: {
   fileId: number;
 }): Promise<{
   byteSize: number | null;
-  content: { text: string } | null;
+  content: ProjectFileContent | null;
   contentType: string | null;
 } | null> {
   const strings = await input.client.listSourceStrings(input.projectId, input.fileId, undefined, {
     maxItems: maxLiveProviderStringPreviewItems + 1,
   });
-  const previewText = serializeCrowdinSourceStringsPreview({
+  const previewContent = buildCrowdinSourceStringsPreviewContent({
     strings: strings.slice(0, maxLiveProviderStringPreviewItems),
     truncated: strings.length > maxLiveProviderStringPreviewItems,
   });
-  if (!previewText) {
+  if (!previewContent) {
     return null;
   }
 
-  const byteSize = new TextEncoder().encode(previewText).byteLength;
+  const serialized = JSON.stringify(previewContent);
+  const byteSize = new TextEncoder().encode(serialized).byteLength;
   return {
     byteSize,
-    content: byteSize <= maxLiveProviderInlineTextBytes ? { text: previewText } : null,
+    content: byteSize <= maxLiveProviderInlineTextBytes ? previewContent : null,
     contentType: "application/json",
   };
 }
@@ -501,7 +508,7 @@ async function downloadLiveProviderFileContent(input: {
   sourcePath: string;
 }): Promise<{
   byteSize: number | null;
-  content: { text: string } | null;
+  content: ProjectFileContent | null;
   contentType: string | null;
 }> {
   if (input.context.providerKind !== "crowdin") {
@@ -801,7 +808,7 @@ export async function getTmsProviderLiveFileDetail(
         byteSize: downloaded.byteSize,
         sha256: null,
         metadata: file.metadata,
-        content: downloaded.content,
+        content: normalizeProjectFileContent(downloaded.content),
       },
     ],
     jobsByLocale: [],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Crowdin/TMS file previews no longer show raw JSON with a nested `strings` array. Source strings are returned as structured `content.sourceStrings` and rendered as a table with **Key**, **Text**, and **Context** columns.

Users can pick an enabled GitHub repository and run **Find in repo** on any row. That calls a new `POST .../files/string-context` endpoint, which runs the same repository subagent used by Slack to explain where a string lives in code.

## Changes

- **API**: `projectFileContent` supports optional `sourceStrings`; Crowdin fallback stores structured entries instead of legacy JSON metadata
- **API**: `POST /api/orgs/:slug/projects/:projectId/files/string-context` for per-string repository context lookup
- **UI**: Table preview, repo selector (enabled GitHub repos), dialog with agent summary
- **Parsing**: Normalizes stored JSON and legacy `strings[]` payloads into `sourceStrings`

## Testing

- `vp check --fix` (pass)
- `vp test src/lib/projects/project-file-source-strings.test.ts` (pass)
- Full `vp test` requires `DATABASE_URL` in `.env` (not available in this cloud VM session)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c65ae29d-5913-429f-accd-f9731e0804c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c65ae29d-5913-429f-accd-f9731e0804c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

