### PR TITLE
feat(web): add Crowdin CAT concordance before AI recommendations

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
@@ -81,7 +81,13 @@ describe("project file CAT routes", () => {
     });
     loadCatSegmentConcordanceMock.mockResolvedValue({
       glossaryTerms: [
-        { id: "glossary-1", source: "workspace", target: "espace de travail", approved: true },
+        {
+          id: "glossary-1",
+          source: "workspace",
+          target: "espace de travail",
+          approved: true,
+          forbidden: false,
+        },
       ],
       translationMemoryMatches: [
         {

--- a/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
@@ -8,16 +8,26 @@ import { db } from "@/lib/database";
 import { TmsProviderLiveError } from "@/lib/providers/tms-provider-live";
 
 import { createProjectTestFixture } from "./project.fixture";
-import type { ProjectFileCatResponse, ProjectFileCatTranslationResponse } from "./project.schema";
+import type {
+  ProjectFileCatConcordanceResponse,
+  ProjectFileCatResponse,
+  ProjectFileCatTranslationResponse,
+} from "./project.schema";
 
 const {
   getTmsProviderConnectionMock,
   getTmsProviderLiveCatFileMock,
   saveTmsProviderLiveCatTranslationMock,
+  loadCatSegmentConcordanceMock,
 } = vi.hoisted(() => ({
   getTmsProviderConnectionMock: vi.fn(),
   getTmsProviderLiveCatFileMock: vi.fn(),
   saveTmsProviderLiveCatTranslationMock: vi.fn(),
+  loadCatSegmentConcordanceMock: vi.fn(),
+}));
+
+vi.mock("@/lib/translation/load-cat-segment-concordance", () => ({
+  loadCatSegmentConcordance: (...args: unknown[]) => loadCatSegmentConcordanceMock(...args),
 }));
 
 vi.mock("@/lib/providers/tms-provider-live", async (importOriginal) => {
@@ -61,6 +71,62 @@ afterEach(async () => {
 });
 
 describe("project file CAT routes", () => {
+  it("returns Crowdin concordance matches for a CAT segment", async () => {
+    const translator = projectFixture.createWorkosIdentityWithRole("translator");
+    getTmsProviderConnectionMock.mockResolvedValue({
+      providerKind: "crowdin",
+      displayName: "Crowdin",
+      validationStatus: "valid",
+      validationMessage: null,
+    });
+    loadCatSegmentConcordanceMock.mockResolvedValue({
+      glossaryTerms: [
+        { id: "glossary-1", source: "workspace", target: "espace de travail", approved: true },
+      ],
+      translationMemoryMatches: [
+        {
+          id: "tm-1",
+          sourceText: "Hello",
+          targetText: "Bonjour",
+          matchPercent: 100,
+          contextLabel: "Website TM",
+        },
+      ],
+    });
+
+    const response = await client.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].files.detail.cat.concordance.$post(
+      {
+        param: {
+          organizationSlug: translator.organization.slug ?? "missing-slug",
+          projectId: "ext:crowdin:42",
+        },
+        json: {
+          sourceLocale: "en",
+          targetLocale: "fr",
+          sourceText: "Hello workspace",
+        },
+      },
+      { headers: await projectFixture.authHeadersFor(translator) },
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as ProjectFileCatConcordanceResponse;
+    expect(body.concordance.glossaryTerms).toHaveLength(1);
+    expect(body.concordance.translationMemoryMatches).toHaveLength(1);
+    expect(loadCatSegmentConcordanceMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "ext:crowdin:42",
+        providerKind: "crowdin",
+        externalProjectId: "42",
+        sourceLocale: "en",
+        targetLocale: "fr",
+        sourceText: "Hello workspace",
+      }),
+    );
+  });
+
   it("returns Crowdin CAT content for an encoded provider project", async () => {
     const translator = projectFixture.createWorkosIdentityWithRole("translator");
     getTmsProviderConnectionMock.mockResolvedValue({

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -43,6 +43,7 @@ import {
   createProjectBodySchema,
   maxProjectFileUploadBytes,
   projectFileCatQuerySchema,
+  projectFileCatConcordanceBodySchema,
   projectFileCatRecommendationBodySchema,
   projectFileCatStatusBodySchema,
   projectFileCatTranslationBodySchema,
@@ -78,6 +79,7 @@ import {
 } from "./project.shared";
 import { createJobRoutes } from "./job.route";
 import { generateCatAiRecommendation } from "@/lib/translation/generate-cat-ai-recommendation";
+import { loadCatSegmentConcordance } from "@/lib/translation/load-cat-segment-concordance";
 import { inferSupportedFileTranslationFileFormat } from "@/lib/translation/file-formats";
 
 type ProjectUpdateErrorCode =
@@ -305,6 +307,16 @@ const validateProjectFileCatQuery = validator("query", (value, c) => {
 
 const validateProjectFileCatTranslationBody = validator("json", (value, c) => {
   const parsed = projectFileCatTranslationBodySchema.safeParse(value);
+
+  if (!parsed.success) {
+    return invalidProjectPayloadResponse(c);
+  }
+
+  return parsed.data;
+});
+
+const validateProjectFileCatConcordanceBody = validator("json", (value, c) => {
+  const parsed = projectFileCatConcordanceBodySchema.safeParse(value);
 
   if (!parsed.success) {
     return invalidProjectPayloadResponse(c);
@@ -597,6 +609,42 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
       },
     )
     .post(
+      "/:projectId/files/detail/cat/concordance",
+      validateProjectParams,
+      validateProjectFileCatConcordanceBody,
+      async (c) => {
+        const params = c.req.valid("param");
+        const body = c.req.valid("json");
+        const target = await resolveProjectResourceTarget(c.var.auth, params.projectId);
+        if (target.kind === "provider_unavailable") {
+          return providerProjectUnavailableResponse(c, target);
+        }
+
+        if (target.kind === "native") {
+          const project = await getOwnedProject(c.var.auth, params.projectId);
+          if (!project) {
+            return projectNotFoundResponse(c);
+          }
+        }
+
+        try {
+          const concordance = await loadCatSegmentConcordance({
+            organizationId: c.var.auth.organization.localOrganizationId,
+            projectId: params.projectId,
+            providerKind: target.kind === "provider" ? target.providerKind : null,
+            externalProjectId: target.kind === "provider" ? target.externalProjectId : null,
+            sourceLocale: body.sourceLocale,
+            targetLocale: body.targetLocale,
+            sourceText: body.sourceText,
+          });
+
+          return c.json({ concordance }, 200);
+        } catch (error) {
+          return tmsProviderLiveErrorResponse(c, error);
+        }
+      },
+    )
+    .post(
       "/:projectId/files/detail/cat/recommendation",
       validateProjectParams,
       validateProjectFileCatRecommendationBody,
@@ -631,6 +679,8 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
           context: body.context ?? null,
           agentContext: body.agentContext ?? null,
           maxLength: body.maxLength,
+          glossaryTerms: body.glossaryTerms,
+          translationMemoryMatches: body.translationMemoryMatches,
         });
 
         if (isErr(result)) {

--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -395,6 +395,7 @@ export const projectFileCatConcordanceGlossaryTermSchema = z.object({
   source: z.string(),
   target: z.string(),
   approved: z.boolean(),
+  forbidden: z.boolean(),
 });
 
 export const projectFileCatConcordanceTranslationMemoryMatchSchema = z.object({

--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -362,6 +362,54 @@ export const projectFileCatRecommendationBodySchema = z.object({
   context: z.string().trim().max(16_384).nullable().optional(),
   agentContext: z.string().trim().max(16_384).nullable().optional(),
   maxLength: z.number().int().positive().optional(),
+  glossaryTerms: z
+    .array(
+      z.object({
+        sourceTerm: z.string(),
+        targetTerm: z.string(),
+        targetLocale: z.string(),
+        forbidden: z.boolean().nullable().optional(),
+        description: z.string().nullable().optional(),
+      }),
+    )
+    .optional(),
+  translationMemoryMatches: z
+    .array(
+      z.object({
+        sourceText: z.string(),
+        targetText: z.string(),
+        targetLocale: z.string(),
+      }),
+    )
+    .optional(),
+});
+
+export const projectFileCatConcordanceBodySchema = z.object({
+  sourceLocale: z.string().trim().min(1).max(32),
+  targetLocale: z.string().trim().min(1).max(32),
+  sourceText: z.string().min(1).max(100_000),
+});
+
+export const projectFileCatConcordanceGlossaryTermSchema = z.object({
+  id: z.string(),
+  source: z.string(),
+  target: z.string(),
+  approved: z.boolean(),
+});
+
+export const projectFileCatConcordanceTranslationMemoryMatchSchema = z.object({
+  id: z.string(),
+  sourceText: z.string(),
+  targetText: z.string(),
+  matchPercent: z.number(),
+  contextLabel: z.string().optional(),
+});
+
+export const projectFileCatConcordanceResponseSchema = z.object({
+  concordance: z.object({
+    glossaryTerms: z.array(projectFileCatConcordanceGlossaryTermSchema),
+    translationMemoryMatches: z.array(projectFileCatConcordanceTranslationMemoryMatchSchema),
+  }),
 });
 
 export const projectFileCatRecommendationResponseSchema = z.object({
@@ -427,6 +475,10 @@ export type ProjectFileCatQuery = z.infer<typeof projectFileCatQuerySchema>;
 export type ProjectFileCatTranslationBody = z.infer<typeof projectFileCatTranslationBodySchema>;
 export type ProjectFileCatRecommendationBody = z.infer<
   typeof projectFileCatRecommendationBodySchema
+>;
+export type ProjectFileCatConcordanceBody = z.infer<typeof projectFileCatConcordanceBodySchema>;
+export type ProjectFileCatConcordanceResponse = z.infer<
+  typeof projectFileCatConcordanceResponseSchema
 >;
 export type ProjectSourceStringEntry = z.infer<typeof projectSourceStringEntrySchema>;
 export type ProjectSourceStringsPreview = z.infer<typeof projectSourceStringsPreviewSchema>;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/tms-job-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/tms-job-cat-workspace.tsx
@@ -21,7 +21,7 @@ import type {
   CatSegmentIntelligence,
   CatWorkspaceState,
 } from "@/components/cat/types";
-import { mapCatConcordanceForAiRecommendation } from "@/lib/translation/load-cat-segment-concordance";
+import { mapCatConcordanceForAiRecommendation } from "@/lib/translation/map-cat-concordance-for-ai-recommendation";
 import { AlertCircleIcon } from "lucide-react";
 import { Spinner } from "@/components/ui/spinner";
 import { TypographyP } from "@/components/ui/typography";
@@ -379,7 +379,7 @@ export function TmsJobCatWorkspace({
   const generateAiRecommendation = useCallback(
     async (segment: CatSegment, targetText: string, intelligence?: CatSegmentIntelligence) => {
       const concordancePayload =
-        intelligence?.glossaryTerms || intelligence?.translationMemoryMatches
+        intelligence != null
           ? mapCatConcordanceForAiRecommendation(
               {
                 glossaryTerms: intelligence.glossaryTerms ?? [],

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/tms-job-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/tms-job-cat-workspace.tsx
@@ -4,6 +4,7 @@ import { useCallback, useMemo } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import type {
+  ProjectFileCatConcordanceResponse,
   ProjectFileCatRecommendationResponse,
   ProjectFileCatResponse,
   ProjectFileCatSegment,
@@ -20,6 +21,7 @@ import type {
   CatSegmentIntelligence,
   CatWorkspaceState,
 } from "@/components/cat/types";
+import { mapCatConcordanceForAiRecommendation } from "@/lib/translation/load-cat-segment-concordance";
 import { AlertCircleIcon } from "lucide-react";
 import { Spinner } from "@/components/ui/spinner";
 import { TypographyP } from "@/components/ui/typography";
@@ -352,8 +354,41 @@ export function TmsJobCatWorkspace({
     },
     [organizationSlug, projectId, repositoryFullName, sourcePath],
   );
+  const lookupSegmentConcordance = useCallback(
+    async (segment: CatSegment) => {
+      const response = await apiClient.api.orgs[":organizationSlug"].projects[
+        ":projectId"
+      ].files.detail.cat.concordance.$post({
+        param: { organizationSlug, projectId },
+        json: {
+          sourceLocale: segment.sourceLocale,
+          targetLocale: segment.targetLocale,
+          sourceText: segment.sourceText,
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(await readApiError(response, "Failed to search glossary and TM"));
+      }
+
+      const body = (await response.json()) as ProjectFileCatConcordanceResponse;
+      return body.concordance;
+    },
+    [organizationSlug, projectId],
+  );
   const generateAiRecommendation = useCallback(
     async (segment: CatSegment, targetText: string, intelligence?: CatSegmentIntelligence) => {
+      const concordancePayload =
+        intelligence?.glossaryTerms || intelligence?.translationMemoryMatches
+          ? mapCatConcordanceForAiRecommendation(
+              {
+                glossaryTerms: intelligence.glossaryTerms ?? [],
+                translationMemoryMatches: intelligence.translationMemoryMatches ?? [],
+              },
+              segment.targetLocale,
+            )
+          : {};
+
       const response = await apiClient.api.orgs[":organizationSlug"].projects[
         ":projectId"
       ].files.detail.cat.recommendation.$post({
@@ -368,6 +403,7 @@ export function TmsJobCatWorkspace({
           context: segment.contextLabel ?? intelligence?.productMeaning ?? null,
           agentContext: intelligence?.agentContext ?? null,
           maxLength: segment.maxLength,
+          ...concordancePayload,
         },
       });
 
@@ -419,6 +455,7 @@ export function TmsJobCatWorkspace({
       className={cn("min-h-0 flex-1", className)}
       services={{
         validateFormat: validateSegmentFormat,
+        lookupSegmentConcordance,
         generateAiRecommendation,
         ...(repositoryFullName ? { lookupSegmentContext } : {}),
       }}

--- a/apps/hyperlocalise-web/src/components/cat/cat-intelligence-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-intelligence-panel.tsx
@@ -42,6 +42,16 @@ function InsightCard({
   );
 }
 
+function ConcordanceSkeleton() {
+  return (
+    <div className="space-y-3 rounded-2xl bg-foreground/3 p-3.5">
+      <Skeleton className="h-4 w-32 rounded-full bg-foreground/8" />
+      <Skeleton className="h-4 w-full rounded-full bg-foreground/8" />
+      <Skeleton className="h-4 w-10/12 rounded-full bg-foreground/8" />
+    </div>
+  );
+}
+
 function AgentContextSkeleton() {
   return (
     <div className="space-y-3 rounded-2xl bg-foreground/3 p-3.5">
@@ -104,10 +114,12 @@ function TranslationMemoryRow({ match }: { match: CatTranslationMemoryMatch }) {
 export function CatIntelligencePanel({
   intelligence,
   isLookingUpContext = false,
+  isConcordanceLoading = false,
   showAgentContext = false,
 }: {
   intelligence: CatSegmentIntelligence;
   isLookingUpContext?: boolean;
+  isConcordanceLoading?: boolean;
   showAgentContext?: boolean;
 }) {
   const hasFileContext = Boolean(intelligence.productMeaning?.trim());
@@ -202,7 +214,18 @@ export function CatIntelligencePanel({
             </PanelSection>
           ) : null}
 
-          {intelligence.glossaryTerms.length > 0 ? (
+          {isConcordanceLoading ? (
+            <>
+              <PanelSection title="Glossary guidance">
+                <ConcordanceSkeleton />
+              </PanelSection>
+              <PanelSection title="Translation memory">
+                <ConcordanceSkeleton />
+              </PanelSection>
+            </>
+          ) : null}
+
+          {!isConcordanceLoading && intelligence.glossaryTerms.length > 0 ? (
             <PanelSection title="Glossary guidance">
               <div className="overflow-hidden rounded-2xl bg-foreground/3">
                 <ul className="divide-y divide-foreground/8">
@@ -214,7 +237,8 @@ export function CatIntelligencePanel({
             </PanelSection>
           ) : null}
 
-          {intelligence.translationMemoryMatches &&
+          {!isConcordanceLoading &&
+          intelligence.translationMemoryMatches &&
           intelligence.translationMemoryMatches.length > 0 ? (
             <PanelSection title="Translation memory">
               <div className="overflow-hidden rounded-2xl bg-foreground/3">

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
@@ -155,6 +155,23 @@ export function mergeCatWorkspaceState(
         agentContext: currentAgentContext,
       };
     }
+
+    const nextConcordance = nextInitialState.segmentIntelligence?.[segment.id];
+    const currentConcordance = currentState.segmentIntelligence?.[segment.id];
+    const hasCurrentConcordance =
+      (currentConcordance?.glossaryTerms.length ?? 0) > 0 ||
+      (currentConcordance?.translationMemoryMatches?.length ?? 0) > 0;
+    const hasNextConcordance =
+      (nextConcordance?.glossaryTerms.length ?? 0) > 0 ||
+      (nextConcordance?.translationMemoryMatches?.length ?? 0) > 0;
+    if (hasCurrentConcordance && !hasNextConcordance) {
+      segmentIntelligence[segment.id] = {
+        ...(segmentIntelligence[segment.id] ?? nextInitialState.intelligence),
+        ...currentState.segmentIntelligence?.[segment.id],
+        glossaryTerms: currentConcordance?.glossaryTerms ?? [],
+        translationMemoryMatches: currentConcordance?.translationMemoryMatches,
+      };
+    }
   }
 
   return {
@@ -205,6 +222,7 @@ export function CatWorkspaceContainer({
   const [isValidating, setIsValidating] = useState(false);
   const [isApproving, setIsApproving] = useState(false);
   const [isLookingUpContext, setIsLookingUpContext] = useState(false);
+  const [isLoadingConcordance, setIsLoadingConcordance] = useState(false);
   const [revealedAgentContextSegmentIds, setRevealedAgentContextSegmentIds] = useState<
     ReadonlySet<string>
   >(() => collectSegmentsWithAgentContext(initialState));
@@ -218,6 +236,7 @@ export function CatWorkspaceContainer({
   const validateFormat = serviceOverrides?.validateFormat;
   const runQaChecks = serviceOverrides?.runQaChecks;
   const lookupSegmentContext = serviceOverrides?.lookupSegmentContext;
+  const lookupSegmentConcordance = serviceOverrides?.lookupSegmentConcordance;
   const generateAiRecommendation = serviceOverrides?.generateAiRecommendation;
   const canLookupContext = Boolean(lookupSegmentContext);
   const canUseAiRecommendation = Boolean(generateAiRecommendation);
@@ -314,13 +333,84 @@ export function CatWorkspaceContainer({
       try {
         let recommendation: CatAiRecommendationResult | undefined;
         let aiFailureCheck: CatFormatCheck | undefined;
+        let intelligenceForRecommendation = currentIntelligence;
+
+        if (lookupSegmentConcordance) {
+          setIsLoadingConcordance(true);
+          try {
+            const concordance = await lookupSegmentConcordance(segment);
+            if (reviewSequenceRef.current !== sequence) {
+              return;
+            }
+
+            intelligenceForRecommendation = {
+              ...currentIntelligence,
+              glossaryTerms: concordance.glossaryTerms,
+              translationMemoryMatches: concordance.translationMemoryMatches,
+            };
+
+            setState((current) => {
+              const segmentIntelligence =
+                current.segmentIntelligence?.[segmentId] ?? current.intelligence;
+
+              return {
+                ...current,
+                segmentIntelligence: {
+                  ...current.segmentIntelligence,
+                  [segmentId]: {
+                    ...segmentIntelligence,
+                    glossaryTerms: concordance.glossaryTerms,
+                    translationMemoryMatches: concordance.translationMemoryMatches,
+                  },
+                },
+              };
+            });
+          } catch (error) {
+            if (reviewSequenceRef.current !== sequence) {
+              return;
+            }
+
+            const message =
+              error instanceof Error ? error.message : "Failed to search glossary and TM.";
+            const concordanceFailureCheck: CatFormatCheck = {
+              id: `concordance-failed-${segmentId}`,
+              label: "Concordance search",
+              status: "fail",
+              message,
+              category: "qa",
+            };
+
+            setState((current) => {
+              const currentChecks =
+                current.segmentFormatChecks?.[segmentId] ?? current.formatChecks;
+              const nextChecks = [
+                concordanceFailureCheck,
+                ...currentChecks.filter((check) => check.id !== concordanceFailureCheck.id),
+              ];
+
+              return {
+                ...current,
+                formatChecks:
+                  current.selectedSegmentId === segmentId ? nextChecks : current.formatChecks,
+                segmentFormatChecks: {
+                  ...current.segmentFormatChecks,
+                  [segmentId]: nextChecks,
+                },
+              };
+            });
+          } finally {
+            if (reviewSequenceRef.current === sequence) {
+              setIsLoadingConcordance(false);
+            }
+          }
+        }
 
         if (includeAi && generateAiRecommendation) {
           try {
             recommendation = await generateAiRecommendation(
               segment,
               segment.targetText,
-              currentIntelligence,
+              intelligenceForRecommendation,
             );
           } catch (error) {
             if (reviewSequenceRef.current !== sequence) {
@@ -390,7 +480,13 @@ export function CatWorkspaceContainer({
         }
       }
     },
-    [generateAiRecommendation, onReviewWithAi, runQaChecks, validateFormat],
+    [
+      generateAiRecommendation,
+      lookupSegmentConcordance,
+      onReviewWithAi,
+      runQaChecks,
+      validateFormat,
+    ],
   );
 
   const runSegmentReviewRef = useRef(runSegmentReview);
@@ -622,6 +718,7 @@ export function CatWorkspaceContainer({
       isValidating={isValidating}
       isApproving={isApproving}
       isLookingUpContext={isLookingUpContext}
+      isConcordanceLoading={isLoadingConcordance}
       isAiSuggestionLoading={
         isGeneratingAiRecommendation && isAiRecommendationEnabled && canUseAiRecommendation
       }

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace.tsx
@@ -40,6 +40,7 @@ export function CatWorkspaceView({
   isValidating: _isValidating = false,
   isApproving = false,
   isLookingUpContext = false,
+  isConcordanceLoading = false,
   isAiSuggestionLoading = false,
   isFormatChecksLoading = false,
   canLookupContext = false,
@@ -144,6 +145,7 @@ export function CatWorkspaceView({
       <CatIntelligencePanel
         intelligence={selectedSegmentIntelligence}
         isLookingUpContext={isLookingUpContext}
+        isConcordanceLoading={isConcordanceLoading}
         showAgentContext={showAgentContext}
       />
     );

--- a/apps/hyperlocalise-web/src/components/cat/cat.fixture.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat.fixture.ts
@@ -498,9 +498,15 @@ export const catIntelligenceFixture: CatSegmentIntelligence = {
   reviewerPreference: "Keep dashboard cards short, direct, and free of marketing tone.",
   constraints: "Short text · Max 2 lines on mobile",
   glossaryTerms: [
-    { id: "term-1", source: "Dashboard", target: "Bảng điều khiển", approved: true },
-    { id: "term-2", source: "Review", target: "Đánh giá", approved: true },
-    { id: "term-3", source: "Approval", target: "Phê duyệt", approved: true },
+    {
+      id: "term-1",
+      source: "Dashboard",
+      target: "Bảng điều khiển",
+      approved: true,
+      forbidden: false,
+    },
+    { id: "term-2", source: "Review", target: "Đánh giá", approved: true, forbidden: false },
+    { id: "term-3", source: "Approval", target: "Phê duyệt", approved: true, forbidden: false },
   ],
   translationMemoryMatches: [
     {

--- a/apps/hyperlocalise-web/src/components/cat/dependencies.ts
+++ b/apps/hyperlocalise-web/src/components/cat/dependencies.ts
@@ -1,8 +1,10 @@
 import type {
   CatFormatCheck,
+  CatGlossaryTerm,
   CatSegment,
   CatSegmentIntelligence,
   CatSegmentStatus,
+  CatTranslationMemoryMatch,
   CatWorkspaceState,
 } from "./types";
 
@@ -10,6 +12,11 @@ export interface CatAiRecommendationResult {
   aiSuggestion: string;
   aiReasoning?: string;
   formatChecks?: CatFormatCheck[];
+}
+
+export interface CatSegmentConcordanceResult {
+  glossaryTerms: CatGlossaryTerm[];
+  translationMemoryMatches: CatTranslationMemoryMatch[];
 }
 
 export interface CatWorkspaceNavigation {
@@ -38,6 +45,7 @@ export interface CatWorkspaceServices {
   validateFormat?: (segment: CatSegment, value: string) => Promise<CatFormatCheck[]>;
   runQaChecks?: (segment: CatSegment, value: string) => Promise<CatFormatCheck[]>;
   lookupSegmentContext?: (segment: CatSegment) => Promise<string>;
+  lookupSegmentConcordance?: (segment: CatSegment) => Promise<CatSegmentConcordanceResult>;
   generateAiRecommendation?: (
     segment: CatSegment,
     targetText: string,
@@ -65,6 +73,7 @@ export interface CatWorkspaceViewProps {
   isValidating?: boolean;
   isApproving?: boolean;
   isLookingUpContext?: boolean;
+  isConcordanceLoading?: boolean;
   isAiSuggestionLoading?: boolean;
   isFormatChecksLoading?: boolean;
   canLookupContext?: boolean;

--- a/apps/hyperlocalise-web/src/components/cat/types.ts
+++ b/apps/hyperlocalise-web/src/components/cat/types.ts
@@ -42,6 +42,7 @@ export interface CatGlossaryTerm {
   source: string;
   target: string;
   approved: boolean;
+  forbidden: boolean;
 }
 
 export interface CatTranslationMemoryMatch {

--- a/apps/hyperlocalise-web/src/components/marketing/hero-frame.tsx
+++ b/apps/hyperlocalise-web/src/components/marketing/hero-frame.tsx
@@ -386,12 +386,14 @@ const heroDemoState: CatWorkspaceState = {
         source: "globally",
         target: "à l'international",
         approved: true,
+        forbidden: false,
       },
       {
         id: "term-launch",
         source: "launch",
         target: "lancer",
         approved: true,
+        forbidden: false,
       },
     ],
     translationMemoryMatches: [
@@ -442,6 +444,7 @@ const heroDemoState: CatWorkspaceState = {
           source: "review",
           target: "validation",
           approved: true,
+          forbidden: false,
         },
       ],
       translationMemoryMatches: [

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-cat-concordance.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-cat-concordance.test.ts
@@ -64,4 +64,39 @@ describe("searchCrowdinCatConcordance", () => {
       memoryName: "Website TM",
     });
   });
+
+  it("maps forbidden Crowdin glossary term status into normalized term flags", async () => {
+    const client = {
+      glossaryConcordanceSearch: vi.fn().mockResolvedValue([
+        {
+          glossary: { id: 7, name: "Product terms" },
+          concept: {
+            id: 1,
+            subject: "",
+            definition: "",
+            translatable: true,
+            note: "",
+            url: "",
+            figure: "",
+          },
+          sourceTerms: [{ id: 11, languageId: "en", text: "workspace", status: "preferred" }],
+          targetTerms: [{ id: 12, languageId: "fr", text: "espace", status: "forbidden" }],
+        },
+      ]),
+      concordanceSearch: vi.fn().mockResolvedValue([]),
+    } as unknown as CrowdinApiClient;
+
+    const result = await searchCrowdinCatConcordance({
+      client,
+      externalProjectId: "42",
+      sourceLocale: "en",
+      targetLocale: "fr",
+      sourceText: "workspace",
+    });
+
+    expect(result.glossaryTerms[0]?.termStatus).toEqual({
+      forbidden: true,
+      preferred: false,
+    });
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-cat-concordance.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-cat-concordance.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { CrowdinApiClient } from "./crowdin-api";
+import { searchCrowdinCatConcordance } from "./crowdin-cat-concordance";
+
+describe("searchCrowdinCatConcordance", () => {
+  it("maps Crowdin glossary and TM concordance results without attached resource filtering", async () => {
+    const glossaryConcordanceSearch = vi.fn().mockResolvedValue([
+      {
+        glossary: { id: 7, name: "Product terms" },
+        concept: {
+          id: 1,
+          subject: "",
+          definition: "",
+          translatable: true,
+          note: "",
+          url: "",
+          figure: "",
+        },
+        sourceTerms: [{ id: 11, languageId: "en", text: "workspace", status: "preferred" }],
+        targetTerms: [{ id: 12, languageId: "fr", text: "espace de travail", status: "preferred" }],
+      },
+    ]);
+    const concordanceSearch = vi.fn().mockResolvedValue([
+      {
+        tm: { id: 3, name: "Website TM" },
+        recordId: 99,
+        source: "Sign in to your workspace",
+        target: "Connectez-vous a votre espace de travail",
+        relevant: 92,
+      },
+    ]);
+
+    const client = {
+      glossaryConcordanceSearch,
+      concordanceSearch,
+    } as unknown as CrowdinApiClient;
+
+    const result = await searchCrowdinCatConcordance({
+      client,
+      externalProjectId: "42",
+      sourceLocale: "en",
+      targetLocale: "fr",
+      sourceText: "Sign in to your workspace",
+    });
+
+    expect(glossaryConcordanceSearch).toHaveBeenCalledWith(42, {
+      sourceLanguageId: "en",
+      targetLanguageId: "fr",
+      expressions: ["Sign in to your workspace"],
+    });
+    expect(result.glossaryTerms).toHaveLength(1);
+    expect(result.glossaryTerms[0]).toMatchObject({
+      sourceTerm: "workspace",
+      targetTerm: "espace de travail",
+      glossaryName: "Product terms",
+      matchSource: "live_provider",
+    });
+    expect(result.translationMemoryMatches).toHaveLength(1);
+    expect(result.translationMemoryMatches[0]).toMatchObject({
+      sourceText: "Sign in to your workspace",
+      targetText: "Connectez-vous a votre espace de travail",
+      matchScore: 92,
+      memoryName: "Website TM",
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-cat-concordance.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-cat-concordance.ts
@@ -1,0 +1,139 @@
+import { createHash } from "node:crypto";
+
+import type { NormalizedGlossaryMatch } from "@/lib/providers/contracts/glossary-match";
+import { normalizeProviderGlossaryMatch } from "@/lib/providers/contracts/glossary-match";
+import type { NormalizedTranslationMemoryMatch } from "@/lib/providers/contracts/translation-memory-match";
+import { normalizeProviderTranslationMemoryMatch } from "@/lib/providers/contracts/translation-memory-match";
+
+import { CrowdinApiClient, CrowdinApiError } from "./crowdin-api";
+
+function stableConcordanceTermId(
+  glossaryId: string,
+  sourceTerm: string,
+  targetLocale: string,
+): string {
+  return createHash("sha256")
+    .update(`${glossaryId}\0${sourceTerm}\0${targetLocale}`, "utf8")
+    .digest("hex");
+}
+
+function pickTermText(
+  terms: Array<{ languageId: string; text: string }>,
+  locale: string,
+): string | null {
+  const match = terms.find((term) => term.languageId === locale);
+  return match?.text?.trim() ? match.text.trim() : null;
+}
+
+function pickTermStatus(
+  terms: Array<{ languageId: string; status?: string | null }>,
+  locale: string,
+): string | null {
+  const match = terms.find((term) => term.languageId === locale);
+  return match?.status ?? null;
+}
+
+export async function searchCrowdinCatConcordance(input: {
+  client: CrowdinApiClient;
+  externalProjectId: string;
+  sourceLocale: string;
+  targetLocale: string;
+  sourceText: string;
+  glossaryLimit?: number;
+  translationMemoryLimit?: number;
+}): Promise<{
+  glossaryTerms: NormalizedGlossaryMatch[];
+  translationMemoryMatches: NormalizedTranslationMemoryMatch[];
+}> {
+  const projectId = Number(input.externalProjectId);
+  if (Number.isNaN(projectId)) {
+    return { glossaryTerms: [], translationMemoryMatches: [] };
+  }
+
+  const glossaryLimit = input.glossaryLimit ?? 20;
+  const translationMemoryLimit = input.translationMemoryLimit ?? 10;
+
+  let glossaryResults: Awaited<ReturnType<CrowdinApiClient["glossaryConcordanceSearch"]>>;
+  let translationMemoryResults: Awaited<ReturnType<CrowdinApiClient["concordanceSearch"]>>;
+
+  try {
+    [glossaryResults, translationMemoryResults] = await Promise.all([
+      input.client.glossaryConcordanceSearch(projectId, {
+        sourceLanguageId: input.sourceLocale,
+        targetLanguageId: input.targetLocale,
+        expressions: [input.sourceText],
+      }),
+      input.client.concordanceSearch(projectId, {
+        sourceLanguageId: input.sourceLocale,
+        targetLanguageId: input.targetLocale,
+        expressions: [input.sourceText],
+        minRelevant: 50,
+        autoSubstitution: false,
+      }),
+    ]);
+  } catch (error) {
+    if (error instanceof CrowdinApiError && error.status === 401) {
+      throw new Error("crowdin_auth_invalid");
+    }
+    throw error;
+  }
+
+  const glossaryTerms: NormalizedGlossaryMatch[] = [];
+
+  for (const [index, result] of glossaryResults.entries()) {
+    const sourceTerm = pickTermText(result.sourceTerms, input.sourceLocale);
+    const targetTerm = pickTermText(result.targetTerms, input.targetLocale);
+    if (!sourceTerm || !targetTerm) {
+      continue;
+    }
+
+    const externalGlossaryId = String(result.glossary.id);
+    const status =
+      pickTermStatus(result.targetTerms, input.targetLocale) ??
+      pickTermStatus(result.sourceTerms, input.sourceLocale);
+    const providerTermId = result.sourceTerms[0]?.id ?? result.targetTerms[0]?.id;
+    const externalTermId =
+      providerTermId != null
+        ? String(providerTermId)
+        : stableConcordanceTermId(externalGlossaryId, sourceTerm, input.targetLocale);
+
+    glossaryTerms.push(
+      normalizeProviderGlossaryMatch({
+        sourceTerm,
+        targetTerm,
+        sourceLocale: input.sourceLocale,
+        targetLocale: input.targetLocale,
+        providerKind: "crowdin",
+        resourceId: externalGlossaryId,
+        externalResourceId: externalGlossaryId,
+        externalTermId,
+        glossaryName: result.glossary.name,
+        rank: 1 - index * 0.01,
+        status: { status },
+      }),
+    );
+  }
+
+  const translationMemoryMatches = translationMemoryResults
+    .slice(0, translationMemoryLimit)
+    .map((result, index) =>
+      normalizeProviderTranslationMemoryMatch({
+        sourceText: result.source,
+        targetText: result.target,
+        sourceLocale: input.sourceLocale,
+        targetLocale: input.targetLocale,
+        matchScore: result.relevant,
+        providerKind: "crowdin",
+        resourceId: String(result.tm.id),
+        externalResourceId: String(result.tm.id),
+        externalSegmentId: String(result.recordId),
+        memoryName: result.tm.name,
+        rank: 1 - index * 0.01,
+      }),
+    );
+
+  return {
+    glossaryTerms: glossaryTerms.slice(0, glossaryLimit),
+    translationMemoryMatches,
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-cat-concordance.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-cat-concordance.ts
@@ -4,8 +4,36 @@ import type { NormalizedGlossaryMatch } from "@/lib/providers/contracts/glossary
 import { normalizeProviderGlossaryMatch } from "@/lib/providers/contracts/glossary-match";
 import type { NormalizedTranslationMemoryMatch } from "@/lib/providers/contracts/translation-memory-match";
 import { normalizeProviderTranslationMemoryMatch } from "@/lib/providers/contracts/translation-memory-match";
+import { TmsProviderLiveError } from "@/lib/providers/tms-provider-live";
 
 import { CrowdinApiClient, CrowdinApiError } from "./crowdin-api";
+
+function rethrowCrowdinConcordanceApiError(error: unknown): never {
+  if (error instanceof CrowdinApiError) {
+    if (error.status === 401 || error.status === 403) {
+      throw new TmsProviderLiveError(
+        "crowdin_auth_invalid",
+        "Crowdin credentials are invalid or lack permission for this project.",
+      );
+    }
+    if (error.status === 404) {
+      throw new TmsProviderLiveError(
+        "invalid_crowdin_project_or_file_id",
+        "The Crowdin project could not be found.",
+      );
+    }
+    throw new TmsProviderLiveError(
+      "provider_fetch_failed",
+      "Failed to fetch glossary and translation memory from Crowdin.",
+    );
+  }
+
+  if (error instanceof Error && error.message === "crowdin_auth_invalid") {
+    throw new TmsProviderLiveError("crowdin_auth_invalid", "Crowdin credentials are invalid.");
+  }
+
+  throw error;
+}
 
 function stableConcordanceTermId(
   glossaryId: string,
@@ -72,10 +100,7 @@ export async function searchCrowdinCatConcordance(input: {
       }),
     ]);
   } catch (error) {
-    if (error instanceof CrowdinApiError && error.status === 401) {
-      throw new Error("crowdin_auth_invalid");
-    }
-    throw error;
+    rethrowCrowdinConcordanceApiError(error);
   }
 
   const glossaryTerms: NormalizedGlossaryMatch[] = [];

--- a/apps/hyperlocalise-web/src/lib/translation/assemble-translation-context.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/assemble-translation-context.ts
@@ -83,6 +83,7 @@ export async function assembleStringTranslationContextSnapshot(
     externalJobUid?: string | null;
     translationMemoryMatchResolution?: TranslationMemoryMatchResolution;
     glossaryMatchResolution?: GlossaryMatchResolution;
+    skipConcordance?: boolean;
   },
 ) {
   const project =
@@ -97,10 +98,32 @@ export async function assembleStringTranslationContextSnapshot(
 
   const providerKind = options?.providerKind ?? project.externalProviderKind ?? undefined;
 
+  const knowledgeMemoryPromise = getKnowledgeMemoryForOrganization(project.organizationId).then(
+    (memory) => memory.content.trim(),
+  );
+
+  if (options?.skipConcordance) {
+    const knowledgeMemory = await knowledgeMemoryPromise;
+
+    return {
+      ok: true,
+      snapshot: {
+        assembledAt: new Date().toISOString(),
+        project: {
+          id: project.id,
+          name: project.name,
+          translationContext: project.translationContext,
+        },
+        job: jobInput,
+        glossaryTerms: [],
+        translationMemoryMatches: [],
+        ...(knowledgeMemory ? { knowledgeMemory } : {}),
+      } satisfies StringTranslationContextSnapshot,
+    } as const;
+  }
+
   const [knowledgeMemory, glossaryTerms, translationMemoryMatches] = await Promise.all([
-    getKnowledgeMemoryForOrganization(project.organizationId).then((memory) =>
-      memory.content.trim(),
-    ),
+    knowledgeMemoryPromise,
     loadGlossaryMatchesForContext({
       projectId,
       organizationId: options?.organizationId,

--- a/apps/hyperlocalise-web/src/lib/translation/generate-cat-ai-recommendation.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/generate-cat-ai-recommendation.ts
@@ -5,6 +5,10 @@ import { err, ok, type Result } from "@/lib/primitives/result/results";
 
 import { assembleStringTranslationContextSnapshot } from "./assemble-translation-context";
 import { loadOrganizationTranslationModel } from "./load-organization-translation-generator";
+import {
+  defaultGlossaryMatchResolution,
+  defaultTranslationMemoryMatchResolution,
+} from "@/lib/providers/match-resolution";
 
 const catAiRecommendationOutputSchema = z.object({
   suggestion: z.string().refine((text) => text.trim().length > 0, {
@@ -28,6 +32,18 @@ export type CatAiRecommendationInput = {
   context?: string | null;
   agentContext?: string | null;
   maxLength?: number;
+  glossaryTerms?: Array<{
+    sourceTerm: string;
+    targetTerm: string;
+    targetLocale: string;
+    forbidden?: boolean | null;
+    description?: string | null;
+  }>;
+  translationMemoryMatches?: Array<{
+    sourceText: string;
+    targetText: string;
+    targetLocale: string;
+  }>;
 };
 
 export type CatAiRecommendationResult = {
@@ -199,6 +215,9 @@ export async function generateCatAiRecommendation(
     });
   }
 
+  const hasPreloadedConcordance =
+    input.glossaryTerms !== undefined || input.translationMemoryMatches !== undefined;
+
   const contextResult = await assembleStringTranslationContextSnapshot(
     input.projectId,
     {
@@ -215,6 +234,9 @@ export async function generateCatAiRecommendation(
     undefined,
     {
       organizationId: input.organizationId,
+      glossaryMatchResolution: defaultGlossaryMatchResolution,
+      translationMemoryMatchResolution: defaultTranslationMemoryMatchResolution,
+      skipConcordance: hasPreloadedConcordance,
     },
   );
 
@@ -230,8 +252,9 @@ export async function generateCatAiRecommendation(
       projectName: contextResult.snapshot.project.name,
       projectTranslationContext: contextResult.snapshot.project.translationContext,
       knowledgeMemory: contextResult.snapshot.knowledgeMemory,
-      glossaryTerms: contextResult.snapshot.glossaryTerms,
-      translationMemoryMatches: contextResult.snapshot.translationMemoryMatches,
+      glossaryTerms: input.glossaryTerms ?? contextResult.snapshot.glossaryTerms,
+      translationMemoryMatches:
+        input.translationMemoryMatches ?? contextResult.snapshot.translationMemoryMatches,
     });
 
     return ok(recommendation);

--- a/apps/hyperlocalise-web/src/lib/translation/load-cat-segment-concordance.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/load-cat-segment-concordance.ts
@@ -1,0 +1,161 @@
+import type { CatGlossaryTerm, CatTranslationMemoryMatch } from "@/components/cat/types";
+import { searchCrowdinCatConcordance } from "@/lib/providers/adapters/crowdin/crowdin-cat-concordance";
+import { CrowdinApiClient } from "@/lib/providers/adapters/crowdin/crowdin-api";
+import type { ExternalTmsProviderKind } from "@/lib/providers/contracts/external-tms-provider-kind";
+import type { NormalizedGlossaryMatch } from "@/lib/providers/contracts/glossary-match";
+import type { NormalizedTranslationMemoryMatch } from "@/lib/providers/contracts/translation-memory-match";
+import {
+  defaultGlossaryMatchResolution,
+  defaultTranslationMemoryMatchResolution,
+} from "@/lib/providers/match-resolution";
+import { getActiveOrganizationExternalTmsProviderCredentialRow } from "@/lib/providers/organization-external-tms-provider-credentials";
+import {
+  decryptProviderCredential,
+  unwrapProviderCredentialCrypto,
+} from "@/lib/security/provider-credential-crypto";
+import { loadGlossaryMatchesForContext } from "@/lib/translation/load-glossary-matches";
+import { loadTranslationMemoryMatchesForContext } from "@/lib/translation/load-translation-memory-matches";
+
+import type { CatAiRecommendationInput } from "./generate-cat-ai-recommendation";
+
+export type CatSegmentConcordance = {
+  glossaryTerms: CatGlossaryTerm[];
+  translationMemoryMatches: CatTranslationMemoryMatch[];
+};
+
+function toCatGlossaryTerm(match: NormalizedGlossaryMatch): CatGlossaryTerm {
+  return {
+    id: match.id,
+    source: match.sourceTerm,
+    target: match.targetTerm,
+    approved: match.termStatus.preferred,
+  };
+}
+
+function toCatTranslationMemoryMatch(
+  match: NormalizedTranslationMemoryMatch,
+): CatTranslationMemoryMatch {
+  return {
+    id: match.id,
+    sourceText: match.sourceText,
+    targetText: match.targetText,
+    matchPercent: match.matchScore ?? 0,
+    contextLabel: match.memoryName,
+  };
+}
+
+async function loadCrowdinLiveConcordance(input: {
+  organizationId: string;
+  externalProjectId: string;
+  sourceLocale: string;
+  targetLocale: string;
+  sourceText: string;
+}): Promise<{
+  glossaryTerms: NormalizedGlossaryMatch[];
+  translationMemoryMatches: NormalizedTranslationMemoryMatch[];
+}> {
+  const credential = await getActiveOrganizationExternalTmsProviderCredentialRow(
+    input.organizationId,
+  );
+  if (!credential || credential.providerKind !== "crowdin") {
+    return { glossaryTerms: [], translationMemoryMatches: [] };
+  }
+
+  const secretMaterial = unwrapProviderCredentialCrypto(
+    decryptProviderCredential({
+      algorithm: credential.encryptionAlgorithm,
+      keyVersion: credential.keyVersion,
+      ciphertext: credential.ciphertext,
+      iv: credential.iv,
+      authTag: credential.authTag,
+    }),
+  );
+
+  const client = new CrowdinApiClient({
+    token: secretMaterial,
+    baseUrl: credential.baseUrl ?? undefined,
+  });
+
+  return searchCrowdinCatConcordance({
+    client,
+    externalProjectId: input.externalProjectId,
+    sourceLocale: input.sourceLocale,
+    targetLocale: input.targetLocale,
+    sourceText: input.sourceText,
+  });
+}
+
+export async function loadCatSegmentConcordance(input: {
+  organizationId: string;
+  projectId: string;
+  providerKind?: ExternalTmsProviderKind | null;
+  externalProjectId?: string | null;
+  sourceLocale: string;
+  targetLocale: string;
+  sourceText: string;
+}): Promise<CatSegmentConcordance> {
+  if (input.providerKind === "crowdin" && input.externalProjectId) {
+    const liveMatches = await loadCrowdinLiveConcordance({
+      organizationId: input.organizationId,
+      externalProjectId: input.externalProjectId,
+      sourceLocale: input.sourceLocale,
+      targetLocale: input.targetLocale,
+      sourceText: input.sourceText,
+    });
+
+    return {
+      glossaryTerms: liveMatches.glossaryTerms.map(toCatGlossaryTerm),
+      translationMemoryMatches: liveMatches.translationMemoryMatches.map(
+        toCatTranslationMemoryMatch,
+      ),
+    };
+  }
+
+  const [glossaryMatches, translationMemoryMatches] = await Promise.all([
+    loadGlossaryMatchesForContext({
+      projectId: input.projectId,
+      organizationId: input.organizationId,
+      providerKind: input.providerKind ?? undefined,
+      sourceLocale: input.sourceLocale,
+      targetLocales: [input.targetLocale],
+      sourceText: input.sourceText,
+      glossaryMatchResolution: defaultGlossaryMatchResolution,
+    }),
+    loadTranslationMemoryMatchesForContext({
+      projectId: input.projectId,
+      organizationId: input.organizationId,
+      providerKind: input.providerKind ?? undefined,
+      sourceLocale: input.sourceLocale,
+      targetLocales: [input.targetLocale],
+      sourceText: input.sourceText,
+      translationMemoryMatchResolution: defaultTranslationMemoryMatchResolution,
+    }),
+  ]);
+
+  return {
+    glossaryTerms: glossaryMatches.map((match) => toCatGlossaryTerm(match)),
+    translationMemoryMatches: translationMemoryMatches.map((match) =>
+      toCatTranslationMemoryMatch(match),
+    ),
+  };
+}
+
+export function mapCatConcordanceForAiRecommendation(
+  concordance: CatSegmentConcordance,
+  targetLocale: string,
+): Pick<CatAiRecommendationInput, "glossaryTerms" | "translationMemoryMatches"> {
+  return {
+    glossaryTerms: concordance.glossaryTerms.map((term) => ({
+      sourceTerm: term.source,
+      targetTerm: term.target,
+      targetLocale,
+      forbidden: term.approved ? false : null,
+      description: null,
+    })),
+    translationMemoryMatches: concordance.translationMemoryMatches.map((match) => ({
+      sourceText: match.sourceText,
+      targetText: match.targetText,
+      targetLocale,
+    })),
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/translation/load-cat-segment-concordance.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/load-cat-segment-concordance.ts
@@ -16,7 +16,8 @@ import {
 import { loadGlossaryMatchesForContext } from "@/lib/translation/load-glossary-matches";
 import { loadTranslationMemoryMatchesForContext } from "@/lib/translation/load-translation-memory-matches";
 
-import type { CatAiRecommendationInput } from "./generate-cat-ai-recommendation";
+export type { CatConcordanceForAiRecommendation } from "./map-cat-concordance-for-ai-recommendation";
+export { mapCatConcordanceForAiRecommendation } from "./map-cat-concordance-for-ai-recommendation";
 
 export type CatSegmentConcordance = {
   glossaryTerms: CatGlossaryTerm[];
@@ -29,6 +30,7 @@ function toCatGlossaryTerm(match: NormalizedGlossaryMatch): CatGlossaryTerm {
     source: match.sourceTerm,
     target: match.targetTerm,
     approved: match.termStatus.preferred,
+    forbidden: match.termStatus.forbidden,
   };
 }
 
@@ -137,25 +139,5 @@ export async function loadCatSegmentConcordance(input: {
     translationMemoryMatches: translationMemoryMatches.map((match) =>
       toCatTranslationMemoryMatch(match),
     ),
-  };
-}
-
-export function mapCatConcordanceForAiRecommendation(
-  concordance: CatSegmentConcordance,
-  targetLocale: string,
-): Pick<CatAiRecommendationInput, "glossaryTerms" | "translationMemoryMatches"> {
-  return {
-    glossaryTerms: concordance.glossaryTerms.map((term) => ({
-      sourceTerm: term.source,
-      targetTerm: term.target,
-      targetLocale,
-      forbidden: term.approved ? false : null,
-      description: null,
-    })),
-    translationMemoryMatches: concordance.translationMemoryMatches.map((match) => ({
-      sourceText: match.sourceText,
-      targetText: match.targetText,
-      targetLocale,
-    })),
   };
 }

--- a/apps/hyperlocalise-web/src/lib/translation/map-cat-concordance-for-ai-recommendation.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/map-cat-concordance-for-ai-recommendation.ts
@@ -1,0 +1,28 @@
+import type { CatGlossaryTerm, CatTranslationMemoryMatch } from "@/components/cat/types";
+
+import type { CatAiRecommendationInput } from "./generate-cat-ai-recommendation";
+
+export type CatConcordanceForAiRecommendation = {
+  glossaryTerms: CatGlossaryTerm[];
+  translationMemoryMatches: CatTranslationMemoryMatch[];
+};
+
+export function mapCatConcordanceForAiRecommendation(
+  concordance: CatConcordanceForAiRecommendation,
+  targetLocale: string,
+): Pick<CatAiRecommendationInput, "glossaryTerms" | "translationMemoryMatches"> {
+  return {
+    glossaryTerms: concordance.glossaryTerms.map((term) => ({
+      sourceTerm: term.source,
+      targetTerm: term.target,
+      targetLocale,
+      forbidden: term.forbidden,
+      description: null,
+    })),
+    translationMemoryMatches: concordance.translationMemoryMatches.map((match) => ({
+      sourceText: match.sourceText,
+      targetText: match.targetText,
+      targetLocale,
+    })),
+  };
+}


### PR DESCRIPTION
## What changed

Adds Crowdin glossary and translation memory concordance search to the CAT tool. When a reviewer selects a string, the workspace fetches concordance matches from Crowdin, shows them in the intelligence panel, and only then generates the AI recommendation using those resolved matches (avoiding duplicate Crowdin API calls).

## How to test

- Open a Crowdin TMS job CAT workspace and select a segment
- Confirm glossary and TM matches load in the Translation Intelligence panel before the AI suggestion appears
- Verify AI recommendations reflect concordance terminology when matches exist
- Run targeted tests:
  - `cd apps/hyperlocalise-web && vp test src/api/routes/project/project-cat.route.test.ts src/lib/providers/adapters/crowdin/crowdin-cat-concordance.test.ts`
  - `cd apps/hyperlocalise-web && vp check`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)