### PR TITLE
feat(cat): add TMS in-context screenshot preview for provider projects

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
@@ -270,6 +270,7 @@ describe("project file CAT routes", () => {
         providerKind: "crowdin",
         externalProjectId: "42",
         externalStringId: "99",
+        sourcePath: "home.json",
       }),
     );
   });

--- a/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
@@ -23,6 +23,7 @@ const {
   saveTmsProviderLiveCatTranslationMock,
   saveTmsProviderLiveCatCommentMock,
   loadCatSegmentConcordanceMock,
+  loadCatSegmentVisualContextMock,
   generateCatAiRecommendationMock,
   ensureOrganizationProjectRecordMock,
 } = vi.hoisted(() => ({
@@ -31,12 +32,17 @@ const {
   saveTmsProviderLiveCatTranslationMock: vi.fn(),
   saveTmsProviderLiveCatCommentMock: vi.fn(),
   loadCatSegmentConcordanceMock: vi.fn(),
+  loadCatSegmentVisualContextMock: vi.fn(),
   generateCatAiRecommendationMock: vi.fn(),
   ensureOrganizationProjectRecordMock: vi.fn(),
 }));
 
 vi.mock("@/lib/translation/load-cat-segment-concordance", () => ({
   loadCatSegmentConcordance: (...args: unknown[]) => loadCatSegmentConcordanceMock(...args),
+}));
+
+vi.mock("@/lib/translation/load-cat-segment-visual-context", () => ({
+  loadCatSegmentVisualContext: (...args: unknown[]) => loadCatSegmentVisualContextMock(...args),
 }));
 
 vi.mock("@/lib/translation/generate-cat-ai-recommendation", () => ({
@@ -209,6 +215,87 @@ describe("project file CAT routes", () => {
         sourceText: "Hello workspace",
       }),
     );
+  });
+
+  it("loads provider visual context for TMS segments", async () => {
+    const translator = projectFixture.createWorkosIdentityWithRole("translator");
+    getTmsProviderConnectionMock.mockResolvedValue({
+      providerKind: "crowdin",
+      displayName: "Crowdin",
+      validationStatus: "valid",
+      validationMessage: null,
+    });
+    loadCatSegmentVisualContextMock.mockResolvedValue({
+      screenshots: [
+        {
+          id: "12",
+          name: "Checkout",
+          imageUrl: "https://example.com/screen.jpg",
+          width: 200,
+          height: 400,
+          markers: [{ left: 10, top: 10, width: 25, height: 5 }],
+        },
+      ],
+    });
+
+    const response = await client.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].files.detail.cat["visual-context"].$post(
+      {
+        param: {
+          organizationSlug: translator.organization.slug ?? "missing-slug",
+          projectId: "ext:crowdin:42",
+        },
+        json: {
+          sourcePath: "home.json",
+          externalStringId: "99",
+        },
+      },
+      { headers: await projectFixture.authHeadersFor(translator) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      visualContext: {
+        screenshots: [
+          expect.objectContaining({
+            id: "12",
+            imageUrl: "https://example.com/screen.jpg",
+          }),
+        ],
+      },
+    });
+    expect(loadCatSegmentVisualContextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerKind: "crowdin",
+        externalProjectId: "42",
+        externalStringId: "99",
+      }),
+    );
+  });
+
+  it("rejects visual context for native projects", async () => {
+    const { identity, project } = await projectFixture.createStoredProjectFixture();
+    const headers = await projectFixture.authHeadersFor(identity);
+
+    const response = await client.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].files.detail.cat["visual-context"].$post(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: project.id,
+        },
+        json: {
+          sourcePath: "home.json",
+          externalStringId: "segment-1",
+        },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({ error: "visual_context_unavailable" });
   });
 
   it("returns Crowdin CAT content for an encoded provider project", async () => {

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -51,6 +51,7 @@ import {
   projectFileCatRecommendationBodySchema,
   projectFileCatStatusBodySchema,
   projectFileCatTranslationBodySchema,
+  projectFileCatVisualContextBodySchema,
   projectFileDetailQuerySchema,
   projectFileStringContextBodySchema,
   projectFileUploadBodySchema,
@@ -88,6 +89,7 @@ import {
 import { createJobRoutes } from "./job.route";
 import { generateCatAiRecommendation } from "@/lib/translation/generate-cat-ai-recommendation";
 import { loadCatSegmentConcordance } from "@/lib/translation/load-cat-segment-concordance";
+import { loadCatSegmentVisualContext } from "@/lib/translation/load-cat-segment-visual-context";
 import { inferSupportedFileTranslationFileFormat } from "@/lib/translation/file-formats";
 
 type ProjectUpdateErrorCode =
@@ -350,6 +352,16 @@ const validateProjectFileCatCommentBody = validator("json", (value, c) => {
 
 const validateProjectFileCatConcordanceBody = validator("json", (value, c) => {
   const parsed = projectFileCatConcordanceBodySchema.safeParse(value);
+
+  if (!parsed.success) {
+    return invalidProjectPayloadResponse(c);
+  }
+
+  return parsed.data;
+});
+
+const validateProjectFileCatVisualContextBody = validator("json", (value, c) => {
+  const parsed = projectFileCatVisualContextBodySchema.safeParse(value);
 
   if (!parsed.success) {
     return invalidProjectPayloadResponse(c);
@@ -711,6 +723,41 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
           });
 
           return c.json({ concordance }, 200);
+        } catch (error) {
+          return tmsProviderLiveErrorResponse(c, error);
+        }
+      },
+    )
+    .post(
+      "/:projectId/files/detail/cat/visual-context",
+      validateProjectParams,
+      validateProjectFileCatVisualContextBody,
+      async (c) => {
+        const params = c.req.valid("param");
+        const body = c.req.valid("json");
+        const target = await resolveProjectResourceTarget(c.var.auth, params.projectId);
+        if (target.kind === "provider_unavailable") {
+          return providerProjectUnavailableResponse(c, target);
+        }
+
+        if (target.kind !== "provider") {
+          return badRequestResponse(
+            c,
+            "visual_context_unavailable",
+            "In-context preview is only available for connected TMS provider projects.",
+          );
+        }
+
+        try {
+          const visualContext = await loadCatSegmentVisualContext({
+            organizationId: c.var.auth.organization.localOrganizationId,
+            providerKind: target.providerKind,
+            externalProjectId: target.externalProjectId,
+            externalStringId: body.externalStringId,
+            actorUserId: c.var.auth.user.localUserId,
+          });
+
+          return c.json({ visualContext }, 200);
         } catch (error) {
           return tmsProviderLiveErrorResponse(c, error);
         }

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -754,6 +754,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
             providerKind: target.providerKind,
             externalProjectId: target.externalProjectId,
             externalStringId: body.externalStringId,
+            sourcePath: body.sourcePath,
             actorUserId: c.var.auth.user.localUserId,
           });
 

--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -447,6 +447,33 @@ export const projectFileCatConcordanceResponseSchema = z.object({
   }),
 });
 
+export const projectFileCatVisualContextMarkerSchema = z.object({
+  left: z.number(),
+  top: z.number(),
+  width: z.number(),
+  height: z.number(),
+});
+
+export const projectFileCatVisualContextScreenshotSchema = z.object({
+  id: z.string(),
+  name: z.string().nullable(),
+  imageUrl: z.string().min(1),
+  width: z.number().nullable(),
+  height: z.number().nullable(),
+  markers: z.array(projectFileCatVisualContextMarkerSchema),
+});
+
+export const projectFileCatVisualContextBodySchema = z.object({
+  sourcePath: z.string().trim().min(1).max(2048),
+  externalStringId: z.string().trim().min(1).max(128),
+});
+
+export const projectFileCatVisualContextResponseSchema = z.object({
+  visualContext: z.object({
+    screenshots: z.array(projectFileCatVisualContextScreenshotSchema),
+  }),
+});
+
 export const projectFileCatRecommendationResponseSchema = z.object({
   recommendation: z.object({
     aiSuggestion: z.string(),
@@ -531,6 +558,10 @@ export type ProjectFileCatRecommendationBody = z.infer<
 export type ProjectFileCatConcordanceBody = z.infer<typeof projectFileCatConcordanceBodySchema>;
 export type ProjectFileCatConcordanceResponse = z.infer<
   typeof projectFileCatConcordanceResponseSchema
+>;
+export type ProjectFileCatVisualContextBody = z.infer<typeof projectFileCatVisualContextBodySchema>;
+export type ProjectFileCatVisualContextResponse = z.infer<
+  typeof projectFileCatVisualContextResponseSchema
 >;
 export type ProjectSourceStringEntry = z.infer<typeof projectSourceStringEntrySchema>;
 export type ProjectSourceStringsPreview = z.infer<typeof projectSourceStringsPreviewSchema>;

--- a/apps/hyperlocalise-web/src/components/cat/cat-intelligence-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-intelligence-panel.tsx
@@ -24,6 +24,7 @@ import { cn } from "@/lib/primitives/cn";
 
 import { catIntelligencePanelMessages } from "./cat.messages";
 import { requiresLowMatchConfirmation } from "./tm-match-quality";
+import { CatVisualContextPanel } from "./cat-visual-context-panel";
 import type {
   CatGlossaryTerm,
   CatSegmentIntelligence,
@@ -197,7 +198,9 @@ export function CatIntelligencePanel({
   intelligence,
   isLookingUpContext = false,
   isConcordanceLoading = false,
+  isVisualContextLoading = false,
   showAgentContext = false,
+  showVisualContext = false,
   canEditTranslations = true,
   onUseTmMatch,
   onUseGlossaryTerm,
@@ -205,7 +208,9 @@ export function CatIntelligencePanel({
   intelligence: CatSegmentIntelligence;
   isLookingUpContext?: boolean;
   isConcordanceLoading?: boolean;
+  isVisualContextLoading?: boolean;
   showAgentContext?: boolean;
+  showVisualContext?: boolean;
   canEditTranslations?: boolean;
   onUseTmMatch?: (match: CatTranslationMemoryMatch) => void;
   onUseGlossaryTerm?: (term: CatGlossaryTerm) => void;
@@ -257,6 +262,12 @@ export function CatIntelligencePanel({
 
       <ScrollArea className="min-h-0 flex-1">
         <div className="space-y-5 p-4">
+          <CatVisualContextPanel
+            visualContext={intelligence.visualContext}
+            isLoading={isVisualContextLoading}
+            showPanel={showVisualContext}
+          />
+
           <PanelSection title={intl.formatMessage(catIntelligencePanelMessages.fileContextTitle)}>
             {hasFileContext ? (
               <MarkdownContent

--- a/apps/hyperlocalise-web/src/components/cat/cat-visual-context-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-visual-context-panel.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { Skeleton } from "@/components/ui/skeleton";
+import type {
+  CatVisualContext,
+  CatVisualContextScreenshot,
+} from "@/lib/translation/cat-visual-context";
+import { cn } from "@/lib/primitives/cn";
+
+import { catVisualContextPanelMessages } from "./cat.messages";
+
+function VisualContextSkeleton() {
+  return (
+    <div className="space-y-3 rounded-2xl bg-foreground/3 p-3.5">
+      <Skeleton className="h-3 w-32 rounded-full bg-foreground/8" />
+      <Skeleton className="aspect-[9/16] w-full rounded-xl bg-foreground/8" />
+    </div>
+  );
+}
+
+function VisualContextScreenshotCard({ screenshot }: { screenshot: CatVisualContextScreenshot }) {
+  const intl = useIntl();
+
+  return (
+    <figure className="overflow-hidden rounded-xl border border-foreground/8 bg-background">
+      {screenshot.name ? (
+        <figcaption className="border-b border-foreground/8 px-3 py-2 text-xs text-muted-foreground">
+          {screenshot.name}
+        </figcaption>
+      ) : null}
+      <div className="relative bg-foreground/2">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={screenshot.imageUrl}
+          alt={
+            screenshot.name ??
+            intl.formatMessage(catVisualContextPanelMessages.screenshotAltFallback)
+          }
+          className="block h-auto w-full"
+          loading="lazy"
+          decoding="async"
+        />
+        {screenshot.markers.map((marker, index) => (
+          <span
+            key={`${screenshot.id}-${index}`}
+            className={cn(
+              "pointer-events-none absolute rounded-sm border-2 border-grove-300/80 bg-grove-300/15",
+              "shadow-[0_0_0_1px_rgba(255,255,255,0.35)_inset]",
+            )}
+            style={{
+              left: `${marker.left}%`,
+              top: `${marker.top}%`,
+              width: `${marker.width}%`,
+              height: `${marker.height}%`,
+            }}
+          />
+        ))}
+      </div>
+    </figure>
+  );
+}
+
+export function CatVisualContextPanel({
+  visualContext,
+  isLoading = false,
+  showPanel = false,
+}: {
+  visualContext?: CatVisualContext;
+  isLoading?: boolean;
+  showPanel?: boolean;
+}) {
+  if (!showPanel) {
+    return null;
+  }
+
+  const screenshots = visualContext?.screenshots ?? [];
+
+  return (
+    <section className="space-y-3">
+      <div>
+        <h3 className="text-xs font-medium text-muted-foreground">
+          <FormattedMessage {...catVisualContextPanelMessages.title} />
+        </h3>
+        <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+          <FormattedMessage {...catVisualContextPanelMessages.description} />
+        </p>
+      </div>
+
+      {isLoading ? (
+        <VisualContextSkeleton />
+      ) : screenshots.length > 0 ? (
+        <div className="space-y-3">
+          {screenshots.map((screenshot) => (
+            <VisualContextScreenshotCard key={screenshot.id} screenshot={screenshot} />
+          ))}
+        </div>
+      ) : (
+        <p className="text-sm leading-relaxed text-muted-foreground">
+          <FormattedMessage {...catVisualContextPanelMessages.empty} />
+        </p>
+      )}
+    </section>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
@@ -770,6 +770,7 @@ export function CatWorkspaceContainer({
 
     const existingVisualContext = stateRef.current.segmentIntelligence?.[segmentId]?.visualContext;
     if (existingVisualContext) {
+      setIsLoadingVisualContext(false);
       return;
     }
 

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
@@ -816,18 +816,19 @@ export function CatWorkspaceContainer({
         setState((current) => {
           const currentChecks =
             current.segmentFormatChecks?.[segmentId] ?? current.formatChecks ?? [];
+          const nextChecks = [
+            visualContextFailureCheck,
+            ...currentChecks.filter((check) => check.id !== visualContextFailureCheck.id),
+          ];
 
           return {
             ...current,
             segmentFormatChecks: {
               ...current.segmentFormatChecks,
-              [segmentId]: [
-                visualContextFailureCheck,
-                ...currentChecks.filter((check) => check.id !== visualContextFailureCheck.id),
-              ],
+              [segmentId]: nextChecks,
             },
             formatChecks:
-              current.selectedSegmentId === segmentId ? currentChecks : current.formatChecks,
+              current.selectedSegmentId === segmentId ? nextChecks : current.formatChecks,
           };
         });
       })

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
@@ -41,7 +41,11 @@ import {
   type CatQueueFilter,
 } from "./cat-queue-filter";
 import { buildCatSegmentShareUrl } from "./cat-segment-share-link";
-import { catEditorPanelMessages, catWorkspaceContainerMessages } from "./cat.messages";
+import {
+  catEditorPanelMessages,
+  catIntelligencePanelMessages,
+  catWorkspaceContainerMessages,
+} from "./cat.messages";
 import {
   selectBestTmMatchForAutoFill,
   TM_AUTO_FILL_MIN_MATCH_PERCENT_DEFAULT,
@@ -209,6 +213,16 @@ export function mergeCatWorkspaceState(
         translationMemoryMatches: currentConcordance?.translationMemoryMatches,
       };
     }
+
+    const nextVisualContext = nextInitialState.segmentIntelligence?.[segment.id]?.visualContext;
+    const currentVisualContext = currentState.segmentIntelligence?.[segment.id]?.visualContext;
+    if (!nextVisualContext && currentVisualContext) {
+      segmentIntelligence[segment.id] = {
+        ...(segmentIntelligence[segment.id] ?? nextInitialState.intelligence),
+        ...currentState.segmentIntelligence?.[segment.id],
+        visualContext: currentVisualContext,
+      };
+    }
   }
 
   return {
@@ -306,6 +320,7 @@ export function CatWorkspaceContainer({
   const [commentPostError, setCommentPostError] = useState<string | undefined>();
   const [isLookingUpContext, setIsLookingUpContext] = useState(false);
   const [isLoadingConcordance, setIsLoadingConcordance] = useState(false);
+  const [isLoadingVisualContext, setIsLoadingVisualContext] = useState(false);
   const [revealedAgentContextSegmentIds, setRevealedAgentContextSegmentIds] = useState<
     ReadonlySet<string>
   >(() => collectSegmentsWithAgentContext(initialState));
@@ -327,8 +342,12 @@ export function CatWorkspaceContainer({
   const runQaChecks = serviceOverrides?.runQaChecks;
   const lookupSegmentContext = serviceOverrides?.lookupSegmentContext;
   const lookupSegmentConcordance = serviceOverrides?.lookupSegmentConcordance;
+  const lookupSegmentVisualContext = serviceOverrides?.lookupSegmentVisualContext;
   const generateAiRecommendation = serviceOverrides?.generateAiRecommendation;
   const canLookupContext = Boolean(lookupSegmentContext);
+  const canLoadVisualContext = Boolean(
+    lookupSegmentVisualContext && state.providerKind && state.providerKind !== "native",
+  );
   const canUseAiRecommendation = Boolean(generateAiRecommendation);
   const canRunSegmentReview = Boolean(
     lookupSegmentConcordance || generateAiRecommendation || validateFormat || runQaChecks,
@@ -740,6 +759,96 @@ export function CatWorkspaceContainer({
 
   useEffect(() => {
     const segmentId = state.selectedSegmentId;
+    if (!segmentId || !lookupSegmentVisualContext || !canLoadVisualContext) {
+      return;
+    }
+
+    const segment = stateRef.current.segments.find((item) => item.id === segmentId);
+    if (!segment) {
+      return;
+    }
+
+    const existingVisualContext = stateRef.current.segmentIntelligence?.[segmentId]?.visualContext;
+    if (existingVisualContext) {
+      return;
+    }
+
+    let cancelled = false;
+    setIsLoadingVisualContext(true);
+
+    void lookupSegmentVisualContext(segment)
+      .then((visualContext) => {
+        if (cancelled) {
+          return;
+        }
+
+        setState((current) => {
+          const segmentIntelligence =
+            current.segmentIntelligence?.[segmentId] ?? current.intelligence;
+
+          return {
+            ...current,
+            segmentIntelligence: {
+              ...current.segmentIntelligence,
+              [segmentId]: {
+                ...segmentIntelligence,
+                visualContext,
+              },
+            },
+          };
+        });
+      })
+      .catch(() => {
+        if (cancelled) {
+          return;
+        }
+
+        const message = intl.formatMessage(catWorkspaceContainerMessages.visualContextLoadFailed);
+        const visualContextFailureCheck: CatFormatCheck = {
+          id: `visual-context-failed-${segmentId}`,
+          label: intl.formatMessage(catIntelligencePanelMessages.panelTitle),
+          status: "warn",
+          message,
+          category: "qa",
+        };
+
+        setState((current) => {
+          const currentChecks =
+            current.segmentFormatChecks?.[segmentId] ?? current.formatChecks ?? [];
+
+          return {
+            ...current,
+            segmentFormatChecks: {
+              ...current.segmentFormatChecks,
+              [segmentId]: [
+                visualContextFailureCheck,
+                ...currentChecks.filter((check) => check.id !== visualContextFailureCheck.id),
+              ],
+            },
+            formatChecks:
+              current.selectedSegmentId === segmentId ? currentChecks : current.formatChecks,
+          };
+        });
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsLoadingVisualContext(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    canLoadVisualContext,
+    intl,
+    lookupSegmentVisualContext,
+    state.providerKind,
+    state.selectedSegmentId,
+  ]);
+
+  useEffect(() => {
+    const segmentId = state.selectedSegmentId;
     if (!segmentId || !canRunSegmentReview) {
       return;
     }
@@ -1140,10 +1249,12 @@ export function CatWorkspaceContainer({
         commentPostError={commentPostError}
         isLookingUpContext={isLookingUpContext}
         isConcordanceLoading={isLoadingConcordance}
+        isVisualContextLoading={isLoadingVisualContext}
         isAiSuggestionLoading={isGeneratingAiRecommendation && canUseAiRecommendation}
         isFormatChecksLoading={isRunningFormatChecks || isValidating}
         canLookupContext={canLookupContext}
         showAgentContext={revealedAgentContextSegmentIds.has(state.selectedSegmentId)}
+        showVisualContext={canLoadVisualContext}
         canUseAiRecommendation={canUseAiRecommendation}
         className={className}
         queueSearch={queueSearch}

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace.tsx
@@ -46,11 +46,13 @@ export function CatWorkspaceView({
   commentPostError,
   isLookingUpContext = false,
   isConcordanceLoading = false,
+  isVisualContextLoading = false,
   isAiSuggestionLoading = false,
   isFormatChecksLoading = false,
   canLookupContext = false,
   canUseAiRecommendation = false,
   showAgentContext = false,
+  showVisualContext = false,
   dirtySegmentIds,
   className,
   queueSearch,
@@ -213,7 +215,9 @@ export function CatWorkspaceView({
         intelligence={selectedSegmentIntelligence}
         isLookingUpContext={isLookingUpContext}
         isConcordanceLoading={isConcordanceLoading}
+        isVisualContextLoading={isVisualContextLoading}
         showAgentContext={showAgentContext}
+        showVisualContext={showVisualContext}
         canEditTranslations={fullState.canEditTranslations !== false}
         onUseTmMatch={(match) => editing.onUseTmMatch(selectedSegment.id, match)}
         onUseGlossaryTerm={(term) =>

--- a/apps/hyperlocalise-web/src/components/cat/cat.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat.messages.ts
@@ -218,6 +218,11 @@ export const catWorkspaceContainerMessages = defineMessages({
     id: "BGfQ06k8Pb",
     description: "Fallback error when repository context lookup fails",
   },
+  visualContextLoadFailed: {
+    defaultMessage: "Failed to load in-context preview from the provider.",
+    id: "qd8sDGeNiM",
+    description: "Fallback error when TMS visual context preview fails to load",
+  },
   saveTranslationFailed: {
     defaultMessage: "Failed to save translation.",
     id: "pMRZvoJLzS",
@@ -587,5 +592,28 @@ export const catEditorPanelMessages = defineMessages({
     defaultMessage: "Copy link to this segment",
     id: "CqDUHu+YvU",
     description: "Accessible label for the CAT segment share link button",
+  },
+});
+
+export const catVisualContextPanelMessages = defineMessages({
+  title: {
+    defaultMessage: "In-context preview",
+    id: "2W3toA+qRz",
+    description: "Section heading for TMS screenshot context in the CAT intelligence panel",
+  },
+  description: {
+    defaultMessage: "Screenshots attached in your TMS for this string.",
+    id: "3Td/QL9gLC",
+    description: "Supporting copy for TMS screenshot context in the CAT intelligence panel",
+  },
+  empty: {
+    defaultMessage: "No screenshots are attached to this string in the provider.",
+    id: "ISCo8PAGGI",
+    description: "Empty state when a TMS string has no screenshot context",
+  },
+  screenshotAltFallback: {
+    defaultMessage: "Screenshot context for this string",
+    id: "jORzWMtK+S",
+    description: "Accessible fallback label for a TMS screenshot preview image",
   },
 });

--- a/apps/hyperlocalise-web/src/components/cat/dependencies.ts
+++ b/apps/hyperlocalise-web/src/components/cat/dependencies.ts
@@ -1,3 +1,4 @@
+import type { CatVisualContext } from "@/lib/translation/cat-visual-context";
 import type {
   CatFormatCheck,
   CatGlossaryTerm,
@@ -19,6 +20,8 @@ export interface CatSegmentConcordanceResult {
   glossaryTerms: CatGlossaryTerm[];
   translationMemoryMatches: CatTranslationMemoryMatch[];
 }
+
+export type CatSegmentVisualContextResult = CatVisualContext;
 
 export interface CatWorkspaceNavigation {
   onSelectSegment: (segmentId: string) => void;
@@ -52,6 +55,7 @@ export interface CatWorkspaceServices {
   runQaChecks?: (segment: CatSegment, value: string) => Promise<CatFormatCheck[]>;
   lookupSegmentContext?: (segment: CatSegment) => Promise<string>;
   lookupSegmentConcordance?: (segment: CatSegment) => Promise<CatSegmentConcordanceResult>;
+  lookupSegmentVisualContext?: (segment: CatSegment) => Promise<CatSegmentVisualContextResult>;
   generateAiRecommendation?: (
     segment: CatSegment,
     targetText: string,
@@ -82,11 +86,13 @@ export interface CatWorkspaceViewProps {
   commentPostError?: string;
   isLookingUpContext?: boolean;
   isConcordanceLoading?: boolean;
+  isVisualContextLoading?: boolean;
   isAiSuggestionLoading?: boolean;
   isFormatChecksLoading?: boolean;
   canLookupContext?: boolean;
   canUseAiRecommendation?: boolean;
   showAgentContext?: boolean;
+  showVisualContext?: boolean;
   dirtySegmentIds?: ReadonlySet<string>;
   className?: string;
   queueSearch?: string;

--- a/apps/hyperlocalise-web/src/components/cat/project-file-cat-mapper.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file-cat-mapper.ts
@@ -230,6 +230,7 @@ export function projectFileCatToWorkspaceState(
     primaryActionLabel: catFile.provider ? "Save to provider" : "Save translation",
     canEditTranslations: catFile.canEditTranslations,
     canAddComments: Boolean(catFile.provider?.kind === "crowdin" && catFile.canEditTranslations),
+    providerKind: catFile.provider?.kind ?? null,
   };
 }
 

--- a/apps/hyperlocalise-web/src/components/cat/project-file-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/project-file-cat-workspace.tsx
@@ -10,6 +10,7 @@ import type {
   ProjectFileCatComment,
   ProjectFileCatRecommendationResponse,
   ProjectFileCatTranslation,
+  ProjectFileCatVisualContextResponse,
 } from "@/api/routes/project/project.schema";
 import { Spinner } from "@/components/ui/spinner";
 import {
@@ -307,6 +308,28 @@ export function ProjectFileCatWorkspace({
     [organizationSlug, projectId],
   );
 
+  const lookupSegmentVisualContext = useCallback(
+    async (segment: CatSegment) => {
+      const response = await apiClient.api.orgs[":organizationSlug"].projects[
+        ":projectId"
+      ].files.detail.cat["visual-context"].$post({
+        param: { organizationSlug, projectId },
+        json: {
+          sourcePath,
+          externalStringId: segment.id,
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(await readApiError(response, "Failed to load in-context preview"));
+      }
+
+      const body = (await response.json()) as ProjectFileCatVisualContextResponse;
+      return body.visualContext;
+    },
+    [organizationSlug, projectId, sourcePath],
+  );
+
   const generateAiRecommendation = useCallback(
     async (segment: CatSegment, targetText: string, intelligence?: CatSegmentIntelligence) => {
       const concordancePayload =
@@ -435,6 +458,10 @@ export function ProjectFileCatWorkspace({
         services={{
           validateFormat,
           lookupSegmentConcordance,
+          lookupSegmentVisualContext:
+            catQuery.data?.provider?.kind && catQuery.data.provider.kind !== "native"
+              ? lookupSegmentVisualContext
+              : undefined,
           generateAiRecommendation,
           ...(repositoryFullName ? { lookupSegmentContext } : {}),
         }}

--- a/apps/hyperlocalise-web/src/components/cat/types.ts
+++ b/apps/hyperlocalise-web/src/components/cat/types.ts
@@ -1,3 +1,5 @@
+import type { CatVisualContext } from "@/lib/translation/cat-visual-context";
+
 export type CatSegmentStatus = "pending" | "needs_review" | "reviewed" | "skipped";
 
 export type CatTmMatchKind = "exact" | "context" | "fuzzy";
@@ -74,6 +76,7 @@ export interface CatSegmentIntelligence {
   translationMemoryMatches?: CatTranslationMemoryMatch[];
   aiSuggestion?: string;
   aiReasoning?: string;
+  visualContext?: CatVisualContext;
 }
 
 export interface CatQueueSummary {
@@ -97,4 +100,5 @@ export interface CatWorkspaceState {
   primaryActionLabel?: string;
   canEditTranslations?: boolean;
   canAddComments?: boolean;
+  providerKind?: string | null;
 }

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
@@ -85,6 +85,31 @@ export interface CrowdinSourceString {
   labelIds: number[] | null;
 }
 
+export interface CrowdinScreenshotTagPosition {
+  x?: number | null;
+  y?: number | null;
+  width?: number | null;
+  height?: number | null;
+}
+
+export interface CrowdinScreenshotTag {
+  id: number;
+  screenshotId: number;
+  stringId: number;
+  position?: CrowdinScreenshotTagPosition | null;
+}
+
+export interface CrowdinScreenshot {
+  id: number;
+  webUrl: string;
+  name: string;
+  size?: {
+    width: number;
+    height: number;
+  } | null;
+  tags?: CrowdinScreenshotTag[] | null;
+}
+
 export interface CrowdinLanguageRef {
   id: string;
   name?: string;
@@ -575,6 +600,57 @@ export class CrowdinApiClient {
    *
    * Supported filters: `fileId`, `taskId`, or `croql` (mutually exclusive with each other).
    */
+  async listScreenshots(
+    projectId: number,
+    options?: {
+      stringIds?: number[];
+      maxItems?: number;
+    },
+  ): Promise<CrowdinScreenshot[]> {
+    const screenshots: CrowdinScreenshot[] = [];
+    let offset = 0;
+    const pageLimit = 25;
+
+    while (true) {
+      const remaining =
+        options?.maxItems === undefined
+          ? pageLimit
+          : Math.max(options.maxItems - screenshots.length, 0);
+      if (options?.maxItems !== undefined && remaining === 0) {
+        break;
+      }
+
+      const params = new URLSearchParams({
+        limit: String(Math.min(remaining, pageLimit)),
+        offset: String(offset),
+      });
+      if (options?.stringIds?.length) {
+        params.set("stringIds", options.stringIds.join(","));
+      }
+
+      const response = await this.get<CrowdinListResponse<CrowdinScreenshot>>(
+        `/projects/${projectId}/screenshots?${params.toString()}`,
+      );
+      const page = response.data.map((item) => item.data);
+      screenshots.push(...page);
+
+      if (
+        page.length < Math.min(remaining, pageLimit) ||
+        (options?.maxItems !== undefined && screenshots.length >= options.maxItems)
+      ) {
+        break;
+      }
+
+      offset += page.length;
+    }
+
+    if (options?.maxItems !== undefined && screenshots.length > options.maxItems) {
+      return screenshots.slice(0, options.maxItems);
+    }
+
+    return screenshots;
+  }
+
   async listSourceStrings(
     projectId: number,
     options?: {

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-cat-visual-context.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-cat-visual-context.ts
@@ -1,0 +1,65 @@
+import {
+  pixelRectToPercentMarkers,
+  type CatVisualContext,
+  type CatVisualContextScreenshot,
+} from "@/lib/translation/cat-visual-context";
+
+import { CrowdinApiClient } from "./crowdin-api";
+
+const maxCrowdinScreenshotsPerSegment = 8;
+
+export async function loadCrowdinCatVisualContext(input: {
+  client: CrowdinApiClient;
+  externalProjectId: string;
+  externalStringId: string;
+}): Promise<CatVisualContext> {
+  const projectId = Number(input.externalProjectId);
+  const stringId = Number(input.externalStringId);
+  if (Number.isNaN(projectId) || Number.isNaN(stringId)) {
+    return { screenshots: [] };
+  }
+
+  const screenshots = await input.client.listScreenshots(projectId, {
+    stringIds: [stringId],
+    maxItems: maxCrowdinScreenshotsPerSegment,
+  });
+
+  return {
+    screenshots: screenshots.flatMap((screenshot) => mapCrowdinScreenshot(screenshot, stringId)),
+  };
+}
+
+function mapCrowdinScreenshot(
+  screenshot: Awaited<ReturnType<CrowdinApiClient["listScreenshots"]>>[number],
+  stringId: number,
+): CatVisualContextScreenshot[] {
+  const imageUrl = screenshot.webUrl?.trim();
+  if (!imageUrl) {
+    return [];
+  }
+
+  const markers = (screenshot.tags ?? [])
+    .filter((tag) => tag.stringId === stringId && tag.position)
+    .map((tag) =>
+      pixelRectToPercentMarkers({
+        width: screenshot.size?.width,
+        height: screenshot.size?.height,
+        left: tag.position?.x ?? 0,
+        top: tag.position?.y ?? 0,
+        widthPx: tag.position?.width ?? 0,
+        heightPx: tag.position?.height ?? 0,
+      }),
+    )
+    .filter((marker): marker is NonNullable<typeof marker> => marker != null);
+
+  return [
+    {
+      id: String(screenshot.id),
+      name: screenshot.name?.trim() || null,
+      imageUrl,
+      width: screenshot.size?.width ?? null,
+      height: screenshot.size?.height ?? null,
+      markers,
+    },
+  ];
+}

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-api.test.ts
@@ -397,6 +397,53 @@ describe("LokaliseApiClient", () => {
     );
   });
 
+  it("retrieves a screenshot with key coordinates", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      if (String(url).includes("/projects/proj.123/screenshots/123")) {
+        return new Response(
+          JSON.stringify({
+            project_id: "proj.123",
+            screenshot: {
+              screenshot_id: 123,
+              title: "Homepage",
+              url: "https://example.com/screenshot.png",
+              width: 800,
+              height: 600,
+              key_ids: [4242],
+              keys: [
+                {
+                  key_id: 4242,
+                  coordinates: {
+                    left: 40,
+                    top: 80,
+                    width: 120,
+                    height: 24,
+                  },
+                },
+              ],
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify({ screenshot: null }), { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    const screenshot = await client.getScreenshot("proj.123", 123);
+
+    expect(screenshot.keyAreas).toEqual([
+      {
+        keyId: 4242,
+        left: 40,
+        top: 80,
+        width: 120,
+        height: 24,
+      },
+    ]);
+  });
+
   it("filters completed tasks by completion time and caps pagination", async () => {
     const recentCompletedAt = Math.floor(Date.now() / 1000) - 60;
     const staleCompletedAt = Math.floor(Date.now() / 1000) - 60 * 60 * 24 * 60;

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-api.test.ts
@@ -363,6 +363,40 @@ describe("LokaliseApiClient", () => {
     );
   });
 
+  it("filters screenshots by key in the Lokalise API request", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      if (String(url).includes("/projects/proj.123/screenshots?")) {
+        return new Response(
+          JSON.stringify({
+            project_id: "proj.123",
+            screenshots: [
+              {
+                screenshot_id: 123,
+                title: "Homepage",
+                url: "https://example.com/screenshot.png",
+                key_ids: [4242],
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify({ screenshots: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    const screenshots = await client.listScreenshotsForKey("proj.123", 4242);
+
+    expect(screenshots).toHaveLength(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.lokalise.test/api2/projects/proj.123/screenshots?page=1&limit=100&filter_keys=4242",
+      expect.objectContaining({
+        headers: { "X-Api-Token": "test-token" },
+      }),
+    );
+  });
+
   it("filters completed tasks by completion time and caps pagination", async () => {
     const recentCompletedAt = Math.floor(Date.now() / 1000) - 60;
     const staleCompletedAt = Math.floor(Date.now() / 1000) - 60 * 60 * 24 * 60;

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-api.ts
@@ -214,6 +214,25 @@ export interface LokaliseKey {
   translations: LokaliseTranslation[];
 }
 
+export interface LokaliseScreenshotKeyArea {
+  keyId: number;
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+export interface LokaliseScreenshot {
+  screenshotId: number;
+  title: string | null;
+  description: string | null;
+  imageUrl: string;
+  width: number | null;
+  height: number | null;
+  keyIds: number[];
+  keyAreas: LokaliseScreenshotKeyArea[];
+}
+
 export const LOKALISE_DEFAULT_BUNDLE_STRUCTURE = "%LANG_ISO%.%FORMAT%";
 
 /** Caps glossary-term pagination during sync and live lookup. */
@@ -688,6 +707,36 @@ export class LokaliseApiClient {
     return (response.comments ?? []).map(normalizeLokaliseComment);
   }
 
+  async listScreenshotsForKey(
+    projectId: string,
+    keyId: number,
+    options?: { maxItems?: number },
+  ): Promise<LokaliseScreenshot[]> {
+    const screenshots: LokaliseScreenshot[] = [];
+    let page = 1;
+    const limit = 100;
+    const maxItems = options?.maxItems ?? 8;
+
+    while (screenshots.length < maxItems) {
+      const response = await this.get<LokaliseScreenshotsListResponse>(
+        `/projects/${encodeURIComponent(projectId)}/screenshots?page=${page}&limit=${limit}`,
+      );
+      const pageItems = (response.screenshots ?? [])
+        .map(normalizeLokaliseScreenshot)
+        .filter((screenshot) => screenshot.keyIds.includes(keyId));
+
+      screenshots.push(...pageItems);
+
+      if ((response.screenshots ?? []).length < limit || screenshots.length >= maxItems) {
+        break;
+      }
+
+      page += 1;
+    }
+
+    return screenshots.slice(0, maxItems);
+  }
+
   async listWebhooks(projectId: string): Promise<LokaliseWebhook[]> {
     const response = await this.get<LokaliseWebhooksListResponse>(
       `/projects/${encodeURIComponent(projectId)}/webhooks`,
@@ -1038,6 +1087,30 @@ type LokaliseKeyCommentsCreateResponse = {
   comments?: LokaliseCommentApiRecord[];
 };
 
+type LokaliseScreenshotsListResponse = {
+  project_id?: string;
+  screenshots?: LokaliseScreenshotApiRecord[];
+};
+
+type LokaliseScreenshotApiRecord = {
+  screenshot_id?: number;
+  title?: string | null;
+  description?: string | null;
+  url?: string | null;
+  width?: number | null;
+  height?: number | null;
+  key_ids?: number[];
+  keys?: Array<{
+    key_id?: number;
+    coordinates?: {
+      left?: number;
+      top?: number;
+      width?: number;
+      height?: number;
+    } | null;
+  }>;
+};
+
 type LokaliseLanguagesListResponse = {
   project_id?: string;
   languages?: LokaliseLanguageApiRecord[];
@@ -1256,6 +1329,35 @@ function normalizeLokaliseLanguage(record: LokaliseLanguageApiRecord): LokaliseL
     langIso: record.lang_iso,
     langName: record.lang_name,
     isRtl: record.is_rtl ?? false,
+  };
+}
+
+function normalizeLokaliseScreenshot(record: LokaliseScreenshotApiRecord): LokaliseScreenshot {
+  return {
+    screenshotId: record.screenshot_id ?? 0,
+    title: record.title?.trim() || null,
+    description: record.description?.trim() || null,
+    imageUrl: record.url?.trim() ?? "",
+    width: record.width ?? null,
+    height: record.height ?? null,
+    keyIds: (record.key_ids ?? []).filter((keyId): keyId is number => typeof keyId === "number"),
+    keyAreas: (record.keys ?? [])
+      .map((key) => {
+        const keyId = key.key_id;
+        const coordinates = key.coordinates;
+        if (keyId == null || !coordinates) {
+          return null;
+        }
+
+        return {
+          keyId,
+          left: coordinates.left ?? 0,
+          top: coordinates.top ?? 0,
+          width: coordinates.width ?? 0,
+          height: coordinates.height ?? 0,
+        };
+      })
+      .filter((area): area is LokaliseScreenshotKeyArea => area != null),
   };
 }
 

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-api.ts
@@ -1339,7 +1339,7 @@ function normalizeLokaliseLanguage(record: LokaliseLanguageApiRecord): LokaliseL
 
 function normalizeLokaliseScreenshot(record: LokaliseScreenshotApiRecord): LokaliseScreenshot {
   return {
-    screenshotId: record.screenshot_id ?? 0,
+    screenshotId: record.screenshot_id ?? -1,
     title: record.title?.trim() || null,
     description: record.description?.trim() || null,
     imageUrl: record.url?.trim() ?? "",

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-api.ts
@@ -742,6 +742,19 @@ export class LokaliseApiClient {
     return screenshots.slice(0, maxItems);
   }
 
+  async getScreenshot(projectId: string, screenshotId: number): Promise<LokaliseScreenshot> {
+    const response = await this.get<LokaliseScreenshotGetResponse>(
+      `/projects/${encodeURIComponent(projectId)}/screenshots/${encodeURIComponent(String(screenshotId))}`,
+    );
+
+    const record = response.screenshot;
+    if (!record) {
+      throw new LokaliseApiError("lokalise_screenshot_not_found", 404, response);
+    }
+
+    return normalizeLokaliseScreenshot(record);
+  }
+
   async listWebhooks(projectId: string): Promise<LokaliseWebhook[]> {
     const response = await this.get<LokaliseWebhooksListResponse>(
       `/projects/${encodeURIComponent(projectId)}/webhooks`,
@@ -1097,6 +1110,11 @@ type LokaliseScreenshotsListResponse = {
   screenshots?: LokaliseScreenshotApiRecord[];
 };
 
+type LokaliseScreenshotGetResponse = {
+  project_id?: string;
+  screenshot?: LokaliseScreenshotApiRecord;
+};
+
 type LokaliseScreenshotApiRecord = {
   screenshot_id?: number;
   title?: string | null;
@@ -1338,6 +1356,7 @@ function normalizeLokaliseLanguage(record: LokaliseLanguageApiRecord): LokaliseL
 }
 
 function normalizeLokaliseScreenshot(record: LokaliseScreenshotApiRecord): LokaliseScreenshot {
+  // The list endpoint often omits keys[].coordinates; retrieve-a-screenshot includes them.
   return {
     screenshotId: record.screenshot_id ?? -1,
     title: record.title?.trim() || null,

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-api.ts
@@ -718,8 +718,13 @@ export class LokaliseApiClient {
     const maxItems = options?.maxItems ?? 8;
 
     while (screenshots.length < maxItems) {
+      const params = new URLSearchParams({
+        page: String(page),
+        limit: String(limit),
+        filter_keys: String(keyId),
+      });
       const response = await this.get<LokaliseScreenshotsListResponse>(
-        `/projects/${encodeURIComponent(projectId)}/screenshots?page=${page}&limit=${limit}`,
+        `/projects/${encodeURIComponent(projectId)}/screenshots?${params.toString()}`,
       );
       const pageItems = (response.screenshots ?? [])
         .map(normalizeLokaliseScreenshot)

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-cat-visual-context.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-cat-visual-context.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { type LokaliseApiClient } from "./lokalise-api";
+import { loadLokaliseCatVisualContext } from "./lokalise-cat-visual-context";
+
+describe("loadLokaliseCatVisualContext", () => {
+  it("fetches screenshot details when the list response omits key coordinates", async () => {
+    const client = {
+      listScreenshotsForKey: vi.fn(async () => [
+        {
+          screenshotId: 123,
+          title: "Homepage",
+          description: null,
+          imageUrl: "https://example.com/screenshot.png",
+          width: 800,
+          height: 600,
+          keyIds: [4242],
+          keyAreas: [],
+        },
+      ]),
+      getScreenshot: vi.fn(async () => ({
+        screenshotId: 123,
+        title: "Homepage",
+        description: null,
+        imageUrl: "https://example.com/screenshot.png",
+        width: 800,
+        height: 600,
+        keyIds: [4242],
+        keyAreas: [
+          {
+            keyId: 4242,
+            left: 40,
+            top: 80,
+            width: 120,
+            height: 24,
+          },
+        ],
+      })),
+    } as unknown as LokaliseApiClient;
+
+    const visualContext = await loadLokaliseCatVisualContext({
+      client,
+      externalProjectId: "proj.123",
+      externalStringId: "4242",
+    });
+
+    expect(client.getScreenshot).toHaveBeenCalledWith("proj.123", 123);
+    expect(visualContext.screenshots).toEqual([
+      {
+        id: "123",
+        name: "Homepage",
+        imageUrl: "https://example.com/screenshot.png",
+        width: 800,
+        height: 600,
+        markers: [{ left: 5, top: 13.333333333333334, width: 15, height: 4 }],
+      },
+    ]);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-cat-visual-context.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-cat-visual-context.ts
@@ -1,0 +1,54 @@
+import {
+  pixelRectToPercentMarkers,
+  type CatVisualContext,
+  type CatVisualContextScreenshot,
+} from "@/lib/translation/cat-visual-context";
+
+import { LokaliseApiClient } from "./lokalise-api";
+
+export async function loadLokaliseCatVisualContext(input: {
+  client: LokaliseApiClient;
+  externalProjectId: string;
+  externalStringId: string;
+}): Promise<CatVisualContext> {
+  const keyId = Number(input.externalStringId);
+  if (Number.isNaN(keyId)) {
+    return { screenshots: [] };
+  }
+
+  const screenshots = await input.client.listScreenshotsForKey(input.externalProjectId, keyId);
+
+  return {
+    screenshots: screenshots
+      .filter((screenshot) => screenshot.imageUrl.trim().length > 0)
+      .map((screenshot) => mapLokaliseScreenshot(screenshot, keyId)),
+  };
+}
+
+function mapLokaliseScreenshot(
+  screenshot: Awaited<ReturnType<LokaliseApiClient["listScreenshotsForKey"]>>[number],
+  keyId: number,
+): CatVisualContextScreenshot {
+  const markers = screenshot.keyAreas
+    .filter((area) => area.keyId === keyId)
+    .map((area) =>
+      pixelRectToPercentMarkers({
+        width: screenshot.width,
+        height: screenshot.height,
+        left: area.left,
+        top: area.top,
+        widthPx: area.width,
+        heightPx: area.height,
+      }),
+    )
+    .filter((marker): marker is NonNullable<typeof marker> => marker != null);
+
+  return {
+    id: String(screenshot.screenshotId),
+    name: screenshot.title,
+    imageUrl: screenshot.imageUrl,
+    width: screenshot.width,
+    height: screenshot.height,
+    markers,
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-cat-visual-context.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/lokalise/lokalise-cat-visual-context.ts
@@ -1,3 +1,4 @@
+import { mapWithConcurrency } from "@/lib/primitives/map-with-concurrency/map-with-concurrency";
 import {
   pixelRectToPercentMarkers,
   type CatVisualContext,
@@ -5,6 +6,8 @@ import {
 } from "@/lib/translation/cat-visual-context";
 
 import { LokaliseApiClient } from "./lokalise-api";
+
+const lokaliseScreenshotDetailConcurrency = 5;
 
 export async function loadLokaliseCatVisualContext(input: {
   client: LokaliseApiClient;
@@ -17,11 +20,23 @@ export async function loadLokaliseCatVisualContext(input: {
   }
 
   const screenshots = await input.client.listScreenshotsForKey(input.externalProjectId, keyId);
+  const withImage = screenshots.filter((screenshot) => screenshot.imageUrl.trim().length > 0);
+
+  const enriched = await mapWithConcurrency(
+    withImage,
+    lokaliseScreenshotDetailConcurrency,
+    async (screenshot) => {
+      const hasKeyArea = screenshot.keyAreas.some((area) => area.keyId === keyId);
+      if (hasKeyArea || screenshot.screenshotId <= 0) {
+        return screenshot;
+      }
+
+      return input.client.getScreenshot(input.externalProjectId, screenshot.screenshotId);
+    },
+  );
 
   return {
-    screenshots: screenshots
-      .filter((screenshot) => screenshot.imageUrl.trim().length > 0)
-      .map((screenshot) => mapLokaliseScreenshot(screenshot, keyId)),
+    screenshots: enriched.map((screenshot) => mapLokaliseScreenshot(screenshot, keyId)),
   };
 }
 

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-api.test.ts
@@ -268,4 +268,34 @@ describe("PhraseApiClient", () => {
 
     await expect(client.listProjects()).rejects.toBeInstanceOf(PhraseApiError);
   });
+
+  it("caps listKeyScreenshots pagination with maxItems", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      const path = String(url);
+      if (path.includes("/keys/key-1/screenshots") && path.includes("page=1")) {
+        return new Response(
+          JSON.stringify(
+            Array.from({ length: 100 }, (_, index) => ({
+              id: `screenshot-${index + 1}`,
+              name: `Screenshot ${index + 1}`,
+              screenshot_url: `https://example.com/${index + 1}.png`,
+            })),
+          ),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/keys/key-1/screenshots") && path.includes("page=2")) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+
+      return new Response(JSON.stringify([]), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    const screenshots = await client.listKeyScreenshots("proj-1", "key-1", { maxItems: 8 });
+
+    expect(screenshots).toHaveLength(8);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-api.ts
@@ -81,6 +81,23 @@ export interface PhraseUpload {
   updatedAt: string | null;
 }
 
+export interface PhraseScreenshot {
+  id: string;
+  name: string | null;
+  description: string | null;
+  screenshotUrl: string | null;
+  markersCount: number;
+}
+
+export interface PhraseScreenshotMarker {
+  id: string;
+  keyId: string;
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
 export interface PhraseUserPreview {
   id: string;
   username: string | null;
@@ -346,6 +363,55 @@ export class PhraseApiClient {
           branch: options.branch,
         }),
       normalize: (record) => normalizePhraseTranslation(record as PhraseTranslationApiRecord),
+    });
+  }
+
+  async listScreenshots(
+    projectId: string,
+    options: PhraseListOptions & { maxItems?: number } = {},
+  ): Promise<PhraseScreenshot[]> {
+    const screenshots: PhraseScreenshot[] = [];
+    let page = 1;
+    const perPage = 100;
+    const maxItems = options.maxItems ?? 50;
+
+    while (screenshots.length < maxItems) {
+      const pageItems = await this.get<unknown[]>(
+        this.buildPath(`/projects/${encodeURIComponent(projectId)}/screenshots`, {
+          page,
+          per_page: perPage,
+          branch: options.branch,
+        }),
+      );
+      screenshots.push(...pageItems.map((record) => normalizePhraseScreenshot(record)));
+
+      if (pageItems.length < perPage || screenshots.length >= maxItems) {
+        break;
+      }
+
+      page += 1;
+    }
+
+    return screenshots.slice(0, maxItems);
+  }
+
+  async listScreenshotMarkers(
+    projectId: string,
+    screenshotId: string,
+    options: PhraseListOptions = {},
+  ): Promise<PhraseScreenshotMarker[]> {
+    return this.paginate({
+      buildPath: (page, perPage) =>
+        this.buildPath(
+          `/projects/${encodeURIComponent(projectId)}/screenshots/${encodeURIComponent(screenshotId)}/markers`,
+          {
+            page,
+            per_page: perPage,
+            branch: options.branch,
+          },
+        ),
+      normalize: (record) =>
+        normalizePhraseScreenshotMarker(record as PhraseScreenshotMarkerApiRecord),
     });
   }
 
@@ -680,6 +746,27 @@ type PhraseUploadApiRecord = {
   updated_at?: string | null;
 };
 
+type PhraseScreenshotApiRecord = {
+  id?: string;
+  name?: string | null;
+  description?: string | null;
+  screenshot_url?: string | null;
+  markers_count?: number;
+};
+
+type PhraseScreenshotMarkerApiRecord = {
+  id?: string;
+  presentation?: {
+    x?: number;
+    y?: number;
+    w?: number;
+    h?: number;
+  } | null;
+  translation_key?: {
+    id?: string;
+  } | null;
+};
+
 type PhraseUserPreviewApiRecord = {
   id: string;
   username?: string | null;
@@ -789,6 +876,31 @@ function normalizePhraseUpload(upload: PhraseUploadApiRecord): PhraseUpload {
     url: upload.url ?? null,
     createdAt: upload.created_at ?? null,
     updatedAt: upload.updated_at ?? null,
+  };
+}
+
+function normalizePhraseScreenshot(record: unknown): PhraseScreenshot {
+  const screenshot = record as PhraseScreenshotApiRecord;
+
+  return {
+    id: screenshot.id ?? "",
+    name: screenshot.name?.trim() || null,
+    description: screenshot.description?.trim() || null,
+    screenshotUrl: screenshot.screenshot_url?.trim() || null,
+    markersCount: screenshot.markers_count ?? 0,
+  };
+}
+
+function normalizePhraseScreenshotMarker(
+  record: PhraseScreenshotMarkerApiRecord,
+): PhraseScreenshotMarker {
+  return {
+    id: record.id ?? "",
+    keyId: record.translation_key?.id ?? "",
+    left: record.presentation?.x ?? 0,
+    top: record.presentation?.y ?? 0,
+    width: record.presentation?.w ?? 0,
+    height: record.presentation?.h ?? 0,
   };
 }
 

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-api.ts
@@ -402,20 +402,30 @@ export class PhraseApiClient {
   async listKeyScreenshots(
     projectId: string,
     keyId: string,
-    options: PhraseListOptions = {},
+    options: PhraseListOptions & { maxItems?: number } = {},
   ): Promise<PhraseKeyScreenshot[]> {
-    return this.paginate({
-      buildPath: (page, perPage) =>
+    const results: PhraseKeyScreenshot[] = [];
+    const maxItems = options.maxItems ?? 50;
+    const perPage = 100;
+    let page = 1;
+
+    while (results.length < maxItems) {
+      const pageItems = await this.get<unknown[]>(
         this.buildPath(
           `/projects/${encodeURIComponent(projectId)}/keys/${encodeURIComponent(keyId)}/screenshots`,
-          {
-            page,
-            per_page: perPage,
-            branch: options.branch,
-          },
+          { page, per_page: perPage, branch: options.branch },
         ),
-      normalize: (record) => normalizePhraseKeyScreenshot(record),
-    });
+      );
+      results.push(...pageItems.map((record) => normalizePhraseKeyScreenshot(record)));
+
+      if (pageItems.length < perPage || results.length >= maxItems) {
+        break;
+      }
+
+      page += 1;
+    }
+
+    return results.slice(0, maxItems);
   }
 
   async listScreenshotMarkers(

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-api.ts
@@ -98,6 +98,10 @@ export interface PhraseScreenshotMarker {
   height: number;
 }
 
+export interface PhraseKeyScreenshot extends PhraseScreenshot {
+  markers: PhraseScreenshotMarker[] | null;
+}
+
 export interface PhraseUserPreview {
   id: string;
   username: string | null;
@@ -393,6 +397,25 @@ export class PhraseApiClient {
     }
 
     return screenshots.slice(0, maxItems);
+  }
+
+  async listKeyScreenshots(
+    projectId: string,
+    keyId: string,
+    options: PhraseListOptions = {},
+  ): Promise<PhraseKeyScreenshot[]> {
+    return this.paginate({
+      buildPath: (page, perPage) =>
+        this.buildPath(
+          `/projects/${encodeURIComponent(projectId)}/keys/${encodeURIComponent(keyId)}/screenshots`,
+          {
+            page,
+            per_page: perPage,
+            branch: options.branch,
+          },
+        ),
+      normalize: (record) => normalizePhraseKeyScreenshot(record),
+    });
   }
 
   async listScreenshotMarkers(
@@ -752,10 +775,12 @@ type PhraseScreenshotApiRecord = {
   description?: string | null;
   screenshot_url?: string | null;
   markers_count?: number;
+  markers?: PhraseScreenshotMarkerApiRecord[];
 };
 
 type PhraseScreenshotMarkerApiRecord = {
   id?: string;
+  key_id?: string;
   presentation?: {
     x?: number;
     y?: number;
@@ -891,12 +916,22 @@ function normalizePhraseScreenshot(record: unknown): PhraseScreenshot {
   };
 }
 
+function normalizePhraseKeyScreenshot(record: unknown): PhraseKeyScreenshot {
+  const screenshot = record as PhraseScreenshotApiRecord;
+  return {
+    ...normalizePhraseScreenshot(record),
+    markers: Array.isArray(screenshot.markers)
+      ? screenshot.markers.map((marker) => normalizePhraseScreenshotMarker(marker))
+      : null,
+  };
+}
+
 function normalizePhraseScreenshotMarker(
   record: PhraseScreenshotMarkerApiRecord,
 ): PhraseScreenshotMarker {
   return {
     id: record.id ?? "",
-    keyId: record.translation_key?.id ?? "",
+    keyId: record.translation_key?.id ?? record.key_id ?? "",
     left: record.presentation?.x ?? 0,
     top: record.presentation?.y ?? 0,
     width: record.presentation?.w ?? 0,

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-cat-visual-context.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-cat-visual-context.test.ts
@@ -49,6 +49,57 @@ describe("loadPhraseCatVisualContextWithClient", () => {
     expect(client.listScreenshotMarkers).not.toHaveBeenCalled();
   });
 
+  it("filters key screenshot markers to the requested key only", async () => {
+    const client = {
+      listKeyScreenshots: vi.fn(async () => [
+        {
+          id: "screenshot-1",
+          name: "Homepage",
+          description: null,
+          screenshotUrl: "https://example.com/home.png",
+          markersCount: 2,
+          markers: [
+            {
+              id: "marker-1",
+              keyId: "key-1",
+              left: 12.5,
+              top: 20,
+              width: 30,
+              height: 15,
+            },
+            {
+              id: "marker-2",
+              keyId: "key-2",
+              left: 50,
+              top: 60,
+              width: 10,
+              height: 10,
+            },
+          ],
+        },
+      ]),
+      listScreenshots: vi.fn(),
+      listScreenshotMarkers: vi.fn(),
+    } as unknown as PhraseApiClient;
+
+    const visualContext = await loadPhraseCatVisualContextWithClient({
+      client,
+      externalProjectId: "project-1",
+      externalStringId: "key-1",
+    });
+
+    expect(visualContext.screenshots).toEqual([
+      {
+        id: "screenshot-1",
+        name: "Homepage",
+        imageUrl: "https://example.com/home.png",
+        width: null,
+        height: null,
+        markers: [{ left: 12.5, top: 20, width: 30, height: 15 }],
+      },
+    ]);
+  });
+
   it("falls back to project screenshots when key screenshots are unavailable", async () => {
     const client = {
       listKeyScreenshots: vi.fn(async () => {

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-cat-visual-context.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-cat-visual-context.test.ts
@@ -1,11 +1,59 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 
-import type { PhraseApiClient } from "./phrase-api";
+import { PhraseApiError, type PhraseApiClient } from "./phrase-api";
 import { loadPhraseCatVisualContextWithClient } from "./phrase-cat-visual-context";
 
 describe("loadPhraseCatVisualContextWithClient", () => {
-  it("maps Phrase percentage presentation markers directly", async () => {
+  it("maps Phrase key screenshot markers without scanning project screenshots", async () => {
     const client = {
+      listKeyScreenshots: vi.fn(async () => [
+        {
+          id: "screenshot-1",
+          name: "Homepage",
+          description: null,
+          screenshotUrl: "https://example.com/home.png",
+          markersCount: 1,
+          markers: [
+            {
+              id: "marker-1",
+              keyId: "key-1",
+              left: 12.5,
+              top: 20,
+              width: 30,
+              height: 15,
+            },
+          ],
+        },
+      ]),
+      listScreenshots: vi.fn(),
+      listScreenshotMarkers: vi.fn(),
+    } as unknown as PhraseApiClient;
+
+    const visualContext = await loadPhraseCatVisualContextWithClient({
+      client,
+      externalProjectId: "project-1",
+      externalStringId: "key-1",
+    });
+
+    expect(visualContext.screenshots).toEqual([
+      {
+        id: "screenshot-1",
+        name: "Homepage",
+        imageUrl: "https://example.com/home.png",
+        width: null,
+        height: null,
+        markers: [{ left: 12.5, top: 20, width: 30, height: 15 }],
+      },
+    ]);
+    expect(client.listScreenshots).not.toHaveBeenCalled();
+    expect(client.listScreenshotMarkers).not.toHaveBeenCalled();
+  });
+
+  it("falls back to project screenshots when key screenshots are unavailable", async () => {
+    const client = {
+      listKeyScreenshots: vi.fn(async () => {
+        throw new PhraseApiError("missing route", 404, null);
+      }),
       listScreenshots: vi.fn(async () => [
         {
           id: "screenshot-1",

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-cat-visual-context.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-cat-visual-context.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import type { PhraseApiClient } from "./phrase-api";
+import { loadPhraseCatVisualContextWithClient } from "./phrase-cat-visual-context";
+
+describe("loadPhraseCatVisualContextWithClient", () => {
+  it("maps Phrase percentage presentation markers directly", async () => {
+    const client = {
+      listScreenshots: vi.fn(async () => [
+        {
+          id: "screenshot-1",
+          name: "Homepage",
+          description: null,
+          screenshotUrl: "https://example.com/home.png",
+          markersCount: 1,
+        },
+      ]),
+      listScreenshotMarkers: vi.fn(async () => [
+        {
+          id: "marker-1",
+          keyId: "key-1",
+          left: 12.5,
+          top: 20,
+          width: 30,
+          height: 15,
+        },
+      ]),
+    } as unknown as PhraseApiClient;
+
+    const visualContext = await loadPhraseCatVisualContextWithClient({
+      client,
+      externalProjectId: "project-1",
+      externalStringId: "key-1",
+    });
+
+    expect(visualContext.screenshots).toEqual([
+      {
+        id: "screenshot-1",
+        name: "Homepage",
+        imageUrl: "https://example.com/home.png",
+        width: null,
+        height: null,
+        markers: [{ left: 12.5, top: 20, width: 30, height: 15 }],
+      },
+    ]);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-cat-visual-context.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-cat-visual-context.ts
@@ -1,7 +1,7 @@
 import { mapWithConcurrency } from "@/lib/primitives/map-with-concurrency/map-with-concurrency";
 import {
-  pixelRectToPercentMarkers,
   type CatVisualContext,
+  type CatVisualContextMarker,
   type CatVisualContextScreenshot,
 } from "@/lib/translation/cat-visual-context";
 
@@ -78,17 +78,26 @@ function mapPhraseScreenshot(
   }
 
   const mappedMarkers = markers
-    .map((marker) =>
-      pixelRectToPercentMarkers({
-        width: null,
-        height: null,
+    .map((marker): CatVisualContextMarker | null => {
+      if (
+        !Number.isFinite(marker.left) ||
+        !Number.isFinite(marker.top) ||
+        !Number.isFinite(marker.width) ||
+        !Number.isFinite(marker.height) ||
+        marker.width <= 0 ||
+        marker.height <= 0
+      ) {
+        return null;
+      }
+
+      return {
         left: marker.left,
         top: marker.top,
-        widthPx: marker.width,
-        heightPx: marker.height,
-      }),
-    )
-    .filter((marker): marker is NonNullable<typeof marker> => marker != null);
+        width: marker.width,
+        height: marker.height,
+      };
+    })
+    .filter((marker): marker is CatVisualContextMarker => marker != null);
 
   return {
     id: screenshot.id,

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-cat-visual-context.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-cat-visual-context.ts
@@ -44,7 +44,14 @@ export async function loadPhraseCatVisualContextWithClient(input: {
       phraseMarkerFetchConcurrency,
       async (screenshot) => {
         if (screenshot.markers) {
-          return mapPhraseScreenshot(screenshot, screenshot.markers);
+          const keyMarkers = screenshot.markers.filter(
+            (marker) => marker.keyId === input.externalStringId,
+          );
+          if (keyMarkers.length === 0) {
+            return null;
+          }
+
+          return mapPhraseScreenshot(screenshot, keyMarkers);
         }
 
         const markers = await input.client.listScreenshotMarkers(

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-cat-visual-context.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-cat-visual-context.ts
@@ -5,7 +5,7 @@ import {
   type CatVisualContextScreenshot,
 } from "@/lib/translation/cat-visual-context";
 
-import { PhraseApiClient } from "./phrase-api";
+import { PhraseApiClient, PhraseApiError, type PhraseKeyScreenshot } from "./phrase-api";
 import { createPhraseStringsApiClient } from "./phrase-strings-client";
 
 const maxPhraseScreenshotsToScan = 50;
@@ -37,6 +37,36 @@ export async function loadPhraseCatVisualContextWithClient(input: {
   externalProjectId: string;
   externalStringId: string;
 }): Promise<CatVisualContext> {
+  const keyScreenshots = await loadPhraseKeyScreenshots(input);
+  if (keyScreenshots) {
+    const mapped = await mapWithConcurrency(
+      keyScreenshots.filter((screenshot) => screenshot.screenshotUrl),
+      phraseMarkerFetchConcurrency,
+      async (screenshot) => {
+        if (screenshot.markers) {
+          return mapPhraseScreenshot(screenshot, screenshot.markers);
+        }
+
+        const markers = await input.client.listScreenshotMarkers(
+          input.externalProjectId,
+          screenshot.id,
+        );
+        const keyMarkers = markers.filter((marker) => marker.keyId === input.externalStringId);
+        if (keyMarkers.length === 0) {
+          return null;
+        }
+
+        return mapPhraseScreenshot(screenshot, keyMarkers);
+      },
+    );
+
+    return {
+      screenshots: mapped
+        .filter((screenshot): screenshot is CatVisualContextScreenshot => screenshot != null)
+        .slice(0, maxPhraseScreenshotsPerSegment),
+    };
+  }
+
   const screenshots = await input.client.listScreenshots(input.externalProjectId, {
     maxItems: maxPhraseScreenshotsToScan,
   });
@@ -68,8 +98,26 @@ export async function loadPhraseCatVisualContextWithClient(input: {
   };
 }
 
+async function loadPhraseKeyScreenshots(input: {
+  client: PhraseApiClient;
+  externalProjectId: string;
+  externalStringId: string;
+}): Promise<PhraseKeyScreenshot[] | null> {
+  try {
+    return await input.client.listKeyScreenshots(input.externalProjectId, input.externalStringId);
+  } catch (error) {
+    if (error instanceof PhraseApiError && error.status === 404) {
+      return null;
+    }
+
+    throw error;
+  }
+}
+
 function mapPhraseScreenshot(
-  screenshot: Awaited<ReturnType<PhraseApiClient["listScreenshots"]>>[number],
+  screenshot:
+    | Awaited<ReturnType<PhraseApiClient["listScreenshots"]>>[number]
+    | Awaited<ReturnType<PhraseApiClient["listKeyScreenshots"]>>[number],
   markers: Awaited<ReturnType<PhraseApiClient["listScreenshotMarkers"]>>,
 ): CatVisualContextScreenshot | null {
   const imageUrl = screenshot.screenshotUrl?.trim();

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-cat-visual-context.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-cat-visual-context.ts
@@ -1,0 +1,101 @@
+import { mapWithConcurrency } from "@/lib/primitives/map-with-concurrency/map-with-concurrency";
+import {
+  pixelRectToPercentMarkers,
+  type CatVisualContext,
+  type CatVisualContextScreenshot,
+} from "@/lib/translation/cat-visual-context";
+
+import { PhraseApiClient } from "./phrase-api";
+import { createPhraseStringsApiClient } from "./phrase-strings-client";
+
+const maxPhraseScreenshotsToScan = 50;
+const maxPhraseScreenshotsPerSegment = 8;
+const phraseMarkerFetchConcurrency = 5;
+
+export async function loadPhraseCatVisualContext(input: {
+  token: string;
+  region?: string | null;
+  baseUrl?: string | null;
+  externalProjectId: string;
+  externalStringId: string;
+}): Promise<CatVisualContext> {
+  const client = createPhraseStringsApiClient({
+    token: input.token,
+    region: input.region,
+    baseUrl: input.baseUrl,
+  });
+
+  return loadPhraseCatVisualContextWithClient({
+    client,
+    externalProjectId: input.externalProjectId,
+    externalStringId: input.externalStringId,
+  });
+}
+
+export async function loadPhraseCatVisualContextWithClient(input: {
+  client: PhraseApiClient;
+  externalProjectId: string;
+  externalStringId: string;
+}): Promise<CatVisualContext> {
+  const screenshots = await input.client.listScreenshots(input.externalProjectId, {
+    maxItems: maxPhraseScreenshotsToScan,
+  });
+  const candidates = screenshots.filter(
+    (screenshot) => screenshot.markersCount > 0 && screenshot.screenshotUrl,
+  );
+
+  const matched = await mapWithConcurrency(
+    candidates,
+    phraseMarkerFetchConcurrency,
+    async (screenshot) => {
+      const markers = await input.client.listScreenshotMarkers(
+        input.externalProjectId,
+        screenshot.id,
+      );
+      const keyMarkers = markers.filter((marker) => marker.keyId === input.externalStringId);
+      if (keyMarkers.length === 0) {
+        return null;
+      }
+
+      return mapPhraseScreenshot(screenshot, keyMarkers);
+    },
+  );
+
+  return {
+    screenshots: matched
+      .filter((screenshot): screenshot is CatVisualContextScreenshot => screenshot != null)
+      .slice(0, maxPhraseScreenshotsPerSegment),
+  };
+}
+
+function mapPhraseScreenshot(
+  screenshot: Awaited<ReturnType<PhraseApiClient["listScreenshots"]>>[number],
+  markers: Awaited<ReturnType<PhraseApiClient["listScreenshotMarkers"]>>,
+): CatVisualContextScreenshot | null {
+  const imageUrl = screenshot.screenshotUrl?.trim();
+  if (!imageUrl) {
+    return null;
+  }
+
+  const mappedMarkers = markers
+    .map((marker) =>
+      pixelRectToPercentMarkers({
+        width: null,
+        height: null,
+        left: marker.left,
+        top: marker.top,
+        widthPx: marker.width,
+        heightPx: marker.height,
+      }),
+    )
+    .filter((marker): marker is NonNullable<typeof marker> => marker != null);
+
+  return {
+    id: screenshot.id,
+    name: screenshot.name,
+    imageUrl,
+    width: null,
+    height: null,
+    markers: mappedMarkers,
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-cat-visual-context.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-cat-visual-context.ts
@@ -111,7 +111,9 @@ async function loadPhraseKeyScreenshots(input: {
   externalStringId: string;
 }): Promise<PhraseKeyScreenshot[] | null> {
   try {
-    return await input.client.listKeyScreenshots(input.externalProjectId, input.externalStringId);
+    return await input.client.listKeyScreenshots(input.externalProjectId, input.externalStringId, {
+      maxItems: maxPhraseScreenshotsPerSegment,
+    });
   } catch (error) {
     if (error instanceof PhraseApiError && error.status === 404) {
       return null;

--- a/apps/hyperlocalise-web/src/lib/translation/cat-visual-context.test.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/cat-visual-context.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { loadCrowdinCatVisualContext } from "@/lib/providers/adapters/crowdin/crowdin-cat-visual-context";
+import { pixelRectToPercentMarkers } from "@/lib/translation/cat-visual-context";
+
+describe("pixelRectToPercentMarkers", () => {
+  it("converts pixel coordinates to percentages", () => {
+    expect(
+      pixelRectToPercentMarkers({
+        width: 400,
+        height: 800,
+        left: 40,
+        top: 80,
+        widthPx: 120,
+        heightPx: 40,
+      }),
+    ).toEqual({
+      left: 10,
+      top: 10,
+      width: 30,
+      height: 5,
+    });
+  });
+
+  it("returns null when screenshot dimensions are missing", () => {
+    expect(
+      pixelRectToPercentMarkers({
+        width: null,
+        height: 800,
+        left: 10,
+        top: 10,
+        widthPx: 20,
+        heightPx: 20,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("loadCrowdinCatVisualContext", () => {
+  it("maps tagged screenshots for the selected string", async () => {
+    const client = {
+      listScreenshots: async () => [
+        {
+          id: 12,
+          webUrl: "https://example.com/screen.jpg",
+          name: "Checkout",
+          size: { width: 200, height: 400 },
+          tags: [
+            {
+              id: 1,
+              screenshotId: 12,
+              stringId: 99,
+              position: { x: 20, y: 40, width: 50, height: 20 },
+            },
+            {
+              id: 2,
+              screenshotId: 12,
+              stringId: 100,
+              position: { x: 0, y: 0, width: 10, height: 10 },
+            },
+          ],
+        },
+      ],
+    };
+
+    const visualContext = await loadCrowdinCatVisualContext({
+      client: client as never,
+      externalProjectId: "7",
+      externalStringId: "99",
+    });
+
+    expect(visualContext.screenshots).toEqual([
+      {
+        id: "12",
+        name: "Checkout",
+        imageUrl: "https://example.com/screen.jpg",
+        width: 200,
+        height: 400,
+        markers: [
+          {
+            left: 10,
+            top: 10,
+            width: 25,
+            height: 5,
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/translation/cat-visual-context.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/cat-visual-context.ts
@@ -1,0 +1,43 @@
+export type CatVisualContextMarker = {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+};
+
+export type CatVisualContextScreenshot = {
+  id: string;
+  name: string | null;
+  imageUrl: string;
+  width: number | null;
+  height: number | null;
+  markers: CatVisualContextMarker[];
+};
+
+export type CatVisualContext = {
+  screenshots: CatVisualContextScreenshot[];
+};
+
+export function pixelRectToPercentMarkers(input: {
+  width: number | null | undefined;
+  height: number | null | undefined;
+  left: number;
+  top: number;
+  widthPx: number;
+  heightPx: number;
+}): CatVisualContextMarker | null {
+  if (!input.width || !input.height || input.width <= 0 || input.height <= 0) {
+    return null;
+  }
+
+  if (input.widthPx <= 0 || input.heightPx <= 0) {
+    return null;
+  }
+
+  return {
+    left: (input.left / input.width) * 100,
+    top: (input.top / input.height) * 100,
+    width: (input.widthPx / input.width) * 100,
+    height: (input.heightPx / input.height) * 100,
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/translation/load-cat-segment-visual-context.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/load-cat-segment-visual-context.ts
@@ -1,0 +1,63 @@
+import type { CatVisualContext } from "@/lib/translation/cat-visual-context";
+import { CrowdinApiClient } from "@/lib/providers/adapters/crowdin/crowdin-api";
+import { loadCrowdinCatVisualContext } from "@/lib/providers/adapters/crowdin/crowdin-cat-visual-context";
+import { LokaliseApiClient } from "@/lib/providers/adapters/lokalise/lokalise-api";
+import { loadLokaliseCatVisualContext } from "@/lib/providers/adapters/lokalise/lokalise-cat-visual-context";
+import { loadPhraseCatVisualContext } from "@/lib/providers/adapters/phrase/phrase-cat-visual-context";
+import type { ExternalTmsProviderKind } from "@/lib/providers/contracts/external-tms-provider-kind";
+import { tryLoadActiveTmsProviderContext } from "@/lib/providers/tms-provider-live";
+
+export async function loadCatSegmentVisualContext(input: {
+  organizationId: string;
+  providerKind: ExternalTmsProviderKind;
+  externalProjectId: string;
+  externalStringId: string;
+  actorUserId?: string | null;
+}): Promise<CatVisualContext> {
+  const context = await tryLoadActiveTmsProviderContext(input.organizationId, {
+    actorUserId: input.actorUserId,
+  });
+
+  if (!context || context.providerKind !== input.providerKind) {
+    return { screenshots: [] };
+  }
+
+  switch (input.providerKind) {
+    case "crowdin": {
+      const client = new CrowdinApiClient({
+        token: context.secretMaterial,
+        baseUrl: context.credential.baseUrl ?? undefined,
+      });
+
+      return loadCrowdinCatVisualContext({
+        client,
+        externalProjectId: input.externalProjectId,
+        externalStringId: input.externalStringId,
+      });
+    }
+    case "lokalise": {
+      const client = new LokaliseApiClient({
+        token: context.secretMaterial,
+        baseUrl: context.credential.baseUrl ?? undefined,
+      });
+
+      return loadLokaliseCatVisualContext({
+        client,
+        externalProjectId: input.externalProjectId,
+        externalStringId: input.externalStringId,
+      });
+    }
+    case "phrase":
+      return loadPhraseCatVisualContext({
+        token: context.secretMaterial,
+        region: context.credential.region,
+        baseUrl: context.credential.baseUrl ?? undefined,
+        externalProjectId: input.externalProjectId,
+        externalStringId: input.externalStringId,
+      });
+    case "smartling":
+      return { screenshots: [] };
+    default:
+      return { screenshots: [] };
+  }
+}

--- a/apps/hyperlocalise-web/src/lib/translation/load-cat-segment-visual-context.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/load-cat-segment-visual-context.ts
@@ -12,6 +12,8 @@ export async function loadCatSegmentVisualContext(input: {
   providerKind: ExternalTmsProviderKind;
   externalProjectId: string;
   externalStringId: string;
+  // Kept at this boundary for provider implementations that need file-scoped lookups.
+  sourcePath?: string;
   actorUserId?: string | null;
 }): Promise<CatVisualContext> {
   const context = await tryLoadActiveTmsProviderContext(input.organizationId, {


### PR DESCRIPTION
## What changed

Adds in-context visual preview (TMS screenshots with string highlight overlays) to the CAT workspace for connected TMS provider projects. Screenshots are fetched live from Crowdin, Lokalise, and Phrase via a new `/files/detail/cat/visual-context` API route. Native Hyperlocalise projects return `visual_context_unavailable`.

## How to test

- Run `vp check --fix` and `vp test src/lib/translation/cat-visual-context.test.ts` in `apps/hyperlocalise-web`
- With Postgres running, run `vp test src/api/routes/project/project-cat.route.test.ts`
- Open a provider-linked CAT workspace (Crowdin/Lokalise/Phrase), select a segment with screenshots in the TMS, and confirm the intelligence panel shows screenshot cards with highlight overlays

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)