### PR TITLE
fix(web): improve agent-slack channels error handling

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/agent-slack/agent-slack.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/agent-slack/agent-slack.route.test.ts
@@ -2,7 +2,7 @@ import "dotenv/config";
 
 import { and, eq } from "drizzle-orm";
 import { testClient } from "hono/testing";
-import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { app } from "@/api/app";
 import { createProjectTestFixture } from "@/api/routes/project/project.fixture";
@@ -21,7 +21,7 @@ const mocks = vi.hoisted(() => ({
   initializeMock: vi.fn().mockResolvedValue(undefined),
   getAdapterMock: vi.fn(),
   getInstallationMock: vi.fn().mockResolvedValue({ botToken: "xoxb-token" }),
-  providerSafeFetchMock: vi.fn(),
+  fetchMock: vi.fn(),
 }));
 
 vi.mock("@/lib/agents/slack/bot", () => ({
@@ -40,10 +40,6 @@ vi.mock("@/api/auth/workos-session", async (importOriginal) => {
     resolveApiAuthContextFromSession: mocks.resolveApiAuthContextFromSessionMock,
   };
 });
-
-vi.mock("@/lib/providers/provider-safe-fetch", () => ({
-  providerSafeFetch: mocks.providerSafeFetchMock,
-}));
 
 const client = testClient(app);
 const fixture = createProjectTestFixture(client);
@@ -78,6 +74,10 @@ async function createStoredSlackConnector(input: {
 describe("agentSlackRoutes", () => {
   beforeAll(async () => {
     await db.$client.query("select 1");
+  });
+
+  beforeEach(() => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(mocks.fetchMock);
   });
 
   afterEach(async () => {
@@ -158,7 +158,7 @@ describe("agentSlackRoutes", () => {
       teamName: "My Team",
     });
 
-    mocks.providerSafeFetchMock.mockResolvedValue({
+    mocks.fetchMock.mockResolvedValue({
       ok: true,
       json: vi.fn().mockResolvedValue({
         ok: true,
@@ -186,7 +186,7 @@ describe("agentSlackRoutes", () => {
       ],
     });
     expect(mocks.getInstallationMock).toHaveBeenCalledWith("T123");
-    expect(mocks.providerSafeFetchMock).toHaveBeenCalledWith(
+    expect(mocks.fetchMock).toHaveBeenCalledWith(
       expect.objectContaining({
         href: expect.stringContaining("https://slack.com/api/conversations.list"),
       }),

--- a/apps/hyperlocalise-web/src/api/routes/agent-slack/agent-slack.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/agent-slack/agent-slack.route.test.ts
@@ -22,6 +22,14 @@ const mocks = vi.hoisted(() => ({
   getAdapterMock: vi.fn(),
   getInstallationMock: vi.fn().mockResolvedValue({ botToken: "xoxb-token" }),
   fetchMock: vi.fn(),
+  loggerErrorMock: vi.fn(),
+}));
+
+vi.mock("@/lib/log", () => ({
+  createLogger: vi.fn(() => ({
+    error: mocks.loggerErrorMock,
+  })),
+  serializeErrorForLog: (error: unknown) => error,
 }));
 
 vi.mock("@/lib/agents/slack/bot", () => ({
@@ -71,17 +79,55 @@ async function createStoredSlackConnector(input: {
   return connector;
 }
 
+function restoreDefaultMocks() {
+  mocks.resolveApiAuthContextFromSessionMock.mockImplementation(
+    (options) =>
+      globalThis.__resolveTestApiAuthContextFromSession?.(options) ??
+      globalThis.__testApiAuthContext ??
+      null,
+  );
+  mocks.initializeMock.mockResolvedValue(undefined);
+  mocks.getInstallationMock.mockResolvedValue({ botToken: "xoxb-token" });
+  mocks.getAdapterMock.mockReturnValue({
+    getInstallation: mocks.getInstallationMock,
+  });
+  mocks.getSlackBotMock.mockResolvedValue({
+    initialize: mocks.initializeMock,
+    getAdapter: mocks.getAdapterMock,
+  });
+}
+
+async function setupEnabledSlackConnector() {
+  const identity = fixture.createWorkosIdentityWithRole("admin");
+  const organizationSlug = identity.organization.slug ?? "missing-slug";
+  const headers = await fixture.authHeadersFor(identity);
+  const auth = globalThis.__testApiAuthContext;
+  if (!auth) {
+    throw new Error("missing auth context");
+  }
+
+  await createStoredSlackConnector({
+    organizationId: auth.organization.localOrganizationId,
+    enabled: true,
+    teamId: "T123",
+    teamName: "My Team",
+  });
+
+  return { organizationSlug, headers, auth };
+}
+
 describe("agentSlackRoutes", () => {
   beforeAll(async () => {
     await db.$client.query("select 1");
   });
 
   beforeEach(() => {
+    restoreDefaultMocks();
     vi.spyOn(globalThis, "fetch").mockImplementation(mocks.fetchMock);
   });
 
   afterEach(async () => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     vi.unstubAllGlobals();
     await fixture.cleanup();
   });
@@ -143,20 +189,7 @@ describe("agentSlackRoutes", () => {
   });
 
   it("lists Slack channels for an enabled connector", async () => {
-    const identity = fixture.createWorkosIdentityWithRole("admin");
-    const organizationSlug = identity.organization.slug ?? "missing-slug";
-    const headers = await fixture.authHeadersFor(identity);
-    const auth = globalThis.__testApiAuthContext;
-    if (!auth) {
-      throw new Error("missing auth context");
-    }
-
-    await createStoredSlackConnector({
-      organizationId: auth.organization.localOrganizationId,
-      enabled: true,
-      teamId: "T123",
-      teamName: "My Team",
-    });
+    const { organizationSlug, headers } = await setupEnabledSlackConnector();
 
     mocks.fetchMock.mockResolvedValue({
       ok: true,
@@ -193,6 +226,100 @@ describe("agentSlackRoutes", () => {
       expect.objectContaining({
         headers: { authorization: "Bearer xoxb-token" },
       }),
+    );
+  });
+
+  it("returns 404 when the Slack installation is missing", async () => {
+    const { organizationSlug, headers } = await setupEnabledSlackConnector();
+    mocks.getInstallationMock.mockResolvedValue(null);
+
+    const response = await client.api.orgs[":organizationSlug"]["agent-slack"].channels.$get(
+      {
+        param: { organizationSlug },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: "slack_installation_not_found" });
+    expect(mocks.loggerErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 502 when Slack responds with a non-2xx status", async () => {
+    const { organizationSlug, headers, auth } = await setupEnabledSlackConnector();
+    mocks.fetchMock.mockResolvedValue({
+      ok: false,
+      status: 503,
+    } as Response);
+
+    const response = await client.api.orgs[":organizationSlug"]["agent-slack"].channels.$get(
+      {
+        param: { organizationSlug },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual({ error: "slack_channels_unavailable" });
+    expect(mocks.loggerErrorMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        errorCode: "slack_http_error",
+        status: 503,
+        organizationId: auth.organization.localOrganizationId,
+        teamId: "T123",
+      }),
+      "slack channel list failed",
+    );
+  });
+
+  it("returns 502 when Slack returns an API error", async () => {
+    const { organizationSlug, headers, auth } = await setupEnabledSlackConnector();
+    mocks.fetchMock.mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ ok: false, error: "invalid_auth" }),
+    } as unknown as Response);
+
+    const response = await client.api.orgs[":organizationSlug"]["agent-slack"].channels.$get(
+      {
+        param: { organizationSlug },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual({ error: "slack_channels_unavailable" });
+    expect(mocks.loggerErrorMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        errorCode: "slack_api_error",
+        slackError: "invalid_auth",
+        organizationId: auth.organization.localOrganizationId,
+        teamId: "T123",
+      }),
+      "slack channel list failed",
+    );
+  });
+
+  it("returns 502 when the Slack bot is unavailable", async () => {
+    const { organizationSlug, headers, auth } = await setupEnabledSlackConnector();
+    mocks.fetchMock.mockRejectedValue(new Error("network unavailable"));
+
+    const response = await client.api.orgs[":organizationSlug"]["agent-slack"].channels.$get(
+      {
+        param: { organizationSlug },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual({ error: "slack_channels_unavailable" });
+    expect(mocks.loggerErrorMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        errorCode: "bot_unavailable",
+        err: expect.any(Error),
+        organizationId: auth.organization.localOrganizationId,
+        teamId: "T123",
+      }),
+      "slack channel list failed",
     );
   });
 

--- a/apps/hyperlocalise-web/src/api/routes/agent-slack/agent-slack.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/agent-slack/agent-slack.route.ts
@@ -16,7 +16,8 @@ import {
 } from "@/lib/agents/slack/oauth-state";
 import { db, schema } from "@/lib/database";
 import { env } from "@/lib/env";
-import { providerSafeFetch } from "@/lib/providers/provider-safe-fetch";
+import { createLogger, serializeErrorForLog } from "@/lib/log";
+import { err, fromThrowableAsync, isErr, ok, type Result } from "@/lib/primitives/result/results";
 import { assertProviderCredentialAdmin } from "@/lib/providers/organization-provider-credentials";
 
 import { updateSlackAgentBodySchema } from "./agent-slack.schema";
@@ -30,6 +31,15 @@ type SlackConversationsListResponse = {
   channels?: SlackChannel[];
   response_metadata?: { next_cursor?: string };
 };
+
+type SlackChannelListItem = { id: string; name: string; private: boolean };
+type SlackChannelListError =
+  | { code: "installation_not_found" }
+  | { code: "bot_unavailable"; cause: unknown }
+  | { code: "slack_http_error"; status: number }
+  | { code: "slack_api_error"; slackError: string };
+
+const logger = createLogger("agent-slack");
 
 const validateUpdateSlackAgentBody = validator("json", (value, c) => {
   const parsed = updateSlackAgentBodySchema.safeParse(value);
@@ -59,18 +69,36 @@ async function getSlackConnector(organizationId: string) {
   return connector ?? null;
 }
 
-async function getSlackInstallation(teamId: string): Promise<SlackInstallation | null> {
-  const bot = await getSlackBot();
-  await bot.initialize();
-  const adapter = bot.getAdapter("slack") as {
-    getInstallation: (teamId: string) => Promise<SlackInstallation | null>;
-  };
+async function getSlackInstallation(
+  teamId: string,
+): Promise<Result<SlackInstallation, SlackChannelListError>> {
+  const installationResult = await fromThrowableAsync(
+    (async () => {
+      const bot = await getSlackBot();
+      await bot.initialize();
+      const adapter = bot.getAdapter("slack") as {
+        getInstallation: (teamId: string) => Promise<SlackInstallation | null>;
+      };
 
-  return adapter.getInstallation(teamId);
+      return adapter.getInstallation(teamId);
+    })(),
+  );
+
+  if (isErr(installationResult)) {
+    return err({ code: "bot_unavailable", cause: installationResult.error });
+  }
+
+  if (!installationResult.value?.botToken) {
+    return err({ code: "installation_not_found" });
+  }
+
+  return ok(installationResult.value);
 }
 
-async function listSlackChannels(botToken: string) {
-  const channels: Array<{ id: string; name: string; private: boolean }> = [];
+async function listSlackChannels(
+  botToken: string,
+): Promise<Result<SlackChannelListItem[], SlackChannelListError>> {
+  const channels: SlackChannelListItem[] = [];
   let cursor = "";
 
   do {
@@ -82,17 +110,31 @@ async function listSlackChannels(botToken: string) {
       url.searchParams.set("cursor", cursor);
     }
 
-    // Use providerSafeFetch to prevent SSRF when calling Slack API
-    const response = await providerSafeFetch(url, {
-      headers: { authorization: `Bearer ${botToken}` },
-    });
-    if (!response.ok) {
-      throw new Error("Slack channel list request failed");
+    const responseResult = await fromThrowableAsync(
+      fetch(url, {
+        headers: { authorization: `Bearer ${botToken}` },
+        redirect: "error",
+      }),
+    );
+    if (isErr(responseResult)) {
+      return err({ code: "bot_unavailable", cause: responseResult.error });
     }
 
-    const body = (await response.json()) as SlackConversationsListResponse;
+    const response = responseResult.value;
+    if (!response.ok) {
+      return err({ code: "slack_http_error", status: response.status });
+    }
+
+    const bodyResult = await fromThrowableAsync(
+      response.json() as Promise<SlackConversationsListResponse>,
+    );
+    if (isErr(bodyResult)) {
+      return err({ code: "bot_unavailable", cause: bodyResult.error });
+    }
+
+    const body = bodyResult.value;
     if (!body.ok) {
-      throw new Error(body.error ?? "Slack channel list request failed");
+      return err({ code: "slack_api_error", slackError: body.error ?? "unknown" });
     }
 
     for (const channel of body.channels ?? []) {
@@ -109,7 +151,31 @@ async function listSlackChannels(botToken: string) {
     cursor = body.response_metadata?.next_cursor ?? "";
   } while (cursor);
 
-  return channels.sort((left, right) => left.name.localeCompare(right.name));
+  return ok(channels.sort((left, right) => left.name.localeCompare(right.name)));
+}
+
+async function loadSlackChannelsForTeam(
+  teamId: string,
+): Promise<Result<SlackChannelListItem[], SlackChannelListError>> {
+  const installationResult = await getSlackInstallation(teamId);
+  if (isErr(installationResult)) {
+    return installationResult;
+  }
+
+  return listSlackChannels(installationResult.value.botToken);
+}
+
+function slackChannelListErrorLogFields(error: SlackChannelListError) {
+  switch (error.code) {
+    case "installation_not_found":
+      return {};
+    case "slack_api_error":
+      return { slackError: error.slackError };
+    case "slack_http_error":
+      return { status: error.status };
+    case "bot_unavailable":
+      return { err: serializeErrorForLog(error.cause) };
+  }
 }
 
 export function createAgentSlackRoutes() {
@@ -147,17 +213,25 @@ export function createAgentSlackRoutes() {
         return c.json({ channels: [] }, 200);
       }
 
-      try {
-        const installation = await getSlackInstallation(config.teamId);
-        if (!installation?.botToken) {
+      const channelsResult = await loadSlackChannelsForTeam(config.teamId);
+      if (isErr(channelsResult)) {
+        if (channelsResult.error.code === "installation_not_found") {
           return c.json({ error: "slack_installation_not_found" as const }, 404);
         }
 
-        const channels = await listSlackChannels(installation.botToken);
-        return c.json({ channels }, 200);
-      } catch {
+        logger.error(
+          {
+            ...slackChannelListErrorLogFields(channelsResult.error),
+            organizationId: c.var.auth.organization.localOrganizationId,
+            teamId: config.teamId,
+            errorCode: channelsResult.error.code,
+          },
+          "slack channel list failed",
+        );
         return c.json({ error: "slack_channels_unavailable" as const }, 502);
       }
+
+      return c.json({ channels: channelsResult.value }, 200);
     })
     .get("/install-url", async (c) => {
       try {


### PR DESCRIPTION
## What changed

The `GET /agent-slack/channels` endpoint was returning opaque 502s with no server logs when Slack channel listing failed. This change:

- Replaces `providerSafeFetch` with plain `fetch` for the hardcoded Slack `conversations.list` call
- Refactors channel loading to use `Result` types with discriminated errors (`installation_not_found`, `slack_api_error`, `slack_http_error`, `bot_unavailable`)
- Adds structured error logging with `errorCode` and Slack-specific fields before returning `slack_channels_unavailable`

## How to test

- `cd apps/hyperlocalise-web && vp test src/api/routes/agent-slack/agent-slack.route.test.ts`
- `cd apps/hyperlocalise-web && vp check --fix src/api/routes/agent-slack/`
- With Slack connected, call `GET /api/orgs/:slug/agent-slack/channels` and confirm channels load; on failure, confirm logs include `agent-slack` / `slack channel list failed` with `errorCode` and `slackError` when applicable

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)