### PR TITLE
refactor(web): simplify Contentful integration setup

### DIFF
--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/contentful-connection-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/contentful-connection-panel.tsx
@@ -54,6 +54,26 @@ export type ContentfulConnectionForm = {
   accessToken: string;
 };
 
+type SaveContentfulConnectionPayloadBase = {
+  projectId: string;
+  displayName: string;
+  spaceId: string;
+  environmentId: string;
+  sourceLocale: string;
+  targetLocales: string[];
+  contentTypeIds: string[];
+};
+
+type SaveContentfulConnectionPayload =
+  | (SaveContentfulConnectionPayloadBase & {
+      connectionId: string;
+      accessToken?: string;
+    })
+  | (SaveContentfulConnectionPayloadBase & {
+      connectionId?: undefined;
+      accessToken: string;
+    });
+
 export function useContentfulConnections(organizationSlug: string) {
   return useQuery({
     queryKey: ["contentful-connections", organizationSlug],
@@ -70,9 +90,10 @@ export function useContentfulConnections(organizationSlug: string) {
   });
 }
 
-export function useProjectOptions(organizationSlug: string) {
+export function useProjectOptions(organizationSlug: string, enabled = true) {
   return useQuery({
     queryKey: ["contentful-project-options", organizationSlug],
+    enabled,
     queryFn: async () => {
       const res = await api.api.orgs[":organizationSlug"].projects.$get({
         param: { organizationSlug },
@@ -93,54 +114,46 @@ export function useSaveContentfulConnection(organizationSlug: string) {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (payload: {
-      connectionId?: string;
-      projectId: string;
-      displayName: string;
-      spaceId: string;
-      environmentId: string;
-      sourceLocale: string;
-      targetLocales: string[];
-      contentTypeIds: string[];
-      accessToken?: string;
-    }) => {
-      const { connectionId, ...connectionPayload } = payload;
+    mutationFn: async (payload: SaveContentfulConnectionPayload) => {
       const fieldConfig = { fieldMode: "auto" as const, overwriteDraftLocales: false };
-      const res = connectionId
-        ? await api.api.orgs[":organizationSlug"]["contentful-connections"][":connectionId"].$patch(
-            {
-              param: { organizationSlug, connectionId },
-              json: {
-                projectId: connectionPayload.projectId,
-                displayName: connectionPayload.displayName,
-                spaceId: connectionPayload.spaceId,
-                environmentId: connectionPayload.environmentId,
-                sourceLocale: connectionPayload.sourceLocale,
-                targetLocales: connectionPayload.targetLocales,
-                contentTypeIds: connectionPayload.contentTypeIds,
-                fieldConfig,
-                enabled: true,
-                ...(connectionPayload.accessToken
-                  ? { accessToken: connectionPayload.accessToken }
-                  : {}),
-              },
-            },
-          )
-        : await api.api.orgs[":organizationSlug"]["contentful-connections"].$post({
-            param: { organizationSlug },
+      const accessToken = payload.accessToken?.trim();
+
+      const res = await (payload.connectionId
+        ? api.api.orgs[":organizationSlug"]["contentful-connections"][":connectionId"].$patch({
+            param: { organizationSlug, connectionId: payload.connectionId },
             json: {
-              projectId: connectionPayload.projectId,
-              displayName: connectionPayload.displayName,
-              spaceId: connectionPayload.spaceId,
-              environmentId: connectionPayload.environmentId,
-              sourceLocale: connectionPayload.sourceLocale,
-              targetLocales: connectionPayload.targetLocales,
-              contentTypeIds: connectionPayload.contentTypeIds,
+              projectId: payload.projectId,
+              displayName: payload.displayName,
+              spaceId: payload.spaceId,
+              environmentId: payload.environmentId,
+              sourceLocale: payload.sourceLocale,
+              targetLocales: payload.targetLocales,
+              contentTypeIds: payload.contentTypeIds,
               fieldConfig,
               enabled: true,
-              accessToken: payload.accessToken ?? "",
+              ...(accessToken ? { accessToken } : {}),
             },
-          });
+          })
+        : (() => {
+            if (!accessToken) {
+              throw new Error("accessToken is required for new Contentful connections");
+            }
+            return api.api.orgs[":organizationSlug"]["contentful-connections"].$post({
+              param: { organizationSlug },
+              json: {
+                projectId: payload.projectId,
+                displayName: payload.displayName,
+                spaceId: payload.spaceId,
+                environmentId: payload.environmentId,
+                sourceLocale: payload.sourceLocale,
+                targetLocales: payload.targetLocales,
+                contentTypeIds: payload.contentTypeIds,
+                fieldConfig,
+                enabled: true,
+                accessToken,
+              },
+            });
+          })());
       if (!res.ok) {
         const error = await res.json().catch(() => ({ error: "contentful_connection_failed" }));
         throw new Error(

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/contentful-connection-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/contentful-connection-panel.tsx
@@ -1,0 +1,412 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { SaveIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { createApiClient } from "@/lib/api-client";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Field, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger } from "@/components/ui/select";
+
+const api = createApiClient();
+
+export type ContentfulConnectionSummary = {
+  id: string;
+  displayName: string;
+  projectId: string;
+  spaceId: string;
+  environmentId: string;
+  sourceLocale: string;
+  targetLocales: string[];
+  contentTypeIds: string[];
+  validationStatus: string;
+  validationMessage: string | null;
+  maskedTokenSuffix: string;
+  webhook: {
+    id: string;
+    status: string;
+    providerWebhookId: string | null;
+    url: string | null;
+    lastDeliveryId: string | null;
+    lastDeliveredAt: string | null;
+    lastError: string | null;
+  } | null;
+};
+
+export type ProjectOption = {
+  id: string;
+  name: string;
+};
+
+export type ContentfulConnectionForm = {
+  displayName: string;
+  projectId: string;
+  spaceId: string;
+  environmentId: string;
+  sourceLocale: string;
+  targetLocales: string;
+  contentTypeIds: string;
+  accessToken: string;
+};
+
+export function useContentfulConnections(organizationSlug: string) {
+  return useQuery({
+    queryKey: ["contentful-connections", organizationSlug],
+    queryFn: async () => {
+      const res = await api.api.orgs[":organizationSlug"]["contentful-connections"].$get({
+        param: { organizationSlug },
+      });
+      if (!res.ok) {
+        throw new Error("Failed to fetch Contentful connections");
+      }
+      const data = await res.json();
+      return data.contentfulConnections as ContentfulConnectionSummary[];
+    },
+  });
+}
+
+export function useProjectOptions(organizationSlug: string) {
+  return useQuery({
+    queryKey: ["contentful-project-options", organizationSlug],
+    queryFn: async () => {
+      const res = await api.api.orgs[":organizationSlug"].projects.$get({
+        param: { organizationSlug },
+      });
+      if (!res.ok) {
+        throw new Error("Failed to fetch projects");
+      }
+      const data = await res.json();
+      return data.projects.map((project) => ({
+        id: project.id,
+        name: project.name,
+      })) as ProjectOption[];
+    },
+  });
+}
+
+export function useSaveContentfulConnection(organizationSlug: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (payload: {
+      connectionId?: string;
+      projectId: string;
+      displayName: string;
+      spaceId: string;
+      environmentId: string;
+      sourceLocale: string;
+      targetLocales: string[];
+      contentTypeIds: string[];
+      accessToken?: string;
+    }) => {
+      const { connectionId, ...connectionPayload } = payload;
+      const fieldConfig = { fieldMode: "auto" as const, overwriteDraftLocales: false };
+      const res = connectionId
+        ? await api.api.orgs[":organizationSlug"]["contentful-connections"][":connectionId"].$patch(
+            {
+              param: { organizationSlug, connectionId },
+              json: {
+                projectId: connectionPayload.projectId,
+                displayName: connectionPayload.displayName,
+                spaceId: connectionPayload.spaceId,
+                environmentId: connectionPayload.environmentId,
+                sourceLocale: connectionPayload.sourceLocale,
+                targetLocales: connectionPayload.targetLocales,
+                contentTypeIds: connectionPayload.contentTypeIds,
+                fieldConfig,
+                enabled: true,
+                ...(connectionPayload.accessToken
+                  ? { accessToken: connectionPayload.accessToken }
+                  : {}),
+              },
+            },
+          )
+        : await api.api.orgs[":organizationSlug"]["contentful-connections"].$post({
+            param: { organizationSlug },
+            json: {
+              projectId: connectionPayload.projectId,
+              displayName: connectionPayload.displayName,
+              spaceId: connectionPayload.spaceId,
+              environmentId: connectionPayload.environmentId,
+              sourceLocale: connectionPayload.sourceLocale,
+              targetLocales: connectionPayload.targetLocales,
+              contentTypeIds: connectionPayload.contentTypeIds,
+              fieldConfig,
+              enabled: true,
+              accessToken: payload.accessToken ?? "",
+            },
+          });
+      if (!res.ok) {
+        const error = await res.json().catch(() => ({ error: "contentful_connection_failed" }));
+        throw new Error(
+          "message" in error ? String(error.message) : "Unable to save Contentful connection",
+        );
+      }
+      return res.json();
+    },
+    onSuccess: async (result) => {
+      await queryClient.invalidateQueries({
+        queryKey: ["contentful-connections", organizationSlug],
+      });
+      toast.success("Contentful connection saved");
+      if (result.webhookSecret) {
+        toast.message("Contentful webhook registered", {
+          description:
+            "Hyperlocalise created the Contentful webhook automatically. Save the secret below if you need to re-register manually.",
+        });
+      } else if (result.contentfulConnection.webhook?.providerWebhookId) {
+        toast.message("Contentful webhook synced", {
+          description: "Hyperlocalise updated the Contentful webhook configuration.",
+        });
+      } else if (result.contentfulConnection.webhook?.lastError) {
+        toast.message("Contentful webhook needs attention", {
+          description: result.contentfulConnection.webhook.lastError,
+        });
+      }
+    },
+    onError: (error) => {
+      toast.error(error.message);
+    },
+  });
+}
+
+export function ContentfulConnectionPanel({
+  connection,
+  disabled,
+  lastWebhookSecret,
+  onSave,
+  isSaving,
+  form,
+  onFormChange,
+  projects,
+  isLoadingProjects,
+}: {
+  connection?: ContentfulConnectionSummary;
+  disabled: boolean;
+  lastWebhookSecret: string;
+  onSave: () => void;
+  isSaving: boolean;
+  form: ContentfulConnectionForm;
+  onFormChange: (form: ContentfulConnectionForm) => void;
+  projects: ProjectOption[];
+  isLoadingProjects: boolean;
+}) {
+  const [isReplacingToken, setIsReplacingToken] = useState(false);
+  const selectedProject = projects.find((project) => project.id === form.projectId);
+  const projectLabel =
+    selectedProject?.name ?? (form.projectId ? "Unknown project" : "Select project");
+  const targetLocales = form.targetLocales
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+  const contentTypeIds = form.contentTypeIds
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+  const tokenRequired = !connection || isReplacingToken;
+  const canSaveContentfulConnection =
+    form.displayName.trim().length > 0 &&
+    form.projectId.trim().length > 0 &&
+    form.spaceId.trim().length > 0 &&
+    form.environmentId.trim().length > 0 &&
+    form.sourceLocale.trim().length > 0 &&
+    targetLocales.length > 0 &&
+    contentTypeIds.length > 0 &&
+    (!tokenRequired || form.accessToken.trim().length > 0);
+
+  useEffect(() => {
+    setIsReplacingToken(false);
+  }, [connection?.id]);
+
+  return (
+    <div className="flex flex-col gap-5">
+      {connection ? (
+        <div className="flex flex-wrap gap-2 text-xs">
+          <Badge variant="outline">Token ...{connection.maskedTokenSuffix}</Badge>
+          <Badge variant="outline">
+            {connection.spaceId}/{connection.environmentId}
+          </Badge>
+        </div>
+      ) : null}
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <Field className="gap-2">
+          <FieldLabel>Display name</FieldLabel>
+          <Input
+            value={form.displayName}
+            disabled={disabled}
+            placeholder="Contentful Help Center"
+            onChange={(event) => onFormChange({ ...form, displayName: event.target.value })}
+          />
+        </Field>
+        <Field className="gap-2">
+          <FieldLabel>Project</FieldLabel>
+          <Select
+            value={form.projectId || undefined}
+            disabled={disabled || isLoadingProjects || projects.length === 0}
+            onValueChange={(value) => {
+              if (!value) {
+                return;
+              }
+              onFormChange({ ...form, projectId: value });
+            }}
+          >
+            <SelectTrigger className="w-full">
+              <span className="truncate">
+                {isLoadingProjects ? "Loading projects..." : projectLabel}
+              </span>
+            </SelectTrigger>
+            <SelectContent>
+              {projects.length === 0 ? (
+                <SelectItem value="__empty" disabled>
+                  No projects found
+                </SelectItem>
+              ) : null}
+              {projects.map((project) => (
+                <SelectItem key={project.id} value={project.id}>
+                  {project.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </Field>
+        <Field className="gap-2">
+          <FieldLabel>Space ID</FieldLabel>
+          <Input
+            value={form.spaceId}
+            disabled={disabled}
+            onChange={(event) => onFormChange({ ...form, spaceId: event.target.value })}
+          />
+        </Field>
+        <Field className="gap-2">
+          <FieldLabel>Environment ID</FieldLabel>
+          <Input
+            value={form.environmentId}
+            disabled={disabled}
+            placeholder="master"
+            onChange={(event) => onFormChange({ ...form, environmentId: event.target.value })}
+          />
+        </Field>
+        <Field className="gap-2">
+          <FieldLabel>Source locale</FieldLabel>
+          <Input
+            value={form.sourceLocale}
+            disabled={disabled}
+            placeholder="en-US"
+            onChange={(event) => onFormChange({ ...form, sourceLocale: event.target.value })}
+          />
+        </Field>
+        <Field className="gap-2">
+          <FieldLabel>Target locales</FieldLabel>
+          <Input
+            value={form.targetLocales}
+            disabled={disabled}
+            placeholder="fr-FR, de-DE"
+            onChange={(event) => onFormChange({ ...form, targetLocales: event.target.value })}
+          />
+        </Field>
+        <Field className="gap-2">
+          <FieldLabel>Content type IDs</FieldLabel>
+          <Input
+            value={form.contentTypeIds}
+            disabled={disabled}
+            placeholder="helpCenterArticle"
+            onChange={(event) => onFormChange({ ...form, contentTypeIds: event.target.value })}
+          />
+        </Field>
+        {!connection || isReplacingToken ? (
+          <Field className="gap-2">
+            <FieldLabel>Management API token</FieldLabel>
+            <div className="flex gap-2">
+              <Input
+                type="password"
+                value={form.accessToken}
+                disabled={disabled}
+                autoComplete="off"
+                onChange={(event) => onFormChange({ ...form, accessToken: event.target.value })}
+              />
+              {connection ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={disabled}
+                  onClick={() => {
+                    setIsReplacingToken(false);
+                    onFormChange({ ...form, accessToken: "" });
+                  }}
+                >
+                  Cancel
+                </Button>
+              ) : null}
+            </div>
+          </Field>
+        ) : (
+          <Field className="gap-2">
+            <FieldLabel>Management API token</FieldLabel>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={disabled}
+              className="justify-start"
+              onClick={() => setIsReplacingToken(true)}
+            >
+              Replace token
+            </Button>
+          </Field>
+        )}
+      </div>
+
+      {connection?.webhook ? (
+        <div className="text-sm">
+          <h4 className="font-medium">Webhook</h4>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Hyperlocalise registers a Contentful webhook for entry publish events when you save or
+            validate this connection. Automations with a Contentful trigger use it to start
+            translation runs.
+          </p>
+          <div className="mt-3 grid gap-2 rounded-lg bg-muted/50 p-3 text-xs">
+            <span>
+              Registration:{" "}
+              {connection.webhook.providerWebhookId
+                ? "Registered in Contentful"
+                : connection.webhook.lastError
+                  ? "Not registered"
+                  : "Pending registration"}
+            </span>
+            <span className="font-mono break-all">
+              URL: {connection.webhook.url ?? "Set HYPERLOCALISE_PUBLIC_APP_URL"}
+            </span>
+            {connection.webhook.providerWebhookId ? (
+              <span className="font-mono break-all">
+                Contentful webhook ID: {connection.webhook.providerWebhookId}
+              </span>
+            ) : null}
+            {lastWebhookSecret ? (
+              <span className="font-mono break-all">Secret: {lastWebhookSecret}</span>
+            ) : null}
+            {connection.webhook.lastError ? (
+              <span className="text-destructive">{connection.webhook.lastError}</span>
+            ) : null}
+            <span>Last delivery: {connection.webhook.lastDeliveredAt ?? "No deliveries yet"}</span>
+          </div>
+        </div>
+      ) : null}
+
+      <div className="flex justify-end">
+        <Button
+          type="button"
+          disabled={disabled || isSaving || isLoadingProjects || !canSaveContentfulConnection}
+          onClick={onSave}
+        >
+          <HugeiconsIcon icon={SaveIcon} strokeWidth={1.8} />
+          {isSaving ? "Saving..." : connection ? "Update connection" : "Save connection"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-page-content.tsx
@@ -814,6 +814,7 @@ export function IntegrationsPageContent({
   const [apiKey, setApiKey] = useState("");
   const [dialogOpen, setDialogOpen] = useState(false);
   const [showApiKey, setShowApiKey] = useState(false);
+  const [expandedContentful, setExpandedContentful] = useState(false);
 
   const modelFieldId = useId();
   const apiKeyFieldId = useId();
@@ -825,7 +826,7 @@ export function IntegrationsPageContent({
   const { data: contentfulConnections, isLoading: isLoadingContentful } =
     useContentfulConnections(organizationSlug);
   const { data: contentfulProjectOptions, isLoading: isLoadingContentfulProjects } =
-    useProjectOptions(organizationSlug);
+    useProjectOptions(organizationSlug, expandedContentful);
   const saveExternalTms = useSaveExternalTmsCredential(organizationSlug);
   const saveCrowdinOAuthApp = useSaveCrowdinOAuthApp(organizationSlug);
   const savePhraseOAuthApp = useSavePhraseOAuthApp(organizationSlug);
@@ -854,7 +855,6 @@ export function IntegrationsPageContent({
     accessToken: "",
   });
   const [lastContentfulWebhookSecret, setLastContentfulWebhookSecret] = useState("");
-  const [expandedContentful, setExpandedContentful] = useState(false);
 
   const tmsDisplayNameFieldId = useId();
   const tmsSecretFieldId = useId();
@@ -1200,24 +1200,31 @@ export function IntegrationsPageContent({
                     isSaving={saveContentfulConnection.isPending}
                     onSave={() => {
                       const accessToken = contentfulForm.accessToken.trim();
+                      const existingConnection = contentfulConnections?.[0];
+                      const payload = {
+                        projectId: contentfulForm.projectId.trim(),
+                        displayName: contentfulForm.displayName.trim(),
+                        spaceId: contentfulForm.spaceId.trim(),
+                        environmentId: contentfulForm.environmentId.trim() || "master",
+                        sourceLocale: contentfulForm.sourceLocale.trim(),
+                        targetLocales: contentfulForm.targetLocales
+                          .split(",")
+                          .map((value) => value.trim())
+                          .filter(Boolean),
+                        contentTypeIds: contentfulForm.contentTypeIds
+                          .split(",")
+                          .map((value) => value.trim())
+                          .filter(Boolean),
+                      };
+
                       saveContentfulConnection.mutate(
-                        {
-                          connectionId: contentfulConnections?.[0]?.id,
-                          projectId: contentfulForm.projectId.trim(),
-                          displayName: contentfulForm.displayName.trim(),
-                          spaceId: contentfulForm.spaceId.trim(),
-                          environmentId: contentfulForm.environmentId.trim() || "master",
-                          sourceLocale: contentfulForm.sourceLocale.trim(),
-                          targetLocales: contentfulForm.targetLocales
-                            .split(",")
-                            .map((value) => value.trim())
-                            .filter(Boolean),
-                          contentTypeIds: contentfulForm.contentTypeIds
-                            .split(",")
-                            .map((value) => value.trim())
-                            .filter(Boolean),
-                          ...(accessToken ? { accessToken } : {}),
-                        },
+                        existingConnection
+                          ? {
+                              ...payload,
+                              connectionId: existingConnection.id,
+                              ...(accessToken ? { accessToken } : {}),
+                            }
+                          : { ...payload, accessToken },
                         {
                           onSuccess: (result) => {
                             setContentfulForm((current) => ({ ...current, accessToken: "" }));

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-page-content.tsx
@@ -1,16 +1,8 @@
 "use client";
 
-import { useEffect, useId, useRef, useState, type ReactNode } from "react";
+import { useEffect, useId, useState, type ReactNode } from "react";
 import Image from "next/image";
-import {
-  Alert02Icon,
-  ArrowRight01Icon,
-  Copy01Icon,
-  Delete02Icon,
-  Key01Icon,
-  SaveIcon,
-  Tick02Icon,
-} from "@hugeicons/core-free-icons";
+import { Alert02Icon, Delete02Icon, Key01Icon, SaveIcon } from "@hugeicons/core-free-icons";
 import { ChevronDownIcon, EyeIcon, EyeOffIcon } from "lucide-react";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { SimpleIcon } from "simple-icons";
@@ -30,8 +22,6 @@ import type {
   ExternalTmsProviderKind,
 } from "@/lib/providers/organization-external-tms-provider-credentials";
 import { isTmsProviderShellModeEnabled } from "@/lib/providers/tms-provider-shell-mode";
-import { CROWDIN_OAUTH_SCOPE_GUIDE } from "@/lib/providers/adapters/crowdin/crowdin-oauth-scopes";
-import { PHRASE_OAUTH_SCOPE_GUIDE } from "@/lib/providers/adapters/phrase/phrase-oauth-scopes";
 import {
   AlertDialog,
   AlertDialogCancel,
@@ -61,12 +51,6 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
-import {
-  InputGroup,
-  InputGroupAddon,
-  InputGroupButton,
-  InputGroupInput,
-} from "@/components/ui/input-group";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { TypographyH1 } from "@/components/ui/typography";
@@ -75,8 +59,18 @@ import {
   CollaborationIntegrationsSection,
   SourceControlIntegrationsSection,
 } from "./agent-integrations-section";
+import {
+  ContentfulConnectionPanel,
+  type ContentfulConnectionForm,
+  type ContentfulConnectionSummary,
+  useContentfulConnections,
+  useProjectOptions,
+  useSaveContentfulConnection,
+} from "./contentful-connection-panel";
 import { IntegrationCategoryLabel, integrationConnectButtonClassName } from "./integration-row";
+import { ModelProviderCard, type ModelProviderCardConfig } from "./model-provider-card";
 import { SimpleBrandIcon } from "./simple-brand-icon";
+import { TmsProviderCredentialPanel } from "./tms-provider-credential-panel";
 import { tmsUserConnectCtaQueryKey } from "../../_hooks/use-tms-user-connect-cta";
 
 const api = createApiClient();
@@ -214,15 +208,6 @@ const byokProviders = [
   icon?: SimpleIcon;
 }[];
 
-type ModelProviderCardConfig = {
-  id: ProviderOptionId;
-  label: string;
-  description: string;
-  logo: string;
-  icon?: SimpleIcon;
-  managed?: boolean;
-};
-
 const modelProviderCards: readonly ModelProviderCardConfig[] = [
   hyperlocaliseGoProvider,
   ...byokProviders,
@@ -287,40 +272,6 @@ const contentfulIntegration = {
   icon: siContentful,
   detail: "CMS connector for agentic article translation and draft writeback.",
 } as const;
-
-type ContentfulConnectionSummary = {
-  id: string;
-  displayName: string;
-  projectId: string;
-  spaceId: string;
-  environmentId: string;
-  sourceLocale: string;
-  targetLocales: string[];
-  contentTypeIds: string[];
-  validationStatus: string;
-  validationMessage: string | null;
-  maskedTokenSuffix: string;
-  webhook: {
-    id: string;
-    status: string;
-    providerWebhookId: string | null;
-    url: string | null;
-    lastDeliveryId: string | null;
-    lastDeliveredAt: string | null;
-    lastError: string | null;
-  } | null;
-};
-
-type ContentfulConnectionForm = {
-  displayName: string;
-  projectId: string;
-  spaceId: string;
-  environmentId: string;
-  sourceLocale: string;
-  targetLocales: string;
-  contentTypeIds: string;
-  accessToken: string;
-};
 
 function useProviderCredential(organizationSlug: string) {
   return useQuery({
@@ -816,527 +767,6 @@ function CmsIntegrationRow({
   );
 }
 
-function CrowdinOAuthSetupFields({
-  providerKind,
-  providerName,
-  crowdinRedirectUri,
-  redirectUriFieldId,
-  redirectUriCopied,
-  onCopyRedirectUri,
-  oauthClientIdFieldId,
-  oauthClientId,
-  onOauthClientIdChange,
-  oauthClientSecretFieldId,
-  oauthClientSecret,
-  onOauthClientSecretChange,
-  showSecret,
-  onToggleShowSecret,
-}: {
-  providerKind: ExternalTmsProviderKind;
-  providerName: string;
-  crowdinRedirectUri: string;
-  redirectUriFieldId: string;
-  redirectUriCopied: boolean;
-  onCopyRedirectUri: () => void;
-  oauthClientIdFieldId: string;
-  oauthClientId: string;
-  onOauthClientIdChange: (value: string) => void;
-  oauthClientSecretFieldId: string;
-  oauthClientSecret: string;
-  onOauthClientSecretChange: (value: string) => void;
-  showSecret: boolean;
-  onToggleShowSecret: () => void;
-}) {
-  return (
-    <>
-      <Field className="gap-2">
-        <FieldLabel htmlFor={redirectUriFieldId}>OAuth callback URL</FieldLabel>
-        <InputGroup className="h-10 bg-muted/30">
-          <InputGroupInput
-            id={redirectUriFieldId}
-            readOnly
-            tabIndex={-1}
-            value={crowdinRedirectUri}
-            aria-label="OAuth callback URL"
-            className="truncate text-sm cursor-default"
-          />
-          <InputGroupAddon align="inline-end">
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <InputGroupButton
-                    variant="ghost"
-                    size="icon-sm"
-                    onClick={onCopyRedirectUri}
-                    disabled={!crowdinRedirectUri}
-                    aria-label={
-                      redirectUriCopied ? "Copied OAuth callback URL" : "Copy OAuth callback URL"
-                    }
-                  >
-                    <HugeiconsIcon
-                      icon={redirectUriCopied ? Tick02Icon : Copy01Icon}
-                      strokeWidth={1.8}
-                    />
-                  </InputGroupButton>
-                }
-              />
-              <TooltipContent>
-                {redirectUriCopied ? "Copied!" : "Copy OAuth callback URL"}
-              </TooltipContent>
-            </Tooltip>
-          </InputGroupAddon>
-        </InputGroup>
-      </Field>
-
-      <div className="space-y-3 rounded-lg border border-border bg-muted/30 p-4">
-        <div>
-          <p className="text-sm font-medium text-foreground">Required OAuth scopes</p>
-          <p className="mt-1 text-sm leading-6 text-muted-foreground">
-            {providerKind === "crowdin"
-              ? "In your Crowdin OAuth App, enable every scope below. Hyperlocalise requests the same list when you connect Crowdin."
-              : "Phrase TMS OAuth uses the scope below when Hyperlocalise requests an authorization code and exchanges it for a user bearer token."}
-          </p>
-        </div>
-        {providerKind === "crowdin" || providerKind === "phrase" ? (
-          <ul className="space-y-2">
-            {(providerKind === "crowdin"
-              ? CROWDIN_OAUTH_SCOPE_GUIDE
-              : PHRASE_OAUTH_SCOPE_GUIDE
-            ).map((entry) => (
-              <li key={entry.scope} className="flex flex-col gap-1 sm:flex-row sm:gap-3">
-                <code className="shrink-0 rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-foreground">
-                  {entry.scope}
-                </code>
-                <span className="text-sm leading-6 text-muted-foreground">{entry.description}</span>
-              </li>
-            ))}
-          </ul>
-        ) : null}
-      </div>
-
-      <Field className="gap-2">
-        <FieldLabel htmlFor={oauthClientIdFieldId}>OAuth client ID</FieldLabel>
-        <Input
-          id={oauthClientIdFieldId}
-          value={oauthClientId}
-          onChange={(event) => onOauthClientIdChange(event.target.value)}
-          autoComplete="off"
-          placeholder={`${providerName} OAuth App client ID`}
-        />
-      </Field>
-
-      <Field className="gap-2">
-        <FieldLabel htmlFor={oauthClientSecretFieldId}>OAuth client secret</FieldLabel>
-        <div className="relative">
-          <HugeiconsIcon
-            icon={Key01Icon}
-            strokeWidth={1.8}
-            className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground"
-          />
-          <Input
-            id={oauthClientSecretFieldId}
-            type={showSecret ? "text" : "password"}
-            autoComplete="off"
-            value={oauthClientSecret}
-            onChange={(event) => onOauthClientSecretChange(event.target.value)}
-            placeholder={`${providerName} OAuth App client secret`}
-            className="ps-9 pe-9"
-          />
-          <button
-            type="button"
-            onClick={onToggleShowSecret}
-            className="absolute top-1/2 right-3 -translate-y-1/2 text-muted-foreground transition-colors hover:text-foreground"
-            aria-label={showSecret ? "Hide secret" : "Show secret"}
-          >
-            {showSecret ? <EyeOffIcon size={16} /> : <EyeIcon size={16} />}
-          </button>
-        </div>
-      </Field>
-    </>
-  );
-}
-
-type TmsProviderCredentialPanelProps = {
-  providerKind: ExternalTmsProviderKind;
-  providerName: string;
-  credential?: ExternalTmsProviderCredentialListItem;
-  organizationSlug: string;
-  userIsAdmin: boolean;
-  displayName: string;
-  onDisplayNameChange: (value: string) => void;
-  secret: string;
-  onSecretChange: (value: string) => void;
-  oauthClientId: string;
-  onOauthClientIdChange: (value: string) => void;
-  oauthClientSecret: string;
-  onOauthClientSecretChange: (value: string) => void;
-  baseUrl: string;
-  onBaseUrlChange: (value: string) => void;
-  showSecret: boolean;
-  onToggleShowSecret: () => void;
-  onDisconnect: () => void;
-  onSave: () => void;
-  isSaving: boolean;
-  isDisconnecting: boolean;
-  displayNameFieldId: string;
-  secretFieldId: string;
-  oauthClientIdFieldId: string;
-  oauthClientSecretFieldId: string;
-  redirectUriFieldId: string;
-  baseUrlFieldId: string;
-};
-
-function TmsProviderCredentialPanel({
-  providerKind,
-  providerName,
-  credential,
-  organizationSlug,
-  userIsAdmin,
-  displayName,
-  onDisplayNameChange,
-  secret,
-  onSecretChange,
-  oauthClientId,
-  onOauthClientIdChange,
-  oauthClientSecret,
-  onOauthClientSecretChange,
-  baseUrl,
-  onBaseUrlChange,
-  showSecret,
-  onToggleShowSecret,
-  onDisconnect,
-  onSave,
-  isSaving,
-  isDisconnecting,
-  displayNameFieldId,
-  secretFieldId,
-  oauthClientIdFieldId,
-  oauthClientSecretFieldId,
-  redirectUriFieldId,
-  baseUrlFieldId,
-}: TmsProviderCredentialPanelProps) {
-  const isCrowdin = providerKind === "crowdin";
-  const isOAuthProvider = isCrowdin || providerKind === "phrase" || providerKind === "lokalise";
-  const oauthRedirectUri =
-    typeof window === "undefined"
-      ? ""
-      : `${window.location.origin}/api/orgs/${encodeURIComponent(organizationSlug)}/external-tms-provider-credential/${providerKind}/oauth/callback`;
-  const [redirectUriCopied, setRedirectUriCopied] = useState(false);
-  const [advancedSettingsOpen, setAdvancedSettingsOpen] = useState(false);
-  const redirectUriCopyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (redirectUriCopyTimeoutRef.current) {
-        clearTimeout(redirectUriCopyTimeoutRef.current);
-      }
-    };
-  }, []);
-
-  const copyCrowdinRedirectUri = async () => {
-    if (!oauthRedirectUri) {
-      return;
-    }
-
-    await navigator.clipboard.writeText(oauthRedirectUri);
-    setRedirectUriCopied(true);
-    toast.success("OAuth callback URL copied");
-
-    if (redirectUriCopyTimeoutRef.current) {
-      clearTimeout(redirectUriCopyTimeoutRef.current);
-    }
-
-    redirectUriCopyTimeoutRef.current = setTimeout(() => {
-      setRedirectUriCopied(false);
-    }, 2000);
-  };
-
-  const isOAuthConnected = isOAuthProvider && credential?.authMode === "oauth";
-  const [oauthReconnectOpen, setOauthReconnectOpen] = useState(false);
-  const showOAuthSetupFields = !isOAuthConnected || oauthReconnectOpen;
-
-  const canSubmit = isOAuthProvider
-    ? isOAuthConnected && !oauthReconnectOpen
-      ? false
-      : Boolean(displayName.trim() && oauthClientId.trim() && oauthClientSecret.trim())
-    : Boolean(displayName.trim() && secret.trim());
-
-  return (
-    <form
-      className="flex flex-col gap-5"
-      onSubmit={(event) => {
-        event.preventDefault();
-        onSave();
-      }}
-    >
-      {isOAuthProvider && isOAuthConnected ? (
-        <div className="space-y-2 rounded-lg border border-border bg-muted/30 p-4 text-sm">
-          <p className="font-medium text-foreground">{providerName} is connected via OAuth</p>
-          <p className="leading-6 text-muted-foreground">
-            Access and refresh tokens are stored encrypted. Projects, jobs, glossaries, and
-            translation memories load live from {providerName} when you open those pages.
-          </p>
-          {credential.oauthExpiresAt ? (
-            <p className="text-xs text-muted-foreground">
-              Access token expires {new Date(credential.oauthExpiresAt).toLocaleString()}
-            </p>
-          ) : null}
-        </div>
-      ) : null}
-
-      {isOAuthProvider && !isOAuthConnected ? (
-        <p className="text-sm leading-6 text-muted-foreground">
-          {`Connect ${providerName} with an OAuth App. Projects, jobs, glossaries, and translation memories load live from ${providerName}. API-token setup is disabled in Hyperlocalise.`}
-        </p>
-      ) : !isOAuthProvider ? (
-        <p className="text-sm leading-6 text-muted-foreground">
-          Save credentials to connect {providerName}. The secret is encrypted at rest and used to
-          sync projects, files, and jobs into the workspace.
-        </p>
-      ) : null}
-
-      <Field className="gap-2">
-        <FieldLabel htmlFor={displayNameFieldId}>Display name</FieldLabel>
-        <Input
-          id={displayNameFieldId}
-          value={displayName}
-          onChange={(event) => onDisplayNameChange(event.target.value)}
-          placeholder="e.g. Crowdin Production"
-        />
-      </Field>
-
-      {isOAuthProvider && isOAuthConnected ? (
-        <Collapsible open={oauthReconnectOpen} onOpenChange={setOauthReconnectOpen}>
-          <CollapsibleTrigger
-            render={
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className="h-8 w-full justify-between px-2 text-muted-foreground hover:text-foreground"
-              >
-                Reconnect with a different OAuth app
-                <ChevronDownIcon
-                  className={cn(
-                    "size-3.5 shrink-0 transition-transform",
-                    oauthReconnectOpen && "rotate-180",
-                  )}
-                  strokeWidth={2}
-                />
-              </Button>
-            }
-          />
-          <CollapsibleContent className="space-y-5 pt-3">
-            <CrowdinOAuthSetupFields
-              providerKind={providerKind}
-              providerName={providerName}
-              crowdinRedirectUri={oauthRedirectUri}
-              redirectUriFieldId={redirectUriFieldId}
-              redirectUriCopied={redirectUriCopied}
-              onCopyRedirectUri={() => {
-                void copyCrowdinRedirectUri();
-              }}
-              oauthClientIdFieldId={oauthClientIdFieldId}
-              oauthClientId={oauthClientId}
-              onOauthClientIdChange={onOauthClientIdChange}
-              oauthClientSecretFieldId={oauthClientSecretFieldId}
-              oauthClientSecret={oauthClientSecret}
-              onOauthClientSecretChange={onOauthClientSecretChange}
-              showSecret={showSecret}
-              onToggleShowSecret={onToggleShowSecret}
-            />
-          </CollapsibleContent>
-        </Collapsible>
-      ) : null}
-
-      {isOAuthProvider && showOAuthSetupFields && !isOAuthConnected ? (
-        <CrowdinOAuthSetupFields
-          providerKind={providerKind}
-          providerName={providerName}
-          crowdinRedirectUri={oauthRedirectUri}
-          redirectUriFieldId={redirectUriFieldId}
-          redirectUriCopied={redirectUriCopied}
-          onCopyRedirectUri={() => {
-            void copyCrowdinRedirectUri();
-          }}
-          oauthClientIdFieldId={oauthClientIdFieldId}
-          oauthClientId={oauthClientId}
-          onOauthClientIdChange={onOauthClientIdChange}
-          oauthClientSecretFieldId={oauthClientSecretFieldId}
-          oauthClientSecret={oauthClientSecret}
-          onOauthClientSecretChange={onOauthClientSecretChange}
-          showSecret={showSecret}
-          onToggleShowSecret={onToggleShowSecret}
-        />
-      ) : null}
-
-      {!isOAuthProvider ? (
-        <Field className="gap-2">
-          <FieldLabel htmlFor={secretFieldId}>API token / secret</FieldLabel>
-          <div className="relative">
-            <HugeiconsIcon
-              icon={Key01Icon}
-              strokeWidth={1.8}
-              className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground"
-            />
-            <Input
-              id={secretFieldId}
-              type={showSecret ? "text" : "password"}
-              autoComplete="off"
-              value={secret}
-              onChange={(event) => onSecretChange(event.target.value)}
-              placeholder="Enter provider API token"
-              className="ps-9 pe-9"
-            />
-            <button
-              type="button"
-              onClick={onToggleShowSecret}
-              className="absolute top-1/2 right-3 -translate-y-1/2 text-muted-foreground transition-colors hover:text-foreground"
-              aria-label={showSecret ? "Hide secret" : "Show secret"}
-            >
-              {showSecret ? <EyeOffIcon size={16} /> : <EyeIcon size={16} />}
-            </button>
-          </div>
-        </Field>
-      ) : null}
-
-      <Collapsible open={advancedSettingsOpen} onOpenChange={setAdvancedSettingsOpen}>
-        <CollapsibleTrigger
-          render={
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              className="h-8 w-full justify-between px-2 text-muted-foreground hover:text-foreground"
-            >
-              Advanced settings
-              <ChevronDownIcon
-                className={cn(
-                  "size-3.5 shrink-0 transition-transform",
-                  advancedSettingsOpen && "rotate-180",
-                )}
-                strokeWidth={2}
-              />
-            </Button>
-          }
-        />
-        <CollapsibleContent className="pt-1">
-          <Field className="gap-2">
-            <FieldLabel htmlFor={baseUrlFieldId}>Base URL (optional)</FieldLabel>
-            <Input
-              id={baseUrlFieldId}
-              value={baseUrl}
-              onChange={(event) => onBaseUrlChange(event.target.value)}
-              placeholder="https://api.example.com"
-            />
-          </Field>
-        </CollapsibleContent>
-      </Collapsible>
-
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        {credential && userIsAdmin ? (
-          <Button type="button" variant="outline" onClick={onDisconnect} disabled={isDisconnecting}>
-            <HugeiconsIcon icon={Delete02Icon} strokeWidth={1.8} />
-            Disconnect
-          </Button>
-        ) : (
-          <div />
-        )}
-        <Button type="submit" disabled={!canSubmit || isSaving} className="sm:ms-auto">
-          <HugeiconsIcon icon={SaveIcon} strokeWidth={1.8} />
-          {isSaving
-            ? "Saving..."
-            : isOAuthProvider
-              ? isOAuthConnected
-                ? `Update ${providerName}`
-                : `Save ${providerName}`
-              : "Save provider"}
-        </Button>
-      </div>
-    </form>
-  );
-}
-
-function ModelProviderCard({
-  provider,
-  isActive,
-  isManaged,
-  footerLabel,
-  onSelect,
-  disabled,
-}: {
-  provider: ModelProviderCardConfig;
-  isActive: boolean;
-  isManaged?: boolean;
-  footerLabel?: string;
-  onSelect: () => void;
-  disabled?: boolean;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onSelect}
-      disabled={disabled}
-      className={cn(
-        "group relative flex min-h-44 w-full flex-col rounded-lg border border-border bg-card p-5 text-left text-card-foreground transition-colors",
-        "hover:bg-accent disabled:cursor-not-allowed disabled:opacity-60",
-        isActive && "border-foreground",
-      )}
-    >
-      {isActive ? (
-        <Badge
-          variant="outline"
-          className={cn(
-            "absolute top-4 right-4 text-[10px]",
-            "border-grove-500/35 bg-grove-100 text-grove-900 dark:border-grove-300/20 dark:bg-grove-300/10 dark:text-grove-300",
-          )}
-        >
-          Active
-        </Badge>
-      ) : null}
-
-      <div
-        className={cn(
-          "flex size-10 shrink-0 items-center justify-center rounded-lg border border-border p-2",
-          isActive ? "bg-muted text-foreground" : "bg-background text-foreground",
-        )}
-      >
-        {provider.icon ? (
-          <SimpleBrandIcon icon={provider.icon} colored={isActive} />
-        ) : (
-          <Image
-            src={provider.logo}
-            alt=""
-            width={28}
-            height={28}
-            className={cn("max-h-7 w-auto object-contain", !isActive && "opacity-75")}
-          />
-        )}
-      </div>
-
-      <div className="mt-4 flex flex-wrap items-center gap-2">
-        <span className="text-base font-medium text-foreground">{provider.label}</span>
-        {isManaged ? (
-          <Badge variant="outline" className="text-[10px]">
-            Managed
-          </Badge>
-        ) : null}
-      </div>
-
-      <p className="mt-1 text-sm text-muted-foreground">{provider.description}</p>
-
-      <div className="mt-auto flex items-center justify-end gap-1 pt-6 text-sm text-muted-foreground">
-        {footerLabel ? <span>{footerLabel}</span> : null}
-        <HugeiconsIcon
-          icon={ArrowRight01Icon}
-          strokeWidth={1.8}
-          className="size-4 transition-transform group-hover:translate-x-0.5 group-disabled:translate-x-0"
-        />
-      </div>
-    </button>
-  );
-}
-
 function useDeleteExternalTmsCredential(organizationSlug: string) {
   const queryClient = useQueryClient();
 
@@ -1369,227 +799,6 @@ function useDeleteExternalTmsCredential(organizationSlug: string) {
   });
 }
 
-function useContentfulConnections(organizationSlug: string) {
-  return useQuery({
-    queryKey: ["contentful-connections", organizationSlug],
-    queryFn: async () => {
-      const res = await api.api.orgs[":organizationSlug"]["contentful-connections"].$get({
-        param: { organizationSlug },
-      });
-      if (!res.ok) {
-        throw new Error("Failed to fetch Contentful connections");
-      }
-      const data = await res.json();
-      return data.contentfulConnections as ContentfulConnectionSummary[];
-    },
-  });
-}
-
-function useSaveContentfulConnection(organizationSlug: string) {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: async (payload: {
-      projectId: string;
-      displayName: string;
-      spaceId: string;
-      environmentId: string;
-      sourceLocale: string;
-      targetLocales: string[];
-      contentTypeIds: string[];
-      accessToken: string;
-    }) => {
-      const res = await api.api.orgs[":organizationSlug"]["contentful-connections"].$post({
-        param: { organizationSlug },
-        json: {
-          ...payload,
-          fieldConfig: { fieldMode: "auto", overwriteDraftLocales: false },
-          enabled: true,
-        },
-      });
-      if (!res.ok) {
-        const error = await res.json().catch(() => ({ error: "contentful_connection_failed" }));
-        throw new Error(
-          "message" in error ? String(error.message) : "Unable to save Contentful connection",
-        );
-      }
-      return res.json();
-    },
-    onSuccess: async (result) => {
-      await queryClient.invalidateQueries({
-        queryKey: ["contentful-connections", organizationSlug],
-      });
-      toast.success("Contentful connection saved");
-      if (result.webhookSecret) {
-        toast.message("Contentful webhook registered", {
-          description:
-            "Hyperlocalise created the Contentful webhook automatically. Save the secret below if you need to re-register manually.",
-        });
-      } else if (result.contentfulConnection.webhook?.providerWebhookId) {
-        toast.message("Contentful webhook synced", {
-          description: "Hyperlocalise updated the Contentful webhook configuration.",
-        });
-      } else if (result.contentfulConnection.webhook?.lastError) {
-        toast.message("Contentful webhook needs attention", {
-          description: result.contentfulConnection.webhook.lastError,
-        });
-      }
-    },
-    onError: (error) => {
-      toast.error(error.message);
-    },
-  });
-}
-
-function ContentfulConnectionPanel({
-  connection,
-  disabled,
-  lastWebhookSecret,
-  onSave,
-  isSaving,
-  form,
-  onFormChange,
-}: {
-  connection?: ContentfulConnectionSummary;
-  disabled: boolean;
-  lastWebhookSecret: string;
-  onSave: () => void;
-  isSaving: boolean;
-  form: ContentfulConnectionForm;
-  onFormChange: (form: ContentfulConnectionForm) => void;
-}) {
-  return (
-    <div className="flex flex-col gap-5">
-      {connection ? (
-        <div className="flex flex-wrap gap-2 text-xs">
-          <Badge variant="outline">Token ...{connection.maskedTokenSuffix}</Badge>
-          <Badge variant="outline">
-            {connection.spaceId}/{connection.environmentId}
-          </Badge>
-        </div>
-      ) : null}
-
-      <div className="grid gap-4 lg:grid-cols-2">
-        <Field className="gap-2">
-          <FieldLabel>Display name</FieldLabel>
-          <Input
-            value={form.displayName}
-            disabled={disabled}
-            placeholder="Contentful Help Center"
-            onChange={(event) => onFormChange({ ...form, displayName: event.target.value })}
-          />
-        </Field>
-        <Field className="gap-2">
-          <FieldLabel>Project ID</FieldLabel>
-          <Input
-            value={form.projectId}
-            disabled={disabled}
-            placeholder="Hyperlocalise project ID"
-            onChange={(event) => onFormChange({ ...form, projectId: event.target.value })}
-          />
-        </Field>
-        <Field className="gap-2">
-          <FieldLabel>Space ID</FieldLabel>
-          <Input
-            value={form.spaceId}
-            disabled={disabled}
-            onChange={(event) => onFormChange({ ...form, spaceId: event.target.value })}
-          />
-        </Field>
-        <Field className="gap-2">
-          <FieldLabel>Environment ID</FieldLabel>
-          <Input
-            value={form.environmentId}
-            disabled={disabled}
-            placeholder="master"
-            onChange={(event) => onFormChange({ ...form, environmentId: event.target.value })}
-          />
-        </Field>
-        <Field className="gap-2">
-          <FieldLabel>Source locale</FieldLabel>
-          <Input
-            value={form.sourceLocale}
-            disabled={disabled}
-            placeholder="en-US"
-            onChange={(event) => onFormChange({ ...form, sourceLocale: event.target.value })}
-          />
-        </Field>
-        <Field className="gap-2">
-          <FieldLabel>Target locales</FieldLabel>
-          <Input
-            value={form.targetLocales}
-            disabled={disabled}
-            placeholder="fr-FR, de-DE"
-            onChange={(event) => onFormChange({ ...form, targetLocales: event.target.value })}
-          />
-        </Field>
-        <Field className="gap-2">
-          <FieldLabel>Content type IDs</FieldLabel>
-          <Input
-            value={form.contentTypeIds}
-            disabled={disabled}
-            placeholder="helpCenterArticle"
-            onChange={(event) => onFormChange({ ...form, contentTypeIds: event.target.value })}
-          />
-        </Field>
-        <Field className="gap-2">
-          <FieldLabel>Management API token</FieldLabel>
-          <Input
-            type="password"
-            value={form.accessToken}
-            disabled={disabled}
-            autoComplete="off"
-            onChange={(event) => onFormChange({ ...form, accessToken: event.target.value })}
-          />
-        </Field>
-      </div>
-
-      {connection?.webhook ? (
-        <div className="text-sm">
-          <h4 className="font-medium">Webhook</h4>
-          <p className="mt-1 text-xs text-muted-foreground">
-            Hyperlocalise registers a Contentful webhook for entry publish events when you save or
-            validate this connection. Automations with a Contentful trigger use it to start
-            translation runs.
-          </p>
-          <div className="mt-3 grid gap-2 rounded-lg bg-muted/50 p-3 text-xs">
-            <span>
-              Registration:{" "}
-              {connection.webhook.providerWebhookId
-                ? "Registered in Contentful"
-                : connection.webhook.lastError
-                  ? "Not registered"
-                  : "Pending registration"}
-            </span>
-            <span className="font-mono break-all">
-              URL: {connection.webhook.url ?? "Set HYPERLOCALISE_PUBLIC_APP_URL"}
-            </span>
-            {connection.webhook.providerWebhookId ? (
-              <span className="font-mono break-all">
-                Contentful webhook ID: {connection.webhook.providerWebhookId}
-              </span>
-            ) : null}
-            {lastWebhookSecret ? (
-              <span className="font-mono break-all">Secret: {lastWebhookSecret}</span>
-            ) : null}
-            {connection.webhook.lastError ? (
-              <span className="text-destructive">{connection.webhook.lastError}</span>
-            ) : null}
-            <span>Last delivery: {connection.webhook.lastDeliveredAt ?? "No deliveries yet"}</span>
-          </div>
-        </div>
-      ) : null}
-
-      <div className="flex justify-end">
-        <Button type="button" disabled={disabled || isSaving} onClick={onSave}>
-          <HugeiconsIcon icon={SaveIcon} strokeWidth={1.8} />
-          {isSaving ? "Saving..." : connection ? "Update connection" : "Save connection"}
-        </Button>
-      </div>
-    </div>
-  );
-}
-
 export function IntegrationsPageContent({
   organizationSlug,
   membershipRole,
@@ -1615,6 +824,8 @@ export function IntegrationsPageContent({
   const activeExternalTmsProviderCredential = externalTmsCredentialState?.activeCredential ?? null;
   const { data: contentfulConnections, isLoading: isLoadingContentful } =
     useContentfulConnections(organizationSlug);
+  const { data: contentfulProjectOptions, isLoading: isLoadingContentfulProjects } =
+    useProjectOptions(organizationSlug);
   const saveExternalTms = useSaveExternalTmsCredential(organizationSlug);
   const saveCrowdinOAuthApp = useSaveCrowdinOAuthApp(organizationSlug);
   const savePhraseOAuthApp = useSavePhraseOAuthApp(organizationSlug);
@@ -1983,11 +1194,15 @@ export function IntegrationsPageContent({
                     disabled={!userIsAdmin}
                     form={contentfulForm}
                     onFormChange={setContentfulForm}
+                    projects={contentfulProjectOptions ?? []}
+                    isLoadingProjects={isLoadingContentfulProjects}
                     lastWebhookSecret={lastContentfulWebhookSecret}
                     isSaving={saveContentfulConnection.isPending}
                     onSave={() => {
+                      const accessToken = contentfulForm.accessToken.trim();
                       saveContentfulConnection.mutate(
                         {
+                          connectionId: contentfulConnections?.[0]?.id,
                           projectId: contentfulForm.projectId.trim(),
                           displayName: contentfulForm.displayName.trim(),
                           spaceId: contentfulForm.spaceId.trim(),
@@ -2001,7 +1216,7 @@ export function IntegrationsPageContent({
                             .split(",")
                             .map((value) => value.trim())
                             .filter(Boolean),
-                          accessToken: contentfulForm.accessToken.trim(),
+                          ...(accessToken ? { accessToken } : {}),
                         },
                         {
                           onSuccess: (result) => {

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/model-provider-card.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/model-provider-card.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import Image from "next/image";
+import { ArrowRight01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import type { SimpleIcon } from "simple-icons";
+
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/primitives/cn";
+import { SimpleBrandIcon } from "./simple-brand-icon";
+
+export type ModelProviderCardConfig = {
+  id: string;
+  label: string;
+  description: string;
+  icon?: SimpleIcon;
+  logo: string;
+};
+
+export function ModelProviderCard({
+  provider,
+  isActive,
+  isManaged,
+  footerLabel,
+  onSelect,
+  disabled,
+}: {
+  provider: ModelProviderCardConfig;
+  isActive: boolean;
+  isManaged?: boolean;
+  footerLabel?: string;
+  onSelect: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      disabled={disabled}
+      className={cn(
+        "group relative flex min-h-44 w-full flex-col rounded-lg border border-border bg-card p-5 text-left text-card-foreground transition-colors",
+        "hover:bg-accent disabled:cursor-not-allowed disabled:opacity-60",
+        isActive && "border-foreground",
+      )}
+    >
+      {isActive ? (
+        <Badge
+          variant="outline"
+          className={cn(
+            "absolute top-4 right-4 text-[10px]",
+            "border-grove-500/35 bg-grove-100 text-grove-900 dark:border-grove-300/20 dark:bg-grove-300/10 dark:text-grove-300",
+          )}
+        >
+          Active
+        </Badge>
+      ) : null}
+
+      <div
+        className={cn(
+          "flex size-10 shrink-0 items-center justify-center rounded-lg border border-border p-2",
+          isActive ? "bg-muted text-foreground" : "bg-background text-foreground",
+        )}
+      >
+        {provider.icon ? (
+          <SimpleBrandIcon icon={provider.icon} colored={isActive} />
+        ) : (
+          <Image
+            src={provider.logo}
+            alt=""
+            width={28}
+            height={28}
+            className={cn("max-h-7 w-auto object-contain", !isActive && "opacity-75")}
+          />
+        )}
+      </div>
+
+      <div className="mt-4 flex flex-wrap items-center gap-2">
+        <span className="text-base font-medium text-foreground">{provider.label}</span>
+        {isManaged ? (
+          <Badge variant="outline" className="text-[10px]">
+            Managed
+          </Badge>
+        ) : null}
+      </div>
+
+      <p className="mt-1 text-sm text-muted-foreground">{provider.description}</p>
+
+      <div className="mt-auto flex items-center justify-end gap-1 pt-6 text-sm text-muted-foreground">
+        {footerLabel ? <span>{footerLabel}</span> : null}
+        <HugeiconsIcon
+          icon={ArrowRight01Icon}
+          strokeWidth={1.8}
+          className="size-4 transition-transform group-hover:translate-x-0.5 group-disabled:translate-x-0"
+        />
+      </div>
+    </button>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/tms-provider-credential-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/tms-provider-credential-panel.tsx
@@ -1,0 +1,473 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import {
+  Copy01Icon,
+  Delete02Icon,
+  Key01Icon,
+  SaveIcon,
+  Tick02Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { ChevronDownIcon, EyeIcon, EyeOffIcon } from "lucide-react";
+import { toast } from "sonner";
+
+import type {
+  ExternalTmsProviderCredentialListItem,
+  ExternalTmsProviderKind,
+} from "@/lib/providers/organization-external-tms-provider-credentials";
+import { CROWDIN_OAUTH_SCOPE_GUIDE } from "@/lib/providers/adapters/crowdin/crowdin-oauth-scopes";
+import { PHRASE_OAUTH_SCOPE_GUIDE } from "@/lib/providers/adapters/phrase/phrase-oauth-scopes";
+import { Button } from "@/components/ui/button";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { Field, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from "@/components/ui/input-group";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn } from "@/lib/primitives/cn";
+
+function CrowdinOAuthSetupFields({
+  providerKind,
+  providerName,
+  crowdinRedirectUri,
+  redirectUriFieldId,
+  redirectUriCopied,
+  onCopyRedirectUri,
+  oauthClientIdFieldId,
+  oauthClientId,
+  onOauthClientIdChange,
+  oauthClientSecretFieldId,
+  oauthClientSecret,
+  onOauthClientSecretChange,
+  showSecret,
+  onToggleShowSecret,
+}: {
+  providerKind: ExternalTmsProviderKind;
+  providerName: string;
+  crowdinRedirectUri: string;
+  redirectUriFieldId: string;
+  redirectUriCopied: boolean;
+  onCopyRedirectUri: () => void;
+  oauthClientIdFieldId: string;
+  oauthClientId: string;
+  onOauthClientIdChange: (value: string) => void;
+  oauthClientSecretFieldId: string;
+  oauthClientSecret: string;
+  onOauthClientSecretChange: (value: string) => void;
+  showSecret: boolean;
+  onToggleShowSecret: () => void;
+}) {
+  return (
+    <>
+      <Field className="gap-2">
+        <FieldLabel htmlFor={redirectUriFieldId}>OAuth callback URL</FieldLabel>
+        <InputGroup className="h-10 bg-muted/30">
+          <InputGroupInput
+            id={redirectUriFieldId}
+            readOnly
+            tabIndex={-1}
+            value={crowdinRedirectUri}
+            aria-label="OAuth callback URL"
+            className="truncate text-sm cursor-default"
+          />
+          <InputGroupAddon align="inline-end">
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <InputGroupButton
+                    variant="ghost"
+                    size="icon-sm"
+                    onClick={onCopyRedirectUri}
+                    disabled={!crowdinRedirectUri}
+                    aria-label={
+                      redirectUriCopied ? "Copied OAuth callback URL" : "Copy OAuth callback URL"
+                    }
+                  >
+                    <HugeiconsIcon
+                      icon={redirectUriCopied ? Tick02Icon : Copy01Icon}
+                      strokeWidth={1.8}
+                    />
+                  </InputGroupButton>
+                }
+              />
+              <TooltipContent>
+                {redirectUriCopied ? "Copied!" : "Copy OAuth callback URL"}
+              </TooltipContent>
+            </Tooltip>
+          </InputGroupAddon>
+        </InputGroup>
+      </Field>
+
+      <div className="space-y-3 rounded-lg border border-border bg-muted/30 p-4">
+        <div>
+          <p className="text-sm font-medium text-foreground">Required OAuth scopes</p>
+          <p className="mt-1 text-sm leading-6 text-muted-foreground">
+            {providerKind === "crowdin"
+              ? "In your Crowdin OAuth App, enable every scope below. Hyperlocalise requests the same list when you connect Crowdin."
+              : "Phrase TMS OAuth uses the scope below when Hyperlocalise requests an authorization code and exchanges it for a user bearer token."}
+          </p>
+        </div>
+        {providerKind === "crowdin" || providerKind === "phrase" ? (
+          <ul className="space-y-2">
+            {(providerKind === "crowdin"
+              ? CROWDIN_OAUTH_SCOPE_GUIDE
+              : PHRASE_OAUTH_SCOPE_GUIDE
+            ).map((entry) => (
+              <li key={entry.scope} className="flex flex-col gap-1 sm:flex-row sm:gap-3">
+                <code className="shrink-0 rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-foreground">
+                  {entry.scope}
+                </code>
+                <span className="text-sm leading-6 text-muted-foreground">{entry.description}</span>
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </div>
+
+      <Field className="gap-2">
+        <FieldLabel htmlFor={oauthClientIdFieldId}>OAuth client ID</FieldLabel>
+        <Input
+          id={oauthClientIdFieldId}
+          value={oauthClientId}
+          onChange={(event) => onOauthClientIdChange(event.target.value)}
+          autoComplete="off"
+          placeholder={`${providerName} OAuth App client ID`}
+        />
+      </Field>
+
+      <Field className="gap-2">
+        <FieldLabel htmlFor={oauthClientSecretFieldId}>OAuth client secret</FieldLabel>
+        <div className="relative">
+          <HugeiconsIcon
+            icon={Key01Icon}
+            strokeWidth={1.8}
+            className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground"
+          />
+          <Input
+            id={oauthClientSecretFieldId}
+            type={showSecret ? "text" : "password"}
+            autoComplete="off"
+            value={oauthClientSecret}
+            onChange={(event) => onOauthClientSecretChange(event.target.value)}
+            placeholder={`${providerName} OAuth App client secret`}
+            className="ps-9 pe-9"
+          />
+          <button
+            type="button"
+            onClick={onToggleShowSecret}
+            className="absolute top-1/2 right-3 -translate-y-1/2 text-muted-foreground transition-colors hover:text-foreground"
+            aria-label={showSecret ? "Hide secret" : "Show secret"}
+          >
+            {showSecret ? <EyeOffIcon size={16} /> : <EyeIcon size={16} />}
+          </button>
+        </div>
+      </Field>
+    </>
+  );
+}
+
+type TmsProviderCredentialPanelProps = {
+  providerKind: ExternalTmsProviderKind;
+  providerName: string;
+  credential?: ExternalTmsProviderCredentialListItem;
+  organizationSlug: string;
+  userIsAdmin: boolean;
+  displayName: string;
+  onDisplayNameChange: (value: string) => void;
+  secret: string;
+  onSecretChange: (value: string) => void;
+  oauthClientId: string;
+  onOauthClientIdChange: (value: string) => void;
+  oauthClientSecret: string;
+  onOauthClientSecretChange: (value: string) => void;
+  baseUrl: string;
+  onBaseUrlChange: (value: string) => void;
+  showSecret: boolean;
+  onToggleShowSecret: () => void;
+  onDisconnect: () => void;
+  onSave: () => void;
+  isSaving: boolean;
+  isDisconnecting: boolean;
+  displayNameFieldId: string;
+  secretFieldId: string;
+  oauthClientIdFieldId: string;
+  oauthClientSecretFieldId: string;
+  redirectUriFieldId: string;
+  baseUrlFieldId: string;
+};
+
+export function TmsProviderCredentialPanel({
+  providerKind,
+  providerName,
+  credential,
+  organizationSlug,
+  userIsAdmin,
+  displayName,
+  onDisplayNameChange,
+  secret,
+  onSecretChange,
+  oauthClientId,
+  onOauthClientIdChange,
+  oauthClientSecret,
+  onOauthClientSecretChange,
+  baseUrl,
+  onBaseUrlChange,
+  showSecret,
+  onToggleShowSecret,
+  onDisconnect,
+  onSave,
+  isSaving,
+  isDisconnecting,
+  displayNameFieldId,
+  secretFieldId,
+  oauthClientIdFieldId,
+  oauthClientSecretFieldId,
+  redirectUriFieldId,
+  baseUrlFieldId,
+}: TmsProviderCredentialPanelProps) {
+  const isCrowdin = providerKind === "crowdin";
+  const isOAuthProvider = isCrowdin || providerKind === "phrase" || providerKind === "lokalise";
+  const oauthRedirectUri =
+    typeof window === "undefined"
+      ? ""
+      : `${window.location.origin}/api/orgs/${encodeURIComponent(organizationSlug)}/external-tms-provider-credential/${providerKind}/oauth/callback`;
+  const [redirectUriCopied, setRedirectUriCopied] = useState(false);
+  const [advancedSettingsOpen, setAdvancedSettingsOpen] = useState(false);
+  const redirectUriCopyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (redirectUriCopyTimeoutRef.current) {
+        clearTimeout(redirectUriCopyTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const copyCrowdinRedirectUri = async () => {
+    if (!oauthRedirectUri) {
+      return;
+    }
+
+    await navigator.clipboard.writeText(oauthRedirectUri);
+    setRedirectUriCopied(true);
+    toast.success("OAuth callback URL copied");
+
+    if (redirectUriCopyTimeoutRef.current) {
+      clearTimeout(redirectUriCopyTimeoutRef.current);
+    }
+
+    redirectUriCopyTimeoutRef.current = setTimeout(() => {
+      setRedirectUriCopied(false);
+    }, 2000);
+  };
+
+  const isOAuthConnected = isOAuthProvider && credential?.authMode === "oauth";
+  const [oauthReconnectOpen, setOauthReconnectOpen] = useState(false);
+  const showOAuthSetupFields = !isOAuthConnected || oauthReconnectOpen;
+
+  const canSubmit = isOAuthProvider
+    ? isOAuthConnected && !oauthReconnectOpen
+      ? false
+      : Boolean(displayName.trim() && oauthClientId.trim() && oauthClientSecret.trim())
+    : Boolean(displayName.trim() && secret.trim());
+
+  return (
+    <form
+      className="flex flex-col gap-5"
+      onSubmit={(event) => {
+        event.preventDefault();
+        onSave();
+      }}
+    >
+      {isOAuthProvider && isOAuthConnected ? (
+        <div className="space-y-2 rounded-lg border border-border bg-muted/30 p-4 text-sm">
+          <p className="font-medium text-foreground">{providerName} is connected via OAuth</p>
+          <p className="leading-6 text-muted-foreground">
+            Access and refresh tokens are stored encrypted. Projects, jobs, glossaries, and
+            translation memories load live from {providerName} when you open those pages.
+          </p>
+          {credential.oauthExpiresAt ? (
+            <p className="text-xs text-muted-foreground">
+              Access token expires {new Date(credential.oauthExpiresAt).toLocaleString()}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+
+      {isOAuthProvider && !isOAuthConnected ? (
+        <p className="text-sm leading-6 text-muted-foreground">
+          {`Connect ${providerName} with an OAuth App. Projects, jobs, glossaries, and translation memories load live from ${providerName}. API-token setup is disabled in Hyperlocalise.`}
+        </p>
+      ) : !isOAuthProvider ? (
+        <p className="text-sm leading-6 text-muted-foreground">
+          Save credentials to connect {providerName}. The secret is encrypted at rest and used to
+          sync projects, files, and jobs into the workspace.
+        </p>
+      ) : null}
+
+      <Field className="gap-2">
+        <FieldLabel htmlFor={displayNameFieldId}>Display name</FieldLabel>
+        <Input
+          id={displayNameFieldId}
+          value={displayName}
+          onChange={(event) => onDisplayNameChange(event.target.value)}
+          placeholder="e.g. Crowdin Production"
+        />
+      </Field>
+
+      {isOAuthProvider && isOAuthConnected ? (
+        <Collapsible open={oauthReconnectOpen} onOpenChange={setOauthReconnectOpen}>
+          <CollapsibleTrigger
+            render={
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-8 w-full justify-between px-2 text-muted-foreground hover:text-foreground"
+              >
+                Reconnect with a different OAuth app
+                <ChevronDownIcon
+                  className={cn(
+                    "size-3.5 shrink-0 transition-transform",
+                    oauthReconnectOpen && "rotate-180",
+                  )}
+                  strokeWidth={2}
+                />
+              </Button>
+            }
+          />
+          <CollapsibleContent className="space-y-5 pt-3">
+            <CrowdinOAuthSetupFields
+              providerKind={providerKind}
+              providerName={providerName}
+              crowdinRedirectUri={oauthRedirectUri}
+              redirectUriFieldId={redirectUriFieldId}
+              redirectUriCopied={redirectUriCopied}
+              onCopyRedirectUri={() => {
+                void copyCrowdinRedirectUri();
+              }}
+              oauthClientIdFieldId={oauthClientIdFieldId}
+              oauthClientId={oauthClientId}
+              onOauthClientIdChange={onOauthClientIdChange}
+              oauthClientSecretFieldId={oauthClientSecretFieldId}
+              oauthClientSecret={oauthClientSecret}
+              onOauthClientSecretChange={onOauthClientSecretChange}
+              showSecret={showSecret}
+              onToggleShowSecret={onToggleShowSecret}
+            />
+          </CollapsibleContent>
+        </Collapsible>
+      ) : null}
+
+      {isOAuthProvider && showOAuthSetupFields && !isOAuthConnected ? (
+        <CrowdinOAuthSetupFields
+          providerKind={providerKind}
+          providerName={providerName}
+          crowdinRedirectUri={oauthRedirectUri}
+          redirectUriFieldId={redirectUriFieldId}
+          redirectUriCopied={redirectUriCopied}
+          onCopyRedirectUri={() => {
+            void copyCrowdinRedirectUri();
+          }}
+          oauthClientIdFieldId={oauthClientIdFieldId}
+          oauthClientId={oauthClientId}
+          onOauthClientIdChange={onOauthClientIdChange}
+          oauthClientSecretFieldId={oauthClientSecretFieldId}
+          oauthClientSecret={oauthClientSecret}
+          onOauthClientSecretChange={onOauthClientSecretChange}
+          showSecret={showSecret}
+          onToggleShowSecret={onToggleShowSecret}
+        />
+      ) : null}
+
+      {!isOAuthProvider ? (
+        <Field className="gap-2">
+          <FieldLabel htmlFor={secretFieldId}>API token / secret</FieldLabel>
+          <div className="relative">
+            <HugeiconsIcon
+              icon={Key01Icon}
+              strokeWidth={1.8}
+              className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground"
+            />
+            <Input
+              id={secretFieldId}
+              type={showSecret ? "text" : "password"}
+              autoComplete="off"
+              value={secret}
+              onChange={(event) => onSecretChange(event.target.value)}
+              placeholder="Enter provider API token"
+              className="ps-9 pe-9"
+            />
+            <button
+              type="button"
+              onClick={onToggleShowSecret}
+              className="absolute top-1/2 right-3 -translate-y-1/2 text-muted-foreground transition-colors hover:text-foreground"
+              aria-label={showSecret ? "Hide secret" : "Show secret"}
+            >
+              {showSecret ? <EyeOffIcon size={16} /> : <EyeIcon size={16} />}
+            </button>
+          </div>
+        </Field>
+      ) : null}
+
+      <Collapsible open={advancedSettingsOpen} onOpenChange={setAdvancedSettingsOpen}>
+        <CollapsibleTrigger
+          render={
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-8 w-full justify-between px-2 text-muted-foreground hover:text-foreground"
+            >
+              Advanced settings
+              <ChevronDownIcon
+                className={cn(
+                  "size-3.5 shrink-0 transition-transform",
+                  advancedSettingsOpen && "rotate-180",
+                )}
+                strokeWidth={2}
+              />
+            </Button>
+          }
+        />
+        <CollapsibleContent className="pt-1">
+          <Field className="gap-2">
+            <FieldLabel htmlFor={baseUrlFieldId}>Base URL (optional)</FieldLabel>
+            <Input
+              id={baseUrlFieldId}
+              value={baseUrl}
+              onChange={(event) => onBaseUrlChange(event.target.value)}
+              placeholder="https://api.example.com"
+            />
+          </Field>
+        </CollapsibleContent>
+      </Collapsible>
+
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        {credential && userIsAdmin ? (
+          <Button type="button" variant="outline" onClick={onDisconnect} disabled={isDisconnecting}>
+            <HugeiconsIcon icon={Delete02Icon} strokeWidth={1.8} />
+            Disconnect
+          </Button>
+        ) : (
+          <div />
+        )}
+        <Button type="submit" disabled={!canSubmit || isSaving} className="sm:ms-auto">
+          <HugeiconsIcon icon={SaveIcon} strokeWidth={1.8} />
+          {isSaving
+            ? "Saving..."
+            : isOAuthProvider
+              ? isOAuthConnected
+                ? `Update ${providerName}`
+                : `Save ${providerName}`
+              : "Save provider"}
+        </Button>
+      </div>
+    </form>
+  );
+}


### PR DESCRIPTION
## What changed

- Split the integrations page into focused component modules for Contentful setup, TMS credentials, and model provider cards.
- Changed the Contentful connection form from a free-text “Project ID” field to a workspace Project select.
- Simplified existing Contentful connection updates by hiding the token field behind “Replace token” and using the update route so users do not need to re-enter the token for ordinary edits.
- Added basic save gating for required Contentful connection fields.

## How to test

- `vp check --fix`
- `vp test` was attempted, but the suite hit the unrelated existing WorkOS replacement sentinel uniqueness failure in `member.test.ts` / `api-key.test.ts`.

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review