### PR TITLE
🧪 Scout: add AST tests for ICU select and selectordinal

### DIFF
--- a/internal/i18n/icuparser/parse_test.go
+++ b/internal/i18n/icuparser/parse_test.go
@@ -493,3 +493,73 @@ func TestParsePluralWithSpaceInOffset(t *testing.T) {
 		})
 	}
 }
+
+func TestParseASTSelect(t *testing.T) {
+	msg := "{gender, select, male {He} female {She} other {They}}"
+	elems, err := Parse(msg, nil)
+	if err != nil {
+		t.Fatalf("Parse() failed: %v", err)
+	}
+	if len(elems) != 1 {
+		t.Fatalf("expected 1 element, got %d", len(elems))
+	}
+	se, ok := elems[0].(SelectElement)
+	if !ok {
+		t.Fatalf("expected SelectElement, got %T", elems[0])
+	}
+	if se.Value != "gender" {
+		t.Errorf("expected argument 'gender', got %q", se.Value)
+	}
+	if len(se.Options) != 3 {
+		t.Fatalf("expected 3 options, got %d", len(se.Options))
+	}
+
+	expected := map[string]string{
+		"male":   "He",
+		"female": "She",
+		"other":  "They",
+	}
+
+	for _, opt := range se.Options {
+		val, ok := expected[opt.Selector]
+		if !ok {
+			t.Errorf("unexpected selector %q", opt.Selector)
+			continue
+		}
+		if len(opt.Value) != 1 {
+			t.Errorf("expected 1 element in option %q, got %d", opt.Selector, len(opt.Value))
+			continue
+		}
+		lit, ok := opt.Value[0].(LiteralElement)
+		if !ok || lit.Value != val {
+			t.Errorf("expected literal %q for option %q, got %v", val, opt.Selector, opt.Value[0])
+		}
+	}
+}
+
+func TestParseASTSelectOrdinal(t *testing.T) {
+	msg := "{pos, selectordinal, one {#st} other {#th}}"
+	elems, err := Parse(msg, nil)
+	if err != nil {
+		t.Fatalf("Parse() failed: %v", err)
+	}
+	if len(elems) != 1 {
+		t.Fatalf("expected 1 element, got %d", len(elems))
+	}
+	pl, ok := elems[0].(PluralElement)
+	if !ok {
+		t.Fatalf("expected PluralElement, got %T", elems[0])
+	}
+	if pl.Type() != TypeSelectOrdinal {
+		t.Errorf("expected type %q, got %q", TypeSelectOrdinal, pl.Type())
+	}
+	if !pl.Ordinal {
+		t.Errorf("expected Ordinal to be true")
+	}
+	if pl.Value != "pos" {
+		t.Errorf("expected argument 'pos', got %q", pl.Value)
+	}
+	if len(pl.Options) != 2 {
+		t.Fatalf("expected 2 options, got %d", len(pl.Options))
+	}
+}

--- a/internal/i18n/icuparser/parse_test.go
+++ b/internal/i18n/icuparser/parse_test.go
@@ -562,4 +562,29 @@ func TestParseASTSelectOrdinal(t *testing.T) {
 	if len(pl.Options) != 2 {
 		t.Fatalf("expected 2 options, got %d", len(pl.Options))
 	}
+
+	expected := map[string]string{
+		"one":   "st",
+		"other": "th",
+	}
+
+	for _, opt := range pl.Options {
+		suffix, ok := expected[opt.Selector]
+		if !ok {
+			t.Errorf("unexpected selector %q", opt.Selector)
+			continue
+		}
+		if len(opt.Value) != 2 {
+			t.Errorf("expected 2 elements in option %q, got %d", opt.Selector, len(opt.Value))
+			continue
+		}
+		if _, ok := opt.Value[0].(PoundElement); !ok {
+			t.Errorf("expected PoundElement for option %q, got %v", opt.Selector, opt.Value[0])
+			continue
+		}
+		lit, ok := opt.Value[1].(LiteralElement)
+		if !ok || lit.Value != suffix {
+			t.Errorf("expected literal %q for option %q, got %v", suffix, opt.Selector, opt.Value[1])
+		}
+	}
 }

--- a/internal/i18n/icuparser/parse_test.go
+++ b/internal/i18n/icuparser/parse_test.go
@@ -575,16 +575,15 @@ func TestParseASTSelectOrdinal(t *testing.T) {
 			continue
 		}
 		if len(opt.Value) != 2 {
-			t.Errorf("expected 2 elements in option %q, got %d", opt.Selector, len(opt.Value))
+			t.Errorf("expected 2 elements (pound + literal) in option %q, got %d", opt.Selector, len(opt.Value))
 			continue
 		}
 		if _, ok := opt.Value[0].(PoundElement); !ok {
-			t.Errorf("expected PoundElement for option %q, got %v", opt.Selector, opt.Value[0])
-			continue
+			t.Errorf("expected first element to be PoundElement for option %q, got %T", opt.Selector, opt.Value[0])
 		}
 		lit, ok := opt.Value[1].(LiteralElement)
 		if !ok || lit.Value != suffix {
-			t.Errorf("expected literal %q for option %q, got %v", suffix, opt.Selector, opt.Value[1])
+			t.Errorf("expected literal suffix %q for option %q, got %v", suffix, opt.Selector, opt.Value[1])
 		}
 	}
 }


### PR DESCRIPTION
- 💡 What: Added `TestParseASTSelect` and `TestParseASTSelectOrdinal` unit tests.
- 🎯 Why: Protects the core ICU message parsing logic for conditional and ordinal messages, which was previously less explicitly tested in the AST layer.
- 🧩 Scope: `internal/i18n/icuparser/parse_test.go`
- ✅ Verification: Ran `go test ./internal/i18n/icuparser/...` and `go test ./...`.
- 🛡️ Confidence: Prevents regressions in Abstract Syntax Tree generation for complex localization messages.

---
*PR created automatically by Jules for task [9274544319502406166](https://jules.google.com/task/9274544319502406166) started by @cungminh2710*