### PR TITLE
feat(web): add Phrase provider live CAT support

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -486,7 +486,7 @@ export const projectFileCatCommentSchema = z.object({
   type: z.enum(["comment", "issue"]),
   status: z.string().nullable(),
   text: z.string(),
-  createdAt: z.string(),
+  createdAt: z.string().nullable(),
   locale: z.string().nullable(),
   author: z.string().nullable().optional(),
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/tms-job-cat-workspace.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/tms-job-cat-workspace.test.ts
@@ -108,7 +108,7 @@ describe("projectFileCatToWorkspaceState", () => {
       filePath: "en-US.json",
     });
     expect(state.segmentIntelligence?.["issue-string"]?.productMeaning).toContain(
-      "1 Crowdin comment is attached",
+      "1 provider comment is attached",
     );
     expect(state.breadcrumbs).toEqual(["crowdin", "en-US.json", "vi"]);
     expect(state.canEditTranslations).toBe(true);

--- a/apps/hyperlocalise-web/src/components/cat/cat-editor-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-editor-panel.tsx
@@ -503,7 +503,9 @@ export function CatEditorPanel({
                       {comment.author ? (
                         <span className="font-medium text-foreground/78">{comment.author}</span>
                       ) : null}
-                      <span>{formatCommentTimestamp(intl, comment.createdAt)}</span>
+                      {comment.createdAt ? (
+                        <span>{formatCommentTimestamp(intl, comment.createdAt)}</span>
+                      ) : null}
                       {comment.status ? <span className="capitalize">{comment.status}</span> : null}
                     </div>
                     <p className="text-sm leading-relaxed text-foreground/88">{comment.text}</p>

--- a/apps/hyperlocalise-web/src/components/cat/cat-queue-filter.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat-queue-filter.test.ts
@@ -98,6 +98,10 @@ describe("resolveAvailableCatQueueFilters", () => {
   it("includes has issues for Crowdin projects", () => {
     expect(resolveAvailableCatQueueFilters("crowdin")).toContain("has_issues");
   });
+
+  it("includes has issues for Phrase projects", () => {
+    expect(resolveAvailableCatQueueFilters("phrase")).toContain("has_issues");
+  });
 });
 
 describe("resolveVisibleQueueSegments", () => {

--- a/apps/hyperlocalise-web/src/components/cat/cat-queue-filter.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat-queue-filter.ts
@@ -22,7 +22,7 @@ export function isQueueFilterSupportedForProvider(
   providerKind: string | null | undefined,
 ) {
   if (filter === "has_issues") {
-    return providerKind === "crowdin";
+    return providerKind === "crowdin" || providerKind === "phrase";
   }
 
   return true;

--- a/apps/hyperlocalise-web/src/components/cat/project-file-cat-mapper.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file-cat-mapper.ts
@@ -135,16 +135,18 @@ function intelligenceFor(catFile: CatFile): CatSegmentIntelligence {
   );
   const providerKind = catFile.provider?.kind;
 
+  const providerSupportsComments = providerKind === "crowdin" || providerKind === "phrase";
+
   return {
     intent: `Translate ${catFile.filename} into ${catFile.targetLocale}.`,
     locationBreadcrumb: catFile.sourcePath,
     filePath: catFile.sourcePath,
     componentName: catFile.provider?.format ?? providerKind ?? undefined,
     productMeaning:
-      providerKind === "crowdin" && commentCount > 0
-        ? `${commentCount} Crowdin comment${commentCount === 1 ? "" : "s"} are attached to this file, including ${issueCount} issue${issueCount === 1 ? "" : "s"}.`
-        : providerKind === "crowdin"
-          ? "Crowdin did not return comments or issues for this file."
+      providerSupportsComments && commentCount > 0
+        ? `${commentCount} provider comment${commentCount === 1 ? "" : "s"} are attached to this file${providerKind === "crowdin" && issueCount > 0 ? `, including ${issueCount} issue${issueCount === 1 ? "" : "s"}` : ""}.`
+        : providerSupportsComments
+          ? "The provider did not return comments for this file."
           : undefined,
     reviewerPreference: catFile.canEditTranslations
       ? providerKind
@@ -167,6 +169,8 @@ function segmentIntelligenceFor(
   const repositoryContext = segment.repositoryContext?.trim();
   const providerKind = catFile.provider?.kind;
 
+  const providerSupportsComments = providerKind === "crowdin" || providerKind === "phrase";
+
   return {
     intent: `Translate ${segment.key} into ${catFile.targetLocale}.`,
     locationBreadcrumb: segment.key,
@@ -174,10 +178,10 @@ function segmentIntelligenceFor(
     componentName: segment.type ?? catFile.provider?.format ?? providerKind ?? undefined,
     productMeaning:
       context ||
-      (providerKind === "crowdin" && comments > 0
-        ? `${comments} Crowdin comment${comments === 1 ? "" : "s"} ${comments === 1 ? "is" : "are"} attached to this string, including ${issues} issue${issues === 1 ? "" : "s"}.`
-        : providerKind === "crowdin"
-          ? "Crowdin did not return context, comments, or issues for this string."
+      (providerSupportsComments && comments > 0
+        ? `${comments} provider comment${comments === 1 ? "" : "s"} ${comments === 1 ? "is" : "are"} attached to this string${providerKind === "crowdin" && issues > 0 ? `, including ${issues} issue${issues === 1 ? "" : "s"}` : ""}.`
+        : providerSupportsComments
+          ? "The provider did not return context or comments for this string."
           : undefined),
     agentContext: repositoryContext || undefined,
     reviewerPreference: catFile.canEditTranslations
@@ -237,7 +241,10 @@ export function projectFileCatToWorkspaceState(
     breadcrumbs: [catFile.provider?.kind ?? "native", catFile.filename, catFile.targetLocale],
     primaryActionLabel: catFile.provider ? "Save to provider" : "Save translation",
     canEditTranslations: catFile.canEditTranslations,
-    canAddComments: Boolean(catFile.provider?.kind === "crowdin" && catFile.canEditTranslations),
+    canAddComments: Boolean(
+      (catFile.provider?.kind === "crowdin" || catFile.provider?.kind === "phrase") &&
+      catFile.canEditTranslations,
+    ),
     providerKind: catFile.provider?.kind ?? null,
   };
 }

--- a/apps/hyperlocalise-web/src/components/cat/types.ts
+++ b/apps/hyperlocalise-web/src/components/cat/types.ts
@@ -15,7 +15,7 @@ export interface CatSegmentComment {
   type: CatSegmentCommentType;
   status: string | null;
   text: string;
-  createdAt: string;
+  createdAt: string | null;
   locale: string | null;
   author?: string | null;
 }

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-api.test.ts
@@ -102,20 +102,6 @@ describe("PhraseApiClient", () => {
     const fetchMock = vi.fn(async (url: string) => {
       const path = String(url);
 
-      if (path.includes("/keys")) {
-        return new Response(
-          JSON.stringify([
-            {
-              id: "key-1",
-              name: "home.hero.title",
-              tags: ["app"],
-              custom_metadata: { screen: "home" },
-            },
-          ]),
-          { status: 200 },
-        );
-      }
-
       if (path.includes("/uploads")) {
         return new Response(
           JSON.stringify([
@@ -145,6 +131,20 @@ describe("PhraseApiClient", () => {
         );
       }
 
+      if (path.includes("/keys")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "key-1",
+              name: "home.hero.title",
+              tags: ["app"],
+              custom_metadata: { screen: "home" },
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+
       return new Response(JSON.stringify([]), { status: 200 });
     }) as unknown as typeof fetch;
 
@@ -152,6 +152,9 @@ describe("PhraseApiClient", () => {
     const keys = await client.listKeys("proj-1", { branch: "feature" });
     const uploads = await client.listUploads("proj-1", { branch: "feature" });
     const translations = await client.listTranslations("proj-1", "fr", { branch: "feature" });
+    const keyTranslations = await client.listKeyTranslations("proj-1", "key-1", {
+      branch: "feature",
+    });
 
     expect(keys[0]).toMatchObject({
       id: "key-1",
@@ -161,6 +164,12 @@ describe("PhraseApiClient", () => {
     });
     expect(uploads[0]).toMatchObject({ id: "upload-1", filename: "home.json", format: "json" });
     expect(translations[0]).toMatchObject({
+      keyId: "key-1",
+      localeName: "fr",
+      content: "Bonjour",
+      state: "translated",
+    });
+    expect(keyTranslations[0]).toMatchObject({
       keyId: "key-1",
       localeName: "fr",
       content: "Bonjour",

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-api.ts
@@ -416,6 +416,25 @@ export class PhraseApiClient {
     });
   }
 
+  async listKeyTranslations(
+    projectId: string,
+    keyId: string,
+    options: PhraseListOptions = {},
+  ): Promise<PhraseTranslation[]> {
+    return this.paginate({
+      buildPath: (page, perPage) =>
+        this.buildPath(
+          `/projects/${encodeURIComponent(projectId)}/keys/${encodeURIComponent(keyId)}/translations`,
+          {
+            page,
+            per_page: perPage,
+            branch: options.branch,
+          },
+        ),
+      normalize: (record) => normalizePhraseTranslation(record as PhraseTranslationApiRecord),
+    });
+  }
+
   async listScreenshots(
     projectId: string,
     options: PhraseListOptions & { maxItems?: number } = {},

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-api.ts
@@ -312,6 +312,52 @@ export class PhraseApiClient {
     });
   }
 
+  async getKey(
+    projectId: string,
+    keyId: string,
+    options: PhraseListOptions = {},
+  ): Promise<PhraseKey | null> {
+    try {
+      const record = await this.get<PhraseKeyApiRecord>(
+        this.buildPath(
+          `/projects/${encodeURIComponent(projectId)}/keys/${encodeURIComponent(keyId)}`,
+          { branch: options.branch },
+        ),
+      );
+      return normalizePhraseKey(record);
+    } catch (error) {
+      if (error instanceof PhraseApiError && error.status === 404) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  async createKeyComment(
+    projectId: string,
+    keyId: string,
+    input: {
+      message: string;
+      localeName?: string | null;
+    },
+    options: PhraseListOptions = {},
+  ): Promise<PhraseKeyComment> {
+    const payload: Record<string, unknown> = {
+      message: input.message,
+    };
+    if (input.localeName?.trim()) {
+      payload.locale = { name: input.localeName.trim() };
+    }
+
+    const record = await this.post<PhraseKeyCommentApiRecord>(
+      `/projects/${encodeURIComponent(projectId)}/keys/${encodeURIComponent(keyId)}/comments`,
+      payload,
+      { branch: options.branch },
+    );
+
+    return normalizePhraseKeyComment(record);
+  }
+
   async listKeyComments(
     projectId: string,
     keyId: string,

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-live-cat.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-live-cat.test.ts
@@ -1,0 +1,409 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import type { TmsProviderLiveFile } from "@/lib/providers/tms-provider-live";
+
+import {
+  buildPhraseLiveCatFile,
+  savePhraseLiveCatComment,
+  savePhraseLiveCatTranslation,
+} from "./phrase-live-cat";
+
+function createPhraseKeyFile(overrides: Partial<TmsProviderLiveFile> = {}): TmsProviderLiveFile {
+  return {
+    origin: "provider",
+    sourcePath: "keys/home.hero.title",
+    sourceHash: null,
+    commitSha: null,
+    workflowRunId: null,
+    uploadedAt: "2026-06-08T00:00:00Z",
+    storedFileId: null,
+    metadata: {
+      id: "key-1",
+      key: "home.hero.title",
+      branch: null,
+      tags: ["app"],
+    },
+    filename: "home.hero.title",
+    byteSize: null,
+    provider: {
+      kind: "phrase",
+      resourceType: "key",
+      externalProjectId: "project-1",
+      externalResourceId: "key-1",
+      externalUrl: null,
+      syncState: "synced",
+      sourceLocale: "en",
+      targetLocales: ["fr"],
+      localeReadiness: {},
+      revision: null,
+      format: "json",
+      lastSyncedAt: null,
+    },
+    latestJob: null,
+    ...overrides,
+  };
+}
+
+describe("buildPhraseLiveCatFile", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.clearAllMocks();
+  });
+
+  it("loads a single key file with source, target, and comments", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      const path = String(url);
+
+      if (path.includes("/locales")) {
+        return new Response(
+          JSON.stringify([
+            { id: "loc-en", name: "en", code: "en-US", default: true },
+            { id: "loc-fr", name: "fr", code: "fr-FR", default: false },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/keys/key-1") && !path.includes("/comments")) {
+        return new Response(
+          JSON.stringify({
+            id: "key-1",
+            name: "home.hero.title",
+            description: "Hero headline",
+            plural: false,
+            tags: ["app"],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/translations") && path.includes("locale_name=en")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "tr-en",
+              key_id: "key-1",
+              locale_name: "en",
+              content: "Hello",
+              state: "translated",
+              unverified: false,
+              excluded: false,
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/translations") && path.includes("locale_name=fr")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "tr-fr",
+              key_id: "key-1",
+              locale_name: "fr",
+              content: "Bonjour",
+              state: "translated",
+              unverified: false,
+              excluded: false,
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/keys/key-1/comments")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "comment-1",
+              message: "Check tone",
+              has_replies: false,
+              user: { id: "user-1", username: "reviewer", name: "Reviewer" },
+              created_at: "2026-06-08T00:01:00Z",
+              locales: [{ id: "loc-fr", name: "fr", code: "fr-FR" }],
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify([]), { status: 200 });
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const catFile = await buildPhraseLiveCatFile({
+      secretMaterial: "token",
+      externalProjectId: "project-1",
+      file: createPhraseKeyFile(),
+      targetLocale: "fr",
+      canEditTranslations: true,
+    });
+
+    expect(catFile.segments).toHaveLength(1);
+    expect(catFile.segments[0]).toMatchObject({
+      externalStringId: "key-1",
+      key: "home.hero.title",
+      sourceText: "Hello",
+      context: "Hero headline",
+      target: {
+        text: "Bonjour",
+        externalTranslationId: "tr-fr",
+        isApproved: true,
+      },
+      comments: [{ externalCommentId: "comment-1", type: "comment", text: "Check tone" }],
+    });
+    expect(catFile.queueSummary).toMatchObject({
+      total: 1,
+      reviewed: 1,
+      hasIssues: 1,
+    });
+  });
+
+  it("filters upload-scoped keys by tags and paginates search results", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      const path = String(url);
+
+      if (path.includes("/locales")) {
+        return new Response(
+          JSON.stringify([
+            { id: "loc-en", name: "en", code: "en-US", default: true },
+            { id: "loc-fr", name: "fr", code: "fr-FR", default: false },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/keys?")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "key-hero",
+              name: "home.hero.title",
+              description: null,
+              plural: false,
+              tags: ["app"],
+            },
+            {
+              id: "key-footer",
+              name: "home.footer.title",
+              description: null,
+              plural: false,
+              tags: ["marketing"],
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/translations") && path.includes("locale_name=en")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "tr-en-hero",
+              key_id: "key-hero",
+              locale_name: "en",
+              content: "Hero",
+              state: "translated",
+              unverified: false,
+              excluded: false,
+            },
+            {
+              id: "tr-en-footer",
+              key_id: "key-footer",
+              locale_name: "en",
+              content: "Footer",
+              state: "translated",
+              unverified: false,
+              excluded: false,
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/translations") && path.includes("locale_name=fr")) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+
+      if (path.includes("/comments")) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+
+      return new Response(JSON.stringify([]), { status: 200 });
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const catFile = await buildPhraseLiveCatFile({
+      secretMaterial: "token",
+      externalProjectId: "project-1",
+      file: createPhraseKeyFile({
+        sourcePath: "locales/en/home.json",
+        filename: "home.json",
+        metadata: {
+          id: "upload-1",
+          name: "home.json",
+          branch: null,
+          tags: ["app"],
+        },
+        provider: {
+          kind: "phrase",
+          resourceType: "file",
+          externalProjectId: "project-1",
+          externalResourceId: "upload-1",
+          externalUrl: null,
+          syncState: "synced",
+          sourceLocale: "en",
+          targetLocales: ["fr"],
+          localeReadiness: {},
+          revision: null,
+          format: "json",
+          lastSyncedAt: null,
+        },
+      }),
+      targetLocale: "fr",
+      canEditTranslations: true,
+      pagination: {
+        offset: 0,
+        limit: 10,
+        search: "hero",
+        queueFilter: "untranslated",
+        paginated: true,
+      },
+    });
+
+    expect(catFile.segments).toHaveLength(1);
+    expect(catFile.segments[0]?.key).toBe("home.hero.title");
+    expect(catFile.pagination).toMatchObject({
+      offset: 0,
+      limit: 10,
+      returnedCount: 1,
+      totalCount: 1,
+      hasMore: false,
+    });
+    expect(catFile.queueSummary).toMatchObject({
+      total: 1,
+      untranslated: 1,
+    });
+  });
+});
+
+describe("savePhraseLiveCatTranslation", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.clearAllMocks();
+  });
+
+  it("upserts a verified translation for the target locale", async () => {
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      const path = String(url);
+
+      if (path.includes("/locales")) {
+        return new Response(
+          JSON.stringify([
+            { id: "loc-en", name: "en", code: "en-US", default: true },
+            { id: "loc-fr", name: "fr", code: "fr-FR", default: false },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/translations") && init?.method === "POST") {
+        return new Response(
+          JSON.stringify({
+            id: "tr-fr-new",
+            key_id: "key-1",
+            locale_name: "fr",
+            content: "Bonjour amélioré",
+            state: "translated",
+            unverified: false,
+            excluded: false,
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify([]), { status: 200 });
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const translation = await savePhraseLiveCatTranslation({
+      secretMaterial: "token",
+      externalProjectId: "project-1",
+      file: createPhraseKeyFile(),
+      targetLocale: "fr",
+      externalStringId: "key-1",
+      text: "Bonjour amélioré",
+    });
+
+    expect(translation).toEqual({
+      text: "Bonjour amélioré",
+      externalTranslationId: "tr-fr-new",
+      isApproved: true,
+    });
+  });
+});
+
+describe("savePhraseLiveCatComment", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.clearAllMocks();
+  });
+
+  it("creates a key comment in Phrase", async () => {
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      const path = String(url);
+
+      if (path.includes("/comments") && init?.method === "POST") {
+        return new Response(
+          JSON.stringify({
+            id: "comment-new",
+            message: "Please review wording",
+            has_replies: false,
+            user: { id: "user-1", username: "editor", name: "Editor" },
+            created_at: "2026-06-08T00:02:00Z",
+            locales: [{ id: "loc-fr", name: "fr", code: "fr-FR" }],
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify([]), { status: 200 });
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const comment = await savePhraseLiveCatComment({
+      secretMaterial: "token",
+      externalProjectId: "project-1",
+      file: createPhraseKeyFile(),
+      targetLocale: "fr",
+      externalStringId: "key-1",
+      text: "Please review wording",
+    });
+
+    expect(comment).toMatchObject({
+      externalCommentId: "comment-new",
+      type: "comment",
+      text: "Please review wording",
+      locale: "fr-FR",
+      author: "Editor",
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-live-cat.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-live-cat.test.ts
@@ -71,7 +71,11 @@ describe("buildPhraseLiveCatFile", () => {
         );
       }
 
-      if (path.includes("/keys/key-1") && !path.includes("/comments") && !path.includes("/translations")) {
+      if (
+        path.includes("/keys/key-1") &&
+        !path.includes("/comments") &&
+        !path.includes("/translations")
+      ) {
         return new Response(
           JSON.stringify({
             id: "key-1",
@@ -498,11 +502,28 @@ describe("savePhraseLiveCatComment", () => {
     vi.clearAllMocks();
   });
 
-  it("creates a key comment in Phrase", async () => {
+  it("creates a key comment in Phrase with the resolved locale name", async () => {
     const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
       const path = String(url);
 
+      if (path.includes("/locales")) {
+        return new Response(
+          JSON.stringify([
+            { id: "loc-en", name: "en", code: "en-US", default: true },
+            { id: "loc-fr", name: "fr", code: "fr-FR", default: false },
+          ]),
+          { status: 200 },
+        );
+      }
+
       if (path.includes("/comments") && init?.method === "POST") {
+        const rawBody = init.body;
+        const body =
+          typeof rawBody === "string"
+            ? (JSON.parse(rawBody) as { locale?: { name?: string } })
+            : {};
+        expect(body.locale?.name).toBe("fr");
+
         return new Response(
           JSON.stringify({
             id: "comment-new",
@@ -524,7 +545,7 @@ describe("savePhraseLiveCatComment", () => {
       secretMaterial: "token",
       externalProjectId: "project-1",
       file: createPhraseKeyFile(),
-      targetLocale: "fr",
+      targetLocale: "fr-FR",
       externalStringId: "key-1",
       text: "Please review wording",
     });
@@ -536,5 +557,35 @@ describe("savePhraseLiveCatComment", () => {
       locale: "fr-FR",
       author: "Editor",
     });
+  });
+
+  it("throws when creating a comment for an unmatched target locale", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      const path = String(url);
+
+      if (path.includes("/locales")) {
+        return new Response(
+          JSON.stringify([
+            { id: "loc-en", name: "en", code: "en-US", default: true },
+            { id: "loc-de", name: "de", code: "de-DE", default: false },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify([]), { status: 200 });
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await expect(
+      savePhraseLiveCatComment({
+        secretMaterial: "token",
+        externalProjectId: "project-1",
+        file: createPhraseKeyFile(),
+        targetLocale: "fr-FR",
+        externalStringId: "key-1",
+        text: "Please review wording",
+      }),
+    ).rejects.toBeInstanceOf(PhraseLiveCatError);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-live-cat.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-live-cat.test.ts
@@ -4,6 +4,7 @@ import type { TmsProviderLiveFile } from "@/lib/providers/tms-provider-live";
 
 import {
   buildPhraseLiveCatFile,
+  PhraseLiveCatError,
   savePhraseLiveCatComment,
   savePhraseLiveCatTranslation,
 } from "./phrase-live-cat";
@@ -70,7 +71,7 @@ describe("buildPhraseLiveCatFile", () => {
         );
       }
 
-      if (path.includes("/keys/key-1") && !path.includes("/comments")) {
+      if (path.includes("/keys/key-1") && !path.includes("/comments") && !path.includes("/translations")) {
         return new Response(
           JSON.stringify({
             id: "key-1",
@@ -83,7 +84,7 @@ describe("buildPhraseLiveCatFile", () => {
         );
       }
 
-      if (path.includes("/translations") && path.includes("locale_name=en")) {
+      if (path.includes("/keys/key-1/translations")) {
         return new Response(
           JSON.stringify([
             {
@@ -95,14 +96,6 @@ describe("buildPhraseLiveCatFile", () => {
               unverified: false,
               excluded: false,
             },
-          ]),
-          { status: 200 },
-        );
-      }
-
-      if (path.includes("/translations") && path.includes("locale_name=fr")) {
-        return new Response(
-          JSON.stringify([
             {
               id: "tr-fr",
               key_id: "key-1",
@@ -115,6 +108,10 @@ describe("buildPhraseLiveCatFile", () => {
           ]),
           { status: 200 },
         );
+      }
+
+      if (path.includes("/translations")) {
+        return new Response(JSON.stringify([]), { status: 200 });
       }
 
       if (path.includes("/keys/key-1/comments")) {
@@ -201,7 +198,7 @@ describe("buildPhraseLiveCatFile", () => {
         );
       }
 
-      if (path.includes("/translations") && path.includes("locale_name=en")) {
+      if (path.includes("/keys/key-hero/translations")) {
         return new Response(
           JSON.stringify([
             {
@@ -213,6 +210,14 @@ describe("buildPhraseLiveCatFile", () => {
               unverified: false,
               excluded: false,
             },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/keys/key-footer/translations")) {
+        return new Response(
+          JSON.stringify([
             {
               id: "tr-en-footer",
               key_id: "key-footer",
@@ -227,7 +232,7 @@ describe("buildPhraseLiveCatFile", () => {
         );
       }
 
-      if (path.includes("/translations") && path.includes("locale_name=fr")) {
+      if (path.includes("/translations")) {
         return new Response(JSON.stringify([]), { status: 200 });
       }
 
@@ -291,6 +296,102 @@ describe("buildPhraseLiveCatFile", () => {
       untranslated: 1,
     });
   });
+
+  it("throws when the requested target locale cannot be matched", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      const path = String(url);
+
+      if (path.includes("/locales")) {
+        return new Response(
+          JSON.stringify([
+            { id: "loc-en", name: "en", code: "en-US", default: true },
+            { id: "loc-de", name: "de", code: "de-DE", default: false },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify([]), { status: 200 });
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await expect(
+      buildPhraseLiveCatFile({
+        secretMaterial: "token",
+        externalProjectId: "project-1",
+        file: createPhraseKeyFile(),
+        targetLocale: "fr-FR",
+        canEditTranslations: true,
+      }),
+    ).rejects.toMatchObject({
+      code: "phrase_target_locale_not_found",
+    });
+  });
+
+  it("leaves comment timestamps null when Phrase omits created and updated times", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      const path = String(url);
+
+      if (path.includes("/locales")) {
+        return new Response(
+          JSON.stringify([
+            { id: "loc-en", name: "en", code: "en-US", default: true },
+            { id: "loc-fr", name: "fr", code: "fr-FR", default: false },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      if (
+        path.includes("/keys/key-1") &&
+        !path.includes("/comments") &&
+        !path.includes("/translations")
+      ) {
+        return new Response(
+          JSON.stringify({
+            id: "key-1",
+            name: "home.hero.title",
+            description: null,
+            plural: false,
+            tags: ["app"],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/keys/key-1/translations")) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+
+      if (path.includes("/keys/key-1/comments")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "comment-1",
+              message: "Check tone",
+              has_replies: false,
+              user: { id: "user-1", username: "reviewer", name: "Reviewer" },
+              locales: [{ id: "loc-fr", name: "fr", code: "fr-FR" }],
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify([]), { status: 200 });
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const catFile = await buildPhraseLiveCatFile({
+      secretMaterial: "token",
+      externalProjectId: "project-1",
+      file: createPhraseKeyFile(),
+      targetLocale: "fr",
+      canEditTranslations: true,
+    });
+
+    expect(catFile.segments[0]?.comments[0]?.createdAt).toBeNull();
+  });
 });
 
 describe("savePhraseLiveCatTranslation", () => {
@@ -352,6 +453,36 @@ describe("savePhraseLiveCatTranslation", () => {
       externalTranslationId: "tr-fr-new",
       isApproved: true,
     });
+  });
+
+  it("throws when saving to an unmatched target locale", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      const path = String(url);
+
+      if (path.includes("/locales")) {
+        return new Response(
+          JSON.stringify([
+            { id: "loc-en", name: "en", code: "en-US", default: true },
+            { id: "loc-de", name: "de", code: "de-DE", default: false },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify([]), { status: 200 });
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await expect(
+      savePhraseLiveCatTranslation({
+        secretMaterial: "token",
+        externalProjectId: "project-1",
+        file: createPhraseKeyFile(),
+        targetLocale: "fr-FR",
+        externalStringId: "key-1",
+        text: "Bonjour",
+      }),
+    ).rejects.toBeInstanceOf(PhraseLiveCatError);
   });
 });
 

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-live-cat.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-live-cat.ts
@@ -140,6 +140,18 @@ function mapPhraseTargetTranslation(
   };
 }
 
+function resolvePhraseTargetLocale(targetLocale: string, locales: PhraseLocale[]): PhraseLocale {
+  const matched = matchPhraseTargetLocale(targetLocale, locales);
+  if (!matched) {
+    throw new PhraseLiveCatError(
+      "phrase_target_locale_not_found",
+      `Target locale "${targetLocale}" was not found in the Phrase project.`,
+    );
+  }
+
+  return matched;
+}
+
 function mapPhraseKeyComment(
   comment: {
     id: string;
@@ -159,7 +171,7 @@ function mapPhraseKeyComment(
     type: "comment",
     status: null,
     text: comment.message,
-    createdAt: comment.createdAt ?? comment.updatedAt ?? new Date().toISOString(),
+    createdAt: comment.createdAt ?? comment.updatedAt ?? null,
     locale,
     author: comment.user?.name ?? comment.user?.username ?? null,
   };
@@ -204,30 +216,32 @@ function segmentMatchesSearch(segment: PhraseCatSegmentDraft, search: string | u
 async function loadTranslationsByKeyId(input: {
   client: ReturnType<typeof createPhraseStringsApiClient>;
   projectId: string;
-  locales: PhraseLocale[];
+  localeNames: Set<string>;
   branch: string | null;
-  keyIds: Set<string>;
+  keyIds: string[];
 }) {
   const translationsByKeyId = new Map<string, Map<string, PhraseTranslation>>();
   const listOptions = input.branch ? { branch: input.branch } : {};
+  if (input.keyIds.length === 0) {
+    return translationsByKeyId;
+  }
 
-  await mapWithConcurrency(input.locales, LOCALE_FETCH_CONCURRENCY, async (locale) => {
+  await mapWithConcurrency(input.keyIds, LOCALE_FETCH_CONCURRENCY, async (keyId) => {
     try {
-      const translations = await input.client.listTranslations(
+      const translations = await input.client.listKeyTranslations(
         input.projectId,
-        locale.name,
+        keyId,
         listOptions,
       );
 
       for (const translation of translations) {
-        if (!translation.keyId || !input.keyIds.has(translation.keyId)) {
+        if (!translation.localeName || !input.localeNames.has(translation.localeName)) {
           continue;
         }
 
-        const byLocale =
-          translationsByKeyId.get(translation.keyId) ?? new Map<string, PhraseTranslation>();
-        byLocale.set(locale.name, translation);
-        translationsByKeyId.set(translation.keyId, byLocale);
+        const byLocale = translationsByKeyId.get(keyId) ?? new Map<string, PhraseTranslation>();
+        byLocale.set(translation.localeName, translation);
+        translationsByKeyId.set(keyId, byLocale);
       }
     } catch (error) {
       mapPhraseApiError(error);
@@ -363,15 +377,7 @@ export async function buildPhraseLiveCatFile(input: {
   }
 
   const sourceLocale = locales.find((locale) => locale.default) ?? null;
-  const targetLocale =
-    matchPhraseTargetLocale(input.targetLocale, locales) ??
-    locales.find((locale) => !locale.default);
-  if (!targetLocale) {
-    throw new PhraseLiveCatError(
-      "phrase_target_locale_not_found",
-      "Target locale was not found in the Phrase project.",
-    );
-  }
+  const targetLocale = resolvePhraseTargetLocale(input.targetLocale, locales);
 
   const scopedKeys = await resolveScopedKeys({
     client,
@@ -379,15 +385,17 @@ export async function buildPhraseLiveCatFile(input: {
     branch: scope.branch,
     file: input.file,
   });
-  const keyIds = new Set(scopedKeys.map((key) => key.id));
-  const localesToLoad = [sourceLocale, targetLocale].filter(
-    (locale): locale is PhraseLocale => locale != null,
+  const keyIds = scopedKeys.map((key) => key.id);
+  const localeNames = new Set(
+    [sourceLocale, targetLocale]
+      .filter((locale): locale is PhraseLocale => locale != null)
+      .map((locale) => locale.name),
   );
 
   const translationsByKeyId = await loadTranslationsByKeyId({
     client,
     projectId: scope.stringsProjectId,
-    locales: localesToLoad,
+    localeNames,
     branch: scope.branch,
     keyIds,
   });
@@ -509,15 +517,7 @@ export async function savePhraseLiveCatTranslation(input: {
     mapPhraseApiError(error);
   }
 
-  const targetLocale =
-    matchPhraseTargetLocale(input.targetLocale, locales) ??
-    locales.find((locale) => !locale.default);
-  if (!targetLocale) {
-    throw new PhraseLiveCatError(
-      "phrase_target_locale_not_found",
-      "Target locale was not found in the Phrase project.",
-    );
-  }
+  const targetLocale = resolvePhraseTargetLocale(input.targetLocale, locales);
 
   let saved: PhraseTranslation;
   try {
@@ -563,7 +563,7 @@ export async function savePhraseLiveCatComment(input: {
   });
   const listOptions = scope.branch ? { branch: scope.branch } : {};
 
-  let created;
+  let created: Awaited<ReturnType<typeof client.createKeyComment>>;
   try {
     created = await client.createKeyComment(
       scope.stringsProjectId,

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-live-cat.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-live-cat.ts
@@ -563,6 +563,15 @@ export async function savePhraseLiveCatComment(input: {
   });
   const listOptions = scope.branch ? { branch: scope.branch } : {};
 
+  let locales: PhraseLocale[];
+  try {
+    locales = await client.listLocales(scope.stringsProjectId, listOptions);
+  } catch (error) {
+    mapPhraseApiError(error);
+  }
+
+  const resolvedLocale = resolvePhraseTargetLocale(input.targetLocale, locales);
+
   let created: Awaited<ReturnType<typeof client.createKeyComment>>;
   try {
     created = await client.createKeyComment(
@@ -570,7 +579,7 @@ export async function savePhraseLiveCatComment(input: {
       input.externalStringId,
       {
         message: input.text,
-        localeName: input.targetLocale,
+        localeName: resolvedLocale.name,
       },
       listOptions,
     );

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-live-cat.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-live-cat.ts
@@ -1,0 +1,582 @@
+import type {
+  ProjectFileCatComment,
+  ProjectFileCatQueueSummary,
+  ProjectFileCatResponse,
+  ProjectFileCatTranslation,
+} from "@/api/routes/project/project.schema";
+import { legacyProviderCatSegmentLimit } from "@/api/routes/project/project.schema";
+import {
+  buildCatFilePagination,
+  type ProjectFileCatPaginationInput,
+} from "@/lib/projects/cat/project-file-cat-pagination";
+import { mapWithConcurrency } from "@/lib/primitives/map-with-concurrency/map-with-concurrency";
+import type { TmsProviderLiveFile } from "@/lib/providers/tms-provider-live";
+
+import {
+  PhraseApiError,
+  type PhraseKey,
+  type PhraseLocale,
+  type PhraseTranslation,
+} from "./phrase-api";
+import {
+  matchPhraseTargetLocale,
+  resolvePhraseBranch,
+  resolvePhraseStringsProjectId,
+} from "./phrase-job-context";
+import {
+  mapPhraseTranslationReadiness,
+  parsePhraseExternalResourceId,
+} from "./phrase-locale-readiness";
+import { createPhraseStringsApiClient } from "./phrase-strings-client";
+
+const LOCALE_FETCH_CONCURRENCY = 8;
+const COMMENT_FETCH_CONCURRENCY = 8;
+
+export class PhraseLiveCatError extends Error {
+  constructor(
+    readonly code: string,
+    message?: string,
+  ) {
+    super(message ?? code);
+    this.name = "PhraseLiveCatError";
+  }
+}
+
+type PhraseLiveCatContext = {
+  token: string;
+  region?: string | null;
+  baseUrl?: string | null;
+  stringsProjectId: string;
+  branch: string | null;
+};
+
+type PhraseCatSegmentDraft = {
+  externalStringId: string;
+  key: string;
+  sourceText: string;
+  context: string | null;
+  type: string | null;
+  target: ProjectFileCatTranslation | null;
+  comments: ProjectFileCatComment[];
+};
+
+function mapPhraseApiError(error: unknown): never {
+  if (error instanceof PhraseApiError && error.status === 401) {
+    throw new PhraseLiveCatError("phrase_auth_invalid", "Phrase credentials are invalid.");
+  }
+  throw error;
+}
+
+function readFileMetadata(file: TmsProviderLiveFile) {
+  const payload = file.metadata ?? {};
+  const branch =
+    typeof payload.branch === "string" && payload.branch.trim() ? payload.branch.trim() : null;
+  const tags = Array.isArray(payload.tags)
+    ? payload.tags.filter((tag): tag is string => typeof tag === "string" && tag.trim().length > 0)
+    : [];
+
+  return { branch, tags };
+}
+
+function resolvePhraseLiveCatContext(input: {
+  file: TmsProviderLiveFile;
+  externalProjectId: string;
+  secretMaterial: string;
+  region?: string | null;
+  baseUrl?: string | null;
+}): PhraseLiveCatContext {
+  const stringsProjectId = resolvePhraseStringsProjectId(
+    { providerMetadata: {} },
+    input.externalProjectId,
+  );
+  if (!stringsProjectId) {
+    throw new PhraseLiveCatError(
+      "invalid_phrase_project_id",
+      "Phrase project identifier is invalid.",
+    );
+  }
+
+  const metadata = readFileMetadata(input.file);
+  const parsedResource = parsePhraseExternalResourceId(
+    input.file.provider?.externalResourceId ?? "",
+  );
+
+  return {
+    token: input.secretMaterial,
+    region: input.region,
+    baseUrl: input.baseUrl,
+    stringsProjectId,
+    branch:
+      metadata.branch ?? parsedResource.branch ?? resolvePhraseBranch({ providerMetadata: {} }),
+  };
+}
+
+function phraseTranslationIsApproved(translation: PhraseTranslation | null | undefined) {
+  if (!translation) {
+    return false;
+  }
+
+  return (
+    mapPhraseTranslationReadiness({
+      content: translation.content,
+      state: translation.state,
+      unverified: translation.unverified,
+      excluded: translation.excluded,
+    }) === "ready"
+  );
+}
+
+function mapPhraseTargetTranslation(
+  translation: PhraseTranslation | null | undefined,
+): ProjectFileCatTranslation | null {
+  if (!translation?.content?.trim()) {
+    return null;
+  }
+
+  return {
+    text: translation.content,
+    externalTranslationId: translation.id,
+    isApproved: phraseTranslationIsApproved(translation),
+  };
+}
+
+function mapPhraseKeyComment(
+  comment: {
+    id: string;
+    message: string;
+    createdAt: string | null;
+    updatedAt: string | null;
+    user: { username: string | null; name: string | null } | null;
+    locales: Array<{ name: string; code: string | null }>;
+  },
+  targetLocale: string,
+): ProjectFileCatComment {
+  const locale =
+    comment.locales[0]?.code?.trim() || comment.locales[0]?.name?.trim() || targetLocale || null;
+
+  return {
+    externalCommentId: comment.id,
+    type: "comment",
+    status: null,
+    text: comment.message,
+    createdAt: comment.createdAt ?? comment.updatedAt ?? new Date().toISOString(),
+    locale,
+    author: comment.user?.name ?? comment.user?.username ?? null,
+  };
+}
+
+function segmentMatchesQueueFilter(
+  segment: PhraseCatSegmentDraft,
+  filter: ProjectFileCatPaginationInput["queueFilter"],
+) {
+  const hasComments = segment.comments.length > 0;
+  const isApproved = segment.target?.isApproved ?? false;
+  const hasTarget = Boolean(segment.target?.text?.trim());
+
+  switch (filter) {
+    case "untranslated":
+      return !hasTarget;
+    case "needs_review":
+      return hasTarget && !isApproved;
+    case "reviewed":
+      return isApproved;
+    case "has_issues":
+      return hasComments;
+    case "all":
+    default:
+      return true;
+  }
+}
+
+function segmentMatchesSearch(segment: PhraseCatSegmentDraft, search: string | undefined) {
+  const query = search?.trim().toLowerCase();
+  if (!query) {
+    return true;
+  }
+
+  return (
+    segment.key.toLowerCase().includes(query) ||
+    segment.sourceText.toLowerCase().includes(query) ||
+    (segment.target?.text?.toLowerCase().includes(query) ?? false)
+  );
+}
+
+async function loadTranslationsByKeyId(input: {
+  client: ReturnType<typeof createPhraseStringsApiClient>;
+  projectId: string;
+  locales: PhraseLocale[];
+  branch: string | null;
+  keyIds: Set<string>;
+}) {
+  const translationsByKeyId = new Map<string, Map<string, PhraseTranslation>>();
+  const listOptions = input.branch ? { branch: input.branch } : {};
+
+  await mapWithConcurrency(input.locales, LOCALE_FETCH_CONCURRENCY, async (locale) => {
+    try {
+      const translations = await input.client.listTranslations(
+        input.projectId,
+        locale.name,
+        listOptions,
+      );
+
+      for (const translation of translations) {
+        if (!translation.keyId || !input.keyIds.has(translation.keyId)) {
+          continue;
+        }
+
+        const byLocale =
+          translationsByKeyId.get(translation.keyId) ?? new Map<string, PhraseTranslation>();
+        byLocale.set(locale.name, translation);
+        translationsByKeyId.set(translation.keyId, byLocale);
+      }
+    } catch (error) {
+      mapPhraseApiError(error);
+    }
+  });
+
+  return translationsByKeyId;
+}
+
+async function resolveScopedKeys(input: {
+  client: ReturnType<typeof createPhraseStringsApiClient>;
+  stringsProjectId: string;
+  branch: string | null;
+  file: TmsProviderLiveFile;
+}) {
+  const listOptions = input.branch ? { branch: input.branch } : {};
+  const resourceType = input.file.provider?.resourceType;
+  const parsedResource = parsePhraseExternalResourceId(
+    input.file.provider?.externalResourceId ?? "",
+  );
+  const metadata = readFileMetadata(input.file);
+
+  if (resourceType === "key") {
+    const key =
+      (await input.client.getKey(input.stringsProjectId, parsedResource.resourceId, listOptions)) ??
+      null;
+    return key ? [key] : [];
+  }
+
+  let keys: PhraseKey[];
+  try {
+    keys = await input.client.listKeys(input.stringsProjectId, listOptions);
+  } catch (error) {
+    mapPhraseApiError(error);
+  }
+
+  if (metadata.tags.length === 0) {
+    return keys;
+  }
+
+  return keys.filter((key) => key.tags.some((tag) => metadata.tags.includes(tag)));
+}
+
+function buildSegmentDrafts(input: {
+  keys: PhraseKey[];
+  sourceLocale: PhraseLocale | null;
+  targetLocale: PhraseLocale;
+  targetLocaleCode: string;
+  translationsByKeyId: Map<string, Map<string, PhraseTranslation>>;
+  commentsByKeyId: Map<string, ProjectFileCatComment[]>;
+}): PhraseCatSegmentDraft[] {
+  return input.keys.map((key) => {
+    const translationsByLocale = input.translationsByKeyId.get(key.id);
+    const sourceTranslation = input.sourceLocale
+      ? translationsByLocale?.get(input.sourceLocale.name)
+      : null;
+    const targetTranslation = translationsByLocale?.get(input.targetLocale.name);
+
+    return {
+      externalStringId: key.id,
+      key: key.name,
+      sourceText: sourceTranslation?.content?.trim() || key.name,
+      context: key.description,
+      type: key.dataType,
+      target: mapPhraseTargetTranslation(targetTranslation),
+      comments: input.commentsByKeyId.get(key.id) ?? [],
+    };
+  });
+}
+
+function buildQueueSummary(segments: PhraseCatSegmentDraft[]): ProjectFileCatQueueSummary {
+  let reviewed = 0;
+  let untranslated = 0;
+  let needsReview = 0;
+  let hasIssues = 0;
+
+  for (const segment of segments) {
+    const hasTarget = Boolean(segment.target?.text?.trim());
+    const isApproved = segment.target?.isApproved ?? false;
+    const hasComments = segment.comments.length > 0;
+
+    if (!hasTarget) {
+      untranslated += 1;
+    } else if (isApproved) {
+      reviewed += 1;
+    } else {
+      needsReview += 1;
+    }
+
+    if (hasComments) {
+      hasIssues += 1;
+    }
+  }
+
+  return {
+    total: segments.length,
+    reviewed,
+    untranslated,
+    needsReview,
+    hasIssues,
+  };
+}
+
+export async function buildPhraseLiveCatFile(input: {
+  secretMaterial: string;
+  region?: string | null;
+  baseUrl?: string | null;
+  externalProjectId: string;
+  file: TmsProviderLiveFile;
+  targetLocale: string;
+  canEditTranslations: boolean;
+  pagination?: ProjectFileCatPaginationInput;
+}): Promise<ProjectFileCatResponse["catFile"]> {
+  const scope = resolvePhraseLiveCatContext({
+    file: input.file,
+    externalProjectId: input.externalProjectId,
+    secretMaterial: input.secretMaterial,
+    region: input.region,
+    baseUrl: input.baseUrl,
+  });
+  const client = createPhraseStringsApiClient({
+    token: scope.token,
+    region: scope.region,
+    baseUrl: scope.baseUrl,
+  });
+  const listOptions = scope.branch ? { branch: scope.branch } : {};
+
+  let locales: PhraseLocale[];
+  try {
+    locales = await client.listLocales(scope.stringsProjectId, listOptions);
+  } catch (error) {
+    mapPhraseApiError(error);
+  }
+
+  const sourceLocale = locales.find((locale) => locale.default) ?? null;
+  const targetLocale =
+    matchPhraseTargetLocale(input.targetLocale, locales) ??
+    locales.find((locale) => !locale.default);
+  if (!targetLocale) {
+    throw new PhraseLiveCatError(
+      "phrase_target_locale_not_found",
+      "Target locale was not found in the Phrase project.",
+    );
+  }
+
+  const scopedKeys = await resolveScopedKeys({
+    client,
+    stringsProjectId: scope.stringsProjectId,
+    branch: scope.branch,
+    file: input.file,
+  });
+  const keyIds = new Set(scopedKeys.map((key) => key.id));
+  const localesToLoad = [sourceLocale, targetLocale].filter(
+    (locale): locale is PhraseLocale => locale != null,
+  );
+
+  const translationsByKeyId = await loadTranslationsByKeyId({
+    client,
+    projectId: scope.stringsProjectId,
+    locales: localesToLoad,
+    branch: scope.branch,
+    keyIds,
+  });
+
+  const commentsByKeyId = new Map<string, ProjectFileCatComment[]>();
+  await mapWithConcurrency(scopedKeys, COMMENT_FETCH_CONCURRENCY, async (key) => {
+    try {
+      const comments = await client.listKeyComments(scope.stringsProjectId, key.id, listOptions);
+      if (comments.length === 0) {
+        return;
+      }
+
+      commentsByKeyId.set(
+        key.id,
+        comments.map((comment) => mapPhraseKeyComment(comment, input.targetLocale)),
+      );
+    } catch (error) {
+      if (error instanceof PhraseApiError && error.status === 404) {
+        return;
+      }
+      mapPhraseApiError(error);
+    }
+  });
+
+  const allSegments = buildSegmentDrafts({
+    keys: scopedKeys,
+    sourceLocale,
+    targetLocale,
+    targetLocaleCode: input.targetLocale,
+    translationsByKeyId,
+    commentsByKeyId,
+  });
+
+  const paginationInput = input.pagination ?? {
+    offset: 0,
+    limit: legacyProviderCatSegmentLimit,
+    search: undefined,
+    queueFilter: "all",
+    paginated: false,
+  };
+
+  const queueSummary = buildQueueSummary(allSegments);
+  const filteredSegments = allSegments.filter(
+    (segment) =>
+      segmentMatchesQueueFilter(segment, paginationInput.queueFilter) &&
+      segmentMatchesSearch(segment, paginationInput.search),
+  );
+
+  if (!paginationInput.paginated) {
+    const truncated = filteredSegments.length > legacyProviderCatSegmentLimit;
+    const visibleSegments = truncated
+      ? filteredSegments.slice(0, legacyProviderCatSegmentLimit)
+      : filteredSegments;
+
+    return {
+      sourcePath: input.file.sourcePath,
+      filename: input.file.filename,
+      provider: input.file.provider,
+      targetLocale: input.targetLocale,
+      canEditTranslations: input.canEditTranslations,
+      truncated,
+      queueSummary,
+      segments: visibleSegments,
+    };
+  }
+
+  const offset = paginationInput.offset;
+  const limit = paginationInput.limit;
+  const pageSegments = filteredSegments.slice(offset, offset + limit);
+  const pagination = buildCatFilePagination({
+    offset,
+    limit,
+    returnedCount: pageSegments.length,
+    totalCount: filteredSegments.length,
+    hasMore: offset + pageSegments.length < filteredSegments.length,
+  });
+
+  return {
+    sourcePath: input.file.sourcePath,
+    filename: input.file.filename,
+    provider: input.file.provider,
+    targetLocale: input.targetLocale,
+    canEditTranslations: input.canEditTranslations,
+    truncated: pagination.hasMore,
+    pagination,
+    queueSummary,
+    segments: pageSegments,
+  };
+}
+
+export async function savePhraseLiveCatTranslation(input: {
+  secretMaterial: string;
+  region?: string | null;
+  baseUrl?: string | null;
+  externalProjectId: string;
+  file: TmsProviderLiveFile;
+  targetLocale: string;
+  externalStringId: string;
+  text: string;
+}): Promise<ProjectFileCatTranslation> {
+  const scope = resolvePhraseLiveCatContext({
+    file: input.file,
+    externalProjectId: input.externalProjectId,
+    secretMaterial: input.secretMaterial,
+    region: input.region,
+    baseUrl: input.baseUrl,
+  });
+  const client = createPhraseStringsApiClient({
+    token: scope.token,
+    region: scope.region,
+    baseUrl: scope.baseUrl,
+  });
+  const listOptions = scope.branch ? { branch: scope.branch } : {};
+
+  let locales: PhraseLocale[];
+  try {
+    locales = await client.listLocales(scope.stringsProjectId, listOptions);
+  } catch (error) {
+    mapPhraseApiError(error);
+  }
+
+  const targetLocale =
+    matchPhraseTargetLocale(input.targetLocale, locales) ??
+    locales.find((locale) => !locale.default);
+  if (!targetLocale) {
+    throw new PhraseLiveCatError(
+      "phrase_target_locale_not_found",
+      "Target locale was not found in the Phrase project.",
+    );
+  }
+
+  let saved: PhraseTranslation;
+  try {
+    saved = await client.upsertTranslation(scope.stringsProjectId, {
+      keyId: input.externalStringId,
+      localeName: targetLocale.name,
+      content: input.text,
+      branch: scope.branch,
+      unverified: false,
+    });
+  } catch (error) {
+    mapPhraseApiError(error);
+  }
+
+  return {
+    text: saved.content?.trim() || input.text,
+    externalTranslationId: saved.id,
+    isApproved: phraseTranslationIsApproved(saved),
+  };
+}
+
+export async function savePhraseLiveCatComment(input: {
+  secretMaterial: string;
+  region?: string | null;
+  baseUrl?: string | null;
+  externalProjectId: string;
+  file: TmsProviderLiveFile;
+  targetLocale: string;
+  externalStringId: string;
+  text: string;
+}): Promise<ProjectFileCatComment> {
+  const scope = resolvePhraseLiveCatContext({
+    file: input.file,
+    externalProjectId: input.externalProjectId,
+    secretMaterial: input.secretMaterial,
+    region: input.region,
+    baseUrl: input.baseUrl,
+  });
+  const client = createPhraseStringsApiClient({
+    token: scope.token,
+    region: scope.region,
+    baseUrl: scope.baseUrl,
+  });
+  const listOptions = scope.branch ? { branch: scope.branch } : {};
+
+  let created;
+  try {
+    created = await client.createKeyComment(
+      scope.stringsProjectId,
+      input.externalStringId,
+      {
+        message: input.text,
+        localeName: input.targetLocale,
+      },
+      listOptions,
+    );
+  } catch (error) {
+    mapPhraseApiError(error);
+  }
+
+  return mapPhraseKeyComment(created, input.targetLocale);
+}

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-locale-readiness.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-locale-readiness.test.ts
@@ -4,6 +4,7 @@ import {
   buildPhraseKeyExternalResourceId,
   buildPhraseKeySourcePath,
   mapPhraseTranslationReadiness,
+  parsePhraseExternalResourceId,
 } from "./phrase-locale-readiness";
 
 describe("phrase locale readiness", () => {
@@ -54,6 +55,14 @@ describe("phrase locale readiness", () => {
   it("scopes key identity by branch when present", () => {
     expect(buildPhraseKeyExternalResourceId("key-1", "feature")).toBe("feature::key-1");
     expect(buildPhraseKeyExternalResourceId("key-1", null)).toBe("key-1");
+    expect(parsePhraseExternalResourceId("feature::key-1")).toEqual({
+      branch: "feature",
+      resourceId: "key-1",
+    });
+    expect(parsePhraseExternalResourceId("key-1")).toEqual({
+      branch: null,
+      resourceId: "key-1",
+    });
     expect(buildPhraseKeySourcePath("home.hero.title", null)).toBe("keys/home.hero.title");
     expect(buildPhraseKeySourcePath("home.hero.title", "feature")).toBe(
       "feature/keys/home.hero.title",

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-locale-readiness.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-locale-readiness.ts
@@ -27,6 +27,24 @@ export function mapPhraseTranslationReadiness(input: {
   return "unverified";
 }
 
+export function parsePhraseExternalResourceId(externalResourceId: string) {
+  const trimmed = externalResourceId.trim();
+  const separatorIndex = trimmed.indexOf("::");
+  if (separatorIndex === -1) {
+    return {
+      branch: null as string | null,
+      resourceId: trimmed,
+    };
+  }
+
+  const branch = trimmed.slice(0, separatorIndex).trim() || null;
+  const resourceId = trimmed.slice(separatorIndex + 2).trim();
+  return {
+    branch,
+    resourceId,
+  };
+}
+
 export function buildPhraseKeyExternalResourceId(keyId: string, branch: string | null) {
   const trimmedId = keyId.trim();
   const trimmedBranch = branch?.trim();

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live-error-response.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live-error-response.ts
@@ -20,6 +20,7 @@ export function getTmsProviderLiveErrorStatus(code: string): TmsProviderLiveErro
     case "crowdin_auth_invalid":
     case "crowdin_user_auth_invalid":
     case "crowdin_user_connection_required":
+    case "phrase_auth_invalid":
     case "phrase_user_auth_invalid":
     case "phrase_user_connection_required":
     case "lokalise_user_auth_invalid":
@@ -28,6 +29,8 @@ export function getTmsProviderLiveErrorStatus(code: string): TmsProviderLiveErro
     case "invalid_encoded_job_id":
     case "invalid_crowdin_project_or_file_id":
     case "invalid_crowdin_project_or_string_id":
+    case "invalid_phrase_project_id":
+    case "phrase_target_locale_not_found":
       return 400;
     case "provider_fetcher_unavailable":
     case "provider_description_edit_unsupported":

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
@@ -38,6 +38,12 @@ import {
   resolvePhraseUserConnectionSecretMaterial,
 } from "@/lib/providers/adapters/phrase/phrase-user-connections";
 import {
+  buildPhraseLiveCatFile,
+  PhraseLiveCatError,
+  savePhraseLiveCatComment,
+  savePhraseLiveCatTranslation,
+} from "@/lib/providers/adapters/phrase/phrase-live-cat";
+import {
   getLokaliseUserConnection,
   resolveLokaliseUserConnectionSecretMaterial,
 } from "@/lib/providers/adapters/lokalise/lokalise-user-connections";
@@ -720,6 +726,96 @@ function mapLiveFile(input: {
     },
     latestJob: null,
   };
+}
+
+function mapPhraseLiveCatError(error: unknown): never {
+  if (error instanceof PhraseLiveCatError) {
+    throw new TmsProviderLiveError(error.code, error.message);
+  }
+
+  throw error;
+}
+
+function supportsLiveProviderCat(
+  providerKind: ExternalTmsProviderKind,
+  file: TmsProviderLiveFile,
+): boolean {
+  if (!file.provider) {
+    return false;
+  }
+
+  if (providerKind === "crowdin") {
+    return file.provider.resourceType === "file";
+  }
+
+  if (providerKind === "phrase") {
+    return file.provider.resourceType === "file" || file.provider.resourceType === "key";
+  }
+
+  return false;
+}
+
+function resolveLiveCatFileFromExternalResourceId(input: {
+  providerKind: ExternalTmsProviderKind;
+  externalProjectId: string;
+  externalResourceId: string;
+  sourcePath: string;
+  resourceType?: "file" | "key";
+}): TmsProviderLiveFile {
+  return mapLiveFile({
+    providerKind: input.providerKind,
+    externalProjectId: input.externalProjectId,
+    file: {
+      resourceType: input.resourceType ?? (input.providerKind === "phrase" ? "key" : "file"),
+      externalResourceId: input.externalResourceId,
+      sourcePath: input.sourcePath,
+    },
+  });
+}
+
+async function resolveLiveCatFile(input: {
+  organizationId: string;
+  externalProjectId: string;
+  sourcePath: string;
+  externalResourceId?: string | null;
+  context: ActiveTmsProviderContext;
+}): Promise<TmsProviderLiveFile | null> {
+  const files = await listTmsProviderLiveFilesForProject(
+    input.organizationId,
+    input.externalProjectId,
+    {
+      context: input.context,
+      limit: 1000,
+    },
+  );
+
+  const bySourcePath = files.find((item) => item.sourcePath === input.sourcePath);
+  if (bySourcePath) {
+    return bySourcePath;
+  }
+
+  if (!input.externalResourceId) {
+    return null;
+  }
+
+  const byResourceId = files.find(
+    (item) => item.provider?.externalResourceId === input.externalResourceId,
+  );
+  if (byResourceId) {
+    return byResourceId;
+  }
+
+  if (input.context.providerKind === "crowdin") {
+    return resolveLiveCatFileFromExternalResourceId({
+      providerKind: input.context.providerKind,
+      externalProjectId: input.externalProjectId,
+      externalResourceId: input.externalResourceId,
+      sourcePath: input.sourcePath,
+      resourceType: "file",
+    });
+  }
+
+  return null;
 }
 
 function crowdinSourceTextValue(text: CrowdinSourceString["text"]) {
@@ -1581,11 +1677,28 @@ export async function getTmsProviderLiveCatFile(
     return null;
   }
 
-  if (context.providerKind !== "crowdin" || file.provider?.resourceType !== "file") {
+  if (!supportsLiveProviderCat(context.providerKind, file)) {
     throw new TmsProviderLiveError(
       "provider_cat_unsupported",
       "CAT editing is not available for this provider file yet.",
     );
+  }
+
+  if (context.providerKind === "phrase") {
+    try {
+      return await buildPhraseLiveCatFile({
+        secretMaterial: context.secretMaterial,
+        region: context.credential.region,
+        baseUrl: context.credential.baseUrl,
+        externalProjectId,
+        file,
+        targetLocale,
+        canEditTranslations: options?.canEditTranslations ?? false,
+        pagination: options?.pagination,
+      });
+    } catch (error) {
+      mapPhraseLiveCatError(error);
+    }
   }
 
   return buildCrowdinLiveCatFile({
@@ -1612,32 +1725,39 @@ export async function saveTmsProviderLiveCatTranslation(
   const context = await loadActiveTmsProviderContext(organizationId, {
     actorUserId: options?.actorUserId,
   });
-  const file =
-    input.externalResourceId && context.providerKind === "crowdin"
-      ? mapLiveFile({
-          providerKind: context.providerKind,
-          externalProjectId,
-          file: {
-            resourceType: "file",
-            externalResourceId: input.externalResourceId,
-            sourcePath,
-          },
-        })
-      : (
-          await listTmsProviderLiveFilesForProject(organizationId, externalProjectId, {
-            context,
-            limit: 1000,
-          })
-        ).find((item) => item.sourcePath === sourcePath);
+  const file = await resolveLiveCatFile({
+    organizationId,
+    externalProjectId,
+    sourcePath,
+    externalResourceId: input.externalResourceId,
+    context,
+  });
   if (!file) {
     return null;
   }
 
-  if (context.providerKind !== "crowdin" || file.provider?.resourceType !== "file") {
+  if (!supportsLiveProviderCat(context.providerKind, file)) {
     throw new TmsProviderLiveError(
       "provider_cat_unsupported",
       "CAT editing is not available for this provider file yet.",
     );
+  }
+
+  if (context.providerKind === "phrase") {
+    try {
+      return await savePhraseLiveCatTranslation({
+        secretMaterial: context.secretMaterial,
+        region: context.credential.region,
+        baseUrl: context.credential.baseUrl,
+        externalProjectId,
+        file,
+        targetLocale: input.targetLocale,
+        externalStringId: input.externalStringId,
+        text: input.text,
+      });
+    } catch (error) {
+      mapPhraseLiveCatError(error);
+    }
   }
 
   return saveCrowdinLiveCatTranslation({
@@ -1665,32 +1785,46 @@ export async function saveTmsProviderLiveCatComment(
   const context = await loadActiveTmsProviderContext(organizationId, {
     actorUserId: options?.actorUserId,
   });
-  const file =
-    input.externalResourceId && context.providerKind === "crowdin"
-      ? mapLiveFile({
-          providerKind: context.providerKind,
-          externalProjectId,
-          file: {
-            resourceType: "file",
-            externalResourceId: input.externalResourceId,
-            sourcePath,
-          },
-        })
-      : (
-          await listTmsProviderLiveFilesForProject(organizationId, externalProjectId, {
-            context,
-            limit: 1000,
-          })
-        ).find((item) => item.sourcePath === sourcePath);
+  const file = await resolveLiveCatFile({
+    organizationId,
+    externalProjectId,
+    sourcePath,
+    externalResourceId: input.externalResourceId,
+    context,
+  });
   if (!file) {
     return null;
   }
 
-  if (context.providerKind !== "crowdin" || file.provider?.resourceType !== "file") {
+  if (!supportsLiveProviderCat(context.providerKind, file)) {
     throw new TmsProviderLiveError(
       "provider_cat_unsupported",
       "CAT comments are not available for this provider file yet.",
     );
+  }
+
+  if (context.providerKind === "phrase") {
+    if (input.type === "issue") {
+      throw new TmsProviderLiveError(
+        "provider_cat_unsupported",
+        "Issue comments are not available for Phrase files.",
+      );
+    }
+
+    try {
+      return await savePhraseLiveCatComment({
+        secretMaterial: context.secretMaterial,
+        region: context.credential.region,
+        baseUrl: context.credential.baseUrl,
+        externalProjectId,
+        file,
+        targetLocale: input.targetLocale,
+        externalStringId: input.externalStringId,
+        text: input.text,
+      });
+    } catch (error) {
+      mapPhraseLiveCatError(error);
+    }
   }
 
   return saveCrowdinLiveCatComment({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds live Phrase provider support to the CAT tool: load segments/translations/comments, save translations, and post comments.

## Babysit status

- **Merge conflicts:** None (branch is up to date with `main`)
- **CI:** All checks green (Hyperlocalise Web Build, CodeQL, Greptile Review)
- **Review comments:** All 5 Greptile threads resolved, including:
  - Strict locale matching (no silent fallback to wrong locale)
  - Explicit `created` typing in `savePhraseLiveCatComment`
  - Per-key translation fetch via `listKeyTranslations`
  - Nullable comment timestamps
  - Locale resolution in `savePhraseLiveCatComment` (uses `resolvePhraseTargetLocale` before `createKeyComment`)

## Remaining blocker

`REVIEW_REQUIRED` — needs human approval before merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-624fec6f-f63c-4c46-a3e1-d1caabbc2abe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-624fec6f-f63c-4c46-a3e1-d1caabbc2abe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

