### PR TITLE
🧪 Scout: support optional whitespace in ICU plural offsets

### DIFF
--- a/internal/i18n/icuparser/parse.go
+++ b/internal/i18n/icuparser/parse.go
@@ -416,10 +416,48 @@ func (p *astParser) parsePluralOptions() (int, []PluralOption, error) {
 		}
 		p.skipSpaces()
 		// BOLT OPTIMIZATION: Quick check for 'o' or 'O' to avoid strings.EqualFold for most selectors.
-		if len(sel) >= 7 && (sel[0] == 'o' || sel[0] == 'O') && strings.EqualFold(sel[:7], "offset:") {
-			n, err := strconv.Atoi(sel[7:])
+		if (sel[0] == 'o' || sel[0] == 'O') && (strings.EqualFold(sel, "offset") || (len(sel) >= 7 && strings.EqualFold(sel[:7], "offset:"))) {
+			var val string
+			if strings.EqualFold(sel, "offset") {
+				p.skipSpaces()
+				if !p.consume(':') {
+					return 0, nil, fmt.Errorf("expected ':' after offset keyword at %d", p.pos)
+				}
+				p.skipSpaces()
+				numStart := p.pos
+				if p.pos < len(p.src) && p.src[p.pos] == '-' {
+					p.pos++
+				}
+				digitStart := p.pos
+				for p.pos < len(p.src) && isASCIIDigit(p.src[p.pos]) {
+					p.pos++
+				}
+				if p.pos == digitStart {
+					return 0, nil, fmt.Errorf("expected offset number at %d", p.pos)
+				}
+				val = p.src[numStart:p.pos]
+			} else {
+				// sel is "offset:..."
+				val = sel[7:]
+				if val == "" {
+					p.skipSpaces()
+					numStart := p.pos
+					if p.pos < len(p.src) && p.src[p.pos] == '-' {
+						p.pos++
+					}
+					digitStart := p.pos
+					for p.pos < len(p.src) && isASCIIDigit(p.src[p.pos]) {
+						p.pos++
+					}
+					if p.pos == digitStart {
+						return 0, nil, fmt.Errorf("expected offset number at %d", p.pos)
+					}
+					val = p.src[numStart:p.pos]
+				}
+			}
+			n, err := strconv.Atoi(val)
 			if err != nil {
-				return 0, nil, fmt.Errorf("invalid plural offset %q", sel)
+				return 0, nil, fmt.Errorf("invalid plural offset %q", val)
 			}
 			offset = n
 			continue

--- a/internal/i18n/icuparser/parse.go
+++ b/internal/i18n/icuparser/parse.go
@@ -424,35 +424,20 @@ func (p *astParser) parsePluralOptions() (int, []PluralOption, error) {
 					return 0, nil, fmt.Errorf("expected ':' after offset keyword at %d", p.pos)
 				}
 				p.skipSpaces()
-				numStart := p.pos
-				if p.pos < len(p.src) && p.src[p.pos] == '-' {
-					p.pos++
+				var err error
+				val, err = p.readOffsetNumber()
+				if err != nil {
+					return 0, nil, err
 				}
-				digitStart := p.pos
-				for p.pos < len(p.src) && isASCIIDigit(p.src[p.pos]) {
-					p.pos++
-				}
-				if p.pos == digitStart {
-					return 0, nil, fmt.Errorf("expected offset number at %d", p.pos)
-				}
-				val = p.src[numStart:p.pos]
 			} else {
 				// sel is "offset:..."
 				val = sel[7:]
 				if val == "" {
-					p.skipSpaces()
-					numStart := p.pos
-					if p.pos < len(p.src) && p.src[p.pos] == '-' {
-						p.pos++
+					var err error
+					val, err = p.readOffsetNumber()
+					if err != nil {
+						return 0, nil, err
 					}
-					digitStart := p.pos
-					for p.pos < len(p.src) && isASCIIDigit(p.src[p.pos]) {
-						p.pos++
-					}
-					if p.pos == digitStart {
-						return 0, nil, fmt.Errorf("expected offset number at %d", p.pos)
-					}
-					val = p.src[numStart:p.pos]
 				}
 			}
 			n, err := strconv.Atoi(val)
@@ -737,6 +722,21 @@ func (p *astParser) readIdentifierLike() (string, bool) {
 	// BOLT OPTIMIZATION: Internal callers (parseArgumentLike, parseSelectOptions, parsePluralOptions)
 	// always call skipSpaces() before, and we break on whitespace, so TrimSpace is redundant.
 	return p.src[start:p.pos], true
+}
+
+func (p *astParser) readOffsetNumber() (string, error) {
+	numStart := p.pos
+	if p.pos < len(p.src) && p.src[p.pos] == '-' {
+		p.pos++
+	}
+	digitStart := p.pos
+	for p.pos < len(p.src) && isASCIIDigit(p.src[p.pos]) {
+		p.pos++
+	}
+	if p.pos == digitStart {
+		return "", fmt.Errorf("expected offset number at %d", p.pos)
+	}
+	return p.src[numStart:p.pos], nil
 }
 
 func (p *astParser) readSelector() (string, bool) {

--- a/internal/i18n/icuparser/parse_test.go
+++ b/internal/i18n/icuparser/parse_test.go
@@ -369,24 +369,29 @@ func TestParseTypedFormatterShouldParseSkeletons(t *testing.T) {
 
 func TestParsePluralWithSpaceInOffset(t *testing.T) {
 	tests := []struct {
-		name string
-		msg  string
+		name           string
+		msg            string
+		expectedOffset int
 	}{
 		{
-			name: "no space",
-			msg:  "{count, plural, offset:1 one {# item} other {# items}}",
+			name:           "no space",
+			msg:            "{count, plural, offset:1 one {# item} other {# items}}",
+			expectedOffset: 1,
 		},
 		{
-			name: "space after colon",
-			msg:  "{count, plural, offset: 1 one {# item} other {# items}}",
+			name:           "space after colon",
+			msg:            "{count, plural, offset: 1 one {# item} other {# items}}",
+			expectedOffset: 1,
 		},
 		{
-			name: "space before colon",
-			msg:  "{count, plural, offset : 1 one {# item} other {# items}}",
+			name:           "space before colon",
+			msg:            "{count, plural, offset : 1 one {# item} other {# items}}",
+			expectedOffset: 1,
 		},
 		{
-			name: "multiple spaces",
-			msg:  "{count, plural, offset  :  2 one {# item} other {# items}}",
+			name:           "multiple spaces",
+			msg:            "{count, plural, offset  :  2 one {# item} other {# items}}",
+			expectedOffset: 2,
 		},
 	}
 
@@ -397,12 +402,8 @@ func TestParsePluralWithSpaceInOffset(t *testing.T) {
 				t.Fatalf("Parse() failed: %v", err)
 			}
 			pl := elems[0].(PluralElement)
-			expectedOffset := 1
-			if tt.name == "multiple spaces" {
-				expectedOffset = 2
-			}
-			if pl.Offset != expectedOffset {
-				t.Errorf("expected offset %d, got %d", expectedOffset, pl.Offset)
+			if pl.Offset != tt.expectedOffset {
+				t.Errorf("expected offset %d, got %d", tt.expectedOffset, pl.Offset)
 			}
 		})
 	}

--- a/internal/i18n/icuparser/parse_test.go
+++ b/internal/i18n/icuparser/parse_test.go
@@ -366,3 +366,44 @@ func TestParseTypedFormatterShouldParseSkeletons(t *testing.T) {
 		t.Fatalf("parsed date options: %#v", de.Skeleton.ParsedOptions)
 	}
 }
+
+func TestParsePluralWithSpaceInOffset(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  string
+	}{
+		{
+			name: "no space",
+			msg:  "{count, plural, offset:1 one {# item} other {# items}}",
+		},
+		{
+			name: "space after colon",
+			msg:  "{count, plural, offset: 1 one {# item} other {# items}}",
+		},
+		{
+			name: "space before colon",
+			msg:  "{count, plural, offset : 1 one {# item} other {# items}}",
+		},
+		{
+			name: "multiple spaces",
+			msg:  "{count, plural, offset  :  2 one {# item} other {# items}}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			elems, err := Parse(tt.msg, nil)
+			if err != nil {
+				t.Fatalf("Parse() failed: %v", err)
+			}
+			pl := elems[0].(PluralElement)
+			expectedOffset := 1
+			if tt.name == "multiple spaces" {
+				expectedOffset = 2
+			}
+			if pl.Offset != expectedOffset {
+				t.Errorf("expected offset %d, got %d", expectedOffset, pl.Offset)
+			}
+		})
+	}
+}


### PR DESCRIPTION
💡 What: Added support for optional whitespace in ICU plural offsets and comprehensive unit tests.
🎯 Why: Standard ICU messages often contain spaces for readability, and the parser was previously too restrictive.
🧩 Scope: Modified 'internal/i18n/icuparser/parse.go' and 'internal/i18n/icuparser/parse_test.go'.
✅ Verification: Ran 'go test -v ./internal/i18n/icuparser' and 'go test ./...'.
🛡️ Confidence: High, as it fixes a known parsing limitation and is verified by targeted and regression tests.

---
*PR created automatically by Jules for task [3432802721482294323](https://jules.google.com/task/3432802721482294323) started by @cungminh2710*