### PR TITLE
⚡ Bolt: precompute HTML syntax counts and optimize scanning

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -166,6 +166,10 @@
 **Learning:** Re-creating `strings.NewReplacer` in a hot loop is extremely expensive due to internal trie construction. Additionally, redundant `slices.Sort` calls on segments that are already in document order and missing `strings.Builder.Grow` hints in renderers are significant avoidable overheads.
 **Action:** Move `strings.NewReplacer` to package-level variables for static rules. Use `strings.Builder.Grow` in renderers. Remove redundant sorting by ensuring parsers produce ordered segments.
 
+## 2026-10-05 - Precomputing syntax counts and optimizing scanning
+**Learning:** Repeatedly scanning the same source strings for syntax validation (e.g., `IntroducesRawHTMLSyntax`) during rendering creates $O(N)$ overhead per segment that can be avoided by precomputing counts during parsing. Additionally, manual byte-by-byte loops for character searching (like finding '<') are significantly slower than Go's optimized `strings.IndexByte`.
+**Action:** Precompute `sourceSyntaxCount` during parsing for HTML/Markdown parts and store it in the struct. Optimize `rawHTMLSyntaxStartCount` using `strings.IndexByte` for faster character discovery.
+
 ## 2026-09-15 - Optimizing ARB marshaling via string fast-paths and partial sorting
 **Learning:** For JSON-based formats like ARB, bypassing `json.Marshal` for simple ASCII strings and avoiding full map sorts when only a few keys are new provides significant efficiency gains. Heuristic capacity hints for maps and slices also minimize GC pressure during large file processing.
 **Action:** Implemented `isSimpleJSONString` fast-path and refactored `MarshalARB` to sort only new keys, resulting in ~11-18% speedup and reduced allocations.

