### PR TITLE
fix(cat): pass approve flag for native translation saves

### DIFF
--- a/apps/hyperlocalise-web/src/components/cat/cat-editor-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-editor-panel.tsx
@@ -72,6 +72,7 @@ export function CatEditorPanel({
   onClearTarget,
   onUseAiSuggestion,
   onApprove,
+  onSaveDraft,
   onAddComment,
   primaryActionLabel,
   onAskQuestion,
@@ -106,6 +107,7 @@ export function CatEditorPanel({
   onClearTarget: () => void;
   onUseAiSuggestion: () => void;
   onApprove: () => void;
+  onSaveDraft?: () => void;
   onAddComment?: (text: string) => void | Promise<void>;
   primaryActionLabel?: string;
   onAskQuestion: () => void;
@@ -338,6 +340,16 @@ export function CatEditorPanel({
               {resolvedPrimaryActionLabel}
               <ShortcutKbd keys={["⌘", "↵"]} className="bg-white/15 text-white" />
             </Button>
+            {onSaveDraft ? (
+              <Button
+                variant="outline"
+                className="min-h-11 flex-1 sm:flex-none lg:min-h-0"
+                onClick={onSaveDraft}
+                disabled={!canTriggerApprove}
+              >
+                <FormattedMessage {...catEditorPanelMessages.saveAsDraft} />
+              </Button>
+            ) : null}
             <Button
               variant="outline"
               className="min-h-11 flex-1 sm:flex-none lg:min-h-0"

--- a/apps/hyperlocalise-web/src/components/cat/cat-editor-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-editor-panel.tsx
@@ -56,6 +56,7 @@ export function CatEditorPanel({
   intelligence,
   isEditorBusy,
   isApproving = false,
+  isSavingDraft = false,
   isLookingUpContext = false,
   isAiSuggestionLoading = false,
   isFormatChecksLoading = false,
@@ -91,6 +92,7 @@ export function CatEditorPanel({
   intelligence: CatSegmentIntelligence;
   isEditorBusy?: boolean;
   isApproving?: boolean;
+  isSavingDraft?: boolean;
   isLookingUpContext?: boolean;
   isAiSuggestionLoading?: boolean;
   isFormatChecksLoading?: boolean;
@@ -129,6 +131,7 @@ export function CatEditorPanel({
   const trimmedCommentDraft = commentDraft.trim();
   const isActionBlocked =
     isApproving ||
+    isSavingDraft ||
     isPostingComment ||
     isLookingUpContext ||
     isAiSuggestionLoading ||
@@ -347,6 +350,7 @@ export function CatEditorPanel({
                 onClick={onSaveDraft}
                 disabled={!canTriggerApprove}
               >
+                {isSavingDraft ? <Spinner className="size-4" /> : null}
                 <FormattedMessage {...catEditorPanelMessages.saveAsDraft} />
               </Button>
             ) : null}
@@ -357,6 +361,7 @@ export function CatEditorPanel({
               disabled={
                 !canLookupContext ||
                 isApproving ||
+                isSavingDraft ||
                 isLookingUpContext ||
                 isAiSuggestionLoading ||
                 isFormatChecksLoading
@@ -379,7 +384,7 @@ export function CatEditorPanel({
               variant="ghost"
               className="hidden lg:inline-flex"
               onClick={onPrevious}
-              disabled={isApproving || isLookingUpContext || !hasPreviousSegment}
+              disabled={isApproving || isSavingDraft || isLookingUpContext || !hasPreviousSegment}
             >
               <FormattedMessage {...catEditorPanelMessages.previous} />
               <ShortcutKbd keys={["⌘", "←"]} />
@@ -388,7 +393,7 @@ export function CatEditorPanel({
               variant="ghost"
               className="hidden lg:inline-flex"
               onClick={onNext}
-              disabled={isApproving || isLookingUpContext || !hasNextSegment}
+              disabled={isApproving || isSavingDraft || isLookingUpContext || !hasNextSegment}
             >
               <FormattedMessage {...catEditorPanelMessages.next} />
               <ShortcutKbd keys={["⌘", "→"]} />

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
@@ -366,6 +366,7 @@ export function CatWorkspaceContainer({
   const onTargetChange = editingOverrides?.onTargetChange;
   const onUseAiSuggestion = editingOverrides?.onUseAiSuggestion;
   const onApprove = reviewOverrides?.onApprove;
+  const onSaveDraft = reviewOverrides?.onSaveDraft;
   const onAddComment = reviewOverrides?.onAddComment;
   const onAskQuestion = reviewOverrides?.onAskQuestion;
   const onReviewWithAi = reviewOverrides?.onReviewWithAi;
@@ -1010,6 +1011,52 @@ export function CatWorkspaceContainer({
           setIsApproving(false);
         }
       },
+      onSaveDraft: async (segmentId: string, targetText: string) => {
+        if (!onSaveDraft) {
+          return;
+        }
+
+        setIsApproving(true);
+        try {
+          const nextStatus = (await onSaveDraft(segmentId, targetText)) ?? "needs_review";
+          setState((current) => {
+            const previousSegment = current.segments.find((segment) => segment.id === segmentId);
+            const segments = updateSegmentTarget(
+              updateSegmentStatus(current.segments, segmentId, nextStatus),
+              segmentId,
+              targetText,
+            );
+            return {
+              ...current,
+              segments,
+              queueSummary: previousSegment
+                ? adjustQueueSummaryForStatusChange(
+                    current.queueSummary,
+                    previousSegment.status,
+                    nextStatus,
+                  )
+                : current.queueSummary,
+            };
+          });
+          setSavedTargetTexts((saved) => markSegmentTargetSaved(saved, segmentId, targetText));
+        } catch (error) {
+          const message =
+            error instanceof Error
+              ? error.message
+              : intl.formatMessage(catWorkspaceContainerMessages.saveTranslationFailed);
+          setState((current) => ({
+            ...current,
+            ...addSaveFailureFormatCheck(
+              current,
+              segmentId,
+              message,
+              intl.formatMessage(catWorkspaceContainerMessages.saveFailedLabel),
+            ),
+          }));
+        } finally {
+          setIsApproving(false);
+        }
+      },
       onAddComment: async (segmentId: string, text: string) => {
         if (!onAddComment) {
           return;
@@ -1135,6 +1182,7 @@ export function CatWorkspaceContainer({
     attemptPageNavigation,
     attemptSegmentNavigation,
     onApprove,
+    onSaveDraft,
     onAddComment,
     onAskQuestion,
     intl,

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
@@ -323,6 +323,7 @@ export function CatWorkspaceContainer({
   const initialSegmentJumpAppliedRef = useRef(false);
   const [isValidating, setIsValidating] = useState(false);
   const [isApproving, setIsApproving] = useState(false);
+  const [isSavingDraft, setIsSavingDraft] = useState(false);
   const [isPostingComment, setIsPostingComment] = useState(false);
   const [commentPostError, setCommentPostError] = useState<string | undefined>();
   const [isLookingUpContext, setIsLookingUpContext] = useState(false);
@@ -1016,7 +1017,7 @@ export function CatWorkspaceContainer({
           return;
         }
 
-        setIsApproving(true);
+        setIsSavingDraft(true);
         try {
           const nextStatus = (await onSaveDraft(segmentId, targetText)) ?? "needs_review";
           setState((current) => {
@@ -1054,7 +1055,7 @@ export function CatWorkspaceContainer({
             ),
           }));
         } finally {
-          setIsApproving(false);
+          setIsSavingDraft(false);
         }
       },
       onAddComment: async (segmentId: string, text: string) => {
@@ -1317,6 +1318,7 @@ export function CatWorkspaceContainer({
           dirtySegmentIds={dirtySegmentIds}
           isValidating={isValidating}
           isApproving={isApproving}
+          isSavingDraft={isSavingDraft}
           isPostingComment={isPostingComment}
           commentPostError={commentPostError}
           isLookingUpContext={isLookingUpContext}

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace.tsx
@@ -159,6 +159,11 @@ export function CatWorkspaceView({
           onClearTarget={() => editing.onTargetChange(selectedSegment.id, "")}
           onUseAiSuggestion={() => editing.onUseAiSuggestion(selectedSegment.id)}
           onApprove={() => void review.onApprove(selectedSegment.id, selectedSegment.targetText)}
+          onSaveDraft={
+            review.onSaveDraft
+              ? () => void review.onSaveDraft?.(selectedSegment.id, selectedSegment.targetText)
+              : undefined
+          }
           onAddComment={
             review.onAddComment
               ? (text) => review.onAddComment?.(selectedSegment.id, text)

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace.tsx
@@ -43,6 +43,7 @@ export function CatWorkspaceView({
   dependencies,
   isValidating: _isValidating = false,
   isApproving = false,
+  isSavingDraft = false,
   isPostingComment = false,
   commentPostError,
   isLookingUpContext = false,
@@ -123,7 +124,7 @@ export function CatWorkspaceView({
   const aiRecommendationError = selectedSegmentFormatChecks.find(
     (check) => check.id === `ai-recommendation-failed-${selectedSegment.id}`,
   )?.message;
-  const isEditorBusy = isApproving;
+  const isEditorBusy = isApproving || isSavingDraft;
   const canApprove = fullState.canEditTranslations !== false;
   const canAddComment = fullState.canAddComments === true;
   const isTargetDirty = dirtySegmentIds?.has(selectedSegment.id) ?? false;
@@ -140,6 +141,7 @@ export function CatWorkspaceView({
           intelligence={selectedSegmentIntelligence}
           isEditorBusy={isEditorBusy}
           isApproving={isApproving}
+          isSavingDraft={isSavingDraft}
           isLookingUpContext={isLookingUpContext}
           isAiSuggestionLoading={isAiSuggestionLoading}
           isFormatChecksLoading={isFormatChecksLoading}

--- a/apps/hyperlocalise-web/src/components/cat/cat.messages.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat.messages.ts
@@ -487,6 +487,11 @@ export const catEditorPanelMessages = defineMessages({
     id: "0+GXVlndL6",
     description: "Primary action to approve the current CAT translation",
   },
+  saveAsDraft: {
+    defaultMessage: "Save as draft",
+    id: "YdeVnuUNms",
+    description: "Secondary action to save the current translation without approving it",
+  },
   findContextTitle: {
     defaultMessage: "Look up where this string appears in the connected repository",
     id: "BnZ3uPwDP7",

--- a/apps/hyperlocalise-web/src/components/cat/dependencies.ts
+++ b/apps/hyperlocalise-web/src/components/cat/dependencies.ts
@@ -42,6 +42,10 @@ export interface CatWorkspaceReview {
     segmentId: string,
     targetText: string,
   ) => void | CatSegmentStatus | Promise<void | CatSegmentStatus>;
+  onSaveDraft?: (
+    segmentId: string,
+    targetText: string,
+  ) => void | CatSegmentStatus | Promise<void | CatSegmentStatus>;
   onAddComment?: (segmentId: string, text: string) => void | Promise<void>;
   onAskQuestion: (segmentId: string) => void | Promise<void>;
   onReviewWithAi: (segmentId: string) => void | Promise<void>;

--- a/apps/hyperlocalise-web/src/components/cat/dependencies.ts
+++ b/apps/hyperlocalise-web/src/components/cat/dependencies.ts
@@ -90,6 +90,7 @@ export interface CatWorkspaceViewProps {
   dependencies: CatWorkspaceDependencies;
   isValidating?: boolean;
   isApproving?: boolean;
+  isSavingDraft?: boolean;
   isPostingComment?: boolean;
   commentPostError?: string;
   isLookingUpContext?: boolean;

--- a/apps/hyperlocalise-web/src/components/cat/project-file-cat-mapper.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file-cat-mapper.test.ts
@@ -106,6 +106,19 @@ describe("projectFileCatToWorkspaceState", () => {
     });
   });
 
+  it("uses Approve as the primary action label for native projects", () => {
+    const state = projectFileCatToWorkspaceState(catFile({ provider: null }), testIntl);
+
+    expect(state.primaryActionLabel).toBe("Approve");
+    expect(state.providerKind).toBeNull();
+  });
+
+  it("uses Save to provider as the primary action label for TMS projects", () => {
+    const state = projectFileCatToWorkspaceState(catFile(), testIntl);
+
+    expect(state.primaryActionLabel).toBe("Save to provider");
+  });
+
   it("uses pagination offset for segment indices and file-level queue totals", () => {
     const state = projectFileCatToWorkspaceState(
       catFile({

--- a/apps/hyperlocalise-web/src/components/cat/project-file-cat-mapper.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file-cat-mapper.ts
@@ -239,7 +239,7 @@ export function projectFileCatToWorkspaceState(
       ]),
     ),
     breadcrumbs: [catFile.provider?.kind ?? "native", catFile.filename, catFile.targetLocale],
-    primaryActionLabel: catFile.provider ? "Save to provider" : "Save translation",
+    primaryActionLabel: catFile.provider ? "Save to provider" : "Approve",
     canEditTranslations: catFile.canEditTranslations,
     canAddComments: Boolean(
       (catFile.provider?.kind === "crowdin" || catFile.provider?.kind === "phrase") &&

--- a/apps/hyperlocalise-web/src/components/cat/project-file-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/project-file-cat-workspace.tsx
@@ -128,7 +128,7 @@ export function ProjectFileCatWorkspace({
   }, [availableQueueFilters, queueFilter, setQueueFilter]);
 
   const saveMutation = useMutation({
-    mutationFn: async (input: { externalStringId: string; text: string }) => {
+    mutationFn: async (input: { externalStringId: string; text: string; approve?: boolean }) => {
       const externalResourceId = catQuery.data?.provider
         ? requireProviderExternalResourceId(catQuery.data)
         : undefined;
@@ -143,6 +143,7 @@ export function ProjectFileCatWorkspace({
           externalStringId: input.externalStringId,
           externalResourceId,
           text: input.text,
+          approve: input.approve,
         },
       });
 
@@ -202,6 +203,8 @@ export function ProjectFileCatWorkspace({
     [intl],
   );
 
+  const isNativeProject = !catQuery.data?.provider;
+
   const handleApprove = useCallback(
     async (segmentId: string, targetText: string) => {
       if (!catQuery.data?.canEditTranslations) {
@@ -211,8 +214,25 @@ export function ProjectFileCatWorkspace({
       const translation = await saveTranslation({
         externalStringId: segmentId,
         text: targetText,
+        approve: isNativeProject ? true : undefined,
       });
       return translation.isApproved ? "reviewed" : "needs_review";
+    },
+    [catQuery.data?.canEditTranslations, isNativeProject, saveTranslation],
+  );
+
+  const handleSaveDraft = useCallback(
+    async (segmentId: string, targetText: string) => {
+      if (!catQuery.data?.canEditTranslations) {
+        throw new Error("Your role cannot write translations back.");
+      }
+
+      await saveTranslation({
+        externalStringId: segmentId,
+        text: targetText,
+        approve: false,
+      });
+      return "needs_review" as const;
     },
     [catQuery.data?.canEditTranslations, saveTranslation],
   );
@@ -468,6 +488,7 @@ export function ProjectFileCatWorkspace({
         }}
         review={{
           onApprove: handleApprove,
+          onSaveDraft: isNativeProject ? handleSaveDraft : undefined,
           onAddComment: handleAddComment,
           onBulkApprove: handleBulkApprove,
         }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Confirmed and fixed a bug in the native CAT review workflow.

**Root cause:** `handleApprove` in `project-file-cat-workspace.tsx` POSTed translations without `approve: true`. The API and `NativeCatService.saveTranslation` already support `approve`, setting status to `approved` vs `draft`. Without the flag, saves always became `draft`, so segments stayed in `needs_review` after clicking Approve.

**Fix:**
- Pass `approve: true` when saving from Approve on native (non-provider) projects
- Add a **Save as draft** secondary action for native projects (`approve: false`)
- Rename the native primary button label from "Save translation" to **Approve** to match behavior

Provider projects are unchanged — their save path does not use the `approve` body field.

## How to test

1. Open a native project CAT workspace for a file with segments needing review
2. Edit a segment and click **Approve** — segment should move to the reviewed queue and persist after refresh
3. Edit another segment and click **Save as draft** — text saves but segment stays in needs review
4. Run `vp test src/components/cat/` — all CAT component tests pass

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, `vp test src/components/cat/`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1701740-7428-4f66-af78-18309fa1baef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1701740-7428-4f66-af78-18309fa1baef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

