### PR TITLE
fix(web): preserve Contentful webhook entry ID in orchestrator tool

### DIFF
--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/run-workspace-orchestrator.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/run-workspace-orchestrator.test.ts
@@ -30,4 +30,30 @@ describe("buildWorkspaceOrchestratorUserMessage", () => {
 
     expect(message).not.toContain("Contentful entry ID");
   });
+
+  it("omits Contentful entry context when the snapshot has no entry ID", () => {
+    const message = buildWorkspaceOrchestratorUserMessage({
+      automationName: "Translate Contentful article",
+      triggerSource: "contentful",
+      inputSnapshot: {},
+    });
+
+    expect(message).toContain("Trigger source: contentful.");
+    expect(message).not.toContain("Contentful entry ID");
+    expect(message).not.toContain("Contentful content type");
+  });
+
+  it("omits Contentful entry context when the snapshot entry ID is blank", () => {
+    const message = buildWorkspaceOrchestratorUserMessage({
+      automationName: "Translate Contentful article",
+      triggerSource: "contentful",
+      inputSnapshot: {
+        entryId: "   ",
+        contentTypeId: "helpCenterArticle",
+      },
+    });
+
+    expect(message).not.toContain("Contentful entry ID");
+    expect(message).toContain("Contentful content type: helpCenterArticle.");
+  });
 });

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/run-workspace-orchestrator.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/run-workspace-orchestrator.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { buildWorkspaceOrchestratorUserMessage } from "./run-workspace-orchestrator";
+
+describe("buildWorkspaceOrchestratorUserMessage", () => {
+  it("includes Contentful webhook context in the orchestrator prompt", () => {
+    const message = buildWorkspaceOrchestratorUserMessage({
+      automationName: "Translate Contentful article",
+      triggerSource: "contentful",
+      inputSnapshot: {
+        entryId: "entry-from-webhook",
+        contentTypeId: "helpCenterArticle",
+      },
+    });
+
+    expect(message).toContain('Execute automation "Translate Contentful article"');
+    expect(message).toContain("Trigger source: contentful.");
+    expect(message).toContain("Contentful entry ID: entry-from-webhook.");
+    expect(message).toContain("Contentful content type: helpCenterArticle.");
+  });
+
+  it("does not add Contentful context for non-Contentful triggers", () => {
+    const message = buildWorkspaceOrchestratorUserMessage({
+      automationName: "Validate localisation on push",
+      triggerSource: "github",
+      inputSnapshot: {
+        entryId: "entry-from-webhook",
+      },
+    });
+
+    expect(message).not.toContain("Contentful entry ID");
+  });
+});

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/run-workspace-orchestrator.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/run-workspace-orchestrator.ts
@@ -7,6 +7,7 @@ import {
   getWorkspaceAutomationById,
   getWorkspaceAutomationRunById,
   updateWorkspaceAutomationRun,
+  type WorkspaceAutomationRunRecord,
   type WorkspaceAutomationRunStatus,
 } from "@/lib/agents/workspace-automations";
 
