### PR TITLE
fix(cli): preserve JSON array shape when marshaling translations

### DIFF
--- a/apps/cli/internal/i18n/runsvc/output_json.go
+++ b/apps/cli/internal/i18n/runsvc/output_json.go
@@ -10,10 +10,16 @@ import (
 	"path/filepath"
 	"reflect"
 	"slices"
+	"strconv"
 	"strings"
 
 	jsoncparser "github.com/tidwall/jsonc"
 )
+
+type jsonPathSegment struct {
+	key   string
+	index *int
+}
 
 func unmarshalJSONForPath(path string, content []byte, out any) error {
 	firstErr := json.Unmarshal(content, out)
@@ -177,11 +183,25 @@ func pruneNestedJSONStringFields(payload map[string]any, prefix string, allowed 
 			if _, ok := allowed[fullKey]; !ok {
 				delete(payload, key)
 			}
+		case []any:
+			pruneJSONArrayStringFields(typed, fullKey, allowed)
 		case map[string]any:
 			pruneNestedJSONStringFields(typed, fullKey, allowed)
 			if len(typed) == 0 {
 				delete(payload, key)
 			}
+		}
+	}
+}
+
+func pruneJSONArrayStringFields(payload []any, prefix string, allowed map[string]struct{}) {
+	for idx, value := range payload {
+		fullKey := prefix + "[" + strconv.Itoa(idx) + "]"
+		switch typed := value.(type) {
+		case []any:
+			pruneJSONArrayStringFields(typed, fullKey, allowed)
+		case map[string]any:
+			pruneNestedJSONStringFields(typed, fullKey, allowed)
 		}
 	}
 }
