### PR TITLE
fix(crowdin): add missing pagination to list responses

### DIFF
--- a/third_party/crowdin-api-client-go/crowdin/model/ai.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/ai.go
@@ -89,6 +89,7 @@ type FineTuningEventsListResponse struct {
 	Data []struct {
 		Data *FineTuningEvent `json:"data"`
 	} `json:"data"`
+	Pagination *Pagination `json:"pagination"`
 }
 
 type (
@@ -171,7 +172,8 @@ type FineTuningJobResponse struct {
 // FineTuningJobsListResponse defines the structure of a response when
 // getting a list of fine-tuning jobs.
 type FineTuningJobsListResponse struct {
-	Data []*FineTuningJobResponse `json:"data"`
+	Data       []*FineTuningJobResponse `json:"data"`
+	Pagination *Pagination              `json:"pagination"`
 }
 
 // FineTuningJobsListOptions specifies the optional parameters to the
@@ -294,7 +296,8 @@ type PromptResponse struct {
 // PromptsListResponse defines the structure of a response when
 // getting a list of AI prompts.
 type PromptsListResponse struct {
-	Data []*PromptResponse `json:"data"`
+	Data       []*PromptResponse `json:"data"`
+	Pagination *Pagination       `json:"pagination"`
 }
 
 // AIPromptsListOptions specifies the optional parameters to the
@@ -414,7 +417,8 @@ type ProviderResponse struct {
 // ProvidersListResponse defines the structure of a response when
 // getting a list of AI providers.
 type ProvidersListResponse struct {
-	Data []*ProviderResponse `json:"data"`
+	Data       []*ProviderResponse `json:"data"`
+	Pagination *Pagination         `json:"pagination"`
 }
 
 // ProviderAddRequest defines the structure of a request to add an AI provider.
@@ -481,7 +485,8 @@ type ProviderModelResponse struct {
 // ProviderModelsListResponse defines the structure of a response when
 // getting a list of AI provider models.
 type ProviderModelsListResponse struct {
-	Data []*ProviderModelResponse `json:"data"`
+	Data       []*ProviderModelResponse `json:"data"`
+	Pagination *Pagination              `json:"pagination"`
 }
 
 // ProxyChatCompletion represents an AI proxy chat completion.

--- a/third_party/crowdin-api-client-go/crowdin/model/applications.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/applications.go
@@ -80,7 +80,8 @@ type InstallationResponse struct {
 // InstallationsListResponse defines the structure of the response
 // when getting a list of installations.
 type InstallationsListResponse struct {
-	Data []*InstallationResponse `json:"data"`
+	Data       []*InstallationResponse `json:"data"`
+	Pagination *Pagination             `json:"pagination"`
 }
 
 // InstallApplicationRequest defines the structure of the request

--- a/third_party/crowdin-api-client-go/crowdin/model/branches.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/branches.go
@@ -25,7 +25,8 @@ type BranchesGetResponse struct {
 
 // BranchesListResponse describes a response with a list of branches.
 type BranchesListResponse struct {
-	Data []*BranchesGetResponse `json:"data"`
+	Data       []*BranchesGetResponse `json:"data"`
+	Pagination *Pagination            `json:"pagination"`
 }
 
 // BranchesListOptions specifies the optional parameters to the

--- a/third_party/crowdin-api-client-go/crowdin/model/bundles.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/bundles.go
@@ -28,7 +28,8 @@ type BundleResponse struct {
 // BundlesListResponse defines the structure of a response
 // when getting a list of bundles.
 type BundlesListResponse struct {
-	Data []*BundleResponse `json:"data"`
+	Data       []*BundleResponse `json:"data"`
+	Pagination *Pagination       `json:"pagination"`
 }
 
 // BundleAddRequest defines the structure of a request

--- a/third_party/crowdin-api-client-go/crowdin/model/dictionaries.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/dictionaries.go
@@ -17,7 +17,8 @@ type DictionaryResponse struct {
 // DictionariesListResponse defines the structure of the response
 // when getting a list of dictionaries.
 type DictionariesListResponse struct {
-	Data []*DictionaryResponse `json:"data"`
+	Data       []*DictionaryResponse `json:"data"`
+	Pagination *Pagination           `json:"pagination"`
 }
 
 // DictionariesListOptions specifies the optional parameters to the

--- a/third_party/crowdin-api-client-go/crowdin/model/distributions.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/distributions.go
@@ -23,7 +23,8 @@ type DistributionResponse struct {
 // DistributionsListResponse defines the structure of the response when
 // getting a list of distributions.
 type DistributionsListResponse struct {
-	Data []*DistributionResponse `json:"data"`
+	Data       []*DistributionResponse `json:"data"`
+	Pagination *Pagination             `json:"pagination"`
 }
 
 // ExportMode is a type representing the export mode of a distribution.

--- a/third_party/crowdin-api-client-go/crowdin/model/fields.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/fields.go
@@ -104,7 +104,8 @@ type FieldResponse struct {
 // FieldsListResponse defines the structure of a response when
 // getting a list of fields.
 type FieldsListResponse struct {
-	Data []*FieldResponse `json:"data"`
+	Data       []*FieldResponse `json:"data"`
+	Pagination *Pagination      `json:"pagination"`
 }
 
 // FieldsListOptions specifies the optional parameters to the

--- a/third_party/crowdin-api-client-go/crowdin/model/glossaries.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/glossaries.go
@@ -43,7 +43,8 @@ type ConceptResponse struct {
 // ConceptsListResponse defines the structure of a response when
 // getting a list of concepts.
 type ConceptsListResponse struct {
-	Data []*ConceptResponse `json:"data"`
+	Data       []*ConceptResponse `json:"data"`
+	Pagination *Pagination        `json:"pagination"`
 }
 
 // ConceptsListOptions specifies the optional parameters to the
@@ -139,7 +140,8 @@ type GlossaryResponse struct {
 // GlossariesListResponse defines the structure of a response when
 // getting a list of glossaries.
 type GlossariesListResponse struct {
-	Data []*GlossaryResponse `json:"data"`
+	Data       []*GlossaryResponse `json:"data"`
+	Pagination *Pagination         `json:"pagination"`
 }
 
 // GlossariesListOptions specifies the optional parameters to the
@@ -414,7 +416,8 @@ type TermResponse struct {
 // TermsListResponse defines the structure of a response when
 // getting a list of terms.
 type TermsListResponse struct {
-	Data []*TermResponse `json:"data"`
+	Data       []*TermResponse `json:"data"`
+	Pagination *Pagination     `json:"pagination"`
 }
 
 // TermsListOptions specifies the optional parameters to the

--- a/third_party/crowdin-api-client-go/crowdin/model/labels.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/labels.go
@@ -21,7 +21,8 @@ type LabelResponse struct {
 // LabelsListResponse defines the structure of a response when
 // getting a list of labels.
 type LabelsListResponse struct {
-	Data []*LabelResponse `json:"data"`
+	Data       []*LabelResponse `json:"data"`
+	Pagination *Pagination      `json:"pagination"`
 }
 
 // LabelsListOptions specifies the optional parameters to the

--- a/third_party/crowdin-api-client-go/crowdin/model/pagination_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/pagination_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -49,4 +50,30 @@ func TestListOptionsValues(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPaginationUnmarshaling(t *testing.T) {
+	jsonResp := `{
+		"data": [
+			{
+				"data": {
+					"id": 1,
+					"projectId": 2,
+					"title": "label1"
+				}
+			}
+		],
+		"pagination": {
+			"offset": 10,
+			"limit": 25
+		}
+	}`
+
+	var resp LabelsListResponse
+	err := json.Unmarshal([]byte(jsonResp), &resp)
+	assert.NoError(t, err)
+
+	assert.NotNil(t, resp.Pagination)
+	assert.Equal(t, 10, resp.Pagination.Offset)
+	assert.Equal(t, 25, resp.Pagination.Limit)
 }

--- a/third_party/crowdin-api-client-go/crowdin/model/pagination_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/pagination_test.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"encoding/json"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -53,27 +54,45 @@ func TestListOptionsValues(t *testing.T) {
 }
 
 func TestPaginationUnmarshaling(t *testing.T) {
-	jsonResp := `{
-		"data": [
-			{
-				"data": {
-					"id": 1,
-					"projectId": 2,
-					"title": "label1"
+	tests := []struct {
+		name   string
+		offset int
+	}{
+		{
+			name:   "first page",
+			offset: 0,
+		},
+		{
+			name:   "later page",
+			offset: 10,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jsonResp := `{
+				"data": [
+					{
+						"data": {
+							"id": 1,
+							"projectId": 2,
+							"title": "label1"
+						}
+					}
+				],
+				"pagination": {
+					"offset": ` + strconv.Itoa(tt.offset) + `,
+					"limit": 25
 				}
-			}
-		],
-		"pagination": {
-			"offset": 10,
-			"limit": 25
-		}
-	}`
+			}`
 
-	var resp LabelsListResponse
-	err := json.Unmarshal([]byte(jsonResp), &resp)
-	assert.NoError(t, err)
+			var resp LabelsListResponse
+			err := json.Unmarshal([]byte(jsonResp), &resp)
+			assert.NoError(t, err)
 
-	assert.NotNil(t, resp.Pagination)
-	assert.Equal(t, 10, resp.Pagination.Offset)
-	assert.Equal(t, 25, resp.Pagination.Limit)
+			assert.NotNil(t, resp.Pagination)
+			assert.Equal(t, tt.offset, resp.Pagination.Offset)
+			assert.Equal(t, 25, resp.Pagination.Limit)
+		})
+	}
 }

--- a/third_party/crowdin-api-client-go/crowdin/model/projects.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/projects.go
@@ -401,7 +401,8 @@ type ProjectsFileFormatSettingsResponse struct {
 // ProjectsFileFormatSettingsListResponse defines the structure of a response when
 // getting a list of project file format settings.
 type ProjectsFileFormatSettingsListResponse struct {
-	Data []*ProjectsFileFormatSettingsResponse `json:"data"`
+	Data       []*ProjectsFileFormatSettingsResponse `json:"data"`
+	Pagination *Pagination                           `json:"pagination"`
 }
 
 type FileFormatSettings interface {
@@ -633,7 +634,8 @@ type ProjectsStringsExporterSettingsResponse struct {
 // ProjectsStringsExporterSettingsListResponse defines the structure of a response when
 // getting a list of project strings exporter settings.
 type ProjectsStringsExporterSettingsListResponse struct {
-	Data []*ProjectsStringsExporterSettingsResponse `json:"data"`
+	Data       []*ProjectsStringsExporterSettingsResponse `json:"data"`
+	Pagination *Pagination                                `json:"pagination"`
 }
 
 // ProjectsStringsExporterSettingsRequest defines the structure of a request

--- a/third_party/crowdin-api-client-go/crowdin/model/reports.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/reports.go
@@ -105,7 +105,8 @@ type ReportArchiveResponse struct {
 // ReportArchiveListResponse defines the structure of a response
 // when getting a list of report archives.
 type ReportArchiveListResponse struct {
-	Data []*ReportArchiveResponse `json:"data"`
+	Data       []*ReportArchiveResponse `json:"data"`
+	Pagination *Pagination              `json:"pagination"`
 }
 
 // ReportArchivesListOptions specifies the optional parameters to
@@ -847,7 +848,8 @@ type ReportSettingsTemplateResponse struct {
 // ReportSettingsTemplateListResponse defines the structure of a response
 // when getting a list of report settings templates.
 type ReportSettingsTemplateListResponse struct {
-	Data []*ReportSettingsTemplateResponse `json:"data"`
+	Data       []*ReportSettingsTemplateResponse `json:"data"`
+	Pagination *Pagination                       `json:"pagination"`
 }
 
 // ReportSettingsTemplatesListOptions specifies the optional parameters to

--- a/third_party/crowdin-api-client-go/crowdin/model/screenshot.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/screenshot.go
@@ -33,7 +33,8 @@ type ScreenshotResponse struct {
 // ScreenshotListResponse defines the structure of a response
 // to list screenshots.
 type ScreenshotListResponse struct {
-	Data []*ScreenshotResponse `json:"data"`
+	Data       []*ScreenshotResponse `json:"data"`
+	Pagination *Pagination           `json:"pagination"`
 }
 
 // Tag represents a tag on a screenshot.
@@ -60,7 +61,8 @@ type TagResponse struct {
 
 // TagListResponse defines the structure of a response to list tags.
 type TagListResponse struct {
-	Data []*TagResponse `json:"data"`
+	Data       []*TagResponse `json:"data"`
+	Pagination *Pagination    `json:"pagination"`
 }
 
 // ScreenshotListOptions specifies the optional parameters

--- a/third_party/crowdin-api-client-go/crowdin/model/security_logs.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/security_logs.go
@@ -26,7 +26,8 @@ type SecurityLogResponse struct {
 // SecurityLogsListResponse defines the structure of a response when
 // getting a list of security logs.
 type SecurityLogsListResponse struct {
-	Data []*SecurityLogResponse `json:"data"`
+	Data       []*SecurityLogResponse `json:"data"`
+	Pagination *Pagination            `json:"pagination"`
 }
 
 // LogEvent is a type representing a security log event.

--- a/third_party/crowdin-api-client-go/crowdin/model/source_files.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/source_files.go
@@ -31,7 +31,8 @@ type DirectoryGetResponse struct {
 
 // DirectoryListResponse describes a response with a list of directories.
 type DirectoryListResponse struct {
-	Data []*DirectoryGetResponse `json:"data"`
+	Data       []*DirectoryGetResponse `json:"data"`
+	Pagination *Pagination             `json:"pagination"`
 }
 
 // DirectoryListOptions specifies the optional parameters to the
@@ -160,7 +161,8 @@ type FileGetResponse struct {
 
 // FileListResponse describes a response with a list of files.
 type FileListResponse struct {
-	Data []*FileGetResponse `json:"data"`
+	Data       []*FileGetResponse `json:"data"`
+	Pagination *Pagination        `json:"pagination"`
 }
 
 // FileListOptions specifies the optional parameters to the
@@ -541,7 +543,8 @@ type FileRevisionResponse struct {
 // FileRevisionListResponse describes a response with
 // a list of file revisions.
 type FileRevisionListResponse struct {
-	Data []*FileRevisionResponse `json:"data"`
+	Data       []*FileRevisionResponse `json:"data"`
+	Pagination *Pagination             `json:"pagination"`
 }
 
 // ReviewedBuild represents a reviewed source file build.
@@ -563,7 +566,8 @@ type ReviewedBuildResponse struct {
 
 // ReviewedBuildListResponse describes a response with a list of reviewed builds.
 type ReviewedBuildListResponse struct {
-	Data []*ReviewedBuildResponse `json:"data"`
+	Data       []*ReviewedBuildResponse `json:"data"`
+	Pagination *Pagination              `json:"pagination"`
 }
 
 // ReviewedBuildListOptions specifies the optional parameters to the

--- a/third_party/crowdin-api-client-go/crowdin/model/source_strings.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/source_strings.go
@@ -42,7 +42,8 @@ type SourceStringsGetResponse struct {
 // SourceStringsListResponse describes the response when getting
 // a list of source strings.
 type SourceStringsListResponse struct {
-	Data []*SourceStringsGetResponse `json:"data"`
+	Data       []*SourceStringsGetResponse `json:"data"`
+	Pagination *Pagination                 `json:"pagination"`
 }
 
 // SourceStringsListOptions specifies the optional parameters

--- a/third_party/crowdin-api-client-go/crowdin/model/string_comments.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/string_comments.go
@@ -53,7 +53,8 @@ type StringCommentsResponse struct {
 // StringCommentsListResponse defines the structure of the response when
 // getting a list of string comments.
 type StringCommentsListResponse struct {
-	Data []*StringCommentsResponse `json:"data"`
+	Data       []*StringCommentsResponse `json:"data"`
+	Pagination *Pagination               `json:"pagination"`
 }
 
 // StringCommentsListOptions specifies the optional parameters to the

--- a/third_party/crowdin-api-client-go/crowdin/model/string_translations.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/string_translations.go
@@ -26,7 +26,8 @@ type ApprovalsGetResponse struct {
 // ApprovalsListResponse defines the structure of the response when
 // getting a list of translation approvals.
 type ApprovalsListResponse struct {
-	Data []*ApprovalsGetResponse `json:"data"`
+	Data       []*ApprovalsGetResponse `json:"data"`
+	Pagination *Pagination             `json:"pagination"`
 }
 
 // ApprovalsListOptions specifies the optional parameters to the
@@ -176,6 +177,7 @@ type LanguageTranslationsListResponse struct {
 	Data []struct {
 		Data *LanguageTranslation `json:"data"`
 	} `json:"data"`
+	Pagination *Pagination `json:"pagination"`
 }
 
 // LanguageTranslationsListOptions specifies the optional parameters to the
@@ -270,7 +272,8 @@ type TranslationGetResponse struct {
 // TranslationsListResponse defines the structure of the response when
 // getting a list of translations.
 type TranslationsListResponse struct {
-	Data []*TranslationGetResponse `json:"data"`
+	Data       []*TranslationGetResponse `json:"data"`
+	Pagination *Pagination               `json:"pagination"`
 }
 
 // TranslationGetOptions specifies the optional parameters to the
@@ -397,7 +400,8 @@ type VoteGetResponse struct {
 // VotesListResponse defines the structure of the response when
 // getting a list of translation votes.
 type VotesListResponse struct {
-	Data []*VoteGetResponse `json:"data"`
+	Data       []*VoteGetResponse `json:"data"`
+	Pagination *Pagination        `json:"pagination"`
 }
 
 // VotesListOptions specifies the optional parameters to the

--- a/third_party/crowdin-api-client-go/crowdin/model/tasks.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/tasks.go
@@ -92,7 +92,8 @@ type TaskResponse struct {
 // TasksListResponse defines the structure of the response
 // when getting a list of tasks.
 type TasksListResponse struct {
-	Data []*TaskResponse `json:"data"`
+	Data       []*TaskResponse `json:"data"`
+	Pagination *Pagination     `json:"pagination"`
 }
 
 // TasksListOptions specifies the optional parameters to the
@@ -1004,7 +1005,8 @@ type TaskSettingsTemplateResponse struct {
 // TaskSettingsTemplatesListResponse defines the structure of the response
 // when getting a list of task settings templates.
 type TaskSettingsTemplatesListResponse struct {
-	Data []*TaskSettingsTemplateResponse `json:"data"`
+	Data       []*TaskSettingsTemplateResponse `json:"data"`
+	Pagination *Pagination                    `json:"pagination"`
 }
 
 // TaskSettingsTemplateAddRequest defines the structure of the request
@@ -1053,7 +1055,8 @@ type TaskCommentResponse struct {
 // TaskCommentsListResponse defines the structure of the response
 // when getting a list of task comments.
 type TaskCommentsListResponse struct {
-	Data []*TaskCommentResponse `json:"data"`
+	Data       []*TaskCommentResponse `json:"data"`
+	Pagination *Pagination            `json:"pagination"`
 }
 
 // TaskCommentAddRequest defines the structure of the request

--- a/third_party/crowdin-api-client-go/crowdin/model/tasks.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/tasks.go
@@ -1006,7 +1006,7 @@ type TaskSettingsTemplateResponse struct {
 // when getting a list of task settings templates.
 type TaskSettingsTemplatesListResponse struct {
 	Data       []*TaskSettingsTemplateResponse `json:"data"`
-	Pagination *Pagination                    `json:"pagination"`
+	Pagination *Pagination                     `json:"pagination"`
 }
 
 // TaskSettingsTemplateAddRequest defines the structure of the request

--- a/third_party/crowdin-api-client-go/crowdin/model/teams.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/teams.go
@@ -24,7 +24,8 @@ type TeamResponse struct {
 // TeamsListResponse defines the structure of the response when
 // getting a list of teams.
 type TeamsListResponse struct {
-	Data []*TeamResponse `json:"data"`
+	Data       []*TeamResponse `json:"data"`
+	Pagination *Pagination     `json:"pagination"`
 }
 
 // TeamsListOptions specifies the optional parameters to the
@@ -126,7 +127,8 @@ type TeamMemberResponse struct {
 // TeamMembersListResponse defines the structure of the response when
 // getting a list of team members.
 type TeamMembersListResponse struct {
-	Data []*TeamMemberResponse `json:"data"`
+	Data       []*TeamMemberResponse `json:"data"`
+	Pagination *Pagination           `json:"pagination"`
 }
 
 // TeamMemberAddRequest defines the structure of the request when

--- a/third_party/crowdin-api-client-go/crowdin/model/translation_memory.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/translation_memory.go
@@ -33,7 +33,8 @@ type TranslationMemoryResponse struct {
 // TranslationMemoriesListResponse defines the structure of the response
 // when getting a list of Translation Memories.
 type TranslationMemoriesListResponse struct {
-	Data []*TranslationMemoryResponse `json:"data"`
+	Data       []*TranslationMemoryResponse `json:"data"`
+	Pagination *Pagination                  `json:"pagination"`
 }
 
 // TranslationMemoriesListOptions specifies the optional parameters to the
@@ -317,7 +318,8 @@ type TMSegmentResponse struct {
 // TMSegmentsListResponse defines the structure of the response
 // when getting a list of Translation Memory segments.
 type TMSegmentsListResponse struct {
-	Data []*TMSegmentResponse `json:"data"`
+	Data       []*TMSegmentResponse `json:"data"`
+	Pagination *Pagination          `json:"pagination"`
 }
 
 // TMSegmentsListOptions specifies the optional parameters to the

--- a/third_party/crowdin-api-client-go/crowdin/model/translations.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/translations.go
@@ -85,7 +85,8 @@ type PreTranslationsResponse struct {
 // PreTranslationsListResponse defines the structure of a response when
 // getting a list of pre-translations.
 type PreTranslationsListResponse struct {
-	Data []*PreTranslationsResponse `json:"data"`
+	Data       []*PreTranslationsResponse `json:"data"`
+	Pagination *Pagination                `json:"pagination"`
 }
 
 // PreTranslationReportResponse defines the structure of a response when
@@ -392,7 +393,8 @@ type TranslationsProjectBuildResponse struct {
 // TranslationsProjectBuildsListResponse defines the structure of a response when
 // getting a list of project builds.
 type TranslationsProjectBuildsListResponse struct {
-	Data []*TranslationsProjectBuildResponse `json:"data"`
+	Data       []*TranslationsProjectBuildResponse `json:"data"`
+	Pagination *Pagination                         `json:"pagination"`
 }
 
 type (

--- a/third_party/crowdin-api-client-go/crowdin/model/users.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/users.go
@@ -94,7 +94,8 @@ type ProjectMemberResponse struct {
 // ProjectMembersListResponse defines the structure of the response
 // when getting a list of project members.
 type ProjectMembersListResponse struct {
-	Data []*ProjectMemberResponse `json:"data"`
+	Data       []*ProjectMemberResponse `json:"data"`
+	Pagination *Pagination              `json:"pagination"`
 }
 
 // ProjectMembersListOptions specifies the optional parameters to the
@@ -254,7 +255,8 @@ type UserResponse struct {
 // UsersListResponse defines the structure of the response
 // when getting a list of users.
 type UsersListResponse struct {
-	Data []*UserResponse `json:"data"`
+	Data       []*UserResponse `json:"data"`
+	Pagination *Pagination     `json:"pagination"`
 }
 
 // UsersListOptions specifies the optional parameters to the

--- a/third_party/crowdin-api-client-go/crowdin/model/vendor.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/vendor.go
@@ -18,5 +18,6 @@ type VendorResponse struct {
 // VendorsListResponse defines the structure of the response when
 // getting a list of vendors.
 type VendorsListResponse struct {
-	Data []*VendorResponse `json:"data"`
+	Data       []*VendorResponse `json:"data"`
+	Pagination *Pagination       `json:"pagination"`
 }

--- a/third_party/crowdin-api-client-go/crowdin/model/webhooks.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/webhooks.go
@@ -146,7 +146,8 @@ type WebhookResponse struct {
 // WebhooksListResponse defines the structure of the response
 // when getting a list of webhooks.
 type WebhooksListResponse struct {
-	Data []*WebhookResponse `json:"data"`
+	Data       []*WebhookResponse `json:"data"`
+	Pagination *Pagination        `json:"pagination"`
 }
 
 // WebhookAddRequest defines the structure of the request

--- a/third_party/crowdin-api-client-go/crowdin/model/workflows.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/workflows.go
@@ -72,7 +72,8 @@ type WorkflowTemplateResponse struct {
 // WorkflowTemplatesListResponse defines the structure of the response when
 // getting a list of workflow templates.
 type WorkflowTemplatesListResponse struct {
-	Data []*WorkflowTemplateResponse `json:"data"`
+	Data       []*WorkflowTemplateResponse `json:"data"`
+	Pagination *Pagination                 `json:"pagination"`
 }
 
 // WorkflowStepStringsListOptions specifies the optional parameters to the


### PR DESCRIPTION
Added the missing `Pagination` field to 46 `*ListResponse` structs across the `third_party/crowdin-api-client-go/crowdin/model/` package to align with the official Crowdin API v2 contract. This change allows SDK users to access pagination metadata (offset and limit) directly from the response object when listing resources. Verified the fix with a new contract test in `model/pagination_test.go`.

---
*PR created automatically by Jules for task [10227479444935322867](https://jules.google.com/task/10227479444935322867) started by @cungminh2710*