### PR TITLE
feat(web): add file and GitHub repo selectors to strings CAT

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -347,6 +347,7 @@ async function hydrateProjectFileCatAgentContexts(input: {
   organizationId: string;
   projectId: string;
   catFile: NonNullable<Awaited<ReturnType<typeof getTmsProviderLiveCatFile>>>;
+  preferredRepositoryFullName?: string | null;
 }) {
   const log = catContextHydrationLogger.child({
     organizationId: input.organizationId,
@@ -359,7 +360,7 @@ async function hydrateProjectFileCatAgentContexts(input: {
       organizationId: input.organizationId,
       projectId: input.projectId,
       catFile: input.catFile,
-      preferredRepositoryFullName: null,
+      preferredRepositoryFullName: input.preferredRepositoryFullName ?? null,
     });
   } catch (error) {
     log.warn(
@@ -472,6 +473,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
             organizationId: c.var.auth.organization.localOrganizationId,
             projectId: params.projectId,
             catFile,
+            preferredRepositoryFullName: query.repositoryFullName ?? null,
           });
 
           return c.json({ catFile: hydratedCatFile }, 200);
@@ -496,6 +498,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
             organizationId: c.var.auth.organization.localOrganizationId,
             projectId: params.projectId,
             catFile,
+            preferredRepositoryFullName: query.repositoryFullName ?? null,
           });
 
           return c.json({ catFile: hydratedCatFile }, 200);

