### PR TITLE
test(cat): assert native projects have no comments and unsupported comment API

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
@@ -5,6 +5,8 @@ import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
 
 import { app } from "@/api/app";
 import { db } from "@/lib/database";
+import { ensureRepositorySourceFile } from "@/lib/file-storage/records";
+import { upsertProjectTranslationKeysFromEntries } from "@/lib/projects/translations/project-translation-service";
 import { TmsProviderLiveError } from "@/lib/providers/tms-provider-live";
 
 import { createProjectTestFixture } from "./project.fixture";
@@ -301,6 +303,97 @@ describe("project file CAT routes", () => {
 
     expect(response.status).toBe(400);
     expect(await response.json()).toMatchObject({ error: "visual_context_unavailable" });
+  });
+
+  it("returns native CAT segments with empty comments", async () => {
+    const { identity, project, organization } = await projectFixture.createStoredProjectFixture();
+    const headers = await projectFixture.authHeadersFor(identity);
+    const sourcePath = "locales/en.json";
+    const sourceFile = await ensureRepositorySourceFile({
+      organizationId: organization.id,
+      projectId: project.id,
+      sourcePath,
+    });
+
+    await upsertProjectTranslationKeysFromEntries({
+      organizationId: organization.id,
+      projectId: project.id,
+      repositorySourceFileId: sourceFile.id,
+      entries: [{ key: "greeting", text: "Hello", context: null }],
+    });
+
+    const response = await client.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].files.detail.cat.$get(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: project.id,
+        },
+        query: { sourcePath, targetLocale: "fr-FR" },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as ProjectFileCatResponse;
+    expect(body.catFile.provider).toBeNull();
+    expect(body.catFile.segments).toHaveLength(1);
+    expect(body.catFile.segments[0]?.comments).toEqual([]);
+  });
+
+  it("rejects native CAT comment posts with provider_cat_unsupported", async () => {
+    const { identity, project, organization } = await projectFixture.createStoredProjectFixture();
+    const translator = projectFixture.createWorkosIdentityForOrganization(organization, "translator");
+    const headers = await projectFixture.authHeadersFor(translator);
+
+    const response = await client.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].files.detail.cat.comments.$post(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: project.id,
+        },
+        json: {
+          sourcePath: "locales/en.json",
+          targetLocale: "fr-FR",
+          externalStringId: "segment-1",
+          text: "Please clarify tone.",
+        },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({ error: "provider_cat_unsupported" });
+    expect(saveTmsProviderLiveCatCommentMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects native CAT comment resolution with provider_cat_unsupported", async () => {
+    const { identity, project, organization } = await projectFixture.createStoredProjectFixture();
+    const translator = projectFixture.createWorkosIdentityForOrganization(organization, "translator");
+    const headers = await projectFixture.authHeadersFor(translator);
+
+    const response = await client.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].files.detail.cat.comments[":commentId"].resolve.$patch(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: project.id,
+          commentId: "comment-1",
+        },
+        json: {
+          sourcePath: "locales/en.json",
+        },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({ error: "provider_cat_unsupported" });
+    expect(resolveTmsProviderLiveCatCommentMock).not.toHaveBeenCalled();
   });
 
   it("returns Crowdin CAT content for an encoded provider project", async () => {

--- a/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
@@ -344,7 +344,10 @@ describe("project file CAT routes", () => {
 
   it("rejects native CAT comment posts with provider_cat_unsupported", async () => {
     const { identity, project, organization } = await projectFixture.createStoredProjectFixture();
-    const translator = projectFixture.createWorkosIdentityForOrganization(organization, "translator");
+    const translator = projectFixture.createWorkosIdentityForOrganization(
+      organization,
+      "translator",
+    );
     const headers = await projectFixture.authHeadersFor(translator);
 
     const response = await client.api.orgs[":organizationSlug"].projects[
@@ -372,7 +375,10 @@ describe("project file CAT routes", () => {
 
   it("rejects native CAT comment resolution with provider_cat_unsupported", async () => {
     const { identity, project, organization } = await projectFixture.createStoredProjectFixture();
-    const translator = projectFixture.createWorkosIdentityForOrganization(organization, "translator");
+    const translator = projectFixture.createWorkosIdentityForOrganization(
+      organization,
+      "translator",
+    );
     const headers = await projectFixture.authHeadersFor(translator);
 
     const response = await client.api.orgs[":organizationSlug"].projects[

--- a/apps/hyperlocalise-web/src/components/cat/project-file-cat-mapper.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file-cat-mapper.test.ts
@@ -159,6 +159,29 @@ describe("projectFileCatToWorkspaceState", () => {
     expect(state.segments[0]?.maxLength).toBe(24);
   });
 
+  it("disables comment actions for native projects", () => {
+    const state = projectFileCatToWorkspaceState(
+      catFile({
+        provider: null,
+        segments: [
+          {
+            externalStringId: "native-string",
+            key: "hero.title",
+            sourceText: "Welcome",
+            context: null,
+            type: "text",
+            target: null,
+            comments: [],
+          },
+        ],
+      }),
+      testIntl,
+    );
+
+    expect(state.canAddComments).toBe(false);
+    expect(state.segments[0]?.comments).toEqual([]);
+  });
+
   it("omits maxLength from workspace state when the CAT segment has a non-positive value", () => {
     const state = projectFileCatToWorkspaceState(
       catFile({

--- a/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-service.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-service.test.ts
@@ -110,6 +110,7 @@ describe("NativeCatService.getCatFile", () => {
       externalStringId: "key_51",
       key: "hero.title",
       sourceText: "Welcome",
+      comments: [],
     });
     expect(result?.segments[0]?.maxLength).toBeUndefined();
     expect(result?.queueSummary).toEqual({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Locks in native-project comment behavior with regression tests. Native CAT already returns empty `comments: []` per segment and the comment write API already rejects native projects with `provider_cat_unsupported`; this PR adds explicit coverage so that contract does not drift.

## Changes

- **Native CAT service**: assert segments include `comments: []`
- **CAT route tests**: verify native GET returns empty comments; POST/PATCH comment endpoints return `provider_cat_unsupported` without calling provider APIs
- **CAT mapper**: verify native projects set `canAddComments: false`

## Testing

- `vp test src/lib/projects/cat/native-cat-service.test.ts src/components/cat/project-file-cat-mapper.test.ts src/api/routes/project/project-cat.route.test.ts`
- `vp check --fix`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae37fa22-9f07-46e4-8d10-6231b29f9c83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae37fa22-9f07-46e4-8d10-6231b29f9c83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

