### PR TITLE
feat(cat): add Crowdin task strings workspace

### DIFF
--- a/apps/hyperlocalise-web/src/api/auth/capability-guards.ts
+++ b/apps/hyperlocalise-web/src/api/auth/capability-guards.ts
@@ -51,6 +51,10 @@ export function isWriteBackApproveAllowed(role: OrganizationMembershipRole): boo
   return hasCapability(role, "write_back:approve");
 }
 
+export function isWriteBackTranslationAllowed(role: OrganizationMembershipRole): boolean {
+  return hasCapability(role, "write_back:translation");
+}
+
 export function isIntegrationsReadAllowed(role: OrganizationMembershipRole): boolean {
   return hasCapability(role, "integrations:read");
 }

--- a/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
@@ -1,0 +1,290 @@
+import "dotenv/config";
+
+import { testClient } from "hono/testing";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
+
+import { app } from "@/api/app";
+import { db } from "@/lib/database";
+import { TmsProviderLiveError } from "@/lib/providers/tms-provider-live";
+
+import { createProjectTestFixture } from "./project.fixture";
+import type { ProjectFileCatResponse, ProjectFileCatTranslationResponse } from "./project.schema";
+
+const {
+  getTmsProviderConnectionMock,
+  getTmsProviderLiveCatFileMock,
+  saveTmsProviderLiveCatTranslationMock,
+} = vi.hoisted(() => ({
+  getTmsProviderConnectionMock: vi.fn(),
+  getTmsProviderLiveCatFileMock: vi.fn(),
+  saveTmsProviderLiveCatTranslationMock: vi.fn(),
+}));
+
+vi.mock("@/lib/providers/tms-provider-live", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/providers/tms-provider-live")>();
+  return {
+    ...actual,
+    getTmsProviderConnection: (...args: unknown[]) => getTmsProviderConnectionMock(...args),
+    getTmsProviderLiveCatFile: (...args: unknown[]) => getTmsProviderLiveCatFileMock(...args),
+    saveTmsProviderLiveCatTranslation: (...args: unknown[]) =>
+      saveTmsProviderLiveCatTranslationMock(...args),
+  };
+});
+
+const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
+  resolveApiAuthContextFromSessionMock: vi.fn(
+    (options) =>
+      globalThis.__resolveTestApiAuthContextFromSession?.(options) ??
+      globalThis.__testApiAuthContext ??
+      null,
+  ),
+}));
+
+vi.mock("@/api/auth/workos-session", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/auth/workos-session")>();
+  return {
+    ...actual,
+    resolveApiAuthContextFromSession: resolveApiAuthContextFromSessionMock,
+  };
+});
+
+const client = testClient(app);
+const projectFixture = createProjectTestFixture(client);
+
+beforeAll(async () => {
+  await db.$client.query("select 1");
+});
+
+afterEach(async () => {
+  vi.clearAllMocks();
+  await projectFixture.cleanup();
+});
+
+describe("project file CAT routes", () => {
+  it("returns Crowdin CAT content for an encoded provider project", async () => {
+    const translator = projectFixture.createWorkosIdentityWithRole("translator");
+    getTmsProviderConnectionMock.mockResolvedValue({
+      providerKind: "crowdin",
+      displayName: "Crowdin",
+      validationStatus: "valid",
+      validationMessage: null,
+    });
+    getTmsProviderLiveCatFileMock.mockResolvedValue({
+      sourcePath: "crowdin/home.json",
+      filename: "home.json",
+      provider: {
+        kind: "crowdin",
+        resourceType: "file",
+        externalProjectId: "42",
+        externalResourceId: "101",
+        externalUrl: null,
+        syncState: "synced",
+        sourceLocale: "en",
+        targetLocales: ["fr"],
+        localeReadiness: {},
+        revision: "1",
+        format: "json",
+        lastSyncedAt: null,
+      },
+      targetLocale: "fr",
+      canEditTranslations: true,
+      truncated: false,
+      segments: [
+        {
+          externalStringId: "1001",
+          key: "hello",
+          sourceText: "Hello",
+          context: null,
+          type: "text",
+          target: { text: "Bonjour", externalTranslationId: "9001", isApproved: true },
+          comments: [
+            {
+              externalCommentId: "42",
+              type: "issue",
+              status: "unresolved",
+              text: "Needs product wording",
+              createdAt: "2026-06-08T00:00:00Z",
+              locale: "fr",
+            },
+          ],
+        },
+      ],
+    });
+
+    const response = await client.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].files.detail.cat.$get(
+      {
+        param: {
+          organizationSlug: translator.organization.slug ?? "missing-slug",
+          projectId: "ext:crowdin:42",
+        },
+        query: { sourcePath: "crowdin/home.json", targetLocale: "fr" },
+      },
+      { headers: await projectFixture.authHeadersFor(translator) },
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as ProjectFileCatResponse;
+    expect(body.catFile.segments[0]).toMatchObject({
+      externalStringId: "1001",
+      target: { text: "Bonjour", isApproved: true },
+      comments: [{ type: "issue", status: "unresolved" }],
+    });
+    expect(getTmsProviderLiveCatFileMock).toHaveBeenCalledWith(
+      expect.any(String),
+      "42",
+      "crowdin/home.json",
+      "fr",
+      expect.objectContaining({ canEditTranslations: true }),
+    );
+  });
+
+  it("returns project_not_found when the provider file is missing", async () => {
+    const translator = projectFixture.createWorkosIdentityWithRole("translator");
+    getTmsProviderConnectionMock.mockResolvedValue({
+      providerKind: "crowdin",
+      displayName: "Crowdin",
+      validationStatus: "valid",
+      validationMessage: null,
+    });
+    getTmsProviderLiveCatFileMock.mockResolvedValue(null);
+
+    const response = await client.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].files.detail.cat.$get(
+      {
+        param: {
+          organizationSlug: translator.organization.slug ?? "missing-slug",
+          projectId: "ext:crowdin:42",
+        },
+        query: { sourcePath: "missing.json", targetLocale: "fr" },
+      },
+      { headers: await projectFixture.authHeadersFor(translator) },
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toMatchObject({ error: "project_not_found" });
+  });
+
+  it("returns provider_cat_unsupported for unsupported providers", async () => {
+    const translator = projectFixture.createWorkosIdentityWithRole("translator");
+    getTmsProviderConnectionMock.mockResolvedValue({
+      providerKind: "phrase",
+      displayName: "Phrase",
+      validationStatus: "valid",
+      validationMessage: null,
+    });
+    getTmsProviderLiveCatFileMock.mockRejectedValue(
+      new TmsProviderLiveError(
+        "provider_cat_unsupported",
+        "CAT editing is not available for this provider file yet.",
+      ),
+    );
+
+    const response = await client.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].files.detail.cat.$get(
+      {
+        param: {
+          organizationSlug: translator.organization.slug ?? "missing-slug",
+          projectId: "ext:phrase:42",
+        },
+        query: { sourcePath: "phrase/home.json", targetLocale: "fr" },
+      },
+      { headers: await projectFixture.authHeadersFor(translator) },
+    );
+
+    expect(response.status).toBe(501);
+    expect(await response.json()).toMatchObject({ error: "provider_cat_unsupported" });
+  });
+
+  it("rejects invalid CAT query payloads", async () => {
+    const translator = projectFixture.createWorkosIdentityWithRole("translator");
+
+    const response = await client.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].files.detail.cat.$get(
+      {
+        param: {
+          organizationSlug: translator.organization.slug ?? "missing-slug",
+          projectId: "ext:crowdin:42",
+        },
+        query: { sourcePath: "crowdin/home.json", targetLocale: "" },
+      },
+      { headers: await projectFixture.authHeadersFor(translator) },
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({ error: "invalid_project_payload" });
+  });
+
+  it("saves Crowdin CAT translations for users with write-back permission", async () => {
+    const translator = projectFixture.createWorkosIdentityWithRole("translator");
+    getTmsProviderConnectionMock.mockResolvedValue({
+      providerKind: "crowdin",
+      displayName: "Crowdin",
+      validationStatus: "valid",
+      validationMessage: null,
+    });
+    saveTmsProviderLiveCatTranslationMock.mockResolvedValue({
+      text: "Bonjour",
+      externalTranslationId: "9001",
+      isApproved: false,
+    });
+
+    const response = await client.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].files.detail.cat.translations.$post(
+      {
+        param: {
+          organizationSlug: translator.organization.slug ?? "missing-slug",
+          projectId: "ext:crowdin:42",
+        },
+        json: {
+          sourcePath: "crowdin/home.json",
+          targetLocale: "fr",
+          externalStringId: "1001",
+          text: "Bonjour",
+        },
+      },
+      { headers: await projectFixture.authHeadersFor(translator) },
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as ProjectFileCatTranslationResponse;
+    expect(body.translation).toMatchObject({ text: "Bonjour", externalTranslationId: "9001" });
+    expect(saveTmsProviderLiveCatTranslationMock).toHaveBeenCalledWith(
+      expect.any(String),
+      "42",
+      "crowdin/home.json",
+      { targetLocale: "fr", externalStringId: "1001", text: "Bonjour" },
+      expect.objectContaining({ actorUserId: expect.any(String) }),
+    );
+  });
+
+  it("denies CAT translation saves without write-back permission", async () => {
+    const member = projectFixture.createWorkosIdentityWithRole("member");
+
+    const response = await client.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].files.detail.cat.translations.$post(
+      {
+        param: {
+          organizationSlug: member.organization.slug ?? "missing-slug",
+          projectId: "ext:crowdin:42",
+        },
+        json: {
+          sourcePath: "crowdin/home.json",
+          targetLocale: "fr",
+          externalStringId: "1001",
+          text: "Bonjour",
+        },
+      },
+      { headers: await projectFixture.authHeadersFor(member) },
+    );
+
+    expect(response.status).toBe(403);
+    expect(saveTmsProviderLiveCatTranslationMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
@@ -245,6 +245,7 @@ describe("project file CAT routes", () => {
           sourcePath: "crowdin/home.json",
           targetLocale: "fr",
           externalStringId: "1001",
+          externalResourceId: "101",
           text: "Bonjour",
         },
       },
@@ -258,7 +259,7 @@ describe("project file CAT routes", () => {
       expect.any(String),
       "42",
       "crowdin/home.json",
-      { targetLocale: "fr", externalStringId: "1001", text: "Bonjour" },
+      { targetLocale: "fr", externalStringId: "1001", externalResourceId: "101", text: "Bonjour" },
       expect.objectContaining({ actorUserId: expect.any(String) }),
     );
   });

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -497,6 +497,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
             {
               targetLocale: body.targetLocale,
               externalStringId: body.externalStringId,
+              externalResourceId: body.externalResourceId,
               text: body.text,
             },
             { actorUserId: c.var.auth.user.localUserId },

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -14,10 +14,12 @@ import { createRepositorySourceFileVersion, createStoredFile } from "@/lib/file-
 import { sourceContentType } from "@/lib/file-storage/source-file-metadata";
 import {
   getTmsProviderConnection,
+  getTmsProviderLiveCatFile,
   getTmsProviderLiveFileDetail,
   getTmsProviderLiveProject,
   listTmsProviderLiveFilesForProject,
   listTmsProviderLiveProjects,
+  saveTmsProviderLiveCatTranslation,
 } from "@/lib/providers/tms-provider-live";
 import { getProjectFileDetail } from "@/lib/projects/project-file-detail";
 import { lookupProjectFileStringRepositoryContext } from "@/lib/projects/project-file-string-context";
@@ -29,6 +31,8 @@ import { createTranslationJobEventQueue } from "@/workflows/adapters";
 import {
   createProjectBodySchema,
   maxProjectFileUploadBytes,
+  projectFileCatQuerySchema,
+  projectFileCatTranslationBodySchema,
   projectFileDetailQuerySchema,
   projectFileStringContextBodySchema,
   projectFileUploadBodySchema,
@@ -43,7 +47,7 @@ import { normalizeProjectLocalePatch, type ProjectLocalePatchError } from "@/lib
 import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
 import { ensureDefaultWorkspaceTeam } from "@/lib/teams/default-workspace-team";
 
-import { isAiActionAllowed } from "@/api/auth/capability-guards";
+import { isAiActionAllowed, isWriteBackTranslationAllowed } from "@/api/auth/capability-guards";
 import {
   buildAccessibleProjectsWhere,
   forbiddenResponse,
@@ -275,6 +279,26 @@ const validateProjectFileDetailQuery = validator("query", (value, c) => {
   return parsed.data;
 });
 
+const validateProjectFileCatQuery = validator("query", (value, c) => {
+  const parsed = projectFileCatQuerySchema.safeParse(value);
+
+  if (!parsed.success) {
+    return invalidProjectPayloadResponse(c);
+  }
+
+  return parsed.data;
+});
+
+const validateProjectFileCatTranslationBody = validator("json", (value, c) => {
+  const parsed = projectFileCatTranslationBodySchema.safeParse(value);
+
+  if (!parsed.success) {
+    return invalidProjectPayloadResponse(c);
+  }
+
+  return parsed.data;
+});
+
 const validateProjectFileStringContextBody = validator("json", (value, c) => {
   const parsed = projectFileStringContextBodySchema.safeParse(value);
 
@@ -400,6 +424,93 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
       }
     })
     .route("/:projectId/jobs", createJobRoutes({ jobQueue }))
+    .get(
+      "/:projectId/files/detail/cat",
+      validateProjectParams,
+      validateProjectFileCatQuery,
+      async (c) => {
+        const params = c.req.valid("param");
+        const query = c.req.valid("query");
+        const target = await resolveProjectResourceTarget(c.var.auth, params.projectId);
+        if (target.kind === "provider_unavailable") {
+          return providerProjectUnavailableResponse(c, target);
+        }
+
+        if (target.kind !== "provider") {
+          return badRequestResponse(
+            c,
+            "provider_cat_unsupported",
+            "CAT editing is only available for provider files.",
+          );
+        }
+
+        try {
+          const catFile = await getTmsProviderLiveCatFile(
+            c.var.auth.organization.localOrganizationId,
+            target.externalProjectId,
+            query.sourcePath,
+            query.targetLocale,
+            {
+              actorUserId: c.var.auth.user.localUserId,
+              canEditTranslations: isWriteBackTranslationAllowed(c.var.auth.membership.role),
+            },
+          );
+          if (!catFile) {
+            return projectNotFoundResponse(c);
+          }
+
+          return c.json({ catFile }, 200);
+        } catch (error) {
+          return tmsProviderLiveErrorResponse(c, error);
+        }
+      },
+    )
+    .post(
+      "/:projectId/files/detail/cat/translations",
+      validateProjectParams,
+      validateProjectFileCatTranslationBody,
+      async (c) => {
+        if (!isWriteBackTranslationAllowed(c.var.auth.membership.role)) {
+          return forbiddenResponse(c);
+        }
+
+        const params = c.req.valid("param");
+        const body = c.req.valid("json");
+        const target = await resolveProjectResourceTarget(c.var.auth, params.projectId);
+        if (target.kind === "provider_unavailable") {
+          return providerProjectUnavailableResponse(c, target);
+        }
+
+        if (target.kind !== "provider") {
+          return badRequestResponse(
+            c,
+            "provider_cat_unsupported",
+            "CAT editing is only available for provider files.",
+          );
+        }
+
+        try {
+          const translation = await saveTmsProviderLiveCatTranslation(
+            c.var.auth.organization.localOrganizationId,
+            target.externalProjectId,
+            body.sourcePath,
+            {
+              targetLocale: body.targetLocale,
+              externalStringId: body.externalStringId,
+              text: body.text,
+            },
+            { actorUserId: c.var.auth.user.localUserId },
+          );
+          if (!translation) {
+            return projectNotFoundResponse(c);
+          }
+
+          return c.json({ translation }, 200);
+        } catch (error) {
+          return tmsProviderLiveErrorResponse(c, error);
+        }
+      },
+    )
     .get(
       "/:projectId/files/detail",
       validateProjectParams,

--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -209,6 +209,18 @@ export const projectFileDetailQuerySchema = z.object({
   sourcePath: z.string().trim().min(1).max(2048),
 });
 
+export const projectFileCatQuerySchema = z.object({
+  sourcePath: z.string().trim().min(1).max(2048),
+  targetLocale: z.string().trim().min(1).max(32),
+});
+
+export const projectFileCatTranslationBodySchema = z.object({
+  sourcePath: z.string().trim().min(1).max(2048),
+  targetLocale: z.string().trim().min(1).max(32),
+  externalStringId: z.string().trim().min(1).max(128),
+  text: z.string().max(100_000),
+});
+
 export const maxProjectFileUploadBytes = 25 * 1024 * 1024;
 
 export const projectFileUploadBodySchema = z.object({
@@ -328,6 +340,47 @@ export const projectFileDetailResponseSchema = z.object({
   }),
 });
 
+export const projectFileCatCommentSchema = z.object({
+  externalCommentId: z.string(),
+  type: z.enum(["comment", "issue"]),
+  status: z.string().nullable(),
+  text: z.string(),
+  createdAt: z.string(),
+  locale: z.string().nullable(),
+});
+
+export const projectFileCatTranslationSchema = z.object({
+  text: z.string(),
+  externalTranslationId: z.string().nullable(),
+  isApproved: z.boolean(),
+});
+
+export const projectFileCatSegmentSchema = z.object({
+  externalStringId: z.string(),
+  key: z.string(),
+  sourceText: z.string(),
+  context: z.string().nullable(),
+  type: z.string().nullable(),
+  target: projectFileCatTranslationSchema.nullable(),
+  comments: z.array(projectFileCatCommentSchema),
+});
+
+export const projectFileCatResponseSchema = z.object({
+  catFile: z.object({
+    sourcePath: z.string(),
+    filename: z.string(),
+    provider: projectFileRecordSchema.shape.provider,
+    targetLocale: z.string(),
+    canEditTranslations: z.boolean(),
+    truncated: z.boolean(),
+    segments: z.array(projectFileCatSegmentSchema),
+  }),
+});
+
+export const projectFileCatTranslationResponseSchema = z.object({
+  translation: projectFileCatTranslationSchema,
+});
+
 export type ProjectIdParams = z.infer<typeof projectIdParamsSchema>;
 export type CreateProjectBody = z.infer<typeof createProjectBodySchema>;
 export type UpdateProjectBody = z.infer<typeof updateProjectBodySchema>;
@@ -338,6 +391,8 @@ export type ProjectFileRecord = z.infer<typeof projectFileRecordSchema>;
 export type ProjectFilesResponse = z.infer<typeof projectFilesResponseSchema>;
 export type ProjectFilesQuery = z.infer<typeof projectFilesQuerySchema>;
 export type ProjectFileDetailQuery = z.infer<typeof projectFileDetailQuerySchema>;
+export type ProjectFileCatQuery = z.infer<typeof projectFileCatQuerySchema>;
+export type ProjectFileCatTranslationBody = z.infer<typeof projectFileCatTranslationBodySchema>;
 export type ProjectSourceStringEntry = z.infer<typeof projectSourceStringEntrySchema>;
 export type ProjectSourceStringsPreview = z.infer<typeof projectSourceStringsPreviewSchema>;
 export type ProjectFileContent = z.infer<typeof projectFileContentSchema>;
@@ -350,5 +405,12 @@ export type ProjectFileOutputRecord = z.infer<typeof projectFileOutputRecordSche
 export type ProjectFileJobRecord = z.infer<typeof projectFileJobRecordSchema>;
 export type ProjectFileProviderJobRecord = z.infer<typeof projectFileProviderJobRecordSchema>;
 export type ProjectFileDetailResponse = z.infer<typeof projectFileDetailResponseSchema>;
+export type ProjectFileCatComment = z.infer<typeof projectFileCatCommentSchema>;
+export type ProjectFileCatTranslation = z.infer<typeof projectFileCatTranslationSchema>;
+export type ProjectFileCatSegment = z.infer<typeof projectFileCatSegmentSchema>;
+export type ProjectFileCatResponse = z.infer<typeof projectFileCatResponseSchema>;
+export type ProjectFileCatTranslationResponse = z.infer<
+  typeof projectFileCatTranslationResponseSchema
+>;
 export type WorkspaceFileRecord = z.infer<typeof workspaceFileRecordSchema>;
 export type WorkspaceFilesResponse = z.infer<typeof workspaceFilesResponseSchema>;

--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -218,6 +218,7 @@ export const projectFileCatTranslationBodySchema = z.object({
   sourcePath: z.string().trim().min(1).max(2048),
   targetLocale: z.string().trim().min(1).max(32),
   externalStringId: z.string().trim().min(1).max(128),
+  externalResourceId: z.string().trim().min(1).max(128).optional(),
   text: z.string().max(100_000),
 });
 

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-workspace.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-workspace.stories.tsx
@@ -1,0 +1,136 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, userEvent } from "storybook/test";
+
+import type { ProjectFileCatResponse } from "@/api/routes/project/project.schema";
+import { ProjectFileCatWorkspaceView } from "./project-file-cat-workspace";
+import { providerProjectFilesFixture } from "./project-files.fixture";
+
+const providerFile = providerProjectFilesFixture[0]!;
+
+const catFile: ProjectFileCatResponse["catFile"] = {
+  sourcePath: providerFile.sourcePath,
+  filename: providerFile.filename,
+  provider: providerFile.provider,
+  targetLocale: "fr-FR",
+  canEditTranslations: true,
+  truncated: false,
+  segments: [
+    {
+      externalStringId: "1001",
+      key: "hero.title",
+      sourceText: "Ship localized product pages faster",
+      context: "Homepage hero headline",
+      type: "text",
+      target: {
+        text: "Publiez des pages produit localisees plus vite",
+        externalTranslationId: "9001",
+        isApproved: true,
+      },
+      comments: [],
+    },
+    {
+      externalStringId: "1002",
+      key: "hero.cta",
+      sourceText: "Start translating",
+      context: "Primary call to action",
+      type: "text",
+      target: null,
+      comments: [
+        {
+          externalCommentId: "comment_42",
+          type: "issue",
+          status: "unresolved",
+          text: "Use the approved product verb here.",
+          createdAt: "2026-06-06T10:30:00.000Z",
+          locale: "fr-FR",
+        },
+      ],
+    },
+    {
+      externalStringId: "1003",
+      key: "pricing.badge",
+      sourceText: "Most popular",
+      context: null,
+      type: "text",
+      target: {
+        text: "Le plus populaire",
+        externalTranslationId: "9003",
+        isApproved: false,
+      },
+      comments: [
+        {
+          externalCommentId: "comment_43",
+          type: "comment",
+          status: null,
+          text: "Check whether this should match the pricing-page badge.",
+          createdAt: "2026-06-06T10:15:00.000Z",
+          locale: "fr-FR",
+        },
+      ],
+    },
+  ],
+};
+
+const meta = {
+  title: "App/Project/Files/CAT Workspace",
+  component: ProjectFileCatWorkspaceView,
+  parameters: {
+    layout: "fullscreen",
+  },
+  args: {
+    catFile,
+    targetLocales: ["fr-FR", "de-DE"],
+    targetLocale: "fr-FR",
+    onTargetLocaleChange: () => undefined,
+    isLoading: false,
+    onSave: async (_externalStringId: string, text: string) => ({
+      text,
+      externalTranslationId: "new_translation",
+      isApproved: false,
+    }),
+  },
+} satisfies Meta<typeof ProjectFileCatWorkspaceView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Editable: Story = {
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("hero.cta")).toBeInTheDocument();
+    await expect(canvas.getByText("Use the approved product verb here.")).toBeInTheDocument();
+    const textarea = canvas.getByPlaceholderText("Add translation");
+    await userEvent.type(textarea, "Commencer a traduire");
+    await expect(canvas.getByRole("button", { name: "Save" })).toBeEnabled();
+  },
+};
+
+export const ReadOnly: Story = {
+  args: {
+    catFile: {
+      ...catFile,
+      canEditTranslations: false,
+    },
+    onSave: undefined,
+  },
+  play: async ({ canvas }) => {
+    await expect(
+      canvas.getByText(
+        "You can view this CAT workspace, but your role cannot write translations back.",
+      ),
+    ).toBeInTheDocument();
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    catFile: null,
+    isLoading: true,
+  },
+};
+
+export const LoadError: Story = {
+  args: {
+    catFile: null,
+    error: new Error("Crowdin credentials are invalid."),
+  },
+};

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-workspace.test.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-workspace.test.ts
@@ -69,4 +69,31 @@ describe("mergeCatWorkspaceRows", () => {
     });
     expect(merged.rowErrors).toEqual({ dirty: "Still local" });
   });
