### PR TITLE
fix(cat): use next-gen CAT workspace for Crowdin tasks

### DIFF
--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
@@ -11,8 +11,8 @@ import { apiClient } from "@/lib/api-client-instance";
 import type { TmsProviderLiveFile } from "@/lib/providers/tms-provider-live";
 
 import { ProjectPageShell } from "../../../../_components/project-page-shell";
-import { ProjectFileCatWorkspace } from "../../../../files/_components/project-file-cat-workspace";
 import { tmsLiveFileToProjectFileRecord } from "../../_components/tms/job-source-file-mappers";
+import { TmsJobCatWorkspace } from "./tms-job-cat-workspace";
 
 function tmsLiveJobFilesQueryKey(organizationSlug: string, encodedJobId: string) {
   return ["tms-provider-job-files", organizationSlug, encodedJobId] as const;
@@ -119,6 +119,18 @@ export function JobCatPageContent({
     );
   }
 
+  if (targetLocales.length === 0) {
+    return (
+      <ProjectPageShell>
+        <div className="rounded-lg border border-border bg-card p-5">
+          <TypographyP className="text-sm text-muted-foreground">
+            No target locale is available for this provider task file.
+          </TypographyP>
+        </div>
+      </ProjectPageShell>
+    );
+  }
+
   return (
     <main className="-mx-4 -my-5 flex min-h-[calc(100svh-var(--app-shell-header-height))] flex-col overflow-hidden bg-background sm:-mx-6 lg:-mx-8">
       <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border px-4 py-3 sm:px-6 lg:px-8">
@@ -139,13 +151,11 @@ export function JobCatPageContent({
       </div>
 
       <div className="flex min-h-0 flex-1 flex-col px-4 py-3 sm:px-6 lg:px-8">
-        <ProjectFileCatWorkspace
+        <TmsJobCatWorkspace
           organizationSlug={organizationSlug}
           projectId={projectId}
           sourcePath={selectedFile.sourcePath}
-          targetLocales={targetLocales}
-          highlightLocale={targetLocale}
-          layout="fullscreen"
+          targetLocale={targetLocales[0]}
         />
       </div>
     </main>

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
@@ -12,6 +12,7 @@ import type { TmsProviderLiveFile } from "@/lib/providers/tms-provider-live";
 
 import { ProjectPageShell } from "../../../../_components/project-page-shell";
 import { tmsLiveFileToProjectFileRecord } from "../../_components/tms/job-source-file-mappers";
+import { selectJobCatTargetLocale } from "./job-cat-target-locale";
 import { TmsJobCatWorkspace } from "./tms-job-cat-workspace";
 
 function tmsLiveJobFilesQueryKey(organizationSlug: string, encodedJobId: string) {
@@ -54,8 +55,6 @@ export function JobCatPageContent({
   const selectedFile = sourcePath
     ? (filesQuery.data ?? []).find((file) => file.sourcePath === sourcePath)
     : null;
-  const targetLocales =
-    selectedFile?.provider?.targetLocales ?? (targetLocale ? [targetLocale] : []);
 
   if (!sourcePath) {
     return (
@@ -119,7 +118,12 @@ export function JobCatPageContent({
     );
   }
 
-  if (targetLocales.length === 0) {
+  const selectedTargetLocale = selectJobCatTargetLocale({
+    requestedTargetLocale: targetLocale,
+    providerTargetLocales: selectedFile.provider.targetLocales,
+  });
+
+  if (!selectedTargetLocale) {
     return (
       <ProjectPageShell>
         <div className="rounded-lg border border-border bg-card p-5">
@@ -155,7 +159,7 @@ export function JobCatPageContent({
           organizationSlug={organizationSlug}
           projectId={projectId}
           sourcePath={selectedFile.sourcePath}
-          targetLocale={targetLocales[0]}
+          targetLocale={selectedTargetLocale}
         />
       </div>
     </main>

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-target-locale.test.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-target-locale.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { selectJobCatTargetLocale } from "./job-cat-target-locale";
+
+describe("selectJobCatTargetLocale", () => {
+  it("honors the requested URL target locale when the provider file supports it", () => {
+    expect(
+      selectJobCatTargetLocale({
+        requestedTargetLocale: "fr",
+        providerTargetLocales: ["de", "fr"],
+      }),
+    ).toBe("fr");
+  });
+
+  it("falls back to the first provider target locale when no supported locale is requested", () => {
+    expect(
+      selectJobCatTargetLocale({
+        requestedTargetLocale: null,
+        providerTargetLocales: ["de", "fr"],
+      }),
+    ).toBe("de");
+  });
+});

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-target-locale.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-target-locale.ts
@@ -1,0 +1,13 @@
+export function selectJobCatTargetLocale({
+  requestedTargetLocale,
+  providerTargetLocales,
+}: {
+  requestedTargetLocale: string | null;
+  providerTargetLocales: readonly string[];
+}) {
+  if (requestedTargetLocale && providerTargetLocales.includes(requestedTargetLocale)) {
+    return requestedTargetLocale;
+  }
+
+  return providerTargetLocales[0] ?? null;
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/tms-job-cat-workspace.test.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/tms-job-cat-workspace.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import type { ProjectFileCatResponse } from "@/api/routes/project/project.schema";
-import { projectFileCatToWorkspaceState } from "./tms-job-cat-workspace";
+import {
+  projectFileCatToWorkspaceState,
+  requireProviderExternalResourceId,
+} from "./tms-job-cat-workspace";
 
 function catFile(): ProjectFileCatResponse["catFile"] {
   return {
@@ -82,5 +85,15 @@ describe("projectFileCatToWorkspaceState", () => {
     });
     expect(state.intelligence.filePath).toBe("en-US.json");
     expect(state.breadcrumbs).toEqual(["crowdin", "en-US.json", "vi"]);
+  });
+});
+
+describe("requireProviderExternalResourceId", () => {
+  it("throws a clear error when a CAT save has no provider file identifier", () => {
+    const file = { ...catFile(), provider: null };
+
+    expect(() => requireProviderExternalResourceId(file)).toThrow(
+      "Cannot save translation because the provider file identifier is missing.",
+    );
   });
 });

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/tms-job-cat-workspace.test.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/tms-job-cat-workspace.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import type { ProjectFileCatResponse } from "@/api/routes/project/project.schema";
+import { projectFileCatToWorkspaceState } from "./tms-job-cat-workspace";
+
+function catFile(): ProjectFileCatResponse["catFile"] {
+  return {
+    sourcePath: "en-US.json",
+    filename: "en-US.json",
+    provider: {
+      kind: "crowdin",
+      resourceType: "file",
+      externalProjectId: "crowdin-project",
+      externalResourceId: "crowdin-file",
+      externalUrl: null,
+      syncState: "ready",
+      sourceLocale: "en-US",
+      targetLocales: ["vi"],
+      localeReadiness: {},
+      revision: null,
+      format: "react_intl",
+      lastSyncedAt: null,
+    },
+    targetLocale: "vi",
+    canEditTranslations: true,
+    truncated: false,
+    segments: [
+      {
+        externalStringId: "approved-string",
+        key: "auth.signIn.title",
+        sourceText: "Sign in to your workspace",
+        context: "Heading on the sign-in screen",
+        type: "text",
+        target: {
+          text: "Dang nhap vao khong gian lam viec",
+          externalTranslationId: "translation-1",
+          isApproved: true,
+        },
+        comments: [],
+      },
+      {
+        externalStringId: "issue-string",
+        key: "dashboard.pendingReviews",
+        sourceText: "{count, plural, one {# review pending} other {# reviews pending}}",
+        context: null,
+        type: "icu",
+        target: null,
+        comments: [
+          {
+            externalCommentId: "comment-1",
+            type: "issue",
+            status: "unresolved",
+            text: "Needs product context",
+            createdAt: "2026-06-10T00:00:00.000Z",
+            locale: "vi",
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe("projectFileCatToWorkspaceState", () => {
+  it("maps live Crowdin CAT content into the next-gen CAT workspace shape", () => {
+    const state = projectFileCatToWorkspaceState(catFile());
+
+    expect(state.selectedSegmentId).toBe("approved-string");
+    expect(state.queueSummary).toEqual({ total: 2, reviewed: 1 });
+    expect(state.segments[0]).toMatchObject({
+      id: "approved-string",
+      key: "auth.signIn.title",
+      sourceLocale: "en-US",
+      targetLocale: "vi",
+      targetText: "Dang nhap vao khong gian lam viec",
+      contextLabel: "Heading on the sign-in screen",
+      status: "reviewed",
+    });
+    expect(state.segments[1]).toMatchObject({
+      id: "issue-string",
+      status: "needs_review",
+      tags: ["icu", "1 comment", "1 issue"],
+    });
+    expect(state.intelligence.filePath).toBe("en-US.json");
+    expect(state.breadcrumbs).toEqual(["crowdin", "en-US.json", "vi"]);
+  });
+});

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/tms-job-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/tms-job-cat-workspace.tsx
@@ -28,6 +28,15 @@ import { cn } from "@/lib/primitives/cn";
 
 type CatFile = ProjectFileCatResponse["catFile"];
 
+export function requireProviderExternalResourceId(catFile: CatFile | null | undefined) {
+  const externalResourceId = catFile?.provider?.externalResourceId;
+  if (!externalResourceId) {
+    throw new Error("Cannot save translation because the provider file identifier is missing.");
+  }
+
+  return externalResourceId;
+}
+
 function projectFileCatQueryKey(
   organizationSlug: string,
   projectId: string,
@@ -205,6 +214,8 @@ export function TmsJobCatWorkspace({
 
   const saveMutation = useMutation({
     mutationFn: async (input: { externalStringId: string; text: string }) => {
+      const externalResourceId = requireProviderExternalResourceId(catQuery.data);
+
       const response = await apiClient.api.orgs[":organizationSlug"].projects[
         ":projectId"
       ].files.detail.cat.translations.$post({
@@ -213,7 +224,7 @@ export function TmsJobCatWorkspace({
           sourcePath,
           targetLocale,
           externalStringId: input.externalStringId,
-          externalResourceId: catQuery.data?.provider?.externalResourceId,
+          externalResourceId,
           text: input.text,
         },
       });

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/tms-job-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/tms-job-cat-workspace.tsx
@@ -1,0 +1,292 @@
+"use client";
+
+import { useMemo } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import type {
+  ProjectFileCatResponse,
+  ProjectFileCatSegment,
+  ProjectFileCatTranslation,
+} from "@/api/routes/project/project.schema";
+import { CatWorkspaceContainer } from "@/components/cat";
+import {
+  analyzeCatMessageFormat,
+  compareCatMessageFormats,
+} from "@/components/cat/cat-message-format";
+import type {
+  CatFormatCheck,
+  CatSegment,
+  CatSegmentIntelligence,
+  CatWorkspaceState,
+} from "@/components/cat/types";
+import { AlertCircleIcon } from "lucide-react";
+import { Spinner } from "@/components/ui/spinner";
+import { TypographyP } from "@/components/ui/typography";
+import { readApiError } from "@/lib/api-error";
+import { apiClient } from "@/lib/api-client-instance";
+import { cn } from "@/lib/primitives/cn";
+
+type CatFile = ProjectFileCatResponse["catFile"];
+
+function projectFileCatQueryKey(
+  organizationSlug: string,
+  projectId: string,
+  sourcePath: string,
+  targetLocale: string,
+) {
+  return ["project-file-cat", organizationSlug, projectId, sourcePath, targetLocale] as const;
+}
+
+function segmentStatusFor(segment: ProjectFileCatSegment): CatSegment["status"] {
+  if (segment.target?.isApproved) {
+    return "reviewed";
+  }
+
+  if (segment.comments.some((comment) => comment.type === "issue")) {
+    return "needs_review";
+  }
+
+  return segment.target?.text.trim() ? "needs_review" : "pending";
+}
+
+function formatCheckForSegment(segment: CatSegment, value: string): CatFormatCheck[] {
+  const checks: CatFormatCheck[] = [];
+  const sourceAnalysis = analyzeCatMessageFormat(segment.sourceText);
+  const targetAnalysis = analyzeCatMessageFormat(value);
+  const parityIssues = compareCatMessageFormats(sourceAnalysis, targetAnalysis);
+
+  if (parityIssues.length === 0) {
+    checks.push({
+      id: "format-parity",
+      label: sourceAnalysis.tokens.length > 0 ? "Placeholders & ICU" : "Format",
+      status: "pass",
+      message:
+        sourceAnalysis.tokens.length > 0
+          ? "Target keeps the required placeholders and ICU structure."
+          : "No placeholders or ICU blocks detected.",
+      category: "placeholder",
+    });
+  } else {
+    checks.push(
+      ...parityIssues.map(
+        (issue, index) =>
+          ({
+            id: `format-${issue.kind}-${index}`,
+            label: issue.label,
+            status: issue.kind === "extra-token" ? "warn" : "fail",
+            message: issue.message,
+            category:
+              issue.kind === "parse-error"
+                ? "syntax"
+                : issue.kind === "icu-mismatch"
+                  ? "icu"
+                  : "placeholder",
+            relatedTokens: issue.tokens,
+          }) satisfies CatFormatCheck,
+      ),
+    );
+  }
+
+  if (segment.maxLength && value.length > segment.maxLength) {
+    checks.unshift({
+      id: "length",
+      label: "Length",
+      status: "fail",
+      message: `Translation exceeds ${segment.maxLength} characters.`,
+      category: "length",
+    });
+  }
+
+  return checks;
+}
+
+function intelligenceFor(catFile: CatFile): CatSegmentIntelligence {
+  const issueCount = catFile.segments.reduce(
+    (count, segment) =>
+      count + segment.comments.filter((comment) => comment.type === "issue").length,
+    0,
+  );
+  const commentCount = catFile.segments.reduce(
+    (count, segment) => count + segment.comments.length,
+    0,
+  );
+
+  return {
+    intent: `Translate ${catFile.filename} into ${catFile.targetLocale}.`,
+    locationBreadcrumb: catFile.sourcePath,
+    filePath: catFile.sourcePath,
+    componentName: catFile.provider?.format ?? catFile.provider?.kind ?? undefined,
+    productMeaning:
+      commentCount > 0
+        ? `${commentCount} Crowdin comment${commentCount === 1 ? "" : "s"} are attached to this file, including ${issueCount} issue${issueCount === 1 ? "" : "s"}.`
+        : "Crowdin did not return comments or issues for this file.",
+    reviewerPreference: catFile.canEditTranslations
+      ? "Approve writes the current target text back to Crowdin."
+      : "This role can inspect strings but cannot write translations back.",
+    constraints: catFile.truncated ? "Showing the visible Crowdin segment window." : undefined,
+    glossaryTerms: [],
+    translationMemoryMatches: [],
+  };
+}
+
+export function projectFileCatToWorkspaceState(catFile: CatFile): CatWorkspaceState {
+  const sourceLocale = catFile.provider?.sourceLocale ?? "source";
+  const segments = catFile.segments.map((segment, index): CatSegment => {
+    const comments = segment.comments.length;
+    const issueComments = segment.comments.filter((comment) => comment.type === "issue").length;
+    const tags = [
+      segment.type,
+      comments > 0 ? `${comments} comment${comments === 1 ? "" : "s"}` : null,
+      issueComments > 0 ? `${issueComments} issue${issueComments === 1 ? "" : "s"}` : null,
+    ].filter((tag): tag is string => Boolean(tag));
+
+    return {
+      id: segment.externalStringId,
+      index: index + 1,
+      key: segment.key,
+      sourceText: segment.sourceText,
+      targetText: segment.target?.text ?? "",
+      sourceLocale,
+      targetLocale: catFile.targetLocale,
+      contextLabel: segment.context ?? undefined,
+      status: segmentStatusFor(segment),
+      tags,
+    };
+  });
+
+  return {
+    segments,
+    selectedSegmentId: segments[0]?.id ?? "",
+    queueSummary: {
+      total: segments.length,
+      reviewed: segments.filter((segment) => segment.status === "reviewed").length,
+    },
+    formatChecks: segments[0] ? formatCheckForSegment(segments[0], segments[0].targetText) : [],
+    suggestions: [],
+    intelligence: intelligenceFor(catFile),
+    breadcrumbs: [catFile.provider?.kind ?? "provider", catFile.filename, catFile.targetLocale],
+    primaryActionLabel: "Save to Crowdin",
+  };
+}
+
+export function TmsJobCatWorkspace({
+  organizationSlug,
+  projectId,
+  sourcePath,
+  targetLocale,
+  className,
+}: {
+  organizationSlug: string;
+  projectId: string;
+  sourcePath: string;
+  targetLocale: string;
+  className?: string;
+}) {
+  const queryClient = useQueryClient();
+  const queryKey = projectFileCatQueryKey(organizationSlug, projectId, sourcePath, targetLocale);
+  const catQuery = useQuery({
+    queryKey,
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"].projects[
+        ":projectId"
+      ].files.detail.cat.$get({
+        param: { organizationSlug, projectId },
+        query: { sourcePath, targetLocale },
+      });
+
+      if (!response.ok) {
+        throw new Error(await readApiError(response, "Failed to load CAT workspace"));
+      }
+
+      const body = (await response.json()) as ProjectFileCatResponse;
+      return body.catFile;
+    },
+  });
+
+  const saveMutation = useMutation({
+    mutationFn: async (input: { externalStringId: string; text: string }) => {
+      const response = await apiClient.api.orgs[":organizationSlug"].projects[
+        ":projectId"
+      ].files.detail.cat.translations.$post({
+        param: { organizationSlug, projectId },
+        json: {
+          sourcePath,
+          targetLocale,
+          externalStringId: input.externalStringId,
+          externalResourceId: catQuery.data?.provider?.externalResourceId,
+          text: input.text,
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(await readApiError(response, "Failed to save translation"));
+      }
+
+      const body = (await response.json()) as { translation: ProjectFileCatTranslation };
+      return body.translation;
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey });
+    },
+  });
+
+  const workspaceState = useMemo(
+    () => (catQuery.data ? projectFileCatToWorkspaceState(catQuery.data) : null),
+    [catQuery.data],
+  );
+
+  if (catQuery.isLoading) {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center gap-2 text-muted-foreground">
+        <Spinner />
+        <TypographyP className="text-sm">Loading CAT workspace...</TypographyP>
+      </div>
+    );
+  }
+
+  if (catQuery.isError) {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center gap-2 text-flame-100">
+        <AlertCircleIcon className="size-4" />
+        <TypographyP className="text-sm">
+          {catQuery.error instanceof Error
+            ? catQuery.error.message
+            : "Failed to load CAT workspace."}
+        </TypographyP>
+      </div>
+    );
+  }
+
+  if (!workspaceState || workspaceState.segments.length === 0) {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center text-muted-foreground">
+        <TypographyP className="text-sm">
+          No source strings are available for this file.
+        </TypographyP>
+      </div>
+    );
+  }
+
+  return (
+    <CatWorkspaceContainer
+      initialState={workspaceState}
+      className={cn("min-h-0 flex-1", className)}
+      services={{
+        validateFormat: async (segment, value) => formatCheckForSegment(segment, value),
+      }}
+      review={{
+        onApprove: async (segmentId, targetText) => {
+          if (!catQuery.data?.canEditTranslations) {
+            throw new Error("Your role cannot write translations back.");
+          }
+
+          const translation = await saveMutation.mutateAsync({
+            externalStringId: segmentId,
+            text: targetText,
+          });
+          return translation.isApproved ? "reviewed" : "needs_review";
+        },
+      }}
+    />
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/tms-job-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/tms-job-cat-workspace.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import type {
@@ -107,6 +107,10 @@ function formatCheckForSegment(segment: CatSegment, value: string): CatFormatChe
   }
 
   return checks;
+}
+
+async function validateSegmentFormat(segment: CatSegment, value: string) {
+  return formatCheckForSegment(segment, value);
 }
 
 function intelligenceFor(catFile: CatFile): CatSegmentIntelligence {
@@ -240,10 +244,25 @@ export function TmsJobCatWorkspace({
       await queryClient.invalidateQueries({ queryKey });
     },
   });
+  const saveTranslation = saveMutation.mutateAsync;
 
   const workspaceState = useMemo(
     () => (catQuery.data ? projectFileCatToWorkspaceState(catQuery.data) : null),
     [catQuery.data],
+  );
+  const handleApprove = useCallback(
+    async (segmentId: string, targetText: string) => {
+      if (!catQuery.data?.canEditTranslations) {
+        throw new Error("Your role cannot write translations back.");
+      }
+
+      const translation = await saveTranslation({
+        externalStringId: segmentId,
+        text: targetText,
+      });
+      return translation.isApproved ? "reviewed" : "needs_review";
+    },
+    [catQuery.data?.canEditTranslations, saveTranslation],
   );
 
   if (catQuery.isLoading) {
@@ -283,20 +302,10 @@ export function TmsJobCatWorkspace({
       initialState={workspaceState}
       className={cn("min-h-0 flex-1", className)}
       services={{
-        validateFormat: async (segment, value) => formatCheckForSegment(segment, value),
+        validateFormat: validateSegmentFormat,
       }}
       review={{
-        onApprove: async (segmentId, targetText) => {
-          if (!catQuery.data?.canEditTranslations) {
-            throw new Error("Your role cannot write translations back.");
-          }
-
-          const translation = await saveMutation.mutateAsync({
-            externalStringId: segmentId,
-            text: targetText,
-          });
-          return translation.isApproved ? "reviewed" : "needs_review";
-        },
+        onApprove: handleApprove,
       }}
     />
   );

--- a/apps/hyperlocalise-web/src/components/cat/cat-editor-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-editor-panel.tsx
@@ -43,6 +43,7 @@ export function CatEditorPanel({
   onTargetChange,
   onUseAiSuggestion,
   onApprove,
+  primaryActionLabel = "Approve",
   onAskQuestion,
   onPrevious,
   onNext,
@@ -58,6 +59,7 @@ export function CatEditorPanel({
   onTargetChange: (value: string) => void;
   onUseAiSuggestion: () => void;
   onApprove: () => void;
+  primaryActionLabel?: string;
   onAskQuestion: () => void;
   onPrevious: () => void;
   onNext: () => void;
@@ -221,7 +223,7 @@ export function CatEditorPanel({
               onClick={onApprove}
               disabled={isBusy}
             >
-              Approve
+              {primaryActionLabel}
               <ShortcutKbd keys={["⌘", "↵"]} className="bg-white/15 text-white" />
             </Button>
             <Button variant="outline" onClick={onAskQuestion} disabled={isBusy}>

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { createCatWorkspaceState } from "./cat.fixture";
+import { mergeCatWorkspaceState } from "./cat-workspace-container";
+
+describe("mergeCatWorkspaceState", () => {
+  it("preserves selected segment and unsaved target edits across server refreshes", () => {
+    const previousInitialState = createCatWorkspaceState({
+      selectedSegmentId: "seg-02",
+      segments: [
+        {
+          id: "seg-01",
+          index: 1,
+          key: "first",
+          sourceText: "First",
+          targetText: "Old first",
+          sourceLocale: "en-US",
+          targetLocale: "vi",
+          status: "needs_review",
+        },
+        {
+          id: "seg-02",
+          index: 2,
+          key: "second",
+          sourceText: "Second",
+          targetText: "Old second",
+          sourceLocale: "en-US",
+          targetLocale: "vi",
+          status: "pending",
+        },
+      ],
+    });
+    const currentState = {
+      ...previousInitialState,
+      segments: previousInitialState.segments.map((segment) =>
+        segment.id === "seg-02" ? { ...segment, targetText: "Unsaved second" } : segment,
+      ),
+    };
+    const nextInitialState = createCatWorkspaceState({
+      selectedSegmentId: "seg-01",
+      segments: [
+        {
+          id: "seg-01",
+          index: 1,
+          key: "first",
+          sourceText: "First",
+          targetText: "Saved first",
+          sourceLocale: "en-US",
+          targetLocale: "vi",
+          status: "reviewed",
+        },
+        {
+          id: "seg-02",
+          index: 2,
+          key: "second",
+          sourceText: "Second",
+          targetText: "Old second",
+          sourceLocale: "en-US",
+          targetLocale: "vi",
+          status: "pending",
+        },
+      ],
+    });
+
+    const merged = mergeCatWorkspaceState(previousInitialState, currentState, nextInitialState);
+
+    expect(merged.selectedSegmentId).toBe("seg-02");
+    expect(merged.segments).toMatchObject([
+      {
+        id: "seg-01",
+        targetText: "Saved first",
+        status: "reviewed",
+      },
+      {
+        id: "seg-02",
+        targetText: "Unsaved second",
+        status: "pending",
+      },
+    ]);
+  });
+});

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
@@ -98,6 +98,10 @@ export function CatWorkspaceContainer({
     stateRef.current = state;
   }, [state]);
 
+  useEffect(() => {
+    setState(initialState);
+  }, [initialState]);
+
   const runSegmentChecks = useCallback(
     async (segment: CatSegment, value: string) => {
       if (!validateFormat && !runQaChecks) {
@@ -183,19 +187,39 @@ export function CatWorkspaceContainer({
     };
 
     const review = {
-      onApprove: (segmentId: string) => {
-        setState((current) => {
-          const segments = updateSegmentStatus(current.segments, segmentId, "reviewed");
-          return {
+      onApprove: async (segmentId: string, targetText: string) => {
+        setIsBusy(true);
+        try {
+          const nextStatus = (await onApprove?.(segmentId, targetText)) ?? "reviewed";
+          setState((current) => {
+            const segments = updateSegmentStatus(current.segments, segmentId, nextStatus);
+            return {
+              ...current,
+              segments,
+              queueSummary: {
+                total: current.queueSummary.total,
+                reviewed: countReviewed(segments),
+              },
+            };
+          });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : "Failed to save translation.";
+          setState((current) => ({
             ...current,
-            segments,
-            queueSummary: {
-              total: current.queueSummary.total,
-              reviewed: countReviewed(segments),
-            },
-          };
-        });
-        onApprove?.(segmentId);
+            formatChecks: [
+              {
+                id: `save-failed-${segmentId}`,
+                label: "Crowdin write-back",
+                status: "fail",
+                message,
+                category: "qa",
+              },
+              ...current.formatChecks.filter((check) => !check.id.startsWith("save-failed-")),
+            ],
+          }));
+        } finally {
+          setIsBusy(false);
+        }
       },
       onAskQuestion: (segmentId: string) => {
         onAskQuestion?.(segmentId);

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
@@ -59,6 +59,53 @@ function countReviewed(segments: CatSegment[]) {
   return segments.filter((segment) => segment.status === "reviewed").length;
 }
 
+function getSegmentsById(state: CatWorkspaceState) {
+  return new Map(state.segments.map((segment) => [segment.id, segment]));
+}
+
+export function mergeCatWorkspaceState(
+  previousInitialState: CatWorkspaceState,
+  currentState: CatWorkspaceState,
+  nextInitialState: CatWorkspaceState,
+): CatWorkspaceState {
+  const previousSegments = getSegmentsById(previousInitialState);
+  const currentSegments = getSegmentsById(currentState);
+  const segments = nextInitialState.segments.map((nextSegment) => {
+    const previousSegment = previousSegments.get(nextSegment.id);
+    const currentSegment = currentSegments.get(nextSegment.id);
+    if (!previousSegment || !currentSegment) {
+      return nextSegment;
+    }
+
+    if (currentSegment.targetText === previousSegment.targetText) {
+      return nextSegment;
+    }
+
+    return {
+      ...nextSegment,
+      targetText: currentSegment.targetText,
+    };
+  });
+  const nextSegmentIds = new Set(segments.map((segment) => segment.id));
+  const selectedSegmentId = nextSegmentIds.has(currentState.selectedSegmentId)
+    ? currentState.selectedSegmentId
+    : (nextInitialState.selectedSegmentId ?? segments[0]?.id ?? "");
+
+  return {
+    ...nextInitialState,
+    segments,
+    selectedSegmentId,
+    queueSummary: {
+      total: segments.length,
+      reviewed: countReviewed(segments),
+    },
+    formatChecks:
+      selectedSegmentId === currentState.selectedSegmentId
+        ? currentState.formatChecks
+        : nextInitialState.formatChecks,
+  };
+}
+
 export interface CatWorkspaceContainerProps {
   initialState: CatWorkspaceState;
   dependencies?: PartialCatWorkspaceDependencies;
@@ -81,6 +128,7 @@ export function CatWorkspaceContainer({
   const [state, setState] = useState(initialState);
   const [isBusy, setIsBusy] = useState(false);
   const stateRef = useRef(state);
+  const previousInitialStateRef = useRef(initialState);
   const validationSequenceRef = useRef(0);
   const validateFormat = serviceOverrides?.validateFormat;
   const runQaChecks = serviceOverrides?.runQaChecks;
@@ -99,7 +147,10 @@ export function CatWorkspaceContainer({
   }, [state]);
 
   useEffect(() => {
-    setState(initialState);
+    setState((current) =>
+      mergeCatWorkspaceState(previousInitialStateRef.current, current, initialState),
+    );
+    previousInitialStateRef.current = initialState;
   }, [initialState]);
 
   const runSegmentChecks = useCallback(
@@ -209,7 +260,7 @@ export function CatWorkspaceContainer({
             formatChecks: [
               {
                 id: `save-failed-${segmentId}`,
-                label: "Crowdin write-back",
+                label: "Save failed",
                 status: "fail",
                 message,
                 category: "qa",

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace.tsx
@@ -65,7 +65,10 @@ export function CatWorkspaceView({
               isBusy={isBusy}
               onTargetChange={(value) => editing.onTargetChange(selectedSegment.id, value)}
               onUseAiSuggestion={() => editing.onUseAiSuggestion(selectedSegment.id)}
-              onApprove={() => review.onApprove(selectedSegment.id)}
+              onApprove={() =>
+                void review.onApprove(selectedSegment.id, selectedSegment.targetText)
+              }
+              primaryActionLabel={state.primaryActionLabel}
               onAskQuestion={() => review.onAskQuestion(selectedSegment.id)}
               onPrevious={navigation.onPreviousSegment}
               onNext={navigation.onNextSegment}

--- a/apps/hyperlocalise-web/src/components/cat/dependencies.ts
+++ b/apps/hyperlocalise-web/src/components/cat/dependencies.ts
@@ -1,4 +1,4 @@
-import type { CatFormatCheck, CatSegment, CatWorkspaceState } from "./types";
+import type { CatFormatCheck, CatSegment, CatSegmentStatus, CatWorkspaceState } from "./types";
 
 export interface CatWorkspaceNavigation {
   onSelectSegment: (segmentId: string) => void;
@@ -13,7 +13,10 @@ export interface CatWorkspaceEditing {
 }
 
 export interface CatWorkspaceReview {
-  onApprove: (segmentId: string) => void;
+  onApprove: (
+    segmentId: string,
+    targetText: string,
+  ) => void | CatSegmentStatus | Promise<void | CatSegmentStatus>;
   onAskQuestion: (segmentId: string) => void;
   onSkip: (segmentId: string) => void;
 }

--- a/apps/hyperlocalise-web/src/components/cat/types.ts
+++ b/apps/hyperlocalise-web/src/components/cat/types.ts
@@ -82,4 +82,5 @@ export interface CatWorkspaceState {
   intelligence: CatSegmentIntelligence;
   jobTitle?: string;
   breadcrumbs?: string[];
+  primaryActionLabel?: string;
 }


### PR DESCRIPTION
## What changed

- Replaced the task strings page’s legacy table CAT view with a Crowdin-backed adapter for `components/cat`.
- Mapped live Crowdin CAT file segments into the next-gen CAT workspace state, including segment status, locale metadata, file context, comments/issues, and format checks.
- Added async write-back support to the CAT workspace so saving waits for the Crowdin save endpoint before updating segment state.
- Added regression coverage for mapping live Crowdin CAT content into the next-gen CAT workspace shape.

## How to test

- `vp test 'src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/tms-job-cat-workspace.test.ts' src/components/cat/cat-message-format.test.ts`
- `vp check --fix`
- `vp test`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review