### PR TITLE
feat(cli): add crowdin download sources command

### DIFF
--- a/apps/cli/cmd/crowdin.go
+++ b/apps/cli/cmd/crowdin.go
@@ -31,6 +31,17 @@ type crowdinCommonOptions struct {
 	dryRun                  bool
 }
 
+type crowdinDownloadSourcesOptions struct {
+	configPath   string
+	identityPath string
+	branch       string
+	fileID       int
+	sourcePaths  []string
+	outputPath   string
+	force        bool
+	dryRun       bool
+}
+
 type crowdinGlossaryDownloadOptions struct {
 	configPath   string
 	identityPath string
@@ -203,10 +214,22 @@ func newCrowdinUploadTranslationsCmd() *cobra.Command {
 	return cmd
 }
 
+var downloadCrowdinSourceFileByID = crowdinstorage.DownloadSourceFileByID
+
 func newCrowdinDownloadCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "download",
+		Short: "download source or translated files from Crowdin",
+	}
+	cmd.AddCommand(newCrowdinDownloadSourcesCmd())
+	cmd.AddCommand(newCrowdinDownloadTranslationsCmd())
+	return cmd
+}
+
+func newCrowdinDownloadTranslationsCmd() *cobra.Command {
 	o := crowdinCommonOptions{}
 	cmd := &cobra.Command{
-		Use:          "download",
+		Use:          "translations",
 		Short:        "download translated files defined in crowdin.yml",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -232,6 +255,108 @@ func newCrowdinDownloadCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&o.mergeApproved, "merge-approved", false, "merge approved downloaded JSON strings into existing translation files")
 	cmd.Flags().BoolVar(&o.includeSources, "include-sources", false, "also download source files into files[].source paths")
 	return cmd
+}
+
+func newCrowdinDownloadSourcesCmd() *cobra.Command {
+	o := crowdinDownloadSourcesOptions{}
+	cmd := &cobra.Command{
+		Use:          "sources",
+		Short:        "download source files from Crowdin",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return executeCrowdinDownloadSources(cmd, o)
+		},
+	}
+	cmd.Flags().StringVar(&o.configPath, "config", "", "path to crowdin.yml")
+	cmd.Flags().StringVar(&o.identityPath, "identity", "", "path to Crowdin identity file")
+	cmd.Flags().StringVar(&o.branch, "branch", "", "Crowdin branch name to process")
+	cmd.Flags().IntVar(&o.fileID, "file-id", 0, "download one source file by Crowdin file ID")
+	cmd.Flags().StringSliceVar(&o.sourcePaths, "source", nil, "limit config-based download to one or more files[].source paths")
+	cmd.Flags().StringVarP(&o.outputPath, "output", "o", "", "output file path for --file-id; omit or use - for stdout")
+	cmd.Flags().BoolVar(&o.force, "force", false, "overwrite an existing output file")
+	cmd.Flags().BoolVar(&o.dryRun, "dry-run", false, "preview command without downloading content")
+	return cmd
+}
+
+func executeCrowdinDownloadSources(cmd *cobra.Command, o crowdinDownloadSourcesOptions) error {
+	outputPath := strings.TrimSpace(o.outputPath)
+	if o.fileID > 0 {
+		if o.dryRun {
+			destination := outputPath
+			if destination == "" {
+				destination = "-"
+			}
+			_, err := fmt.Fprintf(cmd.OutOrStdout(), "dry-run action=download-sources file_id=%d output=%s\n", o.fileID, destination)
+			return err
+		}
+		if err := validateCrowdinDownloadSourcesOutputPath(outputPath, o.force); err != nil {
+			return err
+		}
+
+		cfg, _, err := crowdinstorage.LoadClientConfig(o.configPath, o.identityPath)
+		if err != nil {
+			return err
+		}
+		content, err := downloadCrowdinSourceFileByID(backgroundContext(), cfg, o.fileID)
+		if err != nil {
+			return fmt.Errorf("crowdin download sources: %w", err)
+		}
+		if outputPath == "" || outputPath == "-" {
+			_, err := cmd.OutOrStdout().Write(content)
+			return err
+		}
+		if err := writeCrowdinDownloadedSource(outputPath, content, o.force); err != nil {
+			return err
+		}
+		_, err = fmt.Fprintf(cmd.OutOrStdout(), "downloaded file=%s bytes=%d file_id=%d\n", outputPath, len(content), o.fileID)
+		return err
+	}
+
+	cfg, _, err := loadCrowdinWorkflowConfig(o.configPath, o.identityPath)
+	if err != nil {
+		return err
+	}
+	if o.dryRun {
+		_, err := fmt.Fprintf(cmd.OutOrStdout(), "dry-run action=download-sources files=%d sources=%s\n", len(cfg.Files), strings.Join(o.sourcePaths, ","))
+		return err
+	}
+	cfg = overrideCrowdinBranch(cfg, o.branch)
+	adapter, err := crowdinstorage.NewFileAdapter(cfg)
+	if err != nil {
+		return err
+	}
+	result, err := adapter.DownloadSources(backgroundContext(), storage.FileDownloadSourcesRequest{
+		Config:      cfg,
+		SourcePaths: o.sourcePaths,
+	})
+	return writeCrowdinResultError(cmd, "download-sources", result, err)
+}
+
+func writeCrowdinDownloadedSource(path string, content []byte, force bool) error {
+	if err := validateCrowdinDownloadSourcesOutputPath(path, force); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("crowdin download sources: mkdir output directory: %w", err)
+	}
+	return writeFileAtomic(path, content)
+}
+
+func validateCrowdinDownloadSourcesOutputPath(path string, force bool) error {
+	if path == "" || path == "-" {
+		return nil
+	}
+	if info, err := os.Stat(path); err == nil {
+		if info.IsDir() {
+			return fmt.Errorf("crowdin download sources: output file %q is a directory", path)
+		}
+		if !force {
+			return fmt.Errorf("crowdin download sources: output file %q already exists; use --force to overwrite", path)
+		}
+	} else if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("crowdin download sources: stat output file %q: %w", path, err)
+	}
+	return nil
 }
 
 func newCrowdinGlossaryCmd() *cobra.Command {

--- a/apps/cli/cmd/crowdin.go
+++ b/apps/cli/cmd/crowdin.go
@@ -280,6 +280,9 @@ func newCrowdinDownloadSourcesCmd() *cobra.Command {
 
 func executeCrowdinDownloadSources(cmd *cobra.Command, o crowdinDownloadSourcesOptions) error {
 	outputPath := strings.TrimSpace(o.outputPath)
+	if outputPath != "" && o.fileID == 0 {
+		return fmt.Errorf("crowdin download sources: --output requires --file-id")
+	}
 	if o.fileID > 0 {
 		if o.dryRun {
 			destination := outputPath

--- a/apps/cli/cmd/crowdin_test.go
+++ b/apps/cli/cmd/crowdin_test.go
@@ -613,3 +613,96 @@ func (f *fakeCrowdinTranslationMemoryWriter) WriteTranslationMemoryTMX(_ context
 	}
 	return crowdinstorage.TranslationMemoryDownloadResult{Rows: 1, Segments: 1}, nil
 }
+
+func TestCrowdinDownloadSourcesDryRunByFileID(t *testing.T) {
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"crowdin", "download", "sources", "--file-id", "101", "--output", "en.json", "--dry-run"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute crowdin download sources dry-run: %v", err)
+	}
+	if !strings.Contains(out.String(), "dry-run action=download-sources") || !strings.Contains(out.String(), "file_id=101") {
+		t.Fatalf("unexpected output: %q", out.String())
+	}
+}
+
+func TestCrowdinDownloadSourcesWritesStdoutByFileID(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("CROWDIN_PROJECT_ID", "123")
+	t.Setenv("CROWDIN_PERSONAL_TOKEN", "secret")
+
+	if err := os.WriteFile(filepath.Join(dir, "crowdin.yml"), []byte(`
+project_id_env: CROWDIN_PROJECT_ID
+api_token_env: CROWDIN_PERSONAL_TOKEN
+`), 0o644); err != nil {
+		t.Fatalf("write crowdin config: %v", err)
+	}
+
+	oldDownloader := downloadCrowdinSourceFileByID
+	defer func() {
+		downloadCrowdinSourceFileByID = oldDownloader
+	}()
+	downloadCrowdinSourceFileByID = func(_ context.Context, cfg crowdinstorage.Config, fileID int) ([]byte, error) {
+		if cfg.ProjectID != "123" || cfg.APIToken != "secret" || fileID != 101 {
+			t.Fatalf("unexpected download input: project=%q token=%q fileID=%d", cfg.ProjectID, cfg.APIToken, fileID)
+		}
+		return []byte(`{"hello":"Hello"}`), nil
+	}
+
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"crowdin", "download", "sources", "--file-id", "101"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute crowdin download sources: %v", err)
+	}
+	if got := out.String(); got != `{"hello":"Hello"}` {
+		t.Fatalf("unexpected stdout content: %q", got)
+	}
+}
+
+func TestCrowdinDownloadSourcesWritesOutputFileByFileID(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("CROWDIN_PROJECT_ID", "123")
+	t.Setenv("CROWDIN_PERSONAL_TOKEN", "secret")
+
+	if err := os.WriteFile(filepath.Join(dir, "crowdin.yml"), []byte(`
+project_id_env: CROWDIN_PROJECT_ID
+api_token_env: CROWDIN_PERSONAL_TOKEN
+`), 0o644); err != nil {
+		t.Fatalf("write crowdin config: %v", err)
+	}
+
+	oldDownloader := downloadCrowdinSourceFileByID
+	defer func() {
+		downloadCrowdinSourceFileByID = oldDownloader
+	}()
+	downloadCrowdinSourceFileByID = func(_ context.Context, _ crowdinstorage.Config, _ int) ([]byte, error) {
+		return []byte(`{"hello":"Hello"}`), nil
+	}
+
+	outputPath := filepath.Join(dir, "locales", "en.json")
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"crowdin", "download", "sources", "--file-id", "101", "--output", outputPath})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute crowdin download sources: %v", err)
+	}
+	content, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read output file: %v", err)
+	}
+	if string(content) != `{"hello":"Hello"}` {
+		t.Fatalf("unexpected file content: %q", string(content))
+	}
+	if !strings.Contains(out.String(), "downloaded file="+outputPath) || !strings.Contains(out.String(), "bytes=17") {
+		t.Fatalf("unexpected output: %q", out.String())
+	}
+}

