### PR TITLE
fix(web): remove stale sync labels and fix external TMS open job count

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.test.ts
@@ -133,4 +133,61 @@ describe("project detail route", () => {
       actorUserId: userId,
     });
   });
+
+  it("returns the live provider open job count when the provider lookup succeeds", async () => {
+    const admin = projectFixture.createWorkosIdentityWithRole("admin");
+    const headers = await projectFixture.authHeadersFor(admin);
+    const organizationId = globalThis.__testApiAuthContext!.organization.localOrganizationId;
+    const userId = globalThis.__testApiAuthContext!.user.localUserId;
+    const externalProjectId = "902808";
+    const projectId = encodeProviderProjectId({
+      providerKind: "crowdin",
+      externalProjectId,
+    });
+
+    await upsertOrganizationExternalTmsProviderCredential({
+      organizationId,
+      userId,
+      role: "admin",
+      providerKind: "crowdin",
+      displayName: "Crowdin",
+      secretMaterial: "crowdin-secret",
+    });
+
+    getTmsProviderLiveProjectMock.mockResolvedValue({
+      id: projectId,
+      name: "Live Crowdin Project",
+      description: null,
+      translationContext: null,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      source: "external_tms",
+      externalProviderKind: "crowdin",
+      externalProjectId,
+      sourceLocale: "en",
+      targetLocales: ["fr"],
+      externalProjectUrl: "https://crowdin.com/project/live",
+      isActive: true,
+      openJobCount: 3,
+    });
+
+    const response = await client.api.orgs[":organizationSlug"].projects[":projectId"].$get(
+      {
+        param: {
+          organizationSlug: admin.organization.slug ?? "missing-slug",
+          projectId,
+        },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as ProjectResponse;
+    expect(body.project).toMatchObject({
+      id: projectId,
+      source: "external_tms",
+      externalProjectId,
+      openJobCount: 3,
+    });
+  });
 });

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -1628,7 +1628,7 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
             "live provider project lookup succeeded",
           );
 
