### PR TITLE
fix(web): show only job files in CAT source file picker

### DIFF
--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/job-source-file-mappers.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/tms/job-source-file-mappers.ts
@@ -25,6 +25,7 @@ export function providerSourceFileToProjectFileRecord(
   file: ProviderSourceFile,
   providerKind: string,
   externalProjectId: string,
+  targetLocales: readonly string[] = [],
 ): ProjectFileRecord | null {
   if (!file.sourcePath) {
     return null;
@@ -49,7 +50,7 @@ export function providerSourceFileToProjectFileRecord(
       externalUrl: file.externalUrl,
       syncState: "synced",
       sourceLocale: null,
-      targetLocales: [],
+      targetLocales: [...targetLocales],
       localeReadiness: {},
       revision: null,
       format: null,

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
@@ -134,7 +134,7 @@ export function JobCatPageContent({
   const providerFilesQuery = useQuery({
     queryKey: projectJobCatProviderFilesQueryKey(organizationSlug, projectId, jobId),
     enabled: hasFileReference && !isNativeJob,
-    queryFn: () => loadJobCatProviderJobFiles({ organizationSlug, projectId, jobId }),
+    queryFn: () => loadJobCatProviderJobFiles({ organizationSlug, projectId, jobId, targetLocale }),
   });
 
   const repositoriesQuery = useQuery({

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
@@ -26,7 +26,7 @@ import {
   writeCatFileRepositoryPreference,
 } from "./job-cat-repository-preference";
 import { selectJobCatTargetLocale } from "./job-cat-target-locale";
-import { loadJobCatProviderFiles, loadJobCatTargetFile } from "./load-job-cat-files";
+import { loadJobCatProviderJobFiles, loadJobCatTargetFile } from "./load-job-cat-files";
 import { selectJobCatRepository, sortJobCatProviderFiles } from "./select-job-cat-repository";
 import { ProjectFileCatWorkspace } from "@/components/cat/project-file-cat-workspace";
 
@@ -53,8 +53,12 @@ function projectJobCatTargetFileQueryKey(
   ] as const;
 }
 
-function projectJobCatProviderFilesQueryKey(organizationSlug: string, projectId: string) {
-  return ["project-job-cat-provider-files", organizationSlug, projectId] as const;
+function projectJobCatProviderFilesQueryKey(
+  organizationSlug: string,
+  projectId: string,
+  jobId: string,
+) {
+  return ["project-job-cat-provider-files", organizationSlug, projectId, jobId] as const;
 }
 
 function githubInstallationRepositoriesQueryKey(organizationSlug: string) {
@@ -128,9 +132,9 @@ export function JobCatPageContent({
   });
 
   const providerFilesQuery = useQuery({
-    queryKey: projectJobCatProviderFilesQueryKey(organizationSlug, projectId),
+    queryKey: projectJobCatProviderFilesQueryKey(organizationSlug, projectId, jobId),
     enabled: hasFileReference && !isNativeJob,
-    queryFn: () => loadJobCatProviderFiles({ organizationSlug, projectId }),
+    queryFn: () => loadJobCatProviderJobFiles({ organizationSlug, projectId, jobId }),
   });
 
   const repositoriesQuery = useQuery({

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/load-job-cat-files.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/load-job-cat-files.test.ts
@@ -3,7 +3,12 @@ import { describe, expect, it } from "vite-plus/test";
 import type { ProjectFileRecord } from "@/api/routes/project/project.schema";
 
 import {
+  createNativeJobDetail,
+  createProviderBackedJobDetail,
+} from "../../_components/job-detail.fixture";
+import {
   PROJECT_FILES_FETCH_LIMIT,
+  mapSyncedProviderSourceFiles,
   resolveJobCatTargetFromStoredFileId,
 } from "./load-job-cat-files";
 
@@ -52,5 +57,47 @@ describe("resolveJobCatTargetFromStoredFileId", () => {
       reference: "file_missing",
       fetchedCount: PROJECT_FILES_FETCH_LIMIT,
     });
+  });
+});
+
+describe("mapSyncedProviderSourceFiles", () => {
+  it("maps synced provider source files to project file records", () => {
+    const job = createProviderBackedJobDetail({
+      providerSourceFiles: [
+        {
+          id: "42",
+          displayName: "messages.po",
+          sourcePath: "locales/messages.po",
+          resourceType: "file",
+          externalUrl: null,
+        },
+        {
+          id: "99",
+          displayName: "missing-path",
+          sourcePath: null,
+          resourceType: "file",
+          externalUrl: null,
+        },
+      ],
+    });
+
+    const files = mapSyncedProviderSourceFiles({
+      job,
+      projectId: "ext:crowdin:902807",
+    });
+
+    expect(files).toHaveLength(1);
+    expect(files[0]?.sourcePath).toBe("locales/messages.po");
+    expect(files[0]?.provider?.kind).toBe("crowdin");
+    expect(files[0]?.provider?.externalProjectId).toBe("902807");
+  });
+
+  it("returns an empty list when the job has no provider kind", () => {
+    const files = mapSyncedProviderSourceFiles({
+      job: createNativeJobDetail({ externalProviderKind: null, providerSourceFiles: [] }),
+      projectId: "project_1",
+    });
+
+    expect(files).toEqual([]);
   });
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/load-job-cat-files.test.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/load-job-cat-files.test.ts
@@ -8,8 +8,10 @@ import {
 } from "../../_components/job-detail.fixture";
 import {
   PROJECT_FILES_FETCH_LIMIT,
+  assertProviderJobBelongsToProject,
   mapSyncedProviderSourceFiles,
   resolveJobCatTargetFromStoredFileId,
+  resolveSyncedProviderTargetLocales,
 } from "./load-job-cat-files";
 
 function createFile(overrides: Partial<ProjectFileRecord> = {}): ProjectFileRecord {
@@ -90,6 +92,30 @@ describe("mapSyncedProviderSourceFiles", () => {
     expect(files[0]?.sourcePath).toBe("locales/messages.po");
     expect(files[0]?.provider?.kind).toBe("crowdin");
     expect(files[0]?.provider?.externalProjectId).toBe("902807");
+    expect(files[0]?.provider?.targetLocales).toEqual(["fr-FR", "de-DE"]);
+  });
+
+  it("falls back to the requested target locale when synced job locales are missing", () => {
+    const job = createProviderBackedJobDetail({
+      externalTargetLocales: null,
+      providerSourceFiles: [
+        {
+          id: "42",
+          displayName: "messages.po",
+          sourcePath: "locales/messages.po",
+          resourceType: "file",
+          externalUrl: null,
+        },
+      ],
+    });
+
+    const files = mapSyncedProviderSourceFiles({
+      job,
+      projectId: "ext:crowdin:902807",
+      targetLocale: "fr-FR",
+    });
+
+    expect(files[0]?.provider?.targetLocales).toEqual(["fr-FR"]);
   });
 
   it("returns an empty list when the job has no provider kind", () => {
@@ -99,5 +125,39 @@ describe("mapSyncedProviderSourceFiles", () => {
     });
 
     expect(files).toEqual([]);
+  });
+});
+
+describe("resolveSyncedProviderTargetLocales", () => {
+  it("prefers external target locales from the job", () => {
+    expect(
+      resolveSyncedProviderTargetLocales(
+        createProviderBackedJobDetail({ externalTargetLocales: ["fr-FR", "de-DE"] }),
+        "ja-JP",
+      ),
+    ).toEqual(["fr-FR", "de-DE"]);
+  });
+
+  it("falls back to the requested locale when the job has none", () => {
+    expect(
+      resolveSyncedProviderTargetLocales(
+        createProviderBackedJobDetail({ externalTargetLocales: null }),
+        "fr-FR",
+      ),
+    ).toEqual(["fr-FR"]);
+  });
+});
+
+describe("assertProviderJobBelongsToProject", () => {
+  it("allows encoded provider jobs that match the encoded project id", () => {
+    expect(() =>
+      assertProviderJobBelongsToProject("ext:crowdin:902807:1204", "ext:crowdin:902807"),
+    ).not.toThrow();
+  });
+
+  it("rejects encoded provider jobs from a different project", () => {
+    expect(() =>
+      assertProviderJobBelongsToProject("ext:crowdin:902807:1204", "ext:crowdin:999999"),
+    ).toThrow("Task does not belong to this project");
   });
 });

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/load-job-cat-files.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/load-job-cat-files.ts
@@ -155,19 +155,53 @@ async function fetchJobDetail(organizationSlug: string, jobId: string) {
   return body.job;
 }
 
-export function mapSyncedProviderSourceFiles(input: { job: JobDetailRecord; projectId: string }) {
+export function resolveSyncedProviderTargetLocales(
+  job: JobDetailRecord,
+  targetLocale: string | null = null,
+) {
+  if (job.externalTargetLocales && job.externalTargetLocales.length > 0) {
+    return [...job.externalTargetLocales];
+  }
+
+  return targetLocale ? [targetLocale] : [];
+}
+
+export function assertProviderJobBelongsToProject(encodedJobId: string, projectId: string) {
+  const parsedJob = parseProviderJobId(encodedJobId);
+  if (!parsedJob) {
+    return;
+  }
+
+  const parsedProject = parseProviderProjectId(projectId);
+  const projectMatches = parsedProject
+    ? parsedProject.providerKind === parsedJob.providerKind &&
+      parsedProject.externalProjectId === parsedJob.externalProjectId
+    : parsedJob.externalProjectId === projectId;
+
+  if (!projectMatches) {
+    throw new Error("Task does not belong to this project");
+  }
+}
+
+export function mapSyncedProviderSourceFiles(input: {
+  job: JobDetailRecord;
+  projectId: string;
+  targetLocale?: string | null;
+}) {
   if (!input.job.externalProviderKind) {
     return [];
   }
 
   const encodedProjectId = parseProviderProjectId(input.projectId);
   const externalProjectId = encodedProjectId?.externalProjectId ?? input.projectId;
+  const targetLocales = resolveSyncedProviderTargetLocales(input.job, input.targetLocale ?? null);
 
   return (input.job.providerSourceFiles ?? []).flatMap((file) => {
     const record = providerSourceFileToProjectFileRecord(
       file,
       input.job.externalProviderKind as string,
       externalProjectId,
+      targetLocales,
     );
     return record ? [record] : [];
   });
@@ -177,8 +211,11 @@ export async function loadJobCatProviderJobFiles(input: {
   organizationSlug: string;
   projectId: string;
   jobId: string;
+  targetLocale?: string | null;
 }) {
-  if (parseProviderJobId(input.jobId)) {
+  const parsedJobId = parseProviderJobId(input.jobId);
+  if (parsedJobId) {
+    assertProviderJobBelongsToProject(input.jobId, input.projectId);
     return fetchTmsProviderLiveJobFiles({
       organizationSlug: input.organizationSlug,
       encodedJobId: input.jobId,
@@ -199,11 +236,16 @@ export async function loadJobCatProviderJobFiles(input: {
   });
 
   if (encodedJobId) {
+    assertProviderJobBelongsToProject(encodedJobId, input.projectId);
     return fetchTmsProviderLiveJobFiles({
       organizationSlug: input.organizationSlug,
       encodedJobId,
     });
   }
 
-  return mapSyncedProviderSourceFiles({ job, projectId: input.projectId });
+  return mapSyncedProviderSourceFiles({
+    job,
+    projectId: input.projectId,
+    targetLocale: input.targetLocale ?? null,
+  });
 }

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/load-job-cat-files.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/load-job-cat-files.ts
@@ -3,6 +3,18 @@ import type {
   ProjectFileRecord,
 } from "@/api/routes/project/project.schema";
 import { apiClient } from "@/lib/api-client-instance";
+import {
+  parseProviderJobId,
+  parseProviderProjectId,
+  resolveEncodedProviderJobId,
+} from "@/lib/providers/tms-provider-resource-id";
+import type { TmsProviderLiveFile } from "@/lib/providers/tms-provider-live";
+
+import type { JobDetailRecord } from "../../_components/job-detail-types";
+import {
+  providerSourceFileToProjectFileRecord,
+  tmsLiveFileToProjectFileRecord,
+} from "../../_components/tms/job-source-file-mappers";
 
 export const PROJECT_FILES_FETCH_LIMIT = 1_000;
 
@@ -112,13 +124,86 @@ export async function loadJobCatTargetFile(input: {
   return { status: "not_found", reference: "" };
 }
 
-export async function loadJobCatProviderFiles(input: {
+async function fetchTmsProviderLiveJobFiles(input: {
+  organizationSlug: string;
+  encodedJobId: string;
+}) {
+  const response = await apiClient.api.orgs[":organizationSlug"]["tms-provider"].jobs[
+    ":encodedJobId"
+  ].files.$get({
+    param: { organizationSlug: input.organizationSlug, encodedJobId: input.encodedJobId },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to load task files (${response.status})`);
+  }
+
+  const body = (await response.json()) as { files: TmsProviderLiveFile[] };
+  return body.files.map(tmsLiveFileToProjectFileRecord);
+}
+
+async function fetchJobDetail(organizationSlug: string, jobId: string) {
+  const response = await apiClient.api.orgs[":organizationSlug"].jobs[":jobId"].$get({
+    param: { organizationSlug, jobId },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to load task (${response.status})`);
+  }
+
+  const body = (await response.json()) as { job: JobDetailRecord };
+  return body.job;
+}
+
+export function mapSyncedProviderSourceFiles(input: { job: JobDetailRecord; projectId: string }) {
+  if (!input.job.externalProviderKind) {
+    return [];
+  }
+
+  const encodedProjectId = parseProviderProjectId(input.projectId);
+  const externalProjectId = encodedProjectId?.externalProjectId ?? input.projectId;
+
+  return (input.job.providerSourceFiles ?? []).flatMap((file) => {
+    const record = providerSourceFileToProjectFileRecord(
+      file,
+      input.job.externalProviderKind as string,
+      externalProjectId,
+    );
+    return record ? [record] : [];
+  });
+}
+
+export async function loadJobCatProviderJobFiles(input: {
   organizationSlug: string;
   projectId: string;
+  jobId: string;
 }) {
-  return fetchProjectFiles({
-    organizationSlug: input.organizationSlug,
+  if (parseProviderJobId(input.jobId)) {
+    return fetchTmsProviderLiveJobFiles({
+      organizationSlug: input.organizationSlug,
+      encodedJobId: input.jobId,
+    });
+  }
+
+  const job = await fetchJobDetail(input.organizationSlug, input.jobId);
+  if (job.projectId !== input.projectId) {
+    throw new Error("Task does not belong to this project");
+  }
+
+  const encodedJobId = resolveEncodedProviderJobId({
+    jobId: input.jobId,
     projectId: input.projectId,
-    origin: "provider",
+    externalProviderKind: job.externalProviderKind,
+    externalJobId: job.externalJobId,
+    externalTaskId: job.externalTaskId,
   });
+
+  if (encodedJobId) {
+    return fetchTmsProviderLiveJobFiles({
+      organizationSlug: input.organizationSlug,
+      encodedJobId,
+    });
+  }
+
+  return mapSyncedProviderSourceFiles({ job, projectId: input.projectId });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

When viewing job strings in the CAT workspace, the source file dropdown was loading every provider file in the project instead of only the files linked to the current task. This regressed during the TMS workspace unification (#1081).

This change restores job-scoped file loading by:
- Fetching files from the TMS provider job files API for live provider tasks
- Falling back to synced `providerSourceFiles` on the task record when a live encoded job ID is unavailable
- Populating `targetLocales` on synced fallback records so dropdown navigation works
- Verifying encoded provider job IDs belong to the current project before loading live task files

## How to test

1. Open a provider task with multiple files and click **View strings** for one file.
2. Confirm the **Source file** dropdown in the CAT header lists only files belonging to that task, not every provider file in the project.
3. Switch between files in the dropdown and verify navigation still works.
4. For synced provider tasks, confirm switching files preserves the active target locale.

```bash
cd apps/hyperlocalise-web
vp test src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/load-job-cat-files.test.ts
vp check --fix
```

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, `vp test`)
- [x] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f22ca-4653-7bcf-911a-ab387a63cffc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f22ca-4653-7bcf-911a-ab387a63cffc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

