### PR TITLE
fix(crowdin): use valid CroQL field for file-scoped string search

### DIFF
--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-croql.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-croql.test.ts
@@ -5,20 +5,20 @@ import { buildCrowdinFileSearchCroql, escapeCrowdinCroqlString } from "./crowdin
 describe("buildCrowdinFileSearchCroql", () => {
   it("scopes search to a file and matches identifier or text", () => {
     expect(buildCrowdinFileSearchCroql(101, "hello")).toBe(
-      'fileId = 101 and (identifier contains "hello" or text contains "hello")',
+      'id of file = 101 and (identifier contains "hello" or text contains "hello")',
     );
   });
 
   it("escapes quotes and backslashes in search terms", () => {
     expect(escapeCrowdinCroqlString(String.raw`say "hi"`)).toBe(String.raw`say \"hi\"`);
     expect(buildCrowdinFileSearchCroql(42, String.raw`path\to\key`)).toBe(
-      String.raw`fileId = 42 and (identifier contains "path\\to\\key" or text contains "path\\to\\key")`,
+      String.raw`id of file = 42 and (identifier contains "path\\to\\key" or text contains "path\\to\\key")`,
     );
   });
 
   it("trims whitespace from the search term", () => {
     expect(buildCrowdinFileSearchCroql(7, "  workspace  ")).toBe(
-      'fileId = 7 and (identifier contains "workspace" or text contains "workspace")',
+      'id of file = 7 and (identifier contains "workspace" or text contains "workspace")',
     );
   });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-croql.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-croql.ts
@@ -4,5 +4,5 @@ export function escapeCrowdinCroqlString(value: string) {
 
 export function buildCrowdinFileSearchCroql(fileId: number, search: string) {
   const escaped = escapeCrowdinCroqlString(search.trim());
-  return `fileId = ${fileId} and (identifier contains "${escaped}" or text contains "${escaped}")`;
+  return `id of file = ${fileId} and (identifier contains "${escaped}" or text contains "${escaped}")`;
 }


### PR DESCRIPTION
## What changed

Crowdin file-scoped string search was building invalid CroQL (`fileId = N`), which caused HTTP 400 responses from `GET /projects/{id}/strings?croql=...`.

Updated `buildCrowdinFileSearchCroql` to use Crowdin's documented syntax (`id of file = N`) when scoping search queries to a file.

## How to test

- `cd apps/hyperlocalise-web && vp test src/lib/providers/adapters/crowdin/crowdin-croql.test.ts`
- In the live provider CAT workspace, search strings within a Crowdin-linked file (e.g. search for `mention`) and confirm results load instead of a 400 error.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)