### PR TITLE
fix(web): reconcile stale TMS projects and jobs during sync

### DIFF
--- a/apps/hyperlocalise-web/src/lib/projects/list-organization-jobs.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/list-organization-jobs.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, isNull, ne, or } from "drizzle-orm";
 
 import type { ApiAuthContext } from "@/api/auth/workos";
 import { buildAccessibleJobsWhere } from "@/api/auth/team-access";
@@ -75,6 +75,16 @@ function jobListFilters(input: {
   return filters;
 }
 
+function visibleSyncedJobConditions() {
+  return [
+    or(
+      isNull(schema.externalJobDetails.syncState),
+      ne(schema.externalJobDetails.syncState, "removed"),
+    ),
+    or(isNull(schema.projects.isActive), eq(schema.projects.isActive, true)),
+  ];
+}
+
 /**
  * Returns paginate-friendly job rows from the local database only.
  */
@@ -109,6 +119,7 @@ export async function listOrganizationJobs(
     .where(
       and(
         await buildAccessibleJobsWhere(auth),
+        ...visibleSyncedJobConditions(),
         ...jobListFilters({
           kind: query.kind,
           type: query.type,
@@ -155,6 +166,7 @@ export async function listOrganizationProjectJobs(
       and(
         eq(schema.jobs.organizationId, auth.organization.localOrganizationId),
         eq(schema.jobs.projectId, projectId),
+        ...visibleSyncedJobConditions(),
         ...jobListFilters({
           kind: query.kind,
           type: query.type,

--- a/apps/hyperlocalise-web/src/lib/projects/list-organization-projects.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/list-organization-projects.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, inArray, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, isNull, or, sql } from "drizzle-orm";
 
 import type { ApiAuthContext } from "@/api/auth/workos";
 import { buildAccessibleProjectsWhere } from "@/api/auth/team-access";
@@ -80,7 +80,12 @@ export async function listOrganizationProjects(
   const databaseProjects = await db
     .select()
     .from(schema.projects)
-    .where(and(await buildAccessibleProjectsWhere(auth), eq(schema.projects.isActive, true)))
+    .where(
+      and(
+        await buildAccessibleProjectsWhere(auth),
+        or(isNull(schema.projects.isActive), eq(schema.projects.isActive, true)),
+      ),
+    )
     .orderBy(desc(schema.projects.updatedAt));
 
   const projects = await attachOpenJobCounts(organizationId, databaseProjects);

--- a/apps/hyperlocalise-web/src/lib/projects/list-organization-projects.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/list-organization-projects.ts
@@ -80,7 +80,7 @@ export async function listOrganizationProjects(
   const databaseProjects = await db
     .select()
     .from(schema.projects)
-    .where(await buildAccessibleProjectsWhere(auth))
+    .where(and(await buildAccessibleProjectsWhere(auth), eq(schema.projects.isActive, true)))
     .orderBy(desc(schema.projects.updatedAt));
 
   const projects = await attachOpenJobCounts(organizationId, databaseProjects);

--- a/apps/hyperlocalise-web/src/lib/projects/upsert-external-tms-job-records.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/upsert-external-tms-job-records.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, ne, notInArray } from "drizzle-orm";
 
 import { db, schema } from "@/lib/database";
 import type { ExternalTmsProviderKind } from "@/lib/providers/organization-external-tms-provider-credentials";
@@ -145,7 +145,14 @@ export async function upsertExternalTmsJobRecords(input: {
     }
   }
 
-  if (upserted > 0) {
+  const removed = await reconcileMissingExternalTmsJobs({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    providerKind: input.providerKind,
+    syncedJobIds: candidateJobIds,
+  });
+
+  if (upserted > 0 || removed > 0) {
     await db
       .update(schema.projects)
       .set({
@@ -160,5 +167,58 @@ export async function upsertExternalTmsJobRecords(input: {
       );
   }
 
-  return { upserted, newlySyncedJobIds };
+  return { upserted, newlySyncedJobIds, removed };
+}
+
+export async function reconcileMissingExternalTmsJobs(input: {
+  organizationId: string;
+  projectId: string;
+  providerKind: ExternalTmsProviderKind;
+  syncedJobIds: string[];
+}) {
+  const now = new Date();
+  const scope = and(
+    eq(schema.jobs.organizationId, input.organizationId),
+    eq(schema.jobs.projectId, input.projectId),
+    eq(schema.externalJobDetails.providerKind, input.providerKind),
+    ne(schema.externalJobDetails.syncState, "removed"),
+  );
+
+  const staleJobs = await db
+    .select({ id: schema.jobs.id })
+    .from(schema.jobs)
+    .innerJoin(schema.externalJobDetails, eq(schema.externalJobDetails.jobId, schema.jobs.id))
+    .where(
+      input.syncedJobIds.length > 0
+        ? and(scope, notInArray(schema.jobs.id, input.syncedJobIds))
+        : scope,
+    );
+
+  if (staleJobs.length === 0) {
+    return 0;
+  }
+
+  const staleJobIds = staleJobs.map((job) => job.id);
+
+  await db.transaction(async (tx) => {
+    await tx
+      .update(schema.jobs)
+      .set({
+        status: "cancelled",
+        completedAt: now,
+        updatedAt: now,
+      })
+      .where(inArray(schema.jobs.id, staleJobIds));
+
+    await tx
+      .update(schema.externalJobDetails)
+      .set({
+        externalStatus: "removed_from_provider",
+        syncState: "removed",
+        updatedAt: now,
+      })
+      .where(inArray(schema.externalJobDetails.jobId, staleJobIds));
+  });
+
+  return staleJobIds.length;
 }

--- a/apps/hyperlocalise-web/src/lib/projects/upsert-external-tms-job-records.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/upsert-external-tms-job-records.ts
@@ -170,35 +170,25 @@ export async function upsertExternalTmsJobRecords(input: {
   return { upserted, newlySyncedJobIds, removed };
 }
 
-export async function reconcileMissingExternalTmsJobs(input: {
+function externalTmsJobsScope(input: {
   organizationId: string;
   projectId: string;
   providerKind: ExternalTmsProviderKind;
-  syncedJobIds: string[];
 }) {
-  const now = new Date();
-  const scope = and(
+  return and(
     eq(schema.jobs.organizationId, input.organizationId),
     eq(schema.jobs.projectId, input.projectId),
     eq(schema.externalJobDetails.providerKind, input.providerKind),
     ne(schema.externalJobDetails.syncState, "removed"),
   );
+}
 
-  const staleJobs = await db
-    .select({ id: schema.jobs.id })
-    .from(schema.jobs)
-    .innerJoin(schema.externalJobDetails, eq(schema.externalJobDetails.jobId, schema.jobs.id))
-    .where(
-      input.syncedJobIds.length > 0
-        ? and(scope, notInArray(schema.jobs.id, input.syncedJobIds))
-        : scope,
-    );
-
-  if (staleJobs.length === 0) {
+async function cancelExternalTmsJobs(jobIds: string[]) {
+  if (jobIds.length === 0) {
     return 0;
   }
 
-  const staleJobIds = staleJobs.map((job) => job.id);
+  const now = new Date();
 
   await db.transaction(async (tx) => {
     await tx
@@ -208,7 +198,7 @@ export async function reconcileMissingExternalTmsJobs(input: {
         completedAt: now,
         updatedAt: now,
       })
-      .where(inArray(schema.jobs.id, staleJobIds));
+      .where(inArray(schema.jobs.id, jobIds));
 
     await tx
       .update(schema.externalJobDetails)
@@ -217,8 +207,41 @@ export async function reconcileMissingExternalTmsJobs(input: {
         syncState: "removed",
         updatedAt: now,
       })
-      .where(inArray(schema.externalJobDetails.jobId, staleJobIds));
+      .where(inArray(schema.externalJobDetails.jobId, jobIds));
   });
 
-  return staleJobIds.length;
+  return jobIds.length;
+}
+
+export async function removeAllExternalTmsJobsForProject(input: {
+  organizationId: string;
+  projectId: string;
+  providerKind: ExternalTmsProviderKind;
+}) {
+  const staleJobs = await db
+    .select({ id: schema.jobs.id })
+    .from(schema.jobs)
+    .innerJoin(schema.externalJobDetails, eq(schema.externalJobDetails.jobId, schema.jobs.id))
+    .where(externalTmsJobsScope(input));
+
+  return cancelExternalTmsJobs(staleJobs.map((job) => job.id));
+}
+
+export async function reconcileMissingExternalTmsJobs(input: {
+  organizationId: string;
+  projectId: string;
+  providerKind: ExternalTmsProviderKind;
+  syncedJobIds: string[];
+}) {
+  if (input.syncedJobIds.length === 0) {
+    return 0;
+  }
+
+  const staleJobs = await db
+    .select({ id: schema.jobs.id })
+    .from(schema.jobs)
+    .innerJoin(schema.externalJobDetails, eq(schema.externalJobDetails.jobId, schema.jobs.id))
+    .where(and(externalTmsJobsScope(input), notInArray(schema.jobs.id, input.syncedJobIds)));
+
+  return cancelExternalTmsJobs(staleJobs.map((job) => job.id));
 }

--- a/apps/hyperlocalise-web/src/lib/projects/upsert-external-tms-project-record.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/upsert-external-tms-project-record.ts
@@ -1,8 +1,30 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, notInArray } from "drizzle-orm";
 
 import { db, schema } from "@/lib/database";
+import type { ExternalTmsProviderKind } from "@/lib/providers/organization-external-tms-provider-credentials";
 import type { TmsProviderLiveProject } from "@/lib/providers/tms-provider-live";
 import { encodeProviderProjectId } from "@/lib/providers/tms-provider-resource-id";
+
+import { reconcileMissingExternalTmsJobs } from "./upsert-external-tms-job-records";
+
+async function removeExternalTmsJobsForProjects(input: {
+  organizationId: string;
+  providerKind: ExternalTmsProviderKind;
+  projectIds: string[];
+}) {
+  let removedJobs = 0;
+
+  for (const projectId of input.projectIds) {
+    removedJobs += await reconcileMissingExternalTmsJobs({
+      organizationId: input.organizationId,
+      projectId,
+      providerKind: input.providerKind,
+      syncedJobIds: [],
+    });
+  }
+
+  return removedJobs;
+}
 
 export async function upsertExternalTmsProjectRecord(input: {
   organizationId: string;
@@ -54,6 +76,83 @@ export async function upsertExternalTmsProjectRecord(input: {
     });
 
   return projectId;
+}
+
+export async function deactivateMissingExternalTmsProjects(input: {
+  organizationId: string;
+  providerCredentialId: string;
+  providerKind: (typeof schema.externalTmsProviderKindEnum.enumValues)[number];
+  syncedProjectIds: string[];
+}) {
+  const now = new Date();
+  const scope = and(
+    eq(schema.projects.organizationId, input.organizationId),
+    eq(schema.projects.source, "external_tms"),
+    eq(schema.projects.externalProviderKind, input.providerKind),
+    eq(schema.projects.externalProviderCredentialId, input.providerCredentialId),
+    eq(schema.projects.isActive, true),
+  );
+
+  const deactivated = await db
+    .update(schema.projects)
+    .set({
+      isActive: false,
+      updatedAt: now,
+    })
+    .where(
+      input.syncedProjectIds.length > 0
+        ? and(scope, notInArray(schema.projects.id, input.syncedProjectIds))
+        : scope,
+    )
+    .returning({ id: schema.projects.id });
+
+  await removeExternalTmsJobsForProjects({
+    organizationId: input.organizationId,
+    providerKind: input.providerKind,
+    projectIds: deactivated.map((project) => project.id),
+  });
+
+  return deactivated.length;
+}
+
+export async function deactivateExternalTmsProject(input: {
+  organizationId: string;
+  projectId: string;
+}) {
+  const now = new Date();
+  const deactivated = await db
+    .update(schema.projects)
+    .set({
+      isActive: false,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(schema.projects.id, input.projectId),
+        eq(schema.projects.organizationId, input.organizationId),
+        eq(schema.projects.source, "external_tms"),
+        eq(schema.projects.isActive, true),
+      ),
+    )
+    .returning({
+      id: schema.projects.id,
+      externalProviderKind: schema.projects.externalProviderKind,
+    });
+
+  if (deactivated.length === 0) {
+    return false;
+  }
+
+  const [project] = deactivated;
+  if (project.externalProviderKind) {
+    await removeExternalTmsJobsForProjects({
+      organizationId: input.organizationId,
+      providerKind: project.externalProviderKind,
+      projectIds: [project.id],
+    });
+  }
+
+  return true;
 }
 
 export async function getOrganizationExternalTmsCredentialId(

--- a/apps/hyperlocalise-web/src/lib/projects/upsert-external-tms-project-record.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/upsert-external-tms-project-record.ts
@@ -5,7 +5,7 @@ import type { ExternalTmsProviderKind } from "@/lib/providers/organization-exter
 import type { TmsProviderLiveProject } from "@/lib/providers/tms-provider-live";
 import { encodeProviderProjectId } from "@/lib/providers/tms-provider-resource-id";
 
-import { reconcileMissingExternalTmsJobs } from "./upsert-external-tms-job-records";
+import { removeAllExternalTmsJobsForProject } from "./upsert-external-tms-job-records";
 
 async function removeExternalTmsJobsForProjects(input: {
   organizationId: string;
@@ -15,11 +15,10 @@ async function removeExternalTmsJobsForProjects(input: {
   let removedJobs = 0;
 
   for (const projectId of input.projectIds) {
-    removedJobs += await reconcileMissingExternalTmsJobs({
+    removedJobs += await removeAllExternalTmsJobsForProject({
       organizationId: input.organizationId,
       projectId,
       providerKind: input.providerKind,
-      syncedJobIds: [],
     });
   }
 
@@ -84,15 +83,11 @@ export async function deactivateMissingExternalTmsProjects(input: {
   providerKind: (typeof schema.externalTmsProviderKindEnum.enumValues)[number];
   syncedProjectIds: string[];
 }) {
-  const now = new Date();
-  const scope = and(
-    eq(schema.projects.organizationId, input.organizationId),
-    eq(schema.projects.source, "external_tms"),
-    eq(schema.projects.externalProviderKind, input.providerKind),
-    eq(schema.projects.externalProviderCredentialId, input.providerCredentialId),
-    eq(schema.projects.isActive, true),
-  );
+  if (input.syncedProjectIds.length === 0) {
+    return 0;
+  }
 
+  const now = new Date();
   const deactivated = await db
     .update(schema.projects)
     .set({
@@ -100,9 +95,14 @@ export async function deactivateMissingExternalTmsProjects(input: {
       updatedAt: now,
     })
     .where(
-      input.syncedProjectIds.length > 0
-        ? and(scope, notInArray(schema.projects.id, input.syncedProjectIds))
-        : scope,
+      and(
+        eq(schema.projects.organizationId, input.organizationId),
+        eq(schema.projects.source, "external_tms"),
+        eq(schema.projects.externalProviderKind, input.providerKind),
+        eq(schema.projects.externalProviderCredentialId, input.providerCredentialId),
+        eq(schema.projects.isActive, true),
+        notInArray(schema.projects.id, input.syncedProjectIds),
+      ),
     )
     .returning({ id: schema.projects.id });
 

--- a/apps/hyperlocalise-web/src/lib/providers/provider-sync-executor.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-sync-executor.test.ts
@@ -11,6 +11,8 @@ const {
   resolveSecretMaterialForActorMock,
   runTmsAgentAutomationForSyncedJobMock,
   upsertExternalTmsJobRecordsMock,
+  deactivateMissingExternalTmsProjectsMock,
+  deactivateExternalTmsProjectMock,
 } = vi.hoisted(() => ({
   createProviderAgentTranslationQueueMock: vi.fn(() => ({ enqueue: vi.fn() })),
   dbInsertMock: vi.fn(),
@@ -24,6 +26,8 @@ const {
     async (): Promise<{ triggered: string[] }> => ({ triggered: [] }),
   ),
   upsertExternalTmsJobRecordsMock: vi.fn(),
+  deactivateMissingExternalTmsProjectsMock: vi.fn(async () => 0),
+  deactivateExternalTmsProjectMock: vi.fn(async () => false),
 }));
 
 vi.mock("@/lib/database", () => ({
@@ -60,6 +64,8 @@ vi.mock("@/lib/providers/tms-provider-live", () => ({
 
 vi.mock("@/lib/projects/upsert-external-tms-project-record", () => ({
   upsertExternalTmsProjectRecord: vi.fn(async () => "ext:crowdin:902807"),
+  deactivateMissingExternalTmsProjects: deactivateMissingExternalTmsProjectsMock,
+  deactivateExternalTmsProject: deactivateExternalTmsProjectMock,
 }));
 
 vi.mock("./provider-sync-intent", () => ({
@@ -174,7 +180,11 @@ describe("executeProviderSyncIntent", () => {
     });
     resolveSecretMaterialForActorMock.mockResolvedValue("secret");
     fetchCrowdinJobTasksMock.mockResolvedValue([]);
-    upsertExternalTmsJobRecordsMock.mockResolvedValue({ upserted: 0, newlySyncedJobIds: [] });
+    upsertExternalTmsJobRecordsMock.mockResolvedValue({
+      upserted: 0,
+      newlySyncedJobIds: [],
+      removed: 0,
+    });
     runTmsAgentAutomationForSyncedJobMock.mockResolvedValue({ triggered: [] });
   });
 
@@ -202,6 +212,12 @@ describe("executeProviderSyncIntent", () => {
       providerKind: "crowdin",
       projectId: "ext:crowdin:902807",
       cause: "manual",
+    });
+    expect(deactivateMissingExternalTmsProjectsMock).toHaveBeenCalledWith({
+      organizationId: "org_123",
+      providerCredentialId: "credential_123",
+      providerKind: "crowdin",
+      syncedProjectIds: ["ext:crowdin:902807"],
     });
   });
 
@@ -274,6 +290,7 @@ describe("executeProviderSyncIntent", () => {
     upsertExternalTmsJobRecordsMock.mockResolvedValue({
       upserted: 1,
       newlySyncedJobIds: [hyperlocaliseJobId],
+      removed: 0,
     });
 
     const result = await executeProviderSyncIntent(createJobTaskIntent());
@@ -375,6 +392,7 @@ describe("executeProviderSyncIntent", () => {
     upsertExternalTmsJobRecordsMock.mockResolvedValue({
       upserted: 2,
       newlySyncedJobIds: [jobId1, jobId2],
+      removed: 0,
     });
     runTmsAgentAutomationForSyncedJobMock
       .mockRejectedValueOnce(new Error("queue unavailable"))
@@ -440,6 +458,7 @@ describe("executeProviderSyncIntent", () => {
     upsertExternalTmsJobRecordsMock.mockResolvedValue({
       upserted: 1,
       newlySyncedJobIds: [],
+      removed: 0,
     });
 
     const result = await executeProviderSyncIntent(createJobTaskIntent());

--- a/apps/hyperlocalise-web/src/lib/providers/provider-sync-executor.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-sync-executor.ts
@@ -13,7 +13,11 @@ import {
   parseProviderProjectId,
 } from "@/lib/providers/tms-provider-resource-id";
 import { upsertExternalTmsJobRecords } from "@/lib/projects/upsert-external-tms-job-records";
-import { upsertExternalTmsProjectRecord } from "@/lib/projects/upsert-external-tms-project-record";
+import {
+  deactivateExternalTmsProject,
+  deactivateMissingExternalTmsProjects,
+  upsertExternalTmsProjectRecord,
+} from "@/lib/projects/upsert-external-tms-project-record";
 import { err, ok, type Result } from "@/lib/primitives/result/results";
 
 import { enqueueProviderProjectJobSyncIntent } from "./provider-sync-intent";
@@ -197,15 +201,18 @@ async function refreshMaterializedProjectFromLive(
   );
 
   if (!liveProject) {
+    const deactivated = await deactivateExternalTmsProject({
+      organizationId: intent.organizationId,
+      projectId: intent.projectId,
+    });
+
     await completeProviderSyncRun({
       runId,
-      status: "failed",
-      errorMessage: "Provider project is unavailable.",
+      status: "succeeded",
+      counts: { deactivatedProjects: deactivated ? 1 : 0 },
     });
-    return err({
-      code: "provider_project_unavailable",
-      message: "Provider project is unavailable.",
-    });
+
+    return ok({ runId });
   }
 
   const projectId = await upsertExternalTmsProjectRecord({
@@ -245,6 +252,7 @@ async function syncProjectCatalogFromLive(
   const actorUserId = await resolveProviderSyncActorUserId(intent);
   const liveProjects = await listTmsProviderLiveProjects(intent.organizationId, { actorUserId });
   let syncedCount = 0;
+  const syncedProjectIds: string[] = [];
 
   for (const liveProject of liveProjects) {
     const projectId = await upsertExternalTmsProjectRecord({
@@ -252,6 +260,7 @@ async function syncProjectCatalogFromLive(
       providerCredentialId: intent.providerCredentialId,
       liveProject,
     });
+    syncedProjectIds.push(projectId);
     await enqueueProviderProjectJobSyncIntent({
       organizationId: intent.organizationId,
       providerCredentialId: intent.providerCredentialId,
@@ -262,10 +271,17 @@ async function syncProjectCatalogFromLive(
     syncedCount += 1;
   }
 
+  const deactivatedProjects = await deactivateMissingExternalTmsProjects({
+    organizationId: intent.organizationId,
+    providerCredentialId: intent.providerCredentialId,
+    providerKind: intent.providerKind,
+    syncedProjectIds,
+  });
+
   await completeProviderSyncRun({
     runId,
     status: "succeeded",
-    counts: { projects: syncedCount },
+    counts: { projects: syncedCount, deactivatedProjects },
   });
 
   return ok({ runId });
@@ -302,7 +318,7 @@ async function syncProviderJobTasksFromLive(
     project: context.value.project,
     secretMaterial,
   });
-  const { upserted, newlySyncedJobIds } = await upsertExternalTmsJobRecords({
+  const { upserted, newlySyncedJobIds, removed } = await upsertExternalTmsJobRecords({
     organizationId: intent.organizationId,
     projectId: intent.projectId!,
     providerKind: intent.providerKind,
@@ -363,6 +379,7 @@ async function syncProviderJobTasksFromLive(
     status: "succeeded",
     counts: {
       jobs: upserted,
+      removedJobs: removed,
       ...(automationFailures.length > 0 ? { automationFailures: automationFailures.length } : {}),
     },
   });


### PR DESCRIPTION
## What changed

TMS catalog and job sync previously only upserted provider records. Projects and jobs deleted or archived in the TMS stayed in the local database and continued to appear in list views.

This change adds reconciliation during provider sync:

- Catalog sync deactivates external projects missing from the live provider response and marks their jobs as removed.
- Job sync marks external jobs no longer returned by the provider as cancelled with `syncState: removed`.
- Single-project refresh deactivates the local project when the provider project is gone.
- Project and job list endpoints filter inactive projects and provider-removed jobs.

The existing scheduled reconciliation cron (`/api/cron/tms-scheduled-reconciliation`, every 15 minutes) runs this cleanup automatically.

## How to test

1. Connect a TMS credential with synced projects and jobs.
2. Delete or archive a project or job in the TMS provider.
3. Trigger sync via **Sync projects** / **Sync jobs**, or wait for the scheduled cron.
4. Confirm the deleted project/job no longer appears in the Projects or Jobs list.

```bash
cd apps/hyperlocalise-web
vp test src/lib/providers/provider-sync-executor.test.ts
vp check --fix
```

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)