### PR TITLE
fix(crowdin): add missing pagination to response models and optimize manager options

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -167,3 +167,9 @@
 **Learning:** The Crowdin API v2 for uploading translations (`POST /api/v2/projects/{projectId}/translations/{languageId}`) supports `directoryId` for string-based projects, which was missing from the SDK. Additionally, `SourceStringsUploadRequest.Validate()` would panic if `updateOption` was set while `updateStrings` was nil.
 
 **Action:** Added `DirectoryID` (int) to `UploadTranslationsRequest` and updated `Validate()` to ensure `FileID` is not used with `BranchID` or `DirectoryID`. Added `BranchID` and `DirectoryID` to the `UploadTranslations` response struct. Fixed potential nil pointer dereference in `SourceStringsUploadRequest.Validate()` and corrected a struct name in documentation comments. Verified with comprehensive unit and contract tests.
+
+## 2026-10-03 - Improve response parity for Pagination and optimize ManagerListOptions
+
+**Learning:** Several list response models in the Crowdin Go SDK were missing the `pagination` field, preventing callers from handling multi-page results for translation progress, QA checks, and group managers. Additionally, the `ManagerListOptions.Values()` method was using a manual loop for slice joining, which is less efficient and consistent than the `JoinSlice` helper.
+
+**Action:** Added `Pagination *Pagination` to `TranslationProgressResponse`, `QAChecksResponse`, and `ManagerResponse`. Refactored `ManagerListOptions.Values()` to use `JoinSlice`. Added comprehensive unmarshaling tests to verify that the new pagination fields are correctly populated from API responses. Verified with `go test` in the fork.

--- a/third_party/crowdin-api-client-go/crowdin/model/managers.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/managers.go
@@ -2,8 +2,6 @@ package model
 
 import (
 	"net/url"
-	"strconv"
-	"strings"
 )
 
 // Manager represents a manager in the organization.
@@ -22,7 +20,8 @@ type ManagerGetResponse struct {
 // ManagerResponse defines the structure of the response when
 // getting a list of group managers.
 type ManagerResponse struct {
-	Data []*ManagerGetResponse `json:"data"`
+	Data       []*ManagerGetResponse `json:"data"`
+	Pagination *Pagination           `json:"pagination"`
 }
 
 // ManagerListOptions specifies the optional parameters to the
@@ -36,17 +35,13 @@ type ManagerListOptions struct {
 // Values returns the url.Values representation of the ManagerListOptions.
 // It implements the crowdin.ListOptionsProvider interface.
 func (o *ManagerListOptions) Values() (url.Values, bool) {
-	v := url.Values{}
 	if o == nil {
 		return nil, false
 	}
 
+	v := url.Values{}
 	if len(o.TeamIDs) > 0 {
-		ids := make([]string, len(o.TeamIDs))
-		for i, id := range o.TeamIDs {
-			ids[i] = strconv.Itoa(id)
-		}
-		v.Set("teamIds", strings.Join(ids, ","))
+		v.Add("teamIds", JoinSlice(o.TeamIDs))
 	}
 
 	if o.OrderBy != "" {

--- a/third_party/crowdin-api-client-go/crowdin/model/managers_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/managers_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -44,4 +45,31 @@ func TestManagerListOptionsValues(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestManagerResponseUnmarshaling(t *testing.T) {
+	jsonResp := `{
+		"data": [
+			{
+				"data": {
+					"id": 1,
+					"user": {
+						"id": 10,
+						"username": "john_doe"
+					}
+				}
+			}
+		],
+		"pagination": {
+			"offset": 0,
+			"limit": 25
+		}
+	}`
+
+	var resp ManagerResponse
+	err := json.Unmarshal([]byte(jsonResp), &resp)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp.Pagination)
+	assert.Equal(t, 0, resp.Pagination.Offset)
+	assert.Equal(t, 25, resp.Pagination.Limit)
 }

--- a/third_party/crowdin-api-client-go/crowdin/model/translation_status.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/translation_status.go
@@ -21,6 +21,7 @@ type TranslationProgressResponse struct {
 	Data []struct {
 		Data *TranslationProgress `json:"data"`
 	} `json:"data"`
+	Pagination *Pagination `json:"pagination"`
 }
 
 // TranslationProgressListOptions specifies the optional parameters for progress
@@ -103,6 +104,7 @@ type QAChecksResponse struct {
 	Data []struct {
 		Data *QACheck `json:"data"`
 	} `json:"data"`
+	Pagination *Pagination `json:"pagination"`
 }
 
 // QACheckListOptions specifies the optional parameters to the

--- a/third_party/crowdin-api-client-go/crowdin/model/translation_status_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/translation_status_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -42,6 +43,57 @@ func TestProjectProgressListOptionsValues(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTranslationProgressResponseUnmarshaling(t *testing.T) {
+	jsonResp := `{
+		"data": [
+			{
+				"data": {
+					"words": {"total": 100},
+					"phrases": {"total": 10},
+					"translationProgress": 50,
+					"approvalProgress": 20
+				}
+			}
+		],
+		"pagination": {
+			"offset": 0,
+			"limit": 25
+		}
+	}`
+
+	var resp TranslationProgressResponse
+	err := json.Unmarshal([]byte(jsonResp), &resp)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp.Pagination)
+	assert.Equal(t, 0, resp.Pagination.Offset)
+	assert.Equal(t, 25, resp.Pagination.Limit)
+}
+
+func TestQAChecksResponseUnmarshaling(t *testing.T) {
+	jsonResp := `{
+		"data": [
+			{
+				"data": {
+					"stringId": 1,
+					"languageId": "uk",
+					"category": "variables"
+				}
+			}
+		],
+		"pagination": {
+			"offset": 10,
+			"limit": 50
+		}
+	}`
+
+	var resp QAChecksResponse
+	err := json.Unmarshal([]byte(jsonResp), &resp)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp.Pagination)
+	assert.Equal(t, 10, resp.Pagination.Offset)
+	assert.Equal(t, 50, resp.Pagination.Limit)
 }
 
 func TestQACheckListOptionsValues(t *testing.T) {


### PR DESCRIPTION
- What: Added `Pagination` field to `TranslationProgressResponse`, `QAChecksResponse`, and `ManagerResponse`. Optimized `ManagerListOptions.Values()` to use `JoinSlice`.
- Why: To align with Crowdin API v2 contract for list responses and improve code consistency and performance.
- Docs: https://developer.crowdin.com/api/v2/
- Scope: `third_party/crowdin-api-client-go/crowdin/model/{translation_status,managers}{,_test}.go`
- Tests: Added `TestTranslationProgressResponseUnmarshaling`, `TestQAChecksResponseUnmarshaling`, and `TestManagerResponseUnmarshaling`. Ran all tests in the fork with `GOWORK=off go test ./...`.
- Confidence: High. Verified with focused contract tests and full package test suite.

---
*PR created automatically by Jules for task [11850531495101492981](https://jules.google.com/task/11850531495101492981) started by @cungminh2710*