### PR TITLE
fix(web): load native and TMS projects/jobs in parallel

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.tsx
@@ -13,6 +13,7 @@ import { apiClient } from "@/lib/api-client-instance";
 import { readApiResponseError } from "@/lib/api-error";
 import { isNativeWorkspaceJob } from "@/lib/projects/workspace-resource-capabilities";
 import { parseProviderProjectId } from "@/lib/providers/tms-provider-resource-id";
+import { readTmsProviderListResponse } from "@/lib/providers/tms-provider-list-fetch";
 import { isTmsUserConnectionRequiredError } from "@/lib/providers/tms-user-connection-shared";
 
 import { useActiveTmsProvider } from "../../_hooks/use-active-tms-provider";
@@ -164,12 +165,8 @@ async function fetchTmsWorkspaceJobs(organizationSlug: string, mine = false) {
     param: { organizationSlug },
     query: { mine: mine ? "true" : "false" },
   });
-  if (!response.ok) {
-    throw await readApiResponseError(response, "Failed to load TMS jobs");
-  }
 
-  const body = await response.json();
-  return body.jobs as JobListResponse[];
+  return readTmsProviderListResponse<JobListResponse>(response, "jobs", "Failed to load TMS jobs");
 }
 
 async function fetchTmsProjectJobs(
@@ -183,12 +180,8 @@ async function fetchTmsProjectJobs(
     param: { organizationSlug, externalProjectId },
     query: { mine: mine ? "true" : "false" },
   });
-  if (!response.ok) {
-    throw await readApiResponseError(response, "Failed to load TMS jobs");
-  }
 
