### PR TITLE
feat(cat): support Crowdin issue comments in CAT workspace

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
@@ -766,7 +766,6 @@ describe("project file CAT routes", () => {
         },
         json: {
           sourcePath: "crowdin/home.json",
-          targetLocale: "fr",
           externalResourceId: "101",
         },
       },

--- a/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
@@ -22,6 +22,7 @@ const {
   getTmsProviderLiveCatFileMock,
   saveTmsProviderLiveCatTranslationMock,
   saveTmsProviderLiveCatCommentMock,
+  resolveTmsProviderLiveCatCommentMock,
   loadCatSegmentConcordanceMock,
   loadCatSegmentVisualContextMock,
   generateCatAiRecommendationMock,
@@ -31,6 +32,7 @@ const {
   getTmsProviderLiveCatFileMock: vi.fn(),
   saveTmsProviderLiveCatTranslationMock: vi.fn(),
   saveTmsProviderLiveCatCommentMock: vi.fn(),
+  resolveTmsProviderLiveCatCommentMock: vi.fn(),
   loadCatSegmentConcordanceMock: vi.fn(),
   loadCatSegmentVisualContextMock: vi.fn(),
   generateCatAiRecommendationMock: vi.fn(),
@@ -64,6 +66,8 @@ vi.mock("@/lib/providers/tms-provider-live", async (importOriginal) => {
       saveTmsProviderLiveCatTranslationMock(...args),
     saveTmsProviderLiveCatComment: (...args: unknown[]) =>
       saveTmsProviderLiveCatCommentMock(...args),
+    resolveTmsProviderLiveCatComment: (...args: unknown[]) =>
+      resolveTmsProviderLiveCatCommentMock(...args),
   };
 });
 
@@ -683,6 +687,100 @@ describe("project file CAT routes", () => {
         externalResourceId: "101",
         text: "Please clarify tone.",
         type: undefined,
+        issueType: undefined,
+      },
+      expect.objectContaining({ actorUserId: expect.any(String) }),
+    );
+  });
+
+  it("posts Crowdin CAT issues with issue type for users with write-back permission", async () => {
+    const translator = projectFixture.createWorkosIdentityWithRole("translator");
+    saveTmsProviderLiveCatCommentMock.mockResolvedValue({
+      externalCommentId: "5002",
+      type: "issue",
+      status: "unresolved",
+      text: "Wrong tone.",
+      createdAt: "2026-06-19T00:00:00.000Z",
+      locale: "fr",
+      author: "Reviewer",
+    });
+
+    const response = await client.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].files.detail.cat.comments.$post(
+      {
+        param: {
+          organizationSlug: translator.organization.slug ?? "missing-slug",
+          projectId: "ext:crowdin:42",
+        },
+        json: {
+          sourcePath: "crowdin/home.json",
+          targetLocale: "fr",
+          externalStringId: "1001",
+          externalResourceId: "101",
+          text: "Wrong tone.",
+          type: "issue",
+          issueType: "translation_mistake",
+        },
+      },
+      { headers: await projectFixture.authHeadersFor(translator) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(saveTmsProviderLiveCatCommentMock).toHaveBeenCalledWith(
+      expect.any(String),
+      "42",
+      "crowdin/home.json",
+      {
+        targetLocale: "fr",
+        externalStringId: "1001",
+        externalResourceId: "101",
+        text: "Wrong tone.",
+        type: "issue",
+        issueType: "translation_mistake",
+      },
+      expect.objectContaining({ actorUserId: expect.any(String) }),
+    );
+  });
+
+  it("resolves Crowdin CAT issues for users with write-back permission", async () => {
+    const translator = projectFixture.createWorkosIdentityWithRole("translator");
+    resolveTmsProviderLiveCatCommentMock.mockResolvedValue({
+      externalCommentId: "5002",
+      type: "issue",
+      status: "resolved",
+      text: "Wrong tone.",
+      createdAt: "2026-06-19T00:00:00.000Z",
+      locale: "fr",
+      author: "Reviewer",
+    });
+
+    const response = await client.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].files.detail.cat.comments[":commentId"].resolve.$patch(
+      {
+        param: {
+          organizationSlug: translator.organization.slug ?? "missing-slug",
+          projectId: "ext:crowdin:42",
+          commentId: "5002",
+        },
+        json: {
+          sourcePath: "crowdin/home.json",
+          targetLocale: "fr",
+          externalResourceId: "101",
+        },
+      },
+      { headers: await projectFixture.authHeadersFor(translator) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(resolveTmsProviderLiveCatCommentMock).toHaveBeenCalledWith(
+      expect.any(String),
+      "42",
+      "crowdin/home.json",
+      {
+        externalCommentId: "5002",
+        externalResourceId: "101",
       },
       expect.objectContaining({ actorUserId: expect.any(String) }),
     );

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -33,6 +33,7 @@ import {
   listTmsProviderLiveFilesForProject,
   saveTmsProviderLiveCatTranslation,
   saveTmsProviderLiveCatComment,
+  resolveTmsProviderLiveCatComment,
 } from "@/lib/providers/tms-provider-live";
 import { listOrganizationProjects } from "@/lib/projects/organization/organization-project-service";
 import {
@@ -70,6 +71,7 @@ import {
   projectFileCatQuerySchema,
   projectFileCatConcordanceBodySchema,
   projectFileCatCommentBodySchema,
+  projectFileCatCommentResolveBodySchema,
   projectFileCatRecommendationBodySchema,
   projectFileCatStatusBodySchema,
   projectFileCatTranslationBodySchema,
@@ -81,6 +83,7 @@ import {
   projectFileTranslationDownloadQuerySchema,
   projectFilesQuerySchema,
   projectIdParamsSchema,
+  projectFileCatCommentIdParamsSchema,
   updateProjectBodySchema,
   type CreateProjectBody,
   type UpdateProjectBody,
@@ -338,6 +341,16 @@ const validateProjectParams = validator("param", (value, c) => {
   return parsed.data;
 });
 
+const validateProjectFileCatCommentIdParams = validator("param", (value, c) => {
+  const parsed = projectFileCatCommentIdParamsSchema.safeParse(value);
+
+  if (!parsed.success) {
+    return invalidProjectPayloadResponse(c);
+  }
+
+  return parsed.data;
+});
+
 const validateProjectFileDetailQuery = validator("query", (value, c) => {
   const parsed = projectFileDetailQuerySchema.safeParse(value);
 
@@ -370,6 +383,16 @@ const validateProjectFileCatTranslationBody = validator("json", (value, c) => {
 
 const validateProjectFileCatCommentBody = validator("json", (value, c) => {
   const parsed = projectFileCatCommentBodySchema.safeParse(value);
+
+  if (!parsed.success) {
+    return invalidProjectPayloadResponse(c);
+  }
+
+  return parsed.data;
+});
+
+const validateProjectFileCatCommentResolveBody = validator("json", (value, c) => {
+  const parsed = projectFileCatCommentResolveBodySchema.safeParse(value);
 
   if (!parsed.success) {
     return invalidProjectPayloadResponse(c);
@@ -737,6 +760,52 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
               externalResourceId: body.externalResourceId,
               text: body.text,
               type: body.type,
+              issueType: body.issueType,
+            },
+            { actorUserId: c.var.auth.user.localUserId },
+          );
+          if (!comment) {
+            return projectNotFoundResponse(c);
+          }
+
+          return c.json({ comment }, 200);
+        } catch (error) {
+          return tmsProviderLiveErrorResponse(c, error);
+        }
+      },
+    )
+    .patch(
+      "/:projectId/files/detail/cat/comments/:commentId/resolve",
+      validateProjectFileCatCommentIdParams,
+      validateProjectFileCatCommentResolveBody,
+      async (c) => {
+        if (!isWriteBackTranslationAllowed(c.var.auth.membership.role)) {
+          return forbiddenResponse(c);
+        }
+
+        const params = c.req.valid("param");
+        const body = c.req.valid("json");
+        const target = await resolveProjectResourceTarget(c.var.auth, params.projectId);
+        if (target.kind === "provider_unavailable") {
+          return providerProjectUnavailableResponse(c, target);
+        }
+
+        if (target.kind !== "provider") {
+          return badRequestResponse(
+            c,
+            "provider_cat_unsupported",
+            "CAT comments are only available for provider-connected projects.",
+          );
+        }
+
+        try {
+          const comment = await resolveTmsProviderLiveCatComment(
+            c.var.auth.organization.localOrganizationId,
+            target.externalProjectId,
+            body.sourcePath,
+            {
+              externalCommentId: params.commentId,
+              externalResourceId: body.externalResourceId,
             },
             { actorUserId: c.var.auth.user.localUserId },
           );

--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -529,7 +529,6 @@ export const projectFileCatCommentResponseSchema = z.object({
 
 export const projectFileCatCommentResolveBodySchema = z.object({
   sourcePath: z.string().trim().min(1).max(2048),
-  targetLocale: z.string().trim().min(1).max(32),
   externalResourceId: z.string().trim().min(1).max(128).optional(),
 });
 

--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -11,6 +11,10 @@ export const projectIdParamsSchema = z.object({
   projectId: projectIdSchema,
 });
 
+export const projectFileCatCommentIdParamsSchema = projectIdParamsSchema.extend({
+  commentId: z.string().trim().min(1).max(128),
+});
+
 export const externalTmsContentSyncBodySchema = z.object({
   externalJobId: z.string().trim().min(1).max(128),
 });
@@ -502,6 +506,13 @@ export const projectFileCatCommentSchema = z.object({
   author: z.string().nullable().optional(),
 });
 
+export const crowdinIssueTypes = [
+  "general_question",
+  "translation_mistake",
+  "context_request",
+  "source_mistake",
+] as const;
+
 export const projectFileCatCommentBodySchema = z.object({
   sourcePath: z.string().trim().min(1).max(2048),
   targetLocale: z.string().trim().min(1).max(32),
@@ -509,9 +520,20 @@ export const projectFileCatCommentBodySchema = z.object({
   externalResourceId: z.string().trim().min(1).max(128).optional(),
   text: z.string().trim().min(1).max(16_384),
   type: z.enum(["comment", "issue"]).optional(),
+  issueType: z.enum(crowdinIssueTypes).optional(),
 });
 
 export const projectFileCatCommentResponseSchema = z.object({
+  comment: projectFileCatCommentSchema,
+});
+
+export const projectFileCatCommentResolveBodySchema = z.object({
+  sourcePath: z.string().trim().min(1).max(2048),
+  targetLocale: z.string().trim().min(1).max(32),
+  externalResourceId: z.string().trim().min(1).max(128).optional(),
+});
+
+export const projectFileCatCommentResolveResponseSchema = z.object({
   comment: projectFileCatCommentSchema,
 });
 
@@ -589,6 +611,12 @@ export type ProjectFileDetailResponse = z.infer<typeof projectFileDetailResponse
 export type ProjectFileCatComment = z.infer<typeof projectFileCatCommentSchema>;
 export type ProjectFileCatCommentBody = z.infer<typeof projectFileCatCommentBodySchema>;
 export type ProjectFileCatCommentResponse = z.infer<typeof projectFileCatCommentResponseSchema>;
+export type ProjectFileCatCommentResolveBody = z.infer<
+  typeof projectFileCatCommentResolveBodySchema
+>;
+export type ProjectFileCatCommentResolveResponse = z.infer<
+  typeof projectFileCatCommentResolveResponseSchema
+>;
 export type ProjectFileCatTranslation = z.infer<typeof projectFileCatTranslationSchema>;
 export type ProjectFileCatSegment = z.infer<typeof projectFileCatSegmentSchema>;
 export type ProjectFileCatQueueSummary = z.infer<typeof projectFileCatQueueSummarySchema>;

--- a/apps/hyperlocalise-web/src/components/cat/cat-editor-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-editor-panel.tsx
@@ -24,6 +24,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/primitives/cn";
 
 import { CatFormatChecks } from "./cat-format-checks";
+import { isOpenIssueStatus } from "./cat-queue-filter";
 import { catEditorPanelMessages } from "./cat.messages";
 import { analyzeCatMessageFormat } from "./cat-message-format";
 import { CatIcuStructureSummary, CatMessagePreview, CatTargetEditor } from "./cat-target-editor";
@@ -61,10 +62,6 @@ function formatCommentTimestamp(intl: IntlShape, createdAt: string) {
     hour: "numeric",
     minute: "2-digit",
   });
-}
-
-function isOpenIssueStatus(status: string | null | undefined) {
-  return status === "open" || status === "unresolved";
 }
 
 const crowdinIssueTypeOptions: Array<{

--- a/apps/hyperlocalise-web/src/components/cat/cat-editor-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-editor-panel.tsx
@@ -10,8 +10,16 @@ import { FormattedMessage, useIntl, type IntlShape } from "react-intl";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Kbd, KbdGroup } from "@/components/ui/kbd";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/primitives/cn";
 
@@ -19,7 +27,14 @@ import { CatFormatChecks } from "./cat-format-checks";
 import { catEditorPanelMessages } from "./cat.messages";
 import { analyzeCatMessageFormat } from "./cat-message-format";
 import { CatIcuStructureSummary, CatMessagePreview, CatTargetEditor } from "./cat-target-editor";
-import type { CatFormatCheck, CatSegment, CatSegmentIntelligence } from "./types";
+import type {
+  CatFormatCheck,
+  CatSegment,
+  CatSegmentCommentInput,
+  CatSegmentCommentType,
+  CatSegmentIntelligence,
+  CrowdinIssueType,
+} from "./types";
 
 function ShortcutKbd({ keys, className }: { keys: string[]; className?: string }) {
   return (
@@ -48,6 +63,20 @@ function formatCommentTimestamp(intl: IntlShape, createdAt: string) {
   });
 }
 
+function isOpenIssueStatus(status: string | null | undefined) {
+  return status === "open" || status === "unresolved";
+}
+
+const crowdinIssueTypeOptions: Array<{
+  value: CrowdinIssueType;
+  message: (typeof catEditorPanelMessages)[keyof typeof catEditorPanelMessages];
+}> = [
+  { value: "general_question", message: catEditorPanelMessages.issueTypeGeneralQuestion },
+  { value: "translation_mistake", message: catEditorPanelMessages.issueTypeTranslationMistake },
+  { value: "context_request", message: catEditorPanelMessages.issueTypeContextRequest },
+  { value: "source_mistake", message: catEditorPanelMessages.issueTypeSourceMistake },
+];
+
 export function CatEditorPanel({
   segment,
   segmentPosition,
@@ -66,13 +95,17 @@ export function CatEditorPanel({
   canUseAiRecommendation = false,
   isTargetDirty = false,
   isPostingComment = false,
+  isResolvingComment = false,
+  resolvingCommentId = null,
   commentPostError,
+  providerKind = null,
   onTargetChange,
   onCopySource,
   onClearTarget,
   onUseAiSuggestion,
   onApprove,
   onAddComment,
+  onResolveComment,
   primaryActionLabel,
   onAskQuestion,
   onGenerateAiRecommendation,
@@ -100,13 +133,16 @@ export function CatEditorPanel({
   canUseAiRecommendation?: boolean;
   isTargetDirty?: boolean;
   isPostingComment?: boolean;
+  isResolvingComment?: boolean;
+  resolvingCommentId?: string | null;
   commentPostError?: string;
   onTargetChange: (value: string) => void;
   onCopySource: () => void;
   onClearTarget: () => void;
   onUseAiSuggestion: () => void;
   onApprove: () => void;
-  onAddComment?: (text: string) => void | Promise<void>;
+  onAddComment?: (input: CatSegmentCommentInput) => void | Promise<void>;
+  onResolveComment?: (commentId: string) => void | Promise<void>;
   primaryActionLabel?: string;
   onAskQuestion: () => void;
   onGenerateAiRecommendation?: () => void;
@@ -116,15 +152,23 @@ export function CatEditorPanel({
   hasPreviousSegment: boolean;
   hasNextSegment: boolean;
   segmentShareUrl?: string | null;
+  providerKind?: string | null;
 }) {
   const intl = useIntl();
   const [shareLinkState, setShareLinkState] = useState<"idle" | "copied" | "error">("idle");
   const resolvedPrimaryActionLabel =
     primaryActionLabel ?? intl.formatMessage(catEditorPanelMessages.approve);
   const [commentDrafts, setCommentDrafts] = useState<Record<string, string>>({});
+  const [commentInputTypes, setCommentInputTypes] = useState<Record<string, CatSegmentCommentType>>(
+    {},
+  );
+  const [issueTypes, setIssueTypes] = useState<Record<string, CrowdinIssueType>>({});
   const commentDraft = commentDrafts[segment.id] ?? "";
+  const commentInputType = commentInputTypes[segment.id] ?? "comment";
+  const issueType = issueTypes[segment.id] ?? "general_question";
   const segmentComments = segment.comments ?? [];
   const trimmedCommentDraft = commentDraft.trim();
+  const supportsCrowdinIssues = providerKind === "crowdin" && canAddComment;
   const isActionBlocked =
     isApproving ||
     isPostingComment ||
@@ -197,8 +241,36 @@ export function CatEditorPanel({
       return;
     }
 
-    await onAddComment(trimmedCommentDraft);
+    const input: CatSegmentCommentInput = {
+      text: trimmedCommentDraft,
+      ...(supportsCrowdinIssues && commentInputType === "issue"
+        ? { type: "issue" as const, issueType }
+        : {}),
+    };
+
+    await onAddComment(input);
     handleCommentDraftChange("");
+  }
+
+  function handleCommentInputTypeChange(value: string) {
+    if (value !== "comment" && value !== "issue") {
+      return;
+    }
+
+    setCommentInputTypes((current) => ({ ...current, [segment.id]: value }));
+  }
+
+  function handleIssueTypeChange(value: CrowdinIssueType | null) {
+    if (
+      value !== "general_question" &&
+      value !== "translation_mistake" &&
+      value !== "context_request" &&
+      value !== "source_mistake"
+    ) {
+      return;
+    }
+
+    setIssueTypes((current) => ({ ...current, [segment.id]: value }));
   }
 
   async function handleShareSegment() {
@@ -509,6 +581,31 @@ export function CatEditorPanel({
                       {comment.status ? <span className="capitalize">{comment.status}</span> : null}
                     </div>
                     <p className="text-sm leading-relaxed text-foreground/88">{comment.text}</p>
+                    {comment.type === "issue" &&
+                    isOpenIssueStatus(comment.status) &&
+                    onResolveComment ? (
+                      <div className="flex justify-end pt-1">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => void onResolveComment(comment.id)}
+                          disabled={
+                            isResolvingComment ||
+                            isPostingComment ||
+                            (resolvingCommentId !== null && resolvingCommentId !== comment.id)
+                          }
+                        >
+                          {isResolvingComment && resolvingCommentId === comment.id ? (
+                            <Spinner className="size-4" />
+                          ) : null}
+                          {isResolvingComment && resolvingCommentId === comment.id ? (
+                            <FormattedMessage {...catEditorPanelMessages.resolvingIssue} />
+                          ) : (
+                            <FormattedMessage {...catEditorPanelMessages.resolveIssue} />
+                          )}
+                        </Button>
+                      </div>
+                    ) : null}
                   </li>
                 ))}
               </ul>
@@ -522,9 +619,42 @@ export function CatEditorPanel({
               onChange={(event) => handleCommentDraftChange(event.currentTarget.value)}
               className="min-h-20 resize-y rounded-xl border-foreground/12 bg-background px-3 py-3 text-sm leading-relaxed"
               placeholder={intl.formatMessage(catEditorPanelMessages.commentPlaceholder)}
-              disabled={!canAddComment || isPostingComment}
+              disabled={!canAddComment || isPostingComment || isResolvingComment}
               data-cat-comment-input="true"
             />
+            {supportsCrowdinIssues ? (
+              <div className="flex flex-wrap items-center gap-3">
+                <Tabs value={commentInputType} onValueChange={handleCommentInputTypeChange}>
+                  <TabsList className="h-8">
+                    <TabsTrigger value="comment" className="px-3 text-xs">
+                      <FormattedMessage {...catEditorPanelMessages.commentTypeComment} />
+                    </TabsTrigger>
+                    <TabsTrigger value="issue" className="px-3 text-xs">
+                      <FormattedMessage {...catEditorPanelMessages.commentTypeIssue} />
+                    </TabsTrigger>
+                  </TabsList>
+                </Tabs>
+                {commentInputType === "issue" ? (
+                  <div className="flex min-w-48 flex-1 items-center gap-2">
+                    <span className="text-xs text-muted-foreground">
+                      <FormattedMessage {...catEditorPanelMessages.issueTypeLabel} />
+                    </span>
+                    <Select value={issueType} onValueChange={handleIssueTypeChange}>
+                      <SelectTrigger className="h-8 flex-1 text-xs">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {crowdinIssueTypeOptions.map((option) => (
+                          <SelectItem key={option.value} value={option.value}>
+                            <FormattedMessage {...option.message} />
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
             {commentPostError ? <p className="text-sm text-flame-100">{commentPostError}</p> : null}
             <div className="flex justify-end">
               <Button
@@ -532,12 +662,18 @@ export function CatEditorPanel({
                 size="sm"
                 onClick={() => void handleAddComment()}
                 disabled={
-                  !canAddComment || !trimmedCommentDraft || isPostingComment || !onAddComment
+                  !canAddComment ||
+                  !trimmedCommentDraft ||
+                  isPostingComment ||
+                  isResolvingComment ||
+                  !onAddComment
                 }
               >
                 {isPostingComment ? <Spinner className="size-4" /> : null}
                 {isPostingComment ? (
                   <FormattedMessage {...catEditorPanelMessages.postingComment} />
+                ) : supportsCrowdinIssues && commentInputType === "issue" ? (
+                  <FormattedMessage {...catEditorPanelMessages.addIssue} />
                 ) : (
                   <FormattedMessage {...catEditorPanelMessages.addComment} />
                 )}

--- a/apps/hyperlocalise-web/src/components/cat/cat-queue-filter.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat-queue-filter.test.ts
@@ -57,6 +57,25 @@ describe("segmentMatchesQueueFilter", () => {
     expect(segmentMatchesQueueFilter(withIssue, "needs_review")).toBe(false);
   });
 
+  it("treats Crowdin unresolved issue status as open", () => {
+    const withUnresolvedIssue = createSegment({
+      status: "needs_review",
+      comments: [
+        {
+          id: "c-1",
+          type: "issue",
+          status: "unresolved",
+          text: "Wrong tone",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          locale: "vi",
+        },
+      ],
+    });
+
+    expect(segmentMatchesQueueFilter(withUnresolvedIssue, "has_issues")).toBe(true);
+    expect(segmentMatchesQueueFilter(withUnresolvedIssue, "needs_review")).toBe(false);
+  });
+
   it("ignores resolved issue comments for the has issues filter", () => {
     const withResolvedIssue = createSegment({
       status: "needs_review",

--- a/apps/hyperlocalise-web/src/components/cat/cat-queue-filter.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat-queue-filter.ts
@@ -56,7 +56,7 @@ export function findSegmentIdByKeyOrId(segments: CatSegment[], segmentIdOrKey: s
   return match?.id ?? null;
 }
 
-function isOpenIssueStatus(status: string | null | undefined) {
+export function isOpenIssueStatus(status: string | null | undefined) {
   return status === "open" || status === "unresolved";
 }
 

--- a/apps/hyperlocalise-web/src/components/cat/cat-queue-filter.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat-queue-filter.ts
@@ -56,10 +56,15 @@ export function findSegmentIdByKeyOrId(segments: CatSegment[], segmentIdOrKey: s
   return match?.id ?? null;
 }
 
+function isOpenIssueStatus(status: string | null | undefined) {
+  return status === "open" || status === "unresolved";
+}
+
 export function segmentHasOpenIssues(segment: CatSegment) {
   return (
-    segment.comments?.some((comment) => comment.type === "issue" && comment.status === "open") ??
-    false
+    segment.comments?.some(
+      (comment) => comment.type === "issue" && isOpenIssueStatus(comment.status),
+    ) ?? false
   );
 }
 

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
@@ -54,6 +54,7 @@ import type {
   CatFormatCheck,
   CatGlossaryTerm,
   CatSegment,
+  CatSegmentCommentInput,
   CatTranslationMemoryMatch,
   CatWorkspaceState,
 } from "./types";
@@ -323,6 +324,8 @@ export function CatWorkspaceContainer({
   const [isValidating, setIsValidating] = useState(false);
   const [isApproving, setIsApproving] = useState(false);
   const [isPostingComment, setIsPostingComment] = useState(false);
+  const [isResolvingComment, setIsResolvingComment] = useState(false);
+  const [resolvingCommentId, setResolvingCommentId] = useState<string | null>(null);
   const [commentPostError, setCommentPostError] = useState<string | undefined>();
   const [isLookingUpContext, setIsLookingUpContext] = useState(false);
   const [isLoadingConcordance, setIsLoadingConcordance] = useState(false);
@@ -366,6 +369,7 @@ export function CatWorkspaceContainer({
   const onUseAiSuggestion = editingOverrides?.onUseAiSuggestion;
   const onApprove = reviewOverrides?.onApprove;
   const onAddComment = reviewOverrides?.onAddComment;
+  const onResolveComment = reviewOverrides?.onResolveComment;
   const onAskQuestion = reviewOverrides?.onAskQuestion;
   const onReviewWithAi = reviewOverrides?.onReviewWithAi;
   const onSkip = reviewOverrides?.onSkip;
@@ -1009,7 +1013,7 @@ export function CatWorkspaceContainer({
           setIsApproving(false);
         }
       },
-      onAddComment: async (segmentId: string, text: string) => {
+      onAddComment: async (segmentId: string, input: CatSegmentCommentInput) => {
         if (!onAddComment) {
           return;
         }
@@ -1017,7 +1021,7 @@ export function CatWorkspaceContainer({
         setCommentPostError(undefined);
         setIsPostingComment(true);
         try {
-          await onAddComment(segmentId, text);
+          await onAddComment(segmentId, input);
         } catch (error) {
           const message =
             error instanceof Error
@@ -1027,6 +1031,28 @@ export function CatWorkspaceContainer({
           throw error;
         } finally {
           setIsPostingComment(false);
+        }
+      },
+      onResolveComment: async (segmentId: string, commentId: string) => {
+        if (!onResolveComment) {
+          return;
+        }
+
+        setCommentPostError(undefined);
+        setResolvingCommentId(commentId);
+        setIsResolvingComment(true);
+        try {
+          await onResolveComment(segmentId, commentId);
+        } catch (error) {
+          const message =
+            error instanceof Error
+              ? error.message
+              : intl.formatMessage(catEditorPanelMessages.commentResolveFailed);
+          setCommentPostError(message);
+          throw error;
+        } finally {
+          setIsResolvingComment(false);
+          setResolvingCommentId(null);
         }
       },
       onAskQuestion: async (segmentId: string) => {
@@ -1135,6 +1161,7 @@ export function CatWorkspaceContainer({
     attemptSegmentNavigation,
     onApprove,
     onAddComment,
+    onResolveComment,
     onAskQuestion,
     intl,
     onNextSegment,
@@ -1264,6 +1291,8 @@ export function CatWorkspaceContainer({
         isValidating={isValidating}
         isApproving={isApproving}
         isPostingComment={isPostingComment}
+        isResolvingComment={isResolvingComment}
+        resolvingCommentId={resolvingCommentId}
         commentPostError={commentPostError}
         isLookingUpContext={isLookingUpContext}
         isConcordanceLoading={isLoadingConcordance}

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace.tsx
@@ -43,6 +43,8 @@ export function CatWorkspaceView({
   isValidating: _isValidating = false,
   isApproving = false,
   isPostingComment = false,
+  isResolvingComment = false,
+  resolvingCommentId = null,
   commentPostError,
   isLookingUpContext = false,
   isConcordanceLoading = false,
@@ -142,7 +144,10 @@ export function CatWorkspaceView({
         isAiSuggestionLoading={isAiSuggestionLoading}
         isFormatChecksLoading={isFormatChecksLoading}
         isPostingComment={isPostingComment}
+        isResolvingComment={isResolvingComment}
+        resolvingCommentId={resolvingCommentId}
         commentPostError={commentPostError}
+        providerKind={fullState.providerKind ?? null}
         canApprove={canApprove}
         canAddComment={canAddComment}
         canEditTranslations={canApprove}
@@ -157,7 +162,12 @@ export function CatWorkspaceView({
         onApprove={() => void review.onApprove(selectedSegment.id, selectedSegment.targetText)}
         onAddComment={
           review.onAddComment
-            ? (text) => review.onAddComment?.(selectedSegment.id, text)
+            ? (input) => review.onAddComment?.(selectedSegment.id, input)
+            : undefined
+        }
+        onResolveComment={
+          review.onResolveComment
+            ? (commentId) => review.onResolveComment?.(selectedSegment.id, commentId)
             : undefined
         }
         primaryActionLabel={fullState.primaryActionLabel}

--- a/apps/hyperlocalise-web/src/components/cat/cat.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat.messages.ts
@@ -592,10 +592,65 @@ export const catEditorPanelMessages = defineMessages({
     id: "wAW00AgfLK",
     description: "Error message when posting a segment comment to the TMS fails",
   },
+  commentResolveFailed: {
+    defaultMessage: "Failed to resolve issue. Try again.",
+    id: "i6rHhL31CZ",
+    description: "Error message when resolving a Crowdin issue comment fails",
+  },
   postingComment: {
     defaultMessage: "Posting…",
     id: "j+ggKPYEzH",
     description: "Button label while a segment comment is being posted to the TMS",
+  },
+  commentTypeComment: {
+    defaultMessage: "Comment",
+    id: "yn7Eufu4t+",
+    description: "Toggle option to post a plain comment to Crowdin",
+  },
+  commentTypeIssue: {
+    defaultMessage: "Issue",
+    id: "qHwoyBJJm0",
+    description: "Toggle option to raise a Crowdin issue on the current segment",
+  },
+  addIssue: {
+    defaultMessage: "Raise issue",
+    id: "cIUvYdnnCL",
+    description: "Button to submit a new Crowdin issue on the current segment",
+  },
+  resolveIssue: {
+    defaultMessage: "Resolve",
+    id: "gOG3lApYkM",
+    description: "Button to mark a Crowdin issue comment as resolved",
+  },
+  resolvingIssue: {
+    defaultMessage: "Resolving…",
+    id: "E8rEmEqTpX",
+    description: "Button label while a Crowdin issue is being resolved",
+  },
+  issueTypeGeneralQuestion: {
+    defaultMessage: "General question",
+    id: "2oU/YE7MsU",
+    description: "Crowdin issue type for general questions",
+  },
+  issueTypeTranslationMistake: {
+    defaultMessage: "Translation mistake",
+    id: "p83H7uOHst",
+    description: "Crowdin issue type for translation mistakes",
+  },
+  issueTypeContextRequest: {
+    defaultMessage: "Context request",
+    id: "YNB1czGowu",
+    description: "Crowdin issue type for context requests",
+  },
+  issueTypeSourceMistake: {
+    defaultMessage: "Source mistake",
+    id: "LMW/LqnbFb",
+    description: "Crowdin issue type for source mistakes",
+  },
+  issueTypeLabel: {
+    defaultMessage: "Issue type",
+    id: "t/OSX7F5nd",
+    description: "Label for the Crowdin issue type selector",
   },
   unsavedChanges: {
     defaultMessage: "Unsaved",

--- a/apps/hyperlocalise-web/src/components/cat/dependencies.ts
+++ b/apps/hyperlocalise-web/src/components/cat/dependencies.ts
@@ -3,6 +3,7 @@ import type {
   CatFormatCheck,
   CatGlossaryTerm,
   CatSegment,
+  CatSegmentCommentInput,
   CatSegmentIntelligence,
   CatSegmentStatus,
   CatTranslationMemoryMatch,
@@ -42,7 +43,8 @@ export interface CatWorkspaceReview {
     segmentId: string,
     targetText: string,
   ) => void | CatSegmentStatus | Promise<void | CatSegmentStatus>;
-  onAddComment?: (segmentId: string, text: string) => void | Promise<void>;
+  onAddComment?: (segmentId: string, input: CatSegmentCommentInput) => void | Promise<void>;
+  onResolveComment?: (segmentId: string, commentId: string) => void | Promise<void>;
   onAskQuestion: (segmentId: string) => void | Promise<void>;
   onReviewWithAi: (segmentId: string) => void | Promise<void>;
   onSkip: (segmentId: string) => void;
@@ -87,6 +89,8 @@ export interface CatWorkspaceViewProps {
   isValidating?: boolean;
   isApproving?: boolean;
   isPostingComment?: boolean;
+  isResolvingComment?: boolean;
+  resolvingCommentId?: string | null;
   commentPostError?: string;
   isLookingUpContext?: boolean;
   isConcordanceLoading?: boolean;

--- a/apps/hyperlocalise-web/src/components/cat/project-file-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/project-file-cat-workspace.tsx
@@ -40,6 +40,7 @@ import type {
   CatSegment,
   CatSegmentCommentInput,
   CatSegmentIntelligence,
+  CrowdinIssueType,
 } from "./types";
 
 function initialTargetLocale(targetLocales: string[], highlightLocale: string | null) {
@@ -169,7 +170,7 @@ export function ProjectFileCatWorkspace({
       externalStringId: string;
       text: string;
       type?: "comment" | "issue";
-      issueType?: string;
+      issueType?: CrowdinIssueType;
     }) => {
       const externalResourceId = catQuery.data?.provider
         ? requireProviderExternalResourceId(catQuery.data)
@@ -186,12 +187,7 @@ export function ProjectFileCatWorkspace({
           externalResourceId,
           text: input.text,
           type: input.type,
-          issueType: input.issueType as
-            | "general_question"
-            | "translation_mistake"
-            | "context_request"
-            | "source_mistake"
-            | undefined,
+          issueType: input.issueType,
         },
       });
 
@@ -224,7 +220,6 @@ export function ProjectFileCatWorkspace({
         },
         json: {
           sourcePath,
-          targetLocale,
           externalResourceId,
         },
       });

--- a/apps/hyperlocalise-web/src/components/cat/project-file-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/project-file-cat-workspace.tsx
@@ -35,7 +35,12 @@ import {
   validateSegmentFormat,
 } from "./project-file-cat-mapper";
 import { useCatSegmentQuery } from "./use-cat-segment-query";
-import type { CatGlossaryTerm, CatSegment, CatSegmentIntelligence } from "./types";
+import type {
+  CatGlossaryTerm,
+  CatSegment,
+  CatSegmentCommentInput,
+  CatSegmentIntelligence,
+} from "./types";
 
 function initialTargetLocale(targetLocales: string[], highlightLocale: string | null) {
   if (highlightLocale && targetLocales.includes(highlightLocale)) {
@@ -160,7 +165,12 @@ export function ProjectFileCatWorkspace({
   const saveTranslation = saveMutation.mutateAsync;
 
   const commentMutation = useMutation({
-    mutationFn: async (input: { externalStringId: string; text: string }) => {
+    mutationFn: async (input: {
+      externalStringId: string;
+      text: string;
+      type?: "comment" | "issue";
+      issueType?: string;
+    }) => {
       const externalResourceId = catQuery.data?.provider
         ? requireProviderExternalResourceId(catQuery.data)
         : undefined;
@@ -175,6 +185,13 @@ export function ProjectFileCatWorkspace({
           externalStringId: input.externalStringId,
           externalResourceId,
           text: input.text,
+          type: input.type,
+          issueType: input.issueType as
+            | "general_question"
+            | "translation_mistake"
+            | "context_request"
+            | "source_mistake"
+            | undefined,
         },
       });
 
@@ -190,6 +207,40 @@ export function ProjectFileCatWorkspace({
     },
   });
   const postComment = commentMutation.mutateAsync;
+
+  const resolveCommentMutation = useMutation({
+    mutationFn: async (input: { externalCommentId: string }) => {
+      const externalResourceId = catQuery.data?.provider
+        ? requireProviderExternalResourceId(catQuery.data)
+        : undefined;
+
+      const response = await apiClient.api.orgs[":organizationSlug"].projects[
+        ":projectId"
+      ].files.detail.cat.comments[":commentId"].resolve.$patch({
+        param: {
+          organizationSlug,
+          projectId,
+          commentId: input.externalCommentId,
+        },
+        json: {
+          sourcePath,
+          targetLocale,
+          externalResourceId,
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(await readApiError(response, "Failed to resolve issue"));
+      }
+
+      const body = (await response.json()) as { comment: ProjectFileCatComment };
+      return body.comment;
+    },
+    onSuccess: async () => {
+      await invalidateCurrentPage();
+    },
+  });
+  const resolveComment = resolveCommentMutation.mutateAsync;
 
   const workspaceState = useMemo(
     () => (catQuery.data ? projectFileCatToWorkspaceState(catQuery.data, intl) : null),
@@ -218,17 +269,30 @@ export function ProjectFileCatWorkspace({
   );
 
   const handleAddComment = useCallback(
-    async (segmentId: string, text: string) => {
+    async (segmentId: string, input: CatSegmentCommentInput) => {
       if (!catQuery.data?.canEditTranslations) {
         throw new Error("Your role cannot post comments to the provider.");
       }
 
       await postComment({
         externalStringId: segmentId,
-        text,
+        text: input.text,
+        type: input.type,
+        issueType: input.issueType,
       });
     },
     [catQuery.data?.canEditTranslations, postComment],
+  );
+
+  const handleResolveComment = useCallback(
+    async (_segmentId: string, commentId: string) => {
+      if (!catQuery.data?.canEditTranslations) {
+        throw new Error("Your role cannot resolve issues in the provider.");
+      }
+
+      await resolveComment({ externalCommentId: commentId });
+    },
+    [catQuery.data?.canEditTranslations, resolveComment],
   );
 
   const handleBulkApprove = useCallback(
@@ -469,6 +533,8 @@ export function ProjectFileCatWorkspace({
         review={{
           onApprove: handleApprove,
           onAddComment: handleAddComment,
+          onResolveComment:
+            catQuery.data?.provider?.kind === "crowdin" ? handleResolveComment : undefined,
           onBulkApprove: handleBulkApprove,
         }}
         initialSegmentKeyOrId={initialSegmentKey}

--- a/apps/hyperlocalise-web/src/components/cat/types.ts
+++ b/apps/hyperlocalise-web/src/components/cat/types.ts
@@ -10,6 +10,18 @@ export type CatFormatCheckStatus = "pass" | "warn" | "fail";
 
 export type CatSegmentCommentType = "comment" | "issue";
 
+export type CrowdinIssueType =
+  | "general_question"
+  | "translation_mistake"
+  | "context_request"
+  | "source_mistake";
+
+export interface CatSegmentCommentInput {
+  text: string;
+  type?: CatSegmentCommentType;
+  issueType?: CrowdinIssueType;
+}
+
 export interface CatSegmentComment {
   id: string;
   type: CatSegmentCommentType;

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
@@ -876,6 +876,18 @@ export class CrowdinApiClient {
     return response.data;
   }
 
+  async editStringComment(
+    projectId: number,
+    commentId: number,
+    operations: CrowdinPatchOperation[],
+  ): Promise<CrowdinStringComment> {
+    const response = await this.patch<CrowdinGetResponse<CrowdinStringComment>>(
+      `/projects/${projectId}/comments/${commentId}`,
+      operations,
+    );
+    return response.data;
+  }
+
   /**
    * Search translation memory concordance for source expressions.
    */

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
@@ -1236,6 +1236,7 @@ async function saveCrowdinLiveCatComment(input: {
   externalStringId: string;
   text: string;
   type?: "comment" | "issue";
+  issueType?: string;
 }): Promise<ProjectFileCatComment> {
   const projectId = Number(input.file.provider?.externalProjectId);
   const stringId = Number(input.externalStringId);
@@ -1251,15 +1252,52 @@ async function saveCrowdinLiveCatComment(input: {
     baseUrl: input.context.credential.baseUrl ?? undefined,
   });
 
+  const commentType = input.type ?? "comment";
+
   try {
     const created = await client.addStringComment(projectId, {
       text: input.text,
       stringId,
       targetLanguageId: input.targetLocale,
-      type: input.type ?? "comment",
+      type: commentType,
+      ...(commentType === "issue" ? { issueType: input.issueType ?? "general_question" } : {}),
     });
 
     return mapCrowdinStringComment(created);
+  } catch (error) {
+    if (error instanceof CrowdinApiError && error.status === 401) {
+      throw new TmsProviderLiveError("crowdin_auth_invalid", "Crowdin credentials are invalid.");
+    }
+
+    throw error;
+  }
+}
+
+async function resolveCrowdinLiveCatComment(input: {
+  context: ActiveTmsProviderContext;
+  file: TmsProviderLiveFile;
+  externalCommentId: string;
+}): Promise<ProjectFileCatComment> {
+  const projectId = Number(input.file.provider?.externalProjectId);
+  const commentId = Number(input.externalCommentId);
+  if (Number.isNaN(projectId) || Number.isNaN(commentId)) {
+    throw new TmsProviderLiveError(
+      "invalid_crowdin_project_or_comment_id",
+      "Crowdin project or comment identifier is invalid.",
+    );
+  }
+
+  const client = new CrowdinApiClient({
+    token: input.context.secretMaterial,
+    baseUrl: input.context.credential.baseUrl ?? undefined,
+  });
+
+  try {
+    const updated = await client.editStringComment(projectId, commentId, [
+      { op: "replace", path: "/issueStatus", value: "resolved" },
+    ]);
+
+    return mapCrowdinStringComment(updated);
   } catch (error) {
     if (error instanceof CrowdinApiError && error.status === 401) {
       throw new TmsProviderLiveError("crowdin_auth_invalid", "Crowdin credentials are invalid.");
@@ -1779,6 +1817,7 @@ export async function saveTmsProviderLiveCatComment(
     text: string;
     externalResourceId?: string | null;
     type?: "comment" | "issue";
+    issueType?: string;
   },
   options?: { actorUserId?: string | null },
 ): Promise<ProjectFileCatComment | null> {
@@ -1834,6 +1873,52 @@ export async function saveTmsProviderLiveCatComment(
     externalStringId: input.externalStringId,
     text: input.text,
     type: input.type,
+    issueType: input.issueType,
+  });
+}
+
+export async function resolveTmsProviderLiveCatComment(
+  organizationId: string,
+  externalProjectId: string,
+  sourcePath: string,
+  input: {
+    externalCommentId: string;
+    externalResourceId?: string | null;
+  },
+  options?: { actorUserId?: string | null },
+): Promise<ProjectFileCatComment | null> {
+  const context = await loadActiveTmsProviderContext(organizationId, {
+    actorUserId: options?.actorUserId,
+  });
+  const file = await resolveLiveCatFile({
+    organizationId,
+    externalProjectId,
+    sourcePath,
+    externalResourceId: input.externalResourceId,
+    context,
+  });
+  if (!file) {
+    return null;
+  }
+
+  if (!supportsLiveProviderCat(context.providerKind, file)) {
+    throw new TmsProviderLiveError(
+      "provider_cat_unsupported",
+      "CAT comments are not available for this provider file yet.",
+    );
+  }
+
+  if (context.providerKind !== "crowdin") {
+    throw new TmsProviderLiveError(
+      "provider_cat_unsupported",
+      "Resolving issue comments is only available for Crowdin files.",
+    );
+  }
+
+  return resolveCrowdinLiveCatComment({
+    context,
+    file,
+    externalCommentId: input.externalCommentId,
   });
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Crowdin's comment API supports `type: "issue"`, but the CAT UI only posted plain comments. This adds full raise/resolve issue support for Crowdin provider projects.

## Changes

- **API**: Extended comment POST body with optional `issueType`; added `PATCH .../cat/comments/:commentId/resolve` route
- **Provider**: Pass `issueType` when creating Crowdin issues (defaults to `general_question`); added `editStringComment` + `resolveTmsProviderLiveCatComment`
- **UI**: Comment/Issue toggle and issue-type selector in the CAT editor (Crowdin only); Resolve button on unresolved issues
- **Fix**: `segmentHasOpenIssues` now treats Crowdin's `unresolved` status as open (in addition to `open`)

## Testing

- `vp test src/api/routes/project/project-cat.route.test.ts` — issue post + resolve route tests
- `vp test src/components/cat/cat-queue-filter.test.ts` — unresolved status filter test
- `vp check --fix` — passes (0 errors)

## Notes

Phrase projects continue to post plain comments only; issue creation remains Crowdin-specific. Resolve is rejected for non-Crowdin providers at the provider layer.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a95bdd03-9c7a-4c50-a07b-0cf8a536f613"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a95bdd03-9c7a-4c50-a07b-0cf8a536f613"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

