### PR TITLE
🧪 Scout: handle parentheses in quoted Markdown link titles

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -83,3 +83,7 @@
 ## 2026-07-03 - [Heuristic Tag Identification for Parity]
 **Learning:** HTML tag parity checks must balance protecting application-specific markup (like MDX or Web Components) with allowing legitimate removal of template-style placeholders (like `<resource_id>` or `<v1>`). Aggressively treating any tag containing dots, underscores, or digits as structural markup causes false-positive mismatches when translators omit these tokens. Strong indicators of "true" markup include hyphens, colons, PascalCase (MDX), or the presence of attributes.
 **Action:** Use heuristics to distinguish markup from placeholders: treat tags as markup if they are known atoms (excluding generic placeholders like `name` and `id`), contain hyphens/colons, start with an uppercase letter, or have attributes. Avoid treating plain attribute-less tokens with dots, underscores, or digits as structural markup by default.
+
+## 2026-07-10 - [Robust Markdown Link Title Parentheses Handling]
+**Learning:** Naive depth-counting scanners for Markdown link destinations (e.g., `[](/url "title")`) fail when parentheses appear inside quoted titles (e.g., `[link](/url "title )")`). The scanner prematurely terminates the destination segment at the first unquoted closing parenthesis, leading to corrupted metadata and broken round-trips.
+**Action:** Always implement quote-aware scanning for link destinations and titles. Parentheses encountered while inside a single or double-quoted literal must be ignored by depth counters to ensure the full span of the link is correctly identified and protected.

--- a/internal/i18n/translationfileparser/markdown_parser.go
+++ b/internal/i18n/translationfileparser/markdown_parser.go
@@ -217,13 +217,24 @@ func findJSXTagEnd(line string, start int) int {
 
 func findMarkdownLinkDestinationEnd(line string, start int) int {
 	depth := 1
+	var quote byte
 	for idx := start; idx < len(line); idx++ {
-		if line[idx] == '\\' {
+		ch := line[idx]
+		if ch == '\\' {
 			idx++
 			continue
 		}
 
-		switch line[idx] {
+		if quote != 0 {
+			if ch == quote {
+				quote = 0
+			}
+			continue
+		}
+
+		switch ch {
+		case '"', '\'':
+			quote = ch
 		case '(':
 			depth++
 		case ')':

--- a/internal/i18n/translationfileparser/markdown_parser_test.go
+++ b/internal/i18n/translationfileparser/markdown_parser_test.go
@@ -184,6 +184,28 @@ func TestMarshalMarkdownPreservesLinkDestinationsWithParentheses(t *testing.T) {
 	}
 }
 
+func TestMarshalMarkdownPreservesLinkTitleWithParenthesis(t *testing.T) {
+	template := []byte("[link](/url \"title with ) paren\")\n")
+
+	entries, err := (MarkdownParser{}).Parse(template)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	updates := map[string]string{}
+	for k, v := range entries {
+		updates[k] = strings.ToUpper(v)
+	}
+
+	output := string(MarshalMarkdown(template, updates, false))
+	if !strings.Contains(output, "(/url \"title with ) paren\")") {
+		t.Fatalf("expected full link destination and title preserved, got %q", output)
+	}
+	if !strings.Contains(output, "[LINK]") {
+		t.Fatalf("expected link text translated, got %q", output)
+	}
+}
+
 func TestMarshalMarkdownPreservesDoubleBacktickInlineCode(t *testing.T) {
 	template := []byte("Use ``code with ` inside`` safely.\n")
 


### PR DESCRIPTION
💡 What: Improved Markdown link parsing to correctly handle parentheses within quoted link titles.
🎯 Why: Prevents premature truncation of link metadata and corruption during translation round-trips.
🧩 Scope: `internal/i18n/translationfileparser/markdown_parser.go` (scanner logic) and `internal/i18n/translationfileparser/markdown_parser_test.go` (regression test).
✅ Verification: Ran `go test ./...` and specifically the new test case.
🛡️ Confidence: High. The fix is targeted and verified with a regression test that fails without the change.

---
*PR created automatically by Jules for task [12102888961395847314](https://jules.google.com/task/12102888961395847314) started by @cungminh2710*