### PR TITLE
refactor(web): make jobs components storybook friendly

### DIFF
--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.stories.tsx
@@ -1,0 +1,167 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect } from "storybook/test";
+
+import { JobsPageView, type JobRow } from "./jobs-page-view";
+
+const fixedNow = Date.UTC(2026, 5, 6, 12, 0, 0);
+
+function iso(offsetMs: number) {
+  return new Date(fixedNow + offsetMs).toISOString();
+}
+
+function createJob(overrides: Partial<JobRow>): JobRow {
+  return {
+    id: "job_001",
+    projectId: "project_website",
+    projectName: "Website",
+    createdByUserId: "user_001",
+    kind: "translation",
+    type: "file",
+    status: "running",
+    createdAt: iso(-3_600_000),
+    updatedAt: iso(-600_000),
+    completedAt: null,
+    workflowRunId: null,
+    lastError: null,
+    inputPayload: { sourceFileId: "marketing/home.json" },
+    outcomeKind: null,
+    outcomePayload: null,
+    reviewCriteria: null,
+    reviewTargetLocale: null,
+    syncConnectorKind: null,
+    syncDirection: null,
+    assetType: null,
+    assetOperation: null,
+    externalProviderKind: "crowdin",
+    externalTaskId: "CR-1204",
+    externalStatus: "in_progress",
+    externalTitle: "Translate marketing homepage",
+    externalDueDate: iso(86_400_000),
+    externalTargetLocales: ["fr-FR", "de-DE"],
+    externalAssignedUsers: ["Mina", "Otto"],
+    externalSyncState: "synced",
+    ...overrides,
+  };
+}
+
+const jobs: JobRow[] = [
+  createJob({ id: "job_translate_homepage", status: "running" }),
+  createJob({
+    id: "job_review_checkout",
+    kind: "review",
+    type: null,
+    status: "waiting_for_review",
+    externalTitle: "Review checkout strings",
+    externalTaskId: "CR-1205",
+    externalTargetLocales: ["ja-JP"],
+    externalAssignedUsers: ["Aiko"],
+    externalDueDate: iso(172_800_000),
+    updatedAt: iso(-1_800_000),
+  }),
+  createJob({
+    id: "job_sync_mobile",
+    kind: "sync",
+    type: null,
+    status: "succeeded",
+    projectId: "project_mobile",
+    projectName: "Mobile app",
+    externalProviderKind: null,
+    externalTaskId: null,
+    externalTitle: null,
+    externalTargetLocales: null,
+    externalAssignedUsers: null,
+    syncConnectorKind: "crowdin",
+    syncDirection: "pull",
+    updatedAt: iso(-7_200_000),
+  }),
+];
+
+const meta = {
+  title: "App/Jobs/Page",
+  component: JobsPageView,
+  parameters: {
+    layout: "fullscreen",
+  },
+} satisfies Meta<typeof JobsPageView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WorkspaceJobs: Story = {
+  args: {
+    organizationSlug: "acme",
+    jobs,
+    isLoading: false,
+    now: fixedNow,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("heading", { name: "Jobs" })).toBeInTheDocument();
+    await expect(canvas.getByText("Translate marketing homepage")).toBeInTheDocument();
+  },
+};
+
+export const MyJobs: Story = {
+  args: {
+    organizationSlug: "acme",
+    scope: "mine",
+    jobs: jobs.slice(0, 2),
+    isLoading: false,
+    now: fixedNow,
+  },
+};
+
+export const ProjectJobs: Story = {
+  args: {
+    organizationSlug: "acme",
+    projectId: "project_website",
+    jobs: jobs.slice(0, 2),
+    isLoading: false,
+    now: fixedNow,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    organizationSlug: "acme",
+    jobs: [],
+    isLoading: true,
+    now: fixedNow,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    organizationSlug: "acme",
+    jobs: [],
+    isLoading: false,
+    now: fixedNow,
+  },
+};
+
+export const GeneralError: Story = {
+  args: {
+    organizationSlug: "acme",
+    jobs,
+    isLoading: false,
+    error: new Error("The jobs API returned a 500."),
+    now: fixedNow,
+  },
+};
+
+export const TmsConnectionRequired: Story = {
+  args: {
+    organizationSlug: "acme",
+    jobs: [],
+    isLoading: false,
+    error: new Error("Crowdin needs a user connection."),
+    renderError: ({ error }) => (
+      <div>
+        <p className="text-sm font-medium text-flame-100">Connect Crowdin to view provider jobs.</p>
+        {error instanceof Error ? (
+          <p className="mt-1 text-xs text-foreground/42">{error.message}</p>
+        ) : null}
+      </div>
+    ),
+    now: fixedNow,
+  },
+};

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
@@ -85,10 +86,10 @@ export function JobsPageContent({
   projectId?: string;
 }) {
   const searchParams = useSearchParams();
-  const initialStatusFilter = readInitialStatusFilter(searchParams);
+  const [statusFilter, setStatusFilter] = useState(() => readInitialStatusFilter(searchParams));
 
   const jobsQuery = useQuery({
-    queryKey: ["jobs", organizationSlug, scope, initialStatusFilter, projectId ?? "workspace"],
+    queryKey: ["jobs", organizationSlug, scope, statusFilter, projectId ?? "workspace"],
     queryFn: async () => {
       if (projectId) {
         const response = await apiClient.api.orgs[":organizationSlug"].projects[
@@ -98,7 +99,7 @@ export function JobsPageContent({
           query: {
             limit: "100",
             mine: "false",
-            ...(initialStatusFilter === "all" ? {} : { status: initialStatusFilter }),
+            ...(statusFilter === "all" ? {} : { status: statusFilter }),
           },
         });
         if (!response.ok) throw await readApiResponseError(response, "Failed to load jobs");
@@ -111,7 +112,7 @@ export function JobsPageContent({
         query: {
           limit: "100",
           mine: scope === "mine" ? "true" : "false",
-          ...(initialStatusFilter === "all" ? {} : { status: initialStatusFilter }),
+          ...(statusFilter === "all" ? {} : { status: statusFilter }),
         },
       });
       if (!response.ok) throw await readApiResponseError(response, "Failed to load jobs");
@@ -123,14 +124,15 @@ export function JobsPageContent({
   return (
     <JobsPageView
       error={jobsQuery.error}
-      initialStatusFilter={initialStatusFilter}
       isLoading={jobsQuery.isLoading}
       jobs={jobsQuery.data ?? []}
+      onStatusFilterChange={setStatusFilter}
       organizationSlug={organizationSlug}
       projectId={projectId}
       renderError={renderProductionJobsError}
       renderJobLink={renderProductionJobLink}
       scope={scope}
+      statusFilter={statusFilter}
     />
   );
 }

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.tsx
@@ -1,360 +1,79 @@
 "use client";
 
-import { useId, useMemo, useState, type ReactNode } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
-import { SearchIcon, Task01Icon, WorkHistoryIcon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { useQuery } from "@tanstack/react-query";
 
 import { TmsUserConnectionErrorPanel } from "@/components/app-shell/tms-user-connection-prompt";
-import { isTmsUserConnectionRequiredError } from "@/lib/providers/tms-user-connection-shared";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Separator } from "@/components/ui/separator";
 import { apiClient } from "@/lib/api-client-instance";
 import { readApiResponseError } from "@/lib/api-error";
-import { cn } from "@/lib/primitives/cn";
+import { isTmsUserConnectionRequiredError } from "@/lib/providers/tms-user-connection-shared";
 
-import { formatLocaleList, getCrowdinTargetLocales } from "./provider-crowdin-job-display";
+import {
+  JobsPageErrorMessage,
+  JobsPageView,
+  jobsStatusOptions,
+  type ApiJob,
+  type JobRow,
+  type JobsErrorRenderer,
+  type JobsLinkRenderer,
+  type JobsScope,
+  type JobsStatusFilter,
+} from "./jobs-page-view";
 
 import {
   JOB_STATUS_FILTERS,
   readWorkspaceFilterParam,
 } from "../../_components/workspace-filter-params";
-import {
-  PageHeader,
-  WorkspacePageShell,
-  toneClass,
-  type Tone,
-} from "../../_components/workspace-resource-shared";
-import {
-  ProjectPageShell,
-  ProjectSectionHeader,
-} from "../../projects/[projectId]/_components/project-page-shell";
-import { TypographyP } from "@/components/ui/typography";
 
-type JobsScope = "all" | "mine";
-
-type ApiJob = {
-  id: string;
-  projectId: string | null;
-  createdByUserId: string | null;
-  kind: "translation" | "research" | "review" | "sync" | "asset_management";
-  type: "string" | "file" | null;
-  status: "queued" | "running" | "succeeded" | "failed" | "waiting_for_review" | "cancelled";
-  createdAt: string;
-  updatedAt: string;
-  completedAt: string | null;
-  workflowRunId: string | null;
-  lastError: string | null;
-  inputPayload: unknown;
-  outcomeKind: string | null;
-  outcomePayload: unknown;
-  reviewCriteria: string | null;
-  reviewTargetLocale: string | null;
-  syncConnectorKind: string | null;
-  syncDirection: string | null;
-  assetType: string | null;
-  assetOperation: string | null;
-  externalProviderKind: string | null;
-  externalTaskId: string | null;
-  externalStatus: string | null;
-  externalTitle: string | null;
-  externalDueDate: string | null;
-  externalTargetLocales: string[] | null;
-  externalAssignedUsers: string[] | null;
-  externalSyncState: string | null;
-};
-
-type JobRow = ApiJob & {
-  projectName: string | null;
-};
-
-const statusOptions = [
-  "all",
-  "queued",
-  "running",
-  "succeeded",
-  "failed",
-  "waiting_for_review",
-  "cancelled",
-] as const;
-
-const statusFilterLabels = {
-  all: "All status",
-  queued: "Queued",
-  running: "Running",
-  succeeded: "Succeeded",
-  failed: "Failed",
-  waiting_for_review: "Waiting for review",
-  cancelled: "Cancelled",
-} as const satisfies Record<(typeof statusOptions)[number], string>;
-
-const jobsFilterTriggerClassName =
-  "h-9 min-h-9 w-full border-foreground/14 bg-transparent px-3 text-sm text-foreground data-[size=default]:h-9";
-
-const jobsFilterSelectContentClassName =
-  "w-max min-w-[var(--anchor-width)] max-w-[min(16rem,calc(100vw-2rem))]";
-
-const jobsTableGridClassName =
-  "grid grid-cols-[minmax(13rem,1.35fr)_7.5rem_minmax(8rem,0.8fr)_7.5rem_minmax(10rem,1fr)_5.5rem] gap-3";
-
-function JobsFilterField({
-  label,
-  className,
-  children,
-}: {
-  label: string;
-  className?: string;
-  children: ReactNode;
-}) {
-  return (
-    <div className={cn("grid gap-1.5", className)}>
-      <span className="text-xs font-medium text-muted-foreground">{label}</span>
-      {children}
-    </div>
-  );
+function readInitialStatusFilter(searchParams: URLSearchParams): JobsStatusFilter {
+  const status = readWorkspaceFilterParam(searchParams, "status", JOB_STATUS_FILTERS);
+  return (jobsStatusOptions as readonly string[]).includes(status)
+    ? (status as JobsStatusFilter)
+    : "all";
 }
 
-function jobTone(status: ApiJob["status"]): Tone {
-  switch (status) {
-    case "succeeded":
-      return "safe";
-    case "failed":
-      return "risk";
-    case "queued":
-    case "waiting_for_review":
-      return "watch";
-    default:
-      return "info";
-  }
-}
-
-const RELATIVE_TIME_FORMATTER = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
-
-function formatRelativeTime(value: string | null) {
-  if (!value) return "—";
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return value;
-  const deltaSeconds = Math.round((date.getTime() - Date.now()) / 1000);
-  const absoluteSeconds = Math.abs(deltaSeconds);
-  if (absoluteSeconds < 60) return RELATIVE_TIME_FORMATTER.format(deltaSeconds, "second");
-  if (absoluteSeconds < 3_600)
-    return RELATIVE_TIME_FORMATTER.format(Math.round(deltaSeconds / 60), "minute");
-  if (absoluteSeconds < 86_400)
-    return RELATIVE_TIME_FORMATTER.format(Math.round(deltaSeconds / 3_600), "hour");
-  if (absoluteSeconds < 2_592_000)
-    return RELATIVE_TIME_FORMATTER.format(Math.round(deltaSeconds / 86_400), "day");
-  if (absoluteSeconds < 31_536_000)
-    return RELATIVE_TIME_FORMATTER.format(Math.round(deltaSeconds / 2_592_000), "month");
-  return RELATIVE_TIME_FORMATTER.format(Math.round(deltaSeconds / 31_536_000), "year");
-}
-
-function sourceLabel(job: ApiJob) {
-  return job.externalProviderKind ? `Provider · ${job.externalProviderKind}` : "Native";
-}
-
-function targetLocales(job: ApiJob) {
-  if (job.externalTargetLocales?.length) return job.externalTargetLocales.join(", ");
-  if (job.reviewTargetLocale) return job.reviewTargetLocale;
-  return "—";
-}
-
-function assignees(job: ApiJob) {
-  if (job.externalAssignedUsers?.length) return job.externalAssignedUsers.join(", ");
-  return "—";
-}
-
-function formatJobName(value: string) {
-  return value.slice(0, 72);
-}
-
-function getInputPayloadString(job: ApiJob, key: string) {
-  if (typeof job.inputPayload !== "object" || !job.inputPayload || !(key in job.inputPayload)) {
-    return null;
-  }
-  const value = (job.inputPayload as Record<string, unknown>)[key];
-  return typeof value === "string" && value.length > 0 ? value : null;
-}
-
-function getJobName(job: ApiJob) {
-  if (job.externalTitle) return formatJobName(job.externalTitle);
-  if (job.kind === "review" && job.reviewCriteria)
-    return formatJobName(`Review: ${job.reviewCriteria}`);
-  if (job.kind === "sync" && job.syncConnectorKind)
-    return formatJobName(`${job.syncDirection ?? "sync"} ${job.syncConnectorKind}`);
-  if (job.kind === "asset_management" && job.assetType)
-    return formatJobName(`${job.assetOperation ?? "manage"} ${job.assetType}`);
-  const researchScope = getInputPayloadString(job, "scope");
-  if (job.kind === "research" && researchScope) return formatJobName(`Research: ${researchScope}`);
-  const sourceText = getInputPayloadString(job, "sourceText");
-  if (sourceText) return formatJobName(sourceText);
-  const sourceFileId = getInputPayloadString(job, "sourceFileId");
-  if (sourceFileId) return formatJobName(sourceFileId);
-  return job.id;
-}
-
-function formatJobKind(job: ApiJob) {
-  if (job.kind === "translation" && job.type) return `${job.kind.replace("_", " ")} · ${job.type}`;
-  return job.kind.replace("_", " ");
-}
-
-function taskDetailSummary(job: ApiJob) {
-  const fallbackTargetLocales = job.externalTargetLocales?.length
-    ? job.externalTargetLocales
-    : job.reviewTargetLocale
-      ? [job.reviewTargetLocale]
-      : [];
-  const locales = formatLocaleList(getCrowdinTargetLocales(null, fallbackTargetLocales));
-  const people = assignees(job);
-  if (locales === "—" && people === "—") return "No locales or assignees";
-  if (locales === "—") return people;
-  if (people === "—") return locales;
-  return `${locales} · ${people}`;
-}
-
-function JobsList({
-  emptyLabel,
-  isLoading,
-  jobs,
-  organizationSlug,
-  projectId,
-}: {
-  emptyLabel: string;
-  isLoading: boolean;
-  jobs: JobRow[];
-  organizationSlug: string;
-  projectId?: string;
-}) {
-  if (isLoading)
+function renderProductionJobLink({ href, kind, children }: Parameters<JobsLinkRenderer>[0]) {
+  if (kind === "title") {
     return (
-      <TypographyP className="px-3 py-8 text-sm text-foreground/58">Loading jobs…</TypographyP>
+      <Button
+        nativeButton={false}
+        render={<Link href={href} />}
+        variant="ghost"
+        className="-mx-2 h-auto min-w-0 justify-start px-2 py-1 text-left hover:bg-foreground/6"
+      >
+        {children}
+      </Button>
     );
-  if (jobs.length === 0) {
-    return <TypographyP className="px-3 py-8 text-sm text-foreground/58">{emptyLabel}</TypographyP>;
   }
 
   return (
-    <>
-      <div className="overflow-x-auto">
-        <div className="min-w-[56rem]">
-          <div
-            className={cn(
-              jobsTableGridClassName,
-              "px-3 py-3 text-sm font-medium text-foreground/42",
-            )}
-          >
-            <TypographyP>Name</TypographyP>
-            <TypographyP>Source</TypographyP>
-            <TypographyP>Project</TypographyP>
-            <TypographyP>Status</TypographyP>
-            <TypographyP>Task details</TypographyP>
-            <span aria-hidden />
-          </div>
-          {jobs.map((job, index) => {
-            const detailHref = getJobDetailHref(
-              organizationSlug,
-              projectId ?? job.projectId,
-              job.id,
-            );
-
-            return (
-              <div key={job.id}>
-                <div className={cn(jobsTableGridClassName, "items-center px-3 py-3")}>
-                  {detailHref ? (
-                    <Button
-                      nativeButton={false}
-                      render={<Link href={detailHref} />}
-                      variant="ghost"
-                      className="-mx-2 h-auto min-w-0 justify-start px-2 py-1 text-left hover:bg-foreground/6"
-                    >
-                      <JobListItemTitle job={job} />
-                    </Button>
-                  ) : (
-                    <div className="min-w-0 px-0 py-1">
-                      <JobListItemTitle job={job} />
-                    </div>
-                  )}
-                  <Badge variant="outline" className="w-fit rounded-full">
-                    {sourceLabel(job)}
-                  </Badge>
-                  <TypographyP className="truncate text-sm text-foreground/58">
-                    {job.projectName ?? "Workspace"}
-                  </TypographyP>
-                  <Badge
-                    variant="outline"
-                    className={cn("w-fit rounded-full capitalize", toneClass(jobTone(job.status)))}
-                  >
-                    {job.status}
-                  </Badge>
-                  <div className="min-w-0">
-                    <TypographyP className="truncate text-sm text-foreground/68">
-                      {taskDetailSummary(job)}
-                    </TypographyP>
-                    <TypographyP className="mt-1 truncate text-xs text-foreground/38">
-                      Due {formatRelativeTime(job.externalDueDate)} · Synced{" "}
-                      {formatRelativeTime(job.updatedAt)}
-                    </TypographyP>
-                  </div>
-                  {detailHref ? (
-                    <Button
-                      nativeButton={false}
-                      render={<Link href={detailHref} />}
-                      variant="outline"
-                      size="sm"
-                      className="w-fit"
-                    >
-                      Details
-                    </Button>
-                  ) : (
-                    <Button variant="outline" size="sm" className="w-fit" disabled>
-                      Details
-                    </Button>
-                  )}
-                </div>
-                {index < jobs.length - 1 ? <Separator className="bg-foreground/8" /> : null}
-              </div>
-            );
-          })}
-        </div>
-      </div>
-    </>
+    <Button
+      nativeButton={false}
+      render={<Link href={href} />}
+      variant="outline"
+      size="sm"
+      className="w-fit"
+    >
+      {children}
+    </Button>
   );
 }
 
-function getJobDetailHref(
-  organizationSlug: string,
-  projectId: string | null | undefined,
-  jobId: string,
-) {
-  if (!projectId) {
-    return null;
+const renderProductionJobsError: JobsErrorRenderer = ({ error, organizationSlug }) => {
+  if (isTmsUserConnectionRequiredError(error)) {
+    return (
+      <TmsUserConnectionErrorPanel
+        organizationSlug={organizationSlug}
+        resource="jobs"
+        error={error}
+      />
+    );
   }
 
-  return `/org/${organizationSlug}/projects/${encodeURIComponent(projectId)}/jobs/${encodeURIComponent(jobId)}`;
-}
-
-function JobListItemTitle({ job }: { job: ApiJob }) {
-  return (
-    <span className="min-w-0">
-      <span className="block truncate text-base font-medium text-foreground">
-        {getJobName(job)}
-      </span>
-      <span className="mt-1 block truncate text-xs font-normal text-foreground/38">
-        {formatJobKind(job)} · {job.externalTaskId ?? job.id}
-      </span>
-    </span>
-  );
-}
+  return <JobsPageErrorMessage error={error} />;
+};
 
 export function JobsPageContent({
   organizationSlug,
@@ -366,17 +85,10 @@ export function JobsPageContent({
   projectId?: string;
 }) {
   const searchParams = useSearchParams();
-  const searchId = useId();
-  const [search, setSearch] = useState("");
-  const [statusFilter, setStatusFilter] = useState<(typeof statusOptions)[number]>(() => {
-    const status = readWorkspaceFilterParam(searchParams, "status", JOB_STATUS_FILTERS);
-    return (statusOptions as readonly string[]).includes(status)
-      ? (status as (typeof statusOptions)[number])
-      : "all";
-  });
+  const initialStatusFilter = readInitialStatusFilter(searchParams);
 
   const jobsQuery = useQuery({
-    queryKey: ["jobs", organizationSlug, scope, statusFilter, projectId ?? "workspace"],
+    queryKey: ["jobs", organizationSlug, scope, initialStatusFilter, projectId ?? "workspace"],
     queryFn: async () => {
       if (projectId) {
         const response = await apiClient.api.orgs[":organizationSlug"].projects[
@@ -386,7 +98,7 @@ export function JobsPageContent({
           query: {
             limit: "100",
             mine: "false",
-            ...(statusFilter === "all" ? {} : { status: statusFilter }),
+            ...(initialStatusFilter === "all" ? {} : { status: initialStatusFilter }),
           },
         });
         if (!response.ok) throw await readApiResponseError(response, "Failed to load jobs");
@@ -399,7 +111,7 @@ export function JobsPageContent({
         query: {
           limit: "100",
           mine: scope === "mine" ? "true" : "false",
-          ...(statusFilter === "all" ? {} : { status: statusFilter }),
+          ...(initialStatusFilter === "all" ? {} : { status: initialStatusFilter }),
         },
       });
       if (!response.ok) throw await readApiResponseError(response, "Failed to load jobs");
@@ -408,134 +120,17 @@ export function JobsPageContent({
     },
   });
 
-  const jobs = jobsQuery.data ?? [];
-  const visibleJobs = useMemo(() => {
-    const normalizedSearch = search.trim().toLowerCase();
-    return jobs.filter((job) => {
-      const matchesStatus = statusFilter === "all" || job.status === statusFilter;
-      const matchesSearch =
-        !normalizedSearch ||
-        [
-          getJobName(job),
-          job.projectName,
-          job.id,
-          job.kind,
-          job.externalProviderKind,
-          job.externalStatus,
-          targetLocales(job),
-          assignees(job),
-        ]
-          .join(" ")
-          .toLowerCase()
-          .includes(normalizedSearch);
-      return matchesStatus && matchesSearch;
-    });
-  }, [jobs, search, statusFilter]);
-
-  const isMyWork = scope === "mine";
-  const emptyLabel = projectId
-    ? "No jobs found for this project."
-    : scope === "mine"
-      ? "No work items found for your account."
-      : "No jobs found for this workspace.";
-
-  const jobsSection = (
-    <section className="space-y-5">
-      <div className="flex flex-col gap-3 lg:flex-row lg:items-end">
-        <JobsFilterField label="Search" className="min-w-0 flex-1">
-          <div className="relative">
-            <HugeiconsIcon
-              icon={SearchIcon}
-              strokeWidth={2}
-              className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-foreground/42"
-            />
-            <Input
-              id={searchId}
-              value={search}
-              onChange={(event) => setSearch(event.target.value)}
-              placeholder="Jobs, providers, locales, assignees..."
-              className="h-9 border-foreground/14 bg-transparent pl-9 text-foreground placeholder:text-foreground/42"
-            />
-          </div>
-        </JobsFilterField>
-        <JobsFilterField label="Status" className="w-full lg:w-40">
-          <Select
-            value={statusFilter}
-            onValueChange={(value) =>
-              setStatusFilter((value ?? "all") as (typeof statusOptions)[number])
-            }
-          >
-            <SelectTrigger className={jobsFilterTriggerClassName}>
-              <SelectValue>{statusFilterLabels[statusFilter]}</SelectValue>
-            </SelectTrigger>
-            <SelectContent className={jobsFilterSelectContentClassName}>
-              {statusOptions.map((status) => (
-                <SelectItem key={status} value={status} label={statusFilterLabels[status]}>
-                  {statusFilterLabels[status]}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </JobsFilterField>
-      </div>
-      {jobsQuery.error ? (
-        <div>
-          {isTmsUserConnectionRequiredError(jobsQuery.error) ? (
-            <TmsUserConnectionErrorPanel
-              organizationSlug={organizationSlug}
-              resource="jobs"
-              error={jobsQuery.error}
-            />
-          ) : (
-            <>
-              <TypographyP className="text-sm font-medium text-flame-100">
-                Jobs failed to load.
-              </TypographyP>
-              <TypographyP className="mt-1 text-sm text-foreground/58">
-                {jobsQuery.error instanceof Error
-                  ? jobsQuery.error.message
-                  : "Failed to load jobs."}
-              </TypographyP>
-            </>
-          )}
-        </div>
-      ) : null}
-      <JobsList
-        emptyLabel={emptyLabel}
-        isLoading={jobsQuery.isLoading}
-        jobs={visibleJobs}
-        organizationSlug={organizationSlug}
-        projectId={projectId}
-      />
-    </section>
-  );
-
-  if (projectId) {
-    return (
-      <ProjectPageShell>
-        <ProjectSectionHeader
-          icon={Task01Icon}
-          section="Jobs"
-          description="Translation, review, QA, and sync work."
-        />
-        {jobsSection}
-      </ProjectPageShell>
-    );
-  }
-
   return (
-    <WorkspacePageShell>
-      <PageHeader
-        icon={isMyWork ? WorkHistoryIcon : Task01Icon}
-        label="Workspace"
-        title={isMyWork ? "My Jobs" : "Jobs"}
-        description={
-          isMyWork
-            ? "Translation, review, and sync work assigned to you across projects."
-            : "Translation, review, QA, and sync work tracked across the workspace."
-        }
-      />
-      {jobsSection}
-    </WorkspacePageShell>
+    <JobsPageView
+      error={jobsQuery.error}
+      initialStatusFilter={initialStatusFilter}
+      isLoading={jobsQuery.isLoading}
+      jobs={jobsQuery.data ?? []}
+      organizationSlug={organizationSlug}
+      projectId={projectId}
+      renderError={renderProductionJobsError}
+      renderJobLink={renderProductionJobLink}
+      scope={scope}
+    />
   );
 }

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-view.tsx
@@ -1,0 +1,528 @@
+"use client";
+
+import { useId, useMemo, useState, type ReactNode } from "react";
+import { SearchIcon, Task01Icon, WorkHistoryIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
+import { TypographyP } from "@/components/ui/typography";
+import { cn } from "@/lib/primitives/cn";
+
+import { formatLocaleList, getCrowdinTargetLocales } from "./provider-crowdin-job-display";
+
+import {
+  PageHeader,
+  WorkspacePageShell,
+  toneClass,
+  type Tone,
+} from "../../_components/workspace-resource-shared";
+import {
+  ProjectPageShell,
+  ProjectSectionHeader,
+} from "../../projects/[projectId]/_components/project-page-shell";
+
+export type JobsScope = "all" | "mine";
+
+export type ApiJob = {
+  id: string;
+  projectId: string | null;
+  createdByUserId: string | null;
+  kind: "translation" | "research" | "review" | "sync" | "asset_management";
+  type: "string" | "file" | null;
+  status: "queued" | "running" | "succeeded" | "failed" | "waiting_for_review" | "cancelled";
+  createdAt: string;
+  updatedAt: string;
+  completedAt: string | null;
+  workflowRunId: string | null;
+  lastError: string | null;
+  inputPayload: unknown;
+  outcomeKind: string | null;
+  outcomePayload: unknown;
+  reviewCriteria: string | null;
+  reviewTargetLocale: string | null;
+  syncConnectorKind: string | null;
+  syncDirection: string | null;
+  assetType: string | null;
+  assetOperation: string | null;
+  externalProviderKind: string | null;
+  externalTaskId: string | null;
+  externalStatus: string | null;
+  externalTitle: string | null;
+  externalDueDate: string | null;
+  externalTargetLocales: string[] | null;
+  externalAssignedUsers: string[] | null;
+  externalSyncState: string | null;
+};
+
+export type JobRow = ApiJob & {
+  projectName: string | null;
+};
+
+export const jobsStatusOptions = [
+  "all",
+  "queued",
+  "running",
+  "succeeded",
+  "failed",
+  "waiting_for_review",
+  "cancelled",
+] as const;
+
+export type JobsStatusFilter = (typeof jobsStatusOptions)[number];
+
+type JobLinkKind = "title" | "details";
+
+export type JobsLinkRenderer = (props: {
+  href: string;
+  kind: JobLinkKind;
+  children: ReactNode;
+}) => ReactNode;
+
+export type JobsErrorRenderer = (props: { error: unknown; organizationSlug: string }) => ReactNode;
+
+const statusFilterLabels = {
+  all: "All status",
+  queued: "Queued",
+  running: "Running",
+  succeeded: "Succeeded",
+  failed: "Failed",
+  waiting_for_review: "Waiting for review",
+  cancelled: "Cancelled",
+} as const satisfies Record<JobsStatusFilter, string>;
+
+const jobsFilterTriggerClassName =
+  "h-9 min-h-9 w-full border-foreground/14 bg-transparent px-3 text-sm text-foreground data-[size=default]:h-9";
+
+const jobsFilterSelectContentClassName =
+  "w-max min-w-[var(--anchor-width)] max-w-[min(16rem,calc(100vw-2rem))]";
+
+const jobsTableGridClassName =
+  "grid grid-cols-[minmax(13rem,1.35fr)_7.5rem_minmax(8rem,0.8fr)_7.5rem_minmax(10rem,1fr)_5.5rem] gap-3";
+
+function JobsFilterField({
+  label,
+  className,
+  children,
+}: {
+  label: string;
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className={cn("grid gap-1.5", className)}>
+      <span className="text-xs font-medium text-muted-foreground">{label}</span>
+      {children}
+    </div>
+  );
+}
+
+export function jobTone(status: ApiJob["status"]): Tone {
+  switch (status) {
+    case "succeeded":
+      return "safe";
+    case "failed":
+      return "risk";
+    case "queued":
+    case "waiting_for_review":
+      return "watch";
+    default:
+      return "info";
+  }
+}
+
+const RELATIVE_TIME_FORMATTER = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
+
+export function formatRelativeTime(value: string | null, now = Date.now()) {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  const deltaSeconds = Math.round((date.getTime() - now) / 1000);
+  const absoluteSeconds = Math.abs(deltaSeconds);
+  if (absoluteSeconds < 60) return RELATIVE_TIME_FORMATTER.format(deltaSeconds, "second");
+  if (absoluteSeconds < 3_600)
+    return RELATIVE_TIME_FORMATTER.format(Math.round(deltaSeconds / 60), "minute");
+  if (absoluteSeconds < 86_400)
+    return RELATIVE_TIME_FORMATTER.format(Math.round(deltaSeconds / 3_600), "hour");
+  if (absoluteSeconds < 2_592_000)
+    return RELATIVE_TIME_FORMATTER.format(Math.round(deltaSeconds / 86_400), "day");
+  if (absoluteSeconds < 31_536_000)
+    return RELATIVE_TIME_FORMATTER.format(Math.round(deltaSeconds / 2_592_000), "month");
+  return RELATIVE_TIME_FORMATTER.format(Math.round(deltaSeconds / 31_536_000), "year");
+}
+
+function sourceLabel(job: ApiJob) {
+  return job.externalProviderKind ? `Provider · ${job.externalProviderKind}` : "Native";
+}
+
+function targetLocales(job: ApiJob) {
+  if (job.externalTargetLocales?.length) return job.externalTargetLocales.join(", ");
+  if (job.reviewTargetLocale) return job.reviewTargetLocale;
+  return "—";
+}
+
+function assignees(job: ApiJob) {
+  if (job.externalAssignedUsers?.length) return job.externalAssignedUsers.join(", ");
+  return "—";
+}
+
+function formatJobName(value: string) {
+  return value.slice(0, 72);
+}
+
+function getInputPayloadString(job: ApiJob, key: string) {
+  if (typeof job.inputPayload !== "object" || !job.inputPayload || !(key in job.inputPayload)) {
+    return null;
+  }
+  const value = (job.inputPayload as Record<string, unknown>)[key];
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+export function getJobName(job: ApiJob) {
+  if (job.externalTitle) return formatJobName(job.externalTitle);
+  if (job.kind === "review" && job.reviewCriteria)
+    return formatJobName(`Review: ${job.reviewCriteria}`);
+  if (job.kind === "sync" && job.syncConnectorKind)
+    return formatJobName(`${job.syncDirection ?? "sync"} ${job.syncConnectorKind}`);
+  if (job.kind === "asset_management" && job.assetType)
+    return formatJobName(`${job.assetOperation ?? "manage"} ${job.assetType}`);
+  const researchScope = getInputPayloadString(job, "scope");
+  if (job.kind === "research" && researchScope) return formatJobName(`Research: ${researchScope}`);
+  const sourceText = getInputPayloadString(job, "sourceText");
+  if (sourceText) return formatJobName(sourceText);
+  const sourceFileId = getInputPayloadString(job, "sourceFileId");
+  if (sourceFileId) return formatJobName(sourceFileId);
+  return job.id;
+}
+
+function formatJobKind(job: ApiJob) {
+  if (job.kind === "translation" && job.type) return `${job.kind.replace("_", " ")} · ${job.type}`;
+  return job.kind.replace("_", " ");
+}
+
+export function taskDetailSummary(job: ApiJob) {
+  const fallbackTargetLocales = job.externalTargetLocales?.length
+    ? job.externalTargetLocales
+    : job.reviewTargetLocale
+      ? [job.reviewTargetLocale]
+      : [];
+  const locales = formatLocaleList(getCrowdinTargetLocales(null, fallbackTargetLocales));
+  const people = assignees(job);
+  if (locales === "—" && people === "—") return "No locales or assignees";
+  if (locales === "—") return people;
+  if (people === "—") return locales;
+  return `${locales} · ${people}`;
+}
+
+function defaultBuildJobDetailHref(
+  organizationSlug: string,
+  projectId: string | null | undefined,
+  jobId: string,
+) {
+  if (!projectId) {
+    return null;
+  }
+
+  return `/org/${organizationSlug}/projects/${encodeURIComponent(projectId)}/jobs/${encodeURIComponent(jobId)}`;
+}
+
+function defaultRenderJobLink({ href, kind, children }: Parameters<JobsLinkRenderer>[0]) {
+  if (kind === "title") {
+    return (
+      <Button
+        nativeButton={false}
+        render={<a href={href} />}
+        variant="ghost"
+        className="-mx-2 h-auto min-w-0 justify-start px-2 py-1 text-left hover:bg-foreground/6"
+      >
+        {children}
+      </Button>
+    );
+  }
+
+  return (
+    <Button
+      nativeButton={false}
+      render={<a href={href} />}
+      variant="outline"
+      size="sm"
+      className="w-fit"
+    >
+      {children}
+    </Button>
+  );
+}
+
+export function JobsPageErrorMessage({ error }: { error: unknown }) {
+  return (
+    <>
+      <TypographyP className="text-sm font-medium text-flame-100">Jobs failed to load.</TypographyP>
+      <TypographyP className="mt-1 text-sm text-foreground/58">
+        {error instanceof Error ? error.message : "Failed to load jobs."}
+      </TypographyP>
+    </>
+  );
+}
+
+function JobsList({
+  buildJobDetailHref,
+  emptyLabel,
+  isLoading,
+  jobs,
+  now,
+  organizationSlug,
+  projectId,
+  renderJobLink,
+}: {
+  buildJobDetailHref: typeof defaultBuildJobDetailHref;
+  emptyLabel: string;
+  isLoading: boolean;
+  jobs: JobRow[];
+  now?: number;
+  organizationSlug: string;
+  projectId?: string;
+  renderJobLink: JobsLinkRenderer;
+}) {
+  if (isLoading)
+    return (
+      <TypographyP className="px-3 py-8 text-sm text-foreground/58">Loading jobs…</TypographyP>
+    );
+  if (jobs.length === 0) {
+    return <TypographyP className="px-3 py-8 text-sm text-foreground/58">{emptyLabel}</TypographyP>;
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <div className="min-w-[56rem]">
+        <div
+          className={cn(jobsTableGridClassName, "px-3 py-3 text-sm font-medium text-foreground/42")}
+        >
+          <TypographyP>Name</TypographyP>
+          <TypographyP>Source</TypographyP>
+          <TypographyP>Project</TypographyP>
+          <TypographyP>Status</TypographyP>
+          <TypographyP>Task details</TypographyP>
+          <span aria-hidden />
+        </div>
+        {jobs.map((job, index) => {
+          const detailHref = buildJobDetailHref(
+            organizationSlug,
+            projectId ?? job.projectId,
+            job.id,
+          );
+
+          return (
+            <div key={job.id}>
+              <div className={cn(jobsTableGridClassName, "items-center px-3 py-3")}>
+                {detailHref ? (
+                  renderJobLink({
+                    href: detailHref,
+                    kind: "title",
+                    children: <JobListItemTitle job={job} />,
+                  })
+                ) : (
+                  <div className="min-w-0 px-0 py-1">
+                    <JobListItemTitle job={job} />
+                  </div>
+                )}
+                <Badge variant="outline" className="w-fit rounded-full">
+                  {sourceLabel(job)}
+                </Badge>
+                <TypographyP className="truncate text-sm text-foreground/58">
+                  {job.projectName ?? "Workspace"}
+                </TypographyP>
+                <Badge
+                  variant="outline"
+                  className={cn("w-fit rounded-full capitalize", toneClass(jobTone(job.status)))}
+                >
+                  {job.status}
+                </Badge>
+                <div className="min-w-0">
+                  <TypographyP className="truncate text-sm text-foreground/68">
+                    {taskDetailSummary(job)}
+                  </TypographyP>
+                  <TypographyP className="mt-1 truncate text-xs text-foreground/38">
+                    Due {formatRelativeTime(job.externalDueDate, now)} · Synced{" "}
+                    {formatRelativeTime(job.updatedAt, now)}
+                  </TypographyP>
+                </div>
+                {detailHref ? (
+                  renderJobLink({ href: detailHref, kind: "details", children: "Details" })
+                ) : (
+                  <Button variant="outline" size="sm" className="w-fit" disabled>
+                    Details
+                  </Button>
+                )}
+              </div>
+              {index < jobs.length - 1 ? <Separator className="bg-foreground/8" /> : null}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function JobListItemTitle({ job }: { job: ApiJob }) {
+  return (
+    <span className="min-w-0">
+      <span className="block truncate text-base font-medium text-foreground">
+        {getJobName(job)}
+      </span>
+      <span className="mt-1 block truncate text-xs font-normal text-foreground/38">
+        {formatJobKind(job)} · {job.externalTaskId ?? job.id}
+      </span>
+    </span>
+  );
+}
+
+export function JobsPageView({
+  buildJobDetailHref = defaultBuildJobDetailHref,
+  error,
+  initialSearch = "",
+  initialStatusFilter = "all",
+  isLoading,
+  jobs,
+  now,
+  organizationSlug,
+  projectId,
+  renderError = ({ error: renderError }) => <JobsPageErrorMessage error={renderError} />,
+  renderJobLink = defaultRenderJobLink,
+  scope = "all",
+}: {
+  buildJobDetailHref?: typeof defaultBuildJobDetailHref;
+  error?: unknown;
+  initialSearch?: string;
+  initialStatusFilter?: JobsStatusFilter;
+  isLoading: boolean;
+  jobs: JobRow[];
+  now?: number;
+  organizationSlug: string;
+  projectId?: string;
+  renderError?: JobsErrorRenderer;
+  renderJobLink?: JobsLinkRenderer;
+  scope?: JobsScope;
+}) {
+  const searchId = useId();
+  const [search, setSearch] = useState(initialSearch);
+  const [statusFilter, setStatusFilter] = useState<JobsStatusFilter>(initialStatusFilter);
+
+  const visibleJobs = useMemo(() => {
+    const normalizedSearch = search.trim().toLowerCase();
+    return jobs.filter((job) => {
+      const matchesStatus = statusFilter === "all" || job.status === statusFilter;
+      const matchesSearch =
+        !normalizedSearch ||
+        [
+          getJobName(job),
+          job.projectName,
+          job.id,
+          job.kind,
+          job.externalProviderKind,
+          job.externalStatus,
+          targetLocales(job),
+          assignees(job),
+        ]
+          .join(" ")
+          .toLowerCase()
+          .includes(normalizedSearch);
+      return matchesStatus && matchesSearch;
+    });
+  }, [jobs, search, statusFilter]);
+
+  const isMyWork = scope === "mine";
+  const emptyLabel = projectId
+    ? "No jobs found for this project."
+    : scope === "mine"
+      ? "No work items found for your account."
+      : "No jobs found for this workspace.";
+
+  const jobsSection = (
+    <section className="space-y-5">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-end">
+        <JobsFilterField label="Search" className="min-w-0 flex-1">
+          <div className="relative">
+            <HugeiconsIcon
+              icon={SearchIcon}
+              strokeWidth={2}
+              className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-foreground/42"
+            />
+            <Input
+              id={searchId}
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Jobs, providers, locales, assignees..."
+              className="h-9 border-foreground/14 bg-transparent pl-9 text-foreground placeholder:text-foreground/42"
+            />
+          </div>
+        </JobsFilterField>
+        <JobsFilterField label="Status" className="w-full lg:w-40">
+          <Select
+            value={statusFilter}
+            onValueChange={(value) => setStatusFilter((value ?? "all") as JobsStatusFilter)}
+          >
+            <SelectTrigger className={jobsFilterTriggerClassName}>
+              <SelectValue>{statusFilterLabels[statusFilter]}</SelectValue>
+            </SelectTrigger>
+            <SelectContent className={jobsFilterSelectContentClassName}>
+              {jobsStatusOptions.map((status) => (
+                <SelectItem key={status} value={status} label={statusFilterLabels[status]}>
+                  {statusFilterLabels[status]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </JobsFilterField>
+      </div>
+      {error ? <div>{renderError({ error, organizationSlug })}</div> : null}
+      <JobsList
+        buildJobDetailHref={buildJobDetailHref}
+        emptyLabel={emptyLabel}
+        isLoading={isLoading}
+        jobs={visibleJobs}
+        now={now}
+        organizationSlug={organizationSlug}
+        projectId={projectId}
+        renderJobLink={renderJobLink}
+      />
+    </section>
+  );
+
+  if (projectId) {
+    return (
+      <ProjectPageShell>
+        <ProjectSectionHeader
+          icon={Task01Icon}
+          section="Jobs"
+          description="Translation, review, QA, and sync work."
+        />
+        {jobsSection}
+      </ProjectPageShell>
+    );
+  }
+
+  return (
+    <WorkspacePageShell>
+      <PageHeader
+        icon={isMyWork ? WorkHistoryIcon : Task01Icon}
+        label="Workspace"
+        title={isMyWork ? "My Jobs" : "Jobs"}
+        description={
+          isMyWork
+            ? "Translation, review, and sync work assigned to you across projects."
+            : "Translation, review, QA, and sync work tracked across the workspace."
+        }
+      />
+      {jobsSection}
+    </WorkspacePageShell>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-view.tsx
@@ -393,11 +393,13 @@ export function JobsPageView({
   isLoading,
   jobs,
   now,
+  onStatusFilterChange,
   organizationSlug,
   projectId,
-  renderError = ({ error: renderError }) => <JobsPageErrorMessage error={renderError} />,
+  renderError = ({ error }) => <JobsPageErrorMessage error={error} />,
   renderJobLink = defaultRenderJobLink,
   scope = "all",
+  statusFilter: controlledStatusFilter,
 }: {
   buildJobDetailHref?: typeof defaultBuildJobDetailHref;
   error?: unknown;
@@ -406,15 +408,19 @@ export function JobsPageView({
   isLoading: boolean;
   jobs: JobRow[];
   now?: number;
+  onStatusFilterChange?: (statusFilter: JobsStatusFilter) => void;
   organizationSlug: string;
   projectId?: string;
   renderError?: JobsErrorRenderer;
   renderJobLink?: JobsLinkRenderer;
   scope?: JobsScope;
+  statusFilter?: JobsStatusFilter;
 }) {
   const searchId = useId();
   const [search, setSearch] = useState(initialSearch);
-  const [statusFilter, setStatusFilter] = useState<JobsStatusFilter>(initialStatusFilter);
+  const [uncontrolledStatusFilter, setUncontrolledStatusFilter] =
+    useState<JobsStatusFilter>(initialStatusFilter);
+  const statusFilter = controlledStatusFilter ?? uncontrolledStatusFilter;
 
   const visibleJobs = useMemo(() => {
     const normalizedSearch = search.trim().toLowerCase();
@@ -468,7 +474,13 @@ export function JobsPageView({
         <JobsFilterField label="Status" className="w-full lg:w-40">
           <Select
             value={statusFilter}
-            onValueChange={(value) => setStatusFilter((value ?? "all") as JobsStatusFilter)}
+            onValueChange={(value) => {
+              const nextStatusFilter = (value ?? "all") as JobsStatusFilter;
+              if (controlledStatusFilter === undefined) {
+                setUncontrolledStatusFilter(nextStatusFilter);
+              }
+              onStatusFilterChange?.(nextStatusFilter);
+            }}
           >
             <SelectTrigger className={jobsFilterTriggerClassName}>
               <SelectValue>{statusFilterLabels[statusFilter]}</SelectValue>

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/_components/provider-crowdin-job-detail-rows.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/_components/provider-crowdin-job-detail-rows.stories.tsx
@@ -1,0 +1,113 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect } from "storybook/test";
+
+import {
+  JobDetailRow,
+  ProviderCrowdinJobDetailRows,
+  type CrowdinJobDetailSource,
+} from "./provider-crowdin-job-detail-rows";
+import { ProviderJobDescriptionFieldView } from "./provider-job-description-field";
+
+const job = {
+  id: "ext:crowdin:task:1204",
+  externalProviderKind: "crowdin",
+  externalTargetLocales: ["fr-FR", "de-DE"],
+  externalStatus: "in_progress",
+  status: "running",
+  projectName: "Website",
+  externalDueDate: "2026-06-08T12:00:00.000Z",
+  updatedAt: "2026-06-06T11:30:00.000Z",
+  externalJobId: "1204",
+  externalUrl: "https://crowdin.example/tasks/1204",
+  kind: "translation",
+  type: "file",
+} satisfies CrowdinJobDetailSource;
+
+const providerPayload = {
+  type: 0,
+  targetLanguageIds: ["fr-FR", "de-DE"],
+  languageId: "fr-FR",
+  description:
+    "Translate the launch campaign strings. Preserve product names and ICU placeholders.",
+  localeReadiness: {
+    translationProgress: 68,
+    approvalProgress: 24,
+    words: {
+      total: 2400,
+      translated: 1580,
+      approved: 520,
+    },
+  },
+};
+
+function formatJobKind(value: CrowdinJobDetailSource) {
+  return [value.kind, value.type].filter(Boolean).join(" · ");
+}
+
+function formatDateTime(value: string | null | undefined) {
+  if (!value) {
+    return "—";
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+const meta = {
+  title: "App/Jobs/Provider Crowdin Job Detail Rows",
+  component: ProviderCrowdinJobDetailRows,
+  render: (args) => (
+    <div className="max-w-3xl p-6">
+      <dl className="divide-y divide-foreground/8">
+        <ProviderCrowdinJobDetailRows
+          {...args}
+          renderDescriptionField={({ description, editable }) => (
+            <ProviderJobDescriptionFieldView
+              description={description}
+              editable={editable}
+              onSaveDescription={async (nextDescription) => nextDescription}
+            />
+          )}
+        />
+      </dl>
+    </div>
+  ),
+} satisfies Meta<typeof ProviderCrowdinJobDetailRows>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const CrowdinTask: Story = {
+  args: {
+    job,
+    providerPayload,
+    organizationSlug: "acme",
+    formatJobKind,
+    formatDateTime,
+    descriptionQueryKey: ["job", "acme", "project_website", "ext:crowdin:task:1204"],
+    canEditDescription: true,
+    extraRows: <JobDetailRow label="Internal owner" value="Localization team" />,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Translate by own translators")).toBeInTheDocument();
+    await expect(canvas.getByText("68% translated · 24% approved")).toBeInTheDocument();
+  },
+};
+
+export const NonCrowdinProvider: Story = {
+  args: {
+    job: {
+      ...job,
+      id: "job_native_001",
+      externalProviderKind: "phrase",
+      externalUrl: null,
+    },
+    providerPayload: null,
+    organizationSlug: "acme",
+    formatJobKind,
+    formatDateTime,
+    showProviderLink: false,
+  },
+};

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/_components/provider-crowdin-job-detail-rows.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/_components/provider-crowdin-job-detail-rows.tsx
@@ -38,6 +38,18 @@ export type CrowdinJobDetailSource = {
   type?: string | null;
 };
 
+export type ProviderJobDescriptionFieldRenderer = (props: {
+  organizationSlug: string;
+  encodedJobId: string;
+  description: string;
+  editable: boolean;
+  queryKey: readonly unknown[];
+}) => ReactNode;
+
+const renderProviderJobDescriptionField: ProviderJobDescriptionFieldRenderer = (props) => (
+  <ProviderJobDescriptionField {...props} />
+);
+
 export function ProviderCrowdinJobDetailRows<J extends CrowdinJobDetailSource>({
   job,
   providerPayload,
@@ -47,6 +59,7 @@ export function ProviderCrowdinJobDetailRows<J extends CrowdinJobDetailSource>({
   descriptionQueryKey,
   canEditDescription,
   showProviderLink = true,
+  renderDescriptionField = renderProviderJobDescriptionField,
   extraRows,
 }: {
   job: J;
@@ -57,6 +70,7 @@ export function ProviderCrowdinJobDetailRows<J extends CrowdinJobDetailSource>({
   descriptionQueryKey?: readonly unknown[];
   canEditDescription?: boolean;
   showProviderLink?: boolean;
+  renderDescriptionField?: ProviderJobDescriptionFieldRenderer;
   extraRows?: ReactNode;
 }) {
   const isCrowdin = job.externalProviderKind === "crowdin";
@@ -84,23 +98,15 @@ export function ProviderCrowdinJobDetailRows<J extends CrowdinJobDetailSource>({
         <div className="grid gap-1 py-3 sm:grid-cols-[9rem_minmax(0,1fr)] sm:gap-4">
           <dt className="text-sm text-foreground/42">Description</dt>
           <dd className="min-w-0">
-            {canEditDescription && canEditProviderDescription && descriptionQueryKey ? (
-              <ProviderJobDescriptionField
-                organizationSlug={organizationSlug}
-                encodedJobId={job.id}
-                description={crowdinDescription ?? ""}
-                editable
-                queryKey={descriptionQueryKey}
-              />
-            ) : (
-              <ProviderJobDescriptionField
-                organizationSlug={organizationSlug}
-                encodedJobId={job.id}
-                description={crowdinDescription ?? ""}
-                editable={false}
-                queryKey={descriptionQueryKey ?? []}
-              />
-            )}
+            {renderDescriptionField({
+              organizationSlug,
+              encodedJobId: job.id,
+              description: crowdinDescription ?? "",
+              editable: Boolean(
+                canEditDescription && canEditProviderDescription && descriptionQueryKey,
+              ),
+              queryKey: descriptionQueryKey ?? [],
+            })}
           </dd>
         </div>
       ) : null}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/_components/provider-job-description-field.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/_components/provider-job-description-field.stories.tsx
@@ -1,0 +1,95 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, userEvent } from "storybook/test";
+
+import { ProviderJobDescriptionFieldView } from "./provider-job-description-field";
+
+const description = [
+  "Translate the product launch page for the spring campaign.",
+  "",
+  "- Keep product names in English",
+  "- Use a friendly, concise tone",
+].join("\n");
+
+const meta = {
+  title: "App/Jobs/Provider Job Description Field",
+  component: ProviderJobDescriptionFieldView,
+  render: (args) => (
+    <div className="max-w-2xl p-6">
+      <ProviderJobDescriptionFieldView {...args} />
+    </div>
+  ),
+} satisfies Meta<typeof ProviderJobDescriptionFieldView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ReadOnlyEmpty: Story = {
+  args: {
+    description: "",
+    editable: false,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("No description")).toBeInTheDocument();
+  },
+};
+
+export const ReadOnlyMarkdown: Story = {
+  args: {
+    description,
+    editable: false,
+  },
+};
+
+export const EditablePreview: Story = {
+  args: {
+    description,
+    editable: true,
+    onSaveDescription: async (nextDescription) => nextDescription,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("button", { name: "Edit description" })).toBeInTheDocument();
+  },
+};
+
+export const EditingDirty: Story = {
+  args: {
+    description,
+    editable: true,
+    initialIsEditing: true,
+    initialDraft: `${description}\n\nPlease preserve placeholders like {userName}.`,
+    onSaveDescription: async (nextDescription) => nextDescription,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("button", { name: "Save description" })).toBeEnabled();
+  },
+};
+
+export const Saving: Story = {
+  args: {
+    description,
+    editable: true,
+    initialIsEditing: true,
+    initialDraft: `${description}\n\nSaving this revised brief.`,
+    isSaving: true,
+    onSaveDescription: async (nextDescription) => nextDescription,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("button", { name: "Saving…" })).toBeDisabled();
+  },
+};
+
+export const SaveError: Story = {
+  args: {
+    description,
+    editable: true,
+    initialIsEditing: true,
+    initialDraft: `${description}\n\nThis save will fail.`,
+    onSaveDescription: async () => {
+      throw new Error("Crowdin rejected the update.");
+    },
+  },
+  play: async ({ canvas }) => {
+    await userEvent.click(canvas.getByRole("button", { name: "Save description" }));
+    await expect(canvas.getByRole("button", { name: "Save description" })).toBeEnabled();
+  },
+};

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/_components/provider-job-description-field.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/jobs/_components/provider-job-description-field.tsx
@@ -13,79 +13,32 @@ import {
 import { Button } from "@/components/ui/button";
 import { apiClient } from "@/lib/api-client-instance";
 
-export function ProviderJobDescriptionField({
-  organizationSlug,
-  encodedJobId,
+export function ProviderJobDescriptionFieldView({
   description,
   editable,
-  queryKey,
+  initialDraft,
+  initialIsEditing = false,
+  isSaving = false,
+  onSaveDescription,
+  onSaveError,
 }: {
-  organizationSlug: string;
-  encodedJobId: string;
   description: string;
   editable: boolean;
-  queryKey: readonly unknown[];
+  initialDraft?: string;
+  initialIsEditing?: boolean;
+  isSaving?: boolean;
+  onSaveDescription?: (description: string) => Promise<string | void>;
+  onSaveError?: (error: unknown) => void;
 }) {
-  const queryClient = useQueryClient();
-  const [isEditing, setIsEditing] = useState(false);
+  const [isEditing, setIsEditing] = useState(initialIsEditing);
   const [draftState, setDraftState] = useState({
     baseDescription: description,
-    draft: description,
+    draft: initialDraft ?? description,
   });
   const draft = draftState.baseDescription === description ? draftState.draft : description;
   const isDirty = draft !== description;
-
-  const saveMutation = useMutation({
-    mutationFn: async () => {
-      const response = await apiClient.api.orgs[":organizationSlug"]["tms-provider"].jobs[
-        ":encodedJobId"
-      ].description.$patch({
-        param: { organizationSlug, encodedJobId },
-        json: { description: draft },
-      });
-
-      if (!response.ok) {
-        const body = (await response.json().catch(() => null)) as {
-          error?: string;
-          message?: string;
-        } | null;
-        throw new Error(
-          body?.message ?? body?.error ?? `Failed to save description (${response.status})`,
-        );
-      }
-
-      return response.json() as Promise<{
-        job: { externalProviderPayload?: Record<string, unknown> };
-      }>;
-    },
-    onSuccess: ({ job }) => {
-      const nextDescription =
-        typeof job.externalProviderPayload?.description === "string"
-          ? job.externalProviderPayload.description
-          : draft;
-
-      queryClient.setQueryData(queryKey, (current: unknown) => {
-        if (!current || typeof current !== "object" || Array.isArray(current)) {
-          return job;
-        }
-
-        const currentJob = current as { externalProviderPayload?: Record<string, unknown> };
-        return {
-          ...currentJob,
-          externalProviderPayload: {
-            ...currentJob.externalProviderPayload,
-            ...job.externalProviderPayload,
-          },
-        };
-      });
-      setDraftState({ baseDescription: nextDescription, draft: nextDescription });
-      setIsEditing(false);
-      toast.success("Description saved");
-    },
-    onError: (error) => {
-      toast.error(error instanceof Error ? error.message : "Failed to save description");
-    },
-  });
+  const [internalIsSaving, setInternalIsSaving] = useState(false);
+  const savePending = isSaving || internalIsSaving;
 
   if (!editable) {
     if (!description.trim()) {
@@ -132,20 +85,35 @@ export function ProviderJobDescriptionField({
         onChange={(nextDraft) => {
           setDraftState({ baseDescription: description, draft: nextDraft });
         }}
-        disabled={saveMutation.isPending}
+        disabled={savePending}
       />
       <div className="flex flex-wrap items-center gap-2">
         <Button
           size="sm"
-          disabled={!isDirty || saveMutation.isPending}
-          onClick={() => saveMutation.mutate()}
+          disabled={!isDirty || savePending || !onSaveDescription}
+          onClick={async () => {
+            if (!onSaveDescription) {
+              return;
+            }
+
+            setInternalIsSaving(true);
+            try {
+              const nextDescription = (await onSaveDescription(draft)) ?? draft;
+              setDraftState({ baseDescription: nextDescription, draft: nextDescription });
+              setIsEditing(false);
+            } catch (error) {
+              onSaveError?.(error);
+            } finally {
+              setInternalIsSaving(false);
+            }
+          }}
         >
-          {saveMutation.isPending ? "Saving…" : "Save description"}
+          {savePending ? "Saving…" : "Save description"}
         </Button>
         <Button
           size="sm"
           variant="outline"
-          disabled={!isDirty || saveMutation.isPending}
+          disabled={!isDirty || savePending}
           onClick={() => {
             setDraftState({ baseDescription: description, draft: description });
           }}
@@ -155,7 +123,7 @@ export function ProviderJobDescriptionField({
         <Button
           size="sm"
           variant="ghost"
-          disabled={saveMutation.isPending}
+          disabled={savePending}
           onClick={() => {
             setDraftState({ baseDescription: description, draft: description });
             setIsEditing(false);
@@ -165,5 +133,82 @@ export function ProviderJobDescriptionField({
         </Button>
       </div>
     </div>
+  );
+}
+
+export function ProviderJobDescriptionField({
+  organizationSlug,
+  encodedJobId,
+  description,
+  editable,
+  queryKey,
+}: {
+  organizationSlug: string;
+  encodedJobId: string;
+  description: string;
+  editable: boolean;
+  queryKey: readonly unknown[];
+}) {
+  const queryClient = useQueryClient();
+
+  const saveMutation = useMutation({
+    mutationFn: async (nextDraft: string) => {
+      const response = await apiClient.api.orgs[":organizationSlug"]["tms-provider"].jobs[
+        ":encodedJobId"
+      ].description.$patch({
+        param: { organizationSlug, encodedJobId },
+        json: { description: nextDraft },
+      });
+
+      if (!response.ok) {
+        const body = (await response.json().catch(() => null)) as {
+          error?: string;
+          message?: string;
+        } | null;
+        throw new Error(
+          body?.message ?? body?.error ?? `Failed to save description (${response.status})`,
+        );
+      }
+
+      const body = (await response.json()) as {
+        job: { externalProviderPayload?: Record<string, unknown> };
+      };
+      const nextDescription =
+        typeof body.job.externalProviderPayload?.description === "string"
+          ? body.job.externalProviderPayload.description
+          : nextDraft;
+
+      queryClient.setQueryData(queryKey, (current: unknown) => {
+        if (!current || typeof current !== "object" || Array.isArray(current)) {
+          return body.job;
+        }
+
+        const currentJob = current as { externalProviderPayload?: Record<string, unknown> };
+        return {
+          ...currentJob,
+          externalProviderPayload: {
+            ...currentJob.externalProviderPayload,
+            ...body.job.externalProviderPayload,
+          },
+        };
+      });
+
+      return nextDescription;
+    },
+    onSuccess: () => {
+      toast.success("Description saved");
+    },
+  });
+
+  return (
+    <ProviderJobDescriptionFieldView
+      description={description}
+      editable={editable}
+      isSaving={saveMutation.isPending}
+      onSaveDescription={(nextDescription) => saveMutation.mutateAsync(nextDescription)}
+      onSaveError={(error) => {
+        toast.error(error instanceof Error ? error.message : "Failed to save description");
+      }}
+    />
   );
 }


### PR DESCRIPTION
## What changed

- Split the jobs page into a production container and Storybook-friendly `JobsPageView` with injected link, error, and deterministic time dependencies.
- Extracted `ProviderJobDescriptionFieldView` with injected save behavior while keeping the production React Query/API wrapper.
- Added DI-based Storybook stories for jobs page states, provider description states, and Crowdin job detail rows.

## How to test

- `vp check --fix`
- `vp test`
- `vp run build-storybook`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)