### PR TITLE
feat(cat): isolate panel runtime errors with react-error-boundary

### DIFF
--- a/apps/hyperlocalise-web/package.json
+++ b/apps/hyperlocalise-web/package.json
@@ -83,6 +83,7 @@
     "pg": "8.21.0",
     "react": "19.2.7",
     "react-dom": "19.2.7",
+    "react-error-boundary": "^6.1.2",
     "react-hook-form": "7.78.0",
     "react-hotkeys-hook": "^5.3.2",
     "react-intersection-observer": "10.0.3",

--- a/apps/hyperlocalise-web/pnpm-lock.yaml
+++ b/apps/hyperlocalise-web/pnpm-lock.yaml
@@ -228,6 +228,9 @@ importers:
       react-dom:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
+      react-error-boundary:
+        specifier: ^6.1.2
+        version: 6.1.2(react@19.2.7)
       react-hook-form:
         specifier: 7.78.0
         version: 7.78.0(react@19.2.7)
@@ -7648,6 +7651,11 @@ packages:
     resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
     peerDependencies:
       react: ^19.2.7
+
+  react-error-boundary@6.1.2:
+    resolution: {integrity: sha512-3DpCr5HVdZ0caUjYE/kIHBEJN0mNP3ZCgf16c48uJ5TbWjorKVp+YG8W3XqlJ7vJAVNw6wNIImyPXmFydwmyng==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
 
   react-hook-form@7.78.0:
     resolution: {integrity: sha512-EEZqc+N23moyzTlz61Pj+JvcXo76ICkpfOZo8JZw+sM4+wLQGh6nI2Ms+PdMOYNluFu0ghlM7B8mCzhRYtJCnA==}
@@ -16654,6 +16662,10 @@ snapshots:
     dependencies:
       react: 19.2.7
       scheduler: 0.27.0
+
+  react-error-boundary@6.1.2(react@19.2.7):
+    dependencies:
+      react: 19.2.7
 
   react-hook-form@7.78.0(react@19.2.7):
     dependencies:

--- a/apps/hyperlocalise-web/src/components/cat/cat-panel-error-boundary.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-panel-error-boundary.tsx
@@ -17,7 +17,7 @@ type CatPanelErrorBoundaryProps = {
   children: ReactNode;
   scope: CatPanelErrorBoundaryScope;
   className?: string;
-  resetKeys?: ReadonlyArray<unknown>;
+  resetKeys?: unknown[];
 };
 
 const panelTitleMessageByScope = {
@@ -40,6 +40,8 @@ function CatPanelErrorFallback({
   scope,
   className,
 }: FallbackProps & { scope: CatPanelErrorBoundaryScope; className?: string }) {
+  const errorMessage = error instanceof Error ? error.message : null;
+
   return (
     <div
       className={cn(
@@ -57,8 +59,8 @@ function CatPanelErrorFallback({
           <p>
             <FormattedMessage {...catPanelErrorBoundaryMessages.description} />
           </p>
-          {process.env.NODE_ENV !== "production" && error.message ? (
-            <p className="font-mono text-xs break-words">{error.message}</p>
+          {process.env.NODE_ENV !== "production" && errorMessage ? (
+            <p className="font-mono text-xs break-words">{errorMessage}</p>
           ) : null}
           <Button type="button" variant="outline" size="sm" onClick={resetErrorBoundary}>
             <FormattedMessage {...catPanelErrorBoundaryMessages.retry} />
@@ -81,7 +83,9 @@ export function CatPanelErrorBoundary({
         <CatPanelErrorFallback {...fallbackProps} scope={scope} className={className} />
       )}
       onError={(error) => {
-        logCatPanelError(scope, error);
+        if (error instanceof Error) {
+          logCatPanelError(scope, error);
+        }
       }}
       resetKeys={resetKeys}
     >

--- a/apps/hyperlocalise-web/src/components/cat/cat-panel-error-boundary.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-panel-error-boundary.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { AlertCircleIcon } from "lucide-react";
-import { type ReactNode } from "react";
+import { type ErrorInfo, type ReactNode } from "react";
 import { ErrorBoundary, type FallbackProps } from "react-error-boundary";
 import { FormattedMessage } from "react-intl";
 
@@ -27,10 +27,12 @@ const panelTitleMessageByScope = {
   workspace: catPanelErrorBoundaryMessages.workspaceTitle,
 } as const;
 
-function logCatPanelError(scope: CatPanelErrorBoundaryScope, error: Error) {
+function logCatPanelError(scope: CatPanelErrorBoundaryScope, error: Error, info: ErrorInfo) {
   console.error(`[cat:${scope}]`, {
     name: error.name,
     message: error.message,
+    stack: error.stack,
+    componentStack: info.componentStack,
   });
 }
 
@@ -82,9 +84,9 @@ export function CatPanelErrorBoundary({
       fallbackRender={(fallbackProps) => (
         <CatPanelErrorFallback {...fallbackProps} scope={scope} className={className} />
       )}
-      onError={(error) => {
+      onError={(error, info) => {
         if (error instanceof Error) {
-          logCatPanelError(scope, error);
+          logCatPanelError(scope, error, info);
         }
       }}
       resetKeys={resetKeys}

--- a/apps/hyperlocalise-web/src/components/cat/cat-panel-error-boundary.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-panel-error-boundary.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { AlertCircleIcon } from "lucide-react";
+import { type ReactNode } from "react";
+import { ErrorBoundary, type FallbackProps } from "react-error-boundary";
+import { FormattedMessage } from "react-intl";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/primitives/cn";
+
+import { catPanelErrorBoundaryMessages } from "./cat.messages";
+
+export type CatPanelErrorBoundaryScope = "queue" | "editor" | "intelligence" | "workspace";
+
+type CatPanelErrorBoundaryProps = {
+  children: ReactNode;
+  scope: CatPanelErrorBoundaryScope;
+  className?: string;
+  resetKeys?: ReadonlyArray<unknown>;
+};
+
+const panelTitleMessageByScope = {
+  queue: catPanelErrorBoundaryMessages.queuePanelTitle,
+  editor: catPanelErrorBoundaryMessages.editorPanelTitle,
+  intelligence: catPanelErrorBoundaryMessages.intelligencePanelTitle,
+  workspace: catPanelErrorBoundaryMessages.workspaceTitle,
+} as const;
+
+function logCatPanelError(scope: CatPanelErrorBoundaryScope, error: Error) {
+  console.error(`[cat:${scope}]`, {
+    name: error.name,
+    message: error.message,
+  });
+}
+
+function CatPanelErrorFallback({
+  error,
+  resetErrorBoundary,
+  scope,
+  className,
+}: FallbackProps & { scope: CatPanelErrorBoundaryScope; className?: string }) {
+  return (
+    <div
+      className={cn(
+        "flex h-full min-h-0 min-w-0 flex-col items-center justify-center p-4",
+        className,
+      )}
+      role="alert"
+    >
+      <Alert variant="destructive" className="max-w-md">
+        <AlertCircleIcon />
+        <AlertTitle>
+          <FormattedMessage {...panelTitleMessageByScope[scope]} />
+        </AlertTitle>
+        <AlertDescription className="space-y-3">
+          <p>
+            <FormattedMessage {...catPanelErrorBoundaryMessages.description} />
+          </p>
+          {process.env.NODE_ENV !== "production" && error.message ? (
+            <p className="font-mono text-xs break-words">{error.message}</p>
+          ) : null}
+          <Button type="button" variant="outline" size="sm" onClick={resetErrorBoundary}>
+            <FormattedMessage {...catPanelErrorBoundaryMessages.retry} />
+          </Button>
+        </AlertDescription>
+      </Alert>
+    </div>
+  );
+}
+
+export function CatPanelErrorBoundary({
+  children,
+  scope,
+  className,
+  resetKeys,
+}: CatPanelErrorBoundaryProps) {
+  return (
+    <ErrorBoundary
+      fallbackRender={(fallbackProps) => (
+        <CatPanelErrorFallback {...fallbackProps} scope={scope} className={className} />
+      )}
+      onError={(error) => {
+        logCatPanelError(scope, error);
+      }}
+      resetKeys={resetKeys}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
@@ -24,6 +24,7 @@ import type {
   CatWorkspaceViewProps,
   PartialCatWorkspaceDependencies,
 } from "./dependencies";
+import { CatPanelErrorBoundary } from "./cat-panel-error-boundary";
 import { CatWorkspaceView } from "./cat-workspace";
 import {
   buildSavedTargetTextMap,
@@ -1256,7 +1257,12 @@ export function CatWorkspaceContainer({
 
   return (
     <>
-      <CatWorkspaceView
+      <CatPanelErrorBoundary
+        scope="workspace"
+        className={className}
+        resetKeys={[state.selectedSegmentId, queueFilter, queueSearch, queuePagination?.offset]}
+      >
+        <CatWorkspaceView
         state={queueViewState}
         editorState={state}
         dependencies={dependencies}
@@ -1297,6 +1303,7 @@ export function CatWorkspaceContainer({
         isBulkActionPending={isBulkActionPending}
         buildSegmentShareUrl={resolvedBuildSegmentShareUrl}
       />
+      </CatPanelErrorBoundary>
 
       <AlertDialog
         open={unsavedNavigationPrompt !== null}

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
@@ -1263,46 +1263,48 @@ export function CatWorkspaceContainer({
         resetKeys={[state.selectedSegmentId, queueFilter, queueSearch, queuePagination?.offset]}
       >
         <CatWorkspaceView
-        state={queueViewState}
-        editorState={state}
-        dependencies={dependencies}
-        dirtySegmentIds={dirtySegmentIds}
-        isValidating={isValidating}
-        isApproving={isApproving}
-        isPostingComment={isPostingComment}
-        commentPostError={commentPostError}
-        isLookingUpContext={isLookingUpContext}
-        isConcordanceLoading={isLoadingConcordance}
-        isVisualContextLoading={isLoadingVisualContext}
-        isAiSuggestionLoading={isGeneratingAiRecommendation && canUseAiRecommendation}
-        isFormatChecksLoading={isRunningFormatChecks || isValidating}
-        canLookupContext={canLookupContext}
-        showAgentContext={revealedAgentContextSegmentIds.has(state.selectedSegmentId)}
-        showVisualContext={canLoadVisualContext}
-        canUseAiRecommendation={canUseAiRecommendation}
-        className={className}
-        queueSearch={queueSearch}
-        onQueueSearchChange={onQueueSearchChange}
-        isQueueSearchPending={isQueueSearchPending}
-        isQueueFetchingPage={isQueueFetchingPage}
-        queuePagination={queuePagination}
-        onQueuePreviousPage={
-          onQueuePreviousPage ? () => attemptPageNavigation(onQueuePreviousPage) : undefined
-        }
-        onQueueNextPage={onQueueNextPage ? () => attemptPageNavigation(onQueueNextPage) : undefined}
-        onQueueNearEnd={onQueueNearEnd}
-        queueFilter={queueFilter}
-        onQueueFilterChange={handleQueueFilterChange}
-        availableQueueFilters={availableQueueFilters}
-        checkedSegmentIds={checkedSegmentIds}
-        onToggleSegmentChecked={handleToggleSegmentChecked}
-        onSelectAllVisible={handleSelectAllVisible}
-        onClearChecked={handleClearChecked}
-        onBulkApprove={() => void handleBulkApprove()}
-        onBulkSkip={() => void handleBulkSkip()}
-        isBulkActionPending={isBulkActionPending}
-        buildSegmentShareUrl={resolvedBuildSegmentShareUrl}
-      />
+          state={queueViewState}
+          editorState={state}
+          dependencies={dependencies}
+          dirtySegmentIds={dirtySegmentIds}
+          isValidating={isValidating}
+          isApproving={isApproving}
+          isPostingComment={isPostingComment}
+          commentPostError={commentPostError}
+          isLookingUpContext={isLookingUpContext}
+          isConcordanceLoading={isLoadingConcordance}
+          isVisualContextLoading={isLoadingVisualContext}
+          isAiSuggestionLoading={isGeneratingAiRecommendation && canUseAiRecommendation}
+          isFormatChecksLoading={isRunningFormatChecks || isValidating}
+          canLookupContext={canLookupContext}
+          showAgentContext={revealedAgentContextSegmentIds.has(state.selectedSegmentId)}
+          showVisualContext={canLoadVisualContext}
+          canUseAiRecommendation={canUseAiRecommendation}
+          className={className}
+          queueSearch={queueSearch}
+          onQueueSearchChange={onQueueSearchChange}
+          isQueueSearchPending={isQueueSearchPending}
+          isQueueFetchingPage={isQueueFetchingPage}
+          queuePagination={queuePagination}
+          onQueuePreviousPage={
+            onQueuePreviousPage ? () => attemptPageNavigation(onQueuePreviousPage) : undefined
+          }
+          onQueueNextPage={
+            onQueueNextPage ? () => attemptPageNavigation(onQueueNextPage) : undefined
+          }
+          onQueueNearEnd={onQueueNearEnd}
+          queueFilter={queueFilter}
+          onQueueFilterChange={handleQueueFilterChange}
+          availableQueueFilters={availableQueueFilters}
+          checkedSegmentIds={checkedSegmentIds}
+          onToggleSegmentChecked={handleToggleSegmentChecked}
+          onSelectAllVisible={handleSelectAllVisible}
+          onClearChecked={handleClearChecked}
+          onBulkApprove={() => void handleBulkApprove()}
+          onBulkSkip={() => void handleBulkSkip()}
+          isBulkActionPending={isBulkActionPending}
+          buildSegmentShareUrl={resolvedBuildSegmentShareUrl}
+        />
       </CatPanelErrorBoundary>
 
       <AlertDialog

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace.tsx
@@ -9,6 +9,7 @@ import { cn } from "@/lib/primitives/cn";
 
 import { CatEditorPanel } from "./cat-editor-panel";
 import { CatIntelligencePanel } from "./cat-intelligence-panel";
+import { CatPanelErrorBoundary } from "./cat-panel-error-boundary";
 import { CatQueuePanel } from "./cat-queue-panel";
 import { catWorkspaceMessages } from "./cat.messages";
 import type { CatWorkspaceViewProps } from "./dependencies";
@@ -130,7 +131,11 @@ export function CatWorkspaceView({
 
   function renderEditorPanel() {
     return (
-      <CatEditorPanel
+      <CatPanelErrorBoundary
+        scope="editor"
+        resetKeys={[selectedSegment.id, selectedSegment.targetText]}
+      >
+        <CatEditorPanel
         segment={selectedSegment}
         segmentPosition={segmentPosition}
         totalSegments={totalSegments}
@@ -171,12 +176,17 @@ export function CatWorkspaceView({
         hasPreviousSegment={hasPreviousSegment}
         hasNextSegment={hasNextSegment}
       />
+      </CatPanelErrorBoundary>
     );
   }
 
   function renderQueuePanel() {
     return (
-      <CatQueuePanel
+      <CatPanelErrorBoundary
+        scope="queue"
+        resetKeys={[state.segments.length, selectedSegment.id, queueSearch, queueFilter]}
+      >
+        <CatQueuePanel
         segments={state.segments}
         selectedSegmentId={selectedSegment.id}
         summary={fullState.queueSummary}
@@ -206,12 +216,17 @@ export function CatWorkspaceView({
         onNextPage={onQueueNextPage}
         onNearEnd={onQueueNearEnd}
       />
+      </CatPanelErrorBoundary>
     );
   }
 
   function renderIntelligencePanel() {
     return (
-      <CatIntelligencePanel
+      <CatPanelErrorBoundary
+        scope="intelligence"
+        resetKeys={[selectedSegment.id, selectedSegment.targetText]}
+      >
+        <CatIntelligencePanel
         intelligence={selectedSegmentIntelligence}
         targetText={selectedSegment.targetText}
         isLookingUpContext={isLookingUpContext}
@@ -225,6 +240,7 @@ export function CatWorkspaceView({
           editing.onUseGlossaryTerm(selectedSegment.id, term, selectedSegment.sourceText)
         }
       />
+      </CatPanelErrorBoundary>
     );
   }
 

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace.tsx
@@ -131,10 +131,7 @@ export function CatWorkspaceView({
 
   function renderEditorPanel() {
     return (
-      <CatPanelErrorBoundary
-        scope="editor"
-        resetKeys={[selectedSegment.id, selectedSegment.targetText]}
-      >
+      <CatPanelErrorBoundary scope="editor" resetKeys={[selectedSegment.id]}>
         <CatEditorPanel
           segment={selectedSegment}
           segmentPosition={segmentPosition}

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace.tsx
@@ -136,46 +136,50 @@ export function CatWorkspaceView({
         resetKeys={[selectedSegment.id, selectedSegment.targetText]}
       >
         <CatEditorPanel
-        segment={selectedSegment}
-        segmentPosition={segmentPosition}
-        totalSegments={totalSegments}
-        formatChecks={selectedSegmentFormatChecks}
-        intelligence={selectedSegmentIntelligence}
-        isEditorBusy={isEditorBusy}
-        isApproving={isApproving}
-        isLookingUpContext={isLookingUpContext}
-        isAiSuggestionLoading={isAiSuggestionLoading}
-        isFormatChecksLoading={isFormatChecksLoading}
-        isPostingComment={isPostingComment}
-        commentPostError={commentPostError}
-        canApprove={canApprove}
-        canAddComment={canAddComment}
-        canEditTranslations={canApprove}
-        isTargetDirty={isTargetDirty}
-        canLookupContext={canLookupContext}
-        canUseAiRecommendation={canUseAiRecommendation}
-        segmentShareUrl={segmentShareUrl}
-        onTargetChange={(value) => editing.onTargetChange(selectedSegment.id, value)}
-        onCopySource={() => editing.onTargetChange(selectedSegment.id, selectedSegment.sourceText)}
-        onClearTarget={() => editing.onTargetChange(selectedSegment.id, "")}
-        onUseAiSuggestion={() => editing.onUseAiSuggestion(selectedSegment.id)}
-        onApprove={() => void review.onApprove(selectedSegment.id, selectedSegment.targetText)}
-        onAddComment={
-          review.onAddComment
-            ? (text) => review.onAddComment?.(selectedSegment.id, text)
-            : undefined
-        }
-        primaryActionLabel={fullState.primaryActionLabel}
-        onAskQuestion={() => review.onAskQuestion(selectedSegment.id)}
-        onGenerateAiRecommendation={
-          canUseAiRecommendation ? () => void review.onReviewWithAi(selectedSegment.id) : undefined
-        }
-        aiRecommendationError={aiRecommendationError}
-        onPrevious={navigation.onPreviousSegment}
-        onNext={navigation.onNextSegment}
-        hasPreviousSegment={hasPreviousSegment}
-        hasNextSegment={hasNextSegment}
-      />
+          segment={selectedSegment}
+          segmentPosition={segmentPosition}
+          totalSegments={totalSegments}
+          formatChecks={selectedSegmentFormatChecks}
+          intelligence={selectedSegmentIntelligence}
+          isEditorBusy={isEditorBusy}
+          isApproving={isApproving}
+          isLookingUpContext={isLookingUpContext}
+          isAiSuggestionLoading={isAiSuggestionLoading}
+          isFormatChecksLoading={isFormatChecksLoading}
+          isPostingComment={isPostingComment}
+          commentPostError={commentPostError}
+          canApprove={canApprove}
+          canAddComment={canAddComment}
+          canEditTranslations={canApprove}
+          isTargetDirty={isTargetDirty}
+          canLookupContext={canLookupContext}
+          canUseAiRecommendation={canUseAiRecommendation}
+          segmentShareUrl={segmentShareUrl}
+          onTargetChange={(value) => editing.onTargetChange(selectedSegment.id, value)}
+          onCopySource={() =>
+            editing.onTargetChange(selectedSegment.id, selectedSegment.sourceText)
+          }
+          onClearTarget={() => editing.onTargetChange(selectedSegment.id, "")}
+          onUseAiSuggestion={() => editing.onUseAiSuggestion(selectedSegment.id)}
+          onApprove={() => void review.onApprove(selectedSegment.id, selectedSegment.targetText)}
+          onAddComment={
+            review.onAddComment
+              ? (text) => review.onAddComment?.(selectedSegment.id, text)
+              : undefined
+          }
+          primaryActionLabel={fullState.primaryActionLabel}
+          onAskQuestion={() => review.onAskQuestion(selectedSegment.id)}
+          onGenerateAiRecommendation={
+            canUseAiRecommendation
+              ? () => void review.onReviewWithAi(selectedSegment.id)
+              : undefined
+          }
+          aiRecommendationError={aiRecommendationError}
+          onPrevious={navigation.onPreviousSegment}
+          onNext={navigation.onNextSegment}
+          hasPreviousSegment={hasPreviousSegment}
+          hasNextSegment={hasNextSegment}
+        />
       </CatPanelErrorBoundary>
     );
   }
@@ -187,35 +191,35 @@ export function CatWorkspaceView({
         resetKeys={[state.segments.length, selectedSegment.id, queueSearch, queueFilter]}
       >
         <CatQueuePanel
-        segments={state.segments}
-        selectedSegmentId={selectedSegment.id}
-        summary={fullState.queueSummary}
-        dirtySegmentIds={dirtySegmentIds}
-        onSelectSegment={(segmentId) => {
-          navigation.onSelectSegment(segmentId);
-          if (isCompact) {
-            setActivePanel("edit");
-          }
-        }}
-        search={queueSearch}
-        onSearchChange={onQueueSearchChange}
-        isSearching={isQueueSearchPending}
-        queueFilter={queueFilter}
-        onQueueFilterChange={onQueueFilterChange}
-        availableQueueFilters={availableQueueFilters}
-        checkedSegmentIds={checkedSegmentIds}
-        onToggleSegmentChecked={onToggleSegmentChecked}
-        onSelectAllVisible={onSelectAllVisible}
-        onClearChecked={onClearChecked}
-        onBulkApprove={onBulkApprove}
-        onBulkSkip={onBulkSkip}
-        isBulkActionPending={isBulkActionPending}
-        isFetchingPage={isQueueFetchingPage}
-        pagination={queuePagination}
-        onPreviousPage={onQueuePreviousPage}
-        onNextPage={onQueueNextPage}
-        onNearEnd={onQueueNearEnd}
-      />
+          segments={state.segments}
+          selectedSegmentId={selectedSegment.id}
+          summary={fullState.queueSummary}
+          dirtySegmentIds={dirtySegmentIds}
+          onSelectSegment={(segmentId) => {
+            navigation.onSelectSegment(segmentId);
+            if (isCompact) {
+              setActivePanel("edit");
+            }
+          }}
+          search={queueSearch}
+          onSearchChange={onQueueSearchChange}
+          isSearching={isQueueSearchPending}
+          queueFilter={queueFilter}
+          onQueueFilterChange={onQueueFilterChange}
+          availableQueueFilters={availableQueueFilters}
+          checkedSegmentIds={checkedSegmentIds}
+          onToggleSegmentChecked={onToggleSegmentChecked}
+          onSelectAllVisible={onSelectAllVisible}
+          onClearChecked={onClearChecked}
+          onBulkApprove={onBulkApprove}
+          onBulkSkip={onBulkSkip}
+          isBulkActionPending={isBulkActionPending}
+          isFetchingPage={isQueueFetchingPage}
+          pagination={queuePagination}
+          onPreviousPage={onQueuePreviousPage}
+          onNextPage={onQueueNextPage}
+          onNearEnd={onQueueNearEnd}
+        />
       </CatPanelErrorBoundary>
     );
   }
@@ -227,19 +231,19 @@ export function CatWorkspaceView({
         resetKeys={[selectedSegment.id, selectedSegment.targetText]}
       >
         <CatIntelligencePanel
-        intelligence={selectedSegmentIntelligence}
-        targetText={selectedSegment.targetText}
-        isLookingUpContext={isLookingUpContext}
-        isConcordanceLoading={isConcordanceLoading}
-        isVisualContextLoading={isVisualContextLoading}
-        showAgentContext={showAgentContext}
-        showVisualContext={showVisualContext}
-        canEditTranslations={fullState.canEditTranslations !== false}
-        onUseTmMatch={(match) => editing.onUseTmMatch(selectedSegment.id, match)}
-        onUseGlossaryTerm={(term) =>
-          editing.onUseGlossaryTerm(selectedSegment.id, term, selectedSegment.sourceText)
-        }
-      />
+          intelligence={selectedSegmentIntelligence}
+          targetText={selectedSegment.targetText}
+          isLookingUpContext={isLookingUpContext}
+          isConcordanceLoading={isConcordanceLoading}
+          isVisualContextLoading={isVisualContextLoading}
+          showAgentContext={showAgentContext}
+          showVisualContext={showVisualContext}
+          canEditTranslations={fullState.canEditTranslations !== false}
+          onUseTmMatch={(match) => editing.onUseTmMatch(selectedSegment.id, match)}
+          onUseGlossaryTerm={(term) =>
+            editing.onUseGlossaryTerm(selectedSegment.id, term, selectedSegment.sourceText)
+          }
+        />
       </CatPanelErrorBoundary>
     );
   }

--- a/apps/hyperlocalise-web/src/components/cat/cat.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat.messages.ts
@@ -660,32 +660,33 @@ export const catVisualContextPanelMessages = defineMessages({
 export const catPanelErrorBoundaryMessages = defineMessages({
   queuePanelTitle: {
     defaultMessage: "Queue panel failed to load",
-    id: "kQp3mN8vXa",
+    id: "ppXDMSLgyj",
     description: "Error boundary title when the CAT queue panel crashes",
   },
   editorPanelTitle: {
     defaultMessage: "Editor panel failed to load",
-    id: "rTn7wL2bYc",
+    id: "6PFnjoc6zP",
     description: "Error boundary title when the CAT editor panel crashes",
   },
   intelligencePanelTitle: {
     defaultMessage: "Intelligence panel failed to load",
-    id: "hFs9dK4mZp",
+    id: "W5kKZQXtt1",
     description: "Error boundary title when the CAT intelligence panel crashes",
   },
   workspaceTitle: {
     defaultMessage: "CAT workspace failed to load",
-    id: "vBw6jR1nQe",
+    id: "Kdwno+5sGa",
     description: "Error boundary title when the full CAT workspace crashes",
   },
   description: {
-    defaultMessage: "Something went wrong in this part of the tool. You can retry or keep working in the other panels.",
-    id: "cDx8pM5tRu",
+    defaultMessage:
+      "Something went wrong in this part of the tool. You can retry or keep working in the other panels.",
+    id: "e7p8bFrcw5",
     description: "Error boundary description shown when a CAT panel crashes",
   },
   retry: {
     defaultMessage: "Try again",
-    id: "nGy2sV7wKf",
+    id: "27qrEmB3yO",
     description: "Button label to retry rendering a crashed CAT panel",
   },
 });

--- a/apps/hyperlocalise-web/src/components/cat/cat.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat.messages.ts
@@ -656,3 +656,36 @@ export const catVisualContextPanelMessages = defineMessages({
     description: "Accessible fallback label for a TMS screenshot preview image",
   },
 });
+
+export const catPanelErrorBoundaryMessages = defineMessages({
+  queuePanelTitle: {
+    defaultMessage: "Queue panel failed to load",
+    id: "kQp3mN8vXa",
+    description: "Error boundary title when the CAT queue panel crashes",
+  },
+  editorPanelTitle: {
+    defaultMessage: "Editor panel failed to load",
+    id: "rTn7wL2bYc",
+    description: "Error boundary title when the CAT editor panel crashes",
+  },
+  intelligencePanelTitle: {
+    defaultMessage: "Intelligence panel failed to load",
+    id: "hFs9dK4mZp",
+    description: "Error boundary title when the CAT intelligence panel crashes",
+  },
+  workspaceTitle: {
+    defaultMessage: "CAT workspace failed to load",
+    id: "vBw6jR1nQe",
+    description: "Error boundary title when the full CAT workspace crashes",
+  },
+  description: {
+    defaultMessage: "Something went wrong in this part of the tool. You can retry or keep working in the other panels.",
+    id: "cDx8pM5tRu",
+    description: "Error boundary description shown when a CAT panel crashes",
+  },
+  retry: {
+    defaultMessage: "Try again",
+    id: "nGy2sV7wKf",
+    description: "Button label to retry rendering a crashed CAT panel",
+  },
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `react-error-boundary` to the CAT tool so a runtime error in one panel does not crash the entire workspace.

- Installed `react-error-boundary`
- Added `CatPanelErrorBoundary` with scoped fallback UI, retry, and safe error logging
- Wrapped queue, editor, and intelligence panels in `cat-workspace.tsx`
- Wrapped the full workspace view in `cat-workspace-container.tsx` (unsaved-changes dialog stays outside the boundary)

## Behavior

When a panel throws during render, users see a localized error state for that panel only and can click **Try again**. Other panels keep working. Boundaries also reset when relevant data changes (selected segment, queue filter/search, pagination).

## Testing

- `vp check --fix` — passes for changed files (one pre-existing warning in `workos-adapter.ts`)
- `vp test src/components/cat/` — 53 tests passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e854b78-56cb-4408-a481-1fce214eda48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e854b78-56cb-4408-a481-1fce214eda48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

