### PR TITLE
fix(crowdin): improve Screenshot and Distribution model parity

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -191,3 +191,9 @@
 **Learning:** The Crowdin Screenshots API v2 returns a `url` field in its response, which is used to download the screenshot. While the `webUrl` field was already present, the `url` field was missing from the `Screenshot` model, leading to incomplete parsing of API responses.
 
 **Action:** Added the `URL` field to the `Screenshot` struct in `model/screenshot.go`. Updated the `TestScreenshotsService_GetScreenshot` and label-related tests in `labels_test.go` to include the `URL` field in expected results, ensuring documentation parity and correct unmarshaling. Verified with `go test` in the fork.
+
+## 2026-10-24 - Improve Screenshot and Distribution model parity
+
+**Learning:** The Crowdin Screenshots API v2 returns a `projectId` field which was missing from the SDK. Additionally, the Distributions API supports `branchIds` and `directoryIds` in both response models and addition requests, allowing for distribution of content from specific branches or directories.
+
+**Action:** Added `ProjectID` to the `Screenshot` struct in `model/screenshot.go`. Added `BranchIDs` and `DirectoryIDs` to both `Distribution` and `DistributionAddRequest` in `model/distributions.go`. Updated contract tests in `screenshots_test.go`, `labels_test.go`, and `distributions_test.go` to verify correct parsing and serialization of these new fields.

