### PR TITLE
refactor(inbox): add dependency injection and Storybook stories

### DIFF
--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-details.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-details.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect } from "storybook/test";
+
+import { conversationsFixture, linkedJobsFixture } from "./inbox.fixture";
+import { ConversationDetails } from "./conversation-details";
+
+const meta = {
+  title: "App/Inbox/ConversationDetails",
+  component: ConversationDetails,
+  parameters: {
+    layout: "padded",
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-72 rounded-xl border border-border bg-card p-4">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    organizationSlug: "acme",
+    conversation: conversationsFixture[0],
+    jobs: linkedJobsFixture,
+    jobsIsLoading: false,
+  },
+} satisfies Meta<typeof ConversationDetails>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Conversation details")).toBeInTheDocument();
+    await expect(canvas.getByText("Linked jobs")).toBeInTheDocument();
+    await expect(canvas.getByText("job_translate_homepage")).toBeInTheDocument();
+  },
+};
+
+export const LoadingJobs: Story = {
+  args: {
+    jobs: [],
+    jobsIsLoading: true,
+  },
+};
+
+export const NoLinkedJobs: Story = {
+  args: {
+    jobs: [],
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("None linked")).toBeInTheDocument();
+  },
+};
+
+export const EmailConversation: Story = {
+  args: {
+    conversation: conversationsFixture[1],
+    jobs: [],
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Email")).toBeInTheDocument();
+  },
+};

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-message-list.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-message-list.stories.tsx
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect } from "storybook/test";
+
+import {
+  conversationsFixture,
+  createStreamedAssistantMessage,
+  currentUserFixture,
+  messagesFixture,
+} from "./inbox.fixture";
+import { ConversationMessageList } from "./conversation-message-list";
+
+const meta = {
+  title: "App/Inbox/MessageList",
+  component: ConversationMessageList,
+  parameters: {
+    layout: "padded",
+  },
+  decorators: [
+    (Story) => (
+      <div className="h-[32rem] w-full max-w-3xl border border-border bg-background">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    conversationId: conversationsFixture[0].id,
+    currentUser: currentUserFixture,
+    messages: messagesFixture,
+    isLoading: false,
+    isStreaming: false,
+    streamedAssistant: null,
+  },
+} satisfies Meta<typeof ConversationMessageList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvas }) => {
+    await expect(
+      canvas.getByText("Can you localize the hero section for French and German?"),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByText(
+        "I'll start by extracting the hero strings and creating translation jobs for French and German.",
+      ),
+    ).toBeInTheDocument();
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    messages: [],
+    isLoading: true,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    messages: [],
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("No messages yet")).toBeInTheDocument();
+  },
+};
+
+export const Streaming: Story = {
+  args: {
+    isStreaming: true,
+    streamedAssistant: createStreamedAssistantMessage(),
+  },
+};

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-panel.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/conversation-panel.stories.tsx
@@ -1,0 +1,99 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, fn } from "storybook/test";
+
+import {
+  conversationsFixture,
+  createStreamedAssistantMessage,
+  currentUserFixture,
+  linkedJobsFixture,
+  messagesFixture,
+} from "./inbox.fixture";
+import { ConversationPanel } from "./conversation-panel";
+
+const meta = {
+  title: "App/Inbox/ConversationPanel",
+  component: ConversationPanel,
+  parameters: {
+    layout: "fullscreen",
+  },
+  decorators: [
+    (Story) => (
+      <div className="h-[40rem] bg-background">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    organizationSlug: "acme",
+    currentUser: currentUserFixture,
+    conversation: conversationsFixture[0],
+    messages: messagesFixture,
+    messagesIsLoading: false,
+    jobs: linkedJobsFixture,
+    jobsIsLoading: false,
+    isSending: false,
+    isStreaming: false,
+    streamedAssistant: null,
+    onSendMessage: fn(),
+  },
+} satisfies Meta<typeof ConversationPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ChatConversation: Story = {
+  play: async ({ canvas }) => {
+    await expect(
+      canvas.getByRole("heading", { name: "Translate homepage hero copy" }),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByPlaceholderText("Paste text or describe what to translate..."),
+    ).toBeInTheDocument();
+  },
+};
+
+export const NoSelection: Story = {
+  args: {
+    conversation: undefined,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Select a conversation to view details")).toBeInTheDocument();
+  },
+};
+
+export const LoadingMessages: Story = {
+  args: {
+    messages: [],
+    messagesIsLoading: true,
+    jobsIsLoading: true,
+  },
+};
+
+export const EmptyMessages: Story = {
+  args: {
+    messages: [],
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("No messages yet")).toBeInTheDocument();
+  },
+};
+
+export const EmailConversation: Story = {
+  args: {
+    conversation: conversationsFixture[1],
+    messages: [],
+    jobs: [],
+  },
+  play: async ({ canvas }) => {
+    await expect(
+      canvas.queryByPlaceholderText("Paste text or describe what to translate..."),
+    ).not.toBeInTheDocument();
+  },
+};
+
+export const Streaming: Story = {
+  args: {
+    isStreaming: true,
+    streamedAssistant: createStreamedAssistantMessage(),
+  },
+};

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-api.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-api.ts
@@ -21,7 +21,7 @@ export type InboxApi = {
     organizationSlug: string,
     conversationId: string,
     input: SendConversationMessageInput,
-  ): Promise<unknown>;
+  ): Promise<void>;
 };
 
 type ApiClient = ReturnType<typeof createApiClient>;
