### PR TITLE
fix(crowdin): add URL field to Screenshot model for API parity

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -185,3 +185,9 @@
 **Learning:** The Crowdin Enterprise API v2 supports `dateFrom` in `EnterpriseVendorTaskCreateForm`, but it was missing from the SDK model. Additionally, several test function names in `tasks_test.go` contained typos (e.g., "Tepmlate").
 
 **Action:** Added `DateFrom` string field to `EnterpriseVendorTaskCreateForm` in `model/tasks.go`. Corrected "Tepmlate" to "Template" and "Tepmlates" to "Templates" in `tasks_test.go`. Added `TestTasksService_Add_EnterpriseVendorTaskCreateForm` to verify parity.
+
+## 2026-10-17 - Improve Screenshot model parity for URL field
+
+**Learning:** The Crowdin Screenshots API v2 returns a `url` field in its response, which is used to download the screenshot. While the `webUrl` field was already present, the `url` field was missing from the `Screenshot` model, leading to incomplete parsing of API responses.
+
+**Action:** Added the `URL` field to the `Screenshot` struct in `model/screenshot.go`. Updated the `TestScreenshotsService_GetScreenshot` and label-related tests in `labels_test.go` to include the `URL` field in expected results, ensuring documentation parity and correct unmarshaling. Verified with `go test` in the fork.

--- a/third_party/crowdin-api-client-go/crowdin/labels_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/labels_test.go
@@ -518,6 +518,7 @@ func TestLabelsService_AssignToScreenshots(t *testing.T) {
 		{
 			ID:     2,
 			UserID: 6,
+			URL:    "https://production-enterprise-screenshots.downloads.crowdin.com/992000002/6/2/middle.jpg",
 			WebURL: "https://production-enterprise-screenshots.downloads.crowdin.com/992000002/6/2/middle.jpg",
 			Name:   "translate_with_siri.jpg",
 			Size: struct {
@@ -636,6 +637,7 @@ func TestLabelsService_UnassignFromScreenshots(t *testing.T) {
 		{
 			ID:     2,
 			UserID: 6,
+			URL:    "https://production-enterprise-screenshots.downloads.crowdin.com/992000002/6/2/middle.jpg",
 			WebURL: "https://production-enterprise-screenshots.downloads.crowdin.com/992000002/6/2/middle.jpg",
 			Name:   "translate_with_siri.jpg",
 			Size: struct {

--- a/third_party/crowdin-api-client-go/crowdin/model/screenshot.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/screenshot.go
@@ -11,6 +11,7 @@ import (
 type Screenshot struct {
 	ID     int    `json:"id"`
 	UserID int    `json:"userId"`
+	URL    string `json:"url"`
 	WebURL string `json:"webUrl"`
 	Name   string `json:"name"`
 	Size   struct {

--- a/third_party/crowdin-api-client-go/crowdin/screenshots_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/screenshots_test.go
@@ -61,6 +61,7 @@ func TestScreenshotsService_GetScreenshot(t *testing.T) {
 	expected := &model.Screenshot{
 		ID:     2,
 		UserID: 6,
+		URL:    "https://production-enterprise-screenshots.downloads.crowdin.com/992000002/6/2/middle.jpg",
 		WebURL: "https://production-enterprise-screenshots.downloads.crowdin.com/992000002/6/2/middle.jpg",
 		Name:   "translate_with_siri.jpg",
 		Size: struct {


### PR DESCRIPTION
- What: Added the missing `URL` field (direct download link) to the `Screenshot` struct in the Crowdin fork.
- Why: To align with the Crowdin API v2 contract and ensure that screenshot download links are correctly parsed from API responses.
- Docs: https://developer.crowdin.com/api/v2/#operation/api.projects.screenshots.get
- Scope: `third_party/crowdin-api-client-go/crowdin/model/screenshot.go`, `third_party/crowdin-api-client-go/crowdin/screenshots_test.go`, `third_party/crowdin-api-client-go/crowdin/labels_test.go`.
- Tests: Updated `TestScreenshotsService_GetScreenshot` and label-related tests; verified with `go test` in the fork.
- Confidence: Ensures full response parity for Screenshots and prevents data loss when parsing responses.

---
*PR created automatically by Jules for task [9980756472077957596](https://jules.google.com/task/9980756472077957596) started by @cungminh2710*