### PR TITLE
🧪 Scout: add regression tests for ICU pound summation in sibling blocks

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -103,3 +103,7 @@
 ## 2026-06-24 - [CSV Injection: Escaping Line Feeds]
 **Learning:** Security best practices (OWASP) for CSV injection/Formula injection require escaping not just '=', '+', '-', and '@', but also whitespace characters like Tab (0x09), Carriage Return (0x0D), and Line Feed (0x0A). If these characters appear at the start of a cell, some spreadsheet software may interpret the following content as a formula.
 **Action:** Always include '\n' (Line Feed) in the set of characters that trigger formula escaping (prepending a single quote) in CSV cell values.
+
+## 2026-06-26 - [ICU Pound Summation in Sibling Blocks]
+**Learning:** In ICU message invariant analysis, pound signs (#) within sibling conditional blocks (like multiple 'select' blocks inside a single 'plural' branch) must be summed to correctly identify the maximum possible pound usage. While 'select' branches are mutually exclusive within a single block, sibling blocks are independent and both will contribute their respective 'active' branch content to the final message.
+**Action:** When calculating pound invariants for a plural block, ensure that sibling elements correctly accumulate their counts, while only mutually exclusive branches (like those within a single 'select' or 'plural') take the maximum.

--- a/internal/i18n/icuparser/invariant_test.go
+++ b/internal/i18n/icuparser/invariant_test.go
@@ -379,6 +379,8 @@ func TestHasDuplicatePounds(t *testing.T) {
 		{"select block", "{gender, select, male {he} female {she} other {they}}", false},
 		{"selectordinal duplicate", "{n, selectordinal, one {##st} other {#th}}", true},
 		{"mustache placeholder", "Hello {{name}}", false},
+		{"sibling selects with duplicates", "{n, plural, other {{g1, select, male {#} other {#}} {g2, select, male {#} other {#}}}}", true},
+		{"nested select with duplicate", "{n, plural, other {{g, select, other {{s, select, other {##}}}}}}", true},
 	}
 
 	for _, tt := range tests {
@@ -578,6 +580,15 @@ func TestCountPoundsComplexNesting(t *testing.T) {
 			msg:  "{n, plural, other {<a href=\"#foo\">#</a>}}",
 			want: []BlockSignature{
 				{Arg: "n", Type: "plural", Options: []string{"other"}, Pounds: []int{1}},
+			},
+		},
+		{
+			name: "sibling selects sum pounds",
+			msg:  "{n, plural, other {{g1, select, male {#} other {##}} {g2, select, other {###}}}}",
+			want: []BlockSignature{
+				{Arg: "g1", Type: "select", Options: []string{"male", "other"}},
+				{Arg: "g2", Type: "select", Options: []string{"other"}},
+				{Arg: "n", Type: "plural", Options: []string{"other"}, Pounds: []int{5}},
 			},
 		},
 	}


### PR DESCRIPTION
- 💡 What: Added regression test cases to `internal/i18n/icuparser/invariant_test.go` covering sibling `select` blocks and nested `select` blocks.
- 🎯 Why: To ensure that the ICU parser correctly identifies and sums pound symbols (#) in sibling conditional blocks within a plural branch, preventing false negatives in duplication detection.
- 🧩 Scope: `internal/i18n/icuparser/invariant_test.go`
- ✅ Verification: Ran `go test ./internal/i18n/icuparser/...`
- 🛡️ Confidence: High. The tests explicitly cover the independent contribution of sibling blocks to the parent plural's pound count.

---
*PR created automatically by Jules for task [4378356757345266908](https://jules.google.com/task/4378356757345266908) started by @cungminh2710*