### PR TITLE
feat(web): show TMS comments inline and wire CAT approve shortcut

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
@@ -11,6 +11,7 @@ import { createProjectTestFixture } from "./project.fixture";
 import { ok } from "@/lib/primitives/result/results";
 import type {
   ProjectFileCatConcordanceResponse,
+  ProjectFileCatCommentResponse,
   ProjectFileCatRecommendationResponse,
   ProjectFileCatResponse,
   ProjectFileCatTranslationResponse,
@@ -20,6 +21,7 @@ const {
   getTmsProviderConnectionMock,
   getTmsProviderLiveCatFileMock,
   saveTmsProviderLiveCatTranslationMock,
+  saveTmsProviderLiveCatCommentMock,
   loadCatSegmentConcordanceMock,
   generateCatAiRecommendationMock,
   ensureOrganizationProjectRecordMock,
@@ -27,6 +29,7 @@ const {
   getTmsProviderConnectionMock: vi.fn(),
   getTmsProviderLiveCatFileMock: vi.fn(),
   saveTmsProviderLiveCatTranslationMock: vi.fn(),
+  saveTmsProviderLiveCatCommentMock: vi.fn(),
   loadCatSegmentConcordanceMock: vi.fn(),
   generateCatAiRecommendationMock: vi.fn(),
   ensureOrganizationProjectRecordMock: vi.fn(),
@@ -53,6 +56,8 @@ vi.mock("@/lib/providers/tms-provider-live", async (importOriginal) => {
     getTmsProviderLiveCatFile: (...args: unknown[]) => getTmsProviderLiveCatFileMock(...args),
     saveTmsProviderLiveCatTranslation: (...args: unknown[]) =>
       saveTmsProviderLiveCatTranslationMock(...args),
+    saveTmsProviderLiveCatComment: (...args: unknown[]) =>
+      saveTmsProviderLiveCatCommentMock(...args),
   };
 });
 
@@ -528,5 +533,82 @@ describe("project file CAT routes", () => {
 
     expect(response.status).toBe(403);
     expect(saveTmsProviderLiveCatTranslationMock).not.toHaveBeenCalled();
+  });
+
+  it("posts Crowdin CAT comments for users with write-back permission", async () => {
+    const translator = projectFixture.createWorkosIdentityWithRole("translator");
+    saveTmsProviderLiveCatCommentMock.mockResolvedValue({
+      externalCommentId: "5001",
+      type: "comment",
+      status: null,
+      text: "Please clarify tone.",
+      createdAt: "2026-06-19T00:00:00.000Z",
+      locale: "fr",
+      author: "Reviewer",
+    });
+
+    const response = await client.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].files.detail.cat.comments.$post(
+      {
+        param: {
+          organizationSlug: translator.organization.slug ?? "missing-slug",
+          projectId: "ext:crowdin:42",
+        },
+        json: {
+          sourcePath: "crowdin/home.json",
+          targetLocale: "fr",
+          externalStringId: "1001",
+          externalResourceId: "101",
+          text: "Please clarify tone.",
+        },
+      },
+      { headers: await projectFixture.authHeadersFor(translator) },
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as ProjectFileCatCommentResponse;
+    expect(body.comment).toMatchObject({
+      externalCommentId: "5001",
+      text: "Please clarify tone.",
+    });
+    expect(saveTmsProviderLiveCatCommentMock).toHaveBeenCalledWith(
+      expect.any(String),
+      "42",
+      "crowdin/home.json",
+      {
+        targetLocale: "fr",
+        externalStringId: "1001",
+        externalResourceId: "101",
+        text: "Please clarify tone.",
+        type: undefined,
+      },
+      expect.objectContaining({ actorUserId: expect.any(String) }),
+    );
+  });
+
+  it("denies CAT comment posts without write-back permission", async () => {
+    const member = projectFixture.createWorkosIdentityWithRole("member");
+
+    const response = await client.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].files.detail.cat.comments.$post(
+      {
+        param: {
+          organizationSlug: member.organization.slug ?? "missing-slug",
+          projectId: "ext:crowdin:42",
+        },
+        json: {
+          sourcePath: "crowdin/home.json",
+          targetLocale: "fr",
+          externalStringId: "1001",
+          text: "Please clarify tone.",
+        },
+      },
+      { headers: await projectFixture.authHeadersFor(member) },
+    );
+
+    expect(response.status).toBe(403);
+    expect(saveTmsProviderLiveCatCommentMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -19,6 +19,7 @@ import {
   getTmsProviderLiveProject,
   listTmsProviderLiveFilesForProject,
   saveTmsProviderLiveCatTranslation,
+  saveTmsProviderLiveCatComment,
 } from "@/lib/providers/tms-provider-live";
 import { listOrganizationProjects } from "@/lib/projects/organization/organization-project-service";
 import {
@@ -46,6 +47,7 @@ import {
   maxProjectFileUploadBytes,
   projectFileCatQuerySchema,
   projectFileCatConcordanceBodySchema,
+  projectFileCatCommentBodySchema,
   projectFileCatRecommendationBodySchema,
   projectFileCatStatusBodySchema,
   projectFileCatTranslationBodySchema,
@@ -336,6 +338,16 @@ const validateProjectFileCatTranslationBody = validator("json", (value, c) => {
   return parsed.data;
 });
 
+const validateProjectFileCatCommentBody = validator("json", (value, c) => {
+  const parsed = projectFileCatCommentBodySchema.safeParse(value);
+
+  if (!parsed.success) {
+    return invalidProjectPayloadResponse(c);
+  }
+
+  return parsed.data;
+});
+
 const validateProjectFileCatConcordanceBody = validator("json", (value, c) => {
   const parsed = projectFileCatConcordanceBodySchema.safeParse(value);
 
@@ -608,6 +620,54 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
           }
 
           return c.json({ translation }, 200);
+        } catch (error) {
+          return tmsProviderLiveErrorResponse(c, error);
+        }
+      },
+    )
+    .post(
+      "/:projectId/files/detail/cat/comments",
+      validateProjectParams,
+      validateProjectFileCatCommentBody,
+      async (c) => {
+        if (!isWriteBackTranslationAllowed(c.var.auth.membership.role)) {
+          return forbiddenResponse(c);
+        }
+
+        const params = c.req.valid("param");
+        const body = c.req.valid("json");
+        const target = await resolveProjectResourceTarget(c.var.auth, params.projectId);
+        if (target.kind === "provider_unavailable") {
+          return providerProjectUnavailableResponse(c, target);
+        }
+
+        if (target.kind !== "provider") {
+          return badRequestResponse(
+            c,
+            "provider_cat_unsupported",
+            "CAT comments are only available for provider-connected projects.",
+          );
+        }
+
+        try {
+          const comment = await saveTmsProviderLiveCatComment(
+            c.var.auth.organization.localOrganizationId,
+            target.externalProjectId,
+            body.sourcePath,
+            {
+              targetLocale: body.targetLocale,
+              externalStringId: body.externalStringId,
+              externalResourceId: body.externalResourceId,
+              text: body.text,
+              type: body.type,
+            },
+            { actorUserId: c.var.auth.user.localUserId },
+          );
+          if (!comment) {
+            return projectNotFoundResponse(c);
+          }
+
+          return c.json({ comment }, 200);
         } catch (error) {
           return tmsProviderLiveErrorResponse(c, error);
         }

--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -444,6 +444,20 @@ export const projectFileCatCommentSchema = z.object({
   text: z.string(),
   createdAt: z.string(),
   locale: z.string().nullable(),
+  author: z.string().nullable().optional(),
+});
+
+export const projectFileCatCommentBodySchema = z.object({
+  sourcePath: z.string().trim().min(1).max(2048),
+  targetLocale: z.string().trim().min(1).max(32),
+  externalStringId: z.string().trim().min(1).max(128),
+  externalResourceId: z.string().trim().min(1).max(128).optional(),
+  text: z.string().trim().min(1).max(16_384),
+  type: z.enum(["comment", "issue"]).optional(),
+});
+
+export const projectFileCatCommentResponseSchema = z.object({
+  comment: projectFileCatCommentSchema,
 });
 
 export const projectFileCatTranslationSchema = z.object({
@@ -512,6 +526,8 @@ export type ProjectFileJobRecord = z.infer<typeof projectFileJobRecordSchema>;
 export type ProjectFileProviderJobRecord = z.infer<typeof projectFileProviderJobRecordSchema>;
 export type ProjectFileDetailResponse = z.infer<typeof projectFileDetailResponseSchema>;
 export type ProjectFileCatComment = z.infer<typeof projectFileCatCommentSchema>;
+export type ProjectFileCatCommentBody = z.infer<typeof projectFileCatCommentBodySchema>;
+export type ProjectFileCatCommentResponse = z.infer<typeof projectFileCatCommentResponseSchema>;
 export type ProjectFileCatTranslation = z.infer<typeof projectFileCatTranslationSchema>;
 export type ProjectFileCatSegment = z.infer<typeof projectFileCatSegmentSchema>;
 export type ProjectFileCatResponse = z.infer<typeof projectFileCatResponseSchema>;

--- a/apps/hyperlocalise-web/src/components/cat/cat-editor-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-editor-panel.tsx
@@ -4,8 +4,9 @@ import { useMemo, useState } from "react";
 import { ArrowLeft01Icon, ArrowRight01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useHotkeys } from "react-hotkeys-hook";
-import { FormattedMessage, useIntl } from "react-intl";
+import { FormattedMessage, useIntl, type IntlShape } from "react-intl";
 
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Kbd, KbdGroup } from "@/components/ui/kbd";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -31,11 +32,19 @@ function ShortcutKbd({ keys, className }: { keys: string[]; className?: string }
   );
 }
 
-interface CatEditorComment {
-  id: string;
-  author: string;
-  createdAtLabel: string;
-  body: string;
+function formatCommentTimestamp(intl: IntlShape, createdAt: string) {
+  const parsed = Date.parse(createdAt);
+  if (Number.isNaN(parsed)) {
+    return createdAt;
+  }
+
+  return intl.formatDate(parsed, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
 }
 
 export function CatEditorPanel({
@@ -50,11 +59,15 @@ export function CatEditorPanel({
   isAiSuggestionLoading = false,
   isFormatChecksLoading = false,
   canApprove = true,
+  canAddComment = false,
   canLookupContext = false,
   canUseAiRecommendation = false,
+  isPostingComment = false,
+  commentPostError,
   onTargetChange,
   onUseAiSuggestion,
   onApprove,
+  onAddComment,
   primaryActionLabel,
   onAskQuestion,
   onGenerateAiRecommendation,
@@ -75,11 +88,15 @@ export function CatEditorPanel({
   isAiSuggestionLoading?: boolean;
   isFormatChecksLoading?: boolean;
   canApprove?: boolean;
+  canAddComment?: boolean;
   canLookupContext?: boolean;
   canUseAiRecommendation?: boolean;
+  isPostingComment?: boolean;
+  commentPostError?: string;
   onTargetChange: (value: string) => void;
   onUseAiSuggestion: () => void;
   onApprove: () => void;
+  onAddComment?: (text: string) => void | Promise<void>;
   primaryActionLabel?: string;
   onAskQuestion: () => void;
   onGenerateAiRecommendation?: () => void;
@@ -93,12 +110,12 @@ export function CatEditorPanel({
   const resolvedPrimaryActionLabel =
     primaryActionLabel ?? intl.formatMessage(catEditorPanelMessages.approve);
   const [commentDrafts, setCommentDrafts] = useState<Record<string, string>>({});
-  const [commentsBySegmentId, setCommentsBySegmentId] = useState<
-    Record<string, CatEditorComment[]>
-  >({});
   const commentDraft = commentDrafts[segment.id] ?? "";
-  const segmentComments = commentsBySegmentId[segment.id] ?? [];
+  const segmentComments = segment.comments ?? [];
   const trimmedCommentDraft = commentDraft.trim();
+  const isActionBlocked =
+    isApproving || isLookingUpContext || isAiSuggestionLoading || isFormatChecksLoading;
+  const canTriggerApprove = canApprove && !isActionBlocked;
   const sourceMessageAnalysis = useMemo(
     () => analyzeCatMessageFormat(segment.sourceText),
     [segment.sourceText],
@@ -132,31 +149,35 @@ export function CatEditorPanel({
     [hasNextSegment, onNext],
   );
 
+  useHotkeys(
+    "mod+enter",
+    (event) => {
+      const activeElement = document.activeElement;
+      if (activeElement instanceof HTMLElement && activeElement.dataset.catCommentInput === "true") {
+        return;
+      }
+
+      event.preventDefault();
+      onApprove();
+    },
+    {
+      enabled: canTriggerApprove,
+      enableOnFormTags: true,
+      preventDefault: true,
+    },
+    [canTriggerApprove, onApprove],
+  );
+
   function handleCommentDraftChange(value: string) {
     setCommentDrafts((current) => ({ ...current, [segment.id]: value }));
   }
 
-  function handleAddComment() {
-    if (!trimmedCommentDraft) {
+  async function handleAddComment() {
+    if (!trimmedCommentDraft || !onAddComment || isPostingComment) {
       return;
     }
 
-    setCommentsBySegmentId((current) => {
-      const currentComments = current[segment.id] ?? [];
-      const commentNumber = currentComments.length + 1;
-      return {
-        ...current,
-        [segment.id]: [
-          ...currentComments,
-          {
-            id: `${segment.id}-comment-${commentNumber}`,
-            author: intl.formatMessage(catEditorPanelMessages.commentAuthorReviewer),
-            createdAtLabel: intl.formatMessage(catEditorPanelMessages.commentCreatedJustNow),
-            body: trimmedCommentDraft,
-          },
-        ],
-      };
-    });
+    await onAddComment(trimmedCommentDraft);
     handleCommentDraftChange("");
   }
 
@@ -229,13 +250,7 @@ export function CatEditorPanel({
             <Button
               className="min-h-11 flex-1 bg-grove-500 text-white hover:bg-grove-400 sm:flex-none lg:min-h-0"
               onClick={onApprove}
-              disabled={
-                !canApprove ||
-                isApproving ||
-                isLookingUpContext ||
-                isAiSuggestionLoading ||
-                isFormatChecksLoading
-              }
+              disabled={!canTriggerApprove}
             >
               {isApproving ? <Spinner className="size-4 text-white" /> : null}
               {resolvedPrimaryActionLabel}
@@ -393,12 +408,23 @@ export function CatEditorPanel({
             {segmentComments.length > 0 ? (
               <ul className="space-y-3">
                 {segmentComments.map((comment) => (
-                  <li key={comment.id} className="space-y-1">
-                    <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                      <span className="font-medium text-foreground/78">{comment.author}</span>
-                      <span>{comment.createdAtLabel}</span>
+                  <li
+                    key={comment.id}
+                    className="space-y-1 rounded-lg border border-foreground/8 p-3"
+                  >
+                    <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                      {comment.type === "issue" ? (
+                        <Badge variant="outline" className="border-flame-200/40 text-flame-100">
+                          <FormattedMessage {...catEditorPanelMessages.commentIssueLabel} />
+                        </Badge>
+                      ) : null}
+                      {comment.author ? (
+                        <span className="font-medium text-foreground/78">{comment.author}</span>
+                      ) : null}
+                      <span>{formatCommentTimestamp(intl, comment.createdAt)}</span>
+                      {comment.status ? <span className="capitalize">{comment.status}</span> : null}
                     </div>
-                    <p className="text-sm leading-relaxed text-foreground/88">{comment.body}</p>
+                    <p className="text-sm leading-relaxed text-foreground/88">{comment.text}</p>
                   </li>
                 ))}
               </ul>
@@ -412,15 +438,25 @@ export function CatEditorPanel({
               onChange={(event) => handleCommentDraftChange(event.currentTarget.value)}
               className="min-h-20 resize-y rounded-xl border-foreground/12 bg-background px-3 py-3 text-sm leading-relaxed"
               placeholder={intl.formatMessage(catEditorPanelMessages.commentPlaceholder)}
+              disabled={!canAddComment || isPostingComment}
+              data-cat-comment-input="true"
             />
+            {commentPostError ? <p className="text-sm text-flame-100">{commentPostError}</p> : null}
             <div className="flex justify-end">
               <Button
                 variant="ghost"
                 size="sm"
-                onClick={handleAddComment}
-                disabled={!trimmedCommentDraft}
+                onClick={() => void handleAddComment()}
+                disabled={
+                  !canAddComment || !trimmedCommentDraft || isPostingComment || !onAddComment
+                }
               >
-                <FormattedMessage {...catEditorPanelMessages.addComment} />
+                {isPostingComment ? <Spinner className="size-4" /> : null}
+                {isPostingComment ? (
+                  <FormattedMessage {...catEditorPanelMessages.postingComment} />
+                ) : (
+                  <FormattedMessage {...catEditorPanelMessages.addComment} />
+                )}
               </Button>
             </div>
           </section>

--- a/apps/hyperlocalise-web/src/components/cat/cat-editor-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-editor-panel.tsx
@@ -114,7 +114,11 @@ export function CatEditorPanel({
   const segmentComments = segment.comments ?? [];
   const trimmedCommentDraft = commentDraft.trim();
   const isActionBlocked =
-    isApproving || isLookingUpContext || isAiSuggestionLoading || isFormatChecksLoading;
+    isApproving ||
+    isPostingComment ||
+    isLookingUpContext ||
+    isAiSuggestionLoading ||
+    isFormatChecksLoading;
   const canTriggerApprove = canApprove && !isActionBlocked;
   const sourceMessageAnalysis = useMemo(
     () => analyzeCatMessageFormat(segment.sourceText),

--- a/apps/hyperlocalise-web/src/components/cat/cat-editor-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-editor-panel.tsx
@@ -153,7 +153,10 @@ export function CatEditorPanel({
     "mod+enter",
     (event) => {
       const activeElement = document.activeElement;
-      if (activeElement instanceof HTMLElement && activeElement.dataset.catCommentInput === "true") {
+      if (
+        activeElement instanceof HTMLElement &&
+        activeElement.dataset.catCommentInput === "true"
+      ) {
         return;
       }
 

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
@@ -14,7 +14,7 @@ import type {
   PartialCatWorkspaceDependencies,
 } from "./dependencies";
 import { CatWorkspaceView } from "./cat-workspace";
-import { catWorkspaceContainerMessages } from "./cat.messages";
+import { catEditorPanelMessages, catWorkspaceContainerMessages } from "./cat.messages";
 import type { CatFormatCheck, CatSegment, CatWorkspaceState } from "./types";
 
 function getSegmentQueueIndex(segments: CatSegment[], segmentIdOrKey: string) {
@@ -242,6 +242,8 @@ export function CatWorkspaceContainer({
   const [state, setState] = useState(initialState);
   const [isValidating, setIsValidating] = useState(false);
   const [isApproving, setIsApproving] = useState(false);
+  const [isPostingComment, setIsPostingComment] = useState(false);
+  const [commentPostError, setCommentPostError] = useState<string | undefined>();
   const [isLookingUpContext, setIsLookingUpContext] = useState(false);
   const [isLoadingConcordance, setIsLoadingConcordance] = useState(false);
   const [revealedAgentContextSegmentIds, setRevealedAgentContextSegmentIds] = useState<
@@ -268,6 +270,7 @@ export function CatWorkspaceContainer({
   const onTargetChange = editingOverrides?.onTargetChange;
   const onUseAiSuggestion = editingOverrides?.onUseAiSuggestion;
   const onApprove = reviewOverrides?.onApprove;
+  const onAddComment = reviewOverrides?.onAddComment;
   const onAskQuestion = reviewOverrides?.onAskQuestion;
   const onReviewWithAi = reviewOverrides?.onReviewWithAi;
   const onSkip = reviewOverrides?.onSkip;
@@ -286,6 +289,10 @@ export function CatWorkspaceContainer({
       return new Set([...current, ...next]);
     });
   }, [initialState]);
+
+  useEffect(() => {
+    setCommentPostError(undefined);
+  }, [state.selectedSegmentId]);
 
   const runSegmentChecks = useCallback(
     async (segment: CatSegment, value: string) => {
@@ -626,6 +633,26 @@ export function CatWorkspaceContainer({
           setIsApproving(false);
         }
       },
+      onAddComment: async (segmentId: string, text: string) => {
+        if (!onAddComment) {
+          return;
+        }
+
+        setCommentPostError(undefined);
+        setIsPostingComment(true);
+        try {
+          await onAddComment(segmentId, text);
+        } catch (error) {
+          const message =
+            error instanceof Error
+              ? error.message
+              : intl.formatMessage(catEditorPanelMessages.commentPostFailed);
+          setCommentPostError(message);
+          throw error;
+        } finally {
+          setIsPostingComment(false);
+        }
+      },
       onAskQuestion: async (segmentId: string) => {
         await onAskQuestion?.(segmentId);
         if (!lookupSegmentContext) {
@@ -729,6 +756,7 @@ export function CatWorkspaceContainer({
     };
   }, [
     onApprove,
+    onAddComment,
     onAskQuestion,
     intl,
     onNextSegment,
@@ -752,6 +780,8 @@ export function CatWorkspaceContainer({
       dependencies={dependencies}
       isValidating={isValidating}
       isApproving={isApproving}
+      isPostingComment={isPostingComment}
+      commentPostError={commentPostError}
       isLookingUpContext={isLookingUpContext}
       isConcordanceLoading={isLoadingConcordance}
       isAiSuggestionLoading={isGeneratingAiRecommendation && canUseAiRecommendation}

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace.tsx
@@ -41,6 +41,8 @@ export function CatWorkspaceView({
   dependencies,
   isValidating: _isValidating = false,
   isApproving = false,
+  isPostingComment = false,
+  commentPostError,
   isLookingUpContext = false,
   isConcordanceLoading = false,
   isAiSuggestionLoading = false,
@@ -96,6 +98,7 @@ export function CatWorkspaceView({
   )?.message;
   const isEditorBusy = isApproving;
   const canApprove = state.canEditTranslations !== false;
+  const canAddComment = state.canAddComments === true;
 
   function renderEditorPanel() {
     return (
@@ -110,12 +113,20 @@ export function CatWorkspaceView({
         isLookingUpContext={isLookingUpContext}
         isAiSuggestionLoading={isAiSuggestionLoading}
         isFormatChecksLoading={isFormatChecksLoading}
+        isPostingComment={isPostingComment}
+        commentPostError={commentPostError}
         canApprove={canApprove}
+        canAddComment={canAddComment}
         canLookupContext={canLookupContext}
         canUseAiRecommendation={canUseAiRecommendation}
         onTargetChange={(value) => editing.onTargetChange(selectedSegment.id, value)}
         onUseAiSuggestion={() => editing.onUseAiSuggestion(selectedSegment.id)}
         onApprove={() => void review.onApprove(selectedSegment.id, selectedSegment.targetText)}
+        onAddComment={
+          review.onAddComment
+            ? (text) => review.onAddComment?.(selectedSegment.id, text)
+            : undefined
+        }
         primaryActionLabel={state.primaryActionLabel}
         onAskQuestion={() => review.onAskQuestion(selectedSegment.id)}
         onGenerateAiRecommendation={

--- a/apps/hyperlocalise-web/src/components/cat/cat.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat.messages.ts
@@ -462,4 +462,19 @@ export const catEditorPanelMessages = defineMessages({
     id: "LOKE6DdX5z",
     description: "Timestamp label for a comment added moments ago",
   },
+  commentIssueLabel: {
+    defaultMessage: "Issue",
+    id: "rfurrkqR11",
+    description: "Badge label for an unresolved TMS issue on a segment",
+  },
+  commentPostFailed: {
+    defaultMessage: "Failed to post comment. Try again.",
+    id: "wAW00AgfLK",
+    description: "Error message when posting a segment comment to the TMS fails",
+  },
+  postingComment: {
+    defaultMessage: "Posting…",
+    id: "j+ggKPYEzH",
+    description: "Button label while a segment comment is being posted to the TMS",
+  },
 });

--- a/apps/hyperlocalise-web/src/components/cat/dependencies.ts
+++ b/apps/hyperlocalise-web/src/components/cat/dependencies.ts
@@ -36,6 +36,7 @@ export interface CatWorkspaceReview {
     segmentId: string,
     targetText: string,
   ) => void | CatSegmentStatus | Promise<void | CatSegmentStatus>;
+  onAddComment?: (segmentId: string, text: string) => void | Promise<void>;
   onAskQuestion: (segmentId: string) => void | Promise<void>;
   onReviewWithAi: (segmentId: string) => void | Promise<void>;
   onSkip: (segmentId: string) => void;
@@ -72,6 +73,8 @@ export interface CatWorkspaceViewProps {
   dependencies: CatWorkspaceDependencies;
   isValidating?: boolean;
   isApproving?: boolean;
+  isPostingComment?: boolean;
+  commentPostError?: string;
   isLookingUpContext?: boolean;
   isConcordanceLoading?: boolean;
   isAiSuggestionLoading?: boolean;

--- a/apps/hyperlocalise-web/src/components/cat/project-file-cat-mapper.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file-cat-mapper.test.ts
@@ -79,6 +79,17 @@ describe("projectFileCatToWorkspaceState", () => {
       id: "issue-string",
       status: "needs_review",
       tags: ["icu", "1 comment", "1 issue"],
+      comments: [
+        {
+          id: "comment-1",
+          type: "issue",
+          status: "unresolved",
+          text: "Needs product context",
+          createdAt: "2026-06-10T00:00:00.000Z",
+          locale: "vi",
+          author: null,
+        },
+      ],
     });
   });
 

--- a/apps/hyperlocalise-web/src/components/cat/project-file-cat-mapper.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file-cat-mapper.ts
@@ -22,17 +22,15 @@ import type {
 type CatFile = ProjectFileCatResponse["catFile"];
 
 function mapSegmentComments(segment: ProjectFileCatSegment): CatSegmentComment[] {
-  return segment.comments
-    .toSorted((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
-    .map((comment) => ({
-      id: comment.externalCommentId,
-      type: comment.type,
-      status: comment.status,
-      text: comment.text,
-      createdAt: comment.createdAt,
-      locale: comment.locale,
-      author: comment.author ?? null,
-    }));
+  return segment.comments.map((comment) => ({
+    id: comment.externalCommentId,
+    type: comment.type,
+    status: comment.status,
+    text: comment.text,
+    createdAt: comment.createdAt,
+    locale: comment.locale,
+    author: comment.author ?? null,
+  }));
 }
 
 export function segmentStatusFor(segment: ProjectFileCatSegment): CatSegment["status"] {
@@ -235,7 +233,7 @@ export function projectFileCatToWorkspaceState(
     breadcrumbs: [catFile.provider?.kind ?? "native", catFile.filename, catFile.targetLocale],
     primaryActionLabel: catFile.provider ? "Save to provider" : "Save translation",
     canEditTranslations: catFile.canEditTranslations,
-    canAddComments: Boolean(catFile.provider && catFile.canEditTranslations),
+    canAddComments: Boolean(catFile.provider?.kind === "crowdin" && catFile.canEditTranslations),
   };
 }
 

--- a/apps/hyperlocalise-web/src/components/cat/project-file-cat-mapper.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file-cat-mapper.ts
@@ -14,11 +14,26 @@ import {
 import type {
   CatFormatCheck,
   CatSegment,
+  CatSegmentComment,
   CatSegmentIntelligence,
   CatWorkspaceState,
 } from "@/components/cat/types";
 
 type CatFile = ProjectFileCatResponse["catFile"];
+
+function mapSegmentComments(segment: ProjectFileCatSegment): CatSegmentComment[] {
+  return segment.comments
+    .toSorted((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+    .map((comment) => ({
+      id: comment.externalCommentId,
+      type: comment.type,
+      status: comment.status,
+      text: comment.text,
+      createdAt: comment.createdAt,
+      locale: comment.locale,
+      author: comment.author ?? null,
+    }));
+}
 
 export function segmentStatusFor(segment: ProjectFileCatSegment): CatSegment["status"] {
   if (segment.target?.isApproved) {
@@ -196,6 +211,7 @@ export function projectFileCatToWorkspaceState(
       contextLabel: segment.context ?? undefined,
       status: segmentStatusFor(segment),
       tags,
+      comments: mapSegmentComments(segment),
     };
   });
 
@@ -219,6 +235,7 @@ export function projectFileCatToWorkspaceState(
     breadcrumbs: [catFile.provider?.kind ?? "native", catFile.filename, catFile.targetLocale],
     primaryActionLabel: catFile.provider ? "Save to provider" : "Save translation",
     canEditTranslations: catFile.canEditTranslations,
+    canAddComments: Boolean(catFile.provider && catFile.canEditTranslations),
   };
 }
 

--- a/apps/hyperlocalise-web/src/components/cat/project-file-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/project-file-cat-workspace.tsx
@@ -7,6 +7,7 @@ import { useIntl } from "react-intl";
 
 import type {
   ProjectFileCatConcordanceResponse,
+  ProjectFileCatComment,
   ProjectFileCatRecommendationResponse,
   ProjectFileCatTranslation,
 } from "@/api/routes/project/project.schema";
@@ -138,6 +139,38 @@ export function ProjectFileCatWorkspace({
   });
   const saveTranslation = saveMutation.mutateAsync;
 
+  const commentMutation = useMutation({
+    mutationFn: async (input: { externalStringId: string; text: string }) => {
+      const externalResourceId = catQuery.data?.provider
+        ? requireProviderExternalResourceId(catQuery.data)
+        : undefined;
+
+      const response = await apiClient.api.orgs[":organizationSlug"].projects[
+        ":projectId"
+      ].files.detail.cat.comments.$post({
+        param: { organizationSlug, projectId },
+        json: {
+          sourcePath,
+          targetLocale,
+          externalStringId: input.externalStringId,
+          externalResourceId,
+          text: input.text,
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(await readApiError(response, "Failed to post comment"));
+      }
+
+      const body = (await response.json()) as { comment: ProjectFileCatComment };
+      return body.comment;
+    },
+    onSuccess: async () => {
+      await invalidateCurrentPage();
+    },
+  });
+  const postComment = commentMutation.mutateAsync;
+
   const workspaceState = useMemo(
     () => (catQuery.data ? projectFileCatToWorkspaceState(catQuery.data, intl) : null),
     [catQuery.data, intl],
@@ -161,6 +194,20 @@ export function ProjectFileCatWorkspace({
       return translation.isApproved ? "reviewed" : "needs_review";
     },
     [catQuery.data?.canEditTranslations, saveTranslation],
+  );
+
+  const handleAddComment = useCallback(
+    async (segmentId: string, text: string) => {
+      if (!catQuery.data?.canEditTranslations) {
+        throw new Error("Your role cannot post comments to the provider.");
+      }
+
+      await postComment({
+        externalStringId: segmentId,
+        text,
+      });
+    },
+    [catQuery.data?.canEditTranslations, postComment],
   );
 
   const lookupSegmentContext = useCallback(
@@ -346,6 +393,7 @@ export function ProjectFileCatWorkspace({
         }}
         review={{
           onApprove: handleApprove,
+          onAddComment: handleAddComment,
         }}
         queueSearch={search}
         onQueueSearchChange={setSearch}

--- a/apps/hyperlocalise-web/src/components/cat/types.ts
+++ b/apps/hyperlocalise-web/src/components/cat/types.ts
@@ -6,6 +6,18 @@ export type CatRiskLevel = "low" | "medium" | "high" | "good";
 
 export type CatFormatCheckStatus = "pass" | "warn" | "fail";
 
+export type CatSegmentCommentType = "comment" | "issue";
+
+export interface CatSegmentComment {
+  id: string;
+  type: CatSegmentCommentType;
+  status: string | null;
+  text: string;
+  createdAt: string;
+  locale: string | null;
+  author?: string | null;
+}
+
 export interface CatSegment {
   id: string;
   index: number;
@@ -18,6 +30,7 @@ export interface CatSegment {
   status: CatSegmentStatus;
   tags?: string[];
   maxLength?: number;
+  comments?: CatSegmentComment[];
 }
 
 export interface CatSuggestion {
@@ -88,4 +101,5 @@ export interface CatWorkspaceState {
   breadcrumbs?: string[];
   primaryActionLabel?: string;
   canEditTranslations?: boolean;
+  canAddComments?: boolean;
 }

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
@@ -1,6 +1,7 @@
 import { createLogger } from "@/lib/log";
 import { schema } from "@/lib/database";
 import type {
+  ProjectFileCatComment,
   ProjectFileCatResponse,
   ProjectFileCatTranslation,
   ProjectFileContent,
@@ -1018,14 +1019,7 @@ async function buildCrowdinLiveCatFile(input: {
             : null,
           comments: (commentsByStringId.get(sourceString.id) ?? [])
             .toSorted((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
-            .map((comment) => ({
-              externalCommentId: String(comment.id),
-              type: comment.type === "issue" ? ("issue" as const) : ("comment" as const),
-              status: comment.issueStatus ?? null,
-              text: comment.text,
-              createdAt: comment.createdAt,
-              locale: comment.languageId || null,
-            })),
+            .map((comment) => mapCrowdinStringComment(comment)),
         };
       }),
     };
@@ -1094,6 +1088,58 @@ async function saveCrowdinLiveCatTranslation(input: {
       externalTranslationId: translationId != null ? String(translationId) : null,
       isApproved: false,
     };
+  } catch (error) {
+    if (error instanceof CrowdinApiError && error.status === 401) {
+      throw new TmsProviderLiveError("crowdin_auth_invalid", "Crowdin credentials are invalid.");
+    }
+
+    throw error;
+  }
+}
+
+function mapCrowdinStringComment(comment: CrowdinStringComment): ProjectFileCatComment {
+  return {
+    externalCommentId: String(comment.id),
+    type: comment.type === "issue" ? "issue" : "comment",
+    status: comment.issueStatus ?? null,
+    text: comment.text,
+    createdAt: comment.createdAt,
+    locale: comment.languageId || null,
+    author: comment.user?.fullName ?? comment.user?.username ?? null,
+  };
+}
+
+async function saveCrowdinLiveCatComment(input: {
+  context: ActiveTmsProviderContext;
+  file: TmsProviderLiveFile;
+  targetLocale: string;
+  externalStringId: string;
+  text: string;
+  type?: "comment" | "issue";
+}): Promise<ProjectFileCatComment> {
+  const projectId = Number(input.file.provider?.externalProjectId);
+  const stringId = Number(input.externalStringId);
+  if (Number.isNaN(projectId) || Number.isNaN(stringId)) {
+    throw new TmsProviderLiveError(
+      "invalid_crowdin_project_or_string_id",
+      "Crowdin project or string identifier is invalid.",
+    );
+  }
+
+  const client = new CrowdinApiClient({
+    token: input.context.secretMaterial,
+    baseUrl: input.context.credential.baseUrl ?? undefined,
+  });
+
+  try {
+    const created = await client.addStringComment(projectId, {
+      text: input.text,
+      stringId,
+      targetLanguageId: input.targetLocale,
+      type: input.type ?? "comment",
+    });
+
+    return mapCrowdinStringComment(created);
   } catch (error) {
     if (error instanceof CrowdinApiError && error.status === 401) {
       throw new TmsProviderLiveError("crowdin_auth_invalid", "Crowdin credentials are invalid.");
@@ -1580,6 +1626,60 @@ export async function saveTmsProviderLiveCatTranslation(
     targetLocale: input.targetLocale,
     externalStringId: input.externalStringId,
     text: input.text,
+  });
+}
+
+export async function saveTmsProviderLiveCatComment(
+  organizationId: string,
+  externalProjectId: string,
+  sourcePath: string,
+  input: {
+    targetLocale: string;
+    externalStringId: string;
+    text: string;
+    externalResourceId?: string | null;
+    type?: "comment" | "issue";
+  },
+  options?: { actorUserId?: string | null },
+): Promise<ProjectFileCatComment | null> {
+  const context = await loadActiveTmsProviderContext(organizationId, {
+    actorUserId: options?.actorUserId,
+  });
+  const file =
+    input.externalResourceId && context.providerKind === "crowdin"
+      ? mapLiveFile({
+          providerKind: context.providerKind,
+          externalProjectId,
+          file: {
+            resourceType: "file",
+            externalResourceId: input.externalResourceId,
+            sourcePath,
+          },
+        })
+      : (
+          await listTmsProviderLiveFilesForProject(organizationId, externalProjectId, {
+            context,
+            limit: 1000,
+          })
+        ).find((item) => item.sourcePath === sourcePath);
+  if (!file) {
+    return null;
+  }
+
+  if (context.providerKind !== "crowdin" || file.provider?.resourceType !== "file") {
+    throw new TmsProviderLiveError(
+      "provider_cat_unsupported",
+      "CAT comments are not available for this provider file yet.",
+    );
+  }
+
+  return saveCrowdinLiveCatComment({
+    context,
+    file,
+    targetLocale: input.targetLocale,
+    externalStringId: input.externalStringId,
+    text: input.text,
+    type: input.type,
   });
 }
 


### PR DESCRIPTION
## What changed

CAT editor comments were local-only React state and disappeared on navigation, while Crowdin/Lokalise provider comments were only summarized in intelligence—not shown as a thread. The Approve button advertised ⌘↵ but no handler was registered.

This PR:
- Maps provider comments onto each `CatSegment` and renders them inline with issue badges, author, and timestamps
- Adds `POST …/files/detail/cat/comments` to post reviewer comments back to Crowdin
- Wires `mod+enter` to approve (works in the target editor; skipped when focus is in the comment field)

## How to test

1. Open a Crowdin-connected project file in the CAT workspace as a user with write-back permission.
2. Select a segment with existing Crowdin comments/issues and confirm they appear in the Comments section.
3. Add a new comment and confirm it posts to Crowdin and reappears after refresh.
4. Edit a target translation and press ⌘↵ (or Ctrl+Enter) to approve and advance to the next segment.
5. Run `cd apps/hyperlocalise-web && vp test src/components/cat/project-file-cat-mapper.test.ts src/api/routes/project/project-cat.route.test.ts`
6. Run `cd apps/hyperlocalise-web && vp check --fix`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)