### PR TITLE
fix(cat): TipTap decision context and action loading UX

### DIFF
--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/tms-job-cat-workspace.test.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/tms-job-cat-workspace.test.ts
@@ -99,6 +99,16 @@ describe("projectFileCatToWorkspaceState", () => {
       "1 Crowdin comment is attached",
     );
     expect(state.breadcrumbs).toEqual(["crowdin", "en-US.json", "vi"]);
+    expect(state.canEditTranslations).toBe(true);
+  });
+
+  it("maps canEditTranslations from the CAT file payload", () => {
+    const readOnlyState = projectFileCatToWorkspaceState({
+      ...catFile(),
+      canEditTranslations: false,
+    });
+
+    expect(readOnlyState.canEditTranslations).toBe(false);
   });
 });
 

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/tms-job-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/tms-job-cat-workspace.tsx
@@ -215,6 +215,7 @@ export function projectFileCatToWorkspaceState(catFile: CatFile): CatWorkspaceSt
     ),
     breadcrumbs: [catFile.provider?.kind ?? "provider", catFile.filename, catFile.targetLocale],
     primaryActionLabel: "Save to Crowdin",
+    canEditTranslations: catFile.canEditTranslations,
   };
 }
 
@@ -362,7 +363,7 @@ export function TmsJobCatWorkspace({
       className={cn("min-h-0 flex-1", className)}
       services={{
         validateFormat: validateSegmentFormat,
-        lookupSegmentContext: catQuery.data?.canEditTranslations ? lookupSegmentContext : undefined,
+        lookupSegmentContext,
       }}
       review={{
         onApprove: handleApprove,

--- a/apps/hyperlocalise-web/src/components/cat/cat-editor-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-editor-panel.tsx
@@ -7,6 +7,7 @@ import { useHotkeys } from "react-hotkeys-hook";
 
 import { Button } from "@/components/ui/button";
 import { Kbd, KbdGroup } from "@/components/ui/kbd";
+import { Spinner } from "@/components/ui/spinner";
 import { Textarea } from "@/components/ui/textarea";
 
 import { CatFormatChecks } from "./cat-format-checks";
@@ -39,7 +40,11 @@ export function CatEditorPanel({
   totalSegments,
   formatChecks,
   intelligence,
-  isBusy,
+  isEditorBusy,
+  isApproving = false,
+  isLookingUpContext = false,
+  canApprove = true,
+  canLookupContext = false,
   onTargetChange,
   onUseAiSuggestion,
   onApprove,
@@ -55,7 +60,11 @@ export function CatEditorPanel({
   totalSegments: number;
   formatChecks: CatFormatCheck[];
   intelligence: CatSegmentIntelligence;
-  isBusy?: boolean;
+  isEditorBusy?: boolean;
+  isApproving?: boolean;
+  isLookingUpContext?: boolean;
+  canApprove?: boolean;
+  canLookupContext?: boolean;
   onTargetChange: (value: string) => void;
   onUseAiSuggestion: () => void;
   onApprove: () => void;
@@ -187,7 +196,7 @@ export function CatEditorPanel({
               sourceText={segment.sourceText}
               value={segment.targetText}
               onChange={onTargetChange}
-              disabled={isBusy}
+              disabled={isEditorBusy}
             />
             <CatIcuStructureSummary blocks={sourceMessageAnalysis.icuBlocks} />
           </section>
@@ -221,20 +230,39 @@ export function CatEditorPanel({
             <Button
               className="bg-grove-500 text-white hover:bg-grove-400"
               onClick={onApprove}
-              disabled={isBusy}
+              disabled={!canApprove || isApproving || isLookingUpContext}
             >
+              {isApproving ? <Spinner className="size-4 text-white" /> : null}
               {primaryActionLabel}
               <ShortcutKbd keys={["⌘", "↵"]} className="bg-white/15 text-white" />
             </Button>
-            <Button variant="outline" onClick={onAskQuestion} disabled={isBusy}>
-              Find context
+            <Button
+              variant="outline"
+              onClick={onAskQuestion}
+              disabled={!canLookupContext || isApproving || isLookingUpContext}
+              title={
+                canLookupContext
+                  ? "Look up where this string appears in the connected repository"
+                  : "Repository context lookup is not available"
+              }
+            >
+              {isLookingUpContext ? <Spinner className="size-4" /> : null}
+              {isLookingUpContext ? "Finding context…" : "Find context"}
               <ShortcutKbd keys={["⌘", "K"]} />
             </Button>
-            <Button variant="ghost" onClick={onPrevious} disabled={isBusy || !hasPreviousSegment}>
+            <Button
+              variant="ghost"
+              onClick={onPrevious}
+              disabled={isApproving || isLookingUpContext || !hasPreviousSegment}
+            >
               Previous
               <ShortcutKbd keys={["⌘", "←"]} />
             </Button>
-            <Button variant="ghost" onClick={onNext} disabled={isBusy || !hasNextSegment}>
+            <Button
+              variant="ghost"
+              onClick={onNext}
+              disabled={isApproving || isLookingUpContext || !hasNextSegment}
+            >
               Next
               <ShortcutKbd keys={["⌘", "→"]} />
             </Button>

--- a/apps/hyperlocalise-web/src/components/cat/cat-intelligence-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-intelligence-panel.tsx
@@ -4,7 +4,9 @@ import type { ReactNode } from "react";
 import { BulbIcon, CheckmarkCircle02Icon, InformationCircleIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 
+import { MarkdownContent } from "@/components/markdown-description-editor";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { Spinner } from "@/components/ui/spinner";
 
 import type { CatGlossaryTerm, CatSegmentIntelligence, CatTranslationMemoryMatch } from "./types";
 
@@ -89,12 +91,22 @@ function TranslationMemoryRow({ match }: { match: CatTranslationMemoryMatch }) {
   );
 }
 
-export function CatIntelligencePanel({ intelligence }: { intelligence: CatSegmentIntelligence }) {
+export function CatIntelligencePanel({
+  intelligence,
+  isLookingUpContext = false,
+}: {
+  intelligence: CatSegmentIntelligence;
+  isLookingUpContext?: boolean;
+}) {
   const contextChips = [
     intelligence.locationBreadcrumb,
     intelligence.componentName,
     intelligence.filePath,
   ].filter(Boolean);
+  const productMeaning =
+    intelligence.productMeaning ?? intelligence.intent ?? "No product context provided.";
+  const showIntent =
+    Boolean(intelligence.productMeaning && intelligence.intent) && !isLookingUpContext;
 
   return (
     <div className="flex h-full min-h-0 flex-col border-l border-foreground/8 bg-background">
@@ -116,16 +128,28 @@ export function CatIntelligencePanel({ intelligence }: { intelligence: CatSegmen
                 label="Meaning in product"
                 icon={<HugeiconsIcon icon={InformationCircleIcon} className="size-3.5" />}
               >
-                <p className="whitespace-pre-wrap break-words text-pretty text-sm leading-relaxed text-foreground/88">
-                  {intelligence.productMeaning ??
-                    intelligence.intent ??
-                    "No product context provided."}
-                </p>
-                {intelligence.productMeaning && intelligence.intent ? (
-                  <p className="mt-2 whitespace-pre-wrap break-words text-pretty text-xs leading-relaxed text-muted-foreground">
-                    {intelligence.intent}
-                  </p>
-                ) : null}
+                {isLookingUpContext ? (
+                  <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                    <Spinner className="size-4" />
+                    <span>Looking up repository context…</span>
+                  </div>
+                ) : (
+                  <>
+                    <MarkdownContent
+                      value={productMeaning}
+                      contentClassName="min-h-0 px-0 py-0 text-sm leading-relaxed text-foreground/88"
+                      ariaLabel="Product context"
+                    />
+                    {showIntent ? (
+                      <MarkdownContent
+                        value={intelligence.intent ?? ""}
+                        className="mt-2"
+                        contentClassName="min-h-0 px-0 py-0 text-xs leading-relaxed text-muted-foreground"
+                        ariaLabel="Translation intent"
+                      />
+                    ) : null}
+                  </>
+                )}
               </InsightCard>
 
               {contextChips.length > 0 ? (

--- a/apps/hyperlocalise-web/src/components/cat/cat-intelligence-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-intelligence-panel.tsx
@@ -134,21 +134,20 @@ export function CatIntelligencePanel({
                     <span>Looking up repository context…</span>
                   </div>
                 ) : (
-                  <>
+                  <div className="min-h-[1.25rem] space-y-2">
                     <MarkdownContent
                       value={productMeaning}
-                      contentClassName="min-h-0 px-0 py-0 text-sm leading-relaxed text-foreground/88"
+                      contentClassName="min-h-[1.25rem] px-0 py-0 text-sm leading-relaxed text-foreground/88"
                       ariaLabel="Product context"
                     />
                     {showIntent ? (
                       <MarkdownContent
                         value={intelligence.intent ?? ""}
-                        className="mt-2"
-                        contentClassName="min-h-0 px-0 py-0 text-xs leading-relaxed text-muted-foreground"
+                        contentClassName="min-h-[1rem] px-0 py-0 text-xs leading-relaxed text-muted-foreground"
                         ariaLabel="Translation intent"
                       />
                     ) : null}
-                  </>
+                  </div>
                 )}
               </InsightCard>
 

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
@@ -179,13 +179,16 @@ export function CatWorkspaceContainer({
   className,
 }: CatWorkspaceContainerProps) {
   const [state, setState] = useState(initialState);
-  const [isBusy, setIsBusy] = useState(false);
+  const [isValidating, setIsValidating] = useState(false);
+  const [isApproving, setIsApproving] = useState(false);
+  const [isLookingUpContext, setIsLookingUpContext] = useState(false);
   const stateRef = useRef(state);
   const previousInitialStateRef = useRef(initialState);
   const validationSequenceRef = useRef(0);
   const validateFormat = serviceOverrides?.validateFormat;
   const runQaChecks = serviceOverrides?.runQaChecks;
   const lookupSegmentContext = serviceOverrides?.lookupSegmentContext;
+  const canLookupContext = Boolean(lookupSegmentContext);
   const onSelectSegment = navigationOverrides?.onSelectSegment;
   const onPreviousSegment = navigationOverrides?.onPreviousSegment;
   const onNextSegment = navigationOverrides?.onNextSegment;
@@ -215,7 +218,7 @@ export function CatWorkspaceContainer({
 
       const sequence = validationSequenceRef.current + 1;
       validationSequenceRef.current = sequence;
-      setIsBusy(true);
+      setIsValidating(true);
       try {
         const [formatChecks, qaChecks] = await Promise.all([
           validateFormat ? validateFormat(segment, value) : Promise.resolve([]),
@@ -235,7 +238,7 @@ export function CatWorkspaceContainer({
         }));
       } finally {
         if (validationSequenceRef.current === sequence) {
-          setIsBusy(false);
+          setIsValidating(false);
         }
       }
     },
@@ -301,7 +304,7 @@ export function CatWorkspaceContainer({
 
     const review = {
       onApprove: async (segmentId: string, targetText: string) => {
-        setIsBusy(true);
+        setIsApproving(true);
         try {
           const nextStatus = (await onApprove?.(segmentId, targetText)) ?? "reviewed";
           setState((current) => {
@@ -322,7 +325,7 @@ export function CatWorkspaceContainer({
             ...addSaveFailureFormatCheck(current, segmentId, message),
           }));
         } finally {
-          setIsBusy(false);
+          setIsApproving(false);
         }
       },
       onAskQuestion: async (segmentId: string) => {
@@ -336,7 +339,7 @@ export function CatWorkspaceContainer({
           return;
         }
 
-        setIsBusy(true);
+        setIsLookingUpContext(true);
         try {
           const productMeaning = await lookupSegmentContext(segment);
           setState((current) => {
@@ -393,7 +396,7 @@ export function CatWorkspaceContainer({
             };
           });
         } finally {
-          setIsBusy(false);
+          setIsLookingUpContext(false);
         }
       },
       onSkip: (segmentId: string) => {
@@ -434,7 +437,10 @@ export function CatWorkspaceContainer({
     <CatWorkspaceView
       state={state}
       dependencies={dependencies}
-      isBusy={isBusy}
+      isValidating={isValidating}
+      isApproving={isApproving}
+      isLookingUpContext={isLookingUpContext}
+      canLookupContext={canLookupContext}
       className={className}
     />
   );

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace.tsx
@@ -10,7 +10,10 @@ import type { CatWorkspaceViewProps } from "./dependencies";
 export function CatWorkspaceView({
   state,
   dependencies,
-  isBusy = false,
+  isValidating = false,
+  isApproving = false,
+  isLookingUpContext = false,
+  canLookupContext = false,
   className,
 }: CatWorkspaceViewProps) {
   const selectedSegmentIndex = state.segments.findIndex(
@@ -40,6 +43,8 @@ export function CatWorkspaceView({
     state.segmentIntelligence?.[selectedSegment.id] ?? state.intelligence;
   const selectedSegmentFormatChecks =
     state.segmentFormatChecks?.[selectedSegment.id] ?? state.formatChecks;
+  const isEditorBusy = isValidating || isApproving || isLookingUpContext;
+  const canApprove = state.canEditTranslations !== false;
 
   return (
     <div
@@ -66,7 +71,11 @@ export function CatWorkspaceView({
               totalSegments={state.segments.length}
               formatChecks={selectedSegmentFormatChecks}
               intelligence={selectedSegmentIntelligence}
-              isBusy={isBusy}
+              isEditorBusy={isEditorBusy}
+              isApproving={isApproving}
+              isLookingUpContext={isLookingUpContext}
+              canApprove={canApprove}
+              canLookupContext={canLookupContext}
               onTargetChange={(value) => editing.onTargetChange(selectedSegment.id, value)}
               onUseAiSuggestion={() => editing.onUseAiSuggestion(selectedSegment.id)}
               onApprove={() =>
@@ -83,7 +92,10 @@ export function CatWorkspaceView({
         </div>
 
         <div className="min-w-0 overflow-hidden">
-          <CatIntelligencePanel intelligence={selectedSegmentIntelligence} />
+          <CatIntelligencePanel
+            intelligence={selectedSegmentIntelligence}
+            isLookingUpContext={isLookingUpContext}
+          />
         </div>
       </div>
     </div>

--- a/apps/hyperlocalise-web/src/components/cat/dependencies.ts
+++ b/apps/hyperlocalise-web/src/components/cat/dependencies.ts
@@ -44,7 +44,10 @@ export type PartialCatWorkspaceDependencies = {
 export interface CatWorkspaceViewProps {
   state: CatWorkspaceState;
   dependencies: CatWorkspaceDependencies;
-  isBusy?: boolean;
+  isValidating?: boolean;
+  isApproving?: boolean;
+  isLookingUpContext?: boolean;
+  canLookupContext?: boolean;
   className?: string;
 }
 

--- a/apps/hyperlocalise-web/src/components/cat/types.ts
+++ b/apps/hyperlocalise-web/src/components/cat/types.ts
@@ -85,4 +85,5 @@ export interface CatWorkspaceState {
   jobTitle?: string;
   breadcrumbs?: string[];
   primaryActionLabel?: string;
+  canEditTranslations?: boolean;
 }

--- a/apps/hyperlocalise-web/src/components/markdown-description-editor.tsx
+++ b/apps/hyperlocalise-web/src/components/markdown-description-editor.tsx
@@ -227,16 +227,16 @@ export function MarkdownDescriptionEditor({
   );
 }
 
-export function MarkdownDescriptionPreview({
+export function MarkdownContent({
   value,
   className,
   contentClassName,
-  emptyMessage = "No description",
+  ariaLabel = "Markdown content",
 }: {
   value: string;
   className?: string;
   contentClassName?: string;
-  emptyMessage?: string;
+  ariaLabel?: string;
 }) {
   const editor = useEditor({
     extensions: markdownExtensions,
@@ -246,8 +246,8 @@ export function MarkdownDescriptionPreview({
     immediatelyRender: false,
     editorProps: {
       attributes: {
-        class: cn(markdownDescriptionContentClassName, "min-h-[5rem]", contentClassName),
-        "aria-label": "Task description preview",
+        class: cn(markdownDescriptionContentClassName, contentClassName),
+        "aria-label": ariaLabel,
       },
     },
   });
@@ -265,6 +265,28 @@ export function MarkdownDescriptionPreview({
     editor.commands.setContent(value, { contentType: "markdown", emitUpdate: false });
   }, [editor, value]);
 
+  if (!editor) {
+    return <div className={className} />;
+  }
+
+  return (
+    <div className={className}>
+      <EditorContent editor={editor} />
+    </div>
+  );
+}
+
+export function MarkdownDescriptionPreview({
+  value,
+  className,
+  contentClassName,
+  emptyMessage = "No description",
+}: {
+  value: string;
+  className?: string;
+  contentClassName?: string;
+  emptyMessage?: string;
+}) {
   if (!value.trim()) {
     return (
       <div
@@ -278,20 +300,12 @@ export function MarkdownDescriptionPreview({
     );
   }
 
-  if (!editor) {
-    return (
-      <div
-        className={cn(
-          "min-h-[5rem] rounded-lg border border-foreground/8 bg-foreground/2.5",
-          className,
-        )}
-      />
-    );
-  }
-
   return (
-    <div className={cn("rounded-lg border border-foreground/8 bg-foreground/2.5", className)}>
-      <EditorContent editor={editor} />
-    </div>
+    <MarkdownContent
+      value={value}
+      className={cn("rounded-lg border border-foreground/8 bg-foreground/2.5", className)}
+      contentClassName={cn("min-h-[5rem]", contentClassName)}
+      ariaLabel="Task description preview"
+    />
   );
 }

--- a/apps/hyperlocalise-web/src/components/markdown-description-editor.tsx
+++ b/apps/hyperlocalise-web/src/components/markdown-description-editor.tsx
@@ -266,7 +266,9 @@ export function MarkdownContent({
   }, [editor, value]);
 
   if (!editor) {
-    return <div className={className} />;
+    return (
+      <div className={cn(className, contentClassName)} aria-busy="true" aria-label={ariaLabel} />
+    );
   }
 
   return (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves the CAT workspace Decision context panel and primary action buttons.

- **Decision context** now renders through TipTap (`MarkdownContent`) so repository/agent summaries with markdown formatting (headings, lists, code, links) display correctly instead of raw text.
- **Find context** and **Approve/Save** now have dedicated loading states with spinners and clearer button labels, instead of sharing a single opaque `isBusy` flag that also fired during format validation.
- **Intelligence panel** shows an inline "Looking up repository context…" state while context lookup is in progress.
- **Repository context lookup** is available to all roles that can view the CAT workspace, not only users with write-back permission.
- **Approve** is disabled when `canEditTranslations` is false, instead of failing on click.

## Test plan

- [x] `vp test` on CAT component tests and `tms-job-cat-workspace.test.ts`
- [x] `vp check --fix`
- [ ] Manually verify Find context shows spinner + intelligence panel loading state, then renders markdown summary
- [ ] Manually verify Approve shows spinner while saving to Crowdin

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6d84f48-28a3-4730-83c6-98eff7309b1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6d84f48-28a3-4730-83c6-98eff7309b1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

