### PR TITLE
fix(cat): show accurate segment format and context

### DIFF
--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/tms-job-cat-workspace.test.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/tms-job-cat-workspace.test.ts
@@ -83,7 +83,21 @@ describe("projectFileCatToWorkspaceState", () => {
       status: "needs_review",
       tags: ["icu", "1 comment", "1 issue"],
     });
+    expect(state.segmentFormatChecks?.["issue-string"]).toContainEqual(
+      expect.objectContaining({
+        label: "ICU structure",
+        status: "fail",
+      }),
+    );
     expect(state.intelligence.filePath).toBe("en-US.json");
+    expect(state.segmentIntelligence?.["approved-string"]).toMatchObject({
+      productMeaning: "Heading on the sign-in screen",
+      locationBreadcrumb: "auth.signIn.title",
+      filePath: "en-US.json",
+    });
+    expect(state.segmentIntelligence?.["issue-string"]?.productMeaning).toContain(
+      "1 Crowdin comment",
+    );
     expect(state.breadcrumbs).toEqual(["crowdin", "en-US.json", "vi"]);
   });
 });

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/tms-job-cat-workspace.test.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/tms-job-cat-workspace.test.ts
@@ -96,7 +96,7 @@ describe("projectFileCatToWorkspaceState", () => {
       filePath: "en-US.json",
     });
     expect(state.segmentIntelligence?.["issue-string"]?.productMeaning).toContain(
-      "1 Crowdin comment",
+      "1 Crowdin comment is attached",
     );
     expect(state.breadcrumbs).toEqual(["crowdin", "en-US.json", "vi"]);
   });

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/tms-job-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/tms-job-cat-workspace.tsx
@@ -158,7 +158,7 @@ function segmentIntelligenceFor(
     productMeaning:
       context ||
       (comments > 0
-        ? `${comments} Crowdin comment${comments === 1 ? "" : "s"} are attached to this string, including ${issues} issue${issues === 1 ? "" : "s"}.`
+        ? `${comments} Crowdin comment${comments === 1 ? "" : "s"} ${comments === 1 ? "is" : "are"} attached to this string, including ${issues} issue${issues === 1 ? "" : "s"}.`
         : "Crowdin did not return context, comments, or issues for this string."),
     reviewerPreference: catFile.canEditTranslations
       ? "Approve writes the current target text back to Crowdin."

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/tms-job-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/tms-job-cat-workspace.tsx
@@ -142,6 +142,33 @@ function intelligenceFor(catFile: CatFile): CatSegmentIntelligence {
   };
 }
 
+function segmentIntelligenceFor(
+  catFile: CatFile,
+  segment: ProjectFileCatSegment,
+): CatSegmentIntelligence {
+  const comments = segment.comments.length;
+  const issues = segment.comments.filter((comment) => comment.type === "issue").length;
+  const context = segment.context?.trim();
+
+  return {
+    intent: `Translate ${segment.key} into ${catFile.targetLocale}.`,
+    locationBreadcrumb: segment.key,
+    filePath: catFile.sourcePath,
+    componentName: segment.type ?? catFile.provider?.format ?? catFile.provider?.kind ?? undefined,
+    productMeaning:
+      context ||
+      (comments > 0
+        ? `${comments} Crowdin comment${comments === 1 ? "" : "s"} are attached to this string, including ${issues} issue${issues === 1 ? "" : "s"}.`
+        : "Crowdin did not return context, comments, or issues for this string."),
+    reviewerPreference: catFile.canEditTranslations
+      ? "Approve writes the current target text back to Crowdin."
+      : "This role can inspect strings but cannot write translations back.",
+    constraints: catFile.truncated ? "Showing the visible Crowdin segment window." : undefined,
+    glossaryTerms: [],
+    translationMemoryMatches: [],
+  };
+}
+
 export function projectFileCatToWorkspaceState(catFile: CatFile): CatWorkspaceState {
   const sourceLocale = catFile.provider?.sourceLocale ?? "source";
   const segments = catFile.segments.map((segment, index): CatSegment => {
@@ -175,8 +202,17 @@ export function projectFileCatToWorkspaceState(catFile: CatFile): CatWorkspaceSt
       reviewed: segments.filter((segment) => segment.status === "reviewed").length,
     },
     formatChecks: segments[0] ? formatCheckForSegment(segments[0], segments[0].targetText) : [],
+    segmentFormatChecks: Object.fromEntries(
+      segments.map((segment) => [segment.id, formatCheckForSegment(segment, segment.targetText)]),
+    ),
     suggestions: [],
     intelligence: intelligenceFor(catFile),
+    segmentIntelligence: Object.fromEntries(
+      catFile.segments.map((segment) => [
+        segment.externalStringId,
+        segmentIntelligenceFor(catFile, segment),
+      ]),
+    ),
     breadcrumbs: [catFile.provider?.kind ?? "provider", catFile.filename, catFile.targetLocale],
     primaryActionLabel: "Save to Crowdin",
   };

--- a/apps/hyperlocalise-web/src/components/cat/cat-message-format.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat-message-format.test.ts
@@ -60,4 +60,15 @@ describe("cat message format utilities", () => {
 
     expect(analysis.parseError?.message).toBeTruthy();
   });
+
+  it("does not pass format checks when source ICU syntax cannot be parsed", () => {
+    const issues = compare("{count, plural, one {# file}}", "1 file");
+
+    expect(issues).toContainEqual(
+      expect.objectContaining({
+        kind: "parse-error",
+        label: "Source message syntax",
+      }),
+    );
+  });
 });

