### PR TITLE
feat(web): unify inbox chat with Slack agent skills

### DIFF
--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/slack.ts
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/slack.ts
@@ -15,6 +15,7 @@ import {
   resolveConversationRepositoryContext,
 } from "@/lib/agent-runtime/loops/conversation-turn";
 import { resolveOrganizationHasTmsIntegration } from "@/lib/agent-runtime/skills/conversation-tms-integration";
+import { stopRepositorySandbox } from "@/lib/agent-runtime/workspaces/repository-sandbox";
 import { createChatStateAdapter } from "@/lib/agents/runtime/state";
 import {
   postThreadMessageWithoutTracking,
@@ -382,10 +383,22 @@ async function processSlackMessage(
       });
       sandboxId = sandboxResult.sandboxId;
       updatedThreadState = sandboxResult.updatedSession;
-      await thread.setState({
-        ...latestThreadState,
-        ...updatedThreadState,
-      });
+      try {
+        await thread.setState({
+          ...latestThreadState,
+          ...updatedThreadState,
+        });
+      } catch (error) {
+        if (sandboxResult.sandboxCreated) {
+          await stopRepositorySandbox(sandboxResult.sandboxId).catch((cleanupError: unknown) => {
+            log.warn(
+              { err: serializeErrorForLog(cleanupError), sandboxId: sandboxResult.sandboxId },
+              "repository sandbox cleanup failed after slack state write failure",
+            );
+          });
+        }
+        throw error;
+      }
     }
 
     const hasTmsIntegration = await resolveOrganizationHasTmsIntegration(organizationId);

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/slack.ts
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/slack.ts
@@ -8,19 +8,13 @@ import {
   getRecentUserConversationText,
   loadInteractionModelMessages,
   replaceLastUserMessage,
-  shouldAttemptRepositoryContextResolution,
-  shouldRequireRepositoryContextClarification,
 } from "@/lib/agent-runtime/loops/hyperlocalise-agent";
+import {
+  buildFileTranslationInstructions,
+  getOrCreateConversationRepositorySandbox,
+  resolveConversationRepositoryContext,
+} from "@/lib/agent-runtime/loops/conversation-turn";
 import { resolveOrganizationHasTmsIntegration } from "@/lib/agent-runtime/skills/conversation-tms-integration";
