### PR TITLE
feat(web): add teams UI with create and member assignment

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/team/team-slug.ts
+++ b/apps/hyperlocalise-web/src/api/routes/team/team-slug.ts
@@ -1,0 +1,7 @@
+export function slugifyTeamName(name: string) {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 120);
+}

--- a/apps/hyperlocalise-web/src/api/routes/team/team.shared.ts
+++ b/apps/hyperlocalise-web/src/api/routes/team/team.shared.ts
@@ -6,13 +6,7 @@ import type { JsonContext } from "@/api/errors";
 import { db, schema } from "@/lib/database";
 import type { TeamMembershipRole } from "@/lib/database/types";
 
-export function slugifyTeamName(name: string) {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, 120);
-}
+export { slugifyTeamName } from "./team-slug";
 
 export function forbiddenResponse(c: { json(body: { error: string }, status: 403): Response }) {
   return c.json({ error: "forbidden" }, 403);

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/[teamId]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/[teamId]/page.tsx
@@ -1,0 +1,22 @@
+import { hasCapability } from "@/api/auth/policy";
+import { requireAppAuthContext } from "@/lib/workos/app-auth";
+
+import { TeamDetailPageContent } from "../_components/team-detail-page-content";
+
+export default async function TeamDetailPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string; teamId: string }>;
+}) {
+  const { organizationSlug, teamId } = await params;
+  const auth = await requireAppAuthContext({ organizationSlug });
+
+  return (
+    <TeamDetailPageContent
+      organizationSlug={organizationSlug}
+      teamId={teamId}
+      canManageTeams={hasCapability(auth.membership.role, "teams:write")}
+      currentUserWorkosId={auth.user.workosUserId}
+    />
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/add-team-member-dialog.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/add-team-member-dialog.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, fn } from "storybook/test";
+
+import { memberDirectoryFixture } from "./teams.fixture";
+import { AddTeamMemberDialog } from "./add-team-member-dialog";
+
+const meta = {
+  title: "App/Teams/AddMemberDialog",
+  component: AddTeamMemberDialog,
+  parameters: {
+    layout: "centered",
+  },
+  args: {
+    open: true,
+    assignableMembers: memberDirectoryFixture,
+    isSaving: false,
+    onOpenChange: fn(),
+    onSubmit: fn(),
+  },
+} satisfies Meta<typeof AddTeamMemberDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("dialog", { name: "Add team member" })).toBeInTheDocument();
+    await expect(canvas.getByText("sam@example.com")).toBeInTheDocument();
+  },
+};
+
+export const NoAssignableMembers: Story = {
+  args: {
+    assignableMembers: [],
+  },
+  play: async ({ canvas }) => {
+    await expect(
+      canvas.getByText("Everyone in this workspace is already on the team."),
+    ).toBeInTheDocument();
+  },
+};
+
+export const Saving: Story = {
+  args: {
+    isSaving: true,
+  },
+};

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/add-team-member-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/add-team-member-dialog.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { type FormEvent, useEffect, useId, useState } from "react";
+import { Add01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+import type { TeamRole } from "@/api/routes/team/team.schema";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Field, FieldDescription, FieldLabel } from "@/components/ui/field";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Spinner } from "@/components/ui/spinner";
+
+import type { OrganizationMemberDirectoryEntry } from "./teams-api";
+import { getTeamRoleDescription, getTeamRoleLabel } from "./teams-settings-view-model";
+
+const teamRoles: TeamRole[] = ["member", "manager"];
+
+export function AddTeamMemberDialog({
+  open,
+  assignableMembers,
+  isSaving,
+  onOpenChange,
+  onSubmit,
+}: {
+  open: boolean;
+  assignableMembers: OrganizationMemberDirectoryEntry[];
+  isSaving: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (input: { workosUserId: string; role: TeamRole }) => void;
+}) {
+  const [workosUserId, setWorkosUserId] = useState("");
+  const [role, setRole] = useState<TeamRole>("member");
+  const memberId = useId();
+
+  useEffect(() => {
+    if (open) {
+      setWorkosUserId(assignableMembers[0]?.workosUserId ?? "");
+      setRole("member");
+    }
+  }, [assignableMembers, open]);
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!workosUserId) {
+      return;
+    }
+
+    onSubmit({ workosUserId, role });
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen && isSaving) {
+          return;
+        }
+
+        onOpenChange(nextOpen);
+      }}
+    >
+      <DialogContent className="border-foreground/10 bg-background text-foreground sm:max-w-md">
+        <form onSubmit={handleSubmit} className="grid gap-4">
+          <DialogHeader>
+            <DialogTitle>Add team member</DialogTitle>
+            <DialogDescription>
+              Assign an existing workspace member to this team. People must already belong to the
+              workspace before they can join a team.
+            </DialogDescription>
+          </DialogHeader>
+
+          {assignableMembers.length === 0 ? (
+            <p className="text-sm text-foreground/52">
+              Everyone in this workspace is already on the team.
+            </p>
+          ) : (
+            <>
+              <Field>
+                <FieldLabel htmlFor={memberId}>Member</FieldLabel>
+                <Select
+                  value={workosUserId}
+                  onValueChange={(value) => {
+                    if (value) {
+                      setWorkosUserId(value);
+                    }
+                  }}
+                  disabled={isSaving}
+                >
+                  <SelectTrigger id={memberId} className="border-foreground/10 bg-foreground/4">
+                    <SelectValue placeholder="Select a member" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {assignableMembers.map((member) => (
+                      <SelectItem key={member.workosUserId} value={member.workosUserId}>
+                        {member.email}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </Field>
+
+              <Field>
+                <FieldLabel>Role</FieldLabel>
+                <Select
+                  value={role}
+                  onValueChange={(value) => setRole(value as TeamRole)}
+                  disabled={isSaving}
+                >
+                  <SelectTrigger className="border-foreground/10 bg-foreground/4">
+                    <SelectValue>{getTeamRoleLabel(role)}</SelectValue>
+                  </SelectTrigger>
+                  <SelectContent>
+                    {teamRoles.map((teamRole) => (
+                      <SelectItem key={teamRole} value={teamRole}>
+                        {getTeamRoleLabel(teamRole)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FieldDescription>{getTeamRoleDescription(role)}</FieldDescription>
+              </Field>
+            </>
+          )}
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={isSaving}
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSaving || assignableMembers.length === 0}>
+              {isSaving ? <Spinner /> : <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />}
+              {isSaving ? "Adding..." : "Add member"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/team-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/team-detail-page-content.tsx
@@ -122,7 +122,9 @@ export function TeamDetailPageContent({
       isEditOpen={isEditOpen}
       isSavingTeam={updateTeam.isPending}
       isRemovingMember={removeMember.isPending}
-      isUpdatingRole={updateMemberRole.isPending}
+      updatingMemberRoleId={
+        updateMemberRole.isPending ? (updateMemberRole.variables?.workosUserId ?? null) : null
+      }
       removingMember={removingMember}
       onAddMemberOpenChange={setIsAddMemberOpen}
       onEditOpenChange={setIsEditOpen}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/team-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/team-detail-page-content.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import type { TeamRole } from "@/api/routes/team/team.schema";
+import { apiClient } from "@/lib/api-client-instance";
+
+import { createTeamsApi, type TeamMemberRow } from "./teams-api";
+import { toUpdateTeamPayload } from "./team-form";
+import { TeamDetailPageView } from "./team-detail-page-view";
+
+const teamsApi = createTeamsApi(apiClient);
+
+function teamQueryKey(organizationSlug: string, teamId: string) {
+  return ["workspace-team", organizationSlug, teamId] as const;
+}
+
+function memberDirectoryQueryKey(organizationSlug: string) {
+  return ["workspace-team-member-directory", organizationSlug] as const;
+}
+
+export function TeamDetailPageContent({
+  organizationSlug,
+  teamId,
+  canManageTeams,
+  currentUserWorkosId,
+  teamsApi: injectedTeamsApi = teamsApi,
+}: {
+  organizationSlug: string;
+  teamId: string;
+  canManageTeams: boolean;
+  currentUserWorkosId: string;
+  teamsApi?: typeof teamsApi;
+}) {
+  const queryClient = useQueryClient();
+  const [isAddMemberOpen, setIsAddMemberOpen] = useState(false);
+  const [isEditOpen, setIsEditOpen] = useState(false);
+  const [removingMember, setRemovingMember] = useState<TeamMemberRow | null>(null);
+
+  const teamQuery = useQuery({
+    queryKey: teamQueryKey(organizationSlug, teamId),
+    queryFn: () => injectedTeamsApi.getTeam(organizationSlug, teamId),
+  });
+
+  const memberDirectoryQuery = useQuery({
+    queryKey: memberDirectoryQueryKey(organizationSlug),
+    queryFn: () => injectedTeamsApi.listMemberDirectory(organizationSlug),
+    enabled: isAddMemberOpen,
+  });
+
+  const invalidateTeam = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: teamQueryKey(organizationSlug, teamId) }),
+      queryClient.invalidateQueries({ queryKey: ["workspace-teams", organizationSlug] }),
+    ]);
+  };
+
+  const updateTeam = useMutation({
+    mutationFn: (values: { name: string; slug: string }) =>
+      injectedTeamsApi.updateTeam(organizationSlug, teamId, toUpdateTeamPayload(values)),
+    onSuccess: async () => {
+      setIsEditOpen(false);
+      await invalidateTeam();
+      toast.success("Team updated");
+    },
+    onError: (error) => {
+      toast.error(error.message);
+    },
+  });
+
+  const addMember = useMutation({
+    mutationFn: (input: { workosUserId: string; role: TeamRole }) =>
+      injectedTeamsApi.addTeamMember(organizationSlug, teamId, input),
+    onSuccess: async () => {
+      setIsAddMemberOpen(false);
+      await invalidateTeam();
+      toast.success("Member added to team");
+    },
+    onError: (error) => {
+      toast.error(error.message);
+    },
+  });
+
+  const updateMemberRole = useMutation({
+    mutationFn: (input: { workosUserId: string; role: TeamRole }) =>
+      injectedTeamsApi.addTeamMember(organizationSlug, teamId, input),
+    onSuccess: async () => {
+      await invalidateTeam();
+      toast.success("Team role updated");
+    },
+    onError: (error) => {
+      toast.error(error.message);
+    },
+  });
+
+  const removeMember = useMutation({
+    mutationFn: (workosUserId: string) =>
+      injectedTeamsApi.removeTeamMember(organizationSlug, teamId, workosUserId),
+    onSuccess: async () => {
+      setRemovingMember(null);
+      await invalidateTeam();
+      toast.success("Member removed from team");
+    },
+    onError: (error) => {
+      toast.error(error.message);
+    },
+  });
+
+  return (
+    <TeamDetailPageView
+      organizationSlug={organizationSlug}
+      team={teamQuery.data}
+      canManageTeams={canManageTeams}
+      currentUserWorkosId={currentUserWorkosId}
+      memberDirectory={memberDirectoryQuery.data ?? []}
+      isLoading={teamQuery.isLoading}
+      error={teamQuery.error}
+      isAddMemberOpen={isAddMemberOpen}
+      isAddingMember={addMember.isPending}
+      isEditOpen={isEditOpen}
+      isSavingTeam={updateTeam.isPending}
+      isRemovingMember={removeMember.isPending}
+      isUpdatingRole={updateMemberRole.isPending}
+      removingMember={removingMember}
+      onAddMemberOpenChange={setIsAddMemberOpen}
+      onEditOpenChange={setIsEditOpen}
+      onAddMember={(input) => addMember.mutate(input)}
+      onUpdateTeam={(values) => updateTeam.mutate(values)}
+      onUpdateMemberRole={(input) => updateMemberRole.mutate(input)}
+      onRemoveMember={(workosUserId) => removeMember.mutate(workosUserId)}
+      onRemovingMemberChange={setRemovingMember}
+    />
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/team-detail-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/team-detail-page-view.stories.tsx
@@ -1,0 +1,93 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, fn } from "storybook/test";
+
+import { createTeamDetail, memberDirectoryFixture } from "./teams.fixture";
+import { TeamDetailPageView } from "./team-detail-page-view";
+
+const team = createTeamDetail();
+
+const meta = {
+  title: "App/Teams/Detail",
+  component: TeamDetailPageView,
+  parameters: {
+    layout: "fullscreen",
+  },
+  args: {
+    organizationSlug: "acme",
+    team,
+    canManageTeams: true,
+    currentUserWorkosId: "user_001",
+    memberDirectory: memberDirectoryFixture,
+    isLoading: false,
+    isAddMemberOpen: false,
+    isAddingMember: false,
+    isEditOpen: false,
+    isSavingTeam: false,
+    isRemovingMember: false,
+    isUpdatingRole: false,
+    removingMember: null,
+    onAddMemberOpenChange: fn(),
+    onEditOpenChange: fn(),
+    onAddMember: fn(),
+    onUpdateTeam: fn(),
+    onUpdateMemberRole: fn(),
+    onRemoveMember: fn(),
+    onRemovingMemberChange: fn(),
+  },
+} satisfies Meta<typeof TeamDetailPageView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("heading", { name: "Localization" })).toBeInTheDocument();
+    await expect(canvas.getByText("mina@example.com")).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Add member" })).toBeInTheDocument();
+  },
+};
+
+export const ManagerWithoutAdminAccess: Story = {
+  args: {
+    canManageTeams: false,
+    currentUserWorkosId: "user_001",
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("button", { name: "Add member" })).toBeInTheDocument();
+    await expect(canvas.queryByRole("button", { name: "Edit team" })).not.toBeInTheDocument();
+  },
+};
+
+export const ReadOnlyMember: Story = {
+  args: {
+    canManageTeams: false,
+    currentUserWorkosId: "user_002",
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.queryByRole("button", { name: "Add member" })).not.toBeInTheDocument();
+  },
+};
+
+export const AddMemberDialogOpen: Story = {
+  args: {
+    isAddMemberOpen: true,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("dialog", { name: "Add team member" })).toBeInTheDocument();
+    await expect(canvas.getByText("sam@example.com")).toBeInTheDocument();
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    team: undefined,
+    isLoading: true,
+  },
+};
+
+export const LoadError: Story = {
+  args: {
+    team: undefined,
+    error: new Error("Team not found."),
+  },
+};

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/team-detail-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/team-detail-page-view.stories.tsx
@@ -24,7 +24,7 @@ const meta = {
     isEditOpen: false,
     isSavingTeam: false,
     isRemovingMember: false,
-    isUpdatingRole: false,
+    updatingMemberRoleId: null,
     removingMember: null,
     onAddMemberOpenChange: fn(),
     onEditOpenChange: fn(),

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/team-detail-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/team-detail-page-view.tsx
@@ -1,0 +1,372 @@
+"use client";
+
+import Link from "next/link";
+import {
+  Add01Icon,
+  ArrowLeft01Icon,
+  Delete01Icon,
+  UserGroupIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+import type { TeamRole } from "@/api/routes/team/team.schema";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { TypographyP } from "@/components/ui/typography";
+import { cn } from "@/lib/primitives/cn";
+
+import { PageHeader, WorkspacePageShell } from "../../_components/workspace-resource-shared";
+
+import { AddTeamMemberDialog } from "./add-team-member-dialog";
+import { TeamDialog } from "./team-dialog";
+import type { OrganizationMemberDirectoryEntry, TeamDetail, TeamMemberRow } from "./teams-api";
+import { createTeamFormFromSummary } from "./team-form";
+import {
+  canRemoveTeamMember,
+  canUpdateTeamMemberRole,
+  getTeamRoleDescription,
+  getTeamRoleLabel,
+  listAssignableMembers,
+  resolveTeamDetailPageState,
+} from "./teams-settings-view-model";
+
+function MembersTableHeader() {
+  return (
+    <div
+      role="row"
+      className="hidden grid-cols-[minmax(0,1.5fr)_12rem_2.5rem] gap-4 border-b border-foreground/8 px-1 py-2.5 text-xs font-medium tracking-[0.08em] text-foreground/36 uppercase md:grid"
+    >
+      <div role="columnheader">Member</div>
+      <div role="columnheader">Role</div>
+      <div role="columnheader" className="text-right">
+        Actions
+      </div>
+    </div>
+  );
+}
+
+export function TeamDetailPageView({
+  organizationSlug,
+  team,
+  canManageTeams,
+  currentUserWorkosId,
+  memberDirectory,
+  isLoading,
+  error,
+  isAddMemberOpen,
+  isAddingMember,
+  isEditOpen,
+  isSavingTeam,
+  isRemovingMember,
+  isUpdatingRole,
+  removingMember,
+  onAddMemberOpenChange,
+  onEditOpenChange,
+  onAddMember,
+  onUpdateTeam,
+  onUpdateMemberRole,
+  onRemoveMember,
+  onRemovingMemberChange,
+}: {
+  organizationSlug: string;
+  team: TeamDetail | undefined;
+  canManageTeams: boolean;
+  currentUserWorkosId: string;
+  memberDirectory: OrganizationMemberDirectoryEntry[];
+  isLoading: boolean;
+  error?: unknown;
+  isAddMemberOpen: boolean;
+  isAddingMember: boolean;
+  isEditOpen: boolean;
+  isSavingTeam: boolean;
+  isRemovingMember: boolean;
+  isUpdatingRole: boolean;
+  removingMember: TeamMemberRow | null;
+  onAddMemberOpenChange: (open: boolean) => void;
+  onEditOpenChange: (open: boolean) => void;
+  onAddMember: (input: { workosUserId: string; role: TeamRole }) => void;
+  onUpdateTeam: (values: { name: string; slug: string }) => void;
+  onUpdateMemberRole: (input: { workosUserId: string; role: TeamRole }) => void;
+  onRemoveMember: (workosUserId: string) => void;
+  onRemovingMemberChange: (member: TeamMemberRow | null) => void;
+}) {
+  const pageState = resolveTeamDetailPageState({
+    team,
+    canManageTeams,
+    currentUserWorkosId,
+  });
+  const assignableMembers = listAssignableMembers({
+    directory: memberDirectory,
+    members: pageState.members,
+  });
+
+  return (
+    <WorkspacePageShell>
+      <div className="flex flex-col gap-4">
+        <Button
+          nativeButton={false}
+          render={<Link href={`/org/${organizationSlug}/teams`} />}
+          variant="ghost"
+          size="sm"
+          className="w-fit px-2 text-foreground/56 hover:text-foreground"
+        >
+          <HugeiconsIcon icon={ArrowLeft01Icon} strokeWidth={1.8} />
+          Back to teams
+        </Button>
+
+        <PageHeader
+          icon={UserGroupIcon}
+          label="Team"
+          title={team?.name ?? "Team"}
+          description={
+            team
+              ? `Manage membership and roles for the ${team.slug} team.`
+              : "Load team membership and roles."
+          }
+          actions={
+            pageState.canManageTeams && team ? (
+              <Button
+                type="button"
+                variant="outline"
+                className="w-full sm:w-fit"
+                onClick={() => onEditOpenChange(true)}
+                disabled={isSavingTeam}
+              >
+                Edit team
+              </Button>
+            ) : null
+          }
+        />
+      </div>
+
+      <section aria-label="Team members" className="min-w-0">
+        <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <TypographyP className="text-sm font-medium text-foreground">Members</TypographyP>
+            <TypographyP className="mt-1 text-sm text-foreground/52">
+              People assigned to this team can access its projects and jobs.
+            </TypographyP>
+          </div>
+          {pageState.canManageMembers ? (
+            <Button
+              type="button"
+              onClick={() => onAddMemberOpenChange(true)}
+              className="w-full sm:w-fit"
+              disabled={isAddingMember}
+            >
+              <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
+              Add member
+            </Button>
+          ) : null}
+        </div>
+
+        {isLoading ? (
+          <TypographyP className="py-8 text-sm text-foreground/52">Loading team...</TypographyP>
+        ) : error ? (
+          <div className="py-8">
+            <TypographyP className="text-sm font-medium text-flame-100">
+              Team failed to load.
+            </TypographyP>
+            <TypographyP className="mt-1 text-xs text-foreground/48">
+              {error instanceof Error ? error.message : "Refresh the page to try again."}
+            </TypographyP>
+          </div>
+        ) : pageState.members.length === 0 ? (
+          <div className="py-10">
+            <TypographyP className="text-sm font-medium text-foreground">
+              No members on this team
+            </TypographyP>
+            <TypographyP className="mt-2 max-w-xl text-sm leading-6 text-foreground/52">
+              Add workspace members to start scoping projects and jobs to this team.
+            </TypographyP>
+          </div>
+        ) : (
+          <div role="table" className="min-w-0">
+            <MembersTableHeader />
+            {pageState.members.map((member) => {
+              const isCurrentUser = member.workosUserId === currentUserWorkosId;
+              const canUpdateRole = canUpdateTeamMemberRole({
+                member,
+                members: pageState.members,
+                canManageMembers: pageState.canManageMembers,
+              });
+              const canRemove = canRemoveTeamMember({
+                member,
+                members: pageState.members,
+                canManageMembers: pageState.canManageMembers,
+                currentUserWorkosId,
+              });
+
+              return (
+                <div
+                  key={member.workosUserId}
+                  role="row"
+                  className="grid gap-4 border-t border-foreground/8 px-1 py-4 md:grid-cols-[minmax(0,1.5fr)_12rem_2.5rem] md:items-center"
+                >
+                  <div role="cell" className="min-w-0">
+                    <div className="flex min-w-0 flex-wrap items-center gap-2">
+                      <TypographyP className="truncate text-sm font-medium text-foreground">
+                        {member.email}
+                      </TypographyP>
+                      {isCurrentUser ? (
+                        <span className="rounded-full border border-foreground/10 bg-foreground/4 px-2 py-0.5 text-xs font-medium text-foreground/58">
+                          You
+                        </span>
+                      ) : null}
+                    </div>
+                  </div>
+
+                  <div role="cell" className="min-w-0">
+                    <div className="flex items-center justify-between gap-3 md:block">
+                      <span className="text-xs font-medium tracking-[0.08em] text-foreground/34 uppercase md:hidden">
+                        Role
+                      </span>
+                      {canUpdateRole ? (
+                        <Select
+                          value={member.role}
+                          onValueChange={(value) => {
+                            if (value === member.role) {
+                              return;
+                            }
+
+                            onUpdateMemberRole({
+                              workosUserId: member.workosUserId,
+                              role: value as TeamRole,
+                            });
+                          }}
+                          disabled={isUpdatingRole}
+                        >
+                          <SelectTrigger className="h-9 w-[12rem] max-w-full border-foreground/10 bg-background/60 text-foreground/78 hover:bg-foreground/4">
+                            <SelectValue>{getTeamRoleLabel(member.role)}</SelectValue>
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="manager">{getTeamRoleLabel("manager")}</SelectItem>
+                            <SelectItem value="member">{getTeamRoleLabel("member")}</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      ) : (
+                        <Tooltip>
+                          <TooltipTrigger
+                            render={
+                              <Badge
+                                variant="outline"
+                                className={cn(
+                                  "h-auto max-w-[12rem] truncate rounded-lg px-3 py-1.5 text-sm",
+                                  "border-foreground/12 bg-foreground/4 text-foreground/72",
+                                )}
+                              >
+                                {getTeamRoleLabel(member.role)}
+                              </Badge>
+                            }
+                          />
+                          <TooltipContent side="bottom" align="start" className="max-w-xs">
+                            {getTeamRoleDescription(member.role)}
+                          </TooltipContent>
+                        </Tooltip>
+                      )}
+                    </div>
+                  </div>
+
+                  <div role="cell" className="flex items-center justify-end">
+                    {canRemove ? (
+                      <Tooltip>
+                        <TooltipTrigger
+                          render={
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="icon"
+                              className="border-foreground/10 bg-transparent text-foreground/52 hover:border-destructive/25 hover:bg-destructive/10 hover:text-destructive"
+                              onClick={() => onRemovingMemberChange(member)}
+                              disabled={isRemovingMember}
+                              aria-label={`Remove ${member.email}`}
+                            >
+                              <HugeiconsIcon icon={Delete01Icon} strokeWidth={1.8} />
+                            </Button>
+                          }
+                        />
+                        <TooltipContent side="bottom" align="end">
+                          Remove from team
+                        </TooltipContent>
+                      </Tooltip>
+                    ) : null}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </section>
+
+      {team ? (
+        <TeamDialog
+          open={isEditOpen}
+          mode="edit"
+          title="Edit team"
+          description="Update the team name or slug used for project scoping."
+          initialValues={createTeamFormFromSummary(team)}
+          isSaving={isSavingTeam}
+          onOpenChange={onEditOpenChange}
+          onSubmit={onUpdateTeam}
+        />
+      ) : null}
+
+      <AddTeamMemberDialog
+        open={isAddMemberOpen}
+        assignableMembers={assignableMembers}
+        isSaving={isAddingMember}
+        onOpenChange={onAddMemberOpenChange}
+        onSubmit={onAddMember}
+      />
+
+      <Dialog
+        open={removingMember !== null}
+        onOpenChange={(open) => !open && onRemovingMemberChange(null)}
+      >
+        <DialogContent className="border-foreground/10 bg-background text-foreground sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Remove team member</DialogTitle>
+            <DialogDescription>
+              {removingMember
+                ? `${removingMember.email} will lose access to projects scoped to this team.`
+                : ""}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onRemovingMemberChange(null)}>
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={!removingMember || isRemovingMember}
+              onClick={() => {
+                if (removingMember) {
+                  onRemoveMember(removingMember.workosUserId);
+                }
+              }}
+            >
+              Remove member
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </WorkspacePageShell>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/team-detail-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/team-detail-page-view.tsx
@@ -74,7 +74,7 @@ export function TeamDetailPageView({
   isEditOpen,
   isSavingTeam,
   isRemovingMember,
-  isUpdatingRole,
+  updatingMemberRoleId,
   removingMember,
   onAddMemberOpenChange,
   onEditOpenChange,
@@ -96,7 +96,7 @@ export function TeamDetailPageView({
   isEditOpen: boolean;
   isSavingTeam: boolean;
   isRemovingMember: boolean;
-  isUpdatingRole: boolean;
+  updatingMemberRoleId: string | null;
   removingMember: TeamMemberRow | null;
   onAddMemberOpenChange: (open: boolean) => void;
   onEditOpenChange: (open: boolean) => void;
@@ -210,7 +210,6 @@ export function TeamDetailPageView({
                 member,
                 members: pageState.members,
                 canManageMembers: pageState.canManageMembers,
-                currentUserWorkosId,
               });
 
               return (
@@ -250,7 +249,7 @@ export function TeamDetailPageView({
                               role: value as TeamRole,
                             });
                           }}
-                          disabled={isUpdatingRole}
+                          disabled={updatingMemberRoleId === member.workosUserId}
                         >
                           <SelectTrigger className="h-9 w-[12rem] max-w-full border-foreground/10 bg-background/60 text-foreground/78 hover:bg-foreground/4">
                             <SelectValue>{getTeamRoleLabel(member.role)}</SelectValue>

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/team-dialog.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/team-dialog.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, fn } from "storybook/test";
+
+import { createEmptyTeamForm, createTeamFormFromSummary } from "./team-form";
+import { createTeamSummary } from "./teams.fixture";
+import { TeamDialog } from "./team-dialog";
+
+const meta = {
+  title: "App/Teams/TeamDialog",
+  component: TeamDialog,
+  parameters: {
+    layout: "centered",
+  },
+  args: {
+    open: true,
+    isSaving: false,
+    onOpenChange: fn(),
+    onSubmit: fn(),
+  },
+} satisfies Meta<typeof TeamDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Create: Story = {
+  args: {
+    mode: "create",
+    title: "Create team",
+    description: "Teams group workspace members and scope which projects they can access.",
+    initialValues: createEmptyTeamForm(),
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("dialog", { name: "Create team" })).toBeInTheDocument();
+    await expect(canvas.getByLabelText("Name")).toBeInTheDocument();
+  },
+};
+
+export const Edit: Story = {
+  args: {
+    mode: "edit",
+    title: "Edit team",
+    description: "Update the team name or slug used for project scoping.",
+    initialValues: createTeamFormFromSummary(createTeamSummary()),
+  },
+};
+
+export const Saving: Story = {
+  args: {
+    mode: "create",
+    title: "Create team",
+    description: "Teams group workspace members and scope which projects they can access.",
+    initialValues: createEmptyTeamForm(),
+    isSaving: true,
+  },
+};

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/team-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/team-dialog.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { type FormEvent, useEffect, useId, useState } from "react";
+import { SaveIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Field, FieldDescription, FieldError, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { Spinner } from "@/components/ui/spinner";
+
+import {
+  createEmptyTeamForm,
+  suggestTeamSlug,
+  teamFormHasErrors,
+  validateTeamForm,
+  type TeamFormErrors,
+  type TeamFormValues,
+} from "./team-form";
+
+export function TeamDialog({
+  open,
+  mode,
+  title,
+  description,
+  initialValues,
+  isSaving,
+  onOpenChange,
+  onSubmit,
+}: {
+  open: boolean;
+  mode: "create" | "edit";
+  title: string;
+  description: string;
+  initialValues?: TeamFormValues;
+  isSaving: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (values: TeamFormValues) => void;
+}) {
+  const [values, setValues] = useState<TeamFormValues>(initialValues ?? createEmptyTeamForm());
+  const [errors, setErrors] = useState<TeamFormErrors>({});
+  const [slugTouched, setSlugTouched] = useState(false);
+  const nameId = useId();
+  const slugId = useId();
+
+  useEffect(() => {
+    if (open) {
+      setValues(initialValues ?? createEmptyTeamForm());
+      setErrors({});
+      setSlugTouched(mode === "edit");
+    }
+  }, [initialValues, mode, open]);
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    const nextErrors = validateTeamForm(values, mode);
+    setErrors(nextErrors);
+
+    if (teamFormHasErrors(nextErrors)) {
+      return;
+    }
+
+    onSubmit(values);
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen && isSaving) {
+          return;
+        }
+
+        onOpenChange(nextOpen);
+      }}
+    >
+      <DialogContent className="border-foreground/10 bg-background text-foreground sm:max-w-md">
+        <form onSubmit={handleSubmit} className="grid gap-4">
+          <DialogHeader>
+            <DialogTitle>{title}</DialogTitle>
+            <DialogDescription>{description}</DialogDescription>
+          </DialogHeader>
+
+          <Field>
+            <FieldLabel htmlFor={nameId}>Name</FieldLabel>
+            <Input
+              id={nameId}
+              value={values.name}
+              onChange={(event) => {
+                const name = event.target.value;
+                setValues((current) => ({
+                  name,
+                  slug: mode === "create" && !slugTouched ? suggestTeamSlug(name) : current.slug,
+                }));
+              }}
+              aria-invalid={Boolean(errors.name)}
+              disabled={isSaving}
+              placeholder="Localization"
+              className="border-foreground/10 bg-foreground/4"
+            />
+            <FieldError errors={errors.name ? [{ message: errors.name }] : undefined} />
+          </Field>
+
+          <Field>
+            <FieldLabel htmlFor={slugId}>Slug</FieldLabel>
+            <Input
+              id={slugId}
+              value={values.slug}
+              onChange={(event) => {
+                setSlugTouched(true);
+                setValues((current) => ({ ...current, slug: event.target.value }));
+              }}
+              aria-invalid={Boolean(errors.slug)}
+              disabled={isSaving}
+              placeholder="localization"
+              className="border-foreground/10 bg-foreground/4"
+            />
+            <FieldDescription>
+              Used in URLs and project scoping. Lowercase letters, numbers, and hyphens only.
+            </FieldDescription>
+            <FieldError errors={errors.slug ? [{ message: errors.slug }] : undefined} />
+          </Field>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={isSaving}
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSaving}>
+              {isSaving ? <Spinner /> : <HugeiconsIcon icon={SaveIcon} strokeWidth={1.8} />}
+              {isSaving ? "Saving..." : mode === "create" ? "Create team" : "Save changes"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/team-form.test.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/team-form.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  createEmptyTeamForm,
+  suggestTeamSlug,
+  teamFormHasErrors,
+  toCreateTeamPayload,
+  validateTeamForm,
+} from "./team-form";
+
+describe("team-form", () => {
+  it("requires a team name", () => {
+    const errors = validateTeamForm(createEmptyTeamForm(), "create");
+    expect(errors.name).toBeTruthy();
+    expect(teamFormHasErrors(errors)).toBe(true);
+  });
+
+  it("suggests a slug from the team name", () => {
+    expect(suggestTeamSlug("Platform Team")).toBe("platform-team");
+  });
+
+  it("omits empty slug from create payloads", () => {
+    expect(toCreateTeamPayload({ name: "Platform", slug: "" })).toEqual({
+      name: "Platform",
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/team-form.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/team-form.ts
@@ -1,0 +1,78 @@
+import { slugifyTeamName } from "@/api/routes/team/team.shared";
+import type { CreateTeamBody, UpdateTeamBody } from "@/api/routes/team/team.schema";
+
+import type { TeamSummaryRow } from "./teams-api";
+
+export type TeamFormValues = {
+  name: string;
+  slug: string;
+};
+
+export type TeamFormErrors = Partial<Record<keyof TeamFormValues, string>>;
+
+const slugPattern = /^[a-z0-9-]+$/;
+
+export function createEmptyTeamForm(): TeamFormValues {
+  return {
+    name: "",
+    slug: "",
+  };
+}
+
+export function createTeamFormFromSummary(
+  team: Pick<TeamSummaryRow, "name" | "slug">,
+): TeamFormValues {
+  return {
+    name: team.name,
+    slug: team.slug,
+  };
+}
+
+export function validateTeamForm(values: TeamFormValues, mode: "create" | "edit"): TeamFormErrors {
+  const errors: TeamFormErrors = {};
+  const name = values.name.trim();
+  const slug = values.slug.trim();
+
+  if (!name) {
+    errors.name = "Team name is required.";
+  } else if (name.length > 120) {
+    errors.name = "Team name must be 120 characters or fewer.";
+  }
+
+  if (mode === "edit" || slug.length > 0) {
+    if (!slug) {
+      errors.slug = "Team slug is required.";
+    } else if (!slugPattern.test(slug)) {
+      errors.slug = "Use lowercase letters, numbers, and hyphens only.";
+    } else if (slug.length > 120) {
+      errors.slug = "Team slug must be 120 characters or fewer.";
+    }
+  }
+
+  return errors;
+}
+
+export function teamFormHasErrors(errors: TeamFormErrors) {
+  return Object.keys(errors).length > 0;
+}
+
+export function toCreateTeamPayload(values: TeamFormValues): CreateTeamBody {
+  const name = values.name.trim();
+  const slug = values.slug.trim();
+
+  return {
+    name,
+    ...(slug ? { slug } : {}),
+  };
+}
+
+export function toUpdateTeamPayload(values: TeamFormValues): UpdateTeamBody {
+  return {
+    name: values.name.trim(),
+    slug: values.slug.trim(),
+  };
+}
+
+export function suggestTeamSlug(name: string) {
+  return slugifyTeamName(name);
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/team-form.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/team-form.ts
@@ -1,4 +1,4 @@
-import { slugifyTeamName } from "@/api/routes/team/team.shared";
+import { slugifyTeamName } from "@/api/routes/team/team-slug";
 import type { CreateTeamBody, UpdateTeamBody } from "@/api/routes/team/team.schema";
 
 import type { TeamSummaryRow } from "./teams-api";

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/teams-api.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/teams-api.ts
@@ -1,0 +1,134 @@
+import type {
+  AddTeamMemberBody,
+  CreateTeamBody,
+  TeamRecord,
+  TeamRole,
+  TeamWithMembersResponse,
+  TeamsResponse,
+  UpdateTeamBody,
+} from "@/api/routes/team/team.schema";
+import type { createApiClient } from "@/lib/api-client";
+import { readApiResponseError } from "@/lib/api-error";
+
+export type TeamSummaryRow = TeamsResponse["teams"][number];
+
+export type TeamMemberRow = TeamWithMembersResponse["team"]["members"][number];
+
+export type TeamDetail = TeamWithMembersResponse["team"];
+
+export type OrganizationMemberDirectoryEntry = {
+  workosUserId: string;
+  email: string;
+};
+
+export type TeamsApi = {
+  listTeams(organizationSlug: string): Promise<TeamSummaryRow[]>;
+  getTeam(organizationSlug: string, teamId: string): Promise<TeamDetail>;
+  listMemberDirectory(organizationSlug: string): Promise<OrganizationMemberDirectoryEntry[]>;
+  createTeam(organizationSlug: string, body: CreateTeamBody): Promise<TeamRecord>;
+  updateTeam(organizationSlug: string, teamId: string, body: UpdateTeamBody): Promise<TeamRecord>;
+  deleteTeam(organizationSlug: string, teamId: string): Promise<void>;
+  addTeamMember(
+    organizationSlug: string,
+    teamId: string,
+    body: AddTeamMemberBody,
+  ): Promise<TeamMemberRow>;
+  removeTeamMember(organizationSlug: string, teamId: string, workosUserId: string): Promise<void>;
+};
+
+type ApiClient = ReturnType<typeof createApiClient>;
+
+export function createTeamsApi(client: ApiClient): TeamsApi {
+  const teams = client.api.orgs[":organizationSlug"].teams;
+
+  return {
+    async listTeams(organizationSlug) {
+      const response = await teams.$get({
+        param: { organizationSlug },
+      });
+      if (!response.ok) {
+        throw await readApiResponseError(response, "Failed to load teams");
+      }
+      const body = (await response.json()) as TeamsResponse;
+      return body.teams;
+    },
+
+    async getTeam(organizationSlug, teamId) {
+      const response = await teams[":teamId"].$get({
+        param: { organizationSlug, teamId },
+      });
+      if (!response.ok) {
+        throw await readApiResponseError(response, "Failed to load team");
+      }
+      const body = (await response.json()) as TeamWithMembersResponse;
+      return body.team;
+    },
+
+    async listMemberDirectory(organizationSlug) {
+      const response = await teams["member-directory"].$get({
+        param: { organizationSlug },
+      });
+      if (!response.ok) {
+        throw await readApiResponseError(response, "Failed to load member directory");
+      }
+      const body = (await response.json()) as { members: OrganizationMemberDirectoryEntry[] };
+      return body.members;
+    },
+
+    async createTeam(organizationSlug, body) {
+      const response = await teams.$post({
+        param: { organizationSlug },
+        json: body,
+      });
+      if (!response.ok) {
+        throw await readApiResponseError(response, "Failed to create team");
+      }
+      const result = (await response.json()) as { team: TeamRecord };
+      return result.team;
+    },
+
+    async updateTeam(organizationSlug, teamId, body) {
+      const response = await teams[":teamId"].$patch({
+        param: { organizationSlug, teamId },
+        json: body,
+      });
+      if (!response.ok) {
+        throw await readApiResponseError(response, "Failed to update team");
+      }
+      const result = (await response.json()) as { team: TeamRecord };
+      return result.team;
+    },
+
+    async deleteTeam(organizationSlug, teamId) {
+      const response = await teams[":teamId"].$delete({
+        param: { organizationSlug, teamId },
+      });
+      if (response.status !== 204 && !response.ok) {
+        throw await readApiResponseError(response, "Failed to delete team");
+      }
+    },
+
+    async addTeamMember(organizationSlug, teamId, body) {
+      const response = await teams[":teamId"].members.$post({
+        param: { organizationSlug, teamId },
+        json: body,
+      });
+      if (!response.ok) {
+        throw await readApiResponseError(response, "Failed to add team member");
+      }
+      const result = (await response.json()) as { member: TeamMemberRow };
+      return result.member;
+    },
+
+    async removeTeamMember(organizationSlug, teamId, workosUserId) {
+      const response = await teams[":teamId"].members[":workosUserId"].$delete({
+        param: { organizationSlug, teamId, workosUserId },
+      });
+      if (response.status !== 204 && !response.ok) {
+        throw await readApiResponseError(response, "Failed to remove team member");
+      }
+    },
+  };
+}
+
+export type { TeamRole };

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/teams-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/teams-page-content.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { apiClient } from "@/lib/api-client-instance";
+
+import { createTeamsApi } from "./teams-api";
+import { toCreateTeamPayload } from "./team-form";
+import { TeamsPageView } from "./teams-page-view";
+
+const teamsApi = createTeamsApi(apiClient);
+
+function teamsQueryKey(organizationSlug: string) {
+  return ["workspace-teams", organizationSlug] as const;
+}
+
+export function TeamsPageContent({
+  organizationSlug,
+  canManageTeams,
+  teamsApi: injectedTeamsApi = teamsApi,
+}: {
+  organizationSlug: string;
+  canManageTeams: boolean;
+  teamsApi?: typeof teamsApi;
+}) {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+
+  const teamsQuery = useQuery({
+    queryKey: teamsQueryKey(organizationSlug),
+    queryFn: () => injectedTeamsApi.listTeams(organizationSlug),
+  });
+
+  const createTeam = useMutation({
+    mutationFn: (values: { name: string; slug: string }) =>
+      injectedTeamsApi.createTeam(organizationSlug, toCreateTeamPayload(values)),
+    onSuccess: async (team) => {
+      setIsCreateOpen(false);
+      await queryClient.invalidateQueries({ queryKey: teamsQueryKey(organizationSlug) });
+      toast.success("Team created");
+      router.push(`/org/${organizationSlug}/teams/${team.id}`);
+    },
+    onError: (error) => {
+      toast.error(error.message);
+    },
+  });
+
+  return (
+    <TeamsPageView
+      organizationSlug={organizationSlug}
+      teams={teamsQuery.data ?? []}
+      canManageTeams={canManageTeams}
+      isLoading={teamsQuery.isLoading}
+      error={teamsQuery.error}
+      isCreateOpen={isCreateOpen}
+      isCreating={createTeam.isPending}
+      onCreateOpenChange={setIsCreateOpen}
+      onCreateTeam={(values) => createTeam.mutate(values)}
+    />
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/teams-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/teams-page-view.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, fn } from "storybook/test";
+
+import { teamsFixture } from "./teams.fixture";
+import { TeamsPageView } from "./teams-page-view";
+
+const meta = {
+  title: "App/Teams/Page",
+  component: TeamsPageView,
+  parameters: {
+    layout: "fullscreen",
+  },
+  args: {
+    organizationSlug: "acme",
+    teams: teamsFixture,
+    canManageTeams: true,
+    isLoading: false,
+    isCreateOpen: false,
+    isCreating: false,
+    onCreateOpenChange: fn(),
+    onCreateTeam: fn(),
+  },
+} satisfies Meta<typeof TeamsPageView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("heading", { name: "Teams" })).toBeInTheDocument();
+    await expect(canvas.getByText("Localization")).toBeInTheDocument();
+    await expect(canvas.getByText("Marketing")).toBeInTheDocument();
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    teams: [],
+    isLoading: true,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    teams: [],
+    isLoading: false,
+  },
+};
+
+export const ReadOnly: Story = {
+  args: {
+    canManageTeams: false,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.queryByRole("button", { name: "Create team" })).not.toBeInTheDocument();
+  },
+};
+
+export const CreateDialogOpen: Story = {
+  args: {
+    isCreateOpen: true,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("dialog", { name: "Create team" })).toBeInTheDocument();
+  },
+};
+
+export const LoadError: Story = {
+  args: {
+    teams: [],
+    error: new Error("The teams API returned a 500."),
+  },
+};

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/teams-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/teams-page-view.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import type { ReactNode } from "react";
+import Link from "next/link";
+import { Add01Icon, UserGroupIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { TypographyP } from "@/components/ui/typography";
+import { cn } from "@/lib/primitives/cn";
+
+import { PageHeader, WorkspacePageShell } from "../../_components/workspace-resource-shared";
+
+import { TeamDialog } from "./team-dialog";
+import type { TeamSummaryRow } from "./teams-api";
+import { createEmptyTeamForm } from "./team-form";
+import { getTeamRoleLabel, resolveTeamsListPageState } from "./teams-settings-view-model";
+
+export type TeamsLinkRenderer = (props: {
+  href: string;
+  children: ReactNode;
+  className?: string;
+}) => ReactNode;
+
+function defaultRenderTeamLink({ href, children, className }: Parameters<TeamsLinkRenderer>[0]) {
+  return (
+    <Link href={href} className={className}>
+      {children}
+    </Link>
+  );
+}
+
+export function TeamsPageView({
+  organizationSlug,
+  teams,
+  canManageTeams,
+  isLoading,
+  error,
+  isCreateOpen,
+  isCreating,
+  onCreateOpenChange,
+  onCreateTeam,
+  renderTeamLink = defaultRenderTeamLink,
+}: {
+  organizationSlug: string;
+  teams: TeamSummaryRow[];
+  canManageTeams: boolean;
+  isLoading: boolean;
+  error?: unknown;
+  isCreateOpen: boolean;
+  isCreating: boolean;
+  onCreateOpenChange: (open: boolean) => void;
+  onCreateTeam: (values: { name: string; slug: string }) => void;
+  renderTeamLink?: TeamsLinkRenderer;
+}) {
+  const pageState = resolveTeamsListPageState({ teams, canManageTeams });
+
+  return (
+    <WorkspacePageShell>
+      <PageHeader
+        icon={UserGroupIcon}
+        label="Workspace"
+        title="Teams"
+        description="Group people into teams to scope projects, jobs, and localization ownership."
+        actions={
+          pageState.canCreateTeam ? (
+            <Button
+              type="button"
+              onClick={() => onCreateOpenChange(true)}
+              className="w-full sm:w-fit"
+              disabled={isCreating}
+            >
+              <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
+              Create team
+            </Button>
+          ) : null
+        }
+      />
+
+      <section aria-label="Workspace teams" className="min-w-0">
+        {isLoading ? (
+          <TypographyP className="py-8 text-sm text-foreground/52">Loading teams...</TypographyP>
+        ) : error ? (
+          <div className="py-8">
+            <TypographyP className="text-sm font-medium text-flame-100">
+              Teams failed to load.
+            </TypographyP>
+            <TypographyP className="mt-1 text-xs text-foreground/48">
+              {error instanceof Error ? error.message : "Refresh the page to try again."}
+            </TypographyP>
+          </div>
+        ) : pageState.teams.length === 0 ? (
+          <div className="py-10">
+            <TypographyP className="text-sm font-medium text-foreground">No teams yet</TypographyP>
+            <TypographyP className="mt-2 max-w-xl text-sm leading-6 text-foreground/52">
+              Create a team to group workspace members and scope project access.
+            </TypographyP>
+          </div>
+        ) : (
+          <div role="table" className="min-w-0">
+            <div
+              role="row"
+              className="hidden grid-cols-[minmax(0,1.4fr)_10rem_8rem_7rem] gap-4 border-b border-foreground/8 px-1 py-2.5 text-xs font-medium tracking-[0.08em] text-foreground/36 uppercase md:grid"
+            >
+              <div role="columnheader">Team</div>
+              <div role="columnheader">Slug</div>
+              <div role="columnheader">Your role</div>
+              <div role="columnheader" className="text-right">
+                Members
+              </div>
+            </div>
+
+            {pageState.teams.map((team) => (
+              <div
+                key={team.id}
+                role="row"
+                className="grid gap-4 border-t border-foreground/8 px-1 py-4 md:grid-cols-[minmax(0,1.4fr)_10rem_8rem_7rem] md:items-center"
+              >
+                <div role="cell" className="min-w-0">
+                  {renderTeamLink({
+                    href: `/org/${organizationSlug}/teams/${team.id}`,
+                    className: "block min-w-0 rounded-md transition-colors hover:bg-foreground/4",
+                    children: (
+                      <div className="px-2 py-1">
+                        <TypographyP className="truncate text-sm font-medium text-foreground">
+                          {team.name}
+                        </TypographyP>
+                        <TypographyP className="mt-0.5 truncate text-xs text-foreground/48 md:hidden">
+                          {team.slug}
+                        </TypographyP>
+                      </div>
+                    ),
+                  })}
+                </div>
+
+                <div role="cell" className="hidden min-w-0 md:block">
+                  <TypographyP className="truncate font-mono text-xs text-foreground/56">
+                    {team.slug}
+                  </TypographyP>
+                </div>
+
+                <div role="cell" className="min-w-0">
+                  <div className="flex items-center justify-between gap-3 md:block">
+                    <span className="text-xs font-medium tracking-[0.08em] text-foreground/34 uppercase md:hidden">
+                      Your role
+                    </span>
+                    {team.currentUserRole ? (
+                      <Badge
+                        variant="outline"
+                        className="w-fit rounded-full border-foreground/12 bg-foreground/4 px-2.5 py-0.5 text-xs font-medium text-foreground/72"
+                      >
+                        {getTeamRoleLabel(team.currentUserRole)}
+                      </Badge>
+                    ) : (
+                      <span className="text-sm text-foreground/42">—</span>
+                    )}
+                  </div>
+                </div>
+
+                <div role="cell" className="flex items-center justify-between gap-3 md:justify-end">
+                  <span className="text-xs font-medium tracking-[0.08em] text-foreground/34 uppercase md:hidden">
+                    Members
+                  </span>
+                  <span
+                    className={cn(
+                      "tabular-nums text-sm text-foreground/68",
+                      "md:text-right md:text-foreground/56",
+                    )}
+                  >
+                    {team.memberCount}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <TeamDialog
+        open={isCreateOpen}
+        mode="create"
+        title="Create team"
+        description="Teams group workspace members and scope which projects they can access."
+        initialValues={createEmptyTeamForm()}
+        isSaving={isCreating}
+        onOpenChange={onCreateOpenChange}
+        onSubmit={onCreateTeam}
+      />
+    </WorkspacePageShell>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/teams-settings-view-model.test.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/teams-settings-view-model.test.ts
@@ -58,9 +58,23 @@ describe("teams-settings-view-model", () => {
         member: members[0]!,
         members,
         canManageMembers: true,
-        currentUserWorkosId: "user_manager",
       }),
     ).toBe(false);
+  });
+
+  it("allows removing a manager when another manager remains", () => {
+    const members = [
+      createTeamMember({ workosUserId: "user_manager_a", role: "manager" }),
+      createTeamMember({ workosUserId: "user_manager_b", role: "manager" }),
+    ];
+
+    expect(
+      canRemoveTeamMember({
+        member: members[0]!,
+        members,
+        canManageMembers: true,
+      }),
+    ).toBe(true);
   });
 
   it("prevents demoting the last team manager", () => {

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/teams-settings-view-model.test.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/teams-settings-view-model.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { createTeamDetail, createTeamMember, createTeamSummary } from "./teams.fixture";
+import {
+  canRemoveTeamMember,
+  canUpdateTeamMemberRole,
+  listAssignableMembers,
+  resolveTeamDetailPageState,
+  resolveTeamsListPageState,
+} from "./teams-settings-view-model";
+
+describe("teams-settings-view-model", () => {
+  it("enables team creation for workspace admins", () => {
+    const state = resolveTeamsListPageState({
+      teams: [createTeamSummary()],
+      canManageTeams: true,
+    });
+
+    expect(state.canCreateTeam).toBe(true);
+  });
+
+  it("lets team managers manage members without workspace admin access", () => {
+    const team = createTeamDetail({
+      members: [
+        createTeamMember({ workosUserId: "user_manager", role: "manager" }),
+        createTeamMember({ workosUserId: "user_member", role: "member" }),
+      ],
+    });
+
+    const state = resolveTeamDetailPageState({
+      team,
+      canManageTeams: false,
+      currentUserWorkosId: "user_manager",
+    });
+
+    expect(state.canManageMembers).toBe(true);
+  });
+
+  it("filters already-assigned members out of the add-member picker", () => {
+    const members = [createTeamMember({ workosUserId: "user_001", email: "mina@example.com" })];
+
+    const assignable = listAssignableMembers({
+      directory: [
+        { workosUserId: "user_001", email: "mina@example.com" },
+        { workosUserId: "user_002", email: "otto@example.com" },
+      ],
+      members,
+    });
+
+    expect(assignable).toEqual([{ workosUserId: "user_002", email: "otto@example.com" }]);
+  });
+
+  it("prevents removing the last team manager", () => {
+    const members = [createTeamMember({ workosUserId: "user_manager", role: "manager" })];
+
+    expect(
+      canRemoveTeamMember({
+        member: members[0]!,
+        members,
+        canManageMembers: true,
+        currentUserWorkosId: "user_manager",
+      }),
+    ).toBe(false);
+  });
+
+  it("prevents demoting the last team manager", () => {
+    const members = [createTeamMember({ workosUserId: "user_manager", role: "manager" })];
+
+    expect(
+      canUpdateTeamMemberRole({
+        member: members[0]!,
+        members,
+        canManageMembers: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/teams-settings-view-model.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/teams-settings-view-model.ts
@@ -1,0 +1,99 @@
+import type { TeamRole } from "@/api/routes/team/team.schema";
+
+import type {
+  OrganizationMemberDirectoryEntry,
+  TeamDetail,
+  TeamMemberRow,
+  TeamSummaryRow,
+} from "./teams-api";
+
+const teamRoleLabels: Record<TeamRole, string> = {
+  manager: "Manager",
+  member: "Member",
+};
+
+const teamRoleDescriptions: Record<TeamRole, string> = {
+  manager: "Can add or remove people and update team membership roles.",
+  member: "Can access projects and work assigned to this team.",
+};
+
+export function getTeamRoleLabel(role: TeamRole) {
+  return teamRoleLabels[role];
+}
+
+export function getTeamRoleDescription(role: TeamRole) {
+  return teamRoleDescriptions[role];
+}
+
+export function resolveTeamsListPageState(input: {
+  teams: TeamSummaryRow[];
+  canManageTeams: boolean;
+}) {
+  return {
+    teams: input.teams,
+    canCreateTeam: input.canManageTeams,
+    canManageTeams: input.canManageTeams,
+  };
+}
+
+export function resolveTeamDetailPageState(input: {
+  team: TeamDetail | undefined;
+  canManageTeams: boolean;
+  currentUserWorkosId: string;
+}) {
+  const members = input.team?.members ?? [];
+  const currentUserMembership = members.find(
+    (member) => member.workosUserId === input.currentUserWorkosId,
+  );
+  const canManageMembers = input.canManageTeams || currentUserMembership?.role === "manager";
+
+  return {
+    team: input.team,
+    members,
+    canManageMembers,
+    canManageTeams: input.canManageTeams,
+    currentUserMembership,
+  };
+}
+
+export function listAssignableMembers(input: {
+  directory: OrganizationMemberDirectoryEntry[];
+  members: TeamMemberRow[];
+}) {
+  const memberIds = new Set(input.members.map((member) => member.workosUserId));
+  return input.directory.filter((entry) => !memberIds.has(entry.workosUserId));
+}
+
+export function canRemoveTeamMember(input: {
+  member: TeamMemberRow;
+  members: TeamMemberRow[];
+  canManageMembers: boolean;
+  currentUserWorkosId: string;
+}) {
+  if (!input.canManageMembers) {
+    return false;
+  }
+
+  if (input.member.workosUserId === input.currentUserWorkosId) {
+    const managerCount = input.members.filter((member) => member.role === "manager").length;
+    return managerCount > 1 || input.member.role !== "manager";
+  }
+
+  return true;
+}
+
+export function canUpdateTeamMemberRole(input: {
+  member: TeamMemberRow;
+  members: TeamMemberRow[];
+  canManageMembers: boolean;
+}) {
+  if (!input.canManageMembers) {
+    return false;
+  }
+
+  if (input.member.role !== "manager") {
+    return true;
+  }
+
+  return input.members.filter((member) => member.role === "manager").length > 1;
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/teams-settings-view-model.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/teams-settings-view-model.ts
@@ -68,18 +68,16 @@ export function canRemoveTeamMember(input: {
   member: TeamMemberRow;
   members: TeamMemberRow[];
   canManageMembers: boolean;
-  currentUserWorkosId: string;
 }) {
   if (!input.canManageMembers) {
     return false;
   }
 
-  if (input.member.workosUserId === input.currentUserWorkosId) {
-    const managerCount = input.members.filter((member) => member.role === "manager").length;
-    return managerCount > 1 || input.member.role !== "manager";
+  if (input.member.role !== "manager") {
+    return true;
   }
 
-  return true;
+  return input.members.filter((member) => member.role === "manager").length > 1;
 }
 
 export function canUpdateTeamMemberRole(input: {

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/teams.fixture.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/_components/teams.fixture.ts
@@ -1,0 +1,92 @@
+import type {
+  OrganizationMemberDirectoryEntry,
+  TeamDetail,
+  TeamMemberRow,
+  TeamSummaryRow,
+} from "./teams-api";
+
+const fixedNow = "2026-06-07T12:00:00.000Z";
+
+export function createTeamSummary(overrides: Partial<TeamSummaryRow> = {}): TeamSummaryRow {
+  return {
+    id: "11111111-1111-4111-8111-111111111111",
+    slug: "localization",
+    name: "Localization",
+    createdAt: fixedNow,
+    updatedAt: fixedNow,
+    memberCount: 4,
+    currentUserRole: "manager",
+    ...overrides,
+  };
+}
+
+export function createTeamMember(overrides: Partial<TeamMemberRow> = {}): TeamMemberRow {
+  return {
+    workosUserId: "user_001",
+    email: "mina@example.com",
+    role: "manager",
+    ...overrides,
+  };
+}
+
+export function createTeamDetail(overrides: Partial<TeamDetail> = {}): TeamDetail {
+  const summary = createTeamSummary();
+  return {
+    id: summary.id,
+    organizationId: "org_001",
+    slug: summary.slug,
+    name: summary.name,
+    createdAt: summary.createdAt,
+    updatedAt: summary.updatedAt,
+    members: [
+      createTeamMember(),
+      createTeamMember({
+        workosUserId: "user_002",
+        email: "otto@example.com",
+        role: "member",
+      }),
+      createTeamMember({
+        workosUserId: "user_003",
+        email: "aiko@example.com",
+        role: "member",
+      }),
+    ],
+    ...overrides,
+  };
+}
+
+export function createMemberDirectoryEntry(
+  overrides: Partial<OrganizationMemberDirectoryEntry> = {},
+): OrganizationMemberDirectoryEntry {
+  return {
+    workosUserId: "user_004",
+    email: "sam@example.com",
+    ...overrides,
+  };
+}
+
+export const teamsFixture: TeamSummaryRow[] = [
+  createTeamSummary(),
+  createTeamSummary({
+    id: "22222222-2222-4222-8222-222222222222",
+    slug: "marketing",
+    name: "Marketing",
+    memberCount: 2,
+    currentUserRole: "member",
+  }),
+  createTeamSummary({
+    id: "33333333-3333-4333-8333-333333333333",
+    slug: "default",
+    name: "Default",
+    memberCount: 8,
+    currentUserRole: null,
+  }),
+];
+
+export const memberDirectoryFixture: OrganizationMemberDirectoryEntry[] = [
+  createMemberDirectoryEntry(),
+  createMemberDirectoryEntry({
+    workosUserId: "user_005",
+    email: "lee@example.com",
+  }),
+];

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/page.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/teams/page.tsx
@@ -1,0 +1,20 @@
+import { hasCapability } from "@/api/auth/policy";
+import { requireAppAuthContext } from "@/lib/workos/app-auth";
+
+import { TeamsPageContent } from "./_components/teams-page-content";
+
+export default async function TeamsPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string }>;
+}) {
+  const { organizationSlug } = await params;
+  const auth = await requireAppAuthContext({ organizationSlug });
+
+  return (
+    <TeamsPageContent
+      organizationSlug={organizationSlug}
+      canManageTeams={hasCapability(auth.membership.role, "teams:write")}
+    />
+  );
+}

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
@@ -107,9 +107,10 @@ export function buildGlobalNavigationGroups(organizationSlug: string): readonly 
           icon: LinkSquare02Icon,
         },
         {
-          label: "Team",
-          href: org("settings/members"),
+          label: "Teams",
+          href: org("teams"),
           icon: UserGroupIcon,
+          description: "Create teams and assign workspace members",
         },
         {
           label: "Settings",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Adds Teams management UI at `/org/[slug]/teams` so admins can create teams and assign workspace members to them.

- **Teams list page** — browse teams, create new teams via dialog
- **Team detail page** — view members, add members from workspace directory, update roles, remove members, edit team name/slug
- **Dependency injection** — `createTeamsApi(client)` interface with injectable `teamsApi` prop on `TeamsPageContent` and `TeamDetailPageContent` for testability
- **Storybook** — stories for `TeamsPageView`, `TeamDetailPageView`, `TeamDialog`, and `AddTeamMemberDialog`
- **Tests** — view-model and form validation unit tests
- **Navigation** — "Team" nav item renamed to "Teams" and points to `/teams` instead of `/settings/members`

Permissions follow existing API rules: `teams:write` for create/edit; team managers can add/remove members without org admin.

## How to test

1. Run `vp check --fix` and `vp test src/app/(authenticated)/org/[organizationSlug]/teams/_components/` in `apps/hyperlocalise-web`
2. Start dev server with Postgres and navigate to `/org/<slug>/teams`
3. As an admin, create a team and assign members from the detail page
4. Review Storybook stories under App/Teams/*

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, teams component tests)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://hyperlocalise.slack.com/archives/D0B5GKZKTRB/p1780869407639669?thread_ts=1780869407.639669&cid=D0B5GKZKTRB)

<div><a href="https://cursor.com/agents/bc-64c99fb7-7228-5bf2-8b01-5b55c7c08a6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64c99fb7-7228-5bf2-8b01-5b55c7c08a6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