@@ -220,6 +240,22 @@ func collectNestedJSONStrings(out map[string]string, prefix string, payload map[
 		switch typed := value.(type) {
 		case string:
 			out[fullKey] = typed
+		case []any:
+			collectJSONArrayStrings(out, fullKey, typed)
+		case map[string]any:
+			collectNestedJSONStrings(out, fullKey, typed)
+		}
+	}
+}
+
+func collectJSONArrayStrings(out map[string]string, prefix string, payload []any) {
+	for idx, value := range payload {
+		fullKey := prefix + "[" + strconv.Itoa(idx) + "]"
+		switch typed := value.(type) {
+		case string:
+			out[fullKey] = typed
+		case []any:
+			collectJSONArrayStrings(out, fullKey, typed)
 		case map[string]any:
 			collectNestedJSONStrings(out, fullKey, typed)
 		}
@@ -235,26 +271,125 @@ func sortedEntryKeysMapAny(entries map[string]any) []string {
 	return keys
 }
 
+func parseJSONPath(key string) ([]jsonPathSegment, error) {
+	if key == "" {
+		return nil, fmt.Errorf("json path cannot be empty")
+	}
+
+	parts := strings.Split(key, ".")
+	segments := make([]jsonPathSegment, 0, len(parts))
+	for _, part := range parts {
+		if part == "" {
+			return nil, fmt.Errorf("invalid json path %q", key)
+		}
+
+		bracket := strings.Index(part, "[")
+		if bracket < 0 {
+			segments = append(segments, jsonPathSegment{key: part})
+			continue
+		}
+		if !strings.HasSuffix(part, "]") {
+			return nil, fmt.Errorf("invalid json path segment %q", part)
+		}
+
+		name := part[:bracket]
+		if name == "" {
+			return nil, fmt.Errorf("invalid json path segment %q", part)
+		}
+		idx, err := strconv.Atoi(part[bracket+1 : len(part)-1])
+		if err != nil || idx < 0 {
+			return nil, fmt.Errorf("invalid json array index in %q", part)
+		}
+		index := idx
+		segments = append(segments, jsonPathSegment{key: name, index: &index})
+	}
+
+	return segments, nil
+}
+
 func setNestedValue(payload map[string]any, dottedKey, value string) {
-	parts := strings.Split(dottedKey, ".")
+	segments, err := parseJSONPath(dottedKey)
+	if err != nil {
+		return
+	}
+
 	current := payload
-	for i, part := range parts {
-		if i == len(parts)-1 {
-			current[part] = value
+	for i := 0; i < len(segments)-1; i++ {
+		nextMap, ok := descendJSONPath(current, segments[i], true)
+		if !ok {
 			return
 		}
-		next, ok := current[part]
+		current = nextMap
+	}
+
+	last := segments[len(segments)-1]
+	if last.index == nil {
+		current[last.key] = value
+		return
+	}
+
+	arr, ok := current[last.key].([]any)
+	if !ok {
+		arr = make([]any, *last.index+1)
+		current[last.key] = arr
+	}
+	for len(arr) <= *last.index {
+		arr = append(arr, nil)
+	}
+	current[last.key] = arr
+	arr[*last.index] = value
+}
+
+func descendJSONPath(current map[string]any, segment jsonPathSegment, create bool) (map[string]any, bool) {
+	if segment.index == nil {
+		next, ok := current[segment.key]
 		if !ok {
+			if !create {
+				return nil, false
+			}
 			nested := map[string]any{}
-			current[part] = nested
-			current = nested
-			continue
+			current[segment.key] = nested
+			return nested, true
 		}
 		nested, ok := next.(map[string]any)
 		if !ok {
+			if !create {
+				return nil, false
+			}
 			nested = map[string]any{}
-			current[part] = nested
+			current[segment.key] = nested
 		}
-		current = nested
+		return nested, true
 	}
+
+	next, ok := current[segment.key]
+	if !ok {
+		if !create {
+			return nil, false
+		}
+		next = []any{}
+		current[segment.key] = next
+	}
+	arr, ok := next.([]any)
+	if !ok {
+		return nil, false
+	}
+	for len(arr) <= *segment.index {
+		if !create {
+			return nil, false
+		}
+		arr = append(arr, map[string]any{})
+	}
+	current[segment.key] = arr
+
+	elem := arr[*segment.index]
+	elemMap, ok := elem.(map[string]any)
+	if !ok {
+		if !create {
+			return nil, false
+		}
+		elemMap = map[string]any{}
+		arr[*segment.index] = elemMap
+	}
+	return elemMap, true
 }

--- a/apps/cli/internal/i18n/runsvc/output_json.go
+++ b/apps/cli/internal/i18n/runsvc/output_json.go
@@ -198,6 +198,10 @@ func pruneJSONArrayStringFields(payload []any, prefix string, allowed map[string
 	for idx, value := range payload {
 		fullKey := prefix + "[" + strconv.Itoa(idx) + "]"
 		switch typed := value.(type) {
+		case string:
+			if _, ok := allowed[fullKey]; !ok {
+				payload[idx] = nil
+			}
 		case []any:
 			pruneJSONArrayStringFields(typed, fullKey, allowed)
 		case map[string]any:
@@ -283,25 +287,48 @@ func parseJSONPath(key string) ([]jsonPathSegment, error) {
 			return nil, fmt.Errorf("invalid json path %q", key)
 		}
 
-		bracket := strings.Index(part, "[")
-		if bracket < 0 {
-			segments = append(segments, jsonPathSegment{key: part})
-			continue
+		partSegments, err := parseJSONPathPart(part)
+		if err != nil {
+			return nil, err
 		}
-		if !strings.HasSuffix(part, "]") {
-			return nil, fmt.Errorf("invalid json path segment %q", part)
-		}
+		segments = append(segments, partSegments...)
+	}
 
-		name := part[:bracket]
-		if name == "" {
+	return segments, nil
+}
+
+func parseJSONPathPart(part string) ([]jsonPathSegment, error) {
+	bracket := strings.Index(part, "[")
+	if bracket < 0 {
+		return []jsonPathSegment{{key: part}}, nil
+	}
+
+	name := part[:bracket]
+	if name == "" {
+		return nil, fmt.Errorf("invalid json path segment %q", part)
+	}
+
+	remainder := part[bracket:]
+	segments := make([]jsonPathSegment, 0, 4)
+	for remainder != "" {
+		if remainder[0] != '[' {
 			return nil, fmt.Errorf("invalid json path segment %q", part)
 		}
-		idx, err := strconv.Atoi(part[bracket+1 : len(part)-1])
+		closeBracket := strings.Index(remainder, "]")
+		if closeBracket < 0 {
+			return nil, fmt.Errorf("invalid json path segment %q", part)
+		}
+		idx, err := strconv.Atoi(remainder[1:closeBracket])
 		if err != nil || idx < 0 {
 			return nil, fmt.Errorf("invalid json array index in %q", part)
 		}
 		index := idx
-		segments = append(segments, jsonPathSegment{key: name, index: &index})
+		if len(segments) == 0 {
+			segments = append(segments, jsonPathSegment{key: name, index: &index})
+		} else {
+			segments = append(segments, jsonPathSegment{index: &index})
+		}
+		remainder = remainder[closeBracket+1:]
 	}
 
 	return segments, nil
@@ -313,64 +340,99 @@ func setNestedValue(payload map[string]any, dottedKey, value string) {
 		return
 	}
 
-	current := payload
+	current := any(payload)
 	for i := 0; i < len(segments)-1; i++ {
-		nextMap, ok := descendJSONPath(current, segments[i], true)
+		var nextSegment *jsonPathSegment
+		if i+1 < len(segments) {
+			nextSegment = &segments[i+1]
+		}
+		next, ok := descendJSONPath(current, segments[i], nextSegment, true)
 		if !ok {
 			return
 		}
-		current = nextMap
+		current = next
 	}
 
-	last := segments[len(segments)-1]
-	if last.index == nil {
-		current[last.key] = value
-		return
-	}
-
-	arr, ok := current[last.key].([]any)
-	if !ok {
-		arr = make([]any, *last.index+1)
-		current[last.key] = arr
-	}
-	for len(arr) <= *last.index {
-		arr = append(arr, nil)
-	}
-	current[last.key] = arr
-	arr[*last.index] = value
+	setJSONPathValue(current, segments[len(segments)-1], value)
 }
 
-func descendJSONPath(current map[string]any, segment jsonPathSegment, create bool) (map[string]any, bool) {
-	if segment.index == nil {
-		next, ok := current[segment.key]
-		if !ok {
-			if !create {
-				return nil, false
-			}
-			nested := map[string]any{}
-			current[segment.key] = nested
-			return nested, true
+func setJSONPathValue(current any, segment jsonPathSegment, value string) {
+	switch typed := current.(type) {
+	case map[string]any:
+		if segment.index == nil {
+			typed[segment.key] = value
+			return
 		}
-		nested, ok := next.(map[string]any)
+		arr, ok := typed[segment.key].([]any)
 		if !ok {
-			if !create {
-				return nil, false
-			}
-			nested = map[string]any{}
-			current[segment.key] = nested
+			arr = make([]any, *segment.index+1)
 		}
-		return nested, true
+		for len(arr) <= *segment.index {
+			arr = append(arr, nil)
+		}
+		typed[segment.key] = arr
+		arr[*segment.index] = value
+	case []any:
+		if segment.index == nil {
+			return
+		}
+		for len(typed) <= *segment.index {
+			typed = append(typed, nil)
+		}
+		typed[*segment.index] = value
 	}
+}
 
-	next, ok := current[segment.key]
-	if !ok {
-		if !create {
+func descendJSONPath(current any, segment jsonPathSegment, nextSegment *jsonPathSegment, create bool) (any, bool) {
+	if segment.key != "" {
+		currentMap, ok := current.(map[string]any)
+		if !ok {
 			return nil, false
 		}
-		next = []any{}
-		current[segment.key] = next
+		if segment.index == nil {
+			next, ok := currentMap[segment.key]
+			if !ok {
+				if !create {
+					return nil, false
+				}
+				nested := map[string]any{}
+				currentMap[segment.key] = nested
+				return nested, true
+			}
+			nested, ok := next.(map[string]any)
+			if !ok {
+				if !create {
+					return nil, false
+				}
+				nested = map[string]any{}
+				currentMap[segment.key] = nested
+			}
+			return nested, true
+		}
+
+		next, ok := currentMap[segment.key]
+		if !ok {
+			if !create {
+				return nil, false
+			}
+			next = []any{}
+			currentMap[segment.key] = next
+		}
+		arr, ok := next.([]any)
+		if !ok {
+			return nil, false
+		}
+		for len(arr) <= *segment.index {
+			if !create {
+				return nil, false
+			}
+			arr = append(arr, nil)
+		}
+		currentMap[segment.key] = arr
+		return ensureJSONArrayElement(arr, *segment.index, nextSegment, create)
 	}
-	arr, ok := next.([]any)
+
+	arr, ok := current.([]any)
 	if !ok {
 		return nil, false
 	}
@@ -378,18 +440,26 @@ func descendJSONPath(current map[string]any, segment jsonPathSegment, create boo
 		if !create {
 			return nil, false
 		}
-		arr = append(arr, map[string]any{})
+		arr = append(arr, nil)
 	}
-	current[segment.key] = arr
+	return ensureJSONArrayElement(arr, *segment.index, nextSegment, create)
+}
 
-	elem := arr[*segment.index]
-	elemMap, ok := elem.(map[string]any)
-	if !ok {
-		if !create {
-			return nil, false
-		}
-		elemMap = map[string]any{}
-		arr[*segment.index] = elemMap
+func ensureJSONArrayElement(arr []any, index int, nextSegment *jsonPathSegment, create bool) (any, bool) {
+	elem := arr[index]
+	if elem == nil && create {
+		elem = newJSONPathChild(nextSegment)
+		arr[index] = elem
 	}
-	return elemMap, true
+	if elem == nil {
+		return nil, create
+	}
+	return elem, true
+}
+
+func newJSONPathChild(nextSegment *jsonPathSegment) any {
+	if nextSegment != nil && nextSegment.key == "" && nextSegment.index != nil {
+		return []any{}
+	}
+	return map[string]any{}
 }

--- a/apps/cli/internal/i18n/runsvc/output_json.go
+++ b/apps/cli/internal/i18n/runsvc/output_json.go
@@ -334,127 +334,170 @@ func parseJSONPathPart(part string) ([]jsonPathSegment, error) {
 	return segments, nil
 }
 
+type jsonPathCursor struct {
+	node      any
+	parentArr []any
+	parentIdx int
+	hasParent bool
+}
+
 func setNestedValue(payload map[string]any, dottedKey, value string) {
 	segments, err := parseJSONPath(dottedKey)
 	if err != nil {
 		return
 	}
 
-	current := any(payload)
+	cursor := jsonPathCursor{node: payload}
 	for i := 0; i < len(segments)-1; i++ {
 		var nextSegment *jsonPathSegment
 		if i+1 < len(segments) {
 			nextSegment = &segments[i+1]
 		}
-		next, ok := descendJSONPath(current, segments[i], nextSegment, true)
-		if !ok {
+		if !cursor.descend(segments[i], nextSegment, true) {
 			return
 		}
-		current = next
 	}
-
-	setJSONPathValue(current, segments[len(segments)-1], value)
+	cursor.setValue(segments[len(segments)-1], value)
 }
 
-func setJSONPathValue(current any, segment jsonPathSegment, value string) {
-	switch typed := current.(type) {
-	case map[string]any:
-		if segment.index == nil {
-			typed[segment.key] = value
-			return
+func (c *jsonPathCursor) writeBackArray(arr []any) {
+	if c.hasParent {
+		c.parentArr[c.parentIdx] = arr
+	}
+}
+
+func extendJSONArray(arr []any, index int, create bool) ([]any, bool) {
+	if len(arr) <= index {
+		if !create {
+			return nil, false
 		}
-		arr, ok := typed[segment.key].([]any)
-		if !ok {
-			arr = make([]any, *segment.index+1)
-		}
-		for len(arr) <= *segment.index {
+		for len(arr) <= index {
 			arr = append(arr, nil)
 		}
-		typed[segment.key] = arr
-		arr[*segment.index] = value
-	case []any:
-		if segment.index == nil {
-			return
-		}
-		for len(typed) <= *segment.index {
-			typed = append(typed, nil)
-		}
-		typed[*segment.index] = value
 	}
+	return arr, true
 }
 
-func descendJSONPath(current any, segment jsonPathSegment, nextSegment *jsonPathSegment, create bool) (any, bool) {
+func (c *jsonPathCursor) descend(segment jsonPathSegment, nextSegment *jsonPathSegment, create bool) bool {
 	if segment.key != "" {
-		currentMap, ok := current.(map[string]any)
+		currentMap, ok := c.node.(map[string]any)
 		if !ok {
-			return nil, false
+			return false
 		}
 		if segment.index == nil {
 			next, ok := currentMap[segment.key]
 			if !ok {
 				if !create {
-					return nil, false
+					return false
 				}
-				nested := map[string]any{}
-				currentMap[segment.key] = nested
-				return nested, true
+				next = map[string]any{}
+				currentMap[segment.key] = next
 			}
 			nested, ok := next.(map[string]any)
 			if !ok {
 				if !create {
-					return nil, false
+					return false
 				}
 				nested = map[string]any{}
 				currentMap[segment.key] = nested
 			}
-			return nested, true
+			c.node = nested
+			c.hasParent = false
+			return true
 		}
 
 		next, ok := currentMap[segment.key]
 		if !ok {
 			if !create {
-				return nil, false
+				return false
 			}
 			next = []any{}
 			currentMap[segment.key] = next
 		}
 		arr, ok := next.([]any)
 		if !ok {
-			return nil, false
+			return false
 		}
-		for len(arr) <= *segment.index {
-			if !create {
-				return nil, false
-			}
-			arr = append(arr, nil)
+		arr, ok = extendJSONArray(arr, *segment.index, create)
+		if !ok {
+			return false
 		}
 		currentMap[segment.key] = arr
-		return ensureJSONArrayElement(arr, *segment.index, nextSegment, create)
-	}
-
-	arr, ok := current.([]any)
-	if !ok {
-		return nil, false
-	}
-	for len(arr) <= *segment.index {
-		if !create {
-			return nil, false
+		elem := arr[*segment.index]
+		if elem == nil && create {
+			elem = newJSONPathChild(nextSegment)
+			arr[*segment.index] = elem
+			currentMap[segment.key] = arr
 		}
-		arr = append(arr, nil)
+		if elem == nil {
+			return create
+		}
+		c.node = elem
+		c.parentArr = arr
+		c.parentIdx = *segment.index
+		c.hasParent = true
+		return true
 	}
-	return ensureJSONArrayElement(arr, *segment.index, nextSegment, create)
-}
 
-func ensureJSONArrayElement(arr []any, index int, nextSegment *jsonPathSegment, create bool) (any, bool) {
-	elem := arr[index]
+	arr, ok := c.node.([]any)
+	if !ok {
+		return false
+	}
+	arr, ok = extendJSONArray(arr, *segment.index, create)
+	if !ok {
+		return false
+	}
+	c.writeBackArray(arr)
+	elem := arr[*segment.index]
 	if elem == nil && create {
 		elem = newJSONPathChild(nextSegment)
-		arr[index] = elem
+		arr[*segment.index] = elem
+		c.writeBackArray(arr)
 	}
 	if elem == nil {
-		return nil, create
+		return create
 	}
-	return elem, true
+	c.node = elem
+	c.parentArr = arr
+	c.parentIdx = *segment.index
+	c.hasParent = true
+	return true
+}
+
+func (c *jsonPathCursor) setValue(segment jsonPathSegment, value string) {
+	if segment.key != "" {
+		currentMap, ok := c.node.(map[string]any)
+		if !ok {
+			return
+		}
+		if segment.index == nil {
+			currentMap[segment.key] = value
+			return
+		}
+		arr, ok := currentMap[segment.key].([]any)
+		if !ok {
+			arr = make([]any, *segment.index+1)
+		}
+		arr, ok = extendJSONArray(arr, *segment.index, true)
+		if !ok {
+			return
+		}
+		arr[*segment.index] = value
+		currentMap[segment.key] = arr
+		return
+	}
+
+	arr, ok := c.node.([]any)
+	if !ok {
+		return
+	}
+	arr, ok = extendJSONArray(arr, *segment.index, true)
+	if !ok {
+		return
+	}
+	c.writeBackArray(arr)
+	arr[*segment.index] = value
+	c.writeBackArray(arr)
 }
 
 func newJSONPathChild(nextSegment *jsonPathSegment) any {

--- a/apps/cli/internal/i18n/runsvc/output_json_test.go
+++ b/apps/cli/internal/i18n/runsvc/output_json_test.go
@@ -92,7 +92,7 @@ func TestParseJSONEntriesLenientIgnoresNonStringLeaves(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse lenient non-string leaves: %v", err)
 	}
-	want := map[string]string{"a.s": "x"}
+	want := map[string]string{"a.s": "x", "a.arr[0]": "x"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("entries mismatch\nwant: %#v\n got: %#v", want, got)
 	}
@@ -205,5 +205,101 @@ func TestUnmarshalJSONForPathResetsTargetBeforeJSONCRetry(t *testing.T) {
 	want := map[string]any{"first": "one", "second": "two"}
 	if !reflect.DeepEqual(payload, want) {
 		t.Fatalf("payload mismatch\nwant: %#v\n got: %#v", want, payload)
+	}
+}
+
+func TestMarshalJSONTargetPreservesObjectArrayShape(t *testing.T) {
+	template := []byte(`{
+  "home": {
+    "title": "Welcome",
+    "steps": [
+      {"title": "One", "description": "First"},
+      {"title": "Two", "description": "Second"},
+      {"title": "Three", "description": "Third"}
+    ]
+  }
+}`)
+	values := map[string]string{
+		"home.steps[0].title":       "Uno",
+		"home.steps[1].description": "Segundo",
+	}
+	content, err := marshalJSONTarget("/tmp/nested.json", template, values, nil)
+	if err != nil {
+		t.Fatalf("marshal nested json with arrays: %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(content, &payload); err != nil {
+		t.Fatalf("decode nested payload: %v", err)
+	}
+
+	home := payload["home"].(map[string]any)
+	steps, ok := home["steps"].([]any)
+	if !ok {
+		t.Fatalf("expected steps array, got %T", home["steps"])
+	}
+	if len(steps) != 3 {
+		t.Fatalf("expected 3 steps, got %d", len(steps))
+	}
+	if _, ok := home["steps[0]"]; ok {
+		t.Fatalf("expected indexed keys to remain inside steps array")
+	}
+
+	first := steps[0].(map[string]any)
+	if got := first["title"]; got != "Uno" {
+		t.Fatalf("first step title mismatch: %v", got)
+	}
+	second := steps[1].(map[string]any)
+	if got := second["description"]; got != "Segundo" {
+		t.Fatalf("second step description mismatch: %v", got)
+	}
+}
+
+func TestParseJSONEntriesLenientCollectsArrayStrings(t *testing.T) {
+	got, err := parseJSONEntriesLenient("/tmp/messages.json", []byte(`{
+  "home": {
+    "steps": [
+      {"title": "One", "description": "First"},
+      {"title": "Two", "description": "Second"}
+    ],
+    "tags": ["Alpha", "Beta"]
+  }
+}`))
+	if err != nil {
+		t.Fatalf("parse lenient arrays: %v", err)
+	}
+
+	if got["home.steps[0].title"] != "One" {
+		t.Fatalf("unexpected home.steps[0].title: %q", got["home.steps[0].title"])
+	}
+	if got["home.steps[1].description"] != "Second" {
+		t.Fatalf("unexpected home.steps[1].description: %q", got["home.steps[1].description"])
+	}
+	if got["home.tags[0]"] != "Alpha" {
+		t.Fatalf("unexpected home.tags[0]: %q", got["home.tags[0]"])
+	}
+}
+
+func TestSetNestedValueHandlesArrayIndexedPaths(t *testing.T) {
+	payload := map[string]any{
+		"home": map[string]any{
+			"steps": []any{
+				map[string]any{"title": "Old", "description": "First"},
+			},
+		},
+	}
+
+	setNestedValue(payload, "home.steps[0].title", "New title")
+	setNestedValue(payload, "home.tags[0]", "Alpha")
+
+	home := payload["home"].(map[string]any)
+	steps := home["steps"].([]any)
+	first := steps[0].(map[string]any)
+	if got := first["title"]; got != "New title" {
+		t.Fatalf("step title mismatch: %v", got)
+	}
+	tags := home["tags"].([]any)
+	if got := tags[0]; got != "Alpha" {
+		t.Fatalf("tags[0] mismatch: %v", got)
 	}
 }

--- a/apps/cli/internal/i18n/runsvc/output_json_test.go
+++ b/apps/cli/internal/i18n/runsvc/output_json_test.go
@@ -255,6 +255,118 @@ func TestMarshalJSONTargetPreservesObjectArrayShape(t *testing.T) {
 	}
 }
 
+func TestMarshalJSONTargetPrunesArrayStringFields(t *testing.T) {
+	template := []byte(`{
+  "home": {
+    "steps": [
+      {"title": "One", "description": "First"},
+      {"title": "Two", "description": "Second"},
+      {"title": "Three", "description": "Third"}
+    ],
+    "tags": ["Alpha", "Beta"]
+  }
+}`)
+	values := map[string]string{
+		"home.steps[0].title":       "Uno",
+		"home.steps[1].description": "Segundo",
+	}
+	pruneKeys := map[string]struct{}{
+		"home.steps[0].title":       {},
+		"home.steps[1].description": {},
+	}
+	content, err := marshalJSONTarget("/tmp/nested.json", template, values, pruneKeys)
+	if err != nil {
+		t.Fatalf("marshal nested json with array pruning: %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(content, &payload); err != nil {
+		t.Fatalf("decode nested payload: %v", err)
+	}
+
+	home := payload["home"].(map[string]any)
+	steps := home["steps"].([]any)
+	if len(steps) != 3 {
+		t.Fatalf("expected 3 steps, got %d", len(steps))
+	}
+
+	first := steps[0].(map[string]any)
+	if got := first["title"]; got != "Uno" {
+		t.Fatalf("first step title mismatch: %v", got)
+	}
+	if _, ok := first["description"]; ok {
+		t.Fatalf("expected first step description to be pruned")
+	}
+
+	second := steps[1].(map[string]any)
+	if got := second["description"]; got != "Segundo" {
+		t.Fatalf("second step description mismatch: %v", got)
+	}
+	if _, ok := second["title"]; ok {
+		t.Fatalf("expected second step title to be pruned")
+	}
+
+	third := steps[2].(map[string]any)
+	if len(third) != 0 {
+		t.Fatalf("expected third step object to be empty after pruning, got %#v", third)
+	}
+
+	tags := home["tags"].([]any)
+	if len(tags) != 2 {
+		t.Fatalf("expected tags array length to be preserved, got %d", len(tags))
+	}
+	if tags[0] != nil {
+		t.Fatalf("expected pruned tags[0] to be nil, got %v", tags[0])
+	}
+	if tags[1] != nil {
+		t.Fatalf("expected pruned tags[1] to be nil, got %v", tags[1])
+	}
+}
+
+func TestMarshalJSONTargetNestedStringArrayRoundTrip(t *testing.T) {
+	template := []byte(`{"rows":[["a","b"],["c"]]}`)
+	values := map[string]string{
+		"rows[0][0]": "alpha",
+		"rows[0][1]": "beta",
+		"rows[1][0]": "gamma",
+	}
+	content, err := marshalJSONTarget("/tmp/nested.json", template, values, nil)
+	if err != nil {
+		t.Fatalf("marshal nested string arrays: %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(content, &payload); err != nil {
+		t.Fatalf("decode nested payload: %v", err)
+	}
+
+	rows := payload["rows"].([]any)
+	inner := rows[0].([]any)
+	if got := inner[0]; got != "alpha" {
+		t.Fatalf("rows[0][0] mismatch: %v", got)
+	}
+	if got := inner[1]; got != "beta" {
+		t.Fatalf("rows[0][1] mismatch: %v", got)
+	}
+	outer := rows[1].([]any)
+	if got := outer[0]; got != "gamma" {
+		t.Fatalf("rows[1][0] mismatch: %v", got)
+	}
+}
+
+func TestParseJSONPathNestedArrayIndices(t *testing.T) {
+	segments, err := parseJSONPath("rows[0][1]")
+	if err != nil {
+		t.Fatalf("parse nested array path: %v", err)
+	}
+	if len(segments) != 2 || segments[0].key != "rows" || segments[0].index == nil || *segments[0].index != 0 {
+		t.Fatalf("unexpected first segment: %#v", segments)
+	}
+	if segments[1].key != "" || segments[1].index == nil || *segments[1].index != 1 {
+		t.Fatalf("unexpected second segment: %#v", segments)
+	}
+}
+
 func TestParseJSONEntriesLenientCollectsArrayStrings(t *testing.T) {
 	got, err := parseJSONEntriesLenient("/tmp/messages.json", []byte(`{
   "home": {

--- a/apps/cli/internal/i18n/runsvc/output_json_test.go
+++ b/apps/cli/internal/i18n/runsvc/output_json_test.go
@@ -354,6 +354,32 @@ func TestMarshalJSONTargetNestedStringArrayRoundTrip(t *testing.T) {
 	}
 }
 
+func TestMarshalJSONTargetGrowsNestedStringArrayRows(t *testing.T) {
+	template := []byte(`{"rows":[[]]}`)
+	values := map[string]string{"rows[0][0]": "alpha"}
+	content, err := marshalJSONTarget("/tmp/nested.json", template, values, nil)
+	if err != nil {
+		t.Fatalf("marshal nested string arrays with growth: %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(content, &payload); err != nil {
+		t.Fatalf("decode nested payload: %v", err)
+	}
+
+	rows := payload["rows"].([]any)
+	inner, ok := rows[0].([]any)
+	if !ok {
+		t.Fatalf("expected rows[0] to be an array, got %T", rows[0])
+	}
+	if len(inner) != 1 {
+		t.Fatalf("expected grown inner row length 1, got %d", len(inner))
+	}
+	if got := inner[0]; got != "alpha" {
+		t.Fatalf("rows[0][0] mismatch: %v", got)
+	}
+}
+
 func TestParseJSONPathNestedArrayIndices(t *testing.T) {
 	segments, err := parseJSONPath("rows[0][1]")
 	if err != nil {


### PR DESCRIPTION
## What changed

JSON translation flush was writing flattened array keys (for example home.steps[0].title) as literal object keys instead of updating the underlying array. This fix parses bracket-indexed path segments when applying translations, collecting entries, and pruning, so arrays round-trip with the correct structure.

## How to test

go test ./apps/cli/internal/i18n/runsvc/... -run 'TestMarshalJSONTargetPreservesObjectArrayShape|TestParseJSONEntriesLenientCollectsArrayStrings|TestSetNestedValueHandlesArrayIndexedPaths' -count=1

Then flush a JSON locale file that contains object arrays and confirm output keeps array fields (for example "steps": [{...}]) instead of "steps[0]" keys.

## Checklist

- [x] I ran relevant checks locally (make fmt, make lint, make test)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review