### PR TITLE
feat(web): add per-file translation import for native TMS

### DIFF
--- a/apps/hyperlocalise-web/src/api/app.ts
+++ b/apps/hyperlocalise-web/src/api/app.ts
@@ -11,6 +11,7 @@ import type {
   ProviderSyncQueue,
   ProviderAgentTranslationQueue,
   ProviderAgentWritebackQueue,
+  TranslationFileImportQueue,
   TranslationJobEventData,
 } from "@/lib/workflow/types";
 import { handleUnexpectedError, notFoundHandler } from "./errors";
@@ -74,6 +75,7 @@ type CreateAppOptions = {
   providerAgentWritebackQueue?: ProviderAgentWritebackQueue;
   providerSyncQueue?: ProviderSyncQueue;
   fileStorageAdapter?: FileStorageAdapter;
+  translationFileImportQueue?: TranslationFileImportQueue;
 };
 
 export function createApp(options: CreateAppOptions = {}) {

--- a/apps/hyperlocalise-web/src/api/routes/project/project-file-translation-import.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project-file-translation-import.route.test.ts
@@ -1,0 +1,195 @@
+import "dotenv/config";
+
+import { randomUUID } from "node:crypto";
+
+import { eq } from "drizzle-orm";
+import { testClient } from "hono/testing";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
+
+import { createApp } from "@/api/app";
+import { db, schema } from "@/lib/database";
+import type { TranslationFileImportEventData } from "@/lib/workflow/types";
+
+import { createProjectTestFixture } from "./project.fixture";
+import { createMemoryFileStorageAdapter } from "../public-files/public-files.fixture";
+
+const { resolveApiAuthContextFromSessionMock } = vi.hoisted(() => ({
+  resolveApiAuthContextFromSessionMock: vi.fn(
+    (options) =>
+      globalThis.__resolveTestApiAuthContextFromSession?.(options) ??
+      globalThis.__testApiAuthContext ??
+      null,
+  ),
+}));
+
+vi.mock("@/api/auth/workos-session", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/auth/workos-session")>();
+  return {
+    ...actual,
+    resolveApiAuthContextFromSession: resolveApiAuthContextFromSessionMock,
+  };
+});
+
+const enqueuedImports: TranslationFileImportEventData[] = [];
+const translationFileImportQueue = {
+  async enqueue(event: TranslationFileImportEventData) {
+    enqueuedImports.push(event);
+    return { ids: [`run_${enqueuedImports.length}`] };
+  },
+};
+const fileStorageAdapter = createMemoryFileStorageAdapter();
+const app = createApp({ fileStorageAdapter, translationFileImportQueue });
+const client = testClient(app);
+const projectFixture = createProjectTestFixture(client);
+
+async function createNativeProject(targetLocales: string[]) {
+  const admin = projectFixture.createWorkosIdentityWithRole("admin");
+  const headers = await projectFixture.authHeadersFor(admin);
+  const organizationId = globalThis.__testApiAuthContext!.organization.localOrganizationId;
+  const userId = globalThis.__testApiAuthContext!.user.localUserId;
+  const projectId = `project_${randomUUID()}`;
+
+  await db.insert(schema.projects).values({
+    id: projectId,
+    organizationId,
+    teamId: null,
+    createdByUserId: userId,
+    name: "Native Project",
+    description: "",
+    translationContext: "",
+    source: "native",
+    sourceLocale: "en",
+    targetLocales,
+  });
+
+  return { admin, headers, organizationId, projectId };
+}
+
+async function postImport(input: {
+  slug: string;
+  projectId: string;
+  sourcePath: string;
+  locale: string;
+  file: File;
+  headers: Record<string, string>;
+}) {
+  const form = new FormData();
+  form.set("sourcePath", input.sourcePath);
+  form.set("locale", input.locale);
+  form.set("file", input.file);
+
+  return app.request(
+    `/api/orgs/${encodeURIComponent(input.slug)}/projects/${encodeURIComponent(input.projectId)}/files/translations/import`,
+    { method: "POST", body: form, headers: input.headers },
+  );
+}
+
+beforeAll(async () => {
+  await db.$client.query("select 1");
+});
+
+afterEach(async () => {
+  vi.clearAllMocks();
+  enqueuedImports.length = 0;
+  await projectFixture.cleanup();
+});
+
+describe("project file translation import route", () => {
+  it("stores the file and enqueues an import for a native source file", async () => {
+    const { admin, headers, organizationId, projectId } = await createNativeProject(["fr", "de"]);
+    await db.insert(schema.repositorySourceFiles).values({
+      organizationId,
+      projectId,
+      sourcePath: "locales/en.json",
+    });
+
+    const response = await postImport({
+      slug: admin.organization.slug ?? "missing-slug",
+      projectId,
+      sourcePath: "locales/en.json",
+      locale: "fr",
+      file: new File(['{"greeting":"Bonjour"}'], "en.json", { type: "application/json" }),
+      headers,
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      import: { status: "queued", sourcePath: "locales/en.json", locale: "fr" },
+    });
+
+    expect(enqueuedImports).toHaveLength(1);
+    expect(enqueuedImports[0]).toMatchObject({
+      organizationId,
+      projectId,
+      sourcePath: "locales/en.json",
+      targetLocale: "fr",
+    });
+
+    const storedFiles = await db
+      .select({ role: schema.storedFiles.role })
+      .from(schema.storedFiles)
+      .where(eq(schema.storedFiles.projectId, projectId));
+    expect(storedFiles).toHaveLength(1);
+    expect(storedFiles[0]?.role).toBe("reference");
+  });
+
+  it("rejects an unsupported translation file format", async () => {
+    const { admin, headers, organizationId, projectId } = await createNativeProject(["fr"]);
+    await db.insert(schema.repositorySourceFiles).values({
+      organizationId,
+      projectId,
+      sourcePath: "Dockerfile",
+    });
+
+    const response = await postImport({
+      slug: admin.organization.slug ?? "missing-slug",
+      projectId,
+      sourcePath: "Dockerfile",
+      locale: "fr",
+      file: new File(["FROM node"], "Dockerfile", { type: "text/plain" }),
+      headers,
+    });
+
+    expect(response.status).toBe(400);
+    expect(enqueuedImports).toHaveLength(0);
+  });
+
+  it("returns not found when the source file does not exist", async () => {
+    const { admin, headers, projectId } = await createNativeProject(["fr"]);
+
+    const response = await postImport({
+      slug: admin.organization.slug ?? "missing-slug",
+      projectId,
+      sourcePath: "locales/en.json",
+      locale: "fr",
+      file: new File(['{"greeting":"Bonjour"}'], "en.json", { type: "application/json" }),
+      headers,
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({ error: "source_file_not_found" });
+    expect(enqueuedImports).toHaveLength(0);
+  });
+
+  it("rejects a locale that is not a project target locale", async () => {
+    const { admin, headers, organizationId, projectId } = await createNativeProject(["fr"]);
+    await db.insert(schema.repositorySourceFiles).values({
+      organizationId,
+      projectId,
+      sourcePath: "locales/en.json",
+    });
+
+    const response = await postImport({
+      slug: admin.organization.slug ?? "missing-slug",
+      projectId,
+      sourcePath: "locales/en.json",
+      locale: "es",
+      file: new File(['{"greeting":"Hola"}'], "en.json", { type: "application/json" }),
+      headers,
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ error: "invalid_target_locale" });
+    expect(enqueuedImports).toHaveLength(0);
+  });
+});

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -52,8 +52,17 @@ import {
   loadProjectTranslationsAsPrefilledEntries,
 } from "@/lib/projects/translations/project-translation-service";
 import type { ExternalTmsFileKeyMetadata } from "@/lib/providers/tms-provider-types";
-import type { JobQueue, ProviderSyncQueue, TranslationJobEventData } from "@/lib/workflow/types";
-import { createProviderSyncQueue, createTranslationJobEventQueue } from "@/workflows/adapters";
+import type {
+  JobQueue,
+  ProviderSyncQueue,
+  TranslationFileImportQueue,
+  TranslationJobEventData,
+} from "@/lib/workflow/types";
+import {
+  createProviderSyncQueue,
+  createTranslationFileImportQueue,
+  createTranslationJobEventQueue,
+} from "@/workflows/adapters";
 
 import {
   createProjectBodySchema,
@@ -68,6 +77,7 @@ import {
   projectFileDetailQuerySchema,
   projectFileStringContextBodySchema,
   projectFileUploadBodySchema,
+  projectFileTranslationImportBodySchema,
   projectFileTranslationDownloadQuerySchema,
   projectFilesQuerySchema,
   projectIdParamsSchema,
@@ -488,11 +498,14 @@ type CreateProjectRoutesOptions = {
   jobQueue?: JobQueue<TranslationJobEventData>;
   providerSyncQueue?: ProviderSyncQueue;
   fileStorageAdapter?: FileStorageAdapter;
+  translationFileImportQueue?: TranslationFileImportQueue;
 };
 
 export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
   const jobQueue = options.jobQueue ?? createTranslationJobEventQueue();
   const providerSyncQueue = options.providerSyncQueue ?? createProviderSyncQueue();
+  const translationFileImportQueue =
+    options.translationFileImportQueue ?? createTranslationFileImportQueue();
 
   return new Hono<{ Variables: AuthVariables }>()
     .use("*", workosAuthMiddleware)
@@ -1266,6 +1279,117 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
             },
           },
           201,
+        );
+      },
+    )
+    .post(
+      "/:projectId/files/translations/import",
+      validateProjectParams,
+      bodyLimit({
+        maxSize: maxProjectFileUploadBytes,
+        onError: (c) => badRequestResponse(c, "file_upload_too_large", "File upload is too large"),
+      }),
+      async (c) => {
+        if (!isWriteBackTranslationAllowed(c.var.auth.membership.role)) {
+          return forbiddenResponse(c);
+        }
+
+        const params = c.req.valid("param");
+        const target = await resolveProjectResourceTarget(c.var.auth, params.projectId);
+        if (target.kind === "provider_unavailable") {
+          return providerProjectUnavailableResponse(c, target);
+        }
+
+        if (target.kind === "provider") {
+          return badRequestResponse(
+            c,
+            "provider_import_unsupported",
+            "Translation imports are only available for workspace files.",
+          );
+        }
+
+        const project = await getOwnedProjectRecord(c.var.auth, params.projectId);
+        if (!project) {
+          return projectNotFoundResponse(c);
+        }
+
+        const body = await c.req.parseBody({ all: true });
+        const parsed = projectFileTranslationImportBodySchema.safeParse({
+          sourcePath: asString(body.sourcePath),
+          locale: asString(body.locale),
+        });
+
+        if (!parsed.success) {
+          return invalidProjectPayloadResponse(c);
+        }
+
+        const file = asFile(body.file);
+        if (!file) {
+          return invalidProjectPayloadResponse(c);
+        }
+
+        if (!inferSupportedFileTranslationFileFormat(parsed.data.sourcePath)) {
+          return unsupportedProjectFileResponse(c, parsed.data.sourcePath);
+        }
+
+        if (!project.targetLocales.includes(parsed.data.locale)) {
+          return badRequestResponse(
+            c,
+            "invalid_target_locale",
+            "Locale is not a target locale of this project.",
+          );
+        }
+
+        const sourceFile = await getRepositorySourceFileByPath({
+          organizationId: c.var.auth.organization.localOrganizationId,
+          projectId: params.projectId,
+          sourcePath: parsed.data.sourcePath,
+        });
+        if (!sourceFile) {
+          return notFoundResponse(c, "source_file_not_found", "Source file not found");
+        }
+
+        const adapter = options.fileStorageAdapter ?? getFileStorageAdapter();
+        const storedFile = await createStoredFile({
+          organizationId: c.var.auth.organization.localOrganizationId,
+          projectId: params.projectId,
+          createdByUserId: c.var.auth.user.localUserId,
+          role: "reference",
+          sourceKind: "tms_file",
+          filename: file.name,
+          contentType: file.type || sourceContentType(parsed.data.sourcePath),
+          content: await file.arrayBuffer(),
+          metadata: {
+            sourcePath: parsed.data.sourcePath,
+            targetLocale: parsed.data.locale,
+            uploadSurface: "files_page_translation_import",
+          },
+          adapter,
+        });
+
+        try {
+          await translationFileImportQueue.enqueue({
+            organizationId: c.var.auth.organization.localOrganizationId,
+            projectId: params.projectId,
+            storedFileId: storedFile.id,
+            sourcePath: parsed.data.sourcePath,
+            targetLocale: parsed.data.locale,
+            actorUserId: c.var.auth.user.localUserId,
+          });
+        } catch (error) {
+          await adapter.delete({ keyOrUrl: storedFile.storageKey }).catch(() => undefined);
+          throw error;
+        }
+
+        return c.json(
+          {
+            import: {
+              status: "queued" as const,
+              sourcePath: parsed.data.sourcePath,
+              locale: parsed.data.locale,
+            },
+          },
+          200,
         );
       },
     )

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -1377,6 +1377,10 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
             actorUserId: c.var.auth.user.localUserId,
           });
         } catch (error) {
+          await db
+            .delete(schema.storedFiles)
+            .where(eq(schema.storedFiles.id, storedFile.id))
+            .catch(() => undefined);
           await adapter.delete({ keyOrUrl: storedFile.storageKey }).catch(() => undefined);
           throw error;
         }

