### PR TITLE
fix(web): unblock users stuck on invitation pending after WorkOS acceptance

### DIFF
--- a/apps/hyperlocalise-web/src/api/auth/identity-access-regression.test.ts
+++ b/apps/hyperlocalise-web/src/api/auth/identity-access-regression.test.ts
@@ -202,6 +202,63 @@ describe("enterprise identity access regression", () => {
       ).resolves.toBeNull();
     });
 
+    it("grants access when an existing user accepted a pending invite even if reconcile TTL would skip", async () => {
+      const ownerIdentity = createWorkosIdentity();
+      const existingUserIdentity = createWorkosIdentity();
+      const ownerSynced = await syncWorkosIdentity(db, ownerIdentity);
+      const existingSynced = await syncWorkosIdentity(db, existingUserIdentity);
+      const workosMembershipId = `om_${randomUUID()}`;
+
+      await db.insert(schema.organizationMemberships).values({
+        organizationId: ownerSynced.organization.id,
+        userId: existingSynced.user.id,
+        role: "member",
+        workosMembershipId: null,
+      });
+
+      await db
+        .update(schema.users)
+        .set({ workosMembershipsReconciledAt: new Date() })
+        .where(eq(schema.users.workosUserId, existingUserIdentity.user.workosUserId));
+
+      listMembershipsMock.mockResolvedValue({
+        autoPagination: async () => [
+          {
+            id: workosMembershipId,
+            organizationId: ownerIdentity.organization.workosOrganizationId,
+            status: "active",
+            role: { slug: "member" },
+          },
+        ],
+      });
+      getOrganizationMock.mockResolvedValue({
+        id: ownerIdentity.organization.workosOrganizationId,
+        name: ownerIdentity.organization.name,
+      });
+
+      withAuthMock.mockResolvedValue({
+        user: {
+          id: existingUserIdentity.user.workosUserId,
+          email: existingUserIdentity.user.email,
+          firstName: null,
+          lastName: null,
+          profilePictureUrl: null,
+        },
+        organizationId: null,
+      });
+
+      const { resolveApiAuthContextFromSession } = await import("./workos-session");
+      const auth = await resolveApiAuthContextFromSession({
+        organizationSlug: ownerIdentity.organization.slug,
+      });
+
+      expect(listMembershipsMock).toHaveBeenCalled();
+      expect(auth?.membership.accessSource).toBe("workos_authoritative");
+      expect(auth?.activeOrganization.workosOrganizationId).toBe(
+        ownerIdentity.organization.workosOrganizationId,
+      );
+    });
+
     it("denies access while invite replacement sentinel is set", async () => {
       const identity = createWorkosIdentity();
       const synced = await syncWorkosIdentity(db, identity);

--- a/apps/hyperlocalise-web/src/api/auth/workos-membership-reconcile.test.ts
+++ b/apps/hyperlocalise-web/src/api/auth/workos-membership-reconcile.test.ts
@@ -1,5 +1,6 @@
 import "dotenv/config";
 
+import { randomUUID } from "node:crypto";
 import { eq } from "drizzle-orm";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
 
@@ -267,6 +268,69 @@ describe("reconcileWorkosMembershipsForUser", () => {
     });
 
     expect(result.status).toBe("lookup_failed");
+  });
+
+  it("links accepted WorkOS memberships when the role slug is unknown but a pending local invite exists", async () => {
+    const ownerIdentity = createWorkosIdentity();
+    await syncWorkosIdentity(db, ownerIdentity);
+
+    const pendingEmail = `pending-role-${randomUUID()}@example.com`;
+    const realWorkosUserId = `user_${randomUUID()}`;
+    const workosMembershipId = `om_${randomUUID()}`;
+
+    await syncWorkosIdentity(db, {
+      user: {
+        workosUserId: `${INVITED_WORKOS_USER_ID_PREFIX}${randomUUID()}`,
+        email: pendingEmail,
+      },
+      organization: ownerIdentity.organization,
+      membership: {
+        role: "member",
+      },
+    });
+
+    listMembershipsMock.mockResolvedValue({
+      autoPagination: async () => [
+        {
+          id: workosMembershipId,
+          organizationId: ownerIdentity.organization.workosOrganizationId,
+          status: "active",
+          role: { slug: "unsupported-workos-role" },
+        },
+      ],
+    });
+    getOrganizationMock.mockResolvedValue({
+      id: ownerIdentity.organization.workosOrganizationId,
+      name: ownerIdentity.organization.name,
+    });
+
+    const { reconcileWorkosMembershipsForUser } = await import("./workos-membership-reconcile");
+    const result = await reconcileWorkosMembershipsForUser(db, {
+      workosUserId: realWorkosUserId,
+      email: pendingEmail,
+      force: true,
+    });
+
+    expect(result).toMatchObject({ status: "reconciled", updated: 1 });
+
+    const [membership] = await db
+      .select({
+        workosMembershipId: schema.organizationMemberships.workosMembershipId,
+        role: schema.organizationMemberships.role,
+        workosUserId: schema.users.workosUserId,
+      })
+      .from(schema.organizationMemberships)
+      .innerJoin(schema.users, eq(schema.organizationMemberships.userId, schema.users.id))
+      .innerJoin(
+        schema.organizations,
+        eq(schema.organizationMemberships.organizationId, schema.organizations.id),
+      )
+      .where(eq(schema.users.email, pendingEmail))
+      .limit(1);
+
+    expect(membership?.workosUserId).toBe(realWorkosUserId);
+    expect(membership?.workosMembershipId).toBe(workosMembershipId);
+    expect(membership?.role).toBe("member");
   });
 });
 

