### PR TITLE
🧪 Scout: Fix ICU plural parsing for negative exact-value selectors

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -61,5 +61,5 @@
 **Action:** When testing identifier validation, include "tail" cases where valid segments are followed by invalid characters to ensure the state machine or regex correctly terminates or rejects the input.
 
 ## 2025-06-18 - [ICU Plural Negative Selectors]
-**Learning:** ICU plural exact-value selectors (e.g., `=-1`) can include negative numbers. A naive selector parser that only expects digits after the `=` prefix will fail on these valid selectors.
-**Action:** Ensure plural selector parsing explicitly handles an optional minus sign following the `=` prefix before consuming digits.
+**Learning:** ICU plural exact-value selectors (e.g., `=-1`) can include negative numbers. A naive selector parser that only expects digits after the `=` prefix will fail on these valid selectors. Additionally, when parsing sequences that require at least one element (like digits after a sign), using an explicit starting position marker (`digitStart`) to verify consumption is clearer and more robust than checking the last character's properties.
+**Action:** Ensure plural selector parsing explicitly handles an optional minus sign following the `=` prefix before consuming digits, and use explicit position markers to validate that at least one digit was consumed.

--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -59,3 +59,7 @@
 ## 2025-06-12 - [Structural Validation of Complex Identifiers]
 **Learning:** ICU placeholders often use flattened JSON paths (dots and array indices). Validation must ensure structural integrity: a closing bracket `]` must either end the identifier or be immediately followed by a path separator (`.`) or another index (`[`). Failing to enforce this allows malformed strings like `{items[0]suffix}` to be collected as valid placeholders.
 **Action:** When testing identifier validation, include "tail" cases where valid segments are followed by invalid characters to ensure the state machine or regex correctly terminates or rejects the input.
+
+## 2025-06-18 - [ICU Plural Negative Selectors]
+**Learning:** ICU plural exact-value selectors (e.g., `=-1`) can include negative numbers. A naive selector parser that only expects digits after the `=` prefix will fail on these valid selectors.
+**Action:** Ensure plural selector parsing explicitly handles an optional minus sign following the `=` prefix before consuming digits.

