### PR TITLE
🧪 Scout: add translator request validation tests

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -95,3 +95,7 @@
 ## 2025-07-20 - [ICU Element Type and Nesting Validation]
 **Learning:** ICU `PluralElement` can represent both `plural` and `selectordinal` types. Structural parity checks rely on the `Type()` method, which correctly chooses the type based on the `Ordinal` flag or an explicit override. Additionally, pound signs (`#`) must be identified as `PoundElement` even when nested inside non-plural blocks (like `select`) if they are ultimately contained by a `plural` or `selectordinal` block.
 **Action:** Always test the `Type()` method for all AST elements, especially for polymorphic elements like `PluralElement`. Ensure nesting tests cover cases where markers like `#` are separated from their parent block by other types of ICU blocks.
+
+## 2026-06-23 - [Translator Request Validation Safety]
+**Learning:** Shared request types in the translator package (Request, ImageEditRequest) lack explicit validation tests, despite being critical internal APIs. Adding dedicated tests for their validation logic ensures that contract requirements (like mandatory fields or supported image formats) are consistently enforced across all provider implementations.
+**Action:** Always include comprehensive success and failure test cases for validation helpers when introducing or modifying shared data structures to prevent regressions in API contract enforcement.

--- a/internal/i18n/translator/types_test.go
+++ b/internal/i18n/translator/types_test.go
@@ -50,6 +50,15 @@ func TestValidateRequest(t *testing.T) {
 			wantErr: "target language is required",
 		},
 		{
+			name: "whitespace target language",
+			req: Request{
+				Source:         "hello",
+				TargetLanguage: "   ",
+				Model:          "gpt-4o",
+			},
+			wantErr: "target language is required",
+		},
+		{
 			name: "missing model",
 			req: Request{
 				Source:         "hello",
@@ -58,23 +67,31 @@ func TestValidateRequest(t *testing.T) {
 			},
 			wantErr: "model is required",
 		},
+		{
+			name: "whitespace model",
+			req: Request{
+				Source:         "hello",
+				TargetLanguage: "fr",
+				Model:          "   ",
+			},
+			wantErr: "model is required",
+		},
 	}
 
 	for _, tt := range tests {
-		tc := tt
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			err := validateRequest(tc.req)
-			if tc.wantErr == "" {
+			err := validateRequest(tt.req)
+			if tt.wantErr == "" {
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)
 				}
 			} else {
 				if err == nil {
-					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
 				}
-				if !strings.Contains(err.Error(), tc.wantErr) {
-					t.Fatalf("error %q does not contain %q", err.Error(), tc.wantErr)
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tt.wantErr)
 				}
 			}
 		})
@@ -103,9 +120,20 @@ func TestValidateImageEditRequest(t *testing.T) {
 			wantErr: "",
 		},
 		{
-			name: "missing source image",
+			name: "missing source image (nil)",
 			req: ImageEditRequest{
 				SourceImage:    nil,
+				TargetLanguage: "es",
+				Model:          "dall-e-3",
+				Prompt:         "translate text in image",
+				OutputFormat:   "png",
+			},
+			wantErr: "source image is required",
+		},
+		{
+			name: "missing source image (empty slice)",
+			req: ImageEditRequest{
+				SourceImage:    []byte{},
 				TargetLanguage: "es",
 				Model:          "dall-e-3",
 				Prompt:         "translate text in image",
@@ -125,11 +153,33 @@ func TestValidateImageEditRequest(t *testing.T) {
 			wantErr: "target language is required",
 		},
 		{
+			name: "whitespace target language",
+			req: ImageEditRequest{
+				SourceImage:    validImg,
+				TargetLanguage: "   ",
+				Model:          "dall-e-3",
+				Prompt:         "translate text in image",
+				OutputFormat:   "png",
+			},
+			wantErr: "target language is required",
+		},
+		{
 			name: "missing model",
 			req: ImageEditRequest{
 				SourceImage:    validImg,
 				TargetLanguage: "es",
 				Model:          "",
+				Prompt:         "translate text in image",
+				OutputFormat:   "png",
+			},
+			wantErr: "model is required",
+		},
+		{
+			name: "whitespace model",
+			req: ImageEditRequest{
+				SourceImage:    validImg,
+				TargetLanguage: "es",
+				Model:          "   ",
 				Prompt:         "translate text in image",
 				OutputFormat:   "png",
 			},
@@ -142,6 +192,17 @@ func TestValidateImageEditRequest(t *testing.T) {
 				TargetLanguage: "es",
 				Model:          "dall-e-3",
 				Prompt:         "",
+				OutputFormat:   "png",
+			},
+			wantErr: "prompt is required",
+		},
+		{
+			name: "whitespace prompt",
+			req: ImageEditRequest{
+				SourceImage:    validImg,
+				TargetLanguage: "es",
+				Model:          "dall-e-3",
+				Prompt:         "   ",
 				OutputFormat:   "png",
 			},
 			wantErr: "prompt is required",
@@ -171,20 +232,19 @@ func TestValidateImageEditRequest(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tc := tt
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			err := validateImageEditRequest(tc.req)
-			if tc.wantErr == "" {
+			err := validateImageEditRequest(tt.req)
+			if tt.wantErr == "" {
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)
 				}
 			} else {
 				if err == nil {
-					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
 				}
-				if !strings.Contains(err.Error(), tc.wantErr) {
-					t.Fatalf("error %q does not contain %q", err.Error(), tc.wantErr)
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tt.wantErr)
 				}
 			}
 		})
