### PR TITLE
Improve SourceStrings API v2 parity

### DIFF
--- a/third_party/crowdin-api-client-go/crowdin/model/source_strings.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/source_strings.go
@@ -80,6 +80,11 @@ type SourceStringsListOptions struct {
 	// Specify field to be the target of filtering. It can be one scope or
 	// a list of comma-separated scopes. Enum: identifier, text, context.
 	Scope string `json:"scope,omitempty"`
+	// OrderBy is used to sort source strings.
+	// Enum: id, identifier, text, createdAt, updatedAt.
+	// Default: id.
+	// Example: orderBy=createdAt desc,identifier.
+	OrderBy string `json:"orderBy,omitempty"`
 
 	ListOptions
 }
@@ -92,6 +97,9 @@ func (o *SourceStringsListOptions) Values() (url.Values, bool) {
 	}
 
 	v, _ := o.ListOptions.Values()
+	if o.OrderBy != "" {
+		v.Add("orderBy", o.OrderBy)
+	}
 	if o.DenormalizePlaceholders != nil &&
 		(*o.DenormalizePlaceholders == 0 || *o.DenormalizePlaceholders == 1) {
 		v.Add("denormalizePlaceholders", strconv.Itoa(*o.DenormalizePlaceholders))
@@ -169,6 +177,8 @@ type SourceStringsAddRequest struct {
 	FileID int `json:"fileId,omitempty"`
 	// Branch identifier.
 	BranchID int `json:"branchId,omitempty"`
+	// Directory identifier.
+	DirectoryID int `json:"directoryId,omitempty"`
 	// Defines unique string identifier.
 	Identifier string `json:"identifier,omitempty"`
 	// Use to provide additional information for better source text understanding.
@@ -208,8 +218,8 @@ func (r *SourceStringsAddRequest) Validate() error {
 		return errors.New("text must be a string or map of strings")
 	}
 
-	if r.FileID == 0 && r.BranchID == 0 {
-		return errors.New("fileId or branchId is required")
+	if r.FileID == 0 && r.BranchID == 0 && r.DirectoryID == 0 {
+		return errors.New("fileId, branchId or directoryId is required")
 	}
 
 	return nil
@@ -222,6 +232,7 @@ type SourceStringsUpload struct {
 	Progress   int    `json:"progress"`
 	Attributes struct {
 		BranchID      int    `json:"branchId"`
+		DirectoryID   int    `json:"directoryId"`
 		StorageID     int    `json:"storageId"`
 		FileType      string `json:"fileType"`
 		ParserVersion int    `json:"parserVersion"`
@@ -253,7 +264,10 @@ type SourceStringsUploadRequest struct {
 	StorageID int `json:"storageId"`
 	// Branch Identifier.
 	// Defines branch to which file will be added.
-	BranchID int `json:"branchId"`
+	BranchID int `json:"branchId,omitempty"`
+	// Directory Identifier.
+	// Defines directory to which file will be added.
+	DirectoryID int `json:"directoryId,omitempty"`
 	// Default: auto
 	// Enum: auto, android, macosx, arb, csv, json, xlsx, xliff, xliff_two
 	// - empty value or `auto` — Try to detect file type by extension or MIME type
@@ -305,8 +319,8 @@ func (o *SourceStringsUploadRequest) Validate() error {
 	if o.StorageID == 0 {
 		return errors.New("storageId is required")
 	}
-	if o.BranchID == 0 {
-		return errors.New("branchId is required")
+	if o.BranchID == 0 && o.DirectoryID == 0 {
+		return errors.New("branchId or directoryId is required")
 	}
 	if o.UpdateOption != "" && !(*o.UpdateStrings) {
 		return errors.New("updateStrings must be set to true to use updateOption")

--- a/third_party/crowdin-api-client-go/crowdin/model/source_strings.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/source_strings.go
@@ -221,6 +221,9 @@ func (r *SourceStringsAddRequest) Validate() error {
 	if r.FileID == 0 && r.BranchID == 0 && r.DirectoryID == 0 {
 		return errors.New("fileId, branchId or directoryId is required")
 	}
+	if (r.FileID != 0 && r.BranchID != 0) || (r.FileID != 0 && r.DirectoryID != 0) || (r.BranchID != 0 && r.DirectoryID != 0) {
+		return errors.New("only one of fileId, branchId or directoryId may be set")
+	}
 
 	return nil
 }
@@ -321,6 +324,9 @@ func (o *SourceStringsUploadRequest) Validate() error {
 	}
 	if o.BranchID == 0 && o.DirectoryID == 0 {
 		return errors.New("branchId or directoryId is required")
+	}
+	if o.BranchID != 0 && o.DirectoryID != 0 {
+		return errors.New("only one of branchId or directoryId may be set")
 	}
 	if o.UpdateOption != "" && !(*o.UpdateStrings) {
 		return errors.New("updateStrings must be set to true to use updateOption")

--- a/third_party/crowdin-api-client-go/crowdin/model/source_strings_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/source_strings_test.go
@@ -36,13 +36,18 @@ func TestSourceStringsListOptionsValues(t *testing.T) {
 			out:  "excludeLabelIds=4%2C5",
 		},
 		{
+			name: "with OrderBy",
+			opts: &SourceStringsListOptions{OrderBy: "createdAt desc,identifier"},
+			out:  "orderBy=createdAt+desc%2Cidentifier",
+		},
+		{
 			name: "with all options",
 			opts: &SourceStringsListOptions{
 				DenormalizePlaceholders: toPtr(1), LabelIDs: []int{1, 2, 3}, ExcludeLabelIDs: []int{4, 5},
 				FileID: 1, BranchID: 1, DirectoryID: 1, TaskID: 2, CroQL: "croql", Filter: "text", Scope: "identifier",
-				IsIcu: toPtr(0),
+				IsIcu: toPtr(0), OrderBy: "id",
 			},
-			out: "branchId=1&croql=croql&denormalizePlaceholders=1&directoryId=1&excludeLabelIds=4%2C5&fileId=1&filter=text&isIcu=0&labelIds=1%2C2%2C3&scope=identifier&taskId=2",
+			out: "branchId=1&croql=croql&denormalizePlaceholders=1&directoryId=1&excludeLabelIds=4%2C5&fileId=1&filter=text&isIcu=0&labelIds=1%2C2%2C3&orderBy=id&scope=identifier&taskId=2",
 		},
 	}
 
@@ -138,13 +143,23 @@ func TestSourceStringsAddRequestValidate(t *testing.T) {
 			err:  "text cannot be empty",
 		},
 		{
-			name: "empty fileID",
+			name: "missing identifiers",
 			req:  &SourceStringsAddRequest{Text: "Not all videos are shown to users.", Identifier: "name"},
-			err:  "fileId or branchId is required",
+			err:  "fileId, branchId or directoryId is required",
 		},
 		{
-			name:  "valid request",
+			name:  "valid request with fileId",
 			req:   &SourceStringsAddRequest{Text: "Not all videos are shown to users.", Identifier: "name", FileID: 1},
+			valid: true,
+		},
+		{
+			name:  "valid request with branchId",
+			req:   &SourceStringsAddRequest{Text: "Not all videos are shown to users.", Identifier: "name", BranchID: 1},
+			valid: true,
+		},
+		{
+			name:  "valid request with directoryId",
+			req:   &SourceStringsAddRequest{Text: "Not all videos are shown to users.", Identifier: "name", DirectoryID: 1},
 			valid: true,
 		},
 		{
@@ -153,7 +168,7 @@ func TestSourceStringsAddRequestValidate(t *testing.T) {
 			valid: true,
 		},
 		{
-			name: "valid request",
+			name: "valid request with all fields",
 			req: &SourceStringsAddRequest{
 				Text: map[string]string{
 					"one":   "string",
@@ -204,9 +219,9 @@ func TestSourceStringsUploadRequestValidate(t *testing.T) {
 			err:  "storageId is required",
 		},
 		{
-			name: "missing branchId",
+			name: "missing identifiers",
 			req:  &SourceStringsUploadRequest{StorageID: 1},
-			err:  "branchId is required",
+			err:  "branchId or directoryId is required",
 		},
 		{
 			name: "invalid request",
@@ -221,9 +236,21 @@ func TestSourceStringsUploadRequestValidate(t *testing.T) {
 			err: "updateStrings must be set to true to use updateOption",
 		},
 		{
-			name: "valid request",
+			name: "valid request with branchId",
 			req: &SourceStringsUploadRequest{
 				StorageID: 1, BranchID: 1, Type: "xlsx", ParserVersion: 1,
+				LabelIDs: []int{1, 2, 3}, UpdateStrings: toPtr(false), CleanupMode: toPtr(false),
+				ImportOptions: &SourceStringsImportOptions{
+					FirstLineContainsHeader: toPtr(true),
+					ImportTranslations:      toPtr(true), Scheme: map[string]int{"key": 0},
+				},
+			},
+			valid: true,
+		},
+		{
+			name: "valid request with directoryId",
+			req: &SourceStringsUploadRequest{
+				StorageID: 1, DirectoryID: 1, Type: "xlsx", ParserVersion: 1,
 				LabelIDs: []int{1, 2, 3}, UpdateStrings: toPtr(false), CleanupMode: toPtr(false),
 				ImportOptions: &SourceStringsImportOptions{
 					FirstLineContainsHeader: toPtr(true),

--- a/third_party/crowdin-api-client-go/crowdin/model/source_strings_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/source_strings_test.go
@@ -168,6 +168,11 @@ func TestSourceStringsAddRequestValidate(t *testing.T) {
 			valid: true,
 		},
 		{
+			name: "multi-set identifiers",
+			req:  &SourceStringsAddRequest{Text: "text", FileID: 1, BranchID: 1},
+			err:  "only one of fileId, branchId or directoryId may be set",
+		},
+		{
 			name: "valid request with all fields",
 			req: &SourceStringsAddRequest{
 				Text: map[string]string{
@@ -246,6 +251,11 @@ func TestSourceStringsUploadRequestValidate(t *testing.T) {
 				},
 			},
 			valid: true,
+		},
+		{
+			name: "multi-set identifiers",
+			req:  &SourceStringsUploadRequest{StorageID: 1, BranchID: 1, DirectoryID: 1},
+			err:  "only one of branchId or directoryId may be set",
 		},
 		{
 			name: "valid request with directoryId",

--- a/third_party/crowdin-api-client-go/crowdin/source_strings_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/source_strings_test.go
@@ -525,12 +525,12 @@ func TestSourceStringsService_AddWithValidationErrors(t *testing.T) {
 			"text cannot be empty",
 		},
 		{
-			"empty fileID and branchID",
+			"empty fileID, branchID and directoryID",
 			&model.SourceStringsAddRequest{
 				Text:       "Not all videos are shown to users.",
 				Identifier: "name",
 			},
-			"fileId or branchId is required",
+			"fileId, branchId or directoryId is required",
 		},
 	}
 
@@ -798,6 +798,7 @@ func TestSourceStringsService_GetUploadStatus(t *testing.T) {
 		Progress:   100,
 		Attributes: struct {
 			BranchID      int    `json:"branchId"`
+			DirectoryID   int    `json:"directoryId"`
 			StorageID     int    `json:"storageId"`
 			FileType      string `json:"fileType"`
 			ParserVersion int    `json:"parserVersion"`
@@ -921,6 +922,7 @@ func TestSourceStringsService_Upload(t *testing.T) {
 		Progress:   100,
 		Attributes: struct {
 			BranchID      int    `json:"branchId"`
+			DirectoryID   int    `json:"directoryId"`
 			StorageID     int    `json:"storageId"`
 			FileType      string `json:"fileType"`
 			ParserVersion int    `json:"parserVersion"`
@@ -995,7 +997,7 @@ func TestSourceStringsService_UploadWithValidationError(t *testing.T) {
 	}{
 		{"nil request", nil, "request cannot be nil"},
 		{"empty storageId", &model.SourceStringsUploadRequest{BranchID: 34}, "storageId is required"},
-		{"empty branchId", &model.SourceStringsUploadRequest{StorageID: 61}, "branchId is required"},
+		{"empty branchId and directoryId", &model.SourceStringsUploadRequest{StorageID: 61}, "branchId or directoryId is required"},
 		{"misconfigured updateStrings for non-empty updateOption", &model.SourceStringsUploadRequest{BranchID: 34, StorageID: 61, UpdateStrings: ToPtr(false), UpdateOption: "clear_translations_and_approvals"}, "updateStrings must be set to true to use updateOption"},
 	}
 


### PR DESCRIPTION
This PR brings the `SourceStrings` service in the Crowdin fork into closer alignment with the official Crowdin API v2 contract.

Key changes:
- **Listing**: Added `OrderBy` support to `SourceStringsListOptions` (supporting `id`, `identifier`, `text`, `createdAt`, `updatedAt`).
- **Adding**: Added `DirectoryID` to `SourceStringsAddRequest` and updated validation to allow any one of `FileID`, `BranchID`, or `DirectoryID`.
- **Uploading**: Updated `SourceStringsUploadRequest` to include `DirectoryID` and made `BranchID` optional, reflecting that exactly one of them is required.
- **Status**: Added `DirectoryID` to the `SourceStringsUpload.Attributes` struct to match the API response envelope.

All changes are verified with new and updated unit tests. Module-wide linting and tests pass.

---
*PR created automatically by Jules for task [16725849227467772252](https://jules.google.com/task/16725849227467772252) started by @cungminh2710*