### PR TITLE
fix(web): show assigned provider jobs in My Jobs without team access

### DIFF
--- a/apps/hyperlocalise-web/src/api/auth/team-access.ts
+++ b/apps/hyperlocalise-web/src/api/auth/team-access.ts
@@ -97,15 +97,63 @@ export async function buildAccessibleJobsWhere(auth: ApiAuthContext): Promise<SQ
   return and(organizationScope, inArray(schema.jobs.projectId, accessibleProjectIds))!;
 }
 
-/** Personal My Jobs queries scope by assignment/ownership instead of team membership. */
+function providerAssignedUsersMatch(candidates: string[]) {
+  const normalizedCandidates = Array.from(
+    new Set(candidates.map((candidate) => candidate.trim().toLowerCase()).filter(Boolean)),
+  );
+
+  if (normalizedCandidates.length === 0) {
+    return sql`false`;
+  }
+
+  const candidatePredicates = normalizedCandidates.map(
+    (candidate) => sql`
+      lower(assigned_user.value) = ${candidate}
+      or lower(assigned_user.value) like '%' || ${candidate} || '%'
+      or ${candidate} like '%' || lower(assigned_user.value) || '%'
+    `,
+  );
+
+  return sql`exists (
+    select 1
+    from jsonb_array_elements_text(${schema.externalJobDetails.assignedUsers}) as assigned_user(value)
+    where ${sql.join(candidatePredicates, sql` or `)}
+  )`;
+}
+
+function buildPersonalJobRelationshipWhere(input: {
+  userId: string;
+  relationship: "assigned" | "created";
+  providerAssigneeCandidates?: string[];
+}) {
+  if (input.relationship === "assigned") {
+    return or(
+      eq(schema.jobs.ownerUserId, input.userId),
+      providerAssignedUsersMatch(input.providerAssigneeCandidates ?? []),
+    )!;
+  }
+
+  return eq(schema.jobs.createdByUserId, input.userId);
+}
+
 export async function buildOrganizationJobsListWhere(
   auth: ApiAuthContext,
-  options?: { relationship?: "assigned" | "created" },
+  options?: {
+    relationship?: "assigned" | "created";
+    providerAssigneeCandidates?: string[];
+  },
 ): Promise<SQL> {
   const organizationScope = eq(schema.jobs.organizationId, auth.organization.localOrganizationId);
 
   if (options?.relationship === "assigned" || options?.relationship === "created") {
-    return organizationScope;
+    return and(
+      organizationScope,
+      buildPersonalJobRelationshipWhere({
+        userId: auth.user.localUserId,
+        relationship: options.relationship,
+        providerAssigneeCandidates: options.providerAssigneeCandidates,
+      }),
+    )!;
   }
 
   return buildAccessibleJobsWhere(auth);

--- a/apps/hyperlocalise-web/src/api/auth/team-access.ts
+++ b/apps/hyperlocalise-web/src/api/auth/team-access.ts
@@ -97,6 +97,20 @@ export async function buildAccessibleJobsWhere(auth: ApiAuthContext): Promise<SQ
   return and(organizationScope, inArray(schema.jobs.projectId, accessibleProjectIds))!;
 }
 
