### PR TITLE
feat(web): add row and kanban views to project jobs

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-kanban-board.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-kanban-board.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { TypographyP } from "@/components/ui/typography";
+import { cn } from "@/lib/primitives/cn";
+
+import {
+  formatRelativeTime,
+  getJobName,
+  jobTone,
+  taskDetailSummary,
+  type ApiJob,
+  type JobRow,
+  type JobsLinkRenderer,
+} from "./jobs-page-view";
+import { buildJobCatHref, buildJobDetailHref, kanbanStatusColumns } from "./jobs-view-helpers";
+import { toneClass, type Tone } from "../../_components/workspace-resource-shared";
+
+const kanbanStatusLabels: Record<ApiJob["status"], string> = {
+  queued: "Queued",
+  running: "Running",
+  waiting_for_review: "Waiting for review",
+  succeeded: "Succeeded",
+  failed: "Failed",
+  cancelled: "Cancelled",
+};
+
+function sourceLabel(job: ApiJob) {
+  return job.externalProviderKind ? `Provider · ${job.externalProviderKind}` : "Native";
+}
+
+function formatJobKind(job: ApiJob) {
+  if (job.kind === "translation" && job.type) {
+    return `${job.kind.replace("_", " ")} · ${job.type}`;
+  }
+
+  return job.kind.replace("_", " ");
+}
+
+export function JobRowActions({
+  buildJobDetailHref: buildDetailHref = buildJobDetailHref,
+  job,
+  organizationSlug,
+  projectId,
+  renderJobLink,
+}: {
+  buildJobDetailHref?: typeof buildJobDetailHref;
+  job: JobRow;
+  organizationSlug: string;
+  projectId?: string;
+  renderJobLink: JobsLinkRenderer;
+}) {
+  const resolvedProjectId = projectId ?? job.projectId;
+  const detailHref = buildDetailHref(organizationSlug, resolvedProjectId, job.id);
+  const catHref = buildJobCatHref(organizationSlug, resolvedProjectId, job);
+  const showCat = Boolean(catHref);
+
+  return (
+    <div className="flex flex-wrap items-center justify-end gap-2">
+      {showCat && catHref ? renderJobLink({ href: catHref, kind: "cat", children: "CAT" }) : null}
+      {detailHref ? (
+        renderJobLink({ href: detailHref, kind: "details", children: "Details" })
+      ) : (
+        <Button variant="outline" size="sm" className="w-fit" disabled>
+          Details
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function JobKanbanCard({
+  buildJobDetailHref: buildDetailHref = buildJobDetailHref,
+  job,
+  now,
+  organizationSlug,
+  projectId,
+  renderJobLink,
+}: {
+  buildJobDetailHref?: typeof buildJobDetailHref;
+  job: JobRow;
+  now?: number;
+  organizationSlug: string;
+  projectId?: string;
+  renderJobLink: JobsLinkRenderer;
+}) {
+  const resolvedProjectId = projectId ?? job.projectId;
+  const detailHref = buildDetailHref(organizationSlug, resolvedProjectId, job.id);
+
+  return (
+    <article className="rounded-lg border border-foreground/10 bg-background p-3 shadow-sm">
+      {detailHref ? (
+        renderJobLink({
+          href: detailHref,
+          kind: "title",
+          children: (
+            <span className="min-w-0">
+              <span className="block truncate text-sm font-medium text-foreground">
+                {getJobName(job)}
+              </span>
+              <span className="mt-1 block truncate text-xs font-normal text-foreground/38">
+                {formatJobKind(job)} · {job.externalTaskId ?? job.id}
+              </span>
+            </span>
+          ),
+        })
+      ) : (
+        <div className="min-w-0">
+          <TypographyP className="truncate text-sm font-medium text-foreground">
+            {getJobName(job)}
+          </TypographyP>
+          <TypographyP className="mt-1 truncate text-xs text-foreground/38">
+            {formatJobKind(job)} · {job.externalTaskId ?? job.id}
+          </TypographyP>
+        </div>
+      )}
+
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        <Badge variant="outline" className="w-fit rounded-full text-[11px]">
+          {sourceLabel(job)}
+        </Badge>
+        {!projectId ? (
+          <Badge variant="outline" className="w-fit rounded-full text-[11px]">
+            {job.projectName ?? job.projectId ?? "Workspace"}
+          </Badge>
+        ) : null}
+      </div>
+
+      <TypographyP className="mt-3 line-clamp-2 text-xs text-foreground/68">
+        {taskDetailSummary(job)}
+      </TypographyP>
+      <TypographyP className="mt-1 text-[11px] text-foreground/38">
+        Due {formatRelativeTime(job.externalDueDate, now)} · Synced{" "}
+        {formatRelativeTime(job.updatedAt, now)}
+      </TypographyP>
+
+      <div className="mt-3 border-t border-foreground/8 pt-3">
+        <JobRowActions
+          buildJobDetailHref={buildDetailHref}
+          job={job}
+          organizationSlug={organizationSlug}
+          projectId={projectId}
+          renderJobLink={renderJobLink}
+        />
+      </div>
+    </article>
+  );
+}
+
+function KanbanColumn({
+  jobs,
+  label,
+  statusTone,
+  ...cardProps
+}: {
+  jobs: JobRow[];
+  label: string;
+  statusTone: Tone;
+} & Omit<Parameters<typeof JobKanbanCard>[0], "job">) {
+  return (
+    <section className="flex min-w-[17rem] flex-1 flex-col rounded-xl border border-foreground/10 bg-foreground/2">
+      <header className="flex items-center justify-between gap-2 border-b border-foreground/8 px-3 py-3">
+        <TypographyP className="text-sm font-medium text-foreground">{label}</TypographyP>
+        <Badge variant="outline" className={cn("rounded-full capitalize", toneClass(statusTone))}>
+          {jobs.length}
+        </Badge>
+      </header>
+      <div className="flex flex-1 flex-col gap-3 p-3">
+        {jobs.length === 0 ? (
+          <TypographyP className="px-1 py-6 text-center text-xs text-foreground/38">
+            No jobs
+          </TypographyP>
+        ) : (
+          jobs.map((job) => <JobKanbanCard key={job.id} job={job} {...cardProps} />)
+        )}
+      </div>
+    </section>
+  );
+}
+
+export function JobsKanbanBoard({
+  buildJobDetailHref: buildDetailHref = buildJobDetailHref,
+  emptyLabel,
+  isLoading,
+  jobs,
+  now,
+  organizationSlug,
+  projectId,
+  renderJobLink,
+}: {
+  buildJobDetailHref?: typeof buildJobDetailHref;
+  emptyLabel: string;
+  isLoading: boolean;
+  jobs: JobRow[];
+  now?: number;
+  organizationSlug: string;
+  projectId?: string;
+  renderJobLink: JobsLinkRenderer;
+}) {
+  if (isLoading) {
+    return (
+      <TypographyP className="px-3 py-8 text-sm text-foreground/58">Loading jobs…</TypographyP>
+    );
+  }
+
+  if (jobs.length === 0) {
+    return <TypographyP className="px-3 py-8 text-sm text-foreground/58">{emptyLabel}</TypographyP>;
+  }
+
+  const jobsByStatus = new Map<ApiJob["status"], JobRow[]>();
+  for (const status of kanbanStatusColumns) {
+    jobsByStatus.set(status, []);
+  }
+
+  for (const job of jobs) {
+    jobsByStatus.get(job.status)?.push(job);
+  }
+
+  const visibleColumns = kanbanStatusColumns.filter(
+    (status) => (jobsByStatus.get(status)?.length ?? 0) > 0,
+  );
+
+  return (
+    <div className="overflow-x-auto pb-1">
+      <div className="flex min-w-max gap-3">
+        {visibleColumns.map((status) => (
+          <KanbanColumn
+            key={status}
+            label={kanbanStatusLabels[status]}
+            statusTone={jobTone(status)}
+            jobs={jobsByStatus.get(status) ?? []}
+            buildJobDetailHref={buildDetailHref}
+            now={now}
+            organizationSlug={organizationSlug}
+            projectId={projectId}
+            renderJobLink={renderJobLink}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-kanban-board.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-kanban-board.tsx
@@ -6,15 +6,23 @@ import { TypographyP } from "@/components/ui/typography";
 import { cn } from "@/lib/primitives/cn";
 
 import {
+  formatJobKind,
   formatRelativeTime,
   getJobName,
   jobTone,
+  sourceLabel,
   taskDetailSummary,
   type ApiJob,
   type JobRow,
   type JobsLinkRenderer,
 } from "./jobs-page-view";
-import { buildJobCatHref, buildJobDetailHref, kanbanStatusColumns } from "./jobs-view-helpers";
+import {
+  buildJobCatHref,
+  buildJobDetailHref,
+  isKanbanStatus,
+  kanbanStatusColumns,
+  type KanbanStatus,
+} from "./jobs-view-helpers";
 import { toneClass, type Tone } from "../../_components/workspace-resource-shared";
 
 const kanbanStatusLabels: Record<ApiJob["status"], string> = {
@@ -26,17 +34,12 @@ const kanbanStatusLabels: Record<ApiJob["status"], string> = {
   cancelled: "Cancelled",
 };
 
-function sourceLabel(job: ApiJob) {
-  return job.externalProviderKind ? `Provider · ${job.externalProviderKind}` : "Native";
-}
-
-function formatJobKind(job: ApiJob) {
-  if (job.kind === "translation" && job.type) {
-    return `${job.kind.replace("_", " ")} · ${job.type}`;
-  }
-
-  return job.kind.replace("_", " ");
-}
+type KanbanColumnDef = {
+  key: string;
+  label: string;
+  statusTone: Tone;
+  jobs: JobRow[];
+};
 
 export function JobRowActions({
   buildJobDetailHref: buildDetailHref = buildJobDetailHref,
@@ -54,11 +57,10 @@ export function JobRowActions({
   const resolvedProjectId = projectId ?? job.projectId;
   const detailHref = buildDetailHref(organizationSlug, resolvedProjectId, job.id);
   const catHref = buildJobCatHref(organizationSlug, resolvedProjectId, job);
-  const showCat = Boolean(catHref);
 
   return (
     <div className="flex flex-wrap items-center justify-end gap-2">
-      {showCat && catHref ? renderJobLink({ href: catHref, kind: "cat", children: "CAT" }) : null}
+      {catHref ? renderJobLink({ href: catHref, kind: "cat", children: "CAT" }) : null}
       {detailHref ? (
         renderJobLink({ href: detailHref, kind: "details", children: "Details" })
       ) : (
@@ -208,28 +210,52 @@ export function JobsKanbanBoard({
     return <TypographyP className="px-3 py-8 text-sm text-foreground/58">{emptyLabel}</TypographyP>;
   }
 
-  const jobsByStatus = new Map<ApiJob["status"], JobRow[]>();
+  const jobsByStatus = new Map<KanbanStatus, JobRow[]>();
   for (const status of kanbanStatusColumns) {
     jobsByStatus.set(status, []);
   }
 
+  const unknownStatusJobs: JobRow[] = [];
   for (const job of jobs) {
-    jobsByStatus.get(job.status)?.push(job);
+    const status = job.status as string;
+    if (isKanbanStatus(status)) {
+      jobsByStatus.get(status)?.push(job);
+      continue;
+    }
+
+    if (process.env.NODE_ENV !== "production") {
+      console.warn(`[JobsKanbanBoard] Unknown job status "${status}" for job ${job.id}`);
+    }
+    unknownStatusJobs.push(job);
   }
 
-  const visibleColumns = kanbanStatusColumns.filter(
-    (status) => (jobsByStatus.get(status)?.length ?? 0) > 0,
-  );
+  const columns: KanbanColumnDef[] = kanbanStatusColumns
+    .filter((status) => (jobsByStatus.get(status)?.length ?? 0) > 0)
+    .map((status) => ({
+      key: status,
+      label: kanbanStatusLabels[status],
+      statusTone: jobTone(status),
+      jobs: jobsByStatus.get(status) ?? [],
+    }));
+
+  if (unknownStatusJobs.length > 0) {
+    columns.push({
+      key: "other",
+      label: "Other",
+      statusTone: "watch",
+      jobs: unknownStatusJobs,
+    });
+  }
 
   return (
     <div className="overflow-x-auto pb-1">
       <div className="flex min-w-max gap-3">
-        {visibleColumns.map((status) => (
+        {columns.map((column) => (
           <KanbanColumn
-            key={status}
-            label={kanbanStatusLabels[status]}
-            statusTone={jobTone(status)}
-            jobs={jobsByStatus.get(status) ?? []}
+            key={column.key}
+            label={column.label}
+            statusTone={column.statusTone}
+            jobs={column.jobs}
             buildJobDetailHref={buildDetailHref}
             now={now}
             organizationSlug={organizationSlug}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.stories.tsx
@@ -133,6 +133,27 @@ export const ProjectJobs: Story = {
     isLoading: false,
     now: fixedNow,
   },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByRole("button", { name: "Row" })).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Board" })).toBeInTheDocument();
+    await expect(canvas.getAllByRole("link", { name: "CAT" }).length).toBeGreaterThan(0);
+    await expect(canvas.getAllByRole("link", { name: "Details" }).length).toBeGreaterThan(0);
+  },
+};
+
+export const ProjectJobsKanban: Story = {
+  args: {
+    organizationSlug: "acme",
+    projectId: "project_website",
+    jobs,
+    isLoading: false,
+    now: fixedNow,
+  },
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByRole("button", { name: "Board" }));
+    await expect(canvas.getByText("Queued")).toBeInTheDocument();
+    await expect(canvas.getByText("Running")).toBeInTheDocument();
+  },
 };
 
 export const Loading: Story = {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.tsx
@@ -4,6 +4,8 @@ import { useState } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { TranslateIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { toast } from "sonner";
 
 import { TmsUserConnectionErrorPanel } from "@/components/app-shell/tms-user-connection-prompt";
@@ -44,6 +46,21 @@ function renderProductionJobLink({ href, kind, children }: Parameters<JobsLinkRe
         variant="ghost"
         className="-mx-2 h-auto min-w-0 justify-start px-2 py-1 text-left hover:bg-foreground/6"
       >
+        {children}
+      </Button>
+    );
+  }
+
+  if (kind === "cat") {
+    return (
+      <Button
+        nativeButton={false}
+        render={<Link href={href} />}
+        variant="outline"
+        size="sm"
+        className="w-fit"
+      >
+        <HugeiconsIcon icon={TranslateIcon} strokeWidth={1.8} />
         {children}
       </Button>
     );

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-view.tsx
@@ -1,16 +1,20 @@
 "use client";
 
-import { useId, useMemo, useState, type ReactNode } from "react";
+import { useEffect, useId, useMemo, useState, type ReactNode } from "react";
 import {
   DatabaseSyncIcon,
+  KanbanIcon,
+  ListViewIcon,
   SearchIcon,
   Task01Icon,
+  TranslateIcon,
   WorkHistoryIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { ButtonGroup } from "@/components/ui/button-group";
 import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
 import {
@@ -24,6 +28,13 @@ import { Separator } from "@/components/ui/separator";
 import { TypographyP } from "@/components/ui/typography";
 import { cn } from "@/lib/primitives/cn";
 
+import { JobsKanbanBoard, JobRowActions } from "./jobs-kanban-board";
+import {
+  buildJobDetailHref,
+  readJobsViewMode,
+  writeJobsViewMode,
+  type JobsViewMode,
+} from "./jobs-view-helpers";
 import { formatLocaleList, getCrowdinTargetLocales } from "./provider-crowdin-job-display";
 
 import {
@@ -86,7 +97,7 @@ export const jobsStatusOptions = [
 
 export type JobsStatusFilter = (typeof jobsStatusOptions)[number];
 
-type JobLinkKind = "title" | "details";
+type JobLinkKind = "title" | "details" | "cat";
 
 export type JobsLinkRenderer = (props: {
   href: string;
@@ -113,7 +124,7 @@ const jobsFilterSelectContentClassName =
   "w-max min-w-[var(--anchor-width)] max-w-[min(16rem,calc(100vw-2rem))]";
 
 const jobsTableGridClassName =
-  "grid grid-cols-[minmax(13rem,1.35fr)_7.5rem_minmax(8rem,0.8fr)_7.5rem_minmax(10rem,1fr)_5.5rem] gap-3";
+  "grid grid-cols-[minmax(13rem,1.35fr)_7.5rem_minmax(8rem,0.8fr)_7.5rem_minmax(10rem,1fr)_minmax(11rem,auto)] gap-3";
 
 function JobsFilterField({
   label,
@@ -249,18 +260,6 @@ export function taskDetailSummary(job: ApiJob) {
   return `${locales} · ${people}`;
 }
 
-function defaultBuildJobDetailHref(
-  organizationSlug: string,
-  projectId: string | null | undefined,
-  jobId: string,
-) {
-  if (!projectId) {
-    return null;
-  }
-
-  return `/org/${organizationSlug}/projects/${encodeURIComponent(projectId)}/jobs/${encodeURIComponent(jobId)}`;
-}
-
 function defaultRenderJobLink({ href, kind, children }: Parameters<JobsLinkRenderer>[0]) {
   if (kind === "title") {
     return (
@@ -270,6 +269,21 @@ function defaultRenderJobLink({ href, kind, children }: Parameters<JobsLinkRende
         variant="ghost"
         className="-mx-2 h-auto min-w-0 justify-start px-2 py-1 text-left hover:bg-foreground/6"
       >
+        {children}
+      </Button>
+    );
+  }
+
+  if (kind === "cat") {
+    return (
+      <Button
+        nativeButton={false}
+        render={<a href={href} />}
+        variant="outline"
+        size="sm"
+        className="w-fit"
+      >
+        <HugeiconsIcon icon={TranslateIcon} strokeWidth={1.8} />
         {children}
       </Button>
     );
@@ -300,7 +314,7 @@ export function JobsPageErrorMessage({ error }: { error: unknown }) {
 }
 
 function JobsList({
-  buildJobDetailHref,
+  buildJobDetailHref: buildDetailHref = buildJobDetailHref,
   emptyLabel,
   isLoading,
   jobs,
@@ -309,7 +323,7 @@ function JobsList({
   projectId,
   renderJobLink,
 }: {
-  buildJobDetailHref: typeof defaultBuildJobDetailHref;
+  buildJobDetailHref?: typeof buildJobDetailHref;
   emptyLabel: string;
   isLoading: boolean;
   jobs: JobRow[];
@@ -337,14 +351,10 @@ function JobsList({
           <TypographyP>Project</TypographyP>
           <TypographyP>Status</TypographyP>
           <TypographyP>Task details</TypographyP>
-          <span aria-hidden />
+          <TypographyP className="text-end">Actions</TypographyP>
         </div>
         {jobs.map((job, index) => {
-          const detailHref = buildJobDetailHref(
-            organizationSlug,
-            projectId ?? job.projectId,
-            job.id,
-          );
+          const detailHref = buildDetailHref(organizationSlug, projectId ?? job.projectId, job.id);
 
           return (
             <div key={job.id}>
@@ -381,13 +391,13 @@ function JobsList({
                     {formatRelativeTime(job.updatedAt, now)}
                   </TypographyP>
                 </div>
-                {detailHref ? (
-                  renderJobLink({ href: detailHref, kind: "details", children: "Details" })
-                ) : (
-                  <Button variant="outline" size="sm" className="w-fit" disabled>
-                    Details
-                  </Button>
-                )}
+                <JobRowActions
+                  buildJobDetailHref={buildDetailHref}
+                  job={job}
+                  organizationSlug={organizationSlug}
+                  projectId={projectId}
+                  renderJobLink={renderJobLink}
+                />
               </div>
               {index < jobs.length - 1 ? <Separator className="bg-foreground/8" /> : null}
             </div>
@@ -411,9 +421,92 @@ function JobListItemTitle({ job }: { job: ApiJob }) {
   );
 }
 
+function JobsViewModeToggle({
+  viewMode,
+  onViewModeChange,
+}: {
+  viewMode: JobsViewMode;
+  onViewModeChange: (viewMode: JobsViewMode) => void;
+}) {
+  return (
+    <ButtonGroup aria-label="Jobs view mode">
+      <Button
+        type="button"
+        variant={viewMode === "row" ? "default" : "outline"}
+        size="sm"
+        className="h-9"
+        onClick={() => onViewModeChange("row")}
+      >
+        <HugeiconsIcon icon={ListViewIcon} strokeWidth={1.8} />
+        Row
+      </Button>
+      <Button
+        type="button"
+        variant={viewMode === "kanban" ? "default" : "outline"}
+        size="sm"
+        className="h-9"
+        onClick={() => onViewModeChange("kanban")}
+      >
+        <HugeiconsIcon icon={KanbanIcon} strokeWidth={1.8} />
+        Board
+      </Button>
+    </ButtonGroup>
+  );
+}
+
+function JobsCollection({
+  buildJobDetailHref: buildDetailHref = buildJobDetailHref,
+  emptyLabel,
+  isLoading,
+  jobs,
+  now,
+  organizationSlug,
+  projectId,
+  renderJobLink,
+  viewMode,
+}: {
+  buildJobDetailHref?: typeof buildJobDetailHref;
+  emptyLabel: string;
+  isLoading: boolean;
+  jobs: JobRow[];
+  now?: number;
+  organizationSlug: string;
+  projectId?: string;
+  renderJobLink: JobsLinkRenderer;
+  viewMode: JobsViewMode;
+}) {
+  if (viewMode === "kanban") {
+    return (
+      <JobsKanbanBoard
+        buildJobDetailHref={buildDetailHref}
+        emptyLabel={emptyLabel}
+        isLoading={isLoading}
+        jobs={jobs}
+        now={now}
+        organizationSlug={organizationSlug}
+        projectId={projectId}
+        renderJobLink={renderJobLink}
+      />
+    );
+  }
+
+  return (
+    <JobsList
+      buildJobDetailHref={buildDetailHref}
+      emptyLabel={emptyLabel}
+      isLoading={isLoading}
+      jobs={jobs}
+      now={now}
+      organizationSlug={organizationSlug}
+      projectId={projectId}
+      renderJobLink={renderJobLink}
+    />
+  );
+}
+
 export function JobsPageView({
   assignedJobs,
-  buildJobDetailHref = defaultBuildJobDetailHref,
+  buildJobDetailHref: buildDetailHref = buildJobDetailHref,
   createdJobs,
   error,
   initialSearch = "",
@@ -432,7 +525,7 @@ export function JobsPageView({
   statusFilter: controlledStatusFilter,
 }: {
   assignedJobs?: JobRow[];
-  buildJobDetailHref?: typeof defaultBuildJobDetailHref;
+  buildJobDetailHref?: typeof buildJobDetailHref;
   createdJobs?: JobRow[];
   error?: unknown;
   initialSearch?: string;
@@ -452,9 +545,25 @@ export function JobsPageView({
 }) {
   const searchId = useId();
   const [search, setSearch] = useState(initialSearch);
+  const [viewMode, setViewMode] = useState<JobsViewMode>("row");
   const [uncontrolledStatusFilter, setUncontrolledStatusFilter] =
     useState<JobsStatusFilter>(initialStatusFilter);
   const statusFilter = controlledStatusFilter ?? uncontrolledStatusFilter;
+
+  useEffect(() => {
+    if (!projectId) {
+      return;
+    }
+
+    setViewMode(readJobsViewMode());
+  }, [projectId]);
+
+  const handleViewModeChange = (nextViewMode: JobsViewMode) => {
+    setViewMode(nextViewMode);
+    if (projectId) {
+      writeJobsViewMode(nextViewMode);
+    }
+  };
 
   const visibleJobs = useMemo(() => {
     const normalizedSearch = search.trim().toLowerCase();
@@ -541,6 +650,11 @@ export function JobsPageView({
             </SelectContent>
           </Select>
         </JobsFilterField>
+        {projectId ? (
+          <JobsFilterField label="View" className="w-full lg:w-auto">
+            <JobsViewModeToggle viewMode={viewMode} onViewModeChange={handleViewModeChange} />
+          </JobsFilterField>
+        ) : null}
       </div>
       {error ? <div>{renderError({ error, organizationSlug })}</div> : null}
       {isPersonalWork ? (
@@ -551,8 +665,8 @@ export function JobsPageView({
                 Jobs assigned to me
               </TypographyP>
             </div>
-            <JobsList
-              buildJobDetailHref={buildJobDetailHref}
+            <JobsCollection
+              buildJobDetailHref={buildDetailHref}
               emptyLabel="No assigned jobs found for your account."
               isLoading={isLoading}
               jobs={visibleAssignedJobs}
@@ -560,6 +674,7 @@ export function JobsPageView({
               organizationSlug={organizationSlug}
               projectId={projectId}
               renderJobLink={renderJobLink}
+              viewMode={viewMode}
             />
           </div>
           <div className="space-y-3">
@@ -568,8 +683,8 @@ export function JobsPageView({
                 Jobs created by me
               </TypographyP>
             </div>
-            <JobsList
-              buildJobDetailHref={buildJobDetailHref}
+            <JobsCollection
+              buildJobDetailHref={buildDetailHref}
               emptyLabel="No jobs created by you found."
               isLoading={isLoading}
               jobs={visibleCreatedJobs}
@@ -577,12 +692,13 @@ export function JobsPageView({
               organizationSlug={organizationSlug}
               projectId={projectId}
               renderJobLink={renderJobLink}
+              viewMode={viewMode}
             />
           </div>
         </div>
       ) : (
-        <JobsList
-          buildJobDetailHref={buildJobDetailHref}
+        <JobsCollection
+          buildJobDetailHref={buildDetailHref}
           emptyLabel={emptyLabel}
           isLoading={isLoading}
           jobs={visibleJobs}
@@ -590,6 +706,7 @@ export function JobsPageView({
           organizationSlug={organizationSlug}
           projectId={projectId}
           renderJobLink={renderJobLink}
+          viewMode={viewMode}
         />
       )}
     </section>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-view.tsx
@@ -177,7 +177,7 @@ export function formatRelativeTime(value: string | null, now = Date.now()) {
   return RELATIVE_TIME_FORMATTER.format(Math.round(deltaSeconds / 31_536_000), "year");
 }
 
-function sourceLabel(job: ApiJob) {
+export function sourceLabel(job: ApiJob) {
   return job.externalProviderKind ? `Provider · ${job.externalProviderKind}` : "Native";
 }
 
@@ -221,7 +221,7 @@ export function getJobName(job: ApiJob) {
   return job.id;
 }
 
-function formatJobKind(job: ApiJob) {
+export function formatJobKind(job: ApiJob) {
   if (job.kind === "translation" && job.type) return `${job.kind.replace("_", " ")} · ${job.type}`;
   return job.kind.replace("_", " ");
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-view-helpers.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-view-helpers.test.ts
@@ -5,6 +5,7 @@ import {
   buildJobCatHref,
   buildJobDetailHref,
   canOpenJobCat,
+  isKanbanStatus,
   readJobsViewMode,
   writeJobsViewMode,
 } from "./jobs-view-helpers";
@@ -83,6 +84,11 @@ describe("jobs-view-helpers", () => {
     );
     expect(buildJobCatHref("acme", null, createJob())).toBeNull();
     expect(buildJobCatHref("acme", "project-1", createJob({ kind: "sync" }))).toBeNull();
+  });
+
+  it("identifies known kanban statuses", () => {
+    expect(isKanbanStatus("running")).toBe(true);
+    expect(isKanbanStatus("unknown_status")).toBe(false);
   });
 
   it("persists project jobs view mode in local storage", () => {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-view-helpers.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-view-helpers.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import type { ApiJob } from "./jobs-page-view";
+import {
+  buildJobCatHref,
+  buildJobDetailHref,
+  canOpenJobCat,
+  readJobsViewMode,
+  writeJobsViewMode,
+} from "./jobs-view-helpers";
+
+function createJob(overrides: Partial<ApiJob> = {}): ApiJob {
+  return {
+    id: "ext:crowdin:project-1:job-1",
+    projectId: "ext:crowdin:project-1",
+    createdByUserId: null,
+    kind: "translation",
+    type: "file",
+    status: "running",
+    createdAt: "2026-06-01T00:00:00.000Z",
+    updatedAt: "2026-06-01T01:00:00.000Z",
+    completedAt: null,
+    workflowRunId: null,
+    lastError: null,
+    inputPayload: { sourceFileId: "locales/en.json" },
+    outcomeKind: null,
+    outcomePayload: null,
+    reviewCriteria: null,
+    reviewTargetLocale: null,
+    syncConnectorKind: null,
+    syncDirection: null,
+    assetType: null,
+    assetOperation: null,
+    externalProviderKind: "crowdin",
+    externalTaskId: "CR-1204",
+    externalStatus: "in_progress",
+    externalTitle: "Translate homepage",
+    externalDueDate: "2026-06-10T00:00:00.000Z",
+    externalTargetLocales: ["fr-FR"],
+    externalAssignedUsers: ["Mina"],
+    externalSyncState: "synced",
+    ...overrides,
+  };
+}
+
+describe("jobs-view-helpers", () => {
+  it("builds project job detail hrefs", () => {
+    expect(buildJobDetailHref("acme", "project-1", "job-1")).toBe(
+      "/org/acme/projects/project-1/jobs/job-1",
+    );
+    expect(buildJobDetailHref("acme", null, "job-1")).toBeNull();
+  });
+
+  it("allows CAT for provider-backed translation and review jobs", () => {
+    expect(canOpenJobCat(createJob())).toBe(true);
+    expect(canOpenJobCat(createJob({ kind: "review" }))).toBe(true);
+    expect(canOpenJobCat(createJob({ kind: "sync" }))).toBe(false);
+    expect(
+      canOpenJobCat(
+        createJob({
+          externalProviderKind: null,
+          id: "job_native",
+          kind: "translation",
+          type: "file",
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      canOpenJobCat(
+        createJob({
+          externalProviderKind: null,
+          id: "job_native",
+          kind: "translation",
+          type: "string",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("builds CAT hrefs with locale and source path when available", () => {
+    expect(buildJobCatHref("acme", "project-1", createJob())).toBe(
+      "/org/acme/projects/project-1/jobs/ext%3Acrowdin%3Aproject-1%3Ajob-1/strings?targetLocale=fr-FR&sourcePath=locales%2Fen.json",
+    );
+    expect(buildJobCatHref("acme", null, createJob())).toBeNull();
+    expect(buildJobCatHref("acme", "project-1", createJob({ kind: "sync" }))).toBeNull();
+  });
+
+  it("persists project jobs view mode in local storage", () => {
+    const storage = new Map<string, string>();
+    const originalWindow = globalThis.window;
+
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: {
+        localStorage: {
+          getItem: (key: string) => storage.get(key) ?? null,
+          setItem: (key: string, value: string) => {
+            storage.set(key, value);
+          },
+        },
+      },
+    });
+
+    try {
+      expect(readJobsViewMode()).toBe("row");
+      writeJobsViewMode("kanban");
+      expect(readJobsViewMode()).toBe("kanban");
+    } finally {
+      Object.defineProperty(globalThis, "window", {
+        configurable: true,
+        value: originalWindow,
+      });
+    }
+  });
+});

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-view-helpers.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-view-helpers.ts
@@ -13,6 +13,12 @@ export const kanbanStatusColumns = [
   "cancelled",
 ] as const;
 
+export type KanbanStatus = (typeof kanbanStatusColumns)[number];
+
+export function isKanbanStatus(status: string): status is KanbanStatus {
+  return (kanbanStatusColumns as readonly string[]).includes(status);
+}
+
 type JobCatTarget = {
   id: string;
   kind: "translation" | "research" | "review" | "sync" | "asset_management";
@@ -50,6 +56,10 @@ export function readJobsViewMode(): JobsViewMode {
 }
 
 export function writeJobsViewMode(mode: JobsViewMode) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
   try {
     window.localStorage.setItem(JOBS_VIEW_MODE_STORAGE_KEY, mode);
   } catch {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-view-helpers.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-view-helpers.ts
@@ -1,0 +1,107 @@
+import { parseProviderJobId } from "@/lib/providers/tms-provider-resource-id";
+
+export type JobsViewMode = "row" | "kanban";
+
+export const JOBS_VIEW_MODE_STORAGE_KEY = "project-jobs-view-mode:v1";
+
+export const kanbanStatusColumns = [
+  "queued",
+  "running",
+  "waiting_for_review",
+  "succeeded",
+  "failed",
+  "cancelled",
+] as const;
+
+type JobCatTarget = {
+  id: string;
+  kind: "translation" | "research" | "review" | "sync" | "asset_management";
+  type: "string" | "file" | null;
+  externalProviderKind: string | null;
+  externalTargetLocales: string[] | null;
+  reviewTargetLocale: string | null;
+  inputPayload: unknown;
+};
+
+function getInputPayloadString(job: JobCatTarget, key: string) {
+  if (typeof job.inputPayload !== "object" || !job.inputPayload || !(key in job.inputPayload)) {
+    return null;
+  }
+
+  const value = (job.inputPayload as Record<string, unknown>)[key];
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+export function readJobsViewMode(): JobsViewMode {
+  if (typeof window === "undefined") {
+    return "row";
+  }
+
+  try {
+    const stored = window.localStorage.getItem(JOBS_VIEW_MODE_STORAGE_KEY);
+    if (stored === "row" || stored === "kanban") {
+      return stored;
+    }
+  } catch {
+    return "row";
+  }
+
+  return "row";
+}
+
+export function writeJobsViewMode(mode: JobsViewMode) {
+  try {
+    window.localStorage.setItem(JOBS_VIEW_MODE_STORAGE_KEY, mode);
+  } catch {
+    // Ignore storage failures in private browsing or restricted environments.
+  }
+}
+
+export function buildJobDetailHref(
+  organizationSlug: string,
+  projectId: string | null | undefined,
+  jobId: string,
+) {
+  if (!projectId) {
+    return null;
+  }
+
+  return `/org/${organizationSlug}/projects/${encodeURIComponent(projectId)}/jobs/${encodeURIComponent(jobId)}`;
+}
+
+export function canOpenJobCat(job: JobCatTarget) {
+  if (job.kind !== "translation" && job.kind !== "review") {
+    return false;
+  }
+
+  if (job.externalProviderKind || parseProviderJobId(job.id)) {
+    return true;
+  }
+
+  return job.kind === "translation" && job.type === "file";
+}
+
+export function buildJobCatHref(
+  organizationSlug: string,
+  projectId: string | null | undefined,
+  job: JobCatTarget,
+) {
+  if (!projectId || !canOpenJobCat(job)) {
+    return null;
+  }
+
+  const params = new URLSearchParams();
+  const targetLocale = job.externalTargetLocales?.[0] ?? job.reviewTargetLocale;
+  if (targetLocale) {
+    params.set("targetLocale", targetLocale);
+  }
+
+  const sourcePath = getInputPayloadString(job, "sourceFileId");
+  if (sourcePath) {
+    params.set("sourcePath", sourcePath);
+  }
+
+  const base = `/org/${organizationSlug}/projects/${encodeURIComponent(projectId)}/jobs/${encodeURIComponent(job.id)}/strings`;
+  const query = params.toString();
+  return query ? `${base}?${query}` : base;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds row and kanban board view modes to the project jobs page, along with quick action buttons to open the CAT workspace or job details.

## Changes

- **View toggle** on project jobs (`Row` / `Board`), persisted in `localStorage`
- **Row view** — existing table layout, now with an Actions column
- **Kanban board** — jobs grouped into status columns (queued, running, waiting for review, succeeded, failed, cancelled)
- **Quick actions** on each job:
  - **CAT** — opens `/jobs/{id}/strings` with target locale and source path when available (translation/review jobs with provider backing or native file jobs)
  - **Details** — opens the job detail page

## Testing

- `vp check --fix` passes
- `vp test src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-view-helpers.test.ts` — 4 tests pass
- Storybook stories updated for project jobs row/kanban views

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20a2b3d7-bd63-4037-9555-5a2bfca54d9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20a2b3d7-bd63-4037-9555-5a2bfca54d9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

