### PR TITLE
perf(crowdin): reduce TMS jobs list API fan-out

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.test.ts
+++ b/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.test.ts
@@ -655,4 +655,56 @@ describe("tmsProviderRoutes", () => {
       message: "Connect your Crowdin account before using Crowdin.",
     });
   });
+
+  it("returns locale readiness for a Crowdin project language", async () => {
+    const identity = fixture.createWorkosIdentityWithRole("admin");
+    const headers = await fixture.authHeadersFor(identity);
+    const organizationId = globalThis.__testApiAuthContext!.organization.localOrganizationId;
+
+    await upsertOrganizationExternalTmsProviderCredential({
+      organizationId,
+      userId: globalThis.__testApiAuthContext!.user.localUserId,
+      role: "admin",
+      providerKind: "crowdin",
+      displayName: "Crowdin",
+      secretMaterial: "crowdin-secret",
+    });
+
+    vi.spyOn(tmsProviderLive, "getTmsProviderLiveProjectLocaleReadiness").mockResolvedValue({
+      fr: {
+        translationProgress: 42,
+        approvalProgress: 10,
+        words: { total: 100, translated: 42, approved: 10 },
+      },
+    });
+
+    const response = await client.api.orgs[":organizationSlug"]["tms-provider"].projects[
+      ":externalProjectId"
+    ]["locale-readiness"].$get(
+      {
+        param: {
+          organizationSlug: identity.organization.slug ?? "missing",
+          externalProjectId: "9",
+        },
+        query: { languageId: "fr" },
+      },
+      { headers },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      localeReadiness: {
+        fr: {
+          translationProgress: 42,
+          approvalProgress: 10,
+          words: { total: 100, translated: 42, approved: 10 },
+        },
+      },
+    });
+    expect(tmsProviderLive.getTmsProviderLiveProjectLocaleReadiness).toHaveBeenCalledWith(
+      organizationId,
+      "9",
+      expect.objectContaining({ languageId: "fr" }),
+    );
+  });
 });

