### PR TITLE
feat(web): gate automations and knowledge with WorkOS feature flags

### DIFF
--- a/apps/hyperlocalise-web/package.json
+++ b/apps/hyperlocalise-web/package.json
@@ -66,6 +66,7 @@
     "drizzle-orm": "0.45.2",
     "embla-carousel-react": "^8.6.0",
     "evlog": "^2.17.0",
+    "flags": "^4.2.0",
     "gray-matter": "^4.0.3",
     "hono": "4.12.25",
     "jsonwebtoken": "^9.0.3",

--- a/apps/hyperlocalise-web/pnpm-lock.yaml
+++ b/apps/hyperlocalise-web/pnpm-lock.yaml
@@ -177,6 +177,9 @@ importers:
       evlog:
         specifier: ^2.17.0
         version: 2.19.1(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nuxt/kit@4.4.7)(ai@6.0.204(zod@4.4.3))(express@5.2.1(supports-color@8.1.1))(hono@4.12.25)(next@16.2.9(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      flags:
+        specifier: ^4.2.0
+        version: 4.2.0(@opentelemetry/api@1.9.1)(next@16.2.9(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
@@ -950,6 +953,10 @@ packages:
     engines: {bun: '>=1', deno: '>=2.7.10', node: '>=16'}
     peerDependencies:
       '@noble/ciphers': ^1.0.0
+
+  '@edge-runtime/cookies@5.0.2':
+    resolution: {integrity: sha512-Sd8LcWpZk/SWEeKGE8LT6gMm5MGfX/wm+GPnh1eBEtCpya3vYqn37wYknwAHw92ONoyyREl1hJwxV/Qx2DWNOg==}
+    engines: {node: '>=16'}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -5921,6 +5928,26 @@ packages:
     resolution: {integrity: sha512-2kCCtc+JvcZ86IGAz3Z2Y0A1baIz9fL31pH/0S1IqZr9Iwnjq8izfPtrCyQKO6TLMPELLsQMre7VDqeIKCsHkA==}
     engines: {node: '>=18'}
 
+  flags@4.2.0:
+    resolution: {integrity: sha512-/ahGKxe4Q3C2pi2FS7h6cNR4HWnU7/MWAtwcrTHLBQjM9vVe5NR+uRIbL+vXYYU8PYbb8VnwnD+bdLH6l69m0g==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.7.0
+      '@sveltejs/kit': '*'
+      next: '*'
+      react: '*'
+      react-dom: '*'
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
@@ -9125,7 +9152,7 @@ snapshots:
   '@anthropic-ai/claude-agent-sdk@0.2.92(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.104.1(zod@4.4.3)
-      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.29.0(supports-color@8.1.1)(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
@@ -9506,7 +9533,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/core@7.29.7':
+  '@babel/core@7.29.7(supports-color@8.1.1)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
@@ -9611,7 +9638,7 @@ snapshots:
 
   '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
       '@babel/traverse': 7.29.7
@@ -9906,6 +9933,8 @@ snapshots:
   '@ecies/ciphers@0.2.6(@noble/ciphers@1.3.0)':
     dependencies:
       '@noble/ciphers': 1.3.0
+
+  '@edge-runtime/cookies@5.0.2': {}
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -10360,28 +10389,6 @@ snapshots:
       raw-body: 3.0.2
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
-    dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.25)
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
-      content-type: 1.0.5
-      cors: 2.8.6
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.0.8
-      express: 5.2.1(supports-color@8.1.1)
-      express-rate-limit: 8.3.2(express@5.2.1(supports-color@8.1.1))
-      hono: 4.12.25
-      jose: 6.2.2
-      json-schema-typed: 8.0.2
-      pkce-challenge: 5.0.1
-      raw-body: 3.0.2
-      zod: 4.4.3
-      zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -11766,7 +11773,7 @@ snapshots:
   '@storybook/nextjs-vite@10.4.6(@babel/core@7.29.0(supports-color@8.1.1))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(next@16.2.9(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)))(supports-color@8.1.1)(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@storybook/builder-vite': 10.4.6(esbuild@0.28.1)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
-      '@storybook/react': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)))(typescript@6.0.3)
+      '@storybook/react': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)))(supports-color@8.1.1)(typescript@6.0.3)
       '@storybook/react-vite': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)))(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       next: 16.2.9(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
@@ -11801,11 +11808,11 @@ snapshots:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@rollup/pluginutils': 5.4.0
       '@storybook/builder-vite': 10.4.6(esbuild@0.28.1)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
-      '@storybook/react': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)))(typescript@6.0.3)
+      '@storybook/react': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)))(supports-color@8.1.1)(typescript@6.0.3)
       empathic: 2.0.1
       magic-string: 0.30.21
       react: 19.2.7
