### PR TITLE
🧪 Scout: Support array indices in ICU placeholders

### DIFF
--- a/internal/i18n/icuparser/invariant.go
+++ b/internal/i18n/icuparser/invariant.go
@@ -382,7 +382,7 @@ func isASCIIPlaceholderFirst(b byte) bool {
 }
 
 func isASCIIPlaceholderSubsequent(b byte) bool {
-	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '_' || b == '.' || b == '-' || b == '$'
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '_' || b == '.' || b == '-' || b == '$' || b == '[' || b == ']'
 }
 
 func isASCIIDigit(b byte) bool {
@@ -394,7 +394,7 @@ func isPlaceholderFirstRune(r rune) bool {
 }
 
 func isPlaceholderSubsequentRune(r rune) bool {
-	return unicode.IsLetter(r) || isASCIIDigitRune(r) || r == '_' || r == '.' || r == '-' || r == '$'
+	return unicode.IsLetter(r) || isASCIIDigitRune(r) || r == '_' || r == '.' || r == '-' || r == '$' || r == '[' || r == ']'
 }
 
 func isASCIIDigitRune(r rune) bool {

--- a/internal/i18n/icuparser/invariant.go
+++ b/internal/i18n/icuparser/invariant.go
@@ -353,10 +353,27 @@ func isPlaceholderName(s string) bool {
 				if !isASCIIPlaceholderFirst(ch) {
 					return false
 				}
-			} else {
-				if !isASCIIPlaceholderSubsequent(ch) {
+				i++
+				continue
+			}
+
+			// Support array index notation: items[0]
+			if ch == '[' {
+				i++
+				digitCount := 0
+				for i < len(s) && isASCIIDigit(s[i]) {
+					i++
+					digitCount++
+				}
+				if digitCount == 0 || i >= len(s) || s[i] != ']' {
 					return false
 				}
+				i++
+				continue
+			}
+
+			if !isASCIIPlaceholderSubsequent(ch) {
+				return false
 			}
 			i++
 			continue
@@ -382,7 +399,7 @@ func isASCIIPlaceholderFirst(b byte) bool {
 }
 
 func isASCIIPlaceholderSubsequent(b byte) bool {
-	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '_' || b == '.' || b == '-' || b == '$' || b == '[' || b == ']'
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '_' || b == '.' || b == '-' || b == '$'
 }
 
 func isASCIIDigit(b byte) bool {
@@ -394,7 +411,7 @@ func isPlaceholderFirstRune(r rune) bool {
 }
 
 func isPlaceholderSubsequentRune(r rune) bool {
-	return unicode.IsLetter(r) || isASCIIDigitRune(r) || r == '_' || r == '.' || r == '-' || r == '$' || r == '[' || r == ']'
+	return unicode.IsLetter(r) || isASCIIDigitRune(r) || r == '_' || r == '.' || r == '-' || r == '$'
 }
 
 func isASCIIDigitRune(r rune) bool {

--- a/internal/i18n/icuparser/invariant_test.go
+++ b/internal/i18n/icuparser/invariant_test.go
@@ -2,6 +2,7 @@ package icuparser
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -459,6 +460,16 @@ func TestPlaceholderWithArrayIndices(t *testing.T) {
 			msg:  "{data[0], plural, one {# item} other {# items}}",
 			want: []string{"data[0]"},
 		},
+		{
+			name: "moustache with array index",
+			msg:  "Hello {{items[0]}}",
+			want: []string{"items[0]"},
+		},
+		{
+			name: "moustache with nested array index",
+			msg:  "Value: {{nested.items[123].field}}",
+			want: []string{"nested.items[123].field"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -469,6 +480,52 @@ func TestPlaceholderWithArrayIndices(t *testing.T) {
 			}
 			if !SamePlaceholderSet(inv.Placeholders, tt.want) {
 				t.Errorf("got placeholders %v, want %v", inv.Placeholders, tt.want)
+			}
+		})
+	}
+}
+
+func TestPlaceholderWithMalformedArrayIndices(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  string
+	}{
+		{
+			name: "missing closing bracket",
+			msg:  "Hello {items[0}",
+		},
+		{
+			name: "missing opening bracket",
+			msg:  "Hello {items0]}",
+		},
+		{
+			name: "empty brackets",
+			msg:  "Hello {items[]}",
+		},
+		{
+			name: "non-digit in brackets",
+			msg:  "Hello {items[a]}",
+		},
+		{
+			name: "nested brackets",
+			msg:  "Hello {items[[0]]}",
+		},
+		{
+			name: "unclosed bracket in plural arg",
+			msg:  "{data[0, plural, one {# item} other {# items}}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inv, err := ParseInvariant(tt.msg)
+			// These should either fail parsing or not include the malformed string as a placeholder.
+			if err == nil {
+				for _, p := range inv.Placeholders {
+					if strings.Contains(p, "[") || strings.Contains(p, "]") {
+						t.Errorf("malformed placeholder %q was collected", p)
+					}
+				}
 			}
 		})
 	}

--- a/internal/i18n/icuparser/invariant_test.go
+++ b/internal/i18n/icuparser/invariant_test.go
@@ -438,6 +438,42 @@ func TestParseInvariantIncludesTypedBlocks(t *testing.T) {
 	}
 }
 
+func TestPlaceholderWithArrayIndices(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  string
+		want []string
+	}{
+		{
+			name: "placeholder with array index",
+			msg:  "Hello {items[0]}",
+			want: []string{"items[0]"},
+		},
+		{
+			name: "placeholder with nested array index",
+			msg:  "Value: {nested.items[123].field}",
+			want: []string{"nested.items[123].field"},
+		},
+		{
+			name: "plural with array index argument",
+			msg:  "{data[0], plural, one {# item} other {# items}}",
+			want: []string{"data[0]"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inv, err := ParseInvariant(tt.msg)
+			if err != nil {
+				t.Fatalf("ParseInvariant failed: %v", err)
+			}
+			if !SamePlaceholderSet(inv.Placeholders, tt.want) {
+				t.Errorf("got placeholders %v, want %v", inv.Placeholders, tt.want)
+			}
+		})
+	}
+}
+
 func TestCountPoundsComplexNesting(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
💡 What: Added support for array indices (e.g., `{items[0]}`) in ICU placeholders and added a regression test.
🎯 Why: Flattened JSON data often uses indexed keys, and the ICU parser was failing to recognize these as valid placeholders, leading to incomplete invariant extraction.
🧩 Scope: `internal/i18n/icuparser/invariant.go` and `internal/i18n/icuparser/invariant_test.go`.
✅ Verification: Ran `go test ./internal/i18n/icuparser/...` and verified all tests pass, including the new `TestPlaceholderWithArrayIndices`.
🛡️ Confidence: High. The change is narrow and specifically targets the validation logic for placeholder names.

---
*PR created automatically by Jules for task [7666540753325459650](https://jules.google.com/task/7666540753325459650) started by @cungminh2710*