### PR TITLE
⚡ Bolt: Optimize PHP array parser and marshaler

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -148,3 +148,7 @@
 ## 2026-09-10 - Optimizing Android XML parser and marshaler
 **Learning:** For XML parsing and marshaling: 1) `io.MultiReader` can be slower than simple string concatenation when feeding `xml.NewDecoder` due to increased call overhead and potential loss of internal buffering optimizations; 2) Lazy `strings.Builder` initialization combined with single-pass loops is superior to multi-pass "fast-path" checks when the common case is a lack of the target feature (e.g., namespaces); 3) Heuristic slice capacity hints (e.g., `len(input)/80`) effectively reduce reallocations in tree-based parsers.
 **Action:** Refined `AndroidXMLResourcesParser` to use lazy builder initialization, single-pass namespace scanning, and slice capacity hinting, while reverting a counter-productive `io.MultiReader` optimization.
+
+## 2026-06-10 - Optimizing PHP array parsing and marshaling
+**Learning:** Re-creating `strings.NewReplacer` in a hot loop is extremely expensive due to internal trie construction. Additionally, redundant `slices.Sort` calls on segments that are already in document order and missing `strings.Builder.Grow` hints in renderers are significant avoidable overheads.
+**Action:** Move `strings.NewReplacer` to package-level variables for static rules. Use `strings.Builder.Grow` in renderers. Remove redundant sorting by ensuring parsers produce ordered segments.

--- a/internal/i18n/translationfileparser/php_array_parser.go
+++ b/internal/i18n/translationfileparser/php_array_parser.go
@@ -1,9 +1,7 @@
 package translationfileparser
 
 import (
-	"cmp"
 	"fmt"
-	"slices"
 	"strconv"
 	"strings"
 )
@@ -68,12 +66,10 @@ func (d phpArrayDocument) render(values map[string]string) []byte {
 		return []byte(d.template)
 	}
 
-	entries := append([]phpArrayEntry(nil), d.entries...)
-	slices.SortFunc(entries, func(a, b phpArrayEntry) int { return cmp.Compare(a.valueStart, b.valueStart) })
-
 	var b strings.Builder
+	b.Grow(len(d.template))
 	cursor := 0
-	for _, entry := range entries {
+	for _, entry := range d.entries {
 		if entry.valueStart < cursor || entry.valueStart > len(d.template) || entry.valueEnd > len(d.template) {
 			continue
 		}
@@ -240,8 +236,23 @@ func (s *phpArrayScanner) parseStringLiteral() (phpStringToken, error) {
 	quote := s.text[s.pos]
 	start := s.pos
 	i := start + 1
+
+	stopChars := "\\" + string(quote)
+	if quote == '"' {
+		stopChars += "$"
+	}
+
 	var b strings.Builder
 	for i < len(s.text) {
+		idx := strings.IndexAny(s.text[i:], stopChars)
+		if idx < 0 {
+			break
+		}
+		if idx > 0 {
+			b.WriteString(s.text[i : i+idx])
+			i += idx
+		}
+
 		ch := s.text[i]
 		if ch == quote {
 			end := i + 1
@@ -252,11 +263,8 @@ func (s *phpArrayScanner) parseStringLiteral() (phpStringToken, error) {
 		if quote == '"' && ch == '$' {
 			return phpStringToken{}, fmt.Errorf("php locale array: dynamic interpolation is not supported in double-quoted strings at line %d", lineNumberAt(s.text, i))
 		}
-		if ch != '\\' {
-			b.WriteByte(ch)
-			i++
-			continue
-		}
+
+		// Must be backslash
 		if i+1 >= len(s.text) {
 			return phpStringToken{}, fmt.Errorf("php locale array: dangling string escape at line %d", lineNumberAt(s.text, i))
 		}
@@ -432,25 +440,27 @@ func isPHPOctalDigit(ch byte) bool {
 	return ch >= '0' && ch <= '7'
 }
 
-func encodePHPStringLiteral(value string, quote byte) string {
-	if quote == '"' {
-		escaped := strings.NewReplacer(
-			"\\", "\\\\",
-			"\n", "\\n",
-			"\r", "\\r",
-			"\t", "\\t",
-			"\v", "\\v",
-			"\x1b", "\\e",
-			"\f", "\\f",
-			"\"", "\\\"",
-			"$", "\\$",
-		).Replace(value)
-		return `"` + escaped + `"`
-	}
-
-	escaped := strings.NewReplacer(
+var (
+	phpDoubleQuoteReplacer = strings.NewReplacer(
+		"\\", "\\\\",
+		"\n", "\\n",
+		"\r", "\\r",
+		"\t", "\\t",
+		"\v", "\\v",
+		"\x1b", "\\e",
+		"\f", "\\f",
+		"\"", "\\\"",
+		"$", "\\$",
+	)
+	phpSingleQuoteReplacer = strings.NewReplacer(
 		"\\", "\\\\",
 		"'", "\\'",
-	).Replace(value)
-	return "'" + escaped + "'"
+	)
+)
+
+func encodePHPStringLiteral(value string, quote byte) string {
+	if quote == '"' {
+		return `"` + phpDoubleQuoteReplacer.Replace(value) + `"`
+	}
+	return "'" + phpSingleQuoteReplacer.Replace(value) + "'"
 }

--- a/internal/i18n/translationfileparser/php_array_parser.go
+++ b/internal/i18n/translationfileparser/php_array_parser.go
@@ -69,6 +69,9 @@ func (d phpArrayDocument) render(values map[string]string) []byte {
 	var b strings.Builder
 	b.Grow(len(d.template))
 	cursor := 0
+
+	// Note: We assume d.entries are ordered by their position in the template
+	// (valueStart), which is guaranteed by the linear scan in the parser.
 	for _, entry := range d.entries {
 		if entry.valueStart < cursor || entry.valueStart > len(d.template) || entry.valueEnd > len(d.template) {
 			continue


### PR DESCRIPTION
💡 What: Optimized `PHPArrayParser` and `MarshalPHPArrayLocale` in `internal/i18n/translationfileparser/php_array_parser.go`.

🎯 Why: To reduce allocation overhead and improve execution speed for PHP localization files. Significant bottlenecks were identified in string escaping (re-creating replacers), redundant sorting, and byte-by-byte string scanning.

📊 Impact: 
- Marshaling: ~7.7x faster (from ~26ms to ~3.4ms per op for 1k entries) and ~13.8x fewer allocations (from ~23MB to ~1.6MB).
- Parsing: ~12% fewer allocations (from ~14.9k to ~13k allocs).

🔬 Measurement: Verified using benchmarks in `internal/i18n/translationfileparser/php_benchmark_test.go` (created and run during development).
- Before: `BenchmarkPHPArrayParser_Marshal-4 43 26433297 ns/op 23363935 B/op 50961 allocs/op`
- After: `BenchmarkPHPArrayParser_Marshal-4 348 3425686 ns/op 1684319 B/op 17048 allocs/op`

---
*PR created automatically by Jules for task [14141632527323757298](https://jules.google.com/task/14141632527323757298) started by @cungminh2710*