### PR TITLE
🧪 Scout: escape line feeds in CSV formula neutralization

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -99,3 +99,7 @@
 ## 2026-06-23 - [Translator Request Validation Safety]
 **Learning:** Shared request types in the translator package (Request, ImageEditRequest) lack explicit validation tests, despite being critical internal APIs. Adding dedicated tests for their validation logic ensures that contract requirements (like mandatory fields or supported image formats) are consistently enforced across all provider implementations.
 **Action:** Always include comprehensive success and failure test cases for validation helpers when introducing or modifying shared data structures to prevent regressions in API contract enforcement.
+
+## 2026-06-24 - [CSV Injection: Escaping Line Feeds]
+**Learning:** Security best practices (OWASP) for CSV injection/Formula injection require escaping not just '=', '+', '-', and '@', but also whitespace characters like Tab (0x09), Carriage Return (0x0D), and Line Feed (0x0A). If these characters appear at the start of a cell, some spreadsheet software may interpret the following content as a formula.
+**Action:** Always include '\n' (Line Feed) in the set of characters that trigger formula escaping (prepending a single quote) in CSV cell values.

--- a/internal/csvsafe/csvsafe.go
+++ b/internal/csvsafe/csvsafe.go
@@ -7,7 +7,7 @@ func EscapeFormula(value string) string {
 		return value
 	}
 	switch value[0] {
-	case '=', '+', '-', '@', '\t', '\r':
+	case '=', '+', '-', '@', '\t', '\r', '\n':
 		return "'" + value
 	default:
 		return value

--- a/internal/csvsafe/csvsafe_test.go
+++ b/internal/csvsafe/csvsafe_test.go
@@ -15,6 +15,7 @@ func TestEscapeFormula(t *testing.T) {
 		{"@evil", "'@evil"},
 		{"\tlead", "'\tlead"},
 		{"\rlead", "'\rlead"},
+		{"\nlead", "'\nlead"},
 		{" space", " space"},
 		{"=", "'="},
 	}


### PR DESCRIPTION
💡 What: Added `\n` (Line Feed) to the set of characters neutralized by `EscapeFormula` by prepending a single quote.

🎯 Why: To prevent CSV/Formula injection. Some spreadsheet software (like Excel or LibreOffice) may interpret a cell as a formula if it starts with certain whitespace characters, including Line Feed (0x0A), followed by a formula-initiating character. This change follows OWASP security best practices.

🧩 Scope: `internal/csvsafe/csvsafe.go`, `internal/csvsafe/csvsafe_test.go`, and `.jules/scout.md`.

✅ Verification:
- Ran `go test ./internal/csvsafe/...` (verified failure before fix and success after).
- Ran full workspace tests with `go test ./...`.
- Verified third-party module tests with `GOWORK=off go test ./...` in the module directory.

🛡️ Confidence: High. This is a focused, standard security improvement with explicit test coverage and no breaking impact on data usability.

---
*PR created automatically by Jules for task [16877477606446731544](https://jules.google.com/task/16877477606446731544) started by @cungminh2710*