### PR TITLE
fix(integrations): show skeleton loader for action buttons while loading

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/email-integration-row.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/email-integration-row.tsx
@@ -142,6 +142,7 @@ export function EmailIntegrationRow({
       onExpandedChange={setExpanded}
       onConnect={() => void toggleEnabled(true)}
       isConnecting={updateEmailAgentState.isPending}
+      isLoading={isLoading}
       isLast={isLast}
     >
       <div className="flex flex-col gap-4">

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/github-integration-row.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/github-integration-row.tsx
@@ -386,6 +386,7 @@ export function GitHubIntegrationRow({
       onExpandedChange={setExpanded}
       onConnect={() => void handleConnect()}
       isConnecting={isCreatingInstallUrl}
+      isLoading={isLoading}
       isLast={isLast}
     >
       {isLoading ? (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integration-row.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/integration-row.tsx
@@ -5,6 +5,7 @@ import { ArrowUpRightIcon, ChevronDownIcon } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/primitives/cn";
 
 export type IntegrationRowAction = "connect" | "manage" | "coming-soon" | "view-only";
@@ -19,6 +20,7 @@ type IntegrationRowProps = {
   onExpandedChange?: (expanded: boolean) => void;
   onConnect?: () => void;
   isConnecting?: boolean;
+  isLoading?: boolean;
   isLast?: boolean;
   children?: ReactNode;
 };
@@ -65,6 +67,7 @@ export function IntegrationRow({
   onExpandedChange,
   onConnect,
   isConnecting = false,
+  isLoading = false,
   isLast = false,
   children,
 }: IntegrationRowProps) {
@@ -102,7 +105,9 @@ export function IntegrationRow({
         </div>
 
         <div className="shrink-0">
-          {action === "coming-soon" ? (
+          {isLoading && (action === "connect" || action === "manage") ? (
+            <Skeleton className="h-8 w-[5.75rem] rounded-md" aria-hidden />
+          ) : action === "coming-soon" ? (
             <Button type="button" variant="outline" size="sm" disabled>
               Coming soon
             </Button>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/slack-integration-row.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/integrations/_components/slack-integration-row.tsx
@@ -155,6 +155,7 @@ export function SlackIntegrationRow({
       onExpandedChange={setExpanded}
       onConnect={() => void handleConnect()}
       isConnecting={isCreatingInstallUrl}
+      isLoading={isLoading}
       isLast={isLast}
     >
       {isLoading ? (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

While the integrations page loads GitHub (and other agent) connection status, the row previously showed a **Connect** button before the API response arrived. That was misleading for organizations that are already connected.

This change adds an `isLoading` prop to `IntegrationRow` that renders a skeleton placeholder in place of the Connect/Manage action button until the connection query resolves.

## Changes

- **`integration-row.tsx`**: New optional `isLoading` prop; shows a button-sized skeleton when loading and the action would be Connect or Manage.
- **`github-integration-row.tsx`**: Passes `isLoading` from the GitHub installation query.
- **`slack-integration-row.tsx`** / **`email-integration-row.tsx`**: Same pattern for consistency across agent integrations.

## Testing

- `vp check --fix` — passed
- Integration component unit tests — passed
- Full `vp test` requires local `.env` (DATABASE_URL); not run in this environment
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f548cf6-046d-45fa-af85-730a91128c52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f548cf6-046d-45fa-af85-730a91128c52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