--- a/third_party/crowdin-api-client-go/crowdin/distributions_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/distributions_test.go
@@ -50,6 +50,8 @@ func TestDistributionsService_List(t *testing.T) {
 							"hash": "50fb350641274ba88296f97dc7e3e0c3",
 							"name": "Export Bundle",
 							"bundleIds": [45, 62],
+							"branchIds": [1, 2],
+							"directoryIds": [3, 4],
 							"createdAt": "2023-09-16T13:48:04+00:00",
 							"updatedAt": "2023-09-19T13:25:27+00:00",
 							"exportMode": "bundle",
@@ -62,6 +64,8 @@ func TestDistributionsService_List(t *testing.T) {
 							"hash": "50fb350641274ba88296f97dc7e3e0c4",
 							"name": "Export Bundle",
 							"bundleIds": [47],
+							"branchIds": [5],
+							"directoryIds": [6],
 							"createdAt": "2023-09-16T13:48:04+00:00",
 							"updatedAt": "2023-09-19T13:25:27+00:00",
 							"exportMode": "bundle",
@@ -83,20 +87,24 @@ func TestDistributionsService_List(t *testing.T) {
 
 		expected := []*model.Distribution{
 			{
-				Hash:        "50fb350641274ba88296f97dc7e3e0c3",
-				Name:        "Export Bundle",
-				BundleIDs:   []int{45, 62},
-				CreatedAt:   "2023-09-16T13:48:04+00:00",
+				Hash:         "50fb350641274ba88296f97dc7e3e0c3",
+				Name:         "Export Bundle",
+				BundleIDs:    []int{45, 62},
+				BranchIDs:    []int{1, 2},
+				DirectoryIDs: []int{3, 4},
+				CreatedAt:    "2023-09-16T13:48:04+00:00",
 				UpdatedAt:   "2023-09-19T13:25:27+00:00",
 				ExportMode:  "bundle",
 				FileIDs:     []int{24, 25, 38},
 				ManifestURL: "https://distributions.crowdin.net/50fb350641274ba88296f97dc7e3e0c3/manifest.json",
 			},
 			{
-				Hash:        "50fb350641274ba88296f97dc7e3e0c4",
-				Name:        "Export Bundle",
-				BundleIDs:   []int{47},
-				CreatedAt:   "2023-09-16T13:48:04+00:00",
+				Hash:         "50fb350641274ba88296f97dc7e3e0c4",
+				Name:         "Export Bundle",
+				BundleIDs:    []int{47},
+				BranchIDs:    []int{5},
+				DirectoryIDs: []int{6},
+				CreatedAt:    "2023-09-16T13:48:04+00:00",
 				UpdatedAt:   "2023-09-19T13:25:27+00:00",
 				ExportMode:  "bundle",
 				FileIDs:     []int{25},
@@ -134,6 +142,8 @@ func TestDistributionsService_Get(t *testing.T) {
 				"hash": "50fb350641274ba88296f97dc7e3e0c3",
 				"name": "Export Bundle",
 				"bundleIds": [45, 62],
+				"branchIds": [1, 2],
+				"directoryIds": [3, 4],
 				"createdAt": "2023-09-16T13:48:04+00:00",
 				"updatedAt": "2023-09-19T13:25:27+00:00",
 				"exportMode": "bundle",
@@ -148,10 +158,12 @@ func TestDistributionsService_Get(t *testing.T) {
 	assert.NotNil(t, resp)
 
 	expected := &model.Distribution{
-		Hash:        "50fb350641274ba88296f97dc7e3e0c3",
-		Name:        "Export Bundle",
-		BundleIDs:   []int{45, 62},
-		CreatedAt:   "2023-09-16T13:48:04+00:00",
+		Hash:         "50fb350641274ba88296f97dc7e3e0c3",
+		Name:         "Export Bundle",
+		BundleIDs:    []int{45, 62},
+		BranchIDs:    []int{1, 2},
+		DirectoryIDs: []int{3, 4},
+		CreatedAt:    "2023-09-16T13:48:04+00:00",
 		UpdatedAt:   "2023-09-19T13:25:27+00:00",
 		ExportMode:  "bundle",
 		FileIDs:     []int{24, 25, 38},
@@ -168,7 +180,7 @@ func TestDistributionsService_Add(t *testing.T) {
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
 		testURL(t, r, path)
-		testBody(t, r, `{"name":"Export Bundle","exportMode":"bundle","bundleIds":[45,62]}`+"\n")
+		testBody(t, r, `{"name":"Export Bundle","exportMode":"bundle","bundleIds":[45,62],"branchIds":[1,2],"directoryIds":[3,4]}`+"\n")
 
 		w.WriteHeader(http.StatusCreated)
 		fmt.Fprint(w, `{
@@ -176,6 +188,8 @@ func TestDistributionsService_Add(t *testing.T) {
 				"hash": "50fb350641274ba88296f97dc7e3e0c3",
 				"name": "Export Bundle",
 				"bundleIds": [45, 62],
+				"branchIds": [1, 2],
+				"directoryIds": [3, 4],
 				"createdAt": "2023-09-16T13:48:04+00:00",
 				"updatedAt": "2023-09-19T13:25:27+00:00",
 				"exportMode": "bundle",
@@ -186,19 +200,23 @@ func TestDistributionsService_Add(t *testing.T) {
 	})
 
 	req := &model.DistributionAddRequest{
-		Name:       "Export Bundle",
-		ExportMode: model.ExportModeBundle,
-		BundleIDs:  []int{45, 62},
+		Name:         "Export Bundle",
+		ExportMode:   model.ExportModeBundle,
+		BundleIDs:    []int{45, 62},
+		BranchIDs:    []int{1, 2},
+		DirectoryIDs: []int{3, 4},
 	}
 	distribution, resp, err := client.Distributions.Add(context.Background(), 1, req)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
 	expected := &model.Distribution{
-		Hash:        "50fb350641274ba88296f97dc7e3e0c3",
-		Name:        "Export Bundle",
-		BundleIDs:   []int{45, 62},
-		CreatedAt:   "2023-09-16T13:48:04+00:00",
+		Hash:         "50fb350641274ba88296f97dc7e3e0c3",
+		Name:         "Export Bundle",
+		BundleIDs:    []int{45, 62},
+		BranchIDs:    []int{1, 2},
+		DirectoryIDs: []int{3, 4},
+		CreatedAt:    "2023-09-16T13:48:04+00:00",
 		UpdatedAt:   "2023-09-19T13:25:27+00:00",
 		ExportMode:  "bundle",
 		FileIDs:     []int{24, 25, 38},
@@ -222,6 +240,8 @@ func TestDistributionsService_Edit(t *testing.T) {
 				"hash": "50fb350641274ba88296f97dc7e3e0c3",
 				"name": "Export Bundle",
 				"bundleIds": [45, 62],
+				"branchIds": [1, 2],
+				"directoryIds": [3, 4],
 				"createdAt": "2023-09-16T13:48:04+00:00",
 				"updatedAt": "2023-09-19T13:25:27+00:00",
 				"exportMode": "bundle",
@@ -243,10 +263,12 @@ func TestDistributionsService_Edit(t *testing.T) {
 	assert.NotNil(t, resp)
 
 	expected := &model.Distribution{
-		Hash:        "50fb350641274ba88296f97dc7e3e0c3",
-		Name:        "Export Bundle",
-		BundleIDs:   []int{45, 62},
-		CreatedAt:   "2023-09-16T13:48:04+00:00",
+		Hash:         "50fb350641274ba88296f97dc7e3e0c3",
+		Name:         "Export Bundle",
+		BundleIDs:    []int{45, 62},
+		BranchIDs:    []int{1, 2},
+		DirectoryIDs: []int{3, 4},
+		CreatedAt:    "2023-09-16T13:48:04+00:00",
 		UpdatedAt:   "2023-09-19T13:25:27+00:00",
 		ExportMode:  "bundle",
 		FileIDs:     []int{24, 25, 38},

--- a/third_party/crowdin-api-client-go/crowdin/distributions_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/distributions_test.go
@@ -93,10 +93,10 @@ func TestDistributionsService_List(t *testing.T) {
 				BranchIDs:    []int{1, 2},
 				DirectoryIDs: []int{3, 4},
 				CreatedAt:    "2023-09-16T13:48:04+00:00",
-				UpdatedAt:   "2023-09-19T13:25:27+00:00",
-				ExportMode:  "bundle",
-				FileIDs:     []int{24, 25, 38},
-				ManifestURL: "https://distributions.crowdin.net/50fb350641274ba88296f97dc7e3e0c3/manifest.json",
+				UpdatedAt:    "2023-09-19T13:25:27+00:00",
+				ExportMode:   "bundle",
+				FileIDs:      []int{24, 25, 38},
+				ManifestURL:  "https://distributions.crowdin.net/50fb350641274ba88296f97dc7e3e0c3/manifest.json",
 			},
 			{
 				Hash:         "50fb350641274ba88296f97dc7e3e0c4",
@@ -105,10 +105,10 @@ func TestDistributionsService_List(t *testing.T) {
 				BranchIDs:    []int{5},
 				DirectoryIDs: []int{6},
 				CreatedAt:    "2023-09-16T13:48:04+00:00",
-				UpdatedAt:   "2023-09-19T13:25:27+00:00",
-				ExportMode:  "bundle",
-				FileIDs:     []int{25},
-				ManifestURL: "https://distributions.crowdin.net/50fb350641274ba88296f97dc7e3e0c3/manifest.json",
+				UpdatedAt:    "2023-09-19T13:25:27+00:00",
+				ExportMode:   "bundle",
+				FileIDs:      []int{25},
+				ManifestURL:  "https://distributions.crowdin.net/50fb350641274ba88296f97dc7e3e0c3/manifest.json",
 			},
 		}
 		require.Equal(t, expected, distributions)
@@ -164,10 +164,10 @@ func TestDistributionsService_Get(t *testing.T) {
 		BranchIDs:    []int{1, 2},
 		DirectoryIDs: []int{3, 4},
 		CreatedAt:    "2023-09-16T13:48:04+00:00",
-		UpdatedAt:   "2023-09-19T13:25:27+00:00",
-		ExportMode:  "bundle",
-		FileIDs:     []int{24, 25, 38},
-		ManifestURL: "https://distributions.crowdin.net/50fb350641274ba88296f97dc7e3e0c3/manifest.json",
+		UpdatedAt:    "2023-09-19T13:25:27+00:00",
+		ExportMode:   "bundle",
+		FileIDs:      []int{24, 25, 38},
+		ManifestURL:  "https://distributions.crowdin.net/50fb350641274ba88296f97dc7e3e0c3/manifest.json",
 	}
 	require.Equal(t, expected, distribution)
 }
@@ -217,10 +217,10 @@ func TestDistributionsService_Add(t *testing.T) {
 		BranchIDs:    []int{1, 2},
 		DirectoryIDs: []int{3, 4},
 		CreatedAt:    "2023-09-16T13:48:04+00:00",
-		UpdatedAt:   "2023-09-19T13:25:27+00:00",
-		ExportMode:  "bundle",
-		FileIDs:     []int{24, 25, 38},
-		ManifestURL: "https://distributions.crowdin.net/50fb350641274ba88296f97dc7e3e0c3/manifest.json",
+		UpdatedAt:    "2023-09-19T13:25:27+00:00",
+		ExportMode:   "bundle",
+		FileIDs:      []int{24, 25, 38},
+		ManifestURL:  "https://distributions.crowdin.net/50fb350641274ba88296f97dc7e3e0c3/manifest.json",
 	}
 	assert.Equal(t, expected, distribution)
 }
@@ -269,10 +269,10 @@ func TestDistributionsService_Edit(t *testing.T) {
 		BranchIDs:    []int{1, 2},
 		DirectoryIDs: []int{3, 4},
 		CreatedAt:    "2023-09-16T13:48:04+00:00",
-		UpdatedAt:   "2023-09-19T13:25:27+00:00",
-		ExportMode:  "bundle",
-		FileIDs:     []int{24, 25, 38},
-		ManifestURL: "https://distributions.crowdin.net/50fb350641274ba88296f97dc7e3e0c3/manifest.json",
+		UpdatedAt:    "2023-09-19T13:25:27+00:00",
+		ExportMode:   "bundle",
+		FileIDs:      []int{24, 25, 38},
+		ManifestURL:  "https://distributions.crowdin.net/50fb350641274ba88296f97dc7e3e0c3/manifest.json",
 	}
 	assert.Equal(t, expected, distribution)
 }

--- a/third_party/crowdin-api-client-go/crowdin/labels_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/labels_test.go
@@ -521,8 +521,8 @@ func TestLabelsService_AssignToScreenshots(t *testing.T) {
 			ProjectID: 1,
 			UserID:    6,
 			URL:       "https://production-enterprise-screenshots.downloads.crowdin.com/992000002/6/2/middle.jpg",
-			WebURL: "https://production-enterprise-screenshots.downloads.crowdin.com/992000002/6/2/middle.jpg",
-			Name:   "translate_with_siri.jpg",
+			WebURL:    "https://production-enterprise-screenshots.downloads.crowdin.com/992000002/6/2/middle.jpg",
+			Name:      "translate_with_siri.jpg",
 			Size: struct {
 				Width  int `json:"width"`
 				Height int `json:"height"`
@@ -642,8 +642,8 @@ func TestLabelsService_UnassignFromScreenshots(t *testing.T) {
 			ProjectID: 1,
 			UserID:    6,
 			URL:       "https://production-enterprise-screenshots.downloads.crowdin.com/992000002/6/2/middle.jpg",
-			WebURL: "https://production-enterprise-screenshots.downloads.crowdin.com/992000002/6/2/middle.jpg",
-			Name:   "translate_with_siri.jpg",
+			WebURL:    "https://production-enterprise-screenshots.downloads.crowdin.com/992000002/6/2/middle.jpg",
+			Name:      "translate_with_siri.jpg",
 			Size: struct {
 				Width  int `json:"width"`
 				Height int `json:"height"`

--- a/third_party/crowdin-api-client-go/crowdin/labels_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/labels_test.go
@@ -473,6 +473,7 @@ func TestLabelsService_AssignToScreenshots(t *testing.T) {
 				{
 					"data": {
 						"id": 2,
+						"projectId": 1,
 						"userId": 6,
 						"url": "https://production-enterprise-screenshots.downloads.crowdin.com/992000002/6/2/middle.jpg",
 						"webUrl": "https://production-enterprise-screenshots.downloads.crowdin.com/992000002/6/2/middle.jpg",
@@ -516,9 +517,10 @@ func TestLabelsService_AssignToScreenshots(t *testing.T) {
 
 	expected := []*model.Screenshot{
 		{
-			ID:     2,
-			UserID: 6,
-			URL:    "https://production-enterprise-screenshots.downloads.crowdin.com/992000002/6/2/middle.jpg",
+			ID:        2,
+			ProjectID: 1,
+			UserID:    6,
+			URL:       "https://production-enterprise-screenshots.downloads.crowdin.com/992000002/6/2/middle.jpg",
 			WebURL: "https://production-enterprise-screenshots.downloads.crowdin.com/992000002/6/2/middle.jpg",
 			Name:   "translate_with_siri.jpg",
 			Size: struct {
@@ -592,6 +594,7 @@ func TestLabelsService_UnassignFromScreenshots(t *testing.T) {
 				{
 					"data": {
 						"id": 2,
+						"projectId": 1,
 						"userId": 6,
 						"url": "https://production-enterprise-screenshots.downloads.crowdin.com/992000002/6/2/middle.jpg",
 						"webUrl": "https://production-enterprise-screenshots.downloads.crowdin.com/992000002/6/2/middle.jpg",
@@ -635,9 +638,10 @@ func TestLabelsService_UnassignFromScreenshots(t *testing.T) {
 
 	expected := []*model.Screenshot{
 		{
-			ID:     2,
-			UserID: 6,
-			URL:    "https://production-enterprise-screenshots.downloads.crowdin.com/992000002/6/2/middle.jpg",
+			ID:        2,
+			ProjectID: 1,
+			UserID:    6,
+			URL:       "https://production-enterprise-screenshots.downloads.crowdin.com/992000002/6/2/middle.jpg",
 			WebURL: "https://production-enterprise-screenshots.downloads.crowdin.com/992000002/6/2/middle.jpg",
 			Name:   "translate_with_siri.jpg",
 			Size: struct {

--- a/third_party/crowdin-api-client-go/crowdin/model/distributions.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/distributions.go
@@ -4,14 +4,16 @@ import "errors"
 
 // Distribution represents a distribution in the project.
 type Distribution struct {
-	Hash        string `json:"hash"`
-	Name        string `json:"name"`
-	BundleIDs   []int  `json:"bundleIds"`
-	CreatedAt   string `json:"createdAt"`
-	UpdatedAt   string `json:"updatedAt"`
-	ExportMode  string `json:"exportMode"`
-	FileIDs     []int  `json:"fileIds"`
-	ManifestURL string `json:"manifestUrl"`
+	Hash         string `json:"hash"`
+	Name         string `json:"name"`
+	BundleIDs    []int  `json:"bundleIds"`
+	BranchIDs    []int  `json:"branchIds,omitempty"`
+	DirectoryIDs []int  `json:"directoryIds,omitempty"`
+	CreatedAt    string `json:"createdAt"`
+	UpdatedAt    string `json:"updatedAt"`
+	ExportMode   string `json:"exportMode"`
+	FileIDs      []int  `json:"fileIds"`
+	ManifestURL  string `json:"manifestUrl"`
 }
 
 // DistributionResponse defines the structure of the response when
@@ -48,6 +50,10 @@ type DistributionAddRequest struct {
 	FileIDs []int `json:"fileIds,omitempty"`
 	// Bundles ids. Required for `bundle` export mode.
 	BundleIDs []int `json:"bundleIds,omitempty"`
+	// Branch ids.
+	BranchIDs []int `json:"branchIds,omitempty"`
+	// Directory ids.
+	DirectoryIDs []int `json:"directoryIds,omitempty"`
 }
 
 // Validate checks if the request is valid.

--- a/third_party/crowdin-api-client-go/crowdin/model/distributions.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/distributions.go
@@ -7,12 +7,12 @@ type Distribution struct {
 	Hash         string `json:"hash"`
 	Name         string `json:"name"`
 	BundleIDs    []int  `json:"bundleIds"`
-	BranchIDs    []int  `json:"branchIds,omitempty"`
-	DirectoryIDs []int  `json:"directoryIds,omitempty"`
+	BranchIDs    []int  `json:"branchIds"`
+	DirectoryIDs []int  `json:"directoryIds"`
+	FileIDs      []int  `json:"fileIds"`
 	CreatedAt    string `json:"createdAt"`
 	UpdatedAt    string `json:"updatedAt"`
 	ExportMode   string `json:"exportMode"`
-	FileIDs      []int  `json:"fileIds"`
 	ManifestURL  string `json:"manifestUrl"`
 }
 

--- a/third_party/crowdin-api-client-go/crowdin/model/screenshot.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/screenshot.go
@@ -13,9 +13,9 @@ type Screenshot struct {
 	ProjectID int    `json:"projectId"`
 	UserID    int    `json:"userId"`
 	URL       string `json:"url"`
-	WebURL string `json:"webUrl"`
-	Name   string `json:"name"`
-	Size   struct {
+	WebURL    string `json:"webUrl"`
+	Name      string `json:"name"`
+	Size      struct {
 		Width  int `json:"width"`
 		Height int `json:"height"`
 	} `json:"size"`

--- a/third_party/crowdin-api-client-go/crowdin/model/screenshot.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/screenshot.go
@@ -9,9 +9,10 @@ import (
 // Screenshot represents a screenshot, which provides translators
 // with additional context for the source strings.
 type Screenshot struct {
-	ID     int    `json:"id"`
-	UserID int    `json:"userId"`
-	URL    string `json:"url"`
+	ID        int    `json:"id"`
+	ProjectID int    `json:"projectId"`
+	UserID    int    `json:"userId"`
+	URL       string `json:"url"`
 	WebURL string `json:"webUrl"`
 	Name   string `json:"name"`
 	Size   struct {

--- a/third_party/crowdin-api-client-go/crowdin/screenshots_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/screenshots_test.go
@@ -23,6 +23,7 @@ func TestScreenshotsService_GetScreenshot(t *testing.T) {
 		fmt.Fprint(w, `{
 			"data": {
 				"id": 2,
+				"projectId": 2,
 				"userId": 6,
 				"url": "https://production-enterprise-screenshots.downloads.crowdin.com/992000002/6/2/middle.jpg",
 				"webUrl": "https://production-enterprise-screenshots.downloads.crowdin.com/992000002/6/2/middle.jpg",
@@ -59,9 +60,10 @@ func TestScreenshotsService_GetScreenshot(t *testing.T) {
 	assert.NotNil(t, resp)
 
 	expected := &model.Screenshot{
-		ID:     2,
-		UserID: 6,
-		URL:    "https://production-enterprise-screenshots.downloads.crowdin.com/992000002/6/2/middle.jpg",
+		ID:        2,
+		ProjectID: 2,
+		UserID:    6,
+		URL:       "https://production-enterprise-screenshots.downloads.crowdin.com/992000002/6/2/middle.jpg",
 		WebURL: "https://production-enterprise-screenshots.downloads.crowdin.com/992000002/6/2/middle.jpg",
 		Name:   "translate_with_siri.jpg",
 		Size: struct {

--- a/third_party/crowdin-api-client-go/crowdin/screenshots_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/screenshots_test.go
@@ -64,8 +64,8 @@ func TestScreenshotsService_GetScreenshot(t *testing.T) {
 		ProjectID: 2,
 		UserID:    6,
 		URL:       "https://production-enterprise-screenshots.downloads.crowdin.com/992000002/6/2/middle.jpg",
-		WebURL: "https://production-enterprise-screenshots.downloads.crowdin.com/992000002/6/2/middle.jpg",
-		Name:   "translate_with_siri.jpg",
+		WebURL:    "https://production-enterprise-screenshots.downloads.crowdin.com/992000002/6/2/middle.jpg",
+		Name:      "translate_with_siri.jpg",
 		Size: struct {
 			Width  int `json:"width"`
 			Height int `json:"height"`


### PR DESCRIPTION
This PR improves the parity of the Crowdin Go client models with the official API v2 for Screenshots and Distributions.

What:
- Added `projectId` (int) to the `Screenshot` model.
- Added `branchIds` ([]int) and `directoryIds` ([]int) to both `Distribution` and `DistributionAddRequest` models.
- Updated relevant contract tests in `screenshots_test.go`, `labels_test.go`, and `distributions_test.go`.

Why:
These fields are part of the Crowdin API v2 contract but were missing from the Go SDK, preventing users from accessing or specifying these granular identifiers.

Docs:
- Screenshots: https://developer.crowdin.com/api/v2/#tag/Screenshots
- Distributions: https://developer.crowdin.com/api/v2/#tag/Distributions

Tests:
- Executed `GOWORK=off go test ./crowdin/...` within the `third_party/crowdin-api-client-go` directory.
- Ran `go test ./...` in the repository root.

Confidence:
The changes are additive to response models and use `omitempty` for request models, ensuring backward compatibility while enabling access to documented API fields. Verified with updated contract tests.

---
*PR created automatically by Jules for task [3784772611125568900](https://jules.google.com/task/3784772611125568900) started by @cungminh2710*