### PR TITLE
feat(web): enable translate with agent for live provider jobs

### DIFF
--- a/apps/hyperlocalise-web/src/api/app.ts
+++ b/apps/hyperlocalise-web/src/api/app.ts
@@ -163,7 +163,10 @@ function createOrgScopedAppRoutes(
     .route("/external-tms-provider-credential", createExternalTmsProviderCredentialRoutes())
     .route(
       "/tms-provider",
-      createTmsProviderRoutes({ providerSyncQueue: options.providerSyncQueue }),
+      createTmsProviderRoutes({
+        providerSyncQueue: options.providerSyncQueue,
+        providerAgentTranslationQueue: options.providerAgentTranslationQueue,
+      }),
     )
     .route("/tms-agent-automation", createTmsAgentAutomationRoutes())
     .route("/tms-dashboard-summary", createTmsDashboardSummaryRoutes())

--- a/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.ts
@@ -527,9 +527,14 @@ export function createTmsProviderRoutes(options: CreateTmsProviderRoutesOptions 
         return notFoundResponse(c, "job_not_found", "Provider job not found");
       }
 
-      const liveFiles = await listTmsProviderLiveJobFiles(organizationId, encodedJobId, {
-        actorUserId: c.var.auth.user.localUserId,
-      });
+      let liveFiles;
+      try {
+        liveFiles = await listTmsProviderLiveJobFiles(organizationId, encodedJobId, {
+          actorUserId: c.var.auth.user.localUserId,
+        });
+      } catch (error) {
+        return tmsProviderLiveErrorResponse(c, error);
+      }
       const sourceFiles = (liveFiles ?? []).map((file) => ({
         id: file.provider.externalResourceId,
         displayName: file.filename,
@@ -556,6 +561,13 @@ export function createTmsProviderRoutes(options: CreateTmsProviderRoutesOptions 
       });
 
       if (!options.providerAgentTranslationQueue) {
+        await failAgentRun({
+          runId: agentRun.id,
+          organizationId,
+          outputSummary: { code: "agent_run_queue_unavailable" },
+          warnings: ["agent translation queue unavailable"],
+        });
+
         return serviceUnavailableResponse(
           c,
           "agent_run_queue_unavailable",

--- a/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.ts
@@ -2,12 +2,26 @@ import { Hono } from "hono";
 import { validator } from "hono/validator";
 import { z } from "zod";
 
-import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
+import { isJobProviderActionAllowed } from "@/api/auth/capability-guards";
 import { hasCapability } from "@/api/auth/policy";
-import { serviceUnavailableResponse } from "@/api/response.schema";
+import { ownedProjectWhere } from "@/api/auth/team-access";
+import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
+import {
+  badRequestResponse,
+  conflictResponse,
+  notFoundResponse,
+  serviceUnavailableResponse,
+} from "@/api/errors";
+import { db, schema } from "@/lib/database";
+import { createAgentRun, failAgentRun } from "@/lib/providers/agent-runs/agent-runs";
+import {
+  getJobProviderActionDefinition,
+  isJobProviderActionAvailable,
+} from "@/lib/providers/job-provider-actions";
 import { getActiveOrganizationExternalTmsProviderCredentialRow } from "@/lib/providers/organization-external-tms-provider-credentials";
 import { enqueueProviderCatalogSyncIntent } from "@/lib/providers/provider-sync-intent";
-import type { ProviderSyncQueue } from "@/lib/workflow/types";
+import { parseProviderJobId } from "@/lib/providers/tms-provider-resource-id";
+import type { ProviderAgentTranslationQueue, ProviderSyncQueue } from "@/lib/workflow/types";
 import { createProviderSyncQueue } from "@/workflows/adapters";
 import {
   getTmsProviderConnection,
@@ -46,6 +60,21 @@ const projectFilesQuerySchema = z.object({
 const updateJobDescriptionBodySchema = z.object({
   description: z.string().max(2_048),
 });
+
+const createTmsProviderJobAgentRunBodySchema = z.object({
+  projectId: z.string().min(1),
+  action: z.literal("translate_with_agent"),
+});
+
+function serializeAgentRun(run: typeof schema.agentRuns.$inferSelect) {
+  return {
+    ...run,
+    startedAt: run.startedAt?.toISOString() ?? null,
+    completedAt: run.completedAt?.toISOString() ?? null,
+    createdAt: run.createdAt.toISOString(),
+    updatedAt: run.updatedAt.toISOString(),
+  };
+}
 
 const jobFileDetailQuerySchema = z.object({
   sourcePath: z.string().min(1),
@@ -96,6 +125,15 @@ const validateUpdateJobDescriptionBody = validator("json", (value, c) => {
   return parsed.data;
 });
 
+const validateCreateTmsProviderJobAgentRunBody = validator("json", (value, c) => {
+  const parsed = createTmsProviderJobAgentRunBodySchema.safeParse(value);
+  if (!parsed.success) {
+    return badRequestResponse(c, "invalid_request_body", "Invalid provider agent run payload");
+  }
+
+  return parsed.data;
+});
+
 function canEditTmsProviderJobDescription(auth: AuthVariables["auth"]) {
   const role = auth.membership.role;
   return role === "admin" || (role === "localization_manager" && hasCapability(role, "jobs:write"));
@@ -131,6 +169,7 @@ async function getCurrentUserProviderAssigneeCandidates(auth: AuthVariables["aut
 }
 
 type CreateTmsProviderRoutesOptions = {
+  providerAgentTranslationQueue?: ProviderAgentTranslationQueue;
   providerSyncQueue?: ProviderSyncQueue;
 };
 
@@ -411,6 +450,142 @@ export function createTmsProviderRoutes(options: CreateTmsProviderRoutesOptions 
       } catch (error) {
         return tmsProviderLiveErrorResponse(c, error);
       }
+    })
+    .post("/jobs/:encodedJobId/agent-runs", validateCreateTmsProviderJobAgentRunBody, async (c) => {
+      const payload = c.req.valid("json");
+      const encodedJobId = c.req.param("encodedJobId");
+
+      if (!isJobProviderActionAllowed(c.var.auth.membership.role, payload.action)) {
+        return c.json({ error: "forbidden" }, 403);
+      }
+
+      const organizationId = c.var.auth.organization.localOrganizationId;
+      const parsedJobId = parseProviderJobId(encodedJobId);
+      if (!parsedJobId) {
+        return badRequestResponse(c, "invalid_encoded_job_id", "Job id is not a provider job id");
+      }
+
+      const [project] = await db
+        .select({
+          id: schema.projects.id,
+          externalProjectId: schema.projects.externalProjectId,
+          externalProviderKind: schema.projects.externalProviderKind,
+        })
+        .from(schema.projects)
+        .where(await ownedProjectWhere(c.var.auth, payload.projectId))
+        .limit(1);
+
+      if (!project) {
+        return notFoundResponse(c, "project_not_found", "Project not found");
+      }
+
+      if (
+        project.externalProjectId &&
+        project.externalProjectId !== parsedJobId.externalProjectId
+      ) {
+        return conflictResponse(
+          c,
+          "project_job_mismatch",
+          "Provider job does not belong to this project",
+        );
+      }
+
+      if (
+        project.externalProviderKind &&
+        project.externalProviderKind !== parsedJobId.providerKind
+      ) {
+        return conflictResponse(
+          c,
+          "project_provider_mismatch",
+          "Provider job does not match the connected TMS for this project",
+        );
+      }
+
+      if (!isJobProviderActionAvailable(parsedJobId.providerKind, payload.action)) {
+        return conflictResponse(
+          c,
+          "provider_action_unavailable",
+          "This provider action is not available for the connected TMS",
+        );
+      }
+
+      const actionDefinition = getJobProviderActionDefinition(payload.action);
+      if (!actionDefinition) {
+        return badRequestResponse(c, "invalid_provider_action", "Unknown provider action");
+      }
+
+      let job;
+      try {
+        job = await getTmsProviderLiveJobDetail(organizationId, encodedJobId, {
+          actorUserId: c.var.auth.user.localUserId,
+        });
+      } catch (error) {
+        return tmsProviderLiveErrorResponse(c, error);
+      }
+
+      if (!job) {
+        return notFoundResponse(c, "job_not_found", "Provider job not found");
+      }
+
+      const liveFiles = await listTmsProviderLiveJobFiles(organizationId, encodedJobId, {
+        actorUserId: c.var.auth.user.localUserId,
+      });
+      const sourceFiles = (liveFiles ?? []).map((file) => ({
+        id: file.provider.externalResourceId,
+        displayName: file.filename,
+        sourcePath: file.sourcePath,
+        resourceType: file.provider.resourceType,
+        externalUrl: file.provider.externalUrl,
+      }));
+
+      const agentRun = await createAgentRun({
+        organizationId,
+        providerKind: parsedJobId.providerKind,
+        externalJobId: job.externalJobId,
+        externalTaskId: job.externalTaskId,
+        kind: actionDefinition.agentRunKind,
+        actorUserId: c.var.auth.user.localUserId,
+        inputSnapshot: {
+          ...actionDefinition.inputSnapshot,
+          action: payload.action,
+          projectId: payload.projectId,
+          encodedJobId,
+          providerPayload: job.externalProviderPayload,
+          sourceFiles,
+        },
+      });
+
+      if (!options.providerAgentTranslationQueue) {
+        return serviceUnavailableResponse(
+          c,
+          "agent_run_queue_unavailable",
+          "Agent translation queue is unavailable",
+        );
+      }
+
+      try {
+        await options.providerAgentTranslationQueue.enqueue({
+          agentRunId: agentRun.id,
+          organizationId,
+        });
+      } catch (error) {
+        await failAgentRun({
+          runId: agentRun.id,
+          organizationId,
+          outputSummary: { code: "agent_run_queue_unavailable" },
+          warnings: [
+            error instanceof Error ? error.message : "agent translation queue unavailable",
+          ],
+        });
+
+        return serviceUnavailableResponse(
+          c,
+          "agent_run_queue_unavailable",
+          "Agent translation queue is unavailable",
+        );
+      }
+
+      return c.json({ agentRun: serializeAgentRun(agentRun) }, 201);
     })
     .get("/glossaries", validateExternalProjectIdQuery, async (c) => {
       if (!hasCapability(c.var.auth.membership.role, "glossaries:read")) {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-page-content.tsx
@@ -126,7 +126,7 @@ function NativeJobDetailPageContent({
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: jobQueryKey });
       await queryClient.invalidateQueries({ queryKey: ["jobs", organizationSlug] });
-      toast.success("File translation agent queued");
+      toast.success("Translation agent is running");
     },
     onError: (error) => {
       toast.error(error instanceof Error ? error.message : "Failed to start agent on job");

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-provider-detail-section.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-provider-detail-section.tsx
@@ -96,9 +96,7 @@ export function JobProviderDetailSection({
         queryClient.invalidateQueries({ queryKey: jobQueryKey }),
       ]);
       toast.success(
-        action === "translate_with_agent"
-          ? "Translation agent is running"
-          : "Agent run queued",
+        action === "translate_with_agent" ? "Translation agent is running" : "Agent run queued",
       );
     },
     onError: (error) => {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-provider-detail-section.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-provider-detail-section.tsx
@@ -90,12 +90,16 @@ export function JobProviderDetailSection({
       const body = (await response.json()) as { agentRun: AgentRunRecord };
       return body.agentRun;
     },
-    onSuccess: async () => {
+    onSuccess: async (_data, action) => {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: agentRunsQueryKey }),
         queryClient.invalidateQueries({ queryKey: jobQueryKey }),
       ]);
-      toast.success("Agent run queued");
+      toast.success(
+        action === "translate_with_agent"
+          ? "Translation agent is running"
+          : "Agent run queued",
+      );
     },
     onError: (error) => {
       toast.error(error instanceof Error ? error.message : "Failed to start agent run");

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-content.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 
 import { apiClient } from "@/lib/api-client-instance";
+import { getJobProviderActionAvailability } from "@/lib/providers/job-provider-actions";
 import type {
   TmsProviderLiveJobComment,
   TmsProviderLiveJobDetail,
@@ -11,6 +13,19 @@ import type {
 import { ProviderJobDescriptionField } from "../../../../../jobs/_components/provider-job-description-field";
 import { ProviderLiveJobDetailView } from "./provider-live-job-detail-view";
 import { TmsLiveJobFilesSection } from "./tms/tms-live-job-files-section";
+
+async function parseActionError(response: Response, fallback: string) {
+  let error: string | undefined;
+
+  try {
+    const body = (await response.json()) as { error?: string; message?: string };
+    error = body.message ?? body.error;
+  } catch {
+    error = undefined;
+  }
+
+  return error ? `${fallback}: ${error}` : `${fallback} (${response.status})`;
+}
 
 export function ProviderLiveJobDetailContent({
   jobId,
@@ -62,6 +77,39 @@ export function ProviderLiveJobDetailContent({
     },
   });
 
+  const translateWithAgent = useMutation({
+    mutationFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"]["tms-provider"].jobs[
+        ":encodedJobId"
+      ]["agent-runs"].$post({
+        param: { organizationSlug, encodedJobId: jobId },
+        json: {
+          projectId,
+          action: "translate_with_agent",
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(await parseActionError(response, "Failed to start agent translation"));
+      }
+
+      await response.json();
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: jobQueryKey });
+      toast.success("Translation agent is running");
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Failed to start agent translation");
+    },
+  });
+
+  const translateAction = jobQuery.data?.externalProviderKind
+    ? getJobProviderActionAvailability(jobQuery.data.externalProviderKind).find(
+        (action) => action.id === "translate_with_agent",
+      )
+    : null;
+
   return (
     <ProviderLiveJobDetailView
       jobId={jobId}
@@ -72,6 +120,9 @@ export function ProviderLiveJobDetailContent({
       isLoading={jobQuery.isLoading}
       error={jobQuery.isError ? jobQuery.error : undefined}
       isRefreshing={jobQuery.isFetching}
+      isTranslateWithAgentPending={translateWithAgent.isPending}
+      translateWithAgentAction={translateAction}
+      onTranslateWithAgent={() => translateWithAgent.mutate()}
       onRefresh={() => {
         void queryClient.invalidateQueries({ queryKey: jobQueryKey });
       }}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-view.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { expect } from "storybook/test";
 
 import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
+import { getJobProviderActionAvailability } from "@/lib/providers/job-provider-actions";
 
 import { ProviderJobDescriptionFieldView } from "../../../../../jobs/_components/provider-job-description-field";
 import { createLiveCrowdinJobComments, createLiveCrowdinJobDetail } from "./job-detail.fixture";
@@ -20,6 +21,9 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 const liveJob = createLiveCrowdinJobDetail();
+const translateWithAgentAction = getJobProviderActionAvailability("crowdin").find(
+  (action) => action.id === "translate_with_agent",
+);
 const sourceFiles: ProjectFileRecord[] = [
   {
     origin: "provider",
@@ -94,6 +98,8 @@ export const CrowdinTask: Story = {
     comments: createLiveCrowdinJobComments(),
     commentsLoading: false,
     onRefresh: () => undefined,
+    onTranslateWithAgent: () => undefined,
+    translateWithAgentAction,
     renderDescriptionField: ({ description, editable }) => (
       <ProviderJobDescriptionFieldView
         description={description}
@@ -113,6 +119,7 @@ export const CrowdinTask: Story = {
   },
   play: async ({ canvas }) => {
     await expect(canvas.getByText("Translate marketing homepage")).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Translate with agent" })).toBeInTheDocument();
     await expect(canvas.getByText("68%")).toBeInTheDocument();
     await expect(canvas.getByText("home.json")).toBeInTheDocument();
     await expect(canvas.getByText(/Preserve product name casing/)).toBeInTheDocument();

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-view.tsx
@@ -2,6 +2,7 @@
 
 import { useState, type ReactNode } from "react";
 import {
+  AiMagicIcon,
   ArrowDown01Icon,
   Clock01Icon,
   File01Icon,
@@ -37,7 +38,11 @@ import {
   getReadinessNumber,
 } from "../../../../../jobs/_components/provider-crowdin-job-display";
 
-import { buildJobsListHref, formatJobDetailDate } from "./job-detail-types";
+import {
+  buildJobsListHref,
+  formatJobDetailDate,
+  type ProviderActionAvailability,
+} from "./job-detail-types";
 import {
   defaultRenderBackLink,
   defaultRenderError,
@@ -274,9 +279,11 @@ export function ProviderLiveJobDetailView({
   error,
   isLoading,
   isRefreshing = false,
+  isTranslateWithAgentPending = false,
   job,
   jobId,
   onRefresh,
+  onTranslateWithAgent,
   organizationSlug,
   projectId,
   renderBackLink = defaultRenderBackLink,
@@ -284,6 +291,7 @@ export function ProviderLiveJobDetailView({
   renderError = defaultRenderError,
   renderExternalLink,
   renderFilesSection,
+  translateWithAgentAction,
 }: {
   buildJobsListHref?: typeof buildJobsListHref;
   canEditProviderJobDescription?: boolean;
@@ -293,9 +301,11 @@ export function ProviderLiveJobDetailView({
   error?: unknown;
   isLoading: boolean;
   isRefreshing?: boolean;
+  isTranslateWithAgentPending?: boolean;
   job?: TmsProviderLiveJobDetail;
   jobId: string;
   onRefresh?: () => void;
+  onTranslateWithAgent?: () => void;
   organizationSlug: string;
   projectId: string;
   renderBackLink?: JobDetailBackLinkRenderer;
@@ -303,6 +313,7 @@ export function ProviderLiveJobDetailView({
   renderError?: JobDetailErrorRenderer;
   renderExternalLink?: (props: { href: string; label: string }) => ReactNode;
   renderFilesSection?: ProviderLiveFilesSectionRenderer;
+  translateWithAgentAction?: ProviderActionAvailability | null;
 }) {
   const providerDescription = job
     ? (getProviderPayloadString(job.externalProviderPayload, "description") ?? "")
@@ -313,6 +324,12 @@ export function ProviderLiveJobDetailView({
   const showTaskDescriptionSection =
     providerDescription.trim().length > 0 || canEditProviderDescription;
   const jobsListHref = buildJobsListHrefProp(organizationSlug, projectId);
+  const showTranslateWithAgent = translateWithAgentAction?.visible ?? false;
+  const translateWithAgentDisabled =
+    !translateWithAgentAction?.enabled || isTranslateWithAgentPending || !onTranslateWithAgent;
+  const translateWithAgentLabel = isTranslateWithAgentPending
+    ? "Starting agent..."
+    : (translateWithAgentAction?.label ?? "Translate with agent");
 
   return (
     <main className="mx-auto flex w-full max-w-7xl flex-col gap-5">
@@ -378,16 +395,25 @@ export function ProviderLiveJobDetailView({
                   {isRefreshing ? "Refreshing..." : "Refresh"}
                 </Button>
               ) : null}
-              <Tooltip>
-                <TooltipTrigger
-                  render={
-                    <Button size="sm" disabled>
-                      Run with agent
-                    </Button>
-                  }
-                />
-                <TooltipContent>Agent workflows on provider tasks are coming soon.</TooltipContent>
-              </Tooltip>
+              {showTranslateWithAgent ? (
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <Button
+                        size="sm"
+                        disabled={translateWithAgentDisabled}
+                        onClick={onTranslateWithAgent}
+                      >
+                        <HugeiconsIcon icon={AiMagicIcon} strokeWidth={1.8} />
+                        {translateWithAgentLabel}
+                      </Button>
+                    }
+                  />
+                  {translateWithAgentAction?.disabledReason ? (
+                    <TooltipContent>{translateWithAgentAction.disabledReason}</TooltipContent>
+                  ) : null}
+                </Tooltip>
+              ) : null}
             </div>
           </div>
         ) : null}

--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-translate.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-translate.ts
@@ -17,7 +17,7 @@ import type {
   ExternalTmsTranslationUnit,
 } from "@/lib/providers/tms-provider-types";
 import { getProviderContentPuller } from "@/lib/providers/provider-content-pullers";
-import { resolveProviderSourceFiles } from "@/lib/providers/job-provider-source-files";
+import { resolveProviderAgentRunSourceFiles } from "@/lib/providers/job-provider-source-files";
 import {
   shouldUseProviderFileTranslation,
   translateProviderJobFiles,
@@ -505,14 +505,13 @@ export async function executeProviderAgentTranslation(input: {
       })()
     : [null];
 
-  const sourceFiles = jobDetails?.providerPayload
-    ? await resolveProviderSourceFiles({
-        organizationId: input.organizationId,
-        projectId,
-        providerKind: run.providerKind,
-        providerPayload: jobDetails.providerPayload,
-      })
-    : [];
+  const sourceFiles = await resolveProviderAgentRunSourceFiles({
+    organizationId: input.organizationId,
+    projectId,
+    providerKind: run.providerKind,
+    inputSnapshot: run.inputSnapshot ?? {},
+    syncedProviderPayload: jobDetails?.providerPayload ?? null,
+  });
 
   if (shouldUseProviderFileTranslation({ sourceFiles })) {
     const fileTranslationResult = await translateProviderJobFiles({

--- a/apps/hyperlocalise-web/src/lib/providers/job-provider-source-files.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/job-provider-source-files.test.ts
@@ -1,11 +1,11 @@
-import { describe, expect, it, vi } from "vite-plus/test";
+import { describe, expect, it } from "vite-plus/test";
 
-vi.mock("@/lib/database", () => ({
-  db: {},
-  schema: {},
-}));
-
-import { extractProviderFileIds } from "./job-provider-source-files";
+import {
+  extractProviderFileIds,
+  readProviderAgentRunSourceFilesFromSnapshot,
+  readProviderPayloadFromInputSnapshot,
+  resolveProviderAgentRunSourceFiles,
+} from "@/lib/providers/job-provider-source-files";
 
 describe("extractProviderFileIds", () => {
   it.each([
@@ -33,5 +33,65 @@ describe("extractProviderFileIds", () => {
         fileIds: [123, "", null, undefined, false, true, { id: "456" }, ["789"]],
       }),
     ).toEqual(["123"]);
+  });
+});
+
+describe("provider agent run source files", () => {
+  it("reads explicit source files from the input snapshot", () => {
+    expect(
+      readProviderAgentRunSourceFilesFromSnapshot({
+        sourceFiles: [
+          {
+            id: "42",
+            displayName: "home.json",
+            sourcePath: "marketing/home.json",
+          },
+        ],
+      }),
+    ).toEqual([
+      {
+        id: "42",
+        displayName: "home.json",
+        sourcePath: "marketing/home.json",
+        resourceType: null,
+        externalUrl: null,
+      },
+    ]);
+  });
+
+  it("reads provider payload from the input snapshot", () => {
+    expect(
+      readProviderPayloadFromInputSnapshot({
+        providerPayload: { fileIds: ["42"] },
+      }),
+    ).toEqual({ fileIds: ["42"] });
+  });
+
+  it("prefers explicit source files over synced provider payload", async () => {
+    const sourceFiles = await resolveProviderAgentRunSourceFiles({
+      organizationId: "org_1",
+      projectId: "project_1",
+      providerKind: "crowdin",
+      inputSnapshot: {
+        sourceFiles: [
+          {
+            id: "42",
+            displayName: "home.json",
+            sourcePath: "marketing/home.json",
+          },
+        ],
+      },
+      syncedProviderPayload: { fileIds: ["99"] },
+    });
+
+    expect(sourceFiles).toEqual([
+      {
+        id: "42",
+        displayName: "home.json",
+        sourcePath: "marketing/home.json",
+        resourceType: null,
+        externalUrl: null,
+      },
+    ]);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/job-provider-source-files.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/job-provider-source-files.ts
@@ -22,6 +22,82 @@ export function extractProviderFileIds(
     .filter((fileId): fileId is string => Boolean(fileId));
 }
 
+export type ProviderAgentRunSourceFileRef = {
+  id: string;
+  displayName: string;
+  sourcePath: string | null;
+  resourceType?: string | null;
+  externalUrl?: string | null;
+};
+
+export function readProviderPayloadFromInputSnapshot(
+  inputSnapshot: Record<string, unknown> | null | undefined,
+) {
+  const payload = inputSnapshot?.providerPayload;
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return null;
+  }
+
+  return payload as Record<string, unknown>;
+}
+
+export function readProviderAgentRunSourceFilesFromSnapshot(
+  inputSnapshot: Record<string, unknown> | null | undefined,
+): ProviderAgentRunSourceFileRef[] {
+  const sourceFiles = inputSnapshot?.sourceFiles;
+  if (!Array.isArray(sourceFiles)) {
+    return [];
+  }
+
+  return sourceFiles.flatMap((item) => {
+    if (!item || typeof item !== "object") {
+      return [];
+    }
+
+    const record = item as Record<string, unknown>;
+    const id = typeof record.id === "string" ? record.id : null;
+    if (!id) {
+      return [];
+    }
+
+    return [
+      {
+        id,
+        displayName: typeof record.displayName === "string" ? record.displayName : id,
+        sourcePath: typeof record.sourcePath === "string" ? record.sourcePath : null,
+        resourceType: typeof record.resourceType === "string" ? record.resourceType : null,
+        externalUrl: typeof record.externalUrl === "string" ? record.externalUrl : null,
+      },
+    ];
+  });
+}
+
+export async function resolveProviderAgentRunSourceFiles(input: {
+  organizationId: string;
+  projectId: string;
+  providerKind: ExternalTmsProviderKind;
+  inputSnapshot: Record<string, unknown>;
+  syncedProviderPayload?: Record<string, unknown> | null;
+}) {
+  const explicitSourceFiles = readProviderAgentRunSourceFilesFromSnapshot(input.inputSnapshot);
+  if (explicitSourceFiles.some((file) => Boolean(file.sourcePath?.trim()))) {
+    return explicitSourceFiles;
+  }
+
+  const providerPayload =
+    input.syncedProviderPayload ?? readProviderPayloadFromInputSnapshot(input.inputSnapshot);
+  if (!providerPayload) {
+    return explicitSourceFiles;
+  }
+
+  return resolveProviderSourceFiles({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    providerKind: input.providerKind,
+    providerPayload,
+  });
+}
+
 export async function resolveProviderSourceFiles(input: {
   organizationId: string;
   projectId: string;


### PR DESCRIPTION
## What changed

Enable **Translate with agent** on live TMS provider job detail pages (shell mode). The button now starts a provider agent translation run through the existing file translation workflow instead of showing a disabled placeholder.

- Add `POST /tms-provider/jobs/:encodedJobId/agent-runs` to create and enqueue translate agent runs for live provider jobs
- Resolve source files from live TMS file metadata in agent run snapshots so shell-mode jobs can use file translation
- Show **Translation agent is running** toast when translate starts (native, synced provider, and live provider flows)

## How to test

- Open a live Crowdin provider job in shell mode and click **Translate with agent**
- Confirm the toast says **Translation agent is running** and an agent run is queued
- On a native file job, click **Translate with agent** and confirm the same toast
- Run `cd apps/hyperlocalise-web && vp test src/lib/providers/job-provider-source-files.test.ts src/api/routes/tms-provider/tms-provider.route.test.ts`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)