-          return c.json({ project: { ...project, openJobCount: 0 } }, 200);
+          return c.json({ project: { ...project, openJobCount: project.openJobCount } }, 200);
         } catch (error) {
           projectDetailRouteLogger.warn(
             {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-attention.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-attention.test.ts
@@ -53,19 +53,14 @@ describe("overview-attention", () => {
     expect(fileNeedsAttention(createFile({ fr: "stale" }))).toBe(true);
   });
 
-  it("counts pending actions from jobs, sync errors, and files", () => {
+  it("counts pending actions from jobs and files", () => {
     const files = [
       createFile({ fr: "missing" }, "a.json"),
       createFile({ fr: "changed" }, "b.json"),
       createFile({ fr: "ready" }, "c.json"),
     ];
 
-    expect(
-      computeProjectPendingActionCount(
-        { openJobCount: 2, lastSyncErrorAt: "2026-01-01T00:00:00.000Z" },
-        files,
-      ),
-    ).toBe(5);
+    expect(computeProjectPendingActionCount({ openJobCount: 2 }, files)).toBe(4);
   });
 
   it("formats large pending counts", () => {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-attention.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-attention.ts
@@ -34,7 +34,6 @@ export function countFilesNeedingAttention(files: readonly ProjectFileRecord[]) 
 export function computeProjectPendingActionCount(
   project: {
     openJobCount: number;
-    lastSyncErrorAt: string | null;
   },
   files: readonly ProjectFileRecord[],
 ) {
@@ -42,10 +41,6 @@ export function computeProjectPendingActionCount(
 
   if (project.openJobCount > 0) {
     count += project.openJobCount;
-  }
-
-  if (project.lastSyncErrorAt) {
-    count += 1;
   }
 
   count += countFilesNeedingAttention(files);

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/provider-crowdin-job-detail-rows.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/provider-crowdin-job-detail-rows.tsx
@@ -113,7 +113,6 @@ export function ProviderCrowdinJobDetailRows<J extends CrowdinJobDetailSource>({
       {crowdinProgress ? <JobDetailRow label="Progress" value={crowdinProgress} /> : null}
       {crowdinWordsToDo ? <JobDetailRow label="Words to do" value={crowdinWordsToDo} /> : null}
       <JobDetailRow label="Due date" value={formatDateTime(job.externalDueDate)} />
-      <JobDetailRow label="Last sync" value={formatDateTime(job.updatedAt)} />
       {job.externalJobId ? (
         <JobDetailRow label="External job ID" value={job.externalJobId} />
       ) : null}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.stories.tsx
@@ -6,7 +6,6 @@ import {
   projectOverviewFilesFixture,
   projectOverviewFixture,
   projectOverviewJobsFixture,
-  projectOverviewSyncErrorFixture,
 } from "./project-overview.fixture";
 import { ProjectOverviewPageContentView } from "./project-overview-page-content";
 
@@ -52,18 +51,6 @@ export const CaughtUp: Story = {
   play: async ({ canvas }) => {
     await expect(canvas.getByText("You're all caught up")).toBeInTheDocument();
     await expect(canvas.getByText("Browse files")).toBeInTheDocument();
-  },
-};
-
-export const SyncError: Story = {
-  args: {
-    project: projectOverviewSyncErrorFixture,
-  },
-  play: async ({ canvas }) => {
-    await expect(canvas.getByText("Sync needs attention")).toBeInTheDocument();
-    await expect(
-      canvas.getByText("Provider credentials expired during the last sync."),
-    ).toBeInTheDocument();
   },
 };
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.tsx
@@ -2,12 +2,7 @@
 
 import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
-import {
-  AlertCircleIcon,
-  File01Icon,
-  Settings02Icon,
-  Task01Icon,
-} from "@hugeicons/core-free-icons";
+import { File01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 
 import { jobsResponseSchema } from "@/api/routes/project/job.schema";
@@ -22,7 +17,6 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { TypographyH1, TypographyP } from "@/components/ui/typography";
 import { parseApiJsonResponse, readApiResponseError } from "@/lib/api-error";
 import { apiClient } from "@/lib/api-client-instance";
-import { cn } from "@/lib/primitives/cn";
 
 import { OverviewActionCard } from "../../../_components/overview/overview-action-card";
 import {
@@ -87,9 +81,6 @@ function buildHeroCopy(
   const parts: string[] = [];
   if (project.openJobCount > 0) {
     parts.push(`${project.openJobCount} open ${project.openJobCount === 1 ? "job" : "jobs"}`);
-  }
-  if (project.lastSyncErrorAt) {
-    parts.push("sync issue");
   }
   if (filesNeedingAttention > 0) {
     parts.push(
@@ -191,16 +182,6 @@ export function ProjectOverviewPageContentView({
               ? providerLabel(project.externalProviderKind)
               : "Native project",
         },
-        ...(project.source === "native"
-          ? [
-              {
-                label: "Last sync",
-                value: project.lastSyncedAt
-                  ? formatRelativeTimestamp(project.lastSyncedAt)
-                  : "Not synced yet",
-              },
-            ]
-          : []),
         {
           label: "Open jobs",
           value: String(project.openJobCount),
@@ -377,74 +358,6 @@ export function ProjectOverviewPageContentView({
               <HugeiconsIcon icon={File01Icon} strokeWidth={1.8} />
               Open files
             </Button>
-          </CardContent>
-        </Card>
-      ) : null}
-
-      {project && project.source === "native" ? (
-        <Card
-          className={cn(
-            "rounded-2xl border py-0 ring-0",
-            project.lastSyncErrorAt
-              ? "border-flame-700/20 bg-flame-700/10"
-              : "border-foreground/8 bg-foreground/2.5",
-          )}
-        >
-          <CardContent className="flex flex-col gap-4 px-5 py-5 sm:flex-row sm:items-center sm:justify-between">
-            <div className="flex items-start gap-3">
-              {project.lastSyncErrorAt ? (
-                <HugeiconsIcon
-                  icon={AlertCircleIcon}
-                  strokeWidth={1.8}
-                  className="mt-0.5 size-5 shrink-0 text-flame-100"
-                />
-              ) : null}
-              <div>
-                <TypographyP className="text-sm font-medium text-foreground">
-                  {project.lastSyncErrorAt ? "Sync needs attention" : "Sync health"}
-                </TypographyP>
-                <TypographyP className="mt-1 text-sm text-muted-foreground">
-                  {project.lastSyncErrorAt
-                    ? (project.lastSyncErrorMessage ?? "The last provider sync reported an error.")
-                    : project.lastSyncedAt
-                      ? `Last synced ${formatRelativeTimestamp(project.lastSyncedAt)}.`
-                      : "This project has not synced with a provider yet."}
-                </TypographyP>
-              </div>
-            </div>
-
-            <div className="flex flex-wrap gap-2">
-              <Button
-                nativeButton={false}
-                render={<Link href={buildProjectPath(organizationSlug, projectId, "jobs")} />}
-                variant="outline"
-                size="sm"
-                className="rounded-full"
-              >
-                <HugeiconsIcon icon={Task01Icon} strokeWidth={1.8} />
-                Jobs
-              </Button>
-              <Button
-                nativeButton={false}
-                render={<Link href={buildProjectPath(organizationSlug, projectId, "files")} />}
-                variant="outline"
-                size="sm"
-                className="rounded-full"
-              >
-                <HugeiconsIcon icon={File01Icon} strokeWidth={1.8} />
-                Files
-              </Button>
-              <Button
-                nativeButton={false}
-                render={<Link href={buildProjectPath(organizationSlug, projectId, "settings")} />}
-                variant="outline"
-                size="sm"
-                className="rounded-full"
-              >
-                <HugeiconsIcon icon={Settings02Icon} strokeWidth={1.8} />
-                Settings
-              </Button>
-            </div>
           </CardContent>
         </Card>
       ) : null}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview-page-content.tsx
@@ -191,12 +191,16 @@ export function ProjectOverviewPageContentView({
               ? providerLabel(project.externalProviderKind)
               : "Native project",
         },
-        {
-          label: "Last sync",
-          value: project.lastSyncedAt
-            ? formatRelativeTimestamp(project.lastSyncedAt)
-            : "Not synced yet",
-        },
+        ...(project.source === "native"
+          ? [
+              {
+                label: "Last sync",
+                value: project.lastSyncedAt
+                  ? formatRelativeTimestamp(project.lastSyncedAt)
+                  : "Not synced yet",
+              },
+            ]
+          : []),
         {
           label: "Open jobs",
           value: String(project.openJobCount),
@@ -377,7 +381,7 @@ export function ProjectOverviewPageContentView({
         </Card>
       ) : null}
 
-      {project ? (
+      {project && project.source === "native" ? (
         <Card
           className={cn(
             "rounded-2xl border py-0 ring-0",

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview.fixture.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview.fixture.ts
@@ -35,6 +35,10 @@ export const projectOverviewCaughtUpFixture: ProjectListRow = {
 
 export const projectOverviewSyncErrorFixture: ProjectListRow = {
   ...projectOverviewFixture,
+  source: "native",
+  externalProviderKind: null,
+  externalProjectId: null,
+  externalProjectUrl: null,
   lastSyncErrorAt: new Date(Date.now() - 30 * 60 * 1000).toISOString(),
   lastSyncErrorMessage: "Provider credentials expired during the last sync.",
 };

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview.fixture.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/_components/project-overview.fixture.ts
@@ -29,18 +29,6 @@ export const projectOverviewFixture: ProjectListRow = {
 export const projectOverviewCaughtUpFixture: ProjectListRow = {
   ...projectOverviewFixture,
   openJobCount: 0,
-  lastSyncErrorAt: null,
-  lastSyncErrorMessage: null,
-};
-
-export const projectOverviewSyncErrorFixture: ProjectListRow = {
-  ...projectOverviewFixture,
-  source: "native",
-  externalProviderKind: null,
-  externalProjectId: null,
-  externalProjectUrl: null,
-  lastSyncErrorAt: new Date(Date.now() - 30 * 60 * 1000).toISOString(),
-  lastSyncErrorMessage: "Provider credentials expired during the last sync.",
 };
 
 export const projectOverviewJobsFixture: ApiJob[] = [

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-layout-helpers.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-layout-helpers.tsx
@@ -45,7 +45,6 @@ export type JobDetailTaskLayoutInput = {
   status: JobDetailRecord["status"];
   title: string | null;
   updatedAt: string;
-  updatedMetricLabel?: "Last synced" | "Updated";
 };
 
 function statusTone(status: JobDetailRecord["status"]) {
@@ -118,7 +117,7 @@ export function jobDetailTaskMetrics(input: JobDetailTaskLayoutInput): JobDetail
     },
     {
       icon: Clock01Icon,
-      label: `${input.updatedMetricLabel ?? "Last synced"} ${formatJobDetailDate(input.updatedAt)}`,
+      label: `Updated ${formatJobDetailDate(input.updatedAt)}`,
     },
   ];
 }
@@ -185,7 +184,6 @@ export function jobDetailTaskProperties(input: JobDetailTaskLayoutInput): {
       label: "Language",
       value: getCrowdinLanguageLabel(payload) ?? "—",
     },
-    { label: "Last sync", value: formatJobDetailDate(input.updatedAt) },
     { label: "External job ID", value: input.externalJobId },
     { label: "External task ID", value: input.externalTaskId },
   ];
@@ -218,7 +216,6 @@ export function jobDetailTaskLayoutFromRecord(job: JobDetailRecord): {
     projectName: job.projectName,
     kind: job.kind,
     sourceFilesMetric: sourcePath ?? (isProviderBackedJob(job) ? null : "Source files linked"),
-    updatedMetricLabel: isProviderBackedJob(job) ? "Last synced" : "Updated",
   };
 
   const { properties, secondaryProperties } = jobDetailTaskProperties(input);
@@ -255,7 +252,6 @@ export function jobDetailTaskLayoutFromLiveJob(job: TmsProviderLiveJobDetail): {
     projectId: job.projectId,
     projectName: job.projectName,
     kind: job.kind,
-    updatedMetricLabel: "Last synced",
   };
 
   const { properties, secondaryProperties } = jobDetailTaskProperties(input);

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-provider-detail-section-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-provider-detail-section-view.tsx
@@ -165,7 +165,6 @@ export function JobProviderDetailSectionView({
             <DetailRow label="Provider title" value={job.externalTitle} />
             <DetailRow label="Provider status" value={job.externalStatus} />
             <DetailRow label="Sync state" value={job.externalSyncState} />
-            <DetailRow label="Last sync" value={formatJobDetailDate(job.updatedAt)} />
             {job.externalProviderKind === "crowdin" ? (
               <>
                 <DetailRow

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.test.ts
@@ -1,11 +1,19 @@
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
-vi.mock("@/lib/providers/organization-external-tms-provider-credentials", () => ({
-  API_TOKEN_AUTH_MODE: "api_token",
-  OAUTH_AUTH_MODE: "oauth",
-  getActiveOrganizationExternalTmsProviderCredentialRow: vi.fn(),
-  resolveExternalTmsSecretMaterial: vi.fn(),
-}));
+vi.mock(
+  "@/lib/providers/organization-external-tms-provider-credentials",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("@/lib/providers/organization-external-tms-provider-credentials")
+      >();
+    return {
+      ...actual,
+      getActiveOrganizationExternalTmsProviderCredentialRow: vi.fn(),
+      resolveExternalTmsSecretMaterial: vi.fn(),
+    };
+  },
+);
 
 vi.mock("@/lib/providers/adapters/crowdin/crowdin-user-connections", () => ({
   getCrowdinUserConnection: vi.fn(),
@@ -17,13 +25,37 @@ vi.mock("@/lib/providers/adapters/phrase/phrase-user-connections", () => ({
   resolvePhraseUserConnectionSecretMaterial: vi.fn(),
 }));
 
-import { getActiveOrganizationExternalTmsProviderCredentialRow } from "@/lib/providers/organization-external-tms-provider-credentials";
+vi.mock("@/lib/providers/adapters/crowdin/crowdin-api", () => ({
+  CrowdinApiClient: vi.fn(function CrowdinApiClientMock() {
+    return {
+      getProject: vi.fn(),
+    };
+  }),
+  CrowdinApiError: class CrowdinApiError extends Error {
+    status: number;
+
+    constructor(status: number, message: string) {
+      super(message);
+      this.name = "CrowdinApiError";
+      this.status = status;
+    }
+  },
+}));
+
+import { CrowdinApiClient } from "@/lib/providers/adapters/crowdin/crowdin-api";
+import {
+  getActiveOrganizationExternalTmsProviderCredentialRow,
+  resolveExternalTmsSecretMaterial,
+} from "@/lib/providers/organization-external-tms-provider-credentials";
 import {
   getPhraseUserConnection,
   resolvePhraseUserConnectionSecretMaterial,
 } from "@/lib/providers/adapters/phrase/phrase-user-connections";
 
-import { TmsProviderLiveError, tryLoadActiveTmsProviderContext } from "./tms-provider-live";
+import * as tmsProviderLive from "./tms-provider-live";
+
+const { getTmsProviderLiveProject, TmsProviderLiveError, tryLoadActiveTmsProviderContext } =
+  tmsProviderLive;
 
 const phraseOAuthCredential = {
   id: "credential-1",
@@ -36,6 +68,22 @@ const phraseOAuthCredential = {
   validationStatus: "valid",
   validationMessage: null,
   lastValidatedAt: null,
+};
+
+const crowdinCredential = {
+  id: "credential-crowdin",
+  providerKind: "crowdin",
+  authMode: "api_token",
+  displayName: "Crowdin",
+  region: null,
+  baseUrl: null,
+  oauthExpiresAt: null,
+  validationStatus: "valid",
+  validationMessage: null,
+  lastValidatedAt: null,
+  maskedSecretSuffix: "oken",
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-01-01T00:00:00.000Z"),
 };
 
 describe("tryLoadActiveTmsProviderContext", () => {
@@ -61,4 +109,43 @@ describe("tryLoadActiveTmsProviderContext", () => {
       });
     },
   );
+});
+
+describe("getTmsProviderLiveProject", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it("returns the project with openJobCount 0 when job enrichment fails", async () => {
+    vi.mocked(getActiveOrganizationExternalTmsProviderCredentialRow).mockResolvedValue(
+      crowdinCredential as never,
+    );
+    vi.mocked(resolveExternalTmsSecretMaterial).mockResolvedValue("crowdin-token");
+
+    const getProject = vi.fn().mockResolvedValue({
+      id: 42,
+      name: "Crowdin Project",
+      sourceLanguageId: "en",
+      targetLanguageIds: ["fr"],
+      webUrl: "https://crowdin.com/project/test",
+      isSuspended: false,
+    });
+    vi.mocked(CrowdinApiClient).mockImplementation(function () {
+      return { getProject } as never;
+    });
+
+    vi.spyOn(tmsProviderLive, "listTmsProviderLiveJobsForProject").mockRejectedValue(
+      new TmsProviderLiveError("crowdin_rate_limited", "Rate limited"),
+    );
+
+    const project = await getTmsProviderLiveProject("org-1", "42");
+
+    expect(project).toMatchObject({
+      name: "Crowdin Project",
+      externalProjectId: "42",
+      openJobCount: 0,
+    });
+    expect(getProject).toHaveBeenCalledWith(42);
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
@@ -1438,20 +1438,36 @@ async function attachOpenJobCountsToLiveProjects(
     liveProjectMetadata,
     LIVE_PROJECT_JOB_FANOUT_CONCURRENCY,
     async (project) => {
-      const jobs = await listTmsProviderLiveJobsForProject(
-        organizationId,
-        project.externalProjectId,
-        {
-          context,
-          projects: liveProjectMetadata,
-          actorUserId: options?.actorUserId,
-        },
-      );
+      try {
+        const jobs = await listTmsProviderLiveJobsForProject(
+          organizationId,
+          project.externalProjectId,
+          {
+            context,
+            projects: liveProjectMetadata,
+            actorUserId: options?.actorUserId,
+          },
+        );
 
-      return {
-        externalProjectId: project.externalProjectId,
-        openJobCount: countOpenLiveJobs(jobs),
-      };
+        return {
+          externalProjectId: project.externalProjectId,
+          openJobCount: countOpenLiveJobs(jobs),
+        };
+      } catch (error) {
+        logger.warn(
+          {
+            organizationId,
+            externalProjectId: project.externalProjectId,
+            error: error instanceof Error ? error.message : "unknown_error",
+          },
+          "failed to fetch live jobs for open job count enrichment",
+        );
+
+        return {
+          externalProjectId: project.externalProjectId,
+          openJobCount: 0,
+        };
+      }
     },
   );
 

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
@@ -1525,14 +1525,23 @@ export async function getTmsProviderLiveProject(
 
     try {
       const project = await client.getProject(crowdinProjectId);
-      return mapLiveProject(context.providerKind, {
+      const projectMetadata: ExternalTmsProjectMetadata = {
         externalProjectId: String(project.id),
         name: project.name,
         sourceLocale: project.sourceLanguageId,
         targetLocales: project.targetLanguageIds,
         externalProjectUrl: project.webUrl,
         isActive: !project.isSuspended,
-      });
+      };
+      const mappedProject = mapLiveProject(context.providerKind, projectMetadata);
+      const [projectWithOpenJobCount] = await attachOpenJobCountsToLiveProjects(
+        organizationId,
+        [mappedProject],
+        context,
+        [projectMetadata],
+        options,
+      );
+      return projectWithOpenJobCount ?? null;
     } catch (error) {
       if (error instanceof CrowdinApiError && error.status === 404) {
         return null;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

External TMS projects are read live from the provider, so "last synced" and "sync health" copy was misleading. Native projects don't have project-level sync either. This also fixes **Open jobs** showing `0` on the project overview while ongoing jobs were visible.

## Changes

### Open jobs count (bug fix)
- Project detail API returned `openJobCount: 0` for successful live provider lookups instead of the computed count
- Crowdin `getTmsProviderLiveProject` fast path now attaches open job counts like the list path
- Open job count enrichment is **best-effort**: if the jobs endpoint fails (rate limit, timeout, etc.), the project still returns with `openJobCount: 0`

### UI cleanup — all project types
- **Project snapshot**: removed "Last sync" row
- **Project overview**: removed the "Sync health" card entirely
- **Pending actions**: no longer counts `lastSyncErrorAt` as a pending item
- **Job detail**: replaced "Last synced" / "Last sync" with "Updated"; removed redundant last-sync rows from provider detail panels

## Testing
- `vp test src/api/routes/project/project.route.test.ts`
- `vp test src/lib/providers/tms-provider-live.test.ts`
- `vp test src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/overview/overview-attention.test.ts`
- `vp check --fix`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a9c32ccb-7e47-4ff4-9027-143806d191e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9c32ccb-7e47-4ff4-9027-143806d191e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

