### PR TITLE
fix(contentful): localize rich text assets in place

### DIFF
--- a/apps/hyperlocalise-web/src/lib/contentful/automation-executor.test.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/automation-executor.test.ts
@@ -130,7 +130,7 @@ describe("contentful automation executor", () => {
     expect(second.get("asset-source")).toBe("asset-localized");
   });
 
-  it("keeps translated rich-text locales when embedded asset localization fails for another locale", async () => {
+  it("writes translated rich-text locales with source assets when embedded asset localization fails", async () => {
     mocks.assembleStringTranslationContextSnapshot.mockResolvedValue({
       ok: true,
       snapshot: {
@@ -215,7 +215,7 @@ describe("contentful automation executor", () => {
       undefined,
       { organizationId: "org-1" },
     );
-    expect(result.translations).toHaveLength(1);
+    expect(result.translations).toHaveLength(2);
     expect(result.translations[0]).toMatchObject({
       fieldId: "body",
       locale: "fr-FR",
@@ -226,6 +226,21 @@ describe("contentful automation executor", () => {
           data: expect.objectContaining({
             target: expect.objectContaining({
               sys: expect.objectContaining({ id: "asset-fr-fr" }),
+            }),
+          }),
+        }),
+      ]),
+    });
+    expect(result.translations[1]).toMatchObject({
+      fieldId: "body",
+      locale: "de-DE",
+    });
+    expect(result.translations[1]?.value).toMatchObject({
+      content: expect.arrayContaining([
+        expect.objectContaining({
+          data: expect.objectContaining({
+            target: expect.objectContaining({
+              sys: expect.objectContaining({ id: "asset-source" }),
             }),
           }),
         }),
@@ -243,9 +258,8 @@ describe("contentful automation executor", () => {
         runId: "run-1",
         fieldId: "body",
         locale: "de-DE",
-        status: "failed",
+        status: "translated",
         translationPreview: "Hero-Text",
-        error: { message: "Contentful asset upload failed" },
       },
     ]);
   });

--- a/apps/hyperlocalise-web/src/lib/contentful/automation-executor.test.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/automation-executor.test.ts
@@ -258,7 +258,7 @@ describe("contentful automation executor", () => {
         runId: "run-1",
         fieldId: "body",
         locale: "de-DE",
-        status: "translated",
+        status: "translated_partial",
         translationPreview: "Hero-Text",
       },
     ]);

--- a/apps/hyperlocalise-web/src/lib/contentful/automation-executor.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/automation-executor.ts
@@ -373,24 +373,9 @@ export async function translateTextUnit(input: {
                   "contentful_embedded_asset_localization_failed",
                 ),
               },
-              "contentful automation blocked draft writeback after embedded asset localization failed",
+              "contentful automation preserved embedded asset references after localization failed",
             );
           }
-          await createTextRunItem({
-            runId: input.runId,
-            unit: input.unit,
-            locale: translation.locale,
-            status: "failed",
-            translatedText: translation.text,
-            qaFindings: findings,
-            error: {
-              message: getContentfulAutomationErrorMessage(
-                error,
-                "contentful_embedded_asset_localization_failed",
-              ),
-            },
-          });
-          continue;
         }
       }
 

--- a/apps/hyperlocalise-web/src/lib/contentful/automation-executor.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/automation-executor.ts
@@ -336,6 +336,7 @@ export async function translateTextUnit(input: {
       : [];
     qaFindings.push(...findings);
     const hasQaError = contentfulQaFindingsContainError(findings);
+    let embeddedAssetLocalizationFailed = false;
     if (hasQaError) {
       if (input.logContext) {
         logger.warn(
@@ -361,6 +362,7 @@ export async function translateTextUnit(input: {
             cache: input.localizedAssetCache,
           });
         } catch (error) {
+          embeddedAssetLocalizationFailed = true;
           if (input.logContext) {
             logger.warn(
               {
@@ -394,7 +396,11 @@ export async function translateTextUnit(input: {
       runId: input.runId,
       unit: input.unit,
       locale: translation.locale,
-      status: hasQaError ? "qa_failed" : "translated",
+      status: hasQaError
+        ? "qa_failed"
+        : embeddedAssetLocalizationFailed
+          ? "translated_partial"
+          : "translated",
       translatedText: translation.text,
       qaFindings: findings,
     });

--- a/apps/hyperlocalise-web/src/lib/contentful/client.asset.test.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/client.asset.test.ts
@@ -197,6 +197,92 @@ describe("ContentfulManagementClient asset helpers", () => {
     expect(body.fields.file["en-US"]).not.toHaveProperty("url");
   });
 
+  it("does not carry pending upload references from other asset locales", async () => {
+    let assetUpdateRequestInit: RequestInit | undefined;
+    const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.endsWith("/uploads") && init?.method === "POST") {
+        return Response.json({ sys: { id: "upload-3" } });
+      }
+
+      if (url.endsWith("/assets/asset-source") && init?.method === "PUT") {
+        assetUpdateRequestInit = init;
+        const requestBody = init?.body;
+        const body = JSON.parse(typeof requestBody === "string" ? requestBody : "") as Record<
+          string,
+          unknown
+        >;
+        return Response.json({
+          sys: { id: "asset-source", version: 3 },
+          fields: body.fields,
+        });
+      }
+
+      if (url.endsWith("/assets/asset-source/files/de-DE/process") && init?.method === "PUT") {
+        return new Response(null, { status: 204 });
+      }
+
+      return new Response(null, { status: 404 });
+    });
+
+    const client = new ContentfulManagementClient({
+      accessToken: "token",
+      spaceId: "space",
+      environmentId: "master",
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+
+    const localizedResult = await client.updateAssetLocaleFile({
+      asset: {
+        ...asset(),
+        fields: {
+          ...asset().fields,
+          file: {
+            ...asset().fields.file,
+            "fr-FR": {
+              fileName: "hero-fr-fr.png",
+              contentType: "image/png",
+              uploadFrom: {
+                sys: {
+                  type: "Link",
+                  linkType: "Upload",
+                  id: "upload-1",
+                },
+              },
+            },
+          },
+        },
+      },
+      locale: "de-DE",
+      fileName: "hero-de-de.png",
+      contentType: "image/png",
+      buffer: Buffer.from("localized-image"),
+      title: "Hero banner",
+    });
+    if (isErr(localizedResult)) {
+      throw new Error("expected localized asset locale update");
+    }
+
+    const body = JSON.parse(
+      typeof assetUpdateRequestInit?.body === "string" ? assetUpdateRequestInit.body : "",
+    ) as Record<string, { file: Record<string, unknown> }>;
+    expect(body.fields.file["fr-FR"]).toMatchObject({
+      fileName: "hero-fr-fr.png",
+      contentType: "image/png",
+    });
+    expect(body.fields.file["fr-FR"]).not.toHaveProperty("uploadFrom");
+    expect(body.fields.file["de-DE"]).toMatchObject({
+      fileName: "hero-de-de.png",
+      contentType: "image/png",
+      uploadFrom: {
+        sys: {
+          type: "Link",
+          linkType: "Upload",
+          id: "upload-3",
+        },
+      },
+    });
+  });
+
   it("fails when the requested asset locale has no file", async () => {
     const fetchImpl = vi.fn();
     const client = new ContentfulManagementClient({

--- a/apps/hyperlocalise-web/src/lib/contentful/client.asset.test.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/client.asset.test.ts
@@ -115,6 +115,87 @@ describe("ContentfulManagementClient asset helpers", () => {
     });
   });
 
+  it("adds a localized file version to an existing asset", async () => {
+    let assetUpdateRequestInit: RequestInit | undefined;
+    let processRequestInit: RequestInit | undefined;
+    let uploadRequestInit: RequestInit | undefined;
+    const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.endsWith("/uploads") && init?.method === "POST") {
+        uploadRequestInit = init;
+        return Response.json({ sys: { id: "upload-2" } });
+      }
+
+      if (url.endsWith("/assets/asset-source") && init?.method === "PUT") {
+        assetUpdateRequestInit = init;
+        const requestBody = init?.body;
+        const body = JSON.parse(typeof requestBody === "string" ? requestBody : "") as Record<
+          string,
+          unknown
+        >;
+        return Response.json({
+          sys: { id: "asset-source", version: 2 },
+          fields: body.fields,
+        });
+      }
+
+      if (url.endsWith("/assets/asset-source/files/fr-FR/process") && init?.method === "PUT") {
+        processRequestInit = init;
+        return new Response(null, { status: 204 });
+      }
+
+      return new Response(null, { status: 404 });
+    });
+
+    const client = new ContentfulManagementClient({
+      accessToken: "token",
+      spaceId: "space",
+      environmentId: "master",
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+
+    const localizedResult = await client.updateAssetLocaleFile({
+      asset: asset(),
+      locale: "fr-FR",
+      fileName: "hero-fr-fr.png",
+      contentType: "image/png",
+      buffer: Buffer.from("localized-image"),
+      title: "Hero banner",
+    });
+    if (isErr(localizedResult)) {
+      throw new Error("expected localized asset locale update");
+    }
+
+    expect(localizedResult.value.sys.id).toBe("asset-source");
+    expect(new Headers(uploadRequestInit?.headers).get("content-type")).toBe(
+      "application/octet-stream",
+    );
+    expect(new Headers(assetUpdateRequestInit?.headers).get("x-contentful-version")).toBe("1");
+    expect(new Headers(processRequestInit?.headers).get("x-contentful-version")).toBe("2");
+    const body = JSON.parse(
+      typeof assetUpdateRequestInit?.body === "string" ? assetUpdateRequestInit.body : "",
+    ) as Record<string, { file: Record<string, unknown>; title: Record<string, string> }>;
+    expect(body.fields).toMatchObject({
+      title: { "en-US": "Hero banner", "fr-FR": "Hero banner" },
+      file: {
+        "en-US": {
+          fileName: "hero.png",
+          contentType: "image/png",
+        },
+        "fr-FR": {
+          fileName: "hero-fr-fr.png",
+          contentType: "image/png",
+          uploadFrom: {
+            sys: {
+              type: "Link",
+              linkType: "Upload",
+              id: "upload-2",
+            },
+          },
+        },
+      },
+    });
+  });
+
   it("fails when the requested asset locale has no file", async () => {
     const fetchImpl = vi.fn();
     const client = new ContentfulManagementClient({

--- a/apps/hyperlocalise-web/src/lib/contentful/client.asset.test.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/client.asset.test.ts
@@ -194,6 +194,7 @@ describe("ContentfulManagementClient asset helpers", () => {
         },
       },
     });
+    expect(body.fields.file["en-US"]).not.toHaveProperty("url");
   });
 
   it("fails when the requested asset locale has no file", async () => {

--- a/apps/hyperlocalise-web/src/lib/contentful/client.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/client.ts
@@ -78,6 +78,18 @@ type ContentfulAssetFileDownload = {
   contentType: string;
 };
 
+type ContentfulAssetUploadFile = {
+  contentType: string;
+  fileName: string;
+  uploadFrom: {
+    sys: {
+      type: "Link";
+      linkType: "Upload";
+      id: string;
+    };
+  };
+};
+
 export class ContentfulManagementClient {
   constructor(
     private readonly options: {
@@ -363,6 +375,91 @@ export class ContentfulManagementClient {
         },
       }),
     });
+    if (isErr(assetResult)) {
+      return err(assetResult.error);
+    }
+
+    const processResult = await this.request<void>(
+      this.environmentPath(
+        `/assets/${encodeURIComponent(assetResult.value.sys.id)}/files/${encodeURIComponent(input.locale)}/process`,
+      ),
+      {
+        method: "PUT",
+        headers: {
+          "X-Contentful-Version": String(assetResult.value.sys.version),
+        },
+      },
+    );
+    if (isErr(processResult)) {
+      return err(processResult.error);
+    }
+
+    return ok(assetResult.value);
+  }
+
+  async updateAssetLocaleFile(input: {
+    asset: ContentfulAsset;
+    locale: string;
+    fileName: string;
+    contentType: string;
+    buffer: Buffer;
+    title?: string;
+    description?: string;
+  }): Promise<Result<ContentfulAsset, ContentfulClientError>> {
+    const uploadResult = await this.request<{ sys: { id: string } }>(this.spacePath("/uploads"), {
+      method: "POST",
+      headers: {
+        "content-type": "application/octet-stream",
+      },
+      body: new Uint8Array(input.buffer),
+    });
+    if (isErr(uploadResult)) {
+      return err(uploadResult.error);
+    }
+
+    const file: ContentfulAssetUploadFile = {
+      contentType: input.contentType,
+      fileName: input.fileName,
+      uploadFrom: {
+        sys: {
+          type: "Link",
+          linkType: "Upload",
+          id: uploadResult.value.sys.id,
+        },
+      },
+    };
+    const fields: ContentfulAsset["fields"] = {
+      ...input.asset.fields,
+      title: {
+        ...input.asset.fields.title,
+        [input.locale]: input.asset.fields.title?.[input.locale] ?? input.title ?? input.fileName,
+      },
+      ...(input.asset.fields.description || input.description
+        ? {
+            description: {
+              ...input.asset.fields.description,
+              ...(input.description && !input.asset.fields.description?.[input.locale]
+                ? { [input.locale]: input.description }
+                : {}),
+            },
+          }
+        : {}),
+      file: {
+        ...input.asset.fields.file,
+        [input.locale]: file,
+      },
+    };
+
+    const assetResult = await this.request<ContentfulAsset>(
+      this.environmentPath(`/assets/${encodeURIComponent(input.asset.sys.id)}`),
+      {
+        method: "PUT",
+        headers: {
+          "X-Contentful-Version": String(input.asset.sys.version),
+        },
+        body: JSON.stringify({ fields }),
+      },
+    );
     if (isErr(assetResult)) {
       return err(assetResult.error);
     }

--- a/apps/hyperlocalise-web/src/lib/contentful/client.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/client.ts
@@ -90,6 +90,20 @@ type ContentfulAssetUploadFile = {
   };
 };
 
+function prepareAssetFilesForLocaleUpdate(input: {
+  existingFiles?: ContentfulAsset["fields"]["file"];
+  locale: string;
+  file: ContentfulAssetUploadFile;
+}): ContentfulAsset["fields"]["file"] {
+  const files: NonNullable<ContentfulAsset["fields"]["file"]> = {};
+  for (const [locale, existingFile] of Object.entries(input.existingFiles ?? {})) {
+    const { url: _url, ...fileWithoutProcessedUrl } = existingFile;
+    files[locale] = fileWithoutProcessedUrl;
+  }
+  files[input.locale] = input.file;
+  return files;
+}
+
 export class ContentfulManagementClient {
   constructor(
     private readonly options: {
@@ -444,10 +458,11 @@ export class ContentfulManagementClient {
             },
           }
         : {}),
-      file: {
-        ...input.asset.fields.file,
-        [input.locale]: file,
-      },
+      file: prepareAssetFilesForLocaleUpdate({
+        existingFiles: input.asset.fields.file,
+        locale: input.locale,
+        file,
+      }),
     };
 
     const assetResult = await this.request<ContentfulAsset>(

--- a/apps/hyperlocalise-web/src/lib/contentful/client.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/client.ts
@@ -97,8 +97,8 @@ function prepareAssetFilesForLocaleUpdate(input: {
 }): ContentfulAsset["fields"]["file"] {
   const files: NonNullable<ContentfulAsset["fields"]["file"]> = {};
   for (const [locale, existingFile] of Object.entries(input.existingFiles ?? {})) {
-    const { url: _url, ...fileWithoutProcessedUrl } = existingFile;
-    files[locale] = fileWithoutProcessedUrl;
+    const { url: _url, uploadFrom: _uploadFrom, ...fileDescriptor } = existingFile;
+    files[locale] = fileDescriptor;
   }
   files[input.locale] = input.file;
   return files;

--- a/apps/hyperlocalise-web/src/lib/contentful/field-detector.test.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/field-detector.test.ts
@@ -223,6 +223,95 @@ describe("contentful field detector", () => {
     });
   });
 
+  it("keeps empty rich-text nodes structural instead of translating them", () => {
+    const sourceValue = {
+      nodeType: "document",
+      data: {},
+      content: [
+        {
+          nodeType: "paragraph",
+          data: {},
+          content: [
+            {
+              nodeType: "text",
+              value:
+                "A peaceful walk through the park as the sun rises, with birds singing and fresh air setting a calm mood for the day.",
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+        {
+          nodeType: "embedded-asset-block",
+          data: {
+            target: {
+              sys: { type: "Link", linkType: "Asset", id: "asset-inline" },
+            },
+          },
+          content: [],
+        },
+        {
+          nodeType: "paragraph",
+          data: {},
+          content: [{ nodeType: "text", value: "", marks: [], data: {} }],
+        },
+      ],
+    };
+
+    const units = detectContentfulTranslatableFields({
+      entry: {
+        sys: {
+          id: "entry-1",
+          version: 1,
+          contentType: { sys: { id: "helpCenterArticle" } },
+        },
+        fields: {
+          content: {
+            "en-US": sourceValue,
+          },
+        },
+      },
+      contentType: {
+        sys: { id: "helpCenterArticle" },
+        fields: [{ id: "content", name: "Content", type: "RichText", localized: true }],
+      },
+      sourceLocale: "en-US",
+      targetLocales: ["fr-FR"],
+      fieldConfig: { fieldMode: "auto" },
+    });
+
+    expect(units[0]?.kind === "text" ? units[0].sourceText : "").toBe(
+      JSON.stringify([
+        "A peaceful walk through the park as the sun rises, with birds singing and fresh air setting a calm mood for the day.",
+      ]),
+    );
+
+    const formatted = formatTranslatedValueForContentful({
+      sourceValue,
+      translatedText: JSON.stringify(["Une promenade paisible dans le parc au lever du soleil."]),
+      valueKind: "rich_text",
+    });
+
+    expect(formatted).toMatchObject({
+      content: [
+        {
+          content: [{ value: "Une promenade paisible dans le parc au lever du soleil." }],
+        },
+        {
+          nodeType: "embedded-asset-block",
+          data: {
+            target: {
+              sys: { type: "Link", linkType: "Asset", id: "asset-inline" },
+            },
+          },
+        },
+        {
+          content: [{ value: "" }],
+        },
+      ],
+    });
+  });
+
   it("detects localized asset link fields for image translation", () => {
     const imageContentType: ContentfulContentType = {
       sys: { id: "marketingPage" },

--- a/apps/hyperlocalise-web/src/lib/contentful/field-detector.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/field-detector.ts
@@ -171,7 +171,7 @@ function collectRichTextTextValues(value: unknown): string[] {
       return;
     }
 
-    if (node.nodeType === "text" && typeof node.value === "string") {
+    if (node.nodeType === "text" && typeof node.value === "string" && node.value.trim()) {
       values.push(node.value);
       return;
     }
@@ -295,6 +295,10 @@ function replaceRichTextTextNodes(value: unknown, translatedText: string): unkno
     }
 
     if (node.nodeType === "text" && typeof node.value === "string") {
+      if (!node.value.trim()) {
+        return node;
+      }
+
       const translatedSegment = translatedSegments[textNodeIndex];
       const isLastTextNode = textNodeIndex === textNodeCount - 1;
       const remainingSegments = translatedSegments.slice(textNodeIndex);

--- a/apps/hyperlocalise-web/src/lib/contentful/image-localization.test.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/image-localization.test.ts
@@ -23,7 +23,7 @@ describe("contentful image localization", () => {
     });
   });
 
-  it("downloads, localizes, and uploads a Contentful asset for the target locale", async () => {
+  it("downloads, localizes, and updates the Contentful asset target locale", async () => {
     const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
       if (url === "https://images.ctfassets.net/space/asset-source/hero.png") {
         return new Response(Buffer.from("source-image"), { status: 200 });
@@ -33,9 +33,9 @@ describe("contentful image localization", () => {
         return Response.json({ sys: { id: "upload-1" } });
       }
 
-      if (url.endsWith("/assets") && init?.method === "POST") {
+      if (url.endsWith("/assets/asset-source") && init?.method === "PUT") {
         return Response.json({
-          sys: { id: "asset-localized", version: 1 },
+          sys: { id: "asset-source", version: 2 },
           fields: {},
         });
       }
@@ -56,7 +56,7 @@ describe("contentful image localization", () => {
         });
       }
 
-      if (url.endsWith("/assets/asset-localized/files/fr-FR/process") && init?.method === "PUT") {
+      if (url.endsWith("/assets/asset-source/files/fr-FR/process") && init?.method === "PUT") {
         return new Response(null, { status: 204 });
       }
 
@@ -83,7 +83,7 @@ describe("contentful image localization", () => {
     }
     expect(result.value).toEqual({
       sourceAssetId: "asset-source",
-      localizedAssetId: "asset-localized",
+      localizedAssetId: "asset-source",
       fileName: "hero-fr-fr.png",
     });
     expect(regenerateImageFromAttachment).toHaveBeenCalledWith(
@@ -91,5 +91,58 @@ describe("contentful image localization", () => {
       "image/png",
       expect.stringContaining("Target locale: fr-FR"),
     );
+  });
+
+  it("reuses an existing target-locale Contentful asset file", async () => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url.endsWith("/assets/asset-source")) {
+        return Response.json({
+          sys: { id: "asset-source", version: 1 },
+          fields: {
+            title: { "en-US": "Hero banner", "fr-FR": "Bannière hero" },
+            file: {
+              "en-US": {
+                url: "//images.ctfassets.net/space/asset-source/hero.png",
+                fileName: "hero.png",
+                contentType: "image/png",
+              },
+              "fr-FR": {
+                url: "//images.ctfassets.net/space/asset-source/hero-fr.png",
+                fileName: "hero-fr.png",
+                contentType: "image/png",
+              },
+            },
+          },
+        });
+      }
+
+      return new Response(null, { status: 404 });
+    });
+
+    const client = new ContentfulManagementClient({
+      accessToken: "token",
+      spaceId: "space",
+      environmentId: "master",
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+
+    const result = await localizeContentfulAssetForLocale({
+      client,
+      assetId: "asset-source",
+      sourceLocale: "en-US",
+      targetLocale: "fr-FR",
+      fieldName: "Hero Image",
+    });
+
+    if (isErr(result)) {
+      throw new Error("expected existing localized asset file");
+    }
+    expect(result.value).toEqual({
+      sourceAssetId: "asset-source",
+      localizedAssetId: "asset-source",
+      fileName: "hero-fr.png",
+    });
+    expect(regenerateImageFromAttachment).not.toHaveBeenCalled();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/contentful/image-localization.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/image-localization.ts
@@ -40,6 +40,15 @@ export async function localizeContentfulAssetForLocale(input: {
     return err(sourceAssetResult.error);
   }
 
+  const targetLocaleFile = sourceAssetResult.value.fields.file?.[input.targetLocale];
+  if (targetLocaleFile?.url) {
+    return ok({
+      sourceAssetId: input.assetId,
+      localizedAssetId: input.assetId,
+      fileName: targetLocaleFile.fileName,
+    });
+  }
+
   const downloadedResult = await input.client.downloadAssetFile({
     asset: sourceAssetResult.value,
     locale: input.sourceLocale,
@@ -62,7 +71,8 @@ export async function localizeContentfulAssetForLocale(input: {
     input.targetLocale,
     localized.mimeType,
   );
-  const createdAssetResult = await input.client.createLocalizedAsset({
+  const updatedAssetResult = await input.client.updateAssetLocaleFile({
+    asset: sourceAssetResult.value,
     locale: input.targetLocale,
     fileName: localizedFileName,
     contentType: localized.mimeType,
@@ -70,13 +80,13 @@ export async function localizeContentfulAssetForLocale(input: {
     title: sourceAssetResult.value.fields.title?.[input.sourceLocale] ?? localizedFileName,
     description: sourceAssetResult.value.fields.description?.[input.sourceLocale],
   });
-  if (isErr(createdAssetResult)) {
-    return err(createdAssetResult.error);
+  if (isErr(updatedAssetResult)) {
+    return err(updatedAssetResult.error);
   }
 
   return ok({
     sourceAssetId: input.assetId,
-    localizedAssetId: createdAssetResult.value.sys.id,
+    localizedAssetId: updatedAssetResult.value.sys.id,
     fileName: localizedFileName,
   });
 }

--- a/apps/hyperlocalise-web/src/lib/contentful/types.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/types.ts
@@ -83,9 +83,16 @@ export type ContentfulAsset = {
     file?: Record<
       string,
       {
-        url: string;
+        url?: string;
         fileName: string;
         contentType: string;
+        uploadFrom?: {
+          sys: {
+            type: "Link";
+            linkType: "Upload";
+            id: string;
+          };
+        };
       }
     >;
   };


### PR DESCRIPTION
## What changed

- Localize Contentful rich-text embedded assets without changing the rich-text asset link.
- Reuse an existing target-locale asset file when `fields.file[targetLocale]` already exists.
- When the target locale is missing, generate a localized image, upload it, update the same Contentful asset with `fields.file[targetLocale].uploadFrom`, and process that locale file.
- Keep rich-text translation write-back from failing when embedded asset localization fails; translated text is still written with the original asset reference.
- Treat empty rich-text text nodes as structure so trailing empty paragraphs are not sent as translation segments.
- Add focused coverage for rich-text asset fallback, existing target-locale asset files, in-place asset locale updates, and empty rich-text nodes.

## How to test

- `vp test src/lib/contentful/field-detector.test.ts src/lib/contentful/automation-executor.test.ts src/lib/contentful/client.test.ts src/lib/contentful/client.asset.test.ts src/lib/contentful/image-localization.test.ts`
- `vp test src/lib/contentful/image-localization.test.ts src/lib/contentful/field-detector.test.ts src/lib/contentful/automation-executor.test.ts src/lib/contentful/client.asset.test.ts`
- `vp test src/lib/contentful/client.asset.test.ts src/lib/contentful/image-localization.test.ts src/lib/contentful/automation-executor.test.ts src/lib/contentful/field-detector.test.ts`
- `vp check --fix`
- `vp test` currently fails on local DB schema drift unrelated to this change:
  - `contentful_connections.project_id` is still `NOT NULL` locally while tests insert default/null project IDs.
  - `project_file_string_repository_contexts` is missing locally.

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review