### PR TITLE
🧪 Scout: Improve HTML tag parity robustness for quoted attributes

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -51,3 +51,7 @@
 ## 2026-06-03 - [Robust ICU Tag Parsing with Attributes]
 **Learning:** ICU parsers that support HTML-style tags must correctly handle attributes and namespaced tags (e.g., `<ui:button>`). Naive tag detection that stops at the first `>` can fail if that character appears inside a quoted attribute value (e.g., `<div attr=">">`). Misidentifying tag boundaries leads to incorrect structural analysis and false-positive placeholder/pound-sign detections.
 **Action:** Implement attribute skipping in tag parsers that explicitly handles both single and double-quoted literals. Ensure the parser remains strict about tag closing to prevent malformed tags from silently being treated as literal text.
+
+## 2026-06-12 - [Robust HTML Tag Parity with Quoted Attributes]
+**Learning:** Standard regex-based tag extraction (e.g., `</?[A-Za-z][^>]*?>`) is insufficient for HTML tag parity checks when attributes contain `>` or tag-like content (e.g., `<div title="a > b">`). The regex prematurely terminates at the first `>`, leading to incorrect tag sequences and false-positive mismatches.
+**Action:** Use a scanner-based approach for tag extraction that respects single and double quotes within tags. Ensure the scanner correctly identifies the full span of a tag before normalization and comparison.

--- a/internal/i18n/htmltagparity/htmltagparity.go
+++ b/internal/i18n/htmltagparity/htmltagparity.go
@@ -38,7 +38,7 @@ func findAllTags(s string) []string {
 			}
 			next = s[i+2]
 		}
-		if !((next >= 'a' && next <= 'z') || (next >= 'A' && next <= 'Z')) {
+		if (next < 'a' || next > 'z') && (next < 'A' || next > 'Z') {
 			continue
 		}
 

--- a/internal/i18n/htmltagparity/htmltagparity.go
+++ b/internal/i18n/htmltagparity/htmltagparity.go
@@ -3,21 +3,76 @@
 package htmltagparity
 
 import (
-	"regexp"
 	"slices"
 	"strings"
 
 	"golang.org/x/net/html/atom"
 )
 
-var tagPattern = regexp.MustCompile(`</?[A-Za-z][^>]*?>`)
-
 // Mismatch reports whether the normalized HTML tag name sequences differ
 // between source and target (same semantics as check hasHTMLTagMismatch).
 func Mismatch(sourceValue, targetValue string) bool {
-	sourceTags := normalizedMarkupTagNames(tagPattern.FindAllString(sourceValue, -1))
-	targetTags := normalizedMarkupTagNames(tagPattern.FindAllString(targetValue, -1))
+	sourceTags := normalizedMarkupTagNames(findAllTags(sourceValue))
+	targetTags := normalizedMarkupTagNames(findAllTags(targetValue))
 	return !slices.Equal(sourceTags, targetTags)
+}
+
+func findAllTags(s string) []string {
+	var out []string
+	for i := 0; i < len(s); i++ {
+		if s[i] != '<' {
+			continue
+		}
+
+		// Potential tag start.
+		start := i
+		if i+1 >= len(s) {
+			break
+		}
+
+		// We only care about </?[A-Za-z] to match the previous regex behavior.
+		next := s[i+1]
+		if next == '/' {
+			if i+2 >= len(s) {
+				break
+			}
+			next = s[i+2]
+		}
+		if !((next >= 'a' && next <= 'z') || (next >= 'A' && next <= 'Z')) {
+			continue
+		}
+
+		// Found a tag start, scan until we find the closing '>', respecting quotes.
+		var quote byte
+		found := false
+		for j := i + 1; j < len(s); j++ {
+			ch := s[j]
+			if quote != 0 {
+				if ch == quote {
+					quote = 0
+				}
+				continue
+			}
+
+			if ch == '"' || ch == '\'' {
+				quote = ch
+				continue
+			}
+
+			if ch == '>' {
+				out = append(out, s[start:j+1])
+				i = j
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			// Unclosed tag, skip it as a potential start.
+			continue
+		}
+	}
+	return out
 }
 
 // NormalizedTagNames returns normalized tag names from raw HTML snippets (exported for tests).

--- a/internal/i18n/htmltagparity/htmltagparity_test.go
+++ b/internal/i18n/htmltagparity/htmltagparity_test.go
@@ -115,6 +115,18 @@ func TestMismatchFormattingAndKnownTags(t *testing.T) {
 			tgt:  "Path <id> and <name>",
 			want: false,
 		},
+		{
+			name: "greater-than sign in quoted attribute does not terminate tag",
+			src:  `<div title="a > b">content</div>`,
+			tgt:  `<div title="something">content</div>`,
+			want: false,
+		},
+		{
+			name: "tag-like content in quoted attribute is ignored",
+			src:  `<div title=" > <br/> ">content</div>`,
+			tgt:  `<div title="something">content</div>`,
+			want: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
💡 What: Improved HTML tag extraction in `htmltagparity` to handle quoted attributes and added regression tests.
🎯 Why: Prevents false-positive tag mismatches when attributes contain `>` or tag-like content, which previously broke parity checks.
🧩 Scope: `internal/i18n/htmltagparity/htmltagparity.go`, `internal/i18n/htmltagparity/htmltagparity_test.go`, `.jules/scout.md`.
✅ Verification: `go test ./internal/i18n/htmltagparity/...` and `go test ./...`.
🛡️ Confidence: High. The scanner-based approach is more robust than regex for this purpose and is verified by targeted regression tests.


---
*PR created automatically by Jules for task [18239394929096169204](https://jules.google.com/task/18239394929096169204) started by @cungminh2710*