### PR TITLE
fix(web): show project sidebar and correct project breadcrumbs

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.tsx
@@ -17,8 +17,6 @@ import {
   JobsPageErrorMessage,
   JobsPageView,
   jobsStatusOptions,
-  type ApiJob,
-  type JobRow,
   type JobsErrorRenderer,
   type JobsLinkRenderer,
   type JobsScope,
@@ -108,8 +106,8 @@ export function JobsPageContent({
           },
         });
         if (!response.ok) throw await readApiResponseError(response, "Failed to load jobs");
-        const body = (await response.json()) as { jobs: ApiJob[] };
-        return body.jobs.map((job) => ({ ...job, projectName: null }));
+        const body = await response.json();
+        return body.jobs;
       }
 
       const response = await apiClient.api.orgs[":organizationSlug"].jobs.$get({
@@ -121,7 +119,7 @@ export function JobsPageContent({
         },
       });
       if (!response.ok) throw await readApiResponseError(response, "Failed to load jobs");
-      const body = (await response.json()) as { jobs: JobRow[] };
+      const body = await response.json();
       return body.jobs;
     },
   });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-view.tsx
@@ -344,7 +344,7 @@ function JobsList({
                   {sourceLabel(job)}
                 </Badge>
                 <TypographyP className="truncate text-sm text-foreground/58">
-                  {job.projectName ?? "Workspace"}
+                  {job.projectName ?? job.projectId ?? "Workspace"}
                 </TypographyP>
                 <Badge
                   variant="outline"

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.test.ts
@@ -10,7 +10,7 @@ describe("getAppShellTitle", () => {
     ["/org/acme/new-request", "New Request"],
     ["/org/acme/chat", "New Request"],
     ["/org/acme/projects", "Projects"],
-    ["/org/acme/projects/proj_1", "Overview"],
+    ["/org/acme/projects/proj_1", "proj_1"],
     ["/org/acme/projects/proj_1/files", "Files"],
     ["/org/acme/projects/proj_1/jobs", "Jobs"],
     ["/org/acme/projects/proj_1/agent-runs", "Agent Runs"],
@@ -50,19 +50,27 @@ describe("getAppShellBreadcrumbs", () => {
     expect(
       getAppShellBreadcrumbs("/org/acme/projects/proj_1/files", { projectName: "Checkout" }),
     ).toEqual([
-      { label: "Project", href: "/org/acme/projects" },
+      { label: "Projects", href: "/org/acme/projects" },
       { label: "Checkout", href: "/org/acme/projects/proj_1" },
       { label: "Files" },
+    ]);
+  });
+
+  it("falls back to the project id when the project name is unavailable", () => {
+    expect(getAppShellBreadcrumbs("/org/acme/projects/proj_1/jobs")).toEqual([
+      { label: "Projects", href: "/org/acme/projects" },
+      { label: "proj_1", href: "/org/acme/projects/proj_1" },
+      { label: "Jobs" },
     ]);
   });
 
   it("returns project overview breadcrumbs without a section crumb", () => {
     expect(
       getAppShellBreadcrumbs("/org/acme/projects/proj_1", { projectName: "Checkout" }),
-    ).toEqual([{ label: "Project", href: "/org/acme/projects" }, { label: "Checkout" }]);
+    ).toEqual([{ label: "Projects", href: "/org/acme/projects" }, { label: "Checkout" }]);
     expect(getAppShellBreadcrumbs("/org/acme/projects/proj_1")).toEqual([
-      { label: "Project", href: "/org/acme/projects" },
-      { label: "Overview" },
+      { label: "Projects", href: "/org/acme/projects" },
+      { label: "proj_1" },
     ]);
   });
 });

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.ts
@@ -76,6 +76,14 @@ function buildOrgPath(organizationSlug: string, ...parts: string[]) {
   return `/org/${organizationSlug}/${parts.join("/")}`;
 }
 
+function decodePathSegment(value: string) {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
 function routeTitle(segment: string) {
   return isRouteTitleKey(segment) ? ROUTE_TITLES[segment] : segment;
 }
@@ -104,20 +112,21 @@ export function getAppShellBreadcrumbs(
   }
 
   if (section === "projects" && subsection) {
-    const projectName = options?.projectName?.trim() || (projectSection ? "Project" : "Overview");
+    const projectId = decodePathSegment(subsection);
+    const projectLabel = options?.projectName?.trim() || projectId;
     const projectHref = buildOrgPath(organizationSlug, "projects", subsection);
 
     if (projectSection && isProjectSectionKey(projectSection)) {
       return [
-        { label: "Project", href: buildOrgPath(organizationSlug, "projects") },
-        { label: projectName, href: projectHref },
+        { label: ROUTE_TITLES.projects, href: buildOrgPath(organizationSlug, "projects") },
+        { label: projectLabel, href: projectHref },
         { label: PROJECT_SECTION_TITLES[projectSection] },
       ];
     }
 
     return [
-      { label: "Project", href: buildOrgPath(organizationSlug, "projects") },
-      { label: projectName },
+      { label: ROUTE_TITLES.projects, href: buildOrgPath(organizationSlug, "projects") },
+      { label: projectLabel },
     ];
   }
 

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
@@ -15,6 +15,33 @@ describe("navigation-config", () => {
     });
   });
 
