### PR TITLE
🧪 Scout: support flexible whitespace in self-closing tags

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -63,3 +63,7 @@
 ## 2025-06-18 - [ICU Plural Negative Selectors]
 **Learning:** ICU plural exact-value selectors (e.g., `=-1`) can include negative numbers. A naive selector parser that only expects digits after the `=` prefix will fail on these valid selectors. Additionally, when parsing sequences that require at least one element (like digits after a sign), using an explicit starting position marker (`digitStart`) to verify consumption is clearer and more robust than checking the last character's properties.
 **Action:** Ensure plural selector parsing explicitly handles an optional minus sign following the `=` prefix before consuming digits, and use explicit position markers to validate that at least one digit was consumed.
+
+## 2025-06-19 - [Flexible Whitespace in Self-Closing Tags]
+**Learning:** ICU and HTML-style tag parsers must handle flexible whitespace in self-closing tags (e.g., `<br / >`). Standard XML is strict about `/>`, but real-world localization strings often contain these variations. Failing to support them leads to "unclosed tag" errors during parsing.
+**Action:** Always allow whitespace after the slash in self-closing tag detection to improve compatibility with common HTML formatting.

--- a/internal/i18n/icuparser/parse.go
+++ b/internal/i18n/icuparser/parse.go
@@ -483,6 +483,7 @@ func (p *astParser) tryParseTag(ctx parseCtx) (TagElement, bool, error) {
 			continue
 		}
 		if p.consume('/') {
+			p.skipSpaces()
 			if p.consume('>') {
 				return TagElement{Value: name, SelfClosing: true}, true, nil
 			}

--- a/internal/i18n/icuparser/parse_test.go
+++ b/internal/i18n/icuparser/parse_test.go
@@ -92,6 +92,52 @@ func TestParseASTPluralNegativeSelector(t *testing.T) {
 	}
 }
 
+func TestParseSelfClosingTagsWithWhitespace(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  string
+	}{
+		{
+			name: "no space",
+			msg:  "Hello<br/>world",
+		},
+		{
+			name: "space before slash",
+			msg:  "Hello<br />world",
+		},
+		{
+			name: "space after slash",
+			msg:  "Hello<br/ >world",
+		},
+		{
+			name: "multiple spaces",
+			msg:  "Hello<br  /  >world",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			elems, err := Parse(tt.msg, nil)
+			if err != nil {
+				t.Fatalf("Parse(%q) failed: %v", tt.msg, err)
+			}
+			if len(elems) != 3 {
+				t.Fatalf("expected 3 elements, got %d", len(elems))
+			}
+			tag, ok := elems[1].(TagElement)
+			if !ok {
+				t.Fatalf("expected tag element, got %T", elems[1])
+			}
+			if tag.Value != "br" {
+				t.Errorf("expected tag name %q, got %q", "br", tag.Value)
+			}
+			if !tag.SelfClosing {
+				t.Errorf("expected tag to be self-closing")
+			}
+		})
+	}
+}
+
 func TestParseASTPluralWithNonASCIIWhitespace(t *testing.T) {
 	msg := "{\u00a0count\u00a0,\u00a0plural\u00a0,\u00a0Offset:2\u00a0=0\u00a0{nobody}\u00a0other\u00a0{# items}}"
 	elems, err := Parse(msg, nil)


### PR DESCRIPTION
- 💡 What: Support flexible whitespace in self-closing tags (e.g., `<br / >`) in the ICU parser.
- 🎯 Why: Standardize behavior with common HTML formatting and prevent "unclosed tag" errors for valid regionalized content.
- 🧩 Scope: `internal/i18n/icuparser/parse.go`, `internal/i18n/icuparser/parse_test.go`
- ✅ Verification: `go test -v ./internal/i18n/icuparser`
- 🛡️ Confidence: High, verified with multiple whitespace variations in tests.

---
*PR created automatically by Jules for task [7081838471177922923](https://jules.google.com/task/7081838471177922923) started by @cungminh2710*