### PR TITLE
fix(web): provider view header actions and job detail skeleton

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.tsx
@@ -13,7 +13,10 @@ import { Button } from "@/components/ui/button";
 import { apiClient } from "@/lib/api-client-instance";
 import { readApiResponseError } from "@/lib/api-error";
 import { getProjectWorkspaceCapabilities } from "@/lib/projects/workspace-resource-capabilities";
+import { parseProviderProjectId } from "@/lib/providers/tms-provider-resource-id";
 import { isTmsUserConnectionRequiredError } from "@/lib/providers/tms-user-connection-shared";
+
+import { useProjectPageQuery } from "../../projects/[projectId]/_components/project-page-shell";
 
 import {
   JobsPageErrorMessage,
@@ -120,7 +123,20 @@ export function JobsPageContent({
     statusFilter,
     projectId ?? "workspace",
   ];
-  const projectCapabilities = projectId ? getProjectWorkspaceCapabilities({ projectId }) : null;
+  const projectQuery = useProjectPageQuery(organizationSlug, projectId ?? "", {
+    enabled: Boolean(projectId),
+  });
+  const parsedProviderProject = projectId ? parseProviderProjectId(projectId) : null;
+  const projectCapabilities = projectId
+    ? getProjectWorkspaceCapabilities({
+        projectId,
+        source: projectQuery.data?.source,
+      })
+    : null;
+  const canSyncProviderJobs = Boolean(projectCapabilities?.canSyncProviderJobs);
+  const syncJobsReady = parsedProviderProject
+    ? true
+    : projectQuery.isSuccess || projectQuery.isError;
 
   const jobsQuery = useQuery({
     queryKey: jobsQueryKey,
@@ -229,7 +245,7 @@ export function JobsPageContent({
       isSyncingProviderJobs={syncProviderJobs.isPending}
       jobs={jobsQuery.data ?? []}
       onSyncProviderJobs={
-        projectCapabilities?.canSyncProviderJobs ? syncProviderJobs.mutate : undefined
+        canSyncProviderJobs && syncJobsReady ? syncProviderJobs.mutate : undefined
       }
       onStatusFilterChange={setStatusFilter}
       organizationSlug={organizationSlug}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.tsx
@@ -123,10 +123,10 @@ export function JobsPageContent({
     statusFilter,
     projectId ?? "workspace",
   ];
-  const projectQuery = useProjectPageQuery(organizationSlug, projectId ?? "", {
-    enabled: Boolean(projectId),
-  });
   const parsedProviderProject = projectId ? parseProviderProjectId(projectId) : null;
+  const projectQuery = useProjectPageQuery(organizationSlug, projectId ?? "", {
+    enabled: Boolean(projectId) && !parsedProviderProject,
+  });
   const projectCapabilities = projectId
     ? getProjectWorkspaceCapabilities({
         projectId,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-page-shell.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-page-shell.tsx
@@ -14,9 +14,14 @@ import {
 
 import { mapProjectToListRow } from "../../_components/project-list";
 
-export function useProjectPageQuery(organizationSlug: string, projectId: string) {
+export function useProjectPageQuery(
+  organizationSlug: string,
+  projectId: string,
+  options?: { enabled?: boolean },
+) {
   return useQuery({
     queryKey: ["translation-project", organizationSlug, projectId],
+    enabled: options?.enabled ?? true,
     queryFn: async () => {
       const response = await apiClient.api.orgs[":organizationSlug"].projects[":projectId"].$get({
         param: { organizationSlug, projectId },

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-page-content.tsx
@@ -2,7 +2,6 @@
 
 import { useQuery } from "@tanstack/react-query";
 
-import { Skeleton } from "@/components/ui/skeleton";
 import { apiClient } from "@/lib/api-client-instance";
 import {
   parseProviderJobId,
@@ -10,6 +9,8 @@ import {
 } from "@/lib/providers/tms-provider-resource-id";
 
 import { useActiveTmsProvider } from "../../../../../_hooks/use-active-tms-provider";
+
+import { JobDetailSkeleton } from "./job-detail-skeleton";
 
 import type { JobDetailRecord } from "./job-detail-types";
 import { NativeJobDetailContent } from "./native-job-detail-content";
@@ -69,14 +70,7 @@ export function JobDetailPageContent({
     activeTmsProviderQuery.isLoading ||
     (!encodedProviderJobFromRoute && routingJobQuery.isLoading)
   ) {
-    return (
-      <main className="mx-auto flex w-full max-w-6xl flex-col gap-5">
-        <div className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
-          <Skeleton className="h-5 w-48 bg-foreground/8" />
-          <Skeleton className="mt-4 h-40 w-full bg-foreground/8" />
-        </div>
-      </main>
-    );
+    return <JobDetailSkeleton />;
   }
 
   if (useLiveProviderJob && encodedProviderJobId) {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-skeleton.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-skeleton.tsx
@@ -1,0 +1,67 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+function PropertyRowSkeleton() {
+  return (
+    <div className="grid grid-cols-[7.5rem_minmax(0,1fr)] items-start gap-3 py-2">
+      <Skeleton className="h-5 w-20" />
+      <Skeleton className="h-5 w-full max-w-40" />
+    </div>
+  );
+}
+
+export function JobDetailSkeleton() {
+  return (
+    <main
+      className="mx-auto flex w-full max-w-7xl flex-col gap-5"
+      aria-busy="true"
+      aria-label="Loading job"
+    >
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0 space-y-4">
+          <Skeleton className="h-4 w-14" />
+          <Skeleton className="h-8 w-full max-w-md" />
+          <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
+            <Skeleton className="h-5 w-32" />
+            <Skeleton className="h-5 w-28" />
+            <Skeleton className="h-5 w-36" />
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Skeleton className="h-8 w-32" />
+          <Skeleton className="h-8 w-24" />
+        </div>
+      </div>
+
+      <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_20rem]">
+        <div className="flex min-w-0 flex-col gap-5">
+          <section className="rounded-lg border border-border bg-card p-5">
+            <Skeleton className="h-5 w-24" />
+            <Skeleton className="mt-4 h-20 w-full" />
+          </section>
+          <section className="rounded-lg border border-border bg-card p-5">
+            <Skeleton className="h-5 w-28" />
+            <Skeleton className="mt-4 h-10 w-full" />
+            <Skeleton className="mt-3 h-48 w-full" />
+          </section>
+          <section>
+            <Skeleton className="h-5 w-24" />
+            <div className="mt-4 space-y-3">
+              <Skeleton className="h-16 w-full" />
+              <Skeleton className="h-16 w-full" />
+            </div>
+          </section>
+        </div>
+        <aside className="flex min-w-0 flex-col gap-5">
+          <section className="rounded-lg border border-border bg-card p-5 xl:sticky xl:top-5">
+            <Skeleton className="h-5 w-24" />
+            <div className="mt-5">
+              {Array.from({ length: 5 }).map((_, index) => (
+                <PropertyRowSkeleton key={index} />
+              ))}
+            </div>
+          </section>
+        </aside>
+      </div>
+    </main>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-view.tsx
@@ -4,7 +4,6 @@ import { useState, type ReactNode } from "react";
 import { ArrowDown01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 
-import { Skeleton } from "@/components/ui/skeleton";
 import { TypographyH1, TypographyH4 } from "@/components/ui/typography";
 import { cn } from "@/lib/primitives/cn";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
@@ -15,6 +14,7 @@ import {
   type JobDetailBackLinkRenderer,
   type JobDetailErrorRenderer,
 } from "./job-detail-shared";
+import { JobDetailSkeleton } from "./job-detail-skeleton";
 import { buildJobsListHref } from "./job-detail-types";
 
 export type JobDetailViewMetric = {
@@ -132,6 +132,10 @@ export function JobDetailView({
 }) {
   const jobsListHref = buildJobsListHrefProp(organizationSlug, projectId);
 
+  if (isLoading) {
+    return <JobDetailSkeleton />;
+  }
+
   return (
     <main className="mx-auto flex w-full max-w-7xl flex-col gap-5">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
@@ -153,16 +157,9 @@ export function JobDetailView({
         ) : null}
       </div>
 
-      {isLoading ? (
-        <div className="rounded-lg border border-border bg-card p-5">
-          <Skeleton className="h-5 w-48" />
-          <Skeleton className="mt-4 h-40 w-full" />
-        </div>
-      ) : null}
-
       {error ? renderError({ error }) : null}
 
-      {!isLoading && !error ? (
+      {!error ? (
         <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_20rem]">
           <div className="flex min-w-0 flex-col gap-5">{renderMain?.()}</div>
           <aside className="flex min-w-0 flex-col gap-5">

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
@@ -215,7 +215,19 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
   const useLiveProviderProjects = Boolean(activeTmsProviderQuery.data);
   const isProviderModeResolved = activeTmsProviderQuery.isSuccess;
 
-  const headerActions = !isProviderModeResolved ? null : useLiveProviderProjects ? (
+  const createProjectAction = (
+    <Button
+      type="button"
+      onClick={openCreateProjectDialog}
+      className="w-full sm:w-fit"
+      disabled={isSavingProject}
+    >
+      <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
+      Create project
+    </Button>
+  );
+
+  const syncProjectsAction = useLiveProviderProjects ? (
     <Button
       type="button"
       variant="outline"
@@ -230,16 +242,13 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
       )}
       Sync projects
     </Button>
-  ) : (
-    <Button
-      type="button"
-      onClick={openCreateProjectDialog}
-      className="w-full sm:w-fit"
-      disabled={isSavingProject}
-    >
-      <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
-      Create project
-    </Button>
+  ) : null;
+
+  const headerActions = !isProviderModeResolved ? null : (
+    <>
+      {syncProjectsAction}
+      {createProjectAction}
+    </>
   );
 
   return (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
@@ -213,7 +213,7 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
   }
 
   const useLiveProviderProjects = Boolean(activeTmsProviderQuery.data);
-  const isProviderModeResolved = activeTmsProviderQuery.isSuccess;
+  const isProviderModeResolved = activeTmsProviderQuery.isSuccess || activeTmsProviderQuery.isError;
 
   const createProjectAction = (
     <Button

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { Add01Icon, FolderKanbanIcon } from "@hugeicons/core-free-icons";
+import { Add01Icon, DatabaseSyncIcon, FolderKanbanIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Spinner } from "@/components/ui/spinner";
 import { apiClient } from "@/lib/api-client-instance";
 import { readApiResponseError } from "@/lib/api-error";
 
@@ -16,6 +17,7 @@ import {
   WorkspaceFilterField,
   WorkspacePageShell,
 } from "../../_components/workspace-resource-shared";
+import { useActiveTmsProvider } from "../../_hooks/use-active-tms-provider";
 import { DeleteProjectDialog } from "./delete-project-dialog";
 import {
   createEmptyProjectForm,
@@ -28,10 +30,6 @@ import { mapProjectToListRow, type ProjectListRow } from "./project-list";
 import { ProjectsTable } from "./projects-table";
 
 const projectQueryKey = (organizationSlug: string) => ["translation-projects", organizationSlug];
-const tmsConnectionQueryKey = (organizationSlug: string) => [
-  "tms-provider-connection",
-  organizationSlug,
-];
 
 function useProjectSearch(projects: ProjectListRow[]) {
   const [searchQuery, setSearchQuery] = useState("");
@@ -74,28 +72,7 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
       return body.projects.map(mapProjectToListRow);
     },
   });
-  const tmsConnectionQuery = useQuery({
-    queryKey: tmsConnectionQueryKey(organizationSlug),
-    enabled: projectsQuery.isSuccess && (projectsQuery.data ?? []).length === 0,
-    queryFn: async () => {
-      const response = await apiClient.api.orgs[":organizationSlug"][
-        "tms-provider"
-      ].connection.$get({
-        param: { organizationSlug },
-      });
-
-      if (response.status === 404) {
-        return null;
-      }
-
-      if (response.status !== 200) {
-        throw await readApiResponseError(response, "Failed to load TMS provider connection");
-      }
-
-      const body = await response.json();
-      return body.connection;
-    },
-  });
+  const activeTmsProviderQuery = useActiveTmsProvider(organizationSlug);
   const createProject = useMutation({
     mutationFn: async (values: ProjectFormValues) => {
       const response = await apiClient.api.orgs[":organizationSlug"].projects.$post({
@@ -235,7 +212,35 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
     createProject.mutate(values);
   }
 
-  const hasExternalProjects = projects.some((p) => p.source === "external_tms");
+  const useLiveProviderProjects = Boolean(activeTmsProviderQuery.data);
+  const isProviderModeResolved = activeTmsProviderQuery.isSuccess;
+
+  const headerActions = !isProviderModeResolved ? null : useLiveProviderProjects ? (
+    <Button
+      type="button"
+      variant="outline"
+      className="w-full sm:w-fit"
+      onClick={() => syncProviderProjects.mutate()}
+      disabled={syncProviderProjects.isPending}
+    >
+      {syncProviderProjects.isPending ? (
+        <Spinner className="size-4" />
+      ) : (
+        <HugeiconsIcon icon={DatabaseSyncIcon} strokeWidth={1.8} />
+      )}
+      Sync projects
+    </Button>
+  ) : (
+    <Button
+      type="button"
+      onClick={openCreateProjectDialog}
+      className="w-full sm:w-fit"
+      disabled={isSavingProject}
+    >
+      <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
+      Create project
+    </Button>
+  );
 
   return (
     <WorkspacePageShell>
@@ -244,19 +249,7 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
         label="Workspace"
         title="Projects"
         description="Track localization programs before they move into translation jobs."
-        actions={
-          hasExternalProjects ? null : (
-            <Button
-              type="button"
-              onClick={openCreateProjectDialog}
-              className="w-full sm:w-fit"
-              disabled={isSavingProject}
-            >
-              <HugeiconsIcon icon={Add01Icon} strokeWidth={1.8} />
-              Create project
-            </Button>
-          )
-        }
+        actions={headerActions}
       />
 
       {projectsQuery.isSuccess && projects.length > 0 ? (
@@ -291,8 +284,10 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
           projectsQuery={projectsQuery}
           isSavingProject={isSavingProject}
           isDeletingProject={deleteProjectMutation.isPending}
-          hasActiveTmsConnection={Boolean(tmsConnectionQuery.data)}
-          isCheckingTmsConnection={tmsConnectionQuery.isLoading}
+          hasActiveTmsConnection={Boolean(activeTmsProviderQuery.data)}
+          isCheckingTmsConnection={
+            activeTmsProviderQuery.isLoading && projectsQuery.isSuccess && projects.length === 0
+          }
           isSyncingProviderProjects={syncProviderProjects.isPending}
           organizationSlug={organizationSlug}
           onSyncProviderProjects={syncProviderProjects.mutate}

--- a/apps/hyperlocalise-web/src/lib/projects/workspace-resource-capabilities.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/workspace-resource-capabilities.test.ts
@@ -28,6 +28,22 @@ describe("getProjectWorkspaceCapabilities", () => {
       canSyncProviderJobs: true,
     });
   });
+
+  it("returns provider sync capabilities for synced external projects", () => {
+    expect(
+      getProjectWorkspaceCapabilities({
+        projectId: "project_abc123",
+        source: "external_tms",
+      }),
+    ).toEqual({
+      source: "external_tms",
+      isProviderProject: false,
+      canUploadFiles: false,
+      canEditProjectSettings: false,
+      canDeleteProject: false,
+      canSyncProviderJobs: true,
+    });
+  });
 });
 
 describe("canOpenProviderJobCat", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes provider-view UX issues from the unified TMS workspace:

1. **Projects header** — When TMS is connected, shows **Sync projects** and **Create project** together (native projects remain creatable). Header actions stay hidden while provider mode is loading to avoid a create-button flash.
2. **Jobs header** — **Sync jobs** now appears for synced external TMS projects (UUID project IDs with `source: external_tms`), not only encoded `ext:` provider project IDs.
3. **Job detail loading** — Replaced the old single-card skeleton with `JobDetailSkeleton` matching the unified two-column layout.

## Testing

- `vp check --fix` — pass
- `vp test` on workspace capabilities + job detail components — pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-185f3e6b-a42b-42d8-a012-69ece5c445d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-185f3e6b-a42b-42d8-a012-69ece5c445d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