+  it("parses project routes with a locale prefix", () => {
+    const projectId = "proj_1";
+
+    expect(parseProjectRoute("/en/org/acme/projects/proj_1")).toEqual({
+      organizationSlug: "acme",
+      projectId,
+      section: null,
+    });
+    expect(parseProjectRoute("/en/org/acme/projects/proj_1/files")).toEqual({
+      organizationSlug: "acme",
+      projectId,
+      section: "files",
+    });
+  });
+
+  it("marks navigation active for locale-prefixed project paths", () => {
+    const projectId = "proj_1";
+    const filesHref = buildProjectPath("acme", projectId, "files");
+
+    expect(
+      isNavigationItemActive("/en/org/acme/projects/proj_1/files", filesHref, {
+        organizationSlug: "acme",
+        projectId,
+      }),
+    ).toBe(true);
+  });
+
   it("keeps project overview active state exact for encoded external project ids", () => {
     const projectId = "ext:crowdin:902807";
     const overviewHref = buildProjectPath("hyperlocalise", projectId);

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
@@ -1,4 +1,6 @@
 import type { ComponentProps } from "react";
+
+import { normalizeAppLocale } from "@/lib/app-i18n/locales";
 import {
   AiBrain01Icon,
   BookOpenTextIcon,
@@ -152,10 +154,23 @@ export function buildProjectNavigationItems(
   ] as const;
 }
 
+function stripAppLocalePrefix(pathname: string) {
+  const [, firstSegment, ...rest] = pathname.split("/");
+  const locale = firstSegment ? normalizeAppLocale(firstSegment) : null;
+
+  if (!locale) {
+    return pathname;
+  }
+
+  return `/${rest.join("/")}`.replace(/\/+$/, "") || "/";
+}
+
 export function parseProjectRoute(pathname: string | null) {
   if (!pathname) return null;
 
-  const match = pathname.match(/^\/org\/([^/]+)\/projects\/([^/]+)(?:\/(.*))?$/);
+  const match = stripAppLocalePrefix(pathname).match(
+    /^\/org\/([^/]+)\/projects\/([^/]+)(?:\/(.*))?$/,
+  );
   if (!match) return null;
 
   const [, organizationSlug, projectIdSegment, remainder] = match;
@@ -185,30 +200,31 @@ export function isNavigationItemActive(
     organizationSlug?: string;
   },
 ) {
+  const normalizedPathname = stripAppLocalePrefix(pathname);
   const itemPathname = href.split("#", 1)[0];
 
   if (options?.exact) {
-    return pathname === itemPathname;
+    return normalizedPathname === itemPathname;
   }
 
   if (options?.projectId && options.organizationSlug) {
     const overviewHref = buildProjectPath(options.organizationSlug, options.projectId);
     if (itemPathname === overviewHref) {
-      return pathname === overviewHref;
+      return normalizedPathname === overviewHref;
     }
   }
 
-  if (pathname === itemPathname) {
+  if (normalizedPathname === itemPathname) {
     return true;
   }
 
   if (itemPathname.endsWith("/projects")) {
-    return pathname === itemPathname;
+    return normalizedPathname === itemPathname;
   }
 
-  if (pathname.startsWith(`${itemPathname}/`)) {
+  if (normalizedPathname.startsWith(`${itemPathname}/`)) {
     if (itemPathname.endsWith("/settings")) {
-      const settingsSubpath = pathname.slice(itemPathname.length + 1);
+      const settingsSubpath = normalizedPathname.slice(itemPathname.length + 1);
       if (settingsSubpath === "members" || settingsSubpath.startsWith("members/")) {
         return false;
       }
@@ -218,14 +234,14 @@ export function isNavigationItemActive(
 
   if (
     itemPathname.endsWith("/command-center") &&
-    pathname.startsWith(itemPathname.replace("command-center", "dashboard"))
+    normalizedPathname.startsWith(itemPathname.replace("command-center", "dashboard"))
   ) {
     return true;
   }
 
   if (
     itemPathname.endsWith("/my-work") &&
-    pathname.startsWith(itemPathname.replace("my-work", "my-jobs"))
+    normalizedPathname.startsWith(itemPathname.replace("my-work", "my-jobs"))
   ) {
     return true;
   }


### PR DESCRIPTION
## What changed

- Strip locale prefixes when parsing project routes so the app shell switches to the project sidebar on localized URLs (for example `/en/org/.../projects/...`).
- Normalize locale-prefixed pathnames when determining active navigation items.
- Update project breadcrumbs to use `Projects` for the list link and the project name (or id while loading) for the project crumb.

## How to test

1. Open a project at `/en/org/<org>/projects/<projectId>/jobs`.
2. Confirm the sidebar shows project navigation (Overview, Files, Jobs, Settings) instead of the global workspace sidebar.
3. Confirm the breadcrumb reads `Projects > <project name or id> > Jobs`.
4. Run `cd apps/hyperlocalise-web && vp test src/components/app-shell/navigation-config.test.ts src/components/app-shell/app-shell-title.test.ts`.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)