### PR TITLE
feat(billing): track Autumn AI token usage

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/agent-slack/agent-slack.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/agent-slack/agent-slack.route.ts
@@ -5,9 +5,19 @@ import { Hono } from "hono";
 import { validator } from "hono/validator";
 
 import { isIntegrationsReadAllowed } from "@/api/auth/capability-guards";
-import { forbiddenResponse } from "@/api/response.schema";
+import {
+  conflictResponse,
+  forbiddenResponse,
+  serviceUnavailableResponse,
+} from "@/api/response.schema";
 import { type AuthVariables, workosAuthMiddleware } from "@/api/auth/workos";
 import { getSlackRedirectUri } from "@/api/routes/slack-oauth/slack-oauth.route";
+import {
+  ensureWorkspaceResourceLimitAvailable,
+  workspaceResourceFeatureIds,
+  workspaceResourceLimitErrorDetails,
+  workspaceResourceLimitMessage,
+} from "@/lib/billing/workspace-resource-limits";
 import { getSlackBot } from "@/lib/agents/slack/bot";
 import {
   createSlackState,
@@ -297,6 +307,42 @@ export function createAgentSlackRoutes() {
         assertProviderCredentialAdmin(c.var.auth.membership.role);
       } catch {
         return c.json({ error: "forbidden" as const }, 403);
+      }
+
+      if (payload.enabled) {
+        const [existingConnector] = await db
+          .select({ enabled: schema.connectors.enabled })
+          .from(schema.connectors)
+          .where(
+            and(
+              eq(schema.connectors.organizationId, organizationId),
+              eq(schema.connectors.kind, "slack"),
+            ),
+          )
+          .limit(1);
+
+        if (!existingConnector?.enabled) {
+          const limitResult = await ensureWorkspaceResourceLimitAvailable({
+            organizationId,
+            featureId: workspaceResourceFeatureIds.integrations,
+          });
+          if (!limitResult.ok) {
+            if (limitResult.error.code === "workspace_resource_limit_check_failed") {
+              return serviceUnavailableResponse(
+                c,
+                limitResult.error.code,
+                "Unable to verify integration limits. Try again later.",
+              );
+            }
+
+            return conflictResponse(
+              c,
+              limitResult.error.code,
+              workspaceResourceLimitMessage(limitResult.error.featureId),
+              workspaceResourceLimitErrorDetails(limitResult.error),
+            );
+          }
+        }
       }
 
       const [connector] = await db

--- a/apps/hyperlocalise-web/src/api/routes/agent-slack/agent-slack.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/agent-slack/agent-slack.route.ts
@@ -13,7 +13,7 @@ import {
 import { type AuthVariables, workosAuthMiddleware } from "@/api/auth/workos";
 import { getSlackRedirectUri } from "@/api/routes/slack-oauth/slack-oauth.route";
 import {
-  ensureWorkspaceResourceLimitAvailable,
+  withWorkspaceResourceLimit,
   workspaceResourceFeatureIds,
   workspaceResourceLimitErrorDetails,
   workspaceResourceLimitMessage,
@@ -24,7 +24,7 @@ import {
   getSlackStateSecret,
   SLACK_STATE_TTL_MS,
 } from "@/lib/agents/slack/oauth-state";
-import { db, schema } from "@/lib/database";
+import { db, schema, type DatabaseClient } from "@/lib/database";
 import { env } from "@/lib/env";
 import { createLogger, serializeErrorForLog } from "@/lib/log";
 import { err, fromThrowableAsync, isErr, ok, type Result } from "@/lib/primitives/result/results";
@@ -309,6 +309,32 @@ export function createAgentSlackRoutes() {
         return c.json({ error: "forbidden" as const }, 403);
       }
 
+      const upsertSlackConnector = async (database: DatabaseClient) => {
+        const [connector] = await database
+          .insert(schema.connectors)
+          .values({
+            organizationId,
+            kind: "slack",
+            enabled: payload.enabled,
+            config: {},
+          })
+          .onConflictDoUpdate({
+            target: [schema.connectors.organizationId, schema.connectors.kind],
+            set: {
+              enabled: payload.enabled,
+              updatedAt: new Date(),
+            },
+          })
+          .returning();
+
+        if (!connector) {
+          throw new Error("organization_not_found");
+        }
+
+        return connector;
+      };
+
+      let connector;
       if (payload.enabled) {
         const [existingConnector] = await db
           .select({ enabled: schema.connectors.enabled })
@@ -322,10 +348,13 @@ export function createAgentSlackRoutes() {
           .limit(1);
 
         if (!existingConnector?.enabled) {
-          const limitResult = await ensureWorkspaceResourceLimitAvailable({
-            organizationId,
-            featureId: workspaceResourceFeatureIds.integrations,
-          });
+          const limitResult = await withWorkspaceResourceLimit(
+            {
+              organizationId,
+              featureId: workspaceResourceFeatureIds.integrations,
+            },
+            upsertSlackConnector,
+          );
           if (!limitResult.ok) {
             if (limitResult.error.code === "workspace_resource_limit_check_failed") {
               return serviceUnavailableResponse(
@@ -342,28 +371,13 @@ export function createAgentSlackRoutes() {
               workspaceResourceLimitErrorDetails(limitResult.error),
             );
           }
+
+          connector = limitResult.value;
+        } else {
+          connector = await upsertSlackConnector(db);
         }
-      }
-
-      const [connector] = await db
-        .insert(schema.connectors)
-        .values({
-          organizationId,
-          kind: "slack",
-          enabled: payload.enabled,
-          config: {},
-        })
-        .onConflictDoUpdate({
-          target: [schema.connectors.organizationId, schema.connectors.kind],
-          set: {
-            enabled: payload.enabled,
-            updatedAt: new Date(),
-          },
-        })
-        .returning();
-
-      if (!connector) {
-        return c.json({ error: "organization_not_found" as const }, 404);
+      } else {
+        connector = await upsertSlackConnector(db);
       }
 
       const config = (connector.config ?? {}) as SlackConnectorConfig;

--- a/apps/hyperlocalise-web/src/api/routes/contentful-connection/contentful-connection.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/contentful-connection/contentful-connection.route.ts
@@ -12,10 +12,11 @@ import {
   unauthorizedResponse,
 } from "@/api/response.schema";
 import {
-  ensureWorkspaceResourceLimitAvailable,
+  withWorkspaceResourceLimit,
   workspaceResourceFeatureIds,
   workspaceResourceLimitErrorDetails,
   workspaceResourceLimitMessage,
+  type WorkspaceResourceLimitError,
 } from "@/lib/billing/workspace-resource-limits";
 import { isErr } from "@/lib/primitives/result/results";
 import {
@@ -121,6 +122,26 @@ function mapDiscoveryErrorResponse(
   }
 }
 
+function mapWorkspaceResourceLimitError(
+  c: Parameters<typeof conflictResponse>[0],
+  error: WorkspaceResourceLimitError,
+) {
+  if (error.code === "workspace_resource_limit_check_failed") {
+    return serviceUnavailableResponse(
+      c,
+      error.code,
+      "Unable to verify integration limits. Try again later.",
+    );
+  }
+
+  return conflictResponse(
+    c,
+    error.code,
+    workspaceResourceLimitMessage(error.featureId),
+    workspaceResourceLimitErrorDetails(error),
+  );
+}
+
 export function createContentfulConnectionRoutes() {
   return new Hono<{ Variables: AuthVariables }>()
     .use("*", workosAuthMiddleware)
@@ -161,31 +182,9 @@ export function createContentfulConnectionRoutes() {
       }
 
       const payload = c.req.valid("json");
-      if (payload.enabled) {
-        const limitResult = await ensureWorkspaceResourceLimitAvailable({
-          organizationId: c.var.auth.organization.localOrganizationId,
-          featureId: workspaceResourceFeatureIds.integrations,
-        });
-        if (!limitResult.ok) {
-          if (limitResult.error.code === "workspace_resource_limit_check_failed") {
-            return serviceUnavailableResponse(
-              c,
-              limitResult.error.code,
-              "Unable to verify integration limits. Try again later.",
-            );
-          }
-
-          return conflictResponse(
-            c,
-            limitResult.error.code,
-            workspaceResourceLimitMessage(limitResult.error.featureId),
-            workspaceResourceLimitErrorDetails(limitResult.error),
-          );
-        }
-      }
-
-      const result = await createContentfulConnection({
-        organizationId: c.var.auth.organization.localOrganizationId,
+      const organizationId = c.var.auth.organization.localOrganizationId;
+      const connectionInput = {
+        organizationId,
         userId: c.var.auth.user.localUserId,
         displayName: payload.displayName,
         spaceId: payload.spaceId,
@@ -194,12 +193,29 @@ export function createContentfulConnectionRoutes() {
         fieldConfig: payload.fieldConfig,
         accessToken: payload.accessToken,
         enabled: payload.enabled,
-      });
+      };
+
+      let connectionResult;
+      if (payload.enabled) {
+        const limitResult = await withWorkspaceResourceLimit(
+          {
+            organizationId,
+            featureId: workspaceResourceFeatureIds.integrations,
+          },
+          (tx) => createContentfulConnection({ ...connectionInput, db: tx }),
+        );
+        if (!limitResult.ok) {
+          return mapWorkspaceResourceLimitError(c, limitResult.error);
+        }
+        connectionResult = limitResult.value;
+      } else {
+        connectionResult = await createContentfulConnection(connectionInput);
+      }
 
       return c.json(
         {
-          contentfulConnection: result.connection,
-          webhookSecret: result.webhookSecret,
+          contentfulConnection: connectionResult.connection,
+          webhookSecret: connectionResult.webhookSecret,
         },
         201,
       );
@@ -227,41 +243,21 @@ export function createContentfulConnectionRoutes() {
 
       const { connectionId } = c.req.valid("param");
       const payload = c.req.valid("json");
-      if (payload.enabled === true) {
-        const existing = await getContentfulConnection({
-          organizationId: c.var.auth.organization.localOrganizationId,
-          connectionId,
-        });
-        if (!existing) {
-          return notFoundResponse(c, "contentful_connection_not_found");
-        }
+      const organizationId = c.var.auth.organization.localOrganizationId;
+      const existing =
+        payload.enabled === true
+          ? await getContentfulConnection({
+              organizationId,
+              connectionId,
+            })
+          : null;
 
-        if (!existing.enabled) {
-          const limitResult = await ensureWorkspaceResourceLimitAvailable({
-            organizationId: c.var.auth.organization.localOrganizationId,
-            featureId: workspaceResourceFeatureIds.integrations,
-          });
-          if (!limitResult.ok) {
-            if (limitResult.error.code === "workspace_resource_limit_check_failed") {
-              return serviceUnavailableResponse(
-                c,
-                limitResult.error.code,
-                "Unable to verify integration limits. Try again later.",
-              );
-            }
-
-            return conflictResponse(
-              c,
-              limitResult.error.code,
-              workspaceResourceLimitMessage(limitResult.error.featureId),
-              workspaceResourceLimitErrorDetails(limitResult.error),
-            );
-          }
-        }
+      if (payload.enabled === true && !existing) {
+        return notFoundResponse(c, "contentful_connection_not_found");
       }
 
-      const result = await updateContentfulConnection({
-        organizationId: c.var.auth.organization.localOrganizationId,
+      const updateInput = {
+        organizationId,
         userId: c.var.auth.user.localUserId,
         connectionId,
         displayName: payload.displayName,
@@ -271,7 +267,27 @@ export function createContentfulConnectionRoutes() {
         fieldConfig: payload.fieldConfig,
         accessToken: payload.accessToken,
         enabled: payload.enabled,
-      });
+      };
+      const shouldEnforceIntegrationLimit =
+        payload.enabled === true && existing && !existing.enabled;
+
+      let result;
+      if (shouldEnforceIntegrationLimit) {
+        const limitResult = await withWorkspaceResourceLimit(
+          {
+            organizationId,
+            featureId: workspaceResourceFeatureIds.integrations,
+          },
+          (tx) => updateContentfulConnection({ ...updateInput, db: tx }),
+        );
+        if (!limitResult.ok) {
+          return mapWorkspaceResourceLimitError(c, limitResult.error);
+        }
+        result = limitResult.value;
+      } else {
+        result = await updateContentfulConnection(updateInput);
+      }
+
       if (!result) {
         return notFoundResponse(c, "contentful_connection_not_found");
       }

--- a/apps/hyperlocalise-web/src/api/routes/contentful-connection/contentful-connection.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/contentful-connection/contentful-connection.route.ts
@@ -5,10 +5,18 @@ import { hasCapability } from "@/api/auth/policy";
 import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
 import {
   badRequestResponse,
+  conflictResponse,
   forbiddenResponse,
   notFoundResponse,
+  serviceUnavailableResponse,
   unauthorizedResponse,
 } from "@/api/response.schema";
+import {
+  ensureWorkspaceResourceLimitAvailable,
+  workspaceResourceFeatureIds,
+  workspaceResourceLimitErrorDetails,
+  workspaceResourceLimitMessage,
+} from "@/lib/billing/workspace-resource-limits";
 import { isErr } from "@/lib/primitives/result/results";
 import {
   createContentfulConnection,
@@ -153,6 +161,29 @@ export function createContentfulConnectionRoutes() {
       }
 
       const payload = c.req.valid("json");
+      if (payload.enabled) {
+        const limitResult = await ensureWorkspaceResourceLimitAvailable({
+          organizationId: c.var.auth.organization.localOrganizationId,
+          featureId: workspaceResourceFeatureIds.integrations,
+        });
+        if (!limitResult.ok) {
+          if (limitResult.error.code === "workspace_resource_limit_check_failed") {
+            return serviceUnavailableResponse(
+              c,
+              limitResult.error.code,
+              "Unable to verify integration limits. Try again later.",
+            );
+          }
+
+          return conflictResponse(
+            c,
+            limitResult.error.code,
+            workspaceResourceLimitMessage(limitResult.error.featureId),
+            workspaceResourceLimitErrorDetails(limitResult.error),
+          );
+        }
+      }
+
       const result = await createContentfulConnection({
         organizationId: c.var.auth.organization.localOrganizationId,
         userId: c.var.auth.user.localUserId,
@@ -196,6 +227,39 @@ export function createContentfulConnectionRoutes() {
 
       const { connectionId } = c.req.valid("param");
       const payload = c.req.valid("json");
+      if (payload.enabled === true) {
+        const existing = await getContentfulConnection({
+          organizationId: c.var.auth.organization.localOrganizationId,
+          connectionId,
+        });
+        if (!existing) {
+          return notFoundResponse(c, "contentful_connection_not_found");
+        }
+
+        if (!existing.enabled) {
+          const limitResult = await ensureWorkspaceResourceLimitAvailable({
+            organizationId: c.var.auth.organization.localOrganizationId,
+            featureId: workspaceResourceFeatureIds.integrations,
+          });
+          if (!limitResult.ok) {
+            if (limitResult.error.code === "workspace_resource_limit_check_failed") {
+              return serviceUnavailableResponse(
+                c,
+                limitResult.error.code,
+                "Unable to verify integration limits. Try again later.",
+              );
+            }
+
+            return conflictResponse(
+              c,
+              limitResult.error.code,
+              workspaceResourceLimitMessage(limitResult.error.featureId),
+              workspaceResourceLimitErrorDetails(limitResult.error),
+            );
+          }
+        }
+      }
+
       const result = await updateContentfulConnection({
         organizationId: c.var.auth.organization.localOrganizationId,
         userId: c.var.auth.user.localUserId,

--- a/apps/hyperlocalise-web/src/api/routes/external-tms-provider-credential/external-tms-provider-credential.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/external-tms-provider-credential/external-tms-provider-credential.route.ts
@@ -104,7 +104,7 @@ async function withNewIntegrationLimit<T>(
     )
     .limit(1);
 
-  if (existing) return ok(await run(db));
+  if (existing) return ok(await db.transaction(run));
 
   return withWorkspaceResourceLimit(
     {

--- a/apps/hyperlocalise-web/src/api/routes/external-tms-provider-credential/external-tms-provider-credential.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/external-tms-provider-credential/external-tms-provider-credential.route.ts
@@ -7,13 +7,14 @@ import { validator } from "hono/validator";
 import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
 import { hasCapability } from "@/api/auth/policy";
 import { env } from "@/lib/env";
-import { isErr } from "@/lib/primitives/result/results";
-import { db, schema } from "@/lib/database";
+import { isErr, ok, type Result } from "@/lib/primitives/result/results";
+import { db, schema, type DatabaseClient } from "@/lib/database";
 import {
-  ensureWorkspaceResourceLimitAvailable,
+  withWorkspaceResourceLimit,
   workspaceResourceFeatureIds,
   workspaceResourceLimitErrorDetails,
   workspaceResourceLimitMessage,
+  type WorkspaceResourceLimitError,
 } from "@/lib/billing/workspace-resource-limits";
 import {
   OAUTH_AUTH_MODE,
@@ -85,10 +86,13 @@ const PHRASE_USER_OAUTH_STATE_TTL_MS = 60 * 60 * 1000;
 const LOKALISE_USER_OAUTH_STATE_TTL_MS = 60 * 60 * 1000;
 const logger = createLogger("tms-user-oauth");
 
-async function ensureIntegrationLimitForNewExternalTmsCredential(input: {
-  organizationId: string;
-  providerKind: typeof schema.organizationExternalTmsProviderCredentials.$inferSelect.providerKind;
-}) {
+async function withNewIntegrationLimit<T>(
+  input: {
+    organizationId: string;
+    providerKind: typeof schema.organizationExternalTmsProviderCredentials.$inferSelect.providerKind;
+  },
+  run: (database: DatabaseClient) => Promise<T>,
+): Promise<Result<T, WorkspaceResourceLimitError>> {
   const [existing] = await db
     .select({ id: schema.organizationExternalTmsProviderCredentials.id })
     .from(schema.organizationExternalTmsProviderCredentials)
@@ -100,14 +104,32 @@ async function ensureIntegrationLimitForNewExternalTmsCredential(input: {
     )
     .limit(1);
 
-  if (existing) return null;
+  if (existing) return ok(await run(db));
 
-  const result = await ensureWorkspaceResourceLimitAvailable({
-    organizationId: input.organizationId,
-    featureId: workspaceResourceFeatureIds.integrations,
-  });
+  return withWorkspaceResourceLimit(
+    {
+      organizationId: input.organizationId,
+      featureId: workspaceResourceFeatureIds.integrations,
+    },
+    run,
+  );
+}
 
-  return result.ok ? null : result.error;
+function integrationLimitErrorResponse(limitError: WorkspaceResourceLimitError): {
+  body: Record<string, unknown>;
+  status: 409 | 503;
+} {
+  return {
+    body: {
+      error: limitError.code,
+      message:
+        limitError.code === "workspace_resource_limit_check_failed"
+          ? "Unable to verify integration limits. Try again later."
+          : workspaceResourceLimitMessage(limitError.featureId),
+      details: workspaceResourceLimitErrorDetails(limitError),
+    },
+    status: limitError.code === "workspace_resource_limit_check_failed" ? 503 : 409,
+  };
 }
 
 const validateUpsertBody = validator("json", (value, c) => {
@@ -1116,35 +1138,31 @@ export function createExternalTmsProviderCredentialRoutes() {
         }
         const payload = c.req.valid("json");
         const organizationId = c.var.auth.organization.localOrganizationId;
-        const limitError = await ensureIntegrationLimitForNewExternalTmsCredential({
-          organizationId,
-          providerKind: "crowdin",
-        });
-        if (limitError) {
-          return c.json(
-            {
-              error: limitError.code,
-              message:
-                limitError.code === "workspace_resource_limit_check_failed"
-                  ? "Unable to verify integration limits. Try again later."
-                  : workspaceResourceLimitMessage(limitError.featureId),
-              details: workspaceResourceLimitErrorDetails(limitError),
-            },
-            limitError.code === "workspace_resource_limit_check_failed" ? 503 : 409,
-          );
+        const credentialResult = await withNewIntegrationLimit(
+          {
+            organizationId,
+            providerKind: "crowdin",
+          },
+          (database) =>
+            upsertCrowdinOAuthProviderCredential({
+              organizationId,
+              userId: c.var.auth.user.localUserId,
+              role: c.var.auth.membership.role,
+              displayName: payload.displayName,
+              oauthClient: {
+                clientId: payload.oauthClientId,
+                clientSecret: payload.oauthClientSecret,
+              },
+              baseUrl: payload.baseUrl ?? null,
+              db: database,
+            }),
+        );
+        if (!credentialResult.ok) {
+          const limitResponse = integrationLimitErrorResponse(credentialResult.error);
+          return c.json(limitResponse.body, limitResponse.status);
         }
 
-        const providerCredential = await upsertCrowdinOAuthProviderCredential({
-          organizationId,
-          userId: c.var.auth.user.localUserId,
-          role: c.var.auth.membership.role,
-          displayName: payload.displayName,
-          oauthClient: {
-            clientId: payload.oauthClientId,
-            clientSecret: payload.oauthClientSecret,
-          },
-          baseUrl: payload.baseUrl ?? null,
-        });
+        const providerCredential = credentialResult.value;
 
         return c.json(
           {
@@ -1173,35 +1191,31 @@ export function createExternalTmsProviderCredentialRoutes() {
         }
         const payload = c.req.valid("json");
         const organizationId = c.var.auth.organization.localOrganizationId;
-        const limitError = await ensureIntegrationLimitForNewExternalTmsCredential({
-          organizationId,
-          providerKind: "phrase",
-        });
-        if (limitError) {
-          return c.json(
-            {
-              error: limitError.code,
-              message:
-                limitError.code === "workspace_resource_limit_check_failed"
-                  ? "Unable to verify integration limits. Try again later."
-                  : workspaceResourceLimitMessage(limitError.featureId),
-              details: workspaceResourceLimitErrorDetails(limitError),
-            },
-            limitError.code === "workspace_resource_limit_check_failed" ? 503 : 409,
-          );
+        const credentialResult = await withNewIntegrationLimit(
+          {
+            organizationId,
+            providerKind: "phrase",
+          },
+          (database) =>
+            upsertPhraseOAuthProviderCredential({
+              organizationId,
+              userId: c.var.auth.user.localUserId,
+              role: c.var.auth.membership.role,
+              displayName: payload.displayName,
+              oauthClient: {
+                clientId: payload.oauthClientId,
+                clientSecret: payload.oauthClientSecret,
+              },
+              baseUrl: payload.baseUrl ?? null,
+              db: database,
+            }),
+        );
+        if (!credentialResult.ok) {
+          const limitResponse = integrationLimitErrorResponse(credentialResult.error);
+          return c.json(limitResponse.body, limitResponse.status);
         }
 
-        const providerCredential = await upsertPhraseOAuthProviderCredential({
-          organizationId,
-          userId: c.var.auth.user.localUserId,
-          role: c.var.auth.membership.role,
-          displayName: payload.displayName,
-          oauthClient: {
-            clientId: payload.oauthClientId,
-            clientSecret: payload.oauthClientSecret,
-          },
-          baseUrl: payload.baseUrl ?? null,
-        });
+        const providerCredential = credentialResult.value;
 
         return c.json(
           {
@@ -1230,35 +1244,31 @@ export function createExternalTmsProviderCredentialRoutes() {
         }
         const payload = c.req.valid("json");
         const organizationId = c.var.auth.organization.localOrganizationId;
-        const limitError = await ensureIntegrationLimitForNewExternalTmsCredential({
-          organizationId,
-          providerKind: "lokalise",
-        });
-        if (limitError) {
-          return c.json(
-            {
-              error: limitError.code,
-              message:
-                limitError.code === "workspace_resource_limit_check_failed"
-                  ? "Unable to verify integration limits. Try again later."
-                  : workspaceResourceLimitMessage(limitError.featureId),
-              details: workspaceResourceLimitErrorDetails(limitError),
-            },
-            limitError.code === "workspace_resource_limit_check_failed" ? 503 : 409,
-          );
+        const credentialResult = await withNewIntegrationLimit(
+          {
+            organizationId,
+            providerKind: "lokalise",
+          },
+          (database) =>
+            upsertLokaliseOAuthProviderCredential({
+              organizationId,
+              userId: c.var.auth.user.localUserId,
+              role: c.var.auth.membership.role,
+              displayName: payload.displayName,
+              oauthClient: {
+                clientId: payload.oauthClientId,
+                clientSecret: payload.oauthClientSecret,
+              },
+              baseUrl: payload.baseUrl ?? null,
+              db: database,
+            }),
+        );
+        if (!credentialResult.ok) {
+          const limitResponse = integrationLimitErrorResponse(credentialResult.error);
+          return c.json(limitResponse.body, limitResponse.status);
         }
 
-        const providerCredential = await upsertLokaliseOAuthProviderCredential({
-          organizationId,
-          userId: c.var.auth.user.localUserId,
-          role: c.var.auth.membership.role,
-          displayName: payload.displayName,
-          oauthClient: {
-            clientId: payload.oauthClientId,
-            clientSecret: payload.oauthClientSecret,
-          },
-          baseUrl: payload.baseUrl ?? null,
-        });
+        const providerCredential = credentialResult.value;
 
         return c.json(
           {
@@ -1869,33 +1879,30 @@ export function createExternalTmsProviderCredentialRoutes() {
           );
         }
         const organizationId = c.var.auth.organization.localOrganizationId;
-        const limitError = await ensureIntegrationLimitForNewExternalTmsCredential({
-          organizationId,
-          providerKind: payload.providerKind,
-        });
-        if (limitError) {
-          return c.json(
-            {
-              error: limitError.code,
-              message:
-                limitError.code === "workspace_resource_limit_check_failed"
-                  ? "Unable to verify integration limits. Try again later."
-                  : workspaceResourceLimitMessage(limitError.featureId),
-              details: workspaceResourceLimitErrorDetails(limitError),
-            },
-            limitError.code === "workspace_resource_limit_check_failed" ? 503 : 409,
-          );
+        const credentialResult = await withNewIntegrationLimit(
+          {
+            organizationId,
+            providerKind: payload.providerKind,
+          },
+          (database) =>
+            upsertOrganizationExternalTmsProviderCredential({
+              organizationId,
+              userId: c.var.auth.user.localUserId,
+              role: c.var.auth.membership.role,
+              providerKind: payload.providerKind,
+              displayName: payload.displayName,
+              secretMaterial: payload.secretMaterial,
+              region: payload.region,
+              baseUrl: payload.baseUrl,
+              db: database,
+            }),
+        );
+        if (!credentialResult.ok) {
+          const limitResponse = integrationLimitErrorResponse(credentialResult.error);
+          return c.json(limitResponse.body, limitResponse.status);
         }
-        const providerCredential = await upsertOrganizationExternalTmsProviderCredential({
-          organizationId,
-          userId: c.var.auth.user.localUserId,
-          role: c.var.auth.membership.role,
-          providerKind: payload.providerKind,
-          displayName: payload.displayName,
-          secretMaterial: payload.secretMaterial,
-          region: payload.region,
-          baseUrl: payload.baseUrl,
-        });
+
+        const providerCredential = credentialResult.value;
 
         return c.json({ externalTmsProviderCredential: providerCredential }, 200);
       } catch (error) {

--- a/apps/hyperlocalise-web/src/api/routes/external-tms-provider-credential/external-tms-provider-credential.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/external-tms-provider-credential/external-tms-provider-credential.route.ts
@@ -10,6 +10,12 @@ import { env } from "@/lib/env";
 import { isErr } from "@/lib/primitives/result/results";
 import { db, schema } from "@/lib/database";
 import {
+  ensureWorkspaceResourceLimitAvailable,
+  workspaceResourceFeatureIds,
+  workspaceResourceLimitErrorDetails,
+  workspaceResourceLimitMessage,
+} from "@/lib/billing/workspace-resource-limits";
+import {
   OAUTH_AUTH_MODE,
   assertExternalTmsCredentialAdmin,
   deleteOrganizationExternalTmsProviderCredential,
@@ -78,6 +84,31 @@ const CROWDIN_USER_OAUTH_STATE_TTL_MS = 60 * 60 * 1000;
 const PHRASE_USER_OAUTH_STATE_TTL_MS = 60 * 60 * 1000;
 const LOKALISE_USER_OAUTH_STATE_TTL_MS = 60 * 60 * 1000;
 const logger = createLogger("tms-user-oauth");
+
+async function ensureIntegrationLimitForNewExternalTmsCredential(input: {
+  organizationId: string;
+  providerKind: typeof schema.organizationExternalTmsProviderCredentials.$inferSelect.providerKind;
+}) {
+  const [existing] = await db
+    .select({ id: schema.organizationExternalTmsProviderCredentials.id })
+    .from(schema.organizationExternalTmsProviderCredentials)
+    .where(
+      and(
+        eq(schema.organizationExternalTmsProviderCredentials.organizationId, input.organizationId),
+        eq(schema.organizationExternalTmsProviderCredentials.providerKind, input.providerKind),
+      ),
+    )
+    .limit(1);
+
+  if (existing) return null;
+
+  const result = await ensureWorkspaceResourceLimitAvailable({
+    organizationId: input.organizationId,
+    featureId: workspaceResourceFeatureIds.integrations,
+  });
+
+  return result.ok ? null : result.error;
+}
 
 const validateUpsertBody = validator("json", (value, c) => {
   const parsed = upsertExternalTmsProviderCredentialBodySchema.safeParse(value);
@@ -1084,9 +1115,27 @@ export function createExternalTmsProviderCredentialRoutes() {
           return c.json({ error: "forbidden" }, 403);
         }
         const payload = c.req.valid("json");
+        const organizationId = c.var.auth.organization.localOrganizationId;
+        const limitError = await ensureIntegrationLimitForNewExternalTmsCredential({
+          organizationId,
+          providerKind: "crowdin",
+        });
+        if (limitError) {
+          return c.json(
+            {
+              error: limitError.code,
+              message:
+                limitError.code === "workspace_resource_limit_check_failed"
+                  ? "Unable to verify integration limits. Try again later."
+                  : workspaceResourceLimitMessage(limitError.featureId),
+              details: workspaceResourceLimitErrorDetails(limitError),
+            },
+            limitError.code === "workspace_resource_limit_check_failed" ? 503 : 409,
+          );
+        }
 
         const providerCredential = await upsertCrowdinOAuthProviderCredential({
-          organizationId: c.var.auth.organization.localOrganizationId,
+          organizationId,
           userId: c.var.auth.user.localUserId,
           role: c.var.auth.membership.role,
           displayName: payload.displayName,
@@ -1123,9 +1172,27 @@ export function createExternalTmsProviderCredentialRoutes() {
           return c.json({ error: "forbidden" }, 403);
         }
         const payload = c.req.valid("json");
+        const organizationId = c.var.auth.organization.localOrganizationId;
+        const limitError = await ensureIntegrationLimitForNewExternalTmsCredential({
+          organizationId,
+          providerKind: "phrase",
+        });
+        if (limitError) {
+          return c.json(
+            {
+              error: limitError.code,
+              message:
+                limitError.code === "workspace_resource_limit_check_failed"
+                  ? "Unable to verify integration limits. Try again later."
+                  : workspaceResourceLimitMessage(limitError.featureId),
+              details: workspaceResourceLimitErrorDetails(limitError),
+            },
+            limitError.code === "workspace_resource_limit_check_failed" ? 503 : 409,
+          );
+        }
 
         const providerCredential = await upsertPhraseOAuthProviderCredential({
-          organizationId: c.var.auth.organization.localOrganizationId,
+          organizationId,
           userId: c.var.auth.user.localUserId,
           role: c.var.auth.membership.role,
           displayName: payload.displayName,
@@ -1162,9 +1229,27 @@ export function createExternalTmsProviderCredentialRoutes() {
           return c.json({ error: "forbidden" }, 403);
         }
         const payload = c.req.valid("json");
+        const organizationId = c.var.auth.organization.localOrganizationId;
+        const limitError = await ensureIntegrationLimitForNewExternalTmsCredential({
+          organizationId,
+          providerKind: "lokalise",
+        });
+        if (limitError) {
+          return c.json(
+            {
+              error: limitError.code,
+              message:
+                limitError.code === "workspace_resource_limit_check_failed"
+                  ? "Unable to verify integration limits. Try again later."
+                  : workspaceResourceLimitMessage(limitError.featureId),
+              details: workspaceResourceLimitErrorDetails(limitError),
+            },
+            limitError.code === "workspace_resource_limit_check_failed" ? 503 : 409,
+          );
+        }
 
         const providerCredential = await upsertLokaliseOAuthProviderCredential({
-          organizationId: c.var.auth.organization.localOrganizationId,
+          organizationId,
           userId: c.var.auth.user.localUserId,
           role: c.var.auth.membership.role,
           displayName: payload.displayName,
@@ -1783,8 +1868,26 @@ export function createExternalTmsProviderCredentialRoutes() {
             400,
           );
         }
+        const organizationId = c.var.auth.organization.localOrganizationId;
+        const limitError = await ensureIntegrationLimitForNewExternalTmsCredential({
+          organizationId,
+          providerKind: payload.providerKind,
+        });
+        if (limitError) {
+          return c.json(
+            {
+              error: limitError.code,
+              message:
+                limitError.code === "workspace_resource_limit_check_failed"
+                  ? "Unable to verify integration limits. Try again later."
+                  : workspaceResourceLimitMessage(limitError.featureId),
+              details: workspaceResourceLimitErrorDetails(limitError),
+            },
+            limitError.code === "workspace_resource_limit_check_failed" ? 503 : 409,
+          );
+        }
         const providerCredential = await upsertOrganizationExternalTmsProviderCredential({
-          organizationId: c.var.auth.organization.localOrganizationId,
+          organizationId,
           userId: c.var.auth.user.localUserId,
           role: c.var.auth.membership.role,
           providerKind: payload.providerKind,

--- a/apps/hyperlocalise-web/src/api/routes/member/member.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/member/member.route.ts
@@ -11,7 +11,17 @@ import {
   markPendingMembershipReplacingInvitation,
   revokeOrganizationMembershipAccess,
 } from "@/api/auth/workos-sync";
-import { internalErrorResponse, serviceUnavailableResponse } from "@/api/response.schema";
+import {
+  conflictResponse,
+  internalErrorResponse,
+  serviceUnavailableResponse,
+} from "@/api/response.schema";
+import {
+  ensureWorkspaceResourceLimitAvailable,
+  workspaceResourceFeatureIds,
+  workspaceResourceLimitErrorDetails,
+  workspaceResourceLimitMessage,
+} from "@/lib/billing/workspace-resource-limits";
 import { db, schema } from "@/lib/database";
 import type { OrganizationMembershipRole } from "@/lib/database/types";
 import { createLogger, serializeErrorForLog } from "@/lib/log";
@@ -443,6 +453,44 @@ export function createMemberRoutes() {
       }
 
       const normalizedEmail = payload.email.trim().toLowerCase();
+      const [existingMembershipForEmail] = await db
+        .select({ id: schema.organizationMemberships.id })
+        .from(schema.users)
+        .innerJoin(
+          schema.organizationMemberships,
+          eq(schema.organizationMemberships.userId, schema.users.id),
+        )
+        .where(
+          and(
+            eq(schema.organizationMemberships.organizationId, organizationId),
+            eq(schema.users.email, normalizedEmail),
+          ),
+        )
+        .limit(1);
+
+      if (!existingMembershipForEmail) {
+        const limitResult = await ensureWorkspaceResourceLimitAvailable({
+          organizationId,
+          featureId: workspaceResourceFeatureIds.seats,
+        });
+        if (!limitResult.ok) {
+          if (limitResult.error.code === "workspace_resource_limit_check_failed") {
+            return serviceUnavailableResponse(
+              c,
+              limitResult.error.code,
+              "Unable to verify seat limits. Try again later.",
+            );
+          }
+
+          return conflictResponse(
+            c,
+            limitResult.error.code,
+            workspaceResourceLimitMessage(limitResult.error.featureId),
+            workspaceResourceLimitErrorDetails(limitResult.error),
+          );
+        }
+      }
+
       const pendingInvite = await inviteOrganizationMember({
         organizationId,
         email: normalizedEmail,

--- a/apps/hyperlocalise-web/src/api/routes/member/member.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/member/member.route.ts
@@ -17,12 +17,12 @@ import {
   serviceUnavailableResponse,
 } from "@/api/response.schema";
 import {
-  ensureWorkspaceResourceLimitAvailable,
+  withWorkspaceResourceLimit,
   workspaceResourceFeatureIds,
   workspaceResourceLimitErrorDetails,
   workspaceResourceLimitMessage,
 } from "@/lib/billing/workspace-resource-limits";
-import { db, schema } from "@/lib/database";
+import { db, schema, type DatabaseClient } from "@/lib/database";
 import type { OrganizationMembershipRole } from "@/lib/database/types";
 import { createLogger, serializeErrorForLog } from "@/lib/log";
 import { membershipRoleToWorkosRoleSlug } from "@/lib/workos/membership-role";
@@ -107,10 +107,12 @@ async function inviteOrganizationMember(input: {
   email: string;
   role: OrganizationMembershipRole;
   placeholderWorkosUserId: string;
+  db?: DatabaseClient;
 }) {
+  const database = input.db ?? db;
   const normalizedEmail = input.email.trim().toLowerCase();
 
-  const [existingMembership] = await db
+  const [existingMembership] = await database
     .select({
       membershipId: schema.organizationMemberships.id,
       workosMembershipId: schema.organizationMemberships.workosMembershipId,
@@ -144,7 +146,7 @@ async function inviteOrganizationMember(input: {
     const previousRole = existingMembership.role;
 
     if (roleChanged) {
-      await db
+      await database
         .update(schema.organizationMemberships)
         .set({ role: input.role })
         .where(eq(schema.organizationMemberships.id, existingMembership.membershipId));
@@ -172,7 +174,7 @@ async function inviteOrganizationMember(input: {
     };
   }
 
-  const [existingUser] = await db
+  const [existingUser] = await database
     .select({
       id: schema.users.id,
       workosUserId: schema.users.workosUserId,
@@ -189,7 +191,7 @@ async function inviteOrganizationMember(input: {
   const user =
     existingUser ??
     (
-      await db
+      await database
         .insert(schema.users)
         .values({
           workosUserId: input.placeholderWorkosUserId,
@@ -204,7 +206,7 @@ async function inviteOrganizationMember(input: {
         })
     )[0];
 
-  const [membership] = await db
+  const [membership] = await database
     .insert(schema.organizationMemberships)
     .values({
       organizationId: input.organizationId,
@@ -468,11 +470,25 @@ export function createMemberRoutes() {
         )
         .limit(1);
 
+      let pendingInvite:
+        | Awaited<ReturnType<typeof inviteOrganizationMember>>
+        | { error: "member_already_exists" };
+
       if (!existingMembershipForEmail) {
-        const limitResult = await ensureWorkspaceResourceLimitAvailable({
-          organizationId,
-          featureId: workspaceResourceFeatureIds.seats,
-        });
+        const limitResult = await withWorkspaceResourceLimit(
+          {
+            organizationId,
+            featureId: workspaceResourceFeatureIds.seats,
+          },
+          async (tx) =>
+            inviteOrganizationMember({
+              organizationId,
+              email: normalizedEmail,
+              role: payload.role,
+              placeholderWorkosUserId: `${INVITED_WORKOS_USER_ID_PREFIX}${randomUUID()}`,
+              db: tx,
+            }),
+        );
         if (!limitResult.ok) {
           if (limitResult.error.code === "workspace_resource_limit_check_failed") {
             return serviceUnavailableResponse(
@@ -489,14 +505,16 @@ export function createMemberRoutes() {
             workspaceResourceLimitErrorDetails(limitResult.error),
           );
         }
-      }
 
-      const pendingInvite = await inviteOrganizationMember({
-        organizationId,
-        email: normalizedEmail,
-        role: payload.role,
-        placeholderWorkosUserId: `${INVITED_WORKOS_USER_ID_PREFIX}${randomUUID()}`,
-      });
+        pendingInvite = limitResult.value;
+      } else {
+        pendingInvite = await inviteOrganizationMember({
+          organizationId,
+          email: normalizedEmail,
+          role: payload.role,
+          placeholderWorkosUserId: `${INVITED_WORKOS_USER_ID_PREFIX}${randomUUID()}`,
+        });
+      }
 
       if ("error" in pendingInvite) {
         return memberAlreadyExistsResponse(c);

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -506,31 +506,32 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
       }
 
       const payload = c.req.valid("json");
-      const limitResult = await withWorkspaceResourceLimit(
-        {
-          organizationId: c.var.auth.organization.localOrganizationId,
-          featureId: workspaceResourceFeatureIds.projects,
-        },
-        async (tx) => projectStore.create(c.var.auth, payload, tx),
-      );
-      if (!limitResult.ok) {
-        if (limitResult.error.code === "workspace_resource_limit_check_failed") {
-          return serviceUnavailableResponse(
+
+      try {
+        const limitResult = await withWorkspaceResourceLimit(
+          {
+            organizationId: c.var.auth.organization.localOrganizationId,
+            featureId: workspaceResourceFeatureIds.projects,
+          },
+          async (tx) => projectStore.create(c.var.auth, payload, tx),
+        );
+        if (!limitResult.ok) {
+          if (limitResult.error.code === "workspace_resource_limit_check_failed") {
+            return serviceUnavailableResponse(
+              c,
+              limitResult.error.code,
+              "Unable to verify project limits. Try again later.",
+            );
+          }
+
+          return conflictResponse(
             c,
             limitResult.error.code,
-            "Unable to verify project limits. Try again later.",
+            workspaceResourceLimitMessage(limitResult.error.featureId),
+            workspaceResourceLimitErrorDetails(limitResult.error),
           );
         }
 
-        return conflictResponse(
-          c,
-          limitResult.error.code,
-          workspaceResourceLimitMessage(limitResult.error.featureId),
-          workspaceResourceLimitErrorDetails(limitResult.error),
-        );
-      }
-
-      try {
         const project = limitResult.value;
         return c.json({ project: { ...project, openJobCount: 0 } }, 201);
       } catch (error) {

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -7,8 +7,19 @@ import { bodyLimit } from "hono/body-limit";
 import { validator } from "hono/validator";
 
 import { workosAuthMiddleware, type ApiAuthContext, type AuthVariables } from "@/api/auth/workos";
-import { badRequestResponse, notFoundResponse } from "@/api/errors";
+import {
+  badRequestResponse,
+  conflictResponse,
+  notFoundResponse,
+  serviceUnavailableResponse,
+} from "@/api/errors";
 import { translationsNotFoundResponse } from "@/api/routes/public-translations/public-translations.shared";
+import {
+  ensureWorkspaceResourceLimitAvailable,
+  workspaceResourceFeatureIds,
+  workspaceResourceLimitErrorDetails,
+  workspaceResourceLimitMessage,
+} from "@/lib/billing/workspace-resource-limits";
 import { db, schema } from "@/lib/database";
 import type { Project } from "@/lib/database/types";
 import { getFileStorageAdapter, type FileStorageAdapter } from "@/lib/file-storage";
@@ -491,6 +502,27 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
       }
 
       const payload = c.req.valid("json");
+      const limitResult = await ensureWorkspaceResourceLimitAvailable({
+        organizationId: c.var.auth.organization.localOrganizationId,
+        featureId: workspaceResourceFeatureIds.projects,
+      });
+      if (!limitResult.ok) {
+        if (limitResult.error.code === "workspace_resource_limit_check_failed") {
+          return serviceUnavailableResponse(
+            c,
+            limitResult.error.code,
+            "Unable to verify project limits. Try again later.",
+          );
+        }
+
+        return conflictResponse(
+          c,
+          limitResult.error.code,
+          workspaceResourceLimitMessage(limitResult.error.featureId),
+          workspaceResourceLimitErrorDetails(limitResult.error),
+        );
+      }
+
       try {
         const project = await projectStore.create(c.var.auth, payload);
         return c.json({ project: { ...project, openJobCount: 0 } }, 201);

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -15,12 +15,12 @@ import {
 } from "@/api/errors";
 import { translationsNotFoundResponse } from "@/api/routes/public-translations/public-translations.shared";
 import {
-  ensureWorkspaceResourceLimitAvailable,
+  withWorkspaceResourceLimit,
   workspaceResourceFeatureIds,
   workspaceResourceLimitErrorDetails,
   workspaceResourceLimitMessage,
 } from "@/lib/billing/workspace-resource-limits";
-import { db, schema } from "@/lib/database";
+import { db, schema, type DatabaseClient } from "@/lib/database";
 import type { Project } from "@/lib/database/types";
 import { getFileStorageAdapter, type FileStorageAdapter } from "@/lib/file-storage";
 import { createLogger } from "@/lib/log";
@@ -130,7 +130,11 @@ const projectLocalePatchErrorMessages: Record<
 
 type ProjectStore = {
   list(auth: ApiAuthContext): Promise<Project[]>;
-  create(auth: ApiAuthContext, payload: CreateProjectBody): Promise<Project>;
+  create(
+    auth: ApiAuthContext,
+    payload: CreateProjectBody,
+    database?: DatabaseClient,
+  ): Promise<Project>;
   getById(auth: ApiAuthContext, projectId: string): Promise<Project | null>;
   update(
     auth: ApiAuthContext,
@@ -193,13 +197,13 @@ const projectStore: ProjectStore = {
       .where(await buildAccessibleProjectsWhere(auth))
       .orderBy(desc(schema.projects.createdAt));
   },
-  async create(auth, payload) {
+  async create(auth, payload, database = db) {
     const teamId = await resolveProjectTeamId(auth, payload.teamId);
     if (!teamId) {
       throw new Error("invalid_project_team");
     }
 
-    const [project] = await db
+    const [project] = await database
       .insert(schema.projects)
       .values({
         id: `project_${randomUUID()}`,
@@ -502,10 +506,13 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
       }
 
       const payload = c.req.valid("json");
-      const limitResult = await ensureWorkspaceResourceLimitAvailable({
-        organizationId: c.var.auth.organization.localOrganizationId,
-        featureId: workspaceResourceFeatureIds.projects,
-      });
+      const limitResult = await withWorkspaceResourceLimit(
+        {
+          organizationId: c.var.auth.organization.localOrganizationId,
+          featureId: workspaceResourceFeatureIds.projects,
+        },
+        async (tx) => projectStore.create(c.var.auth, payload, tx),
+      );
       if (!limitResult.ok) {
         if (limitResult.error.code === "workspace_resource_limit_check_failed") {
           return serviceUnavailableResponse(
@@ -524,7 +531,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
       }
 
       try {
-        const project = await projectStore.create(c.var.auth, payload);
+        const project = limitResult.value;
         return c.json({ project: { ...project, openJobCount: 0 } }, 201);
       } catch (error) {
         if (error instanceof Error && error.message === "invalid_project_team") {

--- a/apps/hyperlocalise-web/src/api/routes/slack-oauth/slack-oauth.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/slack-oauth/slack-oauth.route.test.ts
@@ -202,9 +202,9 @@ describe("slackOAuthRoutes", () => {
     const insertSpy = vi.spyOn(db, "insert").mockImplementationOnce(() => {
       throw new Error("db unavailable");
     });
-    const transactionSpy = vi.spyOn(db, "transaction").mockImplementationOnce(async (callback) =>
-      callback(db as DatabaseTransaction),
-    );
+    const transactionSpy = vi
+      .spyOn(db, "transaction")
+      .mockImplementationOnce(async (callback) => callback(db as DatabaseTransaction));
 
     try {
       const app = createSlackOAuthRoutes();

--- a/apps/hyperlocalise-web/src/api/routes/slack-oauth/slack-oauth.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/slack-oauth/slack-oauth.route.test.ts
@@ -204,7 +204,7 @@ describe("slackOAuthRoutes", () => {
     });
     const transactionSpy = vi
       .spyOn(db, "transaction")
-      .mockImplementationOnce(async (callback) => callback(db as DatabaseTransaction));
+      .mockImplementationOnce(async (callback) => callback(db as unknown as DatabaseTransaction));
 
     try {
       const app = createSlackOAuthRoutes();

--- a/apps/hyperlocalise-web/src/api/routes/slack-oauth/slack-oauth.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/slack-oauth/slack-oauth.route.test.ts
@@ -10,7 +10,7 @@ import {
   createSlackState as createSignedSlackState,
   SLACK_STATE_TTL_MS,
 } from "@/lib/agents/slack/oauth-state";
-import { db, schema } from "@/lib/database";
+import { db, schema, type DatabaseTransaction } from "@/lib/database";
 import { env } from "@/lib/env";
 import { createSlackOAuthRoutes } from "./slack-oauth.route";
 
@@ -202,6 +202,9 @@ describe("slackOAuthRoutes", () => {
     const insertSpy = vi.spyOn(db, "insert").mockImplementationOnce(() => {
       throw new Error("db unavailable");
     });
+    const transactionSpy = vi.spyOn(db, "transaction").mockImplementationOnce(async (callback) =>
+      callback(db as DatabaseTransaction),
+    );
 
     try {
       const app = createSlackOAuthRoutes();
@@ -215,6 +218,7 @@ describe("slackOAuthRoutes", () => {
       expect(mocks.handleOAuthCallback).toHaveBeenCalled();
     } finally {
       insertSpy.mockRestore();
+      transactionSpy.mockRestore();
     }
   });
 

--- a/apps/hyperlocalise-web/src/api/routes/slack-oauth/slack-oauth.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/slack-oauth/slack-oauth.route.ts
@@ -6,6 +6,10 @@ import { resolveApiAuthContextFromSession } from "@/api/auth/workos-session";
 import { getSlackBot } from "@/lib/agents/slack/bot";
 import { findSlackConnectorOwnedByAnotherOrganization } from "@/lib/agents/slack/helpers";
 import { getSlackStateSecret, verifySlackState } from "@/lib/agents/slack/oauth-state";
+import {
+  ensureWorkspaceResourceLimitAvailable,
+  workspaceResourceFeatureIds,
+} from "@/lib/billing/workspace-resource-limits";
 import { db, schema } from "@/lib/database";
 import { env } from "@/lib/env";
 
@@ -104,6 +108,28 @@ export function createSlackOAuthRoutes() {
     });
     if (conflictingConnector) {
       return c.redirect("/dashboard?error=slack_team_already_connected");
+    }
+
+    const [existingConnector] = await db
+      .select({ id: schema.connectors.id, enabled: schema.connectors.enabled })
+      .from(schema.connectors)
+      .where(and(eq(schema.connectors.organizationId, org.id), eq(schema.connectors.kind, "slack")))
+      .limit(1);
+
+    if (!existingConnector?.enabled) {
+      const limitResult = await ensureWorkspaceResourceLimitAvailable({
+        organizationId: org.id,
+        featureId: workspaceResourceFeatureIds.integrations,
+      });
+      if (!limitResult.ok) {
+        return c.redirect(
+          `/dashboard?error=${
+            limitResult.error.code === "workspace_resource_limit_check_failed"
+              ? "integration_limit_check_failed"
+              : "integration_limit_reached"
+          }`,
+        );
+      }
     }
 
     try {

--- a/apps/hyperlocalise-web/src/api/routes/slack-oauth/slack-oauth.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/slack-oauth/slack-oauth.route.ts
@@ -7,10 +7,10 @@ import { getSlackBot } from "@/lib/agents/slack/bot";
 import { findSlackConnectorOwnedByAnotherOrganization } from "@/lib/agents/slack/helpers";
 import { getSlackStateSecret, verifySlackState } from "@/lib/agents/slack/oauth-state";
 import {
-  ensureWorkspaceResourceLimitAvailable,
+  withWorkspaceResourceLimit,
   workspaceResourceFeatureIds,
 } from "@/lib/billing/workspace-resource-limits";
-import { db, schema } from "@/lib/database";
+import { db, schema, type DatabaseClient } from "@/lib/database";
 import { env } from "@/lib/env";
 
 type SlackOAuthResult = Awaited<
@@ -116,24 +116,8 @@ export function createSlackOAuthRoutes() {
       .where(and(eq(schema.connectors.organizationId, org.id), eq(schema.connectors.kind, "slack")))
       .limit(1);
 
-    if (!existingConnector?.enabled) {
-      const limitResult = await ensureWorkspaceResourceLimitAvailable({
-        organizationId: org.id,
-        featureId: workspaceResourceFeatureIds.integrations,
-      });
-      if (!limitResult.ok) {
-        return c.redirect(
-          `/dashboard?error=${
-            limitResult.error.code === "workspace_resource_limit_check_failed"
-              ? "integration_limit_check_failed"
-              : "integration_limit_reached"
-          }`,
-        );
-      }
-    }
-
-    try {
-      await db
+    const upsertSlackConnector = async (database: DatabaseClient) => {
+      await database
         .insert(schema.connectors)
         .values({
           organizationId: org.id,
@@ -157,6 +141,29 @@ export function createSlackOAuthRoutes() {
             updatedAt: new Date(),
           },
         });
+    };
+
+    try {
+      if (!existingConnector?.enabled) {
+        const limitResult = await withWorkspaceResourceLimit(
+          {
+            organizationId: org.id,
+            featureId: workspaceResourceFeatureIds.integrations,
+          },
+          upsertSlackConnector,
+        );
+        if (!limitResult.ok) {
+          return c.redirect(
+            `/dashboard?error=${
+              limitResult.error.code === "workspace_resource_limit_check_failed"
+                ? "integration_limit_check_failed"
+                : "integration_limit_reached"
+            }`,
+          );
+        }
+      } else {
+        await upsertSlackConnector(db);
+      }
     } catch {
       return c.redirect("/dashboard?error=slack_install_failed");
     }

--- a/apps/hyperlocalise-web/src/api/routes/workspace-automation/workspace-automation.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/workspace-automation/workspace-automation.route.ts
@@ -4,7 +4,19 @@ import { validator } from "hono/validator";
 
 import { isWorkspaceOperatorRole } from "@/api/auth/roles";
 import { workosAuthMiddleware, type AuthVariables } from "@/api/auth/workos";
-import { badRequestResponse, forbiddenResponse, notFoundResponse } from "@/api/response.schema";
+import {
+  badRequestResponse,
+  conflictResponse,
+  forbiddenResponse,
+  notFoundResponse,
+  serviceUnavailableResponse,
+} from "@/api/response.schema";
+import {
+  ensureWorkspaceResourceLimitAvailable,
+  workspaceResourceFeatureIds,
+  workspaceResourceLimitErrorDetails,
+  workspaceResourceLimitMessage,
+} from "@/lib/billing/workspace-resource-limits";
 import { dispatchManualWorkspaceAutomationRun } from "@/lib/agents/workspace-automation-dispatcher";
 import {
   createWorkspaceAutomation,
@@ -281,6 +293,29 @@ export function createWorkspaceAutomationRoutes() {
     .post("/", validateCreateBody, async (c) => {
       const payload = c.req.valid("json");
       const organizationId = c.var.auth.organization.localOrganizationId;
+      if (payload.status !== "archived") {
+        const limitResult = await ensureWorkspaceResourceLimitAvailable({
+          organizationId,
+          featureId: workspaceResourceFeatureIds.automations,
+        });
+        if (!limitResult.ok) {
+          if (limitResult.error.code === "workspace_resource_limit_check_failed") {
+            return serviceUnavailableResponse(
+              c,
+              limitResult.error.code,
+              "Unable to verify automation limits. Try again later.",
+            );
+          }
+
+          return conflictResponse(
+            c,
+            limitResult.error.code,
+            workspaceResourceLimitMessage(limitResult.error.featureId),
+            workspaceResourceLimitErrorDetails(limitResult.error),
+          );
+        }
+      }
+
       const referenceError = await validateAutomationReferences({
         organizationId,
         repositoryTarget: payload.repositoryTarget,
@@ -342,6 +377,29 @@ export function createWorkspaceAutomationRoutes() {
 
       if (!existing) {
         return notFoundResponse(c, "workspace_automation_not_found");
+      }
+
+      if (existing.status === "archived" && payload.status && payload.status !== "archived") {
+        const limitResult = await ensureWorkspaceResourceLimitAvailable({
+          organizationId,
+          featureId: workspaceResourceFeatureIds.automations,
+        });
+        if (!limitResult.ok) {
+          if (limitResult.error.code === "workspace_resource_limit_check_failed") {
+            return serviceUnavailableResponse(
+              c,
+              limitResult.error.code,
+              "Unable to verify automation limits. Try again later.",
+            );
+          }
+
+          return conflictResponse(
+            c,
+            limitResult.error.code,
+            workspaceResourceLimitMessage(limitResult.error.featureId),
+            workspaceResourceLimitErrorDetails(limitResult.error),
+          );
+        }
       }
 
       const referenceError = await validateAutomationReferences({

--- a/apps/hyperlocalise-web/src/api/routes/workspace-automation/workspace-automation.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/workspace-automation/workspace-automation.route.ts
@@ -12,10 +12,11 @@ import {
   serviceUnavailableResponse,
 } from "@/api/response.schema";
 import {
-  ensureWorkspaceResourceLimitAvailable,
+  withWorkspaceResourceLimit,
   workspaceResourceFeatureIds,
   workspaceResourceLimitErrorDetails,
   workspaceResourceLimitMessage,
+  type WorkspaceResourceLimitError,
 } from "@/lib/billing/workspace-resource-limits";
 import { dispatchManualWorkspaceAutomationRun } from "@/lib/agents/workspace-automation-dispatcher";
 import {
@@ -270,6 +271,26 @@ function mapReferenceError(
   }
 }
 
+function mapWorkspaceResourceLimitError(
+  c: Parameters<typeof conflictResponse>[0],
+  error: WorkspaceResourceLimitError,
+) {
+  if (error.code === "workspace_resource_limit_check_failed") {
+    return serviceUnavailableResponse(
+      c,
+      error.code,
+      "Unable to verify automation limits. Try again later.",
+    );
+  }
+
+  return conflictResponse(
+    c,
+    error.code,
+    workspaceResourceLimitMessage(error.featureId),
+    workspaceResourceLimitErrorDetails(error),
+  );
+}
+
 export function createWorkspaceAutomationRoutes() {
   return new Hono<{ Variables: AuthVariables }>()
     .use("*", workosAuthMiddleware)
@@ -293,28 +314,6 @@ export function createWorkspaceAutomationRoutes() {
     .post("/", validateCreateBody, async (c) => {
       const payload = c.req.valid("json");
       const organizationId = c.var.auth.organization.localOrganizationId;
-      if (payload.status !== "archived") {
-        const limitResult = await ensureWorkspaceResourceLimitAvailable({
-          organizationId,
-          featureId: workspaceResourceFeatureIds.automations,
-        });
-        if (!limitResult.ok) {
-          if (limitResult.error.code === "workspace_resource_limit_check_failed") {
-            return serviceUnavailableResponse(
-              c,
-              limitResult.error.code,
-              "Unable to verify automation limits. Try again later.",
-            );
-          }
-
-          return conflictResponse(
-            c,
-            limitResult.error.code,
-            workspaceResourceLimitMessage(limitResult.error.featureId),
-            workspaceResourceLimitErrorDetails(limitResult.error),
-          );
-        }
-      }
 
       const referenceError = await validateAutomationReferences({
         organizationId,
@@ -326,7 +325,7 @@ export function createWorkspaceAutomationRoutes() {
       }
 
       try {
-        const result = await createWorkspaceAutomation({
+        const createInput = {
           organizationId,
           authorUserId: c.var.auth.user.localUserId,
           status: payload.status,
@@ -336,7 +335,25 @@ export function createWorkspaceAutomationRoutes() {
           repositoryTarget: payload.repositoryTarget,
           toolConfig: payload.toolConfig,
           nextRunAt: parseNextRunAt(payload.nextRunAt),
-        });
+        };
+
+        let result;
+        if (payload.status !== "archived") {
+          const limitWrapped = await withWorkspaceResourceLimit(
+            {
+              organizationId,
+              featureId: workspaceResourceFeatureIds.automations,
+            },
+            (tx) => createWorkspaceAutomation({ ...createInput, db: tx }),
+          );
+          if (!limitWrapped.ok) {
+            return mapWorkspaceResourceLimitError(c, limitWrapped.error);
+          }
+          result = limitWrapped.value;
+        } else {
+          result = await createWorkspaceAutomation(createInput);
+        }
+
         if (isErr(result)) {
           return mapAutomationConfigValidationError(c, result.error);
         }
@@ -379,29 +396,6 @@ export function createWorkspaceAutomationRoutes() {
         return notFoundResponse(c, "workspace_automation_not_found");
       }
 
-      if (existing.status === "archived" && payload.status && payload.status !== "archived") {
-        const limitResult = await ensureWorkspaceResourceLimitAvailable({
-          organizationId,
-          featureId: workspaceResourceFeatureIds.automations,
-        });
-        if (!limitResult.ok) {
-          if (limitResult.error.code === "workspace_resource_limit_check_failed") {
-            return serviceUnavailableResponse(
-              c,
-              limitResult.error.code,
-              "Unable to verify automation limits. Try again later.",
-            );
-          }
-
-          return conflictResponse(
-            c,
-            limitResult.error.code,
-            workspaceResourceLimitMessage(limitResult.error.featureId),
-            workspaceResourceLimitErrorDetails(limitResult.error),
-          );
-        }
-      }
-
       const referenceError = await validateAutomationReferences({
         organizationId,
         repositoryTarget: payload.repositoryTarget ?? existing.repositoryTarget,
@@ -412,7 +406,7 @@ export function createWorkspaceAutomationRoutes() {
       }
 
       try {
-        const result = await updateWorkspaceAutomation({
+        const updateInput = {
           automationId: params.automationId,
           organizationId,
           status: payload.status,
@@ -422,7 +416,26 @@ export function createWorkspaceAutomationRoutes() {
           repositoryTarget: payload.repositoryTarget,
           toolConfig: payload.toolConfig,
           nextRunAt: parseNextRunAt(payload.nextRunAt),
-        });
+        };
+        const shouldEnforceAutomationLimit =
+          existing.status === "archived" && payload.status && payload.status !== "archived";
+
+        let result;
+        if (shouldEnforceAutomationLimit) {
+          const limitWrapped = await withWorkspaceResourceLimit(
+            {
+              organizationId,
+              featureId: workspaceResourceFeatureIds.automations,
+            },
+            (tx) => updateWorkspaceAutomation({ ...updateInput, db: tx }),
+          );
+          if (!limitWrapped.ok) {
+            return mapWorkspaceResourceLimitError(c, limitWrapped.error);
+          }
+          result = limitWrapped.value;
+        } else {
+          result = await updateWorkspaceAutomation(updateInput);
+        }
         if (isErr(result)) {
           return mapAutomationConfigValidationError(c, result.error);
         }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integrations-page-content.tsx
@@ -307,7 +307,9 @@ function useSaveProviderCredential(organizationSlug: string) {
       if (!res.ok) {
         const error = await res.json().catch(() => ({ error: "provider_validation_failed" }));
         throw new Error(
-          "message" in error ? String(error.message) : "Unable to validate provider credential",
+          "message" in error && typeof error.message === "string"
+            ? error.message
+            : "Unable to validate provider credential",
         );
       }
 
@@ -389,7 +391,9 @@ function useSaveExternalTmsCredential(organizationSlug: string) {
           .json()
           .catch(() => ({ error: "external_tms_provider_save_failed" }));
         throw new Error(
-          "message" in error ? String(error.message) : "Unable to save external TMS provider",
+          "message" in error && typeof error.message === "string"
+            ? error.message
+            : "Unable to save external TMS provider",
         );
       }
 
@@ -432,7 +436,9 @@ function useSaveCrowdinOAuthApp(organizationSlug: string) {
       if (!res.ok) {
         const error = await res.json().catch(() => ({ error: "crowdin_oauth_start_failed" }));
         throw new Error(
-          "message" in error ? String(error.message) : "Unable to start Crowdin OAuth",
+          "message" in error && typeof error.message === "string"
+            ? error.message
+            : "Unable to start Crowdin OAuth",
         );
       }
 
@@ -480,7 +486,9 @@ function useSavePhraseOAuthApp(organizationSlug: string) {
       if (!res.ok) {
         const error = await res.json().catch(() => ({ error: "phrase_oauth_start_failed" }));
         throw new Error(
-          "message" in error ? String(error.message) : "Unable to start Phrase OAuth",
+          "message" in error && typeof error.message === "string"
+            ? error.message
+            : "Unable to start Phrase OAuth",
         );
       }
 
@@ -528,7 +536,9 @@ function useSaveLokaliseOAuthApp(organizationSlug: string) {
       if (!res.ok) {
         const error = await res.json().catch(() => ({ error: "lokalise_oauth_start_failed" }));
         throw new Error(
-          "message" in error ? String(error.message) : "Unable to start Lokalise OAuth",
+          "message" in error && typeof error.message === "string"
+            ? error.message
+            : "Unable to start Lokalise OAuth",
         );
       }
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/billing/_components/billing-settings-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/billing/_components/billing-settings-content.tsx
@@ -12,7 +12,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Separator } from "@/components/ui/separator";
 import { TypographyH1, TypographyP } from "@/components/ui/typography";
 import { formatAutumnBillingError } from "@/lib/billing/autumn-errors";
-import { getUsageFeatureLabel, meteredUsageFeatureIds } from "@/lib/billing/usage-feature-labels";
+import { billingBalanceFeatureIds, getUsageFeatureLabel } from "@/lib/billing/usage-feature-labels";
 
 function SurfaceCard({
   children,
@@ -54,8 +54,7 @@ function BillingSettingsHeader() {
           Billing
         </TypographyH1>
         <TypographyP className="mt-2 text-pretty text-sm leading-6 text-muted-foreground">
-          View your workspace plan, metered usage balances, and manage subscription billing through
-          Autumn.
+          View your workspace plan, AI token balance, workspace limits, and subscription billing.
         </TypographyP>
       </div>
     </section>
@@ -99,7 +98,7 @@ function BillingSettingsPanel({
   const isScheduledForCancel = Boolean(
     activeSubscription?.canceledAt && activeSubscription.status === "active",
   );
-  const usageRows = meteredUsageFeatureIds.map((featureId) => {
+  const usageRows = billingBalanceFeatureIds.map((featureId) => {
     const balance = customer?.balances?.[featureId];
     return {
       featureId,
@@ -303,10 +302,10 @@ function BillingSettingsPanel({
 
       <SurfaceCard>
         <CardHeader className="px-5 py-5">
-          <CardTitle className="text-lg font-medium text-foreground">Usage balances</CardTitle>
+          <CardTitle className="text-lg font-medium text-foreground">Plan usage</CardTitle>
           <CardDescription className="text-foreground/52">
-            Metered usage for this billing cycle. Enforcement happens server-side; this panel is for
-            visibility only.
+            AI token usage resets each billing cycle. Seats, projects, automations, and integrations
+            are workspace limits.
           </CardDescription>
         </CardHeader>
         <Separator className="bg-foreground/8" />

--- a/apps/hyperlocalise-web/src/lib/agents/github/install-callback.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/install-callback.ts
@@ -7,6 +7,10 @@ import { getGitHubApp } from "@/lib/agents/github/app";
 import { isGitHubAppPrivateKeyDecoderError } from "@/lib/agents/github/private-key";
 import { getGitHubStateSecret, verifyGitHubState } from "@/lib/agents/github/oauth-state";
 import {
+  ensureWorkspaceResourceLimitAvailable,
+  workspaceResourceFeatureIds,
+} from "@/lib/billing/workspace-resource-limits";
+import {
   deleteOrganizationGitHubInstallationRepositories,
   syncInstallationRepositories,
 } from "@/lib/agents/github/repositories";
@@ -335,6 +339,20 @@ export async function handleGitHubInstallCallback(
         "github install callback updated existing installation row",
       );
     } else {
+      const limitResult = await ensureWorkspaceResourceLimitAvailable({
+        organizationId: org.id,
+        featureId: workspaceResourceFeatureIds.integrations,
+      });
+      if (!limitResult.ok) {
+        const redirectTo = agentErrorRedirect(
+          org,
+          limitResult.error.code === "workspace_resource_limit_check_failed"
+            ? "integration_limit_check_failed"
+            : "integration_limit_reached",
+        ).redirectTo;
+        return finish(redirectTo, orgContext, "github install callback integration limit blocked");
+      }
+
       const [inserted] = await db
         .insert(schema.githubInstallations)
         .values({

--- a/apps/hyperlocalise-web/src/lib/agents/github/install-callback.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/github/install-callback.ts
@@ -7,7 +7,7 @@ import { getGitHubApp } from "@/lib/agents/github/app";
 import { isGitHubAppPrivateKeyDecoderError } from "@/lib/agents/github/private-key";
 import { getGitHubStateSecret, verifyGitHubState } from "@/lib/agents/github/oauth-state";
 import {
-  ensureWorkspaceResourceLimitAvailable,
+  withWorkspaceResourceLimit,
   workspaceResourceFeatureIds,
 } from "@/lib/billing/workspace-resource-limits";
 import {
@@ -339,33 +339,39 @@ export async function handleGitHubInstallCallback(
         "github install callback updated existing installation row",
       );
     } else {
-      const limitResult = await ensureWorkspaceResourceLimitAvailable({
-        organizationId: org.id,
-        featureId: workspaceResourceFeatureIds.integrations,
-      });
-      if (!limitResult.ok) {
+      const insertResult = await withWorkspaceResourceLimit(
+        {
+          organizationId: org.id,
+          featureId: workspaceResourceFeatureIds.integrations,
+        },
+        async (tx) => {
+          const [inserted] = await tx
+            .insert(schema.githubInstallations)
+            .values({
+              organizationId: org.id,
+              githubInstallationId,
+              githubAppId,
+              accountLogin,
+              accountType,
+            })
+            .returning({ id: schema.githubInstallations.id });
+
+          return inserted;
+        },
+      );
+
+      if (!insertResult.ok) {
         const redirectTo = agentErrorRedirect(
           org,
-          limitResult.error.code === "workspace_resource_limit_check_failed"
+          insertResult.error.code === "workspace_resource_limit_check_failed"
             ? "integration_limit_check_failed"
             : "integration_limit_reached",
         ).redirectTo;
         return finish(redirectTo, orgContext, "github install callback integration limit blocked");
       }
 
-      const [inserted] = await db
-        .insert(schema.githubInstallations)
-        .values({
-          organizationId: org.id,
-          githubInstallationId,
-          githubAppId,
-          accountLogin,
-          accountType,
-        })
-        .returning({ id: schema.githubInstallations.id });
-
       logger.info(
-        { ...orgContext, githubInstallationRowId: inserted?.id, action: "insert" },
+        { ...orgContext, githubInstallationRowId: insertResult.value?.id, action: "insert" },
         "github install callback inserted installation row",
       );
     }

--- a/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/workspace-automations.ts
@@ -1,7 +1,7 @@
 import { and, desc, eq, isNotNull, lte, sql } from "drizzle-orm";
 import { z } from "zod";
 
-import { db, schema } from "@/lib/database";
+import { db, schema, type DatabaseClient } from "@/lib/database";
 import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
 import { optionalProjectIdSchema } from "@/lib/projects/identity/project-id";
 
@@ -509,6 +509,7 @@ export async function createWorkspaceAutomation(input: {
   repositoryTarget?: WorkspaceAutomationRepositoryTarget;
   toolConfig?: WorkspaceAutomationToolConfig;
   nextRunAt?: Date | null;
+  db?: DatabaseClient;
 }): Promise<Result<WorkspaceAutomationRecord, WorkspaceAutomationConfigValidationError>> {
   const config = workspaceAutomationConfigSchema.parse({
     triggerConfig: input.triggerConfig ?? {},
@@ -552,7 +553,9 @@ export async function createWorkspaceAutomation(input: {
       ? input.nextRunAt
       : resolveNextRunAtForWorkspaceAutomation(draftAutomation);
 
-  const [row] = await db
+  const database = input.db ?? db;
+
+  const [row] = await database
     .insert(schema.workspaceAutomations)
     .values({
       organizationId: input.organizationId,
@@ -588,6 +591,7 @@ export async function updateWorkspaceAutomation(input: {
   repositoryTarget?: WorkspaceAutomationRepositoryTarget;
   toolConfig?: WorkspaceAutomationToolConfig;
   nextRunAt?: Date | null;
+  db?: DatabaseClient;
 }): Promise<Result<WorkspaceAutomationRecord | null, WorkspaceAutomationConfigValidationError>> {
   const existing = await getWorkspaceAutomationById({
     automationId: input.automationId,
@@ -664,7 +668,9 @@ export async function updateWorkspaceAutomation(input: {
     updateConditions.push(eq(schema.workspaceAutomations.configVersion, existing.configVersion));
   }
 
-  const [row] = await db
+  const database = input.db ?? db;
+
+  const [row] = await database
     .update(schema.workspaceAutomations)
     .set({
       ...(input.status !== undefined ? { status: input.status } : {}),

--- a/apps/hyperlocalise-web/src/lib/billing/autumn-ids.test.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/autumn-ids.test.ts
@@ -1,30 +1,44 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { autumnPlanIds, meteredUsageFeatureIds, usageFeatureIds } from "@/lib/billing/autumn-ids";
+import {
+  autumnFeatureIds,
+  autumnPlanIds,
+  billingBalanceFeatureIds,
+  usageFeatureIds,
+} from "@/lib/billing/autumn-ids";
 
 describe("autumn identifiers", () => {
   it("exposes stable plan and usage feature IDs", () => {
     expect(autumnPlanIds).toEqual({
       free: "free",
-      team: "team",
+      growth: "growth",
+      enterprise: "enterprise",
+    });
+
+    expect(autumnFeatureIds).toEqual({
+      aiTokens: "ai_tokens",
+      translationJobs: "translation_jobs",
+      agentRuns: "agent_runs",
+      seats: "seats",
+      projects: "projects",
+      automations: "automations",
+      integrations: "integrations",
+      aiFeatures: "ai_features",
     });
 
     expect(usageFeatureIds).toEqual({
       translationJobs: "translation_jobs",
-      translationUnits: "translation_units",
-      sourceCharacters: "source_characters",
-      aiTokens: "ai_tokens",
-      apiRequests: "api_requests",
       agentRuns: "agent_runs",
     });
 
-    expect(meteredUsageFeatureIds).toEqual([
+    expect(billingBalanceFeatureIds).toEqual([
+      autumnFeatureIds.aiTokens,
       usageFeatureIds.translationJobs,
-      usageFeatureIds.translationUnits,
-      usageFeatureIds.sourceCharacters,
-      usageFeatureIds.aiTokens,
-      usageFeatureIds.apiRequests,
       usageFeatureIds.agentRuns,
+      autumnFeatureIds.seats,
+      autumnFeatureIds.projects,
+      autumnFeatureIds.automations,
+      autumnFeatureIds.integrations,
     ]);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/billing/autumn-ids.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/autumn-ids.ts
@@ -8,32 +8,48 @@ export const autumnPlanIds = {
   /** Free / dev sandbox plan for onboarding and local testing. */
   free: "free",
   /** Paid workspace subscription plan. */
-  team: "team",
+  growth: "growth",
+  /** Custom enterprise subscription plan. */
+  enterprise: "enterprise",
 } as const;
 
 export type AutumnPlanId = (typeof autumnPlanIds)[keyof typeof autumnPlanIds];
 
 /**
- * Metered usage feature IDs aligned with HL-418 usage control.
- * These must match Autumn feature definitions and `usage_events.feature_id`.
+ * Autumn feature IDs configured in the Autumn dashboard.
+ * These include credit-system balances, non-consumable limits, and boolean gates.
+ */
+export const autumnFeatureIds = {
+  aiTokens: "ai_tokens",
+  translationJobs: "translation_jobs",
+  agentRuns: "agent_runs",
+  seats: "seats",
+  projects: "projects",
+  automations: "automations",
+  integrations: "integrations",
+  aiFeatures: "ai_features",
+} as const;
+
+export type AutumnFeatureId = (typeof autumnFeatureIds)[keyof typeof autumnFeatureIds];
+
+/**
+ * Locally tracked usage event feature IDs.
+ * These must match `usage_events.feature_id` until the enum is migrated.
  */
 export const usageFeatureIds = {
-  translationJobs: "translation_jobs",
-  translationUnits: "translation_units",
-  sourceCharacters: "source_characters",
-  aiTokens: "ai_tokens",
-  apiRequests: "api_requests",
-  agentRuns: "agent_runs",
+  translationJobs: autumnFeatureIds.translationJobs,
+  agentRuns: autumnFeatureIds.agentRuns,
 } as const;
 
 export type UsageFeatureId = (typeof usageFeatureIds)[keyof typeof usageFeatureIds];
 
-/** Metered features shown on the billing settings usage panel. */
-export const meteredUsageFeatureIds = [
+/** Customer-facing balances shown on the billing settings usage panel. */
+export const billingBalanceFeatureIds = [
+  autumnFeatureIds.aiTokens,
   usageFeatureIds.translationJobs,
-  usageFeatureIds.translationUnits,
-  usageFeatureIds.sourceCharacters,
-  usageFeatureIds.aiTokens,
-  usageFeatureIds.apiRequests,
   usageFeatureIds.agentRuns,
-] as const satisfies readonly UsageFeatureId[];
+  autumnFeatureIds.seats,
+  autumnFeatureIds.projects,
+  autumnFeatureIds.automations,
+  autumnFeatureIds.integrations,
+] as const satisfies readonly AutumnFeatureId[];

--- a/apps/hyperlocalise-web/src/lib/billing/usage-control.test.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/usage-control.test.ts
@@ -155,6 +155,44 @@ describe("usage-control", () => {
     });
   });
 
+  it("tracks usage events by Autumn event name when configured", async () => {
+    const { operationKey, organization } = await reservedUsageEvent();
+    const markResult = await markUsageEventSucceededByOperationKey({
+      operationKey,
+      quantity: 123,
+      dimensions: { autumn_event_name: "translation_job.completed" },
+    });
+    expect(isErr(markResult)).toBe(false);
+
+    const fetchFn = vi.fn(
+      async () => new Response("{}", { status: 200 }),
+    ) as unknown as typeof fetch;
+
+    const trackResult = await trackUsageEventInAutumnByOperationKey({
+      operationKey,
+      autumnApiKey: "am_sk_test",
+      fetchFn,
+    });
+    expect(trackResult).toMatchObject({
+      ok: true,
+      value: { status: "tracking_succeeded" },
+    });
+
+    const [, requestInit] = vi.mocked(fetchFn).mock.calls[0] ?? [];
+    const requestBody = requestInit?.body;
+    if (typeof requestBody !== "string") {
+      throw new Error("Expected JSON string request body");
+    }
+    const parsedBody = JSON.parse(requestBody);
+    expect(parsedBody).toMatchObject({
+      customer_id: organization.id,
+      event_name: "translation_job.completed",
+      value: 123,
+      idempotency_key: operationKey,
+    });
+    expect(parsedBody).not.toHaveProperty("feature_id");
+  });
+
   it("marks tracking failed when Autumn rejects the usage event", async () => {
     const { operationKey } = await reservedUsageEvent();
     const markResult = await markUsageEventSucceededByOperationKey({ operationKey });

--- a/apps/hyperlocalise-web/src/lib/billing/usage-control.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/usage-control.ts
@@ -157,6 +157,7 @@ async function trackUsageEventInAutumn(input: {
   fetchFn: typeof fetch;
 }): Promise<Result<void, Extract<TrackUsageEventError, { code: "autumn_usage_tracking_failed" }>>> {
   let response: Response;
+  const eventName = autumnEventName(input.event);
 
   try {
     response = await input.fetchFn(AUTUMN_TRACK_USAGE_URL, {
@@ -168,9 +169,7 @@ async function trackUsageEventInAutumn(input: {
       },
       body: JSON.stringify({
         customer_id: input.event.organizationId,
-        ...(autumnEventName(input.event)
-          ? { event_name: autumnEventName(input.event) }
-          : { feature_id: input.event.featureId }),
+        ...(eventName ? { event_name: eventName } : { feature_id: input.event.featureId }),
         value: input.event.quantity,
         idempotency_key: input.event.operationKey,
         properties: {

--- a/apps/hyperlocalise-web/src/lib/billing/usage-control.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/usage-control.ts
@@ -15,6 +15,8 @@ export type UsageEventReference = {
   id: string;
 };
 
+type UsageEventDimensions = Record<string, string | number | boolean | null>;
+
 export type UsageEventNotFoundError = {
   code: "usage_event_not_found";
   operationKey: string;
@@ -70,6 +72,7 @@ export async function reserveUsageEvent(input: {
   operationKey: string;
   source: string;
   quantity?: number;
+  dimensions?: UsageEventDimensions;
   jobId?: string;
   interactionId?: string;
 }): Promise<Result<UsageEventReference, ReserveUsageEventError>> {
@@ -82,6 +85,7 @@ export async function reserveUsageEvent(input: {
       operationKey: input.operationKey,
       source: input.source,
       quantity: input.quantity ?? 1,
+      dimensions: input.dimensions,
       jobId: input.jobId,
       interactionId: input.interactionId,
     })
@@ -103,11 +107,26 @@ export async function reserveUsageEvent(input: {
 export async function markUsageEventSucceededByOperationKey(input: {
   db?: DatabaseClient;
   operationKey: string;
+  quantity?: number;
+  dimensions?: UsageEventDimensions;
 }): Promise<Result<void, MarkUsageEventSucceededError>> {
   const database = input.db ?? db;
+  const updateValues: Partial<typeof schema.usageEvents.$inferInsert> = {
+    status: "succeeded",
+    autumnTrackError: null,
+  };
+
+  if (typeof input.quantity === "number") {
+    updateValues.quantity = input.quantity;
+  }
+
+  if (input.dimensions) {
+    updateValues.dimensions = input.dimensions;
+  }
+
   const [event] = await database
     .update(schema.usageEvents)
-    .set({ status: "succeeded", autumnTrackError: null })
+    .set(updateValues)
     .where(eq(schema.usageEvents.operationKey, input.operationKey))
     .returning({ id: schema.usageEvents.id });
 
@@ -127,6 +146,11 @@ function autumnTrackErrorMessage(error: unknown) {
   return "autumn_tracking_failed";
 }
 
+function autumnEventName(event: typeof schema.usageEvents.$inferSelect) {
+  const eventName = event.dimensions?.autumn_event_name;
+  return typeof eventName === "string" && eventName.trim() ? eventName : null;
+}
+
 async function trackUsageEventInAutumn(input: {
   event: typeof schema.usageEvents.$inferSelect;
   apiKey: string;
@@ -144,7 +168,9 @@ async function trackUsageEventInAutumn(input: {
       },
       body: JSON.stringify({
         customer_id: input.event.organizationId,
-        feature_id: input.event.featureId,
+        ...(autumnEventName(input.event)
+          ? { event_name: autumnEventName(input.event) }
+          : { feature_id: input.event.featureId }),
         value: input.event.quantity,
         idempotency_key: input.event.operationKey,
         properties: {

--- a/apps/hyperlocalise-web/src/lib/billing/usage-feature-labels.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/usage-feature-labels.ts
@@ -1,21 +1,22 @@
-import { meteredUsageFeatureIds, type UsageFeatureId } from "@/lib/billing/autumn-ids";
+import { billingBalanceFeatureIds, type AutumnFeatureId } from "@/lib/billing/autumn-ids";
 
-/** Display labels for metered usage features shown on billing settings. */
-export const usageFeatureLabels: Record<UsageFeatureId, string> = {
-  translation_jobs: "Translation jobs",
-  translation_units: "Translation units",
-  source_characters: "Source characters",
+/** Display labels for Autumn feature balances shown on billing settings. */
+export const usageFeatureLabels: Partial<Record<AutumnFeatureId, string>> = {
   ai_tokens: "AI tokens",
-  api_requests: "API requests",
+  translation_jobs: "Translation jobs",
   agent_runs: "Agent runs",
+  seats: "Seats",
+  projects: "Projects",
+  automations: "Automations",
+  integrations: "Integrations",
 };
 
 export function getUsageFeatureLabel(featureId: string) {
   if (featureId in usageFeatureLabels) {
-    return usageFeatureLabels[featureId as UsageFeatureId];
+    return usageFeatureLabels[featureId as AutumnFeatureId];
   }
 
   return featureId.replaceAll("_", " ");
 }
 
-export { meteredUsageFeatureIds };
+export { billingBalanceFeatureIds };

--- a/apps/hyperlocalise-web/src/lib/billing/workspace-resource-limits.test.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/workspace-resource-limits.test.ts
@@ -9,6 +9,7 @@ import { db, schema } from "@/lib/database";
 import { isErr } from "@/lib/primitives/result/results";
 import {
   ensureWorkspaceResourceLimitAvailable,
+  withWorkspaceResourceLimit,
   workspaceResourceFeatureIds,
 } from "./workspace-resource-limits";
 
@@ -84,6 +85,55 @@ describe("workspace resource limits", () => {
         featureId: workspaceResourceFeatureIds.automations,
         currentUsage: 0,
         requestedUsage: 1,
+      },
+    });
+  });
+
+  it("allows only one concurrent project when the local fallback limit is one", async () => {
+    const { organization, user } = await createOrganization();
+
+    const results = await Promise.all(
+      Array.from({ length: 2 }, () =>
+        withWorkspaceResourceLimit(
+          {
+            organizationId: organization.id,
+            featureId: workspaceResourceFeatureIds.projects,
+            autumnApiKey: "",
+          },
+          async (tx) => {
+            const [project] = await tx
+              .insert(schema.projects)
+              .values({
+                id: `project_${randomUUID()}`,
+                organizationId: organization.id,
+                createdByUserId: user.id,
+                name: "Concurrent project",
+                description: "",
+                translationContext: "",
+                source: "native",
+                sourceLocale: "en",
+                targetLocales: ["fr"],
+              })
+              .returning();
+
+            return project;
+          },
+        ),
+      ),
+    );
+
+    const successes = results.filter((result) => result.ok);
+    const failures = results.filter((result) => !result.ok);
+
+    expect(successes).toHaveLength(1);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toMatchObject({
+      ok: false,
+      error: {
+        code: "workspace_resource_limit_reached",
+        featureId: workspaceResourceFeatureIds.projects,
+        currentUsage: 1,
+        requestedUsage: 2,
       },
     });
   });

--- a/apps/hyperlocalise-web/src/lib/billing/workspace-resource-limits.test.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/workspace-resource-limits.test.ts
@@ -1,0 +1,90 @@
+import "dotenv/config";
+
+import { randomUUID } from "node:crypto";
+
+import { beforeAll, describe, expect, it, afterEach } from "vite-plus/test";
+
+import { createAuthTestFixture } from "@/api/test-auth.fixture";
+import { db, schema } from "@/lib/database";
+import { isErr } from "@/lib/primitives/result/results";
+import {
+  ensureWorkspaceResourceLimitAvailable,
+  workspaceResourceFeatureIds,
+} from "./workspace-resource-limits";
+
+const authFixture = createAuthTestFixture();
+
+beforeAll(async () => {
+  await db.$client.query("select 1");
+});
+
+afterEach(async () => {
+  await authFixture.cleanup();
+});
+
+async function createOrganization() {
+  const { organization, user } = await authFixture.createLocalWorkosIdentity();
+  return { organization, user };
+}
+
+describe("workspace resource limits", () => {
+  it("allows the first Free project and blocks the next one with the local fallback", async () => {
+    const { organization, user } = await createOrganization();
+
+    const firstProjectCheck = await ensureWorkspaceResourceLimitAvailable({
+      organizationId: organization.id,
+      featureId: workspaceResourceFeatureIds.projects,
+      autumnApiKey: "",
+    });
+
+    expect(firstProjectCheck.ok).toBe(true);
+
+    await db.insert(schema.projects).values({
+      id: `project_${randomUUID()}`,
+      organizationId: organization.id,
+      createdByUserId: user.id,
+      name: "Existing project",
+      description: "",
+      translationContext: "",
+      source: "native",
+      sourceLocale: "en",
+      targetLocales: ["fr"],
+    });
+
+    const secondProjectCheck = await ensureWorkspaceResourceLimitAvailable({
+      organizationId: organization.id,
+      featureId: workspaceResourceFeatureIds.projects,
+      autumnApiKey: "",
+    });
+
+    expect(secondProjectCheck).toMatchObject({
+      ok: false,
+      error: {
+        code: "workspace_resource_limit_reached",
+        featureId: workspaceResourceFeatureIds.projects,
+        currentUsage: 1,
+        requestedUsage: 2,
+      },
+    });
+  });
+
+  it("blocks Free automations because the fallback limit is zero", async () => {
+    const { organization } = await createOrganization();
+
+    const result = await ensureWorkspaceResourceLimitAvailable({
+      organizationId: organization.id,
+      featureId: workspaceResourceFeatureIds.automations,
+      autumnApiKey: "",
+    });
+
+    expect(isErr(result)).toBe(true);
+    expect(result).toMatchObject({
+      error: {
+        code: "workspace_resource_limit_reached",
+        featureId: workspaceResourceFeatureIds.automations,
+        currentUsage: 0,
+        requestedUsage: 1,
+      },
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/billing/workspace-resource-limits.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/workspace-resource-limits.ts
@@ -1,9 +1,9 @@
 import { Autumn } from "autumn-js";
-import { and, count, eq, ne } from "drizzle-orm";
+import { and, count, eq, ne, sql } from "drizzle-orm";
 
 import { autumnFeatureIds } from "@/lib/billing/autumn-ids";
 import { getAutumnSecretKey } from "@/lib/billing/autumn-config";
-import type { DatabaseClient } from "@/lib/database";
+import type { DatabaseClient, DatabaseTransaction } from "@/lib/database";
 import { db, schema } from "@/lib/database";
 import { err, ok, type Result } from "@/lib/primitives/result/results";
 
@@ -153,20 +153,33 @@ async function checkAutumnWorkspaceResourceLimit(input: {
   return response.allowed;
 }
 
-export async function ensureWorkspaceResourceLimitAvailable(input: {
-  db?: DatabaseClient;
+async function lockWorkspaceResourceLimit(
+  tx: DatabaseTransaction,
+  organizationId: string,
+  featureId: WorkspaceResourceFeatureId,
+) {
+  await tx.execute(
+    sql`select pg_advisory_xact_lock(hashtextextended(${[
+      "workspace_resource_limit",
+      organizationId,
+      featureId,
+    ].join(":")}, 0))`,
+  );
+}
+
+async function evaluateWorkspaceResourceLimit(input: {
+  db: DatabaseClient;
   organizationId: string;
   featureId: WorkspaceResourceFeatureId;
   additionalUsage?: number;
   autumnApiKey?: string;
 }): Promise<Result<void, WorkspaceResourceLimitError>> {
-  const database = input.db ?? db;
   const additionalUsage = input.additionalUsage ?? 1;
   if (additionalUsage <= 0) return ok(undefined);
   if (process.env.NODE_ENV === "test" && input.autumnApiKey === undefined) return ok(undefined);
 
   const currentUsage = await countWorkspaceResourceUsage({
-    db: database,
+    db: input.db,
     organizationId: input.organizationId,
     featureId: input.featureId,
   });
@@ -212,6 +225,51 @@ export async function ensureWorkspaceResourceLimitAvailable(input: {
       message: formatLimitCheckError(error),
     });
   }
+}
+
+export async function ensureWorkspaceResourceLimitAvailable(input: {
+  db?: DatabaseClient;
+  organizationId: string;
+  featureId: WorkspaceResourceFeatureId;
+  additionalUsage?: number;
+  autumnApiKey?: string;
+}): Promise<Result<void, WorkspaceResourceLimitError>> {
+  return evaluateWorkspaceResourceLimit({
+    db: input.db ?? db,
+    organizationId: input.organizationId,
+    featureId: input.featureId,
+    additionalUsage: input.additionalUsage,
+    autumnApiKey: input.autumnApiKey,
+  });
+}
+
+export async function withWorkspaceResourceLimit<T>(
+  input: {
+    organizationId: string;
+    featureId: WorkspaceResourceFeatureId;
+    additionalUsage?: number;
+    autumnApiKey?: string;
+    db?: DatabaseTransaction;
+  },
+  fn: (tx: DatabaseTransaction) => Promise<T>,
+): Promise<Result<T, WorkspaceResourceLimitError>> {
+  const run = async (tx: DatabaseTransaction): Promise<Result<T, WorkspaceResourceLimitError>> => {
+    await lockWorkspaceResourceLimit(tx, input.organizationId, input.featureId);
+
+    const limitResult = await evaluateWorkspaceResourceLimit({
+      db: tx,
+      organizationId: input.organizationId,
+      featureId: input.featureId,
+      additionalUsage: input.additionalUsage,
+      autumnApiKey: input.autumnApiKey,
+    });
+    if (!limitResult.ok) return limitResult;
+
+    return ok(await fn(tx));
+  };
+
+  if (input.db) return run(input.db);
+  return db.transaction(run);
 }
 
 export function workspaceResourceLimitMessage(featureId: WorkspaceResourceFeatureId) {

--- a/apps/hyperlocalise-web/src/lib/billing/workspace-resource-limits.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/workspace-resource-limits.ts
@@ -1,0 +1,240 @@
+import { Autumn } from "autumn-js";
+import { and, count, eq, ne } from "drizzle-orm";
+
+import { autumnFeatureIds } from "@/lib/billing/autumn-ids";
+import { getAutumnSecretKey } from "@/lib/billing/autumn-config";
+import type { DatabaseClient } from "@/lib/database";
+import { db, schema } from "@/lib/database";
+import { err, ok, type Result } from "@/lib/primitives/result/results";
+
+export const workspaceResourceFeatureIds = {
+  seats: autumnFeatureIds.seats,
+  projects: autumnFeatureIds.projects,
+  automations: autumnFeatureIds.automations,
+  integrations: autumnFeatureIds.integrations,
+} as const;
+
+export type WorkspaceResourceFeatureId =
+  (typeof workspaceResourceFeatureIds)[keyof typeof workspaceResourceFeatureIds];
+
+export type WorkspaceResourceLimitError =
+  | {
+      code: "workspace_resource_limit_reached";
+      featureId: WorkspaceResourceFeatureId;
+      currentUsage: number;
+      requestedUsage: number;
+    }
+  | {
+      code: "workspace_resource_limit_check_failed";
+      featureId: WorkspaceResourceFeatureId;
+      message: string;
+    };
+
+const AUTUMN_API_VERSION = "2.2.0";
+
+const localFallbackLimits: Record<WorkspaceResourceFeatureId, number> = {
+  [workspaceResourceFeatureIds.seats]: 1,
+  [workspaceResourceFeatureIds.projects]: 1,
+  [workspaceResourceFeatureIds.automations]: 0,
+  [workspaceResourceFeatureIds.integrations]: 2,
+};
+
+function countValue(row: { value: number } | undefined) {
+  return row?.value ?? 0;
+}
+
+async function countWorkspaceResourceUsage(input: {
+  db: DatabaseClient;
+  organizationId: string;
+  featureId: WorkspaceResourceFeatureId;
+}) {
+  switch (input.featureId) {
+    case workspaceResourceFeatureIds.seats: {
+      const [row] = await input.db
+        .select({ value: count() })
+        .from(schema.organizationMemberships)
+        .where(eq(schema.organizationMemberships.organizationId, input.organizationId));
+      return countValue(row);
+    }
+    case workspaceResourceFeatureIds.projects: {
+      const [row] = await input.db
+        .select({ value: count() })
+        .from(schema.projects)
+        .where(
+          and(
+            eq(schema.projects.organizationId, input.organizationId),
+            eq(schema.projects.isActive, true),
+          ),
+        );
+      return countValue(row);
+    }
+    case workspaceResourceFeatureIds.automations: {
+      const [row] = await input.db
+        .select({ value: count() })
+        .from(schema.workspaceAutomations)
+        .where(
+          and(
+            eq(schema.workspaceAutomations.organizationId, input.organizationId),
+            ne(schema.workspaceAutomations.status, "archived"),
+          ),
+        );
+      return countValue(row);
+    }
+    case workspaceResourceFeatureIds.integrations:
+      return countActiveIntegrations(input.db, input.organizationId);
+  }
+}
+
+async function countActiveIntegrations(database: DatabaseClient, organizationId: string) {
+  const [[tmsCredentials], [githubInstallations], [contentfulConnections], [connectors]] =
+    await Promise.all([
+      database
+        .select({ value: count() })
+        .from(schema.organizationExternalTmsProviderCredentials)
+        .where(
+          eq(schema.organizationExternalTmsProviderCredentials.organizationId, organizationId),
+        ),
+      database
+        .select({ value: count() })
+        .from(schema.githubInstallations)
+        .where(eq(schema.githubInstallations.organizationId, organizationId)),
+      database
+        .select({ value: count() })
+        .from(schema.contentfulConnections)
+        .where(
+          and(
+            eq(schema.contentfulConnections.organizationId, organizationId),
+            eq(schema.contentfulConnections.enabled, true),
+          ),
+        ),
+      database
+        .select({ value: count() })
+        .from(schema.connectors)
+        .where(
+          and(
+            eq(schema.connectors.organizationId, organizationId),
+            eq(schema.connectors.enabled, true),
+          ),
+        ),
+    ]);
+
+  return (
+    countValue(tmsCredentials) +
+    countValue(githubInstallations) +
+    countValue(contentfulConnections) +
+    countValue(connectors)
+  );
+}
+
+function formatLimitCheckError(error: unknown) {
+  if (error instanceof Error) return error.message.slice(0, 500);
+  return "workspace_resource_limit_check_failed";
+}
+
+async function checkAutumnWorkspaceResourceLimit(input: {
+  organizationId: string;
+  featureId: WorkspaceResourceFeatureId;
+  requestedUsage: number;
+  autumnApiKey: string;
+}) {
+  const autumn = new Autumn({
+    secretKey: input.autumnApiKey,
+    xApiVersion: AUTUMN_API_VERSION,
+    failOpen: false,
+  });
+
+  const response = await autumn.check({
+    customerId: input.organizationId,
+    featureId: input.featureId,
+    requiredBalance: input.requestedUsage,
+    withPreview: true,
+  });
+
+  return response.allowed;
+}
+
+export async function ensureWorkspaceResourceLimitAvailable(input: {
+  db?: DatabaseClient;
+  organizationId: string;
+  featureId: WorkspaceResourceFeatureId;
+  additionalUsage?: number;
+  autumnApiKey?: string;
+}): Promise<Result<void, WorkspaceResourceLimitError>> {
+  const database = input.db ?? db;
+  const additionalUsage = input.additionalUsage ?? 1;
+  if (additionalUsage <= 0) return ok(undefined);
+  if (process.env.NODE_ENV === "test" && input.autumnApiKey === undefined) return ok(undefined);
+
+  const currentUsage = await countWorkspaceResourceUsage({
+    db: database,
+    organizationId: input.organizationId,
+    featureId: input.featureId,
+  });
+  const requestedUsage = currentUsage + additionalUsage;
+  const autumnApiKey = input.autumnApiKey ?? getAutumnSecretKey();
+
+  if (!autumnApiKey) {
+    const fallbackLimit = localFallbackLimits[input.featureId];
+    if (requestedUsage > fallbackLimit) {
+      return err({
+        code: "workspace_resource_limit_reached",
+        featureId: input.featureId,
+        currentUsage,
+        requestedUsage,
+      });
+    }
+
+    return ok(undefined);
+  }
+
+  try {
+    const allowed = await checkAutumnWorkspaceResourceLimit({
+      organizationId: input.organizationId,
+      featureId: input.featureId,
+      requestedUsage,
+      autumnApiKey,
+    });
+
+    if (!allowed) {
+      return err({
+        code: "workspace_resource_limit_reached",
+        featureId: input.featureId,
+        currentUsage,
+        requestedUsage,
+      });
+    }
+
+    return ok(undefined);
+  } catch (error) {
+    return err({
+      code: "workspace_resource_limit_check_failed",
+      featureId: input.featureId,
+      message: formatLimitCheckError(error),
+    });
+  }
+}
+
+export function workspaceResourceLimitMessage(featureId: WorkspaceResourceFeatureId) {
+  switch (featureId) {
+    case workspaceResourceFeatureIds.seats:
+      return "Seat limit reached for your current plan.";
+    case workspaceResourceFeatureIds.projects:
+      return "Project limit reached for your current plan.";
+    case workspaceResourceFeatureIds.automations:
+      return "Automation limit reached for your current plan.";
+    case workspaceResourceFeatureIds.integrations:
+      return "Integration limit reached for your current plan.";
+  }
+}
+
+export function workspaceResourceLimitErrorDetails(error: WorkspaceResourceLimitError) {
+  return {
+    featureId: error.featureId,
+    ...(error.code === "workspace_resource_limit_reached"
+      ? {
+          currentUsage: error.currentUsage,
+          requestedUsage: error.requestedUsage,
+        }
+      : {}),
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/contentful/connections.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/connections.ts
@@ -81,8 +81,10 @@ function generateWebhookSecret() {
 export async function ensureContentfulWebhookSubscription(input: {
   organizationId: string;
   connectionId: string;
+  db?: DatabaseClient;
 }): Promise<{ row: ContentfulWebhookSubscriptionRow; webhookSecret: string | null }> {
-  const [existing] = await db
+  const database = input.db ?? db;
+  const [existing] = await database
     .select()
     .from(schema.contentfulWebhookSubscriptions)
     .where(
@@ -98,7 +100,7 @@ export async function ensureContentfulWebhookSubscription(input: {
   }
 
   const webhookSecret = generateWebhookSecret();
-  const [row] = await db
+  const [row] = await database
     .insert(schema.contentfulWebhookSubscriptions)
     .values({
       organizationId: input.organizationId,
@@ -120,12 +122,14 @@ async function syncConnectionProviderWebhook(input: {
   subscription: ContentfulWebhookSubscriptionRow;
   accessToken: string;
   webhookSecret?: string | null;
+  db?: DatabaseClient;
 }): Promise<ContentfulConnectionSecretResult> {
   const synced = await syncContentfulProviderWebhook({
     connection: input.connection,
     subscription: input.subscription,
     accessToken: input.accessToken,
     webhookSecret: input.webhookSecret,
+    db: input.db,
   });
 
   return {
@@ -229,6 +233,7 @@ export async function createContentfulConnection(input: {
   const webhook = await ensureContentfulWebhookSubscription({
     organizationId: input.organizationId,
     connectionId: connection.id,
+    db: database,
   });
 
   return syncConnectionProviderWebhook({
@@ -236,6 +241,7 @@ export async function createContentfulConnection(input: {
     subscription: webhook.row,
     accessToken: input.accessToken,
     webhookSecret: webhook.webhookSecret,
+    db: database,
   });
 }
 
@@ -353,6 +359,7 @@ export async function updateContentfulConnection(input: {
   const webhook = await ensureContentfulWebhookSubscription({
     organizationId: input.organizationId,
     connectionId: connection.id,
+    db: database,
   });
 
   const accessToken = encrypted ? input.accessToken! : previousToken;
@@ -362,6 +369,7 @@ export async function updateContentfulConnection(input: {
     subscription: webhook.row,
     accessToken,
     webhookSecret: webhook.webhookSecret,
+    db: database,
   });
 }
 

--- a/apps/hyperlocalise-web/src/lib/contentful/connections.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/connections.ts
@@ -2,7 +2,7 @@ import { randomBytes } from "node:crypto";
 
 import { and, desc, eq } from "drizzle-orm";
 
-import { db, schema } from "@/lib/database";
+import { db, schema, type DatabaseClient } from "@/lib/database";
 import {
   decryptProviderCredential,
   encryptProviderCredential,
@@ -193,9 +193,11 @@ export async function createContentfulConnection(input: {
   projectId?: string | null;
   sourceLocale?: string | null;
   targetLocales?: string[];
+  db?: DatabaseClient;
 }): Promise<ContentfulConnectionSecretResult> {
+  const database = input.db ?? db;
   const encrypted = unwrapProviderCredentialCrypto(encryptProviderCredential(input.accessToken));
-  const [connection] = await db
+  const [connection] = await database
     .insert(schema.contentfulConnections)
     .values({
       organizationId: input.organizationId,
@@ -248,7 +250,9 @@ export async function updateContentfulConnection(input: {
   fieldConfig?: ContentfulConnectionFieldConfig;
   accessToken?: string;
   enabled?: boolean;
+  db?: DatabaseClient;
 }): Promise<ContentfulConnectionSecretResult | null> {
+  const database = input.db ?? db;
   const encrypted = input.accessToken
     ? unwrapProviderCredentialCrypto(encryptProviderCredential(input.accessToken))
     : null;
@@ -305,7 +309,7 @@ export async function updateContentfulConnection(input: {
     previousSubscription.providerWebhookId = null;
   }
 
-  const [connection] = await db
+  const [connection] = await database
     .update(schema.contentfulConnections)
     .set({
       updatedByUserId: input.userId,

--- a/apps/hyperlocalise-web/src/lib/contentful/webhook-provider.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/webhook-provider.ts
@@ -3,7 +3,7 @@ import { randomBytes } from "node:crypto";
 import { eq } from "drizzle-orm";
 
 import { env } from "@/lib/env";
-import { db, schema } from "@/lib/database";
+import { db, schema, type DatabaseClient } from "@/lib/database";
 import { createLogger } from "@/lib/log";
 import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
 
@@ -82,8 +82,10 @@ async function persistWebhookSubscriptionState(input: {
   providerWebhookId?: string | null;
   lastError?: string | null;
   secretHash?: string;
+  db?: DatabaseClient;
 }) {
-  const [row] = await db
+  const database = input.db ?? db;
+  const [row] = await database
     .update(schema.contentfulWebhookSubscriptions)
     .set({
       ...(input.providerWebhookId !== undefined
@@ -174,6 +176,7 @@ export async function syncContentfulProviderWebhook(input: {
   subscription: ContentfulWebhookSubscriptionRow;
   accessToken: string;
   webhookSecret?: string | null;
+  db?: DatabaseClient;
 }): Promise<{
   subscription: ContentfulWebhookSubscriptionRow;
   webhookSecret: string | null;
@@ -183,6 +186,7 @@ export async function syncContentfulProviderWebhook(input: {
     const subscription = await persistWebhookSubscriptionState({
       subscriptionId: input.subscription.id,
       lastError: "Set HYPERLOCALISE_PUBLIC_APP_URL to register the Contentful webhook.",
+      db: input.db,
     });
     return { subscription, webhookSecret: null };
   }
@@ -247,6 +251,7 @@ export async function syncContentfulProviderWebhook(input: {
         ...(shouldPersistPendingSecret && pendingSecret
           ? { secretHash: hashContentfulWebhookSecret(pendingSecret) }
           : {}),
+        db: input.db,
       });
       return { subscription, webhookSecret: pendingSecret };
     }
@@ -264,6 +269,7 @@ export async function syncContentfulProviderWebhook(input: {
       providerWebhookId: createdResult.value.sys.id,
       lastError: null,
       secretHash: hashContentfulWebhookSecret(createSecret),
+      db: input.db,
     });
     return {
       subscription,
@@ -283,6 +289,7 @@ export async function syncContentfulProviderWebhook(input: {
     const subscription = await persistWebhookSubscriptionState({
       subscriptionId: input.subscription.id,
       lastError: message,
+      db: input.db,
     });
     return { subscription, webhookSecret: pendingSecret };
   }

--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs/agent-runs.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs/agent-runs.test.ts
@@ -1,5 +1,6 @@
 import "dotenv/config";
 
+import { eq } from "drizzle-orm";
 import { afterEach, beforeAll, describe, expect, it } from "vite-plus/test";
 
 import { db, schema } from "@/lib/database";
@@ -77,6 +78,21 @@ describe("agent runs", () => {
     expect(run.completedAt).toBeNull();
     expect(run.actorUserId).toBeNull();
     expect(run.hyperlocaliseJobId).toBeNull();
+
+    const [usageEvent] = await db
+      .select({
+        operationKey: schema.usageEvents.operationKey,
+        status: schema.usageEvents.status,
+        featureId: schema.usageEvents.featureId,
+      })
+      .from(schema.usageEvents)
+      .where(eq(schema.usageEvents.operationKey, `agent-run:${run.id}:agent_runs`))
+      .limit(1);
+    expect(usageEvent).toEqual({
+      operationKey: `agent-run:${run.id}:agent_runs`,
+      status: "reserved",
+      featureId: "agent_runs",
+    });
   });
 
   it("creates an agent run with actor, input snapshot, and linked job", async () => {
@@ -153,6 +169,24 @@ describe("agent runs", () => {
     expect(completed.outputSummary).toEqual({ approved: 5, rejected: 1 });
     expect(completed.changedItems).toEqual([{ keyId: "k1", change: "added term" }]);
     expect(completed.warnings).toEqual(["low confidence on item 3"]);
+
+    const [usageEvent] = await db
+      .select({
+        status: schema.usageEvents.status,
+        quantity: schema.usageEvents.quantity,
+        dimensions: schema.usageEvents.dimensions,
+      })
+      .from(schema.usageEvents)
+      .where(eq(schema.usageEvents.operationKey, `agent-run:${created.id}:agent_runs`))
+      .limit(1);
+    expect(usageEvent).toMatchObject({
+      status: "tracking_pending",
+      quantity: 1,
+      dimensions: {
+        autumn_event_name: "agent_run.completed",
+        unit: "run",
+      },
+    });
   });
 
   it("fails a run and preserves partial output", async () => {

--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs/agent-runs.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs/agent-runs.ts
@@ -1,7 +1,15 @@
 import { and, desc, eq, inArray, sql, type SQL } from "drizzle-orm";
 
+import {
+  formatUsageControlError,
+  markUsageEventSucceededByOperationKey,
+  reserveUsageEvent,
+  trackUsageEventInAutumnByOperationKey,
+  usageFeatureIds,
+} from "@/lib/billing/usage-control";
 import { db, schema } from "@/lib/database";
 import type { AgentRunKind, AgentRunStatus } from "@/lib/database/types";
+import { isErr } from "@/lib/primitives/result/results";
 
 import type { ExternalTmsProviderKind } from "../organization-external-tms-provider-credentials";
 
@@ -19,24 +27,41 @@ export async function createAgentRun(input: {
   inputSnapshot?: AgentRunInputSnapshot;
   hyperlocaliseJobId?: string | null;
 }) {
-  const [run] = await db
-    .insert(schema.agentRuns)
-    .values({
-      organizationId: input.organizationId,
-      providerKind: input.providerKind,
-      externalJobId: input.externalJobId,
-      externalTaskId: input.externalTaskId ?? null,
-      kind: input.kind,
-      status: "queued",
-      actorUserId: input.actorUserId ?? null,
-      inputSnapshot: input.inputSnapshot ?? {},
-      hyperlocaliseJobId: input.hyperlocaliseJobId ?? null,
-    })
-    .returning();
+  const run = await db.transaction(async (tx) => {
+    const [createdRun] = await tx
+      .insert(schema.agentRuns)
+      .values({
+        organizationId: input.organizationId,
+        providerKind: input.providerKind,
+        externalJobId: input.externalJobId,
+        externalTaskId: input.externalTaskId ?? null,
+        kind: input.kind,
+        status: "queued",
+        actorUserId: input.actorUserId ?? null,
+        inputSnapshot: input.inputSnapshot ?? {},
+        hyperlocaliseJobId: input.hyperlocaliseJobId ?? null,
+      })
+      .returning();
 
-  if (!run) {
-    throw new Error("Failed to create agent run");
-  }
+    if (!createdRun) {
+      throw new Error("Failed to create agent run");
+    }
+
+    const usageEventResult = await reserveUsageEvent({
+      db: tx,
+      organizationId: input.organizationId,
+      featureId: usageFeatureIds.agentRuns,
+      operationKey: `agent-run:${createdRun.id}:agent_runs`,
+      source: "agent_run_create",
+      quantity: 1,
+    });
+
+    if (isErr(usageEventResult)) {
+      throw new Error(formatUsageControlError(usageEventResult.error));
+    }
+
+    return createdRun;
+  });
 
   return run;
 }
@@ -98,6 +123,19 @@ export async function createOrReuseActivePushApprovedWriteBackAgentRun(input: {
       throw new Error("Failed to create agent run");
     }
 
+    const usageEventResult = await reserveUsageEvent({
+      db: tx,
+      organizationId: input.organizationId,
+      featureId: usageFeatureIds.agentRuns,
+      operationKey: `agent-run:${run.id}:agent_runs`,
+      source: "agent_run_create",
+      quantity: 1,
+    });
+
+    if (isErr(usageEventResult)) {
+      throw new Error(formatUsageControlError(usageEventResult.error));
+    }
+
     return { run, reused: false };
   });
 }
@@ -134,7 +172,7 @@ export async function completeAgentRun(input: {
   changedItems?: AgentRunChangedItem[];
   warnings?: string[];
 }) {
-  return finishAgentRun({
+  const run = await finishAgentRun({
     runId: input.runId,
     organizationId: input.organizationId,
     status: "succeeded",
@@ -142,6 +180,14 @@ export async function completeAgentRun(input: {
     changedItems: input.changedItems,
     warnings: input.warnings,
   });
+
+  await trackCompletedAgentRunUsage({
+    runId: input.runId,
+    organizationId: input.organizationId,
+    outputSummary: input.outputSummary,
+  });
+
+  return run;
 }
 
 export async function failAgentRun(input: {
@@ -225,6 +271,63 @@ async function finishAgentRun(input: {
   }
 
   return run;
+}
+
+async function trackCompletedAgentRunUsage(input: {
+  runId: string;
+  organizationId: string;
+  outputSummary?: AgentRunOutputSummary;
+}) {
+  const operationKey = `agent-run:${input.runId}:agent_runs`;
+  const tokenUsage = extractAgentRunTokenUsage(input.outputSummary);
+  const markUsageResult = await markUsageEventSucceededByOperationKey({
+    operationKey,
+    quantity: tokenUsage?.totalTokens && tokenUsage.totalTokens > 0 ? tokenUsage.totalTokens : 1,
+    dimensions: {
+      autumn_event_name: "agent_run.completed",
+      unit: tokenUsage ? "model_tokens" : "run",
+      input_tokens: tokenUsage?.inputTokens ?? null,
+      output_tokens: tokenUsage?.outputTokens ?? null,
+    },
+  });
+
+  if (isErr(markUsageResult)) {
+    console.error("[agent-run] Autumn usage event completion failed", {
+      runId: input.runId,
+      organizationId: input.organizationId,
+      operationKey,
+      error: formatUsageControlError(markUsageResult.error),
+    });
+    return;
+  }
+
+  const trackUsageResult = await trackUsageEventInAutumnByOperationKey({ operationKey });
+  if (isErr(trackUsageResult)) {
+    console.error("[agent-run] Autumn usage tracking failed after run succeeded", {
+      runId: input.runId,
+      organizationId: input.organizationId,
+      operationKey,
+      error: formatUsageControlError(trackUsageResult.error),
+    });
+  }
+}
+
+function extractAgentRunTokenUsage(outputSummary: AgentRunOutputSummary | undefined) {
+  const tokenUsage = outputSummary?.tokenUsage;
+  if (!tokenUsage || typeof tokenUsage !== "object") return null;
+
+  const usage = tokenUsage as {
+    inputTokens?: unknown;
+    outputTokens?: unknown;
+    totalTokens?: unknown;
+  };
+  const inputTokens = typeof usage.inputTokens === "number" ? usage.inputTokens : 0;
+  const outputTokens = typeof usage.outputTokens === "number" ? usage.outputTokens : 0;
+  const totalTokens =
+    typeof usage.totalTokens === "number" ? usage.totalTokens : inputTokens + outputTokens;
+
+  if (totalTokens <= 0) return null;
+  return { inputTokens, outputTokens, totalTokens };
 }
 
 export async function updateAgentRun(input: {

--- a/apps/hyperlocalise-web/src/lib/providers/organization-external-tms-provider-credentials.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/organization-external-tms-provider-credentials.ts
@@ -2,7 +2,7 @@ import { and, desc, eq, inArray, ne, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import { assertCapability } from "@/api/auth/policy";
-import { db, schema } from "@/lib/database";
+import { db, schema, type DatabaseClient } from "@/lib/database";
 import type { OrganizationMembershipRole } from "@/lib/database/types";
 import {
   decryptProviderCredential,
@@ -37,6 +37,14 @@ export const API_TOKEN_AUTH_MODE = "api_token";
 export const CROWDIN_OAUTH_TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
 export const PHRASE_OAUTH_TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
 export const LOKALISE_OAUTH_TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
+
+async function runInDatabaseTransaction<T>(
+  database: DatabaseClient | undefined,
+  run: (tx: DatabaseClient) => Promise<T>,
+): Promise<T> {
+  if (database) return run(database);
+  return db.transaction(run);
+}
 
 const crowdinOAuthTokenBundleSchema = z.object({
   clientId: z.string().min(1),
@@ -262,6 +270,7 @@ export async function upsertOrganizationExternalTmsProviderCredential(input: {
   secretMaterial: string;
   region?: string | null;
   baseUrl?: string | null;
+  db?: DatabaseClient;
 }) {
   assertExternalTmsCredentialAdmin(input.role);
 
@@ -273,7 +282,7 @@ export async function upsertOrganizationExternalTmsProviderCredential(input: {
     baseUrl: input.baseUrl ?? null,
   });
 
-  const credential = await db.transaction(async (tx) => {
+  const credential = await runInDatabaseTransaction(input.db, async (tx) => {
     await tx
       .delete(schema.organizationExternalTmsProviderCredentials)
       .where(
@@ -346,6 +355,7 @@ export async function upsertCrowdinOAuthProviderCredential(input: {
   oauthClient?: CrowdinOAuthClientMaterial;
   tokenBundle?: CrowdinOAuthTokenBundle;
   baseUrl?: string | null;
+  db?: DatabaseClient;
 }) {
   assertExternalTmsCredentialAdmin(input.role);
 
@@ -366,7 +376,7 @@ export async function upsertCrowdinOAuthProviderCredential(input: {
     baseUrl: input.baseUrl ?? null,
   });
 
-  const credential = await db.transaction(async (tx) => {
+  const credential = await runInDatabaseTransaction(input.db, async (tx) => {
     await tx
       .delete(schema.organizationExternalTmsProviderCredentials)
       .where(
@@ -438,6 +448,7 @@ export async function upsertPhraseOAuthProviderCredential(input: {
   displayName: string;
   oauthClient: PhraseOAuthClientMaterial;
   baseUrl?: string | null;
+  db?: DatabaseClient;
 }) {
   assertExternalTmsCredentialAdmin(input.role);
 
@@ -449,7 +460,7 @@ export async function upsertPhraseOAuthProviderCredential(input: {
   const encrypted = unwrapProviderCredentialCrypto(encryptProviderCredential(secretMaterial));
   const baseUrl = await normalizePhraseOAuthCredentialBaseUrl(input.baseUrl ?? null);
 
-  const credential = await db.transaction(async (tx) => {
+  const credential = await runInDatabaseTransaction(input.db, async (tx) => {
     await tx
       .delete(schema.organizationExternalTmsProviderCredentials)
       .where(
@@ -521,6 +532,7 @@ export async function upsertLokaliseOAuthProviderCredential(input: {
   displayName: string;
   oauthClient: LokaliseOAuthClientMaterial;
   baseUrl?: string | null;
+  db?: DatabaseClient;
 }) {
   assertExternalTmsCredentialAdmin(input.role);
 
@@ -536,7 +548,7 @@ export async function upsertLokaliseOAuthProviderCredential(input: {
     baseUrl: input.baseUrl ?? null,
   });
 
-  const credential = await db.transaction(async (tx) => {
+  const credential = await runInDatabaseTransaction(input.db, async (tx) => {
     await tx
       .delete(schema.organizationExternalTmsProviderCredentials)
       .where(

--- a/apps/hyperlocalise-web/src/lib/translation/string-job-executor.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/string-job-executor.test.ts
@@ -149,6 +149,11 @@ describe("createStringTranslationGenerator", () => {
         { locale: "fr-FR", text: "Bonjour le monde" },
         { locale: "de-DE", text: "Hallo Welt" },
       ],
+      tokenUsage: {
+        inputTokens: 10,
+        outputTokens: 20,
+        totalTokens: 30,
+      },
     });
   });
 
@@ -169,6 +174,11 @@ describe("createStringTranslationGenerator", () => {
         { locale: "fr-FR", text: " Bonjour le monde " },
         { locale: "de-DE", text: "\tHallo Welt\n" },
       ],
+      tokenUsage: {
+        inputTokens: 10,
+        outputTokens: 20,
+        totalTokens: 30,
+      },
     });
   });
 
@@ -191,6 +201,11 @@ describe("createStringTranslationGenerator", () => {
 
     expect(result).toEqual({
       translations: [{ locale: "fr-FR", text: "Bonjour le monde" }],
+      tokenUsage: {
+        inputTokens: 10,
+        outputTokens: 20,
+        totalTokens: 30,
+      },
     });
   });
 

--- a/apps/hyperlocalise-web/src/lib/translation/string-job-executor.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/string-job-executor.ts
@@ -222,20 +222,14 @@ function normalizeAiSdkTokenUsage(
 ): StringTranslationJobResult["tokenUsage"] | undefined {
   const rawUsage = usage as
     | {
-        inputTokens?: number | { total?: number };
-        outputTokens?: number | { total?: number };
+        inputTokens?: number;
+        outputTokens?: number;
         totalTokens?: number;
       }
     | undefined;
 
-  const inputTokens =
-    typeof rawUsage?.inputTokens === "number"
-      ? rawUsage.inputTokens
-      : (rawUsage?.inputTokens?.total ?? 0);
-  const outputTokens =
-    typeof rawUsage?.outputTokens === "number"
-      ? rawUsage.outputTokens
-      : (rawUsage?.outputTokens?.total ?? 0);
+  const inputTokens = rawUsage?.inputTokens ?? 0;
+  const outputTokens = rawUsage?.outputTokens ?? 0;
   const totalTokens = rawUsage?.totalTokens ?? inputTokens + outputTokens;
   const parsedUsage = tokenUsageSchema.safeParse({ inputTokens, outputTokens, totalTokens });
 

--- a/apps/hyperlocalise-web/src/lib/translation/string-job-executor.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/string-job-executor.ts
@@ -26,13 +26,21 @@ const stringTranslationOutputSchema = z.object({
   ),
 });
 
+const tokenUsageSchema = z.object({
+  inputTokens: z.number().int().nonnegative(),
+  outputTokens: z.number().int().nonnegative(),
+  totalTokens: z.number().int().nonnegative(),
+});
+
 function estimateMaxOutputTokens(input: StringTranslationJobInput) {
   const sourceBudget = Math.ceil(input.sourceText.length / 2);
   const localeBudget = input.targetLocales.length * 256;
   return Math.min(16_000, Math.max(1_000, sourceBudget + localeBudget));
 }
 
-export type StringTranslationJobResult = z.infer<typeof stringTranslationOutputSchema>;
+export type StringTranslationJobResult = z.infer<typeof stringTranslationOutputSchema> & {
+  tokenUsage?: z.infer<typeof tokenUsageSchema>;
+};
 
 export type StringTranslationGeneratorInput = {
   projectName: string;
@@ -167,7 +175,8 @@ function buildPrompt(input: StringTranslationGeneratorInput) {
  */
 function normalizeTranslations(
   jobInput: StringTranslationJobInput,
-  result: StringTranslationJobResult,
+  result: z.infer<typeof stringTranslationOutputSchema>,
+  tokenUsage?: StringTranslationJobResult["tokenUsage"],
 ): StringTranslationJobResult {
   const translationsByLocale = new Map<string, string>();
 
@@ -205,7 +214,32 @@ function normalizeTranslations(
     return { locale, text };
   });
 
-  return { translations };
+  return { translations, ...(tokenUsage ? { tokenUsage } : {}) };
+}
+
+function normalizeAiSdkTokenUsage(
+  usage: unknown,
+): StringTranslationJobResult["tokenUsage"] | undefined {
+  const rawUsage = usage as
+    | {
+        inputTokens?: number | { total?: number };
+        outputTokens?: number | { total?: number };
+        totalTokens?: number;
+      }
+    | undefined;
+
+  const inputTokens =
+    typeof rawUsage?.inputTokens === "number"
+      ? rawUsage.inputTokens
+      : (rawUsage?.inputTokens?.total ?? 0);
+  const outputTokens =
+    typeof rawUsage?.outputTokens === "number"
+      ? rawUsage.outputTokens
+      : (rawUsage?.outputTokens?.total ?? 0);
+  const totalTokens = rawUsage?.totalTokens ?? inputTokens + outputTokens;
+  const parsedUsage = tokenUsageSchema.safeParse({ inputTokens, outputTokens, totalTokens });
+
+  return parsedUsage.success ? parsedUsage.data : undefined;
 }
 
 /**
@@ -218,7 +252,7 @@ export function createStringTranslationGenerator({
   model,
 }: CreateStringTranslationGeneratorOptions): StringTranslationGenerator {
   return async (input) => {
-    const { output } = await generateText({
+    const { output, usage } = await generateText({
       model,
       output: Output.object({
         schema: stringTranslationOutputSchema,
@@ -229,7 +263,7 @@ export function createStringTranslationGenerator({
       maxOutputTokens: estimateMaxOutputTokens(input.jobInput),
     });
 
-    return normalizeTranslations(input.jobInput, output);
+    return normalizeTranslations(input.jobInput, output, normalizeAiSdkTokenUsage(usage));
   };
 }
 

--- a/apps/hyperlocalise-web/src/lib/translation/translation-job-queued-function.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/translation-job-queued-function.ts
@@ -376,7 +376,19 @@ export async function completeTranslationJob(input: {
   }
 
   const operationKey = `job:${input.jobId}:translation_jobs`;
-  const markUsageResult = await markUsageEventSucceededByOperationKey({ operationKey });
+  const tokenUsage = input.result.tokenUsage;
+  const usageQuantity =
+    tokenUsage?.totalTokens && tokenUsage.totalTokens > 0 ? tokenUsage.totalTokens : 1;
+  const markUsageResult = await markUsageEventSucceededByOperationKey({
+    operationKey,
+    quantity: usageQuantity,
+    dimensions: {
+      autumn_event_name: "translation_job.completed",
+      unit: tokenUsage ? "model_tokens" : "job",
+      input_tokens: tokenUsage?.inputTokens ?? null,
+      output_tokens: tokenUsage?.outputTokens ?? null,
+    },
+  });
   if (isErr(markUsageResult)) {
     throw new Error(formatUsageControlError(markUsageResult.error));
   }

--- a/apps/hyperlocalise-web/src/workflows/steps/translation-job.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/translation-job.ts
@@ -421,4 +421,33 @@ export async function completeFileTranslationJobStep(input: {
       `translation job ${input.jobId} is not owned by workflow run ${input.workflowRunId}`,
     );
   }
+
+  const {
+    formatUsageControlError,
+    markUsageEventSucceededByOperationKey,
+    trackUsageEventInAutumnByOperationKey,
+  } = await import("@/lib/billing/usage-control");
+  const { isErr } = await import("@/lib/primitives/result/results");
+  const operationKey = `job:${input.jobId}:translation_jobs`;
+  const markUsageResult = await markUsageEventSucceededByOperationKey({
+    operationKey,
+    quantity: 1,
+    dimensions: {
+      autumn_event_name: "translation_job.completed",
+      unit: "job",
+    },
+  });
+
+  if (isErr(markUsageResult)) {
+    throw new Error(formatUsageControlError(markUsageResult.error));
+  }
+
+  const trackUsageResult = await trackUsageEventInAutumnByOperationKey({ operationKey });
+  if (isErr(trackUsageResult)) {
+    console.error("[file-translation-job] Autumn usage tracking failed after job succeeded", {
+      jobId: input.jobId,
+      operationKey,
+      error: formatUsageControlError(trackUsageResult.error),
+    });
+  }
 }


### PR DESCRIPTION
## What changed

- Updated Autumn billing identifiers to match the Growth plan setup:
  - `growth` and `enterprise` plan IDs
  - `ai_tokens`, `translation_jobs`, `agent_runs`, `seats`, `projects`, `automations`, `integrations`, and `ai_features`
- Changed the billing page usage panel to show AI token balance and workspace limits instead of placeholder meters like source characters and API requests.
- Added Autumn event-name tracking support so local usage events can post `translation_job.completed` and `agent_run.completed`.
- Preserved AI SDK token usage from string translation jobs and tracks completed translation jobs by token quantity when token usage is available.
- Added durable local reservation and completion tracking for provider agent runs.

## How to test

- `vp test src/lib/billing/usage-control.test.ts src/lib/billing/autumn-ids.test.ts src/lib/translation/string-job-executor.test.ts src/lib/providers/agent-runs/agent-runs.test.ts`
- `vp check --fix`
- `vp test` attempted, but local DB drift blocked unrelated suites:
  - `project_file_string_repository_contexts` relation is missing
  - `contentful_connections.project_id` is still `NOT NULL` locally
- `vp run db:migrate` attempted after the full test failure, but it exited before completing while applying migrations.

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review