### PR TITLE
feat(web): localize CAT workspace UI strings

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/tms-job-cat-workspace.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/tms-job-cat-workspace.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import type { ProjectFileCatResponse } from "@/api/routes/project/project.schema";
+import { getIntlShape } from "@/lib/app-i18n/intl";
 import {
   projectFileCatToWorkspaceState,
   requireProviderExternalResourceId,
 } from "./tms-job-cat-workspace";
+
+const testIntl = getIntlShape("en");
 
 function catFile(): ProjectFileCatResponse["catFile"] {
   return {
@@ -65,7 +68,7 @@ function catFile(): ProjectFileCatResponse["catFile"] {
 
 describe("projectFileCatToWorkspaceState", () => {
   it("maps live Crowdin CAT content into the next-gen CAT workspace shape", () => {
-    const state = projectFileCatToWorkspaceState(catFile());
+    const state = projectFileCatToWorkspaceState(catFile(), testIntl);
 
     expect(state.selectedSegmentId).toBe("approved-string");
     expect(state.queueSummary).toEqual({ total: 2, reviewed: 1 });
@@ -103,16 +106,19 @@ describe("projectFileCatToWorkspaceState", () => {
   });
 
   it("maps persisted repository context into segment intelligence", () => {
-    const state = projectFileCatToWorkspaceState({
-      ...catFile(),
-      segments: [
-        {
-          ...catFile().segments[0],
-          repositoryContext: "Hero title on the sign-in page.",
-        },
-        catFile().segments[1],
-      ],
-    });
+    const state = projectFileCatToWorkspaceState(
+      {
+        ...catFile(),
+        segments: [
+          {
+            ...catFile().segments[0],
+            repositoryContext: "Hero title on the sign-in page.",
+          },
+          catFile().segments[1],
+        ],
+      },
+      testIntl,
+    );
 
     expect(state.segmentIntelligence?.["approved-string"]?.agentContext).toBe(
       "Hero title on the sign-in page.",
@@ -120,10 +126,13 @@ describe("projectFileCatToWorkspaceState", () => {
   });
 
   it("maps canEditTranslations from the CAT file payload", () => {
-    const readOnlyState = projectFileCatToWorkspaceState({
-      ...catFile(),
-      canEditTranslations: false,
-    });
+    const readOnlyState = projectFileCatToWorkspaceState(
+      {
+        ...catFile(),
+        canEditTranslations: false,
+      },
+      testIntl,
+    );
 
     expect(readOnlyState.canEditTranslations).toBe(false);
   });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/tms-job-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/tms-job-cat-workspace.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useMemo } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useIntl } from "react-intl";
 
 import type {
   ProjectFileCatConcordanceResponse,
@@ -15,6 +16,11 @@ import {
   analyzeCatMessageFormat,
   compareCatMessageFormats,
 } from "@/components/cat/cat-message-format";
+import type { CatMessageParityIssue } from "@/components/cat/cat-message-format";
+import {
+  localizeCatMessageParityIssue,
+  type CatFormatMessageIntl,
+} from "@/components/cat/cat-message-format-i18n";
 import type {
   CatFormatCheck,
   CatSegment,
@@ -69,7 +75,33 @@ function segmentStatusFor(segment: ProjectFileCatSegment): CatSegment["status"] 
   return segment.target?.text.trim() ? "needs_review" : "pending";
 }
 
-function formatCheckForSegment(segment: CatSegment, value: string): CatFormatCheck[] {
+function formatCheckFromParityIssue(
+  issue: CatMessageParityIssue,
+  index: number,
+  intl: CatFormatMessageIntl,
+): CatFormatCheck {
+  const localized = localizeCatMessageParityIssue(issue, intl);
+
+  return {
+    id: `format-${issue.kind}-${index}`,
+    label: localized.label,
+    status: issue.kind === "extra-token" ? "warn" : "fail",
+    message: localized.message,
+    category:
+      issue.kind === "parse-error"
+        ? "syntax"
+        : issue.kind === "icu-mismatch"
+          ? "icu"
+          : "placeholder",
+    relatedTokens: issue.tokens,
+  };
+}
+
+function formatCheckForSegment(
+  segment: CatSegment,
+  value: string,
+  intl: CatFormatMessageIntl,
+): CatFormatCheck[] {
   const checks: CatFormatCheck[] = [];
   const sourceAnalysis = analyzeCatMessageFormat(segment.sourceText);
   const targetAnalysis = analyzeCatMessageFormat(value);
@@ -88,22 +120,7 @@ function formatCheckForSegment(segment: CatSegment, value: string): CatFormatChe
     });
   } else {
     checks.push(
-      ...parityIssues.map(
-        (issue, index) =>
-          ({
-            id: `format-${issue.kind}-${index}`,
-            label: issue.label,
-            status: issue.kind === "extra-token" ? "warn" : "fail",
-            message: issue.message,
-            category:
-              issue.kind === "parse-error"
-                ? "syntax"
-                : issue.kind === "icu-mismatch"
-                  ? "icu"
-                  : "placeholder",
-            relatedTokens: issue.tokens,
-          }) satisfies CatFormatCheck,
-      ),
+      ...parityIssues.map((issue, index) => formatCheckFromParityIssue(issue, index, intl)),
     );
   }
 
@@ -120,8 +137,12 @@ function formatCheckForSegment(segment: CatSegment, value: string): CatFormatChe
   return checks;
 }
 
-async function validateSegmentFormat(segment: CatSegment, value: string) {
-  return formatCheckForSegment(segment, value);
+async function validateSegmentFormat(
+  segment: CatSegment,
+  value: string,
+  intl: CatFormatMessageIntl,
+) {
+  return formatCheckForSegment(segment, value, intl);
 }
 
 function intelligenceFor(catFile: CatFile): CatSegmentIntelligence {
@@ -182,7 +203,10 @@ function segmentIntelligenceFor(
   };
 }
 
-export function projectFileCatToWorkspaceState(catFile: CatFile): CatWorkspaceState {
+export function projectFileCatToWorkspaceState(
+  catFile: CatFile,
+  intl: CatFormatMessageIntl,
+): CatWorkspaceState {
   const sourceLocale = catFile.provider?.sourceLocale ?? "source";
   const segments = catFile.segments.map((segment, index): CatSegment => {
     const comments = segment.comments.length;
@@ -214,9 +238,14 @@ export function projectFileCatToWorkspaceState(catFile: CatFile): CatWorkspaceSt
       total: segments.length,
       reviewed: segments.filter((segment) => segment.status === "reviewed").length,
     },
-    formatChecks: segments[0] ? formatCheckForSegment(segments[0], segments[0].targetText) : [],
+    formatChecks: segments[0]
+      ? formatCheckForSegment(segments[0], segments[0].targetText, intl)
+      : [],
     segmentFormatChecks: Object.fromEntries(
-      segments.map((segment) => [segment.id, formatCheckForSegment(segment, segment.targetText)]),
+      segments.map((segment) => [
+        segment.id,
+        formatCheckForSegment(segment, segment.targetText, intl),
+      ]),
     ),
     suggestions: [],
     intelligence: intelligenceFor(catFile),
@@ -247,6 +276,7 @@ export function TmsJobCatWorkspace({
   repositoryFullName?: string | null;
   className?: string;
 }) {
+  const intl = useIntl();
   const queryClient = useQueryClient();
   const queryKey = projectFileCatQueryKey(
     organizationSlug,
@@ -309,8 +339,12 @@ export function TmsJobCatWorkspace({
   const saveTranslation = saveMutation.mutateAsync;
 
   const workspaceState = useMemo(
-    () => (catQuery.data ? projectFileCatToWorkspaceState(catQuery.data) : null),
-    [catQuery.data],
+    () => (catQuery.data ? projectFileCatToWorkspaceState(catQuery.data, intl) : null),
+    [catQuery.data, intl],
+  );
+  const validateFormat = useCallback(
+    (segment: CatSegment, value: string) => validateSegmentFormat(segment, value, intl),
+    [intl],
   );
   const handleApprove = useCallback(
     async (segmentId: string, targetText: string) => {
@@ -454,7 +488,7 @@ export function TmsJobCatWorkspace({
       initialState={workspaceState}
       className={cn("min-h-0 flex-1", className)}
       services={{
-        validateFormat: validateSegmentFormat,
+        validateFormat,
         lookupSegmentConcordance,
         generateAiRecommendation,
         ...(repositoryFullName ? { lookupSegmentContext } : {}),

--- a/apps/hyperlocalise-web/src/components/cat/cat-editor-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-editor-panel.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from "react";
 import { ArrowLeft01Icon, ArrowRight01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useHotkeys } from "react-hotkeys-hook";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import { Button } from "@/components/ui/button";
 import { Kbd, KbdGroup } from "@/components/ui/kbd";
@@ -13,6 +14,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/primitives/cn";
 
 import { CatFormatChecks } from "./cat-format-checks";
+import { catEditorPanelMessages } from "./cat.messages";
 import { analyzeCatMessageFormat } from "./cat-message-format";
 import { CatIcuStructureSummary, CatMessagePreview, CatTargetEditor } from "./cat-target-editor";
 import type { CatFormatCheck, CatSegment, CatSegmentIntelligence } from "./types";
@@ -53,7 +55,7 @@ export function CatEditorPanel({
   onTargetChange,
   onUseAiSuggestion,
   onApprove,
-  primaryActionLabel = "Approve",
+  primaryActionLabel,
   onAskQuestion,
   onGenerateAiRecommendation,
   aiRecommendationError,
@@ -87,6 +89,9 @@ export function CatEditorPanel({
   hasPreviousSegment: boolean;
   hasNextSegment: boolean;
 }) {
+  const intl = useIntl();
+  const resolvedPrimaryActionLabel =
+    primaryActionLabel ?? intl.formatMessage(catEditorPanelMessages.approve);
   const [commentDrafts, setCommentDrafts] = useState<Record<string, string>>({});
   const [commentsBySegmentId, setCommentsBySegmentId] = useState<
     Record<string, CatEditorComment[]>
@@ -145,8 +150,8 @@ export function CatEditorPanel({
           ...currentComments,
           {
             id: `${segment.id}-comment-${commentNumber}`,
-            author: "Reviewer",
-            createdAtLabel: "Just now",
+            author: intl.formatMessage(catEditorPanelMessages.commentAuthorReviewer),
+            createdAtLabel: intl.formatMessage(catEditorPanelMessages.commentCreatedJustNow),
             body: trimmedCommentDraft,
           },
         ],
@@ -169,8 +174,8 @@ export function CatEditorPanel({
             size="icon-sm"
             onClick={onPrevious}
             disabled={!hasPreviousSegment}
-            aria-label="Previous segment"
-            title="Previous segment (⌘←)"
+            aria-label={intl.formatMessage(catEditorPanelMessages.previousSegmentAria)}
+            title={intl.formatMessage(catEditorPanelMessages.previousSegmentTitle)}
           >
             <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
           </Button>
@@ -179,8 +184,8 @@ export function CatEditorPanel({
             size="icon-sm"
             onClick={onNext}
             disabled={!hasNextSegment}
-            aria-label="Next segment"
-            title="Next segment (⌘→)"
+            aria-label={intl.formatMessage(catEditorPanelMessages.nextSegmentAria)}
+            title={intl.formatMessage(catEditorPanelMessages.nextSegmentTitle)}
           >
             <HugeiconsIcon icon={ArrowRight01Icon} className="size-4" />
           </Button>
@@ -191,7 +196,10 @@ export function CatEditorPanel({
         <div className="mx-auto max-w-3xl space-y-6 px-4 py-5 sm:px-6 lg:space-y-7 lg:px-8 lg:py-8">
           <section className="space-y-3">
             <h3 className="text-xs font-medium text-muted-foreground">
-              Source ({segment.sourceLocale})
+              <FormattedMessage
+                {...catEditorPanelMessages.sourceHeading}
+                values={{ locale: segment.sourceLocale }}
+              />
             </h3>
             <p className="text-pretty text-base leading-relaxed text-foreground/92 lg:text-lg">
               <CatMessagePreview message={segment.sourceText} />
@@ -201,7 +209,10 @@ export function CatEditorPanel({
           <section className="space-y-3">
             <div className="flex items-center justify-between gap-2">
               <h3 className="text-xs font-medium text-muted-foreground">
-                Target ({segment.targetLocale})
+                <FormattedMessage
+                  {...catEditorPanelMessages.targetHeading}
+                  values={{ locale: segment.targetLocale }}
+                />
               </h3>
             </div>
             <CatTargetEditor
@@ -226,7 +237,7 @@ export function CatEditorPanel({
               }
             >
               {isApproving ? <Spinner className="size-4 text-white" /> : null}
-              {primaryActionLabel}
+              {resolvedPrimaryActionLabel}
               <ShortcutKbd keys={["⌘", "↵"]} className="bg-white/15 text-white" />
             </Button>
             <Button
@@ -242,12 +253,16 @@ export function CatEditorPanel({
               }
               title={
                 canLookupContext
-                  ? "Look up where this string appears in the connected repository"
-                  : "Repository context lookup is not available"
+                  ? intl.formatMessage(catEditorPanelMessages.findContextTitle)
+                  : intl.formatMessage(catEditorPanelMessages.findContextUnavailableTitle)
               }
             >
               {isLookingUpContext ? <Spinner className="size-4" /> : null}
-              {isLookingUpContext ? "Finding context…" : "Find context"}
+              {isLookingUpContext ? (
+                <FormattedMessage {...catEditorPanelMessages.findingContext} />
+              ) : (
+                <FormattedMessage {...catEditorPanelMessages.findContext} />
+              )}
               <ShortcutKbd keys={["⌘", "K"]} />
             </Button>
             <Button
@@ -256,7 +271,7 @@ export function CatEditorPanel({
               onClick={onPrevious}
               disabled={isApproving || isLookingUpContext || !hasPreviousSegment}
             >
-              Previous
+              <FormattedMessage {...catEditorPanelMessages.previous} />
               <ShortcutKbd keys={["⌘", "←"]} />
             </Button>
             <Button
@@ -265,7 +280,7 @@ export function CatEditorPanel({
               onClick={onNext}
               disabled={isApproving || isLookingUpContext || !hasNextSegment}
             >
-              Next
+              <FormattedMessage {...catEditorPanelMessages.next} />
               <ShortcutKbd keys={["⌘", "→"]} />
             </Button>
           </div>
@@ -291,11 +306,13 @@ export function CatEditorPanel({
                 )}
               >
                 <div className="mb-2 flex items-center justify-between gap-3">
-                  <p className="text-xs font-medium text-muted-foreground">AI recommendation</p>
+                  <p className="text-xs font-medium text-muted-foreground">
+                    <FormattedMessage {...catEditorPanelMessages.aiRecommendation} />
+                  </p>
                   <div className="flex items-center gap-1">
                     {intelligence.aiSuggestion ? (
                       <Button variant="ghost" size="sm" onClick={onUseAiSuggestion}>
-                        Use
+                        <FormattedMessage {...catEditorPanelMessages.use} />
                       </Button>
                     ) : null}
                     {onGenerateAiRecommendation ? (
@@ -305,7 +322,11 @@ export function CatEditorPanel({
                         onClick={onGenerateAiRecommendation}
                         disabled={isAiSuggestionLoading}
                       >
-                        {intelligence.aiSuggestion ? "Regenerate" : "Get recommendation"}
+                        {intelligence.aiSuggestion ? (
+                          <FormattedMessage {...catEditorPanelMessages.regenerate} />
+                        ) : (
+                          <FormattedMessage {...catEditorPanelMessages.getRecommendation} />
+                        )}
                       </Button>
                     ) : null}
                   </div>
@@ -319,14 +340,16 @@ export function CatEditorPanel({
                     </p>
                     {intelligence.aiReasoning ? (
                       <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
-                        <span className="font-medium text-foreground/70">Reasoning:</span>{" "}
+                        <span className="font-medium text-foreground/70">
+                          <FormattedMessage {...catEditorPanelMessages.reasoningPrefix} />
+                        </span>{" "}
                         {intelligence.aiReasoning}
                       </p>
                     ) : null}
                   </>
                 ) : (
                   <p className="text-sm text-muted-foreground">
-                    Generate a translation suggestion for this string.
+                    <FormattedMessage {...catEditorPanelMessages.aiSuggestionEmpty} />
                   </p>
                 )}
               </aside>
@@ -334,7 +357,9 @@ export function CatEditorPanel({
           ) : null}
 
           <section className="space-y-3">
-            <h3 className="text-xs font-medium text-muted-foreground">Format & QA checks</h3>
+            <h3 className="text-xs font-medium text-muted-foreground">
+              <FormattedMessage {...catEditorPanelMessages.formatQaChecks} />
+            </h3>
             {isFormatChecksLoading ? (
               <div className="space-y-0 divide-y divide-foreground/8 rounded-xl border border-foreground/8 bg-foreground/2">
                 {[0, 1, 2].map((item) => (
@@ -357,7 +382,9 @@ export function CatEditorPanel({
 
           <section className="space-y-3 border-t border-foreground/8 pt-5">
             <div className="flex items-center justify-between gap-2">
-              <h3 className="text-xs font-medium text-muted-foreground">Comments</h3>
+              <h3 className="text-xs font-medium text-muted-foreground">
+                <FormattedMessage {...catEditorPanelMessages.comments} />
+              </h3>
               <span className="text-xs text-muted-foreground tabular-nums">
                 {segmentComments.length}
               </span>
@@ -376,14 +403,14 @@ export function CatEditorPanel({
               </ul>
             ) : (
               <p className="text-sm text-muted-foreground">
-                No comments yet. Add a note for reviewers or translators.
+                <FormattedMessage {...catEditorPanelMessages.noComments} />
               </p>
             )}
             <Textarea
               value={commentDraft}
               onChange={(event) => handleCommentDraftChange(event.currentTarget.value)}
               className="min-h-20 resize-y rounded-xl border-foreground/12 bg-background px-3 py-3 text-sm leading-relaxed"
-              placeholder="Add a comment..."
+              placeholder={intl.formatMessage(catEditorPanelMessages.commentPlaceholder)}
             />
             <div className="flex justify-end">
               <Button
@@ -392,7 +419,7 @@ export function CatEditorPanel({
                 onClick={handleAddComment}
                 disabled={!trimmedCommentDraft}
               >
-                Add comment
+                <FormattedMessage {...catEditorPanelMessages.addComment} />
               </Button>
             </div>
           </section>

--- a/apps/hyperlocalise-web/src/components/cat/cat-format-checks.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-format-checks.tsx
@@ -6,9 +6,11 @@ import {
   InformationCircleIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import { cn } from "@/lib/primitives/cn";
 
+import { catFormatChecksMessages } from "./cat.messages";
 import type { CatFormatCheck } from "./types";
 
 function FormatCheckIcon({ status }: { status: CatFormatCheck["status"] }) {
@@ -22,24 +24,29 @@ function FormatCheckIcon({ status }: { status: CatFormatCheck["status"] }) {
   }
 }
 
-function formatCheckStatusLabel(status: CatFormatCheck["status"]) {
+function formatCheckStatusLabel(
+  status: CatFormatCheck["status"],
+  intl: ReturnType<typeof useIntl>,
+) {
   switch (status) {
     case "pass":
-      return "Passed";
+      return intl.formatMessage(catFormatChecksMessages.statusPass);
     case "warn":
-      return "Check";
+      return intl.formatMessage(catFormatChecksMessages.statusWarn);
     case "fail":
-      return "Issue";
+      return intl.formatMessage(catFormatChecksMessages.statusFail);
     default:
       return status;
   }
 }
 
 export function CatFormatChecks({ checks }: { checks: CatFormatCheck[] }) {
+  const intl = useIntl();
+
   if (checks.length === 0) {
     return (
       <div className="rounded-lg border border-dashed border-foreground/12 px-3 py-4 text-center text-xs text-muted-foreground">
-        No format or QA checks for this segment yet.
+        <FormattedMessage {...catFormatChecksMessages.emptyChecks} />
       </div>
     );
   }
@@ -60,7 +67,7 @@ export function CatFormatChecks({ checks }: { checks: CatFormatCheck[] }) {
                   check.status === "fail" && "text-flame-200",
                 )}
               >
-                {formatCheckStatusLabel(check.status)}
+                {formatCheckStatusLabel(check.status, intl)}
               </span>
             </div>
             <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{check.message}</p>

--- a/apps/hyperlocalise-web/src/components/cat/cat-intelligence-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-intelligence-panel.tsx
@@ -3,12 +3,14 @@
 import type { ReactNode } from "react";
 import { BulbIcon, CheckmarkCircle02Icon, InformationCircleIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import { MarkdownContent } from "@/components/markdown-description-editor";
 import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 
+import { catIntelligencePanelMessages } from "./cat.messages";
 import type { CatGlossaryTerm, CatSegmentIntelligence, CatTranslationMemoryMatch } from "./types";
 
 function PanelSection({ title, children }: { title: string; children: ReactNode }) {
@@ -70,6 +72,8 @@ function AgentContextSkeleton() {
 }
 
 function GlossaryTermRow({ term }: { term: CatGlossaryTerm }) {
+  const intl = useIntl();
+
   return (
     <li className="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-2 px-3 py-2.5">
       <span className="min-w-0 truncate text-sm text-foreground/86">{term.source}</span>
@@ -80,7 +84,7 @@ function GlossaryTermRow({ term }: { term: CatGlossaryTerm }) {
           <HugeiconsIcon
             icon={CheckmarkCircle02Icon}
             className="size-3.5 shrink-0 text-grove-300"
-            aria-label="Approved"
+            aria-label={intl.formatMessage(catIntelligencePanelMessages.approvedAria)}
           />
         ) : null}
       </span>
@@ -93,7 +97,10 @@ function TranslationMemoryRow({ match }: { match: CatTranslationMemoryMatch }) {
     <li className="space-y-2 px-3 py-3">
       <div className="flex items-center justify-between gap-3">
         <span className="rounded-full border border-dew-500/25 bg-dew-500/10 px-2 py-0.5 text-[11px] font-medium text-dew-100">
-          {match.matchPercent}% match
+          <FormattedMessage
+            {...catIntelligencePanelMessages.matchPercent}
+            values={{ matchPercent: match.matchPercent }}
+          />
         </span>
         {match.contextLabel ? (
           <span className="min-w-0 truncate text-xs text-muted-foreground">
@@ -122,6 +129,7 @@ export function CatIntelligencePanel({
   isConcordanceLoading?: boolean;
   showAgentContext?: boolean;
 }) {
+  const intl = useIntl();
   const hasFileContext = Boolean(intelligence.productMeaning?.trim());
   const agentBadges = [
     intelligence.locationBreadcrumb,
@@ -136,51 +144,59 @@ export function CatIntelligencePanel({
       <div className="border-b border-foreground/8 px-4 py-3">
         <div className="flex items-center gap-2">
           <HugeiconsIcon icon={BulbIcon} className="size-4 text-bud-300" />
-          <h2 className="text-sm font-semibold text-foreground">Translation Intelligence</h2>
+          <h2 className="text-sm font-semibold text-foreground">
+            <FormattedMessage {...catIntelligencePanelMessages.panelTitle} />
+          </h2>
         </div>
         <p className="mt-1 text-xs text-muted-foreground">
-          Context and terminology for this string.
+          <FormattedMessage {...catIntelligencePanelMessages.panelDescription} />
         </p>
       </div>
 
       <ScrollArea className="min-h-0 flex-1">
         <div className="space-y-5 p-4">
-          <PanelSection title="Context attached in the file">
+          <PanelSection title={intl.formatMessage(catIntelligencePanelMessages.fileContextTitle)}>
             {hasFileContext ? (
               <MarkdownContent
                 value={intelligence.productMeaning ?? ""}
                 contentClassName="px-0 py-0 text-sm leading-relaxed text-foreground/88"
-                ariaLabel="File context"
+                ariaLabel={intl.formatMessage(catIntelligencePanelMessages.fileContextAria)}
               />
             ) : (
               <p className="text-sm leading-relaxed text-muted-foreground">
-                No context is attached to this string in the source file.
+                <FormattedMessage {...catIntelligencePanelMessages.noFileContext} />
               </p>
             )}
           </PanelSection>
 
           {showAgentContext ? (
-            <PanelSection title="Context found by agent">
+            <PanelSection
+              title={intl.formatMessage(catIntelligencePanelMessages.agentContextTitle)}
+            >
               {isLookingUpContext ? (
                 <AgentContextSkeleton />
               ) : hasAgentContext ? (
                 <div className="space-y-3">
                   {hasAgentInsight ? (
                     <InsightCard
-                      label="Meaning in product"
+                      label={intl.formatMessage(catIntelligencePanelMessages.meaningInProduct)}
                       icon={<HugeiconsIcon icon={InformationCircleIcon} className="size-3.5" />}
                     >
                       <div className="min-h-[1.25rem] space-y-2">
                         <MarkdownContent
                           value={intelligence.agentContext ?? ""}
                           contentClassName="min-h-[1.25rem] px-0 py-0 text-sm leading-relaxed text-foreground/88"
-                          ariaLabel="Agent context"
+                          ariaLabel={intl.formatMessage(
+                            catIntelligencePanelMessages.agentContextAria,
+                          )}
                         />
                         {intelligence.intent ? (
                           <MarkdownContent
                             value={intelligence.intent}
                             contentClassName="min-h-[1rem] px-0 py-0 text-xs leading-relaxed text-muted-foreground"
-                            ariaLabel="Translation intent"
+                            ariaLabel={intl.formatMessage(
+                              catIntelligencePanelMessages.translationIntentAria,
+                            )}
                           />
                         ) : null}
                       </div>
@@ -208,7 +224,7 @@ export function CatIntelligencePanel({
                 </div>
               ) : (
                 <p className="text-sm leading-relaxed text-muted-foreground">
-                  No repository context was found for this string.
+                  <FormattedMessage {...catIntelligencePanelMessages.noRepositoryContext} />
                 </p>
               )}
             </PanelSection>
@@ -216,17 +232,21 @@ export function CatIntelligencePanel({
 
           {isConcordanceLoading ? (
             <>
-              <PanelSection title="Glossary guidance">
+              <PanelSection
+                title={intl.formatMessage(catIntelligencePanelMessages.glossaryGuidance)}
+              >
                 <ConcordanceSkeleton />
               </PanelSection>
-              <PanelSection title="Translation memory">
+              <PanelSection
+                title={intl.formatMessage(catIntelligencePanelMessages.translationMemory)}
+              >
                 <ConcordanceSkeleton />
               </PanelSection>
             </>
           ) : null}
 
           {!isConcordanceLoading && intelligence.glossaryTerms.length > 0 ? (
-            <PanelSection title="Glossary guidance">
+            <PanelSection title={intl.formatMessage(catIntelligencePanelMessages.glossaryGuidance)}>
               <div className="overflow-hidden rounded-2xl bg-foreground/3">
                 <ul className="divide-y divide-foreground/8">
                   {intelligence.glossaryTerms.map((term) => (
@@ -240,7 +260,9 @@ export function CatIntelligencePanel({
           {!isConcordanceLoading &&
           intelligence.translationMemoryMatches &&
           intelligence.translationMemoryMatches.length > 0 ? (
-            <PanelSection title="Translation memory">
+            <PanelSection
+              title={intl.formatMessage(catIntelligencePanelMessages.translationMemory)}
+            >
               <div className="overflow-hidden rounded-2xl bg-foreground/3">
                 <ul className="divide-y divide-foreground/8">
                   {intelligence.translationMemoryMatches.map((match) => (

--- a/apps/hyperlocalise-web/src/components/cat/cat-message-format-i18n.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat-message-format-i18n.ts
@@ -1,0 +1,97 @@
+import type { IntlShape } from "@formatjs/intl";
+
+import type { CatMessageParityIssue } from "./cat-message-format";
+
+export type CatFormatMessageIntl = Pick<IntlShape, "formatMessage">;
+
+export function localizeCatMessageParityIssue(
+  issue: CatMessageParityIssue,
+  intl: CatFormatMessageIntl,
+): { label: string; message: string } {
+  switch (issue.kind) {
+    case "parse-error": {
+      const label =
+        issue.parseTarget === "source"
+          ? intl.formatMessage({
+              defaultMessage: "Source message syntax",
+              id: "yRRevnNvnn",
+              description: "CAT format check label for invalid source message syntax",
+            })
+          : intl.formatMessage({
+              defaultMessage: "Target message syntax",
+              id: "wmlNXZkocx",
+              description: "CAT format check label for invalid target message syntax",
+            });
+
+      return {
+        label,
+        message:
+          issue.parseErrorMessage ??
+          intl.formatMessage({
+            defaultMessage: "Message syntax could not be parsed.",
+            id: "H0k47esZhc",
+            description: "Fallback error when ICU message syntax parsing fails",
+          }),
+      };
+    }
+    case "missing-token": {
+      const tokens = issue.tokens?.join(", ") ?? "";
+      return {
+        label: intl.formatMessage({
+          defaultMessage: "Missing placeholders",
+          id: "AAnhNKa9eI",
+          description: "CAT format check label when target is missing required placeholders",
+        }),
+        message: intl.formatMessage(
+          {
+            defaultMessage: "Target is missing {tokens} from the source string.",
+            id: "dy2mVzOtSq",
+            description: "CAT format check message listing placeholders missing from the target",
+          },
+          { tokens },
+        ),
+      };
+    }
+    case "extra-token": {
+      const tokens = issue.tokens?.join(", ") ?? "";
+      return {
+        label: intl.formatMessage({
+          defaultMessage: "Extra placeholders",
+          id: "bajKG/XM1h",
+          description: "CAT format check label when target has placeholders not in the source",
+        }),
+        message: intl.formatMessage(
+          {
+            defaultMessage: "Target includes {tokens} that is not in the source string.",
+            id: "RuN49xBd1k",
+            description: "CAT format check message listing extra placeholders in the target",
+          },
+          { tokens },
+        ),
+      };
+    }
+    case "icu-mismatch": {
+      const tokens = issue.tokens?.join(", ") ?? "";
+      return {
+        label: intl.formatMessage({
+          defaultMessage: "ICU structure",
+          id: "BresGxSzFx",
+          description: "CAT format check label when target ICU structure does not match source",
+        }),
+        message: intl.formatMessage(
+          {
+            defaultMessage: "Target ICU structure must match {tokens} from the source string.",
+            id: "tsN6wGlUZC",
+            description: "CAT format check message listing ICU blocks missing from the target",
+          },
+          { tokens },
+        ),
+      };
+    }
+    default:
+      return {
+        label: issue.kind,
+        message: issue.kind,
+      };
+  }
+}

--- a/apps/hyperlocalise-web/src/components/cat/cat-message-format.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat-message-format.test.ts
@@ -67,7 +67,7 @@ describe("cat message format utilities", () => {
     expect(issues).toContainEqual(
       expect.objectContaining({
         kind: "parse-error",
-        label: "Source message syntax",
+        parseTarget: "source",
       }),
     );
   });

--- a/apps/hyperlocalise-web/src/components/cat/cat-message-format.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat-message-format.ts
@@ -48,9 +48,9 @@ export interface CatMessageAnalysis {
 
 export interface CatMessageParityIssue {
   kind: "missing-token" | "extra-token" | "icu-mismatch" | "parse-error";
-  label: string;
-  message: string;
   tokens?: string[];
+  parseErrorMessage?: string;
+  parseTarget?: "source" | "target";
 }
 
 function locationRange(location: Location | undefined, fallbackEnd: number) {
@@ -204,7 +204,7 @@ export function analyzeCatMessageFormat(message: string): CatMessageAnalysis {
       placeholders: [],
       icuBlocks: [],
       parseError: {
-        message: parserError.message ?? "Message syntax could not be parsed.",
+        message: parserError.message ?? "",
         start: range.start,
         end: Math.max(range.end, range.start + 1),
       },
@@ -246,14 +246,14 @@ export function compareCatMessageFormats(
   if (source.parseError) {
     issues.push({
       kind: "parse-error",
-      label: "Source message syntax",
-      message: source.parseError.message,
+      parseTarget: "source",
+      parseErrorMessage: source.parseError.message || undefined,
     });
     if (target.parseError) {
       issues.push({
         kind: "parse-error",
-        label: "Target message syntax",
-        message: target.parseError.message,
+        parseTarget: "target",
+        parseErrorMessage: target.parseError.message || undefined,
       });
     }
     return issues;
@@ -262,8 +262,8 @@ export function compareCatMessageFormats(
   if (target.parseError) {
     issues.push({
       kind: "parse-error",
-      label: "Target message syntax",
-      message: target.parseError.message,
+      parseTarget: "target",
+      parseErrorMessage: target.parseError.message || undefined,
     });
     return issues;
   }
@@ -273,8 +273,6 @@ export function compareCatMessageFormats(
     const labels = uniqueSorted(missingPlaceholders.map(tokenDisplayName));
     issues.push({
       kind: "missing-token",
-      label: "Missing placeholders",
-      message: `Target is missing ${labels.join(", ")} from the source string.`,
       tokens: labels,
     });
   }
@@ -284,8 +282,6 @@ export function compareCatMessageFormats(
     const labels = uniqueSorted(extraPlaceholders.map(tokenDisplayName));
     issues.push({
       kind: "extra-token",
-      label: "Extra placeholders",
-      message: `Target includes ${labels.join(", ")} that is not in the source string.`,
       tokens: labels,
     });
   }
@@ -298,8 +294,6 @@ export function compareCatMessageFormats(
     const labels = uniqueSorted(missingIcuBlocks.map(tokenDisplayName));
     issues.push({
       kind: "icu-mismatch",
-      label: "ICU structure",
-      message: `Target ICU structure must match ${labels.join(", ")} from the source string.`,
       tokens: labels,
     });
   }

--- a/apps/hyperlocalise-web/src/components/cat/cat-queue-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-queue-panel.tsx
@@ -6,12 +6,14 @@ import {
   MoreHorizontalCircle01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/primitives/cn";
 
+import { catQueuePanelMessages } from "./cat.messages";
 import type { CatQueueSummary, CatSegment } from "./types";
 
 function QueueStatusIcon({ status }: { status: CatSegment["status"] }) {
@@ -37,6 +39,7 @@ export function CatQueuePanel({
   summary: CatQueueSummary;
   onSelectSegment: (segmentId: string) => void;
 }) {
+  const intl = useIntl();
   const progressValue =
     summary.total > 0 ? Math.round((summary.reviewed / summary.total) * 100) : 0;
 
@@ -44,16 +47,29 @@ export function CatQueuePanel({
     <div className="flex h-full min-h-0 flex-col bg-background lg:border-r lg:border-foreground/8">
       <div className="flex items-center justify-between gap-2 border-b border-foreground/8 px-4 py-3">
         <div>
-          <h2 className="text-sm font-semibold text-foreground">Queue</h2>
+          <h2 className="text-sm font-semibold text-foreground">
+            <FormattedMessage {...catQueuePanelMessages.queueTitle} />
+          </h2>
           <p className="text-xs text-muted-foreground">
-            {summary.total} total · {summary.reviewed} reviewed
+            <FormattedMessage
+              {...catQueuePanelMessages.queueSummary}
+              values={{ total: summary.total, reviewed: summary.reviewed }}
+            />
           </p>
         </div>
         <div className="flex items-center gap-1">
-          <Button variant="ghost" size="icon-sm" aria-label="Filter queue">
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label={intl.formatMessage(catQueuePanelMessages.filterQueueAria)}
+          >
             <HugeiconsIcon icon={FilterIcon} className="size-4" />
           </Button>
-          <Button variant="ghost" size="icon-sm" aria-label="Queue actions">
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label={intl.formatMessage(catQueuePanelMessages.queueActionsAria)}
+          >
             <HugeiconsIcon icon={MoreHorizontalCircle01Icon} className="size-4" />
           </Button>
         </div>

--- a/apps/hyperlocalise-web/src/components/cat/cat-suggestions-tabs.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-suggestions-tabs.tsx
@@ -3,6 +3,7 @@
 import { useId, useState } from "react";
 import { ArrowDown01Icon, ArrowUp01Icon, InformationCircleIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -10,10 +11,28 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/primitives/cn";
 
-import { catToneClass, suggestionSourceLabel } from "./cat-tone";
+import { catSuggestionsTabsMessages, catToneMessages } from "./cat.messages";
+import { catToneClass } from "./cat-tone";
 import type { CatSuggestion } from "./types";
 
+function suggestionSourceLabel(source: string, intl: ReturnType<typeof useIntl>) {
+  switch (source) {
+    case "ai":
+      return intl.formatMessage(catToneMessages.sourceAi);
+    case "glossary":
+      return intl.formatMessage(catToneMessages.sourceGlossary);
+    case "tm":
+      return intl.formatMessage(catToneMessages.sourceTm);
+    case "mt":
+      return intl.formatMessage(catToneMessages.sourceMt);
+    default:
+      return source;
+  }
+}
+
 function SuggestionRow({ suggestion, onUse }: { suggestion: CatSuggestion; onUse: () => void }) {
+  const intl = useIntl();
+
   return (
     <li className="rounded-lg border border-foreground/8 bg-foreground/2 px-3 py-2.5">
       <div className="flex items-start justify-between gap-3">
@@ -23,7 +42,7 @@ function SuggestionRow({ suggestion, onUse }: { suggestion: CatSuggestion; onUse
               variant="outline"
               className={cn("rounded-full text-[10px]", catToneClass("info"))}
             >
-              {suggestionSourceLabel(suggestion.source)}
+              {suggestionSourceLabel(suggestion.source, intl)}
               {suggestion.matchPercent ? ` ${suggestion.matchPercent}%` : ""}
             </Badge>
             {suggestion.metadata ? (
@@ -33,7 +52,7 @@ function SuggestionRow({ suggestion, onUse }: { suggestion: CatSuggestion; onUse
           <p className="text-sm text-foreground/88">{suggestion.text}</p>
         </div>
         <Button variant="outline" size="sm" onClick={onUse}>
-          Use
+          <FormattedMessage {...catSuggestionsTabsMessages.use} />
         </Button>
       </div>
     </li>
@@ -60,9 +79,24 @@ export function CatSuggestionsTabs({
     <div className="relative flex min-h-0 flex-1 flex-col">
       <Tabs defaultValue="suggestions" className="flex min-h-0 flex-1 flex-col">
         <TabsList className="w-full justify-start rounded-none border-b border-foreground/8 bg-transparent px-4 pe-28">
-          <TabsTrigger value="suggestions">Suggestions {suggestions.length}</TabsTrigger>
-          <TabsTrigger value="history">History {historyCount}</TabsTrigger>
-          <TabsTrigger value="glossary">Glossary matches {glossaryMatchCount}</TabsTrigger>
+          <TabsTrigger value="suggestions">
+            <FormattedMessage
+              {...catSuggestionsTabsMessages.suggestionsTab}
+              values={{ count: suggestions.length }}
+            />
+          </TabsTrigger>
+          <TabsTrigger value="history">
+            <FormattedMessage
+              {...catSuggestionsTabsMessages.historyTab}
+              values={{ count: historyCount }}
+            />
+          </TabsTrigger>
+          <TabsTrigger value="glossary">
+            <FormattedMessage
+              {...catSuggestionsTabsMessages.glossaryTab}
+              values={{ count: glossaryMatchCount }}
+            />
+          </TabsTrigger>
         </TabsList>
 
         <div
@@ -87,24 +121,37 @@ export function CatSuggestionsTabs({
             {tmMatchBasisCount ? (
               <div className="flex items-center gap-1.5 border-t border-foreground/8 px-4 py-2 text-xs text-muted-foreground">
                 <HugeiconsIcon icon={InformationCircleIcon} className="size-3.5" />
-                Based on {tmMatchBasisCount} similar translations
+                <FormattedMessage
+                  {...catSuggestionsTabsMessages.basedOnSimilar}
+                  values={{ count: tmMatchBasisCount }}
+                />
               </div>
             ) : null}
           </TabsContent>
 
           <TabsContent value="history" className="mt-0 p-4">
             <p className="text-sm text-muted-foreground">
-              {historyCount > 0
-                ? `${historyCount} previous revisions available for this string.`
-                : "No revision history yet."}
+              {historyCount > 0 ? (
+                <FormattedMessage
+                  {...catSuggestionsTabsMessages.historyAvailable}
+                  values={{ count: historyCount }}
+                />
+              ) : (
+                <FormattedMessage {...catSuggestionsTabsMessages.noHistory} />
+              )}
             </p>
           </TabsContent>
 
           <TabsContent value="glossary" className="mt-0 p-4">
             <p className="text-sm text-muted-foreground">
-              {glossaryMatchCount > 0
-                ? `${glossaryMatchCount} approved glossary terms match this segment.`
-                : "No glossary matches for this segment."}
+              {glossaryMatchCount > 0 ? (
+                <FormattedMessage
+                  {...catSuggestionsTabsMessages.glossaryMatches}
+                  values={{ count: glossaryMatchCount }}
+                />
+              ) : (
+                <FormattedMessage {...catSuggestionsTabsMessages.noGlossaryMatches} />
+              )}
             </p>
           </TabsContent>
         </div>
@@ -117,7 +164,11 @@ export function CatSuggestionsTabs({
         aria-expanded={isOpen}
         onClick={() => setIsOpen((current) => !current)}
       >
-        {isOpen ? "Collapse" : "Expand"}
+        {isOpen ? (
+          <FormattedMessage {...catSuggestionsTabsMessages.collapse} />
+        ) : (
+          <FormattedMessage {...catSuggestionsTabsMessages.expand} />
+        )}
         <HugeiconsIcon icon={isOpen ? ArrowDown01Icon : ArrowUp01Icon} className="size-4" />
       </button>
     </div>

--- a/apps/hyperlocalise-web/src/components/cat/cat-target-editor.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-target-editor.tsx
@@ -6,6 +6,7 @@ import StarterKit from "@tiptap/starter-kit";
 import { Extension, type Extensions } from "@tiptap/core";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
 import { Decoration, DecorationSet } from "@tiptap/pm/view";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/primitives/cn";
@@ -18,6 +19,7 @@ import {
   type CatMessageAnalysis,
   type CatMessageToken,
 } from "./cat-message-format";
+import { catTargetEditorMessages } from "./cat.messages";
 
 function textDocFromValue(value: string) {
   const lines = value.split("\n");
@@ -228,7 +230,9 @@ export function CatIcuStructureSummary({ blocks }: { blocks: CatIcuBlockSummary[
 
   return (
     <div className="space-y-2 rounded-xl border border-foreground/8 bg-foreground/3 px-3 py-2.5">
-      <p className="text-xs font-medium text-muted-foreground">ICU structure</p>
+      <p className="text-xs font-medium text-muted-foreground">
+        <FormattedMessage {...catTargetEditorMessages.icuStructure} />
+      </p>
       <ul className="space-y-2">
         {blocks.map((block) => (
           <li key={block.id} className="space-y-1">
@@ -267,6 +271,7 @@ export function CatTargetEditor({
   disabled?: boolean;
   onChange: (value: string) => void;
 }) {
+  const intl = useIntl();
   const sourceAnalysis = useMemo(() => analyzeCatMessageFormat(sourceText), [sourceText]);
   const targetAnalysis = useMemo(() => analyzeCatMessageFormat(value), [value]);
   const parityIssues = useMemo(
@@ -294,8 +299,8 @@ export function CatTargetEditor({
           "min-h-36 px-4 py-4 text-lg leading-relaxed text-foreground/92 focus:outline-none md:text-lg",
           "whitespace-pre-wrap break-words",
         ),
-        "aria-label": "Target translation",
-        "data-placeholder": "Enter translation...",
+        "aria-label": intl.formatMessage(catTargetEditorMessages.targetTranslationAria),
+        "data-placeholder": intl.formatMessage(catTargetEditorMessages.targetPlaceholder),
         autocapitalize: "off",
         autocomplete: "off",
         autocorrect: "off",
@@ -366,7 +371,9 @@ export function CatTargetEditor({
 
       {sourceTokens.length > 0 ? (
         <div className="flex flex-wrap items-center gap-1.5">
-          <span className="me-1 text-xs font-medium text-muted-foreground">Required tokens</span>
+          <span className="me-1 text-xs font-medium text-muted-foreground">
+            <FormattedMessage {...catTargetEditorMessages.requiredTokens} />
+          </span>
           {sourceTokens.map((token) => {
             const isMissing = missingTokens.some((missingToken) => missingToken.id === token.id);
             const isPresent = targetSignatures.has(

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.test.ts
@@ -186,7 +186,12 @@ describe("addSaveFailureFormatCheck", () => {
       },
     });
 
-    const next = addSaveFailureFormatCheck(state, "seg-02", "Provider rejected the update.");
+    const next = addSaveFailureFormatCheck(
+      state,
+      "seg-02",
+      "Provider rejected the update.",
+      "Save failed",
+    );
 
     expect(next.formatChecks).toMatchObject([
       {

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useIntl } from "react-intl";
 
 import type {
   CatAiRecommendationResult,
@@ -12,6 +13,7 @@ import type {
   PartialCatWorkspaceDependencies,
 } from "./dependencies";
 import { CatWorkspaceView } from "./cat-workspace";
+import { catWorkspaceContainerMessages } from "./cat.messages";
 import type { CatFormatCheck, CatSegment, CatWorkspaceState } from "./types";
 
 function getSegmentQueueIndex(segments: CatSegment[], segmentIdOrKey: string) {
@@ -76,10 +78,11 @@ export function addSaveFailureFormatCheck(
   state: CatWorkspaceState,
   segmentId: string,
   message: string,
+  label: string,
 ): Pick<CatWorkspaceState, "formatChecks" | "segmentFormatChecks"> {
   const saveFailureCheck: CatFormatCheck = {
     id: `save-failed-${segmentId}`,
-    label: "Save failed",
+    label,
     status: "fail",
     message,
     category: "qa",
@@ -218,6 +221,7 @@ export function CatWorkspaceContainer({
   services: serviceOverrides = dependencyOverrides?.services,
   className,
 }: CatWorkspaceContainerProps) {
+  const intl = useIntl();
   const [state, setState] = useState(initialState);
   const [isValidating, setIsValidating] = useState(false);
   const [isApproving, setIsApproving] = useState(false);
@@ -369,10 +373,12 @@ export function CatWorkspaceContainer({
             }
 
             const message =
-              error instanceof Error ? error.message : "Failed to search glossary and TM.";
+              error instanceof Error
+                ? error.message
+                : intl.formatMessage(catWorkspaceContainerMessages.concordanceSearchFailed);
             const concordanceFailureCheck: CatFormatCheck = {
               id: `concordance-failed-${segmentId}`,
-              label: "Concordance search",
+              label: intl.formatMessage(catWorkspaceContainerMessages.concordanceSearchLabel),
               status: "fail",
               message,
               category: "qa",
@@ -418,10 +424,10 @@ export function CatWorkspaceContainer({
             const message =
               error instanceof Error
                 ? error.message
-                : "Failed to generate AI translation recommendation.";
+                : intl.formatMessage(catWorkspaceContainerMessages.aiRecommendationFailed);
             aiFailureCheck = {
               id: `ai-recommendation-failed-${segmentId}`,
-              label: "AI recommendation",
+              label: intl.formatMessage(catWorkspaceContainerMessages.aiRecommendationLabel),
               status: "fail",
               message,
               category: "qa",
@@ -485,6 +491,7 @@ export function CatWorkspaceContainer({
     },
     [
       generateAiRecommendation,
+      intl,
       lookupSegmentConcordance,
       onReviewWithAi,
       runQaChecks,
@@ -581,10 +588,18 @@ export function CatWorkspaceContainer({
             };
           });
         } catch (error) {
-          const message = error instanceof Error ? error.message : "Failed to save translation.";
+          const message =
+            error instanceof Error
+              ? error.message
+              : intl.formatMessage(catWorkspaceContainerMessages.saveTranslationFailed);
           setState((current) => ({
             ...current,
-            ...addSaveFailureFormatCheck(current, segmentId, message),
+            ...addSaveFailureFormatCheck(
+              current,
+              segmentId,
+              message,
+              intl.formatMessage(catWorkspaceContainerMessages.saveFailedLabel),
+            ),
           }));
         } finally {
           setIsApproving(false);
@@ -638,10 +653,12 @@ export function CatWorkspaceContainer({
           });
         } catch (error) {
           const message =
-            error instanceof Error ? error.message : "Failed to look up repository context.";
+            error instanceof Error
+              ? error.message
+              : intl.formatMessage(catWorkspaceContainerMessages.contextLookupFailed);
           const lookupFailureCheck: CatFormatCheck = {
             id: `context-lookup-failed-${segmentId}`,
-            label: "Context lookup",
+            label: intl.formatMessage(catWorkspaceContainerMessages.contextLookupLabel),
             status: "fail",
             message,
             category: "qa",
@@ -692,6 +709,7 @@ export function CatWorkspaceContainer({
   }, [
     onApprove,
     onAskQuestion,
+    intl,
     onNextSegment,
     onPreviousSegment,
     onReviewInSequence,

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { FormattedMessage } from "react-intl";
 
 import { Progress } from "@/components/ui/progress";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -9,6 +10,7 @@ import { cn } from "@/lib/primitives/cn";
 import { CatEditorPanel } from "./cat-editor-panel";
 import { CatIntelligencePanel } from "./cat-intelligence-panel";
 import { CatQueuePanel } from "./cat-queue-panel";
+import { catWorkspaceMessages } from "./cat.messages";
 import type { CatWorkspaceViewProps } from "./dependencies";
 
 const COMPACT_WORKSPACE_QUERY = "(max-width: 1023px)";
@@ -68,7 +70,7 @@ export function CatWorkspaceView({
           className,
         )}
       >
-        No segments in queue.
+        <FormattedMessage {...catWorkspaceMessages.emptyQueue} />
       </div>
     );
   }
@@ -168,9 +170,20 @@ export function CatWorkspaceView({
                 </p>
               </div>
               <div className="shrink-0 text-right">
-                <p className="text-xs font-medium text-foreground">{reviewedProgress}% reviewed</p>
+                <p className="text-xs font-medium text-foreground">
+                  <FormattedMessage
+                    {...catWorkspaceMessages.reviewedProgress}
+                    values={{ progress: reviewedProgress }}
+                  />
+                </p>
                 <p className="text-xs text-muted-foreground">
-                  {state.queueSummary.reviewed} of {state.queueSummary.total}
+                  <FormattedMessage
+                    {...catWorkspaceMessages.reviewedSummary}
+                    values={{
+                      reviewed: state.queueSummary.reviewed,
+                      total: state.queueSummary.total,
+                    }}
+                  />
                 </p>
               </div>
             </div>
@@ -183,9 +196,15 @@ export function CatWorkspaceView({
             className="min-h-0 flex-1 gap-0 overflow-hidden"
           >
             <TabsList className="mx-4 mt-3 grid h-10 w-auto grid-cols-3">
-              <TabsTrigger value="edit">Edit</TabsTrigger>
-              <TabsTrigger value="queue">Queue</TabsTrigger>
-              <TabsTrigger value="ai">AI</TabsTrigger>
+              <TabsTrigger value="edit">
+                <FormattedMessage {...catWorkspaceMessages.tabEdit} />
+              </TabsTrigger>
+              <TabsTrigger value="queue">
+                <FormattedMessage {...catWorkspaceMessages.tabQueue} />
+              </TabsTrigger>
+              <TabsTrigger value="ai">
+                <FormattedMessage {...catWorkspaceMessages.tabAi} />
+              </TabsTrigger>
             </TabsList>
             <TabsContent
               value="edit"

--- a/apps/hyperlocalise-web/src/components/cat/cat.fixture.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat.fixture.ts
@@ -5,7 +5,31 @@ import type {
   CatSuggestion,
   CatWorkspaceState,
 } from "./types";
+import { getIntlShape } from "@/lib/app-i18n/intl";
+
 import { analyzeCatMessageFormat, compareCatMessageFormats } from "./cat-message-format";
+import type { CatMessageParityIssue } from "./cat-message-format";
+import { localizeCatMessageParityIssue } from "./cat-message-format-i18n";
+
+const fixtureIntl = getIntlShape("en");
+
+function formatCheckFromParityIssue(issue: CatMessageParityIssue, id: string): CatFormatCheck {
+  const localized = localizeCatMessageParityIssue(issue, fixtureIntl);
+
+  return {
+    id,
+    label: localized.label,
+    status: issue.kind === "extra-token" ? "warn" : "fail",
+    message: localized.message,
+    category:
+      issue.kind === "parse-error"
+        ? "syntax"
+        : issue.kind === "icu-mismatch"
+          ? "icu"
+          : "placeholder",
+    relatedTokens: issue.tokens,
+  };
+}
 
 type CatSegmentFixtureInput = Omit<CatSegment, "id" | "index" | "sourceLocale" | "targetLocale">;
 
@@ -579,34 +603,13 @@ export async function mockValidateFormat(
   const placeholderCheckIndex = checks.findIndex((check) => check.id === "check-placeholders");
 
   if (parityIssues.length > 0) {
-    checks[placeholderCheckIndex] = {
-      id: `check-format-${parityIssues[0].kind}`,
-      label: parityIssues[0].label,
-      status: parityIssues[0].kind === "extra-token" ? "warn" : "fail",
-      message: parityIssues[0].message,
-      category:
-        parityIssues[0].kind === "parse-error"
-          ? "syntax"
-          : parityIssues[0].kind === "icu-mismatch"
-            ? "icu"
-            : "placeholder",
-      relatedTokens: parityIssues[0].tokens,
-    };
+    checks[placeholderCheckIndex] = formatCheckFromParityIssue(
+      parityIssues[0],
+      `check-format-${parityIssues[0].kind}`,
+    );
 
     parityIssues.slice(1).forEach((issue, index) => {
-      checks.push({
-        id: `check-format-${issue.kind}-${index + 1}`,
-        label: issue.label,
-        status: issue.kind === "extra-token" ? "warn" : "fail",
-        message: issue.message,
-        category:
-          issue.kind === "parse-error"
-            ? "syntax"
-            : issue.kind === "icu-mismatch"
-              ? "icu"
-              : "placeholder",
-        relatedTokens: issue.tokens,
-      });
+      checks.push(formatCheckFromParityIssue(issue, `check-format-${issue.kind}-${index + 1}`));
     });
   } else if (sourceAnalysis.tokens.length > 0) {
     checks[placeholderCheckIndex] = {

--- a/apps/hyperlocalise-web/src/components/cat/cat.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat.messages.ts
@@ -1,0 +1,435 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const catWorkspaceMessages = defineMessages({
+  emptyQueue: {
+    defaultMessage: "No segments in queue.",
+    id: "WrdM0sMy06",
+    description: "Empty state when the CAT translation queue has no segments",
+  },
+  reviewedProgress: {
+    defaultMessage: "{progress}% reviewed",
+    id: "IXl2JrsI/Q",
+    description: "Compact workspace header showing review completion percentage",
+  },
+  reviewedSummary: {
+    defaultMessage: "{reviewed} of {total}",
+    id: "mBxKladfFz",
+    description: "Compact workspace header showing reviewed segment count out of total",
+  },
+  tabEdit: {
+    defaultMessage: "Edit",
+    id: "HrB9mIwARt",
+    description: "Compact CAT workspace tab for the translation editor",
+  },
+  tabQueue: {
+    defaultMessage: "Queue",
+    id: "jEsou0wF0/",
+    description: "Compact CAT workspace tab for the segment queue",
+  },
+  tabAi: {
+    defaultMessage: "AI",
+    id: "X9FvsfXTfJ",
+    description: "Compact CAT workspace tab for translation intelligence",
+  },
+});
+
+export const catQueuePanelMessages = defineMessages({
+  queueTitle: {
+    defaultMessage: "Queue",
+    id: "EUZbcVhX5v",
+    description: "Heading for the CAT segment queue panel",
+  },
+  queueSummary: {
+    defaultMessage: "{total} total · {reviewed} reviewed",
+    id: "QCxFpsyrag",
+    description: "Segment queue summary showing total and reviewed counts",
+  },
+  filterQueueAria: {
+    defaultMessage: "Filter queue",
+    id: "qSH0vWKsTL",
+    description: "Accessible label for the queue filter button",
+  },
+  queueActionsAria: {
+    defaultMessage: "Queue actions",
+    id: "fDknk0nTC0",
+    description: "Accessible label for the queue overflow actions button",
+  },
+});
+
+export const catFormatChecksMessages = defineMessages({
+  emptyChecks: {
+    defaultMessage: "No format or QA checks for this segment yet.",
+    id: "UAby6HY7Nw",
+    description: "Empty state when a CAT segment has no format or QA checks",
+  },
+  statusPass: {
+    defaultMessage: "Passed",
+    id: "pV6OSYt6fC",
+    description: "Label for a CAT format check that passed",
+  },
+  statusWarn: {
+    defaultMessage: "Check",
+    id: "92YYrAXEnO",
+    description: "Label for a CAT format check that needs attention",
+  },
+  statusFail: {
+    defaultMessage: "Issue",
+    id: "deD7TAf/DJ",
+    description: "Label for a CAT format check that failed",
+  },
+});
+
+export const catToneMessages = defineMessages({
+  sourceAi: {
+    defaultMessage: "AI",
+    id: "tK0t302C5U",
+    description: "Badge label for an AI-generated CAT suggestion",
+  },
+  sourceGlossary: {
+    defaultMessage: "Glossary",
+    id: "V+GHSOFLEr",
+    description: "Badge label for a glossary-based CAT suggestion",
+  },
+  sourceTm: {
+    defaultMessage: "TM",
+    id: "+H5q/WALpt",
+    description: "Badge label for a translation memory CAT suggestion",
+  },
+  sourceMt: {
+    defaultMessage: "MT",
+    id: "expYVaTo2d",
+    description: "Badge label for a machine translation CAT suggestion",
+  },
+});
+
+export const catWorkspaceContainerMessages = defineMessages({
+  saveFailedLabel: {
+    defaultMessage: "Save failed",
+    id: "JikjOnc0U+",
+    description: "CAT format check label when saving a translation fails",
+  },
+  concordanceSearchLabel: {
+    defaultMessage: "Concordance search",
+    id: "7lj/bHhabs",
+    description: "CAT format check label when glossary and TM lookup fails",
+  },
+  concordanceSearchFailed: {
+    defaultMessage: "Failed to search glossary and TM.",
+    id: "gEzAovu3oc",
+    description: "Fallback error when glossary and translation memory lookup fails",
+  },
+  aiRecommendationLabel: {
+    defaultMessage: "AI recommendation",
+    id: "itUSZfLzOK",
+    description: "CAT format check label when AI translation recommendation fails",
+  },
+  aiRecommendationFailed: {
+    defaultMessage: "Failed to generate AI translation recommendation.",
+    id: "QUgt69cPVZ",
+    description: "Fallback error when AI translation recommendation generation fails",
+  },
+  contextLookupLabel: {
+    defaultMessage: "Context lookup",
+    id: "baKeJi7lvv",
+    description: "CAT format check label when repository context lookup fails",
+  },
+  contextLookupFailed: {
+    defaultMessage: "Failed to look up repository context.",
+    id: "BGfQ06k8Pb",
+    description: "Fallback error when repository context lookup fails",
+  },
+  saveTranslationFailed: {
+    defaultMessage: "Failed to save translation.",
+    id: "pMRZvoJLzS",
+    description: "Fallback error when approving or saving a CAT translation fails",
+  },
+});
+
+export const catTargetEditorMessages = defineMessages({
+  icuStructure: {
+    defaultMessage: "ICU structure",
+    id: "J6dfku2qcD",
+    description: "Heading for ICU plural/select structure summary below the CAT target editor",
+  },
+  targetTranslationAria: {
+    defaultMessage: "Target translation",
+    id: "7qpCwZIaq2",
+    description: "Accessible label for the CAT target translation editor",
+  },
+  targetPlaceholder: {
+    defaultMessage: "Enter translation...",
+    id: "3vrwpYmV2v",
+    description: "Placeholder for the CAT target translation editor",
+  },
+  requiredTokens: {
+    defaultMessage: "Required tokens",
+    id: "zVk2EFJa3O",
+    description: "Label for required ICU and placeholder tokens below the CAT target editor",
+  },
+});
+
+export const catSuggestionsTabsMessages = defineMessages({
+  suggestionsTab: {
+    defaultMessage: "Suggestions {count}",
+    id: "eMf+c9N3t5",
+    description: "CAT suggestions drawer tab showing suggestion count",
+  },
+  historyTab: {
+    defaultMessage: "History {count}",
+    id: "C9czZHFhB5",
+    description: "CAT suggestions drawer tab showing revision history count",
+  },
+  glossaryTab: {
+    defaultMessage: "Glossary matches {count}",
+    id: "fnePVmHoGg",
+    description: "CAT suggestions drawer tab showing glossary match count",
+  },
+  basedOnSimilar: {
+    defaultMessage: "Based on {count} similar translations",
+    id: "5IfbvZ6RDU",
+    description: "Footer note for CAT suggestions derived from translation memory matches",
+  },
+  historyAvailable: {
+    defaultMessage: "{count} previous revisions available for this string.",
+    id: "A4FjXhuep2",
+    description: "CAT history tab when prior revisions exist",
+  },
+  noHistory: {
+    defaultMessage: "No revision history yet.",
+    id: "T4JM/NthUA",
+    description: "CAT history tab empty state",
+  },
+  glossaryMatches: {
+    defaultMessage: "{count} approved glossary terms match this segment.",
+    id: "v4I2Z4hlz+",
+    description: "CAT glossary tab when approved terms match the segment",
+  },
+  noGlossaryMatches: {
+    defaultMessage: "No glossary matches for this segment.",
+    id: "FaKEfdW84W",
+    description: "CAT glossary tab empty state",
+  },
+  use: {
+    defaultMessage: "Use",
+    id: "1JXFNEtQ4J",
+    description: "Button to apply a CAT suggestion to the target translation",
+  },
+  collapse: {
+    defaultMessage: "Collapse",
+    id: "eABCOj2JVn",
+    description: "Button to collapse the CAT suggestions drawer",
+  },
+  expand: {
+    defaultMessage: "Expand",
+    id: "a5kZWopQ4Y",
+    description: "Button to expand the CAT suggestions drawer",
+  },
+});
+
+export const catIntelligencePanelMessages = defineMessages({
+  panelTitle: {
+    defaultMessage: "Translation Intelligence",
+    id: "uR9VI1Hsnk",
+    description: "Heading for the CAT translation intelligence side panel",
+  },
+  panelDescription: {
+    defaultMessage: "Context and terminology for this string.",
+    id: "bzdmXkD3a+",
+    description: "Supporting copy below the CAT translation intelligence panel heading",
+  },
+  fileContextTitle: {
+    defaultMessage: "Context attached in the file",
+    id: "HZtAltEBuQ",
+    description: "Section heading for developer context attached in the source file",
+  },
+  fileContextAria: {
+    defaultMessage: "File context",
+    id: "9RkSMcYnN2",
+    description: "Accessible label for file-attached context markdown content",
+  },
+  noFileContext: {
+    defaultMessage: "No context is attached to this string in the source file.",
+    id: "H3PhSgBYwu",
+    description: "Empty state when no developer context is attached in the source file",
+  },
+  agentContextTitle: {
+    defaultMessage: "Context found by agent",
+    id: "obaPDIKyjU",
+    description: "Section heading for repository context discovered by an agent",
+  },
+  meaningInProduct: {
+    defaultMessage: "Meaning in product",
+    id: "99wOujGZDN",
+    description: "Insight card label for agent-discovered product meaning",
+  },
+  agentContextAria: {
+    defaultMessage: "Agent context",
+    id: "4lhHg5n2pX",
+    description: "Accessible label for agent-discovered context markdown content",
+  },
+  translationIntentAria: {
+    defaultMessage: "Translation intent",
+    id: "cQwXYuUd6c",
+    description: "Accessible label for translation intent markdown content",
+  },
+  noRepositoryContext: {
+    defaultMessage: "No repository context was found for this string.",
+    id: "30EiG+BWcI",
+    description: "Empty state when agent repository context lookup returns nothing",
+  },
+  glossaryGuidance: {
+    defaultMessage: "Glossary guidance",
+    id: "ee60kiAN7Z",
+    description: "Section heading for glossary term guidance in the intelligence panel",
+  },
+  translationMemory: {
+    defaultMessage: "Translation memory",
+    id: "okYWXGLSBl",
+    description: "Section heading for translation memory matches in the intelligence panel",
+  },
+  approvedAria: {
+    defaultMessage: "Approved",
+    id: "jGuaDovXli",
+    description: "Accessible label for an approved glossary term",
+  },
+  matchPercent: {
+    defaultMessage: "{matchPercent}% match",
+    id: "c8ULJQ9Qs8",
+    description: "Translation memory match quality badge",
+  },
+});
+
+export const catEditorPanelMessages = defineMessages({
+  previousSegmentAria: {
+    defaultMessage: "Previous segment",
+    id: "fXIJvHCrL6",
+    description: "Accessible label for the previous segment navigation button",
+  },
+  nextSegmentAria: {
+    defaultMessage: "Next segment",
+    id: "7+I/+6Aeqq",
+    description: "Accessible label for the next segment navigation button",
+  },
+  previousSegmentTitle: {
+    defaultMessage: "Previous segment (⌘←)",
+    id: "fjCr7YjlbN",
+    description: "Tooltip for the previous segment navigation button",
+  },
+  nextSegmentTitle: {
+    defaultMessage: "Next segment (⌘→)",
+    id: "A4pgNxiL6F",
+    description: "Tooltip for the next segment navigation button",
+  },
+  sourceHeading: {
+    defaultMessage: "Source ({locale})",
+    id: "wnYoaQhT6i",
+    description: "Section heading for the source string with locale code",
+  },
+  targetHeading: {
+    defaultMessage: "Target ({locale})",
+    id: "1PcszZ/Z93",
+    description: "Section heading for the target translation with locale code",
+  },
+  approve: {
+    defaultMessage: "Approve",
+    id: "0+GXVlndL6",
+    description: "Primary action to approve the current CAT translation",
+  },
+  findContextTitle: {
+    defaultMessage: "Look up where this string appears in the connected repository",
+    id: "BnZ3uPwDP7",
+    description: "Tooltip for the find repository context button when available",
+  },
+  findContextUnavailableTitle: {
+    defaultMessage: "Repository context lookup is not available",
+    id: "jSRe68HWab",
+    description: "Tooltip for the find repository context button when unavailable",
+  },
+  findingContext: {
+    defaultMessage: "Finding context…",
+    id: "rjJJmHDMJh",
+    description: "Loading label while repository context is being looked up",
+  },
+  findContext: {
+    defaultMessage: "Find context",
+    id: "/MBsvL6JVH",
+    description: "Button to look up repository context for the current string",
+  },
+  previous: {
+    defaultMessage: "Previous",
+    id: "tTTsndxkMz",
+    description: "Desktop navigation button to the previous segment",
+  },
+  next: {
+    defaultMessage: "Next",
+    id: "4R0gB8zCuT",
+    description: "Desktop navigation button to the next segment",
+  },
+  aiRecommendation: {
+    defaultMessage: "AI recommendation",
+    id: "nkxYJYYDTw",
+    description: "Heading for the AI translation recommendation panel",
+  },
+  use: {
+    defaultMessage: "Use",
+    id: "fp+BAxQben",
+    description: "Button to apply the AI recommendation to the target translation",
+  },
+  regenerate: {
+    defaultMessage: "Regenerate",
+    id: "oghE756t99",
+    description: "Button to regenerate an existing AI translation recommendation",
+  },
+  getRecommendation: {
+    defaultMessage: "Get recommendation",
+    id: "MN2GW5Szxo",
+    description: "Button to request an AI translation recommendation",
+  },
+  reasoningPrefix: {
+    defaultMessage: "Reasoning:",
+    id: "0zYUPddzdy",
+    description: "Label prefix before AI recommendation reasoning text",
+  },
+  aiSuggestionEmpty: {
+    defaultMessage: "Generate a translation suggestion for this string.",
+    id: "8yJ9TkhoZy",
+    description: "Empty state when no AI recommendation has been generated yet",
+  },
+  formatQaChecks: {
+    defaultMessage: "Format & QA checks",
+    id: "ubk8Jr6n+B",
+    description: "Section heading for format and quality assurance checks",
+  },
+  comments: {
+    defaultMessage: "Comments",
+    id: "3bgw2z94hj",
+    description: "Section heading for reviewer comments on the current segment",
+  },
+  noComments: {
+    defaultMessage: "No comments yet. Add a note for reviewers or translators.",
+    id: "EQ94/v/KcI",
+    description: "Empty state for the segment comments section",
+  },
+  commentPlaceholder: {
+    defaultMessage: "Add a comment...",
+    id: "9bSARO1BLR",
+    description: "Placeholder for the segment comment input",
+  },
+  addComment: {
+    defaultMessage: "Add comment",
+    id: "Iv9Zw2Kz/I",
+    description: "Button to submit a new segment comment",
+  },
+  commentAuthorReviewer: {
+    defaultMessage: "Reviewer",
+    id: "dLflEs1D1h",
+    description: "Default author name for locally added segment comments",
+  },
+  commentCreatedJustNow: {
+    defaultMessage: "Just now",
+    id: "LOKE6DdX5z",
+    description: "Timestamp label for a comment added moments ago",
+  },
+});


### PR DESCRIPTION
## What changed

Localize hardcoded user-facing copy in the CAT (computer-assisted translation) workspace using react-intl. All messages live in a single `cat.messages.ts` module, with `FormattedMessage` / `useIntl().formatMessage` at call sites.

Also refactors message-format parity checks to return structured issues and localize labels via `cat-message-format-i18n.ts`, including TMS job workspace integration.

## How to test

- `cd apps/hyperlocalise-web && vp check --fix`
- `cd apps/hyperlocalise-web && vp test src/components/cat`
- Open a CAT workspace in the app and confirm UI labels, tabs, empty states, and format-check copy render correctly under `IntlProvider`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)