@@ -96,8 +96,6 @@ export function createInboxApi(client: ApiClient): InboxApi {
       if (!response.ok) {
         throw await readApiResponseError(response, "Failed to send message");
       }
-
-      return response.json();
     },
   };
 }

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-api.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-api.ts
@@ -1,0 +1,103 @@
+import type { ProjectsResponse } from "@/api/routes/project/project.schema";
+import type { createApiClient } from "@/lib/api-client";
+import { readApiResponseError } from "@/lib/api-error";
+
+import type { Conversation, ConversationMessage, LinkedJob } from "./inbox-types";
+
+export type InboxProjectSummary = ProjectsResponse["projects"][number];
+
+export type SendConversationMessageInput = {
+  text: string;
+  files: File[];
+  projectId?: string;
+};
+
+export type InboxApi = {
+  listConversations(organizationSlug: string, limit?: number): Promise<Conversation[]>;
+  listMessages(organizationSlug: string, conversationId: string): Promise<ConversationMessage[]>;
+  listLinkedJobs(organizationSlug: string, conversationId: string): Promise<LinkedJob[]>;
+  listProjects(organizationSlug: string): Promise<InboxProjectSummary[]>;
+  sendMessage(
+    organizationSlug: string,
+    conversationId: string,
+    input: SendConversationMessageInput,
+  ): Promise<unknown>;
+};
+
+type ApiClient = ReturnType<typeof createApiClient>;
+
+export function createInboxApi(client: ApiClient): InboxApi {
+  const conversations = client.api.orgs[":organizationSlug"].conversations;
+
+  return {
+    async listConversations(organizationSlug, limit = 50) {
+      const response = await conversations.$get({
+        param: { organizationSlug },
+        query: { limit: String(limit) },
+      });
+      if (!response.ok) {
+        throw await readApiResponseError(response, "Failed to load conversations");
+      }
+      const body = (await response.json()) as { conversations: Conversation[] };
+      return body.conversations;
+    },
+
+    async listMessages(organizationSlug, conversationId) {
+      const response = await conversations[":conversationId"].messages.$get({
+        param: { organizationSlug, conversationId },
+      });
+      if (!response.ok) {
+        throw await readApiResponseError(response, "Failed to load messages");
+      }
+      const body = (await response.json()) as { messages: ConversationMessage[] };
+      return body.messages;
+    },
+
+    async listLinkedJobs(organizationSlug, conversationId) {
+      const response = await conversations[":conversationId"].jobs.$get({
+        param: { organizationSlug, conversationId },
+      });
+      if (!response.ok) {
+        throw await readApiResponseError(response, "Failed to load jobs");
+      }
+      const body = (await response.json()) as { jobs: LinkedJob[] };
+      return body.jobs;
+    },
+
+    async listProjects(organizationSlug) {
+      const response = await client.api.orgs[":organizationSlug"].projects.$get({
+        param: { organizationSlug },
+      });
+      if (!response.ok) {
+        throw await readApiResponseError(response, "Failed to load projects");
+      }
+      const body = (await response.json()) as ProjectsResponse;
+      return body.projects;
+    },
+
+    async sendMessage(organizationSlug, conversationId, input) {
+      const formData = new FormData();
+      formData.append("text", input.text);
+      if (input.projectId) {
+        formData.append("projectId", input.projectId);
+      }
+      for (const file of input.files) {
+        formData.append("files", file);
+      }
+
+      const response = await fetch(
+        `/api/orgs/${encodeURIComponent(organizationSlug)}/conversations/${encodeURIComponent(conversationId)}/messages`,
+        {
+          method: "POST",
+          body: formData,
+        },
+      );
+
+      if (!response.ok) {
+        throw await readApiResponseError(response, "Failed to send message");
+      }
+
+      return response.json();
+    },
+  };
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-list.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-list.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, fn } from "storybook/test";
+
+import { conversationsFixture, currentUserFixture } from "./inbox.fixture";
+import { InboxList } from "./inbox-list";
+
+const meta = {
+  title: "App/Inbox/List",
+  component: InboxList,
+  parameters: {
+    layout: "padded",
+  },
+  decorators: [
+    (Story) => (
+      <div className="h-[32rem] w-full max-w-sm border border-border bg-background">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    conversations: conversationsFixture,
+    currentUser: currentUserFixture,
+    isLoading: false,
+    isError: false,
+    selectedConversationId: conversationsFixture[0].id,
+    onSelectConversation: fn(),
+  },
+} satisfies Meta<typeof InboxList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Translate homepage hero copy")).toBeInTheDocument();
+    await expect(canvas.getByText("Email: Q3 release notes")).toBeInTheDocument();
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    conversations: [],
+    isLoading: true,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    conversations: [],
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("No conversations yet.")).toBeInTheDocument();
+  },
+};
+
+export const Error: Story = {
+  args: {
+    conversations: [],
+    isError: true,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Unable to load conversations.")).toBeInTheDocument();
+  },
+};

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-page-content.tsx
@@ -6,7 +6,7 @@ import { useMutation, useQuery } from "@tanstack/react-query";
 
 import { apiClient } from "@/lib/api-client-instance";
 
