### PR TITLE
fix(crowdin): fetch source strings by numeric id via Get String endpoint

### DIFF
--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.test.ts
@@ -544,14 +544,103 @@ describe("CrowdinApiClient", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("gets a source string by numeric id", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      expect(String(url)).toBe("https://api.crowdin.test/api/v2/projects/1/strings/1001");
+      return new Response(
+        JSON.stringify({
+          data: {
+            id: 1001,
+            projectId: 1,
+            fileId: 101,
+            branchId: null,
+            directoryId: null,
+            identifier: "hello",
+            text: "Hello",
+            type: "text",
+            context: null,
+            labelIds: null,
+          },
+        }),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    const string = await client.getSourceString(1, 1001);
+
+    expect(string).toMatchObject({ id: 1001, identifier: "hello", fileId: 101 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null when a source string id is not found", async () => {
+    const fetchMock = vi.fn(
+      async () => new Response(JSON.stringify({ errors: [] }), { status: 404 }),
+    ) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    await expect(client.getSourceString(1, 9999)).resolves.toBeNull();
+  });
+
+  it("gets multiple source strings by numeric id", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      const path = String(url);
+      if (path.endsWith("/strings/1001")) {
+        return new Response(
+          JSON.stringify({
+            data: {
+              id: 1001,
+              projectId: 1,
+              fileId: 101,
+              branchId: null,
+              directoryId: null,
+              identifier: "hello",
+              text: "Hello",
+              type: "text",
+              context: null,
+              labelIds: null,
+            },
+          }),
+          { status: 200 },
+        );
+      }
+      if (path.endsWith("/strings/1002")) {
+        return new Response(
+          JSON.stringify({
+            data: {
+              id: 1002,
+              projectId: 1,
+              fileId: 101,
+              branchId: null,
+              directoryId: null,
+              identifier: "world",
+              text: "World",
+              type: "text",
+              context: null,
+              labelIds: null,
+            },
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({ errors: [] }), { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const client = createClient(fetchMock);
+    const strings = await client.getSourceStringsByIds(1, [1001, 1002, 9999]);
+
+    expect(strings.map((entry) => entry.id)).toEqual([1001, 1002]);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
   it("lists source strings by croql", async () => {
     const fetchMock = vi.fn(async (url) => {
-      expect(String(url)).toContain("croql=id+in+%281001%2C1002%29");
+      expect(String(url)).toContain("croql=identifier+%3D+%22hello%22");
       return new Response(JSON.stringify({ data: [] }), { status: 200 });
     }) as unknown as typeof fetch;
 
     const client = createClient(fetchMock);
-    await client.listSourceStrings(1, { croql: "id in (1001,1002)" });
+    await client.listSourceStrings(1, { croql: 'identifier = "hello"' });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
@@ -7,6 +7,7 @@
  */
 
 import { createLogger } from "@/lib/log";
+import { mapWithConcurrency } from "@/lib/primitives/map-with-concurrency/map-with-concurrency";
 import { resolveCrowdinApiBaseUrl } from "@/lib/providers/adapters/crowdin/crowdin-base-url";
 import { normalizeProviderDownloadUrl } from "@/lib/providers/provider-url-safety";
 
@@ -707,6 +708,41 @@ export class CrowdinApiClient {
     }
 
     return strings;
+  }
+
+  /**
+   * Fetch a single source string by Crowdin numeric ID.
+   *
+   * Crowdin CROQL cannot filter by string id — use this instead of `croql: "id = …"`.
+   */
+  async getSourceString(projectId: number, stringId: number): Promise<CrowdinSourceString | null> {
+    try {
+      const response = await this.get<CrowdinGetResponse<CrowdinSourceString>>(
+        `/projects/${projectId}/strings/${stringId}`,
+      );
+      return response.data;
+    } catch (error) {
+      if (error instanceof CrowdinApiError && error.status === 404) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  async getSourceStringsByIds(
+    projectId: number,
+    stringIds: number[],
+  ): Promise<CrowdinSourceString[]> {
+    const uniqueIds = [...new Set(stringIds)];
+    if (uniqueIds.length === 0) {
+      return [];
+    }
+
+    const results = await mapWithConcurrency(uniqueIds, 10, async (stringId) =>
+      this.getSourceString(projectId, stringId),
+    );
+
+    return results.filter((string): string is CrowdinSourceString => string !== null);
   }
 
   async listSourceStringsPage(

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-content-puller.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-content-puller.test.ts
@@ -292,25 +292,21 @@ describe("pullCrowdinTaskContent", () => {
         return new Response(JSON.stringify({ data: [] }), { status: 200 });
       }
 
-      if (path.includes("/projects/42/strings?") && path.includes("croql=")) {
+      if (path.endsWith("/projects/42/strings/1001")) {
         return new Response(
           JSON.stringify({
-            data: [
-              {
-                data: {
-                  id: 1001,
-                  projectId: 42,
-                  fileId: 101,
-                  branchId: null,
-                  directoryId: null,
-                  identifier: "hello",
-                  text: "Hello",
-                  type: "text",
-                  context: null,
-                  labelIds: null,
-                },
-              },
-            ],
+            data: {
+              id: 1001,
+              projectId: 42,
+              fileId: 101,
+              branchId: null,
+              directoryId: null,
+              identifier: "hello",
+              text: "Hello",
+              type: "text",
+              context: null,
+              labelIds: null,
+            },
           }),
           { status: 200 },
         );
@@ -361,7 +357,7 @@ describe("pullCrowdinTaskContent", () => {
     expect(
       fetchMock.mock.calls.some(([requestUrl]) => {
         const requestPath = String(requestUrl);
-        return requestPath.includes("/projects/42/strings?") && requestPath.includes("croql=");
+        return requestPath.endsWith("/projects/42/strings/1001");
       }),
     ).toBe(true);
     expect(

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-content-puller.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-content-puller.ts
@@ -41,8 +41,7 @@ async function listSourceStringsByStringIds(
   projectId: number,
   stringIds: number[],
 ): Promise<CrowdinSourceString[]> {
-  const strings = await client.getSourceStringsByIds(projectId, stringIds);
-  return dedupeSourceStringsById(strings);
+  return client.getSourceStringsByIds(projectId, stringIds);
 }
 
 async function listSourceStringsByFileIds(

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-content-puller.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-content-puller.ts
@@ -41,16 +41,8 @@ async function listSourceStringsByStringIds(
   projectId: number,
   stringIds: number[],
 ): Promise<CrowdinSourceString[]> {
-  const uniqueIds = [...new Set(stringIds)];
-  const results: CrowdinSourceString[] = [];
-
-  for (const chunk of chunkArray(uniqueIds, 25)) {
-    const croql = `id in (${chunk.join(",")})`;
-    const page = await client.listSourceStrings(projectId, { croql });
-    results.push(...page);
-  }
-
-  return dedupeSourceStringsById(results);
+  const strings = await client.getSourceStringsByIds(projectId, stringIds);
+  return dedupeSourceStringsById(strings);
 }
 
 async function listSourceStringsByFileIds(

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-progress.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-progress.ts
@@ -229,11 +229,7 @@ async function resolveCrowdinString(
   >
 > {
   if (input.stringId != null) {
-    const strings = await client.listSourceStrings(crowdinProjectId, {
-      croql: `id = ${input.stringId}`,
-      maxItems: 1,
-    });
-    const match = strings[0];
+    const match = await client.getSourceString(crowdinProjectId, input.stringId);
     if (!match) {
       return err({
         code: "crowdin_resource_not_found" as const,

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live-cat.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live-cat.test.ts
@@ -1123,25 +1123,21 @@ describe("getTmsProviderLiveCatSegmentDetail", () => {
         );
       }
 
-      if (path.includes("/projects/42/strings?") && path.includes("croql=")) {
+      if (path.endsWith("/projects/42/strings/1001")) {
         return new Response(
           JSON.stringify({
-            data: [
-              {
-                data: {
-                  id: 1001,
-                  projectId: 42,
-                  fileId: 101,
-                  branchId: null,
-                  directoryId: null,
-                  identifier: "hero.title",
-                  text: "Hello",
-                  type: "text",
-                  context: "Hero",
-                  labelIds: null,
-                },
-              },
-            ],
+            data: {
+              id: 1001,
+              projectId: 42,
+              fileId: 101,
+              branchId: null,
+              directoryId: null,
+              identifier: "hero.title",
+              text: "Hello",
+              type: "text",
+              context: "Hero",
+              labelIds: null,
+            },
           }),
           { status: 200 },
         );

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
@@ -1214,13 +1214,9 @@ async function buildCrowdinLiveCatSegmentDetail(input: {
   });
 
   try {
-    const [sourceStringPage, translations, approvals, plainComments, unresolvedIssues] =
+    const [sourceString, translations, approvals, plainComments, unresolvedIssues] =
       await Promise.all([
-        client.listSourceStringsPage(projectId, {
-          croql: `id = ${stringId}`,
-          offset: 0,
-          limit: 1,
-        }),
+        client.getSourceString(projectId, stringId),
         client.listLanguageTranslations(projectId, input.targetLocale, {
           stringIds: [stringId],
         }),
@@ -1238,7 +1234,6 @@ async function buildCrowdinLiveCatSegmentDetail(input: {
         }),
       ]);
 
-    const sourceString = sourceStringPage.strings[0];
     if (!sourceString) {
       return null;
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Crowdin rejects CROQL queries like `id = 721366` with HTTP 400 because numeric source string IDs are not available in the CROQL context.

This PR adds `getSourceString` and `getSourceStringsByIds` to `CrowdinApiClient`, using `GET /projects/{projectId}/strings/{stringId}` instead of invalid CROQL filters. Call sites updated:

- Live CAT segment detail (`tms-provider-live.ts`)
- Crowdin progress checks by `stringId` (`crowdin-progress.ts`)
- Task content pulls that resolve strings by ID (`crowdin-content-puller.ts`)

## How to test

- `vp test src/lib/providers/adapters/crowdin/crowdin-api.test.ts`
- `vp test src/lib/providers/adapters/crowdin/crowdin-content-puller.test.ts`
- `vp test src/lib/providers/adapters/crowdin/crowdin-progress.test.ts`
- Open a Crowdin-linked CAT segment by numeric string ID and confirm segment detail loads without HTTP 400.

## Checklist

- [x] I ran relevant checks locally (`vp check --fix`, targeted tests)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c0fff50-33b9-44f0-b725-cb2b6db789fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c0fff50-33b9-44f0-b725-cb2b6db789fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

