### PR TITLE
🧪 Scout: add ICU parser edge case tests

### DIFF
--- a/internal/i18n/icuparser/parse_test.go
+++ b/internal/i18n/icuparser/parse_test.go
@@ -422,15 +422,28 @@ func TestParseASTTagsWithDotsAndNumbers(t *testing.T) {
 	if len(elems) != 3 {
 		t.Fatalf("expected 3 top-level elements, got %d", len(elems))
 	}
+	if lit, ok := elems[0].(LiteralElement); !ok || lit.Value != "Click " {
+		t.Errorf("expected leading literal 'Click ', got %+v", elems[0])
+	}
 	tag, ok := elems[1].(TagElement)
 	if !ok {
 		t.Fatalf("expected tag element, got %T", elems[1])
 	}
 	if tag.Value != "My.Component.v1" {
-		t.Fatalf("unexpected tag value: %q", tag.Value)
+		t.Errorf("expected tag value %q, got %q", "My.Component.v1", tag.Value)
 	}
 	if len(tag.Children) != 1 {
 		t.Fatalf("expected 1 child for My.Component.v1, got %d", len(tag.Children))
+	}
+	innerTag, ok := tag.Children[0].(TagElement)
+	if !ok || innerTag.Value != "b" {
+		t.Fatalf("expected inner <b> tag, got %+v", tag.Children[0])
+	}
+	if len(innerTag.Children) != 1 || innerTag.Children[0].Type() != TypeArgument {
+		t.Fatalf("expected argument child for <b>, got %+v", innerTag.Children)
+	}
+	if lit, ok := elems[2].(LiteralElement); !ok || lit.Value != " now" {
+		t.Errorf("expected trailing literal ' now', got %+v", elems[2])
 	}
 }
 

--- a/internal/i18n/icuparser/parse_test.go
+++ b/internal/i18n/icuparser/parse_test.go
@@ -413,6 +413,27 @@ func TestParseTypedFormatterShouldParseSkeletons(t *testing.T) {
 	}
 }
 
+func TestParseASTTagsWithDotsAndNumbers(t *testing.T) {
+	msg := `Click <My.Component.v1 id="1"><b>{name}</b></My.Component.v1> now`
+	elems, err := Parse(msg, nil)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(elems) != 3 {
+		t.Fatalf("expected 3 top-level elements, got %d", len(elems))
+	}
+	tag, ok := elems[1].(TagElement)
+	if !ok {
+		t.Fatalf("expected tag element, got %T", elems[1])
+	}
+	if tag.Value != "My.Component.v1" {
+		t.Fatalf("unexpected tag value: %q", tag.Value)
+	}
+	if len(tag.Children) != 1 {
+		t.Fatalf("expected 1 child for My.Component.v1, got %d", len(tag.Children))
+	}
+}
+
 func TestParsePluralWithSpaceInOffset(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -438,6 +459,11 @@ func TestParsePluralWithSpaceInOffset(t *testing.T) {
 			name:           "multiple spaces",
 			msg:            "{count, plural, offset  :  2 one {# item} other {# items}}",
 			expectedOffset: 2,
+		},
+		{
+			name:           "negative offset",
+			msg:            "{count, plural, offset:-1 one {# item} other {# items}}",
+			expectedOffset: -1,
 		},
 	}
 


### PR DESCRIPTION
Improved ICU parser test coverage by adding validation for MDX-style member component tags (containing dots and numbers) and negative plural offsets. These tests ensure that Hyperlocalise robustly handles modern frontend component patterns and valid but less common ICU message syntax.

---
*PR created automatically by Jules for task [16158431175174750477](https://jules.google.com/task/16158431175174750477) started by @cungminh2710*