+/** Personal My Jobs queries scope by assignment/ownership instead of team membership. */
+export async function buildOrganizationJobsListWhere(
+  auth: ApiAuthContext,
+  options?: { relationship?: "assigned" | "created" },
+): Promise<SQL> {
+  const organizationScope = eq(schema.jobs.organizationId, auth.organization.localOrganizationId);
+
+  if (options?.relationship === "assigned" || options?.relationship === "created") {
+    return organizationScope;
+  }
+
+  return buildAccessibleJobsWhere(auth);
+}
+
 export async function buildProjectLinkedGlossaryWhere(auth: ApiAuthContext): Promise<SQL> {
   const organizationId = auth.organization.localOrganizationId;
   const organizationScope = eq(schema.glossaries.organizationId, organizationId);

--- a/apps/hyperlocalise-web/src/api/routes/project/job.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/job.route.test.ts
@@ -8,6 +8,8 @@ import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
 import { app } from "@/api/app";
 import { db, schema } from "@/lib/database";
 import { upsertExternalTmsJobRecords } from "@/lib/projects/external-tms/external-tms-sync-service";
+import { encodeProviderProjectId } from "@/lib/providers/tms-provider-resource-id";
+import { ensureDefaultWorkspaceTeam } from "@/lib/teams/default-workspace-team";
 
 import { createProjectTestFixture } from "./project.fixture";
 import type { WorkspaceJobsResponse } from "./job.schema";
@@ -149,5 +151,100 @@ describe("workspace job list", () => {
     expect(createdJobIds).not.toEqual(
       expect.arrayContaining([expect.stringContaining("assigned-to-current-user")]),
     );
+  });
+
+  it("returns assigned provider jobs for translators without team project access", async () => {
+    const admin = projectFixture.createWorkosIdentityWithRole("admin");
+    const translator = projectFixture.createWorkosIdentityForOrganization(
+      admin.organization,
+      "translator",
+    );
+
+    await projectFixture.authHeadersFor(admin);
+    const organizationId = globalThis.__testApiAuthContext!.organization.localOrganizationId;
+    const defaultTeam = await ensureDefaultWorkspaceTeam(organizationId);
+    const providerProjectId = encodeProviderProjectId({
+      providerKind: "crowdin",
+      externalProjectId: "provider-project",
+    });
+
+    await db.insert(schema.projects).values({
+      id: providerProjectId,
+      organizationId,
+      teamId: defaultTeam.id,
+      name: "Provider project",
+      description: "",
+      translationContext: "",
+      source: "external_tms",
+      externalProviderKind: "crowdin",
+      externalProjectId: "provider-project",
+      sourceLocale: "en-US",
+      targetLocales: ["fr-FR"],
+      isActive: true,
+    });
+
+    await upsertExternalTmsJobRecords({
+      organizationId,
+      projectId: providerProjectId,
+      providerKind: "crowdin",
+      externalProjectId: "provider-project",
+      tasks: [
+        {
+          externalJobId: "assigned-to-translator",
+          externalStatus: "todo",
+          title: "Assigned to translator",
+          assignedUsers: [translator.user.email],
+        },
+        {
+          externalJobId: "assigned-to-someone-else",
+          externalStatus: "todo",
+          title: "Assigned to someone else",
+          assignedUsers: ["someone-else@example.com"],
+        },
+      ],
+    });
+
+    const translatorHeaders = await projectFixture.authHeadersFor(translator);
+
+    const assignedResponse = await client.api.orgs[":organizationSlug"].jobs.$get(
+      {
+        param: { organizationSlug: translator.organization.slug ?? "missing-slug" },
+        query: { relationship: "assigned", limit: "100" },
+      },
+      { headers: translatorHeaders },
+    );
+
+    expect(assignedResponse.status).toBe(200);
+    const assignedBody = (await assignedResponse.json()) as WorkspaceJobsResponse;
+    expect(assignedBody.jobs.map((job) => job.id)).toEqual(
+      expect.arrayContaining([expect.stringContaining("assigned-to-translator")]),
+    );
+    expect(assignedBody.jobs.map((job) => job.id)).not.toEqual(
+      expect.arrayContaining([expect.stringContaining("assigned-to-someone-else")]),
+    );
+
+    const workspaceResponse = await client.api.orgs[":organizationSlug"].jobs.$get(
+      {
+        param: { organizationSlug: translator.organization.slug ?? "missing-slug" },
+        query: { limit: "100" },
+      },
+      { headers: translatorHeaders },
+    );
+
+    expect(workspaceResponse.status).toBe(200);
+    const workspaceBody = (await workspaceResponse.json()) as WorkspaceJobsResponse;
+    expect(workspaceBody.jobs).toEqual([]);
+
+    const createdResponse = await client.api.orgs[":organizationSlug"].jobs.$get(
+      {
+        param: { organizationSlug: translator.organization.slug ?? "missing-slug" },
+        query: { relationship: "created", limit: "100" },
+      },
+      { headers: translatorHeaders },
+    );
+
+    expect(createdResponse.status).toBe(200);
+    const createdBody = (await createdResponse.json()) as WorkspaceJobsResponse;
+    expect(createdBody.jobs).toEqual([]);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/projects/jobs/organization-job-query-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/jobs/organization-job-query-service.ts
@@ -173,6 +173,7 @@ export class OrganizationJobQueryService extends ProjectServiceBase {
         and(
           await buildOrganizationJobsListWhere(auth, {
             relationship: query.relationship,
+            providerAssigneeCandidates,
           }),
           ...visibleSyncedJobConditions(),
           ...jobListFilters({
@@ -180,9 +181,6 @@ export class OrganizationJobQueryService extends ProjectServiceBase {
             type: query.type,
             status: query.status,
             open: query.open,
-            relationship: query.relationship,
-            userId: auth.user.localUserId,
-            providerAssigneeCandidates,
           }),
         ),
       )

--- a/apps/hyperlocalise-web/src/lib/projects/jobs/organization-job-query-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/jobs/organization-job-query-service.ts
@@ -2,7 +2,7 @@ import { and, desc, eq, inArray, isNull, ne, or, sql } from "drizzle-orm";
 
 import type { ApiAuthContext } from "@/api/auth/workos";
 import { openJobStatusValues } from "@/api/routes/project/job.schema";
-import { buildAccessibleJobsWhere } from "@/api/auth/team-access";
+import { buildAccessibleJobsWhere, buildOrganizationJobsListWhere } from "@/api/auth/team-access";
 import { db, schema } from "@/lib/database";
 import { getCurrentUserProviderAssigneeCandidates } from "@/lib/providers/tms-provider-assignee-candidates";
 import { ProjectServiceBase } from "@/lib/projects/project-service-base";
@@ -171,7 +171,9 @@ export class OrganizationJobQueryService extends ProjectServiceBase {
       )
       .where(
         and(
-          await buildAccessibleJobsWhere(auth),
+          await buildOrganizationJobsListWhere(auth, {
+            relationship: query.relationship,
+          }),
           ...visibleSyncedJobConditions(),
           ...jobListFilters({
             kind: query.kind,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes My Jobs showing empty for provider/TMS workflows when a user has assigned or created work but is not on the project's team.

Organization-level My Jobs queries (`relationship=assigned` / `relationship=created`) now scope by ownership and TMS assignee matching instead of team membership. This aligns with provider project job listings, which already bypass team checks for synced TMS projects.

## Root cause

- **My Jobs** used `buildAccessibleJobsWhere`, which requires team membership (or org-wide access).
- **Provider project job pages** skip team checks for synced TMS projects.
- Result: translators could see plenty of jobs inside a provider project, but My Jobs returned nothing.

## Changes

- Add `buildOrganizationJobsListWhere()` to skip team scoping for personal relationship queries.
- Use it in `OrganizationJobQueryService.list()`.
- Add regression test: translator without team access sees assigned provider jobs in My Jobs, but not the full workspace jobs list.

## Test plan

- [x] `vp test src/api/routes/project/job.route.test.ts`
- [x] `vp check --fix`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba288391-0a76-4cd3-bdd5-1b6a67b6fb61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba288391-0a76-4cd3-bdd5-1b6a67b6fb61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

