### PR TITLE
feat(web): show Crowdin task files on job detail page

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.test.ts
@@ -277,6 +277,63 @@ describe("tmsProviderRoutes", () => {
     });
   });
 
+  it("returns live job files for a provider task", async () => {
+    const identity = fixture.createWorkosIdentityWithRole("admin");
+    const headers = await fixture.authHeadersFor(identity);
+    const organizationId = globalThis.__testApiAuthContext!.organization.localOrganizationId;
+
+    const listJobFiles = vi
+      .spyOn(tmsProviderLive, "listTmsProviderLiveJobFiles")
+      .mockResolvedValue([
+        {
+          origin: "provider",
+          sourcePath: "locales/en.json",
+          sourceHash: null,
+          commitSha: null,
+          workflowRunId: null,
+          uploadedAt: "2026-06-01T10:00:00.000Z",
+          storedFileId: null,
+          metadata: {},
+          filename: "en.json",
+          byteSize: null,
+          provider: {
+            kind: "crowdin",
+            resourceType: "file",
+            externalProjectId: "902807",
+            externalResourceId: "12",
+            externalUrl: "https://crowdin.com/file/12",
+            syncState: "synced",
+            sourceLocale: "en",
+            targetLocales: ["fr"],
+            localeReadiness: {},
+            revision: "1",
+            format: "json",
+            lastSyncedAt: "2026-06-01T10:00:00.000Z",
+          },
+          latestJob: null,
+        },
+      ]);
+
+    const response = await client.api.orgs[":organizationSlug"]["tms-provider"].jobs[
+      ":encodedJobId"
+    ].files.$get(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing",
+          encodedJobId: "ext:crowdin:902807:99",
+        },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { files: unknown[] };
+    expect(body.files).toHaveLength(1);
+    expect(listJobFiles).toHaveBeenCalledWith(organizationId, "ext:crowdin:902807:99", {
+      actorUserId: expect.any(String),
+    });
+  });
+
   it("returns 401 when the stored Crowdin OAuth token bundle is invalid", async () => {
     const identity = fixture.createWorkosIdentityWithRole("admin");
     const headers = await fixture.authHeadersFor(identity);

--- a/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.test.ts
@@ -4,6 +4,7 @@ import { eq } from "drizzle-orm";
 import { testClient } from "hono/testing";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
 
+import * as policy from "@/api/auth/policy";
 import { app } from "@/api/app";
 import { db, schema } from "@/lib/database";
 import {
@@ -12,6 +13,7 @@ import {
   upsertOrganizationExternalTmsProviderCredential,
 } from "@/lib/providers/organization-external-tms-provider-credentials";
 import * as tmsProviderLive from "@/lib/providers/tms-provider-live";
+import type { TmsProviderLiveFileDetail } from "@/lib/providers/tms-provider-live";
 import {
   encryptProviderCredential,
   unwrapProviderCredentialCrypto,
@@ -275,6 +277,154 @@ describe("tmsProviderRoutes", () => {
     expect(listComments).toHaveBeenCalledWith(organizationId, "ext:crowdin:902807:99", {
       actorUserId: expect.any(String),
     });
+  });
+
+  it("returns live job file detail for a provider task", async () => {
+    const identity = fixture.createWorkosIdentityWithRole("admin");
+    const headers = await fixture.authHeadersFor(identity);
+    const organizationId = globalThis.__testApiAuthContext!.organization.localOrganizationId;
+
+    const fileDetail: TmsProviderLiveFileDetail = {
+      sourcePath: "locales/en.json",
+      filename: "en.json",
+      provider: {
+        kind: "crowdin" as const,
+        resourceType: "file" as const,
+        externalProjectId: "902807",
+        externalResourceId: "12",
+        externalUrl: "https://crowdin.com/file/12",
+        syncState: "synced" as const,
+        sourceLocale: "en",
+        targetLocales: ["fr"],
+        localeReadiness: {},
+        revision: "1",
+        format: "json",
+        lastSyncedAt: "2026-06-01T10:00:00.000Z",
+      },
+      versions: [
+        {
+          id: "provider-live:crowdin:902807:12",
+          origin: "provider" as const,
+          sourcePath: "locales/en.json",
+          sourceHash: null,
+          revision: "1",
+          commitSha: null,
+          workflowRunId: null,
+          uploadedAt: "2026-06-01T10:00:00.000Z",
+          storedFileId: null,
+          filename: "en.json",
+          contentType: "application/json",
+          byteSize: 18,
+          sha256: null,
+          metadata: {},
+          content: { text: '{"hello":"world"}' },
+        },
+      ],
+      jobsByLocale: [],
+      providerJobsByLocale: [],
+    };
+
+    const getJobFileDetail = vi
+      .spyOn(tmsProviderLive, "getTmsProviderLiveJobFileDetail")
+      .mockResolvedValue(fileDetail);
+
+    const response = await client.api.orgs[":organizationSlug"]["tms-provider"].jobs[
+      ":encodedJobId"
+    ].files.detail.$get(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing",
+          encodedJobId: "ext:crowdin:902807:99",
+        },
+        query: { sourcePath: "locales/en.json" },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ file: fileDetail });
+    expect(getJobFileDetail).toHaveBeenCalledWith(
+      organizationId,
+      "ext:crowdin:902807:99",
+      "locales/en.json",
+      { actorUserId: expect.any(String) },
+    );
+  });
+
+  it("returns 404 when live job file detail is not found", async () => {
+    const identity = fixture.createWorkosIdentityWithRole("admin");
+    const headers = await fixture.authHeadersFor(identity);
+
+    vi.spyOn(tmsProviderLive, "getTmsProviderLiveJobFileDetail").mockResolvedValue(null);
+
+    const response = await client.api.orgs[":organizationSlug"]["tms-provider"].jobs[
+      ":encodedJobId"
+    ].files.detail.$get(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing",
+          encodedJobId: "ext:crowdin:902807:99",
+        },
+        query: { sourcePath: "locales/missing.json" },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: "file_not_found" });
+  });
+
+  it("returns 403 when reading live job file detail without jobs:read", async () => {
+    const identity = fixture.createWorkosIdentityWithRole("admin");
+    const headers = await fixture.authHeadersFor(identity);
+    const originalHasCapability = policy.hasCapability;
+    const hasCapabilitySpy = vi
+      .spyOn(policy, "hasCapability")
+      .mockImplementation((role, capability) => {
+        if (capability === "jobs:read") {
+          return false;
+        }
+
+        return originalHasCapability(role, capability);
+      });
+
+    const response = await client.api.orgs[":organizationSlug"]["tms-provider"].jobs[
+      ":encodedJobId"
+    ].files.detail.$get(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing",
+          encodedJobId: "ext:crowdin:902807:99",
+        },
+        query: { sourcePath: "locales/en.json" },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: "forbidden" });
+    hasCapabilitySpy.mockRestore();
+  });
+
+  it("returns 400 when live job file detail query is invalid", async () => {
+    const identity = fixture.createWorkosIdentityWithRole("admin");
+    const headers = await fixture.authHeadersFor(identity);
+
+    const response = await client.api.orgs[":organizationSlug"]["tms-provider"].jobs[
+      ":encodedJobId"
+    ].files.detail.$get(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing",
+          encodedJobId: "ext:crowdin:902807:99",
+        },
+        query: { sourcePath: "" },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "invalid_query" });
   });
 
   it("returns live job files for a provider task", async () => {

--- a/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.ts
@@ -6,7 +6,9 @@ import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
 import { hasCapability } from "@/api/auth/policy";
 import {
   getTmsProviderConnection,
+  getTmsProviderLiveJobFileDetail,
   listTmsProviderLiveJobComments,
+  listTmsProviderLiveJobFiles,
   getTmsProviderLiveJobDetail,
   updateTmsProviderLiveJobDescription,
   getTmsProviderLiveProject,
@@ -40,6 +42,10 @@ const updateJobDescriptionBodySchema = z.object({
   description: z.string().max(2_048),
 });
 
+const jobFileDetailQuerySchema = z.object({
+  sourcePath: z.string().min(1),
+});
+
 const validateMineQuery = validator("query", (value, c) => {
   const parsed = mineQuerySchema.safeParse(value);
   if (!parsed.success) {
@@ -60,6 +66,15 @@ const validateExternalProjectIdQuery = validator("query", (value, c) => {
 
 const validateProjectFilesQuery = validator("query", (value, c) => {
   const parsed = projectFilesQuerySchema.safeParse(value);
+  if (!parsed.success) {
+    return c.json({ error: "invalid_query" }, 400);
+  }
+
+  return parsed.data;
+});
+
+const validateJobFileDetailQuery = validator("query", (value, c) => {
+  const parsed = jobFileDetailQuerySchema.safeParse(value);
   if (!parsed.success) {
     return c.json({ error: "invalid_query" }, 400);
   }
@@ -246,6 +261,49 @@ export function createTmsProviderRoutes() {
         }
 
         return c.json({ job }, 200);
+      } catch (error) {
+        return tmsProviderLiveErrorResponse(c, error);
+      }
+    })
+    .get("/jobs/:encodedJobId/files", async (c) => {
+      if (!hasCapability(c.var.auth.membership.role, "jobs:read")) {
+        return c.json({ error: "forbidden" }, 403);
+      }
+
+      try {
+        const files = await listTmsProviderLiveJobFiles(
+          c.var.auth.organization.localOrganizationId,
+          c.req.param("encodedJobId"),
+          { actorUserId: c.var.auth.user.localUserId },
+        );
+        if (!files) {
+          return c.json({ error: "job_not_found" }, 404);
+        }
+
+        return c.json({ files }, 200);
+      } catch (error) {
+        return tmsProviderLiveErrorResponse(c, error);
+      }
+    })
+    .get("/jobs/:encodedJobId/files/detail", validateJobFileDetailQuery, async (c) => {
+      if (!hasCapability(c.var.auth.membership.role, "jobs:read")) {
+        return c.json({ error: "forbidden" }, 403);
+      }
+
+      const query = c.req.valid("query");
+
+      try {
+        const file = await getTmsProviderLiveJobFileDetail(
+          c.var.auth.organization.localOrganizationId,
+          c.req.param("encodedJobId"),
+          query.sourcePath,
+          { actorUserId: c.var.auth.user.localUserId },
+        );
+        if (!file) {
+          return c.json({ error: "file_not_found" }, 404);
+        }
+
+        return c.json({ file }, 200);
       } catch (error) {
         return tmsProviderLiveErrorResponse(c, error);
       }

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/_components/provider-crowdin-job-detail-rows.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/_components/provider-crowdin-job-detail-rows.tsx
@@ -6,7 +6,6 @@ import {
   formatLocaleList,
   formatReadinessProgress,
   formatWordsToDo,
-  getCrowdinFileCount,
   getCrowdinLanguageLabel,
   getCrowdinLocaleReadiness,
   getCrowdinTargetLocales,
@@ -69,7 +68,6 @@ export function ProviderCrowdinJobDetailRows<J extends CrowdinJobDetailSource>({
   const crowdinDescription = isCrowdin
     ? getProviderPayloadString(providerPayload, "description")
     : null;
-  const crowdinFileCount = isCrowdin ? getCrowdinFileCount(providerPayload) : null;
   const crowdinLocaleReadiness = isCrowdin ? getCrowdinLocaleReadiness(providerPayload) : null;
   const crowdinProgress = formatReadinessProgress(crowdinLocaleReadiness);
   const crowdinWordsToDo = formatWordsToDo(crowdinLocaleReadiness);
@@ -105,12 +103,6 @@ export function ProviderCrowdinJobDetailRows<J extends CrowdinJobDetailSource>({
             )}
           </dd>
         </div>
-      ) : null}
-      {crowdinFileCount !== null ? (
-        <JobDetailRow
-          label="Resources"
-          value={`${crowdinFileCount} file${crowdinFileCount === 1 ? "" : "s"}`}
-        />
       ) : null}
       {crowdinProgress ? <JobDetailRow label="Progress" value={crowdinProgress} /> : null}
       {crowdinWordsToDo ? <JobDetailRow label="Words to do" value={crowdinWordsToDo} /> : null}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-detail-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-detail-panel.tsx
@@ -27,8 +27,11 @@ function projectFileDetailQueryKey(
   organizationSlug: string,
   projectId: string,
   sourcePath: string,
+  encodedJobId?: string | null,
 ) {
-  return ["project-file-detail", organizationSlug, projectId, sourcePath] as const;
+  return encodedJobId
+    ? (["tms-provider-job-file-detail", organizationSlug, encodedJobId, sourcePath] as const)
+    : (["project-file-detail", organizationSlug, projectId, sourcePath] as const);
 }
 
 function formatBytes(bytes: number | null) {
@@ -87,6 +90,7 @@ export function ProjectFileDetailPanel({
   requestedSourcePath,
   highlightLocale,
   canFindInRepo,
+  encodedJobId,
 }: {
   organizationSlug: string;
   projectId: string;
@@ -94,13 +98,35 @@ export function ProjectFileDetailPanel({
   requestedSourcePath: string | null;
   highlightLocale: string | null;
   canFindInRepo: boolean;
+  encodedJobId?: string | null;
 }) {
   const sourcePath = file?.sourcePath ?? null;
 
   const detailQuery = useQuery({
-    queryKey: projectFileDetailQueryKey(organizationSlug, projectId, sourcePath ?? ""),
+    queryKey: projectFileDetailQueryKey(
+      organizationSlug,
+      projectId,
+      sourcePath ?? "",
+      encodedJobId,
+    ),
     enabled: Boolean(sourcePath),
     queryFn: async () => {
+      if (encodedJobId) {
+        const response = await apiClient.api.orgs[":organizationSlug"]["tms-provider"].jobs[
+          ":encodedJobId"
+        ].files.detail.$get({
+          param: { organizationSlug, encodedJobId },
+          query: { sourcePath: sourcePath as string },
+        });
+
+        if (!response.ok) {
+          throw new Error(await readApiError(response, "Failed to load file details"));
+        }
+
+        const body = (await response.json()) as ProjectFileDetailResponse;
+        return body.file;
+      }
+
       const response = await apiClient.api.orgs[":organizationSlug"].projects[
         ":projectId"
       ].files.detail.$get({

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-provider-detail-section.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-provider-detail-section.tsx
@@ -36,6 +36,7 @@ import {
 } from "../../../../../jobs/_components/provider-crowdin-job-display";
 import { JobAgentRunDiffReviewSection } from "./job-agent-run-diff-review-section";
 import { JobQaFindingsSection } from "./job-qa-findings-section";
+import { SyncedJobSourceFilesSection } from "./tms/synced-job-source-files-section";
 
 export type ProviderSourceFile = {
   id: string;
@@ -290,42 +291,15 @@ export function JobProviderDetailSection({
         </dl>
       </section>
 
-      <section className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
-        <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
-          Source Files
-        </TypographyH2>
-        {sourceFiles.length > 0 ? (
-          <ul className="mt-4 space-y-2">
-            {sourceFiles.map((file) => (
-              <li
-                key={file.id}
-                className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-foreground/8 bg-foreground/3.5 px-3 py-2 text-sm"
-              >
-                <div className="min-w-0">
-                  <p className="font-medium text-foreground/82">{file.displayName}</p>
-                  {file.sourcePath ? (
-                    <p className="text-xs text-foreground/48">{file.sourcePath}</p>
-                  ) : null}
-                </div>
-                {file.externalUrl ? (
-                  <Link
-                    href={file.externalUrl}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="text-xs text-foreground/62 underline decoration-foreground/24 underline-offset-4 hover:text-foreground"
-                  >
-                    Open
-                  </Link>
-                ) : null}
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <p className="mt-4 text-sm text-foreground/48">
-            No synced source files linked to this job.
-          </p>
-        )}
-      </section>
+      {projectId ? (
+        <SyncedJobSourceFilesSection
+          organizationSlug={organizationSlug}
+          projectId={projectId}
+          providerKind={job.externalProviderKind}
+          sourceFiles={sourceFiles}
+          highlightLocale={job.externalTargetLocales?.[0] ?? null}
+        />
+      ) : null}
 
       {visibleActions.length > 0 ? (
         <section className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-content.tsx
@@ -22,6 +22,7 @@ import {
   JobDetailRow,
   ProviderCrowdinJobDetailRows,
 } from "../../../../../jobs/_components/provider-crowdin-job-detail-rows";
+import { TmsLiveJobFilesSection } from "./tms/tms-live-job-files-section";
 import {
   formatLocaleList,
   getCrowdinTargetLocales,
@@ -327,11 +328,23 @@ export function ProviderLiveJobDetailContent({
       ) : null}
 
       {job?.externalProviderKind === "crowdin" ? (
-        <TaskCommentsSection
-          comments={commentsQuery.data ?? []}
-          isError={commentsQuery.isError}
-          isLoading={commentsQuery.isLoading}
-        />
+        <>
+          <TmsLiveJobFilesSection
+            organizationSlug={organizationSlug}
+            projectId={projectId}
+            encodedJobId={jobId}
+            highlightLocale={
+              typeof job.externalProviderPayload.languageId === "string"
+                ? job.externalProviderPayload.languageId
+                : null
+            }
+          />
+          <TaskCommentsSection
+            comments={commentsQuery.data ?? []}
+            isError={commentsQuery.isError}
+            isLoading={commentsQuery.isLoading}
+          />
+        </>
       ) : null}
     </main>
   );

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/job-source-file-mappers.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/job-source-file-mappers.ts
@@ -36,7 +36,7 @@ export function providerSourceFileToProjectFileRecord(
     sourceHash: null,
     commitSha: null,
     workflowRunId: null,
-    uploadedAt: new Date().toISOString(),
+    uploadedAt: new Date(0).toISOString(),
     storedFileId: null,
     metadata: {},
     filename: file.displayName,

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/job-source-file-mappers.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/job-source-file-mappers.ts
@@ -1,0 +1,60 @@
+import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
+import type { ExternalTmsProviderKind } from "@/lib/providers/contracts/external-tms-provider-kind";
+import type { TmsProviderLiveFile } from "@/lib/providers/tms-provider-live";
+
+import type { ProviderSourceFile } from "../job-provider-detail-section";
+
+export function tmsLiveFileToProjectFileRecord(file: TmsProviderLiveFile): ProjectFileRecord {
+  return {
+    origin: file.origin,
+    sourcePath: file.sourcePath,
+    sourceHash: file.sourceHash,
+    commitSha: file.commitSha,
+    workflowRunId: file.workflowRunId,
+    uploadedAt: file.uploadedAt,
+    storedFileId: file.storedFileId,
+    metadata: file.metadata,
+    filename: file.filename,
+    byteSize: file.byteSize,
+    provider: file.provider,
+    latestJob: file.latestJob,
+  };
+}
+
+export function providerSourceFileToProjectFileRecord(
+  file: ProviderSourceFile,
+  providerKind: string,
+  externalProjectId: string,
+): ProjectFileRecord | null {
+  if (!file.sourcePath) {
+    return null;
+  }
+
+  return {
+    origin: "provider",
+    sourcePath: file.sourcePath,
+    sourceHash: null,
+    commitSha: null,
+    workflowRunId: null,
+    uploadedAt: new Date().toISOString(),
+    storedFileId: null,
+    metadata: {},
+    filename: file.displayName,
+    byteSize: null,
+    provider: {
+      kind: providerKind as ExternalTmsProviderKind,
+      resourceType: (file.resourceType ?? "file") as "file" | "key",
+      externalProjectId,
+      externalResourceId: file.id,
+      externalUrl: file.externalUrl,
+      syncState: "synced",
+      sourceLocale: null,
+      targetLocales: [],
+      localeReadiness: {},
+      revision: null,
+      format: null,
+      lastSyncedAt: null,
+    },
+    latestJob: null,
+  };
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/job-source-files-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/job-source-files-panel.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
+import { Skeleton } from "@/components/ui/skeleton";
+import { TypographyH2 } from "@/components/ui/typography";
+import { cn } from "@/lib/primitives/cn";
+
+import { ProjectFileDetailPanel } from "../../../../files/_components/project-file-detail-panel";
+
+function sortFilesByPath(files: ProjectFileRecord[]) {
+  return [...files].toSorted((a, b) =>
+    a.sourcePath.localeCompare(b.sourcePath, undefined, { sensitivity: "base" }),
+  );
+}
+
+export function JobSourceFilesPanel({
+  organizationSlug,
+  projectId,
+  encodedJobId,
+  files,
+  isLoading,
+  isError,
+  errorMessage,
+  emptyMessage = "No source files linked to this job.",
+  canFindInRepo = false,
+  highlightLocale = null,
+}: {
+  organizationSlug: string;
+  projectId: string;
+  encodedJobId?: string | null;
+  files: ProjectFileRecord[];
+  isLoading?: boolean;
+  isError?: boolean;
+  errorMessage?: string;
+  emptyMessage?: string;
+  canFindInRepo?: boolean;
+  highlightLocale?: string | null;
+}) {
+  const sortedFiles = useMemo(() => sortFilesByPath(files), [files]);
+  const [selectedSourcePath, setSelectedSourcePath] = useState<string | null>(null);
+  const selectedFile =
+    sortedFiles.find((file) => file.sourcePath === selectedSourcePath) ?? sortedFiles[0] ?? null;
+  const activeSourcePath = selectedFile?.sourcePath ?? null;
+
+  return (
+    <section className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
+      <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
+        Source files
+      </TypographyH2>
+
+      {isLoading ? (
+        <div className="mt-4 space-y-3">
+          <Skeleton className="h-10 w-full bg-foreground/8" />
+          <Skeleton className="h-48 w-full bg-foreground/8" />
+        </div>
+      ) : null}
+
+      {isError ? (
+        <p className="mt-4 text-sm text-flame-100">
+          {errorMessage ?? "Unable to load source files."}
+        </p>
+      ) : null}
+
+      {!isLoading && !isError && sortedFiles.length === 0 ? (
+        <p className="mt-4 text-sm text-foreground/48">{emptyMessage}</p>
+      ) : null}
+
+      {!isLoading && !isError && sortedFiles.length > 0 ? (
+        <div className="mt-4 overflow-hidden rounded-lg border border-foreground/8 bg-background/40 lg:grid lg:grid-cols-[minmax(0,16rem)_minmax(0,1fr)]">
+          <ul className="max-h-[min(28rem,60vh)] divide-y divide-foreground/8 overflow-y-auto border-b border-foreground/8 lg:border-r lg:border-b-0">
+            {sortedFiles.map((file) => {
+              const isSelected = file.sourcePath === activeSourcePath;
+
+              return (
+                <li key={file.sourcePath}>
+                  <button
+                    type="button"
+                    onClick={() => setSelectedSourcePath(file.sourcePath)}
+                    className={cn(
+                      "flex w-full flex-col gap-1 px-3 py-2.5 text-left transition-colors hover:bg-foreground/4",
+                      isSelected && "bg-primary/8",
+                    )}
+                  >
+                    <span className="truncate text-sm font-medium text-foreground/82">
+                      {file.filename}
+                    </span>
+                    <span className="truncate font-mono text-xs text-foreground/48">
+                      {file.sourcePath}
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+
+          <div className="min-h-[min(20rem,50vh)] overflow-y-auto">
+            <ProjectFileDetailPanel
+              organizationSlug={organizationSlug}
+              projectId={projectId}
+              encodedJobId={encodedJobId}
+              file={selectedFile}
+              requestedSourcePath={activeSourcePath}
+              highlightLocale={highlightLocale}
+              canFindInRepo={canFindInRepo}
+            />
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/synced-job-source-files-section.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/synced-job-source-files-section.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { parseProviderProjectId } from "@/lib/providers/tms-provider-resource-id";
+
+import type { ProviderSourceFile } from "../job-provider-detail-section";
+import { providerSourceFileToProjectFileRecord } from "./job-source-file-mappers";
+import { JobSourceFilesPanel } from "./job-source-files-panel";
+
+export function SyncedJobSourceFilesSection({
+  organizationSlug,
+  projectId,
+  providerKind,
+  sourceFiles,
+  highlightLocale,
+}: {
+  organizationSlug: string;
+  projectId: string;
+  providerKind: string;
+  sourceFiles: ProviderSourceFile[];
+  highlightLocale?: string | null;
+}) {
+  const encodedProjectId = parseProviderProjectId(projectId);
+  const externalProjectId = encodedProjectId?.externalProjectId ?? projectId;
+
+  const files = useMemo(
+    () =>
+      sourceFiles.flatMap((file) => {
+        const record = providerSourceFileToProjectFileRecord(file, providerKind, externalProjectId);
+        return record ? [record] : [];
+      }),
+    [externalProjectId, providerKind, sourceFiles],
+  );
+
+  return (
+    <JobSourceFilesPanel
+      organizationSlug={organizationSlug}
+      projectId={projectId}
+      files={files}
+      emptyMessage="No synced source files linked to this job."
+      canFindInRepo
+      highlightLocale={highlightLocale ?? null}
+    />
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/tms-live-job-files-section.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/tms-live-job-files-section.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { apiClient } from "@/lib/api-client-instance";
+import type { TmsProviderLiveFile } from "@/lib/providers/tms-provider-live";
+
+import { tmsLiveFileToProjectFileRecord } from "./job-source-file-mappers";
+import { JobSourceFilesPanel } from "./job-source-files-panel";
+
+function tmsLiveJobFilesQueryKey(organizationSlug: string, encodedJobId: string) {
+  return ["tms-provider-job-files", organizationSlug, encodedJobId] as const;
+}
+
+export function TmsLiveJobFilesSection({
+  organizationSlug,
+  projectId,
+  encodedJobId,
+  highlightLocale,
+}: {
+  organizationSlug: string;
+  projectId: string;
+  encodedJobId: string;
+  highlightLocale?: string | null;
+}) {
+  const filesQuery = useQuery({
+    queryKey: tmsLiveJobFilesQueryKey(organizationSlug, encodedJobId),
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"]["tms-provider"].jobs[
+        ":encodedJobId"
+      ].files.$get({
+        param: { organizationSlug, encodedJobId },
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to load task files (${response.status})`);
+      }
+
+      const body = (await response.json()) as { files: TmsProviderLiveFile[] };
+      return body.files;
+    },
+  });
+
+  const files = (filesQuery.data ?? []).map(tmsLiveFileToProjectFileRecord);
+
+  return (
+    <JobSourceFilesPanel
+      organizationSlug={organizationSlug}
+      projectId={projectId}
+      encodedJobId={encodedJobId}
+      files={files}
+      isLoading={filesQuery.isLoading}
+      isError={filesQuery.isError}
+      errorMessage={
+        filesQuery.error instanceof Error ? filesQuery.error.message : "Unable to load task files"
+      }
+      emptyMessage="No files are linked to this task."
+      highlightLocale={highlightLocale ?? null}
+    />
+  );
+}

--- a/apps/hyperlocalise-web/src/lib/providers/job-provider-source-files.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/job-provider-source-files.ts
@@ -4,7 +4,9 @@ import { db, schema } from "@/lib/database";
 
 import type { ExternalTmsProviderKind } from "./organization-external-tms-provider-credentials";
 
-function extractProviderFileIds(providerPayload: Record<string, unknown> | null | undefined) {
+export function extractProviderFileIds(
+  providerPayload: Record<string, unknown> | null | undefined,
+) {
   if (!providerPayload) return [];
 
   const fileIds = providerPayload.fileIds;

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
@@ -1049,21 +1049,11 @@ export async function listTmsProviderLiveFilesForProject(
     .map((file) => mapLiveFile({ providerKind: context.providerKind, externalProjectId, file }));
 }
 
-export async function getTmsProviderLiveFileDetail(
-  organizationId: string,
-  externalProjectId: string,
-  sourcePath: string,
-  options?: { actorUserId?: string | null },
+async function buildTmsProviderLiveFileDetail(
+  context: ActiveTmsProviderContext,
+  file: TmsProviderLiveFile,
 ): Promise<TmsProviderLiveFileDetail | null> {
-  const context = await loadActiveTmsProviderContext(organizationId, {
-    actorUserId: options?.actorUserId,
-  });
-  const files = await listTmsProviderLiveFilesForProject(organizationId, externalProjectId, {
-    context,
-    limit: 1000,
-  });
-  const file = files.find((item) => item.sourcePath === sourcePath);
-  if (!file?.provider) {
+  if (!file.provider) {
     return null;
   }
 
@@ -1071,7 +1061,7 @@ export async function getTmsProviderLiveFileDetail(
     file.provider.resourceType === "file"
       ? await downloadLiveProviderFileContent({
           context,
-          externalProjectId,
+          externalProjectId: file.provider.externalProjectId,
           externalResourceId: file.provider.externalResourceId,
           sourcePath: file.sourcePath,
         })
@@ -1103,6 +1093,27 @@ export async function getTmsProviderLiveFileDetail(
     jobsByLocale: [],
     providerJobsByLocale: [],
   };
+}
+
+export async function getTmsProviderLiveFileDetail(
+  organizationId: string,
+  externalProjectId: string,
+  sourcePath: string,
+  options?: { actorUserId?: string | null },
+): Promise<TmsProviderLiveFileDetail | null> {
+  const context = await loadActiveTmsProviderContext(organizationId, {
+    actorUserId: options?.actorUserId,
+  });
+  const files = await listTmsProviderLiveFilesForProject(organizationId, externalProjectId, {
+    context,
+    limit: 1000,
+  });
+  const file = files.find((item) => item.sourcePath === sourcePath);
+  if (!file) {
+    return null;
+  }
+
+  return buildTmsProviderLiveFileDetail(context, file);
 }
 
 export async function listTmsProviderLiveJobs(
@@ -1315,39 +1326,7 @@ export async function listTmsProviderLiveJobFiles(
 
   return resolved.fileIds.flatMap((fileId) => {
     const file = filesByResourceId.get(fileId);
-    if (file) {
-      return [file];
-    }
-
-    return [
-      {
-        origin: "provider" as const,
-        sourcePath: fileId,
-        sourceHash: null,
-        commitSha: null,
-        workflowRunId: null,
-        uploadedAt: new Date().toISOString(),
-        storedFileId: null,
-        metadata: {},
-        filename: fileId,
-        byteSize: null,
-        provider: {
-          kind: context.providerKind,
-          resourceType: "file" as const,
-          externalProjectId: resolved.externalProjectId,
-          externalResourceId: fileId,
-          externalUrl: null,
-          syncState: "unknown",
-          sourceLocale: null,
-          targetLocales: [],
-          localeReadiness: {},
-          revision: null,
-          format: null,
-          lastSyncedAt: null,
-        },
-        latestJob: null,
-      },
-    ];
+    return file ? [file] : [];
   });
 }
 
@@ -1367,17 +1346,11 @@ export async function getTmsProviderLiveJobFileDetail(
     return null;
   }
 
-  const parsed = parseProviderJobId(encodedJobId);
-  if (!parsed || !file.provider) {
-    return null;
-  }
+  const context = await loadActiveTmsProviderContext(organizationId, {
+    actorUserId: options?.actorUserId,
+  });
 
-  return getTmsProviderLiveFileDetail(
-    organizationId,
-    parsed.externalProjectId,
-    sourcePath,
-    options,
-  );
+  return buildTmsProviderLiveFileDetail(context, file);
 }
 
 export async function listTmsProviderLiveJobComments(

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
@@ -44,6 +44,7 @@ import {
   tmsProviderProjectFetchers,
   tmsProviderTranslationMemoryFetchers,
 } from "@/lib/providers/tms-provider-fetcher-registry";
+import { extractProviderFileIds } from "@/lib/providers/job-provider-source-files";
 import {
   encodeProviderJobId,
   encodeProviderProjectId,
@@ -1263,6 +1264,120 @@ export async function getTmsProviderLiveJobDetail(
     projectName: project.name,
     task,
   });
+}
+
+async function resolveTmsProviderLiveJobFileIds(
+  organizationId: string,
+  encodedJobId: string,
+  options?: { actorUserId?: string | null },
+): Promise<{ externalProjectId: string; fileIds: string[] } | null> {
+  const job = await getTmsProviderLiveJobDetail(organizationId, encodedJobId, options);
+  if (!job) {
+    return null;
+  }
+
+  const parsed = parseProviderJobId(encodedJobId);
+  if (!parsed) {
+    return null;
+  }
+
+  return {
+    externalProjectId: parsed.externalProjectId,
+    fileIds: extractProviderFileIds(job.externalProviderPayload),
+  };
+}
+
+export async function listTmsProviderLiveJobFiles(
+  organizationId: string,
+  encodedJobId: string,
+  options?: { actorUserId?: string | null },
+): Promise<TmsProviderLiveFile[] | null> {
+  const resolved = await resolveTmsProviderLiveJobFileIds(organizationId, encodedJobId, options);
+  if (!resolved) {
+    return null;
+  }
+
+  if (resolved.fileIds.length === 0) {
+    return [];
+  }
+
+  const context = await loadActiveTmsProviderContext(organizationId, {
+    actorUserId: options?.actorUserId,
+  });
+  const projectFiles = await listTmsProviderLiveFilesForProject(
+    organizationId,
+    resolved.externalProjectId,
+    { context, limit: 1000, actorUserId: options?.actorUserId },
+  );
+  const filesByResourceId = new Map(
+    projectFiles.map((file) => [file.provider?.externalResourceId ?? "", file]),
+  );
+
+  return resolved.fileIds.flatMap((fileId) => {
+    const file = filesByResourceId.get(fileId);
+    if (file) {
+      return [file];
+    }
+
+    return [
+      {
+        origin: "provider" as const,
+        sourcePath: fileId,
+        sourceHash: null,
+        commitSha: null,
+        workflowRunId: null,
+        uploadedAt: new Date().toISOString(),
+        storedFileId: null,
+        metadata: {},
+        filename: fileId,
+        byteSize: null,
+        provider: {
+          kind: context.providerKind,
+          resourceType: "file" as const,
+          externalProjectId: resolved.externalProjectId,
+          externalResourceId: fileId,
+          externalUrl: null,
+          syncState: "unknown",
+          sourceLocale: null,
+          targetLocales: [],
+          localeReadiness: {},
+          revision: null,
+          format: null,
+          lastSyncedAt: null,
+        },
+        latestJob: null,
+      },
+    ];
+  });
+}
+
+export async function getTmsProviderLiveJobFileDetail(
+  organizationId: string,
+  encodedJobId: string,
+  sourcePath: string,
+  options?: { actorUserId?: string | null },
+): Promise<TmsProviderLiveFileDetail | null> {
+  const files = await listTmsProviderLiveJobFiles(organizationId, encodedJobId, options);
+  if (!files) {
+    return null;
+  }
+
+  const file = files.find((item) => item.sourcePath === sourcePath);
+  if (!file) {
+    return null;
+  }
+
+  const parsed = parseProviderJobId(encodedJobId);
+  if (!parsed || !file.provider) {
+    return null;
+  }
+
+  return getTmsProviderLiveFileDetail(
+    organizationId,
+    parsed.externalProjectId,
+    sourcePath,
+    options,
+  );
 }
 
 export async function listTmsProviderLiveJobComments(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Crowdin job detail pages now show the files linked to a task, with a selectable file list and source content preview — reusing the same file detail components as the project files page.

## Changes

### API
- `GET /api/orgs/:slug/tms-provider/jobs/:encodedJobId/files` — lists files for a live provider job by resolving task `fileIds` against live project files
- `GET /api/orgs/:slug/tms-provider/jobs/:encodedJobId/files/detail?sourcePath=` — fetches file content scoped to the job
- Backend helpers: `listTmsProviderLiveJobFiles`, `getTmsProviderLiveJobFileDetail`
- Exported `extractProviderFileIds` for reuse across live and synced paths

### UI (`jobs/[jobId]/_components/tms/`)
- `JobSourceFilesPanel` — shared split-pane list + `ProjectFileDetailPanel` preview
- `TmsLiveJobFilesSection` — for live Crowdin tasks (shell mode)
- `SyncedJobSourceFilesSection` — for DB-synced provider jobs
- `ProjectFileDetailPanel` extended with optional `encodedJobId` to use job-scoped file detail API

### Integration
- Live Crowdin job detail shows the new files section
- Synced provider job detail replaces the plain file link list with the interactive panel
- Removed redundant "Resources: N files" count row from Crowdin metadata (files section is the source of truth)

### Review fixes
- **Double fetch**: `getTmsProviderLiveJobFileDetail` now builds detail from the already-resolved job file via `buildTmsProviderLiveFileDetail`, avoiding a second `listTmsProviderLiveFilesForProject` call
- **Stub files**: unresolved task file IDs are omitted from the list rather than shown as clickable entries that 404
- **Timestamps**: synced provider source files use epoch `uploadedAt` instead of render-time `new Date()`
- **Tests**: added `/files/detail` route tests for success, 404, 403, and invalid query

## Testing
- `vp check --fix` passes
- `tms-provider.route.test.ts`: 11/11 passing (includes new `/files/detail` tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41c9c60a-aaf0-4229-8324-4731dfb3508e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41c9c60a-aaf0-4229-8324-4731dfb3508e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

