### PR TITLE
fix(crowdin): improve task list parity for creatorId and projectId

### DIFF
--- a/.jules/crowdin-steward.md
+++ b/.jules/crowdin-steward.md
@@ -203,3 +203,9 @@
 **Learning:** The Crowdin API v2 for creating distributions allows specifying content via `fileIds`, `branchIds`, or `directoryIds` when using the 'default' export mode. The Go SDK was incorrectly requiring `fileIds` exclusively, causing validation failures for valid branch or directory-based distribution requests.
 
 **Action:** Updated `DistributionAddRequest.Validate` in `model/distributions.go` to check that at least one of `fileIds`, `branchIds`, or `directoryIds` is provided for the default export mode. Expanded `model/distributions_test.go` with contract tests verifying each of these valid configurations.
+
+## 2026-06-30 - Improve Task model parity for creatorId and projectId
+
+**Learning:** The Crowdin Tasks API v2 supports filtering by `creatorId` when listing project tasks and by `projectId` when listing user tasks. These parameters were missing from the SDK's `TasksListOptions` and `UserTasksListOptions` respectively.
+
+**Action:** Added `CreatorID` to `TasksListOptions` and `ProjectID` to `UserTasksListOptions` in `model/tasks.go`. Updated their `Values()` methods to correctly encode these parameters in query strings. Verified with updated unit tests in `tasks_test.go`.

--- a/third_party/crowdin-api-client-go/crowdin/model/tasks.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/tasks.go
@@ -110,6 +110,8 @@ type TasksListOptions struct {
 	Status []TaskStatus `json:"status,omitempty"`
 	// List tasks for specified assignee.
 	AssigneeID int `json:"assigneeId,omitempty"`
+	// List tasks for specified creator.
+	CreatorID int `json:"creatorId,omitempty"`
 	// List tasks for specified workflow step.
 	WorkflowStepID int `json:"workflowStepId,omitempty"`
 	// Filter tasks by labelIds.
@@ -137,6 +139,9 @@ func (o *TasksListOptions) Values() (url.Values, bool) {
 	}
 	if o.AssigneeID > 0 {
 		v.Add("assigneeId", strconv.Itoa(o.AssigneeID))
+	}
+	if o.CreatorID > 0 {
+		v.Add("creatorId", strconv.Itoa(o.CreatorID))
 	}
 	if o.WorkflowStepID > 0 {
 		v.Add("workflowStepId", strconv.Itoa(o.WorkflowStepID))
@@ -944,6 +949,8 @@ type UserTasksListOptions struct {
 	// or a list of status values.
 	// Enum: todo, in_progress, done, closed.
 	Status []TaskStatus `json:"status,omitempty"`
+	// Project identifier.
+	ProjectID int `json:"projectId,omitempty"`
 	// List archived/not archived tasks for the authorized user.
 	// Enum: 1 - archived, 0 - not archived. Default: 0.
 	IsArchived *int `json:"isArchived,omitempty"`
@@ -965,6 +972,9 @@ func (o *UserTasksListOptions) Values() (url.Values, bool) {
 	}
 	if len(o.Status) > 0 {
 		v.Add("status", JoinSlice(o.Status))
+	}
+	if o.ProjectID > 0 {
+		v.Add("projectId", strconv.Itoa(o.ProjectID))
 	}
 	if o.IsArchived != nil {
 		v.Add("isArchived", strconv.Itoa(*o.IsArchived))

--- a/third_party/crowdin-api-client-go/crowdin/model/tasks_test.go
+++ b/third_party/crowdin-api-client-go/crowdin/model/tasks_test.go
@@ -24,10 +24,10 @@ func TestTasksListOptionsValues(t *testing.T) {
 			name: "all options",
 			opts: &TasksListOptions{
 				OrderBy: "createdAt desc,name", Status: []TaskStatus{TaskStatusTodo, TaskStatusDone},
-				AssigneeID: 1, ListOptions: ListOptions{Limit: 10, Offset: 5},
+				AssigneeID: 1, CreatorID: 2, ListOptions: ListOptions{Limit: 10, Offset: 5},
 				LabelIDs: []int{1, 2}, ExcludeLabelIDs: []int{3, 4},
 			},
-			out: "assigneeId=1&excludeLabelIds=3%2C4&labelIds=1%2C2&limit=10&offset=5&orderBy=createdAt+desc%2Cname&status=todo%2Cdone",
+			out: "assigneeId=1&creatorId=2&excludeLabelIds=3%2C4&labelIds=1%2C2&limit=10&offset=5&orderBy=createdAt+desc%2Cname&status=todo%2Cdone",
 		},
 	}
 
@@ -68,9 +68,9 @@ func TestUserTasksListOptionsValues(t *testing.T) {
 			name: "all options",
 			opts: &UserTasksListOptions{
 				OrderBy: "createdAt desc,name", Status: []TaskStatus{TaskStatusTodo, TaskStatusDone},
-				IsArchived: toPtr(1), ListOptions: ListOptions{Limit: 10, Offset: 5},
+				ProjectID: 123, IsArchived: toPtr(1), ListOptions: ListOptions{Limit: 10, Offset: 5},
 			},
-			out: "isArchived=1&limit=10&offset=5&orderBy=createdAt+desc%2Cname&status=todo%2Cdone",
+			out: "isArchived=1&limit=10&offset=5&orderBy=createdAt+desc%2Cname&projectId=123&status=todo%2Cdone",
 		},
 	}
 


### PR DESCRIPTION
### 💡 What
Added missing query parameters to the Crowdin API client's task listing models:
- `CreatorID` added to `TasksListOptions` (List Project Tasks)
- `ProjectID` added to `UserTasksListOptions` (List User Tasks)

### 🎯 Why
To maintain parity with the official Crowdin API v2 documentation, which supports these filters. This allows Hyperlocalise or other consumers to filter tasks more granularly by creator or project.

### 📊 Impact
Improved API coverage and feature parity. Callers can now use these filters without manually constructing query strings.

### 🔬 Measurement
Updated `TestTasksListOptionsValues` and `TestUserTasksListOptionsValues` in `third_party/crowdin-api-client-go/crowdin/model/tasks_test.go` to verify correct serialization. All tests passed.

### 🔗 Docs
- https://developer.crowdin.com/api/v2/#operation/api.projects.tasks.getMany
- https://developer.crowdin.com/api/v2/#operation/api.user.tasks.getMany

---
*PR created automatically by Jules for task [3616421545541705989](https://jules.google.com/task/3616421545541705989) started by @cungminh2710*