### PR TITLE
fix(translation): guard string persist after job succeeds

### DIFF
--- a/apps/hyperlocalise-web/src/lib/translation/translation-job-queued-function.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/translation-job-queued-function.ts
@@ -24,7 +24,6 @@ import {
   type StringTranslationGenerator,
   type StringTranslationJobResult,
 } from "@/lib/translation/string-job-executor";
-import { userFacingFailureReason } from "@/lib/translation/sandbox-translation";
 
 type ClaimTranslationJobInput = {
   event: TranslationJobEventData;
@@ -482,7 +481,7 @@ export async function completeTranslationJob(input: {
           projectId: input.projectId,
           organizationId: project.organizationId,
           translationKeyId: parsedInput.data.translationKeyId,
-          error: userFacingFailureReason(error),
+          error,
         });
       }
     }

--- a/apps/hyperlocalise-web/src/lib/translation/translation-job-queued-function.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/translation-job-queued-function.ts
@@ -24,6 +24,7 @@ import {
   type StringTranslationGenerator,
   type StringTranslationJobResult,
 } from "@/lib/translation/string-job-executor";
+import { userFacingFailureReason } from "@/lib/translation/sandbox-translation";
 
 type ClaimTranslationJobInput = {
   event: TranslationJobEventData;
@@ -466,14 +467,24 @@ export async function completeTranslationJob(input: {
       .limit(1);
 
     if (project?.organizationId) {
-      await persistStringJobTranslations({
-        organizationId: project.organizationId,
-        projectId: input.projectId,
-        jobId: input.jobId,
-        sourceLocale: parsedInput.data.sourceLocale,
-        translations: input.result.translations,
-        translationKeyId: parsedInput.data.translationKeyId,
-      });
+      try {
+        await persistStringJobTranslations({
+          organizationId: project.organizationId,
+          projectId: input.projectId,
+          jobId: input.jobId,
+          sourceLocale: parsedInput.data.sourceLocale,
+          translations: input.result.translations,
+          translationKeyId: parsedInput.data.translationKeyId,
+        });
+      } catch (error) {
+        console.warn("[translation-job] string translation persistence failed", {
+          jobId: input.jobId,
+          projectId: input.projectId,
+          organizationId: project.organizationId,
+          translationKeyId: parsedInput.data.translationKeyId,
+          error: userFacingFailureReason(error),
+        });
+      }
     }
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

`completeTranslationJob` marks the job as `"succeeded"` before calling `persistStringJobTranslations`. If that persist step throws, the workflow's outer `try/catch` calls `failTranslationJob`, which overwrites the status to `"failed"` even though translation already completed.

This wraps the persist call in a best-effort `try/catch`, matching the pattern already used for file translation persistence in `file-translation-job.ts`. Persistence failures are logged as warnings but no longer clobber a succeeded job.

## How to test

- `vp test src/api/routes/project/job.workflow.test.ts`
- `vp check --fix`

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://hyperlocalise.slack.com/archives/D0B5GKZKTRB/p1781310412264789?thread_ts=1781310412.264789&cid=D0B5GKZKTRB)

<div><a href="https://cursor.com/agents/bc-7c190311-45bf-55d2-8a09-58e1afdb6665"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c190311-45bf-55d2-8a09-58e1afdb6665"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

