### PR TITLE
fix(web): return plain workspace automation step results

### DIFF
--- a/apps/hyperlocalise-web/src/workflows/steps/workspace-automation-execution.test.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/workspace-automation-execution.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 
 const { runWorkspaceOrchestratorMock } = vi.hoisted(() => ({
-  runWorkspaceOrchestratorMock: vi.fn(async () => {
+  runWorkspaceOrchestratorMock: vi.fn(async (): Promise<unknown> => {
     class OkResult {
       readonly ok = true;
 

--- a/apps/hyperlocalise-web/src/workflows/steps/workspace-automation-execution.test.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/workspace-automation-execution.test.ts
@@ -1,10 +1,18 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 
 const { runWorkspaceOrchestratorMock } = vi.hoisted(() => ({
-  runWorkspaceOrchestratorMock: vi.fn(async () => ({
-    ok: true,
-    value: { runId: "run-1", status: "succeeded" as const },
-  })),
+  runWorkspaceOrchestratorMock: vi.fn(async () => {
+    class OkResult {
+      readonly ok = true;
+
+      constructor(readonly value: { runId: string; status: "succeeded" }) {}
+    }
+
+    return new OkResult({
+      runId: "run-1",
+      status: "succeeded" as const,
+    });
+  }),
 }));
 
 vi.mock("@/agents/automations/workspace/agent/run-workspace-orchestrator", () => ({
@@ -27,6 +35,7 @@ describe("executeWorkspaceAutomationStep", () => {
       organizationId: "org-1",
     });
     expect(result.ok).toBe(true);
+    expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
     if (result.ok) {
       expect(result.value.status).toBe("succeeded");
     }

--- a/apps/hyperlocalise-web/src/workflows/steps/workspace-automation-execution.test.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/workspace-automation-execution.test.ts
@@ -40,4 +40,62 @@ describe("executeWorkspaceAutomationStep", () => {
       expect(result.value.status).toBe("succeeded");
     }
   });
+
+  it("returns a plain object when the orchestrator returns an error result", async () => {
+    runWorkspaceOrchestratorMock.mockClear();
+    class ErrResult {
+      readonly ok = false;
+
+      constructor(
+        readonly error: {
+          code: "workspace_orchestrator_failed";
+          message: string;
+          runId: string;
+        },
+      ) {}
+    }
+
+    runWorkspaceOrchestratorMock.mockResolvedValueOnce(
+      new ErrResult({
+        code: "workspace_orchestrator_failed",
+        message: "Orchestrator failed",
+        runId: "run-1",
+      }),
+    );
+
+    const result = await executeWorkspaceAutomationStep({
+      workspaceAutomationRunId: "run-1",
+      organizationId: "org-1",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+    if (!result.ok) {
+      expect(result.error).toEqual({
+        code: "workspace_orchestrator_failed",
+        message: "Orchestrator failed",
+        runId: "run-1",
+      });
+    }
+  });
+
+  it("returns a plain object when the orchestrator throws", async () => {
+    runWorkspaceOrchestratorMock.mockClear();
+    runWorkspaceOrchestratorMock.mockRejectedValueOnce(new Error("Runtime unavailable"));
+
+    const result = await executeWorkspaceAutomationStep({
+      workspaceAutomationRunId: "run-1",
+      organizationId: "org-1",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+    if (!result.ok) {
+      expect(result.error).toEqual({
+        code: "workspace_orchestrator_failed",
+        message: "Runtime unavailable",
+        runId: "run-1",
+      });
+    }
+  });
 });

--- a/apps/hyperlocalise-web/src/workflows/steps/workspace-automation-execution.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/workspace-automation-execution.ts
@@ -4,13 +4,22 @@ import type {
   WorkspaceOrchestratorExecutionError,
   WorkspaceOrchestratorExecutionSuccess,
 } from "@/agents/automations/workspace/agent/run-workspace-orchestrator";
-import { err, ok, type Result } from "@/lib/primitives/result/results";
 
 const logger = createLogger("workspace-automation-step");
 
+export type WorkspaceAutomationStepResult =
+  | {
+      ok: true;
+      value: WorkspaceOrchestratorExecutionSuccess;
+    }
+  | {
+      ok: false;
+      error: WorkspaceOrchestratorExecutionError;
+    };
+
 export async function executeWorkspaceAutomationStep(
   event: WorkspaceAutomationExecutionEventData,
-): Promise<Result<WorkspaceOrchestratorExecutionSuccess, WorkspaceOrchestratorExecutionError>> {
+): Promise<WorkspaceAutomationStepResult> {
   "use step";
 
   const stepContext = {
@@ -34,21 +43,24 @@ export async function executeWorkspaceAutomationStep(
         { ...stepContext, message: result.error.message },
         "workspace automation orchestrator step completed with execution error",
       );
-      return err(result.error);
+      return { ok: false, error: result.error };
     }
 
     logger.info(
       { ...stepContext, status: result.value.status },
       "workspace automation orchestrator step completed successfully",
     );
-    return ok(result.value);
+    return { ok: true, value: result.value };
   } catch (error) {
     const message = error instanceof Error ? error.message : "workspace_orchestrator_step_failed";
     logger.error({ ...stepContext, message }, "workspace automation orchestrator step threw");
-    return err({
-      code: "workspace_orchestrator_failed",
-      message,
-      runId: event.workspaceAutomationRunId,
-    });
+    return {
+      ok: false,
+      error: {
+        code: "workspace_orchestrator_failed",
+        message,
+        runId: event.workspaceAutomationRunId,
+      },
+    };
   }
 }


### PR DESCRIPTION
## What changed

- Convert workspace automation workflow step results from `Result` class instances into plain `{ ok, value/error }` objects before returning from the `"use step"` boundary.
- Add a regression test that mocks a class-instance orchestrator result and asserts the step returns a plain object for Workflow serialization.

## How to test

- `vp test src/workflows/steps/workspace-automation-execution.test.ts`
- `vp check --fix`

## Checklist

- [ ] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review