@@ -205,11 +265,10 @@ func TestNormalizeProvider(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tc := tt
-		t.Run(tc.in, func(t *testing.T) {
+		t.Run(tt.in, func(t *testing.T) {
 			t.Parallel()
-			if got := normalizeProvider(tc.in); got != tc.want {
-				t.Fatalf("normalizeProvider(%q) = %q, want %q", tc.in, got, tc.want)
+			if got := normalizeProvider(tt.in); got != tt.want {
+				t.Fatalf("normalizeProvider(%q) = %q, want %q", tt.in, got, tt.want)
 			}
 		})
 	}

--- a/internal/i18n/translator/types_test.go
+++ b/internal/i18n/translator/types_test.go
@@ -1,0 +1,216 @@
+package translator
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateRequest(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		req     Request
+		wantErr string
+	}{
+		{
+			name: "valid request",
+			req: Request{
+				Source:         "hello",
+				TargetLanguage: "fr",
+				Model:          "gpt-4o",
+			},
+			wantErr: "",
+		},
+		{
+			name: "missing source",
+			req: Request{
+				Source:         "",
+				TargetLanguage: "fr",
+				Model:          "gpt-4o",
+			},
+			wantErr: "source is required",
+		},
+		{
+			name: "whitespace source",
+			req: Request{
+				Source:         "   ",
+				TargetLanguage: "fr",
+				Model:          "gpt-4o",
+			},
+			wantErr: "source is required",
+		},
+		{
+			name: "missing target language",
+			req: Request{
+				Source:         "hello",
+				TargetLanguage: "",
+				Model:          "gpt-4o",
+			},
+			wantErr: "target language is required",
+		},
+		{
+			name: "missing model",
+			req: Request{
+				Source:         "hello",
+				TargetLanguage: "fr",
+				Model:          "",
+			},
+			wantErr: "model is required",
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateRequest(tc.req)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tc.wantErr)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateImageEditRequest(t *testing.T) {
+	t.Parallel()
+
+	validImg := []byte("fake-image-data")
+
+	tests := []struct {
+		name    string
+		req     ImageEditRequest
+		wantErr string
+	}{
+		{
+			name: "valid request",
+			req: ImageEditRequest{
+				SourceImage:    validImg,
+				TargetLanguage: "es",
+				Model:          "dall-e-3",
+				Prompt:         "translate text in image",
+				OutputFormat:   "png",
+			},
+			wantErr: "",
+		},
+		{
+			name: "missing source image",
+			req: ImageEditRequest{
+				SourceImage:    nil,
+				TargetLanguage: "es",
+				Model:          "dall-e-3",
+				Prompt:         "translate text in image",
+				OutputFormat:   "png",
+			},
+			wantErr: "source image is required",
+		},
+		{
+			name: "missing target language",
+			req: ImageEditRequest{
+				SourceImage:    validImg,
+				TargetLanguage: "",
+				Model:          "dall-e-3",
+				Prompt:         "translate text in image",
+				OutputFormat:   "png",
+			},
+			wantErr: "target language is required",
+		},
+		{
+			name: "missing model",
+			req: ImageEditRequest{
+				SourceImage:    validImg,
+				TargetLanguage: "es",
+				Model:          "",
+				Prompt:         "translate text in image",
+				OutputFormat:   "png",
+			},
+			wantErr: "model is required",
+		},
+		{
+			name: "missing prompt",
+			req: ImageEditRequest{
+				SourceImage:    validImg,
+				TargetLanguage: "es",
+				Model:          "dall-e-3",
+				Prompt:         "",
+				OutputFormat:   "png",
+			},
+			wantErr: "prompt is required",
+		},
+		{
+			name: "unsupported format",
+			req: ImageEditRequest{
+				SourceImage:    validImg,
+				TargetLanguage: "es",
+				Model:          "dall-e-3",
+				Prompt:         "translate",
+				OutputFormat:   "bmp",
+			},
+			wantErr: "unsupported output format \"bmp\"",
+		},
+		{
+			name: "valid formats case-insensitive",
+			req: ImageEditRequest{
+				SourceImage:    validImg,
+				TargetLanguage: "es",
+				Model:          "dall-e-3",
+				Prompt:         "translate",
+				OutputFormat:   " JPEG ",
+			},
+			wantErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateImageEditRequest(tc.req)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tc.wantErr)
+				}
+			}
+		})
+	}
+}
+
+func TestNormalizeProvider(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"OpenAI", "openai"},
+		{"  Anthropic  ", "anthropic"},
+		{"", ""},
+		{"\tGEMINI\n", "gemini"},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tc.in, func(t *testing.T) {
+			t.Parallel()
+			if got := normalizeProvider(tc.in); got != tc.want {
+				t.Fatalf("normalizeProvider(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- 💡 What: Added dedicated unit tests for `validateRequest`, `validateImageEditRequest`, and `normalizeProvider` in the translator package.
- 🎯 Why: These core validation functions enforce the API contract for all translation and image editing providers, but lacked explicit coverage.
- 🧩 Scope: `internal/i18n/translator/types_test.go` and `.jules/scout.md`.
- ✅ Verification: Ran `make lint` and `go test ./internal/i18n/translator/...` (all passed).
- 🛡️ Confidence: Prevents regressions in mandatory field enforcement and format validation for the translation system.

---
*PR created automatically by Jules for task [18151390689152167708](https://jules.google.com/task/18151390689152167708) started by @cungminh2710*