### PR TITLE
feat(jobs): split My Jobs by assigned and created

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.test.ts
@@ -1,0 +1,132 @@
+import "dotenv/config";
+
+import { randomUUID } from "node:crypto";
+
+import { testClient } from "hono/testing";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
+
+import { app } from "@/api/app";
+import { db, schema } from "@/lib/database";
+import { upsertExternalTmsJobRecords } from "@/lib/projects/upsert-external-tms-job-records";
+
+import { createProjectTestFixture } from "./project.fixture";
+import type { WorkspaceJobsResponse } from "./job.schema";
+
+const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
+  resolveApiAuthContextFromSessionMock: vi.fn(
+    (options) =>
+      globalThis.__resolveTestApiAuthContextFromSession?.(options) ??
+      globalThis.__testApiAuthContext ??
+      null,
+  ),
+}));
+
+vi.mock("@/api/auth/workos-session", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/auth/workos-session")>();
+  return {
+    ...actual,
+    resolveApiAuthContextFromSession: resolveApiAuthContextFromSessionMock,
+  };
+});
+
+const client = testClient(app);
+const projectFixture = createProjectTestFixture(client);
+
+beforeAll(async () => {
+  await db.$client.query("select 1");
+});
+
+afterEach(async () => {
+  vi.clearAllMocks();
+  await projectFixture.cleanup();
+});
+
+async function insertNativeJob(input: {
+  organizationId: string;
+  projectId: string;
+  createdByUserId?: string | null;
+  ownerUserId?: string | null;
+}) {
+  return db
+    .insert(schema.jobs)
+    .values({
+      id: `job_${randomUUID()}`,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      createdByUserId: input.createdByUserId ?? null,
+      ownerUserId: input.ownerUserId ?? null,
+      kind: "translation",
+      status: "queued",
+      inputPayload: {
+        sourceText: "Hello",
+        sourceLocale: "en-US",
+        targetLocales: ["fr-FR"],
+      },
+    })
+    .returning();
+}
+
+describe("workspace job list", () => {
+  it("includes synced provider jobs assigned to the current provider user in My Jobs", async () => {
+    const { identity, organization, project, user } =
+      await projectFixture.createStoredProjectFixture();
+    const headers = await projectFixture.authHeadersFor(identity);
+
+    await insertNativeJob({
+      organizationId: organization.id,
+      projectId: project.id,
+      createdByUserId: user.id,
+    });
+    const [ownedNativeJob] = await insertNativeJob({
+      organizationId: organization.id,
+      projectId: project.id,
+      ownerUserId: user.id,
+    });
+    const [otherNativeJob] = await insertNativeJob({
+      organizationId: organization.id,
+      projectId: project.id,
+    });
+
+    await upsertExternalTmsJobRecords({
+      organizationId: organization.id,
+      projectId: project.id,
+      providerKind: "crowdin",
+      externalProjectId: "crowdin-project",
+      tasks: [
+        {
+          externalJobId: "assigned-to-current-user",
+          externalStatus: "todo",
+          title: "Assigned to current user",
+          assignedUsers: [identity.user.email.toUpperCase()],
+        },
+        {
+          externalJobId: "assigned-to-other-user",
+          externalStatus: "todo",
+          title: "Assigned to other user",
+          assignedUsers: ["someone-else@example.com"],
+        },
+      ],
+    });
+
+    const response = await client.api.orgs[":organizationSlug"].jobs.$get(
+      {
+        param: { organizationSlug: identity.organization.slug ?? "missing-slug" },
+        query: { mine: "true", limit: "100" },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as WorkspaceJobsResponse;
+    const jobIds = body.jobs.map((job) => job.id);
+
+    expect(jobIds).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("assigned-to-current-user"),
+        ownedNativeJob.id,
+      ]),
+    );
+    expect(jobIds).not.toEqual(expect.arrayContaining([otherNativeJob.id]));
+    expect(jobIds).not.toEqual(expect.arrayContaining([expect.stringContaining("other-user")]));
+  });
+});

