### PR TITLE
Correct Distribution validation for branch and directory IDs

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -197,3 +197,9 @@
 **Learning:** The Crowdin Screenshots API v2 returns a `projectId` field which was missing from the SDK. Additionally, the Distributions API supports `branchIds` and `directoryIds` in both response models and addition requests, allowing for distribution of content from specific branches or directories.
 
 **Action:** Added `ProjectID` to the `Screenshot` struct in `model/screenshot.go`. Added `BranchIDs` and `DirectoryIDs` to both `Distribution` and `DistributionAddRequest` in `model/distributions.go`. Updated contract tests in `screenshots_test.go`, `labels_test.go`, and `distributions_test.go` to verify correct parsing and serialization of these new fields.
+
+## 2026-10-31 - Fix Distribution validation for branch and directory IDs
+
+**Learning:** The Crowdin API v2 for creating distributions allows specifying content via `fileIds`, `branchIds`, or `directoryIds` when using the 'default' export mode. The Go SDK was incorrectly requiring `fileIds` exclusively, causing validation failures for valid branch or directory-based distribution requests.
+
+**Action:** Updated `DistributionAddRequest.Validate` in `model/distributions.go` to check that at least one of `fileIds`, `branchIds`, or `directoryIds` is provided for the default export mode. Expanded `model/distributions_test.go` with contract tests verifying each of these valid configurations.

--- a/third_party/crowdin-api-client-go/crowdin/model/distributions.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/distributions.go
@@ -68,8 +68,9 @@ func (r *DistributionAddRequest) Validate() error {
 	if r.ExportMode == ExportModeBundle && len(r.BundleIDs) == 0 {
 		return errors.New("bundleIds is required for bundle export mode")
 	}
-	if r.ExportMode == ExportModeDefault && len(r.FileIDs) == 0 {
-		return errors.New("fileIds is required for default export mode")
+	if (r.ExportMode == "" || r.ExportMode == ExportModeDefault) &&
+		len(r.FileIDs) == 0 && len(r.BranchIDs) == 0 && len(r.DirectoryIDs) == 0 {
+		return errors.New("one of fileIds, branchIds or directoryIds is required for default export mode")
 	}
 
 	return nil

--- a/third_party/crowdin-api-client-go/crowdin/model/distributions_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/distributions_test.go
@@ -33,15 +33,33 @@ func TestDistributionAddRequestValidate(t *testing.T) {
 			err: "bundleIds is required for bundle export mode",
 		},
 		{
-			name: "empty fileIds",
+			name: "empty content in default mode",
 			req: &DistributionAddRequest{
 				Name:       "Export Bundle",
 				ExportMode: ExportModeDefault,
 			},
-			err: "fileIds is required for default export mode",
+			err: "one of fileIds, branchIds or directoryIds is required for default export mode",
 		},
 		{
-			name: "valid request",
+			name: "valid request in default mode with branchIds",
+			req: &DistributionAddRequest{
+				Name:       "Export Bundle",
+				ExportMode: ExportModeDefault,
+				BranchIDs:  []int{1, 2},
+			},
+			valid: true,
+		},
+		{
+			name: "valid request in default mode with directoryIds",
+			req: &DistributionAddRequest{
+				Name:         "Export Bundle",
+				ExportMode:   ExportModeDefault,
+				DirectoryIDs: []int{3, 4},
+			},
+			valid: true,
+		},
+		{
+			name: "valid request in bundle mode",
 			req: &DistributionAddRequest{
 				Name:       "Export Bundle",
 				ExportMode: ExportModeBundle,


### PR DESCRIPTION
I've fixed a validation bug in the Crowdin fork where creating a distribution with branch or directory IDs (instead of file IDs) would incorrectly fail validation.

**💡 What:**
Updated `DistributionAddRequest.Validate` in `model/distributions.go` to correctly handle `branchIds` and `directoryIds` for the default export mode.

**🎯 Why:**
The Crowdin API v2 allows any of these three fields to define the distribution's content, but the SDK was strictly requiring `fileIds`.

**📊 Impact:**
Allows users to correctly create distributions based on branches or directories, matching official API behavior.

**🔬 Measurement:**
Verified with new contract tests in `model/distributions_test.go` and ran the full test suite in the fork (`GOWORK=off go test ./...`). All tests passed.

---
*PR created automatically by Jules for task [9957493826620473722](https://jules.google.com/task/9957493826620473722) started by @cungminh2710*