--- a/apps/cli/internal/i18n/runsvc/translation_output_validate.go
+++ b/apps/cli/internal/i18n/runsvc/translation_output_validate.go
@@ -52,7 +52,7 @@ func validateTranslatedOutputForKind(kind translationOutputKind, source, transla
 		if err := translationfileparser.ValidateMarkdownInternalPlaceholders(source, translated); err != nil {
 			return &postTranslateValidationError{msg: err.Error()}
 		}
-		if translationfileparser.IntroducesRawHTMLSyntax(source, translated) {
+		if translationfileparser.IntroducesRawHTMLSyntax(translationfileparser.RawHTMLSyntaxStartCount(source), translated) {
 			return &postTranslateValidationError{msg: "raw HTML syntax introduced in translated markdown"}
 		}
 		return nil
@@ -62,7 +62,7 @@ func validateTranslatedOutputForKind(kind translationOutputKind, source, transla
 				msg: fmt.Sprintf("html tag structure differs from source | %s", formatInvariantDebugContext(source, translated)),
 			}
 		}
-		if translationfileparser.IntroducesRawHTMLSyntax(source, translated) {
+		if translationfileparser.IntroducesRawHTMLSyntax(translationfileparser.RawHTMLSyntaxStartCount(source), translated) {
 			return &postTranslateValidationError{msg: "raw HTML syntax introduced in translated html"}
 		}
 		return validateTranslatedInvariant(source, translated)
@@ -70,7 +70,7 @@ func validateTranslatedOutputForKind(kind translationOutputKind, source, transla
 		if err := translationfileparser.ValidateLiquidInternalPlaceholders(source, translated); err != nil {
 			return &postTranslateValidationError{msg: err.Error()}
 		}
-		if translationfileparser.IntroducesRawHTMLSyntax(source, translated) {
+		if translationfileparser.IntroducesRawHTMLSyntax(translationfileparser.RawHTMLSyntaxStartCount(source), translated) {
 			return &postTranslateValidationError{msg: "raw HTML syntax introduced in translated liquid"}
 		}
 		return validateTranslatedInvariant(source, translated)

--- a/internal/i18n/translationfileparser/html_parser.go
+++ b/internal/i18n/translationfileparser/html_parser.go
@@ -101,7 +101,7 @@ func RawHTMLSyntaxStartCount(s string) int {
 func isAllHTMLWhitespace(s string) bool {
 	for i := 0; i < len(s); {
 		if s[i] < 0x80 {
-			if s[i] != ' ' && s[i] != '\t' && s[i] != '\n' && s[i] != '\r' {
+			if s[i] != ' ' && s[i] != '\t' && s[i] != '\n' && s[i] != '\r' && s[i] != '\f' {
 				return false
 			}
 			i++
@@ -265,8 +265,10 @@ func parseHTMLDocument(content []byte) (htmlDocument, map[string]string, error) 
 			break
 		}
 
+		// BOLT OPTIMIZATION: Capture z.Raw() before any TagName calls to avoid buffer corruption.
+		rawBytes := z.Raw()
+
 		if skipDepth > 0 {
-			rawBytes := z.Raw()
 			switch tt {
 			case html.EndTagToken:
 				tn, _ := z.TagName()
@@ -286,46 +288,46 @@ func parseHTMLDocument(content []byte) (htmlDocument, map[string]string, error) 
 		switch tt {
 		case html.DoctypeToken, html.CommentToken:
 			flushBuffer()
-			appendLiteral(string(z.Raw()))
+			appendLiteral(string(rawBytes))
 
 		case html.StartTagToken:
 			tn, _ := z.TagName()
 			if htmlSkipElements[string(tn)] {
 				flushBuffer()
 				skipDepth++
-				appendLiteral(string(z.Raw()))
+				appendLiteral(string(rawBytes))
 			} else if htmlBlockElements[string(tn)] || htmlStructuralElements[string(tn)] {
 				flushBuffer()
-				appendLiteral(string(z.Raw()))
+				appendLiteral(string(rawBytes))
 			} else if attrName, isVoid := htmlVoidTranslatableAttrs[string(tn)]; isVoid {
-				handleVoidTranslatable(z.Raw(), attrName)
+				handleVoidTranslatable(rawBytes, attrName)
 			} else {
 				// Inline element: accumulate into the text buffer.
-				buffer.Write(z.Raw())
+				buffer.Write(rawBytes)
 			}
 
 		case html.EndTagToken:
 			tn, _ := z.TagName()
 			if htmlBlockElements[string(tn)] || htmlStructuralElements[string(tn)] {
 				flushBuffer()
-				appendLiteral(string(z.Raw()))
+				appendLiteral(string(rawBytes))
 			} else {
-				buffer.Write(z.Raw())
+				buffer.Write(rawBytes)
 			}
 
 		case html.SelfClosingTagToken:
 			tn, _ := z.TagName()
 			if htmlBlockElements[string(tn)] || htmlStructuralElements[string(tn)] {
 				flushBuffer()
-				appendLiteral(string(z.Raw()))
+				appendLiteral(string(rawBytes))
 			} else if attrName, isVoid := htmlVoidTranslatableAttrs[string(tn)]; isVoid {
-				handleVoidTranslatable(z.Raw(), attrName)
+				handleVoidTranslatable(rawBytes, attrName)
 			} else {
-				buffer.Write(z.Raw())
+				buffer.Write(rawBytes)
 			}
 
 		case html.TextToken:
-			buffer.Write(z.Raw())
+			buffer.Write(rawBytes)
 		}
 	}
 

--- a/internal/i18n/translationfileparser/html_parser.go
+++ b/internal/i18n/translationfileparser/html_parser.go
@@ -234,7 +234,7 @@ func parseHTMLDocument(content []byte) (htmlDocument, map[string]string, error) 
 		})
 	}
 
-	handleVoidTranslatable := func(raw string, attrName string) {
+	handleVoidTranslatable := func(raw, attrName string) {
 		prefix, rawVal, suffix, found := splitVoidAttrTag(raw, attrName)
 		decoded := html.UnescapeString(rawVal)
 		if found && isTranslatableChunk(decoded) {
@@ -264,10 +264,13 @@ func parseHTMLDocument(content []byte) (htmlDocument, map[string]string, error) 
 			break
 		}
 
-		// Copy raw bytes before any TagName call; TagName may mutate the Raw() slice.
-		raw := string(z.Raw())
+		// BOLT OPTIMIZATION: Use z.Raw() directly for TextToken to avoid allocations.
+		// For tag tokens, we must copy z.Raw() before calling z.TagName() because
+		// TagName may modify the tokenizer's internal buffer.
+		rawBytes := z.Raw()
 
 		if skipDepth > 0 {
+			raw := string(rawBytes)
 			switch tt {
 			case html.EndTagToken:
 				tn, _ := z.TagName()
@@ -285,11 +288,15 @@ func parseHTMLDocument(content []byte) (htmlDocument, map[string]string, error) 
 		}
 
 		switch tt {
+		case html.TextToken:
+			buffer.Write(rawBytes)
+
 		case html.DoctypeToken, html.CommentToken:
 			flushBuffer()
-			appendLiteral(raw)
+			appendLiteral(string(rawBytes))
 
 		case html.StartTagToken:
+			raw := string(rawBytes)
 			tn, _ := z.TagName()
 			if htmlSkipElements[string(tn)] {
 				flushBuffer()
@@ -306,6 +313,7 @@ func parseHTMLDocument(content []byte) (htmlDocument, map[string]string, error) 
 			}
 
 		case html.EndTagToken:
+			raw := string(rawBytes)
 			tn, _ := z.TagName()
 			if htmlBlockElements[string(tn)] || htmlStructuralElements[string(tn)] {
 				flushBuffer()
@@ -315,6 +323,7 @@ func parseHTMLDocument(content []byte) (htmlDocument, map[string]string, error) 
 			}
 
 		case html.SelfClosingTagToken:
+			raw := string(rawBytes)
 			tn, _ := z.TagName()
 			if htmlBlockElements[string(tn)] || htmlStructuralElements[string(tn)] {
 				flushBuffer()
@@ -324,9 +333,6 @@ func parseHTMLDocument(content []byte) (htmlDocument, map[string]string, error) 
 			} else {
 				buffer.WriteString(raw)
 			}
-
-		case html.TextToken:
-			buffer.WriteString(raw)
 		}
 	}
 

--- a/internal/i18n/translationfileparser/html_parser.go
+++ b/internal/i18n/translationfileparser/html_parser.go
@@ -12,6 +12,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"golang.org/x/net/html"
 )
@@ -36,10 +38,14 @@ type htmlPart struct {
 	isVoidAttr    bool
 	voidTagPrefix string
 	voidTagSuffix string
+	// BOLT OPTIMIZATION: precompute raw HTML syntax count to avoid redundant scans.
+	sourceSyntaxCount int
 }
 
 type htmlDocument struct {
 	parts []htmlPart
+	// BOLT OPTIMIZATION: store original template length to hint strings.Builder capacity.
+	templateLen int
 }
 
 // HTMLRenderDiagnostics records keys that fell back to source text during render.
@@ -82,18 +88,46 @@ var htmlSkipElements = map[string]bool{
 var htmlTagPattern = regexp.MustCompile(`<(?:[^>"']*(?:"[^"]*"|'[^']*'))*[^>]*>`)
 
 // IntroducesRawHTMLSyntax reports whether translated contains more raw
-// tag-shaped syntax starts than source. It catches incomplete tag openers that
-// complete-tag regexes intentionally cannot see.
-func IntroducesRawHTMLSyntax(source, translated string) bool {
-	return rawHTMLSyntaxStartCount(translated) > rawHTMLSyntaxStartCount(source)
+// tag-shaped syntax starts than the precomputed sourceCount. It catches
+// incomplete tag openers that complete-tag regexes intentionally cannot see.
+func IntroducesRawHTMLSyntax(sourceCount int, translated string) bool {
+	return rawHTMLSyntaxStartCount(translated) > sourceCount
+}
+
+func RawHTMLSyntaxStartCount(s string) int {
+	return rawHTMLSyntaxStartCount(s)
+}
+
+func isAllHTMLWhitespace(s string) bool {
+	for i := 0; i < len(s); {
+		if s[i] < 0x80 {
+			if s[i] != ' ' && s[i] != '\t' && s[i] != '\n' && s[i] != '\r' {
+				return false
+			}
+			i++
+			continue
+		}
+		r, size := utf8.DecodeRuneInString(s[i:])
+		if !unicode.IsSpace(r) {
+			return false
+		}
+		i += size
+	}
+	return true
 }
 
 func rawHTMLSyntaxStartCount(s string) int {
 	count := 0
-	for i := 0; i < len(s); i++ {
-		if s[i] != '<' || i+1 >= len(s) {
-			continue
+	for i := 0; i < len(s); {
+		idx := strings.IndexByte(s[i:], '<')
+		if idx < 0 {
+			break
 		}
+		i += idx
+		if i+1 >= len(s) {
+			break
+		}
+
 		next := s[i+1]
 		switch {
 		case next == '>':
@@ -103,6 +137,7 @@ func rawHTMLSyntaxStartCount(s string) int {
 		case (next >= 'A' && next <= 'Z') || (next >= 'a' && next <= 'z'):
 			count++
 		}
+		i++
 	}
 	return count
 }
@@ -156,9 +191,13 @@ func splitVoidAttrTag(raw, attrName string) (prefix, rawVal, suffix string, ok b
 // returning the document, a map of key → source (with placeholders), and any
 // non-EOF tokenizer error.
 func parseHTMLDocument(content []byte) (htmlDocument, map[string]string, error) {
-	var doc htmlDocument
-	entries := map[string]string{}
-	occurrences := map[string]int{}
+	// BOLT OPTIMIZATION: Heuristic capacity hints to minimize re-allocations.
+	doc := htmlDocument{
+		parts:       make([]htmlPart, 0, len(content)/128),
+		templateLen: len(content),
+	}
+	entries := make(map[string]string, len(content)/256)
+	occurrences := make(map[string]int, len(content)/256)
 
 	z := html.NewTokenizer(bytes.NewReader(content))
 
@@ -175,7 +214,8 @@ func parseHTMLDocument(content []byte) (htmlDocument, map[string]string, error) 
 		if raw == "" {
 			return
 		}
-		if strings.TrimSpace(raw) == "" {
+		// BOLT OPTIMIZATION: Use isAllHTMLWhitespace helper to avoid string allocation.
+		if isAllHTMLWhitespace(raw) {
 			appendLiteral(raw)
 			return
 		}
@@ -187,13 +227,15 @@ func parseHTMLDocument(content []byte) (htmlDocument, map[string]string, error) 
 		key := htmlSegmentKey(placeholdered, occurrences)
 		entries[key] = placeholdered
 		doc.parts = append(doc.parts, htmlPart{
-			key:          key,
-			source:       placeholdered,
-			placeholders: placeholders,
+			key:               key,
+			source:            placeholdered,
+			placeholders:      placeholders,
+			sourceSyntaxCount: rawHTMLSyntaxStartCount(placeholdered),
 		})
 	}
 
-	handleVoidTranslatable := func(raw, attrName string) {
+	handleVoidTranslatable := func(rawBytes []byte, attrName string) {
+		raw := string(rawBytes)
 		prefix, rawVal, suffix, found := splitVoidAttrTag(raw, attrName)
 		decoded := html.UnescapeString(rawVal)
 		if found && isTranslatableChunk(decoded) {
@@ -201,11 +243,12 @@ func parseHTMLDocument(content []byte) (htmlDocument, map[string]string, error) 
 			key := htmlSegmentKey(decoded, occurrences)
 			entries[key] = decoded
 			doc.parts = append(doc.parts, htmlPart{
-				key:           key,
-				source:        decoded,
-				isVoidAttr:    true,
-				voidTagPrefix: prefix,
-				voidTagSuffix: suffix,
+				key:               key,
+				source:            decoded,
+				isVoidAttr:        true,
+				voidTagPrefix:     prefix,
+				voidTagSuffix:     suffix,
+				sourceSyntaxCount: rawHTMLSyntaxStartCount(decoded),
 			})
 		} else {
 			buffer.WriteString(raw)
@@ -222,10 +265,8 @@ func parseHTMLDocument(content []byte) (htmlDocument, map[string]string, error) 
 			break
 		}
 
-		// Copy raw bytes before any TagName call which may advance internal state.
-		raw := string(z.Raw())
-
 		if skipDepth > 0 {
+			rawBytes := z.Raw()
 			switch tt {
 			case html.EndTagToken:
 				tn, _ := z.TagName()
@@ -238,53 +279,53 @@ func parseHTMLDocument(content []byte) (htmlDocument, map[string]string, error) 
 					skipDepth++
 				}
 			}
-			appendLiteral(raw)
+			appendLiteral(string(rawBytes))
 			continue
 		}
 
 		switch tt {
 		case html.DoctypeToken, html.CommentToken:
 			flushBuffer()
-			appendLiteral(raw)
+			appendLiteral(string(z.Raw()))
 
 		case html.StartTagToken:
 			tn, _ := z.TagName()
 			if htmlSkipElements[string(tn)] {
 				flushBuffer()
 				skipDepth++
-				appendLiteral(raw)
+				appendLiteral(string(z.Raw()))
 			} else if htmlBlockElements[string(tn)] || htmlStructuralElements[string(tn)] {
 				flushBuffer()
-				appendLiteral(raw)
+				appendLiteral(string(z.Raw()))
 			} else if attrName, isVoid := htmlVoidTranslatableAttrs[string(tn)]; isVoid {
-				handleVoidTranslatable(raw, attrName)
+				handleVoidTranslatable(z.Raw(), attrName)
 			} else {
 				// Inline element: accumulate into the text buffer.
-				buffer.WriteString(raw)
+				buffer.Write(z.Raw())
 			}
 
 		case html.EndTagToken:
 			tn, _ := z.TagName()
 			if htmlBlockElements[string(tn)] || htmlStructuralElements[string(tn)] {
 				flushBuffer()
-				appendLiteral(raw)
+				appendLiteral(string(z.Raw()))
 			} else {
-				buffer.WriteString(raw)
+				buffer.Write(z.Raw())
 			}
 
 		case html.SelfClosingTagToken:
 			tn, _ := z.TagName()
 			if htmlBlockElements[string(tn)] || htmlStructuralElements[string(tn)] {
 				flushBuffer()
-				appendLiteral(raw)
+				appendLiteral(string(z.Raw()))
 			} else if attrName, isVoid := htmlVoidTranslatableAttrs[string(tn)]; isVoid {
-				handleVoidTranslatable(raw, attrName)
+				handleVoidTranslatable(z.Raw(), attrName)
 			} else {
-				buffer.WriteString(raw)
+				buffer.Write(z.Raw())
 			}
 
 		case html.TextToken:
-			buffer.WriteString(raw)
+			buffer.Write(z.Raw())
 		}
 	}
 
@@ -422,6 +463,8 @@ func MarshalHTMLWithTargetFallback(sourceTemplate, targetTemplate []byte, values
 func (d htmlDocument) render(values map[string]string) ([]byte, HTMLRenderDiagnostics) {
 	var diags HTMLRenderDiagnostics
 	var b strings.Builder
+	// BOLT OPTIMIZATION: hint builder capacity to minimize re-allocations.
+	b.Grow(d.templateLen)
 	for _, part := range d.parts {
 		if part.isVoidAttr {
 			translated, ok := values[part.key]
@@ -453,7 +496,7 @@ func (d htmlDocument) render(values map[string]string) ([]byte, HTMLRenderDiagno
 				break
 			}
 		}
-		if !allPresent || IntroducesRawHTMLSyntax(part.source, rendered) {
+		if !allPresent || IntroducesRawHTMLSyntax(part.sourceSyntaxCount, rendered) {
 			diags.SourceFallbackKeys = append(diags.SourceFallbackKeys, part.key)
 			b.WriteString(expandHTMLPlaceholders(part.source, part.placeholders))
 			continue

--- a/internal/i18n/translationfileparser/html_parser.go
+++ b/internal/i18n/translationfileparser/html_parser.go
@@ -234,8 +234,7 @@ func parseHTMLDocument(content []byte) (htmlDocument, map[string]string, error) 
 		})
 	}
 
-	handleVoidTranslatable := func(rawBytes []byte, attrName string) {
-		raw := string(rawBytes)
+	handleVoidTranslatable := func(raw string, attrName string) {
 		prefix, rawVal, suffix, found := splitVoidAttrTag(raw, attrName)
 		decoded := html.UnescapeString(rawVal)
 		if found && isTranslatableChunk(decoded) {
@@ -265,8 +264,8 @@ func parseHTMLDocument(content []byte) (htmlDocument, map[string]string, error) 
 			break
 		}
 
-		// BOLT OPTIMIZATION: Capture z.Raw() before any TagName calls to avoid buffer corruption.
-		rawBytes := z.Raw()
+		// Copy raw bytes before any TagName call; TagName may mutate the Raw() slice.
+		raw := string(z.Raw())
 
 		if skipDepth > 0 {
 			switch tt {
@@ -281,53 +280,53 @@ func parseHTMLDocument(content []byte) (htmlDocument, map[string]string, error) 
 					skipDepth++
 				}
 			}
-			appendLiteral(string(rawBytes))
+			appendLiteral(raw)
 			continue
 		}
 
 		switch tt {
 		case html.DoctypeToken, html.CommentToken:
 			flushBuffer()
-			appendLiteral(string(rawBytes))
+			appendLiteral(raw)
 
 		case html.StartTagToken:
 			tn, _ := z.TagName()
 			if htmlSkipElements[string(tn)] {
 				flushBuffer()
 				skipDepth++
-				appendLiteral(string(rawBytes))
+				appendLiteral(raw)
 			} else if htmlBlockElements[string(tn)] || htmlStructuralElements[string(tn)] {
 				flushBuffer()
-				appendLiteral(string(rawBytes))
+				appendLiteral(raw)
 			} else if attrName, isVoid := htmlVoidTranslatableAttrs[string(tn)]; isVoid {
-				handleVoidTranslatable(rawBytes, attrName)
+				handleVoidTranslatable(raw, attrName)
 			} else {
 				// Inline element: accumulate into the text buffer.
-				buffer.Write(rawBytes)
+				buffer.WriteString(raw)
 			}
 
 		case html.EndTagToken:
 			tn, _ := z.TagName()
 			if htmlBlockElements[string(tn)] || htmlStructuralElements[string(tn)] {
 				flushBuffer()
-				appendLiteral(string(rawBytes))
+				appendLiteral(raw)
 			} else {
-				buffer.Write(rawBytes)
+				buffer.WriteString(raw)
 			}
 
 		case html.SelfClosingTagToken:
 			tn, _ := z.TagName()
 			if htmlBlockElements[string(tn)] || htmlStructuralElements[string(tn)] {
 				flushBuffer()
-				appendLiteral(string(rawBytes))
+				appendLiteral(raw)
 			} else if attrName, isVoid := htmlVoidTranslatableAttrs[string(tn)]; isVoid {
-				handleVoidTranslatable(rawBytes, attrName)
+				handleVoidTranslatable(raw, attrName)
 			} else {
-				buffer.Write(rawBytes)
+				buffer.WriteString(raw)
 			}
 
 		case html.TextToken:
-			buffer.Write(rawBytes)
+			buffer.WriteString(raw)
 		}
 	}
 

--- a/internal/i18n/translationfileparser/liquid_parser.go
+++ b/internal/i18n/translationfileparser/liquid_parser.go
@@ -434,7 +434,7 @@ func (d liquidDocument) renderTextPart(part htmlPart, values map[string]string, 
 	rendered := preserveChunkBoundaryWhitespace(part.source, translated)
 	// Ensure every placeholder survived translation and no new raw HTML syntax
 	// was introduced (to prevent XSS).
-	if !htmlPlaceholdersPresent(part, rendered) || !liquidPlaceholdersPresent(part.source, rendered) || IntroducesRawHTMLSyntax(part.source, rendered) {
+	if !htmlPlaceholdersPresent(part, rendered) || !liquidPlaceholdersPresent(part.source, rendered) || IntroducesRawHTMLSyntax(part.sourceSyntaxCount, rendered) {
 		diags.SourceFallbackKeys = append(diags.SourceFallbackKeys, part.key)
 		return renderLiquidSourcePart(part, d.liquidReplacer)
 	}

--- a/internal/i18n/translationfileparser/markdown_md_parser.go
+++ b/internal/i18n/translationfileparser/markdown_md_parser.go
@@ -75,10 +75,11 @@ func parseMarkdownASTDocument(content []byte) (markdownDocument, map[string]stri
 		}
 
 		part := markdownPart{
-			source:       placeholdered,
-			placeholders: placeholders,
-			path:         candidate.path,
-			yamlPlain:    candidate.yamlPlain,
+			source:            placeholdered,
+			placeholders:      placeholders,
+			path:              candidate.path,
+			yamlPlain:         candidate.yamlPlain,
+			sourceSyntaxCount: rawHTMLSyntaxStartCount(placeholdered),
 		}
 		part.key = markdownSegmentKey(part.source, hashOccurrences)
 		doc.parts = append(doc.parts, part)

--- a/internal/i18n/translationfileparser/markdown_parser.go
+++ b/internal/i18n/translationfileparser/markdown_parser.go
@@ -21,6 +21,8 @@ type markdownPart struct {
 	placeholders map[string]string
 	path         string
 	yamlPlain    bool
+	// BOLT OPTIMIZATION: precompute raw HTML syntax count to avoid redundant scans.
+	sourceSyntaxCount int
 }
 
 type markdownDocument struct {
@@ -177,7 +179,7 @@ func emitMarkdownLineParts(line string, doc *markdownDocument, appendKey func(ma
 		}
 		return
 	}
-	appendKey(markdownPart{source: placeholdered, placeholders: placeholders, path: path})
+	appendKey(markdownPart{source: placeholdered, placeholders: placeholders, path: path, sourceSyntaxCount: rawHTMLSyntaxStartCount(placeholdered)})
 	for _, literal := range trailingLiterals {
 		doc.parts = append(doc.parts, markdownPart{literal: literal})
 	}
@@ -605,7 +607,7 @@ func emitFrontmatterLineParts(line string, doc *markdownDocument, appendKey func
 			return
 		}
 		doc.parts = append(doc.parts, markdownPart{literal: body[:colon+1] + valuePart[:lead]})
-		appendKey(markdownPart{source: plainValue, yamlPlain: true})
+		appendKey(markdownPart{source: plainValue, yamlPlain: true, sourceSyntaxCount: rawHTMLSyntaxStartCount(plainValue)})
 		doc.parts = append(doc.parts, markdownPart{literal: newline})
 		return
 	}
@@ -623,7 +625,7 @@ func emitFrontmatterLineParts(line string, doc *markdownDocument, appendKey func
 	}
 
 	doc.parts = append(doc.parts, markdownPart{literal: body[:colon+1] + valuePart[:lead] + string(quote)})
-	appendKey(markdownPart{source: quotedText})
+	appendKey(markdownPart{source: quotedText, sourceSyntaxCount: rawHTMLSyntaxStartCount(quotedText)})
 	doc.parts = append(doc.parts, markdownPart{literal: valueRest[end:] + newline})
 }
 
@@ -699,7 +701,7 @@ func renderMarkdownPartWithDiagnostics(part markdownPart, translated string, dia
 		rendered = yamlDoubleQuoteScalar(rendered)
 	}
 	rendered = normalizeMarkdownTableRowBoundaries(part, rendered)
-	if !trustedFallback && IntroducesRawHTMLSyntax(part.source, rendered) {
+	if !trustedFallback && IntroducesRawHTMLSyntax(part.sourceSyntaxCount, rendered) {
 		if diags != nil && part.key != "" {
 			diags.SourceFallbackKeys = append(diags.SourceFallbackKeys, part.key)
 		}


### PR DESCRIPTION
### 💡 What
This optimization improves the performance of the i18n rendering and parsing logic, specifically for HTML, Markdown, and Liquid files. 

Key changes include:
- Precomputing the `sourceSyntaxCount` for each translatable segment during the parsing phase and storing it in the `htmlPart` and `markdownPart` structs.
- Updating `IntroducesRawHTMLSyntax` to take the precomputed count, avoiding a redundant $O(N)$ scan of the source string during every render call.
- Optimizing `rawHTMLSyntaxStartCount` to use `strings.IndexByte` for faster character scanning.
- Implementing an allocation-free `isAllHTMLWhitespace` check that operates directly on byte/string data without intermediate `strings.TrimSpace` allocations.
- Adding capacity hints to `strings.Builder` (using `Grow`) and internal slices/maps in the HTML parser to minimize re-allocations.
- Deferring string conversions in the `html.Tokenizer` loop.

### 🎯 Why
Document rendering is a high-frequency operation. In the original implementation, the `IntroducesRawHTMLSyntax` function scanned the source string for every translatable segment to count HTML-like characters, leading to avoidable CPU cycles. Furthermore, the parser was performing several intermediate string allocations for whitespace checks and literal content that could be handled more efficiently with byte-level operations and capacity hinting.

### 📊 Impact
- **Faster Rendering:** The render path for HTML, Markdown, and Liquid is now faster by avoiding redundant $O(N)$ source scans.
- **Lower Memory Pressure:** Reduced heap allocations during parsing by using byte-level checks and pre-allocating slice/map capacities.
- **Efficient Scanning:** `rawHTMLSyntaxStartCount` is significantly faster due to the use of Go's optimized `strings.IndexByte`.

### 🔬 Measurement
Verified the improvements using local benchmarks (`BenchmarkHTMLParser` and `BenchmarkHTMLMarshal`) and ensured functional correctness by running the full unit test suite (`go test ./...`). Structural refactoring was verified across the CLI and core library packages.


---
*PR created automatically by Jules for task [12835489267583032486](https://jules.google.com/task/12835489267583032486) started by @cungminh2710*