### PR TITLE
feat(cat): add glossary compliance checks and forbidden term warnings

### DIFF
--- a/apps/hyperlocalise-web/src/components/cat/cat-glossary-checks.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat-glossary-checks.test.ts
@@ -30,6 +30,11 @@ describe("containsGlossaryTerm", () => {
     expect(containsGlossaryTerm("Open the dashboard settings", "Dashboard")).toBe(true);
     expect(containsGlossaryTerm("Open the Dashboards settings", "Dashboard")).toBe(false);
   });
+
+  it("uses unicode word boundaries for multi-word target terms", () => {
+    expect(containsGlossaryTerm("Mở Bảng điều khiển", "Bảng điều khiển")).toBe(true);
+    expect(containsGlossaryTerm("xềBảng điều khiển", "Bảng điều khiển")).toBe(false);
+  });
 });
 
 describe("glossaryFormatChecksForSegment", () => {
@@ -52,7 +57,7 @@ describe("glossaryFormatChecksForSegment", () => {
 
   it("flags forbidden terms that appear in the target", () => {
     const checks = glossaryFormatChecksForSegment(
-      "Reviews awaiting approval",
+      "Review awaiting approval",
       "Review đang chờ phê duyệt",
       glossaryTerms,
       testIntl,
@@ -87,5 +92,43 @@ describe("glossaryFormatChecksForSegment", () => {
 
   it("returns no checks when the target is empty", () => {
     expect(glossaryFormatChecksForSegment("Dashboard", "", glossaryTerms, testIntl)).toEqual([]);
+  });
+
+  it("does not warn for unapproved non-forbidden terms", () => {
+    const checks = glossaryFormatChecksForSegment(
+      "Open Dashboard settings",
+      "Mở cài đặt",
+      [
+        {
+          id: "draft-term",
+          source: "Dashboard",
+          target: "Bảng điều khiển",
+          approved: false,
+          forbidden: false,
+        },
+      ],
+      testIntl,
+    );
+
+    expect(checks).toEqual([]);
+  });
+
+  it("returns no checks when glossary terms are not relevant to the segment", () => {
+    const checks = glossaryFormatChecksForSegment(
+      "Save your work before closing",
+      "Lưu công việc trước khi đóng",
+      [
+        {
+          id: "term-dashboard",
+          source: "Dashboard",
+          target: "Bảng điều khiển",
+          approved: true,
+          forbidden: false,
+        },
+      ],
+      testIntl,
+    );
+
+    expect(checks).toEqual([]);
   });
 });

--- a/apps/hyperlocalise-web/src/components/cat/cat-glossary-checks.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat-glossary-checks.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { getIntlShape } from "@/lib/app-i18n/intl";
+
+import { containsGlossaryTerm, glossaryFormatChecksForSegment } from "./cat-glossary-checks";
+import type { CatGlossaryTerm } from "./types";
+
+const testIntl = getIntlShape("en");
+
+const glossaryTerms: CatGlossaryTerm[] = [
+  {
+    id: "term-dashboard",
+    source: "Dashboard",
+    target: "Bảng điều khiển",
+    approved: true,
+    forbidden: false,
+  },
+  {
+    id: "term-review-forbidden",
+    source: "Review",
+    target: "Đánh giá",
+    approved: false,
+    forbidden: true,
+  },
+];
+
+describe("containsGlossaryTerm", () => {
+  it("matches whole words case-insensitively", () => {
+    expect(containsGlossaryTerm("Open the Dashboard settings", "Dashboard")).toBe(true);
+    expect(containsGlossaryTerm("Open the dashboard settings", "Dashboard")).toBe(true);
+    expect(containsGlossaryTerm("Open the Dashboards settings", "Dashboard")).toBe(false);
+  });
+});
+
+describe("glossaryFormatChecksForSegment", () => {
+  it("returns a pass check when approved glossary terms are used correctly", () => {
+    const checks = glossaryFormatChecksForSegment(
+      "Dashboard card showing pending reviews",
+      "Thẻ Bảng điều khiển hiển thị các mục đang chờ",
+      glossaryTerms,
+      testIntl,
+    );
+
+    expect(checks).toEqual([
+      expect.objectContaining({
+        id: "glossary-compliance",
+        status: "pass",
+        category: "glossary",
+      }),
+    ]);
+  });
+
+  it("flags forbidden terms that appear in the target", () => {
+    const checks = glossaryFormatChecksForSegment(
+      "Reviews awaiting approval",
+      "Review đang chờ phê duyệt",
+      glossaryTerms,
+      testIntl,
+    );
+
+    expect(checks).toEqual([
+      expect.objectContaining({
+        id: "glossary-forbidden-term-review-forbidden",
+        status: "fail",
+        category: "glossary",
+        relatedTokens: ["Review"],
+      }),
+    ]);
+  });
+
+  it("warns when a required glossary rendering is missing from the target", () => {
+    const checks = glossaryFormatChecksForSegment(
+      "Open Dashboard settings",
+      "Mở cài đặt",
+      glossaryTerms,
+      testIntl,
+    );
+
+    expect(checks).toEqual([
+      expect.objectContaining({
+        id: "glossary-missing-term-dashboard",
+        status: "warn",
+        category: "glossary",
+      }),
+    ]);
+  });
+
+  it("returns no checks when the target is empty", () => {
+    expect(glossaryFormatChecksForSegment("Dashboard", "", glossaryTerms, testIntl)).toEqual([]);
+  });
+});

--- a/apps/hyperlocalise-web/src/components/cat/cat-glossary-checks.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat-glossary-checks.ts
@@ -1,0 +1,83 @@
+import type { CatFormatMessageIntl } from "./cat-message-format-i18n";
+import { catGlossaryChecksMessages } from "./cat.messages";
+import type { CatFormatCheck, CatGlossaryTerm } from "./types";
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function containsGlossaryTerm(text: string, term: string) {
+  const normalizedTerm = term.trim();
+  if (!normalizedTerm) {
+    return false;
+  }
+
+  const patternStr = `(?<![a-zA-Z0-9_])${escapeRegExp(normalizedTerm)}(?![a-zA-Z0-9_])`;
+  return new RegExp(patternStr, "i").test(text);
+}
+
+export function glossaryFormatChecksForSegment(
+  sourceText: string,
+  targetText: string,
+  glossaryTerms: CatGlossaryTerm[],
+  intl: CatFormatMessageIntl,
+): CatFormatCheck[] {
+  if (glossaryTerms.length === 0 || !targetText.trim()) {
+    return [];
+  }
+
+  const checks: CatFormatCheck[] = [];
+
+  for (const term of glossaryTerms) {
+    if (term.forbidden) {
+      if (containsGlossaryTerm(targetText, term.source)) {
+        checks.push({
+          id: `glossary-forbidden-${term.id}`,
+          label: intl.formatMessage(catGlossaryChecksMessages.forbiddenTermLabel),
+          status: "fail",
+          message: intl.formatMessage(catGlossaryChecksMessages.forbiddenTermMessage, {
+            term: term.source,
+          }),
+          category: "glossary",
+          relatedTokens: [term.source],
+        });
+      }
+      continue;
+    }
+
+    if (!containsGlossaryTerm(sourceText, term.source)) {
+      continue;
+    }
+
+    const expectedTarget = term.target.trim();
+    if (!expectedTarget) {
+      continue;
+    }
+
+    if (!containsGlossaryTerm(targetText, expectedTarget)) {
+      checks.push({
+        id: `glossary-missing-${term.id}`,
+        label: intl.formatMessage(catGlossaryChecksMessages.missingTermLabel),
+        status: "warn",
+        message: intl.formatMessage(catGlossaryChecksMessages.missingTermMessage, {
+          sourceTerm: term.source,
+          targetTerm: expectedTarget,
+        }),
+        category: "glossary",
+        relatedTokens: [term.source, expectedTarget],
+      });
+    }
+  }
+
+  if (checks.length === 0) {
+    checks.push({
+      id: "glossary-compliance",
+      label: intl.formatMessage(catGlossaryChecksMessages.complianceLabel),
+      status: "pass",
+      message: intl.formatMessage(catGlossaryChecksMessages.compliancePassMessage),
+      category: "glossary",
+    });
+  }
+
+  return checks;
+}

--- a/apps/hyperlocalise-web/src/components/cat/cat-glossary-checks.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat-glossary-checks.ts
@@ -2,6 +2,8 @@ import type { CatFormatMessageIntl } from "./cat-message-format-i18n";
 import { catGlossaryChecksMessages } from "./cat.messages";
 import type { CatFormatCheck, CatGlossaryTerm } from "./types";
 
+const UNICODE_WORD_CHAR = String.raw`\p{L}\p{N}_`;
+
 function escapeRegExp(value: string) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -12,8 +14,8 @@ export function containsGlossaryTerm(text: string, term: string) {
     return false;
   }
 
-  const patternStr = `(?<![a-zA-Z0-9_])${escapeRegExp(normalizedTerm)}(?![a-zA-Z0-9_])`;
-  return new RegExp(patternStr, "i").test(text);
+  const patternStr = `(?<![${UNICODE_WORD_CHAR}])${escapeRegExp(normalizedTerm)}(?![${UNICODE_WORD_CHAR}])`;
+  return new RegExp(patternStr, "iu").test(text);
 }
 
 export function glossaryFormatChecksForSegment(
@@ -27,9 +29,11 @@ export function glossaryFormatChecksForSegment(
   }
 
   const checks: CatFormatCheck[] = [];
+  let evaluatedTermCount = 0;
 
   for (const term of glossaryTerms) {
     if (term.forbidden) {
+      evaluatedTermCount += 1;
       if (containsGlossaryTerm(targetText, term.source)) {
         checks.push({
           id: `glossary-forbidden-${term.id}`,
@@ -45,6 +49,10 @@ export function glossaryFormatChecksForSegment(
       continue;
     }
 
+    if (!term.approved) {
+      continue;
+    }
+
     if (!containsGlossaryTerm(sourceText, term.source)) {
       continue;
     }
@@ -53,6 +61,8 @@ export function glossaryFormatChecksForSegment(
     if (!expectedTarget) {
       continue;
     }
+
+    evaluatedTermCount += 1;
 
     if (!containsGlossaryTerm(targetText, expectedTarget)) {
       checks.push({
@@ -69,7 +79,7 @@ export function glossaryFormatChecksForSegment(
     }
   }
 
-  if (checks.length === 0) {
+  if (evaluatedTermCount > 0 && checks.length === 0) {
     checks.push({
       id: "glossary-compliance",
       label: intl.formatMessage(catGlossaryChecksMessages.complianceLabel),

--- a/apps/hyperlocalise-web/src/components/cat/cat-intelligence-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-intelligence-panel.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import { useState, type ReactNode } from "react";
-import { BulbIcon, CheckmarkCircle02Icon, InformationCircleIcon } from "@hugeicons/core-free-icons";
+import {
+  BulbIcon,
+  AlertCircleIcon,
+  CheckmarkCircle02Icon,
+  InformationCircleIcon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { FormattedMessage, useIntl } from "react-intl";
 
@@ -23,6 +28,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/primitives/cn";
 
 import { catIntelligencePanelMessages } from "./cat.messages";
+import { containsGlossaryTerm } from "./cat-glossary-checks";
 import { requiresLowMatchConfirmation } from "./tm-match-quality";
 import { CatVisualContextPanel } from "./cat-visual-context-panel";
 import type {
@@ -92,12 +98,15 @@ function AgentContextSkeleton() {
 
 function GlossaryTermRow({
   term,
+  targetText,
   onUse,
 }: {
   term: CatGlossaryTerm;
+  targetText: string;
   onUse?: (term: CatGlossaryTerm) => void;
 }) {
   const intl = useIntl();
+  const forbiddenInTarget = term.forbidden && containsGlossaryTerm(targetText, term.source);
 
   return (
     <li className="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)_auto] items-center gap-2 px-3 py-2.5">
@@ -105,7 +114,13 @@ function GlossaryTermRow({
       <span className="text-xs text-muted-foreground">→</span>
       <span className="inline-flex min-w-0 items-center justify-end gap-1.5 text-right text-sm font-medium text-foreground/92">
         <span className="truncate">{term.target}</span>
-        {term.approved ? (
+        {forbiddenInTarget ? (
+          <HugeiconsIcon
+            icon={AlertCircleIcon}
+            className="size-3.5 shrink-0 text-flame-200"
+            aria-label={intl.formatMessage(catIntelligencePanelMessages.forbiddenInTargetAria)}
+          />
+        ) : term.approved ? (
           <HugeiconsIcon
             icon={CheckmarkCircle02Icon}
             className="size-3.5 shrink-0 text-grove-300"
@@ -196,6 +211,7 @@ function TranslationMemoryRow({
 
 export function CatIntelligencePanel({
   intelligence,
+  targetText = "",
   isLookingUpContext = false,
   isConcordanceLoading = false,
   isVisualContextLoading = false,
@@ -206,6 +222,7 @@ export function CatIntelligencePanel({
   onUseGlossaryTerm,
 }: {
   intelligence: CatSegmentIntelligence;
+  targetText?: string;
   isLookingUpContext?: boolean;
   isConcordanceLoading?: boolean;
   isVisualContextLoading?: boolean;
@@ -366,6 +383,7 @@ export function CatIntelligencePanel({
                     <GlossaryTermRow
                       key={term.id}
                       term={term}
+                      targetText={targetText}
                       onUse={
                         canEditTranslations && onUseGlossaryTerm ? onUseGlossaryTerm : undefined
                       }

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
@@ -112,6 +112,12 @@ function hasSaveFailureCheck(checks: CatFormatCheck[]) {
   return checks.some((check) => check.id.startsWith("save-failed-"));
 }
 
+function glossaryTermsForSegment(state: CatWorkspaceState, segmentId: string) {
+  return (
+    state.segmentIntelligence?.[segmentId]?.glossaryTerms ?? state.intelligence.glossaryTerms ?? []
+  );
+}
+
 export function addSaveFailureFormatCheck(
   state: CatWorkspaceState,
   segmentId: string,
@@ -489,7 +495,7 @@ export function CatWorkspaceContainer({
   }, [state.selectedSegmentId]);
 
   const runSegmentChecks = useCallback(
-    async (segment: CatSegment, value: string) => {
+    async (segment: CatSegment, value: string, glossaryTermsOverride?: CatGlossaryTerm[]) => {
       if (!validateFormat && !runQaChecks) {
         return;
       }
@@ -498,8 +504,10 @@ export function CatWorkspaceContainer({
       validationSequenceRef.current = sequence;
       setIsValidating(true);
       try {
+        const glossaryTerms =
+          glossaryTermsOverride ?? glossaryTermsForSegment(stateRef.current, segment.id);
         const [formatChecks, qaChecks] = await Promise.all([
-          validateFormat ? validateFormat(segment, value) : Promise.resolve([]),
+          validateFormat ? validateFormat(segment, value, glossaryTerms) : Promise.resolve([]),
           runQaChecks ? runQaChecks(segment, value) : Promise.resolve([]),
         ]);
         if (validationSequenceRef.current !== sequence) {
@@ -614,7 +622,11 @@ export function CatWorkspaceContainer({
               onTargetChange?.(segmentId, bestTmMatch.targetText);
               const updatedSegment = segments.find((item) => item.id === segmentId);
               if (updatedSegment && (validateFormat || runQaChecks)) {
-                void runSegmentChecks(updatedSegment, bestTmMatch.targetText);
+                void runSegmentChecks(
+                  updatedSegment,
+                  bestTmMatch.targetText,
+                  concordance.glossaryTerms,
+                );
               }
             }
           } catch (error) {
@@ -688,7 +700,11 @@ export function CatWorkspaceContainer({
         if (includeFormatChecks || includeAi) {
           const [formatChecks, qaChecks] = await Promise.all([
             includeFormatChecks && validateFormat
-              ? validateFormat(segment, segment.targetText)
+              ? validateFormat(
+                  segment,
+                  segment.targetText,
+                  intelligenceForRecommendation.glossaryTerms,
+                )
               : Promise.resolve([]),
             includeFormatChecks && runQaChecks
               ? runQaChecks(segment, segment.targetText)

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace.tsx
@@ -213,6 +213,7 @@ export function CatWorkspaceView({
     return (
       <CatIntelligencePanel
         intelligence={selectedSegmentIntelligence}
+        targetText={selectedSegment.targetText}
         isLookingUpContext={isLookingUpContext}
         isConcordanceLoading={isConcordanceLoading}
         isVisualContextLoading={isVisualContextLoading}

--- a/apps/hyperlocalise-web/src/components/cat/cat.fixture.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat.fixture.ts
@@ -1,5 +1,6 @@
 import type {
   CatFormatCheck,
+  CatGlossaryTerm,
   CatSegment,
   CatSegmentIntelligence,
   CatWorkspaceState,
@@ -9,6 +10,7 @@ import { getIntlShape } from "@/lib/app-i18n/intl";
 import { analyzeCatMessageFormat, compareCatMessageFormats } from "./cat-message-format";
 import type { CatMessageParityIssue } from "./cat-message-format";
 import { localizeCatMessageParityIssue } from "./cat-message-format-i18n";
+import { glossaryFormatChecksForSegment } from "./cat-glossary-checks";
 
 const fixtureIntl = getIntlShape("en");
 
@@ -464,13 +466,6 @@ export const catSegmentsFixture: CatSegment[] = catSegmentInputs.map((segment, i
 
 export const catFormatChecksFixture: CatFormatCheck[] = [
   {
-    id: "check-glossary",
-    label: "Glossary compliance",
-    status: "pass",
-    message: "Approved terms for Dashboard and Review are used correctly.",
-    category: "glossary",
-  },
-  {
     id: "check-placeholders",
     label: "Placeholders & markup",
     status: "pass",
@@ -506,7 +501,7 @@ export const catIntelligenceFixture: CatSegmentIntelligence = {
       approved: true,
       forbidden: false,
     },
-    { id: "term-2", source: "Review", target: "Đánh giá", approved: true, forbidden: false },
+    { id: "term-2", source: "Review", target: "Đánh giá", approved: false, forbidden: true },
     { id: "term-3", source: "Approval", target: "Phê duyệt", approved: true, forbidden: false },
   ],
   translationMemoryMatches: [
@@ -563,8 +558,19 @@ export const catWorkspaceFixture = createCatWorkspaceState();
 export async function mockValidateFormat(
   segment: CatSegment,
   value: string,
+  glossaryTerms: CatGlossaryTerm[] = catIntelligenceFixture.glossaryTerms,
 ): Promise<CatFormatCheck[]> {
   const checks = [...catFormatChecksFixture];
+
+  const glossaryChecks = glossaryFormatChecksForSegment(
+    segment.sourceText,
+    value,
+    glossaryTerms,
+    fixtureIntl,
+  );
+  if (glossaryChecks.length > 0) {
+    checks.unshift(...glossaryChecks);
+  }
 
   if (segment.maxLength && value.length > segment.maxLength) {
     checks.unshift({

--- a/apps/hyperlocalise-web/src/components/cat/cat.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat.messages.ts
@@ -159,6 +159,40 @@ export const catQueuePanelMessages = defineMessages({
   },
 });
 
+export const catGlossaryChecksMessages = defineMessages({
+  complianceLabel: {
+    defaultMessage: "Glossary compliance",
+    id: "8BeERYABTz",
+    description: "CAT format check label for glossary compliance summary",
+  },
+  compliancePassMessage: {
+    defaultMessage: "Approved glossary terms are used correctly and forbidden terms are absent.",
+    id: "irDjU9PSS4",
+    description: "CAT format check message when glossary terms pass validation",
+  },
+  forbiddenTermLabel: {
+    defaultMessage: "Forbidden glossary term",
+    id: "8OHSn5eQCa",
+    description: "CAT format check label when a forbidden glossary term appears in the target",
+  },
+  forbiddenTermMessage: {
+    defaultMessage: 'Forbidden term "{term}" appears in the target translation.',
+    id: "ivdHFzfBNo",
+    description: "CAT format check message when a forbidden glossary term appears in the target",
+  },
+  missingTermLabel: {
+    defaultMessage: "Glossary term mismatch",
+    id: "lN7mrKGBHB",
+    description: "CAT format check label when a required glossary rendering is missing",
+  },
+  missingTermMessage: {
+    defaultMessage:
+      'Source term "{sourceTerm}" should be translated as "{targetTerm}" per the glossary.',
+    id: "nG1gispZFL",
+    description: "CAT format check message when a required glossary rendering is missing",
+  },
+});
+
 export const catFormatChecksMessages = defineMessages({
   emptyChecks: {
     defaultMessage: "No format or QA checks for this segment yet.",
@@ -358,6 +392,11 @@ export const catIntelligencePanelMessages = defineMessages({
     defaultMessage: "Approved",
     id: "jGuaDovXli",
     description: "Accessible label for an approved glossary term",
+  },
+  forbiddenInTargetAria: {
+    defaultMessage: "Forbidden term used in translation",
+    id: "gEtNXv9OoK",
+    description: "Accessible label when a forbidden glossary term appears in the target text",
   },
   matchPercent: {
     defaultMessage: "{matchPercent}% match",

--- a/apps/hyperlocalise-web/src/components/cat/dependencies.ts
+++ b/apps/hyperlocalise-web/src/components/cat/dependencies.ts
@@ -51,7 +51,11 @@ export interface CatWorkspaceReview {
 }
 
 export interface CatWorkspaceServices {
-  validateFormat?: (segment: CatSegment, value: string) => Promise<CatFormatCheck[]>;
+  validateFormat?: (
+    segment: CatSegment,
+    value: string,
+    glossaryTerms?: CatGlossaryTerm[],
+  ) => Promise<CatFormatCheck[]>;
   runQaChecks?: (segment: CatSegment, value: string) => Promise<CatFormatCheck[]>;
   lookupSegmentContext?: (segment: CatSegment) => Promise<string>;
   lookupSegmentConcordance?: (segment: CatSegment) => Promise<CatSegmentConcordanceResult>;

--- a/apps/hyperlocalise-web/src/components/cat/project-file-cat-mapper.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file-cat-mapper.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vite-plus/test";
 import type { ProjectFileCatResponse } from "@/api/routes/project/project.schema";
 import { getIntlShape } from "@/lib/app-i18n/intl";
 
-import { projectFileCatToWorkspaceState } from "./project-file-cat-mapper";
+import { projectFileCatToWorkspaceState, formatCheckForSegment } from "./project-file-cat-mapper";
 
 const testIntl = getIntlShape("en");
 
@@ -135,5 +135,40 @@ describe("projectFileCatToWorkspaceState", () => {
       needsReview: 40,
       hasIssues: 5,
     });
+  });
+});
+
+describe("formatCheckForSegment", () => {
+  it("includes glossary compliance checks when glossary terms are provided", () => {
+    const segment = {
+      id: "seg-1",
+      index: 1,
+      key: "dashboard.title",
+      sourceText: "Open Dashboard settings",
+      targetText: "Mở cài đặt",
+      sourceLocale: "en-US",
+      targetLocale: "vi",
+      status: "needs_review" as const,
+    };
+
+    const checks = formatCheckForSegment(segment, segment.targetText, testIntl, [
+      {
+        id: "term-dashboard",
+        source: "Dashboard",
+        target: "Bảng điều khiển",
+        approved: true,
+        forbidden: false,
+      },
+    ]);
+
+    expect(checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "glossary-missing-term-dashboard",
+          status: "warn",
+          category: "glossary",
+        }),
+      ]),
+    );
   });
 });

--- a/apps/hyperlocalise-web/src/components/cat/project-file-cat-mapper.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file-cat-mapper.ts
@@ -11,8 +11,10 @@ import {
   localizeCatMessageParityIssue,
   type CatFormatMessageIntl,
 } from "@/components/cat/cat-message-format-i18n";
+import { glossaryFormatChecksForSegment } from "@/components/cat/cat-glossary-checks";
 import type {
   CatFormatCheck,
+  CatGlossaryTerm,
   CatSegment,
   CatSegmentComment,
   CatSegmentIntelligence,
@@ -71,6 +73,7 @@ export function formatCheckForSegment(
   segment: CatSegment,
   value: string,
   intl: CatFormatMessageIntl,
+  glossaryTerms: CatGlossaryTerm[] = [],
 ): CatFormatCheck[] {
   const checks: CatFormatCheck[] = [];
   const sourceAnalysis = analyzeCatMessageFormat(segment.sourceText);
@@ -104,6 +107,10 @@ export function formatCheckForSegment(
     });
   }
 
+  if (glossaryTerms.length > 0) {
+    checks.push(...glossaryFormatChecksForSegment(segment.sourceText, value, glossaryTerms, intl));
+  }
+
   return checks;
 }
 
@@ -111,8 +118,9 @@ export async function validateSegmentFormat(
   segment: CatSegment,
   value: string,
   intl: CatFormatMessageIntl,
+  glossaryTerms: CatGlossaryTerm[] = [],
 ) {
-  return formatCheckForSegment(segment, value, intl);
+  return formatCheckForSegment(segment, value, intl, glossaryTerms);
 }
 
 function intelligenceFor(catFile: CatFile): CatSegmentIntelligence {

--- a/apps/hyperlocalise-web/src/components/cat/project-file-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/project-file-cat-workspace.tsx
@@ -35,7 +35,7 @@ import {
   validateSegmentFormat,
 } from "./project-file-cat-mapper";
 import { useCatSegmentQuery } from "./use-cat-segment-query";
-import type { CatSegment, CatSegmentIntelligence } from "./types";
+import type { CatGlossaryTerm, CatSegment, CatSegmentIntelligence } from "./types";
 
 function initialTargetLocale(targetLocales: string[], highlightLocale: string | null) {
   if (highlightLocale && targetLocales.includes(highlightLocale)) {
@@ -197,7 +197,8 @@ export function ProjectFileCatWorkspace({
   );
 
   const validateFormat = useCallback(
-    (segment: CatSegment, value: string) => validateSegmentFormat(segment, value, intl),
+    (segment: CatSegment, value: string, glossaryTerms: CatGlossaryTerm[] = []) =>
+      validateSegmentFormat(segment, value, intl, glossaryTerms),
     [intl],
   );
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The CAT workspace had glossary/terminology check categories in types and fixtures, but production only ran client-side ICU/placeholder validation. Forbidden glossary terms were also ignored in the intelligence panel UI.

This change wires real glossary compliance checks into the production validation path and surfaces forbidden-term violations in the intelligence panel.

## Changes

- Add `cat-glossary-checks.ts` with client-side glossary validation (forbidden terms in target, missing required renderings, pass summary)
- Extend `formatCheckForSegment` / `validateSegmentFormat` to accept concordance glossary terms
- Pass glossary terms from segment intelligence through `validateFormat` in the workspace container (including immediately after concordance lookup)
- Show a warning icon on glossary rows when a forbidden term appears in the current target translation
- Update fixtures and tests to cover glossary check behavior

## Testing

- `vp test src/components/cat/cat-glossary-checks.test.ts`
- `vp test src/components/cat/project-file-cat-mapper.test.ts`
- `vp check --fix`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ee2a825-8b69-4d4d-816f-8d6276a5b0e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ee2a825-8b69-4d4d-816f-8d6276a5b0e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

