### PR TITLE
fix(cat): include maxLength in native CAT segment payload

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -527,6 +527,7 @@ export const projectFileCatSegmentSchema = z.object({
   sourceText: z.string(),
   context: z.string().nullable(),
   type: z.string().nullable(),
+  maxLength: z.number().int().positive().optional(),
   target: projectFileCatTranslationSchema.nullable(),
   comments: z.array(projectFileCatCommentSchema),
   repositoryContext: z.string().nullable().optional(),

--- a/apps/hyperlocalise-web/src/components/cat/project-file-cat-mapper.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file-cat-mapper.test.ts
@@ -136,6 +136,28 @@ describe("projectFileCatToWorkspaceState", () => {
       hasIssues: 5,
     });
   });
+
+  it("maps maxLength from CAT segments into workspace state", () => {
+    const state = projectFileCatToWorkspaceState(
+      catFile({
+        segments: [
+          {
+            externalStringId: "limited-string",
+            key: "hero.cta",
+            sourceText: "Get started",
+            context: null,
+            type: "text",
+            maxLength: 24,
+            target: null,
+            comments: [],
+          },
+        ],
+      }),
+      testIntl,
+    );
+
+    expect(state.segments[0]?.maxLength).toBe(24);
+  });
 });
 
 describe("formatCheckForSegment", () => {

--- a/apps/hyperlocalise-web/src/components/cat/project-file-cat-mapper.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file-cat-mapper.test.ts
@@ -158,6 +158,28 @@ describe("projectFileCatToWorkspaceState", () => {
 
     expect(state.segments[0]?.maxLength).toBe(24);
   });
+
+  it("omits maxLength from workspace state when the CAT segment has a non-positive value", () => {
+    const state = projectFileCatToWorkspaceState(
+      catFile({
+        segments: [
+          {
+            externalStringId: "limited-string",
+            key: "hero.cta",
+            sourceText: "Get started",
+            context: null,
+            type: "text",
+            maxLength: 0,
+            target: null,
+            comments: [],
+          },
+        ],
+      }),
+      testIntl,
+    );
+
+    expect(state.segments[0]?.maxLength).toBeUndefined();
+  });
 });
 
 describe("formatCheckForSegment", () => {

--- a/apps/hyperlocalise-web/src/components/cat/project-file-cat-mapper.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file-cat-mapper.ts
@@ -221,6 +221,7 @@ export function projectFileCatToWorkspaceState(
       contextLabel: segment.context ?? undefined,
       status: segmentStatusFor(segment),
       tags,
+      ...(segment.maxLength != null ? { maxLength: segment.maxLength } : {}),
       comments: mapSegmentComments(segment),
     };
   });

--- a/apps/hyperlocalise-web/src/components/cat/project-file-cat-mapper.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file-cat-mapper.ts
@@ -221,7 +221,9 @@ export function projectFileCatToWorkspaceState(
       contextLabel: segment.context ?? undefined,
       status: segmentStatusFor(segment),
       tags,
-      ...(segment.maxLength != null ? { maxLength: segment.maxLength } : {}),
+      ...(segment.maxLength != null && segment.maxLength > 0
+        ? { maxLength: segment.maxLength }
+        : {}),
       comments: mapSegmentComments(segment),
     };
   });

--- a/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-service.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-service.test.ts
@@ -111,6 +111,7 @@ describe("NativeCatService.getCatFile", () => {
       key: "hero.title",
       sourceText: "Welcome",
     });
+    expect(result?.segments[0]?.maxLength).toBeUndefined();
     expect(result?.queueSummary).toEqual({
       total: 120,
       reviewed: 45,
@@ -118,5 +119,28 @@ describe("NativeCatService.getCatFile", () => {
       needsReview: 40,
       hasIssues: 5,
     });
+  });
+
+  it("includes maxLength on segments when the translation key has one", async () => {
+    listKeysForFile.mockResolvedValue([
+      {
+        id: "key_1",
+        key: "hero.cta",
+        sourceText: "Get started",
+        context: null,
+        type: "text",
+        maxLength: 24,
+      },
+    ]);
+
+    const result = await service.getCatFile({
+      organizationId: "org_1",
+      projectId: "project_1",
+      sourcePath: "locales/en.json",
+      targetLocale: "fr",
+      canEditTranslations: true,
+    });
+
+    expect(result?.segments[0]?.maxLength).toBe(24);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-service.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-service.test.ts
@@ -143,4 +143,27 @@ describe("NativeCatService.getCatFile", () => {
 
     expect(result?.segments[0]?.maxLength).toBe(24);
   });
+
+  it("omits maxLength when the translation key has a non-positive value", async () => {
+    listKeysForFile.mockResolvedValue([
+      {
+        id: "key_1",
+        key: "hero.cta",
+        sourceText: "Get started",
+        context: null,
+        type: "text",
+        maxLength: 0,
+      },
+    ]);
+
+    const result = await service.getCatFile({
+      organizationId: "org_1",
+      projectId: "project_1",
+      sourcePath: "locales/en.json",
+      targetLocale: "fr",
+      canEditTranslations: true,
+    });
+
+    expect(result?.segments[0]?.maxLength).toBeUndefined();
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-service.ts
@@ -180,7 +180,7 @@ export class NativeCatService extends ProjectServiceBase {
           sourceText: key.sourceText,
           context: key.context,
           type: key.type,
-          ...(key.maxLength != null ? { maxLength: key.maxLength } : {}),
+          ...(key.maxLength != null && key.maxLength > 0 ? { maxLength: key.maxLength } : {}),
           target: translation ? toCatTranslation(translation) : null,
           comments: [],
         };

--- a/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-service.ts
@@ -180,6 +180,7 @@ export class NativeCatService extends ProjectServiceBase {
           sourceText: key.sourceText,
           context: key.context,
           type: key.type,
+          ...(key.maxLength != null ? { maxLength: key.maxLength } : {}),
           target: translation ? toCatTranslation(translation) : null,
           comments: [],
         };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Native CAT segments now include `maxLength` from translation keys so the editor, format checks, and AI recommendations can enforce character limits stored in the database.

## Problem

`project_translation_keys.max_length` was already selected by `ProjectTranslationService.listKeysForFile`, but the value was dropped before reaching the client:

- `projectFileCatSegmentSchema` had no `maxLength` field
- `NativeCatService.buildCatFileResponse` omitted it from segment payloads
- `projectFileCatToWorkspaceState` did not map it onto `CatSegment`

The UI, format checks, and AI recommendation flow already support `maxLength` when present client-side, so limits were silently ignored for native CAT files.

## Changes

- Add optional `maxLength` to `projectFileCatSegmentSchema`
- Include `maxLength` in native CAT segment payloads when the key has a value
- Map `maxLength` through `projectFileCatToWorkspaceState`
- Add tests for service payload and mapper behavior

## Testing

- `CI=true vp test src/lib/projects/cat/native-cat-service.test.ts src/components/cat/project-file-cat-mapper.test.ts`
- `CI=true vp check --fix`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3001478c-d2e6-424e-aa2d-1cc8ac99771c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3001478c-d2e6-424e-aa2d-1cc8ac99771c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