--- a/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/tms-provider/tms-provider.route.ts
@@ -26,6 +26,7 @@ import {
   listTmsProviderLiveJobComments,
   listTmsProviderLiveJobFiles,
   getTmsProviderLiveJobDetail,
+  getTmsProviderLiveProjectLocaleReadiness,
   updateTmsProviderLiveJobDescription,
   getTmsProviderLiveProject,
   listTmsProviderLiveFilesForProject,
@@ -52,6 +53,10 @@ const externalProjectIdQuerySchema = z.object({
 
 const projectFilesQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(1_000).optional().default(500),
+});
+
+const localeReadinessQuerySchema = z.object({
+  languageId: z.string().min(1).optional(),
 });
 
 const updateJobDescriptionBodySchema = z.object({
@@ -97,6 +102,15 @@ const validateExternalProjectIdQuery = validator("query", (value, c) => {
 
 const validateProjectFilesQuery = validator("query", (value, c) => {
   const parsed = projectFilesQuerySchema.safeParse(value);
+  if (!parsed.success) {
+    return c.json({ error: "invalid_query" }, 400);
+  }
+
+  return parsed.data;
+});
+
+const validateLocaleReadinessQuery = validator("query", (value, c) => {
+  const parsed = localeReadinessQuerySchema.safeParse(value);
   if (!parsed.success) {
     return c.json({ error: "invalid_query" }, 400);
   }
@@ -239,6 +253,31 @@ export function createTmsProviderRoutes(options: CreateTmsProviderRoutesOptions 
         return tmsProviderLiveErrorResponse(c, error);
       }
     })
+    .get(
+      "/projects/:externalProjectId/locale-readiness",
+      validateLocaleReadinessQuery,
+      async (c) => {
+        if (!hasCapability(c.var.auth.membership.role, "jobs:read")) {
+          return c.json({ error: "forbidden" }, 403);
+        }
+
+        const query = c.req.valid("query");
+
+        try {
+          const localeReadiness = await getTmsProviderLiveProjectLocaleReadiness(
+            c.var.auth.organization.localOrganizationId,
+            c.req.param("externalProjectId"),
+            {
+              languageId: query.languageId,
+              actorUserId: c.var.auth.user.localUserId,
+            },
+          );
+          return c.json({ localeReadiness }, 200);
+        } catch (error) {
+          return tmsProviderLiveErrorResponse(c, error);
+        }
+      },
+    )
     .get("/jobs", validateMineQuery, async (c) => {
       if (!hasCapability(c.var.auth.membership.role, "jobs:read")) {
         return c.json({ error: "forbidden" }, 403);

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_hooks/use-crowdin-job-locale-readiness.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/_hooks/use-crowdin-job-locale-readiness.ts
@@ -1,0 +1,61 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { apiClient } from "@/lib/api-client-instance";
+import {
+  extractCrowdinLocaleReadinessEntry,
+  getCrowdinTaskLanguageId,
+} from "../jobs/_components/provider-crowdin-job-display";
+
+export const crowdinJobLocaleReadinessQueryKey = (
+  organizationSlug: string,
+  externalProjectId: string,
+  languageId: string,
+) => ["crowdin-job-locale-readiness", organizationSlug, externalProjectId, languageId] as const;
+
+export async function fetchCrowdinJobLocaleReadiness(
+  organizationSlug: string,
+  externalProjectId: string,
+  languageId: string,
+) {
+  const response = await apiClient.api.orgs[":organizationSlug"]["tms-provider"].projects[
+    ":externalProjectId"
+  ]["locale-readiness"].$get({
+    param: { organizationSlug, externalProjectId },
+    query: { languageId },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to load translation progress (${response.status})`);
+  }
+
+  const body = (await response.json()) as { localeReadiness: Record<string, unknown> | null };
+  return extractCrowdinLocaleReadinessEntry(body.localeReadiness, languageId);
+}
+
+export function useCrowdinJobLocaleReadiness(input: {
+  organizationSlug: string;
+  externalProjectId: string | null | undefined;
+  providerKind: string | null | undefined;
+  providerPayload: Record<string, unknown> | null | undefined;
+  enabled?: boolean;
+}) {
+  const languageId = getCrowdinTaskLanguageId(input.providerPayload ?? null);
+  const isCrowdin = input.providerKind === "crowdin";
+  const externalProjectId = input.externalProjectId?.trim() ?? "";
+  const enabled =
+    (input.enabled ?? true) && isCrowdin && externalProjectId.length > 0 && Boolean(languageId);
+
+  return useQuery({
+    queryKey: crowdinJobLocaleReadinessQueryKey(
+      input.organizationSlug,
+      externalProjectId,
+      languageId ?? "",
+    ),
+    enabled,
+    queryFn: () =>
+      fetchCrowdinJobLocaleReadiness(input.organizationSlug, externalProjectId, languageId!),
+    staleTime: 60_000,
+  });
+}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/provider-crowdin-job-detail-rows.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/provider-crowdin-job-detail-rows.tsx
@@ -7,10 +7,10 @@ import {
   formatReadinessProgress,
   formatWordsToDo,
   getCrowdinLanguageLabel,
-  getCrowdinLocaleReadiness,
   getCrowdinTargetLocales,
   getCrowdinTaskTypeLabel,
   getProviderPayloadString,
+  resolveCrowdinLocaleReadiness,
 } from "./provider-crowdin-job-display";
 import { ProviderJobDescriptionField } from "./provider-job-description-field";
 
@@ -59,6 +59,8 @@ export function ProviderCrowdinJobDetailRows<J extends CrowdinJobDetailSource>({
   descriptionQueryKey,
   canEditDescription,
   showProviderLink = true,
+  localeReadinessLoading = false,
+  localeReadinessOverride,
   renderDescriptionField = renderProviderJobDescriptionField,
   extraRows,
 }: {
@@ -70,6 +72,8 @@ export function ProviderCrowdinJobDetailRows<J extends CrowdinJobDetailSource>({
   descriptionQueryKey?: readonly unknown[];
   canEditDescription?: boolean;
   showProviderLink?: boolean;
+  localeReadinessLoading?: boolean;
+  localeReadinessOverride?: Record<string, unknown> | null;
   renderDescriptionField?: ProviderJobDescriptionFieldRenderer;
   extraRows?: ReactNode;
 }) {
@@ -82,9 +86,13 @@ export function ProviderCrowdinJobDetailRows<J extends CrowdinJobDetailSource>({
   const crowdinDescription = isCrowdin
     ? getProviderPayloadString(providerPayload, "description")
     : null;
-  const crowdinLocaleReadiness = isCrowdin ? getCrowdinLocaleReadiness(providerPayload) : null;
-  const crowdinProgress = formatReadinessProgress(crowdinLocaleReadiness);
-  const crowdinWordsToDo = formatWordsToDo(crowdinLocaleReadiness);
+  const crowdinLocaleReadiness = isCrowdin
+    ? (localeReadinessOverride ?? resolveCrowdinLocaleReadiness(providerPayload))
+    : null;
+  const crowdinProgress = localeReadinessLoading
+    ? "Loading progress..."
+    : formatReadinessProgress(crowdinLocaleReadiness);
+  const crowdinWordsToDo = localeReadinessLoading ? null : formatWordsToDo(crowdinLocaleReadiness);
   const canEditProviderDescription =
     isCrowdin && job.id.startsWith("ext:") && Boolean(descriptionQueryKey?.length);
 
@@ -110,7 +118,9 @@ export function ProviderCrowdinJobDetailRows<J extends CrowdinJobDetailSource>({
           </dd>
         </div>
       ) : null}
-      {crowdinProgress ? <JobDetailRow label="Progress" value={crowdinProgress} /> : null}
+      {crowdinProgress || localeReadinessLoading ? (
+        <JobDetailRow label="Progress" value={crowdinProgress ?? "Loading progress..."} />
+      ) : null}
       {crowdinWordsToDo ? <JobDetailRow label="Words to do" value={crowdinWordsToDo} /> : null}
       <JobDetailRow label="Due date" value={formatDateTime(job.externalDueDate)} />
       {job.externalJobId ? (

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/provider-crowdin-job-display.ts
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/jobs/_components/provider-crowdin-job-display.ts
@@ -115,6 +115,60 @@ export function getCrowdinLocaleReadiness(payload: Record<string, unknown> | nul
   return readiness as Record<string, unknown>;
 }
 
+export function getCrowdinTaskLanguageId(payload: Record<string, unknown> | null) {
+  return (
+    getProviderPayloadString(payload, "languageId") ??
+    getProviderPayloadString(payload, "targetLanguageId") ??
+    getProviderPayloadStringArray(payload, "targetLanguageIds")[0] ??
+    null
+  );
+}
+
+function isLocaleReadinessEntry(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.translationProgress === "number" ||
+    typeof record.approvalProgress === "number" ||
+    (typeof record.words === "object" && record.words !== null && !Array.isArray(record.words))
+  );
+}
+
+export function extractCrowdinLocaleReadinessEntry(
+  localeReadiness: Record<string, unknown> | null | undefined,
+  languageId: string | null,
+): Record<string, unknown> | null {
+  if (!localeReadiness) {
+    return null;
+  }
+
+  if (isLocaleReadinessEntry(localeReadiness)) {
+    return localeReadiness;
+  }
+
+  if (languageId && isLocaleReadinessEntry(localeReadiness[languageId])) {
+    return localeReadiness[languageId] as Record<string, unknown>;
+  }
+
+  return null;
+}
+
+export function resolveCrowdinLocaleReadiness(
+  payload: Record<string, unknown> | null,
+  lazyReadinessByLanguage?: Record<string, unknown> | null,
+): Record<string, unknown> | null {
+  const languageId = getCrowdinTaskLanguageId(payload);
+  const fromLazy = extractCrowdinLocaleReadinessEntry(lazyReadinessByLanguage ?? null, languageId);
+  if (fromLazy) {
+    return fromLazy;
+  }
+
+  return extractCrowdinLocaleReadinessEntry(getCrowdinLocaleReadiness(payload), languageId);
+}
+
 export function getReadinessNumber(readiness: Record<string, unknown> | null, key: string) {
   const value = readiness?.[key];
   return typeof value === "number" && Number.isFinite(value) ? value : null;

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-layout-helpers.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/job-detail-layout-helpers.tsx
@@ -19,10 +19,10 @@ import {
   formatReadinessProgress,
   formatWordsToDo,
   getCrowdinLanguageLabel,
-  getCrowdinLocaleReadiness,
   getCrowdinTargetLocales,
   getCrowdinTaskTypeLabel,
   getReadinessNumber,
+  resolveCrowdinLocaleReadiness,
 } from "../../../../../jobs/_components/provider-crowdin-job-display";
 
 import { formatJobDetailDate, isProviderBackedJob, type JobDetailRecord } from "./job-detail-types";
@@ -39,6 +39,8 @@ export type JobDetailTaskLayoutInput = {
   externalTaskId: string | null;
   id: string;
   kind: string;
+  localeReadinessLoading?: boolean;
+  localeReadinessOverride?: Record<string, unknown> | null;
   projectId: string | null;
   projectName: string | null;
   sourceFilesMetric?: string | null;
@@ -69,8 +71,15 @@ function formatProviderKind(kind: string | null | undefined) {
   return getTmsProviderBranding(kind).name;
 }
 
-function getProgressValue(payload: Record<string, unknown> | null) {
-  const readiness = getCrowdinLocaleReadiness(payload);
+function resolveTaskLocaleReadiness(input: JobDetailTaskLayoutInput) {
+  if (input.localeReadinessOverride) {
+    return input.localeReadinessOverride;
+  }
+
+  return resolveCrowdinLocaleReadiness(input.externalProviderPayload);
+}
+
+function getProgressValue(readiness: Record<string, unknown> | null) {
   const translationProgress = getReadinessNumber(readiness, "translationProgress");
   const approvalProgress = getReadinessNumber(readiness, "approvalProgress");
   return Math.max(0, Math.min(100, Math.round(translationProgress ?? approvalProgress ?? 0)));
@@ -92,6 +101,8 @@ export function jobDetailTaskTitle(input: JobDetailTaskLayoutInput) {
 export function jobDetailTaskMetrics(input: JobDetailTaskLayoutInput): JobDetailViewMetric[] {
   const providerKind = input.externalProviderKind;
   const payload = input.externalProviderPayload;
+  const readiness = resolveTaskLocaleReadiness(input);
+  const wordsToDo = formatWordsToDo(readiness);
   const taskLabel = providerKind
     ? `${formatProviderKind(providerKind)} task`
     : `${formatJobKind(input.kind)} task`;
@@ -111,7 +122,7 @@ export function jobDetailTaskMetrics(input: JobDetailTaskLayoutInput): JobDetail
     {
       icon: File01Icon,
       label:
-        formatWordsToDo(getCrowdinLocaleReadiness(payload)) ??
+        (input.localeReadinessLoading ? "Loading progress..." : wordsToDo) ??
         input.sourceFilesMetric ??
         "Source files linked",
     },
@@ -127,11 +138,12 @@ export function jobDetailTaskProperties(input: JobDetailTaskLayoutInput): {
   secondaryProperties: JobDetailViewProperty[];
 } {
   const payload = input.externalProviderPayload;
-  const readiness = getCrowdinLocaleReadiness(payload);
+  const readiness = resolveTaskLocaleReadiness(input);
   const hasReadiness = readiness !== null;
-  const progress = hasReadiness ? getProgressValue(payload) : null;
-  const progressLabel =
-    hasReadiness && progress !== null
+  const progress = hasReadiness ? getProgressValue(readiness) : null;
+  const progressLabel = input.localeReadinessLoading
+    ? "Loading progress..."
+    : hasReadiness && progress !== null
       ? (formatReadinessProgress(readiness) ?? `${progress}% translated`)
       : null;
   const providerName = formatProviderKind(input.externalProviderKind);
@@ -229,7 +241,13 @@ export function jobDetailTaskLayoutFromRecord(job: JobDetailRecord): {
   };
 }
 
-export function jobDetailTaskLayoutFromLiveJob(job: TmsProviderLiveJobDetail): {
+export function jobDetailTaskLayoutFromLiveJob(
+  job: TmsProviderLiveJobDetail,
+  options?: {
+    localeReadinessLoading?: boolean;
+    localeReadinessOverride?: Record<string, unknown> | null;
+  },
+): {
   input: JobDetailTaskLayoutInput;
   metrics: JobDetailViewMetric[];
   properties: JobDetailViewProperty[];
@@ -252,6 +270,8 @@ export function jobDetailTaskLayoutFromLiveJob(job: TmsProviderLiveJobDetail): {
     projectId: job.projectId,
     projectName: job.projectName,
     kind: job.kind,
+    localeReadinessLoading: options?.localeReadinessLoading,
+    localeReadinessOverride: options?.localeReadinessOverride,
   };
 
   const { properties, secondaryProperties } = jobDetailTaskProperties(input);

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-content.tsx
@@ -9,6 +9,7 @@ import type { TmsProviderLiveJobDetail } from "@/lib/providers/tms-provider-live
 import { parseProviderJobId } from "@/lib/providers/tms-provider-resource-id";
 
 import { ProviderJobDescriptionField } from "../../../../../jobs/_components/provider-job-description-field";
+import { useCrowdinJobLocaleReadiness } from "../../../../../_hooks/use-crowdin-job-locale-readiness";
 import { ProviderLiveJobDetailView } from "./provider-live-job-detail-view";
 import { TmsLiveJobFilesSection } from "./tms/tms-live-job-files-section";
 
@@ -58,6 +59,15 @@ export function ProviderLiveJobDetailContent({
     },
   });
 
+  const parsedJobId = parseProviderJobId(jobId);
+  const localeReadinessQuery = useCrowdinJobLocaleReadiness({
+    organizationSlug,
+    externalProjectId: parsedJobId?.externalProjectId,
+    providerKind: jobQuery.data?.externalProviderKind,
+    providerPayload: jobQuery.data?.externalProviderPayload,
+    enabled: Boolean(jobQuery.data),
+  });
+
   const translateWithAgent = useMutation({
     mutationFn: async () => {
       const response = await apiClient.api.orgs[":organizationSlug"]["tms-provider"].jobs[
@@ -100,6 +110,8 @@ export function ProviderLiveJobDetailContent({
       job={jobQuery.data}
       isLoading={jobQuery.isLoading}
       error={jobQuery.isError ? jobQuery.error : undefined}
+      localeReadinessLoading={localeReadinessQuery.isLoading}
+      localeReadinessOverride={localeReadinessQuery.data ?? null}
       isRefreshing={jobQuery.isFetching}
       isTranslateWithAgentPending={translateWithAgent.isPending}
       translateWithAgentAction={translateAction}

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-view.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/_components/provider-live-job-detail-view.tsx
@@ -42,6 +42,8 @@ export function ProviderLiveJobDetailView({
   isTranslateWithAgentPending = false,
   job,
   jobId,
+  localeReadinessLoading = false,
+  localeReadinessOverride,
   onRefresh,
   onTranslateWithAgent,
   organizationSlug,
@@ -62,6 +64,8 @@ export function ProviderLiveJobDetailView({
   isTranslateWithAgentPending?: boolean;
   job?: TmsProviderLiveJobDetail;
   jobId: string;
+  localeReadinessLoading?: boolean;
+  localeReadinessOverride?: Record<string, unknown> | null;
   onRefresh?: () => void;
   onTranslateWithAgent?: () => void;
   organizationSlug: string;
@@ -86,7 +90,12 @@ export function ProviderLiveJobDetailView({
   const translateWithAgentLabel = isTranslateWithAgentPending
     ? "Starting agent..."
     : (translateWithAgentAction?.label ?? "Translate with agent");
-  const layout = job ? jobDetailTaskLayoutFromLiveJob(job) : null;
+  const layout = job
+    ? jobDetailTaskLayoutFromLiveJob(job, {
+        localeReadinessLoading,
+        localeReadinessOverride,
+      })
+    : null;
 
   const headerActions = job ? (
     <>

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
@@ -693,6 +693,47 @@ describe("CrowdinApiClient", () => {
     });
   });
 
+  it("lists user tasks", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      const path = String(url);
+      expect(path).toContain("/user/tasks?");
+      expect(path).toContain("projectId=1");
+
+      return new Response(
+        JSON.stringify({
+          data: [
+            {
+              data: {
+                id: 3001,
+                projectId: 1,
+                type: 0,
+                status: "todo",
+                title: "Assigned task",
+                description: null,
+                languageId: "de",
+                fileIds: [],
+                assignees: [{ id: 2, username: "me" }],
+                deadline: null,
+                webUrl: "https://crowdin.com/project/1/tasks/3001",
+              },
+            },
+          ],
+        }),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    const tasks = await client.listUserTasks({ projectId: 1 });
+
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]).toMatchObject({
+      id: 3001,
+      projectId: 1,
+      title: "Assigned task",
+    });
+  });
+
   it("gets a task and uploads translations through storage", async () => {
     const fetchMock = vi.fn(async (url, init) => {
       const path = String(url);

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
@@ -656,8 +656,13 @@ describe("CrowdinApiClient", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("lists tasks", async () => {
-    const fetchMock = vi.fn(async () => {
+  it("lists tasks with live list defaults", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      const path = String(url);
+      expect(path).toContain("/projects/1/tasks?");
+      expect(path).toContain("limit=50");
+      expect(path).toContain("orderBy=createdAt%20desc");
+
       return new Response(
         JSON.stringify({
           data: [
@@ -693,11 +698,13 @@ describe("CrowdinApiClient", () => {
     });
   });
 
-  it("lists user tasks", async () => {
+  it("lists user tasks with live list defaults", async () => {
     const fetchMock = vi.fn(async (url) => {
       const path = String(url);
       expect(path).toContain("/user/tasks?");
       expect(path).toContain("projectId=1");
+      expect(path).toContain("limit=50");
+      expect(path).toContain("orderBy=createdAt%20desc");
 
       return new Response(
         JSON.stringify({

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
@@ -805,6 +805,32 @@ export class CrowdinApiClient {
   }
 
   /**
+   * List tasks assigned to the authenticated user, optionally scoped to a project.
+   */
+  async listUserTasks(options?: { projectId?: number }): Promise<CrowdinTask[]> {
+    const tasks: CrowdinTask[] = [];
+    let offset = 0;
+    const limit = 500;
+    const projectParam = options?.projectId !== undefined ? `&projectId=${options.projectId}` : "";
+
+    while (true) {
+      const response = await this.get<CrowdinListResponse<CrowdinTask>>(
+        `/user/tasks?limit=${limit}&offset=${offset}${projectParam}`,
+      );
+      const page = response.data.map((item) => item.data);
+      tasks.push(...page);
+
+      if (page.length < limit) {
+        break;
+      }
+
+      offset += limit;
+    }
+
+    return tasks;
+  }
+
+  /**
    * Get a single task by identifier.
    */
   async getTask(projectId: number, taskId: number): Promise<CrowdinTaskDetails> {

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
@@ -12,6 +12,17 @@ import { normalizeProviderDownloadUrl } from "@/lib/providers/provider-url-safet
 
 const logger = createLogger("crowdin-api");
 
+export const CROWDIN_LIVE_TASK_LIST_LIMIT = 50;
+export const CROWDIN_LIVE_TASK_LIST_ORDER_BY = "createdAt desc";
+export const CROWDIN_SYNC_TASK_PAGE_LIMIT = 500;
+
+export type ListCrowdinTasksOptions = {
+  limit?: number;
+  offset?: number;
+  orderBy?: string;
+  fetchAll?: boolean;
+};
+
 function defaultCrowdinFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
   return globalThis.fetch(input, init);
 }
@@ -781,20 +792,27 @@ export class CrowdinApiClient {
 
   /**
    * List tasks for a given project.
+   *
+   * Live list views request a single page of the newest tasks. Sync passes
+   * `fetchAll: true` to paginate through the full task history.
    */
-  async listTasks(projectId: number): Promise<CrowdinTask[]> {
+  async listTasks(projectId: number, options?: ListCrowdinTasksOptions): Promise<CrowdinTask[]> {
+    const fetchAll = options?.fetchAll ?? false;
+    const limit =
+      options?.limit ?? (fetchAll ? CROWDIN_SYNC_TASK_PAGE_LIMIT : CROWDIN_LIVE_TASK_LIST_LIMIT);
+    const orderBy = options?.orderBy ?? (fetchAll ? undefined : CROWDIN_LIVE_TASK_LIST_ORDER_BY);
     const tasks: CrowdinTask[] = [];
-    let offset = 0;
-    const limit = 500;
+    let offset = options?.offset ?? 0;
 
     while (true) {
+      const orderParam = orderBy ? `&orderBy=${encodeURIComponent(orderBy)}` : "";
       const response = await this.get<CrowdinListResponse<CrowdinTask>>(
-        `/projects/${projectId}/tasks?limit=${limit}&offset=${offset}`,
+        `/projects/${projectId}/tasks?limit=${limit}&offset=${offset}${orderParam}`,
       );
       const page = response.data.map((item) => item.data);
       tasks.push(...page);
 
-      if (page.length < limit) {
+      if (!fetchAll || page.length < limit) {
         break;
       }
 
@@ -807,20 +825,26 @@ export class CrowdinApiClient {
   /**
    * List tasks assigned to the authenticated user, optionally scoped to a project.
    */
-  async listUserTasks(options?: { projectId?: number }): Promise<CrowdinTask[]> {
+  async listUserTasks(
+    options?: { projectId?: number } & ListCrowdinTasksOptions,
+  ): Promise<CrowdinTask[]> {
+    const fetchAll = options?.fetchAll ?? false;
+    const limit =
+      options?.limit ?? (fetchAll ? CROWDIN_SYNC_TASK_PAGE_LIMIT : CROWDIN_LIVE_TASK_LIST_LIMIT);
+    const orderBy = options?.orderBy ?? (fetchAll ? undefined : CROWDIN_LIVE_TASK_LIST_ORDER_BY);
     const tasks: CrowdinTask[] = [];
-    let offset = 0;
-    const limit = 500;
+    let offset = options?.offset ?? 0;
     const projectParam = options?.projectId !== undefined ? `&projectId=${options.projectId}` : "";
 
     while (true) {
+      const orderParam = orderBy ? `&orderBy=${encodeURIComponent(orderBy)}` : "";
       const response = await this.get<CrowdinListResponse<CrowdinTask>>(
-        `/user/tasks?limit=${limit}&offset=${offset}${projectParam}`,
+        `/user/tasks?limit=${limit}&offset=${offset}${projectParam}${orderParam}`,
       );
       const page = response.data.map((item) => item.data);
       tasks.push(...page);
 
-      if (page.length < limit) {
+      if (!fetchAll || page.length < limit) {
         break;
       }
 

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-job-task-fetcher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-job-task-fetcher.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
-import { fetchCrowdinJobTasks } from "./crowdin-job-task-fetcher";
+import { fetchCrowdinJobTasks, fetchCrowdinUserJobTasks } from "./crowdin-job-task-fetcher";
 
 describe("fetchCrowdinJobTasks", () => {
   let originalFetch: typeof fetch;
@@ -74,6 +74,7 @@ describe("fetchCrowdinJobTasks", () => {
       credential: { baseUrl: "https://api.crowdin.test/api/v2" } as never,
       project: {} as never,
       secretMaterial: "test-token",
+      includeLocaleProgress: true,
     });
 
     expect(result).toHaveLength(1);
@@ -90,6 +91,60 @@ describe("fetchCrowdinJobTasks", () => {
         translationProgress: 80,
         approvalProgress: 60,
       },
+    });
+  });
+
+  it("skips language progress on list fetches by default", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      const path = String(url);
+
+      if (path.includes("/tasks?")) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  id: 2001,
+                  projectId: 1,
+                  type: 0,
+                  status: "in_progress",
+                  title: "French translations",
+                  description: "Translate homepage",
+                  languageId: "fr",
+                  fileIds: [101],
+                  assignees: [],
+                  deadline: null,
+                  webUrl: "https://crowdin.com/project/1/tasks/2001",
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/languages/progress?")) {
+        throw new Error("language progress should not be requested");
+      }
+
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    globalThis.fetch = fetchMock;
+
+    const result = await fetchCrowdinJobTasks({
+      organizationId: "org-1",
+      projectId: "project-1",
+      providerKind: "crowdin",
+      externalProjectId: "1",
+      credential: { baseUrl: "https://api.crowdin.test/api/v2" } as never,
+      project: {} as never,
+      secretMaterial: "test-token",
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.providerPayload).toMatchObject({
+      localeReadiness: null,
     });
   });
 
@@ -184,5 +239,60 @@ describe("fetchCrowdinJobTasks", () => {
         secretMaterial: "test-token",
       }),
     ).rejects.toThrow("crowdin_auth_invalid");
+  });
+
+  it("lists user tasks without language progress", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      const path = String(url);
+
+      if (path.includes("/user/tasks?")) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  id: 4001,
+                  projectId: 2,
+                  type: 0,
+                  status: "todo",
+                  title: "My task",
+                  description: null,
+                  languageId: "fr",
+                  fileIds: [],
+                  assignees: [{ id: 1, username: "translator1" }],
+                  deadline: null,
+                  webUrl: "https://crowdin.com/project/2/tasks/4001",
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    globalThis.fetch = fetchMock;
+
+    const result = await fetchCrowdinUserJobTasks({
+      credential: { baseUrl: "https://api.crowdin.test/api/v2" } as never,
+      secretMaterial: "test-token",
+      externalProjectId: "2",
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      externalJobId: "4001",
+      title: "My task",
+    });
+    expect(result[0]?.providerPayload).toMatchObject({
+      projectId: 2,
+      localeReadiness: null,
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringMatching(/\/user\/tasks\?.*projectId=2/),
+      expect.anything(),
+    );
   });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-job-task-fetcher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-job-task-fetcher.ts
@@ -48,14 +48,23 @@ export function mapCrowdinTaskToJobTaskMetadata(
 async function loadCrowdinLocaleReadiness(
   client: CrowdinApiClient,
   projectId: number,
+  languageIds?: string[],
 ): Promise<Record<string, unknown>> {
   let progress: Awaited<ReturnType<typeof client.listProjectLanguageProgress>> = [];
   try {
-    progress = await client.listProjectLanguageProgress(projectId);
+    progress = await client.listProjectLanguageProgress(projectId, {
+      languageIds,
+    });
   } catch {
     // Translation progress is best-effort; do not fail task sync if it is unavailable
   }
 
+  return mapCrowdinLanguageProgressToLocaleReadiness(progress);
+}
+
+export function mapCrowdinLanguageProgressToLocaleReadiness(
+  progress: Awaited<ReturnType<CrowdinApiClient["listProjectLanguageProgress"]>>,
+): Record<string, unknown> {
   const localeReadiness: Record<string, unknown> = {};
   for (const lang of progress) {
     localeReadiness[lang.languageId] = {
@@ -65,7 +74,6 @@ async function loadCrowdinLocaleReadiness(
       phrases: lang.phrases,
     };
   }
-
   return localeReadiness;
 }
 
@@ -84,6 +92,7 @@ export const fetchCrowdinJobTasks: ExternalTmsJobTaskFetcher = async ({
   externalProjectId,
   secretMaterial,
   includeLocaleProgress = false,
+  fetchAllTasks = false,
 }) => {
   const client = createCrowdinJobTaskClient({ credential, secretMaterial });
 
@@ -94,7 +103,7 @@ export const fetchCrowdinJobTasks: ExternalTmsJobTaskFetcher = async ({
 
   let tasks: Awaited<ReturnType<typeof client.listTasks>>;
   try {
-    tasks = await client.listTasks(projectId);
+    tasks = await client.listTasks(projectId, { fetchAll: fetchAllTasks });
   } catch (error) {
     if (error instanceof CrowdinApiError && error.status === 401) {
       throw new Error("crowdin_auth_invalid");
@@ -113,6 +122,7 @@ export async function fetchCrowdinUserJobTasks(input: {
   credential: { baseUrl?: string | null };
   secretMaterial: string;
   externalProjectId?: string;
+  fetchAllTasks?: boolean;
 }): Promise<ExternalTmsJobTaskMetadata[]> {
   const client = createCrowdinJobTaskClient(input);
 
@@ -124,7 +134,10 @@ export async function fetchCrowdinUserJobTasks(input: {
 
   let tasks: Awaited<ReturnType<typeof client.listUserTasks>>;
   try {
-    tasks = await client.listUserTasks(projectId !== undefined ? { projectId } : undefined);
+    tasks = await client.listUserTasks({
+      ...(projectId !== undefined ? { projectId } : {}),
+      fetchAll: input.fetchAllTasks ?? false,
+    });
   } catch (error) {
     if (error instanceof CrowdinApiError && error.status === 401) {
       throw new Error("crowdin_auth_invalid");

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-job-task-fetcher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-job-task-fetcher.ts
@@ -29,6 +29,7 @@ export function mapCrowdinTaskToJobTaskMetadata(
     assignedUsers: task.assignees?.map((a) => (a.username ? a.username : String(a.id))) ?? [],
     externalUrl: task.webUrl,
     providerPayload: {
+      projectId: task.projectId,
       type: task.type,
       description: task.description,
       fileIds: task.fileIds,
@@ -44,31 +45,10 @@ export function mapCrowdinTaskToJobTaskMetadata(
   };
 }
 
-export const fetchCrowdinJobTasks: ExternalTmsJobTaskFetcher = async ({
-  credential,
-  externalProjectId,
-  secretMaterial,
-}) => {
-  const client = new CrowdinApiClient({
-    token: secretMaterial,
-    baseUrl: credential.baseUrl ?? undefined,
-  });
-
-  const projectId = Number(externalProjectId);
-  if (Number.isNaN(projectId)) {
-    throw new Error("invalid_crowdin_project_id");
-  }
-
-  let tasks: Awaited<ReturnType<typeof client.listTasks>>;
-  try {
-    tasks = await client.listTasks(projectId);
-  } catch (error) {
-    if (error instanceof CrowdinApiError && error.status === 401) {
-      throw new Error("crowdin_auth_invalid");
-    }
-    throw error;
-  }
-
+async function loadCrowdinLocaleReadiness(
+  client: CrowdinApiClient,
+  projectId: number,
+): Promise<Record<string, unknown>> {
   let progress: Awaited<ReturnType<typeof client.listProjectLanguageProgress>> = [];
   try {
     progress = await client.listProjectLanguageProgress(projectId);
@@ -86,8 +66,74 @@ export const fetchCrowdinJobTasks: ExternalTmsJobTaskFetcher = async ({
     };
   }
 
+  return localeReadiness;
+}
+
+function createCrowdinJobTaskClient(input: {
+  credential: { baseUrl?: string | null };
+  secretMaterial: string;
+}) {
+  return new CrowdinApiClient({
+    token: input.secretMaterial,
+    baseUrl: input.credential.baseUrl ?? undefined,
+  });
+}
+
+export const fetchCrowdinJobTasks: ExternalTmsJobTaskFetcher = async ({
+  credential,
+  externalProjectId,
+  secretMaterial,
+  includeLocaleProgress = false,
+}) => {
+  const client = createCrowdinJobTaskClient({ credential, secretMaterial });
+
+  const projectId = Number(externalProjectId);
+  if (Number.isNaN(projectId)) {
+    throw new Error("invalid_crowdin_project_id");
+  }
+
+  let tasks: Awaited<ReturnType<typeof client.listTasks>>;
+  try {
+    tasks = await client.listTasks(projectId);
+  } catch (error) {
+    if (error instanceof CrowdinApiError && error.status === 401) {
+      throw new Error("crowdin_auth_invalid");
+    }
+    throw error;
+  }
+
+  const localeReadiness = includeLocaleProgress
+    ? await loadCrowdinLocaleReadiness(client, projectId)
+    : {};
+
   return tasks.map((task) => mapCrowdinTaskToJobTaskMetadata(task, localeReadiness));
 };
+
+export async function fetchCrowdinUserJobTasks(input: {
+  credential: { baseUrl?: string | null };
+  secretMaterial: string;
+  externalProjectId?: string;
+}): Promise<ExternalTmsJobTaskMetadata[]> {
+  const client = createCrowdinJobTaskClient(input);
+
+  const projectId =
+    input.externalProjectId !== undefined ? Number(input.externalProjectId) : undefined;
+  if (projectId !== undefined && Number.isNaN(projectId)) {
+    throw new Error("invalid_crowdin_project_id");
+  }
+
+  let tasks: Awaited<ReturnType<typeof client.listUserTasks>>;
+  try {
+    tasks = await client.listUserTasks(projectId !== undefined ? { projectId } : undefined);
+  } catch (error) {
+    if (error instanceof CrowdinApiError && error.status === 401) {
+      throw new Error("crowdin_auth_invalid");
+    }
+    throw error;
+  }
+
+  return tasks.map((task) => mapCrowdinTaskToJobTaskMetadata(task, {}));
+}
 
 function mapTaskTypeToKind(
   taskType: number,

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-project-detail.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-project-detail.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { fetchCrowdinProjectDetailMetadata } from "./crowdin-project-detail";
+
+describe("fetchCrowdinProjectDetailMetadata", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("includes branch metadata for project detail", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      const path = String(url);
+
+      if (path.endsWith("/projects/42")) {
+        return new Response(
+          JSON.stringify({
+            data: {
+              id: 42,
+              name: "Marketing",
+              identifier: "marketing",
+              sourceLanguageId: "en",
+              targetLanguageIds: ["fr"],
+              webUrl: "https://crowdin.com/project/marketing",
+              isSuspended: false,
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/projects/42/branches?")) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  id: 10,
+                  name: "main",
+                  title: "Main Branch",
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    globalThis.fetch = fetchMock;
+
+    const result = await fetchCrowdinProjectDetailMetadata({
+      projectId: 42,
+      token: "test-token",
+      baseUrl: "https://api.crowdin.test/api/v2",
+    });
+
+    expect(result).toMatchObject({
+      externalProjectId: "42",
+      name: "Marketing",
+      metadata: {
+        identifier: "marketing",
+        branches: [{ id: 10, name: "main", title: "Main Branch" }],
+      },
+    });
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-project-detail.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-project-detail.ts
@@ -1,0 +1,57 @@
+import type { ExternalTmsProjectMetadata } from "@/lib/providers/tms-provider-types";
+
+import { CrowdinApiClient, CrowdinApiError } from "./crowdin-api";
+import { mapCrowdinProjectToMetadata } from "./crowdin-project-fetcher";
+
+export async function fetchCrowdinProjectDetailMetadata(input: {
+  projectId: number;
+  token: string;
+  baseUrl?: string;
+}): Promise<ExternalTmsProjectMetadata | null> {
+  const client = new CrowdinApiClient({
+    token: input.token,
+    baseUrl: input.baseUrl,
+  });
+
+  let project;
+  try {
+    project = await client.getProject(input.projectId);
+  } catch (error) {
+    if (error instanceof CrowdinApiError && error.status === 404) {
+      return null;
+    }
+    if (error instanceof CrowdinApiError && error.status === 401) {
+      throw new Error("crowdin_auth_invalid");
+    }
+    throw error;
+  }
+
+  const metadata = mapCrowdinProjectToMetadata(project);
+
+  try {
+    const branches = await client.listBranches(project.id);
+    return {
+      ...metadata,
+      metadata: {
+        ...metadata.metadata,
+        branches: branches.map((branch) => ({
+          id: branch.id,
+          name: branch.name,
+          title: branch.title,
+        })),
+      },
+    };
+  } catch (error) {
+    if (error instanceof CrowdinApiError && error.status === 401) {
+      throw new Error("crowdin_auth_invalid");
+    }
+
+    return {
+      ...metadata,
+      metadata: {
+        ...metadata.metadata,
+        syncWarning: error instanceof Error ? error.message : "branch_fetch_failed",
+      },
+    };
+  }
+}

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-project-fetcher.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-project-fetcher.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { fetchCrowdinProjects } from "./crowdin-project-fetcher";
+
+describe("fetchCrowdinProjects", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("lists projects without fetching branches", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      const path = String(url);
+
+      if (path.includes("/projects?")) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  id: 42,
+                  name: "Marketing",
+                  identifier: "marketing",
+                  sourceLanguageId: "en",
+                  targetLanguageIds: ["fr"],
+                  webUrl: "https://crowdin.com/project/marketing",
+                  isSuspended: false,
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/branches?")) {
+        throw new Error("branches should not be requested for project list");
+      }
+
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    globalThis.fetch = fetchMock;
+
+    const result = await fetchCrowdinProjects({
+      organizationId: "org-1",
+      providerKind: "crowdin",
+      credential: { baseUrl: "https://api.crowdin.test/api/v2" } as never,
+      secretMaterial: "test-token",
+    });
+
+    expect(result).toEqual([
+      {
+        externalProjectId: "42",
+        name: "Marketing",
+        sourceLocale: "en",
+        targetLocales: ["fr"],
+        externalProjectUrl: "https://crowdin.com/project/marketing",
+        isActive: true,
+        metadata: {
+          identifier: "marketing",
+        },
+      },
+    ]);
+  });
+});

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-project-fetcher.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-project-fetcher.ts
@@ -2,6 +2,20 @@ import type { ExternalTmsProjectFetcher } from "@/lib/providers/tms-provider-typ
 
 import { CrowdinApiClient, CrowdinApiError, type CrowdinProject } from "./crowdin-api";
 
+export function mapCrowdinProjectToMetadata(project: CrowdinProject) {
+  return {
+    externalProjectId: String(project.id),
+    name: project.name,
+    sourceLocale: project.sourceLanguageId,
+    targetLocales: project.targetLanguageIds,
+    externalProjectUrl: project.webUrl,
+    isActive: !project.isSuspended,
+    metadata: {
+      identifier: project.identifier,
+    },
+  };
+}
+
 export const fetchCrowdinProjects: ExternalTmsProjectFetcher = async ({
   credential,
   secretMaterial,
@@ -21,50 +35,5 @@ export const fetchCrowdinProjects: ExternalTmsProjectFetcher = async ({
     throw error;
   }
 
-  const results = await Promise.all(
-    projects.map(async (project) => {
-      try {
-        const branches = await client.listBranches(project.id);
-
-        return {
-          externalProjectId: String(project.id),
-          name: project.name,
-          sourceLocale: project.sourceLanguageId,
-          targetLocales: project.targetLanguageIds,
-          externalProjectUrl: project.webUrl,
-          isActive: !project.isSuspended,
-          metadata: {
-            identifier: project.identifier,
-            branches: branches.map((b) => ({
-              id: b.id,
-              name: b.name,
-              title: b.title,
-            })),
-          },
-        };
-      } catch (error) {
-        if (error instanceof CrowdinApiError && error.status === 401) {
-          throw new Error("crowdin_auth_invalid");
-        }
-
-        // Return a partial record so that one failed project does not abort
-        // the entire scan.  The sync orchestrator will record the failure
-        // and continue with the rest.
-        return {
-          externalProjectId: String(project.id),
-          name: project.name,
-          sourceLocale: project.sourceLanguageId,
-          targetLocales: project.targetLanguageIds,
-          externalProjectUrl: project.webUrl,
-          isActive: !project.isSuspended,
-          metadata: {
-            identifier: project.identifier,
-            syncWarning: error instanceof Error ? error.message : "branch_fetch_failed",
-          },
-        };
-      }
-    }),
-  );
-
-  return results;
+  return projects.map(mapCrowdinProjectToMetadata);
 };

--- a/apps/hyperlocalise-web/src/lib/providers/provider-sync-executor.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-sync-executor.test.ts
@@ -373,6 +373,7 @@ describe("executeProviderSyncIntent", () => {
       credential,
       project,
       secretMaterial: "secret",
+      fetchAllTasks: true,
     });
     expect(upsertExternalTmsJobRecordsMock).toHaveBeenCalledWith({
       organizationId: "org_123",

--- a/apps/hyperlocalise-web/src/lib/providers/provider-sync-executor.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/provider-sync-executor.ts
@@ -317,6 +317,7 @@ async function syncProviderJobTasksFromLive(
     credential: context.value.credential,
     project: context.value.project,
     secretMaterial,
+    fetchAllTasks: true,
   });
   const { upserted, newlySyncedJobIds, removed } = await upsertExternalTmsJobRecords({
     organizationId: intent.organizationId,

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.test.ts
@@ -29,6 +29,7 @@ vi.mock("@/lib/providers/adapters/crowdin/crowdin-api", () => ({
   CrowdinApiClient: vi.fn(function CrowdinApiClientMock() {
     return {
       getProject: vi.fn(),
+      listBranches: vi.fn(),
     };
   }),
   CrowdinApiError: class CrowdinApiError extends Error {
@@ -117,7 +118,7 @@ describe("getTmsProviderLiveProject", () => {
     vi.clearAllMocks();
   });
 
-  it("returns the live Crowdin project", async () => {
+  it("returns the live Crowdin project with branch metadata", async () => {
     vi.mocked(getActiveOrganizationExternalTmsProviderCredentialRow).mockResolvedValue(
       crowdinCredential as never,
     );
@@ -126,13 +127,17 @@ describe("getTmsProviderLiveProject", () => {
     const getProject = vi.fn().mockResolvedValue({
       id: 42,
       name: "Crowdin Project",
+      identifier: "crowdin-project",
       sourceLanguageId: "en",
       targetLanguageIds: ["fr"],
       webUrl: "https://crowdin.com/project/test",
       isSuspended: false,
     });
+    const listBranches = vi
+      .fn()
+      .mockResolvedValue([{ id: 10, name: "main", title: "Main Branch" }]);
     vi.mocked(CrowdinApiClient).mockImplementation(function () {
-      return { getProject } as never;
+      return { getProject, listBranches } as never;
     });
 
     const project = await getTmsProviderLiveProject("org-1", "42");
@@ -140,7 +145,12 @@ describe("getTmsProviderLiveProject", () => {
     expect(project).toMatchObject({
       name: "Crowdin Project",
       externalProjectId: "42",
+      metadata: {
+        identifier: "crowdin-project",
+        branches: [{ id: 10, name: "main", title: "Main Branch" }],
+      },
     });
     expect(getProject).toHaveBeenCalledWith(42);
+    expect(listBranches).toHaveBeenCalledWith(42);
   });
 });

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
@@ -32,6 +32,7 @@ import {
 } from "@/lib/providers/adapters/crowdin/crowdin-api";
 import {
   fetchCrowdinUserJobTasks,
+  mapCrowdinLanguageProgressToLocaleReadiness,
   mapCrowdinTaskToJobTaskMetadata,
 } from "@/lib/providers/adapters/crowdin/crowdin-job-task-fetcher";
 import { fetchCrowdinProjectDetailMetadata } from "@/lib/providers/adapters/crowdin/crowdin-project-detail";
@@ -2356,24 +2357,42 @@ async function fetchCrowdinLiveJobTaskMetadata(input: {
     throw error;
   }
 
-  let progress: Awaited<ReturnType<typeof client.listProjectLanguageProgress>> = [];
+  return mapCrowdinTaskToJobTaskMetadata(crowdinTask, {});
+}
+
+export async function getTmsProviderLiveProjectLocaleReadiness(
+  organizationId: string,
+  externalProjectId: string,
+  options?: { languageId?: string; actorUserId?: string | null },
+): Promise<Record<string, unknown> | null> {
+  const context = await loadActiveTmsProviderContext(organizationId, {
+    actorUserId: options?.actorUserId,
+  });
+  if (context.providerKind !== "crowdin") {
+    return null;
+  }
+
+  const projectId = Number(externalProjectId);
+  if (!Number.isFinite(projectId) || projectId <= 0) {
+    return null;
+  }
+
+  const client = new CrowdinApiClient({
+    token: context.secretMaterial,
+    baseUrl: context.credential.baseUrl ?? undefined,
+  });
+
+  const languageIds = options?.languageId?.trim() ? [options.languageId.trim()] : undefined;
+
   try {
-    progress = await client.listProjectLanguageProgress(projectId);
-  } catch {
-    // Best-effort progress for detail view
+    const progress = await client.listProjectLanguageProgress(projectId, { languageIds });
+    return mapCrowdinLanguageProgressToLocaleReadiness(progress);
+  } catch (error) {
+    if (error instanceof CrowdinApiError && error.status === 401) {
+      throw new TmsProviderLiveError("crowdin_auth_invalid", "Crowdin credentials are invalid.");
+    }
+    throw error;
   }
-
-  const localeReadiness: Record<string, unknown> = {};
-  for (const lang of progress) {
-    localeReadiness[lang.languageId] = {
-      translationProgress: lang.translationProgress,
-      approvalProgress: lang.approvalProgress,
-      words: lang.words,
-      phrases: lang.phrases,
-    };
-  }
-
-  return mapCrowdinTaskToJobTaskMetadata(crowdinTask, localeReadiness);
 }
 
 export async function getTmsProviderLiveJobDetail(

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
@@ -30,7 +30,11 @@ import {
   type CrowdinSourceString,
   type CrowdinStringComment,
 } from "@/lib/providers/adapters/crowdin/crowdin-api";
-import { mapCrowdinTaskToJobTaskMetadata } from "@/lib/providers/adapters/crowdin/crowdin-job-task-fetcher";
+import {
+  fetchCrowdinUserJobTasks,
+  mapCrowdinTaskToJobTaskMetadata,
+} from "@/lib/providers/adapters/crowdin/crowdin-job-task-fetcher";
+import { fetchCrowdinProjectDetailMetadata } from "@/lib/providers/adapters/crowdin/crowdin-project-detail";
 import {
   getCrowdinUserConnection,
   resolveCrowdinUserConnectionSecretMaterial,
@@ -92,6 +96,7 @@ const logger = createLogger("tms-provider-live");
 
 const LIVE_PROJECT_JOB_FANOUT_CONCURRENCY = 5;
 const LIVE_GLOSSARY_TM_FANOUT_CONCURRENCY = 5;
+const LIVE_PROJECT_LIST_CACHE_TTL_MS = 60_000;
 const openLiveJobStatuses = new Set<string>(openJobStatusValues);
 const maxLiveProviderInlineTextBytes = 512 * 1024;
 const maxLiveProviderStringPreviewItems = 1_000;
@@ -145,6 +150,7 @@ export type TmsProviderLiveProject = {
   targetLocales: string[];
   externalProjectUrl: string | null;
   isActive: boolean;
+  metadata?: Record<string, unknown>;
 };
 
 export type TmsProviderLiveJob = {
@@ -601,6 +607,7 @@ function mapLiveProject(
     targetLocales,
     externalProjectUrl: project.externalProjectUrl ?? null,
     isActive: project.isActive ?? true,
+    metadata: project.metadata,
   };
 }
 
@@ -1537,6 +1544,98 @@ async function fetchLiveProjects(context: ActiveTmsProviderContext) {
   }
 }
 
+type LiveProjectListCacheEntry = {
+  expiresAt: number;
+  projects: ExternalTmsProjectMetadata[];
+};
+
+const liveProjectListCache = new Map<string, LiveProjectListCacheEntry>();
+
+function liveProjectListCacheKey(
+  context: ActiveTmsProviderContext,
+  options?: { actorUserId?: string | null },
+) {
+  return `${context.organizationId}:${context.credential.id}:${context.providerKind}:${options?.actorUserId ?? ""}`;
+}
+
+async function fetchLiveProjectsCached(
+  context: ActiveTmsProviderContext,
+  options?: { actorUserId?: string | null },
+): Promise<ExternalTmsProjectMetadata[]> {
+  const cacheKey = liveProjectListCacheKey(context, options);
+  const cached = liveProjectListCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.projects;
+  }
+
+  const projects = await fetchLiveProjects(context);
+  liveProjectListCache.set(cacheKey, {
+    projects,
+    expiresAt: Date.now() + LIVE_PROJECT_LIST_CACHE_TTL_MS,
+  });
+  return projects;
+}
+
+function shouldUseCrowdinUserTasksForMine(
+  context: ActiveTmsProviderContext,
+  mine?: boolean,
+): boolean {
+  return (
+    Boolean(mine) &&
+    context.providerKind === "crowdin" &&
+    crowdinUsesPerUserAuth(context.credential.authMode)
+  );
+}
+
+function readCrowdinTaskProjectId(task: ExternalTmsJobTaskMetadata): string | null {
+  const projectId = task.providerPayload?.projectId;
+  if (typeof projectId === "number" && Number.isFinite(projectId)) {
+    return String(projectId);
+  }
+  if (typeof projectId === "string" && projectId.trim()) {
+    return projectId.trim();
+  }
+  return null;
+}
+
+async function listCrowdinUserAssignedLiveJobs(input: {
+  context: ActiveTmsProviderContext;
+  projects: ExternalTmsProjectMetadata[];
+  externalProjectId?: string;
+}): Promise<TmsProviderLiveJob[]> {
+  const projectNameById = new Map(
+    input.projects.map((project) => [project.externalProjectId, project.name]),
+  );
+
+  let tasks;
+  try {
+    tasks = await fetchCrowdinUserJobTasks({
+      credential: input.context.credential,
+      secretMaterial: input.context.secretMaterial,
+      externalProjectId: input.externalProjectId,
+    });
+  } catch (error) {
+    rethrowProviderFetcherError(error);
+  }
+
+  return tasks.flatMap((task) => {
+    const taskProjectId = readCrowdinTaskProjectId(task) ?? input.externalProjectId ?? null;
+    if (!taskProjectId) {
+      return [];
+    }
+
+    const projectName = projectNameById.get(taskProjectId) ?? "Unknown project";
+    return [
+      mapLiveJob({
+        providerKind: input.context.providerKind,
+        externalProjectId: taskProjectId,
+        projectName,
+        task,
+      }),
+    ];
+  });
+}
+
 export async function getTmsProviderConnection(
   organizationId: string,
 ): Promise<TmsProviderConnection | null> {
@@ -1560,7 +1659,7 @@ async function loadActiveLiveProjects(
   const context = await loadActiveTmsProviderContext(organizationId, {
     actorUserId: options?.actorUserId,
   });
-  const projects = await fetchLiveProjects(context);
+  const projects = await fetchLiveProjectsCached(context, options);
   const activeProjects = projects.filter((project) => project.isActive !== false);
   return { context, activeProjects };
 }
@@ -1576,11 +1675,30 @@ export async function listTmsProviderLiveProjects(
 async function resolveLiveProjectMetadata(
   context: ActiveTmsProviderContext,
   externalProjectId: string,
+  options?: { includeBranches?: boolean },
 ): Promise<ExternalTmsProjectMetadata | null> {
   if (context.providerKind === "crowdin") {
     const crowdinProjectId = Number(externalProjectId);
     if (!Number.isFinite(crowdinProjectId) || crowdinProjectId <= 0) {
       return null;
+    }
+
+    if (options?.includeBranches) {
+      try {
+        return await fetchCrowdinProjectDetailMetadata({
+          projectId: crowdinProjectId,
+          token: context.secretMaterial,
+          baseUrl: context.credential.baseUrl ?? undefined,
+        });
+      } catch (error) {
+        if (error instanceof Error && error.message === "crowdin_auth_invalid") {
+          throw new TmsProviderLiveError(
+            "crowdin_auth_invalid",
+            "Crowdin credentials are invalid.",
+          );
+        }
+        throw error;
+      }
     }
 
     const client = new CrowdinApiClient({
@@ -1597,6 +1715,9 @@ async function resolveLiveProjectMetadata(
         targetLocales: project.targetLanguageIds,
         externalProjectUrl: project.webUrl,
         isActive: !project.isSuspended,
+        metadata: {
+          identifier: project.identifier,
+        },
       };
     } catch (error) {
       if (error instanceof CrowdinApiError && error.status === 404) {
@@ -1606,7 +1727,7 @@ async function resolveLiveProjectMetadata(
     }
   }
 
-  const projects = await fetchLiveProjects(context);
+  const projects = await fetchLiveProjectsCached(context);
   const activeProject = projects.find(
     (project) => project.externalProjectId === externalProjectId && project.isActive !== false,
   );
@@ -1625,7 +1746,9 @@ export async function getTmsProviderLiveProject(
   const context = await loadActiveTmsProviderContext(organizationId, {
     actorUserId: options?.actorUserId,
   });
-  const projectMetadata = await resolveLiveProjectMetadata(context, externalProjectId);
+  const projectMetadata = await resolveLiveProjectMetadata(context, externalProjectId, {
+    includeBranches: true,
+  });
   if (!projectMetadata) {
     return null;
   }
@@ -1678,6 +1801,15 @@ export async function listTmsProviderLiveJobsForProject(
     (await resolveLiveProjectMetadata(context, externalProjectId));
   if (!projectMetadata) {
     return [];
+  }
+
+  if (shouldUseCrowdinUserTasksForMine(context, options?.mine)) {
+    const projects = options?.projects ?? (await fetchLiveProjectsCached(context, options));
+    return listCrowdinUserAssignedLiveJobs({
+      context,
+      projects,
+      externalProjectId,
+    });
   }
 
   const liveProject = buildLiveProviderProject({
@@ -2172,7 +2304,13 @@ export async function listTmsProviderLiveJobs(
   const context =
     options?.context ??
     (await loadActiveTmsProviderContext(organizationId, { actorUserId: options?.actorUserId }));
-  const projects = await fetchLiveProjects(context);
+
+  if (shouldUseCrowdinUserTasksForMine(context, options?.mine)) {
+    const projects = await fetchLiveProjectsCached(context, options);
+    return listCrowdinUserAssignedLiveJobs({ context, projects });
+  }
+
+  const projects = await fetchLiveProjectsCached(context, options);
   const activeProjects = projects.filter((project) => project.isActive !== false);
 
   const jobsByProject = await mapWithConcurrency(
@@ -2255,7 +2393,7 @@ export async function getTmsProviderLiveJobDetail(
     return null;
   }
 
-  const projects = await fetchLiveProjects(context);
+  const projects = await fetchLiveProjectsCached(context, options);
   const project = projects.find((item) => item.externalProjectId === parsed.externalProjectId);
   if (!project) {
     return null;
@@ -2486,7 +2624,7 @@ export async function updateTmsProviderLiveJobDescription(
     return null;
   }
 
-  const projects = await fetchLiveProjects(context);
+  const projects = await fetchLiveProjectsCached(context, { actorUserId });
   const project = projects.find((item) => item.externalProjectId === parsed.externalProjectId);
   if (!project) {
     return null;
@@ -2605,7 +2743,7 @@ export async function listTmsProviderLiveGlossaries(
     );
   }
 
-  const projects = await fetchLiveProjects(context);
+  const projects = await fetchLiveProjectsCached(context, options);
   const scopedProjects = options?.externalProjectId
     ? projects.filter((project) => project.externalProjectId === options.externalProjectId)
     : projects.filter((project) => project.isActive !== false);
@@ -2694,7 +2832,7 @@ export async function listTmsProviderLiveTranslationMemories(
     );
   }
 
-  const projects = await fetchLiveProjects(context);
+  const projects = await fetchLiveProjectsCached(context, options);
   const scopedProjects = options?.externalProjectId
     ? projects.filter((project) => project.externalProjectId === options.externalProjectId)
     : projects.filter((project) => project.isActive !== false);

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-types.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-types.ts
@@ -79,6 +79,7 @@ export type ExternalTmsJobTaskFetcher = (input: {
   secretMaterial: string;
   enrichResources?: boolean;
   includeLocaleProgress?: boolean;
+  fetchAllTasks?: boolean;
 }) => Promise<ExternalTmsJobTaskMetadata[]>;
 
 export type ExternalTmsGlossaryTermMetadata = {

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-types.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-types.ts
@@ -78,6 +78,7 @@ export type ExternalTmsJobTaskFetcher = (input: {
   project: ExternalTmsProject;
   secretMaterial: string;
   enrichResources?: boolean;
+  includeLocaleProgress?: boolean;
 }) => Promise<ExternalTmsJobTaskMetadata[]>;
 
 export type ExternalTmsGlossaryTermMetadata = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Further reduces Crowdin live API latency for project jobs and language progress, building on the earlier jobs-list optimizations.

### Tasks API (live views)
- Live task lists now request **`limit=50`** with **`orderBy=createdAt desc`** (newest first) instead of fetching 500 tasks per project
- Background sync still uses `fetchAll: true` with 500-item pages to preserve full task history

### Language progress (lazy load)
- Removed `languages/progress` from the job detail initial load (~12s in production for project 9)
- Added `GET /tms-provider/projects/:externalProjectId/locale-readiness?languageId=fr` to fetch progress for a single target language
- Job detail UI loads progress asynchronously via `useCrowdinJobLocaleReadiness` and shows "Loading progress..." until ready

### Earlier changes (same PR)
- Project list no longer fans out per-project branch fetches
- `mine=true` uses Crowdin `/user/tasks` when per-user OAuth is available
- Project list cached for 60s
- Job list skips locale progress by default

## Expected impact

For project detail / job detail on large Crowdin projects:
- **Tasks call**: ~26s → should drop substantially (50 tasks vs 500, no progress blocking)
- **Progress**: loads in parallel after the page renders, filtered to the task's target language only

## Testing

- `vp check --fix` passes
- `crowdin-api.test.ts` and `crowdin-job-task-fetcher.test.ts` pass (42 tests)
- Route integration tests require migrated Postgres (schema mismatch in cloud agent env)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d5ee80b-7cfc-4488-a9fe-b90357c17348"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d5ee80b-7cfc-4488-a9fe-b90357c17348"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