+
+  it("keeps failed drafts and row errors when refreshed CAT data arrives", () => {
+    const merged = mergeCatWorkspaceRows(
+      catFileWithSegments([{ externalStringId: "failed", text: "Serveur" }]),
+      {
+        drafts: {
+          failed: "Draft that failed to save",
+        },
+        saveStates: {
+          failed: "failed",
+        },
+        rowErrors: {
+          failed: "Crowdin rejected the update",
+        },
+      },
+    );
+
+    expect(merged.drafts).toEqual({
+      failed: "Draft that failed to save",
+    });
+    expect(merged.saveStates).toEqual({
+      failed: "failed",
+    });
+    expect(merged.rowErrors).toEqual({
+      failed: "Crowdin rejected the update",
+    });
+  });
 });

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-workspace.test.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-workspace.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import type { ProjectFileCatResponse } from "@/api/routes/project/project.schema";
+import { mergeCatWorkspaceRows } from "./project-file-cat-workspace";
+
+function catFileWithSegments(
+  segments: Array<{ externalStringId: string; text: string | null }>,
+): ProjectFileCatResponse["catFile"] {
+  return {
+    sourcePath: "home.json",
+    filename: "home.json",
+    provider: null,
+    targetLocale: "fr",
+    canEditTranslations: true,
+    truncated: false,
+    segments: segments.map((segment) => ({
+      externalStringId: segment.externalStringId,
+      key: segment.externalStringId,
+      sourceText: "Source",
+      context: null,
+      type: "text",
+      target:
+        segment.text == null
+          ? null
+          : {
+              text: segment.text,
+              externalTranslationId: null,
+              isApproved: false,
+            },
+      comments: [],
+    })),
+  } as ProjectFileCatResponse["catFile"];
+}
+
+describe("mergeCatWorkspaceRows", () => {
+  it("keeps dirty and saving drafts when refreshed CAT data arrives", () => {
+    const merged = mergeCatWorkspaceRows(
+      catFileWithSegments([
+        { externalStringId: "clean", text: "Serveur" },
+        { externalStringId: "dirty", text: "Ancienne valeur" },
+        { externalStringId: "saving", text: "Ancienne sauvegarde" },
+      ]),
+      {
+        drafts: {
+          clean: "Old clean",
+          dirty: "Draft in progress",
+          saving: "Saving draft",
+        },
+        saveStates: {
+          clean: "unchanged",
+          dirty: "dirty",
+          saving: "saving",
+        },
+        rowErrors: {
+          dirty: "Still local",
+        },
+      },
+    );
+
+    expect(merged.drafts).toEqual({
+      clean: "Serveur",
+      dirty: "Draft in progress",
+      saving: "Saving draft",
+    });
+    expect(merged.saveStates).toEqual({
+      clean: "unchanged",
+      dirty: "dirty",
+      saving: "saving",
+    });
+    expect(merged.rowErrors).toEqual({ dirty: "Still local" });
+  });
+});

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-workspace.tsx
@@ -65,6 +65,38 @@ function saveStatesFor(catFile: CatFile | null) {
   );
 }
 
