### PR TITLE
🧪 Scout: improve locale normalization unit tests

### DIFF
--- a/internal/i18n/locales/normalize_test.go
+++ b/internal/i18n/locales/normalize_test.go
@@ -36,6 +36,26 @@ func TestNormalizeListSplitsTrimsAndDeduplicates(t *testing.T) {
 			in:   []string{"en", "en-US", "en-GB"},
 			want: []string{"en", "en-US", "en-GB"},
 		},
+		{
+			name: "overlapping values across multiple strings",
+			in:   []string{"en-US, fr-FR", "de-DE, EN-US", "FR-fr, es-ES"},
+			want: []string{"en-US", "fr-FR", "de-DE", "es-ES"},
+		},
+		{
+			name: "first encounter casing wins",
+			in:   []string{"fr-ca", "FR-CA", "Fr-Ca"},
+			want: []string{"fr-ca"},
+		},
+		{
+			name: "various whitespace characters",
+			in:   []string{"en-US\t,\nfr-FR\r,\fde-DE\v"},
+			want: []string{"en-US", "fr-FR", "de-DE"},
+		},
+		{
+			name: "non-breaking space around comma",
+			in:   []string{"en-US\u00A0,\u00A0fr-FR"},
+			want: []string{"en-US", "fr-FR"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
- 💡 What: Added comprehensive test cases to `internal/i18n/locales/normalize_test.go`.
- 🎯 Why: To ensure `NormalizeList` robustly handles overlapping values, "first-seen" casing retention, and various whitespace characters (including non-breaking space).
- 🧩 Scope: `internal/i18n/locales/normalize_test.go`
- ✅ Verification: Ran `go test ./internal/i18n/locales/...`
- 🛡️ Confidence: Prevents regressions in locale list parsing when dealing with messy input from configuration files or API responses.

---
*PR created automatically by Jules for task [645406899846358883](https://jules.google.com/task/645406899846358883) started by @cungminh2710*