### PR TITLE
feat(cli): add --prefix-id flag to check command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,9 @@ inputs:
   github-diff:
     description: "For check mode, fetch the GitHub pull request diff and pass it to hyperlocalise check --diff-stdin so only changed translation keys are checked."
     default: "false"
+  prefix-id:
+    description: "For check mode, pass --prefix-id so source keys stripped by extract/pack --prefix-id are compared against packed target ids."
+    default: "false"
   summary-format:
     description: "Control the GitHub job summary verbosity. Supported values: 'compact' and 'detailed'."
     default: compact
@@ -77,6 +80,7 @@ runs:
       env:
         CHECK: ${{ inputs.check }}
         GITHUB_DIFF: ${{ inputs.github-diff }}
+        PREFIX_ID: ${{ inputs.prefix-id }}
         PR_NUMBER: ${{ github.event.pull_request.number }}
         SEVERITY_THRESHOLD: ${{ inputs.severity-threshold }}
       run: |
@@ -102,6 +106,15 @@ runs:
         if [[ "${SEVERITY_THRESHOLD}" != "warning" && "${SEVERITY_THRESHOLD}" != "error" ]]; then
           echo "Unsupported severity threshold: ${SEVERITY_THRESHOLD}" >&2
           echo "Supported values are 'warning' and 'error'." >&2
+          exit 1
+        fi
+        if [[ "${PREFIX_ID}" != "true" && "${PREFIX_ID}" != "false" ]]; then
+          echo "Unsupported prefix-id value: ${PREFIX_ID}" >&2
+          echo "Supported values are 'true' and 'false'." >&2
+          exit 1
+        fi
+        if [[ "${PREFIX_ID}" == "true" && "${CHECK}" != "check" ]]; then
+          echo "prefix-id is only supported when check is 'check'." >&2
           exit 1
         fi
 
@@ -163,6 +176,7 @@ runs:
         CONFIG_PATH: ${{ inputs.config-path }}
         GITHUB_DIFF: ${{ inputs.github-diff }}
         GITHUB_DIFF_PATH: ${{ steps.prepare.outputs.github-diff-path }}
+        PREFIX_ID: ${{ inputs.prefix-id }}
         WORKING_DIRECTORY: ${{ inputs.working-directory }}
         REPORT_PATH: ${{ steps.prepare.outputs.report-path }}
       run: |
@@ -175,6 +189,9 @@ runs:
           args=(check --no-fail --json-report "${REPORT_PATH}")
           if [[ "${GITHUB_DIFF}" == "true" ]]; then
             args+=(--diff-stdin)
+          fi
+          if [[ "${PREFIX_ID}" == "true" ]]; then
+            args+=(--prefix-id)
           fi
         fi
         if [[ -n "${CONFIG_PATH}" ]]; then

