### PR TITLE
fix(crowdin): require user OAuth tokens for provider requests

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/external-tms-provider-credential/external-tms-provider-credential.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/external-tms-provider-credential/external-tms-provider-credential.route.ts
@@ -12,7 +12,6 @@ import { providerSafeFetch } from "@/lib/providers/provider-safe-fetch";
 import { db, schema } from "@/lib/database";
 import {
   decryptProviderCredential,
-  encryptProviderCredential,
   unwrapProviderCredentialCrypto,
 } from "@/lib/security/provider-credential-crypto";
 import { fetchCrowdinProjects } from "@/lib/providers/adapters/crowdin/crowdin-project-fetcher";
@@ -68,7 +67,6 @@ import {
   upsertExternalTmsProviderCredentialBodySchema,
 } from "./external-tms-provider-credential.schema";
 
-const CROWDIN_OAUTH_STATE_TTL_MS = 60 * 60 * 1000;
 const CROWDIN_USER_OAUTH_STATE_TTL_MS = 60 * 60 * 1000;
 
 const validateUpsertBody = validator("json", (value, c) => {
@@ -387,43 +385,25 @@ export function createExternalTmsProviderCredentialRoutes() {
           return c.json({ error: "forbidden" }, 403);
         }
         const payload = c.req.valid("json");
-        const organizationSlug = c.var.auth.organization.slug;
-        if (!organizationSlug) {
-          return c.json({ error: "organization_slug_missing" }, 400);
-        }
-        const nonce = randomBytes(24).toString("hex");
-        const codeVerifier = base64Url(randomBytes(48));
-        const encryptedClientSecret = unwrapProviderCredentialCrypto(
-          encryptProviderCredential(payload.oauthClientSecret),
-        );
-        const now = new Date();
-        await db.insert(schema.crowdinOAuthStates).values({
-          nonce,
-          codeVerifier,
-          oauthClientId: payload.oauthClientId,
-          oauthClientSecretEncryptionAlgorithm: encryptedClientSecret.algorithm,
-          oauthClientSecretCiphertext: encryptedClientSecret.ciphertext,
-          oauthClientSecretIv: encryptedClientSecret.iv,
-          oauthClientSecretAuthTag: encryptedClientSecret.authTag,
-          oauthClientSecretKeyVersion: encryptedClientSecret.keyVersion,
+        const providerCredential = await upsertCrowdinOAuthProviderCredential({
           organizationId: c.var.auth.organization.localOrganizationId,
           userId: c.var.auth.user.localUserId,
+          role: c.var.auth.membership.role,
           displayName: payload.displayName,
+          oauthClient: {
+            clientId: payload.oauthClientId,
+            clientSecret: payload.oauthClientSecret,
+          },
           baseUrl: payload.baseUrl ?? null,
-          expiresAt: new Date(now.getTime() + CROWDIN_OAUTH_STATE_TTL_MS),
         });
 
-        const authorizationUrl = new URL("https://accounts.crowdin.com/oauth/authorize");
-        const redirectUri = getCrowdinOAuthRedirectUri(c.req.url, organizationSlug);
-        authorizationUrl.searchParams.set("client_id", payload.oauthClientId);
-        authorizationUrl.searchParams.set("redirect_uri", redirectUri);
-        authorizationUrl.searchParams.set("response_type", "code");
-        authorizationUrl.searchParams.set("scope", getCrowdinOAuthScopeString());
-        authorizationUrl.searchParams.set("state", nonce);
-        authorizationUrl.searchParams.set("code_challenge", createCodeChallenge(codeVerifier));
-        authorizationUrl.searchParams.set("code_challenge_method", "S256");
-
-        return c.json({ authorizationUrl: authorizationUrl.toString(), redirectUri }, 200);
+        return c.json(
+          {
+            externalTmsProviderCredential: providerCredential,
+            shouldConnectCrowdinUser: true,
+          },
+          200,
+        );
       } catch (error) {
         if (error instanceof Error && error.message === "provider_base_url_invalid") {
           return c.json(
@@ -883,6 +863,7 @@ export function createExternalTmsProviderCredentialRoutes() {
           organizationId: c.var.auth.organization.localOrganizationId,
           providerKind: providerKind.data,
           fetchProjects,
+          actorUserId: c.var.auth.user.localUserId,
         });
 
         return c.json({ externalTmsProjectSync: result }, 200);

--- a/apps/hyperlocalise-web/src/api/routes/external-tms-provider-credential/external-tms-provider-credential.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/external-tms-provider-credential/external-tms-provider-credential.test.ts
@@ -1,7 +1,5 @@
 import "dotenv/config";
 
-import { createHash } from "node:crypto";
-
 import { and, eq } from "drizzle-orm";
 import { testClient } from "hono/testing";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
@@ -34,10 +32,6 @@ vi.mock("@/api/auth/workos-session", async (importOriginal) => {
 
 const client = testClient(app);
 const fixture = createProviderCredentialTestFixture(client);
-
-function base64Url(input: Buffer) {
-  return input.toString("base64").replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
-}
 
 function fetchInputUrl(input: string | URL | Request) {
   if (typeof input === "string") return input;
@@ -195,7 +189,7 @@ describe("externalTmsProviderCredentialRoutes", () => {
     });
   });
 
-  it("creates scoped Crowdin OAuth state and a PKCE authorization URL for admins", async () => {
+  it("saves Crowdin OAuth app client config for admins without creating an org token state", async () => {
     const identity = fixture.createWorkosIdentityWithRole("admin");
     const headers = await fixture.authHeadersFor(identity);
     const authContext = globalThis.__testApiAuthContext!;
@@ -216,24 +210,26 @@ describe("externalTmsProviderCredentialRoutes", () => {
 
     expect(response.status).toBe(200);
     const data = (await response.json()) as {
-      authorizationUrl: string;
-      redirectUri: string;
+      externalTmsProviderCredential: {
+        id: string;
+        authMode: string;
+        maskedSecretSuffix: string;
+        oauthExpiresAt: string | null;
+      };
+      shouldConnectCrowdinUser: boolean;
     };
-    const authorizationUrl = new URL(data.authorizationUrl);
-    expect(authorizationUrl.origin).toBe("https://accounts.crowdin.com");
-    expect(authorizationUrl.searchParams.get("client_id")).toBe("crowdin-client-id");
-    expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(data.redirectUri);
-    expect(authorizationUrl.searchParams.get("response_type")).toBe("code");
-    expect(authorizationUrl.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(data.shouldConnectCrowdinUser).toBe(true);
+    expect(data.externalTmsProviderCredential).toMatchObject({
+      authMode: "oauth",
+      maskedSecretSuffix: "oauth",
+      oauthExpiresAt: null,
+    });
 
-    const stateParam = authorizationUrl.searchParams.get("state");
-    expect(stateParam).toEqual(expect.any(String));
-    const [state] = await db
+    const states = await db
       .select()
       .from(schema.crowdinOAuthStates)
       .where(
         and(
-          eq(schema.crowdinOAuthStates.nonce, stateParam!),
           eq(
             schema.crowdinOAuthStates.organizationId,
             authContext.organization.localOrganizationId,
@@ -242,19 +238,25 @@ describe("externalTmsProviderCredentialRoutes", () => {
         ),
       )
       .limit(1);
+    expect(states).toHaveLength(0);
 
-    expect(state).toMatchObject({
-      oauthClientId: "crowdin-client-id",
+    const [credential] = await db
+      .select()
+      .from(schema.organizationExternalTmsProviderCredentials)
+      .where(
+        eq(
+          schema.organizationExternalTmsProviderCredentials.id,
+          data.externalTmsProviderCredential.id,
+        ),
+      )
+      .limit(1);
+    expect(credential).toMatchObject({
       displayName: "Crowdin OAuth",
-      consumedAt: null,
+      authMode: "oauth",
+      maskedSecretSuffix: "oauth",
+      oauthExpiresAt: null,
     });
-    expect(state!.oauthClientSecretCiphertext).not.toContain("crowdin-client-secret");
-    expect(authorizationUrl.searchParams.get("code_challenge")).toBe(
-      base64Url(createHash("sha256").update(state!.codeVerifier).digest()),
-    );
-    expect(data.redirectUri).toContain(
-      `/api/orgs/${encodeURIComponent(identity.organization.slug ?? "missing")}/external-tms-provider-credential/crowdin/oauth/callback`,
-    );
+    expect(credential!.ciphertext).not.toContain("crowdin-client-secret");
   });
 
   it("blocks non-admins from starting Crowdin OAuth", async () => {
@@ -299,10 +301,9 @@ describe("externalTmsProviderCredentialRoutes", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("exchanges Crowdin OAuth callbacks into encrypted OAuth credentials once", async () => {
+  it("does not exchange org Crowdin OAuth callbacks after client config save", async () => {
     const identity = fixture.createWorkosIdentityWithRole("admin");
     const headers = await fixture.authHeadersFor(identity);
-    const authContext = globalThis.__testApiAuthContext!;
 
     const startResponse = await client.api.orgs[":organizationSlug"][
       "external-tms-provider-credential"
@@ -317,37 +318,11 @@ describe("externalTmsProviderCredentialRoutes", () => {
       },
       { headers },
     );
-    const startBody = (await startResponse.json()) as { authorizationUrl: string };
-    const stateParam = new URL(startBody.authorizationUrl).searchParams.get("state");
-    const [state] = await db
-      .select()
-      .from(schema.crowdinOAuthStates)
-      .where(eq(schema.crowdinOAuthStates.nonce, stateParam!))
-      .limit(1);
-
-    let capturedTokenBody: Record<string, unknown> | undefined;
-    let capturedUserHeaders: HeadersInit | undefined;
+    expect(startResponse.status).toBe(200);
 
     const fetchMock = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
-      const requestUrl = fetchInputUrl(url);
-      if (requestUrl === "https://accounts.crowdin.com/oauth/token") {
-        capturedTokenBody = JSON.parse(requestBodyString(init?.body)) as Record<string, unknown>;
-        return new Response(
-          JSON.stringify({
-            access_token: "crowdin-access-token",
-            refresh_token: "crowdin-refresh-token",
-            token_type: "bearer",
-            expires_in: 3600,
-          }),
-          { status: 200 },
-        );
-      }
-
-      if (requestUrl === "https://api.crowdin.com/api/v2/user") {
-        capturedUserHeaders = init?.headers;
-        return new Response("{}", { status: 200 });
-      }
-
+      void init;
+      void url;
       return new Response("Not Found", { status: 404 });
     });
 
@@ -355,7 +330,7 @@ describe("externalTmsProviderCredentialRoutes", () => {
 
     const callbackResponse = await app.request(
       crowdinOAuthCallbackUrl(identity.organization.slug ?? "missing", {
-        state: stateParam!,
+        state: "missing-org-state",
         code: "oauth-code",
       }),
       { headers },
@@ -363,66 +338,9 @@ describe("externalTmsProviderCredentialRoutes", () => {
 
     expect(callbackResponse.status).toBe(302);
     expect(callbackResponse.headers.get("location")).toBe(
-      `/org/${identity.organization.slug}/integrations?crowdin_connected=1`,
-    );
-    expect(capturedTokenBody).toMatchObject({
-      grant_type: "authorization_code",
-      client_id: "crowdin-client-id",
-      client_secret: "crowdin-client-secret",
-      code: "oauth-code",
-      code_verifier: state!.codeVerifier,
-    });
-    expect(String(capturedTokenBody!.redirect_uri)).toContain("/crowdin/oauth/callback");
-    expect(capturedUserHeaders).toEqual({ Authorization: "Bearer crowdin-access-token" });
-
-    const [credential] = await db
-      .select()
-      .from(schema.organizationExternalTmsProviderCredentials)
-      .where(
-        and(
-          eq(
-            schema.organizationExternalTmsProviderCredentials.organizationId,
-            authContext.organization.localOrganizationId,
-          ),
-          eq(schema.organizationExternalTmsProviderCredentials.providerKind, "crowdin"),
-        ),
-      )
-      .limit(1);
-
-    expect(credential).toMatchObject({
-      displayName: "Crowdin OAuth",
-      authMode: "oauth",
-      maskedSecretSuffix: "oauth",
-      validationStatus: "connected",
-      validationMessage: null,
-    });
-    expect(credential!.ciphertext).not.toContain("crowdin-access-token");
-    expect(credential!.oauthExpiresAt).not.toBeNull();
-
-    const [consumedState] = await db
-      .select()
-      .from(schema.crowdinOAuthStates)
-      .where(eq(schema.crowdinOAuthStates.nonce, stateParam!))
-      .limit(1);
-    expect(consumedState!.consumedAt).not.toBeNull();
-
-    const replayResponse = await app.request(
-      crowdinOAuthCallbackUrl(identity.organization.slug ?? "missing", {
-        state: stateParam!,
-        code: "second-code",
-      }),
-      { headers },
-    );
-
-    expect(replayResponse.status).toBe(302);
-    expect(replayResponse.headers.get("location")).toBe(
       "/dashboard?error=invalid_crowdin_oauth_state",
     );
-    expect(
-      fetchMock.mock.calls.filter(
-        ([url]) => fetchInputUrl(url) === "https://accounts.crowdin.com/oauth/token",
-      ),
-    ).toHaveLength(1);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("lets workspace members start Crowdin user OAuth when the org integration exists", async () => {

--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
@@ -408,6 +408,7 @@ export function createJobRoutes(options: CreateJobRoutesOptions) {
             {
               mine: query.mine,
               assignee: c.var.auth.user.email,
+              actorUserId: c.var.auth.user.localUserId,
             },
           );
           return c.json({ jobs }, 200);
@@ -669,12 +670,15 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
       const organizationId = c.var.auth.organization.localOrganizationId;
 
       try {
-        const context = await tryLoadActiveTmsProviderContext(organizationId);
+        const context = await tryLoadActiveTmsProviderContext(organizationId, {
+          actorUserId: c.var.auth.user.localUserId,
+        });
         if (context) {
           const jobs = filterLiveProviderJobs(
             await listTmsProviderLiveJobs(organizationId, {
               mine: query.mine,
               assignee: c.var.auth.user.email,
+              actorUserId: c.var.auth.user.localUserId,
               context,
             }),
             {
@@ -1191,6 +1195,7 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
           projectId: job.projectId,
           providerKind: job.externalProviderKind,
           externalJobId: job.externalJobId,
+          actorUserId: c.var.auth.user.localUserId,
         });
 
         const qaReport = {

--- a/apps/hyperlocalise-web/src/api/routes/project/job.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.test.ts
@@ -374,6 +374,7 @@ describe("jobRoutes", () => {
     expect(listJobs).toHaveBeenCalledWith(organizationId, "902807", {
       mine: false,
       assignee: identity.user.email,
+      actorUserId: expect.any(String),
     });
   });
 

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -446,6 +446,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
         try {
           const projects = await listTmsProviderLiveProjects(
             c.var.auth.organization.localOrganizationId,
+            { actorUserId: c.var.auth.user.localUserId },
           );
           return c.json({ projects }, 200);
         } catch (error) {
@@ -521,6 +522,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
               c.var.auth.organization.localOrganizationId,
               target.externalProjectId,
               query.sourcePath,
+              { actorUserId: c.var.auth.user.localUserId },
             );
             if (!file) {
               return projectNotFoundResponse(c);
@@ -611,7 +613,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
           const files = await listTmsProviderLiveFilesForProject(
             c.var.auth.organization.localOrganizationId,
             target.externalProjectId,
-            { limit: query.limit },
+            { limit: query.limit, actorUserId: c.var.auth.user.localUserId },
           );
           return c.json({ files }, 200);
         } catch (error) {
@@ -768,6 +770,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
           const project = await getTmsProviderLiveProject(
             c.var.auth.organization.localOrganizationId,
             target.externalProjectId,
+            { actorUserId: c.var.auth.user.localUserId },
           );
           if (!project) {
             return projectNotFoundResponse(c);
@@ -843,6 +846,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
         projectId: project.id,
         providerKind: project.externalProviderKind,
         fetchFileKeys,
+        actorUserId: c.var.auth.user.localUserId,
       });
 
       return c.json({ externalTmsFileKeySync: result }, result.status === "failed" ? 207 : 200);
@@ -873,6 +877,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
         projectId: project.id,
         providerKind: project.externalProviderKind,
         fetchJobTasks,
+        actorUserId: c.var.auth.user.localUserId,
         automationQueues:
           options.providerAgentTranslationQueue && options.providerAgentQaQueue
             ? {
@@ -910,6 +915,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
         projectId: project.id,
         providerKind: project.externalProviderKind,
         fetchGlossaries,
+        actorUserId: c.var.auth.user.localUserId,
       });
 
       return c.json({ externalTmsGlossarySync: result }, result.status === "failed" ? 207 : 200);
@@ -941,6 +947,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
         projectId: project.id,
         providerKind: project.externalProviderKind,
         fetchTranslationMemories,
+        actorUserId: c.var.auth.user.localUserId,
       });
 
       return c.json(

--- a/apps/hyperlocalise-web/src/api/routes/project/project.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.test.ts
@@ -158,7 +158,9 @@ describe("projectRoutes", () => {
       source: "external_tms",
       externalProviderKind: "crowdin",
     });
-    expect(listProjects).toHaveBeenCalledWith(organizationId);
+    expect(listProjects).toHaveBeenCalledWith(organizationId, {
+      actorUserId: expect.any(String),
+    });
   });
 
   it("creates a project with validated input", async () => {
@@ -225,7 +227,9 @@ describe("projectRoutes", () => {
       externalProviderKind: "crowdin",
       openJobCount: 0,
     });
-    expect(getProject).toHaveBeenCalledWith(organizationId, "902807");
+    expect(getProject).toHaveBeenCalledWith(organizationId, "902807", {
+      actorUserId: expect.any(String),
+    });
   });
 
   it("returns 400 when create payload omits locales", async () => {
@@ -988,7 +992,10 @@ describe("projectRoutes", () => {
         externalProjectId: "902807",
       }),
     });
-    expect(listFiles).toHaveBeenCalledWith(organizationId, "902807", { limit: 500 });
+    expect(listFiles).toHaveBeenCalledWith(organizationId, "902807", {
+      limit: 500,
+      actorUserId: expect.any(String),
+    });
   });
 
   it("falls back to Crowdin source strings for live file detail preview", async () => {

--- a/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.test.ts
@@ -122,7 +122,9 @@ describe("tmsProviderRoutes", () => {
     expect(response.status).toBe(200);
     const body = (await response.json()) as { projects: unknown[] };
     expect(body.projects).toHaveLength(1);
-    expect(listProjects).toHaveBeenCalledWith(organizationId);
+    expect(listProjects).toHaveBeenCalledWith(organizationId, {
+      actorUserId: expect.any(String),
+    });
   });
 
   it("returns 401 when Crowdin OAuth refresh fails while loading live projects", async () => {
@@ -159,8 +161,8 @@ describe("tmsProviderRoutes", () => {
 
     expect(response.status).toBe(401);
     await expect(response.json()).resolves.toMatchObject({
-      error: "crowdin_auth_invalid",
-      message: "Crowdin credentials are invalid.",
+      error: "crowdin_user_connection_required",
+      message: "Connect your Crowdin account before using Crowdin.",
     });
   });
 
@@ -217,7 +219,10 @@ describe("tmsProviderRoutes", () => {
     expect(response.status).toBe(200);
     const body = (await response.json()) as { files: unknown[] };
     expect(body.files).toHaveLength(1);
-    expect(listFiles).toHaveBeenCalledWith(organizationId, "902807", { limit: 500 });
+    expect(listFiles).toHaveBeenCalledWith(organizationId, "902807", {
+      limit: 500,
+      actorUserId: expect.any(String),
+    });
   });
 
   it("returns 401 when the stored Crowdin OAuth token bundle is invalid", async () => {
@@ -260,8 +265,8 @@ describe("tmsProviderRoutes", () => {
 
     expect(response.status).toBe(401);
     await expect(response.json()).resolves.toMatchObject({
-      error: "crowdin_auth_invalid",
-      message: "Crowdin credentials are invalid.",
+      error: "crowdin_user_connection_required",
+      message: "Connect your Crowdin account before using Crowdin.",
     });
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.ts
@@ -148,6 +148,7 @@ export function createTmsProviderRoutes() {
       try {
         const projects = await listTmsProviderLiveProjects(
           c.var.auth.organization.localOrganizationId,
+          { actorUserId: c.var.auth.user.localUserId },
         );
         return c.json({ projects }, 200);
       } catch (error) {
@@ -163,6 +164,7 @@ export function createTmsProviderRoutes() {
         const project = await getTmsProviderLiveProject(
           c.var.auth.organization.localOrganizationId,
           c.req.param("externalProjectId"),
+          { actorUserId: c.var.auth.user.localUserId },
         );
         if (!project) {
           return c.json({ error: "project_not_found" }, 404);
@@ -190,6 +192,7 @@ export function createTmsProviderRoutes() {
           {
             mine: query.mine,
             assigneeCandidates,
+            actorUserId: c.var.auth.user.localUserId,
           },
         );
         return c.json({ jobs }, 200);
@@ -208,7 +211,7 @@ export function createTmsProviderRoutes() {
         const files = await listTmsProviderLiveFilesForProject(
           c.var.auth.organization.localOrganizationId,
           c.req.param("externalProjectId"),
-          { limit: query.limit },
+          { limit: query.limit, actorUserId: c.var.auth.user.localUserId },
         );
         return c.json({ files }, 200);
       } catch (error) {
@@ -229,6 +232,7 @@ export function createTmsProviderRoutes() {
         const jobs = await listTmsProviderLiveJobs(c.var.auth.organization.localOrganizationId, {
           mine: query.mine,
           assigneeCandidates,
+          actorUserId: c.var.auth.user.localUserId,
         });
         return c.json({ jobs }, 200);
       } catch (error) {
@@ -244,6 +248,7 @@ export function createTmsProviderRoutes() {
         const job = await getTmsProviderLiveJobDetail(
           c.var.auth.organization.localOrganizationId,
           c.req.param("encodedJobId"),
+          { actorUserId: c.var.auth.user.localUserId },
         );
         if (!job) {
           return c.json({ error: "job_not_found" }, 404);
@@ -287,7 +292,10 @@ export function createTmsProviderRoutes() {
       try {
         const glossaries = await listTmsProviderLiveGlossaries(
           c.var.auth.organization.localOrganizationId,
-          { externalProjectId: query.externalProjectId },
+          {
+            externalProjectId: query.externalProjectId,
+            actorUserId: c.var.auth.user.localUserId,
+          },
         );
         return c.json({ glossaries }, 200);
       } catch (error) {
@@ -304,7 +312,10 @@ export function createTmsProviderRoutes() {
       try {
         const translationMemories = await listTmsProviderLiveTranslationMemories(
           c.var.auth.organization.localOrganizationId,
-          { externalProjectId: query.externalProjectId },
+          {
+            externalProjectId: query.externalProjectId,
+            actorUserId: c.var.auth.user.localUserId,
+          },
         );
         return c.json({ translationMemories }, 200);
       } catch (error) {

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-page-content.tsx
@@ -484,6 +484,8 @@ function useSaveExternalTmsCredential(organizationSlug: string) {
 }
 
 function useStartCrowdinOAuth(organizationSlug: string) {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: async (payload: {
       displayName: string;
@@ -506,8 +508,24 @@ function useStartCrowdinOAuth(organizationSlug: string) {
 
       return res.json();
     },
-    onSuccess: (data) => {
-      window.location.assign(data.authorizationUrl);
+    onSuccess: async (data, payload) => {
+      if ("authorizationUrl" in data && typeof data.authorizationUrl === "string") {
+        window.location.assign(data.authorizationUrl);
+        return;
+      }
+
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ["external-tms-credentials", organizationSlug],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ["tms-provider-connection", organizationSlug],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ["crowdin-user-connection", organizationSlug],
+        }),
+      ]);
+      toast.success(`${payload.displayName} saved. Connect your Crowdin account to continue.`);
     },
     onError: (error) => {
       toast.error(error.message);
@@ -1295,8 +1313,8 @@ function TmsProviderCredentialPanel({
             ? "Saving..."
             : isCrowdin
               ? isCrowdinOAuthConnected
-                ? "Reconnect Crowdin"
-                : "Connect Crowdin"
+                ? "Update Crowdin"
+                : "Save Crowdin"
               : "Save provider"}
         </Button>
       </div>

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.tsx
@@ -7,6 +7,7 @@ import { SearchIcon, Task01Icon, WorkHistoryIcon } from "@hugeicons/core-free-ic
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useQuery } from "@tanstack/react-query";
 
+import { CrowdinUserConnectButton } from "@/components/app-shell/crowdin-user-connect-button";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -123,6 +124,25 @@ const statusFilterLabels = {
   waiting_for_review: "Waiting for review",
   cancelled: "Cancelled",
 } as const satisfies Record<(typeof statusOptions)[number], string>;
+
+async function readJobsError(response: Response, fallback: string) {
+  const body = await response.json().catch(() => null);
+
+  if (body && typeof body === "object") {
+    if ("message" in body && typeof body.message === "string") {
+      return body.message;
+    }
+    if ("error" in body && typeof body.error === "string") {
+      return body.error;
+    }
+  }
+
+  return fallback;
+}
+
+function isCrowdinUserConnectionError(error: unknown) {
+  return error instanceof Error && error.message.includes("Connect your Crowdin account");
+}
 
 const jobsFilterTriggerClassName =
   "h-9 min-h-9 w-full border-foreground/14 bg-transparent px-3 text-sm text-foreground data-[size=default]:h-9";
@@ -528,7 +548,7 @@ export function JobsPageContent({
             ...(statusFilter === "all" ? {} : { status: statusFilter }),
           },
         });
-        if (!response.ok) throw new Error(`Failed to load jobs (${response.status})`);
+        if (!response.ok) throw new Error(await readJobsError(response, "Failed to load jobs"));
         const body = (await response.json()) as { jobs: ApiJob[] };
         return body.jobs.map((job) => ({ ...job, projectName: null }));
       }
@@ -541,7 +561,7 @@ export function JobsPageContent({
           ...(statusFilter === "all" ? {} : { status: statusFilter }),
         },
       });
-      if (!response.ok) throw new Error(`Failed to load jobs (${response.status})`);
+      if (!response.ok) throw new Error(await readJobsError(response, "Failed to load jobs"));
       const body = (await response.json()) as { jobs: JobRow[] };
       return body.jobs;
     },
@@ -671,9 +691,19 @@ export function JobsPageContent({
         </JobsFilterField>
       </div>
       {jobsQuery.error ? (
-        <TypographyP className="text-sm text-flame-100">
-          {jobsQuery.error instanceof Error ? jobsQuery.error.message : "Failed to load jobs."}
-        </TypographyP>
+        <div>
+          <TypographyP className="text-sm font-medium text-flame-100">
+            {isCrowdinUserConnectionError(jobsQuery.error)
+              ? "Connect Crowdin to view provider jobs."
+              : "Jobs failed to load."}
+          </TypographyP>
+          <TypographyP className="mt-1 text-sm text-foreground/58">
+            {jobsQuery.error instanceof Error ? jobsQuery.error.message : "Failed to load jobs."}
+          </TypographyP>
+          {isCrowdinUserConnectionError(jobsQuery.error) ? (
+            <CrowdinUserConnectButton organizationSlug={organizationSlug} className="mt-4 flex" />
+          ) : null}
+        </div>
       ) : null}
       <JobsList
         emptyLabel={emptyLabel}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.tsx
@@ -28,6 +28,7 @@ import {
 } from "@/components/ui/sheet";
 import { Skeleton } from "@/components/ui/skeleton";
 import { apiClient } from "@/lib/api-client-instance";
+import { isApiResponseErrorCode, readApiResponseError } from "@/lib/api-error";
 import { cn } from "@/lib/primitives/cn";
 
 import { JobDetailRow, ProviderCrowdinJobDetailRows } from "./provider-crowdin-job-detail-rows";
@@ -125,23 +126,8 @@ const statusFilterLabels = {
   cancelled: "Cancelled",
 } as const satisfies Record<(typeof statusOptions)[number], string>;
 
-async function readJobsError(response: Response, fallback: string) {
-  const body = await response.json().catch(() => null);
-
-  if (body && typeof body === "object") {
-    if ("message" in body && typeof body.message === "string") {
-      return body.message;
-    }
-    if ("error" in body && typeof body.error === "string") {
-      return body.error;
-    }
-  }
-
-  return fallback;
-}
-
 function isCrowdinUserConnectionError(error: unknown) {
-  return error instanceof Error && error.message.includes("Connect your Crowdin account");
+  return isApiResponseErrorCode(error, "crowdin_user_connection_required");
 }
 
 const jobsFilterTriggerClassName =
@@ -548,7 +534,7 @@ export function JobsPageContent({
             ...(statusFilter === "all" ? {} : { status: statusFilter }),
           },
         });
-        if (!response.ok) throw new Error(await readJobsError(response, "Failed to load jobs"));
+        if (!response.ok) throw await readApiResponseError(response, "Failed to load jobs");
         const body = (await response.json()) as { jobs: ApiJob[] };
         return body.jobs.map((job) => ({ ...job, projectName: null }));
       }
@@ -561,7 +547,7 @@ export function JobsPageContent({
           ...(statusFilter === "all" ? {} : { status: statusFilter }),
         },
       });
-      if (!response.ok) throw new Error(await readJobsError(response, "Failed to load jobs"));
+      if (!response.ok) throw await readApiResponseError(response, "Failed to load jobs");
       const body = (await response.json()) as { jobs: JobRow[] };
       return body.jobs;
     },

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
@@ -10,6 +10,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
 import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
+import { CrowdinUserConnectButton } from "@/components/app-shell/crowdin-user-connect-button";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { TypographyP } from "@/components/ui/typography";
@@ -52,6 +53,10 @@ async function readActionError(response: Response, fallback: string) {
   }
 
   return fallback;
+}
+
+function isCrowdinUserConnectionError(error: unknown) {
+  return error instanceof Error && error.message.includes("Connect your Crowdin account");
 }
 
 function formatBytes(bytes: number | null) {
@@ -390,11 +395,24 @@ export function ProjectFilesPageContent({
             {filesQuery.isLoading ? (
               <TypographyP className="p-4 text-sm text-foreground/52">Loading files…</TypographyP>
             ) : filesQuery.isError ? (
-              <TypographyP className="p-4 text-sm text-flame-100">
-                {filesQuery.error instanceof Error
-                  ? filesQuery.error.message
-                  : "Failed to load files."}
-              </TypographyP>
+              <div className="p-4">
+                <TypographyP className="text-sm font-medium text-flame-100">
+                  {isCrowdinUserConnectionError(filesQuery.error)
+                    ? "Connect Crowdin to view provider files."
+                    : "Files failed to load."}
+                </TypographyP>
+                <TypographyP className="mt-1 text-sm text-foreground/58">
+                  {filesQuery.error instanceof Error
+                    ? filesQuery.error.message
+                    : "Failed to load files."}
+                </TypographyP>
+                {isCrowdinUserConnectionError(filesQuery.error) ? (
+                  <CrowdinUserConnectButton
+                    organizationSlug={organizationSlug}
+                    className="mt-4 flex"
+                  />
+                ) : null}
+              </div>
             ) : files.length === 0 ? (
               <div className="flex flex-col gap-2 p-4">
                 <TypographyP className="text-sm font-medium text-foreground">

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
@@ -14,6 +14,7 @@ import { CrowdinUserConnectButton } from "@/components/app-shell/crowdin-user-co
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { TypographyP } from "@/components/ui/typography";
+import { isApiResponseErrorCode, readApiResponseError } from "@/lib/api-error";
 import { parseProviderProjectId } from "@/lib/providers/tms-provider-resource-id";
 
 import {
@@ -40,23 +41,8 @@ function apiPath(organizationSlug: string, projectId: string) {
   return `/api/orgs/${encodeURIComponent(organizationSlug)}/projects/${encodeURIComponent(projectId)}/files`;
 }
 
-async function readActionError(response: Response, fallback: string) {
-  const body = await response.json().catch(() => null);
-
-  if (body && typeof body === "object") {
-    if ("message" in body && typeof body.message === "string") {
-      return body.message;
-    }
-    if ("error" in body && typeof body.error === "string") {
-      return body.error;
-    }
-  }
-
-  return fallback;
-}
-
 function isCrowdinUserConnectionError(error: unknown) {
-  return error instanceof Error && error.message.includes("Connect your Crowdin account");
+  return isApiResponseErrorCode(error, "crowdin_user_connection_required");
 }
 
 function formatBytes(bytes: number | null) {
@@ -228,7 +214,7 @@ export function ProjectFilesPageContent({
       });
 
       if (!response.ok) {
-        throw new Error(await readActionError(response, "Failed to load project files"));
+        throw await readApiResponseError(response, "Failed to load project files");
       }
 
       const body = (await response.json()) as { files: ProjectFileRecord[] };
@@ -249,9 +235,7 @@ export function ProjectFilesPageContent({
         });
 
         if (!response.ok) {
-          throw new Error(
-            await readActionError(response, `Failed to upload ${sourcePathForFile(file)}`),
-          );
+          throw await readApiResponseError(response, `Failed to upload ${sourcePathForFile(file)}`);
         }
       }
     },

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
@@ -17,6 +17,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { apiClient } from "@/lib/api-client-instance";
+import { readApiResponseError } from "@/lib/api-error";
 
 import {
   PROJECT_SOURCE_FILTERS,
@@ -61,21 +62,6 @@ const statusFilterLabels = {
   active: "Active",
   inactive: "Inactive",
 } as const;
-
-async function readProjectError(response: Response, fallback: string) {
-  const body = await response.json().catch(() => null);
-
-  if (body && typeof body === "object") {
-    if ("message" in body && typeof body.message === "string") {
-      return body.message;
-    }
-    if ("error" in body && typeof body.error === "string") {
-      return body.error;
-    }
-  }
-
-  return fallback;
-}
 
 function useProjectFilters(projects: ProjectListRow[], searchParams: URLSearchParams) {
   const [searchQuery, setSearchQuery] = useState("");
@@ -147,7 +133,7 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
       });
 
       if (!response.ok) {
-        throw new Error(await readProjectError(response, "Failed to load projects"));
+        throw await readApiResponseError(response, "Failed to load projects");
       }
 
       const body = await response.json();
@@ -162,7 +148,7 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
       });
 
       if (!response.ok) {
-        throw new Error(await readProjectError(response, "Unable to create project"));
+        throw await readApiResponseError(response, "Unable to create project");
       }
 
       return response.json();
@@ -187,7 +173,7 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
       });
 
       if (!response.ok) {
-        throw new Error(await readProjectError(response, "Unable to update project"));
+        throw await readApiResponseError(response, "Unable to update project");
       }
 
       return response.json();
@@ -211,7 +197,7 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
       );
 
       if (!response.ok) {
-        throw new Error(await readProjectError(response, "Unable to delete project"));
+        throw await readApiResponseError(response, "Unable to delete project");
       }
     },
     onSuccess: async () => {

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
@@ -65,8 +65,13 @@ const statusFilterLabels = {
 async function readProjectError(response: Response, fallback: string) {
   const body = await response.json().catch(() => null);
 
-  if (body && typeof body === "object" && "error" in body) {
-    return String(body.error);
+  if (body && typeof body === "object") {
+    if ("message" in body && typeof body.message === "string") {
+      return body.message;
+    }
+    if ("error" in body && typeof body.error === "string") {
+      return body.error;
+    }
   }
 
   return fallback;
@@ -142,7 +147,7 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
       });
 
       if (!response.ok) {
-        throw new Error(`Failed to load projects (${response.status})`);
+        throw new Error(await readProjectError(response, "Failed to load projects"));
       }
 
       const body = await response.json();

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.tsx
@@ -14,6 +14,7 @@ import { CrowdinUserConnectButton } from "@/components/app-shell/crowdin-user-co
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { isApiResponseErrorCode } from "@/lib/api-error";
 
 import type { ProjectListRow } from "./project-list";
 import { TypographyH3, TypographyP } from "@/components/ui/typography";
@@ -116,7 +117,7 @@ function SyncInfo({ project }: { project: ProjectListRow }) {
 }
 
 function isCrowdinUserConnectionError(error: unknown) {
-  return error instanceof Error && error.message.includes("Connect your Crowdin account");
+  return isApiResponseErrorCode(error, "crowdin_user_connection_required");
 }
 
 export function ProjectsTable({

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.tsx
@@ -10,6 +10,7 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { UseQueryResult } from "@tanstack/react-query";
 
+import { CrowdinUserConnectButton } from "@/components/app-shell/crowdin-user-connect-button";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -114,6 +115,10 @@ function SyncInfo({ project }: { project: ProjectListRow }) {
   return <span className="text-xs text-foreground/42">Not synced yet</span>;
 }
 
+function isCrowdinUserConnectionError(error: unknown) {
+  return error instanceof Error && error.message.includes("Connect your Crowdin account");
+}
+
 export function ProjectsTable({
   projects,
   projectsQuery,
@@ -141,13 +146,18 @@ export function ProjectsTable({
       {projectsQuery.isError ? (
         <div className="border-t border-foreground/8 px-1 py-8">
           <TypographyP className="text-sm font-medium text-flame-100">
-            Projects failed to load.
+            {isCrowdinUserConnectionError(projectsQuery.error)
+              ? "Connect Crowdin to view provider projects."
+              : "Projects failed to load."}
           </TypographyP>
           <TypographyP className="mt-1 text-xs text-foreground/42">
             {projectsQuery.error instanceof Error
               ? projectsQuery.error.message
               : "Refresh the page to try again."}
           </TypographyP>
+          {isCrowdinUserConnectionError(projectsQuery.error) ? (
+            <CrowdinUserConnectButton organizationSlug={organizationSlug} className="mt-4 flex" />
+          ) : null}
         </div>
       ) : null}
       {projectsQuery.isSuccess && projects.length === 0 ? (

--- a/apps/hyperlocalise-web/src/components/app-shell/crowdin-user-connect-button.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/crowdin-user-connect-button.tsx
@@ -7,8 +7,15 @@ import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import { apiClient } from "@/lib/api-client-instance";
+import { cn } from "@/lib/primitives/cn";
 
-export function CrowdinUserConnectButton({ organizationSlug }: { organizationSlug: string }) {
+export function CrowdinUserConnectButton({
+  organizationSlug,
+  className,
+}: {
+  organizationSlug: string;
+  className?: string;
+}) {
   const [isPending, setIsPending] = useState(false);
 
   async function handleConnect() {
@@ -45,7 +52,7 @@ export function CrowdinUserConnectButton({ organizationSlug }: { organizationSlu
       type="button"
       size="sm"
       variant="outline"
-      className="hidden sm:inline-flex"
+      className={cn("hidden sm:inline-flex", className)}
       disabled={isPending}
       onClick={handleConnect}
     >

--- a/apps/hyperlocalise-web/src/lib/api-error.test.ts
+++ b/apps/hyperlocalise-web/src/lib/api-error.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  ApiResponseError,
+  isApiResponseErrorCode,
+  readApiError,
+  readApiResponseError,
+} from "./api-error";
+
+describe("api error helpers", () => {
+  it("preserves the machine-readable error code separately from the display message", async () => {
+    const error = await readApiResponseError(
+      new Response(
+        JSON.stringify({
+          error: "crowdin_user_connection_required",
+          message: "Sign in to Crowdin before continuing.",
+        }),
+        { status: 403 },
+      ),
+      "Failed to load projects",
+    );
+
+    expect(error).toBeInstanceOf(ApiResponseError);
+    expect(error.message).toBe("Sign in to Crowdin before continuing.");
+    expect(error.code).toBe("crowdin_user_connection_required");
+    expect(error.status).toBe(403);
+    expect(isApiResponseErrorCode(error, "crowdin_user_connection_required")).toBe(true);
+  });
+
+  it("keeps the legacy string helper returning the display message", async () => {
+    await expect(
+      readApiError(
+        new Response(
+          JSON.stringify({
+            error: "project_not_found",
+            message: "Project not found.",
+          }),
+          { status: 404 },
+        ),
+        "Failed to load project",
+      ),
+    ).resolves.toBe("Project not found.");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/api-error.ts
+++ b/apps/hyperlocalise-web/src/lib/api-error.ts
@@ -1,12 +1,53 @@
-export function readApiError(response: Response, fallback: string) {
-  return response
-    .json()
-    .then((body) =>
-      body && typeof body === "object" && "message" in body
-        ? String(body.message)
-        : body && typeof body === "object" && "error" in body
-          ? String(body.error)
-          : fallback,
-    )
-    .catch(() => fallback);
+type ApiErrorResponseBody = {
+  error?: unknown;
+  message?: unknown;
+};
+
+export class ApiResponseError extends Error {
+  readonly code: string | null;
+  readonly status: number;
+
+  constructor(message: string, options: { code: string | null; status: number }) {
+    super(message);
+    this.name = "ApiResponseError";
+    this.code = options.code;
+    this.status = options.status;
+  }
+}
+
+function readApiErrorBody(body: unknown, fallback: string) {
+  if (!body || typeof body !== "object") {
+    return { code: null, message: fallback };
+  }
+
+  const { error, message } = body as ApiErrorResponseBody;
+  const code = typeof error === "string" ? error : null;
+
+  if (typeof message === "string") {
+    return { code, message };
+  }
+
+  if (code) {
+    return { code, message: code };
+  }
+
+  return { code: null, message: fallback };
+}
+
+export async function readApiResponseError(response: Response, fallback: string) {
+  const body = await response.json().catch(() => null);
+  const { code, message } = readApiErrorBody(body, fallback);
+
+  return new ApiResponseError(message, {
+    code,
+    status: response.status,
+  });
+}
+
+export async function readApiError(response: Response, fallback: string) {
+  return (await readApiResponseError(response, fallback)).message;
+}
+
+export function isApiResponseErrorCode(error: unknown, code: string) {
+  return error instanceof ApiResponseError && error.code === code;
 }

--- a/apps/hyperlocalise-web/src/lib/database/schema/providers.ts
+++ b/apps/hyperlocalise-web/src/lib/database/schema/providers.ts
@@ -84,6 +84,10 @@ export const organizationExternalTmsProviderCredentials = pgTable(
     }),
     providerKind: externalTmsProviderKindEnum("provider_kind").notNull(),
     displayName: text("display_name").notNull(),
+    /**
+     * @deprecated For Crowdin, `api_token` is legacy personal-token auth. Use
+     * `oauth` plus a row in `crowdin_user_connections` for the active user.
+     */
     authMode: text("auth_mode").notNull().default("api_token"),
     region: text("region"),
     baseUrl: text("base_url"),

--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-comment.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-comment.ts
@@ -17,6 +17,11 @@ import type {
 import { buildFindingId } from "../provider-job-qa/build-finding-id";
 import type { ProviderQaFinding } from "../provider-job-qa/types";
 import {
+  getCrowdinUserConnection,
+  resolveCrowdinUserConnectionSecretMaterial,
+} from "../adapters/crowdin/crowdin-user-connections";
+import {
+  CROWDIN_OAUTH_AUTH_MODE,
   resolveExternalTmsSecretMaterial,
   type ExternalTmsProviderKind,
 } from "../organization-external-tms-provider-credentials";
@@ -368,7 +373,11 @@ export async function executeProviderAgentComment(input: {
   }));
 
   try {
-    const secretMaterial = await resolveExternalTmsSecretMaterial({ credential });
+    const secretMaterial = await resolveProviderCommentSecretMaterial({
+      credential,
+      organizationId: input.organizationId,
+      actorUserId: run.actorUserId,
+    });
 
     const pushResult = await pushComments({
       organizationId: input.organizationId,
@@ -421,4 +430,31 @@ export async function executeProviderAgentComment(input: {
       message,
     };
   }
+}
+
+async function resolveProviderCommentSecretMaterial(input: {
+  credential: typeof schema.organizationExternalTmsProviderCredentials.$inferSelect;
+  organizationId: string;
+  actorUserId?: string | null;
+}) {
+  if (
+    input.credential.providerKind !== "crowdin" ||
+    input.credential.authMode !== CROWDIN_OAUTH_AUTH_MODE
+  ) {
+    return resolveExternalTmsSecretMaterial({ credential: input.credential });
+  }
+
+  if (!input.actorUserId) {
+    throw new Error("crowdin_user_connection_required");
+  }
+
+  const connection = await getCrowdinUserConnection({
+    organizationId: input.organizationId,
+    userId: input.actorUserId,
+  });
+  if (!connection) {
+    throw new Error("crowdin_user_connection_required");
+  }
+
+  return resolveCrowdinUserConnectionSecretMaterial({ connection });
 }

--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-qa.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-qa.ts
@@ -130,6 +130,7 @@ export async function runProviderJobQaForJob(input: {
   projectId: string;
   providerKind: ExternalTmsProviderKind;
   externalJobId: string;
+  actorUserId?: string | null;
 }) {
   const pullContent = getProviderContentPuller(input.providerKind);
   if (!pullContent) {
@@ -142,6 +143,7 @@ export async function runProviderJobQaForJob(input: {
     providerKind: input.providerKind,
     externalJobId: input.externalJobId,
     pullContent,
+    actorUserId: input.actorUserId,
   });
 
   const qaResult = await executeProviderJobQaForContent({
@@ -323,6 +325,7 @@ export async function prepareProviderAgentQaRun(input: {
       providerKind: run.providerKind,
       externalJobId: run.externalJobId,
       pullContent,
+      actorUserId: run.actorUserId,
     });
 
     return {
@@ -365,6 +368,7 @@ export async function completeProviderAgentQaRun(input: {
   hlResult: RunHlCheckResult;
   syncProviderReview?: boolean;
   hyperlocaliseJobId?: string | null;
+  actorUserId?: string | null;
 }): Promise<ProviderAgentQaResult> {
   const glossaryTerms = await loadProjectGlossaryTerms(input.projectId);
   const [translationMemoryUsage, glossaryUsage] = await Promise.all([
@@ -424,6 +428,7 @@ export async function completeProviderAgentQaRun(input: {
           externalJobId: input.externalJobId,
           content: input.content,
           previousReport,
+          actorUserId: input.actorUserId,
         })) ?? buildProviderReviewReport([]);
     } catch (error) {
       const message =
@@ -502,5 +507,6 @@ export async function executeProviderAgentQa(input: {
     hlResult,
     syncProviderReview: readInputSnapshotAction(run?.inputSnapshot ?? {}) === "review_with_agent",
     hyperlocaliseJobId: run?.hyperlocaliseJobId ?? null,
+    actorUserId: run?.actorUserId ?? null,
   });
 }

--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-translate.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-translate.ts
@@ -437,6 +437,7 @@ export async function executeProviderAgentTranslation(input: {
       providerKind: run.providerKind,
       externalJobId: run.externalJobId,
       pullContent,
+      actorUserId: run.actorUserId,
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : "Provider content pull failed";

--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-writeback.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-writeback.ts
@@ -425,6 +425,7 @@ export async function executeProviderAgentWriteback(input: {
       externalJobId: run.externalJobId,
       translations,
       pushTranslations,
+      actorUserId: run.actorUserId,
     });
 
     const changedItems = buildWritebackChangedItems({

--- a/apps/hyperlocalise-web/src/lib/providers/organization-external-tms-provider-credentials.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/organization-external-tms-provider-credentials.test.ts
@@ -83,7 +83,7 @@ describe("organization external TMS provider credentials", () => {
   });
 
   describe("resolveExternalTmsSecretMaterial", () => {
-    it("returns fresh Crowdin OAuth access tokens without refreshing", async () => {
+    it("requires a user connection for Crowdin OAuth access tokens", async () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
 
@@ -108,11 +108,11 @@ describe("organization external TMS provider credentials", () => {
 
       await expect(
         resolveExternalTmsSecretMaterial({ credential, fetchFn: fetchMock }),
-      ).resolves.toBe("fresh-access-token");
+      ).rejects.toThrow("crowdin_user_connection_required");
       expect(fetchMock).not.toHaveBeenCalled();
     });
 
-    it("refreshes expired Crowdin OAuth access tokens and persists the replacement", async () => {
+    it("does not refresh deprecated org Crowdin OAuth token bundles", async () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
 
@@ -147,37 +147,15 @@ describe("organization external TMS provider credentials", () => {
 
       await expect(
         resolveExternalTmsSecretMaterial({ credential, fetchFn: fetchMock }),
-      ).resolves.toBe("new-access-token");
-      expect(fetchMock).toHaveBeenCalledWith(
-        "https://accounts.crowdin.com/oauth/token",
-        expect.objectContaining({
-          method: "POST",
-          body: JSON.stringify({
-            grant_type: "refresh_token",
-            client_id: "client-id",
-            client_secret: "client-secret",
-            refresh_token: "old-refresh-token",
-          }),
-        }),
-      );
+      ).rejects.toThrow("crowdin_user_connection_required");
+      expect(fetchMock).not.toHaveBeenCalled();
 
       const [updatedCredential] = await db
         .select()
         .from(schema.organizationExternalTmsProviderCredentials)
         .where(eq(schema.organizationExternalTmsProviderCredentials.id, credential.id))
         .limit(1);
-      const secondFetchMock = vi.fn(async () => {
-        throw new Error("should not refresh a fresh persisted token");
-      });
-
-      await expect(
-        resolveExternalTmsSecretMaterial({
-          credential: updatedCredential!,
-          fetchFn: secondFetchMock,
-        }),
-      ).resolves.toBe("new-access-token");
-      expect(secondFetchMock).not.toHaveBeenCalled();
-      expect(updatedCredential!.oauthExpiresAt?.toISOString()).toBe("2026-01-01T02:00:00.000Z");
+      expect(updatedCredential!.oauthExpiresAt).toBeNull();
     });
   });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/organization-external-tms-provider-credentials.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/organization-external-tms-provider-credentials.ts
@@ -48,6 +48,13 @@ const crowdinOAuthTokenBundleSchema = z.object({
 
 export type CrowdinOAuthTokenBundle = z.infer<typeof crowdinOAuthTokenBundleSchema>;
 
+const crowdinOAuthClientMaterialSchema = z.object({
+  clientId: z.string().min(1),
+  clientSecret: z.string().min(1),
+});
+
+export type CrowdinOAuthClientMaterial = z.infer<typeof crowdinOAuthClientMaterialSchema>;
+
 export function assertExternalTmsCredentialAdmin(role: OrganizationMembershipRole) {
   assertCapability(role, "provider_credentials:write");
 }
@@ -332,13 +339,22 @@ export async function upsertCrowdinOAuthProviderCredential(input: {
   userId: string;
   role: OrganizationMembershipRole;
   displayName: string;
-  tokenBundle: CrowdinOAuthTokenBundle;
+  oauthClient?: CrowdinOAuthClientMaterial;
+  tokenBundle?: CrowdinOAuthTokenBundle;
   baseUrl?: string | null;
 }) {
   assertExternalTmsCredentialAdmin(input.role);
 
   const now = new Date();
-  const secretMaterial = JSON.stringify(input.tokenBundle);
+  const oauthClient = input.oauthClient ?? input.tokenBundle;
+  if (!oauthClient) {
+    throw new Error("crowdin_oauth_client_required");
+  }
+
+  const secretMaterial = JSON.stringify({
+    clientId: oauthClient.clientId,
+    clientSecret: oauthClient.clientSecret,
+  });
   const encrypted = unwrapProviderCredentialCrypto(encryptProviderCredential(secretMaterial));
   const baseUrl = await normalizeExternalTmsCredentialBaseUrl({
     providerKind: "crowdin",
@@ -370,7 +386,7 @@ export async function upsertCrowdinOAuthProviderCredential(input: {
         authMode: CROWDIN_OAUTH_AUTH_MODE,
         region: null,
         baseUrl,
-        oauthExpiresAt: new Date(input.tokenBundle.expiresAt),
+        oauthExpiresAt: null,
         validationStatus: "unvalidated",
         encryptionAlgorithm: encrypted.algorithm,
         ciphertext: encrypted.ciphertext,
@@ -390,7 +406,7 @@ export async function upsertCrowdinOAuthProviderCredential(input: {
           authMode: CROWDIN_OAUTH_AUTH_MODE,
           region: null,
           baseUrl,
-          oauthExpiresAt: new Date(input.tokenBundle.expiresAt),
+          oauthExpiresAt: null,
           validationStatus: "unvalidated",
           validationMessage: null,
           lastValidatedAt: null,
@@ -436,6 +452,35 @@ export function decryptCrowdinOAuthTokenBundle(
   return parsed.data;
 }
 
+function decryptCrowdinOAuthClientMaterial(
+  credential: CredentialCryptoFields,
+): CrowdinOAuthClientMaterial {
+  const secretMaterial = unwrapProviderCredentialCrypto(
+    decryptProviderCredential({
+      algorithm: credential.encryptionAlgorithm,
+      keyVersion: credential.keyVersion,
+      ciphertext: credential.ciphertext,
+      iv: credential.iv,
+      authTag: credential.authTag,
+    }),
+  );
+  const raw = safeJsonParse(secretMaterial);
+  const clientMaterial = crowdinOAuthClientMaterialSchema.safeParse(raw);
+  if (clientMaterial.success) {
+    return clientMaterial.data;
+  }
+
+  const tokenBundle = crowdinOAuthTokenBundleSchema.safeParse(raw);
+  if (tokenBundle.success) {
+    return {
+      clientId: tokenBundle.data.clientId,
+      clientSecret: tokenBundle.data.clientSecret,
+    };
+  }
+
+  throw new Error("crowdin_oauth_client_invalid");
+}
+
 export function isCrowdinOAuthAccessTokenFresh(tokenBundle: CrowdinOAuthTokenBundle) {
   return (
     new Date(tokenBundle.expiresAt).getTime() - Date.now() > CROWDIN_OAUTH_TOKEN_REFRESH_BUFFER_MS
@@ -463,6 +508,13 @@ export async function resolveExternalTmsSecretMaterial(input: {
     return secretMaterial;
   }
 
+  throw new Error("crowdin_user_connection_required");
+}
+
+export async function resolveDeprecatedCrowdinOAuthSecretMaterial(input: {
+  credential: ExternalTmsCredential;
+  fetchFn?: typeof fetch;
+}) {
   const tokenBundle = decryptCrowdinOAuthTokenBundle(input.credential);
   if (isCrowdinOAuthAccessTokenFresh(tokenBundle)) {
     return tokenBundle.accessToken;
@@ -548,11 +600,7 @@ export function getCrowdinOAuthClientFromCredential(credential: ExternalTmsCrede
     throw new Error("crowdin_oauth_credential_required");
   }
 
-  const tokenBundle = decryptCrowdinOAuthTokenBundle(credential);
-  return {
-    clientId: tokenBundle.clientId,
-    clientSecret: tokenBundle.clientSecret,
-  };
+  return decryptCrowdinOAuthClientMaterial(credential);
 }
 
 export function mapCrowdinOAuthTokenResponse(

--- a/apps/hyperlocalise-web/src/lib/providers/sync/external-tms-content-sync.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/sync/external-tms-content-sync.ts
@@ -3,6 +3,11 @@ import { and, eq } from "drizzle-orm";
 import { db, schema } from "@/lib/database";
 import type { ProviderSyncRunStatus } from "@/lib/database/types";
 import {
+  getCrowdinUserConnection,
+  resolveCrowdinUserConnectionSecretMaterial,
+} from "../adapters/crowdin/crowdin-user-connections";
+import {
+  CROWDIN_OAUTH_AUTH_MODE,
   resolveExternalTmsSecretMaterial,
   type ExternalTmsCredential,
   type ExternalTmsProviderKind,
@@ -125,6 +130,7 @@ export async function pullExternalTmsTaskContent(input: {
   providerKind: ExternalTmsProviderKind;
   externalJobId: string;
   pullContent: ExternalTmsContentPuller;
+  actorUserId?: string | null;
 }): Promise<ExternalTmsContentPullResult> {
   const project = await getExternalTmsProject(input);
 
@@ -156,7 +162,11 @@ export async function pullExternalTmsTaskContent(input: {
   });
 
   try {
-    const secretMaterial = await resolveExternalTmsSecretMaterial({ credential });
+    const secretMaterial = await resolveExternalTmsSecretMaterialForActor({
+      credential,
+      organizationId: input.organizationId,
+      actorUserId: input.actorUserId,
+    });
 
     const content = await input.pullContent({
       organizationId: input.organizationId,
@@ -228,6 +238,7 @@ export async function pushExternalTmsTranslations(input: {
   externalJobId: string;
   translations: ExternalTmsApprovedTranslationUpload[];
   pushTranslations: ExternalTmsTranslationPusher;
+  actorUserId?: string | null;
 }): Promise<ExternalTmsTranslationPushResult> {
   const project = await getExternalTmsProject(input);
 
@@ -264,7 +275,11 @@ export async function pushExternalTmsTranslations(input: {
   const failures: ExternalTmsContentSyncFailure[] = [];
 
   try {
-    const secretMaterial = await resolveExternalTmsSecretMaterial({ credential });
+    const secretMaterial = await resolveExternalTmsSecretMaterialForActor({
+      credential,
+      organizationId: input.organizationId,
+      actorUserId: input.actorUserId,
+    });
 
     const pushResult = await input.pushTranslations({
       organizationId: input.organizationId,
@@ -343,6 +358,33 @@ export async function pushExternalTmsTranslations(input: {
     });
     throw error;
   }
+}
+
+export async function resolveExternalTmsSecretMaterialForActor(input: {
+  credential: ExternalTmsCredential;
+  organizationId: string;
+  actorUserId?: string | null;
+}) {
+  if (
+    input.credential.providerKind !== "crowdin" ||
+    input.credential.authMode !== CROWDIN_OAUTH_AUTH_MODE
+  ) {
+    return resolveExternalTmsSecretMaterial({ credential: input.credential });
+  }
+
+  if (!input.actorUserId) {
+    throw new Error("crowdin_user_connection_required");
+  }
+
+  const connection = await getCrowdinUserConnection({
+    organizationId: input.organizationId,
+    userId: input.actorUserId,
+  });
+  if (!connection) {
+    throw new Error("crowdin_user_connection_required");
+  }
+
+  return resolveCrowdinUserConnectionSecretMaterial({ connection });
 }
 
 async function getExternalTmsProject(input: {

--- a/apps/hyperlocalise-web/src/lib/providers/sync/external-tms-file-sync.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/sync/external-tms-file-sync.ts
@@ -3,10 +3,10 @@ import { and, eq } from "drizzle-orm";
 import { db, schema } from "@/lib/database";
 import type { ProviderSyncRunStatus } from "@/lib/database/types";
 import {
-  resolveExternalTmsSecretMaterial,
   type ExternalTmsCredential,
   type ExternalTmsProviderKind,
 } from "../organization-external-tms-provider-credentials";
+import { resolveExternalTmsSecretMaterialForActor } from "./external-tms-content-sync";
 import { upsertExternalTmsFile } from "./organization-external-tms-files";
 import {
   completeProviderSyncRun,
@@ -68,6 +68,7 @@ export async function syncExternalTmsFileKeys(input: {
   projectId: string;
   providerKind: ExternalTmsProviderKind;
   fetchFileKeys: ExternalTmsFileKeyFetcher;
+  actorUserId?: string | null;
 }): Promise<ExternalTmsFileKeySyncResult> {
   const project = await getExternalTmsProject(input);
 
@@ -104,7 +105,11 @@ export async function syncExternalTmsFileKeys(input: {
   const failures: ExternalTmsFileKeySyncFailure[] = [];
 
   try {
-    const secretMaterial = await resolveExternalTmsSecretMaterial({ credential });
+    const secretMaterial = await resolveExternalTmsSecretMaterialForActor({
+      credential,
+      organizationId: input.organizationId,
+      actorUserId: input.actorUserId,
+    });
     const fileKeys = await input.fetchFileKeys({
       organizationId: input.organizationId,
       projectId: project.id,

--- a/apps/hyperlocalise-web/src/lib/providers/sync/external-tms-glossary-sync.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/sync/external-tms-glossary-sync.ts
@@ -8,10 +8,10 @@ import {
   type ExternalTmsTerminologyResourceType,
 } from "./organization-external-tms-glossaries";
 import {
-  resolveExternalTmsSecretMaterial,
   type ExternalTmsCredential,
   type ExternalTmsProviderKind,
 } from "../organization-external-tms-provider-credentials";
+import { resolveExternalTmsSecretMaterialForActor } from "./external-tms-content-sync";
 import {
   completeProviderSyncRun,
   failProviderSyncRun,
@@ -84,6 +84,7 @@ export async function syncExternalTmsGlossaries(input: {
   projectId: string;
   providerKind: ExternalTmsProviderKind;
   fetchGlossaries: ExternalTmsGlossaryFetcher;
+  actorUserId?: string | null;
 }): Promise<ExternalTmsGlossarySyncResult> {
   const project = await getExternalTmsProject(input);
 
@@ -121,7 +122,11 @@ export async function syncExternalTmsGlossaries(input: {
   const failures: ExternalTmsGlossarySyncFailure[] = [];
 
   try {
-    const secretMaterial = await resolveExternalTmsSecretMaterial({ credential });
+    const secretMaterial = await resolveExternalTmsSecretMaterialForActor({
+      credential,
+      organizationId: input.organizationId,
+      actorUserId: input.actorUserId,
+    });
 
     const glossaries = await input.fetchGlossaries({
       organizationId: input.organizationId,

--- a/apps/hyperlocalise-web/src/lib/providers/sync/external-tms-job-sync.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/sync/external-tms-job-sync.ts
@@ -3,10 +3,10 @@ import { and, eq, inArray } from "drizzle-orm";
 import { db, schema } from "@/lib/database";
 import type { JobKind, ProviderSyncRunStatus } from "@/lib/database/types";
 import {
-  resolveExternalTmsSecretMaterial,
   type ExternalTmsCredential,
   type ExternalTmsProviderKind,
 } from "../organization-external-tms-provider-credentials";
+import { resolveExternalTmsSecretMaterialForActor } from "./external-tms-content-sync";
 import { upsertExternalJob } from "./organization-external-tms-jobs";
 import {
   completeProviderSyncRun,
@@ -72,6 +72,7 @@ export async function syncExternalTmsJobTasks(input: {
   providerKind: ExternalTmsProviderKind;
   fetchJobTasks: ExternalTmsJobTaskFetcher;
   automationQueues?: TmsAgentAutomationQueues;
+  actorUserId?: string | null;
 }): Promise<ExternalTmsJobTaskSyncResult> {
   const project = await getExternalTmsProject(input);
 
@@ -109,7 +110,11 @@ export async function syncExternalTmsJobTasks(input: {
   const failures: ExternalTmsJobTaskSyncFailure[] = [];
 
   try {
-    const secretMaterial = await resolveExternalTmsSecretMaterial({ credential });
+    const secretMaterial = await resolveExternalTmsSecretMaterialForActor({
+      credential,
+      organizationId: input.organizationId,
+      actorUserId: input.actorUserId,
+    });
     const jobTasks = await input.fetchJobTasks({
       organizationId: input.organizationId,
       projectId: project.id,

--- a/apps/hyperlocalise-web/src/lib/providers/sync/external-tms-project-sync.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/sync/external-tms-project-sync.ts
@@ -3,10 +3,10 @@ import { and, eq } from "drizzle-orm";
 import { db, schema } from "@/lib/database";
 import type { ProviderSyncRunStatus } from "@/lib/database/types";
 import {
-  resolveExternalTmsSecretMaterial,
   type ExternalTmsCredential,
   type ExternalTmsProviderKind,
 } from "../organization-external-tms-provider-credentials";
+import { resolveExternalTmsSecretMaterialForActor } from "./external-tms-content-sync";
 import { upsertOrganizationExternalTmsProject } from "./organization-external-tms-projects";
 import {
   completeProviderSyncRun,
@@ -57,6 +57,7 @@ export async function syncExternalTmsProjects(input: {
   organizationId: string;
   providerKind: ExternalTmsProviderKind;
   fetchProjects: ExternalTmsProjectFetcher;
+  actorUserId?: string | null;
 }): Promise<ExternalTmsProjectSyncResult> {
   const credential = await getExternalTmsCredential({
     organizationId: input.organizationId,
@@ -85,7 +86,11 @@ export async function syncExternalTmsProjects(input: {
   const failures: ExternalTmsProjectSyncFailure[] = [];
 
   try {
-    const secretMaterial = await resolveExternalTmsSecretMaterial({ credential });
+    const secretMaterial = await resolveExternalTmsSecretMaterialForActor({
+      credential,
+      organizationId: input.organizationId,
+      actorUserId: input.actorUserId,
+    });
     const projects = await input.fetchProjects({
       organizationId: input.organizationId,
       providerKind: input.providerKind,

--- a/apps/hyperlocalise-web/src/lib/providers/sync/external-tms-tm-sync.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/sync/external-tms-tm-sync.ts
@@ -7,10 +7,10 @@ import {
   upsertOrganizationExternalTmsMemoryEntries,
 } from "./organization-external-tms-memories";
 import {
-  resolveExternalTmsSecretMaterial,
   type ExternalTmsCredential,
   type ExternalTmsProviderKind,
 } from "../organization-external-tms-provider-credentials";
+import { resolveExternalTmsSecretMaterialForActor } from "./external-tms-content-sync";
 import {
   completeProviderSyncRun,
   failProviderSyncRun,
@@ -78,6 +78,7 @@ export async function syncExternalTmsTranslationMemories(input: {
   projectId: string;
   providerKind: ExternalTmsProviderKind;
   fetchTranslationMemories: ExternalTmsTranslationMemoryFetcher;
+  actorUserId?: string | null;
 }): Promise<ExternalTmsTranslationMemorySyncResult> {
   const project = await getExternalTmsProject(input);
 
@@ -115,7 +116,11 @@ export async function syncExternalTmsTranslationMemories(input: {
   const failures: ExternalTmsTranslationMemorySyncFailure[] = [];
 
   try {
-    const secretMaterial = await resolveExternalTmsSecretMaterial({ credential });
+    const secretMaterial = await resolveExternalTmsSecretMaterialForActor({
+      credential,
+      organizationId: input.organizationId,
+      actorUserId: input.actorUserId,
+    });
 
     const memories = await input.fetchTranslationMemories({
       organizationId: input.organizationId,

--- a/apps/hyperlocalise-web/src/lib/providers/sync/sync-provider-review.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/sync/sync-provider-review.ts
@@ -1,11 +1,11 @@
 import { and, eq } from "drizzle-orm";
 
 import { db, schema } from "@/lib/database";
-import type { ExternalTmsTaskContent } from "./external-tms-content-sync";
 import {
-  resolveExternalTmsSecretMaterial,
-  type ExternalTmsProviderKind,
-} from "../organization-external-tms-provider-credentials";
+  resolveExternalTmsSecretMaterialForActor,
+  type ExternalTmsTaskContent,
+} from "./external-tms-content-sync";
+import { type ExternalTmsProviderKind } from "../organization-external-tms-provider-credentials";
 import { mergeProviderReviewReports } from "../provider-job-review/normalize-provider-review";
 import type { ProviderReviewReport } from "../provider-job-review/types";
 import { getProviderReviewPuller } from "../provider-review-pullers";
@@ -17,6 +17,7 @@ export async function pullProviderReviewForJob(input: {
   externalJobId: string;
   content: ExternalTmsTaskContent;
   previousReport?: ProviderReviewReport | null;
+  actorUserId?: string | null;
 }): Promise<ProviderReviewReport | null> {
   const pullReview = getProviderReviewPuller(input.providerKind);
   if (!pullReview) {
@@ -63,7 +64,11 @@ export async function pullProviderReviewForJob(input: {
     throw new Error("provider_credential_not_found");
   }
 
-  const secretMaterial = await resolveExternalTmsSecretMaterial({ credential });
+  const secretMaterial = await resolveExternalTmsSecretMaterialForActor({
+    credential,
+    organizationId: input.organizationId,
+    actorUserId: input.actorUserId,
+  });
 
   const incoming = await pullReview({
     organizationId: input.organizationId,

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
@@ -22,6 +22,7 @@ import { sourceContentType } from "@/lib/file-storage/source-file-metadata";
 import { mapWithConcurrency } from "@/lib/primitives/map-with-concurrency/map-with-concurrency";
 import {
   API_TOKEN_AUTH_MODE,
+  CROWDIN_OAUTH_AUTH_MODE,
   getActiveOrganizationExternalTmsProviderCredentialRow,
   resolveExternalTmsSecretMaterial,
   type ExternalTmsCredential,
@@ -197,18 +198,34 @@ type ActiveTmsProviderContext = {
 async function buildActiveTmsProviderContext(
   organizationId: string,
   credential: ExternalTmsCredential,
+  options?: { actorUserId?: string | null },
 ): Promise<ActiveTmsProviderContext> {
   const providerKind = credential.providerKind as ExternalTmsProviderKind;
   let secretMaterial: string;
   try {
-    secretMaterial = await resolveExternalTmsSecretMaterial({ credential });
+    secretMaterial = await resolveActiveTmsProviderSecretMaterial({
+      organizationId,
+      credential,
+      actorUserId: options?.actorUserId,
+    });
   } catch (error) {
     if (
       error instanceof Error &&
       (error.message === "crowdin_oauth_refresh_failed" ||
-        error.message === "crowdin_oauth_token_invalid")
+        error.message === "crowdin_oauth_token_invalid" ||
+        error.message === "crowdin_user_connection_required")
     ) {
-      throw new TmsProviderLiveError("crowdin_auth_invalid", "Crowdin credentials are invalid.");
+      if (error.message === "crowdin_user_connection_required") {
+        throw new TmsProviderLiveError(
+          "crowdin_user_connection_required",
+          "Connect your Crowdin account before using Crowdin.",
+        );
+      }
+
+      throw new TmsProviderLiveError(
+        "crowdin_user_auth_invalid",
+        "Your Crowdin connection is invalid. Reconnect Crowdin and try again.",
+      );
     }
 
     throw error;
@@ -237,21 +254,49 @@ async function buildActiveTmsProviderContext(
   };
 }
 
+async function resolveActiveTmsProviderSecretMaterial(input: {
+  organizationId: string;
+  credential: ExternalTmsCredential;
+  actorUserId?: string | null;
+}) {
+  if (
+    input.credential.providerKind !== "crowdin" ||
+    input.credential.authMode !== CROWDIN_OAUTH_AUTH_MODE ||
+    !input.actorUserId
+  ) {
+    return resolveExternalTmsSecretMaterial({ credential: input.credential });
+  }
+
+  const crowdinUserConnection = await getCrowdinUserConnection({
+    organizationId: input.organizationId,
+    userId: input.actorUserId,
+  });
+  if (!crowdinUserConnection) {
+    throw new Error("crowdin_user_connection_required");
+  }
+
+  return resolveCrowdinUserConnectionSecretMaterial({
+    connection: crowdinUserConnection,
+  });
+}
+
 export async function tryLoadActiveTmsProviderContext(
   organizationId: string,
+  options?: { actorUserId?: string | null },
 ): Promise<ActiveTmsProviderContext | null> {
   const credential = await getActiveOrganizationExternalTmsProviderCredentialRow(organizationId);
   if (!credential) {
     return null;
   }
 
-  return buildActiveTmsProviderContext(organizationId, credential);
+  return buildActiveTmsProviderContext(organizationId, credential, options);
 }
 
 async function loadActiveTmsProviderContext(
   organizationId: string,
+  options?: { actorUserId?: string | null },
 ): Promise<ActiveTmsProviderContext> {
-  const context = await tryLoadActiveTmsProviderContext(organizationId);
+  const context = await tryLoadActiveTmsProviderContext(organizationId, options);
   if (!context) {
     throw new TmsProviderLiveError("no_active_tms_provider", "No external TMS is connected.");
   }
@@ -649,8 +694,11 @@ export async function getTmsProviderConnection(
 
 export async function listTmsProviderLiveProjects(
   organizationId: string,
+  options?: { actorUserId?: string | null },
 ): Promise<TmsProviderLiveProject[]> {
-  const context = await loadActiveTmsProviderContext(organizationId);
+  const context = await loadActiveTmsProviderContext(organizationId, {
+    actorUserId: options?.actorUserId,
+  });
   const projects = await fetchLiveProjects(context);
 
   return projects
@@ -661,8 +709,9 @@ export async function listTmsProviderLiveProjects(
 export async function getTmsProviderLiveProject(
   organizationId: string,
   externalProjectId: string,
+  options?: { actorUserId?: string | null },
 ): Promise<TmsProviderLiveProject | null> {
-  const projects = await listTmsProviderLiveProjects(organizationId);
+  const projects = await listTmsProviderLiveProjects(organizationId, options);
   return projects.find((project) => project.externalProjectId === externalProjectId) ?? null;
 }
 
@@ -675,9 +724,12 @@ export async function listTmsProviderLiveJobsForProject(
     assigneeCandidates?: string[];
     context?: ActiveTmsProviderContext;
     projects?: ExternalTmsProjectMetadata[];
+    actorUserId?: string | null;
   },
 ): Promise<TmsProviderLiveJob[]> {
-  const context = options?.context ?? (await loadActiveTmsProviderContext(organizationId));
+  const context =
+    options?.context ??
+    (await loadActiveTmsProviderContext(organizationId, { actorUserId: options?.actorUserId }));
   const fetcher = tmsProviderJobTaskFetchers[context.providerKind];
   if (!fetcher) {
     throw new TmsProviderLiveError(
@@ -759,9 +811,12 @@ export async function listTmsProviderLiveFilesForProject(
     limit?: number;
     context?: ActiveTmsProviderContext;
     projects?: ExternalTmsProjectMetadata[];
+    actorUserId?: string | null;
   },
 ): Promise<TmsProviderLiveFile[]> {
-  const context = options?.context ?? (await loadActiveTmsProviderContext(organizationId));
+  const context =
+    options?.context ??
+    (await loadActiveTmsProviderContext(organizationId, { actorUserId: options?.actorUserId }));
   const fetcher = tmsProviderFileKeyFetchers[context.providerKind];
   if (!fetcher) {
     throw new TmsProviderLiveError(
@@ -812,8 +867,11 @@ export async function getTmsProviderLiveFileDetail(
   organizationId: string,
   externalProjectId: string,
   sourcePath: string,
+  options?: { actorUserId?: string | null },
 ): Promise<TmsProviderLiveFileDetail | null> {
-  const context = await loadActiveTmsProviderContext(organizationId);
+  const context = await loadActiveTmsProviderContext(organizationId, {
+    actorUserId: options?.actorUserId,
+  });
   const files = await listTmsProviderLiveFilesForProject(organizationId, externalProjectId, {
     context,
     limit: 1000,
@@ -868,9 +926,12 @@ export async function listTmsProviderLiveJobs(
     assignee?: string | null;
     assigneeCandidates?: string[];
     context?: ActiveTmsProviderContext;
+    actorUserId?: string | null;
   },
 ): Promise<TmsProviderLiveJob[]> {
-  const context = options?.context ?? (await loadActiveTmsProviderContext(organizationId));
+  const context =
+    options?.context ??
+    (await loadActiveTmsProviderContext(organizationId, { actorUserId: options?.actorUserId }));
   const projects = await fetchLiveProjects(context);
   const activeProjects = projects.filter((project) => project.isActive !== false);
 
@@ -940,13 +1001,16 @@ async function fetchCrowdinLiveJobTaskMetadata(input: {
 export async function getTmsProviderLiveJobDetail(
   organizationId: string,
   encodedJobId: string,
+  options?: { actorUserId?: string | null },
 ): Promise<TmsProviderLiveJobDetail | null> {
   const parsed = parseProviderJobId(encodedJobId);
   if (!parsed) {
     throw new TmsProviderLiveError("invalid_encoded_job_id", "Job id is not a provider job id.");
   }
 
-  const context = await loadActiveTmsProviderContext(organizationId);
+  const context = await loadActiveTmsProviderContext(organizationId, {
+    actorUserId: options?.actorUserId,
+  });
   if (context.providerKind !== parsed.providerKind) {
     return null;
   }
@@ -1027,7 +1091,7 @@ export async function updateTmsProviderLiveJobDescription(
     throw new TmsProviderLiveError("invalid_encoded_job_id", "Job id is not a provider job id.");
   }
 
-  const context = await loadActiveTmsProviderContext(organizationId);
+  const context = await loadActiveTmsProviderContext(organizationId, { actorUserId });
   if (context.providerKind !== parsed.providerKind) {
     return null;
   }
@@ -1150,9 +1214,11 @@ function mapLiveGlossary(input: {
 
 export async function listTmsProviderLiveGlossaries(
   organizationId: string,
-  options?: { externalProjectId?: string },
+  options?: { externalProjectId?: string; actorUserId?: string | null },
 ): Promise<TmsProviderLiveGlossary[]> {
-  const context = await loadActiveTmsProviderContext(organizationId);
+  const context = await loadActiveTmsProviderContext(organizationId, {
+    actorUserId: options?.actorUserId,
+  });
   const fetcher = tmsProviderGlossaryFetchers[context.providerKind];
   if (!fetcher) {
     throw new TmsProviderLiveError(
@@ -1237,9 +1303,11 @@ function mapLiveTranslationMemory(input: {
 
 export async function listTmsProviderLiveTranslationMemories(
   organizationId: string,
-  options?: { externalProjectId?: string },
+  options?: { externalProjectId?: string; actorUserId?: string | null },
 ): Promise<TmsProviderLiveTranslationMemory[]> {
-  const context = await loadActiveTmsProviderContext(organizationId);
+  const context = await loadActiveTmsProviderContext(organizationId, {
+    actorUserId: options?.actorUserId,
+  });
   const fetcher = tmsProviderTranslationMemoryFetchers[context.providerKind];
   if (!fetcher) {
     throw new TmsProviderLiveError(


### PR DESCRIPTION
Title: fix(crowdin): require user OAuth tokens for provider requests

## What changed

- Store Crowdin OAuth app client config at the org integration level instead of using an org OAuth access token as the API actor.
- Require the active user’s Crowdin connection for live provider reads, manual syncs, provider review pulls, agent content pulls, comment write-back, and translation write-back.
- Keep Crowdin personal-token auth deprecated with JSDoc on the schema `authMode` field.
- Add user-facing empty/error states with a `Connect Crowdin` CTA when the active user has not connected Crowdin.

## How to test

- `vp check --fix`
- `vp test`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review