### PR TITLE
feat(agent): disambiguate multi-repo GitHub context in Hyperlocalise agent

### DIFF
--- a/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/slack.ts
+++ b/apps/hyperlocalise-web/src/agents/hyperlocalise/agent/channels/slack.ts
@@ -472,7 +472,11 @@ async function processSlackMessage(
               githubContextResolution.followUp,
             );
 
-            if (shouldRequireRepositoryContextClarification(classification)) {
+            if (
+              shouldRequireRepositoryContextClarification(classification, {
+                repositoryContextStatus: githubContextResolution.status,
+              })
+            ) {
               await removeEyesReaction(thread, message);
               wrapThreadPost(thread, interactionId);
               await thread.post({ markdown: githubContextResolution.followUp });

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-classifier.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-classifier.test.ts
@@ -77,6 +77,24 @@ describe("conversation classifier", () => {
     ).toBe(true);
   });
 
+  it("requires clarification when repository tools are needed but context is unresolved", () => {
+    expect(
+      shouldRequireRepositoryContextClarification(
+        repositoryClassification({ shouldAskForRepositoryClarification: false }),
+        { repositoryContextStatus: "unresolved" },
+      ),
+    ).toBe(true);
+  });
+
+  it("does not require clarification when repository context resolved", () => {
+    expect(
+      shouldRequireRepositoryContextClarification(
+        repositoryClassification({ shouldAskForRepositoryClarification: false }),
+        { repositoryContextStatus: "resolved" },
+      ),
+    ).toBe(false);
+  });
+
   it("builds recent user conversation text for classification", () => {
     expect(
       getRecentUserConversationText(

--- a/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-classifier.ts
+++ b/apps/hyperlocalise-web/src/lib/agent-runtime/loops/conversation-classifier.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import type { RepositoryAgentGitHubContext } from "@/lib/agent-contracts/repository-task";
 
+import type { RepositoryGitHubContextResolution } from "@/lib/agents/repository-context";
 import { getHyperlocaliseAgentModel } from "./model";
 
 export const conversationClassificationSchema = z.object({
@@ -171,6 +172,13 @@ export function shouldAttemptRepositoryContextResolution(input: {
 
 export function shouldRequireRepositoryContextClarification(
   classification: ConversationClassification,
+  input?: {
+    repositoryContextStatus?: RepositoryGitHubContextResolution["status"];
+  },
 ): boolean {
+  if (input?.repositoryContextStatus === "unresolved" && classification.needsRepositoryTools) {
+    return true;
+  }
+
   return classification.shouldAskForRepositoryClarification;
 }

--- a/apps/hyperlocalise-web/src/lib/agents/repository-context.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/repository-context.test.ts
@@ -10,10 +10,12 @@ vi.mock("./github/app", () => ({
 }));
 
 import {
+  buildMultipleRepositorySelectionFollowUp,
   buildRepositoryGitHubContextInstructions,
   defaultRepositoryGitHubContextDependencies,
   extractGitHubPullRequestReferences,
   extractGitHubRepositoryFullNameReferences,
+  formatEnabledRepositoryList,
   resolveGitHubRepositoryGitHubContext,
   resolveSlackRepositoryGitHubContext,
   type RepositoryGitHubContextDependencies,
@@ -238,7 +240,41 @@ describe("resolveSlackRepositoryGitHubContext", () => {
         resolved: false,
         reason: "The Slack request matched multiple installed GitHub repositories.",
       },
-      followUp: expect.stringContaining("owner/repository"),
+      followUp: expect.stringContaining("acme/web"),
+    });
+    expect(resolution).toMatchObject({
+      followUp: expect.stringContaining("other/web"),
+    });
+  });
+
+  it("resolves Slack context from a unique owner name in the message", async () => {
+    const resolution = await resolveSlackRepositoryGitHubContext({
+      organizationId: "org_123",
+      text: "Find context for 'Email agent' in acme",
+      requirePullRequest: false,
+      dependencies: createDependencies({
+        listEnabledRepositories: vi.fn(async () => [
+          {
+            installationId: 12345,
+            repositoryFullName: "acme/web",
+            defaultBranch: "main",
+          },
+          {
+            installationId: 67890,
+            repositoryFullName: "other/api",
+            defaultBranch: "main",
+          },
+        ]),
+      }),
+    });
+
+    expect(resolution).toMatchObject({
+      status: "resolved",
+      source: "slack_repo_reference",
+      context: {
+        resolved: true,
+        repositoryFullName: "acme/web",
+      },
     });
   });
 
@@ -345,16 +381,24 @@ describe("resolveSlackRepositoryGitHubContext", () => {
       organizationId: "org_123",
       text: "Run the repo checks",
       requirePullRequest: true,
-      dependencies: createDependencies(),
+      dependencies: createDependencies({
+        listEnabledRepositories: vi.fn(async () => [
+          {
+            installationId: 12345,
+            repositoryFullName: "acme/web",
+            defaultBranch: "main",
+          },
+        ]),
+      }),
     });
 
     expect(resolution).toMatchObject({
       status: "unresolved",
-      followUp: expect.stringContaining("Please send a GitHub pull request URL"),
+      followUp: expect.stringContaining("pull request number"),
     });
   });
 
-  it("asks for repo context when a Slack repo intent has no repository fallback", async () => {
+  it("asks to enable a repository when none are enabled", async () => {
     const resolution = await resolveSlackRepositoryGitHubContext({
       organizationId: "org_123",
       text: "Run the repo checks",
@@ -364,7 +408,7 @@ describe("resolveSlackRepositoryGitHubContext", () => {
 
     expect(resolution).toMatchObject({
       status: "unresolved",
-      followUp: expect.stringContaining("include the repository name"),
+      followUp: expect.stringContaining("No GitHub repositories are enabled"),
     });
   });
 
@@ -391,8 +435,50 @@ describe("resolveSlackRepositoryGitHubContext", () => {
 
     expect(resolution).toMatchObject({
       status: "unresolved",
-      followUp: expect.stringContaining("include the repository name"),
+      followUp: expect.stringContaining("acme/web"),
     });
+    expect(resolution).toMatchObject({
+      followUp: expect.stringContaining("acme/api"),
+    });
+    expect(resolution).toMatchObject({
+      followUp: expect.stringContaining("Which repository should I use"),
+    });
+  });
+});
+
+describe("repository selection follow-up helpers", () => {
+  it("formats enabled repositories for confirmation prompts", () => {
+    expect(
+      formatEnabledRepositoryList([
+        {
+          installationId: 1,
+          repositoryFullName: "acme/web",
+          defaultBranch: "main",
+        },
+        {
+          installationId: 2,
+          repositoryFullName: "acme/api",
+          defaultBranch: "main",
+        },
+      ]),
+    ).toBe("`acme/web`, `acme/api`");
+  });
+
+  it("builds a multi-repository selection follow-up", () => {
+    expect(
+      buildMultipleRepositorySelectionFollowUp([
+        {
+          installationId: 1,
+          repositoryFullName: "acme/web",
+          defaultBranch: "main",
+        },
+        {
+          installationId: 2,
+          repositoryFullName: "acme/api",
+          defaultBranch: "main",
+        },
+      ]),
+    ).toContain("Which repository should I use?");
   });
 });
 

--- a/apps/hyperlocalise-web/src/lib/agents/repository-context.test.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/repository-context.test.ts
@@ -278,6 +278,33 @@ describe("resolveSlackRepositoryGitHubContext", () => {
     });
   });
 
+  it("does not match owner names without repository context in the message", async () => {
+    const resolution = await resolveSlackRepositoryGitHubContext({
+      organizationId: "org_123",
+      text: "check the new copy for the login page",
+      requirePullRequest: false,
+      dependencies: createDependencies({
+        listEnabledRepositories: vi.fn(async () => [
+          {
+            installationId: 12345,
+            repositoryFullName: "new/web",
+            defaultBranch: "main",
+          },
+          {
+            installationId: 67890,
+            repositoryFullName: "other/api",
+            defaultBranch: "main",
+          },
+        ]),
+      }),
+    });
+
+    expect(resolution).toMatchObject({
+      status: "unresolved",
+      followUp: expect.stringContaining("Which repository should I use"),
+    });
+  });
+
   it("returns a Slack follow-up when repository access validation fails", async () => {
     const resolution = await resolveSlackRepositoryGitHubContext({
       organizationId: "org_123",

--- a/apps/hyperlocalise-web/src/lib/agents/repository-context.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/repository-context.ts
@@ -169,18 +169,10 @@ export async function resolveConversationRepositoryGitHubContext(input: {
       );
     }
 
-    if (installedRepositories.length > 1) {
-      return unresolved(
-        "Multiple GitHub repositories are enabled and the request did not identify which one to use.",
-        "Reply with owner/repository, a GitHub URL, or the repository name from the list.",
-        buildMultipleRepositorySelectionFollowUp(installedRepositories),
-      );
-    }
-
     return unresolved(
-      "No GitHub repository context was configured for this request.",
-      "Provide a GitHub pull request URL, repo name, or configure a project repository fallback.",
-      "Please send a GitHub pull request URL, include the repository name, or configure a default repository for this project.",
+      "Multiple GitHub repositories are enabled and the request did not identify which one to use.",
+      "Reply with owner/repository, a GitHub URL, or the repository name from the list.",
+      buildMultipleRepositorySelectionFollowUp(installedRepositories),
     );
   }
 
@@ -561,9 +553,10 @@ function findRepositoriesReferencedInText(
     return byRepositoryName;
   }
 
-  const byOwnerName = installedRepositories.filter((repository) =>
-    slackTextContainsToken(text, repository.repositoryFullName.split("/")[0] ?? ""),
-  );
+  const byOwnerName = installedRepositories.filter((repository) => {
+    const owner = repository.repositoryFullName.split("/")[0] ?? "";
+    return slackTextContainsOwnerReference(text, owner);
+  });
   if (byOwnerName.length > 0) {
     return byOwnerName;
   }
@@ -577,6 +570,24 @@ function slackTextContainsToken(text: string, token: string) {
   }
 
   return new RegExp(`(^|[^A-Za-z0-9_.-])${escapeRegExp(token)}($|[^A-Za-z0-9_.-])`, "i").test(text);
+}
+
+function slackTextContainsOwnerReference(text: string, owner: string) {
+  if (!owner) {
+    return false;
+  }
+
+  const escapedOwner = escapeRegExp(owner);
+  const contextualPatterns = [
+    new RegExp(`\\bin\\s+${escapedOwner}\\b`, "i"),
+    new RegExp(`\\bfrom\\s+${escapedOwner}\\b`, "i"),
+    new RegExp(`\\bon\\s+${escapedOwner}\\b`, "i"),
+    new RegExp(`\\bfor\\s+${escapedOwner}\\b`, "i"),
+    new RegExp(`\\b${escapedOwner}'s\\b`, "i"),
+    new RegExp(`\\b${escapedOwner}/`, "i"),
+  ];
+
+  return contextualPatterns.some((pattern) => pattern.test(text));
 }
 
 function repositoryFullNameFromConfigValue(value: unknown): string | null {

--- a/apps/hyperlocalise-web/src/lib/agents/repository-context.ts
+++ b/apps/hyperlocalise-web/src/lib/agents/repository-context.ts
@@ -145,6 +145,22 @@ export async function resolveSlackRepositoryGitHubContext(input: {
       ? referencedRepository.repository
       : (configuredRepository ?? getSingleInstalledRepository(installedRepositories));
   if (!fallback) {
+    if (installedRepositories.length === 0) {
+      return unresolved(
+        "No GitHub repositories are enabled for this workspace.",
+        "Enable a repository in Agent → GitHub.",
+        "No GitHub repositories are enabled for this workspace. Open Agent → GitHub and enable at least one repository, then ask again.",
+      );
+    }
+
+    if (installedRepositories.length > 1) {
+      return unresolved(
+        "Multiple GitHub repositories are enabled and the request did not identify which one to use.",
+        "Reply with owner/repository, a GitHub URL, or the repository name from the list.",
+        buildMultipleRepositorySelectionFollowUp(installedRepositories),
+      );
+    }
+
     return unresolved(
       "No GitHub repository context was configured for this Slack request.",
       "Provide a GitHub pull request URL, repo name, or configure a project/channel repository fallback.",
@@ -442,14 +458,13 @@ function resolveSlackReferencedRepository(input: {
     };
   }
 
-  const matches = input.installedRepositories.filter((repository) =>
-    slackTextContainsRepositoryName(input.text, repository.repositoryFullName),
-  );
-  const uniqueMatches = uniqueRepositories(matches);
+  const matches = findRepositoriesReferencedInText(input.text, input.installedRepositories);
 
-  if (uniqueMatches.length === 0) {
+  if (matches.length === 0) {
     return { status: "not_found" };
   }
+
+  const uniqueMatches = uniqueRepositories(matches);
 
   if (uniqueMatches.length > 1) {
     return {
@@ -457,7 +472,7 @@ function resolveSlackReferencedRepository(input: {
       resolution: unresolved(
         "The Slack request matched multiple installed GitHub repositories.",
         "Please include owner/repository or a pull request URL.",
-        "I found multiple installed repositories matching that name. Please include owner/repository or send the PR URL so I know which repo to use.",
+        buildAmbiguousRepositoryMatchFollowUp(uniqueMatches),
       ),
     };
   }
@@ -498,16 +513,51 @@ function uniqueRepositories(repositories: EnabledGitHubRepository[]) {
   return [...unique.values()];
 }
 
-function slackTextContainsRepositoryName(text: string, repositoryFullName: string) {
-  const repositoryName = repositoryFullName.split("/")[1];
-  if (!repositoryName) {
+export function formatEnabledRepositoryList(repositories: EnabledGitHubRepository[]): string {
+  return uniqueRepositories(repositories)
+    .map((repository) => `\`${repository.repositoryFullName}\``)
+    .join(", ");
+}
+
+export function buildMultipleRepositorySelectionFollowUp(
+  repositories: EnabledGitHubRepository[],
+): string {
+  const repositoryList = formatEnabledRepositoryList(repositories);
+  return `Multiple GitHub repositories are enabled for this workspace: ${repositoryList}. Which repository should I use? Reply with owner/repository or the repository name.`;
+}
+
+function buildAmbiguousRepositoryMatchFollowUp(repositories: EnabledGitHubRepository[]): string {
+  const repositoryList = formatEnabledRepositoryList(repositories);
+  return `That message matches more than one enabled repository: ${repositoryList}. Please include owner/repository or send the PR URL so I know which repo to use.`;
+}
+
+function findRepositoriesReferencedInText(
+  text: string,
+  installedRepositories: EnabledGitHubRepository[],
+): EnabledGitHubRepository[] {
+  const byRepositoryName = installedRepositories.filter((repository) =>
+    slackTextContainsToken(text, repository.repositoryFullName.split("/")[1] ?? ""),
+  );
+  if (byRepositoryName.length > 0) {
+    return byRepositoryName;
+  }
+
+  const byOwnerName = installedRepositories.filter((repository) =>
+    slackTextContainsToken(text, repository.repositoryFullName.split("/")[0] ?? ""),
+  );
+  if (byOwnerName.length > 0) {
+    return byOwnerName;
+  }
+
+  return [];
+}
+
+function slackTextContainsToken(text: string, token: string) {
+  if (!token) {
     return false;
   }
 
-  return new RegExp(
-    `(^|[^A-Za-z0-9_.-])${escapeRegExp(repositoryName)}($|[^A-Za-z0-9_.-])`,
-    "i",
-  ).test(text);
+  return new RegExp(`(^|[^A-Za-z0-9_.-])${escapeRegExp(token)}($|[^A-Za-z0-9_.-])`, "i").test(text);
 }
 
 function repositoryFullNameFromConfigValue(value: unknown): string | null {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When multiple GitHub repositories are enabled for a workspace, the Hyperlocalise agent now tries harder to match the user's request to the correct repo and asks for explicit confirmation when it cannot.

## Changes

- **Repository matching**: Match by repository name (existing) and by unique owner name in the message (e.g. "find context in acme").
- **Confirmation prompts**: When multiple repos are enabled and the request is ambiguous, the agent lists all enabled repositories and asks which one to use.
- **Ambiguous partial matches**: When a short name matches multiple repos, the follow-up now lists the matching candidates.
- **Deterministic clarification**: When repository tools are needed but context cannot be resolved, Slack always posts the clarification prompt instead of running the agent without a sandbox (previously depended on LLM classifier flag alone).
- **No repos enabled**: Clearer message when zero repositories are enabled.

## Testing

- `vp test src/lib/agents/repository-context.test.ts src/lib/agent-runtime/loops/conversation-classifier.test.ts src/lib/agents/slack/bot.test.ts`
- `vp check --fix`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2069-96db-7b8f-8c2e-ae1cdcec6c5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2069-96db-7b8f-8c2e-ae1cdcec6c5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