--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -212,6 +212,7 @@ export const projectFileDetailQuerySchema = z.object({
 export const projectFileCatQuerySchema = z.object({
   sourcePath: z.string().trim().min(1).max(2048),
   targetLocale: z.string().trim().min(1).max(32),
+  repositoryFullName: z.string().trim().min(1).max(256).optional(),
 });
 
 export const projectFileCatTranslationBodySchema = z.object({

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
@@ -113,14 +113,14 @@ export function JobCatPageContent({
     },
   });
 
-  const providerFiles = useMemo(
-    () => sortJobCatProviderFiles((filesQuery.data ?? []).filter((file) => file.provider)),
+  const taskFiles = useMemo(
+    () => sortJobCatProviderFiles(filesQuery.data ?? []),
     [filesQuery.data],
   );
 
-  const selectedFile = sourcePath
-    ? providerFiles.find((file) => file.sourcePath === sourcePath)
-    : null;
+  const providerFiles = useMemo(() => taskFiles.filter((file) => file.provider), [taskFiles]);
+
+  const selectedFile = sourcePath ? taskFiles.find((file) => file.sourcePath === sourcePath) : null;
 
   const enabledRepositoryFullNames = useMemo(
     () =>
@@ -134,21 +134,24 @@ export function JobCatPageContent({
     ? catFileRepositoryPreferenceKey(organizationSlug, projectId, selectedFile.sourcePath)
     : null;
 
-  const [selectedRepositoryFullName, setSelectedRepositoryFullName] = useState<string | null>(null);
+  const [repositoryOverride, setRepositoryOverride] = useState<string | null>(null);
 
   useEffect(() => {
+    setRepositoryOverride(null);
+  }, [repositoryPreferenceKey]);
+
+  const autoSelectedRepositoryFullName = useMemo(() => {
     if (!repositoryPreferenceKey) {
-      setSelectedRepositoryFullName(null);
-      return;
+      return null;
     }
 
-    setSelectedRepositoryFullName(
-      selectJobCatRepository({
-        enabledRepositoryFullNames,
-        savedRepositoryFullName: readCatFileRepositoryPreference(repositoryPreferenceKey),
-      }),
-    );
+    return selectJobCatRepository({
+      enabledRepositoryFullNames,
+      savedRepositoryFullName: readCatFileRepositoryPreference(repositoryPreferenceKey),
+    });
   }, [enabledRepositoryFullNames, repositoryPreferenceKey]);
+
+  const selectedRepositoryFullName = repositoryOverride ?? autoSelectedRepositoryFullName;
 
   if (!sourcePath) {
     return (
@@ -167,7 +170,7 @@ export function JobCatPageContent({
       <ProjectPageShell>
         <div className="flex min-h-48 items-center justify-center gap-2 rounded-lg border border-border bg-card p-5">
           <Spinner />
-          <TypographyP className="text-sm text-muted-foreground">Loading task file…</TypographyP>
+          <TypographyP className="text-sm text-muted-foreground">Loading workspace…</TypographyP>
         </div>
       </ProjectPageShell>
     );
@@ -265,7 +268,7 @@ export function JobCatPageContent({
     }
 
     writeCatFileRepositoryPreference(repositoryPreferenceKey, nextRepositoryFullName);
-    setSelectedRepositoryFullName(nextRepositoryFullName);
+    setRepositoryOverride(nextRepositoryFullName);
   };
 
   return (
@@ -314,13 +317,7 @@ export function JobCatPageContent({
                 onValueChange={handleRepositoryChange}
               >
                 <SelectTrigger className="h-9 w-full font-mono text-xs">
-                  <SelectValue
-                    placeholder={
-                      enabledRepositoryFullNames.length > 1
-                        ? "Select repository"
-                        : "No repository selected"
-                    }
-                  />
+                  <SelectValue placeholder="Select repository" />
                 </SelectTrigger>
                 <SelectContent>
                   {enabledRepositoryFullNames.map((repositoryFullName) => (

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
@@ -1,10 +1,19 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
 import { ArrowLeftIcon } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 
 import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
 import { TypographyP } from "@/components/ui/typography";
 import { apiClient } from "@/lib/api-client-instance";
@@ -12,11 +21,42 @@ import type { TmsProviderLiveFile } from "@/lib/providers/tms-provider-live";
 
 import { ProjectPageShell } from "../../../../_components/project-page-shell";
 import { tmsLiveFileToProjectFileRecord } from "../../_components/tms/job-source-file-mappers";
+import {
+  catFileRepositoryPreferenceKey,
+  readCatFileRepositoryPreference,
+  writeCatFileRepositoryPreference,
+} from "./job-cat-repository-preference";
 import { selectJobCatTargetLocale } from "./job-cat-target-locale";
+import { selectJobCatRepository, sortJobCatProviderFiles } from "./select-job-cat-repository";
 import { TmsJobCatWorkspace } from "./tms-job-cat-workspace";
+
+type JobCatGithubRepository = {
+  fullName: string;
+  enabled: boolean;
+  archived: boolean;
+};
 
 function tmsLiveJobFilesQueryKey(organizationSlug: string, encodedJobId: string) {
   return ["tms-provider-job-files", organizationSlug, encodedJobId] as const;
+}
+
+function githubInstallationRepositoriesQueryKey(organizationSlug: string) {
+  return ["github-installation-repositories", organizationSlug] as const;
+}
+
+function stringsPageHref(input: {
+  organizationSlug: string;
+  projectId: string;
+  jobId: string;
+  sourcePath: string;
+  targetLocale: string;
+}) {
+  const params = new URLSearchParams({
+    sourcePath: input.sourcePath,
+    targetLocale: input.targetLocale,
+  });
+
+  return `/org/${input.organizationSlug}/projects/${encodeURIComponent(input.projectId)}/jobs/${encodeURIComponent(input.jobId)}/strings?${params.toString()}`;
 }
 
 export function JobCatPageContent({
@@ -32,6 +72,7 @@ export function JobCatPageContent({
   sourcePath: string | null;
   targetLocale: string | null;
 }) {
+  const router = useRouter();
   const taskHref = `/org/${organizationSlug}/projects/${encodeURIComponent(projectId)}/jobs/${encodeURIComponent(jobId)}`;
   const filesQuery = useQuery({
     queryKey: tmsLiveJobFilesQueryKey(organizationSlug, jobId),
@@ -52,9 +93,62 @@ export function JobCatPageContent({
     },
   });
 
+  const repositoriesQuery = useQuery({
+    queryKey: githubInstallationRepositoriesQueryKey(organizationSlug),
+    enabled: Boolean(sourcePath),
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"]["github-installation"][
+        "repositories"
+      ].$get({
+        param: { organizationSlug },
+        query: {},
+      });
+
+      if (!response.ok) {
+        throw new Error("Failed to load GitHub repositories");
+      }
+
+      const body = (await response.json()) as { repositories: JobCatGithubRepository[] };
+      return body.repositories;
+    },
+  });
+
+  const providerFiles = useMemo(
+    () => sortJobCatProviderFiles((filesQuery.data ?? []).filter((file) => file.provider)),
+    [filesQuery.data],
+  );
+
   const selectedFile = sourcePath
-    ? (filesQuery.data ?? []).find((file) => file.sourcePath === sourcePath)
+    ? providerFiles.find((file) => file.sourcePath === sourcePath)
     : null;
+
+  const enabledRepositoryFullNames = useMemo(
+    () =>
+      (repositoriesQuery.data ?? [])
+        .filter((repository) => repository.enabled && !repository.archived)
+        .map((repository) => repository.fullName),
+    [repositoriesQuery.data],
+  );
+
+  const repositoryPreferenceKey = selectedFile
+    ? catFileRepositoryPreferenceKey(organizationSlug, projectId, selectedFile.sourcePath)
+    : null;
+
+  const [selectedRepositoryFullName, setSelectedRepositoryFullName] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!repositoryPreferenceKey) {
+      setSelectedRepositoryFullName(null);
+      return;
+    }
+
+    setSelectedRepositoryFullName(
+      selectJobCatRepository({
+        enabledRepositoryFullNames,
+        savedRepositoryFullName: readCatFileRepositoryPreference(repositoryPreferenceKey),
+      }),
+    );
+  }, [enabledRepositoryFullNames, repositoryPreferenceKey]);
 
   if (!sourcePath) {
     return (
@@ -68,7 +162,7 @@ export function JobCatPageContent({
     );
   }
 
-  if (filesQuery.isLoading) {
+  if (filesQuery.isLoading || repositoriesQuery.isLoading) {
     return (
       <ProjectPageShell>
         <div className="flex min-h-48 items-center justify-center gap-2 rounded-lg border border-border bg-card p-5">
@@ -135,31 +229,132 @@ export function JobCatPageContent({
     );
   }
 
+  const handleFileChange = (nextSourcePath: string | null) => {
+    if (!nextSourcePath) {
+      return;
+    }
+
+    const nextFile = providerFiles.find((file) => file.sourcePath === nextSourcePath);
+    if (!nextFile?.provider) {
+      return;
+    }
+
+    const nextTargetLocale = selectJobCatTargetLocale({
+      requestedTargetLocale: targetLocale,
+      providerTargetLocales: nextFile.provider.targetLocales,
+    });
+
+    if (!nextTargetLocale) {
+      return;
+    }
+
+    router.push(
+      stringsPageHref({
+        organizationSlug,
+        projectId,
+        jobId,
+        sourcePath: nextSourcePath,
+        targetLocale: nextTargetLocale,
+      }),
+    );
+  };
+
+  const handleRepositoryChange = (nextRepositoryFullName: string | null) => {
+    if (!nextRepositoryFullName || !repositoryPreferenceKey) {
+      return;
+    }
+
+    writeCatFileRepositoryPreference(repositoryPreferenceKey, nextRepositoryFullName);
+    setSelectedRepositoryFullName(nextRepositoryFullName);
+  };
+
   return (
     <main className="-mx-4 -my-5 flex min-h-[calc(100svh-var(--app-shell-header-height))] flex-col overflow-hidden bg-background sm:-mx-6 lg:-mx-8">
-      <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border px-4 py-3 sm:px-6 lg:px-8">
-        <div className="flex min-w-0 items-center gap-3">
-          <Button variant="outline" size="sm" render={<Link href={taskHref} />}>
-            <ArrowLeftIcon />
-            Task
-          </Button>
-          <div className="min-w-0">
-            <TypographyP className="truncate font-mono text-sm font-medium text-foreground">
-              {selectedFile.sourcePath}
-            </TypographyP>
-            <TypographyP className="truncate text-xs text-muted-foreground">
-              {selectedFile.provider.kind} · {selectedFile.provider.format ?? "file"}
-            </TypographyP>
+      <div className="flex shrink-0 flex-col gap-3 border-b border-border px-4 py-3 sm:px-6 lg:px-8">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex min-w-0 items-center gap-3">
+            <Button variant="outline" size="sm" render={<Link href={taskHref} />}>
+              <ArrowLeftIcon />
+              Task
+            </Button>
+            <div className="min-w-0">
+              <TypographyP className="truncate text-xs text-muted-foreground">
+                {selectedFile.provider.kind} · {selectedFile.provider.format ?? "file"}
+              </TypographyP>
+            </div>
           </div>
         </div>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="flex min-w-0 flex-col gap-1.5">
+            <TypographyP className="text-[10px] font-medium tracking-wide text-muted-foreground uppercase">
+              Source file
+            </TypographyP>
+            <Select value={selectedFile.sourcePath} onValueChange={handleFileChange}>
+              <SelectTrigger className="h-9 w-full font-mono text-xs">
+                <SelectValue placeholder="Select file" />
+              </SelectTrigger>
+              <SelectContent>
+                {providerFiles.map((file) => (
+                  <SelectItem key={file.sourcePath} value={file.sourcePath}>
+                    {file.sourcePath}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {enabledRepositoryFullNames.length > 0 ? (
+            <div className="flex min-w-0 flex-col gap-1.5">
+              <TypographyP className="text-[10px] font-medium tracking-wide text-muted-foreground uppercase">
+                GitHub repository
+              </TypographyP>
+              <Select
+                value={selectedRepositoryFullName ?? ""}
+                onValueChange={handleRepositoryChange}
+              >
+                <SelectTrigger className="h-9 w-full font-mono text-xs">
+                  <SelectValue
+                    placeholder={
+                      enabledRepositoryFullNames.length > 1
+                        ? "Select repository"
+                        : "No repository selected"
+                    }
+                  />
+                </SelectTrigger>
+                <SelectContent>
+                  {enabledRepositoryFullNames.map((repositoryFullName) => (
+                    <SelectItem key={repositoryFullName} value={repositoryFullName}>
+                      {repositoryFullName}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          ) : null}
+        </div>
+
+        {repositoriesQuery.isError ? (
+          <TypographyP className="text-xs text-muted-foreground">
+            GitHub repositories could not be loaded. Repository context lookup is unavailable.
+          </TypographyP>
+        ) : null}
+
+        {enabledRepositoryFullNames.length > 1 && !selectedRepositoryFullName ? (
+          <TypographyP className="text-xs text-muted-foreground">
+            Select a GitHub repository to look up string context for this file.
+          </TypographyP>
+        ) : null}
       </div>
 
       <div className="flex min-h-0 flex-1 flex-col px-4 py-3 sm:px-6 lg:px-8">
         <TmsJobCatWorkspace
+          key={`${selectedFile.sourcePath}:${selectedRepositoryFullName ?? "default"}`}
           organizationSlug={organizationSlug}
           projectId={projectId}
           sourcePath={selectedFile.sourcePath}
           targetLocale={selectedTargetLocale}
+          repositoryFullName={selectedRepositoryFullName}
         />
       </div>
     </main>

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-repository-preference.test.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-repository-preference.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import {
+  catFileRepositoryPreferenceKey,
+  readCatFileRepositoryPreference,
+  writeCatFileRepositoryPreference,
+} from "./job-cat-repository-preference";
+
+function createLocalStorageMock() {
+  const store = new Map<string, string>();
+
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+    clear: () => {
+      store.clear();
+    },
+  };
+}
+
+describe("job-cat-repository-preference", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", createLocalStorageMock());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("builds a stable storage key per file", () => {
+    expect(catFileRepositoryPreferenceKey("acme", "project-1", "en-US.json")).toBe(
+      "job-cat-repository:acme:project-1:en-US.json",
+    );
+  });
+
+  it("persists and reads the selected repository for a file", () => {
+    const storageKey = catFileRepositoryPreferenceKey("acme", "project-1", "en-US.json");
+
+    writeCatFileRepositoryPreference(storageKey, "acme/web");
+    expect(readCatFileRepositoryPreference(storageKey)).toBe("acme/web");
+  });
+});

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-repository-preference.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-repository-preference.ts
@@ -1,0 +1,34 @@
+const STORAGE_PREFIX = "job-cat-repository";
+
+export function catFileRepositoryPreferenceKey(
+  organizationSlug: string,
+  projectId: string,
+  sourcePath: string,
+) {
+  return `${STORAGE_PREFIX}:${organizationSlug}:${projectId}:${sourcePath}`;
+}
+
+export function readCatFileRepositoryPreference(storageKey: string): string | null {
+  try {
+    if (typeof localStorage === "undefined") {
+      return null;
+    }
+
+    const value = localStorage.getItem(storageKey);
+    return value?.trim() ? value.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeCatFileRepositoryPreference(storageKey: string, repositoryFullName: string) {
+  try {
+    if (typeof localStorage === "undefined") {
+      return;
+    }
+
+    localStorage.setItem(storageKey, repositoryFullName);
+  } catch {
+    // Storage may be unavailable in private browsing or when quota is exceeded.
+  }
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/select-job-cat-repository.test.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/select-job-cat-repository.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { selectJobCatRepository, sortJobCatProviderFiles } from "./select-job-cat-repository";
+
+describe("selectJobCatRepository", () => {
+  it("returns the saved repository when it is still enabled", () => {
+    expect(
+      selectJobCatRepository({
+        enabledRepositoryFullNames: ["acme/web", "acme/docs"],
+        savedRepositoryFullName: "acme/docs",
+      }),
+    ).toBe("acme/docs");
+  });
+
+  it("auto-selects the only enabled repository", () => {
+    expect(
+      selectJobCatRepository({
+        enabledRepositoryFullNames: ["acme/web"],
+        savedRepositoryFullName: null,
+      }),
+    ).toBe("acme/web");
+  });
+
+  it("requires an explicit choice when multiple repositories are enabled", () => {
+    expect(
+      selectJobCatRepository({
+        enabledRepositoryFullNames: ["acme/web", "acme/docs"],
+        savedRepositoryFullName: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("ignores a saved repository that is no longer enabled", () => {
+    expect(
+      selectJobCatRepository({
+        enabledRepositoryFullNames: ["acme/web"],
+        savedRepositoryFullName: "acme/legacy",
+      }),
+    ).toBe("acme/web");
+  });
+});
+
+describe("sortJobCatProviderFiles", () => {
+  it("sorts files by source path", () => {
+    expect(
+      sortJobCatProviderFiles([
+        { sourcePath: "locales/fr.json" },
+        { sourcePath: "locales/en.json" },
+      ]).map((file) => file.sourcePath),
+    ).toEqual(["locales/en.json", "locales/fr.json"]);
+  });
+});

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/select-job-cat-repository.ts
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/select-job-cat-repository.ts
@@ -1,0 +1,23 @@
+export function selectJobCatRepository({
+  enabledRepositoryFullNames,
+  savedRepositoryFullName,
+}: {
+  enabledRepositoryFullNames: readonly string[];
+  savedRepositoryFullName: string | null;
+}) {
+  if (savedRepositoryFullName && enabledRepositoryFullNames.includes(savedRepositoryFullName)) {
+    return savedRepositoryFullName;
+  }
+
+  if (enabledRepositoryFullNames.length === 1) {
+    return enabledRepositoryFullNames[0] ?? null;
+  }
+
+  return null;
+}
+
+export function sortJobCatProviderFiles<T extends { sourcePath: string }>(files: readonly T[]) {
+  return [...files].toSorted((left, right) =>
+    left.sourcePath.localeCompare(right.sourcePath, undefined, { sensitivity: "base" }),
+  );
+}

--- a/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/tms-job-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/app/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/tms-job-cat-workspace.tsx
@@ -42,8 +42,16 @@ function projectFileCatQueryKey(
   projectId: string,
   sourcePath: string,
   targetLocale: string,
+  repositoryFullName: string | null,
 ) {
-  return ["project-file-cat", organizationSlug, projectId, sourcePath, targetLocale] as const;
+  return [
+    "project-file-cat",
+    organizationSlug,
+    projectId,
+    sourcePath,
+    targetLocale,
+    repositoryFullName,
+  ] as const;
 }
 
 function segmentStatusFor(segment: ProjectFileCatSegment): CatSegment["status"] {
@@ -226,16 +234,24 @@ export function TmsJobCatWorkspace({
   projectId,
   sourcePath,
   targetLocale,
+  repositoryFullName = null,
   className,
 }: {
   organizationSlug: string;
   projectId: string;
   sourcePath: string;
   targetLocale: string;
+  repositoryFullName?: string | null;
   className?: string;
 }) {
   const queryClient = useQueryClient();
-  const queryKey = projectFileCatQueryKey(organizationSlug, projectId, sourcePath, targetLocale);
+  const queryKey = projectFileCatQueryKey(
+    organizationSlug,
+    projectId,
+    sourcePath,
+    targetLocale,
+    repositoryFullName,
+  );
   const catQuery = useQuery({
     queryKey,
     queryFn: async () => {
@@ -243,7 +259,11 @@ export function TmsJobCatWorkspace({
         ":projectId"
       ].files.detail.cat.$get({
         param: { organizationSlug, projectId },
-        query: { sourcePath, targetLocale },
+        query: {
+          sourcePath,
+          targetLocale,
+          ...(repositoryFullName ? { repositoryFullName } : {}),
+        },
       });
 
       if (!response.ok) {
@@ -305,12 +325,17 @@ export function TmsJobCatWorkspace({
   );
   const lookupSegmentContext = useCallback(
     async (segment: CatSegment) => {
+      if (!repositoryFullName) {
+        throw new Error("Select a GitHub repository before looking up string context.");
+      }
+
       const response = await apiClient.api.orgs[":organizationSlug"].projects[":projectId"].files[
         "string-context"
       ].$post({
         param: { organizationSlug, projectId },
         json: {
           sourcePath,
+          repositoryFullName,
           key: segment.key,
           text: segment.sourceText,
           context: segment.contextLabel ?? null,
@@ -324,7 +349,7 @@ export function TmsJobCatWorkspace({
       const body = (await response.json()) as { stringContext: { summary: string } };
       return body.stringContext.summary;
     },
-    [organizationSlug, projectId, sourcePath],
+    [organizationSlug, projectId, repositoryFullName, sourcePath],
   );
 
   if (catQuery.isLoading) {
@@ -365,7 +390,7 @@ export function TmsJobCatWorkspace({
       className={cn("min-h-0 flex-1", className)}
       services={{
         validateFormat: validateSegmentFormat,
-        lookupSegmentContext,
+        ...(repositoryFullName ? { lookupSegmentContext } : {}),
       }}
       review={{
         onApprove: handleApprove,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds file and GitHub repository selectors to the job strings CAT workspace so translators can switch task files and choose which connected repository is used for agent context lookups.

## Changes

- **Source file select** — dropdown in the strings CAT header lists all provider-linked task files and updates the page URL when changed.
- **GitHub repository select** — dropdown lists enabled, non-archived repositories for the workspace. The choice is saved per file in `localStorage` and auto-selects when only one repository is enabled.
- **API wiring** — optional `repositoryFullName` on `GET /files/detail/cat` hydrates cached agent context for the selected repository; `POST /files/string-context` receives the same value for new lookups.
- **Context lookup guard** — "Find context" stays disabled until a repository is selected when multiple repositories are enabled.

## Testing

- `vp test` on strings CAT component tests (13 passed)
- `vp check --fix` (format, lint, types)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff5be65d-70e3-4bdd-9765-7fe4994c6971"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff5be65d-70e3-4bdd-9765-7fe4994c6971"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

