### PR TITLE
fix(providers): refresh LLM model catalog

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/provider-credential/provider-credential.fixture.ts
+++ b/apps/hyperlocalise-web/src/api/routes/provider-credential/provider-credential.fixture.ts
@@ -15,7 +15,7 @@ export function createProviderCredentialTestFixture(client?: Client) {
     input: UpdateProviderCredentialBody = {
       provider: "openai",
       apiKey: "sk-live-provider-key",
-      defaultModel: "gpt-4.1-mini",
+      defaultModel: "gpt-5.5",
     },
   ) {
     if (!client) {

--- a/apps/hyperlocalise-web/src/api/routes/provider-credential/provider-credential.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/provider-credential/provider-credential.test.ts
@@ -50,14 +50,14 @@ describe("providerCredentialRoutes", () => {
     const response = await fixture.upsertProviderCredentialViaApi(identity, {
       provider: "openai",
       apiKey: "sk-live-provider-key",
-      defaultModel: "gpt-4.1-mini",
+      defaultModel: "gpt-5.5",
     });
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({
       providerCredential: {
         provider: "openai",
-        defaultModel: "gpt-4.1-mini",
+        defaultModel: "gpt-5.5",
         maskedApiKeySuffix: "••••-key",
       },
     });
@@ -82,7 +82,7 @@ describe("providerCredentialRoutes", () => {
     const response = await fixture.upsertProviderCredentialViaApi(identity, {
       provider: "openai",
       apiKey: "sk-member-key",
-      defaultModel: "gpt-4.1-mini",
+      defaultModel: "gpt-5.5",
     });
 
     expect(response.status).toBe(403);
@@ -101,7 +101,7 @@ describe("providerCredentialRoutes", () => {
     const response = await fixture.upsertProviderCredentialViaApi(identity, {
       provider: "openai",
       apiKey: "sk-manager-key",
-      defaultModel: "gpt-4.1-mini",
+      defaultModel: "gpt-5.5",
     });
 
     expect(response.status).toBe(200);
@@ -112,7 +112,7 @@ describe("providerCredentialRoutes", () => {
     const response = await fixture.upsertProviderCredentialViaApi(identity, {
       provider: "openai",
       apiKey: "sk-translator-key",
-      defaultModel: "gpt-4.1-mini",
+      defaultModel: "gpt-5.5",
     });
 
     expect(response.status).toBe(403);
@@ -137,7 +137,7 @@ describe("providerCredentialRoutes", () => {
     await fixture.upsertProviderCredentialViaApi(ownerIdentity, {
       provider: "openai",
       apiKey: "sk-owner-key",
-      defaultModel: "gpt-4.1-mini",
+      defaultModel: "gpt-5.5",
     });
 
     const response = await client.api.orgs[":organizationSlug"]["provider-credential"].$get(
@@ -164,7 +164,7 @@ describe("providerCredentialRoutes", () => {
     await fixture.upsertProviderCredentialViaApi(identity, {
       provider: "openai",
       apiKey: "sk-reveal-provider-key",
-      defaultModel: "gpt-4.1-mini",
+      defaultModel: "gpt-5.5",
     });
 
     const revealResponse = await client.api.orgs[":organizationSlug"]["provider-credential"][
@@ -185,7 +185,7 @@ describe("providerCredentialRoutes", () => {
         apiKey: "sk-reveal-provider-key",
         summary: {
           provider: "openai",
-          defaultModel: "gpt-4.1-mini",
+          defaultModel: "gpt-5.5",
         },
       },
     });

--- a/apps/hyperlocalise-web/src/lib/providers/catalog.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/catalog.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { llmProviderCatalog } from "@/lib/providers/catalog";
+
+describe("llmProviderCatalog", () => {
+  it("uses Anthropic native model IDs for BYOK validation", () => {
+    expect(llmProviderCatalog.anthropic.models).toEqual([
+      "claude-sonnet-4-6",
+      "claude-opus-4-8",
+      "claude-opus-4-7",
+      "claude-opus-4-6",
+      "claude-haiku-4-5",
+      "claude-sonnet-4-5",
+      "claude-opus-4-5",
+    ]);
+
+    expect(llmProviderCatalog.anthropic.models).not.toContain("claude-sonnet-4.6");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/catalog.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/catalog.ts
@@ -20,13 +20,13 @@ export const llmProviderCatalog = {
   anthropic: {
     label: "Anthropic",
     models: [
-      "claude-sonnet-4.6",
-      "claude-opus-4.8",
-      "claude-opus-4.7",
-      "claude-opus-4.6",
-      "claude-haiku-4.5",
-      "claude-sonnet-4.5",
-      "claude-opus-4.5",
+      "claude-sonnet-4-6",
+      "claude-opus-4-8",
+      "claude-opus-4-7",
+      "claude-opus-4-6",
+      "claude-haiku-4-5",
+      "claude-sonnet-4-5",
+      "claude-opus-4-5",
     ],
   },
   gemini: {

--- a/apps/hyperlocalise-web/src/lib/providers/catalog.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/catalog.ts
@@ -15,15 +15,32 @@ export const llmProviderSchema = z.enum(curatedLlmProviders);
 export const llmProviderCatalog = {
   openai: {
     label: "OpenAI",
-    models: ["gpt-4.1-mini", "gpt-4.1", "gpt-4o-mini"],
+    models: ["gpt-5.5", "gpt-5.5-pro", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"],
   },
   anthropic: {
     label: "Anthropic",
-    models: ["claude-3-5-haiku-20241022", "claude-3-7-sonnet-20250219"],
+    models: [
+      "claude-sonnet-4.6",
+      "claude-opus-4.8",
+      "claude-opus-4.7",
+      "claude-opus-4.6",
+      "claude-haiku-4.5",
+      "claude-sonnet-4.5",
+      "claude-opus-4.5",
+    ],
   },
   gemini: {
     label: "Gemini",
-    models: ["gemini-2.0-flash", "gemini-2.5-flash-preview-04-17"],
+    models: [
+      "gemini-3.5-flash",
+      "gemini-3.1-pro-preview",
+      "gemini-3.1-flash-lite",
+      "gemini-3-flash",
+      "gemini-3-pro-preview",
+      "gemini-2.5-pro",
+      "gemini-2.5-flash",
+      "gemini-2.5-flash-lite",
+    ],
   },
   groq: {
     label: "Groq",

--- a/apps/hyperlocalise-web/src/lib/providers/provider-job-qa/materialize-hl-check-workspace.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-job-qa/materialize-hl-check-workspace.ts
@@ -85,7 +85,7 @@ function buildCheckConfigContent(
   "locales": {"source":${JSON.stringify(sourceLocale)},"targets":[${quotedLocales.join(",")}]},
   "buckets": {"provider":{"files":[{"from":${JSON.stringify(sourcePath)},"to":${JSON.stringify(targetPathTemplate)}}]}},
   "groups": {"default":{"targets":[${quotedLocales.join(",")}],"buckets":["provider"]}},
-  "llm": {"profiles":{"default":{"provider":"openai","model":"gpt-4.1-mini","prompt":"Translate {{input}}"}}}
+  "llm": {"profiles":{"default":{"provider":"openai","model":"gpt-5.4-mini","prompt":"Translate {{input}}"}}}
 }`;
 }
 


### PR DESCRIPTION
## What changed

- Refresh the BYOK LLM provider model catalog with current OpenAI, Anthropic, and Gemini model IDs from Vercel AI Gateway.
- Update provider credential fixtures/tests to use `gpt-5.5` as the OpenAI default.
- Update generated provider QA config to use `gpt-5.4-mini` instead of the old `gpt-4.1-mini` default.

## How to test

- `vp test src/api/routes/provider-credential/provider-credential.test.ts src/lib/providers/validation.test.ts`
- `vp check --fix`

Note: full `vp test` was attempted but is blocked by local DB drift: the test database is missing the `knowledge_memories` table, and `vp run db:migrate` exited non-zero while applying migrations.

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review