### PR TITLE
fix(chat): create new requests through conversations

### DIFF
--- a/apps/hyperlocalise-web/src/api/app.ts
+++ b/apps/hyperlocalise-web/src/api/app.ts
@@ -169,7 +169,10 @@ function createOrgScopedAppRoutes(
     .route("/files", createFileRoutes({ fileStorageAdapter: options.fileStorageAdapter }))
     .route("/workspace-files", createWorkspaceFilesRoutes())
     .route("/automations", createWorkspaceAutomationRoutes())
-    .route("/conversations", createConversationRoutes())
+    .route(
+      "/conversations",
+      createConversationRoutes({ fileStorageAdapter: options.fileStorageAdapter }),
+    )
     .route(
       "/chat-requests",
       createChatRequestRoutes({ fileStorageAdapter: options.fileStorageAdapter }),

--- a/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.test.ts
@@ -86,6 +86,7 @@ describe("conversation creation", () => {
 
   it("stores initial translation source files on the conversation message", async () => {
     const identity = createWorkosIdentity();
+    identity.organization.slug = "example org+東京";
     const headers = await authHeadersFor(identity);
     const formData = new FormData();
     formData.set("text", "Translate the attached file");
@@ -96,11 +97,14 @@ describe("conversation creation", () => {
       }),
     );
 
-    const response = await app.request(`/api/orgs/${identity.organization.slug}/conversations`, {
-      method: "POST",
-      headers,
-      body: formData,
-    });
+    const response = await app.request(
+      `/api/orgs/${encodeURIComponent(identity.organization.slug)}/conversations`,
+      {
+        method: "POST",
+        headers,
+        body: formData,
+      },
+    );
 
     expect(response.status).toBe(201);
     const body = (await response.json()) as {
@@ -124,6 +128,56 @@ describe("conversation creation", () => {
         id: body.files[0]!.id,
         filename: "source.json",
         contentType: "application/json",
+        url: `/api/orgs/${encodeURIComponent(identity.organization.slug)}/files/${body.files[0]!.id}`,
+      }),
+    ]);
+  });
+
+  it("stores reply attachment URLs with an encoded organization slug", async () => {
+    const identity = createWorkosIdentity();
+    identity.organization.slug = "example org+東京";
+    const headers = await authHeadersFor(identity);
+    const encodedOrganizationSlug = encodeURIComponent(identity.organization.slug);
+    const conversationFormData = new FormData();
+    conversationFormData.set("text", "Translate this first");
+
+    const conversationResponse = await app.request(
+      `/api/orgs/${encodedOrganizationSlug}/conversations`,
+      {
+        method: "POST",
+        headers,
+        body: conversationFormData,
+      },
+    );
+    expect(conversationResponse.status).toBe(201);
+    const conversationBody = (await conversationResponse.json()) as {
+      conversation: { id: string };
+    };
+    const replyFormData = new FormData();
+    replyFormData.set("text", "Here is another source file");
+    replyFormData.append(
+      "files",
+      new File([JSON.stringify({ goodbye: "Goodbye" })], "reply.json", {
+        type: "application/json",
+      }),
+    );
+
+    const replyResponse = await app.request(
+      `/api/orgs/${encodedOrganizationSlug}/conversations/${conversationBody.conversation.id}/messages`,
+      {
+        method: "POST",
+        headers,
+        body: replyFormData,
+      },
+    );
+
+    expect(replyResponse.status).toBe(201);
+    const replyBody = (await replyResponse.json()) as {
+      message: { attachments: Array<{ id: string; url: string }> };
+    };
+    expect(replyBody.message.attachments).toEqual([
+      expect.objectContaining({
+        url: `/api/orgs/${encodedOrganizationSlug}/files/${replyBody.message.attachments[0]!.id}`,
       }),
     ]);
   });

--- a/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.test.ts
@@ -18,12 +18,24 @@ const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
       null,
   ),
 }));
+const { createInteractionMock } = vi.hoisted(() => ({
+  createInteractionMock: vi.fn(),
+}));
 
 vi.mock("@/api/auth/workos-session", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/api/auth/workos-session")>();
   return {
     ...actual,
     resolveApiAuthContextFromSession: resolveApiAuthContextFromSessionMock,
+  };
+});
+
+vi.mock("@/lib/conversations/interactions", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/conversations/interactions")>();
+  createInteractionMock.mockImplementation(actual.createInteraction);
+  return {
+    ...actual,
+    createInteraction: createInteractionMock,
   };
 });
 