--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.test.ts
@@ -67,12 +67,12 @@ async function insertNativeJob(input: {
 }
 
 describe("workspace job list", () => {
-  it("includes synced provider jobs assigned to the current provider user in My Jobs", async () => {
+  it("filters assigned and created jobs for the current user", async () => {
     const { identity, organization, project, user } =
       await projectFixture.createStoredProjectFixture();
     const headers = await projectFixture.authHeadersFor(identity);
 
-    await insertNativeJob({
+    const [createdNativeJob] = await insertNativeJob({
       organizationId: organization.id,
       projectId: project.id,
       createdByUserId: user.id,
@@ -108,25 +108,46 @@ describe("workspace job list", () => {
       ],
     });
 
-    const response = await client.api.orgs[":organizationSlug"].jobs.$get(
+    const assignedResponse = await client.api.orgs[":organizationSlug"].jobs.$get(
       {
         param: { organizationSlug: identity.organization.slug ?? "missing-slug" },
-        query: { mine: "true", limit: "100" },
+        query: { relationship: "assigned", limit: "100" },
       },
       { headers },
     );
 
-    expect(response.status).toBe(200);
-    const body = (await response.json()) as WorkspaceJobsResponse;
-    const jobIds = body.jobs.map((job) => job.id);
+    expect(assignedResponse.status).toBe(200);
+    const assignedBody = (await assignedResponse.json()) as WorkspaceJobsResponse;
+    const assignedJobIds = assignedBody.jobs.map((job) => job.id);
 
-    expect(jobIds).toEqual(
+    expect(assignedJobIds).toEqual(
       expect.arrayContaining([
         expect.stringContaining("assigned-to-current-user"),
         ownedNativeJob.id,
       ]),
     );
-    expect(jobIds).not.toEqual(expect.arrayContaining([otherNativeJob.id]));
-    expect(jobIds).not.toEqual(expect.arrayContaining([expect.stringContaining("other-user")]));
+    expect(assignedJobIds).not.toEqual(expect.arrayContaining([createdNativeJob.id]));
+    expect(assignedJobIds).not.toEqual(expect.arrayContaining([otherNativeJob.id]));
+    expect(assignedJobIds).not.toEqual(
+      expect.arrayContaining([expect.stringContaining("other-user")]),
+    );
+
+    const createdResponse = await client.api.orgs[":organizationSlug"].jobs.$get(
+      {
+        param: { organizationSlug: identity.organization.slug ?? "missing-slug" },
+        query: { relationship: "created", limit: "100" },
+      },
+      { headers },
+    );
+
+    expect(createdResponse.status).toBe(200);
+    const createdBody = (await createdResponse.json()) as WorkspaceJobsResponse;
+    const createdJobIds = createdBody.jobs.map((job) => job.id);
+
+    expect(createdJobIds).toEqual(expect.arrayContaining([createdNativeJob.id]));
+    expect(createdJobIds).not.toEqual(expect.arrayContaining([ownedNativeJob.id]));
+    expect(createdJobIds).not.toEqual(
+      expect.arrayContaining([expect.stringContaining("assigned-to-current-user")]),
+    );
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/project/job.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.schema.ts
@@ -60,11 +60,7 @@ export const jobListQuerySchema = z.object({
   kind: z.enum(schema.jobKindEnum.enumValues).optional(),
   type: z.enum(schema.translationJobTypeEnum.enumValues).optional(),
   status: z.enum(schema.jobStatusEnum.enumValues).optional(),
-  mine: z
-    .enum(["true", "false"])
-    .optional()
-    .default("false")
-    .transform((value) => value === "true"),
+  relationship: z.enum(["assigned", "created"]).optional(),
   limit: z.coerce.number().int().min(1).max(100).default(50),
 });
 

--- a/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.ts
@@ -39,8 +39,7 @@ import {
   listTmsProviderLiveTranslationMemories,
 } from "@/lib/providers/tms-provider-live";
 import { tmsProviderLiveErrorResponse } from "@/lib/providers/tms-provider-live-error-response";
-import { getCrowdinUserConnectionSummary } from "@/lib/providers/adapters/crowdin/crowdin-user-connections";
-import { getPhraseUserConnectionSummary } from "@/lib/providers/adapters/phrase/phrase-user-connections";
+import { getCurrentUserProviderAssigneeCandidates } from "@/lib/providers/tms-provider-assignee-candidates";
 import { projectIdSchema } from "@/lib/projects/project-id";
 
 const mineQuerySchema = z.object({
@@ -138,35 +137,6 @@ const validateCreateTmsProviderJobAgentRunBody = validator("json", (value, c) =>
 function canEditTmsProviderJobDescription(auth: AuthVariables["auth"]) {
   const role = auth.membership.role;
   return role === "admin" || (role === "localization_manager" && hasCapability(role, "jobs:write"));
-}
-
-async function getCurrentUserProviderAssigneeCandidates(auth: AuthVariables["auth"]) {
-  const candidates = [auth.user.email];
-  const crowdinUserConnection = await getCrowdinUserConnectionSummary({
-    organizationId: auth.organization.localOrganizationId,
-    userId: auth.user.localUserId,
-  });
-  const phraseUserConnection = await getPhraseUserConnectionSummary({
-    organizationId: auth.organization.localOrganizationId,
-    userId: auth.user.localUserId,
-  });
-
-  if (crowdinUserConnection) {
-    candidates.push(
-      crowdinUserConnection.username,
-      crowdinUserConnection.email ?? "",
-      crowdinUserConnection.fullName ?? "",
-    );
-  }
-  if (phraseUserConnection) {
-    candidates.push(
-      phraseUserConnection.username,
-      phraseUserConnection.email ?? "",
-      phraseUserConnection.fullName ?? "",
-    );
-  }
-
-  return candidates.filter((candidate) => candidate.trim().length > 0);
 }
 
 type CreateTmsProviderRoutesOptions = {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/tms-dashboard-summary-section.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/tms-dashboard-summary-section.tsx
@@ -118,7 +118,7 @@ export function TmsDashboardSummarySection({ organizationSlug }: { organizationS
         param: { organizationSlug },
         query: {
           limit: "3",
-          mine: "true",
+          relationship: "assigned",
         },
       });
       if (!response.ok) throw await readApiResponseError(response, "Failed to load my jobs");

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.stories.tsx
@@ -103,8 +103,23 @@ export const WorkspaceJobs: Story = {
 export const MyJobs: Story = {
   args: {
     organizationSlug: "acme",
-    scope: "mine",
-    jobs: jobs.slice(0, 2),
+    scope: "personal",
+    assignedJobs: jobs.slice(0, 2),
+    createdJobs: [
+      createJob({
+        id: "job_created_mobile",
+        status: "queued",
+        projectId: "project_mobile",
+        projectName: "Mobile app",
+        externalProviderKind: null,
+        externalTaskId: null,
+        externalTitle: null,
+        externalTargetLocales: null,
+        externalAssignedUsers: null,
+        updatedAt: iso(-900_000),
+      }),
+    ],
+    jobs: [],
     isLoading: false,
     now: fixedNow,
   },

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.tsx
@@ -89,10 +89,25 @@ export function JobsPageContent({
   const searchParams = useSearchParams();
   const [statusFilter, setStatusFilter] = useState(() => readInitialStatusFilter(searchParams));
   const jobsQueryKey = ["jobs", organizationSlug, scope, statusFilter, projectId ?? "workspace"];
+  const assignedJobsQueryKey = [
+    "jobs",
+    organizationSlug,
+    "assigned",
+    statusFilter,
+    projectId ?? "workspace",
+  ];
+  const createdJobsQueryKey = [
+    "jobs",
+    organizationSlug,
+    "created",
+    statusFilter,
+    projectId ?? "workspace",
+  ];
   const isProviderProject = Boolean(parseProviderProjectId(projectId));
 
   const jobsQuery = useQuery({
     queryKey: jobsQueryKey,
+    enabled: scope !== "personal",
     queryFn: async () => {
       if (projectId) {
         const response = await apiClient.api.orgs[":organizationSlug"].projects[
@@ -101,7 +116,6 @@ export function JobsPageContent({
           param: { organizationSlug, projectId },
           query: {
             limit: "100",
-            mine: "false",
             ...(statusFilter === "all" ? {} : { status: statusFilter }),
           },
         });
@@ -114,11 +128,44 @@ export function JobsPageContent({
         param: { organizationSlug },
         query: {
           limit: "100",
-          mine: scope === "mine" ? "true" : "false",
           ...(statusFilter === "all" ? {} : { status: statusFilter }),
         },
       });
       if (!response.ok) throw await readApiResponseError(response, "Failed to load jobs");
+      const body = await response.json();
+      return body.jobs;
+    },
+  });
+  const assignedJobsQuery = useQuery({
+    queryKey: assignedJobsQueryKey,
+    enabled: scope === "personal" && !projectId,
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"].jobs.$get({
+        param: { organizationSlug },
+        query: {
+          limit: "100",
+          relationship: "assigned",
+          ...(statusFilter === "all" ? {} : { status: statusFilter }),
+        },
+      });
+      if (!response.ok) throw await readApiResponseError(response, "Failed to load assigned jobs");
+      const body = await response.json();
+      return body.jobs;
+    },
+  });
+  const createdJobsQuery = useQuery({
+    queryKey: createdJobsQueryKey,
+    enabled: scope === "personal" && !projectId,
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"].jobs.$get({
+        param: { organizationSlug },
+        query: {
+          limit: "100",
+          relationship: "created",
+          ...(statusFilter === "all" ? {} : { status: statusFilter }),
+        },
+      });
+      if (!response.ok) throw await readApiResponseError(response, "Failed to load created jobs");
       const body = await response.json();
       return body.jobs;
     },
@@ -154,8 +201,14 @@ export function JobsPageContent({
 
   return (
     <JobsPageView
-      error={jobsQuery.error}
-      isLoading={jobsQuery.isLoading}
+      assignedJobs={assignedJobsQuery.data ?? []}
+      createdJobs={createdJobsQuery.data ?? []}
+      error={jobsQuery.error ?? assignedJobsQuery.error ?? createdJobsQuery.error}
+      isLoading={
+        scope === "personal"
+          ? assignedJobsQuery.isLoading || createdJobsQuery.isLoading
+          : jobsQuery.isLoading
+      }
       isSyncingProviderJobs={syncProviderJobs.isPending}
       jobs={jobsQuery.data ?? []}
       onSyncProviderJobs={isProviderProject ? syncProviderJobs.mutate : undefined}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-view.tsx
@@ -37,7 +37,7 @@ import {
   ProjectSectionHeader,
 } from "../../projects/[projectId]/_components/project-page-shell";
 
-export type JobsScope = "all" | "mine";
+export type JobsScope = "all" | "personal";
 
 export type ApiJob = {
   id: string;
@@ -213,6 +213,26 @@ export function getJobName(job: ApiJob) {
 function formatJobKind(job: ApiJob) {
   if (job.kind === "translation" && job.type) return `${job.kind.replace("_", " ")} · ${job.type}`;
   return job.kind.replace("_", " ");
+}
+
+function jobMatchesFilters(job: JobRow, input: { search: string; statusFilter: JobsStatusFilter }) {
+  const matchesStatus = input.statusFilter === "all" || job.status === input.statusFilter;
+  const matchesSearch =
+    !input.search ||
+    [
+      getJobName(job),
+      job.projectName,
+      job.id,
+      job.kind,
+      job.externalProviderKind,
+      job.externalStatus,
+      targetLocales(job),
+      assignees(job),
+    ]
+      .join(" ")
+      .toLowerCase()
+      .includes(input.search);
+  return matchesStatus && matchesSearch;
 }
 
 export function taskDetailSummary(job: ApiJob) {
@@ -392,7 +412,9 @@ function JobListItemTitle({ job }: { job: ApiJob }) {
 }
 
 export function JobsPageView({
+  assignedJobs,
   buildJobDetailHref = defaultBuildJobDetailHref,
+  createdJobs,
   error,
   initialSearch = "",
   initialStatusFilter = "all",
@@ -409,7 +431,9 @@ export function JobsPageView({
   scope = "all",
   statusFilter: controlledStatusFilter,
 }: {
+  assignedJobs?: JobRow[];
   buildJobDetailHref?: typeof defaultBuildJobDetailHref;
+  createdJobs?: JobRow[];
   error?: unknown;
   initialSearch?: string;
   initialStatusFilter?: JobsStatusFilter;
@@ -434,31 +458,27 @@ export function JobsPageView({
 
   const visibleJobs = useMemo(() => {
     const normalizedSearch = search.trim().toLowerCase();
-    return jobs.filter((job) => {
-      const matchesStatus = statusFilter === "all" || job.status === statusFilter;
-      const matchesSearch =
-        !normalizedSearch ||
-        [
-          getJobName(job),
-          job.projectName,
-          job.id,
-          job.kind,
-          job.externalProviderKind,
-          job.externalStatus,
-          targetLocales(job),
-          assignees(job),
-        ]
-          .join(" ")
-          .toLowerCase()
-          .includes(normalizedSearch);
-      return matchesStatus && matchesSearch;
-    });
+    return jobs.filter((job) => jobMatchesFilters(job, { search: normalizedSearch, statusFilter }));
   }, [jobs, search, statusFilter]);
 
-  const isMyWork = scope === "mine";
+  const visibleAssignedJobs = useMemo(() => {
+    const normalizedSearch = search.trim().toLowerCase();
+    return (assignedJobs ?? []).filter((job) =>
+      jobMatchesFilters(job, { search: normalizedSearch, statusFilter }),
+    );
+  }, [assignedJobs, search, statusFilter]);
+
+  const visibleCreatedJobs = useMemo(() => {
+    const normalizedSearch = search.trim().toLowerCase();
+    return (createdJobs ?? []).filter((job) =>
+      jobMatchesFilters(job, { search: normalizedSearch, statusFilter }),
+    );
+  }, [createdJobs, search, statusFilter]);
+
+  const isPersonalWork = scope === "personal";
   const emptyLabel = projectId
     ? "No jobs synced for this project yet. Sync jobs from your TMS to populate this list."
-    : scope === "mine"
+    : scope === "personal"
       ? "No work items found for your account."
       : "No jobs found for this workspace.";
   const syncJobsAction =
@@ -523,16 +543,55 @@ export function JobsPageView({
         </JobsFilterField>
       </div>
       {error ? <div>{renderError({ error, organizationSlug })}</div> : null}
-      <JobsList
-        buildJobDetailHref={buildJobDetailHref}
-        emptyLabel={emptyLabel}
-        isLoading={isLoading}
-        jobs={visibleJobs}
-        now={now}
-        organizationSlug={organizationSlug}
-        projectId={projectId}
-        renderJobLink={renderJobLink}
-      />
+      {isPersonalWork ? (
+        <div className="space-y-8">
+          <div className="space-y-3">
+            <div>
+              <TypographyP className="text-sm font-medium text-foreground">
+                Jobs assigned to me
+              </TypographyP>
+            </div>
+            <JobsList
+              buildJobDetailHref={buildJobDetailHref}
+              emptyLabel="No assigned jobs found for your account."
+              isLoading={isLoading}
+              jobs={visibleAssignedJobs}
+              now={now}
+              organizationSlug={organizationSlug}
+              projectId={projectId}
+              renderJobLink={renderJobLink}
+            />
+          </div>
+          <div className="space-y-3">
+            <div>
+              <TypographyP className="text-sm font-medium text-foreground">
+                Jobs created by me
+              </TypographyP>
+            </div>
+            <JobsList
+              buildJobDetailHref={buildJobDetailHref}
+              emptyLabel="No jobs created by you found."
+              isLoading={isLoading}
+              jobs={visibleCreatedJobs}
+              now={now}
+              organizationSlug={organizationSlug}
+              projectId={projectId}
+              renderJobLink={renderJobLink}
+            />
+          </div>
+        </div>
+      ) : (
+        <JobsList
+          buildJobDetailHref={buildJobDetailHref}
+          emptyLabel={emptyLabel}
+          isLoading={isLoading}
+          jobs={visibleJobs}
+          now={now}
+          organizationSlug={organizationSlug}
+          projectId={projectId}
+          renderJobLink={renderJobLink}
+        />
+      )}
     </section>
   );
 
@@ -553,12 +612,12 @@ export function JobsPageView({
   return (
     <WorkspacePageShell>
       <PageHeader
-        icon={isMyWork ? WorkHistoryIcon : Task01Icon}
+        icon={isPersonalWork ? WorkHistoryIcon : Task01Icon}
         label="Workspace"
-        title={isMyWork ? "My Jobs" : "Jobs"}
+        title={isPersonalWork ? "My Jobs" : "Jobs"}
         description={
-          isMyWork
-            ? "Translation, review, and sync work assigned to you across projects."
+          isPersonalWork
+            ? "Translation, review, and sync work assigned to you or created by you."
             : "Translation, review, QA, and sync work tracked across the workspace."
         }
       />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/my-jobs/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/my-jobs/page.tsx
@@ -11,7 +11,7 @@ export default async function MyJobsPage({
 
   return (
     <Suspense fallback={null}>
-      <JobsPageContent organizationSlug={organizationSlug} scope="mine" />
+      <JobsPageContent organizationSlug={organizationSlug} scope="personal" />
     </Suspense>
   );
 }

--- a/apps/hyperlocalise-web/src/lib/projects/list-organization-jobs.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/list-organization-jobs.ts
@@ -52,7 +52,7 @@ function jobListFilters(input: {
   kind?: "translation" | "research" | "review" | "sync" | "asset_management";
   type?: "string" | "file";
   status?: "queued" | "running" | "succeeded" | "failed" | "waiting_for_review" | "cancelled";
-  mine?: boolean;
+  relationship?: "assigned" | "created";
   userId?: string;
   providerAssigneeCandidates?: string[];
 }) {
@@ -70,14 +70,19 @@ function jobListFilters(input: {
     filters.push(eq(schema.jobs.status, input.status));
   }
 
-  if (input.mine && input.userId) {
-    filters.push(
-      or(
-        eq(schema.jobs.createdByUserId, input.userId),
-        eq(schema.jobs.ownerUserId, input.userId),
-        providerAssignedUsersMatch(input.providerAssigneeCandidates ?? []),
-      ),
+  if (input.userId) {
+    const relationship = input.relationship;
+    const assignedFilter = or(
+      eq(schema.jobs.ownerUserId, input.userId),
+      providerAssignedUsersMatch(input.providerAssigneeCandidates ?? []),
     );
+    const createdFilter = eq(schema.jobs.createdByUserId, input.userId);
+
+    if (relationship === "assigned") {
+      filters.push(assignedFilter);
+    } else if (relationship === "created") {
+      filters.push(createdFilter);
+    }
   }
 
   return filters;
@@ -126,13 +131,14 @@ export async function listOrganizationJobs(
     kind?: "translation" | "research" | "review" | "sync" | "asset_management";
     type?: "string" | "file";
     status?: "queued" | "running" | "succeeded" | "failed" | "waiting_for_review" | "cancelled";
-    mine?: boolean;
+    relationship?: "assigned" | "created";
     limit: number;
   },
 ) {
-  const providerAssigneeCandidates = query.mine
-    ? await getCurrentUserProviderAssigneeCandidates(auth)
-    : undefined;
+  const providerAssigneeCandidates =
+    query.relationship === "assigned"
+      ? await getCurrentUserProviderAssigneeCandidates(auth)
+      : undefined;
 
   return db
     .select(jobWithProjectSelect)
@@ -160,7 +166,7 @@ export async function listOrganizationJobs(
           kind: query.kind,
           type: query.type,
           status: query.status,
-          mine: query.mine,
+          relationship: query.relationship,
           userId: auth.user.localUserId,
           providerAssigneeCandidates,
         }),
@@ -177,13 +183,14 @@ export async function listOrganizationProjectJobs(
     kind?: "translation" | "research" | "review" | "sync" | "asset_management";
     type?: "string" | "file";
     status?: "queued" | "running" | "succeeded" | "failed" | "waiting_for_review" | "cancelled";
-    mine?: boolean;
+    relationship?: "assigned" | "created";
     limit: number;
   },
 ) {
-  const providerAssigneeCandidates = query.mine
-    ? await getCurrentUserProviderAssigneeCandidates(auth)
-    : undefined;
+  const providerAssigneeCandidates =
+    query.relationship === "assigned"
+      ? await getCurrentUserProviderAssigneeCandidates(auth)
+      : undefined;
 
   return db
     .select(jobWithProjectSelect)
@@ -212,7 +219,7 @@ export async function listOrganizationProjectJobs(
           kind: query.kind,
           type: query.type,
           status: query.status,
-          mine: query.mine,
+          relationship: query.relationship,
           userId: auth.user.localUserId,
           providerAssigneeCandidates,
         }),

--- a/apps/hyperlocalise-web/src/lib/projects/list-organization-jobs.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/list-organization-jobs.ts
@@ -1,8 +1,9 @@
-import { and, desc, eq, isNull, ne, or } from "drizzle-orm";
+import { and, desc, eq, isNull, ne, or, sql } from "drizzle-orm";
 
 import type { ApiAuthContext } from "@/api/auth/workos";
 import { buildAccessibleJobsWhere } from "@/api/auth/team-access";
 import { db, schema } from "@/lib/database";
+import { getCurrentUserProviderAssigneeCandidates } from "@/lib/providers/tms-provider-assignee-candidates";
 
 const jobWithProjectSelect = {
   id: schema.jobs.id,
@@ -53,6 +54,7 @@ function jobListFilters(input: {
   status?: "queued" | "running" | "succeeded" | "failed" | "waiting_for_review" | "cancelled";
   mine?: boolean;
   userId?: string;
+  providerAssigneeCandidates?: string[];
 }) {
   const filters = [];
 
@@ -69,10 +71,40 @@ function jobListFilters(input: {
   }
 
   if (input.mine && input.userId) {
-    filters.push(eq(schema.jobs.createdByUserId, input.userId));
+    filters.push(
+      or(
+        eq(schema.jobs.createdByUserId, input.userId),
+        eq(schema.jobs.ownerUserId, input.userId),
+        providerAssignedUsersMatch(input.providerAssigneeCandidates ?? []),
+      ),
+    );
   }
 
   return filters;
+}
+
+function providerAssignedUsersMatch(candidates: string[]) {
+  const normalizedCandidates = Array.from(
+    new Set(candidates.map((candidate) => candidate.trim().toLowerCase()).filter(Boolean)),
+  );
+
+  if (normalizedCandidates.length === 0) {
+    return sql`false`;
+  }
+
+  const candidatePredicates = normalizedCandidates.map(
+    (candidate) => sql`
+      lower(assigned_user.value) = ${candidate}
+      or lower(assigned_user.value) like '%' || ${candidate} || '%'
+      or ${candidate} like '%' || lower(assigned_user.value) || '%'
+    `,
+  );
+
+  return sql`exists (
+    select 1
+    from jsonb_array_elements_text(${schema.externalJobDetails.assignedUsers}) as assigned_user(value)
+    where ${sql.join(candidatePredicates, sql` or `)}
+  )`;
 }
 
 function visibleSyncedJobConditions() {
@@ -98,6 +130,10 @@ export async function listOrganizationJobs(
     limit: number;
   },
 ) {
+  const providerAssigneeCandidates = query.mine
+    ? await getCurrentUserProviderAssigneeCandidates(auth)
+    : undefined;
+
   return db
     .select(jobWithProjectSelect)
     .from(schema.jobs)
@@ -126,6 +162,7 @@ export async function listOrganizationJobs(
           status: query.status,
           mine: query.mine,
           userId: auth.user.localUserId,
+          providerAssigneeCandidates,
         }),
       ),
     )
@@ -144,6 +181,10 @@ export async function listOrganizationProjectJobs(
     limit: number;
   },
 ) {
+  const providerAssigneeCandidates = query.mine
+    ? await getCurrentUserProviderAssigneeCandidates(auth)
+    : undefined;
+
   return db
     .select(jobWithProjectSelect)
     .from(schema.jobs)
@@ -173,6 +214,7 @@ export async function listOrganizationProjectJobs(
           status: query.status,
           mine: query.mine,
           userId: auth.user.localUserId,
+          providerAssigneeCandidates,
         }),
       ),
     )

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-assignee-candidates.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-assignee-candidates.ts
@@ -1,0 +1,34 @@
+import type { ApiAuthContext } from "@/api/auth/workos";
+import { getCrowdinUserConnectionSummary } from "@/lib/providers/adapters/crowdin/crowdin-user-connections";
+import { getPhraseUserConnectionSummary } from "@/lib/providers/adapters/phrase/phrase-user-connections";
+
+export async function getCurrentUserProviderAssigneeCandidates(auth: ApiAuthContext) {
+  const candidates = [auth.user.email];
+  const crowdinUserConnection = await getCrowdinUserConnectionSummary({
+    organizationId: auth.organization.localOrganizationId,
+    userId: auth.user.localUserId,
+  });
+  const phraseUserConnection = await getPhraseUserConnectionSummary({
+    organizationId: auth.organization.localOrganizationId,
+    userId: auth.user.localUserId,
+  });
+
+  if (crowdinUserConnection) {
+    candidates.push(
+      crowdinUserConnection.username,
+      crowdinUserConnection.email ?? "",
+      crowdinUserConnection.fullName ?? "",
+    );
+  }
+  if (phraseUserConnection) {
+    candidates.push(
+      phraseUserConnection.username,
+      phraseUserConnection.email ?? "",
+      phraseUserConnection.fullName ?? "",
+    );
+  }
+
+  return Array.from(
+    new Set(candidates.map((candidate) => candidate.trim()).filter((candidate) => candidate)),
+  );
+}


### PR DESCRIPTION
## What changed

- Split My Jobs into separate “Jobs assigned to me” and “Jobs created by me” sections.
- Replaced the ambiguous workspace jobs `mine` query with an explicit `relationship=assigned|created` filter.
- Made assigned job filtering work for native job owners and provider-synced assignees by sharing provider assignee candidate lookup.
- Updated the dashboard jobs preview to use assigned jobs explicitly.

## How to test

- `vp test src/api/routes/project/job.route.test.ts`
- `vp check --fix`
- `vp test` was started but interrupted before completion.

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review