### PR TITLE
fix(crowdin): correct EditArchivedStatus endpoint path

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -149,3 +149,9 @@
 **Learning:** Test fixtures that only use zero values (like `false` for booleans) may pass even if JSON struct tags are missing or incorrect, as the unmarshaler defaults to the zero value. Using non-zero values in tests ensures that tags like `json:"hasPlurals"` are actually working.
 
 **Action:** Updated `string_comments_test.go` to use `true` for `hasPlurals` and `isIcu` in both the JSON mock and the expected struct. This confirms that these new fields are correctly unmarshaled from Crowdin API responses.
+
+## 2026-06-14 - Correct EditArchivedStatus endpoint path
+
+**Learning:** The Crowdin API v2 endpoint for editing a task's archived status is located under `/api/v2/user/tasks/{taskId}`, not the standard project-specific `/api/v2/projects/{projectId}/tasks/{taskId}` or the incorrect `/api/v2/tasks/{taskId}` path.
+
+**Action:** Updated `EditArchivedStatus` in `tasks.go` to use the correct `/api/v2/user/tasks/%d?projectId=%d` path. Adjusted `TestTasksService_EditArchivedStatus` in `tasks_test.go` to verify the correct URL is called. Verified with `make test`.

--- a/third_party/crowdin-api-client-go/crowdin/tasks.go
+++ b/third_party/crowdin-api-client-go/crowdin/tasks.go
@@ -130,7 +130,7 @@ func (s *TasksService) EditArchivedStatus(ctx context.Context, projectID, taskID
 	*model.Task, *Response, error,
 ) {
 	res := new(model.TaskResponse)
-	resp, err := s.client.Patch(ctx, fmt.Sprintf("/api/v2/tasks/%d?projectId=%d", taskID, projectID), req, res)
+	resp, err := s.client.Patch(ctx, fmt.Sprintf("/api/v2/user/tasks/%d?projectId=%d", taskID, projectID), req, res)
 
 	return res.Data, resp, err
 }

--- a/third_party/crowdin-api-client-go/crowdin/tasks_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/tasks_test.go
@@ -791,7 +791,7 @@ func TestTasksService_EditArchivedStatus(t *testing.T) {
 
 	const (
 		projectID = 123
-		path      = "/api/v2/tasks/2"
+		path      = "/api/v2/user/tasks/2"
 	)
 
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Corrected the endpoint path for `EditArchivedStatus` in the Crowdin fork to align with the official API v2 contract. The previous implementation was missing the `/user/` prefix in the URL path.

Changes:
- Updated `third_party/crowdin-api-client-go/crowdin/tasks.go` to use the correct path.
- Updated `third_party/crowdin-api-client-go/crowdin/tasks_test.go` to verify the fix.
- Added a journal entry to `.jules/crowdin-steward.md`.

---
*PR created automatically by Jules for task [12880943944216794576](https://jules.google.com/task/12880943944216794576) started by @cungminh2710*