### PR TITLE
feat(web): add CAT AI translation recommendations

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -43,6 +43,7 @@ import {
   createProjectBodySchema,
   maxProjectFileUploadBytes,
   projectFileCatQuerySchema,
+  projectFileCatRecommendationBodySchema,
   projectFileCatStatusBodySchema,
   projectFileCatTranslationBodySchema,
   projectFileDetailQuerySchema,
@@ -76,6 +77,7 @@ import {
   unsupportedProjectFileResponse,
 } from "./project.shared";
 import { createJobRoutes } from "./job.route";
+import { generateCatAiRecommendation } from "@/lib/translation/generate-cat-ai-recommendation";
 import { inferSupportedFileTranslationFileFormat } from "@/lib/translation/file-formats";
 
 type ProjectUpdateErrorCode =
@@ -303,6 +305,16 @@ const validateProjectFileCatQuery = validator("query", (value, c) => {
 
 const validateProjectFileCatTranslationBody = validator("json", (value, c) => {
   const parsed = projectFileCatTranslationBodySchema.safeParse(value);
+
+  if (!parsed.success) {
+    return invalidProjectPayloadResponse(c);
+  }
+
+  return parsed.data;
+});
+
+const validateProjectFileCatRecommendationBody = validator("json", (value, c) => {
+  const parsed = projectFileCatRecommendationBodySchema.safeParse(value);
 
   if (!parsed.success) {
     return invalidProjectPayloadResponse(c);
@@ -582,6 +594,50 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
         } catch (error) {
           return tmsProviderLiveErrorResponse(c, error);
         }
+      },
+    )
+    .post(
+      "/:projectId/files/detail/cat/recommendation",
+      validateProjectParams,
+      validateProjectFileCatRecommendationBody,
+      async (c) => {
+        if (!isAiActionAllowed(c.var.auth.membership.role)) {
+          return forbiddenResponse(c);
+        }
+
+        const params = c.req.valid("param");
+        const body = c.req.valid("json");
+        const target = await resolveProjectResourceTarget(c.var.auth, params.projectId);
+        if (target.kind === "provider_unavailable") {
+          return providerProjectUnavailableResponse(c, target);
+        }
+
+        const project = await getOwnedProject(c.var.auth, params.projectId);
+        if (!project) {
+          return projectNotFoundResponse(c);
+        }
+
+        const filename = body.sourcePath.split("/").pop() ?? body.sourcePath;
+        const result = await generateCatAiRecommendation({
+          projectId: params.projectId,
+          organizationId: c.var.auth.organization.localOrganizationId,
+          sourcePath: body.sourcePath,
+          filename,
+          sourceLocale: body.sourceLocale,
+          targetLocale: body.targetLocale,
+          key: body.key,
+          sourceText: body.sourceText,
+          targetText: body.targetText,
+          context: body.context ?? null,
+          agentContext: body.agentContext ?? null,
+          maxLength: body.maxLength,
+        });
+
+        if (isErr(result)) {
+          return badRequestResponse(c, result.error.code, result.error.message);
+        }
+
+        return c.json({ recommendation: result.value }, 200);
       },
     )
     .post(

--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -357,7 +357,7 @@ export const projectFileCatRecommendationBodySchema = z.object({
   targetLocale: z.string().trim().min(1).max(32),
   sourceLocale: z.string().trim().min(1).max(32),
   key: z.string().trim().min(1).max(2048),
-  sourceText: z.string().max(100_000),
+  sourceText: z.string().min(1).max(100_000),
   targetText: z.string().max(100_000).optional(),
   context: z.string().trim().max(16_384).nullable().optional(),
   agentContext: z.string().trim().max(16_384).nullable().optional(),

--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -352,6 +352,25 @@ export const projectFileDetailResponseSchema = z.object({
   }),
 });
 
+export const projectFileCatRecommendationBodySchema = z.object({
+  sourcePath: z.string().trim().min(1).max(2048),
+  targetLocale: z.string().trim().min(1).max(32),
+  sourceLocale: z.string().trim().min(1).max(32),
+  key: z.string().trim().min(1).max(2048),
+  sourceText: z.string().max(100_000),
+  targetText: z.string().max(100_000).optional(),
+  context: z.string().trim().max(16_384).nullable().optional(),
+  agentContext: z.string().trim().max(16_384).nullable().optional(),
+  maxLength: z.number().int().positive().optional(),
+});
+
+export const projectFileCatRecommendationResponseSchema = z.object({
+  recommendation: z.object({
+    aiSuggestion: z.string(),
+    aiReasoning: z.string(),
+  }),
+});
+
 export const projectFileCatCommentSchema = z.object({
   externalCommentId: z.string(),
   type: z.enum(["comment", "issue"]),
@@ -406,6 +425,9 @@ export type ProjectFilesQuery = z.infer<typeof projectFilesQuerySchema>;
 export type ProjectFileDetailQuery = z.infer<typeof projectFileDetailQuerySchema>;
 export type ProjectFileCatQuery = z.infer<typeof projectFileCatQuerySchema>;
 export type ProjectFileCatTranslationBody = z.infer<typeof projectFileCatTranslationBodySchema>;
+export type ProjectFileCatRecommendationBody = z.infer<
+  typeof projectFileCatRecommendationBodySchema
+>;
 export type ProjectSourceStringEntry = z.infer<typeof projectSourceStringEntrySchema>;
 export type ProjectSourceStringsPreview = z.infer<typeof projectSourceStringsPreviewSchema>;
 export type ProjectFileContent = z.infer<typeof projectFileContentSchema>;
@@ -424,6 +446,9 @@ export type ProjectFileCatSegment = z.infer<typeof projectFileCatSegmentSchema>;
 export type ProjectFileCatResponse = z.infer<typeof projectFileCatResponseSchema>;
 export type ProjectFileCatTranslationResponse = z.infer<
   typeof projectFileCatTranslationResponseSchema
+>;
+export type ProjectFileCatRecommendationResponse = z.infer<
+  typeof projectFileCatRecommendationResponseSchema
 >;
 export type WorkspaceFileRecord = z.infer<typeof workspaceFileRecordSchema>;
 export type WorkspaceFilesResponse = z.infer<typeof workspaceFilesResponseSchema>;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/tms-job-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/tms-job-cat-workspace.tsx
@@ -4,6 +4,7 @@ import { useCallback, useMemo } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import type {
+  ProjectFileCatRecommendationResponse,
   ProjectFileCatResponse,
   ProjectFileCatSegment,
   ProjectFileCatTranslation,
@@ -351,6 +352,34 @@ export function TmsJobCatWorkspace({
     },
     [organizationSlug, projectId, repositoryFullName, sourcePath],
   );
+  const generateAiRecommendation = useCallback(
+    async (segment: CatSegment, targetText: string, intelligence?: CatSegmentIntelligence) => {
+      const response = await apiClient.api.orgs[":organizationSlug"].projects[
+        ":projectId"
+      ].files.detail.cat.recommendation.$post({
+        param: { organizationSlug, projectId },
+        json: {
+          sourcePath,
+          targetLocale,
+          sourceLocale: segment.sourceLocale,
+          key: segment.key,
+          sourceText: segment.sourceText,
+          targetText,
+          context: segment.contextLabel ?? intelligence?.productMeaning ?? null,
+          agentContext: intelligence?.agentContext ?? null,
+          maxLength: segment.maxLength,
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(await readApiError(response, "Failed to generate AI recommendation"));
+      }
+
+      const body = (await response.json()) as ProjectFileCatRecommendationResponse;
+      return body.recommendation;
+    },
+    [organizationSlug, projectId, sourcePath, targetLocale],
+  );
 
   if (catQuery.isLoading) {
     return (
@@ -390,6 +419,7 @@ export function TmsJobCatWorkspace({
       className={cn("min-h-0 flex-1", className)}
       services={{
         validateFormat: validateSegmentFormat,
+        generateAiRecommendation,
         ...(repositoryFullName ? { lookupSegmentContext } : {}),
       }}
       review={{

--- a/apps/hyperlocalise-web/src/components/cat/cat-editor-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-editor-panel.tsx
@@ -12,6 +12,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/primitives/cn";
 
 import { CatFormatChecks } from "./cat-format-checks";
 import { analyzeCatMessageFormat } from "./cat-message-format";
@@ -57,7 +58,9 @@ export function CatEditorPanel({
   onApprove,
   primaryActionLabel = "Approve",
   onAskQuestion,
+  onRetryAiRecommendation,
   onAiRecommendationEnabledChange,
+  aiRecommendationError,
   onPrevious,
   onNext,
   hasPreviousSegment,
@@ -82,7 +85,9 @@ export function CatEditorPanel({
   onApprove: () => void;
   primaryActionLabel?: string;
   onAskQuestion: () => void;
+  onRetryAiRecommendation?: () => void;
   onAiRecommendationEnabledChange: (enabled: boolean) => void;
+  aiRecommendationError?: string;
   onPrevious: () => void;
   onNext: () => void;
   hasPreviousSegment: boolean;
@@ -301,23 +306,53 @@ export function CatEditorPanel({
               </div>
               <Skeleton className="h-3 w-10/12 rounded-full bg-foreground/8" />
             </aside>
-          ) : isAiRecommendationEnabled && intelligence.aiSuggestion ? (
-            <aside className="border-l border-grove-300/40 pl-4">
+          ) : isAiRecommendationEnabled && canUseAiRecommendation ? (
+            <aside
+              className={cn(
+                "border-l pl-4",
+                intelligence.aiSuggestion ? "border-grove-300/40" : "border-foreground/12",
+              )}
+            >
               <div className="mb-2 flex items-center justify-between gap-3">
                 <p className="text-xs font-medium text-muted-foreground">AI recommendation</p>
-                <Button variant="ghost" size="sm" onClick={onUseAiSuggestion}>
-                  Use
-                </Button>
+                <div className="flex items-center gap-1">
+                  {intelligence.aiSuggestion ? (
+                    <Button variant="ghost" size="sm" onClick={onUseAiSuggestion}>
+                      Use
+                    </Button>
+                  ) : null}
+                  {onRetryAiRecommendation ? (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={onRetryAiRecommendation}
+                      disabled={isAiSuggestionLoading}
+                    >
+                      {isAiSuggestionLoading ? <Spinner className="size-4" /> : null}
+                      Retry
+                    </Button>
+                  ) : null}
+                </div>
               </div>
-              <p className="text-sm leading-relaxed text-foreground/88">
-                {intelligence.aiSuggestion}
-              </p>
-              {intelligence.aiReasoning ? (
-                <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
-                  <span className="font-medium text-foreground/70">Reasoning:</span>{" "}
-                  {intelligence.aiReasoning}
+              {aiRecommendationError ? (
+                <p className="text-sm leading-relaxed text-flame-100">{aiRecommendationError}</p>
+              ) : intelligence.aiSuggestion ? (
+                <>
+                  <p className="text-sm leading-relaxed text-foreground/88">
+                    {intelligence.aiSuggestion}
+                  </p>
+                  {intelligence.aiReasoning ? (
+                    <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+                      <span className="font-medium text-foreground/70">Reasoning:</span>{" "}
+                      {intelligence.aiReasoning}
+                    </p>
+                  ) : null}
+                </>
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  No recommendation yet. Retry to generate one for this string.
                 </p>
-              ) : null}
+              )}
             </aside>
           ) : null}
 

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
@@ -304,13 +304,16 @@ export function CatWorkspaceContainer({
         return;
       }
 
+      const currentIntelligence =
+        stateRef.current.segmentIntelligence?.[segmentId] ?? stateRef.current.intelligence;
+
       const sequence = reviewSequenceRef.current + 1;
       reviewSequenceRef.current = sequence;
       setIsGeneratingAiRecommendation(true);
       try {
         const [recommendation, formatChecks, qaChecks] = await Promise.all([
           includeAi && generateAiRecommendation
-            ? generateAiRecommendation(segment, segment.targetText)
+            ? generateAiRecommendation(segment, segment.targetText, currentIntelligence)
             : Promise.resolve(undefined),
           includeFormatChecks && validateFormat
             ? validateFormat(segment, segment.targetText)
@@ -322,7 +325,11 @@ export function CatWorkspaceContainer({
         if (reviewSequenceRef.current !== sequence) {
           return;
         }
-        const checks = recommendation?.formatChecks ?? [...formatChecks, ...qaChecks];
+        const withoutAiFailure = (segmentChecks: CatFormatCheck[]) =>
+          segmentChecks.filter((check) => check.id !== `ai-recommendation-failed-${segmentId}`);
+        const checks = withoutAiFailure(
+          recommendation?.formatChecks ?? [...formatChecks, ...qaChecks],
+        );
 
         setState((current) => {
           const currentIntelligence =
@@ -345,6 +352,40 @@ export function CatWorkspaceContainer({
                   },
                 }
               : current.segmentIntelligence,
+          };
+        });
+      } catch (error) {
+        if (reviewSequenceRef.current !== sequence) {
+          return;
+        }
+
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Failed to generate AI translation recommendation.";
+        const aiFailureCheck: CatFormatCheck = {
+          id: `ai-recommendation-failed-${segmentId}`,
+          label: "AI recommendation",
+          status: "fail",
+          message,
+          category: "qa",
+        };
+
+        setState((current) => {
+          const currentChecks = current.segmentFormatChecks?.[segmentId] ?? current.formatChecks;
+          const nextChecks = [
+            aiFailureCheck,
+            ...currentChecks.filter((check) => check.id !== aiFailureCheck.id),
+          ];
+
+          return {
+            ...current,
+            formatChecks:
+              current.selectedSegmentId === segmentId ? nextChecks : current.formatChecks,
+            segmentFormatChecks: {
+              ...current.segmentFormatChecks,
+              [segmentId]: nextChecks,
+            },
           };
         });
       } finally {
@@ -540,7 +581,7 @@ export function CatWorkspaceContainer({
         }
       },
       onReviewWithAi: async (segmentId: string) => {
-        await runSegmentReview(segmentId);
+        await runSegmentReview(segmentId, { includeAi: true });
       },
       onSkip: (segmentId: string) => {
         setState((current) => {

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type {
+  CatAiRecommendationResult,
   CatWorkspaceDependencies,
   CatWorkspaceEditing,
   CatWorkspaceNavigation,
@@ -311,10 +312,36 @@ export function CatWorkspaceContainer({
       reviewSequenceRef.current = sequence;
       setIsGeneratingAiRecommendation(true);
       try {
-        const [recommendation, formatChecks, qaChecks] = await Promise.all([
-          includeAi && generateAiRecommendation
-            ? generateAiRecommendation(segment, segment.targetText, currentIntelligence)
-            : Promise.resolve(undefined),
+        let recommendation: CatAiRecommendationResult | undefined;
+        let aiFailureCheck: CatFormatCheck | undefined;
+
+        if (includeAi && generateAiRecommendation) {
+          try {
+            recommendation = await generateAiRecommendation(
+              segment,
+              segment.targetText,
+              currentIntelligence,
+            );
+          } catch (error) {
+            if (reviewSequenceRef.current !== sequence) {
+              return;
+            }
+
+            const message =
+              error instanceof Error
+                ? error.message
+                : "Failed to generate AI translation recommendation.";
+            aiFailureCheck = {
+              id: `ai-recommendation-failed-${segmentId}`,
+              label: "AI recommendation",
+              status: "fail",
+              message,
+              category: "qa",
+            };
+          }
+        }
+
+        const [formatChecks, qaChecks] = await Promise.all([
           includeFormatChecks && validateFormat
             ? validateFormat(segment, segment.targetText)
             : Promise.resolve([]),
@@ -327,9 +354,12 @@ export function CatWorkspaceContainer({
         }
         const withoutAiFailure = (segmentChecks: CatFormatCheck[]) =>
           segmentChecks.filter((check) => check.id !== `ai-recommendation-failed-${segmentId}`);
-        const checks = withoutAiFailure(
+        const baseChecks = withoutAiFailure(
           recommendation?.formatChecks ?? [...formatChecks, ...qaChecks],
         );
+        const checks = aiFailureCheck
+          ? [aiFailureCheck, ...baseChecks.filter((check) => check.id !== aiFailureCheck.id)]
+          : baseChecks;
 
         setState((current) => {
           const currentIntelligence =
@@ -352,40 +382,6 @@ export function CatWorkspaceContainer({
                   },
                 }
               : current.segmentIntelligence,
-          };
-        });
-      } catch (error) {
-        if (reviewSequenceRef.current !== sequence) {
-          return;
-        }
-
-        const message =
-          error instanceof Error
-            ? error.message
-            : "Failed to generate AI translation recommendation.";
-        const aiFailureCheck: CatFormatCheck = {
-          id: `ai-recommendation-failed-${segmentId}`,
-          label: "AI recommendation",
-          status: "fail",
-          message,
-          category: "qa",
-        };
-
-        setState((current) => {
-          const currentChecks = current.segmentFormatChecks?.[segmentId] ?? current.formatChecks;
-          const nextChecks = [
-            aiFailureCheck,
-            ...currentChecks.filter((check) => check.id !== aiFailureCheck.id),
-          ];
-
-          return {
-            ...current,
-            formatChecks:
-              current.selectedSegmentId === segmentId ? nextChecks : current.formatChecks,
-            segmentFormatChecks: {
-              ...current.segmentFormatChecks,
-              [segmentId]: nextChecks,
-            },
           };
         });
       } finally {

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace.tsx
@@ -82,6 +82,9 @@ export function CatWorkspaceView({
     state.segmentIntelligence?.[selectedSegment.id] ?? state.intelligence;
   const selectedSegmentFormatChecks =
     state.segmentFormatChecks?.[selectedSegment.id] ?? state.formatChecks;
+  const aiRecommendationError = selectedSegmentFormatChecks.find(
+    (check) => check.id === `ai-recommendation-failed-${selectedSegment.id}`,
+  )?.message;
   const isEditorBusy = isApproving;
   const canApprove = state.canEditTranslations !== false;
 
@@ -107,6 +110,10 @@ export function CatWorkspaceView({
         onApprove={() => void review.onApprove(selectedSegment.id, selectedSegment.targetText)}
         primaryActionLabel={state.primaryActionLabel}
         onAskQuestion={() => review.onAskQuestion(selectedSegment.id)}
+        onRetryAiRecommendation={
+          canUseAiRecommendation ? () => void review.onReviewWithAi(selectedSegment.id) : undefined
+        }
+        aiRecommendationError={aiRecommendationError}
         onAiRecommendationEnabledChange={onAiRecommendationEnabledChange}
         onPrevious={navigation.onPreviousSegment}
         onNext={navigation.onNextSegment}

--- a/apps/hyperlocalise-web/src/components/cat/dependencies.ts
+++ b/apps/hyperlocalise-web/src/components/cat/dependencies.ts
@@ -1,4 +1,10 @@
-import type { CatFormatCheck, CatSegment, CatSegmentStatus, CatWorkspaceState } from "./types";
+import type {
+  CatFormatCheck,
+  CatSegment,
+  CatSegmentIntelligence,
+  CatSegmentStatus,
+  CatWorkspaceState,
+} from "./types";
 
 export interface CatAiRecommendationResult {
   aiSuggestion: string;
@@ -35,6 +41,7 @@ export interface CatWorkspaceServices {
   generateAiRecommendation?: (
     segment: CatSegment,
     targetText: string,
+    intelligence?: CatSegmentIntelligence,
   ) => Promise<CatAiRecommendationResult>;
 }
 

--- a/apps/hyperlocalise-web/src/components/marketing/hero-frame.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/hero-frame.tsx
@@ -3,7 +3,12 @@
 import { motion, useReducedMotion } from "motion/react";
 
 import { CatWorkspaceContainer } from "@/components/cat";
-import type { CatFormatCheck, CatSegment, CatWorkspaceState } from "@/components/cat";
+import type {
+  CatFormatCheck,
+  CatSegment,
+  CatSegmentIntelligence,
+  CatWorkspaceState,
+} from "@/components/cat";
 
 const heroDemoSegments: CatSegment[] = [
   {
@@ -485,6 +490,8 @@ async function lookupHeroDemoContext(segment: CatSegment) {
 
 async function generateHeroAiRecommendation(
   segment: CatSegment,
+  _targetText: string,
+  intelligence?: CatSegmentIntelligence,
 ): Promise<{ aiSuggestion: string; aiReasoning: string; formatChecks: CatFormatCheck[] }> {
   await wait(1200);
 
@@ -497,7 +504,7 @@ async function generateHeroAiRecommendation(
     };
   }
 
-  const segmentIntelligence = heroDemoState.segmentIntelligence?.[segment.id];
+  const segmentIntelligence = intelligence ?? heroDemoState.segmentIntelligence?.[segment.id];
 
   return {
     aiSuggestion: segmentIntelligence?.aiSuggestion ?? segment.targetText,

--- a/apps/hyperlocalise-web/src/lib/translation/generate-cat-ai-recommendation.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/generate-cat-ai-recommendation.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+const generateTextMock = vi.fn();
+const loadOrganizationTranslationModelMock = vi.fn();
+const assembleStringTranslationContextSnapshotMock = vi.fn();
+
+vi.mock("ai", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("ai")>();
+  return {
+    ...actual,
+    generateText: (...args: unknown[]) => generateTextMock(...args),
+  };
+});
+
+vi.mock("./load-organization-translation-generator", () => ({
+  loadOrganizationTranslationModel: (...args: unknown[]) =>
+    loadOrganizationTranslationModelMock(...args),
+}));
+
+vi.mock("./assemble-translation-context", () => ({
+  assembleStringTranslationContextSnapshot: (...args: unknown[]) =>
+    assembleStringTranslationContextSnapshotMock(...args),
+}));
+
+import { generateCatAiRecommendation } from "./generate-cat-ai-recommendation";
+
+describe("generateCatAiRecommendation", () => {
+  it("returns a recommendation using file and agent context", async () => {
+    loadOrganizationTranslationModelMock.mockResolvedValue({
+      ok: true,
+      project: {
+        name: "Hyperlocalise",
+        translationContext: "Use concise product UI language.",
+      },
+      model: {},
+    });
+    assembleStringTranslationContextSnapshotMock.mockResolvedValue({
+      ok: true,
+      snapshot: {
+        project: {
+          id: "proj_1",
+          name: "Hyperlocalise",
+          translationContext: "Use concise product UI language.",
+        },
+        glossaryTerms: [],
+        translationMemoryMatches: [],
+      },
+    });
+    generateTextMock.mockResolvedValue({
+      output: {
+        suggestion: "Dang nhap vao khong gian lam viec",
+        reasoning: "Matches the sign-in screen tone and keeps the workspace metaphor.",
+      },
+    });
+
+    const result = await generateCatAiRecommendation({
+      projectId: "proj_1",
+      organizationId: "org_1",
+      sourcePath: "en-US.json",
+      filename: "en-US.json",
+      sourceLocale: "en-US",
+      targetLocale: "vi",
+      key: "auth.signIn.title",
+      sourceText: "Sign in to your workspace",
+      targetText: "",
+      context: "Heading on the sign-in screen",
+      agentContext: "Hero title on the sign-in page.",
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual({
+        aiSuggestion: "Dang nhap vao khong gian lam viec",
+        aiReasoning: "Matches the sign-in screen tone and keeps the workspace metaphor.",
+      });
+    }
+
+    expect(generateTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: expect.stringContaining("Heading on the sign-in screen"),
+      }),
+    );
+    expect(generateTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: expect.stringContaining("Hero title on the sign-in page."),
+      }),
+    );
+  });
+
+  it("maps model setup failures to a result error", async () => {
+    loadOrganizationTranslationModelMock.mockResolvedValue({
+      ok: false,
+      code: "provider_credential_missing",
+      message: "no organization provider credential or managed translation model is configured",
+    });
+
+    const result = await generateCatAiRecommendation({
+      projectId: "proj_1",
+      organizationId: "org_1",
+      sourcePath: "en-US.json",
+      filename: "en-US.json",
+      sourceLocale: "en-US",
+      targetLocale: "vi",
+      key: "auth.signIn.title",
+      sourceText: "Sign in to your workspace",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        code: "provider_credential_missing",
+        message: "no organization provider credential or managed translation model is configured",
+      },
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/translation/generate-cat-ai-recommendation.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/generate-cat-ai-recommendation.ts
@@ -1,0 +1,244 @@
+import { generateText, Output, type LanguageModel } from "ai";
+import { z } from "zod";
+
+import { err, ok, type Result } from "@/lib/primitives/result/results";
+
+import { assembleStringTranslationContextSnapshot } from "./assemble-translation-context";
+import { loadOrganizationTranslationModel } from "./load-organization-translation-generator";
+
+const catAiRecommendationOutputSchema = z.object({
+  suggestion: z.string().refine((text) => text.trim().length > 0, {
+    message: "Suggestion text cannot be empty",
+  }),
+  reasoning: z.string().refine((text) => text.trim().length > 0, {
+    message: "Reasoning cannot be empty",
+  }),
+});
+
+export type CatAiRecommendationInput = {
+  projectId: string;
+  organizationId: string;
+  sourcePath: string;
+  filename: string;
+  sourceLocale: string;
+  targetLocale: string;
+  key: string;
+  sourceText: string;
+  targetText?: string;
+  context?: string | null;
+  agentContext?: string | null;
+  maxLength?: number;
+};
+
+export type CatAiRecommendationResult = {
+  aiSuggestion: string;
+  aiReasoning: string;
+};
+
+export type CatAiRecommendationError = {
+  code:
+    | "translation_project_not_found"
+    | "provider_credential_invalid"
+    | "provider_credential_missing"
+    | "translation_context_assembly_failed"
+    | "ai_recommendation_failed";
+  message: string;
+};
+
+function estimateCatRecommendationMaxOutputTokens(input: CatAiRecommendationInput) {
+  const sourceBudget = Math.ceil(input.sourceText.length / 2);
+  const contextBudget = Math.ceil(
+    ((input.context?.length ?? 0) + (input.agentContext?.length ?? 0)) / 4,
+  );
+  return Math.min(4_000, Math.max(512, sourceBudget + contextBudget + 256));
+}
+
+function buildCatRecommendationSystemPrompt(input: {
+  projectName: string;
+  projectTranslationContext: string;
+  knowledgeMemory?: string;
+  glossaryTerms: Array<{
+    sourceTerm: string;
+    targetTerm: string;
+    targetLocale: string;
+    forbidden?: boolean | null;
+    description?: string | null;
+  }>;
+  translationMemoryMatches: Array<{
+    sourceText: string;
+    targetText: string;
+    targetLocale: string;
+  }>;
+}) {
+  const glossaryTerms = input.glossaryTerms;
+  const translationMemoryMatches = input.translationMemoryMatches;
+  const knowledgeMemory = input.knowledgeMemory?.trim();
+
+  const instructions = [
+    "You are an expert software localization assistant helping a human reviewer in a CAT tool.",
+    "Recommend the best target-locale translation for the provided source string.",
+    "Preserve meaning, tone, placeholders, HTML, Markdown, punctuation, whitespace, and line breaks.",
+    "Follow project translation context, file context, and repository context as binding style and usage guidance.",
+    "Follow workspace knowledge memory when present.",
+    "Use glossary terms exactly for the target locale. Do not use forbidden glossary terms.",
+    "Use approved translation memory matches as consistency references when they apply.",
+    "If constraints conflict, prioritize placeholder and markup preservation first, then glossary rules, then project context, file context, repository context, workspace knowledge memory, then translation memory examples.",
+    "When a current target draft is provided, improve it when needed instead of repeating it unchanged.",
+    "Return concise reasoning that explains terminology, tone, or product-fit choices.",
+    "",
+    `Project translation context: ${input.projectTranslationContext || "(none)"}`,
+    `Workspace knowledge memory: ${knowledgeMemory || "(none)"}`,
+    glossaryTerms.length > 0
+      ? [
+          "Glossary terms:",
+          ...glossaryTerms.map((term) =>
+            [
+              `- ${term.sourceTerm} -> ${term.targetTerm} (${term.targetLocale})`,
+              term.forbidden ? "forbidden" : null,
+              term.description ? `note: ${term.description}` : null,
+            ]
+              .filter(Boolean)
+              .join("; "),
+          ),
+        ].join("\n")
+      : "Glossary terms: (none)",
+    translationMemoryMatches.length > 0
+      ? [
+          "Translation memory matches:",
+          ...translationMemoryMatches.map(
+            (match) => `- ${match.sourceText} -> ${match.targetText} (${match.targetLocale})`,
+          ),
+        ].join("\n")
+      : "Translation memory matches: (none)",
+  ];
+
+  return instructions.join("\n");
+}
+
+function buildCatRecommendationPrompt(input: CatAiRecommendationInput) {
+  const sections = [
+    `Project file: ${input.filename}`,
+    `Source path: ${input.sourcePath}`,
+    `String key: ${input.key}`,
+    `Source locale: ${input.sourceLocale}`,
+    `Target locale: ${input.targetLocale}`,
+    `File context: ${input.context?.trim() || "(none)"}`,
+    `Repository context: ${input.agentContext?.trim() || "(none)"}`,
+  ];
+
+  if (input.maxLength) {
+    sections.push(`Maximum length: ${input.maxLength} characters`);
+  }
+
+  if (input.targetText?.trim()) {
+    sections.push("Current target draft:", input.targetText);
+  }
+
+  sections.push("Source text:", input.sourceText);
+
+  return sections.join("\n\n");
+}
+
+async function generateCatAiRecommendationWithModel(
+  model: LanguageModel,
+  input: CatAiRecommendationInput,
+  context: {
+    projectName: string;
+    projectTranslationContext: string;
+    knowledgeMemory?: string;
+    glossaryTerms: Array<{
+      sourceTerm: string;
+      targetTerm: string;
+      targetLocale: string;
+      forbidden?: boolean | null;
+      description?: string | null;
+    }>;
+    translationMemoryMatches: Array<{
+      sourceText: string;
+      targetText: string;
+      targetLocale: string;
+    }>;
+  },
+): Promise<CatAiRecommendationResult> {
+  const { output } = await generateText({
+    model,
+    output: Output.object({
+      schema: catAiRecommendationOutputSchema,
+    }),
+    system: buildCatRecommendationSystemPrompt({
+      projectName: context.projectName,
+      projectTranslationContext: context.projectTranslationContext,
+      knowledgeMemory: context.knowledgeMemory,
+      glossaryTerms: context.glossaryTerms,
+      translationMemoryMatches: context.translationMemoryMatches,
+    }),
+    prompt: buildCatRecommendationPrompt(input),
+    temperature: 0,
+    maxOutputTokens: estimateCatRecommendationMaxOutputTokens(input),
+  });
+
+  if (input.maxLength && output.suggestion.length > input.maxLength) {
+    throw new Error(`recommendation exceeds maxLength of ${input.maxLength}`);
+  }
+
+  return {
+    aiSuggestion: output.suggestion,
+    aiReasoning: output.reasoning,
+  };
+}
+
+export async function generateCatAiRecommendation(
+  input: CatAiRecommendationInput,
+): Promise<Result<CatAiRecommendationResult, CatAiRecommendationError>> {
+  const modelResult = await loadOrganizationTranslationModel(input.projectId);
+  if (!modelResult.ok) {
+    return err({
+      code: modelResult.code,
+      message: modelResult.message,
+    });
+  }
+
+  const contextResult = await assembleStringTranslationContextSnapshot(
+    input.projectId,
+    {
+      sourceLocale: input.sourceLocale,
+      targetLocales: [input.targetLocale],
+      sourceText: input.sourceText,
+      context: input.context ?? undefined,
+      maxLength: input.maxLength,
+      metadata: {
+        sourcePath: input.sourcePath,
+        key: input.key,
+      },
+    },
+    undefined,
+    {
+      organizationId: input.organizationId,
+    },
+  );
+
+  if (!contextResult.ok) {
+    return err({
+      code: "translation_context_assembly_failed",
+      message: contextResult.message,
+    });
+  }
+
+  try {
+    const recommendation = await generateCatAiRecommendationWithModel(modelResult.model, input, {
+      projectName: contextResult.snapshot.project.name,
+      projectTranslationContext: contextResult.snapshot.project.translationContext,
+      knowledgeMemory: contextResult.snapshot.knowledgeMemory,
+      glossaryTerms: contextResult.snapshot.glossaryTerms,
+      translationMemoryMatches: contextResult.snapshot.translationMemoryMatches,
+    });
+
+    return ok(recommendation);
+  } catch (error) {
+    return err({
+      code: "ai_recommendation_failed",
+      message:
+        error instanceof Error ? error.message : "Failed to generate AI translation recommendation",
+    });
+  }
+}

--- a/apps/hyperlocalise-web/src/lib/translation/generate-cat-ai-recommendation.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/generate-cat-ai-recommendation.ts
@@ -86,6 +86,7 @@ function buildCatRecommendationSystemPrompt(input: {
     "When a current target draft is provided, improve it when needed instead of repeating it unchanged.",
     "Return concise reasoning that explains terminology, tone, or product-fit choices.",
     "",
+    `Project name: ${input.projectName}`,
     `Project translation context: ${input.projectTranslationContext || "(none)"}`,
     `Workspace knowledge memory: ${knowledgeMemory || "(none)"}`,
     glossaryTerms.length > 0

--- a/apps/hyperlocalise-web/src/lib/translation/load-organization-translation-generator.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/load-organization-translation-generator.ts
@@ -1,3 +1,4 @@
+import type { LanguageModel } from "ai";
 import { desc, eq } from "drizzle-orm";
 
 import { db, schema } from "@/lib/database";
@@ -8,10 +9,35 @@ import {
 import {
   createManagedStringTranslationGenerator,
   createProviderStringTranslationGenerator,
+  getManagedTranslationLanguageModel,
   isManagedTranslationModelAvailable,
+  resolveProviderLanguageModel,
 } from "@/lib/translation/string-job-executor";
 
-export async function loadOrganizationTranslationGenerator(projectId: string) {
+type OrganizationTranslationProject = {
+  name: string;
+  translationContext: string;
+};
+
+type OrganizationTranslationSetupResult =
+  | {
+      ok: false;
+      code:
+        | "translation_project_not_found"
+        | "provider_credential_invalid"
+        | "provider_credential_missing";
+      message: string;
+    }
+  | {
+      ok: true;
+      project: OrganizationTranslationProject;
+      model: LanguageModel;
+      translateStringJob: ReturnType<typeof createProviderStringTranslationGenerator>;
+    };
+
+async function loadOrganizationTranslationSetup(
+  projectId: string,
+): Promise<OrganizationTranslationSetupResult> {
   const [project] = await db
     .select({
       name: schema.projects.name,
@@ -76,9 +102,16 @@ export async function loadOrganizationTranslationGenerator(projectId: string) {
       }),
     );
 
+    const model = resolveProviderLanguageModel({
+      provider: credential.provider,
+      apiKey,
+      model: credential.defaultModel,
+    });
+
     return {
       ok: true,
       project: projectContext,
+      model,
       translateStringJob: createProviderStringTranslationGenerator({
         provider: credential.provider,
         apiKey,
@@ -98,8 +131,35 @@ export async function loadOrganizationTranslationGenerator(projectId: string) {
   return {
     ok: true,
     project: projectContext,
+    model: getManagedTranslationLanguageModel(),
     translateStringJob: createManagedStringTranslationGenerator(),
   } as const;
+}
+
+export async function loadOrganizationTranslationGenerator(projectId: string) {
+  const setup = await loadOrganizationTranslationSetup(projectId);
+  if (!setup.ok) {
+    return setup;
+  }
+
+  return {
+    ok: true as const,
+    project: setup.project,
+    translateStringJob: setup.translateStringJob,
+  };
+}
+
+export async function loadOrganizationTranslationModel(projectId: string) {
+  const setup = await loadOrganizationTranslationSetup(projectId);
+  if (!setup.ok) {
+    return setup;
+  }
+
+  return {
+    ok: true as const,
+    project: setup.project,
+    model: setup.model,
+  };
 }
 
 /** @deprecated Use `loadOrganizationTranslationGenerator` instead. */

--- a/apps/hyperlocalise-web/src/lib/translation/string-job-executor.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/string-job-executor.ts
@@ -267,29 +267,25 @@ const openAiCompatibleBaseUrlByProvider = {
   mistral: "https://api.mistral.ai/v1",
 } as const satisfies Partial<Record<LlmProvider, string>>;
 
-export function createProviderStringTranslationGenerator(input: {
+export function resolveProviderLanguageModel(input: {
   provider: LlmProvider;
   apiKey: string;
   model: string;
-}): StringTranslationGenerator {
+}): LanguageModel {
   switch (input.provider) {
     case "anthropic": {
       const provider = createAnthropic({
         apiKey: input.apiKey,
       });
 
-      return createStringTranslationGenerator({
-        model: provider(input.model),
-      });
+      return provider(input.model);
     }
     case "openai": {
       const provider = createOpenAI({
         apiKey: input.apiKey,
       });
 
-      return createStringTranslationGenerator({
-        model: provider(input.model),
-      });
+      return provider(input.model);
     }
     case "gemini":
     case "groq":
@@ -300,20 +296,32 @@ export function createProviderStringTranslationGenerator(input: {
         ...(baseURL ? { baseURL } : {}),
       });
 
-      return createStringTranslationGenerator({
-        model: provider(input.model),
-      });
+      return provider(input.model);
     }
   }
 }
 
-export function createManagedStringTranslationGenerator(): StringTranslationGenerator {
+export function createProviderStringTranslationGenerator(input: {
+  provider: LlmProvider;
+  apiKey: string;
+  model: string;
+}): StringTranslationGenerator {
+  return createStringTranslationGenerator({
+    model: resolveProviderLanguageModel(input),
+  });
+}
+
+export function getManagedTranslationLanguageModel(): LanguageModel {
   if (!env.OPENAI_API_KEY) {
     throw new Error("OPENAI_API_KEY is not configured");
   }
 
+  return openai(hyperlocaliseAgentModelId);
+}
+
+export function createManagedStringTranslationGenerator(): StringTranslationGenerator {
   return createStringTranslationGenerator({
-    model: openai(hyperlocaliseAgentModelId),
+    model: getManagedTranslationLanguageModel(),
   });
 }
 


### PR DESCRIPTION
## What changed

Adds AI translation recommendations to the CAT Tool segment workspace. When viewing a string, the editor now requests a per-segment suggestion that uses file context (source path, key, TMS/file notes), agent/repository context when available, and org translation resources (project context, glossary, translation memory, knowledge memory).

- New `POST /api/orgs/:slug/projects/:id/files/detail/cat/recommendation` route
- `generateCatAiRecommendation` server helper reuses org LLM credentials and context assembly
- `TmsJobCatWorkspace` wires `generateAiRecommendation` into `CatWorkspaceContainer`
- Editor shows suggestion + reasoning with **Use** and **Retry** buttons; failures surface inline

## How to test

1. Open a job file in the CAT workspace (`/jobs/:jobId/strings?sourcePath=...&targetLocale=...`)
2. Select a segment and confirm an AI recommendation loads (AI toggle on)
3. Click **Find context** with a GitHub repo selected, then **Retry** to regenerate with agent context
4. Click **Use** to apply the suggestion to the target editor
5. Run `cd apps/hyperlocalise-web && vp test src/lib/translation/generate-cat-ai-recommendation.test.ts` and `vp check`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)