### PR TITLE
feat(hyperlocalise-web): add Crowdin progress skill and agent tool

### DIFF
--- a/apps/hyperlocalise-web/src/agents/_runtime/shared-skills/crowdin-progress.md
+++ b/apps/hyperlocalise-web/src/agents/_runtime/shared-skills/crowdin-progress.md
@@ -1,0 +1,36 @@
+## Crowdin progress checks
+
+Use `check_crowdin_progress` when the user asks about translation status, completion, or progress in Crowdin.
+
+### Prerequisites
+
+- The Hyperlocalise project must be linked to a Crowdin TMS project with valid credentials.
+- Prefer the conversation's attached project. Pass `projectId` only when the user names a different linked project.
+
+### Scope selection
+
+| User asks about                        | scope     | Required identifiers             |
+| -------------------------------------- | --------- | -------------------------------- |
+| Overall project or locale progress     | `project` | none                             |
+| A source file or path                  | `file`    | `filePath` or `fileId`           |
+| A string key, identifier, or string ID | `string`  | `stringIdentifier` or `stringId` |
+
+### Optional filters
+
+- `languageIds`: limit results to specific Crowdin language IDs (for example `["fr", "de"]`).
+- `targetLocale`: when `scope` is `file`, also return queue counts (`untranslated`, `needsReview`, `reviewed`, `hasIssues`) for that locale.
+
+### Response interpretation
+
+- `translationProgress` and `approvalProgress` are percentages (0–100).
+- `words` and `phrases` show absolute counts when available.
+- For `string` scope, `stringTranslations` lists per-locale translation text and approval state.
+- If multiple files or strings match a fuzzy path/identifier, ask the user to specify `fileId` or `stringId`.
+
+### Examples
+
+- "How complete is French in Crowdin?" → `scope: "project"`, `languageIds: ["fr"]`
+- "What's the progress on `locales/en.json`?" → `scope: "file"`, `filePath: "locales/en.json"`
+- "Is `nav.home.label` translated into German?" → `scope: "string"`, `stringIdentifier: "nav.home.label"`, `languageIds: ["de"]`
+
+Return concise summaries with percentages and counts. Mention the Crowdin project name when helpful.

--- a/apps/hyperlocalise-web/src/agents/_runtime/shared-skills/crowdin.md
+++ b/apps/hyperlocalise-web/src/agents/_runtime/shared-skills/crowdin.md
@@ -1,36 +1,51 @@
-## Crowdin progress checks
+---
+id: crowdin
+name: Crowdin TMS
+provider: crowdin
+---
 
-Use `check_crowdin_progress` when the user asks about translation status, completion, or progress in Crowdin.
+## Crowdin TMS
+
+Use Crowdin tools when the user asks about translation work in a Hyperlocalise project linked to Crowdin. This skill covers all Crowdin-specific agent capabilities; new tools are added here as the integration grows.
 
 ### Prerequisites
 
-- The Hyperlocalise project must be linked to a Crowdin TMS project with valid credentials.
+- The Hyperlocalise project must be linked to a Crowdin TMS project with valid organization credentials.
 - Prefer the conversation's attached project. Pass `projectId` only when the user names a different linked project.
+- Do not ask the user for Crowdin API tokens or personal access tokens.
 
-### Scope selection
+### General rules
 
-| User asks about                        | scope     | Required identifiers             |
+- Choose the tool and scope that best matches the user's request.
+- Resolve ambiguous file paths or string identifiers before answering; ask for `fileId` or `stringId` when multiple matches exist.
+- Summarize results concisely with percentages, counts, and the Crowdin project name when helpful.
+- If Crowdin is not configured for the project, say so clearly and stop — do not guess progress.
+
+### Available tools
+
+#### `check_crowdin_progress`
+
+Check translation and approval progress for a Crowdin project, source file, or string.
+
+| User asks about                        | `scope`   | Required identifiers             |
 | -------------------------------------- | --------- | -------------------------------- |
 | Overall project or locale progress     | `project` | none                             |
 | A source file or path                  | `file`    | `filePath` or `fileId`           |
 | A string key, identifier, or string ID | `string`  | `stringIdentifier` or `stringId` |
 
-### Optional filters
+Optional parameters:
 
 - `languageIds`: limit results to specific Crowdin language IDs (for example `["fr", "de"]`).
 - `targetLocale`: when `scope` is `file`, also return queue counts (`untranslated`, `needsReview`, `reviewed`, `hasIssues`) for that locale.
 
-### Response interpretation
+Response fields:
 
 - `translationProgress` and `approvalProgress` are percentages (0–100).
 - `words` and `phrases` show absolute counts when available.
 - For `string` scope, `stringTranslations` lists per-locale translation text and approval state.
-- If multiple files or strings match a fuzzy path/identifier, ask the user to specify `fileId` or `stringId`.
 
-### Examples
+Examples:
 
 - "How complete is French in Crowdin?" → `scope: "project"`, `languageIds: ["fr"]`
 - "What's the progress on `locales/en.json`?" → `scope: "file"`, `filePath: "locales/en.json"`
 - "Is `nav.home.label` translated into German?" → `scope: "string"`, `stringIdentifier: "nav.home.label"`, `languageIds: ["de"]`
-
-Return concise summaries with percentages and counts. Mention the Crowdin project name when helpful.

