### PR TITLE
fix(flags): await isEnabled in WorkOS adapter error boundary

### DIFF
--- a/apps/hyperlocalise-web/src/lib/flags/workos-adapter.test.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workos-adapter.test.ts
@@ -90,6 +90,24 @@ describe("workosAdapter", () => {
     expect(isEnabled).toHaveBeenCalledTimes(2);
   });
 
+  it("returns false when isEnabled rejects", async () => {
+    isEnabled.mockRejectedValue(new Error("WorkOS API error"));
+
+    const { createWorkosAdapter } = await import("./workos-adapter");
+    const adapter = createWorkosAdapter()();
+    const enabled = await adapter.decide({
+      key: WORKSPACE_AUTOMATIONS_FLAG,
+      entities: {
+        user: { id: "user_123" },
+        organization: { id: "org_456" },
+      },
+      headers: new Headers(),
+      cookies: createMockCookies(),
+    });
+
+    expect(enabled).toBe(false);
+  });
+
   it("returns false when WorkOS is disabled", async () => {
     vi.resetModules();
     vi.doMock("@/lib/workos/config", () => ({

--- a/apps/hyperlocalise-web/src/lib/flags/workos-adapter.ts
+++ b/apps/hyperlocalise-web/src/lib/flags/workos-adapter.ts
@@ -48,10 +48,10 @@ export function createWorkosAdapter() {
         try {
           const client = getFeatureFlagsRuntimeClient();
           await waitForFeatureFlagsReady(client);
-          return client.isEnabled(key, {
+          return (await client.isEnabled(key, {
             organizationId: context?.organization?.id,
             userId: context?.user?.id,
-          }) as ValueType;
+          })) as ValueType;
         } catch {
           return false as ValueType;
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a code review issue where `client.isEnabled()` was returned without `await`, so rejections bypassed the surrounding `try/catch` and could fail page renders.

## Changes

- Await `client.isEnabled()` inside the adapter's `decide` handler so async rejections are caught and return `false`.
- Add a test that mocks `isEnabled` rejecting and asserts the adapter returns `false`.

## Testing

- `vp test src/lib/flags/workos-adapter.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-37a3a7e3-dead-40fe-a441-981b8b1830ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37a3a7e3-dead-40fe-a441-981b8b1830ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

