### PR TITLE
feat(web): unify Teams and Members navigation

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/workspace-people-nav.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/workspace-people-nav.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
+import { stripAppLocalePrefix } from "@/components/app-shell/navigation-config";
 import { cn } from "@/lib/primitives/cn";
 
 type WorkspacePeopleSection = "teams" | "members";
@@ -26,7 +27,7 @@ const peopleSections: readonly {
 
 function resolveActiveSection(pathname: string, organizationSlug: string): WorkspacePeopleSection {
   const basePath = `/org/${organizationSlug}`;
-  const normalizedPath = pathname.replace(/^\/[a-z]{2}(?=\/)/, "");
+  const normalizedPath = stripAppLocalePrefix(pathname);
 
   if (normalizedPath.startsWith(`${basePath}/members`)) {
     return "members";

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/workspace-people-nav.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/workspace-people-nav.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import { cn } from "@/lib/primitives/cn";
+
+type WorkspacePeopleSection = "teams" | "members";
+
+const peopleSections: readonly {
+  id: WorkspacePeopleSection;
+  label: string;
+  description: string;
+}[] = [
+  {
+    id: "teams",
+    label: "Teams",
+    description: "Group workspace members into teams for project access.",
+  },
+  {
+    id: "members",
+    label: "Members",
+    description: "Invite people and manage workspace roles.",
+  },
+] as const;
+
+function resolveActiveSection(pathname: string, organizationSlug: string): WorkspacePeopleSection {
+  const basePath = `/org/${organizationSlug}`;
+  const normalizedPath = pathname.replace(/^\/[a-z]{2}(?=\/)/, "");
+
+  if (normalizedPath.startsWith(`${basePath}/members`)) {
+    return "members";
+  }
+
+  return "teams";
+}
+
+export function WorkspacePeopleNav({ organizationSlug }: { organizationSlug: string }) {
+  const pathname = usePathname();
+  const activeSection = resolveActiveSection(pathname, organizationSlug);
+
+  return (
+    <nav aria-label="Workspace people" className="border-b border-foreground/8">
+      <div className="flex flex-wrap gap-1">
+        {peopleSections.map((section) => {
+          const href = `/org/${organizationSlug}/${section.id}`;
+          const isActive = activeSection === section.id;
+
+          return (
+            <Link
+              key={section.id}
+              href={href}
+              aria-current={isActive ? "page" : undefined}
+              className={cn(
+                "relative inline-flex items-center px-3 py-2.5 text-sm font-medium transition-colors",
+                "after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:transition-opacity",
+                isActive
+                  ? "text-foreground after:bg-foreground after:opacity-100"
+                  : "text-foreground/56 hover:text-foreground after:opacity-0",
+              )}
+            >
+              {section.label}
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/members/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/members/page.tsx
@@ -1,0 +1,14 @@
+import { requireAppAuthContext } from "@/lib/workos/app-auth";
+
+import { MembersPageContent } from "../settings/_components/members-page-content";
+
+export default async function MembersPage({
+  params,
+}: {
+  params: Promise<{ organizationSlug: string }>;
+}) {
+  const { organizationSlug } = await params;
+  await requireAppAuthContext({ organizationSlug });
+
+  return <MembersPageContent organizationSlug={organizationSlug} />;
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/members-page-content.tsx
@@ -32,7 +32,8 @@ import { apiClient } from "@/lib/api-client-instance";
 import type { OrganizationMembershipRole } from "@/lib/database/types";
 import { cn } from "@/lib/primitives/cn";
 
-import { PageHeader } from "../../_components/workspace-resource-shared";
+import { WorkspacePeopleNav } from "../../_components/workspace-people-nav";
+import { PageHeader, WorkspacePageShell } from "../../_components/workspace-resource-shared";
 
 import {
   getMembershipStatusLabel,
@@ -140,7 +141,7 @@ function MembersTableHeader() {
   );
 }
 
-export function MembersSettingsPageContent({ organizationSlug }: { organizationSlug: string }) {
+export function MembersPageContent({ organizationSlug }: { organizationSlug: string }) {
   const queryClient = useQueryClient();
   const [isInviteOpen, setIsInviteOpen] = useState(false);
   const [inviteEmail, setInviteEmail] = useState("");
@@ -242,10 +243,12 @@ export function MembersSettingsPageContent({ organizationSlug }: { organizationS
   }
 
   return (
-    <main className="mx-auto flex w-full max-w-6xl flex-col gap-6">
+    <WorkspacePageShell>
+      <WorkspacePeopleNav organizationSlug={organizationSlug} />
+
       <PageHeader
         icon={UserGroupIcon}
-        label="Workspace settings"
+        label="Workspace"
         title="Members"
         description="Manage workspace access, invitations, and localization roles."
         actions={
@@ -506,6 +509,6 @@ export function MembersSettingsPageContent({ organizationSlug }: { organizationS
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </main>
+    </WorkspacePageShell>
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/settings-pages.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/_components/settings-pages.tsx
@@ -4,7 +4,6 @@ import {
   AiUserIcon,
   ArrowRight01Icon,
   Key01Icon,
-  UserGroupIcon,
   CreditCardIcon,
   Settings01Icon,
 } from "@hugeicons/core-free-icons";
@@ -47,13 +46,6 @@ const settingsRows = [
     description: "Profile details and workspace identity.",
     href: "account",
     icon: AiUserIcon,
-  },
-  {
-    label: "Members",
-    description: "Invite people to this workspace and manage their roles.",
-    href: "members",
-    icon: UserGroupIcon,
-    requiredCapability: "workspace:read" as const,
   },
   {
     label: "API Keys",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/members/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/members/page.tsx
@@ -1,14 +1,10 @@
-import { requireAppAuthContext } from "@/lib/workos/app-auth";
+import { redirect } from "next/navigation";
 
-import { MembersSettingsPageContent } from "../_components/members-page-content";
-
-export default async function MembersSettingsPage({
+export default async function MembersSettingsRedirectPage({
   params,
 }: {
   params: Promise<{ organizationSlug: string }>;
 }) {
   const { organizationSlug } = await params;
-  await requireAppAuthContext({ organizationSlug });
-
-  return <MembersSettingsPageContent organizationSlug={organizationSlug} />;
+  redirect(`/org/${organizationSlug}/members`);
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/team-detail-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/team-detail-page-view.tsx
@@ -31,6 +31,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { TypographyP } from "@/components/ui/typography";
 import { cn } from "@/lib/primitives/cn";
 
+import { WorkspacePeopleNav } from "../../_components/workspace-people-nav";
 import { PageHeader, WorkspacePageShell } from "../../_components/workspace-resource-shared";
 
 import { AddTeamMemberDialog } from "./add-team-member-dialog";
@@ -118,6 +119,8 @@ export function TeamDetailPageView({
 
   return (
     <WorkspacePageShell>
+      <WorkspacePeopleNav organizationSlug={organizationSlug} />
+
       <div className="flex flex-col gap-4">
         <Button
           nativeButton={false}
@@ -160,7 +163,15 @@ export function TeamDetailPageView({
           <div>
             <TypographyP className="text-sm font-medium text-foreground">Members</TypographyP>
             <TypographyP className="mt-1 text-sm text-foreground/52">
-              People assigned to this team can access its projects and jobs.
+              People assigned to this team can access its projects and jobs. Need someone new in the
+              workspace?{" "}
+              <Link
+                href={`/org/${organizationSlug}/members`}
+                className="font-medium text-foreground/72 underline-offset-4 hover:text-foreground hover:underline"
+              >
+                Invite a member
+              </Link>
+              .
             </TypographyP>
           </div>
           {pageState.canManageMembers ? (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/teams-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/teams/_components/teams-page-view.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/button";
 import { TypographyP } from "@/components/ui/typography";
 import { cn } from "@/lib/primitives/cn";
 
+import { WorkspacePeopleNav } from "../../_components/workspace-people-nav";
 import { PageHeader, WorkspacePageShell } from "../../_components/workspace-resource-shared";
 
 import { TeamDialog } from "./team-dialog";
@@ -58,6 +59,8 @@ export function TeamsPageView({
 
   return (
     <WorkspacePageShell>
+      <WorkspacePeopleNav organizationSlug={organizationSlug} />
+
       <PageHeader
         icon={UserGroupIcon}
         label="Workspace"
@@ -94,7 +97,15 @@ export function TeamsPageView({
           <div className="py-10">
             <TypographyP className="text-sm font-medium text-foreground">No teams yet</TypographyP>
             <TypographyP className="mt-2 max-w-xl text-sm leading-6 text-foreground/52">
-              Create a team to group workspace members and scope project access.
+              Create a team to group workspace members and scope project access. Invite people on
+              the{" "}
+              <Link
+                href={`/org/${organizationSlug}/members`}
+                className="font-medium text-foreground/72 underline-offset-4 hover:text-foreground hover:underline"
+              >
+                Members
+              </Link>{" "}
+              page first if your workspace is still empty.
             </TypographyP>
           </div>
         ) : (

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.test.ts
@@ -20,8 +20,11 @@ describe("getAppShellTitle", () => {
     ["/org/acme/glossaries", "Glossaries"],
     ["/org/acme/translation-memories", "Translation Memories"],
     ["/org/acme/integrations", "Integrations"],
+    ["/org/acme/teams", "Teams"],
+    ["/org/acme/teams/team_1", "team_1"],
+    ["/org/acme/members", "Members"],
     ["/org/acme/settings", "Settings"],
-    ["/org/acme/settings/members", "Team"],
+    ["/org/acme/settings/members", "Members"],
     ["/org/acme/settings/account", "Account"],
     ["/org/acme/settings/billing", "Billing"],
   ])("returns the route title for %s", (pathname, title) => {
@@ -40,10 +43,22 @@ describe("getAppShellBreadcrumbs", () => {
   });
 
   it("returns settings breadcrumbs for settings subpages", () => {
-    expect(getAppShellBreadcrumbs("/org/acme/settings/members")).toEqual([
+    expect(getAppShellBreadcrumbs("/org/acme/settings/account")).toEqual([
       { label: "Settings", href: "/org/acme/settings" },
-      { label: "Team" },
+      { label: "Account" },
     ]);
+  });
+
+  it("returns teams breadcrumbs for team detail pages", () => {
+    expect(getAppShellBreadcrumbs("/org/acme/teams")).toEqual([{ label: "Teams" }]);
+    expect(getAppShellBreadcrumbs("/org/acme/teams/team_1")).toEqual([
+      { label: "Teams", href: "/org/acme/teams" },
+      { label: "team_1" },
+    ]);
+  });
+
+  it("returns members breadcrumbs", () => {
+    expect(getAppShellBreadcrumbs("/org/acme/members")).toEqual([{ label: "Members" }]);
   });
 
   it("returns project breadcrumbs with the project name", () => {

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell-title.ts
@@ -14,7 +14,7 @@ const ROUTE_TITLES = {
   jobs: "Jobs",
   knowledge: "Knowledge",
   locales: "Locales",
-  members: "Team",
+  members: "Members",
   "my-jobs": "My Jobs",
   "my-work": "My Jobs",
   "new-request": "New Request",
@@ -22,6 +22,7 @@ const ROUTE_TITLES = {
   qa: "QA",
   reviews: "Reviews",
   settings: "Settings",
+  teams: "Teams",
   "translation-memories": "Translation Memories",
 } as const;
 
@@ -109,6 +110,21 @@ export function getAppShellBreadcrumbs(
       { label: ROUTE_TITLES.settings, href: buildOrgPath(organizationSlug, "settings") },
       { label: routeTitle(subsection) },
     ];
+  }
+
+  if (section === "teams") {
+    if (!subsection) {
+      return [{ label: ROUTE_TITLES.teams }];
+    }
+
+    return [
+      { label: ROUTE_TITLES.teams, href: buildOrgPath(organizationSlug, "teams") },
+      { label: decodePathSegment(subsection) },
+    ];
+  }
+
+  if (section === "members") {
+    return [{ label: ROUTE_TITLES.members }];
   }
 
   if (section === "projects" && subsection) {

--- a/apps/hyperlocalise-web/src/components/app-shell/nav-user.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/nav-user.tsx
@@ -116,7 +116,7 @@ export function NavUser({
             Account
           </DropdownMenuItem>
           {showMembersLink ? (
-            <DropdownMenuItem render={<Link href={`/org/${organizationSlug}/settings/members`} />}>
+            <DropdownMenuItem render={<Link href={`/org/${organizationSlug}/members`} />}>
               <HugeiconsIcon icon={UserGroupIcon} strokeWidth={2} className="size-4" />
               Members
             </DropdownMenuItem>

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
@@ -80,3 +80,28 @@ describe("navigation-config", () => {
     ).toBe(false);
   });
 });
+
+describe("workspace people navigation", () => {
+  it("marks teams active for team detail routes", () => {
+    const teamsHref = "/org/acme/teams";
+
+    expect(isNavigationItemActive("/org/acme/teams", teamsHref)).toBe(true);
+    expect(isNavigationItemActive("/org/acme/teams/team_1", teamsHref)).toBe(true);
+    expect(isNavigationItemActive("/org/acme/members", teamsHref)).toBe(false);
+  });
+
+  it("marks members active only on members routes", () => {
+    const membersHref = "/org/acme/members";
+
+    expect(isNavigationItemActive("/org/acme/members", membersHref)).toBe(true);
+    expect(isNavigationItemActive("/org/acme/teams", membersHref)).toBe(false);
+    expect(isNavigationItemActive("/org/acme/teams/team_1", membersHref)).toBe(false);
+  });
+
+  it("does not mark settings active on members routes", () => {
+    const settingsHref = "/org/acme/settings";
+
+    expect(isNavigationItemActive("/org/acme/members", settingsHref)).toBe(false);
+    expect(isNavigationItemActive("/org/acme/settings/account", settingsHref)).toBe(true);
+  });
+});

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.test.ts
@@ -94,6 +94,7 @@ describe("workspace people navigation", () => {
     const membersHref = "/org/acme/members";
 
     expect(isNavigationItemActive("/org/acme/members", membersHref)).toBe(true);
+    expect(isNavigationItemActive("/en/org/acme/members", membersHref)).toBe(true);
     expect(isNavigationItemActive("/org/acme/teams", membersHref)).toBe(false);
     expect(isNavigationItemActive("/org/acme/teams/team_1", membersHref)).toBe(false);
   });

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
@@ -14,6 +14,7 @@ import {
   Settings01Icon,
   Task01Icon,
   UserGroupIcon,
+  UserMultiple02Icon,
   WorkHistoryIcon,
 } from "@hugeicons/core-free-icons";
 import type { HugeiconsIcon } from "@hugeicons/react";
@@ -113,6 +114,12 @@ export function buildGlobalNavigationGroups(organizationSlug: string): readonly 
           href: org("teams"),
           icon: UserGroupIcon,
           description: "Create teams and assign workspace members",
+        },
+        {
+          label: "Members",
+          href: org("members"),
+          icon: UserMultiple02Icon,
+          description: "Invite people and manage workspace roles",
         },
         {
           label: "Settings",
@@ -223,12 +230,6 @@ export function isNavigationItemActive(
   }
 
   if (normalizedPathname.startsWith(`${itemPathname}/`)) {
-    if (itemPathname.endsWith("/settings")) {
-      const settingsSubpath = normalizedPathname.slice(itemPathname.length + 1);
-      if (settingsSubpath === "members" || settingsSubpath.startsWith("members/")) {
-        return false;
-      }
-    }
     return true;
   }
 

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
@@ -161,7 +161,7 @@ export function buildProjectNavigationItems(
   ] as const;
 }
 
-function stripAppLocalePrefix(pathname: string) {
+export function stripAppLocalePrefix(pathname: string) {
   const [, firstSegment, ...rest] = pathname.split("/");
   const locale = firstSegment ? normalizeAppLocale(firstSegment) : null;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Teams and Members were split across different parts of the app — Teams in the sidebar, Members buried under Settings — with no way to navigate between them. This restructures workspace people management into a coherent section.

## Changes

- **New `/org/{slug}/members` route** — Members is now a top-level workspace page, matching Teams
- **Shared tab navigation** — `WorkspacePeopleNav` on Teams list, Members, and team detail pages lets users switch between the two views
- **Sidebar** — Added Members next to Teams in the Workspace group
- **Settings hub** — Removed the duplicate Members entry (Account, API Keys, Billing remain)
- **Redirect** — `/settings/members` redirects to `/members` for existing links
- **Breadcrumbs** — Fixed Teams/Members titles (was showing "Overview" / "Team")
- **Cross-links** — Team detail and empty states link to Members for inviting people

## Test plan

- [x] `vp check --fix` passes
- [x] Navigation unit tests pass (`navigation-config.test.ts`, `app-shell-title.test.ts`)
- [ ] Manual: sidebar shows Teams + Members, tabs switch between pages
- [ ] Manual: `/settings/members` redirects to `/members`
- [ ] Manual: team detail page shows people tabs and "Invite a member" link
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fd3f307f-0024-495b-b9d5-295b734f11cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd3f307f-0024-495b-b9d5-295b734f11cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

