### PR TITLE
feat(web): add loading skeleton to automations list

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.stories.tsx
@@ -38,7 +38,8 @@ export const Loading: Story = {
     isLoading: true,
   },
   play: async ({ canvas }) => {
-    await expect(canvas.getByText("Loading automations...")).toBeInTheDocument();
+    const loadingRegion = canvas.getByLabelText("Loading automations");
+    await expect(loadingRegion.children).toHaveLength(5);
   },
 };
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/_components/automations-page-view.tsx
@@ -8,6 +8,7 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { TypographyP } from "@/components/ui/typography";
 import type { WorkspaceAutomationTemplateCategory } from "@/lib/agents/workspace-automation-templates";
@@ -27,6 +28,33 @@ import {
 
 const TEMPLATE_FILTER_TABS_CLASS =
   "h-auto flex-none rounded-full border-transparent px-3 py-1.5 text-muted-foreground shadow-none after:hidden hover:text-foreground data-active:bg-foreground/10 data-active:text-foreground dark:data-active:border-transparent dark:data-active:bg-foreground/10";
+
+const AUTOMATION_LIST_GRID_CLASS =
+  "grid grid-cols-[minmax(0,1.6fr)_minmax(0,0.8fr)_minmax(0,0.8fr)_minmax(0,0.5fr)] gap-4";
+
+function AutomationListSkeleton() {
+  return (
+    <div aria-busy="true" aria-label="Loading automations">
+      {Array.from({ length: 5 }).map((_, index) => (
+        <div
+          key={index}
+          className={`${AUTOMATION_LIST_GRID_CLASS} border-b border-foreground/10 px-4 py-4 last:border-b-0`}
+        >
+          <div className="flex min-w-0 flex-col gap-2">
+            <Skeleton className="h-4 w-3/5 rounded-full bg-muted" />
+            <Skeleton className="h-3 w-2/5 rounded-full bg-muted" />
+          </div>
+          <div className="flex flex-wrap gap-1">
+            <Skeleton className="h-5 w-14 rounded-full bg-muted" />
+            <Skeleton className="h-5 w-12 rounded-full bg-muted" />
+          </div>
+          <Skeleton className="h-5 w-16 rounded-full bg-muted" />
+          <Skeleton className="h-4 w-8 rounded-full bg-muted" />
+        </div>
+      ))}
+    </div>
+  );
+}
 
 export type AutomationsLinkRenderer = (props: {
   href: string;
@@ -153,14 +181,16 @@ export function AutomationsPageView({
 
       <section className="flex flex-col gap-4">
         <div className="overflow-hidden rounded-xl border border-foreground/10">
-          <div className="grid grid-cols-[minmax(0,1.6fr)_minmax(0,0.8fr)_minmax(0,0.8fr)_minmax(0,0.5fr)] gap-4 border-b border-foreground/10 px-4 py-3 text-xs font-medium text-muted-foreground">
+          <div
+            className={`${AUTOMATION_LIST_GRID_CLASS} border-b border-foreground/10 px-4 py-3 text-xs font-medium text-muted-foreground`}
+          >
             <span>Automation</span>
             <span>Tools</span>
             <span>Status</span>
             <span>Created</span>
           </div>
           {isLoading ? (
-            <div className="px-4 py-10 text-sm text-muted-foreground">Loading automations...</div>
+            <AutomationListSkeleton />
           ) : error ? (
             <div className="px-4 py-10">
               <TypographyP className="text-sm font-medium text-flame-100">
@@ -179,8 +209,7 @@ export function AutomationsPageView({
               <Fragment key={automation.id}>
                 {renderAutomationLink({
                   href: `/org/${organizationSlug}/automations/${automation.id}`,
-                  className:
-                    "grid grid-cols-[minmax(0,1.6fr)_minmax(0,0.8fr)_minmax(0,0.8fr)_minmax(0,0.5fr)] gap-4 border-b border-foreground/10 px-4 py-4 transition-colors last:border-b-0 hover:bg-foreground/5",
+                  className: `${AUTOMATION_LIST_GRID_CLASS} border-b border-foreground/10 px-4 py-4 transition-colors last:border-b-0 hover:bg-foreground/5`,
                   children: (
                     <>
                       <div className="min-w-0">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces the plain "Loading automations..." text on the automations list with a structured loading skeleton that mirrors the table layout.

- Shows **5 skeleton rows** while automations are loading
- Each row matches the four columns: name/trigger, tools, status, and created date
- Adds `aria-busy` and `aria-label` for accessibility
- Updates the Storybook loading story to assert five skeleton rows

## Test plan

- [x] `vp check --fix` passes
- [ ] Open `/org/{slug}/automations` and confirm five skeleton rows appear before data loads
- [ ] Confirm skeleton is replaced by real rows once the query resolves
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://hyperlocalise.slack.com/archives/D0B5GKZKTRB/p1781390231575149?thread_ts=1781390231.575149&cid=D0B5GKZKTRB)

<div><a href="https://cursor.com/agents/bc-1ee4fa77-6a12-5b07-b8f4-e72b471181a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ee4fa77-6a12-5b07-b8f4-e72b471181a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

