### PR TITLE
refactor(web): split job detail components for Storybook DI

### DIFF
--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-page-content.tsx
@@ -1,157 +1,20 @@
 "use client";
 
-import { useState, type ReactNode } from "react";
-import Link from "next/link";
-import { ArrowLeft02Icon, RefreshIcon, StopCircleIcon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
+import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
-import {
-  AlertDialog,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { TypographyH1, TypographyH2 } from "@/components/ui/typography";
 import { apiClient } from "@/lib/api-client-instance";
-import { cn } from "@/lib/primitives/cn";
 import { isTmsProviderShellModeEnabled } from "@/lib/providers/tms-provider-shell-mode";
-
-import { toneClass } from "../../../../../_components/workspace-resource-shared";
-import { useActiveTmsProvider } from "../../../../../_hooks/use-active-tms-provider";
-
 import { parseProviderJobId } from "@/lib/providers/tms-provider-resource-id";
 
+import { useActiveTmsProvider } from "../../../../../_hooks/use-active-tms-provider";
+
+import type { JobDetailRecord } from "./job-detail-types";
 import { JobProviderDetailSection } from "./job-provider-detail-section";
+import { NativeJobDetailView } from "./native-job-detail-view";
 import { ProviderLiveJobDetailContent } from "./provider-live-job-detail-content";
-
-type JobDetail = {
-  id: string;
-  projectId: string | null;
-  projectName: string | null;
-  createdByUserId: string | null;
-  ownerUserId: string | null;
-  kind: "translation" | "research" | "review" | "sync" | "asset_management";
-  type: "string" | "file" | null;
-  status: "queued" | "running" | "succeeded" | "failed" | "waiting_for_review" | "cancelled";
-  inputPayload: unknown;
-  outcomeKind: string | null;
-  outcomePayload: unknown;
-  lastError: string | null;
-  workflowRunId: string | null;
-  interactionId: string | null;
-  contextSnapshot: unknown;
-  reviewCriteria: string | null;
-  reviewTargetLocale: string | null;
-  reviewConfig: unknown;
-  syncConnectorKind: string | null;
-  syncDirection: string | null;
-  syncExternalIdentifiers: unknown;
-  assetType: string | null;
-  assetOperation: string | null;
-  assetConfig: unknown;
-  externalProviderKind: string | null;
-  externalJobId: string | null;
-  externalTaskId: string | null;
-  externalStatus: string | null;
-  externalTitle: string | null;
-  externalDueDate: string | null;
-  externalTargetLocales: string[] | null;
-  externalAssignedUsers: string[] | null;
-  externalUrl: string | null;
-  externalSyncState: string | null;
-  externalProviderPayload: Record<string, unknown> | null;
-  linkedJobId: string | null;
-  providerSourceFiles?: Array<{
-    id: string;
-    displayName: string;
-    sourcePath: string | null;
-    resourceType: string | null;
-    externalUrl: string | null;
-  }>;
-  providerActions?: Array<{
-    id:
-      | "translate_with_agent"
-      | "review_with_agent"
-      | "fix_qa_issues"
-      | "leave_provider_comment"
-      | "push_approved_changes";
-    label: string;
-    agentRunKind: string;
-    visible: boolean;
-    enabled: boolean;
-    disabledReason?: string;
-  }>;
-  createdAt: string;
-  updatedAt: string;
-  completedAt: string | null;
-};
-
-function isProviderBackedJob(job: JobDetail): job is JobDetail & { externalProviderKind: string } {
-  return Boolean(job.externalProviderKind);
-}
-
-function statusTone(status: JobDetail["status"]) {
-  switch (status) {
-    case "succeeded":
-      return "safe";
-    case "failed":
-      return "risk";
-    case "queued":
-    case "waiting_for_review":
-      return "watch";
-    default:
-      return "info";
-  }
-}
-
-function formatKind(job: JobDetail) {
-  if (job.kind === "translation" && job.type) {
-    return `translation · ${job.type}`;
-  }
-
-  return job.kind.replace("_", " ");
-}
-
-/**
- * BOLT OPTIMIZATION: Reuse Intl.DateTimeFormat instance.
- * Creating Intl objects is expensive (~0.18ms per instance).
- * Reusing a single instance reduces overhead by >95%.
- */
-const DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
-  dateStyle: "medium",
-  timeStyle: "short",
-});
-
-function formatDate(value: string | null) {
-  if (!value) return "—";
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return value;
-  return DATE_FORMATTER.format(date);
-}
-
-function JsonBlock({ value }: { value: unknown }) {
-  return (
-    <pre className="max-h-96 overflow-auto rounded-lg border border-foreground/8 bg-foreground/3.5 p-4 text-xs leading-6 text-foreground/72">
-      {JSON.stringify(value ?? null, null, 2)}
-    </pre>
-  );
-}
-
-function canRetryJob(job: JobDetail) {
-  return job.kind === "translation" && (job.status === "queued" || job.status === "failed");
-}
-
-function canMarkJobFailed(job: JobDetail) {
-  return job.status === "queued" || job.status === "running";
-}
 
 async function parseActionError(response: Response, fallback: string) {
   let error: string | undefined;
@@ -164,15 +27,6 @@ async function parseActionError(response: Response, fallback: string) {
   }
 
   return error ? `${fallback}: ${error}` : `${fallback} (${response.status})`;
-}
-
-function DetailRow({ label, value }: { label: string; value: ReactNode }) {
-  return (
-    <div className="grid gap-1 py-3 sm:grid-cols-[12rem_minmax(0,1fr)] sm:gap-4">
-      <dt className="text-sm text-foreground/42">{label}</dt>
-      <dd className="min-w-0 wrap-break-word text-sm text-foreground/74">{value ?? "—"}</dd>
-    </div>
-  );
 }
 
 export function JobDetailPageContent({
@@ -247,7 +101,7 @@ function NativeJobDetailPageContent({
         throw new Error(`Failed to load job (${response.status})`);
       }
 
-      const body = (await response.json()) as { job: JobDetail };
+      const body = (await response.json()) as { job: JobDetailRecord };
       if (body.job.projectId !== projectId) {
         throw new Error("Job does not belong to this project");
       }
@@ -265,7 +119,7 @@ function NativeJobDetailPageContent({
         throw new Error(await parseActionError(response, "Failed to retry job"));
       }
 
-      const body = (await response.json()) as { job: JobDetail };
+      const body = (await response.json()) as { job: JobDetailRecord };
       return body.job;
     },
     onSuccess: async (updatedJob) => {
@@ -290,7 +144,7 @@ function NativeJobDetailPageContent({
         throw new Error(await parseActionError(response, "Failed to mark job as failed"));
       }
 
-      const body = (await response.json()) as { job: JobDetail };
+      const body = (await response.json()) as { job: JobDetailRecord };
       return body.job;
     },
     onSuccess: async (updatedJob) => {
@@ -304,201 +158,28 @@ function NativeJobDetailPageContent({
     },
   });
 
-  const job = jobQuery.data;
-  const showActions = job ? canRetryJob(job) || canMarkJobFailed(job) : false;
-
   return (
-    <main className="mx-auto flex w-full max-w-6xl flex-col gap-5">
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-        <div className="min-w-0">
-          <Button
-            nativeButton={false}
-            render={
-              <Link
-                href={`/org/${organizationSlug}/projects/${encodeURIComponent(projectId)}/jobs`}
-              />
-            }
-            variant="ghost"
-            className="-ml-2 mb-2 text-foreground/54 hover:bg-foreground/6 hover:text-foreground"
-          >
-            <HugeiconsIcon icon={ArrowLeft02Icon} strokeWidth={1.8} />
-            Jobs
-          </Button>
-          <TypographyH1 className="wrap-break-word font-heading text-3xl font-semibold text-foreground md:text-4xl">
-            {job?.externalTitle ?? job?.id ?? jobId}
-          </TypographyH1>
-        </div>
-        {job ? (
-          <div className="flex flex-col items-start gap-3 sm:items-end">
-            <Badge
-              variant="outline"
-              className={cn("w-fit rounded-full capitalize", toneClass(statusTone(job.status)))}
-            >
-              {job.status}
-            </Badge>
-            {showActions ? (
-              <div className="flex flex-wrap gap-2 sm:justify-end">
-                {canRetryJob(job) ? (
-                  <Button
-                    size="sm"
-                    disabled={retryJob.isPending || markJobFailed.isPending}
-                    onClick={() => retryJob.mutate()}
-                  >
-                    <HugeiconsIcon icon={RefreshIcon} strokeWidth={1.8} />
-                    {retryJob.isPending ? "Retrying..." : "Retry job"}
-                  </Button>
-                ) : null}
-                {canMarkJobFailed(job) ? (
-                  <Button
-                    size="sm"
-                    variant="destructive"
-                    disabled={retryJob.isPending || markJobFailed.isPending}
-                    onClick={() => setMarkFailedDialogOpen(true)}
-                  >
-                    <HugeiconsIcon icon={StopCircleIcon} strokeWidth={1.8} />
-                    Mark as failed
-                  </Button>
-                ) : null}
-              </div>
-            ) : null}
-          </div>
-        ) : null}
-      </div>
-
-      {jobQuery.isLoading ? (
-        <div className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
-          <Skeleton className="h-5 w-48 bg-foreground/8" />
-          <Skeleton className="mt-4 h-40 w-full bg-foreground/8" />
-        </div>
-      ) : null}
-
-      {jobQuery.isError ? (
-        <div className="rounded-lg border border-flame-300/20 bg-flame-300/8 p-5 text-sm text-flame-100">
-          {jobQuery.error instanceof Error ? jobQuery.error.message : "Unable to load job"}
-        </div>
-      ) : null}
-
-      {job ? (
-        <>
-          <section className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
-            <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
-              Overview
-            </TypographyH2>
-            <dl className="mt-3 divide-y divide-foreground/8">
-              <DetailRow label="Job ID" value={job.id} />
-              <DetailRow label="Kind" value={formatKind(job)} />
-              <DetailRow
-                label="Source"
-                value={
-                  isProviderBackedJob(job) ? `Provider · ${job.externalProviderKind}` : "Native"
-                }
-              />
-              <DetailRow label="Project" value={job.projectName ?? job.projectId ?? "Workspace"} />
-              <DetailRow label="Interaction" value={job.interactionId} />
-              <DetailRow label="Workflow run" value={job.workflowRunId} />
-              <DetailRow label="Created" value={formatDate(job.createdAt)} />
-              <DetailRow label="Updated" value={formatDate(job.updatedAt)} />
-              <DetailRow label="Completed" value={formatDate(job.completedAt)} />
-              <DetailRow label="Last error" value={job.lastError} />
-            </dl>
-          </section>
-
-          {isProviderBackedJob(job) ? (
-            <JobProviderDetailSection
-              job={job}
-              jobId={jobId}
-              organizationSlug={organizationSlug}
-              projectId={job.projectId}
-            />
-          ) : null}
-
-          {job.kind === "review" || job.kind === "sync" || job.kind === "asset_management" ? (
-            <section className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
-              <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
-                Kind Details
-              </TypographyH2>
-              <dl className="mt-3 divide-y divide-foreground/8">
-                {job.kind === "review" ? (
-                  <>
-                    <DetailRow label="Criteria" value={job.reviewCriteria} />
-                    <DetailRow label="Target locale" value={job.reviewTargetLocale} />
-                  </>
-                ) : null}
-                {job.kind === "sync" ? (
-                  <>
-                    <DetailRow label="Connector" value={job.syncConnectorKind} />
-                    <DetailRow label="Direction" value={job.syncDirection} />
-                  </>
-                ) : null}
-                {job.kind === "asset_management" ? (
-                  <>
-                    <DetailRow label="Asset type" value={job.assetType} />
-                    <DetailRow label="Operation" value={job.assetOperation} />
-                  </>
-                ) : null}
-              </dl>
-            </section>
-          ) : null}
-
-          <section className="grid gap-4 xl:grid-cols-2">
-            <div className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
-              <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
-                Input
-              </TypographyH2>
-              <div className="mt-4">
-                <JsonBlock value={job.inputPayload} />
-              </div>
-            </div>
-            <div className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
-              <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
-                Output
-              </TypographyH2>
-              <div className="mt-4">
-                <JsonBlock value={job.outcomePayload} />
-              </div>
-            </div>
-          </section>
-
-          <section className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
-            <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
-              Context Snapshot
-            </TypographyH2>
-            <div className="mt-4">
-              <JsonBlock value={job.contextSnapshot} />
-            </div>
-          </section>
-        </>
-      ) : null}
-
-      <AlertDialog
-        open={markFailedDialogOpen}
-        onOpenChange={(open) => {
-          if (!markJobFailed.isPending) {
-            setMarkFailedDialogOpen(open);
-          }
-        }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Mark job as failed?</AlertDialogTitle>
-            <AlertDialogDescription>
-              This will stop the job from appearing queued or running and prevent the current
-              workflow run from updating it later.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={markJobFailed.isPending}>Cancel</AlertDialogCancel>
-            <Button
-              variant="destructive"
-              disabled={markJobFailed.isPending}
-              onClick={() => markJobFailed.mutate()}
-            >
-              <HugeiconsIcon icon={StopCircleIcon} strokeWidth={1.8} />
-              {markJobFailed.isPending ? "Marking..." : "Mark failed"}
-            </Button>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-    </main>
+    <NativeJobDetailView
+      jobId={jobId}
+      organizationSlug={organizationSlug}
+      projectId={projectId}
+      job={jobQuery.data}
+      isLoading={jobQuery.isLoading}
+      error={jobQuery.isError ? jobQuery.error : undefined}
+      isRetryPending={retryJob.isPending}
+      isMarkFailedPending={markJobFailed.isPending}
+      markFailedDialogOpen={markFailedDialogOpen}
+      onMarkFailedDialogOpenChange={setMarkFailedDialogOpen}
+      onRetry={() => retryJob.mutate()}
+      onMarkFailed={() => markJobFailed.mutate()}
+      renderProviderDetailSection={(props) => (
+        <JobProviderDetailSection
+          job={props.job}
+          jobId={props.jobId}
+          organizationSlug={props.organizationSlug}
+          projectId={props.projectId}
+        />
+      )}
+    />
   );
 }

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-types.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-types.ts
@@ -1,0 +1,157 @@
+import type { JobProviderActionId } from "@/lib/providers/job-provider-actions";
+
+export type JobDetailRecord = {
+  id: string;
+  projectId: string | null;
+  projectName: string | null;
+  createdByUserId: string | null;
+  ownerUserId: string | null;
+  kind: "translation" | "research" | "review" | "sync" | "asset_management";
+  type: "string" | "file" | null;
+  status: "queued" | "running" | "succeeded" | "failed" | "waiting_for_review" | "cancelled";
+  inputPayload: unknown;
+  outcomeKind: string | null;
+  outcomePayload: unknown;
+  lastError: string | null;
+  workflowRunId: string | null;
+  interactionId: string | null;
+  contextSnapshot: unknown;
+  reviewCriteria: string | null;
+  reviewTargetLocale: string | null;
+  reviewConfig: unknown;
+  syncConnectorKind: string | null;
+  syncDirection: string | null;
+  syncExternalIdentifiers: unknown;
+  assetType: string | null;
+  assetOperation: string | null;
+  assetConfig: unknown;
+  externalProviderKind: string | null;
+  externalJobId: string | null;
+  externalTaskId: string | null;
+  externalStatus: string | null;
+  externalTitle: string | null;
+  externalDueDate: string | null;
+  externalTargetLocales: string[] | null;
+  externalAssignedUsers: string[] | null;
+  externalUrl: string | null;
+  externalSyncState: string | null;
+  externalProviderPayload: Record<string, unknown> | null;
+  linkedJobId: string | null;
+  providerSourceFiles?: Array<{
+    id: string;
+    displayName: string;
+    sourcePath: string | null;
+    resourceType: string | null;
+    externalUrl: string | null;
+  }>;
+  providerActions?: Array<{
+    id: JobProviderActionId;
+    label: string;
+    agentRunKind: string;
+    visible: boolean;
+    enabled: boolean;
+    disabledReason?: string;
+  }>;
+  createdAt: string;
+  updatedAt: string;
+  completedAt: string | null;
+};
+
+export type ProviderSourceFile = {
+  id: string;
+  displayName: string;
+  sourcePath: string | null;
+  resourceType: string | null;
+  externalUrl: string | null;
+};
+
+export type ProviderActionAvailability = {
+  id: JobProviderActionId;
+  label: string;
+  agentRunKind: string;
+  visible: boolean;
+  enabled: boolean;
+  disabledReason?: string;
+};
+
+export type ProviderBackedJobFields = {
+  externalProviderKind: string;
+  externalJobId: string | null;
+  externalTaskId: string | null;
+  externalStatus: string | null;
+  externalTitle: string | null;
+  externalDueDate: string | null;
+  externalTargetLocales: string[] | null;
+  externalAssignedUsers: string[] | null;
+  externalUrl: string | null;
+  externalSyncState: string | null;
+  externalProviderPayload: Record<string, unknown> | null;
+  lastError: string | null;
+  updatedAt: string;
+  providerSourceFiles?: ProviderSourceFile[];
+  providerActions?: ProviderActionAvailability[];
+};
+
+export type AgentRunRecord = {
+  id: string;
+  kind: string;
+  status: "queued" | "running" | "succeeded" | "failed" | "cancelled";
+  inputSnapshot: Record<string, unknown>;
+  outputSummary: Record<string, unknown>;
+  changedItems: Record<string, unknown>[];
+  warnings: string[];
+  createdAt: string;
+  completedAt: string | null;
+};
+
+export function isProviderBackedJob(
+  job: JobDetailRecord,
+): job is JobDetailRecord & { externalProviderKind: string } {
+  return Boolean(job.externalProviderKind);
+}
+
+export function jobDetailStatusTone(status: JobDetailRecord["status"]) {
+  switch (status) {
+    case "succeeded":
+      return "safe";
+    case "failed":
+      return "risk";
+    case "queued":
+    case "waiting_for_review":
+      return "watch";
+    default:
+      return "info";
+  }
+}
+
+export function formatJobDetailKind(job: Pick<JobDetailRecord, "kind" | "type">) {
+  if (job.kind === "translation" && job.type) {
+    return `translation · ${job.type}`;
+  }
+
+  return job.kind.replace("_", " ");
+}
+
+const DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+export function formatJobDetailDate(value: string | null | undefined) {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return DATE_FORMATTER.format(date);
+}
+
+export function canRetryJob(job: JobDetailRecord) {
+  return job.kind === "translation" && (job.status === "queued" || job.status === "failed");
+}
+
+export function canMarkJobFailed(job: JobDetailRecord) {
+  return job.status === "queued" || job.status === "running";
+}
+
+export function buildJobsListHref(organizationSlug: string, projectId: string) {
+  return `/org/${organizationSlug}/projects/${encodeURIComponent(projectId)}/jobs`;
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail.fixture.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail.fixture.ts
@@ -1,0 +1,227 @@
+import type { AgentRunRecord, JobDetailRecord, ProviderBackedJobFields } from "./job-detail-types";
+import type {
+  TmsProviderLiveJobComment,
+  TmsProviderLiveJobDetail,
+} from "@/lib/providers/tms-provider-live";
+
+const fixedNow = Date.UTC(2026, 5, 6, 12, 0, 0);
+
+function iso(offsetMs: number) {
+  return new Date(fixedNow + offsetMs).toISOString();
+}
+
+export const jobDetailFixtureNow = fixedNow;
+
+export function createNativeJobDetail(overrides: Partial<JobDetailRecord> = {}): JobDetailRecord {
+  return {
+    id: "job_translate_homepage",
+    projectId: "project_website",
+    projectName: "Website",
+    createdByUserId: "user_001",
+    ownerUserId: "user_001",
+    kind: "translation",
+    type: "file",
+    status: "running",
+    inputPayload: { sourceFileId: "marketing/home.json" },
+    outcomeKind: null,
+    outcomePayload: null,
+    lastError: null,
+    workflowRunId: "wf_run_001",
+    interactionId: null,
+    contextSnapshot: { locale: "fr-FR" },
+    reviewCriteria: null,
+    reviewTargetLocale: null,
+    reviewConfig: null,
+    syncConnectorKind: null,
+    syncDirection: null,
+    syncExternalIdentifiers: null,
+    assetType: null,
+    assetOperation: null,
+    assetConfig: null,
+    externalProviderKind: null,
+    externalJobId: null,
+    externalTaskId: null,
+    externalStatus: null,
+    externalTitle: null,
+    externalDueDate: null,
+    externalTargetLocales: null,
+    externalAssignedUsers: null,
+    externalUrl: null,
+    externalSyncState: null,
+    externalProviderPayload: null,
+    linkedJobId: null,
+    createdAt: iso(-86_400_000),
+    updatedAt: iso(-600_000),
+    completedAt: null,
+    ...overrides,
+  };
+}
+
+export function createProviderBackedJobDetail(
+  overrides: Partial<JobDetailRecord> = {},
+): JobDetailRecord {
+  return createNativeJobDetail({
+    id: "job_crowdin_1204",
+    externalProviderKind: "crowdin",
+    externalJobId: "1204",
+    externalTaskId: "CR-1204",
+    externalStatus: "in_progress",
+    externalTitle: "Translate marketing homepage",
+    externalDueDate: iso(86_400_000),
+    externalTargetLocales: ["fr-FR", "de-DE"],
+    externalAssignedUsers: ["Mina", "Otto"],
+    externalUrl: "https://crowdin.example/tasks/1204",
+    externalSyncState: "synced",
+    externalProviderPayload: {
+      type: 0,
+      targetLanguageIds: ["fr-FR", "de-DE"],
+      languageId: "fr-FR",
+      description: "Translate the launch campaign strings.",
+      localeReadiness: {
+        translationProgress: 68,
+        approvalProgress: 24,
+        words: { total: 2400, translated: 1580, approved: 520 },
+      },
+    },
+    providerSourceFiles: [
+      {
+        id: "file_home_json",
+        displayName: "home.json",
+        sourcePath: "marketing/home.json",
+        resourceType: "json",
+        externalUrl: null,
+      },
+    ],
+    providerActions: [
+      {
+        id: "translate_with_agent",
+        label: "Translate with agent",
+        agentRunKind: "translate_with_agent",
+        visible: true,
+        enabled: true,
+      },
+      {
+        id: "review_with_agent",
+        label: "Review with agent",
+        agentRunKind: "review_with_agent",
+        visible: true,
+        enabled: false,
+        disabledReason: "Waiting for translation to finish",
+      },
+    ],
+    ...overrides,
+  });
+}
+
+export function createLiveCrowdinJobDetail(
+  overrides: Partial<TmsProviderLiveJobDetail> = {},
+): TmsProviderLiveJobDetail {
+  return {
+    id: "ext:crowdin:task:1204",
+    projectId: "project_website",
+    projectName: "Website",
+    createdByUserId: null,
+    kind: "translation",
+    type: null,
+    status: "running",
+    createdAt: iso(-86_400_000),
+    updatedAt: iso(-600_000),
+    completedAt: null,
+    workflowRunId: null,
+    lastError: null,
+    inputPayload: null,
+    outcomeKind: null,
+    outcomePayload: null,
+    reviewCriteria: null,
+    reviewTargetLocale: null,
+    syncConnectorKind: null,
+    syncDirection: null,
+    assetType: null,
+    assetOperation: null,
+    externalProviderKind: "crowdin",
+    externalTaskId: "1204",
+    externalStatus: "in_progress",
+    externalTitle: "Translate marketing homepage",
+    externalDueDate: iso(86_400_000),
+    externalTargetLocales: ["fr-FR", "de-DE"],
+    externalAssignedUsers: ["Mina", "Otto"],
+    externalSyncState: null,
+    externalJobId: "1204",
+    externalUrl: "https://crowdin.example/tasks/1204",
+    externalProviderPayload: {
+      type: 0,
+      targetLanguageIds: ["fr-FR", "de-DE"],
+      languageId: "fr-FR",
+      description:
+        "Translate the launch campaign strings. Preserve product names and ICU placeholders.",
+      localeReadiness: {
+        translationProgress: 68,
+        approvalProgress: 24,
+        words: { total: 2400, translated: 1580, approved: 520 },
+      },
+    },
+    ...overrides,
+  };
+}
+
+export function createLiveCrowdinJobComments(): TmsProviderLiveJobComment[] {
+  return [
+    {
+      id: "comment_001",
+      externalCommentId: "c_001",
+      userId: "42",
+      taskId: "1204",
+      text: "Please preserve the product name casing in the hero headline.",
+      timeSpentSeconds: 900,
+      createdAt: iso(-3_600_000),
+      updatedAt: iso(-3_600_000),
+    },
+  ];
+}
+
+export function createAgentRunRecords(): AgentRunRecord[] {
+  return [
+    {
+      id: "agent_run_001",
+      kind: "translate_with_agent",
+      status: "succeeded",
+      inputSnapshot: { locale: "fr-FR" },
+      outputSummary: { proposedCount: 12 },
+      changedItems: [{ id: "item_1" }],
+      warnings: [],
+      createdAt: iso(-7_200_000),
+      completedAt: iso(-6_800_000),
+    },
+    {
+      id: "agent_run_002",
+      kind: "review_with_agent",
+      status: "running",
+      inputSnapshot: { locale: "fr-FR" },
+      outputSummary: {},
+      changedItems: [],
+      warnings: [],
+      createdAt: iso(-1_800_000),
+      completedAt: null,
+    },
+  ];
+}
+
+export function toProviderBackedJobFields(job: JobDetailRecord): ProviderBackedJobFields {
+  return {
+    externalProviderKind: job.externalProviderKind!,
+    externalJobId: job.externalJobId,
+    externalTaskId: job.externalTaskId,
+    externalStatus: job.externalStatus,
+    externalTitle: job.externalTitle,
+    externalDueDate: job.externalDueDate,
+    externalTargetLocales: job.externalTargetLocales,
+    externalAssignedUsers: job.externalAssignedUsers,
+    externalUrl: job.externalUrl,
+    externalSyncState: job.externalSyncState,
+    externalProviderPayload: job.externalProviderPayload,
+    lastError: job.lastError,
+    updatedAt: job.updatedAt,
+    providerSourceFiles: job.providerSourceFiles,
+    providerActions: job.providerActions,
+  };
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-provider-detail-section-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-provider-detail-section-view.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect } from "storybook/test";
+
+import {
+  createAgentRunRecords,
+  createProviderBackedJobDetail,
+  toProviderBackedJobFields,
+} from "./job-detail.fixture";
+import { JobProviderDetailSectionView } from "./job-provider-detail-section-view";
+
+const meta = {
+  title: "App/Jobs/Detail/Provider Section",
+  component: JobProviderDetailSectionView,
+  parameters: {
+    layout: "fullscreen",
+  },
+} satisfies Meta<typeof JobProviderDetailSectionView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const providerJob = toProviderBackedJobFields(createProviderBackedJobDetail());
+
+export const SyncedCrowdinJob: Story = {
+  args: {
+    job: providerJob,
+    jobId: "job_crowdin_1204",
+    organizationSlug: "acme",
+    projectId: "project_website",
+    agentRuns: createAgentRunRecords(),
+    agentRunsLoading: false,
+    onStartAgentRun: () => undefined,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Provider Details")).toBeInTheDocument();
+    await expect(canvas.getByText("Translate marketing homepage")).toBeInTheDocument();
+    await expect(canvas.getByText("Translate with agent")).toBeInTheDocument();
+  },
+};
+
+export const LoadingAgentRuns: Story = {
+  args: {
+    job: providerJob,
+    jobId: "job_crowdin_1204",
+    organizationSlug: "acme",
+    projectId: "project_website",
+    agentRunsLoading: true,
+  },
+};
+
+export const EmptyAgentRuns: Story = {
+  args: {
+    job: providerJob,
+    jobId: "job_crowdin_1204",
+    organizationSlug: "acme",
+    projectId: "project_website",
+    agentRuns: [],
+    agentRunsLoading: false,
+  },
+};

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-provider-detail-section-view.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-provider-detail-section-view.tsx
@@ -1,0 +1,336 @@
+"use client";
+
+import Link from "next/link";
+import type { ReactNode } from "react";
+import { AiMagicIcon, Comment01Icon, RefreshIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+import { MarkdownDescriptionPreview } from "@/components/markdown-description-editor";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { TypographyH2 } from "@/components/ui/typography";
+import { agentRunHasReviewableProposals } from "@/lib/providers/agent-runs/agent-run-proposals";
+import type { JobProviderActionId } from "@/lib/providers/job-provider-actions";
+import { cn } from "@/lib/primitives/cn";
+
+import { toneClass } from "../../../../../_components/workspace-resource-shared";
+
+import {
+  countGlossaryMatchesInUsage,
+  parseGlossaryUsageFromOutputSummary,
+} from "@/lib/translation/agent-run-glossary";
+import {
+  countTranslationMemoryMatchesInUsage,
+  parseTranslationMemoryUsageFromOutputSummary,
+} from "@/lib/translation/agent-run-translation-memory";
+
+import {
+  formatLocaleList,
+  getCrowdinLanguageLabel,
+  getCrowdinTargetLocales,
+  getProviderPayloadString,
+} from "../../../../../jobs/_components/provider-crowdin-job-display";
+
+import {
+  formatJobDetailDate,
+  type AgentRunRecord,
+  type ProviderActionAvailability,
+  type ProviderBackedJobFields,
+} from "./job-detail-types";
+
+export type JobProviderExternalLinkRenderer = (props: { href: string; label: string }) => ReactNode;
+
+export type JobProviderSourceFilesRenderer = (props: {
+  job: ProviderBackedJobFields;
+  organizationSlug: string;
+  projectId: string;
+}) => ReactNode;
+
+export type JobProviderQaFindingsRenderer = (props: {
+  agentRuns?: AgentRunRecord[];
+  agentRunsLoading: boolean;
+  job: ProviderBackedJobFields;
+  jobId: string;
+  organizationSlug: string;
+  projectId: string | null;
+}) => ReactNode;
+
+export type JobProviderDiffReviewRenderer = (props: {
+  agentRuns?: AgentRunRecord[];
+  agentRunsLoading: boolean;
+  jobId: string;
+  organizationSlug: string;
+}) => ReactNode;
+
+function DetailRow({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <div className="grid gap-1 py-3 sm:grid-cols-[12rem_minmax(0,1fr)] sm:gap-4">
+      <dt className="text-sm text-foreground/42">{label}</dt>
+      <dd className="min-w-0 wrap-break-word text-sm text-foreground/74">{value ?? "—"}</dd>
+    </div>
+  );
+}
+
+function actionIcon(actionId: JobProviderActionId) {
+  switch (actionId) {
+    case "leave_provider_comment":
+      return Comment01Icon;
+    case "push_approved_changes":
+      return RefreshIcon;
+    default:
+      return AiMagicIcon;
+  }
+}
+
+function agentRunTone(status: AgentRunRecord["status"]) {
+  switch (status) {
+    case "succeeded":
+      return "safe";
+    case "failed":
+      return "risk";
+    case "queued":
+      return "watch";
+    default:
+      return "info";
+  }
+}
+
+function defaultRenderExternalLink({
+  href,
+  label,
+}: Parameters<JobProviderExternalLinkRenderer>[0]) {
+  return (
+    <Link
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      className="text-foreground underline decoration-foreground/24 underline-offset-4 hover:decoration-foreground/48"
+    >
+      {label}
+    </Link>
+  );
+}
+
+export function JobProviderDetailSectionView({
+  agentRuns,
+  agentRunsError,
+  agentRunsLoading = false,
+  job,
+  jobId,
+  onStartAgentRun,
+  organizationSlug,
+  pendingActionId,
+  projectId,
+  renderDiffReview,
+  renderExternalLink = defaultRenderExternalLink,
+  renderQaFindings,
+  renderSourceFiles,
+}: {
+  agentRuns?: AgentRunRecord[];
+  agentRunsError?: unknown;
+  agentRunsLoading?: boolean;
+  job: ProviderBackedJobFields;
+  jobId: string;
+  onStartAgentRun?: (actionId: JobProviderActionId) => void;
+  organizationSlug: string;
+  pendingActionId?: JobProviderActionId | null;
+  projectId: string | null;
+  renderDiffReview?: JobProviderDiffReviewRenderer;
+  renderExternalLink?: JobProviderExternalLinkRenderer;
+  renderQaFindings?: JobProviderQaFindingsRenderer;
+  renderSourceFiles?: JobProviderSourceFilesRenderer;
+}) {
+  const visibleActions = (job.providerActions ?? []).filter((action) => action.visible);
+  const crowdinDescription =
+    getProviderPayloadString(job.externalProviderPayload, "description")?.trim() ?? "";
+
+  return (
+    <>
+      <section className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
+            Provider Details
+          </TypographyH2>
+          <Badge variant="outline" className="rounded-full capitalize">
+            {job.externalProviderKind}
+          </Badge>
+        </div>
+        <dl className="mt-3 divide-y divide-foreground/8">
+          <DetailRow label="Provider title" value={job.externalTitle} />
+          <DetailRow label="Provider status" value={job.externalStatus} />
+          <DetailRow label="Sync state" value={job.externalSyncState} />
+          <DetailRow label="Last sync" value={formatJobDetailDate(job.updatedAt)} />
+          {job.externalProviderKind === "crowdin" ? (
+            <>
+              <DetailRow
+                label="Language"
+                value={getCrowdinLanguageLabel(job.externalProviderPayload) ?? "—"}
+              />
+              <DetailRow
+                label="Target locales"
+                value={formatLocaleList(
+                  getCrowdinTargetLocales(
+                    job.externalProviderPayload,
+                    job.externalTargetLocales ?? [],
+                  ),
+                )}
+              />
+              <div className="grid gap-1 py-3 sm:grid-cols-[12rem_minmax(0,1fr)] sm:gap-4">
+                <dt className="text-sm text-foreground/42">Description</dt>
+                <dd className="min-w-0 text-sm text-foreground/74">
+                  {crowdinDescription ? (
+                    <MarkdownDescriptionPreview
+                      value={crowdinDescription}
+                      className="border-foreground/8 bg-transparent"
+                    />
+                  ) : (
+                    "—"
+                  )}
+                </dd>
+              </div>
+            </>
+          ) : (
+            <DetailRow label="Target locales" value={job.externalTargetLocales?.join(", ")} />
+          )}
+          <DetailRow label="Assignees" value={job.externalAssignedUsers?.join(", ")} />
+          <DetailRow label="Deadline" value={formatJobDetailDate(job.externalDueDate)} />
+          <DetailRow label="External job ID" value={job.externalJobId} />
+          <DetailRow label="External task ID" value={job.externalTaskId} />
+          <DetailRow
+            label="Provider link"
+            value={
+              job.externalUrl
+                ? renderExternalLink({
+                    href: job.externalUrl,
+                    label: `Open in ${job.externalProviderKind}`,
+                  })
+                : "—"
+            }
+          />
+          <DetailRow label="Raw error" value={job.lastError} />
+        </dl>
+      </section>
+
+      {projectId && renderSourceFiles
+        ? renderSourceFiles({ job, organizationSlug, projectId })
+        : null}
+
+      {visibleActions.length > 0 ? (
+        <section className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
+          <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
+            Agent Actions
+          </TypographyH2>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {visibleActions.map((action: ProviderActionAvailability) => (
+              <Button
+                key={action.id}
+                size="sm"
+                variant={action.id === "push_approved_changes" ? "outline" : "default"}
+                disabled={!action.enabled || Boolean(pendingActionId) || !onStartAgentRun}
+                title={action.disabledReason}
+                onClick={() => onStartAgentRun?.(action.id)}
+              >
+                <HugeiconsIcon icon={actionIcon(action.id)} strokeWidth={1.8} />
+                {pendingActionId === action.id ? "Starting..." : action.label}
+              </Button>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {renderQaFindings
+        ? renderQaFindings({
+            agentRuns,
+            agentRunsLoading,
+            job,
+            jobId,
+            organizationSlug,
+            projectId,
+          })
+        : null}
+
+      {renderDiffReview
+        ? renderDiffReview({
+            agentRuns,
+            agentRunsLoading,
+            jobId,
+            organizationSlug,
+          })
+        : null}
+
+      <section className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
+        <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
+          Agent Activity
+        </TypographyH2>
+        {agentRunsLoading ? <Skeleton className="mt-4 h-20 w-full bg-foreground/8" /> : null}
+        {agentRunsError ? (
+          <p className="mt-4 text-sm text-flame-100">
+            {agentRunsError instanceof Error ? agentRunsError.message : "Unable to load agent runs"}
+          </p>
+        ) : null}
+        {agentRuns && agentRuns.length > 0 ? (
+          <ul className="mt-4 space-y-2">
+            {agentRuns.map((run) => {
+              const hasProposals = agentRunHasReviewableProposals({
+                kind: run.kind,
+                status: run.status,
+                changedItems: run.changedItems,
+              });
+              const proposedCount =
+                typeof run.outputSummary.proposedCount === "number"
+                  ? run.outputSummary.proposedCount
+                  : run.changedItems.length;
+              const translationMemoryUsage = parseTranslationMemoryUsageFromOutputSummary(
+                run.outputSummary,
+              );
+              const translationMemoryMatchCount =
+                countTranslationMemoryMatchesInUsage(translationMemoryUsage);
+              const glossaryUsage = parseGlossaryUsageFromOutputSummary(run.outputSummary);
+              const glossaryMatchCount = countGlossaryMatchesInUsage(glossaryUsage);
+
+              return (
+                <li
+                  key={run.id}
+                  className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-foreground/8 bg-foreground/3.5 px-3 py-2"
+                >
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium capitalize text-foreground/82">
+                      {run.kind.replaceAll("_", " ")}
+                    </p>
+                    <p className="text-xs text-foreground/48">
+                      Started {formatJobDetailDate(run.createdAt)}
+                      {hasProposals ? ` · ${proposedCount} proposals` : null}
+                      {translationMemoryMatchCount > 0
+                        ? ` · ${translationMemoryMatchCount} TM match${translationMemoryMatchCount === 1 ? "" : "es"}`
+                        : null}
+                      {glossaryMatchCount > 0
+                        ? ` · ${glossaryMatchCount} glossary match${glossaryMatchCount === 1 ? "" : "es"}`
+                        : null}
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    {hasProposals ? (
+                      <Badge variant="outline" className="rounded-full">
+                        Review proposals
+                      </Badge>
+                    ) : null}
+                    <Badge
+                      variant="outline"
+                      className={cn("rounded-full capitalize", toneClass(agentRunTone(run.status)))}
+                    >
+                      {run.status}
+                    </Badge>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        ) : null}
+        {agentRuns && agentRuns.length === 0 ? (
+          <p className="mt-4 text-sm text-foreground/48">No agent runs yet.</p>
+        ) : null}
+      </section>
+    </>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-provider-detail-section.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-provider-detail-section.tsx
@@ -1,134 +1,23 @@
 "use client";
 
-import Link from "next/link";
-import type { ReactNode } from "react";
-import { AiMagicIcon, Comment01Icon, RefreshIcon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
-import { MarkdownDescriptionPreview } from "@/components/markdown-description-editor";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Skeleton } from "@/components/ui/skeleton";
-import { TypographyH2 } from "@/components/ui/typography";
 import { apiClient } from "@/lib/api-client-instance";
-import { agentRunHasReviewableProposals } from "@/lib/providers/agent-runs/agent-run-proposals";
 import type { JobProviderActionId } from "@/lib/providers/job-provider-actions";
-import { cn } from "@/lib/primitives/cn";
 
-import { toneClass } from "../../../../../_components/workspace-resource-shared";
-
-import {
-  countGlossaryMatchesInUsage,
-  parseGlossaryUsageFromOutputSummary,
-} from "@/lib/translation/agent-run-glossary";
-import {
-  countTranslationMemoryMatchesInUsage,
-  parseTranslationMemoryUsageFromOutputSummary,
-} from "@/lib/translation/agent-run-translation-memory";
-
-import {
-  formatLocaleList,
-  getCrowdinLanguageLabel,
-  getCrowdinTargetLocales,
-  getProviderPayloadString,
-} from "../../../../../jobs/_components/provider-crowdin-job-display";
 import { JobAgentRunDiffReviewSection } from "./job-agent-run-diff-review-section";
+import { JobProviderDetailSectionView } from "./job-provider-detail-section-view";
 import { JobQaFindingsSection } from "./job-qa-findings-section";
+import type { AgentRunRecord, ProviderBackedJobFields } from "./job-detail-types";
 import { SyncedJobSourceFilesSection } from "./tms/synced-job-source-files-section";
 
-export type ProviderSourceFile = {
-  id: string;
-  displayName: string;
-  sourcePath: string | null;
-  resourceType: string | null;
-  externalUrl: string | null;
-};
-
-export type ProviderActionAvailability = {
-  id: JobProviderActionId;
-  label: string;
-  agentRunKind: string;
-  visible: boolean;
-  enabled: boolean;
-  disabledReason?: string;
-};
-
-export type ProviderBackedJobFields = {
-  externalProviderKind: string;
-  externalJobId: string | null;
-  externalTaskId: string | null;
-  externalStatus: string | null;
-  externalTitle: string | null;
-  externalDueDate: string | null;
-  externalTargetLocales: string[] | null;
-  externalAssignedUsers: string[] | null;
-  externalUrl: string | null;
-  externalSyncState: string | null;
-  externalProviderPayload: Record<string, unknown> | null;
-  lastError: string | null;
-  updatedAt: string;
-  providerSourceFiles?: ProviderSourceFile[];
-  providerActions?: ProviderActionAvailability[];
-};
-
-export type AgentRunRecord = {
-  id: string;
-  kind: string;
-  status: "queued" | "running" | "succeeded" | "failed" | "cancelled";
-  inputSnapshot: Record<string, unknown>;
-  outputSummary: Record<string, unknown>;
-  changedItems: Record<string, unknown>[];
-  warnings: string[];
-  createdAt: string;
-  completedAt: string | null;
-};
-
-const DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
-  dateStyle: "medium",
-  timeStyle: "short",
-});
-
-function formatDate(value: string | null) {
-  if (!value) return "—";
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return value;
-  return DATE_FORMATTER.format(date);
-}
-
-function agentRunTone(status: AgentRunRecord["status"]) {
-  switch (status) {
-    case "succeeded":
-      return "safe";
-    case "failed":
-      return "risk";
-    case "queued":
-      return "watch";
-    default:
-      return "info";
-  }
-}
-
-function DetailRow({ label, value }: { label: string; value: ReactNode }) {
-  return (
-    <div className="grid gap-1 py-3 sm:grid-cols-[12rem_minmax(0,1fr)] sm:gap-4">
-      <dt className="text-sm text-foreground/42">{label}</dt>
-      <dd className="min-w-0 wrap-break-word text-sm text-foreground/74">{value ?? "—"}</dd>
-    </div>
-  );
-}
-
-function actionIcon(actionId: JobProviderActionId) {
-  switch (actionId) {
-    case "leave_provider_comment":
-      return Comment01Icon;
-    case "push_approved_changes":
-      return RefreshIcon;
-    default:
-      return AiMagicIcon;
-  }
-}
+export type {
+  AgentRunRecord,
+  ProviderActionAvailability,
+  ProviderBackedJobFields,
+  ProviderSourceFile,
+} from "./job-detail-types";
 
 async function parseActionError(response: Response, fallback: string) {
   let error: string | undefined;
@@ -213,218 +102,51 @@ export function JobProviderDetailSection({
     },
   });
 
-  const visibleActions = (job.providerActions ?? []).filter((action) => action.visible);
-  const sourceFiles = job.providerSourceFiles ?? [];
-  const crowdinDescription =
-    getProviderPayloadString(job.externalProviderPayload, "description")?.trim() ?? "";
-
   return (
-    <>
-      <section className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
-            Provider Details
-          </TypographyH2>
-          <Badge variant="outline" className="rounded-full capitalize">
-            {job.externalProviderKind}
-          </Badge>
-        </div>
-        <dl className="mt-3 divide-y divide-foreground/8">
-          <DetailRow label="Provider title" value={job.externalTitle} />
-          <DetailRow label="Provider status" value={job.externalStatus} />
-          <DetailRow label="Sync state" value={job.externalSyncState} />
-          <DetailRow label="Last sync" value={formatDate(job.updatedAt)} />
-          {job.externalProviderKind === "crowdin" ? (
-            <>
-              <DetailRow
-                label="Language"
-                value={getCrowdinLanguageLabel(job.externalProviderPayload) ?? "—"}
-              />
-              <DetailRow
-                label="Target locales"
-                value={formatLocaleList(
-                  getCrowdinTargetLocales(
-                    job.externalProviderPayload,
-                    job.externalTargetLocales ?? [],
-                  ),
-                )}
-              />
-              <div className="grid gap-1 py-3 sm:grid-cols-[12rem_minmax(0,1fr)] sm:gap-4">
-                <dt className="text-sm text-foreground/42">Description</dt>
-                <dd className="min-w-0 text-sm text-foreground/74">
-                  {crowdinDescription ? (
-                    <MarkdownDescriptionPreview
-                      value={crowdinDescription}
-                      className="border-foreground/8 bg-transparent"
-                    />
-                  ) : (
-                    "—"
-                  )}
-                </dd>
-              </div>
-            </>
-          ) : (
-            <DetailRow label="Target locales" value={job.externalTargetLocales?.join(", ")} />
-          )}
-          <DetailRow label="Assignees" value={job.externalAssignedUsers?.join(", ")} />
-          <DetailRow label="Deadline" value={formatDate(job.externalDueDate)} />
-          <DetailRow label="External job ID" value={job.externalJobId} />
-          <DetailRow label="External task ID" value={job.externalTaskId} />
-          <DetailRow
-            label="Provider link"
-            value={
-              job.externalUrl ? (
-                <Link
-                  href={job.externalUrl}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="text-foreground underline decoration-foreground/24 underline-offset-4 hover:decoration-foreground/48"
-                >
-                  Open in {job.externalProviderKind}
-                </Link>
-              ) : (
-                "—"
-              )
-            }
-          />
-          <DetailRow label="Raw error" value={job.lastError} />
-        </dl>
-      </section>
-
-      {projectId ? (
+    <JobProviderDetailSectionView
+      job={job}
+      jobId={jobId}
+      organizationSlug={organizationSlug}
+      projectId={projectId}
+      agentRuns={agentRunsQuery.data}
+      agentRunsLoading={agentRunsQuery.isLoading}
+      agentRunsError={agentRunsQuery.isError ? agentRunsQuery.error : undefined}
+      pendingActionId={startAgentRun.isPending ? startAgentRun.variables : null}
+      onStartAgentRun={(actionId) => startAgentRun.mutate(actionId)}
+      renderSourceFiles={({ job: providerJob, organizationSlug: orgSlug, projectId: projId }) => (
         <SyncedJobSourceFilesSection
-          organizationSlug={organizationSlug}
-          projectId={projectId}
-          providerKind={job.externalProviderKind}
-          sourceFiles={sourceFiles}
-          highlightLocale={job.externalTargetLocales?.[0] ?? null}
+          organizationSlug={orgSlug}
+          projectId={projId}
+          providerKind={providerJob.externalProviderKind}
+          sourceFiles={providerJob.providerSourceFiles ?? []}
+          highlightLocale={providerJob.externalTargetLocales?.[0] ?? null}
         />
-      ) : null}
-
-      {visibleActions.length > 0 ? (
-        <section className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
-          <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
-            Agent Actions
-          </TypographyH2>
-          <div className="mt-4 flex flex-wrap gap-2">
-            {visibleActions.map((action) => (
-              <Button
-                key={action.id}
-                size="sm"
-                variant={action.id === "push_approved_changes" ? "outline" : "default"}
-                disabled={!action.enabled || startAgentRun.isPending}
-                title={action.disabledReason}
-                onClick={() => startAgentRun.mutate(action.id)}
-              >
-                <HugeiconsIcon icon={actionIcon(action.id)} strokeWidth={1.8} />
-                {startAgentRun.isPending && startAgentRun.variables === action.id
-                  ? "Starting..."
-                  : action.label}
-              </Button>
-            ))}
-          </div>
-        </section>
-      ) : null}
-
-      <JobQaFindingsSection
-        jobId={jobId}
-        organizationSlug={organizationSlug}
-        projectId={projectId}
-        externalUrl={job.externalUrl}
-        agentRuns={agentRunsQuery.data}
-        agentRunsLoading={agentRunsQuery.isLoading}
-        providerActions={job.providerActions ?? []}
-        onAgentRunStarted={async () => {
-          await Promise.all([
-            queryClient.invalidateQueries({ queryKey: agentRunsQueryKey }),
-            queryClient.invalidateQueries({ queryKey: jobQueryKey }),
-          ]);
-        }}
-      />
-
-      <JobAgentRunDiffReviewSection
-        jobId={jobId}
-        organizationSlug={organizationSlug}
-        agentRuns={agentRunsQuery.data}
-        agentRunsLoading={agentRunsQuery.isLoading}
-      />
-
-      <section className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
-        <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
-          Agent Activity
-        </TypographyH2>
-        {agentRunsQuery.isLoading ? (
-          <Skeleton className="mt-4 h-20 w-full bg-foreground/8" />
-        ) : null}
-        {agentRunsQuery.isError ? (
-          <p className="mt-4 text-sm text-flame-100">
-            {agentRunsQuery.error instanceof Error
-              ? agentRunsQuery.error.message
-              : "Unable to load agent runs"}
-          </p>
-        ) : null}
-        {agentRunsQuery.data && agentRunsQuery.data.length > 0 ? (
-          <ul className="mt-4 space-y-2">
-            {agentRunsQuery.data.map((run) => {
-              const hasProposals = agentRunHasReviewableProposals({
-                kind: run.kind,
-                status: run.status,
-                changedItems: run.changedItems,
-              });
-              const proposedCount =
-                typeof run.outputSummary.proposedCount === "number"
-                  ? run.outputSummary.proposedCount
-                  : run.changedItems.length;
-              const translationMemoryUsage = parseTranslationMemoryUsageFromOutputSummary(
-                run.outputSummary,
-              );
-              const translationMemoryMatchCount =
-                countTranslationMemoryMatchesInUsage(translationMemoryUsage);
-              const glossaryUsage = parseGlossaryUsageFromOutputSummary(run.outputSummary);
-              const glossaryMatchCount = countGlossaryMatchesInUsage(glossaryUsage);
-
-              return (
-                <li
-                  key={run.id}
-                  className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-foreground/8 bg-foreground/3.5 px-3 py-2"
-                >
-                  <div className="min-w-0">
-                    <p className="text-sm font-medium capitalize text-foreground/82">
-                      {run.kind.replaceAll("_", " ")}
-                    </p>
-                    <p className="text-xs text-foreground/48">
-                      Started {formatDate(run.createdAt)}
-                      {hasProposals ? ` · ${proposedCount} proposals` : null}
-                      {translationMemoryMatchCount > 0
-                        ? ` · ${translationMemoryMatchCount} TM match${translationMemoryMatchCount === 1 ? "" : "es"}`
-                        : null}
-                      {glossaryMatchCount > 0
-                        ? ` · ${glossaryMatchCount} glossary match${glossaryMatchCount === 1 ? "" : "es"}`
-                        : null}
-                    </p>
-                  </div>
-                  <div className="flex flex-wrap items-center gap-2">
-                    {hasProposals ? (
-                      <Badge variant="outline" className="rounded-full">
-                        Review proposals
-                      </Badge>
-                    ) : null}
-                    <Badge
-                      variant="outline"
-                      className={cn("rounded-full capitalize", toneClass(agentRunTone(run.status)))}
-                    >
-                      {run.status}
-                    </Badge>
-                  </div>
-                </li>
-              );
-            })}
-          </ul>
-        ) : null}
-        {agentRunsQuery.data && agentRunsQuery.data.length === 0 ? (
-          <p className="mt-4 text-sm text-foreground/48">No agent runs yet.</p>
-        ) : null}
-      </section>
-    </>
+      )}
+      renderQaFindings={(props) => (
+        <JobQaFindingsSection
+          jobId={props.jobId}
+          organizationSlug={props.organizationSlug}
+          projectId={props.projectId}
+          externalUrl={props.job.externalUrl}
+          agentRuns={props.agentRuns}
+          agentRunsLoading={props.agentRunsLoading}
+          providerActions={props.job.providerActions ?? []}
+          onAgentRunStarted={async () => {
+            await Promise.all([
+              queryClient.invalidateQueries({ queryKey: agentRunsQueryKey }),
+              queryClient.invalidateQueries({ queryKey: jobQueryKey }),
+            ]);
+          }}
+        />
+      )}
+      renderDiffReview={(props) => (
+        <JobAgentRunDiffReviewSection
+          jobId={props.jobId}
+          organizationSlug={props.organizationSlug}
+          agentRuns={props.agentRuns}
+          agentRunsLoading={props.agentRunsLoading}
+        />
+      )}
+    />
   );
 }

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/native-job-detail-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/native-job-detail-view.stories.tsx
@@ -1,0 +1,98 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect } from "storybook/test";
+
+import {
+  createNativeJobDetail,
+  createProviderBackedJobDetail,
+  toProviderBackedJobFields,
+} from "./job-detail.fixture";
+import { JobProviderDetailSectionView } from "./job-provider-detail-section-view";
+import { NativeJobDetailView } from "./native-job-detail-view";
+
+const meta = {
+  title: "App/Jobs/Detail/Native",
+  component: NativeJobDetailView,
+  parameters: {
+    layout: "fullscreen",
+  },
+} satisfies Meta<typeof NativeJobDetailView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const RunningTranslationJob: Story = {
+  args: {
+    jobId: "job_translate_homepage",
+    organizationSlug: "acme",
+    projectId: "project_website",
+    job: createNativeJobDetail(),
+    isLoading: false,
+    onRetry: () => undefined,
+    onMarkFailed: () => undefined,
+  },
+  play: async ({ canvas }) => {
+    await expect(
+      canvas.getByRole("heading", { name: "job_translate_homepage" }),
+    ).toBeInTheDocument();
+    await expect(canvas.getByText("Overview")).toBeInTheDocument();
+  },
+};
+
+export const FailedJob: Story = {
+  args: {
+    jobId: "job_translate_homepage",
+    organizationSlug: "acme",
+    projectId: "project_website",
+    job: createNativeJobDetail({
+      status: "failed",
+      lastError: "Translation provider timed out after 120 seconds.",
+    }),
+    isLoading: false,
+    onRetry: () => undefined,
+    onMarkFailed: () => undefined,
+  },
+};
+
+export const ProviderBackedJob: Story = {
+  args: {
+    jobId: "job_crowdin_1204",
+    organizationSlug: "acme",
+    projectId: "project_website",
+    job: createProviderBackedJobDetail(),
+    isLoading: false,
+    renderProviderDetailSection: ({ job, jobId, organizationSlug, projectId }) => (
+      <JobProviderDetailSectionView
+        job={toProviderBackedJobFields(job)}
+        jobId={jobId}
+        organizationSlug={organizationSlug}
+        projectId={projectId}
+        agentRuns={[]}
+        agentRunsLoading={false}
+        onStartAgentRun={() => undefined}
+      />
+    ),
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Translate marketing homepage")).toBeInTheDocument();
+    await expect(canvas.getByText("Provider Details")).toBeInTheDocument();
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    jobId: "job_translate_homepage",
+    organizationSlug: "acme",
+    projectId: "project_website",
+    isLoading: true,
+  },
+};
+
+export const LoadError: Story = {
+  args: {
+    jobId: "job_translate_homepage",
+    organizationSlug: "acme",
+    projectId: "project_website",
+    isLoading: false,
+    error: "Failed to load job (404)",
+  },
+};

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/native-job-detail-view.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/native-job-detail-view.tsx
@@ -61,7 +61,10 @@ function DetailRow({ label, value }: { label: string; value: ReactNode }) {
   );
 }
 
-function defaultRenderBackLink({ href, children }: Parameters<JobDetailBackLinkRenderer>[0]) {
+export function defaultRenderBackLink({
+  href,
+  children,
+}: Parameters<JobDetailBackLinkRenderer>[0]) {
   return (
     <Button
       nativeButton={false}
@@ -75,7 +78,7 @@ function defaultRenderBackLink({ href, children }: Parameters<JobDetailBackLinkR
   );
 }
 
-function defaultRenderError({ error }: Parameters<JobDetailErrorRenderer>[0]) {
+export function defaultRenderError({ error }: Parameters<JobDetailErrorRenderer>[0]) {
   return (
     <div className="rounded-lg border border-flame-300/20 bg-flame-300/8 p-5 text-sm text-flame-100">
       {error instanceof Error ? error.message : "Unable to load job"}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/native-job-detail-view.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/native-job-detail-view.tsx
@@ -1,0 +1,308 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import Link from "next/link";
+import { ArrowLeft02Icon, RefreshIcon, StopCircleIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { TypographyH1, TypographyH2 } from "@/components/ui/typography";
+import { cn } from "@/lib/primitives/cn";
+
+import { toneClass } from "../../../../../_components/workspace-resource-shared";
+
+import {
+  buildJobsListHref,
+  canMarkJobFailed,
+  canRetryJob,
+  formatJobDetailDate,
+  formatJobDetailKind,
+  isProviderBackedJob,
+  jobDetailStatusTone,
+  type JobDetailRecord,
+} from "./job-detail-types";
+
+export type JobDetailBackLinkRenderer = (props: { href: string; children: ReactNode }) => ReactNode;
+
+export type JobDetailErrorRenderer = (props: { error: unknown }) => ReactNode;
+
+export type JobDetailProviderSectionRenderer = (props: {
+  job: JobDetailRecord & { externalProviderKind: string };
+  jobId: string;
+  organizationSlug: string;
+  projectId: string | null;
+}) => ReactNode;
+
+function JsonBlock({ value }: { value: unknown }) {
+  return (
+    <pre className="max-h-96 overflow-auto rounded-lg border border-foreground/8 bg-foreground/3.5 p-4 text-xs leading-6 text-foreground/72">
+      {JSON.stringify(value ?? null, null, 2)}
+    </pre>
+  );
+}
+
+function DetailRow({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <div className="grid gap-1 py-3 sm:grid-cols-[12rem_minmax(0,1fr)] sm:gap-4">
+      <dt className="text-sm text-foreground/42">{label}</dt>
+      <dd className="min-w-0 wrap-break-word text-sm text-foreground/74">{value ?? "—"}</dd>
+    </div>
+  );
+}
+
+function defaultRenderBackLink({ href, children }: Parameters<JobDetailBackLinkRenderer>[0]) {
+  return (
+    <Button
+      nativeButton={false}
+      render={<Link href={href} />}
+      variant="ghost"
+      className="-ml-2 mb-2 text-foreground/54 hover:bg-foreground/6 hover:text-foreground"
+    >
+      <HugeiconsIcon icon={ArrowLeft02Icon} strokeWidth={1.8} />
+      {children}
+    </Button>
+  );
+}
+
+function defaultRenderError({ error }: Parameters<JobDetailErrorRenderer>[0]) {
+  return (
+    <div className="rounded-lg border border-flame-300/20 bg-flame-300/8 p-5 text-sm text-flame-100">
+      {error instanceof Error ? error.message : "Unable to load job"}
+    </div>
+  );
+}
+
+export function NativeJobDetailView({
+  buildJobsListHref: buildJobsListHrefProp = buildJobsListHref,
+  error,
+  isLoading,
+  isMarkFailedPending = false,
+  isRetryPending = false,
+  job,
+  jobId,
+  markFailedDialogOpen: controlledMarkFailedDialogOpen,
+  onMarkFailed,
+  onMarkFailedDialogOpenChange,
+  onRetry,
+  organizationSlug,
+  projectId,
+  renderBackLink = defaultRenderBackLink,
+  renderError = defaultRenderError,
+  renderProviderDetailSection,
+}: {
+  buildJobsListHref?: typeof buildJobsListHref;
+  error?: unknown;
+  isLoading: boolean;
+  isMarkFailedPending?: boolean;
+  isRetryPending?: boolean;
+  job?: JobDetailRecord;
+  jobId: string;
+  markFailedDialogOpen?: boolean;
+  onMarkFailed?: () => void;
+  onMarkFailedDialogOpenChange?: (open: boolean) => void;
+  onRetry?: () => void;
+  organizationSlug: string;
+  projectId: string;
+  renderBackLink?: JobDetailBackLinkRenderer;
+  renderError?: JobDetailErrorRenderer;
+  renderProviderDetailSection?: JobDetailProviderSectionRenderer;
+}) {
+  const [uncontrolledMarkFailedDialogOpen, setUncontrolledMarkFailedDialogOpen] = useState(false);
+  const markFailedDialogOpen = controlledMarkFailedDialogOpen ?? uncontrolledMarkFailedDialogOpen;
+  const setMarkFailedDialogOpen =
+    onMarkFailedDialogOpenChange ?? setUncontrolledMarkFailedDialogOpen;
+
+  const showActions = job ? canRetryJob(job) || canMarkJobFailed(job) : false;
+  const jobsListHref = buildJobsListHrefProp(organizationSlug, projectId);
+
+  return (
+    <main className="mx-auto flex w-full max-w-6xl flex-col gap-5">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          {renderBackLink({ href: jobsListHref, children: "Jobs" })}
+          <TypographyH1 className="wrap-break-word font-heading text-3xl font-semibold text-foreground md:text-4xl">
+            {job?.externalTitle ?? job?.id ?? jobId}
+          </TypographyH1>
+        </div>
+        {job ? (
+          <div className="flex flex-col items-start gap-3 sm:items-end">
+            <Badge
+              variant="outline"
+              className={cn(
+                "w-fit rounded-full capitalize",
+                toneClass(jobDetailStatusTone(job.status)),
+              )}
+            >
+              {job.status}
+            </Badge>
+            {showActions ? (
+              <div className="flex flex-wrap gap-2 sm:justify-end">
+                {canRetryJob(job) && onRetry ? (
+                  <Button
+                    size="sm"
+                    disabled={isRetryPending || isMarkFailedPending}
+                    onClick={onRetry}
+                  >
+                    <HugeiconsIcon icon={RefreshIcon} strokeWidth={1.8} />
+                    {isRetryPending ? "Retrying..." : "Retry job"}
+                  </Button>
+                ) : null}
+                {canMarkJobFailed(job) && onMarkFailed ? (
+                  <Button
+                    size="sm"
+                    variant="destructive"
+                    disabled={isRetryPending || isMarkFailedPending}
+                    onClick={() => setMarkFailedDialogOpen(true)}
+                  >
+                    <HugeiconsIcon icon={StopCircleIcon} strokeWidth={1.8} />
+                    Mark as failed
+                  </Button>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+
+      {isLoading ? (
+        <div className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
+          <Skeleton className="h-5 w-48 bg-foreground/8" />
+          <Skeleton className="mt-4 h-40 w-full bg-foreground/8" />
+        </div>
+      ) : null}
+
+      {error ? renderError({ error }) : null}
+
+      {job ? (
+        <>
+          <section className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
+            <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
+              Overview
+            </TypographyH2>
+            <dl className="mt-3 divide-y divide-foreground/8">
+              <DetailRow label="Job ID" value={job.id} />
+              <DetailRow label="Kind" value={formatJobDetailKind(job)} />
+              <DetailRow
+                label="Source"
+                value={
+                  isProviderBackedJob(job) ? `Provider · ${job.externalProviderKind}` : "Native"
+                }
+              />
+              <DetailRow label="Project" value={job.projectName ?? job.projectId ?? "Workspace"} />
+              <DetailRow label="Interaction" value={job.interactionId} />
+              <DetailRow label="Workflow run" value={job.workflowRunId} />
+              <DetailRow label="Created" value={formatJobDetailDate(job.createdAt)} />
+              <DetailRow label="Updated" value={formatJobDetailDate(job.updatedAt)} />
+              <DetailRow label="Completed" value={formatJobDetailDate(job.completedAt)} />
+              <DetailRow label="Last error" value={job.lastError} />
+            </dl>
+          </section>
+
+          {isProviderBackedJob(job) && renderProviderDetailSection
+            ? renderProviderDetailSection({
+                job,
+                jobId,
+                organizationSlug,
+                projectId: job.projectId,
+              })
+            : null}
+
+          {job.kind === "review" || job.kind === "sync" || job.kind === "asset_management" ? (
+            <section className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
+              <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
+                Kind Details
+              </TypographyH2>
+              <dl className="mt-3 divide-y divide-foreground/8">
+                {job.kind === "review" ? (
+                  <>
+                    <DetailRow label="Criteria" value={job.reviewCriteria} />
+                    <DetailRow label="Target locale" value={job.reviewTargetLocale} />
+                  </>
+                ) : null}
+                {job.kind === "sync" ? (
+                  <>
+                    <DetailRow label="Connector" value={job.syncConnectorKind} />
+                    <DetailRow label="Direction" value={job.syncDirection} />
+                  </>
+                ) : null}
+                {job.kind === "asset_management" ? (
+                  <>
+                    <DetailRow label="Asset type" value={job.assetType} />
+                    <DetailRow label="Operation" value={job.assetOperation} />
+                  </>
+                ) : null}
+              </dl>
+            </section>
+          ) : null}
+
+          <section className="grid gap-4 xl:grid-cols-2">
+            <div className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
+              <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
+                Input
+              </TypographyH2>
+              <div className="mt-4">
+                <JsonBlock value={job.inputPayload} />
+              </div>
+            </div>
+            <div className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
+              <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
+                Output
+              </TypographyH2>
+              <div className="mt-4">
+                <JsonBlock value={job.outcomePayload} />
+              </div>
+            </div>
+          </section>
+
+          <section className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
+            <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
+              Context Snapshot
+            </TypographyH2>
+            <div className="mt-4">
+              <JsonBlock value={job.contextSnapshot} />
+            </div>
+          </section>
+        </>
+      ) : null}
+
+      {onMarkFailed ? (
+        <AlertDialog
+          open={markFailedDialogOpen}
+          onOpenChange={(open) => {
+            if (!isMarkFailedPending) {
+              setMarkFailedDialogOpen(open);
+            }
+          }}
+        >
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Mark job as failed?</AlertDialogTitle>
+              <AlertDialogDescription>
+                This will stop the job from appearing queued or running and prevent the current
+                workflow run from updating it later.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={isMarkFailedPending}>Cancel</AlertDialogCancel>
+              <Button variant="destructive" disabled={isMarkFailedPending} onClick={onMarkFailed}>
+                <HugeiconsIcon icon={StopCircleIcon} strokeWidth={1.8} />
+                {isMarkFailedPending ? "Marking..." : "Mark failed"}
+              </Button>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      ) : null}
+    </main>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-content.tsx
@@ -1,337 +1,16 @@
 "use client";
 
-import Link from "next/link";
-import {
-  ArrowLeft02Icon,
-  Clock01Icon,
-  File01Icon,
-  LanguageSquareIcon,
-  LinkSquare02Icon,
-  RefreshIcon,
-  Task01Icon,
-} from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Skeleton } from "@/components/ui/skeleton";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { TypographyH1, TypographyH2 } from "@/components/ui/typography";
 import { apiClient } from "@/lib/api-client-instance";
-import { cn } from "@/lib/primitives/cn";
 import type {
   TmsProviderLiveJobComment,
   TmsProviderLiveJobDetail,
 } from "@/lib/providers/tms-provider-live";
 
-import { toneClass } from "../../../../../_components/workspace-resource-shared";
-import { JobDetailRow } from "../../../../../jobs/_components/provider-crowdin-job-detail-rows";
 import { ProviderJobDescriptionField } from "../../../../../jobs/_components/provider-job-description-field";
+import { ProviderLiveJobDetailView } from "./provider-live-job-detail-view";
 import { TmsLiveJobFilesSection } from "./tms/tms-live-job-files-section";
-import {
-  formatReadinessProgress,
-  formatLocaleList,
-  getCrowdinTargetLocales,
-  formatWordsToDo,
-  getCrowdinLanguageLabel,
-  getCrowdinLocaleReadiness,
-  getCrowdinTaskTypeLabel,
-  getProviderPayloadString,
-  getReadinessNumber,
-  getReadinessWords,
-} from "../../../../../jobs/_components/provider-crowdin-job-display";
-
-function statusTone(status: TmsProviderLiveJobDetail["status"]) {
-  switch (status) {
-    case "succeeded":
-      return "safe";
-    case "failed":
-      return "risk";
-    case "queued":
-    case "waiting_for_review":
-      return "watch";
-    default:
-      return "info";
-  }
-}
-
-const DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
-  dateStyle: "medium",
-  timeStyle: "short",
-});
-
-function formatDate(value: string | null | undefined) {
-  if (!value) return "—";
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return value;
-  return DATE_FORMATTER.format(date);
-}
-
-function formatJobKind(job: TmsProviderLiveJobDetail) {
-  return job.kind.replaceAll("_", " ");
-}
-
-function formatProviderKind(kind: string | null | undefined) {
-  if (!kind) return "Provider";
-  return kind.charAt(0).toUpperCase() + kind.slice(1);
-}
-
-function formatTimeSpent(seconds: number | null) {
-  if (!seconds || seconds <= 0) {
-    return null;
-  }
-
-  const minutes = Math.round(seconds / 60);
-  if (minutes < 60) {
-    return `${minutes} min`;
-  }
-
-  const hours = Math.floor(minutes / 60);
-  const remainingMinutes = minutes % 60;
-  return remainingMinutes > 0 ? `${hours} hr ${remainingMinutes} min` : `${hours} hr`;
-}
-
-function MetricItem({
-  icon,
-  label,
-}: {
-  icon: Parameters<typeof HugeiconsIcon>[0]["icon"];
-  label: string;
-}) {
-  return (
-    <span className="inline-flex min-w-0 items-center gap-2 text-sm text-foreground/58">
-      <HugeiconsIcon icon={icon} strokeWidth={1.8} className="size-4 shrink-0 text-foreground/42" />
-      <span className="truncate">{label}</span>
-    </span>
-  );
-}
-
-function getProgressValue(job: TmsProviderLiveJobDetail) {
-  const readiness = getCrowdinLocaleReadiness(job.externalProviderPayload);
-  const translationProgress = getReadinessNumber(readiness, "translationProgress");
-  const approvalProgress = getReadinessNumber(readiness, "approvalProgress");
-  return Math.max(0, Math.min(100, Math.round(translationProgress ?? approvalProgress ?? 0)));
-}
-
-function getWordsProgress(job: TmsProviderLiveJobDetail) {
-  const readiness = getCrowdinLocaleReadiness(job.externalProviderPayload);
-  const words = getReadinessWords(readiness);
-  const total = getReadinessNumber(words, "total");
-  const translated = getReadinessNumber(words, "translated");
-  const approved = getReadinessNumber(words, "approved");
-
-  if (total === null) {
-    return null;
-  }
-
-  return {
-    completed: Math.max(0, translated ?? approved ?? 0),
-    total,
-  };
-}
-
-function TaskDescriptionSection({
-  canEditProviderJobDescription,
-  description,
-  job,
-  jobQueryKey,
-  organizationSlug,
-}: {
-  canEditProviderJobDescription: boolean;
-  description: string;
-  job: TmsProviderLiveJobDetail;
-  jobQueryKey: readonly unknown[];
-  organizationSlug: string;
-}) {
-  const canEditProviderDescription = job.id.startsWith("ext:");
-
-  return (
-    <section className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
-      <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
-        Task description
-      </TypographyH2>
-      <div className="mt-4">
-        <ProviderJobDescriptionField
-          organizationSlug={organizationSlug}
-          encodedJobId={job.id}
-          description={description}
-          editable={canEditProviderJobDescription && canEditProviderDescription}
-          queryKey={jobQueryKey}
-        />
-      </div>
-    </section>
-  );
-}
-
-function StatusSummaryCard({ job }: { job: TmsProviderLiveJobDetail }) {
-  const readiness = getCrowdinLocaleReadiness(job.externalProviderPayload);
-  const hasReadiness = readiness !== null;
-  const progress = hasReadiness ? getProgressValue(job) : null;
-  const progressLabel =
-    hasReadiness && progress !== null
-      ? (formatReadinessProgress(readiness) ?? `${progress}% translated`)
-      : null;
-  const wordsProgress = hasReadiness ? getWordsProgress(job) : null;
-
-  return (
-    <section className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
-      <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
-        Status
-      </TypographyH2>
-      <Badge
-        variant="outline"
-        className={cn("mt-5 w-fit rounded-full capitalize", toneClass(statusTone(job.status)))}
-      >
-        {job.status}
-      </Badge>
-      {progress !== null && progressLabel !== null ? (
-        <div className="mt-7">
-          <div className="flex items-baseline gap-2">
-            <span className="text-3xl font-semibold text-foreground">{progress}%</span>
-            <span className="text-sm text-foreground/58">
-              {progressLabel.replace(/^\d+%\s*/, "")}
-            </span>
-          </div>
-          <div
-            className="mt-4 h-1.5 overflow-hidden rounded-full bg-foreground/10"
-            role="progressbar"
-            aria-label="Translation progress"
-            aria-valuemin={0}
-            aria-valuemax={100}
-            aria-valuenow={progress}
-          >
-            <div className="h-full rounded-full bg-primary" style={{ width: `${progress}%` }} />
-          </div>
-          {wordsProgress ? (
-            <p className="mt-3 text-sm text-foreground/52">
-              {wordsProgress.completed} / {wordsProgress.total} words
-            </p>
-          ) : null}
-        </div>
-      ) : (
-        <p className="mt-5 text-sm text-foreground/58">
-          Provider status: {job.externalStatus || job.status}
-        </p>
-      )}
-    </section>
-  );
-}
-
-function TaskDetailsCard({ job }: { job: TmsProviderLiveJobDetail }) {
-  const providerName = formatProviderKind(job.externalProviderKind);
-  const targetLocales = formatLocaleList(
-    getCrowdinTargetLocales(job.externalProviderPayload, job.externalTargetLocales),
-  );
-  const taskType = getCrowdinTaskTypeLabel(job.externalProviderPayload) ?? formatJobKind(job);
-  const wordsToDo = formatWordsToDo(getCrowdinLocaleReadiness(job.externalProviderPayload));
-
-  return (
-    <section className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
-      <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
-        Details
-      </TypographyH2>
-      <dl className="mt-3 divide-y divide-foreground/8">
-        <JobDetailRow label="Provider" value={providerName} />
-        <JobDetailRow label="Task type" value={taskType} />
-        <JobDetailRow label="Project" value={job.projectName ?? job.projectId} />
-        <JobDetailRow
-          label="Language"
-          value={getCrowdinLanguageLabel(job.externalProviderPayload) ?? "—"}
-        />
-        <JobDetailRow label="Target locales" value={targetLocales} />
-        <JobDetailRow
-          label="Assignees"
-          value={job.externalAssignedUsers.length > 0 ? job.externalAssignedUsers.join(", ") : "—"}
-        />
-        <JobDetailRow label="Due date" value={formatDate(job.externalDueDate)} />
-        <JobDetailRow label="Last sync" value={formatDate(job.updatedAt)} />
-        {wordsToDo ? <JobDetailRow label="Words to do" value={wordsToDo} /> : null}
-        <JobDetailRow label="External job ID" value={job.externalJobId} />
-        <JobDetailRow label="External task ID" value={job.id} />
-      </dl>
-    </section>
-  );
-}
-
-function TaskCommentsSection({
-  comments,
-  isError,
-  isLoading,
-}: {
-  comments: TmsProviderLiveJobComment[];
-  isError: boolean;
-  isLoading: boolean;
-}) {
-  return (
-    <section className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
-      <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
-        Task comments
-      </TypographyH2>
-
-      {isLoading ? (
-        <div className="mt-4 space-y-3">
-          <Skeleton className="h-16 w-full bg-foreground/8" />
-          <Skeleton className="h-16 w-full bg-foreground/8" />
-        </div>
-      ) : null}
-
-      {isError ? (
-        <p className="mt-4 text-sm text-flame-100">Unable to load task comments.</p>
-      ) : null}
-
-      {!isLoading && !isError && comments.length === 0 ? (
-        <p className="mt-4 text-sm text-foreground/52">No task comments yet.</p>
-      ) : null}
-
-      {!isLoading && !isError && comments.length > 0 ? (
-        <ul className="mt-4 divide-y divide-foreground/8 rounded-md border border-foreground/8 bg-background/50">
-          {comments.map((comment) => {
-            const timeSpent = formatTimeSpent(comment.timeSpentSeconds);
-
-            return (
-              <li key={comment.id} className="px-3 py-3">
-                <div className="flex flex-wrap items-center justify-between gap-2">
-                  <span className="text-sm font-medium text-foreground">User {comment.userId}</span>
-                  <span className="text-xs text-foreground/42">
-                    {formatDate(comment.createdAt)}
-                  </span>
-                </div>
-                <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-foreground/74">
-                  {comment.text}
-                </p>
-                {timeSpent ? (
-                  <p className="mt-2 text-xs text-foreground/42">Time spent: {timeSpent}</p>
-                ) : null}
-              </li>
-            );
-          })}
-        </ul>
-      ) : null}
-    </section>
-  );
-}
-
-function TaskActivitySection({ job }: { job: TmsProviderLiveJobDetail }) {
-  return (
-    <section className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
-      <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
-        Activity
-      </TypographyH2>
-      <ul className="mt-4 divide-y divide-foreground/8 rounded-md border border-foreground/8 bg-background/50">
-        <li className="px-3 py-3">
-          <div className="flex flex-wrap items-center justify-between gap-2">
-            <span className="text-sm font-medium text-foreground">Task refreshed</span>
-            <span className="text-xs text-foreground/42">{formatDate(job.updatedAt)}</span>
-          </div>
-          <p className="mt-2 text-sm leading-6 text-foreground/58">
-            Latest provider status is {job.status}.
-          </p>
-        </li>
-      </ul>
-    </section>
-  );
-}
 
 export function ProviderLiveJobDetailContent({
   jobId,
@@ -383,160 +62,50 @@ export function ProviderLiveJobDetailContent({
     },
   });
 
-  const job = jobQuery.data;
-  const providerDescription = job
-    ? (getProviderPayloadString(job.externalProviderPayload, "description") ?? "")
-    : "";
-  const canEditProviderDescription = Boolean(
-    job && canEditProviderJobDescription && job.id.startsWith("ext:"),
-  );
-  const showTaskDescriptionSection =
-    providerDescription.trim().length > 0 || canEditProviderDescription;
-
   return (
-    <main className="mx-auto flex w-full max-w-7xl flex-col gap-5">
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-        <div className="min-w-0">
-          <Button
-            nativeButton={false}
-            render={
-              <Link
-                href={`/org/${organizationSlug}/projects/${encodeURIComponent(projectId)}/jobs`}
-              />
+    <ProviderLiveJobDetailView
+      jobId={jobId}
+      organizationSlug={organizationSlug}
+      projectId={projectId}
+      canEditProviderJobDescription={canEditProviderJobDescription}
+      job={jobQuery.data}
+      isLoading={jobQuery.isLoading}
+      error={jobQuery.isError ? jobQuery.error : undefined}
+      isRefreshing={jobQuery.isFetching}
+      onRefresh={() => {
+        void queryClient.invalidateQueries({ queryKey: jobQueryKey });
+      }}
+      comments={commentsQuery.data ?? []}
+      commentsLoading={commentsQuery.isLoading}
+      commentsError={commentsQuery.isError ? commentsQuery.error : undefined}
+      renderDescriptionField={({ description, editable, job }) => (
+        <ProviderJobDescriptionField
+          organizationSlug={organizationSlug}
+          encodedJobId={job.id}
+          description={description}
+          editable={editable}
+          queryKey={jobQueryKey}
+        />
+      )}
+      renderFilesSection={({
+        job,
+        jobId: encodedJobId,
+        organizationSlug: orgSlug,
+        projectId: projId,
+      }) =>
+        job.externalProviderKind === "crowdin" ? (
+          <TmsLiveJobFilesSection
+            organizationSlug={orgSlug}
+            projectId={projId}
+            encodedJobId={encodedJobId}
+            highlightLocale={
+              typeof job.externalProviderPayload.languageId === "string"
+                ? job.externalProviderPayload.languageId
+                : null
             }
-            variant="ghost"
-            className="-ml-2 mb-2 text-foreground/54 hover:bg-foreground/6 hover:text-foreground"
-          >
-            <HugeiconsIcon icon={ArrowLeft02Icon} strokeWidth={1.8} />
-            Jobs
-          </Button>
-          <TypographyH1 className="wrap-break-word font-heading text-3xl font-semibold text-foreground md:text-4xl">
-            {job?.externalTitle ?? jobId}
-          </TypographyH1>
-          {job ? (
-            <div className="mt-4 flex flex-wrap items-center gap-x-6 gap-y-2">
-              <MetricItem
-                icon={Task01Icon}
-                label={`${formatProviderKind(job.externalProviderKind)} task`}
-              />
-              <MetricItem
-                icon={LanguageSquareIcon}
-                label={
-                  getCrowdinLanguageLabel(job.externalProviderPayload) ??
-                  formatLocaleList(
-                    getCrowdinTargetLocales(job.externalProviderPayload, job.externalTargetLocales),
-                  )
-                }
-              />
-              <MetricItem
-                icon={File01Icon}
-                label={
-                  formatWordsToDo(getCrowdinLocaleReadiness(job.externalProviderPayload)) ??
-                  "Source files linked"
-                }
-              />
-              <MetricItem icon={Clock01Icon} label={`Last synced ${formatDate(job.updatedAt)}`} />
-            </div>
-          ) : null}
-        </div>
-        {job ? (
-          <div className="flex flex-col items-start gap-3 sm:items-end">
-            <div className="flex flex-wrap gap-2 sm:justify-end">
-              {job.externalUrl ? (
-                <Button
-                  nativeButton={false}
-                  render={
-                    <a href={job.externalUrl} target="_blank" rel="noreferrer noopener">
-                      <HugeiconsIcon icon={LinkSquare02Icon} strokeWidth={1.8} />
-                      Open in {job.externalProviderKind}
-                    </a>
-                  }
-                  size="sm"
-                  variant="outline"
-                />
-              ) : null}
-              <Button
-                size="sm"
-                variant="outline"
-                disabled={jobQuery.isFetching}
-                onClick={() => {
-                  void queryClient.invalidateQueries({ queryKey: jobQueryKey });
-                }}
-              >
-                <HugeiconsIcon icon={RefreshIcon} strokeWidth={1.8} />
-                {jobQuery.isFetching ? "Refreshing..." : "Refresh"}
-              </Button>
-              <Tooltip>
-                <TooltipTrigger
-                  render={
-                    <Button size="sm" disabled>
-                      Run with agent
-                    </Button>
-                  }
-                />
-                <TooltipContent>Agent workflows on provider tasks are coming soon.</TooltipContent>
-              </Tooltip>
-            </div>
-          </div>
-        ) : null}
-      </div>
-
-      {jobQuery.isLoading ? (
-        <div className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
-          <Skeleton className="h-5 w-48 bg-foreground/8" />
-          <Skeleton className="mt-4 h-40 w-full bg-foreground/8" />
-        </div>
-      ) : null}
-
-      {jobQuery.isError ? (
-        <div className="rounded-lg border border-flame-300/20 bg-flame-300/8 p-5 text-sm text-flame-100">
-          {jobQuery.error instanceof Error ? jobQuery.error.message : "Unable to load provider job"}
-        </div>
-      ) : null}
-
-      {job ? (
-        <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_20rem]">
-          <div className="flex min-w-0 flex-col gap-5">
-            {showTaskDescriptionSection ? (
-              <TaskDescriptionSection
-                canEditProviderJobDescription={canEditProviderJobDescription}
-                description={providerDescription}
-                job={job}
-                jobQueryKey={jobQueryKey}
-                organizationSlug={organizationSlug}
-              />
-            ) : null}
-
-            {job.externalProviderKind === "crowdin" ? (
-              <TmsLiveJobFilesSection
-                organizationSlug={organizationSlug}
-                projectId={projectId}
-                encodedJobId={jobId}
-                highlightLocale={
-                  typeof job.externalProviderPayload.languageId === "string"
-                    ? job.externalProviderPayload.languageId
-                    : null
-                }
-              />
-            ) : null}
-          </div>
-          <aside className="flex min-w-0 flex-col gap-5">
-            <StatusSummaryCard job={job} />
-            <TaskDetailsCard job={job} />
-          </aside>
-        </div>
-      ) : null}
-
-      {job?.externalProviderKind === "crowdin" ? (
-        <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_20rem]">
-          <TaskCommentsSection
-            comments={commentsQuery.data ?? []}
-            isError={commentsQuery.isError}
-            isLoading={commentsQuery.isLoading}
           />
-          <TaskActivitySection job={job} />
-        </div>
-      ) : null}
-    </main>
+        ) : null
+      }
+    />
   );
 }

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-view.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect } from "storybook/test";
+
+import { ProviderJobDescriptionFieldView } from "../../../../../jobs/_components/provider-job-description-field";
+import { createLiveCrowdinJobComments, createLiveCrowdinJobDetail } from "./job-detail.fixture";
+import { ProviderLiveJobDetailView } from "./provider-live-job-detail-view";
+
+const meta = {
+  title: "App/Jobs/Detail/Live Provider",
+  component: ProviderLiveJobDetailView,
+  parameters: {
+    layout: "fullscreen",
+  },
+} satisfies Meta<typeof ProviderLiveJobDetailView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const liveJob = createLiveCrowdinJobDetail();
+
+export const CrowdinTask: Story = {
+  args: {
+    jobId: liveJob.id,
+    organizationSlug: "acme",
+    projectId: "project_website",
+    job: liveJob,
+    isLoading: false,
+    canEditProviderJobDescription: true,
+    comments: createLiveCrowdinJobComments(),
+    commentsLoading: false,
+    onRefresh: () => undefined,
+    renderDescriptionField: ({ description, editable }) => (
+      <ProviderJobDescriptionFieldView
+        description={description}
+        editable={editable}
+        onSaveDescription={async (nextDescription) => nextDescription}
+      />
+    ),
+    renderFilesSection: () => (
+      <section className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
+        <p className="text-sm text-foreground/58">Source files panel (mock)</p>
+      </section>
+    ),
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Translate marketing homepage")).toBeInTheDocument();
+    await expect(canvas.getByText("68%")).toBeInTheDocument();
+    await expect(canvas.getByText(/Preserve product name casing/)).toBeInTheDocument();
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    jobId: liveJob.id,
+    organizationSlug: "acme",
+    projectId: "project_website",
+    isLoading: true,
+  },
+};
+
+export const LoadError: Story = {
+  args: {
+    jobId: liveJob.id,
+    organizationSlug: "acme",
+    projectId: "project_website",
+    isLoading: false,
+    error: "Crowdin needs a user connection.",
+  },
+};
+
+export const CommentsLoading: Story = {
+  args: {
+    jobId: liveJob.id,
+    organizationSlug: "acme",
+    projectId: "project_website",
+    job: liveJob,
+    isLoading: false,
+    commentsLoading: true,
+  },
+};

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-view.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-view.tsx
@@ -1,9 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
-import Link from "next/link";
 import {
-  ArrowLeft02Icon,
   Clock01Icon,
   File01Icon,
   LanguageSquareIcon,
@@ -40,7 +38,12 @@ import {
 } from "../../../../../jobs/_components/provider-crowdin-job-display";
 
 import { buildJobsListHref, formatJobDetailDate } from "./job-detail-types";
-import type { JobDetailBackLinkRenderer, JobDetailErrorRenderer } from "./native-job-detail-view";
+import {
+  defaultRenderBackLink,
+  defaultRenderError,
+  type JobDetailBackLinkRenderer,
+  type JobDetailErrorRenderer,
+} from "./native-job-detail-view";
 
 export type ProviderLiveDescriptionFieldRenderer = (props: {
   description: string;
@@ -216,7 +219,7 @@ function TaskDetailsCard({ job }: { job: TmsProviderLiveJobDetail }) {
         <JobDetailRow label="Last sync" value={formatJobDetailDate(job.updatedAt)} />
         {wordsToDo ? <JobDetailRow label="Words to do" value={wordsToDo} /> : null}
         <JobDetailRow label="External job ID" value={job.externalJobId} />
-        <JobDetailRow label="External task ID" value={job.id} />
+        <JobDetailRow label="External task ID" value={job.externalTaskId} />
       </dl>
     </section>
   );
@@ -298,28 +301,6 @@ function TaskActivitySection({ job }: { job: TmsProviderLiveJobDetail }) {
         </li>
       </ul>
     </section>
-  );
-}
-
-function defaultRenderBackLink({ href, children }: Parameters<JobDetailBackLinkRenderer>[0]) {
-  return (
-    <Button
-      nativeButton={false}
-      render={<Link href={href} />}
-      variant="ghost"
-      className="-ml-2 mb-2 text-foreground/54 hover:bg-foreground/6 hover:text-foreground"
-    >
-      <HugeiconsIcon icon={ArrowLeft02Icon} strokeWidth={1.8} />
-      {children}
-    </Button>
-  );
-}
-
-function defaultRenderError({ error }: Parameters<JobDetailErrorRenderer>[0]) {
-  return (
-    <div className="rounded-lg border border-flame-300/20 bg-flame-300/8 p-5 text-sm text-flame-100">
-      {error instanceof Error ? error.message : "Unable to load provider job"}
-    </div>
   );
 }
 

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-view.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-view.tsx
@@ -1,0 +1,506 @@
+"use client";
+
+import type { ReactNode } from "react";
+import Link from "next/link";
+import {
+  ArrowLeft02Icon,
+  Clock01Icon,
+  File01Icon,
+  LanguageSquareIcon,
+  LinkSquare02Icon,
+  RefreshIcon,
+  Task01Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { TypographyH1, TypographyH2 } from "@/components/ui/typography";
+import { cn } from "@/lib/primitives/cn";
+import type {
+  TmsProviderLiveJobComment,
+  TmsProviderLiveJobDetail,
+} from "@/lib/providers/tms-provider-live";
+
+import { toneClass } from "../../../../../_components/workspace-resource-shared";
+import { JobDetailRow } from "../../../../../jobs/_components/provider-crowdin-job-detail-rows";
+import {
+  formatReadinessProgress,
+  formatLocaleList,
+  getCrowdinTargetLocales,
+  formatWordsToDo,
+  getCrowdinLanguageLabel,
+  getCrowdinLocaleReadiness,
+  getCrowdinTaskTypeLabel,
+  getProviderPayloadString,
+  getReadinessNumber,
+  getReadinessWords,
+} from "../../../../../jobs/_components/provider-crowdin-job-display";
+
+import { buildJobsListHref, formatJobDetailDate } from "./job-detail-types";
+import type { JobDetailBackLinkRenderer, JobDetailErrorRenderer } from "./native-job-detail-view";
+
+export type ProviderLiveDescriptionFieldRenderer = (props: {
+  description: string;
+  editable: boolean;
+  job: TmsProviderLiveJobDetail;
+}) => ReactNode;
+
+export type ProviderLiveFilesSectionRenderer = (props: {
+  job: TmsProviderLiveJobDetail;
+  jobId: string;
+  organizationSlug: string;
+  projectId: string;
+}) => ReactNode;
+
+function statusTone(status: TmsProviderLiveJobDetail["status"]) {
+  switch (status) {
+    case "succeeded":
+      return "safe";
+    case "failed":
+      return "risk";
+    case "queued":
+    case "waiting_for_review":
+      return "watch";
+    default:
+      return "info";
+  }
+}
+
+function formatJobKind(job: TmsProviderLiveJobDetail) {
+  return job.kind.replaceAll("_", " ");
+}
+
+function formatProviderKind(kind: string | null | undefined) {
+  if (!kind) return "Provider";
+  return kind.charAt(0).toUpperCase() + kind.slice(1);
+}
+
+function formatTimeSpent(seconds: number | null) {
+  if (!seconds || seconds <= 0) {
+    return null;
+  }
+
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes} min`;
+  }
+
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return remainingMinutes > 0 ? `${hours} hr ${remainingMinutes} min` : `${hours} hr`;
+}
+
+function MetricItem({
+  icon,
+  label,
+}: {
+  icon: Parameters<typeof HugeiconsIcon>[0]["icon"];
+  label: string;
+}) {
+  return (
+    <span className="inline-flex min-w-0 items-center gap-2 text-sm text-foreground/58">
+      <HugeiconsIcon icon={icon} strokeWidth={1.8} className="size-4 shrink-0 text-foreground/42" />
+      <span className="truncate">{label}</span>
+    </span>
+  );
+}
+
+function getProgressValue(job: TmsProviderLiveJobDetail) {
+  const readiness = getCrowdinLocaleReadiness(job.externalProviderPayload);
+  const translationProgress = getReadinessNumber(readiness, "translationProgress");
+  const approvalProgress = getReadinessNumber(readiness, "approvalProgress");
+  return Math.max(0, Math.min(100, Math.round(translationProgress ?? approvalProgress ?? 0)));
+}
+
+function getWordsProgress(job: TmsProviderLiveJobDetail) {
+  const readiness = getCrowdinLocaleReadiness(job.externalProviderPayload);
+  const words = getReadinessWords(readiness);
+  const total = getReadinessNumber(words, "total");
+  const translated = getReadinessNumber(words, "translated");
+  const approved = getReadinessNumber(words, "approved");
+
+  if (total === null) {
+    return null;
+  }
+
+  return {
+    completed: Math.max(0, translated ?? approved ?? 0),
+    total,
+  };
+}
+
+function StatusSummaryCard({ job }: { job: TmsProviderLiveJobDetail }) {
+  const readiness = getCrowdinLocaleReadiness(job.externalProviderPayload);
+  const hasReadiness = readiness !== null;
+  const progress = hasReadiness ? getProgressValue(job) : null;
+  const progressLabel =
+    hasReadiness && progress !== null
+      ? (formatReadinessProgress(readiness) ?? `${progress}% translated`)
+      : null;
+  const wordsProgress = hasReadiness ? getWordsProgress(job) : null;
+
+  return (
+    <section className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
+      <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
+        Status
+      </TypographyH2>
+      <Badge
+        variant="outline"
+        className={cn("mt-5 w-fit rounded-full capitalize", toneClass(statusTone(job.status)))}
+      >
+        {job.status}
+      </Badge>
+      {progress !== null && progressLabel !== null ? (
+        <div className="mt-7">
+          <div className="flex items-baseline gap-2">
+            <span className="text-3xl font-semibold text-foreground">{progress}%</span>
+            <span className="text-sm text-foreground/58">
+              {progressLabel.replace(/^\d+%\s*/, "")}
+            </span>
+          </div>
+          <div
+            className="mt-4 h-1.5 overflow-hidden rounded-full bg-foreground/10"
+            role="progressbar"
+            aria-label="Translation progress"
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={progress}
+          >
+            <div className="h-full rounded-full bg-primary" style={{ width: `${progress}%` }} />
+          </div>
+          {wordsProgress ? (
+            <p className="mt-3 text-sm text-foreground/52">
+              {wordsProgress.completed} / {wordsProgress.total} words
+            </p>
+          ) : null}
+        </div>
+      ) : (
+        <p className="mt-5 text-sm text-foreground/58">
+          Provider status: {job.externalStatus || job.status}
+        </p>
+      )}
+    </section>
+  );
+}
+
+function TaskDetailsCard({ job }: { job: TmsProviderLiveJobDetail }) {
+  const providerName = formatProviderKind(job.externalProviderKind);
+  const targetLocales = formatLocaleList(
+    getCrowdinTargetLocales(job.externalProviderPayload, job.externalTargetLocales),
+  );
+  const taskType = getCrowdinTaskTypeLabel(job.externalProviderPayload) ?? formatJobKind(job);
+  const wordsToDo = formatWordsToDo(getCrowdinLocaleReadiness(job.externalProviderPayload));
+
+  return (
+    <section className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
+      <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
+        Details
+      </TypographyH2>
+      <dl className="mt-3 divide-y divide-foreground/8">
+        <JobDetailRow label="Provider" value={providerName} />
+        <JobDetailRow label="Task type" value={taskType} />
+        <JobDetailRow label="Project" value={job.projectName ?? job.projectId} />
+        <JobDetailRow
+          label="Language"
+          value={getCrowdinLanguageLabel(job.externalProviderPayload) ?? "—"}
+        />
+        <JobDetailRow label="Target locales" value={targetLocales} />
+        <JobDetailRow
+          label="Assignees"
+          value={job.externalAssignedUsers.length > 0 ? job.externalAssignedUsers.join(", ") : "—"}
+        />
+        <JobDetailRow label="Due date" value={formatJobDetailDate(job.externalDueDate)} />
+        <JobDetailRow label="Last sync" value={formatJobDetailDate(job.updatedAt)} />
+        {wordsToDo ? <JobDetailRow label="Words to do" value={wordsToDo} /> : null}
+        <JobDetailRow label="External job ID" value={job.externalJobId} />
+        <JobDetailRow label="External task ID" value={job.id} />
+      </dl>
+    </section>
+  );
+}
+
+function TaskCommentsSection({
+  comments,
+  isError,
+  isLoading,
+}: {
+  comments: TmsProviderLiveJobComment[];
+  isError: boolean;
+  isLoading: boolean;
+}) {
+  return (
+    <section className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
+      <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
+        Task comments
+      </TypographyH2>
+
+      {isLoading ? (
+        <div className="mt-4 space-y-3">
+          <Skeleton className="h-16 w-full bg-foreground/8" />
+          <Skeleton className="h-16 w-full bg-foreground/8" />
+        </div>
+      ) : null}
+
+      {isError ? (
+        <p className="mt-4 text-sm text-flame-100">Unable to load task comments.</p>
+      ) : null}
+
+      {!isLoading && !isError && comments.length === 0 ? (
+        <p className="mt-4 text-sm text-foreground/52">No task comments yet.</p>
+      ) : null}
+
+      {!isLoading && !isError && comments.length > 0 ? (
+        <ul className="mt-4 divide-y divide-foreground/8 rounded-md border border-foreground/8 bg-background/50">
+          {comments.map((comment) => {
+            const timeSpent = formatTimeSpent(comment.timeSpentSeconds);
+
+            return (
+              <li key={comment.id} className="px-3 py-3">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <span className="text-sm font-medium text-foreground">User {comment.userId}</span>
+                  <span className="text-xs text-foreground/42">
+                    {formatJobDetailDate(comment.createdAt)}
+                  </span>
+                </div>
+                <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-foreground/74">
+                  {comment.text}
+                </p>
+                {timeSpent ? (
+                  <p className="mt-2 text-xs text-foreground/42">Time spent: {timeSpent}</p>
+                ) : null}
+              </li>
+            );
+          })}
+        </ul>
+      ) : null}
+    </section>
+  );
+}
+
+function TaskActivitySection({ job }: { job: TmsProviderLiveJobDetail }) {
+  return (
+    <section className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
+      <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
+        Activity
+      </TypographyH2>
+      <ul className="mt-4 divide-y divide-foreground/8 rounded-md border border-foreground/8 bg-background/50">
+        <li className="px-3 py-3">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <span className="text-sm font-medium text-foreground">Task refreshed</span>
+            <span className="text-xs text-foreground/42">{formatJobDetailDate(job.updatedAt)}</span>
+          </div>
+          <p className="mt-2 text-sm leading-6 text-foreground/58">
+            Latest provider status is {job.status}.
+          </p>
+        </li>
+      </ul>
+    </section>
+  );
+}
+
+function defaultRenderBackLink({ href, children }: Parameters<JobDetailBackLinkRenderer>[0]) {
+  return (
+    <Button
+      nativeButton={false}
+      render={<Link href={href} />}
+      variant="ghost"
+      className="-ml-2 mb-2 text-foreground/54 hover:bg-foreground/6 hover:text-foreground"
+    >
+      <HugeiconsIcon icon={ArrowLeft02Icon} strokeWidth={1.8} />
+      {children}
+    </Button>
+  );
+}
+
+function defaultRenderError({ error }: Parameters<JobDetailErrorRenderer>[0]) {
+  return (
+    <div className="rounded-lg border border-flame-300/20 bg-flame-300/8 p-5 text-sm text-flame-100">
+      {error instanceof Error ? error.message : "Unable to load provider job"}
+    </div>
+  );
+}
+
+export function ProviderLiveJobDetailView({
+  buildJobsListHref: buildJobsListHrefProp = buildJobsListHref,
+  canEditProviderJobDescription = false,
+  comments = [],
+  commentsError,
+  commentsLoading = false,
+  error,
+  isLoading,
+  isRefreshing = false,
+  job,
+  jobId,
+  onRefresh,
+  organizationSlug,
+  projectId,
+  renderBackLink = defaultRenderBackLink,
+  renderDescriptionField,
+  renderError = defaultRenderError,
+  renderExternalLink,
+  renderFilesSection,
+}: {
+  buildJobsListHref?: typeof buildJobsListHref;
+  canEditProviderJobDescription?: boolean;
+  comments?: TmsProviderLiveJobComment[];
+  commentsError?: unknown;
+  commentsLoading?: boolean;
+  error?: unknown;
+  isLoading: boolean;
+  isRefreshing?: boolean;
+  job?: TmsProviderLiveJobDetail;
+  jobId: string;
+  onRefresh?: () => void;
+  organizationSlug: string;
+  projectId: string;
+  renderBackLink?: JobDetailBackLinkRenderer;
+  renderDescriptionField?: ProviderLiveDescriptionFieldRenderer;
+  renderError?: JobDetailErrorRenderer;
+  renderExternalLink?: (props: { href: string; label: string }) => ReactNode;
+  renderFilesSection?: ProviderLiveFilesSectionRenderer;
+}) {
+  const providerDescription = job
+    ? (getProviderPayloadString(job.externalProviderPayload, "description") ?? "")
+    : "";
+  const canEditProviderDescription = Boolean(
+    job && canEditProviderJobDescription && job.id.startsWith("ext:"),
+  );
+  const showTaskDescriptionSection =
+    providerDescription.trim().length > 0 || canEditProviderDescription;
+  const jobsListHref = buildJobsListHrefProp(organizationSlug, projectId);
+
+  return (
+    <main className="mx-auto flex w-full max-w-7xl flex-col gap-5">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          {renderBackLink({ href: jobsListHref, children: "Jobs" })}
+          <TypographyH1 className="wrap-break-word font-heading text-3xl font-semibold text-foreground md:text-4xl">
+            {job?.externalTitle ?? jobId}
+          </TypographyH1>
+          {job ? (
+            <div className="mt-4 flex flex-wrap items-center gap-x-6 gap-y-2">
+              <MetricItem
+                icon={Task01Icon}
+                label={`${formatProviderKind(job.externalProviderKind)} task`}
+              />
+              <MetricItem
+                icon={LanguageSquareIcon}
+                label={
+                  getCrowdinLanguageLabel(job.externalProviderPayload) ??
+                  formatLocaleList(
+                    getCrowdinTargetLocales(job.externalProviderPayload, job.externalTargetLocales),
+                  )
+                }
+              />
+              <MetricItem
+                icon={File01Icon}
+                label={
+                  formatWordsToDo(getCrowdinLocaleReadiness(job.externalProviderPayload)) ??
+                  "Source files linked"
+                }
+              />
+              <MetricItem
+                icon={Clock01Icon}
+                label={`Last synced ${formatJobDetailDate(job.updatedAt)}`}
+              />
+            </div>
+          ) : null}
+        </div>
+        {job ? (
+          <div className="flex flex-col items-start gap-3 sm:items-end">
+            <div className="flex flex-wrap gap-2 sm:justify-end">
+              {job.externalUrl ? (
+                renderExternalLink ? (
+                  renderExternalLink({
+                    href: job.externalUrl,
+                    label: `Open in ${job.externalProviderKind}`,
+                  })
+                ) : (
+                  <Button
+                    nativeButton={false}
+                    render={
+                      <a href={job.externalUrl} target="_blank" rel="noreferrer noopener">
+                        <HugeiconsIcon icon={LinkSquare02Icon} strokeWidth={1.8} />
+                        Open in {job.externalProviderKind}
+                      </a>
+                    }
+                    size="sm"
+                    variant="outline"
+                  />
+                )
+              ) : null}
+              {onRefresh ? (
+                <Button size="sm" variant="outline" disabled={isRefreshing} onClick={onRefresh}>
+                  <HugeiconsIcon icon={RefreshIcon} strokeWidth={1.8} />
+                  {isRefreshing ? "Refreshing..." : "Refresh"}
+                </Button>
+              ) : null}
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Button size="sm" disabled>
+                      Run with agent
+                    </Button>
+                  }
+                />
+                <TooltipContent>Agent workflows on provider tasks are coming soon.</TooltipContent>
+              </Tooltip>
+            </div>
+          </div>
+        ) : null}
+      </div>
+
+      {isLoading ? (
+        <div className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
+          <Skeleton className="h-5 w-48 bg-foreground/8" />
+          <Skeleton className="mt-4 h-40 w-full bg-foreground/8" />
+        </div>
+      ) : null}
+
+      {error ? renderError({ error }) : null}
+
+      {job ? (
+        <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_20rem]">
+          <div className="flex min-w-0 flex-col gap-5">
+            {showTaskDescriptionSection && renderDescriptionField ? (
+              <section className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
+                <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
+                  Task description
+                </TypographyH2>
+                <div className="mt-4">
+                  {renderDescriptionField({
+                    description: providerDescription,
+                    editable: canEditProviderDescription,
+                    job,
+                  })}
+                </div>
+              </section>
+            ) : null}
+
+            {job.externalProviderKind === "crowdin" && renderFilesSection
+              ? renderFilesSection({ job, jobId, organizationSlug, projectId })
+              : null}
+          </div>
+          <aside className="flex min-w-0 flex-col gap-5">
+            <StatusSummaryCard job={job} />
+            <TaskDetailsCard job={job} />
+          </aside>
+        </div>
+      ) : null}
+
+      {job?.externalProviderKind === "crowdin" ? (
+        <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_20rem]">
+          <TaskCommentsSection
+            comments={comments}
+            isError={Boolean(commentsError)}
+            isLoading={commentsLoading}
+          />
+          <TaskActivitySection job={job} />
+        </div>
+      ) : null}
+    </main>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Refactors the job detail route to follow the same Content/View dependency injection pattern already used by `JobsPageView`. Presentational views accept data and injectable render props; content components stay thin wrappers that wire React Query and `apiClient`.

## Changes

- **`NativeJobDetailView`** — native/synced job UI with injectable `renderBackLink`, `renderError`, `renderProviderDetailSection`, and action callbacks
- **`ProviderLiveJobDetailView`** — live TMS provider shell UI with injectable description field, files section, external link, and refresh handler
- **`JobProviderDetailSectionView`** — provider metadata, agent actions, and activity with injectable source files, QA findings, and diff review slots
- **`job-detail-types.ts`** — shared `JobDetailRecord`, provider types, and formatting helpers
- **`job-detail.fixture.ts`** — factory helpers for Storybook and tests
- **Storybook stories** under `App/Jobs/Detail/` for native, live provider, and provider section views

## Storybook

Stories target the View components directly with static fixtures — no API or MSW required. Example injectables used in stories:

- `ProviderJobDescriptionFieldView` for editable descriptions
- Mock files panel for live provider layout
- Composed `JobProviderDetailSectionView` inside native provider-backed job story

## Verification

- `vp check --fix` passes (lint + types)
- Existing job detail behavior unchanged; production content components delegate to views with default renderers
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f522c4aa-dc07-495d-adf5-78b796ff9d90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f522c4aa-dc07-495d-adf5-78b796ff9d90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

