### PR TITLE
feat(hyperlocalise-web): add robots.txt metadata route

### DIFF
--- a/apps/hyperlocalise-web/src/app/robots.test.ts
+++ b/apps/hyperlocalise-web/src/app/robots.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import robots from "./robots";
+
+describe("robots", () => {
+  it("allows public pages and blocks auth, api, and workspace routes", () => {
+    const config = robots();
+
+    expect(config.rules).toMatchObject({
+      userAgent: "*",
+      allow: "/",
+    });
+
+    const disallow = Array.isArray(config.rules)
+      ? config.rules.flatMap((rule) => rule.disallow ?? [])
+      : (config.rules?.disallow ?? []);
+
+    expect(disallow).toEqual(
+      expect.arrayContaining(["/auth/", "/api/", "/mcp", "/en/dashboard", "/en/org/"]),
+    );
+    expect(config.sitemap).toBe("https://www.hyperlocalise.com/sitemap.xml");
+  });
+});

--- a/apps/hyperlocalise-web/src/app/robots.test.ts
+++ b/apps/hyperlocalise-web/src/app/robots.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 
+import { SUPPORTED_APP_LOCALES } from "@/lib/app-i18n/locales";
 import robots from "./robots";
 
 describe("robots", () => {
@@ -15,8 +16,12 @@ describe("robots", () => {
       ? config.rules.flatMap((rule) => rule.disallow ?? [])
       : (config.rules?.disallow ?? []);
 
+    const localizedPaths = SUPPORTED_APP_LOCALES.flatMap((locale) => [
+      `/${locale}/dashboard/`,
+      `/${locale}/org/`,
+    ]);
     expect(disallow).toEqual(
-      expect.arrayContaining(["/auth/", "/api/", "/mcp", "/en/dashboard", "/en/org/"]),
+      expect.arrayContaining(["/auth/", "/api/", "/mcp", ...localizedPaths]),
     );
     expect(config.sitemap).toBe("https://www.hyperlocalise.com/sitemap.xml");
   });

--- a/apps/hyperlocalise-web/src/app/robots.ts
+++ b/apps/hyperlocalise-web/src/app/robots.ts
@@ -6,7 +6,7 @@ const BASE_URL = "https://www.hyperlocalise.com";
 
 export default function robots(): MetadataRoute.Robots {
   const protectedLocalizedDisallows = SUPPORTED_APP_LOCALES.flatMap((locale) => [
-    `/${locale}/dashboard`,
+    `/${locale}/dashboard/`,
     `/${locale}/org/`,
   ]);
 

--- a/apps/hyperlocalise-web/src/app/robots.ts
+++ b/apps/hyperlocalise-web/src/app/robots.ts
@@ -1,0 +1,21 @@
+import { MetadataRoute } from "next";
+
+import { SUPPORTED_APP_LOCALES } from "@/lib/app-i18n/locales";
+
+const BASE_URL = "https://www.hyperlocalise.com";
+
+export default function robots(): MetadataRoute.Robots {
+  const protectedLocalizedDisallows = SUPPORTED_APP_LOCALES.flatMap((locale) => [
+    `/${locale}/dashboard`,
+    `/${locale}/org/`,
+  ]);
+
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: ["/auth/", "/api/", "/mcp", ...protectedLocalizedDisallows],
+    },
+    sitemap: `${BASE_URL}/sitemap.xml`,
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a missing `robots.txt` via Next.js metadata route (`src/app/robots.ts`).

## Proxy check

`src/proxy.ts` already excludes `robots.txt` from the middleware matcher, so the proxy was **not** blocking it — the file simply did not exist.

## Behavior

- Allows crawling of public marketing pages (`Allow: /`)
- Disallows auth, API, MCP, and authenticated workspace routes (`/auth/`, `/api/`, `/mcp`, `/en/dashboard`, `/en/org/`)
- Points crawlers to `https://www.hyperlocalise.com/sitemap.xml`

## Testing

- Added `src/app/robots.test.ts`
- `vp test src/app/robots.test.ts`
- `vp check --fix`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-73baedff-cbcc-4671-ac95-f6300cd9040c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73baedff-cbcc-4671-ac95-f6300cd9040c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