-import { createInboxApi } from "./inbox-api";
+import { createInboxApi, type InboxApi } from "./inbox-api";
 import { InboxPageView } from "./inbox-page-view";
 import type { InboxCurrentUser } from "./inbox-types";
 import { useConversationStream } from "./use-conversation-stream";
@@ -32,7 +32,7 @@ export function InboxPageContent({
 }: {
   currentUser: InboxCurrentUser;
   organizationSlug: string;
-  inboxApi?: typeof inboxApi;
+  inboxApi?: InboxApi;
 }) {
   const router = useRouter();
   const params = useParams();

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-page-content.tsx
@@ -5,76 +5,60 @@ import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 
 import { apiClient } from "@/lib/api-client-instance";
-import { cn } from "@/lib/primitives/cn";
 
-import { ConversationPanel } from "./conversation-panel";
-import { InboxList } from "./inbox-list";
-import type { Conversation, ConversationMessage, InboxCurrentUser, LinkedJob } from "./inbox-types";
+import { createInboxApi } from "./inbox-api";
+import { InboxPageView } from "./inbox-page-view";
+import type { InboxCurrentUser } from "./inbox-types";
 import { useConversationStream } from "./use-conversation-stream";
+
+const inboxApi = createInboxApi(apiClient);
+
+function conversationsQueryKey(organizationSlug: string) {
+  return ["conversations", organizationSlug] as const;
+}
+
+function messagesQueryKey(conversationId: string) {
+  return ["conversation-messages", conversationId] as const;
+}
+
+function jobsQueryKey(conversationId: string) {
+  return ["conversation-jobs", conversationId] as const;
+}
 
 export function InboxPageContent({
   currentUser,
   organizationSlug,
+  inboxApi: injectedInboxApi = inboxApi,
 }: {
   currentUser: InboxCurrentUser;
   organizationSlug: string;
+  inboxApi?: typeof inboxApi;
 }) {
   const router = useRouter();
   const params = useParams();
   const urlConversationId = params?.conversationId as string | undefined;
 
   const conversationsQuery = useQuery({
-    queryKey: ["conversations", organizationSlug],
-    queryFn: async () => {
-      const response = await apiClient.api.orgs[":organizationSlug"].conversations.$get({
-        param: { organizationSlug },
-        query: { limit: "50" },
-      });
-
-      if (!response.ok) throw new Error("Failed to load conversations");
-      return (await response.json()) as { conversations: Conversation[] };
-    },
+    queryKey: conversationsQueryKey(organizationSlug),
+    queryFn: () => injectedInboxApi.listConversations(organizationSlug),
   });
 
-  const conversations = conversationsQuery.data?.conversations ?? [];
+  const conversations = conversationsQuery.data ?? [];
   const selectedConversationId = urlConversationId ?? conversations[0]?.id ?? "";
-  // Memoize selected conversation to prevent re-calculating on every stream chunk
   const selectedConversation = useMemo(
     () => conversations.find((conversation) => conversation.id === selectedConversationId),
     [conversations, selectedConversationId],
   );
 
   const messagesQuery = useQuery({
-    queryKey: ["conversation-messages", selectedConversationId],
-    queryFn: async () => {
-      if (!selectedConversationId) return { messages: [] as ConversationMessage[] };
-
-      const response = await apiClient.api.orgs[":organizationSlug"].conversations[
-        ":conversationId"
-      ].messages.$get({
-        param: { organizationSlug, conversationId: selectedConversationId },
-      });
-
-      if (!response.ok) throw new Error("Failed to load messages");
-      return (await response.json()) as { messages: ConversationMessage[] };
-    },
+    queryKey: messagesQueryKey(selectedConversationId),
+    queryFn: () => injectedInboxApi.listMessages(organizationSlug, selectedConversationId),
     enabled: !!selectedConversationId,
   });
 
   const jobsQuery = useQuery({
-    queryKey: ["conversation-jobs", selectedConversationId],
-    queryFn: async () => {
-      if (!selectedConversationId) return { jobs: [] as LinkedJob[] };
-
-      const response = await apiClient.api.orgs[":organizationSlug"].conversations[
-        ":conversationId"
-      ].jobs.$get({
-        param: { organizationSlug, conversationId: selectedConversationId },
-      });
-
-      if (!response.ok) throw new Error("Failed to load jobs");
-      return (await response.json()) as { jobs: LinkedJob[] };
-    },
+    queryKey: jobsQueryKey(selectedConversationId),
+    queryFn: () => injectedInboxApi.listLinkedJobs(organizationSlug, selectedConversationId),
     enabled: !!selectedConversationId,
   });
 
@@ -89,35 +73,8 @@ export function InboxPageContent({
   });
 
   const sendMessageMutation = useMutation({
-    mutationFn: async ({
-      text,
-      files,
-      projectId,
-    }: {
-      text: string;
-      files: File[];
-      projectId?: string;
-    }) => {
-      const formData = new FormData();
-      formData.append("text", text);
-      if (projectId) {
-        formData.append("projectId", projectId);
-      }
-      for (const file of files) {
-        formData.append("files", file);
-      }
-
-      const response = await fetch(
-        `/api/orgs/${encodeURIComponent(organizationSlug)}/conversations/${encodeURIComponent(selectedConversationId)}/messages`,
-        {
-          method: "POST",
-          body: formData,
-        },
-      );
-
-      if (!response.ok) throw new Error("Failed to send message");
-      return response.json();
-    },
+    mutationFn: (input: { text: string; files: File[]; projectId?: string }) =>
+      injectedInboxApi.sendMessage(organizationSlug, selectedConversationId, input),
     onSuccess: () => {
       void messagesQuery.refetch();
       void conversationsQuery.refetch();
@@ -125,9 +82,10 @@ export function InboxPageContent({
   });
 
   const mutateAsync = sendMessageMutation.mutateAsync;
-  // Stabilize callbacks to prevent unnecessary re-renders of memoized child components
   const onSendMessage = useCallback(
-    (text: string, files: File[], projectId?: string) => mutateAsync({ text, files, projectId }),
+    async (text: string, files: File[], projectId?: string) => {
+      await mutateAsync({ text, files, projectId });
+    },
     [mutateAsync],
   );
 
@@ -138,8 +96,8 @@ export function InboxPageContent({
     [router, organizationSlug],
   );
 
-  const messages = messagesQuery.data?.messages ?? [];
-  const jobs = jobsQuery.data?.jobs ?? [];
+  const messages = messagesQuery.data ?? [];
+  const jobs = jobsQuery.data ?? [];
   const lastMessage = messages.at(-1);
   const isSparseInbox = !conversationsQuery.isLoading && conversations.length <= 1;
 
@@ -170,41 +128,24 @@ export function InboxPageContent({
   ]);
 
   return (
-    <main
-      data-organization={organizationSlug}
-      className="-mx-4 -my-5 bg-background text-foreground sm:-mx-6 lg:-mx-8 lg:min-h-[calc(100svh-3.5rem)] lg:overflow-hidden"
-    >
-      <div
-        className={cn(
-          "grid grid-cols-1 lg:min-h-[calc(100svh-3.5rem)]",
-          isSparseInbox
-            ? "lg:grid-cols-[minmax(14rem,17rem)_minmax(0,1fr)]"
-            : "lg:grid-cols-[minmax(20rem,24rem)_minmax(0,1fr)] xl:grid-cols-[minmax(22rem,26rem)_minmax(0,1fr)]",
-        )}
-      >
-        <InboxList
-          conversations={conversations}
-          currentUser={currentUser}
-          isError={conversationsQuery.isError}
-          isLoading={conversationsQuery.isLoading}
-          onSelectConversation={onSelectConversation}
-          selectedConversationId={selectedConversationId}
-        />
-
-        <ConversationPanel
-          conversation={selectedConversation}
-          currentUser={currentUser}
-          isSending={sendMessageMutation.isPending}
-          isStreaming={isStreaming}
-          jobs={jobs}
-          jobsIsLoading={jobsQuery.isLoading}
-          messages={messages}
-          messagesIsLoading={messagesQuery.isLoading}
-          onSendMessage={onSendMessage}
-          organizationSlug={organizationSlug}
-          streamedAssistant={streamedAssistant}
-        />
-      </div>
-    </main>
+    <InboxPageView
+      conversations={conversations}
+      conversationsIsError={conversationsQuery.isError}
+      conversationsIsLoading={conversationsQuery.isLoading}
+      currentUser={currentUser}
+      isSending={sendMessageMutation.isPending}
+      isSparseInbox={isSparseInbox}
+      isStreaming={isStreaming}
+      jobs={jobs}
+      jobsIsLoading={jobsQuery.isLoading}
+      messages={messages}
+      messagesIsLoading={messagesQuery.isLoading}
+      onSelectConversation={onSelectConversation}
+      onSendMessage={onSendMessage}
+      organizationSlug={organizationSlug}
+      selectedConversation={selectedConversation}
+      selectedConversationId={selectedConversationId}
+      streamedAssistant={streamedAssistant}
+    />
   );
 }

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-page-view.stories.tsx
@@ -1,0 +1,151 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, fn } from "storybook/test";
+
+import {
+  conversationsFixture,
+  createConversation,
+  createStreamedAssistantMessage,
+  currentUserFixture,
+  linkedJobsFixture,
+  messagesFixture,
+} from "./inbox.fixture";
+import { InboxPageView } from "./inbox-page-view";
+
+const meta = {
+  title: "App/Inbox/Page",
+  component: InboxPageView,
+  parameters: {
+    layout: "fullscreen",
+  },
+  args: {
+    organizationSlug: "acme",
+    currentUser: currentUserFixture,
+    conversations: conversationsFixture,
+    conversationsIsLoading: false,
+    conversationsIsError: false,
+    selectedConversationId: conversationsFixture[0].id,
+    selectedConversation: conversationsFixture[0],
+    messages: messagesFixture,
+    messagesIsLoading: false,
+    jobs: linkedJobsFixture,
+    jobsIsLoading: false,
+    isSending: false,
+    isStreaming: false,
+    isSparseInbox: false,
+    streamedAssistant: null,
+    onSelectConversation: fn(),
+    onSendMessage: fn(),
+  },
+} satisfies Meta<typeof InboxPageView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Translate homepage hero copy")).toBeInTheDocument();
+    await expect(
+      canvas.getByText("Can you localize the hero section for French and German?"),
+    ).toBeInTheDocument();
+  },
+};
+
+export const LoadingConversations: Story = {
+  args: {
+    conversations: [],
+    selectedConversationId: "",
+    selectedConversation: undefined,
+    messages: [],
+    jobs: [],
+    conversationsIsLoading: true,
+    messagesIsLoading: true,
+    jobsIsLoading: true,
+  },
+};
+
+export const EmptyInbox: Story = {
+  args: {
+    conversations: [],
+    selectedConversationId: "",
+    selectedConversation: undefined,
+    messages: [],
+    jobs: [],
+    isSparseInbox: true,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("No conversations yet.")).toBeInTheDocument();
+    await expect(canvas.getByText("Select a conversation to view details")).toBeInTheDocument();
+  },
+};
+
+export const ConversationsLoadError: Story = {
+  args: {
+    conversations: [],
+    selectedConversationId: "",
+    selectedConversation: undefined,
+    messages: [],
+    jobs: [],
+    conversationsIsError: true,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Unable to load conversations.")).toBeInTheDocument();
+  },
+};
+
+export const SparseInbox: Story = {
+  args: {
+    conversations: [conversationsFixture[0]],
+    isSparseInbox: true,
+  },
+};
+
+export const StreamingResponse: Story = {
+  args: {
+    isStreaming: true,
+    streamedAssistant: createStreamedAssistantMessage(),
+  },
+};
+
+export const EmailConversation: Story = {
+  args: {
+    selectedConversationId: conversationsFixture[1].id,
+    selectedConversation: conversationsFixture[1],
+    messages: [],
+    jobs: [],
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Email: Q3 release notes")).toBeInTheDocument();
+    await expect(
+      canvas.queryByPlaceholderText("Paste text or describe what to translate..."),
+    ).not.toBeInTheDocument();
+  },
+};
+
+export const ArchivedConversation: Story = {
+  args: {
+    selectedConversationId: conversationsFixture[2].id,
+    selectedConversation: conversationsFixture[2],
+    messages: [
+      {
+        id: "msg_archived",
+        conversationId: conversationsFixture[2].id,
+        senderType: "agent",
+        senderEmail: null,
+        text: "Opened a PR with updated checkout copy.",
+        attachments: null,
+        createdAt: conversationsFixture[2].lastMessageAt,
+      },
+    ],
+    jobs: [],
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("archived")).toBeInTheDocument();
+  },
+};
+
+export const SendingMessage: Story = {
+  args: {
+    isSending: true,
+    selectedConversation: createConversation({ source: "chat_ui" }),
+  },
+};

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/inbox-page-view.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { cn } from "@/lib/primitives/cn";
+
+import { ConversationPanel } from "./conversation-panel";
+import { InboxList } from "./inbox-list";
+import type {
+  Conversation,
+  ConversationMessage,
+  InboxCurrentUser,
+  LinkedJob,
+  StreamedAssistantMessage,
+} from "./inbox-types";
+
+export function InboxPageView({
+  conversations,
+  conversationsIsError,
+  conversationsIsLoading,
+  currentUser,
+  isSending,
+  isSparseInbox,
+  isStreaming,
+  jobs,
+  jobsIsLoading,
+  messages,
+  messagesIsLoading,
+  onSelectConversation,
+  onSendMessage,
+  organizationSlug,
+  selectedConversation,
+  selectedConversationId,
+  streamedAssistant,
+}: {
+  conversations: Conversation[];
+  conversationsIsError: boolean;
+  conversationsIsLoading: boolean;
+  currentUser: InboxCurrentUser;
+  isSending: boolean;
+  isSparseInbox: boolean;
+  isStreaming: boolean;
+  jobs: LinkedJob[];
+  jobsIsLoading: boolean;
+  messages: ConversationMessage[];
+  messagesIsLoading: boolean;
+  onSelectConversation: (conversationId: string) => void;
+  onSendMessage: (text: string, files: File[], projectId?: string) => void | Promise<void>;
+  organizationSlug: string;
+  selectedConversation: Conversation | undefined;
+  selectedConversationId: string;
+  streamedAssistant: StreamedAssistantMessage | null;
+}) {
+  return (
+    <main
+      data-organization={organizationSlug}
+      className="-mx-4 -my-5 bg-background text-foreground sm:-mx-6 lg:-mx-8 lg:min-h-[calc(100svh-3.5rem)] lg:overflow-hidden"
+    >
+      <div
+        className={cn(
+          "grid grid-cols-1 lg:min-h-[calc(100svh-3.5rem)]",
+          isSparseInbox
+            ? "lg:grid-cols-[minmax(14rem,17rem)_minmax(0,1fr)]"
+            : "lg:grid-cols-[minmax(20rem,24rem)_minmax(0,1fr)] xl:grid-cols-[minmax(22rem,26rem)_minmax(0,1fr)]",
+        )}
+      >
+        <InboxList
+          conversations={conversations}
+          currentUser={currentUser}
+          isError={conversationsIsError}
+          isLoading={conversationsIsLoading}
+          onSelectConversation={onSelectConversation}
+          selectedConversationId={selectedConversationId}
+        />
+
+        <ConversationPanel
+          conversation={selectedConversation}
+          currentUser={currentUser}
+          isSending={isSending}
+          isStreaming={isStreaming}
+          jobs={jobs}
+          jobsIsLoading={jobsIsLoading}
+          messages={messages}
+          messagesIsLoading={messagesIsLoading}
+          onSendMessage={onSendMessage}
+          organizationSlug={organizationSlug}
+          streamedAssistant={streamedAssistant}
+        />
+      </div>
+    </main>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/inbox.fixture.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/inbox.fixture.ts
@@ -1,0 +1,190 @@
+import type { UIMessage } from "ai";
+
+import type { InboxProjectSummary } from "./inbox-api";
+import type {
+  Conversation,
+  ConversationMessage,
+  InboxCurrentUser,
+  LinkedJob,
+  StreamedAssistantMessage,
+} from "./inbox-types";
+
+const fixedNow = "2026-06-07T12:00:00.000Z";
+
+function iso(offsetMs: number) {
+  return new Date(Date.parse(fixedNow) + offsetMs).toISOString();
+}
+
+export function createCurrentUser(overrides: Partial<InboxCurrentUser> = {}): InboxCurrentUser {
+  return {
+    avatarUrl: null,
+    email: "mina@example.com",
+    name: "Mina Chen",
+    ...overrides,
+  };
+}
+
+export function createConversation(overrides: Partial<Conversation> = {}): Conversation {
+  return {
+    id: "11111111-1111-4111-8111-111111111111",
+    title: "Translate homepage hero copy",
+    source: "chat_ui",
+    status: "active",
+    projectId: "project_website",
+    lastMessageAt: iso(-1_800_000),
+    createdAt: iso(-86_400_000),
+    participantEmail: "mina@example.com",
+    lastMessage: {
+      text: "Can you localize the hero section for French and German?",
+      senderType: "user",
+      createdAt: iso(-1_800_000),
+    },
+    ...overrides,
+  };
+}
+
+export function createConversationMessage(
+  overrides: Partial<ConversationMessage> = {},
+): ConversationMessage {
+  return {
+    id: "msg_001",
+    conversationId: "11111111-1111-4111-8111-111111111111",
+    senderType: "user",
+    senderEmail: "mina@example.com",
+    text: "Can you localize the hero section for French and German?",
+    attachments: null,
+    createdAt: iso(-1_800_000),
+    ...overrides,
+  };
+}
+
+export function createLinkedJob(overrides: Partial<LinkedJob> = {}): LinkedJob {
+  return {
+    id: "job_translate_homepage",
+    projectId: "project_website",
+    kind: "translation",
+    type: "file",
+    status: "running",
+    outcomeKind: null,
+    createdAt: iso(-3_600_000),
+    completedAt: null,
+    ...overrides,
+  };
+}
+
+export function createProjectSummary(
+  overrides: Partial<InboxProjectSummary> = {},
+): InboxProjectSummary {
+  return {
+    id: "project_website",
+    organizationId: "org_001",
+    teamId: null,
+    createdByUserId: "user_001",
+    name: "Website",
+    description: "Marketing website localization",
+    translationContext: "Public marketing copy",
+    source: "native",
+    externalProviderKind: null,
+    externalProjectId: null,
+    sourceLocale: "en-US",
+    targetLocales: ["fr-FR", "de-DE"],
+    externalProjectUrl: null,
+    isActive: true,
+    lastSyncedAt: null,
+    lastSyncErrorAt: null,
+    lastSyncErrorMessage: null,
+    createdAt: iso(-604_800_000),
+    updatedAt: iso(-86_400_000),
+    openJobCount: 2,
+    ...overrides,
+  };
+}
+
+export function createStreamedAssistantMessage(
+  overrides: Partial<StreamedAssistantMessage> = {},
+): StreamedAssistantMessage {
+  const message: UIMessage = {
+    id: "stream-msg_001",
+    role: "assistant",
+    parts: [
+      {
+        type: "text",
+        text: "I can help translate the hero section. I'll create translation jobs for French and German.",
+        state: "done",
+      },
+    ],
+  };
+
+  return {
+    conversationId: "11111111-1111-4111-8111-111111111111",
+    responseToMessageId: "msg_001",
+    message,
+    status: "streaming",
+    ...overrides,
+  };
+}
+
+export const currentUserFixture = createCurrentUser();
+
+export const conversationsFixture: Conversation[] = [
+  createConversation(),
+  createConversation({
+    id: "22222222-2222-4222-8222-222222222222",
+    title: "Email: Q3 release notes",
+    source: "email_agent",
+    participantEmail: "partner@example.com",
+    lastMessage: {
+      text: "Please review the attached release notes draft.",
+      senderType: "user",
+      createdAt: iso(-7_200_000),
+    },
+    lastMessageAt: iso(-7_200_000),
+    createdAt: iso(-172_800_000),
+    projectId: null,
+  }),
+  createConversation({
+    id: "33333333-3333-4333-8333-333333333333",
+    title: "GitHub: checkout strings",
+    source: "github_agent",
+    status: "archived",
+    participantEmail: "dev@example.com",
+    lastMessage: {
+      text: "Opened a PR with updated checkout copy.",
+      senderType: "agent",
+      createdAt: iso(-259_200_000),
+    },
+    lastMessageAt: iso(-259_200_000),
+    createdAt: iso(-432_000_000),
+    projectId: "project_mobile",
+  }),
+];
+
+export const messagesFixture: ConversationMessage[] = [
+  createConversationMessage(),
+  createConversationMessage({
+    id: "msg_002",
+    senderType: "agent",
+    senderEmail: null,
+    text: "I'll start by extracting the hero strings and creating translation jobs for French and German.",
+    createdAt: iso(-1_500_000),
+  }),
+];
+
+export const linkedJobsFixture: LinkedJob[] = [
+  createLinkedJob(),
+  createLinkedJob({
+    id: "job_review_hero",
+    kind: "review",
+    type: null,
+    status: "waiting_for_review",
+    createdAt: iso(-1_200_000),
+  }),
+];
+
+export const projectsFixture: InboxProjectSummary[] = [
+  createProjectSummary(),
+  createProjectSummary({
+    id: "project_mobile",
+    name: "Mobile app",
+  }),
+];

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, fn } from "storybook/test";
+
+import { PromptInputProvider } from "@/components/ai-elements/prompt-input";
+
+import { projectsFixture } from "./inbox.fixture";
+import { ReplyComposerView } from "./reply-composer";
+
+const meta = {
+  title: "App/Inbox/ReplyComposer",
+  component: ReplyComposerView,
+  parameters: {
+    layout: "padded",
+  },
+  decorators: [
+    (Story) => (
+      <PromptInputProvider>
+        <div className="w-full max-w-3xl bg-background">
+          <Story />
+        </div>
+      </PromptInputProvider>
+    ),
+  ],
+  args: {
+    conversationProjectId: "project_website",
+    disabled: false,
+    isStreaming: false,
+    projects: projectsFixture,
+    projectsIsLoading: false,
+    projectsIsError: false,
+    onSend: fn(),
+  },
+} satisfies Meta<typeof ReplyComposerView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvas }) => {
+    await expect(
+      canvas.getByPlaceholderText("Paste text or describe what to translate..."),
+    ).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Send reply" })).toBeInTheDocument();
+    await expect(canvas.getByText("Website")).toBeInTheDocument();
+  },
+};
+
+export const Streaming: Story = {
+  args: {
+    isStreaming: true,
+    disabled: true,
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByPlaceholderText("Agent is responding...")).toBeInTheDocument();
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+};
+
+export const LoadingProjects: Story = {
+  args: {
+    projects: [],
+    projectsIsLoading: true,
+  },
+};
+
+export const ProjectsLoadError: Story = {
+  args: {
+    projects: [],
+    projectsIsError: true,
+  },
+};
+
+export const NoProjects: Story = {
+  args: {
+    projects: [],
+    conversationProjectId: null,
+  },
+};

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.tsx
@@ -45,6 +45,10 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { apiClient } from "@/lib/api-client-instance";
 
