### PR TITLE
fix(web): route invitees to dashboard after accept, not onboarding

### DIFF
--- a/apps/hyperlocalise-web/src/api/auth/identity-access-regression.test.ts
+++ b/apps/hyperlocalise-web/src/api/auth/identity-access-regression.test.ts
@@ -380,6 +380,72 @@ describe("enterprise identity access regression", () => {
 
       expect(user?.workosUserId).toBe(realWorkosUserId);
     });
+
+    it("promotes invited placeholders during session bootstrap and reconciles accepted membership", async () => {
+      const ownerIdentity = createWorkosIdentity();
+      await syncWorkosIdentity(db, ownerIdentity);
+
+      const pendingEmail = `session-promote-${randomUUID()}@example.com`;
+      const placeholderUserId = `${INVITED_WORKOS_USER_ID_PREFIX}${randomUUID()}`;
+      const realWorkosUserId = `user_${randomUUID()}`;
+      const workosMembershipId = `om_${randomUUID()}`;
+
+      trackWorkosUserId(placeholderUserId);
+      trackWorkosUserId(realWorkosUserId);
+
+      await syncWorkosIdentity(db, {
+        user: {
+          workosUserId: placeholderUserId,
+          email: pendingEmail,
+        },
+        organization: ownerIdentity.organization,
+        membership: {
+          role: "member",
+        },
+      });
+
+      listMembershipsMock.mockResolvedValue({
+        autoPagination: async () => [
+          {
+            id: workosMembershipId,
+            organizationId: ownerIdentity.organization.workosOrganizationId,
+            status: "active",
+            role: { slug: "member" },
+          },
+        ],
+      });
+      getOrganizationMock.mockResolvedValue({
+        id: ownerIdentity.organization.workosOrganizationId,
+        name: ownerIdentity.organization.name,
+      });
+
+      withAuthMock.mockResolvedValue({
+        user: {
+          id: realWorkosUserId,
+          email: pendingEmail,
+          firstName: null,
+          lastName: null,
+          profilePictureUrl: null,
+        },
+        organizationId: ownerIdentity.organization.workosOrganizationId,
+      });
+
+      const { resolveApiAuthContextFromSession } = await import("./workos-session");
+      const auth = await resolveApiAuthContextFromSession();
+
+      expect(auth?.membership.accessSource).toBe("workos_authoritative");
+      expect(auth?.activeOrganization.workosOrganizationId).toBe(
+        ownerIdentity.organization.workosOrganizationId,
+      );
+
+      const [user] = await db
+        .select({ workosUserId: schema.users.workosUserId })
+        .from(schema.users)
+        .where(eq(schema.users.email, pendingEmail))
+        .limit(1);
+
+      expect(user?.workosUserId).toBe(realWorkosUserId);
+    });
   });
 
   describe("route authorization for membership states", () => {

--- a/apps/hyperlocalise-web/src/api/auth/workos-session.test.ts
+++ b/apps/hyperlocalise-web/src/api/auth/workos-session.test.ts
@@ -296,6 +296,34 @@ describe("resolveApiAuthContextFromSession", () => {
     );
   });
 
+  it("forces membership reconcile when the WorkOS session includes an organization", async () => {
+    const identity = fixture.createWorkosIdentity();
+    await syncWorkosIdentity(db, identity);
+
+    withAuthMock.mockResolvedValue({
+      user: {
+        id: identity.user.workosUserId,
+        email: identity.user.email,
+        firstName: identity.user.firstName ?? null,
+        lastName: identity.user.lastName ?? null,
+        profilePictureUrl: identity.user.avatarUrl ?? null,
+      },
+      organizationId: identity.organization.workosOrganizationId,
+    });
+
+    const { resolveApiAuthContextFromSession } = await import("./workos-session");
+    await resolveApiAuthContextFromSession();
+
+    expect(reconcileWorkosMembershipsMock).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({
+        workosUserId: identity.user.workosUserId,
+        workosOrganizationId: identity.organization.workosOrganizationId,
+        force: true,
+      }),
+    );
+  });
+
   it("uses the injected session without performing another withAuth lookup", async () => {
     const identity = fixture.createWorkosIdentity();
     await syncWorkosIdentity(db, identity);

--- a/apps/hyperlocalise-web/src/api/auth/workos-session.test.ts
+++ b/apps/hyperlocalise-web/src/api/auth/workos-session.test.ts
@@ -9,10 +9,12 @@ import type { WorkosAuthIdentity } from "@/api/auth/workos";
 import { createProjectTestFixture } from "@/api/routes/project/project.fixture";
 import { setMembershipReplacingSentinelForTest } from "@/api/test-cleanup";
 
-const { withAuthMock, reconcileWorkosMembershipsMock } = vi.hoisted(() => ({
-  withAuthMock: vi.fn(),
-  reconcileWorkosMembershipsMock: vi.fn().mockResolvedValue({ status: "skipped" }),
-}));
+const { withAuthMock, reconcileWorkosMembershipsMock, promoteInvitedPlaceholderUserMock } =
+  vi.hoisted(() => ({
+    withAuthMock: vi.fn(),
+    reconcileWorkosMembershipsMock: vi.fn().mockResolvedValue({ status: "skipped" }),
+    promoteInvitedPlaceholderUserMock: vi.fn().mockResolvedValue(false),
+  }));
 
 vi.mock("@workos-inc/authkit-nextjs", () => ({
   withAuth: withAuthMock,
@@ -26,6 +28,14 @@ vi.mock("./workos-membership-reconcile", async (importOriginal) => {
   };
 });
 
+vi.mock("@/api/auth/workos-sync", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/auth/workos-sync")>();
+  return {
+    ...actual,
+    promoteInvitedPlaceholderUser: promoteInvitedPlaceholderUserMock,
+  };
+});
+
 describe("resolveApiAuthContextFromSession", () => {
   const fixture = createProjectTestFixture();
 
@@ -36,6 +46,7 @@ describe("resolveApiAuthContextFromSession", () => {
   afterEach(async () => {
     vi.clearAllMocks();
     reconcileWorkosMembershipsMock.mockResolvedValue({ status: "skipped" });
+    promoteInvitedPlaceholderUserMock.mockResolvedValue(false);
     await fixture.cleanup();
   });
 
@@ -314,11 +325,61 @@ describe("resolveApiAuthContextFromSession", () => {
     const { resolveApiAuthContextFromSession } = await import("./workos-session");
     await resolveApiAuthContextFromSession();
 
+    expect(promoteInvitedPlaceholderUserMock).toHaveBeenCalledWith(db, {
+      email: identity.user.email,
+      workosUserId: identity.user.workosUserId,
+    });
     expect(reconcileWorkosMembershipsMock).toHaveBeenCalledWith(
       db,
       expect.objectContaining({
         workosUserId: identity.user.workosUserId,
         workosOrganizationId: identity.organization.workosOrganizationId,
+        force: true,
+      }),
+    );
+  });
+
+  it("forces membership reconcile when an invited placeholder user is promoted", async () => {
+    const identity = fixture.createWorkosIdentity();
+    await syncWorkosIdentity(db, identity);
+
+    promoteInvitedPlaceholderUserMock.mockResolvedValueOnce(true);
+    withAuthMock.mockResolvedValue({
+      user: {
+        id: identity.user.workosUserId,
+        email: identity.user.email,
+      },
+      organizationId: null,
+    });
+
+    const { resolveApiAuthContextFromSession } = await import("./workos-session");
+    await resolveApiAuthContextFromSession();
+
+    expect(reconcileWorkosMembershipsMock).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({
+        workosUserId: identity.user.workosUserId,
+        force: true,
+      }),
+    );
+  });
+
+  it("skips placeholder promotion when the session user has no email", async () => {
+    const identity = fixture.createWorkosIdentity();
+    await syncWorkosIdentity(db, identity);
+
+    withAuthMock.mockResolvedValue({
+      user: { id: identity.user.workosUserId },
+      organizationId: identity.organization.workosOrganizationId,
+    });
+
+    const { resolveApiAuthContextFromSession } = await import("./workos-session");
+    await resolveApiAuthContextFromSession();
+
+    expect(promoteInvitedPlaceholderUserMock).not.toHaveBeenCalled();
+    expect(reconcileWorkosMembershipsMock).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({
         force: true,
       }),
     );

--- a/apps/hyperlocalise-web/src/api/auth/workos-session.ts
+++ b/apps/hyperlocalise-web/src/api/auth/workos-session.ts
@@ -237,10 +237,12 @@ export async function resolveApiAuthContextFromSession(
     return null;
   }
 
-  const promotedPlaceholder = await promoteInvitedPlaceholderUser(db, {
-    email: session.user.email,
-    workosUserId: session.user.id,
-  });
+  const promotedPlaceholder = session.user.email
+    ? await promoteInvitedPlaceholderUser(db, {
+        email: session.user.email,
+        workosUserId: session.user.id,
+      })
+    : false;
 
   const reconcileResult = await reconcileWorkosMembershipsForUser(db, {
     workosUserId: session.user.id,

--- a/apps/hyperlocalise-web/src/api/auth/workos-session.ts
+++ b/apps/hyperlocalise-web/src/api/auth/workos-session.ts
@@ -7,6 +7,7 @@ import {
   assertWorkosMembershipReconcileAllowsAccess,
   reconcileWorkosMembershipsForUser,
 } from "@/api/auth/workos-membership-reconcile";
+import { promoteInvitedPlaceholderUser } from "@/api/auth/workos-sync";
 import type { ApiAuthContext } from "@/api/auth/workos";
 import { db, schema } from "@/lib/database";
 import { REPLACING_WORKOS_MEMBERSHIP_ID } from "@/lib/workos/constants";
@@ -236,12 +237,19 @@ export async function resolveApiAuthContextFromSession(
     return null;
   }
 
+  const promotedPlaceholder = await promoteInvitedPlaceholderUser(db, {
+    email: session.user.email,
+    workosUserId: session.user.id,
+  });
+
   const reconcileResult = await reconcileWorkosMembershipsForUser(db, {
     workosUserId: session.user.id,
     email: session.user.email,
     firstName: session.user.firstName ?? undefined,
     lastName: session.user.lastName ?? undefined,
     avatarUrl: session.user.profilePictureUrl ?? undefined,
+    workosOrganizationId: session.organizationId ?? undefined,
+    force: promotedPlaceholder || Boolean(session.organizationId),
   });
 
   await assertWorkosMembershipReconcileAllowsAccess(db, session.user.id, reconcileResult);

--- a/apps/hyperlocalise-web/src/api/auth/workos-sync.test.ts
+++ b/apps/hyperlocalise-web/src/api/auth/workos-sync.test.ts
@@ -130,6 +130,15 @@ describe("promoteInvitedPlaceholderUser", () => {
 
     expect(promoted).toBe(false);
   });
+
+  it("returns false when the email is blank", async () => {
+    const promoted = await promoteInvitedPlaceholderUser(db, {
+      email: "   ",
+      workosUserId: "user_real",
+    });
+
+    expect(promoted).toBe(false);
+  });
 });
 
 describe("revokeOrganizationMembershipAccess", () => {

--- a/apps/hyperlocalise-web/src/api/auth/workos-sync.ts
+++ b/apps/hyperlocalise-web/src/api/auth/workos-sync.ts
@@ -143,7 +143,10 @@ export async function promoteInvitedPlaceholderUser(
   database: DatabaseClient,
   input: { email: string; workosUserId: string },
 ): Promise<boolean> {
-  const normalizedEmail = input.email.trim().toLowerCase();
+  const normalizedEmail = input.email?.trim().toLowerCase();
+  if (!normalizedEmail) {
+    return false;
+  }
 
   const [invitedUser] = await database
     .select({ id: schema.users.id })

--- a/apps/hyperlocalise-web/src/api/routes/external-tms-provider-credential/tms-user-oauth-log-context.ts
+++ b/apps/hyperlocalise-web/src/api/routes/external-tms-provider-credential/tms-user-oauth-log-context.ts
@@ -344,8 +344,7 @@ export function buildTmsUserOAuthProfileLookupLogContext(input: {
     context.status = input.error.status;
     context.apiEndpoint = buildProfileLookupEndpoint({
       resolvedBaseUrl,
-      requestPath:
-        extractRequestPathFromProviderApiError(input.error) ?? config.defaultRequestPath,
+      requestPath: extractRequestPathFromProviderApiError(input.error) ?? config.defaultRequestPath,
     });
 
     const sanitizedResponse = sanitizeProviderApiErrorResponseBody(input.error.responseBody);
@@ -365,8 +364,7 @@ export function buildTmsUserOAuthProfileLookupLogContext(input: {
     context.errorType = input.error.constructor.name;
     context.apiEndpoint = buildProfileLookupEndpoint({
       resolvedBaseUrl,
-      requestPath:
-        extractRequestPathFromProviderApiError(input.error) ?? config.defaultRequestPath,
+      requestPath: extractRequestPathFromProviderApiError(input.error) ?? config.defaultRequestPath,
     });
     return context;
   }

--- a/apps/hyperlocalise-web/src/app/auth/access-denied/page.tsx
+++ b/apps/hyperlocalise-web/src/app/auth/access-denied/page.tsx
@@ -12,6 +12,7 @@ type AccessDeniedReason =
   | "workspace-archived"
   | "insufficient-permissions"
   | "missing-org-slug"
+  | "pending-invite"
   | "callback";
 
 function getAccessDeniedCopy(reason: AccessDeniedReason | undefined, intl: IntlShape) {
@@ -90,6 +91,27 @@ function getAccessDeniedCopy(reason: AccessDeniedReason | undefined, intl: IntlS
             "Choose an organization from your account or contact support if this continues.",
           id: "I9aLSBsZbT",
           description: "Access denied page guidance when the organization slug is missing",
+        }),
+      };
+    case "pending-invite":
+      return {
+        title: intl.formatMessage({
+          defaultMessage: "Invitation pending",
+          id: "+yMkmaDvaM",
+          description:
+            "Access denied page title when the user has not finished accepting an invite",
+        }),
+        description: intl.formatMessage({
+          defaultMessage:
+            "Your account is signed in, but this workspace invitation has not been confirmed yet.",
+          id: "Xc6qahwRY8",
+          description: "Access denied page summary when the user has a pending workspace invite",
+        }),
+        body: intl.formatMessage({
+          defaultMessage:
+            "Open the invitation email from your workspace admin and finish accepting the invite, then sign in again.",
+          id: "FE2l2eesst",
+          description: "Access denied page guidance when the user has a pending workspace invite",
         }),
       };
     case "callback":

--- a/apps/hyperlocalise-web/src/lib/workos/app-auth.test.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/app-auth.test.ts
@@ -8,6 +8,7 @@ const {
   resolveApiAuthContextFromSessionMock,
   getStoredActiveOrganizationSlugMock,
   setStoredActiveOrganizationSlugMock,
+  redirectForMissingOrganizationAccessMock,
 } = vi.hoisted(() => ({
   redirectMock: vi.fn((location: string) => {
     throw new Error(`redirect:${location}`);
@@ -16,6 +17,9 @@ const {
   resolveApiAuthContextFromSessionMock: vi.fn(),
   getStoredActiveOrganizationSlugMock: vi.fn(),
   setStoredActiveOrganizationSlugMock: vi.fn(),
+  redirectForMissingOrganizationAccessMock: vi.fn(async () => {
+    throw new Error("redirect:/auth/onboarding");
+  }),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -37,6 +41,10 @@ vi.mock("@/api/auth/workos-session", async (importOriginal) => {
 vi.mock("@/lib/workos/active-organization", () => ({
   getStoredActiveOrganizationSlug: getStoredActiveOrganizationSlugMock,
   setStoredActiveOrganizationSlug: setStoredActiveOrganizationSlugMock,
+}));
+
+vi.mock("@/lib/workos/missing-organization-access", () => ({
+  redirectForMissingOrganizationAccess: redirectForMissingOrganizationAccessMock,
 }));
 
 describe("requireAppAuthContext", () => {
@@ -65,7 +73,7 @@ describe("requireAppAuthContext", () => {
     expect(redirectMock).toHaveBeenCalledWith("/auth/select-organization");
   });
 
-  it("redirects to onboarding when org access is denied", async () => {
+  it("routes missing organization access through the shared redirect helper", async () => {
     const session = {
       user: { id: "user_123", email: "person@example.com" },
       organizationId: null,
@@ -79,10 +87,10 @@ describe("requireAppAuthContext", () => {
     await expect(requireAppAuthContext({ organizationSlug: "stale-slug" })).rejects.toThrow(
       "redirect:/auth/onboarding",
     );
-    expect(redirectMock).toHaveBeenCalledWith("/auth/onboarding");
+    expect(redirectForMissingOrganizationAccessMock).toHaveBeenCalledWith("person@example.com");
   });
 
-  it("redirects to onboarding when the signed-in user has no memberships yet", async () => {
+  it("routes users without memberships through the shared redirect helper", async () => {
     const session = {
       user: { id: "user_123", email: "person@example.com" },
       organizationId: null,
@@ -94,7 +102,7 @@ describe("requireAppAuthContext", () => {
     const { requireAppAuthContext } = await import("./app-auth");
 
     await expect(requireAppAuthContext()).rejects.toThrow("redirect:/auth/onboarding");
-    expect(redirectMock).toHaveBeenCalledWith("/auth/onboarding");
+    expect(redirectForMissingOrganizationAccessMock).toHaveBeenCalledWith("person@example.com");
   });
 
   it("can ignore the stored active organization when resolving memberships", async () => {

--- a/apps/hyperlocalise-web/src/lib/workos/app-auth.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/app-auth.ts
@@ -13,6 +13,7 @@ import {
   getStoredActiveOrganizationSlug,
   setStoredActiveOrganizationSlug,
 } from "@/lib/workos/active-organization";
+import { redirectForMissingOrganizationAccess } from "@/lib/workos/missing-organization-access";
 
 export type AppAuthContext = ApiAuthContext & {
   sessionUser: NonNullable<Awaited<ReturnType<typeof withAuth>>["user"]>;
@@ -56,7 +57,7 @@ export async function requireAppAuthContext(options: RequireAppAuthContextOption
     }
 
     if (error instanceof Error && error.message === "organization_access_denied") {
-      redirect("/auth/onboarding");
+      return redirectForMissingOrganizationAccess(session.user.email);
     }
 
     if (error instanceof Error && error.message === "workos_membership_lookup_failed") {
@@ -67,7 +68,7 @@ export async function requireAppAuthContext(options: RequireAppAuthContextOption
   }
 
   if (!auth) {
-    redirect("/auth/onboarding");
+    return redirectForMissingOrganizationAccess(session.user.email);
   }
 
   return {

--- a/apps/hyperlocalise-web/src/lib/workos/missing-organization-access.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/missing-organization-access.ts
@@ -1,0 +1,39 @@
+import { redirect } from "next/navigation";
+import { and, eq, isNull, or } from "drizzle-orm";
+
+import { db, schema } from "@/lib/database";
+import { REPLACING_WORKOS_MEMBERSHIP_ID } from "@/lib/workos/constants";
+
+export async function hasPendingOrganizationMembership(email: string): Promise<boolean> {
+  const normalizedEmail = email.trim().toLowerCase();
+
+  const [membership] = await db
+    .select({ id: schema.organizationMemberships.id })
+    .from(schema.organizationMemberships)
+    .innerJoin(schema.users, eq(schema.organizationMemberships.userId, schema.users.id))
+    .innerJoin(
+      schema.organizations,
+      eq(schema.organizationMemberships.organizationId, schema.organizations.id),
+    )
+    .where(
+      and(
+        eq(schema.users.email, normalizedEmail),
+        eq(schema.organizations.lifecycleStatus, "active"),
+        or(
+          isNull(schema.organizationMemberships.workosMembershipId),
+          eq(schema.organizationMemberships.workosMembershipId, REPLACING_WORKOS_MEMBERSHIP_ID),
+        ),
+      ),
+    )
+    .limit(1);
+
+  return Boolean(membership);
+}
+
+export async function redirectForMissingOrganizationAccess(email: string): Promise<never> {
+  if (await hasPendingOrganizationMembership(email)) {
+    redirect("/auth/access-denied?reason=pending-invite");
+  }
+
+  redirect("/auth/onboarding");
+}


### PR DESCRIPTION
## What changed

Invited users were incorrectly sent to `/auth/onboarding` (the create-workspace wizard) after accepting an invite or while an invite was still pending.

This PR fixes post-invite routing in two ways:

1. **Session bootstrap** — On login, promote invited placeholder users (`invited_user_*` → real WorkOS user id) and force membership reconcile when promotion succeeds or the WorkOS session includes an `organizationId`. That syncs the confirmed `workos_membership_id` on the first login after accept, so `/dashboard` can resolve org access and redirect to `/org/{slug}/dashboard`.

2. **Fallback routing** — When org access still cannot be resolved, distinguish pending invitees from brand-new users:
   - Pending local membership (`workos_membership_id IS NULL` or replacing sentinel) → `/auth/access-denied?reason=pending-invite`
   - No pending invite → `/auth/onboarding` (create first workspace)

Also adds access-denied copy for the pending-invite case.

## How to test

- [ ] Invite a new user by email, accept the invite via WorkOS, and sign in — should land on `/org/{slug}/dashboard`, not onboarding
- [ ] Invite an existing user, accept, and sign in — same expected result
- [ ] Sign in as a user with a pending (unaccepted) invite — should see access denied with “Invitation pending”, not the create-workspace wizard
- [ ] Sign in as a brand-new user with no invite — should still see onboarding