--- a/internal/i18n/icuparser/parse.go
+++ b/internal/i18n/icuparser/parse.go
@@ -699,12 +699,13 @@ func (p *astParser) readSelector() (string, bool) {
 		if p.pos < len(p.src) && p.src[p.pos] == '-' {
 			p.pos++
 		}
+		digitStart := p.pos
 		for p.pos < len(p.src) && isASCIIDigit(p.src[p.pos]) {
 			p.pos++
 		}
 		// BOLT OPTIMIZATION: break on first non-digit, no TrimSpace needed.
 		// Valid selector must have at least one digit after = or =-.
-		return p.src[start:p.pos], p.pos > start+1 && p.src[p.pos-1] != '-'
+		return p.src[start:p.pos], p.pos > digitStart
 	}
 	for p.pos < len(p.src) {
 		// BOLT OPTIMIZATION: Fast-path for ASCII to avoid utf8 decoding and unicode checks.

--- a/internal/i18n/icuparser/parse.go
+++ b/internal/i18n/icuparser/parse.go
@@ -696,11 +696,15 @@ func (p *astParser) readSelector() (string, bool) {
 	start := p.pos
 	if p.pos < len(p.src) && p.src[p.pos] == '=' {
 		p.pos++
+		if p.pos < len(p.src) && p.src[p.pos] == '-' {
+			p.pos++
+		}
 		for p.pos < len(p.src) && isASCIIDigit(p.src[p.pos]) {
 			p.pos++
 		}
 		// BOLT OPTIMIZATION: break on first non-digit, no TrimSpace needed.
-		return p.src[start:p.pos], p.pos > start+1
+		// Valid selector must have at least one digit after = or =-.
+		return p.src[start:p.pos], p.pos > start+1 && p.src[p.pos-1] != '-'
 	}
 	for p.pos < len(p.src) {
 		// BOLT OPTIMIZATION: Fast-path for ASCII to avoid utf8 decoding and unicode checks.

--- a/internal/i18n/icuparser/parse_test.go
+++ b/internal/i18n/icuparser/parse_test.go
@@ -52,23 +52,43 @@ func TestParseASTPluralHasPound(t *testing.T) {
 }
 
 func TestParseASTPluralNegativeSelector(t *testing.T) {
-	msg := "{n, plural, =-1 {minus one} other {other}}"
-	elems, err := Parse(msg, nil)
-	if err != nil {
-		t.Fatalf("parse negative plural selector: %v", err)
+	tests := []struct {
+		name    string
+		msg     string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "single digit negative",
+			msg:  "{n, plural, =-1 {minus one} other {other}}",
+			want: "=-1",
+		},
+		{
+			name: "multi digit negative",
+			msg:  "{n, plural, =-10 {minus ten} other {other}}",
+			want: "=-10",
+		},
+		{
+			name:    "degenerate minus only",
+			msg:     "{n, plural, =- {error} other {other}}",
+			wantErr: true,
+		},
 	}
-	if len(elems) != 1 {
-		t.Fatalf("expected 1 element, got %d", len(elems))
-	}
-	pl, ok := elems[0].(PluralElement)
-	if !ok {
-		t.Fatalf("expected plural element, got %T", elems[0])
-	}
-	if len(pl.Options) != 2 {
-		t.Fatalf("expected 2 plural options, got %d", len(pl.Options))
-	}
-	if pl.Options[0].Selector != "=-1" {
-		t.Errorf("expected selector =-1, got %q", pl.Options[0].Selector)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			elems, err := Parse(tt.msg, nil)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Parse(%q) error = %v, wantErr %v", tt.msg, err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			pl := elems[0].(PluralElement)
+			if pl.Options[0].Selector != tt.want {
+				t.Errorf("expected selector %q, got %q", tt.want, pl.Options[0].Selector)
+			}
+		})
 	}
 }
 

--- a/internal/i18n/icuparser/parse_test.go
+++ b/internal/i18n/icuparser/parse_test.go
@@ -51,6 +51,27 @@ func TestParseASTPluralHasPound(t *testing.T) {
 	}
 }
 
+func TestParseASTPluralNegativeSelector(t *testing.T) {
+	msg := "{n, plural, =-1 {minus one} other {other}}"
+	elems, err := Parse(msg, nil)
+	if err != nil {
+		t.Fatalf("parse negative plural selector: %v", err)
+	}
+	if len(elems) != 1 {
+		t.Fatalf("expected 1 element, got %d", len(elems))
+	}
+	pl, ok := elems[0].(PluralElement)
+	if !ok {
+		t.Fatalf("expected plural element, got %T", elems[0])
+	}
+	if len(pl.Options) != 2 {
+		t.Fatalf("expected 2 plural options, got %d", len(pl.Options))
+	}
+	if pl.Options[0].Selector != "=-1" {
+		t.Errorf("expected selector =-1, got %q", pl.Options[0].Selector)
+	}
+}
+
 func TestParseASTTags(t *testing.T) {
 	elems, err := Parse("Click <b>{name}</b> now", nil)
 	if err != nil {


### PR DESCRIPTION
### 💡 What
This change enables the ICU parser to correctly handle negative exact-value selectors in plural messages, such as `=-1`.

### 🎯 Why
Previously, the parser only expected digits after the `=` prefix, causing valid ICU messages containing negative explicit values to fail parsing.

### 🧩 Scope
- `internal/i18n/icuparser/parse.go`: Updated `readSelector` to support an optional minus sign.
- `internal/i18n/icuparser/parse_test.go`: Added `TestParseASTPluralNegativeSelector`.
- `.jules/scout.md`: Added journal entry for this learning.

### ✅ Verification
- Ran `go test -v ./internal/i18n/icuparser/ -run TestParseASTPluralNegativeSelector` (Passed)
- Ran all tests in `internal/i18n/icuparser/` (Passed)

### 🛡️ Confidence
High. The fix is a straightforward extension of the existing selector scanning logic and is covered by a new regression test. All existing ICU parser tests passed, ensuring no regressions in standard selector or message parsing.

---
*PR created automatically by Jules for task [10233562293591862890](https://jules.google.com/task/10233562293591862890) started by @cungminh2710*