### PR TITLE
⚡ Bolt: fix(crowdin): improve upload translations parity and fix panic

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -161,3 +161,9 @@
 **Learning:** The Crowdin API v2 recently introduced a `POST /ai/translate` endpoint for on-demand AI translations of dynamic content. This endpoint exists both at the root `/api/v2/ai/translate` (for Enterprise) and under user-specific paths `/api/v2/users/{userId}/ai/translate`. The request body requires `strings` and `targetLanguageId`. Due to minimal documentation on the exact response schema, a generic `any` response model was used to ensure compatibility with future changes.
 
 **Action:** Implemented `AIService.Translate` method and added typed `AITranslateRequest` and `AITranslateResponse` models in `model/ai.go`. Verified request serialization and response unmarshaling with a contract test in `ai_test.go`.
+
+## 2026-09-26 - Improve Upload Translations parity and fix panic in Source Strings upload
+
+**Learning:** The Crowdin API v2 for uploading translations (`POST /api/v2/projects/{projectId}/translations/{languageId}`) supports `directoryId` for string-based projects, which was missing from the SDK. Additionally, `SourceStringsUploadRequest.Validate()` would panic if `updateOption` was set while `updateStrings` was nil.
+
+**Action:** Added `DirectoryID` (int) to `UploadTranslationsRequest` and updated `Validate()` to ensure `FileID` is not used with `BranchID` or `DirectoryID`. Added `BranchID` and `DirectoryID` to the `UploadTranslations` response struct. Fixed potential nil pointer dereference in `SourceStringsUploadRequest.Validate()` and corrected a struct name in documentation comments. Verified with comprehensive unit and contract tests.

--- a/third_party/crowdin-api-client-go/crowdin/model/source_strings.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/source_strings.go
@@ -228,7 +228,7 @@ func (r *SourceStringsAddRequest) Validate() error {
 	return nil
 }
 
