### PR TITLE
fix(web): add PlanetScale to trust center subprocessors

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/trust-center/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/trust-center/page.tsx
@@ -65,6 +65,12 @@ const subprocessors = [
     location: "Global infrastructure",
   },
   {
+    name: "PlanetScale",
+    purpose: "Managed PostgreSQL database hosting and persistent data storage",
+    data: "Account, organization, project, localization workflow, and application metadata stored in the platform database",
+    location: "United States",
+  },
+  {
     name: "WorkOS",
     purpose: "Authentication, session management, and organization membership",
     data: "Account identity, organization membership, and session metadata",


### PR DESCRIPTION
Document PlanetScale as the managed PostgreSQL provider on the trust center page.

## What changed

<!-- Describe the change and why it is needed. -->

## How to test

<!-- List manual checks or commands used to verify this change. -->

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [ ] This PR is scoped and ready for review
