### PR TITLE
fix(web): align Crowdin API client query params with v2 spec

### DIFF
--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
@@ -478,8 +478,11 @@ describe("CrowdinApiClient", () => {
     );
   });
 
-  it("lists source strings", async () => {
-    const fetchMock = vi.fn(async () => {
+  it("lists source strings by fileId", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      expect(String(url)).toContain("/projects/1/strings?");
+      expect(String(url)).toContain("fileId=101");
+      expect(String(url)).not.toContain("stringIds=");
       return new Response(
         JSON.stringify({
           data: [
@@ -504,10 +507,83 @@ describe("CrowdinApiClient", () => {
     }) as unknown as typeof fetch;
 
     const client = createClient(fetchMock);
-    const strings = await client.listSourceStrings(1, 101);
+    const strings = await client.listSourceStrings(1, { fileId: 101 });
 
     expect(strings).toHaveLength(1);
     expect(strings[0]).toMatchObject({ id: 1001, identifier: "hello", fileId: 101 });
+  });
+
+  it("lists source strings by taskId", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      expect(String(url)).toContain("/projects/1/strings?");
+      expect(String(url)).toContain("taskId=9");
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    await client.listSourceStrings(1, { taskId: 9 });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("lists source strings by croql", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      expect(String(url)).toContain("croql=id+in+%281001%2C1002%29");
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    await client.listSourceStrings(1, { croql: "id in (1001,1002)" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("lists string comments for strings without languageId", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      const path = String(url);
+      expect(path).toContain("/projects/1/comments?stringId=1001&type=comment");
+      expect(path).not.toContain("languageId=");
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    await client.listStringCommentsForStrings(1, [1001], { type: "comment" });
+  });
+
+  it("lists translation approvals with fileId and languageId", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      const path = String(url);
+      expect(path).toContain("/projects/1/approvals?");
+      expect(path).toContain("languageId=fr");
+      expect(path).toContain("fileId=101");
+      expect(path).not.toContain("stringIds=");
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    await client.listTranslationApprovals(1, "fr", { fileId: 101 });
+  });
+
+  it("scopes translation approvals to source string files", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      const path = String(url);
+      expect(path).toContain("languageId=fr");
+      expect(path).toContain("fileId=101");
+      return new Response(
+        JSON.stringify({
+          data: [{ data: { id: 1, translationId: 9001, stringId: 1001, languageId: "fr" } }],
+        }),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    const approvals = await client.listTranslationApprovalsForSourceStrings(1, "fr", [
+      { id: 1001, fileId: 101 },
+    ]);
+
+    expect(approvals).toHaveLength(1);
+    expect(approvals[0]?.translationId).toBe(9001);
   });
 
   it("lists tasks", async () => {

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
@@ -586,6 +586,18 @@ describe("CrowdinApiClient", () => {
     expect(approvals[0]?.translationId).toBe(9001);
   });
 
+  it("skips translation approvals when there are no source strings", async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    const approvals = await client.listTranslationApprovalsForSourceStrings(1, "fr", []);
+
+    expect(approvals).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("lists tasks", async () => {
     const fetchMock = vi.fn(async () => {
       return new Response(

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
@@ -563,13 +563,18 @@ export class CrowdinApiClient {
   }
 
   /**
-   * List source strings for a given project, optionally filtered by file.
+   * List source strings for a given project.
+   *
+   * Supported filters: `fileId`, `taskId`, or `croql` (mutually exclusive with each other).
    */
   async listSourceStrings(
     projectId: number,
-    fileId?: number,
-    stringIds?: number[],
-    options?: { maxItems?: number },
+    options?: {
+      fileId?: number;
+      taskId?: number;
+      croql?: string;
+      maxItems?: number;
+    },
   ): Promise<CrowdinSourceString[]> {
     const strings: CrowdinSourceString[] = [];
     let offset = 0;
@@ -588,11 +593,14 @@ export class CrowdinApiClient {
         limit: String(pageLimit),
         offset: String(offset),
       });
-      if (fileId !== undefined) {
-        params.append("fileId", String(fileId));
+      if (options?.fileId !== undefined) {
+        params.append("fileId", String(options.fileId));
       }
-      if (stringIds?.length) {
-        params.append("stringIds", stringIds.join(","));
+      if (options?.taskId !== undefined) {
+        params.append("taskId", String(options.taskId));
+      }
+      if (options?.croql) {
+        params.append("croql", options.croql);
       }
 
       const response = await this.get<CrowdinListResponse<CrowdinSourceString>>(
@@ -609,6 +617,39 @@ export class CrowdinApiClient {
     }
 
     return strings;
+  }
+
+  /**
+   * List string comments for a set of strings, chunking requests to stay within API limits.
+   */
+  async listStringCommentsForStrings(
+    projectId: number,
+    stringIds: number[],
+    filter: {
+      type?: "comment" | "issue";
+      issueStatus?: "resolved" | "unresolved";
+    },
+  ): Promise<CrowdinStringComment[]> {
+    const comments: CrowdinStringComment[] = [];
+
+    for (let index = 0; index < stringIds.length; index += 25) {
+      const chunk = stringIds.slice(index, index + 25);
+      const chunkResults = await Promise.all(
+        chunk.map((stringId) =>
+          this.listStringComments(projectId, {
+            stringId,
+            type: filter.type,
+            issueStatus: filter.issueStatus,
+          }),
+        ),
+      );
+
+      for (const page of chunkResults) {
+        comments.push(...page);
+      }
+    }
+
+    return comments;
   }
 
   /**
@@ -668,7 +709,6 @@ export class CrowdinApiClient {
     projectId: number,
     options?: {
       stringId?: number;
-      languageId?: string;
       type?: "comment" | "issue";
       issueStatus?: "resolved" | "unresolved";
     },
@@ -679,9 +719,6 @@ export class CrowdinApiClient {
     }
     if (options?.type) {
       params.set("type", options.type);
-    }
-    if (options?.languageId) {
-      params.set("languageId", options.languageId);
     }
     if (options?.issueStatus) {
       params.set("issueStatus", options.issueStatus);
@@ -870,7 +907,9 @@ export class CrowdinApiClient {
   }
 
   /**
-   * List translation approvals, optionally filtered by language.
+   * List translation approvals.
+   *
+   * When `languageId` is set, Crowdin requires `fileId` or `stringId` in the same request.
    */
   async listTranslationApprovals(
     projectId: number,
@@ -907,6 +946,51 @@ export class CrowdinApiClient {
     }
 
     return approvals;
+  }
+
+  /**
+   * List approvals for task/file strings, scoping requests by file or string identifiers.
+   */
+  async listTranslationApprovalsForSourceStrings(
+    projectId: number,
+    languageId: string,
+    sourceStrings: Array<Pick<CrowdinSourceString, "id" | "fileId">>,
+  ): Promise<CrowdinTranslationApproval[]> {
+    const fileIds = [
+      ...new Set(
+        sourceStrings
+          .map((sourceString) => sourceString.fileId)
+          .filter((fileId): fileId is number => fileId != null),
+      ),
+    ];
+
+    if (fileIds.length > 0) {
+      const approvals: CrowdinTranslationApproval[] = [];
+      for (const fileId of fileIds) {
+        approvals.push(...(await this.listTranslationApprovals(projectId, languageId, { fileId })));
+      }
+      return approvals;
+    }
+
+    const stringIds = sourceStrings.map((sourceString) => sourceString.id);
+    if (stringIds.length > 0) {
+      const approvals: CrowdinTranslationApproval[] = [];
+      for (let index = 0; index < stringIds.length; index += 25) {
+        const chunk = stringIds.slice(index, index + 25);
+        const chunkResults = await Promise.all(
+          chunk.map((stringId) =>
+            this.listTranslationApprovals(projectId, languageId, { stringId }),
+          ),
+        );
+        for (const page of chunkResults) {
+          approvals.push(...page);
+        }
+      }
+      return approvals;
+    }
+
+    const allApprovals = await this.listTranslationApprovals(projectId);
+    return allApprovals.filter((approval) => approval.languageId === languageId);
   }
 
   /**

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
@@ -956,6 +956,10 @@ export class CrowdinApiClient {
     languageId: string,
     sourceStrings: Array<Pick<CrowdinSourceString, "id" | "fileId">>,
   ): Promise<CrowdinTranslationApproval[]> {
+    if (sourceStrings.length === 0) {
+      return [];
+    }
+
     const fileIds = [
       ...new Set(
         sourceStrings
@@ -973,24 +977,17 @@ export class CrowdinApiClient {
     }
 
     const stringIds = sourceStrings.map((sourceString) => sourceString.id);
-    if (stringIds.length > 0) {
-      const approvals: CrowdinTranslationApproval[] = [];
-      for (let index = 0; index < stringIds.length; index += 25) {
-        const chunk = stringIds.slice(index, index + 25);
-        const chunkResults = await Promise.all(
-          chunk.map((stringId) =>
-            this.listTranslationApprovals(projectId, languageId, { stringId }),
-          ),
-        );
-        for (const page of chunkResults) {
-          approvals.push(...page);
-        }
+    const approvals: CrowdinTranslationApproval[] = [];
+    for (let index = 0; index < stringIds.length; index += 25) {
+      const chunk = stringIds.slice(index, index + 25);
+      const chunkResults = await Promise.all(
+        chunk.map((stringId) => this.listTranslationApprovals(projectId, languageId, { stringId })),
+      );
+      for (const page of chunkResults) {
+        approvals.push(...page);
       }
-      return approvals;
     }
-
-    const allApprovals = await this.listTranslationApprovals(projectId);
-    return allApprovals.filter((approval) => approval.languageId === languageId);
+    return approvals;
   }
 
   /**

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-content-puller.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-content-puller.test.ts
@@ -41,7 +41,7 @@ describe("pullCrowdinTaskContent", () => {
         );
       }
 
-      if (path.includes("/projects/42/strings?") && path.includes("fileId=101")) {
+      if (path.includes("/projects/42/strings?") && path.includes("taskId=2001")) {
         return new Response(
           JSON.stringify({
             data: [
@@ -65,7 +65,11 @@ describe("pullCrowdinTaskContent", () => {
         );
       }
 
-      if (path.includes("/projects/42/approvals?")) {
+      if (
+        path.includes("/projects/42/approvals?") &&
+        path.includes("languageId=fr") &&
+        path.includes("fileId=101")
+      ) {
         return new Response(
           JSON.stringify({
             data: [{ data: { id: 1, translationId: 9001, stringId: 1001, languageId: "fr" } }],
@@ -126,6 +130,13 @@ describe("pullCrowdinTaskContent", () => {
       sourceText: "Hello",
       translations: [{ locale: "fr", text: "Bonjour", isApproved: true }],
     });
+
+    expect(
+      fetchMock.mock.calls.some(
+        ([url]) =>
+          String(url).includes("/projects/42/strings?") && String(url).includes("taskId=2001"),
+      ),
+    ).toBe(true);
 
     const languageTranslationCalls = fetchMock.mock.calls.filter(([url]) =>
       String(url).includes("/projects/42/languages/fr/translations?"),

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-content-puller.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-content-puller.ts
@@ -50,23 +50,13 @@ export const pullCrowdinTaskContent: ExternalTmsContentPuller = async ({
     throw new Error("crowdin_task_missing_target_language");
   }
 
-  const fileIds = task.fileIds ?? [];
-  const stringIds = task.stringIds ?? [];
-  const sourceStrings: Awaited<ReturnType<typeof client.listSourceStrings>> = [];
+  const sourceStrings = await client.listSourceStrings(projectId, { taskId });
 
-  if (stringIds.length > 0) {
-    for (const chunk of chunkArray(stringIds, 25)) {
-      sourceStrings.push(...(await client.listSourceStrings(projectId, undefined, chunk)));
-    }
-  } else if (fileIds.length > 0) {
-    for (const fileId of fileIds) {
-      sourceStrings.push(...(await client.listSourceStrings(projectId, fileId)));
-    }
-  } else {
-    sourceStrings.push(...(await client.listSourceStrings(projectId)));
-  }
-
-  const approvals = await client.listTranslationApprovals(projectId, targetLanguageId);
+  const approvals = await client.listTranslationApprovalsForSourceStrings(
+    projectId,
+    targetLanguageId,
+    sourceStrings,
+  );
   const approvedTranslationIds = new Set(approvals.map((approval) => approval.translationId));
 
   const translationsByStringId = new Map<

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live-cat.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live-cat.test.ts
@@ -193,6 +193,7 @@ describe("getTmsProviderLiveCatFile", () => {
 
       if (
         path.includes("/projects/42/comments?") &&
+        path.includes("stringId=1001") &&
         path.includes("type=comment") &&
         init?.method !== "POST"
       ) {
@@ -217,7 +218,11 @@ describe("getTmsProviderLiveCatFile", () => {
         );
       }
 
-      if (path.includes("/projects/42/comments?") && path.includes("type=issue")) {
+      if (
+        path.includes("/projects/42/comments?") &&
+        path.includes("stringId=1002") &&
+        path.includes("type=issue")
+      ) {
         return new Response(
           JSON.stringify({
             data: [
@@ -274,8 +279,9 @@ describe("getTmsProviderLiveCatFile", () => {
       requestedPaths.some(
         (path) =>
           path.includes("/projects/42/comments?") &&
+          path.includes("stringId=1001") &&
           path.includes("type=comment") &&
-          path.includes("languageId=fr"),
+          !path.includes("languageId="),
       ),
     ).toBe(true);
     expect(
@@ -290,8 +296,9 @@ describe("getTmsProviderLiveCatFile", () => {
       requestedPaths.some(
         (path) =>
           path.includes("/projects/42/comments?") &&
+          path.includes("stringId=1002") &&
           path.includes("type=issue") &&
-          path.includes("languageId=fr") &&
+          !path.includes("languageId=") &&
           path.includes("issueStatus=unresolved"),
       ),
     ).toBe(true);

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
@@ -756,7 +756,8 @@ async function downloadCrowdinSourceStringPreview(input: {
   content: ProjectFileContent | null;
   contentType: string | null;
 } | null> {
-  const strings = await input.client.listSourceStrings(input.projectId, input.fileId, undefined, {
+  const strings = await input.client.listSourceStrings(input.projectId, {
+    fileId: input.fileId,
     maxItems: maxLiveProviderStringPreviewItems + 1,
   });
   const previewContent = buildCrowdinSourceStringsPreviewContent({
@@ -835,7 +836,8 @@ async function buildCrowdinLiveCatFile(input: {
   });
 
   try {
-    const strings = await client.listSourceStrings(projectId, fileId, undefined, {
+    const strings = await client.listSourceStrings(projectId, {
+      fileId,
       maxItems: maxLiveProviderStringPreviewItems + 1,
     });
     const visibleStrings = strings.slice(0, maxLiveProviderStringPreviewItems);
@@ -868,10 +870,9 @@ async function buildCrowdinLiveCatFile(input: {
     const approvedTranslationIds = new Set(approvals.map((approval) => approval.translationId));
 
     const [plainComments, unresolvedIssues] = await Promise.all([
-      client.listStringComments(projectId, { type: "comment", languageId: input.targetLocale }),
-      client.listStringComments(projectId, {
+      client.listStringCommentsForStrings(projectId, sourceStringIds, { type: "comment" }),
+      client.listStringCommentsForStrings(projectId, sourceStringIds, {
         type: "issue",
-        languageId: input.targetLocale,
         issueStatus: "unresolved",
       }),
     ]);


### PR DESCRIPTION
## What changed

Crowdin production errors were caused by unsupported list filters (`stringIds` on approvals, `languageId` on comments, and `stringIds` on source strings). This PR aligns `crowdin-api.ts` and its callers with the Crowdin v2 API:

- Remove invalid `languageId` from comment list requests; filter locale client-side.
- Replace source-string `stringIds` with `taskId`, `fileId`, or `croql`.
- Scope CAT comment fetches per `stringId` instead of listing all project comments.
- Scope task/content approval fetches via `fileId` or `stringId` so `languageId` is never sent alone.

## How to test

- `cd apps/hyperlocalise-web && vp test src/lib/providers/adapters/crowdin/crowdin-api.test.ts src/lib/providers/adapters/crowdin/crowdin-content-puller.test.ts src/lib/providers/tms-provider-live-cat.test.ts`
- `cd apps/hyperlocalise-web && vp check --fix`
- Open a Crowdin CAT file in Vietnamese and confirm comments/issues load without HTTP 400.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review


Made with [Cursor](https://cursor.com)