### PR TITLE
feat(web): enable agent file translation on TMS and native jobs

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.ts
@@ -1121,6 +1121,135 @@ export function createWorkspaceJobRoutes(options: CreateWorkspaceJobRoutesOption
         return badRequestResponse(c, "provider_qa_failed", message);
       }
     })
+    .post("/:jobId/run-agent", validateWorkspaceJobParams, async (c) => {
+      if (!isAiActionAllowed(c.var.auth.membership.role)) {
+        return forbiddenResponse(c);
+      }
+
+      const params = c.req.valid("param");
+      const [job] = await db
+        .select({
+          id: schema.jobs.id,
+          projectId: schema.jobs.projectId,
+          kind: schema.jobs.kind,
+          type: schema.translationJobDetails.type,
+          status: schema.jobs.status,
+          externalProviderKind: schema.externalJobDetails.providerKind,
+        })
+        .from(schema.jobs)
+        .leftJoin(
+          schema.translationJobDetails,
+          eq(schema.translationJobDetails.jobId, schema.jobs.id),
+        )
+        .leftJoin(schema.externalJobDetails, eq(schema.externalJobDetails.jobId, schema.jobs.id))
+        .where(and(eq(schema.jobs.id, params.jobId), await buildAccessibleJobsWhere(c.var.auth)))
+        .limit(1);
+
+      if (!job) {
+        return notFoundResponse(c, "job_not_found", "Job not found");
+      }
+
+      if (job.externalProviderKind) {
+        return conflictResponse(
+          c,
+          "native_job_required",
+          "Use agent runs for provider-backed jobs",
+        );
+      }
+
+      if (job.kind !== "translation" || job.type !== "file" || !job.projectId) {
+        return conflictResponse(
+          c,
+          "file_translation_job_required",
+          "Agent runs are only available for native file translation jobs",
+        );
+      }
+
+      if (job.status === "running" || job.status === "queued") {
+        return conflictResponse(c, "job_already_running", "Job is already queued or running");
+      }
+
+      const projectId = job.projectId;
+      const type = job.type;
+
+      const restartedJob = await db.transaction(async (tx) => {
+        const [updatedJob] = await tx
+          .update(schema.jobs)
+          .set({
+            status: "queued",
+            workflowRunId: null,
+            lastError: null,
+            completedAt: null,
+          })
+          .where(
+            and(
+              eq(schema.jobs.id, params.jobId),
+              await buildAccessibleJobsWhere(c.var.auth),
+              or(eq(schema.jobs.status, "failed"), eq(schema.jobs.status, "succeeded")),
+            ),
+          )
+          .returning({ id: schema.jobs.id, projectId: schema.jobs.projectId });
+
+        if (!updatedJob) {
+          return null;
+        }
+
+        await tx
+          .update(schema.translationJobDetails)
+          .set({ outcomeKind: null })
+          .where(eq(schema.translationJobDetails.jobId, params.jobId));
+
+        return { id: updatedJob.id, projectId, type };
+      });
+
+      if (!restartedJob) {
+        return conflictResponse(c, "job_action_unavailable", "Job action is not available");
+      }
+
+      try {
+        const result = await options.jobQueue.enqueue({
+          kind: "translation",
+          jobId: restartedJob.id,
+          projectId: restartedJob.projectId,
+          type: restartedJob.type,
+        });
+
+        await db
+          .update(schema.jobs)
+          .set({ workflowRunId: result.ids[0] ?? null })
+          .where(eq(schema.jobs.id, restartedJob.id));
+      } catch (error) {
+        await db
+          .update(schema.jobs)
+          .set({
+            status: "failed",
+            lastError: error instanceof Error ? error.message : "translation job queue unavailable",
+            completedAt: new Date(),
+          })
+          .where(eq(schema.jobs.id, restartedJob.id));
+
+        return serviceUnavailableResponse(c, "job_queue_unavailable", "Job queue is unavailable");
+      }
+
+      const [updatedJob] = await db
+        .select(jobWithProjectSelect)
+        .from(schema.jobs)
+        .leftJoin(
+          schema.translationJobDetails,
+          eq(schema.translationJobDetails.jobId, schema.jobs.id),
+        )
+        .leftJoin(schema.reviewJobDetails, eq(schema.reviewJobDetails.jobId, schema.jobs.id))
+        .leftJoin(schema.syncJobDetails, eq(schema.syncJobDetails.jobId, schema.jobs.id))
+        .leftJoin(
+          schema.assetManagementJobDetails,
+          eq(schema.assetManagementJobDetails.jobId, schema.jobs.id),
+        )
+        .leftJoin(schema.externalJobDetails, eq(schema.externalJobDetails.jobId, schema.jobs.id))
+        .where(eq(schema.jobs.id, restartedJob.id))
+        .limit(1);
+
+      return c.json({ job: updatedJob ?? restartedJob }, 200);
+    })
     .post("/:jobId/retry", validateWorkspaceJobParams, async (c) => {
       if (!isJobMutationAllowed(c.var.auth.membership.role)) {
         return forbiddenResponse(c);

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-page-content.tsx
@@ -109,6 +109,30 @@ function NativeJobDetailPageContent({
     },
   });
 
+  const runAgentJob = useMutation({
+    mutationFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"].jobs[":jobId"][
+        "run-agent"
+      ].$post({
+        param: { organizationSlug, jobId },
+      });
+
+      if (!response.ok) {
+        throw new Error(await parseActionError(response, "Failed to start agent on job"));
+      }
+
+      await response.json();
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: jobQueryKey });
+      await queryClient.invalidateQueries({ queryKey: ["jobs", organizationSlug] });
+      toast.success("File translation agent queued");
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Failed to start agent on job");
+    },
+  });
+
   const retryJob = useMutation({
     mutationFn: async () => {
       const response = await apiClient.api.orgs[":organizationSlug"].jobs[":jobId"].retry.$post({
@@ -167,10 +191,12 @@ function NativeJobDetailPageContent({
       isLoading={jobQuery.isLoading}
       error={jobQuery.isError ? jobQuery.error : undefined}
       isRetryPending={retryJob.isPending}
+      isRunAgentPending={runAgentJob.isPending}
       isMarkFailedPending={markJobFailed.isPending}
       markFailedDialogOpen={markFailedDialogOpen}
       onMarkFailedDialogOpenChange={setMarkFailedDialogOpen}
       onRetry={() => retryJob.mutate()}
+      onRunAgent={() => runAgentJob.mutate()}
       onMarkFailed={() => markJobFailed.mutate()}
       renderProviderDetailSection={(props) => (
         <JobProviderDetailSection

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-types.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-types.ts
@@ -144,6 +144,15 @@ export function formatJobDetailDate(value: string | null | undefined) {
   return DATE_FORMATTER.format(date);
 }
 
+export function canRunAgentOnNativeFileJob(job: JobDetailRecord) {
+  return (
+    !isProviderBackedJob(job) &&
+    job.kind === "translation" &&
+    job.type === "file" &&
+    (job.status === "succeeded" || job.status === "failed")
+  );
+}
+
 export function canRetryJob(job: JobDetailRecord) {
   return job.kind === "translation" && (job.status === "queued" || job.status === "failed");
 }

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/native-job-detail-view.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/native-job-detail-view.tsx
@@ -2,7 +2,12 @@
 
 import { useState, type ReactNode } from "react";
 import Link from "next/link";
-import { ArrowLeft02Icon, RefreshIcon, StopCircleIcon } from "@hugeicons/core-free-icons";
+import {
+  ArrowLeft02Icon,
+  AiMagicIcon,
+  RefreshIcon,
+  StopCircleIcon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 
 import {
@@ -26,6 +31,7 @@ import {
   buildJobsListHref,
   canMarkJobFailed,
   canRetryJob,
+  canRunAgentOnNativeFileJob,
   formatJobDetailDate,
   formatJobDetailKind,
   isProviderBackedJob,
@@ -92,12 +98,14 @@ export function NativeJobDetailView({
   isLoading,
   isMarkFailedPending = false,
   isRetryPending = false,
+  isRunAgentPending = false,
   job,
   jobId,
   markFailedDialogOpen: controlledMarkFailedDialogOpen,
   onMarkFailed,
   onMarkFailedDialogOpenChange,
   onRetry,
+  onRunAgent,
   organizationSlug,
   projectId,
   renderBackLink = defaultRenderBackLink,
@@ -109,12 +117,14 @@ export function NativeJobDetailView({
   isLoading: boolean;
   isMarkFailedPending?: boolean;
   isRetryPending?: boolean;
+  isRunAgentPending?: boolean;
   job?: JobDetailRecord;
   jobId: string;
   markFailedDialogOpen?: boolean;
   onMarkFailed?: () => void;
   onMarkFailedDialogOpenChange?: (open: boolean) => void;
   onRetry?: () => void;
+  onRunAgent?: () => void;
   organizationSlug: string;
   projectId: string;
   renderBackLink?: JobDetailBackLinkRenderer;
@@ -126,7 +136,9 @@ export function NativeJobDetailView({
   const setMarkFailedDialogOpen =
     onMarkFailedDialogOpenChange ?? setUncontrolledMarkFailedDialogOpen;
 
-  const showActions = job ? canRetryJob(job) || canMarkJobFailed(job) : false;
+  const showActions = job
+    ? canRetryJob(job) || canMarkJobFailed(job) || canRunAgentOnNativeFileJob(job)
+    : false;
   const jobsListHref = buildJobsListHrefProp(organizationSlug, projectId);
 
   return (
@@ -151,6 +163,16 @@ export function NativeJobDetailView({
             </Badge>
             {showActions ? (
               <div className="flex flex-wrap gap-2 sm:justify-end">
+                {canRunAgentOnNativeFileJob(job) && onRunAgent ? (
+                  <Button
+                    size="sm"
+                    disabled={isRunAgentPending || isRetryPending || isMarkFailedPending}
+                    onClick={onRunAgent}
+                  >
+                    <HugeiconsIcon icon={AiMagicIcon} strokeWidth={1.8} />
+                    {isRunAgentPending ? "Starting agent..." : "Translate with agent"}
+                  </Button>
+                ) : null}
                 {canRetryJob(job) && onRetry ? (
                   <Button
                     size="sm"

--- a/apps/hyperlocalise-web/src/lib/projects/upsert-external-tms-job-records.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/upsert-external-tms-job-records.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 
 import { db, schema } from "@/lib/database";
 import type { ExternalTmsProviderKind } from "@/lib/providers/organization-external-tms-provider-credentials";
@@ -39,6 +39,23 @@ export async function upsertExternalTmsJobRecords(input: {
 }) {
   const now = new Date();
   let upserted = 0;
+  const newlySyncedJobIds: string[] = [];
+
+  const candidateJobIds = input.tasks.map((task) =>
+    encodeProviderJobId({
+      providerKind: input.providerKind,
+      externalProjectId: input.externalProjectId,
+      externalJobId: task.externalJobId,
+    }),
+  );
+  const existingJobRows =
+    candidateJobIds.length > 0
+      ? await db
+          .select({ id: schema.jobs.id })
+          .from(schema.jobs)
+          .where(inArray(schema.jobs.id, candidateJobIds))
+      : [];
+  const existingJobIds = new Set(existingJobRows.map((row) => row.id));
 
   for (const task of input.tasks) {
     const jobId = encodeProviderJobId({
@@ -46,6 +63,7 @@ export async function upsertExternalTmsJobRecords(input: {
       externalProjectId: input.externalProjectId,
       externalJobId: task.externalJobId,
     });
+    const isNewlySynced = !existingJobIds.has(jobId);
     const status = mapProviderStatusToNormalized(input.providerKind, task.externalStatus);
     const completedAt =
       status === "succeeded" || status === "failed" ? normalizeDate(task.completedAt) : null;
@@ -122,6 +140,9 @@ export async function upsertExternalTmsJobRecords(input: {
     });
 
     upserted += 1;
+    if (isNewlySynced) {
+      newlySyncedJobIds.push(jobId);
+    }
   }
 
   if (upserted > 0) {
@@ -139,5 +160,5 @@ export async function upsertExternalTmsJobRecords(input: {
       );
   }
 
-  return { upserted };
+  return { upserted, newlySyncedJobIds };
 }

--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.ts
@@ -1,0 +1,473 @@
+import {
+  detectAgentRunProposalWarnings,
+  deriveChangedFields,
+  buildAgentRunProposalItemId,
+  serializeAgentRunProposalItem,
+  type AgentRunProposalItem,
+} from "@/lib/providers/agent-runs/agent-run-proposals";
+import { downloadProviderSourceFile } from "@/lib/providers/download-provider-source-file";
+import type {
+  ExternalTmsTaskContent,
+  ExternalTmsTranslationUnit,
+} from "@/lib/providers/tms-provider-types";
+import {
+  sourceContainsTerm,
+  validateGlossaryTermsInTranslation,
+} from "@/lib/glossary/validate-glossary-terms-in-translation";
+import { reuseFileTranslationMemoryEntries } from "@/lib/translation/file-translation-memory";
+import type { SandboxTranslationContext } from "@/lib/translation/sandbox-translation";
+import type { ExternalTmsProviderKind } from "@/lib/providers/organization-external-tms-provider-credentials";
+import { loadTranslationContextProject } from "@/lib/translation/assemble-translation-context";
+
+type ProviderSourceFileRef = {
+  id: string;
+  displayName: string;
+  sourcePath: string | null;
+};
+
+async function loadFileGlossaryTerms(input: {
+  projectId: string;
+  sourceLocale: string;
+  targetLocales: string[];
+  sourceText: string;
+}) {
+  const { and, asc, eq, inArray } = await import("drizzle-orm");
+  const { db, schema } = await import("@/lib/database");
+
+  const attachedTerms = await db
+    .select({
+      sourceTerm: schema.glossaryTerms.sourceTerm,
+      targetTerm: schema.glossaryTerms.targetTerm,
+      targetLocale: schema.glossaries.targetLocale,
+      description: schema.glossaryTerms.description,
+      forbidden: schema.glossaryTerms.forbidden,
+      caseSensitive: schema.glossaryTerms.caseSensitive,
+      priority: schema.projectGlossaries.priority,
+    })
+    .from(schema.projectGlossaries)
+    .innerJoin(schema.glossaries, eq(schema.glossaries.id, schema.projectGlossaries.glossaryId))
+    .innerJoin(schema.glossaryTerms, eq(schema.glossaryTerms.glossaryId, schema.glossaries.id))
+    .where(
+      and(
+        eq(schema.projectGlossaries.projectId, input.projectId),
+        eq(schema.glossaries.sourceLocale, input.sourceLocale),
+        inArray(schema.glossaries.targetLocale, input.targetLocales),
+        eq(schema.glossaries.status, "active"),
+        eq(schema.glossaryTerms.reviewStatus, "approved"),
+      ),
+    )
+    .orderBy(asc(schema.projectGlossaries.priority), asc(schema.glossaryTerms.sourceTerm))
+    .limit(500);
+
+  return attachedTerms
+    .filter((term) => sourceContainsTerm(input.sourceText, term))
+    .slice(0, 50)
+    .map(({ sourceTerm, targetTerm, targetLocale, description, forbidden, caseSensitive }) => ({
+      sourceTerm,
+      targetTerm,
+      targetLocale,
+      description,
+      forbidden,
+      caseSensitive,
+    }));
+}
+
+export type ProviderAgentFileTranslationResult = {
+  changedItems: AgentRunProposalItem[];
+  warnings: string[];
+  unitsProcessed: number;
+  skippedExistingLocales: number;
+  filesProcessed: number;
+};
+
+function shellSingleQuote(value: string) {
+  return value.replaceAll("'", "'\\''");
+}
+
+function sanitizeSandboxFilename(filename: string): string {
+  return filename.replace(/[^a-zA-Z0-9._-]/g, "_");
+}
+
+function getSandboxOutputFilename(attachmentFilename: string, targetLocale: string): string {
+  const inputFilename = sanitizeSandboxFilename(attachmentFilename);
+  const lastDot = inputFilename.lastIndexOf(".");
+  if (lastDot === -1) {
+    return `${inputFilename}-${targetLocale}`;
+  }
+
+  const name = inputFilename.slice(0, lastDot);
+  const ext = inputFilename.slice(lastDot);
+  return `${name}-${targetLocale}${ext}`;
+}
+
+function existingTranslationForLocale(unit: ExternalTmsTranslationUnit, locale: string) {
+  return unit.translations.find((translation) => translation.locale === locale) ?? null;
+}
+
+function shouldSkipExistingTranslation(
+  translation: ExternalTmsTranslationUnit["translations"][number] | null,
+) {
+  return Boolean(translation?.text?.trim());
+}
+
+function unitsForFile(units: ExternalTmsTranslationUnit[], externalFileId: string) {
+  return units.filter((unit) => unit.fileId === externalFileId);
+}
+
+function buildPrefilledEntriesForLocale(input: {
+  units: ExternalTmsTranslationUnit[];
+  targetLocale: string;
+}) {
+  const prefilled: Record<string, string> = {};
+  for (const unit of input.units) {
+    const existing = existingTranslationForLocale(unit, input.targetLocale);
+    if (!existing?.text?.trim()) {
+      continue;
+    }
+    prefilled[unit.key] = existing.text;
+  }
+  return prefilled;
+}
+
+function buildGlossaryContext(input: {
+  sourceText: string;
+  projectName: string;
+  projectTranslationContext: string;
+  glossaryTerms: SandboxTranslationContext["glossaryTerms"];
+  targetLocale: string;
+}): SandboxTranslationContext {
+  const attachedTerms = (input.glossaryTerms ?? []).filter((term) =>
+    sourceContainsTerm(input.sourceText, {
+      sourceTerm: term.sourceTerm,
+      caseSensitive: term.caseSensitive ?? false,
+    }),
+  );
+
+  return {
+    projectName: input.projectName,
+    projectTranslationContext: input.projectTranslationContext,
+    glossaryTerms: attachedTerms
+      .filter((term) => term.targetLocale === input.targetLocale)
+      .slice(0, 50),
+  };
+}
+
+async function runFileTranslationInSandbox(input: {
+  sourceContent: Buffer;
+  sourceFilename: string;
+  sourceLocale: string;
+  targetLocale: string;
+  context: SandboxTranslationContext;
+  prefilledEntries: Record<string, string>;
+}) {
+  const {
+    buildTempConfig,
+    createTranslationSandbox,
+    getSandboxTranslationEnv,
+    prepareSandbox,
+    readTranslatedFile,
+    runSandboxCommand,
+    stopTranslationSandbox,
+    writeFileToSandbox,
+    writeTempConfig,
+  } = await import("@/lib/translation/sandbox-translation");
+
+  const inputFilename = sanitizeSandboxFilename(input.sourceFilename);
+  const outputFilename = getSandboxOutputFilename(input.sourceFilename, input.targetLocale);
+  const { sandboxId } = await createTranslationSandbox();
+
+  try {
+    await prepareSandbox(sandboxId);
+    await writeFileToSandbox(sandboxId, inputFilename, input.sourceContent);
+
+    const configPath = "/tmp/hyperlocalise-file.yml";
+    const config = buildTempConfig(
+      inputFilename,
+      outputFilename,
+      input.sourceLocale,
+      input.targetLocale,
+      null,
+      input.context,
+    );
+    await writeTempConfig(sandboxId, config, configPath);
+
+    const prefilledPath = `/tmp/hyperlocalise-prefilled-${input.targetLocale}.json`;
+    let prefilledFlags = "";
+    if (Object.keys(input.prefilledEntries).length > 0) {
+      await writeFileToSandbox(
+        sandboxId,
+        prefilledPath,
+        Buffer.from(JSON.stringify(input.prefilledEntries), "utf8"),
+      );
+      prefilledFlags = ` --prefilled-entries '${shellSingleQuote(prefilledPath)}' --prefilled-target-path '${shellSingleQuote(outputFilename)}'`;
+    }
+
+    const translation = await runSandboxCommand(
+      sandboxId,
+      "bash",
+      [
+        "-lc",
+        `export PATH="$HOME/.local/bin:$PATH"; hl run --config '${shellSingleQuote(configPath)}' --locale '${shellSingleQuote(input.targetLocale)}' --force --progress off${prefilledFlags}`,
+      ],
+      { env: getSandboxTranslationEnv() },
+    );
+
+    if (translation.exitCode !== 0) {
+      throw new Error(`translation failed for ${input.targetLocale}: ${translation.output}`);
+    }
+
+    const translatedContent = await readTranslatedFile(sandboxId, outputFilename);
+    const extractResult = await runSandboxCommand(
+      sandboxId,
+      "bash",
+      [
+        "-lc",
+        `export PATH="$HOME/.local/bin:$PATH"; hl entries '${shellSingleQuote(outputFilename)}'`,
+      ],
+      { env: getSandboxTranslationEnv(), output: "stdout" },
+    );
+    if (extractResult.exitCode !== 0) {
+      throw new Error(`failed to extract translated entries: ${extractResult.output}`);
+    }
+
+    return {
+      translatedText: translatedContent.toString("utf8"),
+      translatedEntries: JSON.parse(extractResult.output) as Record<string, string>,
+    };
+  } finally {
+    await stopTranslationSandbox(sandboxId);
+  }
+}
+
+export function shouldUseProviderFileTranslation(input: { sourceFiles: ProviderSourceFileRef[] }) {
+  return input.sourceFiles.some((file) => Boolean(file.sourcePath?.trim()));
+}
+
+export async function translateProviderJobFiles(input: {
+  organizationId: string;
+  projectId: string;
+  providerKind: ExternalTmsProviderKind;
+  content: ExternalTmsTaskContent;
+  sourceFiles: ProviderSourceFileRef[];
+  actorUserId?: string | null;
+  targetLocales?: string[];
+}): Promise<ProviderAgentFileTranslationResult> {
+  const project = await loadTranslationContextProject(input.projectId);
+  if (!project) {
+    return {
+      changedItems: [],
+      warnings: [`Translation project ${input.projectId} was not found`],
+      unitsProcessed: 0,
+      skippedExistingLocales: 0,
+      filesProcessed: 0,
+    };
+  }
+
+  const sourceLocale = input.content.sourceLocale ?? "en";
+  const targetLocales =
+    input.targetLocales && input.targetLocales.length > 0
+      ? input.content.targetLocales.filter((locale) => input.targetLocales!.includes(locale))
+      : input.content.targetLocales;
+
+  const changedItems: AgentRunProposalItem[] = [];
+  const warnings: string[] = [];
+  let unitsProcessed = 0;
+  let skippedExistingLocales = 0;
+  let filesProcessed = 0;
+
+  for (const sourceFile of input.sourceFiles) {
+    if (!sourceFile.sourcePath?.trim()) {
+      continue;
+    }
+
+    const fileUnits = unitsForFile(input.content.units, sourceFile.id);
+    if (fileUnits.length === 0) {
+      continue;
+    }
+
+    const download = await downloadProviderSourceFile({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      providerKind: input.providerKind,
+      externalFileId: sourceFile.id,
+      sourcePath: sourceFile.sourcePath,
+      actorUserId: input.actorUserId,
+    });
+
+    if (!download.ok) {
+      warnings.push(`Skipped file ${sourceFile.displayName ?? sourceFile.id}: ${download.message}`);
+      continue;
+    }
+
+    filesProcessed += 1;
+    const sourceText = download.content.toString("utf8");
+    const fileGlossaryTerms = await loadFileGlossaryTerms({
+      projectId: input.projectId,
+      sourceLocale,
+      targetLocales,
+      sourceText,
+    });
+
+    let sourceEntries: Record<string, string> | null = null;
+    try {
+      const {
+        createTranslationSandbox,
+        prepareSandbox,
+        runSandboxCommand,
+        stopTranslationSandbox,
+        writeFileToSandbox,
+        getSandboxTranslationEnv,
+      } = await import("@/lib/translation/sandbox-translation");
+      const inputFilename = sanitizeSandboxFilename(download.filename);
+      const { sandboxId } = await createTranslationSandbox();
+      try {
+        await prepareSandbox(sandboxId);
+        await writeFileToSandbox(sandboxId, inputFilename, download.content);
+        const extractResult = await runSandboxCommand(
+          sandboxId,
+          "bash",
+          [
+            "-lc",
+            `export PATH="$HOME/.local/bin:$PATH"; hl entries '${shellSingleQuote(inputFilename)}'`,
+          ],
+          { env: getSandboxTranslationEnv(), output: "stdout" },
+        );
+        if (extractResult.exitCode === 0) {
+          sourceEntries = JSON.parse(extractResult.output) as Record<string, string>;
+        }
+      } finally {
+        await stopTranslationSandbox(sandboxId);
+      }
+    } catch (error) {
+      warnings.push(
+        `Could not extract entries for ${sourceFile.displayName ?? sourceFile.id}: ${
+          error instanceof Error ? error.message : "unknown error"
+        }`,
+      );
+    }
+
+    for (const targetLocale of targetLocales) {
+      const localesNeedingTranslation = fileUnits.filter((unit) => {
+        const existing = existingTranslationForLocale(unit, targetLocale);
+        if (shouldSkipExistingTranslation(existing)) {
+          skippedExistingLocales += 1;
+          return false;
+        }
+        return true;
+      });
+      unitsProcessed += localesNeedingTranslation.length;
+
+      if (localesNeedingTranslation.length === 0) {
+        continue;
+      }
+
+      const existingPrefilled = buildPrefilledEntriesForLocale({
+        units: fileUnits,
+        targetLocale,
+      });
+      let tmPrefilled: Record<string, string> = {};
+      if (sourceEntries) {
+        tmPrefilled = await reuseFileTranslationMemoryEntries({
+          projectId: input.projectId,
+          sourceLocale,
+          targetLocale,
+          sourceEntries,
+        });
+      }
+      const prefilledEntries = { ...tmPrefilled, ...existingPrefilled };
+
+      const localeContext = buildGlossaryContext({
+        sourceText,
+        projectName: project.name,
+        projectTranslationContext: project.translationContext,
+        glossaryTerms: fileGlossaryTerms,
+        targetLocale,
+      });
+
+      try {
+        const { translatedText, translatedEntries } = await runFileTranslationInSandbox({
+          sourceContent: download.content,
+          sourceFilename: download.filename,
+          sourceLocale,
+          targetLocale,
+          context: localeContext,
+          prefilledEntries,
+        });
+
+        const glossaryFailures = validateGlossaryTermsInTranslation({
+          sourceText,
+          translatedText,
+          terms: (localeContext.glossaryTerms ?? []).map((term) => ({
+            sourceTerm: term.sourceTerm,
+            targetTerm: term.targetTerm,
+            targetLocale: term.targetLocale,
+            forbidden: term.forbidden ?? null,
+            caseSensitive: term.caseSensitive ?? null,
+          })),
+        });
+        if (glossaryFailures.length > 0) {
+          warnings.push(
+            `Glossary validation failed for ${sourceFile.displayName ?? sourceFile.id} (${targetLocale})`,
+          );
+        }
+
+        for (const unit of localesNeedingTranslation) {
+          const existing = existingTranslationForLocale(unit, targetLocale);
+          const from = existing?.text ?? "";
+          const to = translatedEntries[unit.key] ?? from;
+          if (!to.trim() || to === from) {
+            continue;
+          }
+
+          const proposalWarnings = detectAgentRunProposalWarnings({
+            sourceText: unit.sourceText,
+            from,
+            to,
+            locale: targetLocale,
+            externalStringId: unit.externalStringId,
+            key: unit.key,
+            glossaryTerms: (localeContext.glossaryTerms ?? []).map((term) => ({
+              sourceTerm: term.sourceTerm,
+              targetTerm: term.targetTerm,
+              targetLocale: term.targetLocale,
+              forbidden: term.forbidden,
+              caseSensitive: term.caseSensitive,
+            })),
+          });
+
+          changedItems.push(
+            serializeAgentRunProposalItem({
+              itemId: buildAgentRunProposalItemId({
+                externalStringId: unit.externalStringId,
+                locale: targetLocale,
+              }),
+              externalStringId: unit.externalStringId,
+              key: unit.key,
+              locale: targetLocale,
+              sourceText: unit.sourceText,
+              from,
+              to,
+              reviewState: "pending",
+              changedFields: deriveChangedFields(from, to),
+              warnings: proposalWarnings,
+            }),
+          );
+        }
+      } catch (error) {
+        warnings.push(
+          `File translation failed for ${sourceFile.displayName ?? sourceFile.id} (${targetLocale}): ${
+            error instanceof Error ? error.message : "unknown error"
+          }`,
+        );
+      }
+    }
+  }
+
+  return {
+    changedItems,
+    warnings,
+    unitsProcessed,
+    skippedExistingLocales,
+    filesProcessed,
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-translate.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-translate.test.ts
@@ -144,7 +144,7 @@ describe("executeProviderAgentTranslation", () => {
       ok: true,
       proposedCount: 1,
       unitsProcessed: 2,
-      skippedApprovedLocales: 1,
+      skippedExistingLocales: 1,
       pullRunId: "pull-run-1",
     });
 
@@ -171,7 +171,7 @@ describe("executeProviderAgentTranslation", () => {
       pullRunId: "pull-run-1",
       proposedCount: 1,
       unitsProcessed: 2,
-      skippedApprovedLocales: 1,
+      skippedExistingLocales: 1,
     });
   });
 
@@ -405,7 +405,7 @@ describe("executeProviderAgentTranslation", () => {
         pullRunId: "pull-run-done",
         proposedCount: 2,
         unitsProcessed: 3,
-        skippedApprovedLocales: 1,
+        skippedExistingLocales: 1,
       },
     });
 
@@ -419,7 +419,7 @@ describe("executeProviderAgentTranslation", () => {
       alreadyCompleted: true,
       proposedCount: 2,
       unitsProcessed: 3,
-      skippedApprovedLocales: 1,
+      skippedExistingLocales: 1,
       pullRunId: "pull-run-done",
     });
     expect(pullExternalTmsTaskContentMock).not.toHaveBeenCalled();

--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-translate.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-translate.ts
@@ -17,6 +17,11 @@ import type {
   ExternalTmsTranslationUnit,
 } from "@/lib/providers/tms-provider-types";
 import { getProviderContentPuller } from "@/lib/providers/provider-content-pullers";
+import { resolveProviderSourceFiles } from "@/lib/providers/job-provider-source-files";
+import {
+  shouldUseProviderFileTranslation,
+  translateProviderJobFiles,
+} from "@/lib/providers/agent-runs/provider-agent-file-translate";
 import {
   assembleStringTranslationContextSnapshot,
   loadTranslationContextProject,
@@ -52,6 +57,17 @@ export type ProviderAgentTranslationResult =
 
 const defaultSourceLocale = "en";
 
+function readAutomationLocales(inputSnapshot: Record<string, unknown>): string[] | null {
+  const automationLocales = inputSnapshot.automationLocales;
+  if (!Array.isArray(automationLocales)) {
+    return null;
+  }
+
+  return automationLocales.filter(
+    (locale): locale is string => typeof locale === "string" && locale.trim().length > 0,
+  );
+}
+
 function readProjectIdFromInputSnapshot(inputSnapshot: Record<string, unknown>): string | null {
   const projectId = inputSnapshot.projectId;
   return typeof projectId === "string" && projectId.length > 0 ? projectId : null;
@@ -71,10 +87,10 @@ function existingTranslationForLocale(unit: ExternalTmsTranslationUnit, locale: 
   return unit.translations.find((translation) => translation.locale === locale) ?? null;
 }
 
-function shouldSkipApprovedTranslation(
+function shouldSkipExistingTranslation(
   translation: ExternalTmsTranslationUnit["translations"][number] | null,
 ) {
-  return translation?.isApproved === true;
+  return Boolean(translation?.text?.trim());
 }
 
 function buildJobInputForUnit(input: {
@@ -143,7 +159,7 @@ async function translateProviderUnits(input: {
     unitsProcessed += 1;
     const targetLocales = input.content.targetLocales.filter((locale) => {
       const existing = existingTranslationForLocale(unit, locale);
-      if (shouldSkipApprovedTranslation(existing)) {
+      if (shouldSkipExistingTranslation(existing)) {
         skippedApprovedLocales += 1;
         return false;
       }
@@ -456,6 +472,79 @@ export async function executeProviderAgentTranslation(input: {
     };
   }
 
+  const automationLocales = readAutomationLocales(run.inputSnapshot);
+  const filteredContent =
+    automationLocales && automationLocales.length > 0
+      ? {
+          ...pullResult.content,
+          targetLocales: pullResult.content.targetLocales.filter((locale) =>
+            automationLocales.includes(locale),
+          ),
+        }
+      : pullResult.content;
+
+  const [jobDetails] = run.hyperlocaliseJobId
+    ? await (async () => {
+        const { db, schema } = await import("@/lib/database");
+        const { eq } = await import("drizzle-orm");
+        return db
+          .select({
+            providerPayload: schema.externalJobDetails.providerPayload,
+          })
+          .from(schema.externalJobDetails)
+          .where(eq(schema.externalJobDetails.jobId, run.hyperlocaliseJobId!))
+          .limit(1);
+      })()
+    : [null];
+
+  const sourceFiles = jobDetails?.providerPayload
+    ? await resolveProviderSourceFiles({
+        organizationId: input.organizationId,
+        projectId,
+        providerKind: run.providerKind,
+        providerPayload: jobDetails.providerPayload,
+      })
+    : [];
+
+  if (shouldUseProviderFileTranslation({ sourceFiles })) {
+    const fileTranslationResult = await translateProviderJobFiles({
+      organizationId: input.organizationId,
+      projectId,
+      providerKind: run.providerKind,
+      content: filteredContent,
+      sourceFiles,
+      actorUserId: run.actorUserId,
+      targetLocales: automationLocales ?? undefined,
+    });
+
+    await completeAgentRun({
+      runId: run.id,
+      organizationId: input.organizationId,
+      outputSummary: {
+        pullRunId: pullResult.runId,
+        unitsDiscovered: pullResult.counts.unitsDiscovered,
+        unitsProcessed: fileTranslationResult.unitsProcessed,
+        proposedCount: fileTranslationResult.changedItems.length,
+        skippedApprovedLocales: fileTranslationResult.skippedExistingLocales,
+        filesProcessed: fileTranslationResult.filesProcessed,
+        translationMode: "file",
+        targetLocales: filteredContent.targetLocales,
+        sourceLocale: filteredContent.sourceLocale ?? defaultSourceLocale,
+      },
+      changedItems: fileTranslationResult.changedItems,
+      warnings: fileTranslationResult.warnings,
+    });
+
+    return {
+      ok: true,
+      agentRunId: input.agentRunId,
+      proposedCount: fileTranslationResult.changedItems.length,
+      unitsProcessed: fileTranslationResult.unitsProcessed,
+      skippedApprovedLocales: fileTranslationResult.skippedExistingLocales,
+      pullRunId: pullResult.runId,
+    };
+  }
+
   const organizationGenerator = await loadOrganizationTranslationGenerator(projectId);
 
   if (!organizationGenerator.ok && !input.translateStringJobOverride) {
@@ -505,7 +594,7 @@ export async function executeProviderAgentTranslation(input: {
     organizationId: input.organizationId,
     projectId,
     providerKind: run.providerKind,
-    content: pullResult.content,
+    content: filteredContent,
     translateStringJob,
     projectName: organizationGenerator.ok ? organizationGenerator.project.name : "Provider job",
     projectTranslationContext: organizationGenerator.ok
@@ -544,8 +633,8 @@ export async function executeProviderAgentTranslation(input: {
       unitsProcessed: translationResult.unitsProcessed,
       proposedCount: translationResult.changedItems.length,
       skippedApprovedLocales: translationResult.skippedApprovedLocales,
-      targetLocales: pullResult.content.targetLocales,
-      sourceLocale: pullResult.content.sourceLocale ?? defaultSourceLocale,
+      targetLocales: filteredContent.targetLocales,
+      sourceLocale: filteredContent.sourceLocale ?? defaultSourceLocale,
       translationMemoryUsage: translationResult.translationMemoryUsageByUnit,
       glossaryUsage: translationResult.glossaryUsageByUnit,
     },

--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-translate.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-translate.ts
@@ -44,7 +44,7 @@ export type ProviderAgentTranslationResult =
       agentRunId: string;
       proposedCount: number;
       unitsProcessed: number;
-      skippedApprovedLocales: number;
+      skippedExistingLocales: number;
       pullRunId: string;
       alreadyCompleted?: boolean;
     }
@@ -76,6 +76,14 @@ function readProjectIdFromInputSnapshot(inputSnapshot: Record<string, unknown>):
 function readOutputSummaryNumber(outputSummary: Record<string, unknown>, key: string): number {
   const value = outputSummary[key];
   return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function readSkippedExistingLocalesCount(outputSummary: Record<string, unknown>): number {
+  if ("skippedExistingLocales" in outputSummary) {
+    return readOutputSummaryNumber(outputSummary, "skippedExistingLocales");
+  }
+
+  return readOutputSummaryNumber(outputSummary, "skippedApprovedLocales");
 }
 
 function readOutputSummaryString(outputSummary: Record<string, unknown>, key: string): string {
@@ -136,7 +144,7 @@ async function translateProviderUnits(input: {
     matches: AgentRunGlossaryMatchUsage[];
   }> = [];
   let unitsProcessed = 0;
-  let skippedApprovedLocales = 0;
+  let skippedExistingLocales = 0;
 
   const project = await loadTranslationContextProject(input.projectId);
   if (!project) {
@@ -145,7 +153,7 @@ async function translateProviderUnits(input: {
       changedItems,
       warnings: [`Translation project ${input.projectId} was not found`],
       unitsProcessed: 0,
-      skippedApprovedLocales: 0,
+      skippedExistingLocales: 0,
       translationMemoryUsageByUnit: [],
       glossaryUsageByUnit: [],
     };
@@ -160,7 +168,7 @@ async function translateProviderUnits(input: {
     const targetLocales = input.content.targetLocales.filter((locale) => {
       const existing = existingTranslationForLocale(unit, locale);
       if (shouldSkipExistingTranslation(existing)) {
-        skippedApprovedLocales += 1;
+        skippedExistingLocales += 1;
         return false;
       }
       return true;
@@ -329,7 +337,7 @@ async function translateProviderUnits(input: {
     changedItems,
     warnings,
     unitsProcessed,
-    skippedApprovedLocales,
+    skippedExistingLocales,
     translationMemoryUsageByUnit,
     glossaryUsageByUnit,
   };
@@ -370,7 +378,7 @@ export async function executeProviderAgentTranslation(input: {
       agentRunId: input.agentRunId,
       proposedCount: readOutputSummaryNumber(outputSummary, "proposedCount"),
       unitsProcessed: readOutputSummaryNumber(outputSummary, "unitsProcessed"),
-      skippedApprovedLocales: readOutputSummaryNumber(outputSummary, "skippedApprovedLocales"),
+      skippedExistingLocales: readSkippedExistingLocalesCount(outputSummary),
       pullRunId: readOutputSummaryString(outputSummary, "pullRunId"),
       alreadyCompleted: true,
     };
@@ -514,7 +522,6 @@ export async function executeProviderAgentTranslation(input: {
       content: filteredContent,
       sourceFiles,
       actorUserId: run.actorUserId,
-      targetLocales: automationLocales ?? undefined,
     });
 
     await completeAgentRun({
@@ -525,7 +532,7 @@ export async function executeProviderAgentTranslation(input: {
         unitsDiscovered: pullResult.counts.unitsDiscovered,
         unitsProcessed: fileTranslationResult.unitsProcessed,
         proposedCount: fileTranslationResult.changedItems.length,
-        skippedApprovedLocales: fileTranslationResult.skippedExistingLocales,
+        skippedExistingLocales: fileTranslationResult.skippedExistingLocales,
         filesProcessed: fileTranslationResult.filesProcessed,
         translationMode: "file",
         targetLocales: filteredContent.targetLocales,
@@ -540,7 +547,7 @@ export async function executeProviderAgentTranslation(input: {
       agentRunId: input.agentRunId,
       proposedCount: fileTranslationResult.changedItems.length,
       unitsProcessed: fileTranslationResult.unitsProcessed,
-      skippedApprovedLocales: fileTranslationResult.skippedExistingLocales,
+      skippedExistingLocales: fileTranslationResult.skippedExistingLocales,
       pullRunId: pullResult.runId,
     };
   }
@@ -632,7 +639,7 @@ export async function executeProviderAgentTranslation(input: {
       unitsDiscovered: pullResult.counts.unitsDiscovered,
       unitsProcessed: translationResult.unitsProcessed,
       proposedCount: translationResult.changedItems.length,
-      skippedApprovedLocales: translationResult.skippedApprovedLocales,
+      skippedExistingLocales: translationResult.skippedExistingLocales,
       targetLocales: filteredContent.targetLocales,
       sourceLocale: filteredContent.sourceLocale ?? defaultSourceLocale,
       translationMemoryUsage: translationResult.translationMemoryUsageByUnit,
@@ -647,7 +654,7 @@ export async function executeProviderAgentTranslation(input: {
     agentRunId: input.agentRunId,
     proposedCount: translationResult.changedItems.length,
     unitsProcessed: translationResult.unitsProcessed,
-    skippedApprovedLocales: translationResult.skippedApprovedLocales,
+    skippedExistingLocales: translationResult.skippedExistingLocales,
     pullRunId: pullResult.runId,
   };
 }

--- a/apps/hyperlocalise-web/src/lib/providers/download-provider-source-file.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/download-provider-source-file.ts
@@ -1,0 +1,177 @@
+import { and, eq } from "drizzle-orm";
+
+import { db, schema } from "@/lib/database";
+import { inferSupportedFileTranslationFileFormat } from "@/lib/translation/file-formats";
+import { CrowdinApiClient, CrowdinApiError } from "@/lib/providers/adapters/crowdin/crowdin-api";
+import type {
+  ExternalTmsCredential,
+  ExternalTmsProviderKind,
+} from "@/lib/providers/organization-external-tms-provider-credentials";
+import { resolveExternalTmsSecretMaterialForActor } from "@/lib/providers/tms-provider-content";
+
+export type DownloadProviderSourceFileResult =
+  | {
+      ok: true;
+      content: Buffer;
+      filename: string;
+      fileFormat: NonNullable<ReturnType<typeof inferSupportedFileTranslationFileFormat>>;
+    }
+  | {
+      ok: false;
+      code: string;
+      message: string;
+    };
+
+async function loadProjectCredential(input: {
+  organizationId: string;
+  projectId: string;
+  providerKind: ExternalTmsProviderKind;
+}) {
+  const [project] = await db
+    .select({
+      externalProjectId: schema.projects.externalProjectId,
+      externalProviderCredentialId: schema.projects.externalProviderCredentialId,
+    })
+    .from(schema.projects)
+    .where(
+      and(
+        eq(schema.projects.id, input.projectId),
+        eq(schema.projects.organizationId, input.organizationId),
+        eq(schema.projects.externalProviderKind, input.providerKind),
+        eq(schema.projects.source, "external_tms"),
+      ),
+    )
+    .limit(1);
+
+  if (!project?.externalProjectId || !project.externalProviderCredentialId) {
+    return null;
+  }
+
+  const [credential] = await db
+    .select()
+    .from(schema.organizationExternalTmsProviderCredentials)
+    .where(
+      and(
+        eq(schema.organizationExternalTmsProviderCredentials.organizationId, input.organizationId),
+        eq(schema.organizationExternalTmsProviderCredentials.providerKind, input.providerKind),
+        eq(
+          schema.organizationExternalTmsProviderCredentials.id,
+          project.externalProviderCredentialId,
+        ),
+      ),
+    )
+    .limit(1);
+
+  if (!credential) {
+    return null;
+  }
+
+  return {
+    externalProjectId: project.externalProjectId,
+    credential: credential as ExternalTmsCredential,
+  };
+}
+
+async function downloadCrowdinSourceFile(input: {
+  credential: ExternalTmsCredential;
+  secretMaterial: string;
+  externalProjectId: string;
+  externalFileId: string;
+  sourcePath: string;
+}): Promise<DownloadProviderSourceFileResult> {
+  const fileFormat = inferSupportedFileTranslationFileFormat(input.sourcePath);
+  if (!fileFormat) {
+    return {
+      ok: false,
+      code: "unsupported_file_format",
+      message: `Source path ${input.sourcePath} is not a supported translation file format`,
+    };
+  }
+
+  const projectId = Number(input.externalProjectId);
+  const fileId = Number(input.externalFileId);
+  if (Number.isNaN(projectId) || Number.isNaN(fileId)) {
+    return {
+      ok: false,
+      code: "invalid_provider_file_id",
+      message: "Provider file identifiers are invalid",
+    };
+  }
+
+  const client = new CrowdinApiClient({
+    token: input.secretMaterial,
+    baseUrl: input.credential.baseUrl ?? undefined,
+  });
+
+  try {
+    const downloadLink = await client.downloadFile(projectId, fileId);
+    const bytes = await client.downloadUrl(downloadLink.url);
+    const filename = input.sourcePath.split("/").pop() ?? `source-${input.externalFileId}`;
+
+    return {
+      ok: true,
+      content: Buffer.from(bytes),
+      filename,
+      fileFormat,
+    };
+  } catch (error) {
+    if (error instanceof CrowdinApiError && error.status === 401) {
+      return {
+        ok: false,
+        code: "provider_auth_invalid",
+        message: "Provider credentials are invalid",
+      };
+    }
+
+    return {
+      ok: false,
+      code: "provider_file_download_failed",
+      message: error instanceof Error ? error.message : "Provider file download failed",
+    };
+  }
+}
+
+export async function downloadProviderSourceFile(input: {
+  organizationId: string;
+  projectId: string;
+  providerKind: ExternalTmsProviderKind;
+  externalFileId: string;
+  sourcePath: string;
+  actorUserId?: string | null;
+}): Promise<DownloadProviderSourceFileResult> {
+  const context = await loadProjectCredential({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    providerKind: input.providerKind,
+  });
+
+  if (!context) {
+    return {
+      ok: false,
+      code: "provider_project_unavailable",
+      message: "Provider project credentials are unavailable",
+    };
+  }
+
+  const secretMaterial = await resolveExternalTmsSecretMaterialForActor({
+    credential: context.credential,
+    organizationId: input.organizationId,
+    actorUserId: input.actorUserId,
+  });
+
+  if (input.providerKind === "crowdin") {
+    return downloadCrowdinSourceFile({
+      credential: context.credential,
+      secretMaterial,
+      externalProjectId: context.externalProjectId,
+      externalFileId: input.externalFileId,
+      sourcePath: input.sourcePath,
+    });
+  }
+
+  return {
+    ok: false,
+    code: "provider_file_download_unsupported",
+    message: `File download is not supported for ${input.providerKind} yet`,
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/providers/provider-sync-executor.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-sync-executor.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 const {
+  createProviderAgentTranslationQueueMock,
   dbInsertMock,
   dbSelectMock,
   dbUpdateMock,
@@ -8,8 +9,10 @@ const {
   fetchCrowdinJobTasksMock,
   listTmsProviderLiveProjectsMock,
   resolveSecretMaterialForActorMock,
+  runTmsAgentAutomationForSyncedJobMock,
   upsertExternalTmsJobRecordsMock,
 } = vi.hoisted(() => ({
+  createProviderAgentTranslationQueueMock: vi.fn(() => ({ enqueue: vi.fn() })),
   dbInsertMock: vi.fn(),
   dbSelectMock: vi.fn(),
   dbUpdateMock: vi.fn(),
@@ -17,6 +20,7 @@ const {
   fetchCrowdinJobTasksMock: vi.fn(),
   listTmsProviderLiveProjectsMock: vi.fn(),
   resolveSecretMaterialForActorMock: vi.fn(),
+  runTmsAgentAutomationForSyncedJobMock: vi.fn(async () => ({ triggered: [] })),
   upsertExternalTmsJobRecordsMock: vi.fn(),
 }));
 
@@ -72,6 +76,17 @@ vi.mock("@/lib/providers/tms-provider-content", () => ({
 
 vi.mock("@/lib/projects/upsert-external-tms-job-records", () => ({
   upsertExternalTmsJobRecords: upsertExternalTmsJobRecordsMock,
+}));
+
+vi.mock("./agent-runs/tms-agent-automation-runner", () => ({
+  runTmsAgentAutomationForSyncedJob: runTmsAgentAutomationForSyncedJobMock,
+}));
+
+vi.mock("@/workflows/adapters", () => ({
+  createProviderAgentCommentQueue: vi.fn(() => ({ enqueue: vi.fn() })),
+  createProviderAgentQaQueue: vi.fn(() => ({ enqueue: vi.fn() })),
+  createProviderAgentTranslationQueue: createProviderAgentTranslationQueueMock,
+  createProviderAgentWritebackQueue: vi.fn(() => ({ enqueue: vi.fn() })),
 }));
 
 import { isOk } from "@/lib/primitives/result/results";
@@ -157,7 +172,8 @@ describe("executeProviderSyncIntent", () => {
     });
     resolveSecretMaterialForActorMock.mockResolvedValue("secret");
     fetchCrowdinJobTasksMock.mockResolvedValue([]);
-    upsertExternalTmsJobRecordsMock.mockResolvedValue({ upserted: 0 });
+    upsertExternalTmsJobRecordsMock.mockResolvedValue({ upserted: 0, newlySyncedJobIds: [] });
+    runTmsAgentAutomationForSyncedJobMock.mockResolvedValue({ triggered: [] });
   });
 
   it("uses the credential user when executing a catalog project scan", async () => {
@@ -252,7 +268,11 @@ describe("executeProviderSyncIntent", () => {
         })),
       });
     fetchCrowdinJobTasksMock.mockResolvedValue(tasks);
-    upsertExternalTmsJobRecordsMock.mockResolvedValue({ upserted: 1 });
+    const hyperlocaliseJobId = "ext:crowdin:902807:task-1";
+    upsertExternalTmsJobRecordsMock.mockResolvedValue({
+      upserted: 1,
+      newlySyncedJobIds: [hyperlocaliseJobId],
+    });
 
     const result = await executeProviderSyncIntent(createJobTaskIntent());
 
@@ -278,5 +298,77 @@ describe("executeProviderSyncIntent", () => {
       externalProjectId: "902807",
       tasks,
     });
+    expect(runTmsAgentAutomationForSyncedJobMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organizationId: "org_123",
+        projectId: "ext:crowdin:902807",
+        providerKind: "crowdin",
+        hyperlocaliseJobId,
+        externalJobId: "task-1",
+        targetLocales: ["fr"],
+        isNewlySynced: true,
+      }),
+    );
+  });
+
+  it("does not trigger agent automation when no jobs were newly synced", async () => {
+    const project = {
+      id: "ext:crowdin:902807",
+      organizationId: "org_123",
+      externalProviderKind: "crowdin",
+      externalProjectId: "902807",
+      source: "external_tms",
+    };
+    const credential = {
+      id: "credential_123",
+      organizationId: "org_123",
+      providerKind: "crowdin",
+      authMode: "api_token",
+    };
+
+    dbSelectMock
+      .mockReturnValueOnce({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({
+            limit: vi.fn(async () => [project]),
+          })),
+        })),
+      })
+      .mockReturnValueOnce({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({
+            limit: vi.fn(async () => [credential]),
+          })),
+        })),
+      })
+      .mockReturnValueOnce({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({
+            limit: vi.fn(async () => [
+              {
+                createdByUserId: "user_created",
+                updatedByUserId: "user_updated",
+              },
+            ]),
+          })),
+        })),
+      });
+    fetchCrowdinJobTasksMock.mockResolvedValue([
+      {
+        externalJobId: "task-1",
+        externalStatus: "in_progress",
+        title: "Homepage",
+        targetLocales: ["fr"],
+      },
+    ]);
+    upsertExternalTmsJobRecordsMock.mockResolvedValue({
+      upserted: 1,
+      newlySyncedJobIds: [],
+    });
+
+    const result = await executeProviderSyncIntent(createJobTaskIntent());
+
+    expect(isOk(result)).toBe(true);
+    expect(runTmsAgentAutomationForSyncedJobMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/provider-sync-executor.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-sync-executor.test.ts
@@ -20,7 +20,9 @@ const {
   fetchCrowdinJobTasksMock: vi.fn(),
   listTmsProviderLiveProjectsMock: vi.fn(),
   resolveSecretMaterialForActorMock: vi.fn(),
-  runTmsAgentAutomationForSyncedJobMock: vi.fn(async () => ({ triggered: [] })),
+  runTmsAgentAutomationForSyncedJobMock: vi.fn(
+    async (): Promise<{ triggered: string[] }> => ({ triggered: [] }),
+  ),
   upsertExternalTmsJobRecordsMock: vi.fn(),
 }));
 
@@ -309,6 +311,80 @@ describe("executeProviderSyncIntent", () => {
         isNewlySynced: true,
       }),
     );
+  });
+
+  it("continues agent automation for remaining jobs when one job fails", async () => {
+    const project = {
+      id: "ext:crowdin:902807",
+      organizationId: "org_123",
+      externalProviderKind: "crowdin",
+      externalProjectId: "902807",
+      source: "external_tms",
+    };
+    const credential = {
+      id: "credential_123",
+      organizationId: "org_123",
+      providerKind: "crowdin",
+      authMode: "api_token",
+    };
+    const tasks = [
+      {
+        externalJobId: "task-1",
+        externalStatus: "in_progress",
+        title: "Homepage",
+        targetLocales: ["fr"],
+      },
+      {
+        externalJobId: "task-2",
+        externalStatus: "in_progress",
+        title: "About",
+        targetLocales: ["fr"],
+      },
+    ];
+    const jobId1 = "ext:crowdin:902807:task-1";
+    const jobId2 = "ext:crowdin:902807:task-2";
+
+    dbSelectMock
+      .mockReturnValueOnce({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({
+            limit: vi.fn(async () => [project]),
+          })),
+        })),
+      })
+      .mockReturnValueOnce({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({
+            limit: vi.fn(async () => [credential]),
+          })),
+        })),
+      })
+      .mockReturnValueOnce({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({
+            limit: vi.fn(async () => [
+              {
+                createdByUserId: "user_created",
+                updatedByUserId: "user_updated",
+              },
+            ]),
+          })),
+        })),
+      });
+    fetchCrowdinJobTasksMock.mockResolvedValue(tasks);
+    upsertExternalTmsJobRecordsMock.mockResolvedValue({
+      upserted: 2,
+      newlySyncedJobIds: [jobId1, jobId2],
+    });
+    runTmsAgentAutomationForSyncedJobMock
+      .mockRejectedValueOnce(new Error("queue unavailable"))
+      .mockResolvedValueOnce({ triggered: ["translate_with_agent"] });
+
+    const result = await executeProviderSyncIntent(createJobTaskIntent());
+
+    expect(isOk(result)).toBe(true);
+    expect(runTmsAgentAutomationForSyncedJobMock).toHaveBeenCalledTimes(2);
+    expect(dbUpdateMock).toHaveBeenCalled();
   });
 
   it("does not trigger agent automation when no jobs were newly synced", async () => {

--- a/apps/hyperlocalise-web/src/lib/providers/provider-sync-executor.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-sync-executor.ts
@@ -8,12 +8,22 @@ import {
   listTmsProviderLiveProjects,
 } from "@/lib/providers/tms-provider-live";
 import { resolveExternalTmsSecretMaterialForActor } from "@/lib/providers/tms-provider-content";
-import { parseProviderProjectId } from "@/lib/providers/tms-provider-resource-id";
+import {
+  encodeProviderJobId,
+  parseProviderProjectId,
+} from "@/lib/providers/tms-provider-resource-id";
 import { upsertExternalTmsJobRecords } from "@/lib/projects/upsert-external-tms-job-records";
 import { upsertExternalTmsProjectRecord } from "@/lib/projects/upsert-external-tms-project-record";
 import { err, ok, type Result } from "@/lib/primitives/result/results";
 
 import { enqueueProviderProjectJobSyncIntent } from "./provider-sync-intent";
+import { runTmsAgentAutomationForSyncedJob } from "./agent-runs/tms-agent-automation-runner";
+import {
+  createProviderAgentCommentQueue,
+  createProviderAgentQaQueue,
+  createProviderAgentTranslationQueue,
+  createProviderAgentWritebackQueue,
+} from "@/workflows/adapters";
 
 type ProviderSyncIntentRow = typeof schema.providerSyncIntents.$inferSelect;
 
@@ -292,13 +302,52 @@ async function syncProviderJobTasksFromLive(
     project: context.value.project,
     secretMaterial,
   });
-  const { upserted } = await upsertExternalTmsJobRecords({
+  const { upserted, newlySyncedJobIds } = await upsertExternalTmsJobRecords({
     organizationId: intent.organizationId,
     projectId: intent.projectId!,
     providerKind: intent.providerKind,
     externalProjectId: context.value.externalProjectId,
     tasks,
   });
+
+  if (newlySyncedJobIds.length > 0) {
+    const automationQueues = {
+      providerAgentTranslationQueue: createProviderAgentTranslationQueue(),
+      providerAgentQaQueue: createProviderAgentQaQueue(),
+      providerAgentWritebackQueue: createProviderAgentWritebackQueue(),
+      providerAgentCommentQueue: createProviderAgentCommentQueue(),
+    };
+    const tasksByJobId = new Map(
+      tasks.map((task) => [
+        encodeProviderJobId({
+          providerKind: intent.providerKind,
+          externalProjectId: context.value.externalProjectId,
+          externalJobId: task.externalJobId,
+        }),
+        task,
+      ]),
+    );
+
+    for (const hyperlocaliseJobId of newlySyncedJobIds) {
+      const task = tasksByJobId.get(hyperlocaliseJobId);
+      if (!task) {
+        continue;
+      }
+
+      await runTmsAgentAutomationForSyncedJob({
+        organizationId: intent.organizationId,
+        projectId: intent.projectId!,
+        providerKind: intent.providerKind,
+        providerCredentialId: intent.providerCredentialId,
+        hyperlocaliseJobId,
+        externalJobId: task.externalJobId,
+        externalTaskId: task.externalTaskId ?? null,
+        targetLocales: task.targetLocales ?? [],
+        isNewlySynced: true,
+        queues: automationQueues,
+      });
+    }
+  }
 
   await completeProviderSyncRun({
     runId,

--- a/apps/hyperlocalise-web/src/lib/providers/provider-sync-executor.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-sync-executor.ts
@@ -310,6 +310,8 @@ async function syncProviderJobTasksFromLive(
     tasks,
   });
 
+  const automationFailures: Array<{ hyperlocaliseJobId: string; message: string }> = [];
+
   if (newlySyncedJobIds.length > 0) {
     const automationQueues = {
       providerAgentTranslationQueue: createProviderAgentTranslationQueue(),
@@ -334,25 +336,35 @@ async function syncProviderJobTasksFromLive(
         continue;
       }
 
-      await runTmsAgentAutomationForSyncedJob({
-        organizationId: intent.organizationId,
-        projectId: intent.projectId!,
-        providerKind: intent.providerKind,
-        providerCredentialId: intent.providerCredentialId,
-        hyperlocaliseJobId,
-        externalJobId: task.externalJobId,
-        externalTaskId: task.externalTaskId ?? null,
-        targetLocales: task.targetLocales ?? [],
-        isNewlySynced: true,
-        queues: automationQueues,
-      });
+      try {
+        await runTmsAgentAutomationForSyncedJob({
+          organizationId: intent.organizationId,
+          projectId: intent.projectId!,
+          providerKind: intent.providerKind,
+          providerCredentialId: intent.providerCredentialId,
+          hyperlocaliseJobId,
+          externalJobId: task.externalJobId,
+          externalTaskId: task.externalTaskId ?? null,
+          targetLocales: task.targetLocales ?? [],
+          isNewlySynced: true,
+          queues: automationQueues,
+        });
+      } catch (error) {
+        automationFailures.push({
+          hyperlocaliseJobId,
+          message: error instanceof Error ? error.message : "agent automation failed",
+        });
+      }
     }
   }
 
   await completeProviderSyncRun({
     runId,
     status: "succeeded",
-    counts: { jobs: upserted },
+    counts: {
+      jobs: upserted,
+      ...(automationFailures.length > 0 ? { automationFailures: automationFailures.length } : {}),
+    },
   });
 
   return ok({ runId });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Enables the AI agent to work on translation jobs using the file translation workflow (`hl run` in sandbox), with translation memory reuse, glossary validation, and skipping keys that already have non-empty translations.

**Provider-backed (TMS) jobs**
- After job sync, newly synced external jobs now trigger TMS agent automation (`translate_with_agent`, QA, etc.) when configured in org/project settings.
- `translate_with_agent` routes to file-based translation when the job has provider source files with paths (Crowdin file download supported); otherwise falls back to string-by-string translation.
- Honors `automationLocales` from the agent run input snapshot.
- Skips any locale that already has a non-empty translation (not only approved ones).

**Native file translation jobs**
- New `POST /orgs/:slug/jobs/:jobId/run-agent` endpoint re-queues the file translation workflow for succeeded/failed jobs.
- Job detail UI adds a "Translate with agent" action for native file jobs.

## How to test

```bash
cd apps/hyperlocalise-web
vp test
vp check --fix
```

Manual:
1. Sync a Crowdin project with file-based jobs and auto-draft translation enabled — verify agent run is created after sync.
2. Trigger `translate_with_agent` on a provider job with source files — verify proposals only for untranslated keys and TM/glossary applied.
3. On a native file translation job (succeeded/failed), click "Translate with agent" — verify job re-queues.

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83a72266-6a13-4332-be7e-6cdb3a4e100e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83a72266-6a13-4332-be7e-6cdb3a4e100e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

