### PR TITLE
fix(crowdin): tolerate array tmPenalties in project responses

### DIFF
--- a/third_party/crowdin-api-client-go/crowdin/model/projects.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/projects.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"encoding/json"
 	"errors"
 	"net/url"
 	"strconv"
@@ -137,6 +138,18 @@ type (
 		LanguageIDs []string `json:"languageIds,omitempty"`
 	}
 )
+
+// UnmarshalJSON accepts both object and array tmPenalties payloads from Crowdin.
+// Some projects return an empty array instead of an object.
+func (p *ProjectTMPenalties) UnmarshalJSON(data []byte) error {
+	if len(data) > 0 && data[0] == '[' {
+		*p = ProjectTMPenalties{}
+		return nil
+	}
+
+	type projectTMPenaltiesAlias ProjectTMPenalties
+	return json.Unmarshal(data, (*projectTMPenaltiesAlias)(p))
+}
 
 // ProjectsListOptions specifies the optional parameters to the ProjectsService.List method.
 type ProjectsListOptions struct {

--- a/third_party/crowdin-api-client-go/crowdin/model/projects_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/projects_test.go
@@ -1,10 +1,55 @@
 package model
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestProjectTMPenaltiesUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+		want *ProjectTMPenalties
+	}{
+		{
+			name: "object",
+			data: `{"autoSubstitution":1,"multipleTranslations":1}`,
+			want: &ProjectTMPenalties{AutoSubstitution: 1, MultipleTranslations: 1},
+		},
+		{
+			name: "empty array",
+			data: `[]`,
+			want: &ProjectTMPenalties{},
+		},
+		{
+			name: "non-empty array",
+			data: `[1,2,3]`,
+			want: &ProjectTMPenalties{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var actual ProjectTMPenalties
+			err := actual.UnmarshalJSON([]byte(tt.data))
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, &actual)
+		})
+	}
+
+	t.Run("project response with array tmPenalties", func(t *testing.T) {
+		const payload = `{"data":{"id":1,"type":0,"userId":1,"sourceLanguageId":"en","targetLanguageIds":["fr"],"languageAccessPolicy":"all","name":"Test","identifier":"test","description":"","visibility":"private","logo":"","publicDownloads":false,"createdAt":"","updatedAt":"","lastActivity":"","webUrl":"","tmPenalties":[]}}`
+
+		var resp ProjectsGetResponse
+		err := json.Unmarshal([]byte(payload), &resp)
+		assert.NoError(t, err)
+		assert.NotNil(t, resp.Data)
+		assert.NotNil(t, resp.Data.TMPenalties)
+		assert.Equal(t, &ProjectTMPenalties{}, resp.Data.TMPenalties)
+	})
+}
 
 func TestProjectsListOptionsValues(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## What changed

Crowdin’s GET /projects/{id} response can return tmPenalties as a JSON array ([]) instead of the documented object shape. After TMPenalties was typed as *ProjectTMPenalties, that mismatch caused:

```
json: cannot unmarshal array into Go struct field Project.data.tmPenalties of type model.ProjectTMPenalties
```

This blocked Projects.Get calls used when resolving locales (e.g. get project: ... in the Crowdin HTTP client).

Added custom UnmarshalJSON on *ProjectTMPenalties so array payloads are treated as empty penalties, while object payloads still decode normally. Matches the existing LanguagesAccess pattern in the SDK.