--- a/apps/cli/cmd/crowdin_test.go
+++ b/apps/cli/cmd/crowdin_test.go
@@ -706,3 +706,18 @@ api_token_env: CROWDIN_PERSONAL_TOKEN
 		t.Fatalf("unexpected output: %q", out.String())
 	}
 }
+
+func TestCrowdinDownloadSourcesOutputRequiresFileID(t *testing.T) {
+	cmd := newRootCmd("")
+	out := bytes.NewBuffer(nil)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"crowdin", "download", "sources", "--output", "en.json"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when --output is set without --file-id")
+	}
+	if !strings.Contains(err.Error(), "--output requires --file-id") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.ts
@@ -95,18 +95,6 @@ function sanitizeSandboxFilename(filename: string): string {
   return filename.replace(/[^a-zA-Z0-9._-]/g, "_");
 }
 
-function getSandboxOutputFilename(attachmentFilename: string, targetLocale: string): string {
-  const inputFilename = sanitizeSandboxFilename(attachmentFilename);
-  const lastDot = inputFilename.lastIndexOf(".");
-  if (lastDot === -1) {
-    return `${inputFilename}-${targetLocale}`;
-  }
-
-  const name = inputFilename.slice(0, lastDot);
-  const ext = inputFilename.slice(lastDot);
-  return `${name}-${targetLocale}${ext}`;
-}
-
 function existingTranslationForLocale(unit: ExternalTmsTranslationUnit, locale: string) {
   return unit.translations.find((translation) => translation.locale === locale) ?? null;
 }
