### PR TITLE
🧪 Scout: Capture ICU styles in message invariants

### DIFF
--- a/.jules/scout.md
+++ b/.jules/scout.md
@@ -115,3 +115,7 @@
 ## 2025-08-01 - [Preserving Path Relativity with Empty Tokens]
 **Learning:** Path resolution patterns starting with tokens (e.g., `{{localeDir}}/index.mdx`) can become absolute (e.g., `/index.mdx`) if the token resolves to an empty string. This causes "path escapes root" errors in security-sensitive CLI operations that expect relative paths.
 **Action:** When resolving paths, only trim leading slashes if the original pattern was relative. Use `strings.TrimPrefix(path, "/")` conditionally based on the original pattern's prefix to preserve both absolute paths and intended relativity.
+
+## 2025-08-05 - [ICU Invariant Styles]
+**Learning:** ICU invariant analysis must capture styles for typed elements (number, date, time) in the BlockSignature Options field. This ensures that changes to the formatting style are detected as invariant mismatches, which is critical for maintaining consistency between source and translations.
+**Action:** Always include the Style field from NumberElement, DateElement, and TimeElement in the ICUBlocks signature when collecting message invariants.

--- a/internal/i18n/icuparser/invariant.go
+++ b/internal/i18n/icuparser/invariant.go
@@ -181,23 +181,11 @@ func collectInvariantFromElement(el Element, inv *Invariant, pluralArg string) {
 	case ArgumentElement:
 		appendPlaceholder(inv, v.Value)
 	case NumberElement:
-		appendPlaceholder(inv, v.Value)
-		inv.ICUBlocks = append(inv.ICUBlocks, BlockSignature{
-			Arg:  v.Value,
-			Type: "number",
-		})
+		appendTypedBlockInvariant(inv, v.Value, "number", v.Style)
 	case DateElement:
-		appendPlaceholder(inv, v.Value)
-		inv.ICUBlocks = append(inv.ICUBlocks, BlockSignature{
-			Arg:  v.Value,
-			Type: "date",
-		})
+		appendTypedBlockInvariant(inv, v.Value, "date", v.Style)
 	case TimeElement:
-		appendPlaceholder(inv, v.Value)
-		inv.ICUBlocks = append(inv.ICUBlocks, BlockSignature{
-			Arg:  v.Value,
-			Type: "time",
-		})
+		appendTypedBlockInvariant(inv, v.Value, "time", v.Style)
 	case SelectElement:
 		appendSelectBlockInvariant(inv, v, pluralArg)
 	case PluralElement:
@@ -221,6 +209,18 @@ func appendPlaceholder(inv *Invariant, value string) {
 	if isPlaceholderName(value) {
 		inv.Placeholders = append(inv.Placeholders, value)
 	}
+}
+
+func appendTypedBlockInvariant(inv *Invariant, arg, kind, style string) {
+	appendPlaceholder(inv, arg)
+	sig := BlockSignature{
+		Arg:  arg,
+		Type: kind,
+	}
+	if style != "" {
+		sig.Options = []string{style}
+	}
+	inv.ICUBlocks = append(inv.ICUBlocks, sig)
 }
 
 func appendSelectBlockInvariant(inv *Invariant, v SelectElement, pluralArg string) {

--- a/internal/i18n/icuparser/invariant_scout_test.go
+++ b/internal/i18n/icuparser/invariant_scout_test.go
@@ -1,0 +1,48 @@
+package icuparser
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseInvariantIncludesTypedBlockOptions(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  string
+		want []BlockSignature
+	}{
+		{
+			name: "number with style",
+			msg:  "{n, number, currency}",
+			want: []BlockSignature{
+				{Arg: "n", Type: "number", Options: []string{"currency"}},
+			},
+		},
+		{
+			name: "date with style",
+			msg:  "{d, date, short}",
+			want: []BlockSignature{
+				{Arg: "d", Type: "date", Options: []string{"short"}},
+			},
+		},
+		{
+			name: "time with style",
+			msg:  "{t, time, ::Hmm}",
+			want: []BlockSignature{
+				{Arg: "t", Type: "time", Options: []string{"::Hmm"}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inv, err := ParseInvariant(tt.msg)
+			if err != nil {
+				t.Fatalf("ParseInvariant failed: %v", err)
+			}
+			if !reflect.DeepEqual(inv.ICUBlocks, tt.want) {
+				t.Errorf("ICUBlocks mismatch\n got: %s\nwant: %s", FormatICUBlocks(inv.ICUBlocks), FormatICUBlocks(tt.want))
+			}
+		})
+	}
+}

--- a/internal/i18n/icuparser/parser_test.go
+++ b/internal/i18n/icuparser/parser_test.go
@@ -23,8 +23,9 @@ func TestParserFeatureParitySubset(t *testing.T) {
 			msg:              "Date {ts, date, ::yyyyMMdd}",
 			wantPlaceholders: []string{"ts"},
 			wantICU: []BlockSignature{{
-				Arg:  "ts",
-				Type: "date",
+				Arg:     "ts",
+				Type:    "date",
+				Options: []string{"::yyyyMMdd"},
 			}},
 		},
 		{


### PR DESCRIPTION
💡 What: Updated ICU invariant analysis to capture formatting styles for number, date, and time elements.
🎯 Why: Ensuring formatting styles are part of the message invariant structure allows for more precise parity checks between source and translations, preventing regressions where a translator might accidentally change or omit a required style.
🧩 Scope: Modified `internal/i18n/icuparser/invariant.go` and updated related tests in `internal/i18n/icuparser/`.
✅ Verification: Ran `go test ./internal/i18n/icuparser/...` and verified all 38 tests pass, including the new `TestParseInvariantIncludesTypedBlockOptions`.
🛡️ Confidence: High. The change is straightforward and improves the accuracy of message structural fingerprints.

---
*PR created automatically by Jules for task [4356535212841888702](https://jules.google.com/task/4356535212841888702) started by @cungminh2710*