### PR TITLE
feat(web): localize theme toggle and markdown editor

### DIFF
--- a/apps/hyperlocalise-web/AGENTS.md
+++ b/apps/hyperlocalise-web/AGENTS.md
@@ -47,6 +47,12 @@ Follow the official Hono best-practices guide for this app: [Best Practices](htt
 
 <!-- END:hono-agent-rules -->
 
+# Frontend Module Imports
+
+- **Do not add barrel files** (`index.ts` / `index.tsx`) that re-export a folder’s public API. Import the concrete module instead, for example `@/components/theme-toggle/theme-toggle` rather than `@/components/theme-toggle`.
+- **Prefer direct file paths** for components, hooks, messages, and utilities so bundlers and static analysis see explicit dependencies.
+- **Colocate related files in folders** when a feature has multiple modules (component, messages, tests), but export from the implementation file, not an `index.ts` shim.
+
 # API Response Conventions
 
 New JSON routes must follow the conventions below. Shared schemas and helpers live in [`src/api/response.schema.ts`](src/api/response.schema.ts).

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/provider-job-description-field.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/provider-job-description-field.tsx
@@ -9,7 +9,7 @@ import { toast } from "sonner";
 import {
   MarkdownDescriptionEditor,
   MarkdownDescriptionPreview,
-} from "@/components/markdown-description-editor";
+} from "@/components/markdown-description-editor/markdown-description-editor";
 import { Button } from "@/components/ui/button";
 import { apiClient } from "@/lib/api-client-instance";
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-provider-detail-section-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-provider-detail-section-view.tsx
@@ -5,7 +5,7 @@ import type { ReactNode } from "react";
 import { AiMagicIcon, Comment01Icon, RefreshIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 
-import { MarkdownDescriptionPreview } from "@/components/markdown-description-editor";
+import { MarkdownDescriptionPreview } from "@/components/markdown-description-editor/markdown-description-editor";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";

--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/_components/navbar.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/_components/navbar.tsx
@@ -19,7 +19,7 @@ import { env } from "@/lib/env";
 import Image from "next/image";
 import Link from "next/link";
 
-import ThemeToggle from "@/components/theme-toggle";
+import ThemeToggle from "@/components/theme-toggle/theme-toggle";
 
 const navigationLinks: { href: string; label: string; active?: boolean }[] = [
   { href: "/product/agents-automation", label: "Agents" },

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-client.tsx
@@ -14,7 +14,7 @@ import {
   SidebarRail,
   SidebarTrigger,
 } from "@/components/ui/sidebar";
-import ThemeToggle from "@/components/theme-toggle";
+import ThemeToggle from "@/components/theme-toggle/theme-toggle";
 import { AppShellBreadcrumb } from "./app-shell-breadcrumb";
 import { TmsUserConnectButton } from "./tms-user-connect-button";
 import type { TmsUserConnectCta } from "@/lib/providers/tms-user-connection-shared";

--- a/apps/hyperlocalise-web/src/components/cat/cat-intelligence-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-intelligence-panel.tsx
@@ -5,7 +5,7 @@ import { BulbIcon, CheckmarkCircle02Icon, InformationCircleIcon } from "@hugeico
 import { HugeiconsIcon } from "@hugeicons/react";
 import { FormattedMessage, useIntl } from "react-intl";
 
-import { MarkdownContent } from "@/components/markdown-description-editor";
+import { MarkdownContent } from "@/components/markdown-description-editor/markdown-description-editor";
 import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";

--- a/apps/hyperlocalise-web/src/components/markdown-description-editor/markdown-description-editor.messages.ts
+++ b/apps/hyperlocalise-web/src/components/markdown-description-editor/markdown-description-editor.messages.ts
@@ -1,0 +1,111 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const markdownDescriptionEditorMessages = defineMessages({
+  boldTitle: {
+    defaultMessage: "Bold",
+    id: "Qe6R9CCAC7",
+    description: "Tooltip and accessible label for the bold formatting toolbar button",
+  },
+  boldLabel: {
+    defaultMessage: "B",
+    id: "O368wEYD1O",
+    description: "Visible abbreviation on the bold formatting toolbar button",
+  },
+  italicTitle: {
+    defaultMessage: "Italic",
+    id: "2Ce/RC/wfJ",
+    description: "Tooltip and accessible label for the italic formatting toolbar button",
+  },
+  italicLabel: {
+    defaultMessage: "I",
+    id: "2QU4QHjp8c",
+    description: "Visible abbreviation on the italic formatting toolbar button",
+  },
+  heading2Title: {
+    defaultMessage: "Heading 2",
+    id: "g9BGh+CmB5",
+    description: "Tooltip and accessible label for the level-2 heading toolbar button",
+  },
+  heading2Label: {
+    defaultMessage: "H2",
+    id: "ioubvwX5dG",
+    description: "Visible abbreviation on the level-2 heading toolbar button",
+  },
+  heading3Title: {
+    defaultMessage: "Heading 3",
+    id: "JMPR7Ba6ot",
+    description: "Tooltip and accessible label for the level-3 heading toolbar button",
+  },
+  heading3Label: {
+    defaultMessage: "H3",
+    id: "A2Qe3R87fV",
+    description: "Visible abbreviation on the level-3 heading toolbar button",
+  },
+  bulletListLabel: {
+    defaultMessage: "• List",
+    id: "L3ycwnosUv",
+    description: "Visible label for the bullet list toolbar button",
+  },
+  bulletListTitle: {
+    defaultMessage: "Bullet list",
+    id: "88gAEWUFj7",
+    description: "Tooltip and accessible label for the bullet list toolbar button",
+  },
+  orderedListLabel: {
+    defaultMessage: "1. List",
+    id: "K89oxCMVZA",
+    description: "Visible label for the numbered list toolbar button",
+  },
+  orderedListTitle: {
+    defaultMessage: "Numbered list",
+    id: "dZcHfTdmF2",
+    description: "Tooltip and accessible label for the numbered list toolbar button",
+  },
+  blockquoteLabel: {
+    defaultMessage: "Quote",
+    id: "8w4ZXUPESp",
+    description: "Visible label for the blockquote toolbar button",
+  },
+  blockquoteTitle: {
+    defaultMessage: "Blockquote",
+    id: "6ubkC6hfDe",
+    description: "Tooltip and accessible label for the blockquote toolbar button",
+  },
+  codeLabel: {
+    defaultMessage: "Code",
+    id: "OnnGrPT4U5",
+    description: "Visible label for the inline code toolbar button",
+  },
+  codeTitle: {
+    defaultMessage: "Inline code",
+    id: "Q26vSR4mR9",
+    description: "Tooltip and accessible label for the inline code toolbar button",
+  },
+  placeholder: {
+    defaultMessage: "Add a description…",
+    id: "z6mrxTSFHp",
+    description: "Placeholder shown in an empty markdown description editor",
+  },
+  taskDescriptionAria: {
+    defaultMessage: "Task description",
+    id: "UU5/+HYaD2",
+    description: "Accessible label for the markdown description editor field",
+  },
+  markdownContentAria: {
+    defaultMessage: "Markdown content",
+    id: "ECh2wuwOCJ",
+    description: "Default accessible label for read-only rendered markdown content",
+  },
+  noDescription: {
+    defaultMessage: "No description",
+    id: "++FVhiWhMw",
+    description: "Empty state message when a markdown description preview has no content",
+  },
+  taskDescriptionPreviewAria: {
+    defaultMessage: "Task description preview",
+    id: "fvXYWA/jR+",
+    description: "Accessible label for the read-only markdown description preview",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/markdown-description-editor/markdown-description-editor.tsx
+++ b/apps/hyperlocalise-web/src/components/markdown-description-editor/markdown-description-editor.tsx
@@ -5,8 +5,11 @@ import { EditorContent, type Editor, useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import { Markdown } from "@tiptap/markdown";
 import type { Extensions } from "@tiptap/core";
+import { useIntl } from "react-intl";
 
 import { cn } from "@/lib/primitives/cn";
+
+import { markdownDescriptionEditorMessages } from "./markdown-description-editor.messages";
 
 const markdownDescriptionContentClassName = cn(
   "max-w-none px-3 py-2 text-sm text-foreground/74 focus:outline-none",
@@ -76,62 +79,63 @@ function MarkdownToolbarButton({
 }
 
 function MarkdownDescriptionToolbar({ editor, disabled }: { editor: Editor; disabled: boolean }) {
+  const intl = useIntl();
   const isDisabled = disabled || !editor.isEditable;
 
   return (
     <div className="flex flex-wrap items-center gap-1 border-b border-foreground/8 bg-foreground/2 px-2 py-1.5">
       <MarkdownToolbarButton
-        label="B"
-        title="Bold"
+        label={intl.formatMessage(markdownDescriptionEditorMessages.boldLabel)}
+        title={intl.formatMessage(markdownDescriptionEditorMessages.boldTitle)}
         pressed={editor.isActive("bold")}
         disabled={isDisabled}
         onClick={() => markdownCommandChain(editor).toggleBold().run()}
       />
       <MarkdownToolbarButton
-        label="I"
-        title="Italic"
+        label={intl.formatMessage(markdownDescriptionEditorMessages.italicLabel)}
+        title={intl.formatMessage(markdownDescriptionEditorMessages.italicTitle)}
         pressed={editor.isActive("italic")}
         disabled={isDisabled}
         onClick={() => markdownCommandChain(editor).toggleItalic().run()}
       />
       <MarkdownToolbarButton
-        label="H2"
-        title="Heading 2"
+        label={intl.formatMessage(markdownDescriptionEditorMessages.heading2Label)}
+        title={intl.formatMessage(markdownDescriptionEditorMessages.heading2Title)}
         pressed={editor.isActive("heading", { level: 2 })}
         disabled={isDisabled}
         onClick={() => markdownCommandChain(editor).toggleHeading({ level: 2 }).run()}
       />
       <MarkdownToolbarButton
-        label="H3"
-        title="Heading 3"
+        label={intl.formatMessage(markdownDescriptionEditorMessages.heading3Label)}
+        title={intl.formatMessage(markdownDescriptionEditorMessages.heading3Title)}
         pressed={editor.isActive("heading", { level: 3 })}
         disabled={isDisabled}
         onClick={() => markdownCommandChain(editor).toggleHeading({ level: 3 }).run()}
       />
       <MarkdownToolbarButton
-        label="• List"
-        title="Bullet list"
+        label={intl.formatMessage(markdownDescriptionEditorMessages.bulletListLabel)}
+        title={intl.formatMessage(markdownDescriptionEditorMessages.bulletListTitle)}
         pressed={editor.isActive("bulletList")}
         disabled={isDisabled}
         onClick={() => editor.chain().focus().toggleBulletList().run()}
       />
       <MarkdownToolbarButton
-        label="1. List"
-        title="Numbered list"
+        label={intl.formatMessage(markdownDescriptionEditorMessages.orderedListLabel)}
+        title={intl.formatMessage(markdownDescriptionEditorMessages.orderedListTitle)}
         pressed={editor.isActive("orderedList")}
         disabled={isDisabled}
         onClick={() => editor.chain().focus().toggleOrderedList().run()}
       />
       <MarkdownToolbarButton
-        label="Quote"
-        title="Blockquote"
+        label={intl.formatMessage(markdownDescriptionEditorMessages.blockquoteLabel)}
+        title={intl.formatMessage(markdownDescriptionEditorMessages.blockquoteTitle)}
         pressed={editor.isActive("blockquote")}
         disabled={isDisabled}
         onClick={() => markdownCommandChain(editor).toggleBlockquote().run()}
       />
       <MarkdownToolbarButton
-        label="Code"
-        title="Inline code"
+        label={intl.formatMessage(markdownDescriptionEditorMessages.codeLabel)}
+        title={intl.formatMessage(markdownDescriptionEditorMessages.codeTitle)}
         pressed={editor.isActive("code")}
         disabled={isDisabled}
         onClick={() => markdownCommandChain(editor).toggleCode().run()}
@@ -145,7 +149,7 @@ export function MarkdownDescriptionEditor({
   onChange,
   disabled = false,
   className,
-  placeholder = "Add a description…",
+  placeholder,
 }: {
   value: string;
   onChange: (value: string) => void;
@@ -153,6 +157,13 @@ export function MarkdownDescriptionEditor({
   className?: string;
   placeholder?: string;
 }) {
+  const intl = useIntl();
+  const resolvedPlaceholder =
+    placeholder ?? intl.formatMessage(markdownDescriptionEditorMessages.placeholder);
+  const taskDescriptionAria = intl.formatMessage(
+    markdownDescriptionEditorMessages.taskDescriptionAria,
+  );
+
   const editor = useEditor({
     extensions: markdownExtensions,
     content: value,
@@ -165,8 +176,8 @@ export function MarkdownDescriptionEditor({
     editorProps: {
       attributes: {
         class: cn(markdownDescriptionContentClassName, "min-h-[8rem]"),
-        "aria-label": "Task description",
-        "data-placeholder": placeholder,
+        "aria-label": taskDescriptionAria,
+        "data-placeholder": resolvedPlaceholder,
       },
     },
   });
@@ -191,6 +202,22 @@ export function MarkdownDescriptionEditor({
 
     editor.commands.setContent(value, { contentType: "markdown", emitUpdate: false });
   }, [editor, value]);
+
+  useEffect(() => {
+    if (!editor) {
+      return;
+    }
+
+    editor.setOptions({
+      editorProps: {
+        attributes: {
+          class: cn(markdownDescriptionContentClassName, "min-h-[8rem]"),
+          "aria-label": taskDescriptionAria,
+          "data-placeholder": resolvedPlaceholder,
+        },
+      },
+    });
+  }, [editor, resolvedPlaceholder, taskDescriptionAria]);
 
   if (!editor) {
     return (
@@ -231,13 +258,17 @@ export function MarkdownContent({
   value,
   className,
   contentClassName,
-  ariaLabel = "Markdown content",
+  ariaLabel,
 }: {
   value: string;
   className?: string;
   contentClassName?: string;
   ariaLabel?: string;
 }) {
+  const intl = useIntl();
+  const resolvedAriaLabel =
+    ariaLabel ?? intl.formatMessage(markdownDescriptionEditorMessages.markdownContentAria);
+
   const editor = useEditor({
     extensions: markdownExtensions,
     content: value,
@@ -247,7 +278,7 @@ export function MarkdownContent({
     editorProps: {
       attributes: {
         class: cn(markdownDescriptionContentClassName, contentClassName),
-        "aria-label": ariaLabel,
+        "aria-label": resolvedAriaLabel,
       },
     },
   });
@@ -265,9 +296,28 @@ export function MarkdownContent({
     editor.commands.setContent(value, { contentType: "markdown", emitUpdate: false });
   }, [editor, value]);
 
+  useEffect(() => {
+    if (!editor) {
+      return;
+    }
+
+    editor.setOptions({
+      editorProps: {
+        attributes: {
+          class: cn(markdownDescriptionContentClassName, contentClassName),
+          "aria-label": resolvedAriaLabel,
+        },
+      },
+    });
+  }, [contentClassName, editor, resolvedAriaLabel]);
+
   if (!editor) {
     return (
-      <div className={cn(className, contentClassName)} aria-busy="true" aria-label={ariaLabel} />
+      <div
+        className={cn(className, contentClassName)}
+        aria-busy="true"
+        aria-label={resolvedAriaLabel}
+      />
     );
   }
 
@@ -282,13 +332,20 @@ export function MarkdownDescriptionPreview({
   value,
   className,
   contentClassName,
-  emptyMessage = "No description",
+  emptyMessage,
 }: {
   value: string;
   className?: string;
   contentClassName?: string;
   emptyMessage?: string;
 }) {
+  const intl = useIntl();
+  const resolvedEmptyMessage =
+    emptyMessage ?? intl.formatMessage(markdownDescriptionEditorMessages.noDescription);
+  const previewAriaLabel = intl.formatMessage(
+    markdownDescriptionEditorMessages.taskDescriptionPreviewAria,
+  );
+
   if (!value.trim()) {
     return (
       <div
@@ -297,7 +354,7 @@ export function MarkdownDescriptionPreview({
           className,
         )}
       >
-        {emptyMessage}
+        {resolvedEmptyMessage}
       </div>
     );
   }
@@ -307,7 +364,7 @@ export function MarkdownDescriptionPreview({
       value={value}
       className={cn("rounded-lg border border-foreground/8 bg-foreground/2.5", className)}
       contentClassName={cn("min-h-[5rem]", contentClassName)}
-      ariaLabel="Task description preview"
+      ariaLabel={previewAriaLabel}
     />
   );
 }

--- a/apps/hyperlocalise-web/src/components/theme-toggle/theme-toggle.messages.ts
+++ b/apps/hyperlocalise-web/src/components/theme-toggle/theme-toggle.messages.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const themeToggleMessages = defineMessages({
+  changeTheme: {
+    defaultMessage: "Change theme",
+    id: "bkfXJLTZg0",
+    description: "Accessible label and tooltip for the color theme toggle button",
+  },
+  colorThemeAria: {
+    defaultMessage: "Color theme",
+    id: "DEaqfo0mck",
+    description: "Accessible label for the theme selection radio group",
+  },
+  light: {
+    defaultMessage: "Light",
+    id: "wZj9YtEHDA",
+    description: "Light color theme option in the theme toggle menu",
+  },
+  dark: {
+    defaultMessage: "Dark",
+    id: "SI44gUPbhn",
+    description: "Dark color theme option in the theme toggle menu",
+  },
+  system: {
+    defaultMessage: "System",
+    id: "5CjwrQGWSz",
+    description: "System color theme option that follows the OS preference",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/theme-toggle/theme-toggle.tsx
+++ b/apps/hyperlocalise-web/src/components/theme-toggle/theme-toggle.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import { ComputerIcon, Moon02Icon, Sun01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useTheme } from "next-themes";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -14,6 +15,8 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+
+import { themeToggleMessages } from "./theme-toggle.messages";
 
 type ThemeOption = "light" | "dark" | "system";
 
@@ -30,6 +33,7 @@ function ThemeToggleIcon({ theme }: { theme: ThemeOption }) {
 }
 
 export function ThemeToggle() {
+  const intl = useIntl();
   const { resolvedTheme, setTheme, theme } = useTheme();
   const [mounted, setMounted] = React.useState(false);
 
@@ -55,33 +59,35 @@ export function ThemeToggle() {
               render={
                 <Button variant="outline" size="icon-sm" className="rounded-full">
                   <ThemeToggleIcon theme={triggerTheme} />
-                  <span className="sr-only">Change theme</span>
+                  <span className="sr-only">
+                    <FormattedMessage {...themeToggleMessages.changeTheme} />
+                  </span>
                 </Button>
               }
             />
           }
         />
         <TooltipContent side="bottom" align="center">
-          Change theme
+          <FormattedMessage {...themeToggleMessages.changeTheme} />
         </TooltipContent>
       </Tooltip>
       <DropdownMenuContent align="end">
         <DropdownMenuRadioGroup
-          aria-label="Color theme"
+          aria-label={intl.formatMessage(themeToggleMessages.colorThemeAria)}
           value={activeTheme}
           onValueChange={(value) => setTheme(value as ThemeOption)}
         >
           <DropdownMenuRadioItem value="light">
             <HugeiconsIcon icon={Sun01Icon} strokeWidth={2} className="size-4" />
-            Light
+            <FormattedMessage {...themeToggleMessages.light} />
           </DropdownMenuRadioItem>
           <DropdownMenuRadioItem value="dark">
             <HugeiconsIcon icon={Moon02Icon} strokeWidth={2} className="size-4" />
-            Dark
+            <FormattedMessage {...themeToggleMessages.dark} />
           </DropdownMenuRadioItem>
           <DropdownMenuRadioItem value="system">
             <HugeiconsIcon icon={ComputerIcon} strokeWidth={2} className="size-4" />
-            System
+            <FormattedMessage {...themeToggleMessages.system} />
           </DropdownMenuRadioItem>
         </DropdownMenuRadioGroup>
       </DropdownMenuContent>

--- a/apps/hyperlocalise-web/vite.config.ts
+++ b/apps/hyperlocalise-web/vite.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
     rules: {
       ...pluginFormatjs.configs.strict.rules,
       // Most UI is not localized yet; re-enable as /localise coverage grows.
-      // "formatjs/no-literal-string-in-jsx": "off",
+      "formatjs/no-literal-string-in-jsx": "off",
     },
     overrides: [
       {

--- a/apps/hyperlocalise-web/vite.config.ts
+++ b/apps/hyperlocalise-web/vite.config.ts
@@ -9,6 +9,12 @@ const rootDir = path.dirname(fileURLToPath(import.meta.url));
 
 loadDotenv({ path: path.join(rootDir, ".env") });
 
+const formatjsRulesOff = Object.fromEntries(
+  Object.entries({
+    ...pluginFormatjs.configs.strict.rules,
+  }).map(([rule]) => [rule, "off"]),
+);
+
 export default defineConfig({
   fmt: {
     ignorePatterns: ["drizzle/**", "pnpm-*.yaml"],
@@ -20,16 +26,14 @@ export default defineConfig({
     rules: {
       ...pluginFormatjs.configs.strict.rules,
       // Most UI is not localized yet; re-enable as /localise coverage grows.
-      "formatjs/no-literal-string-in-jsx": "off",
+      // "formatjs/no-literal-string-in-jsx": "off",
     },
     overrides: [
       {
-        files: ["**/*.stories.ts", "**/*.stories.tsx"],
-        rules: {
-          "formatjs/enforce-id": "off",
-          "formatjs/enforce-description": "off",
-          "formatjs/no-emoji": "off",
-        },
+        files: ["**/*.stories.ts", "**/*.stories.tsx", "**/*.test.ts", "**/*.test.tsx"],
+        rules: formatjsRulesOff as Partial<
+          Record<keyof typeof pluginFormatjs.configs.strict.rules, "off">
+        >,
       },
     ],
   },


### PR DESCRIPTION
## What changed

- Localized `theme-toggle` and `markdown-description-editor` with colocated `*.messages.ts` modules and react-intl.
- Moved both components into feature folders (`theme-toggle/`, `markdown-description-editor/`) without barrel `index.ts` files; consumers import the concrete module path.
- Disabled all formatjs lint rules for `*.stories.*` and `*.test.*` files in `vite.config.ts`.
- Documented the no-barrel-import convention in `apps/hyperlocalise-web/AGENTS.md`.

## How to test

- `cd apps/hyperlocalise-web && vp check src/components/theme-toggle src/components/markdown-description-editor vite.config.ts`
- Open the app shell or marketing navbar and verify the theme toggle tooltip/menu labels render.
- Open a job description field and verify the markdown editor toolbar, placeholder, and preview empty state.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)