@@ -179,6 +167,8 @@ async function runFileTranslationInSandbox(input: {
 }) {
   const {
     buildTempConfig,
+    extractSandboxEntries,
+    getSandboxOutputFilename,
     getSandboxTranslationEnv,
     readTranslatedFile,
     runSandboxCommand,
@@ -226,46 +216,15 @@ async function runFileTranslationInSandbox(input: {
   }
 
   const translatedContent = await readTranslatedFile(input.sandboxId, outputFilename);
-  const extractResult = await runSandboxCommand(
-    input.sandboxId,
-    "bash",
-    [
-      "-lc",
-      `export PATH="$HOME/.local/bin:$PATH"; hl entries '${shellSingleQuote(outputFilename)}'`,
-    ],
-    { env: getSandboxTranslationEnv(), output: "stdout" },
-  );
-  if (extractResult.exitCode !== 0) {
-    throw new Error(`failed to extract translated entries: ${extractResult.output}`);
+  const translatedEntries = await extractSandboxEntries(input.sandboxId, outputFilename);
+  if (!translatedEntries) {
+    throw new Error(`failed to extract translated entries: ${outputFilename}`);
   }
 
   return {
     translatedText: translatedContent.toString("utf8"),
-    translatedEntries: JSON.parse(extractResult.output) as Record<string, string>,
+    translatedEntries,
   };
-}
-
-async function extractSourceEntriesInSandbox(
-  sandboxId: string,
-  inputFilename: string,
-): Promise<Record<string, string> | null> {
-  const { getSandboxTranslationEnv, runSandboxCommand } =
-    await import("@/lib/translation/sandbox-translation");
-
-  const extractResult = await runSandboxCommand(
-    sandboxId,
-    "bash",
-    [
-      "-lc",
-      `export PATH="$HOME/.local/bin:$PATH"; hl entries '${shellSingleQuote(inputFilename)}'`,
-    ],
-    { env: getSandboxTranslationEnv(), output: "stdout" },
-  );
-  if (extractResult.exitCode !== 0) {
-    return null;
-  }
-
-  return JSON.parse(extractResult.output) as Record<string, string>;
 }
 
 export function shouldUseProviderFileTranslation(input: { sourceFiles: ProviderSourceFileRef[] }) {
@@ -451,6 +410,9 @@ export async function translateProviderJobFiles(input: {
       createTranslationSandbox,
       downloadAttachment,
       downloadCrowdinSourceInSandbox,
+      downloadCrowdinTranslationsInSandbox,
+      extractSandboxEntries,
+      getSandboxOutputFilename,
       prepareSandbox,
       readTranslatedFile,
       stopTranslationSandbox,
@@ -467,7 +429,7 @@ export async function translateProviderJobFiles(input: {
         await downloadCrowdinSourceInSandbox({
           sandboxId,
           externalFileId: sourceFile.id,
-          outputFilename: inputFilename,
+          sourceFilename: inputFilename,
           externalProjectId: crowdinContext.externalProjectId,
           secretMaterial: crowdinContext.secretMaterial,
           baseUrl: crowdinContext.baseUrl,
@@ -495,7 +457,7 @@ export async function translateProviderJobFiles(input: {
       );
 
       try {
-        sourceEntries = await extractSourceEntriesInSandbox(sandboxId, inputFilename);
+        sourceEntries = await extractSandboxEntries(sandboxId, inputFilename);
       } catch (error) {
         warnings.push(
           `Could not extract entries for ${sourceFile.displayName ?? sourceFile.id}: ${
@@ -549,7 +511,24 @@ export async function translateProviderJobFiles(input: {
             sourceEntries,
           });
         }
-        const prefilledEntries = { ...tmPrefilled, ...existingPrefilled };
+
+        let crowdinPrefilled: Record<string, string> = {};
+        if (crowdinContext?.ok) {
+          const outputFilename = getSandboxOutputFilename(inputFilename, targetLocale);
+          const downloadResult = await downloadCrowdinTranslationsInSandbox({
+            sandboxId,
+            targetLocale,
+            externalProjectId: crowdinContext.externalProjectId,
+            secretMaterial: crowdinContext.secretMaterial,
+            baseUrl: crowdinContext.baseUrl,
+            mergeApproved: true,
+          });
+          if (downloadResult.ok) {
+            crowdinPrefilled = (await extractSandboxEntries(sandboxId, outputFilename)) ?? {};
+          }
+        }
+
+        const prefilledEntries = { ...tmPrefilled, ...crowdinPrefilled, ...existingPrefilled };
 
         const localeContext = buildGlossaryContext({
           sourceText,

--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.ts
@@ -301,6 +301,16 @@ export async function translateProviderJobFiles(input: {
     "provider agent file translation started",
   );
 
+  const crowdinContext =
+    input.providerKind === "crowdin"
+      ? await loadProviderCrowdinDownloadContext({
+          organizationId: input.organizationId,
+          projectId: input.projectId,
+          providerKind: input.providerKind,
+          actorUserId: input.actorUserId,
+        })
+      : null;
+
   for (const sourceFile of input.sourceFiles) {
     if (!sourceFile.sourcePath?.trim()) {
       skippedMissingSourcePathCount += 1;
@@ -346,15 +356,6 @@ export async function translateProviderJobFiles(input: {
       continue;
     }
 
-    const crowdinContext =
-      input.providerKind === "crowdin"
-        ? await loadProviderCrowdinDownloadContext({
-            organizationId: input.organizationId,
-            projectId: input.projectId,
-            providerKind: input.providerKind,
-            actorUserId: input.actorUserId,
-          })
-        : null;
     if (crowdinContext && !crowdinContext.ok) {
       skippedDownloadFailureCount += 1;
       logger.warn(

--- a/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/agent-runs/provider-agent-file-translate.ts
@@ -5,7 +5,11 @@ import {
   serializeAgentRunProposalItem,
   type AgentRunProposalItem,
 } from "@/lib/providers/agent-runs/agent-run-proposals";
-import { downloadProviderSourceFile } from "@/lib/providers/download-provider-source-file";
+import {
+  loadProviderCrowdinDownloadContext,
+  resolveProviderSourceFileDownload,
+} from "@/lib/providers/download-provider-source-file";
+import { inferSupportedFileTranslationFileFormat } from "@/lib/translation/file-formats";
 import type {
   ExternalTmsTaskContent,
   ExternalTmsTranslationUnit,
@@ -166,7 +170,7 @@ function buildGlossaryContext(input: {
 }
 
 async function runFileTranslationInSandbox(input: {
-  sourceContent: Buffer;
+  sandboxId: string;
   sourceFilename: string;
   sourceLocale: string;
   targetLocale: string;
@@ -175,81 +179,93 @@ async function runFileTranslationInSandbox(input: {
 }) {
   const {
     buildTempConfig,
-    createTranslationSandbox,
     getSandboxTranslationEnv,
-    prepareSandbox,
     readTranslatedFile,
     runSandboxCommand,
-    stopTranslationSandbox,
     writeFileToSandbox,
     writeTempConfig,
   } = await import("@/lib/translation/sandbox-translation");
 
   const inputFilename = sanitizeSandboxFilename(input.sourceFilename);
   const outputFilename = getSandboxOutputFilename(input.sourceFilename, input.targetLocale);
-  const { sandboxId } = await createTranslationSandbox();
 
-  try {
-    await prepareSandbox(sandboxId);
-    await writeFileToSandbox(sandboxId, inputFilename, input.sourceContent);
+  const configPath = "/tmp/hyperlocalise-file.yml";
+  const config = buildTempConfig(
+    inputFilename,
+    outputFilename,
+    input.sourceLocale,
+    input.targetLocale,
+    null,
+    input.context,
+  );
+  await writeTempConfig(input.sandboxId, config, configPath);
 
-    const configPath = "/tmp/hyperlocalise-file.yml";
-    const config = buildTempConfig(
-      inputFilename,
-      outputFilename,
-      input.sourceLocale,
-      input.targetLocale,
-      null,
-      input.context,
+  const prefilledPath = `/tmp/hyperlocalise-prefilled-${input.targetLocale}.json`;
+  let prefilledFlags = "";
+  if (Object.keys(input.prefilledEntries).length > 0) {
+    await writeFileToSandbox(
+      input.sandboxId,
+      prefilledPath,
+      Buffer.from(JSON.stringify(input.prefilledEntries), "utf8"),
     );
-    await writeTempConfig(sandboxId, config, configPath);
-
-    const prefilledPath = `/tmp/hyperlocalise-prefilled-${input.targetLocale}.json`;
-    let prefilledFlags = "";
-    if (Object.keys(input.prefilledEntries).length > 0) {
-      await writeFileToSandbox(
-        sandboxId,
-        prefilledPath,
-        Buffer.from(JSON.stringify(input.prefilledEntries), "utf8"),
-      );
-      prefilledFlags = ` --prefilled-entries '${shellSingleQuote(prefilledPath)}' --prefilled-target-path '${shellSingleQuote(outputFilename)}'`;
-    }
-
-    const translation = await runSandboxCommand(
-      sandboxId,
-      "bash",
-      [
-        "-lc",
-        `export PATH="$HOME/.local/bin:$PATH"; hl run --config '${shellSingleQuote(configPath)}' --locale '${shellSingleQuote(input.targetLocale)}' --force --progress off${prefilledFlags}`,
-      ],
-      { env: getSandboxTranslationEnv() },
-    );
-
-    if (translation.exitCode !== 0) {
-      throw new Error(`translation failed for ${input.targetLocale}: ${translation.output}`);
-    }
-
-    const translatedContent = await readTranslatedFile(sandboxId, outputFilename);
-    const extractResult = await runSandboxCommand(
-      sandboxId,
-      "bash",
-      [
-        "-lc",
-        `export PATH="$HOME/.local/bin:$PATH"; hl entries '${shellSingleQuote(outputFilename)}'`,
-      ],
-      { env: getSandboxTranslationEnv(), output: "stdout" },
-    );
-    if (extractResult.exitCode !== 0) {
-      throw new Error(`failed to extract translated entries: ${extractResult.output}`);
-    }
-
-    return {
-      translatedText: translatedContent.toString("utf8"),
-      translatedEntries: JSON.parse(extractResult.output) as Record<string, string>,
-    };
-  } finally {
-    await stopTranslationSandbox(sandboxId);
+    prefilledFlags = ` --prefilled-entries '${shellSingleQuote(prefilledPath)}' --prefilled-target-path '${shellSingleQuote(outputFilename)}'`;
   }
+
+  const translation = await runSandboxCommand(
+    input.sandboxId,
+    "bash",
+    [
+      "-lc",
+      `export PATH="$HOME/.local/bin:$PATH"; hl run --config '${shellSingleQuote(configPath)}' --locale '${shellSingleQuote(input.targetLocale)}' --force --progress off${prefilledFlags}`,
+    ],
+    { env: getSandboxTranslationEnv() },
+  );
+
+  if (translation.exitCode !== 0) {
+    throw new Error(`translation failed for ${input.targetLocale}: ${translation.output}`);
+  }
+
+  const translatedContent = await readTranslatedFile(input.sandboxId, outputFilename);
+  const extractResult = await runSandboxCommand(
+    input.sandboxId,
+    "bash",
+    [
+      "-lc",
+      `export PATH="$HOME/.local/bin:$PATH"; hl entries '${shellSingleQuote(outputFilename)}'`,
+    ],
+    { env: getSandboxTranslationEnv(), output: "stdout" },
+  );
+  if (extractResult.exitCode !== 0) {
+    throw new Error(`failed to extract translated entries: ${extractResult.output}`);
+  }
+
+  return {
+    translatedText: translatedContent.toString("utf8"),
+    translatedEntries: JSON.parse(extractResult.output) as Record<string, string>,
+  };
+}
+
+async function extractSourceEntriesInSandbox(
+  sandboxId: string,
+  inputFilename: string,
+): Promise<Record<string, string> | null> {
+  const { getSandboxTranslationEnv, runSandboxCommand } =
+    await import("@/lib/translation/sandbox-translation");
+
+  const extractResult = await runSandboxCommand(
+    sandboxId,
+    "bash",
+    [
+      "-lc",
+      `export PATH="$HOME/.local/bin:$PATH"; hl entries '${shellSingleQuote(inputFilename)}'`,
+    ],
+    { env: getSandboxTranslationEnv(), output: "stdout" },
+  );
+  if (extractResult.exitCode !== 0) {
+    return null;
+  }
+
+  return JSON.parse(extractResult.output) as Record<string, string>;
 }
 
 export function shouldUseProviderFileTranslation(input: { sourceFiles: ProviderSourceFileRef[] }) {
@@ -359,16 +375,28 @@ export async function translateProviderJobFiles(input: {
       continue;
     }
 
-    const download = await downloadProviderSourceFile({
-      organizationId: input.organizationId,
-      projectId: input.projectId,
-      providerKind: input.providerKind,
-      externalFileId: sourceFile.id,
-      sourcePath: sourceFile.sourcePath,
-      actorUserId: input.actorUserId,
-    });
+    const inputFilename = sanitizeSandboxFilename(
+      sourceFile.sourcePath.split("/").pop() ?? `source-${sourceFile.id}`,
+    );
+    const fileFormat = inferSupportedFileTranslationFileFormat(sourceFile.sourcePath);
+    if (!fileFormat) {
+      skippedDownloadFailureCount += 1;
+      warnings.push(
+        `Skipped file ${sourceFile.displayName ?? sourceFile.id}: Source path ${sourceFile.sourcePath} is not a supported translation file format`,
+      );
+      continue;
+    }
 
-    if (!download.ok) {
+    const crowdinContext =
+      input.providerKind === "crowdin"
+        ? await loadProviderCrowdinDownloadContext({
+            organizationId: input.organizationId,
+            projectId: input.projectId,
+            providerKind: input.providerKind,
+            actorUserId: input.actorUserId,
+          })
+        : null;
+    if (crowdinContext && !crowdinContext.ok) {
       skippedDownloadFailureCount += 1;
       logger.warn(
         {
@@ -376,198 +404,260 @@ export async function translateProviderJobFiles(input: {
           sourceFileId: sourceFile.id,
           displayName: sourceFile.displayName,
           sourcePath: sourceFile.sourcePath,
-          downloadCode: download.code,
+          downloadCode: crowdinContext.code,
           matchingUnitCount: fileUnits.length,
           reason: "source_file_download_failed",
         },
         "provider agent file translation skipped source file after download failure",
       );
-      warnings.push(`Skipped file ${sourceFile.displayName ?? sourceFile.id}: ${download.message}`);
+      warnings.push(
+        `Skipped file ${sourceFile.displayName ?? sourceFile.id}: ${crowdinContext.message}`,
+      );
       continue;
     }
 
-    filesProcessed += 1;
-    logger.info(
-      {
-        ...logContext,
-        sourceFileId: sourceFile.id,
-        displayName: sourceFile.displayName,
-        sourcePath: sourceFile.sourcePath,
-        matchingUnitCount: fileUnits.length,
-        byteLength: download.content.byteLength,
-      },
-      "provider agent file translation downloaded source file",
-    );
-    const sourceText = download.content.toString("utf8");
-    const fileGlossaryTerms = await loadFileGlossaryTerms({
-      projectId: input.projectId,
-      sourceLocale,
-      targetLocales,
-      sourceText,
-    });
-
-    let sourceEntries: Record<string, string> | null = null;
-    try {
-      const {
-        createTranslationSandbox,
-        prepareSandbox,
-        runSandboxCommand,
-        stopTranslationSandbox,
-        writeFileToSandbox,
-        getSandboxTranslationEnv,
-      } = await import("@/lib/translation/sandbox-translation");
-      const inputFilename = sanitizeSandboxFilename(download.filename);
-      const { sandboxId } = await createTranslationSandbox();
-      try {
-        await prepareSandbox(sandboxId);
-        await writeFileToSandbox(sandboxId, inputFilename, download.content);
-        const extractResult = await runSandboxCommand(
-          sandboxId,
-          "bash",
-          [
-            "-lc",
-            `export PATH="$HOME/.local/bin:$PATH"; hl entries '${shellSingleQuote(inputFilename)}'`,
-          ],
-          { env: getSandboxTranslationEnv(), output: "stdout" },
-        );
-        if (extractResult.exitCode === 0) {
-          sourceEntries = JSON.parse(extractResult.output) as Record<string, string>;
-        }
-      } finally {
-        await stopTranslationSandbox(sandboxId);
-      }
-    } catch (error) {
-      warnings.push(
-        `Could not extract entries for ${sourceFile.displayName ?? sourceFile.id}: ${
-          error instanceof Error ? error.message : "unknown error"
-        }`,
+    const resolvedDownload =
+      input.providerKind !== "crowdin"
+        ? await resolveProviderSourceFileDownload({
+            organizationId: input.organizationId,
+            projectId: input.projectId,
+            providerKind: input.providerKind,
+            externalFileId: sourceFile.id,
+            sourcePath: sourceFile.sourcePath,
+            actorUserId: input.actorUserId,
+          })
+        : null;
+    if (resolvedDownload && !resolvedDownload.ok) {
+      skippedDownloadFailureCount += 1;
+      logger.warn(
+        {
+          ...logContext,
+          sourceFileId: sourceFile.id,
+          displayName: sourceFile.displayName,
+          sourcePath: sourceFile.sourcePath,
+          downloadCode: resolvedDownload.code,
+          matchingUnitCount: fileUnits.length,
+          reason: "source_file_download_failed",
+        },
+        "provider agent file translation skipped source file after download failure",
       );
+      warnings.push(
+        `Skipped file ${sourceFile.displayName ?? sourceFile.id}: ${resolvedDownload.message}`,
+      );
+      continue;
     }
 
-    for (const targetLocale of targetLocales) {
-      const localesNeedingTranslation = fileUnits.filter((unit) => {
-        const existing = existingTranslationForLocale(unit, targetLocale);
-        if (shouldSkipExistingTranslation(existing)) {
-          skippedExistingLocales += 1;
-          return false;
-        }
-        return true;
-      });
-      unitsProcessed += localesNeedingTranslation.length;
+    const {
+      createTranslationSandbox,
+      downloadAttachment,
+      downloadCrowdinSourceInSandbox,
+      prepareSandbox,
+      readTranslatedFile,
+      stopTranslationSandbox,
+    } = await import("@/lib/translation/sandbox-translation");
+    const { sandboxId } = await createTranslationSandbox();
 
-      if (localesNeedingTranslation.length === 0) {
-        logger.info(
-          {
-            ...logContext,
-            sourceFileId: sourceFile.id,
-            targetLocale,
-            matchingUnitCount: fileUnits.length,
-            reason: "all_units_already_translated",
-          },
-          "provider agent file translation skipped locale because all units already have translations",
-        );
-        continue;
-      }
+    let sourceText = "";
+    let sourceEntries: Record<string, string> | null = null;
 
-      const existingPrefilled = buildPrefilledEntriesForLocale({
-        units: fileUnits,
-        targetLocale,
-      });
-      let tmPrefilled: Record<string, string> = {};
-      if (sourceEntries) {
-        tmPrefilled = await reuseFileTranslationMemoryEntries({
-          projectId: input.projectId,
-          sourceLocale,
-          targetLocale,
-          sourceEntries,
+    try {
+      await prepareSandbox(sandboxId);
+
+      if (crowdinContext?.ok) {
+        await downloadCrowdinSourceInSandbox({
+          sandboxId,
+          externalFileId: sourceFile.id,
+          outputFilename: inputFilename,
+          externalProjectId: crowdinContext.externalProjectId,
+          secretMaterial: crowdinContext.secretMaterial,
+          baseUrl: crowdinContext.baseUrl,
         });
+      } else if (resolvedDownload?.ok) {
+        await downloadAttachment(sandboxId, resolvedDownload.downloadUrl, inputFilename);
       }
-      const prefilledEntries = { ...tmPrefilled, ...existingPrefilled };
 
-      const localeContext = buildGlossaryContext({
-        sourceText,
-        projectName: project.name,
-        projectTranslationContext: project.translationContext,
-        glossaryTerms: fileGlossaryTerms,
-        targetLocale,
-      });
+      const sourceContent = await readTranslatedFile(sandboxId, inputFilename);
+      sourceText = sourceContent.toString("utf8");
+
+      filesProcessed += 1;
+      logger.info(
+        {
+          ...logContext,
+          sourceFileId: sourceFile.id,
+          displayName: sourceFile.displayName,
+          sourcePath: sourceFile.sourcePath,
+          matchingUnitCount: fileUnits.length,
+          byteLength: sourceContent.byteLength,
+          sandboxId,
+          downloadMethod: crowdinContext?.ok ? "hl-crowdin-download-sources" : "curl",
+        },
+        "provider agent file translation downloaded source file in sandbox",
+      );
 
       try {
-        const { translatedText, translatedEntries } = await runFileTranslationInSandbox({
-          sourceContent: download.content,
-          sourceFilename: download.filename,
-          sourceLocale,
-          targetLocale,
-          context: localeContext,
-          prefilledEntries,
-        });
-
-        const glossaryFailures = validateGlossaryTermsInTranslation({
-          sourceText,
-          translatedText,
-          terms: (localeContext.glossaryTerms ?? []).map((term) => ({
-            sourceTerm: term.sourceTerm,
-            targetTerm: term.targetTerm,
-            targetLocale: term.targetLocale,
-            forbidden: term.forbidden ?? null,
-            caseSensitive: term.caseSensitive ?? null,
-          })),
-        });
-        if (glossaryFailures.length > 0) {
-          warnings.push(
-            `Glossary validation failed for ${sourceFile.displayName ?? sourceFile.id} (${targetLocale})`,
-          );
-        }
-
-        for (const unit of localesNeedingTranslation) {
-          const existing = existingTranslationForLocale(unit, targetLocale);
-          const from = existing?.text ?? "";
-          const to = translatedEntries[unit.key] ?? from;
-          if (!to.trim() || to === from) {
-            continue;
-          }
-
-          const proposalWarnings = detectAgentRunProposalWarnings({
-            sourceText: unit.sourceText,
-            from,
-            to,
-            locale: targetLocale,
-            externalStringId: unit.externalStringId,
-            key: unit.key,
-            glossaryTerms: (localeContext.glossaryTerms ?? []).map((term) => ({
-              sourceTerm: term.sourceTerm,
-              targetTerm: term.targetTerm,
-              targetLocale: term.targetLocale,
-              forbidden: term.forbidden,
-              caseSensitive: term.caseSensitive,
-            })),
-          });
-
-          changedItems.push(
-            serializeAgentRunProposalItem({
-              itemId: buildAgentRunProposalItemId({
-                externalStringId: unit.externalStringId,
-                locale: targetLocale,
-              }),
-              externalStringId: unit.externalStringId,
-              key: unit.key,
-              locale: targetLocale,
-              sourceText: unit.sourceText,
-              from,
-              to,
-              reviewState: "pending",
-              changedFields: deriveChangedFields(from, to),
-              warnings: proposalWarnings,
-            }),
-          );
-        }
+        sourceEntries = await extractSourceEntriesInSandbox(sandboxId, inputFilename);
       } catch (error) {
         warnings.push(
-          `File translation failed for ${sourceFile.displayName ?? sourceFile.id} (${targetLocale}): ${
+          `Could not extract entries for ${sourceFile.displayName ?? sourceFile.id}: ${
             error instanceof Error ? error.message : "unknown error"
           }`,
         );
       }
+
+      const fileGlossaryTerms = await loadFileGlossaryTerms({
+        projectId: input.projectId,
+        sourceLocale,
+        targetLocales,
+        sourceText,
+      });
+
+      for (const targetLocale of targetLocales) {
+        const localesNeedingTranslation = fileUnits.filter((unit) => {
+          const existing = existingTranslationForLocale(unit, targetLocale);
+          if (shouldSkipExistingTranslation(existing)) {
+            skippedExistingLocales += 1;
+            return false;
+          }
+          return true;
+        });
+        unitsProcessed += localesNeedingTranslation.length;
+
+        if (localesNeedingTranslation.length === 0) {
+          logger.info(
+            {
+              ...logContext,
+              sourceFileId: sourceFile.id,
+              targetLocale,
+              matchingUnitCount: fileUnits.length,
+              reason: "all_units_already_translated",
+            },
+            "provider agent file translation skipped locale because all units already have translations",
+          );
+          continue;
+        }
+
+        const existingPrefilled = buildPrefilledEntriesForLocale({
+          units: fileUnits,
+          targetLocale,
+        });
+        let tmPrefilled: Record<string, string> = {};
+        if (sourceEntries) {
+          tmPrefilled = await reuseFileTranslationMemoryEntries({
+            projectId: input.projectId,
+            sourceLocale,
+            targetLocale,
+            sourceEntries,
+          });
+        }
+        const prefilledEntries = { ...tmPrefilled, ...existingPrefilled };
+
+        const localeContext = buildGlossaryContext({
+          sourceText,
+          projectName: project.name,
+          projectTranslationContext: project.translationContext,
+          glossaryTerms: fileGlossaryTerms,
+          targetLocale,
+        });
+
+        try {
+          const { translatedText, translatedEntries } = await runFileTranslationInSandbox({
+            sandboxId,
+            sourceFilename: inputFilename,
+            sourceLocale,
+            targetLocale,
+            context: localeContext,
+            prefilledEntries,
+          });
+
+          const glossaryFailures = validateGlossaryTermsInTranslation({
+            sourceText,
+            translatedText,
+            terms: (localeContext.glossaryTerms ?? []).map((term) => ({
+              sourceTerm: term.sourceTerm,
+              targetTerm: term.targetTerm,
+              targetLocale: term.targetLocale,
+              forbidden: term.forbidden ?? null,
+              caseSensitive: term.caseSensitive ?? null,
+            })),
+          });
+          if (glossaryFailures.length > 0) {
+            warnings.push(
+              `Glossary validation failed for ${sourceFile.displayName ?? sourceFile.id} (${targetLocale})`,
+            );
+          }
+
+          for (const unit of localesNeedingTranslation) {
+            const existing = existingTranslationForLocale(unit, targetLocale);
+            const from = existing?.text ?? "";
+            const to = translatedEntries[unit.key] ?? from;
+            if (!to.trim() || to === from) {
+              continue;
+            }
+
+            const proposalWarnings = detectAgentRunProposalWarnings({
+              sourceText: unit.sourceText,
+              from,
+              to,
+              locale: targetLocale,
+              externalStringId: unit.externalStringId,
+              key: unit.key,
+              glossaryTerms: (localeContext.glossaryTerms ?? []).map((term) => ({
+                sourceTerm: term.sourceTerm,
+                targetTerm: term.targetTerm,
+                targetLocale: term.targetLocale,
+                forbidden: term.forbidden,
+                caseSensitive: term.caseSensitive,
+              })),
+            });
+
+            changedItems.push(
+              serializeAgentRunProposalItem({
+                itemId: buildAgentRunProposalItemId({
+                  externalStringId: unit.externalStringId,
+                  locale: targetLocale,
+                }),
+                externalStringId: unit.externalStringId,
+                key: unit.key,
+                locale: targetLocale,
+                sourceText: unit.sourceText,
+                from,
+                to,
+                reviewState: "pending",
+                changedFields: deriveChangedFields(from, to),
+                warnings: proposalWarnings,
+              }),
+            );
+          }
+        } catch (error) {
+          warnings.push(
+            `File translation failed for ${sourceFile.displayName ?? sourceFile.id} (${targetLocale}): ${
+              error instanceof Error ? error.message : "unknown error"
+            }`,
+          );
+        }
+      }
+    } catch (error) {
+      skippedDownloadFailureCount += 1;
+      logger.warn(
+        {
+          ...logContext,
+          sourceFileId: sourceFile.id,
+          displayName: sourceFile.displayName,
+          sourcePath: sourceFile.sourcePath,
+          matchingUnitCount: fileUnits.length,
+          sandboxId,
+          reason: "sandbox_source_file_download_failed",
+          err: error instanceof Error ? error.message : "unknown error",
+        },
+        "provider agent file translation skipped source file after sandbox download failure",
+      );
+      warnings.push(
+        `Skipped file ${sourceFile.displayName ?? sourceFile.id}: ${
+          error instanceof Error ? error.message : "sandbox download failed"
+        }`,
+      );
+    } finally {
+      await stopTranslationSandbox(sandboxId);
     }
   }
 

--- a/apps/hyperlocalise-web/src/lib/providers/download-provider-source-file.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/download-provider-source-file.ts
@@ -7,15 +7,30 @@ import type {
   ExternalTmsCredential,
   ExternalTmsProviderKind,
 } from "@/lib/providers/organization-external-tms-provider-credentials";
+import { normalizeProviderDownloadUrl } from "@/lib/providers/provider-url-safety";
 import { resolveExternalTmsSecretMaterialForActor } from "@/lib/providers/tms-provider-content";
 
-export type DownloadProviderSourceFileResult =
+type ProviderSourceFileMetadata = {
+  filename: string;
+  fileFormat: NonNullable<ReturnType<typeof inferSupportedFileTranslationFileFormat>>;
+};
+
+export type ResolveProviderSourceFileDownloadResult =
+  | ({
+      ok: true;
+      downloadUrl: string;
+    } & ProviderSourceFileMetadata)
   | {
+      ok: false;
+      code: string;
+      message: string;
+    };
+
+export type DownloadProviderSourceFileResult =
+  | ({
       ok: true;
       content: Buffer;
-      filename: string;
-      fileFormat: NonNullable<ReturnType<typeof inferSupportedFileTranslationFileFormat>>;
-    }
+    } & ProviderSourceFileMetadata)
   | {
       ok: false;
       code: string;
@@ -72,13 +87,17 @@ async function loadProjectCredential(input: {
   };
 }
 
-async function downloadCrowdinSourceFile(input: {
-  credential: ExternalTmsCredential;
-  secretMaterial: string;
-  externalProjectId: string;
-  externalFileId: string;
-  sourcePath: string;
-}): Promise<DownloadProviderSourceFileResult> {
+function resolveCrowdinSourceFileMetadata(input: { externalFileId: string; sourcePath: string }):
+  | {
+      ok: true;
+      filename: string;
+      fileFormat: NonNullable<ReturnType<typeof inferSupportedFileTranslationFileFormat>>;
+    }
+  | {
+      ok: false;
+      code: string;
+      message: string;
+    } {
   const fileFormat = inferSupportedFileTranslationFileFormat(input.sourcePath);
   if (!fileFormat) {
     return {
@@ -86,6 +105,28 @@ async function downloadCrowdinSourceFile(input: {
       code: "unsupported_file_format",
       message: `Source path ${input.sourcePath} is not a supported translation file format`,
     };
+  }
+
+  return {
+    ok: true,
+    filename: input.sourcePath.split("/").pop() ?? `source-${input.externalFileId}`,
+    fileFormat,
+  };
+}
+
+async function resolveCrowdinSourceFileDownload(input: {
+  credential: ExternalTmsCredential;
+  secretMaterial: string;
+  externalProjectId: string;
+  externalFileId: string;
+  sourcePath: string;
+}): Promise<ResolveProviderSourceFileDownloadResult> {
+  const metadata = resolveCrowdinSourceFileMetadata({
+    externalFileId: input.externalFileId,
+    sourcePath: input.sourcePath,
+  });
+  if (!metadata.ok) {
+    return metadata;
   }
 
   const projectId = Number(input.externalProjectId);
@@ -105,14 +146,20 @@ async function downloadCrowdinSourceFile(input: {
 
   try {
     const downloadLink = await client.downloadFile(projectId, fileId);
-    const bytes = await client.downloadUrl(downloadLink.url);
-    const filename = input.sourcePath.split("/").pop() ?? `source-${input.externalFileId}`;
+    const downloadUrl = normalizeProviderDownloadUrl(downloadLink.url);
+    if (!downloadUrl) {
+      return {
+        ok: false,
+        code: "provider_file_download_url_invalid",
+        message: "Provider file download URL is invalid or unsafe",
+      };
+    }
 
     return {
       ok: true,
-      content: Buffer.from(bytes),
-      filename,
-      fileFormat,
+      downloadUrl,
+      filename: metadata.filename,
+      fileFormat: metadata.fileFormat,
     };
   } catch (error) {
     if (error instanceof CrowdinApiError && error.status === 401) {
@@ -129,6 +176,139 @@ async function downloadCrowdinSourceFile(input: {
       message: error instanceof Error ? error.message : "Provider file download failed",
     };
   }
+}
+
+async function downloadCrowdinSourceFile(input: {
+  credential: ExternalTmsCredential;
+  secretMaterial: string;
+  externalProjectId: string;
+  externalFileId: string;
+  sourcePath: string;
+}): Promise<DownloadProviderSourceFileResult> {
+  const resolved = await resolveCrowdinSourceFileDownload(input);
+  if (!resolved.ok) {
+    return resolved;
+  }
+
+  const client = new CrowdinApiClient({
+    token: input.secretMaterial,
+    baseUrl: input.credential.baseUrl ?? undefined,
+  });
+
+  try {
+    const bytes = await client.downloadUrl(resolved.downloadUrl);
+    return {
+      ok: true,
+      content: Buffer.from(bytes),
+      filename: resolved.filename,
+      fileFormat: resolved.fileFormat,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      code: "provider_file_download_failed",
+      message: error instanceof Error ? error.message : "Provider file download failed",
+    };
+  }
+}
+
+export async function loadProviderCrowdinDownloadContext(input: {
+  organizationId: string;
+  projectId: string;
+  providerKind: ExternalTmsProviderKind;
+  actorUserId?: string | null;
+}): Promise<
+  | {
+      ok: true;
+      externalProjectId: string;
+      secretMaterial: string;
+      baseUrl: string | null;
+    }
+  | {
+      ok: false;
+      code: string;
+      message: string;
+    }
+> {
+  if (input.providerKind !== "crowdin") {
+    return {
+      ok: false,
+      code: "provider_file_download_unsupported",
+      message: `File download is not supported for ${input.providerKind} yet`,
+    };
+  }
+
+  const context = await loadProjectCredential({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    providerKind: input.providerKind,
+  });
+
+  if (!context) {
+    return {
+      ok: false,
+      code: "provider_project_unavailable",
+      message: "Provider project credentials are unavailable",
+    };
+  }
+
+  const secretMaterial = await resolveExternalTmsSecretMaterialForActor({
+    credential: context.credential,
+    organizationId: input.organizationId,
+    actorUserId: input.actorUserId,
+  });
+
+  return {
+    ok: true,
+    externalProjectId: context.externalProjectId,
+    secretMaterial,
+    baseUrl: context.credential.baseUrl ?? null,
+  };
+}
+
+export async function resolveProviderSourceFileDownload(input: {
+  organizationId: string;
+  projectId: string;
+  providerKind: ExternalTmsProviderKind;
+  externalFileId: string;
+  sourcePath: string;
+  actorUserId?: string | null;
+}): Promise<ResolveProviderSourceFileDownloadResult> {
+  const context = await loadProjectCredential({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    providerKind: input.providerKind,
+  });
+
+  if (!context) {
+    return {
+      ok: false,
+      code: "provider_project_unavailable",
+      message: "Provider project credentials are unavailable",
+    };
+  }
+
+  const secretMaterial = await resolveExternalTmsSecretMaterialForActor({
+    credential: context.credential,
+    organizationId: input.organizationId,
+    actorUserId: input.actorUserId,
+  });
+
+  if (input.providerKind === "crowdin") {
+    return resolveCrowdinSourceFileDownload({
+      credential: context.credential,
+      secretMaterial,
+      externalProjectId: context.externalProjectId,
+      externalFileId: input.externalFileId,
+      sourcePath: input.sourcePath,
+    });
+  }
+
+  return {
+    ok: false,
+    code: "provider_file_download_unsupported",
+    message: `File download is not supported for ${input.providerKind} yet`,
+  };
 }
 
 export async function downloadProviderSourceFile(input: {

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.test.ts
@@ -25,6 +25,8 @@ vi.mock("@vercel/sandbox", () => ({
 }));
 
 import {
+  buildCrowdinFileSandboxConfig,
+  buildCrowdinTranslationPath,
   buildTempConfig,
   createTranslationSandbox,
   runSandboxCommand,
@@ -138,6 +140,19 @@ describe("sandbox translation temporary config", () => {
     expect(config).toContain("system_prompt:");
     expect(config).not.toContain("Project translation context:");
     expect(config).not.toContain("Glossary terms:");
+  });
+});
+
+describe("crowdin sandbox file config", () => {
+  it("maps source and translation paths for hl crowdin download commands", () => {
+    expect(buildCrowdinTranslationPath("messages.json")).toBe("messages-%locale%.json");
+
+    const config = buildCrowdinFileSandboxConfig({
+      sourceFilename: "messages.json",
+      includeBaseUrl: false,
+    });
+    expect(config).toContain("source: messages.json");
+    expect(config).toContain("translation: messages-%locale%.json");
   });
 });
 

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.ts
@@ -235,6 +235,61 @@ export function getSandboxOutputFilename(attachmentFilename: string, targetLocal
   return getOutputFilename(sanitizeFilename(attachmentFilename), targetLocale);
 }
 
+export function buildCrowdinSandboxConfig(input: { includeBaseUrl: boolean }): string {
+  const lines = ["project_id_env: CROWDIN_PROJECT_ID", "api_token_env: CROWDIN_PERSONAL_TOKEN"];
+  if (input.includeBaseUrl) {
+    lines.push("base_url_env: CROWDIN_BASE_URL");
+  }
+  return lines.join("\n");
+}
+
+export function getCrowdinSandboxEnv(input: {
+  externalProjectId: string;
+  secretMaterial: string;
+  baseUrl?: string | null;
+}): Record<string, string> {
+  const env: Record<string, string> = {
+    CROWDIN_PROJECT_ID: input.externalProjectId,
+    CROWDIN_PERSONAL_TOKEN: input.secretMaterial,
+  };
+  if (input.baseUrl?.trim()) {
+    env.CROWDIN_BASE_URL = input.baseUrl.trim();
+  }
+  return env;
+}
+
+export async function downloadCrowdinSourceInSandbox(input: {
+  sandboxId: string;
+  externalFileId: string;
+  outputFilename: string;
+  externalProjectId: string;
+  secretMaterial: string;
+  baseUrl?: string | null;
+}): Promise<void> {
+  const configPath = "/tmp/crowdin.yml";
+  const config = buildCrowdinSandboxConfig({ includeBaseUrl: Boolean(input.baseUrl?.trim()) });
+  await writeFilesToSandbox(input.sandboxId, [{ path: configPath, content: config }]);
+
+  const fileId = Number(input.externalFileId);
+  if (Number.isNaN(fileId)) {
+    throw new Error("Provider file identifiers are invalid");
+  }
+
+  const result = await runSandboxCommand(
+    input.sandboxId,
+    "bash",
+    [
+      "-lc",
+      `export PATH="$HOME/.local/bin:$PATH"; hl crowdin download sources --config ${shellQuote(configPath)} --file-id ${fileId} --output ${shellQuote(input.outputFilename)} --force`,
+    ],
+    { env: getCrowdinSandboxEnv(input) },
+  );
+
+  if (result.exitCode !== 0) {
+    throw new Error(`crowdin source download failed: ${result.output}`);
+  }
+}
+
 export function userFacingFailureReason(error: unknown): string {
   const message = error instanceof Error ? error.message : "Unknown translation failure";
 
@@ -248,6 +303,10 @@ export function userFacingFailureReason(error: unknown): string {
 
   if (message.includes("failed to download attachment")) {
     return "the attachment couldn't be retrieved. It may have been too large or the link expired.";
+  }
+
+  if (message.includes("crowdin source download failed")) {
+    return "the source file couldn't be downloaded from Crowdin. This is usually temporary.";
   }
 
   if (message.includes("translation failed")) {

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.ts
@@ -369,28 +369,6 @@ export async function downloadCrowdinTranslationsInSandbox(input: {
   return { ok: true };
 }
 
-export async function uploadCrowdinTranslationsInSandbox(input: {
-  sandboxId: string;
-  targetLocale: string;
-  externalProjectId: string;
-  secretMaterial: string;
-  baseUrl?: string | null;
-}): Promise<void> {
-  const result = await runSandboxCommand(
-    input.sandboxId,
-    "bash",
-    [
-      "-lc",
-      `export PATH="$HOME/.local/bin:$PATH"; hl crowdin upload translations --config ${shellQuote(crowdinSandboxConfigPath)} --language ${shellQuote(input.targetLocale)}`,
-    ],
-    { env: getCrowdinSandboxEnv(input) },
-  );
-
-  if (result.exitCode !== 0) {
-    throw new Error(`crowdin translation upload failed: ${result.output}`);
-  }
-}
-
 export function userFacingFailureReason(error: unknown): string {
   const message = error instanceof Error ? error.message : "Unknown translation failure";
 

--- a/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/sandbox-translation.ts
@@ -235,11 +235,33 @@ export function getSandboxOutputFilename(attachmentFilename: string, targetLocal
   return getOutputFilename(sanitizeFilename(attachmentFilename), targetLocale);
 }
 
-export function buildCrowdinSandboxConfig(input: { includeBaseUrl: boolean }): string {
+export const crowdinSandboxConfigPath = "/tmp/crowdin.yml";
+
+export function buildCrowdinTranslationPath(sourceFilename: string): string {
+  const lastDot = sourceFilename.lastIndexOf(".");
+  if (lastDot === -1) {
+    return `${sourceFilename}-%locale%`;
+  }
+
+  return `${sourceFilename.slice(0, lastDot)}-%locale%${sourceFilename.slice(lastDot)}`;
+}
+
+export function buildCrowdinFileSandboxConfig(input: {
+  sourceFilename: string;
+  includeBaseUrl: boolean;
+}): string {
   const lines = ["project_id_env: CROWDIN_PROJECT_ID", "api_token_env: CROWDIN_PERSONAL_TOKEN"];
   if (input.includeBaseUrl) {
     lines.push("base_url_env: CROWDIN_BASE_URL");
   }
+
+  lines.push(
+    "base_path: .",
+    "files:",
+    `  - source: ${input.sourceFilename}`,
+    `    translation: ${buildCrowdinTranslationPath(input.sourceFilename)}`,
+  );
+
   return lines.join("\n");
 }
 
@@ -258,17 +280,48 @@ export function getCrowdinSandboxEnv(input: {
   return env;
 }
 
+export async function writeCrowdinFileSandboxConfig(input: {
+  sandboxId: string;
+  sourceFilename: string;
+  baseUrl?: string | null;
+}): Promise<void> {
+  const config = buildCrowdinFileSandboxConfig({
+    sourceFilename: input.sourceFilename,
+    includeBaseUrl: Boolean(input.baseUrl?.trim()),
+  });
+  await writeFilesToSandbox(input.sandboxId, [{ path: crowdinSandboxConfigPath, content: config }]);
+}
+
+export async function extractSandboxEntries(
+  sandboxId: string,
+  path: string,
+): Promise<Record<string, string> | null> {
+  const result = await runSandboxCommand(
+    sandboxId,
+    "bash",
+    ["-lc", `export PATH="$HOME/.local/bin:$PATH"; hl entries ${shellQuote(path)}`],
+    { env: getSandboxTranslationEnv(), output: "stdout" },
+  );
+  if (result.exitCode !== 0) {
+    return null;
+  }
+
+  return JSON.parse(result.output) as Record<string, string>;
+}
+
 export async function downloadCrowdinSourceInSandbox(input: {
   sandboxId: string;
   externalFileId: string;
-  outputFilename: string;
+  sourceFilename: string;
   externalProjectId: string;
   secretMaterial: string;
   baseUrl?: string | null;
 }): Promise<void> {
-  const configPath = "/tmp/crowdin.yml";
-  const config = buildCrowdinSandboxConfig({ includeBaseUrl: Boolean(input.baseUrl?.trim()) });
-  await writeFilesToSandbox(input.sandboxId, [{ path: configPath, content: config }]);
+  await writeCrowdinFileSandboxConfig({
+    sandboxId: input.sandboxId,
+    sourceFilename: input.sourceFilename,
+    baseUrl: input.baseUrl,
+  });
 
   const fileId = Number(input.externalFileId);
   if (Number.isNaN(fileId)) {
@@ -280,13 +333,61 @@ export async function downloadCrowdinSourceInSandbox(input: {
     "bash",
     [
       "-lc",
-      `export PATH="$HOME/.local/bin:$PATH"; hl crowdin download sources --config ${shellQuote(configPath)} --file-id ${fileId} --output ${shellQuote(input.outputFilename)} --force`,
+      `export PATH="$HOME/.local/bin:$PATH"; hl crowdin download sources --config ${shellQuote(crowdinSandboxConfigPath)} --file-id ${fileId} --output ${shellQuote(input.sourceFilename)} --force`,
     ],
     { env: getCrowdinSandboxEnv(input) },
   );
 
   if (result.exitCode !== 0) {
     throw new Error(`crowdin source download failed: ${result.output}`);
+  }
+}
+
+export async function downloadCrowdinTranslationsInSandbox(input: {
+  sandboxId: string;
+  targetLocale: string;
+  externalProjectId: string;
+  secretMaterial: string;
+  baseUrl?: string | null;
+  mergeApproved?: boolean;
+}): Promise<{ ok: true } | { ok: false; output: string }> {
+  const mergeFlag = input.mergeApproved ? " --merge-approved" : "";
+  const result = await runSandboxCommand(
+    input.sandboxId,
+    "bash",
+    [
+      "-lc",
+      `export PATH="$HOME/.local/bin:$PATH"; hl crowdin download translations --config ${shellQuote(crowdinSandboxConfigPath)} --language ${shellQuote(input.targetLocale)}${mergeFlag}`,
+    ],
+    { env: getCrowdinSandboxEnv(input) },
+  );
+
+  if (result.exitCode !== 0) {
+    return { ok: false, output: result.output };
+  }
+
+  return { ok: true };
+}
+
+export async function uploadCrowdinTranslationsInSandbox(input: {
+  sandboxId: string;
+  targetLocale: string;
+  externalProjectId: string;
+  secretMaterial: string;
+  baseUrl?: string | null;
+}): Promise<void> {
+  const result = await runSandboxCommand(
+    input.sandboxId,
+    "bash",
+    [
+      "-lc",
+      `export PATH="$HOME/.local/bin:$PATH"; hl crowdin upload translations --config ${shellQuote(crowdinSandboxConfigPath)} --language ${shellQuote(input.targetLocale)}`,
+    ],
+    { env: getCrowdinSandboxEnv(input) },
+  );
+
+  if (result.exitCode !== 0) {
+    throw new Error(`crowdin translation upload failed: ${result.output}`);
   }
 }
 

--- a/docs/commands/crowdin.mdx
+++ b/docs/commands/crowdin.mdx
@@ -10,7 +10,8 @@ hyperlocalise crowdin init
 hyperlocalise crowdin config validate [--config <path>] [--identity <path>]
 hyperlocalise crowdin upload sources [--config <path>] [--identity <path>] [--branch <name>]
 hyperlocalise crowdin upload translations [--config <path>] [--identity <path>] [--branch <name>] [--language <locale>]
-hyperlocalise crowdin download [--config <path>] [--identity <path>] [--branch <name>] [--language <locale>] [--export-only-approved] [--skip-untranslated-strings] [--merge-approved] [--include-sources]
+hyperlocalise crowdin download sources [--config <path>] [--identity <path>] [--branch <name>] [--file-id <id>] [--source <path>] [--output <path>] [--force]
+hyperlocalise crowdin download translations [--config <path>] [--identity <path>] [--branch <name>] [--language <locale>] [--export-only-approved] [--skip-untranslated-strings] [--merge-approved] [--include-sources]
 ```
 
 ## What this command family does
@@ -23,8 +24,9 @@ Use them when you want Crowdin-compatible file mode:
 
 - source-file upload from `files[].source`
 - translation upload from `files[].translation`
+- source download into `files[].source` or a single output file
 - translation download/export back into your repo
-- optional source download back into `files[].source` with `--include-sources`
+- optional source download alongside translations with `download translations --include-sources`
 - branch-scoped upload and download with root `branch:` or `--branch`
 - strict YAML decoding: only keys Crowdin documents and `hl` recognizes may appear in `crowdin.yml` (unknown keys still error)
 
@@ -93,19 +95,39 @@ Upload sources to a Crowdin branch:
 hyperlocalise crowdin upload sources --branch feature/login
 ```
 
+Download source files from `crowdin.yml` into their configured `files[].source` paths:
+
+```bash
+hyperlocalise crowdin download sources
+```
+
+Download one Crowdin source file by file ID:
+
+```bash
+hyperlocalise crowdin download sources --file-id 101 --output /tmp/messages.json --force
+```
+
+When you pass `--file-id`, Hyperlocalise downloads that file directly from Crowdin. Use `--output` to write a file, or omit it to print the source content to stdout. Credentials still come from `crowdin.yml`, `.crowdin.yml`, or the usual `CROWDIN_PROJECT_ID` and `CROWDIN_PERSONAL_TOKEN` environment variables.
+
+Limit a config-based source download to one or more configured paths:
+
+```bash
+hyperlocalise crowdin download sources --source /src/messages.json
+```
+
 Download only approved French translations:
 
 ```bash
-hyperlocalise crowdin download --language fr --export-only-approved --skip-untranslated-strings
+hyperlocalise crowdin download translations --language fr --export-only-approved --skip-untranslated-strings
 ```
 
 Download French translations and refresh the matching local source files:
 
 ```bash
-hyperlocalise crowdin download --language fr --include-sources
+hyperlocalise crowdin download translations --language fr --include-sources
 ```
 
-For exact `files[].source` paths, Hyperlocalise can write the source file even when it is missing locally. For globbed source paths, local glob expansion still determines which configured files are processed.
+With `download translations --include-sources`, exact `files[].source` paths can be written even when the file is missing locally. For globbed source paths, local glob expansion still determines which configured files are processed.
 
 Or configure the export behavior in `crowdin.yml`:
 
@@ -120,8 +142,8 @@ files:
 Merge approved JSON strings into the existing local translation file without deleting local keys that are absent from the approved export:
 
 ```bash
-hyperlocalise crowdin download --language fr --merge-approved
+hyperlocalise crowdin download translations --language fr --merge-approved
 ```
 
-`--merge-approved` currently supports JSON object translation files. It forces an approved-only sparse export for the request, then overwrites only keys present in the approved Crowdin payload.
+`download translations --merge-approved` currently supports JSON object translation files. It forces an approved-only sparse export for the request, then overwrites only keys present in the approved Crowdin payload.
 Downloaded values that still match the source JSON are treated as Crowdin source-language fallbacks and are not merged over existing local translations.

--- a/docs/storage/crowdin.mdx
+++ b/docs/storage/crowdin.mdx
@@ -98,15 +98,21 @@ hyperlocalise crowdin init
 hyperlocalise crowdin config validate
 hyperlocalise crowdin upload sources
 hyperlocalise crowdin upload translations --language fr
-hyperlocalise crowdin download --language fr --export-only-approved --skip-untranslated-strings
-hyperlocalise crowdin download --language fr --merge-approved
-hyperlocalise crowdin download --language fr --include-sources
+hyperlocalise crowdin download sources
+hyperlocalise crowdin download sources --file-id 101 --output /tmp/messages.json --force
+hyperlocalise crowdin download translations --language fr --export-only-approved --skip-untranslated-strings
+hyperlocalise crowdin download translations --language fr --merge-approved
+hyperlocalise crowdin download translations --language fr --include-sources
 ```
 
-`--merge-approved` merges approved JSON object keys into existing local translation files and preserves local keys omitted from Crowdin's approved export.
+`download sources` writes Crowdin source files into `files[].source` paths from `crowdin.yml`, or into a single `--output` file when you pass `--file-id`.
+
+`download translations --merge-approved` merges approved JSON object keys into existing local translation files and preserves local keys omitted from Crowdin's approved export.
 When Crowdin includes source-language fallback values in that export, Hyperlocalise skips values that still match the source JSON so previously translated local strings are preserved.
 
-`--include-sources` also downloads matching Crowdin source files into the configured `files[].source` paths before writing translations. Exact source paths can be created locally if missing; globbed source paths are limited to files matched by local glob expansion.
+`download translations --include-sources` also downloads matching Crowdin source files into the configured `files[].source` paths before writing translations. Exact source paths can be created locally if missing; globbed source paths are limited to files matched by local glob expansion.
+
+Use `download sources` when you only need source files. It avoids translation export work and is the preferred command for source-only automation.
 
 Use root `branch:` in `crowdin.yml` or pass `--branch <name>` to upload and download files from a Crowdin branch. The flag overrides the config value for that command.
 

--- a/internal/i18n/storage/crowdin/filemode.go
+++ b/internal/i18n/storage/crowdin/filemode.go
@@ -190,6 +190,65 @@ func (a *FileAdapter) UploadTranslations(ctx context.Context, req storage.FileUp
 	return storage.FileOperationResult{Processed: processed, Skipped: skipped}, nil
 }
 
+func (a *FileAdapter) DownloadSources(ctx context.Context, req storage.FileDownloadSourcesRequest) (storage.FileOperationResult, error) {
+	config := a.effectiveConfig(req.Config)
+	baseRoot, err := canonicalCrowdinBasePath(config.BasePath)
+	if err != nil {
+		return storage.FileOperationResult{}, err
+	}
+	branchID, err := a.resolveBranchID(ctx, config)
+	if err != nil {
+		return storage.FileOperationResult{}, err
+	}
+
+	sourceFilter := makeStringSet(req.SourcePaths)
+	processed := make([]string, 0)
+	skipped := make([]string, 0)
+
+	for _, group := range config.Files {
+		sourcePaths, err := resolveCrowdinSourcePaths(config.BasePath, group.Source)
+		if err != nil {
+			return storage.FileOperationResult{Processed: processed, Skipped: skipped}, err
+		}
+		for _, sourcePath := range sourcePaths {
+			if err := validateCrowdinContainedPath(baseRoot, sourcePath); err != nil {
+				return storage.FileOperationResult{Processed: processed, Skipped: skipped}, fmt.Errorf("source path %q: %w", sourcePath, err)
+			}
+			remotePath, err := sourceRemotePath(config, sourcePath)
+			if err != nil {
+				return storage.FileOperationResult{Processed: processed, Skipped: skipped}, err
+			}
+			if len(sourceFilter) > 0 && !matchesCrowdinSourcePathFilter(sourceFilter, remotePath, sourcePath) {
+				skipped = append(skipped, remotePath)
+				continue
+			}
+			dirID, name, err := a.findRemoteLocation(ctx, config.ProjectID, branchID, remotePath)
+			if err != nil {
+				return storage.FileOperationResult{Processed: processed, Skipped: skipped}, err
+			}
+			fileID, err := a.client.FindFile(ctx, config.ProjectID, branchID, dirID, name)
+			if err != nil {
+				return storage.FileOperationResult{Processed: processed, Skipped: skipped}, err
+			}
+			payload, err := a.client.DownloadSourceFile(ctx, config.ProjectID, fileID)
+			if err != nil {
+				return storage.FileOperationResult{Processed: processed, Skipped: skipped}, err
+			}
+			if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
+				return storage.FileOperationResult{Processed: processed, Skipped: skipped}, fmt.Errorf("mkdir source output: %w", err)
+			}
+			if err := os.WriteFile(sourcePath, payload, 0o644); err != nil {
+				return storage.FileOperationResult{Processed: processed, Skipped: skipped}, fmt.Errorf("write source output: %w", err)
+			}
+			processed = append(processed, remotePath)
+		}
+	}
+
+	slices.Sort(processed)
+	slices.Sort(skipped)
+	return storage.FileOperationResult{Processed: processed, Skipped: skipped}, nil
+}
+
 func (a *FileAdapter) DownloadTranslations(ctx context.Context, req storage.FileDownloadTranslationsRequest) (storage.FileOperationResult, error) {
 	config := a.effectiveConfig(req.Config)
 	baseRoot, err := canonicalCrowdinBasePath(config.BasePath)
@@ -819,6 +878,27 @@ func makeStringSet(values []string) map[string]struct{} {
 	out := make(map[string]struct{}, len(values))
 	for _, value := range values {
 		out[value] = struct{}{}
+		normalized := filepath.ToSlash(strings.TrimSpace(value))
+		out[normalized] = struct{}{}
+		out[strings.TrimPrefix(normalized, "/")] = struct{}{}
 	}
 	return out
+}
+
+func matchesCrowdinSourcePathFilter(filter map[string]struct{}, remotePath, sourcePath string) bool {
+	candidates := []string{
+		remotePath,
+		sourcePath,
+		filepath.ToSlash(remotePath),
+		filepath.ToSlash(sourcePath),
+	}
+	for _, candidate := range candidates {
+		if _, ok := filter[candidate]; ok {
+			return true
+		}
+		if _, ok := filter[strings.TrimPrefix(candidate, "/")]; ok {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/i18n/storage/crowdin/source_download.go
+++ b/internal/i18n/storage/crowdin/source_download.go
@@ -1,0 +1,26 @@
+package crowdin
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// DownloadSourceFileByID downloads one Crowdin source file by numeric file ID.
+func DownloadSourceFileByID(ctx context.Context, cfg Config, fileID int) ([]byte, error) {
+	if fileID <= 0 {
+		return nil, fmt.Errorf("crowdin source download: file id must be positive")
+	}
+	if strings.TrimSpace(cfg.ProjectID) == "" {
+		return nil, fmt.Errorf("crowdin source download: project id is required")
+	}
+	if strings.TrimSpace(cfg.APIToken) == "" {
+		return nil, fmt.Errorf("crowdin source download: api token is required")
+	}
+
+	client, err := NewHTTPClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return client.DownloadSourceFile(ctx, cfg.ProjectID, fileID)
+}

--- a/internal/i18n/storage/crowdin/source_download_test.go
+++ b/internal/i18n/storage/crowdin/source_download_test.go
@@ -1,0 +1,93 @@
+package crowdin
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/hyperlocalise/hyperlocalise/internal/i18n/storage"
+)
+
+func TestFileAdapterDownloadSourcesWritesConfiguredPaths(t *testing.T) {
+	base := t.TempDir()
+	sourcePath := filepath.Join(base, "src", "messages.json")
+
+	client := &fakeFileClient{
+		directories:           map[string]int{"src": 1},
+		files:                 map[string]int{"messages.json": 9},
+		failFindMissing:       true,
+		sourceDownloadPayload: []byte(`{"hello":"Remote"}`),
+	}
+	adapter := mustNewFileAdapterForTest(t, storage.FileWorkflowConfig{
+		ProjectID:         "123",
+		APIToken:          "token",
+		BasePath:          base,
+		PreserveHierarchy: true,
+		Files: []storage.FileGroupSpec{{
+			Source:      "/src/messages.json",
+			Translation: "/download/%locale%/%original_file_name%",
+		}},
+	}, client)
+
+	result, err := adapter.DownloadSources(context.Background(), storage.FileDownloadSourcesRequest{})
+	if err != nil {
+		t.Fatalf("download sources: %v", err)
+	}
+	if got, want := result.Processed, []string{"src/messages.json"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("processed = %#v, want %#v", got, want)
+	}
+	if got, want := client.downloadedSources, []int{9}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("downloaded sources = %#v, want %#v", got, want)
+	}
+	sourcePayload, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatalf("read source: %v", err)
+	}
+	if string(sourcePayload) != `{"hello":"Remote"}` {
+		t.Fatalf("source payload = %q", string(sourcePayload))
+	}
+}
+
+func TestFileAdapterDownloadSourcesFiltersBySourcePath(t *testing.T) {
+	base := t.TempDir()
+	sourcePath := writeJSONFixture(t, filepath.Join(base, "src", "messages.json"), `{"hello":"Remote"}`)
+	otherPath := filepath.Join(base, "src", "other.json")
+
+	client := &fakeFileClient{
+		directories:           map[string]int{"src": 1},
+		files:                 map[string]int{"messages.json": 9, "other.json": 10},
+		failFindMissing:       true,
+		sourceDownloadPayload: []byte(`{"hello":"Remote"}`),
+	}
+	adapter := mustNewFileAdapterForTest(t, storage.FileWorkflowConfig{
+		ProjectID:         "123",
+		APIToken:          "token",
+		BasePath:          base,
+		PreserveHierarchy: true,
+		Files: []storage.FileGroupSpec{{
+			Source:      "/src/*.json",
+			Translation: "/download/%locale%/%original_file_name%",
+		}},
+	}, client)
+
+	result, err := adapter.DownloadSources(context.Background(), storage.FileDownloadSourcesRequest{
+		SourcePaths: []string{"src/messages.json"},
+	})
+	if err != nil {
+		t.Fatalf("download sources: %v", err)
+	}
+	if got, want := result.Processed, []string{"src/messages.json"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("processed = %#v, want %#v", got, want)
+	}
+	if got, want := client.downloadedSources, []int{9}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("downloaded sources = %#v, want %#v", got, want)
+	}
+	if _, err := os.Stat(sourcePath); err != nil {
+		t.Fatalf("expected downloaded source file: %v", err)
+	}
+	if _, err := os.Stat(otherPath); !os.IsNotExist(err) {
+		t.Fatalf("expected other source file to remain absent, got err=%v", err)
+	}
+}

--- a/internal/i18n/storage/types.go
+++ b/internal/i18n/storage/types.go
@@ -176,6 +176,12 @@ type FileDownloadTranslationsRequest struct {
 	IncludeSources  bool               `json:"include_sources,omitempty"`
 }
 
+// FileDownloadSourcesRequest downloads source files defined in a file-mode config.
+type FileDownloadSourcesRequest struct {
+	Config      FileWorkflowConfig `json:"config"`
+	SourcePaths []string           `json:"source_paths,omitempty"`
+}
+
 // FileOperationResult returns normalized file-mode execution details.
 type FileOperationResult struct {
 	Processed []string  `json:"processed,omitempty"`
@@ -197,5 +203,6 @@ type FileWorkflowAdapter interface {
 	FileWorkflowCapabilities() FileWorkflowCapabilities
 	UploadSources(ctx context.Context, req FileUploadSourcesRequest) (FileOperationResult, error)
 	UploadTranslations(ctx context.Context, req FileUploadTranslationsRequest) (FileOperationResult, error)
+	DownloadSources(ctx context.Context, req FileDownloadSourcesRequest) (FileOperationResult, error)
 	DownloadTranslations(ctx context.Context, req FileDownloadTranslationsRequest) (FileOperationResult, error)
 }


### PR DESCRIPTION
## What changed

- Added `hyperlocalise crowdin download sources` to download Crowdin source files into configured `files[].source` paths or a single `--output` file via `--file-id`.
- Moved the existing translation download flow under `hyperlocalise crowdin download translations` (breaking change from the flat `crowdin download` command).
- Wired provider agent file translation to download Crowdin sources inside the sandbox with the new CLI command instead of server-side fetches.
- Updated English docs for the new subcommands.

## How to test

- `make fmt && make lint && make test`
- `go run ./apps/cli crowdin download sources --help`
- `go run ./apps/cli crowdin download translations --help`
- `cd apps/hyperlocalise-web && vp test src/lib/translation/sandbox-translation.test.ts src/lib/providers/agent-runs/provider-agent-file-translate.test.ts`
- `cd docs && mint broken-links`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)