--- a/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/check_crowdin_progress.ts
+++ b/apps/hyperlocalise-web/src/agents/_runtime/shared-tools/check_crowdin_progress.ts
@@ -1,0 +1,155 @@
+import { z } from "zod";
+
+import { defineAgentTool } from "@/agents/_runtime/define-agent-tool";
+import { checkCrowdinProgress } from "@/lib/providers/adapters/crowdin/crowdin-progress";
+import type { ToolContext } from "@/lib/agent-contracts/tool-context";
+import { isErr } from "@/lib/primitives/result/results";
+
+const checkCrowdinProgressInputSchema = z.object({
+  projectId: z.string().trim().min(1).optional(),
+  scope: z
+    .enum(["project", "file", "string"])
+    .describe("Progress scope: whole Crowdin project, a source file, or a single string."),
+  languageIds: z
+    .array(z.string().trim().min(1))
+    .optional()
+    .describe("Optional Crowdin language IDs to filter results, for example ['fr', 'de']."),
+  filePath: z
+    .string()
+    .trim()
+    .min(1)
+    .optional()
+    .describe("Crowdin file path or name when scope is file."),
+  fileId: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe("Crowdin numeric file ID when scope is file."),
+  stringIdentifier: z
+    .string()
+    .trim()
+    .min(1)
+    .optional()
+    .describe("Crowdin string identifier/key when scope is string."),
+  stringId: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe("Crowdin numeric string ID when scope is string."),
+  targetLocale: z
+    .string()
+    .trim()
+    .min(1)
+    .optional()
+    .describe(
+      "Optional target locale for detailed file queue counts (untranslated, needs review, etc.).",
+    ),
+});
+
+const checkCrowdinProgressOutputSchema = z.object({
+  success: z.boolean(),
+  error: z.string().optional(),
+  progress: z
+    .object({
+      scope: z.enum(["project", "file", "string"]),
+      crowdinProjectId: z.number(),
+      crowdinProjectName: z.string(),
+      resource: z
+        .object({
+          type: z.enum(["file", "string"]),
+          id: z.number(),
+          path: z.string().optional(),
+          identifier: z.string().optional(),
+          text: z.string().optional(),
+        })
+        .optional(),
+      languages: z.array(
+        z.object({
+          languageId: z.string(),
+          translationProgress: z.number(),
+          approvalProgress: z.number(),
+          words: z.object({
+            total: z.number(),
+            translated: z.number(),
+            approved: z.number(),
+          }),
+          phrases: z.object({
+            total: z.number(),
+            translated: z.number(),
+            approved: z.number(),
+          }),
+        }),
+      ),
+      queueSummary: z
+        .object({
+          targetLocale: z.string(),
+          total: z.number(),
+          reviewed: z.number(),
+          untranslated: z.number(),
+          needsReview: z.number(),
+          hasIssues: z.number(),
+        })
+        .optional(),
+      stringTranslations: z
+        .array(
+          z.object({
+            languageId: z.string(),
+            translated: z.boolean(),
+            approved: z.boolean(),
+            text: z.string().nullable(),
+          }),
+        )
+        .optional(),
+    })
+    .optional(),
+});
+
+export type CheckCrowdinProgressToolInput = z.infer<typeof checkCrowdinProgressInputSchema>;
+export type CheckCrowdinProgressToolOutput = z.infer<typeof checkCrowdinProgressOutputSchema>;
+
+export function createCheckCrowdinProgressTool(
+  ctx: Pick<ToolContext, "organizationId" | "projectId">,
+) {
+  return defineAgentTool({
+    description:
+      "Check Crowdin translation progress for the linked TMS project, a specific source file, or an individual string. Requires the Hyperlocalise project to be connected to Crowdin.",
+    inputSchema: checkCrowdinProgressInputSchema,
+    outputSchema: checkCrowdinProgressOutputSchema,
+    execute: async (input) => {
+      const projectId = input.projectId ?? ctx.projectId;
+      if (!projectId) {
+        return {
+          success: false,
+          error:
+            "check_crowdin_progress requires a project. Attach a Hyperlocalise project linked to Crowdin, or pass projectId.",
+        };
+      }
+
+      const result = await checkCrowdinProgress({
+        organizationId: ctx.organizationId,
+        projectId,
+        scope: input.scope,
+        languageIds: input.languageIds,
+        filePath: input.filePath,
+        fileId: input.fileId,
+        stringIdentifier: input.stringIdentifier,
+        stringId: input.stringId,
+        targetLocale: input.targetLocale,
+      });
+
+      if (isErr(result)) {
+        return {
+          success: false,
+          error: result.error.message,
+        };
+      }
+
+      return {
+        success: true,
+        progress: result.value,
+      };
+    },
+  });
+}

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/orchestration.md
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/orchestration.md
@@ -8,4 +8,5 @@ After each agent returns, synthesize one clear user-facing reply that covers eve
 Translation handoff:
 
 - Use `translation` for uploaded-file translation jobs when sourceFileId values and locales are available.
+- Use `translation` for Crowdin progress checks (project, file, or string status) when the project is linked to Crowdin.
 - When both repository and translation intents are active, complete repository context collection before translation jobs.

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/orchestration.md
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/skills/orchestration.md
@@ -8,5 +8,5 @@ After each agent returns, synthesize one clear user-facing reply that covers eve
 Translation handoff:
 
 - Use `translation` for uploaded-file translation jobs when sourceFileId values and locales are available.
-- Use `translation` for Crowdin progress checks (project, file, or string status) when the project is linked to Crowdin.
+- Use `translation` for Crowdin TMS requests when the project is linked to Crowdin (see the Crowdin skill).
 - When both repository and translation intents are active, complete repository context collection before translation jobs.

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/subagents/translation/agent.ts
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/subagents/translation/agent.ts
@@ -2,6 +2,7 @@ import { stepCountIs, ToolLoopAgent } from "ai";
 import { z } from "zod";
 
 import { loadSubagentInstructions } from "@/agents/_runtime/loader";
