### PR TITLE
fix(web): return 404 for unsupported locale paths instead of 500

### DIFF
--- a/apps/hyperlocalise-web/src/proxy.test.ts
+++ b/apps/hyperlocalise-web/src/proxy.test.ts
@@ -31,6 +31,7 @@ describe("isUnsupportedLocalePath", () => {
   it("allows non-locale root routes", () => {
     expect(isUnsupportedLocalePath("/auth/sign-in")).toBe(false);
     expect(isUnsupportedLocalePath("/install")).toBe(false);
+    expect(isUnsupportedLocalePath("/api/auth/callback")).toBe(false);
   });
 
   it("allows the site root", () => {
@@ -40,6 +41,7 @@ describe("isUnsupportedLocalePath", () => {
 
 describe("proxy", () => {
   it("returns 404 for unsupported locale paths before AuthKit runs", async () => {
+    authkitProxyMock.mockReset();
     const response = await proxy(createRequest("/wp-links.php"), {} as never);
 
     expect(response?.status).toBe(404);
@@ -47,9 +49,20 @@ describe("proxy", () => {
   });
 
   it("still delegates supported locale paths to AuthKit", async () => {
+    authkitProxyMock.mockReset();
     authkitProxyMock.mockResolvedValueOnce(new Response(null, { status: 200 }));
 
     const response = await proxy(createRequest("/en/blog"), {} as never);
+
+    expect(authkitProxyMock).toHaveBeenCalledOnce();
+    expect(response?.status).toBe(200);
+  });
+
+  it("delegates /api paths to AuthKit instead of returning 404", async () => {
+    authkitProxyMock.mockReset();
+    authkitProxyMock.mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    const response = await proxy(createRequest("/api/auth/callback"), {} as never);
 
     expect(authkitProxyMock).toHaveBeenCalledOnce();
     expect(response?.status).toBe(200);

--- a/apps/hyperlocalise-web/src/proxy.test.ts
+++ b/apps/hyperlocalise-web/src/proxy.test.ts
@@ -1,0 +1,57 @@
+import { NextRequest } from "next/server";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import proxy, { isUnsupportedLocalePath } from "./proxy";
+
+const { authkitProxyMock } = vi.hoisted(() => ({
+  authkitProxyMock: vi.fn(),
+}));
+
+vi.mock("@workos-inc/authkit-nextjs", () => ({
+  authkitProxy: () => authkitProxyMock,
+}));
+
+function createRequest(pathname: string) {
+  return new NextRequest(`https://www.hyperlocalise.com${pathname}`);
+}
+
+describe("isUnsupportedLocalePath", () => {
+  it("flags bot scan paths that would match /[lang]", () => {
+    expect(isUnsupportedLocalePath("/wp-links.php")).toBe(true);
+    expect(isUnsupportedLocalePath("/xstelth.php")).toBe(true);
+    expect(isUnsupportedLocalePath("/random-page")).toBe(true);
+  });
+
+  it("allows supported locale paths", () => {
+    expect(isUnsupportedLocalePath("/en")).toBe(false);
+    expect(isUnsupportedLocalePath("/en/blog")).toBe(false);
+    expect(isUnsupportedLocalePath("/EN/product/localisation")).toBe(false);
+  });
+
+  it("allows non-locale root routes", () => {
+    expect(isUnsupportedLocalePath("/auth/sign-in")).toBe(false);
+    expect(isUnsupportedLocalePath("/install")).toBe(false);
+  });
+
+  it("allows the site root", () => {
+    expect(isUnsupportedLocalePath("/")).toBe(false);
+  });
+});
+
+describe("proxy", () => {
+  it("returns 404 for unsupported locale paths before AuthKit runs", async () => {
+    const response = await proxy(createRequest("/wp-links.php"), {} as never);
+
+    expect(response?.status).toBe(404);
+    expect(authkitProxyMock).not.toHaveBeenCalled();
+  });
+
+  it("still delegates supported locale paths to AuthKit", async () => {
+    authkitProxyMock.mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    const response = await proxy(createRequest("/en/blog"), {} as never);
+
+    expect(authkitProxyMock).toHaveBeenCalledOnce();
+    expect(response?.status).toBe(200);
+  });
+});

--- a/apps/hyperlocalise-web/src/proxy.ts
+++ b/apps/hyperlocalise-web/src/proxy.ts
@@ -14,6 +14,7 @@ type WorkosProxyResult = Awaited<ReturnType<typeof workosProxy>>;
 const PUBLIC_LOCALIZED_PREFIXES = ["/product", "/use-cases", "/blog"];
 const PUBLIC_LOCALIZED_PATHS = new Set(["/", "/privacy", "/terms", "/trust-center"]);
 const PROTECTED_LOCALIZED_PREFIXES = ["/dashboard", "/org"];
+const NON_LOCALE_ROOT_PREFIXES = ["/auth", "/install"];
 
 function splitLocalePath(pathname: string): {
   locale: string | null;
@@ -50,6 +51,30 @@ function isLocalizedAppPath(pathname: string): boolean {
   return isPublicLocalizedPath(pathname) || isProtectedLocalizedPath(pathname);
 }
 
+function isNonLocaleRootPath(pathname: string): boolean {
+  return NON_LOCALE_ROOT_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+}
+
+/**
+ * Paths like /wp-links.php are captured by the /[lang] segment even though the
+ * first segment is not a supported locale. Reject them in proxy before rendering
+ * so root layout withAuth() does not throw when AuthKit middleware was skipped.
+ */
+export function isUnsupportedLocalePath(pathname: string): boolean {
+  if (isNonLocaleRootPath(pathname)) {
+    return false;
+  }
+
+  const firstSegment = pathname.split("/").filter(Boolean)[0];
+  if (!firstSegment) {
+    return false;
+  }
+
+  return normalizeAppLocale(firstSegment) === null;
+}
+
 function applyLocaleToResponse(response: WorkosProxyResult, locale: string): WorkosProxyResult {
   if (!response) {
     return response;
@@ -72,6 +97,11 @@ function applyLocaleToResponse(response: WorkosProxyResult, locale: string): Wor
 
 export default async function proxy(request: NextRequest, event: NextFetchEvent) {
   const { pathname } = request.nextUrl;
+
+  if (isUnsupportedLocalePath(pathname)) {
+    return new NextResponse(null, { status: 404 });
+  }
+
   const { locale, pathnameWithoutLocale } = splitLocalePath(pathname);
 
   if (locale && isPublicLocalizedPath(pathnameWithoutLocale)) {
@@ -96,7 +126,7 @@ export default async function proxy(request: NextRequest, event: NextFetchEvent)
 
 export const config = {
   matcher: [
-    "/((?!_next/static|_next/image|favicon.ico|images|api|mcp|\\.well-known|install|.*\\..*).*)",
+    "/((?!_next/static|_next/image|favicon.ico|images|api|mcp|\\.well-known|install).*)",
     "/api/:path*",
   ],
 };

--- a/apps/hyperlocalise-web/src/proxy.ts
+++ b/apps/hyperlocalise-web/src/proxy.ts
@@ -126,7 +126,7 @@ export default async function proxy(request: NextRequest, event: NextFetchEvent)
 
 export const config = {
   matcher: [
-    "/((?!_next/static|_next/image|favicon.ico|images|api|mcp|\\.well-known|install).*)",
+    "/((?!_next/static|_next/image|favicon.ico|images|api|mcp|\\.well-known|install|sitemap\\.xml|robots\\.txt).*)",
     "/api/:path*",
   ],
 };

--- a/apps/hyperlocalise-web/src/proxy.ts
+++ b/apps/hyperlocalise-web/src/proxy.ts
@@ -14,7 +14,7 @@ type WorkosProxyResult = Awaited<ReturnType<typeof workosProxy>>;
 const PUBLIC_LOCALIZED_PREFIXES = ["/product", "/use-cases", "/blog"];
 const PUBLIC_LOCALIZED_PATHS = new Set(["/", "/privacy", "/terms", "/trust-center"]);
 const PROTECTED_LOCALIZED_PREFIXES = ["/dashboard", "/org"];
-const NON_LOCALE_ROOT_PREFIXES = ["/auth", "/install"];
+const NON_LOCALE_ROOT_PREFIXES = ["/auth", "/install", "/api"];
 
 function splitLocalePath(pathname: string): {
   locale: string | null;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Bot scans for paths like `/wp-links.php` were being captured by the `/[lang]` dynamic route even though the first segment is not a supported locale. Those paths also bypassed AuthKit proxy middleware because the matcher excluded any path containing a dot.

When Next.js rendered the route, root layout `withAuth()` threw because the `x-workos-middleware` header was missing, producing 500 errors in Vercel logs instead of a 404.

This change:
- Rejects unsupported first path segments in `proxy.ts` with a 404 before rendering
- Removes the blanket dot-path exclusion from the proxy matcher so AuthKit middleware runs consistently

## How to test

- `cd apps/hyperlocalise-web && vp test src/proxy.test.ts`
- `cd apps/hyperlocalise-web && vp check --fix`
- Request a bogus path like `/wp-links.php` and confirm it returns 404 (not 500)
- Confirm valid routes still work: `/en`, `/en/blog`, `/auth/sign-in`

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, `vp test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c981211-82f5-46cd-8729-df893e8bd8b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c981211-82f5-46cd-8729-df893e8bd8b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