--- a/apps/hyperlocalise-web/src/api/auth/workos-membership-reconcile.ts
+++ b/apps/hyperlocalise-web/src/api/auth/workos-membership-reconcile.ts
@@ -2,12 +2,14 @@ import { and, eq, isNotNull, ne } from "drizzle-orm";
 import type { OrganizationMembership } from "@workos-inc/node";
 
 import {
+  promoteInvitedPlaceholderUser,
   revokeOrganizationMembershipAccess,
   syncWorkosIdentity,
   syncWorkosOrganization,
   syncWorkosUser,
 } from "@/api/auth/workos-sync";
 import type { DatabaseClient } from "@/lib/database";
+import type { OrganizationMembershipRole } from "@/lib/database/types";
 import * as schema from "@/lib/database/schema";
 import { env } from "@/lib/env";
 import { createLogger } from "@/lib/log";
@@ -114,6 +116,76 @@ async function listActiveWorkosMembershipsForUser(input: {
   return page.autoPagination();
 }
 
+async function findLocalOrganizationMembership(input: {
+  database: DatabaseClient;
+  workosUserId: string;
+  email: string;
+  workosOrganizationId: string;
+}) {
+  const normalizedEmail = input.email.trim().toLowerCase();
+
+  const membershipSelection = {
+    workosMembershipId: schema.organizationMemberships.workosMembershipId,
+    role: schema.organizationMemberships.role,
+  };
+
+  const [byWorkosUserId] = await input.database
+    .select(membershipSelection)
+    .from(schema.organizationMemberships)
+    .innerJoin(schema.users, eq(schema.organizationMemberships.userId, schema.users.id))
+    .innerJoin(
+      schema.organizations,
+      eq(schema.organizationMemberships.organizationId, schema.organizations.id),
+    )
+    .where(
+      and(
+        eq(schema.users.workosUserId, input.workosUserId),
+        eq(schema.organizations.workosOrganizationId, input.workosOrganizationId),
+      ),
+    )
+    .limit(1);
+
+  if (byWorkosUserId) {
+    return byWorkosUserId;
+  }
+
+  const [byEmail] = await input.database
+    .select(membershipSelection)
+    .from(schema.organizationMemberships)
+    .innerJoin(schema.users, eq(schema.organizationMemberships.userId, schema.users.id))
+    .innerJoin(
+      schema.organizations,
+      eq(schema.organizationMemberships.organizationId, schema.organizations.id),
+    )
+    .where(
+      and(
+        eq(schema.users.email, normalizedEmail),
+        eq(schema.organizations.workosOrganizationId, input.workosOrganizationId),
+      ),
+    )
+    .limit(1);
+
+  return byEmail ?? null;
+}
+
+async function findPendingLocalMembershipRole(input: {
+  database: DatabaseClient;
+  workosUserId: string;
+  email: string;
+  workosOrganizationId: string;
+}): Promise<OrganizationMembershipRole | null> {
+  const membership = await findLocalOrganizationMembership(input);
+  if (!membership) {
+    return null;
+  }
+
+  const isPending =
+    membership.workosMembershipId == null ||
+    membership.workosMembershipId === REPLACING_WORKOS_MEMBERSHIP_ID;
+
+  return isPending ? membership.role : null;
+}
+
 async function ensureLocalOrganizationForWorkosMembership(
   database: DatabaseClient,
   membership: OrganizationMembership,
@@ -186,6 +258,13 @@ export async function reconcileWorkosMembershipsForUser(
     };
   }
 
+  if (input.email) {
+    await promoteInvitedPlaceholderUser(database, {
+      email: input.email,
+      workosUserId: input.workosUserId,
+    });
+  }
+
   await syncWorkosUser(database, {
     workosUserId: input.workosUserId,
     email: input.email,
@@ -203,14 +282,30 @@ export async function reconcileWorkosMembershipsForUser(
       continue;
     }
 
-    const role = membershipRoleFromUnknownRoleField(remoteMembership.role);
+    let role = membershipRoleFromUnknownRoleField(remoteMembership.role);
     if (!role) {
-      logger.warn("workos_membership_unknown_role_slug", {
+      role = await findPendingLocalMembershipRole({
+        database,
+        workosUserId: input.workosUserId,
+        email: input.email,
+        workosOrganizationId: remoteMembership.organizationId,
+      });
+
+      if (!role) {
+        logger.warn("workos_membership_unknown_role_slug", {
+          workosUserId: input.workosUserId,
+          workosMembershipId: remoteMembership.id,
+          workosOrganizationId: remoteMembership.organizationId,
+        });
+        continue;
+      }
+
+      logger.info("workos_membership_linked_pending_invite_with_local_role", {
         workosUserId: input.workosUserId,
         workosMembershipId: remoteMembership.id,
         workosOrganizationId: remoteMembership.organizationId,
+        role,
       });
-      continue;
     }
 
     authoritativeMembershipIds.add(remoteMembership.id);
@@ -223,24 +318,12 @@ export async function reconcileWorkosMembershipsForUser(
       continue;
     }
 
-    const [existingMembership] = await database
-      .select({
-        workosMembershipId: schema.organizationMemberships.workosMembershipId,
-        role: schema.organizationMemberships.role,
-      })
-      .from(schema.organizationMemberships)
-      .innerJoin(schema.users, eq(schema.organizationMemberships.userId, schema.users.id))
-      .innerJoin(
-        schema.organizations,
-        eq(schema.organizationMemberships.organizationId, schema.organizations.id),
-      )
-      .where(
-        and(
-          eq(schema.users.workosUserId, input.workosUserId),
-          eq(schema.organizations.workosOrganizationId, remoteMembership.organizationId),
-        ),
-      )
-      .limit(1);
+    const existingMembership = await findLocalOrganizationMembership({
+      database,
+      workosUserId: input.workosUserId,
+      email: input.email,
+      workosOrganizationId: remoteMembership.organizationId,
+    });
 
     await syncWorkosIdentity(database, {
       user: {

--- a/apps/hyperlocalise-web/src/api/auth/workos-session.ts
+++ b/apps/hyperlocalise-web/src/api/auth/workos-session.ts
@@ -11,6 +11,7 @@ import { promoteInvitedPlaceholderUser } from "@/api/auth/workos-sync";
 import type { ApiAuthContext } from "@/api/auth/workos";
 import { db, schema } from "@/lib/database";
 import { REPLACING_WORKOS_MEMBERSHIP_ID } from "@/lib/workos/constants";
+import { hasPendingOrganizationMembershipForWorkosUser } from "@/lib/workos/missing-organization-access";
 import { resolveOrganizationMembershipAccessSource } from "@/lib/workos/membership-access";
 
 type ResolveApiAuthContextOptions = {
@@ -244,6 +245,10 @@ export async function resolveApiAuthContextFromSession(
       })
     : false;
 
+  const hasPendingLocalMembership = await hasPendingOrganizationMembershipForWorkosUser(
+    session.user.id,
+  );
+
   const reconcileResult = await reconcileWorkosMembershipsForUser(db, {
     workosUserId: session.user.id,
     email: session.user.email,
@@ -251,7 +256,7 @@ export async function resolveApiAuthContextFromSession(
     lastName: session.user.lastName ?? undefined,
     avatarUrl: session.user.profilePictureUrl ?? undefined,
     workosOrganizationId: session.organizationId ?? undefined,
-    force: promotedPlaceholder || Boolean(session.organizationId),
+    force: promotedPlaceholder || Boolean(session.organizationId) || hasPendingLocalMembership,
   });
 
   await assertWorkosMembershipReconcileAllowsAccess(db, session.user.id, reconcileResult);

--- a/apps/hyperlocalise-web/src/api/routes/external-tms-provider-credential/external-tms-provider-credential.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/external-tms-provider-credential/external-tms-provider-credential.route.ts
@@ -40,6 +40,7 @@ import {
   checkExternalTmsProviderHealth,
   persistExternalTmsProviderHealth,
 } from "@/lib/providers/external-tms-health-check";
+import { isCrowdinEnterpriseApiBaseUrl } from "@/lib/providers/adapters/crowdin/crowdin-base-url";
 import { getCrowdinOAuthScopeString } from "@/lib/providers/adapters/crowdin/crowdin-oauth-scopes";
 import { CrowdinApiClient, CrowdinApiError } from "@/lib/providers/adapters/crowdin/crowdin-api";
 import {
@@ -487,7 +488,9 @@ async function completeCrowdinUserOAuthLink(
       return redirectToUserOAuthReturnTo(c, {
         returnTo: input.returnTo,
         organizationSlug: input.organizationSlug,
-        error: "crowdin_user_oauth_invalid",
+        error: isCrowdinEnterpriseApiBaseUrl(input.credential.baseUrl)
+          ? "crowdin_user_oauth_enterprise_mismatch"
+          : "crowdin_user_oauth_invalid",
       });
     }
     return redirectToUserOAuthReturnTo(c, {

--- a/apps/hyperlocalise-web/src/app/auth/access-denied/page.tsx
+++ b/apps/hyperlocalise-web/src/app/auth/access-denied/page.tsx
@@ -110,7 +110,7 @@ function getAccessDeniedCopy(reason: AccessDeniedReason | undefined, intl: IntlS
         body: intl.formatMessage({
           defaultMessage:
             "Open the invitation email from your workspace admin and finish accepting the invite, then sign in again. If you already accepted, use Try again to refresh your membership.",
-          id: 'MikRGST8w6',
+          id: "MikRGST8w6",
           description: "Access denied page guidance when the user has a pending workspace invite",
         }),
       };
@@ -183,7 +183,7 @@ export default async function AccessDeniedPage({ searchParams }: AccessDeniedPag
   });
   const tryAgainLabel = intl.formatMessage({
     defaultMessage: "Try again",
-    id: 'sAOynMMuiJ',
+    id: "sAOynMMuiJ",
     description: "Button to retry sign-in after a pending workspace invite may have been accepted",
   });
 

--- a/apps/hyperlocalise-web/src/app/auth/access-denied/page.tsx
+++ b/apps/hyperlocalise-web/src/app/auth/access-denied/page.tsx
@@ -109,8 +109,8 @@ function getAccessDeniedCopy(reason: AccessDeniedReason | undefined, intl: IntlS
         }),
         body: intl.formatMessage({
           defaultMessage:
-            "Open the invitation email from your workspace admin and finish accepting the invite, then sign in again.",
-          id: "FE2l2eesst",
+            "Open the invitation email from your workspace admin and finish accepting the invite, then sign in again. If you already accepted, use Try again to refresh your membership.",
+          id: 'MikRGST8w6',
           description: "Access denied page guidance when the user has a pending workspace invite",
         }),
       };
@@ -181,6 +181,11 @@ export default async function AccessDeniedPage({ searchParams }: AccessDeniedPag
     id: "/14v/WK67D",
     description: "Button to return to the marketing site from the access denied page",
   });
+  const tryAgainLabel = intl.formatMessage({
+    defaultMessage: "Try again",
+    id: 'sAOynMMuiJ',
+    description: "Button to retry sign-in after a pending workspace invite may have been accepted",
+  });
 
   return (
     <main className="flex min-h-svh items-center justify-center bg-background px-4 py-10 text-foreground">
@@ -193,6 +198,11 @@ export default async function AccessDeniedPage({ searchParams }: AccessDeniedPag
           <TypographyP className="text-sm leading-6 text-muted-foreground">{copy.body}</TypographyP>
 
           <div className="flex flex-wrap gap-3">
+            {reason === "pending-invite" ? (
+              <Button nativeButton={false} render={<Link href="/dashboard" />}>
+                {tryAgainLabel}
+              </Button>
+            ) : null}
             <Button
               variant="outline"
               nativeButton={false}

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-base-url.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-base-url.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   CROWDIN_DEFAULT_API_BASE_URL,
   crowdinAuthenticatedUserUrl,
+  isCrowdinEnterpriseApiBaseUrl,
   normalizeCrowdinApiBaseUrl,
   resolveCrowdinApiBaseUrl,
 } from "./crowdin-base-url";
@@ -17,6 +18,8 @@ describe("crowdin-base-url", () => {
     expect(resolveCrowdinApiBaseUrl("https://enterprise.crowdin.test/api/v2")).toBe(
       "https://enterprise.crowdin.test/api/v2",
     );
+    expect(isCrowdinEnterpriseApiBaseUrl("https://enterprise.crowdin.test/api/v2")).toBe(true);
+    expect(isCrowdinEnterpriseApiBaseUrl()).toBe(false);
   });
 
   it("builds the authenticated user URL without duplicating /api/v2", () => {

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-base-url.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-base-url.ts
@@ -21,3 +21,12 @@ export function crowdinAuthenticatedUserUrl(baseUrl?: string | null): string | n
 
   return `${normalized}/user`;
 }
+
+export function isCrowdinEnterpriseApiBaseUrl(baseUrl?: string | null): boolean {
+  const normalized = normalizeCrowdinApiBaseUrl(baseUrl);
+  if (!normalized) {
+    return false;
+  }
+
+  return new URL(normalized).hostname !== "api.crowdin.com";
+}

--- a/apps/hyperlocalise-web/src/lib/providers/tms-user-oauth-error-copy.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-user-oauth-error-copy.test.ts
@@ -5,6 +5,7 @@ import { getTmsUserOAuthErrorCopy, isTmsUserOAuthErrorCode } from "./tms-user-oa
 describe("tms-user-oauth-error-copy", () => {
   it("recognizes known TMS user OAuth error codes", () => {
     expect(isTmsUserOAuthErrorCode("crowdin_user_oauth_invalid")).toBe(true);
+    expect(isTmsUserOAuthErrorCode("crowdin_user_oauth_enterprise_mismatch")).toBe(true);
     expect(isTmsUserOAuthErrorCode("invalid_lokalise_oauth_state")).toBe(true);
     expect(isTmsUserOAuthErrorCode("github_oauth_failed")).toBe(false);
   });
@@ -13,7 +14,10 @@ describe("tms-user-oauth-error-copy", () => {
     expect(getTmsUserOAuthErrorCopy("crowdin_user_oauth_invalid")).toEqual({
       title: "Crowdin account link failed",
       description:
-        "Crowdin rejected the access token returned during authorization. Try connecting again, then verify the OAuth app credentials if it repeats.",
+        "Crowdin returned an access token, but the Crowdin API rejected it when loading your profile. Try connecting again. If it keeps failing, verify the OAuth app client ID and secret in Integrations.",
+    });
+    expect(getTmsUserOAuthErrorCopy("crowdin_user_oauth_enterprise_mismatch")).toMatchObject({
+      title: "Crowdin Enterprise account link failed",
     });
     expect(getTmsUserOAuthErrorCopy("unknown_error")).toBeNull();
     expect(getTmsUserOAuthErrorCopy(null)).toBeNull();

--- a/apps/hyperlocalise-web/src/lib/providers/tms-user-oauth-error-copy.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-user-oauth-error-copy.ts
@@ -12,12 +12,17 @@ export const tmsUserOAuthErrorCopyByCode = {
   crowdin_user_oauth_invalid: {
     title: "Crowdin account link failed",
     description:
-      "Crowdin rejected the access token returned during authorization. Try connecting again, then verify the OAuth app credentials if it repeats.",
+      "Crowdin returned an access token, but the Crowdin API rejected it when loading your profile. Try connecting again. If it keeps failing, verify the OAuth app client ID and secret in Integrations.",
+  },
+  crowdin_user_oauth_enterprise_mismatch: {
+    title: "Crowdin Enterprise account link failed",
+    description:
+      "Crowdin returned an access token, but your Enterprise API rejected it when loading your profile. Create the OAuth app under Organization Settings → OAuth Apps in your Enterprise workspace (yourorg.crowdin.com), use that app's client ID and secret in Integrations, and when authorizing sign in with your Enterprise account—not a personal crowdin.com account.",
   },
   crowdin_user_lookup_failed: {
     title: "Crowdin account link failed",
     description:
-      "Hyperlocalise received a token but could not load the authorized Crowdin user. For Crowdin Enterprise, verify the API base URL uses your organization domain.",
+      "Hyperlocalise received a token but could not load the authorized Crowdin user. Try connecting again, or ask an admin to verify the integration base URL and OAuth app settings.",
   },
   crowdin_integration_not_connected: {
     title: "Crowdin integration is not connected",

--- a/apps/hyperlocalise-web/src/lib/workos/app-auth.test.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/app-auth.test.ts
@@ -87,7 +87,10 @@ describe("requireAppAuthContext", () => {
     await expect(requireAppAuthContext({ organizationSlug: "stale-slug" })).rejects.toThrow(
       "redirect:/auth/onboarding",
     );
-    expect(redirectForMissingOrganizationAccessMock).toHaveBeenCalledWith("person@example.com");
+    expect(redirectForMissingOrganizationAccessMock).toHaveBeenCalledWith({
+      email: "person@example.com",
+      workosUserId: "user_123",
+    });
   });
 
   it("routes users without memberships through the shared redirect helper", async () => {
@@ -102,7 +105,10 @@ describe("requireAppAuthContext", () => {
     const { requireAppAuthContext } = await import("./app-auth");
 
     await expect(requireAppAuthContext()).rejects.toThrow("redirect:/auth/onboarding");
-    expect(redirectForMissingOrganizationAccessMock).toHaveBeenCalledWith("person@example.com");
+    expect(redirectForMissingOrganizationAccessMock).toHaveBeenCalledWith({
+      email: "person@example.com",
+      workosUserId: "user_123",
+    });
   });
 
   it("can ignore the stored active organization when resolving memberships", async () => {

--- a/apps/hyperlocalise-web/src/lib/workos/app-auth.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/app-auth.ts
@@ -57,7 +57,10 @@ export async function requireAppAuthContext(options: RequireAppAuthContextOption
     }
 
     if (error instanceof Error && error.message === "organization_access_denied") {
-      return redirectForMissingOrganizationAccess(session.user.email);
+      return redirectForMissingOrganizationAccess({
+        email: session.user.email,
+        workosUserId: session.user.id,
+      });
     }
 
     if (error instanceof Error && error.message === "workos_membership_lookup_failed") {
@@ -68,7 +71,10 @@ export async function requireAppAuthContext(options: RequireAppAuthContextOption
   }
 
   if (!auth) {
-    return redirectForMissingOrganizationAccess(session.user.email);
+    return redirectForMissingOrganizationAccess({
+      email: session.user.email,
+      workosUserId: session.user.id,
+    });
   }
 
   return {

--- a/apps/hyperlocalise-web/src/lib/workos/missing-organization-access.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/missing-organization-access.ts
@@ -1,8 +1,17 @@
 import { redirect } from "next/navigation";
 import { and, eq, isNull, or } from "drizzle-orm";
 
+import { reconcileWorkosMembershipsForUser } from "@/api/auth/workos-membership-reconcile";
 import { db, schema } from "@/lib/database";
 import { REPLACING_WORKOS_MEMBERSHIP_ID } from "@/lib/workos/constants";
+
+const pendingMembershipConditions = [
+  eq(schema.organizations.lifecycleStatus, "active"),
+  or(
+    isNull(schema.organizationMemberships.workosMembershipId),
+    eq(schema.organizationMemberships.workosMembershipId, REPLACING_WORKOS_MEMBERSHIP_ID),
+  ),
+];
 
 export async function hasPendingOrganizationMembership(email: string): Promise<boolean> {
   const normalizedEmail = email.trim().toLowerCase();
@@ -15,23 +24,53 @@ export async function hasPendingOrganizationMembership(email: string): Promise<b
       schema.organizations,
       eq(schema.organizationMemberships.organizationId, schema.organizations.id),
     )
-    .where(
-      and(
-        eq(schema.users.email, normalizedEmail),
-        eq(schema.organizations.lifecycleStatus, "active"),
-        or(
-          isNull(schema.organizationMemberships.workosMembershipId),
-          eq(schema.organizationMemberships.workosMembershipId, REPLACING_WORKOS_MEMBERSHIP_ID),
-        ),
-      ),
-    )
+    .where(and(eq(schema.users.email, normalizedEmail), ...pendingMembershipConditions))
     .limit(1);
 
   return Boolean(membership);
 }
 
-export async function redirectForMissingOrganizationAccess(email: string): Promise<never> {
+export async function hasPendingOrganizationMembershipForWorkosUser(
+  workosUserId: string,
+): Promise<boolean> {
+  const [membership] = await db
+    .select({ id: schema.organizationMemberships.id })
+    .from(schema.organizationMemberships)
+    .innerJoin(schema.users, eq(schema.organizationMemberships.userId, schema.users.id))
+    .innerJoin(
+      schema.organizations,
+      eq(schema.organizationMemberships.organizationId, schema.organizations.id),
+    )
+    .where(and(eq(schema.users.workosUserId, workosUserId), ...pendingMembershipConditions))
+    .limit(1);
+
+  return Boolean(membership);
+}
+
+type RedirectForMissingOrganizationAccessInput = {
+  email: string;
+  workosUserId?: string;
+};
+
+export async function redirectForMissingOrganizationAccess(
+  input: RedirectForMissingOrganizationAccessInput | string,
+): Promise<never> {
+  const { email, workosUserId } =
+    typeof input === "string" ? { email: input, workosUserId: undefined } : input;
+
   if (await hasPendingOrganizationMembership(email)) {
+    if (workosUserId) {
+      await reconcileWorkosMembershipsForUser(db, {
+        workosUserId,
+        email,
+        force: true,
+      });
+
+      if (!(await hasPendingOrganizationMembership(email))) {
+        redirect("/dashboard");
+      }
+    }
+
     redirect("/auth/access-denied?reason=pending-invite");
   }
 


### PR DESCRIPTION
## What changed

Users who accepted a workspace invite in WorkOS could still land on **Invitation pending** (`/auth/access-denied?reason=pending-invite`) because Hyperlocalise’s local membership row was never linked to the active WorkOS membership.

This PR hardens the invite acceptance sync path:

- Force WorkOS membership reconcile on login when the user has any pending local membership (not only for placeholder users or org-scoped sessions).
- Retry a forced reconcile before showing the pending-invite screen; redirect to `/dashboard` if the local row is fixed.
- Promote invited placeholder users during reconcile, match pending memberships by email when WorkOS user IDs differ, and fall back to the locally invited role when WorkOS returns an unknown role slug.
- Add a **Try again** button and clearer copy on the pending-invite screen.

Also includes minor Crowdin Enterprise OAuth improvements: detect enterprise API base URLs, return a dedicated `crowdin_user_oauth_enterprise_mismatch` error when token exchange succeeds but the enterprise `/user` call fails, and improve related error copy.