### PR TITLE
feat(web): prefill native file jobs from project translations

### DIFF
--- a/apps/hyperlocalise-web/src/lib/projects/project-translation-keys.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/project-translation-keys.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const { limitMock, selectMock, whereMock } = vi.hoisted(() => {
+  const limitMock = vi.fn(async (): Promise<unknown[]> => []);
+  const whereMock = vi.fn(() => ({ limit: limitMock }));
+  const fromMock = vi.fn(() => ({ where: whereMock }));
+  const selectMock = vi.fn(() => ({ from: fromMock }));
+
+  return { limitMock, selectMock, whereMock };
+});
+
+vi.mock("drizzle-orm", () => ({
+  and: vi.fn((...conditions: unknown[]) => ["and", conditions]),
+  eq: vi.fn((field: string, value: unknown) => ["eq", field, value]),
+  inArray: vi.fn((field: string, values: unknown[]) => ["inArray", field, values]),
+  sql: vi.fn((strings: TemplateStringsArray) => ({ sql: strings.join("") })),
+}));
+
+vi.mock("@/lib/database", () => ({
+  db: {
+    select: selectMock,
+  },
+  schema: {
+    repositorySourceFiles: {
+      id: "id",
+      sourcePath: "sourcePath",
+      organizationId: "organizationId",
+      projectId: "projectId",
+    },
+    projectTranslationKeys: {
+      id: "id",
+      key: "key",
+      sourceText: "sourceText",
+      context: "context",
+      type: "type",
+      maxLength: "maxLength",
+      organizationId: "organizationId",
+      projectId: "projectId",
+      repositorySourceFileId: "repositorySourceFileId",
+    },
+    projectTranslations: {
+      id: "id",
+      translationKeyId: "translationKeyId",
+      text: "text",
+      status: "status",
+      organizationId: "organizationId",
+      projectId: "projectId",
+      targetLocale: "targetLocale",
+    },
+  },
+}));
+
+import { loadProjectTranslationsAsPrefilledEntries } from "./project-translation-keys";
+
+describe("loadProjectTranslationsAsPrefilledEntries", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    limitMock.mockResolvedValue([]);
+  });
+
+  it("returns an empty map when the source file is not linked to the project", async () => {
+    const result = await loadProjectTranslationsAsPrefilledEntries({
+      organizationId: "org_1",
+      projectId: "project_1",
+      sourcePath: "locales/en.json",
+      targetLocale: "fr",
+    });
+
+    expect(result).toEqual({});
+    expect(selectMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("maps existing project translations to entry keys", async () => {
+    limitMock
+      .mockResolvedValueOnce([{ id: "repo_file_1", sourcePath: "locales/en.json" }])
+      .mockResolvedValueOnce([
+        { id: "key_1", key: "greeting", sourceText: "Hello" },
+        { id: "key_2", key: "farewell", sourceText: "Goodbye" },
+        { id: "key_3", key: "empty", sourceText: "Pending" },
+      ]);
+
+    whereMock.mockImplementationOnce(() => ({
+      limit: limitMock,
+    }));
+    whereMock.mockImplementationOnce(() => ({
+      limit: limitMock,
+    }));
+    whereMock.mockImplementationOnce(
+      () =>
+        Promise.resolve([
+          { id: "translation_1", translationKeyId: "key_1", text: "Bonjour", status: "approved" },
+          { id: "translation_2", translationKeyId: "key_2", text: "Au revoir", status: "draft" },
+          { id: "translation_3", translationKeyId: "key_3", text: "   ", status: "draft" },
+        ]) as unknown as { limit: typeof limitMock },
+    );
+
+    const result = await loadProjectTranslationsAsPrefilledEntries({
+      organizationId: "org_1",
+      projectId: "project_1",
+      sourcePath: "locales/en.json",
+      targetLocale: "fr",
+    });
+
+    expect(result).toEqual({
+      greeting: "Bonjour",
+      farewell: "Au revoir",
+    });
+    expect(selectMock).toHaveBeenCalledTimes(3);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/projects/project-translation-keys.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/project-translation-keys.test.ts
@@ -66,7 +66,12 @@ describe("loadProjectTranslationsAsPrefilledEntries", () => {
       targetLocale: "fr",
     });
 
-    expect(result).toEqual({});
+    expect(result).toEqual({
+      prefilled: {},
+      truncated: false,
+      loadedKeyCount: 0,
+      maxKeyCount: 5_000,
+    });
     expect(selectMock).toHaveBeenCalledTimes(1);
   });
 
@@ -102,9 +107,83 @@ describe("loadProjectTranslationsAsPrefilledEntries", () => {
     });
 
     expect(result).toEqual({
-      greeting: "Bonjour",
-      farewell: "Au revoir",
+      prefilled: {
+        greeting: "Bonjour",
+        farewell: "Au revoir",
+      },
+      truncated: false,
+      loadedKeyCount: 3,
+      maxKeyCount: 5_000,
     });
     expect(selectMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("excludes rejected translations even when text is present", async () => {
+    limitMock
+      .mockResolvedValueOnce([{ id: "repo_file_1", sourcePath: "locales/en.json" }])
+      .mockResolvedValueOnce([{ id: "key_1", key: "greeting", sourceText: "Hello" }]);
+
+    whereMock.mockImplementationOnce(() => ({
+      limit: limitMock,
+    }));
+    whereMock.mockImplementationOnce(() => ({
+      limit: limitMock,
+    }));
+    whereMock.mockImplementationOnce(
+      () =>
+        Promise.resolve([
+          {
+            id: "translation_1",
+            translationKeyId: "key_1",
+            text: "Mauvais",
+            status: "rejected",
+          },
+        ]) as unknown as { limit: typeof limitMock },
+    );
+
+    const result = await loadProjectTranslationsAsPrefilledEntries({
+      organizationId: "org_1",
+      projectId: "project_1",
+      sourcePath: "locales/en.json",
+      targetLocale: "fr",
+    });
+
+    expect(result.prefilled).toEqual({});
+    expect(result.truncated).toBe(false);
+    expect(result.loadedKeyCount).toBe(1);
+  });
+
+  it("reports truncation when the source file exceeds the prefill key cap", async () => {
+    const overLimitKeys = Array.from({ length: 5_001 }, (_, index) => ({
+      id: `key_${index}`,
+      key: `entry_${index}`,
+      sourceText: `Source ${index}`,
+    }));
+
+    limitMock
+      .mockResolvedValueOnce([{ id: "repo_file_1", sourcePath: "locales/en.json" }])
+      .mockResolvedValueOnce(overLimitKeys);
+
+    whereMock.mockImplementationOnce(() => ({
+      limit: limitMock,
+    }));
+    whereMock.mockImplementationOnce(() => ({
+      limit: limitMock,
+    }));
+    whereMock.mockImplementationOnce(
+      () => Promise.resolve([]) as unknown as { limit: typeof limitMock },
+    );
+
+    const result = await loadProjectTranslationsAsPrefilledEntries({
+      organizationId: "org_1",
+      projectId: "project_1",
+      sourcePath: "locales/en.json",
+      targetLocale: "fr",
+    });
+
+    expect(result.truncated).toBe(true);
+    expect(result.loadedKeyCount).toBe(5_000);
+    expect(result.maxKeyCount).toBe(5_000);
+    expect(Object.keys(result.prefilled)).toHaveLength(0);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/projects/project-translation-keys.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/project-translation-keys.ts
@@ -171,7 +171,12 @@ export async function loadProjectTranslationsAsPrefilledEntries(input: {
   projectId: string;
   sourcePath: string;
   targetLocale: string;
-}): Promise<Record<string, string>> {
+}): Promise<{
+  prefilled: Record<string, string>;
+  truncated: boolean;
+  loadedKeyCount: number;
+  maxKeyCount: number;
+}> {
   const sourceFile = await getRepositorySourceFileByPath({
     organizationId: input.organizationId,
     projectId: input.projectId,
@@ -179,23 +184,32 @@ export async function loadProjectTranslationsAsPrefilledEntries(input: {
   });
 
   if (!sourceFile) {
-    return {};
+    return { prefilled: {}, truncated: false, loadedKeyCount: 0, maxKeyCount: maxKeysPerImport };
   }
 
   const keys = await listProjectTranslationKeysForFile({
     organizationId: input.organizationId,
     projectId: input.projectId,
     repositorySourceFileId: sourceFile.id,
+    limit: maxKeysPerImport + 1,
   });
 
-  if (keys.length === 0) {
-    return {};
+  const truncated = keys.length > maxKeysPerImport;
+  const visibleKeys = truncated ? keys.slice(0, maxKeysPerImport) : keys;
+
+  if (visibleKeys.length === 0) {
+    return {
+      prefilled: {},
+      truncated,
+      loadedKeyCount: 0,
+      maxKeyCount: maxKeysPerImport,
+    };
   }
 
   const translations = await getProjectTranslationsByKeyIds({
     organizationId: input.organizationId,
     projectId: input.projectId,
-    translationKeyIds: keys.map((key) => key.id),
+    translationKeyIds: visibleKeys.map((key) => key.id),
     targetLocale: input.targetLocale,
   });
   const translationByKeyId = new Map(
@@ -203,13 +217,18 @@ export async function loadProjectTranslationsAsPrefilledEntries(input: {
   );
 
   const prefilled: Record<string, string> = {};
-  for (const key of keys) {
+  for (const key of visibleKeys) {
     const translation = translationByKeyId.get(key.id);
-    if (!translation?.text?.trim()) {
+    if (!translation?.text?.trim() || translation.status === "rejected") {
       continue;
     }
     prefilled[key.key] = translation.text;
   }
 
-  return prefilled;
+  return {
+    prefilled,
+    truncated,
+    loadedKeyCount: visibleKeys.length,
+    maxKeyCount: maxKeysPerImport,
+  };
 }

--- a/apps/hyperlocalise-web/src/lib/projects/project-translation-keys.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/project-translation-keys.ts
@@ -165,3 +165,51 @@ export async function getProjectTranslationsByKeyIds(input: {
       ),
     );
 }
+
+export async function loadProjectTranslationsAsPrefilledEntries(input: {
+  organizationId: string;
+  projectId: string;
+  sourcePath: string;
+  targetLocale: string;
+}): Promise<Record<string, string>> {
+  const sourceFile = await getRepositorySourceFileByPath({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    sourcePath: input.sourcePath,
+  });
+
+  if (!sourceFile) {
+    return {};
+  }
+
+  const keys = await listProjectTranslationKeysForFile({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    repositorySourceFileId: sourceFile.id,
+  });
+
+  if (keys.length === 0) {
+    return {};
+  }
+
+  const translations = await getProjectTranslationsByKeyIds({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    translationKeyIds: keys.map((key) => key.id),
+    targetLocale: input.targetLocale,
+  });
+  const translationByKeyId = new Map(
+    translations.map((translation) => [translation.translationKeyId, translation]),
+  );
+
+  const prefilled: Record<string, string> = {};
+  for (const key of keys) {
+    const translation = translationByKeyId.get(key.id);
+    if (!translation?.text?.trim()) {
+      continue;
+    }
+    prefilled[key.key] = translation.text;
+  }
+
+  return prefilled;
+}

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -18,6 +18,7 @@ import {
   getStoredFileContentStep,
   getStoredFileStep,
   getRepositorySourcePathForStoredFileStep,
+  loadProjectTranslationsAsPrefilledEntriesStep,
   persistFileProjectTranslationsStep,
   persistFileTranslationMemoryEntriesStep,
   reuseFileTranslationMemoryEntriesStep,
@@ -413,24 +414,45 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
 
     for (const targetLocale of parsedInput.targetLocales) {
       const outputFilename = getSandboxOutputFilename(sourceFile.filename, targetLocale);
-      let reusedEntries: Record<string, string> = {};
+      let tmPrefilled: Record<string, string> = {};
       if (sourceEntries) {
-        reusedEntries = await reuseFileTranslationMemoryEntriesStep({
+        tmPrefilled = await reuseFileTranslationMemoryEntriesStep({
           projectId: claim.job.projectId,
           sourceLocale: parsedInput.sourceLocale,
           targetLocale,
           sourceEntries,
         });
-        if (Object.keys(reusedEntries).length > 0) {
+        if (Object.keys(tmPrefilled).length > 0) {
           console.info("[file-translation-workflow] matched reusable translation memory entries", {
             jobId: claim.job.id,
             projectId: claim.job.projectId,
             targetLocale,
-            reusedEntryCount: Object.keys(reusedEntries).length,
+            reusedEntryCount: Object.keys(tmPrefilled).length,
             sourceEntryCount: Object.keys(sourceEntries).length,
           });
         }
       }
+
+      let existingPrefilled: Record<string, string> = {};
+      if (repositorySourcePath) {
+        existingPrefilled = await loadProjectTranslationsAsPrefilledEntriesStep({
+          organizationId,
+          projectId: claim.job.projectId,
+          sourcePath: repositorySourcePath,
+          targetLocale,
+        });
+        if (Object.keys(existingPrefilled).length > 0) {
+          console.info("[file-translation-workflow] loaded existing project translations", {
+            jobId: claim.job.id,
+            projectId: claim.job.projectId,
+            targetLocale,
+            prefilledEntryCount: Object.keys(existingPrefilled).length,
+            sourcePath: repositorySourcePath,
+          });
+        }
+      }
+
+      const prefilledEntries = { ...tmPrefilled, ...existingPrefilled };
       const localeContext = context.glossaryTerms
         ? {
             ...context,
@@ -449,7 +471,7 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
           targetLocale,
           retryFeedback ? [instructions, retryFeedback].filter(Boolean).join("\n\n") : instructions,
           localeContext,
-          reusedEntries,
+          prefilledEntries,
         );
 
         if (translation.exitCode !== 0) {

--- a/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/file-translation-job.ts
@@ -435,12 +435,23 @@ export async function fileTranslationJobWorkflow(event: TranslationJobEventData)
 
       let existingPrefilled: Record<string, string> = {};
       if (repositorySourcePath) {
-        existingPrefilled = await loadProjectTranslationsAsPrefilledEntriesStep({
+        const projectPrefill = await loadProjectTranslationsAsPrefilledEntriesStep({
           organizationId,
           projectId: claim.job.projectId,
           sourcePath: repositorySourcePath,
           targetLocale,
         });
+        existingPrefilled = projectPrefill.prefilled;
+        if (projectPrefill.truncated) {
+          console.warn("[file-translation-workflow] project translation prefill truncated", {
+            jobId: claim.job.id,
+            projectId: claim.job.projectId,
+            targetLocale,
+            sourcePath: repositorySourcePath,
+            loadedKeyCount: projectPrefill.loadedKeyCount,
+            maxKeyCount: projectPrefill.maxKeyCount,
+          });
+        }
         if (Object.keys(existingPrefilled).length > 0) {
           console.info("[file-translation-workflow] loaded existing project translations", {
             jobId: claim.job.id,

--- a/apps/hyperlocalise-web/src/workflows/steps/translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/translation-job.ts
@@ -329,6 +329,18 @@ export async function reuseFileTranslationMemoryEntriesStep(input: {
   return reuseFileTranslationMemoryEntries(input);
 }
 
+export async function loadProjectTranslationsAsPrefilledEntriesStep(input: {
+  organizationId: string;
+  projectId: string;
+  sourcePath: string;
+  targetLocale: string;
+}) {
+  "use step";
+  const { loadProjectTranslationsAsPrefilledEntries } =
+    await import("@/lib/projects/project-translation-keys");
+  return loadProjectTranslationsAsPrefilledEntries(input);
+}
+
 export async function persistFileTranslationMemoryEntriesStep(input: {
   projectId: string;
   jobId: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Native file translation jobs now load existing `project_translations` for the repository source file and pass them to `hl run` as prefilled entries. This matches provider file translation behavior, where existing unit translations are reused before calling the LLM.

- Added `loadProjectTranslationsAsPrefilledEntries` to read keyed translations from `project_translations`
- Wired the native file workflow to merge TM reuse with existing project translations (`{ ...tmPrefilled, ...existingPrefilled }`, with project translations winning)
- Added unit tests for the new loader

## How to test

1. Run a native file translation job against a repository-linked source file that already has translations in `project_translations`
2. Re-run the job (or use "Run agent") and confirm existing segments are preserved without re-translation
3. `vp test src/lib/projects/project-translation-keys.test.ts`
4. `vp check --fix`

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, targeted tests)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64bc60f6-ef7e-4734-85c0-742112a97654"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64bc60f6-ef7e-4734-85c0-742112a97654"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

