### PR TITLE
refactor(web): remove WORKOS_ENABLED env flag

### DIFF
--- a/apps/hyperlocalise-web/src/api/auth/identity-access-regression.test.ts
+++ b/apps/hyperlocalise-web/src/api/auth/identity-access-regression.test.ts
@@ -36,10 +36,6 @@ vi.mock("@/lib/env", async (importOriginal) => {
           return "sk_test_identity_regression";
         }
 
-        if (property === "WORKOS_ENABLED") {
-          return true;
-        }
-
         return Reflect.get(target, property, receiver);
       },
     }),

--- a/apps/hyperlocalise-web/src/api/auth/workos-membership-reconcile.test.ts
+++ b/apps/hyperlocalise-web/src/api/auth/workos-membership-reconcile.test.ts
@@ -23,10 +23,6 @@ vi.mock("@/lib/env", async (importOriginal) => {
           return "sk_test_reconcile";
         }
 
-        if (property === "WORKOS_ENABLED") {
-          return true;
-        }
-
         return Reflect.get(target, property, receiver);
       },
     }),

--- a/apps/hyperlocalise-web/src/api/auth/workos-membership-reconcile.ts
+++ b/apps/hyperlocalise-web/src/api/auth/workos-membership-reconcile.ts
@@ -59,12 +59,7 @@ type ReconcileWorkosMembershipsInput = {
 };
 
 function isWorkosMembershipApiEnabled() {
-  if (
-    !isLiveWorkosApiKey({
-      workosEnabled: env.WORKOS_ENABLED,
-      apiKey: env.WORKOS_API_KEY,
-    })
-  ) {
+  if (!isLiveWorkosApiKey(env.WORKOS_API_KEY)) {
     return false;
   }
 

--- a/apps/hyperlocalise-web/src/lib/env.ts
+++ b/apps/hyperlocalise-web/src/lib/env.ts
@@ -40,12 +40,6 @@ export const env = createEnv({
     /** WorkOS API key for authentication and organization management. */
     WORKOS_API_KEY: z.string().min(1).optional(),
 
-    /** Enables live WorkOS API calls such as membership reconciliation. */
-    WORKOS_ENABLED: z
-      .enum(["true", "false"])
-      .default("false")
-      .transform((value) => value === "true"),
-
     /** WorkOS client ID for OAuth flows. */
     WORKOS_CLIENT_ID: z.string().min(1).optional(),
 
@@ -220,7 +214,6 @@ export const env = createEnv({
       (isTestEnv ? "test-github-oauth-state-secret" : undefined),
     CHAT_STATE_DATABASE_URL: process.env.CHAT_STATE_DATABASE_URL,
     WORKOS_API_KEY: process.env.WORKOS_API_KEY ?? (isTestEnv ? "test-workos-api-key" : undefined),
-    WORKOS_ENABLED: isTestEnv ? "false" : (process.env.WORKOS_ENABLED ?? "false"),
     WORKOS_CLIENT_ID: process.env.WORKOS_CLIENT_ID ?? (isTestEnv ? "client_test" : undefined),
     WORKOS_REDIRECT_URI:
       process.env.WORKOS_REDIRECT_URI ?? (isTestEnv ? "http://localhost:3000/callback" : undefined),

--- a/apps/hyperlocalise-web/src/lib/workos/constants.ts
+++ b/apps/hyperlocalise-web/src/lib/workos/constants.ts
@@ -29,13 +29,8 @@ export function shouldCleanupPlaceholderUserOnMemberRemoval(workosUserId: string
   return isInvitedPlaceholderWorkosUserId(workosUserId);
 }
 
-/** True when WorkOS API calls are explicitly enabled and a non-placeholder key is configured. */
-export function isLiveWorkosApiKey(input: { workosEnabled: boolean; apiKey: string | undefined }) {
-  if (!input.workosEnabled) {
-    return false;
-  }
-
-  const apiKey = input.apiKey;
+/** True when a non-placeholder WorkOS API key is configured. */
+export function isLiveWorkosApiKey(apiKey: string | undefined) {
   if (!apiKey) {
     return false;
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Removed the `WORKOS_ENABLED` environment variable. WorkOS is now always considered enabled; live API calls (such as membership reconciliation) are gated only by whether a real API key is configured via `isLiveWorkosApiKey()`.

## How to test

- Remove `WORKOS_ENABLED` from your local `.env` if present.
- Run `vp check --fix` and `vp test` in `apps/hyperlocalise-web`.
- Verify membership reconciliation still runs when `WORKOS_API_KEY` is a real `sk_` key.

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, `vp test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1de19a9-b7ef-48b9-bd87-53fe20c78b68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1de19a9-b7ef-48b9-bd87-53fe20c78b68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

