### PR TITLE
fix(web): rename billing AI usage label to AI Credit

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/billing/_components/billing-settings-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/settings/billing/_components/billing-settings-content.tsx
@@ -85,7 +85,7 @@ function BillingSettingsHeader() {
           Billing
         </TypographyH1>
         <TypographyP className="mt-2 text-pretty text-sm leading-6 text-muted-foreground">
-          View your workspace plan, word usage, workspace limits, and subscription billing.
+          View your workspace plan, AI credit usage, workspace limits, and subscription billing.
         </TypographyP>
       </div>
     </section>
@@ -376,8 +376,8 @@ function ConfiguredBillingSettingsPanel({
         <CardHeader className="px-5 py-5">
           <CardTitle className="text-lg font-medium text-foreground">Plan usage</CardTitle>
           <CardDescription className="text-foreground/52">
-            Word usage resets each billing cycle. Seats, projects, automations, and integrations are
-            workspace limits.
+            AI credit usage resets each billing cycle. Seats, projects, automations, and
+            integrations are workspace limits.
           </CardDescription>
         </CardHeader>
         <Separator className="bg-foreground/8" />

--- a/apps/hyperlocalise-web/src/lib/billing/plan-usage.test.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/plan-usage.test.ts
@@ -56,7 +56,7 @@ describe("plan usage helpers", () => {
   it("computes usage progress and summary copy", () => {
     expect(getUsageProgressPercent({ usage: 1_200_000, granted: 2_000_000 })).toBe(60);
     expect(formatPrimaryUsageSummary({ usage: 1_200_000, granted: 2_000_000 })).toMatch(
-      /1\.2M.*2M.*words used/,
+      /1\.2M.*2M.*AI credits used/,
     );
   });
 
@@ -83,7 +83,7 @@ describe("plan usage helpers", () => {
     expect(summary.renewalCopy).toMatch(/^Renews on /);
     expect(summary.renewalLabel).toContain("2027");
     expect(summary.usageProgressPercent).toBe(60);
-    expect(summary.usageSummary).toMatch(/words used/);
+    expect(summary.usageSummary).toMatch(/AI credits used/);
 
     const cancelingSummary = resolvePlanUsageSummary({
       subscriptions: [
@@ -114,7 +114,7 @@ describe("plan usage helpers", () => {
         isScheduledForCancel: false,
         renewalLabel: null,
         renewalCopy: null,
-        usageSummary: "0 / 0 words used",
+        usageSummary: "0 / 0 AI credits used",
         usageProgressPercent: null,
         unlimited: false,
       }),
@@ -126,7 +126,7 @@ describe("plan usage helpers", () => {
         isScheduledForCancel: false,
         renewalLabel: "Aug 24, 2027",
         renewalCopy: "Renews on Aug 24, 2027",
-        usageSummary: "1.2M / 2M words used",
+        usageSummary: "1.2M / 2M AI credits used",
         usageProgressPercent: 60,
         unlimited: false,
       }),

--- a/apps/hyperlocalise-web/src/lib/billing/plan-usage.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/plan-usage.ts
@@ -166,17 +166,14 @@ export function formatPrimaryUsageSummary(input: {
   unlimited?: boolean | null;
   unitLabel?: string;
 }) {
-  const unitLabel = (
-    input.unitLabel ??
-    getUsageFeatureLabel(planUsagePrimaryFeatureId) ??
-    "usage"
-  ).toLowerCase();
+  const unitLabel = input.unitLabel ?? getUsageFeatureLabel(planUsagePrimaryFeatureId) ?? "usage";
+  const summaryUnitLabel = unitLabel === "AI Credit" ? "AI credits" : unitLabel.toLowerCase();
 
   if (input.unlimited) {
     return "Unlimited usage";
   }
 
-  return `${formatCompactUsageValue(input.usage)} / ${formatCompactUsageValue(input.granted)} ${unitLabel} used`;
+  return `${formatCompactUsageValue(input.usage)} / ${formatCompactUsageValue(input.granted)} ${summaryUnitLabel} used`;
 }
 
 export function resolvePlanUsageSummary(input: {

--- a/apps/hyperlocalise-web/src/lib/billing/usage-feature-labels.ts
+++ b/apps/hyperlocalise-web/src/lib/billing/usage-feature-labels.ts
@@ -2,7 +2,7 @@ import { billingBalanceFeatureIds, type AutumnFeatureId } from "@/lib/billing/au
 
 /** Display labels for Autumn feature balances shown on billing settings. */
 export const usageFeatureLabels: Partial<Record<AutumnFeatureId, string>> = {
-  ai_tokens: "Words",
+  ai_tokens: "AI Credit",
   translation_jobs: "Translation jobs",
   agent_runs: "Agent runs",
   seats: "Seats",


### PR DESCRIPTION
## What changed

Renamed the billing usage unit from "Words" to "AI Credit" so plan usage is clearer for customers.

- Updated the Autumn feature display label for `ai_tokens`
- Adjusted billing settings copy and usage summaries (e.g. `1.2M / 2M AI credits used`)
- Updated plan usage helper tests

## How to test

- Open **Settings → Billing** and confirm the header and plan usage section say "AI credit usage"
- Check the sidebar plan usage widget shows `AI credits used` instead of `words used`
- Run `vp test src/lib/billing/plan-usage.test.ts`

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)