-import {
-  buildRepositoryGitHubContextInstructions,
-  resolveSlackRepositoryGitHubContext,
-} from "@/lib/agents/repository-context";
-import {
-  createRepositorySandbox,
-  stopRepositorySandbox,
-} from "@/lib/agent-runtime/workspaces/repository-sandbox";
-import { type RepositoryAgentGitHubContext } from "@/lib/agents/repository-agent-task";
 import { createChatStateAdapter } from "@/lib/agents/runtime/state";
 import {
   postThreadMessageWithoutTracking,
@@ -29,7 +23,6 @@ import {
 import { db } from "@/lib/database";
 import { env } from "@/lib/env";
 import { createChatLogger, createLogger, serializeErrorForLog } from "@/lib/log";
-import { supportedFileTranslationFileFormats } from "@/lib/translation/file-formats";
 import {
   addInteractionMessage,
   createInteraction,
@@ -52,10 +45,7 @@ import {
   handleSlackImageFollowUp,
 } from "@/lib/agents/slack/image-attachments";
 import { threadHasStoredSlackImages } from "@/lib/agents/slack/image-session";
-import {
-  getSlackRepositoryContextKey,
-  type SlackBotThreadState,
-} from "@/lib/agents/slack/repository-session";
+import { type SlackBotThreadState } from "@/lib/agents/slack/repository-session";
 
 type SlackBotState = SlackBotThreadState;
 
@@ -139,10 +129,6 @@ export async function getOrCreateInteraction(
   };
 }
 
-function buildSlackFileTranslationInstructions() {
-  return `When a Slack message includes stored source file IDs, create file translation jobs with type "file", the provided sourceFileId and fileFormat, targetLocales, and sourceLocale. Use sourceLocale "auto" if the user did not specify a source locale. Supported file job formats: ${supportedFileTranslationFileFormats.join(", ")}.`;
-}
-
 function getSlackChannelId(thread: Thread<SlackBotState>, message: Message): string | null {
   const channelId = thread.channelId;
   if (typeof channelId === "string" && channelId.length > 0) {
@@ -151,94 +137,6 @@ function getSlackChannelId(thread: Thread<SlackBotState>, message: Message): str
 
   const raw = message.raw as { channel?: string } | undefined;
   return raw?.channel ?? null;
-}
-
-function buildMissingRepositoryContextInstructions(followUp: string) {
-  return [
-    "Repository context is not available for this request.",
-    `If the user asks where a string, message, copy, or localized text appears in code, ask this follow-up exactly: ${followUp}`,
-    "Do not invent a GitHub repository, pull request, branch, installation ID, path, or file contents.",
-  ].join("\n");
-}
-
-function buildResolvedRepositoryContextInstructions(context: RepositoryAgentGitHubContext) {
-  return [
-    buildRepositoryGitHubContextInstructions(context),
-    "Repository read tools are available for this request.",
-    "Use grep with the user's literal string or copy, then read for surrounding lines when needed.",
-    "Only explain where strings, messages, or copy appear and what nearby code implies.",
-    "Do not modify files, upload sources, commit, push, or create jobs from repository context alone.",
-  ].join("\n");
-}
-
-async function getOrCreateSlackRepositorySandbox(input: {
-  thread: Thread<SlackBotState>;
-  state: SlackBotThreadState | null;
-  githubContext: RepositoryAgentGitHubContext;
-  log: ReturnType<typeof logger.child>;
-}): Promise<string> {
-  const repositoryContextKey = getSlackRepositoryContextKey(input.githubContext);
-  const sandboxSession = input.state?.repositorySandboxSession;
-  const now = new Date().toISOString();
-
-  if (sandboxSession?.repositoryContextKey === repositoryContextKey) {
-    await input.thread.setState({
-      ...input.state,
-      repositorySandboxSession: {
-        ...sandboxSession,
-        lastUsedAt: now,
-      },
-    });
-    input.log.info(
-      { sandboxId: sandboxSession.sandboxId },
-      "reusing stored repository sandbox for slack agent",
-    );
-    return sandboxSession.sandboxId;
-  }
-
-  input.log.info(
-    {
-      installationId: input.githubContext.installationId,
-      branch: input.githubContext.branch ?? null,
-      commitSha: input.githubContext.commitSha ?? null,
-    },
-    "creating repository sandbox for slack agent",
-  );
-  const sandboxId = await createRepositorySandbox(input.githubContext);
-  input.log.info({ sandboxId }, "repository sandbox created for slack agent");
-
-  try {
-    await input.thread.setState({
-      ...input.state,
-      repositoryGitHubContext: input.githubContext,
-      repositorySandboxSession: {
-        sandboxId,
-        repositoryContextKey,
-        createdAt: now,
-        lastUsedAt: now,
-      },
-    });
-  } catch (error) {
-    await stopRepositorySandbox(sandboxId).catch((cleanupError: unknown) => {
-      input.log.warn(
-        { err: serializeErrorForLog(cleanupError) },
-        "repository sandbox cleanup failed after slack state write failure",
-      );
-    });
-    throw error;
-  }
-
-  const staleSandboxId = sandboxSession?.sandboxId;
-  if (staleSandboxId) {
-    await stopRepositorySandbox(staleSandboxId).catch((error: unknown) => {
-      input.log.warn(
-        { err: serializeErrorForLog(error), sandboxId: staleSandboxId },
-        "stale repository sandbox cleanup failed",
-      );
-    });
-  }
-
-  return sandboxId;
 }
 
 async function removeEyesReaction(thread: Thread<SlackBotState>, message: Message): Promise<void> {
@@ -392,13 +290,8 @@ async function processSlackMessage(
       hasStoredRepositoryContext: Boolean(storedRepositoryContext),
       surface: "slack",
     });
-    const shouldResolveRepositoryContext = shouldAttemptRepositoryContextResolution({
-      classification,
-      storedRepositoryContext,
-    });
     log.info(
       {
-        shouldResolveRepositoryContext,
         needsRepositoryTools: classification.needsRepositoryTools,
         continuesRepositoryThread: classification.continuesRepositoryThread,
         hasStoredRepositoryContext: Boolean(storedRepositoryContext),
@@ -407,80 +300,33 @@ async function processSlackMessage(
       "slack agent conversation classified",
     );
 
-    let resolvedRepositoryContext: RepositoryAgentGitHubContext | null = null;
-    let repositoryContextInstructions: string | null = null;
-    if (shouldResolveRepositoryContext) {
-      const canReuseStoredRepositoryContext =
-        storedRepositoryContext !== null && !classification.currentMessageSpecifiesRepository;
+    const repositoryResolution = await resolveConversationRepositoryContext({
+      surface: "slack",
+      organizationId,
+      projectId,
+      conversationText,
+      classification,
+      repositorySession: threadState,
+      connectorConfig,
+      channelId,
+    });
 
-      if (canReuseStoredRepositoryContext) {
-        resolvedRepositoryContext = storedRepositoryContext;
-        repositoryContextInstructions =
-          buildResolvedRepositoryContextInstructions(resolvedRepositoryContext);
-        log.info(
-          {
-            installationId: resolvedRepositoryContext.installationId,
-            hasPullRequestNumber: resolvedRepositoryContext.pullRequestNumber !== undefined,
-          },
-          "reusing stored slack thread repository context",
-        );
-      } else {
-        const githubContextResolution = await resolveSlackRepositoryGitHubContext({
-          organizationId,
-          text: conversationText,
-          connectorConfig,
-          projectId,
-          channelId,
-          requirePullRequest: classification.requiresPullRequest,
-        });
-        log.info(
-          {
-            status: githubContextResolution.status,
-            source:
-              githubContextResolution.status === "resolved" ? githubContextResolution.source : null,
-            repositoryFullName:
-              githubContextResolution.status === "resolved"
-                ? githubContextResolution.context.repositoryFullName
-                : null,
-            installationId:
-              githubContextResolution.status === "resolved"
-                ? githubContextResolution.context.installationId
-                : null,
-            unresolvedReason:
-              githubContextResolution.status === "unresolved"
-                ? githubContextResolution.context.reason
-                : null,
-          },
-          "slack agent repository context resolved",
-        );
+    if (repositoryResolution.clarificationFollowUp) {
+      await removeEyesReaction(thread, message);
+      wrapThreadPost(thread, interactionId);
+      await thread.post({ markdown: repositoryResolution.clarificationFollowUp });
+      return;
+    }
 
-        if (githubContextResolution.status === "resolved") {
-          resolvedRepositoryContext = githubContextResolution.context;
-          repositoryContextInstructions =
-            buildResolvedRepositoryContextInstructions(resolvedRepositoryContext);
-          await thread.setState({
-            ...threadState,
-            repositoryGitHubContext: resolvedRepositoryContext,
-          });
-        } else if (githubContextResolution.status === "unresolved") {
-          if (storedRepositoryContext && !classification.currentMessageSpecifiesRepository) {
-            resolvedRepositoryContext = storedRepositoryContext;
-            repositoryContextInstructions =
-              buildResolvedRepositoryContextInstructions(resolvedRepositoryContext);
-          } else {
-            repositoryContextInstructions = buildMissingRepositoryContextInstructions(
-              githubContextResolution.followUp,
-            );
+    const resolvedRepositoryContext = repositoryResolution.context;
+    const repositoryContextInstructions = repositoryResolution.instructions;
+    let updatedThreadState = repositoryResolution.updatedSession;
 
-            if (shouldRequireRepositoryContextClarification(classification)) {
-              await removeEyesReaction(thread, message);
-              wrapThreadPost(thread, interactionId);
-              await thread.post({ markdown: githubContextResolution.followUp });
-              return;
-            }
-          }
-        }
-      }
+    if (updatedThreadState?.repositoryGitHubContext) {
+      await thread.setState({
+        ...threadState,
+        repositoryGitHubContext: updatedThreadState.repositoryGitHubContext,
+      });
     }
 
     const chatMessages = replaceLastUserMessage(
@@ -526,14 +372,21 @@ async function processSlackMessage(
     }
 
     const latestThreadState = (await thread.state) as SlackBotThreadState | null;
-    const sandboxId = resolvedRepositoryContext
-      ? await getOrCreateSlackRepositorySandbox({
-          thread,
-          state: latestThreadState,
-          githubContext: resolvedRepositoryContext,
-          log,
-        })
-      : null;
+    let sandboxId: string | null = null;
+    if (resolvedRepositoryContext) {
+      const sandboxResult = await getOrCreateConversationRepositorySandbox({
+        conversationId: interactionId,
+        surface: "slack",
+        githubContext: resolvedRepositoryContext,
+        repositorySession: updatedThreadState ?? latestThreadState,
+      });
+      sandboxId = sandboxResult.sandboxId;
+      updatedThreadState = sandboxResult.updatedSession;
+      await thread.setState({
+        ...latestThreadState,
+        ...updatedThreadState,
+      });
+    }
 
     const hasTmsIntegration = await resolveOrganizationHasTmsIntegration(organizationId);
 
@@ -562,10 +415,7 @@ async function processSlackMessage(
       },
       hasFileAttachments: hasTranslationAttachments,
       hasTmsIntegration,
-      additionalInstructions: [
-        buildSlackFileTranslationInstructions(),
-        repositoryContextInstructions,
-      ]
+      additionalInstructions: [buildFileTranslationInstructions(), repositoryContextInstructions]
         .filter((instruction): instruction is string => instruction !== null)
         .join("\n\n"),
     });

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/slack.ts
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/slack.ts
@@ -13,6 +13,7 @@ import {
   buildFileTranslationInstructions,
   getOrCreateConversationRepositorySandbox,
   resolveConversationRepositoryContext,
+  stopStaleRepositorySandbox,
 } from "@/lib/agent-runtime/loops/conversation-turn";
 import { resolveOrganizationHasTmsIntegration } from "@/lib/agent-runtime/skills/conversation-tms-integration";
 import { stopRepositorySandbox } from "@/lib/agent-runtime/workspaces/repository-sandbox";
@@ -388,6 +389,7 @@ async function processSlackMessage(
           ...latestThreadState,
           ...updatedThreadState,
         });
+        await stopStaleRepositorySandbox(sandboxResult.staleSandboxId, log);
       } catch (error) {
         if (sandboxResult.sandboxCreated) {
           await stopRepositorySandbox(sandboxResult.sandboxId).catch((cleanupError: unknown) => {

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/web.test.ts
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/web.test.ts
@@ -12,6 +12,8 @@ const {
 
 vi.mock("@/lib/agent-runtime/loops/conversation-turn", () => ({
   prepareConversationAgentTurn: prepareConversationAgentTurnMock,
+  REPOSITORY_ACCESS_CONTENTION_FOLLOW_UP:
+    "I'm still preparing repository access for this conversation. Please send your message again in a moment.",
 }));
 
 vi.mock("@/lib/agent-runtime/loops/conversation-repository-session", () => ({
@@ -95,5 +97,49 @@ describe("runWebChatAgentTurn", () => {
       }),
     );
     expect(setWebConversationRepositorySessionMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("returns a clarification instead of streaming when repository access is contended", async () => {
+    prepareConversationAgentTurnMock.mockImplementation(async (input) => {
+      if (input.reuseCommittedRepositorySandboxOnly) {
+        return {
+          classification: baseClassification,
+          agent: { stream: vi.fn() },
+          chatMessages: [],
+          clarificationFollowUp:
+            "I'm still preparing repository access for this conversation. Please send your message again in a moment.",
+          updatedRepositorySession: null,
+          staleSandboxId: null,
+        };
+      }
+
+      return {
+        classification: baseClassification,
+        agent: { stream: vi.fn(async () => ({ textStream: (async function* () {})() })) },
+        chatMessages: [],
+        clarificationFollowUp: null,
+        updatedRepositorySession: updatedSession,
+        staleSandboxId: "sandbox_stale",
+      };
+    });
+
+    const turn = await runWebChatAgentTurn({
+      conversationId: "conv_123",
+      messageText: "search acme/other",
+      toolContext: {
+        conversationId: "conv_123",
+        organizationId: "org_123",
+        localUserId: "user_123",
+        membershipRole: "admin",
+        projectId: null,
+        db: {} as never,
+      },
+      hasTranslationAttachments: false,
+    });
+
+    expect(turn.clarificationFollowUp).toBe(
+      "I'm still preparing repository access for this conversation. Please send your message again in a moment.",
+    );
+    expect(turn.textStream).toBeNull();
   });
 });

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/web.test.ts
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/web.test.ts
@@ -19,6 +19,7 @@ vi.mock("@/lib/agent-runtime/loops/conversation-turn", () => ({
 vi.mock("@/lib/agent-runtime/loops/conversation-repository-session", () => ({
   getWebConversationRepositorySession: getWebConversationRepositorySessionMock,
   setWebConversationRepositorySession: setWebConversationRepositorySessionMock,
+  acquireWebRepositorySandboxLease: vi.fn(() => vi.fn()),
 }));
 
 import { runWebChatAgentTurn } from "./web";
@@ -63,6 +64,7 @@ describe("runWebChatAgentTurn", () => {
       clarificationFollowUp: null,
       updatedRepositorySession: updatedSession,
       staleSandboxId: "sandbox_stale",
+      repositorySandboxId: "sandbox_new",
     });
   });
 
@@ -110,6 +112,7 @@ describe("runWebChatAgentTurn", () => {
             "I'm still preparing repository access for this conversation. Please send your message again in a moment.",
           updatedRepositorySession: null,
           staleSandboxId: null,
+          repositorySandboxId: null,
         };
       }
 
@@ -120,6 +123,7 @@ describe("runWebChatAgentTurn", () => {
         clarificationFollowUp: null,
         updatedRepositorySession: updatedSession,
         staleSandboxId: "sandbox_stale",
+        repositorySandboxId: "sandbox_new",
       };
     });
 

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/web.test.ts
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/web.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const {
+  prepareConversationAgentTurnMock,
+  getWebConversationRepositorySessionMock,
+  setWebConversationRepositorySessionMock,
+} = vi.hoisted(() => ({
+  prepareConversationAgentTurnMock: vi.fn(),
+  getWebConversationRepositorySessionMock: vi.fn(),
+  setWebConversationRepositorySessionMock: vi.fn(),
+}));
+
+vi.mock("@/lib/agent-runtime/loops/conversation-turn", () => ({
+  prepareConversationAgentTurn: prepareConversationAgentTurnMock,
+}));
+
+vi.mock("@/lib/agent-runtime/loops/conversation-repository-session", () => ({
+  getWebConversationRepositorySession: getWebConversationRepositorySessionMock,
+  setWebConversationRepositorySession: setWebConversationRepositorySessionMock,
+}));
+
+import { runWebChatAgentTurn } from "./web";
+
+const baseClassification = {
+  needsRepositoryTools: false,
+  requiresPullRequest: false,
+  shouldAskForRepositoryClarification: false,
+  continuesRepositoryThread: false,
+  currentMessageSpecifiesRepository: false,
+  confidence: 0.9,
+};
+
+const updatedSession = {
+  repositorySandboxSession: {
+    sandboxId: "sandbox_new",
+    repositoryContextKey: "ctx_new",
+    createdAt: "2026-07-01T12:00:00.000Z",
+    lastUsedAt: "2026-07-01T12:00:00.000Z",
+  },
+};
+
+describe("runWebChatAgentTurn", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getWebConversationRepositorySessionMock.mockReturnValue({
+      session: {
+        repositorySandboxSession: {
+          sandboxId: "sandbox_committed",
+          repositoryContextKey: "ctx_committed",
+          createdAt: "2026-07-01T12:00:00.000Z",
+          lastUsedAt: "2026-07-01T12:00:00.000Z",
+        },
+      },
+      version: 1,
+    });
+    setWebConversationRepositorySessionMock.mockReturnValue(false);
+    prepareConversationAgentTurnMock.mockResolvedValue({
+      classification: baseClassification,
+      agent: { stream: vi.fn(async () => ({ textStream: (async function* () {})() })) },
+      chatMessages: [],
+      clarificationFollowUp: null,
+      updatedRepositorySession: updatedSession,
+      staleSandboxId: "sandbox_stale",
+    });
+  });
+
+  it("reuses only the committed repository sandbox after repeated session write failures", async () => {
+    await runWebChatAgentTurn({
+      conversationId: "conv_123",
+      messageText: "where is the login copy?",
+      toolContext: {
+        conversationId: "conv_123",
+        organizationId: "org_123",
+        localUserId: "user_123",
+        membershipRole: "admin",
+        projectId: null,
+        db: {} as never,
+      },
+      hasTranslationAttachments: false,
+    });
+
+    expect(prepareConversationAgentTurnMock).toHaveBeenCalledTimes(4);
+    expect(prepareConversationAgentTurnMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        conversationId: "conv_123",
+        reuseCommittedRepositorySandboxOnly: true,
+        repositorySession: {
+          repositorySandboxSession: {
+            sandboxId: "sandbox_committed",
+            repositoryContextKey: "ctx_committed",
+            createdAt: "2026-07-01T12:00:00.000Z",
+            lastUsedAt: "2026-07-01T12:00:00.000Z",
+          },
+        },
+      }),
+    );
+    expect(setWebConversationRepositorySessionMock).toHaveBeenCalledTimes(3);
+  });
+});

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/web.ts
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/web.ts
@@ -3,6 +3,7 @@ import type { Thread } from "chat";
 import type { ToolContext } from "@/lib/agent-contracts/tool-context";
 import { addInteractionMessage } from "@/lib/conversations/interactions";
 import {
+  acquireWebRepositorySandboxLease,
   getWebConversationRepositorySession,
   setWebConversationRepositorySession,
 } from "@/lib/agent-runtime/loops/conversation-repository-session";
@@ -28,6 +29,19 @@ export async function postStreamingAgentReply(
   await thread.post(captureTextStream());
 
   return text;
+}
+
+async function* streamWithSandboxLeaseRelease(
+  stream: AsyncIterable<string>,
+  releaseLease: () => void,
+) {
+  try {
+    for await (const chunk of stream) {
+      yield chunk;
+    }
+  } finally {
+    releaseLease();
+  }
 }
 
 async function prepareAndCommitWebConversationTurn(
@@ -92,12 +106,23 @@ export async function runWebChatAgentTurn(input: {
     };
   }
 
-  const result = await prepared.agent.stream({ messages: prepared.chatMessages });
-  return {
-    classification: prepared.classification,
-    clarificationFollowUp: null,
-    textStream: result.textStream,
-  };
+  const releaseSandboxLease = prepared.repositorySandboxId
+    ? acquireWebRepositorySandboxLease(prepared.repositorySandboxId)
+    : null;
+
+  try {
+    const result = await prepared.agent.stream({ messages: prepared.chatMessages });
+    return {
+      classification: prepared.classification,
+      clarificationFollowUp: null,
+      textStream: releaseSandboxLease
+        ? streamWithSandboxLeaseRelease(result.textStream, releaseSandboxLease)
+        : result.textStream,
+    };
+  } catch (error) {
+    releaseSandboxLease?.();
+    throw error;
+  }
 }
 
 export async function postWebClarificationReply(

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/web.ts
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/web.ts
@@ -61,6 +61,7 @@ async function prepareAndCommitWebConversationTurn(
   return prepareConversationAgentTurn({
     ...prepareInput,
     repositorySession: getWebConversationRepositorySession(conversationId)?.session ?? null,
+    reuseCommittedRepositorySandboxOnly: true,
   });
 }
 

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/web.ts
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/web.ts
@@ -32,6 +32,7 @@ export async function runWebChatAgentTurn(input: {
   toolContext: ToolContext;
   hasTranslationAttachments: boolean;
 }) {
+  const repositorySessionState = getWebConversationRepositorySession(input.conversationId);
   const prepared = await prepareConversationAgentTurn({
     surface: "web",
     conversationId: input.conversationId,
@@ -41,13 +42,16 @@ export async function runWebChatAgentTurn(input: {
     projectId: input.toolContext.projectId,
     messageText: input.messageText,
     hasTranslationAttachments: input.hasTranslationAttachments,
-    repositorySession: getWebConversationRepositorySession(input.conversationId),
+    repositorySession: repositorySessionState?.session ?? null,
     repositorySource: "chat_ui",
     db: input.toolContext.db,
   });
 
   if (prepared.updatedRepositorySession) {
-    setWebConversationRepositorySession(input.conversationId, prepared.updatedRepositorySession);
+    setWebConversationRepositorySession(input.conversationId, {
+      baseVersion: repositorySessionState?.version ?? null,
+      session: prepared.updatedRepositorySession,
+    });
   }
 
   if (prepared.clarificationFollowUp) {

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/web.ts
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/web.ts
@@ -1,15 +1,12 @@
 import type { Thread } from "chat";
 
-import {
-  buildTranslationAttachmentRequiredMessage,
-  classifyConversation,
-  createConversationToolLoopAgent,
-  getRecentUserConversationText,
-  loadInteractionModelMessages,
-} from "@/lib/agent-runtime/loops/hyperlocalise-agent";
-import { resolveOrganizationHasTmsIntegration } from "@/lib/agent-runtime/skills/conversation-tms-integration";
 import type { ToolContext } from "@/lib/agent-contracts/tool-context";
 import { addInteractionMessage } from "@/lib/conversations/interactions";
+import {
+  getWebConversationRepositorySession,
+  setWebConversationRepositorySession,
+} from "@/lib/agent-runtime/loops/conversation-repository-session";
+import { prepareConversationAgentTurn } from "@/lib/agent-runtime/loops/conversation-turn";
 
 export async function postStreamingAgentReply(
   thread: Thread<Record<string, unknown>>,
@@ -34,41 +31,46 @@ export async function runWebChatAgentTurn(input: {
   messageText: string;
   toolContext: ToolContext;
   hasTranslationAttachments: boolean;
-  hasStoredRepositoryContext?: boolean;
 }) {
-  const chatMessages = await loadInteractionModelMessages(input.conversationId);
-  const conversationText = getRecentUserConversationText(chatMessages, input.messageText);
-  const classification = await classifyConversation({
-    currentMessage: input.messageText,
-    conversationText,
-    hasFileAttachments: input.hasTranslationAttachments,
-    hasStoredRepositoryContext: input.hasStoredRepositoryContext ?? false,
+  const prepared = await prepareConversationAgentTurn({
     surface: "web",
+    conversationId: input.conversationId,
+    organizationId: input.toolContext.organizationId,
+    localUserId: input.toolContext.localUserId,
+    membershipRole: input.toolContext.membershipRole,
+    projectId: input.toolContext.projectId,
+    messageText: input.messageText,
+    hasTranslationAttachments: input.hasTranslationAttachments,
+    repositorySession: getWebConversationRepositorySession(input.conversationId),
+    repositorySource: "chat_ui",
+    db: input.toolContext.db,
   });
 
-  const hasTmsIntegration = await resolveOrganizationHasTmsIntegration(
-    input.toolContext.organizationId,
-  );
+  if (prepared.updatedRepositorySession) {
+    setWebConversationRepositorySession(input.conversationId, prepared.updatedRepositorySession);
+  }
 
-  const agent = createConversationToolLoopAgent({
-    surface: "web",
-    toolContext: input.toolContext,
-    hasFileAttachments: input.hasTranslationAttachments,
-    hasTmsIntegration,
-  });
+  if (prepared.clarificationFollowUp) {
+    return {
+      classification: prepared.classification,
+      clarificationFollowUp: prepared.clarificationFollowUp,
+      textStream: null,
+    };
+  }
 
-  const result = await agent.stream({ messages: chatMessages });
+  const result = await prepared.agent.stream({ messages: prepared.chatMessages });
   return {
-    classification,
+    classification: prepared.classification,
+    clarificationFollowUp: null,
     textStream: result.textStream,
   };
 }
 
-export async function postWebAttachmentRequiredReply(
+export async function postWebClarificationReply(
   thread: Thread<Record<string, unknown>>,
   conversationId: string,
+  text: string,
 ) {
-  const text = buildTranslationAttachmentRequiredMessage("web");
   await thread.post(text);
   await addInteractionMessage({
     interactionId: conversationId,

--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/web.ts
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/web.ts
@@ -6,7 +6,11 @@ import {
   getWebConversationRepositorySession,
   setWebConversationRepositorySession,
 } from "@/lib/agent-runtime/loops/conversation-repository-session";
-import { prepareConversationAgentTurn } from "@/lib/agent-runtime/loops/conversation-turn";
+import {
+  prepareConversationAgentTurn,
+  type PrepareConversationAgentTurnInput,
+  type PrepareConversationAgentTurnResult,
+} from "@/lib/agent-runtime/loops/conversation-turn";
 
 export async function postStreamingAgentReply(
   thread: Thread<Record<string, unknown>>,
@@ -26,14 +30,47 @@ export async function postStreamingAgentReply(
   return text;
 }
 
+async function prepareAndCommitWebConversationTurn(
+  conversationId: string,
+  prepareInput: Omit<PrepareConversationAgentTurnInput, "repositorySession">,
+): Promise<PrepareConversationAgentTurnResult> {
+  let repositorySessionState = getWebConversationRepositorySession(conversationId);
+
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const prepared = await prepareConversationAgentTurn({
+      ...prepareInput,
+      repositorySession: repositorySessionState?.session ?? null,
+    });
+
+    if (!prepared.updatedRepositorySession) {
+      return prepared;
+    }
+
+    const committed = setWebConversationRepositorySession(conversationId, {
+      baseVersion: repositorySessionState?.version ?? null,
+      session: prepared.updatedRepositorySession,
+    });
+
+    if (committed) {
+      return prepared;
+    }
+
+    repositorySessionState = getWebConversationRepositorySession(conversationId);
+  }
+
+  return prepareConversationAgentTurn({
+    ...prepareInput,
+    repositorySession: getWebConversationRepositorySession(conversationId)?.session ?? null,
+  });
+}
+
 export async function runWebChatAgentTurn(input: {
   conversationId: string;
   messageText: string;
   toolContext: ToolContext;
   hasTranslationAttachments: boolean;
 }) {
-  const repositorySessionState = getWebConversationRepositorySession(input.conversationId);
-  const prepared = await prepareConversationAgentTurn({
+  const prepared = await prepareAndCommitWebConversationTurn(input.conversationId, {
     surface: "web",
     conversationId: input.conversationId,
     organizationId: input.toolContext.organizationId,
@@ -42,17 +79,9 @@ export async function runWebChatAgentTurn(input: {
     projectId: input.toolContext.projectId,
     messageText: input.messageText,
     hasTranslationAttachments: input.hasTranslationAttachments,
-    repositorySession: repositorySessionState?.session ?? null,
     repositorySource: "chat_ui",
     db: input.toolContext.db,
   });
-
-  if (prepared.updatedRepositorySession) {
-    setWebConversationRepositorySession(input.conversationId, {
-      baseVersion: repositorySessionState?.version ?? null,
-      session: prepared.updatedRepositorySession,
-    });
-  }
 
   if (prepared.clarificationFollowUp) {
     return {

--- a/apps/hyperlocalise-web/src/api/routes/conversation/chat-stream.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/conversation/chat-stream.route.ts
@@ -11,7 +11,7 @@ import { workosAuthMiddleware } from "@/api/auth/workos";
 import { resolveApiAuthContextFromSession } from "@/api/auth/workos-session";
 import {
   postStreamingAgentReply,
-  postWebAttachmentRequiredReply,
+  postWebClarificationReply,
   runWebChatAgentTurn,
 } from "@/agents/hyperlocalise/agent/channels/web";
 import { db } from "@/lib/database";
@@ -84,12 +84,8 @@ export function createChatStreamRoutes() {
 
         const hasTranslationAttachments =
           await interactionHasTranslationAttachments(conversationId);
-        if (!hasTranslationAttachments) {
-          await postWebAttachmentRequiredReply(thread, conversationId);
-          return;
-        }
 
-        const { textStream } = await runWebChatAgentTurn({
+        const turn = await runWebChatAgentTurn({
           conversationId,
           messageText: message.text,
           toolContext: {
@@ -103,7 +99,16 @@ export function createChatStreamRoutes() {
           hasTranslationAttachments,
         });
 
-        const text = await postStreamingAgentReply(thread, textStream);
+        if (turn.clarificationFollowUp) {
+          await postWebClarificationReply(thread, conversationId, turn.clarificationFollowUp);
+          return;
+        }
+
+        if (!turn.textStream) {
+          return;
+        }
+
+        const text = await postStreamingAgentReply(thread, turn.textStream);
 
         try {
           await addInteractionMessage({

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-repository-session.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-repository-session.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const { stopRepositorySandboxMock } = vi.hoisted(() => ({
+    stopRepositorySandboxMock: vi.fn(async () => undefined),
+}));
+
+vi.mock("@/lib/agent-runtime/workspaces/repository-sandbox", () => ({
+    stopRepositorySandbox: stopRepositorySandboxMock,
+}));
+
+vi.mock("@/lib/log", () => ({
+    createLogger: vi.fn(() => ({
+        warn: vi.fn(),
+    })),
+    serializeErrorForLog: vi.fn((error: unknown) => ({ error })),
+}));
+
+import {
+    getWebConversationRepositorySession,
+    setWebConversationRepositorySession,
+} from "./conversation-repository-session";
+
+const WEB_SESSION_TTL_MS = 30 * 60 * 1000;
+
+describe("web conversation repository session", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date("2026-07-01T12:00:00.000Z"));
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("stops the sandbox when a session expires", async () => {
+        setWebConversationRepositorySession("conv_expired", {
+            repositorySandboxSession: {
+                sandboxId: "sbx_expired",
+                repositoryContextKey: "ctx",
+                createdAt: "2026-07-01T12:00:00.000Z",
+                lastUsedAt: "2026-07-01T12:00:00.000Z",
+            },
+        });
+
+        vi.advanceTimersByTime(WEB_SESSION_TTL_MS + 1);
+
+        expect(getWebConversationRepositorySession("conv_expired")).toBeNull();
+        await vi.waitFor(() => {
+            expect(stopRepositorySandboxMock).toHaveBeenCalledWith("sbx_expired");
+        });
+    });
+
+    it("stops the sandbox when the cache exceeds its entry limit", async () => {
+        for (let index = 0; index < 200; index += 1) {
+            setWebConversationRepositorySession(`conv_${index}`, {
+                repositorySandboxSession: {
+                    sandboxId: `sbx_${index}`,
+                    repositoryContextKey: `ctx_${index}`,
+                    createdAt: "2026-07-01T12:00:00.000Z",
+                    lastUsedAt: "2026-07-01T12:00:00.000Z",
+                },
+            });
+        }
+
+        setWebConversationRepositorySession("conv_overflow", {
+            repositorySandboxSession: {
+                sandboxId: "sbx_overflow",
+                repositoryContextKey: "ctx_overflow",
+                createdAt: "2026-07-01T12:00:00.000Z",
+                lastUsedAt: "2026-07-01T12:00:00.000Z",
+            },
+        });
+
+        await vi.waitFor(() => {
+            expect(stopRepositorySandboxMock).toHaveBeenCalledWith("sbx_0");
+        });
+        expect(getWebConversationRepositorySession("conv_overflow")).not.toBeNull();
+    });
+});

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-repository-session.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-repository-session.test.ts
@@ -1,80 +1,80 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 const { stopRepositorySandboxMock } = vi.hoisted(() => ({
-    stopRepositorySandboxMock: vi.fn(async () => undefined),
+  stopRepositorySandboxMock: vi.fn(async () => undefined),
 }));
 
 vi.mock("@/lib/agent-runtime/workspaces/repository-sandbox", () => ({
-    stopRepositorySandbox: stopRepositorySandboxMock,
+  stopRepositorySandbox: stopRepositorySandboxMock,
 }));
 
 vi.mock("@/lib/log", () => ({
-    createLogger: vi.fn(() => ({
-        warn: vi.fn(),
-    })),
-    serializeErrorForLog: vi.fn((error: unknown) => ({ error })),
+  createLogger: vi.fn(() => ({
+    warn: vi.fn(),
+  })),
+  serializeErrorForLog: vi.fn((error: unknown) => ({ error })),
 }));
 
 import {
-    getWebConversationRepositorySession,
-    setWebConversationRepositorySession,
+  getWebConversationRepositorySession,
+  setWebConversationRepositorySession,
 } from "./conversation-repository-session";
 
 const WEB_SESSION_TTL_MS = 30 * 60 * 1000;
 
 describe("web conversation repository session", () => {
-    beforeEach(() => {
-        vi.clearAllMocks();
-        vi.useFakeTimers();
-        vi.setSystemTime(new Date("2026-07-01T12:00:00.000Z"));
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-01T12:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("stops the sandbox when a session expires", async () => {
+    setWebConversationRepositorySession("conv_expired", {
+      repositorySandboxSession: {
+        sandboxId: "sbx_expired",
+        repositoryContextKey: "ctx",
+        createdAt: "2026-07-01T12:00:00.000Z",
+        lastUsedAt: "2026-07-01T12:00:00.000Z",
+      },
     });
 
-    afterEach(() => {
-        vi.useRealTimers();
+    vi.advanceTimersByTime(WEB_SESSION_TTL_MS + 1);
+
+    expect(getWebConversationRepositorySession("conv_expired")).toBeNull();
+    await vi.waitFor(() => {
+      expect(stopRepositorySandboxMock).toHaveBeenCalledWith("sbx_expired");
+    });
+  });
+
+  it("stops the sandbox when the cache exceeds its entry limit", async () => {
+    for (let index = 0; index < 200; index += 1) {
+      setWebConversationRepositorySession(`conv_${index}`, {
+        repositorySandboxSession: {
+          sandboxId: `sbx_${index}`,
+          repositoryContextKey: `ctx_${index}`,
+          createdAt: "2026-07-01T12:00:00.000Z",
+          lastUsedAt: "2026-07-01T12:00:00.000Z",
+        },
+      });
+    }
+
+    setWebConversationRepositorySession("conv_overflow", {
+      repositorySandboxSession: {
+        sandboxId: "sbx_overflow",
+        repositoryContextKey: "ctx_overflow",
+        createdAt: "2026-07-01T12:00:00.000Z",
+        lastUsedAt: "2026-07-01T12:00:00.000Z",
+      },
     });
 
-    it("stops the sandbox when a session expires", async () => {
-        setWebConversationRepositorySession("conv_expired", {
-            repositorySandboxSession: {
-                sandboxId: "sbx_expired",
-                repositoryContextKey: "ctx",
-                createdAt: "2026-07-01T12:00:00.000Z",
-                lastUsedAt: "2026-07-01T12:00:00.000Z",
-            },
-        });
-
-        vi.advanceTimersByTime(WEB_SESSION_TTL_MS + 1);
-
-        expect(getWebConversationRepositorySession("conv_expired")).toBeNull();
-        await vi.waitFor(() => {
-            expect(stopRepositorySandboxMock).toHaveBeenCalledWith("sbx_expired");
-        });
+    await vi.waitFor(() => {
+      expect(stopRepositorySandboxMock).toHaveBeenCalledWith("sbx_0");
     });
-
-    it("stops the sandbox when the cache exceeds its entry limit", async () => {
-        for (let index = 0; index < 200; index += 1) {
-            setWebConversationRepositorySession(`conv_${index}`, {
-                repositorySandboxSession: {
-                    sandboxId: `sbx_${index}`,
-                    repositoryContextKey: `ctx_${index}`,
-                    createdAt: "2026-07-01T12:00:00.000Z",
-                    lastUsedAt: "2026-07-01T12:00:00.000Z",
-                },
-            });
-        }
-
-        setWebConversationRepositorySession("conv_overflow", {
-            repositorySandboxSession: {
-                sandboxId: "sbx_overflow",
-                repositoryContextKey: "ctx_overflow",
-                createdAt: "2026-07-01T12:00:00.000Z",
-                lastUsedAt: "2026-07-01T12:00:00.000Z",
-            },
-        });
-
-        await vi.waitFor(() => {
-            expect(stopRepositorySandboxMock).toHaveBeenCalledWith("sbx_0");
-        });
-        expect(getWebConversationRepositorySession("conv_overflow")).not.toBeNull();
-    });
+    expect(getWebConversationRepositorySession("conv_overflow")).not.toBeNull();
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-repository-session.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-repository-session.test.ts
@@ -22,6 +22,16 @@ import {
 
 const WEB_SESSION_TTL_MS = 30 * 60 * 1000;
 
+function setSession(
+  conversationId: string,
+  input: {
+    baseVersion: number | null;
+    session: Parameters<typeof setWebConversationRepositorySession>[1]["session"];
+  },
+) {
+  return setWebConversationRepositorySession(conversationId, input);
+}
+
 describe("web conversation repository session", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -34,12 +44,15 @@ describe("web conversation repository session", () => {
   });
 
   it("stops the sandbox when a session expires", async () => {
-    setWebConversationRepositorySession("conv_expired", {
-      repositorySandboxSession: {
-        sandboxId: "sbx_expired",
-        repositoryContextKey: "ctx",
-        createdAt: "2026-07-01T12:00:00.000Z",
-        lastUsedAt: "2026-07-01T12:00:00.000Z",
+    setSession("conv_expired", {
+      baseVersion: null,
+      session: {
+        repositorySandboxSession: {
+          sandboxId: "sbx_expired",
+          repositoryContextKey: "ctx",
+          createdAt: "2026-07-01T12:00:00.000Z",
+          lastUsedAt: "2026-07-01T12:00:00.000Z",
+        },
       },
     });
 
@@ -53,22 +66,28 @@ describe("web conversation repository session", () => {
 
   it("stops the sandbox when the cache exceeds its entry limit", async () => {
     for (let index = 0; index < 200; index += 1) {
-      setWebConversationRepositorySession(`conv_${index}`, {
-        repositorySandboxSession: {
-          sandboxId: `sbx_${index}`,
-          repositoryContextKey: `ctx_${index}`,
-          createdAt: "2026-07-01T12:00:00.000Z",
-          lastUsedAt: "2026-07-01T12:00:00.000Z",
+      setSession(`conv_${index}`, {
+        baseVersion: null,
+        session: {
+          repositorySandboxSession: {
+            sandboxId: `sbx_${index}`,
+            repositoryContextKey: `ctx_${index}`,
+            createdAt: "2026-07-01T12:00:00.000Z",
+            lastUsedAt: "2026-07-01T12:00:00.000Z",
+          },
         },
       });
     }
 
-    setWebConversationRepositorySession("conv_overflow", {
-      repositorySandboxSession: {
-        sandboxId: "sbx_overflow",
-        repositoryContextKey: "ctx_overflow",
-        createdAt: "2026-07-01T12:00:00.000Z",
-        lastUsedAt: "2026-07-01T12:00:00.000Z",
+    setSession("conv_overflow", {
+      baseVersion: null,
+      session: {
+        repositorySandboxSession: {
+          sandboxId: "sbx_overflow",
+          repositoryContextKey: "ctx_overflow",
+          createdAt: "2026-07-01T12:00:00.000Z",
+          lastUsedAt: "2026-07-01T12:00:00.000Z",
+        },
       },
     });
 
@@ -76,5 +95,91 @@ describe("web conversation repository session", () => {
       expect(stopRepositorySandboxMock).toHaveBeenCalledWith("sbx_0");
     });
     expect(getWebConversationRepositorySession("conv_overflow")).not.toBeNull();
+  });
+
+  it("stops the overwritten sandbox when a session is replaced", async () => {
+    setSession("conv_replace", {
+      baseVersion: null,
+      session: {
+        repositorySandboxSession: {
+          sandboxId: "sbx_old",
+          repositoryContextKey: "ctx_old",
+          createdAt: "2026-07-01T12:00:00.000Z",
+          lastUsedAt: "2026-07-01T12:00:00.000Z",
+        },
+      },
+    });
+
+    const current = getWebConversationRepositorySession("conv_replace");
+    expect(current?.version).toBe(1);
+
+    setSession("conv_replace", {
+      baseVersion: current?.version ?? null,
+      session: {
+        repositorySandboxSession: {
+          sandboxId: "sbx_new",
+          repositoryContextKey: "ctx_new",
+          createdAt: "2026-07-01T12:01:00.000Z",
+          lastUsedAt: "2026-07-01T12:01:00.000Z",
+        },
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(stopRepositorySandboxMock).toHaveBeenCalledWith("sbx_old");
+    });
+    expect(
+      getWebConversationRepositorySession("conv_replace")?.session.repositorySandboxSession,
+    ).toMatchObject({ sandboxId: "sbx_new" });
+  });
+
+  it("rejects stale writes and stops the sandbox from the losing turn", async () => {
+    setSession("conv_race", {
+      baseVersion: null,
+      session: {
+        repositorySandboxSession: {
+          sandboxId: "sbx_initial",
+          repositoryContextKey: "ctx_initial",
+          createdAt: "2026-07-01T12:00:00.000Z",
+          lastUsedAt: "2026-07-01T12:00:00.000Z",
+        },
+      },
+    });
+
+    const staleRead = getWebConversationRepositorySession("conv_race");
+    const current = getWebConversationRepositorySession("conv_race");
+    expect(staleRead?.version).toBe(current?.version);
+
+    setSession("conv_race", {
+      baseVersion: current?.version ?? null,
+      session: {
+        repositorySandboxSession: {
+          sandboxId: "sbx_winner",
+          repositoryContextKey: "ctx_winner",
+          createdAt: "2026-07-01T12:01:00.000Z",
+          lastUsedAt: "2026-07-01T12:01:00.000Z",
+        },
+      },
+    });
+
+    const committed = setSession("conv_race", {
+      baseVersion: staleRead?.version ?? null,
+      session: {
+        repositorySandboxSession: {
+          sandboxId: "sbx_loser",
+          repositoryContextKey: "ctx_loser",
+          createdAt: "2026-07-01T12:02:00.000Z",
+          lastUsedAt: "2026-07-01T12:02:00.000Z",
+        },
+      },
+    });
+
+    expect(committed).toBe(false);
+    await vi.waitFor(() => {
+      expect(stopRepositorySandboxMock).toHaveBeenCalledWith("sbx_loser");
+    });
+    expect(
+      getWebConversationRepositorySession("conv_race")?.session.repositorySandboxSession,
+    ).toMatchObject({ sandboxId: "sbx_winner" });
   });
 });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-repository-session.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-repository-session.test.ts
@@ -16,6 +16,7 @@ vi.mock("@/lib/log", () => ({
 }));
 
 import {
+  acquireWebRepositorySandboxLease,
   getWebConversationRepositorySession,
   setWebConversationRepositorySession,
 } from "./conversation-repository-session";
@@ -181,5 +182,67 @@ describe("web conversation repository session", () => {
     expect(
       getWebConversationRepositorySession("conv_race")?.session.repositorySandboxSession,
     ).toMatchObject({ sandboxId: "sbx_winner" });
+  });
+
+  it("defers sandbox cleanup while a web turn holds an active lease", async () => {
+    setSession("conv_active", {
+      baseVersion: null,
+      session: {
+        repositorySandboxSession: {
+          sandboxId: "sbx_active",
+          repositoryContextKey: "ctx_active",
+          createdAt: "2026-07-01T12:00:00.000Z",
+          lastUsedAt: "2026-07-01T12:00:00.000Z",
+        },
+      },
+    });
+
+    const releaseLease = acquireWebRepositorySandboxLease("sbx_active");
+
+    vi.advanceTimersByTime(WEB_SESSION_TTL_MS + 1);
+    expect(getWebConversationRepositorySession("conv_active")).toBeNull();
+    expect(stopRepositorySandboxMock).not.toHaveBeenCalledWith("sbx_active");
+
+    releaseLease();
+    await vi.waitFor(() => {
+      expect(stopRepositorySandboxMock).toHaveBeenCalledWith("sbx_active");
+    });
+  });
+
+  it("defers sandbox cleanup on cache eviction while a lease is active", async () => {
+    for (let index = 0; index < 200; index += 1) {
+      setSession(`conv_${index}`, {
+        baseVersion: null,
+        session: {
+          repositorySandboxSession: {
+            sandboxId: `sbx_${index}`,
+            repositoryContextKey: `ctx_${index}`,
+            createdAt: "2026-07-01T12:00:00.000Z",
+            lastUsedAt: "2026-07-01T12:00:00.000Z",
+          },
+        },
+      });
+    }
+
+    const releaseLease = acquireWebRepositorySandboxLease("sbx_0");
+
+    setSession("conv_overflow", {
+      baseVersion: null,
+      session: {
+        repositorySandboxSession: {
+          sandboxId: "sbx_overflow",
+          repositoryContextKey: "ctx_overflow",
+          createdAt: "2026-07-01T12:00:00.000Z",
+          lastUsedAt: "2026-07-01T12:00:00.000Z",
+        },
+      },
+    });
+
+    expect(stopRepositorySandboxMock).not.toHaveBeenCalledWith("sbx_0");
+
+    releaseLease();
+    await vi.waitFor(() => {
+      expect(stopRepositorySandboxMock).toHaveBeenCalledWith("sbx_0");
+    });
   });
 });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-repository-session.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-repository-session.ts
@@ -1,77 +1,108 @@
 import type { RepositoryAgentGitHubContext } from "@/lib/agent-contracts/repository-task";
+import { stopRepositorySandbox } from "@/lib/agent-runtime/workspaces/repository-sandbox";
+import { createLogger, serializeErrorForLog } from "@/lib/log";
+
+const logger = createLogger("conversation-repository-session");
 
 export type ConversationRepositorySandboxSession = {
-  sandboxId: string;
-  repositoryContextKey: string;
-  createdAt: string;
-  lastUsedAt: string;
+    sandboxId: string;
+    repositoryContextKey: string;
+    createdAt: string;
+    lastUsedAt: string;
 };
 
 export type ConversationRepositorySession = {
-  repositoryGitHubContext?: RepositoryAgentGitHubContext;
-  repositorySandboxSession?: ConversationRepositorySandboxSession;
+    repositoryGitHubContext?: RepositoryAgentGitHubContext;
+    repositorySandboxSession?: ConversationRepositorySandboxSession;
 };
 
 export function getRepositoryContextKey(context: RepositoryAgentGitHubContext): string {
-  return JSON.stringify({
-    installationId: context.installationId,
-    repositoryFullName: context.repositoryFullName,
-    pullRequestNumber: context.pullRequestNumber ?? null,
-    branch: context.branch ?? null,
-    commitSha: context.commitSha ?? null,
-    commentId: context.commentId ?? null,
-  });
+    return JSON.stringify({
+        installationId: context.installationId,
+        repositoryFullName: context.repositoryFullName,
+        pullRequestNumber: context.pullRequestNumber ?? null,
+        branch: context.branch ?? null,
+        commitSha: context.commitSha ?? null,
+        commentId: context.commentId ?? null,
+    });
 }
 
 const WEB_SESSION_TTL_MS = 30 * 60 * 1000;
 const WEB_SESSION_MAX_ENTRIES = 200;
 
 type WebSessionEntry = {
-  session: ConversationRepositorySession;
-  expiresAt: number;
+    session: ConversationRepositorySession;
+    expiresAt: number;
 };
 
 const webRepositorySessions = new Map<string, WebSessionEntry>();
 
-function pruneExpiredWebSessions(now: number) {
-  for (const [conversationId, entry] of webRepositorySessions) {
-    if (entry.expiresAt <= now) {
-      webRepositorySessions.delete(conversationId);
+function releaseWebSessionSandbox(session: ConversationRepositorySession) {
+    const sandboxId = session.repositorySandboxSession?.sandboxId;
+    if (!sandboxId) {
+        return;
     }
-  }
 
-  while (webRepositorySessions.size > WEB_SESSION_MAX_ENTRIES) {
-    const oldestConversationId = webRepositorySessions.keys().next().value;
-    if (!oldestConversationId) {
-      break;
+    void stopRepositorySandbox(sandboxId).catch((error: unknown) => {
+        logger.warn(
+            { err: serializeErrorForLog(error), sandboxId },
+            "web repository sandbox cleanup failed during session eviction",
+        );
+    });
+}
+
+function removeWebRepositorySession(conversationId: string) {
+    const entry = webRepositorySessions.get(conversationId);
+    if (!entry) {
+        return;
     }
-    webRepositorySessions.delete(oldestConversationId);
-  }
+
+    releaseWebSessionSandbox(entry.session);
+    webRepositorySessions.delete(conversationId);
+}
+
+function pruneExpiredWebSessions(now: number) {
+    for (const [conversationId, entry] of webRepositorySessions) {
+        if (entry.expiresAt <= now) {
+            removeWebRepositorySession(conversationId);
+        }
+    }
+
+    while (webRepositorySessions.size > WEB_SESSION_MAX_ENTRIES) {
+        const oldestConversationId = webRepositorySessions.keys().next().value;
+        if (!oldestConversationId) {
+            break;
+        }
+        removeWebRepositorySession(oldestConversationId);
+    }
 }
 
 export function getWebConversationRepositorySession(
-  conversationId: string,
+    conversationId: string,
 ): ConversationRepositorySession | null {
-  const now = Date.now();
-  pruneExpiredWebSessions(now);
+    const now = Date.now();
+    pruneExpiredWebSessions(now);
 
-  const entry = webRepositorySessions.get(conversationId);
-  if (!entry || entry.expiresAt <= now) {
-    webRepositorySessions.delete(conversationId);
-    return null;
-  }
+    const entry = webRepositorySessions.get(conversationId);
+    if (!entry || entry.expiresAt <= now) {
+        if (entry) {
+            removeWebRepositorySession(conversationId);
+        }
+        return null;
+    }
 
-  return entry.session;
+    return entry.session;
 }
 
 export function setWebConversationRepositorySession(
-  conversationId: string,
-  session: ConversationRepositorySession,
+    conversationId: string,
+    session: ConversationRepositorySession,
 ): void {
-  const now = Date.now();
-  pruneExpiredWebSessions(now);
-  webRepositorySessions.set(conversationId, {
-    session,
-    expiresAt: now + WEB_SESSION_TTL_MS,
-  });
+    const now = Date.now();
+    pruneExpiredWebSessions(now);
+    webRepositorySessions.set(conversationId, {
+        session,
+        expiresAt: now + WEB_SESSION_TTL_MS,
+    });
+    pruneExpiredWebSessions(now);
 }

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-repository-session.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-repository-session.ts
@@ -1,0 +1,77 @@
+import type { RepositoryAgentGitHubContext } from "@/lib/agent-contracts/repository-task";
+
+export type ConversationRepositorySandboxSession = {
+  sandboxId: string;
+  repositoryContextKey: string;
+  createdAt: string;
+  lastUsedAt: string;
+};
+
+export type ConversationRepositorySession = {
+  repositoryGitHubContext?: RepositoryAgentGitHubContext;
+  repositorySandboxSession?: ConversationRepositorySandboxSession;
+};
+
+export function getRepositoryContextKey(context: RepositoryAgentGitHubContext): string {
+  return JSON.stringify({
+    installationId: context.installationId,
+    repositoryFullName: context.repositoryFullName,
+    pullRequestNumber: context.pullRequestNumber ?? null,
+    branch: context.branch ?? null,
+    commitSha: context.commitSha ?? null,
+    commentId: context.commentId ?? null,
+  });
+}
+
+const WEB_SESSION_TTL_MS = 30 * 60 * 1000;
+const WEB_SESSION_MAX_ENTRIES = 200;
+
+type WebSessionEntry = {
+  session: ConversationRepositorySession;
+  expiresAt: number;
+};
+
+const webRepositorySessions = new Map<string, WebSessionEntry>();
+
+function pruneExpiredWebSessions(now: number) {
+  for (const [conversationId, entry] of webRepositorySessions) {
+    if (entry.expiresAt <= now) {
+      webRepositorySessions.delete(conversationId);
+    }
+  }
+
+  while (webRepositorySessions.size > WEB_SESSION_MAX_ENTRIES) {
+    const oldestConversationId = webRepositorySessions.keys().next().value;
+    if (!oldestConversationId) {
+      break;
+    }
+    webRepositorySessions.delete(oldestConversationId);
+  }
+}
+
+export function getWebConversationRepositorySession(
+  conversationId: string,
+): ConversationRepositorySession | null {
+  const now = Date.now();
+  pruneExpiredWebSessions(now);
+
+  const entry = webRepositorySessions.get(conversationId);
+  if (!entry || entry.expiresAt <= now) {
+    webRepositorySessions.delete(conversationId);
+    return null;
+  }
+
+  return entry.session;
+}
+
+export function setWebConversationRepositorySession(
+  conversationId: string,
+  session: ConversationRepositorySession,
+): void {
+  const now = Date.now();
+  pruneExpiredWebSessions(now);
+  webRepositorySessions.set(conversationId, {
+    session,
+    expiresAt: now + WEB_SESSION_TTL_MS,
+  });
+}

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-repository-session.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-repository-session.ts
@@ -30,8 +30,14 @@ export function getRepositoryContextKey(context: RepositoryAgentGitHubContext): 
 const WEB_SESSION_TTL_MS = 30 * 60 * 1000;
 const WEB_SESSION_MAX_ENTRIES = 200;
 
+export type WebConversationRepositorySessionState = {
+  session: ConversationRepositorySession;
+  version: number;
+};
+
 type WebSessionEntry = {
   session: ConversationRepositorySession;
+  version: number;
   expiresAt: number;
 };
 
@@ -79,7 +85,7 @@ function pruneExpiredWebSessions(now: number) {
 
 export function getWebConversationRepositorySession(
   conversationId: string,
-): ConversationRepositorySession | null {
+): WebConversationRepositorySessionState | null {
   const now = Date.now();
   pruneExpiredWebSessions(now);
 
@@ -91,18 +97,40 @@ export function getWebConversationRepositorySession(
     return null;
   }
 
-  return entry.session;
+  return {
+    session: entry.session,
+    version: entry.version,
+  };
 }
 
 export function setWebConversationRepositorySession(
   conversationId: string,
-  session: ConversationRepositorySession,
-): void {
+  input: {
+    baseVersion: number | null;
+    session: ConversationRepositorySession;
+  },
+): boolean {
   const now = Date.now();
   pruneExpiredWebSessions(now);
+
+  const existing = webRepositorySessions.get(conversationId);
+  const currentVersion = existing?.version ?? null;
+  if (currentVersion !== input.baseVersion) {
+    releaseWebSessionSandbox(input.session);
+    return false;
+  }
+
+  const existingSandboxId = existing?.session.repositorySandboxSession?.sandboxId;
+  const nextSandboxId = input.session.repositorySandboxSession?.sandboxId;
+  if (existingSandboxId && existingSandboxId !== nextSandboxId) {
+    releaseWebSessionSandbox(existing.session);
+  }
+
   webRepositorySessions.set(conversationId, {
-    session,
+    session: input.session,
+    version: (input.baseVersion ?? 0) + 1,
     expiresAt: now + WEB_SESSION_TTL_MS,
   });
   pruneExpiredWebSessions(now);
+  return true;
 }

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-repository-session.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-repository-session.ts
@@ -5,104 +5,104 @@ import { createLogger, serializeErrorForLog } from "@/lib/log";
 const logger = createLogger("conversation-repository-session");
 
 export type ConversationRepositorySandboxSession = {
-    sandboxId: string;
-    repositoryContextKey: string;
-    createdAt: string;
-    lastUsedAt: string;
+  sandboxId: string;
+  repositoryContextKey: string;
+  createdAt: string;
+  lastUsedAt: string;
 };
 
 export type ConversationRepositorySession = {
-    repositoryGitHubContext?: RepositoryAgentGitHubContext;
-    repositorySandboxSession?: ConversationRepositorySandboxSession;
+  repositoryGitHubContext?: RepositoryAgentGitHubContext;
+  repositorySandboxSession?: ConversationRepositorySandboxSession;
 };
 
 export function getRepositoryContextKey(context: RepositoryAgentGitHubContext): string {
-    return JSON.stringify({
-        installationId: context.installationId,
-        repositoryFullName: context.repositoryFullName,
-        pullRequestNumber: context.pullRequestNumber ?? null,
-        branch: context.branch ?? null,
-        commitSha: context.commitSha ?? null,
-        commentId: context.commentId ?? null,
-    });
+  return JSON.stringify({
+    installationId: context.installationId,
+    repositoryFullName: context.repositoryFullName,
+    pullRequestNumber: context.pullRequestNumber ?? null,
+    branch: context.branch ?? null,
+    commitSha: context.commitSha ?? null,
+    commentId: context.commentId ?? null,
+  });
 }
 
 const WEB_SESSION_TTL_MS = 30 * 60 * 1000;
 const WEB_SESSION_MAX_ENTRIES = 200;
 
 type WebSessionEntry = {
-    session: ConversationRepositorySession;
-    expiresAt: number;
+  session: ConversationRepositorySession;
+  expiresAt: number;
 };
 
 const webRepositorySessions = new Map<string, WebSessionEntry>();
 
 function releaseWebSessionSandbox(session: ConversationRepositorySession) {
-    const sandboxId = session.repositorySandboxSession?.sandboxId;
-    if (!sandboxId) {
-        return;
-    }
+  const sandboxId = session.repositorySandboxSession?.sandboxId;
+  if (!sandboxId) {
+    return;
+  }
 
-    void stopRepositorySandbox(sandboxId).catch((error: unknown) => {
-        logger.warn(
-            { err: serializeErrorForLog(error), sandboxId },
-            "web repository sandbox cleanup failed during session eviction",
-        );
-    });
+  void stopRepositorySandbox(sandboxId).catch((error: unknown) => {
+    logger.warn(
+      { err: serializeErrorForLog(error), sandboxId },
+      "web repository sandbox cleanup failed during session eviction",
+    );
+  });
 }
 
 function removeWebRepositorySession(conversationId: string) {
-    const entry = webRepositorySessions.get(conversationId);
-    if (!entry) {
-        return;
-    }
+  const entry = webRepositorySessions.get(conversationId);
+  if (!entry) {
+    return;
+  }
 
-    releaseWebSessionSandbox(entry.session);
-    webRepositorySessions.delete(conversationId);
+  releaseWebSessionSandbox(entry.session);
+  webRepositorySessions.delete(conversationId);
 }
 
 function pruneExpiredWebSessions(now: number) {
-    for (const [conversationId, entry] of webRepositorySessions) {
-        if (entry.expiresAt <= now) {
-            removeWebRepositorySession(conversationId);
-        }
+  for (const [conversationId, entry] of webRepositorySessions) {
+    if (entry.expiresAt <= now) {
+      removeWebRepositorySession(conversationId);
     }
+  }
 
-    while (webRepositorySessions.size > WEB_SESSION_MAX_ENTRIES) {
-        const oldestConversationId = webRepositorySessions.keys().next().value;
-        if (!oldestConversationId) {
-            break;
-        }
-        removeWebRepositorySession(oldestConversationId);
+  while (webRepositorySessions.size > WEB_SESSION_MAX_ENTRIES) {
+    const oldestConversationId = webRepositorySessions.keys().next().value;
+    if (!oldestConversationId) {
+      break;
     }
+    removeWebRepositorySession(oldestConversationId);
+  }
 }
 
 export function getWebConversationRepositorySession(
-    conversationId: string,
+  conversationId: string,
 ): ConversationRepositorySession | null {
-    const now = Date.now();
-    pruneExpiredWebSessions(now);
+  const now = Date.now();
+  pruneExpiredWebSessions(now);
 
-    const entry = webRepositorySessions.get(conversationId);
-    if (!entry || entry.expiresAt <= now) {
-        if (entry) {
-            removeWebRepositorySession(conversationId);
-        }
-        return null;
+  const entry = webRepositorySessions.get(conversationId);
+  if (!entry || entry.expiresAt <= now) {
+    if (entry) {
+      removeWebRepositorySession(conversationId);
     }
+    return null;
+  }
 
-    return entry.session;
+  return entry.session;
 }
 
 export function setWebConversationRepositorySession(
-    conversationId: string,
-    session: ConversationRepositorySession,
+  conversationId: string,
+  session: ConversationRepositorySession,
 ): void {
-    const now = Date.now();
-    pruneExpiredWebSessions(now);
-    webRepositorySessions.set(conversationId, {
-        session,
-        expiresAt: now + WEB_SESSION_TTL_MS,
-    });
-    pruneExpiredWebSessions(now);
+  const now = Date.now();
+  pruneExpiredWebSessions(now);
+  webRepositorySessions.set(conversationId, {
+    session,
+    expiresAt: now + WEB_SESSION_TTL_MS,
+  });
+  pruneExpiredWebSessions(now);
 }

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-repository-session.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-repository-session.ts
@@ -42,10 +42,56 @@ type WebSessionEntry = {
 };
 
 const webRepositorySessions = new Map<string, WebSessionEntry>();
+const webRepositorySandboxLeaseCounts = new Map<string, number>();
+const pendingWebRepositorySandboxStops = new Set<string>();
+
+export function acquireWebRepositorySandboxLease(sandboxId: string): () => void {
+  const nextCount = (webRepositorySandboxLeaseCounts.get(sandboxId) ?? 0) + 1;
+  webRepositorySandboxLeaseCounts.set(sandboxId, nextCount);
+
+  let released = false;
+  return () => {
+    if (released) {
+      return;
+    }
+    released = true;
+    releaseWebRepositorySandboxLease(sandboxId);
+  };
+}
+
+function releaseWebRepositorySandboxLease(sandboxId: string) {
+  const currentCount = webRepositorySandboxLeaseCounts.get(sandboxId) ?? 0;
+  if (currentCount <= 1) {
+    webRepositorySandboxLeaseCounts.delete(sandboxId);
+  } else {
+    webRepositorySandboxLeaseCounts.set(sandboxId, currentCount - 1);
+  }
+
+  if (
+    (webRepositorySandboxLeaseCounts.get(sandboxId) ?? 0) === 0 &&
+    pendingWebRepositorySandboxStops.delete(sandboxId)
+  ) {
+    void stopRepositorySandbox(sandboxId).catch((error: unknown) => {
+      logger.warn(
+        { err: serializeErrorForLog(error), sandboxId },
+        "web repository sandbox cleanup failed during deferred session eviction",
+      );
+    });
+  }
+}
+
+function isWebRepositorySandboxInUse(sandboxId: string) {
+  return (webRepositorySandboxLeaseCounts.get(sandboxId) ?? 0) > 0;
+}
 
 function releaseWebSessionSandbox(session: ConversationRepositorySession) {
   const sandboxId = session.repositorySandboxSession?.sandboxId;
   if (!sandboxId) {
+    return;
+  }
+
+  if (isWebRepositorySandboxInUse(sandboxId)) {
+    pendingWebRepositorySandboxStops.add(sandboxId);
     return;
   }
 

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.test.ts
@@ -75,6 +75,7 @@ vi.mock("@/lib/log", () => ({
 
 import {
   prepareConversationAgentTurn,
+  REPOSITORY_ACCESS_CONTENTION_FOLLOW_UP,
   resolveConversationRepositoryContext,
 } from "./conversation-turn";
 
@@ -306,8 +307,10 @@ describe("conversation turn preparation", () => {
         toolContext: expect.not.objectContaining({
           sandboxId: expect.anything(),
         }),
+        additionalInstructions: expect.not.stringContaining("Repository read tools are available"),
       }),
     );
+    expect(result.clarificationFollowUp).toBe(REPOSITORY_ACCESS_CONTENTION_FOLLOW_UP);
     expect(result.updatedRepositorySession?.repositorySandboxSession?.sandboxId).toBe(
       "sandbox_committed",
     );

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.test.ts
@@ -248,4 +248,68 @@ describe("conversation turn preparation", () => {
       "sandbox_123",
     );
   });
+
+  it("skips creating a sandbox when only a committed sandbox may be reused", async () => {
+    const storedContext = {
+      resolved: true as const,
+      installationId: 42,
+      repositoryFullName: "acme/web",
+    };
+    const requestedContext = {
+      resolved: true as const,
+      installationId: 99,
+      repositoryFullName: "acme/other",
+    };
+    classifyConversationMock.mockResolvedValue({
+      ...baseClassification,
+      needsRepositoryTools: true,
+      currentMessageSpecifiesRepository: true,
+    });
+    resolveConversationRepositoryGitHubContextMock.mockResolvedValue({
+      status: "resolved",
+      source: "single_installed_repository",
+      context: requestedContext,
+    });
+
+    const result = await prepareConversationAgentTurn({
+      surface: "web",
+      conversationId: "conv_123",
+      organizationId: "org_123",
+      localUserId: "user_123",
+      membershipRole: "admin",
+      projectId: null,
+      messageText: "search acme/other",
+      hasTranslationAttachments: false,
+      repositorySession: {
+        repositoryGitHubContext: storedContext,
+        repositorySandboxSession: {
+          sandboxId: "sandbox_committed",
+          repositoryContextKey: JSON.stringify({
+            installationId: storedContext.installationId,
+            repositoryFullName: storedContext.repositoryFullName,
+            pullRequestNumber: null,
+            branch: null,
+            commitSha: null,
+            commentId: null,
+          }),
+          createdAt: "2026-07-01T12:00:00.000Z",
+          lastUsedAt: "2026-07-01T12:00:00.000Z",
+        },
+      },
+      reuseCommittedRepositorySandboxOnly: true,
+      db: {} as never,
+    });
+
+    expect(createRepositorySandboxMock).not.toHaveBeenCalled();
+    expect(createConversationToolLoopAgentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolContext: expect.not.objectContaining({
+          sandboxId: expect.anything(),
+        }),
+      }),
+    );
+    expect(result.updatedRepositorySession?.repositorySandboxSession?.sandboxId).toBe(
+      "sandbox_committed",
+    );
+  });
 });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const {
+  classifyConversationMock,
+  createConversationToolLoopAgentMock,
+  loadInteractionModelMessagesMock,
+  resolveConversationRepositoryGitHubContextMock,
+  createRepositorySandboxMock,
+  resolveOrganizationHasTmsIntegrationMock,
+} = vi.hoisted(() => ({
+  classifyConversationMock: vi.fn(),
+  createConversationToolLoopAgentMock: vi.fn(() => ({ stream: vi.fn() })),
+  loadInteractionModelMessagesMock: vi.fn(),
+  resolveConversationRepositoryGitHubContextMock: vi.fn(),
+  createRepositorySandboxMock: vi.fn(),
+  resolveOrganizationHasTmsIntegrationMock: vi.fn(),
+}));
+
+vi.mock("@/lib/env", () => ({
+  env: {
+    OPENAI_API_KEY: "test-openai-key",
+  },
+}));
+
+vi.mock("./hyperlocalise-agent", () => ({
+  classifyConversation: classifyConversationMock,
+  createConversationToolLoopAgent: createConversationToolLoopAgentMock,
+  loadInteractionModelMessages: loadInteractionModelMessagesMock,
+  getRecentUserConversationText: vi.fn((_messages: unknown[], latestText: string) => latestText),
+  replaceLastUserMessage: vi.fn(
+    (messages: Array<{ role: string; content: string }>, text: string) => [
+      ...messages.slice(0, -1),
+      { role: "user", content: text },
+    ],
+  ),
+  shouldAttemptRepositoryContextResolution: vi.fn(
+    ({ classification }: { classification: { needsRepositoryTools: boolean } }) =>
+      classification.needsRepositoryTools,
+  ),
+  shouldRequireRepositoryContextClarification: vi.fn(
+    (classification: { shouldAskForRepositoryClarification: boolean }) =>
+      classification.shouldAskForRepositoryClarification,
+  ),
+}));
+
+vi.mock("@/lib/agents/repository-context", () => ({
+  buildRepositoryGitHubContextInstructions: vi.fn(() => "resolved-context"),
+  getOrganizationRepositoryConnectorConfig: vi.fn(async () => null),
+  resolveConversationRepositoryGitHubContext: resolveConversationRepositoryGitHubContextMock,
+}));
+
+vi.mock("@/lib/agent-runtime/workspaces/repository-sandbox", () => ({
+  createRepositorySandbox: createRepositorySandboxMock,
+  stopRepositorySandbox: vi.fn(),
+}));
+
+vi.mock("../skills/conversation-tms-integration", () => ({
+  resolveOrganizationHasTmsIntegration: resolveOrganizationHasTmsIntegrationMock,
+}));
+
+vi.mock("@/lib/log", () => ({
+  createLogger: vi.fn(() => ({
+    child: vi.fn(() => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    })),
+  })),
+  serializeErrorForLog: vi.fn((error: unknown) => ({ error })),
+}));
+
+import {
+  prepareConversationAgentTurn,
+  resolveConversationRepositoryContext,
+} from "./conversation-turn";
+
+const baseClassification = {
+  needsRepositoryTools: false,
+  requiresPullRequest: false,
+  shouldAskForRepositoryClarification: false,
+  continuesRepositoryThread: false,
+  currentMessageSpecifiesRepository: false,
+  confidence: 0.9,
+};
+
+describe("conversation turn preparation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    classifyConversationMock.mockResolvedValue(baseClassification);
+    loadInteractionModelMessagesMock.mockResolvedValue([
+      { role: "user", content: "what's the progress of HL test project?" },
+    ]);
+    resolveOrganizationHasTmsIntegrationMock.mockResolvedValue(true);
+    resolveConversationRepositoryGitHubContextMock.mockResolvedValue({
+      status: "not_applicable",
+    });
+  });
+
+  it("runs the shared agent for web chat without requiring attachments", async () => {
+    const result = await prepareConversationAgentTurn({
+      surface: "web",
+      conversationId: "conv_123",
+      organizationId: "org_123",
+      localUserId: "user_123",
+      membershipRole: "admin",
+      projectId: null,
+      messageText: "what's the progress of HL test project?",
+      hasTranslationAttachments: false,
+      db: {} as never,
+    });
+
+    expect(result.clarificationFollowUp).toBeNull();
+    expect(createConversationToolLoopAgentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        surface: "web",
+        hasFileAttachments: false,
+        hasTmsIntegration: true,
+      }),
+    );
+  });
+
+  it("returns clarification follow-up when repository context is required but unresolved", async () => {
+    resolveConversationRepositoryGitHubContextMock.mockResolvedValue({
+      status: "unresolved",
+      context: {
+        resolved: false,
+        reason: "missing repository",
+        hint: "send a repo",
+      },
+      followUp: "Which GitHub repository should I search?",
+    });
+
+    const result = await resolveConversationRepositoryContext({
+      surface: "web",
+      organizationId: "org_123",
+      projectId: null,
+      conversationText: "where is the login copy?",
+      classification: {
+        ...baseClassification,
+        needsRepositoryTools: true,
+        shouldAskForRepositoryClarification: true,
+      },
+      repositorySession: null,
+    });
+
+    expect(result.clarificationFollowUp).toBe("Which GitHub repository should I search?");
+  });
+
+  it("creates a sandbox when repository context resolves", async () => {
+    const githubContext = {
+      resolved: true as const,
+      installationId: 42,
+      repositoryFullName: "acme/web",
+    };
+    classifyConversationMock.mockResolvedValue({
+      ...baseClassification,
+      needsRepositoryTools: true,
+    });
+    resolveConversationRepositoryGitHubContextMock.mockResolvedValue({
+      status: "resolved",
+      source: "single_installed_repository",
+      context: githubContext,
+    });
+    createRepositorySandboxMock.mockResolvedValue("sandbox_123");
+
+    const result = await prepareConversationAgentTurn({
+      surface: "web",
+      conversationId: "conv_123",
+      organizationId: "org_123",
+      localUserId: "user_123",
+      membershipRole: "admin",
+      projectId: null,
+      messageText: "where is the login copy?",
+      hasTranslationAttachments: false,
+      db: {} as never,
+    });
+
+    expect(createRepositorySandboxMock).toHaveBeenCalledWith(githubContext);
+    expect(createConversationToolLoopAgentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolContext: expect.objectContaining({
+          sandboxId: "sandbox_123",
+          repositorySource: "chat_ui",
+        }),
+      }),
+    );
+    expect(result.updatedRepositorySession?.repositorySandboxSession?.sandboxId).toBe(
+      "sandbox_123",
+    );
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.test.ts
@@ -7,6 +7,7 @@ const {
   resolveConversationRepositoryGitHubContextMock,
   createRepositorySandboxMock,
   resolveOrganizationHasTmsIntegrationMock,
+  getOrganizationRepositoryConnectorConfigMock,
 } = vi.hoisted(() => ({
   classifyConversationMock: vi.fn(),
   createConversationToolLoopAgentMock: vi.fn(() => ({ stream: vi.fn() })),
@@ -14,6 +15,9 @@ const {
   resolveConversationRepositoryGitHubContextMock: vi.fn(),
   createRepositorySandboxMock: vi.fn(),
   resolveOrganizationHasTmsIntegrationMock: vi.fn(),
+  getOrganizationRepositoryConnectorConfigMock: vi.fn(
+    async (): Promise<Record<string, unknown> | null> => null,
+  ),
 }));
 
 vi.mock("@/lib/env", () => ({
@@ -45,7 +49,7 @@ vi.mock("./hyperlocalise-agent", () => ({
 
 vi.mock("@/lib/agents/repository-context", () => ({
   buildRepositoryGitHubContextInstructions: vi.fn(() => "resolved-context"),
-  getOrganizationRepositoryConnectorConfig: vi.fn(async () => null),
+  getOrganizationRepositoryConnectorConfig: getOrganizationRepositoryConnectorConfigMock,
   resolveConversationRepositoryGitHubContext: resolveConversationRepositoryGitHubContextMock,
 }));
 
@@ -144,6 +148,62 @@ describe("conversation turn preparation", () => {
     });
 
     expect(result.clarificationFollowUp).toBe("Which GitHub repository should I search?");
+  });
+
+  it("does not load Slack connector config for web repository resolution", async () => {
+    getOrganizationRepositoryConnectorConfigMock.mockResolvedValue({
+      repository: { github: { defaultRepositoryFullName: "acme/web" } },
+    });
+    resolveConversationRepositoryGitHubContextMock.mockResolvedValue({
+      status: "not_applicable",
+    });
+
+    await resolveConversationRepositoryContext({
+      surface: "web",
+      organizationId: "org_123",
+      projectId: null,
+      conversationText: "where is the login copy?",
+      classification: {
+        ...baseClassification,
+        needsRepositoryTools: true,
+      },
+      repositorySession: null,
+    });
+
+    expect(getOrganizationRepositoryConnectorConfigMock).not.toHaveBeenCalled();
+    expect(resolveConversationRepositoryGitHubContextMock).toHaveBeenCalledWith(
+      expect.objectContaining({ connectorConfig: null }),
+    );
+  });
+
+  it("loads Slack connector config for slack when none is provided", async () => {
+    getOrganizationRepositoryConnectorConfigMock.mockResolvedValue({
+      repository: { github: { defaultRepositoryFullName: "acme/web" } },
+    });
+    resolveConversationRepositoryGitHubContextMock.mockResolvedValue({
+      status: "not_applicable",
+    });
+
+    await resolveConversationRepositoryContext({
+      surface: "slack",
+      organizationId: "org_123",
+      projectId: null,
+      conversationText: "where is the login copy?",
+      classification: {
+        ...baseClassification,
+        needsRepositoryTools: true,
+      },
+      repositorySession: null,
+    });
+
+    expect(getOrganizationRepositoryConnectorConfigMock).toHaveBeenCalledWith("org_123");
+    expect(resolveConversationRepositoryGitHubContextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connectorConfig: {
+          repository: { github: { defaultRepositoryFullName: "acme/web" } },
+        },
+      }),
+    );
   });
 
   it("creates a sandbox when repository context resolves", async () => {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.ts
@@ -175,6 +175,7 @@ export async function getOrCreateConversationRepositorySandbox(input: {
   sandboxId: string;
   updatedSession: ConversationRepositorySession;
   sandboxCreated: boolean;
+  staleSandboxId: string | null;
 }> {
   const log = logger.child({
     conversationId: input.conversationId,
@@ -200,6 +201,7 @@ export async function getOrCreateConversationRepositorySandbox(input: {
         },
       },
       sandboxCreated: false,
+      staleSandboxId: null,
     };
   }
 
@@ -225,17 +227,25 @@ export async function getOrCreateConversationRepositorySandbox(input: {
     },
   };
 
-  const staleSandboxId = sandboxSession?.sandboxId;
-  if (staleSandboxId) {
-    await stopRepositorySandbox(staleSandboxId).catch((error: unknown) => {
-      log.warn(
-        { err: serializeErrorForLog(error), sandboxId: staleSandboxId },
-        "stale repository sandbox cleanup failed",
-      );
-    });
+  const staleSandboxId = sandboxSession?.sandboxId ?? null;
+
+  return { sandboxId, updatedSession, sandboxCreated: true, staleSandboxId };
+}
+
+export async function stopStaleRepositorySandbox(
+  staleSandboxId: string | null | undefined,
+  log = logger,
+) {
+  if (!staleSandboxId) {
+    return;
   }
 
-  return { sandboxId, updatedSession, sandboxCreated: true };
+  await stopRepositorySandbox(staleSandboxId).catch((error: unknown) => {
+    log.warn(
+      { err: serializeErrorForLog(error), sandboxId: staleSandboxId },
+      "stale repository sandbox cleanup failed",
+    );
+  });
 }
 
 export type PrepareConversationAgentTurnInput = {
@@ -261,6 +271,7 @@ export type PrepareConversationAgentTurnResult = {
   chatMessages: ModelMessage[];
   clarificationFollowUp: string | null;
   updatedRepositorySession: ConversationRepositorySession | null;
+  staleSandboxId: string | null;
 };
 
 export async function prepareConversationAgentTurn(
@@ -291,6 +302,7 @@ export async function prepareConversationAgentTurn(
 
   let updatedRepositorySession = repositoryResolution.updatedSession;
   let sandboxId: string | null = null;
+  let staleSandboxId: string | null = null;
 
   if (repositoryResolution.context) {
     const sandboxResult = await getOrCreateConversationRepositorySandbox({
@@ -301,6 +313,7 @@ export async function prepareConversationAgentTurn(
     });
     sandboxId = sandboxResult.sandboxId;
     updatedRepositorySession = sandboxResult.updatedSession;
+    staleSandboxId = sandboxResult.staleSandboxId;
   }
 
   const hasTmsIntegration = await resolveOrganizationHasTmsIntegration(input.organizationId);
@@ -344,5 +357,6 @@ export async function prepareConversationAgentTurn(
     chatMessages: preparedMessages,
     clarificationFollowUp: repositoryResolution.clarificationFollowUp,
     updatedRepositorySession,
+    staleSandboxId,
   };
 }

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.ts
@@ -1,0 +1,340 @@
+import type { ModelMessage } from "ai";
+
+import type { HyperlocaliseAgentSurface } from "@/agents/hyperlocalise/agent/agent";
+import type { RepositoryAgentGitHubContext } from "@/lib/agent-contracts/repository-task";
+import type { RepositoryAgentTaskSource } from "@/lib/agent-contracts/repository-task";
+import type { ToolContext } from "@/lib/agent-contracts/tool-context";
+import type { OrganizationMembershipRole } from "@/lib/database/types";
+import {
+  buildRepositoryGitHubContextInstructions,
+  getOrganizationRepositoryConnectorConfig,
+  resolveConversationRepositoryGitHubContext,
+} from "@/lib/agents/repository-context";
+import {
+  createRepositorySandbox,
+  stopRepositorySandbox,
+} from "@/lib/agent-runtime/workspaces/repository-sandbox";
+import { supportedFileTranslationFileFormats } from "@/lib/translation/file-formats";
+import { createLogger, serializeErrorForLog } from "@/lib/log";
+
+import {
+  classifyConversation,
+  createConversationToolLoopAgent,
+  getRecentUserConversationText,
+  loadInteractionModelMessages,
+  replaceLastUserMessage,
+  shouldAttemptRepositoryContextResolution,
+  shouldRequireRepositoryContextClarification,
+  type ConversationClassification,
+} from "./hyperlocalise-agent";
+import { resolveOrganizationHasTmsIntegration } from "../skills/conversation-tms-integration";
+import {
+  getRepositoryContextKey,
+  type ConversationRepositorySession,
+} from "./conversation-repository-session";
+
+const logger = createLogger("conversation-turn");
+
+export function buildFileTranslationInstructions() {
+  return `When a message includes stored source file IDs, create file translation jobs with type "file", the provided sourceFileId and fileFormat, targetLocales, and sourceLocale. Use sourceLocale "auto" if the user did not specify a source locale. Supported file job formats: ${supportedFileTranslationFileFormats.join(", ")}.`;
+}
+
+export function buildMissingRepositoryContextInstructions(followUp: string) {
+  return [
+    "Repository context is not available for this request.",
+    `If the user asks where a string, message, copy, or localized text appears in code, ask this follow-up exactly: ${followUp}`,
+    "Do not invent a GitHub repository, pull request, branch, installation ID, path, or file contents.",
+  ].join("\n");
+}
+
+export function buildResolvedRepositoryContextInstructions(context: RepositoryAgentGitHubContext) {
+  return [
+    buildRepositoryGitHubContextInstructions(context),
+    "Repository read tools are available for this request.",
+    "Use grep with the user's literal string or copy, then read for surrounding lines when needed.",
+    "Only explain where strings, messages, or copy appear and what nearby code implies.",
+    "Do not modify files, upload sources, commit, push, or create jobs from repository context alone.",
+  ].join("\n");
+}
+
+type ResolveRepositoryContextInput = {
+  surface: HyperlocaliseAgentSurface;
+  organizationId: string;
+  projectId: string | null;
+  conversationText: string;
+  classification: ConversationClassification;
+  repositorySession: ConversationRepositorySession | null;
+  connectorConfig?: Record<string, unknown> | null;
+  channelId?: string | null;
+};
+
+export type ResolvedRepositoryContext = {
+  context: RepositoryAgentGitHubContext | null;
+  instructions: string | null;
+  clarificationFollowUp: string | null;
+  updatedSession: ConversationRepositorySession | null;
+};
+
+export async function resolveConversationRepositoryContext(
+  input: ResolveRepositoryContextInput,
+): Promise<ResolvedRepositoryContext> {
+  const storedRepositoryContext = input.repositorySession?.repositoryGitHubContext ?? null;
+  const shouldResolve = shouldAttemptRepositoryContextResolution({
+    classification: input.classification,
+    storedRepositoryContext,
+  });
+
+  if (!shouldResolve) {
+    return {
+      context: null,
+      instructions: null,
+      clarificationFollowUp: null,
+      updatedSession: input.repositorySession,
+    };
+  }
+
+  const connectorConfig =
+    input.connectorConfig ?? (await getOrganizationRepositoryConnectorConfig(input.organizationId));
+
+  const canReuseStoredRepositoryContext =
+    storedRepositoryContext !== null && !input.classification.currentMessageSpecifiesRepository;
+
+  if (canReuseStoredRepositoryContext) {
+    return {
+      context: storedRepositoryContext,
+      instructions: buildResolvedRepositoryContextInstructions(storedRepositoryContext),
+      clarificationFollowUp: null,
+      updatedSession: input.repositorySession,
+    };
+  }
+
+  const githubContextResolution = await resolveConversationRepositoryGitHubContext({
+    organizationId: input.organizationId,
+    text: input.conversationText,
+    connectorConfig,
+    projectId: input.projectId,
+    channelId: input.channelId ?? null,
+    requirePullRequest: input.classification.requiresPullRequest,
+  });
+
+  if (githubContextResolution.status === "resolved") {
+    const context = githubContextResolution.context;
+    return {
+      context,
+      instructions: buildResolvedRepositoryContextInstructions(context),
+      clarificationFollowUp: null,
+      updatedSession: {
+        ...input.repositorySession,
+        repositoryGitHubContext: context,
+      },
+    };
+  }
+
+  if (githubContextResolution.status === "unresolved") {
+    if (storedRepositoryContext && !input.classification.currentMessageSpecifiesRepository) {
+      return {
+        context: storedRepositoryContext,
+        instructions: buildResolvedRepositoryContextInstructions(storedRepositoryContext),
+        clarificationFollowUp: null,
+        updatedSession: input.repositorySession,
+      };
+    }
+
+    const instructions = buildMissingRepositoryContextInstructions(
+      githubContextResolution.followUp,
+    );
+    const clarificationFollowUp = shouldRequireRepositoryContextClarification(input.classification)
+      ? githubContextResolution.followUp
+      : null;
+
+    return {
+      context: null,
+      instructions,
+      clarificationFollowUp,
+      updatedSession: input.repositorySession,
+    };
+  }
+
+  return {
+    context: null,
+    instructions: null,
+    clarificationFollowUp: null,
+    updatedSession: input.repositorySession,
+  };
+}
+
+export async function getOrCreateConversationRepositorySandbox(input: {
+  conversationId: string;
+  surface: HyperlocaliseAgentSurface;
+  githubContext: RepositoryAgentGitHubContext;
+  repositorySession: ConversationRepositorySession | null;
+}): Promise<{ sandboxId: string; updatedSession: ConversationRepositorySession }> {
+  const log = logger.child({
+    conversationId: input.conversationId,
+    surface: input.surface,
+  });
+  const repositoryContextKey = getRepositoryContextKey(input.githubContext);
+  const sandboxSession = input.repositorySession?.repositorySandboxSession;
+  const now = new Date().toISOString();
+
+  if (sandboxSession?.repositoryContextKey === repositoryContextKey) {
+    log.info(
+      { sandboxId: sandboxSession.sandboxId },
+      "reusing stored repository sandbox for conversation agent",
+    );
+    return {
+      sandboxId: sandboxSession.sandboxId,
+      updatedSession: {
+        ...input.repositorySession,
+        repositoryGitHubContext: input.githubContext,
+        repositorySandboxSession: {
+          ...sandboxSession,
+          lastUsedAt: now,
+        },
+      },
+    };
+  }
+
+  log.info(
+    {
+      installationId: input.githubContext.installationId,
+      branch: input.githubContext.branch ?? null,
+      commitSha: input.githubContext.commitSha ?? null,
+    },
+    "creating repository sandbox for conversation agent",
+  );
+  const sandboxId = await createRepositorySandbox(input.githubContext);
+  log.info({ sandboxId }, "repository sandbox created for conversation agent");
+
+  const updatedSession: ConversationRepositorySession = {
+    ...input.repositorySession,
+    repositoryGitHubContext: input.githubContext,
+    repositorySandboxSession: {
+      sandboxId,
+      repositoryContextKey,
+      createdAt: now,
+      lastUsedAt: now,
+    },
+  };
+
+  const staleSandboxId = sandboxSession?.sandboxId;
+  if (staleSandboxId) {
+    await stopRepositorySandbox(staleSandboxId).catch((error: unknown) => {
+      log.warn(
+        { err: serializeErrorForLog(error), sandboxId: staleSandboxId },
+        "stale repository sandbox cleanup failed",
+      );
+    });
+  }
+
+  return { sandboxId, updatedSession };
+}
+
+export type PrepareConversationAgentTurnInput = {
+  surface: HyperlocaliseAgentSurface;
+  conversationId: string;
+  organizationId: string;
+  localUserId: string;
+  membershipRole: OrganizationMembershipRole;
+  projectId: string | null;
+  messageText: string;
+  hasTranslationAttachments: boolean;
+  repositorySession?: ConversationRepositorySession | null;
+  connectorConfig?: Record<string, unknown> | null;
+  channelId?: string | null;
+  repositorySource?: RepositoryAgentTaskSource;
+  actor?: ToolContext["actor"];
+  db: ToolContext["db"];
+};
+
+export type PrepareConversationAgentTurnResult = {
+  classification: ConversationClassification;
+  agent: ReturnType<typeof createConversationToolLoopAgent>;
+  chatMessages: ModelMessage[];
+  clarificationFollowUp: string | null;
+  updatedRepositorySession: ConversationRepositorySession | null;
+};
+
+export async function prepareConversationAgentTurn(
+  input: PrepareConversationAgentTurnInput,
+): Promise<PrepareConversationAgentTurnResult> {
+  const chatMessages = await loadInteractionModelMessages(input.conversationId);
+  const conversationText = getRecentUserConversationText(chatMessages, input.messageText);
+  const storedRepositoryContext = input.repositorySession?.repositoryGitHubContext ?? null;
+
+  const classification = await classifyConversation({
+    currentMessage: input.messageText,
+    conversationText,
+    hasFileAttachments: input.hasTranslationAttachments,
+    hasStoredRepositoryContext: Boolean(storedRepositoryContext),
+    surface: input.surface,
+  });
+
+  const repositoryResolution = await resolveConversationRepositoryContext({
+    surface: input.surface,
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    conversationText,
+    classification,
+    repositorySession: input.repositorySession ?? null,
+    connectorConfig: input.connectorConfig,
+    channelId: input.channelId,
+  });
+
+  let updatedRepositorySession = repositoryResolution.updatedSession;
+  let sandboxId: string | null = null;
+
+  if (repositoryResolution.context) {
+    const sandboxResult = await getOrCreateConversationRepositorySandbox({
+      conversationId: input.conversationId,
+      surface: input.surface,
+      githubContext: repositoryResolution.context,
+      repositorySession: updatedRepositorySession,
+    });
+    sandboxId = sandboxResult.sandboxId;
+    updatedRepositorySession = sandboxResult.updatedSession;
+  }
+
+  const hasTmsIntegration = await resolveOrganizationHasTmsIntegration(input.organizationId);
+
+  const preparedMessages = replaceLastUserMessage(
+    chatMessages,
+    repositoryResolution.context
+      ? getRecentUserConversationText(chatMessages, input.messageText)
+      : input.messageText,
+  );
+
+  const agent = createConversationToolLoopAgent({
+    surface: input.surface,
+    toolContext: {
+      conversationId: input.conversationId,
+      organizationId: input.organizationId,
+      localUserId: input.localUserId,
+      membershipRole: input.membershipRole,
+      projectId: input.projectId,
+      db: input.db,
+      ...(sandboxId
+        ? {
+            sandboxId,
+            githubContext: repositoryResolution.context,
+            workMode: "read_only" as const,
+            repositorySource: input.repositorySource ?? "chat_ui",
+            actor: input.actor,
+          }
+        : {}),
+    },
+    hasFileAttachments: input.hasTranslationAttachments,
+    hasTmsIntegration,
+    additionalInstructions: [buildFileTranslationInstructions(), repositoryResolution.instructions]
+      .filter((instruction): instruction is string => instruction !== null)
+      .join("\n\n"),
+  });
+
+  return {
+    classification,
+    agent,
+    chatMessages: preparedMessages,
+    clarificationFollowUp: repositoryResolution.clarificationFollowUp,
+    updatedRepositorySession,
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.ts
@@ -171,7 +171,11 @@ export async function getOrCreateConversationRepositorySandbox(input: {
   surface: HyperlocaliseAgentSurface;
   githubContext: RepositoryAgentGitHubContext;
   repositorySession: ConversationRepositorySession | null;
-}): Promise<{ sandboxId: string; updatedSession: ConversationRepositorySession }> {
+}): Promise<{
+  sandboxId: string;
+  updatedSession: ConversationRepositorySession;
+  sandboxCreated: boolean;
+}> {
   const log = logger.child({
     conversationId: input.conversationId,
     surface: input.surface,
@@ -195,6 +199,7 @@ export async function getOrCreateConversationRepositorySandbox(input: {
           lastUsedAt: now,
         },
       },
+      sandboxCreated: false,
     };
   }
 
@@ -230,7 +235,7 @@ export async function getOrCreateConversationRepositorySandbox(input: {
     });
   }
 
-  return { sandboxId, updatedSession };
+  return { sandboxId, updatedSession, sandboxCreated: true };
 }
 
 export type PrepareConversationAgentTurnInput = {

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.ts
@@ -263,6 +263,7 @@ export type PrepareConversationAgentTurnInput = {
   repositorySource?: RepositoryAgentTaskSource;
   actor?: ToolContext["actor"];
   db: ToolContext["db"];
+  reuseCommittedRepositorySandboxOnly?: boolean;
 };
 
 export type PrepareConversationAgentTurnResult = {
@@ -305,15 +306,24 @@ export async function prepareConversationAgentTurn(
   let staleSandboxId: string | null = null;
 
   if (repositoryResolution.context) {
-    const sandboxResult = await getOrCreateConversationRepositorySandbox({
-      conversationId: input.conversationId,
-      surface: input.surface,
-      githubContext: repositoryResolution.context,
-      repositorySession: updatedRepositorySession,
-    });
-    sandboxId = sandboxResult.sandboxId;
-    updatedRepositorySession = sandboxResult.updatedSession;
-    staleSandboxId = sandboxResult.staleSandboxId;
+    const repositoryContextKey = getRepositoryContextKey(repositoryResolution.context);
+    const storedSandboxSession = updatedRepositorySession?.repositorySandboxSession;
+    const canReuseStoredSandbox =
+      storedSandboxSession?.repositoryContextKey === repositoryContextKey;
+
+    if (input.reuseCommittedRepositorySandboxOnly && !canReuseStoredSandbox) {
+      updatedRepositorySession = input.repositorySession ?? null;
+    } else {
+      const sandboxResult = await getOrCreateConversationRepositorySandbox({
+        conversationId: input.conversationId,
+        surface: input.surface,
+        githubContext: repositoryResolution.context,
+        repositorySession: updatedRepositorySession,
+      });
+      sandboxId = sandboxResult.sandboxId;
+      updatedRepositorySession = sandboxResult.updatedSession;
+      staleSandboxId = sandboxResult.staleSandboxId;
+    }
   }
 
   const hasTmsIntegration = await resolveOrganizationHasTmsIntegration(input.organizationId);

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.ts
@@ -94,7 +94,10 @@ export async function resolveConversationRepositoryContext(
   }
 
   const connectorConfig =
-    input.connectorConfig ?? (await getOrganizationRepositoryConnectorConfig(input.organizationId));
+    input.connectorConfig ??
+    (input.surface === "slack"
+      ? await getOrganizationRepositoryConnectorConfig(input.organizationId)
+      : null);
 
   const canReuseStoredRepositoryContext =
     storedRepositoryContext !== null && !input.classification.currentMessageSpecifiesRepository;

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.ts
@@ -35,6 +35,9 @@ import {
 
 const logger = createLogger("conversation-turn");
 
+export const REPOSITORY_ACCESS_CONTENTION_FOLLOW_UP =
+  "I'm still preparing repository access for this conversation. Please send your message again in a moment.";
+
 export function buildFileTranslationInstructions() {
   return `When a message includes stored source file IDs, create file translation jobs with type "file", the provided sourceFileId and fileFormat, targetLocales, and sourceLocale. Use sourceLocale "auto" if the user did not specify a source locale. Supported file job formats: ${supportedFileTranslationFileFormats.join(", ")}.`;
 }
@@ -304,6 +307,9 @@ export async function prepareConversationAgentTurn(
   let updatedRepositorySession = repositoryResolution.updatedSession;
   let sandboxId: string | null = null;
   let staleSandboxId: string | null = null;
+  let activeRepositoryContext = repositoryResolution.context;
+  let repositoryInstructions = repositoryResolution.instructions;
+  let clarificationFollowUp = repositoryResolution.clarificationFollowUp;
 
   if (repositoryResolution.context) {
     const repositoryContextKey = getRepositoryContextKey(repositoryResolution.context);
@@ -313,6 +319,9 @@ export async function prepareConversationAgentTurn(
 
     if (input.reuseCommittedRepositorySandboxOnly && !canReuseStoredSandbox) {
       updatedRepositorySession = input.repositorySession ?? null;
+      activeRepositoryContext = null;
+      repositoryInstructions = null;
+      clarificationFollowUp = REPOSITORY_ACCESS_CONTENTION_FOLLOW_UP;
     } else {
       const sandboxResult = await getOrCreateConversationRepositorySandbox({
         conversationId: input.conversationId,
@@ -330,7 +339,7 @@ export async function prepareConversationAgentTurn(
 
   const preparedMessages = replaceLastUserMessage(
     chatMessages,
-    repositoryResolution.context
+    activeRepositoryContext
       ? getRecentUserConversationText(chatMessages, input.messageText)
       : input.messageText,
   );
@@ -347,7 +356,7 @@ export async function prepareConversationAgentTurn(
       ...(sandboxId
         ? {
             sandboxId,
-            githubContext: repositoryResolution.context,
+            githubContext: activeRepositoryContext,
             workMode: "read_only" as const,
             repositorySource: input.repositorySource ?? "chat_ui",
             actor: input.actor,
@@ -356,7 +365,7 @@ export async function prepareConversationAgentTurn(
     },
     hasFileAttachments: input.hasTranslationAttachments,
     hasTmsIntegration,
-    additionalInstructions: [buildFileTranslationInstructions(), repositoryResolution.instructions]
+    additionalInstructions: [buildFileTranslationInstructions(), repositoryInstructions]
       .filter((instruction): instruction is string => instruction !== null)
       .join("\n\n"),
   });
@@ -365,7 +374,7 @@ export async function prepareConversationAgentTurn(
     classification,
     agent,
     chatMessages: preparedMessages,
-    clarificationFollowUp: repositoryResolution.clarificationFollowUp,
+    clarificationFollowUp,
     updatedRepositorySession,
     staleSandboxId,
   };

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-turn.ts
@@ -276,6 +276,7 @@ export type PrepareConversationAgentTurnResult = {
   clarificationFollowUp: string | null;
   updatedRepositorySession: ConversationRepositorySession | null;
   staleSandboxId: string | null;
+  repositorySandboxId: string | null;
 };
 
 export async function prepareConversationAgentTurn(
@@ -377,5 +378,6 @@ export async function prepareConversationAgentTurn(
     clarificationFollowUp,
     updatedRepositorySession,
     staleSandboxId,
+    repositorySandboxId: sandboxId,
   };
 }

--- a/apps/hyperlocalise-web/src/lib/agents/repository-context.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/repository-context.test.ts
@@ -236,7 +236,7 @@ describe("resolveSlackRepositoryGitHubContext", () => {
       status: "unresolved",
       context: {
         resolved: false,
-        reason: "The Slack request matched multiple installed GitHub repositories.",
+        reason: "The request matched multiple installed GitHub repositories.",
       },
       followUp: expect.stringContaining("owner/repository"),
     });

--- a/apps/hyperlocalise-web/src/lib/agents/repository-context.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/repository-context.ts
@@ -92,7 +92,23 @@ export async function resolveWebProjectRepositoryGitHubContext(input: {
   });
 }
 
-export async function resolveSlackRepositoryGitHubContext(input: {
+export async function getOrganizationRepositoryConnectorConfig(organizationId: string) {
+  const [connector] = await db
+    .select({ config: schema.connectors.config })
+    .from(schema.connectors)
+    .where(
+      and(
+        eq(schema.connectors.organizationId, organizationId),
+        eq(schema.connectors.kind, "slack"),
+        eq(schema.connectors.enabled, true),
+      ),
+    )
+    .limit(1);
+
+  return (connector?.config ?? null) as Record<string, unknown> | null;
+}
+
+export async function resolveConversationRepositoryGitHubContext(input: {
   organizationId: string;
   text: string;
   connectorConfig?: Record<string, unknown> | null;
@@ -146,9 +162,9 @@ export async function resolveSlackRepositoryGitHubContext(input: {
       : (configuredRepository ?? getSingleInstalledRepository(installedRepositories));
   if (!fallback) {
     return unresolved(
-      "No GitHub repository context was configured for this Slack request.",
-      "Provide a GitHub pull request URL, repo name, or configure a project/channel repository fallback.",
-      "Please send a GitHub pull request URL, include the repository name, or configure a default repository for this project or Slack channel.",
+      "No GitHub repository context was configured for this request.",
+      "Provide a GitHub pull request URL, repo name, or configure a project repository fallback.",
+      "Please send a GitHub pull request URL, include the repository name, or configure a default repository for this project.",
     );
   }
 
@@ -189,6 +205,9 @@ export async function resolveSlackRepositoryGitHubContext(input: {
     dependencies,
   });
 }
+
+/** @deprecated Use resolveConversationRepositoryGitHubContext */
+export const resolveSlackRepositoryGitHubContext = resolveConversationRepositoryGitHubContext;
 
 export async function resolveGitHubRepositoryGitHubContext(input: {
   raw: GitHubRawMessage;
@@ -455,7 +474,7 @@ function resolveSlackReferencedRepository(input: {
     return {
       status: "unresolved",
       resolution: unresolved(
-        "The Slack request matched multiple installed GitHub repositories.",
+        "The request matched multiple installed GitHub repositories.",
         "Please include owner/repository or a pull request URL.",
         "I found multiple installed repositories matching that name. Please include owner/repository or send the PR URL so I know which repo to use.",
       ),

--- a/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
@@ -780,6 +780,63 @@ describe("handleNewConversation", () => {
     });
   });
 
+  it("stops a newly created sandbox when slack thread state persistence fails", async () => {
+    const { thread, posts } = createThread();
+    const message = createMessage({
+      text: "do you know the context of Knowledge?",
+      raw: { team_id: "T123", channel: "C123" },
+    });
+
+    classifyConversationMock.mockResolvedValueOnce(
+      createMockClassification({
+        needsRepositoryTools: true,
+        confidence: 0.95,
+      }),
+    );
+    resolveSlackRepositoryGitHubContextMock.mockResolvedValueOnce({
+      status: "resolved",
+      source: "slack_pr_url",
+      context: {
+        resolved: true,
+        installationId: 12345,
+        repositoryFullName: "acme/web",
+      },
+    });
+    vi.mocked(findSlackConnector).mockResolvedValue({
+      id: "connector-123",
+      organizationId: "org-123",
+      enabled: true,
+      config: {},
+    } as never);
+    vi.mocked(lookupMembership).mockResolvedValue({
+      role: "member",
+      localUserId: "user-123",
+    } as never);
+    vi.mocked(findInteractionBySourceThreadId).mockResolvedValue({
+      id: "interaction-123",
+      title: "Existing",
+      projectId: null,
+    } as never);
+    vi.mocked(addInteractionMessage).mockResolvedValue({ id: "msg-123" } as never);
+    Object.assign(thread, {
+      setState: vi.fn(async (newState: Record<string, unknown>) => {
+        if ("repositorySandboxSession" in newState) {
+          throw new Error("state write failed");
+        }
+      }),
+    });
+
+    await handleNewConversation(thread, message);
+
+    expect(createRepositorySandbox).toHaveBeenCalled();
+    expect(stopRepositorySandbox).toHaveBeenCalledWith("sbx_test");
+    expect(createConversationToolLoopAgentMock).not.toHaveBeenCalled();
+    expect(posts.at(-1)).toEqual({
+      markdown:
+        "I'm having trouble processing that right now. Attach a supported file or image with a target language and I can help translate it.",
+    });
+  });
+
   it("resolves GitHub context using recent conversation text", async () => {
     const { thread } = createThread();
     const message = createMessage({

--- a/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
@@ -837,6 +837,78 @@ describe("handleNewConversation", () => {
     });
   });
 
+  it("keeps the stored repository sandbox when slack thread state persistence fails after a context switch", async () => {
+    const oldContext = {
+      resolved: true as const,
+      installationId: 12345,
+      repositoryFullName: "org/old-repo",
+    };
+    const newContext = {
+      resolved: true as const,
+      installationId: 67890,
+      repositoryFullName: "org/new-repo",
+      branch: "main",
+    };
+    const { thread } = createThread({
+      repositoryGitHubContext: oldContext,
+      repositorySandboxSession: {
+        sandboxId: "sbx_old",
+        repositoryContextKey: getSlackRepositoryContextKey(oldContext),
+        createdAt: "2026-06-01T00:00:00.000Z",
+        lastUsedAt: "2026-06-01T00:00:00.000Z",
+      },
+    });
+    const message = createMessage({
+      text: "Find 'Email agent' in org/new-repo",
+      raw: { team_id: "T123", channel: "C123" },
+    });
+
+    classifyConversationMock.mockResolvedValueOnce(
+      createMockClassification({
+        needsRepositoryTools: true,
+        currentMessageSpecifiesRepository: true,
+        confidence: 0.95,
+      }),
+    );
+    resolveSlackRepositoryGitHubContextMock.mockResolvedValueOnce({
+      status: "resolved",
+      source: "slack_repo_reference",
+      context: newContext,
+    });
+    vi.mocked(findSlackConnector).mockResolvedValue({
+      id: "connector-123",
+      organizationId: "org-123",
+      enabled: true,
+      config: {},
+    } as never);
+    vi.mocked(lookupMembership).mockResolvedValue({
+      role: "member",
+      localUserId: "user-123",
+    } as never);
+    vi.mocked(findInteractionBySourceThreadId).mockResolvedValue({
+      id: "interaction-123",
+      title: "Existing",
+      projectId: null,
+    } as never);
+    vi.mocked(addInteractionMessage).mockResolvedValue({ id: "msg-123" } as never);
+    const setStateCalls = vi.mocked(thread.setState);
+    setStateCalls.mockImplementation(async (newState: Record<string, unknown>) => {
+      const sandboxSession = newState.repositorySandboxSession as
+        | { sandboxId?: string }
+        | undefined;
+      if (sandboxSession?.sandboxId === "sbx_test") {
+        throw new Error("state write failed");
+      }
+    });
+
+    await handleSubscribedMessage(thread, message);
+
+    expect(createRepositorySandbox).toHaveBeenCalledWith(newContext);
+    expect(stopRepositorySandbox).toHaveBeenCalledWith("sbx_test");
+    expect(stopRepositorySandbox).not.toHaveBeenCalledWith("sbx_old");
+    expect(createConversationToolLoopAgentMock).not.toHaveBeenCalled();
+  });
+
   it("resolves GitHub context using recent conversation text", async () => {
     const { thread } = createThread();
     const message = createMessage({

--- a/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/slack/bot.test.ts
@@ -109,7 +109,9 @@ vi.mock("@/lib/agents/repository-context", async (importOriginal) => {
   const original = await importOriginal<typeof import("@/lib/agents/repository-context")>();
   return {
     ...original,
+    resolveConversationRepositoryGitHubContext: resolveSlackRepositoryGitHubContextMock,
     resolveSlackRepositoryGitHubContext: resolveSlackRepositoryGitHubContextMock,
+    getOrganizationRepositoryConnectorConfig: vi.fn(async () => null),
   };
 });
 
@@ -682,11 +684,10 @@ describe("handleNewConversation", () => {
 
     expect(resolveSlackRepositoryGitHubContextMock).not.toHaveBeenCalled();
     const reuseLog = loggerChildMock.info.mock.calls.find(
-      ([, message]) => message === "reusing stored slack thread repository context",
+      ([, message]) => message === "reusing stored repository sandbox for conversation agent",
     );
     expect(reuseLog?.[0]).toEqual({
-      installationId: 12345,
-      hasPullRequestNumber: false,
+      sandboxId: "sbx_existing",
     });
     expect(createConversationToolLoopAgentMock).toHaveBeenCalledWith(
       expect.objectContaining({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Consolidates web inbox chat onto the same skill-based conversational agent as Slack, with shared repository sandbox preparation and session management.

## Review fixes (latest)

- **Web CAS rejection:** Reprepares on rejected session writes before streaming (up to 3 attempts).
- **Deferred stale sandbox cleanup:** Slack stops replaced sandboxes only after `thread.setState` succeeds.
- **Uncommitted fallback sandbox:** After exhausting CAS retries, web turns use `reuseCommittedRepositorySandboxOnly` so they only reuse an already-persisted sandbox.
- **Contended repository context:** Returns a non-streaming clarification when the fallback cannot reuse the committed sandbox for a newly resolved repository.
- **Active sandbox leases:** Web turns acquire a sandbox lease before streaming and release it when the stream finishes; session eviction defers sandbox stops until no active leases remain.

## Testing

- `vp test` on conversation-repository-session, conversation-turn, and web channel tests
- `vp check --fix`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1c552ff6-f71f-4f1a-94c3-9dd6f37e1f2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c552ff6-f71f-4f1a-94c3-9dd6f37e1f2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

