### PR TITLE
feat(web): add six use-case marketing landing pages

### DIFF
--- a/apps/hyperlocalise-web/src/app/(marketing)/_components/navbar.tsx
+++ b/apps/hyperlocalise-web/src/app/(marketing)/_components/navbar.tsx
@@ -48,7 +48,7 @@ function GitHubMark({ className = "size-4" }: { className?: string }) {
 
 function Logo() {
   return (
-    <Link href="#" className="flex items-center gap-2.5">
+    <Link href="/" className="flex items-center gap-2.5">
       <Image
         src="/images/logo.png"
         className="size-8"

--- a/apps/hyperlocalise-web/src/app/(marketing)/use-cases/[slug]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/(marketing)/use-cases/[slug]/page.tsx
@@ -1,0 +1,55 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import { UseCasePage, useCasePagesBySlug, useCaseSlugs } from "@/components/marketing/use-case";
+
+type UseCaseRouteParams = {
+    slug: string;
+};
+
+type UseCaseRouteProps = {
+    params: Promise<UseCaseRouteParams>;
+};
+
+export function generateStaticParams() {
+    return useCaseSlugs.map((slug) => ({ slug }));
+}
+
+export async function generateMetadata({ params }: UseCaseRouteProps): Promise<Metadata> {
+    const { slug } = await params;
+    const content = useCasePagesBySlug[slug];
+
+    if (!content) {
+        return {};
+    }
+
+    return {
+        title: content.metadata.title,
+        description: content.metadata.description,
+        keywords: content.metadata.keywords,
+        openGraph: {
+            title: content.metadata.title,
+            description: content.metadata.description,
+            type: "website",
+            images: [
+                {
+                    url: "https://www.hyperlocalise.com/images/logo.png",
+                    width: 512,
+                    height: 512,
+                    alt: "Hyperlocalise",
+                },
+            ],
+        },
+    };
+}
+
+export default async function UseCaseRoutePage({ params }: UseCaseRouteProps) {
+    const { slug } = await params;
+    const content = useCasePagesBySlug[slug];
+
+    if (!content) {
+        notFound();
+    }
+
+    return <UseCasePage content={content} />;
+}

--- a/apps/hyperlocalise-web/src/app/(marketing)/use-cases/[slug]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/(marketing)/use-cases/[slug]/page.tsx
@@ -4,52 +4,52 @@ import { notFound } from "next/navigation";
 import { UseCasePage, useCasePagesBySlug, useCaseSlugs } from "@/components/marketing/use-case";
 
 type UseCaseRouteParams = {
-    slug: string;
+  slug: string;
 };
 
 type UseCaseRouteProps = {
-    params: Promise<UseCaseRouteParams>;
+  params: Promise<UseCaseRouteParams>;
 };
 
 export function generateStaticParams() {
-    return useCaseSlugs.map((slug) => ({ slug }));
+  return useCaseSlugs.map((slug) => ({ slug }));
 }
 
 export async function generateMetadata({ params }: UseCaseRouteProps): Promise<Metadata> {
-    const { slug } = await params;
-    const content = useCasePagesBySlug[slug];
+  const { slug } = await params;
+  const content = useCasePagesBySlug[slug];
 
-    if (!content) {
-        return {};
-    }
+  if (!content) {
+    return {};
+  }
 
-    return {
-        title: content.metadata.title,
-        description: content.metadata.description,
-        keywords: content.metadata.keywords,
-        openGraph: {
-            title: content.metadata.title,
-            description: content.metadata.description,
-            type: "website",
-            images: [
-                {
-                    url: "https://www.hyperlocalise.com/images/logo.png",
-                    width: 512,
-                    height: 512,
-                    alt: "Hyperlocalise",
-                },
-            ],
+  return {
+    title: content.metadata.title,
+    description: content.metadata.description,
+    keywords: content.metadata.keywords,
+    openGraph: {
+      title: content.metadata.title,
+      description: content.metadata.description,
+      type: "website",
+      images: [
+        {
+          url: "https://www.hyperlocalise.com/images/logo.png",
+          width: 512,
+          height: 512,
+          alt: "Hyperlocalise",
         },
-    };
+      ],
+    },
+  };
 }
 
 export default async function UseCaseRoutePage({ params }: UseCaseRouteProps) {
-    const { slug } = await params;
-    const content = useCasePagesBySlug[slug];
+  const { slug } = await params;
+  const content = useCasePagesBySlug[slug];
 
-    if (!content) {
-        notFound();
-    }
+  if (!content) {
+    notFound();
+  }
 
-    return <UseCasePage content={content} />;
+  return <UseCasePage content={content} />;
 }

--- a/apps/hyperlocalise-web/src/app/sitemap.ts
+++ b/apps/hyperlocalise-web/src/app/sitemap.ts
@@ -1,6 +1,15 @@
 import { MetadataRoute } from "next";
 
+import { useCaseSlugs } from "@/components/marketing/use-case";
+
 export default function sitemap(): MetadataRoute.Sitemap {
+  const useCaseEntries: MetadataRoute.Sitemap = useCaseSlugs.map((slug) => ({
+    url: `https://www.hyperlocalise.com/use-cases/${slug}`,
+    lastModified: new Date(),
+    changeFrequency: "monthly",
+    priority: 0.8,
+  }));
+
   return [
     {
       url: "https://www.hyperlocalise.com",
@@ -26,5 +35,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "weekly",
       priority: 0.8,
     },
+    ...useCaseEntries,
   ];
 }

--- a/apps/hyperlocalise-web/src/components/marketing/index.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/index.ts
@@ -6,3 +6,11 @@ export { IntakeSourcesIllustration } from "./intake-sources-illustration";
 export { LogoStripSection } from "./logo-strip-section";
 export { MonitorO11yBento } from "./monitor-o11y-bento";
 export { PrinciplesSection } from "./principles-section";
+export {
+  UseCasePage,
+  useCaseFooterLinks,
+  useCasePages,
+  useCasePagesBySlug,
+  useCaseSlugs,
+  type UseCasePageContent,
+} from "./use-case";

--- a/apps/hyperlocalise-web/src/components/marketing/marketing-page-content.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/marketing-page-content.ts
@@ -1,3 +1,5 @@
+import { useCaseFooterLinks } from "@/components/marketing/use-case";
+
 export const githubRepoUrl = "https://github.com/hyperlocalise/hyperlocalise";
 export const githubActionUrl = "https://github.com/marketplace/actions/hyperlocalise-ci";
 export const githubReleasesUrl = "https://github.com/hyperlocalise/hyperlocalise/releases";
@@ -188,6 +190,10 @@ export const footerColumns: MarketingFooterColumn[] = [
       { label: "Monitor", href: "#monitor" },
       { label: "Pricing", href: "#waitlist" },
     ],
+  },
+  {
+    title: "Use cases",
+    links: useCaseFooterLinks,
   },
   {
     title: "Features",

--- a/apps/hyperlocalise-web/src/components/marketing/use-case/index.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/use-case/index.ts
@@ -1,10 +1,10 @@
 export { UseCasePage } from "./use-case-page";
 export {
-    useCaseFooterLinks,
-    useCasePages,
-    useCasePagesBySlug,
-    useCaseSlugs,
-    type UseCaseCapability,
-    type UseCasePageContent,
-    type UseCaseWorkflowStep,
+  useCaseFooterLinks,
+  useCasePages,
+  useCasePagesBySlug,
+  useCaseSlugs,
+  type UseCaseCapability,
+  type UseCasePageContent,
+  type UseCaseWorkflowStep,
 } from "./use-case-page-content";

--- a/apps/hyperlocalise-web/src/components/marketing/use-case/index.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/use-case/index.ts
@@ -1,0 +1,10 @@
+export { UseCasePage } from "./use-case-page";
+export {
+    useCaseFooterLinks,
+    useCasePages,
+    useCasePagesBySlug,
+    useCaseSlugs,
+    type UseCaseCapability,
+    type UseCasePageContent,
+    type UseCaseWorkflowStep,
+} from "./use-case-page-content";

--- a/apps/hyperlocalise-web/src/components/marketing/use-case/use-case-page-content.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/use-case/use-case-page-content.ts
@@ -1,0 +1,722 @@
+export type UseCaseWorkflowStep = {
+    label: string;
+    description?: string;
+};
+
+export type UseCaseCapability = {
+    title: string;
+    description: string;
+};
+
+export type UseCasePageContent = {
+    slug: string;
+    metadata: {
+        title: string;
+        description: string;
+        keywords: string[];
+    };
+    hero: {
+        eyebrow: string;
+        headline: string;
+        subheadline: string;
+        ctaLabel: "Join the waitlist" | "Request a demo";
+    };
+    problem: {
+        title: string;
+        description: string;
+        pains: string[];
+    };
+    workflow: {
+        label: string;
+        title: string;
+        description: string;
+        steps: UseCaseWorkflowStep[];
+    };
+    capabilities: {
+        label: string;
+        title: string;
+        items: UseCaseCapability[];
+    };
+    differentiator: {
+        label: string;
+        title: string;
+        description: string;
+        points: string[];
+    };
+    scenario: {
+        label: string;
+        title: string;
+        narrative: string;
+    };
+    cta: {
+        headline: string;
+        description: string;
+        primaryLabel: "Join the waitlist" | "Request a demo";
+    };
+};
+
+export const useCasePages: UseCasePageContent[] = [
+    {
+        slug: "product-localisation",
+        metadata: {
+            title: "Product Localisation Platform | Hyperlocalise",
+            description:
+                "Turn product changes, pull requests, and launch briefs into reviewed, release-ready translations. Keep localisation inside your release workflow without replacing your TMS.",
+            keywords: [
+                "product localisation platform",
+                "AI product localisation",
+                "GitHub localisation workflow",
+                "software localisation automation",
+            ],
+        },
+        hero: {
+            eyebrow: "Product localisation",
+            headline: "Product localisation that keeps up with every release",
+            subheadline:
+                "Turn product changes, pull requests, and launch briefs into reviewed, release-ready translations with AI-assisted workflows and human approval built in.",
+            ctaLabel: "Join the waitlist",
+        },
+        problem: {
+            title: "Product strings change faster than localisation can follow",
+            description:
+                "Product teams ship continuously. Localisation teams are left reconciling context across tools after the fact.",
+            pains: [
+                "Product context lives across GitHub, Slack, Notion, Figma, and your TMS — never in one place when translation starts.",
+                "AI drafts miss UI constraints, glossary rules, and what actually changed in the pull request.",
+                "Translation work starts too late in the release cycle, so locales block launches or ship with gaps.",
+                "Engineering and localisation rely on manual spot checks before release instead of structured gates.",
+                "Inconsistent UI copy and terminology drift across locales after every sprint.",
+            ],
+        },
+        workflow: {
+            label: "How it works",
+            title: "From pull request to release-ready locales",
+            description:
+                "Hyperlocalise connects product change signals to the review and sync workflow your team already runs.",
+            steps: [
+                { label: "GitHub PR", description: "Detect changed strings and gather PR context" },
+                { label: "Product context", description: "Pull briefs, glossaries, and UI constraints" },
+                { label: "AI translation draft", description: "Generate locale drafts with your LLM" },
+                { label: "Human review", description: "Route to reviewers in your TMS workflow" },
+                { label: "TMS sync", description: "Push approved translations back" },
+                { label: "Release check", description: "Flag unresolved locales before ship" },
+            ],
+        },
+        capabilities: {
+            label: "Key capabilities",
+            title: "Built for product release velocity",
+            items: [
+                {
+                    title: "Pull product context from where work happens",
+                    description:
+                        "Gather string changes, PR descriptions, Slack threads, and launch briefs so translators see why copy changed — not just the diff.",
+                },
+                {
+                    title: "Generate drafts with your preferred LLM",
+                    description:
+                        "Use OpenAI, Claude, Gemini, or another provider without locking your stack to one model vendor.",
+                },
+                {
+                    title: "Apply glossary, tone, and UI constraints before review",
+                    description:
+                        "Enforce terminology, character limits, and product voice before drafts reach human reviewers.",
+                },
+                {
+                    title: "Route work to reviewers inside your existing workflow",
+                    description:
+                        "Keep review assignments, approvals, and comments in the TMS your localisation team already uses.",
+                },
+                {
+                    title: "Sync with your TMS instead of replacing it",
+                    description:
+                        "Push approved strings to Crowdin, Lokalise, Phrase, Smartling, or another platform without a migration project.",
+                },
+                {
+                    title: "Catch bad translations before production",
+                    description:
+                        "Run release checks and regression gates so unresolved locales and quality issues surface before merge.",
+                },
+            ],
+        },
+        differentiator: {
+            label: "Why this is different",
+            title: "An AI-native layer across your product stack — not another TMS",
+            description:
+                "Hyperlocalise is not here to replace your TMS. It adds a workflow layer that connects engineering change signals, LLM-assisted drafting, human review, and release confidence.",
+            points: [
+                "TMS agnostic",
+                "LLM agnostic",
+                "Human-in-the-loop by design",
+                "Context-aware from GitHub and product briefs",
+                "Built for localisation operations at release speed",
+                "Works across engineering, product, and localisation workflows",
+            ],
+        },
+        scenario: {
+            label: "Example workflow",
+            title: "A new onboarding flow ships in Friday's release",
+            narrative:
+                "A product manager merges a pull request with a redesigned onboarding flow. Hyperlocalise detects changed strings, gathers context from the PR and product brief, creates translation drafts for each target locale, checks glossary and tone rules, routes them to reviewers in the TMS, syncs approved translations back, and flags unresolved locales before the release train leaves the station.",
+        },
+        cta: {
+            headline: "Build your AI-native localisation workflow",
+            description:
+                "Join the Hyperlocalise waitlist and see how your team can launch global product content faster without replacing your existing tools.",
+            primaryLabel: "Join the waitlist",
+        },
+    },
+    {
+        slug: "marketing-localisation",
+        metadata: {
+            title: "Marketing Localisation Platform | Hyperlocalise",
+            description:
+                "Turn campaign briefs into brand-safe, locale-adapted marketing copy with review workflows and asset delivery built in. Keep global messaging consistent without slowing launches.",
+            keywords: [
+                "marketing localisation platform",
+                "AI marketing translation",
+                "campaign localisation",
+                "brand-safe translation",
+            ],
+        },
+        hero: {
+            eyebrow: "Marketing localisation",
+            headline: "Campaign localisation that protects brand voice in every market",
+            subheadline:
+                "Turn launch briefs, campaign assets, and regional messaging into reviewed, culturally adapted copy — with approval flows and glossary control built in.",
+            ctaLabel: "Request a demo",
+        },
+        problem: {
+            title: "Global campaigns break when context stays in the brief",
+            description:
+                "Marketing teams move fast. Localisation becomes a bottleneck when brand nuance and regional intent never reach the translator.",
+            pains: [
+                "Campaign context sits in Notion, Figma, Slack, and agency decks — not in the translation workflow.",
+                "Generic AI translation flattens brand voice, cultural references, and regional nuance.",
+                "Approval chains span marketing, legal, and localisation with no shared view of what changed.",
+                "Landing pages and ads drift across locales after the initial launch push.",
+                "Performance learnings from one market rarely feed back into the next campaign cycle.",
+            ],
+        },
+        workflow: {
+            label: "How it works",
+            title: "From campaign brief to market-ready assets",
+            description:
+                "Hyperlocalise carries brand context through adaptation, review, and delivery so every locale ships with intent intact.",
+            steps: [
+                { label: "Campaign brief", description: "Capture goals, audience, and messaging" },
+                { label: "Brand context", description: "Apply voice, glossary, and legal guardrails" },
+                { label: "Locale adaptation", description: "Adapt copy for regional nuance" },
+                { label: "Review workflow", description: "Route to marketing and legal reviewers" },
+                { label: "Asset delivery", description: "Sync approved copy to CMS and ad platforms" },
+                { label: "Performance learning", description: "Feed locale results into the next cycle" },
+            ],
+        },
+        capabilities: {
+            label: "Key capabilities",
+            title: "Built for brand-safe global campaigns",
+            items: [
+                {
+                    title: "Ingest campaign briefs and creative context",
+                    description:
+                        "Pull messaging intent, audience notes, and creative direction from the tools marketing teams already use.",
+                },
+                {
+                    title: "Enforce brand voice and terminology",
+                    description:
+                        "Apply glossaries, tone guides, and do-not-translate rules before drafts reach reviewers.",
+                },
+                {
+                    title: "Adapt for regional nuance, not word-for-word translation",
+                    description:
+                        "Generate locale-aware drafts that respect cultural context while keeping campaign intent aligned.",
+                },
+                {
+                    title: "Run multi-stakeholder approval flows",
+                    description:
+                        "Route copy through marketing, legal, and localisation reviewers with clear status and audit trails.",
+                },
+                {
+                    title: "Deliver to CMS and campaign tools",
+                    description:
+                        "Sync approved copy to Contentful, Webflow, ad platforms, and your TMS without duplicate handoffs.",
+                },
+                {
+                    title: "Track drift across live campaigns",
+                    description:
+                        "Monitor when published marketing copy falls out of sync with source messaging or glossary rules.",
+                },
+            ],
+        },
+        differentiator: {
+            label: "Why this is different",
+            title: "Translation intelligence for marketing — not a generic TMS",
+            description:
+                "Hyperlocalise connects campaign context, brand rules, and review decisions into one workflow. Your TMS stays the system of record; Hyperlocalise makes sure the right context reaches every locale.",
+            points: [
+                "TMS agnostic",
+                "LLM agnostic",
+                "Human-in-the-loop approvals",
+                "Context-aware from briefs and brand guides",
+                "Built for marketing and localisation operations",
+                "Works across CMS, creative, and campaign workflows",
+            ],
+        },
+        scenario: {
+            label: "Example workflow",
+            title: "A product launch campaign goes live in six markets",
+            narrative:
+                "A growth lead shares a launch brief in Slack with positioning, audience segments, and legal disclaimers. Hyperlocalise structures the campaign for localisation, applies brand glossary and tone rules, generates adapted drafts for each locale, routes them through marketing and legal review, syncs approved copy to the CMS and ad platforms, and flags any locale where messaging has drifted from the approved source.",
+        },
+        cta: {
+            headline: "Bring translation intelligence into your localisation workflow",
+            description: "Request early access to Hyperlocalise.",
+            primaryLabel: "Request a demo",
+        },
+    },
+    {
+        slug: "help-center-localisation",
+        metadata: {
+            title: "Help Center Localisation | Hyperlocalise",
+            description:
+                "Keep support articles translated and fresh across locales. Connect CMS updates to review workflows and freshness monitoring without support content lag.",
+            keywords: [
+                "help center localisation",
+                "AI help center translation",
+                "support content localisation",
+                "knowledge base translation",
+            ],
+        },
+        hero: {
+            eyebrow: "Help center localisation",
+            headline: "Support content that stays current in every language",
+            subheadline:
+                "Turn new and updated help articles into reviewed translations, sync them to your CMS, and monitor freshness so customers never read stale guidance.",
+            ctaLabel: "Join the waitlist",
+        },
+        problem: {
+            title: "Support content goes stale the moment it ships in English",
+            description:
+                "Product updates outpace help center translations. Support teams absorb the cost when localized articles lag behind.",
+            pains: [
+                "New articles and updates live in Zendesk, Intercom, Contentful, or Notion — disconnected from localisation queues.",
+                "AI translation misses product terminology, UI labels, and support-specific phrasing.",
+                "Reviewers cannot see what changed in the source article when approving updates.",
+                "Translated articles fall behind after every product release without anyone noticing.",
+                "Support tickets spike in non-English locales when guidance is outdated or missing.",
+            ],
+        },
+        workflow: {
+            label: "How it works",
+            title: "From new article to monitored locale coverage",
+            description:
+                "Hyperlocalise connects CMS change signals to translation, terminology checks, and ongoing freshness monitoring.",
+            steps: [
+                { label: "New article", description: "Detect published or updated support content" },
+                { label: "Content analysis", description: "Extract structure, links, and product terms" },
+                { label: "Translation draft", description: "Generate locale drafts with your LLM" },
+                { label: "Terminology check", description: "Validate glossary and UI label consistency" },
+                { label: "CMS sync", description: "Push approved translations to your help center" },
+                { label: "Freshness monitoring", description: "Alert when locales fall behind source" },
+            ],
+        },
+        capabilities: {
+            label: "Key capabilities",
+            title: "Built for support content at scale",
+            items: [
+                {
+                    title: "Connect to Zendesk, Intercom, Contentful, and more",
+                    description:
+                        "Detect new and updated articles from the CMS and support platforms your team already maintains.",
+                },
+                {
+                    title: "Preserve product terminology and UI labels",
+                    description:
+                        "Apply glossaries and in-product string references so help content matches what users see in the app.",
+                },
+                {
+                    title: "Show reviewers what changed in the source",
+                    description:
+                        "Attach article diffs and product context so reviewers approve updates with full visibility.",
+                },
+                {
+                    title: "Route to support and localisation reviewers",
+                    description:
+                        "Assign articles to the right reviewers based on topic, locale, or expertise.",
+                },
+                {
+                    title: "Sync approved translations back to your CMS",
+                    description:
+                        "Publish localized articles without manual copy-paste between your TMS and help center.",
+                },
+                {
+                    title: "Monitor locale freshness and coverage gaps",
+                    description:
+                        "Track which articles are missing translations or lag behind the English source after product changes.",
+                },
+            ],
+        },
+        differentiator: {
+            label: "Why this is different",
+            title: "Support localisation that stays connected to the product",
+            description:
+                "Hyperlocalise is not another help center tool. It adds an AI-native workflow layer that keeps support content aligned with product changes, glossary rules, and review standards.",
+            points: [
+                "TMS agnostic",
+                "LLM agnostic",
+                "Human-in-the-loop review",
+                "Context-aware from CMS and product docs",
+                "Built for support and localisation operations",
+                "Works across CMS, TMS, and product workflows",
+            ],
+        },
+        scenario: {
+            label: "Example workflow",
+            title: "A billing FAQ update needs to reach twelve locales",
+            narrative:
+                "Support publishes an updated billing FAQ after a pricing change. Hyperlocalise detects the article update, analyzes changed sections and linked product terms, generates translation drafts for each locale, runs terminology checks against the product glossary, routes drafts to support reviewers, syncs approved translations to Zendesk and Contentful, and alerts the team if any locale still shows the pre-change version after forty-eight hours.",
+        },
+        cta: {
+            headline: "Build your AI-native localisation workflow",
+            description:
+                "Join the Hyperlocalise waitlist and see how your team can keep support content current across every locale.",
+            primaryLabel: "Join the waitlist",
+        },
+    },
+    {
+        slug: "github-release-localisation",
+        metadata: {
+            title: "GitHub Localisation Workflow | Hyperlocalise",
+            description:
+                "Automate localisation checks in CI/CD. Detect string changes in pull requests, draft translations, and gate releases before bad translations reach production.",
+            keywords: [
+                "GitHub localisation workflow",
+                "localisation CI",
+                "software translation automation",
+                "AI localisation for developers",
+            ],
+        },
+        hero: {
+            eyebrow: "GitHub release localisation",
+            headline: "Localisation checks that run with every pull request",
+            subheadline:
+                "Detect string changes, gather PR context, draft translations, and gate releases — so engineering teams catch localisation issues before merge, not after launch.",
+            ctaLabel: "Join the waitlist",
+        },
+        problem: {
+            title: "Localisation is still a manual step outside the release pipeline",
+            description:
+                "Developers merge string changes daily. Localisation quality depends on someone remembering to check before ship.",
+            pains: [
+                "String changes hide in large pull requests without clear localisation impact.",
+                "Engineering and localisation coordinate over Slack instead of inside CI/CD.",
+                "Translation files drift from source strings between releases.",
+                "Release gates depend on manual TMS checks that block deploys unpredictably.",
+                "Bad translations reach production because there is no automated regression layer.",
+            ],
+        },
+        workflow: {
+            label: "How it works",
+            title: "From pull request to release gate",
+            description:
+                "Hyperlocalise fits into the developer workflow your team already runs — with GitHub Actions and TMS sync built in.",
+            steps: [
+                { label: "Pull request", description: "Detect added, changed, and removed strings" },
+                { label: "Change analysis", description: "Map diffs to locales and glossary impact" },
+                { label: "Translation draft", description: "Generate locale drafts with your LLM" },
+                { label: "Review routing", description: "Open review tasks in your TMS" },
+                { label: "CI check", description: "Run localisation gates in GitHub Actions" },
+                { label: "Release gate", description: "Block merge when locales are unresolved" },
+            ],
+        },
+        capabilities: {
+            label: "Key capabilities",
+            title: "Built for developer-led release workflows",
+            items: [
+                {
+                    title: "GitHub Action for localisation checks",
+                    description:
+                        "Run drift detection, coverage checks, and regression evals on every pull request.",
+                },
+                {
+                    title: "Detect string changes from PR diffs",
+                    description:
+                        "Surface added, modified, and removed keys with context from the pull request description and linked issues.",
+                },
+                {
+                    title: "Draft translations with your preferred LLM",
+                    description:
+                        "Generate locale drafts automatically when strings change, using glossary and TM context.",
+                },
+                {
+                    title: "Comment on pull requests with localisation status",
+                    description:
+                        "Give reviewers a clear view of locale coverage, quality flags, and unresolved items before merge.",
+                },
+                {
+                    title: "Sync approved strings to your TMS",
+                    description:
+                        "Push translations to Crowdin, Lokalise, Phrase, or Smartling without leaving the release flow.",
+                },
+                {
+                    title: "Block releases when quality gates fail",
+                    description:
+                        "Configure checks that prevent merge when critical locales are missing or regression thresholds are exceeded.",
+                },
+            ],
+        },
+        differentiator: {
+            label: "Why this is different",
+            title: "Localisation intelligence inside your CI/CD pipeline",
+            description:
+                "Hyperlocalise is not a replacement for your TMS or i18n library. It adds an AI-native layer that connects GitHub change signals, translation drafting, and release gates.",
+            points: [
+                "TMS agnostic",
+                "LLM agnostic",
+                "Human-in-the-loop when review is required",
+                "Context-aware from pull requests and issues",
+                "Built for engineering and localisation operations",
+                "Works across GitHub, TMS, and release tooling",
+            ],
+        },
+        scenario: {
+            label: "Example workflow",
+            title: "A pricing page refactor opens a pull request on Tuesday",
+            narrative:
+                "A developer opens a pull request that renames fourteen UI strings and adds six new ones. Hyperlocalise comments on the PR with affected locales, generates translation drafts using glossary context from the linked launch brief, opens review tasks in Lokalise, runs the GitHub Action to verify all target locales are covered, and blocks merge until German and Japanese reviewers approve the updated pricing terminology.",
+        },
+        cta: {
+            headline: "Build your AI-native localisation workflow",
+            description:
+                "Join the Hyperlocalise waitlist and bring localisation checks into your release pipeline.",
+            primaryLabel: "Join the waitlist",
+        },
+    },
+    {
+        slug: "localisation-quality-monitoring",
+        metadata: {
+            title: "Localisation Quality Monitoring | Hyperlocalise",
+            description:
+                "Monitor translation quality, terminology drift, and locale coverage at scale. Run quality gates and catch regressions before they reach customers.",
+            keywords: [
+                "localisation quality monitoring",
+                "translation quality automation",
+                "AI translation QA",
+                "localisation QA checks",
+            ],
+        },
+        hero: {
+            eyebrow: "Localisation quality monitoring",
+            headline: "Catch translation drift before your customers do",
+            subheadline:
+                "Monitor terminology consistency, locale coverage, and translation quality across product, marketing, and support content — with gates that block bad syncs before they go live.",
+            ctaLabel: "Request a demo",
+        },
+        problem: {
+            title: "Quality issues surface after launch, not before",
+            description:
+                "Teams ship translations and hope for the best. Drift, missing locales, and terminology breaks accumulate quietly across releases.",
+            pains: [
+                "No single view of locale health across product strings, marketing copy, and support articles.",
+                "Terminology breaks when different teams translate the same product terms independently.",
+                "Regression checks run manually — or not at all — before major releases.",
+                "Review coverage is unclear: which locales were human-approved vs. machine-translated only.",
+                "Quality problems are discovered by customers, support tickets, or app store reviews.",
+            ],
+        },
+        workflow: {
+            label: "How it works",
+            title: "From content sync to ongoing quality monitoring",
+            description:
+                "Hyperlocalise runs quality checks at every stage — draft, review, sync, and after publish.",
+            steps: [
+                { label: "Content sync", description: "Track strings across TMS and sources" },
+                { label: "Quality analysis", description: "Run glossary, drift, and coverage checks" },
+                { label: "Regression eval", description: "Compare against approved baselines" },
+                { label: "Review routing", description: "Escalate flagged items to reviewers" },
+                { label: "Release gate", description: "Block sync when thresholds fail" },
+                { label: "Ongoing monitor", description: "Alert on drift after publish" },
+            ],
+        },
+        capabilities: {
+            label: "Key capabilities",
+            title: "Built for quality at scale",
+            items: [
+                {
+                    title: "Monitor locale coverage across all content types",
+                    description:
+                        "See which locales are complete, partial, or missing for product, marketing, and support content.",
+                },
+                {
+                    title: "Detect terminology drift and glossary violations",
+                    description:
+                        "Flag when translations diverge from approved terminology or when source strings change without locale updates.",
+                },
+                {
+                    title: "Run regression evals before sync and release",
+                    description:
+                        "Compare new translations against approved baselines and block sync when quality thresholds fail.",
+                },
+                {
+                    title: "Track review coverage and approval status",
+                    description:
+                        "Know which strings were human-reviewed, machine-translated only, or pending approval per locale.",
+                },
+                {
+                    title: "Surface quality issues in pull requests",
+                    description:
+                        "Show localisation health directly in GitHub so engineering and localisation share one view.",
+                },
+                {
+                    title: "Alert on post-publish drift",
+                    description:
+                        "Monitor live content for terminology breaks, missing updates, and locale gaps after release.",
+                },
+            ],
+        },
+        differentiator: {
+            label: "Why this is different",
+            title: "Quality monitoring across your stack — not a point-in-time QA tool",
+            description:
+                "Hyperlocalise connects quality checks to the workflows where content is created, reviewed, and synced. Your TMS stays the system of record; Hyperlocalise makes quality visible at every step.",
+            points: [
+                "TMS agnostic",
+                "LLM agnostic",
+                "Human-in-the-loop escalation",
+                "Context-aware quality checks",
+                "Built for localisation operations and release confidence",
+                "Works across product, marketing, support, and engineering",
+            ],
+        },
+        scenario: {
+            label: "Example workflow",
+            title: "A glossary update needs to propagate across three content types",
+            narrative:
+                "Localisation updates the product glossary after a rebrand. Hyperlocalise scans product strings, marketing landing pages, and help center articles for terminology that no longer matches, runs regression evals against approved baselines, routes flagged strings to reviewers, blocks TMS sync for locales that fail the threshold, and continues monitoring published content for drift over the following two weeks.",
+        },
+        cta: {
+            headline: "Bring translation intelligence into your localisation workflow",
+            description: "Request early access to Hyperlocalise.",
+            primaryLabel: "Request a demo",
+        },
+    },
+    {
+        slug: "localisation-operations",
+        metadata: {
+            title: "Localisation Operations Platform | Hyperlocalise",
+            description:
+                "Orchestrate localisation across TMS platforms, LLM providers, vendors, and reviewers. One workflow layer for localisation managers without replacing your stack.",
+            keywords: [
+                "localisation operations platform",
+                "AI localisation operations",
+                "TMS agnostic localisation",
+                "translation workflow automation",
+            ],
+        },
+        hero: {
+            eyebrow: "Localisation operations",
+            headline: "One operations layer across your entire localisation stack",
+            subheadline:
+                "Orchestrate agents, reviewers, vendors, LLMs, and TMS platforms in a single workflow — without replacing the tools your team already depends on.",
+            ctaLabel: "Request a demo",
+        },
+        problem: {
+            title: "Localisation operations span too many disconnected systems",
+            description:
+                "Localisation managers coordinate across TMS tools, model providers, vendors, and engineering — with no unified view of what is in flight.",
+            pains: [
+                "Work arrives from product, marketing, support, and engineering through different channels with no shared intake.",
+                "Switching LLM providers or TMS platforms disrupts established workflows.",
+                "Vendor and reviewer assignments happen manually across spreadsheets and Slack.",
+                "Approvals and status live in the TMS while context lives elsewhere.",
+                "Reporting on throughput, quality, and locale coverage requires stitching data from multiple tools.",
+            ],
+        },
+        workflow: {
+            label: "How it works",
+            title: "From intake to orchestrated delivery",
+            description:
+                "Hyperlocalise gives localisation operations a single control plane across sources, models, reviewers, and sync targets.",
+            steps: [
+                { label: "Intake", description: "Collect work from GitHub, Slack, CMS, and TMS" },
+                { label: "Context assembly", description: "Attach glossaries, briefs, and history" },
+                { label: "Agent assignment", description: "Route to LLM agents or human reviewers" },
+                { label: "Review & approval", description: "Track decisions across stakeholders" },
+                { label: "TMS sync", description: "Push approved work to your platform" },
+                { label: "Operations report", description: "Monitor throughput and locale health" },
+            ],
+        },
+        capabilities: {
+            label: "Key capabilities",
+            title: "Built for localisation managers",
+            items: [
+                {
+                    title: "Unified intake across product, marketing, and support",
+                    description:
+                        "Collect localisation requests from GitHub, Slack, CMS platforms, and your TMS into one queue.",
+                },
+                {
+                    title: "Orchestrate agents, vendors, and internal reviewers",
+                    description:
+                        "Assign translation, review, and QA work based on locale, content type, or expertise.",
+                },
+                {
+                    title: "Switch LLM providers without workflow redesign",
+                    description:
+                        "Use different models for different content types while keeping review and sync logic consistent.",
+                },
+                {
+                    title: "Stay TMS agnostic across platforms",
+                    description:
+                        "Operate across Crowdin, Lokalise, Phrase, Smartling, and other TMS tools from one workflow layer.",
+                },
+                {
+                    title: "Track approvals and audit trails",
+                    description:
+                        "See who approved what, when, and with what context — across agents and human reviewers.",
+                },
+                {
+                    title: "Report on throughput, coverage, and quality",
+                    description:
+                        "Monitor locale health, review backlog, and quality trends without exporting from three systems.",
+                },
+            ],
+        },
+        differentiator: {
+            label: "Why this is different",
+            title: "An operations platform that connects your stack — not another silo",
+            description:
+                "Hyperlocalise is not a TMS replacement. It is the workflow layer localisation operations teams use to orchestrate agents, humans, models, and platforms without a rip-and-replace migration.",
+            points: [
+                "TMS agnostic",
+                "LLM agnostic",
+                "Human-in-the-loop orchestration",
+                "Context-aware across all content sources",
+                "Built for localisation operations at scale",
+                "Works across product, marketing, support, and engineering",
+            ],
+        },
+        scenario: {
+            label: "Example workflow",
+            title: "A localisation manager plans the quarter across four content streams",
+            narrative:
+                "A localisation manager receives intake from a product release, a marketing campaign, twelve updated help articles, and a vendor translation batch. Hyperlocalise structures each stream with the right context and glossary rules, assigns product strings to an LLM agent with human review, routes marketing copy through legal approval, sends vendor work to the TMS with quality gates, and surfaces a single dashboard showing locale coverage, review backlog, and blocked releases across all four streams.",
+        },
+        cta: {
+            headline: "Build your AI-native localisation workflow",
+            description:
+                "Join the Hyperlocalise waitlist and see how your operations team can orchestrate localisation without replacing your existing tools.",
+            primaryLabel: "Join the waitlist",
+        },
+    },
+];
+
+export const useCasePagesBySlug = Object.fromEntries(
+    useCasePages.map((page) => [page.slug, page]),
+) as Record<string, UseCasePageContent>;
+
+export const useCaseSlugs = useCasePages.map((page) => page.slug);
+
+export const useCaseFooterLinks = useCasePages.map((page) => ({
+    label: page.hero.eyebrow,
+    href: `/use-cases/${page.slug}`,
+}));

--- a/apps/hyperlocalise-web/src/components/marketing/use-case/use-case-page-content.ts
+++ b/apps/hyperlocalise-web/src/components/marketing/use-case/use-case-page-content.ts
@@ -1,722 +1,722 @@
 export type UseCaseWorkflowStep = {
-    label: string;
-    description?: string;
+  label: string;
+  description?: string;
 };
 
 export type UseCaseCapability = {
-    title: string;
-    description: string;
+  title: string;
+  description: string;
 };
 
 export type UseCasePageContent = {
-    slug: string;
-    metadata: {
-        title: string;
-        description: string;
-        keywords: string[];
-    };
-    hero: {
-        eyebrow: string;
-        headline: string;
-        subheadline: string;
-        ctaLabel: "Join the waitlist" | "Request a demo";
-    };
-    problem: {
-        title: string;
-        description: string;
-        pains: string[];
-    };
-    workflow: {
-        label: string;
-        title: string;
-        description: string;
-        steps: UseCaseWorkflowStep[];
-    };
-    capabilities: {
-        label: string;
-        title: string;
-        items: UseCaseCapability[];
-    };
-    differentiator: {
-        label: string;
-        title: string;
-        description: string;
-        points: string[];
-    };
-    scenario: {
-        label: string;
-        title: string;
-        narrative: string;
-    };
-    cta: {
-        headline: string;
-        description: string;
-        primaryLabel: "Join the waitlist" | "Request a demo";
-    };
+  slug: string;
+  metadata: {
+    title: string;
+    description: string;
+    keywords: string[];
+  };
+  hero: {
+    eyebrow: string;
+    headline: string;
+    subheadline: string;
+    ctaLabel: "Join the waitlist" | "Request a demo";
+  };
+  problem: {
+    title: string;
+    description: string;
+    pains: string[];
+  };
+  workflow: {
+    label: string;
+    title: string;
+    description: string;
+    steps: UseCaseWorkflowStep[];
+  };
+  capabilities: {
+    label: string;
+    title: string;
+    items: UseCaseCapability[];
+  };
+  differentiator: {
+    label: string;
+    title: string;
+    description: string;
+    points: string[];
+  };
+  scenario: {
+    label: string;
+    title: string;
+    narrative: string;
+  };
+  cta: {
+    headline: string;
+    description: string;
+    primaryLabel: "Join the waitlist" | "Request a demo";
+  };
 };
 
 export const useCasePages: UseCasePageContent[] = [
-    {
-        slug: "product-localisation",
-        metadata: {
-            title: "Product Localisation Platform | Hyperlocalise",
-            description:
-                "Turn product changes, pull requests, and launch briefs into reviewed, release-ready translations. Keep localisation inside your release workflow without replacing your TMS.",
-            keywords: [
-                "product localisation platform",
-                "AI product localisation",
-                "GitHub localisation workflow",
-                "software localisation automation",
-            ],
-        },
-        hero: {
-            eyebrow: "Product localisation",
-            headline: "Product localisation that keeps up with every release",
-            subheadline:
-                "Turn product changes, pull requests, and launch briefs into reviewed, release-ready translations with AI-assisted workflows and human approval built in.",
-            ctaLabel: "Join the waitlist",
-        },
-        problem: {
-            title: "Product strings change faster than localisation can follow",
-            description:
-                "Product teams ship continuously. Localisation teams are left reconciling context across tools after the fact.",
-            pains: [
-                "Product context lives across GitHub, Slack, Notion, Figma, and your TMS — never in one place when translation starts.",
-                "AI drafts miss UI constraints, glossary rules, and what actually changed in the pull request.",
-                "Translation work starts too late in the release cycle, so locales block launches or ship with gaps.",
-                "Engineering and localisation rely on manual spot checks before release instead of structured gates.",
-                "Inconsistent UI copy and terminology drift across locales after every sprint.",
-            ],
-        },
-        workflow: {
-            label: "How it works",
-            title: "From pull request to release-ready locales",
-            description:
-                "Hyperlocalise connects product change signals to the review and sync workflow your team already runs.",
-            steps: [
-                { label: "GitHub PR", description: "Detect changed strings and gather PR context" },
-                { label: "Product context", description: "Pull briefs, glossaries, and UI constraints" },
-                { label: "AI translation draft", description: "Generate locale drafts with your LLM" },
-                { label: "Human review", description: "Route to reviewers in your TMS workflow" },
-                { label: "TMS sync", description: "Push approved translations back" },
-                { label: "Release check", description: "Flag unresolved locales before ship" },
-            ],
-        },
-        capabilities: {
-            label: "Key capabilities",
-            title: "Built for product release velocity",
-            items: [
-                {
-                    title: "Pull product context from where work happens",
-                    description:
-                        "Gather string changes, PR descriptions, Slack threads, and launch briefs so translators see why copy changed — not just the diff.",
-                },
-                {
-                    title: "Generate drafts with your preferred LLM",
-                    description:
-                        "Use OpenAI, Claude, Gemini, or another provider without locking your stack to one model vendor.",
-                },
-                {
-                    title: "Apply glossary, tone, and UI constraints before review",
-                    description:
-                        "Enforce terminology, character limits, and product voice before drafts reach human reviewers.",
-                },
-                {
-                    title: "Route work to reviewers inside your existing workflow",
-                    description:
-                        "Keep review assignments, approvals, and comments in the TMS your localisation team already uses.",
-                },
-                {
-                    title: "Sync with your TMS instead of replacing it",
-                    description:
-                        "Push approved strings to Crowdin, Lokalise, Phrase, Smartling, or another platform without a migration project.",
-                },
-                {
-                    title: "Catch bad translations before production",
-                    description:
-                        "Run release checks and regression gates so unresolved locales and quality issues surface before merge.",
-                },
-            ],
-        },
-        differentiator: {
-            label: "Why this is different",
-            title: "An AI-native layer across your product stack — not another TMS",
-            description:
-                "Hyperlocalise is not here to replace your TMS. It adds a workflow layer that connects engineering change signals, LLM-assisted drafting, human review, and release confidence.",
-            points: [
-                "TMS agnostic",
-                "LLM agnostic",
-                "Human-in-the-loop by design",
-                "Context-aware from GitHub and product briefs",
-                "Built for localisation operations at release speed",
-                "Works across engineering, product, and localisation workflows",
-            ],
-        },
-        scenario: {
-            label: "Example workflow",
-            title: "A new onboarding flow ships in Friday's release",
-            narrative:
-                "A product manager merges a pull request with a redesigned onboarding flow. Hyperlocalise detects changed strings, gathers context from the PR and product brief, creates translation drafts for each target locale, checks glossary and tone rules, routes them to reviewers in the TMS, syncs approved translations back, and flags unresolved locales before the release train leaves the station.",
-        },
-        cta: {
-            headline: "Build your AI-native localisation workflow",
-            description:
-                "Join the Hyperlocalise waitlist and see how your team can launch global product content faster without replacing your existing tools.",
-            primaryLabel: "Join the waitlist",
-        },
+  {
+    slug: "product-localisation",
+    metadata: {
+      title: "Product Localisation Platform | Hyperlocalise",
+      description:
+        "Turn product changes, pull requests, and launch briefs into reviewed, release-ready translations. Keep localisation inside your release workflow without replacing your TMS.",
+      keywords: [
+        "product localisation platform",
+        "AI product localisation",
+        "GitHub localisation workflow",
+        "software localisation automation",
+      ],
     },
-    {
-        slug: "marketing-localisation",
-        metadata: {
-            title: "Marketing Localisation Platform | Hyperlocalise",
-            description:
-                "Turn campaign briefs into brand-safe, locale-adapted marketing copy with review workflows and asset delivery built in. Keep global messaging consistent without slowing launches.",
-            keywords: [
-                "marketing localisation platform",
-                "AI marketing translation",
-                "campaign localisation",
-                "brand-safe translation",
-            ],
-        },
-        hero: {
-            eyebrow: "Marketing localisation",
-            headline: "Campaign localisation that protects brand voice in every market",
-            subheadline:
-                "Turn launch briefs, campaign assets, and regional messaging into reviewed, culturally adapted copy — with approval flows and glossary control built in.",
-            ctaLabel: "Request a demo",
-        },
-        problem: {
-            title: "Global campaigns break when context stays in the brief",
-            description:
-                "Marketing teams move fast. Localisation becomes a bottleneck when brand nuance and regional intent never reach the translator.",
-            pains: [
-                "Campaign context sits in Notion, Figma, Slack, and agency decks — not in the translation workflow.",
-                "Generic AI translation flattens brand voice, cultural references, and regional nuance.",
-                "Approval chains span marketing, legal, and localisation with no shared view of what changed.",
-                "Landing pages and ads drift across locales after the initial launch push.",
-                "Performance learnings from one market rarely feed back into the next campaign cycle.",
-            ],
-        },
-        workflow: {
-            label: "How it works",
-            title: "From campaign brief to market-ready assets",
-            description:
-                "Hyperlocalise carries brand context through adaptation, review, and delivery so every locale ships with intent intact.",
-            steps: [
-                { label: "Campaign brief", description: "Capture goals, audience, and messaging" },
-                { label: "Brand context", description: "Apply voice, glossary, and legal guardrails" },
-                { label: "Locale adaptation", description: "Adapt copy for regional nuance" },
-                { label: "Review workflow", description: "Route to marketing and legal reviewers" },
-                { label: "Asset delivery", description: "Sync approved copy to CMS and ad platforms" },
-                { label: "Performance learning", description: "Feed locale results into the next cycle" },
-            ],
-        },
-        capabilities: {
-            label: "Key capabilities",
-            title: "Built for brand-safe global campaigns",
-            items: [
-                {
-                    title: "Ingest campaign briefs and creative context",
-                    description:
-                        "Pull messaging intent, audience notes, and creative direction from the tools marketing teams already use.",
-                },
-                {
-                    title: "Enforce brand voice and terminology",
-                    description:
-                        "Apply glossaries, tone guides, and do-not-translate rules before drafts reach reviewers.",
-                },
-                {
-                    title: "Adapt for regional nuance, not word-for-word translation",
-                    description:
-                        "Generate locale-aware drafts that respect cultural context while keeping campaign intent aligned.",
-                },
-                {
-                    title: "Run multi-stakeholder approval flows",
-                    description:
-                        "Route copy through marketing, legal, and localisation reviewers with clear status and audit trails.",
-                },
-                {
-                    title: "Deliver to CMS and campaign tools",
-                    description:
-                        "Sync approved copy to Contentful, Webflow, ad platforms, and your TMS without duplicate handoffs.",
-                },
-                {
-                    title: "Track drift across live campaigns",
-                    description:
-                        "Monitor when published marketing copy falls out of sync with source messaging or glossary rules.",
-                },
-            ],
-        },
-        differentiator: {
-            label: "Why this is different",
-            title: "Translation intelligence for marketing — not a generic TMS",
-            description:
-                "Hyperlocalise connects campaign context, brand rules, and review decisions into one workflow. Your TMS stays the system of record; Hyperlocalise makes sure the right context reaches every locale.",
-            points: [
-                "TMS agnostic",
-                "LLM agnostic",
-                "Human-in-the-loop approvals",
-                "Context-aware from briefs and brand guides",
-                "Built for marketing and localisation operations",
-                "Works across CMS, creative, and campaign workflows",
-            ],
-        },
-        scenario: {
-            label: "Example workflow",
-            title: "A product launch campaign goes live in six markets",
-            narrative:
-                "A growth lead shares a launch brief in Slack with positioning, audience segments, and legal disclaimers. Hyperlocalise structures the campaign for localisation, applies brand glossary and tone rules, generates adapted drafts for each locale, routes them through marketing and legal review, syncs approved copy to the CMS and ad platforms, and flags any locale where messaging has drifted from the approved source.",
-        },
-        cta: {
-            headline: "Bring translation intelligence into your localisation workflow",
-            description: "Request early access to Hyperlocalise.",
-            primaryLabel: "Request a demo",
-        },
+    hero: {
+      eyebrow: "Product localisation",
+      headline: "Product localisation that keeps up with every release",
+      subheadline:
+        "Turn product changes, pull requests, and launch briefs into reviewed, release-ready translations with AI-assisted workflows and human approval built in.",
+      ctaLabel: "Join the waitlist",
     },
-    {
-        slug: "help-center-localisation",
-        metadata: {
-            title: "Help Center Localisation | Hyperlocalise",
-            description:
-                "Keep support articles translated and fresh across locales. Connect CMS updates to review workflows and freshness monitoring without support content lag.",
-            keywords: [
-                "help center localisation",
-                "AI help center translation",
-                "support content localisation",
-                "knowledge base translation",
-            ],
-        },
-        hero: {
-            eyebrow: "Help center localisation",
-            headline: "Support content that stays current in every language",
-            subheadline:
-                "Turn new and updated help articles into reviewed translations, sync them to your CMS, and monitor freshness so customers never read stale guidance.",
-            ctaLabel: "Join the waitlist",
-        },
-        problem: {
-            title: "Support content goes stale the moment it ships in English",
-            description:
-                "Product updates outpace help center translations. Support teams absorb the cost when localized articles lag behind.",
-            pains: [
-                "New articles and updates live in Zendesk, Intercom, Contentful, or Notion — disconnected from localisation queues.",
-                "AI translation misses product terminology, UI labels, and support-specific phrasing.",
-                "Reviewers cannot see what changed in the source article when approving updates.",
-                "Translated articles fall behind after every product release without anyone noticing.",
-                "Support tickets spike in non-English locales when guidance is outdated or missing.",
-            ],
-        },
-        workflow: {
-            label: "How it works",
-            title: "From new article to monitored locale coverage",
-            description:
-                "Hyperlocalise connects CMS change signals to translation, terminology checks, and ongoing freshness monitoring.",
-            steps: [
-                { label: "New article", description: "Detect published or updated support content" },
-                { label: "Content analysis", description: "Extract structure, links, and product terms" },
-                { label: "Translation draft", description: "Generate locale drafts with your LLM" },
-                { label: "Terminology check", description: "Validate glossary and UI label consistency" },
-                { label: "CMS sync", description: "Push approved translations to your help center" },
-                { label: "Freshness monitoring", description: "Alert when locales fall behind source" },
-            ],
-        },
-        capabilities: {
-            label: "Key capabilities",
-            title: "Built for support content at scale",
-            items: [
-                {
-                    title: "Connect to Zendesk, Intercom, Contentful, and more",
-                    description:
-                        "Detect new and updated articles from the CMS and support platforms your team already maintains.",
-                },
-                {
-                    title: "Preserve product terminology and UI labels",
-                    description:
-                        "Apply glossaries and in-product string references so help content matches what users see in the app.",
-                },
-                {
-                    title: "Show reviewers what changed in the source",
-                    description:
-                        "Attach article diffs and product context so reviewers approve updates with full visibility.",
-                },
-                {
-                    title: "Route to support and localisation reviewers",
-                    description:
-                        "Assign articles to the right reviewers based on topic, locale, or expertise.",
-                },
-                {
-                    title: "Sync approved translations back to your CMS",
-                    description:
-                        "Publish localized articles without manual copy-paste between your TMS and help center.",
-                },
-                {
-                    title: "Monitor locale freshness and coverage gaps",
-                    description:
-                        "Track which articles are missing translations or lag behind the English source after product changes.",
-                },
-            ],
-        },
-        differentiator: {
-            label: "Why this is different",
-            title: "Support localisation that stays connected to the product",
-            description:
-                "Hyperlocalise is not another help center tool. It adds an AI-native workflow layer that keeps support content aligned with product changes, glossary rules, and review standards.",
-            points: [
-                "TMS agnostic",
-                "LLM agnostic",
-                "Human-in-the-loop review",
-                "Context-aware from CMS and product docs",
-                "Built for support and localisation operations",
-                "Works across CMS, TMS, and product workflows",
-            ],
-        },
-        scenario: {
-            label: "Example workflow",
-            title: "A billing FAQ update needs to reach twelve locales",
-            narrative:
-                "Support publishes an updated billing FAQ after a pricing change. Hyperlocalise detects the article update, analyzes changed sections and linked product terms, generates translation drafts for each locale, runs terminology checks against the product glossary, routes drafts to support reviewers, syncs approved translations to Zendesk and Contentful, and alerts the team if any locale still shows the pre-change version after forty-eight hours.",
-        },
-        cta: {
-            headline: "Build your AI-native localisation workflow",
-            description:
-                "Join the Hyperlocalise waitlist and see how your team can keep support content current across every locale.",
-            primaryLabel: "Join the waitlist",
-        },
+    problem: {
+      title: "Product strings change faster than localisation can follow",
+      description:
+        "Product teams ship continuously. Localisation teams are left reconciling context across tools after the fact.",
+      pains: [
+        "Product context lives across GitHub, Slack, Notion, Figma, and your TMS — never in one place when translation starts.",
+        "AI drafts miss UI constraints, glossary rules, and what actually changed in the pull request.",
+        "Translation work starts too late in the release cycle, so locales block launches or ship with gaps.",
+        "Engineering and localisation rely on manual spot checks before release instead of structured gates.",
+        "Inconsistent UI copy and terminology drift across locales after every sprint.",
+      ],
     },
-    {
-        slug: "github-release-localisation",
-        metadata: {
-            title: "GitHub Localisation Workflow | Hyperlocalise",
-            description:
-                "Automate localisation checks in CI/CD. Detect string changes in pull requests, draft translations, and gate releases before bad translations reach production.",
-            keywords: [
-                "GitHub localisation workflow",
-                "localisation CI",
-                "software translation automation",
-                "AI localisation for developers",
-            ],
-        },
-        hero: {
-            eyebrow: "GitHub release localisation",
-            headline: "Localisation checks that run with every pull request",
-            subheadline:
-                "Detect string changes, gather PR context, draft translations, and gate releases — so engineering teams catch localisation issues before merge, not after launch.",
-            ctaLabel: "Join the waitlist",
-        },
-        problem: {
-            title: "Localisation is still a manual step outside the release pipeline",
-            description:
-                "Developers merge string changes daily. Localisation quality depends on someone remembering to check before ship.",
-            pains: [
-                "String changes hide in large pull requests without clear localisation impact.",
-                "Engineering and localisation coordinate over Slack instead of inside CI/CD.",
-                "Translation files drift from source strings between releases.",
-                "Release gates depend on manual TMS checks that block deploys unpredictably.",
-                "Bad translations reach production because there is no automated regression layer.",
-            ],
-        },
-        workflow: {
-            label: "How it works",
-            title: "From pull request to release gate",
-            description:
-                "Hyperlocalise fits into the developer workflow your team already runs — with GitHub Actions and TMS sync built in.",
-            steps: [
-                { label: "Pull request", description: "Detect added, changed, and removed strings" },
-                { label: "Change analysis", description: "Map diffs to locales and glossary impact" },
-                { label: "Translation draft", description: "Generate locale drafts with your LLM" },
-                { label: "Review routing", description: "Open review tasks in your TMS" },
-                { label: "CI check", description: "Run localisation gates in GitHub Actions" },
-                { label: "Release gate", description: "Block merge when locales are unresolved" },
-            ],
-        },
-        capabilities: {
-            label: "Key capabilities",
-            title: "Built for developer-led release workflows",
-            items: [
-                {
-                    title: "GitHub Action for localisation checks",
-                    description:
-                        "Run drift detection, coverage checks, and regression evals on every pull request.",
-                },
-                {
-                    title: "Detect string changes from PR diffs",
-                    description:
-                        "Surface added, modified, and removed keys with context from the pull request description and linked issues.",
-                },
-                {
-                    title: "Draft translations with your preferred LLM",
-                    description:
-                        "Generate locale drafts automatically when strings change, using glossary and TM context.",
-                },
-                {
-                    title: "Comment on pull requests with localisation status",
-                    description:
-                        "Give reviewers a clear view of locale coverage, quality flags, and unresolved items before merge.",
-                },
-                {
-                    title: "Sync approved strings to your TMS",
-                    description:
-                        "Push translations to Crowdin, Lokalise, Phrase, or Smartling without leaving the release flow.",
-                },
-                {
-                    title: "Block releases when quality gates fail",
-                    description:
-                        "Configure checks that prevent merge when critical locales are missing or regression thresholds are exceeded.",
-                },
-            ],
-        },
-        differentiator: {
-            label: "Why this is different",
-            title: "Localisation intelligence inside your CI/CD pipeline",
-            description:
-                "Hyperlocalise is not a replacement for your TMS or i18n library. It adds an AI-native layer that connects GitHub change signals, translation drafting, and release gates.",
-            points: [
-                "TMS agnostic",
-                "LLM agnostic",
-                "Human-in-the-loop when review is required",
-                "Context-aware from pull requests and issues",
-                "Built for engineering and localisation operations",
-                "Works across GitHub, TMS, and release tooling",
-            ],
-        },
-        scenario: {
-            label: "Example workflow",
-            title: "A pricing page refactor opens a pull request on Tuesday",
-            narrative:
-                "A developer opens a pull request that renames fourteen UI strings and adds six new ones. Hyperlocalise comments on the PR with affected locales, generates translation drafts using glossary context from the linked launch brief, opens review tasks in Lokalise, runs the GitHub Action to verify all target locales are covered, and blocks merge until German and Japanese reviewers approve the updated pricing terminology.",
-        },
-        cta: {
-            headline: "Build your AI-native localisation workflow",
-            description:
-                "Join the Hyperlocalise waitlist and bring localisation checks into your release pipeline.",
-            primaryLabel: "Join the waitlist",
-        },
+    workflow: {
+      label: "How it works",
+      title: "From pull request to release-ready locales",
+      description:
+        "Hyperlocalise connects product change signals to the review and sync workflow your team already runs.",
+      steps: [
+        { label: "GitHub PR", description: "Detect changed strings and gather PR context" },
+        { label: "Product context", description: "Pull briefs, glossaries, and UI constraints" },
+        { label: "AI translation draft", description: "Generate locale drafts with your LLM" },
+        { label: "Human review", description: "Route to reviewers in your TMS workflow" },
+        { label: "TMS sync", description: "Push approved translations back" },
+        { label: "Release check", description: "Flag unresolved locales before ship" },
+      ],
     },
-    {
-        slug: "localisation-quality-monitoring",
-        metadata: {
-            title: "Localisation Quality Monitoring | Hyperlocalise",
-            description:
-                "Monitor translation quality, terminology drift, and locale coverage at scale. Run quality gates and catch regressions before they reach customers.",
-            keywords: [
-                "localisation quality monitoring",
-                "translation quality automation",
-                "AI translation QA",
-                "localisation QA checks",
-            ],
+    capabilities: {
+      label: "Key capabilities",
+      title: "Built for product release velocity",
+      items: [
+        {
+          title: "Pull product context from where work happens",
+          description:
+            "Gather string changes, PR descriptions, Slack threads, and launch briefs so translators see why copy changed — not just the diff.",
         },
-        hero: {
-            eyebrow: "Localisation quality monitoring",
-            headline: "Catch translation drift before your customers do",
-            subheadline:
-                "Monitor terminology consistency, locale coverage, and translation quality across product, marketing, and support content — with gates that block bad syncs before they go live.",
-            ctaLabel: "Request a demo",
+        {
+          title: "Generate drafts with your preferred LLM",
+          description:
+            "Use OpenAI, Claude, Gemini, or another provider without locking your stack to one model vendor.",
         },
-        problem: {
-            title: "Quality issues surface after launch, not before",
-            description:
-                "Teams ship translations and hope for the best. Drift, missing locales, and terminology breaks accumulate quietly across releases.",
-            pains: [
-                "No single view of locale health across product strings, marketing copy, and support articles.",
-                "Terminology breaks when different teams translate the same product terms independently.",
-                "Regression checks run manually — or not at all — before major releases.",
-                "Review coverage is unclear: which locales were human-approved vs. machine-translated only.",
-                "Quality problems are discovered by customers, support tickets, or app store reviews.",
-            ],
+        {
+          title: "Apply glossary, tone, and UI constraints before review",
+          description:
+            "Enforce terminology, character limits, and product voice before drafts reach human reviewers.",
         },
-        workflow: {
-            label: "How it works",
-            title: "From content sync to ongoing quality monitoring",
-            description:
-                "Hyperlocalise runs quality checks at every stage — draft, review, sync, and after publish.",
-            steps: [
-                { label: "Content sync", description: "Track strings across TMS and sources" },
-                { label: "Quality analysis", description: "Run glossary, drift, and coverage checks" },
-                { label: "Regression eval", description: "Compare against approved baselines" },
-                { label: "Review routing", description: "Escalate flagged items to reviewers" },
-                { label: "Release gate", description: "Block sync when thresholds fail" },
-                { label: "Ongoing monitor", description: "Alert on drift after publish" },
-            ],
+        {
+          title: "Route work to reviewers inside your existing workflow",
+          description:
+            "Keep review assignments, approvals, and comments in the TMS your localisation team already uses.",
         },
-        capabilities: {
-            label: "Key capabilities",
-            title: "Built for quality at scale",
-            items: [
-                {
-                    title: "Monitor locale coverage across all content types",
-                    description:
-                        "See which locales are complete, partial, or missing for product, marketing, and support content.",
-                },
-                {
-                    title: "Detect terminology drift and glossary violations",
-                    description:
-                        "Flag when translations diverge from approved terminology or when source strings change without locale updates.",
-                },
-                {
-                    title: "Run regression evals before sync and release",
-                    description:
-                        "Compare new translations against approved baselines and block sync when quality thresholds fail.",
-                },
-                {
-                    title: "Track review coverage and approval status",
-                    description:
-                        "Know which strings were human-reviewed, machine-translated only, or pending approval per locale.",
-                },
-                {
-                    title: "Surface quality issues in pull requests",
-                    description:
-                        "Show localisation health directly in GitHub so engineering and localisation share one view.",
-                },
-                {
-                    title: "Alert on post-publish drift",
-                    description:
-                        "Monitor live content for terminology breaks, missing updates, and locale gaps after release.",
-                },
-            ],
+        {
+          title: "Sync with your TMS instead of replacing it",
+          description:
+            "Push approved strings to Crowdin, Lokalise, Phrase, Smartling, or another platform without a migration project.",
         },
-        differentiator: {
-            label: "Why this is different",
-            title: "Quality monitoring across your stack — not a point-in-time QA tool",
-            description:
-                "Hyperlocalise connects quality checks to the workflows where content is created, reviewed, and synced. Your TMS stays the system of record; Hyperlocalise makes quality visible at every step.",
-            points: [
-                "TMS agnostic",
-                "LLM agnostic",
-                "Human-in-the-loop escalation",
-                "Context-aware quality checks",
-                "Built for localisation operations and release confidence",
-                "Works across product, marketing, support, and engineering",
-            ],
+        {
+          title: "Catch bad translations before production",
+          description:
+            "Run release checks and regression gates so unresolved locales and quality issues surface before merge.",
         },
-        scenario: {
-            label: "Example workflow",
-            title: "A glossary update needs to propagate across three content types",
-            narrative:
-                "Localisation updates the product glossary after a rebrand. Hyperlocalise scans product strings, marketing landing pages, and help center articles for terminology that no longer matches, runs regression evals against approved baselines, routes flagged strings to reviewers, blocks TMS sync for locales that fail the threshold, and continues monitoring published content for drift over the following two weeks.",
-        },
-        cta: {
-            headline: "Bring translation intelligence into your localisation workflow",
-            description: "Request early access to Hyperlocalise.",
-            primaryLabel: "Request a demo",
-        },
+      ],
     },
-    {
-        slug: "localisation-operations",
-        metadata: {
-            title: "Localisation Operations Platform | Hyperlocalise",
-            description:
-                "Orchestrate localisation across TMS platforms, LLM providers, vendors, and reviewers. One workflow layer for localisation managers without replacing your stack.",
-            keywords: [
-                "localisation operations platform",
-                "AI localisation operations",
-                "TMS agnostic localisation",
-                "translation workflow automation",
-            ],
-        },
-        hero: {
-            eyebrow: "Localisation operations",
-            headline: "One operations layer across your entire localisation stack",
-            subheadline:
-                "Orchestrate agents, reviewers, vendors, LLMs, and TMS platforms in a single workflow — without replacing the tools your team already depends on.",
-            ctaLabel: "Request a demo",
-        },
-        problem: {
-            title: "Localisation operations span too many disconnected systems",
-            description:
-                "Localisation managers coordinate across TMS tools, model providers, vendors, and engineering — with no unified view of what is in flight.",
-            pains: [
-                "Work arrives from product, marketing, support, and engineering through different channels with no shared intake.",
-                "Switching LLM providers or TMS platforms disrupts established workflows.",
-                "Vendor and reviewer assignments happen manually across spreadsheets and Slack.",
-                "Approvals and status live in the TMS while context lives elsewhere.",
-                "Reporting on throughput, quality, and locale coverage requires stitching data from multiple tools.",
-            ],
-        },
-        workflow: {
-            label: "How it works",
-            title: "From intake to orchestrated delivery",
-            description:
-                "Hyperlocalise gives localisation operations a single control plane across sources, models, reviewers, and sync targets.",
-            steps: [
-                { label: "Intake", description: "Collect work from GitHub, Slack, CMS, and TMS" },
-                { label: "Context assembly", description: "Attach glossaries, briefs, and history" },
-                { label: "Agent assignment", description: "Route to LLM agents or human reviewers" },
-                { label: "Review & approval", description: "Track decisions across stakeholders" },
-                { label: "TMS sync", description: "Push approved work to your platform" },
-                { label: "Operations report", description: "Monitor throughput and locale health" },
-            ],
-        },
-        capabilities: {
-            label: "Key capabilities",
-            title: "Built for localisation managers",
-            items: [
-                {
-                    title: "Unified intake across product, marketing, and support",
-                    description:
-                        "Collect localisation requests from GitHub, Slack, CMS platforms, and your TMS into one queue.",
-                },
-                {
-                    title: "Orchestrate agents, vendors, and internal reviewers",
-                    description:
-                        "Assign translation, review, and QA work based on locale, content type, or expertise.",
-                },
-                {
-                    title: "Switch LLM providers without workflow redesign",
-                    description:
-                        "Use different models for different content types while keeping review and sync logic consistent.",
-                },
-                {
-                    title: "Stay TMS agnostic across platforms",
-                    description:
-                        "Operate across Crowdin, Lokalise, Phrase, Smartling, and other TMS tools from one workflow layer.",
-                },
-                {
-                    title: "Track approvals and audit trails",
-                    description:
-                        "See who approved what, when, and with what context — across agents and human reviewers.",
-                },
-                {
-                    title: "Report on throughput, coverage, and quality",
-                    description:
-                        "Monitor locale health, review backlog, and quality trends without exporting from three systems.",
-                },
-            ],
-        },
-        differentiator: {
-            label: "Why this is different",
-            title: "An operations platform that connects your stack — not another silo",
-            description:
-                "Hyperlocalise is not a TMS replacement. It is the workflow layer localisation operations teams use to orchestrate agents, humans, models, and platforms without a rip-and-replace migration.",
-            points: [
-                "TMS agnostic",
-                "LLM agnostic",
-                "Human-in-the-loop orchestration",
-                "Context-aware across all content sources",
-                "Built for localisation operations at scale",
-                "Works across product, marketing, support, and engineering",
-            ],
-        },
-        scenario: {
-            label: "Example workflow",
-            title: "A localisation manager plans the quarter across four content streams",
-            narrative:
-                "A localisation manager receives intake from a product release, a marketing campaign, twelve updated help articles, and a vendor translation batch. Hyperlocalise structures each stream with the right context and glossary rules, assigns product strings to an LLM agent with human review, routes marketing copy through legal approval, sends vendor work to the TMS with quality gates, and surfaces a single dashboard showing locale coverage, review backlog, and blocked releases across all four streams.",
-        },
-        cta: {
-            headline: "Build your AI-native localisation workflow",
-            description:
-                "Join the Hyperlocalise waitlist and see how your operations team can orchestrate localisation without replacing your existing tools.",
-            primaryLabel: "Join the waitlist",
-        },
+    differentiator: {
+      label: "Why this is different",
+      title: "An AI-native layer across your product stack — not another TMS",
+      description:
+        "Hyperlocalise is not here to replace your TMS. It adds a workflow layer that connects engineering change signals, LLM-assisted drafting, human review, and release confidence.",
+      points: [
+        "TMS agnostic",
+        "LLM agnostic",
+        "Human-in-the-loop by design",
+        "Context-aware from GitHub and product briefs",
+        "Built for localisation operations at release speed",
+        "Works across engineering, product, and localisation workflows",
+      ],
     },
+    scenario: {
+      label: "Example workflow",
+      title: "A new onboarding flow ships in Friday's release",
+      narrative:
+        "A product manager merges a pull request with a redesigned onboarding flow. Hyperlocalise detects changed strings, gathers context from the PR and product brief, creates translation drafts for each target locale, checks glossary and tone rules, routes them to reviewers in the TMS, syncs approved translations back, and flags unresolved locales before the release train leaves the station.",
+    },
+    cta: {
+      headline: "Build your AI-native localisation workflow",
+      description:
+        "Join the Hyperlocalise waitlist and see how your team can launch global product content faster without replacing your existing tools.",
+      primaryLabel: "Join the waitlist",
+    },
+  },
+  {
+    slug: "marketing-localisation",
+    metadata: {
+      title: "Marketing Localisation Platform | Hyperlocalise",
+      description:
+        "Turn campaign briefs into brand-safe, locale-adapted marketing copy with review workflows and asset delivery built in. Keep global messaging consistent without slowing launches.",
+      keywords: [
+        "marketing localisation platform",
+        "AI marketing translation",
+        "campaign localisation",
+        "brand-safe translation",
+      ],
+    },
+    hero: {
+      eyebrow: "Marketing localisation",
+      headline: "Campaign localisation that protects brand voice in every market",
+      subheadline:
+        "Turn launch briefs, campaign assets, and regional messaging into reviewed, culturally adapted copy — with approval flows and glossary control built in.",
+      ctaLabel: "Request a demo",
+    },
+    problem: {
+      title: "Global campaigns break when context stays in the brief",
+      description:
+        "Marketing teams move fast. Localisation becomes a bottleneck when brand nuance and regional intent never reach the translator.",
+      pains: [
+        "Campaign context sits in Notion, Figma, Slack, and agency decks — not in the translation workflow.",
+        "Generic AI translation flattens brand voice, cultural references, and regional nuance.",
+        "Approval chains span marketing, legal, and localisation with no shared view of what changed.",
+        "Landing pages and ads drift across locales after the initial launch push.",
+        "Performance learnings from one market rarely feed back into the next campaign cycle.",
+      ],
+    },
+    workflow: {
+      label: "How it works",
+      title: "From campaign brief to market-ready assets",
+      description:
+        "Hyperlocalise carries brand context through adaptation, review, and delivery so every locale ships with intent intact.",
+      steps: [
+        { label: "Campaign brief", description: "Capture goals, audience, and messaging" },
+        { label: "Brand context", description: "Apply voice, glossary, and legal guardrails" },
+        { label: "Locale adaptation", description: "Adapt copy for regional nuance" },
+        { label: "Review workflow", description: "Route to marketing and legal reviewers" },
+        { label: "Asset delivery", description: "Sync approved copy to CMS and ad platforms" },
+        { label: "Performance learning", description: "Feed locale results into the next cycle" },
+      ],
+    },
+    capabilities: {
+      label: "Key capabilities",
+      title: "Built for brand-safe global campaigns",
+      items: [
+        {
+          title: "Ingest campaign briefs and creative context",
+          description:
+            "Pull messaging intent, audience notes, and creative direction from the tools marketing teams already use.",
+        },
+        {
+          title: "Enforce brand voice and terminology",
+          description:
+            "Apply glossaries, tone guides, and do-not-translate rules before drafts reach reviewers.",
+        },
+        {
+          title: "Adapt for regional nuance, not word-for-word translation",
+          description:
+            "Generate locale-aware drafts that respect cultural context while keeping campaign intent aligned.",
+        },
+        {
+          title: "Run multi-stakeholder approval flows",
+          description:
+            "Route copy through marketing, legal, and localisation reviewers with clear status and audit trails.",
+        },
+        {
+          title: "Deliver to CMS and campaign tools",
+          description:
+            "Sync approved copy to Contentful, Webflow, ad platforms, and your TMS without duplicate handoffs.",
+        },
+        {
+          title: "Track drift across live campaigns",
+          description:
+            "Monitor when published marketing copy falls out of sync with source messaging or glossary rules.",
+        },
+      ],
+    },
+    differentiator: {
+      label: "Why this is different",
+      title: "Translation intelligence for marketing — not a generic TMS",
+      description:
+        "Hyperlocalise connects campaign context, brand rules, and review decisions into one workflow. Your TMS stays the system of record; Hyperlocalise makes sure the right context reaches every locale.",
+      points: [
+        "TMS agnostic",
+        "LLM agnostic",
+        "Human-in-the-loop approvals",
+        "Context-aware from briefs and brand guides",
+        "Built for marketing and localisation operations",
+        "Works across CMS, creative, and campaign workflows",
+      ],
+    },
+    scenario: {
+      label: "Example workflow",
+      title: "A product launch campaign goes live in six markets",
+      narrative:
+        "A growth lead shares a launch brief in Slack with positioning, audience segments, and legal disclaimers. Hyperlocalise structures the campaign for localisation, applies brand glossary and tone rules, generates adapted drafts for each locale, routes them through marketing and legal review, syncs approved copy to the CMS and ad platforms, and flags any locale where messaging has drifted from the approved source.",
+    },
+    cta: {
+      headline: "Bring translation intelligence into your localisation workflow",
+      description: "Request early access to Hyperlocalise.",
+      primaryLabel: "Request a demo",
+    },
+  },
+  {
+    slug: "help-center-localisation",
+    metadata: {
+      title: "Help Center Localisation | Hyperlocalise",
+      description:
+        "Keep support articles translated and fresh across locales. Connect CMS updates to review workflows and freshness monitoring without support content lag.",
+      keywords: [
+        "help center localisation",
+        "AI help center translation",
+        "support content localisation",
+        "knowledge base translation",
+      ],
+    },
+    hero: {
+      eyebrow: "Help center localisation",
+      headline: "Support content that stays current in every language",
+      subheadline:
+        "Turn new and updated help articles into reviewed translations, sync them to your CMS, and monitor freshness so customers never read stale guidance.",
+      ctaLabel: "Join the waitlist",
+    },
+    problem: {
+      title: "Support content goes stale the moment it ships in English",
+      description:
+        "Product updates outpace help center translations. Support teams absorb the cost when localized articles lag behind.",
+      pains: [
+        "New articles and updates live in Zendesk, Intercom, Contentful, or Notion — disconnected from localisation queues.",
+        "AI translation misses product terminology, UI labels, and support-specific phrasing.",
+        "Reviewers cannot see what changed in the source article when approving updates.",
+        "Translated articles fall behind after every product release without anyone noticing.",
+        "Support tickets spike in non-English locales when guidance is outdated or missing.",
+      ],
+    },
+    workflow: {
+      label: "How it works",
+      title: "From new article to monitored locale coverage",
+      description:
+        "Hyperlocalise connects CMS change signals to translation, terminology checks, and ongoing freshness monitoring.",
+      steps: [
+        { label: "New article", description: "Detect published or updated support content" },
+        { label: "Content analysis", description: "Extract structure, links, and product terms" },
+        { label: "Translation draft", description: "Generate locale drafts with your LLM" },
+        { label: "Terminology check", description: "Validate glossary and UI label consistency" },
+        { label: "CMS sync", description: "Push approved translations to your help center" },
+        { label: "Freshness monitoring", description: "Alert when locales fall behind source" },
+      ],
+    },
+    capabilities: {
+      label: "Key capabilities",
+      title: "Built for support content at scale",
+      items: [
+        {
+          title: "Connect to Zendesk, Intercom, Contentful, and more",
+          description:
+            "Detect new and updated articles from the CMS and support platforms your team already maintains.",
+        },
+        {
+          title: "Preserve product terminology and UI labels",
+          description:
+            "Apply glossaries and in-product string references so help content matches what users see in the app.",
+        },
+        {
+          title: "Show reviewers what changed in the source",
+          description:
+            "Attach article diffs and product context so reviewers approve updates with full visibility.",
+        },
+        {
+          title: "Route to support and localisation reviewers",
+          description:
+            "Assign articles to the right reviewers based on topic, locale, or expertise.",
+        },
+        {
+          title: "Sync approved translations back to your CMS",
+          description:
+            "Publish localized articles without manual copy-paste between your TMS and help center.",
+        },
+        {
+          title: "Monitor locale freshness and coverage gaps",
+          description:
+            "Track which articles are missing translations or lag behind the English source after product changes.",
+        },
+      ],
+    },
+    differentiator: {
+      label: "Why this is different",
+      title: "Support localisation that stays connected to the product",
+      description:
+        "Hyperlocalise is not another help center tool. It adds an AI-native workflow layer that keeps support content aligned with product changes, glossary rules, and review standards.",
+      points: [
+        "TMS agnostic",
+        "LLM agnostic",
+        "Human-in-the-loop review",
+        "Context-aware from CMS and product docs",
+        "Built for support and localisation operations",
+        "Works across CMS, TMS, and product workflows",
+      ],
+    },
+    scenario: {
+      label: "Example workflow",
+      title: "A billing FAQ update needs to reach twelve locales",
+      narrative:
+        "Support publishes an updated billing FAQ after a pricing change. Hyperlocalise detects the article update, analyzes changed sections and linked product terms, generates translation drafts for each locale, runs terminology checks against the product glossary, routes drafts to support reviewers, syncs approved translations to Zendesk and Contentful, and alerts the team if any locale still shows the pre-change version after forty-eight hours.",
+    },
+    cta: {
+      headline: "Build your AI-native localisation workflow",
+      description:
+        "Join the Hyperlocalise waitlist and see how your team can keep support content current across every locale.",
+      primaryLabel: "Join the waitlist",
+    },
+  },
+  {
+    slug: "github-release-localisation",
+    metadata: {
+      title: "GitHub Localisation Workflow | Hyperlocalise",
+      description:
+        "Automate localisation checks in CI/CD. Detect string changes in pull requests, draft translations, and gate releases before bad translations reach production.",
+      keywords: [
+        "GitHub localisation workflow",
+        "localisation CI",
+        "software translation automation",
+        "AI localisation for developers",
+      ],
+    },
+    hero: {
+      eyebrow: "GitHub release localisation",
+      headline: "Localisation checks that run with every pull request",
+      subheadline:
+        "Detect string changes, gather PR context, draft translations, and gate releases — so engineering teams catch localisation issues before merge, not after launch.",
+      ctaLabel: "Join the waitlist",
+    },
+    problem: {
+      title: "Localisation is still a manual step outside the release pipeline",
+      description:
+        "Developers merge string changes daily. Localisation quality depends on someone remembering to check before ship.",
+      pains: [
+        "String changes hide in large pull requests without clear localisation impact.",
+        "Engineering and localisation coordinate over Slack instead of inside CI/CD.",
+        "Translation files drift from source strings between releases.",
+        "Release gates depend on manual TMS checks that block deploys unpredictably.",
+        "Bad translations reach production because there is no automated regression layer.",
+      ],
+    },
+    workflow: {
+      label: "How it works",
+      title: "From pull request to release gate",
+      description:
+        "Hyperlocalise fits into the developer workflow your team already runs — with GitHub Actions and TMS sync built in.",
+      steps: [
+        { label: "Pull request", description: "Detect added, changed, and removed strings" },
+        { label: "Change analysis", description: "Map diffs to locales and glossary impact" },
+        { label: "Translation draft", description: "Generate locale drafts with your LLM" },
+        { label: "Review routing", description: "Open review tasks in your TMS" },
+        { label: "CI check", description: "Run localisation gates in GitHub Actions" },
+        { label: "Release gate", description: "Block merge when locales are unresolved" },
+      ],
+    },
+    capabilities: {
+      label: "Key capabilities",
+      title: "Built for developer-led release workflows",
+      items: [
+        {
+          title: "GitHub Action for localisation checks",
+          description:
+            "Run drift detection, coverage checks, and regression evals on every pull request.",
+        },
+        {
+          title: "Detect string changes from PR diffs",
+          description:
+            "Surface added, modified, and removed keys with context from the pull request description and linked issues.",
+        },
+        {
+          title: "Draft translations with your preferred LLM",
+          description:
+            "Generate locale drafts automatically when strings change, using glossary and TM context.",
+        },
+        {
+          title: "Comment on pull requests with localisation status",
+          description:
+            "Give reviewers a clear view of locale coverage, quality flags, and unresolved items before merge.",
+        },
+        {
+          title: "Sync approved strings to your TMS",
+          description:
+            "Push translations to Crowdin, Lokalise, Phrase, or Smartling without leaving the release flow.",
+        },
+        {
+          title: "Block releases when quality gates fail",
+          description:
+            "Configure checks that prevent merge when critical locales are missing or regression thresholds are exceeded.",
+        },
+      ],
+    },
+    differentiator: {
+      label: "Why this is different",
+      title: "Localisation intelligence inside your CI/CD pipeline",
+      description:
+        "Hyperlocalise is not a replacement for your TMS or i18n library. It adds an AI-native layer that connects GitHub change signals, translation drafting, and release gates.",
+      points: [
+        "TMS agnostic",
+        "LLM agnostic",
+        "Human-in-the-loop when review is required",
+        "Context-aware from pull requests and issues",
+        "Built for engineering and localisation operations",
+        "Works across GitHub, TMS, and release tooling",
+      ],
+    },
+    scenario: {
+      label: "Example workflow",
+      title: "A pricing page refactor opens a pull request on Tuesday",
+      narrative:
+        "A developer opens a pull request that renames fourteen UI strings and adds six new ones. Hyperlocalise comments on the PR with affected locales, generates translation drafts using glossary context from the linked launch brief, opens review tasks in Lokalise, runs the GitHub Action to verify all target locales are covered, and blocks merge until German and Japanese reviewers approve the updated pricing terminology.",
+    },
+    cta: {
+      headline: "Build your AI-native localisation workflow",
+      description:
+        "Join the Hyperlocalise waitlist and bring localisation checks into your release pipeline.",
+      primaryLabel: "Join the waitlist",
+    },
+  },
+  {
+    slug: "localisation-quality-monitoring",
+    metadata: {
+      title: "Localisation Quality Monitoring | Hyperlocalise",
+      description:
+        "Monitor translation quality, terminology drift, and locale coverage at scale. Run quality gates and catch regressions before they reach customers.",
+      keywords: [
+        "localisation quality monitoring",
+        "translation quality automation",
+        "AI translation QA",
+        "localisation QA checks",
+      ],
+    },
+    hero: {
+      eyebrow: "Localisation quality monitoring",
+      headline: "Catch translation drift before your customers do",
+      subheadline:
+        "Monitor terminology consistency, locale coverage, and translation quality across product, marketing, and support content — with gates that block bad syncs before they go live.",
+      ctaLabel: "Request a demo",
+    },
+    problem: {
+      title: "Quality issues surface after launch, not before",
+      description:
+        "Teams ship translations and hope for the best. Drift, missing locales, and terminology breaks accumulate quietly across releases.",
+      pains: [
+        "No single view of locale health across product strings, marketing copy, and support articles.",
+        "Terminology breaks when different teams translate the same product terms independently.",
+        "Regression checks run manually — or not at all — before major releases.",
+        "Review coverage is unclear: which locales were human-approved vs. machine-translated only.",
+        "Quality problems are discovered by customers, support tickets, or app store reviews.",
+      ],
+    },
+    workflow: {
+      label: "How it works",
+      title: "From content sync to ongoing quality monitoring",
+      description:
+        "Hyperlocalise runs quality checks at every stage — draft, review, sync, and after publish.",
+      steps: [
+        { label: "Content sync", description: "Track strings across TMS and sources" },
+        { label: "Quality analysis", description: "Run glossary, drift, and coverage checks" },
+        { label: "Regression eval", description: "Compare against approved baselines" },
+        { label: "Review routing", description: "Escalate flagged items to reviewers" },
+        { label: "Release gate", description: "Block sync when thresholds fail" },
+        { label: "Ongoing monitor", description: "Alert on drift after publish" },
+      ],
+    },
+    capabilities: {
+      label: "Key capabilities",
+      title: "Built for quality at scale",
+      items: [
+        {
+          title: "Monitor locale coverage across all content types",
+          description:
+            "See which locales are complete, partial, or missing for product, marketing, and support content.",
+        },
+        {
+          title: "Detect terminology drift and glossary violations",
+          description:
+            "Flag when translations diverge from approved terminology or when source strings change without locale updates.",
+        },
+        {
+          title: "Run regression evals before sync and release",
+          description:
+            "Compare new translations against approved baselines and block sync when quality thresholds fail.",
+        },
+        {
+          title: "Track review coverage and approval status",
+          description:
+            "Know which strings were human-reviewed, machine-translated only, or pending approval per locale.",
+        },
+        {
+          title: "Surface quality issues in pull requests",
+          description:
+            "Show localisation health directly in GitHub so engineering and localisation share one view.",
+        },
+        {
+          title: "Alert on post-publish drift",
+          description:
+            "Monitor live content for terminology breaks, missing updates, and locale gaps after release.",
+        },
+      ],
+    },
+    differentiator: {
+      label: "Why this is different",
+      title: "Quality monitoring across your stack — not a point-in-time QA tool",
+      description:
+        "Hyperlocalise connects quality checks to the workflows where content is created, reviewed, and synced. Your TMS stays the system of record; Hyperlocalise makes quality visible at every step.",
+      points: [
+        "TMS agnostic",
+        "LLM agnostic",
+        "Human-in-the-loop escalation",
+        "Context-aware quality checks",
+        "Built for localisation operations and release confidence",
+        "Works across product, marketing, support, and engineering",
+      ],
+    },
+    scenario: {
+      label: "Example workflow",
+      title: "A glossary update needs to propagate across three content types",
+      narrative:
+        "Localisation updates the product glossary after a rebrand. Hyperlocalise scans product strings, marketing landing pages, and help center articles for terminology that no longer matches, runs regression evals against approved baselines, routes flagged strings to reviewers, blocks TMS sync for locales that fail the threshold, and continues monitoring published content for drift over the following two weeks.",
+    },
+    cta: {
+      headline: "Bring translation intelligence into your localisation workflow",
+      description: "Request early access to Hyperlocalise.",
+      primaryLabel: "Request a demo",
+    },
+  },
+  {
+    slug: "localisation-operations",
+    metadata: {
+      title: "Localisation Operations Platform | Hyperlocalise",
+      description:
+        "Orchestrate localisation across TMS platforms, LLM providers, vendors, and reviewers. One workflow layer for localisation managers without replacing your stack.",
+      keywords: [
+        "localisation operations platform",
+        "AI localisation operations",
+        "TMS agnostic localisation",
+        "translation workflow automation",
+      ],
+    },
+    hero: {
+      eyebrow: "Localisation operations",
+      headline: "One operations layer across your entire localisation stack",
+      subheadline:
+        "Orchestrate agents, reviewers, vendors, LLMs, and TMS platforms in a single workflow — without replacing the tools your team already depends on.",
+      ctaLabel: "Request a demo",
+    },
+    problem: {
+      title: "Localisation operations span too many disconnected systems",
+      description:
+        "Localisation managers coordinate across TMS tools, model providers, vendors, and engineering — with no unified view of what is in flight.",
+      pains: [
+        "Work arrives from product, marketing, support, and engineering through different channels with no shared intake.",
+        "Switching LLM providers or TMS platforms disrupts established workflows.",
+        "Vendor and reviewer assignments happen manually across spreadsheets and Slack.",
+        "Approvals and status live in the TMS while context lives elsewhere.",
+        "Reporting on throughput, quality, and locale coverage requires stitching data from multiple tools.",
+      ],
+    },
+    workflow: {
+      label: "How it works",
+      title: "From intake to orchestrated delivery",
+      description:
+        "Hyperlocalise gives localisation operations a single control plane across sources, models, reviewers, and sync targets.",
+      steps: [
+        { label: "Intake", description: "Collect work from GitHub, Slack, CMS, and TMS" },
+        { label: "Context assembly", description: "Attach glossaries, briefs, and history" },
+        { label: "Agent assignment", description: "Route to LLM agents or human reviewers" },
+        { label: "Review & approval", description: "Track decisions across stakeholders" },
+        { label: "TMS sync", description: "Push approved work to your platform" },
+        { label: "Operations report", description: "Monitor throughput and locale health" },
+      ],
+    },
+    capabilities: {
+      label: "Key capabilities",
+      title: "Built for localisation managers",
+      items: [
+        {
+          title: "Unified intake across product, marketing, and support",
+          description:
+            "Collect localisation requests from GitHub, Slack, CMS platforms, and your TMS into one queue.",
+        },
+        {
+          title: "Orchestrate agents, vendors, and internal reviewers",
+          description:
+            "Assign translation, review, and QA work based on locale, content type, or expertise.",
+        },
+        {
+          title: "Switch LLM providers without workflow redesign",
+          description:
+            "Use different models for different content types while keeping review and sync logic consistent.",
+        },
+        {
+          title: "Stay TMS agnostic across platforms",
+          description:
+            "Operate across Crowdin, Lokalise, Phrase, Smartling, and other TMS tools from one workflow layer.",
+        },
+        {
+          title: "Track approvals and audit trails",
+          description:
+            "See who approved what, when, and with what context — across agents and human reviewers.",
+        },
+        {
+          title: "Report on throughput, coverage, and quality",
+          description:
+            "Monitor locale health, review backlog, and quality trends without exporting from three systems.",
+        },
+      ],
+    },
+    differentiator: {
+      label: "Why this is different",
+      title: "An operations platform that connects your stack — not another silo",
+      description:
+        "Hyperlocalise is not a TMS replacement. It is the workflow layer localisation operations teams use to orchestrate agents, humans, models, and platforms without a rip-and-replace migration.",
+      points: [
+        "TMS agnostic",
+        "LLM agnostic",
+        "Human-in-the-loop orchestration",
+        "Context-aware across all content sources",
+        "Built for localisation operations at scale",
+        "Works across product, marketing, support, and engineering",
+      ],
+    },
+    scenario: {
+      label: "Example workflow",
+      title: "A localisation manager plans the quarter across four content streams",
+      narrative:
+        "A localisation manager receives intake from a product release, a marketing campaign, twelve updated help articles, and a vendor translation batch. Hyperlocalise structures each stream with the right context and glossary rules, assigns product strings to an LLM agent with human review, routes marketing copy through legal approval, sends vendor work to the TMS with quality gates, and surfaces a single dashboard showing locale coverage, review backlog, and blocked releases across all four streams.",
+    },
+    cta: {
+      headline: "Build your AI-native localisation workflow",
+      description:
+        "Join the Hyperlocalise waitlist and see how your operations team can orchestrate localisation without replacing your existing tools.",
+      primaryLabel: "Join the waitlist",
+    },
+  },
 ];
 
 export const useCasePagesBySlug = Object.fromEntries(
-    useCasePages.map((page) => [page.slug, page]),
+  useCasePages.map((page) => [page.slug, page]),
 ) as Record<string, UseCasePageContent>;
 
 export const useCaseSlugs = useCasePages.map((page) => page.slug);
 
 export const useCaseFooterLinks = useCasePages.map((page) => ({
-    label: page.hero.eyebrow,
-    href: `/use-cases/${page.slug}`,
+  label: page.hero.eyebrow,
+  href: `/use-cases/${page.slug}`,
 }));

--- a/apps/hyperlocalise-web/src/components/marketing/use-case/use-case-page.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/use-case/use-case-page.tsx
@@ -1,0 +1,57 @@
+import { MarketingFooter } from "@/components/marketing/marketing-footer";
+import { footerColumns } from "@/components/marketing/marketing-page-content";
+
+import type { UseCasePageContent } from "./use-case-page-content";
+import {
+    UseCaseCapabilitiesSection,
+    UseCaseCtaSection,
+    UseCaseDifferentiatorSection,
+    UseCaseHero,
+    UseCaseProblemSection,
+    UseCaseScenarioSection,
+    UseCaseWorkflowSection,
+} from "./use-case-sections";
+
+type UseCasePageProps = {
+    content: UseCasePageContent;
+};
+
+export function UseCasePage({ content }: UseCasePageProps) {
+    return (
+        <div className="min-h-screen bg-background text-foreground">
+            <main className="mx-auto max-w-7xl">
+                <section className="px-5 pb-14 pt-8 sm:px-8 lg:px-10 lg:pt-10">
+                    <UseCaseHero content={content.hero} />
+                </section>
+
+                <section className="border-t border-border/70 px-5 py-20 sm:px-8 lg:px-10">
+                    <UseCaseProblemSection content={content.problem} />
+                </section>
+
+                <section className="border-t border-border/70 px-5 py-20 sm:px-8 lg:px-10">
+                    <UseCaseWorkflowSection content={content.workflow} />
+                </section>
+
+                <section className="border-t border-border/70 px-5 py-20 sm:px-8 lg:px-10">
+                    <UseCaseCapabilitiesSection content={content.capabilities} />
+                </section>
+
+                <section className="border-t border-border/70 px-5 py-20 sm:px-8 lg:px-10">
+                    <UseCaseDifferentiatorSection content={content.differentiator} />
+                </section>
+
+                <section className="border-t border-border/70 px-5 py-20 sm:px-8 lg:px-10">
+                    <UseCaseScenarioSection content={content.scenario} />
+                </section>
+
+                <section className="border-t border-border/70 px-5 py-24 sm:px-8 lg:px-10">
+                    <UseCaseCtaSection content={content.cta} />
+                </section>
+
+                <section className="border-t border-border/70 px-5 py-16 sm:px-8 lg:px-10">
+                    <MarketingFooter columns={footerColumns} />
+                </section>
+            </main>
+        </div>
+    );
+}

--- a/apps/hyperlocalise-web/src/components/marketing/use-case/use-case-page.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/use-case/use-case-page.tsx
@@ -3,55 +3,55 @@ import { footerColumns } from "@/components/marketing/marketing-page-content";
 
 import type { UseCasePageContent } from "./use-case-page-content";
 import {
-    UseCaseCapabilitiesSection,
-    UseCaseCtaSection,
-    UseCaseDifferentiatorSection,
-    UseCaseHero,
-    UseCaseProblemSection,
-    UseCaseScenarioSection,
-    UseCaseWorkflowSection,
+  UseCaseCapabilitiesSection,
+  UseCaseCtaSection,
+  UseCaseDifferentiatorSection,
+  UseCaseHero,
+  UseCaseProblemSection,
+  UseCaseScenarioSection,
+  UseCaseWorkflowSection,
 } from "./use-case-sections";
 
 type UseCasePageProps = {
-    content: UseCasePageContent;
+  content: UseCasePageContent;
 };
 
 export function UseCasePage({ content }: UseCasePageProps) {
-    return (
-        <div className="min-h-screen bg-background text-foreground">
-            <main className="mx-auto max-w-7xl">
-                <section className="px-5 pb-14 pt-8 sm:px-8 lg:px-10 lg:pt-10">
-                    <UseCaseHero content={content.hero} />
-                </section>
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <main className="mx-auto max-w-7xl">
+        <section className="px-5 pb-14 pt-8 sm:px-8 lg:px-10 lg:pt-10">
+          <UseCaseHero content={content.hero} />
+        </section>
 
-                <section className="border-t border-border/70 px-5 py-20 sm:px-8 lg:px-10">
-                    <UseCaseProblemSection content={content.problem} />
-                </section>
+        <section className="border-t border-border/70 px-5 py-20 sm:px-8 lg:px-10">
+          <UseCaseProblemSection content={content.problem} />
+        </section>
 
-                <section className="border-t border-border/70 px-5 py-20 sm:px-8 lg:px-10">
-                    <UseCaseWorkflowSection content={content.workflow} />
-                </section>
+        <section className="border-t border-border/70 px-5 py-20 sm:px-8 lg:px-10">
+          <UseCaseWorkflowSection content={content.workflow} />
+        </section>
 
-                <section className="border-t border-border/70 px-5 py-20 sm:px-8 lg:px-10">
-                    <UseCaseCapabilitiesSection content={content.capabilities} />
-                </section>
+        <section className="border-t border-border/70 px-5 py-20 sm:px-8 lg:px-10">
+          <UseCaseCapabilitiesSection content={content.capabilities} />
+        </section>
 
-                <section className="border-t border-border/70 px-5 py-20 sm:px-8 lg:px-10">
-                    <UseCaseDifferentiatorSection content={content.differentiator} />
-                </section>
+        <section className="border-t border-border/70 px-5 py-20 sm:px-8 lg:px-10">
+          <UseCaseDifferentiatorSection content={content.differentiator} />
+        </section>
 
-                <section className="border-t border-border/70 px-5 py-20 sm:px-8 lg:px-10">
-                    <UseCaseScenarioSection content={content.scenario} />
-                </section>
+        <section className="border-t border-border/70 px-5 py-20 sm:px-8 lg:px-10">
+          <UseCaseScenarioSection content={content.scenario} />
+        </section>
 
-                <section className="border-t border-border/70 px-5 py-24 sm:px-8 lg:px-10">
-                    <UseCaseCtaSection content={content.cta} />
-                </section>
+        <section className="border-t border-border/70 px-5 py-24 sm:px-8 lg:px-10">
+          <UseCaseCtaSection content={content.cta} />
+        </section>
 
-                <section className="border-t border-border/70 px-5 py-16 sm:px-8 lg:px-10">
-                    <MarketingFooter columns={footerColumns} />
-                </section>
-            </main>
-        </div>
-    );
+        <section className="border-t border-border/70 px-5 py-16 sm:px-8 lg:px-10">
+          <MarketingFooter columns={footerColumns} />
+        </section>
+      </main>
+    </div>
+  );
 }

--- a/apps/hyperlocalise-web/src/components/marketing/use-case/use-case-sections.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/use-case/use-case-sections.tsx
@@ -8,217 +8,211 @@ import { env } from "@/lib/env";
 import type { UseCasePageContent } from "./use-case-page-content";
 
 type UseCaseHeroProps = {
-    content: UseCasePageContent["hero"];
+  content: UseCasePageContent["hero"];
 };
 
 export function UseCaseHero({ content }: UseCaseHeroProps) {
-    return (
-        <section className="pt-16 lg:pt-20">
-            <div className="max-w-3xl space-y-8">
-                <p className="text-sm font-medium tracking-[0.14em] text-muted-foreground uppercase">
-                    {content.eyebrow}
-                </p>
-                <TypographyH1 className="text-left text-balance">{content.headline}</TypographyH1>
-                <TypographyP className="max-w-2xl text-muted-foreground">{content.subheadline}</TypographyP>
-                <Button
-                    nativeButton={false}
-                    render={
-                        <a href={env.NEXT_PUBLIC_WAITLIST_URL} target="_blank" rel="noopener noreferrer" />
-                    }
-                >
-                    {content.ctaLabel}
-                </Button>
-            </div>
-        </section>
-    );
+  return (
+    <section className="pt-16 lg:pt-20">
+      <div className="max-w-3xl space-y-8">
+        <p className="text-sm font-medium tracking-[0.14em] text-muted-foreground uppercase">
+          {content.eyebrow}
+        </p>
+        <TypographyH1 className="text-left text-balance">{content.headline}</TypographyH1>
+        <TypographyP className="max-w-2xl text-muted-foreground">{content.subheadline}</TypographyP>
+        <Button
+          nativeButton={false}
+          render={
+            <a href={env.NEXT_PUBLIC_WAITLIST_URL} target="_blank" rel="noopener noreferrer" />
+          }
+        >
+          {content.ctaLabel}
+        </Button>
+      </div>
+    </section>
+  );
 }
 
 type UseCaseProblemSectionProps = {
-    content: UseCasePageContent["problem"];
+  content: UseCasePageContent["problem"];
 };
 
 export function UseCaseProblemSection({ content }: UseCaseProblemSectionProps) {
-    return (
-        <section>
-            <div className="max-w-2xl space-y-5">
-                <div className="text-sm text-muted-foreground/60">02 The problem</div>
-                <TypographyH2 className="text-4xl sm:text-5xl">{content.title}</TypographyH2>
-                <TypographyP className="text-muted-foreground">{content.description}</TypographyP>
-            </div>
+  return (
+    <section>
+      <div className="max-w-2xl space-y-5">
+        <div className="text-sm text-muted-foreground/60">02 The problem</div>
+        <TypographyH2 className="text-4xl sm:text-5xl">{content.title}</TypographyH2>
+        <TypographyP className="text-muted-foreground">{content.description}</TypographyP>
+      </div>
 
-            <ul className="mt-10 grid gap-4 sm:grid-cols-2">
-                {content.pains.map((pain, index) => (
-                    <li
-                        key={pain}
-                        className="rounded-[1.25rem] border border-border/70 bg-muted/20 px-5 py-5 text-sm leading-relaxed text-muted-foreground"
-                    >
-                        <span className="mb-2 block text-xs font-medium tracking-[0.12em] text-muted-foreground/60 uppercase">
-                            02.{index + 1}
-                        </span>
-                        {pain}
-                    </li>
-                ))}
-            </ul>
-        </section>
-    );
+      <ul className="mt-10 grid gap-4 sm:grid-cols-2">
+        {content.pains.map((pain, index) => (
+          <li
+            key={pain}
+            className="rounded-[1.25rem] border border-border/70 bg-muted/20 px-5 py-5 text-sm leading-relaxed text-muted-foreground"
+          >
+            <span className="mb-2 block text-xs font-medium tracking-[0.12em] text-muted-foreground/60 uppercase">
+              02.{index + 1}
+            </span>
+            {pain}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
 }
 
 type UseCaseWorkflowSectionProps = {
-    content: UseCasePageContent["workflow"];
+  content: UseCasePageContent["workflow"];
 };
 
 export function UseCaseWorkflowSection({ content }: UseCaseWorkflowSectionProps) {
-    return (
-        <section>
-            <div className="max-w-2xl space-y-5">
-                <div className="text-sm text-muted-foreground/60">03 {content.label}</div>
-                <TypographyH2 className="text-4xl sm:text-5xl">{content.title}</TypographyH2>
-                <TypographyP className="text-muted-foreground">{content.description}</TypographyP>
-            </div>
+  return (
+    <section>
+      <div className="max-w-2xl space-y-5">
+        <div className="text-sm text-muted-foreground/60">03 {content.label}</div>
+        <TypographyH2 className="text-4xl sm:text-5xl">{content.title}</TypographyH2>
+        <TypographyP className="text-muted-foreground">{content.description}</TypographyP>
+      </div>
 
-            <div className="mt-12 overflow-hidden rounded-[1.5rem] border border-foreground/10 bg-background shadow-[0_20px_48px_rgba(0,0,0,0.14)] sm:rounded-[2rem]">
-                <div className="grid divide-y divide-foreground/10 sm:grid-cols-2 lg:grid-cols-3 lg:divide-x lg:divide-y-0">
-                    {content.steps.map((step, index) => (
-                        <article
-                            key={step.label}
-                            className="flex flex-col gap-3 px-6 py-7 sm:px-7 sm:py-8"
-                        >
-                            <TypographyP className="text-[0.95rem] tracking-[-0.02em] text-foreground/40">
-                                03.{index + 1}
-                            </TypographyP>
-                            <TypographyH3 className="text-xl font-medium tracking-[-0.03em] text-foreground">
-                                {step.label}
-                            </TypographyH3>
-                            {step.description ? (
-                                <TypographyP className="text-sm leading-relaxed text-foreground/50">
-                                    {step.description}
-                                </TypographyP>
-                            ) : null}
-                        </article>
-                    ))}
-                </div>
-            </div>
+      <div className="mt-12 overflow-hidden rounded-[1.5rem] border border-foreground/10 bg-background shadow-[0_20px_48px_rgba(0,0,0,0.14)] sm:rounded-[2rem]">
+        <div className="grid divide-y divide-foreground/10 sm:grid-cols-2 lg:grid-cols-3 lg:divide-x lg:divide-y-0">
+          {content.steps.map((step, index) => (
+            <article key={step.label} className="flex flex-col gap-3 px-6 py-7 sm:px-7 sm:py-8">
+              <TypographyP className="text-[0.95rem] tracking-[-0.02em] text-foreground/40">
+                03.{index + 1}
+              </TypographyP>
+              <TypographyH3 className="text-xl font-medium tracking-[-0.03em] text-foreground">
+                {step.label}
+              </TypographyH3>
+              {step.description ? (
+                <TypographyP className="text-sm leading-relaxed text-foreground/50">
+                  {step.description}
+                </TypographyP>
+              ) : null}
+            </article>
+          ))}
+        </div>
+      </div>
 
-            <div className="mt-8 hidden items-center gap-2 text-sm text-muted-foreground/60 lg:flex">
-                {content.steps.map((step, index) => (
-                    <div key={step.label} className="flex items-center gap-2">
-                        <span>{step.label}</span>
-                        {index < content.steps.length - 1 ? (
-                            <HugeiconsIcon icon={ArrowRightIcon} className="size-3.5" strokeWidth={1.7} />
-                        ) : null}
-                    </div>
-                ))}
-            </div>
-        </section>
-    );
+      <div className="mt-8 hidden items-center gap-2 text-sm text-muted-foreground/60 lg:flex">
+        {content.steps.map((step, index) => (
+          <div key={step.label} className="flex items-center gap-2">
+            <span>{step.label}</span>
+            {index < content.steps.length - 1 ? (
+              <HugeiconsIcon icon={ArrowRightIcon} className="size-3.5" strokeWidth={1.7} />
+            ) : null}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
 }
 
 type UseCaseCapabilitiesSectionProps = {
-    content: UseCasePageContent["capabilities"];
+  content: UseCasePageContent["capabilities"];
 };
 
 export function UseCaseCapabilitiesSection({ content }: UseCaseCapabilitiesSectionProps) {
-    return (
-        <section>
-            <div className="max-w-2xl space-y-5">
-                <div className="text-sm text-muted-foreground/60">04 {content.label}</div>
-                <TypographyH2 className="text-4xl sm:text-5xl">{content.title}</TypographyH2>
-            </div>
+  return (
+    <section>
+      <div className="max-w-2xl space-y-5">
+        <div className="text-sm text-muted-foreground/60">04 {content.label}</div>
+        <TypographyH2 className="text-4xl sm:text-5xl">{content.title}</TypographyH2>
+      </div>
 
-            <div className="mt-10 grid gap-4 lg:grid-cols-2">
-                {content.items.map((item, index) => (
-                    <article
-                        key={item.title}
-                        className="rounded-[1.25rem] border border-border/70 px-6 py-6"
-                    >
-                        <div className="text-xs font-medium tracking-[0.12em] text-muted-foreground/60 uppercase">
-                            04.{index + 1}
-                        </div>
-                        <TypographyH3 className="mt-3 text-xl font-medium tracking-[-0.03em]">
-                            {item.title}
-                        </TypographyH3>
-                        <TypographyP className="mt-3 text-sm leading-relaxed text-muted-foreground">
-                            {item.description}
-                        </TypographyP>
-                    </article>
-                ))}
+      <div className="mt-10 grid gap-4 lg:grid-cols-2">
+        {content.items.map((item, index) => (
+          <article key={item.title} className="rounded-[1.25rem] border border-border/70 px-6 py-6">
+            <div className="text-xs font-medium tracking-[0.12em] text-muted-foreground/60 uppercase">
+              04.{index + 1}
             </div>
-        </section>
-    );
+            <TypographyH3 className="mt-3 text-xl font-medium tracking-[-0.03em]">
+              {item.title}
+            </TypographyH3>
+            <TypographyP className="mt-3 text-sm leading-relaxed text-muted-foreground">
+              {item.description}
+            </TypographyP>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
 }
 
 type UseCaseDifferentiatorSectionProps = {
-    content: UseCasePageContent["differentiator"];
+  content: UseCasePageContent["differentiator"];
 };
 
 export function UseCaseDifferentiatorSection({ content }: UseCaseDifferentiatorSectionProps) {
-    return (
-        <section>
-            <div className="max-w-3xl space-y-5">
-                <div className="text-sm text-muted-foreground/60">05 {content.label}</div>
-                <TypographyH2 className="text-4xl sm:text-5xl text-balance">{content.title}</TypographyH2>
-                <TypographyP className="max-w-2xl text-muted-foreground">{content.description}</TypographyP>
-            </div>
+  return (
+    <section>
+      <div className="max-w-3xl space-y-5">
+        <div className="text-sm text-muted-foreground/60">05 {content.label}</div>
+        <TypographyH2 className="text-4xl sm:text-5xl text-balance">{content.title}</TypographyH2>
+        <TypographyP className="max-w-2xl text-muted-foreground">{content.description}</TypographyP>
+      </div>
 
-            <div className="mt-10 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-                {content.points.map((point, index) => (
-                    <div
-                        key={point}
-                        className="rounded-full border border-border/70 px-4 py-3 text-sm text-muted-foreground"
-                    >
-                        05.{index + 1} {point}
-                    </div>
-                ))}
-            </div>
-        </section>
-    );
+      <div className="mt-10 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {content.points.map((point, index) => (
+          <div
+            key={point}
+            className="rounded-full border border-border/70 px-4 py-3 text-sm text-muted-foreground"
+          >
+            05.{index + 1} {point}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
 }
 
 type UseCaseScenarioSectionProps = {
-    content: UseCasePageContent["scenario"];
+  content: UseCasePageContent["scenario"];
 };
 
 export function UseCaseScenarioSection({ content }: UseCaseScenarioSectionProps) {
-    return (
-        <section>
-            <div className="max-w-2xl space-y-5">
-                <div className="text-sm text-muted-foreground/60">06 {content.label}</div>
-                <TypographyH2 className="text-4xl sm:text-5xl">{content.title}</TypographyH2>
-            </div>
+  return (
+    <section>
+      <div className="max-w-2xl space-y-5">
+        <div className="text-sm text-muted-foreground/60">06 {content.label}</div>
+        <TypographyH2 className="text-4xl sm:text-5xl">{content.title}</TypographyH2>
+      </div>
 
-            <blockquote className="mt-10 rounded-[1.5rem] border border-foreground/10 bg-muted/25 px-6 py-8 sm:px-8 sm:py-10">
-                <TypographyP className="text-lg leading-relaxed text-foreground/80 sm:text-xl sm:leading-8">
-                    {content.narrative}
-                </TypographyP>
-            </blockquote>
-        </section>
-    );
+      <blockquote className="mt-10 rounded-[1.5rem] border border-foreground/10 bg-muted/25 px-6 py-8 sm:px-8 sm:py-10">
+        <TypographyP className="text-lg leading-relaxed text-foreground/80 sm:text-xl sm:leading-8">
+          {content.narrative}
+        </TypographyP>
+      </blockquote>
+    </section>
+  );
 }
 
 type UseCaseCtaSectionProps = {
-    content: UseCasePageContent["cta"];
+  content: UseCasePageContent["cta"];
 };
 
 export function UseCaseCtaSection({ content }: UseCaseCtaSectionProps) {
-    return (
-        <section id="waitlist" className="text-center">
-            <TypographyH2 className="pb-0 text-4xl leading-[1.04] font-semibold tracking-[-0.04em] normal-case sm:text-5xl">
-                {content.headline}
-            </TypographyH2>
-            <TypographyP className="mx-auto mt-5 max-w-2xl text-muted-foreground">
-                {content.description}
-            </TypographyP>
-            <div className="mt-8 flex justify-center">
-                <Button
-                    className="rounded-full px-5"
-                    nativeButton={false}
-                    render={
-                        <a href={env.NEXT_PUBLIC_WAITLIST_URL} target="_blank" rel="noopener noreferrer" />
-                    }
-                >
-                    {content.primaryLabel}
-                </Button>
-            </div>
-        </section>
-    );
+  return (
+    <section id="waitlist" className="text-center">
+      <TypographyH2 className="pb-0 text-4xl leading-[1.04] font-semibold tracking-[-0.04em] normal-case sm:text-5xl">
+        {content.headline}
+      </TypographyH2>
+      <TypographyP className="mx-auto mt-5 max-w-2xl text-muted-foreground">
+        {content.description}
+      </TypographyP>
+      <div className="mt-8 flex justify-center">
+        <Button
+          className="rounded-full px-5"
+          nativeButton={false}
+          render={
+            <a href={env.NEXT_PUBLIC_WAITLIST_URL} target="_blank" rel="noopener noreferrer" />
+          }
+        >
+          {content.primaryLabel}
+        </Button>
+      </div>
+    </section>
+  );
 }

--- a/apps/hyperlocalise-web/src/components/marketing/use-case/use-case-sections.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/use-case/use-case-sections.tsx
@@ -1,0 +1,224 @@
+import { ArrowRightIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+import { Button } from "@/components/ui/button";
+import { TypographyH1, TypographyH2, TypographyH3, TypographyP } from "@/components/ui/typography";
+import { env } from "@/lib/env";
+
+import type { UseCasePageContent } from "./use-case-page-content";
+
+type UseCaseHeroProps = {
+    content: UseCasePageContent["hero"];
+};
+
+export function UseCaseHero({ content }: UseCaseHeroProps) {
+    return (
+        <section className="pt-16 lg:pt-20">
+            <div className="max-w-3xl space-y-8">
+                <p className="text-sm font-medium tracking-[0.14em] text-muted-foreground uppercase">
+                    {content.eyebrow}
+                </p>
+                <TypographyH1 className="text-left text-balance">{content.headline}</TypographyH1>
+                <TypographyP className="max-w-2xl text-muted-foreground">{content.subheadline}</TypographyP>
+                <Button
+                    nativeButton={false}
+                    render={
+                        <a href={env.NEXT_PUBLIC_WAITLIST_URL} target="_blank" rel="noopener noreferrer" />
+                    }
+                >
+                    {content.ctaLabel}
+                </Button>
+            </div>
+        </section>
+    );
+}
+
+type UseCaseProblemSectionProps = {
+    content: UseCasePageContent["problem"];
+};
+
+export function UseCaseProblemSection({ content }: UseCaseProblemSectionProps) {
+    return (
+        <section>
+            <div className="max-w-2xl space-y-5">
+                <div className="text-sm text-muted-foreground/60">02 The problem</div>
+                <TypographyH2 className="text-4xl sm:text-5xl">{content.title}</TypographyH2>
+                <TypographyP className="text-muted-foreground">{content.description}</TypographyP>
+            </div>
+
+            <ul className="mt-10 grid gap-4 sm:grid-cols-2">
+                {content.pains.map((pain, index) => (
+                    <li
+                        key={pain}
+                        className="rounded-[1.25rem] border border-border/70 bg-muted/20 px-5 py-5 text-sm leading-relaxed text-muted-foreground"
+                    >
+                        <span className="mb-2 block text-xs font-medium tracking-[0.12em] text-muted-foreground/60 uppercase">
+                            02.{index + 1}
+                        </span>
+                        {pain}
+                    </li>
+                ))}
+            </ul>
+        </section>
+    );
+}
+
+type UseCaseWorkflowSectionProps = {
+    content: UseCasePageContent["workflow"];
+};
+
+export function UseCaseWorkflowSection({ content }: UseCaseWorkflowSectionProps) {
+    return (
+        <section>
+            <div className="max-w-2xl space-y-5">
+                <div className="text-sm text-muted-foreground/60">03 {content.label}</div>
+                <TypographyH2 className="text-4xl sm:text-5xl">{content.title}</TypographyH2>
+                <TypographyP className="text-muted-foreground">{content.description}</TypographyP>
+            </div>
+
+            <div className="mt-12 overflow-hidden rounded-[1.5rem] border border-foreground/10 bg-background shadow-[0_20px_48px_rgba(0,0,0,0.14)] sm:rounded-[2rem]">
+                <div className="grid divide-y divide-foreground/10 sm:grid-cols-2 lg:grid-cols-3 lg:divide-x lg:divide-y-0">
+                    {content.steps.map((step, index) => (
+                        <article
+                            key={step.label}
+                            className="flex flex-col gap-3 px-6 py-7 sm:px-7 sm:py-8"
+                        >
+                            <TypographyP className="text-[0.95rem] tracking-[-0.02em] text-foreground/40">
+                                03.{index + 1}
+                            </TypographyP>
+                            <TypographyH3 className="text-xl font-medium tracking-[-0.03em] text-foreground">
+                                {step.label}
+                            </TypographyH3>
+                            {step.description ? (
+                                <TypographyP className="text-sm leading-relaxed text-foreground/50">
+                                    {step.description}
+                                </TypographyP>
+                            ) : null}
+                        </article>
+                    ))}
+                </div>
+            </div>
+
+            <div className="mt-8 hidden items-center gap-2 text-sm text-muted-foreground/60 lg:flex">
+                {content.steps.map((step, index) => (
+                    <div key={step.label} className="flex items-center gap-2">
+                        <span>{step.label}</span>
+                        {index < content.steps.length - 1 ? (
+                            <HugeiconsIcon icon={ArrowRightIcon} className="size-3.5" strokeWidth={1.7} />
+                        ) : null}
+                    </div>
+                ))}
+            </div>
+        </section>
+    );
+}
+
+type UseCaseCapabilitiesSectionProps = {
+    content: UseCasePageContent["capabilities"];
+};
+
+export function UseCaseCapabilitiesSection({ content }: UseCaseCapabilitiesSectionProps) {
+    return (
+        <section>
+            <div className="max-w-2xl space-y-5">
+                <div className="text-sm text-muted-foreground/60">04 {content.label}</div>
+                <TypographyH2 className="text-4xl sm:text-5xl">{content.title}</TypographyH2>
+            </div>
+
+            <div className="mt-10 grid gap-4 lg:grid-cols-2">
+                {content.items.map((item, index) => (
+                    <article
+                        key={item.title}
+                        className="rounded-[1.25rem] border border-border/70 px-6 py-6"
+                    >
+                        <div className="text-xs font-medium tracking-[0.12em] text-muted-foreground/60 uppercase">
+                            04.{index + 1}
+                        </div>
+                        <TypographyH3 className="mt-3 text-xl font-medium tracking-[-0.03em]">
+                            {item.title}
+                        </TypographyH3>
+                        <TypographyP className="mt-3 text-sm leading-relaxed text-muted-foreground">
+                            {item.description}
+                        </TypographyP>
+                    </article>
+                ))}
+            </div>
+        </section>
+    );
+}
+
+type UseCaseDifferentiatorSectionProps = {
+    content: UseCasePageContent["differentiator"];
+};
+
+export function UseCaseDifferentiatorSection({ content }: UseCaseDifferentiatorSectionProps) {
+    return (
+        <section>
+            <div className="max-w-3xl space-y-5">
+                <div className="text-sm text-muted-foreground/60">05 {content.label}</div>
+                <TypographyH2 className="text-4xl sm:text-5xl text-balance">{content.title}</TypographyH2>
+                <TypographyP className="max-w-2xl text-muted-foreground">{content.description}</TypographyP>
+            </div>
+
+            <div className="mt-10 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                {content.points.map((point, index) => (
+                    <div
+                        key={point}
+                        className="rounded-full border border-border/70 px-4 py-3 text-sm text-muted-foreground"
+                    >
+                        05.{index + 1} {point}
+                    </div>
+                ))}
+            </div>
+        </section>
+    );
+}
+
+type UseCaseScenarioSectionProps = {
+    content: UseCasePageContent["scenario"];
+};
+
+export function UseCaseScenarioSection({ content }: UseCaseScenarioSectionProps) {
+    return (
+        <section>
+            <div className="max-w-2xl space-y-5">
+                <div className="text-sm text-muted-foreground/60">06 {content.label}</div>
+                <TypographyH2 className="text-4xl sm:text-5xl">{content.title}</TypographyH2>
+            </div>
+
+            <blockquote className="mt-10 rounded-[1.5rem] border border-foreground/10 bg-muted/25 px-6 py-8 sm:px-8 sm:py-10">
+                <TypographyP className="text-lg leading-relaxed text-foreground/80 sm:text-xl sm:leading-8">
+                    {content.narrative}
+                </TypographyP>
+            </blockquote>
+        </section>
+    );
+}
+
+type UseCaseCtaSectionProps = {
+    content: UseCasePageContent["cta"];
+};
+
+export function UseCaseCtaSection({ content }: UseCaseCtaSectionProps) {
+    return (
+        <section id="waitlist" className="text-center">
+            <TypographyH2 className="pb-0 text-4xl leading-[1.04] font-semibold tracking-[-0.04em] normal-case sm:text-5xl">
+                {content.headline}
+            </TypographyH2>
+            <TypographyP className="mx-auto mt-5 max-w-2xl text-muted-foreground">
+                {content.description}
+            </TypographyP>
+            <div className="mt-8 flex justify-center">
+                <Button
+                    className="rounded-full px-5"
+                    nativeButton={false}
+                    render={
+                        <a href={env.NEXT_PUBLIC_WAITLIST_URL} target="_blank" rel="noopener noreferrer" />
+                    }
+                >
+                    {content.primaryLabel}
+                </Button>
+            </div>
+        </section>
+    );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds six SEO-focused use-case marketing landing pages that follow the homepage structure and visual rhythm:

1. `/use-cases/product-localisation`
2. `/use-cases/marketing-localisation`
3. `/use-cases/help-center-localisation`
4. `/use-cases/github-release-localisation`
5. `/use-cases/localisation-quality-monitoring`
6. `/use-cases/localisation-operations`

Each page includes the seven sections from the brief: hero, problem, workflow, capabilities, differentiator, example scenario, and CTA.

## Implementation

- Reusable `UseCasePage` component and section components under `src/components/marketing/use-case/`
- Content-driven pages via `use-case-page-content.ts` with per-page metadata, keywords, and copy
- Dynamic route at `use-cases/[slug]` with `generateStaticParams` for static generation
- Sitemap entries for all six pages
- Footer "Use cases" column on homepage and use-case pages
- Navbar logo now links to `/` instead of `#`

## Validation

- `vp check --fix` passes (format, lint, types)
- `vp test` has pre-existing failures in this environment due to missing `.env` / database setup (unrelated to these changes)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5dadaf99-8616-43e0-a0d3-7c56f3d630b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5dadaf99-8616-43e0-a0d3-7c56f3d630b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

