### PR TITLE
🛡️ Sentinel: Standardize providerSafeFetch for outgoing requests

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/external-tms-provider-credential/external-tms-provider-credential.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/external-tms-provider-credential/external-tms-provider-credential.route.ts
@@ -7,6 +7,7 @@ import { validator } from "hono/validator";
 import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
 import { hasCapability } from "@/api/auth/policy";
 import { env } from "@/lib/env";
+import { providerSafeFetch } from "@/lib/providers/provider-safe-fetch";
 import { isErr } from "@/lib/primitives/result/results";
 import { db, schema } from "@/lib/database";
 import {
@@ -208,7 +209,8 @@ async function completeCrowdinUserOAuthLink(
 
   let tokenBundle: ReturnType<typeof mapCrowdinOAuthTokenResponse>;
   try {
-    const response = await fetch("https://accounts.crowdin.com/oauth/token", {
+    // We use providerSafeFetch to mitigate SSRF risks via DNS-level validation and IP blocklisting
+    const response = await providerSafeFetch("https://accounts.crowdin.com/oauth/token", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({

--- a/apps/hyperlocalise-web/src/lib/billing/usage-control.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/usage-control.ts
@@ -4,6 +4,7 @@ import { usageFeatureIds, type UsageFeatureId } from "@/lib/billing/autumn-ids";
 import type { DatabaseClient } from "@/lib/database";
 import { db, schema } from "@/lib/database";
 import { env } from "@/lib/env";
+import { providerSafeFetch } from "@/lib/providers/provider-safe-fetch";
 import { err, ok, type Result } from "@/lib/primitives/result/results";
 
 const AUTUMN_API_VERSION = "2.2.0";
@@ -226,7 +227,8 @@ export async function trackUsageEventInAutumnByOperationKey(input: {
   const trackingResult = await trackUsageEventInAutumn({
     event,
     apiKey: autumnApiKey,
-    fetchFn: input.fetchFn ?? fetch,
+    // We use providerSafeFetch to mitigate SSRF risks via DNS-level validation and IP blocklisting
+    fetchFn: input.fetchFn ?? providerSafeFetch,
   });
 
   if (!trackingResult.ok) {

--- a/apps/hyperlocalise-web/src/lib/contentful/client.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/client.ts
@@ -1,3 +1,5 @@
+import { providerSafeFetch } from "@/lib/providers/provider-safe-fetch";
+
 import type { ContentfulContentType, ContentfulDraftTranslation, ContentfulEntry } from "./types";
 
 const CONTENTFUL_CMA_BASE_URL = "https://api.contentful.com";
@@ -19,7 +21,8 @@ export class ContentfulManagementClient {
   ) {}
 
   private async request<T>(path: string, init: RequestInit = {}): Promise<T> {
-    const fetchImpl = this.options.fetchImpl ?? fetch;
+    // We use providerSafeFetch to mitigate SSRF risks via DNS-level validation and IP blocklisting
+    const fetchImpl = this.options.fetchImpl ?? providerSafeFetch;
     const headers = new Headers(init.headers);
     headers.set("authorization", `Bearer ${this.options.accessToken}`);
     headers.set("content-type", "application/vnd.contentful.management.v1+json");

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/smartling/smartling-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/smartling/smartling-api.ts
@@ -5,6 +5,8 @@
  * credential validation, TMS connector scans, terminology resources, and job-scoped content pull/write-back.
  */
 
+import { providerSafeFetch } from "@/lib/providers/provider-safe-fetch";
+
 import { parseSmartlingCredentials, type SmartlingCredentials } from "./smartling-credentials";
 import { uniqueLocales } from "./smartling-locales";
 import { requireProviderBaseUrl } from "../../provider-url-safety";
@@ -363,7 +365,8 @@ export class SmartlingApiClient {
       options.webhooksBaseUrl ?? deriveServiceBaseUrl(this.authBaseUrl, "webhooks"),
       DEFAULT_WEBHOOKS_BASE_URL,
     );
-    this.fetchFn = options.fetchFn ?? fetch;
+    // We use providerSafeFetch to mitigate SSRF risks via DNS-level validation and IP blocklisting
+    this.fetchFn = options.fetchFn ?? providerSafeFetch;
   }
 
   get credentialScope() {

--- a/apps/hyperlocalise-web/src/lib/providers/organization-external-tms-provider-credentials.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/organization-external-tms-provider-credentials.ts
@@ -17,6 +17,7 @@ import {
 } from "@/lib/providers/tms-capabilities";
 import { assertProviderUrlResolvable } from "@/lib/providers/provider-url-resolve";
 import { normalizeProviderBaseUrl } from "@/lib/providers/provider-url-safety";
+import { providerSafeFetch } from "@/lib/providers/provider-safe-fetch";
 import { resolvePhraseBaseUrl } from "@/lib/providers/adapters/phrase/phrase-base-url";
 
 export type { ExternalTmsProviderKind } from "@/lib/providers/contracts/external-tms-provider-kind";
@@ -537,17 +538,21 @@ export async function refreshCrowdinOAuthToken(input: {
   tokenBundle: CrowdinOAuthTokenBundle;
   fetchFn?: typeof fetch;
 }): Promise<CrowdinOAuthTokenBundle> {
-  const response = await (input.fetchFn ?? fetch)("https://accounts.crowdin.com/oauth/token", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      grant_type: "refresh_token",
-      client_id: input.tokenBundle.clientId,
-      client_secret: input.tokenBundle.clientSecret,
-      refresh_token: input.tokenBundle.refreshToken,
-    }),
-    redirect: "error",
-  });
+  // We use providerSafeFetch to mitigate SSRF risks via DNS-level validation and IP blocklisting
+  const response = await (input.fetchFn ?? providerSafeFetch)(
+    "https://accounts.crowdin.com/oauth/token",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "refresh_token",
+        client_id: input.tokenBundle.clientId,
+        client_secret: input.tokenBundle.clientSecret,
+        refresh_token: input.tokenBundle.refreshToken,
+      }),
+      redirect: "error",
+    },
+  );
 
   if (!response.ok) {
     throw new Error("crowdin_oauth_refresh_failed");


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Potential SSRF (Server-Side Request Forgery) in backend components using global `fetch`.
🎯 Impact: Outbound requests to external providers (TMS, CMS, billing) were using the insecure global `fetch`, which lacks DNS-level validation. This could potentially allow access to restricted internal resources if request parameters were influenced by user input.
🔧 Fix: Replaced global `fetch` with `providerSafeFetch` in Crowdin OAuth token management, Autumn usage tracking, Contentful CMA client, and Smartling API client. `providerSafeFetch` mitigates SSRF by performing DNS resolution and validating target IP addresses against a blocklist of private/restricted ranges. Added security comments explaining the mitigation.
✅ Verification: Verified changes via `vp check --fix` and existing unit tests for Smartling and Contentful clients. Verified manual inspection of code for correct imports and usage.

---
*PR created automatically by Jules for task [12768666847736690082](https://jules.google.com/task/12768666847736690082) started by @cungminh2710*