+import { composeInstructions } from "@/agents/_runtime/compose-instructions";
 import { getHyperlocaliseAgentModel } from "@/lib/agent-runtime/loops/model";
 import { buildSubagentToolSet } from "@/lib/agent-runtime/subagents/build-subagent-tools";
 import {
@@ -18,7 +19,10 @@ const callOptionsSchema = z.object({
 });
 
 function buildTranslationSystemPrompt() {
-  const base = loadSubagentInstructions({ agentId: "hyperlocalise", subagentId: "translation" });
+  const base = composeInstructions({
+    base: loadSubagentInstructions({ agentId: "hyperlocalise", subagentId: "translation" }),
+    sharedSkills: ["crowdin-progress"],
+  });
   return `${base}
 
 ## Rules

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/subagents/translation/agent.ts
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/subagents/translation/agent.ts
@@ -21,7 +21,7 @@ const callOptionsSchema = z.object({
 function buildTranslationSystemPrompt() {
   const base = composeInstructions({
     base: loadSubagentInstructions({ agentId: "hyperlocalise", subagentId: "translation" }),
-    sharedSkills: ["crowdin-progress"],
+    sharedSkills: ["crowdin"],
   });
   return `${base}
 

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/subagents/translation/instructions.md
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/subagents/translation/instructions.md
@@ -2,12 +2,13 @@ You are the Hyperlocalise translation agent.
 
 ## Role
 
-Create and queue file translation jobs from source files already attached to the conversation, or translate inline strings with `translate_string` when appropriate.
+Create and queue file translation jobs from source files already attached to the conversation, translate inline strings with `translate_string`, or check Crowdin TMS progress with `check_crowdin_progress` when the project is linked to Crowdin.
 
 ## Rules
 
 - Use createTranslationJob with type "file" only when sourceFileId values are present.
 - Use translate_string for direct string translation when source text and target locales are known.
+- Use check_crowdin_progress for Crowdin translation status on projects, files, or strings.
 - Ask for targetLocales (and sourceLocale when missing) in your summary if you could not complete the work.
 - Do not invent sourceFileId values.
 

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/subagents/translation/instructions.md
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/subagents/translation/instructions.md
@@ -2,13 +2,13 @@ You are the Hyperlocalise translation agent.
 
 ## Role
 
-Create and queue file translation jobs from source files already attached to the conversation, translate inline strings with `translate_string`, or check Crowdin TMS progress with `check_crowdin_progress` when the project is linked to Crowdin.
+Create and queue file translation jobs from source files already attached to the conversation, translate inline strings with `translate_string`, or use Crowdin TMS tools when the project is linked to Crowdin.
 
 ## Rules
 
 - Use createTranslationJob with type "file" only when sourceFileId values are present.
 - Use translate_string for direct string translation when source text and target locales are known.
-- Use check_crowdin_progress for Crowdin translation status on projects, files, or strings.
+- Follow the Crowdin skill for Crowdin TMS requests (progress checks and future Crowdin tools).
 - Ask for targetLocales (and sourceLocale when missing) in your summary if you could not complete the work.
 - Do not invent sourceFileId values.
 

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-classifier.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-classifier.ts
@@ -52,7 +52,7 @@ function buildConversationClassificationPrompt(input: ClassifyConversationInput)
     "Classify this Hyperlocalise agent conversation for routing and GitHub repository tooling.",
     "",
     "Intent rules (return one or more in `intents`):",
-    '- "translation": translate or localize uploaded files/images, create translation jobs, set locales for attached sources, or check TMS progress (Crowdin project/file/string status).',
+    '- "translation": translate or localize uploaded files/images, create translation jobs, set locales for attached sources, or handle Crowdin TMS requests (progress, status, and other linked Crowdin operations).',
     '- "repository": read-only localization context from a connected GitHub repo (where a string/key/copy appears, surrounding text, product context, nearby words).',
     '- "general": greetings, product questions, job status, glossary, or requests outside translation/repo lookup.',
     "",

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-classifier.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-classifier.ts
@@ -52,7 +52,7 @@ function buildConversationClassificationPrompt(input: ClassifyConversationInput)
     "Classify this Hyperlocalise agent conversation for routing and GitHub repository tooling.",
     "",
     "Intent rules (return one or more in `intents`):",
-    '- "translation": translate or localize uploaded files/images, create translation jobs, or set locales for attached sources.',
+    '- "translation": translate or localize uploaded files/images, create translation jobs, set locales for attached sources, or check TMS progress (Crowdin project/file/string status).',
     '- "repository": read-only localization context from a connected GitHub repo (where a string/key/copy appears, surrounding text, product context, nearby words).',
     '- "general": greetings, product questions, job status, glossary, or requests outside translation/repo lookup.',
     "",

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/subagents/build-subagent-tools.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/subagents/build-subagent-tools.ts
@@ -8,6 +8,7 @@ import { buildTools } from "@/lib/agent-runtime/tools/registry";
 import type { ToolContext } from "@/lib/agent-contracts/tool-context";
 
 import { createTranslateStringTool } from "@/agents/_runtime/shared-tools/translate_string";
+import { createCheckCrowdinProgressTool } from "@/agents/_runtime/shared-tools/check_crowdin_progress";
 
 import type { HyperlocaliseSubagentType } from "./types";
 
@@ -19,7 +20,7 @@ const subagentToolNames = {
 function listTranslationToolNames(projectId: string | null): string[] {
   const names = [...subagentToolNames.translation];
   if (projectId) {
-    names.push("translate_string");
+    names.push("translate_string", "check_crowdin_progress");
   }
   return names;
 }
@@ -39,6 +40,7 @@ export function buildSubagentToolSet(
     return {
       ...filtered,
       translate_string: createTranslateStringTool(toolContext),
+      check_crowdin_progress: createCheckCrowdinProgressTool(toolContext),
     };
   }
 

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/subagents/definitions.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/subagents/definitions.ts
@@ -13,12 +13,14 @@ export { SUBAGENT_TYPES, type HyperlocaliseSubagentType };
 export const SUBAGENT_REGISTRY = {
   translation: {
     shortDescription:
-      "Translate uploaded localization files and queue translation jobs when sourceFileId values are available",
+      "Translate uploaded localization files, queue translation jobs, check Crowdin TMS progress, and translate inline strings when a project is attached",
     agent: translationSubagent,
     isAvailable: (runtime: HyperlocaliseAgentRuntimeContext) =>
-      runtime.hasFileAttachments || runtime.suggestedIntents.includes("translation"),
+      runtime.hasFileAttachments ||
+      runtime.suggestedIntents.includes("translation") ||
+      Boolean(runtime.toolContext.projectId),
     unavailableMessage: (_runtime) =>
-      "Translation requires an attached localization file with a target language.",
+      "Translation requires an attached localization file with a target language, an attached Crowdin-linked project, or a translation/TMS progress request.",
   },
   repository: {
     shortDescription:

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/subagents/definitions.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/subagents/definitions.ts
@@ -13,14 +13,14 @@ export { SUBAGENT_TYPES, type HyperlocaliseSubagentType };
 export const SUBAGENT_REGISTRY = {
   translation: {
     shortDescription:
-      "Translate uploaded localization files, queue translation jobs, check Crowdin TMS progress, and translate inline strings when a project is attached",
+      "Translate uploaded localization files, queue translation jobs, run Crowdin TMS tools, and translate inline strings when a project is attached",
     agent: translationSubagent,
     isAvailable: (runtime: HyperlocaliseAgentRuntimeContext) =>
       runtime.hasFileAttachments ||
       runtime.suggestedIntents.includes("translation") ||
       Boolean(runtime.toolContext.projectId),
     unavailableMessage: (_runtime) =>
-      "Translation requires an attached localization file with a target language, an attached Crowdin-linked project, or a translation/TMS progress request.",
+      "Translation requires an attached localization file with a target language, an attached Crowdin-linked project, or a translation/Crowdin TMS request.",
   },
   repository: {
     shortDescription:

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/manifest.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/manifest.ts
@@ -23,6 +23,7 @@ export const toolManifests = [
   { name: "task", domain: "tms", sideEffect: "none" },
   { name: "createTranslationJob", domain: "translation", sideEffect: "external_write" },
   { name: "translate_string", domain: "translation", sideEffect: "none" },
+  { name: "check_crowdin_progress", domain: "tms", sideEffect: "none" },
   { name: "todoWrite", domain: "session", sideEffect: "none" },
   { name: "fetch", domain: "web", sideEffect: "none" },
   {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/task-tool.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/task-tool.ts
@@ -51,6 +51,7 @@ ${subagentSummaryLines}
 
 WHEN TO USE:
 - Translation requests with attached files → \`translation\`
+- Crowdin or TMS progress/status for projects, files, or strings → \`translation\`
 - Finding localization context for source strings, messages, keys, or uploaded-file segments in GitHub → \`repository\`
 - Any work that matches an agent description above
 

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/tools/task-tool.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/tools/task-tool.ts
@@ -51,7 +51,7 @@ ${subagentSummaryLines}
 
 WHEN TO USE:
 - Translation requests with attached files → \`translation\`
-- Crowdin or TMS progress/status for projects, files, or strings → \`translation\`
+- Crowdin or TMS status for projects, files, or strings → \`translation\`
 - Finding localization context for source strings, messages, keys, or uploaded-file segments in GitHub → \`repository\`
 - Any work that matches an agent description above
 

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
@@ -1009,4 +1009,34 @@ describe("CrowdinApiClient", () => {
       approvalProgress: 60,
     });
   });
+
+  it("lists file language progress with language filter", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      expect(url).toContain("/projects/1/files/9/languages/progress");
+      expect(url).toContain("languageIds=fr");
+
+      return new Response(
+        JSON.stringify({
+          data: [
+            {
+              data: {
+                languageId: "fr",
+                words: { total: 20, translated: 10, approved: 5 },
+                phrases: { total: 10, translated: 5, approved: 2 },
+                translationProgress: 50,
+                approvalProgress: 25,
+              },
+            },
+          ],
+        }),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    const progress = await client.listFileLanguageProgress(1, 9, { languageIds: ["fr"] });
+
+    expect(progress[0]?.languageId).toBe("fr");
+    expect(progress[0]?.translationProgress).toBe(50);
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
@@ -1365,14 +1365,70 @@ export class CrowdinApiClient {
   /**
    * Get translation progress for each target language in a project.
    */
-  async listProjectLanguageProgress(projectId: number): Promise<CrowdinLanguageProgress[]> {
+  async listProjectLanguageProgress(
+    projectId: number,
+    options?: { languageIds?: string[] },
+  ): Promise<CrowdinLanguageProgress[]> {
+    return this.listTranslationProgress(`/projects/${projectId}/languages/progress`, options);
+  }
+
+  /**
+   * Get translation progress for each target language in a file.
+   */
+  async listFileLanguageProgress(
+    projectId: number,
+    fileId: number,
+    options?: { languageIds?: string[] },
+  ): Promise<CrowdinLanguageProgress[]> {
+    return this.listTranslationProgress(
+      `/projects/${projectId}/files/${fileId}/languages/progress`,
+      options,
+    );
+  }
+
+  /**
+   * Get translation progress for each target language in a branch.
+   */
+  async listBranchLanguageProgress(
+    projectId: number,
+    branchId: number,
+    options?: { languageIds?: string[] },
+  ): Promise<CrowdinLanguageProgress[]> {
+    return this.listTranslationProgress(
+      `/projects/${projectId}/branches/${branchId}/languages/progress`,
+      options,
+    );
+  }
+
+  /**
+   * Get translation progress for each target language in a directory.
+   */
+  async listDirectoryLanguageProgress(
+    projectId: number,
+    directoryId: number,
+    options?: { languageIds?: string[] },
+  ): Promise<CrowdinLanguageProgress[]> {
+    return this.listTranslationProgress(
+      `/projects/${projectId}/directories/${directoryId}/languages/progress`,
+      options,
+    );
+  }
+
+  private async listTranslationProgress(
+    path: string,
+    options?: { languageIds?: string[] },
+  ): Promise<CrowdinLanguageProgress[]> {
     const progress: CrowdinLanguageProgress[] = [];
     let offset = 0;
     const limit = 500;
+    const languageFilter =
+      options?.languageIds?.length && options.languageIds.length > 0
+        ? `&languageIds=${options.languageIds.join(",")}`
+        : "";
 
     while (true) {
       const response = await this.get<CrowdinListResponse<CrowdinLanguageProgress>>(
-        `/projects/${projectId}/languages/progress?limit=${limit}&offset=${offset}`,
+        `${path}?limit=${limit}&offset=${offset}${languageFilter}`,
       );
       const page = response.data.map((item) => item.data);
       progress.push(...page);

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-progress.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-progress.test.ts
@@ -110,9 +110,13 @@ describe("checkCrowdinProgress", () => {
 
     expect(result.ok).toBe(true);
     expect(
-      vi.mocked(providerSafeFetch).mock.calls.some(([url]) =>
-        String(url).startsWith("https://acme.api.crowdin.com/api/v2/projects/42"),
-      ),
+      vi.mocked(providerSafeFetch).mock.calls.some((call) => {
+        const url = call[0];
+        return (
+          typeof url === "string" &&
+          url.startsWith("https://acme.api.crowdin.com/api/v2/projects/42")
+        );
+      }),
     ).toBe(true);
   });
 

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-progress.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-progress.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { checkCrowdinProgress } from "./crowdin-progress";
+
+vi.mock("./load-crowdin-project-credential", () => ({
+  loadCrowdinProjectCredential: vi.fn(async () => ({
+    externalProjectId: "42",
+    credential: {
+      encryptionAlgorithm: "aes-256-gcm",
+      keyVersion: 1,
+      ciphertext: "cipher",
+      iv: "iv",
+      authTag: "tag",
+      baseUrl: null,
+    },
+  })),
+  decryptCrowdinCredentialToken: vi.fn(() => "token"),
+}));
+
+vi.mock("@/lib/providers/provider-safe-fetch", () => ({
+  providerSafeFetch: vi.fn(async (url: string) => {
+    if (String(url).includes("/projects/42/languages/progress")) {
+      return new Response(
+        JSON.stringify({
+          data: [
+            {
+              data: {
+                languageId: "fr",
+                words: { total: 100, translated: 80, approved: 60 },
+                phrases: { total: 50, translated: 40, approved: 30 },
+                translationProgress: 80,
+                approvalProgress: 60,
+              },
+            },
+          ],
+        }),
+        { status: 200 },
+      );
+    }
+
+    if (String(url).includes("/projects/42")) {
+      return new Response(
+        JSON.stringify({
+          data: {
+            id: 42,
+            name: "Demo App",
+            identifier: "demo-app",
+            sourceLanguageId: "en",
+            targetLanguageIds: ["en", "fr", "de"],
+            webUrl: "https://example.crowdin.com/u/projects/42",
+            isSuspended: false,
+          },
+        }),
+        { status: 200 },
+      );
+    }
+
+    return new Response(JSON.stringify({ data: [] }), { status: 200 });
+  }),
+}));
+
+describe("checkCrowdinProgress", () => {
+  it("returns project-level language progress", async () => {
+    const result = await checkCrowdinProgress({
+      organizationId: "org_1",
+      projectId: "proj_1",
+      scope: "project",
+      languageIds: ["fr"],
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toMatchObject({
+        scope: "project",
+        crowdinProjectId: 42,
+        crowdinProjectName: "Demo App",
+        languages: [
+          {
+            languageId: "fr",
+            translationProgress: 80,
+            approvalProgress: 60,
+          },
+        ],
+      });
+    }
+  });
+
+  it("returns an error when Crowdin is not configured", async () => {
+    const { loadCrowdinProjectCredential } = await import("./load-crowdin-project-credential");
+    vi.mocked(loadCrowdinProjectCredential).mockResolvedValueOnce(null);
+
+    const result = await checkCrowdinProgress({
+      organizationId: "org_1",
+      projectId: "proj_1",
+      scope: "project",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("crowdin_not_configured");
+    }
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-progress.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-progress.test.ts
@@ -85,6 +85,37 @@ describe("checkCrowdinProgress", () => {
     }
   });
 
+  it("uses the credential enterprise base URL for API requests", async () => {
+    const { loadCrowdinProjectCredential } = await import("./load-crowdin-project-credential");
+    const { providerSafeFetch } = await import("@/lib/providers/provider-safe-fetch");
+
+    vi.mocked(providerSafeFetch).mockClear();
+    vi.mocked(loadCrowdinProjectCredential).mockResolvedValueOnce({
+      externalProjectId: "42",
+      credential: {
+        encryptionAlgorithm: "aes-256-gcm",
+        keyVersion: 1,
+        ciphertext: "cipher",
+        iv: "iv",
+        authTag: "tag",
+        baseUrl: "https://acme.api.crowdin.com/api/v2",
+      },
+    } as NonNullable<Awaited<ReturnType<typeof loadCrowdinProjectCredential>>>);
+
+    const result = await checkCrowdinProgress({
+      organizationId: "org_1",
+      projectId: "proj_1",
+      scope: "project",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(
+      vi.mocked(providerSafeFetch).mock.calls.some(([url]) =>
+        String(url).startsWith("https://acme.api.crowdin.com/api/v2/projects/42"),
+      ),
+    ).toBe(true);
+  });
+
   it("returns an error when Crowdin is not configured", async () => {
     const { loadCrowdinProjectCredential } = await import("./load-crowdin-project-credential");
     vi.mocked(loadCrowdinProjectCredential).mockResolvedValueOnce(null);

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-progress.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-progress.ts
@@ -1,0 +1,426 @@
+import {
+  CrowdinApiClient,
+  type CrowdinFile,
+  type CrowdinSourceString,
+} from "@/lib/providers/adapters/crowdin/crowdin-api";
+import { escapeCrowdinCroqlString } from "@/lib/providers/adapters/crowdin/crowdin-croql";
+import {
+  decryptCrowdinCredentialToken,
+  loadCrowdinProjectCredential,
+} from "@/lib/providers/adapters/crowdin/load-crowdin-project-credential";
+import { countCrowdinFileQueueSummary } from "@/lib/projects/cat/project-file-cat-queue-summary";
+import { err, isErr, ok, type Result } from "@/lib/primitives/result/results";
+
+export type CrowdinProgressScope = "project" | "file" | "string";
+
+export type CheckCrowdinProgressInput = {
+  organizationId: string;
+  projectId: string;
+  scope: CrowdinProgressScope;
+  languageIds?: string[];
+  filePath?: string;
+  fileId?: number;
+  stringIdentifier?: string;
+  stringId?: number;
+  targetLocale?: string;
+};
+
+export type CrowdinProgressLanguageSummary = {
+  languageId: string;
+  translationProgress: number;
+  approvalProgress: number;
+  words: CrowdinLanguageProgressWords;
+  phrases: CrowdinLanguageProgressWords;
+};
+
+type CrowdinLanguageProgressWords = {
+  total: number;
+  translated: number;
+  approved: number;
+};
+
+export type CheckCrowdinProgressResult = {
+  scope: CrowdinProgressScope;
+  crowdinProjectId: number;
+  crowdinProjectName: string;
+  resource?: {
+    type: "file" | "string";
+    id: number;
+    path?: string;
+    identifier?: string;
+    text?: string;
+  };
+  languages: CrowdinProgressLanguageSummary[];
+  queueSummary?: {
+    targetLocale: string;
+    total: number;
+    reviewed: number;
+    untranslated: number;
+    needsReview: number;
+    hasIssues: number;
+  };
+  stringTranslations?: Array<{
+    languageId: string;
+    translated: boolean;
+    approved: boolean;
+    text: string | null;
+  }>;
+};
+
+type CrowdinProgressError =
+  | { code: "crowdin_not_configured"; message: string }
+  | { code: "crowdin_resource_not_found"; message: string }
+  | { code: "crowdin_invalid_input"; message: string }
+  | { code: "crowdin_api_error"; message: string };
+
+function toLanguageSummary(
+  progress: Awaited<ReturnType<CrowdinApiClient["listProjectLanguageProgress"]>>[number],
+): CrowdinProgressLanguageSummary {
+  return {
+    languageId: progress.languageId,
+    translationProgress: progress.translationProgress,
+    approvalProgress: progress.approvalProgress,
+    words: progress.words,
+    phrases: progress.phrases,
+  };
+}
+
+function normalizePath(value: string) {
+  return value.trim().replace(/^\/+/, "").toLowerCase();
+}
+
+async function createCrowdinClient(input: {
+  organizationId: string;
+  projectId: string;
+}): Promise<
+  Result<
+    { client: CrowdinApiClient; crowdinProjectId: number },
+    Extract<CrowdinProgressError, { code: "crowdin_not_configured" }>
+  >
+> {
+  const projectCredential = await loadCrowdinProjectCredential(input);
+  if (!projectCredential) {
+    return err({
+      code: "crowdin_not_configured" as const,
+      message:
+        "This project is not linked to Crowdin. Connect a Crowdin TMS project before checking progress.",
+    });
+  }
+
+  const token = decryptCrowdinCredentialToken(projectCredential.credential);
+  const crowdinProjectId = Number.parseInt(projectCredential.externalProjectId, 10);
+  if (!Number.isFinite(crowdinProjectId)) {
+    return err({
+      code: "crowdin_not_configured" as const,
+      message: "The linked Crowdin project ID is invalid.",
+    });
+  }
+
+  const client = new CrowdinApiClient({ token });
+  return ok({ client, crowdinProjectId });
+}
+
+async function resolveCrowdinFile(
+  client: CrowdinApiClient,
+  crowdinProjectId: number,
+  input: Pick<CheckCrowdinProgressInput, "fileId" | "filePath">,
+): Promise<
+  Result<
+    CrowdinFile,
+    Extract<CrowdinProgressError, { code: "crowdin_resource_not_found" | "crowdin_invalid_input" }>
+  >
+> {
+  if (input.fileId != null) {
+    const files = await client.listFiles(crowdinProjectId);
+    const match = files.find((file) => file.id === input.fileId);
+    if (!match) {
+      return err({
+        code: "crowdin_resource_not_found" as const,
+        message: `Crowdin file ${input.fileId} was not found in this project.`,
+      });
+    }
+
+    return ok(match);
+  }
+
+  const filePath = input.filePath?.trim();
+  if (!filePath) {
+    return err({
+      code: "crowdin_invalid_input" as const,
+      message: "Provide fileId or filePath when checking file progress.",
+    });
+  }
+
+  const normalizedTarget = normalizePath(filePath);
+  const files = await client.listFiles(crowdinProjectId);
+  const exact = files.find((file) => normalizePath(file.path) === normalizedTarget);
+  if (exact) {
+    return ok(exact);
+  }
+
+  const basename = normalizedTarget.split("/").at(-1);
+  const basenameMatches = files.filter((file) => normalizePath(file.name) === basename);
+  if (basenameMatches.length === 1) {
+    return ok(basenameMatches[0]!);
+  }
+
+  const partialMatches = files.filter(
+    (file) =>
+      normalizePath(file.path).includes(normalizedTarget) ||
+      normalizePath(file.name).includes(normalizedTarget),
+  );
+  if (partialMatches.length === 1) {
+    return ok(partialMatches[0]!);
+  }
+
+  if (partialMatches.length > 1) {
+    const paths = partialMatches.slice(0, 5).map((file) => file.path);
+    return err({
+      code: "crowdin_resource_not_found" as const,
+      message: `Multiple Crowdin files matched "${filePath}". Specify fileId or a more precise path. Matches: ${paths.join(", ")}`,
+    });
+  }
+
+  return err({
+    code: "crowdin_resource_not_found" as const,
+    message: `No Crowdin file matched "${filePath}".`,
+  });
+}
+
+async function resolveCrowdinString(
+  client: CrowdinApiClient,
+  crowdinProjectId: number,
+  input: Pick<CheckCrowdinProgressInput, "stringId" | "stringIdentifier">,
+): Promise<
+  Result<
+    CrowdinSourceString,
+    Extract<CrowdinProgressError, { code: "crowdin_resource_not_found" | "crowdin_invalid_input" }>
+  >
+> {
+  if (input.stringId != null) {
+    const strings = await client.listSourceStrings(crowdinProjectId, {
+      croql: `id = ${input.stringId}`,
+      maxItems: 1,
+    });
+    const match = strings[0];
+    if (!match) {
+      return err({
+        code: "crowdin_resource_not_found" as const,
+        message: `Crowdin string ${input.stringId} was not found in this project.`,
+      });
+    }
+
+    return ok(match);
+  }
+
+  const identifier = input.stringIdentifier?.trim();
+  if (!identifier) {
+    return err({
+      code: "crowdin_invalid_input" as const,
+      message: "Provide stringId or stringIdentifier when checking string progress.",
+    });
+  }
+
+  const escaped = escapeCrowdinCroqlString(identifier);
+  const exactStrings = await client.listSourceStrings(crowdinProjectId, {
+    croql: `identifier = "${escaped}"`,
+    maxItems: 5,
+  });
+  if (exactStrings.length === 1) {
+    return ok(exactStrings[0]!);
+  }
+
+  if (exactStrings.length > 1) {
+    const ids = exactStrings.map((entry) => entry.id).join(", ");
+    return err({
+      code: "crowdin_resource_not_found" as const,
+      message: `Multiple Crowdin strings matched identifier "${identifier}". Refine with stringId. Matches: ${ids}`,
+    });
+  }
+
+  const partialStrings = await client.listSourceStrings(crowdinProjectId, {
+    croql: `identifier contains "${escaped}"`,
+    maxItems: 5,
+  });
+  if (partialStrings.length === 1) {
+    return ok(partialStrings[0]!);
+  }
+
+  if (partialStrings.length > 1) {
+    const ids = partialStrings.map((entry) => entry.id).join(", ");
+    return err({
+      code: "crowdin_resource_not_found" as const,
+      message: `Multiple Crowdin strings partially matched "${identifier}". Refine with stringId. Matches: ${ids}`,
+    });
+  }
+
+  return err({
+    code: "crowdin_resource_not_found" as const,
+    message: `No Crowdin string matched identifier "${identifier}".`,
+  });
+}
+
+function formatStringText(text: string | Record<string, string>) {
+  if (typeof text === "string") {
+    return text;
+  }
+
+  const values = Object.values(text);
+  return values[0] ?? JSON.stringify(text);
+}
+
+async function loadStringTranslationStatus(
+  client: CrowdinApiClient,
+  crowdinProjectId: number,
+  stringId: number,
+  languageIds: string[],
+) {
+  const stringTranslations: CheckCrowdinProgressResult["stringTranslations"] = [];
+
+  for (const languageId of languageIds) {
+    const translations = await client.listStringTranslations(
+      crowdinProjectId,
+      stringId,
+      languageId,
+    );
+    const latest = translations.at(-1) ?? null;
+    const approvals = latest
+      ? await client.listTranslationApprovals(crowdinProjectId, languageId, {
+          stringId,
+        })
+      : [];
+
+    stringTranslations.push({
+      languageId,
+      translated: Boolean(latest?.text?.trim()),
+      approved: approvals.some((approval) => approval.translationId === latest?.id),
+      text: latest?.text ?? null,
+    });
+  }
+
+  return stringTranslations;
+}
+
+export async function checkCrowdinProgress(
+  input: CheckCrowdinProgressInput,
+): Promise<Result<CheckCrowdinProgressResult, CrowdinProgressError>> {
+  const clientResult = await createCrowdinClient({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+  });
+  if (isErr(clientResult)) {
+    return clientResult;
+  }
+
+  const { client, crowdinProjectId } = clientResult.value;
+
+  try {
+    const crowdinProject = await client.getProject(crowdinProjectId);
+    const languageFilter = input.languageIds?.length ? input.languageIds : undefined;
+
+    if (input.scope === "project") {
+      const languages = await client.listProjectLanguageProgress(crowdinProjectId, {
+        languageIds: languageFilter,
+      });
+
+      return ok({
+        scope: "project",
+        crowdinProjectId,
+        crowdinProjectName: crowdinProject.name,
+        languages: languages.map(toLanguageSummary),
+      });
+    }
+
+    if (input.scope === "file") {
+      const fileResult = await resolveCrowdinFile(client, crowdinProjectId, input);
+      if (isErr(fileResult)) {
+        return fileResult;
+      }
+
+      const file = fileResult.value;
+      const languages = await client.listFileLanguageProgress(crowdinProjectId, file.id, {
+        languageIds: languageFilter,
+      });
+
+      const result: CheckCrowdinProgressResult = {
+        scope: "file",
+        crowdinProjectId,
+        crowdinProjectName: crowdinProject.name,
+        resource: {
+          type: "file",
+          id: file.id,
+          path: file.path,
+        },
+        languages: languages.map(toLanguageSummary),
+      };
+
+      const targetLocale = input.targetLocale?.trim();
+      if (targetLocale) {
+        const queueSummary = await countCrowdinFileQueueSummary(
+          client,
+          crowdinProjectId,
+          file.id,
+          targetLocale,
+        );
+        result.queueSummary = {
+          targetLocale,
+          ...queueSummary,
+        };
+      }
+
+      return ok(result);
+    }
+
+    const stringResult = await resolveCrowdinString(client, crowdinProjectId, input);
+    if (isErr(stringResult)) {
+      return stringResult;
+    }
+
+    const sourceString = stringResult.value;
+    const languageIds =
+      languageFilter ??
+      crowdinProject.targetLanguageIds.filter(
+        (languageId) => languageId !== crowdinProject.sourceLanguageId,
+      );
+
+    const stringTranslations = await loadStringTranslationStatus(
+      client,
+      crowdinProjectId,
+      sourceString.id,
+      languageIds,
+    );
+
+    return ok({
+      scope: "string",
+      crowdinProjectId,
+      crowdinProjectName: crowdinProject.name,
+      resource: {
+        type: "string",
+        id: sourceString.id,
+        identifier: sourceString.identifier,
+        text: formatStringText(sourceString.text),
+      },
+      languages: stringTranslations.map((entry) => ({
+        languageId: entry.languageId,
+        translationProgress: entry.translated ? 100 : 0,
+        approvalProgress: entry.approved ? 100 : 0,
+        words: {
+          total: 1,
+          translated: entry.translated ? 1 : 0,
+          approved: entry.approved ? 1 : 0,
+        },
+        phrases: {
+          total: 1,
+          translated: entry.translated ? 1 : 0,
+          approved: entry.approved ? 1 : 0,
+        },
+      })),
+      stringTranslations,
+    });
+  } catch (error) {
+    return err({
+      code: "crowdin_api_error",
+      message: error instanceof Error ? error.message : "Crowdin API request failed.",
+    });
+  }
+}

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-progress.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-progress.ts
@@ -116,7 +116,10 @@ async function createCrowdinClient(input: {
     });
   }
 
-  const client = new CrowdinApiClient({ token });
+  const client = new CrowdinApiClient({
+    token,
+    baseUrl: projectCredential.credential.baseUrl ?? undefined,
+  });
   return ok({ client, crowdinProjectId });
 }
 

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/load-crowdin-project-credential.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/load-crowdin-project-credential.ts
@@ -1,0 +1,76 @@
+import { and, eq } from "drizzle-orm";
+
+import { db, schema } from "@/lib/database";
+import {
+  decryptProviderCredential,
+  unwrapProviderCredentialCrypto,
+} from "@/lib/security/provider-credential-crypto";
+
+export type CrowdinProjectCredential = {
+  externalProjectId: string;
+  credential: typeof schema.organizationExternalTmsProviderCredentials.$inferSelect;
+};
+
+export async function loadCrowdinProjectCredential(input: {
+  organizationId: string;
+  projectId: string;
+}): Promise<CrowdinProjectCredential | null> {
+  const [project] = await db
+    .select({
+      externalProjectId: schema.projects.externalProjectId,
+      externalProviderCredentialId: schema.projects.externalProviderCredentialId,
+      externalProviderKind: schema.projects.externalProviderKind,
+    })
+    .from(schema.projects)
+    .where(
+      and(
+        eq(schema.projects.id, input.projectId),
+        eq(schema.projects.organizationId, input.organizationId),
+        eq(schema.projects.externalProviderKind, "crowdin"),
+        eq(schema.projects.source, "external_tms"),
+      ),
+    )
+    .limit(1);
+
+  if (!project?.externalProjectId || !project.externalProviderCredentialId) {
+    return null;
+  }
+
+  const [credential] = await db
+    .select()
+    .from(schema.organizationExternalTmsProviderCredentials)
+    .where(
+      and(
+        eq(schema.organizationExternalTmsProviderCredentials.organizationId, input.organizationId),
+        eq(schema.organizationExternalTmsProviderCredentials.providerKind, "crowdin"),
+        eq(
+          schema.organizationExternalTmsProviderCredentials.id,
+          project.externalProviderCredentialId,
+        ),
+      ),
+    )
+    .limit(1);
+
+  if (!credential) {
+    return null;
+  }
+
+  return {
+    externalProjectId: project.externalProjectId,
+    credential,
+  };
+}
+
+export function decryptCrowdinCredentialToken(
+  credential: CrowdinProjectCredential["credential"],
+): string {
+  return unwrapProviderCredentialCrypto(
+    decryptProviderCredential({
+      algorithm: credential.encryptionAlgorithm,
+      keyVersion: credential.keyVersion,
+      ciphertext: credential.ciphertext,
+      iv: credential.iv,
+      authTag: credential.authTag,
+    }),
+  );
+}

--- a/apps/hyperlocalise-web/src/lib/translation/load-cat-segment-concordance.ts
+++ b/apps/hyperlocalise-web/src/lib/translation/load-cat-segment-concordance.ts
@@ -2,6 +2,10 @@ import type { CatGlossaryTerm, CatTranslationMemoryMatch } from "@/components/ca
 import { inferTmMatchKind } from "@/components/cat/tm-match-quality";
 import { searchCrowdinCatConcordance } from "@/lib/providers/adapters/crowdin/crowdin-cat-concordance";
 import { CrowdinApiClient } from "@/lib/providers/adapters/crowdin/crowdin-api";
+import {
+  decryptCrowdinCredentialToken,
+  loadCrowdinProjectCredential,
+} from "@/lib/providers/adapters/crowdin/load-crowdin-project-credential";
 import type { ExternalTmsProviderKind } from "@/lib/providers/contracts/external-tms-provider-kind";
 import type { NormalizedGlossaryMatch } from "@/lib/providers/contracts/glossary-match";
 import type { NormalizedTranslationMemoryMatch } from "@/lib/providers/contracts/translation-memory-match";
@@ -11,12 +15,6 @@ import {
 } from "@/lib/providers/match-resolution";
 import { loadGlossaryMatchesForContext } from "@/lib/translation/load-glossary-matches";
 import { loadTranslationMemoryMatchesForContext } from "@/lib/translation/load-translation-memory-matches";
-import {
-  decryptProviderCredential,
-  unwrapProviderCredentialCrypto,
-} from "@/lib/security/provider-credential-crypto";
-import { db, schema } from "@/lib/database";
-import { and, eq } from "drizzle-orm";
 
 export type { CatConcordanceForAiRecommendation } from "./map-cat-concordance-for-ai-recommendation";
 export { mapCatConcordanceForAiRecommendation } from "./map-cat-concordance-for-ai-recommendation";
@@ -52,53 +50,6 @@ function toCatTranslationMemoryMatch(
   };
 }
 
-async function loadCrowdinProjectCredential(input: { organizationId: string; projectId: string }) {
-  const [project] = await db
-    .select({
-      externalProjectId: schema.projects.externalProjectId,
-      externalProviderCredentialId: schema.projects.externalProviderCredentialId,
-      externalProviderKind: schema.projects.externalProviderKind,
-    })
-    .from(schema.projects)
-    .where(
-      and(
-        eq(schema.projects.id, input.projectId),
-        eq(schema.projects.organizationId, input.organizationId),
-        eq(schema.projects.externalProviderKind, "crowdin"),
-        eq(schema.projects.source, "external_tms"),
-      ),
-    )
-    .limit(1);
-
-  if (!project?.externalProjectId || !project.externalProviderCredentialId) {
-    return null;
-  }
-
-  const [credential] = await db
-    .select()
-    .from(schema.organizationExternalTmsProviderCredentials)
-    .where(
-      and(
-        eq(schema.organizationExternalTmsProviderCredentials.organizationId, input.organizationId),
-        eq(schema.organizationExternalTmsProviderCredentials.providerKind, "crowdin"),
-        eq(
-          schema.organizationExternalTmsProviderCredentials.id,
-          project.externalProviderCredentialId,
-        ),
-      ),
-    )
-    .limit(1);
-
-  if (!credential) {
-    return null;
-  }
-
-  return {
-    externalProjectId: project.externalProjectId,
-    credential,
-  };
-}
-
 type CrowdinLiveConcordance = {
   glossaryTerms: NormalizedGlossaryMatch[];
   translationMemoryMatches: NormalizedTranslationMemoryMatch[];
@@ -120,18 +71,8 @@ async function loadCrowdinLiveConcordance(input: {
   }
 
   const { credential, externalProjectId } = projectCredential;
-  const secretMaterial = unwrapProviderCredentialCrypto(
-    decryptProviderCredential({
-      algorithm: credential.encryptionAlgorithm,
-      keyVersion: credential.keyVersion,
-      ciphertext: credential.ciphertext,
-      iv: credential.iv,
-      authTag: credential.authTag,
-    }),
-  );
-
   const client = new CrowdinApiClient({
-    token: secretMaterial,
+    token: decryptCrowdinCredentialToken(credential),
     baseUrl: credential.baseUrl ?? undefined,
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Crowdin TMS capability to the Hyperlocalise conversational agent so users can ask about translation status for projects, files, or strings.

## Changes

- **`check_crowdin_progress` agent tool** — calls the Crowdin API to return translation/approval progress for projects, files, or strings
- **`crowdin` shared skill** — generic Crowdin TMS skill (not progress-specific) with an "Available tools" section so new Crowdin tools can be added without renaming the skill
- **Crowdin progress service** — resolves linked project credentials, looks up files/strings, and formats API results
- **Crowdin API client extensions** — file/branch/directory language progress endpoints
- **Shared credential loader** — extracted for reuse across Crowdin integrations

## Skill structure

The `crowdin` skill defines provider-wide rules (prerequisites, credential handling, disambiguation) and documents each Crowdin tool under `### Available tools`. Today that includes `check_crowdin_progress`; future tools (e.g. list files, trigger sync) get new subsections here.

## Agent wiring

- Translation subagent loads the `crowdin` skill and receives Crowdin tools when a project is attached
- Orchestrator and classifier route Crowdin TMS requests to the translation subagent

## Testing

- `vp test src/lib/providers/adapters/crowdin/crowdin-progress.test.ts`
- `vp test src/lib/providers/adapters/crowdin/crowdin-api.test.ts`
- `vp check --fix`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c38b732-3ad5-4ecf-ae1d-fd0914a68071"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c38b732-3ad5-4ecf-ae1d-fd0914a68071"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

