### PR TITLE
fix(web): improve Contentful discovery errors and logging

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/contentful-connection/contentful-connection.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/contentful-connection/contentful-connection.route.ts
@@ -108,6 +108,8 @@ function mapDiscoveryErrorResponse(
       return notFoundResponse(c, error.code, error.message);
     case "contentful_discovery_invalid_credentials":
       return unauthorizedResponse(c, error.code, error.message);
+    case "contentful_discovery_space_unavailable":
+      return notFoundResponse(c, error.code, error.message);
     default:
       return badRequestResponse(
         c,

--- a/apps/hyperlocalise-web/src/api/routes/contentful-connection/contentful-connection.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/contentful-connection/contentful-connection.route.ts
@@ -3,17 +3,24 @@ import { validator } from "hono/validator";
 
 import { hasCapability } from "@/api/auth/policy";
 import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
-import { badRequestResponse, forbiddenResponse, notFoundResponse } from "@/api/response.schema";
+import {
+  badRequestResponse,
+  forbiddenResponse,
+  notFoundResponse,
+  unauthorizedResponse,
+} from "@/api/response.schema";
 import { isErr } from "@/lib/primitives/result/results";
 import {
   createContentfulConnection,
   deleteContentfulConnection,
-  discoverContentfulSpace,
   getContentfulConnection,
   listContentfulConnections,
   updateContentfulConnection,
   validateContentfulConnection,
 } from "@/lib/contentful/connections";
+import { discoverContentfulSpace } from "@/lib/contentful/discover-contentful-space";
+import type { ContentfulDiscoveryError } from "@/lib/contentful/types";
+import { createLogger } from "@/lib/log";
 
 import {
   contentfulConnectionIdParamSchema,
@@ -21,6 +28,8 @@ import {
   discoverContentfulSpaceBodySchema,
   updateContentfulConnectionBodySchema,
 } from "./contentful-connection.schema";
+
+const logger = createLogger("contentful-connection");
 
 const validateConnectionParams = validator("param", (value, c) => {
   const parsed = contentfulConnectionIdParamSchema.safeParse(value);
@@ -59,6 +68,12 @@ const validateUpdateBody = validator("json", (value, c) => {
 const validateDiscoverBody = validator("json", (value, c) => {
   const parsed = discoverContentfulSpaceBodySchema.safeParse(value);
   if (!parsed.success) {
+    logger.warn(
+      {
+        issues: parsed.error.flatten(),
+      },
+      "contentful discovery payload invalid",
+    );
     return badRequestResponse(
       c,
       "invalid_contentful_discovery_payload",
@@ -82,6 +97,25 @@ function mapContentfulError(c: Parameters<typeof badRequestResponse>[0], error: 
     return notFoundResponse(c, "project_not_found");
   }
   throw error;
+}
+
+function mapDiscoveryErrorResponse(
+  c: Parameters<typeof badRequestResponse>[0],
+  error: ContentfulDiscoveryError,
+) {
+  switch (error.code) {
+    case "contentful_discovery_connection_not_found":
+      return notFoundResponse(c, error.code, error.message);
+    case "contentful_discovery_invalid_credentials":
+      return unauthorizedResponse(c, error.code, error.message);
+    default:
+      return badRequestResponse(
+        c,
+        error.code,
+        error.message,
+        "contentfulStatus" in error ? { contentfulStatus: error.contentfulStatus } : undefined,
+      );
+  }
 }
 
 export function createContentfulConnectionRoutes() {
@@ -113,7 +147,7 @@ export function createContentfulConnectionRoutes() {
       });
 
       if (isErr(result)) {
-        return badRequestResponse(c, result.error.code, result.error.message);
+        return mapDiscoveryErrorResponse(c, result.error);
       }
 
       return c.json({ contentfulSpaceDiscovery: result.value }, 200);

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/contentful-connection-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/integrations/_components/contentful-connection-panel.tsx
@@ -10,7 +10,7 @@ import { createApiClient } from "@/lib/api-client";
 import { getLocaleLabel } from "@/lib/i18n/locales";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Field, FieldLabel } from "@/components/ui/field";
+import { Field, FieldDescription, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger } from "@/components/ui/select";
 
@@ -159,9 +159,20 @@ function useDiscoverContentfulSpace(input: {
         const error = await res
           .json()
           .catch(() => ({ message: "Unable to load Contentful metadata" }));
-        throw new Error(
-          "message" in error ? String(error.message) : "Unable to load Contentful metadata",
-        );
+        const message =
+          typeof error === "object" &&
+          error !== null &&
+          "message" in error &&
+          typeof error.message === "string" &&
+          error.message.length > 0
+            ? error.message
+            : typeof error === "object" &&
+                error !== null &&
+                "error" in error &&
+                typeof error.error === "string"
+              ? error.error.replaceAll("_", " ")
+              : "Unable to load Contentful metadata";
+        throw new Error(message);
       }
       const data = await res.json();
       return data.contentfulSpaceDiscovery as {
@@ -251,6 +262,16 @@ export function useSaveContentfulConnection(organizationSlug: string) {
   });
 }
 
+function ContentfulTokenGuidance() {
+  return (
+    <FieldDescription>
+      Use a Content Management API personal access token from Contentful Settings → Content
+      management tokens. Do not use Content Delivery or Preview API keys — those are read-only and
+      cannot write draft translations or register webhooks.
+    </FieldDescription>
+  );
+}
+
 function ProjectLocalesSummary({ project }: { project: ProjectOption | undefined }) {
   if (!project) {
     return (
@@ -320,7 +341,7 @@ function ContentTypePicker({
   if (requiresCredentials) {
     return (
       <p className="text-sm text-muted-foreground">
-        Enter your Space ID and Management API token to load content types from Contentful.
+        Enter your Space ID and Content Management API token to load content types from Contentful.
       </p>
     );
   }
@@ -507,7 +528,8 @@ export function ContentfulConnectionPanel({
         </Field>
         {!connection || isReplacingToken ? (
           <Field className="gap-2 lg:col-span-2">
-            <FieldLabel>Management API token</FieldLabel>
+            <FieldLabel>Content Management API token</FieldLabel>
+            <ContentfulTokenGuidance />
             <div className="flex gap-2">
               <Input
                 type="password"
@@ -533,7 +555,8 @@ export function ContentfulConnectionPanel({
           </Field>
         ) : (
           <Field className="gap-2 lg:col-span-2">
-            <FieldLabel>Management API token</FieldLabel>
+            <FieldLabel>Content Management API token</FieldLabel>
+            <ContentfulTokenGuidance />
             <Button
               type="button"
               variant="outline"

--- a/apps/hyperlocalise-web/src/lib/contentful/client.test.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/client.test.ts
@@ -260,4 +260,34 @@ describe("ContentfulManagementClient", () => {
     expect(result.value[100]).toEqual({ id: "contentType100", name: "Content Type 100" });
     expect(fetchImpl).toHaveBeenCalledTimes(2);
   });
+
+  it("surfaces Contentful management API error messages from response bodies", async () => {
+    const fetchImpl = vi.fn(async () =>
+      Response.json(
+        {
+          sys: { type: "Error", id: "AccessTokenInvalid" },
+          message: "The access token you sent could not be found or is invalid.",
+        },
+        { status: 401 },
+      ),
+    );
+
+    const client = new ContentfulManagementClient({
+      accessToken: "token",
+      spaceId: "space",
+      environmentId: "master",
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+
+    const result = await client.listContentTypes();
+    if (!isErr(result)) {
+      throw new Error("expected content type list failure");
+    }
+
+    expect(result.error.status).toBe(401);
+    expect(result.error.message).toBe(
+      "The access token you sent could not be found or is invalid.",
+    );
+    expect(result.error.contentfulErrorId).toBe("AccessTokenInvalid");
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/contentful/client.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/client.ts
@@ -32,7 +32,40 @@ export type ContentfulClientError = {
   code: "contentful_request_failed";
   status: number;
   message: string;
+  contentfulErrorId?: string;
 };
+
+function parseContentfulManagementError(text: string): {
+  message?: string;
+  contentfulErrorId?: string;
+} {
+  try {
+    const body = JSON.parse(text) as {
+      message?: string;
+      sys?: { id?: string };
+    };
+    return {
+      message: typeof body.message === "string" ? body.message : undefined,
+      contentfulErrorId: typeof body.sys?.id === "string" ? body.sys.id : undefined,
+    };
+  } catch {
+    return {};
+  }
+}
+
+function buildContentfulClientError(input: {
+  status: number;
+  fallbackMessage: string;
+  responseText?: string;
+}): ContentfulClientError {
+  const parsed = input.responseText ? parseContentfulManagementError(input.responseText) : {};
+  return {
+    code: "contentful_request_failed",
+    status: input.status,
+    message: parsed.message ?? input.fallbackMessage,
+    ...(parsed.contentfulErrorId ? { contentfulErrorId: parsed.contentfulErrorId } : {}),
+  };
+}
 
 type ContentfulLocale = { code: string; name: string; default: boolean };
 type ContentfulConnectionValidation = {
@@ -73,19 +106,34 @@ export class ContentfulManagementClient {
         headers,
       });
     } catch {
-      return err({
-        code: "contentful_request_failed",
-        status: 0,
-        message: "Contentful request failed before receiving a response",
-      });
+      return err(
+        buildContentfulClientError({
+          status: 0,
+          fallbackMessage: "Contentful request failed before receiving a response",
+        }),
+      );
     }
 
     if (!response.ok) {
-      return err({
-        code: "contentful_request_failed",
-        status: response.status,
-        message: `Contentful request failed with status ${response.status}`,
-      });
+      let responseText = "";
+      try {
+        responseText = await response.text();
+      } catch {
+        return err(
+          buildContentfulClientError({
+            status: response.status,
+            fallbackMessage: `Contentful request failed with status ${response.status}`,
+          }),
+        );
+      }
+
+      return err(
+        buildContentfulClientError({
+          status: response.status,
+          fallbackMessage: `Contentful request failed with status ${response.status}`,
+          responseText,
+        }),
+      );
     }
 
     if (response.status === 204) {
@@ -96,11 +144,12 @@ export class ContentfulManagementClient {
     try {
       text = await response.text();
     } catch {
-      return err({
-        code: "contentful_request_failed",
-        status: response.status,
-        message: "Contentful response body could not be read",
-      });
+      return err(
+        buildContentfulClientError({
+          status: response.status,
+          fallbackMessage: "Contentful response body could not be read",
+        }),
+      );
     }
 
     if (!text) {
@@ -110,11 +159,13 @@ export class ContentfulManagementClient {
     try {
       return ok(JSON.parse(text) as T);
     } catch {
-      return err({
-        code: "contentful_request_failed",
-        status: response.status,
-        message: "Contentful response body was not valid JSON",
-      });
+      return err(
+        buildContentfulClientError({
+          status: response.status,
+          fallbackMessage: "Contentful response body was not valid JSON",
+          responseText: text,
+        }),
+      );
     }
   }
 

--- a/apps/hyperlocalise-web/src/lib/contentful/connections.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/connections.ts
@@ -13,6 +13,7 @@ import {
 import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
 
 import { ContentfulManagementClient, isContentfulClientError } from "./client";
+import { loadContentfulConnectionWithToken } from "./contentful-connection-access";
 import { hashContentfulWebhookSecret } from "./webhook";
 import {
   contentfulWebhookCallbackUrl,
@@ -25,7 +26,6 @@ import type {
   ContentfulConnectionSummary,
   ContentfulConnectionValidation,
   ContentfulConnectionValidationError,
-  ContentfulSpaceDiscovery,
 } from "./types";
 
 type ContentfulConnectionRow = typeof schema.contentfulConnections.$inferSelect;
@@ -179,37 +179,7 @@ export async function getContentfulConnection(input: {
   return row ? serializeConnection(row.connection, row.webhook) : null;
 }
 
-export async function loadContentfulConnectionWithToken(input: {
-  organizationId: string;
-  connectionId: string;
-}) {
-  const [connection] = await db
-    .select()
-    .from(schema.contentfulConnections)
-    .where(
-      and(
-        eq(schema.contentfulConnections.organizationId, input.organizationId),
-        eq(schema.contentfulConnections.id, input.connectionId),
-      ),
-    )
-    .limit(1);
-
-  if (!connection) {
-    return null;
-  }
-
-  const token = unwrapProviderCredentialCrypto(
-    decryptProviderCredential({
-      algorithm: connection.encryptionAlgorithm,
-      keyVersion: connection.keyVersion,
-      ciphertext: connection.ciphertext,
-      iv: connection.iv,
-      authTag: connection.authTag,
-    }),
-  );
-
-  return { connection, token };
-}
+export { loadContentfulConnectionWithToken } from "./contentful-connection-access";
 
 async function assertProjectBelongsToOrganization(input: {
   organizationId: string;
@@ -465,64 +435,7 @@ export async function deleteContentfulConnection(input: {
   return Boolean(deleted);
 }
 
-export async function discoverContentfulSpace(input: {
-  organizationId: string;
-  spaceId: string;
-  environmentId: string;
-  accessToken?: string;
-  connectionId?: string;
-}): Promise<Result<ContentfulSpaceDiscovery, ContentfulConnectionValidationError>> {
-  let accessToken = input.accessToken?.trim();
-  if (!accessToken && input.connectionId) {
-    const loaded = await loadContentfulConnectionWithToken({
-      organizationId: input.organizationId,
-      connectionId: input.connectionId,
-    });
-    if (!loaded) {
-      return err({
-        code: "contentful_connection_validation_failed",
-        message: "Contentful connection not found.",
-      });
-    }
-    accessToken = loaded.token;
-  }
-
-  if (!accessToken) {
-    return err({
-      code: "contentful_connection_validation_failed",
-      message: "A Management API token is required to load Contentful metadata.",
-    });
-  }
-
-  const client = new ContentfulManagementClient({
-    accessToken,
-    spaceId: input.spaceId,
-    environmentId: input.environmentId,
-  });
-
-  const [validationResult, contentTypesResult] = await Promise.all([
-    client.validateConnection(),
-    client.listContentTypes(),
-  ]);
-  if (isErr(validationResult)) {
-    return err({
-      code: "contentful_connection_validation_failed",
-      message: validationResult.error.message,
-    });
-  }
-  if (isErr(contentTypesResult)) {
-    return err({
-      code: "contentful_connection_validation_failed",
-      message: contentTypesResult.error.message,
-    });
-  }
-
-  return ok({
-    environmentId: validationResult.value.environmentId,
-    locales: validationResult.value.locales,
-    contentTypes: contentTypesResult.value,
-  });
-}
+export { discoverContentfulSpace } from "./discover-contentful-space";
 
 export async function validateContentfulConnection(input: {
   organizationId: string;

--- a/apps/hyperlocalise-web/src/lib/contentful/contentful-connection-access.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/contentful-connection-access.ts
@@ -1,0 +1,39 @@
+import { and, eq } from "drizzle-orm";
+
+import { db, schema } from "@/lib/database";
+import {
+  decryptProviderCredential,
+  unwrapProviderCredentialCrypto,
+} from "@/lib/security/provider-credential-crypto";
+
+export async function loadContentfulConnectionWithToken(input: {
+  organizationId: string;
+  connectionId: string;
+}) {
+  const [connection] = await db
+    .select()
+    .from(schema.contentfulConnections)
+    .where(
+      and(
+        eq(schema.contentfulConnections.organizationId, input.organizationId),
+        eq(schema.contentfulConnections.id, input.connectionId),
+      ),
+    )
+    .limit(1);
+
+  if (!connection) {
+    return null;
+  }
+
+  const token = unwrapProviderCredentialCrypto(
+    decryptProviderCredential({
+      algorithm: connection.encryptionAlgorithm,
+      keyVersion: connection.keyVersion,
+      ciphertext: connection.ciphertext,
+      iv: connection.iv,
+      authTag: connection.authTag,
+    }),
+  );
+
+  return { connection, token };
+}

--- a/apps/hyperlocalise-web/src/lib/contentful/discover-contentful-space.test.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/discover-contentful-space.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { isErr } from "@/lib/primitives/result/results";
+
+import { discoverContentfulSpace } from "./discover-contentful-space";
+
+describe("discoverContentfulSpace", () => {
+  it("returns a missing-credentials Result when no token or connection is provided", async () => {
+    const result = await discoverContentfulSpace({
+      organizationId: crypto.randomUUID(),
+      spaceId: "space-id",
+      environmentId: "master",
+    });
+
+    expect(isErr(result)).toBe(true);
+    if (isErr(result)) {
+      expect(result.error.code).toBe("contentful_discovery_missing_credentials");
+      expect(result.error.message).toContain("Content Management API token");
+    }
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/contentful/discover-contentful-space.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/discover-contentful-space.ts
@@ -1,0 +1,184 @@
+import { createLogger } from "@/lib/log";
+import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
+
+import { ContentfulManagementClient, type ContentfulClientError } from "./client";
+import { loadContentfulConnectionWithToken } from "./contentful-connection-access";
+import type { ContentfulDiscoveryError, ContentfulSpaceDiscovery } from "./types";
+
+const logger = createLogger("contentful-discovery");
+
+function mapContentfulClientError(error: ContentfulClientError): ContentfulDiscoveryError {
+  if (error.status === 401 || error.status === 403) {
+    return {
+      code: "contentful_discovery_invalid_credentials",
+      message:
+        error.message ||
+        "Contentful rejected the Management API token. Use a Content Management API personal access token, not Content Delivery or Preview keys.",
+      contentfulStatus: error.status,
+    };
+  }
+
+  if (error.status === 404) {
+    return {
+      code: "contentful_discovery_space_unavailable",
+      message:
+        error.message ||
+        "Contentful could not find the requested space or environment. Check the Space ID and Environment ID.",
+      contentfulStatus: error.status,
+    };
+  }
+
+  return {
+    code: "contentful_discovery_request_failed",
+    message: error.message,
+    contentfulStatus: error.status,
+  };
+}
+
+function logDiscoveryFailure(input: {
+  organizationId: string;
+  spaceId: string;
+  environmentId: string;
+  credentialSource: "inline_token" | "stored_connection" | "missing";
+  connectionId?: string;
+  error: ContentfulDiscoveryError;
+  contentfulErrorId?: string;
+}) {
+  logger.warn(
+    {
+      organizationId: input.organizationId,
+      spaceId: input.spaceId,
+      environmentId: input.environmentId,
+      credentialSource: input.credentialSource,
+      connectionId: input.connectionId,
+      errorCode: input.error.code,
+      contentfulStatus:
+        "contentfulStatus" in input.error ? input.error.contentfulStatus : undefined,
+      contentfulErrorId: input.contentfulErrorId,
+    },
+    "contentful space discovery failed",
+  );
+}
+
+export async function discoverContentfulSpace(input: {
+  organizationId: string;
+  spaceId: string;
+  environmentId: string;
+  accessToken?: string;
+  connectionId?: string;
+}): Promise<Result<ContentfulSpaceDiscovery, ContentfulDiscoveryError>> {
+  const spaceId = input.spaceId.trim();
+  const environmentId = input.environmentId.trim() || "master";
+  let accessToken = input.accessToken?.trim();
+  let credentialSource: "inline_token" | "stored_connection" | "missing" = accessToken
+    ? "inline_token"
+    : "missing";
+
+  if (!accessToken && input.connectionId) {
+    const loaded = await loadContentfulConnectionWithToken({
+      organizationId: input.organizationId,
+      connectionId: input.connectionId,
+    });
+    if (!loaded) {
+      const discoveryError: ContentfulDiscoveryError = {
+        code: "contentful_discovery_connection_not_found",
+        message: "Contentful connection not found.",
+      };
+      logDiscoveryFailure({
+        organizationId: input.organizationId,
+        spaceId,
+        environmentId,
+        credentialSource: "missing",
+        connectionId: input.connectionId,
+        error: discoveryError,
+      });
+      return err(discoveryError);
+    }
+    accessToken = loaded.token;
+    credentialSource = "stored_connection";
+  }
+
+  if (!accessToken) {
+    const discoveryError: ContentfulDiscoveryError = {
+      code: "contentful_discovery_missing_credentials",
+      message:
+        "A Content Management API token is required to load Contentful metadata. Use a personal access token from Contentful Settings → Content management tokens.",
+    };
+    logDiscoveryFailure({
+      organizationId: input.organizationId,
+      spaceId,
+      environmentId,
+      credentialSource,
+      connectionId: input.connectionId,
+      error: discoveryError,
+    });
+    return err(discoveryError);
+  }
+
+  logger.info(
+    {
+      organizationId: input.organizationId,
+      spaceId,
+      environmentId,
+      credentialSource,
+      connectionId: input.connectionId,
+    },
+    "contentful space discovery started",
+  );
+
+  const client = new ContentfulManagementClient({
+    accessToken,
+    spaceId,
+    environmentId,
+  });
+
+  const [validationResult, contentTypesResult] = await Promise.all([
+    client.validateConnection(),
+    client.listContentTypes(),
+  ]);
+
+  if (isErr(validationResult)) {
+    const discoveryError = mapContentfulClientError(validationResult.error);
+    logDiscoveryFailure({
+      organizationId: input.organizationId,
+      spaceId,
+      environmentId,
+      credentialSource,
+      connectionId: input.connectionId,
+      error: discoveryError,
+      contentfulErrorId: validationResult.error.contentfulErrorId,
+    });
+    return err(discoveryError);
+  }
+
+  if (isErr(contentTypesResult)) {
+    const discoveryError = mapContentfulClientError(contentTypesResult.error);
+    logDiscoveryFailure({
+      organizationId: input.organizationId,
+      spaceId,
+      environmentId,
+      credentialSource,
+      connectionId: input.connectionId,
+      error: discoveryError,
+      contentfulErrorId: contentTypesResult.error.contentfulErrorId,
+    });
+    return err(discoveryError);
+  }
+
+  logger.info(
+    {
+      organizationId: input.organizationId,
+      spaceId,
+      environmentId,
+      localeCount: validationResult.value.locales.length,
+      contentTypeCount: contentTypesResult.value.length,
+    },
+    "contentful space discovery succeeded",
+  );
+
+  return ok({
+    environmentId: validationResult.value.environmentId,
+    locales: validationResult.value.locales,
+    contentTypes: contentTypesResult.value,
+  });
+}

--- a/apps/hyperlocalise-web/src/lib/contentful/discover-contentful-space.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/discover-contentful-space.ts
@@ -8,12 +8,22 @@ import type { ContentfulDiscoveryError, ContentfulSpaceDiscovery } from "./types
 const logger = createLogger("contentful-discovery");
 
 function mapContentfulClientError(error: ContentfulClientError): ContentfulDiscoveryError {
-  if (error.status === 401 || error.status === 403) {
+  if (error.status === 401) {
     return {
       code: "contentful_discovery_invalid_credentials",
       message:
         error.message ||
         "Contentful rejected the Management API token. Use a Content Management API personal access token, not Content Delivery or Preview keys.",
+      contentfulStatus: error.status,
+    };
+  }
+
+  if (error.status === 403) {
+    return {
+      code: "contentful_discovery_invalid_credentials",
+      message:
+        error.message ||
+        "The token does not have access to this space. Use a Content Management API token that can manage the space you entered.",
       contentfulStatus: error.status,
     };
   }
@@ -88,7 +98,7 @@ export async function discoverContentfulSpace(input: {
         organizationId: input.organizationId,
         spaceId,
         environmentId,
-        credentialSource: "missing",
+        credentialSource: "stored_connection",
         connectionId: input.connectionId,
         error: discoveryError,
       });

--- a/apps/hyperlocalise-web/src/lib/contentful/types.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/types.ts
@@ -175,6 +175,31 @@ export type ContentfulConnectionValidationError = {
   message: string;
 };
 
+export type ContentfulDiscoveryError =
+  | {
+      code: "contentful_discovery_missing_credentials";
+      message: string;
+    }
+  | {
+      code: "contentful_discovery_connection_not_found";
+      message: string;
+    }
+  | {
+      code: "contentful_discovery_invalid_credentials";
+      message: string;
+      contentfulStatus: number;
+    }
+  | {
+      code: "contentful_discovery_space_unavailable";
+      message: string;
+      contentfulStatus: number;
+    }
+  | {
+      code: "contentful_discovery_request_failed";
+      message: string;
+      contentfulStatus: number;
+    };
+
 export type ContentfulAutomationExecutionSuccess = {
   runId: string;
 };


### PR DESCRIPTION
## What changed

The Contentful `/discover` endpoint now returns structured `Result` errors with clearer messages parsed from Contentful's Management API responses. Invalid credentials map to 401 instead of a generic 400, discovery failures are logged with safe metadata (no tokens), and the integration form shows clearer CMA token guidance.

## How to test

1. Open **Integrations → Contentful** and enter Space ID + a Content Management API personal access token.
2. Confirm content types load successfully.
3. Retry with a Content Delivery or Preview key and confirm the UI shows Contentful's auth error (401) instead of a vague 400.
4. Check server logs for `contentful space discovery started` / `contentful space discovery failed` entries.
5. Run `cd apps/hyperlocalise-web && vp test src/lib/contentful/client.test.ts src/lib/contentful/discover-contentful-space.test.ts`
6. Run `cd apps/hyperlocalise-web && vp check --fix`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)