--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -280,6 +280,11 @@ export const projectFileUploadBodySchema = z.object({
   workflowRunId: z.string().trim().min(1).max(256).optional(),
 });
 
+export const projectFileTranslationImportBodySchema = z.object({
+  sourcePath: z.string().trim().min(1).max(2048),
+  locale: z.string().trim().min(1).max(32),
+});
+
 export const projectSourceStringEntrySchema = z.object({
   key: z.string(),
   text: z.string(),

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/import-translations-dialog.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/import-translations-dialog.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Spinner } from "@/components/ui/spinner";
+import { readApiResponseError } from "@/lib/api-error";
+import { inferSupportedFileTranslationFileFormat } from "@/lib/translation/file-formats";
+
+const FILE_ACCEPT =
+  ".json,.jsonc,.yaml,.yml,.arb,.xlf,.xlif,.xliff,.po,.html,.md,.mdx,.strings,.stringsdict,.xcstrings,.csv";
+
+type ImportTranslationsDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  organizationSlug: string;
+  projectId: string;
+  sourcePath: string;
+  targetLocales: string[];
+};
+
+function importApiPath(organizationSlug: string, projectId: string) {
+  return `/api/orgs/${encodeURIComponent(organizationSlug)}/projects/${encodeURIComponent(projectId)}/files/translations/import`;
+}
+
+export function ImportTranslationsDialog({
+  open,
+  onOpenChange,
+  organizationSlug,
+  projectId,
+  sourcePath,
+  targetLocales,
+}: ImportTranslationsDialogProps) {
+  const queryClient = useQueryClient();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [locale, setLocale] = useState<string>(targetLocales[0] ?? "");
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setLocale(targetLocales[0] ?? "");
+      setSelectedFile(null);
+    }
+  }, [open, targetLocales]);
+
+  const importTranslations = useMutation({
+    mutationFn: async () => {
+      if (!locale) {
+        throw new Error("Select a target locale.");
+      }
+      if (!selectedFile) {
+        throw new Error("Choose a translation file to import.");
+      }
+      if (!inferSupportedFileTranslationFileFormat(sourcePath)) {
+        throw new Error("This file format is not supported for translation import.");
+      }
+
+      const formData = new FormData();
+      formData.set("file", selectedFile);
+      formData.set("sourcePath", sourcePath);
+      formData.set("locale", locale);
+
+      const response = await fetch(importApiPath(organizationSlug, projectId), {
+        method: "POST",
+        body: formData,
+      });
+
+      if (!response.ok) {
+        throw await readApiResponseError(response, "Failed to import translations");
+      }
+    },
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["project-files", organizationSlug, projectId] }),
+        queryClient.invalidateQueries({
+          queryKey: ["project-file-detail", organizationSlug, projectId, sourcePath],
+        }),
+      ]);
+      toast.success("Import started — translations will appear once processing completes.");
+      onOpenChange(false);
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Failed to import translations");
+    },
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Import translations</DialogTitle>
+          <DialogDescription>
+            Upload an already-translated file for{" "}
+            <span className="font-mono text-foreground">{sourcePath}</span>. Keys are matched to the
+            source file and imported as approved.
+          </DialogDescription>
+        </DialogHeader>
+
+        {targetLocales.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            Add target locales in project settings before importing translations.
+          </p>
+        ) : (
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <p className="text-sm font-medium text-foreground">Target locale</p>
+              <div className="space-y-2">
+                {targetLocales.map((targetLocale) => (
+                  <label
+                    key={targetLocale}
+                    className="flex cursor-pointer items-center gap-2 rounded-md border border-border px-3 py-2 text-sm"
+                  >
+                    <input
+                      type="radio"
+                      name="import-target-locale"
+                      className="size-4 border border-input accent-primary"
+                      checked={locale === targetLocale}
+                      onChange={() => setLocale(targetLocale)}
+                    />
+                    <span>{targetLocale}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <p className="text-sm font-medium text-foreground">Translation file</p>
+              <input
+                ref={inputRef}
+                type="file"
+                accept={FILE_ACCEPT}
+                className="sr-only"
+                onChange={(event) => {
+                  setSelectedFile(event.target.files?.[0] ?? null);
+                  event.currentTarget.value = "";
+                }}
+              />
+              <div className="flex items-center gap-3">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => inputRef.current?.click()}
+                  disabled={importTranslations.isPending}
+                >
+                  Choose file
+                </Button>
+                <span className="min-w-0 truncate font-mono text-xs text-muted-foreground">
+                  {selectedFile ? selectedFile.name : "No file selected"}
+                </span>
+              </div>
+            </div>
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            disabled={
+              importTranslations.isPending || targetLocales.length === 0 || !locale || !selectedFile
+            }
+            onClick={() => importTranslations.mutate()}
+          >
+            {importTranslations.isPending ? <Spinner className="size-4" /> : null}
+            Import
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-detail-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-detail-panel.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from "react";
 import Link from "next/link";
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Download01Icon, TranslateIcon } from "@hugeicons/core-free-icons";
+import { Download01Icon, TranslateIcon, Upload01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 
 import type {
@@ -22,6 +22,7 @@ import { parseSourceStringsFromFileContent } from "@/lib/projects/files/project-
 import { cn } from "@/lib/primitives/cn";
 import { formatBytes } from "./project-files-shared";
 import { CreateTranslationJobDialog } from "./create-translation-job-dialog";
+import { ImportTranslationsDialog } from "./import-translations-dialog";
 import { ProjectFileSourceStringsPreview } from "./project-file-source-strings-preview";
 import {
   countReadyLocales,
@@ -224,6 +225,7 @@ export function ProjectFileDetailPanelView({
   renderSourceStringsPreview?: ProjectFileSourceStringsPreviewRenderer;
 }) {
   const [translateDialogOpen, setTranslateDialogOpen] = useState(false);
+  const [importDialogOpen, setImportDialogOpen] = useState(false);
   const sourcePath = file?.sourcePath ?? null;
 
   if (!file || !sourcePath) {
@@ -311,6 +313,16 @@ export function ProjectFileDetailPanelView({
         sourceLocale={sourceLocale}
         targetLocales={targetLocales}
       />
+      {!provider ? (
+        <ImportTranslationsDialog
+          open={importDialogOpen}
+          onOpenChange={setImportDialogOpen}
+          organizationSlug={organizationSlug}
+          projectId={projectId}
+          sourcePath={sourcePath}
+          targetLocales={targetLocales}
+        />
+      ) : null}
       <header className="space-y-2 border-b border-border pb-4">
         <TypographyP className="font-mono text-sm font-medium text-foreground">
           {sourcePath}
@@ -365,6 +377,15 @@ export function ProjectFileDetailPanelView({
             <Button type="button" size="sm" onClick={() => setTranslateDialogOpen(true)}>
               <HugeiconsIcon icon={TranslateIcon} strokeWidth={1.8} />
               Translate
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => setImportDialogOpen(true)}
+            >
+              <HugeiconsIcon icon={Upload01Icon} strokeWidth={1.8} />
+              Import translations
             </Button>
             {downloadableLocales.length > 0 ? (
               downloadableLocales.map((locale) => (

--- a/apps/hyperlocalise-web/src/lib/projects/translations/project-translation-import.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/translations/project-translation-import.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const { insertMock, limitMock, onConflictDoUpdateMock, selectMock, valuesMock, whereMock } =
+  vi.hoisted(() => {
+    const onConflictDoUpdateMock = vi.fn(() => undefined);
+    const valuesMock = vi.fn(() => ({ onConflictDoUpdate: onConflictDoUpdateMock }));
+    const insertMock = vi.fn(() => ({ values: valuesMock }));
+    const limitMock = vi.fn(async (): Promise<unknown[]> => []);
+    const whereMock = vi.fn(() => ({ limit: limitMock }));
+    const fromMock = vi.fn(() => ({ where: whereMock }));
+    const selectMock = vi.fn(() => ({ from: fromMock }));
+
+    return {
+      insertMock,
+      limitMock,
+      onConflictDoUpdateMock,
+      selectMock,
+      valuesMock,
+      whereMock,
+    };
+  });
+
+vi.mock("drizzle-orm", () => ({
+  and: vi.fn((...conditions: unknown[]) => ["and", conditions]),
+  eq: vi.fn((field: string, value: unknown) => ["eq", field, value]),
+  inArray: vi.fn((field: string, values: unknown[]) => ["inArray", field, values]),
+  sql: Object.assign(
+    vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({
+      sql: strings.join(""),
+      values,
+    })),
+    { raw: vi.fn((value: string) => ({ raw: value })) },
+  ),
+}));
+
+vi.mock("@/lib/database", () => ({
+  db: {
+    insert: insertMock,
+    select: selectMock,
+  },
+  schema: {
+    repositorySourceFiles: {
+      id: "id",
+      organizationId: "organizationId",
+      projectId: "projectId",
+      sourcePath: "sourcePath",
+    },
+    projectTranslationKeys: {
+      id: "id",
+      key: "key",
+      projectId: "projectId",
+      repositorySourceFileId: "repositorySourceFileId",
+    },
+    projectTranslations: {
+      translationKeyId: "translationKeyId",
+      targetLocale: "targetLocale",
+    },
+  },
+}));
+
+import { importApprovedProjectTranslationsFromEntries } from "./project-translation-service";
+
+describe("importApprovedTranslationsFromEntries", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    limitMock.mockResolvedValue([]);
+  });
+
+  it("imports matched keys as approved translations with import provenance", async () => {
+    whereMock
+      .mockImplementationOnce(() => ({ limit: limitMock }))
+      .mockImplementationOnce(
+        () =>
+          Promise.resolve([{ id: "key_1", key: "greeting" }]) as unknown as {
+            limit: typeof limitMock;
+          },
+      );
+    limitMock.mockResolvedValueOnce([{ id: "repo_file_1" }]);
+
+    const result = await importApprovedProjectTranslationsFromEntries({
+      organizationId: "org_1",
+      projectId: "project_1",
+      sourcePath: "locales/en.json",
+      targetLocale: "fr",
+      entries: { greeting: "Bonjour", missing: "Inconnu" },
+      actorUserId: "user_1",
+    });
+
+    expect(result).toEqual({ matched: 1, imported: 1, skipped: 1 });
+
+    expect(valuesMock).toHaveBeenCalledWith([
+      expect.objectContaining({
+        translationKeyId: "key_1",
+        targetLocale: "fr",
+        text: "Bonjour",
+        status: "approved",
+        provenance: "import",
+        reviewedByUserId: "user_1",
+      }),
+    ]);
+
+    expect(onConflictDoUpdateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        set: expect.objectContaining({
+          text: expect.objectContaining({ sql: "excluded.text" }),
+          status: expect.objectContaining({ sql: "excluded.status" }),
+          provenance: expect.objectContaining({ sql: "excluded.provenance" }),
+        }),
+      }),
+    );
+  });
+
+  it("skips everything when the source file is not found", async () => {
+    limitMock.mockResolvedValueOnce([]);
+
+    const result = await importApprovedProjectTranslationsFromEntries({
+      organizationId: "org_1",
+      projectId: "project_1",
+      sourcePath: "locales/en.json",
+      targetLocale: "fr",
+      entries: { greeting: "Bonjour" },
+    });
+
+    expect(result).toEqual({ matched: 0, imported: 0, skipped: 1 });
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it("returns zero counts for empty input without touching the database", async () => {
+    const result = await importApprovedProjectTranslationsFromEntries({
+      organizationId: "org_1",
+      projectId: "project_1",
+      sourcePath: "locales/en.json",
+      targetLocale: "fr",
+      entries: {},
+    });
+
+    expect(result).toEqual({ matched: 0, imported: 0, skipped: 0 });
+    expect(selectMock).not.toHaveBeenCalled();
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/projects/translations/project-translation-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/translations/project-translation-service.ts
@@ -718,6 +718,121 @@ export class ProjectTranslationService extends ProjectServiceBase {
         },
       });
   }
+
+  /**
+   * Migrates already-translated entries into a target locale, matching them to
+   * existing source keys for the given file. Imported translations are stored as
+   * approved (provenance: import) and overwrite any existing translation for the
+   * key/locale pair, since the caller is explicitly importing known-good content.
+   */
+  async importApprovedTranslationsFromEntries(input: {
+    organizationId: string;
+    projectId: string;
+    sourcePath: string;
+    targetLocale: string;
+    entries: Record<string, string>;
+    actorUserId?: string | null;
+  }): Promise<{ matched: number; imported: number; skipped: number }> {
+    const entryKeys = Object.keys(input.entries);
+    if (entryKeys.length === 0) {
+      return { matched: 0, imported: 0, skipped: 0 };
+    }
+
+    const [sourceFile] = await this.database
+      .select({ id: schema.repositorySourceFiles.id })
+      .from(schema.repositorySourceFiles)
+      .where(
+        and(
+          eq(schema.repositorySourceFiles.organizationId, input.organizationId),
+          eq(schema.repositorySourceFiles.projectId, input.projectId),
+          eq(schema.repositorySourceFiles.sourcePath, input.sourcePath),
+        ),
+      )
+      .limit(1);
+
+    if (!sourceFile) {
+      return { matched: 0, imported: 0, skipped: entryKeys.length };
+    }
+
+    const keys = await this.database
+      .select({
+        id: schema.projectTranslationKeys.id,
+        key: schema.projectTranslationKeys.key,
+      })
+      .from(schema.projectTranslationKeys)
+      .where(
+        and(
+          eq(schema.projectTranslationKeys.projectId, input.projectId),
+          eq(schema.projectTranslationKeys.repositorySourceFileId, sourceFile.id),
+          inArray(schema.projectTranslationKeys.key, entryKeys),
+        ),
+      );
+
+    const reviewedAt = new Date();
+    const reviewedByUserId = input.actorUserId ?? null;
+
+    const translationValues = keys.flatMap((key) => {
+      const text = input.entries[key.key];
+      if (!text?.trim()) {
+        return [];
+      }
+
+      return [
+        {
+          organizationId: input.organizationId,
+          projectId: input.projectId,
+          translationKeyId: key.id,
+          targetLocale: input.targetLocale,
+          text,
+          status: "approved" as const,
+          provenance: "import" as const,
+          reviewedAt,
+          reviewedByUserId,
+        },
+      ];
+    });
+
+    const matched = keys.length;
+    const imported = translationValues.length;
+    const skipped = entryKeys.length - imported;
+
+    if (translationValues.length === 0) {
+      return { matched, imported, skipped };
+    }
+
+    await this.database
+      .insert(schema.projectTranslations)
+      .values(translationValues)
+      .onConflictDoUpdate({
+        target: [
+          schema.projectTranslations.translationKeyId,
+          schema.projectTranslations.targetLocale,
+        ],
+        set: {
+          text: sql`excluded.text`,
+          status: sql`excluded.status`,
+          provenance: sql`excluded.provenance`,
+          sourceJobId: sql`NULL`,
+          reviewedAt: sql`excluded.reviewed_at`,
+          reviewedByUserId: sql`excluded.reviewed_by_user_id`,
+          updatedAt: sql`now()`,
+        },
+      });
+
+    this.log.info(
+      {
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        targetLocale: input.targetLocale,
+        matched,
+        imported,
+        skipped,
+      },
+      "imported approved project translations",
+    );
+
+    return { matched, imported, skipped };
+  }
 }
 
 export const projectTranslationService = new ProjectTranslationService();
@@ -757,3 +872,7 @@ export const persistStringJobTranslations = (
 export const persistFileJobTranslations = (
   input: Parameters<ProjectTranslationService["persistFileJobTranslations"]>[0],
 ) => projectTranslationService.persistFileJobTranslations(input);
+
+export const importApprovedProjectTranslationsFromEntries = (
+  input: Parameters<ProjectTranslationService["importApprovedTranslationsFromEntries"]>[0],
+) => projectTranslationService.importApprovedTranslationsFromEntries(input);

--- a/apps/hyperlocalise-web/src/lib/workflow/types.ts
+++ b/apps/hyperlocalise-web/src/lib/workflow/types.ts
@@ -125,3 +125,14 @@ export type SourceFileIngestEventData = {
 };
 
 export type SourceFileIngestQueue = JobQueue<SourceFileIngestEventData>;
+
+export type TranslationFileImportEventData = {
+  organizationId: string;
+  projectId: string;
+  storedFileId: string;
+  sourcePath: string;
+  targetLocale: string;
+  actorUserId?: string | null;
+};
+
+export type TranslationFileImportQueue = JobQueue<TranslationFileImportEventData>;

--- a/apps/hyperlocalise-web/src/workflows/adapters.ts
+++ b/apps/hyperlocalise-web/src/workflows/adapters.ts
@@ -19,6 +19,7 @@ import type {
   ProviderAgentTranslationQueue,
   ProviderAgentWritebackQueue,
   SourceFileIngestQueue,
+  TranslationFileImportQueue,
   WorkspaceAutomationExecutionQueue,
   RepositoryAgentTaskQueue,
 } from "@/lib/workflow/types";
@@ -126,6 +127,16 @@ export function createSourceFileIngestQueue(): SourceFileIngestQueue {
     async enqueue(event) {
       const { sourceFileIngestWorkflow } = await import("@/workflows/source-file-ingest");
       const run = await start(sourceFileIngestWorkflow, [event]);
+      return { ids: [run.runId] };
+    },
+  };
+}
+
+export function createTranslationFileImportQueue(): TranslationFileImportQueue {
+  return {
+    async enqueue(event) {
+      const { translationFileImportWorkflow } = await import("@/workflows/translation-file-import");
+      const run = await start(translationFileImportWorkflow, [event]);
       return { ids: [run.runId] };
     },
   };

--- a/apps/hyperlocalise-web/src/workflows/steps/translation-file-import.ts
+++ b/apps/hyperlocalise-web/src/workflows/steps/translation-file-import.ts
@@ -1,0 +1,20 @@
+export async function importTranslationsFromEntriesStep(input: {
+  organizationId: string;
+  projectId: string;
+  sourcePath: string;
+  targetLocale: string;
+  entries: Record<string, string>;
+  actorUserId?: string | null;
+}) {
+  "use step";
+  const { importApprovedProjectTranslationsFromEntries } =
+    await import("@/lib/projects/translations/project-translation-service");
+  return importApprovedProjectTranslationsFromEntries({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    sourcePath: input.sourcePath,
+    targetLocale: input.targetLocale,
+    entries: input.entries,
+    actorUserId: input.actorUserId ?? null,
+  });
+}

--- a/apps/hyperlocalise-web/src/workflows/translation-file-import.ts
+++ b/apps/hyperlocalise-web/src/workflows/translation-file-import.ts
@@ -1,0 +1,64 @@
+import type { TranslationFileImportEventData } from "@/lib/workflow/types";
+import {
+  createSourceIngestSandboxStep,
+  extractSourceIngestEntriesStep,
+  getStoredFileMetadataStep,
+  prepareSourceIngestSandboxStep,
+  stopSourceIngestSandboxStep,
+  writeSourceIngestFileStep,
+} from "./steps/source-file-ingest";
+import { getStoredFileContentStep } from "./steps/translation-job";
+import { importTranslationsFromEntriesStep } from "./steps/translation-file-import";
+
+function sanitizeSandboxFilename(filename: string): string {
+  return filename.replace(/[^a-zA-Z0-9._-]/g, "_");
+}
+
+function basename(filePath: string): string {
+  const normalized = filePath.replace(/\\/g, "/");
+  const lastSlash = normalized.lastIndexOf("/");
+  return lastSlash === -1 ? normalized : normalized.slice(lastSlash + 1);
+}
+
+export async function translationFileImportWorkflow(event: TranslationFileImportEventData) {
+  "use workflow";
+
+  let sandboxId: string | null = null;
+
+  try {
+    const [storedFile, content] = await Promise.all([
+      getStoredFileMetadataStep(event.storedFileId, event.organizationId),
+      getStoredFileContentStep(event.storedFileId, event.organizationId),
+    ]);
+
+    const inputFilename = sanitizeSandboxFilename(
+      basename(event.sourcePath) || storedFile.filename,
+    );
+    ({ sandboxId } = await createSourceIngestSandboxStep());
+
+    await prepareSourceIngestSandboxStep(sandboxId);
+    await writeSourceIngestFileStep(sandboxId, inputFilename, content);
+
+    const entries = await extractSourceIngestEntriesStep(sandboxId, inputFilename);
+
+    const result = await importTranslationsFromEntriesStep({
+      organizationId: event.organizationId,
+      projectId: event.projectId,
+      sourcePath: event.sourcePath,
+      targetLocale: event.targetLocale,
+      entries,
+      actorUserId: event.actorUserId ?? null,
+    });
+
+    return {
+      status: "imported" as const,
+      matched: result.matched,
+      imported: result.imported,
+      skipped: result.skipped,
+    };
+  } finally {
+    if (sandboxId) {
+      await stopSourceIngestSandboxStep(sandboxId).catch(() => undefined);
+    }
+  }
+}


### PR DESCRIPTION
## What changed

Adds a per-file "Import translations" flow to the native TMS project files view. Users can upload an already-translated file for a selected target locale from the file detail panel. The upload is stored, parsed asynchronously via the existing hl sandbox workflow, and matched keys are upserted into `project_translations` as approved with `import` provenance.

## How to test

- Start Postgres and run `vp run db:migrate` in `apps/hyperlocalise-web`
- Run `vp test src/lib/projects/translations/project-translation-import.test.ts`
- Run `vp test src/api/routes/project/project-file-translation-import.route.test.ts`
- Run `vp check --fix`
- In the app, open a native project file detail panel and use **Import translations** to upload a translated file for a target locale; confirm locale readiness updates after the workflow completes

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review