### PR TITLE
fix(web): remove redundant copy from mobile nav sheet

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(marketing)/_components/navbar.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(marketing)/_components/navbar.tsx
@@ -9,7 +9,6 @@ import {
   Sheet,
   SheetClose,
   SheetContent,
-  SheetDescription,
   SheetFooter,
   SheetHeader,
   SheetTitle,
@@ -97,17 +96,12 @@ function MobileNavigation() {
         className="w-[min(90vw,22rem)] border-s border-border/70 bg-background/98 px-0"
       >
         <SheetHeader className="gap-4 border-b border-border/70 px-5 pb-5 pt-6 text-left">
+          <SheetTitle className="sr-only">Navigation menu</SheetTitle>
           <div className="text-xs font-medium tracking-[0.18em] text-muted-foreground uppercase">
             Navigation
           </div>
           <div className="pr-10">
             <Logo />
-          </div>
-          <div className="space-y-1">
-            <SheetTitle>Move through the site</SheetTitle>
-            <SheetDescription>
-              Browse the homepage sections, then jump to the waitlist when you are ready.
-            </SheetDescription>
           </div>
         </SheetHeader>
         <div className="flex flex-1 flex-col px-3 py-4">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the unnecessary title and description from the mobile navigation sheet:

- "Move through the site"
- "Browse the homepage sections, then jump to the waitlist when you are ready."

The drawer already shows a "Navigation" label, logo, link list, and waitlist CTA, so the extra copy added clutter without helping wayfinding.

## Changes

- Drop visible `SheetTitle` / `SheetDescription` marketing copy from the mobile nav header
- Keep a screen-reader-only `SheetTitle` ("Navigation menu") for accessibility

## Validation

- `vp check --fix` passes (0 errors)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d890b150-1f3e-4d9e-ae04-81335d0eb4f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d890b150-1f3e-4d9e-ae04-81335d0eb4f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

