### PR TITLE
fix(cat): improve queue status a11y and cross-platform shortcuts

### DIFF
--- a/apps/hyperlocalise-web/src/components/cat/cat-editor-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-editor-panel.tsx
@@ -13,15 +13,32 @@ import { Kbd, KbdGroup } from "@/components/ui/kbd";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { Textarea } from "@/components/ui/textarea";
+import { useIsMac } from "@/hooks/use-is-mac";
 import { cn } from "@/lib/primitives/cn";
 
 import { CatFormatChecks } from "./cat-format-checks";
 import { catEditorPanelMessages } from "./cat.messages";
 import { analyzeCatMessageFormat } from "./cat-message-format";
+import {
+  getCatShortcutKeys,
+  getCatShortcutLabel,
+  type CatEditorShortcut,
+} from "./cat-keyboard-shortcuts";
+import { SegmentStatusBadge } from "./cat-segment-status";
 import { CatIcuStructureSummary, CatMessagePreview, CatTargetEditor } from "./cat-target-editor";
 import type { CatFormatCheck, CatSegment, CatSegmentIntelligence } from "./types";
 
-function ShortcutKbd({ keys, className }: { keys: string[]; className?: string }) {
+function ShortcutKbd({
+  shortcut,
+  isMac,
+  className,
+}: {
+  shortcut: CatEditorShortcut;
+  isMac: boolean;
+  className?: string;
+}) {
+  const keys = getCatShortcutKeys(isMac, shortcut);
+
   return (
     <KbdGroup aria-hidden="true" className="ms-2 hidden items-center gap-1 lg:inline-flex">
       {keys.map((key) => (
@@ -118,6 +135,7 @@ export function CatEditorPanel({
   segmentShareUrl?: string | null;
 }) {
   const intl = useIntl();
+  const isMac = useIsMac();
   const [shareLinkState, setShareLinkState] = useState<"idle" | "copied" | "error">("idle");
   const resolvedPrimaryActionLabel =
     primaryActionLabel ?? intl.formatMessage(catEditorPanelMessages.approve);
@@ -132,6 +150,12 @@ export function CatEditorPanel({
     isAiSuggestionLoading ||
     isFormatChecksLoading;
   const canTriggerApprove = canApprove && !isActionBlocked;
+  const canTriggerFindContext =
+    canLookupContext &&
+    !isApproving &&
+    !isLookingUpContext &&
+    !isAiSuggestionLoading &&
+    !isFormatChecksLoading;
   const canEditTarget = canEditTranslations && !isEditorBusy;
   const sourceMessageAnalysis = useMemo(
     () => analyzeCatMessageFormat(segment.sourceText),
@@ -188,6 +212,20 @@ export function CatEditorPanel({
     [canTriggerApprove, onApprove],
   );
 
+  useHotkeys(
+    "mod+k",
+    (event) => {
+      event.preventDefault();
+      onAskQuestion();
+    },
+    {
+      enabled: canTriggerFindContext,
+      enableOnFormTags: false,
+      preventDefault: true,
+    },
+    [canTriggerFindContext, onAskQuestion],
+  );
+
   function handleCommentDraftChange(value: string) {
     setCommentDrafts((current) => ({ ...current, [segment.id]: value }));
   }
@@ -224,10 +262,11 @@ export function CatEditorPanel({
   return (
     <div className="flex h-full min-h-0 flex-col bg-background">
       <div className="flex flex-wrap items-center justify-between gap-3 border-b border-foreground/8 px-4 py-3 lg:px-5">
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           <span className="font-mono text-xs text-muted-foreground tabular-nums">
             {String(segmentPosition).padStart(2, "0")} / {String(totalSegments).padStart(2, "0")}
           </span>
+          <SegmentStatusBadge status={segment.status} />
           {isTargetDirty ? (
             <Badge variant="outline" className="border-bud-500/40 bg-bud-500/10 text-bud-300">
               <FormattedMessage {...catEditorPanelMessages.unsavedChanges} />
@@ -262,7 +301,9 @@ export function CatEditorPanel({
             onClick={onPrevious}
             disabled={!hasPreviousSegment}
             aria-label={intl.formatMessage(catEditorPanelMessages.previousSegmentAria)}
-            title={intl.formatMessage(catEditorPanelMessages.previousSegmentTitle)}
+            title={intl.formatMessage(catEditorPanelMessages.previousSegmentTitle, {
+              shortcut: getCatShortcutLabel(isMac, "previous"),
+            })}
           >
             <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
           </Button>
@@ -272,7 +313,9 @@ export function CatEditorPanel({
             onClick={onNext}
             disabled={!hasNextSegment}
             aria-label={intl.formatMessage(catEditorPanelMessages.nextSegmentAria)}
-            title={intl.formatMessage(catEditorPanelMessages.nextSegmentTitle)}
+            title={intl.formatMessage(catEditorPanelMessages.nextSegmentTitle, {
+              shortcut: getCatShortcutLabel(isMac, "next"),
+            })}
           >
             <HugeiconsIcon icon={ArrowRight01Icon} className="size-4" />
           </Button>
@@ -336,19 +379,13 @@ export function CatEditorPanel({
             >
               {isApproving ? <Spinner className="size-4 text-white" /> : null}
               {resolvedPrimaryActionLabel}
-              <ShortcutKbd keys={["⌘", "↵"]} className="bg-white/15 text-white" />
+              <ShortcutKbd shortcut="approve" isMac={isMac} className="bg-white/15 text-white" />
             </Button>
             <Button
               variant="outline"
               className="min-h-11 flex-1 sm:flex-none lg:min-h-0"
               onClick={onAskQuestion}
-              disabled={
-                !canLookupContext ||
-                isApproving ||
-                isLookingUpContext ||
-                isAiSuggestionLoading ||
-                isFormatChecksLoading
-              }
+              disabled={!canTriggerFindContext}
               title={
                 canLookupContext
                   ? intl.formatMessage(catEditorPanelMessages.findContextTitle)
@@ -361,7 +398,7 @@ export function CatEditorPanel({
               ) : (
                 <FormattedMessage {...catEditorPanelMessages.findContext} />
               )}
-              <ShortcutKbd keys={["⌘", "K"]} />
+              <ShortcutKbd shortcut="findContext" isMac={isMac} />
             </Button>
             <Button
               variant="ghost"
@@ -370,7 +407,7 @@ export function CatEditorPanel({
               disabled={isApproving || isLookingUpContext || !hasPreviousSegment}
             >
               <FormattedMessage {...catEditorPanelMessages.previous} />
-              <ShortcutKbd keys={["⌘", "←"]} />
+              <ShortcutKbd shortcut="previous" isMac={isMac} />
             </Button>
             <Button
               variant="ghost"
@@ -379,7 +416,7 @@ export function CatEditorPanel({
               disabled={isApproving || isLookingUpContext || !hasNextSegment}
             >
               <FormattedMessage {...catEditorPanelMessages.next} />
-              <ShortcutKbd keys={["⌘", "→"]} />
+              <ShortcutKbd shortcut="next" isMac={isMac} />
             </Button>
           </div>
 

--- a/apps/hyperlocalise-web/src/components/cat/cat-keyboard-shortcuts.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat-keyboard-shortcuts.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { getCatShortcutKeys, getCatShortcutLabel, getModKeyLabel } from "./cat-keyboard-shortcuts";
+
+describe("cat keyboard shortcuts", () => {
+  it("uses command key labels on macOS", () => {
+    expect(getModKeyLabel(true)).toBe("⌘");
+    expect(getCatShortcutKeys(true, "findContext")).toEqual(["⌘", "K"]);
+    expect(getCatShortcutLabel(true, "previous")).toBe("⌘←");
+  });
+
+  it("uses control key labels on Windows", () => {
+    expect(getModKeyLabel(false)).toBe("Ctrl");
+    expect(getCatShortcutKeys(false, "findContext")).toEqual(["Ctrl", "K"]);
+    expect(getCatShortcutLabel(false, "previous")).toBe("Ctrl+←");
+  });
+});

--- a/apps/hyperlocalise-web/src/components/cat/cat-keyboard-shortcuts.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat-keyboard-shortcuts.test.ts
@@ -5,13 +5,23 @@ import { getCatShortcutKeys, getCatShortcutLabel, getModKeyLabel } from "./cat-k
 describe("cat keyboard shortcuts", () => {
   it("uses command key labels on macOS", () => {
     expect(getModKeyLabel(true)).toBe("⌘");
+    expect(getCatShortcutKeys(true, "approve")).toEqual(["⌘", "↵"]);
     expect(getCatShortcutKeys(true, "findContext")).toEqual(["⌘", "K"]);
+    expect(getCatShortcutKeys(true, "previous")).toEqual(["⌘", "←"]);
+    expect(getCatShortcutKeys(true, "next")).toEqual(["⌘", "→"]);
+    expect(getCatShortcutLabel(true, "approve")).toBe("⌘↵");
     expect(getCatShortcutLabel(true, "previous")).toBe("⌘←");
+    expect(getCatShortcutLabel(true, "next")).toBe("⌘→");
   });
 
   it("uses control key labels on Windows", () => {
     expect(getModKeyLabel(false)).toBe("Ctrl");
+    expect(getCatShortcutKeys(false, "approve")).toEqual(["Ctrl", "Enter"]);
     expect(getCatShortcutKeys(false, "findContext")).toEqual(["Ctrl", "K"]);
+    expect(getCatShortcutKeys(false, "previous")).toEqual(["Ctrl", "←"]);
+    expect(getCatShortcutKeys(false, "next")).toEqual(["Ctrl", "→"]);
+    expect(getCatShortcutLabel(false, "approve")).toBe("Ctrl+Enter");
     expect(getCatShortcutLabel(false, "previous")).toBe("Ctrl+←");
+    expect(getCatShortcutLabel(false, "next")).toBe("Ctrl+→");
   });
 });

--- a/apps/hyperlocalise-web/src/components/cat/cat-keyboard-shortcuts.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat-keyboard-shortcuts.ts
@@ -1,0 +1,25 @@
+export type CatEditorShortcut = "approve" | "findContext" | "previous" | "next";
+
+export function getModKeyLabel(isMac: boolean): string {
+  return isMac ? "⌘" : "Ctrl";
+}
+
+export function getCatShortcutKeys(isMac: boolean, shortcut: CatEditorShortcut): string[] {
+  const mod = getModKeyLabel(isMac);
+
+  switch (shortcut) {
+    case "approve":
+      return [mod, isMac ? "↵" : "Enter"];
+    case "findContext":
+      return [mod, "K"];
+    case "previous":
+      return [mod, "←"];
+    case "next":
+      return [mod, "→"];
+  }
+}
+
+export function getCatShortcutLabel(isMac: boolean, shortcut: CatEditorShortcut): string {
+  const keys = getCatShortcutKeys(isMac, shortcut);
+  return isMac ? keys.join("") : keys.join("+");
+}

--- a/apps/hyperlocalise-web/src/components/cat/cat-queue-virtual-list.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-queue-virtual-list.tsx
@@ -7,21 +7,10 @@ import { useIntl } from "react-intl";
 import { cn } from "@/lib/primitives/cn";
 
 import { catQueuePanelMessages } from "./cat.messages";
+import { QueueStatusDot } from "./cat-segment-status";
 import type { CatSegment } from "./types";
 
 const ESTIMATED_ROW_HEIGHT = 72;
-
-function QueueStatusDot({ status }: { status: CatSegment["status"] }) {
-  if (status === "reviewed") {
-    return <span className="size-2.5 rounded-full bg-grove-300" />;
-  }
-
-  if (status === "needs_review") {
-    return <span className="size-2.5 rounded-full bg-bud-400" />;
-  }
-
-  return <span className="size-2.5 rounded-full border border-foreground/25" />;
-}
 
 export function CatQueueVirtualList({
   segments,

--- a/apps/hyperlocalise-web/src/components/cat/cat-segment-status.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-segment-status.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import type { MessageDescriptor } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/primitives/cn";
+
+import { catSegmentStatusMessages } from "./cat.messages";
+import { catToneClass, segmentStatusTone } from "./cat-tone";
+import type { CatSegmentStatus } from "./types";
+
+function getSegmentStatusMessage(status: CatSegmentStatus): MessageDescriptor {
+  switch (status) {
+    case "reviewed":
+      return catSegmentStatusMessages.reviewed;
+    case "needs_review":
+      return catSegmentStatusMessages.needsReview;
+    case "skipped":
+      return catSegmentStatusMessages.skipped;
+    default:
+      return catSegmentStatusMessages.pending;
+  }
+}
+
+function queueStatusDotClassName(status: CatSegmentStatus) {
+  if (status === "reviewed") {
+    return "size-2.5 rounded-full bg-grove-300";
+  }
+
+  if (status === "needs_review") {
+    return "size-2.5 rounded-full bg-bud-400";
+  }
+
+  return "size-2.5 rounded-full border border-foreground/25";
+}
+
+export function QueueStatusDot({ status }: { status: CatSegmentStatus }) {
+  const intl = useIntl();
+  const statusLabel = intl.formatMessage(getSegmentStatusMessage(status));
+
+  return (
+    <span
+      role="img"
+      aria-label={intl.formatMessage(catSegmentStatusMessages.statusDotAria, {
+        status: statusLabel,
+      })}
+      className={queueStatusDotClassName(status)}
+    />
+  );
+}
+
+export function SegmentStatusBadge({ status }: { status: CatSegmentStatus }) {
+  return (
+    <Badge variant="outline" className={cn(catToneClass(segmentStatusTone(status)))}>
+      <FormattedMessage {...getSegmentStatusMessage(status)} />
+    </Badge>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/cat/cat.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat.messages.ts
@@ -159,6 +159,34 @@ export const catQueuePanelMessages = defineMessages({
   },
 });
 
+export const catSegmentStatusMessages = defineMessages({
+  pending: {
+    defaultMessage: "Untranslated",
+    id: "pmgrWye2G2",
+    description: "CAT segment status label for segments without a target translation",
+  },
+  needsReview: {
+    defaultMessage: "Needs review",
+    id: "18VKZNqtbO",
+    description: "CAT segment status label for translated segments awaiting review",
+  },
+  reviewed: {
+    defaultMessage: "Approved",
+    id: "kGM2czQvBa",
+    description: "CAT segment status label for approved segments",
+  },
+  skipped: {
+    defaultMessage: "Skipped",
+    id: "9Pt2hFyO/v",
+    description: "CAT segment status label for skipped segments",
+  },
+  statusDotAria: {
+    defaultMessage: "Status: {status}",
+    id: "ecBrADENW6",
+    description: "Accessible label for segment status indicator dot in the CAT queue",
+  },
+});
+
 export const catGlossaryChecksMessages = defineMessages({
   complianceLabel: {
     defaultMessage: "Glossary compliance",
@@ -463,13 +491,13 @@ export const catEditorPanelMessages = defineMessages({
     description: "Accessible label for the next segment navigation button",
   },
   previousSegmentTitle: {
-    defaultMessage: "Previous segment (⌘←)",
-    id: "fjCr7YjlbN",
+    defaultMessage: "Previous segment ({shortcut})",
+    id: "VGayu+ZFkL",
     description: "Tooltip for the previous segment navigation button",
   },
   nextSegmentTitle: {
-    defaultMessage: "Next segment (⌘→)",
-    id: "A4pgNxiL6F",
+    defaultMessage: "Next segment ({shortcut})",
+    id: "kHLqanH9yi",
     description: "Tooltip for the next segment navigation button",
   },
   sourceHeading: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

- Queue status dots now expose screen-reader labels (`Status: Approved`, etc.) instead of relying on color alone.
- The editor panel header shows a text status badge (Untranslated / Needs review / Approved / Skipped) for the current segment.
- **Find context** is now bound to `mod+K` / `Ctrl+K`, matching the shortcut shown in the toolbar.
- Keyboard hints in the editor adapt to the platform: `⌘` on macOS, `Ctrl` on Windows/Linux.

## How to test

1. Open a CAT workspace with segments in different statuses.
2. Confirm the queue dots have accessible names (inspect with a screen reader or DevTools accessibility tree).
3. Select a segment and verify the status badge appears in the editor header next to the segment counter.
4. Press `Ctrl+K` (Windows/Linux) or `⌘K` (macOS) to trigger **Find context**.
5. Confirm shortcut labels show `Ctrl` on non-Mac platforms and `⌘` on Mac.

```bash
cd apps/hyperlocalise-web && vp test src/components/cat/cat-keyboard-shortcuts.test.ts
cd apps/hyperlocalise-web && vp check --fix
```

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, `vp test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-481963bd-7e78-485e-b569-c35a0d9d8662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-481963bd-7e78-485e-b569-c35a0d9d8662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

