### PR TITLE
🧪 Scout: Fix path resolution edge case for empty localeDir

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -71,3 +71,11 @@
 ## 2025-06-25 - [Path Resolution with Empty Tokens]
 **Learning:** Path resolution patterns using tokens like {{localeDir}} can produce leading slashes if the token is at the start of the pattern and resolves to an empty string (e.g., when source and target locales match). These leading slashes can cause downstream safety checks that expect strictly relative paths to fail.
 **Action:** Always apply repository-relative path normalization after token substitution and before safety validation to ensure consistent handling of relative paths regardless of token resolution.
+
+## 2025-06-25 - [Slash Collapsing in Path Resolution]
+**Learning:**  may only handle leading/trailing slashes and specific segments (like  or ). It might not collapse internal multiple slashes (e.g., ).
+**Action:** When performing token substitution that might result in empty segments, explicitly collapse multiple slashes using a regex (e.g., ) before applying repository-wide normalization.
+
+## 2025-06-25 - [Slash Collapsing in Path Resolution]
+**Learning:** `normalizeRepositoryRelativePath` may only handle leading/trailing slashes and specific segments (like `.` or `..`). It might not collapse internal multiple slashes (e.g., `a//b`).
+**Action:** When performing token substitution that might result in empty segments, explicitly collapse multiple slashes using a regex (e.g., `path.replace(/\/+/g, "/")`) before applying repository-wide normalization.

--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -67,3 +67,7 @@
 ## 2025-06-19 - [Flexible Whitespace in Self-Closing Tags]
 **Learning:** ICU and HTML-style tag parsers must handle flexible whitespace in self-closing tags (e.g., `<br / >`). Standard XML is strict about `/>`, but real-world localization strings often contain these variations. Failing to support them leads to "unclosed tag" errors during parsing.
 **Action:** Always allow whitespace after the slash in self-closing tag detection to improve compatibility with common HTML formatting.
+
+## 2025-06-25 - [Path Resolution with Empty Tokens]
+**Learning:** Path resolution patterns using tokens like {{localeDir}} can produce leading slashes if the token is at the start of the pattern and resolves to an empty string (e.g., when source and target locales match). These leading slashes can cause downstream safety checks that expect strictly relative paths to fail.
+**Action:** Always apply repository-relative path normalization after token substitution and before safety validation to ensure consistent handling of relative paths regardless of token resolution.

--- a/apps/hyperlocalise-web/src/lib/i18n/i18n-pathresolver.test.ts
+++ b/apps/hyperlocalise-web/src/lib/i18n/i18n-pathresolver.test.ts
@@ -22,4 +22,10 @@ describe("i18n-pathresolver", () => {
   it("handles empty {{localeDir}} at the start of a pattern when source matches target", () => {
     expect(resolveTargetPath("{{localeDir}}/messages.json", "en", "en")).toBe("messages.json");
   });
+
+  it("collapses internal double slashes when {{localeDir}} is empty", () => {
+    expect(resolveTargetPath("locales/{{localeDir}}/messages.json", "en", "en")).toBe(
+      "locales/messages.json",
+    );
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/i18n/i18n-pathresolver.test.ts
+++ b/apps/hyperlocalise-web/src/lib/i18n/i18n-pathresolver.test.ts
@@ -18,4 +18,8 @@ describe("i18n-pathresolver", () => {
       "locales/de/messages.json",
     );
   });
+
+  it("handles empty {{localeDir}} at the start of a pattern when source matches target", () => {
+    expect(resolveTargetPath("{{localeDir}}/messages.json", "en", "en")).toBe("messages.json");
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/i18n/i18n-pathresolver.ts
+++ b/apps/hyperlocalise-web/src/lib/i18n/i18n-pathresolver.ts
@@ -16,7 +16,7 @@ function resolve(pattern: string, sourceLocale: string, targetLocale: string): s
   path = path.replaceAll(TOKEN_LOCALE_DIR, localeDir);
   path = path.replaceAll(LEGACY_LOCALE, targetLocale);
 
-  path = normalizeRepositoryRelativePath(path);
+  path = normalizeRepositoryRelativePath(path.replace(/\/+/g, "/"));
 
   if (!isSafeRepositoryRelativePath(path)) {
     throw new Error(`Unsafe repository path: ${path}`);

--- a/apps/hyperlocalise-web/src/lib/i18n/i18n-pathresolver.ts
+++ b/apps/hyperlocalise-web/src/lib/i18n/i18n-pathresolver.ts
@@ -1,4 +1,7 @@
-import { isSafeRepositoryRelativePath } from "./safe-repository-path";
+import {
+  isSafeRepositoryRelativePath,
+  normalizeRepositoryRelativePath,
+} from "./safe-repository-path";
 
 const TOKEN_SOURCE = "{{source}}";
 const TOKEN_TARGET = "{{target}}";
@@ -13,9 +16,7 @@ function resolve(pattern: string, sourceLocale: string, targetLocale: string): s
   path = path.replaceAll(TOKEN_LOCALE_DIR, localeDir);
   path = path.replaceAll(LEGACY_LOCALE, targetLocale);
 
-  while (path.includes("//")) {
-    path = path.replaceAll("//", "/");
-  }
+  path = normalizeRepositoryRelativePath(path);
 
   if (!isSafeRepositoryRelativePath(path)) {
     throw new Error(`Unsafe repository path: ${path}`);


### PR DESCRIPTION
💡 What: Improved path resolution logic and added a regression test for i18n path resolution with empty tokens.
🎯 Why: A pattern starting with {{localeDir}} (e.g., {{localeDir}}/messages.json) would resolve to /messages.json when the source and target locales matched, causing the isSafeRepositoryRelativePath check to fail because of the leading slash.
🧩 Scope: apps/hyperlocalise-web/src/lib/i18n/i18n-pathresolver.ts, apps/hyperlocalise-web/src/lib/i18n/i18n-pathresolver.test.ts
✅ Verification: Ran `pnpm exec vp test src/lib/i18n/i18n-pathresolver.test.ts` and `pnpm exec vp check` in `apps/hyperlocalise-web`.
🛡️ Confidence: High. The fix uses existing normalization utilities and is protected by a new unit test.

---
*PR created automatically by Jules for task [16844340908794113760](https://jules.google.com/task/16844340908794113760) started by @cungminh2710*