--- a/apps/hyperlocalise-web/src/components/cat/cat-message-format.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat-message-format.ts
@@ -249,6 +249,14 @@ export function compareCatMessageFormats(
       label: "Source message syntax",
       message: source.parseError.message,
     });
+    if (target.parseError) {
+      issues.push({
+        kind: "parse-error",
+        label: "Target message syntax",
+        message: target.parseError.message,
+      });
+    }
+    return issues;
   }
 
   if (target.parseError) {
@@ -257,10 +265,6 @@ export function compareCatMessageFormats(
       label: "Target message syntax",
       message: target.parseError.message,
     });
-    return issues;
-  }
-
-  if (source.parseError) {
     return issues;
   }
 

--- a/apps/hyperlocalise-web/src/components/cat/cat-message-format.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat-message-format.ts
@@ -243,12 +243,24 @@ export function compareCatMessageFormats(
 ): CatMessageParityIssue[] {
   const issues: CatMessageParityIssue[] = [];
 
+  if (source.parseError) {
+    issues.push({
+      kind: "parse-error",
+      label: "Source message syntax",
+      message: source.parseError.message,
+    });
+  }
+
   if (target.parseError) {
     issues.push({
       kind: "parse-error",
-      label: "Message syntax",
+      label: "Target message syntax",
       message: target.parseError.message,
     });
+    return issues;
+  }
+
+  if (source.parseError) {
     return issues;
   }
 

--- a/apps/hyperlocalise-web/src/components/cat/cat-queue-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-queue-panel.tsx
@@ -68,7 +68,7 @@ export function CatQueuePanel({
         maskHeight={44}
         maskClassName="before:via-background/90 before:backdrop-blur-[1px] after:via-background/90 after:backdrop-blur-[1px]"
       >
-        <ul className="space-y-1 px-2 pb-2">
+        <ul className="space-y-1 px-4 pb-3">
           {segments.map((segment) => {
             const selected = segment.id === selectedSegmentId;
 
@@ -79,7 +79,9 @@ export function CatQueuePanel({
                   onClick={() => onSelectSegment(segment.id)}
                   className={cn(
                     "flex w-full items-start gap-3 rounded-lg px-3 py-2.5 text-left transition-colors",
-                    selected ? "bg-grove-500/10 ring-1 ring-grove-400/25" : "hover:bg-foreground/4",
+                    selected
+                      ? "bg-grove-500/10 ring-1 ring-inset ring-grove-400/25"
+                      : "hover:bg-foreground/4",
                   )}
                 >
                   <span className="mt-0.5 w-5 shrink-0 font-mono text-xs text-muted-foreground">

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.test.ts
@@ -95,6 +95,65 @@ describe("mergeCatWorkspaceState", () => {
       id: "edited-check",
     });
   });
+
+  it("preserves save failure checks for unedited segments across server refreshes", () => {
+    const previousInitialState = createCatWorkspaceState({
+      selectedSegmentId: "seg-02",
+      segments: [
+        {
+          id: "seg-02",
+          index: 2,
+          key: "second",
+          sourceText: "Second",
+          targetText: "Old second",
+          sourceLocale: "en-US",
+          targetLocale: "vi",
+          status: "pending",
+        },
+      ],
+    });
+    const saveFailureCheck = {
+      id: "save-failed-seg-02",
+      label: "Save failed",
+      status: "fail" as const,
+      message: "Provider rejected the update.",
+      category: "qa" as const,
+    };
+    const currentState = {
+      ...previousInitialState,
+      formatChecks: [saveFailureCheck],
+      segmentFormatChecks: {
+        "seg-02": [saveFailureCheck],
+      },
+    };
+    const nextInitialState = createCatWorkspaceState({
+      selectedSegmentId: "seg-02",
+      segments: [
+        {
+          id: "seg-02",
+          index: 2,
+          key: "second",
+          sourceText: "Second",
+          targetText: "Old second",
+          sourceLocale: "en-US",
+          targetLocale: "vi",
+          status: "pending",
+        },
+      ],
+      segmentFormatChecks: {
+        "seg-02": [],
+      },
+    });
+
+    const merged = mergeCatWorkspaceState(previousInitialState, currentState, nextInitialState);
+
+    expect(merged.segmentFormatChecks?.["seg-02"]).toContainEqual(
+      expect.objectContaining({
+        id: "save-failed-seg-02",
+        message: "Provider rejected the update.",
+      }),
+    );
+  });
 });
 
 describe("addSaveFailureFormatCheck", () => {

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.test.ts
@@ -35,6 +35,16 @@ describe("mergeCatWorkspaceState", () => {
       segments: previousInitialState.segments.map((segment) =>
         segment.id === "seg-02" ? { ...segment, targetText: "Unsaved second" } : segment,
       ),
+      segmentFormatChecks: {
+        "seg-02": [
+          {
+            id: "edited-check",
+            label: "Edited format",
+            status: "pass" as const,
+            message: "Edited segment checks are still current.",
+          },
+        ],
+      },
     };
     const nextInitialState = createCatWorkspaceState({
       selectedSegmentId: "seg-01",
@@ -77,5 +87,8 @@ describe("mergeCatWorkspaceState", () => {
         status: "pending",
       },
     ]);
+    expect(merged.segmentFormatChecks?.["seg-02"]?.[0]).toMatchObject({
+      id: "edited-check",
+    });
   });
 });

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import { createCatWorkspaceState } from "./cat.fixture";
-import { mergeCatWorkspaceState } from "./cat-workspace-container";
+import {
+  addSaveFailureFormatCheck,
+  getAiSuggestionForSegment,
+  mergeCatWorkspaceState,
+} from "./cat-workspace-container";
 
 describe("mergeCatWorkspaceState", () => {
   it("preserves selected segment and unsaved target edits across server refreshes", () => {
@@ -90,5 +94,77 @@ describe("mergeCatWorkspaceState", () => {
     expect(merged.segmentFormatChecks?.["seg-02"]?.[0]).toMatchObject({
       id: "edited-check",
     });
+  });
+});
+
+describe("addSaveFailureFormatCheck", () => {
+  it("adds the save failure to file-level and selected segment format checks", () => {
+    const state = createCatWorkspaceState({
+      formatChecks: [
+        {
+          id: "save-failed-old",
+          label: "Save failed",
+          status: "fail",
+          message: "Previous failure.",
+          category: "qa",
+        },
+        {
+          id: "file-check",
+          label: "File check",
+          status: "warn",
+          message: "Visible through the file-level fallback.",
+        },
+      ],
+      segmentFormatChecks: {
+        "seg-02": [
+          {
+            id: "segment-check",
+            label: "Segment check",
+            status: "warn",
+            message: "Visible for the selected segment.",
+          },
+        ],
+      },
+    });
+
+    const next = addSaveFailureFormatCheck(state, "seg-02", "Provider rejected the update.");
+
+    expect(next.formatChecks).toMatchObject([
+      {
+        id: "save-failed-seg-02",
+        message: "Provider rejected the update.",
+      },
+      {
+        id: "file-check",
+      },
+    ]);
+    expect(next.segmentFormatChecks?.["seg-02"]).toMatchObject([
+      {
+        id: "save-failed-seg-02",
+        message: "Provider rejected the update.",
+      },
+      {
+        id: "segment-check",
+      },
+    ]);
+  });
+});
+
+describe("getAiSuggestionForSegment", () => {
+  it("prefers segment-level AI suggestions over the file-level fallback", () => {
+    const state = createCatWorkspaceState({
+      intelligence: {
+        ...createCatWorkspaceState().intelligence,
+        aiSuggestion: "Use the file-level suggestion.",
+      },
+      segmentIntelligence: {
+        "seg-02": {
+          ...createCatWorkspaceState().intelligence,
+          aiSuggestion: "Use the segment-level suggestion.",
+        },
+      },
+    });
+
+    expect(getAiSuggestionForSegment(state, "seg-02")).toBe("Use the segment-level suggestion.");
   });
 });

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
@@ -11,7 +11,7 @@ import type {
   PartialCatWorkspaceDependencies,
 } from "./dependencies";
 import { CatWorkspaceView } from "./cat-workspace";
-import type { CatSegment, CatWorkspaceState } from "./types";
+import type { CatFormatCheck, CatSegment, CatWorkspaceState } from "./types";
 
 function getSegmentQueueIndex(segments: CatSegment[], segmentIdOrKey: string) {
   return segments.findIndex(
@@ -61,6 +61,37 @@ function countReviewed(segments: CatSegment[]) {
 
 function getSegmentsById(state: CatWorkspaceState) {
   return new Map(state.segments.map((segment) => [segment.id, segment]));
+}
+
+function withoutSaveFailureChecks(checks: CatFormatCheck[]) {
+  return checks.filter((check) => !check.id.startsWith("save-failed-"));
+}
+
+export function addSaveFailureFormatCheck(
+  state: CatWorkspaceState,
+  segmentId: string,
+  message: string,
+): Pick<CatWorkspaceState, "formatChecks" | "segmentFormatChecks"> {
+  const saveFailureCheck: CatFormatCheck = {
+    id: `save-failed-${segmentId}`,
+    label: "Save failed",
+    status: "fail",
+    message,
+    category: "qa",
+  };
+  const segmentChecks = state.segmentFormatChecks?.[segmentId] ?? state.formatChecks;
+
+  return {
+    formatChecks: [saveFailureCheck, ...withoutSaveFailureChecks(state.formatChecks)],
+    segmentFormatChecks: {
+      ...state.segmentFormatChecks,
+      [segmentId]: [saveFailureCheck, ...withoutSaveFailureChecks(segmentChecks)],
+    },
+  };
+}
+
+export function getAiSuggestionForSegment(state: CatWorkspaceState, segmentId: string) {
+  return state.segmentIntelligence?.[segmentId]?.aiSuggestion ?? state.intelligence.aiSuggestion;
 }
 
 export function mergeCatWorkspaceState(
@@ -253,7 +284,7 @@ export function CatWorkspaceContainer({
         onTargetChange?.(segmentId, value);
       },
       onUseAiSuggestion: (segmentId: string) => {
-        const aiSuggestion = stateRef.current.intelligence.aiSuggestion;
+        const aiSuggestion = getAiSuggestionForSegment(stateRef.current, segmentId);
         if (!aiSuggestion) {
           return;
         }
@@ -282,16 +313,7 @@ export function CatWorkspaceContainer({
           const message = error instanceof Error ? error.message : "Failed to save translation.";
           setState((current) => ({
             ...current,
-            formatChecks: [
-              {
-                id: `save-failed-${segmentId}`,
-                label: "Save failed",
-                status: "fail",
-                message,
-                category: "qa",
-              },
-              ...current.formatChecks.filter((check) => !check.id.startsWith("save-failed-")),
-            ],
+            ...addSaveFailureFormatCheck(current, segmentId, message),
           }));
         } finally {
           setIsBusy(false);

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
@@ -90,6 +90,22 @@ export function mergeCatWorkspaceState(
   const selectedSegmentId = nextSegmentIds.has(currentState.selectedSegmentId)
     ? currentState.selectedSegmentId
     : (nextInitialState.selectedSegmentId ?? segments[0]?.id ?? "");
+  const segmentFormatChecks: CatWorkspaceState["segmentFormatChecks"] = {
+    ...nextInitialState.segmentFormatChecks,
+  };
+  for (const segment of segments) {
+    const previousSegment = previousSegments.get(segment.id);
+    const currentSegment = currentSegments.get(segment.id);
+    const currentChecks = currentState.segmentFormatChecks?.[segment.id];
+    if (
+      previousSegment &&
+      currentSegment &&
+      currentChecks &&
+      currentSegment.targetText !== previousSegment.targetText
+    ) {
+      segmentFormatChecks[segment.id] = currentChecks;
+    }
+  }
 
   return {
     ...nextInitialState,
@@ -103,6 +119,7 @@ export function mergeCatWorkspaceState(
       selectedSegmentId === currentState.selectedSegmentId
         ? currentState.formatChecks
         : nextInitialState.formatChecks,
+    segmentFormatChecks,
   };
 }
 
@@ -170,7 +187,15 @@ export function CatWorkspaceContainer({
         if (validationSequenceRef.current !== sequence) {
           return;
         }
-        setState((current) => ({ ...current, formatChecks: [...formatChecks, ...qaChecks] }));
+        const checks = [...formatChecks, ...qaChecks];
+        setState((current) => ({
+          ...current,
+          formatChecks: checks,
+          segmentFormatChecks: {
+            ...current.segmentFormatChecks,
+            [segment.id]: checks,
+          },
+        }));
       } finally {
         if (validationSequenceRef.current === sequence) {
           setIsBusy(false);

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
@@ -67,6 +67,10 @@ function withoutSaveFailureChecks(checks: CatFormatCheck[]) {
   return checks.filter((check) => !check.id.startsWith("save-failed-"));
 }
 
+function hasSaveFailureCheck(checks: CatFormatCheck[]) {
+  return checks.some((check) => check.id.startsWith("save-failed-"));
+}
+
 export function addSaveFailureFormatCheck(
   state: CatWorkspaceState,
   segmentId: string,
@@ -132,7 +136,8 @@ export function mergeCatWorkspaceState(
       previousSegment &&
       currentSegment &&
       currentChecks &&
-      currentSegment.targetText !== previousSegment.targetText
+      (currentSegment.targetText !== previousSegment.targetText ||
+        hasSaveFailureCheck(currentChecks))
     ) {
       segmentFormatChecks[segment.id] = currentChecks;
     }

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace.tsx
@@ -36,6 +36,10 @@ export function CatWorkspaceView({
   const hasPreviousSegment = segmentPosition > 1;
   const hasNextSegment = segmentPosition < state.segments.length;
   const { navigation, editing, review } = dependencies;
+  const selectedSegmentIntelligence =
+    state.segmentIntelligence?.[selectedSegment.id] ?? state.intelligence;
+  const selectedSegmentFormatChecks =
+    state.segmentFormatChecks?.[selectedSegment.id] ?? state.formatChecks;
 
   return (
     <div
@@ -60,8 +64,8 @@ export function CatWorkspaceView({
               segment={selectedSegment}
               segmentPosition={segmentPosition}
               totalSegments={state.segments.length}
-              formatChecks={state.formatChecks}
-              intelligence={state.intelligence}
+              formatChecks={selectedSegmentFormatChecks}
+              intelligence={selectedSegmentIntelligence}
               isBusy={isBusy}
               onTargetChange={(value) => editing.onTargetChange(selectedSegment.id, value)}
               onUseAiSuggestion={() => editing.onUseAiSuggestion(selectedSegment.id)}
@@ -79,7 +83,7 @@ export function CatWorkspaceView({
         </div>
 
         <div className="min-w-0 overflow-hidden">
-          <CatIntelligencePanel intelligence={state.intelligence} />
+          <CatIntelligencePanel intelligence={selectedSegmentIntelligence} />
         </div>
       </div>
     </div>

--- a/apps/hyperlocalise-web/src/components/cat/types.ts
+++ b/apps/hyperlocalise-web/src/components/cat/types.ts
@@ -78,8 +78,10 @@ export interface CatWorkspaceState {
   selectedSegmentId: string;
   queueSummary: CatQueueSummary;
   formatChecks: CatFormatCheck[];
+  segmentFormatChecks?: Record<string, CatFormatCheck[]>;
   suggestions: CatSuggestion[];
   intelligence: CatSegmentIntelligence;
+  segmentIntelligence?: Record<string, CatSegmentIntelligence>;
   jobTitle?: string;
   breadcrumbs?: string[];
   primaryActionLabel?: string;


### PR DESCRIPTION
## What changed

- Fixed CAT format checks so ICU/source parse issues do not incorrectly show as “No placeholders or ICU blocks detected.”
- Track format checks and decision context per segment, so selecting a Crowdin string shows the correct ICU status and Crowdin-provided string context.
- Added extra queue row gutter and inset selected ring styling so the selected row border is not clipped.

## How to test

- `vp test`
- `vp check --fix`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review