### PR TITLE
feat(blog): add TMS-agnostic AI translation post for July 2026

### DIFF
--- a/apps/hyperlocalise-web/_posts/en/how-to-add-ai-translation-without-replacing-tms.md
+++ b/apps/hyperlocalise-web/_posts/en/how-to-add-ai-translation-without-replacing-tms.md
@@ -1,0 +1,118 @@
+---
+title: How to Add AI Translation Without Replacing Phrase, Lokalise, Crowdin, or Smartling
+date: 2026-07-01T00:00:00.000Z
+excerpt: AI translation does not have to mean ripping out your TMS. Learn how to add an intelligence layer around Phrase, Lokalise, Crowdin, Smartling, and the workflows you already run.
+category: Product
+tags:
+  - AI translation
+  - TMS-agnostic
+  - translation management
+  - localisation
+  - localization
+  - Phrase
+  - Lokalise
+  - Crowdin
+  - Smartling
+  - translation intelligence
+  - human-in-the-loop
+  - context-aware localisation
+  - product localisation
+  - brand voice
+  - terminology management
+---
+
+Many localisation teams are under pressure to move faster, reduce manual work, and support more languages without increasing headcount. AI translation is an obvious part of the answer, but for most teams, the question is not whether AI should be used. The harder question is how to introduce AI translation without disrupting the systems, workflows, and vendor relationships that already exist.
+
+For companies already using [Phrase](https://phrase.com), [Lokalise](https://lokalise.com), [Crowdin](https://crowdin.com), [Smartling](https://www.smartling.com), or another translation management system, replacing the TMS is rarely the right first move. These platforms often sit deeply inside product release processes, content workflows, vendor operations, translation memory, glossary management, review cycles, and reporting. A rip-and-replace project can create months of migration work before the team sees any meaningful improvement.
+
+A better approach is to add AI translation as an intelligence layer around the existing localisation workflow. Instead of replacing the TMS, companies can augment it with AI that gathers context, prepares translation tasks, improves translation quality, supports reviewers, and learns from past decisions across tools.
+
+That is the idea behind a TMS-agnostic workflow.
+
+## The problem is not the TMS
+
+Phrase, Lokalise, Crowdin, and Smartling already offer strong localisation infrastructure. Phrase positions itself as an AI-powered localisation platform with capabilities across workflow automation, context, model selection, quality evaluation, and output transformation. Lokalise promotes AI orchestration, smart routing across multiple LLMs, and continuous localisation integrations for product teams. Crowdin offers AI translation, AI QA checks, AI debugging, and a broad integration ecosystem. Smartling provides AI translation capabilities and tools for managing translation workflows, brand consistency, approval processes, and localisation spend.
+
+These systems are not the problem. In many companies, they are the operational backbone of localisation.
+
+The problem is that localisation work now happens across far more places than the TMS alone. Product context sits in design files, screenshots, pull requests, tickets, customer feedback, CMS entries, marketing briefs, analytics, and internal discussions. Brand rules may live in documents. Glossary decisions may be scattered across spreadsheets, Slack threads, and reviewer comments. Engineering teams may ship strings through GitHub. Marketing teams may update pages in a CMS. Customer support teams may maintain help centre content elsewhere.
+
+AI translation becomes much more useful when it can understand this broader context. Without it, AI is simply producing fluent output from limited input. That may be faster than traditional translation, but it does not always solve the real localisation problem: making the right translation decision for the right audience in the right context.
+
+## Why replacing your TMS is usually the wrong starting point
+
+Replacing an existing TMS sounds attractive when a team wants a more modern AI workflow, but the hidden cost is high. The team must migrate translation memory, glossaries, projects, integrations, vendor access, review workflows, permissions, billing rules, reporting, and internal operating habits. Even if the migration succeeds, the organisation may still face the same underlying issue: context remains fragmented outside the localisation platform.
+
+For many companies, the smarter question is not "Which TMS should we move to?" but "How do we make our existing localisation workflow more intelligent?"
+
+That shift matters. A TMS replacement focuses on the system of record. A TMS-agnostic AI workflow focuses on the system of work. It asks how translation requests are created, how context is collected, how AI suggestions are produced, how human reviewers make decisions, how feedback is captured, and how that knowledge improves future work.
+
+This approach allows teams to keep Phrase, Lokalise, Crowdin, Smartling, or another existing system while introducing AI where it has the most leverage.
+
+## What AI translation needs to do beyond generating text
+
+Most AI translation conversations focus on the output: how accurate the translation is, how natural it sounds, or how much editing it needs. Those are important, but they are only one part of the workflow.
+
+For AI translation to work well in a real company, it needs to support the entire localisation decision process.
+
+It should **understand what the source text is used for**. A short string in a checkout button is not the same as a help centre paragraph, a legal notice, a campaign headline, or an onboarding tooltip. The same English phrase can require different translations depending on placement, audience, product surface, character limits, tone, and regional expectations.
+
+It should **know the brand voice**. Some brands want direct, concise, product-led language. Others need a warmer, more conversational tone. B2B SaaS copy may need to sound precise and credible, while consumer marketing copy may need to feel local, emotional, and culturally familiar.
+
+It should **respect terminology and glossary rules**. Product names, feature names, technical terms, and legal phrases should not be translated inconsistently across markets. AI should not invent terminology simply because it sounds natural.
+
+It should **help reviewers, not bypass them**. Localisation teams still need human judgement, especially for high-impact product, marketing, legal, regulated, or brand-sensitive content. The role of AI should be to reduce repetitive work, surface better suggestions, explain trade-offs, and help reviewers move faster with more confidence.
+
+It should **learn from feedback**. The most valuable localisation knowledge often appears after the first translation is reviewed: why a phrase was rejected, why a tone was changed, why a market preferred one expression over another, or why a literal translation failed. If this feedback disappears into comments and spreadsheets, AI cannot improve over time.
+
+For more on why context matters as much as output, see [AI Translation Is Not Enough: Why Global Teams Need Context-Aware Localisation](/blog/ai-translation-is-not-enough-context-aware-localisation).
+
+## The TMS-agnostic model
+
+A TMS-agnostic AI translation workflow does not require a company to abandon its current platform. Instead, it connects to the tools the team already uses and adds an intelligence layer across them.
+
+For a team using Phrase AI translation workflows, this means AI can help gather product context, screenshots, glossary rules, and reviewer history before content reaches the translation workflow. For a team using Lokalise AI translation, it can support product teams by enriching source strings with context from repositories, design files, and tickets. For a team using Crowdin AI translation, it can help prepare better prompts, improve review confidence, and capture decisions across software localisation workflows. For a team using Smartling AI translation, it can support enterprise teams that need stronger brand, terminology, and approval context across multiple content systems.
+
+The key is that AI does not need to live inside only one platform to be useful. In modern localisation, the work is distributed. The intelligence should be distributed too.
+
+A TMS-agnostic layer can sit between source systems, translation platforms, reviewers, and downstream publishing workflows. It can collect context from where the work begins, apply AI translation and review support where appropriate, and send structured outputs back into the tools where teams already operate.
+
+This is especially useful for companies with multiple localisation workflows. One team may use a TMS for software strings, another may rely on a CMS for marketing pages, another may work through spreadsheets with an agency, and another may use a help centre integration. A single-platform approach often struggles to cover all of this. A TMS-agnostic workflow gives the company a way to standardise localisation intelligence without forcing every team into the same tool.
+
+## Where Hyperlocalise fits
+
+Hyperlocalise is built for teams that want to add AI translation intelligence without replacing their existing localisation stack.
+
+Instead of asking teams to move away from Phrase, Lokalise, Crowdin, Smartling, or their current process, Hyperlocalise helps teams bring better context, automation, and AI-assisted decision-making into the workflow they already have. The goal is not to become another isolated translation system. The goal is to make localisation work smarter across systems.
+
+Hyperlocalise focuses on three areas.
+
+**First, it helps gather context automatically.** Translation quality improves when AI understands the product, the user journey, the screenshot, the design constraint, the previous decision, the glossary rule, and the intended audience. Instead of expecting localisation managers to manually collect all of this information for every task, AI agents can help retrieve and structure the context before translation begins.
+
+**Second, it supports human-in-the-loop translation.** AI can generate suggestions, explain choices, flag risks, and apply rules, but reviewers still need control. The best workflow is not fully manual or blindly automated. It is a structured collaboration between AI and human judgement, where the reviewer has more information and less repetitive work.
+
+**Third, it creates a self-evolving knowledge layer.** Every approved translation, rejected suggestion, glossary update, reviewer comment, and market-specific decision can become part of the organisation's localisation intelligence. Over time, this reduces repeated mistakes and helps future translations become more consistent, more contextual, and faster to approve.
+
+This builds on the same foundation as [translation intelligence](/blog/what-is-translation-intelligence): the infrastructure that turns scattered product, brand, UI, market, and reviewer knowledge into better localisation decisions.
+
+## The practical benefits
+
+Adding AI translation through a TMS-agnostic workflow gives localisation teams a more flexible path to modernisation.
+
+It **reduces migration risk** because teams can keep their existing TMS, permissions, integrations, vendors, and reporting structures. It **improves AI quality** because translation decisions are informed by context outside the TMS. It **supports multiple departments** because product, marketing, support, and content teams can all benefit without being forced into a single rigid workflow.
+
+It also gives companies more control over their AI strategy. Teams can avoid being locked into one platform's AI model, one workflow design, or one translation approach. They can use AI where it makes sense, keep human review where it matters, and adapt the workflow as their localisation maturity grows.
+
+This is important because AI translation is not a one-time feature purchase. It is an operating model. The companies that get the most value from AI will not simply translate more words faster. They will build better systems for capturing context, applying judgement, measuring quality, and learning from every localisation decision.
+
+## Add AI translation without starting over
+
+Phrase, Lokalise, Crowdin, and Smartling have all moved strongly into AI-powered localisation. That is good for the industry. It shows that AI is becoming a core part of how global content will be created, translated, reviewed, and managed.
+
+But companies do not need to replace their TMS to benefit from AI translation. In many cases, the better path is to keep the systems that already work and add an intelligence layer that makes the entire workflow more contextual, automated, and adaptive.
+
+That is the promise of a TMS-agnostic workflow.
+
+With Hyperlocalise, teams can bring AI translation intelligence into their existing localisation stack, connect context across tools, support human reviewers, and build a knowledge layer that improves over time.
+
+AI translation should not force teams to start again. It should help them move faster from where they already are.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a new blog post dated **1 July 2026** about introducing AI translation without replacing existing TMS platforms (Phrase, Lokalise, Crowdin, Smartling).

## Post details

- **Slug:** `how-to-add-ai-translation-without-replacing-tms`
- **URL:** `/en/blog/how-to-add-ai-translation-without-replacing-tms`
- **Category:** Product

## Content highlights

- Argues for a TMS-agnostic intelligence layer instead of rip-and-replace migrations
- Covers what AI translation needs beyond text generation (context, brand voice, terminology, reviewer support, feedback loops)
- Positions Hyperlocalise as augmentation for existing stacks
- Cross-links to related posts on context-aware localisation and translation intelligence

## Testing

- `vp test src/lib/blog/blog-post.test.ts` — all 9 tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1e52-2b35-74e2-9d7e-c3b36be42587"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1e52-2b35-74e2-9d7e-c3b36be42587"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

