### PR TITLE
feat(slack): track image assets for multi-turn localization

### DIFF
--- a/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
@@ -11,7 +11,7 @@ import {
   handleSubscribedMessage,
   wrapThreadPost,
 } from "./bot";
-import { getSlackRepositoryContextKey } from "./repository-session";
+import { getSlackRepositoryContextKey, type SlackBotThreadState } from "./repository-session";
 
 function createMockClassification(
   overrides: Partial<ConversationClassification> = {},
@@ -136,12 +136,24 @@ vi.mock("@/lib/agent-runtime/workspaces/repository-sandbox", () => ({
 }));
 
 vi.mock("@/lib/file-storage/records", () => ({
-  createStoredFile: vi.fn(async (input: { filename: string; contentType: string }) => ({
-    id: "file_123",
-    filename: input.filename,
-    contentType: input.contentType,
-    downloadUrl: null,
-    storageUrl: "https://files.example/file_123",
+  createStoredFile: vi.fn(
+    async (input: { filename: string; contentType: string; role?: string }) => ({
+      id: input.role === "output" ? "file_output_123" : "file_123",
+      filename: input.filename,
+      contentType: input.contentType,
+      downloadUrl: null,
+      storageUrl: "https://files.example/file_123",
+      storageKey: "organizations/org/files/file_123/banner.png",
+    }),
+  ),
+  getStoredFileContent: vi.fn(async () => ({
+    file: {
+      id: "file_123",
+      filename: "banner.png",
+      contentType: "image/png",
+      storageKey: "organizations/org/files/file_123/banner.png",
+    },
+    content: Buffer.from("source-image"),
   })),
 }));
 
@@ -206,7 +218,7 @@ vi.mock("@/lib/database", () => {
 
 import { generateText } from "ai";
 import { findSlackConnector, lookupMembership } from "@/lib/agents/slack/helpers";
-import { createStoredFile } from "@/lib/file-storage/records";
+import { createStoredFile, getStoredFileContent } from "@/lib/file-storage/records";
 import { regenerateImageFromAttachment } from "@/lib/agents/image-generation";
 import {
   addInteractionMessage,
@@ -1374,6 +1386,15 @@ describe("handleSubscribedMessage", () => {
         content: fileData,
       }),
     );
+    expect(createStoredFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        role: "source",
+        filename: "banner.png",
+        metadata: expect.objectContaining({
+          imageLocalizationSource: true,
+        }),
+      }),
+    );
     expect(generateText).toHaveBeenCalledOnce();
     expect(regenerateImageFromAttachment).toHaveBeenCalledWith(
       imageData,
@@ -1497,7 +1518,18 @@ describe("handleSubscribedMessage", () => {
 
     await handleSubscribedMessage(thread, message);
 
-    expect(createStoredFile).not.toHaveBeenCalled();
+    expect(createStoredFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        role: "source",
+        filename: "banner.png",
+      }),
+    );
+    expect(createStoredFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        role: "output",
+        filename: "banner-fr.webp",
+      }),
+    );
     expect(agentGenerateMock).not.toHaveBeenCalled();
     expect(posts).toEqual([
       { markdown: expect.stringContaining("brief.pdf") },
@@ -1645,6 +1677,189 @@ describe("handleSubscribedMessage", () => {
     expect(posts).toEqual([
       SLACK_PROCESSING_ACK_POST,
       expect.stringContaining("I need the target language"),
+    ]);
+    expect(createStoredFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        role: "source",
+        filename: "banner.png",
+        metadata: expect.objectContaining({
+          imageLocalizationSource: true,
+        }),
+      }),
+    );
+  });
+
+  it("localizes a stored image when the user replies with a target language", async () => {
+    const { thread, posts, getState } = createThread({
+      pendingSlackImageTask: {
+        sourceAssets: [
+          {
+            sourceFileId: "file_123",
+            filename: "banner.png",
+            contentType: "image/png",
+          },
+        ],
+      },
+      imageSourceAssets: [
+        {
+          sourceFileId: "file_123",
+          filename: "banner.png",
+          contentType: "image/png",
+          localizedOutputs: [],
+        },
+      ],
+    });
+    const generatedImage = Buffer.from("generated-image");
+    const message = createMessage({ text: "Localize to French" });
+
+    vi.mocked(findSlackConnector).mockResolvedValue({
+      id: "connector-123",
+      organizationId: "org-123",
+      enabled: true,
+    } as never);
+    vi.mocked(lookupMembership).mockResolvedValue({
+      role: "member",
+      localUserId: "user-123",
+    } as never);
+    vi.mocked(findInteractionBySourceThreadId).mockResolvedValue({
+      id: "interaction-123",
+      title: "Existing",
+      projectId: null,
+    } as never);
+    vi.mocked(addInteractionMessage).mockResolvedValue({ id: "msg-123" } as never);
+    vi.mocked(generateText).mockResolvedValueOnce({
+      output: {
+        targetLocale: "fr",
+        instructions: null,
+        confidence: 0.98,
+        missingFields: [],
+      },
+    } as never);
+    vi.mocked(regenerateImageFromAttachment).mockResolvedValueOnce({
+      image: generatedImage,
+      mimeType: "image/webp",
+      prompt: "prompt",
+    });
+
+    await handleSubscribedMessage(thread, message);
+
+    expect(getStoredFileContent).toHaveBeenCalledWith({
+      organizationId: "org-123",
+      projectId: null,
+      fileId: "file_123",
+    });
+    expect(regenerateImageFromAttachment).toHaveBeenCalledWith(
+      Buffer.from("source-image"),
+      "image/png",
+      expect.stringContaining("Target locale: fr"),
+    );
+    expect(createStoredFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        role: "output",
+        metadata: expect.objectContaining({
+          imageLocalizationOutput: true,
+          sourceFileId: "file_123",
+          targetLocale: "fr",
+        }),
+      }),
+    );
+    expect(agentGenerateMock).not.toHaveBeenCalled();
+    expect(posts).toEqual([
+      SLACK_PROCESSING_ACK_POST,
+      {
+        raw: expect.stringContaining("localized version of banner.png for fr"),
+        files: [
+          {
+            data: generatedImage,
+            filename: "banner-fr.webp",
+            mimeType: "image/webp",
+          },
+        ],
+      },
+    ]);
+    const state = getState() as SlackBotThreadState | null;
+    expect(state?.pendingSlackImageTask).toBeUndefined();
+    expect(state?.imageSourceAssets?.[0]?.localizedOutputs).toEqual([
+      expect.objectContaining({
+        fileId: "file_output_123",
+        targetLocale: "fr",
+      }),
+    ]);
+  });
+
+  it("re-localizes a stored image to another locale without a new upload", async () => {
+    const { thread, posts } = createThread({
+      imageSourceAssets: [
+        {
+          sourceFileId: "file_123",
+          filename: "banner.png",
+          contentType: "image/png",
+          localizedOutputs: [
+            {
+              fileId: "file_output_fr",
+              filename: "banner-fr.webp",
+              contentType: "image/webp",
+              targetLocale: "fr",
+              instructions: null,
+              createdAt: "2026-06-01T00:00:00.000Z",
+            },
+          ],
+        },
+      ],
+    });
+    const generatedImage = Buffer.from("generated-image-ja");
+    const message = createMessage({ text: "Now localize it to Japanese" });
+
+    vi.mocked(findSlackConnector).mockResolvedValue({
+      id: "connector-123",
+      organizationId: "org-123",
+      enabled: true,
+    } as never);
+    vi.mocked(lookupMembership).mockResolvedValue({
+      role: "member",
+      localUserId: "user-123",
+    } as never);
+    vi.mocked(findInteractionBySourceThreadId).mockResolvedValue({
+      id: "interaction-123",
+      title: "Existing",
+      projectId: null,
+    } as never);
+    vi.mocked(addInteractionMessage).mockResolvedValue({ id: "msg-123" } as never);
+    vi.mocked(generateText).mockResolvedValueOnce({
+      output: {
+        targetLocale: "ja",
+        instructions: null,
+        confidence: 0.98,
+        missingFields: [],
+      },
+    } as never);
+    vi.mocked(regenerateImageFromAttachment).mockResolvedValueOnce({
+      image: generatedImage,
+      mimeType: "image/webp",
+      prompt: "prompt",
+    });
+
+    await handleSubscribedMessage(thread, message);
+
+    expect(getStoredFileContent).toHaveBeenCalled();
+    expect(regenerateImageFromAttachment).toHaveBeenCalledWith(
+      Buffer.from("source-image"),
+      "image/png",
+      expect.stringContaining("Target locale: ja"),
+    );
+    expect(agentGenerateMock).not.toHaveBeenCalled();
+    expect(posts).toEqual([
+      SLACK_PROCESSING_ACK_POST,
+      {
+        raw: expect.stringContaining("localized version of banner.png for ja"),
+        files: [
+          {
+            data: generatedImage,
+            filename: "banner-ja.webp",
+            mimeType: "image/webp",
+          },
+        ],
+      },
     ]);
   });
 

--- a/apps/hyperlocalise-web/src/lib/agents/slack/bot.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/bot.ts
@@ -45,7 +45,12 @@ import {
   getUnsupportedSlackFileAttachments,
   storeSlackFileAttachments,
 } from "./file-attachments";
-import { getSlackImageAttachments, handleSlackImageAttachments } from "./image-attachments";
+import {
+  getSlackImageAttachments,
+  handleSlackImageAttachments,
+  handleSlackImageFollowUp,
+} from "./image-attachments";
+import { threadHasStoredSlackImages } from "./image-session";
 import { getSlackRepositoryContextKey, type SlackBotThreadState } from "./repository-session";
 
 type SlackBotState = SlackBotThreadState;
@@ -346,11 +351,19 @@ async function processSlackMessage(
     }
 
     const hasTranslationAttachments = await interactionHasTranslationAttachments(interactionId);
+    const threadState = (await thread.state) as SlackBotThreadState | null;
+    const imageStorageContext = {
+      organizationId,
+      projectId,
+      createdByUserId: membership.localUserId,
+      interactionId,
+    };
     const shouldPostProcessingAck =
       options.isNewInteraction === true ||
       storedFileAttachments.length > 0 ||
       imageAttachments.length > 0 ||
-      hasTranslationAttachments;
+      hasTranslationAttachments ||
+      (imageAttachments.length === 0 && threadHasStoredSlackImages(threadState));
 
     if (shouldPostProcessingAck) {
       await postSlackProcessingAck(thread);
@@ -358,7 +371,15 @@ async function processSlackMessage(
 
     const loadedMessages = await loadInteractionModelMessages(interactionId);
     const conversationText = getRecentUserConversationText(loadedMessages, persistedUserText);
-    const threadState = (await thread.state) as SlackBotThreadState | null;
+    const imageIntentMessages = loadedMessages.flatMap((chatMessage) => {
+      if (
+        (chatMessage.role !== "user" && chatMessage.role !== "assistant") ||
+        typeof chatMessage.content !== "string"
+      ) {
+        return [];
+      }
+      return [{ role: chatMessage.role, content: chatMessage.content }];
+    });
     const storedRepositoryContext = threadState?.repositoryGitHubContext ?? null;
     const classification = await classifyConversation({
       currentMessage: message.text,
@@ -467,27 +488,34 @@ async function processSlackMessage(
     );
 
     if (imageAttachments.length > 0) {
-      const imageIntentMessages = chatMessages.flatMap((chatMessage) => {
-        if (
-          (chatMessage.role !== "user" && chatMessage.role !== "assistant") ||
-          typeof chatMessage.content !== "string"
-        ) {
-          return [];
-        }
-        return [{ role: chatMessage.role, content: chatMessage.content }];
-      });
-
       await removeEyesReaction(thread, message);
       wrapThreadPost(thread, interactionId);
       await handleSlackImageAttachments(thread, message, {
         imageAttachments,
         conversationMessages: imageIntentMessages,
+        threadState,
+        storage: imageStorageContext,
         beforePostGeneratedImage: async () => {
           await removeEyesReaction(thread, message);
         },
       });
 
       if (storedFileAttachments.length === 0) {
+        return;
+      }
+    } else if (threadHasStoredSlackImages(threadState)) {
+      await removeEyesReaction(thread, message);
+      wrapThreadPost(thread, interactionId);
+      const followUpResult = await handleSlackImageFollowUp(thread, message, {
+        conversationMessages: imageIntentMessages,
+        threadState,
+        storage: imageStorageContext,
+        beforePostGeneratedImage: async () => {
+          await removeEyesReaction(thread, message);
+        },
+      });
+
+      if (followUpResult.handled) {
         return;
       }
     }

--- a/apps/hyperlocalise-web/src/lib/agents/slack/bot.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/bot.ts
@@ -505,11 +505,13 @@ async function processSlackMessage(
       }
     } else if (threadHasStoredSlackImages(threadState)) {
       await removeEyesReaction(thread, message);
-      wrapThreadPost(thread, interactionId);
       const followUpResult = await handleSlackImageFollowUp(thread, message, {
         conversationMessages: imageIntentMessages,
         threadState,
         storage: imageStorageContext,
+        beforeLocalize: () => {
+          wrapThreadPost(thread, interactionId);
+        },
         beforePostGeneratedImage: async () => {
           await removeEyesReaction(thread, message);
         },

--- a/apps/hyperlocalise-web/src/lib/agents/slack/image-attachments.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/image-attachments.ts
@@ -10,7 +10,17 @@ import {
 } from "@/lib/agents/image-localization";
 import { env } from "@/lib/env";
 
-type SlackImageThread = Thread<Record<string, unknown>>;
+import {
+  createStoredSlackImageAttachment,
+  getSlackImageSourcesForFollowUp,
+  storeSlackImageOutput,
+  storeSlackImageSource,
+  threadHasStoredSlackImages,
+  updateSlackImageThreadState,
+} from "./image-session";
+import type { SlackBotThreadState } from "./repository-session";
+
+type SlackImageThread = Thread<SlackBotThreadState>;
 type SlackImageIntentMessage = {
   role: "user" | "assistant";
   content: string;
@@ -32,6 +42,13 @@ type CreateSlackImageRequestInterpreterOptions = {
 type InterpretSlackImageRequestInput = {
   text: string;
   messages?: SlackImageIntentMessage[];
+};
+
+type SlackImageStorageContext = {
+  organizationId: string;
+  projectId: string | null;
+  createdByUserId: string | null;
+  interactionId: string;
 };
 
 function getSlackImageIntentModel() {
@@ -134,19 +151,151 @@ function buildMissingTargetLocaleMessage() {
   return [
     "I received your image, but I need the target language before I can localize it.",
     "",
-    "Please resend the image with a target language, for example: `Localize this image to Japanese`.",
+    "Reply in this thread with the target language, for example: `Localize to Japanese`.",
+    "You do not need to upload the image again.",
   ].join("\n");
 }
 
-function buildImageFailureMessage(imageAttachment: ImageLocalizationAttachment) {
-  return `Sorry, I couldn't localize ${imageAttachment.name ?? "that image"} right now. Please try again with the image and target language.`;
+function buildImageFailureMessage(imageName: string | undefined) {
+  return `Sorry, I couldn't localize ${imageName ?? "that image"} right now. Please try again with the image and target language.`;
+}
+
+function buildLocalizedImageReplyMessage(imageName: string | undefined, targetLocale: string) {
+  return [
+    `Here is the localized version of ${imageName ?? "your image"} for ${targetLocale}. I kept the layout and style as close to the original as possible.`,
+    "",
+    "Tell me if you'd like any adjustments to the text placement or tone, or ask for another target language without reuploading the image.",
+  ].join("\n");
 }
 
 export type HandleSlackImageAttachmentsOptions = {
   imageAttachments?: ImageLocalizationAttachment[];
   conversationMessages?: SlackImageIntentMessage[];
+  threadState?: SlackBotThreadState | null;
+  storage?: SlackImageStorageContext;
   beforePostGeneratedImage?: () => Promise<void> | void;
 };
+
+type LocalizeSlackImageSourceInput = {
+  thread: SlackImageThread;
+  message: Message;
+  source: { sourceFileId: string; filename: string; contentType: string };
+  targetLocale: string;
+  instructions: string | null;
+  threadState: SlackBotThreadState | null;
+  storage: SlackImageStorageContext;
+  beforePostGeneratedImage?: () => Promise<void> | void;
+};
+
+async function localizeSlackImageSource(input: LocalizeSlackImageSourceInput) {
+  const attachment = await createStoredSlackImageAttachment({
+    organizationId: input.storage.organizationId,
+    projectId: input.storage.projectId,
+    sourceFileId: input.source.sourceFileId,
+    filename: input.source.filename,
+    contentType: input.source.contentType,
+  });
+
+  const file = await localizeImageAttachment({
+    attachment,
+    targetLocale: input.targetLocale,
+    instructions: input.instructions,
+    contextLines: [input.message.text ? `Slack request: ${input.message.text}` : null],
+  });
+
+  const storedOutput = await storeSlackImageOutput({
+    organizationId: input.storage.organizationId,
+    projectId: input.storage.projectId,
+    createdByUserId: input.storage.createdByUserId,
+    interactionId: input.storage.interactionId,
+    sourceFileId: input.source.sourceFileId,
+    filename: file.filename,
+    contentType: file.mimeType,
+    content: file.data,
+    targetLocale: input.targetLocale,
+    instructions: input.instructions,
+  });
+
+  if (input.beforePostGeneratedImage) {
+    try {
+      await input.beforePostGeneratedImage();
+    } catch (error) {
+      console.error("Failed to run Slack pre-image-post hook", {
+        error,
+        imageName: input.source.filename,
+        targetLocale: input.targetLocale,
+      });
+    }
+  }
+
+  await input.thread.post({
+    raw: buildLocalizedImageReplyMessage(input.source.filename, input.targetLocale),
+    files: [
+      {
+        data: file.data,
+        filename: file.filename,
+        mimeType: file.mimeType,
+      },
+    ],
+  });
+
+  await updateSlackImageThreadState(input.thread, input.threadState, {
+    pendingSlackImageTask: null,
+    newSources: [input.source],
+    localizedOutput: {
+      sourceFileId: input.source.sourceFileId,
+      output: {
+        fileId: storedOutput.fileId,
+        filename: storedOutput.filename,
+        contentType: storedOutput.contentType,
+        targetLocale: input.targetLocale,
+        instructions: input.instructions,
+        createdAt: new Date().toISOString(),
+      },
+    },
+  });
+
+  return true;
+}
+
+async function localizeSlackImageSources(input: {
+  thread: SlackImageThread;
+  message: Message;
+  sources: Array<{ sourceFileId: string; filename: string; contentType: string }>;
+  targetLocale: string;
+  instructions: string | null;
+  threadState: SlackBotThreadState | null;
+  storage: SlackImageStorageContext;
+  beforePostGeneratedImage?: () => Promise<void> | void;
+}) {
+  let localizedCount = 0;
+
+  for (const source of input.sources) {
+    try {
+      await localizeSlackImageSource({
+        thread: input.thread,
+        message: input.message,
+        source,
+        targetLocale: input.targetLocale,
+        instructions: input.instructions,
+        threadState: input.threadState,
+        storage: input.storage,
+        beforePostGeneratedImage: input.beforePostGeneratedImage,
+      });
+      localizedCount += 1;
+      input.threadState = (await input.thread.state) as SlackBotThreadState | null;
+    } catch (error) {
+      console.error("Failed to localize Slack image attachment", {
+        error,
+        imageName: source.filename,
+        targetLocale: input.targetLocale,
+      });
+      await input.thread.post(buildImageFailureMessage(source.filename));
+    }
+  }
+
+  return localizedCount;
+}
 
 export async function handleSlackImageAttachments(
   thread: SlackImageThread,
@@ -164,57 +313,139 @@ export async function handleSlackImageAttachments(
     messages: conversationMessages,
   });
   const targetLocale = intent.targetLocale;
+  const threadState = options.threadState ?? null;
+  const storage = options.storage;
+
+  const storedSources = storage
+    ? await Promise.all(
+        imageAttachments.map(async (imageAttachment) =>
+          storeSlackImageSource({
+            attachment: imageAttachment,
+            organizationId: storage.organizationId,
+            projectId: storage.projectId,
+            createdByUserId: storage.createdByUserId,
+            interactionId: storage.interactionId,
+          }),
+        ),
+      )
+    : imageAttachments.map((imageAttachment, index) => ({
+        sourceFileId: `ephemeral-${index}`,
+        filename: imageAttachment.name ?? `slack-image-${index + 1}.png`,
+        contentType: imageAttachment.mimeType ?? "image/png",
+      }));
 
   if (!targetLocale) {
+    if (storage) {
+      await updateSlackImageThreadState(thread, threadState, {
+        pendingSlackImageTask: { sourceAssets: storedSources },
+        newSources: storedSources,
+      });
+    }
+
     await thread.post(buildMissingTargetLocaleMessage());
     return { handled: true, localizedCount: 0, missingTargetLocale: true };
   }
 
-  let localizedCount = 0;
-  for (const imageAttachment of imageAttachments) {
-    try {
-      const file = await localizeImageAttachment({
-        attachment: imageAttachment,
-        targetLocale,
-        instructions: intent.instructions,
-        contextLines: [message.text ? `Slack request: ${message.text}` : null],
-      });
+  if (!storage) {
+    let localizedCount = 0;
+    for (const imageAttachment of imageAttachments) {
+      try {
+        const file = await localizeImageAttachment({
+          attachment: imageAttachment,
+          targetLocale,
+          instructions: intent.instructions,
+          contextLines: [message.text ? `Slack request: ${message.text}` : null],
+        });
 
-      if (options.beforePostGeneratedImage) {
-        try {
-          await options.beforePostGeneratedImage();
-        } catch (error) {
-          console.error("Failed to run Slack pre-image-post hook", {
-            error,
-            imageName: imageAttachment.name,
-            targetLocale,
-          });
+        if (options.beforePostGeneratedImage) {
+          try {
+            await options.beforePostGeneratedImage();
+          } catch (error) {
+            console.error("Failed to run Slack pre-image-post hook", {
+              error,
+              imageName: imageAttachment.name,
+              targetLocale,
+            });
+          }
         }
+
+        await thread.post({
+          raw: buildLocalizedImageReplyMessage(imageAttachment.name, targetLocale),
+          files: [
+            {
+              data: file.data,
+              filename: file.filename,
+              mimeType: file.mimeType,
+            },
+          ],
+        });
+        localizedCount += 1;
+      } catch (error) {
+        console.error("Failed to localize Slack image attachment", {
+          error,
+          imageName: imageAttachment.name,
+          targetLocale,
+        });
+        await thread.post(buildImageFailureMessage(imageAttachment.name));
       }
-      await thread.post({
-        raw: [
-          `Here is the localized version of ${imageAttachment.name ?? "your image"} for ${targetLocale}. I kept the layout and style as close to the original as possible.`,
-          "",
-          "Tell me if you'd like any adjustments to the text placement or tone.",
-        ].join("\n"),
-        files: [
-          {
-            data: file.data,
-            filename: file.filename,
-            mimeType: file.mimeType,
-          },
-        ],
-      });
-      localizedCount += 1;
-    } catch (error) {
-      console.error("Failed to localize Slack image attachment", {
-        error,
-        imageName: imageAttachment.name,
-        targetLocale,
-      });
-      await thread.post(buildImageFailureMessage(imageAttachment));
     }
+
+    return { handled: true, localizedCount, targetLocale };
   }
 
+  const localizedCount = await localizeSlackImageSources({
+    thread,
+    message,
+    sources: storedSources,
+    targetLocale,
+    instructions: intent.instructions,
+    threadState,
+    storage,
+    beforePostGeneratedImage: options.beforePostGeneratedImage,
+  });
+
   return { handled: true, localizedCount, targetLocale };
+}
+
+export async function handleSlackImageFollowUp(
+  thread: SlackImageThread,
+  message: Message,
+  options: {
+    conversationMessages?: SlackImageIntentMessage[];
+    threadState?: SlackBotThreadState | null;
+    storage: SlackImageStorageContext;
+    beforePostGeneratedImage?: () => Promise<void> | void;
+  },
+) {
+  const threadState = options.threadState ?? null;
+  if (!threadHasStoredSlackImages(threadState)) {
+    return { handled: false, localizedCount: 0 };
+  }
+
+  const intent = await interpretSlackImageRequest({
+    text: message.text,
+    messages: options.conversationMessages ?? [],
+  });
+
+  if (!intent.targetLocale) {
+    return { handled: false, localizedCount: 0 };
+  }
+
+  const sources = getSlackImageSourcesForFollowUp(threadState);
+  if (sources.length === 0) {
+    return { handled: false, localizedCount: 0 };
+  }
+
+  const localizedCount = await localizeSlackImageSources({
+    thread,
+    message,
+    sources,
+    targetLocale: intent.targetLocale,
+    instructions: intent.instructions,
+    threadState,
+    storage: options.storage,
+    beforePostGeneratedImage: options.beforePostGeneratedImage,
+  });
+
+  return { handled: true, localizedCount, targetLocale: intent.targetLocale };
 }

--- a/apps/hyperlocalise-web/src/lib/agents/slack/image-attachments.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/image-attachments.ts
@@ -269,6 +269,7 @@ async function localizeSlackImageSources(input: {
   beforePostGeneratedImage?: () => Promise<void> | void;
 }) {
   let localizedCount = 0;
+  let threadState = input.threadState;
 
   for (const source of input.sources) {
     try {
@@ -278,12 +279,12 @@ async function localizeSlackImageSources(input: {
         source,
         targetLocale: input.targetLocale,
         instructions: input.instructions,
-        threadState: input.threadState,
+        threadState,
         storage: input.storage,
         beforePostGeneratedImage: input.beforePostGeneratedImage,
       });
       localizedCount += 1;
-      input.threadState = (await input.thread.state) as SlackBotThreadState | null;
+      threadState = (await input.thread.state) as SlackBotThreadState | null;
     } catch (error) {
       console.error("Failed to localize Slack image attachment", {
         error,
@@ -318,9 +319,10 @@ export async function handleSlackImageAttachments(
 
   const storedSources = storage
     ? await Promise.all(
-        imageAttachments.map(async (imageAttachment) =>
+        imageAttachments.map(async (imageAttachment, index) =>
           storeSlackImageSource({
             attachment: imageAttachment,
+            index,
             organizationId: storage.organizationId,
             projectId: storage.projectId,
             createdByUserId: storage.createdByUserId,
@@ -414,6 +416,7 @@ export async function handleSlackImageFollowUp(
     conversationMessages?: SlackImageIntentMessage[];
     threadState?: SlackBotThreadState | null;
     storage: SlackImageStorageContext;
+    beforeLocalize?: () => void;
     beforePostGeneratedImage?: () => Promise<void> | void;
   },
 ) {
@@ -435,6 +438,8 @@ export async function handleSlackImageFollowUp(
   if (sources.length === 0) {
     return { handled: false, localizedCount: 0 };
   }
+
+  options.beforeLocalize?.();
 
   const localizedCount = await localizeSlackImageSources({
     thread,

--- a/apps/hyperlocalise-web/src/lib/agents/slack/image-session.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/image-session.ts
@@ -1,0 +1,228 @@
+import type { Thread } from "chat";
+
+import {
+  getImageAttachmentData,
+  type ImageLocalizationAttachment,
+} from "@/lib/agents/image-localization";
+import { createStoredFile, getStoredFileContent } from "@/lib/file-storage/records";
+
+import type {
+  PendingSlackImageTask,
+  SlackBotThreadState,
+  SlackImageLocalizationOutput,
+  SlackImageSourceAsset,
+} from "./repository-session";
+
+type StoreSlackImageSourceInput = {
+  attachment: ImageLocalizationAttachment;
+  organizationId: string;
+  projectId: string | null;
+  createdByUserId: string | null;
+  interactionId: string;
+};
+
+type StoreSlackImageOutputInput = {
+  organizationId: string;
+  projectId: string | null;
+  createdByUserId: string | null;
+  interactionId: string;
+  sourceFileId: string;
+  filename: string;
+  contentType: string;
+  content: Buffer;
+  targetLocale: string;
+  instructions: string | null;
+};
+
+function attachmentFilename(attachment: ImageLocalizationAttachment, index: number) {
+  return attachment.name?.trim() || `slack-image-${index + 1}.png`;
+}
+
+function attachmentContentType(attachment: ImageLocalizationAttachment) {
+  return attachment.mimeType?.trim() || "image/png";
+}
+
+export async function storeSlackImageSource(input: StoreSlackImageSourceInput) {
+  const content = await getImageAttachmentData(input.attachment);
+  const filename = attachmentFilename(input.attachment, 0);
+
+  const file = await createStoredFile({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    createdByUserId: input.createdByUserId,
+    role: "source",
+    sourceKind: "chat_upload",
+    sourceInteractionId: input.interactionId,
+    filename,
+    contentType: attachmentContentType(input.attachment),
+    content,
+    metadata: {
+      uploadSurface: "slack_agent",
+      imageLocalizationSource: true,
+      slackAttachmentType: input.attachment.type,
+      slackAttachmentUrl: input.attachment.url,
+    },
+  });
+
+  return {
+    sourceFileId: file.id,
+    filename: file.filename,
+    contentType: file.contentType,
+  };
+}
+
+export async function storeSlackImageOutput(input: StoreSlackImageOutputInput) {
+  const file = await createStoredFile({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    createdByUserId: input.createdByUserId,
+    role: "output",
+    sourceKind: "chat_upload",
+    sourceInteractionId: input.interactionId,
+    filename: input.filename,
+    contentType: input.contentType,
+    content: input.content,
+    metadata: {
+      uploadSurface: "slack_agent",
+      imageLocalizationOutput: true,
+      sourceFileId: input.sourceFileId,
+      targetLocale: input.targetLocale,
+      instructions: input.instructions,
+    },
+  });
+
+  return {
+    fileId: file.id,
+    filename: file.filename,
+    contentType: file.contentType,
+  };
+}
+
+export async function createStoredSlackImageAttachment(input: {
+  organizationId: string;
+  projectId: string | null;
+  sourceFileId: string;
+  filename: string;
+  contentType: string;
+}): Promise<ImageLocalizationAttachment> {
+  const { content } = await getStoredFileContent({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    fileId: input.sourceFileId,
+  });
+
+  return {
+    type: "image",
+    name: input.filename,
+    mimeType: input.contentType,
+    fetchData: async () => content,
+  } as ImageLocalizationAttachment;
+}
+
+function upsertImageSourceAsset(
+  assets: SlackImageSourceAsset[],
+  source: { sourceFileId: string; filename: string; contentType: string },
+) {
+  const existing = assets.find((asset) => asset.sourceFileId === source.sourceFileId);
+  if (existing) {
+    return assets;
+  }
+
+  return [
+    ...assets,
+    {
+      sourceFileId: source.sourceFileId,
+      filename: source.filename,
+      contentType: source.contentType,
+      localizedOutputs: [],
+    },
+  ];
+}
+
+export function recordSlackImageLocalizationOutput(input: {
+  assets: SlackImageSourceAsset[];
+  sourceFileId: string;
+  output: SlackImageLocalizationOutput;
+}) {
+  return input.assets.map((asset) => {
+    if (asset.sourceFileId !== input.sourceFileId) {
+      return asset;
+    }
+
+    const localizedOutputs = asset.localizedOutputs.filter(
+      (existing) => existing.targetLocale !== input.output.targetLocale,
+    );
+
+    return {
+      ...asset,
+      localizedOutputs: [...localizedOutputs, input.output],
+    };
+  });
+}
+
+export async function updateSlackImageThreadState(
+  thread: Thread<SlackBotThreadState>,
+  currentState: SlackBotThreadState | null,
+  update: {
+    pendingSlackImageTask?: PendingSlackImageTask | null;
+    newSources?: Array<{ sourceFileId: string; filename: string; contentType: string }>;
+    localizedOutput?: {
+      sourceFileId: string;
+      output: SlackImageLocalizationOutput;
+    };
+  },
+) {
+  let imageSourceAssets = currentState?.imageSourceAssets ?? [];
+
+  if (update.newSources) {
+    for (const source of update.newSources) {
+      imageSourceAssets = upsertImageSourceAsset(imageSourceAssets, source);
+    }
+  }
+
+  if (update.localizedOutput) {
+    imageSourceAssets = recordSlackImageLocalizationOutput({
+      assets: imageSourceAssets,
+      sourceFileId: update.localizedOutput.sourceFileId,
+      output: update.localizedOutput.output,
+    });
+  }
+
+  await thread.setState({
+    ...currentState,
+    imageSourceAssets,
+    pendingSlackImageTask:
+      update.pendingSlackImageTask === null
+        ? undefined
+        : (update.pendingSlackImageTask ?? currentState?.pendingSlackImageTask),
+  });
+}
+
+export function getSlackImageSourcesForFollowUp(state: SlackBotThreadState | null) {
+  if (state?.pendingSlackImageTask?.sourceAssets.length) {
+    return state.pendingSlackImageTask.sourceAssets;
+  }
+
+  const assets = state?.imageSourceAssets ?? [];
+  if (assets.length === 0) {
+    return [];
+  }
+
+  const latestAsset = assets.at(-1);
+  return latestAsset
+    ? [
+        {
+          sourceFileId: latestAsset.sourceFileId,
+          filename: latestAsset.filename,
+          contentType: latestAsset.contentType,
+        },
+      ]
+    : [];
+}
+
+export function threadHasStoredSlackImages(state: SlackBotThreadState | null) {
+  return (
+    Boolean(state?.pendingSlackImageTask?.sourceAssets.length) ||
+    Boolean(state?.imageSourceAssets?.length)
+  );
+}

--- a/apps/hyperlocalise-web/src/lib/agents/slack/image-session.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/image-session.ts
@@ -15,6 +15,7 @@ import type {
 
 type StoreSlackImageSourceInput = {
   attachment: ImageLocalizationAttachment;
+  index: number;
   organizationId: string;
   projectId: string | null;
   createdByUserId: string | null;
@@ -44,7 +45,7 @@ function attachmentContentType(attachment: ImageLocalizationAttachment) {
 
 export async function storeSlackImageSource(input: StoreSlackImageSourceInput) {
   const content = await getImageAttachmentData(input.attachment);
-  const filename = attachmentFilename(input.attachment, 0);
+  const filename = attachmentFilename(input.attachment, input.index);
 
   const file = await createStoredFile({
     organizationId: input.organizationId,
@@ -60,7 +61,6 @@ export async function storeSlackImageSource(input: StoreSlackImageSourceInput) {
       uploadSurface: "slack_agent",
       imageLocalizationSource: true,
       slackAttachmentType: input.attachment.type,
-      slackAttachmentUrl: input.attachment.url,
     },
   });
 

--- a/apps/hyperlocalise-web/src/lib/agents/slack/repository-session.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/repository-session.ts
@@ -20,8 +20,34 @@ export type SlackRepositorySandboxSession = {
   lastUsedAt: string;
 };
 
+export type SlackImageLocalizationOutput = {
+  fileId: string;
+  filename: string;
+  contentType: string;
+  targetLocale: string;
+  instructions: string | null;
+  createdAt: string;
+};
+
+export type SlackImageSourceAsset = {
+  sourceFileId: string;
+  filename: string;
+  contentType: string;
+  localizedOutputs: SlackImageLocalizationOutput[];
+};
+
+export type PendingSlackImageTask = {
+  sourceAssets: Array<{
+    sourceFileId: string;
+    filename: string;
+    contentType: string;
+  }>;
+};
+
 export type SlackBotThreadState = {
   warnedNonMemberUsers?: string[];
   repositoryGitHubContext?: RepositoryAgentGitHubContext;
   repositorySandboxSession?: SlackRepositorySandboxSession;
+  pendingSlackImageTask?: PendingSlackImageTask;
+  imageSourceAssets?: SlackImageSourceAsset[];
 };

--- a/apps/hyperlocalise-web/src/lib/file-storage/records.ts
+++ b/apps/hyperlocalise-web/src/lib/file-storage/records.ts
@@ -4,6 +4,11 @@ import { db, schema } from "@/lib/database";
 
 import { getFileStorageAdapter, type FileStorageAdapter } from ".";
 
+async function readStoredObjectBody(body: ReadableStream) {
+  const arrayBuffer = await new Response(body).arrayBuffer();
+  return Buffer.from(arrayBuffer);
+}
+
 type StoredFileRole = (typeof schema.storedFileRoleEnum.enumValues)[number];
 type StoredFileSourceKind = (typeof schema.storedFileSourceKindEnum.enumValues)[number];
 
@@ -153,6 +158,24 @@ export async function createStoredFile(input: CreateStoredFileInput) {
     await adapter.delete({ keyOrUrl: uploaded.key });
     throw error;
   }
+}
+
+export async function getStoredFileContent(input: StoredFileScopeInput) {
+  const file = await getStoredFileForJobScope(input);
+  if (!file) {
+    throw new Error(`Stored file ${input.fileId} not found`);
+  }
+
+  const adapter = getFileStorageAdapter();
+  const storedObject = await adapter.get({ keyOrUrl: file.storageKey });
+  if (!storedObject) {
+    throw new Error(`Stored file content for ${input.fileId} not found`);
+  }
+
+  return {
+    file,
+    content: await readStoredObjectBody(storedObject.body),
+  };
 }
 
 export async function getStoredFileForJobScope(input: StoredFileScopeInput) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Slack image localization now persists source and translated images across thread turns, so users can clarify a target locale or request another localization without reuploading.

## Changes

- Store uploaded Slack images as `stored_files` with role `source` and metadata `imageLocalizationSource: true`
- Store generated localized images as `stored_files` with role `output`, linked to the source via `sourceFileId` and `targetLocale`
- Track thread state in `SlackBotThreadState`:
  - `pendingSlackImageTask` when an image is uploaded without a target locale
  - `imageSourceAssets` with localized output history per source image
- Handle text-only follow-ups via `handleSlackImageFollowUp` (e.g. "Localize to French" or "Now do Japanese")
- Update missing-locale prompt to ask for a reply instead of reuploading
- Add `getStoredFileContent` helper for reloading stored image bytes

## Review fixes

- Pass attachment index into `storeSlackImageSource` so batch nameless uploads get unique fallback filenames
- Use a local `threadState` variable in `localizeSlackImageSources` instead of mutating the input object
- Remove expiring `slackAttachmentUrl` from persisted source metadata
- Call `wrapThreadPost` only when image follow-up will localize (via `beforeLocalize` callback)

## User flows enabled

1. Upload image → bot asks for language → user replies "French" → localization runs from stored source
2. Upload + localize to French → user replies "Now localize to Japanese" → new output from same source
3. Existing single-turn upload + localize behavior unchanged

## Testing

- `vp test src/lib/agents/slack/bot.test.ts` (41 tests)
- `vp check --fix`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cd62a301-6f85-476c-8bfd-a46c9360cc20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd62a301-6f85-476c-8bfd-a46c9360cc20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

