### PR TITLE
🧪 Scout: add unit tests for element types and nesting edge cases

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -91,3 +91,7 @@
 ## 2025-07-15 - [ICU Parser Error Robustness]
 **Learning:** ICU parsers should provide clear error messages for common syntax mistakes like unclosed braces, mismatched tags, or missing options. While leniency is good for some things (like unclosed quotes), structural errors should be caught to prevent malformed ASTs that could lead to incorrect translations or application crashes.
 **Action:** Include comprehensive error-case tests for the parser to ensure it correctly identifies and reports syntax errors in ICU messages and HTML tags.
+
+## 2025-07-20 - [ICU Element Type and Nesting Validation]
+**Learning:** ICU `PluralElement` can represent both `plural` and `selectordinal` types. Structural parity checks rely on the `Type()` method, which correctly chooses the type based on the `Ordinal` flag or an explicit override. Additionally, pound signs (`#`) must be identified as `PoundElement` even when nested inside non-plural blocks (like `select`) if they are ultimately contained by a `plural` or `selectordinal` block.
+**Action:** Always test the `Type()` method for all AST elements, especially for polymorphic elements like `PluralElement`. Ensure nesting tests cover cases where markers like `#` are separated from their parent block by other types of ICU blocks.

--- a/internal/i18n/icuparser/ast_test.go
+++ b/internal/i18n/icuparser/ast_test.go
@@ -8,10 +8,17 @@ func TestElementTypeMethods(t *testing.T) {
 		el   Element
 		want ElementType
 	}{
+		{name: "literal", el: LiteralElement{}, want: TypeLiteral},
+		{name: "argument", el: ArgumentElement{}, want: TypeArgument},
 		{name: "number", el: NumberElement{}, want: TypeNumber},
 		{name: "date", el: DateElement{}, want: TypeDate},
 		{name: "time", el: TimeElement{}, want: TypeTime},
 		{name: "select", el: SelectElement{}, want: TypeSelect},
+		{name: "plural", el: PluralElement{Ordinal: false}, want: TypePlural},
+		{name: "plural_explicit", el: PluralElement{PluralType: TypePlural}, want: TypePlural},
+		{name: "selectordinal", el: PluralElement{Ordinal: true}, want: TypeSelectOrdinal},
+		{name: "selectordinal_explicit", el: PluralElement{PluralType: TypeSelectOrdinal}, want: TypeSelectOrdinal},
+		{name: "pound", el: PoundElement{}, want: TypePound},
 		{name: "tag", el: TagElement{}, want: TypeTag},
 	}
 

--- a/internal/i18n/icuparser/parse_test.go
+++ b/internal/i18n/icuparser/parse_test.go
@@ -789,10 +789,33 @@ func TestParseASTPoundNesting(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Parse failed: %v", err)
 	}
+	if len(elems) != 1 {
+		t.Fatalf("expected 1 element, got %d", len(elems))
+	}
 
-	pl := elems[0].(PluralElement)
+	pl, ok := elems[0].(PluralElement)
+	if !ok {
+		t.Fatalf("expected PluralElement, got %T", elems[0])
+	}
+	if pl.Value != "n" {
+		t.Errorf("expected plural arg 'n', got %q", pl.Value)
+	}
+	if len(pl.Options) == 0 {
+		t.Fatalf("expected plural options")
+	}
+
 	opt := pl.Options[0] // other
-	sel := opt.Value[0].(SelectElement)
+	if len(opt.Value) == 0 {
+		t.Fatalf("expected elements in plural option body")
+	}
+
+	sel, ok := opt.Value[0].(SelectElement)
+	if !ok {
+		t.Fatalf("expected SelectElement inside plural option, got %T", opt.Value[0])
+	}
+	if sel.Value != "gender" {
+		t.Errorf("expected select arg 'gender', got %q", sel.Value)
+	}
 
 	for _, sopt := range sel.Options {
 		foundPound := false

--- a/internal/i18n/icuparser/parse_test.go
+++ b/internal/i18n/icuparser/parse_test.go
@@ -744,3 +744,66 @@ func TestParseASTSelectOrdinal(t *testing.T) {
 		}
 	}
 }
+
+func TestParseASTEscaping(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  string
+		want string
+	}{
+		{name: "escaped open brace", msg: "'{'", want: "{"},
+		{name: "escaped close brace", msg: "'}'", want: "}"},
+		{name: "escaped pound", msg: "'#'", want: "#"},
+		{name: "escaped open angle", msg: "'<'", want: "<"},
+		{name: "escaped close angle", msg: "'>'", want: ">"},
+		{name: "doubled apostrophe", msg: "''", want: "'"},
+		{name: "escaped block", msg: "'{name}'", want: "{name}"},
+		{name: "escaped tag", msg: "'<b>'", want: "<b>"},
+		{name: "mixed escaped and literal", msg: "a'{'b'}'c", want: "a{b}c"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			elems, err := Parse(tt.msg, nil)
+			if err != nil {
+				t.Fatalf("Parse(%q) failed: %v", tt.msg, err)
+			}
+			if len(elems) != 1 {
+				t.Fatalf("expected 1 element, got %d", len(elems))
+			}
+			lit, ok := elems[0].(LiteralElement)
+			if !ok {
+				t.Fatalf("expected LiteralElement, got %T", elems[0])
+			}
+			if lit.Value != tt.want {
+				t.Errorf("expected %q, got %q", tt.want, lit.Value)
+			}
+		})
+	}
+}
+
+func TestParseASTPoundNesting(t *testing.T) {
+	// Inside the select branch, # should still refer to the plural argument 'n'.
+	msg := "{n, plural, other {{gender, select, male {# he} other {# they}}}}"
+	elems, err := Parse(msg, nil)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	pl := elems[0].(PluralElement)
+	opt := pl.Options[0] // other
+	sel := opt.Value[0].(SelectElement)
+
+	for _, sopt := range sel.Options {
+		foundPound := false
+		for _, el := range sopt.Value {
+			if el.Type() == TypePound {
+				foundPound = true
+				break
+			}
+		}
+		if !foundPound {
+			t.Errorf("expected PoundElement in select option %q", sopt.Selector)
+		}
+	}
+}


### PR DESCRIPTION
💡 What: Added unit tests for ICU AST element types and specific parsing edge cases.
🎯 Why: To ensure structural consistency and protect ICU escaping and nested pound sign resolution.
🧩 Scope: internal/i18n/icuparser/ast_test.go, internal/i18n/icuparser/parse_test.go
✅ Verification: make fmt, make lint, and go test ./...
🛡️ Confidence: High, as these tests cover previously untested structural and parsing logic.

---
*PR created automatically by Jules for task [1374574287915054763](https://jules.google.com/task/1374574287915054763) started by @cungminh2710*