### PR TITLE
fix(crowdin): improve webhook model parity and add missing events

### DIFF
--- a/third_party/crowdin-api-client-go/crowdin/model/webhooks.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/webhooks.go
@@ -23,10 +23,14 @@ const (
 	FileTranslated Event = "file.translated"
 	// Project file is fully reviewed.
 	FileApproved Event = "file.approved"
+	// File QA check is finished.
+	FileQAFinished Event = "file.qa.finished"
 	// All strings in project are translated.
 	ProjectTranslated Event = "project.translated"
 	// All strings in project are approved.
 	ProjectApproved Event = "project.approved"
+	// Project QA check is finished.
+	ProjectQAFinished Event = "project.qa.finished"
 	// Project are successfully built.
 	ProjectBuilt Event = "project.built"
 	// Final translation of string is updated (using Replace in suggestions feature).
@@ -59,6 +63,8 @@ const (
 	TaskAdded Event = "task.added"
 	// Task status was changed.
 	TaskStatusChanged Event = "task.statusChanged"
+	// Task is updated.
+	TaskUpdated Event = "task.updated"
 	// Task is deleted.
 	TaskDeleted Event = "task.deleted"
 
@@ -67,6 +73,10 @@ const (
 	ProjectCreated Event = "project.created"
 	// Project is deleted.
 	ProjectDeleted Event = "project.deleted"
+	// Group is created.
+	GroupCreated Event = "group.created"
+	// Group is deleted.
+	GroupDeleted Event = "group.deleted"
 )
 
 // ContentType is a type that represents the content type of a webhook.
@@ -81,7 +91,7 @@ const (
 // Webhook represents a webhook in Crowdin projects or account.
 type Webhook struct {
 	ID              int               `json:"id"`
-	ProjectID       int               `json:"projectId"`
+	ProjectID       *int              `json:"projectId,omitempty"`
 	Name            string            `json:"name"`
 	URL             string            `json:"url"`
 	Events          []string          `json:"events"`

--- a/third_party/crowdin-api-client-go/crowdin/webhooks_organization_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/webhooks_organization_test.go
@@ -102,11 +102,11 @@ func TestOrganizationWebhooksService_Get(t *testing.T) {
 	webhook, resp, err := client.OrganizationWebhooks.Get(context.Background(), 1)
 	require.NoError(t, err)
 	assert.NotNil(t, resp)
-	assert.Equal(t, 0, webhook.ProjectID)
+	assert.Nil(t, webhook.ProjectID)
 
 	expected := &model.Webhook{
 		ID:        4,
-		ProjectID: 0,
+		ProjectID: nil,
 		Name:      "Proofread",
 		URL:       "https://webhook.site/1c20d9b5-6e6a-4522-974d-9da7ea7595c9",
 		Events:    []string{"file.approved"},
@@ -246,12 +246,12 @@ func TestOrganizationWebhooksService_List(t *testing.T) {
 					Headers: map[string]string{
 						"Autorization": "Bearer ef231f493cafe336f98d486f596282205b3c2a0",
 					},
-					ProjectID: 0,
+					ProjectID: nil,
 				},
 				{
 					ID:        6,
 					Headers:   map[string]string{},
-					ProjectID: 0,
+					ProjectID: nil,
 				},
 			}
 			assert.Equal(t, expected, webhooks)

--- a/third_party/crowdin-api-client-go/crowdin/webhooks_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/webhooks_test.go
@@ -106,7 +106,7 @@ func TestWebhooksService_Get(t *testing.T) {
 
 	expected := &model.Webhook{
 		ID:        4,
-		ProjectID: 2,
+		ProjectID: ToPtr(2),
 		Name:      "Proofread",
 		URL:       "https://webhook.site/1c20d9b5-6e6a-4522-974d-9da7ea7595c9",
 		Events:    []string{"file.approved"},


### PR DESCRIPTION
### fix(crowdin): improve webhook model parity and add missing events

#### 💡 What
Improved the `Webhook` model and constants in the Crowdin fork to better align with the official API v2 specification. Specifically:
- Added missing `Event` constants: `FileQAFinished` ("file.qa.finished"), `ProjectQAFinished` ("project.qa.finished"), `TaskUpdated` ("task.updated"), `GroupCreated` ("group.created"), and `GroupDeleted` ("group.deleted").
- Changed `Webhook.ProjectID` from `int` to `*int` and added the `omitempty` JSON tag.

#### 🎯 Why
The previous implementation had two issues:
1. It was missing several events currently supported by Crowdin.
2. It used a non-pointer `int` for `projectId`. Since organization-level webhooks do not return a `projectId`, the SDK was either defaulting it to `0` or failing to correctly represent its absence. Using `*int` allows for proper `nil` handling, matching the Crowdin API's optionality for this field.

#### 🔭 Docs
- [Webhooks API v2](https://developer.crowdin.com/api/v2/#tag/Webhooks)
- [Organization Webhooks API v2](https://developer.crowdin.com/api/v2/#tag/Organization-Webhooks)

#### 🧩 Scope
- `third_party/crowdin-api-client-go/crowdin/model/webhooks.go`
- `third_party/crowdin-api-client-go/crowdin/webhooks_test.go`
- `third_party/crowdin-api-client-go/crowdin/webhooks_organization_test.go`

#### ✅ Verification
- Ran focused unit tests for webhooks and organization webhooks.
- Verified correct serialization/deserialization for both project-level and organization-level webhook payloads.
- Full verification: `make fmt`, `make lint`, and `make test` (with `GOWORK=off` for the third_party module).

#### 🛡️ Confidence
High. The changes strictly follow the documented API contract and maintain compatibility with existing project-level logic while fixing organization-level parity.

---
*PR created automatically by Jules for task [17736697183324290146](https://jules.google.com/task/17736697183324290146) started by @cungminh2710*