### PR TITLE
🧪 Scout: add unit tests for XML utility functions

### DIFF
--- a/internal/i18n/translationfileparser/xml_util_test.go
+++ b/internal/i18n/translationfileparser/xml_util_test.go
@@ -19,9 +19,11 @@ func TestEscapeXMLText(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		if got := escapeXMLText(tt.in); got != tt.want {
-			t.Errorf("escapeXMLText(%q) = %q, want %q", tt.in, got, tt.want)
-		}
+		t.Run(tt.in, func(t *testing.T) {
+			if got := escapeXMLText(tt.in); got != tt.want {
+				t.Errorf("escapeXMLText() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -39,9 +41,11 @@ func TestEscapeXMLAttr(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		if got := escapeXMLAttr(tt.in); got != tt.want {
-			t.Errorf("escapeXMLAttr(%q) = %q, want %q", tt.in, got, tt.want)
-		}
+		t.Run(tt.in, func(t *testing.T) {
+			if got := escapeXMLAttr(tt.in); got != tt.want {
+				t.Errorf("escapeXMLAttr() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -60,6 +64,7 @@ func TestContainsXMLTextEntityReference(t *testing.T) {
 		{"&#x0A;", true},
 		{"&#X0A;", true},
 		{"&unknown;", false},
+		{"&unknown; &amp;", true},
 		{"&incomplete", false},
 		{"&;", false},
 		{"a & b", false},
@@ -69,9 +74,11 @@ func TestContainsXMLTextEntityReference(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		if got := containsXMLTextEntityReference(tt.in); got != tt.want {
-			t.Errorf("containsXMLTextEntityReference(%q) = %v, want %v", tt.in, got, tt.want)
-		}
+		t.Run(tt.in, func(t *testing.T) {
+			if got := containsXMLTextEntityReference(tt.in); got != tt.want {
+				t.Errorf("containsXMLTextEntityReference() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -84,21 +91,26 @@ func TestAttrValue(t *testing.T) {
 
 	tests := []struct {
 		name string
+		attr string
 		want string
 	}{
-		{"id", "main-id"},
-		{"class", "primary"},
-		{"unknown", ""},
-		{"", ""},
+		{"id attribute", "id", "main-id"},
+		{"class attribute", "class", "primary"},
+		{"unknown attribute", "unknown", ""},
+		{"empty name", "", ""},
 	}
 
 	for _, tt := range tests {
-		if got := attrValue(attrs, tt.name); got != tt.want {
-			t.Errorf("attrValue(attrs, %q) = %q, want %q", tt.name, got, tt.want)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			if got := attrValue(attrs, tt.attr); got != tt.want {
+				t.Errorf("attrValue() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 
-	if got := attrValue(nil, "id"); got != "" {
-		t.Errorf("attrValue(nil, \"id\") = %q, want \"\"", got)
-	}
+	t.Run("nil attributes", func(t *testing.T) {
+		if got := attrValue(nil, "id"); got != "" {
+			t.Errorf("attrValue(nil) = %q, want \"\"", got)
+		}
+	})
 }

--- a/internal/i18n/translationfileparser/xml_util_test.go
+++ b/internal/i18n/translationfileparser/xml_util_test.go
@@ -1,0 +1,104 @@
+package translationfileparser
+
+import (
+	"encoding/xml"
+	"testing"
+)
+
+func TestEscapeXMLText(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"hello", "hello"},
+		{"a & b", "a &amp; b"},
+		{"<tag>", "&lt;tag&gt;"},
+		{`"quoted"`, `"quoted"`},
+		{"'apos'", "'apos'"},
+		{"< & >", "&lt; &amp; &gt;"},
+	}
+
+	for _, tt := range tests {
+		if got := escapeXMLText(tt.in); got != tt.want {
+			t.Errorf("escapeXMLText(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestEscapeXMLAttr(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"hello", "hello"},
+		{"a & b", "a &amp; b"},
+		{"<tag>", "&lt;tag&gt;"},
+		{`"quoted"`, "&quot;quoted&quot;"},
+		{"'apos'", "&apos;apos&apos;"},
+		{"< & > \" '", "&lt; &amp; &gt; &quot; &apos;"},
+	}
+
+	for _, tt := range tests {
+		if got := escapeXMLAttr(tt.in); got != tt.want {
+			t.Errorf("escapeXMLAttr(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestContainsXMLTextEntityReference(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{"no entities", false},
+		{"&amp;", true},
+		{"&lt;", true},
+		{"&gt;", true},
+		{"&apos;", true},
+		{"&quot;", true},
+		{"&#10;", true},
+		{"&#x0A;", true},
+		{"&#X0A;", true},
+		{"&unknown;", false},
+		{"&incomplete", false},
+		{"&;", false},
+		{"a & b", false},
+		{"Value: &#1234; - more", true},
+		{"&#xZ123;", false},
+		{"&#123A;", false},
+	}
+
+	for _, tt := range tests {
+		if got := containsXMLTextEntityReference(tt.in); got != tt.want {
+			t.Errorf("containsXMLTextEntityReference(%q) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestAttrValue(t *testing.T) {
+	attrs := []xml.Attr{
+		{Name: xml.Name{Local: "id"}, Value: "  main-id  "},
+		{Name: xml.Name{Local: "class"}, Value: "primary"},
+		{Name: xml.Name{Local: "id"}, Value: "ignored-id"},
+	}
+
+	tests := []struct {
+		name string
+		want string
+	}{
+		{"id", "main-id"},
+		{"class", "primary"},
+		{"unknown", ""},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		if got := attrValue(attrs, tt.name); got != tt.want {
+			t.Errorf("attrValue(attrs, %q) = %q, want %q", tt.name, got, tt.want)
+		}
+	}
+
+	if got := attrValue(nil, "id"); got != "" {
+		t.Errorf("attrValue(nil, \"id\") = %q, want \"\"", got)
+	}
+}


### PR DESCRIPTION
💡 What: Added a new unit test file `internal/i18n/translationfileparser/xml_util_test.go` covering XML utility functions.
🎯 Why: The functions in `xml_util.go` (escaping, entity detection, attribute retrieval) were previously untested, posing a risk for XML-based parsers like XLIFF and Android XML.
🧩 Scope: `internal/i18n/translationfileparser/xml_util.go`
✅ Verification: Ran `go test -v ./internal/i18n/translationfileparser/xml_util_test.go ./internal/i18n/translationfileparser/xml_util.go` and `go test ./...`. Verified with `make lint`.
🛡️ Confidence: Ensures that XML escaping and entity handling remain correct as parsers are optimized or expanded.

---
*PR created automatically by Jules for task [3700871914613467272](https://jules.google.com/task/3700871914613467272) started by @cungminh2710*