### PR TITLE
fix(web): allow locale redirect for product, use-cases, and blog paths

### DIFF
--- a/apps/hyperlocalise-web/src/proxy.test.ts
+++ b/apps/hyperlocalise-web/src/proxy.test.ts
@@ -34,6 +34,13 @@ describe("isUnsupportedLocalePath", () => {
     expect(isUnsupportedLocalePath("/api/auth/callback")).toBe(false);
   });
 
+  it("allows localized marketing paths without a locale prefix", () => {
+    expect(isUnsupportedLocalePath("/product/agents-automation")).toBe(false);
+    expect(isUnsupportedLocalePath("/use-cases/saas")).toBe(false);
+    expect(isUnsupportedLocalePath("/blog")).toBe(false);
+    expect(isUnsupportedLocalePath("/privacy")).toBe(false);
+  });
+
   it("allows the site root", () => {
     expect(isUnsupportedLocalePath("/")).toBe(false);
   });
@@ -56,6 +63,28 @@ describe("proxy", () => {
 
     expect(authkitProxyMock).toHaveBeenCalledOnce();
     expect(response?.status).toBe(200);
+  });
+
+  it("redirects localized marketing paths without a locale prefix", async () => {
+    authkitProxyMock.mockReset();
+
+    const response = await proxy(createRequest("/product/agents-automation"), {} as never);
+
+    expect(response?.status).toBe(307);
+    expect(response?.headers.get("location")).toBe(
+      "https://www.hyperlocalise.com/en/product/agents-automation",
+    );
+    expect(authkitProxyMock).not.toHaveBeenCalled();
+  });
+
+  it("redirects blog paths without a locale prefix", async () => {
+    authkitProxyMock.mockReset();
+
+    const response = await proxy(createRequest("/blog"), {} as never);
+
+    expect(response?.status).toBe(307);
+    expect(response?.headers.get("location")).toBe("https://www.hyperlocalise.com/en/blog");
+    expect(authkitProxyMock).not.toHaveBeenCalled();
   });
 
   it("delegates /api paths to AuthKit instead of returning 404", async () => {

--- a/apps/hyperlocalise-web/src/proxy.ts
+++ b/apps/hyperlocalise-web/src/proxy.ts
@@ -72,7 +72,16 @@ export function isUnsupportedLocalePath(pathname: string): boolean {
     return false;
   }
 
-  return normalizeAppLocale(firstSegment) === null;
+  if (normalizeAppLocale(firstSegment) !== null) {
+    return false;
+  }
+
+  // Paths like /product or /blog without a locale prefix should redirect, not 404.
+  if (isLocalizedAppPath(pathname)) {
+    return false;
+  }
+
+  return true;
 }
 
 function applyLocaleToResponse(response: WorkosProxyResult, locale: string): WorkosProxyResult {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

`isUnsupportedLocalePath` in `proxy.ts` was returning 404 for `/product`, `/use-cases`, `/blog`, and other localized marketing paths when visited without a locale prefix. Because that check runs before the locale redirect logic, those routes never reached the redirect to `/en/...`.

The fix excludes known localized app paths from the unsupported-locale check so they redirect as intended. Bot-scan paths like `/wp-links.php` still return 404.

## How to test

- `cd apps/hyperlocalise-web && vp test src/proxy.test.ts`
- Visit `/product/agents-automation`, `/use-cases/saas`, and `/blog` — each should redirect to `/en/...` instead of 404
- Visit `/wp-links.php` — should still return 404

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a7ba5df-75ec-480f-bb4d-729747a72fa0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a7ba5df-75ec-480f-bb4d-729747a72fa0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