-  const body = await response.json();
-  return body.jobs as JobListResponse[];
+  return readTmsProviderListResponse<JobListResponse>(response, "jobs", "Failed to load TMS jobs");
 }
 
 export function JobsPageContent({
@@ -247,8 +240,7 @@ export function JobsPageContent({
   });
   const tmsJobsQuery = useQuery({
     queryKey: tmsJobsQueryKey,
-    enabled:
-      hasActiveTmsConnection && (isProviderProjectScope || scope !== "personal" || !projectId),
+    enabled: isProviderProjectScope || scope !== "personal" || !projectId,
     queryFn: async () => {
       if (parsedProviderProject) {
         return fetchTmsProjectJobs(
@@ -278,10 +270,10 @@ export function JobsPageContent({
     <JobsPageView
       assignedNativeJobs={assignedNativeJobs}
       createdNativeJobs={createdNativeJobs}
-      hasActiveTmsConnection={hasActiveTmsConnection}
+      hasActiveTmsConnection={hasActiveTmsConnection || tmsJobsQuery.isLoading || tmsJobsQuery.isFetching}
       isNativeLoading={isNativeLoading}
       isProviderProjectScope={isProviderProjectScope}
-      isTmsLoading={tmsJobsQuery.isLoading}
+      isTmsLoading={tmsJobsQuery.isLoading || tmsJobsQuery.isFetching}
       nativeError={nativeError}
       nativeJobs={nativeJobs}
       onStatusFilterChange={setStatusFilter}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.tsx
@@ -270,7 +270,9 @@ export function JobsPageContent({
     <JobsPageView
       assignedNativeJobs={assignedNativeJobs}
       createdNativeJobs={createdNativeJobs}
-      hasActiveTmsConnection={hasActiveTmsConnection || tmsJobsQuery.isLoading || tmsJobsQuery.isFetching}
+      hasActiveTmsConnection={
+        hasActiveTmsConnection || tmsJobsQuery.isLoading || tmsJobsQuery.isFetching
+      }
       isNativeLoading={isNativeLoading}
       isProviderProjectScope={isProviderProjectScope}
       isTmsLoading={tmsJobsQuery.isLoading || tmsJobsQuery.isFetching}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
@@ -13,6 +13,7 @@ import { TypographyP } from "@/components/ui/typography";
 import { apiClient } from "@/lib/api-client-instance";
 import { readApiResponseError } from "@/lib/api-error";
 import { getTmsProviderBranding } from "@/lib/providers/tms-provider-branding";
+import { readTmsProviderListResponse } from "@/lib/providers/tms-provider-list-fetch";
 
 import {
   PageHeader,
@@ -28,7 +29,7 @@ import {
   type ProjectFormValues,
 } from "./project-form";
 import { ProjectDialog } from "./project-dialog";
-import { mapProjectToListRow, type ProjectListRow } from "./project-list";
+import { mapProjectToListRow, type ApiProject, type ProjectListRow } from "./project-list";
 import { ProjectsTable } from "./projects-table";
 
 const nativeProjectsQueryKey = (organizationSlug: string) =>
@@ -90,18 +91,17 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
   const activeTmsProviderQuery = useActiveTmsProvider(organizationSlug);
   const tmsProjectsQuery = useQuery({
     queryKey: tmsProjectsQueryKey(organizationSlug),
-    enabled: Boolean(activeTmsProviderQuery.data),
     queryFn: async () => {
       const response = await apiClient.api.orgs[":organizationSlug"]["tms-provider"].projects.$get({
         param: { organizationSlug },
       });
 
-      if (!response.ok) {
-        throw await readApiResponseError(response, "Failed to load TMS projects");
-      }
-
-      const body = await response.json();
-      return body.projects.map(mapProjectToListRow);
+      const projects = await readTmsProviderListResponse<ApiProject>(
+        response,
+        "projects",
+        "Failed to load TMS projects",
+      );
+      return projects.map(mapProjectToListRow);
     },
   });
   const createProject = useMutation({
@@ -208,6 +208,8 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
 
   const hasAnyProjects = nativeProjects.length > 0 || tmsProjects.length > 0;
   const hasFilteredResults = filteredNativeProjects.length > 0 || filteredTmsProjects.length > 0;
+  const hasTmsConnection = Boolean(activeTmsProviderQuery.data);
+  const isTmsProjectsLoading = tmsProjectsQuery.isLoading || tmsProjectsQuery.isFetching;
   const tmsProviderName = activeTmsProviderQuery.data
     ? getTmsProviderBranding(activeTmsProviderQuery.data.providerKind).name
     : "TMS";
@@ -306,7 +308,7 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
           />
         </section>
 
-        {activeTmsProviderQuery.isSuccess && activeTmsProviderQuery.data ? (
+        {hasTmsConnection || isTmsProjectsLoading ? (
           <section className="space-y-4">
             <ProjectsSectionHeader
               title={`${tmsProviderName} projects`}

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-list-fetch.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-list-fetch.test.ts
@@ -23,9 +23,9 @@ describe("readTmsProviderListResponse", () => {
       },
     );
 
-    await expect(readTmsProviderListResponse(response, "jobs", "Failed to load TMS jobs")).rejects.toBeInstanceOf(
-      ApiResponseError,
-    );
+    await expect(
+      readTmsProviderListResponse(response, "jobs", "Failed to load TMS jobs"),
+    ).rejects.toBeInstanceOf(ApiResponseError);
   });
 
   it("returns list items from a successful response", async () => {
@@ -34,6 +34,8 @@ describe("readTmsProviderListResponse", () => {
       headers: { "Content-Type": "application/json" },
     });
 
-    await expect(readTmsProviderListResponse(response, "projects", "Failed")).resolves.toEqual([{ id: "1" }]);
+    await expect(readTmsProviderListResponse(response, "projects", "Failed")).resolves.toEqual([
+      { id: "1" },
+    ]);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-list-fetch.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-list-fetch.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { ApiResponseError } from "@/lib/api-error";
+
+import { readTmsProviderListResponse } from "./tms-provider-list-fetch";
+
+describe("readTmsProviderListResponse", () => {
+  it("returns an empty list when no TMS provider is connected", async () => {
+    const response = new Response(JSON.stringify({ error: "no_active_tms_provider" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+
+    await expect(readTmsProviderListResponse(response, "projects", "Failed")).resolves.toEqual([]);
+  });
+
+  it("throws for other TMS list failures", async () => {
+    const response = new Response(
+      JSON.stringify({ error: "crowdin_user_connection_required", message: "Connect Crowdin" }),
+      {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+
+    await expect(readTmsProviderListResponse(response, "jobs", "Failed to load TMS jobs")).rejects.toBeInstanceOf(
+      ApiResponseError,
+    );
+  });
+
+  it("returns list items from a successful response", async () => {
+    const response = new Response(JSON.stringify({ projects: [{ id: "1" }] }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+
+    await expect(readTmsProviderListResponse(response, "projects", "Failed")).resolves.toEqual([{ id: "1" }]);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-list-fetch.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-list-fetch.ts
@@ -1,0 +1,56 @@
+import { ApiResponseError, readApiResponseError } from "@/lib/api-error";
+
+function readErrorBody(body: unknown, fallback: string) {
+  if (!body || typeof body !== "object") {
+    return { code: null, message: fallback };
+  }
+
+  const { error, message } = body as { error?: unknown; message?: unknown };
+  const code = typeof error === "string" ? error : null;
+
+  if (typeof message === "string") {
+    return { code, message };
+  }
+
+  if (code) {
+    return { code, message: code };
+  }
+
+  return { code: null, message: fallback };
+}
+
+export async function readTmsProviderListResponse<TItem>(
+  response: Response,
+  listKey: string,
+  fallbackMessage: string,
+): Promise<TItem[]> {
+  if (!response.ok) {
+    if (response.status === 404) {
+      const body = await response.json().catch(() => null);
+      if (
+        body &&
+        typeof body === "object" &&
+        (body as { error?: string }).error === "no_active_tms_provider"
+      ) {
+        return [];
+      }
+
+      const { code, message } = readErrorBody(body, fallbackMessage);
+      throw new ApiResponseError(message, { code, status: response.status });
+    }
+
+    throw await readApiResponseError(response, fallbackMessage);
+  }
+
+  const body = (await response.json()) as Record<string, unknown>;
+  const items = body[listKey];
+
+  if (!Array.isArray(items)) {
+    throw new ApiResponseError(fallbackMessage, {
+      code: "invalid_response",
+      status: response.status,
+    });
+  }
+
+  return items as TItem[];
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Native and TMS list pages previously waited for the TMS connection check to finish before starting TMS fetches, which created a sequential load waterfall (connection → TMS data) even though native data could already be loading.

This change starts native and TMS requests at the same time on the projects and jobs pages.

## Changes

- **Projects page**: Removed the `enabled: Boolean(activeTmsProviderQuery.data)` gate on the TMS projects query so it runs in parallel with native projects.
- **Jobs page**: Removed the `hasActiveTmsConnection` gate on the TMS jobs query so it runs in parallel with native jobs.
- **Shared helper**: Added `readTmsProviderListResponse()` to treat `no_active_tms_provider` 404 responses as an empty list instead of an error, so TMS fetches can start before the connection probe resolves.
- **UI**: Show TMS sections while TMS data is loading, not only after the connection check confirms a provider.

## Testing

- `vp test src/lib/providers/tms-provider-list-fetch.test.ts` — pass
- `vp check --fix` — pass (pre-existing unrelated warning in `workos-adapter.ts`)
- Full `vp test` has many pre-existing environment-related failures in this cloud VM (missing DB/env), unrelated to this change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-265a6c22-82b0-4f5b-96d4-a66eebdd2cbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-265a6c22-82b0-4f5b-96d4-a66eebdd2cbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

