### PR TITLE
feat(web): simplify Contentful connection setup UX

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/contentful-connection/contentful-connection.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/contentful-connection/contentful-connection.route.ts
@@ -8,6 +8,7 @@ import { isErr } from "@/lib/primitives/result/results";
 import {
   createContentfulConnection,
   deleteContentfulConnection,
+  discoverContentfulSpace,
   getContentfulConnection,
   listContentfulConnections,
   updateContentfulConnection,
@@ -17,6 +18,7 @@ import {
 import {
   contentfulConnectionIdParamSchema,
   createContentfulConnectionBodySchema,
+  discoverContentfulSpaceBodySchema,
   updateContentfulConnectionBodySchema,
 } from "./contentful-connection.schema";
 
@@ -54,6 +56,19 @@ const validateUpdateBody = validator("json", (value, c) => {
   return parsed.data;
 });
 
+const validateDiscoverBody = validator("json", (value, c) => {
+  const parsed = discoverContentfulSpaceBodySchema.safeParse(value);
+  if (!parsed.success) {
+    return badRequestResponse(
+      c,
+      "invalid_contentful_discovery_payload",
+      "Contentful discovery payload is invalid.",
+      parsed.error.flatten(),
+    );
+  }
+  return parsed.data;
+});
+
 function canReadContentful(role: AuthVariables["auth"]["membership"]["role"]) {
   return hasCapability(role, "integrations:read");
 }
@@ -82,6 +97,26 @@ export function createContentfulConnectionRoutes() {
       });
 
       return c.json({ contentfulConnections }, 200);
+    })
+    .post("/discover", validateDiscoverBody, async (c) => {
+      if (!canReadContentful(c.var.auth.membership.role)) {
+        return forbiddenResponse(c);
+      }
+
+      const payload = c.req.valid("json");
+      const result = await discoverContentfulSpace({
+        organizationId: c.var.auth.organization.localOrganizationId,
+        spaceId: payload.spaceId,
+        environmentId: payload.environmentId,
+        accessToken: payload.accessToken,
+        connectionId: payload.connectionId,
+      });
+
+      if (isErr(result)) {
+        return badRequestResponse(c, result.error.code, result.error.message);
+      }
+
+      return c.json({ contentfulSpaceDiscovery: result.value }, 200);
     })
     .post("/", validateCreateBody, async (c) => {
       if (!canWriteContentful(c.var.auth.membership.role)) {

--- a/apps/hyperlocalise-web/src/api/routes/contentful-connection/contentful-connection.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/contentful-connection/contentful-connection.schema.ts
@@ -43,3 +43,20 @@ export const updateContentfulConnectionBodySchema = z.object({
   accessToken: z.string().trim().min(1).max(4096).optional(),
   enabled: z.boolean().optional(),
 });
+
+export const discoverContentfulSpaceBodySchema = z
+  .object({
+    spaceId: z.string().trim().min(1).max(128),
+    environmentId: z.string().trim().min(1).max(128).default("master"),
+    accessToken: z.string().trim().min(1).max(4096).optional(),
+    connectionId: z.string().uuid().optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (!value.accessToken && !value.connectionId) {
+      ctx.addIssue({
+        code: "custom",
+        message: "accessToken or connectionId is required",
+        path: ["accessToken"],
+      });
+    }
+  });

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/contentful-connection-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/contentful-connection-panel.tsx
@@ -142,7 +142,7 @@ function useDiscoverContentfulSpace(input: {
       trimmedSpaceId,
       trimmedEnvironmentId,
       input.connectionId ?? null,
-      trimmedAccessToken ? "token" : "stored",
+      trimmedAccessToken || "stored",
     ],
     enabled: canDiscover,
     queryFn: async () => {
@@ -293,6 +293,7 @@ function ContentTypePicker({
   disabled,
   isLoading,
   loadError,
+  labelledBy,
   selectedIds,
   onChange,
   requiresCredentials,
@@ -301,11 +302,11 @@ function ContentTypePicker({
   disabled: boolean;
   isLoading: boolean;
   loadError: string | null;
+  labelledBy: string;
   selectedIds: string[];
   onChange: (contentTypeIds: string[]) => void;
   requiresCredentials: boolean;
 }) {
-  const fieldId = useId();
   const selected = useMemo(() => new Set(selectedIds), [selectedIds]);
 
   function toggleContentType(contentTypeId: string) {
@@ -337,7 +338,7 @@ function ContentTypePicker({
   }
 
   return (
-    <div className="flex flex-wrap gap-1.5" role="group" aria-labelledby={fieldId}>
+    <div className="flex flex-wrap gap-1.5" role="group" aria-labelledby={labelledBy}>
       {contentTypes.map((contentType) => {
         const isSelected = selected.has(contentType.id);
         return (
@@ -381,6 +382,7 @@ export function ContentfulConnectionPanel({
   isLoadingProjects: boolean;
   organizationSlug: string;
 }) {
+  const contentTypesFieldId = useId();
   const [isReplacingToken, setIsReplacingToken] = useState(false);
   const selectedProject = projects.find((project) => project.id === form.projectId);
   const projectLabel =
@@ -544,12 +546,13 @@ export function ContentfulConnectionPanel({
           </Field>
         )}
         <Field className="gap-2 lg:col-span-2">
-          <FieldLabel>Content types</FieldLabel>
+          <FieldLabel id={contentTypesFieldId}>Content types</FieldLabel>
           <ContentTypePicker
             contentTypes={discoveredContentTypes}
             disabled={disabled}
             isLoading={discoveryQuery.isFetching}
             loadError={discoveryQuery.error?.message ?? null}
+            labelledBy={contentTypesFieldId}
             selectedIds={form.contentTypeIds}
             onChange={(contentTypeIds) => onFormChange({ ...form, contentTypeIds })}
             requiresCredentials={!canDiscoverContentTypes}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/contentful-connection-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/contentful-connection-panel.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useId, useMemo, useState } from "react";
 import { SaveIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
 import { createApiClient } from "@/lib/api-client";
+import { getLocaleLabel } from "@/lib/i18n/locales";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Field, FieldLabel } from "@/components/ui/field";
@@ -41,6 +42,8 @@ export type ContentfulConnectionSummary = {
 export type ProjectOption = {
   id: string;
   name: string;
+  sourceLocale: string | null;
+  targetLocales: string[];
 };
 
 export type ContentfulConnectionForm = {
@@ -48,10 +51,13 @@ export type ContentfulConnectionForm = {
   projectId: string;
   spaceId: string;
   environmentId: string;
-  sourceLocale: string;
-  targetLocales: string;
-  contentTypeIds: string;
+  contentTypeIds: string[];
   accessToken: string;
+};
+
+type ContentfulContentTypeOption = {
+  id: string;
+  name: string;
 };
 
 type SaveContentfulConnectionPayloadBase = {
@@ -105,7 +111,64 @@ export function useProjectOptions(organizationSlug: string, enabled = true) {
       return data.projects.map((project) => ({
         id: project.id,
         name: project.name,
+        sourceLocale: project.sourceLocale ?? null,
+        targetLocales: project.targetLocales ?? [],
       })) as ProjectOption[];
+    },
+  });
+}
+
+function useDiscoverContentfulSpace(input: {
+  organizationSlug: string;
+  spaceId: string;
+  environmentId: string;
+  accessToken: string;
+  connectionId?: string;
+  enabled: boolean;
+}) {
+  const trimmedSpaceId = input.spaceId.trim();
+  const trimmedEnvironmentId = input.environmentId.trim() || "master";
+  const trimmedAccessToken = input.accessToken.trim();
+  const canDiscover =
+    input.enabled &&
+    trimmedSpaceId.length > 0 &&
+    trimmedEnvironmentId.length > 0 &&
+    (trimmedAccessToken.length > 0 || Boolean(input.connectionId));
+
+  return useQuery({
+    queryKey: [
+      "contentful-space-discovery",
+      input.organizationSlug,
+      trimmedSpaceId,
+      trimmedEnvironmentId,
+      input.connectionId ?? null,
+      trimmedAccessToken ? "token" : "stored",
+    ],
+    enabled: canDiscover,
+    queryFn: async () => {
+      const res = await api.api.orgs[":organizationSlug"]["contentful-connections"].discover.$post({
+        param: { organizationSlug: input.organizationSlug },
+        json: {
+          spaceId: trimmedSpaceId,
+          environmentId: trimmedEnvironmentId,
+          ...(trimmedAccessToken ? { accessToken: trimmedAccessToken } : {}),
+          ...(input.connectionId ? { connectionId: input.connectionId } : {}),
+        },
+      });
+      if (!res.ok) {
+        const error = await res
+          .json()
+          .catch(() => ({ message: "Unable to load Contentful metadata" }));
+        throw new Error(
+          "message" in error ? String(error.message) : "Unable to load Contentful metadata",
+        );
+      }
+      const data = await res.json();
+      return data.contentfulSpaceDiscovery as {
+        environmentId: string;
+        locales: Array<{ code: string; name: string; default: boolean }>;
+        contentTypes: ContentfulContentTypeOption[];
+      };
     },
   });
 }
@@ -188,6 +251,113 @@ export function useSaveContentfulConnection(organizationSlug: string) {
   });
 }
 
+function ProjectLocalesSummary({ project }: { project: ProjectOption | undefined }) {
+  if (!project) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Select a Hyperlocalise project to use its source and target locales.
+      </p>
+    );
+  }
+
+  if (!project.sourceLocale || project.targetLocales.length === 0) {
+    return (
+      <p className="text-sm text-destructive">
+        This project does not have locales configured yet. Set them in project settings before
+        connecting Contentful.
+      </p>
+    );
+  }
+
+  return (
+    <div className="grid gap-2 rounded-lg bg-muted/50 p-3 text-sm">
+      <div>
+        <span className="text-muted-foreground">Source: </span>
+        <span>
+          {getLocaleLabel(project.sourceLocale)} ({project.sourceLocale})
+        </span>
+      </div>
+      <div>
+        <span className="text-muted-foreground">Targets: </span>
+        <span>{project.targetLocales.join(", ")}</span>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Locales come from the selected Hyperlocalise project.
+      </p>
+    </div>
+  );
+}
+
+function ContentTypePicker({
+  contentTypes,
+  disabled,
+  isLoading,
+  loadError,
+  selectedIds,
+  onChange,
+  requiresCredentials,
+}: {
+  contentTypes: ContentfulContentTypeOption[];
+  disabled: boolean;
+  isLoading: boolean;
+  loadError: string | null;
+  selectedIds: string[];
+  onChange: (contentTypeIds: string[]) => void;
+  requiresCredentials: boolean;
+}) {
+  const fieldId = useId();
+  const selected = useMemo(() => new Set(selectedIds), [selectedIds]);
+
+  function toggleContentType(contentTypeId: string) {
+    if (selected.has(contentTypeId)) {
+      onChange(selectedIds.filter((id) => id !== contentTypeId));
+      return;
+    }
+    onChange([...selectedIds, contentTypeId].toSorted());
+  }
+
+  if (requiresCredentials) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Enter your Space ID and Management API token to load content types from Contentful.
+      </p>
+    );
+  }
+
+  if (isLoading) {
+    return <p className="text-sm text-muted-foreground">Loading content types...</p>;
+  }
+
+  if (loadError) {
+    return <p className="text-sm text-destructive">{loadError}</p>;
+  }
+
+  if (contentTypes.length === 0) {
+    return <p className="text-sm text-muted-foreground">No content types found in this space.</p>;
+  }
+
+  return (
+    <div className="flex flex-wrap gap-1.5" role="group" aria-labelledby={fieldId}>
+      {contentTypes.map((contentType) => {
+        const isSelected = selected.has(contentType.id);
+        return (
+          <Button
+            key={contentType.id}
+            type="button"
+            size="sm"
+            variant={isSelected ? "default" : "outline"}
+            disabled={disabled}
+            onClick={() => toggleContentType(contentType.id)}
+            className="h-7 px-2.5 text-xs"
+          >
+            {contentType.name}
+          </Button>
+        );
+      })}
+    </div>
+  );
+}
+
 export function ContentfulConnectionPanel({
   connection,
   disabled,
@@ -198,6 +368,7 @@ export function ContentfulConnectionPanel({
   onFormChange,
   projects,
   isLoadingProjects,
+  organizationSlug,
 }: {
   connection?: ContentfulConnectionSummary;
   disabled: boolean;
@@ -208,33 +379,56 @@ export function ContentfulConnectionPanel({
   onFormChange: (form: ContentfulConnectionForm) => void;
   projects: ProjectOption[];
   isLoadingProjects: boolean;
+  organizationSlug: string;
 }) {
   const [isReplacingToken, setIsReplacingToken] = useState(false);
   const selectedProject = projects.find((project) => project.id === form.projectId);
   const projectLabel =
     selectedProject?.name ?? (form.projectId ? "Unknown project" : "Select project");
-  const targetLocales = form.targetLocales
-    .split(",")
-    .map((value) => value.trim())
-    .filter(Boolean);
-  const contentTypeIds = form.contentTypeIds
-    .split(",")
-    .map((value) => value.trim())
-    .filter(Boolean);
+  const projectLocalesReady = Boolean(
+    selectedProject?.sourceLocale && selectedProject.targetLocales.length > 0,
+  );
   const tokenRequired = !connection || isReplacingToken;
+  const canDiscoverContentTypes =
+    form.spaceId.trim().length > 0 &&
+    (form.accessToken.trim().length > 0 || Boolean(connection?.id));
+  const discoveryQuery = useDiscoverContentfulSpace({
+    organizationSlug,
+    spaceId: form.spaceId,
+    environmentId: form.environmentId,
+    accessToken: form.accessToken,
+    connectionId: connection?.id,
+    enabled: canDiscoverContentTypes,
+  });
+  const discoveredContentTypes = discoveryQuery.data?.contentTypes ?? [];
   const canSaveContentfulConnection =
     form.displayName.trim().length > 0 &&
     form.projectId.trim().length > 0 &&
+    projectLocalesReady &&
     form.spaceId.trim().length > 0 &&
     form.environmentId.trim().length > 0 &&
-    form.sourceLocale.trim().length > 0 &&
-    targetLocales.length > 0 &&
-    contentTypeIds.length > 0 &&
+    form.contentTypeIds.length > 0 &&
     (!tokenRequired || form.accessToken.trim().length > 0);
 
   useEffect(() => {
     setIsReplacingToken(false);
   }, [connection?.id]);
+
+  useEffect(() => {
+    if (!discoveryQuery.data || form.contentTypeIds.length === 0) {
+      return;
+    }
+
+    const availableIds = new Set(
+      discoveryQuery.data.contentTypes.map((contentType) => contentType.id),
+    );
+    const nextIds = form.contentTypeIds.filter((id) => availableIds.has(id));
+    if (nextIds.length !== form.contentTypeIds.length) {
+      onFormChange({ ...form, contentTypeIds: nextIds });
+    }
+    // Prune stale selections only when Contentful metadata is refreshed.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional: avoid loops on selection changes
+  }, [discoveryQuery.data]);
 
   return (
     <div className="flex flex-col gap-5">
@@ -288,6 +482,10 @@ export function ContentfulConnectionPanel({
             </SelectContent>
           </Select>
         </Field>
+        <Field className="gap-2 lg:col-span-2">
+          <FieldLabel>Project locales</FieldLabel>
+          <ProjectLocalesSummary project={selectedProject} />
+        </Field>
         <Field className="gap-2">
           <FieldLabel>Space ID</FieldLabel>
           <Input
@@ -305,35 +503,8 @@ export function ContentfulConnectionPanel({
             onChange={(event) => onFormChange({ ...form, environmentId: event.target.value })}
           />
         </Field>
-        <Field className="gap-2">
-          <FieldLabel>Source locale</FieldLabel>
-          <Input
-            value={form.sourceLocale}
-            disabled={disabled}
-            placeholder="en-US"
-            onChange={(event) => onFormChange({ ...form, sourceLocale: event.target.value })}
-          />
-        </Field>
-        <Field className="gap-2">
-          <FieldLabel>Target locales</FieldLabel>
-          <Input
-            value={form.targetLocales}
-            disabled={disabled}
-            placeholder="fr-FR, de-DE"
-            onChange={(event) => onFormChange({ ...form, targetLocales: event.target.value })}
-          />
-        </Field>
-        <Field className="gap-2">
-          <FieldLabel>Content type IDs</FieldLabel>
-          <Input
-            value={form.contentTypeIds}
-            disabled={disabled}
-            placeholder="helpCenterArticle"
-            onChange={(event) => onFormChange({ ...form, contentTypeIds: event.target.value })}
-          />
-        </Field>
         {!connection || isReplacingToken ? (
-          <Field className="gap-2">
+          <Field className="gap-2 lg:col-span-2">
             <FieldLabel>Management API token</FieldLabel>
             <div className="flex gap-2">
               <Input
@@ -359,7 +530,7 @@ export function ContentfulConnectionPanel({
             </div>
           </Field>
         ) : (
-          <Field className="gap-2">
+          <Field className="gap-2 lg:col-span-2">
             <FieldLabel>Management API token</FieldLabel>
             <Button
               type="button"
@@ -372,6 +543,18 @@ export function ContentfulConnectionPanel({
             </Button>
           </Field>
         )}
+        <Field className="gap-2 lg:col-span-2">
+          <FieldLabel>Content types</FieldLabel>
+          <ContentTypePicker
+            contentTypes={discoveredContentTypes}
+            disabled={disabled}
+            isLoading={discoveryQuery.isFetching}
+            loadError={discoveryQuery.error?.message ?? null}
+            selectedIds={form.contentTypeIds}
+            onChange={(contentTypeIds) => onFormChange({ ...form, contentTypeIds })}
+            requiresCredentials={!canDiscoverContentTypes}
+          />
+        </Field>
       </div>
 
       {connection?.webhook ? (
@@ -422,4 +605,15 @@ export function ContentfulConnectionPanel({
       </div>
     </div>
   );
+}
+
+export function getProjectLocales(project: ProjectOption | undefined) {
+  if (!project?.sourceLocale || project.targetLocales.length === 0) {
+    return null;
+  }
+
+  return {
+    sourceLocale: project.sourceLocale,
+    targetLocales: project.targetLocales,
+  };
 }

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-page-content.tsx
@@ -63,6 +63,7 @@ import {
   ContentfulConnectionPanel,
   type ContentfulConnectionForm,
   type ContentfulConnectionSummary,
+  getProjectLocales,
   useContentfulConnections,
   useProjectOptions,
   useSaveContentfulConnection,
@@ -849,9 +850,7 @@ export function IntegrationsPageContent({
     projectId: "",
     spaceId: "",
     environmentId: "master",
-    sourceLocale: "en-US",
-    targetLocales: "",
-    contentTypeIds: "helpCenterArticle",
+    contentTypeIds: [],
     accessToken: "",
   });
   const [lastContentfulWebhookSecret, setLastContentfulWebhookSecret] = useState("");
@@ -915,9 +914,7 @@ export function IntegrationsPageContent({
       projectId: existingConnection?.projectId ?? "",
       spaceId: existingConnection?.spaceId ?? "",
       environmentId: existingConnection?.environmentId ?? "master",
-      sourceLocale: existingConnection?.sourceLocale ?? "en-US",
-      targetLocales: existingConnection?.targetLocales.join(", ") ?? "",
-      contentTypeIds: existingConnection?.contentTypeIds.join(", ") ?? "helpCenterArticle",
+      contentTypeIds: existingConnection?.contentTypeIds ?? [],
       accessToken: "",
     });
   }
@@ -1198,23 +1195,27 @@ export function IntegrationsPageContent({
                     isLoadingProjects={isLoadingContentfulProjects}
                     lastWebhookSecret={lastContentfulWebhookSecret}
                     isSaving={saveContentfulConnection.isPending}
+                    organizationSlug={organizationSlug}
                     onSave={() => {
                       const accessToken = contentfulForm.accessToken.trim();
                       const existingConnection = contentfulConnections?.[0];
+                      const selectedProject = contentfulProjectOptions?.find(
+                        (project) => project.id === contentfulForm.projectId.trim(),
+                      );
+                      const projectLocales = getProjectLocales(selectedProject);
+                      if (!projectLocales) {
+                        toast.error("Selected project is missing source or target locales.");
+                        return;
+                      }
+
                       const payload = {
                         projectId: contentfulForm.projectId.trim(),
                         displayName: contentfulForm.displayName.trim(),
                         spaceId: contentfulForm.spaceId.trim(),
                         environmentId: contentfulForm.environmentId.trim() || "master",
-                        sourceLocale: contentfulForm.sourceLocale.trim(),
-                        targetLocales: contentfulForm.targetLocales
-                          .split(",")
-                          .map((value) => value.trim())
-                          .filter(Boolean),
-                        contentTypeIds: contentfulForm.contentTypeIds
-                          .split(",")
-                          .map((value) => value.trim())
-                          .filter(Boolean),
+                        sourceLocale: projectLocales.sourceLocale,
+                        targetLocales: projectLocales.targetLocales,
+                        contentTypeIds: contentfulForm.contentTypeIds,
                       };
 
                       saveContentfulConnection.mutate(

--- a/apps/hyperlocalise-web/src/lib/contentful/client.test.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/client.test.ts
@@ -187,4 +187,36 @@ describe("ContentfulManagementClient", () => {
     }
     expect(emptyListResult.value).toHaveLength(0);
   });
+
+  it("lists content types for the configured environment", async () => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url.endsWith("/content_types")) {
+        return Response.json({
+          items: [
+            { sys: { id: "helpCenterArticle" }, name: "Help Center Article" },
+            { sys: { id: "blogPost" }, name: "Blog Post" },
+          ],
+        });
+      }
+
+      return new Response(null, { status: 404 });
+    });
+
+    const client = new ContentfulManagementClient({
+      accessToken: "token",
+      spaceId: "space",
+      environmentId: "master",
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+
+    const result = await client.listContentTypes();
+    if (isErr(result)) {
+      throw new Error("expected content type list");
+    }
+
+    expect(result.value).toEqual([
+      { id: "helpCenterArticle", name: "Help Center Article" },
+      { id: "blogPost", name: "Blog Post" },
+    ]);
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/contentful/client.test.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/client.test.ts
@@ -190,8 +190,9 @@ describe("ContentfulManagementClient", () => {
 
   it("lists content types for the configured environment", async () => {
     const fetchImpl = vi.fn(async (url: string) => {
-      if (url.endsWith("/content_types")) {
+      if (url.includes("/content_types?limit=100&skip=0")) {
         return Response.json({
+          total: 2,
           items: [
             { sys: { id: "helpCenterArticle" }, name: "Help Center Article" },
             { sys: { id: "blogPost" }, name: "Blog Post" },
@@ -218,5 +219,45 @@ describe("ContentfulManagementClient", () => {
       { id: "helpCenterArticle", name: "Help Center Article" },
       { id: "blogPost", name: "Blog Post" },
     ]);
+  });
+
+  it("paginates content types when a space has more than one page", async () => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url.includes("/content_types?limit=100&skip=0")) {
+        return Response.json({
+          total: 101,
+          items: Array.from({ length: 100 }, (_, index) => ({
+            sys: { id: `contentType${index}` },
+            name: `Content Type ${index}`,
+          })),
+        });
+      }
+
+      if (url.includes("/content_types?limit=100&skip=100")) {
+        return Response.json({
+          total: 101,
+          items: [{ sys: { id: "contentType100" }, name: "Content Type 100" }],
+        });
+      }
+
+      return new Response(null, { status: 404 });
+    });
+
+    const client = new ContentfulManagementClient({
+      accessToken: "token",
+      spaceId: "space",
+      environmentId: "master",
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+
+    const result = await client.listContentTypes();
+    if (isErr(result)) {
+      throw new Error("expected paginated content type list");
+    }
+
+    expect(result.value).toHaveLength(101);
+    expect(result.value[0]).toEqual({ id: "contentType0", name: "Content Type 0" });
+    expect(result.value[100]).toEqual({ id: "contentType100", name: "Content Type 100" });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/contentful/client.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/client.ts
@@ -177,6 +177,26 @@ export class ContentfulManagementClient {
     );
   }
 
+  async listContentTypes(): Promise<
+    Result<Array<{ id: string; name: string }>, ContentfulClientError>
+  > {
+    const responseResult = await this.request<{
+      items: Array<{
+        sys: { id: string };
+        name?: string;
+      }>;
+    }>(this.environmentPath("/content_types"));
+    if (isErr(responseResult)) {
+      return err(responseResult.error);
+    }
+    return ok(
+      responseResult.value.items.map((contentType) => ({
+        id: contentType.sys.id,
+        name: contentType.name ?? contentType.sys.id,
+      })),
+    );
+  }
+
   async getAsset(assetId: string): Promise<Result<ContentfulAsset, ContentfulClientError>> {
     return this.request<ContentfulAsset>(
       this.environmentPath(`/assets/${encodeURIComponent(assetId)}`),

--- a/apps/hyperlocalise-web/src/lib/contentful/client.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/client.ts
@@ -180,17 +180,33 @@ export class ContentfulManagementClient {
   async listContentTypes(): Promise<
     Result<Array<{ id: string; name: string }>, ContentfulClientError>
   > {
-    const responseResult = await this.request<{
-      items: Array<{
-        sys: { id: string };
-        name?: string;
-      }>;
-    }>(this.environmentPath("/content_types"));
-    if (isErr(responseResult)) {
-      return err(responseResult.error);
+    const pageSize = 100;
+    const items: Array<{
+      sys: { id: string };
+      name?: string;
+    }> = [];
+    let skip = 0;
+    let total = Number.POSITIVE_INFINITY;
+
+    while (skip < total) {
+      const responseResult = await this.request<{
+        total: number;
+        items: Array<{
+          sys: { id: string };
+          name?: string;
+        }>;
+      }>(this.environmentPath(`/content_types?limit=${pageSize}&skip=${skip}`));
+      if (isErr(responseResult)) {
+        return err(responseResult.error);
+      }
+
+      items.push(...responseResult.value.items);
+      total = responseResult.value.total;
+      skip += pageSize;
     }
+
     return ok(
-      responseResult.value.items.map((contentType) => ({
+      items.map((contentType) => ({
         id: contentType.sys.id,
         name: contentType.name ?? contentType.sys.id,
       })),

--- a/apps/hyperlocalise-web/src/lib/contentful/connections.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/connections.ts
@@ -25,6 +25,7 @@ import type {
   ContentfulConnectionSummary,
   ContentfulConnectionValidation,
   ContentfulConnectionValidationError,
+  ContentfulSpaceDiscovery,
 } from "./types";
 
 type ContentfulConnectionRow = typeof schema.contentfulConnections.$inferSelect;
@@ -462,6 +463,65 @@ export async function deleteContentfulConnection(input: {
     .returning({ id: schema.contentfulConnections.id });
 
   return Boolean(deleted);
+}
+
+export async function discoverContentfulSpace(input: {
+  organizationId: string;
+  spaceId: string;
+  environmentId: string;
+  accessToken?: string;
+  connectionId?: string;
+}): Promise<Result<ContentfulSpaceDiscovery, ContentfulConnectionValidationError>> {
+  let accessToken = input.accessToken?.trim();
+  if (!accessToken && input.connectionId) {
+    const loaded = await loadContentfulConnectionWithToken({
+      organizationId: input.organizationId,
+      connectionId: input.connectionId,
+    });
+    if (!loaded) {
+      return err({
+        code: "contentful_connection_validation_failed",
+        message: "Contentful connection not found.",
+      });
+    }
+    accessToken = loaded.token;
+  }
+
+  if (!accessToken) {
+    return err({
+      code: "contentful_connection_validation_failed",
+      message: "A Management API token is required to load Contentful metadata.",
+    });
+  }
+
+  const client = new ContentfulManagementClient({
+    accessToken,
+    spaceId: input.spaceId,
+    environmentId: input.environmentId,
+  });
+
+  const [validationResult, contentTypesResult] = await Promise.all([
+    client.validateConnection(),
+    client.listContentTypes(),
+  ]);
+  if (isErr(validationResult)) {
+    return err({
+      code: "contentful_connection_validation_failed",
+      message: validationResult.error.message,
+    });
+  }
+  if (isErr(contentTypesResult)) {
+    return err({
+      code: "contentful_connection_validation_failed",
+      message: contentTypesResult.error.message,
+    });
+  }
+
+  return ok({
+    environmentId: validationResult.value.environmentId,
+    locales: validationResult.value.locales,
+    contentTypes: contentTypesResult.value,
+  });
 }
 
 export async function validateContentfulConnection(input: {

--- a/apps/hyperlocalise-web/src/lib/contentful/types.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/types.ts
@@ -155,6 +155,21 @@ export type ContentfulConnectionValidation = {
   }>;
 };
 
+export type ContentfulContentTypeSummary = {
+  id: string;
+  name: string;
+};
+
+export type ContentfulSpaceDiscovery = {
+  environmentId: string;
+  locales: Array<{
+    code: string;
+    name: string;
+    default: boolean;
+  }>;
+  contentTypes: ContentfulContentTypeSummary[];
+};
+
 export type ContentfulConnectionValidationError = {
   code: "contentful_connection_validation_failed";
   message: string;


### PR DESCRIPTION
## What changed

The Contentful integration form no longer asks users to manually type source locale, target locales, or content type IDs.

- Locales are derived from the selected Hyperlocalise project and shown as read-only context.
- Content types are loaded from Contentful via a new `/discover` endpoint once Space ID and Management API credentials are available.
- The UI presents content types as selectable buttons instead of comma-separated text input.

## How to test

1. Open **Integrations → Contentful** in the web app.
2. Select a Hyperlocalise project with configured locales and confirm source/target locales appear automatically.
3. Enter Space ID, Environment ID, and Management API token.
4. Confirm content types load from Contentful and can be selected before saving.
5. Run `cd apps/hyperlocalise-web && vp test src/lib/contentful/client.test.ts src/lib/contentful/connections.test.ts`
6. Run `cd apps/hyperlocalise-web && vp check --fix`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)