### PR TITLE
🧪 Scout: fix PO parser continuation leakage

### DIFF
--- a/internal/i18n/translationfileparser/po_parser.go
+++ b/internal/i18n/translationfileparser/po_parser.go
@@ -137,6 +137,7 @@ func consumePOLine(
 	case strings.HasPrefix(line, "\""):
 		return handlePOContinuation(lineNumber, line, currentMsgID, currentMsgStr, *activeField)
 	default:
+		*activeField = ""
 		return nil
 	}
 }

--- a/internal/i18n/translationfileparser/po_parser_test.go
+++ b/internal/i18n/translationfileparser/po_parser_test.go
@@ -102,6 +102,32 @@ msgstr "value2"
 	}
 }
 
+func TestPOParserUnknownFieldDoesNotLeakContinuation(t *testing.T) {
+	// Continuation lines (quoted strings) following an unknown or ignored field
+	// MUST NOT be appended to the previous valid active field (like msgstr).
+	content := `msgid "key"
+msgstr "value"
+unknown "ignored"
+" leaked"
+
+msgid "next"
+msgstr "val"
+`
+	got, err := (POFileParser{}).Parse([]byte(content))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	expected := map[string]string{
+		"key":  "value",
+		"next": "val",
+	}
+
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("got %v, want %v", got, expected)
+	}
+}
+
 func TestPOParserMsgctxtWithDuplicateMsgidCollidesByMsgid(t *testing.T) {
 	content := []byte(`msgctxt "nav"
 msgid "home"


### PR DESCRIPTION
💡 What: Fixed a bug in the PO file parser where continuation lines could "leak" and be appended to the wrong field if an unknown line was encountered. Added a regression test.
🎯 Why: To ensure localization integrity by preventing data corruption during PO file parsing when malformed or unrecognized lines are present.
🧩 Scope: `internal/i18n/translationfileparser/po_parser.go` and `internal/i18n/translationfileparser/po_parser_test.go`.
✅ Verification: Ran `go test -v -run TestPOParserUnknownFieldDoesNotLeakContinuation` and the full `translationfileparser` test suite.
🛡️ Confidence: High. The fix is a simple state reset in the default case, and the regression test confirms it solves the specific issue without affecting other fields.

---
*PR created automatically by Jules for task [15976699468667601964](https://jules.google.com/task/15976699468667601964) started by @cungminh2710*