+export function mergeCatWorkspaceRows(
+  catFile: CatFile | null,
+  current: {
+    drafts: Record<string, string>;
+    saveStates: Record<string, SaveState>;
+    rowErrors: Record<string, string>;
+  },
+) {
+  const drafts: Record<string, string> = {};
+  const saveStates: Record<string, SaveState> = {};
+  const rowErrors: Record<string, string> = {};
+
+  for (const segment of catFile?.segments ?? []) {
+    const id = segment.externalStringId;
+    const state = current.saveStates[id] ?? "unchanged";
+
+    if (state === "dirty" || state === "saving") {
+      drafts[id] = current.drafts[id] ?? "";
+      saveStates[id] = state;
+      if (current.rowErrors[id]) {
+        rowErrors[id] = current.rowErrors[id];
+      }
+      continue;
+    }
+
+    drafts[id] = segment.target?.text ?? "";
+    saveStates[id] = "unchanged";
+  }
+
+  return { drafts, saveStates, rowErrors };
+}
+
 export function ProjectFileCatWorkspace({
   organizationSlug,
   projectId,
@@ -188,9 +220,10 @@ export function ProjectFileCatWorkspaceView({
   const [rowErrors, setRowErrors] = useState<Record<string, string>>({});
 
   useEffect(() => {
-    setDrafts(draftValuesFor(catFile));
-    setSaveStates(saveStatesFor(catFile));
-    setRowErrors({});
+    const merged = mergeCatWorkspaceRows(catFile, { drafts, saveStates, rowErrors });
+    setDrafts(merged.drafts);
+    setSaveStates(merged.saveStates);
+    setRowErrors(merged.rowErrors);
   }, [catFile]);
 
   const segments = catFile?.segments ?? [];

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-workspace.tsx
@@ -81,7 +81,7 @@ export function mergeCatWorkspaceRows(
     const id = segment.externalStringId;
     const state = current.saveStates[id] ?? "unchanged";
 
-    if (state === "dirty" || state === "saving") {
+    if (state === "dirty" || state === "saving" || state === "failed") {
       drafts[id] = current.drafts[id] ?? "";
       saveStates[id] = state;
       if (current.rowErrors[id]) {

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-workspace.tsx
@@ -1,0 +1,474 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { AlertCircleIcon, CheckIcon, SaveIcon } from "lucide-react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import type {
+  ProjectFileCatResponse,
+  ProjectFileCatSegment,
+  ProjectFileCatTranslation,
+} from "@/api/routes/project/project.schema";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Spinner } from "@/components/ui/spinner";
+import { Textarea } from "@/components/ui/textarea";
+import { TypographyP } from "@/components/ui/typography";
+import { readApiError } from "@/lib/api-error";
+import { apiClient } from "@/lib/api-client-instance";
+import { cn } from "@/lib/primitives/cn";
+
+type CatFile = ProjectFileCatResponse["catFile"];
+type SaveState = "unchanged" | "dirty" | "saving" | "saved" | "failed";
+
+const DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+function projectFileCatQueryKey(
+  organizationSlug: string,
+  projectId: string,
+  sourcePath: string,
+  targetLocale: string,
+) {
+  return ["project-file-cat", organizationSlug, projectId, sourcePath, targetLocale] as const;
+}
+
+function initialTargetLocale(targetLocales: string[], highlightLocale: string | null) {
+  if (highlightLocale && targetLocales.includes(highlightLocale)) {
+    return highlightLocale;
+  }
+
+  return targetLocales[0] ?? "";
+}
+
+function draftValuesFor(catFile: CatFile | null) {
+  return Object.fromEntries(
+    (catFile?.segments ?? []).map((segment) => [
+      segment.externalStringId,
+      segment.target?.text ?? "",
+    ]),
+  );
+}
+
+function saveStatesFor(catFile: CatFile | null) {
+  return Object.fromEntries(
+    (catFile?.segments ?? []).map((segment) => [segment.externalStringId, "unchanged" as const]),
+  );
+}
+
+export function ProjectFileCatWorkspace({
+  organizationSlug,
+  projectId,
+  sourcePath,
+  targetLocales,
+  highlightLocale,
+}: {
+  organizationSlug: string;
+  projectId: string;
+  sourcePath: string;
+  targetLocales: string[];
+  highlightLocale: string | null;
+}) {
+  const [targetLocale, setTargetLocale] = useState(() =>
+    initialTargetLocale(targetLocales, highlightLocale),
+  );
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    setTargetLocale((current) => {
+      if (current && targetLocales.includes(current)) {
+        return current;
+      }
+
+      return initialTargetLocale(targetLocales, highlightLocale);
+    });
+  }, [highlightLocale, targetLocales]);
+
+  const queryKey = projectFileCatQueryKey(organizationSlug, projectId, sourcePath, targetLocale);
+  const catQuery = useQuery({
+    queryKey,
+    enabled: Boolean(targetLocale),
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"].projects[
+        ":projectId"
+      ].files.detail.cat.$get({
+        param: { organizationSlug, projectId },
+        query: { sourcePath, targetLocale },
+      });
+
+      if (!response.ok) {
+        throw new Error(await readApiError(response, "Failed to load CAT workspace"));
+      }
+
+      const body = (await response.json()) as ProjectFileCatResponse;
+      return body.catFile;
+    },
+  });
+
+  const saveMutation = useMutation({
+    mutationFn: async (input: { externalStringId: string; text: string }) => {
+      const response = await apiClient.api.orgs[":organizationSlug"].projects[
+        ":projectId"
+      ].files.detail.cat.translations.$post({
+        param: { organizationSlug, projectId },
+        json: {
+          sourcePath,
+          targetLocale,
+          externalStringId: input.externalStringId,
+          text: input.text,
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(await readApiError(response, "Failed to save translation"));
+      }
+
+      const body = (await response.json()) as { translation: ProjectFileCatTranslation };
+      return { externalStringId: input.externalStringId, translation: body.translation };
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey });
+    },
+  });
+
+  if (targetLocales.length === 0) {
+    return (
+      <TypographyP className="text-sm text-muted-foreground">
+        No target locales are available for this provider file.
+      </TypographyP>
+    );
+  }
+
+  return (
+    <ProjectFileCatWorkspaceView
+      catFile={catQuery.data ?? null}
+      targetLocales={targetLocales}
+      targetLocale={targetLocale}
+      onTargetLocaleChange={setTargetLocale}
+      isLoading={catQuery.isLoading}
+      error={catQuery.isError ? catQuery.error : undefined}
+      onSave={async (externalStringId, text) => {
+        const result = await saveMutation.mutateAsync({ externalStringId, text });
+        return result.translation;
+      }}
+    />
+  );
+}
+
+export function ProjectFileCatWorkspaceView({
+  catFile,
+  targetLocales,
+  targetLocale,
+  onTargetLocaleChange,
+  isLoading,
+  error,
+  onSave,
+}: {
+  catFile: CatFile | null;
+  targetLocales: string[];
+  targetLocale: string;
+  onTargetLocaleChange: (locale: string) => void;
+  isLoading: boolean;
+  error?: unknown;
+  onSave?: (externalStringId: string, text: string) => Promise<ProjectFileCatTranslation>;
+}) {
+  const [drafts, setDrafts] = useState<Record<string, string>>(() => draftValuesFor(catFile));
+  const [saveStates, setSaveStates] = useState<Record<string, SaveState>>(() =>
+    saveStatesFor(catFile),
+  );
+  const [rowErrors, setRowErrors] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    setDrafts(draftValuesFor(catFile));
+    setSaveStates(saveStatesFor(catFile));
+    setRowErrors({});
+  }, [catFile]);
+
+  const segments = catFile?.segments ?? [];
+  const counts = useMemo(() => {
+    const translated = segments.filter((segment) => segment.target?.text.trim()).length;
+    const approved = segments.filter((segment) => segment.target?.isApproved).length;
+    const withComments = segments.filter((segment) => segment.comments.length > 0).length;
+    return { translated, approved, withComments };
+  }, [segments]);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge variant="outline" className="rounded-full text-[10px]">
+            CAT
+          </Badge>
+          {catFile ? (
+            <>
+              <TypographyP className="text-xs text-muted-foreground">
+                {segments.length} segment{segments.length === 1 ? "" : "s"}
+                {catFile.truncated ? " (truncated)" : ""}
+              </TypographyP>
+              <TypographyP className="text-xs text-muted-foreground">
+                {counts.translated} translated · {counts.approved} approved · {counts.withComments}{" "}
+                with comments
+              </TypographyP>
+            </>
+          ) : null}
+        </div>
+        <div className="flex w-full flex-col gap-1.5 sm:max-w-44">
+          <TypographyP className="text-[10px] font-medium tracking-wide text-muted-foreground uppercase">
+            Target locale
+          </TypographyP>
+          <Select
+            value={targetLocale}
+            onValueChange={(value) => {
+              if (value) {
+                onTargetLocaleChange(value);
+              }
+            }}
+          >
+            <SelectTrigger className="h-9 w-full font-mono text-xs">
+              <SelectValue placeholder="Select locale" />
+            </SelectTrigger>
+            <SelectContent>
+              {targetLocales.map((locale) => (
+                <SelectItem key={locale} value={locale}>
+                  {locale}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {isLoading ? (
+        <div className="flex min-h-40 items-center justify-center gap-2 rounded-md border border-border bg-background px-4 py-8">
+          <Spinner />
+          <TypographyP className="text-sm text-muted-foreground">
+            Loading CAT workspace…
+          </TypographyP>
+        </div>
+      ) : error ? (
+        <div className="flex min-h-40 items-center gap-2 rounded-md border border-border bg-background px-4 py-8 text-flame-100">
+          <AlertCircleIcon className="size-4" />
+          <TypographyP className="text-sm">
+            {error instanceof Error ? error.message : "Failed to load CAT workspace."}
+          </TypographyP>
+        </div>
+      ) : segments.length === 0 ? (
+        <TypographyP className="text-sm text-muted-foreground">
+          No source strings are available for this file.
+        </TypographyP>
+      ) : (
+        <div className="overflow-hidden rounded-md border border-border bg-background">
+          <div className="max-h-[min(38rem,62vh)] overflow-auto">
+            <table className="w-full min-w-[56rem] border-collapse text-left text-xs">
+              <thead className="sticky top-0 z-10 border-b border-border bg-background/95 backdrop-blur-sm">
+                <tr>
+                  <th className="w-52 px-3 py-2 font-medium text-muted-foreground">Key</th>
+                  <th className="px-3 py-2 font-medium text-muted-foreground">Source</th>
+                  <th className="px-3 py-2 font-medium text-muted-foreground">Target</th>
+                  <th className="w-36 px-3 py-2 font-medium text-muted-foreground">State</th>
+                  <th className="w-28 px-3 py-2 font-medium text-muted-foreground" />
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {segments.map((segment) => {
+                  const draft = drafts[segment.externalStringId] ?? "";
+                  const original = segment.target?.text ?? "";
+                  const state = saveStates[segment.externalStringId] ?? "unchanged";
+                  const dirty = draft !== original || state === "dirty";
+                  const saving = state === "saving";
+                  const disabled = !catFile?.canEditTranslations || saving || !onSave;
+
+                  return (
+                    <CatSegmentRow
+                      key={segment.externalStringId}
+                      segment={segment}
+                      draft={draft}
+                      saveState={dirty && state === "unchanged" ? "dirty" : state}
+                      rowError={rowErrors[segment.externalStringId]}
+                      disabled={disabled}
+                      onDraftChange={(text) => {
+                        setDrafts((current) => ({
+                          ...current,
+                          [segment.externalStringId]: text,
+                        }));
+                        setSaveStates((current) => ({
+                          ...current,
+                          [segment.externalStringId]: text === original ? "unchanged" : "dirty",
+                        }));
+                        setRowErrors((current) => {
+                          const next = { ...current };
+                          delete next[segment.externalStringId];
+                          return next;
+                        });
+                      }}
+                      onSave={async () => {
+                        if (!onSave || !catFile?.canEditTranslations || !dirty) {
+                          return;
+                        }
+
+                        setSaveStates((current) => ({
+                          ...current,
+                          [segment.externalStringId]: "saving",
+                        }));
+                        try {
+                          await onSave(segment.externalStringId, draft);
+                          setSaveStates((current) => ({
+                            ...current,
+                            [segment.externalStringId]: "saved",
+                          }));
+                        } catch (saveError) {
+                          setSaveStates((current) => ({
+                            ...current,
+                            [segment.externalStringId]: "failed",
+                          }));
+                          setRowErrors((current) => ({
+                            ...current,
+                            [segment.externalStringId]:
+                              saveError instanceof Error
+                                ? saveError.message
+                                : "Failed to save translation.",
+                          }));
+                        }
+                      }}
+                    />
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {catFile && !catFile.canEditTranslations ? (
+        <TypographyP className="text-xs text-muted-foreground">
+          You can view this CAT workspace, but your role cannot write translations back.
+        </TypographyP>
+      ) : null}
+    </div>
+  );
+}
+
+function CatSegmentRow({
+  segment,
+  draft,
+  saveState,
+  rowError,
+  disabled,
+  onDraftChange,
+  onSave,
+}: {
+  segment: ProjectFileCatSegment;
+  draft: string;
+  saveState: SaveState;
+  rowError?: string;
+  disabled: boolean;
+  onDraftChange: (text: string) => void;
+  onSave: () => Promise<void>;
+}) {
+  return (
+    <tr className="align-top">
+      <td className="px-3 py-3">
+        <div className="space-y-2">
+          <TypographyP className="font-mono text-xs text-foreground">{segment.key}</TypographyP>
+          {segment.context?.trim() ? (
+            <TypographyP className="text-xs text-muted-foreground">{segment.context}</TypographyP>
+          ) : null}
+          {segment.comments.length > 0 ? (
+            <div className="space-y-1">
+              {segment.comments.slice(0, 2).map((comment) => (
+                <div
+                  key={comment.externalCommentId}
+                  className={cn(
+                    "rounded border px-2 py-1 text-[11px]",
+                    comment.type === "issue"
+                      ? "border-flame-100/25 bg-flame-100/5 text-flame-100"
+                      : "border-border bg-muted text-muted-foreground",
+                  )}
+                >
+                  <span className="font-medium">
+                    {comment.type === "issue" ? "Issue" : "Comment"}
+                  </span>
+                  <span className="text-muted-foreground">
+                    {" "}
+                    · {DATE_FORMATTER.format(new Date(comment.createdAt))}
+                  </span>
+                  <div className="mt-1 whitespace-pre-wrap">{comment.text}</div>
+                </div>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      </td>
+      <td className="max-w-[18rem] px-3 py-3 whitespace-pre-wrap text-foreground/78">
+        {segment.sourceText}
+      </td>
+      <td className="px-3 py-3">
+        <Textarea
+          value={draft}
+          onChange={(event) => onDraftChange(event.target.value)}
+          disabled={disabled}
+          className="min-h-24 rounded-md font-mono text-xs"
+          placeholder="Add translation"
+        />
+        {rowError ? (
+          <TypographyP className="mt-1 text-xs text-flame-100">{rowError}</TypographyP>
+        ) : null}
+      </td>
+      <td className="px-3 py-3">
+        <div className="flex flex-col gap-1.5">
+          <Badge variant="outline" className="w-fit rounded-full text-[10px]">
+            {segment.target?.isApproved ? "Approved" : segment.target?.text ? "Translated" : "Open"}
+          </Badge>
+          <SaveStateBadge state={saveState} />
+        </div>
+      </td>
+      <td className="px-3 py-3">
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          disabled={disabled || saveState === "unchanged" || saveState === "saved"}
+          onClick={() => void onSave()}
+        >
+          {saveState === "saving" ? (
+            <Spinner className="size-3" />
+          ) : saveState === "saved" ? (
+            <CheckIcon className="size-3" />
+          ) : (
+            <SaveIcon className="size-3" />
+          )}
+          Save
+        </Button>
+      </td>
+    </tr>
+  );
+}
+
+function SaveStateBadge({ state }: { state: SaveState }) {
+  if (state === "unchanged") {
+    return <span className="text-xs text-muted-foreground">Unchanged</span>;
+  }
+
+  if (state === "dirty") {
+    return <span className="text-xs text-foreground">Unsaved</span>;
+  }
+
+  if (state === "saving") {
+    return <span className="text-xs text-muted-foreground">Saving…</span>;
+  }
+
+  if (state === "saved") {
+    return <span className="text-xs text-emerald-600">Saved</span>;
+  }
+
+  return <span className="text-xs text-flame-100">Failed</span>;
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-workspace.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { AlertCircleIcon, CheckIcon, SaveIcon } from "lucide-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
@@ -156,6 +156,7 @@ export function ProjectFileCatWorkspace({
           sourcePath,
           targetLocale,
           externalStringId: input.externalStringId,
+          externalResourceId: catQuery.data?.provider?.externalResourceId,
           text: input.text,
         },
       });
@@ -218,9 +219,14 @@ export function ProjectFileCatWorkspaceView({
     saveStatesFor(catFile),
   );
   const [rowErrors, setRowErrors] = useState<Record<string, string>>({});
+  const rowStateRef = useRef({ drafts, saveStates, rowErrors });
 
   useEffect(() => {
-    const merged = mergeCatWorkspaceRows(catFile, { drafts, saveStates, rowErrors });
+    rowStateRef.current = { drafts, saveStates, rowErrors };
+  }, [drafts, saveStates, rowErrors]);
+
+  useEffect(() => {
+    const merged = mergeCatWorkspaceRows(catFile, rowStateRef.current);
     setDrafts(merged.drafts);
     setSaveStates(merged.saveStates);
     setRowErrors(merged.rowErrors);

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/job-source-files-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/job-source-files-panel.tsx
@@ -62,9 +62,9 @@ export function JobSourceFilesPanel({
     sortedFiles.find((file) => file.sourcePath === selectedSourcePath) ?? sortedFiles[0] ?? null;
   const activeSourcePath = selectedFile?.sourcePath ?? null;
   const targetLocale =
-    highlightLocale && selectedFile?.provider?.targetLocales.includes(highlightLocale)
+    highlightLocale && selectedFile?.provider?.targetLocales?.includes(highlightLocale)
       ? highlightLocale
-      : (selectedFile?.provider?.targetLocales[0] ?? highlightLocale);
+      : (selectedFile?.provider?.targetLocales?.[0] ?? highlightLocale);
   const canViewStrings = Boolean(
     encodedJobId && selectedFile?.provider && activeSourcePath && targetLocale,
   );

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/job-source-files-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/job-source-files-panel.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import Link from "next/link";
+import { ListIcon } from "lucide-react";
 
 import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
+import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { TypographyH4 } from "@/components/ui/typography";
+import { TypographyH4, TypographyP } from "@/components/ui/typography";
 
 import { ProjectFilesTree } from "../../../../files/_components/project-files-tree";
 import { ProjectFileDetailPanel } from "../../../../files/_components/project-file-detail-panel";
@@ -13,6 +16,21 @@ function sortFilesByPath(files: ProjectFileRecord[]) {
   return [...files].toSorted((a, b) =>
     a.sourcePath.localeCompare(b.sourcePath, undefined, { sensitivity: "base" }),
   );
+}
+
+function stringsHref(input: {
+  organizationSlug: string;
+  projectId: string;
+  encodedJobId: string;
+  sourcePath: string;
+  targetLocale: string;
+}) {
+  const params = new URLSearchParams({
+    sourcePath: input.sourcePath,
+    targetLocale: input.targetLocale,
+  });
+
+  return `/org/${input.organizationSlug}/projects/${encodeURIComponent(input.projectId)}/jobs/${encodeURIComponent(input.encodedJobId)}/strings?${params.toString()}`;
 }
 
 export function JobSourceFilesPanel({
@@ -43,6 +61,13 @@ export function JobSourceFilesPanel({
   const selectedFile =
     sortedFiles.find((file) => file.sourcePath === selectedSourcePath) ?? sortedFiles[0] ?? null;
   const activeSourcePath = selectedFile?.sourcePath ?? null;
+  const targetLocale =
+    highlightLocale && selectedFile?.provider?.targetLocales.includes(highlightLocale)
+      ? highlightLocale
+      : (selectedFile?.provider?.targetLocales[0] ?? highlightLocale);
+  const canViewStrings = Boolean(
+    encodedJobId && selectedFile?.provider && activeSourcePath && targetLocale,
+  );
 
   return (
     <section className="rounded-lg border border-border bg-card p-5">
@@ -76,6 +101,41 @@ export function JobSourceFilesPanel({
             />
           </aside>
           <div className="min-h-[min(20rem,50vh)] overflow-y-auto">
+            {selectedFile?.provider ? (
+              <div className="flex flex-col gap-2 border-b border-border px-5 py-3 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <TypographyP className="font-mono text-xs text-foreground">
+                    {selectedFile.sourcePath}
+                  </TypographyP>
+                  <TypographyP className="text-xs text-muted-foreground">
+                    {targetLocale
+                      ? `Edit ${targetLocale} strings in the CAT workspace.`
+                      : "No target locale is available for this task file."}
+                  </TypographyP>
+                </div>
+                <Button
+                  type="button"
+                  size="sm"
+                  disabled={!canViewStrings}
+                  render={
+                    canViewStrings ? (
+                      <Link
+                        href={stringsHref({
+                          organizationSlug,
+                          projectId,
+                          encodedJobId: encodedJobId as string,
+                          sourcePath: activeSourcePath as string,
+                          targetLocale: targetLocale as string,
+                        })}
+                      />
+                    ) : undefined
+                  }
+                >
+                  <ListIcon />
+                  View strings
+                </Button>
+              </div>
+            ) : null}
             <ProjectFileDetailPanel
               organizationSlug={organizationSlug}
               projectId={projectId}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import Link from "next/link";
+import { TranslationIcon } from "@hugeicons/core-free-icons";
+import { ArrowLeftIcon } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import { TypographyP } from "@/components/ui/typography";
+import { apiClient } from "@/lib/api-client-instance";
+import type { TmsProviderLiveFile } from "@/lib/providers/tms-provider-live";
+
+import { ProjectPageShell, ProjectSectionHeader } from "../../../../_components/project-page-shell";
+import { ProjectFileCatWorkspace } from "../../../../files/_components/project-file-cat-workspace";
+import { tmsLiveFileToProjectFileRecord } from "../../_components/tms/job-source-file-mappers";
+
+function tmsLiveJobFilesQueryKey(organizationSlug: string, encodedJobId: string) {
+  return ["tms-provider-job-files", organizationSlug, encodedJobId] as const;
+}
+
+export function JobCatPageContent({
+  organizationSlug,
+  projectId,
+  jobId,
+  sourcePath,
+  targetLocale,
+}: {
+  organizationSlug: string;
+  projectId: string;
+  jobId: string;
+  sourcePath: string | null;
+  targetLocale: string | null;
+}) {
+  const taskHref = `/org/${organizationSlug}/projects/${encodeURIComponent(projectId)}/jobs/${encodeURIComponent(jobId)}`;
+  const filesQuery = useQuery({
+    queryKey: tmsLiveJobFilesQueryKey(organizationSlug, jobId),
+    enabled: Boolean(sourcePath),
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"]["tms-provider"].jobs[
+        ":encodedJobId"
+      ].files.$get({
+        param: { organizationSlug, encodedJobId: jobId },
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to load task files (${response.status})`);
+      }
+
+      const body = (await response.json()) as { files: TmsProviderLiveFile[] };
+      return body.files.map(tmsLiveFileToProjectFileRecord);
+    },
+  });
+
+  const selectedFile = sourcePath
+    ? (filesQuery.data ?? []).find((file) => file.sourcePath === sourcePath)
+    : null;
+  const targetLocales =
+    selectedFile?.provider?.targetLocales ?? (targetLocale ? [targetLocale] : []);
+
+  return (
+    <ProjectPageShell>
+      <ProjectSectionHeader
+        icon={TranslationIcon}
+        section="Strings"
+        description="Edit task source strings and write translations back to the provider."
+        actions={
+          <Button variant="outline" size="sm" render={<Link href={taskHref} />}>
+            <ArrowLeftIcon />
+            Task
+          </Button>
+        }
+      />
+
+      {!sourcePath ? (
+        <div className="rounded-lg border border-border bg-card p-5">
+          <TypographyP className="text-sm text-muted-foreground">
+            Choose a source file from the task, then open View strings.
+          </TypographyP>
+        </div>
+      ) : filesQuery.isLoading ? (
+        <div className="flex min-h-48 items-center justify-center gap-2 rounded-lg border border-border bg-card p-5">
+          <Spinner />
+          <TypographyP className="text-sm text-muted-foreground">Loading task file…</TypographyP>
+        </div>
+      ) : filesQuery.isError ? (
+        <div className="rounded-lg border border-border bg-card p-5">
+          <TypographyP className="text-sm text-flame-100">
+            {filesQuery.error instanceof Error
+              ? filesQuery.error.message
+              : "Unable to load task files."}
+          </TypographyP>
+        </div>
+      ) : !selectedFile ? (
+        <div className="rounded-lg border border-border bg-card p-5">
+          <TypographyP className="font-mono text-sm text-foreground">{sourcePath}</TypographyP>
+          <TypographyP className="mt-2 text-sm text-muted-foreground">
+            This source file is not linked to the task anymore.
+          </TypographyP>
+        </div>
+      ) : !selectedFile.provider ? (
+        <div className="rounded-lg border border-border bg-card p-5">
+          <TypographyP className="text-sm text-muted-foreground">
+            String editing is only available for provider task files.
+          </TypographyP>
+        </div>
+      ) : (
+        <section className="rounded-lg border border-border bg-card p-5">
+          <div className="mb-4 space-y-1">
+            <TypographyP className="font-mono text-sm font-medium text-foreground">
+              {selectedFile.sourcePath}
+            </TypographyP>
+            <TypographyP className="text-xs text-muted-foreground">
+              {selectedFile.provider.kind} · {selectedFile.provider.format ?? "file"}
+            </TypographyP>
+          </div>
+          <ProjectFileCatWorkspace
+            organizationSlug={organizationSlug}
+            projectId={projectId}
+            sourcePath={selectedFile.sourcePath}
+            targetLocales={targetLocales}
+            highlightLocale={targetLocale}
+          />
+        </section>
+      )}
+    </ProjectPageShell>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/page.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/page.tsx
@@ -1,0 +1,25 @@
+import { requireAppAuthContext } from "@/lib/workos/app-auth";
+
+import { JobCatPageContent } from "./_components/job-cat-page-content";
+
+export default async function ProjectJobStringsPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ organizationSlug: string; projectId: string; jobId: string }>;
+  searchParams: Promise<{ sourcePath?: string; targetLocale?: string }>;
+}) {
+  const { organizationSlug, projectId, jobId } = await params;
+  const { sourcePath, targetLocale } = await searchParams;
+  await requireAppAuthContext({ organizationSlug });
+
+  return (
+    <JobCatPageContent
+      organizationSlug={organizationSlug}
+      projectId={projectId}
+      jobId={jobId}
+      sourcePath={sourcePath ?? null}
+      targetLocale={targetLocale ?? null}
+    />
+  );
+}

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
@@ -668,6 +668,19 @@ describe("CrowdinApiClient", () => {
     expect(updated).toMatchObject({ id: 9001, text: "Salut" });
   });
 
+  it("fails translation updates when Crowdin returns no updated item", async () => {
+    const fetchMock = vi.fn(
+      async () => new Response(JSON.stringify({ data: [] }), { status: 200 }),
+    );
+    const client = createClient(fetchMock as unknown as typeof fetch);
+
+    await expect(client.updateTranslation(1, 9001, "Salut")).rejects.toMatchObject({
+      name: "CrowdinApiError",
+      status: 502,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("lists glossaries and translation memories with pagination", async () => {
     const fetchMock = vi.fn(async (url) => {
       const path = String(url);

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
@@ -607,6 +607,67 @@ describe("CrowdinApiClient", () => {
     expect(upload.fileId).toBe(101);
   });
 
+  it("adds and updates string translations", async () => {
+    const fetchMock = vi.fn(async (url, init) => {
+      const path = String(url);
+
+      if (path.endsWith("/projects/1/translations") && init?.method === "POST") {
+        expect(JSON.parse(String(init.body))).toEqual({
+          stringId: 1001,
+          languageId: "fr",
+          text: "Bonjour",
+        });
+        return new Response(
+          JSON.stringify({
+            data: {
+              id: 9001,
+              stringId: 1001,
+              languageId: "fr",
+              text: "Bonjour",
+              createdAt: "2026-06-08T00:00:00Z",
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.endsWith("/projects/1/translations") && init?.method === "PATCH") {
+        expect(JSON.parse(String(init.body))).toEqual([
+          { op: "replace", path: "/9001/text", value: "Salut" },
+        ]);
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  id: 9001,
+                  stringId: 1001,
+                  languageId: "fr",
+                  text: "Salut",
+                  createdAt: "2026-06-08T00:01:00Z",
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    const added = await client.addTranslation(1, {
+      stringId: 1001,
+      languageId: "fr",
+      text: "Bonjour",
+    });
+    const updated = await client.updateTranslation(1, 9001, "Salut");
+
+    expect(added).toMatchObject({ id: 9001, text: "Bonjour" });
+    expect(updated).toMatchObject({ id: 9001, text: "Salut" });
+  });
+
   it("lists glossaries and translation memories with pagination", async () => {
     const fetchMock = vi.fn(async (url) => {
       const path = String(url);

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
@@ -139,6 +139,8 @@ export interface CrowdinStringTranslation {
   id: number;
   text: string;
   createdAt: string;
+  stringId?: number;
+  languageId?: string;
 }
 
 export interface CrowdinTranslationApproval {
@@ -819,6 +821,43 @@ export class CrowdinApiClient {
     }
 
     return translations;
+  }
+
+  async addTranslation(
+    projectId: number,
+    request: {
+      stringId: number;
+      languageId: string;
+      text: string;
+    },
+  ): Promise<CrowdinStringTranslation> {
+    const response = await this.post<CrowdinGetResponse<CrowdinStringTranslation>>(
+      `/projects/${projectId}/translations`,
+      request,
+    );
+    return response.data;
+  }
+
+  async updateTranslation(
+    projectId: number,
+    translationId: number,
+    text: string,
+  ): Promise<CrowdinStringTranslation> {
+    const response = await this.patch<CrowdinListResponse<CrowdinStringTranslation>>(
+      `/projects/${projectId}/translations`,
+      [{ op: "replace", path: `/${translationId}/text`, value: text }],
+    );
+    return response.data[0]?.data ?? (await this.getTranslation(projectId, translationId));
+  }
+
+  async getTranslation(
+    projectId: number,
+    translationId: number,
+  ): Promise<CrowdinStringTranslation> {
+    const response = await this.get<CrowdinGetResponse<CrowdinStringTranslation>>(
+      `/projects/${projectId}/translations/${translationId}`,
+    );
+    return response.data;
   }
 
   /**

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
@@ -851,7 +851,12 @@ export class CrowdinApiClient {
       `/projects/${projectId}/translations`,
       [{ op: "replace", path: `/${translationId}/text`, value: text }],
     );
-    return response.data[0]?.data ?? (await this.getTranslation(projectId, translationId));
+    const updatedTranslation = response.data[0]?.data;
+    if (!updatedTranslation) {
+      throw new CrowdinApiError("Crowdin translation update returned no data", 502, response);
+    }
+
+    return updatedTranslation;
   }
 
   async getTranslation(
@@ -870,6 +875,7 @@ export class CrowdinApiClient {
   async listTranslationApprovals(
     projectId: number,
     languageId?: string,
+    options?: { stringIds?: number[] },
   ): Promise<CrowdinTranslationApproval[]> {
     const approvals: CrowdinTranslationApproval[] = [];
     let offset = 0;
@@ -879,6 +885,9 @@ export class CrowdinApiClient {
       const params = new URLSearchParams({ limit: String(limit), offset: String(offset) });
       if (languageId) {
         params.append("languageId", languageId);
+      }
+      if (options?.stringIds?.length) {
+        params.append("stringIds", options.stringIds.join(","));
       }
 
       const response = await this.get<CrowdinListResponse<CrowdinTranslationApproval>>(

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
@@ -668,6 +668,7 @@ export class CrowdinApiClient {
     projectId: number,
     options?: {
       stringId?: number;
+      languageId?: string;
       type?: "comment" | "issue";
       issueStatus?: "resolved" | "unresolved";
     },
@@ -678,6 +679,9 @@ export class CrowdinApiClient {
     }
     if (options?.type) {
       params.set("type", options.type);
+    }
+    if (options?.languageId) {
+      params.set("languageId", options.languageId);
     }
     if (options?.issueStatus) {
       params.set("issueStatus", options.issueStatus);

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live-cat.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live-cat.test.ts
@@ -178,7 +178,11 @@ describe("getTmsProviderLiveCatFile", () => {
         );
       }
 
-      if (path.includes("/projects/42/approvals?") && path.includes("languageId=fr")) {
+      if (
+        path.includes("/projects/42/approvals?") &&
+        path.includes("languageId=fr") &&
+        path.includes("stringIds=1001%2C1002")
+      ) {
         return new Response(
           JSON.stringify({
             data: [{ data: { id: 1, translationId: 9001, stringId: 1001, languageId: "fr" } }],
@@ -272,6 +276,12 @@ describe("getTmsProviderLiveCatFile", () => {
           path.includes("/projects/42/comments?") &&
           path.includes("type=comment") &&
           path.includes("languageId=fr"),
+      ),
+    ).toBe(true);
+    expect(
+      requestedPaths.some(
+        (path) =>
+          path.includes("/projects/42/approvals?") && path.includes("stringIds=1001%2C1002"),
       ),
     ).toBe(true);
     expect(

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live-cat.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live-cat.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import { createAuthTestFixture } from "@/api/test-auth.fixture";
 import { db } from "@/lib/database";
 import { upsertOrganizationExternalTmsProviderCredential } from "./organization-external-tms-provider-credentials";
-import { getTmsProviderLiveCatFile } from "./tms-provider-live";
+import { getTmsProviderLiveCatFile, saveTmsProviderLiveCatTranslation } from "./tms-provider-live";
 
 const fixture = createAuthTestFixture();
 
@@ -265,5 +265,141 @@ describe("getTmsProviderLiveCatFile", () => {
       target: null,
       comments: [{ externalCommentId: "502", type: "issue", status: "unresolved" }],
     });
+    const requestedPaths = fetchMock.mock.calls.map(([url]) => String(url));
+    expect(
+      requestedPaths.some(
+        (path) =>
+          path.includes("/projects/42/comments?") &&
+          path.includes("type=comment") &&
+          path.includes("languageId=fr"),
+      ),
+    ).toBe(true);
+    expect(
+      requestedPaths.some(
+        (path) =>
+          path.includes("/projects/42/comments?") &&
+          path.includes("type=issue") &&
+          path.includes("languageId=fr") &&
+          path.includes("issueStatus=unresolved"),
+      ),
+    ).toBe(true);
+  });
+
+  it("saves a Crowdin CAT translation without listing project approvals", async () => {
+    const { organization, user } = await fixture.createLocalWorkosIdentity(
+      fixture.createWorkosIdentityWithRole("admin"),
+    );
+    await upsertOrganizationExternalTmsProviderCredential({
+      organizationId: organization.id,
+      userId: user.id,
+      role: "admin",
+      providerKind: "crowdin",
+      displayName: "Crowdin",
+      secretMaterial: "token",
+      baseUrl: "https://api.crowdin.test/api/v2",
+    });
+
+    const fetchMock = vi.fn(async (url, init) => {
+      const path = String(url);
+
+      if (path.includes("/projects?")) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  id: 42,
+                  name: "Website",
+                  identifier: "website",
+                  sourceLanguageId: "en",
+                  targetLanguageIds: ["fr"],
+                  webUrl: "https://crowdin.test/project/website",
+                  isSuspended: false,
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/projects/42/branches?")) {
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }
+
+      if (path.includes("/projects/42/directories?")) {
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }
+
+      if (path.includes("/projects/42/files?")) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  id: 101,
+                  branchId: null,
+                  directoryId: null,
+                  name: "home.json",
+                  title: "home.json",
+                  type: "json",
+                  path: "/home.json",
+                  status: "active",
+                  revisionId: 7,
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/projects/42/files/101/revisions?")) {
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }
+
+      if (
+        path.includes("/projects/42/languages/fr/translations?") &&
+        path.includes("stringIds=1001")
+      ) {
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }
+
+      if (path.includes("/projects/42/translations") && init?.method === "POST") {
+        return new Response(
+          JSON.stringify({
+            data: {
+              id: 9001,
+              stringId: 1001,
+              languageId: "fr",
+              text: "Bonjour",
+              createdAt: "2026-06-08T00:00:00Z",
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const translation = await saveTmsProviderLiveCatTranslation(
+      organization.id,
+      "42",
+      "home.json",
+      {
+        targetLocale: "fr",
+        externalStringId: "1001",
+        text: "Bonjour",
+      },
+    );
+
+    expect(translation).toEqual({
+      text: "Bonjour",
+      externalTranslationId: "9001",
+      isApproved: false,
+    });
+    expect(fetchMock.mock.calls.some(([url]) => String(url).includes("/approvals?"))).toBe(false);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live-cat.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live-cat.test.ts
@@ -1,0 +1,269 @@
+import "dotenv/config";
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { createAuthTestFixture } from "@/api/test-auth.fixture";
+import { db } from "@/lib/database";
+import { upsertOrganizationExternalTmsProviderCredential } from "./organization-external-tms-provider-credentials";
+import { getTmsProviderLiveCatFile } from "./tms-provider-live";
+
+const fixture = createAuthTestFixture();
+
+describe("getTmsProviderLiveCatFile", () => {
+  let originalFetch: typeof fetch;
+
+  beforeAll(async () => {
+    await db.$client.query("select 1");
+  });
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = originalFetch;
+    vi.clearAllMocks();
+    await fixture.cleanup();
+  });
+
+  it("aggregates Crowdin strings, target translations, approvals, and unresolved comments", async () => {
+    const { organization, user } = await fixture.createLocalWorkosIdentity(
+      fixture.createWorkosIdentityWithRole("admin"),
+    );
+    await upsertOrganizationExternalTmsProviderCredential({
+      organizationId: organization.id,
+      userId: user.id,
+      role: "admin",
+      providerKind: "crowdin",
+      displayName: "Crowdin",
+      secretMaterial: "token",
+      baseUrl: "https://api.crowdin.test/api/v2",
+    });
+
+    const fetchMock = vi.fn(async (url, init) => {
+      const path = String(url);
+
+      if (path.includes("/projects?")) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  id: 42,
+                  name: "Website",
+                  identifier: "website",
+                  sourceLanguageId: "en",
+                  targetLanguageIds: ["fr"],
+                  webUrl: "https://crowdin.test/project/website",
+                  isSuspended: false,
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/projects/42/branches?")) {
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }
+
+      if (path.includes("/projects/42/directories?")) {
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }
+
+      if (path.includes("/projects/42/files?")) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  id: 101,
+                  branchId: null,
+                  directoryId: null,
+                  name: "home.json",
+                  title: "home.json",
+                  type: "json",
+                  path: "/home.json",
+                  status: "active",
+                  revisionId: 7,
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/projects/42/files/101/revisions?")) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  id: 7,
+                  fileId: 101,
+                  projectId: 42,
+                  info: {
+                    sourceLanguageId: "en",
+                    addedStrings: 2,
+                    removedStrings: 0,
+                    updatedStrings: 0,
+                  },
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/projects/42/strings?") && path.includes("fileId=101")) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  id: 1001,
+                  projectId: 42,
+                  fileId: 101,
+                  branchId: null,
+                  directoryId: null,
+                  identifier: "hero.title",
+                  text: "Hello",
+                  type: "text",
+                  context: "Hero",
+                  labelIds: null,
+                },
+              },
+              {
+                data: {
+                  id: 1002,
+                  projectId: 42,
+                  fileId: 101,
+                  branchId: null,
+                  directoryId: null,
+                  identifier: "hero.cta",
+                  text: { one: "Start", other: "Start all" },
+                  type: "text",
+                  context: null,
+                  labelIds: null,
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (
+        path.includes("/projects/42/languages/fr/translations?") &&
+        path.includes("stringIds=1001%2C1002")
+      ) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  stringId: 1001,
+                  contentType: "text",
+                  translationId: 9001,
+                  text: "Bonjour",
+                  createdAt: "2026-06-08T00:00:00Z",
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/projects/42/approvals?") && path.includes("languageId=fr")) {
+        return new Response(
+          JSON.stringify({
+            data: [{ data: { id: 1, translationId: 9001, stringId: 1001, languageId: "fr" } }],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (
+        path.includes("/projects/42/comments?") &&
+        path.includes("type=comment") &&
+        init?.method !== "POST"
+      ) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  id: 501,
+                  text: "Check product wording",
+                  userId: 1,
+                  stringId: 1001,
+                  languageId: "fr",
+                  type: "comment",
+                  createdAt: "2026-06-08T00:01:00Z",
+                  projectId: 42,
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/projects/42/comments?") && path.includes("type=issue")) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  id: 502,
+                  text: "Missing CTA translation",
+                  userId: 1,
+                  stringId: 1002,
+                  languageId: "fr",
+                  type: "issue",
+                  issueStatus: "unresolved",
+                  createdAt: "2026-06-08T00:02:00Z",
+                  projectId: 42,
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const catFile = await getTmsProviderLiveCatFile(organization.id, "42", "home.json", "fr", {
+      canEditTranslations: true,
+    });
+
+    expect(catFile).toMatchObject({
+      sourcePath: "home.json",
+      targetLocale: "fr",
+      canEditTranslations: true,
+      truncated: false,
+    });
+    expect(catFile?.provider?.targetLocales).toEqual(["fr"]);
+    expect(catFile?.segments).toHaveLength(2);
+    expect(catFile?.segments[0]).toMatchObject({
+      externalStringId: "1001",
+      key: "hero.title",
+      sourceText: "Hello",
+      target: { text: "Bonjour", externalTranslationId: "9001", isApproved: true },
+      comments: [{ externalCommentId: "501", type: "comment" }],
+    });
+    expect(catFile?.segments[1]).toMatchObject({
+      externalStringId: "1002",
+      sourceText: JSON.stringify({ one: "Start", other: "Start all" }),
+      target: null,
+      comments: [{ externalCommentId: "502", type: "issue", status: "unresolved" }],
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live-error-response.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live-error-response.ts
@@ -26,10 +26,13 @@ export function getTmsProviderLiveErrorStatus(code: string): TmsProviderLiveErro
     case "lokalise_user_connection_required":
       return 401;
     case "invalid_encoded_job_id":
+    case "invalid_crowdin_project_or_file_id":
+    case "invalid_crowdin_project_or_string_id":
       return 400;
     case "provider_fetcher_unavailable":
     case "provider_description_edit_unsupported":
     case "provider_comments_read_unsupported":
+    case "provider_cat_unsupported":
       return 501;
     default:
       return 500;

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
@@ -16,6 +16,7 @@ import {
   type CrowdinLanguageTranslation,
   type CrowdinSourceString,
   type CrowdinStringComment,
+  type CrowdinTranslationApproval,
 } from "@/lib/providers/adapters/crowdin/crowdin-api";
 import { mapCrowdinTaskToJobTaskMetadata } from "@/lib/providers/adapters/crowdin/crowdin-job-task-fetcher";
 import {
@@ -843,11 +844,17 @@ async function buildCrowdinLiveCatFile(input: {
     const sourceStringIdSet = new Set(sourceStringIds);
 
     const translationsByStringId = new Map<number, CrowdinLanguageTranslation[]>();
+    const approvals: CrowdinTranslationApproval[] = [];
     for (let index = 0; index < sourceStringIds.length; index += 25) {
       const chunk = sourceStringIds.slice(index, index + 25);
       const translations = await client.listLanguageTranslations(projectId, input.targetLocale, {
         stringIds: chunk,
       });
+      approvals.push(
+        ...(await client.listTranslationApprovals(projectId, input.targetLocale, {
+          stringIds: chunk,
+        })),
+      );
 
       for (const translation of translations) {
         const existing = translationsByStringId.get(translation.stringId) ?? [];
@@ -856,7 +863,6 @@ async function buildCrowdinLiveCatFile(input: {
       }
     }
 
-    const approvals = await client.listTranslationApprovals(projectId, input.targetLocale);
     const approvedTranslationIds = new Set(approvals.map((approval) => approval.translationId));
 
     const [plainComments, unresolvedIssues] = await Promise.all([
@@ -1368,17 +1374,30 @@ export async function saveTmsProviderLiveCatTranslation(
     targetLocale: string;
     externalStringId: string;
     text: string;
+    externalResourceId?: string | null;
   },
   options?: { actorUserId?: string | null },
 ): Promise<ProjectFileCatTranslation | null> {
   const context = await loadActiveTmsProviderContext(organizationId, {
     actorUserId: options?.actorUserId,
   });
-  const files = await listTmsProviderLiveFilesForProject(organizationId, externalProjectId, {
-    context,
-    limit: 1000,
-  });
-  const file = files.find((item) => item.sourcePath === sourcePath);
+  const file =
+    input.externalResourceId && context.providerKind === "crowdin"
+      ? mapLiveFile({
+          providerKind: context.providerKind,
+          externalProjectId,
+          file: {
+            resourceType: "file",
+            externalResourceId: input.externalResourceId,
+            sourcePath,
+          },
+        })
+      : (
+          await listTmsProviderLiveFilesForProject(organizationId, externalProjectId, {
+            context,
+            limit: 1000,
+          })
+        ).find((item) => item.sourcePath === sourcePath);
   if (!file) {
     return null;
   }

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
@@ -847,14 +847,15 @@ async function buildCrowdinLiveCatFile(input: {
     const approvals: CrowdinTranslationApproval[] = [];
     for (let index = 0; index < sourceStringIds.length; index += 25) {
       const chunk = sourceStringIds.slice(index, index + 25);
-      const translations = await client.listLanguageTranslations(projectId, input.targetLocale, {
-        stringIds: chunk,
-      });
-      approvals.push(
-        ...(await client.listTranslationApprovals(projectId, input.targetLocale, {
+      const [translations, chunkApprovals] = await Promise.all([
+        client.listLanguageTranslations(projectId, input.targetLocale, {
           stringIds: chunk,
-        })),
-      );
+        }),
+        client.listTranslationApprovals(projectId, input.targetLocale, {
+          stringIds: chunk,
+        }),
+      ]);
+      approvals.push(...chunkApprovals);
 
       for (const translation of translations) {
         const existing = translationsByStringId.get(translation.stringId) ?? [];

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
@@ -860,8 +860,12 @@ async function buildCrowdinLiveCatFile(input: {
     const approvedTranslationIds = new Set(approvals.map((approval) => approval.translationId));
 
     const [plainComments, unresolvedIssues] = await Promise.all([
-      client.listStringComments(projectId, { type: "comment" }),
-      client.listStringComments(projectId, { type: "issue", issueStatus: "unresolved" }),
+      client.listStringComments(projectId, { type: "comment", languageId: input.targetLocale }),
+      client.listStringComments(projectId, {
+        type: "issue",
+        languageId: input.targetLocale,
+        issueStatus: "unresolved",
+      }),
     ]);
     const commentsByStringId = relevantCrowdinCatComments({
       comments: [...plainComments, ...unresolvedIssues],
@@ -951,15 +955,11 @@ async function saveCrowdinLiveCatTranslation(input: {
             text: input.text,
           });
     const translationId = saved.id ?? existing?.translationId ?? null;
-    const approvals = await client.listTranslationApprovals(projectId, input.targetLocale);
-    const isApproved =
-      translationId != null &&
-      approvals.some((approval) => approval.translationId === translationId);
 
     return {
       text: saved.text,
       externalTranslationId: translationId != null ? String(translationId) : null,
-      isApproved,
+      isApproved: false,
     };
   } catch (error) {
     if (error instanceof CrowdinApiError && error.status === 401) {

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
@@ -1,6 +1,8 @@
 import { createLogger } from "@/lib/log";
 import { schema } from "@/lib/database";
 import type {
+  ProjectFileCatResponse,
+  ProjectFileCatTranslation,
   ProjectFileContent,
   ProjectFileDetailResponse,
 } from "@/api/routes/project/project.schema";
@@ -11,7 +13,9 @@ import {
 import {
   CrowdinApiClient,
   CrowdinApiError,
+  type CrowdinLanguageTranslation,
   type CrowdinSourceString,
+  type CrowdinStringComment,
 } from "@/lib/providers/adapters/crowdin/crowdin-api";
 import { mapCrowdinTaskToJobTaskMetadata } from "@/lib/providers/adapters/crowdin/crowdin-job-task-fetcher";
 import {
@@ -198,6 +202,7 @@ export type TmsProviderLiveFile = {
 };
 
 export type TmsProviderLiveFileDetail = ProjectFileDetailResponse["file"];
+export type TmsProviderLiveCatFile = ProjectFileCatResponse["catFile"];
 
 export type TmsProviderLiveGlossary = {
   id: string;
@@ -669,6 +674,7 @@ function mapLiveFile(input: {
   providerKind: ExternalTmsProviderKind;
   externalProjectId: string;
   file: ExternalTmsFileKeyMetadata;
+  project?: ExternalTmsProjectMetadata;
 }): TmsProviderLiveFile {
   const timestamp = new Date().toISOString();
   const sourcePath = input.file.sourcePath;
@@ -692,8 +698,8 @@ function mapLiveFile(input: {
       externalResourceId: input.file.externalResourceId,
       externalUrl: input.file.externalUrl ?? null,
       syncState: input.file.syncState ?? "synced",
-      sourceLocale: input.file.sourceLocale ?? null,
-      targetLocales: input.file.targetLocales ?? [],
+      sourceLocale: input.file.sourceLocale ?? input.project?.sourceLocale ?? null,
+      targetLocales: input.file.targetLocales ?? input.project?.targetLocales ?? [],
       localeReadiness: input.file.localeReadiness ?? {},
       revision: input.file.revision ?? null,
       format: input.file.format ?? null,
@@ -705,6 +711,14 @@ function mapLiveFile(input: {
 
 function crowdinSourceTextValue(text: CrowdinSourceString["text"]) {
   return text;
+}
+
+function crowdinCatSourceTextValue(text: CrowdinSourceString["text"]): string {
+  if (typeof text === "string") {
+    return text;
+  }
+
+  return JSON.stringify(text);
 }
 
 function buildCrowdinSourceStringsPreviewContent(input: {
@@ -760,6 +774,200 @@ async function downloadCrowdinSourceStringPreview(input: {
     content: byteSize <= maxLiveProviderInlineTextBytes ? previewContent : null,
     contentType: "application/json",
   };
+}
+
+function latestLanguageTranslation(
+  translations: CrowdinLanguageTranslation[],
+): CrowdinLanguageTranslation | null {
+  return (
+    translations
+      .filter((translation) => translation.text != null)
+      .toSorted((a, b) => {
+        const aTime = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+        const bTime = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+        return bTime - aTime;
+      })[0] ?? null
+  );
+}
+
+function relevantCrowdinCatComments(input: {
+  comments: CrowdinStringComment[];
+  stringIds: Set<number>;
+  targetLocale: string;
+}): Map<number, CrowdinStringComment[]> {
+  const commentsByStringId = new Map<number, CrowdinStringComment[]>();
+
+  for (const comment of input.comments) {
+    if (!input.stringIds.has(comment.stringId)) {
+      continue;
+    }
+
+    if (comment.languageId && comment.languageId !== input.targetLocale) {
+      continue;
+    }
+
+    const comments = commentsByStringId.get(comment.stringId) ?? [];
+    comments.push(comment);
+    commentsByStringId.set(comment.stringId, comments);
+  }
+
+  return commentsByStringId;
+}
+
+async function buildCrowdinLiveCatFile(input: {
+  context: ActiveTmsProviderContext;
+  file: TmsProviderLiveFile;
+  targetLocale: string;
+  canEditTranslations: boolean;
+}): Promise<TmsProviderLiveCatFile> {
+  const projectId = Number(input.file.provider?.externalProjectId);
+  const fileId = Number(input.file.provider?.externalResourceId);
+  if (Number.isNaN(projectId) || Number.isNaN(fileId)) {
+    throw new TmsProviderLiveError(
+      "invalid_crowdin_project_or_file_id",
+      "Crowdin project or file identifier is invalid.",
+    );
+  }
+
+  const client = new CrowdinApiClient({
+    token: input.context.secretMaterial,
+    baseUrl: input.context.credential.baseUrl ?? undefined,
+  });
+
+  try {
+    const strings = await client.listSourceStrings(projectId, fileId, undefined, {
+      maxItems: maxLiveProviderStringPreviewItems + 1,
+    });
+    const visibleStrings = strings.slice(0, maxLiveProviderStringPreviewItems);
+    const sourceStringIds = visibleStrings.map((sourceString) => sourceString.id);
+    const sourceStringIdSet = new Set(sourceStringIds);
+
+    const translationsByStringId = new Map<number, CrowdinLanguageTranslation[]>();
+    for (let index = 0; index < sourceStringIds.length; index += 25) {
+      const chunk = sourceStringIds.slice(index, index + 25);
+      const translations = await client.listLanguageTranslations(projectId, input.targetLocale, {
+        stringIds: chunk,
+      });
+
+      for (const translation of translations) {
+        const existing = translationsByStringId.get(translation.stringId) ?? [];
+        existing.push(translation);
+        translationsByStringId.set(translation.stringId, existing);
+      }
+    }
+
+    const approvals = await client.listTranslationApprovals(projectId, input.targetLocale);
+    const approvedTranslationIds = new Set(approvals.map((approval) => approval.translationId));
+
+    const [plainComments, unresolvedIssues] = await Promise.all([
+      client.listStringComments(projectId, { type: "comment" }),
+      client.listStringComments(projectId, { type: "issue", issueStatus: "unresolved" }),
+    ]);
+    const commentsByStringId = relevantCrowdinCatComments({
+      comments: [...plainComments, ...unresolvedIssues],
+      stringIds: sourceStringIdSet,
+      targetLocale: input.targetLocale,
+    });
+
+    return {
+      sourcePath: input.file.sourcePath,
+      filename: input.file.filename,
+      provider: input.file.provider,
+      targetLocale: input.targetLocale,
+      canEditTranslations: input.canEditTranslations,
+      truncated: strings.length > maxLiveProviderStringPreviewItems,
+      segments: visibleStrings.map((sourceString) => {
+        const target = latestLanguageTranslation(translationsByStringId.get(sourceString.id) ?? []);
+        return {
+          externalStringId: String(sourceString.id),
+          key: sourceString.identifier,
+          sourceText: crowdinCatSourceTextValue(sourceString.text),
+          context: sourceString.context,
+          type: sourceString.type ?? null,
+          target: target?.text
+            ? {
+                text: target.text,
+                externalTranslationId:
+                  target.translationId != null ? String(target.translationId) : null,
+                isApproved:
+                  target.translationId != null && approvedTranslationIds.has(target.translationId),
+              }
+            : null,
+          comments: (commentsByStringId.get(sourceString.id) ?? [])
+            .toSorted((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+            .map((comment) => ({
+              externalCommentId: String(comment.id),
+              type: comment.type === "issue" ? ("issue" as const) : ("comment" as const),
+              status: comment.issueStatus ?? null,
+              text: comment.text,
+              createdAt: comment.createdAt,
+              locale: comment.languageId || null,
+            })),
+        };
+      }),
+    };
+  } catch (error) {
+    if (error instanceof CrowdinApiError && error.status === 401) {
+      throw new TmsProviderLiveError("crowdin_auth_invalid", "Crowdin credentials are invalid.");
+    }
+
+    throw error;
+  }
+}
+
+async function saveCrowdinLiveCatTranslation(input: {
+  context: ActiveTmsProviderContext;
+  file: TmsProviderLiveFile;
+  targetLocale: string;
+  externalStringId: string;
+  text: string;
+}): Promise<ProjectFileCatTranslation> {
+  const projectId = Number(input.file.provider?.externalProjectId);
+  const stringId = Number(input.externalStringId);
+  if (Number.isNaN(projectId) || Number.isNaN(stringId)) {
+    throw new TmsProviderLiveError(
+      "invalid_crowdin_project_or_string_id",
+      "Crowdin project or string identifier is invalid.",
+    );
+  }
+
+  const client = new CrowdinApiClient({
+    token: input.context.secretMaterial,
+    baseUrl: input.context.credential.baseUrl ?? undefined,
+  });
+
+  try {
+    const existing = latestLanguageTranslation(
+      await client.listLanguageTranslations(projectId, input.targetLocale, {
+        stringIds: [stringId],
+      }),
+    );
+    const saved =
+      existing?.translationId != null
+        ? await client.updateTranslation(projectId, existing.translationId, input.text)
+        : await client.addTranslation(projectId, {
+            stringId,
+            languageId: input.targetLocale,
+            text: input.text,
+          });
+    const translationId = saved.id ?? existing?.translationId ?? null;
+    const approvals = await client.listTranslationApprovals(projectId, input.targetLocale);
+    const isApproved =
+      translationId != null &&
+      approvals.some((approval) => approval.translationId === translationId);
+
+    return {
+      text: saved.text,
+      externalTranslationId: translationId != null ? String(translationId) : null,
+      isApproved,
+    };
+  } catch (error) {
+    if (error instanceof CrowdinApiError && error.status === 401) {
+      throw new TmsProviderLiveError("crowdin_auth_invalid", "Crowdin credentials are invalid.");
+    }
+
+    throw error;
+  }
 }
 
 async function downloadLiveProviderFileContent(input: {
@@ -1046,7 +1254,9 @@ export async function listTmsProviderLiveFilesForProject(
 
   return files
     .slice(0, options?.limit ?? 500)
-    .map((file) => mapLiveFile({ providerKind: context.providerKind, externalProjectId, file }));
+    .map((file) =>
+      mapLiveFile({ providerKind: context.providerKind, externalProjectId, file, project }),
+    );
 }
 
 async function buildTmsProviderLiveFileDetail(
@@ -1114,6 +1324,79 @@ export async function getTmsProviderLiveFileDetail(
   }
 
   return buildTmsProviderLiveFileDetail(context, file);
+}
+
+export async function getTmsProviderLiveCatFile(
+  organizationId: string,
+  externalProjectId: string,
+  sourcePath: string,
+  targetLocale: string,
+  options?: { actorUserId?: string | null; canEditTranslations?: boolean },
+): Promise<TmsProviderLiveCatFile | null> {
+  const context = await loadActiveTmsProviderContext(organizationId, {
+    actorUserId: options?.actorUserId,
+  });
+  const files = await listTmsProviderLiveFilesForProject(organizationId, externalProjectId, {
+    context,
+    limit: 1000,
+  });
+  const file = files.find((item) => item.sourcePath === sourcePath);
+  if (!file) {
+    return null;
+  }
+
+  if (context.providerKind !== "crowdin" || file.provider?.resourceType !== "file") {
+    throw new TmsProviderLiveError(
+      "provider_cat_unsupported",
+      "CAT editing is not available for this provider file yet.",
+    );
+  }
+
+  return buildCrowdinLiveCatFile({
+    context,
+    file,
+    targetLocale,
+    canEditTranslations: options?.canEditTranslations ?? false,
+  });
+}
+
+export async function saveTmsProviderLiveCatTranslation(
+  organizationId: string,
+  externalProjectId: string,
+  sourcePath: string,
+  input: {
+    targetLocale: string;
+    externalStringId: string;
+    text: string;
+  },
+  options?: { actorUserId?: string | null },
+): Promise<ProjectFileCatTranslation | null> {
+  const context = await loadActiveTmsProviderContext(organizationId, {
+    actorUserId: options?.actorUserId,
+  });
+  const files = await listTmsProviderLiveFilesForProject(organizationId, externalProjectId, {
+    context,
+    limit: 1000,
+  });
+  const file = files.find((item) => item.sourcePath === sourcePath);
+  if (!file) {
+    return null;
+  }
+
+  if (context.providerKind !== "crowdin" || file.provider?.resourceType !== "file") {
+    throw new TmsProviderLiveError(
+      "provider_cat_unsupported",
+      "CAT editing is not available for this provider file yet.",
+    );
+  }
+
+  return saveCrowdinLiveCatTranslation({
+    context,
+    file,
+    targetLocale: input.targetLocale,
+    externalStringId: input.externalStringId,
+    text: input.text,
+  });
 }
 
 export async function listTmsProviderLiveJobs(


### PR DESCRIPTION
## What changed

- Added a task-scoped CAT workspace for Crowdin files, reachable from Project Tasks via `View strings`.
- Added provider-neutral CAT API routes for loading file segments and saving segment translations.
- Wired Crowdin source strings, translations, approvals, and unresolved comments/issues into the CAT payload.
- Added segment-level Crowdin translation create/update support while leaving existing batch write-back unchanged.
- Gated CAT translation saves behind `write_back:translation`.

## How to test

- `vp test src/lib/providers/tms-provider-live-cat.test.ts src/lib/providers/adapters/crowdin/crowdin-api.test.ts src/api/routes/project/project-cat.route.test.ts`
- `vp check --fix`
- `vp test`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review