### PR TITLE
feat(web): improve CAT translation assistance UX

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
@@ -204,7 +204,6 @@ describe("project file CAT routes", () => {
       expect.objectContaining({
         projectId: "ext:crowdin:42",
         providerKind: "crowdin",
-        externalProjectId: "42",
         sourceLocale: "en",
         targetLocale: "fr",
         sourceText: "Hello workspace",

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -697,7 +697,6 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
             organizationId: c.var.auth.organization.localOrganizationId,
             projectId: params.projectId,
             providerKind: target.kind === "provider" ? target.providerKind : null,
-            externalProjectId: target.kind === "provider" ? target.externalProjectId : null,
             sourceLocale: body.sourceLocale,
             targetLocale: body.targetLocale,
             sourceText: body.sourceText,

--- a/apps/hyperlocalise-web/src/components/cat/cat-dirty-state.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat-dirty-state.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  buildSavedTargetTextMap,
+  collectDirtySegmentIds,
+  isSegmentTargetDirty,
+  markSegmentTargetSaved,
+  syncSavedTargetTexts,
+} from "./cat-dirty-state";
+import { createCatWorkspaceState } from "./cat.fixture";
+
+describe("cat dirty state", () => {
+  it("detects when a segment target differs from the saved baseline", () => {
+    const saved = buildSavedTargetTextMap([
+      {
+        id: "seg-1",
+        index: 1,
+        key: "hello",
+        sourceText: "Hello",
+        targetText: "Saved",
+        sourceLocale: "en",
+        targetLocale: "vi",
+        status: "pending",
+      },
+    ]);
+
+    expect(isSegmentTargetDirty("seg-1", "Edited", saved)).toBe(true);
+    expect(isSegmentTargetDirty("seg-1", "Saved", saved)).toBe(false);
+  });
+
+  it("keeps saved baselines for edited segments across server refreshes", () => {
+    const previousInitialState = createCatWorkspaceState({
+      segments: [
+        {
+          id: "seg-1",
+          index: 1,
+          key: "hello",
+          sourceText: "Hello",
+          targetText: "Saved",
+          sourceLocale: "en",
+          targetLocale: "vi",
+          status: "pending",
+        },
+      ],
+    });
+    const currentState = {
+      ...previousInitialState,
+      segments: previousInitialState.segments.map((segment) => ({
+        ...segment,
+        targetText: "Unsaved edit",
+      })),
+    };
+    const nextInitialState = createCatWorkspaceState({
+      segments: [
+        {
+          id: "seg-1",
+          index: 1,
+          key: "hello",
+          sourceText: "Hello",
+          targetText: "Server refresh",
+          sourceLocale: "en",
+          targetLocale: "vi",
+          status: "pending",
+        },
+      ],
+    });
+
+    const synced = syncSavedTargetTexts({
+      savedTargetTexts: buildSavedTargetTextMap(previousInitialState.segments),
+      previousInitialState,
+      currentState,
+      nextInitialState,
+    });
+
+    expect(synced["seg-1"]).toBe("Saved");
+    expect(collectDirtySegmentIds(currentState.segments, synced)).toEqual(["seg-1"]);
+  });
+
+  it("updates saved baselines after approve", () => {
+    const saved = markSegmentTargetSaved(buildSavedTargetTextMap([]), "seg-1", "Approved");
+    expect(saved["seg-1"]).toBe("Approved");
+  });
+});

--- a/apps/hyperlocalise-web/src/components/cat/cat-dirty-state.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat-dirty-state.ts
@@ -1,0 +1,76 @@
+import type { CatSegment, CatWorkspaceState } from "./types";
+
+export type SavedTargetTextMap = Record<string, string>;
+
+export function buildSavedTargetTextMap(segments: CatSegment[]): SavedTargetTextMap {
+  return Object.fromEntries(segments.map((segment) => [segment.id, segment.targetText]));
+}
+
+export function isSegmentTargetDirty(
+  segmentId: string,
+  targetText: string,
+  savedTargetTexts: SavedTargetTextMap,
+): boolean {
+  const savedTargetText = savedTargetTexts[segmentId];
+  if (savedTargetText === undefined) {
+    return false;
+  }
+
+  return targetText !== savedTargetText;
+}
+
+export function collectDirtySegmentIds(
+  segments: CatSegment[],
+  savedTargetTexts: SavedTargetTextMap,
+): string[] {
+  return segments
+    .filter((segment) => isSegmentTargetDirty(segment.id, segment.targetText, savedTargetTexts))
+    .map((segment) => segment.id);
+}
+
+function getSegmentsById(state: CatWorkspaceState) {
+  return new Map(state.segments.map((segment) => [segment.id, segment]));
+}
+
+export function syncSavedTargetTexts(input: {
+  savedTargetTexts: SavedTargetTextMap;
+  previousInitialState: CatWorkspaceState;
+  currentState: CatWorkspaceState;
+  nextInitialState: CatWorkspaceState;
+}): SavedTargetTextMap {
+  const previousSegments = getSegmentsById(input.previousInitialState);
+  const currentSegments = getSegmentsById(input.currentState);
+  const nextSavedTargetTexts = { ...input.savedTargetTexts };
+
+  for (const nextSegment of input.nextInitialState.segments) {
+    const previousSegment = previousSegments.get(nextSegment.id);
+    const currentSegment = currentSegments.get(nextSegment.id);
+
+    if (!previousSegment || !currentSegment) {
+      nextSavedTargetTexts[nextSegment.id] = nextSegment.targetText;
+      continue;
+    }
+
+    if (currentSegment.targetText !== previousSegment.targetText) {
+      if (nextSavedTargetTexts[nextSegment.id] === undefined) {
+        nextSavedTargetTexts[nextSegment.id] = previousSegment.targetText;
+      }
+      continue;
+    }
+
+    nextSavedTargetTexts[nextSegment.id] = nextSegment.targetText;
+  }
+
+  return nextSavedTargetTexts;
+}
+
+export function markSegmentTargetSaved(
+  savedTargetTexts: SavedTargetTextMap,
+  segmentId: string,
+  targetText: string,
+): SavedTargetTextMap {
+  return {
+    ...savedTargetTexts,
+    [segmentId]: targetText,
+  };
+}

--- a/apps/hyperlocalise-web/src/components/cat/cat-editor-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-editor-panel.tsx
@@ -60,11 +60,15 @@ export function CatEditorPanel({
   isFormatChecksLoading = false,
   canApprove = true,
   canAddComment = false,
+  canEditTranslations = true,
   canLookupContext = false,
   canUseAiRecommendation = false,
+  isTargetDirty = false,
   isPostingComment = false,
   commentPostError,
   onTargetChange,
+  onCopySource,
+  onClearTarget,
   onUseAiSuggestion,
   onApprove,
   onAddComment,
@@ -89,11 +93,15 @@ export function CatEditorPanel({
   isFormatChecksLoading?: boolean;
   canApprove?: boolean;
   canAddComment?: boolean;
+  canEditTranslations?: boolean;
   canLookupContext?: boolean;
   canUseAiRecommendation?: boolean;
+  isTargetDirty?: boolean;
   isPostingComment?: boolean;
   commentPostError?: string;
   onTargetChange: (value: string) => void;
+  onCopySource: () => void;
+  onClearTarget: () => void;
   onUseAiSuggestion: () => void;
   onApprove: () => void;
   onAddComment?: (text: string) => void | Promise<void>;
@@ -120,6 +128,7 @@ export function CatEditorPanel({
     isAiSuggestionLoading ||
     isFormatChecksLoading;
   const canTriggerApprove = canApprove && !isActionBlocked;
+  const canEditTarget = canEditTranslations && !isEditorBusy;
   const sourceMessageAnalysis = useMemo(
     () => analyzeCatMessageFormat(segment.sourceText),
     [segment.sourceText],
@@ -191,10 +200,15 @@ export function CatEditorPanel({
   return (
     <div className="flex h-full min-h-0 flex-col bg-background">
       <div className="flex flex-wrap items-center justify-between gap-3 border-b border-foreground/8 px-4 py-3 lg:px-5">
-        <div className="flex items-center">
+        <div className="flex items-center gap-2">
           <span className="font-mono text-xs text-muted-foreground tabular-nums">
             {String(segmentPosition).padStart(2, "0")} / {String(totalSegments).padStart(2, "0")}
           </span>
+          {isTargetDirty ? (
+            <Badge variant="outline" className="border-bud-500/40 bg-bud-500/10 text-bud-300">
+              <FormattedMessage {...catEditorPanelMessages.unsavedChanges} />
+            </Badge>
+          ) : null}
         </div>
         <div className="flex items-center gap-1">
           <Button
@@ -235,20 +249,36 @@ export function CatEditorPanel({
           </section>
 
           <section className="space-y-3">
-            <div className="flex items-center justify-between gap-2">
+            <div className="flex flex-wrap items-center justify-between gap-2">
               <h3 className="text-xs font-medium text-muted-foreground">
                 <FormattedMessage
                   {...catEditorPanelMessages.targetHeading}
                   values={{ locale: segment.targetLocale }}
                 />
               </h3>
+              {canEditTarget ? (
+                <div className="flex flex-wrap items-center gap-1">
+                  <Button variant="ghost" size="sm" onClick={onCopySource}>
+                    <FormattedMessage {...catEditorPanelMessages.copySource} />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={onClearTarget}
+                    disabled={segment.targetText.length === 0}
+                  >
+                    <FormattedMessage {...catEditorPanelMessages.clearTarget} />
+                  </Button>
+                </div>
+              ) : null}
             </div>
             <CatTargetEditor
               key={segment.id}
               sourceText={segment.sourceText}
               value={segment.targetText}
+              maxLength={segment.maxLength}
               onChange={onTargetChange}
-              disabled={isEditorBusy}
+              disabled={!canEditTarget}
             />
             <CatIcuStructureSummary blocks={sourceMessageAnalysis.icuBlocks} />
           </section>

--- a/apps/hyperlocalise-web/src/components/cat/cat-intelligence-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-intelligence-panel.tsx
@@ -121,13 +121,18 @@ function tmMatchBadgeTone(matchKind: CatTmMatchKind | undefined) {
 }
 
 function tmMatchBadgeLabel(match: CatTranslationMemoryMatch, intl: ReturnType<typeof useIntl>) {
-  if (match.matchKind === "context") {
-    return intl.formatMessage(catIntelligencePanelMessages.matchKindContext);
+  switch (match.matchKind) {
+    case "exact":
+      return intl.formatMessage(catIntelligencePanelMessages.matchKindExact);
+    case "context":
+      return intl.formatMessage(catIntelligencePanelMessages.matchKindContext);
+    case "fuzzy":
+      return intl.formatMessage(catIntelligencePanelMessages.matchKindFuzzy);
+    default:
+      return intl.formatMessage(catIntelligencePanelMessages.matchPercent, {
+        matchPercent: match.matchPercent,
+      });
   }
-
-  return intl.formatMessage(catIntelligencePanelMessages.matchPercent, {
-    matchPercent: match.matchPercent,
-  });
 }
 
 function TranslationMemoryRow({

--- a/apps/hyperlocalise-web/src/components/cat/cat-intelligence-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-intelligence-panel.tsx
@@ -1,17 +1,35 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 import { BulbIcon, CheckmarkCircle02Icon, InformationCircleIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { MarkdownContent } from "@/components/markdown-description-editor/markdown-description-editor";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/primitives/cn";
 
 import { catIntelligencePanelMessages } from "./cat.messages";
-import type { CatGlossaryTerm, CatSegmentIntelligence, CatTranslationMemoryMatch } from "./types";
+import { requiresLowMatchConfirmation } from "./tm-match-quality";
+import type {
+  CatGlossaryTerm,
+  CatSegmentIntelligence,
+  CatTmMatchKind,
+  CatTranslationMemoryMatch,
+} from "./types";
 
 function PanelSection({ title, children }: { title: string; children: ReactNode }) {
   return (
@@ -92,21 +110,60 @@ function GlossaryTermRow({ term }: { term: CatGlossaryTerm }) {
   );
 }
 
-function TranslationMemoryRow({ match }: { match: CatTranslationMemoryMatch }) {
+function tmMatchBadgeTone(matchKind: CatTmMatchKind | undefined) {
+  switch (matchKind) {
+    case "exact":
+    case "context":
+      return "border-grove-300/25 bg-grove-300/10 text-grove-300";
+    default:
+      return "border-bud-500/25 bg-bud-500/10 text-bud-300";
+  }
+}
+
+function tmMatchBadgeLabel(match: CatTranslationMemoryMatch, intl: ReturnType<typeof useIntl>) {
+  if (match.matchKind === "context") {
+    return intl.formatMessage(catIntelligencePanelMessages.matchKindContext);
+  }
+
+  return intl.formatMessage(catIntelligencePanelMessages.matchPercent, {
+    matchPercent: match.matchPercent,
+  });
+}
+
+function TranslationMemoryRow({
+  match,
+  onUse,
+}: {
+  match: CatTranslationMemoryMatch;
+  onUse?: (match: CatTranslationMemoryMatch) => void;
+}) {
+  const intl = useIntl();
+
   return (
     <li className="space-y-2 px-3 py-3">
-      <div className="flex items-center justify-between gap-3">
-        <span className="rounded-full border border-dew-500/25 bg-dew-500/10 px-2 py-0.5 text-[11px] font-medium text-dew-100">
-          <FormattedMessage
-            {...catIntelligencePanelMessages.matchPercent}
-            values={{ matchPercent: match.matchPercent }}
-          />
-        </span>
-        {match.contextLabel ? (
-          <span className="min-w-0 truncate text-xs text-muted-foreground">
-            {match.contextLabel}
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex min-w-0 flex-wrap items-center gap-2">
+          <span
+            className={cn(
+              "rounded-full border px-2 py-0.5 text-[11px] font-medium tabular-nums",
+              tmMatchBadgeTone(match.matchKind),
+            )}
+          >
+            {tmMatchBadgeLabel(match, intl)}
           </span>
-        ) : null}
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          {match.contextLabel ? (
+            <span className="max-w-28 truncate text-xs text-muted-foreground">
+              {match.contextLabel}
+            </span>
+          ) : null}
+          {onUse ? (
+            <Button variant="ghost" size="sm" onClick={() => onUse(match)}>
+              <FormattedMessage {...catIntelligencePanelMessages.useTmMatch} />
+            </Button>
+          ) : null}
+        </div>
       </div>
       <div className="space-y-1">
         <p className="text-pretty text-xs leading-relaxed text-muted-foreground">
@@ -123,13 +180,18 @@ export function CatIntelligencePanel({
   isLookingUpContext = false,
   isConcordanceLoading = false,
   showAgentContext = false,
+  canEditTranslations = true,
+  onUseTmMatch,
 }: {
   intelligence: CatSegmentIntelligence;
   isLookingUpContext?: boolean;
   isConcordanceLoading?: boolean;
   showAgentContext?: boolean;
+  canEditTranslations?: boolean;
+  onUseTmMatch?: (match: CatTranslationMemoryMatch) => void;
 }) {
   const intl = useIntl();
+  const [pendingLowMatch, setPendingLowMatch] = useState<CatTranslationMemoryMatch | null>(null);
   const hasFileContext = Boolean(intelligence.productMeaning?.trim());
   const agentBadges = [
     intelligence.locationBreadcrumb,
@@ -138,6 +200,26 @@ export function CatIntelligencePanel({
   ].filter(Boolean);
   const hasAgentInsight = Boolean(intelligence.agentContext?.trim());
   const hasAgentContext = hasAgentInsight || agentBadges.length > 0;
+
+  function handleUseTmMatch(match: CatTranslationMemoryMatch) {
+    if (!onUseTmMatch) {
+      return;
+    }
+
+    if (requiresLowMatchConfirmation(match.matchPercent)) {
+      setPendingLowMatch(match);
+      return;
+    }
+
+    onUseTmMatch(match);
+  }
+
+  function confirmLowMatchApply() {
+    if (pendingLowMatch && onUseTmMatch) {
+      onUseTmMatch(pendingLowMatch);
+    }
+    setPendingLowMatch(null);
+  }
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-background lg:border-l lg:border-foreground/8">
@@ -266,7 +348,11 @@ export function CatIntelligencePanel({
               <div className="overflow-hidden rounded-2xl bg-foreground/3">
                 <ul className="divide-y divide-foreground/8">
                   {intelligence.translationMemoryMatches.map((match) => (
-                    <TranslationMemoryRow key={match.id} match={match} />
+                    <TranslationMemoryRow
+                      key={match.id}
+                      match={match}
+                      onUse={canEditTranslations && onUseTmMatch ? handleUseTmMatch : undefined}
+                    />
                   ))}
                 </ul>
               </div>
@@ -274,6 +360,39 @@ export function CatIntelligencePanel({
           ) : null}
         </div>
       </ScrollArea>
+
+      <AlertDialog
+        open={pendingLowMatch !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setPendingLowMatch(null);
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              <FormattedMessage {...catIntelligencePanelMessages.lowMatchConfirmTitle} />
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {pendingLowMatch ? (
+                <FormattedMessage
+                  {...catIntelligencePanelMessages.lowMatchConfirmDescription}
+                  values={{ matchPercent: pendingLowMatch.matchPercent }}
+                />
+              ) : null}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>
+              <FormattedMessage {...catIntelligencePanelMessages.cancel} />
+            </AlertDialogCancel>
+            <AlertDialogAction onClick={confirmLowMatchApply}>
+              <FormattedMessage {...catIntelligencePanelMessages.lowMatchConfirmAction} />
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/apps/hyperlocalise-web/src/components/cat/cat-queue-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-queue-panel.tsx
@@ -25,6 +25,7 @@ export function CatQueuePanel({
   segments,
   selectedSegmentId,
   summary,
+  dirtySegmentIds,
   onSelectSegment,
   search = "",
   onSearchChange,
@@ -38,6 +39,7 @@ export function CatQueuePanel({
   segments: CatSegment[];
   selectedSegmentId: string;
   summary: CatQueueSummary;
+  dirtySegmentIds?: ReadonlySet<string>;
   onSelectSegment: (segmentId: string) => void;
   search?: string;
   onSearchChange?: (value: string) => void;
@@ -101,6 +103,7 @@ export function CatQueuePanel({
         <CatQueueVirtualList
           segments={segments}
           selectedSegmentId={selectedSegmentId}
+          dirtySegmentIds={dirtySegmentIds}
           onSelectSegment={onSelectSegment}
           onNearEnd={onNearEnd}
         />

--- a/apps/hyperlocalise-web/src/components/cat/cat-queue-virtual-list.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-queue-virtual-list.tsx
@@ -2,9 +2,11 @@
 
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { useEffect, useRef } from "react";
+import { useIntl } from "react-intl";
 
 import { cn } from "@/lib/primitives/cn";
 
+import { catQueuePanelMessages } from "./cat.messages";
 import type { CatSegment } from "./types";
 
 const ESTIMATED_ROW_HEIGHT = 72;
@@ -24,16 +26,19 @@ function QueueStatusDot({ status }: { status: CatSegment["status"] }) {
 export function CatQueueVirtualList({
   segments,
   selectedSegmentId,
+  dirtySegmentIds,
   onSelectSegment,
   onNearEnd,
   className,
 }: {
   segments: CatSegment[];
   selectedSegmentId: string;
+  dirtySegmentIds?: ReadonlySet<string>;
   onSelectSegment: (segmentId: string) => void;
   onNearEnd?: () => void;
   className?: string;
 }) {
+  const intl = useIntl();
   const parentRef = useRef<HTMLDivElement>(null);
   const virtualizer = useVirtualizer({
     count: segments.length,
@@ -68,6 +73,7 @@ export function CatQueueVirtualList({
           }
 
           const selected = segment.id === selectedSegmentId;
+          const isDirty = dirtySegmentIds?.has(segment.id) ?? false;
 
           return (
             <li
@@ -98,7 +104,13 @@ export function CatQueueVirtualList({
                     </span>
                   </div>
                 </div>
-                <div className="mt-1 shrink-0">
+                <div className="mt-1 flex shrink-0 flex-col items-center gap-1">
+                  {isDirty ? (
+                    <span
+                      className="size-2 rounded-full bg-bud-400"
+                      aria-label={intl.formatMessage(catQueuePanelMessages.unsavedChangesAria)}
+                    />
+                  ) : null}
                   <QueueStatusDot status={segment.status} />
                 </div>
               </button>

--- a/apps/hyperlocalise-web/src/components/cat/cat-suggestions-tabs.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-suggestions-tabs.tsx
@@ -23,8 +23,6 @@ function suggestionSourceLabel(source: string, intl: ReturnType<typeof useIntl>)
       return intl.formatMessage(catToneMessages.sourceGlossary);
     case "tm":
       return intl.formatMessage(catToneMessages.sourceTm);
-    case "mt":
-      return intl.formatMessage(catToneMessages.sourceMt);
     default:
       return source;
   }

--- a/apps/hyperlocalise-web/src/components/cat/cat-target-editor.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-target-editor.tsx
@@ -263,11 +263,13 @@ export function CatIcuStructureSummary({ blocks }: { blocks: CatIcuBlockSummary[
 export function CatTargetEditor({
   sourceText,
   value,
+  maxLength,
   disabled = false,
   onChange,
 }: {
   sourceText: string;
   value: string;
+  maxLength?: number;
   disabled?: boolean;
   onChange: (value: string) => void;
 }) {
@@ -284,6 +286,8 @@ export function CatTargetEditor({
   );
   const targetSignatures = useMemo(() => presentTokenSignatures(targetAnalysis), [targetAnalysis]);
   const sourceTokens = sourceAnalysis.tokens.filter((token) => token.kind !== "pound");
+  const characterCount = value.length;
+  const isOverMaxLength = maxLength !== undefined && characterCount > maxLength;
 
   const editor = useEditor({
     extensions: catTargetEditorExtensions,
@@ -360,7 +364,7 @@ export function CatTargetEditor({
           "[&_.tiptap_p.is-editor-empty:first-child::before]:pointer-events-none",
           disabled && "opacity-60",
         )}
-        aria-invalid={parityIssues.length > 0}
+        aria-invalid={parityIssues.length > 0 || isOverMaxLength}
       >
         {editor ? (
           <EditorContent editor={editor} />
@@ -368,6 +372,27 @@ export function CatTargetEditor({
           <div className="min-h-36 px-4 py-4 text-lg text-muted-foreground" />
         )}
       </div>
+
+      {maxLength !== undefined ? (
+        <div className="flex justify-end px-1">
+          <p
+            className={cn(
+              "text-xs tabular-nums",
+              isOverMaxLength ? "font-medium text-flame-100" : "text-muted-foreground",
+            )}
+            aria-live="polite"
+            aria-label={intl.formatMessage(catTargetEditorMessages.characterCountAria, {
+              count: characterCount,
+              maxLength,
+            })}
+          >
+            <FormattedMessage
+              {...catTargetEditorMessages.characterCount}
+              values={{ count: characterCount, maxLength }}
+            />
+          </p>
+        </div>
+      ) : null}
 
       {sourceTokens.length > 0 ? (
         <div className="flex flex-wrap items-center gap-1.5">

--- a/apps/hyperlocalise-web/src/components/cat/cat-tone.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat-tone.ts
@@ -76,8 +76,6 @@ export function suggestionSourceLabel(source: string) {
       return "Glossary";
     case "tm":
       return "TM";
-    case "mt":
-      return "MT";
     default:
       return source;
   }

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
@@ -516,6 +516,9 @@ export function CatWorkspaceContainer({
                 bestTmMatch.targetText,
               );
               setState((current) => ({ ...current, segments }));
+              setSavedTargetTexts((saved) =>
+                markSegmentTargetSaved(saved, segmentId, bestTmMatch.targetText),
+              );
               onTargetChange?.(segmentId, bestTmMatch.targetText);
               const updatedSegment = segments.find((item) => item.id === segmentId);
               if (updatedSegment && (validateFormat || runQaChecks)) {

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
@@ -1,7 +1,18 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useIntl } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 
 import type {
   CatAiRecommendationResult,
@@ -14,8 +25,25 @@ import type {
   PartialCatWorkspaceDependencies,
 } from "./dependencies";
 import { CatWorkspaceView } from "./cat-workspace";
+import {
+  buildSavedTargetTextMap,
+  collectDirtySegmentIds,
+  isSegmentTargetDirty,
+  markSegmentTargetSaved,
+  syncSavedTargetTexts,
+  type SavedTargetTextMap,
+} from "./cat-dirty-state";
 import { catEditorPanelMessages, catWorkspaceContainerMessages } from "./cat.messages";
-import type { CatFormatCheck, CatSegment, CatWorkspaceState } from "./types";
+import {
+  selectBestTmMatchForAutoFill,
+  TM_AUTO_FILL_MIN_MATCH_PERCENT_DEFAULT,
+} from "./tm-match-quality";
+import type {
+  CatFormatCheck,
+  CatSegment,
+  CatTranslationMemoryMatch,
+  CatWorkspaceState,
+} from "./types";
 
 function getSegmentQueueIndex(segments: CatSegment[], segmentIdOrKey: string) {
   return segments.findIndex(
@@ -211,7 +239,13 @@ export interface CatWorkspaceContainerProps {
   onQueuePreviousPage?: () => void;
   onQueueNextPage?: () => void;
   onQueueNearEnd?: () => void;
+  tmAutoFillMinMatchPercent?: number;
 }
+
+type UnsavedNavigationPrompt = {
+  kind: "segment" | "page";
+  proceed: () => void;
+};
 
 function collectSegmentsWithAgentContext(state: CatWorkspaceState): ReadonlySet<string> {
   return new Set(
@@ -237,6 +271,7 @@ export function CatWorkspaceContainer({
   onQueuePreviousPage,
   onQueueNextPage,
   onQueueNearEnd,
+  tmAutoFillMinMatchPercent = TM_AUTO_FILL_MIN_MATCH_PERCENT_DEFAULT,
 }: CatWorkspaceContainerProps) {
   const intl = useIntl();
   const [state, setState] = useState(initialState);
@@ -251,10 +286,18 @@ export function CatWorkspaceContainer({
   >(() => collectSegmentsWithAgentContext(initialState));
   const [isGeneratingAiRecommendation, setIsGeneratingAiRecommendation] = useState(false);
   const [isRunningFormatChecks, setIsRunningFormatChecks] = useState(false);
+  const [savedTargetTexts, setSavedTargetTexts] = useState<SavedTargetTextMap>(() =>
+    buildSavedTargetTextMap(initialState.segments),
+  );
+  const [unsavedNavigationPrompt, setUnsavedNavigationPrompt] =
+    useState<UnsavedNavigationPrompt | null>(null);
   const stateRef = useRef(state);
   const previousInitialStateRef = useRef(initialState);
   const validationSequenceRef = useRef(0);
   const reviewSequenceRef = useRef(0);
+  const autoFilledSegmentIdsRef = useRef<ReadonlySet<string>>(new Set());
+  const savedTargetTextsRef = useRef(savedTargetTexts);
+  savedTargetTextsRef.current = savedTargetTexts;
   const validateFormat = serviceOverrides?.validateFormat;
   const runQaChecks = serviceOverrides?.runQaChecks;
   const lookupSegmentContext = serviceOverrides?.lookupSegmentContext;
@@ -262,7 +305,9 @@ export function CatWorkspaceContainer({
   const generateAiRecommendation = serviceOverrides?.generateAiRecommendation;
   const canLookupContext = Boolean(lookupSegmentContext);
   const canUseAiRecommendation = Boolean(generateAiRecommendation);
-  const canRunSegmentReview = Boolean(generateAiRecommendation || validateFormat || runQaChecks);
+  const canRunSegmentReview = Boolean(
+    lookupSegmentConcordance || generateAiRecommendation || validateFormat || runQaChecks,
+  );
   const onSelectSegment = navigationOverrides?.onSelectSegment;
   const onPreviousSegment = navigationOverrides?.onPreviousSegment;
   const onNextSegment = navigationOverrides?.onNextSegment;
@@ -283,12 +328,69 @@ export function CatWorkspaceContainer({
     setState((current) =>
       mergeCatWorkspaceState(previousInitialStateRef.current, current, initialState),
     );
+    setSavedTargetTexts((saved) =>
+      syncSavedTargetTexts({
+        savedTargetTexts: saved,
+        previousInitialState: previousInitialStateRef.current,
+        currentState: stateRef.current,
+        nextInitialState: initialState,
+      }),
+    );
     previousInitialStateRef.current = initialState;
     setRevealedAgentContextSegmentIds((current) => {
       const next = collectSegmentsWithAgentContext(initialState);
       return new Set([...current, ...next]);
     });
   }, [initialState]);
+
+  useEffect(() => {
+    const dirtySegmentIds = collectDirtySegmentIds(state.segments, savedTargetTexts);
+    if (dirtySegmentIds.length === 0) {
+      return;
+    }
+
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+    };
+  }, [savedTargetTexts, state.segments]);
+
+  const attemptSegmentNavigation = useCallback((proceed: () => void) => {
+    const currentState = stateRef.current;
+    const selectedSegment = currentState.segments.find(
+      (segment) => segment.id === currentState.selectedSegmentId,
+    );
+    if (
+      selectedSegment &&
+      isSegmentTargetDirty(
+        selectedSegment.id,
+        selectedSegment.targetText,
+        savedTargetTextsRef.current,
+      )
+    ) {
+      setUnsavedNavigationPrompt({ kind: "segment", proceed });
+      return;
+    }
+
+    proceed();
+  }, []);
+
+  const attemptPageNavigation = useCallback((proceed: () => void) => {
+    const dirtySegmentIds = collectDirtySegmentIds(
+      stateRef.current.segments,
+      savedTargetTextsRef.current,
+    );
+    if (dirtySegmentIds.length > 0) {
+      setUnsavedNavigationPrompt({ kind: "page", proceed });
+      return;
+    }
+
+    proceed();
+  }, []);
 
   useEffect(() => {
     setCommentPostError(undefined);
@@ -340,8 +442,9 @@ export function CatWorkspaceContainer({
 
       const includeAi = options?.includeAi === true && Boolean(generateAiRecommendation);
       const includeFormatChecks = Boolean(validateFormat || runQaChecks);
+      const includeConcordance = Boolean(lookupSegmentConcordance);
 
-      if (!includeAi && !includeFormatChecks) {
+      if (!includeAi && !includeFormatChecks && !includeConcordance) {
         return;
       }
 
@@ -391,6 +494,34 @@ export function CatWorkspaceContainer({
                 },
               };
             });
+
+            const currentSegment = stateRef.current.segments.find((item) => item.id === segmentId);
+            const bestTmMatch = selectBestTmMatchForAutoFill(
+              concordance.translationMemoryMatches,
+              tmAutoFillMinMatchPercent,
+            );
+            if (
+              currentSegment &&
+              !currentSegment.targetText.trim() &&
+              bestTmMatch &&
+              !autoFilledSegmentIdsRef.current.has(segmentId)
+            ) {
+              autoFilledSegmentIdsRef.current = new Set([
+                ...autoFilledSegmentIdsRef.current,
+                segmentId,
+              ]);
+              const segments = updateSegmentTarget(
+                stateRef.current.segments,
+                segmentId,
+                bestTmMatch.targetText,
+              );
+              setState((current) => ({ ...current, segments }));
+              onTargetChange?.(segmentId, bestTmMatch.targetText);
+              const updatedSegment = segments.find((item) => item.id === segmentId);
+              if (updatedSegment && (validateFormat || runQaChecks)) {
+                void runSegmentChecks(updatedSegment, bestTmMatch.targetText);
+              }
+            }
           } catch (error) {
             if (reviewSequenceRef.current !== sequence) {
               return;
@@ -459,49 +590,51 @@ export function CatWorkspaceContainer({
           }
         }
 
-        const [formatChecks, qaChecks] = await Promise.all([
-          includeFormatChecks && validateFormat
-            ? validateFormat(segment, segment.targetText)
-            : Promise.resolve([]),
-          includeFormatChecks && runQaChecks
-            ? runQaChecks(segment, segment.targetText)
-            : Promise.resolve([]),
-        ]);
-        if (reviewSequenceRef.current !== sequence) {
-          return;
+        if (includeFormatChecks || includeAi) {
+          const [formatChecks, qaChecks] = await Promise.all([
+            includeFormatChecks && validateFormat
+              ? validateFormat(segment, segment.targetText)
+              : Promise.resolve([]),
+            includeFormatChecks && runQaChecks
+              ? runQaChecks(segment, segment.targetText)
+              : Promise.resolve([]),
+          ]);
+          if (reviewSequenceRef.current !== sequence) {
+            return;
+          }
+          const withoutAiFailure = (segmentChecks: CatFormatCheck[]) =>
+            segmentChecks.filter((check) => check.id !== `ai-recommendation-failed-${segmentId}`);
+          const baseChecks = withoutAiFailure(
+            recommendation?.formatChecks ?? [...formatChecks, ...qaChecks],
+          );
+          const checks = aiFailureCheck
+            ? [aiFailureCheck, ...baseChecks.filter((check) => check.id !== aiFailureCheck.id)]
+            : baseChecks;
+
+          setState((current) => {
+            const currentIntelligence =
+              current.segmentIntelligence?.[segmentId] ?? current.intelligence;
+
+            return {
+              ...current,
+              formatChecks: current.selectedSegmentId === segmentId ? checks : current.formatChecks,
+              segmentFormatChecks: {
+                ...current.segmentFormatChecks,
+                [segmentId]: checks,
+              },
+              segmentIntelligence: recommendation
+                ? {
+                    ...current.segmentIntelligence,
+                    [segmentId]: {
+                      ...currentIntelligence,
+                      aiSuggestion: recommendation.aiSuggestion,
+                      aiReasoning: recommendation.aiReasoning,
+                    },
+                  }
+                : current.segmentIntelligence,
+            };
+          });
         }
-        const withoutAiFailure = (segmentChecks: CatFormatCheck[]) =>
-          segmentChecks.filter((check) => check.id !== `ai-recommendation-failed-${segmentId}`);
-        const baseChecks = withoutAiFailure(
-          recommendation?.formatChecks ?? [...formatChecks, ...qaChecks],
-        );
-        const checks = aiFailureCheck
-          ? [aiFailureCheck, ...baseChecks.filter((check) => check.id !== aiFailureCheck.id)]
-          : baseChecks;
-
-        setState((current) => {
-          const currentIntelligence =
-            current.segmentIntelligence?.[segmentId] ?? current.intelligence;
-
-          return {
-            ...current,
-            formatChecks: current.selectedSegmentId === segmentId ? checks : current.formatChecks,
-            segmentFormatChecks: {
-              ...current.segmentFormatChecks,
-              [segmentId]: checks,
-            },
-            segmentIntelligence: recommendation
-              ? {
-                  ...current.segmentIntelligence,
-                  [segmentId]: {
-                    ...currentIntelligence,
-                    aiSuggestion: recommendation.aiSuggestion,
-                    aiReasoning: recommendation.aiReasoning,
-                  },
-                }
-              : current.segmentIntelligence,
-          };
-        });
       } finally {
         if (reviewSequenceRef.current === sequence) {
           if (includeAi) {
@@ -518,7 +651,10 @@ export function CatWorkspaceContainer({
       intl,
       lookupSegmentConcordance,
       onReviewWithAi,
+      onTargetChange,
       runQaChecks,
+      runSegmentChecks,
+      tmAutoFillMinMatchPercent,
       validateFormat,
     ],
   );
@@ -538,31 +674,41 @@ export function CatWorkspaceContainer({
   const dependencies = useMemo<CatWorkspaceDependencies>(() => {
     const navigation = {
       onSelectSegment: (segmentId: string) => {
-        setState((current) => {
-          const selectedSegmentId = getSegmentId(current.segments, segmentId) ?? segmentId;
-          return { ...current, selectedSegmentId };
+        attemptSegmentNavigation(() => {
+          setState((current) => {
+            const selectedSegmentId = getSegmentId(current.segments, segmentId) ?? segmentId;
+            return { ...current, selectedSegmentId };
+          });
+          onSelectSegment?.(segmentId);
         });
-        onSelectSegment?.(segmentId);
       },
       onPreviousSegment: () => {
-        setState((current) => {
-          const previousId = getAdjacentSegmentId(current.segments, current.selectedSegmentId, -1);
-          if (!previousId) {
-            return current;
-          }
-          return { ...current, selectedSegmentId: previousId };
+        attemptSegmentNavigation(() => {
+          setState((current) => {
+            const previousId = getAdjacentSegmentId(
+              current.segments,
+              current.selectedSegmentId,
+              -1,
+            );
+            if (!previousId) {
+              return current;
+            }
+            return { ...current, selectedSegmentId: previousId };
+          });
+          onPreviousSegment?.();
         });
-        onPreviousSegment?.();
       },
       onNextSegment: () => {
-        setState((current) => {
-          const nextId = getAdjacentSegmentId(current.segments, current.selectedSegmentId, 1);
-          if (!nextId) {
-            return current;
-          }
-          return { ...current, selectedSegmentId: nextId };
+        attemptSegmentNavigation(() => {
+          setState((current) => {
+            const nextId = getAdjacentSegmentId(current.segments, current.selectedSegmentId, 1);
+            if (!nextId) {
+              return current;
+            }
+            return { ...current, selectedSegmentId: nextId };
+          });
+          onNextSegment?.();
         });
-        onNextSegment?.();
       },
       onReviewInSequence: () => {
         onReviewInSequence?.();
@@ -590,6 +736,9 @@ export function CatWorkspaceContainer({
         editing.onTargetChange(segmentId, aiSuggestion);
         onUseAiSuggestion?.(segmentId);
       },
+      onUseTmMatch: (segmentId: string, match: CatTranslationMemoryMatch) => {
+        editing.onTargetChange(segmentId, match.targetText);
+      },
     };
 
     const review = {
@@ -615,6 +764,7 @@ export function CatWorkspaceContainer({
               },
             };
           });
+          setSavedTargetTexts((saved) => markSegmentTargetSaved(saved, segmentId, targetText));
         } catch (error) {
           const message =
             error instanceof Error
@@ -755,6 +905,8 @@ export function CatWorkspaceContainer({
       },
     };
   }, [
+    attemptPageNavigation,
+    attemptSegmentNavigation,
     onApprove,
     onAddComment,
     onAskQuestion,
@@ -774,30 +926,88 @@ export function CatWorkspaceContainer({
     validateFormat,
   ]);
 
+  const dirtySegmentIds = useMemo(
+    () => new Set(collectDirtySegmentIds(state.segments, savedTargetTexts)),
+    [savedTargetTexts, state.segments],
+  );
+
   return (
-    <CatWorkspaceView
-      state={state}
-      dependencies={dependencies}
-      isValidating={isValidating}
-      isApproving={isApproving}
-      isPostingComment={isPostingComment}
-      commentPostError={commentPostError}
-      isLookingUpContext={isLookingUpContext}
-      isConcordanceLoading={isLoadingConcordance}
-      isAiSuggestionLoading={isGeneratingAiRecommendation && canUseAiRecommendation}
-      isFormatChecksLoading={isRunningFormatChecks || isValidating}
-      canLookupContext={canLookupContext}
-      showAgentContext={revealedAgentContextSegmentIds.has(state.selectedSegmentId)}
-      canUseAiRecommendation={canUseAiRecommendation}
-      className={className}
-      queueSearch={queueSearch}
-      onQueueSearchChange={onQueueSearchChange}
-      isQueueSearchPending={isQueueSearchPending}
-      isQueueFetchingPage={isQueueFetchingPage}
-      queuePagination={queuePagination}
-      onQueuePreviousPage={onQueuePreviousPage}
-      onQueueNextPage={onQueueNextPage}
-      onQueueNearEnd={onQueueNearEnd}
-    />
+    <>
+      <CatWorkspaceView
+        state={state}
+        dependencies={dependencies}
+        dirtySegmentIds={dirtySegmentIds}
+        isValidating={isValidating}
+        isApproving={isApproving}
+        isPostingComment={isPostingComment}
+        commentPostError={commentPostError}
+        isLookingUpContext={isLookingUpContext}
+        isConcordanceLoading={isLoadingConcordance}
+        isAiSuggestionLoading={isGeneratingAiRecommendation && canUseAiRecommendation}
+        isFormatChecksLoading={isRunningFormatChecks || isValidating}
+        canLookupContext={canLookupContext}
+        showAgentContext={revealedAgentContextSegmentIds.has(state.selectedSegmentId)}
+        canUseAiRecommendation={canUseAiRecommendation}
+        className={className}
+        queueSearch={queueSearch}
+        onQueueSearchChange={onQueueSearchChange}
+        isQueueSearchPending={isQueueSearchPending}
+        isQueueFetchingPage={isQueueFetchingPage}
+        queuePagination={queuePagination}
+        onQueuePreviousPage={
+          onQueuePreviousPage ? () => attemptPageNavigation(onQueuePreviousPage) : undefined
+        }
+        onQueueNextPage={onQueueNextPage ? () => attemptPageNavigation(onQueueNextPage) : undefined}
+        onQueueNearEnd={onQueueNearEnd}
+      />
+
+      <AlertDialog
+        open={unsavedNavigationPrompt !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setUnsavedNavigationPrompt(null);
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {unsavedNavigationPrompt?.kind === "page" ? (
+                <FormattedMessage {...catWorkspaceContainerMessages.unsavedPageNavigationTitle} />
+              ) : (
+                <FormattedMessage
+                  {...catWorkspaceContainerMessages.unsavedSegmentNavigationTitle}
+                />
+              )}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {unsavedNavigationPrompt?.kind === "page" ? (
+                <FormattedMessage
+                  {...catWorkspaceContainerMessages.unsavedPageNavigationDescription}
+                />
+              ) : (
+                <FormattedMessage
+                  {...catWorkspaceContainerMessages.unsavedSegmentNavigationDescription}
+                />
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>
+              <FormattedMessage {...catWorkspaceContainerMessages.unsavedNavigationStay} />
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                const proceed = unsavedNavigationPrompt?.proceed;
+                setUnsavedNavigationPrompt(null);
+                proceed?.();
+              }}
+            >
+              <FormattedMessage {...catWorkspaceContainerMessages.unsavedNavigationDiscard} />
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace.tsx
@@ -50,6 +50,7 @@ export function CatWorkspaceView({
   canLookupContext = false,
   canUseAiRecommendation = false,
   showAgentContext = false,
+  dirtySegmentIds,
   className,
   queueSearch,
   onQueueSearchChange,
@@ -99,6 +100,7 @@ export function CatWorkspaceView({
   const isEditorBusy = isApproving;
   const canApprove = state.canEditTranslations !== false;
   const canAddComment = state.canAddComments === true;
+  const isTargetDirty = dirtySegmentIds?.has(selectedSegment.id) ?? false;
 
   function renderEditorPanel() {
     return (
@@ -117,9 +119,13 @@ export function CatWorkspaceView({
         commentPostError={commentPostError}
         canApprove={canApprove}
         canAddComment={canAddComment}
+        canEditTranslations={canApprove}
+        isTargetDirty={isTargetDirty}
         canLookupContext={canLookupContext}
         canUseAiRecommendation={canUseAiRecommendation}
         onTargetChange={(value) => editing.onTargetChange(selectedSegment.id, value)}
+        onCopySource={() => editing.onTargetChange(selectedSegment.id, selectedSegment.sourceText)}
+        onClearTarget={() => editing.onTargetChange(selectedSegment.id, "")}
         onUseAiSuggestion={() => editing.onUseAiSuggestion(selectedSegment.id)}
         onApprove={() => void review.onApprove(selectedSegment.id, selectedSegment.targetText)}
         onAddComment={
@@ -147,6 +153,7 @@ export function CatWorkspaceView({
         segments={state.segments}
         selectedSegmentId={selectedSegment.id}
         summary={state.queueSummary}
+        dirtySegmentIds={dirtySegmentIds}
         onSelectSegment={(segmentId) => {
           navigation.onSelectSegment(segmentId);
           if (isCompact) {
@@ -172,6 +179,8 @@ export function CatWorkspaceView({
         isLookingUpContext={isLookingUpContext}
         isConcordanceLoading={isConcordanceLoading}
         showAgentContext={showAgentContext}
+        canEditTranslations={state.canEditTranslations !== false}
+        onUseTmMatch={(match) => editing.onUseTmMatch(selectedSegment.id, match)}
       />
     );
   }

--- a/apps/hyperlocalise-web/src/components/cat/cat.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat.messages.ts
@@ -86,6 +86,11 @@ export const catQueuePanelMessages = defineMessages({
     id: "U/tZOaayjq",
     description: "Next page button label in CAT queue",
   },
+  unsavedChangesAria: {
+    defaultMessage: "Unsaved changes",
+    id: "CHs2ugz7iN",
+    description: "Accessible label for queue row indicator when a segment has unsaved edits",
+  },
 });
 
 export const catFormatChecksMessages = defineMessages({
@@ -126,11 +131,6 @@ export const catToneMessages = defineMessages({
     defaultMessage: "TM",
     id: "+H5q/WALpt",
     description: "Badge label for a translation memory CAT suggestion",
-  },
-  sourceMt: {
-    defaultMessage: "MT",
-    id: "expYVaTo2d",
-    description: "Badge label for a machine translation CAT suggestion",
   },
 });
 
@@ -175,6 +175,36 @@ export const catWorkspaceContainerMessages = defineMessages({
     id: "pMRZvoJLzS",
     description: "Fallback error when approving or saving a CAT translation fails",
   },
+  unsavedSegmentNavigationTitle: {
+    defaultMessage: "Leave segment with unsaved changes?",
+    id: "2O/RojUz55",
+    description: "Title when navigating away from a segment with unsaved target text",
+  },
+  unsavedSegmentNavigationDescription: {
+    defaultMessage: "Your edits to this segment have not been saved. Leave without saving?",
+    id: "37yFkjafwR",
+    description: "Body when navigating away from a segment with unsaved target text",
+  },
+  unsavedPageNavigationTitle: {
+    defaultMessage: "Leave page with unsaved changes?",
+    id: "oeD72ehQB/",
+    description: "Title when changing CAT queue page with unsaved target text",
+  },
+  unsavedPageNavigationDescription: {
+    defaultMessage: "Some segments on this page have unsaved edits. Change page without saving?",
+    id: "+pyXMBZm58",
+    description: "Body when changing CAT queue page with unsaved target text",
+  },
+  unsavedNavigationStay: {
+    defaultMessage: "Stay",
+    id: "+EhuajKQYW",
+    description: "Cancel button for unsaved changes navigation guard",
+  },
+  unsavedNavigationDiscard: {
+    defaultMessage: "Leave without saving",
+    id: "VR+xvnXyUj",
+    description: "Confirm button to navigate away without saving target edits",
+  },
 });
 
 export const catTargetEditorMessages = defineMessages({
@@ -197,6 +227,16 @@ export const catTargetEditorMessages = defineMessages({
     defaultMessage: "Required tokens",
     id: "zVk2EFJa3O",
     description: "Label for required ICU and placeholder tokens below the CAT target editor",
+  },
+  characterCount: {
+    defaultMessage: "{count}/{maxLength} characters",
+    id: "MB3Jte6am8",
+    description: "Live character count for the CAT target translation against a max length limit",
+  },
+  characterCountAria: {
+    defaultMessage: "{count} of {maxLength} characters used",
+    id: "+jUwPCSypy",
+    description: "Accessible label for the CAT target translation character counter",
   },
 });
 
@@ -328,6 +368,47 @@ export const catIntelligencePanelMessages = defineMessages({
     defaultMessage: "{matchPercent}% match",
     id: "c8ULJQ9Qs8",
     description: "Translation memory match quality badge",
+  },
+  matchKindExact: {
+    defaultMessage: "100% match",
+    id: "hhrYYWvHkj",
+    description: "Badge label for an exact translation memory match",
+  },
+  matchKindContext: {
+    defaultMessage: "Context match",
+    id: "5H+UdOBSV9",
+    description: "Badge label for a context translation memory match",
+  },
+  matchKindFuzzy: {
+    defaultMessage: "Fuzzy match",
+    id: "ReZgZHvqUS",
+    description: "Badge label for a fuzzy translation memory match",
+  },
+  useTmMatch: {
+    defaultMessage: "Use",
+    id: "rHDcSl4Kt4",
+    description: "Button to apply a translation memory match to the target field",
+  },
+  lowMatchConfirmTitle: {
+    defaultMessage: "Apply low-quality TM match?",
+    id: "nojhrDNSfO",
+    description: "Title for confirmation dialog when applying a TM match below 70%",
+  },
+  lowMatchConfirmDescription: {
+    defaultMessage:
+      "This match is only {matchPercent}% similar. Applying it may introduce errors. Continue?",
+    id: "R+eufhiwar",
+    description: "Body for confirmation dialog when applying a low-quality TM match",
+  },
+  lowMatchConfirmAction: {
+    defaultMessage: "Apply anyway",
+    id: "y/0rjxqRwk",
+    description: "Confirm button for applying a low-quality TM match",
+  },
+  cancel: {
+    defaultMessage: "Cancel",
+    id: "Eecec2KI1k",
+    description: "Cancel button for low-quality TM match confirmation",
   },
 });
 
@@ -476,5 +557,20 @@ export const catEditorPanelMessages = defineMessages({
     defaultMessage: "Posting…",
     id: "j+ggKPYEzH",
     description: "Button label while a segment comment is being posted to the TMS",
+  },
+  unsavedChanges: {
+    defaultMessage: "Unsaved",
+    id: "RSN+J7hbqE",
+    description: "Badge shown when the current segment has unsaved target edits",
+  },
+  copySource: {
+    defaultMessage: "Copy source",
+    id: "JERGbk68rN",
+    description: "Button to copy the source string into the target translation field",
+  },
+  clearTarget: {
+    defaultMessage: "Clear target",
+    id: "5/hlw6iDag",
+    description: "Button to clear the target translation field",
   },
 });

--- a/apps/hyperlocalise-web/src/components/cat/dependencies.ts
+++ b/apps/hyperlocalise-web/src/components/cat/dependencies.ts
@@ -29,6 +29,7 @@ export interface CatWorkspaceNavigation {
 export interface CatWorkspaceEditing {
   onTargetChange: (segmentId: string, value: string) => void;
   onUseAiSuggestion: (segmentId: string) => void;
+  onUseTmMatch: (segmentId: string, match: CatTranslationMemoryMatch) => void;
 }
 
 export interface CatWorkspaceReview {
@@ -82,6 +83,7 @@ export interface CatWorkspaceViewProps {
   canLookupContext?: boolean;
   canUseAiRecommendation?: boolean;
   showAgentContext?: boolean;
+  dirtySegmentIds?: ReadonlySet<string>;
   className?: string;
   queueSearch?: string;
   onQueueSearchChange?: (value: string) => void;
@@ -109,6 +111,7 @@ export const noopCatDependencies: CatWorkspaceDependencies = {
   editing: {
     onTargetChange: () => undefined,
     onUseAiSuggestion: () => undefined,
+    onUseTmMatch: () => undefined,
   },
   review: {
     onApprove: () => undefined,

--- a/apps/hyperlocalise-web/src/components/cat/index.ts
+++ b/apps/hyperlocalise-web/src/components/cat/index.ts
@@ -28,5 +28,6 @@ export type {
   CatSegmentStatus,
   CatSuggestion,
   CatSuggestionSource,
+  CatTmMatchKind,
   CatWorkspaceState,
 } from "./types";

--- a/apps/hyperlocalise-web/src/components/cat/tm-match-quality.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/tm-match-quality.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  inferTmMatchKind,
+  requiresLowMatchConfirmation,
+  selectBestTmMatchForAutoFill,
+} from "./tm-match-quality";
+import type { CatTranslationMemoryMatch } from "./types";
+
+describe("inferTmMatchKind", () => {
+  it("classifies below-100 scores as fuzzy", () => {
+    expect(inferTmMatchKind(85, "Hello", "Hello")).toBe("fuzzy");
+  });
+
+  it("classifies identical source at 100% as exact", () => {
+    expect(inferTmMatchKind(100, "Hello world", "Hello world")).toBe("exact");
+  });
+
+  it("classifies different source at 100% as context", () => {
+    expect(inferTmMatchKind(100, "Hello", "Hello world")).toBe("context");
+  });
+});
+
+describe("requiresLowMatchConfirmation", () => {
+  it("requires confirmation below 70%", () => {
+    expect(requiresLowMatchConfirmation(69)).toBe(true);
+    expect(requiresLowMatchConfirmation(70)).toBe(false);
+  });
+});
+
+describe("selectBestTmMatchForAutoFill", () => {
+  const matches: CatTranslationMemoryMatch[] = [
+    {
+      id: "tm-1",
+      sourceText: "A",
+      targetText: "Alpha",
+      matchPercent: 95,
+    },
+    {
+      id: "tm-2",
+      sourceText: "B",
+      targetText: "Beta",
+      matchPercent: 100,
+      matchKind: "exact",
+    },
+  ];
+
+  it("returns the highest match when it meets the threshold", () => {
+    expect(selectBestTmMatchForAutoFill(matches, 100)?.id).toBe("tm-2");
+  });
+
+  it("returns undefined when the best match is below the threshold", () => {
+    expect(selectBestTmMatchForAutoFill(matches, 100)).toBeDefined();
+    expect(selectBestTmMatchForAutoFill([matches[0]], 100)).toBeUndefined();
+  });
+});

--- a/apps/hyperlocalise-web/src/components/cat/tm-match-quality.ts
+++ b/apps/hyperlocalise-web/src/components/cat/tm-match-quality.ts
@@ -1,0 +1,40 @@
+import type { CatTmMatchKind, CatTranslationMemoryMatch } from "./types";
+
+export const TM_LOW_MATCH_CONFIRM_THRESHOLD = 70;
+export const TM_AUTO_FILL_MIN_MATCH_PERCENT_DEFAULT = 100;
+
+export function inferTmMatchKind(
+  matchPercent: number,
+  querySourceText: string,
+  tmSourceText: string,
+): CatTmMatchKind {
+  if (matchPercent < 100) {
+    return "fuzzy";
+  }
+
+  if (querySourceText.trim() === tmSourceText.trim()) {
+    return "exact";
+  }
+
+  return "context";
+}
+
+export function requiresLowMatchConfirmation(matchPercent: number): boolean {
+  return matchPercent < TM_LOW_MATCH_CONFIRM_THRESHOLD;
+}
+
+export function selectBestTmMatchForAutoFill(
+  matches: CatTranslationMemoryMatch[] | undefined,
+  minMatchPercent: number,
+): CatTranslationMemoryMatch | undefined {
+  if (!matches?.length) {
+    return undefined;
+  }
+
+  const best = matches.toSorted((left, right) => right.matchPercent - left.matchPercent)[0];
+  if (best.matchPercent >= minMatchPercent) {
+    return best;
+  }
+
+  return undefined;
+}

--- a/apps/hyperlocalise-web/src/components/cat/types.ts
+++ b/apps/hyperlocalise-web/src/components/cat/types.ts
@@ -1,6 +1,8 @@
 export type CatSegmentStatus = "pending" | "needs_review" | "reviewed" | "skipped";
 
-export type CatSuggestionSource = "ai" | "glossary" | "tm" | "mt";
+export type CatSuggestionSource = "ai" | "glossary" | "tm";
+
+export type CatTmMatchKind = "exact" | "context" | "fuzzy";
 
 export type CatRiskLevel = "low" | "medium" | "high" | "good";
 
@@ -63,6 +65,7 @@ export interface CatTranslationMemoryMatch {
   sourceText: string;
   targetText: string;
   matchPercent: number;
+  matchKind?: CatTmMatchKind;
   contextLabel?: string;
 }
 

--- a/apps/hyperlocalise-web/src/lib/translation/load-cat-segment-concordance.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/load-cat-segment-concordance.ts
@@ -1,4 +1,5 @@
 import type { CatGlossaryTerm, CatTranslationMemoryMatch } from "@/components/cat/types";
+import { inferTmMatchKind } from "@/components/cat/tm-match-quality";
 import { searchCrowdinCatConcordance } from "@/lib/providers/adapters/crowdin/crowdin-cat-concordance";
 import { CrowdinApiClient } from "@/lib/providers/adapters/crowdin/crowdin-api";
 import type { ExternalTmsProviderKind } from "@/lib/providers/contracts/external-tms-provider-kind";
@@ -8,13 +9,14 @@ import {
   defaultGlossaryMatchResolution,
   defaultTranslationMemoryMatchResolution,
 } from "@/lib/providers/match-resolution";
-import { getActiveOrganizationExternalTmsProviderCredentialRow } from "@/lib/providers/organization-external-tms-provider-credentials";
+import { loadGlossaryMatchesForContext } from "@/lib/translation/load-glossary-matches";
+import { loadTranslationMemoryMatchesForContext } from "@/lib/translation/load-translation-memory-matches";
 import {
   decryptProviderCredential,
   unwrapProviderCredentialCrypto,
 } from "@/lib/security/provider-credential-crypto";
-import { loadGlossaryMatchesForContext } from "@/lib/translation/load-glossary-matches";
-import { loadTranslationMemoryMatchesForContext } from "@/lib/translation/load-translation-memory-matches";
+import { db, schema } from "@/lib/database";
+import { and, eq } from "drizzle-orm";
 
 export type { CatConcordanceForAiRecommendation } from "./map-cat-concordance-for-ai-recommendation";
 export { mapCatConcordanceForAiRecommendation } from "./map-cat-concordance-for-ai-recommendation";
@@ -36,19 +38,70 @@ function toCatGlossaryTerm(match: NormalizedGlossaryMatch): CatGlossaryTerm {
 
 function toCatTranslationMemoryMatch(
   match: NormalizedTranslationMemoryMatch,
+  querySourceText: string,
 ): CatTranslationMemoryMatch {
+  const matchPercent = match.matchScore ?? 0;
+
   return {
     id: match.id,
     sourceText: match.sourceText,
     targetText: match.targetText,
-    matchPercent: match.matchScore ?? 0,
+    matchPercent,
+    matchKind: inferTmMatchKind(matchPercent, querySourceText, match.sourceText),
     contextLabel: match.memoryName,
+  };
+}
+
+async function loadCrowdinProjectCredential(input: { organizationId: string; projectId: string }) {
+  const [project] = await db
+    .select({
+      externalProjectId: schema.projects.externalProjectId,
+      externalProviderCredentialId: schema.projects.externalProviderCredentialId,
+      externalProviderKind: schema.projects.externalProviderKind,
+    })
+    .from(schema.projects)
+    .where(
+      and(
+        eq(schema.projects.id, input.projectId),
+        eq(schema.projects.organizationId, input.organizationId),
+        eq(schema.projects.externalProviderKind, "crowdin"),
+        eq(schema.projects.source, "external_tms"),
+      ),
+    )
+    .limit(1);
+
+  if (!project?.externalProjectId || !project.externalProviderCredentialId) {
+    return null;
+  }
+
+  const [credential] = await db
+    .select()
+    .from(schema.organizationExternalTmsProviderCredentials)
+    .where(
+      and(
+        eq(schema.organizationExternalTmsProviderCredentials.organizationId, input.organizationId),
+        eq(schema.organizationExternalTmsProviderCredentials.providerKind, "crowdin"),
+        eq(
+          schema.organizationExternalTmsProviderCredentials.id,
+          project.externalProviderCredentialId,
+        ),
+      ),
+    )
+    .limit(1);
+
+  if (!credential) {
+    return null;
+  }
+
+  return {
+    externalProjectId: project.externalProjectId,
+    credential,
   };
 }
 
 async function loadCrowdinLiveConcordance(input: {
   organizationId: string;
-  externalProjectId: string;
+  projectId: string;
   sourceLocale: string;
   targetLocale: string;
   sourceText: string;
@@ -56,13 +109,15 @@ async function loadCrowdinLiveConcordance(input: {
   glossaryTerms: NormalizedGlossaryMatch[];
   translationMemoryMatches: NormalizedTranslationMemoryMatch[];
 }> {
-  const credential = await getActiveOrganizationExternalTmsProviderCredentialRow(
-    input.organizationId,
-  );
-  if (!credential || credential.providerKind !== "crowdin") {
+  const projectCredential = await loadCrowdinProjectCredential({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+  });
+  if (!projectCredential) {
     return { glossaryTerms: [], translationMemoryMatches: [] };
   }
 
+  const { credential, externalProjectId } = projectCredential;
   const secretMaterial = unwrapProviderCredentialCrypto(
     decryptProviderCredential({
       algorithm: credential.encryptionAlgorithm,
@@ -80,7 +135,7 @@ async function loadCrowdinLiveConcordance(input: {
 
   return searchCrowdinCatConcordance({
     client,
-    externalProjectId: input.externalProjectId,
+    externalProjectId,
     sourceLocale: input.sourceLocale,
     targetLocale: input.targetLocale,
     sourceText: input.sourceText,
@@ -99,7 +154,7 @@ export async function loadCatSegmentConcordance(input: {
   if (input.providerKind === "crowdin" && input.externalProjectId) {
     const liveMatches = await loadCrowdinLiveConcordance({
       organizationId: input.organizationId,
-      externalProjectId: input.externalProjectId,
+      projectId: input.projectId,
       sourceLocale: input.sourceLocale,
       targetLocale: input.targetLocale,
       sourceText: input.sourceText,
@@ -107,8 +162,8 @@ export async function loadCatSegmentConcordance(input: {
 
     return {
       glossaryTerms: liveMatches.glossaryTerms.map(toCatGlossaryTerm),
-      translationMemoryMatches: liveMatches.translationMemoryMatches.map(
-        toCatTranslationMemoryMatch,
+      translationMemoryMatches: liveMatches.translationMemoryMatches.map((match) =>
+        toCatTranslationMemoryMatch(match, input.sourceText),
       ),
     };
   }
@@ -137,7 +192,7 @@ export async function loadCatSegmentConcordance(input: {
   return {
     glossaryTerms: glossaryMatches.map((match) => toCatGlossaryTerm(match)),
     translationMemoryMatches: translationMemoryMatches.map((match) =>
-      toCatTranslationMemoryMatch(match),
+      toCatTranslationMemoryMatch(match, input.sourceText),
     ),
   };
 }

--- a/apps/hyperlocalise-web/src/lib/translation/load-cat-segment-concordance.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/load-cat-segment-concordance.ts
@@ -99,22 +99,24 @@ async function loadCrowdinProjectCredential(input: { organizationId: string; pro
   };
 }
 
+type CrowdinLiveConcordance = {
+  glossaryTerms: NormalizedGlossaryMatch[];
+  translationMemoryMatches: NormalizedTranslationMemoryMatch[];
+};
+
 async function loadCrowdinLiveConcordance(input: {
   organizationId: string;
   projectId: string;
   sourceLocale: string;
   targetLocale: string;
   sourceText: string;
-}): Promise<{
-  glossaryTerms: NormalizedGlossaryMatch[];
-  translationMemoryMatches: NormalizedTranslationMemoryMatch[];
-}> {
+}): Promise<CrowdinLiveConcordance | null> {
   const projectCredential = await loadCrowdinProjectCredential({
     organizationId: input.organizationId,
     projectId: input.projectId,
   });
   if (!projectCredential) {
-    return { glossaryTerms: [], translationMemoryMatches: [] };
+    return null;
   }
 
   const { credential, externalProjectId } = projectCredential;
@@ -146,12 +148,11 @@ export async function loadCatSegmentConcordance(input: {
   organizationId: string;
   projectId: string;
   providerKind?: ExternalTmsProviderKind | null;
-  externalProjectId?: string | null;
   sourceLocale: string;
   targetLocale: string;
   sourceText: string;
 }): Promise<CatSegmentConcordance> {
-  if (input.providerKind === "crowdin" && input.externalProjectId) {
+  if (input.providerKind === "crowdin") {
     const liveMatches = await loadCrowdinLiveConcordance({
       organizationId: input.organizationId,
       projectId: input.projectId,
@@ -160,12 +161,14 @@ export async function loadCatSegmentConcordance(input: {
       sourceText: input.sourceText,
     });
 
-    return {
-      glossaryTerms: liveMatches.glossaryTerms.map(toCatGlossaryTerm),
-      translationMemoryMatches: liveMatches.translationMemoryMatches.map((match) =>
-        toCatTranslationMemoryMatch(match, input.sourceText),
-      ),
-    };
+    if (liveMatches) {
+      return {
+        glossaryTerms: liveMatches.glossaryTerms.map(toCatGlossaryTerm),
+        translationMemoryMatches: liveMatches.translationMemoryMatches.map((match) =>
+          toCatTranslationMemoryMatch(match, input.sourceText),
+        ),
+      };
+    }
   }
 
   const [glossaryMatches, translationMemoryMatches] = await Promise.all([


### PR DESCRIPTION
## What changed

Improves the CAT workspace translation assistance experience:

- **TM matches**: one-click **Use** in the intelligence panel, single color-coded match badge (green for 100%/context, yellow for fuzzy), confirmation below 70%, and optional auto-fill from 100% TM on empty targets
- **Concordance**: loads on segment focus (not only during AI review) and uses the project's linked Crowdin credential instead of the org's most recently updated credential
- **Unsaved changes**: dirty indicators in the editor and queue, navigation/page-change confirmation, and browser `beforeunload` guard
- **Editor toolbar**: copy source and clear target actions
- **maxLength**: live character counter in the target editor
- **Cleanup**: removed unused `mt` suggestion source type

## How to test

- Open a CAT file workspace with TM/glossary concordance enabled
- Select a segment and confirm glossary/TM load without clicking **Get recommendation**
- Apply a TM match via **Use**; verify fuzzy matches below 70% prompt for confirmation
- Edit a target, navigate to another segment or queue page, and confirm the unsaved-changes dialog
- Use **Copy source** / **Clear target** in the target toolbar
- For segments with `maxLength`, confirm the live `{count}/{maxLength}` counter updates while typing
- Run `cd apps/hyperlocalise-web && vp test src/components/cat/ && vp check --fix`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)