### PR TITLE
feat(web): lazy-load TMS job detail tabs and projects section

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/org-tms-query-provider.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/org-tms-query-provider.tsx
@@ -6,10 +6,9 @@ import { useQuery } from "@tanstack/react-query";
 import {
   activeTmsProviderQueryKey,
   fetchActiveTmsProviderConnection,
+  TMS_PROVIDER_CONNECTION_STALE_TIME_MS,
   type ActiveTmsProviderConnection,
 } from "../_hooks/use-active-tms-provider";
-
-const TMS_PROVIDER_CONNECTION_STALE_TIME_MS = 60_000;
 
 export function OrgTmsQueryProvider({
   children,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/org-tms-query-provider.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/org-tms-query-provider.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  activeTmsProviderQueryKey,
+  fetchActiveTmsProviderConnection,
+  type ActiveTmsProviderConnection,
+} from "../_hooks/use-active-tms-provider";
+
+const TMS_PROVIDER_CONNECTION_STALE_TIME_MS = 60_000;
+
+export function OrgTmsQueryProvider({
+  children,
+  initialTmsProviderConnection,
+  organizationSlug,
+}: {
+  children: ReactNode;
+  initialTmsProviderConnection: ActiveTmsProviderConnection | null;
+  organizationSlug: string;
+}) {
+  useQuery({
+    queryKey: activeTmsProviderQueryKey(organizationSlug),
+    queryFn: () => fetchActiveTmsProviderConnection(organizationSlug),
+    initialData: initialTmsProviderConnection,
+    staleTime: TMS_PROVIDER_CONNECTION_STALE_TIME_MS,
+  });
+
+  return children;
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/tms-live-project-picker.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_components/tms-live-project-picker.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+import { useTmsLiveProjects } from "../_hooks/use-tms-live-projects";
+import { WorkspaceFilterField, workspaceFilterTriggerClassName } from "./workspace-resource-shared";
+
+export function TmsLiveProjectPicker({
+  organizationSlug,
+  value,
+  onValueChange,
+  disabled = false,
+}: {
+  organizationSlug: string;
+  value: string;
+  onValueChange: (externalProjectId: string) => void;
+  disabled?: boolean;
+}) {
+  const tmsProjectsQuery = useTmsLiveProjects(organizationSlug);
+  const projects = (tmsProjectsQuery.data ?? []).filter(
+    (project) => project.isActive !== false && project.externalProjectId,
+  );
+
+  return (
+    <WorkspaceFilterField label="TMS project" className="w-full sm:max-w-sm">
+      <Select
+        value={value || null}
+        onValueChange={(nextValue) => onValueChange(nextValue ?? "")}
+        disabled={disabled || tmsProjectsQuery.isLoading}
+      >
+        <SelectTrigger className={workspaceFilterTriggerClassName}>
+          <SelectValue
+            placeholder={tmsProjectsQuery.isLoading ? "Loading projects…" : "Select a project"}
+          />
+        </SelectTrigger>
+        <SelectContent>
+          {projects.map((project) => (
+            <SelectItem
+              key={project.externalProjectId!}
+              value={project.externalProjectId!}
+              label={project.name}
+            >
+              {project.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </WorkspaceFilterField>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_hooks/use-active-tms-provider.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_hooks/use-active-tms-provider.ts
@@ -16,26 +16,33 @@ export function activeTmsProviderQueryKey(organizationSlug: string) {
   return ["tms-provider-connection", organizationSlug] as const;
 }
 
-export function useActiveTmsProvider(organizationSlug: string) {
+export async function fetchActiveTmsProviderConnection(
+  organizationSlug: string,
+): Promise<ActiveTmsProviderConnection | null> {
+  const response = await apiClient.api.orgs[":organizationSlug"]["tms-provider"].connection.$get({
+    param: { organizationSlug },
+  });
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    throw new Error(`Failed to load TMS connection (${response.status})`);
+  }
+
+  const body = (await response.json()) as { connection: ActiveTmsProviderConnection };
+  return body.connection;
+}
+
+export function useActiveTmsProvider(
+  organizationSlug: string,
+  options?: { initialData?: ActiveTmsProviderConnection | null },
+) {
   return useQuery({
     queryKey: activeTmsProviderQueryKey(organizationSlug),
-    queryFn: async (): Promise<ActiveTmsProviderConnection | null> => {
-      const response = await apiClient.api.orgs[":organizationSlug"][
-        "tms-provider"
-      ].connection.$get({
-        param: { organizationSlug },
-      });
-
-      if (response.status === 404) {
-        return null;
-      }
-
-      if (!response.ok) {
-        throw new Error(`Failed to load TMS connection (${response.status})`);
-      }
-
-      const body = (await response.json()) as { connection: ActiveTmsProviderConnection };
-      return body.connection;
-    },
+    queryFn: () => fetchActiveTmsProviderConnection(organizationSlug),
+    initialData: options?.initialData,
+    staleTime: options?.initialData !== undefined ? 60_000 : undefined,
   });
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_hooks/use-active-tms-provider.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_hooks/use-active-tms-provider.ts
@@ -12,6 +12,8 @@ export type ActiveTmsProviderConnection = {
   validationMessage: string | null;
 };
 
+export const TMS_PROVIDER_CONNECTION_STALE_TIME_MS = 60_000;
+
 export function activeTmsProviderQueryKey(organizationSlug: string) {
   return ["tms-provider-connection", organizationSlug] as const;
 }
@@ -43,6 +45,6 @@ export function useActiveTmsProvider(
     queryKey: activeTmsProviderQueryKey(organizationSlug),
     queryFn: () => fetchActiveTmsProviderConnection(organizationSlug),
     initialData: options?.initialData,
-    staleTime: options?.initialData !== undefined ? 60_000 : undefined,
+    staleTime: TMS_PROVIDER_CONNECTION_STALE_TIME_MS,
   });
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_hooks/use-tms-live-projects.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_hooks/use-tms-live-projects.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { apiClient } from "@/lib/api-client-instance";
+import { readTmsProviderListResponse } from "@/lib/providers/tms-provider-list-fetch";
+
+import type { ApiProject } from "../projects/_components/project-list";
+import { useActiveTmsProvider } from "./use-active-tms-provider";
+
+export const tmsLiveProjectsQueryKey = (organizationSlug: string) =>
+  ["translation-projects", organizationSlug, "tms-live"] as const;
+
+export async function fetchTmsLiveProjects(organizationSlug: string) {
+  const response = await apiClient.api.orgs[":organizationSlug"]["tms-provider"].projects.$get({
+    param: { organizationSlug },
+  });
+
+  return readTmsProviderListResponse<ApiProject>(
+    response,
+    "projects",
+    "Failed to load TMS projects",
+  );
+}
+
+export function useTmsLiveProjects(organizationSlug: string, options?: { enabled?: boolean }) {
+  const activeTmsProviderQuery = useActiveTmsProvider(organizationSlug);
+  const hasConnection = Boolean(activeTmsProviderQuery.data);
+  const enabled = (options?.enabled ?? true) && hasConnection;
+
+  return useQuery({
+    queryKey: tmsLiveProjectsQueryKey(organizationSlug),
+    enabled,
+    queryFn: () => fetchTmsLiveProjects(organizationSlug),
+  });
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/glossaries/_components/glossaries-page-content.tsx
@@ -28,10 +28,13 @@ import {
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { Textarea } from "@/components/ui/textarea";
+import { TypographyP } from "@/components/ui/typography";
 import { readApiError, readApiResponseError } from "@/lib/api-error";
 import { apiClient } from "@/lib/api-client-instance";
 
 import { useActiveTmsProvider } from "../../_hooks/use-active-tms-provider";
+
+import { TmsLiveProjectPicker } from "../../_components/tms-live-project-picker";
 
 import {
   GLOSSARY_SYNC_FILTERS,
@@ -227,6 +230,7 @@ export function GlossariesPageContent({
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [createForm, setCreateForm] = useState<GlossaryCreateForm>(() => createEmptyGlossaryForm());
   const [createErrors, setCreateErrors] = useState<{ name?: string; targetLocales?: string }>({});
+  const [selectedExternalProjectId, setSelectedExternalProjectId] = useState("");
   const {
     filters,
     searchQuery,
@@ -248,6 +252,7 @@ export function GlossariesPageContent({
 
   const projectsQuery = useQuery({
     queryKey: projectsQueryKey(organizationSlug),
+    enabled: !useLiveProviderGlossaries,
     queryFn: async () => {
       const response = await apiClient.api.orgs[":organizationSlug"].projects.$get({
         param: { organizationSlug },
@@ -264,6 +269,7 @@ export function GlossariesPageContent({
 
   const credentialsQuery = useQuery({
     queryKey: credentialsQueryKey(organizationSlug),
+    enabled: !useLiveProviderGlossaries,
     queryFn: async () => {
       const response = await apiClient.api.orgs[":organizationSlug"][
         "external-tms-provider-credential"
@@ -284,14 +290,18 @@ export function GlossariesPageContent({
     queryKey: [
       ...glossariesQueryKey(organizationSlug, page, filters),
       useLiveProviderGlossaries ? "live" : "native",
+      selectedExternalProjectId,
     ],
+    enabled: !useLiveProviderGlossaries || Boolean(selectedExternalProjectId),
     queryFn: async () => {
       if (useLiveProviderGlossaries && activeTmsProvider) {
         const response = await apiClient.api.orgs[":organizationSlug"][
           "tms-provider"
         ].glossaries.$get({
           param: { organizationSlug },
-          query: {},
+          query: {
+            externalProjectId: selectedExternalProjectId,
+          },
         });
 
         if (!response.ok) {
@@ -412,7 +422,11 @@ export function GlossariesPageContent({
 
   useEffect(() => {
     setPage(1);
-  }, [organizationSlug, filters]);
+  }, [organizationSlug, filters, selectedExternalProjectId]);
+
+  useEffect(() => {
+    setSelectedExternalProjectId("");
+  }, [organizationSlug, useLiveProviderGlossaries]);
 
   useEffect(() => {
     if (glossariesQuery.isSuccess && page > totalPages) {
@@ -424,7 +438,11 @@ export function GlossariesPageContent({
   const connectedCredentials = (credentialsQuery.data ?? []).filter(
     (credential) => credential.validationStatus === "connected",
   );
-  const hasConnectedProvider = credentialsQuery.isSuccess && connectedCredentials.length > 0;
+  const hasConnectedProvider = useLiveProviderGlossaries
+    ? Boolean(activeTmsProvider)
+    : credentialsQuery.isSuccess && connectedCredentials.length > 0;
+
+  const liveProjectSelectionRequired = useLiveProviderGlossaries && !selectedExternalProjectId;
 
   const emptyTitle = hasConnectedProvider ? "No glossaries yet" : "Connect a TMS provider";
   const emptyDescription = hasConnectedProvider
@@ -472,6 +490,16 @@ export function GlossariesPageContent({
           ) : null
         }
       />
+
+      {useLiveProviderGlossaries ? (
+        <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end sm:gap-2">
+          <TmsLiveProjectPicker
+            organizationSlug={organizationSlug}
+            value={selectedExternalProjectId}
+            onValueChange={setSelectedExternalProjectId}
+          />
+        </div>
+      ) : null}
 
       {glossariesQuery.isSuccess && (glossaryTotal > 0 || hasActiveFilters) ? (
         <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end sm:gap-2">
@@ -637,28 +665,42 @@ export function GlossariesPageContent({
         </div>
       ) : null}
 
-      <GlossariesTable
-        glossaries={glossaries}
-        glossariesQuery={glossariesQuery}
-        organizationSlug={organizationSlug}
-        emptyTitle={allowCreateGlossaries ? "No glossaries yet" : emptyTitle}
-        emptyDescription={
-          allowCreateGlossaries
-            ? "Create a workspace glossary, import terms, then assign it to the projects that should use it."
-            : emptyDescription
-        }
-        emptyAction={
-          allowCreateGlossaries ? (
-            <Button type="button" size="sm" onClick={() => setCreateDialogOpen(true)}>
-              Create glossary
-            </Button>
-          ) : (
-            <GlossariesEmptyAction organizationSlug={organizationSlug} />
-          )
-        }
-      />
+      {liveProjectSelectionRequired ? (
+        <div className="space-y-3 py-10">
+          <TypographyP className="text-sm font-medium text-foreground">
+            Choose a TMS project
+          </TypographyP>
+          <TypographyP className="max-w-xl text-sm leading-6 text-foreground/52">
+            Select a project above to load live glossaries and term bases from your connected
+            provider.
+          </TypographyP>
+        </div>
+      ) : (
+        <GlossariesTable
+          glossaries={glossaries}
+          glossariesQuery={glossariesQuery}
+          organizationSlug={organizationSlug}
+          emptyTitle={allowCreateGlossaries ? "No glossaries yet" : emptyTitle}
+          emptyDescription={
+            allowCreateGlossaries
+              ? "Create a workspace glossary, import terms, then assign it to the projects that should use it."
+              : emptyDescription
+          }
+          emptyAction={
+            allowCreateGlossaries ? (
+              <Button type="button" size="sm" onClick={() => setCreateDialogOpen(true)}>
+                Create glossary
+              </Button>
+            ) : (
+              <GlossariesEmptyAction organizationSlug={organizationSlug} />
+            )
+          }
+        />
+      )}
 
-      {glossariesQuery.isSuccess && glossaryTotal > GLOSSARIES_PAGE_SIZE ? (
+      {!liveProjectSelectionRequired &&
+      glossariesQuery.isSuccess &&
+      glossaryTotal > GLOSSARIES_PAGE_SIZE ? (
         <div className="flex flex-wrap items-center justify-between gap-2">
           <p className="text-sm text-foreground/52">
             Showing {pageStart}–{pageEnd} of {glossaryTotal} glossaries

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-page-content.tsx
@@ -5,7 +5,7 @@ import { useCallback, useMemo, useRef, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { File01Icon, Upload01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
 import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
@@ -26,7 +26,6 @@ import { ProjectFileDetailPanel } from "./project-file-detail-panel";
 import { ProjectFilesErrorBoundary } from "./project-files-error-boundary";
 import {
   ProjectFilesTreePanel,
-  fetchProjectFiles,
   projectFilesQueryKey,
   sortFilesByPath,
 } from "./project-files-tree-panel";
@@ -139,6 +138,7 @@ export function ProjectFilesPageContent({
   const searchParams = useSearchParams();
   const queryClient = useQueryClient();
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+  const [loadedFiles, setLoadedFiles] = useState<ProjectFileRecord[]>([]);
 
   const selectedSourcePath = searchParams.get("sourcePath");
   const highlightLocale = searchParams.get("locale");
@@ -204,14 +204,7 @@ export function ProjectFilesPageContent({
     setSelectedFiles((currentFiles) => currentFiles.filter((item) => item !== file));
   }, []);
 
-  const cachedFilesQuery = useQuery({
-    queryKey: projectFilesQueryKey(organizationSlug, projectId),
-    queryFn: () => fetchProjectFiles(organizationSlug, projectId),
-  });
-  const resolvedFiles = useMemo(
-    () => sortFilesByPath(cachedFilesQuery.data ?? []),
-    [cachedFilesQuery.data],
-  );
+  const resolvedFiles = useMemo(() => sortFilesByPath(loadedFiles), [loadedFiles]);
 
   return (
     <ProjectFilesPageContentView
@@ -235,6 +228,7 @@ export function ProjectFilesPageContent({
           projectId={projectId}
           selectedSourcePath={selectedSourcePath}
           onSelectSourcePath={setSelectedSourcePath}
+          onLoadedFilesChange={setLoadedFiles}
         />
       }
     />

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree-panel.tsx
@@ -130,31 +130,61 @@ export function ProjectFilesTreePanel({
 }) {
   const queryClient = useQueryClient();
   const [fileLimit, setFileLimit] = useState(PROJECT_FILES_PAGE_SIZE);
-  const queryKey = projectFilesQueryKey(organizationSlug, projectId, fileLimit);
+  const [autoAdvanceExhausted, setAutoAdvanceExhausted] = useState(false);
+  const fetchLimit = Math.min(fileLimit + 1, PROJECT_FILES_MAX_LIMIT);
+  const queryKey = projectFilesQueryKey(organizationSlug, projectId, fetchLimit);
   const filesQuery = useQuery({
     queryKey,
-    queryFn: () => fetchProjectFiles(organizationSlug, projectId, fileLimit),
+    queryFn: () => fetchProjectFiles(organizationSlug, projectId, fetchLimit),
   });
 
-  const files = useMemo(() => sortFilesByPath(filesQuery.data ?? []), [filesQuery.data]);
-  const hasMoreFiles = files.length >= fileLimit && fileLimit < PROJECT_FILES_MAX_LIMIT;
+  const fetchedFiles = filesQuery.data ?? [];
+  const hasMoreFiles = fetchedFiles.length > fileLimit && fileLimit < PROJECT_FILES_MAX_LIMIT;
+  const files = useMemo(
+    () => sortFilesByPath(fetchedFiles.slice(0, fileLimit)),
+    [fetchedFiles, fileLimit],
+  );
+
+  useEffect(() => {
+    setAutoAdvanceExhausted(false);
+  }, [selectedSourcePath]);
 
   useEffect(() => {
     onLoadedFilesChange?.(files);
   }, [files, onLoadedFilesChange]);
 
   useEffect(() => {
-    if (!selectedSourcePath || filesQuery.isLoading || filesQuery.isFetching) {
+    if (
+      autoAdvanceExhausted ||
+      !selectedSourcePath ||
+      filesQuery.isLoading ||
+      filesQuery.isFetching
+    ) {
       return;
     }
 
     const selectedFileLoaded = files.some((file) => file.sourcePath === selectedSourcePath);
-    if (!selectedFileLoaded && hasMoreFiles) {
-      setFileLimit((currentLimit) =>
-        Math.min(currentLimit + PROJECT_FILES_PAGE_SIZE, PROJECT_FILES_MAX_LIMIT),
-      );
+    if (selectedFileLoaded) {
+      return;
     }
-  }, [files, filesQuery.isFetching, filesQuery.isLoading, hasMoreFiles, selectedSourcePath]);
+
+    if (!hasMoreFiles || fileLimit >= PROJECT_FILES_MAX_LIMIT) {
+      setAutoAdvanceExhausted(true);
+      return;
+    }
+
+    setFileLimit((currentLimit) =>
+      Math.min(currentLimit + PROJECT_FILES_PAGE_SIZE, PROJECT_FILES_MAX_LIMIT),
+    );
+  }, [
+    autoAdvanceExhausted,
+    fileLimit,
+    files,
+    filesQuery.isFetching,
+    filesQuery.isLoading,
+    hasMoreFiles,
+    selectedSourcePath,
+  ]);
 
   const invalidateFiles = () => {
     void queryClient.invalidateQueries({

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree-panel.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/files/_components/project-files-tree-panel.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
+import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { TypographyP } from "@/components/ui/typography";
 import { readApiResponseError } from "@/lib/api-error";
@@ -13,12 +14,21 @@ import { ProjectSectionTitle } from "../../_components/project-page-shell";
 import { ProjectFilesErrorBoundary } from "./project-files-error-boundary";
 import { ProjectFilesTree } from "./project-files-tree";
 
-export function projectFilesQueryKey(organizationSlug: string, projectId: string) {
-  return ["project-files", organizationSlug, projectId] as const;
+export const PROJECT_FILES_PAGE_SIZE = 50;
+export const PROJECT_FILES_MAX_LIMIT = 1_000;
+
+export function projectFilesQueryKey(organizationSlug: string, projectId: string, limit?: number) {
+  return limit === undefined
+    ? (["project-files", organizationSlug, projectId] as const)
+    : (["project-files", organizationSlug, projectId, limit] as const);
 }
 
-export async function fetchProjectFiles(organizationSlug: string, projectId: string) {
-  const response = await fetch(`${apiPath(organizationSlug, projectId)}?limit=500`, {
+export async function fetchProjectFiles(
+  organizationSlug: string,
+  projectId: string,
+  limit: number = PROJECT_FILES_PAGE_SIZE,
+) {
+  const response = await fetch(`${apiPath(organizationSlug, projectId)}?limit=${limit}`, {
     method: "GET",
   });
 
@@ -110,20 +120,47 @@ export function ProjectFilesTreePanel({
   projectId,
   selectedSourcePath,
   onSelectSourcePath,
+  onLoadedFilesChange,
 }: {
   organizationSlug: string;
   projectId: string;
   selectedSourcePath: string | null;
   onSelectSourcePath: (sourcePath: string | null) => void;
+  onLoadedFilesChange?: (files: ProjectFileRecord[]) => void;
 }) {
   const queryClient = useQueryClient();
-  const queryKey = projectFilesQueryKey(organizationSlug, projectId);
+  const [fileLimit, setFileLimit] = useState(PROJECT_FILES_PAGE_SIZE);
+  const queryKey = projectFilesQueryKey(organizationSlug, projectId, fileLimit);
   const filesQuery = useQuery({
     queryKey,
-    queryFn: () => fetchProjectFiles(organizationSlug, projectId),
+    queryFn: () => fetchProjectFiles(organizationSlug, projectId, fileLimit),
   });
 
   const files = useMemo(() => sortFilesByPath(filesQuery.data ?? []), [filesQuery.data]);
+  const hasMoreFiles = files.length >= fileLimit && fileLimit < PROJECT_FILES_MAX_LIMIT;
+
+  useEffect(() => {
+    onLoadedFilesChange?.(files);
+  }, [files, onLoadedFilesChange]);
+
+  useEffect(() => {
+    if (!selectedSourcePath || filesQuery.isLoading || filesQuery.isFetching) {
+      return;
+    }
+
+    const selectedFileLoaded = files.some((file) => file.sourcePath === selectedSourcePath);
+    if (!selectedFileLoaded && hasMoreFiles) {
+      setFileLimit((currentLimit) =>
+        Math.min(currentLimit + PROJECT_FILES_PAGE_SIZE, PROJECT_FILES_MAX_LIMIT),
+      );
+    }
+  }, [files, filesQuery.isFetching, filesQuery.isLoading, hasMoreFiles, selectedSourcePath]);
+
+  const invalidateFiles = () => {
+    void queryClient.invalidateQueries({
+      queryKey: projectFilesQueryKey(organizationSlug, projectId),
+    });
+  };
 
   return (
     <>
@@ -135,7 +172,9 @@ export function ProjectFilesTreePanel({
               ? "Loading…"
               : filesQuery.isError
                 ? "Could not load files"
-                : `${files.length} file${files.length === 1 ? "" : "s"}`}
+                : hasMoreFiles
+                  ? `${files.length}+ files`
+                  : `${files.length} file${files.length === 1 ? "" : "s"}`}
           </TypographyP>
         </div>
         {filesQuery.isFetching && !filesQuery.isLoading ? <Spinner /> : null}
@@ -148,10 +187,8 @@ export function ProjectFilesTreePanel({
           organizationSlug={organizationSlug}
           scope="tree"
           resetKeys={queryKey}
-          onReset={() => {
-            void queryClient.invalidateQueries({ queryKey });
-          }}
-          className="min-h-0 flex-1"
+          onReset={invalidateFiles}
+          className="flex min-h-0 flex-1 flex-col"
         >
           <ProjectFilesTreeQueryResult
             error={filesQuery.isError ? filesQuery.error : null}
@@ -160,6 +197,31 @@ export function ProjectFilesTreePanel({
             selectedSourcePath={selectedSourcePath}
             onSelectSourcePath={onSelectSourcePath}
           />
+          {hasMoreFiles ? (
+            <div className="shrink-0 border-t border-foreground/8 p-2">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="w-full"
+                disabled={filesQuery.isFetching}
+                onClick={() => {
+                  setFileLimit((currentLimit) =>
+                    Math.min(currentLimit + PROJECT_FILES_PAGE_SIZE, PROJECT_FILES_MAX_LIMIT),
+                  );
+                }}
+              >
+                {filesQuery.isFetching ? (
+                  <>
+                    <Spinner />
+                    Loading more…
+                  </>
+                ) : (
+                  "Load more files"
+                )}
+              </Button>
+            </div>
+          ) : null}
         </ProjectFilesErrorBoundary>
       )}
     </>

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-task-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-task-view.tsx
@@ -103,7 +103,7 @@ export function JobDetailTaskView({
     ) : null;
 
   const filesSection =
-    hasFilesTab && activeTab === "files"
+    hasFilesTab && activeTab === "files" && !isLoading
       ? renderFilesSection?.({ jobId, organizationSlug, projectId })
       : null;
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-task-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-task-view.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { type ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 
 import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { TypographyH4 } from "@/components/ui/typography";
-import type { TmsProviderLiveJobComment } from "@/lib/providers/tms-provider-live";
 
 import {
   defaultRenderBackLink,
@@ -12,12 +12,13 @@ import {
   type JobDetailBackLinkRenderer,
   type JobDetailErrorRenderer,
 } from "./job-detail-shared";
-import { buildJobsListHref, formatJobDetailDate } from "./job-detail-types";
+import { buildJobsListHref } from "./job-detail-types";
 import {
   JobDetailView,
   type JobDetailViewMetric,
   type JobDetailViewProperty,
 } from "./job-detail-view";
+import { TmsLiveJobCommentsSection } from "./tms/tms-live-job-comments-section";
 
 export type JobDetailTaskDescriptionRenderer = (props: {
   description: string;
@@ -30,83 +31,16 @@ export type JobDetailTaskFilesRenderer = (props: {
   projectId: string;
 }) => ReactNode;
 
-function formatTimeSpent(seconds: number | null) {
-  if (!seconds || seconds <= 0) {
-    return null;
-  }
+export type JobDetailTaskCommentsRenderer = (props: {
+  jobId: string;
+  organizationSlug: string;
+}) => ReactNode;
 
-  const minutes = Math.round(seconds / 60);
-  if (minutes < 60) {
-    return `${minutes} min`;
-  }
-
-  const hours = Math.floor(minutes / 60);
-  const remainingMinutes = minutes % 60;
-  return remainingMinutes > 0 ? `${hours} hr ${remainingMinutes} min` : `${hours} hr`;
-}
-
-function TaskCommentsSection({
-  comments,
-  isError,
-  isLoading,
-}: {
-  comments: TmsProviderLiveJobComment[];
-  isError: boolean;
-  isLoading: boolean;
-}) {
-  return (
-    <section>
-      <TypographyH4>Comments</TypographyH4>
-
-      {isLoading ? (
-        <div className="mt-4 space-y-3">
-          <Skeleton className="h-16 w-full" />
-          <Skeleton className="h-16 w-full" />
-        </div>
-      ) : null}
-
-      {isError ? (
-        <p className="mt-4 text-sm text-flame-100">Unable to load task comments.</p>
-      ) : null}
-
-      {!isLoading && !isError && comments.length === 0 ? (
-        <p className="mt-4 text-sm text-muted-foreground">No comments yet.</p>
-      ) : null}
-
-      {!isLoading && !isError && comments.length > 0 ? (
-        <ul className="mt-4 divide-y divide-border rounded-md border border-border bg-card">
-          {comments.map((comment) => {
-            const timeSpent = formatTimeSpent(comment.timeSpentSeconds);
-
-            return (
-              <li key={comment.id} className="px-3 py-3">
-                <div className="flex flex-wrap items-center justify-between gap-2">
-                  <span className="text-sm font-medium text-foreground">User {comment.userId}</span>
-                  <span className="text-xs text-muted-foreground">
-                    {formatJobDetailDate(comment.createdAt)}
-                  </span>
-                </div>
-                <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-foreground">
-                  {comment.text}
-                </p>
-                {timeSpent ? (
-                  <p className="mt-2 text-xs text-muted-foreground">Time spent: {timeSpent}</p>
-                ) : null}
-              </li>
-            );
-          })}
-        </ul>
-      ) : null}
-    </section>
-  );
-}
+type JobDetailTaskTab = "overview" | "files" | "comments";
 
 export function JobDetailTaskView({
   buildJobsListHref: buildJobsListHrefProp = buildJobsListHref,
   canEditDescription = false,
-  comments = [],
-  commentsError,
-  commentsLoading = false,
   description = "",
   error,
   headerActions,
@@ -121,15 +55,13 @@ export function JobDetailTaskView({
   renderError = defaultRenderError,
   renderExtraMain,
   renderFilesSection,
+  renderCommentsSection,
   secondaryProperties = [],
   showComments = false,
   title,
 }: {
   buildJobsListHref?: typeof buildJobsListHref;
   canEditDescription?: boolean;
-  comments?: TmsProviderLiveJobComment[];
-  commentsError?: unknown;
-  commentsLoading?: boolean;
   description?: string;
   error?: unknown;
   headerActions?: ReactNode;
@@ -144,12 +76,86 @@ export function JobDetailTaskView({
   renderError?: JobDetailErrorRenderer;
   renderExtraMain?: () => ReactNode;
   renderFilesSection?: JobDetailTaskFilesRenderer;
+  renderCommentsSection?: JobDetailTaskCommentsRenderer;
   secondaryProperties?: JobDetailViewProperty[];
   showComments?: boolean;
   title?: string;
 }) {
+  const [activeTab, setActiveTab] = useState<JobDetailTaskTab>("overview");
+
   const showDescriptionSection =
     description.trim().length > 0 || (canEditDescription && renderDescriptionField);
+  const hasFilesTab = Boolean(renderFilesSection);
+  const hasCommentsTab = showComments;
+  const useTabs = hasFilesTab || hasCommentsTab;
+
+  const descriptionSection =
+    showDescriptionSection && renderDescriptionField ? (
+      <section>
+        <TypographyH4>Description</TypographyH4>
+        <div className="mt-4">
+          {renderDescriptionField({
+            description,
+            editable: canEditDescription,
+          })}
+        </div>
+      </section>
+    ) : null;
+
+  const filesSection =
+    hasFilesTab && activeTab === "files"
+      ? renderFilesSection?.({ jobId, organizationSlug, projectId })
+      : null;
+
+  const commentsSection =
+    hasCommentsTab && activeTab === "comments"
+      ? (renderCommentsSection?.({ jobId, organizationSlug }) ?? (
+          <TmsLiveJobCommentsSection organizationSlug={organizationSlug} encodedJobId={jobId} />
+        ))
+      : null;
+
+  const mainContent = useTabs ? (
+    <Tabs
+      value={activeTab}
+      onValueChange={(value) => setActiveTab(value as JobDetailTaskTab)}
+      className="gap-4"
+    >
+      <TabsList variant="line" className="w-full justify-start">
+        <TabsTrigger value="overview">Overview</TabsTrigger>
+        {hasFilesTab ? <TabsTrigger value="files">Files</TabsTrigger> : null}
+        {hasCommentsTab ? <TabsTrigger value="comments">Comments</TabsTrigger> : null}
+      </TabsList>
+
+      <TabsContent value="overview" className="space-y-8">
+        {descriptionSection}
+        {renderExtraMain?.()}
+      </TabsContent>
+
+      {hasFilesTab ? (
+        <TabsContent value="files" className="space-y-4">
+          {isLoading ? (
+            <div className="space-y-3">
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+          ) : (
+            filesSection
+          )}
+        </TabsContent>
+      ) : null}
+
+      {hasCommentsTab ? (
+        <TabsContent value="comments" className="space-y-4">
+          {commentsSection}
+        </TabsContent>
+      ) : null}
+    </Tabs>
+  ) : (
+    <>
+      {descriptionSection}
+      {renderExtraMain?.()}
+    </>
+  );
 
   return (
     <JobDetailView
@@ -166,33 +172,7 @@ export function JobDetailTaskView({
       error={error}
       renderBackLink={renderBackLink}
       renderError={renderError}
-      renderMain={() => (
-        <>
-          {showDescriptionSection && renderDescriptionField ? (
-            <section>
-              <TypographyH4>Description</TypographyH4>
-              <div className="mt-4">
-                {renderDescriptionField({
-                  description,
-                  editable: canEditDescription,
-                })}
-              </div>
-            </section>
-          ) : null}
-
-          {renderFilesSection ? renderFilesSection({ jobId, organizationSlug, projectId }) : null}
-
-          {renderExtraMain?.()}
-
-          {showComments ? (
-            <TaskCommentsSection
-              comments={comments}
-              isError={Boolean(commentsError)}
-              isLoading={commentsLoading}
-            />
-          ) : null}
-        </>
-      )}
+      renderMain={() => mainContent}
     />
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-view.stories.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-view.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
-import { expect } from "storybook/test";
+import { expect, userEvent } from "storybook/test";
 import { AiMagicIcon, LinkSquare02Icon, RefreshIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 
@@ -183,6 +183,22 @@ function liveFilesSection({
   );
 }
 
+function liveCommentsSection() {
+  const comments = createLiveCrowdinJobComments();
+
+  return (
+    <ul className="divide-y divide-border rounded-md border border-border bg-card">
+      {comments.map((comment) => (
+        <li key={comment.id} className="px-3 py-3">
+          <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-foreground">
+            {comment.text}
+          </p>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
 export const RunningFileTranslation: Story = {
   args: {
     ...taskViewArgsFromRecord(nativeJob),
@@ -198,6 +214,7 @@ export const RunningFileTranslation: Story = {
     await expect(canvas.getByText("Properties")).toBeInTheDocument();
     await expect(canvas.getByText("Task type")).toBeInTheDocument();
     await expect(canvas.getByText("Running")).toBeInTheDocument();
+    await userEvent.click(canvas.getByRole("tab", { name: "Files" }));
     await expect(canvas.getByText("home.json")).toBeInTheDocument();
   },
 };
@@ -297,14 +314,15 @@ export const LiveCrowdinTask: Story = {
     ),
     renderFilesSection: liveFilesSection,
     showComments: true,
-    comments: createLiveCrowdinJobComments(),
-    commentsLoading: false,
+    renderCommentsSection: liveCommentsSection,
   },
   play: async ({ canvas }) => {
     await expect(canvas.getByText("Translate marketing homepage")).toBeInTheDocument();
     await expect(canvas.getByRole("button", { name: "Translate with agent" })).toBeInTheDocument();
     await expect(canvas.getByText("68%")).toBeInTheDocument();
+    await userEvent.click(canvas.getByRole("tab", { name: "Files" }));
     await expect(canvas.getByText("home.json")).toBeInTheDocument();
+    await userEvent.click(canvas.getByRole("tab", { name: "Comments" }));
     await expect(canvas.getByText(/Preserve product name casing/)).toBeInTheDocument();
   },
 };
@@ -314,7 +332,11 @@ export const CommentsLoading: Story = {
     ...taskViewArgsFromLiveJob(liveJob),
     renderFilesSection: liveFilesSection,
     showComments: true,
-    commentsLoading: true,
+    renderCommentsSection: () => <p className="text-sm text-muted-foreground">Loading comments…</p>,
+  },
+  play: async ({ canvas }) => {
+    await userEvent.click(canvas.getByRole("tab", { name: "Comments" }));
+    await expect(canvas.getByText("Loading comments…")).toBeInTheDocument();
   },
 };
 

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-provider-detail-section-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-provider-detail-section-view.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import type { ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 import { AiMagicIcon, Comment01Icon, RefreshIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 
@@ -148,6 +148,7 @@ export function JobProviderDetailSectionView({
   const visibleActions = (job.providerActions ?? []).filter((action) => action.visible);
   const crowdinDescription =
     getProviderPayloadString(job.externalProviderPayload, "description")?.trim() ?? "";
+  const [sourceFilesExpanded, setSourceFilesExpanded] = useState(false);
 
   return (
     <>
@@ -217,9 +218,27 @@ export function JobProviderDetailSectionView({
         </section>
       ) : null}
 
-      {projectId && renderSourceFiles
-        ? renderSourceFiles({ job, organizationSlug, projectId })
-        : null}
+      {projectId && renderSourceFiles ? (
+        <section className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <TypographyH2 className="font-heading text-lg font-medium text-foreground md:text-lg">
+              Source files
+            </TypographyH2>
+            {!sourceFilesExpanded ? (
+              <Button size="sm" variant="outline" onClick={() => setSourceFilesExpanded(true)}>
+                Show source files
+              </Button>
+            ) : null}
+          </div>
+          {sourceFilesExpanded ? (
+            renderSourceFiles({ job, organizationSlug, projectId })
+          ) : (
+            <p className="mt-3 text-sm text-foreground/48">
+              Load linked source files when you are ready to review or open them.
+            </p>
+          )}
+        </section>
+      ) : null}
 
       {showAgentActions && visibleActions.length > 0 ? (
         <section className="rounded-lg border border-foreground/8 bg-foreground/2.5 p-5">

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-content.tsx
@@ -5,10 +5,8 @@ import { toast } from "sonner";
 
 import { apiClient } from "@/lib/api-client-instance";
 import { getJobProviderActionAvailability } from "@/lib/providers/job-provider-actions";
-import type {
-  TmsProviderLiveJobComment,
-  TmsProviderLiveJobDetail,
-} from "@/lib/providers/tms-provider-live";
+import type { TmsProviderLiveJobDetail } from "@/lib/providers/tms-provider-live";
+import { parseProviderJobId } from "@/lib/providers/tms-provider-resource-id";
 
 import { ProviderJobDescriptionField } from "../../../../../jobs/_components/provider-job-description-field";
 import { ProviderLiveJobDetailView } from "./provider-live-job-detail-view";
@@ -40,7 +38,8 @@ export function ProviderLiveJobDetailContent({
 }) {
   const queryClient = useQueryClient();
   const jobQueryKey = ["tms-provider-job", organizationSlug, jobId] as const;
-  const commentsQueryKey = ["tms-provider-job-comments", organizationSlug, jobId] as const;
+  const showComments = parseProviderJobId(jobId)?.providerKind === "crowdin";
+
   const jobQuery = useQuery({
     queryKey: jobQueryKey,
     queryFn: async () => {
@@ -56,24 +55,6 @@ export function ProviderLiveJobDetailContent({
 
       const body = (await response.json()) as { job: TmsProviderLiveJobDetail };
       return body.job;
-    },
-  });
-  const commentsQuery = useQuery({
-    queryKey: commentsQueryKey,
-    enabled: jobQuery.data?.externalProviderKind === "crowdin",
-    queryFn: async () => {
-      const response = await apiClient.api.orgs[":organizationSlug"]["tms-provider"].jobs[
-        ":encodedJobId"
-      ].comments.$get({
-        param: { organizationSlug, encodedJobId: jobId },
-      });
-
-      if (!response.ok) {
-        throw new Error(`Failed to load task comments (${response.status})`);
-      }
-
-      const body = (await response.json()) as { comments: TmsProviderLiveJobComment[] };
-      return body.comments;
     },
   });
 
@@ -126,9 +107,7 @@ export function ProviderLiveJobDetailContent({
       onRefresh={() => {
         void queryClient.invalidateQueries({ queryKey: jobQueryKey });
       }}
-      comments={commentsQuery.data ?? []}
-      commentsLoading={commentsQuery.isLoading}
-      commentsError={commentsQuery.isError ? commentsQuery.error : undefined}
+      showComments={showComments}
       renderDescriptionField={({ description, editable }) => (
         <ProviderJobDescriptionField
           organizationSlug={organizationSlug}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-view.tsx
@@ -6,10 +6,7 @@ import { HugeiconsIcon } from "@hugeicons/react";
 
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import type {
-  TmsProviderLiveJobComment,
-  TmsProviderLiveJobDetail,
-} from "@/lib/providers/tms-provider-live";
+import type { TmsProviderLiveJobDetail } from "@/lib/providers/tms-provider-live";
 
 import { getProviderPayloadString } from "../../../../../jobs/_components/provider-crowdin-job-display";
 
@@ -39,9 +36,6 @@ export type ProviderLiveFilesSectionRenderer = (props: {
 export function ProviderLiveJobDetailView({
   buildJobsListHref: buildJobsListHrefProp = buildJobsListHref,
   canEditProviderJobDescription = false,
-  comments = [],
-  commentsError,
-  commentsLoading = false,
   error,
   isLoading,
   isRefreshing = false,
@@ -57,13 +51,11 @@ export function ProviderLiveJobDetailView({
   renderError = defaultRenderError,
   renderExternalLink,
   renderFilesSection,
+  showComments = false,
   translateWithAgentAction,
 }: {
   buildJobsListHref?: typeof buildJobsListHref;
   canEditProviderJobDescription?: boolean;
-  comments?: TmsProviderLiveJobComment[];
-  commentsError?: unknown;
-  commentsLoading?: boolean;
   error?: unknown;
   isLoading: boolean;
   isRefreshing?: boolean;
@@ -79,6 +71,7 @@ export function ProviderLiveJobDetailView({
   renderError?: JobDetailErrorRenderer;
   renderExternalLink?: (props: { href: string; label: string }) => ReactNode;
   renderFilesSection?: ProviderLiveFilesSectionRenderer;
+  showComments?: boolean;
   translateWithAgentAction?: ProviderActionAvailability | null;
 }) {
   const providerDescription = job
@@ -174,10 +167,7 @@ export function ProviderLiveJobDetailView({
       canEditDescription={canEditProviderDescription}
       renderDescriptionField={renderDescriptionField}
       renderFilesSection={filesRenderer}
-      showComments={job?.externalProviderKind === "crowdin"}
-      comments={comments}
-      commentsLoading={commentsLoading}
-      commentsError={commentsError}
+      showComments={showComments}
     />
   );
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/tms-live-job-comments-section.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/tms-live-job-comments-section.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { apiClient } from "@/lib/api-client-instance";
+import type { TmsProviderLiveJobComment } from "@/lib/providers/tms-provider-live";
+
+import { formatJobDetailDate } from "../job-detail-types";
+
+function tmsLiveJobCommentsQueryKey(organizationSlug: string, encodedJobId: string) {
+  return ["tms-provider-job-comments", organizationSlug, encodedJobId] as const;
+}
+
+function formatTimeSpent(seconds: number | null) {
+  if (!seconds || seconds <= 0) {
+    return null;
+  }
+
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes} min`;
+  }
+
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return remainingMinutes > 0 ? `${hours} hr ${remainingMinutes} min` : `${hours} hr`;
+}
+
+export function TmsLiveJobCommentsSection({
+  organizationSlug,
+  encodedJobId,
+}: {
+  organizationSlug: string;
+  encodedJobId: string;
+}) {
+  const commentsQuery = useQuery({
+    queryKey: tmsLiveJobCommentsQueryKey(organizationSlug, encodedJobId),
+    queryFn: async () => {
+      const response = await apiClient.api.orgs[":organizationSlug"]["tms-provider"].jobs[
+        ":encodedJobId"
+      ].comments.$get({
+        param: { organizationSlug, encodedJobId },
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to load task comments (${response.status})`);
+      }
+
+      const body = (await response.json()) as { comments: TmsProviderLiveJobComment[] };
+      return body.comments;
+    },
+  });
+
+  if (commentsQuery.isLoading) {
+    return <p className="text-sm text-muted-foreground">Loading comments…</p>;
+  }
+
+  if (commentsQuery.isError) {
+    return <p className="text-sm text-flame-100">Unable to load task comments.</p>;
+  }
+
+  const comments = commentsQuery.data ?? [];
+
+  if (comments.length === 0) {
+    return <p className="text-sm text-muted-foreground">No comments yet.</p>;
+  }
+
+  return (
+    <ul className="divide-y divide-border rounded-md border border-border bg-card">
+      {comments.map((comment) => {
+        const timeSpent = formatTimeSpent(comment.timeSpentSeconds);
+
+        return (
+          <li key={comment.id} className="px-3 py-3">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <span className="text-sm font-medium text-foreground">User {comment.userId}</span>
+              <span className="text-xs text-muted-foreground">
+                {formatJobDetailDate(comment.createdAt)}
+              </span>
+            </div>
+            <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-foreground">
+              {comment.text}
+            </p>
+            {timeSpent ? (
+              <p className="mt-2 text-xs text-muted-foreground">Time spent: {timeSpent}</p>
+            ) : null}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
@@ -73,6 +73,7 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
   const [projectDialogMode, setProjectDialogMode] = useState<"create" | "edit" | null>(null);
   const [editingProject, setEditingProject] = useState<ProjectListRow | null>(null);
   const [deleteProject, setDeleteProject] = useState<ProjectListRow | null>(null);
+  const [tmsProjectsRequested, setTmsProjectsRequested] = useState(false);
   const nativeProjectsQuery = useQuery({
     queryKey: nativeProjectsQueryKey(organizationSlug),
     queryFn: async () => {
@@ -89,8 +90,10 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
     },
   });
   const activeTmsProviderQuery = useActiveTmsProvider(organizationSlug);
+  const hasTmsConnection = Boolean(activeTmsProviderQuery.data);
   const tmsProjectsQuery = useQuery({
     queryKey: tmsProjectsQueryKey(organizationSlug),
+    enabled: tmsProjectsRequested && hasTmsConnection,
     queryFn: async () => {
       const response = await apiClient.api.orgs[":organizationSlug"]["tms-provider"].projects.$get({
         param: { organizationSlug },
@@ -206,10 +209,10 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
     [editingProject, projectDialogMode],
   );
 
-  const hasAnyProjects = nativeProjects.length > 0 || tmsProjects.length > 0;
-  const hasFilteredResults = filteredNativeProjects.length > 0 || filteredTmsProjects.length > 0;
-  const hasTmsConnection = Boolean(activeTmsProviderQuery.data);
-  const isTmsProjectsLoading = tmsProjectsQuery.isLoading || tmsProjectsQuery.isFetching;
+  const hasAnyProjects =
+    nativeProjects.length > 0 || (tmsProjectsRequested && tmsProjects.length > 0);
+  const hasFilteredResults =
+    filteredNativeProjects.length > 0 || (tmsProjectsRequested && filteredTmsProjects.length > 0);
   const tmsProviderName = activeTmsProviderQuery.data
     ? getTmsProviderBranding(activeTmsProviderQuery.data.providerKind).name
     : "TMS";
@@ -308,20 +311,33 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
           />
         </section>
 
-        {hasTmsConnection || isTmsProjectsLoading ? (
+        {hasTmsConnection ? (
           <section className="space-y-4">
             <ProjectsSectionHeader
               title={`${tmsProviderName} projects`}
               description="Live projects fetched from your connected TMS provider."
             />
-            <ProjectsTable
-              projects={filteredTmsProjects}
-              projectsQuery={tmsProjectsQuery}
-              isSavingProject={isSavingProject}
-              isDeletingProject={deleteProjectMutation.isPending}
-              organizationSlug={organizationSlug}
-              variant="tms"
-            />
+            {tmsProjectsRequested ? (
+              <ProjectsTable
+                projects={filteredTmsProjects}
+                projectsQuery={tmsProjectsQuery}
+                isSavingProject={isSavingProject}
+                isDeletingProject={deleteProjectMutation.isPending}
+                organizationSlug={organizationSlug}
+                variant="tms"
+              />
+            ) : (
+              <div className="max-w-xl py-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setTmsProjectsRequested(true)}
+                >
+                  Show live TMS projects
+                </Button>
+              </div>
+            )}
           </section>
         ) : activeTmsProviderQuery.isSuccess ? (
           <section className="space-y-4">

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/_components/projects-page-content.tsx
@@ -13,7 +13,6 @@ import { TypographyP } from "@/components/ui/typography";
 import { apiClient } from "@/lib/api-client-instance";
 import { readApiResponseError } from "@/lib/api-error";
 import { getTmsProviderBranding } from "@/lib/providers/tms-provider-branding";
-import { readTmsProviderListResponse } from "@/lib/providers/tms-provider-list-fetch";
 
 import {
   PageHeader,
@@ -21,6 +20,7 @@ import {
   WorkspacePageShell,
 } from "../../_components/workspace-resource-shared";
 import { useActiveTmsProvider } from "../../_hooks/use-active-tms-provider";
+import { fetchTmsLiveProjects, tmsLiveProjectsQueryKey } from "../../_hooks/use-tms-live-projects";
 import { DeleteProjectDialog } from "./delete-project-dialog";
 import {
   createEmptyProjectForm,
@@ -29,14 +29,11 @@ import {
   type ProjectFormValues,
 } from "./project-form";
 import { ProjectDialog } from "./project-dialog";
-import { mapProjectToListRow, type ApiProject, type ProjectListRow } from "./project-list";
+import { mapProjectToListRow, type ProjectListRow } from "./project-list";
 import { ProjectsTable } from "./projects-table";
 
 const nativeProjectsQueryKey = (organizationSlug: string) =>
   ["translation-projects", organizationSlug, "native"] as const;
-
-const tmsProjectsQueryKey = (organizationSlug: string) =>
-  ["translation-projects", organizationSlug, "tms-live"] as const;
 
 function useProjectSearch(projects: ProjectListRow[]) {
   const [searchQuery, setSearchQuery] = useState("");
@@ -73,7 +70,6 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
   const [projectDialogMode, setProjectDialogMode] = useState<"create" | "edit" | null>(null);
   const [editingProject, setEditingProject] = useState<ProjectListRow | null>(null);
   const [deleteProject, setDeleteProject] = useState<ProjectListRow | null>(null);
-  const [tmsProjectsRequested, setTmsProjectsRequested] = useState(false);
   const nativeProjectsQuery = useQuery({
     queryKey: nativeProjectsQueryKey(organizationSlug),
     queryFn: async () => {
@@ -92,20 +88,10 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
   const activeTmsProviderQuery = useActiveTmsProvider(organizationSlug);
   const hasTmsConnection = Boolean(activeTmsProviderQuery.data);
   const tmsProjectsQuery = useQuery({
-    queryKey: tmsProjectsQueryKey(organizationSlug),
-    enabled: tmsProjectsRequested && hasTmsConnection,
-    queryFn: async () => {
-      const response = await apiClient.api.orgs[":organizationSlug"]["tms-provider"].projects.$get({
-        param: { organizationSlug },
-      });
-
-      const projects = await readTmsProviderListResponse<ApiProject>(
-        response,
-        "projects",
-        "Failed to load TMS projects",
-      );
-      return projects.map(mapProjectToListRow);
-    },
+    queryKey: tmsLiveProjectsQueryKey(organizationSlug),
+    enabled: hasTmsConnection,
+    queryFn: () => fetchTmsLiveProjects(organizationSlug),
+    select: (projects) => projects.map(mapProjectToListRow),
   });
   const createProject = useMutation({
     mutationFn: async (values: ProjectFormValues) => {
@@ -209,10 +195,9 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
     [editingProject, projectDialogMode],
   );
 
-  const hasAnyProjects =
-    nativeProjects.length > 0 || (tmsProjectsRequested && tmsProjects.length > 0);
-  const hasFilteredResults =
-    filteredNativeProjects.length > 0 || (tmsProjectsRequested && filteredTmsProjects.length > 0);
+  const hasAnyProjects = nativeProjects.length > 0 || tmsProjects.length > 0;
+  const hasFilteredResults = filteredNativeProjects.length > 0 || filteredTmsProjects.length > 0;
+  const isTmsProjectsLoading = tmsProjectsQuery.isLoading || tmsProjectsQuery.isFetching;
   const tmsProviderName = activeTmsProviderQuery.data
     ? getTmsProviderBranding(activeTmsProviderQuery.data.providerKind).name
     : "TMS";
@@ -311,33 +296,20 @@ export function ProjectsPageContent({ organizationSlug }: { organizationSlug: st
           />
         </section>
 
-        {hasTmsConnection ? (
+        {hasTmsConnection || isTmsProjectsLoading ? (
           <section className="space-y-4">
             <ProjectsSectionHeader
               title={`${tmsProviderName} projects`}
               description="Live projects fetched from your connected TMS provider."
             />
-            {tmsProjectsRequested ? (
-              <ProjectsTable
-                projects={filteredTmsProjects}
-                projectsQuery={tmsProjectsQuery}
-                isSavingProject={isSavingProject}
-                isDeletingProject={deleteProjectMutation.isPending}
-                organizationSlug={organizationSlug}
-                variant="tms"
-              />
-            ) : (
-              <div className="max-w-xl py-2">
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={() => setTmsProjectsRequested(true)}
-                >
-                  Show live TMS projects
-                </Button>
-              </div>
-            )}
+            <ProjectsTable
+              projects={filteredTmsProjects}
+              projectsQuery={tmsProjectsQuery}
+              isSavingProject={isSavingProject}
+              isDeletingProject={deleteProjectMutation.isPending}
+              organizationSlug={organizationSlug}
+              variant="tms"
+            />
           </section>
         ) : activeTmsProviderQuery.isSuccess ? (
           <section className="space-y-4">

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/translation-memories/_components/translation-memories-page-content.tsx
@@ -27,10 +27,13 @@ import {
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { Textarea } from "@/components/ui/textarea";
+import { TypographyP } from "@/components/ui/typography";
 import { readApiError, readApiResponseError } from "@/lib/api-error";
 import { apiClient } from "@/lib/api-client-instance";
 
 import { useActiveTmsProvider } from "../../_hooks/use-active-tms-provider";
+
+import { TmsLiveProjectPicker } from "../../_components/tms-live-project-picker";
 
 import {
   GLOSSARY_SYNC_FILTERS,
@@ -168,11 +171,13 @@ export function TranslationMemoriesPageContent({
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [createForm, setCreateForm] = useState<MemoryCreateForm>(() => createEmptyMemoryForm());
   const [createErrors, setCreateErrors] = useState<{ name?: string }>({});
+  const [selectedExternalProjectId, setSelectedExternalProjectId] = useState("");
   const { data: activeTmsProvider } = useActiveTmsProvider(organizationSlug);
   const useLiveProviderMemories = Boolean(activeTmsProvider);
   const allowCreateMemories = canCreateMemories && !useLiveProviderMemories;
   const projectsQuery = useQuery({
     queryKey: projectsQueryKey(organizationSlug),
+    enabled: !useLiveProviderMemories,
     queryFn: async () => {
       const response = await apiClient.api.orgs[":organizationSlug"].projects.$get({
         param: { organizationSlug },
@@ -189,6 +194,7 @@ export function TranslationMemoriesPageContent({
 
   const credentialsQuery = useQuery({
     queryKey: credentialsQueryKey(organizationSlug),
+    enabled: !useLiveProviderMemories,
     queryFn: async () => {
       const response = await apiClient.api.orgs[":organizationSlug"][
         "external-tms-provider-credential"
@@ -209,14 +215,18 @@ export function TranslationMemoriesPageContent({
     queryKey: [
       ...memoriesQueryKey(organizationSlug, page),
       useLiveProviderMemories ? "live" : "native",
+      selectedExternalProjectId,
     ],
+    enabled: !useLiveProviderMemories || Boolean(selectedExternalProjectId),
     queryFn: async () => {
       if (useLiveProviderMemories && activeTmsProvider) {
         const response = await apiClient.api.orgs[":organizationSlug"]["tms-provider"][
           "translation-memories"
         ].$get({
           param: { organizationSlug },
-          query: {},
+          query: {
+            externalProjectId: selectedExternalProjectId,
+          },
         });
 
         if (!response.ok) {
@@ -334,7 +344,18 @@ export function TranslationMemoriesPageContent({
 
   useEffect(() => {
     setPage(1);
-  }, [organizationSlug, searchQuery, sourceFilter, providerFilter, syncFilter]);
+  }, [
+    organizationSlug,
+    searchQuery,
+    sourceFilter,
+    providerFilter,
+    syncFilter,
+    selectedExternalProjectId,
+  ]);
+
+  useEffect(() => {
+    setSelectedExternalProjectId("");
+  }, [organizationSlug, useLiveProviderMemories]);
 
   useEffect(() => {
     if (memoriesQuery.isSuccess && page > totalPages) {
@@ -346,7 +367,11 @@ export function TranslationMemoriesPageContent({
   const connectedCredentials = (credentialsQuery.data ?? []).filter(
     (credential) => credential.validationStatus === "connected",
   );
-  const hasConnectedProvider = credentialsQuery.isSuccess && connectedCredentials.length > 0;
+  const hasConnectedProvider = useLiveProviderMemories
+    ? Boolean(activeTmsProvider)
+    : credentialsQuery.isSuccess && connectedCredentials.length > 0;
+
+  const liveProjectSelectionRequired = useLiveProviderMemories && !selectedExternalProjectId;
 
   const emptyTitle = hasConnectedProvider
     ? "No translation memories yet"
@@ -393,6 +418,16 @@ export function TranslationMemoriesPageContent({
           ) : null
         }
       />
+
+      {useLiveProviderMemories ? (
+        <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end sm:gap-2">
+          <TmsLiveProjectPicker
+            organizationSlug={organizationSlug}
+            value={selectedExternalProjectId}
+            onValueChange={setSelectedExternalProjectId}
+          />
+        </div>
+      ) : null}
 
       {memoriesQuery.isSuccess && memories.length > 0 ? (
         <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end sm:gap-2">
@@ -527,28 +562,41 @@ export function TranslationMemoriesPageContent({
         </div>
       ) : null}
 
-      <TranslationMemoriesTable
-        memories={filteredMemories}
-        memoriesQuery={memoriesQuery}
-        organizationSlug={organizationSlug}
-        emptyTitle={allowCreateMemories ? "No translation memories yet" : emptyTitle}
-        emptyDescription={
-          allowCreateMemories
-            ? "Create a workspace memory, import entries, then assign it to the projects that should use it."
-            : emptyDescription
-        }
-        emptyAction={
-          allowCreateMemories ? (
-            <Button type="button" size="sm" onClick={() => setCreateDialogOpen(true)}>
-              Create memory
-            </Button>
-          ) : (
-            <TranslationMemoriesEmptyAction organizationSlug={organizationSlug} />
-          )
-        }
-      />
+      {liveProjectSelectionRequired ? (
+        <div className="space-y-3 py-10">
+          <TypographyP className="text-sm font-medium text-foreground">
+            Choose a TMS project
+          </TypographyP>
+          <TypographyP className="max-w-xl text-sm leading-6 text-foreground/52">
+            Select a project above to load live translation memories from your connected provider.
+          </TypographyP>
+        </div>
+      ) : (
+        <TranslationMemoriesTable
+          memories={filteredMemories}
+          memoriesQuery={memoriesQuery}
+          organizationSlug={organizationSlug}
+          emptyTitle={allowCreateMemories ? "No translation memories yet" : emptyTitle}
+          emptyDescription={
+            allowCreateMemories
+              ? "Create a workspace memory, import entries, then assign it to the projects that should use it."
+              : emptyDescription
+          }
+          emptyAction={
+            allowCreateMemories ? (
+              <Button type="button" size="sm" onClick={() => setCreateDialogOpen(true)}>
+                Create memory
+              </Button>
+            ) : (
+              <TranslationMemoriesEmptyAction organizationSlug={organizationSlug} />
+            )
+          }
+        />
+      )}
 
-      {memoriesQuery.isSuccess && memoryTotal > MEMORIES_PAGE_SIZE ? (
+      {!liveProjectSelectionRequired &&
+      memoriesQuery.isSuccess &&
+      memoryTotal > MEMORIES_PAGE_SIZE ? (
         <div className="flex flex-wrap items-center justify-between gap-2">
           <p className="text-sm text-foreground/52">
             Showing {pageStart}–{pageEnd} of {memoryTotal} translation memories

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell.tsx
@@ -46,12 +46,19 @@ export async function AppShell({
         userId: auth.user.localUserId,
       })
     : { showConnectCta: false };
-  const initialTmsProviderConnection: ActiveTmsProviderConnection | null = hasCapability(
-    auth.membership.role,
-    "provider_credentials:read",
-  )
-    ? await getTmsProviderConnection(auth.activeOrganization.localOrganizationId)
-    : null;
+  let initialTmsProviderConnection: ActiveTmsProviderConnection | null = null;
+  if (hasCapability(auth.membership.role, "provider_credentials:read")) {
+    try {
+      initialTmsProviderConnection = await getTmsProviderConnection(
+        auth.activeOrganization.localOrganizationId,
+      );
+    } catch (error) {
+      console.error("[app-shell] Failed to prefetch TMS provider connection", {
+        organizationId: auth.activeOrganization.localOrganizationId,
+        error,
+      });
+    }
+  }
 
   return (
     <AppShellClient

--- a/apps/hyperlocalise-web/src/components/app-shell/app-shell.tsx
+++ b/apps/hyperlocalise-web/src/components/app-shell/app-shell.tsx
@@ -8,11 +8,15 @@ import {
   evaluateWorkspaceFeatureFlags,
   filterNavigationByWorkspaceFlags,
 } from "@/lib/flags/workspace-flags";
+import { getTmsProviderConnection } from "@/lib/providers/tms-provider-live";
 import {
   getTmsUserConnectCtaState,
   type TmsUserConnectCta,
 } from "@/lib/providers/tms-user-connection";
 import { requireAppAuthContext } from "@/lib/workos/app-auth";
+
+import { OrgTmsQueryProvider } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/_components/org-tms-query-provider";
+import type { ActiveTmsProviderConnection } from "@/app/[lang]/(authenticated)/org/[organizationSlug]/_hooks/use-active-tms-provider";
 
 export type AppShellProps = {
   autumnConfigured?: boolean;
@@ -42,6 +46,12 @@ export async function AppShell({
         userId: auth.user.localUserId,
       })
     : { showConnectCta: false };
+  const initialTmsProviderConnection: ActiveTmsProviderConnection | null = hasCapability(
+    auth.membership.role,
+    "provider_credentials:read",
+  )
+    ? await getTmsProviderConnection(auth.activeOrganization.localOrganizationId)
+    : null;
 
   return (
     <AppShellClient
@@ -60,7 +70,12 @@ export async function AppShell({
         <AppShellNavigation organizationSlug={activeOrganizationSlug} groups={navigationGroups} />
       }
     >
-      {children}
+      <OrgTmsQueryProvider
+        organizationSlug={activeOrganizationSlug}
+        initialTmsProviderConnection={initialTmsProviderConnection}
+      >
+        {children}
+      </OrgTmsQueryProvider>
     </AppShellClient>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continues the TMS UI lazy-loading work with items 9 and 10 from the performance review.

### Item 9 — Project files pagination
- Initial fetch loads **50 files** instead of 500
- **Load more files** button increases the limit in 50-file steps (up to API max 1,000)
- Deep-linked `?sourcePath=` URLs auto-load additional pages until the selected file appears
- Removed duplicate React Query subscription from the page content; the tree panel reports loaded files via callback

### Item 10 — Prefetch TMS connection in org layout
- `AppShell` server-fetches the active TMS provider connection (when permitted)
- `OrgTmsQueryProvider` seeds the React Query cache so pages using `useActiveTmsProvider()` skip the initial client round-trip
- 60s stale time avoids immediate refetch on mount

### Previously in this PR
- Job detail tab-gated loading (Overview / Files / Comments)
- TM/Glossary project picker before live list fetch
- Job provider section lazy source files expand

## Test plan
- [x] `vp check --fix`
- [x] `vp test` on files + org hooks + app-shell (38 tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2295-53ec-7d43-92c3-3c920e66cc08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2295-53ec-7d43-92c3-3c920e66cc08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

