### PR TITLE
fix(web): show file tree when opening CAT without a source file

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/native-job-detail-helpers.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/native-job-detail-helpers.tsx
@@ -110,6 +110,7 @@ export function NativeJobSourceFilesSection({
     <JobSourceFilesPanel
       organizationSlug={organizationSlug}
       projectId={projectId}
+      encodedJobId={job.id}
       files={[file]}
       highlightLocale={highlightLocale}
       emptyMessage="No source file linked to this job."

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/job-source-files-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/job-source-files-panel.tsx
@@ -23,13 +23,21 @@ function stringsHref(input: {
   organizationSlug: string;
   projectId: string;
   encodedJobId: string;
-  sourcePath: string;
   targetLocale: string;
+  sourcePath?: string;
+  storedFileId?: string;
 }) {
   const params = new URLSearchParams({
-    sourcePath: input.sourcePath,
     targetLocale: input.targetLocale,
   });
+
+  if (input.sourcePath) {
+    params.set("sourcePath", input.sourcePath);
+  }
+
+  if (input.storedFileId) {
+    params.set("storedFileId", input.storedFileId);
+  }
 
   return `/org/${input.organizationSlug}/projects/${encodeURIComponent(input.projectId)}/jobs/${encodeURIComponent(input.encodedJobId)}/strings?${params.toString()}`;
 }
@@ -60,17 +68,22 @@ export function JobSourceFilesPanel({
   const selectedFile =
     sortedFiles.find((file) => file.sourcePath === selectedSourcePath) ?? sortedFiles[0] ?? null;
   const activeSourcePath = selectedFile?.sourcePath ?? null;
-  const targetLocale =
-    highlightLocale && selectedFile?.provider?.targetLocales?.includes(highlightLocale)
+  const targetLocale = selectedFile?.provider
+    ? highlightLocale && selectedFile.provider.targetLocales?.includes(highlightLocale)
       ? highlightLocale
-      : (selectedFile?.provider?.targetLocales?.[0] ?? highlightLocale);
+      : (selectedFile.provider.targetLocales?.[0] ?? highlightLocale)
+    : highlightLocale;
+  const isProviderCatFile = Boolean(selectedFile && supportsProviderCatFile(selectedFile));
+  const isNativeCatFile = Boolean(
+    selectedFile && !selectedFile.provider && selectedFile.storedFileId,
+  );
   const canViewStrings = Boolean(
     encodedJobId &&
     selectedFile &&
-    supportsProviderCatFile(selectedFile) &&
-    activeSourcePath &&
-    targetLocale,
+    targetLocale &&
+    ((isProviderCatFile && activeSourcePath) || isNativeCatFile),
   );
+  const showStringsAction = isProviderCatFile || isNativeCatFile;
 
   return (
     <section className="rounded-lg border border-border bg-card p-5">
@@ -104,11 +117,11 @@ export function JobSourceFilesPanel({
             />
           </aside>
           <div className="min-h-[min(20rem,50vh)] overflow-y-auto">
-            {selectedFile?.provider ? (
+            {showStringsAction ? (
               <div className="flex flex-col gap-2 border-b border-border px-5 py-3 sm:flex-row sm:items-center sm:justify-between">
                 <div>
                   <TypographyP className="font-mono text-xs text-foreground">
-                    {selectedFile.sourcePath}
+                    {selectedFile?.sourcePath}
                   </TypographyP>
                   <TypographyP className="text-xs text-muted-foreground">
                     {targetLocale
@@ -127,8 +140,10 @@ export function JobSourceFilesPanel({
                           organizationSlug,
                           projectId,
                           encodedJobId: encodedJobId as string,
-                          sourcePath: activeSourcePath as string,
                           targetLocale: targetLocale as string,
+                          ...(isProviderCatFile
+                            ? { sourcePath: activeSourcePath as string }
+                            : { storedFileId: selectedFile?.storedFileId as string }),
                         })}
                       />
                     ) : undefined

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
@@ -30,6 +30,8 @@ import { loadJobCatProviderFiles, loadJobCatTargetFile } from "./load-job-cat-fi
 import { selectJobCatRepository, sortJobCatProviderFiles } from "./select-job-cat-repository";
 import { ProjectFileCatWorkspace } from "@/components/cat/project-file-cat-workspace";
 
+import { JobCatSourceFilePicker } from "./job-cat-source-file-picker";
+
 type JobCatGithubRepository = {
   fullName: string;
   enabled: boolean;
@@ -195,13 +197,12 @@ export function JobCatPageContent({
 
   if (!hasFileReference) {
     return (
-      <ProjectPageShell>
-        <div className="rounded-lg border border-border bg-card p-5">
-          <TypographyP className="text-sm text-muted-foreground">
-            Choose a source file from the task, then open View strings.
-          </TypographyP>
-        </div>
-      </ProjectPageShell>
+      <JobCatSourceFilePicker
+        organizationSlug={organizationSlug}
+        projectId={projectId}
+        jobId={jobId}
+        targetLocale={targetLocale}
+      />
     );
   }
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-source-file-picker.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-source-file-picker.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowLeftIcon } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import { TypographyP } from "@/components/ui/typography";
+import { apiClient } from "@/lib/api-client-instance";
+import { parseProviderJobId } from "@/lib/providers/tms-provider-resource-id";
+
+import { ProjectPageShell } from "../../../../_components/project-page-shell";
+import type { JobDetailRecord } from "../../_components/job-detail-types";
+import {
+  buildNativeJobFileRecord,
+  isNativeFileTranslationJob,
+} from "../../_components/native-job-detail-helpers";
+import { TmsLiveJobFilesSection } from "../../_components/tms/tms-live-job-files-section";
+import { JobSourceFilesPanel } from "../../_components/tms/job-source-files-panel";
+
+function jobDetailQueryKey(organizationSlug: string, projectId: string, jobId: string) {
+  return ["job", organizationSlug, projectId, jobId] as const;
+}
+
+function NativeJobCatSourceFilePicker({
+  organizationSlug,
+  projectId,
+  jobId,
+  targetLocale,
+}: {
+  organizationSlug: string;
+  projectId: string;
+  jobId: string;
+  targetLocale: string | null;
+}) {
+  const jobQuery = useQuery({
+    queryKey: jobDetailQueryKey(organizationSlug, projectId, jobId),
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"].jobs[":jobId"].$get({
+        param: { organizationSlug, jobId },
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to load task (${response.status})`);
+      }
+
+      const body = (await response.json()) as { job: JobDetailRecord };
+      if (body.job.projectId !== projectId) {
+        throw new Error("Task does not belong to this project");
+      }
+
+      return body.job;
+    },
+  });
+
+  if (jobQuery.isLoading) {
+    return (
+      <div className="flex min-h-48 items-center justify-center gap-2 rounded-lg border border-border bg-card p-5">
+        <Spinner />
+        <TypographyP className="text-sm text-muted-foreground">Loading task files…</TypographyP>
+      </div>
+    );
+  }
+
+  if (jobQuery.isError) {
+    return (
+      <div className="rounded-lg border border-border bg-card p-5">
+        <TypographyP className="text-sm text-flame-100">
+          {jobQuery.error instanceof Error ? jobQuery.error.message : "Unable to load task files."}
+        </TypographyP>
+      </div>
+    );
+  }
+
+  const job = jobQuery.data;
+  if (!job || !isNativeFileTranslationJob(job)) {
+    return (
+      <div className="rounded-lg border border-border bg-card p-5">
+        <TypographyP className="text-sm text-muted-foreground">
+          No source file is linked to this task. Open the task details to choose a file, then open
+          View strings.
+        </TypographyP>
+      </div>
+    );
+  }
+
+  const file = buildNativeJobFileRecord(job);
+  if (!file) {
+    return (
+      <div className="rounded-lg border border-border bg-card p-5">
+        <TypographyP className="text-sm text-muted-foreground">
+          No source file is linked to this task.
+        </TypographyP>
+      </div>
+    );
+  }
+
+  return (
+    <JobSourceFilesPanel
+      organizationSlug={organizationSlug}
+      projectId={projectId}
+      encodedJobId={jobId}
+      files={[file]}
+      highlightLocale={targetLocale}
+      emptyMessage="No source file linked to this task."
+    />
+  );
+}
+
+export function JobCatSourceFilePicker({
+  organizationSlug,
+  projectId,
+  jobId,
+  targetLocale,
+}: {
+  organizationSlug: string;
+  projectId: string;
+  jobId: string;
+  targetLocale: string | null;
+}) {
+  const taskHref = `/org/${organizationSlug}/projects/${encodeURIComponent(projectId)}/jobs/${encodeURIComponent(jobId)}`;
+  const isProviderJob = Boolean(parseProviderJobId(jobId));
+
+  return (
+    <ProjectPageShell>
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-wrap items-center gap-3">
+          <Button variant="outline" size="sm" render={<Link href={taskHref} />}>
+            <ArrowLeftIcon />
+            Task
+          </Button>
+          <TypographyP className="text-sm text-muted-foreground">
+            Choose a source file to open in the CAT workspace.
+          </TypographyP>
+        </div>
+
+        {isProviderJob ? (
+          <TmsLiveJobFilesSection
+            organizationSlug={organizationSlug}
+            projectId={projectId}
+            encodedJobId={jobId}
+            highlightLocale={targetLocale}
+          />
+        ) : (
+          <NativeJobCatSourceFilePicker
+            organizationSlug={organizationSlug}
+            projectId={projectId}
+            jobId={jobId}
+            targetLocale={targetLocale}
+          />
+        )}
+      </div>
+    </ProjectPageShell>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Clicking **View strings** from a jobs row for a provider-backed task often opens the CAT route without a `sourcePath` query param (the job list does not always include a linked file id). The strings page previously showed only a text message asking users to pick a file from the task, with no way to do that in the CAT UI.

This change replaces that empty state with the same task source-files panel used on the job detail page, including the `ProjectFilesTree` file browser. Users can select a file from the tree and then open **View strings** to enter the CAT workspace.

## How to test

1. Open a project with synced provider jobs where **View strings** appears on a jobs row but the task has multiple source files (or no `sourceFileId` in the job payload).
2. Click **View strings** from the jobs row.
3. Confirm the page shows a file tree on the left instead of only the “choose a file” message.
4. Select a file and click **View strings** in the panel header to open the CAT workspace for that file.

Also ran `vp test` and `vp check --fix` in `apps/hyperlocalise-web`.

## Checklist

- [x] I ran relevant checks locally (`vp test`, `vp check --fix`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4f74a325-a1e5-4f00-afe3-a2d91360f4df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f74a325-a1e5-4f00-afe3-a2d91360f4df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

