### PR TITLE
fix(web): route Contentful agent through deterministic executor tool

### DIFF
--- a/apps/hyperlocalise-web/src/agents/automations/contentful/agent/context.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/contentful/agent/context.ts
@@ -4,6 +4,7 @@ import {
 } from "@/lib/contentful/automation-executor";
 import type { ContentfulManagementClient } from "@/lib/contentful/client";
 import type {
+  ContentfulAutomationExecutionSuccess,
   ContentfulConnectionFieldConfig,
   ContentfulDraftTranslation,
   ContentfulTranslatableFieldUnit,
@@ -35,6 +36,8 @@ export type ContentfulAgentSession = {
   translations: ContentfulDraftTranslation[];
   qaFindings: Array<Record<string, unknown>>;
   defaultLocale?: string;
+  executionResult?: ContentfulAutomationExecutionSuccess;
+  executionError?: string;
 };
 
 export function createContentfulAgentSession(

--- a/apps/hyperlocalise-web/src/agents/automations/contentful/agent/instructions.md
+++ b/apps/hyperlocalise-web/src/agents/automations/contentful/agent/instructions.md
@@ -1,6 +1,6 @@
 You are the Hyperlocalise Contentful localization agent.
 
-Your job is to translate Contentful entries into configured target locales using the tools provided.
+Your job is to translate Contentful entries into configured target locales.
 Follow composed customer and template instructions when present.
-Use tools in a sensible order: fetch the entry, list translatable fields, translate each required field, run QA when enabled, then write drafts when enabled.
+Call the `run_translation` tool to execute the full translation pipeline: fetch the entry, detect translatable fields, translate, run QA when enabled, and write drafts when enabled.
 Do not publish entries. Write localized values as drafts only.

--- a/apps/hyperlocalise-web/src/agents/automations/contentful/agent/run-contentful-agent.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/contentful/agent/run-contentful-agent.ts
@@ -11,10 +11,11 @@ import type {
   ContentfulAutomationExecutionError,
   ContentfulAutomationExecutionSuccess,
 } from "@/lib/contentful/types";
+import { hasContentfulNoWriteback } from "@/lib/contentful/types";
 import { loadOrganizationTranslationGenerator } from "@/lib/translation/load-organization-translation-generator";
 import { composeContentfulAutomationInstructions } from "@/agents/automations/workspace/agent/workspace-template-manifest";
 
-import { createContentfulAgentSession } from "./context";
+import { createContentfulAgentSession, type ContentfulAgentSession } from "./context";
 import {
   buildContentfulAgentTools,
   CONTENTFUL_TRANSLATION_EXECUTOR_TOOL_NAME,
@@ -72,16 +73,14 @@ export async function runContentfulAgent(
     userOverride: userInstructions,
   });
 
-  await db
-    .update(schema.contentfulTranslationRuns)
-    .set({ status: "running", startedAt: new Date(), updatedAt: new Date() })
-    .where(eq(schema.contentfulTranslationRuns.id, run.id));
   if (manageWorkspaceRunStatus) {
     await db
       .update(schema.workspaceAutomationRuns)
       .set({ status: "running", startedAt: new Date(), updatedAt: new Date() })
       .where(eq(schema.workspaceAutomationRuns.id, input.workspaceAutomationRunId));
   }
+
+  let session: ContentfulAgentSession | undefined;
 
   try {
     const generator = await loadOrganizationTranslationGenerator(run.projectId);
@@ -94,7 +93,7 @@ export async function runContentfulAgent(
       connectionId: run.connectionId,
     });
 
-    const session = createContentfulAgentSession({
+    session = createContentfulAgentSession({
       organizationId: input.organizationId,
       runId: run.id,
       entryId: run.entryId,
@@ -169,6 +168,51 @@ export async function runContentfulAgent(
       "contentful agent translation finished",
     );
 
+    if (
+      manageWorkspaceRunStatus &&
+      hasContentfulNoWriteback({
+        writeDrafts: run.writeDrafts,
+        fieldsDetected: session.executionResult.fieldsDetected,
+        localeValuesWritten: session.executionResult.localeValuesWritten,
+      })
+    ) {
+      const message = "contentful_no_draft_writebacks";
+      const completedAt = new Date();
+
+      await db
+        .update(schema.workspaceAutomationRuns)
+        .set({
+          status: "failed",
+          outputSummary: {
+            contentfulTranslationRunId: run.id,
+            fieldsDetected: session.executionResult.fieldsDetected,
+            localeValuesWritten: session.executionResult.localeValuesWritten,
+            error: message,
+          },
+          completedAt,
+          updatedAt: completedAt,
+        })
+        .where(eq(schema.workspaceAutomationRuns.id, input.workspaceAutomationRunId));
+
+      logger.warn(
+        {
+          contentfulTranslationRunId: run.id,
+          workspaceAutomationRunId: input.workspaceAutomationRunId,
+          organizationId: input.organizationId,
+          entryId: run.entryId,
+          fieldsDetected: session.executionResult.fieldsDetected,
+          localeValuesWritten: session.executionResult.localeValuesWritten,
+        },
+        "contentful agent translation finished with no draft writebacks",
+      );
+
+      return err({
+        code: "contentful_automation_failed",
+        message,
+        runId: run.id,
+      });
+    }
+
     if (manageWorkspaceRunStatus) {
       const completedAt = new Date();
       await db
@@ -192,15 +236,17 @@ export async function runContentfulAgent(
     const message = error instanceof Error ? error.message : "contentful_agent_failed";
     const completedAt = new Date();
 
-    await db
-      .update(schema.contentfulTranslationRuns)
-      .set({
-        status: "failed",
-        error: { message },
-        completedAt,
-        updatedAt: completedAt,
-      })
-      .where(eq(schema.contentfulTranslationRuns.id, run.id));
+    if (!session?.executionError) {
+      await db
+        .update(schema.contentfulTranslationRuns)
+        .set({
+          status: "failed",
+          error: { message },
+          completedAt,
+          updatedAt: completedAt,
+        })
+        .where(eq(schema.contentfulTranslationRuns.id, run.id));
+    }
 
     if (manageWorkspaceRunStatus) {
       await db

--- a/apps/hyperlocalise-web/src/agents/automations/contentful/agent/run-contentful-agent.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/contentful/agent/run-contentful-agent.ts
@@ -5,6 +5,7 @@ import { getHyperlocaliseAgentModel } from "@/lib/agent-runtime/loops/model";
 import { WORKFLOW_AGENT_TIMEOUT } from "@/lib/agent-runtime/subagents/constants";
 import type { ContentfulAutomationExecutionEvent } from "@/lib/contentful/automation-executor";
 import { db, schema } from "@/lib/database";
+import { createLogger } from "@/lib/log";
 import { err, ok, type Result } from "@/lib/primitives/result/results";
 import type {
   ContentfulAutomationExecutionError,
@@ -16,10 +17,12 @@ import { composeContentfulAutomationInstructions } from "@/agents/automations/wo
 import { createContentfulAgentSession } from "./context";
 import {
   buildContentfulAgentTools,
+  CONTENTFUL_TRANSLATION_EXECUTOR_TOOL_NAME,
   loadContentfulAgentClient,
 } from "./tools/build-contentful-tools";
 
-const CONTENTFUL_AGENT_STEP_LIMIT = 20;
+const CONTENTFUL_AGENT_STEP_LIMIT = 2;
+const logger = createLogger("contentful-agent");
 
 export type RunContentfulAgentOptions = {
   manageWorkspaceRunStatus?: boolean;
@@ -116,9 +119,22 @@ export async function runContentfulAgent(
       model: getHyperlocaliseAgentModel(),
       instructions: composedInstructions,
       tools,
+      activeTools: [CONTENTFUL_TRANSLATION_EXECUTOR_TOOL_NAME],
       stopWhen: stepCountIs(CONTENTFUL_AGENT_STEP_LIMIT),
       timeout: WORKFLOW_AGENT_TIMEOUT,
       experimental_context: session,
+      prepareStep: ({ stepNumber }) => {
+        if (stepNumber === 0) {
+          return {
+            activeTools: [CONTENTFUL_TRANSLATION_EXECUTOR_TOOL_NAME],
+            toolChoice: { type: "tool", toolName: CONTENTFUL_TRANSLATION_EXECUTOR_TOOL_NAME },
+          };
+        }
+
+        return {
+          toolChoice: "none",
+        };
+      },
     });
 
     await agent.generate({
@@ -129,45 +145,41 @@ export async function runContentfulAgent(
             `Translate Contentful entry ${run.entryId}.`,
             `Source locale: ${run.sourceLocale}.`,
             `Target locales: ${run.targetLocales.join(", ")}.`,
-            "Use tools to fetch the entry, detect fields, translate, QA, and write drafts as configured.",
+            "Call run_translation to execute the translation pipeline.",
           ].join("\n"),
         },
       ],
     });
 
-    const qaErrorCount = session.qaFindings.filter(
-      (finding) => finding.severity === "error",
-    ).length;
-    const completedAt = new Date();
+    if (!session.executionResult) {
+      const message = session.executionError ?? "contentful_translation_executor_not_called";
+      throw new Error(message);
+    }
 
-    await db
-      .update(schema.contentfulTranslationRuns)
-      .set({
-        status: qaErrorCount > 0 ? "succeeded_with_warnings" : "succeeded",
-        qaSummary: {
-          total: session.qaFindings.length,
-          errors: qaErrorCount,
-          warnings: session.qaFindings.filter((finding) => finding.severity === "warning").length,
-        },
-        writebackSummary: {
-          fieldsWritten: new Set(session.translations.map((item) => item.fieldId)).size,
-          localeValuesWritten: session.translations.length,
-          blockedByQaErrors: qaErrorCount,
-        },
-        completedAt,
-        updatedAt: completedAt,
-      })
-      .where(eq(schema.contentfulTranslationRuns.id, run.id));
+    logger.info(
+      {
+        contentfulTranslationRunId: run.id,
+        workspaceAutomationRunId: input.workspaceAutomationRunId,
+        organizationId: input.organizationId,
+        entryId: run.entryId,
+        fieldsDetected: session.executionResult.fieldsDetected,
+        localeValuesWritten: session.executionResult.localeValuesWritten,
+        qaFindingCount: session.executionResult.qaFindingCount,
+      },
+      "contentful agent translation finished",
+    );
 
     if (manageWorkspaceRunStatus) {
+      const completedAt = new Date();
       await db
         .update(schema.workspaceAutomationRuns)
         .set({
           status: "succeeded",
           outputSummary: {
             contentfulTranslationRunId: run.id,
-            qaFindingCount: session.qaFindings.length,
-            qaErrorCount,
+            fieldsDetected: session.executionResult.fieldsDetected,
+            localeValuesWritten: session.executionResult.localeValuesWritten,
+            qaFindingCount: session.executionResult.qaFindingCount,
           },
           completedAt,
           updatedAt: completedAt,
@@ -175,9 +187,7 @@ export async function runContentfulAgent(
         .where(eq(schema.workspaceAutomationRuns.id, input.workspaceAutomationRunId));
     }
 
-    return ok({
-      runId: run.id,
-    });
+    return ok(session.executionResult);
   } catch (error) {
     const message = error instanceof Error ? error.message : "contentful_agent_failed";
     const completedAt = new Date();
@@ -203,6 +213,17 @@ export async function runContentfulAgent(
         })
         .where(eq(schema.workspaceAutomationRuns.id, input.workspaceAutomationRunId));
     }
+
+    logger.error(
+      {
+        contentfulTranslationRunId: run.id,
+        workspaceAutomationRunId: input.workspaceAutomationRunId,
+        organizationId: input.organizationId,
+        entryId: run.entryId,
+        message,
+      },
+      "contentful agent translation failed",
+    );
 
     return err({
       code: "contentful_automation_failed",

--- a/apps/hyperlocalise-web/src/agents/automations/contentful/agent/tools/build-contentful-tools.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/contentful/agent/tools/build-contentful-tools.test.ts
@@ -1,56 +1,25 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 
 import type { ContentfulManagementClient } from "@/lib/contentful/client";
-import type { ContentfulContentType, ContentfulEntry } from "@/lib/contentful/types";
+import { ok } from "@/lib/primitives/result/results";
 
 import { createContentfulAgentSession } from "../context";
-import { buildContentfulAgentTools } from "./build-contentful-tools";
+import {
+  buildContentfulAgentTools,
+  CONTENTFUL_TRANSLATION_EXECUTOR_TOOL_NAME,
+} from "./build-contentful-tools";
 
-const contentType: ContentfulContentType = {
-  sys: { id: "helpCenterArticle" },
-  fields: [
-    { id: "title", name: "Title", type: "Symbol", localized: true },
-    { id: "body", name: "Body", type: "RichText", localized: true },
-    { id: "slug", name: "Slug", type: "Symbol", localized: true },
-  ],
-};
+const mocks = vi.hoisted(() => ({
+  executeContentfulAutomation: vi.fn(),
+}));
 
-const entry: ContentfulEntry = {
-  sys: {
-    id: "entry-1",
-    version: 1,
-    contentType: { sys: { id: "helpCenterArticle" } },
-  },
-  fields: {
-    title: {
-      "en-US": "Reset your password",
-      "fr-FR": "Réinitialisez votre mot de passe",
-    },
-    body: {
-      "en-US": {
-        nodeType: "document",
-        data: {},
-        content: [
-          {
-            nodeType: "paragraph",
-            data: {},
-            content: [
-              {
-                nodeType: "text",
-                value: "Visit https://example.com/reset.",
-                marks: [],
-                data: {},
-              },
-            ],
-          },
-        ],
-      },
-    },
-    slug: {
-      "en-US": "reset-password",
-    },
-  },
-};
+vi.mock("@/lib/contentful/automation-executor", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/contentful/automation-executor")>();
+  return {
+    ...original,
+    executeContentfulAutomation: mocks.executeContentfulAutomation,
+  };
+});
 
 function createTestSession() {
   return createContentfulAgentSession({
@@ -62,8 +31,8 @@ function createTestSession() {
     instructions: "Translate help center content.",
     sourceLocale: "en-US",
     targetLocales: ["fr-FR"],
-    runQa: false,
-    writeDrafts: false,
+    runQa: true,
+    writeDrafts: true,
     overwriteDraftLocales: false,
     fieldConfig: {
       fieldMode: "configured",
@@ -77,26 +46,40 @@ function createTestSession() {
 }
 
 describe("buildContentfulAgentTools", () => {
-  it("respects configured field allow-lists when listing translatable fields", async () => {
-    const session = createTestSession();
-    session.entry = entry as unknown as Record<string, unknown>;
-    session.contentType = contentType as unknown as Record<string, unknown>;
-
-    const tools = buildContentfulAgentTools(session);
-    const listTranslatableFields = tools.list_translatable_fields;
-
-    if (!listTranslatableFields?.execute) {
-      throw new Error("list_translatable_fields tool is missing execute");
-    }
-
-    const result = await listTranslatableFields.execute(
-      {},
-      { toolCallId: "test-tool-call", messages: [] },
+  it("exposes run_translation as the executor tool", async () => {
+    mocks.executeContentfulAutomation.mockResolvedValue(
+      ok({
+        runId: "run_123",
+        fieldsDetected: 2,
+        localeValuesWritten: 2,
+        qaFindingCount: 0,
+      }),
     );
 
+    const session = createTestSession();
+    const tools = buildContentfulAgentTools(session);
+    const runTranslation = tools[CONTENTFUL_TRANSLATION_EXECUTOR_TOOL_NAME];
+
+    if (!runTranslation?.execute) {
+      throw new Error("run_translation tool is missing execute");
+    }
+
+    const result = await runTranslation.execute({}, { toolCallId: "test-tool-call", messages: [] });
+
+    expect(mocks.executeContentfulAutomation).toHaveBeenCalledWith(
+      {
+        contentfulTranslationRunId: "run_123",
+        workspaceAutomationRunId: "workspace_run_123",
+        organizationId: "org_123",
+      },
+      { manageWorkspaceRunStatus: false },
+    );
     expect(result).toEqual({
-      count: 1,
-      fields: [{ fieldId: "body", kind: "text" }],
+      runId: "run_123",
+      fieldsDetected: 2,
+      localeValuesWritten: 2,
+      qaFindingCount: 0,
     });
+    expect(session.executionResult).toEqual(result);
   });
 });

--- a/apps/hyperlocalise-web/src/agents/automations/contentful/agent/tools/build-contentful-tools.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/contentful/agent/tools/build-contentful-tools.ts
@@ -2,228 +2,38 @@ import type { ToolSet } from "ai";
 import { z } from "zod";
 
 import { defineAgentTool } from "@/agents/_runtime/define-agent-tool";
-import { executeTranslateString } from "@/agents/_runtime/shared-tools/translate_string";
-import { detectContentfulTranslatableFields } from "@/lib/contentful/field-detector";
-import {
-  contentfulQaFindingsContainError,
-  ensureLocalizedAssets,
-} from "@/lib/contentful/automation-executor";
+import { executeContentfulAutomation } from "@/lib/contentful/automation-executor";
 import { ContentfulManagementClient } from "@/lib/contentful/client";
-import { isErr } from "@/lib/primitives/result/results";
 import { loadContentfulConnectionWithToken } from "@/lib/contentful/connections";
-import type { ContentfulContentType, ContentfulEntry } from "@/lib/contentful/types";
 
 import type { ContentfulAgentSession } from "../context";
 
-function collectBasicQaFindings(input: {
-  unit: { fieldId: string; sourceText: string };
-  locale: string;
-  translatedText: string;
-}) {
-  const PLACEHOLDER_REGEX = /(\{\{[^}]+\}\}|\{[A-Za-z0-9_.-]+\}|%[sdif])/g;
-  const URL_REGEX = /https?:\/\/[^\s)]+/g;
-  const findings: Array<Record<string, unknown>> = [];
-  const sourcePlaceholders = new Set(input.unit.sourceText.match(PLACEHOLDER_REGEX) ?? []);
-  const targetPlaceholders = new Set(input.translatedText.match(PLACEHOLDER_REGEX) ?? []);
-  for (const placeholder of sourcePlaceholders) {
-    if (!targetPlaceholders.has(placeholder)) {
-      findings.push({
-        checkType: "placeholder_mismatch",
-        severity: "error",
-        locale: input.locale,
-        fieldId: input.unit.fieldId,
-        placeholder,
-      });
-    }
-  }
-
-  const sourceLinks = new Set(input.unit.sourceText.match(URL_REGEX) ?? []);
-  const targetLinks = new Set(input.translatedText.match(URL_REGEX) ?? []);
-  for (const link of sourceLinks) {
-    if (!targetLinks.has(link)) {
-      findings.push({
-        checkType: "markdown_link",
-        severity: "warning",
-        locale: input.locale,
-        fieldId: input.unit.fieldId,
-        link,
-      });
-    }
-  }
-
-  return findings;
-}
+export const CONTENTFUL_TRANSLATION_EXECUTOR_TOOL_NAME = "run_translation";
 
 export function buildContentfulAgentTools(session: ContentfulAgentSession): ToolSet {
   const tools = {} as ToolSet;
 
-  tools.fetch_entry = defineAgentTool({
-    description: "Fetch the Contentful entry and content type for the current automation run.",
+  tools[CONTENTFUL_TRANSLATION_EXECUTOR_TOOL_NAME] = defineAgentTool({
+    description:
+      "Run the Contentful translation pipeline: fetch the entry, detect translatable fields, translate into target locales, run QA when enabled, and write drafts back to Contentful.",
     inputSchema: z.object({}),
     execute: async () => {
-      const entryResult = await session.client.getEntry(session.entryId);
-      if (isErr(entryResult)) {
-        throw entryResult.error;
+      const result = await executeContentfulAutomation(
+        {
+          contentfulTranslationRunId: session.runId,
+          workspaceAutomationRunId: session.workspaceAutomationRunId,
+          organizationId: session.organizationId,
+        },
+        { manageWorkspaceRunStatus: false },
+      );
+
+      if (!result.ok) {
+        session.executionError = result.error.message;
+        throw new Error(result.error.message);
       }
 
-      session.entry = entryResult.value as unknown as Record<string, unknown>;
-      const contentTypeId = entryResult.value.sys?.contentType?.sys?.id;
-      if (!contentTypeId) {
-        throw new Error("contentful_entry_missing_content_type");
-      }
-
-      const contentTypeResult = await session.client.getContentType(contentTypeId);
-      if (isErr(contentTypeResult)) {
-        throw contentTypeResult.error;
-      }
-
-      session.contentType = contentTypeResult.value as unknown as Record<string, unknown>;
-      return {
-        entryId: session.entryId,
-        contentTypeId,
-        fieldCount: Object.keys(
-          (entryResult.value as { fields?: Record<string, unknown> }).fields ?? {},
-        ).length,
-      };
-    },
-  });
-
-  tools.list_translatable_fields = defineAgentTool({
-    description: "Detect translatable fields on the loaded Contentful entry.",
-    inputSchema: z.object({}),
-    execute: async () => {
-      if (!session.entry || !session.contentType) {
-        throw new Error("fetch_entry_required");
-      }
-
-      const fieldConfig = session.fieldConfig;
-      session.units = detectContentfulTranslatableFields({
-        entry: session.entry as ContentfulEntry,
-        contentType: session.contentType as ContentfulContentType,
-        sourceLocale: session.sourceLocale,
-        targetLocales: session.targetLocales,
-        fieldConfig,
-        overwriteDraftLocales: session.overwriteDraftLocales,
-        defaultLocale: session.defaultLocale,
-      });
-
-      return {
-        count: session.units.length,
-        fields: session.units.map((unit) => ({
-          fieldId: unit.fieldId,
-          kind: unit.kind,
-        })),
-      };
-    },
-  });
-
-  tools.translate_string = defineAgentTool({
-    description: "Translate a source string into target locales for a Contentful field.",
-    inputSchema: z.object({
-      fieldId: z.string(),
-      sourceText: z.string(),
-      targetLocales: z.array(z.string()).optional(),
-    }),
-    execute: async ({ fieldId, sourceText, targetLocales }) => {
-      const locales = targetLocales ?? session.targetLocales;
-      const result = await executeTranslateString({
-        projectId: session.projectId,
-        sourceText,
-        targetLocales: locales,
-        sourceLocale: session.sourceLocale,
-        context: session.userBindingContext ?? undefined,
-      });
-
-      for (const translation of result.translations) {
-        session.translations.push({
-          fieldId,
-          locale: translation.locale,
-          value: translation.text,
-        });
-      }
-
-      return result;
-    },
-  });
-
-  if (session.runQa) {
-    tools.run_qa = defineAgentTool({
-      description: "Run QA checks on translated field text.",
-      inputSchema: z.object({
-        fieldId: z.string(),
-        locale: z.string(),
-        sourceText: z.string(),
-        translatedText: z.string(),
-      }),
-      execute: async (input) => {
-        const findings = collectBasicQaFindings({
-          unit: {
-            fieldId: input.fieldId,
-            sourceText: input.sourceText,
-          },
-          locale: input.locale,
-          translatedText: input.translatedText,
-        });
-        session.qaFindings.push(...findings);
-        return { findings, hasErrors: contentfulQaFindingsContainError(findings) };
-      },
-    });
-  }
-
-  if (session.writeDrafts) {
-    tools.write_drafts = defineAgentTool({
-      description: "Write accumulated draft translations back to Contentful.",
-      inputSchema: z.object({
-        translations: z
-          .array(
-            z.object({
-              fieldId: z.string(),
-              locale: z.string(),
-              value: z.unknown(),
-            }),
-          )
-          .optional(),
-      }),
-      execute: async ({ translations }) => {
-        const payload = translations ?? session.translations;
-        if (!session.entry || payload.length === 0) {
-          return { fieldsWritten: 0, localeValuesWritten: 0 };
-        }
-
-        const updatedEntryResult = await session.client.updateEntryDraft({
-          entry: session.entry as never,
-          translations: payload,
-        });
-        if (isErr(updatedEntryResult)) {
-          throw updatedEntryResult.error;
-        }
-
-        session.entry = updatedEntryResult.value as unknown as Record<string, unknown>;
-        return {
-          fieldsWritten: new Set(payload.map((item) => item.fieldId)).size,
-          localeValuesWritten: payload.length,
-        };
-      },
-    });
-  }
-
-  tools.localize_asset = defineAgentTool({
-    description: "Localize a Contentful asset for a target locale.",
-    inputSchema: z.object({
-      fieldName: z.string(),
-      assetId: z.string(),
-      targetLocale: z.string(),
-    }),
-    execute: async ({ fieldName, assetId, targetLocale }) => {
-      const localized = await ensureLocalizedAssets({
-        client: session.client,
-        sourceLocale: session.sourceLocale,
-        targetLocale,
-        fieldName,
-        assetIds: [assetId],
-        cache: session.localizedAssetCache,
-      });
-      return { localizedAssetId: localized.get(assetId) ?? null };
+      session.executionResult = result.value;
+      return result.value;
     },
   });
 

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/run-workspace-orchestrator.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/run-workspace-orchestrator.ts
@@ -1,6 +1,7 @@
 import { and, eq } from "drizzle-orm";
 
 import { db, schema } from "@/lib/database";
+import { createLogger } from "@/lib/log";
 import { err, ok, type Result } from "@/lib/primitives/result/results";
 import {
   getWorkspaceAutomationById,
@@ -14,6 +15,8 @@ import { composeWorkspaceAutomationInstructions } from "./compose-workspace-inst
 import { createWorkspaceOrchestratorSession, type WorkspaceOrchestratorSession } from "./context";
 import { buildWorkspaceOrchestratorPlan } from "./plan";
 
+const logger = createLogger("workspace-orchestrator");
+
 export type WorkspaceOrchestratorExecutionError = {
   code:
     | "workspace_automation_not_found"
@@ -26,6 +29,8 @@ export type WorkspaceOrchestratorExecutionError = {
 export type WorkspaceOrchestratorExecutionSuccess = {
   runId: string;
   status: WorkspaceAutomationRunStatus;
+  planTools: string[];
+  stepResults: Record<string, unknown>;
 };
 
 function resolveTemplateSkillId(inputSnapshot: Record<string, unknown>) {
@@ -172,6 +177,8 @@ export async function runWorkspaceOrchestrator(input: {
     return ok({
       runId: run.id,
       status: "skipped",
+      planTools: plan.tools,
+      stepResults: {},
     });
   }
 
@@ -215,9 +222,23 @@ export async function runWorkspaceOrchestrator(input: {
       completedAt: new Date(),
     });
 
+    logger.info(
+      {
+        workspaceAutomationRunId: run.id,
+        organizationId: input.organizationId,
+        planTools: plan.tools,
+        terminalStatus,
+        stepResults: session.stepResults,
+        ...(session.terminalError ? { terminalError: session.terminalError } : {}),
+      },
+      "workspace orchestrator finished",
+    );
+
     return ok({
       runId: run.id,
       status: terminalStatus,
+      planTools: plan.tools,
+      stepResults: session.stepResults,
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : "workspace_orchestrator_failed";

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/run_contentful_translation.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/run_contentful_translation.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { defineAgentTool } from "@/agents/_runtime/define-agent-tool";
 import { runContentfulAgent } from "@/agents/automations/contentful/agent/run-contentful-agent";
 import { createContentfulTranslationRun } from "@/lib/contentful/automation-executor";
+import { hasContentfulNoWriteback } from "@/lib/contentful/types";
 import { updateWorkspaceAutomationRun } from "@/lib/agents/workspace-automations";
 
 import type { WorkspaceOrchestratorSession } from "../context";
@@ -126,9 +127,11 @@ export function createRunContentfulTranslationTool(session: WorkspaceOrchestrato
         return failure;
       }
 
-      const writeDrafts = contentful.writeDrafts ?? true;
-      const noWriteback =
-        writeDrafts && result.value.fieldsDetected > 0 && result.value.localeValuesWritten === 0;
+      const noWriteback = hasContentfulNoWriteback({
+        writeDrafts: contentful.writeDrafts ?? true,
+        fieldsDetected: result.value.fieldsDetected,
+        localeValuesWritten: result.value.localeValuesWritten,
+      });
 
       if (noWriteback) {
         const message = "contentful_no_draft_writebacks";

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/run_contentful_translation.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/run_contentful_translation.ts
@@ -126,11 +126,41 @@ export function createRunContentfulTranslationTool(session: WorkspaceOrchestrato
         return failure;
       }
 
+      const writeDrafts = contentful.writeDrafts ?? true;
+      const noWriteback =
+        writeDrafts && result.value.fieldsDetected > 0 && result.value.localeValuesWritten === 0;
+
+      if (noWriteback) {
+        const message = "contentful_no_draft_writebacks";
+        session.terminalStatus = "failed";
+        session.terminalError = message;
+        await updateWorkspaceAutomationRun({
+          runId: session.run.id,
+          organizationId: session.organizationId,
+          status: "failed",
+          error: { message },
+          completedAt: new Date(),
+        });
+
+        const failure = {
+          contentfulTranslationRunId: translationRun.id,
+          status: "failed",
+          message,
+          fieldsDetected: result.value.fieldsDetected,
+          localeValuesWritten: result.value.localeValuesWritten,
+        };
+        session.stepResults.run_contentful_translation = failure;
+        return failure;
+      }
+
       session.terminalStatus = "succeeded";
       const success = {
         contentfulTranslationRunId: translationRun.id,
         status: "succeeded",
         runId: result.value.runId,
+        fieldsDetected: result.value.fieldsDetected,
+        localeValuesWritten: result.value.localeValuesWritten,
+        qaFindingCount: result.value.qaFindingCount,
       };
       session.stepResults.run_contentful_translation = success;
       return success;

--- a/apps/hyperlocalise-web/src/lib/contentful/automation-executor.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/automation-executor.ts
@@ -47,6 +47,10 @@ export type ContentfulAutomationExecutionEvent = {
   organizationId: string;
 };
 
+export type ExecuteContentfulAutomationOptions = {
+  manageWorkspaceRunStatus?: boolean;
+};
+
 type ContentfulAutomationFieldLogContext = ContentfulAutomationExecutionEvent & {
   runId: string;
   fieldId: string;
@@ -604,7 +608,9 @@ export async function createContentfulTranslationRun(input: {
 
 export async function executeContentfulAutomation(
   input: ContentfulAutomationExecutionEvent,
+  options: ExecuteContentfulAutomationOptions = {},
 ): Promise<Result<ContentfulAutomationExecutionSuccess, ContentfulAutomationExecutionError>> {
+  const manageWorkspaceRunStatus = options.manageWorkspaceRunStatus ?? true;
   const executionContext = {
     contentfulTranslationRunId: input.contentfulTranslationRunId,
     workspaceAutomationRunId: input.workspaceAutomationRunId,
@@ -633,15 +639,17 @@ export async function executeContentfulAutomation(
     .update(schema.contentfulTranslationRuns)
     .set({ status: "running", startedAt: new Date(), updatedAt: new Date() })
     .where(eq(schema.contentfulTranslationRuns.id, run.id));
-  await db
-    .update(schema.workspaceAutomationRuns)
-    .set({ status: "running", startedAt: new Date(), updatedAt: new Date() })
-    .where(
-      and(
-        eq(schema.workspaceAutomationRuns.id, input.workspaceAutomationRunId),
-        eq(schema.workspaceAutomationRuns.organizationId, input.organizationId),
-      ),
-    );
+  if (manageWorkspaceRunStatus) {
+    await db
+      .update(schema.workspaceAutomationRuns)
+      .set({ status: "running", startedAt: new Date(), updatedAt: new Date() })
+      .where(
+        and(
+          eq(schema.workspaceAutomationRuns.id, input.workspaceAutomationRunId),
+          eq(schema.workspaceAutomationRuns.organizationId, input.organizationId),
+        ),
+      );
+  }
 
   try {
     const loaded = await loadContentfulConnectionWithToken({
@@ -852,25 +860,27 @@ export async function executeContentfulAutomation(
         updatedAt: completedAt,
       })
       .where(eq(schema.contentfulTranslationRuns.id, run.id));
-    await db
-      .update(schema.workspaceAutomationRuns)
-      .set({
-        status: "succeeded",
-        outputSummary: {
-          contentfulTranslationRunId: run.id,
-          fieldsDetected: units.length,
-          localeValuesWritten: translations.length,
-          qaFindings: qaFindings.length,
-        },
-        completedAt,
-        updatedAt: completedAt,
-      })
-      .where(
-        and(
-          eq(schema.workspaceAutomationRuns.id, input.workspaceAutomationRunId),
-          eq(schema.workspaceAutomationRuns.organizationId, input.organizationId),
-        ),
-      );
+    if (manageWorkspaceRunStatus) {
+      await db
+        .update(schema.workspaceAutomationRuns)
+        .set({
+          status: "succeeded",
+          outputSummary: {
+            contentfulTranslationRunId: run.id,
+            fieldsDetected: units.length,
+            localeValuesWritten: translations.length,
+            qaFindings: qaFindings.length,
+          },
+          completedAt,
+          updatedAt: completedAt,
+        })
+        .where(
+          and(
+            eq(schema.workspaceAutomationRuns.id, input.workspaceAutomationRunId),
+            eq(schema.workspaceAutomationRuns.organizationId, input.organizationId),
+          ),
+        );
+    }
 
     if (run.webhookEventId) {
       await syncContentfulWebhookEventStatus({
@@ -892,7 +902,12 @@ export async function executeContentfulAutomation(
       "contentful automation execution succeeded",
     );
 
-    return ok({ runId: run.id });
+    return ok({
+      runId: run.id,
+      fieldsDetected: units.length,
+      localeValuesWritten: translations.length,
+      qaFindingCount: qaFindings.length,
+    });
   } catch (error) {
     const completedAt = new Date();
     const message = isContentfulClientError(error)
@@ -918,20 +933,22 @@ export async function executeContentfulAutomation(
         updatedAt: completedAt,
       })
       .where(eq(schema.contentfulTranslationRuns.id, run.id));
-    await db
-      .update(schema.workspaceAutomationRuns)
-      .set({
-        status: "failed",
-        error: { message },
-        completedAt,
-        updatedAt: completedAt,
-      })
-      .where(
-        and(
-          eq(schema.workspaceAutomationRuns.id, input.workspaceAutomationRunId),
-          eq(schema.workspaceAutomationRuns.organizationId, input.organizationId),
-        ),
-      );
+    if (manageWorkspaceRunStatus) {
+      await db
+        .update(schema.workspaceAutomationRuns)
+        .set({
+          status: "failed",
+          error: { message },
+          completedAt,
+          updatedAt: completedAt,
+        })
+        .where(
+          and(
+            eq(schema.workspaceAutomationRuns.id, input.workspaceAutomationRunId),
+            eq(schema.workspaceAutomationRuns.organizationId, input.organizationId),
+          ),
+        );
+    }
     if (run.webhookEventId) {
       await syncContentfulWebhookEventStatus({
         eventId: run.webhookEventId,

--- a/apps/hyperlocalise-web/src/lib/contentful/types.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/types.ts
@@ -212,6 +212,9 @@ export type ContentfulDiscoveryError =
 
 export type ContentfulAutomationExecutionSuccess = {
   runId: string;
+  fieldsDetected: number;
+  localeValuesWritten: number;
+  qaFindingCount: number;
 };
 
 export type ContentfulAutomationExecutionError = {

--- a/apps/hyperlocalise-web/src/lib/contentful/types.ts
+++ b/apps/hyperlocalise-web/src/lib/contentful/types.ts
@@ -217,6 +217,14 @@ export type ContentfulAutomationExecutionSuccess = {
   qaFindingCount: number;
 };
 
+export function hasContentfulNoWriteback(input: {
+  writeDrafts?: boolean | null;
+  fieldsDetected: number;
+  localeValuesWritten: number;
+}) {
+  return input.writeDrafts !== false && input.fieldsDetected > 0 && input.localeValuesWritten === 0;
+}
+
 export type ContentfulAutomationExecutionError = {
   code: "contentful_automation_failed";
   runId: string;

--- a/apps/hyperlocalise-web/src/workflows/README.md
+++ b/apps/hyperlocalise-web/src/workflows/README.md
@@ -57,7 +57,7 @@ workspaceAutomationExecutionWorkflow
 runWorkspaceOrchestrator (ToolLoopAgent)
         |
         +-- run_github_workflows ----> githubRepositoryAutomationWorkflow (poll to terminal)
-        +-- run_contentful_translation -> runContentfulAgent (inline)
+        +-- run_contentful_translation -> runContentfulAgent -> run_translation tool (executor)
         +-- notify_slack
         `-- notify_email
 ```

--- a/apps/hyperlocalise-web/src/workflows/steps/workspace-automation-execution.test.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/workspace-automation-execution.test.ts
@@ -11,6 +11,8 @@ const { runWorkspaceOrchestratorMock } = vi.hoisted(() => ({
     return new OkResult({
       runId: "run-1",
       status: "succeeded" as const,
+      planTools: [],
+      stepResults: {},
     });
   }),
 }));

--- a/apps/hyperlocalise-web/src/workflows/steps/workspace-automation-execution.test.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/workspace-automation-execution.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 
+import type { WorkspaceOrchestratorExecutionSuccess } from "@/agents/automations/workspace/agent/run-workspace-orchestrator";
+
 const { runWorkspaceOrchestratorMock } = vi.hoisted(() => ({
   runWorkspaceOrchestratorMock: vi.fn(async (): Promise<unknown> => {
     class OkResult {
       readonly ok = true;
 
-      constructor(readonly value: { runId: string; status: "succeeded" }) {}
+      constructor(readonly value: WorkspaceOrchestratorExecutionSuccess) {}
     }
 
     return new OkResult({

--- a/apps/hyperlocalise-web/src/workflows/steps/workspace-automation-execution.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/workspace-automation-execution.ts
@@ -47,9 +47,15 @@ export async function executeWorkspaceAutomationStep(
     }
 
     logger.info(
-      { ...stepContext, status: result.value.status },
+      { ...stepContext, status: result.value.status, planTools: result.value.planTools },
       "workspace automation orchestrator step completed successfully",
     );
+    if (Object.keys(result.value.stepResults).length > 0) {
+      logger.info(
+        { ...stepContext, stepResults: result.value.stepResults },
+        "workspace automation orchestrator step results",
+      );
+    }
     return { ok: true, value: result.value };
   } catch (error) {
     const message = error instanceof Error ? error.message : "workspace_orchestrator_step_failed";


### PR DESCRIPTION
## What changed

The Contentful automation agent no longer relies on the LLM to call granular tools (`fetch_entry`, `translate_string`, `write_drafts`) in sequence. It now exposes a single `run_translation` tool that delegates to `executeContentfulAutomation`, and the agent is forced to call that tool on step 0.

This fixes runs that fetched entries and translated text but never wrote drafts back to Contentful. The orchestrator and executor now log field detection and writeback counts, and runs fail with `contentful_no_draft_writebacks` when writeback is enabled but nothing is written.

## How to test

- [ ] Trigger a Contentful webhook automation and confirm Contentful PUT/PATCH calls appear in the external API trace
- [ ] Confirm logs include `contentful automation detected translatable fields` and `contentful agent translation finished` with non-zero `localeValuesWritten`
- [ ] Run `cd apps/hyperlocalise-web && vp test src/agents/automations/contentful/agent/tools/build-contentful-tools.test.ts src/lib/contentful/automation-executor.test.ts`
- [ ] Run `cd apps/hyperlocalise-web && vp check --fix`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)