@@ -169,6 +181,50 @@ describe("conversation creation", () => {
     expect(conversations).toHaveLength(0);
     expect(inboxItems).toHaveLength(0);
     expect(storedFiles).toHaveLength(0);
+  });
+
+  it("cleans up initial uploads when conversation creation fails", async () => {
+    const adapter = createMemoryFileStorageAdapter();
+    const deleteFile = vi.spyOn(adapter, "delete");
+    const failingApp = createApp({ fileStorageAdapter: adapter });
+    const identity = createWorkosIdentity();
+    const headers = await authHeadersFor(identity);
+    const formData = new FormData();
+    formData.set("text", "Translate the attached file");
+    formData.append(
+      "files",
+      new File([JSON.stringify({ hello: "Hello" })], "source.json", {
+        type: "application/json",
+      }),
+    );
+
+    createInteractionMock.mockRejectedValueOnce(new Error("database unavailable"));
+
+    const response = await failingApp.request(
+      `/api/orgs/${identity.organization.slug}/conversations`,
+      {
+        method: "POST",
+        headers,
+        body: formData,
+      },
+    );
+
+    expect(response.status).toBe(500);
+
+    const organizationId = globalThis.__testApiAuthContext?.activeOrganization.localOrganizationId;
+    if (!organizationId) {
+      throw new Error("Expected test auth context to include an active organization");
+    }
+    const storedFiles = await db
+      .select()
+      .from(schema.storedFiles)
+      .where(eq(schema.storedFiles.organizationId, organizationId));
+
+    expect(storedFiles).toHaveLength(0);
+    expect(deleteFile).toHaveBeenCalledOnce();
+    const deletedFile = deleteFile.mock.calls[0]?.[0];
+    expect(deletedFile?.keyOrUrl).toBeTruthy();
+    await expect(adapter.get({ keyOrUrl: deletedFile?.keyOrUrl ?? "" })).resolves.toBeNull();
   });
 
   it("rejects conversations linked to another organization's project", async () => {

--- a/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.test.ts
@@ -1,0 +1,137 @@
+import "dotenv/config";
+
+import { eq } from "drizzle-orm";
+import { testClient } from "hono/testing";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
+
+import { createApp } from "@/api/app";
+import { db, schema } from "@/lib/database";
+import { createMemoryFileStorageAdapter } from "../file/file.fixture";
+import { createProjectTestFixture } from "../project/project.fixture";
+
+const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
+  resolveApiAuthContextFromSessionMock: vi.fn(
+    (options) =>
+      globalThis.__resolveTestApiAuthContextFromSession?.(options) ??
+      globalThis.__testApiAuthContext ??
+      null,
+  ),
+}));
+
+vi.mock("@/api/auth/workos-session", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/auth/workos-session")>();
+  return {
+    ...actual,
+    resolveApiAuthContextFromSession: resolveApiAuthContextFromSessionMock,
+  };
+});
+
+const app = createApp({ fileStorageAdapter: createMemoryFileStorageAdapter() });
+const client = testClient(app);
+const { authHeadersFor, cleanup, createProjectViaApi, createWorkosIdentity } =
+  createProjectTestFixture(client);
+
+beforeAll(async () => {
+  await db.$client.query("select 1");
+});
+
+afterEach(async () => {
+  vi.clearAllMocks();
+  await cleanup();
+});
+
+describe("conversation creation", () => {
+  it("creates a chat UI conversation with the initial user message", async () => {
+    const identity = createWorkosIdentity();
+    const projectResponse = await createProjectViaApi(identity);
+    const projectBody = (await projectResponse.json()) as { project: { id: string } };
+    const headers = await authHeadersFor(identity);
+    const formData = new FormData();
+    formData.set("text", "Translate this to fr-FR");
+    formData.set("projectId", projectBody.project.id);
+
+    const response = await app.request(`/api/orgs/${identity.organization.slug}/conversations`, {
+      method: "POST",
+      headers,
+      body: formData,
+    });
+
+    expect(response.status).toBe(201);
+    const body = (await response.json()) as {
+      conversation: { id: string; source: string; projectId: string };
+      message: { id: string; text: string; senderType: string };
+    };
+    expect(body.conversation).toMatchObject({
+      source: "chat_ui",
+      projectId: projectBody.project.id,
+    });
+    expect(body.message).toMatchObject({
+      text: "Translate this to fr-FR",
+      senderType: "user",
+    });
+  });
+
+  it("stores initial translation source files on the conversation message", async () => {
+    const identity = createWorkosIdentity();
+    const headers = await authHeadersFor(identity);
+    const formData = new FormData();
+    formData.set("text", "Translate the attached file");
+    formData.append(
+      "files",
+      new File([JSON.stringify({ hello: "Hello" })], "source.json", {
+        type: "application/json",
+      }),
+    );
+
+    const response = await app.request(`/api/orgs/${identity.organization.slug}/conversations`, {
+      method: "POST",
+      headers,
+      body: formData,
+    });
+
+    expect(response.status).toBe(201);
+    const body = (await response.json()) as {
+      conversation: { id: string };
+      files: Array<{ id: string; filename: string; sourceInteractionId: string }>;
+    };
+    expect(body.files).toHaveLength(1);
+    expect(body.files[0]).toMatchObject({
+      filename: "source.json",
+      sourceInteractionId: body.conversation.id,
+    });
+
+    const [message] = await db
+      .select()
+      .from(schema.interactionMessages)
+      .where(eq(schema.interactionMessages.interactionId, body.conversation.id))
+      .limit(1);
+
+    expect(message?.attachments).toEqual([
+      expect.objectContaining({
+        id: body.files[0]!.id,
+        filename: "source.json",
+        contentType: "application/json",
+      }),
+    ]);
+  });
+
+  it("rejects conversations linked to another organization's project", async () => {
+    const identity = createWorkosIdentity();
+    const otherIdentity = createWorkosIdentity();
+    const otherProjectResponse = await createProjectViaApi(otherIdentity);
+    const otherProjectBody = (await otherProjectResponse.json()) as { project: { id: string } };
+    const headers = await authHeadersFor(identity);
+    const formData = new FormData();
+    formData.set("text", "Translate this");
+    formData.set("projectId", otherProjectBody.project.id);
+
+    const response = await app.request(`/api/orgs/${identity.organization.slug}/conversations`, {
+      method: "POST",
+      headers,
+      body: formData,
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "project_not_found" });
+  });
+});

--- a/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
 
 import { createApp } from "@/api/app";
 import { db, schema } from "@/lib/database";
+import type { FileStorageAdapter } from "@/lib/file-storage";
 import { createMemoryFileStorageAdapter } from "../file/file.fixture";
 import { createProjectTestFixture } from "../project/project.fixture";
 
@@ -113,6 +114,61 @@ describe("conversation creation", () => {
         contentType: "application/json",
       }),
     ]);
+  });
+
+  it("does not leave an inbox conversation when initial file upload fails", async () => {
+    const failingAdapter: FileStorageAdapter = {
+      provider: "vercel_blob",
+      put: vi.fn(async () => {
+        throw new Error("storage unavailable");
+      }),
+      get: vi.fn(async () => null),
+      delete: vi.fn(async () => {}),
+      getSignedUrl: vi.fn(async () => "https://blob.example/signed"),
+    };
+    const failingApp = createApp({ fileStorageAdapter: failingAdapter });
+    const identity = createWorkosIdentity();
+    const headers = await authHeadersFor(identity);
+    const formData = new FormData();
+    formData.set("text", "Translate the attached file");
+    formData.append(
+      "files",
+      new File([JSON.stringify({ hello: "Hello" })], "source.json", {
+        type: "application/json",
+      }),
+    );
+
+    const response = await failingApp.request(
+      `/api/orgs/${identity.organization.slug}/conversations`,
+      {
+        method: "POST",
+        headers,
+        body: formData,
+      },
+    );
+
+    expect(response.status).toBe(500);
+
+    const organizationId = globalThis.__testApiAuthContext?.activeOrganization.localOrganizationId;
+    if (!organizationId) {
+      throw new Error("Expected test auth context to include an active organization");
+    }
+    const conversations = await db
+      .select()
+      .from(schema.interactions)
+      .where(eq(schema.interactions.organizationId, organizationId));
+    const inboxItems = await db
+      .select()
+      .from(schema.inboxItems)
+      .where(eq(schema.inboxItems.organizationId, organizationId));
+    const storedFiles = await db
+      .select()
+      .from(schema.storedFiles)
+      .where(eq(schema.storedFiles.organizationId, organizationId));
+
+    expect(conversations).toHaveLength(0);
+    expect(inboxItems).toHaveLength(0);
+    expect(storedFiles).toHaveLength(0);
   });
 
   it("rejects conversations linked to another organization's project", async () => {

--- a/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.ts
@@ -313,8 +313,12 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
             })),
           });
         } catch (error) {
-          await cleanupStoredFiles(storedFiles, adapter);
-          await db.delete(schema.interactions).where(eq(schema.interactions.id, conversation.id));
+          try {
+            await cleanupStoredFiles(storedFiles, adapter);
+            await db.delete(schema.interactions).where(eq(schema.interactions.id, conversation.id));
+          } catch {
+            // Best-effort cleanup; do not mask the original error.
+          }
           throw error;
         }
 

