### PR TITLE
fix(web): use Crowdin remove+add for approved CAT saves

### DIFF
--- a/apps/hyperlocalise-web/src/components/cat/cat-editor-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-editor-panel.tsx
@@ -7,10 +7,8 @@ import { useHotkeys } from "react-hotkeys-hook";
 
 import { Button } from "@/components/ui/button";
 import { Kbd, KbdGroup } from "@/components/ui/kbd";
-import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
-import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/primitives/cn";
 
@@ -52,14 +50,12 @@ export function CatEditorPanel({
   canApprove = true,
   canLookupContext = false,
   canUseAiRecommendation = false,
-  isAiRecommendationEnabled = true,
   onTargetChange,
   onUseAiSuggestion,
   onApprove,
   primaryActionLabel = "Approve",
   onAskQuestion,
-  onRetryAiRecommendation,
-  onAiRecommendationEnabledChange,
+  onGenerateAiRecommendation,
   aiRecommendationError,
   onPrevious,
   onNext,
@@ -79,14 +75,12 @@ export function CatEditorPanel({
   canApprove?: boolean;
   canLookupContext?: boolean;
   canUseAiRecommendation?: boolean;
-  isAiRecommendationEnabled?: boolean;
   onTargetChange: (value: string) => void;
   onUseAiSuggestion: () => void;
   onApprove: () => void;
   primaryActionLabel?: string;
   onAskQuestion: () => void;
-  onRetryAiRecommendation?: () => void;
-  onAiRecommendationEnabledChange: (enabled: boolean) => void;
+  onGenerateAiRecommendation?: () => void;
   aiRecommendationError?: string;
   onPrevious: () => void;
   onNext: () => void;
@@ -196,27 +190,9 @@ export function CatEditorPanel({
       <div className="min-h-0 flex-1 overflow-y-auto">
         <div className="mx-auto max-w-3xl space-y-6 px-4 py-5 sm:px-6 lg:space-y-7 lg:px-8 lg:py-8">
           <section className="space-y-3">
-            <div className="flex items-center justify-between gap-3">
-              <h3 className="text-xs font-medium text-muted-foreground">
-                Source ({segment.sourceLocale})
-              </h3>
-              {canUseAiRecommendation ? (
-                <div className="flex items-center gap-2">
-                  <Label
-                    htmlFor={`ai-recommendation-${segment.id}`}
-                    className="text-xs font-normal text-muted-foreground"
-                  >
-                    AI recommendations
-                  </Label>
-                  <Switch
-                    id={`ai-recommendation-${segment.id}`}
-                    checked={isAiRecommendationEnabled}
-                    onCheckedChange={onAiRecommendationEnabledChange}
-                    aria-label="AI recommendations"
-                  />
-                </div>
-              ) : null}
-            </div>
+            <h3 className="text-xs font-medium text-muted-foreground">
+              Source ({segment.sourceLocale})
+            </h3>
             <p className="text-pretty text-base leading-relaxed text-foreground/92 lg:text-lg">
               <CatMessagePreview message={segment.sourceText} />
             </p>
@@ -294,66 +270,67 @@ export function CatEditorPanel({
             </Button>
           </div>
 
-          {isAiRecommendationEnabled && isAiSuggestionLoading ? (
-            <aside className="space-y-3 rounded-xl border border-foreground/8 bg-foreground/2 p-4">
-              <div className="flex items-center justify-between gap-3">
-                <Skeleton className="h-3 w-28 rounded-full bg-foreground/8" />
-                <Skeleton className="h-8 w-12 rounded-md bg-foreground/8" />
-              </div>
-              <div className="space-y-2">
-                <Skeleton className="h-4 w-11/12 rounded-full bg-foreground/8" />
-                <Skeleton className="h-4 w-8/12 rounded-full bg-foreground/8" />
-              </div>
-              <Skeleton className="h-3 w-10/12 rounded-full bg-foreground/8" />
-            </aside>
-          ) : isAiRecommendationEnabled && canUseAiRecommendation ? (
-            <aside
-              className={cn(
-                "border-l pl-4",
-                intelligence.aiSuggestion ? "border-grove-300/40" : "border-foreground/12",
-              )}
-            >
-              <div className="mb-2 flex items-center justify-between gap-3">
-                <p className="text-xs font-medium text-muted-foreground">AI recommendation</p>
-                <div className="flex items-center gap-1">
-                  {intelligence.aiSuggestion ? (
-                    <Button variant="ghost" size="sm" onClick={onUseAiSuggestion}>
-                      Use
-                    </Button>
-                  ) : null}
-                  {onRetryAiRecommendation ? (
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={onRetryAiRecommendation}
-                      disabled={isAiSuggestionLoading}
-                    >
-                      {isAiSuggestionLoading ? <Spinner className="size-4" /> : null}
-                      Retry
-                    </Button>
-                  ) : null}
+          {canUseAiRecommendation ? (
+            isAiSuggestionLoading ? (
+              <aside className="space-y-3 rounded-xl border border-foreground/8 bg-foreground/2 p-4">
+                <div className="flex items-center justify-between gap-3">
+                  <Skeleton className="h-3 w-28 rounded-full bg-foreground/8" />
+                  <Skeleton className="h-8 w-12 rounded-md bg-foreground/8" />
                 </div>
-              </div>
-              {aiRecommendationError ? (
-                <p className="text-sm leading-relaxed text-flame-100">{aiRecommendationError}</p>
-              ) : intelligence.aiSuggestion ? (
-                <>
-                  <p className="text-sm leading-relaxed text-foreground/88">
-                    {intelligence.aiSuggestion}
-                  </p>
-                  {intelligence.aiReasoning ? (
-                    <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
-                      <span className="font-medium text-foreground/70">Reasoning:</span>{" "}
-                      {intelligence.aiReasoning}
+                <div className="space-y-2">
+                  <Skeleton className="h-4 w-11/12 rounded-full bg-foreground/8" />
+                  <Skeleton className="h-4 w-8/12 rounded-full bg-foreground/8" />
+                </div>
+                <Skeleton className="h-3 w-10/12 rounded-full bg-foreground/8" />
+              </aside>
+            ) : (
+              <aside
+                className={cn(
+                  "border-l pl-4",
+                  intelligence.aiSuggestion ? "border-grove-300/40" : "border-foreground/12",
+                )}
+              >
+                <div className="mb-2 flex items-center justify-between gap-3">
+                  <p className="text-xs font-medium text-muted-foreground">AI recommendation</p>
+                  <div className="flex items-center gap-1">
+                    {intelligence.aiSuggestion ? (
+                      <Button variant="ghost" size="sm" onClick={onUseAiSuggestion}>
+                        Use
+                      </Button>
+                    ) : null}
+                    {onGenerateAiRecommendation ? (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={onGenerateAiRecommendation}
+                        disabled={isAiSuggestionLoading}
+                      >
+                        {intelligence.aiSuggestion ? "Regenerate" : "Get recommendation"}
+                      </Button>
+                    ) : null}
+                  </div>
+                </div>
+                {aiRecommendationError ? (
+                  <p className="text-sm leading-relaxed text-flame-100">{aiRecommendationError}</p>
+                ) : intelligence.aiSuggestion ? (
+                  <>
+                    <p className="text-sm leading-relaxed text-foreground/88">
+                      {intelligence.aiSuggestion}
                     </p>
-                  ) : null}
-                </>
-              ) : (
-                <p className="text-sm text-muted-foreground">
-                  No recommendation yet. Retry to generate one for this string.
-                </p>
-              )}
-            </aside>
+                    {intelligence.aiReasoning ? (
+                      <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+                        <span className="font-medium text-foreground/70">Reasoning:</span>{" "}
+                        {intelligence.aiReasoning}
+                      </p>
+                    ) : null}
+                  </>
+                ) : (
+                  <p className="text-sm text-muted-foreground">
+                    Generate a translation suggestion for this string.
+                  </p>
+                )}
+              </aside>
+            )
           ) : null}
 
           <section className="space-y-3">

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
@@ -227,6 +227,7 @@ export function CatWorkspaceContainer({
     ReadonlySet<string>
   >(() => collectSegmentsWithAgentContext(initialState));
   const [isGeneratingAiRecommendation, setIsGeneratingAiRecommendation] = useState(false);
+  const [isRunningFormatChecks, setIsRunningFormatChecks] = useState(false);
   const stateRef = useRef(state);
   const previousInitialStateRef = useRef(initialState);
   const validationSequenceRef = useRef(0);
@@ -321,7 +322,12 @@ export function CatWorkspaceContainer({
 
       const sequence = reviewSequenceRef.current + 1;
       reviewSequenceRef.current = sequence;
-      setIsGeneratingAiRecommendation(true);
+      if (includeAi) {
+        setIsGeneratingAiRecommendation(true);
+      }
+      if (includeFormatChecks) {
+        setIsRunningFormatChecks(true);
+      }
       try {
         let recommendation: CatAiRecommendationResult | undefined;
         let aiFailureCheck: CatFormatCheck | undefined;
@@ -468,7 +474,12 @@ export function CatWorkspaceContainer({
         });
       } finally {
         if (reviewSequenceRef.current === sequence) {
-          setIsGeneratingAiRecommendation(false);
+          if (includeAi) {
+            setIsGeneratingAiRecommendation(false);
+          }
+          if (includeFormatChecks) {
+            setIsRunningFormatChecks(false);
+          }
         }
       }
     },
@@ -705,7 +716,7 @@ export function CatWorkspaceContainer({
       isLookingUpContext={isLookingUpContext}
       isConcordanceLoading={isLoadingConcordance}
       isAiSuggestionLoading={isGeneratingAiRecommendation && canUseAiRecommendation}
-      isFormatChecksLoading={isGeneratingAiRecommendation || isValidating}
+      isFormatChecksLoading={isRunningFormatChecks || isValidating}
       canLookupContext={canLookupContext}
       showAgentContext={revealedAgentContextSegmentIds.has(state.selectedSegmentId)}
       canUseAiRecommendation={canUseAiRecommendation}

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
@@ -227,12 +227,10 @@ export function CatWorkspaceContainer({
     ReadonlySet<string>
   >(() => collectSegmentsWithAgentContext(initialState));
   const [isGeneratingAiRecommendation, setIsGeneratingAiRecommendation] = useState(false);
-  const [isAiRecommendationEnabled, setIsAiRecommendationEnabled] = useState(true);
   const stateRef = useRef(state);
   const previousInitialStateRef = useRef(initialState);
   const validationSequenceRef = useRef(0);
   const reviewSequenceRef = useRef(0);
-  const isAiRecommendationEnabledRef = useRef(isAiRecommendationEnabled);
   const validateFormat = serviceOverrides?.validateFormat;
   const runQaChecks = serviceOverrides?.runQaChecks;
   const lookupSegmentContext = serviceOverrides?.lookupSegmentContext;
@@ -255,10 +253,6 @@ export function CatWorkspaceContainer({
   useEffect(() => {
     stateRef.current = state;
   }, [state]);
-
-  useEffect(() => {
-    isAiRecommendationEnabledRef.current = isAiRecommendationEnabled;
-  }, [isAiRecommendationEnabled]);
 
   useEffect(() => {
     setState((current) =>
@@ -315,9 +309,7 @@ export function CatWorkspaceContainer({
         return;
       }
 
-      const includeAi =
-        (options?.includeAi ?? isAiRecommendationEnabledRef.current) &&
-        Boolean(generateAiRecommendation);
+      const includeAi = options?.includeAi === true && Boolean(generateAiRecommendation);
       const includeFormatChecks = Boolean(validateFormat || runQaChecks);
 
       if (!includeAi && !includeFormatChecks) {
@@ -498,15 +490,8 @@ export function CatWorkspaceContainer({
       return;
     }
 
-    void runSegmentReviewRef.current(segmentId);
+    void runSegmentReviewRef.current(segmentId, { includeAi: false });
   }, [state.selectedSegmentId, canRunSegmentReview]);
-
-  function handleAiRecommendationEnabledChange(enabled: boolean) {
-    setIsAiRecommendationEnabled(enabled);
-    if (enabled && state.selectedSegmentId && canUseAiRecommendation) {
-      void runSegmentReview(state.selectedSegmentId, { includeAi: true });
-    }
-  }
 
   const dependencies = useMemo<CatWorkspaceDependencies>(() => {
     const navigation = {
@@ -719,15 +704,11 @@ export function CatWorkspaceContainer({
       isApproving={isApproving}
       isLookingUpContext={isLookingUpContext}
       isConcordanceLoading={isLoadingConcordance}
-      isAiSuggestionLoading={
-        isGeneratingAiRecommendation && isAiRecommendationEnabled && canUseAiRecommendation
-      }
+      isAiSuggestionLoading={isGeneratingAiRecommendation && canUseAiRecommendation}
       isFormatChecksLoading={isGeneratingAiRecommendation || isValidating}
       canLookupContext={canLookupContext}
       showAgentContext={revealedAgentContextSegmentIds.has(state.selectedSegmentId)}
       canUseAiRecommendation={canUseAiRecommendation}
-      isAiRecommendationEnabled={isAiRecommendationEnabled}
-      onAiRecommendationEnabledChange={handleAiRecommendationEnabledChange}
       className={className}
     />
   );

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace.tsx
@@ -46,8 +46,6 @@ export function CatWorkspaceView({
   canLookupContext = false,
   canUseAiRecommendation = false,
   showAgentContext = false,
-  isAiRecommendationEnabled = true,
-  onAiRecommendationEnabledChange,
   className,
 }: CatWorkspaceViewProps) {
   const selectedSegmentIndex = state.segments.findIndex(
@@ -105,17 +103,15 @@ export function CatWorkspaceView({
         canApprove={canApprove}
         canLookupContext={canLookupContext}
         canUseAiRecommendation={canUseAiRecommendation}
-        isAiRecommendationEnabled={isAiRecommendationEnabled}
         onTargetChange={(value) => editing.onTargetChange(selectedSegment.id, value)}
         onUseAiSuggestion={() => editing.onUseAiSuggestion(selectedSegment.id)}
         onApprove={() => void review.onApprove(selectedSegment.id, selectedSegment.targetText)}
         primaryActionLabel={state.primaryActionLabel}
         onAskQuestion={() => review.onAskQuestion(selectedSegment.id)}
-        onRetryAiRecommendation={
+        onGenerateAiRecommendation={
           canUseAiRecommendation ? () => void review.onReviewWithAi(selectedSegment.id) : undefined
         }
         aiRecommendationError={aiRecommendationError}
-        onAiRecommendationEnabledChange={onAiRecommendationEnabledChange}
         onPrevious={navigation.onPreviousSegment}
         onNext={navigation.onNextSegment}
         hasPreviousSegment={hasPreviousSegment}

--- a/apps/hyperlocalise-web/src/components/cat/dependencies.ts
+++ b/apps/hyperlocalise-web/src/components/cat/dependencies.ts
@@ -79,8 +79,6 @@ export interface CatWorkspaceViewProps {
   canLookupContext?: boolean;
   canUseAiRecommendation?: boolean;
   showAgentContext?: boolean;
-  isAiRecommendationEnabled?: boolean;
-  onAiRecommendationEnabledChange: (enabled: boolean) => void;
   className?: string;
 }
 

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
@@ -790,6 +790,111 @@ describe("CrowdinApiClient", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("updates unapproved string translations", async () => {
+    const fetchMock = vi.fn(async (url, init) => {
+      const path = String(url);
+
+      if (path.endsWith("/projects/1/translations") && init?.method === "POST") {
+        return new Response(
+          JSON.stringify({
+            data: {
+              id: 9001,
+              stringId: 1001,
+              languageId: "fr",
+              text: "Bonjour",
+              createdAt: "2026-06-08T00:00:00Z",
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.endsWith("/projects/1/translations") && init?.method === "PATCH") {
+        expect(JSON.parse(String(init.body))).toEqual([
+          { op: "replace", path: "/9001/text", value: "Salut" },
+        ]);
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  id: 9001,
+                  stringId: 1001,
+                  languageId: "fr",
+                  text: "Salut",
+                  createdAt: "2026-06-08T00:01:00Z",
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    const added = await client.addTranslation(1, {
+      stringId: 1001,
+      languageId: "fr",
+      text: "Bonjour",
+    });
+    const updated = await client.updateTranslation(1, 9001, "Salut");
+
+    expect(added).toMatchObject({ id: 9001, text: "Bonjour" });
+    expect(updated).toMatchObject({ id: 9001, text: "Salut" });
+  });
+
+  it("fails translation updates when Crowdin returns no updated item", async () => {
+    const fetchMock = vi.fn(
+      async () => new Response(JSON.stringify({ data: [] }), { status: 200 }),
+    );
+    const client = createClient(fetchMock as unknown as typeof fetch);
+
+    await expect(client.updateTranslation(1, 9001, "Salut")).rejects.toMatchObject({
+      name: "CrowdinApiError",
+      status: 502,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails approved translation replacements when response text does not match", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  id: 9001,
+                  stringId: 1001,
+                  languageId: "fr",
+                  text: "Different text",
+                  createdAt: "2026-06-08T00:01:00Z",
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        ),
+    );
+    const client = createClient(fetchMock as unknown as typeof fetch);
+
+    await expect(
+      client.replaceApprovedTranslation(1, {
+        translationId: 9001,
+        stringId: 1001,
+        languageId: "fr",
+        text: "Salut",
+      }),
+    ).rejects.toMatchObject({
+      name: "CrowdinApiError",
+      status: 502,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("lists glossaries and translation memories with pagination", async () => {
     const fetchMock = vi.fn(async (url) => {
       const path = String(url);

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
@@ -695,7 +695,7 @@ describe("CrowdinApiClient", () => {
     expect(upload.fileId).toBe(101);
   });
 
-  it("adds and updates string translations", async () => {
+  it("adds and replaces approved string translations", async () => {
     const fetchMock = vi.fn(async (url, init) => {
       const path = String(url);
 
@@ -721,7 +721,16 @@ describe("CrowdinApiClient", () => {
 
       if (path.endsWith("/projects/1/translations") && init?.method === "PATCH") {
         expect(JSON.parse(String(init.body))).toEqual([
-          { op: "replace", path: "/9001/text", value: "Salut" },
+          { op: "remove", path: "/9001" },
+          {
+            op: "add",
+            path: "/-",
+            value: {
+              stringId: 1001,
+              languageId: "fr",
+              text: "Salut",
+            },
+          },
         ]);
         return new Response(
           JSON.stringify({
@@ -750,19 +759,31 @@ describe("CrowdinApiClient", () => {
       languageId: "fr",
       text: "Bonjour",
     });
-    const updated = await client.updateTranslation(1, 9001, "Salut");
+    const replaced = await client.replaceApprovedTranslation(1, {
+      translationId: 9001,
+      stringId: 1001,
+      languageId: "fr",
+      text: "Salut",
+    });
 
     expect(added).toMatchObject({ id: 9001, text: "Bonjour" });
-    expect(updated).toMatchObject({ id: 9001, text: "Salut" });
+    expect(replaced).toMatchObject({ id: 9001, text: "Salut" });
   });
 
-  it("fails translation updates when Crowdin returns no updated item", async () => {
+  it("fails approved translation replacements when Crowdin returns no added item", async () => {
     const fetchMock = vi.fn(
       async () => new Response(JSON.stringify({ data: [] }), { status: 200 }),
     );
     const client = createClient(fetchMock as unknown as typeof fetch);
 
-    await expect(client.updateTranslation(1, 9001, "Salut")).rejects.toMatchObject({
+    await expect(
+      client.replaceApprovedTranslation(1, {
+        translationId: 9001,
+        stringId: 1001,
+        languageId: "fr",
+        text: "Salut",
+      }),
+    ).rejects.toMatchObject({
       name: "CrowdinApiError",
       status: 502,
     });

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
@@ -879,6 +879,23 @@ export class CrowdinApiClient {
     return response.data;
   }
 
+  async updateTranslation(
+    projectId: number,
+    translationId: number,
+    text: string,
+  ): Promise<CrowdinStringTranslation> {
+    const response = await this.patch<CrowdinListResponse<CrowdinStringTranslation>>(
+      `/projects/${projectId}/translations`,
+      [{ op: "replace", path: `/${translationId}/text`, value: text }],
+    );
+    const updatedTranslation = response.data[0]?.data;
+    if (!updatedTranslation) {
+      throw new CrowdinApiError("Crowdin translation update returned no data", 502, response);
+    }
+
+    return updatedTranslation;
+  }
+
   async replaceApprovedTranslation(
     projectId: number,
     request: {
@@ -903,10 +920,9 @@ export class CrowdinApiClient {
         },
       ],
     );
-    const replacedTranslation =
-      response.data
-        .map((item) => item.data)
-        .findLast((translation) => translation.text === request.text) ?? response.data.at(-1)?.data;
+    const replacedTranslation = response.data
+      .map((item) => item.data)
+      .findLast((translation) => translation.text === request.text);
     if (!replacedTranslation) {
       throw new CrowdinApiError("Crowdin translation replace returned no data", 502, response);
     }

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
@@ -879,21 +879,39 @@ export class CrowdinApiClient {
     return response.data;
   }
 
-  async updateTranslation(
+  async replaceApprovedTranslation(
     projectId: number,
-    translationId: number,
-    text: string,
+    request: {
+      translationId: number;
+      stringId: number;
+      languageId: string;
+      text: string;
+    },
   ): Promise<CrowdinStringTranslation> {
     const response = await this.patch<CrowdinListResponse<CrowdinStringTranslation>>(
       `/projects/${projectId}/translations`,
-      [{ op: "replace", path: `/${translationId}/text`, value: text }],
+      [
+        { op: "remove", path: `/${request.translationId}` },
+        {
+          op: "add",
+          path: "/-",
+          value: {
+            stringId: request.stringId,
+            languageId: request.languageId,
+            text: request.text,
+          },
+        },
+      ],
     );
-    const updatedTranslation = response.data[0]?.data;
-    if (!updatedTranslation) {
-      throw new CrowdinApiError("Crowdin translation update returned no data", 502, response);
+    const replacedTranslation =
+      response.data
+        .map((item) => item.data)
+        .findLast((translation) => translation.text === request.text) ?? response.data.at(-1)?.data;
+    if (!replacedTranslation) {
+      throw new CrowdinApiError("Crowdin translation replace returned no data", 502, response);
     }
 
-    return updatedTranslation;
+    return replacedTranslation;
   }
 
   async getTranslation(

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live-cat.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live-cat.test.ts
@@ -587,7 +587,7 @@ describe("getTmsProviderLiveCatFile", () => {
             data: [
               {
                 data: {
-                  id: 9001,
+                  id: 9010,
                   stringId: 1001,
                   languageId: "fr",
                   text: "Bonjour amélioré",
@@ -617,7 +617,7 @@ describe("getTmsProviderLiveCatFile", () => {
 
     expect(translation).toEqual({
       text: "Bonjour amélioré",
-      externalTranslationId: "9001",
+      externalTranslationId: "9010",
       isApproved: false,
     });
     const patchCall = fetchMock.mock.calls.find(
@@ -626,8 +626,17 @@ describe("getTmsProviderLiveCatFile", () => {
     );
     expect(patchCall).toBeDefined();
     expect(JSON.parse(String(patchCall?.[1]?.body))).toEqual([
-      { op: "replace", path: "/9001/text", value: "Bonjour amélioré" },
+      { op: "remove", path: "/9001" },
+      {
+        op: "add",
+        path: "/-",
+        value: {
+          stringId: 1001,
+          languageId: "fr",
+          text: "Bonjour amélioré",
+        },
+      },
     ]);
-    expect(approvalRequestCount).toBe(2);
+    expect(approvalRequestCount).toBe(1);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live-cat.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live-cat.test.ts
@@ -639,4 +639,162 @@ describe("getTmsProviderLiveCatFile", () => {
     ]);
     expect(approvalRequestCount).toBe(1);
   });
+
+  it("updates an existing unapproved Crowdin CAT translation in place", async () => {
+    const { organization, user } = await fixture.createLocalWorkosIdentity(
+      fixture.createWorkosIdentityWithRole("admin"),
+    );
+    await upsertOrganizationExternalTmsProviderCredential({
+      organizationId: organization.id,
+      userId: user.id,
+      role: "admin",
+      providerKind: "crowdin",
+      displayName: "Crowdin",
+      secretMaterial: "token",
+      baseUrl: "https://api.crowdin.test/api/v2",
+    });
+
+    const fetchMock = vi.fn(async (url, init) => {
+      const path = String(url);
+
+      if (path.includes("/projects?")) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  id: 42,
+                  name: "Website",
+                  identifier: "website",
+                  sourceLanguageId: "en",
+                  targetLanguageIds: ["fr"],
+                  webUrl: "https://crowdin.test/project/website",
+                  isSuspended: false,
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/projects/42/branches?")) {
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }
+
+      if (path.includes("/projects/42/directories?")) {
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }
+
+      if (path.includes("/projects/42/files?")) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  id: 101,
+                  branchId: null,
+                  directoryId: null,
+                  name: "home.json",
+                  title: "home.json",
+                  type: "json",
+                  path: "/home.json",
+                  status: "active",
+                  revisionId: 7,
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/projects/42/files/101/revisions?")) {
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }
+
+      if (
+        path.includes("/projects/42/languages/fr/translations?") &&
+        path.includes("stringIds=1001")
+      ) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  stringId: 1001,
+                  contentType: "text",
+                  translationId: 9002,
+                  text: "Salut",
+                  createdAt: "2026-06-09T00:00:00Z",
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (
+        path.includes("/projects/42/approvals?") &&
+        path.includes("languageId=fr") &&
+        path.includes("fileId=101")
+      ) {
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }
+
+      if (path.includes("/projects/42/translations") && init?.method === "PATCH") {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  id: 9002,
+                  stringId: 1001,
+                  languageId: "fr",
+                  text: "Bonjour amélioré",
+                  createdAt: "2026-06-09T00:00:00Z",
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const translation = await saveTmsProviderLiveCatTranslation(
+      organization.id,
+      "42",
+      "home.json",
+      {
+        targetLocale: "fr",
+        externalStringId: "1001",
+        text: "Bonjour amélioré",
+      },
+    );
+
+    expect(translation).toEqual({
+      text: "Bonjour amélioré",
+      externalTranslationId: "9002",
+      isApproved: false,
+    });
+    const patchCall = fetchMock.mock.calls.find(
+      ([url, init]) =>
+        String(url).includes("/projects/42/translations") && init?.method === "PATCH",
+    );
+    expect(patchCall).toBeDefined();
+    expect(JSON.parse(String(patchCall?.[1]?.body))).toEqual([
+      { op: "replace", path: "/9002/text", value: "Bonjour amélioré" },
+    ]);
+    expect(
+      fetchMock.mock.calls.some(
+        ([url, init]) =>
+          String(url).includes("/projects/42/translations") && init?.method === "POST",
+      ),
+    ).toBe(false);
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
@@ -979,30 +979,27 @@ async function saveCrowdinLiveCatTranslation(input: {
     ]);
     const approvedTranslationIds = new Set(approvals.map((approval) => approval.translationId));
     const existing = preferredLanguageTranslation(translations, approvedTranslationIds);
+    const isExistingApproved =
+      existing?.translationId != null && approvedTranslationIds.has(existing.translationId);
     const saved =
-      existing?.translationId != null
-        ? await client.updateTranslation(projectId, existing.translationId, input.text)
+      isExistingApproved && existing.translationId != null
+        ? await client.replaceApprovedTranslation(projectId, {
+            translationId: existing.translationId,
+            stringId,
+            languageId: input.targetLocale,
+            text: input.text,
+          })
         : await client.addTranslation(projectId, {
             stringId,
             languageId: input.targetLocale,
             text: input.text,
           });
-    const translationId = saved.id ?? existing?.translationId ?? null;
-    const didUpdateExisting = existing?.translationId != null;
-    let isApproved = false;
-    if (didUpdateExisting && translationId != null) {
-      const postSaveApprovals = await client.listTranslationApprovals(
-        projectId,
-        input.targetLocale,
-        Number.isNaN(fileId) ? { stringId } : { fileId },
-      );
-      isApproved = postSaveApprovals.some((approval) => approval.translationId === translationId);
-    }
+    const translationId = saved.id ?? null;
 
     return {
       text: saved.text,
       externalTranslationId: translationId != null ? String(translationId) : null,
-      isApproved,
+      isApproved: false,
     };
   } catch (error) {
     if (error instanceof CrowdinApiError && error.status === 401) {

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
@@ -979,22 +979,23 @@ async function saveCrowdinLiveCatTranslation(input: {
     ]);
     const approvedTranslationIds = new Set(approvals.map((approval) => approval.translationId));
     const existing = preferredLanguageTranslation(translations, approvedTranslationIds);
-    const isExistingApproved =
-      existing?.translationId != null && approvedTranslationIds.has(existing.translationId);
+    const existingTranslationId = existing?.translationId;
     const saved =
-      isExistingApproved && existing.translationId != null
+      existingTranslationId != null && approvedTranslationIds.has(existingTranslationId)
         ? await client.replaceApprovedTranslation(projectId, {
-            translationId: existing.translationId,
+            translationId: existingTranslationId,
             stringId,
             languageId: input.targetLocale,
             text: input.text,
           })
-        : await client.addTranslation(projectId, {
-            stringId,
-            languageId: input.targetLocale,
-            text: input.text,
-          });
-    const translationId = saved.id ?? null;
+        : existingTranslationId != null
+          ? await client.updateTranslation(projectId, existingTranslationId, input.text)
+          : await client.addTranslation(projectId, {
+              stringId,
+              languageId: input.targetLocale,
+              text: input.text,
+            });
+    const translationId = saved.id ?? existingTranslationId ?? null;
 
     return {
       text: saved.text,


### PR DESCRIPTION
## What changed

- Fix Crowdin CAT translation saves by replacing the invalid `op: replace` PATCH with supported batch `remove` + `add` when updating an approved translation; unapproved strings still use `addTranslation`.
- Make CAT AI recommendations manual: format/QA checks still run on segment select, but AI suggestions are generated only when the user clicks **Get recommendation**.

## How to test

- `cd apps/hyperlocalise-web && vp test src/lib/providers/adapters/crowdin/crowdin-api.test.ts src/lib/providers/tms-provider-live-cat.test.ts src/components/cat/`
- `cd apps/hyperlocalise-web && vp check --fix`
- In the CAT workspace, open a segment and confirm format checks load without an AI call until **Get recommendation** is clicked.
- Save a translation against an approved Crowdin string and confirm the PATCH body uses `remove` + `add` instead of `replace`.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)