+import { createInboxApi, type InboxProjectSummary } from "./inbox-api";
+
+const inboxApi = createInboxApi(apiClient);
+
 function dataUrlToFile(dataUrl: string, filename: string, mediaType?: string): File {
   const arr = dataUrl.split(",");
   if (arr.length < 2) {
@@ -75,29 +79,25 @@ const attachOptions = [
   },
 ] as const;
 
-type ReplyComposerProps = {
+type ReplyComposerViewProps = {
   conversationProjectId: string | null;
   disabled: boolean;
   isStreaming: boolean;
   onSend: (text: string, files: File[], projectId?: string) => void | Promise<void>;
-  organizationSlug: string;
+  projects: InboxProjectSummary[];
+  projectsIsError: boolean;
+  projectsIsLoading: boolean;
 };
 
-export const ReplyComposer = memo(function ReplyComposer(props: ReplyComposerProps) {
-  return (
-    <PromptInputProvider>
-      <ReplyComposerContent {...props} />
-    </PromptInputProvider>
-  );
-});
-
-function ReplyComposerContent({
+export function ReplyComposerView({
   conversationProjectId,
   disabled,
   isStreaming,
   onSend,
-  organizationSlug,
-}: ReplyComposerProps) {
+  projects,
+  projectsIsError,
+  projectsIsLoading,
+}: ReplyComposerViewProps) {
   const [replyText, setReplyText] = useState("");
   const [selectedProjectId, setSelectedProjectId] = useState(conversationProjectId ?? "");
 
@@ -105,23 +105,6 @@ function ReplyComposerContent({
     setSelectedProjectId(conversationProjectId ?? "");
   }, [conversationProjectId]);
 
-  const projectsQuery = useQuery({
-    queryKey: ["translation-projects", organizationSlug],
-    queryFn: async () => {
-      const response = await apiClient.api.orgs[":organizationSlug"].projects.$get({
-        param: { organizationSlug },
-      });
-
-      if (response.status !== 200) {
-        throw new Error(`Failed to load projects (${response.status})`);
-      }
-
-      const body = await response.json();
-      return body.projects;
-    },
-  });
-
-  const projects = projectsQuery.data ?? [];
   const selectedProject =
     projects.find((project) => project.id === selectedProjectId) ?? projects[0] ?? null;
   const projectTriggerLabel = selectedProject?.name ?? "Project";
@@ -235,7 +218,7 @@ function ReplyComposerContent({
                         strokeWidth={1.8}
                         className="size-4"
                       />
-                      {projectsQuery.isLoading ? (
+                      {projectsIsLoading ? (
                         <Skeleton className="h-3.5 w-24 rounded-full bg-muted-foreground/20" />
                       ) : (
                         projectTriggerLabel
@@ -251,7 +234,7 @@ function ReplyComposerContent({
                 <DropdownMenuContent className="min-w-56" align="end">
                   <DropdownMenuGroup>
                     <DropdownMenuLabel>Projects</DropdownMenuLabel>
-                    {projectsQuery.isLoading ? (
+                    {projectsIsLoading ? (
                       <>
                         <DropdownMenuItem disabled>
                           <Skeleton className="size-4 rounded-md bg-muted-foreground/20" />
@@ -267,10 +250,10 @@ function ReplyComposerContent({
                         </DropdownMenuItem>
                       </>
                     ) : null}
-                    {projectsQuery.isError ? (
+                    {projectsIsError ? (
                       <DropdownMenuItem disabled>Unable to load projects</DropdownMenuItem>
                     ) : null}
-                    {projectsQuery.isSuccess && projects.length === 0 ? (
+                    {!projectsIsLoading && !projectsIsError && projects.length === 0 ? (
                       <DropdownMenuItem disabled>No projects found</DropdownMenuItem>
                     ) : null}
                     {projects.map((project) => (
@@ -309,3 +292,33 @@ function ReplyComposerContent({
     </section>
   );
 }
+
+type ReplyComposerProps = Omit<
+  ReplyComposerViewProps,
+  "projects" | "projectsIsError" | "projectsIsLoading"
+> & {
+  organizationSlug: string;
+  inboxApi?: typeof inboxApi;
+};
+
+export const ReplyComposer = memo(function ReplyComposer({
+  organizationSlug,
+  inboxApi: injectedInboxApi = inboxApi,
+  ...viewProps
+}: ReplyComposerProps) {
+  const projectsQuery = useQuery({
+    queryKey: ["translation-projects", organizationSlug],
+    queryFn: () => injectedInboxApi.listProjects(organizationSlug),
+  });
+
+  return (
+    <PromptInputProvider>
+      <ReplyComposerView
+        {...viewProps}
+        projects={projectsQuery.data ?? []}
+        projectsIsError={projectsQuery.isError}
+        projectsIsLoading={projectsQuery.isLoading}
+      />
+    </PromptInputProvider>
+  );
+});

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/inbox/_components/reply-composer.tsx
@@ -45,7 +45,7 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { apiClient } from "@/lib/api-client-instance";
 
-import { createInboxApi, type InboxProjectSummary } from "./inbox-api";
+import { createInboxApi, type InboxApi, type InboxProjectSummary } from "./inbox-api";
 
 const inboxApi = createInboxApi(apiClient);
 
@@ -298,7 +298,7 @@ type ReplyComposerProps = Omit<
   "projects" | "projectsIsError" | "projectsIsLoading"
 > & {
   organizationSlug: string;
-  inboxApi?: typeof inboxApi;
+  inboxApi?: InboxApi;
 };
 
 export const ReplyComposer = memo(function ReplyComposer({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Refactors the Inbox page and its components to follow the same dependency injection pattern used by Teams, and adds Storybook coverage for the presentational layer.

## Changes

- **`inbox-api.ts`** — `createInboxApi()` factory encapsulating conversations, messages, linked jobs, projects, and send-message calls
- **`inbox-page-view.tsx`** — pure presentational page component receiving all state via props
- **`inbox-page-content.tsx`** — data-fetching layer using injected `inboxApi` (defaults to production client)
- **`reply-composer.tsx`** — split into `ReplyComposerView` (presentational) and `ReplyComposer` (fetches projects via injected API)
- **`inbox.fixture.ts`** — reusable fixture builders for conversations, messages, jobs, projects, and current user
- **Storybook stories** for:
  - `App/Inbox/Page` — loading, empty, error, sparse, streaming, email, archived states
  - `App/Inbox/List`
  - `App/Inbox/ConversationPanel`
  - `App/Inbox/MessageList`
  - `App/Inbox/ConversationDetails`
  - `App/Inbox/ReplyComposer`

## Testing

- `vp check --fix` — pass
- `vp test` — 1644 tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f3d8297-b267-4ffa-88aa-cfa09f3dc340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f3d8297-b267-4ffa-88aa-cfa09f3dc340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

