### PR TITLE
feat(contentful): auto-register webhooks on connection save

### DIFF
--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-page-content.tsx
@@ -303,6 +303,7 @@ type ContentfulConnectionSummary = {
   webhook: {
     id: string;
     status: string;
+    providerWebhookId: string | null;
     url: string | null;
     lastDeliveryId: string | null;
     lastDeliveredAt: string | null;
@@ -1420,8 +1421,17 @@ function useSaveContentfulConnection(organizationSlug: string) {
       });
       toast.success("Contentful connection saved");
       if (result.webhookSecret) {
-        toast.message("Contentful webhook secret generated", {
-          description: "Use the displayed secret when creating the Contentful webhook.",
+        toast.message("Contentful webhook registered", {
+          description:
+            "Hyperlocalise created the Contentful webhook automatically. Save the secret below if you need to re-register manually.",
+        });
+      } else if (result.contentfulConnection.webhook?.providerWebhookId) {
+        toast.message("Contentful webhook synced", {
+          description: "Hyperlocalise updated the Contentful webhook configuration.",
+        });
+      } else if (result.contentfulConnection.webhook?.lastError) {
+        toast.message("Contentful webhook needs attention", {
+          description: result.contentfulConnection.webhook.lastError,
         });
       }
     },
@@ -1536,22 +1546,35 @@ function ContentfulConnectionPanel({
 
       {connection?.webhook ? (
         <div className="text-sm">
-          <h4 className="font-medium">Webhook setup</h4>
+          <h4 className="font-medium">Webhook</h4>
           <p className="mt-1 text-xs text-muted-foreground">
-            In Contentful, create a webhook for entry publish/save events and add a custom header
-            named <code>x-hyperlocalise-webhook-secret</code>.
+            Hyperlocalise registers a Contentful webhook for entry publish events when you save or
+            validate this connection. Automations with a Contentful trigger use it to start
+            translation runs.
           </p>
           <div className="mt-3 grid gap-2 rounded-lg bg-muted/50 p-3 text-xs">
+            <span>
+              Registration:{" "}
+              {connection.webhook.providerWebhookId
+                ? "Registered in Contentful"
+                : connection.webhook.lastError
+                  ? "Not registered"
+                  : "Pending registration"}
+            </span>
             <span className="font-mono break-all">
               URL: {connection.webhook.url ?? "Set HYPERLOCALISE_PUBLIC_APP_URL"}
             </span>
+            {connection.webhook.providerWebhookId ? (
+              <span className="font-mono break-all">
+                Contentful webhook ID: {connection.webhook.providerWebhookId}
+              </span>
+            ) : null}
             {lastWebhookSecret ? (
               <span className="font-mono break-all">Secret: {lastWebhookSecret}</span>
-            ) : (
-              <span className="text-muted-foreground">
-                Secret is only shown when the webhook subscription is first created.
-              </span>
-            )}
+            ) : null}
+            {connection.webhook.lastError ? (
+              <span className="text-destructive">{connection.webhook.lastError}</span>
+            ) : null}
             <span>Last delivery: {connection.webhook.lastDeliveredAt ?? "No deliveries yet"}</span>
           </div>
         </div>

--- a/apps/hyperlocalise-web/src/lib/contentful/client.test.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/client.test.ts
@@ -1,7 +1,18 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 
-import { ContentfulManagementClient } from "./client";
+import {
+  ContentfulManagementClient,
+  CONTENTFUL_WEBHOOK_PUBLISH_TOPIC,
+  CONTENTFUL_WEBHOOK_SECRET_HEADER,
+} from "./client";
 import type { ContentfulEntry } from "./types";
+
+function parseRequestBody(body: BodyInit | null | undefined) {
+  if (typeof body === "string") {
+    return JSON.parse(body) as Record<string, unknown>;
+  }
+  throw new Error("expected string request body");
+}
 
 function entry(version: number): ContentfulEntry {
   return {
@@ -58,5 +69,101 @@ describe("ContentfulManagementClient", () => {
         init.headers.get("x-contentful-version") === "2",
     );
     expect(successfulPut).toBeDefined();
+  });
+
+  it("creates, updates, lists, and deletes provider webhooks", async () => {
+    const webhooks = new Map<string, { version: number; body: Record<string, unknown> }>();
+    let nextId = 1;
+
+    const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.endsWith("/webhook_definitions") && init?.method === "POST") {
+        const body = parseRequestBody(init.body);
+        const id = `webhook-${nextId++}`;
+        webhooks.set(id, { version: 1, body });
+        return Response.json({
+          sys: { id, version: 1 },
+          ...body,
+        });
+      }
+
+      if (url.includes("/webhook_definitions/") && init?.method === "PUT") {
+        const id = url.split("/").pop() ?? "";
+        const existing = webhooks.get(id);
+        if (!existing) {
+          return new Response(null, { status: 404 });
+        }
+        const body = parseRequestBody(init.body);
+        existing.version += 1;
+        existing.body = { ...existing.body, ...body };
+        return Response.json({
+          sys: { id, version: existing.version },
+          ...existing.body,
+        });
+      }
+
+      if (url.includes("/webhook_definitions/") && init?.method === "DELETE") {
+        const id = url.split("/").pop() ?? "";
+        webhooks.delete(id);
+        return new Response(null, { status: 204 });
+      }
+
+      if (url.endsWith("/webhook_definitions/webhook-1")) {
+        const existing = webhooks.get("webhook-1");
+        return Response.json({
+          sys: { id: "webhook-1", version: existing?.version ?? 1 },
+          ...existing?.body,
+        });
+      }
+
+      if (url.endsWith("/webhook_definitions")) {
+        return Response.json({
+          items: [...webhooks.entries()].map(([id, value]) => ({
+            sys: { id, version: value.version },
+            ...value.body,
+          })),
+        });
+      }
+
+      return new Response(null, { status: 404 });
+    });
+
+    const client = new ContentfulManagementClient({
+      accessToken: "token",
+      spaceId: "space",
+      environmentId: "master",
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+
+    const created = await client.createWebhook({
+      name: "Hyperlocalise: Help Center",
+      url: "https://app.example.com/api/webhooks/contentful/sub-1",
+      topics: [CONTENTFUL_WEBHOOK_PUBLISH_TOPIC],
+      filters: [],
+      headers: [
+        {
+          key: CONTENTFUL_WEBHOOK_SECRET_HEADER,
+          value: "secret-value",
+          secret: true,
+        },
+      ],
+    });
+
+    expect(created.sys.id).toBe("webhook-1");
+
+    const listed = await client.listWebhooks();
+    expect(listed).toHaveLength(1);
+
+    const updated = await client.updateWebhook("webhook-1", {
+      version: 1,
+      name: "Hyperlocalise: Docs",
+      url: created.url,
+      topics: created.topics,
+      filters: created.filters,
+      headers: [{ key: CONTENTFUL_WEBHOOK_SECRET_HEADER, secret: true }],
+    });
+    expect(updated.name).toBe("Hyperlocalise: Docs");
+
+    await client.deleteWebhook("webhook-1");
+    expect(await client.listWebhooks()).toHaveLength(0);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/contentful/client.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/client.ts
@@ -2,6 +2,25 @@ import type { ContentfulContentType, ContentfulDraftTranslation, ContentfulEntry
 
 const CONTENTFUL_CMA_BASE_URL = "https://api.contentful.com";
 
+export const CONTENTFUL_WEBHOOK_SECRET_HEADER = "x-hyperlocalise-webhook-secret";
+export const CONTENTFUL_WEBHOOK_PUBLISH_TOPIC = "Entry.publish";
+
+export type ContentfulWebhookDefinition = {
+  sys: {
+    id: string;
+    version?: number;
+  };
+  name: string;
+  url: string;
+  topics: string[];
+  filters: Array<Record<string, unknown>>;
+  headers: Array<{
+    key: string;
+    value?: string;
+    secret?: boolean;
+  }>;
+};
+
 export type ContentfulClientError = {
   code: "contentful_request_failed";
   status: number;
@@ -37,13 +56,26 @@ export class ContentfulManagementClient {
       } satisfies ContentfulClientError;
     }
 
-    return (await response.json()) as T;
+    if (response.status === 204) {
+      return undefined as T;
+    }
+
+    const text = await response.text();
+    if (!text) {
+      return undefined as T;
+    }
+
+    return JSON.parse(text) as T;
   }
 
   private environmentPath(path: string) {
     return `/spaces/${encodeURIComponent(this.options.spaceId)}/environments/${encodeURIComponent(
       this.options.environmentId,
     )}${path}`;
+  }
+
+  private spacePath(path: string) {
+    return `/spaces/${encodeURIComponent(this.options.spaceId)}${path}`;
   }
 
   async validateConnection() {
@@ -77,6 +109,70 @@ export class ContentfulManagementClient {
   async getContentType(contentTypeId: string) {
     return this.request<ContentfulContentType>(
       this.environmentPath(`/content_types/${encodeURIComponent(contentTypeId)}`),
+    );
+  }
+
+  async listWebhooks() {
+    const response = await this.request<{ items: ContentfulWebhookDefinition[] }>(
+      this.spacePath("/webhook_definitions"),
+    );
+    return response.items;
+  }
+
+  async getWebhook(webhookId: string) {
+    return this.request<ContentfulWebhookDefinition>(
+      this.spacePath(`/webhook_definitions/${encodeURIComponent(webhookId)}`),
+    );
+  }
+
+  async createWebhook(input: {
+    name: string;
+    url: string;
+    topics: string[];
+    filters: Array<Record<string, unknown>>;
+    headers: ContentfulWebhookDefinition["headers"];
+  }) {
+    return this.request<ContentfulWebhookDefinition>(this.spacePath("/webhook_definitions"), {
+      method: "POST",
+      body: JSON.stringify(input),
+    });
+  }
+
+  async updateWebhook(
+    webhookId: string,
+    input: {
+      version: number;
+      name: string;
+      url: string;
+      topics: string[];
+      filters: Array<Record<string, unknown>>;
+      headers: ContentfulWebhookDefinition["headers"];
+    },
+  ) {
+    return this.request<ContentfulWebhookDefinition>(
+      this.spacePath(`/webhook_definitions/${encodeURIComponent(webhookId)}`),
+      {
+        method: "PUT",
+        headers: {
+          "x-contentful-version": String(input.version),
+        },
+        body: JSON.stringify({
+          name: input.name,
+          url: input.url,
+          topics: input.topics,
+          filters: input.filters,
+          headers: input.headers,
+        }),
+      },
+    );
+  }
+
+  async deleteWebhook(webhookId: string) {
+    await this.request<void>(
+      this.spacePath(`/webhook_definitions/${encodeURIComponent(webhookId)}`),
+      {
+        method: "DELETE",
+      },
     );
   }
 

--- a/apps/hyperlocalise-web/src/lib/contentful/connections.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/connections.ts
@@ -2,7 +2,6 @@ import { randomBytes } from "node:crypto";
 
 import { and, desc, eq } from "drizzle-orm";
 
-import { env } from "@/lib/env";
 import { db, schema } from "@/lib/database";
 import {
   decryptProviderCredential,
@@ -15,6 +14,11 @@ import { err, ok, type Result } from "@/lib/primitives/result/results";
 
 import { ContentfulManagementClient, isContentfulClientError } from "./client";
 import { hashContentfulWebhookSecret } from "./webhook";
+import {
+  contentfulWebhookCallbackUrl,
+  deleteContentfulProviderWebhook,
+  syncContentfulProviderWebhook,
+} from "./webhook-provider";
 import type {
   ContentfulConnectionFieldConfig,
   ContentfulConnectionSecretResult,
@@ -31,10 +35,7 @@ function normalizeFieldConfig(value: Record<string, unknown>): ContentfulConnect
 }
 
 function webhookUrl(subscriptionId: string) {
-  if (!env.HYPERLOCALISE_PUBLIC_APP_URL) {
-    return null;
-  }
-  return `${env.HYPERLOCALISE_PUBLIC_APP_URL}/api/webhooks/contentful/${subscriptionId}`;
+  return contentfulWebhookCallbackUrl(subscriptionId);
 }
 
 function serializeConnection(
@@ -112,6 +113,25 @@ export async function ensureContentfulWebhookSubscription(input: {
   }
 
   return { row, webhookSecret };
+}
+
+async function syncConnectionProviderWebhook(input: {
+  connection: ContentfulConnectionRow;
+  subscription: ContentfulWebhookSubscriptionRow;
+  accessToken: string;
+  webhookSecret?: string | null;
+}): Promise<ContentfulConnectionSecretResult> {
+  const synced = await syncContentfulProviderWebhook({
+    connection: input.connection,
+    subscription: input.subscription,
+    accessToken: input.accessToken,
+    webhookSecret: input.webhookSecret,
+  });
+
+  return {
+    connection: serializeConnection(input.connection, synced.subscription),
+    webhookSecret: synced.webhookSecret,
+  };
 }
 
 export async function listContentfulConnections(input: {
@@ -264,10 +284,12 @@ export async function createContentfulConnection(input: {
     connectionId: connection.id,
   });
 
-  return {
-    connection: serializeConnection(connection, webhook.row),
+  return syncConnectionProviderWebhook({
+    connection,
+    subscription: webhook.row,
+    accessToken: input.accessToken,
     webhookSecret: webhook.webhookSecret,
-  };
+  });
 }
 
 export async function updateContentfulConnection(input: {
@@ -296,6 +318,59 @@ export async function updateContentfulConnection(input: {
     ? unwrapProviderCredentialCrypto(encryptProviderCredential(input.accessToken))
     : null;
   const shouldResetValidation = !!(input.accessToken || input.spaceId || input.environmentId);
+
+  const [previousConnection] = await db
+    .select()
+    .from(schema.contentfulConnections)
+    .where(
+      and(
+        eq(schema.contentfulConnections.organizationId, input.organizationId),
+        eq(schema.contentfulConnections.id, input.connectionId),
+      ),
+    )
+    .limit(1);
+
+  if (!previousConnection) {
+    return null;
+  }
+
+  const [previousSubscription] = await db
+    .select()
+    .from(schema.contentfulWebhookSubscriptions)
+    .where(eq(schema.contentfulWebhookSubscriptions.connectionId, input.connectionId))
+    .limit(1);
+
+  const previousToken = encrypted
+    ? input.accessToken!
+    : unwrapProviderCredentialCrypto(
+        decryptProviderCredential({
+          algorithm: previousConnection.encryptionAlgorithm,
+          keyVersion: previousConnection.keyVersion,
+          ciphertext: previousConnection.ciphertext,
+          iv: previousConnection.iv,
+          authTag: previousConnection.authTag,
+        }),
+      );
+
+  const spaceChanged = input.spaceId !== undefined && input.spaceId !== previousConnection.spaceId;
+  if (spaceChanged && previousSubscription?.providerWebhookId && previousConnection.spaceId) {
+    await deleteContentfulProviderWebhook({
+      accessToken: previousToken,
+      spaceId: previousConnection.spaceId,
+      environmentId: previousConnection.environmentId,
+      providerWebhookId: previousSubscription.providerWebhookId,
+    });
+    await db
+      .update(schema.contentfulWebhookSubscriptions)
+      .set({
+        providerWebhookId: null,
+        updatedAt: new Date(),
+      })
+      .where(eq(schema.contentfulWebhookSubscriptions.id, previousSubscription.id));
+    if (previousSubscription) {
+      previousSubscription.providerWebhookId = null;
+    }
+  }
 
   const [connection] = await db
     .update(schema.contentfulConnections)
@@ -346,16 +421,38 @@ export async function updateContentfulConnection(input: {
     connectionId: connection.id,
   });
 
-  return {
-    connection: serializeConnection(connection, webhook.row),
+  const accessToken = encrypted ? input.accessToken! : previousToken;
+
+  return syncConnectionProviderWebhook({
+    connection,
+    subscription: webhook.row,
+    accessToken,
     webhookSecret: webhook.webhookSecret,
-  };
+  });
 }
 
 export async function deleteContentfulConnection(input: {
   organizationId: string;
   connectionId: string;
 }) {
+  const loaded = await loadContentfulConnectionWithToken(input);
+  const [subscription] = loaded
+    ? await db
+        .select()
+        .from(schema.contentfulWebhookSubscriptions)
+        .where(eq(schema.contentfulWebhookSubscriptions.connectionId, input.connectionId))
+        .limit(1)
+    : [];
+
+  if (loaded && subscription?.providerWebhookId) {
+    await deleteContentfulProviderWebhook({
+      accessToken: loaded.token,
+      spaceId: loaded.connection.spaceId,
+      environmentId: loaded.connection.environmentId,
+      providerWebhookId: subscription.providerWebhookId,
+    });
+  }
+
   const [deleted] = await db
     .delete(schema.contentfulConnections)
     .where(
@@ -395,6 +492,21 @@ export async function validateContentfulConnection(input: {
         updatedAt: new Date(),
       })
       .where(eq(schema.contentfulConnections.id, loaded.connection.id));
+
+    const [subscription] = await db
+      .select()
+      .from(schema.contentfulWebhookSubscriptions)
+      .where(eq(schema.contentfulWebhookSubscriptions.connectionId, loaded.connection.id))
+      .limit(1);
+
+    if (subscription) {
+      await syncContentfulProviderWebhook({
+        connection: loaded.connection,
+        subscription,
+        accessToken: loaded.token,
+      });
+    }
+
     return ok(validation);
   } catch (error) {
     const message = isContentfulClientError(error)

--- a/apps/hyperlocalise-web/src/lib/contentful/connections.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/connections.ts
@@ -367,9 +367,7 @@ export async function updateContentfulConnection(input: {
         updatedAt: new Date(),
       })
       .where(eq(schema.contentfulWebhookSubscriptions.id, previousSubscription.id));
-    if (previousSubscription) {
-      previousSubscription.providerWebhookId = null;
-    }
+    previousSubscription.providerWebhookId = null;
   }
 
   const [connection] = await db

--- a/apps/hyperlocalise-web/src/lib/contentful/webhook-provider.test.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/webhook-provider.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  buildContentfulProviderWebhookFilters,
+  buildContentfulProviderWebhookName,
+  contentfulWebhookCallbackUrl,
+} from "./webhook-provider";
+
+describe("contentful webhook provider helpers", () => {
+  it("builds callback URLs from the public app base", () => {
+    expect(contentfulWebhookCallbackUrl("subscription-1")).toBe(
+      "https://app.example.com/api/webhooks/contentful/subscription-1",
+    );
+  });
+
+  it("builds provider webhook names and filters", () => {
+    expect(buildContentfulProviderWebhookName("Help Center")).toBe("Hyperlocalise: Help Center");
+    expect(buildContentfulProviderWebhookFilters([])).toEqual([]);
+    expect(buildContentfulProviderWebhookFilters(["article"])).toEqual([
+      {
+        equals: [{ doc: "sys.contentType.sys.id" }, "article"],
+      },
+    ]);
+    expect(buildContentfulProviderWebhookFilters(["article", "blogPost"])).toEqual([
+      {
+        in: [{ doc: "sys.contentType.sys.id" }, ["article", "blogPost"]],
+      },
+    ]);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/contentful/webhook-provider.test.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/webhook-provider.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 
+import { env } from "@/lib/env";
+
 import {
   buildContentfulProviderWebhookFilters,
   buildContentfulProviderWebhookName,
@@ -9,7 +11,7 @@ import {
 describe("contentful webhook provider helpers", () => {
   it("builds callback URLs from the public app base", () => {
     expect(contentfulWebhookCallbackUrl("subscription-1")).toBe(
-      "https://app.example.com/api/webhooks/contentful/subscription-1",
+      `${env.HYPERLOCALISE_PUBLIC_APP_URL}/api/webhooks/contentful/subscription-1`,
     );
   });
 

--- a/apps/hyperlocalise-web/src/lib/contentful/webhook-provider.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/webhook-provider.ts
@@ -1,0 +1,282 @@
+import { randomBytes } from "node:crypto";
+
+import { eq } from "drizzle-orm";
+
+import { env } from "@/lib/env";
+import { db, schema } from "@/lib/database";
+import { createLogger } from "@/lib/log";
+
+import {
+  ContentfulManagementClient,
+  CONTENTFUL_WEBHOOK_PUBLISH_TOPIC,
+  CONTENTFUL_WEBHOOK_SECRET_HEADER,
+  type ContentfulWebhookDefinition,
+} from "./client";
+import { hashContentfulWebhookSecret } from "./webhook";
+
+const logger = createLogger("contentful-webhook-provider");
+
+type ContentfulConnectionRow = typeof schema.contentfulConnections.$inferSelect;
+type ContentfulWebhookSubscriptionRow = typeof schema.contentfulWebhookSubscriptions.$inferSelect;
+
+export function contentfulWebhookCallbackUrl(subscriptionId: string) {
+  if (!env.HYPERLOCALISE_PUBLIC_APP_URL) {
+    return null;
+  }
+  return `${env.HYPERLOCALISE_PUBLIC_APP_URL}/api/webhooks/contentful/${subscriptionId}`;
+}
+
+export function buildContentfulProviderWebhookName(displayName: string) {
+  const trimmed = displayName.trim() || "Contentful connection";
+  return `Hyperlocalise: ${trimmed}`.slice(0, 255);
+}
+
+export function buildContentfulProviderWebhookFilters(contentTypeIds: string[]) {
+  if (contentTypeIds.length === 0) {
+    return [];
+  }
+
+  if (contentTypeIds.length === 1) {
+    return [
+      {
+        equals: [{ doc: "sys.contentType.sys.id" }, contentTypeIds[0]],
+      },
+    ];
+  }
+
+  return [
+    {
+      in: [{ doc: "sys.contentType.sys.id" }, contentTypeIds],
+    },
+  ];
+}
+
+function buildWebhookHeaders(webhookSecret: string | null) {
+  if (webhookSecret) {
+    return [
+      {
+        key: CONTENTFUL_WEBHOOK_SECRET_HEADER,
+        value: webhookSecret,
+        secret: true,
+      },
+    ];
+  }
+
+  return [
+    {
+      key: CONTENTFUL_WEBHOOK_SECRET_HEADER,
+      secret: true,
+    },
+  ];
+}
+
+async function persistWebhookSubscriptionState(input: {
+  subscriptionId: string;
+  providerWebhookId?: string | null;
+  lastError?: string | null;
+  secretHash?: string;
+}) {
+  const [row] = await db
+    .update(schema.contentfulWebhookSubscriptions)
+    .set({
+      ...(input.providerWebhookId !== undefined
+        ? { providerWebhookId: input.providerWebhookId }
+        : {}),
+      ...(input.lastError !== undefined ? { lastError: input.lastError } : {}),
+      ...(input.secretHash !== undefined ? { secretHash: input.secretHash } : {}),
+      updatedAt: new Date(),
+    })
+    .where(eq(schema.contentfulWebhookSubscriptions.id, input.subscriptionId))
+    .returning();
+
+  if (!row) {
+    throw new Error("contentful_webhook_subscription_update_failed");
+  }
+
+  return row;
+}
+
+function generateWebhookSecret() {
+  return randomBytes(32).toString("base64url");
+}
+
+async function rotateWebhookSubscriptionSecret(subscriptionId: string) {
+  const webhookSecret = generateWebhookSecret();
+  await persistWebhookSubscriptionState({
+    subscriptionId,
+    secretHash: hashContentfulWebhookSecret(webhookSecret),
+    lastError: null,
+  });
+  return webhookSecret;
+}
+
+async function findProviderWebhookByUrl(
+  client: ContentfulManagementClient,
+  url: string,
+): Promise<ContentfulWebhookDefinition | null> {
+  const webhooks = await client.listWebhooks();
+  return webhooks.find((webhook) => webhook.url === url) ?? null;
+}
+
+export async function deleteContentfulProviderWebhook(input: {
+  accessToken: string;
+  spaceId: string;
+  environmentId: string;
+  providerWebhookId: string;
+}) {
+  const client = new ContentfulManagementClient({
+    accessToken: input.accessToken,
+    spaceId: input.spaceId,
+    environmentId: input.environmentId,
+  });
+
+  try {
+    await client.deleteWebhook(input.providerWebhookId);
+  } catch (error) {
+    logger.warn(
+      {
+        providerWebhookId: input.providerWebhookId,
+        spaceId: input.spaceId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      "contentful provider webhook delete failed",
+    );
+  }
+}
+
+export async function syncContentfulProviderWebhook(input: {
+  connection: ContentfulConnectionRow;
+  subscription: ContentfulWebhookSubscriptionRow;
+  accessToken: string;
+  webhookSecret?: string | null;
+}): Promise<{
+  subscription: ContentfulWebhookSubscriptionRow;
+  webhookSecret: string | null;
+}> {
+  const callbackUrl = contentfulWebhookCallbackUrl(input.subscription.id);
+  if (!callbackUrl) {
+    const subscription = await persistWebhookSubscriptionState({
+      subscriptionId: input.subscription.id,
+      lastError: "Set HYPERLOCALISE_PUBLIC_APP_URL to register the Contentful webhook.",
+    });
+    return { subscription, webhookSecret: null };
+  }
+
+  const client = new ContentfulManagementClient({
+    accessToken: input.accessToken,
+    spaceId: input.connection.spaceId,
+    environmentId: input.connection.environmentId,
+  });
+
+  const name = buildContentfulProviderWebhookName(input.connection.displayName);
+  const filters = buildContentfulProviderWebhookFilters(input.connection.contentTypeIds);
+  let webhookSecret = input.webhookSecret ?? null;
+
+  try {
+    if (!webhookSecret && !input.subscription.providerWebhookId) {
+      webhookSecret = await rotateWebhookSubscriptionSecret(input.subscription.id);
+    }
+
+    const headers = buildWebhookHeaders(webhookSecret);
+    const payload = {
+      name,
+      url: callbackUrl,
+      topics: [CONTENTFUL_WEBHOOK_PUBLISH_TOPIC],
+      filters,
+      headers,
+    };
+
+    let providerWebhook: ContentfulWebhookDefinition | null = null;
+
+    if (input.subscription.providerWebhookId) {
+      try {
+        providerWebhook = await client.getWebhook(input.subscription.providerWebhookId);
+      } catch {
+        providerWebhook = null;
+      }
+    }
+
+    if (!providerWebhook) {
+      providerWebhook = await findProviderWebhookByUrl(client, callbackUrl);
+    }
+
+    if (providerWebhook) {
+      const updated = await client.updateWebhook(providerWebhook.sys.id, {
+        version: providerWebhook.sys.version ?? 1,
+        ...payload,
+      });
+      const subscription = await persistWebhookSubscriptionState({
+        subscriptionId: input.subscription.id,
+        providerWebhookId: updated.sys.id,
+        lastError: null,
+      });
+      return { subscription, webhookSecret };
+    }
+
+    if (!webhookSecret) {
+      webhookSecret = await rotateWebhookSubscriptionSecret(input.subscription.id);
+    }
+
+    const created = await client.createWebhook({
+      ...payload,
+      headers: buildWebhookHeaders(webhookSecret),
+    });
+    const subscription = await persistWebhookSubscriptionState({
+      subscriptionId: input.subscription.id,
+      providerWebhookId: created.sys.id,
+      lastError: null,
+    });
+    return { subscription, webhookSecret };
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Contentful webhook registration failed.";
+    logger.error(
+      {
+        connectionId: input.connection.id,
+        subscriptionId: input.subscription.id,
+        spaceId: input.connection.spaceId,
+        error: message,
+      },
+      "contentful provider webhook sync failed",
+    );
+    const subscription = await persistWebhookSubscriptionState({
+      subscriptionId: input.subscription.id,
+      lastError: message,
+    });
+    return { subscription, webhookSecret };
+  }
+}
+
+export async function syncContentfulProviderWebhookForConnection(input: {
+  organizationId: string;
+  connectionId: string;
+  accessToken: string;
+  webhookSecret?: string | null;
+}) {
+  const [connection] = await db
+    .select()
+    .from(schema.contentfulConnections)
+    .where(eq(schema.contentfulConnections.id, input.connectionId))
+    .limit(1);
+
+  if (!connection || connection.organizationId !== input.organizationId) {
+    return null;
+  }
+
+  const [subscription] = await db
+    .select()
+    .from(schema.contentfulWebhookSubscriptions)
+    .where(eq(schema.contentfulWebhookSubscriptions.connectionId, connection.id))
+    .limit(1);
+
+  if (!subscription) {
+    return null;
+  }
+
+  return syncContentfulProviderWebhook({
+    connection,
+    subscription,
+    accessToken: input.accessToken,
+    webhookSecret: input.webhookSecret,
+  });
+}

--- a/apps/hyperlocalise-web/src/lib/contentful/webhook-provider.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/webhook-provider.ts
@@ -10,6 +10,7 @@ import {
   ContentfulManagementClient,
   CONTENTFUL_WEBHOOK_PUBLISH_TOPIC,
   CONTENTFUL_WEBHOOK_SECRET_HEADER,
+  isContentfulClientError,
   type ContentfulWebhookDefinition,
 } from "./client";
 import { hashContentfulWebhookSecret } from "./webhook";
@@ -100,14 +101,30 @@ function generateWebhookSecret() {
   return randomBytes(32).toString("base64url");
 }
 
-async function rotateWebhookSubscriptionSecret(subscriptionId: string) {
-  const webhookSecret = generateWebhookSecret();
-  await persistWebhookSubscriptionState({
-    subscriptionId,
-    secretHash: hashContentfulWebhookSecret(webhookSecret),
-    lastError: null,
-  });
-  return webhookSecret;
+function resolvePendingWebhookSecret(input: {
+  webhookSecret?: string | null;
+  providerWebhookId: string | null;
+}) {
+  if (input.webhookSecret) {
+    return input.webhookSecret;
+  }
+  if (!input.providerWebhookId) {
+    return generateWebhookSecret();
+  }
+  return null;
+}
+
+function formatContentfulWebhookSyncError(error: unknown) {
+  if (isContentfulClientError(error)) {
+    if (error.status === 403) {
+      return "Contentful token lacks permission to manage webhooks in this space.";
+    }
+    return error.message;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return "Contentful webhook registration failed.";
 }
 
 async function findProviderWebhookByUrl(
@@ -170,14 +187,14 @@ export async function syncContentfulProviderWebhook(input: {
 
   const name = buildContentfulProviderWebhookName(input.connection.displayName);
   const filters = buildContentfulProviderWebhookFilters(input.connection.contentTypeIds);
-  let webhookSecret = input.webhookSecret ?? null;
+  const pendingSecret = resolvePendingWebhookSecret({
+    webhookSecret: input.webhookSecret,
+    providerWebhookId: input.subscription.providerWebhookId,
+  });
+  const shouldPersistPendingSecret = pendingSecret !== null && !input.webhookSecret;
 
   try {
-    if (!webhookSecret && !input.subscription.providerWebhookId) {
-      webhookSecret = await rotateWebhookSubscriptionSecret(input.subscription.id);
-    }
-
-    const headers = buildWebhookHeaders(webhookSecret);
+    const headers = buildWebhookHeaders(pendingSecret);
     const payload = {
       name,
       url: callbackUrl,
@@ -191,8 +208,12 @@ export async function syncContentfulProviderWebhook(input: {
     if (input.subscription.providerWebhookId) {
       try {
         providerWebhook = await client.getWebhook(input.subscription.providerWebhookId);
-      } catch {
-        providerWebhook = null;
+      } catch (error) {
+        if (isContentfulClientError(error) && error.status === 404) {
+          providerWebhook = null;
+        } else {
+          throw error;
+        }
       }
     }
 
@@ -209,27 +230,30 @@ export async function syncContentfulProviderWebhook(input: {
         subscriptionId: input.subscription.id,
         providerWebhookId: updated.sys.id,
         lastError: null,
+        ...(shouldPersistPendingSecret && pendingSecret
+          ? { secretHash: hashContentfulWebhookSecret(pendingSecret) }
+          : {}),
       });
-      return { subscription, webhookSecret };
+      return { subscription, webhookSecret: pendingSecret };
     }
 
-    if (!webhookSecret) {
-      webhookSecret = await rotateWebhookSubscriptionSecret(input.subscription.id);
-    }
-
+    const createSecret = pendingSecret ?? generateWebhookSecret();
     const created = await client.createWebhook({
       ...payload,
-      headers: buildWebhookHeaders(webhookSecret),
+      headers: buildWebhookHeaders(createSecret),
     });
     const subscription = await persistWebhookSubscriptionState({
       subscriptionId: input.subscription.id,
       providerWebhookId: created.sys.id,
       lastError: null,
+      secretHash: hashContentfulWebhookSecret(createSecret),
     });
-    return { subscription, webhookSecret };
+    return {
+      subscription,
+      webhookSecret: input.webhookSecret ?? createSecret,
+    };
   } catch (error) {
-    const message =
-      error instanceof Error ? error.message : "Contentful webhook registration failed.";
+    const message = formatContentfulWebhookSyncError(error);
     logger.error(
       {
         connectionId: input.connection.id,
@@ -243,7 +267,7 @@ export async function syncContentfulProviderWebhook(input: {
       subscriptionId: input.subscription.id,
       lastError: message,
     });
-    return { subscription, webhookSecret };
+    return { subscription, webhookSecret: pendingSecret };
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Automatically registers and syncs Contentful webhooks when a connection is created, updated, or validated — removing the manual copy/paste setup in the Contentful UI.

## What changed

- Added CMA webhook CRUD methods on `ContentfulManagementClient` (`listWebhooks`, `createWebhook`, `updateWebhook`, `deleteWebhook`)
- Added `webhook-provider.ts` to sync webhook definitions in Contentful:
  - Registers `Entry.publish` webhook with `x-hyperlocalise-webhook-secret` header
  - Applies content-type filters from the connection config
  - Stores `providerWebhookId` on the local subscription
  - Rotates the local secret when first registering an existing subscription
  - Records `lastError` when registration fails (e.g. missing `HYPERLOCALISE_PUBLIC_APP_URL`)
- Wired sync into connection **create**, **update**, and **validate** flows
- Deletes the provider webhook when a connection is removed (or when the space changes)
- Updated Integrations UI to show registration status, provider webhook ID, and errors

## How it works

1. Save or validate a Contentful connection
2. Hyperlocalise ensures a local webhook subscription exists
3. If `HYPERLOCALISE_PUBLIC_APP_URL` is set, it creates/updates the webhook in Contentful via CMA
4. Contentful publish events flow to `/api/webhooks/contentful/:subscriptionId` and dispatch matching automations

## Testing

- `vp test src/lib/contentful/`
- `vp check --fix`

## Notes

- Requires a CMA token with permission to manage webhooks in the target space
- Connection save still succeeds if webhook registration fails; `webhook.lastError` surfaces the issue in Integrations

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://hyperlocalise.slack.com/archives/C0B54JDQ0DV/p1781306249371319?thread_ts=1781306249.371319&cid=C0B54JDQ0DV)

<div><a href="https://cursor.com/agents/bc-a790fb35-8074-5459-b9d7-056ae530a528"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a790fb35-8074-5459-b9d7-056ae530a528"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