--- a/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.ts
@@ -6,6 +6,7 @@ import { validator } from "hono/validator";
 import { buildAccessibleInteractionsWhere, canAccessInteraction } from "@/api/auth/team-access";
 import type { AuthVariables } from "@/api/auth/workos";
 import { workosAuthMiddleware } from "@/api/auth/workos";
+import { badRequestResponse } from "@/api/response.schema";
 import { normalizeProjectId } from "@/lib/projects/project-id";
 import { db, schema } from "@/lib/database";
 import type { FileStorageAdapter } from "@/lib/file-storage";
@@ -29,12 +30,10 @@ function notFoundResponse(c: { json(body: { error: string }, status: 404): Respo
   return c.json({ error: "not_found" }, 404);
 }
 
-function badRequestResponse(c: { json(body: { error: string }, status: 400): Response }) {
+function invalidMessagePayloadResponse(c: {
+  json(body: { error: string }, status: 400): Response;
+}) {
   return c.json({ error: "invalid_message_payload" }, 400);
-}
-
-function invalidConversationResponse(c: { json(body: { error: string }, status: 400): Response }) {
-  return c.json({ error: "invalid_conversation_payload" }, 400);
 }
 
 async function cleanupStoredFiles(
@@ -60,15 +59,6 @@ function tooManyFilesResponse(c: {
   json(body: { error: string; maxFiles: number }, status: 400): Response;
 }) {
   return c.json({ error: "too_many_files", maxFiles: maxMessageUploadFiles }, 400);
-}
-
-function unsupportedTranslationSourceFileResponse(
-  c: {
-    json(body: { error: string; filename: string }, status: 400): Response;
-  },
-  filename: string,
-) {
-  return c.json({ error: "unsupported_translation_source_file", filename }, 400);
 }
 
 const validateConversationParams = validator("param", (value, c) => {
@@ -216,12 +206,12 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
         });
 
         if (!parsed.success) {
-          return invalidConversationResponse(c);
+          return badRequestResponse(c, "invalid_conversation_payload");
         }
 
         const files = asFiles(body.files);
         if (!parsed.data.text && files.length === 0) {
-          return invalidConversationResponse(c);
+          return badRequestResponse(c, "invalid_conversation_payload");
         }
         const messageText = parsed.data.text || "Please translate the attached source file.";
 
@@ -231,7 +221,9 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
 
         for (const file of files) {
           if (!inferSupportedFileTranslationFileFormat(file.name)) {
-            return unsupportedTranslationSourceFileResponse(c, file.name);
+            return badRequestResponse(c, "unsupported_translation_source_file", undefined, {
+              filename: file.name,
+            });
           }
         }
 
@@ -386,7 +378,7 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
           typeof normalizedProjectId === "string" ? normalizedProjectId : undefined;
 
         if (!text.trim() && files.length === 0) {
-          return badRequestResponse(c);
+          return invalidMessagePayloadResponse(c);
         }
 
         if (files.length > maxMessageUploadFiles) {

--- a/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.ts
@@ -273,19 +273,22 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
             : new Error("failed to store uploaded file");
         }
 
-        const conversation = await createInteraction({
-          organizationId: orgId,
-          source: "chat_ui",
-          title: messageText.slice(0, 120),
-          projectId,
-        });
+        let conversation: Awaited<ReturnType<typeof createInteraction>> | undefined;
         let responseFiles = storedFiles;
         let message;
         try {
+          const createdConversation = await createInteraction({
+            organizationId: orgId,
+            source: "chat_ui",
+            title: messageText.slice(0, 120),
+            projectId,
+          });
+          conversation = createdConversation;
+
           if (storedFiles.length > 0) {
             await db
               .update(schema.storedFiles)
-              .set({ sourceInteractionId: conversation.id })
+              .set({ sourceInteractionId: createdConversation.id })
               .where(
                 inArray(
                   schema.storedFiles.id,
@@ -294,12 +297,12 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
               );
             responseFiles = storedFiles.map((file) => ({
               ...file,
-              sourceInteractionId: conversation.id,
+              sourceInteractionId: createdConversation.id,
             }));
           }
 
           message = await addInteractionMessage({
-            interactionId: conversation.id,
+            interactionId: createdConversation.id,
             senderType: "user",
             senderEmail: c.var.auth.user.email,
             text: messageText,
@@ -315,7 +318,11 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
         } catch (error) {
           try {
             await cleanupStoredFiles(storedFiles, adapter);
-            await db.delete(schema.interactions).where(eq(schema.interactions.id, conversation.id));
+            if (conversation) {
+              await db
+                .delete(schema.interactions)
+                .where(eq(schema.interactions.id, conversation.id));
+            }
           } catch {
             // Best-effort cleanup; do not mask the original error.
           }

--- a/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.ts
@@ -247,12 +247,6 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
         }
 
         const orgId = c.var.auth.activeOrganization.localOrganizationId;
-        const conversation = await createInteraction({
-          organizationId: orgId,
-          source: "chat_ui",
-          title: messageText.slice(0, 120),
-          projectId,
-        });
         const adapter = options.fileStorageAdapter ?? getFileStorageAdapter();
         const organizationSlug = c.var.auth.activeOrganization.slug ?? "";
 
@@ -264,7 +258,6 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
               createdByUserId: c.var.auth.user.localUserId,
               role: "source",
               sourceKind: "chat_upload",
-              sourceInteractionId: conversation.id,
               filename: file.name,
               contentType: file.type || "application/octet-stream",
               content: await file.arrayBuffer(),
@@ -288,8 +281,31 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
             : new Error("failed to store uploaded file");
         }
 
+        const conversation = await createInteraction({
+          organizationId: orgId,
+          source: "chat_ui",
+          title: messageText.slice(0, 120),
+          projectId,
+        });
+        let responseFiles = storedFiles;
         let message;
         try {
+          if (storedFiles.length > 0) {
+            await db
+              .update(schema.storedFiles)
+              .set({ sourceInteractionId: conversation.id })
+              .where(
+                inArray(
+                  schema.storedFiles.id,
+                  storedFiles.map((file) => file.id),
+                ),
+              );
+            responseFiles = storedFiles.map((file) => ({
+              ...file,
+              sourceInteractionId: conversation.id,
+            }));
+          }
+
           message = await addInteractionMessage({
             interactionId: conversation.id,
             senderType: "user",
@@ -306,10 +322,11 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
           });
         } catch (error) {
           await cleanupStoredFiles(storedFiles, adapter);
+          await db.delete(schema.interactions).where(eq(schema.interactions.id, conversation.id));
           throw error;
         }
 
-        return c.json({ conversation, message, files: storedFiles }, 201);
+        return c.json({ conversation, message, files: responseFiles }, 201);
       },
     )
     .get("/:conversationId", validateConversationParams, async (c) => {

--- a/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.ts
@@ -12,10 +12,15 @@ import type { FileStorageAdapter } from "@/lib/file-storage";
 import { getFileStorageAdapter } from "@/lib/file-storage";
 import { createStoredFile } from "@/lib/file-storage/records";
 import { getOwnedProject } from "@/api/routes/project/project.shared";
-import { addInteractionMessage } from "@/lib/conversations/interactions";
+import { addInteractionMessage, createInteraction } from "@/lib/conversations/interactions";
+import { inferSupportedFileTranslationFileFormat } from "@/lib/translation/file-formats";
 
 import { createChatStreamRoutes } from "./chat-stream.route";
-import { conversationIdParamsSchema, listConversationsQuerySchema } from "./conversation.schema";
+import {
+  conversationIdParamsSchema,
+  createConversationRequestSchema,
+  listConversationsQuerySchema,
+} from "./conversation.schema";
 
 const maxMessageUploadBytes = 25 * 1024 * 1024;
 const maxMessageUploadFiles = 5;
@@ -26,6 +31,10 @@ function notFoundResponse(c: { json(body: { error: string }, status: 404): Respo
 
 function badRequestResponse(c: { json(body: { error: string }, status: 400): Response }) {
   return c.json({ error: "invalid_message_payload" }, 400);
+}
+
+function invalidConversationResponse(c: { json(body: { error: string }, status: 400): Response }) {
+  return c.json({ error: "invalid_conversation_payload" }, 400);
 }
 
 async function cleanupStoredFiles(
@@ -51,6 +60,15 @@ function tooManyFilesResponse(c: {
   json(body: { error: string; maxFiles: number }, status: 400): Response;
 }) {
   return c.json({ error: "too_many_files", maxFiles: maxMessageUploadFiles }, 400);
+}
+
+function unsupportedTranslationSourceFileResponse(
+  c: {
+    json(body: { error: string; filename: string }, status: 400): Response;
+  },
+  filename: string,
+) {
+  return c.json({ error: "unsupported_translation_source_file", filename }, 400);
 }
 
 const validateConversationParams = validator("param", (value, c) => {
@@ -184,6 +202,116 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
         200,
       );
     })
+    .post(
+      "/",
+      bodyLimit({
+        maxSize: maxMessageUploadBytes,
+        onError: (c) => c.json({ error: "upload_too_large" }, 413),
+      }),
+      async (c) => {
+        const body = await c.req.parseBody({ all: true });
+        const parsed = createConversationRequestSchema.safeParse({
+          text: asString(body.text),
+          projectId: asString(body.projectId),
+        });
+
+        if (!parsed.success) {
+          return invalidConversationResponse(c);
+        }
+
+        const files = asFiles(body.files);
+        if (!parsed.data.text && files.length === 0) {
+          return invalidConversationResponse(c);
+        }
+        const messageText = parsed.data.text || "Please translate the attached source file.";
+
+        if (files.length > maxMessageUploadFiles) {
+          return tooManyFilesResponse(c);
+        }
+
+        for (const file of files) {
+          if (!inferSupportedFileTranslationFileFormat(file.name)) {
+            return unsupportedTranslationSourceFileResponse(c, file.name);
+          }
+        }
+
+        const projectId = parsed.data.projectId
+          ? normalizeProjectId(parsed.data.projectId)
+          : undefined;
+
+        if (projectId) {
+          const project = await getOwnedProject(c.var.auth, projectId);
+          if (!project) {
+            return c.json({ error: "project_not_found" }, 400);
+          }
+        }
+
+        const orgId = c.var.auth.activeOrganization.localOrganizationId;
+        const conversation = await createInteraction({
+          organizationId: orgId,
+          source: "chat_ui",
+          title: messageText.slice(0, 120),
+          projectId,
+        });
+        const adapter = options.fileStorageAdapter ?? getFileStorageAdapter();
+        const organizationSlug = c.var.auth.activeOrganization.slug ?? "";
+
+        const uploadResults = await Promise.allSettled(
+          files.map(async (file) =>
+            createStoredFile({
+              organizationId: orgId,
+              projectId,
+              createdByUserId: c.var.auth.user.localUserId,
+              role: "source",
+              sourceKind: "chat_upload",
+              sourceInteractionId: conversation.id,
+              filename: file.name,
+              contentType: file.type || "application/octet-stream",
+              content: await file.arrayBuffer(),
+              metadata: {
+                uploadSurface: "chat",
+                translationSource: true,
+              },
+              adapter,
+            }),
+          ),
+        );
+        const storedFiles = uploadResults
+          .filter((result) => result.status === "fulfilled")
+          .map((result) => result.value);
+        const failedUpload = uploadResults.find((result) => result.status === "rejected");
+
+        if (failedUpload) {
+          await cleanupStoredFiles(storedFiles, adapter);
+          throw failedUpload.reason instanceof Error
+            ? failedUpload.reason
+            : new Error("failed to store uploaded file");
+        }
+
+        let message;
+        try {
+          message = await addInteractionMessage({
+            interactionId: conversation.id,
+            senderType: "user",
+            senderEmail: c.var.auth.user.email,
+            text: messageText,
+            attachments: storedFiles.map((file) => ({
+              id: file.id,
+              filename: file.filename,
+              contentType: file.contentType,
+              url: organizationSlug
+                ? `/api/orgs/${organizationSlug}/files/${file.id}`
+                : (file.downloadUrl ?? file.storageUrl),
+            })),
+          });
+        } catch (error) {
+          await cleanupStoredFiles(storedFiles, adapter);
+          throw error;
+        }
+
+        return c.json({ conversation, message, files: storedFiles }, 201);
+      },
+    )
     .get("/:conversationId", validateConversationParams, async (c) => {
       const { conversationId } = c.req.valid("param");
 

--- a/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/conversation.route.ts
@@ -61,6 +61,10 @@ function tooManyFilesResponse(c: {
   return c.json({ error: "too_many_files", maxFiles: maxMessageUploadFiles }, 400);
 }
 
+function buildOrganizationFileUrl(organizationSlug: string, fileId: string) {
+  return `/api/orgs/${encodeURIComponent(organizationSlug)}/files/${fileId}`;
+}
+
 const validateConversationParams = validator("param", (value, c) => {
   const parsed = conversationIdParamsSchema.safeParse(value);
   if (!parsed.success) {
@@ -311,7 +315,7 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
               filename: file.filename,
               contentType: file.contentType,
               url: organizationSlug
-                ? `/api/orgs/${organizationSlug}/files/${file.id}`
+                ? buildOrganizationFileUrl(organizationSlug, file.id)
                 : (file.downloadUrl ?? file.storageUrl),
             })),
           });
@@ -468,7 +472,7 @@ export function createConversationRoutes(options: CreateConversationRoutesOption
               filename: file.filename,
               contentType: file.contentType,
               url: organizationSlug
-                ? `/api/orgs/${organizationSlug}/files/${file.id}`
+                ? buildOrganizationFileUrl(organizationSlug, file.id)
                 : (file.downloadUrl ?? file.storageUrl),
             })),
           });

--- a/apps/hyperlocalise-web/src/api/routes/conversation/conversation.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/conversation.schema.ts
@@ -1,7 +1,14 @@
 import { z } from "zod";
 
+import { optionalProjectIdSchema } from "@/lib/projects/project-id";
+
 export const conversationIdParamsSchema = z.object({
   conversationId: z.uuid(),
+});
+
+export const createConversationRequestSchema = z.object({
+  text: z.string().trim().max(10000).default(""),
+  projectId: optionalProjectIdSchema,
 });
 
 export const listConversationsQuerySchema = z.object({

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/chat/_components/chat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/chat/_components/chat-page-content.tsx
@@ -117,35 +117,24 @@ export function ChatPageContent({ organizationSlug }: { organizationSlug: string
     projects.find((project) => project.id === selectedProjectId) ?? projects[0] ?? null;
   const projectTriggerLabel = selectedProject?.name ?? "Project";
 
-  const chatRequestMutation = useMutation({
+  const createConversationMutation = useMutation({
     mutationFn: async () => {
-      if (files.length > 0) {
-        const formData = new FormData();
-        formData.set("text", text.trim() || "Please translate the attached source file.");
-        if (selectedProject?.id) {
-          formData.set("projectId", selectedProject.id);
-        }
-        for (const file of files) {
-          formData.append("files", file);
-        }
-
-        const response = await fetch(`/api/orgs/${organizationSlug}/chat-requests/upload`, {
-          method: "POST",
-          body: formData,
-        });
-        if (!response.ok) {
-          throw new Error(`Failed to send request (${response.status})`);
-        }
-        return response.json() as Promise<{ conversation: { id: string } }>;
+      const formData = new FormData();
+      formData.set("text", text.trim() || "Please translate the attached source file.");
+      if (selectedProject?.id) {
+        formData.set("projectId", selectedProject.id);
+      }
+      for (const file of files) {
+        formData.append("files", file);
       }
 
-      const response = await apiClient.api.orgs[":organizationSlug"]["chat-requests"].$post({
-        param: { organizationSlug },
-        json: {
-          text,
-          projectId: selectedProject?.id,
+      const response = await fetch(
+        `/api/orgs/${encodeURIComponent(organizationSlug)}/conversations`,
+        {
+          method: "POST",
+          body: formData,
         },
-      });
+      );
       if (!response.ok) {
         throw new Error(`Failed to send request (${response.status})`);
       }
@@ -155,7 +144,8 @@ export function ChatPageContent({ organizationSlug }: { organizationSlug: string
       router.push(`/org/${organizationSlug}/inbox/${data.conversation.id}`);
     },
   });
-  const canSubmit = Boolean(text.trim() || files.length > 0) && !chatRequestMutation.isPending;
+  const canSubmit =
+    Boolean(text.trim() || files.length > 0) && !createConversationMutation.isPending;
 
   return (
     <main className="mx-auto flex min-h-[calc(100svh-7rem)] w-full max-w-6xl flex-col items-center justify-center px-4 py-8 sm:px-6">
@@ -170,7 +160,7 @@ export function ChatPageContent({ organizationSlug }: { organizationSlug: string
           onSubmit={(e) => {
             e.preventDefault();
             if (canSubmit) {
-              chatRequestMutation.mutate();
+              createConversationMutation.mutate();
             }
           }}
           className="overflow-hidden rounded-[1.35rem] bg-muted text-foreground shadow-2xl shadow-black/10 transition-all focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/50"
@@ -186,7 +176,7 @@ export function ChatPageContent({ organizationSlug }: { organizationSlug: string
               if (e.key === "Enter" && !e.shiftKey) {
                 e.preventDefault();
                 if (canSubmit) {
-                  chatRequestMutation.mutate();
+                  createConversationMutation.mutate();
                 }
               }
             }}
@@ -365,7 +355,7 @@ export function ChatPageContent({ organizationSlug }: { organizationSlug: string
                       className="rounded-full bg-primary text-primary-foreground hover:bg-primary/90"
                       aria-label="Send translation request"
                     >
-                      {chatRequestMutation.isPending ? (
+                      {createConversationMutation.isPending ? (
                         <Spinner className="text-primary-foreground" />
                       ) : (
                         <HugeiconsIcon icon={SentIcon} strokeWidth={2} />

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-message-list.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-message-list.tsx
@@ -8,6 +8,7 @@ import type {
   ToolUIPart,
   UIMessage,
 } from "ai";
+import { DownloadIcon, FileTextIcon } from "lucide-react";
 import { memo, type ReactNode } from "react";
 
 import {
@@ -34,6 +35,7 @@ import {
   formatRelativeTime,
   initialsFor,
   type ConversationMessage,
+  type ConversationMessageAttachment,
   type InboxCurrentUser,
   type StreamedAssistantMessage,
 } from "./inbox-types";
@@ -147,14 +149,70 @@ const PersistedMessage = memo(function PersistedMessage({
       avatarLabel={userAvatar?.label}
       createdAt={message.createdAt}
     >
-      {message.senderType === "user" ? (
-        <TypographyP className="whitespace-pre-wrap leading-6">{message.text}</TypographyP>
-      ) : (
-        <MessageResponse>{message.text}</MessageResponse>
-      )}
+      <div className="flex flex-col gap-3">
+        {message.senderType === "user" ? (
+          <TypographyP className="whitespace-pre-wrap leading-6">{message.text}</TypographyP>
+        ) : (
+          <MessageResponse>{message.text}</MessageResponse>
+        )}
+        <MessageAttachments attachments={message.attachments} />
+      </div>
     </MessageFrame>
   );
 });
+
+function MessageAttachments({ attachments }: { attachments: ConversationMessage["attachments"] }) {
+  if (!attachments?.length) {
+    return null;
+  }
+
+  const imageAttachments = attachments.filter(isImageAttachment);
+  const fileAttachments = attachments.filter((attachment) => !isImageAttachment(attachment));
+
+  return (
+    <div className="flex max-w-full flex-col gap-2">
+      {imageAttachments.length > 0 ? (
+        <div className="grid max-w-full grid-cols-1 gap-2 sm:grid-cols-2">
+          {imageAttachments.map((attachment) => (
+            <a
+              key={attachment.id}
+              href={attachment.url}
+              target="_blank"
+              rel="noreferrer"
+              className="group overflow-hidden rounded-md border border-border bg-muted/35"
+            >
+              <img
+                src={attachment.url}
+                alt={attachment.filename}
+                className="aspect-video w-full object-contain"
+              />
+              <span className="block truncate border-t border-border px-2 py-1.5 text-xs text-muted-foreground group-hover:text-foreground">
+                {attachment.filename}
+              </span>
+            </a>
+          ))}
+        </div>
+      ) : null}
+      {fileAttachments.map((attachment) => (
+        <a
+          key={attachment.id}
+          href={attachment.url}
+          target="_blank"
+          rel="noreferrer"
+          className="flex max-w-full items-center gap-2 rounded-md border border-border bg-muted/35 px-3 py-2 text-sm text-foreground hover:bg-muted"
+        >
+          <FileTextIcon className="size-4 shrink-0 text-muted-foreground" />
+          <span className="min-w-0 flex-1 truncate">{attachment.filename}</span>
+          <DownloadIcon className="size-4 shrink-0 text-muted-foreground" />
+        </a>
+      ))}
+    </div>
+  );
+}
+
+function isImageAttachment(attachment: ConversationMessageAttachment) {
+  return attachment.contentType.toLowerCase().startsWith("image/");
+}
 
 function AssistantStreamMessage({
   createdAt,

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-types.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-types.ts
@@ -16,13 +16,20 @@ export type Conversation = {
   } | null;
 };
 
+export type ConversationMessageAttachment = {
+  id: string;
+  filename: string;
+  contentType: string;
+  url: string;
+};
+
 export type ConversationMessage = {
   id: string;
   conversationId: string;
   senderType: "user" | "agent";
   senderEmail: string | null;
   text: string;
-  attachments: Array<{ id: string; filename: string; contentType: string; url: string }> | null;
+  attachments: ConversationMessageAttachment[] | null;
   createdAt: string;
 };
 

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/runs/agent-run-events.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/runs/agent-run-events.test.ts
@@ -1,8 +1,34 @@
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import type { Thread } from "chat";
 
+const { createStoredFileMock, whereMock } = vi.hoisted(() => ({
+  createStoredFileMock: vi.fn(),
+  whereMock: vi.fn(),
+}));
+
 vi.mock("@/lib/conversations/interactions", () => ({
   addInteractionMessage: vi.fn(),
+}));
+
+vi.mock("@/lib/database", () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: whereMock,
+      })),
+    })),
+  },
+  schema: {
+    interactions: {
+      id: "interaction_id",
+      organizationId: "organization_id",
+      projectId: "project_id",
+    },
+  },
+}));
+
+vi.mock("@/lib/file-storage/records", () => ({
+  createStoredFile: createStoredFileMock,
 }));
 
 import { postThreadMessageWithoutTracking, wrapThreadPostForInteraction } from "./agent-run-events";
@@ -22,6 +48,21 @@ function createThread() {
 describe("wrapThreadPostForInteraction", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    whereMock.mockReturnValue({
+      limit: vi.fn(async () => [
+        {
+          organizationId: "org_123",
+          projectId: "project_123",
+        },
+      ]),
+    });
+    createStoredFileMock.mockResolvedValue({
+      id: "file_123",
+      filename: "banner-fr.webp",
+      contentType: "image/webp",
+      storageUrl: "https://files.example/banner-fr.webp",
+      downloadUrl: "https://files.example/banner-fr.webp?download=1",
+    });
   });
 
   it("persists string agent posts", async () => {
@@ -73,6 +114,47 @@ describe("wrapThreadPostForInteraction", () => {
       interactionId: "interaction_123",
       senderType: "agent",
       text: "Agent reply",
+    });
+  });
+
+  it("persists posted files as agent message attachments", async () => {
+    const addMessage = vi.fn(async () => ({ id: "msg_123" }));
+    const { thread } = createThread();
+    const imageData = Buffer.from("image");
+
+    wrapThreadPostForInteraction(thread, "interaction_123", addMessage);
+    await thread.post({
+      raw: "Here is the localized image",
+      files: [{ data: imageData, filename: "banner-fr.webp", mimeType: "image/webp" }],
+    });
+
+    expect(createStoredFileMock).toHaveBeenCalledWith({
+      organizationId: "org_123",
+      projectId: "project_123",
+      createdByUserId: null,
+      role: "output",
+      sourceKind: "chat_upload",
+      sourceInteractionId: "interaction_123",
+      filename: "banner-fr.webp",
+      contentType: "image/webp",
+      content: imageData,
+      metadata: {
+        uploadSurface: "agent_post",
+        chatPostFile: true,
+      },
+    });
+    expect(addMessage).toHaveBeenCalledWith({
+      attachments: [
+        {
+          id: "file_123",
+          filename: "banner-fr.webp",
+          contentType: "image/webp",
+          url: "https://files.example/banner-fr.webp?download=1",
+        },
+      ],
+      interactionId: "interaction_123",
+      senderType: "agent",
+      text: "Here is the localized image",
     });
   });
 

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/runs/agent-run-events.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/runs/agent-run-events.test.ts
@@ -1,11 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import type { Thread } from "chat";
 
-const { createStoredFileMock, deleteStoredObjectMock, whereMock } = vi.hoisted(() => ({
-  createStoredFileMock: vi.fn(),
-  deleteStoredObjectMock: vi.fn(),
-  whereMock: vi.fn(),
-}));
+const { createStoredFileMock, deleteStoredObjectMock, loggerWarnMock, whereMock } = vi.hoisted(
+  () => ({
+    createStoredFileMock: vi.fn(),
+    deleteStoredObjectMock: vi.fn(),
+    loggerWarnMock: vi.fn(),
+    whereMock: vi.fn(),
+  }),
+);
 
 vi.mock("@/lib/conversations/interactions", () => ({
   addInteractionMessage: vi.fn(),
@@ -42,6 +45,19 @@ vi.mock("@/lib/file-storage", () => ({
 
 vi.mock("@/lib/file-storage/records", () => ({
   createStoredFile: createStoredFileMock,
+}));
+
+vi.mock("@/lib/log", () => ({
+  createLogger: vi.fn(() => ({
+    child: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: loggerWarnMock,
+  })),
+  serializeErrorForLog: vi.fn((error: unknown) => ({
+    message: error instanceof Error ? error.message : String(error),
+  })),
 }));
 
 import { postThreadMessageWithoutTracking, wrapThreadPostForInteraction } from "./agent-run-events";
@@ -205,6 +221,29 @@ describe("wrapThreadPostForInteraction", () => {
       senderType: "agent",
       text: "Here are the localized images",
     });
+  });
+
+  it("logs when a files-only agent post cannot persist uploaded files", async () => {
+    const addMessage = vi.fn(async () => ({ id: "msg_123" }));
+    const { thread } = createThread();
+    const uploadError = new Error("storage unavailable");
+    createStoredFileMock.mockRejectedValueOnce(uploadError);
+
+    wrapThreadPostForInteraction(thread, "interaction_123", addMessage);
+    await thread.post({
+      files: [{ data: Buffer.from("image"), filename: "banner-fr.webp", mimeType: "image/webp" }],
+      raw: "",
+    });
+
+    expect(addMessage).not.toHaveBeenCalled();
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      {
+        err: { message: "storage unavailable" },
+        fileCount: 1,
+        interactionId: "interaction_123",
+      },
+      "agent post file persistence failed",
+    );
   });
 
   it("posts without persisting when tracking is enabled", async () => {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/runs/agent-run-events.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/runs/agent-run-events.test.ts
@@ -1,8 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import type { Thread } from "chat";
 
-const { createStoredFileMock, whereMock } = vi.hoisted(() => ({
+const { createStoredFileMock, deleteStoredObjectMock, whereMock } = vi.hoisted(() => ({
   createStoredFileMock: vi.fn(),
+  deleteStoredObjectMock: vi.fn(),
   whereMock: vi.fn(),
 }));
 
@@ -12,6 +13,9 @@ vi.mock("@/lib/conversations/interactions", () => ({
 
 vi.mock("@/lib/database", () => ({
   db: {
+    delete: vi.fn(() => ({
+      where: vi.fn(async () => {}),
+    })),
     select: vi.fn(() => ({
       from: vi.fn(() => ({
         where: whereMock,
@@ -24,7 +28,16 @@ vi.mock("@/lib/database", () => ({
       organizationId: "organization_id",
       projectId: "project_id",
     },
+    storedFiles: {
+      id: "stored_file_id",
+    },
   },
+}));
+
+vi.mock("@/lib/file-storage", () => ({
+  getFileStorageAdapter: vi.fn(() => ({
+    delete: deleteStoredObjectMock,
+  })),
 }));
 
 vi.mock("@/lib/file-storage/records", () => ({
@@ -60,9 +73,11 @@ describe("wrapThreadPostForInteraction", () => {
       id: "file_123",
       filename: "banner-fr.webp",
       contentType: "image/webp",
+      storageKey: "stored/banner-fr.webp",
       storageUrl: "https://files.example/banner-fr.webp",
       downloadUrl: "https://files.example/banner-fr.webp?download=1",
     });
+    deleteStoredObjectMock.mockResolvedValue(undefined);
   });
 
   it("persists string agent posts", async () => {
@@ -155,6 +170,40 @@ describe("wrapThreadPostForInteraction", () => {
       interactionId: "interaction_123",
       senderType: "agent",
       text: "Here is the localized image",
+    });
+  });
+
+  it("cleans up persisted files when a later agent post file upload fails", async () => {
+    const addMessage = vi.fn(async () => ({ id: "msg_123" }));
+    const { thread } = createThread();
+    const uploadError = new Error("storage unavailable");
+    createStoredFileMock
+      .mockResolvedValueOnce({
+        id: "file_uploaded",
+        filename: "banner-fr.webp",
+        contentType: "image/webp",
+        storageKey: "stored/banner-fr.webp",
+        storageUrl: "https://files.example/banner-fr.webp",
+        downloadUrl: "https://files.example/banner-fr.webp?download=1",
+      })
+      .mockRejectedValueOnce(uploadError);
+
+    wrapThreadPostForInteraction(thread, "interaction_123", addMessage);
+    await thread.post({
+      raw: "Here are the localized images",
+      files: [
+        { data: Buffer.from("image"), filename: "banner-fr.webp", mimeType: "image/webp" },
+        { data: Buffer.from("image"), filename: "banner-es.webp", mimeType: "image/webp" },
+      ],
+    });
+
+    expect(deleteStoredObjectMock).toHaveBeenCalledWith({
+      keyOrUrl: "stored/banner-fr.webp",
+    });
+    expect(addMessage).toHaveBeenCalledWith({
+      interactionId: "interaction_123",
+      senderType: "agent",
+      text: "Here are the localized images",
     });
   });
 

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/runs/agent-run-events.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/runs/agent-run-events.ts
@@ -1,8 +1,9 @@
 import type { Thread } from "chat";
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 
 import { addInteractionMessage } from "@/lib/conversations/interactions";
 import { db, schema } from "@/lib/database";
+import { getFileStorageAdapter } from "@/lib/file-storage";
 import { createStoredFile } from "@/lib/file-storage/records";
 
 type AddAgentMessage = (input: {
@@ -87,7 +88,7 @@ async function persistPostFiles(interactionId: string, files: PostableFile[]) {
     return [];
   }
 
-  const storedFiles = await Promise.all(
+  const uploadResults = await Promise.allSettled(
     files.map(async (file) =>
       createStoredFile({
         organizationId: interaction.organizationId,
@@ -106,6 +107,17 @@ async function persistPostFiles(interactionId: string, files: PostableFile[]) {
       }),
     ),
   );
+  const storedFiles = uploadResults
+    .filter((result) => result.status === "fulfilled")
+    .map((result) => result.value);
+  const failedUpload = uploadResults.find((result) => result.status === "rejected");
+
+  if (failedUpload) {
+    await cleanupStoredFiles(storedFiles);
+    throw failedUpload.reason instanceof Error
+      ? failedUpload.reason
+      : new Error("failed to store agent post file");
+  }
 
   return storedFiles.map((file) => ({
     id: file.id,
@@ -113,6 +125,23 @@ async function persistPostFiles(interactionId: string, files: PostableFile[]) {
     contentType: file.contentType,
     url: file.downloadUrl ?? file.storageUrl,
   }));
+}
+
+async function cleanupStoredFiles(storedFiles: Array<typeof schema.storedFiles.$inferSelect>) {
+  if (storedFiles.length === 0) {
+    return;
+  }
+
+  await db.delete(schema.storedFiles).where(
+    inArray(
+      schema.storedFiles.id,
+      storedFiles.map((file) => file.id),
+    ),
+  );
+  const adapter = getFileStorageAdapter();
+  await Promise.allSettled(
+    storedFiles.map((file) => adapter.delete({ keyOrUrl: file.storageKey })),
+  );
 }
 
 export function wrapThreadPostForInteraction<TState>(

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/runs/agent-run-events.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/runs/agent-run-events.ts
@@ -1,12 +1,22 @@
 import type { Thread } from "chat";
+import { eq } from "drizzle-orm";
 
 import { addInteractionMessage } from "@/lib/conversations/interactions";
+import { db, schema } from "@/lib/database";
+import { createStoredFile } from "@/lib/file-storage/records";
 
 type AddAgentMessage = (input: {
+  attachments?: Array<{ id: string; filename: string; contentType: string; url: string }>;
   interactionId: string;
   senderType: "agent";
   text: string;
 }) => Promise<unknown>;
+
+type PostableFile = {
+  data: ArrayBuffer | Blob | Buffer;
+  filename: string;
+  mimeType?: string;
+};
 
 type TrackedPostState = {
   addMessage: AddAgentMessage;
@@ -39,6 +49,72 @@ function getPostText(content: unknown) {
   return "";
 }
 
+function getPostFiles(content: unknown): PostableFile[] {
+  if (typeof content !== "object" || content === null || !("files" in content)) {
+    return [];
+  }
+
+  const files = (content as { files?: unknown }).files;
+  if (!Array.isArray(files)) {
+    return [];
+  }
+
+  return files.filter((file): file is PostableFile => {
+    if (typeof file !== "object" || file === null) {
+      return false;
+    }
+
+    const candidate = file as Partial<PostableFile>;
+    return Boolean(candidate.data) && typeof candidate.filename === "string";
+  });
+}
+
+async function persistPostFiles(interactionId: string, files: PostableFile[]) {
+  if (files.length === 0) {
+    return [];
+  }
+
+  const [interaction] = await db
+    .select({
+      organizationId: schema.interactions.organizationId,
+      projectId: schema.interactions.projectId,
+    })
+    .from(schema.interactions)
+    .where(eq(schema.interactions.id, interactionId))
+    .limit(1);
+
+  if (!interaction) {
+    return [];
+  }
+
+  const storedFiles = await Promise.all(
+    files.map(async (file) =>
+      createStoredFile({
+        organizationId: interaction.organizationId,
+        projectId: interaction.projectId,
+        createdByUserId: null,
+        role: "output",
+        sourceKind: "chat_upload",
+        sourceInteractionId: interactionId,
+        filename: file.filename,
+        contentType: file.mimeType || "application/octet-stream",
+        content: file.data instanceof Blob ? await file.data.arrayBuffer() : file.data,
+        metadata: {
+          uploadSurface: "agent_post",
+          chatPostFile: true,
+        },
+      }),
+    ),
+  );
+
+  return storedFiles.map((file) => ({
+    id: file.id,
+    filename: file.filename,
+    contentType: file.contentType,
+    url: file.downloadUrl ?? file.storageUrl,
+  }));
+}
+
 export function wrapThreadPostForInteraction<TState>(
   thread: Thread<TState>,
   interactionId: string,
@@ -60,8 +136,13 @@ export function wrapThreadPostForInteraction<TState>(
 
     try {
       const text = getPostText(args[0]);
-      if (text) {
+      const attachments = await persistPostFiles(
+        trackedState.interactionId,
+        getPostFiles(args[0]),
+      ).catch(() => []);
+      if (text || attachments.length > 0) {
         await trackedState.addMessage({
+          ...(attachments.length > 0 ? { attachments } : {}),
           interactionId: trackedState.interactionId,
           senderType: "agent",
           text,

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/runs/agent-run-events.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/runs/agent-run-events.ts
@@ -5,6 +5,9 @@ import { addInteractionMessage } from "@/lib/conversations/interactions";
 import { db, schema } from "@/lib/database";
 import { getFileStorageAdapter } from "@/lib/file-storage";
 import { createStoredFile } from "@/lib/file-storage/records";
+import { createLogger, serializeErrorForLog } from "@/lib/log";
+
+const logger = createLogger("agent-run-events");
 
 type AddAgentMessage = (input: {
   attachments?: Array<{ id: string; filename: string; contentType: string; url: string }>;
@@ -165,10 +168,20 @@ export function wrapThreadPostForInteraction<TState>(
 
     try {
       const text = getPostText(args[0]);
-      const attachments = await persistPostFiles(
-        trackedState.interactionId,
-        getPostFiles(args[0]),
-      ).catch(() => []);
+      const postFiles = getPostFiles(args[0]);
+      const attachments = await persistPostFiles(trackedState.interactionId, postFiles).catch(
+        (error) => {
+          logger.warn(
+            {
+              err: serializeErrorForLog(error),
+              fileCount: postFiles.length,
+              interactionId: trackedState.interactionId,
+            },
+            "agent post file persistence failed",
+          );
+          return [];
+        },
+      );
       if (text || attachments.length > 0) {
         await trackedState.addMessage({
           ...(attachments.length > 0 ? { attachments } : {}),


### PR DESCRIPTION
## What changed

- Route the New Request chat form through `POST /api/orgs/:organizationSlug/conversations` instead of the legacy `chat-requests` endpoints.
- Add conversation creation support for initial chat messages, project validation, source-file uploads, and canonical `interaction_messages` persistence.
- Pass the configured file storage adapter into conversation routes and add route coverage for text, upload, and cross-org project rejection cases.

## How to test

- `vp test`
- `vp check --fix`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review