### PR TITLE
feat(web): localize ai-elements with react-intl

### DIFF
--- a/apps/hyperlocalise-web/src/components/ai-elements/agent.messages.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/agent.messages.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const agentMessages = defineMessages({
+  instructions: {
+    id: "mltE2S4MiK",
+
+    defaultMessage: "Instructions",
+    description: "Section label for agent system instructions",
+  },
+  tools: {
+    id: "5atqmuSxdx",
+
+    defaultMessage: "Tools",
+    description: "Section label for agent tools list",
+  },
+  noDescription: {
+    id: "hCvBHiYeFU",
+
+    defaultMessage: "No description",
+    description: "Fallback when an agent tool has no description",
+  },
+  outputSchema: {
+    id: "1zjzxzctS5",
+
+    defaultMessage: "Output Schema",
+    description: "Section label for agent output schema",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/ai-elements/agent.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/agent.tsx
@@ -12,8 +12,10 @@ import type { Tool } from "ai";
 import { BotIcon } from "lucide-react";
 import type { ComponentProps } from "react";
 import { memo } from "react";
+import { FormattedMessage } from "react-intl";
 
 import { CodeBlock } from "./code-block";
+import { agentMessages } from "./agent.messages";
 import { TypographyP } from "@/components/ui/typography";
 
 export type AgentProps = ComponentProps<"div">;
@@ -54,7 +56,9 @@ export type AgentInstructionsProps = ComponentProps<"div"> & {
 export const AgentInstructions = memo(
   ({ className, children, ...props }: AgentInstructionsProps) => (
     <div className={cn("space-y-2", className)} {...props}>
-      <span className="font-medium text-muted-foreground text-sm">Instructions</span>
+      <span className="font-medium text-muted-foreground text-sm">
+        <FormattedMessage {...agentMessages.instructions} />
+      </span>
       <div className="rounded-md bg-muted/50 p-3 text-muted-foreground text-sm">
         <TypographyP>{children}</TypographyP>
       </div>
@@ -66,7 +70,9 @@ export type AgentToolsProps = ComponentProps<typeof Accordion>;
 
 export const AgentTools = memo(({ className, ...props }: AgentToolsProps) => (
   <div className={cn("space-y-2", className)}>
-    <span className="font-medium text-muted-foreground text-sm">Tools</span>
+    <span className="font-medium text-muted-foreground text-sm">
+      <FormattedMessage {...agentMessages.tools} />
+    </span>
     <Accordion className="rounded-md border" {...props} />
   </div>
 ));
@@ -81,7 +87,7 @@ export const AgentTool = memo(({ className, tool, value, ...props }: AgentToolPr
   return (
     <AccordionItem className={cn("border-b last:border-b-0", className)} value={value} {...props}>
       <AccordionTrigger className="px-3 py-2 text-sm hover:no-underline">
-        {tool.description ?? "No description"}
+        {tool.description ?? <FormattedMessage {...agentMessages.noDescription} />}
       </AccordionTrigger>
       <AccordionContent className="px-3 pb-3">
         <div className="rounded-md bg-muted/50">
@@ -98,7 +104,9 @@ export type AgentOutputProps = ComponentProps<"div"> & {
 
 export const AgentOutput = memo(({ className, schema, ...props }: AgentOutputProps) => (
   <div className={cn("space-y-2", className)} {...props}>
-    <span className="font-medium text-muted-foreground text-sm">Output Schema</span>
+    <span className="font-medium text-muted-foreground text-sm">
+      <FormattedMessage {...agentMessages.outputSchema} />
+    </span>
     <div className="rounded-md bg-muted/50">
       <CodeBlock code={schema} language="typescript" />
     </div>

--- a/apps/hyperlocalise-web/src/components/ai-elements/artifact.messages.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/artifact.messages.ts
@@ -1,0 +1,12 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const artifactMessages = defineMessages({
+  close: {
+    id: "ZK/+GGmA14",
+
+    defaultMessage: "Close",
+    description: "Accessible label and tooltip for closing an artifact panel",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/ai-elements/artifact.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/artifact.tsx
@@ -6,7 +6,10 @@ import { cn } from "@/lib/primitives/cn";
 import type { LucideIcon } from "lucide-react";
 import { XIcon } from "lucide-react";
 import type { ComponentProps, HTMLAttributes } from "react";
+import { FormattedMessage } from "react-intl";
 import { TypographyP } from "@/components/ui/typography";
+
+import { artifactMessages } from "./artifact.messages";
 
 export type ArtifactProps = HTMLAttributes<HTMLDivElement>;
 
@@ -49,11 +52,15 @@ export const ArtifactClose = ({
           {...props}
         >
           {children ?? <XIcon className="size-4" />}
-          <span className="sr-only">Close</span>
+          <span className="sr-only">
+            <FormattedMessage {...artifactMessages.close} />
+          </span>
         </Button>
       }
     />
-    <TooltipContent>Close</TooltipContent>
+    <TooltipContent>
+      <FormattedMessage {...artifactMessages.close} />
+    </TooltipContent>
   </Tooltip>
 );
 

--- a/apps/hyperlocalise-web/src/components/ai-elements/attachments.messages.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/attachments.messages.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const attachmentsMessages = defineMessages({
+  source: {
+    id: "Z8vLB9dxFv",
+
+    defaultMessage: "Source",
+    description: "Fallback label for a source document attachment without a title",
+  },
+  image: {
+    id: "ilPzVb1cY6",
+
+    defaultMessage: "Image",
+    description: "Fallback label and alt text for an image attachment without a filename",
+  },
+  attachment: {
+    id: "iV4M/BRREW",
+
+    defaultMessage: "Attachment",
+    description: "Fallback label for a generic file attachment without a filename",
+  },
+  remove: {
+    id: "s3o6M+OdZX",
+
+    defaultMessage: "Remove",
+    description: "Accessible label for removing an attachment",
+  },
+  noAttachments: {
+    id: "nmdumlGzfh",
+
+    defaultMessage: "No attachments",
+    description: "Empty state when no attachments are present",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/ai-elements/attachments.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/attachments.tsx
@@ -15,6 +15,11 @@ import {
 } from "lucide-react";
 import type { ComponentProps, HTMLAttributes, ReactNode } from "react";
 import { createContext, useCallback, useContext, useMemo } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { attachmentsMessages } from "./attachments.messages";
+
+type AttachmentIntl = ReturnType<typeof useIntl>;
 
 // ============================================================================
 // Types
@@ -70,19 +75,29 @@ export const getMediaCategory = (data: AttachmentData): AttachmentMediaCategory 
   return "unknown";
 };
 
-export const getAttachmentLabel = (data: AttachmentData): string => {
+export const getAttachmentLabel = (intl: AttachmentIntl, data: AttachmentData): string => {
   if (data.type === "source-document") {
-    return data.title || data.filename || "Source";
+    return data.title || data.filename || intl.formatMessage(attachmentsMessages.source);
   }
 
   const category = getMediaCategory(data);
-  return data.filename || (category === "image" ? "Image" : "Attachment");
+  return (
+    data.filename ||
+    intl.formatMessage(
+      category === "image" ? attachmentsMessages.image : attachmentsMessages.attachment,
+    )
+  );
 };
 
-const renderAttachmentImage = (url: string, filename: string | undefined, isGrid: boolean) =>
+const renderAttachmentImage = (
+  intl: AttachmentIntl,
+  url: string,
+  filename: string | undefined,
+  isGrid: boolean,
+) =>
   isGrid ? (
     <img
-      alt={filename || "Image"}
+      alt={filename || intl.formatMessage(attachmentsMessages.image)}
       className="size-full object-cover"
       height={96}
       src={url}
@@ -90,7 +105,7 @@ const renderAttachmentImage = (url: string, filename: string | undefined, isGrid
     />
   ) : (
     <img
-      alt={filename || "Image"}
+      alt={filename || intl.formatMessage(attachmentsMessages.image)}
       className="size-full rounded object-cover"
       height={20}
       src={url}
@@ -222,6 +237,7 @@ export const AttachmentPreview = ({
   className,
   ...props
 }: AttachmentPreviewProps) => {
+  const intl = useIntl();
   const { data, mediaCategory, variant } = useAttachmentContext();
 
   const iconSize = variant === "inline" ? "size-3" : "size-4";
@@ -232,7 +248,7 @@ export const AttachmentPreview = ({
 
   const renderContent = () => {
     if (mediaCategory === "image" && data.type === "file" && data.url) {
-      return renderAttachmentImage(data.url, data.filename, variant === "grid");
+      return renderAttachmentImage(intl, data.url, data.filename, variant === "grid");
     }
 
     if (mediaCategory === "video" && data.type === "file" && data.url) {
@@ -272,8 +288,9 @@ export const AttachmentInfo = ({
   className,
   ...props
 }: AttachmentInfoProps) => {
+  const intl = useIntl();
   const { data, variant } = useAttachmentContext();
-  const label = getAttachmentLabel(data);
+  const label = getAttachmentLabel(intl, data);
 
   if (variant === "grid") {
     return null;
@@ -298,11 +315,13 @@ export type AttachmentRemoveProps = ComponentProps<typeof Button> & {
 };
 
 export const AttachmentRemove = ({
-  label = "Remove",
+  label,
   className,
   children,
   ...props
 }: AttachmentRemoveProps) => {
+  const intl = useIntl();
+  const resolvedLabel = label ?? intl.formatMessage(attachmentsMessages.remove);
   const { onRemove, variant } = useAttachmentContext();
 
   const handleClick = useCallback(
@@ -319,7 +338,7 @@ export const AttachmentRemove = ({
 
   return (
     <Button
-      aria-label={label}
+      aria-label={resolvedLabel}
       className={cn(
         variant === "grid" && [
           "absolute top-2 right-2 size-6 rounded-full p-0",
@@ -342,7 +361,7 @@ export const AttachmentRemove = ({
       {...props}
     >
       {children ?? <XIcon />}
-      <span className="sr-only">{label}</span>
+      <span className="sr-only">{resolvedLabel}</span>
     </Button>
   );
 };
@@ -388,6 +407,6 @@ export const AttachmentEmpty = ({ className, children, ...props }: AttachmentEmp
     className={cn("flex items-center justify-center p-4 text-muted-foreground text-sm", className)}
     {...props}
   >
-    {children ?? "No attachments"}
+    {children ?? <FormattedMessage {...attachmentsMessages.noAttachments} />}
   </div>
 );

--- a/apps/hyperlocalise-web/src/components/ai-elements/attachments.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/attachments.tsx
@@ -75,7 +75,7 @@ export const getMediaCategory = (data: AttachmentData): AttachmentMediaCategory 
   return "unknown";
 };
 
-export const getAttachmentLabel = (intl: AttachmentIntl, data: AttachmentData): string => {
+const getAttachmentLabel = (intl: AttachmentIntl, data: AttachmentData): string => {
   if (data.type === "source-document") {
     return data.title || data.filename || intl.formatMessage(attachmentsMessages.source);
   }

--- a/apps/hyperlocalise-web/src/components/ai-elements/chain-of-thought.messages.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/chain-of-thought.messages.ts
@@ -1,0 +1,12 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const chainOfThoughtMessages = defineMessages({
+  header: {
+    id: "S/Jvw/IvO5",
+
+    defaultMessage: "Chain of Thought",
+    description: "Default header label for the chain-of-thought collapsible section",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/ai-elements/chain-of-thought.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/chain-of-thought.tsx
@@ -8,7 +8,10 @@ import type { LucideIcon } from "lucide-react";
 import { BrainIcon, ChevronDownIcon, DotIcon } from "lucide-react";
 import type { ComponentProps, ReactNode } from "react";
 import { createContext, memo, useContext, useMemo } from "react";
+import { FormattedMessage } from "react-intl";
 import { TypographyP } from "@/components/ui/typography";
+
+import { chainOfThoughtMessages } from "./chain-of-thought.messages";
 
 interface ChainOfThoughtContextValue {
   isOpen: boolean;
@@ -74,7 +77,9 @@ export const ChainOfThoughtHeader = memo(
           {...props}
         >
           <BrainIcon className="size-4" />
-          <span className="flex-1 text-start">{children ?? "Chain of Thought"}</span>
+          <span className="flex-1 text-start">
+            {children ?? <FormattedMessage {...chainOfThoughtMessages.header} />}
+          </span>
           <ChevronDownIcon
             className={cn("size-4 transition-transform", isOpen ? "rotate-180" : "rotate-0")}
           />

--- a/apps/hyperlocalise-web/src/components/ai-elements/code-block.messages.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/code-block.messages.ts
@@ -1,0 +1,18 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const codeBlockMessages = defineMessages({
+  copied: {
+    id: "FcsO6dYpho",
+
+    defaultMessage: "Copied!",
+    description: "Tooltip after code is copied to the clipboard",
+  },
+  copyCode: {
+    id: "TnzQT7gNHf",
+
+    defaultMessage: "Copy code",
+    description: "Tooltip and aria label for the copy code button",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/ai-elements/code-block.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/code-block.tsx
@@ -22,8 +22,11 @@ import {
   useRef,
   useState,
 } from "react";
+import { useIntl } from "react-intl";
 import type { BundledLanguage, BundledTheme, HighlighterGeneric, ThemedToken } from "shiki";
 import { createHighlighter } from "shiki";
+
+import { codeBlockMessages } from "./code-block.messages";
 
 // Shiki uses bitflags for font styles: 1=italic, 2=bold, 4=underline
 // oxlint-disable-next-line eslint(no-bitwise)
@@ -441,6 +444,7 @@ export const CodeBlockCopyButton = ({
   const [isCopied, setIsCopied] = useState(false);
   const timeoutRef = useRef<number>(0);
   const { code } = useContext(CodeBlockContext);
+  const intl = useIntl();
 
   const copyToClipboard = useCallback(async () => {
     if (typeof window === "undefined" || !navigator?.clipboard?.writeText) {
@@ -468,7 +472,9 @@ export const CodeBlockCopyButton = ({
   );
 
   const Icon = isCopied ? CheckIcon : CopyIcon;
-  const tooltipText = isCopied ? "Copied!" : "Copy code";
+  const tooltipText = isCopied
+    ? intl.formatMessage(codeBlockMessages.copied)
+    : intl.formatMessage(codeBlockMessages.copyCode);
 
   return (
     <Tooltip>

--- a/apps/hyperlocalise-web/src/components/ai-elements/commit.messages.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/commit.messages.ts
@@ -1,0 +1,18 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const commitMessages = defineMessages({
+  copied: {
+    id: "AcfkWiaJBh",
+
+    defaultMessage: "Copied!",
+    description: "Tooltip after commit hash is copied to the clipboard",
+  },
+  copyHash: {
+    id: "y9Ij/vPLAO",
+
+    defaultMessage: "Copy hash",
+    description: "Tooltip and aria label for copying a commit hash",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/ai-elements/commit.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/commit.tsx
@@ -8,6 +8,9 @@ import { cn } from "@/lib/primitives/cn";
 import { CheckIcon, CopyIcon, FileIcon, GitCommitIcon, MinusIcon, PlusIcon } from "lucide-react";
 import type { ComponentProps, HTMLAttributes } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useIntl } from "react-intl";
+
+import { commitMessages } from "./commit.messages";
 
 export type CommitProps = ComponentProps<typeof Collapsible>;
 
@@ -163,6 +166,7 @@ export const CommitCopyButton = ({
 }: CommitCopyButtonProps) => {
   const [isCopied, setIsCopied] = useState(false);
   const timeoutRef = useRef<number>(0);
+  const intl = useIntl();
 
   const copyToClipboard = useCallback(async () => {
     if (typeof window === "undefined" || !navigator?.clipboard?.writeText) {
@@ -190,7 +194,9 @@ export const CommitCopyButton = ({
   );
 
   const Icon = isCopied ? CheckIcon : CopyIcon;
-  const tooltipText = isCopied ? "Copied!" : "Copy hash";
+  const tooltipText = isCopied
+    ? intl.formatMessage(commitMessages.copied)
+    : intl.formatMessage(commitMessages.copyHash);
 
   return (
     <Tooltip>

--- a/apps/hyperlocalise-web/src/components/ai-elements/context.messages.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/context.messages.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const contextMessages = defineMessages({
+  modelContextUsageAria: {
+    id: "ZvFzVdCf0G",
+
+    defaultMessage: "Model context usage",
+    description: "Accessible label for the circular model context usage indicator",
+  },
+  totalCost: {
+    id: "5dpVYaBmRK",
+
+    defaultMessage: "Total cost",
+    description: "Label for total token usage cost in the context hover card footer",
+  },
+  input: {
+    id: "uArB+a1gRA",
+
+    defaultMessage: "Input",
+    description: "Label for input token usage in the context hover card",
+  },
+  output: {
+    id: "knOsYUbezF",
+
+    defaultMessage: "Output",
+    description: "Label for output token usage in the context hover card",
+  },
+  reasoning: {
+    id: "a5wP5u9Iqr",
+
+    defaultMessage: "Reasoning",
+    description: "Label for reasoning token usage in the context hover card",
+  },
+  cache: {
+    id: "5QymJ2ZjS2",
+
+    defaultMessage: "Cache",
+    description: "Label for cached input token usage in the context hover card",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/ai-elements/context.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/context.tsx
@@ -7,8 +7,11 @@ import { cn } from "@/lib/primitives/cn";
 import type { LanguageModelUsage } from "ai";
 import type { ComponentProps } from "react";
 import { createContext, useContext, useMemo } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
 import { getUsage } from "tokenlens";
 import { TypographyP } from "@/components/ui/typography";
+
+import { contextMessages } from "./context.messages";
 
 const PERCENT_MAX = 100;
 
@@ -75,13 +78,14 @@ export const Context = ({ usedTokens, maxTokens, usage, modelId, ...props }: Con
 
 const ContextIcon = () => {
   const { usedTokens, maxTokens } = useContextValue();
+  const intl = useIntl();
   const circumference = 2 * Math.PI * ICON_RADIUS;
   const usedPercent = usedTokens / maxTokens;
   const dashOffset = circumference * (1 - usedPercent);
 
   return (
     <svg
-      aria-label="Model context usage"
+      aria-label={intl.formatMessage(contextMessages.modelContextUsageAria)}
       height="20"
       role="img"
       style={{ color: "currentcolor" }}
@@ -208,7 +212,9 @@ export const ContextContentFooter = ({
     >
       {children ?? (
         <>
-          <span className="text-muted-foreground">Total cost</span>
+          <span className="text-muted-foreground">
+            <FormattedMessage {...contextMessages.totalCost} />
+          </span>
           <span>{totalCost}</span>
         </>
       )}
@@ -247,7 +253,9 @@ export const ContextInputUsage = ({ className, children, ...props }: ContextInpu
 
   return (
     <div className={cn("flex items-center justify-between text-xs", className)} {...props}>
-      <span className="text-muted-foreground">Input</span>
+      <span className="text-muted-foreground">
+        <FormattedMessage {...contextMessages.input} />
+      </span>
       <TokensWithCost costText={inputCostText} tokens={inputTokens} />
     </div>
   );
@@ -277,7 +285,9 @@ export const ContextOutputUsage = ({ className, children, ...props }: ContextOut
 
   return (
     <div className={cn("flex items-center justify-between text-xs", className)} {...props}>
-      <span className="text-muted-foreground">Output</span>
+      <span className="text-muted-foreground">
+        <FormattedMessage {...contextMessages.output} />
+      </span>
       <TokensWithCost costText={outputCostText} tokens={outputTokens} />
     </div>
   );
@@ -311,7 +321,9 @@ export const ContextReasoningUsage = ({
 
   return (
     <div className={cn("flex items-center justify-between text-xs", className)} {...props}>
-      <span className="text-muted-foreground">Reasoning</span>
+      <span className="text-muted-foreground">
+        <FormattedMessage {...contextMessages.reasoning} />
+      </span>
       <TokensWithCost costText={reasoningCostText} tokens={reasoningTokens} />
     </div>
   );
@@ -341,7 +353,9 @@ export const ContextCacheUsage = ({ className, children, ...props }: ContextCach
 
   return (
     <div className={cn("flex items-center justify-between text-xs", className)} {...props}>
-      <span className="text-muted-foreground">Cache</span>
+      <span className="text-muted-foreground">
+        <FormattedMessage {...contextMessages.cache} />
+      </span>
       <TokensWithCost costText={cacheCostText} tokens={cacheTokens} />
     </div>
   );

--- a/apps/hyperlocalise-web/src/components/ai-elements/conversation.messages.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/conversation.messages.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const conversationMessages = defineMessages({
+  noMessagesYet: {
+    id: "RKI1ij45Ie",
+
+    defaultMessage: "No messages yet",
+    description: "Empty state title when a conversation has no messages",
+  },
+  startConversation: {
+    id: "ZF5d+f8aEU",
+
+    defaultMessage: "Start a conversation to see messages here",
+    description: "Empty state description prompting the user to send a message",
+  },
+  scrollToBottomAria: {
+    id: "6CddYQ5t2q",
+
+    defaultMessage: "Scroll to bottom",
+    description: "Accessible label and tooltip for scrolling to the latest message",
+  },
+  downloadConversationAria: {
+    id: "hwc4QU1Ip1",
+
+    defaultMessage: "Download conversation",
+    description: "Accessible label for downloading the conversation as a file",
+  },
+  downloadConversationTooltip: {
+    id: "hK0QYAJ27z",
+
+    defaultMessage: "Download conversation",
+    description: "Tooltip for the download conversation button",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/ai-elements/conversation.messages.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/conversation.messages.ts
@@ -22,15 +22,10 @@ export const conversationMessages = defineMessages({
     description: "Accessible label and tooltip for scrolling to the latest message",
   },
   downloadConversationAria: {
-    id: "hwc4QU1Ip1",
+    id: "jyL5Pnsg0T",
 
     defaultMessage: "Download conversation",
-    description: "Accessible label for downloading the conversation as a file",
-  },
-  downloadConversationTooltip: {
-    id: "hK0QYAJ27z",
-
-    defaultMessage: "Download conversation",
-    description: "Tooltip for the download conversation button",
+    description:
+      "Accessible label and tooltip for the button that downloads the conversation as a file",
   },
 });

--- a/apps/hyperlocalise-web/src/components/ai-elements/conversation.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/conversation.tsx
@@ -7,8 +7,11 @@ import type { UIMessage } from "ai";
 import { ArrowDownIcon, DownloadIcon } from "lucide-react";
 import type { ComponentProps } from "react";
 import { useCallback } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
 import { StickToBottom, useStickToBottomContext } from "use-stick-to-bottom";
 import { TypographyH3, TypographyP } from "@/components/ui/typography";
+
+import { conversationMessages } from "./conversation.messages";
 
 export type ConversationProps = ComponentProps<typeof StickToBottom>;
 
@@ -36,32 +39,41 @@ export type ConversationEmptyStateProps = ComponentProps<"div"> & {
 
 export const ConversationEmptyState = ({
   className,
-  title = "No messages yet",
-  description = "Start a conversation to see messages here",
+  title,
+  description,
   icon,
   children,
   ...props
-}: ConversationEmptyStateProps) => (
-  <div
-    className={cn(
-      "flex size-full flex-col items-center justify-center gap-3 p-8 text-center",
-      className,
-    )}
-    {...props}
-  >
-    {children ?? (
-      <>
-        {icon && <div className="text-muted-foreground">{icon}</div>}
-        <div className="space-y-1">
-          <TypographyH3 className="font-medium text-sm md:text-sm">{title}</TypographyH3>
-          {description && (
-            <TypographyP className="text-muted-foreground text-sm">{description}</TypographyP>
-          )}
-        </div>
-      </>
-    )}
-  </div>
-);
+}: ConversationEmptyStateProps) => {
+  const intl = useIntl();
+  const resolvedTitle = title ?? intl.formatMessage(conversationMessages.noMessagesYet);
+  const resolvedDescription =
+    description ?? intl.formatMessage(conversationMessages.startConversation);
+
+  return (
+    <div
+      className={cn(
+        "flex size-full flex-col items-center justify-center gap-3 p-8 text-center",
+        className,
+      )}
+      {...props}
+    >
+      {children ?? (
+        <>
+          {icon && <div className="text-muted-foreground">{icon}</div>}
+          <div className="space-y-1">
+            <TypographyH3 className="font-medium text-sm md:text-sm">{resolvedTitle}</TypographyH3>
+            {resolvedDescription && (
+              <TypographyP className="text-muted-foreground text-sm">
+                {resolvedDescription}
+              </TypographyP>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
 
 export type ConversationScrollButtonProps = ComponentProps<typeof Button>;
 
@@ -69,6 +81,7 @@ export const ConversationScrollButton = ({
   className,
   ...props
 }: ConversationScrollButtonProps) => {
+  const intl = useIntl();
   const { isAtBottom, scrollToBottom } = useStickToBottomContext();
 
   const handleScrollToBottom = useCallback(() => {
@@ -81,7 +94,7 @@ export const ConversationScrollButton = ({
         <TooltipTrigger
           render={
             <Button
-              aria-label="Scroll to bottom"
+              aria-label={intl.formatMessage(conversationMessages.scrollToBottomAria)}
               className={cn(
                 "absolute bottom-4 start-[50%] translate-x-[-50%] rtl:-translate-x-[-50%] rounded-full dark:bg-background dark:hover:bg-muted",
                 className,
@@ -96,7 +109,9 @@ export const ConversationScrollButton = ({
             </Button>
           }
         />
-        <TooltipContent side="top">Scroll to bottom</TooltipContent>
+        <TooltipContent side="top">
+          <FormattedMessage {...conversationMessages.scrollToBottomAria} />
+        </TooltipContent>
       </Tooltip>
     )
   );
@@ -132,6 +147,7 @@ export const ConversationDownload = ({
   children,
   ...props
 }: ConversationDownloadProps) => {
+  const intl = useIntl();
   const handleDownload = useCallback(() => {
     const markdown = messagesToMarkdown(messages, formatMessage);
     const blob = new Blob([markdown], { type: "text/markdown" });
@@ -150,7 +166,7 @@ export const ConversationDownload = ({
       <TooltipTrigger
         render={
           <Button
-            aria-label="Download conversation"
+            aria-label={intl.formatMessage(conversationMessages.downloadConversationAria)}
             className={cn(
               "absolute top-4 end-4 rounded-full dark:bg-background dark:hover:bg-muted",
               className,
@@ -166,7 +182,7 @@ export const ConversationDownload = ({
         }
       />
       <TooltipContent side="bottom" align="end">
-        Download conversation
+        <FormattedMessage {...conversationMessages.downloadConversationTooltip} />
       </TooltipContent>
     </Tooltip>
   );

--- a/apps/hyperlocalise-web/src/components/ai-elements/conversation.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/conversation.tsx
@@ -182,7 +182,7 @@ export const ConversationDownload = ({
         }
       />
       <TooltipContent side="bottom" align="end">
-        <FormattedMessage {...conversationMessages.downloadConversationTooltip} />
+        <FormattedMessage {...conversationMessages.downloadConversationAria} />
       </TooltipContent>
     </Tooltip>
   );

--- a/apps/hyperlocalise-web/src/components/ai-elements/environment-variables.messages.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/environment-variables.messages.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const environmentVariablesMessages = defineMessages({
+  title: {
+    id: "/nzPUPTay3",
+
+    defaultMessage: "Environment Variables",
+    description: "Section title for environment variables panel",
+  },
+  toggleVisibilityAria: {
+    id: "0Yq9F0iaq9",
+
+    defaultMessage: "Toggle value visibility",
+    description: "Accessible label for showing or hiding secret environment variable values",
+  },
+  copied: {
+    id: "RsZZrwZXV+",
+
+    defaultMessage: "Copied!",
+    description: "Tooltip after an environment variable value is copied",
+  },
+  copyValue: {
+    id: "IarSQrZ6vP",
+
+    defaultMessage: "Copy value",
+    description: "Tooltip for copying an environment variable value",
+  },
+  copyName: {
+    id: "vfXyrNNj+X",
+
+    defaultMessage: "Copy name",
+    description: "Tooltip for copying an environment variable name",
+  },
+  copyExportCommand: {
+    id: "XEC4R2CUep",
+
+    defaultMessage: "Copy export command",
+    description: "Tooltip for copying a shell export command for an environment variable",
+  },
+  required: {
+    id: "gyGnNuR5md",
+
+    defaultMessage: "Required",
+    description: "Badge label for a required environment variable",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/ai-elements/environment-variables.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/environment-variables.tsx
@@ -16,7 +16,10 @@ import {
   useRef,
   useState,
 } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
 import { TypographyH3 } from "@/components/ui/typography";
+
+import { environmentVariablesMessages } from "./environment-variables.messages";
 
 interface EnvironmentVariablesContextType {
   showValues: boolean;
@@ -86,11 +89,15 @@ export const EnvironmentVariablesTitle = ({
   className,
   children,
   ...props
-}: EnvironmentVariablesTitleProps) => (
-  <TypographyH3 className={cn("font-medium text-sm", className)} {...props}>
-    {children ?? "Environment Variables"}
-  </TypographyH3>
-);
+}: EnvironmentVariablesTitleProps) => {
+  const intl = useIntl();
+
+  return (
+    <TypographyH3 className={cn("font-medium text-sm", className)} {...props}>
+      {children ?? intl.formatMessage(environmentVariablesMessages.title)}
+    </TypographyH3>
+  );
+};
 
 export type EnvironmentVariablesToggleProps = ComponentProps<typeof Switch>;
 
@@ -99,6 +106,7 @@ export const EnvironmentVariablesToggle = ({
   ...props
 }: EnvironmentVariablesToggleProps) => {
   const { showValues, setShowValues } = useContext(EnvironmentVariablesContext);
+  const intl = useIntl();
 
   return (
     <div className={cn("flex items-center gap-2", className)}>
@@ -106,7 +114,7 @@ export const EnvironmentVariablesToggle = ({
         {showValues ? <EyeIcon size={14} /> : <EyeOffIcon size={14} />}
       </span>
       <Switch
-        aria-label="Toggle value visibility"
+        aria-label={intl.formatMessage(environmentVariablesMessages.toggleVisibilityAria)}
         checked={showValues}
         onCheckedChange={setShowValues}
         {...props}
@@ -243,6 +251,7 @@ export const EnvironmentVariableCopyButton = ({
   const [isCopied, setIsCopied] = useState(false);
   const timeoutRef = useRef<number>(0);
   const { name, value } = useContext(EnvironmentVariableContext);
+  const intl = useIntl();
 
   const getTextToCopy = useCallback((): string => {
     const formatMap = {
@@ -279,12 +288,12 @@ export const EnvironmentVariableCopyButton = ({
   const Icon = isCopied ? CheckIcon : CopyIcon;
 
   const tooltipText = isCopied
-    ? "Copied!"
+    ? intl.formatMessage(environmentVariablesMessages.copied)
     : copyFormat === "value"
-      ? "Copy value"
+      ? intl.formatMessage(environmentVariablesMessages.copyValue)
       : copyFormat === "name"
-        ? "Copy name"
-        : "Copy export command";
+        ? intl.formatMessage(environmentVariablesMessages.copyName)
+        : intl.formatMessage(environmentVariablesMessages.copyExportCommand);
 
   return (
     <Tooltip>
@@ -315,6 +324,6 @@ export const EnvironmentVariableRequired = ({
   ...props
 }: EnvironmentVariableRequiredProps) => (
   <Badge className={cn("text-xs", className)} variant="secondary" {...props}>
-    {children ?? "Required"}
+    {children ?? <FormattedMessage {...environmentVariablesMessages.required} />}
   </Badge>
 );

--- a/apps/hyperlocalise-web/src/components/ai-elements/inline-citation.messages.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/inline-citation.messages.ts
@@ -1,0 +1,18 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const inlineCitationMessages = defineMessages({
+  previousAria: {
+    id: "8ibz5Pm78D",
+
+    defaultMessage: "Previous",
+    description: "Accessible label for navigating to the previous citation in a carousel",
+  },
+  nextAria: {
+    id: "Pso/sy4WEl",
+
+    defaultMessage: "Next",
+    description: "Accessible label for navigating to the next citation in a carousel",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/ai-elements/inline-citation.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/inline-citation.tsx
@@ -8,7 +8,10 @@ import { cn } from "@/lib/primitives/cn";
 import { ArrowLeftIcon, ArrowRightIcon } from "lucide-react";
 import type { ComponentProps } from "react";
 import { createContext, useCallback, useContext, useEffect, useState } from "react";
+import { useIntl } from "react-intl";
 import { TypographyH4, TypographyP } from "@/components/ui/typography";
+
+import { inlineCitationMessages } from "./inline-citation.messages";
 
 export type InlineCitationProps = ComponentProps<"span">;
 
@@ -164,6 +167,7 @@ export const InlineCitationCarouselPrev = ({
   ...props
 }: InlineCitationCarouselPrevProps) => {
   const api = useCarouselApi();
+  const intl = useIntl();
 
   const handleClick = useCallback(() => {
     if (api) {
@@ -173,7 +177,7 @@ export const InlineCitationCarouselPrev = ({
 
   return (
     <button
-      aria-label="Previous"
+      aria-label={intl.formatMessage(inlineCitationMessages.previousAria)}
       className={cn("shrink-0", className)}
       onClick={handleClick}
       type="button"
@@ -191,6 +195,7 @@ export const InlineCitationCarouselNext = ({
   ...props
 }: InlineCitationCarouselNextProps) => {
   const api = useCarouselApi();
+  const intl = useIntl();
 
   const handleClick = useCallback(() => {
     if (api) {
@@ -200,7 +205,7 @@ export const InlineCitationCarouselNext = ({
 
   return (
     <button
-      aria-label="Next"
+      aria-label={intl.formatMessage(inlineCitationMessages.nextAria)}
       className={cn("shrink-0", className)}
       onClick={handleClick}
       type="button"

--- a/apps/hyperlocalise-web/src/components/ai-elements/message.messages.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/message.messages.ts
@@ -1,0 +1,16 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const messageMessages = defineMessages({
+  previousBranchAria: {
+    defaultMessage: "Previous branch",
+    id: "nEmus6iEdf",
+    description: "Accessible label and tooltip for navigating to the previous message branch",
+  },
+  nextBranchAria: {
+    defaultMessage: "Next branch",
+    id: "p5GCpw9x8C",
+    description: "Accessible label and tooltip for navigating to the next message branch",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/ai-elements/message.test.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/message.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import React from "react";
+import { IntlProvider } from "react-intl";
 import { renderToStaticMarkup } from "react-dom/server";
 import { MessageBranch, MessageBranchPrevious, MessageBranchNext } from "./message";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -7,11 +8,13 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 describe("MessageBranch Navigation Tooltips", () => {
   it("MessageBranchPrevious renders with tooltip trigger", () => {
     const markup = renderToStaticMarkup(
-      <TooltipProvider>
-        <MessageBranch>
-          <MessageBranchPrevious />
-        </MessageBranch>
-      </TooltipProvider>,
+      <IntlProvider locale="en" messages={{}}>
+        <TooltipProvider>
+          <MessageBranch>
+            <MessageBranchPrevious />
+          </MessageBranch>
+        </TooltipProvider>
+      </IntlProvider>,
     );
 
     expect(markup).toContain('data-slot="tooltip-trigger"');
@@ -24,11 +27,13 @@ describe("MessageBranch Navigation Tooltips", () => {
 
   it("MessageBranchNext renders with tooltip trigger", () => {
     const markup = renderToStaticMarkup(
-      <TooltipProvider>
-        <MessageBranch>
-          <MessageBranchNext />
-        </MessageBranch>
-      </TooltipProvider>,
+      <IntlProvider locale="en" messages={{}}>
+        <TooltipProvider>
+          <MessageBranch>
+            <MessageBranchNext />
+          </MessageBranch>
+        </TooltipProvider>
+      </IntlProvider>,
     );
 
     expect(markup).toContain('data-slot="tooltip-trigger"');

--- a/apps/hyperlocalise-web/src/components/ai-elements/message.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/message.tsx
@@ -12,7 +12,10 @@ import type { UIMessage } from "ai";
 import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
 import type { ComponentProps, HTMLAttributes, ReactElement } from "react";
 import { createContext, memo, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
 import { Streamdown } from "streamdown";
+
+import { messageMessages } from "./message.messages";
 
 export type MessageProps = HTMLAttributes<HTMLDivElement> & {
   from: UIMessage["role"];
@@ -218,13 +221,15 @@ export type MessageBranchPreviousProps = ComponentProps<typeof Button>;
 
 export const MessageBranchPrevious = ({ children, ...props }: MessageBranchPreviousProps) => {
   const { goToPrevious, totalBranches } = useMessageBranch();
+  const intl = useIntl();
+  const ariaLabel = intl.formatMessage(messageMessages.previousBranchAria);
 
   return (
     <Tooltip>
       <TooltipTrigger
         render={
           <Button
-            aria-label="Previous branch"
+            aria-label={ariaLabel}
             disabled={totalBranches <= 1}
             onClick={goToPrevious}
             size="icon-sm"
@@ -236,7 +241,9 @@ export const MessageBranchPrevious = ({ children, ...props }: MessageBranchPrevi
           </Button>
         }
       />
-      <TooltipContent side="bottom">Previous branch</TooltipContent>
+      <TooltipContent side="bottom">
+        <FormattedMessage {...messageMessages.previousBranchAria} />
+      </TooltipContent>
     </Tooltip>
   );
 };
@@ -245,13 +252,15 @@ export type MessageBranchNextProps = ComponentProps<typeof Button>;
 
 export const MessageBranchNext = ({ children, ...props }: MessageBranchNextProps) => {
   const { goToNext, totalBranches } = useMessageBranch();
+  const intl = useIntl();
+  const ariaLabel = intl.formatMessage(messageMessages.nextBranchAria);
 
   return (
     <Tooltip>
       <TooltipTrigger
         render={
           <Button
-            aria-label="Next branch"
+            aria-label={ariaLabel}
             disabled={totalBranches <= 1}
             onClick={goToNext}
             size="icon-sm"
@@ -263,7 +272,9 @@ export const MessageBranchNext = ({ children, ...props }: MessageBranchNextProps
           </Button>
         }
       />
-      <TooltipContent side="bottom">Next branch</TooltipContent>
+      <TooltipContent side="bottom">
+        <FormattedMessage {...messageMessages.nextBranchAria} />
+      </TooltipContent>
     </Tooltip>
   );
 };

--- a/apps/hyperlocalise-web/src/components/ai-elements/mic-selector.messages.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/mic-selector.messages.ts
@@ -1,0 +1,18 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const micSelectorMessages = defineMessages({
+  searchPlaceholder: {
+    id: "sHrPdefvvp",
+
+    defaultMessage: "Search microphones...",
+    description: "Placeholder for the microphone search input",
+  },
+  noMicrophoneFound: {
+    id: "8HFDJwATIe",
+
+    defaultMessage: "No microphone found.",
+    description: "Empty state when no microphones match the search",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/ai-elements/mic-selector.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/mic-selector.tsx
@@ -22,6 +22,9 @@ import {
   useRef,
   useState,
 } from "react";
+import { useIntl } from "react-intl";
+
+import { micSelectorMessages } from "./mic-selector.messages";
 
 const deviceIdRegex = /\(([\da-fA-F]{4}:[\da-fA-F]{4})\)$/;
 
@@ -248,9 +251,16 @@ export type MicSelectorInputProps = ComponentProps<typeof CommandInput> & {
   onValueChange?: (value: string) => void;
 };
 
-export const MicSelectorInput = ({ ...props }: MicSelectorInputProps) => (
-  <CommandInput placeholder="Search microphones..." {...props} />
-);
+export const MicSelectorInput = ({ placeholder, ...props }: MicSelectorInputProps) => {
+  const intl = useIntl();
+
+  return (
+    <CommandInput
+      placeholder={placeholder ?? intl.formatMessage(micSelectorMessages.searchPlaceholder)}
+      {...props}
+    />
+  );
+};
 
 export type MicSelectorListProps = Omit<ComponentProps<typeof CommandList>, "children"> & {
   children: (devices: MediaDeviceInfo[]) => ReactNode;
@@ -264,10 +274,15 @@ export const MicSelectorList = ({ children, ...props }: MicSelectorListProps) =>
 
 export type MicSelectorEmptyProps = ComponentProps<typeof CommandEmpty>;
 
-export const MicSelectorEmpty = ({
-  children = "No microphone found.",
-  ...props
-}: MicSelectorEmptyProps) => <CommandEmpty {...props}>{children}</CommandEmpty>;
+export const MicSelectorEmpty = ({ children, ...props }: MicSelectorEmptyProps) => {
+  const intl = useIntl();
+
+  return (
+    <CommandEmpty {...props}>
+      {children ?? intl.formatMessage(micSelectorMessages.noMicrophoneFound)}
+    </CommandEmpty>
+  );
+};
 
 export type MicSelectorItemProps = ComponentProps<typeof CommandItem>;
 

--- a/apps/hyperlocalise-web/src/components/ai-elements/model-selector.messages.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/model-selector.messages.ts
@@ -1,0 +1,18 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const modelSelectorMessages = defineMessages({
+  title: {
+    id: "dIgSyZztAu",
+
+    defaultMessage: "Model Selector",
+    description: "Accessible dialog title for the model selector",
+  },
+  providerLogoAlt: {
+    id: "EAcDwSK8G7",
+
+    defaultMessage: "{provider} logo",
+    description: "Alt text for a model provider logo image",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/ai-elements/model-selector.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/model-selector.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   Command,
   CommandDialog,
@@ -12,6 +14,9 @@ import {
 import { Dialog, DialogContent, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { cn } from "@/lib/primitives/cn";
 import type { ComponentProps, ReactNode } from "react";
+import { useIntl } from "react-intl";
+
+import { modelSelectorMessages } from "./model-selector.messages";
 
 export type ModelSelectorProps = ComponentProps<typeof Dialog>;
 
@@ -30,18 +35,23 @@ export type ModelSelectorContentProps = ComponentProps<typeof DialogContent> & {
 export const ModelSelectorContent = ({
   className,
   children,
-  title = "Model Selector",
+  title,
   ...props
-}: ModelSelectorContentProps) => (
-  <DialogContent
-    aria-describedby={undefined}
-    className={cn("outline! border-none! p-0 outline-border! outline-solid!", className)}
-    {...props}
-  >
-    <DialogTitle className="sr-only">{title}</DialogTitle>
-    <Command className="**:data-[slot=command-input-wrapper]:h-auto">{children}</Command>
-  </DialogContent>
-);
+}: ModelSelectorContentProps) => {
+  const intl = useIntl();
+  const resolvedTitle = title ?? intl.formatMessage(modelSelectorMessages.title);
+
+  return (
+    <DialogContent
+      aria-describedby={undefined}
+      className={cn("outline! border-none! p-0 outline-border! outline-solid!", className)}
+      {...props}
+    >
+      <DialogTitle className="sr-only">{resolvedTitle}</DialogTitle>
+      <Command className="**:data-[slot=command-input-wrapper]:h-auto">{children}</Command>
+    </DialogContent>
+  );
+};
 
 export type ModelSelectorDialogProps = ComponentProps<typeof CommandDialog>;
 
@@ -145,16 +155,20 @@ export type ModelSelectorLogoProps = Omit<ComponentProps<"img">, "src" | "alt"> 
     | (string & {});
 };
 
-export const ModelSelectorLogo = ({ provider, className, ...props }: ModelSelectorLogoProps) => (
-  <img
-    {...props}
-    alt={`${provider} logo`}
-    className={cn("size-3 dark:invert", className)}
-    height={12}
-    src={`https://models.dev/logos/${provider}.svg`}
-    width={12}
-  />
-);
+export const ModelSelectorLogo = ({ provider, className, ...props }: ModelSelectorLogoProps) => {
+  const intl = useIntl();
+
+  return (
+    <img
+      {...props}
+      alt={intl.formatMessage(modelSelectorMessages.providerLogoAlt, { provider })}
+      className={cn("size-3 dark:invert", className)}
+      height={12}
+      src={`https://models.dev/logos/${provider}.svg`}
+      width={12}
+    />
+  );
+};
 
 export type ModelSelectorLogoGroupProps = ComponentProps<"div">;
 

--- a/apps/hyperlocalise-web/src/components/ai-elements/open-in-chat.messages.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/open-in-chat.messages.ts
@@ -1,0 +1,54 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const openInChatMessages = defineMessages({
+  openInChat: {
+    id: "BJ6vl2NzEe",
+
+    defaultMessage: "Open in chat",
+    description: "Default trigger button label for the open-in-chat dropdown",
+  },
+  openInChatGpt: {
+    id: "VRK24of0oE",
+
+    defaultMessage: "Open in ChatGPT",
+    description: "Menu item to open the prompt in ChatGPT",
+  },
+  openInClaude: {
+    id: "x86tb6Gc1r",
+
+    defaultMessage: "Open in Claude",
+    description: "Menu item to open the prompt in Claude",
+  },
+  openInCursor: {
+    id: "OoB/oKq2Hs",
+
+    defaultMessage: "Open in Cursor",
+    description: "Menu item to open the prompt in Cursor",
+  },
+  openInGitHub: {
+    id: "/ESsUBfxoN",
+
+    defaultMessage: "Open in GitHub",
+    description: "Menu item to open the prompt in GitHub",
+  },
+  openInScira: {
+    id: "jal4p9crNk",
+
+    defaultMessage: "Open in Scira",
+    description: "Menu item to open the prompt in Scira",
+  },
+  openInT3Chat: {
+    id: "2qzhln+URv",
+
+    defaultMessage: "Open in T3 Chat",
+    description: "Menu item to open the prompt in T3 Chat",
+  },
+  openInV0: {
+    id: "VTQVrhBIAm",
+
+    defaultMessage: "Open in v0",
+    description: "Menu item to open the prompt in v0",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/ai-elements/open-in-chat.messages.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/open-in-chat.messages.ts
@@ -27,12 +27,6 @@ export const openInChatMessages = defineMessages({
     defaultMessage: "Open in Cursor",
     description: "Menu item to open the prompt in Cursor",
   },
-  openInGitHub: {
-    id: "/ESsUBfxoN",
-
-    defaultMessage: "Open in GitHub",
-    description: "Menu item to open the prompt in GitHub",
-  },
   openInScira: {
     id: "jal4p9crNk",
 

--- a/apps/hyperlocalise-web/src/components/ai-elements/open-in-chat.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/open-in-chat.tsx
@@ -13,6 +13,9 @@ import { cn } from "@/lib/primitives/cn";
 import { ChevronDownIcon, ExternalLinkIcon, MessageCircleIcon } from "lucide-react";
 import type { ComponentProps } from "react";
 import { createContext, useContext, useMemo } from "react";
+import { useIntl } from "react-intl";
+
+import { openInChatMessages } from "./open-in-chat.messages";
 
 const providers = {
   chatgpt: {
@@ -27,7 +30,6 @@ const providers = {
         <path d="M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364 15.1192 7.2a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.407-.667zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997Z" />
       </svg>
     ),
-    title: "Open in ChatGPT",
   },
   claude: {
     createUrl: (q: string) =>
@@ -44,7 +46,6 @@ const providers = {
         />
       </svg>
     ),
-    title: "Open in Claude",
   },
   cursor: {
     createUrl: (text: string) => {
@@ -61,7 +62,6 @@ const providers = {
         />
       </svg>
     ),
-    title: "Open in Cursor",
   },
   github: {
     createUrl: (url: string) => url,
@@ -71,7 +71,6 @@ const providers = {
         <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
       </svg>
     ),
-    title: "Open in GitHub",
   },
   scira: {
     createUrl: (q: string) =>
@@ -136,7 +135,6 @@ const providers = {
         />
       </svg>
     ),
-    title: "Open in Scira",
   },
   t3: {
     createUrl: (q: string) =>
@@ -144,7 +142,6 @@ const providers = {
         q,
       })}`,
     icon: <MessageCircleIcon />,
-    title: "Open in T3 Chat",
   },
   v0: {
     createUrl: (q: string) =>
@@ -158,7 +155,6 @@ const providers = {
         <path d="M147 56H133V23.9531L100.953 56H133V70H96.6875C85.8144 70 77 61.1856 77 50.3125V14H91V46.1562L123.156 14H91V0H127.312C138.186 0 147 8.81439 147 19.6875V56Z" />
       </svg>
     ),
-    title: "Open in v0",
   },
 };
 
@@ -208,21 +204,27 @@ export const OpenInSeparator = (props: OpenInSeparatorProps) => (
 
 export type OpenInTriggerProps = ComponentProps<typeof DropdownMenuTrigger>;
 
-export const OpenInTrigger = ({ children, ...props }: OpenInTriggerProps) => (
-  <DropdownMenuTrigger {...props}>
-    {children ?? (
-      <Button type="button" variant="outline">
-        Open in chat
-        <ChevronDownIcon className="size-4" />
-      </Button>
-    )}
-  </DropdownMenuTrigger>
-);
+export const OpenInTrigger = ({ children, ...props }: OpenInTriggerProps) => {
+  const intl = useIntl();
+
+  return (
+    <DropdownMenuTrigger {...props}>
+      {children ?? (
+        <Button type="button" variant="outline">
+          {intl.formatMessage(openInChatMessages.openInChat)}
+          <ChevronDownIcon className="size-4" />
+        </Button>
+      )}
+    </DropdownMenuTrigger>
+  );
+};
 
 export type OpenInChatGPTProps = ComponentProps<typeof DropdownMenuItem>;
 
 export const OpenInChatGPT = (props: OpenInChatGPTProps) => {
   const { query } = useOpenInContext();
+  const intl = useIntl();
+
   return (
     <DropdownMenuItem
       {...props}
@@ -236,7 +238,7 @@ export const OpenInChatGPT = (props: OpenInChatGPTProps) => {
       }
     >
       <span className="shrink-0">{providers.chatgpt.icon}</span>
-      <span className="flex-1">{providers.chatgpt.title}</span>
+      <span className="flex-1">{intl.formatMessage(openInChatMessages.openInChatGpt)}</span>
       <ExternalLinkIcon className="size-4 shrink-0" />
     </DropdownMenuItem>
   );
@@ -246,6 +248,8 @@ export type OpenInClaudeProps = ComponentProps<typeof DropdownMenuItem>;
 
 export const OpenInClaude = (props: OpenInClaudeProps) => {
   const { query } = useOpenInContext();
+  const intl = useIntl();
+
   return (
     <DropdownMenuItem
       {...props}
@@ -259,7 +263,7 @@ export const OpenInClaude = (props: OpenInClaudeProps) => {
       }
     >
       <span className="shrink-0">{providers.claude.icon}</span>
-      <span className="flex-1">{providers.claude.title}</span>
+      <span className="flex-1">{intl.formatMessage(openInChatMessages.openInClaude)}</span>
       <ExternalLinkIcon className="size-4 shrink-0" />
     </DropdownMenuItem>
   );
@@ -269,6 +273,8 @@ export type OpenInT3Props = ComponentProps<typeof DropdownMenuItem>;
 
 export const OpenInT3 = (props: OpenInT3Props) => {
   const { query } = useOpenInContext();
+  const intl = useIntl();
+
   return (
     <DropdownMenuItem
       {...props}
@@ -282,7 +288,7 @@ export const OpenInT3 = (props: OpenInT3Props) => {
       }
     >
       <span className="shrink-0">{providers.t3.icon}</span>
-      <span className="flex-1">{providers.t3.title}</span>
+      <span className="flex-1">{intl.formatMessage(openInChatMessages.openInT3Chat)}</span>
       <ExternalLinkIcon className="size-4 shrink-0" />
     </DropdownMenuItem>
   );
@@ -292,6 +298,8 @@ export type OpenInSciraProps = ComponentProps<typeof DropdownMenuItem>;
 
 export const OpenInScira = (props: OpenInSciraProps) => {
   const { query } = useOpenInContext();
+  const intl = useIntl();
+
   return (
     <DropdownMenuItem
       {...props}
@@ -305,7 +313,7 @@ export const OpenInScira = (props: OpenInSciraProps) => {
       }
     >
       <span className="shrink-0">{providers.scira.icon}</span>
-      <span className="flex-1">{providers.scira.title}</span>
+      <span className="flex-1">{intl.formatMessage(openInChatMessages.openInScira)}</span>
       <ExternalLinkIcon className="size-4 shrink-0" />
     </DropdownMenuItem>
   );
@@ -315,6 +323,8 @@ export type OpenInv0Props = ComponentProps<typeof DropdownMenuItem>;
 
 export const OpenInv0 = (props: OpenInv0Props) => {
   const { query } = useOpenInContext();
+  const intl = useIntl();
+
   return (
     <DropdownMenuItem
       {...props}
@@ -328,7 +338,7 @@ export const OpenInv0 = (props: OpenInv0Props) => {
       }
     >
       <span className="shrink-0">{providers.v0.icon}</span>
-      <span className="flex-1">{providers.v0.title}</span>
+      <span className="flex-1">{intl.formatMessage(openInChatMessages.openInV0)}</span>
       <ExternalLinkIcon className="size-4 shrink-0" />
     </DropdownMenuItem>
   );
@@ -338,6 +348,8 @@ export type OpenInCursorProps = ComponentProps<typeof DropdownMenuItem>;
 
 export const OpenInCursor = (props: OpenInCursorProps) => {
   const { query } = useOpenInContext();
+  const intl = useIntl();
+
   return (
     <DropdownMenuItem
       {...props}
@@ -351,7 +363,7 @@ export const OpenInCursor = (props: OpenInCursorProps) => {
       }
     >
       <span className="shrink-0">{providers.cursor.icon}</span>
-      <span className="flex-1">{providers.cursor.title}</span>
+      <span className="flex-1">{intl.formatMessage(openInChatMessages.openInCursor)}</span>
       <ExternalLinkIcon className="size-4 shrink-0" />
     </DropdownMenuItem>
   );

--- a/apps/hyperlocalise-web/src/components/ai-elements/package-info.messages.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/package-info.messages.ts
@@ -1,0 +1,12 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const packageInfoMessages = defineMessages({
+  dependencies: {
+    id: "ZktP8OmKzB",
+
+    defaultMessage: "Dependencies",
+    description: "Section label for package dependencies list",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/ai-elements/package-info.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/package-info.tsx
@@ -5,7 +5,10 @@ import { cn } from "@/lib/primitives/cn";
 import { ArrowRightIcon, MinusIcon, PackageIcon, PlusIcon } from "lucide-react";
 import type { HTMLAttributes } from "react";
 import { createContext, useContext, useMemo } from "react";
+import { FormattedMessage } from "react-intl";
 import { TypographyP } from "@/components/ui/typography";
+
+import { packageInfoMessages } from "./package-info.messages";
 
 type ChangeType = "major" | "minor" | "patch" | "added" | "removed";
 
@@ -177,7 +180,7 @@ export const PackageInfoDependencies = ({
 }: PackageInfoDependenciesProps) => (
   <div className={cn("space-y-2", className)} {...props}>
     <span className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
-      Dependencies
+      <FormattedMessage {...packageInfoMessages.dependencies} />
     </span>
     <div className="space-y-1">{children}</div>
   </div>

--- a/apps/hyperlocalise-web/src/components/ai-elements/plan.messages.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/plan.messages.ts
@@ -1,0 +1,12 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const planMessages = defineMessages({
+  togglePlanAria: {
+    id: "T+6C7vk33X",
+
+    defaultMessage: "Toggle plan",
+    description: "Accessible label for expanding or collapsing the plan card",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/ai-elements/plan.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/plan.tsx
@@ -15,7 +15,9 @@ import { cn } from "@/lib/primitives/cn";
 import { ChevronsUpDownIcon } from "lucide-react";
 import type { ComponentProps } from "react";
 import { createContext, useContext, useMemo } from "react";
+import { FormattedMessage } from "react-intl";
 
+import { planMessages } from "./plan.messages";
 import { Shimmer } from "./shimmer";
 
 interface PlanContextValue {
@@ -131,7 +133,9 @@ export const PlanTrigger = ({ className, children, ...props }: PlanTriggerProps)
     {children ?? (
       <>
         <ChevronsUpDownIcon className="size-4" />
-        <span className="sr-only">Toggle plan</span>
+        <span className="sr-only">
+          <FormattedMessage {...planMessages.togglePlanAria} />
+        </span>
       </>
     )}
   </CollapsibleTrigger>

--- a/apps/hyperlocalise-web/src/components/ai-elements/prompt-input.messages.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/prompt-input.messages.ts
@@ -1,0 +1,60 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const promptInputMessages = defineMessages({
+  addPhotosOrFiles: {
+    id: "MNV3NDchKr",
+
+    defaultMessage: "Add photos or files",
+    description: "Menu item label for attaching photos or files to a prompt",
+  },
+  takeScreenshot: {
+    id: "pg1KEuGKDm",
+
+    defaultMessage: "Take screenshot",
+    description: "Menu item label for capturing a screenshot attachment",
+  },
+  noFilesMatchTypes: {
+    id: "QDxYX6HLaI",
+
+    defaultMessage: "No files match the accepted types.",
+    description: "Error when dropped or selected files do not match accepted MIME types",
+  },
+  allFilesExceedMaxSize: {
+    id: "TdSqSMSpF8",
+
+    defaultMessage: "All files exceed the maximum size.",
+    description: "Error when all selected files are larger than the allowed size",
+  },
+  tooManyFiles: {
+    id: "uk+4BpyVBj",
+
+    defaultMessage: "Too many files. Some were not added.",
+    description: "Error when the number of files exceeds the maximum allowed",
+  },
+  uploadFilesAria: {
+    id: "hgHlEGxrrX",
+
+    defaultMessage: "Upload files",
+    description: "Accessible label for the hidden file upload input",
+  },
+  placeholder: {
+    id: "cjv0VAI0+q",
+
+    defaultMessage: "What would you like to know?",
+    description: "Default placeholder for the prompt text input",
+  },
+  stopAria: {
+    id: "eBW5K6494F",
+
+    defaultMessage: "Stop",
+    description: "Accessible label for stopping an in-progress generation",
+  },
+  submitAria: {
+    id: "PJ5XoQURG9",
+
+    defaultMessage: "Submit",
+    description: "Accessible label for submitting the prompt",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/ai-elements/prompt-input.test.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/prompt-input.test.tsx
@@ -1,8 +1,12 @@
 import { describe, expect, it } from "vitest";
 import React from "react";
+import { IntlProvider } from "react-intl";
 import { renderToStaticMarkup } from "react-dom/server";
 import { PromptInputButton, PromptInputSubmit, PromptInput } from "./prompt-input";
 import { TooltipProvider } from "@/components/ui/tooltip";
+
+const withTestProviders = (children: React.ReactNode) =>
+  React.createElement(IntlProvider, { locale: "en", messages: {} }, children);
 
 describe("PromptInput Components Tooltip & Accessibility", () => {
   it("PromptInputButton renders with tooltip trigger and no nested buttons", () => {
@@ -29,18 +33,20 @@ describe("PromptInput Components Tooltip & Accessibility", () => {
 
   it("PromptInputSubmit renders with tooltip trigger and no nested buttons", () => {
     const markup = renderToStaticMarkup(
-      React.createElement(
-        TooltipProvider,
-        {},
+      withTestProviders(
         React.createElement(
-          PromptInput,
-          { onSubmit: () => {} },
+          TooltipProvider,
+          {},
           React.createElement(
-            PromptInputSubmit,
-            {
-              tooltip: { content: "Send", shortcut: "Enter" },
-            },
-            "Send",
+            PromptInput,
+            { onSubmit: () => {} },
+            React.createElement(
+              PromptInputSubmit,
+              {
+                tooltip: { content: "Send", shortcut: "Enter" },
+              },
+              "Send",
+            ),
           ),
         ),
       ),

--- a/apps/hyperlocalise-web/src/components/ai-elements/prompt-input.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/prompt-input.tsx
@@ -59,6 +59,9 @@ import {
   useRef,
   useState,
 } from "react";
+import { useIntl } from "react-intl";
+
+import { promptInputMessages } from "./prompt-input.messages";
 import { TypographyH3 } from "@/components/ui/typography";
 
 // ============================================================================
@@ -401,10 +404,12 @@ export type PromptInputActionAddAttachmentsProps = ComponentProps<typeof Dropdow
 };
 
 export const PromptInputActionAddAttachments = ({
-  label = "Add photos or files",
+  label,
   ...props
 }: PromptInputActionAddAttachmentsProps) => {
   const attachments = usePromptInputAttachments();
+  const intl = useIntl();
+  const resolvedLabel = label ?? intl.formatMessage(promptInputMessages.addPhotosOrFiles);
 
   const handleSelect = useCallback(
     (event: DropdownMenuItemSelectEvent) => {
@@ -416,7 +421,7 @@ export const PromptInputActionAddAttachments = ({
 
   return (
     <DropdownMenuItem {...props} onSelect={handleSelect}>
-      <ImageIcon className="me-2 size-4" /> {label}
+      <ImageIcon className="me-2 size-4" /> {resolvedLabel}
     </DropdownMenuItem>
   );
 };
@@ -426,11 +431,13 @@ export type PromptInputActionAddScreenshotProps = ComponentProps<typeof Dropdown
 };
 
 export const PromptInputActionAddScreenshot = ({
-  label = "Take screenshot",
+  label,
   onSelect,
   ...props
 }: PromptInputActionAddScreenshotProps) => {
   const attachments = usePromptInputAttachments();
+  const intl = useIntl();
+  const resolvedLabel = label ?? intl.formatMessage(promptInputMessages.takeScreenshot);
 
   const handleSelect = useCallback(
     async (event: DropdownMenuItemSelectEvent) => {
@@ -460,7 +467,7 @@ export const PromptInputActionAddScreenshot = ({
   return (
     <DropdownMenuItem {...props} onSelect={handleSelect}>
       <Monitor className="me-2 size-4" />
-      {label}
+      {resolvedLabel}
     </DropdownMenuItem>
   );
 };
@@ -502,6 +509,7 @@ export const PromptInput = ({
   children,
   ...props
 }: PromptInputProps) => {
+  const intl = useIntl();
   // Try to use a provider controller if present
   const controller = useOptionalPromptInputController();
   const usingProvider = !!controller;
@@ -560,7 +568,7 @@ export const PromptInput = ({
       if (incoming.length && accepted.length === 0) {
         onError?.({
           code: "accept",
-          message: "No files match the accepted types.",
+          message: intl.formatMessage(promptInputMessages.noFilesMatchTypes),
         });
         return;
       }
@@ -569,7 +577,7 @@ export const PromptInput = ({
       if (accepted.length > 0 && sized.length === 0) {
         onError?.({
           code: "max_file_size",
-          message: "All files exceed the maximum size.",
+          message: intl.formatMessage(promptInputMessages.allFilesExceedMaxSize),
         });
         return;
       }
@@ -581,7 +589,7 @@ export const PromptInput = ({
         if (typeof capacity === "number" && sized.length > capacity) {
           onError?.({
             code: "max_files",
-            message: "Too many files. Some were not added.",
+            message: intl.formatMessage(promptInputMessages.tooManyFiles),
           });
         }
         const next: (FileUIPart & { id: string })[] = [];
@@ -597,7 +605,7 @@ export const PromptInput = ({
         return [...prev, ...next];
       });
     },
-    [matchesAccept, maxFiles, maxFileSize, onError],
+    [matchesAccept, maxFiles, maxFileSize, onError, intl],
   );
 
   const removeLocal = useCallback(
@@ -620,7 +628,7 @@ export const PromptInput = ({
       if (incoming.length && accepted.length === 0) {
         onError?.({
           code: "accept",
-          message: "No files match the accepted types.",
+          message: intl.formatMessage(promptInputMessages.noFilesMatchTypes),
         });
         return;
       }
@@ -629,7 +637,7 @@ export const PromptInput = ({
       if (accepted.length > 0 && sized.length === 0) {
         onError?.({
           code: "max_file_size",
-          message: "All files exceed the maximum size.",
+          message: intl.formatMessage(promptInputMessages.allFilesExceedMaxSize),
         });
         return;
       }
@@ -641,7 +649,7 @@ export const PromptInput = ({
       if (typeof capacity === "number" && sized.length > capacity) {
         onError?.({
           code: "max_files",
-          message: "Too many files. Some were not added.",
+          message: intl.formatMessage(promptInputMessages.tooManyFiles),
         });
       }
 
@@ -649,7 +657,7 @@ export const PromptInput = ({
         controller?.attachments.add(capped);
       }
     },
-    [matchesAccept, maxFileSize, maxFiles, onError, files.length, controller],
+    [matchesAccept, maxFileSize, maxFiles, onError, files.length, controller, intl],
   );
 
   const clearAttachments = useCallback(
@@ -870,16 +878,17 @@ export const PromptInput = ({
   );
 
   // Render with or without local provider
+  const uploadLabel = intl.formatMessage(promptInputMessages.uploadFilesAria);
   const inner = (
     <>
       <input
         accept={accept}
-        aria-label="Upload files"
+        aria-label={uploadLabel}
         className="hidden"
         multiple={multiple}
         onChange={handleChange}
         ref={inputRef}
-        title="Upload files"
+        title={uploadLabel}
         type="file"
       />
       <form className={cn("w-full", className)} onSubmit={handleSubmit} ref={formRef} {...props}>
@@ -914,12 +923,14 @@ export const PromptInputTextarea = ({
   onChange,
   onKeyDown,
   className,
-  placeholder = "What would you like to know?",
+  placeholder,
   ...props
 }: PromptInputTextareaProps) => {
   const controller = useOptionalPromptInputController();
   const attachments = usePromptInputAttachments();
+  const intl = useIntl();
   const [isComposing, setIsComposing] = useState(false);
+  const resolvedPlaceholder = placeholder ?? intl.formatMessage(promptInputMessages.placeholder);
 
   const handleKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = useCallback(
     (e) => {
@@ -1014,7 +1025,7 @@ export const PromptInputTextarea = ({
       onCompositionStart={handleCompositionStart}
       onKeyDown={handleKeyDown}
       onPaste={handlePaste}
-      placeholder={placeholder}
+      placeholder={resolvedPlaceholder}
       {...props}
       {...controlledProps}
     />
@@ -1149,6 +1160,7 @@ export const PromptInputSubmit = ({
   ...props
 }: PromptInputSubmitProps) => {
   const isGenerating = status === "submitted" || status === "streaming";
+  const intl = useIntl();
 
   let Icon = <CornerDownLeftIcon className="size-4" />;
 
@@ -1174,7 +1186,11 @@ export const PromptInputSubmit = ({
 
   const button = (
     <InputGroupButton
-      aria-label={isGenerating ? "Stop" : "Submit"}
+      aria-label={
+        isGenerating
+          ? intl.formatMessage(promptInputMessages.stopAria)
+          : intl.formatMessage(promptInputMessages.submitAria)
+      }
       className={cn(className)}
       onClick={handleClick}
       size={size}

--- a/apps/hyperlocalise-web/src/components/ai-elements/reasoning.messages.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/reasoning.messages.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const reasoningMessages = defineMessages({
+  thinking: {
+    id: "7SvzEySkCN",
+
+    defaultMessage: "Thinking...",
+    description: "Label shown while the model is actively reasoning",
+  },
+  thoughtFewSeconds: {
+    id: "IW+967m+1e",
+
+    defaultMessage: "Thought for a few seconds",
+    description: "Label when reasoning completed without a measured duration",
+  },
+  thoughtDuration: {
+    id: "gQ9rDnH0hp",
+
+    defaultMessage: "Thought for {duration} seconds",
+    description: "Label showing how long the model spent reasoning",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/ai-elements/reasoning.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/reasoning.tsx
@@ -20,7 +20,9 @@ import {
   useState,
 } from "react";
 import { Streamdown } from "streamdown";
+import { useIntl } from "react-intl";
 
+import { reasoningMessages } from "./reasoning.messages";
 import { Shimmer } from "./shimmer";
 import { TypographyP } from "@/components/ui/typography";
 
@@ -144,24 +146,28 @@ export type ReasoningTriggerProps = ComponentProps<typeof CollapsibleTrigger> & 
   getThinkingMessage?: (isStreaming: boolean, duration?: number) => ReactNode;
 };
 
-const defaultGetThinkingMessage = (isStreaming: boolean, duration?: number) => {
+const defaultGetThinkingMessage = (
+  intl: ReturnType<typeof useIntl>,
+  isStreaming: boolean,
+  duration?: number,
+): ReactNode => {
   if (isStreaming || duration === 0) {
-    return <Shimmer duration={1}>Thinking...</Shimmer>;
+    return <Shimmer duration={1}>{intl.formatMessage(reasoningMessages.thinking)}</Shimmer>;
   }
   if (duration === undefined) {
-    return <TypographyP>Thought for a few seconds</TypographyP>;
+    return <TypographyP>{intl.formatMessage(reasoningMessages.thoughtFewSeconds)}</TypographyP>;
   }
-  return <TypographyP>Thought for {duration} seconds</TypographyP>;
+  return (
+    <TypographyP>{intl.formatMessage(reasoningMessages.thoughtDuration, { duration })}</TypographyP>
+  );
 };
 
 export const ReasoningTrigger = memo(
-  ({
-    className,
-    children,
-    getThinkingMessage = defaultGetThinkingMessage,
-    ...props
-  }: ReasoningTriggerProps) => {
+  ({ className, children, getThinkingMessage, ...props }: ReasoningTriggerProps) => {
     const { isStreaming, isOpen, duration } = useReasoning();
+    const intl = useIntl();
+    const resolveThinkingMessage =
+      getThinkingMessage ?? ((streaming, dur) => defaultGetThinkingMessage(intl, streaming, dur));
 
     return (
       <CollapsibleTrigger
@@ -174,7 +180,7 @@ export const ReasoningTrigger = memo(
         {children ?? (
           <>
             <BrainIcon className="size-4" />
-            {getThinkingMessage(isStreaming, duration)}
+            {resolveThinkingMessage(isStreaming, duration)}
             <ChevronDownIcon
               className={cn("size-4 transition-transform", isOpen ? "rotate-180" : "rotate-0")}
             />

--- a/apps/hyperlocalise-web/src/components/ai-elements/sandbox.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/sandbox.tsx
@@ -7,7 +7,7 @@ import type { ToolUIPart } from "ai";
 import { ChevronDownIcon, Code } from "lucide-react";
 import type { ComponentProps } from "react";
 
-import { getStatusBadge } from "./tool";
+import { ToolStatusBadge } from "./tool";
 
 export type SandboxRootProps = ComponentProps<typeof Collapsible>;
 
@@ -33,7 +33,7 @@ export const SandboxHeader = ({ className, title, state, ...props }: SandboxHead
     <div className="flex items-center gap-2">
       <Code className="size-4 text-muted-foreground" />
       <span className="font-medium text-sm">{title}</span>
-      {getStatusBadge(state)}
+      <ToolStatusBadge status={state} />
     </div>
     <ChevronDownIcon className="size-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
   </CollapsibleTrigger>

--- a/apps/hyperlocalise-web/src/components/ai-elements/schema-display.messages.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/schema-display.messages.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const schemaDisplayMessages = defineMessages({
+  parameters: {
+    id: "kXbSfNBQLK",
+
+    defaultMessage: "Parameters",
+    description: "Section title for API schema parameters",
+  },
+  requestBody: {
+    id: "XdMf1WMmy8",
+
+    defaultMessage: "Request Body",
+    description: "Section title for API request body schema",
+  },
+  response: {
+    id: "A9BYSi93bG",
+
+    defaultMessage: "Response",
+    description: "Section title for API response schema",
+  },
+  required: {
+    id: "r7/0syRDA9",
+
+    defaultMessage: "required",
+    description: "Badge label for a required schema property",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/ai-elements/schema-display.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/schema-display.tsx
@@ -6,7 +6,10 @@ import { cn } from "@/lib/primitives/cn";
 import { ChevronRightIcon } from "lucide-react";
 import type { ComponentProps, HTMLAttributes } from "react";
 import { createContext, useContext, useMemo } from "react";
+import { FormattedMessage } from "react-intl";
 import { TypographyP } from "@/components/ui/typography";
+
+import { schemaDisplayMessages } from "./schema-display.messages";
 
 type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
 
@@ -171,7 +174,7 @@ export const SchemaDisplayParameter = ({
           className="bg-red-100 text-red-700 text-xs dark:bg-red-900/30 dark:text-red-400"
           variant="secondary"
         >
-          required
+          <FormattedMessage {...schemaDisplayMessages.required} />
         </Badge>
       )}
     </div>
@@ -194,7 +197,9 @@ export const SchemaDisplayParameters = ({
     <Collapsible className={cn(className)} defaultOpen {...props}>
       <CollapsibleTrigger className="group flex w-full items-center gap-2 px-4 py-3 text-start transition-colors hover:bg-muted/50">
         <ChevronRightIcon className="size-4 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-90" />
-        <span className="font-medium text-sm">Parameters</span>
+        <span className="font-medium text-sm">
+          <FormattedMessage {...schemaDisplayMessages.parameters} />
+        </span>
         <Badge className="ms-auto text-xs" variant="secondary">
           {parameters?.length}
         </Badge>
@@ -248,7 +253,7 @@ export const SchemaDisplayProperty = ({
               className="bg-red-100 text-red-700 text-xs dark:bg-red-900/30 dark:text-red-400"
               variant="secondary"
             >
-              required
+              <FormattedMessage {...schemaDisplayMessages.required} />
             </Badge>
           )}
         </CollapsibleTrigger>
@@ -286,7 +291,7 @@ export const SchemaDisplayProperty = ({
             className="bg-red-100 text-red-700 text-xs dark:bg-red-900/30 dark:text-red-400"
             variant="secondary"
           >
-            required
+            <FormattedMessage {...schemaDisplayMessages.required} />
           </Badge>
         )}
       </div>
@@ -310,7 +315,9 @@ export const SchemaDisplayRequest = ({
     <Collapsible className={cn(className)} defaultOpen {...props}>
       <CollapsibleTrigger className="group flex w-full items-center gap-2 px-4 py-3 text-start transition-colors hover:bg-muted/50">
         <ChevronRightIcon className="size-4 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-90" />
-        <span className="font-medium text-sm">Request Body</span>
+        <span className="font-medium text-sm">
+          <FormattedMessage {...schemaDisplayMessages.requestBody} />
+        </span>
       </CollapsibleTrigger>
       <CollapsibleContent>
         <div className="border-t">
@@ -337,7 +344,9 @@ export const SchemaDisplayResponse = ({
     <Collapsible className={cn(className)} defaultOpen {...props}>
       <CollapsibleTrigger className="group flex w-full items-center gap-2 px-4 py-3 text-start transition-colors hover:bg-muted/50">
         <ChevronRightIcon className="size-4 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-90" />
-        <span className="font-medium text-sm">Response</span>
+        <span className="font-medium text-sm">
+          <FormattedMessage {...schemaDisplayMessages.response} />
+        </span>
       </CollapsibleTrigger>
       <CollapsibleContent>
         <div className="border-t">

--- a/apps/hyperlocalise-web/src/components/ai-elements/snippet.messages.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/snippet.messages.ts
@@ -1,0 +1,18 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const snippetMessages = defineMessages({
+  copied: {
+    id: "4vXdOuz0pQ",
+
+    defaultMessage: "Copied!",
+    description: "Tooltip after snippet text is copied to the clipboard",
+  },
+  copy: {
+    id: "9I//qXyS2N",
+
+    defaultMessage: "Copy",
+    description: "Tooltip and aria label for copying snippet text",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/ai-elements/snippet.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/snippet.tsx
@@ -20,6 +20,9 @@ import {
   useRef,
   useState,
 } from "react";
+import { useIntl } from "react-intl";
+
+import { snippetMessages } from "./snippet.messages";
 
 interface SnippetContextType {
   code: string;
@@ -87,6 +90,7 @@ export const SnippetCopyButton = ({
   const [isCopied, setIsCopied] = useState(false);
   const timeoutRef = useRef<number>(0);
   const { code } = useContext(SnippetContext);
+  const intl = useIntl();
 
   const copyToClipboard = useCallback(async () => {
     if (typeof window === "undefined" || !navigator?.clipboard?.writeText) {
@@ -114,7 +118,9 @@ export const SnippetCopyButton = ({
   );
 
   const Icon = isCopied ? CheckIcon : CopyIcon;
-  const tooltipText = isCopied ? "Copied!" : "Copy";
+  const tooltipText = isCopied
+    ? intl.formatMessage(snippetMessages.copied)
+    : intl.formatMessage(snippetMessages.copy);
 
   return (
     <Tooltip>

--- a/apps/hyperlocalise-web/src/components/ai-elements/sources.messages.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/sources.messages.ts
@@ -1,0 +1,12 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const sourcesMessages = defineMessages({
+  usedSources: {
+    id: "hRNM7K3gMN",
+
+    defaultMessage: "Used {count} sources",
+    description: "Collapsible trigger label showing how many sources were cited",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/ai-elements/sources.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/sources.tsx
@@ -4,7 +4,10 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/component
 import { cn } from "@/lib/primitives/cn";
 import { BookIcon, ChevronDownIcon } from "lucide-react";
 import type { ComponentProps } from "react";
+import { FormattedMessage } from "react-intl";
 import { TypographyP } from "@/components/ui/typography";
+
+import { sourcesMessages } from "./sources.messages";
 
 export type SourcesProps = ComponentProps<"div">;
 
@@ -20,7 +23,9 @@ export const SourcesTrigger = ({ className, count, children, ...props }: Sources
   <CollapsibleTrigger className={cn("flex items-center gap-2", className)} {...props}>
     {children ?? (
       <>
-        <TypographyP className="font-medium">Used {count} sources</TypographyP>
+        <TypographyP className="font-medium">
+          <FormattedMessage {...sourcesMessages.usedSources} values={{ count }} />
+        </TypographyP>
         <ChevronDownIcon className="h-4 w-4" />
       </>
     )}

--- a/apps/hyperlocalise-web/src/components/ai-elements/stack-trace.messages.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/stack-trace.messages.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const stackTraceMessages = defineMessages({
+  copied: {
+    id: "77onpKogma",
+
+    defaultMessage: "Copied!",
+    description: "Tooltip after stack trace is copied to the clipboard",
+  },
+  copyStackTrace: {
+    id: "jEwAQCIVg4",
+
+    defaultMessage: "Copy stack trace",
+    description: "Tooltip and aria label for copying a stack trace",
+  },
+  noStackFrames: {
+    id: "cKb/sPVSsm",
+
+    defaultMessage: "No stack frames",
+    description: "Empty state when a stack trace has no frames to display",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/ai-elements/stack-trace.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/stack-trace.tsx
@@ -17,6 +17,9 @@ import {
   useRef,
   useState,
 } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { stackTraceMessages } from "./stack-trace.messages";
 
 // Regex patterns for parsing stack traces
 const STACK_FRAME_WITH_PARENS_REGEX = /^at\s+(.+?)\s+\((.+):(\d+):(\d+)\)$/;
@@ -302,6 +305,7 @@ export const StackTraceCopyButton = memo(
     const [isCopied, setIsCopied] = useState(false);
     const timeoutRef = useRef<number>(0);
     const { raw } = useStackTrace();
+    const intl = useIntl();
 
     const copyToClipboard = useCallback(async () => {
       if (typeof window === "undefined" || !navigator?.clipboard?.writeText) {
@@ -327,7 +331,9 @@ export const StackTraceCopyButton = memo(
     );
 
     const Icon = isCopied ? CheckIcon : CopyIcon;
-    const tooltipText = isCopied ? "Copied!" : "Copy stack trace";
+    const tooltipText = isCopied
+      ? intl.formatMessage(stackTraceMessages.copied)
+      : intl.formatMessage(stackTraceMessages.copyStackTrace);
 
     return (
       <Tooltip>
@@ -472,7 +478,9 @@ export const StackTraceFrames = memo(
           </div>
         ))}
         {framesToShow.length === 0 && (
-          <div className="text-muted-foreground text-xs">No stack frames</div>
+          <div className="text-muted-foreground text-xs">
+            <FormattedMessage {...stackTraceMessages.noStackFrames} />
+          </div>
         )}
       </div>
     );

--- a/apps/hyperlocalise-web/src/components/ai-elements/terminal.messages.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/terminal.messages.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const terminalMessages = defineMessages({
+  title: {
+    id: "1/O6U8eZiP",
+
+    defaultMessage: "Terminal",
+    description: "Default title for the terminal panel header",
+  },
+  copied: {
+    id: "9KuYbR6KRc",
+
+    defaultMessage: "Copied!",
+    description: "Tooltip after terminal output is copied to the clipboard",
+  },
+  copyOutput: {
+    id: "3VQO3rGiUE",
+
+    defaultMessage: "Copy terminal output",
+    description: "Tooltip and aria label for copying terminal output",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/ai-elements/terminal.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/terminal.tsx
@@ -15,6 +15,9 @@ import {
   useRef,
   useState,
 } from "react";
+import { useIntl } from "react-intl";
+
+import { terminalMessages } from "./terminal.messages";
 
 interface TerminalContextType {
   output: string;
@@ -45,12 +48,16 @@ export const TerminalHeader = ({ className, children, ...props }: TerminalHeader
 
 export type TerminalTitleProps = HTMLAttributes<HTMLDivElement>;
 
-export const TerminalTitle = ({ className, children, ...props }: TerminalTitleProps) => (
-  <div className={cn("flex items-center gap-2 text-sm text-zinc-400", className)} {...props}>
-    <TerminalIcon className="size-4" />
-    {children ?? "Terminal"}
-  </div>
-);
+export const TerminalTitle = ({ className, children, ...props }: TerminalTitleProps) => {
+  const intl = useIntl();
+
+  return (
+    <div className={cn("flex items-center gap-2 text-sm text-zinc-400", className)} {...props}>
+      <TerminalIcon className="size-4" />
+      {children ?? intl.formatMessage(terminalMessages.title)}
+    </div>
+  );
+};
 
 export type TerminalStatusProps = HTMLAttributes<HTMLDivElement>;
 
@@ -93,6 +100,7 @@ export const TerminalCopyButton = ({
   const [isCopied, setIsCopied] = useState(false);
   const timeoutRef = useRef<number>(0);
   const { output } = useContext(TerminalContext);
+  const intl = useIntl();
 
   const copyToClipboard = useCallback(async () => {
     if (typeof window === "undefined" || !navigator?.clipboard?.writeText) {
@@ -118,7 +126,9 @@ export const TerminalCopyButton = ({
   );
 
   const Icon = isCopied ? CheckIcon : CopyIcon;
-  const tooltipText = isCopied ? "Copied!" : "Copy terminal output";
+  const tooltipText = isCopied
+    ? intl.formatMessage(terminalMessages.copied)
+    : intl.formatMessage(terminalMessages.copyOutput);
 
   return (
     <Tooltip>

--- a/apps/hyperlocalise-web/src/components/ai-elements/test-results.messages.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/test-results.messages.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const testResultsMessages = defineMessages({
+  passedCount: {
+    id: "FlwYDfCvTq",
+
+    defaultMessage: "{count} passed",
+    description: "Badge label for the number of passed tests",
+  },
+  failedCount: {
+    id: "rQXpyeuWHx",
+
+    defaultMessage: "{count} failed",
+    description: "Badge label for the number of failed tests",
+  },
+  skippedCount: {
+    id: "9gxIcCZ7b1",
+
+    defaultMessage: "{count} skipped",
+    description: "Badge label for the number of skipped tests",
+  },
+  testsPassedProgress: {
+    id: "+t9Xh+JbAF",
+
+    defaultMessage: "{passed}/{total} tests passed",
+    description: "Progress summary showing passed tests out of total",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/ai-elements/test-results.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/test-results.tsx
@@ -12,7 +12,10 @@ import {
 } from "lucide-react";
 import type { ComponentProps, HTMLAttributes } from "react";
 import { createContext, useContext, useMemo } from "react";
+import { FormattedMessage } from "react-intl";
 import { TypographyP } from "@/components/ui/typography";
+
+import { testResultsMessages } from "./test-results.messages";
 
 type TestStatus = "passed" | "failed" | "skipped" | "running";
 
@@ -83,7 +86,10 @@ export const TestResultsSummary = ({ className, children, ...props }: TestResult
             variant="secondary"
           >
             <CheckCircle2Icon className="size-3" />
-            {summary.passed} passed
+            <FormattedMessage
+              {...testResultsMessages.passedCount}
+              values={{ count: summary.passed }}
+            />
           </Badge>
           {summary.failed > 0 && (
             <Badge
@@ -91,7 +97,10 @@ export const TestResultsSummary = ({ className, children, ...props }: TestResult
               variant="secondary"
             >
               <XCircleIcon className="size-3" />
-              {summary.failed} failed
+              <FormattedMessage
+                {...testResultsMessages.failedCount}
+                values={{ count: summary.failed }}
+              />
             </Badge>
           )}
           {summary.skipped > 0 && (
@@ -100,7 +109,10 @@ export const TestResultsSummary = ({ className, children, ...props }: TestResult
               variant="secondary"
             >
               <CircleIcon className="size-3" />
-              {summary.skipped} skipped
+              <FormattedMessage
+                {...testResultsMessages.skippedCount}
+                values={{ count: summary.skipped }}
+              />
             </Badge>
           )}
         </>
@@ -157,7 +169,10 @@ export const TestResultsProgress = ({
           </div>
           <div className="flex justify-between text-muted-foreground text-xs">
             <span>
-              {summary.passed}/{summary.total} tests passed
+              <FormattedMessage
+                {...testResultsMessages.testsPassedProgress}
+                values={{ passed: summary.passed, total: summary.total }}
+              />
             </span>
             <span>{passedPercent.toFixed(0)}%</span>
           </div>

--- a/apps/hyperlocalise-web/src/components/ai-elements/tool.messages.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/tool.messages.ts
@@ -1,0 +1,66 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const toolMessages = defineMessages({
+  statusApprovalRequested: {
+    id: "OQRAAutFV6",
+
+    defaultMessage: "Awaiting Approval",
+    description: "Tool status badge when approval is requested",
+  },
+  statusApprovalResponded: {
+    id: "WpB4HHsI4I",
+
+    defaultMessage: "Responded",
+    description: "Tool status badge after approval was responded to",
+  },
+  statusInputAvailable: {
+    id: "kBjfpWlIHs",
+
+    defaultMessage: "Running",
+    description: "Tool status badge when the tool is running",
+  },
+  statusInputStreaming: {
+    id: "hXSssVY0i9",
+
+    defaultMessage: "Pending",
+    description: "Tool status badge when tool input is still streaming",
+  },
+  statusOutputAvailable: {
+    id: "bg/VgRAQ0S",
+
+    defaultMessage: "Completed",
+    description: "Tool status badge when the tool completed successfully",
+  },
+  statusOutputDenied: {
+    id: "he2yTle2zW",
+
+    defaultMessage: "Denied",
+    description: "Tool status badge when tool output was denied",
+  },
+  statusOutputError: {
+    id: "F1KUlqpyf6",
+
+    defaultMessage: "Error",
+    description: "Tool status badge when the tool returned an error",
+  },
+  parameters: {
+    id: "M4h3UcxULX",
+
+    defaultMessage: "Parameters",
+    description: "Section heading for tool input parameters",
+  },
+  result: {
+    id: "Rg44t9f2lQ",
+
+    defaultMessage: "Result",
+    description: "Section heading for successful tool output",
+  },
+  error: {
+    id: "/Kp0jW/NO6",
+
+    defaultMessage: "Error",
+    description: "Section heading for tool error output",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/ai-elements/tool.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/tool.tsx
@@ -14,8 +14,10 @@ import {
 } from "lucide-react";
 import type { ComponentProps, ReactNode } from "react";
 import { isValidElement } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import { CodeBlock } from "./code-block";
+import { toolMessages } from "./tool.messages";
 import { TypographyH4 } from "@/components/ui/typography";
 
 export type ToolProps = ComponentProps<typeof Collapsible>;
@@ -41,14 +43,14 @@ export type ToolHeaderProps = {
     }
 );
 
-const statusLabels: Record<ToolPart["state"], string> = {
-  "approval-requested": "Awaiting Approval",
-  "approval-responded": "Responded",
-  "input-available": "Running",
-  "input-streaming": "Pending",
-  "output-available": "Completed",
-  "output-denied": "Denied",
-  "output-error": "Error",
+const statusMessageKeys: Record<ToolPart["state"], keyof typeof toolMessages> = {
+  "approval-requested": "statusApprovalRequested",
+  "approval-responded": "statusApprovalResponded",
+  "input-available": "statusInputAvailable",
+  "input-streaming": "statusInputStreaming",
+  "output-available": "statusOutputAvailable",
+  "output-denied": "statusOutputDenied",
+  "output-error": "statusOutputError",
 };
 
 const statusIcons: Record<ToolPart["state"], ReactNode> = {
@@ -61,12 +63,19 @@ const statusIcons: Record<ToolPart["state"], ReactNode> = {
   "output-error": <XCircleIcon className="size-4 text-red-600" />,
 };
 
-export const getStatusBadge = (status: ToolPart["state"]) => (
-  <Badge className="gap-1.5 rounded-full text-xs" variant="secondary">
-    {statusIcons[status]}
-    {statusLabels[status]}
-  </Badge>
-);
+export const ToolStatusBadge = ({ status }: { status: ToolPart["state"] }) => {
+  const intl = useIntl();
+
+  return (
+    <Badge className="gap-1.5 rounded-full text-xs" variant="secondary">
+      {statusIcons[status]}
+      {intl.formatMessage(toolMessages[statusMessageKeys[status]])}
+    </Badge>
+  );
+};
+
+/** @deprecated Use `ToolStatusBadge` instead. */
+export const getStatusBadge = (status: ToolPart["state"]) => <ToolStatusBadge status={status} />;
 
 export const ToolHeader = ({
   className,
@@ -86,7 +95,7 @@ export const ToolHeader = ({
       <div className="flex items-center gap-2">
         <WrenchIcon className="size-4 text-muted-foreground" />
         <span className="font-medium text-sm">{title ?? derivedName}</span>
-        {getStatusBadge(state)}
+        <ToolStatusBadge status={state} />
       </div>
       <ChevronDownIcon className="size-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
     </CollapsibleTrigger>
@@ -112,7 +121,7 @@ export type ToolInputProps = ComponentProps<"div"> & {
 export const ToolInput = ({ className, input, ...props }: ToolInputProps) => (
   <div className={cn("space-y-2 overflow-hidden", className)} {...props}>
     <TypographyH4 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
-      Parameters
+      <FormattedMessage {...toolMessages.parameters} />
     </TypographyH4>
     <div className="rounded-md bg-muted/50">
       <CodeBlock code={JSON.stringify(input, null, 2)} language="json" />
@@ -141,7 +150,11 @@ export const ToolOutput = ({ className, output, errorText, ...props }: ToolOutpu
   return (
     <div className={cn("space-y-2", className)} {...props}>
       <TypographyH4 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
-        {errorText ? "Error" : "Result"}
+        {errorText ? (
+          <FormattedMessage {...toolMessages.error} />
+        ) : (
+          <FormattedMessage {...toolMessages.result} />
+        )}
       </TypographyH4>
       <div
         className={cn(

--- a/apps/hyperlocalise-web/src/components/ai-elements/tooltip-provider.test.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/tooltip-provider.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from "vite-plus/test";
 import React from "react";
+import { IntlProvider } from "react-intl";
 import { renderToStaticMarkup } from "react-dom/server";
 import { MessageAction } from "./message";
 import { ArtifactAction } from "./artifact";
 import { WebPreviewNavigationButton } from "./web-preview";
 import { CodeBlockCopyButton } from "./code-block";
 import { TooltipProvider } from "@/components/ui/tooltip";
+
+const withTestProviders = (children: React.ReactNode) =>
+  React.createElement(IntlProvider, { locale: "en", messages: {} }, children);
 
 describe("Tooltip Redundancy Optimization", () => {
   it("MessageAction renders correctly within a TooltipProvider", () => {
@@ -59,10 +63,12 @@ describe("Tooltip Redundancy Optimization", () => {
 
   it("CodeBlockCopyButton renders correctly within a TooltipProvider", () => {
     const markup = renderToStaticMarkup(
-      React.createElement(
-        TooltipProvider,
-        {},
-        React.createElement(CodeBlockCopyButton, {}, "Copy"),
+      withTestProviders(
+        React.createElement(
+          TooltipProvider,
+          {},
+          React.createElement(CodeBlockCopyButton, {}, "Copy"),
+        ),
       ),
     );
     expect(markup).toContain("Copy");

--- a/apps/hyperlocalise-web/src/components/ai-elements/voice-selector.messages.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/voice-selector.messages.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const voiceSelectorMessages = defineMessages({
+  title: {
+    id: "8xFCdSWcA4",
+
+    defaultMessage: "Voice Selector",
+    description: "Accessible dialog title for the voice selector",
+  },
+  pausePreviewAria: {
+    id: "Tp/KX38QSn",
+
+    defaultMessage: "Pause preview",
+    description: "Accessible label for pausing a voice preview",
+  },
+  playPreviewAria: {
+    id: "kuwnF7iUJu",
+
+    defaultMessage: "Play preview",
+    description: "Accessible label for playing a voice preview",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/ai-elements/voice-selector.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/voice-selector.tsx
@@ -29,6 +29,9 @@ import {
 } from "lucide-react";
 import type { ComponentProps, ReactNode } from "react";
 import { createContext, useCallback, useContext, useMemo } from "react";
+import { useIntl } from "react-intl";
+
+import { voiceSelectorMessages } from "./voice-selector.messages";
 
 interface VoiceSelectorContextValue {
   value: string | undefined;
@@ -109,14 +112,19 @@ export type VoiceSelectorContentProps = ComponentProps<typeof DialogContent> & {
 export const VoiceSelectorContent = ({
   className,
   children,
-  title = "Voice Selector",
+  title,
   ...props
-}: VoiceSelectorContentProps) => (
-  <DialogContent aria-describedby={undefined} className={cn("p-0", className)} {...props}>
-    <DialogTitle className="sr-only">{title}</DialogTitle>
-    <Command className="**:data-[slot=command-input-wrapper]:h-auto">{children}</Command>
-  </DialogContent>
-);
+}: VoiceSelectorContentProps) => {
+  const intl = useIntl();
+  const resolvedTitle = title ?? intl.formatMessage(voiceSelectorMessages.title);
+
+  return (
+    <DialogContent aria-describedby={undefined} className={cn("p-0", className)} {...props}>
+      <DialogTitle className="sr-only">{resolvedTitle}</DialogTitle>
+      <Command className="**:data-[slot=command-input-wrapper]:h-auto">{children}</Command>
+    </DialogContent>
+  );
+};
 
 export type VoiceSelectorDialogProps = ComponentProps<typeof CommandDialog>;
 
@@ -409,6 +417,8 @@ export const VoiceSelectorPreview = ({
   onClick,
   ...props
 }: VoiceSelectorPreviewProps) => {
+  const intl = useIntl();
+
   const handleClick = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
       event.stopPropagation();
@@ -428,7 +438,11 @@ export const VoiceSelectorPreview = ({
 
   return (
     <Button
-      aria-label={playing ? "Pause preview" : "Play preview"}
+      aria-label={
+        playing
+          ? intl.formatMessage(voiceSelectorMessages.pausePreviewAria)
+          : intl.formatMessage(voiceSelectorMessages.playPreviewAria)
+      }
       className={cn("size-6", className)}
       disabled={loading}
       onClick={handleClick}

--- a/apps/hyperlocalise-web/src/components/ai-elements/web-preview.messages.ts
+++ b/apps/hyperlocalise-web/src/components/ai-elements/web-preview.messages.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import { defineMessages } from "react-intl";
+
+export const webPreviewMessages = defineMessages({
+  urlPlaceholder: {
+    id: "iZaQ7K2itB",
+
+    defaultMessage: "Enter URL...",
+    description: "Placeholder for the web preview URL input",
+  },
+  previewTitle: {
+    id: "usgyWI2m6M",
+
+    defaultMessage: "Preview",
+    description: "Title attribute for the web preview iframe",
+  },
+  console: {
+    id: "tj9LSxTmXM",
+
+    defaultMessage: "Console",
+    description: "Label for the web preview console collapsible section",
+  },
+  noConsoleOutput: {
+    id: "P7DyqhOghg",
+
+    defaultMessage: "No console output",
+    description: "Empty state when the web preview console has no logs",
+  },
+});

--- a/apps/hyperlocalise-web/src/components/ai-elements/web-preview.tsx
+++ b/apps/hyperlocalise-web/src/components/ai-elements/web-preview.tsx
@@ -8,7 +8,10 @@ import { cn } from "@/lib/primitives/cn";
 import { ChevronDownIcon } from "lucide-react";
 import type { ComponentProps, ReactNode } from "react";
 import { createContext, useCallback, useContext, useMemo, useState } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
 import { TypographyP } from "@/components/ui/typography";
+
+import { webPreviewMessages } from "./web-preview.messages";
 
 export interface WebPreviewContextValue {
   url: string;
@@ -122,8 +125,15 @@ export const WebPreviewNavigationButton = ({
 
 export type WebPreviewUrlProps = ComponentProps<typeof Input>;
 
-export const WebPreviewUrl = ({ value, onChange, onKeyDown, ...props }: WebPreviewUrlProps) => {
+export const WebPreviewUrl = ({
+  value,
+  onChange,
+  onKeyDown,
+  placeholder,
+  ...props
+}: WebPreviewUrlProps) => {
   const { url, setUrl } = useWebPreview();
+  const intl = useIntl();
   const [prevUrl, setPrevUrl] = useState(url);
   const [inputValue, setInputValue] = useState(url);
 
@@ -154,7 +164,7 @@ export const WebPreviewUrl = ({ value, onChange, onKeyDown, ...props }: WebPrevi
       className="h-8 flex-1 text-sm"
       onChange={onChange ?? handleChange}
       onKeyDown={handleKeyDown}
-      placeholder="Enter URL..."
+      placeholder={placeholder ?? intl.formatMessage(webPreviewMessages.urlPlaceholder)}
       value={value ?? inputValue}
       {...props}
     />
@@ -165,8 +175,15 @@ export type WebPreviewBodyProps = ComponentProps<"iframe"> & {
   loading?: ReactNode;
 };
 
-export const WebPreviewBody = ({ className, loading, src, ...props }: WebPreviewBodyProps) => {
+export const WebPreviewBody = ({
+  className,
+  loading,
+  src,
+  title,
+  ...props
+}: WebPreviewBodyProps) => {
   const { url } = useWebPreview();
+  const intl = useIntl();
 
   return (
     <div className="flex-1">
@@ -175,7 +192,7 @@ export const WebPreviewBody = ({ className, loading, src, ...props }: WebPreview
         // oxlint-disable-next-line eslint-plugin-react(iframe-missing-sandbox)
         sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-presentation"
         src={(src ?? url) || undefined}
-        title="Preview"
+        title={title ?? intl.formatMessage(webPreviewMessages.previewTitle)}
         {...props}
       />
       {loading}
@@ -225,7 +242,7 @@ export const WebPreviewConsole = ({
           />
         }
       >
-        Console
+        <FormattedMessage {...webPreviewMessages.console} />
         <ChevronDownIcon
           className={cn("h-4 w-4 transition-transform duration-200", consoleOpen && "rotate-180")}
         />
@@ -238,7 +255,9 @@ export const WebPreviewConsole = ({
       >
         <div className="max-h-48 space-y-1 overflow-y-auto">
           {logs.length === 0 ? (
-            <TypographyP className="text-muted-foreground">No console output</TypographyP>
+            <TypographyP className="text-muted-foreground">
+              <FormattedMessage {...webPreviewMessages.noConsoleOutput} />
+            </TypographyP>
           ) : (
             logs.map((log) => (
               <div


### PR DESCRIPTION
## What changed

Localize hardcoded user-facing strings in `apps/hyperlocalise-web/src/components/ai-elements` using react-intl with ICU MessageFormat.

- Added 27 colocated `*.messages.ts` modules (one per localized element) using `defineMessages`
- Wired components to use `<FormattedMessage />` in JSX and `useIntl().formatMessage()` for aria labels, placeholders, tooltips, and error copy
- Introduced `ToolStatusBadge` for localized tool status labels (replaces hook-incompatible `getStatusBadge` helper)
- Updated tests to wrap components with `IntlProvider` where `useIntl` is required

## How to test

- `cd apps/hyperlocalise-web && vp check --fix src/components/ai-elements/`
- `cd apps/hyperlocalise-web && vp test src/components/ai-elements/`
- Spot-check AI chat UI surfaces that use ai-elements (prompt input, tool cards, conversation empty state, copy buttons)

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)