### PR TITLE
fix(cat): render segment tags in queue rows

### DIFF
--- a/apps/hyperlocalise-web/src/components/cat/cat-queue-virtual-list.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-queue-virtual-list.tsx
@@ -7,10 +7,11 @@ import { useIntl } from "react-intl";
 import { cn } from "@/lib/primitives/cn";
 
 import { catQueuePanelMessages } from "./cat.messages";
+import { CatSegmentTags } from "./cat-segment-tags";
 import { QueueStatusDot } from "./cat-segment-status";
 import type { CatSegment } from "./types";
 
-const ESTIMATED_ROW_HEIGHT = 72;
+const ESTIMATED_ROW_HEIGHT = 88;
 
 export function CatQueueVirtualList({
   segments,
@@ -119,6 +120,9 @@ export function CatQueueVirtualList({
                         {segment.key}
                       </span>
                     </div>
+                    {segment.tags && segment.tags.length > 0 ? (
+                      <CatSegmentTags tags={segment.tags} />
+                    ) : null}
                   </div>
                   <div className="mt-1 flex shrink-0 flex-col items-center gap-1">
                     {isDirty ? (

--- a/apps/hyperlocalise-web/src/components/cat/cat-segment-tags.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat-segment-tags.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { getSegmentTagKind } from "./cat-segment-tags";
+
+describe("getSegmentTagKind", () => {
+  it("classifies segment type tags", () => {
+    expect(getSegmentTagKind("icu")).toBe("type");
+    expect(getSegmentTagKind("text")).toBe("type");
+    expect(getSegmentTagKind("dashboard")).toBe("type");
+  });
+
+  it("classifies comment count tags", () => {
+    expect(getSegmentTagKind("1 comment")).toBe("comment");
+    expect(getSegmentTagKind("2 comments")).toBe("comment");
+  });
+
+  it("classifies issue count tags", () => {
+    expect(getSegmentTagKind("1 issue")).toBe("issue");
+    expect(getSegmentTagKind("3 issues")).toBe("issue");
+  });
+});

--- a/apps/hyperlocalise-web/src/components/cat/cat-segment-tags.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-segment-tags.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/primitives/cn";
+
+const COMMENT_TAG_PATTERN = /^\d+ comments?$/;
+const ISSUE_TAG_PATTERN = /^\d+ issues?$/;
+
+export type CatSegmentTagKind = "type" | "comment" | "issue";
+
+export function getSegmentTagKind(tag: string): CatSegmentTagKind {
+  if (ISSUE_TAG_PATTERN.test(tag)) {
+    return "issue";
+  }
+
+  if (COMMENT_TAG_PATTERN.test(tag)) {
+    return "comment";
+  }
+
+  return "type";
+}
+
+function segmentTagClassName(kind: CatSegmentTagKind) {
+  switch (kind) {
+    case "issue":
+      return "border-flame-200/40 text-flame-100";
+    case "type":
+      return "font-mono";
+    default:
+      return undefined;
+  }
+}
+
+export function CatSegmentTags({ tags }: { tags: string[] }) {
+  if (tags.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-wrap gap-1">
+      {tags.map((tag) => {
+        const kind = getSegmentTagKind(tag);
+
+        return (
+          <Badge
+            key={tag}
+            variant="outline"
+            className={cn("max-w-full font-normal", segmentTagClassName(kind))}
+          >
+            <span className="truncate">{tag}</span>
+          </Badge>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/cat/cat-segment-tags.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-segment-tags.tsx
@@ -38,12 +38,12 @@ export function CatSegmentTags({ tags }: { tags: string[] }) {
 
   return (
     <div className="flex flex-wrap gap-1">
-      {tags.map((tag) => {
+      {tags.map((tag, index) => {
         const kind = getSegmentTagKind(tag);
 
         return (
           <Badge
-            key={tag}
+            key={`${tag}-${index}`}
             variant="outline"
             className={cn("max-w-full font-normal", segmentTagClassName(kind))}
           >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Segment tags (type, comment count, issue count) were already built by `projectFileCatToWorkspaceState`, but the CAT queue virtual list never rendered them.

This change adds a `CatSegmentTags` badge row under each segment key in the queue, with issue tags styled consistently with the editor panel.

## Changes

- Add `CatSegmentTags` component with tag-kind detection (`type`, `comment`, `issue`)
- Render `segment.tags` in `CatQueueVirtualList` below the segment key
- Bump estimated row height to account for the extra metadata line
- Add unit tests for tag classification

## Test plan

- [x] `vp test src/components/cat/cat-segment-tags.test.ts`
- [x] `vp check --fix`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-38105585-fe63-4609-ba09-a9dd179d17ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38105585-fe63-4609-ba09-a9dd179d17ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