-// SourceStringsService represents the upload strings status.
+// SourceStringsUpload represents the upload strings status.
 type SourceStringsUpload struct {
 	Identifier string `json:"identifier"`
 	Status     string `json:"status"`
@@ -328,7 +328,7 @@ func (o *SourceStringsUploadRequest) Validate() error {
 	if o.BranchID != 0 && o.DirectoryID != 0 {
 		return errors.New("only one of branchId or directoryId may be set")
 	}
-	if o.UpdateOption != "" && !(*o.UpdateStrings) {
+	if o.UpdateOption != "" && (o.UpdateStrings == nil || !(*o.UpdateStrings)) {
 		return errors.New("updateStrings must be set to true to use updateOption")
 	}
 

--- a/third_party/crowdin-api-client-go/crowdin/model/translations.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/translations.go
@@ -541,6 +541,9 @@ type UploadTranslationsRequest struct {
 	// Branch Identifier for import.
 	// Note: Required for string based API.
 	BranchID int `json:"branchId,omitempty"`
+	// Directory Identifier for import.
+	// Note: Required for string based API.
+	DirectoryID int `json:"directoryId,omitempty"`
 	// Defines whether to add translation if it's the same as the source string.
 	// Default: false.
 	ImportEqSuggestions *bool `json:"importEqSuggestions,omitempty"`
@@ -563,8 +566,8 @@ func (r *UploadTranslationsRequest) Validate() error {
 	if r.StorageID == 0 {
 		return errors.New("storageId is required")
 	}
-	if r.FileID > 0 && r.BranchID > 0 {
-		return errors.New("fileId and branchId can not be used at the same request")
+	if r.FileID > 0 && (r.BranchID > 0 || r.DirectoryID > 0) {
+		return errors.New("fileId cannot be used with branchId or directoryId in the same request")
 	}
 	return nil
 }
@@ -572,10 +575,12 @@ func (r *UploadTranslationsRequest) Validate() error {
 type (
 	// UploadTranslations represents the uploaded translations.
 	UploadTranslations struct {
-		ProjectID  int    `json:"projectId"`
-		StorageID  int    `json:"storageId"`
-		LanguageID string `json:"languageId"`
-		FileID     int    `json:"fileId"`
+		ProjectID   int    `json:"projectId"`
+		StorageID   int    `json:"storageId"`
+		LanguageID  string `json:"languageId"`
+		FileID      int    `json:"fileId"`
+		BranchID    int    `json:"branchId"`
+		DirectoryID int    `json:"directoryId"`
 	}
 
 	// UploadTranslationsResponse defines the structure of a response when

--- a/third_party/crowdin-api-client-go/crowdin/model/translations.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/translations.go
@@ -542,7 +542,7 @@ type UploadTranslationsRequest struct {
 	// Note: Required for string based API.
 	BranchID int `json:"branchId,omitempty"`
 	// Directory Identifier for import.
-	// Note: Required for string based API.
+	// Note: Used for string based API; mutually exclusive with branchId.
 	DirectoryID int `json:"directoryId,omitempty"`
 	// Defines whether to add translation if it's the same as the source string.
 	// Default: false.
@@ -568,6 +568,9 @@ func (r *UploadTranslationsRequest) Validate() error {
 	}
 	if r.FileID > 0 && (r.BranchID > 0 || r.DirectoryID > 0) {
 		return errors.New("fileId cannot be used with branchId or directoryId in the same request")
+	}
+	if r.BranchID > 0 && r.DirectoryID > 0 {
+		return errors.New("only one of branchId or directoryId may be set")
 	}
 	return nil
 }

--- a/third_party/crowdin-api-client-go/crowdin/model/translations_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/translations_test.go
@@ -351,9 +351,31 @@ func TestUploadTranslationsRequestValidate(t *testing.T) {
 			err:  "storageId is required",
 		},
 		{
-			name: "one of fileId or branchId is required",
+			name: "fileId and branchId together",
 			req:  &UploadTranslationsRequest{StorageID: 1, FileID: 2, BranchID: 3},
-			err:  "fileId and branchId can not be used at the same request",
+			err:  "fileId cannot be used with branchId or directoryId in the same request",
+		},
+		{
+			name: "fileId and directoryId together",
+			req:  &UploadTranslationsRequest{StorageID: 1, FileID: 2, DirectoryID: 3},
+			err:  "fileId cannot be used with branchId or directoryId in the same request",
+		},
+		{
+			name: "valid request with branchId",
+			req: &UploadTranslationsRequest{
+				StorageID: 1, BranchID: 3,
+				ImportEqSuggestions: toPtr(true), AutoApproveImported: toPtr(true), TranslateHidden: toPtr(true),
+				AddToTM: toPtr(false), MarkAddedAsDone: toPtr(true),
+			},
+			valid: true,
+		},
+		{
+			name: "valid request with directoryId",
+			req: &UploadTranslationsRequest{
+				StorageID: 1, DirectoryID: 3,
+				ImportEqSuggestions: toPtr(true),
+			},
+			valid: true,
 		},
 		{
 			name: "valid request",

--- a/third_party/crowdin-api-client-go/crowdin/model/translations_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/translations_test.go
@@ -361,6 +361,11 @@ func TestUploadTranslationsRequestValidate(t *testing.T) {
 			err:  "fileId cannot be used with branchId or directoryId in the same request",
 		},
 		{
+			name: "branchId and directoryId together",
+			req:  &UploadTranslationsRequest{StorageID: 1, BranchID: 2, DirectoryID: 3},
+			err:  "only one of branchId or directoryId may be set",
+		},
+		{
 			name: "valid request with branchId",
 			req: &UploadTranslationsRequest{
 				StorageID: 1, BranchID: 3,

--- a/third_party/crowdin-api-client-go/crowdin/source_strings_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/source_strings_test.go
@@ -998,7 +998,9 @@ func TestSourceStringsService_UploadWithValidationError(t *testing.T) {
 		{"nil request", nil, "request cannot be nil"},
 		{"empty storageId", &model.SourceStringsUploadRequest{BranchID: 34}, "storageId is required"},
 		{"empty branchId and directoryId", &model.SourceStringsUploadRequest{StorageID: 61}, "branchId or directoryId is required"},
+		{"both branchId and directoryId", &model.SourceStringsUploadRequest{StorageID: 61, BranchID: 34, DirectoryID: 12}, "only one of branchId or directoryId may be set"},
 		{"misconfigured updateStrings for non-empty updateOption", &model.SourceStringsUploadRequest{BranchID: 34, StorageID: 61, UpdateStrings: ToPtr(false), UpdateOption: "clear_translations_and_approvals"}, "updateStrings must be set to true to use updateOption"},
+		{"nil updateStrings for non-empty updateOption", &model.SourceStringsUploadRequest{BranchID: 34, StorageID: 61, UpdateStrings: nil, UpdateOption: "clear_translations_and_approvals"}, "updateStrings must be set to true to use updateOption"},
 	}
 
 	for _, tt := range cases {

--- a/third_party/crowdin-api-client-go/crowdin/translations_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/translations_test.go
@@ -887,7 +887,9 @@ func TestTranslationsService_UploadTranslations(t *testing.T) {
 				"projectId": 8,
 				"storageId": 34,
 				"languageId": "uk",
-				"fileId": 56
+				"fileId": 56,
+				"branchId": 0,
+				"directoryId": 0
 			}
 		}`)
 	})
@@ -905,13 +907,105 @@ func TestTranslationsService_UploadTranslations(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := &model.UploadTranslations{
-		ProjectID:  8,
-		StorageID:  34,
-		LanguageID: "uk",
-		FileID:     56,
+		ProjectID:   8,
+		StorageID:   34,
+		LanguageID:  "uk",
+		FileID:      56,
+		BranchID:    0,
+		DirectoryID: 0,
 	}
 	assert.Equal(t, expected, uploadTranslations)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestTranslationsService_UploadTranslations_WithDirectoryID(t *testing.T) {
+	client, mux, teardown := setupClient()
+	defer teardown()
+
+	const path = "/api/v2/projects/1/translations/uk"
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		testURL(t, r, path)
+		testJSONBody(t, r, `{
+			"storageId": 34,
+			"directoryId": 12,
+			"importEqSuggestions": true
+		}`)
+
+		fmt.Fprint(w, `{
+			"data": {
+				"projectId": 8,
+				"storageId": 34,
+				"languageId": "uk",
+				"fileId": 0,
+				"branchId": 0,
+				"directoryId": 12
+			}
+		}`)
+	})
+
+	req := &model.UploadTranslationsRequest{
+		StorageID:           34,
+		DirectoryID:         12,
+		ImportEqSuggestions: ToPtr(true),
+	}
+	uploadTranslations, resp, err := client.Translations.UploadTranslations(context.Background(), 1, "uk", req)
+	require.NoError(t, err)
+
+	expected := &model.UploadTranslations{
+		ProjectID:   8,
+		StorageID:   34,
+		LanguageID:  "uk",
+		FileID:      0,
+		BranchID:    0,
+		DirectoryID: 12,
+	}
+	assert.Equal(t, expected, uploadTranslations)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestTranslationsService_UploadTranslations_Validation(t *testing.T) {
+	client, _, teardown := setupClient()
+	defer teardown()
+
+	tests := []struct {
+		name          string
+		req           *model.UploadTranslationsRequest
+		expectedError string
+	}{
+		{
+			name: "missing storageId",
+			req: &model.UploadTranslationsRequest{
+				FileID: 56,
+			},
+			expectedError: "storageId is required",
+		},
+		{
+			name: "fileId and branchId together",
+			req: &model.UploadTranslationsRequest{
+				StorageID: 34,
+				FileID:    56,
+				BranchID:  78,
+			},
+			expectedError: "fileId cannot be used with branchId or directoryId in the same request",
+		},
+		{
+			name: "fileId and directoryId together",
+			req: &model.UploadTranslationsRequest{
+				StorageID:   34,
+				FileID:      56,
+				DirectoryID: 12,
+			},
+			expectedError: "fileId cannot be used with branchId or directoryId in the same request",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := client.Translations.UploadTranslations(context.Background(), 1, "uk", tt.req)
+			assert.EqualError(t, err, tt.expectedError)
+		})
+	}
 }
 
 func TestTranslationsService_DownloadProjectTranslations(t *testing.T) {


### PR DESCRIPTION
This PR improves the Crowdin API client parity for translation uploads and fixes a potential panic in source string uploads.

### What
- Added `directoryId` support to the `UploadTranslations` request and response models.
- Updated validation logic for translation uploads.
- Fixed a nil pointer check in `SourceStringsUploadRequest.Validate()`.
- Updated tests to cover new fields and validation scenarios.

### Why
- The Crowdin API v2 for uploading translations supports `directoryId` for string-based projects, which was previously missing from the SDK.
- A nil `UpdateStrings` pointer would cause a panic when `UpdateOption` was provided during a source string upload.

### Docs
- Upload Translations: https://developer.crowdin.com/api/v2/#operation/api.projects.translations.post
- Upload Strings: https://developer.crowdin.com/api/v2/string-based/#operation/api.projects.strings.uploads.post

### Impact
- Improves API parity for string-based projects.
- Prevents runtime panics during source string uploads.

### Measurement
- Verified with new and updated unit tests in `third_party/crowdin-api-client-go`.
- All tests pass with `GOWORK=off go test ./...`.
- `make fmt`, `make lint`, and `make test` pass successfully.

---
*PR created automatically by Jules for task [4744490501761373901](https://jules.google.com/task/4744490501761373901) started by @cungminh2710*