### PR TITLE
fix(tms): sync connected provider projects from empty state

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.test.ts
@@ -172,6 +172,21 @@ describe("tmsProviderRoutes", () => {
     });
   });
 
+  it("returns 403 when queuing a manual project sync without provider credential write access", async () => {
+    const identity = fixture.createWorkosIdentityWithRole("translator");
+    const headers = await fixture.authHeadersFor(identity);
+
+    const response = await client.api.orgs[":organizationSlug"]["tms-provider"].projects.sync.$post(
+      {
+        param: { organizationSlug: identity.organization.slug ?? "missing" },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: "forbidden" });
+  });
+
   it("returns 401 when Crowdin OAuth refresh fails while loading live projects", async () => {
     const identity = fixture.createWorkosIdentityWithRole("admin");
     const headers = await fixture.authHeadersFor(identity);

--- a/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.test.ts
@@ -129,6 +129,49 @@ describe("tmsProviderRoutes", () => {
     });
   });
 
+  it("queues a manual project sync for the active provider", async () => {
+    const identity = fixture.createWorkosIdentityWithRole("admin");
+    const headers = await fixture.authHeadersFor(identity);
+    const organizationId = globalThis.__testApiAuthContext!.organization.localOrganizationId;
+
+    const credential = await upsertOrganizationExternalTmsProviderCredential({
+      organizationId,
+      userId: globalThis.__testApiAuthContext!.user.localUserId,
+      role: "admin",
+      providerKind: "crowdin",
+      displayName: "Crowdin",
+      secretMaterial: "crowdin-secret",
+    });
+
+    const response = await client.api.orgs[":organizationSlug"]["tms-provider"].projects.sync.$post(
+      {
+        param: { organizationSlug: identity.organization.slug ?? "missing" },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toMatchObject({
+      providerProjectSync: {
+        created: true,
+      },
+    });
+
+    const [intent] = await db
+      .select()
+      .from(schema.providerSyncIntents)
+      .where(eq(schema.providerSyncIntents.organizationId, organizationId))
+      .limit(1);
+
+    expect(intent).toMatchObject({
+      providerCredentialId: credential.id,
+      providerKind: "crowdin",
+      syncKind: "project_scan",
+      cause: "manual",
+      status: "pending",
+    });
+  });
+
   it("returns 401 when Crowdin OAuth refresh fails while loading live projects", async () => {
     const identity = fixture.createWorkosIdentityWithRole("admin");
     const headers = await fixture.authHeadersFor(identity);

--- a/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.ts
@@ -4,6 +4,8 @@ import { z } from "zod";
 
 import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
 import { hasCapability } from "@/api/auth/policy";
+import { getActiveOrganizationExternalTmsProviderCredentialRow } from "@/lib/providers/organization-external-tms-provider-credentials";
+import { enqueueProviderCatalogSyncIntent } from "@/lib/providers/provider-sync-intent";
 import {
   getTmsProviderConnection,
   getTmsProviderLiveJobFileDetail,
@@ -160,6 +162,41 @@ export function createTmsProviderRoutes() {
       } catch (error) {
         return tmsProviderLiveErrorResponse(c, error);
       }
+    })
+    .post("/projects/sync", async (c) => {
+      if (!hasCapability(c.var.auth.membership.role, "projects:read")) {
+        return c.json({ error: "forbidden" }, 403);
+      }
+
+      const organizationId = c.var.auth.organization.localOrganizationId;
+      const credential =
+        await getActiveOrganizationExternalTmsProviderCredentialRow(organizationId);
+      if (!credential) {
+        return c.json(
+          {
+            error: "no_active_tms_provider",
+            message: "Connect a TMS provider before syncing projects.",
+          },
+          404,
+        );
+      }
+
+      const result = await enqueueProviderCatalogSyncIntent({
+        organizationId,
+        providerCredentialId: credential.id,
+        providerKind: credential.providerKind,
+        cause: "manual",
+      });
+
+      return c.json(
+        {
+          providerProjectSync: {
+            intentId: result.intentId,
+            created: result.created,
+          },
+        },
+        202,
+      );
     })
     .get("/projects/:externalProjectId", async (c) => {
       if (!hasCapability(c.var.auth.membership.role, "projects:read")) {

--- a/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.ts
@@ -164,7 +164,7 @@ export function createTmsProviderRoutes() {
       }
     })
     .post("/projects/sync", async (c) => {
-      if (!hasCapability(c.var.auth.membership.role, "projects:read")) {
+      if (!hasCapability(c.var.auth.membership.role, "provider_credentials:write")) {
         return c.json({ error: "forbidden" }, 403);
       }
 

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/chat/_components/chat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/chat/_components/chat-page-content.tsx
@@ -36,6 +36,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { TypographyH2, TypographyMuted } from "@/components/ui/typography";
+import { readApiResponseError } from "@/lib/api-error";
 import { apiClient } from "@/lib/api-client-instance";
 
 const suggestedRequests = [
@@ -104,8 +105,8 @@ export function ChatPageContent({ organizationSlug }: { organizationSlug: string
         param: { organizationSlug },
       });
 
-      if (response.status !== 200) {
-        throw new Error(`Failed to load projects (${response.status})`);
+      if (!response.ok) {
+        throw await readApiResponseError(response, "Failed to load projects");
       }
 
       const body = await response.json();

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-page-content.tsx
@@ -28,7 +28,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { Textarea } from "@/components/ui/textarea";
-import { readApiError } from "@/lib/api-error";
+import { readApiError, readApiResponseError } from "@/lib/api-error";
 import { apiClient } from "@/lib/api-client-instance";
 import { isTmsProviderShellModeEnabled } from "@/lib/providers/tms-provider-shell-mode";
 
@@ -254,8 +254,8 @@ export function GlossariesPageContent({
         param: { organizationSlug },
       });
 
-      if (response.status !== 200) {
-        throw new Error(`Failed to load projects (${response.status})`);
+      if (!response.ok) {
+        throw await readApiResponseError(response, "Failed to load projects");
       }
 
       const body = await response.json();

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
@@ -28,6 +28,10 @@ import { mapProjectToListRow, type ProjectListRow } from "./project-list";
 import { ProjectsTable } from "./projects-table";
 
 const projectQueryKey = (organizationSlug: string) => ["translation-projects", organizationSlug];
+const tmsConnectionQueryKey = (organizationSlug: string) => [
+  "tms-provider-connection",
+  organizationSlug,
+];
 
 function useProjectSearch(projects: ProjectListRow[]) {
   const [searchQuery, setSearchQuery] = useState("");
@@ -68,6 +72,28 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
 
       const body = await response.json();
       return body.projects.map(mapProjectToListRow);
+    },
+  });
+  const tmsConnectionQuery = useQuery({
+    queryKey: tmsConnectionQueryKey(organizationSlug),
+    enabled: projectsQuery.isSuccess && (projectsQuery.data ?? []).length === 0,
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"][
+        "tms-provider"
+      ].connection.$get({
+        param: { organizationSlug },
+      });
+
+      if (response.status === 404) {
+        return null;
+      }
+
+      if (response.status !== 200) {
+        throw await readApiResponseError(response, "Failed to load TMS provider connection");
+      }
+
+      const body = await response.json();
+      return body.connection;
     },
   });
   const createProject = useMutation({
@@ -134,6 +160,30 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
       await queryClient.invalidateQueries({ queryKey: projectQueryKey(organizationSlug) });
       setDeleteProject(null);
       toast.success("Project deleted");
+    },
+    onError: (error) => {
+      toast.error(error.message);
+    },
+  });
+  const syncProviderProjects = useMutation({
+    mutationFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"][
+        "tms-provider"
+      ].projects.sync.$post({
+        param: { organizationSlug },
+      });
+
+      if (response.status !== 202) {
+        throw await readApiResponseError(response, "Unable to sync provider projects");
+      }
+
+      return response.json();
+    },
+    onSuccess: async (body) => {
+      await queryClient.invalidateQueries({ queryKey: projectQueryKey(organizationSlug) });
+      toast.success(
+        body.providerProjectSync.created ? "Project sync queued" : "Project sync is already queued",
+      );
     },
     onError: (error) => {
       toast.error(error.message);
@@ -241,7 +291,11 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
           projectsQuery={projectsQuery}
           isSavingProject={isSavingProject}
           isDeletingProject={deleteProjectMutation.isPending}
+          hasActiveTmsConnection={Boolean(tmsConnectionQuery.data)}
+          isCheckingTmsConnection={tmsConnectionQuery.isLoading}
+          isSyncingProviderProjects={syncProviderProjects.isPending}
           organizationSlug={organizationSlug}
+          onSyncProviderProjects={syncProviderProjects.mutate}
           onEditProject={openEditProjectDialog}
           onDeleteProject={setDeleteProject}
         />

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/_components/projects-table.tsx
@@ -5,6 +5,7 @@ import {
   ArrowRight01Icon,
   Alert02Icon,
   CheckmarkCircle02Icon,
+  DatabaseSyncIcon,
   TranslationIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -14,6 +15,7 @@ import { TmsUserConnectionErrorPanel } from "@/components/app-shell/tms-user-con
 import { isTmsUserConnectionRequiredError } from "@/lib/providers/tms-user-connection-shared";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 import type { ProjectListRow } from "./project-list";
@@ -121,7 +123,11 @@ export function ProjectsTable({
   projectsQuery,
   isSavingProject,
   isDeletingProject,
+  hasActiveTmsConnection,
+  isCheckingTmsConnection,
+  isSyncingProviderProjects,
   organizationSlug,
+  onSyncProviderProjects,
   onEditProject,
   onDeleteProject,
 }: {
@@ -129,7 +135,11 @@ export function ProjectsTable({
   projectsQuery: UseQueryResult<ProjectListRow[], Error>;
   isSavingProject: boolean;
   isDeletingProject: boolean;
+  hasActiveTmsConnection: boolean;
+  isCheckingTmsConnection: boolean;
+  isSyncingProviderProjects: boolean;
   organizationSlug: string;
+  onSyncProviderProjects: () => void;
   onEditProject: (project: ProjectListRow) => void;
   onDeleteProject: (project: ProjectListRow) => void;
 }) {
@@ -164,21 +174,58 @@ export function ProjectsTable({
       ) : null}
       {projectsQuery.isSuccess && projects.length === 0 ? (
         <div className="max-w-xl space-y-3 py-10">
-          <TypographyP className="text-sm font-medium text-foreground">
-            Create your first localization project
-          </TypographyP>
-          <TypographyP className="text-sm leading-6 text-foreground/52">
-            Track source content, release ownership, and translation context before work moves into
-            translation jobs. Or connect a TMS provider to import existing projects.
-          </TypographyP>
-          <Button
-            nativeButton={false}
-            render={<Link href={`/org/${organizationSlug}/integrations`} />}
-            variant="outline"
-            size="sm"
-          >
-            Connect a provider
-          </Button>
+          {isCheckingTmsConnection ? (
+            <>
+              <TypographyP className="text-sm font-medium text-foreground">
+                Checking TMS connection
+              </TypographyP>
+              <TypographyP className="text-sm leading-6 text-foreground/52">
+                Looking for an active provider connection before showing project setup actions.
+              </TypographyP>
+            </>
+          ) : hasActiveTmsConnection ? (
+            <>
+              <TypographyP className="text-sm font-medium text-foreground">
+                No synced projects yet
+              </TypographyP>
+              <TypographyP className="text-sm leading-6 text-foreground/52">
+                Your TMS connection is active, but no projects have been imported yet. Run a sync to
+                check for available projects.
+              </TypographyP>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={onSyncProviderProjects}
+                disabled={isSyncingProviderProjects}
+              >
+                {isSyncingProviderProjects ? (
+                  <Spinner className="size-3.5" />
+                ) : (
+                  <HugeiconsIcon icon={DatabaseSyncIcon} strokeWidth={1.8} />
+                )}
+                Sync now
+              </Button>
+            </>
+          ) : (
+            <>
+              <TypographyP className="text-sm font-medium text-foreground">
+                Create your first localization project
+              </TypographyP>
+              <TypographyP className="text-sm leading-6 text-foreground/52">
+                Track source content, release ownership, and translation context before work moves
+                into translation jobs. Or connect a TMS provider to import existing projects.
+              </TypographyP>
+              <Button
+                nativeButton={false}
+                render={<Link href={`/org/${organizationSlug}/integrations`} />}
+                variant="outline"
+                size="sm"
+              >
+                Connect a provider
+              </Button>
+            </>
+          )}
         </div>
       ) : null}
       {projectsQuery.isSuccess && projects.length > 0 ? (

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-page-content.tsx
@@ -27,7 +27,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { Textarea } from "@/components/ui/textarea";
-import { readApiError } from "@/lib/api-error";
+import { readApiError, readApiResponseError } from "@/lib/api-error";
 import { apiClient } from "@/lib/api-client-instance";
 import { isTmsProviderShellModeEnabled } from "@/lib/providers/tms-provider-shell-mode";
 
@@ -179,8 +179,8 @@ export function TranslationMemoriesPageContent({
         param: { organizationSlug },
       });
 
-      if (response.status !== 200) {
-        throw new Error(`Failed to load projects (${response.status})`);
+      if (!response.ok) {
+        throw await readApiResponseError(response, "Failed to load projects");
       }
 
       const body = await response.json();

--- a/apps/hyperlocalise-web/src/lib/providers/provider-sync-executor.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-sync-executor.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const { dbInsertMock, dbSelectMock, dbUpdateMock, listTmsProviderLiveProjectsMock } = vi.hoisted(
+  () => ({
+    dbInsertMock: vi.fn(),
+    dbSelectMock: vi.fn(),
+    dbUpdateMock: vi.fn(),
+    listTmsProviderLiveProjectsMock: vi.fn(),
+  }),
+);
+
+vi.mock("@/lib/database", () => ({
+  db: {
+    insert: dbInsertMock,
+    select: dbSelectMock,
+    update: dbUpdateMock,
+  },
+  schema: {
+    organizationExternalTmsProviderCredentials: {
+      id: "credential_id",
+      createdByUserId: "created_by_user_id",
+      updatedByUserId: "updated_by_user_id",
+    },
+    providerSyncRuns: {
+      id: "id",
+    },
+  },
+}));
+
+vi.mock("@/lib/providers/tms-provider-live", () => ({
+  getTmsProviderLiveProject: vi.fn(),
+  listTmsProviderLiveProjects: listTmsProviderLiveProjectsMock,
+}));
+
+vi.mock("@/lib/projects/upsert-external-tms-project-record", () => ({
+  upsertExternalTmsProjectRecord: vi.fn(),
+}));
+
+import { isOk } from "@/lib/primitives/result/results";
+import { executeProviderSyncIntent } from "./provider-sync-executor";
+
+type ProviderSyncIntentInput = Parameters<typeof executeProviderSyncIntent>[0];
+
+function createCatalogIntent(): ProviderSyncIntentInput {
+  return {
+    id: "intent_123",
+    organizationId: "org_123",
+    providerCredentialId: "credential_123",
+    providerKind: "crowdin",
+    projectId: null,
+    syncKind: "project_scan",
+    resourceId: null,
+    resourceIds: [],
+    cause: "manual",
+    eventReferences: [],
+    priority: 20,
+    status: "pending",
+    attempts: 0,
+    maxAttempts: 5,
+    leaseKey: "org_123:crowdin:project_scan::",
+    leasedUntil: null,
+    leasedBy: null,
+    leaseToken: null,
+    nextAttemptAt: null,
+    providerSyncRunId: null,
+    lastError: null,
+    errorDetails: {},
+    createdAt: new Date("2026-06-14T00:00:00.000Z"),
+    updatedAt: new Date("2026-06-14T00:00:00.000Z"),
+    completedAt: null,
+  };
+}
+
+describe("executeProviderSyncIntent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    dbInsertMock.mockReturnValue({
+      values: vi.fn(() => ({
+        returning: vi.fn(async () => [{ id: "run_123" }]),
+      })),
+    });
+    dbUpdateMock.mockReturnValue({
+      set: vi.fn(() => ({
+        where: vi.fn(async () => {}),
+      })),
+    });
+    dbSelectMock.mockReturnValue({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(async () => [
+            {
+              createdByUserId: "user_created",
+              updatedByUserId: "user_updated",
+            },
+          ]),
+        })),
+      })),
+    });
+    listTmsProviderLiveProjectsMock.mockResolvedValue([]);
+  });
+
+  it("uses the credential user when executing a catalog project scan", async () => {
+    const result = await executeProviderSyncIntent(createCatalogIntent());
+
+    expect(isOk(result)).toBe(true);
+    expect(listTmsProviderLiveProjectsMock).toHaveBeenCalledWith("org_123", {
+      actorUserId: "user_updated",
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/provider-sync-executor.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-sync-executor.test.ts
@@ -71,6 +71,19 @@ function createCatalogIntent(): ProviderSyncIntentInput {
   };
 }
 
+function mockCredentialActor(input: {
+  createdByUserId: string | null;
+  updatedByUserId: string | null;
+}) {
+  dbSelectMock.mockReturnValue({
+    from: vi.fn(() => ({
+      where: vi.fn(() => ({
+        limit: vi.fn(async () => [input]),
+      })),
+    })),
+  });
+}
+
 describe("executeProviderSyncIntent", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -85,17 +98,9 @@ describe("executeProviderSyncIntent", () => {
         where: vi.fn(async () => {}),
       })),
     });
-    dbSelectMock.mockReturnValue({
-      from: vi.fn(() => ({
-        where: vi.fn(() => ({
-          limit: vi.fn(async () => [
-            {
-              createdByUserId: "user_created",
-              updatedByUserId: "user_updated",
-            },
-          ]),
-        })),
-      })),
+    mockCredentialActor({
+      createdByUserId: "user_created",
+      updatedByUserId: "user_updated",
     });
     listTmsProviderLiveProjectsMock.mockResolvedValue([]);
   });
@@ -106,6 +111,20 @@ describe("executeProviderSyncIntent", () => {
     expect(isOk(result)).toBe(true);
     expect(listTmsProviderLiveProjectsMock).toHaveBeenCalledWith("org_123", {
       actorUserId: "user_updated",
+    });
+  });
+
+  it("falls back to the credential creator when the updater is missing", async () => {
+    mockCredentialActor({
+      createdByUserId: "user_created",
+      updatedByUserId: null,
+    });
+
+    const result = await executeProviderSyncIntent(createCatalogIntent());
+
+    expect(isOk(result)).toBe(true);
+    expect(listTmsProviderLiveProjectsMock).toHaveBeenCalledWith("org_123", {
+      actorUserId: "user_created",
     });
   });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/provider-sync-executor.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-sync-executor.ts
@@ -58,6 +58,23 @@ async function startProviderSyncRun(intent: ProviderSyncIntentRow) {
   return run.id;
 }
 
+async function resolveProviderSyncActorUserId(intent: ProviderSyncIntentRow) {
+  if (!intent.providerCredentialId) {
+    return null;
+  }
+
+  const [credential] = await db
+    .select({
+      createdByUserId: schema.organizationExternalTmsProviderCredentials.createdByUserId,
+      updatedByUserId: schema.organizationExternalTmsProviderCredentials.updatedByUserId,
+    })
+    .from(schema.organizationExternalTmsProviderCredentials)
+    .where(eq(schema.organizationExternalTmsProviderCredentials.id, intent.providerCredentialId))
+    .limit(1);
+
+  return credential?.updatedByUserId ?? credential?.createdByUserId ?? null;
+}
+
 async function refreshMaterializedProjectFromLive(
   intent: ProviderSyncIntentRow,
 ): Promise<Result<{ runId: string }, ProviderSyncExecutionError>> {
@@ -77,9 +94,11 @@ async function refreshMaterializedProjectFromLive(
   }
 
   const runId = await startProviderSyncRun(intent);
+  const actorUserId = await resolveProviderSyncActorUserId(intent);
   const liveProject = await getTmsProviderLiveProject(
     intent.organizationId,
     encodedProject.externalProjectId,
+    { actorUserId },
   );
 
   if (!liveProject) {
@@ -120,7 +139,8 @@ async function syncProjectCatalogFromLive(
   }
 
   const runId = await startProviderSyncRun(intent);
-  const liveProjects = await listTmsProviderLiveProjects(intent.organizationId);
+  const actorUserId = await resolveProviderSyncActorUserId(intent);
+  const liveProjects = await listTmsProviderLiveProjects(intent.organizationId, { actorUserId });
   let syncedCount = 0;
 
   for (const liveProject of liveProjects) {


### PR DESCRIPTION
## What changed

- Show a connected-provider empty state on Projects when no projects have been synced yet, with a `Sync now` action instead of `Connect a provider`.
- Add a manual TMS project sync endpoint that queues a provider `project_scan`.
- Execute provider project syncs with the credential actor user so Crowdin OAuth scans do not fail as disconnected.
- Add regression coverage for manual project sync queuing and provider sync actor resolution.

## How to test

- `vp test src/lib/providers/provider-sync-executor.test.ts src/api/routes/tms-provider/tms-provider.route.test.ts`
- `vp check --fix`
  - Passed with 3 existing unrelated warnings in project-loading error branches.
- `vp test`
- `git diff --check`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review