### PR TITLE
perf(web): split CAT file load from per-segment detail fetching

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project-cat.route.test.ts
@@ -18,6 +18,7 @@ import type {
   ProjectFileCatCommentResponse,
   ProjectFileCatRecommendationResponse,
   ProjectFileCatResponse,
+  ProjectFileCatSegmentResponse,
   ProjectFileCatTranslationResponse,
 } from "./project.schema";
 
@@ -308,7 +309,7 @@ describe("project file CAT routes", () => {
     expect(await response.json()).toMatchObject({ error: "visual_context_unavailable" });
   });
 
-  it("returns native CAT comments on segments", async () => {
+  it("returns native CAT comment counts on list and comments on segment detail", async () => {
     const { identity, project, organization } = await projectFixture.createStoredProjectFixture();
     const headers = await projectFixture.authHeadersFor(identity);
     const sourcePath = "locales/en.json";
@@ -369,14 +370,33 @@ describe("project file CAT routes", () => {
 
     expect(response.status).toBe(200);
     const body = (await response.json()) as ProjectFileCatResponse;
-    expect(body.catFile.segments[0]?.comments).toMatchObject([
+    expect(body.catFile.segments[0]?.comments).toEqual([]);
+    expect(body.catFile.segments[0]?.commentCount).toBe(1);
+
+    const detailResponse = await client.api.orgs[":organizationSlug"].projects[
+      ":projectId"
+    ].files.detail.cat.segments[":externalStringId"].$get(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing-slug",
+          projectId: project.id,
+          externalStringId: translationKey!.id,
+        },
+        query: { sourcePath, targetLocale: "fr-FR" },
+      },
+      { headers },
+    );
+
+    expect(detailResponse.status).toBe(200);
+    const detailBody = (await detailResponse.json()) as ProjectFileCatSegmentResponse;
+    expect(detailBody.segment.comments).toMatchObject([
       {
         type: "comment",
         text: "Please clarify tone.",
         author: expect.any(String),
       },
     ]);
-    expect(body.catFile.segments[0]?.comments[0]?.externalCommentId).toBeTruthy();
+    expect(detailBody.segment.comments[0]?.externalCommentId).toBeTruthy();
   });
 
   it("posts and resolves native CAT issues", async () => {
@@ -498,16 +518,8 @@ describe("project file CAT routes", () => {
           context: null,
           type: "text",
           target: { text: "Bonjour", externalTranslationId: "9001", isApproved: true },
-          comments: [
-            {
-              externalCommentId: "42",
-              type: "issue",
-              status: "unresolved",
-              text: "Needs product wording",
-              createdAt: "2026-06-08T00:00:00Z",
-              locale: "fr",
-            },
-          ],
+          comments: [],
+          unresolvedIssueCount: 1,
         },
       ],
     });
@@ -530,7 +542,7 @@ describe("project file CAT routes", () => {
     expect(body.catFile.segments[0]).toMatchObject({
       externalStringId: "1001",
       target: { text: "Bonjour", isApproved: true },
-      comments: [{ type: "issue", status: "unresolved" }],
+      comments: [],
     });
     expect(getTmsProviderLiveCatFileMock).toHaveBeenCalledWith(
       expect.any(String),

--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -29,6 +29,7 @@ import { sourceContentType } from "@/lib/file-storage/source-file-metadata";
 import {
   countTmsProviderLiveOpenJobsForProject,
   getTmsProviderLiveCatFile,
+  getTmsProviderLiveCatSegmentDetail,
   getTmsProviderLiveFileDetail,
   getTmsProviderLiveProject,
   listTmsProviderLiveFilesForProject,
@@ -39,6 +40,7 @@ import {
 import { listOrganizationProjects } from "@/lib/projects/organization/organization-project-service";
 import {
   getNativeProjectCatFile,
+  getNativeProjectCatSegmentDetail,
   resolveNativeProjectCatComment,
   saveNativeProjectCatComment,
   saveNativeProjectCatTranslation,
@@ -69,6 +71,8 @@ import {
 import {
   createProjectBodySchema,
   maxProjectFileUploadBytes,
+  projectFileCatSegmentParamsSchema,
+  projectFileCatSegmentQuerySchema,
   projectFileCatQuerySchema,
   projectFileCatConcordanceBodySchema,
   projectFileCatCommentBodySchema,
@@ -366,6 +370,26 @@ const validateProjectFileDetailQuery = validator("query", (value, c) => {
   return parsed.data;
 });
 
+const validateProjectFileCatSegmentParams = validator("param", (value, c) => {
+  const parsed = projectFileCatSegmentParamsSchema.safeParse(value);
+
+  if (!parsed.success) {
+    return invalidProjectPayloadResponse(c);
+  }
+
+  return parsed.data;
+});
+
+const validateProjectFileCatSegmentQuery = validator("query", (value, c) => {
+  const parsed = projectFileCatSegmentQuerySchema.safeParse(value);
+
+  if (!parsed.success) {
+    return invalidProjectPayloadResponse(c);
+  }
+
+  return parsed.data;
+});
+
 const validateProjectFileCatQuery = validator("query", (value, c) => {
   const parsed = projectFileCatQuerySchema.safeParse(value);
 
@@ -638,6 +662,60 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
           }
 
           return c.json({ catFile }, 200);
+        } catch (error) {
+          return tmsProviderLiveErrorResponse(c, error);
+        }
+      },
+    )
+    .get(
+      "/:projectId/files/detail/cat/segments/:externalStringId",
+      validateProjectParams,
+      validateProjectFileCatSegmentParams,
+      validateProjectFileCatSegmentQuery,
+      async (c) => {
+        const params = c.req.valid("param");
+        const query = c.req.valid("query");
+        const target = await resolveProjectResourceTarget(c.var.auth, params.projectId);
+        if (target.kind === "provider_unavailable") {
+          return providerProjectUnavailableResponse(c, target);
+        }
+
+        if (target.kind !== "provider") {
+          const project = await getOwnedProject(c.var.auth, params.projectId);
+          if (!project) {
+            return projectNotFoundResponse(c);
+          }
+
+          const segment = await getNativeProjectCatSegmentDetail({
+            organizationId: c.var.auth.organization.localOrganizationId,
+            projectId: params.projectId,
+            sourcePath: query.sourcePath,
+            targetLocale: query.targetLocale,
+            externalStringId: params.externalStringId,
+            preferredRepositoryFullName: query.repositoryFullName ?? null,
+          });
+
+          if (!segment) {
+            return notFoundResponse(c, "cat_segment_not_found");
+          }
+
+          return c.json({ segment }, 200);
+        }
+
+        try {
+          const segment = await getTmsProviderLiveCatSegmentDetail(
+            c.var.auth.organization.localOrganizationId,
+            target.externalProjectId,
+            query.sourcePath,
+            query.targetLocale,
+            params.externalStringId,
+            { actorUserId: c.var.auth.user.localUserId },
+          );
+          if (!segment) {
+            return notFoundResponse(c, "cat_segment_not_found");
+          }
+
+          return c.json({ segment }, 200);
         } catch (error) {
           return tmsProviderLiveErrorResponse(c, error);
         }

--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -556,7 +556,25 @@ export const projectFileCatSegmentSchema = z.object({
   maxLength: z.number().int().positive().optional(),
   target: projectFileCatTranslationSchema.nullable(),
   comments: z.array(projectFileCatCommentSchema),
+  commentCount: z.number().int().min(0).optional(),
+  unresolvedIssueCount: z.number().int().min(0).optional(),
   repositoryContext: z.string().nullable().optional(),
+});
+
+export const projectFileCatSegmentParamsSchema = z.object({
+  organizationSlug: z.string().trim().min(1).max(128),
+  projectId: z.string().trim().min(1).max(128),
+  externalStringId: z.string().trim().min(1).max(128),
+});
+
+export const projectFileCatSegmentQuerySchema = z.object({
+  sourcePath: z.string().trim().min(1).max(2048),
+  targetLocale: z.string().trim().min(1).max(32),
+  repositoryFullName: z.string().trim().min(1).max(256).optional(),
+});
+
+export const projectFileCatSegmentResponseSchema = z.object({
+  segment: projectFileCatSegmentSchema,
 });
 
 export const projectFileCatResponseSchema = z.object({
@@ -624,6 +642,9 @@ export type ProjectFileCatCommentResolveResponse = z.infer<
 >;
 export type ProjectFileCatTranslation = z.infer<typeof projectFileCatTranslationSchema>;
 export type ProjectFileCatSegment = z.infer<typeof projectFileCatSegmentSchema>;
+export type ProjectFileCatSegmentParams = z.infer<typeof projectFileCatSegmentParamsSchema>;
+export type ProjectFileCatSegmentQuery = z.infer<typeof projectFileCatSegmentQuerySchema>;
+export type ProjectFileCatSegmentResponse = z.infer<typeof projectFileCatSegmentResponseSchema>;
 export type ProjectFileCatQueueSummary = z.infer<typeof projectFileCatQueueSummarySchema>;
 export type ProjectFileCatResponse = z.infer<typeof projectFileCatResponseSchema>;
 export type ProjectFileCatTranslationResponse = z.infer<

--- a/apps/hyperlocalise-web/src/components/cat/cat-queue-filter.ts
+++ b/apps/hyperlocalise-web/src/components/cat/cat-queue-filter.ts
@@ -61,6 +61,10 @@ export function isOpenIssueStatus(status: string | null | undefined) {
 }
 
 export function segmentHasOpenIssues(segment: CatSegment) {
+  if (segment.hasOpenIssues) {
+    return true;
+  }
+
   return (
     segment.comments?.some(
       (comment) => comment.type === "issue" && isOpenIssueStatus(comment.status),

--- a/apps/hyperlocalise-web/src/components/cat/project-file-cat-mapper.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file-cat-mapper.test.ts
@@ -106,6 +106,45 @@ describe("projectFileCatToWorkspaceState", () => {
     });
   });
 
+  it("ignores resolved issues when computing segment status and tags", () => {
+    const state = projectFileCatToWorkspaceState(
+      catFile({
+        segments: [
+          {
+            externalStringId: "resolved-issue-string",
+            key: "dashboard.title",
+            sourceText: "Dashboard",
+            context: null,
+            type: "text",
+            target: {
+              text: "Bang dieu khien",
+              externalTranslationId: "translation-2",
+              isApproved: false,
+            },
+            comments: [
+              {
+                externalCommentId: "comment-resolved",
+                type: "issue",
+                status: "resolved",
+                text: "Fixed wording",
+                createdAt: "2026-06-10T00:00:00.000Z",
+                locale: "vi",
+              },
+            ],
+          },
+        ],
+      }),
+      testIntl,
+    );
+
+    expect(state.segments[0]).toMatchObject({
+      id: "resolved-issue-string",
+      status: "needs_review",
+      hasOpenIssues: false,
+      tags: ["text", "1 comment"],
+    });
+  });
+
   it("uses Approve as the primary action label for native projects", () => {
     const state = projectFileCatToWorkspaceState(catFile({ provider: null }), testIntl);
 

--- a/apps/hyperlocalise-web/src/components/cat/project-file-cat-mapper.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file-cat-mapper.ts
@@ -20,8 +20,19 @@ import type {
   CatSegmentIntelligence,
   CatWorkspaceState,
 } from "@/components/cat/types";
+import { isOpenIssueStatus } from "@/components/cat/cat-queue-filter";
 
 type CatFile = ProjectFileCatResponse["catFile"];
+
+function countOpenIssues(segment: ProjectFileCatSegment) {
+  if (segment.comments.length > 0) {
+    return segment.comments.filter(
+      (comment) => comment.type === "issue" && isOpenIssueStatus(comment.status),
+    ).length;
+  }
+
+  return segment.unresolvedIssueCount ?? 0;
+}
 
 function mapSegmentComments(segment: ProjectFileCatSegment): CatSegmentComment[] {
   return segment.comments.map((comment) => ({
@@ -40,9 +51,7 @@ export function segmentStatusFor(segment: ProjectFileCatSegment): CatSegment["st
     return "reviewed";
   }
 
-  const hasUnresolvedIssue =
-    (segment.unresolvedIssueCount ?? 0) > 0 ||
-    segment.comments.some((comment) => comment.type === "issue");
+  const hasUnresolvedIssue = countOpenIssues(segment) > 0;
 
   if (hasUnresolvedIssue) {
     return "needs_review";
@@ -220,10 +229,7 @@ function segmentIntelligenceFor(
   segment: ProjectFileCatSegment,
 ): CatSegmentIntelligence {
   const comments = segment.comments.length || segment.commentCount || 0;
-  const issues =
-    segment.comments.filter((comment) => comment.type === "issue").length ||
-    segment.unresolvedIssueCount ||
-    0;
+  const issues = countOpenIssues(segment);
   const context = segment.context?.trim();
   const repositoryContext = segment.repositoryContext?.trim();
   const providerKind = catFile.provider?.kind;
@@ -266,10 +272,7 @@ export function projectFileCatToWorkspaceState(
   const segmentOffset = catFile.pagination?.offset ?? 0;
   const segments = catFile.segments.map((segment, index): CatSegment => {
     const commentCount = segment.comments.length || segment.commentCount || 0;
-    const issueComments =
-      segment.comments.filter((comment) => comment.type === "issue").length ||
-      segment.unresolvedIssueCount ||
-      0;
+    const issueComments = countOpenIssues(segment);
     const tags = [
       segment.type,
       commentCount > 0 ? `${commentCount} comment${commentCount === 1 ? "" : "s"}` : null,

--- a/apps/hyperlocalise-web/src/components/cat/project-file-cat-mapper.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file-cat-mapper.ts
@@ -40,7 +40,11 @@ export function segmentStatusFor(segment: ProjectFileCatSegment): CatSegment["st
     return "reviewed";
   }
 
-  if (segment.comments.some((comment) => comment.type === "issue")) {
+  const hasUnresolvedIssue =
+    (segment.unresolvedIssueCount ?? 0) > 0 ||
+    segment.comments.some((comment) => comment.type === "issue");
+
+  if (hasUnresolvedIssue) {
     return "needs_review";
   }
 
@@ -215,8 +219,11 @@ function segmentIntelligenceFor(
   catFile: CatFile,
   segment: ProjectFileCatSegment,
 ): CatSegmentIntelligence {
-  const comments = segment.comments.length;
-  const issues = segment.comments.filter((comment) => comment.type === "issue").length;
+  const comments = segment.comments.length || segment.commentCount || 0;
+  const issues =
+    segment.comments.filter((comment) => comment.type === "issue").length ||
+    segment.unresolvedIssueCount ||
+    0;
   const context = segment.context?.trim();
   const repositoryContext = segment.repositoryContext?.trim();
   const providerKind = catFile.provider?.kind;
@@ -258,11 +265,14 @@ export function projectFileCatToWorkspaceState(
   const sourceLocale = catFile.provider?.sourceLocale ?? "source";
   const segmentOffset = catFile.pagination?.offset ?? 0;
   const segments = catFile.segments.map((segment, index): CatSegment => {
-    const comments = segment.comments.length;
-    const issueComments = segment.comments.filter((comment) => comment.type === "issue").length;
+    const commentCount = segment.comments.length || segment.commentCount || 0;
+    const issueComments =
+      segment.comments.filter((comment) => comment.type === "issue").length ||
+      segment.unresolvedIssueCount ||
+      0;
     const tags = [
       segment.type,
-      comments > 0 ? `${comments} comment${comments === 1 ? "" : "s"}` : null,
+      commentCount > 0 ? `${commentCount} comment${commentCount === 1 ? "" : "s"}` : null,
       issueComments > 0 ? `${issueComments} issue${issueComments === 1 ? "" : "s"}` : null,
     ].filter((tag): tag is string => Boolean(tag));
 
@@ -276,6 +286,7 @@ export function projectFileCatToWorkspaceState(
       targetLocale: catFile.targetLocale,
       contextLabel: segment.context ?? undefined,
       status: segmentStatusFor(segment),
+      hasOpenIssues: issueComments > 0,
       tags,
       ...(segment.maxLength != null && segment.maxLength > 0
         ? { maxLength: segment.maxLength }
@@ -302,6 +313,52 @@ export function projectFileCatToWorkspaceState(
     canEditTranslations: catFile.canEditTranslations,
     canAddComments: Boolean(catFile.canEditTranslations),
     providerKind: catFile.provider?.kind ?? null,
+  };
+}
+
+export function applyCatSegmentDetailToWorkspaceState(
+  state: CatWorkspaceState,
+  catFile: CatFile,
+  segmentDetail: ProjectFileCatSegment,
+  intl: CatFormatMessageIntl,
+): CatWorkspaceState {
+  const mergedSegment = {
+    ...catFile.segments.find(
+      (segment) => segment.externalStringId === segmentDetail.externalStringId,
+    ),
+    ...segmentDetail,
+  };
+
+  if (!mergedSegment.externalStringId) {
+    return state;
+  }
+
+  const nextCatFile: CatFile = {
+    ...catFile,
+    segments: catFile.segments.map((segment) =>
+      segment.externalStringId === segmentDetail.externalStringId ? mergedSegment : segment,
+    ),
+  };
+  const detailState = projectFileCatToWorkspaceState(nextCatFile, intl);
+  const detailSegment = detailState.segments.find(
+    (segment) => segment.id === segmentDetail.externalStringId,
+  );
+
+  if (!detailSegment) {
+    return state;
+  }
+
+  return {
+    ...state,
+    segments: state.segments.map((segment) =>
+      segment.id === detailSegment.id ? detailSegment : segment,
+    ),
+    segmentIntelligence: {
+      ...state.segmentIntelligence,
+      [detailSegment.id]: detailState.segmentIntelligence?.[detailSegment.id] ?? {
+        ...state.intelligence,
+      },
+    },
   };
 }
 

--- a/apps/hyperlocalise-web/src/components/cat/project-file-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/project-file-cat-workspace.tsx
@@ -30,10 +30,12 @@ import { CatWorkspaceContainer } from "./cat-workspace-container";
 import { buildCatSegmentShareUrl } from "./cat-segment-share-link";
 import { resolveAvailableCatQueueFilters } from "./cat-queue-filter";
 import {
+  applyCatSegmentDetailToWorkspaceState,
   projectFileCatToWorkspaceState,
   requireProviderExternalResourceId,
   validateSegmentFormat,
 } from "./project-file-cat-mapper";
+import { useCatSegmentDetail, useInvalidateCatSegmentDetail } from "./use-cat-segment-detail";
 import { useCatSegmentQuery } from "./use-cat-segment-query";
 import type {
   CatGlossaryTerm,
@@ -75,6 +77,8 @@ export function ProjectFileCatWorkspace({
   className?: string;
 }) {
   const intl = useIntl();
+  const [activeSegmentId, setActiveSegmentId] = useState<string | null>(initialSegmentKey);
+  const invalidateSegmentDetail = useInvalidateCatSegmentDetail();
   const [targetLocaleState, setTargetLocaleState] = useState(
     () => targetLocaleProp ?? initialTargetLocale(targetLocales ?? [], highlightLocale),
   );
@@ -199,8 +203,16 @@ export function ProjectFileCatWorkspace({
       const body = (await response.json()) as { comment: ProjectFileCatComment };
       return body.comment;
     },
-    onSuccess: async () => {
+    onSuccess: async (_data, variables) => {
       await invalidateCurrentPage();
+      await invalidateSegmentDetail({
+        organizationSlug,
+        projectId,
+        sourcePath,
+        targetLocale,
+        externalStringId: variables.externalStringId,
+        repositoryFullName,
+      });
     },
   });
   const postComment = commentMutation.mutateAsync;
@@ -234,6 +246,16 @@ export function ProjectFileCatWorkspace({
     },
     onSuccess: async () => {
       await invalidateCurrentPage();
+      if (activeSegmentId) {
+        await invalidateSegmentDetail({
+          organizationSlug,
+          projectId,
+          sourcePath,
+          targetLocale,
+          externalStringId: activeSegmentId,
+          repositoryFullName,
+        });
+      }
     },
   });
   const resolveComment = resolveCommentMutation.mutateAsync;
@@ -242,6 +264,52 @@ export function ProjectFileCatWorkspace({
     () => (catQuery.data ? projectFileCatToWorkspaceState(catQuery.data, intl) : null),
     [catQuery.data, intl],
   );
+
+  useEffect(() => {
+    if (!workspaceState) {
+      return;
+    }
+
+    setActiveSegmentId((current) => {
+      if (current && workspaceState.segments.some((segment) => segment.id === current)) {
+        return current;
+      }
+
+      if (initialSegmentKey) {
+        const matched = workspaceState.segments.find(
+          (segment) => segment.id === initialSegmentKey || segment.key === initialSegmentKey,
+        );
+        if (matched) {
+          return matched.id;
+        }
+      }
+
+      return workspaceState.segments[0]?.id ?? null;
+    });
+  }, [initialSegmentKey, workspaceState]);
+
+  const segmentDetailQuery = useCatSegmentDetail({
+    organizationSlug,
+    projectId,
+    sourcePath,
+    targetLocale,
+    externalStringId: activeSegmentId,
+    repositoryFullName,
+    enabled: Boolean(catQuery.data),
+  });
+
+  const enrichedWorkspaceState = useMemo(() => {
+    if (!workspaceState || !catQuery.data || !segmentDetailQuery.data) {
+      return workspaceState;
+    }
+
+    return applyCatSegmentDetailToWorkspaceState(
+      workspaceState,
+      catQuery.data,
+      segmentDetailQuery.data,
+      intl,
+    );
+  }, [catQuery.data, intl, segmentDetailQuery.data, workspaceState]);
 
   const validateFormat = useCallback(
     (segment: CatSegment, value: string, glossaryTerms: CatGlossaryTerm[] = []) =>
@@ -483,7 +551,7 @@ export function ProjectFileCatWorkspace({
     );
   }
 
-  if (!workspaceState || workspaceState.segments.length === 0) {
+  if (!enrichedWorkspaceState || enrichedWorkspaceState.segments.length === 0) {
     return (
       <div className="flex min-h-0 flex-1 items-center justify-center text-muted-foreground">
         <TypographyP className="text-sm">
@@ -533,8 +601,13 @@ export function ProjectFileCatWorkspace({
 
       <CatWorkspaceContainer
         key={`${sourcePath}:${targetLocale}:${repositoryFullName ?? "default"}:${debouncedSearch}:${queueFilter}:${pagination?.offset ?? 0}`}
-        initialState={workspaceState}
+        initialState={enrichedWorkspaceState}
         className={cn("min-h-0 flex-1", isFullscreen && "rounded-lg border border-border")}
+        navigation={{
+          onSelectSegment: (segmentId) => {
+            setActiveSegmentId(segmentId);
+          },
+        }}
         services={{
           validateFormat,
           lookupSegmentConcordance,

--- a/apps/hyperlocalise-web/src/components/cat/project-file-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/project-file-cat-workspace.tsx
@@ -218,7 +218,7 @@ export function ProjectFileCatWorkspace({
   const postComment = commentMutation.mutateAsync;
 
   const resolveCommentMutation = useMutation({
-    mutationFn: async (input: { externalCommentId: string }) => {
+    mutationFn: async (input: { externalStringId: string; externalCommentId: string }) => {
       const externalResourceId = catQuery.data?.provider
         ? requireProviderExternalResourceId(catQuery.data)
         : undefined;
@@ -244,18 +244,16 @@ export function ProjectFileCatWorkspace({
       const body = (await response.json()) as { comment: ProjectFileCatComment };
       return body.comment;
     },
-    onSuccess: async () => {
+    onSuccess: async (_data, variables) => {
       await invalidateCurrentPage();
-      if (activeSegmentId) {
-        await invalidateSegmentDetail({
-          organizationSlug,
-          projectId,
-          sourcePath,
-          targetLocale,
-          externalStringId: activeSegmentId,
-          repositoryFullName,
-        });
-      }
+      await invalidateSegmentDetail({
+        organizationSlug,
+        projectId,
+        sourcePath,
+        targetLocale,
+        externalStringId: variables.externalStringId,
+        repositoryFullName,
+      });
     },
   });
   const resolveComment = resolveCommentMutation.mutateAsync;
@@ -368,12 +366,12 @@ export function ProjectFileCatWorkspace({
   );
 
   const handleResolveComment = useCallback(
-    async (_segmentId: string, commentId: string) => {
+    async (segmentId: string, commentId: string) => {
       if (!catQuery.data?.canEditTranslations) {
         throw new Error("Your role cannot resolve issues in the provider.");
       }
 
-      await resolveComment({ externalCommentId: commentId });
+      await resolveComment({ externalStringId: segmentId, externalCommentId: commentId });
     },
     [catQuery.data?.canEditTranslations, resolveComment],
   );

--- a/apps/hyperlocalise-web/src/components/cat/project-file-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/project-file-cat-workspace.tsx
@@ -77,7 +77,7 @@ export function ProjectFileCatWorkspace({
   className?: string;
 }) {
   const intl = useIntl();
-  const [activeSegmentId, setActiveSegmentId] = useState<string | null>(initialSegmentKey);
+  const [activeSegmentId, setActiveSegmentId] = useState<string | null>(null);
   const invalidateSegmentDetail = useInvalidateCatSegmentDetail();
   const [targetLocaleState, setTargetLocaleState] = useState(
     () => targetLocaleProp ?? initialTargetLocale(targetLocales ?? [], highlightLocale),

--- a/apps/hyperlocalise-web/src/components/cat/types.ts
+++ b/apps/hyperlocalise-web/src/components/cat/types.ts
@@ -42,6 +42,7 @@ export interface CatSegment {
   targetLocale: string;
   contextLabel?: string;
   status: CatSegmentStatus;
+  hasOpenIssues?: boolean;
   tags?: string[];
   maxLength?: number;
   comments?: CatSegmentComment[];

--- a/apps/hyperlocalise-web/src/components/cat/use-cat-segment-detail.ts
+++ b/apps/hyperlocalise-web/src/components/cat/use-cat-segment-detail.ts
@@ -1,0 +1,116 @@
+"use client";
+
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+import type { ProjectFileCatSegment } from "@/api/routes/project/project.schema";
+import { readApiError } from "@/lib/api-error";
+import { apiClient } from "@/lib/api-client-instance";
+
+export function projectFileCatSegmentDetailQueryKey(input: {
+  organizationSlug: string;
+  projectId: string;
+  sourcePath: string;
+  targetLocale: string;
+  externalStringId: string;
+  repositoryFullName: string | null;
+}) {
+  return [
+    "project-file-cat-segment-detail",
+    input.organizationSlug,
+    input.projectId,
+    input.sourcePath,
+    input.targetLocale,
+    input.externalStringId,
+    input.repositoryFullName,
+  ] as const;
+}
+
+export async function fetchProjectFileCatSegmentDetail(input: {
+  organizationSlug: string;
+  projectId: string;
+  sourcePath: string;
+  targetLocale: string;
+  externalStringId: string;
+  repositoryFullName: string | null;
+}) {
+  const response = await apiClient.api.orgs[":organizationSlug"].projects[
+    ":projectId"
+  ].files.detail.cat.segments[":externalStringId"].$get({
+    param: {
+      organizationSlug: input.organizationSlug,
+      projectId: input.projectId,
+      externalStringId: input.externalStringId,
+    },
+    query: {
+      sourcePath: input.sourcePath,
+      targetLocale: input.targetLocale,
+      ...(input.repositoryFullName ? { repositoryFullName: input.repositoryFullName } : {}),
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(await readApiError(response, "Failed to load segment details"));
+  }
+
+  const body = (await response.json()) as { segment: ProjectFileCatSegment };
+  return body.segment;
+}
+
+export function useCatSegmentDetail(input: {
+  organizationSlug: string;
+  projectId: string;
+  sourcePath: string;
+  targetLocale: string;
+  externalStringId: string | null;
+  repositoryFullName?: string | null;
+  enabled?: boolean;
+}) {
+  const repositoryFullName = input.repositoryFullName ?? null;
+  const externalStringId = input.externalStringId ?? "";
+
+  return useQuery({
+    queryKey: projectFileCatSegmentDetailQueryKey({
+      organizationSlug: input.organizationSlug,
+      projectId: input.projectId,
+      sourcePath: input.sourcePath,
+      targetLocale: input.targetLocale,
+      externalStringId,
+      repositoryFullName,
+    }),
+    enabled:
+      input.enabled !== false &&
+      Boolean(input.externalStringId) &&
+      Boolean(input.targetLocale) &&
+      Boolean(input.sourcePath),
+    staleTime: 30_000,
+    queryFn: () =>
+      fetchProjectFileCatSegmentDetail({
+        organizationSlug: input.organizationSlug,
+        projectId: input.projectId,
+        sourcePath: input.sourcePath,
+        targetLocale: input.targetLocale,
+        externalStringId,
+        repositoryFullName,
+      }),
+  });
+}
+
+export function useInvalidateCatSegmentDetail() {
+  const queryClient = useQueryClient();
+
+  return async (input: {
+    organizationSlug: string;
+    projectId: string;
+    sourcePath: string;
+    targetLocale: string;
+    externalStringId: string;
+    repositoryFullName?: string | null;
+  }) => {
+    await queryClient.invalidateQueries({
+      queryKey: projectFileCatSegmentDetailQueryKey({
+        ...input,
+        repositoryFullName: input.repositoryFullName ?? null,
+      }),
+    });
+  };
+}

--- a/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-comment-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-comment-service.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, inArray } from "drizzle-orm";
+import { and, asc, eq, inArray, sql } from "drizzle-orm";
 
 import type { ProjectFileCatComment } from "@/api/routes/project/project.schema";
 import { db, schema } from "@/lib/database";
@@ -129,6 +129,60 @@ export class NativeCatCommentService extends ProjectServiceBase {
     }
 
     return commentsByKeyId;
+  }
+
+  async countByKeyIds(input: {
+    organizationId: string;
+    projectId: string;
+    translationKeyIds: string[];
+    targetLocale: string;
+  }) {
+    if (input.translationKeyIds.length === 0) {
+      return new Map<string, { commentCount: number; unresolvedIssueCount: number }>();
+    }
+
+    const rows = await this.database
+      .select({
+        translationKeyId: schema.projectTranslationComments.translationKeyId,
+        type: schema.projectTranslationComments.type,
+        status: schema.projectTranslationComments.status,
+        count: sql<number>`count(*)::int`,
+      })
+      .from(schema.projectTranslationComments)
+      .where(
+        and(
+          eq(schema.projectTranslationComments.organizationId, input.organizationId),
+          eq(schema.projectTranslationComments.projectId, input.projectId),
+          eq(schema.projectTranslationComments.targetLocale, input.targetLocale),
+          inArray(schema.projectTranslationComments.translationKeyId, input.translationKeyIds),
+        ),
+      )
+      .groupBy(
+        schema.projectTranslationComments.translationKeyId,
+        schema.projectTranslationComments.type,
+        schema.projectTranslationComments.status,
+      );
+
+    const countsByKeyId = new Map<string, { commentCount: number; unresolvedIssueCount: number }>();
+
+    for (const row of rows) {
+      const existing = countsByKeyId.get(row.translationKeyId) ?? {
+        commentCount: 0,
+        unresolvedIssueCount: 0,
+      };
+      existing.commentCount += row.count;
+
+      if (
+        row.type === "issue" &&
+        (row.status === "open" || row.status === "unresolved" || row.status === null)
+      ) {
+        existing.unresolvedIssueCount += row.count;
+      }
+
+      countsByKeyId.set(row.translationKeyId, existing);
+    }
+
+    return countsByKeyId;
   }
 
   async save(input: {

--- a/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-service.test.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-service.test.ts
@@ -11,7 +11,7 @@ describe("NativeCatService.getCatFile", () => {
   const listKeysForFile = vi.fn();
   const countKeysForFile = vi.fn();
   const getTranslationsByKeyIds = vi.fn();
-  const listCommentsByKeyIds = vi.fn();
+  const countCommentsByKeyIds = vi.fn();
   const listCached = vi.fn();
 
   let service: NativeCatService;
@@ -20,7 +20,7 @@ describe("NativeCatService.getCatFile", () => {
     vi.clearAllMocks();
     getRepositorySourceFileByPath.mockResolvedValue({ id: "file_1" });
     getTranslationsByKeyIds.mockResolvedValue([]);
-    listCommentsByKeyIds.mockResolvedValue(new Map());
+    countCommentsByKeyIds.mockResolvedValue(new Map());
     countKeysForFile.mockImplementation(async (input) => {
       if (input.queueFilter === "reviewed") {
         return 45;
@@ -49,7 +49,7 @@ describe("NativeCatService.getCatFile", () => {
     } as unknown as ProjectStringContextService;
 
     const comments = {
-      listByKeyIds: listCommentsByKeyIds,
+      countByKeyIds: countCommentsByKeyIds,
     } as unknown as NativeCatCommentService;
 
     service = new NativeCatService(undefined as never, translations, stringContext, comments);

--- a/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-service.ts
@@ -2,6 +2,7 @@ import { and, eq } from "drizzle-orm";
 
 import type {
   ProjectFileCatResponse,
+  ProjectFileCatSegment,
   ProjectFileCatTranslation,
 } from "@/api/routes/project/project.schema";
 import { legacyNativeCatSegmentLimit } from "@/api/routes/project/project.schema";
@@ -158,14 +159,14 @@ export class NativeCatService extends ProjectServiceBase {
     queueSummary: Awaited<ReturnType<typeof countNativeFileQueueSummary>>;
   }): Promise<ProjectFileCatResponse["catFile"]> {
     const translationKeyIds = input.visibleKeys.map((key) => key.id);
-    const [translations, comments] = await Promise.all([
+    const [translations, commentCounts] = await Promise.all([
       this.translations.getTranslationsByKeyIds({
         organizationId: input.input.organizationId,
         projectId: input.input.projectId,
         translationKeyIds,
         targetLocale: input.input.targetLocale,
       }),
-      this.comments.listByKeyIds({
+      this.comments.countByKeyIds({
         organizationId: input.input.organizationId,
         projectId: input.input.projectId,
         translationKeyIds,
@@ -187,6 +188,7 @@ export class NativeCatService extends ProjectServiceBase {
       queueSummary: input.queueSummary,
       segments: input.visibleKeys.map((key) => {
         const translation = translationByKeyId.get(key.id);
+        const counts = commentCounts.get(key.id);
         return {
           externalStringId: key.id,
           key: key.key,
@@ -195,7 +197,13 @@ export class NativeCatService extends ProjectServiceBase {
           type: key.type,
           ...(key.maxLength != null && key.maxLength > 0 ? { maxLength: key.maxLength } : {}),
           target: translation ? toCatTranslation(translation) : null,
-          comments: comments.get(key.id) ?? [],
+          comments: [],
+          ...(counts
+            ? {
+                commentCount: counts.commentCount,
+                unresolvedIssueCount: counts.unresolvedIssueCount,
+              }
+            : {}),
         };
       }),
     };
@@ -355,6 +363,99 @@ export class NativeCatService extends ProjectServiceBase {
     return updated ? toCatTranslation(updated) : null;
   }
 
+  async getSegmentDetail(input: {
+    organizationId: string;
+    projectId: string;
+    sourcePath: string;
+    targetLocale: string;
+    externalStringId: string;
+    preferredRepositoryFullName?: string | null;
+  }): Promise<ProjectFileCatSegment | null> {
+    const sourceFile = await this.translations.getRepositorySourceFileByPath({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      sourcePath: input.sourcePath,
+    });
+
+    if (!sourceFile) {
+      return null;
+    }
+
+    const [key] = await this.database
+      .select({
+        id: schema.projectTranslationKeys.id,
+        key: schema.projectTranslationKeys.key,
+        sourceText: schema.projectTranslationKeys.sourceText,
+        context: schema.projectTranslationKeys.context,
+        type: schema.projectTranslationKeys.type,
+        maxLength: schema.projectTranslationKeys.maxLength,
+      })
+      .from(schema.projectTranslationKeys)
+      .where(
+        and(
+          eq(schema.projectTranslationKeys.id, input.externalStringId),
+          eq(schema.projectTranslationKeys.organizationId, input.organizationId),
+          eq(schema.projectTranslationKeys.projectId, input.projectId),
+          eq(schema.projectTranslationKeys.repositorySourceFileId, sourceFile.id),
+        ),
+      )
+      .limit(1);
+
+    if (!key) {
+      return null;
+    }
+
+    const [translations, commentsByKeyId] = await Promise.all([
+      this.translations.getTranslationsByKeyIds({
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        translationKeyIds: [key.id],
+        targetLocale: input.targetLocale,
+      }),
+      this.comments.listByKeyIds({
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        translationKeyIds: [key.id],
+        targetLocale: input.targetLocale,
+      }),
+    ]);
+
+    const translation = translations[0];
+    const comments = commentsByKeyId.get(key.id) ?? [];
+    const segment: ProjectFileCatSegment = {
+      externalStringId: key.id,
+      key: key.key,
+      sourceText: key.sourceText,
+      context: key.context,
+      type: key.type,
+      ...(key.maxLength != null && key.maxLength > 0 ? { maxLength: key.maxLength } : {}),
+      target: translation ? toCatTranslation(translation) : null,
+      comments,
+      commentCount: comments.length,
+      unresolvedIssueCount: comments.filter(
+        (comment) =>
+          comment.type === "issue" &&
+          (comment.status === "open" || comment.status === "unresolved"),
+      ).length,
+    };
+
+    const cachedSummaries = await this.stringContext.listCached({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      sourcePath: input.sourcePath,
+      stringKeys: [key.key],
+      preferredRepositoryFullName: input.preferredRepositoryFullName,
+      sourceTextByKey: new Map([[key.key, key.sourceText]]),
+    });
+
+    const repositoryContext = cachedSummaries.get(key.key);
+    if (repositoryContext) {
+      segment.repositoryContext = repositoryContext;
+    }
+
+    return segment;
+  }
+
   async attachAgentContexts(input: {
     organizationId: string;
     projectId: string;
@@ -425,6 +526,10 @@ export const nativeCatService = new NativeCatService();
 
 export const getNativeProjectCatFile = (input: Parameters<NativeCatService["getCatFile"]>[0]) =>
   nativeCatService.getCatFile(input);
+
+export const getNativeProjectCatSegmentDetail = (
+  input: Parameters<NativeCatService["getSegmentDetail"]>[0],
+) => nativeCatService.getSegmentDetail(input);
 
 export const saveNativeProjectCatTranslation = (
   input: Parameters<NativeCatService["saveTranslation"]>[0],

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
@@ -589,6 +589,25 @@ describe("CrowdinApiClient", () => {
     await client.listStringCommentsForStrings(1, [1001], { type: "comment" });
   });
 
+  it("lists string comments scoped to targetLanguageId", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      const path = String(url);
+      expect(path).toContain("/projects/1/comments?");
+      expect(path).toContain("stringId=1001");
+      expect(path).toContain("type=issue");
+      expect(path).toContain("targetLanguageId=fr");
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    await client.listStringComments(1, {
+      stringId: 1001,
+      type: "issue",
+      issueStatus: "unresolved",
+      targetLanguageId: "fr",
+    });
+  });
+
   it("lists translation approvals with fileId and languageId", async () => {
     const fetchMock = vi.fn(async (url) => {
       const path = String(url);

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
@@ -838,6 +838,7 @@ export class CrowdinApiClient {
       stringId?: number;
       type?: "comment" | "issue";
       issueStatus?: "resolved" | "unresolved";
+      targetLanguageId?: string;
     },
   ): Promise<CrowdinStringComment[]> {
     const params = new URLSearchParams();
@@ -849,6 +850,9 @@ export class CrowdinApiClient {
     }
     if (options?.issueStatus) {
       params.set("issueStatus", options.issueStatus);
+    }
+    if (options?.targetLanguageId) {
+      params.set("targetLanguageId", options.targetLanguageId);
     }
 
     const query = params.toString();

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-live-cat.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-live-cat.test.ts
@@ -57,7 +57,7 @@ describe("buildPhraseLiveCatFile", () => {
     vi.clearAllMocks();
   });
 
-  it("loads a single key file with source, target, and comments", async () => {
+  it("loads a single key file with source and target without comments", async () => {
     const fetchMock = vi.fn(async (url: string) => {
       const path = String(url);
 
@@ -157,12 +157,109 @@ describe("buildPhraseLiveCatFile", () => {
         externalTranslationId: "tr-fr",
         isApproved: true,
       },
-      comments: [{ externalCommentId: "comment-1", type: "comment", text: "Check tone" }],
+      comments: [],
     });
     expect(catFile.queueSummary).toMatchObject({
       total: 1,
       reviewed: 1,
-      hasIssues: 1,
+      hasIssues: 0,
+    });
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      expect.stringContaining("/keys/key-1/comments"),
+      expect.anything(),
+    );
+  });
+
+  it("loads comments from the segment detail endpoint", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      const path = String(url);
+
+      if (path.includes("/locales")) {
+        return new Response(
+          JSON.stringify([
+            { id: "loc-en", name: "en", code: "en-US", default: true },
+            { id: "loc-fr", name: "fr", code: "fr-FR", default: false },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      if (
+        path.includes("/keys/key-1") &&
+        !path.includes("/comments") &&
+        !path.includes("/translations")
+      ) {
+        return new Response(
+          JSON.stringify({
+            id: "key-1",
+            name: "home.hero.title",
+            description: "Hero headline",
+            plural: false,
+            tags: ["app"],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/keys/key-1/translations")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "tr-en",
+              key_id: "key-1",
+              locale_name: "en",
+              content: "Hello",
+              state: "translated",
+              unverified: false,
+              excluded: false,
+            },
+            {
+              id: "tr-fr",
+              key_id: "key-1",
+              locale_name: "fr",
+              content: "Bonjour",
+              state: "translated",
+              unverified: false,
+              excluded: false,
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/keys/key-1/comments")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: "comment-1",
+              message: "Check tone",
+              has_replies: false,
+              user: { id: "user-1", username: "reviewer", name: "Reviewer" },
+              created_at: "2026-06-08T00:01:00Z",
+              locales: [{ id: "loc-fr", name: "fr", code: "fr-FR" }],
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify([]), { status: 200 });
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const { getPhraseLiveCatSegmentDetail } = await import("./phrase-live-cat");
+    const segment = await getPhraseLiveCatSegmentDetail({
+      secretMaterial: "token",
+      externalProjectId: "project-1",
+      file: createPhraseKeyFile(),
+      targetLocale: "fr",
+      externalStringId: "key-1",
+    });
+
+    expect(segment).toMatchObject({
+      externalStringId: "key-1",
+      comments: [{ externalCommentId: "comment-1", type: "comment", text: "Check tone" }],
+      commentCount: 1,
     });
   });
 
@@ -386,15 +483,16 @@ describe("buildPhraseLiveCatFile", () => {
     });
     globalThis.fetch = fetchMock as typeof fetch;
 
-    const catFile = await buildPhraseLiveCatFile({
+    const { getPhraseLiveCatSegmentDetail } = await import("./phrase-live-cat");
+    const segment = await getPhraseLiveCatSegmentDetail({
       secretMaterial: "token",
       externalProjectId: "project-1",
       file: createPhraseKeyFile(),
       targetLocale: "fr",
-      canEditTranslations: true,
+      externalStringId: "key-1",
     });
 
-    expect(catFile.segments[0]?.comments[0]?.createdAt).toBeNull();
+    expect(segment?.comments[0]?.createdAt).toBeNull();
   });
 });
 

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-live-cat.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/phrase/phrase-live-cat.ts
@@ -2,6 +2,7 @@ import type {
   ProjectFileCatComment,
   ProjectFileCatQueueSummary,
   ProjectFileCatResponse,
+  ProjectFileCatSegment,
   ProjectFileCatTranslation,
 } from "@/api/routes/project/project.schema";
 import { legacyProviderCatSegmentLimit } from "@/api/routes/project/project.schema";
@@ -30,7 +31,6 @@ import {
 import { createPhraseStringsApiClient } from "./phrase-strings-client";
 
 const LOCALE_FETCH_CONCURRENCY = 8;
-const COMMENT_FETCH_CONCURRENCY = 8;
 
 export class PhraseLiveCatError extends Error {
   constructor(
@@ -400,33 +400,13 @@ export async function buildPhraseLiveCatFile(input: {
     keyIds,
   });
 
-  const commentsByKeyId = new Map<string, ProjectFileCatComment[]>();
-  await mapWithConcurrency(scopedKeys, COMMENT_FETCH_CONCURRENCY, async (key) => {
-    try {
-      const comments = await client.listKeyComments(scope.stringsProjectId, key.id, listOptions);
-      if (comments.length === 0) {
-        return;
-      }
-
-      commentsByKeyId.set(
-        key.id,
-        comments.map((comment) => mapPhraseKeyComment(comment, input.targetLocale)),
-      );
-    } catch (error) {
-      if (error instanceof PhraseApiError && error.status === 404) {
-        return;
-      }
-      mapPhraseApiError(error);
-    }
-  });
-
   const allSegments = buildSegmentDrafts({
     keys: scopedKeys,
     sourceLocale,
     targetLocale,
     targetLocaleCode: input.targetLocale,
     translationsByKeyId,
-    commentsByKeyId,
+    commentsByKeyId: new Map(),
   });
 
   const paginationInput = input.pagination ?? {
@@ -458,7 +438,10 @@ export async function buildPhraseLiveCatFile(input: {
       canEditTranslations: input.canEditTranslations,
       truncated,
       queueSummary,
-      segments: visibleSegments,
+      segments: visibleSegments.map((segment) => ({
+        ...segment,
+        comments: [],
+      })),
     };
   }
 
@@ -482,7 +465,107 @@ export async function buildPhraseLiveCatFile(input: {
     truncated: pagination.hasMore,
     pagination,
     queueSummary,
-    segments: pageSegments,
+    segments: pageSegments.map((segment) => ({
+      ...segment,
+      comments: [],
+    })),
+  };
+}
+
+export async function getPhraseLiveCatSegmentDetail(input: {
+  secretMaterial: string;
+  region?: string | null;
+  baseUrl?: string | null;
+  externalProjectId: string;
+  file: TmsProviderLiveFile;
+  targetLocale: string;
+  externalStringId: string;
+}): Promise<ProjectFileCatSegment | null> {
+  const scope = resolvePhraseLiveCatContext({
+    file: input.file,
+    externalProjectId: input.externalProjectId,
+    secretMaterial: input.secretMaterial,
+    region: input.region,
+    baseUrl: input.baseUrl,
+  });
+  const client = createPhraseStringsApiClient({
+    token: scope.token,
+    region: scope.region,
+    baseUrl: scope.baseUrl,
+  });
+  const listOptions = scope.branch ? { branch: scope.branch } : {};
+
+  let locales: PhraseLocale[];
+  try {
+    locales = await client.listLocales(scope.stringsProjectId, listOptions);
+  } catch (error) {
+    mapPhraseApiError(error);
+  }
+
+  const sourceLocale = locales.find((locale) => locale.default) ?? null;
+  const targetLocale = resolvePhraseTargetLocale(input.targetLocale, locales);
+  const localeNames = new Set(
+    [sourceLocale, targetLocale]
+      .filter((locale): locale is PhraseLocale => locale != null)
+      .map((locale) => locale.name),
+  );
+
+  let key: PhraseKey | null;
+  try {
+    key = await client.getKey(scope.stringsProjectId, input.externalStringId, listOptions);
+  } catch (error) {
+    if (error instanceof PhraseApiError && error.status === 404) {
+      return null;
+    }
+    mapPhraseApiError(error);
+  }
+
+  if (!key) {
+    return null;
+  }
+
+  const translationsByKeyId = await loadTranslationsByKeyId({
+    client,
+    projectId: scope.stringsProjectId,
+    localeNames,
+    branch: scope.branch,
+    keyIds: [key.id],
+  });
+
+  let comments: ProjectFileCatComment[] = [];
+  try {
+    const remoteComments = await client.listKeyComments(
+      scope.stringsProjectId,
+      key.id,
+      listOptions,
+    );
+    comments = remoteComments.map((comment) => mapPhraseKeyComment(comment, input.targetLocale));
+  } catch (error) {
+    if (!(error instanceof PhraseApiError && error.status === 404)) {
+      mapPhraseApiError(error);
+    }
+  }
+
+  const translationsByLocale = translationsByKeyId.get(key.id);
+  const sourceTranslation = sourceLocale ? translationsByLocale?.get(sourceLocale.name) : null;
+  const segment = buildSegmentDrafts({
+    keys: [key],
+    sourceLocale,
+    targetLocale,
+    targetLocaleCode: input.targetLocale,
+    translationsByKeyId,
+    commentsByKeyId: new Map([[key.id, comments]]),
+  })[0];
+
+  if (!segment) {
+    return null;
+  }
+
+  return {
+    ...segment,
+    sourceText: sourceTranslation?.content?.trim() || segment.sourceText,
+    commentCount: comments.length,
+    unresolvedIssueCount: 0,
   };
 }
 

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live-cat.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live-cat.test.ts
@@ -84,7 +84,7 @@ describe("getTmsProviderLiveCatFile", () => {
     await fixture.cleanup();
   });
 
-  it("aggregates Crowdin strings, target translations, approvals, and unresolved comments", async () => {
+  it("aggregates Crowdin strings, target translations, approvals, and unresolved issue flags", async () => {
     const { organization, user } = await fixture.createLocalWorkosIdentity(
       fixture.createWorkosIdentityWithRole("admin"),
     );
@@ -172,6 +172,34 @@ describe("getTmsProviderLiveCatFile", () => {
                   labelIds: null,
                 },
               },
+              {
+                data: {
+                  id: 1002,
+                  projectId: 42,
+                  fileId: 101,
+                  branchId: null,
+                  directoryId: null,
+                  identifier: "hero.cta",
+                  text: { one: "Start", other: "Start all" },
+                  type: "text",
+                  context: null,
+                  labelIds: null,
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (
+        path.includes("/projects/42/strings?") &&
+        path.includes("croql=") &&
+        path.includes("has+unresolved+issue")
+      ) {
+        return new Response(
+          JSON.stringify({
+            data: [
               {
                 data: {
                   id: 1002,
@@ -303,22 +331,22 @@ describe("getTmsProviderLiveCatFile", () => {
       key: "hero.title",
       sourceText: "Hello",
       target: { text: "Bonjour", externalTranslationId: "9001", isApproved: true },
-      comments: [{ externalCommentId: "501", type: "comment" }],
+      comments: [],
     });
     expect(catFile?.segments[1]).toMatchObject({
       externalStringId: "1002",
       sourceText: JSON.stringify({ one: "Start", other: "Start all" }),
       target: null,
-      comments: [{ externalCommentId: "502", type: "issue", status: "unresolved" }],
+      comments: [],
+      unresolvedIssueCount: 1,
     });
     const requestedPaths = fetchMock.mock.calls.map(([url]) => String(url));
     expect(
       requestedPaths.some(
         (path) =>
-          path.includes("/projects/42/comments?") &&
-          path.includes("stringId=1001") &&
-          path.includes("type=comment") &&
-          !path.includes("languageId="),
+          path.includes("/projects/42/strings?") &&
+          path.includes("croql=") &&
+          path.includes("has+unresolved+issue"),
       ),
     ).toBe(true);
     expect(
@@ -333,12 +361,10 @@ describe("getTmsProviderLiveCatFile", () => {
       requestedPaths.some(
         (path) =>
           path.includes("/projects/42/comments?") &&
-          path.includes("stringId=1002") &&
-          path.includes("type=issue") &&
-          !path.includes("languageId=") &&
-          path.includes("issueStatus=unresolved"),
+          path.includes("stringId=1001") &&
+          path.includes("type=comment"),
       ),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it("prefers approved Crowdin translations over newer unapproved suggestions", async () => {
@@ -1005,21 +1031,25 @@ describe("getTmsProviderLiveCatFile", () => {
     // buildCrowdinLiveCatFile currently issues parallel count + page requests; croql/fileId
     // assertions above guard the regression regardless of how many calls are made.
     expect(stringsRequests.length).toBeGreaterThanOrEqual(1);
-    expect(queueSummaryCroqls.sort()).toEqual(
-      [
-        buildCrowdinFileQueueCroql({ fileId: 101, targetLocale: "fr", queueFilter: "reviewed" }),
-        buildCrowdinFileQueueCroql({
-          fileId: 101,
-          targetLocale: "fr",
-          queueFilter: "untranslated",
-        }),
-        buildCrowdinFileQueueCroql({
-          fileId: 101,
-          targetLocale: "fr",
-          queueFilter: "needs_review",
-        }),
-        buildCrowdinFileQueueCroql({ fileId: 101, targetLocale: "fr", queueFilter: "has_issues" }),
-      ].sort(),
-    );
+    const expectedQueueSummaryCroqls = [
+      buildCrowdinFileQueueCroql({ fileId: 101, targetLocale: "fr", queueFilter: "reviewed" }),
+      buildCrowdinFileQueueCroql({ fileId: 101, targetLocale: "fr", queueFilter: "untranslated" }),
+      buildCrowdinFileQueueCroql({ fileId: 101, targetLocale: "fr", queueFilter: "needs_review" }),
+      buildCrowdinFileQueueCroql({ fileId: 101, targetLocale: "fr", queueFilter: "has_issues" }),
+    ];
+    for (const croql of expectedQueueSummaryCroqls) {
+      expect(queueSummaryCroqls).toContain(croql);
+    }
+    expect(
+      queueSummaryCroqls.filter(
+        (croql) =>
+          croql ===
+          buildCrowdinFileQueueCroql({
+            fileId: 101,
+            targetLocale: "fr",
+            queueFilter: "has_issues",
+          }),
+      ).length,
+    ).toBeGreaterThanOrEqual(2);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live-cat.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live-cat.test.ts
@@ -9,7 +9,11 @@ import { upsertCrowdinUserPatConnection } from "@/lib/providers/adapters/crowdin
 import { buildCrowdinFileQueueCroql } from "@/lib/providers/adapters/crowdin/crowdin-croql";
 import { isErr } from "@/lib/primitives/result/results";
 import { upsertCrowdinPatProviderCredential } from "./organization-external-tms-provider-credentials";
-import { getTmsProviderLiveCatFile, saveTmsProviderLiveCatTranslation } from "./tms-provider-live";
+import {
+  getTmsProviderLiveCatFile,
+  getTmsProviderLiveCatSegmentDetail,
+  saveTmsProviderLiveCatTranslation,
+} from "./tms-provider-live";
 
 const fixture = createAuthTestFixture();
 
@@ -1051,5 +1055,223 @@ describe("getTmsProviderLiveCatFile", () => {
           }),
       ).length,
     ).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("getTmsProviderLiveCatSegmentDetail", () => {
+  let originalFetch: typeof fetch;
+
+  beforeAll(async () => {
+    await db.$client.query("select 1");
+  });
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = originalFetch;
+    vi.clearAllMocks();
+    await fixture.cleanup();
+  });
+
+  it("scopes Crowdin comments and unresolved issues to the requested target locale", async () => {
+    const { organization, user } = await fixture.createLocalWorkosIdentity(
+      fixture.createWorkosIdentityWithRole("admin"),
+    );
+    await setupCrowdinPatCredential({
+      organizationId: organization.id,
+      userId: user.id,
+    });
+
+    const commentRequests: string[] = [];
+    const fetchMock = vi.fn(async (url) => {
+      const path = String(url);
+
+      if (isCrowdinGetProjectRequest(path)) {
+        return mockCrowdinProject42Response();
+      }
+
+      if (path.includes("/projects/42/branches?")) {
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }
+
+      if (path.includes("/projects/42/directories?")) {
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }
+
+      if (path.includes("/projects/42/files?")) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  id: 101,
+                  branchId: null,
+                  directoryId: null,
+                  name: "home.json",
+                  title: "home.json",
+                  type: "json",
+                  path: "/home.json",
+                  status: "active",
+                  revisionId: 7,
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/projects/42/strings?") && path.includes("croql=")) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  id: 1001,
+                  projectId: 42,
+                  fileId: 101,
+                  branchId: null,
+                  directoryId: null,
+                  identifier: "hero.title",
+                  text: "Hello",
+                  type: "text",
+                  context: "Hero",
+                  labelIds: null,
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/projects/42/languages/fr/translations?")) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  stringId: 1001,
+                  contentType: "text",
+                  translationId: 9001,
+                  text: "Bonjour",
+                  createdAt: "2026-06-08T00:00:00Z",
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/projects/42/approvals?") && path.includes("stringId=1001")) {
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }
+
+      if (path.includes("/projects/42/comments?")) {
+        commentRequests.push(path);
+
+        if (path.includes("type=comment")) {
+          return new Response(
+            JSON.stringify({
+              data: [
+                {
+                  data: {
+                    id: 501,
+                    text: "French note",
+                    userId: 1,
+                    stringId: 1001,
+                    languageId: "fr",
+                    type: "comment",
+                    createdAt: "2026-06-08T00:01:00Z",
+                    projectId: 42,
+                  },
+                },
+                {
+                  data: {
+                    id: 502,
+                    text: "German note",
+                    userId: 1,
+                    stringId: 1001,
+                    languageId: "de",
+                    type: "comment",
+                    createdAt: "2026-06-08T00:02:00Z",
+                    projectId: 42,
+                  },
+                },
+              ],
+            }),
+            { status: 200 },
+          );
+        }
+
+        if (path.includes("type=issue")) {
+          return new Response(
+            JSON.stringify({
+              data: [
+                {
+                  data: {
+                    id: 601,
+                    text: "French issue",
+                    userId: 1,
+                    stringId: 1001,
+                    languageId: "fr",
+                    type: "issue",
+                    issueStatus: "unresolved",
+                    createdAt: "2026-06-08T00:03:00Z",
+                    projectId: 42,
+                  },
+                },
+                {
+                  data: {
+                    id: 602,
+                    text: "German issue",
+                    userId: 1,
+                    stringId: 1001,
+                    languageId: "de",
+                    type: "issue",
+                    issueStatus: "unresolved",
+                    createdAt: "2026-06-08T00:04:00Z",
+                    projectId: 42,
+                  },
+                },
+              ],
+            }),
+            { status: 200 },
+          );
+        }
+      }
+
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const segment = await getTmsProviderLiveCatSegmentDetail(
+      organization.id,
+      "42",
+      "home.json",
+      "fr",
+      "1001",
+      { actorUserId: user.id },
+    );
+
+    expect(segment).toMatchObject({
+      externalStringId: "1001",
+      key: "hero.title",
+      unresolvedIssueCount: 1,
+    });
+    expect(segment?.comments).toHaveLength(2);
+    expect(segment?.comments.map((comment) => comment.locale)).toEqual(["fr", "fr"]);
+    expect(segment?.comments.map((comment) => comment.text)).toEqual([
+      "French issue",
+      "French note",
+    ]);
+    expect(commentRequests).toHaveLength(2);
+    for (const path of commentRequests) {
+      expect(path).toContain("targetLanguageId=fr");
+      expect(path).toContain("stringId=1001");
+    }
   });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
@@ -4,6 +4,7 @@ import { schema } from "@/lib/database";
 import type {
   ProjectFileCatComment,
   ProjectFileCatResponse,
+  ProjectFileCatSegment,
   ProjectFileCatTranslation,
   ProjectFileContent,
   ProjectFileDetailResponse,
@@ -40,6 +41,7 @@ import {
 } from "@/lib/providers/adapters/phrase/phrase-user-connections";
 import {
   buildPhraseLiveCatFile,
+  getPhraseLiveCatSegmentDetail,
   PhraseLiveCatError,
   savePhraseLiveCatComment,
   savePhraseLiveCatTranslation,
@@ -935,30 +937,6 @@ function preferredLanguageTranslation(
   return sortTranslationsByNewest(withText)[0] ?? null;
 }
 
-function relevantCrowdinCatComments(input: {
-  comments: CrowdinStringComment[];
-  stringIds: Set<number>;
-  targetLocale: string;
-}): Map<number, CrowdinStringComment[]> {
-  const commentsByStringId = new Map<number, CrowdinStringComment[]>();
-
-  for (const comment of input.comments) {
-    if (!input.stringIds.has(comment.stringId)) {
-      continue;
-    }
-
-    if (comment.languageId && comment.languageId !== input.targetLocale) {
-      continue;
-    }
-
-    const comments = commentsByStringId.get(comment.stringId) ?? [];
-    comments.push(comment);
-    commentsByStringId.set(comment.stringId, comments);
-  }
-
-  return commentsByStringId;
-}
-
 async function countCrowdinSourceStrings(
   client: CrowdinApiClient,
   projectId: number,
@@ -992,6 +970,41 @@ async function countCrowdinSourceStrings(
   }
 
   return Math.min(total, ceiling);
+}
+
+async function loadCrowdinStringIdsWithUnresolvedIssues(
+  client: CrowdinApiClient,
+  projectId: number,
+  fileId: number,
+) {
+  const croql = buildCrowdinFileQueueCroql({
+    fileId,
+    targetLocale: "en",
+    queueFilter: "has_issues",
+  });
+  const stringIds = new Set<number>();
+  let offset = 0;
+  const limit = 500;
+
+  while (true) {
+    const page = await client.listSourceStringsPage(projectId, {
+      croql,
+      offset,
+      limit,
+    });
+
+    for (const sourceString of page.strings) {
+      stringIds.add(sourceString.id);
+    }
+
+    if (!page.hasMore || page.strings.length === 0) {
+      break;
+    }
+
+    offset += page.strings.length;
+  }
+
+  return stringIds;
 }
 
 async function buildCrowdinLiveCatFile(input: {
@@ -1080,7 +1093,6 @@ async function buildCrowdinLiveCatFile(input: {
     }
 
     const sourceStringIds = visibleStrings.map((sourceString) => sourceString.id);
-    const sourceStringIdSet = new Set(sourceStringIds);
 
     const queueSummaryPromise = countCrowdinFileQueueSummary(
       client,
@@ -1115,19 +1127,10 @@ async function buildCrowdinLiveCatFile(input: {
     const approvals = await approvalsPromise;
     const approvedTranslationIds = new Set(approvals.map((approval) => approval.translationId));
 
-    const [queueSummary, plainComments, unresolvedIssues] = await Promise.all([
+    const [queueSummary, unresolvedIssueStringIds] = await Promise.all([
       queueSummaryPromise,
-      client.listStringCommentsForStrings(projectId, sourceStringIds, { type: "comment" }),
-      client.listStringCommentsForStrings(projectId, sourceStringIds, {
-        type: "issue",
-        issueStatus: "unresolved",
-      }),
+      loadCrowdinStringIdsWithUnresolvedIssues(client, projectId, fileId),
     ]);
-    const commentsByStringId = relevantCrowdinCatComments({
-      comments: [...plainComments, ...unresolvedIssues],
-      stringIds: sourceStringIdSet,
-      targetLocale: input.targetLocale,
-    });
 
     return {
       sourcePath: input.file.sourcePath,
@@ -1143,6 +1146,7 @@ async function buildCrowdinLiveCatFile(input: {
           translationsByStringId.get(sourceString.id) ?? [],
           approvedTranslationIds,
         );
+        const hasUnresolvedIssue = unresolvedIssueStringIds.has(sourceString.id);
         return {
           externalStringId: String(sourceString.id),
           key: sourceString.identifier,
@@ -1158,15 +1162,99 @@ async function buildCrowdinLiveCatFile(input: {
                   target.translationId != null && approvedTranslationIds.has(target.translationId),
               }
             : null,
-          comments: (commentsByStringId.get(sourceString.id) ?? [])
-            .toSorted((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
-            .map((comment) => mapCrowdinStringComment(comment)),
+          comments: [],
+          ...(hasUnresolvedIssue ? { unresolvedIssueCount: 1 } : {}),
         };
       }),
     };
   } catch (error) {
     if (error instanceof CrowdinApiError && error.status === 401) {
       throw new TmsProviderLiveError("crowdin_auth_invalid", "Crowdin credentials are invalid.");
+    }
+
+    throw error;
+  }
+}
+
+async function buildCrowdinLiveCatSegmentDetail(input: {
+  context: ActiveTmsProviderContext;
+  file: TmsProviderLiveFile;
+  targetLocale: string;
+  externalStringId: string;
+}): Promise<ProjectFileCatSegment | null> {
+  const projectId = Number(input.file.provider?.externalProjectId);
+  const fileId = Number(input.file.provider?.externalResourceId);
+  const stringId = Number(input.externalStringId);
+  if (Number.isNaN(projectId) || Number.isNaN(fileId) || Number.isNaN(stringId)) {
+    throw new TmsProviderLiveError(
+      "invalid_crowdin_project_or_file_id",
+      "Crowdin project or file identifier is invalid.",
+    );
+  }
+
+  const client = new CrowdinApiClient({
+    token: input.context.secretMaterial,
+    baseUrl: input.context.credential.baseUrl ?? undefined,
+  });
+
+  try {
+    const [sourceStringPage, translations, approvals, plainComments, unresolvedIssues] =
+      await Promise.all([
+        client.listSourceStringsPage(projectId, {
+          croql: `id = ${stringId}`,
+          offset: 0,
+          limit: 1,
+        }),
+        client.listLanguageTranslations(projectId, input.targetLocale, {
+          stringIds: [stringId],
+        }),
+        client.listTranslationApprovals(projectId, input.targetLocale, { stringId }),
+        client.listStringComments(projectId, { stringId, type: "comment" }),
+        client.listStringComments(projectId, {
+          stringId,
+          type: "issue",
+          issueStatus: "unresolved",
+        }),
+      ]);
+
+    const sourceString = sourceStringPage.strings[0];
+    if (!sourceString) {
+      return null;
+    }
+
+    const approvedTranslationIds = new Set(approvals.map((approval) => approval.translationId));
+    const target = preferredLanguageTranslation(translations, approvedTranslationIds);
+    const comments = [...plainComments, ...unresolvedIssues]
+      .toSorted((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+      .map((comment) => mapCrowdinStringComment(comment));
+
+    return {
+      externalStringId: String(sourceString.id),
+      key: sourceString.identifier,
+      sourceText: crowdinCatSourceTextValue(sourceString.text),
+      context: sourceString.context,
+      type: sourceString.type ?? null,
+      target: target?.text
+        ? {
+            text: target.text,
+            externalTranslationId:
+              target.translationId != null ? String(target.translationId) : null,
+            isApproved:
+              target.translationId != null && approvedTranslationIds.has(target.translationId),
+          }
+        : null,
+      comments,
+      commentCount: comments.length,
+      unresolvedIssueCount: unresolvedIssues.length,
+    };
+  } catch (error) {
+    if (error instanceof CrowdinApiError) {
+      if (error.status === 401) {
+        throw new TmsProviderLiveError("crowdin_auth_invalid", "Crowdin credentials are invalid.");
+      }
+      if (error.status === 404) {
+        return null;
+      }
     }
 
     throw error;
@@ -1821,6 +1909,58 @@ export async function getTmsProviderLiveCatFile(
     targetLocale,
     canEditTranslations: options?.canEditTranslations ?? false,
     pagination: options?.pagination,
+  });
+}
+
+export async function getTmsProviderLiveCatSegmentDetail(
+  organizationId: string,
+  externalProjectId: string,
+  sourcePath: string,
+  targetLocale: string,
+  externalStringId: string,
+  options?: { actorUserId?: string | null },
+): Promise<ProjectFileCatSegment | null> {
+  const context = await loadActiveTmsProviderContext(organizationId, {
+    actorUserId: options?.actorUserId,
+  });
+  const file = await resolveLiveCatFile({
+    organizationId,
+    externalProjectId,
+    sourcePath,
+    context,
+  });
+  if (!file) {
+    return null;
+  }
+
+  if (!supportsLiveProviderCat(context.providerKind, file)) {
+    throw new TmsProviderLiveError(
+      "provider_cat_unsupported",
+      "CAT editing is not available for this provider file yet.",
+    );
+  }
+
+  if (context.providerKind === "phrase") {
+    try {
+      return await getPhraseLiveCatSegmentDetail({
+        secretMaterial: context.secretMaterial,
+        region: context.credential.region,
+        baseUrl: context.credential.baseUrl,
+        externalProjectId,
+        file,
+        targetLocale,
+        externalStringId,
+      });
+    } catch (error) {
+      mapPhraseLiveCatError(error);
+    }
+  }
+
+  return buildCrowdinLiveCatSegmentDetail({
+    context,
+    file,
+    targetLocale,
+    externalStringId,
   });
 }
 

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
@@ -976,10 +976,11 @@ async function loadCrowdinStringIdsWithUnresolvedIssues(
   client: CrowdinApiClient,
   projectId: number,
   fileId: number,
+  targetLocale: string,
 ) {
   const croql = buildCrowdinFileQueueCroql({
     fileId,
-    targetLocale: "en",
+    targetLocale,
     queueFilter: "has_issues",
   });
   const stringIds = new Set<number>();
@@ -1129,7 +1130,7 @@ async function buildCrowdinLiveCatFile(input: {
 
     const [queueSummary, unresolvedIssueStringIds] = await Promise.all([
       queueSummaryPromise,
-      loadCrowdinStringIdsWithUnresolvedIssues(client, projectId, fileId),
+      loadCrowdinStringIdsWithUnresolvedIssues(client, projectId, fileId, input.targetLocale),
     ]);
 
     return {

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
@@ -919,6 +919,13 @@ function sortTranslationsByNewest(
   });
 }
 
+function crowdinCatCommentsForTargetLocale(
+  comments: CrowdinStringComment[],
+  targetLocale: string,
+): CrowdinStringComment[] {
+  return comments.filter((comment) => !comment.languageId || comment.languageId === targetLocale);
+}
+
 function preferredLanguageTranslation(
   translations: CrowdinLanguageTranslation[],
   approvedTranslationIds: ReadonlySet<number>,
@@ -1210,11 +1217,16 @@ async function buildCrowdinLiveCatSegmentDetail(input: {
           stringIds: [stringId],
         }),
         client.listTranslationApprovals(projectId, input.targetLocale, { stringId }),
-        client.listStringComments(projectId, { stringId, type: "comment" }),
+        client.listStringComments(projectId, {
+          stringId,
+          type: "comment",
+          targetLanguageId: input.targetLocale,
+        }),
         client.listStringComments(projectId, {
           stringId,
           type: "issue",
           issueStatus: "unresolved",
+          targetLanguageId: input.targetLocale,
         }),
       ]);
 
@@ -1225,7 +1237,15 @@ async function buildCrowdinLiveCatSegmentDetail(input: {
 
     const approvedTranslationIds = new Set(approvals.map((approval) => approval.translationId));
     const target = preferredLanguageTranslation(translations, approvedTranslationIds);
-    const comments = [...plainComments, ...unresolvedIssues]
+    const localePlainComments = crowdinCatCommentsForTargetLocale(
+      plainComments,
+      input.targetLocale,
+    );
+    const localeUnresolvedIssues = crowdinCatCommentsForTargetLocale(
+      unresolvedIssues,
+      input.targetLocale,
+    );
+    const comments = [...localePlainComments, ...localeUnresolvedIssues]
       .toSorted((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
       .map((comment) => mapCrowdinStringComment(comment));
 
@@ -1246,7 +1266,7 @@ async function buildCrowdinLiveCatSegmentDetail(input: {
         : null,
       comments,
       commentCount: comments.length,
-      unresolvedIssueCount: unresolvedIssues.length,
+      unresolvedIssueCount: localeUnresolvedIssues.length,
     };
   } catch (error) {
     if (error instanceof CrowdinApiError) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Splits CAT file loading from per-segment detail fetching so the list endpoint returns slim segment rows and comments load lazily when a string is selected.

## Review fixes

- Pass real `targetLocale` to Crowdin unresolved-issue CROQL lookup
- Initialize `activeSegmentId` to `null` to avoid spurious detail requests on share links
- Count only open/unresolved issues in the CAT segment mapper (not resolved issues)
- Scope Crowdin segment detail comments/issues to the requested target locale via `targetLanguageId` API filter and client-side locale guard
- Invalidate resolved-comment segment detail from mutation variables (`externalStringId`), not `activeSegmentId`

## Testing

- `vp test` (CAT-related suites)
- `vp check --fix`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-582990ef-5f00-4f1b-a7a6-8efca41f74d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-582990ef-5f00-4f1b-a7a6-8efca41f74d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