--- a/apps/cli/cmd/check.go
+++ b/apps/cli/cmd/check.go
@@ -118,6 +118,10 @@ type checkReport struct {
 	Checks   []string       `json:"checks"`
 	Findings []checkFinding `json:"findings"`
 	Summary  checkSummary   `json:"summary"`
+
+	// sourceEntryKeysByPacked maps source file path -> packed key -> original source key.
+	// Populated when --prefix-id is active so --fix can look up entries in prefixed source files.
+	sourceEntryKeysByPacked map[string]map[string]string
 }
 
 type checkTargetDescriptor struct {
@@ -410,7 +414,7 @@ func runCheck(ctx context.Context, o checkOptions) (checkReport, error) {
 	}
 
 	_, collectSpan := tr.Start(ctx, "check.collect_findings")
-	findings, err := collectCheckFindings(index, enabledChecks, selection, o.prefixID, prefixIndex)
+	collected, err := collectCheckFindings(index, enabledChecks, selection, o.prefixID, prefixIndex)
 	if err != nil {
 		collectSpan.SetStatus(codes.Error, "collect_findings")
 		collectSpan.End()
@@ -418,8 +422,13 @@ func runCheck(ctx context.Context, o checkOptions) (checkReport, error) {
 	}
 	collectSpan.End()
 
-	sortCheckFindings(findings)
-	return checkReport{Checks: enabledChecks, Findings: findings, Summary: summarizeCheckFindings(findings)}, nil
+	sortCheckFindings(collected.Findings)
+	return checkReport{
+		Checks:                  enabledChecks,
+		Findings:                collected.Findings,
+		Summary:                 summarizeCheckFindings(collected.Findings),
+		sourceEntryKeysByPacked: collected.sourceEntryKeysByPacked,
+	}, nil
 }
 
 func buildCheckConfigIndex(cfg *config.I18NConfig, buckets, locales []string) (*checkConfigIndex, error) {
@@ -520,7 +529,11 @@ func buildCheckSelectionFromDiff(index *checkConfigIndex, diffContent []byte, ke
 		changedKeys := changed.keys
 		if prefixID {
 			if _, isSource := index.sourceByPath[changedPath]; isSource {
-				changedKeys = normalizeCheckChangedKeys(changed.keys, prefixIndex)
+				var err error
+				changedKeys, err = normalizeCheckChangedKeys(changed.keys, prefixIndex)
+				if err != nil {
+					return checkSelection{}, err
+				}
 			}
 		}
 		if sourceDesc, ok := index.sourceByPath[changedPath]; ok {
@@ -612,7 +625,7 @@ func filterCheckReportErrorsOnly(r checkReport) checkReport {
 }
 
 func executeCheckFix(cmd *cobra.Command, parentCtx context.Context, o checkOptions, initial checkReport) (*checkReport, error) {
-	targets := buildFixTargetsFromFindings(initial.Findings)
+	targets := buildFixTargetsFromFindings(initial.Findings, initial.sourceEntryKeysByPacked)
 	mdScopes := buildFixMarkdownScopesFromFindings(initial.Findings)
 	if len(targets) == 0 && len(mdScopes) == 0 {
 		_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "check fix: no fixable findings (skipped)")
@@ -730,14 +743,20 @@ func executeCheckFix(cmd *cobra.Command, parentCtx context.Context, o checkOptio
 	return &after, nil
 }
 
-func buildFixTargetsFromFindings(findings []checkFinding) []runsvc.FixTarget {
+func buildFixTargetsFromFindings(findings []checkFinding, sourceEntryKeysByPacked map[string]map[string]string) []runsvc.FixTarget {
 	seen := make(map[string]struct{})
 	var out []runsvc.FixTarget
 	for _, f := range findings {
 		if !isFixableFindingType(f.Type) || strings.TrimSpace(f.Key) == "" {
 			continue
 		}
-		k := fixTargetDedupeKey(f.SourceFile, f.TargetFile, f.Locale, f.Key)
+		entryKey := f.Key
+		if packedToSource := sourceEntryKeysByPacked[filepath.Clean(f.SourceFile)]; packedToSource != nil {
+			if sourceKey, ok := packedToSource[f.Key]; ok {
+				entryKey = sourceKey
+			}
+		}
+		k := fixTargetDedupeKey(f.SourceFile, f.TargetFile, f.Locale, entryKey)
 		if _, ok := seen[k]; ok {
 			continue
 		}
@@ -746,7 +765,7 @@ func buildFixTargetsFromFindings(findings []checkFinding) []runsvc.FixTarget {
 			SourcePath:   f.SourceFile,
 			TargetPath:   f.TargetFile,
 			TargetLocale: f.Locale,
-			EntryKey:     f.Key,
+			EntryKey:     entryKey,
 		})
 	}
 	return out
@@ -871,32 +890,16 @@ func resolveEnabledChecks(includes, excludes []string) ([]string, error) {
 }
 
 func stripCheckPrefixID(id string, prefixIndex packPrefixIndex) string {
-	if originalID, ok := prefixIndex.originalIDs[id]; ok {
-		return originalID
-	}
-
-	for dot := strings.LastIndex(id, "."); dot > 0; dot = strings.LastIndex(id[:dot], ".") {
-		if dot == len(id)-1 {
-			continue
-		}
-		if _, ok := prefixIndex.prefixes[id[:dot]]; ok {
-			return id[dot+1:]
-		}
-	}
-	if stripped, ok := stripPackHyphenatedPrefixID(id); ok {
-		return stripped
-	}
-
-	return id
+	return stripPackPrefixID(id, prefixIndex)
 }
 
-func normalizeCheckSourceEntries(entries map[string]string, prefixIndex packPrefixIndex) (map[string]string, error) {
+func normalizeCheckSourceEntries(entries map[string]string, prefixIndex packPrefixIndex) (map[string]string, map[string]string, error) {
 	if len(entries) == 0 {
-		return entries, nil
+		return entries, nil, nil
 	}
 
 	out := make(map[string]string, len(entries))
-	sourceByPackedID := make(map[string]string, len(entries))
+	packedToSource := make(map[string]string, len(entries))
 	ids := make([]string, 0, len(entries))
 	for id := range entries {
 		ids = append(ids, id)
@@ -905,28 +908,40 @@ func normalizeCheckSourceEntries(entries map[string]string, prefixIndex packPref
 
 	for _, id := range ids {
 		packedID := stripCheckPrefixID(id, prefixIndex)
-		if existingSourceID, ok := sourceByPackedID[packedID]; ok {
-			return nil, packPrefixIDCollisionError(existingSourceID, id, packedID)
+		if existingSourceID, ok := packedToSource[packedID]; ok {
+			return nil, nil, packPrefixIDCollisionError(existingSourceID, id, packedID)
 		}
-		sourceByPackedID[packedID] = id
+		packedToSource[packedID] = id
 		out[packedID] = entries[id]
 	}
 
+	return out, packedToSource, nil
+}
+
+func normalizeCheckChangedKeys(changed map[string]struct{}, prefixIndex packPrefixIndex) (map[string]struct{}, error) {
+	if len(changed) == 0 {
+		return changed, nil
+	}
+	out := make(map[string]struct{}, len(changed))
+	sourceByPackedID := make(map[string]string, len(changed))
+	keys := make([]string, 0, len(changed))
+	for key := range changed {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+
+	for _, key := range keys {
+		packedID := stripCheckPrefixID(key, prefixIndex)
+		if existingSourceID, ok := sourceByPackedID[packedID]; ok {
+			return nil, packPrefixIDCollisionError(existingSourceID, key, packedID)
+		}
+		sourceByPackedID[packedID] = key
+		out[packedID] = struct{}{}
+	}
 	return out, nil
 }
 
-func normalizeCheckChangedKeys(changed map[string]struct{}, prefixIndex packPrefixIndex) map[string]struct{} {
-	if len(changed) == 0 {
-		return changed
-	}
-	out := make(map[string]struct{}, len(changed))
-	for key := range changed {
-		out[stripCheckPrefixID(key, prefixIndex)] = struct{}{}
-	}
-	return out
-}
-
-func collectCheckFindings(index *checkConfigIndex, enabledChecks []string, selection checkSelection, prefixID bool, prefixIndex packPrefixIndex) ([]checkFinding, error) {
+func collectCheckFindings(index *checkConfigIndex, enabledChecks []string, selection checkSelection, prefixID bool, prefixIndex packPrefixIndex) (checkReport, error) {
 	parser := translationfileparser.NewDefaultStrategy()
 	resolver := checkLocationResolver{content: make(map[string][]byte)}
 	checkSet := make(map[string]struct{}, len(enabledChecks))
@@ -935,18 +950,23 @@ func collectCheckFindings(index *checkConfigIndex, enabledChecks []string, selec
 	}
 
 	var findings []checkFinding
+	sourceEntryKeysByPacked := make(map[string]map[string]string)
 	for _, sourceDesc := range index.sources {
 		if !selection.allowsSource(sourceDesc.sourcePath) {
 			continue
 		}
 		sourceEntries, err := readEntriesForStatus(parser, sourceDesc.sourcePath)
 		if err != nil {
-			return nil, err
+			return checkReport{}, err
 		}
 		if prefixID {
-			sourceEntries, err = normalizeCheckSourceEntries(sourceEntries, prefixIndex)
+			var packedToSource map[string]string
+			sourceEntries, packedToSource, err = normalizeCheckSourceEntries(sourceEntries, prefixIndex)
 			if err != nil {
-				return nil, err
+				return checkReport{}, err
+			}
+			if len(packedToSource) > 0 {
+				sourceEntryKeysByPacked[filepath.Clean(sourceDesc.sourcePath)] = packedToSource
 			}
 		}
 		for _, target := range sourceDesc.targets {
@@ -956,7 +976,7 @@ func collectCheckFindings(index *checkConfigIndex, enabledChecks []string, selec
 
 			targetEntries, sourceContent, targetContent, targetExists, err := readCheckTargetEntries(parser, sourceDesc.sourcePath, target.targetPath, target.locale)
 			if err != nil {
-				return nil, err
+				return checkReport{}, err
 			}
 			if !targetExists {
 				if selection.shouldRunFileScopedChecks() {
@@ -985,7 +1005,10 @@ func collectCheckFindings(index *checkConfigIndex, enabledChecks []string, selec
 		}
 	}
 
-	return findings, nil
+	return checkReport{
+		Findings:                findings,
+		sourceEntryKeysByPacked: sourceEntryKeysByPacked,
+	}, nil
 }
 
 func readCheckTargetEntries(parser *translationfileparser.Strategy, sourcePath, targetPath, locale string) (map[string]string, []byte, []byte, bool, error) {

--- a/apps/cli/cmd/check.go
+++ b/apps/cli/cmd/check.go
@@ -74,6 +74,7 @@ type checkOptions struct {
 	bucket        string
 	file          string
 	key           string
+	prefixID      bool
 	diffStdin     bool
 	diffContent   []byte
 	checks        []string
@@ -292,6 +293,7 @@ func newCheckLikeCmd(use, short string, fixDefault bool) *cobra.Command {
 	cmd.Flags().StringVar(&o.bucket, "bucket", "", "filter by bucket name")
 	cmd.Flags().StringVar(&o.file, "file", "", "filter by source file path")
 	cmd.Flags().StringVar(&o.key, "key", "", "filter by translation key")
+	cmd.Flags().BoolVar(&o.prefixID, "prefix-id", false, "strip extract --prefix-id filename prefixes from source keys before comparing with targets (same rules as pack --prefix-id)")
 	cmd.Flags().BoolVar(&o.diffStdin, "diff-stdin", false, "read a unified diff from stdin and validate changed keys only for supported key-value files")
 	cmd.Flags().StringSliceVar(&o.checks, "check", nil, "check(s) to run")
 	cmd.Flags().StringSliceVar(&o.excludeChecks, "exclude-check", nil, "default check(s) to skip")
@@ -390,12 +392,17 @@ func runCheck(ctx context.Context, o checkOptions) (checkReport, error) {
 		return checkReport{}, err
 	}
 
-	selection, err := buildCheckSelection(index, o.file, o.key)
+	var prefixIndex packPrefixIndex
+	if o.prefixID {
+		prefixIndex = collectPackPrefixIndex()
+	}
+
+	selection, err := buildCheckSelection(index, o.file, o.key, o.prefixID, prefixIndex)
 	if err != nil {
 		return checkReport{}, err
 	}
 	if o.diffStdin {
-		selection, err = buildCheckSelectionFromDiff(index, o.diffContent, o.key)
+		selection, err = buildCheckSelectionFromDiff(index, o.diffContent, o.key, o.prefixID, prefixIndex)
 		if err != nil {
 			return checkReport{}, err
 		}
@@ -403,7 +410,7 @@ func runCheck(ctx context.Context, o checkOptions) (checkReport, error) {
 	}
 
 	_, collectSpan := tr.Start(ctx, "check.collect_findings")
-	findings, err := collectCheckFindings(index, enabledChecks, selection)
+	findings, err := collectCheckFindings(index, enabledChecks, selection, o.prefixID, prefixIndex)
 	if err != nil {
 		collectSpan.SetStatus(codes.Error, "collect_findings")
 		collectSpan.End()
@@ -463,11 +470,14 @@ func buildCheckConfigIndex(cfg *config.I18NConfig, buckets, locales []string) (*
 	return index, nil
 }
 
-func buildCheckSelection(index *checkConfigIndex, sourceFileFilter, keyFilter string) (checkSelection, error) {
+func buildCheckSelection(index *checkConfigIndex, sourceFileFilter, keyFilter string, prefixID bool, prefixIndex packPrefixIndex) (checkSelection, error) {
 	selection := checkSelection{}
 
 	trimmedKey := strings.TrimSpace(keyFilter)
 	if trimmedKey != "" {
+		if prefixID {
+			trimmedKey = stripCheckPrefixID(trimmedKey, prefixIndex)
+		}
 		selection.globalKeys = map[string]struct{}{trimmedKey: {}}
 	}
 
@@ -490,7 +500,7 @@ func buildCheckSelection(index *checkConfigIndex, sourceFileFilter, keyFilter st
 	return selection, nil
 }
 
-func buildCheckSelectionFromDiff(index *checkConfigIndex, diffContent []byte, keyFilter string) (checkSelection, error) {
+func buildCheckSelectionFromDiff(index *checkConfigIndex, diffContent []byte, keyFilter string, prefixID bool, prefixIndex packPrefixIndex) (checkSelection, error) {
 	changedFiles, err := parseUnifiedDiffChangedFiles(diffContent)
 	if err != nil {
 		return checkSelection{}, err
@@ -501,12 +511,21 @@ func buildCheckSelectionFromDiff(index *checkConfigIndex, diffContent []byte, ke
 		diffMode: true,
 	}
 	filterKey := strings.TrimSpace(keyFilter)
+	if prefixID && filterKey != "" {
+		filterKey = stripCheckPrefixID(filterKey, prefixIndex)
+	}
 
 	for _, changed := range changedFiles {
 		changedPath := filepath.Clean(changed.path)
+		changedKeys := changed.keys
+		if prefixID {
+			if _, isSource := index.sourceByPath[changedPath]; isSource {
+				changedKeys = normalizeCheckChangedKeys(changed.keys, prefixIndex)
+			}
+		}
 		if sourceDesc, ok := index.sourceByPath[changedPath]; ok {
 			scope := selection.bySource[filepath.Clean(sourceDesc.sourcePath)]
-			scope.keys = intersectChangedKeys(scope.keys, changed.keys, filterKey)
+			scope.keys = intersectChangedKeys(scope.keys, changedKeys, filterKey)
 			scope.sourceInDiff = true
 			scope.locales = nil
 			selection.bySource[filepath.Clean(sourceDesc.sourcePath)] = scope
@@ -517,7 +536,7 @@ func buildCheckSelectionFromDiff(index *checkConfigIndex, diffContent []byte, ke
 			continue
 		}
 		scope := selection.bySource[filepath.Clean(targetLookup.sourcePath)]
-		scope.keys = intersectChangedKeys(scope.keys, changed.keys, filterKey)
+		scope.keys = intersectChangedKeys(scope.keys, changedKeys, filterKey)
 		if !scope.sourceInDiff {
 			if scope.locales == nil {
 				scope.locales = make(map[string]struct{})
@@ -851,7 +870,63 @@ func resolveEnabledChecks(includes, excludes []string) ([]string, error) {
 	return enabled, nil
 }
 
-func collectCheckFindings(index *checkConfigIndex, enabledChecks []string, selection checkSelection) ([]checkFinding, error) {
+func stripCheckPrefixID(id string, prefixIndex packPrefixIndex) string {
+	if originalID, ok := prefixIndex.originalIDs[id]; ok {
+		return originalID
+	}
+
+	for dot := strings.LastIndex(id, "."); dot > 0; dot = strings.LastIndex(id[:dot], ".") {
+		if dot == len(id)-1 {
+			continue
+		}
+		if _, ok := prefixIndex.prefixes[id[:dot]]; ok {
+			return id[dot+1:]
+		}
+	}
+	if stripped, ok := stripPackHyphenatedPrefixID(id); ok {
+		return stripped
+	}
+
+	return id
+}
+
+func normalizeCheckSourceEntries(entries map[string]string, prefixIndex packPrefixIndex) (map[string]string, error) {
+	if len(entries) == 0 {
+		return entries, nil
+	}
+
+	out := make(map[string]string, len(entries))
+	sourceByPackedID := make(map[string]string, len(entries))
+	ids := make([]string, 0, len(entries))
+	for id := range entries {
+		ids = append(ids, id)
+	}
+	slices.Sort(ids)
+
+	for _, id := range ids {
+		packedID := stripCheckPrefixID(id, prefixIndex)
+		if existingSourceID, ok := sourceByPackedID[packedID]; ok {
+			return nil, packPrefixIDCollisionError(existingSourceID, id, packedID)
+		}
+		sourceByPackedID[packedID] = id
+		out[packedID] = entries[id]
+	}
+
+	return out, nil
+}
+
+func normalizeCheckChangedKeys(changed map[string]struct{}, prefixIndex packPrefixIndex) map[string]struct{} {
+	if len(changed) == 0 {
+		return changed
+	}
+	out := make(map[string]struct{}, len(changed))
+	for key := range changed {
+		out[stripCheckPrefixID(key, prefixIndex)] = struct{}{}
+	}
+	return out
+}
+
+func collectCheckFindings(index *checkConfigIndex, enabledChecks []string, selection checkSelection, prefixID bool, prefixIndex packPrefixIndex) ([]checkFinding, error) {
 	parser := translationfileparser.NewDefaultStrategy()
 	resolver := checkLocationResolver{content: make(map[string][]byte)}
 	checkSet := make(map[string]struct{}, len(enabledChecks))
@@ -867,6 +942,12 @@ func collectCheckFindings(index *checkConfigIndex, enabledChecks []string, selec
 		sourceEntries, err := readEntriesForStatus(parser, sourceDesc.sourcePath)
 		if err != nil {
 			return nil, err
+		}
+		if prefixID {
+			sourceEntries, err = normalizeCheckSourceEntries(sourceEntries, prefixIndex)
+			if err != nil {
+				return nil, err
+			}
 		}
 		for _, target := range sourceDesc.targets {
 			if !selection.allowsLocale(sourceDesc.sourcePath, target.locale) {

--- a/apps/cli/cmd/check_test.go
+++ b/apps/cli/cmd/check_test.go
@@ -138,17 +138,81 @@ func TestNormalizeCheckSourceEntriesRejectsPrefixIDCollisions(t *testing.T) {
 		"src.foo.app-header.button.label": "Save settings",
 		"src.bar.app-header.button.label": "Start trial",
 	}
-	_, err := normalizeCheckSourceEntries(entries, packPrefixIndex{})
+	_, _, err := normalizeCheckSourceEntries(entries, packPrefixIndex{})
 	if err == nil {
 		t.Fatalf("expected prefix-id collision error")
 	}
 	assertPackPrefixIDCollisionError(t, err, "src.bar.app-header.button.label", "src.foo.app-header.button.label", "button.label")
 }
 
-func TestStripCheckPrefixIDLeavesPackedKeysUntouched(t *testing.T) {
+func TestStripCheckPrefixIDMatchesPackFallback(t *testing.T) {
 	got := stripCheckPrefixID("button.label", packPrefixIndex{})
-	if got != "button.label" {
-		t.Fatalf("stripCheckPrefixID() = %q, want %q", got, "button.label")
+	if got != "label" {
+		t.Fatalf("stripCheckPrefixID() = %q, want %q", got, "label")
+	}
+}
+
+func TestStripCheckPrefixIDStripsLastSegmentWithoutHyphenatedPrefix(t *testing.T) {
+	got := stripCheckPrefixID("src.components.appheader.title", packPrefixIndex{})
+	if got != "title" {
+		t.Fatalf("stripCheckPrefixID() = %q, want %q", got, "title")
+	}
+}
+
+func TestNormalizeCheckChangedKeysRejectsPrefixIDCollisions(t *testing.T) {
+	changed := map[string]struct{}{
+		"src.foo.app-header.button.label": {},
+		"src.bar.app-header.button.label": {},
+	}
+	_, err := normalizeCheckChangedKeys(changed, packPrefixIndex{})
+	if err == nil {
+		t.Fatalf("expected prefix-id collision error")
+	}
+	assertPackPrefixIDCollisionError(t, err, "src.bar.app-header.button.label", "src.foo.app-header.button.label", "button.label")
+}
+
+func TestCheckFixPrefixIDUsesOriginalSourceEntryKey(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "i18n.jsonc")
+	sourcePath := filepath.Join(dir, "content", "en", "strings.json")
+	targetPath := filepath.Join(dir, "dist", "fr", "strings.json")
+
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
+		t.Fatalf("create source dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		t.Fatalf("create target dir: %v", err)
+	}
+	if err := os.WriteFile(sourcePath, []byte(`{"src.components.app-header.title":"Hello"}`), 0o600); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+	if err := os.WriteFile(targetPath, []byte(`{"title":""}`), 0o600); err != nil {
+		t.Fatalf("write target file: %v", err)
+	}
+	writeCheckConfig(t, configPath, sourcePath, targetPath, []string{"fr"})
+
+	orig := runCheckFixSvc
+	t.Cleanup(func() { runCheckFixSvc = orig })
+	var captured runsvc.Input
+	runCheckFixSvc = func(ctx context.Context, in runsvc.Input) (runsvc.Report, error) {
+		captured = in
+		return runsvc.Report{}, nil
+	}
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"check", "--config", configPath, "--prefix-id", "--fix", "--fix-dry-run", "--no-fail", "--format", "json"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("check --fix --prefix-id --fix-dry-run: %v", err)
+	}
+	if len(captured.FixTargets) != 1 {
+		t.Fatalf("expected 1 fix target, got %+v", captured.FixTargets)
+	}
+	if captured.FixTargets[0].EntryKey != "src.components.app-header.title" {
+		t.Fatalf("expected original source entry key, got %+v", captured.FixTargets[0])
 	}
 }
 

--- a/apps/cli/cmd/check_test.go
+++ b/apps/cli/cmd/check_test.go
@@ -20,6 +20,138 @@ import (
 	"github.com/hyperlocalise/hyperlocalise/internal/i18n/translationfileparser"
 )
 
+func TestCheckCommandPrefixIDAlignsSourceAndTargetKeys(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "i18n.jsonc")
+	sourcePath := filepath.Join(dir, "content", "en", "strings.json")
+	targetPath := filepath.Join(dir, "dist", "fr", "strings.json")
+
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
+		t.Fatalf("create source dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		t.Fatalf("create target dir: %v", err)
+	}
+	if err := os.WriteFile(sourcePath, []byte(`{
+  "src.components.app-header.title": "Dashboard",
+  "src.components.app-header.cta": "Create project"
+}`), 0o600); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+	if err := os.WriteFile(targetPath, []byte(`{
+  "title": "Tableau de bord",
+  "cta": "Créer un projet"
+}`), 0o600); err != nil {
+		t.Fatalf("write target file: %v", err)
+	}
+	writeCheckConfig(t, configPath, sourcePath, targetPath, []string{"fr"})
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"check", "--config", configPath, "--prefix-id"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("check command with --prefix-id: %v", err)
+	}
+	if !strings.Contains(out.String(), "No problems.") {
+		t.Fatalf("expected no-findings stylish output, got %q", out.String())
+	}
+}
+
+func TestCheckCommandWithoutPrefixIDReportsPrefixedSourceMismatch(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "i18n.jsonc")
+	sourcePath := filepath.Join(dir, "content", "en", "strings.json")
+	targetPath := filepath.Join(dir, "dist", "fr", "strings.json")
+
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
+		t.Fatalf("create source dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		t.Fatalf("create target dir: %v", err)
+	}
+	if err := os.WriteFile(sourcePath, []byte(`{"src.components.app-header.title":"Dashboard"}`), 0o600); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+	if err := os.WriteFile(targetPath, []byte(`{"title":"Tableau de bord"}`), 0o600); err != nil {
+		t.Fatalf("write target file: %v", err)
+	}
+	writeCheckConfig(t, configPath, sourcePath, targetPath, []string{"fr"})
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"check", "--config", configPath, "--format", "json", "--no-fail"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("check command without --prefix-id: %v", err)
+	}
+	var report checkReport
+	if err := json.Unmarshal(out.Bytes(), &report); err != nil {
+		t.Fatalf("parse json output: %v\noutput=%s", err, out.String())
+	}
+	assertFindingType(t, report.Findings, checkNotLocalized)
+	assertFindingType(t, report.Findings, checkOrphanedKey)
+}
+
+func TestCheckCommandPrefixIDDiffStdinStripsSourceKeys(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "i18n.jsonc")
+	sourcePath := filepath.Join(dir, "content", "en", "strings.json")
+	targetPath := filepath.Join(dir, "dist", "fr", "strings.json")
+
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
+		t.Fatalf("create source dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		t.Fatalf("create target dir: %v", err)
+	}
+	if err := os.WriteFile(sourcePath, []byte("{\n  \"src.components.app-header.title\": \"Dashboard\",\n  \"src.components.app-header.cta\": \"Create project\"\n}\n"), 0o600); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+	if err := os.WriteFile(targetPath, []byte("{\n  \"title\": \"\",\n  \"cta\": \"Créer un projet\"\n}\n"), 0o600); err != nil {
+		t.Fatalf("write target file: %v", err)
+	}
+	writeCheckConfig(t, configPath, sourcePath, targetPath, []string{"fr"})
+
+	report := executeCheckJSON(t, configPath, unifiedDiffForPath(sourcePath, `@@ -1,4 +1,4 @@
+ {
+-  "src.components.app-header.title": "Old",
++  "src.components.app-header.title": "Dashboard",
+   "src.components.app-header.cta": "Create project"
+ }
+`), "--diff-stdin", "--no-fail", "--prefix-id")
+
+	if len(report.Findings) != 1 {
+		t.Fatalf("expected 1 diff-scoped finding for stripped title key, got %+v", report.Findings)
+	}
+	if report.Findings[0].Key != "title" || report.Findings[0].Type != checkNotLocalized {
+		t.Fatalf("unexpected finding: %+v", report.Findings[0])
+	}
+}
+
+func TestNormalizeCheckSourceEntriesRejectsPrefixIDCollisions(t *testing.T) {
+	entries := map[string]string{
+		"src.foo.app-header.button.label": "Save settings",
+		"src.bar.app-header.button.label": "Start trial",
+	}
+	_, err := normalizeCheckSourceEntries(entries, packPrefixIndex{})
+	if err == nil {
+		t.Fatalf("expected prefix-id collision error")
+	}
+	assertPackPrefixIDCollisionError(t, err, "src.bar.app-header.button.label", "src.foo.app-header.button.label", "button.label")
+}
+
+func TestStripCheckPrefixIDLeavesPackedKeysUntouched(t *testing.T) {
+	got := stripCheckPrefixID("button.label", packPrefixIndex{})
+	if got != "button.label" {
+		t.Fatalf("stripCheckPrefixID() = %q, want %q", got, "button.label")
+	}
+}
+
 func TestCheckCommandNoFindings(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "i18n.jsonc")


### PR DESCRIPTION
## What changed

Adds `--prefix-id` to `check` and `fix` so source keys from `extract --prefix-id` are stripped before comparing against packed target ids (same rules as `pack --prefix-id`). Also adds a `prefix-id` input to the GitHub Action for CI workflows.

## How to test

- `go test ./apps/cli/cmd/ -run TestCheckCommandPrefixID -count=1`
- `hyperlocalise check --prefix-id --config i18n.yml` against a project using prefixed source catalogs and packed targets
- In CI: set `prefix-id: "true"` on the Hyperlocalise action with `check: check`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)