### PR TITLE
fix(web): correct Crowdin approvals fetch and expand CAT layout

### DIFF
--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-workspace.tsx
@@ -248,11 +248,7 @@ export function ProjectFileCatWorkspaceView({
   const isFullscreen = layout === "fullscreen";
 
   return (
-    <div
-      className={cn(
-        isFullscreen ? "flex h-full min-h-0 flex-col gap-3" : "space-y-3",
-      )}
-    >
+    <div className={cn(isFullscreen ? "flex h-full min-h-0 flex-col gap-3" : "space-y-3")}>
       <div className="flex shrink-0 flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
         <div className="flex flex-wrap items-center gap-2">
           <Badge variant="outline" className="rounded-full text-[10px]">
@@ -332,7 +328,12 @@ export function ProjectFileCatWorkspaceView({
             isFullscreen && "flex min-h-0 flex-1 flex-col",
           )}
         >
-          <div className={cn("overflow-auto", isFullscreen ? "min-h-0 flex-1" : "max-h-[min(38rem,62vh)]")}>
+          <div
+            className={cn(
+              "overflow-auto",
+              isFullscreen ? "min-h-0 flex-1" : "max-h-[min(38rem,62vh)]",
+            )}
+          >
             <table className="w-full min-w-[56rem] border-collapse text-left text-xs">
               <thead className="sticky top-0 z-10 border-b border-border bg-background/95 backdrop-blur-sm">
                 <tr>

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-cat-workspace.tsx
@@ -103,12 +103,14 @@ export function ProjectFileCatWorkspace({
   sourcePath,
   targetLocales,
   highlightLocale,
+  layout = "default",
 }: {
   organizationSlug: string;
   projectId: string;
   sourcePath: string;
   targetLocales: string[];
   highlightLocale: string | null;
+  layout?: "default" | "fullscreen";
 }) {
   const [targetLocale, setTargetLocale] = useState(() =>
     initialTargetLocale(targetLocales, highlightLocale),
@@ -189,6 +191,7 @@ export function ProjectFileCatWorkspace({
       onTargetLocaleChange={setTargetLocale}
       isLoading={catQuery.isLoading}
       error={catQuery.isError ? catQuery.error : undefined}
+      layout={layout}
       onSave={async (externalStringId, text) => {
         const result = await saveMutation.mutateAsync({ externalStringId, text });
         return result.translation;
@@ -205,6 +208,7 @@ export function ProjectFileCatWorkspaceView({
   isLoading,
   error,
   onSave,
+  layout = "default",
 }: {
   catFile: CatFile | null;
   targetLocales: string[];
@@ -213,6 +217,7 @@ export function ProjectFileCatWorkspaceView({
   isLoading: boolean;
   error?: unknown;
   onSave?: (externalStringId: string, text: string) => Promise<ProjectFileCatTranslation>;
+  layout?: "default" | "fullscreen";
 }) {
   const [drafts, setDrafts] = useState<Record<string, string>>(() => draftValuesFor(catFile));
   const [saveStates, setSaveStates] = useState<Record<string, SaveState>>(() =>
@@ -240,9 +245,15 @@ export function ProjectFileCatWorkspaceView({
     return { translated, approved, withComments };
   }, [segments]);
 
+  const isFullscreen = layout === "fullscreen";
+
   return (
-    <div className="space-y-3">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+    <div
+      className={cn(
+        isFullscreen ? "flex h-full min-h-0 flex-col gap-3" : "space-y-3",
+      )}
+    >
+      <div className="flex shrink-0 flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
         <div className="flex flex-wrap items-center gap-2">
           <Badge variant="outline" className="rounded-full text-[10px]">
             CAT
@@ -287,14 +298,24 @@ export function ProjectFileCatWorkspaceView({
       </div>
 
       {isLoading ? (
-        <div className="flex min-h-40 items-center justify-center gap-2 rounded-md border border-border bg-background px-4 py-8">
+        <div
+          className={cn(
+            "flex items-center justify-center gap-2 rounded-md border border-border bg-background px-4 py-8",
+            isFullscreen ? "min-h-0 flex-1" : "min-h-40",
+          )}
+        >
           <Spinner />
           <TypographyP className="text-sm text-muted-foreground">
             Loading CAT workspace…
           </TypographyP>
         </div>
       ) : error ? (
-        <div className="flex min-h-40 items-center gap-2 rounded-md border border-border bg-background px-4 py-8 text-flame-100">
+        <div
+          className={cn(
+            "flex items-center gap-2 rounded-md border border-border bg-background px-4 py-8 text-flame-100",
+            isFullscreen ? "min-h-0 flex-1" : "min-h-40",
+          )}
+        >
           <AlertCircleIcon className="size-4" />
           <TypographyP className="text-sm">
             {error instanceof Error ? error.message : "Failed to load CAT workspace."}
@@ -305,8 +326,13 @@ export function ProjectFileCatWorkspaceView({
           No source strings are available for this file.
         </TypographyP>
       ) : (
-        <div className="overflow-hidden rounded-md border border-border bg-background">
-          <div className="max-h-[min(38rem,62vh)] overflow-auto">
+        <div
+          className={cn(
+            "overflow-hidden rounded-md border border-border bg-background",
+            isFullscreen && "flex min-h-0 flex-1 flex-col",
+          )}
+        >
+          <div className={cn("overflow-auto", isFullscreen ? "min-h-0 flex-1" : "max-h-[min(38rem,62vh)]")}>
             <table className="w-full min-w-[56rem] border-collapse text-left text-xs">
               <thead className="sticky top-0 z-10 border-b border-border bg-background/95 backdrop-blur-sm">
                 <tr>

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
@@ -120,7 +120,7 @@ export function JobCatPageContent({
   }
 
   return (
-    <main className="-mx-4 -my-5 flex min-h-[calc(100svh-3.5rem)] flex-col overflow-hidden bg-background sm:-mx-6 lg:-mx-8">
+    <main className="-mx-4 -my-5 flex min-h-[calc(100svh-var(--app-shell-header-height))] flex-col overflow-hidden bg-background sm:-mx-6 lg:-mx-8">
       <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border px-4 py-3 sm:px-6 lg:px-8">
         <div className="flex min-w-0 items-center gap-3">
           <Button variant="outline" size="sm" render={<Link href={taskHref} />}>

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Link from "next/link";
-import { TranslationIcon } from "@hugeicons/core-free-icons";
 import { ArrowLeftIcon } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 
@@ -11,7 +10,7 @@ import { TypographyP } from "@/components/ui/typography";
 import { apiClient } from "@/lib/api-client-instance";
 import type { TmsProviderLiveFile } from "@/lib/providers/tms-provider-live";
 
-import { ProjectPageShell, ProjectSectionHeader } from "../../../../_components/project-page-shell";
+import { ProjectPageShell } from "../../../../_components/project-page-shell";
 import { ProjectFileCatWorkspace } from "../../../../files/_components/project-file-cat-workspace";
 import { tmsLiveFileToProjectFileRecord } from "../../_components/tms/job-source-file-mappers";
 
@@ -58,32 +57,32 @@ export function JobCatPageContent({
   const targetLocales =
     selectedFile?.provider?.targetLocales ?? (targetLocale ? [targetLocale] : []);
 
-  return (
-    <ProjectPageShell>
-      <ProjectSectionHeader
-        icon={TranslationIcon}
-        section="Strings"
-        description="Edit task source strings and write translations back to the provider."
-        actions={
-          <Button variant="outline" size="sm" render={<Link href={taskHref} />}>
-            <ArrowLeftIcon />
-            Task
-          </Button>
-        }
-      />
-
-      {!sourcePath ? (
+  if (!sourcePath) {
+    return (
+      <ProjectPageShell>
         <div className="rounded-lg border border-border bg-card p-5">
           <TypographyP className="text-sm text-muted-foreground">
             Choose a source file from the task, then open View strings.
           </TypographyP>
         </div>
-      ) : filesQuery.isLoading ? (
+      </ProjectPageShell>
+    );
+  }
+
+  if (filesQuery.isLoading) {
+    return (
+      <ProjectPageShell>
         <div className="flex min-h-48 items-center justify-center gap-2 rounded-lg border border-border bg-card p-5">
           <Spinner />
           <TypographyP className="text-sm text-muted-foreground">Loading task file…</TypographyP>
         </div>
-      ) : filesQuery.isError ? (
+      </ProjectPageShell>
+    );
+  }
+
+  if (filesQuery.isError) {
+    return (
+      <ProjectPageShell>
         <div className="rounded-lg border border-border bg-card p-5">
           <TypographyP className="text-sm text-flame-100">
             {filesQuery.error instanceof Error
@@ -91,38 +90,64 @@ export function JobCatPageContent({
               : "Unable to load task files."}
           </TypographyP>
         </div>
-      ) : !selectedFile ? (
+      </ProjectPageShell>
+    );
+  }
+
+  if (!selectedFile) {
+    return (
+      <ProjectPageShell>
         <div className="rounded-lg border border-border bg-card p-5">
           <TypographyP className="font-mono text-sm text-foreground">{sourcePath}</TypographyP>
           <TypographyP className="mt-2 text-sm text-muted-foreground">
             This source file is not linked to the task anymore.
           </TypographyP>
         </div>
-      ) : !selectedFile.provider ? (
+      </ProjectPageShell>
+    );
+  }
+
+  if (!selectedFile.provider) {
+    return (
+      <ProjectPageShell>
         <div className="rounded-lg border border-border bg-card p-5">
           <TypographyP className="text-sm text-muted-foreground">
             String editing is only available for provider task files.
           </TypographyP>
         </div>
-      ) : (
-        <section className="rounded-lg border border-border bg-card p-5">
-          <div className="mb-4 space-y-1">
-            <TypographyP className="font-mono text-sm font-medium text-foreground">
+      </ProjectPageShell>
+    );
+  }
+
+  return (
+    <main className="-mx-4 -my-5 flex min-h-[calc(100svh-3.5rem)] flex-col overflow-hidden bg-background sm:-mx-6 lg:-mx-8">
+      <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border px-4 py-3 sm:px-6 lg:px-8">
+        <div className="flex min-w-0 items-center gap-3">
+          <Button variant="outline" size="sm" render={<Link href={taskHref} />}>
+            <ArrowLeftIcon />
+            Task
+          </Button>
+          <div className="min-w-0">
+            <TypographyP className="truncate font-mono text-sm font-medium text-foreground">
               {selectedFile.sourcePath}
             </TypographyP>
-            <TypographyP className="text-xs text-muted-foreground">
+            <TypographyP className="truncate text-xs text-muted-foreground">
               {selectedFile.provider.kind} · {selectedFile.provider.format ?? "file"}
             </TypographyP>
           </div>
-          <ProjectFileCatWorkspace
-            organizationSlug={organizationSlug}
-            projectId={projectId}
-            sourcePath={selectedFile.sourcePath}
-            targetLocales={targetLocales}
-            highlightLocale={targetLocale}
-          />
-        </section>
-      )}
-    </ProjectPageShell>
+        </div>
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col px-4 py-3 sm:px-6 lg:px-8">
+        <ProjectFileCatWorkspace
+          organizationSlug={organizationSlug}
+          projectId={projectId}
+          sourcePath={selectedFile.sourcePath}
+          targetLocales={targetLocales}
+          highlightLocale={targetLocale}
+          layout="fullscreen"
+        />
+      </div>
+    </main>
   );
 }

--- a/apps/hyperlocalise-web/src/app/globals.css
+++ b/apps/hyperlocalise-web/src/app/globals.css
@@ -116,6 +116,7 @@
 }
 
 :root {
+  --app-shell-header-height: 3.5rem;
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.tsx
@@ -122,7 +122,7 @@ export function AppShellClient({
 
       <SidebarInset className="min-h-svh bg-background">
         <div className="sticky top-0 z-20 border-b border-border bg-background/96 backdrop-blur">
-          <div className="flex h-14 items-center justify-between gap-3 px-4 sm:px-6 lg:px-8">
+          <div className="flex h-[var(--app-shell-header-height)] items-center justify-between gap-3 px-4 sm:px-6 lg:px-8">
             <div className="flex min-w-0 items-center gap-3">
               <SidebarTrigger className="-ms-1" />
               <Separator

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
@@ -875,7 +875,7 @@ export class CrowdinApiClient {
   async listTranslationApprovals(
     projectId: number,
     languageId?: string,
-    options?: { stringIds?: number[] },
+    options?: { fileId?: number; stringId?: number },
   ): Promise<CrowdinTranslationApproval[]> {
     const approvals: CrowdinTranslationApproval[] = [];
     let offset = 0;
@@ -886,8 +886,11 @@ export class CrowdinApiClient {
       if (languageId) {
         params.append("languageId", languageId);
       }
-      if (options?.stringIds?.length) {
-        params.append("stringIds", options.stringIds.join(","));
+      if (options?.fileId !== undefined) {
+        params.append("fileId", String(options.fileId));
+      }
+      if (options?.stringId !== undefined) {
+        params.append("stringId", String(options.stringId));
       }
 
       const response = await this.get<CrowdinListResponse<CrowdinTranslationApproval>>(

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live-cat.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live-cat.test.ts
@@ -181,7 +181,7 @@ describe("getTmsProviderLiveCatFile", () => {
       if (
         path.includes("/projects/42/approvals?") &&
         path.includes("languageId=fr") &&
-        path.includes("stringIds=1001%2C1002")
+        path.includes("fileId=101")
       ) {
         return new Response(
           JSON.stringify({
@@ -281,7 +281,9 @@ describe("getTmsProviderLiveCatFile", () => {
     expect(
       requestedPaths.some(
         (path) =>
-          path.includes("/projects/42/approvals?") && path.includes("stringIds=1001%2C1002"),
+          path.includes("/projects/42/approvals?") &&
+          path.includes("languageId=fr") &&
+          path.includes("fileId=101"),
       ),
     ).toBe(true);
     expect(

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
@@ -846,17 +846,22 @@ async function buildCrowdinLiveCatFile(input: {
     const approvalsPromise = client.listTranslationApprovals(projectId, input.targetLocale, {
       fileId,
     });
-    for (let index = 0; index < sourceStringIds.length; index += 25) {
-      const chunk = sourceStringIds.slice(index, index + 25);
-      const translations = await client.listLanguageTranslations(projectId, input.targetLocale, {
-        stringIds: chunk,
-      });
+    try {
+      for (let index = 0; index < sourceStringIds.length; index += 25) {
+        const chunk = sourceStringIds.slice(index, index + 25);
+        const translations = await client.listLanguageTranslations(projectId, input.targetLocale, {
+          stringIds: chunk,
+        });
 
-      for (const translation of translations) {
-        const existing = translationsByStringId.get(translation.stringId) ?? [];
-        existing.push(translation);
-        translationsByStringId.set(translation.stringId, existing);
+        for (const translation of translations) {
+          const existing = translationsByStringId.get(translation.stringId) ?? [];
+          existing.push(translation);
+          translationsByStringId.set(translation.stringId, existing);
+        }
       }
+    } catch (loopError) {
+      await approvalsPromise.catch(() => undefined);
+      throw loopError;
     }
 
     const approvals = await approvalsPromise;

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
@@ -16,7 +16,6 @@ import {
   type CrowdinLanguageTranslation,
   type CrowdinSourceString,
   type CrowdinStringComment,
-  type CrowdinTranslationApproval,
 } from "@/lib/providers/adapters/crowdin/crowdin-api";
 import { mapCrowdinTaskToJobTaskMetadata } from "@/lib/providers/adapters/crowdin/crowdin-job-task-fetcher";
 import {

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
@@ -844,18 +844,14 @@ async function buildCrowdinLiveCatFile(input: {
     const sourceStringIdSet = new Set(sourceStringIds);
 
     const translationsByStringId = new Map<number, CrowdinLanguageTranslation[]>();
-    const approvals: CrowdinTranslationApproval[] = [];
+    const approvalsPromise = client.listTranslationApprovals(projectId, input.targetLocale, {
+      fileId,
+    });
     for (let index = 0; index < sourceStringIds.length; index += 25) {
       const chunk = sourceStringIds.slice(index, index + 25);
-      const [translations, chunkApprovals] = await Promise.all([
-        client.listLanguageTranslations(projectId, input.targetLocale, {
-          stringIds: chunk,
-        }),
-        client.listTranslationApprovals(projectId, input.targetLocale, {
-          stringIds: chunk,
-        }),
-      ]);
-      approvals.push(...chunkApprovals);
+      const translations = await client.listLanguageTranslations(projectId, input.targetLocale, {
+        stringIds: chunk,
+      });
 
       for (const translation of translations) {
         const existing = translationsByStringId.get(translation.stringId) ?? [];
@@ -864,6 +860,7 @@ async function buildCrowdinLiveCatFile(input: {
       }
     }
 
+    const approvals = await approvalsPromise;
     const approvedTranslationIds = new Set(approvals.map((approval) => approval.translationId));
 
     const [plainComments, unresolvedIssues] = await Promise.all([


### PR DESCRIPTION
## What changed

- Fixed Crowdin translation approvals API calls: the approvals endpoint accepts `fileId` + `languageId` (or a single `stringId`), not `stringIds`, which caused HTTP 400 errors when loading the job strings CAT workspace.
- Fetched approvals once per file instead of per string chunk.
- Reworked the job strings page so the CAT workspace fills the app shell with a compact toolbar and scrollable full-height table.

## How to test

1. Open a Crowdin-linked task and navigate to **View strings** for a source file.
2. Confirm the CAT workspace loads without an "unexpected error" and shows segment rows.
3. Verify the table fills the content area below the app header (no large empty gap).
4. Run `vp test src/lib/providers/tms-provider-live-cat.test.ts` in `apps/hyperlocalise-web`.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)