### PR TITLE
fix(crowdin): add missing DateFrom to EnterpriseVendorTaskCreateForm and fix typos

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -173,3 +173,15 @@
 **Learning:** Several list response models in the Crowdin Go SDK were missing the `pagination` field, preventing callers from handling multi-page results for translation progress, QA checks, and group managers. Additionally, the `ManagerListOptions.Values()` method was using a manual loop for slice joining, which is less efficient and consistent than the `JoinSlice` helper.
 
 **Action:** Added `Pagination *Pagination` to `TranslationProgressResponse`, `QAChecksResponse`, and `ManagerResponse`. Refactored `ManagerListOptions.Values()` to use `JoinSlice`. Added comprehensive unmarshaling tests to verify that the new pagination fields are correctly populated from API responses. Verified with `go test` in the fork.
+
+## 2026-10-10 - Improve Enterprise Task parity and fix test typos
+
+**Learning:** The Crowdin Enterprise API v2 supports  in , but it was missing from the SDK model. Additionally, several test function names in  contained typos (e.g., "Tepmlate").
+
+**Action:** Added  string field to  in . Corrected "Tepmlate" to "Template" and "Tepmlates" to "Templates" in . Added  to verify parity.
+
+## 2026-10-10 - Improve Enterprise Task parity and fix test typos
+
+**Learning:** The Crowdin Enterprise API v2 supports `dateFrom` in `EnterpriseVendorTaskCreateForm`, but it was missing from the SDK model. Additionally, several test function names in `tasks_test.go` contained typos (e.g., "Tepmlate").
+
+**Action:** Added `DateFrom` string field to `EnterpriseVendorTaskCreateForm` in `model/tasks.go`. Corrected "Tepmlate" to "Template" and "Tepmlates" to "Templates" in `tasks_test.go`. Added `TestTasksService_Add_EnterpriseVendorTaskCreateForm` to verify parity.

--- a/third_party/crowdin-api-client-go/crowdin/model/tasks.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/tasks.go
@@ -597,6 +597,8 @@ type (
 		Deadline string `json:"deadline,omitempty"`
 		// Task started date. Format: UTC, ISO 8601.
 		StartedAt string `json:"startedAt,omitempty"`
+		// Start date for interval when strings were modified. Format: UTC, ISO 8601.
+		DateFrom string `json:"dateFrom,omitempty"`
 		// End date for interval when strings were modified. Format: UTC, ISO 8601.
 		DateTo string `json:"dateTo,omitempty"`
 		// Fields for task.

--- a/third_party/crowdin-api-client-go/crowdin/tasks_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/tasks_test.go
@@ -689,6 +689,39 @@ func TestTasksService_Delete(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
 
+func TestTasksService_Add_EnterpriseVendorTaskCreateForm(t *testing.T) {
+	client, mux, teardown := setupClient()
+	defer teardown()
+
+	const path = "/api/v2/projects/1/tasks"
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		testURL(t, r, path)
+		testJSONBody(t, r, `{
+			"workflowStepId": 10,
+			"branchIds": [1, 2],
+			"title": "Vendor Task",
+			"languageId": "fr",
+			"dateFrom": "2023-08-23T09:04:29+00:00",
+			"dateTo": "2023-09-23T09:04:29+00:00"
+		}`)
+
+		fmt.Fprint(w, `{"data":{"id":2}}`)
+	})
+
+	req := &model.EnterpriseVendorTaskCreateForm{
+		WorkflowStepID: 10,
+		BranchIDs:      []int{1, 2},
+		Title:          "Vendor Task",
+		LanguageID:     "fr",
+		DateFrom:       "2023-08-23T09:04:29+00:00",
+		DateTo:         "2023-09-23T09:04:29+00:00",
+	}
+	task, _, err := client.Tasks.Add(context.Background(), 1, req)
+	require.NoError(t, err)
+	assert.Equal(t, 2, task.ID)
+}
+
 func TestTasksService_ListUserTasks(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -865,7 +898,7 @@ func TestTasksService_ExportStrings_NoStrings(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
 
-func TestTasksService_GetSettingsTepmlate(t *testing.T) {
+func TestTasksService_GetSettingsTemplate(t *testing.T) {
 	client, mux, teardown := setupClient()
 	defer teardown()
 
@@ -913,7 +946,7 @@ func TestTasksService_GetSettingsTepmlate(t *testing.T) {
 	assert.Equal(t, expected, template)
 }
 
-func TestTasksService_ListSettingsTepmlates(t *testing.T) {
+func TestTasksService_ListSettingsTemplates(t *testing.T) {
 	tests := []struct {
 		name string
 		opts *model.ListOptions
@@ -1036,7 +1069,7 @@ func TestTasksService_ListSettingsTepmlates(t *testing.T) {
 	}
 }
 
-func TestTasksService_ListSettingsTepmlates_invalidJSON(t *testing.T) {
+func TestTasksService_ListSettingsTemplates_invalidJSON(t *testing.T) {
 	client, mux, teardown := setupClient()
 	defer teardown()
 
@@ -1049,7 +1082,7 @@ func TestTasksService_ListSettingsTepmlates_invalidJSON(t *testing.T) {
 	assert.Nil(t, res)
 }
 
-func TestTasksService_AddSettingsTepmlates(t *testing.T) {
+func TestTasksService_AddSettingsTemplates(t *testing.T) {
 	client, mux, teardown := setupClient()
 	defer teardown()
 
@@ -1110,7 +1143,7 @@ func TestTasksService_AddSettingsTepmlates(t *testing.T) {
 	assert.Equal(t, expected, template)
 }
 
-func TestTasksService_EditSettingsTepmlates(t *testing.T) {
+func TestTasksService_EditSettingsTemplates(t *testing.T) {
 	client, mux, teardown := setupClient()
 	defer teardown()
 
@@ -1166,7 +1199,7 @@ func TestTasksService_EditSettingsTepmlates(t *testing.T) {
 	assert.Equal(t, expected, template)
 }
 
-func TestTasksService_DeleteSettingsTepmlates(t *testing.T) {
+func TestTasksService_DeleteSettingsTemplates(t *testing.T) {
 	client, mux, teardown := setupClient()
 	defer teardown()
 


### PR DESCRIPTION
- What: Added `DateFrom` to `EnterpriseVendorTaskCreateForm` and fixed multiple typos in test function names in `tasks_test.go`.
- Why: To align with the Crowdin Enterprise API v2 contract and improve code maintainability.
- Docs: https://developer.crowdin.com/api/v2/#operation/api.projects.tasks.post
- Scope: `third_party/crowdin-api-client-go/crowdin/model/tasks.go`, `third_party/crowdin-api-client-go/crowdin/tasks_test.go`
- Tests: Added `TestTasksService_Add_EnterpriseVendorTaskCreateForm` to verify serialization. All `crowdin` module tests passed.
- Confidence: Verified documented behavior and ensured no regressions in existing task creation flows.

---
*PR created automatically by Jules for task [5993274668292030332](https://jules.google.com/task/5993274668292030332) started by @cungminh2710*