-      react-docgen: 8.0.3
+      react-docgen: 8.0.3(supports-color@8.1.1)
       react-dom: 19.2.7(react@19.2.7)
       resolve: 1.22.12
       storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0))
@@ -11820,12 +11827,12 @@ snapshots:
       - typescript
       - webpack
 
-  '@storybook/react@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)))(typescript@6.0.3)':
+  '@storybook/react@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)))(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/react-dom-shim': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)))
       react: 19.2.7
-      react-docgen: 8.0.3
+      react-docgen: 8.0.3(supports-color@8.1.1)
       react-docgen-typescript: 2.4.0(typescript@6.0.3)
       react-dom: 19.2.7(react@19.2.7)
       storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0))
@@ -14598,6 +14605,16 @@ snapshots:
       semver-regex: 4.0.5
       super-regex: 1.1.0
 
+  flags@4.2.0(@opentelemetry/api@1.9.1)(next@16.2.9(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      '@edge-runtime/cookies': 5.0.2
+      jose: 5.10.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      next: 16.2.9(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
   flat-cache@4.0.1:
     dependencies:
       flatted: 3.4.2
@@ -16682,9 +16699,9 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  react-docgen@8.0.3:
+  react-docgen@8.0.3(supports-color@8.1.1):
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
       '@types/babel__core': 7.20.5

--- a/apps/hyperlocalise-web/src/app/.well-known/vercel/flags/route.ts
+++ b/apps/hyperlocalise-web/src/app/.well-known/vercel/flags/route.ts
@@ -1,0 +1,13 @@
+import { createFlagsDiscoveryEndpoint, getProviderData } from "flags/next";
+
+import {
+  workspaceAutomationsFlag,
+  workspaceKnowledgeFlag,
+} from "../../../../lib/flags/workspace-flags";
+
+export const GET = createFlagsDiscoveryEndpoint(async () =>
+  getProviderData({
+    workspaceAutomationsFlag,
+    workspaceKnowledgeFlag,
+  }),
+);

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/[automationId]/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/[automationId]/page.tsx
@@ -1,5 +1,8 @@
 import { Suspense } from "react";
 
+import { requireWorkspaceFeatureFlag, workspaceAutomationsFlag } from "@/lib/flags/workspace-flags";
+import { requireAppAuthContext } from "@/lib/workos/app-auth";
+
 import { AutomationDetailPageContent } from "../_components/automation-detail-page-content";
 
 export default async function AutomationDetailPage({
@@ -8,6 +11,8 @@ export default async function AutomationDetailPage({
   params: Promise<{ organizationSlug: string; automationId: string }>;
 }) {
   const { organizationSlug, automationId } = await params;
+  const auth = await requireAppAuthContext({ organizationSlug });
+  await requireWorkspaceFeatureFlag(workspaceAutomationsFlag, auth);
 
   return (
     <Suspense fallback={null}>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/new/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/new/page.tsx
@@ -5,6 +5,8 @@ import {
   createWorkspaceAutomationFormStateFromTemplate,
 } from "@/lib/agents/workspace-automation-view-model";
 import { getMergedWorkspaceAutomationTemplates } from "@/lib/agents/workspace-automation-templates.server";
+import { requireWorkspaceFeatureFlag, workspaceAutomationsFlag } from "@/lib/flags/workspace-flags";
+import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
 import { AutomationsNewPageContent } from "../_components/automations-new-page-content";
 
@@ -17,6 +19,8 @@ export default async function NewAutomationPage({
 }) {
   const { organizationSlug } = await params;
   const { template } = await searchParams;
+  const auth = await requireAppAuthContext({ organizationSlug });
+  await requireWorkspaceFeatureFlag(workspaceAutomationsFlag, auth);
   const templates = getMergedWorkspaceAutomationTemplates();
   const initialForm = template
     ? (createWorkspaceAutomationFormStateFromTemplate(template, templates) ??

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/automations/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react";
 
 import { getMergedWorkspaceAutomationTemplates } from "@/lib/agents/workspace-automation-templates.server";
+import { requireWorkspaceFeatureFlag, workspaceAutomationsFlag } from "@/lib/flags/workspace-flags";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
 import { AutomationsPageContent } from "./_components/automations-page-content";
@@ -11,7 +12,8 @@ export default async function AutomationsPage({
   params: Promise<{ organizationSlug: string }>;
 }) {
   const { organizationSlug } = await params;
-  await requireAppAuthContext({ organizationSlug });
+  const auth = await requireAppAuthContext({ organizationSlug });
+  await requireWorkspaceFeatureFlag(workspaceAutomationsFlag, auth);
   const templates = getMergedWorkspaceAutomationTemplates();
 
   return (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/command-center/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/command-center/page.tsx
@@ -1,10 +1,35 @@
 import { redirect } from "next/navigation";
 
+function buildDashboardRedirectPath(
+  organizationSlug: string,
+  searchParams: Record<string, string | string[] | undefined>,
+) {
+  const query = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(searchParams)) {
+    if (typeof value === "string") {
+      query.set(key, value);
+      continue;
+    }
+
+    for (const entry of value ?? []) {
+      query.append(key, entry);
+    }
+  }
+
+  const queryString = query.toString();
+  return queryString
+    ? `/org/${organizationSlug}/dashboard?${queryString}`
+    : `/org/${organizationSlug}/dashboard`;
+}
+
 export default async function CommandCenterPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ organizationSlug: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
-  const { organizationSlug } = await params;
-  redirect(`/org/${organizationSlug}/dashboard`);
+  const [{ organizationSlug }, resolvedSearchParams] = await Promise.all([params, searchParams]);
+  redirect(buildDashboardRedirectPath(organizationSlug, resolvedSearchParams));
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/dashboard/_components/dashboard-page-content.tsx
@@ -1,11 +1,35 @@
 "use client";
 
 import { DashboardSquare01Icon } from "@hugeicons/core-free-icons";
+import { useSearchParams } from "next/navigation";
+import { useEffect, useRef } from "react";
+import { toast } from "sonner";
 
 import { PageHeader, WorkspacePageShell } from "../../_components/workspace-resource-shared";
+import { WORKSPACE_FEATURE_UNAVAILABLE_REASON } from "@/lib/flags/workos-flag-entities";
 import { TmsDashboardSummarySection } from "./tms-dashboard-summary-section";
 
 export function DashboardPageContent({ organizationSlug }: { organizationSlug: string }) {
+  const searchParams = useSearchParams();
+  const handledFeatureUnavailableRef = useRef(false);
+
+  useEffect(() => {
+    if (
+      searchParams.get("reason") !== WORKSPACE_FEATURE_UNAVAILABLE_REASON ||
+      handledFeatureUnavailableRef.current
+    ) {
+      return;
+    }
+
+    handledFeatureUnavailableRef.current = true;
+
+    const url = new URL(window.location.href);
+    url.searchParams.delete("reason");
+    window.history.replaceState(null, "", url.toString());
+
+    toast.error("This feature is not available for your workspace yet.");
+  }, [searchParams]);
+
   return (
     <WorkspacePageShell>
       <PageHeader

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/knowledge/page.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/knowledge/page.tsx
@@ -1,5 +1,6 @@
 import { hasCapability } from "@/api/auth/policy";
 import { TypographyH1, TypographyP } from "@/components/ui/typography";
+import { requireWorkspaceFeatureFlag, workspaceKnowledgeFlag } from "@/lib/flags/workspace-flags";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
 import { KnowledgeMemoryEditor } from "./_components/knowledge-memory-editor";
@@ -11,6 +12,7 @@ export default async function KnowledgePage({
 }) {
   const { organizationSlug } = await params;
   const auth = await requireAppAuthContext({ organizationSlug });
+  await requireWorkspaceFeatureFlag(workspaceKnowledgeFlag, auth);
 
   return (
     <div className="mx-auto flex w-full max-w-3xl flex-col gap-8">

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell.tsx
@@ -1,14 +1,18 @@
 import type { ReactNode } from "react";
 
 import { hasCapability } from "@/api/auth/policy";
-import { requireAppAuthContext } from "@/lib/workos/app-auth";
 import { AppShellClient } from "@/components/app-shell/app-shell-client";
 import { AppShellNavigation } from "@/components/app-shell/app-shell-navigation";
 import { buildGlobalNavigationGroups } from "@/components/app-shell/navigation-config";
 import {
+  evaluateWorkspaceFeatureFlags,
+  filterNavigationByWorkspaceFlags,
+} from "@/lib/flags/workspace-flags";
+import {
   getTmsUserConnectCtaState,
   type TmsUserConnectCta,
 } from "@/lib/providers/tms-user-connection";
+import { requireAppAuthContext } from "@/lib/workos/app-auth";
 
 export type AppShellProps = {
   children: ReactNode;
@@ -22,7 +26,11 @@ export async function AppShell({ children, organizationSlug }: AppShellProps) {
   const displayName =
     [auth.sessionUser.firstName, auth.sessionUser.lastName].filter(Boolean).join(" ") ||
     auth.sessionUser.email;
-  const navigationGroups = buildGlobalNavigationGroups(activeOrganizationSlug);
+  const workspaceFeatureFlags = await evaluateWorkspaceFeatureFlags(auth);
+  const navigationGroups = filterNavigationByWorkspaceFlags(
+    buildGlobalNavigationGroups(activeOrganizationSlug),
+    workspaceFeatureFlags,
+  );
   const tmsUserConnectCta: TmsUserConnectCta = hasCapability(auth.membership.role, "jobs:read")
     ? await getTmsUserConnectCtaState({
         organizationId: auth.activeOrganization.localOrganizationId,

--- a/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
+++ b/apps/hyperlocalise-web/src/components/app-shell/navigation-config.ts
@@ -2,6 +2,10 @@ import type { ComponentProps } from "react";
 
 import { normalizeAppLocale } from "@/lib/app-i18n/locales";
 import {
+  WORKSPACE_AUTOMATIONS_FLAG,
+  WORKSPACE_KNOWLEDGE_FLAG,
+} from "@/lib/flags/workos-flag-entities";
+import {
   AiBrain01Icon,
   BookOpenTextIcon,
   Chat01Icon,
@@ -26,6 +30,7 @@ export type NavigationItem = {
   icon: NavigationIcon;
   description?: string;
   badge?: string;
+  featureFlagKey?: typeof WORKSPACE_AUTOMATIONS_FLAG | typeof WORKSPACE_KNOWLEDGE_FLAG;
 };
 
 export type NavigationGroup = {
@@ -75,6 +80,7 @@ export function buildGlobalNavigationGroups(organizationSlug: string): readonly 
           icon: Task01Icon,
           description: "Scheduled and GitHub-triggered deterministic workflows",
           badge: "Beta",
+          featureFlagKey: WORKSPACE_AUTOMATIONS_FLAG,
         },
       ],
     },
@@ -91,7 +97,7 @@ export function buildGlobalNavigationGroups(organizationSlug: string): readonly 
           href: org("knowledge"),
           icon: AiBrain01Icon,
           description: "Workspace memory for agents and teams",
-          badge: "Coming soon",
+          featureFlagKey: WORKSPACE_KNOWLEDGE_FLAG,
         },
         {
           label: "Glossaries",

--- a/apps/hyperlocalise-web/src/lib/env.ts
+++ b/apps/hyperlocalise-web/src/lib/env.ts
@@ -58,6 +58,9 @@ export const env = createEnv({
     /** Secret used by WorkOS to sign webhook payloads. Required for secure WorkOS webhook handling. */
     WORKOS_WEBHOOK_SECRET: z.string().min(1).optional(),
 
+    /** Secret used by Flags SDK for toolbar overrides and encrypted flag values. */
+    FLAGS_SECRET: z.string().min(32).optional(),
+
     /** Resend API key for sending and receiving emails. Required for email bot integration. */
     RESEND_API_KEY: z.string().min(1).optional(),
 
@@ -226,6 +229,9 @@ export const env = createEnv({
       (isTestEnv ? "test-workos-cookie-password-at-least-32-chars" : undefined),
     WORKOS_WEBHOOK_SECRET:
       process.env.WORKOS_WEBHOOK_SECRET ?? (isTestEnv ? "test-workos-webhook-secret" : undefined),
+    FLAGS_SECRET:
+      process.env.FLAGS_SECRET ??
+      (isTestEnv ? "test-flags-secret-at-least-32-characters-long" : undefined),
     RESEND_API_KEY: process.env.RESEND_API_KEY ?? (isTestEnv ? "test-resend-api-key" : undefined),
     RESEND_WEBHOOK_SECRET:
       process.env.RESEND_WEBHOOK_SECRET ?? (isTestEnv ? "test-resend-webhook-secret" : undefined),

--- a/apps/hyperlocalise-web/src/lib/flags/identify-workos-context.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/identify-workos-context.ts
@@ -1,6 +1,3 @@
-import { withAuth } from "@workos-inc/authkit-nextjs";
-import { dedupe } from "flags/next";
-
 import type { AppAuthContext } from "@/lib/workos/app-auth";
 
 import type { WorkosFlagEntities } from "./workos-flag-entities";
@@ -13,12 +10,3 @@ export function createWorkosIdentify(
     organization: { id: auth.activeOrganization.workosOrganizationId },
   };
 }
-
-export const identifyWorkosContextFromSession = dedupe(async (): Promise<WorkosFlagEntities> => {
-  const { user, organizationId } = await withAuth({ ensureSignedIn: true });
-
-  return {
-    user: user?.id ? { id: user.id } : undefined,
-    organization: organizationId ? { id: organizationId } : undefined,
-  };
-});

--- a/apps/hyperlocalise-web/src/lib/flags/identify-workos-context.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/identify-workos-context.ts
@@ -1,0 +1,24 @@
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { dedupe } from "flags/next";
+
+import type { AppAuthContext } from "@/lib/workos/app-auth";
+
+import type { WorkosFlagEntities } from "./workos-flag-entities";
+
+export function createWorkosIdentify(
+  auth: Pick<AppAuthContext, "activeOrganization" | "user">,
+): WorkosFlagEntities {
+  return {
+    user: { id: auth.user.workosUserId },
+    organization: { id: auth.activeOrganization.workosOrganizationId },
+  };
+}
+
+export const identifyWorkosContextFromSession = dedupe(async (): Promise<WorkosFlagEntities> => {
+  const { user, organizationId } = await withAuth({ ensureSignedIn: true });
+
+  return {
+    user: user?.id ? { id: user.id } : undefined,
+    organization: organizationId ? { id: organizationId } : undefined,
+  };
+});

--- a/apps/hyperlocalise-web/src/lib/flags/workos-adapter.test.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workos-adapter.test.ts
@@ -59,7 +59,7 @@ describe("workosAdapter", () => {
     });
 
     expect(enabled).toBe(true);
-    expect(waitUntilReady).toHaveBeenCalledWith({ timeoutMs: 5_000 });
+    expect(waitUntilReady).toHaveBeenCalledWith({ timeoutMs: 2_000 });
     expect(isEnabled).toHaveBeenCalledWith(WORKSPACE_AUTOMATIONS_FLAG, {
       organizationId: "org_456",
       userId: "user_123",

--- a/apps/hyperlocalise-web/src/lib/flags/workos-adapter.test.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workos-adapter.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import type { ReadonlyRequestCookies } from "flags";
+
+import { buildGlobalNavigationGroups } from "@/components/app-shell/navigation-config";
+import {
+  WORKSPACE_AUTOMATIONS_FLAG,
+  WORKSPACE_KNOWLEDGE_FLAG,
+} from "@/lib/flags/workos-flag-entities";
+import { filterNavigationByWorkspaceFlags } from "@/lib/flags/workspace-flags";
+
+const isEnabled = vi.fn();
+const waitUntilReady = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("@workos-inc/authkit-nextjs", () => ({
+  getFeatureFlagsRuntimeClient: () => ({
+    isEnabled,
+    waitUntilReady,
+  }),
+}));
+
+vi.mock("@/lib/workos/config", () => ({
+  getWorkosAuthKitConfig: () => ({
+    apiKey: "sk_test",
+    clientId: "client_test",
+    redirectUri: "http://localhost:3000/auth/callback",
+    cookiePassword: "test-workos-cookie-password-at-least-32-chars",
+  }),
+}));
+
+describe("workosAdapter", () => {
+  beforeEach(() => {
+    isEnabled.mockReset();
+    waitUntilReady.mockClear();
+    waitUntilReady.mockResolvedValue(undefined);
+  });
+
+  function createMockCookies(): ReadonlyRequestCookies {
+    return {
+      get: () => undefined,
+      getAll: () => [],
+      has: () => false,
+      size: 0,
+      [Symbol.iterator]: () => [][Symbol.iterator](),
+    } as unknown as ReadonlyRequestCookies;
+  }
+  it("passes organization and user ids to the WorkOS runtime client", async () => {
+    isEnabled.mockResolvedValue(true);
+
+    const { createWorkosAdapter } = await import("./workos-adapter");
+    const adapter = createWorkosAdapter()();
+    const enabled = await adapter.decide({
+      key: WORKSPACE_AUTOMATIONS_FLAG,
+      entities: {
+        user: { id: "user_123" },
+        organization: { id: "org_456" },
+      },
+      headers: new Headers(),
+      cookies: createMockCookies(),
+    });
+
+    expect(enabled).toBe(true);
+    expect(waitUntilReady).toHaveBeenCalledWith({ timeoutMs: 5_000 });
+    expect(isEnabled).toHaveBeenCalledWith(WORKSPACE_AUTOMATIONS_FLAG, {
+      organizationId: "org_456",
+      userId: "user_123",
+    });
+  });
+
+  it("returns false when WorkOS is disabled", async () => {
+    vi.resetModules();
+    vi.doMock("@/lib/workos/config", () => ({
+      getWorkosAuthKitConfig: () => null,
+    }));
+
+    const { createWorkosAdapter } = await import("./workos-adapter");
+    const adapter = createWorkosAdapter()();
+    const enabled = await adapter.decide({
+      key: WORKSPACE_KNOWLEDGE_FLAG,
+      entities: {
+        user: { id: "user_123" },
+        organization: { id: "org_456" },
+      },
+      headers: new Headers(),
+      cookies: createMockCookies(),
+    });
+
+    expect(enabled).toBe(false);
+    expect(isEnabled).not.toHaveBeenCalled();
+
+    vi.doUnmock("@/lib/workos/config");
+    vi.resetModules();
+  });
+});
+
+describe("filterNavigationByWorkspaceFlags", () => {
+  it("removes Automations and Knowledge when workspace flags are disabled", () => {
+    const groups = buildGlobalNavigationGroups("acme");
+    const filtered = filterNavigationByWorkspaceFlags(groups, {
+      automations: false,
+      knowledge: false,
+    });
+
+    const itemLabels = filtered.flatMap((group) => group.items.map((item) => item.label));
+
+    expect(itemLabels).not.toContain("Automations");
+    expect(itemLabels).not.toContain("Knowledge");
+    expect(itemLabels).toContain("Projects");
+  });
+
+  it("keeps Automations and Knowledge when workspace flags are enabled", () => {
+    const groups = buildGlobalNavigationGroups("acme");
+    const filtered = filterNavigationByWorkspaceFlags(groups, {
+      automations: true,
+      knowledge: true,
+    });
+
+    const itemLabels = filtered.flatMap((group) => group.items.map((item) => item.label));
+
+    expect(itemLabels).toContain("Automations");
+    expect(itemLabels).toContain("Knowledge");
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/flags/workos-adapter.test.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workos-adapter.test.ts
@@ -29,6 +29,7 @@ vi.mock("@/lib/workos/config", () => ({
 
 describe("workosAdapter", () => {
   beforeEach(() => {
+    vi.resetModules();
     isEnabled.mockReset();
     waitUntilReady.mockClear();
     waitUntilReady.mockResolvedValue(undefined);
@@ -59,11 +60,34 @@ describe("workosAdapter", () => {
     });
 
     expect(enabled).toBe(true);
+    expect(waitUntilReady).toHaveBeenCalledTimes(1);
     expect(waitUntilReady).toHaveBeenCalledWith({ timeoutMs: 2_000 });
     expect(isEnabled).toHaveBeenCalledWith(WORKSPACE_AUTOMATIONS_FLAG, {
       organizationId: "org_456",
       userId: "user_123",
     });
+  });
+
+  it("waits for feature flag readiness only once per process", async () => {
+    isEnabled.mockResolvedValue(false);
+
+    const { createWorkosAdapter } = await import("./workos-adapter");
+    const adapter = createWorkosAdapter()();
+    const decideArgs = {
+      key: WORKSPACE_AUTOMATIONS_FLAG,
+      entities: {
+        user: { id: "user_123" },
+        organization: { id: "org_456" },
+      },
+      headers: new Headers(),
+      cookies: createMockCookies(),
+    };
+
+    await adapter.decide(decideArgs);
+    await adapter.decide({ ...decideArgs, key: WORKSPACE_KNOWLEDGE_FLAG });
+
+    expect(waitUntilReady).toHaveBeenCalledTimes(1);
+    expect(isEnabled).toHaveBeenCalledTimes(2);
   });
 
   it("returns false when WorkOS is disabled", async () => {

--- a/apps/hyperlocalise-web/src/lib/flags/workos-adapter.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workos-adapter.ts
@@ -6,12 +6,29 @@ import { getWorkosAuthKitConfig } from "@/lib/workos/config";
 import type { WorkosFlagEntities } from "./workos-flag-entities";
 
 const WORKOS_ADAPTER_ID = Symbol("workos-feature-flags");
+const FEATURE_FLAGS_READY_TIMEOUT_MS = 2_000;
 
 let defaultWorkosAdapter: ReturnType<typeof createWorkosAdapter> | undefined;
+let featureFlagsReadyPromise: Promise<void> | undefined;
 
 function isWorkosFeatureFlagsEnabled() {
   const config = getWorkosAuthKitConfig();
   return Boolean(config?.apiKey);
+}
+
+function waitForFeatureFlagsReady(
+  client: ReturnType<typeof getFeatureFlagsRuntimeClient>,
+): Promise<void> {
+  if (!featureFlagsReadyPromise) {
+    featureFlagsReadyPromise = client
+      .waitUntilReady({ timeoutMs: FEATURE_FLAGS_READY_TIMEOUT_MS })
+      .catch((error) => {
+        featureFlagsReadyPromise = undefined;
+        throw error;
+      });
+  }
+
+  return featureFlagsReadyPromise;
 }
 
 export function createWorkosAdapter() {
@@ -30,7 +47,7 @@ export function createWorkosAdapter() {
 
         try {
           const client = getFeatureFlagsRuntimeClient();
-          await client.waitUntilReady({ timeoutMs: 2_000 });
+          await waitForFeatureFlagsReady(client);
           return client.isEnabled(key, {
             organizationId: context?.organization?.id,
             userId: context?.user?.id,

--- a/apps/hyperlocalise-web/src/lib/flags/workos-adapter.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workos-adapter.ts
@@ -1,0 +1,52 @@
+import { getFeatureFlagsRuntimeClient } from "@workos-inc/authkit-nextjs";
+import type { Adapter } from "flags";
+
+import { getWorkosAuthKitConfig } from "@/lib/workos/config";
+
+import type { WorkosFlagEntities } from "./workos-flag-entities";
+
+const WORKOS_ADAPTER_ID = Symbol("workos-feature-flags");
+
+let defaultWorkosAdapter: ReturnType<typeof createWorkosAdapter> | undefined;
+
+function isWorkosFeatureFlagsEnabled() {
+  const config = getWorkosAuthKitConfig();
+  return Boolean(config?.apiKey);
+}
+
+export function createWorkosAdapter() {
+  return function workosAdapter<ValueType, EntitiesType>(): Adapter<ValueType, EntitiesType> {
+    return {
+      adapterId: WORKOS_ADAPTER_ID,
+      origin(key) {
+        return `https://dashboard.workos.com/feature-flags/${key}`;
+      },
+      async decide({ key, entities }) {
+        if (!isWorkosFeatureFlagsEnabled()) {
+          return false as ValueType;
+        }
+
+        const context = entities as WorkosFlagEntities | undefined;
+
+        try {
+          const client = getFeatureFlagsRuntimeClient();
+          await client.waitUntilReady({ timeoutMs: 5_000 });
+          return client.isEnabled(key, {
+            organizationId: context?.organization?.id,
+            userId: context?.user?.id,
+          }) as ValueType;
+        } catch {
+          return false as ValueType;
+        }
+      },
+    };
+  };
+}
+
+export function workosAdapter<ValueType, EntitiesType>(): Adapter<ValueType, EntitiesType> {
+  if (!defaultWorkosAdapter) {
+    defaultWorkosAdapter = createWorkosAdapter();
+  }
+
+  return defaultWorkosAdapter<ValueType, EntitiesType>();
+}

--- a/apps/hyperlocalise-web/src/lib/flags/workos-adapter.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workos-adapter.ts
@@ -30,7 +30,7 @@ export function createWorkosAdapter() {
 
         try {
           const client = getFeatureFlagsRuntimeClient();
-          await client.waitUntilReady({ timeoutMs: 5_000 });
+          await client.waitUntilReady({ timeoutMs: 2_000 });
           return client.isEnabled(key, {
             organizationId: context?.organization?.id,
             userId: context?.user?.id,

--- a/apps/hyperlocalise-web/src/lib/flags/workos-flag-entities.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workos-flag-entities.ts
@@ -1,5 +1,6 @@
 export const WORKSPACE_AUTOMATIONS_FLAG = "workspace-automations";
 export const WORKSPACE_KNOWLEDGE_FLAG = "workspace-knowledge";
+export const WORKSPACE_FEATURE_UNAVAILABLE_REASON = "feature-unavailable";
 
 export type WorkosFlagEntities = {
   user?: { id: string };

--- a/apps/hyperlocalise-web/src/lib/flags/workos-flag-entities.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workos-flag-entities.ts
@@ -1,0 +1,12 @@
+export const WORKSPACE_AUTOMATIONS_FLAG = "workspace-automations";
+export const WORKSPACE_KNOWLEDGE_FLAG = "workspace-knowledge";
+
+export type WorkosFlagEntities = {
+  user?: { id: string };
+  organization?: { id: string };
+};
+
+export type WorkspaceFeatureFlagState = {
+  automations: boolean;
+  knowledge: boolean;
+};

--- a/apps/hyperlocalise-web/src/lib/flags/workspace-flags.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workspace-flags.ts
@@ -15,12 +15,14 @@ import {
 
 export const workspaceAutomationsFlag = flag<boolean, WorkosFlagEntities>({
   key: WORKSPACE_AUTOMATIONS_FLAG,
+  defaultValue: false,
   description: "Workspace automations for scheduled and GitHub-triggered workflows.",
   adapter: workosAdapter(),
 });
 
 export const workspaceKnowledgeFlag = flag<boolean, WorkosFlagEntities>({
   key: WORKSPACE_KNOWLEDGE_FLAG,
+  defaultValue: false,
   description: "Workspace knowledge memory for agents and teams.",
   adapter: workosAdapter(),
 });

--- a/apps/hyperlocalise-web/src/lib/flags/workspace-flags.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workspace-flags.ts
@@ -1,0 +1,80 @@
+import { redirect } from "next/navigation";
+import { flag, type Flag } from "flags/next";
+
+import type { NavigationGroup } from "@/components/app-shell/navigation-config";
+import type { AppAuthContext } from "@/lib/workos/app-auth";
+
+import { createWorkosIdentify } from "./identify-workos-context";
+import { workosAdapter } from "./workos-adapter";
+import {
+  WORKSPACE_AUTOMATIONS_FLAG,
+  WORKSPACE_KNOWLEDGE_FLAG,
+  type WorkosFlagEntities,
+  type WorkspaceFeatureFlagState,
+} from "./workos-flag-entities";
+
+export const workspaceAutomationsFlag = flag<boolean, WorkosFlagEntities>({
+  key: WORKSPACE_AUTOMATIONS_FLAG,
+  description: "Workspace automations for scheduled and GitHub-triggered workflows.",
+  adapter: workosAdapter(),
+});
+
+export const workspaceKnowledgeFlag = flag<boolean, WorkosFlagEntities>({
+  key: WORKSPACE_KNOWLEDGE_FLAG,
+  description: "Workspace knowledge memory for agents and teams.",
+  adapter: workosAdapter(),
+});
+
+export async function evaluateWorkspaceFeatureFlags(
+  auth: Pick<AppAuthContext, "activeOrganization" | "user">,
+): Promise<WorkspaceFeatureFlagState> {
+  const identify = () => createWorkosIdentify(auth);
+
+  const [automations, knowledge] = await Promise.all([
+    workspaceAutomationsFlag.run({ identify }),
+    workspaceKnowledgeFlag.run({ identify }),
+  ]);
+
+  return { automations, knowledge };
+}
+
+export async function requireWorkspaceFeatureFlag(
+  workspaceFlag: Flag<boolean, WorkosFlagEntities>,
+  auth: Pick<AppAuthContext, "activeOrganization" | "user">,
+) {
+  const enabled = await workspaceFlag.run({ identify: () => createWorkosIdentify(auth) });
+
+  if (enabled) {
+    return;
+  }
+
+  const organizationSlug = auth.activeOrganization.slug;
+  if (organizationSlug) {
+    redirect(`/org/${organizationSlug}/command-center?reason=feature-unavailable`);
+  }
+
+  redirect("/auth/select-organization");
+}
+
+export function filterNavigationByWorkspaceFlags(
+  groups: readonly NavigationGroup[],
+  flags: WorkspaceFeatureFlagState,
+): readonly NavigationGroup[] {
+  const enabledByKey: Record<string, boolean> = {
+    [WORKSPACE_AUTOMATIONS_FLAG]: flags.automations,
+    [WORKSPACE_KNOWLEDGE_FLAG]: flags.knowledge,
+  };
+
+  return groups
+    .map((group) => ({
+      ...group,
+      items: group.items.filter((item) => {
+        if (!item.featureFlagKey) {
+          return true;
+        }
+
+        return enabledByKey[item.featureFlagKey] ?? false;
+      }),
+    }))
+    .filter((group) => group.items.length > 0);
+}

--- a/apps/hyperlocalise-web/src/lib/flags/workspace-flags.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workspace-flags.ts
@@ -8,6 +8,7 @@ import { createWorkosIdentify } from "./identify-workos-context";
 import { workosAdapter } from "./workos-adapter";
 import {
   WORKSPACE_AUTOMATIONS_FLAG,
+  WORKSPACE_FEATURE_UNAVAILABLE_REASON,
   WORKSPACE_KNOWLEDGE_FLAG,
   type WorkosFlagEntities,
   type WorkspaceFeatureFlagState,
@@ -52,7 +53,9 @@ export async function requireWorkspaceFeatureFlag(
 
   const organizationSlug = auth.activeOrganization.slug;
   if (organizationSlug) {
-    redirect(`/org/${organizationSlug}/command-center?reason=feature-unavailable`);
+    redirect(
+      `/org/${organizationSlug}/command-center?reason=${WORKSPACE_FEATURE_UNAVAILABLE_REASON}`,
+    );
   }
 
   redirect("/auth/select-organization");


### PR DESCRIPTION
## What changed

Gate **Automations** and **Knowledge** behind WorkOS org-scoped feature flags using the Flags SDK with a custom WorkOS adapter backed by AuthKit's `getFeatureFlagsRuntimeClient()`.

- Add `workspace-automations` and `workspace-knowledge` flag declarations with server-side evaluation helpers
- Filter AppShell navigation based on URL-resolved org context
- Guard automations and knowledge routes with redirects when flags are disabled
- Add optional Flags Explorer discovery endpoint for local dev tooling
- Add unit tests for the WorkOS adapter and nav filtering

## How to test

1. Create `workspace-automations` and `workspace-knowledge` in the WorkOS dashboard with organization targeting and `default_value: false`.
2. Enable flags for a pilot org.
3. With flags off: Automations/Knowledge nav items are hidden and direct URLs redirect to `/org/{slug}/command-center?reason=feature-unavailable`.
4. With flags on: nav items appear and pages load normally.
5. Switch workspaces and confirm nav reflects the URL org's flag state.

```bash
cd apps/hyperlocalise-web
vp test src/lib/flags/workos-adapter.test.ts
vp check --fix
```

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)