### PR TITLE
🧪 Scout: Improve HTML tag parity for flexible self-closing tags

### DIFF
--- a/internal/i18n/htmltagparity/htmltagparity.go
+++ b/internal/i18n/htmltagparity/htmltagparity.go
@@ -84,8 +84,10 @@ func normalizeTagNames(tags []string) []string {
 	out := make([]string, 0, len(tags))
 	for _, tag := range tags {
 		normalized := strings.ToLower(strings.TrimSpace(tag))
-		normalized = strings.TrimSuffix(normalized, "/>")
 		normalized = strings.TrimSuffix(normalized, ">")
+		normalized = strings.TrimSpace(normalized)
+		normalized = strings.TrimSuffix(normalized, "/") // Handle flexible " / >"
+		normalized = strings.TrimSpace(normalized)
 		normalized = strings.TrimPrefix(normalized, "<")
 		parts := strings.Fields(normalized)
 		if len(parts) == 0 {
@@ -155,5 +157,10 @@ func rawTagHasAttributes(raw, rawName string) bool {
 		return false
 	}
 	rest := strings.TrimSpace(inner[len(rawName):])
-	return rest != "" && rest != ">" && rest != "/>"
+	// Strip trailing ">" and flexible self-closing "/"
+	rest = strings.TrimSuffix(rest, ">")
+	rest = strings.TrimSpace(rest)
+	rest = strings.TrimSuffix(rest, "/")
+	rest = strings.TrimSpace(rest)
+	return rest != ""
 }

--- a/internal/i18n/htmltagparity/htmltagparity_test.go
+++ b/internal/i18n/htmltagparity/htmltagparity_test.go
@@ -197,6 +197,30 @@ func TestMismatchFormattingAndKnownTags(t *testing.T) {
 			tgt:  "Content",
 			want: true,
 		},
+		{
+			name: "placeholder with normal self-closing is ignored",
+			src:  "Hello <v1/>",
+			tgt:  "Bonjour",
+			want: false,
+		},
+		{
+			name: "placeholder with space before self-closing is ignored",
+			src:  "Hello <v1 />",
+			tgt:  "Bonjour",
+			want: false,
+		},
+		{
+			name: "placeholder with space after slash (flexible self-closing) is ignored",
+			src:  "Hello <v1 / >",
+			tgt:  "Bonjour",
+			want: false,
+		},
+		{
+			name: "known tag with flexible self-closing is protected",
+			src:  "Hello <br / >",
+			tgt:  "Bonjour",
+			want: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
💡 What: Added unit tests and improved logic for handling flexible whitespace in self-closing HTML tags (e.g., `<v1 />`, `<v1 / >`).
🎯 Why: Translators and various localization formats often use different spacing for self-closing tags. The previous logic was too rigid, leading to false-positive mismatches or incorrect attribute detection for common placeholders like `<v1 />`.
🧩 Scope: `internal/i18n/htmltagparity/htmltagparity.go` and `internal/i18n/htmltagparity/htmltagparity_test.go`.
✅ Verification: Ran `go test ./...` and focused tests in `internal/i18n/htmltagparity`.
🛡️ Confidence: Prevents false-positive tag mismatch warnings when translators use flexible self-closing syntax, matching the behavior already present in the ICU parser.

---
*PR created automatically by Jules for task [7605004237492101632](https://jules.google.com/task/7605004237492101632) started by @cungminh2710*