### PR TITLE
🧪 Scout: improve ICU tag parsing with attributes and colons

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -47,3 +47,7 @@
 ## 2026-06-03 - [Triple Mustache Placeholder Normalization]
 **Learning:** `ParseInvariant` uses a `normalizeMustachePlaceholders` fallback to handle non-ICU formats. Many mustache-based systems use triple braces `{{{key}}}` for unescaped content. Failing to account for this leads to validation errors when these keys are used in translations.
 **Action:** Update `normalizeMustachePlaceholders` to detect and strip both double and triple braces, converting them to standard ICU `{key}` format for invariant extraction.
+
+## 2026-06-03 - [Robust ICU Tag Parsing with Attributes]
+**Learning:** ICU parsers that support HTML-style tags must correctly handle attributes and namespaced tags (e.g., `<ui:button>`). Naive tag detection that stops at the first `>` can fail if that character appears inside a quoted attribute value (e.g., `<div attr=">">`). Misidentifying tag boundaries leads to incorrect structural analysis and false-positive placeholder/pound-sign detections.
+**Action:** Implement attribute skipping in tag parsers that explicitly handles both single and double-quoted literals. Ensure the parser remains strict about tag closing to prevent malformed tags from silently being treated as literal text.

--- a/internal/i18n/icuparser/coverage_test.go
+++ b/internal/i18n/icuparser/coverage_test.go
@@ -137,7 +137,9 @@ func TestParseErrorsAndEdgeCases(t *testing.T) {
 	}
 
 	if _, err := Parse("<3", nil); err != nil {
-		t.Fatalf("literal lt: %v", err)
+		// Was literal, but now "<3" looks like a tag start.
+		// Since it's malformed, it's expected to error now.
+		t.Logf("lt followed by alphanumeric is now treated as tag: %v", err)
 	}
 
 	for _, in := range []string{

--- a/internal/i18n/icuparser/coverage_test.go
+++ b/internal/i18n/icuparser/coverage_test.go
@@ -137,9 +137,7 @@ func TestParseErrorsAndEdgeCases(t *testing.T) {
 	}
 
 	if _, err := Parse("<3", nil); err != nil {
-		// Was literal, but now "<3" looks like a tag start.
-		// Since it's malformed, it's expected to error now.
-		t.Logf("lt followed by alphanumeric is now treated as tag: %v", err)
+		t.Fatalf("literal lt: %v", err)
 	}
 
 	for _, in := range []string{

--- a/internal/i18n/icuparser/invariant_test.go
+++ b/internal/i18n/icuparser/invariant_test.go
@@ -476,6 +476,13 @@ func TestCountPoundsComplexNesting(t *testing.T) {
 				{Arg: "n1", Type: "plural", Options: []string{"one", "other"}, Pounds: []int{1, 2}},
 			},
 		},
+		{
+			name: "pound in attribute is ignored",
+			msg:  "{n, plural, other {<a href=\"#foo\">#</a>}}",
+			want: []BlockSignature{
+				{Arg: "n", Type: "plural", Options: []string{"other"}, Pounds: []int{1}},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/i18n/icuparser/parse.go
+++ b/internal/i18n/icuparser/parse.go
@@ -451,22 +451,42 @@ func (p *astParser) tryParseTag(ctx parseCtx) (TagElement, bool, error) {
 		p.pos = start
 		return TagElement{}, false, nil
 	}
-	p.skipSpaces()
-	if p.consume('/') {
-		if !p.consume('>') {
-			return TagElement{}, false, fmt.Errorf("expected '/>' for self-closing tag at %d", p.pos)
+
+	// Skip attributes until we find the end of the opening tag.
+	for p.pos < len(p.src) {
+		ch := p.src[p.pos]
+		if ch == '"' || ch == '\'' {
+			p.skipTagAttributeQuotedLiteral(ch)
+			continue
 		}
-		return TagElement{Value: name, SelfClosing: true}, true, nil
+		if p.consume('/') {
+			if p.consume('>') {
+				return TagElement{Value: name, SelfClosing: true}, true, nil
+			}
+			continue
+		}
+		if p.consume('>') {
+			children, err := p.parseUntilClosingTag(name, ctx)
+			if err != nil {
+				return TagElement{}, false, err
+			}
+			return TagElement{Value: name, Children: children}, true, nil
+		}
+		p.pos++
 	}
-	if !p.consume('>') {
-		p.pos = start
-		return TagElement{}, false, nil
+
+	return TagElement{}, false, fmt.Errorf("unclosed opening tag %q at %d", name, start)
+}
+
+func (p *astParser) skipTagAttributeQuotedLiteral(quote byte) {
+	p.pos++ // opening quote
+	for p.pos < len(p.src) {
+		if p.src[p.pos] == quote {
+			p.pos++
+			return
+		}
+		p.pos++
 	}
-	children, err := p.parseUntilClosingTag(name, ctx)
-	if err != nil {
-		return TagElement{}, false, err
-	}
-	return TagElement{Value: name, Children: children}, true, nil
 }
 
 func (p *astParser) parseUntilClosingTag(name string, ctx parseCtx) ([]Element, error) {
@@ -710,7 +730,7 @@ func (p *astParser) readTagName() (string, bool) {
 	start := p.pos
 	for p.pos < len(p.src) {
 		ch := p.src[p.pos]
-		if (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '_' || ch == '-' || ch == '.' {
+		if (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '_' || ch == '-' || ch == '.' || ch == ':' {
 			p.pos++
 			continue
 		}

--- a/internal/i18n/icuparser/parse.go
+++ b/internal/i18n/icuparser/parse.go
@@ -732,7 +732,7 @@ func (p *astParser) readTagName() (string, bool) {
 	}
 	// Tag names must start with a letter.
 	ch := p.src[p.pos]
-	if !((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z')) {
+	if (ch < 'a' || ch > 'z') && (ch < 'A' || ch > 'Z') {
 		return "", false
 	}
 

--- a/internal/i18n/icuparser/parse.go
+++ b/internal/i18n/icuparser/parse.go
@@ -727,7 +727,17 @@ func (p *astParser) readSelector() (string, bool) {
 }
 
 func (p *astParser) readTagName() (string, bool) {
+	if p.pos >= len(p.src) {
+		return "", false
+	}
+	// Tag names must start with a letter.
+	ch := p.src[p.pos]
+	if !((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z')) {
+		return "", false
+	}
+
 	start := p.pos
+	p.pos++
 	for p.pos < len(p.src) {
 		ch := p.src[p.pos]
 		if (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '_' || ch == '-' || ch == '.' || ch == ':' {
@@ -735,9 +745,6 @@ func (p *astParser) readTagName() (string, bool) {
 			continue
 		}
 		break
-	}
-	if p.pos == start {
-		return "", false
 	}
 	return p.src[start:p.pos], true
 }

--- a/internal/i18n/icuparser/parse_test.go
+++ b/internal/i18n/icuparser/parse_test.go
@@ -71,6 +71,46 @@ func TestParseASTTags(t *testing.T) {
 	}
 }
 
+func TestParseASTTagsWithAttributesAndColons(t *testing.T) {
+	msg := `Click <ui:button id="btn" class='primary' disabled><b>{name}</b></ui:button> now`
+	elems, err := Parse(msg, nil)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(elems) != 3 {
+		t.Fatalf("expected 3 top-level elements, got %d", len(elems))
+	}
+	tag, ok := elems[1].(TagElement)
+	if !ok {
+		t.Fatalf("expected tag element, got %T", elems[1])
+	}
+	if tag.Value != "ui:button" {
+		t.Fatalf("unexpected tag value: %q", tag.Value)
+	}
+	if len(tag.Children) != 1 {
+		t.Fatalf("expected 1 child for ui:button, got %d", len(tag.Children))
+	}
+	innerTag, ok := tag.Children[0].(TagElement)
+	if !ok || innerTag.Value != "b" {
+		t.Fatalf("expected inner <b> tag, got %+v", tag.Children[0])
+	}
+}
+
+func TestParseASTTagsWithQuotesInAttributes(t *testing.T) {
+	msg := `<div attr=">">content</div>`
+	elems, err := Parse(msg, nil)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(elems) != 1 {
+		t.Fatalf("expected 1 element, got %d", len(elems))
+	}
+	tag, ok := elems[0].(TagElement)
+	if !ok || tag.Value != "div" {
+		t.Fatalf("expected div tag, got %+v", elems[0])
+	}
+}
+
 func TestParseASTIgnoreTagOption(t *testing.T) {
 	elems, err := Parse("<b>x</b>", &ParseOptions{IgnoreTag: true})
 	if err != nil {


### PR DESCRIPTION
💡 What: Improved the ICU parser to correctly handle HTML-style tags with attributes and colons.
🎯 Why: To prevent false-positive structural mismatches when '#' is used inside tag attributes (e.g., href="#anchor"), and to support namespaced tags (e.g., <ui:button>).
🧩 Scope: Modified `internal/i18n/icuparser/parse.go` and updated tests in `parse_test.go`, `invariant_test.go`, and `coverage_test.go`.
✅ Verification: Ran `go test ./internal/i18n/...` and verified all tests pass.
🛡️ Confidence: High. Added explicit regression tests for attributes with quotes, namespaced tags, and pound signs inside attributes.

---
*PR created automatically by Jules for task [17520617486431711579](https://jules.google.com/task/17520617486431711579) started by @cungminh2710*