### PR TITLE
fix(web): remove Teams from workspace sidebar navigation

### DIFF
--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
@@ -13,7 +13,6 @@ import {
   LinkSquare02Icon,
   Settings01Icon,
   Task01Icon,
-  UserGroupIcon,
   UserMultiple02Icon,
   WorkHistoryIcon,
 } from "@hugeicons/core-free-icons";
@@ -108,12 +107,6 @@ export function buildGlobalNavigationGroups(organizationSlug: string): readonly 
           label: "Integrations",
           href: org("integrations"),
           icon: LinkSquare02Icon,
-        },
-        {
-          label: "Teams",
-          href: org("teams"),
-          icon: UserGroupIcon,
-          description: "Create teams and assign workspace members",
         },
         {
           label: "Members",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the **Teams** item from the workspace sidebar so only **Members** appears under the Workspace section.

Teams pages and routes remain available; they are just no longer linked from the main sidebar.

## Changes

- Removed the Teams navigation entry from `buildGlobalNavigationGroups()` in `navigation-config.ts`
- Dropped the unused `UserGroupIcon` import

## Test plan

- [x] `vp test src/components/app-shell/navigation-config.test.ts`
- [x] `vp check --fix`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f1c3fe32-853b-4694-80b3-02a52d4317e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1c3fe32-853b-4694-80b3-02a52d4317e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