@@ -35,6 +36,32 @@ export type WorkspaceOrchestratorExecutionSuccess = {
 
 function resolveTemplateSkillId(inputSnapshot: Record<string, unknown>) {
   return typeof inputSnapshot.templateSkillId === "string" ? inputSnapshot.templateSkillId : null;
+}
+
+export function buildWorkspaceOrchestratorUserMessage(input: {
+  automationName: string;
+  triggerSource: WorkspaceAutomationRunRecord["triggerSource"];
+  inputSnapshot: Record<string, unknown>;
+}) {
+  const lines = [
+    `Execute automation "${input.automationName}" using the planned tools in order.`,
+    `Trigger source: ${input.triggerSource}.`,
+  ];
+
+  if (input.triggerSource === "contentful") {
+    if (typeof input.inputSnapshot.entryId === "string" && input.inputSnapshot.entryId.trim()) {
+      lines.push(`Contentful entry ID: ${input.inputSnapshot.entryId.trim()}.`);
+    }
+    if (
+      typeof input.inputSnapshot.contentTypeId === "string" &&
+      input.inputSnapshot.contentTypeId.trim()
+    ) {
+      lines.push(`Contentful content type: ${input.inputSnapshot.contentTypeId.trim()}.`);
+    }
+  }
+
+  lines.push("Apply customer instructions when running workflow tools.");
+  return lines.join("\n");
 }
 
 function collectNotificationWarnings(session: WorkspaceOrchestratorSession) {
@@ -195,11 +222,11 @@ export async function runWorkspaceOrchestrator(input: {
       messages: [
         {
           role: "user",
-          content: [
-            `Execute automation "${automation.name}" using the planned tools in order.`,
-            `Trigger source: ${run.triggerSource}.`,
-            "Apply customer instructions when running workflow tools.",
-          ].join("\n"),
+          content: buildWorkspaceOrchestratorUserMessage({
+            automationName: automation.name,
+            triggerSource: run.triggerSource,
+            inputSnapshot: run.inputSnapshot,
+          }),
         },
       ],
     });

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/run_contentful_translation.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/run_contentful_translation.test.ts
@@ -88,6 +88,23 @@ describe("resolveContentfulEntryId", () => {
 
     expect(resolved).toBe("entry-from-webhook");
   });
+
+  it("falls back to automation config when the snapshot has no entry ID", () => {
+    const resolved = resolveContentfulEntryId(
+      session({
+        inputSnapshot: {},
+        toolConfigEntryId: "entry-from-config",
+      }),
+    );
+
+    expect(resolved).toBe("entry-from-config");
+  });
+
+  it("returns null when neither the snapshot nor automation config provides an entry ID", () => {
+    const resolved = resolveContentfulEntryId(session({ inputSnapshot: {} }));
+
+    expect(resolved).toBeNull();
+  });
 });
 
 describe("resolveContentfulEntryIdForExecution", () => {

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/run_contentful_translation.test.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/run_contentful_translation.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import type {
+  WorkspaceAutomationRecord,
+  WorkspaceAutomationRunRecord,
+} from "@/lib/agents/workspace-automations";
+
+import type { WorkspaceOrchestratorSession } from "../context";
+import {
+  createRunContentfulTranslationTool,
+  resolveContentfulEntryId,
+  resolveContentfulEntryIdForExecution,
+} from "./run_contentful_translation";
+
+function session(input: {
+  inputSnapshot?: Record<string, unknown>;
+  toolConfigEntryId?: string;
+  automationName?: string;
+}): WorkspaceOrchestratorSession {
+  const automation = {
+    id: "automation-1",
+    organizationId: "org-1",
+    authorUserId: null,
+    status: "active",
+    name: input.automationName ?? "Translate Contentful article",
+    instructions: "",
+    triggerConfig: { mode: "contentful" },
+    repositoryTarget: { kind: "none" },
+    toolConfig: {
+      contentful: {
+        enabled: true,
+        connectionId: "00000000-0000-4000-8000-000000000001",
+        projectId: "00000000-0000-4000-8000-000000000002",
+        sourceLocale: "en",
+        targetLocales: ["fr-FR"],
+        contentTypeIds: [],
+        fieldMode: "auto",
+        overwriteDraftLocales: false,
+        runQa: true,
+        writeDrafts: true,
+        entryId: input.toolConfigEntryId,
+      },
+    },
+    configVersion: 1,
+    nextRunAt: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  } satisfies WorkspaceAutomationRecord;
+
+  const run = {
+    id: "run-1",
+    automationId: automation.id,
+    organizationId: automation.organizationId,
+    triggerSource: "contentful",
+    status: "queued",
+    inputSnapshot: input.inputSnapshot ?? {},
+    outputSummary: {},
+    error: null,
+    githubRepositoryAutomationJobId: null,
+    idempotencyKey: null,
+    startedAt: null,
+    completedAt: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  } satisfies WorkspaceAutomationRunRecord;
+
+  return {
+    organizationId: automation.organizationId,
+    automation,
+    run,
+    plan: { tools: ["run_contentful_translation"] },
+    repository: null,
+    composedInstructions: "",
+    stepResults: {},
+    terminalStatus: null,
+    terminalError: null,
+  };
+}
+
+describe("resolveContentfulEntryId", () => {
+  it("prefers the webhook snapshot entry ID over automation config", () => {
+    const resolved = resolveContentfulEntryId(
+      session({
+        inputSnapshot: { entryId: "entry-from-webhook" },
+        toolConfigEntryId: "Translate Contentful article",
+      }),
+    );
+
+    expect(resolved).toBe("entry-from-webhook");
+  });
+});
+
+describe("resolveContentfulEntryIdForExecution", () => {
+  it("ignores agent overrides when the trigger already provided an entry ID", () => {
+    const resolved = resolveContentfulEntryIdForExecution(
+      session({
+        inputSnapshot: { entryId: "entry-from-webhook" },
+      }),
+      "Translate Contentful article",
+    );
+
+    expect(resolved).toBe("entry-from-webhook");
+  });
+
+  it("falls back to the agent-provided entry ID when none was preset", () => {
+    const resolved = resolveContentfulEntryIdForExecution(
+      session({ inputSnapshot: {} }),
+      "entry-from-agent",
+    );
+
+    expect(resolved).toBe("entry-from-agent");
+  });
+});
+
+describe("createRunContentfulTranslationTool", () => {
+  it("binds the webhook entry ID in the tool description when the trigger provided one", () => {
+    const tool = createRunContentfulTranslationTool(
+      session({
+        inputSnapshot: { entryId: "entry-from-webhook" },
+      }),
+    );
+
+    expect(tool.description).toContain("entry-from-webhook");
+  });
+});

--- a/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/run_contentful_translation.ts
+++ b/apps/hyperlocalise-web/src/agents/automations/workspace/agent/tools/run_contentful_translation.ts
@@ -8,7 +8,7 @@ import { updateWorkspaceAutomationRun } from "@/lib/agents/workspace-automations
 
 import type { WorkspaceOrchestratorSession } from "../context";
 
-function resolveContentfulEntryId(session: WorkspaceOrchestratorSession) {
+export function resolveContentfulEntryId(session: WorkspaceOrchestratorSession) {
   const snapshot = session.run.inputSnapshot;
   if (typeof snapshot.entryId === "string" && snapshot.entryId.trim()) {
     return snapshot.entryId.trim();
@@ -17,21 +17,37 @@ function resolveContentfulEntryId(session: WorkspaceOrchestratorSession) {
   return session.automation.toolConfig.contentful?.entryId?.trim() ?? null;
 }
 
+export function resolveContentfulEntryIdForExecution(
+  session: WorkspaceOrchestratorSession,
+  entryIdOverride?: string,
+) {
+  const resolvedEntryId = resolveContentfulEntryId(session);
+  if (resolvedEntryId) {
+    return resolvedEntryId;
+  }
+
+  return entryIdOverride?.trim() ?? null;
+}
+
+const runContentfulTranslationInputSchema = z.object({
+  entryId: z
+    .string()
+    .trim()
+    .min(1)
+    .describe("Contentful entry ID to translate when none was provided by the trigger."),
+});
+
 export function createRunContentfulTranslationTool(session: WorkspaceOrchestratorSession) {
+  const presetEntryId = resolveContentfulEntryId(session);
+
   return defineAgentTool({
-    description:
-      "Translate the configured Contentful entry into target locales, run QA when enabled, and write drafts.",
-    inputSchema: z.object({
-      entryId: z
-        .string()
-        .trim()
-        .min(1)
-        .optional()
-        .describe(
-          "Optional entry ID override; defaults to the trigger payload or automation config.",
-        ),
-    }),
-    execute: async ({ entryId: entryIdOverride }) => {
+    description: presetEntryId
+      ? `Translate Contentful entry ${presetEntryId} into target locales, run QA when enabled, and write drafts.`
+      : "Translate the configured Contentful entry into target locales, run QA when enabled, and write drafts.",
+    inputSchema: presetEntryId ? z.object({}) : runContentfulTranslationInputSchema,
+    execute: async (input) => {
+      const entryIdOverride =
+        "entryId" in input && typeof input.entryId === "string" ? input.entryId : undefined;
       const contentful = session.automation.toolConfig.contentful;
       if (!contentful?.enabled || !contentful.connectionId || !contentful.projectId) {
         throw new Error("contentful_workflow_not_configured");
@@ -39,7 +55,7 @@ export function createRunContentfulTranslationTool(session: WorkspaceOrchestrato
 
       const sourceLocale = contentful.sourceLocale?.trim();
       const targetLocales = contentful.targetLocales ?? [];
-      const entryId = entryIdOverride?.trim() || resolveContentfulEntryId(session);
+      const entryId = resolveContentfulEntryIdForExecution(session, entryIdOverride);
 
       if (!sourceLocale) {
         throw new Error("contentful_source_locale_missing");


### PR DESCRIPTION
## What changed

Contentful webhook automations were failing with `Invalid resource id` because the workspace orchestrator LLM could pass the automation name (e.g. `Translate Contentful article`) as the `entryId` tool argument, overriding the real entry ID from the webhook payload.

This PR:
- Resolves entry IDs from the trigger snapshot or automation config before accepting agent overrides
- Omits the `entryId` tool input when the webhook already provided one, and binds the ID in the tool description instead
- Includes Contentful entry ID and content type in the orchestrator user message for Contentful-triggered runs

## How to test

- `cd apps/hyperlocalise-web && vp test src/agents/automations/workspace/agent/tools/run_contentful_translation.test.ts src/agents/automations/workspace/agent/run-workspace-orchestrator.test.ts`
- `cd apps/hyperlocalise-web && vp check --fix src/agents/automations/workspace/agent/tools/run_contentful_translation.ts src/agents/automations/workspace/agent/run-workspace-orchestrator.ts`
- Trigger a Contentful webhook automation and confirm the translation run uses the webhook entry ID, not the automation name

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)