### PR TITLE
perf(web): reduce TMS job fan-out and speed up jobs/files loading

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -1047,7 +1047,10 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
               c.var.auth.organization.localOrganizationId,
               target.externalProjectId,
               query.sourcePath,
-              { actorUserId: c.var.auth.user.localUserId },
+              {
+                actorUserId: c.var.auth.user.localUserId,
+                externalResourceId: query.externalResourceId,
+              },
             );
             if (!file) {
               return projectNotFoundResponse(c);

--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -221,6 +221,7 @@ export const workspaceFilesResponseSchema = z.object({
 
 export const projectFileDetailQuerySchema = z.object({
   sourcePath: z.string().trim().min(1).max(2048),
+  externalResourceId: z.string().trim().min(1).max(128).optional(),
 });
 
 export const projectFileCatQueueFilterSchema = z.enum([

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-kanban-board.messages.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-kanban-board.messages.ts
@@ -1,0 +1,56 @@
+"use client";
+
+import type { MessageDescriptor } from "react-intl";
+import { defineMessages } from "react-intl";
+
+import type { KanbanStatus } from "./jobs-view-helpers";
+
+export const jobsKanbanBoardMessages = defineMessages({
+  queued: {
+    defaultMessage: "Queued",
+    id: "8rr2LhuMpW",
+    description: "Kanban column label for queued jobs",
+  },
+  running: {
+    defaultMessage: "Running",
+    id: "nEBGfsZw1I",
+    description: "Kanban column label for running jobs",
+  },
+  waitingForReview: {
+    defaultMessage: "Waiting for review",
+    id: "xsAaVb0T8m",
+    description: "Kanban column label for jobs waiting for review",
+  },
+  succeeded: {
+    defaultMessage: "Succeeded",
+    id: "hKQGjL6KUM",
+    description: "Kanban column label for succeeded jobs",
+  },
+  failed: {
+    defaultMessage: "Failed",
+    id: "vUMdCurROo",
+    description: "Kanban column label for failed jobs",
+  },
+  cancelled: {
+    defaultMessage: "Cancelled",
+    id: "/UI9Zob6RC",
+    description: "Kanban column label for cancelled jobs",
+  },
+});
+
+export function getKanbanStatusMessage(status: KanbanStatus): MessageDescriptor {
+  switch (status) {
+    case "queued":
+      return jobsKanbanBoardMessages.queued;
+    case "running":
+      return jobsKanbanBoardMessages.running;
+    case "waiting_for_review":
+      return jobsKanbanBoardMessages.waitingForReview;
+    case "succeeded":
+      return jobsKanbanBoardMessages.succeeded;
+    case "failed":
+      return jobsKanbanBoardMessages.failed;
+    case "cancelled":
+      return jobsKanbanBoardMessages.cancelled;
+  }
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-kanban-board.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-kanban-board.tsx
@@ -2,6 +2,7 @@
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import { TypographyP } from "@/components/ui/typography";
 import { cn } from "@/lib/primitives/cn";
 
@@ -170,6 +171,58 @@ function KanbanColumn({
   );
 }
 
+function KanbanColumnSkeleton({ label }: { label: string }) {
+  return (
+    <section className="flex min-w-[17rem] flex-1 flex-col rounded-xl border border-foreground/10 bg-foreground/2">
+      <header className="flex items-center justify-between gap-2 border-b border-foreground/8 px-3 py-3">
+        <TypographyP className="text-sm font-medium text-foreground">{label}</TypographyP>
+        <Skeleton className="h-5 w-8 rounded-full" />
+      </header>
+      <div className="flex flex-1 flex-col gap-3 p-3">
+        {Array.from({ length: 2 }, (_, index) => (
+          <div
+            key={index}
+            className="space-y-3 rounded-lg border border-foreground/10 bg-background p-3 shadow-sm"
+          >
+            <Skeleton className="h-4 w-4/5" />
+            <Skeleton className="h-3 w-2/5" />
+            <div className="flex gap-2">
+              <Skeleton className="h-5 w-16 rounded-full" />
+              <Skeleton className="h-5 w-20 rounded-full" />
+            </div>
+            <Skeleton className="h-3 w-full" />
+            <Skeleton className="h-3 w-3/4" />
+            <div className="border-t border-foreground/8 pt-3">
+              <Skeleton className="h-8 w-24 rounded-md" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function JobsKanbanBoardSkeleton() {
+  const skeletonColumns = [
+    "Queued",
+    "Running",
+    "Waiting for review",
+    "Succeeded",
+    "Failed",
+    "Cancelled",
+  ] as const;
+
+  return (
+    <div className="overflow-x-auto pb-1" aria-busy="true" aria-label="Loading jobs board">
+      <div className="flex min-w-max gap-3">
+        {skeletonColumns.map((label) => (
+          <KanbanColumnSkeleton key={label} label={label} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
 export function JobsKanbanBoard({
   buildJobDetailHref: buildDetailHref = buildJobDetailHref,
   emptyLabel,
@@ -190,9 +243,7 @@ export function JobsKanbanBoard({
   renderJobLink: JobsLinkRenderer;
 }) {
   if (isLoading) {
-    return (
-      <TypographyP className="px-3 py-8 text-sm text-foreground/58">Loading jobs…</TypographyP>
-    );
+    return <JobsKanbanBoardSkeleton />;
   }
 
   if (jobs.length === 0) {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-kanban-board.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-kanban-board.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useIntl } from "react-intl";
+
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -24,6 +26,7 @@ import {
   kanbanStatusColumns,
   type KanbanStatus,
 } from "./jobs-view-helpers";
+import { getKanbanStatusMessage } from "./jobs-kanban-board.messages";
 import { toneClass, type Tone } from "../../_components/workspace-resource-shared";
 
 type KanbanColumnDef = {
@@ -203,20 +206,16 @@ function KanbanColumnSkeleton({ label }: { label: string }) {
 }
 
 function JobsKanbanBoardSkeleton() {
-  const skeletonColumns = [
-    "Queued",
-    "Running",
-    "Waiting for review",
-    "Succeeded",
-    "Failed",
-    "Cancelled",
-  ] as const;
+  const intl = useIntl();
 
   return (
     <div className="overflow-x-auto pb-1" aria-busy="true" aria-label="Loading jobs board">
       <div className="flex min-w-max gap-3">
-        {skeletonColumns.map((label) => (
-          <KanbanColumnSkeleton key={label} label={label} />
+        {kanbanStatusColumns.map((status) => (
+          <KanbanColumnSkeleton
+            key={status}
+            label={intl.formatMessage(getKanbanStatusMessage(status))}
+          />
         ))}
       </div>
     </div>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-content.tsx
@@ -240,7 +240,7 @@ export function JobsPageContent({
   });
   const tmsJobsQuery = useQuery({
     queryKey: tmsJobsQueryKey,
-    enabled: isProviderProjectScope || scope !== "personal" || !projectId,
+    enabled: isProviderProjectScope || !projectId,
     queryFn: async () => {
       if (parsedProviderProject) {
         return fetchTmsProjectJobs(

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-page-view.tsx
@@ -630,24 +630,18 @@ export function JobsPageView({
 }) {
   const searchId = useId();
   const [search, setSearch] = useState(initialSearch);
-  const [viewMode, setViewMode] = useState<JobsViewMode>("row");
+  const [viewMode, setViewMode] = useState<JobsViewMode>("kanban");
   const [uncontrolledStatusFilter, setUncontrolledStatusFilter] =
     useState<JobsStatusFilter>(initialStatusFilter);
   const statusFilter = controlledStatusFilter ?? uncontrolledStatusFilter;
 
   useEffect(() => {
-    if (!projectId) {
-      return;
-    }
-
     setViewMode(readJobsViewMode());
-  }, [projectId]);
+  }, []);
 
   const handleViewModeChange = (nextViewMode: JobsViewMode) => {
     setViewMode(nextViewMode);
-    if (projectId) {
-      writeJobsViewMode(nextViewMode);
-    }
+    writeJobsViewMode(nextViewMode);
   };
 
   const filterJobs = (jobs: JobRow[]) => {
@@ -671,7 +665,7 @@ export function JobsPageView({
 
   const isPersonalWork = scope === "personal";
   const showNativeSection = !isProviderProjectScope;
-  const showTmsSection = hasActiveTmsConnection || isProviderProjectScope;
+  const showTmsSection = isProviderProjectScope || (!projectId && hasActiveTmsConnection);
 
   const nativeEmptyLabel = projectId
     ? "No Hyperlocalise jobs found for this project yet."

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-view-helpers.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-view-helpers.test.ts
@@ -130,9 +130,9 @@ describe("jobs-view-helpers", () => {
     });
 
     try {
-      expect(readJobsViewMode()).toBe("row");
-      writeJobsViewMode("kanban");
       expect(readJobsViewMode()).toBe("kanban");
+      writeJobsViewMode("row");
+      expect(readJobsViewMode()).toBe("row");
     } finally {
       Object.defineProperty(globalThis, "window", {
         configurable: true,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-view-helpers.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/jobs-view-helpers.ts
@@ -24,7 +24,7 @@ export { buildJobCatHref, canOpenJobCat, type JobCatTarget };
 
 export function readJobsViewMode(): JobsViewMode {
   if (typeof window === "undefined") {
-    return "row";
+    return "kanban";
   }
 
   try {
@@ -33,10 +33,10 @@ export function readJobsViewMode(): JobsViewMode {
       return stored;
     }
   } catch {
-    return "row";
+    return "kanban";
   }
 
-  return "row";
+  return "kanban";
 }
 
 export function writeJobsViewMode(mode: JobsViewMode) {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-detail-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-file-detail-panel.tsx
@@ -120,6 +120,7 @@ export function ProjectFileDetailPanel({
   encodedJobId?: string | null;
 }) {
   const sourcePath = file?.sourcePath ?? null;
+  const externalResourceId = file?.provider?.externalResourceId ?? null;
 
   const detailQuery = useQuery({
     queryKey: projectFileDetailQueryKey(
@@ -150,7 +151,10 @@ export function ProjectFileDetailPanel({
         ":projectId"
       ].files.detail.$get({
         param: { organizationSlug, projectId },
-        query: { sourcePath: sourcePath as string },
+        query: {
+          sourcePath: sourcePath as string,
+          ...(externalResourceId ? { externalResourceId } : {}),
+        },
       });
 
       if (!response.ok) {

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-error-boundary.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-error-boundary.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { AlertCircleIcon } from "lucide-react";
+import { type ErrorInfo, type ReactNode } from "react";
+import { ErrorBoundary, type FallbackProps } from "react-error-boundary";
+
+import { TmsUserConnectionErrorPanel } from "@/components/app-shell/tms-user-connection-prompt";
+import { Button } from "@/components/ui/button";
+import { TypographyP } from "@/components/ui/typography";
+import { isTmsUserConnectionRequiredError } from "@/lib/providers/tms-user-connection-shared";
+import { cn } from "@/lib/primitives/cn";
+
+function logProjectFilesPanelError(scope: "tree" | "detail", error: Error, info: ErrorInfo) {
+  console.error(`[project-files:${scope}]`, {
+    name: error.name,
+    message: error.message,
+    stack: error.stack,
+    componentStack: info.componentStack,
+  });
+}
+
+function ProjectFilesPanelFallback({
+  error,
+  resetErrorBoundary,
+  organizationSlug,
+  scope,
+  className,
+}: FallbackProps & {
+  organizationSlug: string;
+  scope: "tree" | "detail";
+  className?: string;
+}) {
+  if (isTmsUserConnectionRequiredError(error)) {
+    return (
+      <div className={cn("p-4", className)}>
+        <TmsUserConnectionErrorPanel
+          organizationSlug={organizationSlug}
+          resource="files"
+          error={error}
+        />
+      </div>
+    );
+  }
+
+  const errorMessage = error instanceof Error ? error.message : "Failed to load files.";
+
+  return (
+    <div className={cn("flex min-h-48 flex-col justify-center gap-3 p-4", className)} role="alert">
+      <div className="flex items-start gap-2">
+        <AlertCircleIcon className="mt-0.5 size-4 shrink-0 text-flame-100" aria-hidden />
+        <div className="space-y-1">
+          <TypographyP className="text-sm font-medium text-flame-100">
+            {scope === "tree" ? "Files failed to load." : "File preview failed to load."}
+          </TypographyP>
+          <TypographyP className="text-sm text-foreground/58">{errorMessage}</TypographyP>
+        </div>
+      </div>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="w-fit"
+        onClick={resetErrorBoundary}
+      >
+        Try again
+      </Button>
+    </div>
+  );
+}
+
+export function ProjectFilesErrorBoundary({
+  children,
+  organizationSlug,
+  scope,
+  className,
+  resetKeys,
+  onReset,
+}: {
+  children: ReactNode;
+  organizationSlug: string;
+  scope: "tree" | "detail";
+  className?: string;
+  resetKeys?: readonly unknown[];
+  onReset?: () => void;
+}) {
+  return (
+    <ErrorBoundary
+      fallbackRender={(fallbackProps) => (
+        <ProjectFilesPanelFallback
+          {...fallbackProps}
+          organizationSlug={organizationSlug}
+          scope={scope}
+          className={className}
+        />
+      )}
+      onError={(error, info) => {
+        if (error instanceof Error) {
+          logProjectFilesPanelError(scope, error, info);
+        }
+      }}
+      onReset={onReset}
+      resetKeys={resetKeys ? [...resetKeys] : undefined}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
@@ -28,6 +28,7 @@ import {
   ProjectFilesTreePanel,
   fetchProjectFiles,
   projectFilesQueryKey,
+  sortFilesByPath,
 } from "./project-files-tree-panel";
 import { ProjectFilesTree } from "./project-files-tree";
 import { formatBytes } from "./project-files-shared";
@@ -47,12 +48,6 @@ function sourcePathForFile(file: File) {
 
 function fileKey(file: File) {
   return `${sourcePathForFile(file)}:${file.size}:${file.lastModified}`;
-}
-
-function sortFilesByPath(files: ProjectFileRecord[]) {
-  return [...files].toSorted((a, b) =>
-    a.sourcePath.localeCompare(b.sourcePath, undefined, { sensitivity: "base" }),
-  );
 }
 
 export type ProjectFilesTreeRenderer = (props: {
@@ -209,11 +204,21 @@ export function ProjectFilesPageContent({
     setSelectedFiles((currentFiles) => currentFiles.filter((item) => item !== file));
   }, []);
 
+  const cachedFilesQuery = useQuery({
+    queryKey: projectFilesQueryKey(organizationSlug, projectId),
+    queryFn: () => fetchProjectFiles(organizationSlug, projectId),
+  });
+  const resolvedFiles = useMemo(
+    () => sortFilesByPath(cachedFilesQuery.data ?? []),
+    [cachedFilesQuery.data],
+  );
+
   return (
     <ProjectFilesPageContentView
       organizationSlug={organizationSlug}
       projectId={projectId}
       files={[]}
+      resolvedFiles={resolvedFiles}
       isFilesLoading={false}
       isFilesFetching={false}
       selectedSourcePath={selectedSourcePath}
@@ -240,6 +245,7 @@ export function ProjectFilesPageContentView({
   organizationSlug,
   projectId,
   files,
+  resolvedFiles,
   isFilesLoading,
   isFilesFetching,
   filesError,
@@ -259,6 +265,7 @@ export function ProjectFilesPageContentView({
   organizationSlug: string;
   projectId: string;
   files: ProjectFileRecord[];
+  resolvedFiles?: ProjectFileRecord[];
   isFilesLoading: boolean;
   isFilesFetching: boolean;
   filesError?: unknown;
@@ -276,18 +283,10 @@ export function ProjectFilesPageContentView({
   filesTree?: ReactNode;
 }) {
   const inputRef = useRef<HTMLInputElement>(null);
-  const cachedFilesQuery = useQuery({
-    queryKey: projectFilesQueryKey(organizationSlug, projectId),
-    queryFn: () => fetchProjectFiles(organizationSlug, projectId),
-    enabled: Boolean(filesTree),
-  });
-  const resolvedFiles = useMemo(
-    () => (filesTree ? sortFilesByPath(cachedFilesQuery.data ?? []) : files),
-    [cachedFilesQuery.data, files, filesTree],
-  );
+  const displayFiles = filesTree ? (resolvedFiles ?? []) : files;
   const selectedFile = useMemo(
-    () => resolvedFiles.find((file) => file.sourcePath === selectedSourcePath) ?? null,
-    [resolvedFiles, selectedSourcePath],
+    () => displayFiles.find((file) => file.sourcePath === selectedSourcePath) ?? null,
+    [displayFiles, selectedSourcePath],
   );
   const projectCapabilities = getProjectWorkspaceCapabilities({ projectId });
   const isProviderProject = projectCapabilities.isProviderProject;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
@@ -23,16 +23,18 @@ import {
   ProjectSectionTitle,
 } from "../../_components/project-page-shell";
 import { ProjectFileDetailPanel } from "./project-file-detail-panel";
+import { ProjectFilesErrorBoundary } from "./project-files-error-boundary";
+import {
+  ProjectFilesTreePanel,
+  fetchProjectFiles,
+  projectFilesQueryKey,
+} from "./project-files-tree-panel";
 import { ProjectFilesTree } from "./project-files-tree";
 import { formatBytes } from "./project-files-shared";
 
 const FILE_ACCEPT =
   ".json,.jsonc,.yaml,.yml,.arb,.xlf,.xlif,.xliff,.po,.html,.md,.mdx,.strings,.stringsdict,.xcstrings,.csv";
 const MAX_UPLOAD_FILES = 10;
-
-function projectFilesQueryKey(organizationSlug: string, projectId: string) {
-  return ["project-files", organizationSlug, projectId] as const;
-}
 
 function apiPath(organizationSlug: string, projectId: string) {
   return `/api/orgs/${encodeURIComponent(organizationSlug)}/projects/${encodeURIComponent(projectId)}/files`;
@@ -160,22 +162,6 @@ export function ProjectFilesPageContent({
     [pathname, router, searchParams],
   );
 
-  const filesQuery = useQuery({
-    queryKey: projectFilesQueryKey(organizationSlug, projectId),
-    queryFn: async () => {
-      const response = await fetch(`${apiPath(organizationSlug, projectId)}?limit=500`, {
-        method: "GET",
-      });
-
-      if (!response.ok) {
-        throw await readApiResponseError(response, "Failed to load project files");
-      }
-
-      const body = (await response.json()) as { files: ProjectFileRecord[] };
-      return body.files;
-    },
-  });
-
   const uploadFiles = useMutation({
     mutationFn: async (files: File[]) => {
       for (const file of files) {
@@ -209,7 +195,6 @@ export function ProjectFilesPageContent({
     },
   });
 
-  const files = useMemo(() => sortFilesByPath(filesQuery.data ?? []), [filesQuery.data]);
   const addSelectedFiles = useCallback((nextFiles: File[]) => {
     setSelectedFiles((currentFiles) => {
       const existing = new Set(currentFiles.map(fileKey));
@@ -228,10 +213,9 @@ export function ProjectFilesPageContent({
     <ProjectFilesPageContentView
       organizationSlug={organizationSlug}
       projectId={projectId}
-      files={files}
-      isFilesLoading={filesQuery.isLoading}
-      isFilesFetching={filesQuery.isFetching}
-      filesError={filesQuery.isError ? filesQuery.error : undefined}
+      files={[]}
+      isFilesLoading={false}
+      isFilesFetching={false}
       selectedSourcePath={selectedSourcePath}
       highlightLocale={highlightLocale}
       selectedFiles={selectedFiles}
@@ -240,6 +224,14 @@ export function ProjectFilesPageContent({
       onAddSelectedFiles={addSelectedFiles}
       onRemoveSelectedFile={removeSelectedFile}
       onUploadSelectedFiles={() => uploadFiles.mutate(selectedFiles)}
+      filesTree={
+        <ProjectFilesTreePanel
+          organizationSlug={organizationSlug}
+          projectId={projectId}
+          selectedSourcePath={selectedSourcePath}
+          onSelectSourcePath={setSelectedSourcePath}
+        />
+      }
     />
   );
 }
@@ -262,6 +254,7 @@ export function ProjectFilesPageContentView({
   renderDetailPanel = defaultRenderDetailPanel,
   renderError = defaultRenderFilesError,
   renderFilesTree = defaultRenderFilesTree,
+  filesTree,
 }: {
   organizationSlug: string;
   projectId: string;
@@ -280,11 +273,21 @@ export function ProjectFilesPageContentView({
   renderDetailPanel?: ProjectFilesDetailPanelRenderer;
   renderError?: ProjectFilesErrorRenderer;
   renderFilesTree?: ProjectFilesTreeRenderer;
+  filesTree?: ReactNode;
 }) {
   const inputRef = useRef<HTMLInputElement>(null);
+  const cachedFilesQuery = useQuery({
+    queryKey: projectFilesQueryKey(organizationSlug, projectId),
+    queryFn: () => fetchProjectFiles(organizationSlug, projectId),
+    enabled: Boolean(filesTree),
+  });
+  const resolvedFiles = useMemo(
+    () => (filesTree ? sortFilesByPath(cachedFilesQuery.data ?? []) : files),
+    [cachedFilesQuery.data, files, filesTree],
+  );
   const selectedFile = useMemo(
-    () => files.find((file) => file.sourcePath === selectedSourcePath) ?? null,
-    [files, selectedSourcePath],
+    () => resolvedFiles.find((file) => file.sourcePath === selectedSourcePath) ?? null,
+    [resolvedFiles, selectedSourcePath],
   );
   const projectCapabilities = getProjectWorkspaceCapabilities({ projectId });
   const isProviderProject = projectCapabilities.isProviderProject;
@@ -377,58 +380,85 @@ export function ProjectFilesPageContentView({
       ) : null}
 
       <section className="flex min-h-[min(28rem,70vh)] flex-col overflow-hidden rounded-lg border border-foreground/8 bg-foreground/2.5">
-        <header className="flex shrink-0 items-center justify-between gap-3 border-b border-foreground/8 px-4 py-3">
-          <div>
-            <ProjectSectionTitle>Project files</ProjectSectionTitle>
-            <TypographyP className="mt-0.5 text-sm text-foreground/52">
-              {isFilesLoading
-                ? "Loading…"
-                : filesError
-                  ? "Could not load files"
-                  : `${files.length} file${files.length === 1 ? "" : "s"}`}
-            </TypographyP>
-          </div>
-          {isFilesFetching && !isFilesLoading ? <Spinner /> : null}
-        </header>
-
-        <div className="grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[minmax(14rem,18rem)_minmax(0,1fr)]">
-          <aside className="flex min-h-0 flex-col border-foreground/8 lg:border-e">
-            {isFilesLoading ? (
-              <TypographyP className="p-4 text-sm text-foreground/52">Loading files…</TypographyP>
-            ) : filesError ? (
-              <div className="p-4">{renderError({ organizationSlug, error: filesError })}</div>
-            ) : files.length === 0 ? (
-              <div className="flex flex-col gap-2 p-4">
-                <TypographyP className="text-sm font-medium text-foreground">
-                  No files yet
-                </TypographyP>
-                <TypographyP className="text-sm text-foreground/52">
-                  {isProviderProject
-                    ? "No provider files were found for this project."
-                    : "Use Add files above to upload JSON, YAML, XLIFF, PO, and other supported formats."}
-                </TypographyP>
-              </div>
-            ) : (
-              <div className="min-h-0 flex-1 p-2">
-                {renderFilesTree({
-                  files,
-                  selectedSourcePath,
-                  onSelectFile: onSelectSourcePath,
+        {filesTree ? (
+          <div className="grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[minmax(14rem,18rem)_minmax(0,1fr)]">
+            <aside className="flex min-h-0 flex-col border-foreground/8 lg:border-e">
+              {filesTree}
+            </aside>
+            <main className="min-h-0 overflow-y-auto bg-background/40">
+              <ProjectFilesErrorBoundary
+                organizationSlug={organizationSlug}
+                scope="detail"
+                resetKeys={[selectedSourcePath, highlightLocale, selectedFile?.sourcePath]}
+              >
+                {renderDetailPanel({
+                  organizationSlug,
+                  projectId,
+                  file: selectedFile,
+                  requestedSourcePath: selectedSourcePath,
+                  highlightLocale,
                 })}
+              </ProjectFilesErrorBoundary>
+            </main>
+          </div>
+        ) : (
+          <>
+            <header className="flex shrink-0 items-center justify-between gap-3 border-b border-foreground/8 px-4 py-3">
+              <div>
+                <ProjectSectionTitle>Project files</ProjectSectionTitle>
+                <TypographyP className="mt-0.5 text-sm text-foreground/52">
+                  {isFilesLoading
+                    ? "Loading…"
+                    : filesError
+                      ? "Could not load files"
+                      : `${files.length} file${files.length === 1 ? "" : "s"}`}
+                </TypographyP>
               </div>
-            )}
-          </aside>
+              {isFilesFetching && !isFilesLoading ? <Spinner /> : null}
+            </header>
 
-          <main className="min-h-0 overflow-y-auto bg-background/40">
-            {renderDetailPanel({
-              organizationSlug,
-              projectId,
-              file: selectedFile,
-              requestedSourcePath: selectedSourcePath,
-              highlightLocale,
-            })}
-          </main>
-        </div>
+            <div className="grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[minmax(14rem,18rem)_minmax(0,1fr)]">
+              <aside className="flex min-h-0 flex-col border-foreground/8 lg:border-e">
+                {isFilesLoading ? (
+                  <TypographyP className="p-4 text-sm text-foreground/52">
+                    Loading files…
+                  </TypographyP>
+                ) : filesError ? (
+                  <div className="p-4">{renderError({ organizationSlug, error: filesError })}</div>
+                ) : files.length === 0 ? (
+                  <div className="flex flex-col gap-2 p-4">
+                    <TypographyP className="text-sm font-medium text-foreground">
+                      No files yet
+                    </TypographyP>
+                    <TypographyP className="text-sm text-foreground/52">
+                      {isProviderProject
+                        ? "No provider files were found for this project."
+                        : "Use Add files above to upload JSON, YAML, XLIFF, PO, and other supported formats."}
+                    </TypographyP>
+                  </div>
+                ) : (
+                  <div className="min-h-0 flex-1 p-2">
+                    {renderFilesTree({
+                      files,
+                      selectedSourcePath,
+                      onSelectFile: onSelectSourcePath,
+                    })}
+                  </div>
+                )}
+              </aside>
+
+              <main className="min-h-0 overflow-y-auto bg-background/40">
+                {renderDetailPanel({
+                  organizationSlug,
+                  projectId,
+                  file: selectedFile,
+                  requestedSourcePath: selectedSourcePath,
+                  highlightLocale,
+                })}
+              </main>
+            </div>
+          </>
+        )}
       </section>
     </ProjectPageShell>
   );

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree-panel.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useMemo } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
+import { Spinner } from "@/components/ui/spinner";
+import { TypographyP } from "@/components/ui/typography";
+import { readApiResponseError } from "@/lib/api-error";
+import { getProjectWorkspaceCapabilities } from "@/lib/projects/workspace-resource-capabilities";
+
+import { ProjectSectionTitle } from "../../_components/project-page-shell";
+import { ProjectFilesErrorBoundary } from "./project-files-error-boundary";
+import { ProjectFilesTree } from "./project-files-tree";
+
+export function projectFilesQueryKey(organizationSlug: string, projectId: string) {
+  return ["project-files", organizationSlug, projectId] as const;
+}
+
+export async function fetchProjectFiles(organizationSlug: string, projectId: string) {
+  const response = await fetch(`${apiPath(organizationSlug, projectId)}?limit=500`, {
+    method: "GET",
+  });
+
+  if (!response.ok) {
+    throw await readApiResponseError(response, "Failed to load project files");
+  }
+
+  const body = (await response.json()) as { files: ProjectFileRecord[] };
+  return body.files;
+}
+
+function apiPath(organizationSlug: string, projectId: string) {
+  return `/api/orgs/${encodeURIComponent(organizationSlug)}/projects/${encodeURIComponent(projectId)}/files`;
+}
+
+function sortFilesByPath(files: ProjectFileRecord[]) {
+  return [...files].toSorted((a, b) =>
+    a.sourcePath.localeCompare(b.sourcePath, undefined, { sensitivity: "base" }),
+  );
+}
+
+function ProjectFilesTreeBody({
+  projectId,
+  files,
+  selectedSourcePath,
+  onSelectSourcePath,
+}: {
+  projectId: string;
+  files: ProjectFileRecord[];
+  selectedSourcePath: string | null;
+  onSelectSourcePath: (sourcePath: string | null) => void;
+}) {
+  const projectCapabilities = getProjectWorkspaceCapabilities({ projectId });
+  const isProviderProject = projectCapabilities.isProviderProject;
+
+  if (files.length === 0) {
+    return (
+      <div className="flex flex-col gap-2 p-4">
+        <TypographyP className="text-sm font-medium text-foreground">No files yet</TypographyP>
+        <TypographyP className="text-sm text-foreground/52">
+          {isProviderProject
+            ? "No provider files were found for this project."
+            : "Use Add files above to upload JSON, YAML, XLIFF, PO, and other supported formats."}
+        </TypographyP>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-0 flex-1 p-2">
+      <ProjectFilesTree
+        files={files}
+        selectedSourcePath={selectedSourcePath}
+        onSelectFile={onSelectSourcePath}
+      />
+    </div>
+  );
+}
+
+function ProjectFilesTreeQueryResult({
+  error,
+  projectId,
+  files,
+  selectedSourcePath,
+  onSelectSourcePath,
+}: {
+  error: unknown;
+  projectId: string;
+  files: ProjectFileRecord[];
+  selectedSourcePath: string | null;
+  onSelectSourcePath: (sourcePath: string | null) => void;
+}) {
+  if (error) {
+    throw error;
+  }
+
+  return (
+    <ProjectFilesTreeBody
+      projectId={projectId}
+      files={files}
+      selectedSourcePath={selectedSourcePath}
+      onSelectSourcePath={onSelectSourcePath}
+    />
+  );
+}
+
+export function ProjectFilesTreePanel({
+  organizationSlug,
+  projectId,
+  selectedSourcePath,
+  onSelectSourcePath,
+}: {
+  organizationSlug: string;
+  projectId: string;
+  selectedSourcePath: string | null;
+  onSelectSourcePath: (sourcePath: string | null) => void;
+}) {
+  const queryClient = useQueryClient();
+  const queryKey = projectFilesQueryKey(organizationSlug, projectId);
+  const filesQuery = useQuery({
+    queryKey,
+    queryFn: () => fetchProjectFiles(organizationSlug, projectId),
+  });
+
+  const files = useMemo(() => sortFilesByPath(filesQuery.data ?? []), [filesQuery.data]);
+
+  return (
+    <>
+      <header className="flex shrink-0 items-center justify-between gap-3 border-b border-foreground/8 px-4 py-3">
+        <div>
+          <ProjectSectionTitle>Project files</ProjectSectionTitle>
+          <TypographyP className="mt-0.5 text-sm text-foreground/52">
+            {filesQuery.isLoading
+              ? "Loading…"
+              : filesQuery.isError
+                ? "Could not load files"
+                : `${files.length} file${files.length === 1 ? "" : "s"}`}
+          </TypographyP>
+        </div>
+        {filesQuery.isFetching && !filesQuery.isLoading ? <Spinner /> : null}
+      </header>
+
+      {filesQuery.isLoading ? (
+        <TypographyP className="p-4 text-sm text-foreground/52">Loading files…</TypographyP>
+      ) : (
+        <ProjectFilesErrorBoundary
+          organizationSlug={organizationSlug}
+          scope="tree"
+          resetKeys={queryKey}
+          onReset={() => {
+            void queryClient.invalidateQueries({ queryKey });
+          }}
+          className="min-h-0 flex-1"
+        >
+          <ProjectFilesTreeQueryResult
+            error={filesQuery.isError ? filesQuery.error : null}
+            projectId={projectId}
+            files={files}
+            selectedSourcePath={selectedSourcePath}
+            onSelectSourcePath={onSelectSourcePath}
+          />
+        </ProjectFilesErrorBoundary>
+      )}
+    </>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree-panel.tsx
@@ -34,7 +34,7 @@ function apiPath(organizationSlug: string, projectId: string) {
   return `/api/orgs/${encodeURIComponent(organizationSlug)}/projects/${encodeURIComponent(projectId)}/files`;
 }
 
-function sortFilesByPath(files: ProjectFileRecord[]) {
+export function sortFilesByPath(files: ProjectFileRecord[]) {
   return [...files].toSorted((a, b) =>
     a.sourcePath.localeCompare(b.sourcePath, undefined, { sensitivity: "base" }),
   );

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-job-task-fetcher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-job-task-fetcher.test.ts
@@ -119,6 +119,65 @@ describe("fetchPhraseJobTasks", () => {
     });
   });
 
+  it("skips TM and term-base enrichment when enrichResources is false", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      const path = String(url);
+
+      if (path.includes("/jobs?")) {
+        const workflowLevel = Number(new URL(path).searchParams.get("workflowLevel") ?? "0");
+        if (workflowLevel === 1) {
+          return new Response(
+            JSON.stringify({
+              content: [
+                {
+                  uid: "task-1",
+                  innerId: "phrase-job-1",
+                  status: "NEW",
+                  targetLang: "fr-FR",
+                  filename: "App copy",
+                  workflowStep: { id: "step-1", name: "Translation", workflowLevel: 1 },
+                },
+              ],
+              totalPages: 1,
+            }),
+            { status: 200 },
+          );
+        }
+
+        return new Response(JSON.stringify({ content: [], totalPages: 0 }), { status: 200 });
+      }
+
+      throw new Error(`Unexpected fetch: ${path}`);
+    }) as unknown as typeof fetch;
+
+    globalThis.fetch = fetchMock;
+
+    const result = await fetchPhraseJobTasks({
+      organizationId: "org-1",
+      projectId: "project-1",
+      providerKind: "phrase",
+      externalProjectId: "phrase-project-1",
+      credential,
+      project: tmsProject,
+      secretMaterial: "secret-token",
+      enrichResources: false,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.providerPayload).not.toHaveProperty("translationMemories");
+    expect(result[0]?.providerPayload).not.toHaveProperty("termBases");
+    expect(
+      vi
+        .mocked(fetchMock)
+        .mock.calls.some(([url]) => String(url as string | URL).includes("/transMemories")),
+    ).toBe(false);
+    expect(
+      vi
+        .mocked(fetchMock)
+        .mock.calls.some(([url]) => String(url as string | URL).includes("/termBases")),
+    ).toBe(false);
+  });
+
   it("maps review workflow steps to review job kind", async () => {
     const fetchMock = vi.fn(async (url) => {
       const path = String(url);

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-job-task-fetcher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-job-task-fetcher.ts
@@ -13,6 +13,7 @@ export const fetchPhraseJobTasks: ExternalTmsJobTaskFetcher = async ({
   externalProjectId,
   project,
   secretMaterial,
+  enrichResources = true,
 }) => {
   const tmsProjectUid = resolvePhraseTmsProjectUid(project, externalProjectId);
 
@@ -32,18 +33,20 @@ export const fetchPhraseJobTasks: ExternalTmsJobTaskFetcher = async ({
     throw mapPhraseTmsFetcherError(error);
   }
 
-  const projectTermBases = await loadProjectTermBases(client, tmsProjectUid);
+  const projectTermBases = enrichResources ? await loadProjectTermBases(client, tmsProjectUid) : [];
   const resourceCache = new Map<string, JobResourceBundle>();
 
   return Promise.all(
     jobParts.map(async (jobPart) => {
-      const resources = await loadJobResources({
-        client,
-        projectUid: tmsProjectUid,
-        jobPart,
-        projectTermBases,
-        cache: resourceCache,
-      });
+      const resources = enrichResources
+        ? await loadJobResources({
+            client,
+            projectUid: tmsProjectUid,
+            jobPart,
+            projectTermBases,
+            cache: resourceCache,
+          })
+        : { translationMemories: [], termBases: [] };
 
       const targetLocale = jobPart.targetLang;
       const externalJobId = buildPhraseExternalJobId(jobPart.innerId, targetLocale);
@@ -63,8 +66,12 @@ export const fetchPhraseJobTasks: ExternalTmsJobTaskFetcher = async ({
         providerPayload: {
           workflowStep: jobPart.workflowStep?.name ?? null,
           workflowStepDetails: jobPart.workflowStep,
-          translationMemories: resources.translationMemories,
-          termBases: resources.termBases,
+          ...(enrichResources
+            ? {
+                translationMemories: resources.translationMemories,
+                termBases: resources.termBases,
+              }
+            : {}),
           innerId: jobPart.innerId,
           filename: jobPart.filename,
           importStatus: jobPart.importStatus,

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
@@ -788,8 +788,19 @@ async function resolveLiveCatFile(input: {
   externalProjectId: string;
   sourcePath: string;
   externalResourceId?: string | null;
+  resourceType?: "file" | "key";
   context: ActiveTmsProviderContext;
 }): Promise<TmsProviderLiveFile | null> {
+  if (input.externalResourceId && input.context.providerKind === "crowdin") {
+    return resolveLiveCatFileFromExternalResourceId({
+      providerKind: input.context.providerKind,
+      externalProjectId: input.externalProjectId,
+      externalResourceId: input.externalResourceId,
+      sourcePath: input.sourcePath,
+      resourceType: input.resourceType ?? "file",
+    });
+  }
+
   const files = await listTmsProviderLiveFilesForProject(
     input.organizationId,
     input.externalProjectId,
@@ -1524,6 +1535,7 @@ export async function countTmsProviderLiveOpenJobsForProject(
 ): Promise<number> {
   const jobs = await listTmsProviderLiveJobsForProject(organizationId, externalProjectId, {
     actorUserId: options?.actorUserId,
+    enrichResources: false,
   });
   return countOpenLiveJobs(jobs);
 }
@@ -1538,6 +1550,7 @@ export async function listTmsProviderLiveJobsForProject(
     context?: ActiveTmsProviderContext;
     projects?: ExternalTmsProjectMetadata[];
     actorUserId?: string | null;
+    enrichResources?: boolean;
   },
 ): Promise<TmsProviderLiveJob[]> {
   const context =
@@ -1551,9 +1564,10 @@ export async function listTmsProviderLiveJobsForProject(
     );
   }
 
-  const projects = options?.projects ?? (await fetchLiveProjects(context));
-  const project = projects.find((item) => item.externalProjectId === externalProjectId);
-  if (!project) {
+  const projectMetadata =
+    options?.projects?.find((project) => project.externalProjectId === externalProjectId) ??
+    (await resolveLiveProjectMetadata(context, externalProjectId));
+  if (!projectMetadata) {
     return [];
   }
 
@@ -1561,12 +1575,12 @@ export async function listTmsProviderLiveJobsForProject(
     organizationId: context.organizationId,
     credentialId: context.credential.id,
     providerKind: context.providerKind,
-    externalProjectId: project.externalProjectId,
-    name: project.name,
-    sourceLocale: project.sourceLocale ?? "en",
-    targetLocales: project.targetLocales ?? [],
-    externalProjectUrl: project.externalProjectUrl,
-    isActive: project.isActive,
+    externalProjectId: projectMetadata.externalProjectId,
+    name: projectMetadata.name,
+    sourceLocale: projectMetadata.sourceLocale ?? "en",
+    targetLocales: projectMetadata.targetLocales ?? [],
+    externalProjectUrl: projectMetadata.externalProjectUrl,
+    isActive: projectMetadata.isActive,
   });
 
   let tasks;
@@ -1579,6 +1593,7 @@ export async function listTmsProviderLiveJobsForProject(
       credential: context.credential,
       project: liveProject,
       secretMaterial: context.secretMaterial,
+      enrichResources: options?.enrichResources ?? false,
     });
   } catch (error) {
     rethrowProviderFetcherError(error);
@@ -1607,7 +1622,7 @@ export async function listTmsProviderLiveJobsForProject(
     mapLiveJob({
       providerKind: context.providerKind,
       externalProjectId,
-      projectName: project.name,
+      projectName: projectMetadata.name,
       task,
     }),
   );
@@ -1729,16 +1744,23 @@ export async function getTmsProviderLiveFileDetail(
   organizationId: string,
   externalProjectId: string,
   sourcePath: string,
-  options?: { actorUserId?: string | null },
+  options?: {
+    actorUserId?: string | null;
+    externalResourceId?: string | null;
+    resourceType?: "file" | "key";
+  },
 ): Promise<TmsProviderLiveFileDetail | null> {
   const context = await loadActiveTmsProviderContext(organizationId, {
     actorUserId: options?.actorUserId,
   });
-  const files = await listTmsProviderLiveFilesForProject(organizationId, externalProjectId, {
+  const file = await resolveLiveCatFile({
+    organizationId,
+    externalProjectId,
+    sourcePath,
+    externalResourceId: options?.externalResourceId,
+    resourceType: options?.resourceType,
     context,
-    limit: 1000,
   });
-  const file = files.find((item) => item.sourcePath === sourcePath);
   if (!file) {
     return null;
   }
@@ -2116,6 +2138,7 @@ export async function getTmsProviderLiveJobDetail(
         credential: context.credential,
         project: liveProject,
         secretMaterial: context.secretMaterial,
+        enrichResources: true,
       });
     } catch (error) {
       rethrowProviderFetcherError(error);

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-types.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-types.ts
@@ -77,6 +77,7 @@ export type ExternalTmsJobTaskFetcher = (input: {
   credential: ExternalTmsCredential;
   project: ExternalTmsProject;
   secretMaterial: string;
+  enrichResources?: boolean;
 }) => Promise<ExternalTmsJobTaskMetadata[]>;
 
 export type ExternalTmsGlossaryTermMetadata = {


### PR DESCRIPTION
## What changed

External TMS jobs and provider files were loading slowly because list views triggered unnecessary multi-project API calls and per-job resource enrichment.

- **Per-project TMS jobs** — `listTmsProviderLiveJobsForProject` now resolves a single project via `resolveLiveProjectMetadata` instead of listing all provider projects first (Crowdin: one `getProject` call).
- **Phrase job lists** — skip TM/term-base enrichment on list/count (`enrichResources: false`); detail views still enrich.
- **Jobs UI** — default to kanban board view, add kanban skeleton loading, and stop fetching workspace-wide TMS jobs on native Hyperlocalise project pages (TMS section only on provider projects or workspace jobs).
- **Provider files** — split files page into an independent tree panel with React error boundaries; file detail accepts optional `externalResourceId` so Crowdin can resolve a file without re-listing the full project tree.

## How to test

- [ ] Open a **provider project** jobs page — jobs load via single-project TMS route; no workspace fan-out in network tab.
- [ ] Open a **native Hyperlocalise project** jobs page — only Hyperlocalise jobs shown; no `GET /tms-provider/jobs` workspace call.
- [ ] Open **workspace jobs** — TMS jobs still load across projects; kanban is default with skeleton while loading.
- [ ] Open a **provider project files** page — tree loads independently; selecting a file loads detail; TMS errors show retry UI in the tree panel.
- [ ] Select a **Crowdin file** with `externalResourceId` — detail loads without listing all project files first.