### PR TITLE
feat(cat): queue filters, bulk actions, and segment share links

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -506,6 +506,14 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
             return projectNotFoundResponse(c);
           }
 
+          if (query.queueFilter === "has_issues") {
+            return badRequestResponse(
+              c,
+              "unsupported_queue_filter",
+              "The has issues filter is only available for Crowdin projects.",
+            );
+          }
+
           const catFile = await getNativeProjectCatFile({
             organizationId: c.var.auth.organization.localOrganizationId,
             projectId: params.projectId,

--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -209,11 +209,20 @@ export const projectFileDetailQuerySchema = z.object({
   sourcePath: z.string().trim().min(1).max(2048),
 });
 
+export const projectFileCatQueueFilterSchema = z.enum([
+  "all",
+  "untranslated",
+  "needs_review",
+  "reviewed",
+  "has_issues",
+]);
+
 export const projectFileCatQuerySchema = z.object({
   sourcePath: z.string().trim().min(1).max(2048),
   targetLocale: z.string().trim().min(1).max(32),
   repositoryFullName: z.string().trim().min(1).max(256).optional(),
   search: z.string().trim().max(256).optional(),
+  queueFilter: projectFileCatQueueFilterSchema.optional(),
   offset: z.coerce.number().int().min(0).optional(),
   limit: z.coerce.number().int().min(1).max(100).optional(),
 });
@@ -505,6 +514,7 @@ export type ProjectFilesResponse = z.infer<typeof projectFilesResponseSchema>;
 export type ProjectFilesQuery = z.infer<typeof projectFilesQuerySchema>;
 export type ProjectFileDetailQuery = z.infer<typeof projectFileDetailQuerySchema>;
 export type ProjectFileCatQuery = z.infer<typeof projectFileCatQuerySchema>;
+export type ProjectFileCatQueueFilter = z.infer<typeof projectFileCatQueueFilterSchema>;
 export type ProjectFileCatTranslationBody = z.infer<typeof projectFileCatTranslationBodySchema>;
 export type ProjectFileCatRecommendationBody = z.infer<
   typeof projectFileCatRecommendationBodySchema

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
@@ -50,11 +50,16 @@ function stringsPageHref(input: {
   jobId: string;
   sourcePath: string;
   targetLocale: string;
+  segment?: string | null;
 }) {
   const params = new URLSearchParams({
     sourcePath: input.sourcePath,
     targetLocale: input.targetLocale,
   });
+
+  if (input.segment) {
+    params.set("segment", input.segment);
+  }
 
   return `/org/${input.organizationSlug}/projects/${encodeURIComponent(input.projectId)}/jobs/${encodeURIComponent(input.jobId)}/strings?${params.toString()}`;
 }
@@ -65,12 +70,14 @@ export function JobCatPageContent({
   jobId,
   sourcePath,
   targetLocale,
+  initialSegmentKey = null,
 }: {
   organizationSlug: string;
   projectId: string;
   jobId: string;
   sourcePath: string | null;
   targetLocale: string | null;
+  initialSegmentKey?: string | null;
 }) {
   const router = useRouter();
   const taskHref = `/org/${organizationSlug}/projects/${encodeURIComponent(projectId)}/jobs/${encodeURIComponent(jobId)}`;
@@ -352,6 +359,7 @@ export function JobCatPageContent({
           sourcePath={selectedFile.sourcePath}
           targetLocale={selectedTargetLocale}
           repositoryFullName={selectedRepositoryFullName}
+          initialSegmentKey={initialSegmentKey}
           layout="fullscreen"
         />
       </div>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/page.tsx
@@ -7,10 +7,10 @@ export default async function ProjectJobStringsPage({
   searchParams,
 }: {
   params: Promise<{ organizationSlug: string; projectId: string; jobId: string }>;
-  searchParams: Promise<{ sourcePath?: string; targetLocale?: string }>;
+  searchParams: Promise<{ sourcePath?: string; targetLocale?: string; segment?: string }>;
 }) {
   const { organizationSlug, projectId, jobId } = await params;
-  const { sourcePath, targetLocale } = await searchParams;
+  const { sourcePath, targetLocale, segment } = await searchParams;
   await requireAppAuthContext({ organizationSlug });
 
   return (
@@ -20,6 +20,7 @@ export default async function ProjectJobStringsPage({
       jobId={jobId}
       sourcePath={sourcePath ?? null}
       targetLocale={targetLocale ?? null}
+      initialSegmentKey={segment ?? null}
     />
   );
 }

--- a/apps/hyperlocalise-web/src/components/cat/cat-editor-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-editor-panel.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { ArrowLeft01Icon, ArrowRight01Icon } from "@hugeicons/core-free-icons";
+import { ArrowLeft01Icon, ArrowRight01Icon, LinkSquare02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { CheckIcon } from "lucide-react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { FormattedMessage, useIntl, type IntlShape } from "react-intl";
 
@@ -80,6 +81,7 @@ export function CatEditorPanel({
   onNext,
   hasPreviousSegment,
   hasNextSegment,
+  segmentShareUrl = null,
 }: {
   segment: CatSegment;
   segmentPosition: number;
@@ -113,8 +115,10 @@ export function CatEditorPanel({
   onNext: () => void;
   hasPreviousSegment: boolean;
   hasNextSegment: boolean;
+  segmentShareUrl?: string | null;
 }) {
   const intl = useIntl();
+  const [shareLinkState, setShareLinkState] = useState<"idle" | "copied" | "error">("idle");
   const resolvedPrimaryActionLabel =
     primaryActionLabel ?? intl.formatMessage(catEditorPanelMessages.approve);
   const [commentDrafts, setCommentDrafts] = useState<Record<string, string>>({});
@@ -197,6 +201,26 @@ export function CatEditorPanel({
     handleCommentDraftChange("");
   }
 
+  async function handleShareSegment() {
+    if (!segmentShareUrl) {
+      return;
+    }
+
+    if (typeof window === "undefined" || !navigator?.clipboard?.writeText) {
+      setShareLinkState("error");
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(segmentShareUrl);
+      setShareLinkState("copied");
+      window.setTimeout(() => setShareLinkState("idle"), 2000);
+    } catch {
+      setShareLinkState("error");
+      window.setTimeout(() => setShareLinkState("idle"), 2000);
+    }
+  }
+
   return (
     <div className="flex h-full min-h-0 flex-col bg-background">
       <div className="flex flex-wrap items-center justify-between gap-3 border-b border-foreground/8 px-4 py-3 lg:px-5">
@@ -211,6 +235,27 @@ export function CatEditorPanel({
           ) : null}
         </div>
         <div className="flex items-center gap-1">
+          {segmentShareUrl ? (
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              onClick={() => void handleShareSegment()}
+              aria-label={intl.formatMessage(catEditorPanelMessages.shareSegmentAria)}
+              title={
+                shareLinkState === "copied"
+                  ? intl.formatMessage(catEditorPanelMessages.shareSegmentCopied)
+                  : shareLinkState === "error"
+                    ? intl.formatMessage(catEditorPanelMessages.shareSegmentFailed)
+                    : intl.formatMessage(catEditorPanelMessages.shareSegment)
+              }
+            >
+              {shareLinkState === "copied" ? (
+                <CheckIcon className="size-4" />
+              ) : (
+                <HugeiconsIcon icon={LinkSquare02Icon} className="size-4" />
+              )}
+            </Button>
+          ) : null}
           <Button
             variant="ghost"
             size="icon-sm"

--- a/apps/hyperlocalise-web/src/components/cat/cat-queue-filter.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat-queue-filter.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   filterCatQueueSegments,
   findSegmentIdByKeyOrId,
+  resolveAvailableCatQueueFilters,
   resolveSelectedSegmentId,
+  resolveVisibleQueueSegments,
   segmentMatchesQueueFilter,
 } from "./cat-queue-filter";
 import type { CatSegment } from "./types";
@@ -84,6 +86,39 @@ describe("segmentMatchesQueueFilter", () => {
     expect(filterCatQueueSegments(segments, "reviewed").map((segment) => segment.id)).toEqual([
       "b",
     ]);
+  });
+});
+
+describe("resolveAvailableCatQueueFilters", () => {
+  it("omits has issues for native projects", () => {
+    expect(resolveAvailableCatQueueFilters(null)).not.toContain("has_issues");
+    expect(resolveAvailableCatQueueFilters(undefined)).not.toContain("has_issues");
+  });
+
+  it("includes has issues for Crowdin projects", () => {
+    expect(resolveAvailableCatQueueFilters("crowdin")).toContain("has_issues");
+  });
+});
+
+describe("resolveVisibleQueueSegments", () => {
+  it("keeps server-filtered segments unchanged", () => {
+    const segments = [
+      createSegment({ id: "a", status: "pending" }),
+      createSegment({ id: "b", status: "reviewed" }),
+    ];
+
+    expect(resolveVisibleQueueSegments(segments, "needs_review", true)).toEqual(segments);
+  });
+
+  it("applies local skipped filtering when the server does not own the filter", () => {
+    const segments = [
+      createSegment({ id: "a", status: "skipped" }),
+      createSegment({ id: "b", status: "reviewed" }),
+    ];
+
+    expect(
+      resolveVisibleQueueSegments(segments, "skipped", true).map((segment) => segment.id),
+    ).toEqual(["a"]);
   });
 });
 

--- a/apps/hyperlocalise-web/src/components/cat/cat-queue-filter.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat-queue-filter.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   filterCatQueueSegments,
+  findSegmentIdByKeyOrId,
   resolveSelectedSegmentId,
   segmentMatchesQueueFilter,
 } from "./cat-queue-filter";
@@ -83,6 +84,21 @@ describe("segmentMatchesQueueFilter", () => {
     expect(filterCatQueueSegments(segments, "reviewed").map((segment) => segment.id)).toEqual([
       "b",
     ]);
+  });
+});
+
+describe("findSegmentIdByKeyOrId", () => {
+  const segments = [
+    createSegment({ id: "seg-1", key: "alpha" }),
+    createSegment({ id: "seg-2", key: "beta" }),
+  ];
+
+  it("returns null when the segment is not loaded yet", () => {
+    expect(findSegmentIdByKeyOrId([], "beta")).toBeNull();
+  });
+
+  it("resolves by segment key", () => {
+    expect(findSegmentIdByKeyOrId(segments, "beta")).toBe("seg-2");
   });
 });
 

--- a/apps/hyperlocalise-web/src/components/cat/cat-queue-filter.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat-queue-filter.test.ts
@@ -54,6 +54,25 @@ describe("segmentMatchesQueueFilter", () => {
     expect(segmentMatchesQueueFilter(withIssue, "needs_review")).toBe(false);
   });
 
+  it("ignores resolved issue comments for the has issues filter", () => {
+    const withResolvedIssue = createSegment({
+      status: "needs_review",
+      comments: [
+        {
+          id: "c-1",
+          type: "issue",
+          status: "resolved",
+          text: "Fixed tone",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          locale: "vi",
+        },
+      ],
+    });
+
+    expect(segmentMatchesQueueFilter(withResolvedIssue, "has_issues")).toBe(false);
+    expect(segmentMatchesQueueFilter(withResolvedIssue, "needs_review")).toBe(true);
+  });
+
   it("filters segment lists", () => {
     const segments = [
       createSegment({ id: "a", status: "pending" }),

--- a/apps/hyperlocalise-web/src/components/cat/cat-queue-filter.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat-queue-filter.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  filterCatQueueSegments,
+  resolveSelectedSegmentId,
+  segmentMatchesQueueFilter,
+} from "./cat-queue-filter";
+import type { CatSegment } from "./types";
+
+function createSegment(overrides: Partial<CatSegment> = {}): CatSegment {
+  return {
+    id: "seg-1",
+    index: 1,
+    key: "app.title",
+    sourceText: "Hello",
+    targetText: "",
+    sourceLocale: "en",
+    targetLocale: "vi",
+    status: "pending",
+    ...overrides,
+  };
+}
+
+describe("segmentMatchesQueueFilter", () => {
+  it("matches untranslated pending segments", () => {
+    expect(segmentMatchesQueueFilter(createSegment({ status: "pending" }), "untranslated")).toBe(
+      true,
+    );
+    expect(
+      segmentMatchesQueueFilter(createSegment({ status: "needs_review" }), "untranslated"),
+    ).toBe(false);
+  });
+
+  it("matches reviewed segments", () => {
+    expect(segmentMatchesQueueFilter(createSegment({ status: "reviewed" }), "reviewed")).toBe(true);
+  });
+
+  it("matches issue segments separately from generic needs review", () => {
+    const withIssue = createSegment({
+      status: "needs_review",
+      comments: [
+        {
+          id: "c-1",
+          type: "issue",
+          status: "open",
+          text: "Wrong tone",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          locale: "vi",
+        },
+      ],
+    });
+
+    expect(segmentMatchesQueueFilter(withIssue, "has_issues")).toBe(true);
+    expect(segmentMatchesQueueFilter(withIssue, "needs_review")).toBe(false);
+  });
+
+  it("filters segment lists", () => {
+    const segments = [
+      createSegment({ id: "a", status: "pending" }),
+      createSegment({ id: "b", status: "reviewed" }),
+      createSegment({ id: "c", status: "skipped" }),
+    ];
+
+    expect(filterCatQueueSegments(segments, "reviewed").map((segment) => segment.id)).toEqual([
+      "b",
+    ]);
+  });
+});
+
+describe("resolveSelectedSegmentId", () => {
+  const segments = [
+    createSegment({ id: "seg-1", key: "alpha" }),
+    createSegment({ id: "seg-2", key: "beta" }),
+  ];
+
+  it("resolves by segment key", () => {
+    expect(resolveSelectedSegmentId(segments, "beta", "seg-1")).toBe("seg-2");
+  });
+
+  it("falls back when the preferred segment is missing", () => {
+    expect(resolveSelectedSegmentId(segments, "missing", "seg-1")).toBe("seg-1");
+  });
+});

--- a/apps/hyperlocalise-web/src/components/cat/cat-queue-filter.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat-queue-filter.ts
@@ -17,6 +17,14 @@ export const catQueueFilterValues: CatQueueFilter[] = [
   "skipped",
 ];
 
+export function findSegmentIdByKeyOrId(segments: CatSegment[], segmentIdOrKey: string) {
+  const match = segments.find(
+    (segment) => segment.id === segmentIdOrKey || segment.key === segmentIdOrKey,
+  );
+
+  return match?.id ?? null;
+}
+
 export function segmentHasOpenIssues(segment: CatSegment) {
   return (
     segment.comments?.some((comment) => comment.type === "issue" && comment.status === "open") ??
@@ -60,9 +68,5 @@ export function resolveSelectedSegmentId(
     return fallbackSegmentId;
   }
 
-  const match = segments.find(
-    (segment) => segment.id === preferredSegmentIdOrKey || segment.key === preferredSegmentIdOrKey,
-  );
-
-  return match?.id ?? fallbackSegmentId;
+  return findSegmentIdByKeyOrId(segments, preferredSegmentIdOrKey) ?? fallbackSegmentId;
 }

--- a/apps/hyperlocalise-web/src/components/cat/cat-queue-filter.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat-queue-filter.ts
@@ -1,12 +1,8 @@
+import type { ProjectFileCatQueueFilter } from "@/api/routes/project/project.schema";
+
 import type { CatSegment } from "./types";
 
-export type CatQueueFilter =
-  | "all"
-  | "untranslated"
-  | "needs_review"
-  | "reviewed"
-  | "has_issues"
-  | "skipped";
+export type CatQueueFilter = ProjectFileCatQueueFilter | "skipped";
 
 export const catQueueFilterValues: CatQueueFilter[] = [
   "all",
@@ -16,6 +12,10 @@ export const catQueueFilterValues: CatQueueFilter[] = [
   "has_issues",
   "skipped",
 ];
+
+export function isServerQueueFilter(filter: CatQueueFilter): filter is ProjectFileCatQueueFilter {
+  return filter !== "skipped";
+}
 
 export function findSegmentIdByKeyOrId(segments: CatSegment[], segmentIdOrKey: string) {
   const match = segments.find(

--- a/apps/hyperlocalise-web/src/components/cat/cat-queue-filter.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat-queue-filter.ts
@@ -18,7 +18,10 @@ export const catQueueFilterValues: CatQueueFilter[] = [
 ];
 
 export function segmentHasOpenIssues(segment: CatSegment) {
-  return segment.comments?.some((comment) => comment.type === "issue") ?? false;
+  return (
+    segment.comments?.some((comment) => comment.type === "issue" && comment.status === "open") ??
+    false
+  );
 }
 
 export function segmentMatchesQueueFilter(segment: CatSegment, filter: CatQueueFilter) {

--- a/apps/hyperlocalise-web/src/components/cat/cat-queue-filter.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat-queue-filter.ts
@@ -1,0 +1,65 @@
+import type { CatSegment } from "./types";
+
+export type CatQueueFilter =
+  | "all"
+  | "untranslated"
+  | "needs_review"
+  | "reviewed"
+  | "has_issues"
+  | "skipped";
+
+export const catQueueFilterValues: CatQueueFilter[] = [
+  "all",
+  "untranslated",
+  "needs_review",
+  "reviewed",
+  "has_issues",
+  "skipped",
+];
+
+export function segmentHasOpenIssues(segment: CatSegment) {
+  return segment.comments?.some((comment) => comment.type === "issue") ?? false;
+}
+
+export function segmentMatchesQueueFilter(segment: CatSegment, filter: CatQueueFilter) {
+  switch (filter) {
+    case "all":
+      return true;
+    case "untranslated":
+      return segment.status === "pending";
+    case "needs_review":
+      return segment.status === "needs_review" && !segmentHasOpenIssues(segment);
+    case "reviewed":
+      return segment.status === "reviewed";
+    case "has_issues":
+      return segmentHasOpenIssues(segment);
+    case "skipped":
+      return segment.status === "skipped";
+    default:
+      return true;
+  }
+}
+
+export function filterCatQueueSegments(segments: CatSegment[], filter: CatQueueFilter) {
+  if (filter === "all") {
+    return segments;
+  }
+
+  return segments.filter((segment) => segmentMatchesQueueFilter(segment, filter));
+}
+
+export function resolveSelectedSegmentId(
+  segments: CatSegment[],
+  preferredSegmentIdOrKey: string | null | undefined,
+  fallbackSegmentId: string,
+) {
+  if (!preferredSegmentIdOrKey) {
+    return fallbackSegmentId;
+  }
+
+  const match = segments.find(
+    (segment) => segment.id === preferredSegmentIdOrKey || segment.key === preferredSegmentIdOrKey,
+  );
+
+  return match?.id ?? fallbackSegmentId;
+}

--- a/apps/hyperlocalise-web/src/components/cat/cat-queue-filter.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat-queue-filter.ts
@@ -17,6 +17,37 @@ export function isServerQueueFilter(filter: CatQueueFilter): filter is ProjectFi
   return filter !== "skipped";
 }
 
+export function isQueueFilterSupportedForProvider(
+  filter: CatQueueFilter,
+  providerKind: string | null | undefined,
+) {
+  if (filter === "has_issues") {
+    return providerKind === "crowdin";
+  }
+
+  return true;
+}
+
+export function resolveAvailableCatQueueFilters(
+  providerKind: string | null | undefined,
+): CatQueueFilter[] {
+  return catQueueFilterValues.filter((filter) =>
+    isQueueFilterSupportedForProvider(filter, providerKind),
+  );
+}
+
+export function resolveVisibleQueueSegments(
+  segments: CatSegment[],
+  queueFilter: CatQueueFilter,
+  usesServerQueueFilter: boolean,
+) {
+  if (usesServerQueueFilter && isServerQueueFilter(queueFilter)) {
+    return segments;
+  }
+
+  return filterCatQueueSegments(segments, queueFilter);
+}
+
 export function findSegmentIdByKeyOrId(segments: CatSegment[], segmentIdOrKey: string) {
   const match = segments.find(
     (segment) => segment.id === segmentIdOrKey || segment.key === segmentIdOrKey,

--- a/apps/hyperlocalise-web/src/components/cat/cat-queue-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-queue-panel.tsx
@@ -1,15 +1,26 @@
 "use client";
 
-import { SearchIcon } from "@hugeicons/core-free-icons";
+import { FilterIcon, MoreHorizontalCircle01Icon, SearchIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Progress } from "@/components/ui/progress";
 import { Spinner } from "@/components/ui/spinner";
+import { cn } from "@/lib/primitives/cn";
 
 import { CatQueueVirtualList } from "./cat-queue-virtual-list";
+import { catQueueFilterValues, type CatQueueFilter } from "./cat-queue-filter";
 import { catQueuePanelMessages } from "./cat.messages";
 import type { CatQueueSummary, CatSegment } from "./types";
 
@@ -21,6 +32,18 @@ export type CatQueuePagination = {
   hasMore: boolean;
 };
 
+const queueFilterMessageByValue: Record<
+  CatQueueFilter,
+  (typeof catQueuePanelMessages)[keyof typeof catQueuePanelMessages]
+> = {
+  all: catQueuePanelMessages.filterAll,
+  untranslated: catQueuePanelMessages.filterUntranslated,
+  needs_review: catQueuePanelMessages.filterNeedsReview,
+  reviewed: catQueuePanelMessages.filterReviewed,
+  has_issues: catQueuePanelMessages.filterHasIssues,
+  skipped: catQueuePanelMessages.filterSkipped,
+};
+
 export function CatQueuePanel({
   segments,
   selectedSegmentId,
@@ -30,6 +53,15 @@ export function CatQueuePanel({
   search = "",
   onSearchChange,
   isSearching = false,
+  queueFilter = "all",
+  onQueueFilterChange,
+  checkedSegmentIds,
+  onToggleSegmentChecked,
+  onSelectAllVisible,
+  onClearChecked,
+  onBulkApprove,
+  onBulkSkip,
+  isBulkActionPending = false,
   isFetchingPage = false,
   pagination = null,
   onPreviousPage,
@@ -44,6 +76,15 @@ export function CatQueuePanel({
   search?: string;
   onSearchChange?: (value: string) => void;
   isSearching?: boolean;
+  queueFilter?: CatQueueFilter;
+  onQueueFilterChange?: (filter: CatQueueFilter) => void;
+  checkedSegmentIds?: ReadonlySet<string>;
+  onToggleSegmentChecked?: (segmentId: string, checked: boolean) => void;
+  onSelectAllVisible?: () => void;
+  onClearChecked?: () => void;
+  onBulkApprove?: () => void;
+  onBulkSkip?: () => void;
+  isBulkActionPending?: boolean;
   isFetchingPage?: boolean;
   pagination?: CatQueuePagination | null;
   onPreviousPage?: () => void;
@@ -55,6 +96,13 @@ export function CatQueuePanel({
     summary.total > 0 ? Math.round((summary.reviewed / summary.total) * 100) : 0;
   const rangeStart = pagination ? pagination.offset + 1 : 1;
   const rangeEnd = pagination ? pagination.offset + pagination.returnedCount : segments.length;
+  const selectedCount = checkedSegmentIds?.size ?? 0;
+  const hasBulkActions = Boolean(onBulkApprove || onBulkSkip);
+  const hasActiveFilter = queueFilter !== "all";
+  const emptyMessage =
+    hasActiveFilter && !search.trim()
+      ? catQueuePanelMessages.emptyFilterResults
+      : catQueuePanelMessages.emptySearchResults;
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-background lg:border-r lg:border-foreground/8">
@@ -89,6 +137,108 @@ export function CatQueuePanel({
             ) : null}
           </div>
         ) : null}
+
+        {onQueueFilterChange || hasBulkActions ? (
+          <div className="flex items-center justify-between gap-2">
+            {onQueueFilterChange ? (
+              <DropdownMenu>
+                <DropdownMenuTrigger
+                  render={
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className={cn(
+                        "h-8 gap-1.5 font-normal",
+                        hasActiveFilter && "border-grove-400/40",
+                      )}
+                      aria-label={intl.formatMessage(catQueuePanelMessages.filterQueueAria)}
+                    />
+                  }
+                >
+                  <HugeiconsIcon icon={FilterIcon} className="size-3.5" />
+                  <span className="text-xs">
+                    <FormattedMessage {...queueFilterMessageByValue[queueFilter]} />
+                  </span>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="start" className="w-48">
+                  <DropdownMenuLabel>
+                    <FormattedMessage {...catQueuePanelMessages.filterQueueAria} />
+                  </DropdownMenuLabel>
+                  <DropdownMenuSeparator />
+                  {catQueueFilterValues.map((filterValue) => (
+                    <DropdownMenuCheckboxItem
+                      key={filterValue}
+                      checked={queueFilter === filterValue}
+                      onCheckedChange={() => onQueueFilterChange(filterValue)}
+                    >
+                      <FormattedMessage {...queueFilterMessageByValue[filterValue]} />
+                    </DropdownMenuCheckboxItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            ) : (
+              <span />
+            )}
+
+            {hasBulkActions ? (
+              <DropdownMenu>
+                <DropdownMenuTrigger
+                  render={
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="icon-sm"
+                      className="size-8"
+                      aria-label={intl.formatMessage(catQueuePanelMessages.queueActionsAria)}
+                      disabled={isBulkActionPending}
+                    />
+                  }
+                >
+                  {isBulkActionPending ? (
+                    <Spinner className="size-3.5" />
+                  ) : (
+                    <HugeiconsIcon icon={MoreHorizontalCircle01Icon} className="size-4" />
+                  )}
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-52">
+                  <DropdownMenuLabel>
+                    {selectedCount > 0 ? (
+                      <FormattedMessage
+                        {...catQueuePanelMessages.bulkSelectionSummary}
+                        values={{ count: selectedCount }}
+                      />
+                    ) : (
+                      <FormattedMessage {...catQueuePanelMessages.queueActionsAria} />
+                    )}
+                  </DropdownMenuLabel>
+                  <DropdownMenuSeparator />
+                  {onSelectAllVisible ? (
+                    <DropdownMenuItem onClick={onSelectAllVisible} disabled={segments.length === 0}>
+                      <FormattedMessage {...catQueuePanelMessages.bulkSelectAll} />
+                    </DropdownMenuItem>
+                  ) : null}
+                  {onClearChecked ? (
+                    <DropdownMenuItem onClick={onClearChecked} disabled={selectedCount === 0}>
+                      <FormattedMessage {...catQueuePanelMessages.bulkClearSelection} />
+                    </DropdownMenuItem>
+                  ) : null}
+                  <DropdownMenuSeparator />
+                  {onBulkApprove ? (
+                    <DropdownMenuItem onClick={onBulkApprove} disabled={selectedCount === 0}>
+                      <FormattedMessage {...catQueuePanelMessages.bulkApprove} />
+                    </DropdownMenuItem>
+                  ) : null}
+                  {onBulkSkip ? (
+                    <DropdownMenuItem onClick={onBulkSkip} disabled={selectedCount === 0}>
+                      <FormattedMessage {...catQueuePanelMessages.bulkSkip} />
+                    </DropdownMenuItem>
+                  ) : null}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            ) : null}
+          </div>
+        ) : null}
       </div>
 
       <div className="px-4 py-3">
@@ -97,13 +247,15 @@ export function CatQueuePanel({
 
       {segments.length === 0 ? (
         <div className="flex min-h-0 flex-1 items-center justify-center px-4 pb-3 text-sm text-muted-foreground">
-          <FormattedMessage {...catQueuePanelMessages.emptySearchResults} />
+          <FormattedMessage {...emptyMessage} />
         </div>
       ) : (
         <CatQueueVirtualList
           segments={segments}
           selectedSegmentId={selectedSegmentId}
           dirtySegmentIds={dirtySegmentIds}
+          checkedSegmentIds={checkedSegmentIds}
+          onToggleSegmentChecked={onToggleSegmentChecked}
           onSelectSegment={onSelectSegment}
           onNearEnd={onNearEnd}
         />

--- a/apps/hyperlocalise-web/src/components/cat/cat-queue-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-queue-panel.tsx
@@ -55,6 +55,7 @@ export function CatQueuePanel({
   isSearching = false,
   queueFilter = "all",
   onQueueFilterChange,
+  availableQueueFilters = catQueueFilterValues,
   checkedSegmentIds,
   onToggleSegmentChecked,
   onSelectAllVisible,
@@ -78,6 +79,7 @@ export function CatQueuePanel({
   isSearching?: boolean;
   queueFilter?: CatQueueFilter;
   onQueueFilterChange?: (filter: CatQueueFilter) => void;
+  availableQueueFilters?: CatQueueFilter[];
   checkedSegmentIds?: ReadonlySet<string>;
   onToggleSegmentChecked?: (segmentId: string, checked: boolean) => void;
   onSelectAllVisible?: () => void;
@@ -166,7 +168,7 @@ export function CatQueuePanel({
                     <FormattedMessage {...catQueuePanelMessages.filterQueueAria} />
                   </DropdownMenuLabel>
                   <DropdownMenuSeparator />
-                  {catQueueFilterValues.map((filterValue) => (
+                  {availableQueueFilters.map((filterValue) => (
                     <DropdownMenuCheckboxItem
                       key={filterValue}
                       checked={queueFilter === filterValue}

--- a/apps/hyperlocalise-web/src/components/cat/cat-queue-virtual-list.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-queue-virtual-list.tsx
@@ -27,6 +27,8 @@ export function CatQueueVirtualList({
   segments,
   selectedSegmentId,
   dirtySegmentIds,
+  checkedSegmentIds,
+  onToggleSegmentChecked,
   onSelectSegment,
   onNearEnd,
   className,
@@ -34,12 +36,15 @@ export function CatQueueVirtualList({
   segments: CatSegment[];
   selectedSegmentId: string;
   dirtySegmentIds?: ReadonlySet<string>;
+  checkedSegmentIds?: ReadonlySet<string>;
+  onToggleSegmentChecked?: (segmentId: string, checked: boolean) => void;
   onSelectSegment: (segmentId: string) => void;
   onNearEnd?: () => void;
   className?: string;
 }) {
   const intl = useIntl();
   const parentRef = useRef<HTMLDivElement>(null);
+  const showSelection = Boolean(onToggleSegmentChecked);
   const virtualizer = useVirtualizer({
     count: segments.length,
     getScrollElement: () => parentRef.current,
@@ -74,6 +79,7 @@ export function CatQueueVirtualList({
 
           const selected = segment.id === selectedSegmentId;
           const isDirty = dirtySegmentIds?.has(segment.id) ?? false;
+          const isChecked = checkedSegmentIds?.has(segment.id) ?? false;
 
           return (
             <li
@@ -83,37 +89,59 @@ export function CatQueueVirtualList({
               className="absolute top-0 left-0 w-full"
               style={{ transform: `translateY(${virtualRow.start}px)` }}
             >
-              <button
-                type="button"
-                onClick={() => onSelectSegment(segment.id)}
+              <div
                 className={cn(
-                  "flex min-h-11 w-full items-start gap-3 rounded-lg px-3 py-2.5 text-left transition-colors",
+                  "flex min-h-11 w-full items-start gap-2 rounded-lg px-2 py-2.5 transition-colors",
                   selected
                     ? "bg-grove-500/10 ring-1 ring-inset ring-grove-400/25"
                     : "hover:bg-foreground/4",
                 )}
               >
-                <span className="mt-0.5 w-5 shrink-0 font-mono text-xs text-muted-foreground">
-                  {String(segment.index).padStart(2, "0")}
-                </span>
-                <div className="min-w-0 flex-1 space-y-1">
-                  <p className="line-clamp-2 text-sm text-foreground/90">{segment.sourceText}</p>
-                  <div className="flex min-w-0 items-center">
-                    <span className="min-w-0 truncate font-mono text-xs text-muted-foreground">
-                      {segment.key}
-                    </span>
-                  </div>
-                </div>
-                <div className="mt-1 flex shrink-0 flex-col items-center gap-1">
-                  {isDirty ? (
-                    <span
-                      className="size-2 rounded-full bg-bud-400"
-                      aria-label={intl.formatMessage(catQueuePanelMessages.unsavedChangesAria)}
+                {showSelection ? (
+                  <label className="mt-1.5 flex shrink-0 cursor-pointer items-center">
+                    <input
+                      type="checkbox"
+                      className="size-4 rounded border-foreground/20 accent-foreground"
+                      checked={isChecked}
+                      aria-label={intl.formatMessage(catQueuePanelMessages.selectSegmentAria, {
+                        key: segment.key,
+                      })}
+                      onChange={(event) => {
+                        event.stopPropagation();
+                        onToggleSegmentChecked?.(segment.id, event.currentTarget.checked);
+                      }}
+                      onClick={(event) => event.stopPropagation()}
                     />
-                  ) : null}
-                  <QueueStatusDot status={segment.status} />
-                </div>
-              </button>
+                  </label>
+                ) : null}
+
+                <button
+                  type="button"
+                  onClick={() => onSelectSegment(segment.id)}
+                  className="flex min-w-0 flex-1 items-start gap-3 text-left"
+                >
+                  <span className="mt-0.5 w-5 shrink-0 font-mono text-xs text-muted-foreground">
+                    {String(segment.index).padStart(2, "0")}
+                  </span>
+                  <div className="min-w-0 flex-1 space-y-1">
+                    <p className="line-clamp-2 text-sm text-foreground/90">{segment.sourceText}</p>
+                    <div className="flex min-w-0 items-center">
+                      <span className="min-w-0 truncate font-mono text-xs text-muted-foreground">
+                        {segment.key}
+                      </span>
+                    </div>
+                  </div>
+                  <div className="mt-1 flex shrink-0 flex-col items-center gap-1">
+                    {isDirty ? (
+                      <span
+                        className="size-2 rounded-full bg-bud-400"
+                        aria-label={intl.formatMessage(catQueuePanelMessages.unsavedChangesAria)}
+                      />
+                    ) : null}
+                    <QueueStatusDot status={segment.status} />
+                  </div>
+                </button>
+              </div>
             </li>
           );
         })}

--- a/apps/hyperlocalise-web/src/components/cat/cat-segment-share-link.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat-segment-share-link.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  buildCatSegmentShareUrl,
+  catSegmentShareParam,
+  readCatSegmentShareParam,
+} from "./cat-segment-share-link";
+
+describe("cat segment share link", () => {
+  it("builds a share URL using the segment key when available", () => {
+    const url = buildCatSegmentShareUrl({
+      baseUrl: "https://example.com/strings?sourcePath=messages.json&targetLocale=vi",
+      segmentId: "seg-42",
+      segmentKey: "review.bulk.approve",
+    });
+
+    expect(url).toContain(`${catSegmentShareParam}=review.bulk.approve`);
+  });
+
+  it("reads the segment share param from search params", () => {
+    const params = new URLSearchParams("segment=review.bulk.skip&targetLocale=vi");
+    expect(readCatSegmentShareParam(params)).toBe("review.bulk.skip");
+  });
+});

--- a/apps/hyperlocalise-web/src/components/cat/cat-segment-share-link.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat-segment-share-link.ts
@@ -1,0 +1,16 @@
+export const catSegmentShareParam = "segment";
+
+export function buildCatSegmentShareUrl(input: {
+  baseUrl: string;
+  segmentId: string;
+  segmentKey?: string;
+}) {
+  const url = new URL(input.baseUrl);
+  url.searchParams.set(catSegmentShareParam, input.segmentKey ?? input.segmentId);
+  return url.toString();
+}
+
+export function readCatSegmentShareParam(searchParams: URLSearchParams) {
+  const value = searchParams.get(catSegmentShareParam)?.trim();
+  return value || null;
+}

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
@@ -33,6 +33,12 @@ import {
   syncSavedTargetTexts,
   type SavedTargetTextMap,
 } from "./cat-dirty-state";
+import {
+  filterCatQueueSegments,
+  resolveSelectedSegmentId,
+  type CatQueueFilter,
+} from "./cat-queue-filter";
+import { buildCatSegmentShareUrl } from "./cat-segment-share-link";
 import { catEditorPanelMessages, catWorkspaceContainerMessages } from "./cat.messages";
 import {
   selectBestTmMatchForAutoFill,
@@ -239,6 +245,8 @@ export interface CatWorkspaceContainerProps {
   onQueuePreviousPage?: () => void;
   onQueueNextPage?: () => void;
   onQueueNearEnd?: () => void;
+  initialSegmentKeyOrId?: string | null;
+  buildSegmentShareUrl?: (segment: CatSegment) => string | null;
   tmAutoFillMinMatchPercent?: number;
 }
 
@@ -271,10 +279,22 @@ export function CatWorkspaceContainer({
   onQueuePreviousPage,
   onQueueNextPage,
   onQueueNearEnd,
+  initialSegmentKeyOrId,
+  buildSegmentShareUrl,
   tmAutoFillMinMatchPercent = TM_AUTO_FILL_MIN_MATCH_PERCENT_DEFAULT,
 }: CatWorkspaceContainerProps) {
   const intl = useIntl();
-  const [state, setState] = useState(initialState);
+  const [state, setState] = useState(() => ({
+    ...initialState,
+    selectedSegmentId: resolveSelectedSegmentId(
+      initialState.segments,
+      initialSegmentKeyOrId,
+      initialState.selectedSegmentId,
+    ),
+  }));
+  const [queueFilter, setQueueFilter] = useState<CatQueueFilter>("all");
+  const [checkedSegmentIds, setCheckedSegmentIds] = useState<ReadonlySet<string>>(() => new Set());
+  const [isBulkActionPending, setIsBulkActionPending] = useState(false);
   const [isValidating, setIsValidating] = useState(false);
   const [isApproving, setIsApproving] = useState(false);
   const [isPostingComment, setIsPostingComment] = useState(false);
@@ -319,15 +339,42 @@ export function CatWorkspaceContainer({
   const onAskQuestion = reviewOverrides?.onAskQuestion;
   const onReviewWithAi = reviewOverrides?.onReviewWithAi;
   const onSkip = reviewOverrides?.onSkip;
+  const onBulkApprove = reviewOverrides?.onBulkApprove;
+  const onBulkSkip = reviewOverrides?.onBulkSkip;
+
+  const filteredSegments = useMemo(
+    () => filterCatQueueSegments(state.segments, queueFilter),
+    [queueFilter, state.segments],
+  );
+
+  useEffect(() => {
+    setCheckedSegmentIds((current) => {
+      const visibleIds = new Set(state.segments.map((segment) => segment.id));
+      const next = new Set([...current].filter((segmentId) => visibleIds.has(segmentId)));
+      return next.size === current.size ? current : next;
+    });
+  }, [state.segments]);
 
   useEffect(() => {
     stateRef.current = state;
   }, [state]);
 
   useEffect(() => {
-    setState((current) =>
-      mergeCatWorkspaceState(previousInitialStateRef.current, current, initialState),
-    );
+    setState((current) => {
+      const merged = mergeCatWorkspaceState(previousInitialStateRef.current, current, initialState);
+      if (!initialSegmentKeyOrId) {
+        return merged;
+      }
+
+      return {
+        ...merged,
+        selectedSegmentId: resolveSelectedSegmentId(
+          merged.segments,
+          initialSegmentKeyOrId,
+          merged.selectedSegmentId,
+        ),
+      };
+    });
     setSavedTargetTexts((saved) =>
       syncSavedTargetTexts({
         savedTargetTexts: saved,
@@ -341,7 +388,7 @@ export function CatWorkspaceContainer({
       const next = collectSegmentsWithAgentContext(initialState);
       return new Set([...current, ...next]);
     });
-  }, [initialState]);
+  }, [initialSegmentKeyOrId, initialState]);
 
   useEffect(() => {
     const dirtySegmentIds = collectDirtySegmentIds(state.segments, savedTargetTexts);
@@ -934,10 +981,105 @@ export function CatWorkspaceContainer({
     [savedTargetTexts, state.segments],
   );
 
+  const handleToggleSegmentChecked = useCallback((segmentId: string, checked: boolean) => {
+    setCheckedSegmentIds((current) => {
+      const next = new Set(current);
+      if (checked) {
+        next.add(segmentId);
+      } else {
+        next.delete(segmentId);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleSelectAllVisible = useCallback(() => {
+    setCheckedSegmentIds(new Set(filteredSegments.map((segment) => segment.id)));
+  }, [filteredSegments]);
+
+  const handleClearChecked = useCallback(() => {
+    setCheckedSegmentIds(new Set());
+  }, []);
+
+  const handleBulkApprove = useCallback(async () => {
+    const segmentIds = [...checkedSegmentIds];
+    if (segmentIds.length === 0) {
+      return;
+    }
+
+    setIsBulkActionPending(true);
+    try {
+      if (onBulkApprove) {
+        await onBulkApprove(segmentIds);
+        setCheckedSegmentIds(new Set());
+        return;
+      }
+
+      for (const segmentId of segmentIds) {
+        const segment = stateRef.current.segments.find((item) => item.id === segmentId);
+        if (!segment) {
+          continue;
+        }
+
+        await dependencies.review.onApprove(segmentId, segment.targetText);
+      }
+    } finally {
+      setIsBulkActionPending(false);
+      setCheckedSegmentIds(new Set());
+    }
+  }, [checkedSegmentIds, dependencies.review, onBulkApprove]);
+
+  const handleBulkSkip = useCallback(async () => {
+    const segmentIds = [...checkedSegmentIds];
+    if (segmentIds.length === 0) {
+      return;
+    }
+
+    setIsBulkActionPending(true);
+    try {
+      if (onBulkSkip) {
+        await onBulkSkip(segmentIds);
+      }
+
+      for (const segmentId of segmentIds) {
+        dependencies.review.onSkip(segmentId);
+      }
+    } finally {
+      setIsBulkActionPending(false);
+      setCheckedSegmentIds(new Set());
+    }
+  }, [checkedSegmentIds, dependencies.review, onBulkSkip]);
+
+  const queueViewState = useMemo(
+    () => ({
+      ...state,
+      segments: filteredSegments,
+    }),
+    [filteredSegments, state],
+  );
+
+  const resolvedBuildSegmentShareUrl = useMemo(() => {
+    if (buildSegmentShareUrl) {
+      return buildSegmentShareUrl;
+    }
+
+    if (typeof window === "undefined") {
+      return undefined;
+    }
+
+    return (segment: CatSegment) =>
+      buildCatSegmentShareUrl({
+        baseUrl: window.location.href,
+        segmentId: segment.id,
+        segmentKey: segment.key,
+      });
+  }, [buildSegmentShareUrl]);
+
   return (
     <>
       <CatWorkspaceView
-        state={state}
+        state={queueViewState}
+        editorState={state}
         dependencies={dependencies}
         dirtySegmentIds={dirtySegmentIds}
         isValidating={isValidating}
@@ -962,6 +1104,16 @@ export function CatWorkspaceContainer({
         }
         onQueueNextPage={onQueueNextPage ? () => attemptPageNavigation(onQueueNextPage) : undefined}
         onQueueNearEnd={onQueueNearEnd}
+        queueFilter={queueFilter}
+        onQueueFilterChange={setQueueFilter}
+        checkedSegmentIds={checkedSegmentIds}
+        onToggleSegmentChecked={handleToggleSegmentChecked}
+        onSelectAllVisible={handleSelectAllVisible}
+        onClearChecked={handleClearChecked}
+        onBulkApprove={() => void handleBulkApprove()}
+        onBulkSkip={() => void handleBulkSkip()}
+        isBulkActionPending={isBulkActionPending}
+        buildSegmentShareUrl={resolvedBuildSegmentShareUrl}
       />
 
       <AlertDialog

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
@@ -35,6 +35,7 @@ import {
 } from "./cat-dirty-state";
 import {
   filterCatQueueSegments,
+  findSegmentIdByKeyOrId,
   resolveSelectedSegmentId,
   type CatQueueFilter,
 } from "./cat-queue-filter";
@@ -295,7 +296,7 @@ export function CatWorkspaceContainer({
   const [queueFilter, setQueueFilter] = useState<CatQueueFilter>("all");
   const [checkedSegmentIds, setCheckedSegmentIds] = useState<ReadonlySet<string>>(() => new Set());
   const [isBulkActionPending, setIsBulkActionPending] = useState(false);
-  const initialSegmentJumpAppliedRef = useRef(Boolean(initialSegmentKeyOrId));
+  const initialSegmentJumpAppliedRef = useRef(false);
   const [isValidating, setIsValidating] = useState(false);
   const [isApproving, setIsApproving] = useState(false);
   const [isPostingComment, setIsPostingComment] = useState(false);
@@ -349,6 +350,10 @@ export function CatWorkspaceContainer({
   );
 
   useEffect(() => {
+    setCheckedSegmentIds(new Set());
+  }, [queueFilter]);
+
+  useEffect(() => {
     setCheckedSegmentIds((current) => {
       const visibleIds = new Set(state.segments.map((segment) => segment.id));
       const next = new Set([...current].filter((segmentId) => visibleIds.has(segmentId)));
@@ -363,15 +368,14 @@ export function CatWorkspaceContainer({
   useEffect(() => {
     setState((current) => {
       const merged = mergeCatWorkspaceState(previousInitialStateRef.current, current, initialState);
-      if (initialSegmentKeyOrId && !initialSegmentJumpAppliedRef.current) {
+      const matchedSegmentId = initialSegmentKeyOrId
+        ? findSegmentIdByKeyOrId(merged.segments, initialSegmentKeyOrId)
+        : null;
+      if (matchedSegmentId && !initialSegmentJumpAppliedRef.current) {
         initialSegmentJumpAppliedRef.current = true;
         return {
           ...merged,
-          selectedSegmentId: resolveSelectedSegmentId(
-            merged.segments,
-            initialSegmentKeyOrId,
-            merged.selectedSegmentId,
-          ),
+          selectedSegmentId: matchedSegmentId,
         };
       }
 

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
@@ -295,6 +295,7 @@ export function CatWorkspaceContainer({
   const [queueFilter, setQueueFilter] = useState<CatQueueFilter>("all");
   const [checkedSegmentIds, setCheckedSegmentIds] = useState<ReadonlySet<string>>(() => new Set());
   const [isBulkActionPending, setIsBulkActionPending] = useState(false);
+  const initialSegmentJumpAppliedRef = useRef(Boolean(initialSegmentKeyOrId));
   const [isValidating, setIsValidating] = useState(false);
   const [isApproving, setIsApproving] = useState(false);
   const [isPostingComment, setIsPostingComment] = useState(false);
@@ -362,18 +363,19 @@ export function CatWorkspaceContainer({
   useEffect(() => {
     setState((current) => {
       const merged = mergeCatWorkspaceState(previousInitialStateRef.current, current, initialState);
-      if (!initialSegmentKeyOrId) {
-        return merged;
+      if (initialSegmentKeyOrId && !initialSegmentJumpAppliedRef.current) {
+        initialSegmentJumpAppliedRef.current = true;
+        return {
+          ...merged,
+          selectedSegmentId: resolveSelectedSegmentId(
+            merged.segments,
+            initialSegmentKeyOrId,
+            merged.selectedSegmentId,
+          ),
+        };
       }
 
-      return {
-        ...merged,
-        selectedSegmentId: resolveSelectedSegmentId(
-          merged.segments,
-          initialSegmentKeyOrId,
-          merged.selectedSegmentId,
-        ),
-      };
+      return merged;
     });
     setSavedTargetTexts((saved) =>
       syncSavedTargetTexts({
@@ -1039,6 +1041,7 @@ export function CatWorkspaceContainer({
     try {
       if (onBulkSkip) {
         await onBulkSkip(segmentIds);
+        return;
       }
 
       for (const segmentId of segmentIds) {

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
@@ -34,10 +34,9 @@ import {
   type SavedTargetTextMap,
 } from "./cat-dirty-state";
 import {
-  filterCatQueueSegments,
   findSegmentIdByKeyOrId,
-  isServerQueueFilter,
   resolveSelectedSegmentId,
+  resolveVisibleQueueSegments,
   type CatQueueFilter,
 } from "./cat-queue-filter";
 import { buildCatSegmentShareUrl } from "./cat-segment-share-link";
@@ -243,6 +242,7 @@ export interface CatWorkspaceContainerProps {
   onQueueSearchChange?: (value: string) => void;
   queueFilter?: CatQueueFilter;
   onQueueFilterChange?: (filter: CatQueueFilter) => void;
+  availableQueueFilters?: CatQueueFilter[];
   isQueueSearchPending?: boolean;
   isQueueFetchingPage?: boolean;
   queuePagination?: CatWorkspaceViewProps["queuePagination"];
@@ -279,6 +279,7 @@ export function CatWorkspaceContainer({
   onQueueSearchChange,
   queueFilter: queueFilterProp,
   onQueueFilterChange,
+  availableQueueFilters,
   isQueueSearchPending,
   isQueueFetchingPage,
   queuePagination,
@@ -351,13 +352,27 @@ export function CatWorkspaceContainer({
   const onBulkApprove = reviewOverrides?.onBulkApprove;
   const onBulkSkip = reviewOverrides?.onBulkSkip;
 
-  const filteredSegments = useMemo(() => {
-    if (onQueueFilterChange && isServerQueueFilter(queueFilter)) {
-      return state.segments;
-    }
+  const usesServerQueueFilter = Boolean(onQueueFilterChange);
 
-    return filterCatQueueSegments(state.segments, queueFilter);
-  }, [onQueueFilterChange, queueFilter, state.segments]);
+  const filteredSegments = useMemo(
+    () => resolveVisibleQueueSegments(state.segments, queueFilter, usesServerQueueFilter),
+    [queueFilter, state.segments, usesServerQueueFilter],
+  );
+
+  useEffect(() => {
+    setState((current) => {
+      if (filteredSegments.some((segment) => segment.id === current.selectedSegmentId)) {
+        return current;
+      }
+
+      const nextSelectedSegmentId = filteredSegments[0]?.id;
+      if (!nextSelectedSegmentId || nextSelectedSegmentId === current.selectedSegmentId) {
+        return current;
+      }
+
+      return { ...current, selectedSegmentId: nextSelectedSegmentId };
+    });
+  }, [filteredSegments]);
 
   useEffect(() => {
     setCheckedSegmentIds(new Set());
@@ -751,11 +766,12 @@ export function CatWorkspaceContainer({
       onPreviousSegment: () => {
         attemptSegmentNavigation(() => {
           setState((current) => {
-            const previousId = getAdjacentSegmentId(
+            const visibleSegments = resolveVisibleQueueSegments(
               current.segments,
-              current.selectedSegmentId,
-              -1,
+              queueFilter,
+              usesServerQueueFilter,
             );
+            const previousId = getAdjacentSegmentId(visibleSegments, current.selectedSegmentId, -1);
             if (!previousId) {
               return current;
             }
@@ -767,7 +783,12 @@ export function CatWorkspaceContainer({
       onNextSegment: () => {
         attemptSegmentNavigation(() => {
           setState((current) => {
-            const nextId = getAdjacentSegmentId(current.segments, current.selectedSegmentId, 1);
+            const visibleSegments = resolveVisibleQueueSegments(
+              current.segments,
+              queueFilter,
+              usesServerQueueFilter,
+            );
+            const nextId = getAdjacentSegmentId(visibleSegments, current.selectedSegmentId, 1);
             if (!nextId) {
               return current;
             }
@@ -818,8 +839,13 @@ export function CatWorkspaceContainer({
               segmentId,
               targetText,
             );
+            const visibleSegments = resolveVisibleQueueSegments(
+              segments,
+              queueFilter,
+              usesServerQueueFilter,
+            );
             const nextSelectedSegmentId =
-              getAdjacentSegmentId(current.segments, segmentId, 1) ?? current.selectedSegmentId;
+              getAdjacentSegmentId(visibleSegments, segmentId, 1) ?? current.selectedSegmentId;
             return {
               ...current,
               segments,
@@ -986,6 +1012,8 @@ export function CatWorkspaceContainer({
     onTargetChange,
     onUseAiSuggestion,
     lookupSegmentContext,
+    queueFilter,
+    usesServerQueueFilter,
     runSegmentReview,
     runQaChecks,
     runSegmentChecks,
@@ -1123,6 +1151,7 @@ export function CatWorkspaceContainer({
         onQueueNearEnd={onQueueNearEnd}
         queueFilter={queueFilter}
         onQueueFilterChange={handleQueueFilterChange}
+        availableQueueFilters={availableQueueFilters}
         checkedSegmentIds={checkedSegmentIds}
         onToggleSegmentChecked={handleToggleSegmentChecked}
         onSelectAllVisible={handleSelectAllVisible}

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
@@ -36,6 +36,7 @@ import {
 import {
   filterCatQueueSegments,
   findSegmentIdByKeyOrId,
+  isServerQueueFilter,
   resolveSelectedSegmentId,
   type CatQueueFilter,
 } from "./cat-queue-filter";
@@ -240,6 +241,8 @@ export interface CatWorkspaceContainerProps {
   className?: string;
   queueSearch?: string;
   onQueueSearchChange?: (value: string) => void;
+  queueFilter?: CatQueueFilter;
+  onQueueFilterChange?: (filter: CatQueueFilter) => void;
   isQueueSearchPending?: boolean;
   isQueueFetchingPage?: boolean;
   queuePagination?: CatWorkspaceViewProps["queuePagination"];
@@ -274,6 +277,8 @@ export function CatWorkspaceContainer({
   className,
   queueSearch,
   onQueueSearchChange,
+  queueFilter: queueFilterProp,
+  onQueueFilterChange,
   isQueueSearchPending,
   isQueueFetchingPage,
   queuePagination,
@@ -293,7 +298,9 @@ export function CatWorkspaceContainer({
       initialState.selectedSegmentId,
     ),
   }));
-  const [queueFilter, setQueueFilter] = useState<CatQueueFilter>("all");
+  const [localQueueFilter, setLocalQueueFilter] = useState<CatQueueFilter>("all");
+  const queueFilter = queueFilterProp ?? localQueueFilter;
+  const handleQueueFilterChange = onQueueFilterChange ?? setLocalQueueFilter;
   const [checkedSegmentIds, setCheckedSegmentIds] = useState<ReadonlySet<string>>(() => new Set());
   const [isBulkActionPending, setIsBulkActionPending] = useState(false);
   const initialSegmentJumpAppliedRef = useRef(false);
@@ -344,10 +351,13 @@ export function CatWorkspaceContainer({
   const onBulkApprove = reviewOverrides?.onBulkApprove;
   const onBulkSkip = reviewOverrides?.onBulkSkip;
 
-  const filteredSegments = useMemo(
-    () => filterCatQueueSegments(state.segments, queueFilter),
-    [queueFilter, state.segments],
-  );
+  const filteredSegments = useMemo(() => {
+    if (onQueueFilterChange && isServerQueueFilter(queueFilter)) {
+      return state.segments;
+    }
+
+    return filterCatQueueSegments(state.segments, queueFilter);
+  }, [onQueueFilterChange, queueFilter, state.segments]);
 
   useEffect(() => {
     setCheckedSegmentIds(new Set());
@@ -1112,7 +1122,7 @@ export function CatWorkspaceContainer({
         onQueueNextPage={onQueueNextPage ? () => attemptPageNavigation(onQueueNextPage) : undefined}
         onQueueNearEnd={onQueueNearEnd}
         queueFilter={queueFilter}
-        onQueueFilterChange={setQueueFilter}
+        onQueueFilterChange={handleQueueFilterChange}
         checkedSegmentIds={checkedSegmentIds}
         onToggleSegmentChecked={handleToggleSegmentChecked}
         onSelectAllVisible={handleSelectAllVisible}

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace.tsx
@@ -63,6 +63,7 @@ export function CatWorkspaceView({
   onQueueNearEnd,
   queueFilter,
   onQueueFilterChange,
+  availableQueueFilters,
   checkedSegmentIds,
   onToggleSegmentChecked,
   onSelectAllVisible,
@@ -73,12 +74,16 @@ export function CatWorkspaceView({
   buildSegmentShareUrl,
 }: CatWorkspaceViewProps) {
   const fullState = editorState ?? state;
-  const selectedSegmentIndex = fullState.segments.findIndex(
+  const navigationSegments = editorState ? state.segments : fullState.segments;
+  const selectedSegmentIndex = navigationSegments.findIndex(
     (segment) =>
       segment.id === fullState.selectedSegmentId || segment.key === fullState.selectedSegmentId,
   );
   const selectedSegment =
-    selectedSegmentIndex >= 0 ? fullState.segments[selectedSegmentIndex] : fullState.segments[0];
+    fullState.segments.find(
+      (segment) =>
+        segment.id === fullState.selectedSegmentId || segment.key === fullState.selectedSegmentId,
+    ) ?? navigationSegments[selectedSegmentIndex >= 0 ? selectedSegmentIndex : 0];
   const isCompact = useIsCompactWorkspace();
   const [activePanel, setActivePanel] = useState<CatWorkspacePanel>("edit");
   const reviewedProgress =
@@ -99,9 +104,14 @@ export function CatWorkspaceView({
     );
   }
 
-  const segmentPosition = selectedSegmentIndex >= 0 ? selectedSegmentIndex + 1 : 1;
+  const segmentPosition = queuePagination
+    ? queuePagination.offset + (selectedSegmentIndex >= 0 ? selectedSegmentIndex + 1 : 1)
+    : selectedSegmentIndex >= 0
+      ? selectedSegmentIndex + 1
+      : 1;
+  const totalSegments = queuePagination?.totalCount ?? navigationSegments.length;
   const hasPreviousSegment = segmentPosition > 1;
-  const hasNextSegment = segmentPosition < fullState.segments.length;
+  const hasNextSegment = segmentPosition < totalSegments;
   const { navigation, editing, review } = dependencies;
   const selectedSegmentIntelligence =
     fullState.segmentIntelligence?.[selectedSegment.id] ?? fullState.intelligence;
@@ -121,7 +131,7 @@ export function CatWorkspaceView({
       <CatEditorPanel
         segment={selectedSegment}
         segmentPosition={segmentPosition}
-        totalSegments={fullState.segments.length}
+        totalSegments={totalSegments}
         formatChecks={selectedSegmentFormatChecks}
         intelligence={selectedSegmentIntelligence}
         isEditorBusy={isEditorBusy}
@@ -180,6 +190,7 @@ export function CatWorkspaceView({
         isSearching={isQueueSearchPending}
         queueFilter={queueFilter}
         onQueueFilterChange={onQueueFilterChange}
+        availableQueueFilters={availableQueueFilters}
         checkedSegmentIds={checkedSegmentIds}
         onToggleSegmentChecked={onToggleSegmentChecked}
         onSelectAllVisible={onSelectAllVisible}
@@ -223,7 +234,7 @@ export function CatWorkspaceView({
               <div className="min-w-0 space-y-1">
                 <p className="font-mono text-xs text-muted-foreground tabular-nums">
                   {String(segmentPosition).padStart(2, "0")} /{" "}
-                  {String(fullState.segments.length).padStart(2, "0")}
+                  {String(totalSegments).padStart(2, "0")}
                 </p>
                 <p className="truncate font-mono text-sm font-medium text-foreground">
                   {selectedSegment.key}

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace.tsx
@@ -38,6 +38,7 @@ function useIsCompactWorkspace() {
 
 export function CatWorkspaceView({
   state,
+  editorState,
   dependencies,
   isValidating: _isValidating = false,
   isApproving = false,
@@ -60,17 +61,29 @@ export function CatWorkspaceView({
   onQueuePreviousPage,
   onQueueNextPage,
   onQueueNearEnd,
+  queueFilter,
+  onQueueFilterChange,
+  checkedSegmentIds,
+  onToggleSegmentChecked,
+  onSelectAllVisible,
+  onClearChecked,
+  onBulkApprove,
+  onBulkSkip,
+  isBulkActionPending = false,
+  buildSegmentShareUrl,
 }: CatWorkspaceViewProps) {
-  const selectedSegmentIndex = state.segments.findIndex(
-    (segment) => segment.id === state.selectedSegmentId || segment.key === state.selectedSegmentId,
+  const fullState = editorState ?? state;
+  const selectedSegmentIndex = fullState.segments.findIndex(
+    (segment) =>
+      segment.id === fullState.selectedSegmentId || segment.key === fullState.selectedSegmentId,
   );
   const selectedSegment =
-    selectedSegmentIndex >= 0 ? state.segments[selectedSegmentIndex] : state.segments[0];
+    selectedSegmentIndex >= 0 ? fullState.segments[selectedSegmentIndex] : fullState.segments[0];
   const isCompact = useIsCompactWorkspace();
   const [activePanel, setActivePanel] = useState<CatWorkspacePanel>("edit");
   const reviewedProgress =
-    state.queueSummary.total > 0
-      ? Math.round((state.queueSummary.reviewed / state.queueSummary.total) * 100)
+    fullState.queueSummary.total > 0
+      ? Math.round((fullState.queueSummary.reviewed / fullState.queueSummary.total) * 100)
       : 0;
 
   if (!selectedSegment) {
@@ -88,26 +101,27 @@ export function CatWorkspaceView({
 
   const segmentPosition = selectedSegmentIndex >= 0 ? selectedSegmentIndex + 1 : 1;
   const hasPreviousSegment = segmentPosition > 1;
-  const hasNextSegment = segmentPosition < state.segments.length;
+  const hasNextSegment = segmentPosition < fullState.segments.length;
   const { navigation, editing, review } = dependencies;
   const selectedSegmentIntelligence =
-    state.segmentIntelligence?.[selectedSegment.id] ?? state.intelligence;
+    fullState.segmentIntelligence?.[selectedSegment.id] ?? fullState.intelligence;
   const selectedSegmentFormatChecks =
-    state.segmentFormatChecks?.[selectedSegment.id] ?? state.formatChecks;
+    fullState.segmentFormatChecks?.[selectedSegment.id] ?? fullState.formatChecks;
   const aiRecommendationError = selectedSegmentFormatChecks.find(
     (check) => check.id === `ai-recommendation-failed-${selectedSegment.id}`,
   )?.message;
   const isEditorBusy = isApproving;
-  const canApprove = state.canEditTranslations !== false;
-  const canAddComment = state.canAddComments === true;
+  const canApprove = fullState.canEditTranslations !== false;
+  const canAddComment = fullState.canAddComments === true;
   const isTargetDirty = dirtySegmentIds?.has(selectedSegment.id) ?? false;
+  const segmentShareUrl = buildSegmentShareUrl?.(selectedSegment) ?? null;
 
   function renderEditorPanel() {
     return (
       <CatEditorPanel
         segment={selectedSegment}
         segmentPosition={segmentPosition}
-        totalSegments={state.segments.length}
+        totalSegments={fullState.segments.length}
         formatChecks={selectedSegmentFormatChecks}
         intelligence={selectedSegmentIntelligence}
         isEditorBusy={isEditorBusy}
@@ -123,6 +137,7 @@ export function CatWorkspaceView({
         isTargetDirty={isTargetDirty}
         canLookupContext={canLookupContext}
         canUseAiRecommendation={canUseAiRecommendation}
+        segmentShareUrl={segmentShareUrl}
         onTargetChange={(value) => editing.onTargetChange(selectedSegment.id, value)}
         onCopySource={() => editing.onTargetChange(selectedSegment.id, selectedSegment.sourceText)}
         onClearTarget={() => editing.onTargetChange(selectedSegment.id, "")}
@@ -133,7 +148,7 @@ export function CatWorkspaceView({
             ? (text) => review.onAddComment?.(selectedSegment.id, text)
             : undefined
         }
-        primaryActionLabel={state.primaryActionLabel}
+        primaryActionLabel={fullState.primaryActionLabel}
         onAskQuestion={() => review.onAskQuestion(selectedSegment.id)}
         onGenerateAiRecommendation={
           canUseAiRecommendation ? () => void review.onReviewWithAi(selectedSegment.id) : undefined
@@ -152,7 +167,7 @@ export function CatWorkspaceView({
       <CatQueuePanel
         segments={state.segments}
         selectedSegmentId={selectedSegment.id}
-        summary={state.queueSummary}
+        summary={fullState.queueSummary}
         dirtySegmentIds={dirtySegmentIds}
         onSelectSegment={(segmentId) => {
           navigation.onSelectSegment(segmentId);
@@ -163,6 +178,15 @@ export function CatWorkspaceView({
         search={queueSearch}
         onSearchChange={onQueueSearchChange}
         isSearching={isQueueSearchPending}
+        queueFilter={queueFilter}
+        onQueueFilterChange={onQueueFilterChange}
+        checkedSegmentIds={checkedSegmentIds}
+        onToggleSegmentChecked={onToggleSegmentChecked}
+        onSelectAllVisible={onSelectAllVisible}
+        onClearChecked={onClearChecked}
+        onBulkApprove={onBulkApprove}
+        onBulkSkip={onBulkSkip}
+        isBulkActionPending={isBulkActionPending}
         isFetchingPage={isQueueFetchingPage}
         pagination={queuePagination}
         onPreviousPage={onQueuePreviousPage}
@@ -179,7 +203,7 @@ export function CatWorkspaceView({
         isLookingUpContext={isLookingUpContext}
         isConcordanceLoading={isConcordanceLoading}
         showAgentContext={showAgentContext}
-        canEditTranslations={state.canEditTranslations !== false}
+        canEditTranslations={fullState.canEditTranslations !== false}
         onUseTmMatch={(match) => editing.onUseTmMatch(selectedSegment.id, match)}
       />
     );
@@ -199,7 +223,7 @@ export function CatWorkspaceView({
               <div className="min-w-0 space-y-1">
                 <p className="font-mono text-xs text-muted-foreground tabular-nums">
                   {String(segmentPosition).padStart(2, "0")} /{" "}
-                  {String(state.segments.length).padStart(2, "0")}
+                  {String(fullState.segments.length).padStart(2, "0")}
                 </p>
                 <p className="truncate font-mono text-sm font-medium text-foreground">
                   {selectedSegment.key}
@@ -216,8 +240,8 @@ export function CatWorkspaceView({
                   <FormattedMessage
                     {...catWorkspaceMessages.reviewedSummary}
                     values={{
-                      reviewed: state.queueSummary.reviewed,
-                      total: state.queueSummary.total,
+                      reviewed: fullState.queueSummary.reviewed,
+                      total: fullState.queueSummary.total,
                     }}
                   />
                 </p>

--- a/apps/hyperlocalise-web/src/components/cat/cat.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat.messages.ts
@@ -91,6 +91,71 @@ export const catQueuePanelMessages = defineMessages({
     id: "CHs2ugz7iN",
     description: "Accessible label for queue row indicator when a segment has unsaved edits",
   },
+  filterAll: {
+    defaultMessage: "All strings",
+    id: "V+8wDWpBnh",
+    description: "CAT queue filter option showing every segment",
+  },
+  filterUntranslated: {
+    defaultMessage: "Untranslated",
+    id: "Kdyh8ZKnlc",
+    description: "CAT queue filter option for segments without a target translation",
+  },
+  filterNeedsReview: {
+    defaultMessage: "Needs review",
+    id: "cMuLE7Fon0",
+    description: "CAT queue filter option for translated segments awaiting review",
+  },
+  filterReviewed: {
+    defaultMessage: "Approved",
+    id: "F6X8Sh27Q0",
+    description: "CAT queue filter option for approved segments",
+  },
+  filterHasIssues: {
+    defaultMessage: "Has issues",
+    id: "U+tI5HA1qo",
+    description: "CAT queue filter option for segments with open issue comments",
+  },
+  filterSkipped: {
+    defaultMessage: "Skipped",
+    id: "75tLVTlfqV",
+    description: "CAT queue filter option for skipped segments",
+  },
+  emptyFilterResults: {
+    defaultMessage: "No segments match this filter.",
+    id: "oY/dfpDvR7",
+    description: "Empty state when CAT queue status filter returns no segments",
+  },
+  bulkApprove: {
+    defaultMessage: "Approve selected",
+    id: "sPeeyibl9Y",
+    description: "Bulk action to approve all selected CAT segments",
+  },
+  bulkSkip: {
+    defaultMessage: "Skip selected",
+    id: "zCn3UqvqWI",
+    description: "Bulk action to skip all selected CAT segments",
+  },
+  bulkSelectAll: {
+    defaultMessage: "Select all visible",
+    id: "1v2hbAXp/Y",
+    description: "Bulk action to select every segment in the current queue view",
+  },
+  bulkClearSelection: {
+    defaultMessage: "Clear selection",
+    id: "whr/nciIbp",
+    description: "Bulk action to clear the current segment selection",
+  },
+  bulkSelectionSummary: {
+    defaultMessage: "{count} selected",
+    id: "uZnk0UoDEu",
+    description: "Summary of how many CAT queue segments are selected for bulk actions",
+  },
+  selectSegmentAria: {
+    defaultMessage: "Select {key}",
+    id: "Ygi+pnLdm5",
+    description: "Accessible label for selecting a CAT queue segment for bulk actions",
+  },
 });
 
 export const catFormatChecksMessages = defineMessages({
@@ -572,5 +637,25 @@ export const catEditorPanelMessages = defineMessages({
     defaultMessage: "Clear target",
     id: "5/hlw6iDag",
     description: "Button to clear the target translation field",
+  },
+  shareSegment: {
+    defaultMessage: "Copy link",
+    id: "H7+t0VoSpu",
+    description: "Button to copy a shareable link to the current CAT segment",
+  },
+  shareSegmentCopied: {
+    defaultMessage: "Link copied",
+    id: "0YoaNbe8v4",
+    description: "Tooltip after a CAT segment share link is copied to the clipboard",
+  },
+  shareSegmentFailed: {
+    defaultMessage: "Could not copy link",
+    id: "HLG4pq/SOg",
+    description: "Tooltip when copying a CAT segment share link fails",
+  },
+  shareSegmentAria: {
+    defaultMessage: "Copy link to this segment",
+    id: "CqDUHu+YvU",
+    description: "Accessible label for the CAT segment share link button",
   },
 });

--- a/apps/hyperlocalise-web/src/components/cat/dependencies.ts
+++ b/apps/hyperlocalise-web/src/components/cat/dependencies.ts
@@ -104,6 +104,7 @@ export interface CatWorkspaceViewProps {
   onQueueNearEnd?: () => void;
   queueFilter?: CatQueueFilter;
   onQueueFilterChange?: (filter: CatQueueFilter) => void;
+  availableQueueFilters?: CatQueueFilter[];
   checkedSegmentIds?: ReadonlySet<string>;
   onToggleSegmentChecked?: (segmentId: string, checked: boolean) => void;
   onSelectAllVisible?: () => void;

--- a/apps/hyperlocalise-web/src/components/cat/dependencies.ts
+++ b/apps/hyperlocalise-web/src/components/cat/dependencies.ts
@@ -7,6 +7,7 @@ import type {
   CatTranslationMemoryMatch,
   CatWorkspaceState,
 } from "./types";
+import type { CatQueueFilter } from "./cat-queue-filter";
 
 export interface CatAiRecommendationResult {
   aiSuggestion: string;
@@ -41,6 +42,8 @@ export interface CatWorkspaceReview {
   onAskQuestion: (segmentId: string) => void | Promise<void>;
   onReviewWithAi: (segmentId: string) => void | Promise<void>;
   onSkip: (segmentId: string) => void;
+  onBulkApprove?: (segmentIds: string[]) => void | Promise<void>;
+  onBulkSkip?: (segmentIds: string[]) => void | Promise<void>;
 }
 
 export interface CatWorkspaceServices {
@@ -99,6 +102,17 @@ export interface CatWorkspaceViewProps {
   onQueuePreviousPage?: () => void;
   onQueueNextPage?: () => void;
   onQueueNearEnd?: () => void;
+  queueFilter?: CatQueueFilter;
+  onQueueFilterChange?: (filter: CatQueueFilter) => void;
+  checkedSegmentIds?: ReadonlySet<string>;
+  onToggleSegmentChecked?: (segmentId: string, checked: boolean) => void;
+  onSelectAllVisible?: () => void;
+  onClearChecked?: () => void;
+  onBulkApprove?: () => void;
+  onBulkSkip?: () => void;
+  isBulkActionPending?: boolean;
+  buildSegmentShareUrl?: (segment: CatSegment) => string | null;
+  editorState?: CatWorkspaceState;
 }
 
 export const noopCatDependencies: CatWorkspaceDependencies = {

--- a/apps/hyperlocalise-web/src/components/cat/project-file-cat-api.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file-cat-api.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vite-plus/test";
 import { projectFileCatQueryKey } from "./project-file-cat-api";
 
 describe("projectFileCatQueryKey", () => {
-  it("includes search, limit, and offset for page-scoped cache keys", () => {
+  it("includes search, queue filter, limit, and offset for page-scoped cache keys", () => {
     expect(
       projectFileCatQueryKey({
         organizationSlug: "acme",
@@ -12,6 +12,7 @@ describe("projectFileCatQueryKey", () => {
         targetLocale: "fr",
         repositoryFullName: "acme/web",
         search: "hero",
+        queueFilter: "needs_review",
         limit: 50,
         offset: 50,
       }),
@@ -23,6 +24,7 @@ describe("projectFileCatQueryKey", () => {
       "fr",
       "acme/web",
       "hero",
+      "needs_review",
       50,
       50,
     ]);
@@ -36,6 +38,7 @@ describe("projectFileCatQueryKey", () => {
       targetLocale: "fr",
       repositoryFullName: null,
       search: "",
+      queueFilter: "all" as const,
       limit: 50,
     };
 

--- a/apps/hyperlocalise-web/src/components/cat/project-file-cat-api.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file-cat-api.ts
@@ -1,4 +1,5 @@
 import type { ProjectFileCatResponse } from "@/api/routes/project/project.schema";
+import type { ProjectFileCatQueueFilter } from "@/api/routes/project/project.schema";
 import { defaultProjectFileCatPageLimit } from "@/api/routes/project/project.schema";
 import { readApiError } from "@/lib/api-error";
 import { apiClient } from "@/lib/api-client-instance";
@@ -12,6 +13,7 @@ export function projectFileCatQueryKey(input: {
   targetLocale: string;
   repositoryFullName: string | null;
   search: string;
+  queueFilter: ProjectFileCatQueueFilter;
   limit: number;
   offset: number;
 }) {
@@ -23,6 +25,7 @@ export function projectFileCatQueryKey(input: {
     input.targetLocale,
     input.repositoryFullName,
     input.search,
+    input.queueFilter,
     input.limit,
     input.offset,
   ] as const;
@@ -35,6 +38,7 @@ export function projectFileCatBaseQueryKey(input: {
   targetLocale: string;
   repositoryFullName: string | null;
   search: string;
+  queueFilter: ProjectFileCatQueueFilter;
   limit: number;
 }) {
   return [
@@ -45,6 +49,7 @@ export function projectFileCatBaseQueryKey(input: {
     input.targetLocale,
     input.repositoryFullName,
     input.search,
+    input.queueFilter,
     input.limit,
   ] as const;
 }
@@ -56,6 +61,7 @@ export async function fetchProjectFileCatPage(input: {
   targetLocale: string;
   repositoryFullName: string | null;
   search: string;
+  queueFilter: ProjectFileCatQueueFilter;
   limit: number;
   offset: number;
 }) {
@@ -69,6 +75,7 @@ export async function fetchProjectFileCatPage(input: {
       offset: input.offset,
       limit: input.limit,
       ...(input.search ? { search: input.search } : {}),
+      ...(input.queueFilter !== "all" ? { queueFilter: input.queueFilter } : {}),
       ...(input.repositoryFullName ? { repositoryFullName: input.repositoryFullName } : {}),
     },
   });

--- a/apps/hyperlocalise-web/src/components/cat/project-file-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/project-file-cat-workspace.tsx
@@ -94,6 +94,8 @@ export function ProjectFileCatWorkspace({
     catQuery,
     search,
     setSearch,
+    queueFilter,
+    setQueueFilter,
     debouncedSearch,
     isSearchPending,
     pagination,
@@ -370,7 +372,9 @@ export function ProjectFileCatWorkspace({
         <TypographyP className="text-sm">
           {search.trim()
             ? "No strings match your search."
-            : "No source strings are available for this file."}
+            : queueFilter !== "all"
+              ? "No segments match this filter."
+              : "No source strings are available for this file."}
         </TypographyP>
       </div>
     );
@@ -411,7 +415,7 @@ export function ProjectFileCatWorkspace({
       ) : null}
 
       <CatWorkspaceContainer
-        key={`${sourcePath}:${targetLocale}:${repositoryFullName ?? "default"}:${debouncedSearch}:${pagination?.offset ?? 0}`}
+        key={`${sourcePath}:${targetLocale}:${repositoryFullName ?? "default"}:${debouncedSearch}:${queueFilter}:${pagination?.offset ?? 0}`}
         initialState={workspaceState}
         className={cn("min-h-0 flex-1", isFullscreen && "rounded-lg border border-border")}
         services={{
@@ -429,6 +433,8 @@ export function ProjectFileCatWorkspace({
         buildSegmentShareUrl={buildSegmentShareUrl}
         queueSearch={search}
         onQueueSearchChange={setSearch}
+        queueFilter={queueFilter}
+        onQueueFilterChange={setQueueFilter}
         isQueueSearchPending={isSearchPending}
         isQueueFetchingPage={catQuery.isFetching && !catQuery.isLoading}
         queuePagination={pagination}

--- a/apps/hyperlocalise-web/src/components/cat/project-file-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/project-file-cat-workspace.tsx
@@ -26,6 +26,7 @@ import { mapCatConcordanceForAiRecommendation } from "@/lib/translation/map-cat-
 import { cn } from "@/lib/primitives/cn";
 
 import { CatWorkspaceContainer } from "./cat-workspace-container";
+import { buildCatSegmentShareUrl } from "./cat-segment-share-link";
 import {
   projectFileCatToWorkspaceState,
   requireProviderExternalResourceId,
@@ -50,6 +51,7 @@ export function ProjectFileCatWorkspace({
   targetLocales,
   highlightLocale = null,
   repositoryFullName = null,
+  initialSegmentKey = null,
   layout = "default",
   className,
 }: {
@@ -60,6 +62,7 @@ export function ProjectFileCatWorkspace({
   targetLocales?: string[];
   highlightLocale?: string | null;
   repositoryFullName?: string | null;
+  initialSegmentKey?: string | null;
   layout?: "default" | "fullscreen";
   className?: string;
 }) {
@@ -209,6 +212,32 @@ export function ProjectFileCatWorkspace({
     },
     [catQuery.data?.canEditTranslations, postComment],
   );
+
+  const handleBulkApprove = useCallback(
+    async (segmentIds: string[]) => {
+      for (const segmentId of segmentIds) {
+        const segment = workspaceState?.segments.find((item) => item.id === segmentId);
+        if (!segment) {
+          continue;
+        }
+
+        await handleApprove(segmentId, segment.targetText);
+      }
+    },
+    [handleApprove, workspaceState?.segments],
+  );
+
+  const buildSegmentShareUrl = useCallback((segment: CatSegment) => {
+    if (typeof window === "undefined") {
+      return null;
+    }
+
+    return buildCatSegmentShareUrl({
+      baseUrl: window.location.href,
+      segmentId: segment.id,
+      segmentKey: segment.key,
+    });
+  }, []);
 
   const lookupSegmentContext = useCallback(
     async (segment: CatSegment) => {
@@ -394,7 +423,10 @@ export function ProjectFileCatWorkspace({
         review={{
           onApprove: handleApprove,
           onAddComment: handleAddComment,
+          onBulkApprove: handleBulkApprove,
         }}
+        initialSegmentKeyOrId={initialSegmentKey}
+        buildSegmentShareUrl={buildSegmentShareUrl}
         queueSearch={search}
         onQueueSearchChange={setSearch}
         isQueueSearchPending={isSearchPending}

--- a/apps/hyperlocalise-web/src/components/cat/project-file-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/project-file-cat-workspace.tsx
@@ -27,6 +27,7 @@ import { cn } from "@/lib/primitives/cn";
 
 import { CatWorkspaceContainer } from "./cat-workspace-container";
 import { buildCatSegmentShareUrl } from "./cat-segment-share-link";
+import { resolveAvailableCatQueueFilters } from "./cat-queue-filter";
 import {
   projectFileCatToWorkspaceState,
   requireProviderExternalResourceId,
@@ -111,6 +112,19 @@ export function ProjectFileCatWorkspace({
     repositoryFullName,
     enabled: Boolean(targetLocale),
   });
+
+  const availableQueueFilters = useMemo(
+    () => resolveAvailableCatQueueFilters(catQuery.data?.provider?.kind),
+    [catQuery.data?.provider?.kind],
+  );
+
+  useEffect(() => {
+    if (availableQueueFilters.includes(queueFilter)) {
+      return;
+    }
+
+    setQueueFilter("all");
+  }, [availableQueueFilters, queueFilter, setQueueFilter]);
 
   const saveMutation = useMutation({
     mutationFn: async (input: { externalStringId: string; text: string }) => {
@@ -435,6 +449,7 @@ export function ProjectFileCatWorkspace({
         onQueueSearchChange={setSearch}
         queueFilter={queueFilter}
         onQueueFilterChange={setQueueFilter}
+        availableQueueFilters={availableQueueFilters}
         isQueueSearchPending={isSearchPending}
         isQueueFetchingPage={catQuery.isFetching && !catQuery.isLoading}
         queuePagination={pagination}

--- a/apps/hyperlocalise-web/src/components/cat/use-cat-segment-query.ts
+++ b/apps/hyperlocalise-web/src/components/cat/use-cat-segment-query.ts
@@ -3,6 +3,7 @@
 import { keepPreviousData, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
+import type { ProjectFileCatQueueFilter } from "@/api/routes/project/project.schema";
 import type { ProjectFileCatResponse } from "@/api/routes/project/project.schema";
 
 import {
@@ -11,6 +12,7 @@ import {
   projectFileCatBaseQueryKey,
   projectFileCatQueryKey,
 } from "./project-file-cat-api";
+import { isServerQueueFilter, type CatQueueFilter } from "./cat-queue-filter";
 
 type CatFilePagination = NonNullable<ProjectFileCatResponse["catFile"]["pagination"]>;
 
@@ -25,6 +27,10 @@ function useDebouncedValue<T>(value: T, delayMs: number) {
   return debouncedValue;
 }
 
+function toServerQueueFilter(filter: CatQueueFilter): ProjectFileCatQueueFilter {
+  return isServerQueueFilter(filter) ? filter : "all";
+}
+
 export function useCatSegmentQuery(input: {
   organizationSlug: string;
   projectId: string;
@@ -36,14 +42,16 @@ export function useCatSegmentQuery(input: {
   const queryClient = useQueryClient();
   const repositoryFullName = input.repositoryFullName ?? null;
   const [search, setSearch] = useState("");
+  const [queueFilter, setQueueFilter] = useState<CatQueueFilter>("all");
   const [offset, setOffset] = useState(0);
   const [limit] = useState(defaultCatPageLimit);
   const debouncedSearch = useDebouncedValue(search, 300);
   const isSearchPending = search !== debouncedSearch;
+  const serverQueueFilter = toServerQueueFilter(queueFilter);
 
   useEffect(() => {
     setOffset(0);
-  }, [debouncedSearch, input.sourcePath, input.targetLocale, repositoryFullName]);
+  }, [debouncedSearch, queueFilter, input.sourcePath, input.targetLocale, repositoryFullName]);
 
   const queryKey = useMemo(
     () =>
@@ -54,6 +62,7 @@ export function useCatSegmentQuery(input: {
         targetLocale: input.targetLocale,
         repositoryFullName,
         search: debouncedSearch,
+        queueFilter: serverQueueFilter,
         limit,
         offset,
       }),
@@ -66,6 +75,7 @@ export function useCatSegmentQuery(input: {
       limit,
       offset,
       repositoryFullName,
+      serverQueueFilter,
     ],
   );
 
@@ -81,6 +91,7 @@ export function useCatSegmentQuery(input: {
         targetLocale: input.targetLocale,
         repositoryFullName,
         search: debouncedSearch,
+        queueFilter: serverQueueFilter,
         limit,
         offset,
       }),
@@ -101,6 +112,7 @@ export function useCatSegmentQuery(input: {
       targetLocale: input.targetLocale,
       repositoryFullName,
       search: debouncedSearch,
+      queueFilter: serverQueueFilter,
       limit,
       offset: nextOffset,
     });
@@ -116,6 +128,7 @@ export function useCatSegmentQuery(input: {
           targetLocale: input.targetLocale,
           repositoryFullName,
           search: debouncedSearch,
+          queueFilter: serverQueueFilter,
           limit,
           offset: nextOffset,
         }),
@@ -132,6 +145,7 @@ export function useCatSegmentQuery(input: {
     pagination?.hasMore,
     queryClient,
     repositoryFullName,
+    serverQueueFilter,
   ]);
 
   useEffect(() => {
@@ -159,6 +173,8 @@ export function useCatSegmentQuery(input: {
     catQuery,
     search,
     setSearch,
+    queueFilter,
+    setQueueFilter,
     offset,
     limit,
     debouncedSearch,
@@ -176,6 +192,7 @@ export function useCatSegmentQuery(input: {
       targetLocale: input.targetLocale,
       repositoryFullName,
       search: debouncedSearch,
+      queueFilter: serverQueueFilter,
       limit,
     }),
   };

--- a/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-service.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-service.test.ts
@@ -79,9 +79,12 @@ describe("NativeCatService.getCatFile", () => {
         offset: 50,
         limit: 25,
         search: "hero",
+        targetLocale: "fr",
       }),
     );
-    expect(countKeysForFile).toHaveBeenCalledWith(expect.objectContaining({ search: "hero" }));
+    expect(countKeysForFile).toHaveBeenCalledWith(
+      expect.objectContaining({ search: "hero", targetLocale: "fr" }),
+    );
     expect(result?.pagination).toMatchObject({
       offset: 50,
       limit: 25,

--- a/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-service.ts
@@ -66,6 +66,7 @@ export class NativeCatService extends ProjectServiceBase {
       offset: 0,
       limit: legacyNativeCatSegmentLimit,
       search: undefined,
+      queueFilter: "all",
       paginated: false,
     };
 
@@ -93,15 +94,19 @@ export class NativeCatService extends ProjectServiceBase {
         organizationId: input.organizationId,
         projectId: input.projectId,
         repositorySourceFileId: sourceFile.id,
+        targetLocale: input.targetLocale,
         search: paginationInput.search,
+        queueFilter: paginationInput.queueFilter,
       }),
       this.translations.listKeysForFile({
         organizationId: input.organizationId,
         projectId: input.projectId,
         repositorySourceFileId: sourceFile.id,
+        targetLocale: input.targetLocale,
         limit: paginationInput.limit,
         offset: paginationInput.offset,
         search: paginationInput.search,
+        queueFilter: paginationInput.queueFilter,
       }),
     ]);
 

--- a/apps/hyperlocalise-web/src/lib/projects/cat/project-file-cat-pagination.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/project-file-cat-pagination.test.ts
@@ -11,6 +11,7 @@ describe("resolveProjectFileCatPagination", () => {
       offset: 0,
       limit: 500,
       search: undefined,
+      queueFilter: "all",
       paginated: false,
     });
   });
@@ -20,6 +21,7 @@ describe("resolveProjectFileCatPagination", () => {
       offset: 50,
       limit: 25,
       search: undefined,
+      queueFilter: "all",
       paginated: true,
     });
   });
@@ -29,6 +31,15 @@ describe("resolveProjectFileCatPagination", () => {
       offset: 0,
       limit: 50,
       search: "hello",
+      paginated: true,
+    });
+  });
+
+  it("enables paginated mode when queueFilter is provided", () => {
+    expect(resolveProjectFileCatPagination({ queueFilter: "needs_review" })).toMatchObject({
+      offset: 0,
+      limit: 50,
+      queueFilter: "needs_review",
       paginated: true,
     });
   });

--- a/apps/hyperlocalise-web/src/lib/projects/cat/project-file-cat-pagination.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/project-file-cat-pagination.ts
@@ -1,4 +1,7 @@
-import type { ProjectFileCatQuery } from "@/api/routes/project/project.schema";
+import type {
+  ProjectFileCatQuery,
+  ProjectFileCatQueueFilter,
+} from "@/api/routes/project/project.schema";
 import {
   defaultProjectFileCatPageLimit,
   legacyNativeCatSegmentLimit,
@@ -10,20 +13,32 @@ export type ProjectFileCatPaginationInput = {
   offset: number;
   limit: number;
   search?: string;
+  queueFilter?: ProjectFileCatQueueFilter;
   paginated: boolean;
 };
 
+function normalizeQueueFilter(
+  queueFilter: ProjectFileCatQueueFilter | undefined,
+): ProjectFileCatQueueFilter {
+  return queueFilter ?? "all";
+}
+
 export function resolveProjectFileCatPagination(
-  query: Pick<ProjectFileCatQuery, "search" | "offset" | "limit">,
+  query: Pick<ProjectFileCatQuery, "search" | "offset" | "limit" | "queueFilter">,
 ): ProjectFileCatPaginationInput {
+  const queueFilter = normalizeQueueFilter(query.queueFilter);
   const hasPaginationParams =
-    query.offset !== undefined || query.limit !== undefined || Boolean(query.search?.trim());
+    query.offset !== undefined ||
+    query.limit !== undefined ||
+    Boolean(query.search?.trim()) ||
+    queueFilter !== "all";
 
   if (!hasPaginationParams) {
     return {
       offset: 0,
       limit: legacyNativeCatSegmentLimit,
       search: undefined,
+      queueFilter: "all",
       paginated: false,
     };
   }
@@ -32,6 +47,7 @@ export function resolveProjectFileCatPagination(
     offset: query.offset ?? 0,
     limit: Math.min(query.limit ?? defaultProjectFileCatPageLimit, maxProjectFileCatPageLimit),
     search: query.search?.trim() || undefined,
+    queueFilter,
     paginated: true,
   };
 }

--- a/apps/hyperlocalise-web/src/lib/projects/translations/project-translation-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/translations/project-translation-service.ts
@@ -49,11 +49,7 @@ function translationKeysQueueFilterCondition(input: {
   queueFilter?: ProjectFileCatQueueFilter;
 }) {
   const filter = input.queueFilter;
-  if (!filter || filter === "all" || filter === "has_issues") {
-    if (filter === "has_issues") {
-      return sql`false`;
-    }
-
+  if (!filter || filter === "all") {
     return undefined;
   }
 

--- a/apps/hyperlocalise-web/src/lib/projects/translations/project-translation-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/translations/project-translation-service.ts
@@ -1,7 +1,10 @@
 import { and, asc, count, eq, ilike, inArray, or, sql } from "drizzle-orm";
 import { createHash } from "node:crypto";
 
-import type { ProjectSourceStringEntry } from "@/api/routes/project/project.schema";
+import type {
+  ProjectFileCatQueueFilter,
+  ProjectSourceStringEntry,
+} from "@/api/routes/project/project.schema";
 import { db, schema } from "@/lib/database";
 import { ProjectServiceBase } from "@/lib/projects/project-service-base";
 import { normalizeTranslationMemorySourceText } from "@/lib/translation/normalizeTranslationMemorySourceText";
@@ -37,6 +40,56 @@ function translationKeysSearchCondition(search: string | undefined) {
     ilike(schema.projectTranslationKeys.sourceText, pattern),
     ilike(schema.projectTranslationKeys.context, pattern),
   );
+}
+
+function translationKeysQueueFilterCondition(input: {
+  organizationId: string;
+  projectId: string;
+  targetLocale: string;
+  queueFilter?: ProjectFileCatQueueFilter;
+}) {
+  const filter = input.queueFilter;
+  if (!filter || filter === "all" || filter === "has_issues") {
+    if (filter === "has_issues") {
+      return sql`false`;
+    }
+
+    return undefined;
+  }
+
+  const translationMatch = sql`
+    ${schema.projectTranslations.translationKeyId} = ${schema.projectTranslationKeys.id}
+    and ${schema.projectTranslations.organizationId} = ${input.organizationId}
+    and ${schema.projectTranslations.projectId} = ${input.projectId}
+    and ${schema.projectTranslations.targetLocale} = ${input.targetLocale}
+  `;
+
+  switch (filter) {
+    case "untranslated":
+      return sql`not exists (
+        select 1
+        from ${schema.projectTranslations}
+        where ${translationMatch}
+          and trim(${schema.projectTranslations.text}) != ''
+      )`;
+    case "reviewed":
+      return sql`exists (
+        select 1
+        from ${schema.projectTranslations}
+        where ${translationMatch}
+          and ${schema.projectTranslations.status} = 'approved'
+      )`;
+    case "needs_review":
+      return sql`exists (
+        select 1
+        from ${schema.projectTranslations}
+        where ${translationMatch}
+          and trim(${schema.projectTranslations.text}) != ''
+          and ${schema.projectTranslations.status} != 'approved'
+      )`;
+    default:
+      return undefined;
+  }
 }
 
 export class ProjectTranslationService extends ProjectServiceBase {
@@ -164,13 +217,26 @@ export class ProjectTranslationService extends ProjectServiceBase {
     organizationId: string;
     projectId: string;
     repositorySourceFileId: string;
+    targetLocale?: string;
     search?: string;
+    queueFilter?: ProjectFileCatQueueFilter;
   }) {
     const [row] = await this.database
       .select({ total: count() })
       .from(schema.projectTranslationKeys)
       .where(
-        and(translationKeysFileConditions(input), translationKeysSearchCondition(input.search)),
+        and(
+          translationKeysFileConditions(input),
+          translationKeysSearchCondition(input.search),
+          input.targetLocale
+            ? translationKeysQueueFilterCondition({
+                organizationId: input.organizationId,
+                projectId: input.projectId,
+                targetLocale: input.targetLocale,
+                queueFilter: input.queueFilter,
+              })
+            : undefined,
+        ),
       );
 
     return Number(row?.total ?? 0);
@@ -180,9 +246,11 @@ export class ProjectTranslationService extends ProjectServiceBase {
     organizationId: string;
     projectId: string;
     repositorySourceFileId: string;
+    targetLocale?: string;
     limit?: number;
     offset?: number;
     search?: string;
+    queueFilter?: ProjectFileCatQueueFilter;
   }) {
     const limit = input.limit ?? 2_000;
     const offset = input.offset ?? 0;
@@ -198,7 +266,18 @@ export class ProjectTranslationService extends ProjectServiceBase {
       })
       .from(schema.projectTranslationKeys)
       .where(
-        and(translationKeysFileConditions(input), translationKeysSearchCondition(input.search)),
+        and(
+          translationKeysFileConditions(input),
+          translationKeysSearchCondition(input.search),
+          input.targetLocale
+            ? translationKeysQueueFilterCondition({
+                organizationId: input.organizationId,
+                projectId: input.projectId,
+                targetLocale: input.targetLocale,
+                queueFilter: input.queueFilter,
+              })
+            : undefined,
+        ),
       )
       .orderBy(asc(schema.projectTranslationKeys.key), asc(schema.projectTranslationKeys.id))
       .limit(limit)

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-croql.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-croql.test.ts
@@ -31,6 +31,18 @@ describe("buildCrowdinFileQueueCroql", () => {
       'id of file = 7 and (identifier contains "hero" or text contains "hero") and count of languages summary where (language = @language:"de" and is approved) > 0',
     );
   });
+
+  it("excludes unresolved issues from needs review results", () => {
+    expect(
+      buildCrowdinFileQueueCroql({
+        fileId: 9,
+        targetLocale: "fr",
+        queueFilter: "needs_review",
+      }),
+    ).toBe(
+      'id of file = 9 and count of languages summary where (language = @language:"fr" and is translated and not is approved) > 0 and count of comments where (has unresolved issue) = 0',
+    );
+  });
 });
 
 describe("buildCrowdinFileSearchCroql", () => {

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-croql.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-croql.test.ts
@@ -1,6 +1,37 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { buildCrowdinFileSearchCroql, escapeCrowdinCroqlString } from "./crowdin-croql";
+import {
+  buildCrowdinFileQueueCroql,
+  buildCrowdinFileSearchCroql,
+  escapeCrowdinCroqlString,
+} from "./crowdin-croql";
+
+describe("buildCrowdinFileQueueCroql", () => {
+  it("scopes untranslated segments to a file and target locale", () => {
+    expect(
+      buildCrowdinFileQueueCroql({
+        fileId: 101,
+        targetLocale: "fr",
+        queueFilter: "untranslated",
+      }),
+    ).toBe(
+      'id of file = 101 and count of languages summary where (language = @language:"fr" and is translated) = 0',
+    );
+  });
+
+  it("combines search and queue filters", () => {
+    expect(
+      buildCrowdinFileQueueCroql({
+        fileId: 7,
+        targetLocale: "de",
+        queueFilter: "reviewed",
+        search: "hero",
+      }),
+    ).toBe(
+      'id of file = 7 and (identifier contains "hero" or text contains "hero") and count of languages summary where (language = @language:"de" and is approved) > 0',
+    );
+  });
+});
 
 describe("buildCrowdinFileSearchCroql", () => {
   it("scopes search to a file and matches identifier or text", () => {

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-croql.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-croql.ts
@@ -28,6 +28,7 @@ export function buildCrowdinFileQueueCroql(input: {
       parts.push(
         `count of languages summary where (${languageSummary} and is translated and not is approved) > 0`,
       );
+      parts.push("count of comments where (has unresolved issue) = 0");
       break;
     case "reviewed":
       parts.push(`count of languages summary where (${languageSummary} and is approved) > 0`);

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-croql.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-croql.ts
@@ -1,5 +1,46 @@
+import type { ProjectFileCatQueueFilter } from "@/api/routes/project/project.schema";
+
 export function escapeCrowdinCroqlString(value: string) {
   return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+export function buildCrowdinFileQueueCroql(input: {
+  fileId: number;
+  targetLocale: string;
+  queueFilter?: ProjectFileCatQueueFilter;
+  search?: string;
+}) {
+  const parts: string[] = [`id of file = ${input.fileId}`];
+
+  if (input.search?.trim()) {
+    const escaped = escapeCrowdinCroqlString(input.search.trim());
+    parts.push(`(identifier contains "${escaped}" or text contains "${escaped}")`);
+  }
+
+  const locale = escapeCrowdinCroqlString(input.targetLocale);
+  const languageSummary = `language = @language:"${locale}"`;
+
+  switch (input.queueFilter) {
+    case "untranslated":
+      parts.push(`count of languages summary where (${languageSummary} and is translated) = 0`);
+      break;
+    case "needs_review":
+      parts.push(
+        `count of languages summary where (${languageSummary} and is translated and not is approved) > 0`,
+      );
+      break;
+    case "reviewed":
+      parts.push(`count of languages summary where (${languageSummary} and is approved) > 0`);
+      break;
+    case "has_issues":
+      parts.push("count of comments where (has unresolved issue) > 0");
+      break;
+    case "all":
+    default:
+      break;
+  }
+
+  return parts.join(" and ");
 }
 
 export function buildCrowdinFileSearchCroql(fileId: number, search: string) {

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
@@ -19,7 +19,7 @@ import {
   legacyProviderCatSegmentLimit,
   maxCrowdinSourceStringCountCeiling,
 } from "@/api/routes/project/project.schema";
-import { buildCrowdinFileSearchCroql } from "@/lib/providers/adapters/crowdin/crowdin-croql";
+import { buildCrowdinFileQueueCroql } from "@/lib/providers/adapters/crowdin/crowdin-croql";
 import {
   CrowdinApiClient,
   CrowdinApiError,
@@ -901,6 +901,7 @@ async function buildCrowdinLiveCatFile(input: {
       offset: 0,
       limit: legacyProviderCatSegmentLimit,
       search: undefined,
+      queueFilter: "all",
       paginated: false,
     };
 
@@ -916,9 +917,16 @@ async function buildCrowdinLiveCatFile(input: {
       truncated = strings.length > legacyProviderCatSegmentLimit;
       visibleStrings = truncated ? strings.slice(0, legacyProviderCatSegmentLimit) : strings;
     } else {
-      const croql = paginationInput.search
-        ? buildCrowdinFileSearchCroql(fileId, paginationInput.search)
-        : undefined;
+      const croql =
+        paginationInput.search?.trim() ||
+        (paginationInput.queueFilter && paginationInput.queueFilter !== "all")
+          ? buildCrowdinFileQueueCroql({
+              fileId,
+              targetLocale: input.targetLocale,
+              queueFilter: paginationInput.queueFilter,
+              search: paginationInput.search,
+            })
+          : undefined;
       const [countedTotal, page] = await Promise.all([
         countCrowdinSourceStrings(client, projectId, {
           fileId: croql ? undefined : fileId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds queue filters, bulk approve/skip, and share-link support in the CAT workspace.
- Filters hit the API (Crowdin CroQL / native DB) instead of narrowing only the current page client-side.
- Review fixes:
  - **Has issues** is Crowdin-only: hidden in the filter menu for native projects; native API returns `unsupported_queue_filter` if requested directly.
  - **Prev/next navigation** and segment counter use the filtered queue (and pagination total when applicable).
  - **Needs review** CroQL excludes strings with unresolved issues, matching client-side filter logic.

## Test plan

- [x] `vp test src/components/cat/ src/lib/providers/adapters/crowdin/crowdin-croql.test.ts`
- [x] `vp check --fix`
- [ ] Manual: native project — "Has issues" not shown in filter dropdown
- [ ] Manual: filtered queue — prev/next stays within visible segments; counter uses filtered total
- [ ] Manual: Crowdin — needs_review excludes segments with open issues
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7e7057ec-1390-43c4-a1d1-a7354f114cae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7e7057ec-1390-43c4-a1d1-a7354f114cae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

