### PR TITLE
🧪 Scout: Improve ICU placeholder name validation and test coverage

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -107,3 +107,7 @@
 ## 2026-06-26 - [ICU Pound Summation in Sibling Blocks]
 **Learning:** In ICU message invariant analysis, pound signs (#) within sibling conditional blocks (like multiple 'select' blocks inside a single 'plural' branch) must be summed to correctly identify the maximum possible pound usage. While 'select' branches are mutually exclusive within a single block, sibling blocks are independent and both will contribute their respective 'active' branch content to the final message.
 **Action:** When calculating pound invariants for a plural block, ensure that sibling elements correctly accumulate their counts, while only mutually exclusive branches (like those within a single 'select' or 'plural') take the maximum.
+
+## 2025-07-25 - [Strict ICU Identifier Dot Validation]
+**Learning:** ICU placeholder names that support property paths (dots) must not allow leading, trailing, or consecutive dots (e.g., `.name`, `name.`, `name..last`). Additionally, dots should not immediately precede an array index bracket (e.g., `items.[0]`). Failing to enforce these constraints can lead to malformed identifiers being collected during invariant analysis.
+**Action:** When validating identifiers with dots, ensure each dot is followed by a valid subsequent character that is not another dot or an opening bracket.

--- a/internal/i18n/icuparser/invariant.go
+++ b/internal/i18n/icuparser/invariant.go
@@ -350,7 +350,7 @@ func isPlaceholderName(s string) bool {
 		ch := s[i]
 		if ch < 0x80 {
 			if i == 0 {
-				if !isASCIIPlaceholderFirst(ch) || ch == '.' {
+				if !isASCIIPlaceholderFirst(ch) {
 					return false
 				}
 				i++

--- a/internal/i18n/icuparser/invariant.go
+++ b/internal/i18n/icuparser/invariant.go
@@ -350,7 +350,7 @@ func isPlaceholderName(s string) bool {
 		ch := s[i]
 		if ch < 0x80 {
 			if i == 0 {
-				if !isASCIIPlaceholderFirst(ch) {
+				if !isASCIIPlaceholderFirst(ch) || ch == '.' {
 					return false
 				}
 				i++
@@ -379,6 +379,11 @@ func isPlaceholderName(s string) bool {
 
 			if !isASCIIPlaceholderSubsequent(ch) {
 				return false
+			}
+			if ch == '.' {
+				if i+1 >= len(s) || s[i+1] == '.' || s[i+1] == '[' {
+					return false
+				}
 			}
 			i++
 			continue

--- a/internal/i18n/icuparser/invariant_test.go
+++ b/internal/i18n/icuparser/invariant_test.go
@@ -66,6 +66,39 @@ func TestSameICUBlocks(t *testing.T) {
 	}
 }
 
+func TestIsPlaceholderNameEdgeCases(t *testing.T) {
+	tests := []struct {
+		name string
+		val  string
+		want bool
+	}{
+		{"valid simple", "name", true},
+		{"valid path", "a.b.c", true},
+		{"trailing dot", "a.b.", false},
+		{"multiple dots", "a..b", false},
+		{"leading dot", ".a", false},
+		{"valid dash", "my-arg", true},
+		{"trailing dash", "my-arg-", true},
+		{"valid underscore", "my_arg", true},
+		{"valid dollar", "$amount", true},
+		{"valid array index", "items[0]", true},
+		{"valid nested array", "a.b[0].c", true},
+		{"malformed array", "items[0]suffix", false},
+		{"empty", "", false},
+		{"unicode", "π", true},
+		{"unicode path", "π.val", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isPlaceholderName(tt.val)
+			if got != tt.want {
+				t.Errorf("isPlaceholderName(%q) = %v, want %v", tt.val, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFormatICUBlocks(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/i18n/icuparser/invariant_test.go
+++ b/internal/i18n/icuparser/invariant_test.go
@@ -84,6 +84,7 @@ func TestIsPlaceholderNameEdgeCases(t *testing.T) {
 		{"valid array index", "items[0]", true},
 		{"valid nested array", "a.b[0].c", true},
 		{"malformed array", "items[0]suffix", false},
+		{"dot before bracket", "items.[0]", false},
 		{"empty", "", false},
 		{"unicode", "π", true},
 		{"unicode path", "π.val", true},


### PR DESCRIPTION
💡 What: Added `TestIsPlaceholderNameEdgeCases` and tightened the validation logic in `isPlaceholderName`.
🎯 Why: To ensure that malformed ICU identifiers (e.g., those with leading/trailing dots or consecutive dots) are correctly rejected, preventing incorrect invariant collection.
🧩 Scope: `internal/i18n/icuparser/invariant.go` and `internal/i18n/icuparser/invariant_test.go`.
✅ Verification: Ran `go test ./internal/i18n/icuparser/...` and `go test ./...`.
🛡️ Confidence: High. The new test suite explicitly covers both valid and invalid identifier patterns, and all existing tests pass.

---
*PR created automatically by Jules for task [11857473593389417074](https://jules.google.com/task/11857473593389417074) started by @cungminh2710*