### PR TITLE
feat(web): split CAT queue API and polish skeleton loading

### DIFF
--- a/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.route.ts
@@ -29,6 +29,7 @@ import { sourceContentType } from "@/lib/file-storage/source-file-metadata";
 import {
   countTmsProviderLiveOpenJobsForProject,
   getTmsProviderLiveCatFile,
+  getTmsProviderLiveCatQueueSummary,
   getTmsProviderLiveCatSegmentDetail,
   getTmsProviderLiveFileDetail,
   getTmsProviderLiveProject,
@@ -40,13 +41,17 @@ import {
 import { listOrganizationProjects } from "@/lib/projects/organization/organization-project-service";
 import {
   getNativeProjectCatFile,
+  getNativeProjectCatQueueSummary,
   getNativeProjectCatSegmentDetail,
   resolveNativeProjectCatComment,
   saveNativeProjectCatComment,
   saveNativeProjectCatTranslation,
   updateNativeProjectTranslationStatus,
 } from "@/lib/projects/cat/native-cat-service";
-import { resolveProjectFileCatPagination } from "@/lib/projects/cat/project-file-cat-pagination";
+import {
+  resolveProjectFileCatIncludeQueueSummary,
+  resolveProjectFileCatPagination,
+} from "@/lib/projects/cat/project-file-cat-pagination";
 import {
   getProjectFileDetail,
   listFilteredProjectFiles,
@@ -74,6 +79,7 @@ import {
   projectFileCatSegmentParamsSchema,
   projectFileCatSegmentQuerySchema,
   projectFileCatQuerySchema,
+  projectFileCatQueueSummaryQuerySchema,
   projectFileCatConcordanceBodySchema,
   projectFileCatCommentBodySchema,
   projectFileCatCommentResolveBodySchema,
@@ -91,6 +97,7 @@ import {
   projectFileCatCommentIdParamsSchema,
   updateProjectBodySchema,
   type CreateProjectBody,
+  type ProjectFileCatQuery,
   type UpdateProjectBody,
 } from "./project.schema";
 import { getVisibleTeamIds, hasOrganizationWideProjectAccess } from "@/api/auth/team-access";
@@ -400,6 +407,16 @@ const validateProjectFileCatQuery = validator("query", (value, c) => {
   return parsed.data;
 });
 
+const validateProjectFileCatQueueSummaryQuery = validator("query", (value, c) => {
+  const parsed = projectFileCatQueueSummaryQuerySchema.safeParse(value);
+
+  if (!parsed.success) {
+    return invalidProjectPayloadResponse(c);
+  }
+
+  return parsed.data;
+});
+
 const validateProjectFileCatTranslationBody = validator("json", (value, c) => {
   const parsed = projectFileCatTranslationBodySchema.safeParse(value);
 
@@ -552,6 +569,67 @@ type CreateProjectRoutesOptions = {
   translationFileImportQueue?: TranslationFileImportQueue;
 };
 
+async function loadProjectFileCatQueue(
+  auth: AuthVariables["auth"],
+  projectId: string,
+  query: ProjectFileCatQuery,
+  options?: { includeQueueSummary?: boolean },
+) {
+  const pagination = resolveProjectFileCatPagination(query);
+  const includeQueueSummary = options?.includeQueueSummary ?? false;
+  const target = await resolveProjectResourceTarget(auth, projectId);
+
+  if (target.kind === "provider_unavailable") {
+    return { kind: "provider_unavailable" as const, target };
+  }
+
+  if (target.kind !== "provider") {
+    const project = await getOwnedProject(auth, projectId);
+    if (!project) {
+      return { kind: "project_not_found" as const };
+    }
+
+    const catQueue = await getNativeProjectCatFile({
+      organizationId: auth.organization.localOrganizationId,
+      projectId,
+      sourcePath: query.sourcePath,
+      targetLocale: query.targetLocale,
+      canEditTranslations: isWriteBackTranslationAllowed(auth.membership.role),
+      pagination,
+      includeQueueSummary,
+    });
+
+    if (!catQueue) {
+      return { kind: "source_file_not_found" as const };
+    }
+
+    return { kind: "ok" as const, catQueue };
+  }
+
+  try {
+    const catQueue = await getTmsProviderLiveCatFile(
+      auth.organization.localOrganizationId,
+      target.externalProjectId,
+      query.sourcePath,
+      query.targetLocale,
+      {
+        actorUserId: auth.user.localUserId,
+        canEditTranslations: isWriteBackTranslationAllowed(auth.membership.role),
+        pagination,
+        includeQueueSummary,
+      },
+    );
+
+    if (!catQueue) {
+      return { kind: "project_not_found" as const };
+    }
+
+    return { kind: "ok" as const, catQueue };
+  } catch (error) {
+    return { kind: "provider_error" as const, error };
+  }
+}
+
 export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
   const jobQueue = options.jobQueue ?? createTranslationJobEventQueue();
   const translationFileImportQueue =
@@ -607,13 +685,12 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
     })
     .route("/:projectId/jobs", createJobRoutes({ jobQueue }))
     .get(
-      "/:projectId/files/detail/cat",
+      "/:projectId/files/detail/cat/queue/summary",
       validateProjectParams,
-      validateProjectFileCatQuery,
+      validateProjectFileCatQueueSummaryQuery,
       async (c) => {
         const params = c.req.valid("param");
         const query = c.req.valid("query");
-        const pagination = resolveProjectFileCatPagination(query);
         const target = await resolveProjectResourceTarget(c.var.auth, params.projectId);
         if (target.kind === "provider_unavailable") {
           return providerProjectUnavailableResponse(c, target);
@@ -625,16 +702,14 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
             return projectNotFoundResponse(c);
           }
 
-          const catFile = await getNativeProjectCatFile({
+          const queueSummary = await getNativeProjectCatQueueSummary({
             organizationId: c.var.auth.organization.localOrganizationId,
             projectId: params.projectId,
             sourcePath: query.sourcePath,
             targetLocale: query.targetLocale,
-            canEditTranslations: isWriteBackTranslationAllowed(c.var.auth.membership.role),
-            pagination,
           });
 
-          if (!catFile) {
+          if (!queueSummary) {
             return badRequestResponse(
               c,
               "source_file_not_found",
@@ -642,29 +717,87 @@ export function createProjectRoutes(options: CreateProjectRoutesOptions = {}) {
             );
           }
 
-          return c.json({ catFile }, 200);
+          return c.json({ queueSummary }, 200);
         }
 
         try {
-          const catFile = await getTmsProviderLiveCatFile(
+          const queueSummary = await getTmsProviderLiveCatQueueSummary(
             c.var.auth.organization.localOrganizationId,
             target.externalProjectId,
             query.sourcePath,
             query.targetLocale,
-            {
-              actorUserId: c.var.auth.user.localUserId,
-              canEditTranslations: isWriteBackTranslationAllowed(c.var.auth.membership.role),
-              pagination,
-            },
+            { actorUserId: c.var.auth.user.localUserId },
           );
-          if (!catFile) {
+          if (!queueSummary) {
             return projectNotFoundResponse(c);
           }
 
-          return c.json({ catFile }, 200);
+          return c.json({ queueSummary }, 200);
         } catch (error) {
           return tmsProviderLiveErrorResponse(c, error);
         }
+      },
+    )
+    .get(
+      "/:projectId/files/detail/cat/queue",
+      validateProjectParams,
+      validateProjectFileCatQuery,
+      async (c) => {
+        const params = c.req.valid("param");
+        const query = c.req.valid("query");
+        const result = await loadProjectFileCatQueue(c.var.auth, params.projectId, query, {
+          includeQueueSummary: false,
+        });
+
+        if (result.kind === "provider_unavailable") {
+          return providerProjectUnavailableResponse(c, result.target);
+        }
+        if (result.kind === "project_not_found") {
+          return projectNotFoundResponse(c);
+        }
+        if (result.kind === "source_file_not_found") {
+          return badRequestResponse(
+            c,
+            "source_file_not_found",
+            "Source file not found for the given path",
+          );
+        }
+        if (result.kind === "provider_error") {
+          return tmsProviderLiveErrorResponse(c, result.error);
+        }
+
+        return c.json({ catQueue: result.catQueue }, 200);
+      },
+    )
+    .get(
+      "/:projectId/files/detail/cat",
+      validateProjectParams,
+      validateProjectFileCatQuery,
+      async (c) => {
+        const params = c.req.valid("param");
+        const query = c.req.valid("query");
+        const result = await loadProjectFileCatQueue(c.var.auth, params.projectId, query, {
+          includeQueueSummary: resolveProjectFileCatIncludeQueueSummary(query),
+        });
+
+        if (result.kind === "provider_unavailable") {
+          return providerProjectUnavailableResponse(c, result.target);
+        }
+        if (result.kind === "project_not_found") {
+          return projectNotFoundResponse(c);
+        }
+        if (result.kind === "source_file_not_found") {
+          return badRequestResponse(
+            c,
+            "source_file_not_found",
+            "Source file not found for the given path",
+          );
+        }
+        if (result.kind === "provider_error") {
+          return tmsProviderLiveErrorResponse(c, result.error);
+        }
+
+        return c.json({ catFile: result.catQueue }, 200);
       },
     )
     .get(

--- a/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
+++ b/apps/hyperlocalise-web/src/api/routes/project/project.schema.ts
@@ -240,6 +240,13 @@ export const projectFileCatQuerySchema = z.object({
   queueFilter: projectFileCatQueueFilterSchema.optional(),
   offset: z.coerce.number().int().min(0).optional(),
   limit: z.coerce.number().int().min(1).max(100).optional(),
+  includeQueueSummary: z.enum(["true", "false"]).optional(),
+});
+
+export const projectFileCatQueueSummaryQuerySchema = z.object({
+  sourcePath: z.string().trim().min(1).max(2048),
+  targetLocale: z.string().trim().min(1).max(32),
+  repositoryFullName: z.string().trim().min(1).max(256).optional(),
 });
 
 export const projectFileCatPaginationSchema = z.object({
@@ -256,6 +263,10 @@ export const projectFileCatQueueSummarySchema = z.object({
   untranslated: z.number().int().min(0),
   needsReview: z.number().int().min(0),
   hasIssues: z.number().int().min(0),
+});
+
+export const projectFileCatQueueSummaryResponseSchema = z.object({
+  queueSummary: projectFileCatQueueSummarySchema,
 });
 
 export const defaultProjectFileCatPageLimit = 50;
@@ -587,8 +598,12 @@ export const projectFileCatResponseSchema = z.object({
     truncated: z.boolean(),
     segments: z.array(projectFileCatSegmentSchema),
     pagination: projectFileCatPaginationSchema.optional(),
-    queueSummary: projectFileCatQueueSummarySchema,
+    queueSummary: projectFileCatQueueSummarySchema.optional(),
   }),
+});
+
+export const projectFileCatQueueResponseSchema = z.object({
+  catQueue: projectFileCatResponseSchema.shape.catFile,
 });
 
 export const projectFileCatTranslationResponseSchema = z.object({
@@ -606,6 +621,7 @@ export type ProjectFilesResponse = z.infer<typeof projectFilesResponseSchema>;
 export type ProjectFilesQuery = z.infer<typeof projectFilesQuerySchema>;
 export type ProjectFileDetailQuery = z.infer<typeof projectFileDetailQuerySchema>;
 export type ProjectFileCatQuery = z.infer<typeof projectFileCatQuerySchema>;
+export type ProjectFileCatQueueSummaryQuery = z.infer<typeof projectFileCatQueueSummaryQuerySchema>;
 export type ProjectFileCatQueueFilter = z.infer<typeof projectFileCatQueueFilterSchema>;
 export type ProjectFileCatTranslationBody = z.infer<typeof projectFileCatTranslationBodySchema>;
 export type ProjectFileCatRecommendationBody = z.infer<
@@ -646,6 +662,10 @@ export type ProjectFileCatSegmentParams = z.infer<typeof projectFileCatSegmentPa
 export type ProjectFileCatSegmentQuery = z.infer<typeof projectFileCatSegmentQuerySchema>;
 export type ProjectFileCatSegmentResponse = z.infer<typeof projectFileCatSegmentResponseSchema>;
 export type ProjectFileCatQueueSummary = z.infer<typeof projectFileCatQueueSummarySchema>;
+export type ProjectFileCatQueueSummaryResponse = z.infer<
+  typeof projectFileCatQueueSummaryResponseSchema
+>;
+export type ProjectFileCatQueueResponse = z.infer<typeof projectFileCatQueueResponseSchema>;
 export type ProjectFileCatResponse = z.infer<typeof projectFileCatResponseSchema>;
 export type ProjectFileCatTranslationResponse = z.infer<
   typeof projectFileCatTranslationResponseSchema

--- a/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
+++ b/apps/hyperlocalise-web/src/app/[lang]/(authenticated)/org/[organizationSlug]/projects/[projectId]/jobs/[jobId]/strings/_components/job-cat-page-content.tsx
@@ -378,79 +378,72 @@ export function JobCatPageContent({
   };
 
   return (
-    <main className="-mx-4 -my-5 flex min-h-[calc(100svh-var(--app-shell-header-height))] flex-col overflow-hidden bg-background sm:-mx-6 lg:-mx-8">
-      <div className="flex shrink-0 flex-col gap-3 border-b border-border px-4 py-3 sm:px-6 lg:px-8">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div className="flex min-w-0 items-center gap-3">
-            <Button variant="outline" size="sm" render={<Link href={taskHref} />}>
-              <ArrowLeftIcon />
-              Task
-            </Button>
-            <div className="min-w-0">
-              <TypographyP className="truncate text-xs text-muted-foreground">
-                {selectedFile.provider.kind} · {selectedFile.provider.format ?? "file"}
-              </TypographyP>
-            </div>
-          </div>
-        </div>
+    <main className="-mx-4 -my-5 flex h-[calc(100svh-var(--app-shell-header-height))] min-h-0 flex-col overflow-hidden bg-background sm:-mx-6 lg:-mx-8">
+      <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border px-3 py-2 sm:px-4 lg:px-6">
+        <Button
+          variant="outline"
+          size="icon-sm"
+          className="size-8 shrink-0"
+          render={<Link href={taskHref} />}
+        >
+          <ArrowLeftIcon className="size-4" />
+        </Button>
 
-        <div className="grid gap-3 sm:grid-cols-2">
-          <div className="flex min-w-0 flex-col gap-1.5">
-            <TypographyP className="text-[10px] font-medium tracking-wide text-muted-foreground uppercase">
-              Source file
-            </TypographyP>
-            <Select value={selectedFile.sourcePath} onValueChange={handleFileChange}>
-              <SelectTrigger className="h-9 w-full font-mono text-xs">
-                <SelectValue placeholder="Select file" />
-              </SelectTrigger>
-              <SelectContent>
-                {providerFiles.map((file) => (
-                  <SelectItem key={file.sourcePath} value={file.sourcePath}>
-                    {file.sourcePath}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
+        <Select value={selectedFile.sourcePath} onValueChange={handleFileChange}>
+          <SelectTrigger
+            className="h-8 min-w-0 flex-1 basis-40 font-mono text-xs sm:max-w-xs"
+            aria-label="Source file"
+          >
+            <SelectValue placeholder="Source file" />
+          </SelectTrigger>
+          <SelectContent>
+            {providerFiles.map((file) => (
+              <SelectItem key={file.sourcePath} value={file.sourcePath}>
+                {file.sourcePath}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
 
-          {enabledRepositoryFullNames.length > 0 ? (
-            <div className="flex min-w-0 flex-col gap-1.5">
-              <TypographyP className="text-[10px] font-medium tracking-wide text-muted-foreground uppercase">
-                GitHub repository
-              </TypographyP>
-              <Select
-                value={selectedRepositoryFullName ?? ""}
-                onValueChange={handleRepositoryChange}
-              >
-                <SelectTrigger className="h-9 w-full font-mono text-xs">
-                  <SelectValue placeholder="Select repository" />
-                </SelectTrigger>
-                <SelectContent>
-                  {enabledRepositoryFullNames.map((repositoryFullName) => (
-                    <SelectItem key={repositoryFullName} value={repositoryFullName}>
-                      {repositoryFullName}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          ) : null}
-        </div>
-
-        {repositoriesQuery.isError ? (
-          <TypographyP className="text-xs text-muted-foreground">
-            GitHub repositories could not be loaded. Repository context lookup is unavailable.
-          </TypographyP>
+        {enabledRepositoryFullNames.length > 0 ? (
+          <Select value={selectedRepositoryFullName ?? ""} onValueChange={handleRepositoryChange}>
+            <SelectTrigger
+              className="h-8 min-w-0 flex-1 basis-40 font-mono text-xs sm:max-w-xs"
+              aria-label="GitHub repository"
+            >
+              <SelectValue placeholder="GitHub repo" />
+            </SelectTrigger>
+            <SelectContent>
+              {enabledRepositoryFullNames.map((repositoryFullName) => (
+                <SelectItem key={repositoryFullName} value={repositoryFullName}>
+                  {repositoryFullName}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         ) : null}
 
-        {enabledRepositoryFullNames.length > 1 && !selectedRepositoryFullName ? (
-          <TypographyP className="text-xs text-muted-foreground">
-            Select a GitHub repository to look up string context for this file.
-          </TypographyP>
-        ) : null}
+        <TypographyP className="hidden min-w-0 truncate text-xs text-muted-foreground sm:block lg:max-w-48">
+          {selectedFile.provider.kind} · {selectedFile.provider.format ?? "file"}
+        </TypographyP>
       </div>
 
-      <div className="flex min-h-0 flex-1 flex-col px-4 py-3 sm:px-6 lg:px-8">
+      {(repositoriesQuery.isError ||
+        (enabledRepositoryFullNames.length > 1 && !selectedRepositoryFullName)) && (
+        <div className="shrink-0 border-b border-border px-3 py-1.5 sm:px-4 lg:px-6">
+          {repositoriesQuery.isError ? (
+            <TypographyP className="text-xs text-muted-foreground">
+              GitHub repositories could not be loaded. Repository context lookup is unavailable.
+            </TypographyP>
+          ) : (
+            <TypographyP className="text-xs text-muted-foreground">
+              Select a GitHub repository to look up string context.
+            </TypographyP>
+          )}
+        </div>
+      )}
+
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden px-3 py-2 sm:px-4 lg:px-6">
         <ProjectFileCatWorkspace
           key={`${selectedFile.sourcePath}:${selectedRepositoryFullName ?? "default"}`}
           organizationSlug={organizationSlug}
@@ -460,6 +453,7 @@ export function JobCatPageContent({
           repositoryFullName={selectedRepositoryFullName}
           initialSegmentKey={initialSegmentKey}
           layout="fullscreen"
+          className="min-h-0 flex-1"
         />
       </div>
     </main>

--- a/apps/hyperlocalise-web/src/components/cat/cat-editor-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-editor-panel.tsx
@@ -103,6 +103,7 @@ export function CatEditorPanel({
   isLookingUpContext = false,
   isAiSuggestionLoading = false,
   isFormatChecksLoading = false,
+  isSegmentDetailLoading = false,
   canApprove = true,
   canAddComment = false,
   canEditTranslations = true,
@@ -143,6 +144,7 @@ export function CatEditorPanel({
   isLookingUpContext?: boolean;
   isAiSuggestionLoading?: boolean;
   isFormatChecksLoading?: boolean;
+  isSegmentDetailLoading?: boolean;
   canApprove?: boolean;
   canAddComment?: boolean;
   canEditTranslations?: boolean;
@@ -607,11 +609,28 @@ export function CatEditorPanel({
               <h3 className="text-xs font-medium text-muted-foreground">
                 <FormattedMessage {...catEditorPanelMessages.comments} />
               </h3>
-              <span className="text-xs text-muted-foreground tabular-nums">
-                {segmentComments.length}
-              </span>
+              {isSegmentDetailLoading ? (
+                <Skeleton className="h-3 w-6 rounded-full bg-foreground/8" />
+              ) : (
+                <span className="text-xs text-muted-foreground tabular-nums">
+                  {segmentComments.length}
+                </span>
+              )}
             </div>
-            {segmentComments.length > 0 ? (
+            {isSegmentDetailLoading ? (
+              <ul className="space-y-3" aria-busy="true">
+                {Array.from({ length: 2 }, (_, index) => (
+                  <li
+                    key={`comment-skeleton-${index}`}
+                    className="space-y-2 rounded-lg border border-foreground/8 p-3"
+                  >
+                    <Skeleton className="h-3 w-24 rounded-full bg-foreground/8" />
+                    <Skeleton className="h-4 w-full rounded-full bg-foreground/8" />
+                    <Skeleton className="h-3 w-32 rounded-full bg-foreground/8" />
+                  </li>
+                ))}
+              </ul>
+            ) : segmentComments.length > 0 ? (
               <ul className="space-y-3">
                 {segmentComments.map((comment) => (
                   <li

--- a/apps/hyperlocalise-web/src/components/cat/cat-queue-panel.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-queue-panel.tsx
@@ -18,9 +18,11 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Progress } from "@/components/ui/progress";
+import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/primitives/cn";
 
+import { CatQueueSkeletonList } from "./cat-queue-skeleton-list";
 import { CatQueueVirtualList } from "./cat-queue-virtual-list";
 import { catQueueFilterValues, type CatQueueFilter } from "./cat-queue-filter";
 import { catQueuePanelMessages } from "./cat.messages";
@@ -66,6 +68,8 @@ export function CatQueuePanel({
   onBulkSkip,
   isBulkActionPending = false,
   isFetchingPage = false,
+  isQueueLoading = false,
+  isSummaryLoading = false,
   pagination = null,
   onPreviousPage,
   onNextPage,
@@ -90,6 +94,8 @@ export function CatQueuePanel({
   onBulkSkip?: () => void;
   isBulkActionPending?: boolean;
   isFetchingPage?: boolean;
+  isQueueLoading?: boolean;
+  isSummaryLoading?: boolean;
   pagination?: CatQueuePagination | null;
   onPreviousPage?: () => void;
   onNextPage?: () => void;
@@ -110,23 +116,27 @@ export function CatQueuePanel({
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-background lg:border-r lg:border-foreground/8">
-      <div className="space-y-3 border-b border-foreground/8 px-4 py-3">
+      <div className="shrink-0 space-y-3 border-b border-foreground/8 px-4 py-3">
         <div>
           <h2 className="text-sm font-semibold text-foreground">
             <FormattedMessage {...catQueuePanelMessages.queueTitle} />
           </h2>
-          <p className="text-xs text-muted-foreground">
-            <FormattedMessage
-              {...catQueuePanelMessages.queueSummary}
-              values={{
-                total: summary.total,
-                reviewed: summary.reviewed,
-                untranslated: summary.untranslated,
-                needsReview: summary.needsReview,
-                hasIssues: summary.hasIssues,
-              }}
-            />
-          </p>
+          {isSummaryLoading ? (
+            <Skeleton className="mt-1 h-3 w-full max-w-48 rounded-full bg-foreground/8" />
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              <FormattedMessage
+                {...catQueuePanelMessages.queueSummary}
+                values={{
+                  total: summary.total,
+                  reviewed: summary.reviewed,
+                  untranslated: summary.untranslated,
+                  needsReview: summary.needsReview,
+                  hasIssues: summary.hasIssues,
+                }}
+              />
+            </p>
+          )}
         </div>
 
         {onSearchChange ? (
@@ -259,11 +269,17 @@ export function CatQueuePanel({
         ) : null}
       </div>
 
-      <div className="px-4 py-3">
-        <Progress value={progressValue} className="h-1.5" />
+      <div className="shrink-0 px-4 py-3">
+        {isSummaryLoading ? (
+          <Skeleton className="h-1.5 w-full rounded-full bg-foreground/8" />
+        ) : (
+          <Progress value={progressValue} className="h-1.5" />
+        )}
       </div>
 
-      {segments.length === 0 ? (
+      {isQueueLoading ? (
+        <CatQueueSkeletonList rowCount={pagination?.limit ?? 8} />
+      ) : segments.length === 0 ? (
         <div className="flex min-h-0 flex-1 items-center justify-center px-4 pb-3 text-sm text-muted-foreground">
           <FormattedMessage {...emptyMessage} />
         </div>
@@ -280,7 +296,7 @@ export function CatQueuePanel({
       )}
 
       {pagination ? (
-        <div className="flex items-center justify-between gap-2 border-t border-foreground/8 px-4 py-3">
+        <div className="flex shrink-0 items-center justify-between gap-2 border-t border-foreground/8 px-4 py-3">
           <p className="text-xs text-muted-foreground">
             <FormattedMessage
               {...catQueuePanelMessages.paginationSummary}

--- a/apps/hyperlocalise-web/src/components/cat/cat-queue-skeleton-list.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-queue-skeleton-list.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/primitives/cn";
+
+const DEFAULT_SKELETON_ROWS = 8;
+
+export function CatQueueSummarySkeleton({ className }: { className?: string }) {
+  return (
+    <div className={cn("space-y-3", className)}>
+      <Skeleton className="h-3 w-full max-w-48 rounded-full bg-foreground/8" />
+      <Skeleton className="h-1.5 w-full rounded-full bg-foreground/8" />
+    </div>
+  );
+}
+
+export function CatQueueSkeletonList({
+  rowCount = DEFAULT_SKELETON_ROWS,
+  className,
+}: {
+  rowCount?: number;
+  className?: string;
+}) {
+  return (
+    <div className={cn("min-h-0 flex-1 overflow-hidden px-4 pb-3", className)}>
+      <ul className="space-y-2" aria-busy="true" aria-label="Loading segments">
+        {Array.from({ length: rowCount }, (_, index) => (
+          <li
+            key={`cat-queue-skeleton-${index}`}
+            className="flex min-h-11 items-start gap-3 rounded-lg px-2 py-2.5"
+          >
+            <Skeleton className="mt-0.5 size-4 shrink-0 rounded bg-foreground/8" />
+            <Skeleton className="mt-0.5 h-4 w-5 shrink-0 rounded bg-foreground/8" />
+            <div className="min-w-0 flex-1 space-y-2">
+              <Skeleton className="h-4 w-full rounded-full bg-foreground/8" />
+              <Skeleton className="h-4 w-4/5 rounded-full bg-foreground/8" />
+              <Skeleton className="h-3 w-2/5 rounded-full bg-foreground/8" />
+            </div>
+            <Skeleton className="mt-1 size-2 shrink-0 rounded-full bg-foreground/8" />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace-container.tsx
@@ -262,6 +262,9 @@ export interface CatWorkspaceContainerProps {
   availableQueueFilters?: CatQueueFilter[];
   isQueueSearchPending?: boolean;
   isQueueFetchingPage?: boolean;
+  isQueueLoading?: boolean;
+  isQueueSummaryLoading?: boolean;
+  isSegmentDetailLoading?: boolean;
   queuePagination?: CatWorkspaceViewProps["queuePagination"];
   onQueuePreviousPage?: () => void;
   onQueueNextPage?: () => void;
@@ -299,6 +302,9 @@ export function CatWorkspaceContainer({
   availableQueueFilters,
   isQueueSearchPending,
   isQueueFetchingPage,
+  isQueueLoading,
+  isQueueSummaryLoading = false,
+  isSegmentDetailLoading = false,
   queuePagination,
   onQueuePreviousPage,
   onQueueNextPage,
@@ -1368,6 +1374,9 @@ export function CatWorkspaceContainer({
           onQueueSearchChange={onQueueSearchChange}
           isQueueSearchPending={isQueueSearchPending}
           isQueueFetchingPage={isQueueFetchingPage}
+          isQueueLoading={isQueueLoading}
+          isQueueSummaryLoading={isQueueSummaryLoading}
+          isSegmentDetailLoading={isSegmentDetailLoading}
           queuePagination={queuePagination}
           onQueuePreviousPage={
             onQueuePreviousPage ? () => attemptPageNavigation(onQueuePreviousPage) : undefined

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace-skeleton.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace-skeleton.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/primitives/cn";
+
+import { CatQueueSkeletonList, CatQueueSummarySkeleton } from "./cat-queue-skeleton-list";
+
+function CatEditorPanelSkeleton() {
+  return (
+    <div
+      className="flex h-full min-h-0 flex-col bg-background"
+      aria-busy="true"
+      aria-label="Loading editor"
+    >
+      <div className="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b border-foreground/8 px-4 py-3 lg:px-5">
+        <div className="flex flex-wrap items-center gap-2">
+          <Skeleton className="h-4 w-16 rounded-full bg-foreground/8" />
+          <Skeleton className="h-5 w-20 rounded-md bg-foreground/8" />
+        </div>
+        <div className="flex items-center gap-1">
+          <Skeleton className="size-8 rounded-md bg-foreground/8" />
+          <Skeleton className="size-8 rounded-md bg-foreground/8" />
+          <Skeleton className="size-8 rounded-md bg-foreground/8" />
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <div className="mx-auto max-w-3xl space-y-6 px-4 py-5 sm:px-6 lg:space-y-7 lg:px-8 lg:py-8">
+          <section className="space-y-3">
+            <Skeleton className="h-3 w-24 rounded-full bg-foreground/8" />
+            <Skeleton className="h-20 w-full rounded-xl bg-foreground/8" />
+          </section>
+
+          <section className="space-y-3">
+            <Skeleton className="h-3 w-28 rounded-full bg-foreground/8" />
+            <Skeleton className="h-32 w-full rounded-xl bg-foreground/8" />
+          </section>
+
+          <div className="flex flex-wrap gap-2">
+            <Skeleton className="h-9 w-24 rounded-md bg-foreground/8" />
+            <Skeleton className="h-9 w-28 rounded-md bg-foreground/8" />
+            <Skeleton className="h-9 w-20 rounded-md bg-foreground/8" />
+          </div>
+
+          <section className="space-y-3">
+            <Skeleton className="h-3 w-32 rounded-full bg-foreground/8" />
+            <div className="space-y-0 divide-y divide-foreground/8 rounded-xl border border-foreground/8 bg-foreground/2">
+              {[0, 1, 2].map((item) => (
+                <div key={item} className="flex items-start gap-3 px-3 py-3">
+                  <Skeleton className="size-4 shrink-0 rounded-full bg-foreground/8" />
+                  <div className="min-w-0 flex-1 space-y-2">
+                    <Skeleton className="h-4 w-36 rounded-full bg-foreground/8" />
+                    <Skeleton className="h-3 w-10/12 rounded-full bg-foreground/8" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section className="space-y-3 border-t border-foreground/8 pt-5">
+            <div className="flex items-center justify-between gap-2">
+              <Skeleton className="h-3 w-20 rounded-full bg-foreground/8" />
+              <Skeleton className="h-3 w-6 rounded-full bg-foreground/8" />
+            </div>
+            <ul className="space-y-3">
+              {[0, 1].map((item) => (
+                <li key={item} className="space-y-2 rounded-lg border border-foreground/8 p-3">
+                  <Skeleton className="h-3 w-24 rounded-full bg-foreground/8" />
+                  <Skeleton className="h-4 w-full rounded-full bg-foreground/8" />
+                </li>
+              ))}
+            </ul>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CatIntelligencePanelSkeleton() {
+  return (
+    <div
+      className="flex h-full min-h-0 flex-col bg-background lg:border-l lg:border-foreground/8"
+      aria-busy="true"
+      aria-label="Loading intelligence"
+    >
+      <div className="shrink-0 border-b border-foreground/8 px-4 py-3">
+        <Skeleton className="h-4 w-32 rounded-full bg-foreground/8" />
+        <Skeleton className="mt-2 h-3 w-full max-w-xs rounded-full bg-foreground/8" />
+      </div>
+      <div className="min-h-0 flex-1 space-y-5 overflow-y-auto p-4">
+        {[0, 1, 2].map((item) => (
+          <div key={item} className="space-y-2">
+            <Skeleton className="h-3 w-28 rounded-full bg-foreground/8" />
+            <Skeleton className="h-16 w-full rounded-xl bg-foreground/8" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function CatQueuePanelSkeleton() {
+  return (
+    <div
+      className="flex h-full min-h-0 flex-col bg-background lg:border-r lg:border-foreground/8"
+      aria-busy="true"
+      aria-label="Loading queue"
+    >
+      <div className="shrink-0 space-y-3 border-b border-foreground/8 px-4 py-3">
+        <div className="space-y-2">
+          <Skeleton className="h-4 w-16 rounded-full bg-foreground/8" />
+          <Skeleton className="h-3 w-full max-w-48 rounded-full bg-foreground/8" />
+        </div>
+        <Skeleton className="h-9 w-full rounded-md bg-foreground/8" />
+        <Skeleton className="h-8 w-24 rounded-md bg-foreground/8" />
+      </div>
+
+      <div className="shrink-0 px-4 py-3">
+        <Skeleton className="h-1.5 w-full rounded-full bg-foreground/8" />
+      </div>
+
+      <CatQueueSkeletonList />
+
+      <div className="flex shrink-0 items-center justify-between gap-2 border-t border-foreground/8 px-4 py-3">
+        <Skeleton className="h-3 w-28 rounded-full bg-foreground/8" />
+        <div className="flex items-center gap-1">
+          <Skeleton className="h-8 w-16 rounded-md bg-foreground/8" />
+          <Skeleton className="h-8 w-12 rounded-md bg-foreground/8" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CatCompactWorkspaceSkeleton() {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <div className="shrink-0 border-b border-foreground/8 px-4 py-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0 flex-1 space-y-2">
+            <Skeleton className="h-3 w-14 rounded-full bg-foreground/8" />
+            <Skeleton className="h-4 w-32 rounded-full bg-foreground/8" />
+          </div>
+          <div className="shrink-0 space-y-2 text-right">
+            <Skeleton className="ms-auto h-3 w-20 rounded-full bg-foreground/8" />
+            <Skeleton className="ms-auto h-3 w-16 rounded-full bg-foreground/8" />
+          </div>
+        </div>
+        <CatQueueSummarySkeleton className="mt-3" />
+      </div>
+
+      <div className="mx-4 mt-3 grid h-10 grid-cols-3 gap-1 rounded-lg bg-muted p-1">
+        <Skeleton className="h-full rounded-md bg-foreground/8" />
+        <Skeleton className="h-full rounded-md bg-foreground/6" />
+        <Skeleton className="h-full rounded-md bg-foreground/6" />
+      </div>
+
+      <div className="mt-3 min-h-0 flex-1 overflow-hidden">
+        <CatEditorPanelSkeleton />
+      </div>
+    </div>
+  );
+}
+
+export function CatWorkspaceSkeleton({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn(
+        "flex h-full min-h-0 min-w-0 flex-col overflow-hidden bg-background",
+        className,
+      )}
+      aria-busy="true"
+      aria-label="Loading CAT workspace"
+    >
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden lg:hidden">
+        <CatCompactWorkspaceSkeleton />
+      </div>
+
+      <div className="hidden h-full min-h-0 min-w-0 flex-1 grid-cols-[minmax(0,20rem)_minmax(0,1fr)_minmax(0,22rem)] overflow-hidden lg:grid">
+        <CatQueuePanelSkeleton />
+        <CatEditorPanelSkeleton />
+        <CatIntelligencePanelSkeleton />
+      </div>
+    </div>
+  );
+}

--- a/apps/hyperlocalise-web/src/components/cat/cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/cat-workspace.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { FormattedMessage } from "react-intl";
 
 import { Progress } from "@/components/ui/progress";
+import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/primitives/cn";
 
@@ -63,6 +64,9 @@ export function CatWorkspaceView({
   onQueueSearchChange,
   isQueueSearchPending = false,
   isQueueFetchingPage = false,
+  isQueueLoading = false,
+  isQueueSummaryLoading = false,
+  isSegmentDetailLoading = false,
   queuePagination = null,
   onQueuePreviousPage,
   onQueueNextPage,
@@ -97,7 +101,7 @@ export function CatWorkspaceView({
       ? Math.round((fullState.queueSummary.reviewed / fullState.queueSummary.total) * 100)
       : 0;
 
-  if (!selectedSegment) {
+  if (!selectedSegment && !isQueueLoading) {
     return (
       <div
         className={cn(
@@ -108,6 +112,42 @@ export function CatWorkspaceView({
         <FormattedMessage {...catWorkspaceMessages.emptyQueue} />
       </div>
     );
+  }
+
+  if (!selectedSegment && isQueueLoading) {
+    return (
+      <div
+        className={cn(
+          "flex h-full min-h-0 min-w-0 flex-col overflow-hidden bg-background",
+          className,
+        )}
+      >
+        <CatPanelErrorBoundary scope="queue" resetKeys={[queueSearch, queueFilter]}>
+          <CatQueuePanel
+            segments={[]}
+            selectedSegmentId=""
+            summary={fullState.queueSummary}
+            onSelectSegment={() => undefined}
+            search={queueSearch}
+            onSearchChange={onQueueSearchChange}
+            isSearching={isQueueSearchPending}
+            queueFilter={queueFilter}
+            onQueueFilterChange={onQueueFilterChange}
+            availableQueueFilters={availableQueueFilters}
+            isFetchingPage={isQueueFetchingPage}
+            isQueueLoading
+            isSummaryLoading={isQueueSummaryLoading}
+            pagination={queuePagination}
+            onPreviousPage={onQueuePreviousPage}
+            onNextPage={onQueueNextPage}
+          />
+        </CatPanelErrorBoundary>
+      </div>
+    );
+  }
+
+  if (!selectedSegment) {
+    return null;
   }
 
   const segmentPosition = queuePagination
@@ -147,6 +187,7 @@ export function CatWorkspaceView({
           isLookingUpContext={isLookingUpContext}
           isAiSuggestionLoading={isAiSuggestionLoading}
           isFormatChecksLoading={isFormatChecksLoading}
+          isSegmentDetailLoading={isSegmentDetailLoading}
           isPostingComment={isPostingComment}
           isResolvingComment={isResolvingComment}
           resolvingCommentId={resolvingCommentId}
@@ -229,6 +270,8 @@ export function CatWorkspaceView({
           onBulkSkip={onBulkSkip}
           isBulkActionPending={isBulkActionPending}
           isFetchingPage={isQueueFetchingPage}
+          isQueueLoading={isQueueLoading}
+          isSummaryLoading={isQueueSummaryLoading}
           pagination={queuePagination}
           onPreviousPage={onQueuePreviousPage}
           onNextPage={onQueueNextPage}
@@ -283,24 +326,37 @@ export function CatWorkspaceView({
                 </p>
               </div>
               <div className="shrink-0 text-right">
-                <p className="text-xs font-medium text-foreground">
-                  <FormattedMessage
-                    {...catWorkspaceMessages.reviewedProgress}
-                    values={{ progress: reviewedProgress }}
-                  />
-                </p>
-                <p className="text-xs text-muted-foreground">
-                  <FormattedMessage
-                    {...catWorkspaceMessages.reviewedSummary}
-                    values={{
-                      reviewed: fullState.queueSummary.reviewed,
-                      total: fullState.queueSummary.total,
-                    }}
-                  />
-                </p>
+                {isQueueSummaryLoading ? (
+                  <div className="space-y-2">
+                    <Skeleton className="ms-auto h-3 w-20 rounded-full bg-foreground/8" />
+                    <Skeleton className="ms-auto h-3 w-16 rounded-full bg-foreground/8" />
+                  </div>
+                ) : (
+                  <>
+                    <p className="text-xs font-medium text-foreground">
+                      <FormattedMessage
+                        {...catWorkspaceMessages.reviewedProgress}
+                        values={{ progress: reviewedProgress }}
+                      />
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      <FormattedMessage
+                        {...catWorkspaceMessages.reviewedSummary}
+                        values={{
+                          reviewed: fullState.queueSummary.reviewed,
+                          total: fullState.queueSummary.total,
+                        }}
+                      />
+                    </p>
+                  </>
+                )}
               </div>
             </div>
-            <Progress value={reviewedProgress} className="mt-3 h-1.5" />
+            {isQueueSummaryLoading ? (
+              <Skeleton className="mt-3 h-1.5 w-full rounded-full bg-foreground/8" />
+            ) : (
+              <Progress value={reviewedProgress} className="mt-3 h-1.5" />
+            )}
           </div>
 
           <Tabs
@@ -340,14 +396,18 @@ export function CatWorkspaceView({
           </Tabs>
         </div>
       ) : (
-        <div className="grid min-h-0 min-w-0 flex-1 grid-cols-[20rem_minmax(0,1fr)_22rem] overflow-hidden">
-          <div className="min-w-0 overflow-hidden">{renderQueuePanel()}</div>
-
-          <div className="flex min-w-0 flex-col overflow-hidden">
-            <div className="min-h-0 flex-1 overflow-hidden">{renderEditorPanel()}</div>
+        <div className="grid h-full min-h-0 min-w-0 flex-1 grid-cols-[minmax(0,20rem)_minmax(0,1fr)_minmax(0,22rem)] overflow-hidden">
+          <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
+            {renderQueuePanel()}
           </div>
 
-          <div className="min-w-0 overflow-hidden">{renderIntelligencePanel()}</div>
+          <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
+            {renderEditorPanel()}
+          </div>
+
+          <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
+            {renderIntelligencePanel()}
+          </div>
         </div>
       )}
     </div>

--- a/apps/hyperlocalise-web/src/components/cat/dependencies.ts
+++ b/apps/hyperlocalise-web/src/components/cat/dependencies.ts
@@ -112,6 +112,9 @@ export interface CatWorkspaceViewProps {
   onQueueSearchChange?: (value: string) => void;
   isQueueSearchPending?: boolean;
   isQueueFetchingPage?: boolean;
+  isQueueLoading?: boolean;
+  isQueueSummaryLoading?: boolean;
+  isSegmentDetailLoading?: boolean;
   queuePagination?: {
     offset: number;
     limit: number;

--- a/apps/hyperlocalise-web/src/components/cat/project-file-cat-api.test.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file-cat-api.test.ts
@@ -17,7 +17,7 @@ describe("projectFileCatQueryKey", () => {
         offset: 50,
       }),
     ).toEqual([
-      "project-file-cat",
+      "project-file-cat-queue",
       "acme",
       "project_1",
       "locales/en.json",

--- a/apps/hyperlocalise-web/src/components/cat/project-file-cat-api.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file-cat-api.ts
@@ -1,10 +1,14 @@
-import type { ProjectFileCatResponse } from "@/api/routes/project/project.schema";
-import type { ProjectFileCatQueueFilter } from "@/api/routes/project/project.schema";
+import type {
+  ProjectFileCatQueueFilter,
+  ProjectFileCatQueueResponse,
+  ProjectFileCatResponse,
+} from "@/api/routes/project/project.schema";
 import { defaultProjectFileCatPageLimit } from "@/api/routes/project/project.schema";
 import { readApiError } from "@/lib/api-error";
 import { apiClient } from "@/lib/api-client-instance";
 
 export type ProjectFileCatPage = ProjectFileCatResponse["catFile"];
+export type ProjectFileCatQueuePage = ProjectFileCatQueueResponse["catQueue"];
 
 export function projectFileCatQueryKey(input: {
   organizationSlug: string;
@@ -18,7 +22,7 @@ export function projectFileCatQueryKey(input: {
   offset: number;
 }) {
   return [
-    "project-file-cat",
+    "project-file-cat-queue",
     input.organizationSlug,
     input.projectId,
     input.sourcePath,
@@ -42,7 +46,7 @@ export function projectFileCatBaseQueryKey(input: {
   limit: number;
 }) {
   return [
-    "project-file-cat",
+    "project-file-cat-queue",
     input.organizationSlug,
     input.projectId,
     input.sourcePath,
@@ -54,7 +58,7 @@ export function projectFileCatBaseQueryKey(input: {
   ] as const;
 }
 
-export async function fetchProjectFileCatPage(input: {
+export async function fetchProjectFileCatQueuePage(input: {
   organizationSlug: string;
   projectId: string;
   sourcePath: string;
@@ -67,7 +71,7 @@ export async function fetchProjectFileCatPage(input: {
 }) {
   const response = await apiClient.api.orgs[":organizationSlug"].projects[
     ":projectId"
-  ].files.detail.cat.$get({
+  ].files.detail.cat.queue.$get({
     param: { organizationSlug: input.organizationSlug, projectId: input.projectId },
     query: {
       sourcePath: input.sourcePath,
@@ -81,11 +85,14 @@ export async function fetchProjectFileCatPage(input: {
   });
 
   if (!response.ok) {
-    throw new Error(await readApiError(response, "Failed to load CAT workspace"));
+    throw new Error(await readApiError(response, "Failed to load CAT queue"));
   }
 
-  const body = (await response.json()) as ProjectFileCatResponse;
-  return body.catFile;
+  const body = (await response.json()) as ProjectFileCatQueueResponse;
+  return body.catQueue;
 }
+
+/** @deprecated Use fetchProjectFileCatQueuePage — queue panel loads via GET /cat/queue */
+export const fetchProjectFileCatPage = fetchProjectFileCatQueuePage;
 
 export const defaultCatPageLimit = defaultProjectFileCatPageLimit;

--- a/apps/hyperlocalise-web/src/components/cat/project-file-cat-mapper.ts
+++ b/apps/hyperlocalise-web/src/components/cat/project-file-cat-mapper.ts
@@ -270,6 +270,13 @@ export function projectFileCatToWorkspaceState(
 ): CatWorkspaceState {
   const sourceLocale = catFile.provider?.sourceLocale ?? "source";
   const segmentOffset = catFile.pagination?.offset ?? 0;
+  const queueSummary = catFile.queueSummary ?? {
+    total: 0,
+    reviewed: 0,
+    untranslated: 0,
+    needsReview: 0,
+    hasIssues: 0,
+  };
   const segments = catFile.segments.map((segment, index): CatSegment => {
     const commentCount = segment.comments.length || segment.commentCount || 0;
     const issueComments = countOpenIssues(segment);
@@ -301,7 +308,7 @@ export function projectFileCatToWorkspaceState(
   return {
     segments,
     selectedSegmentId: segments[0]?.id ?? "",
-    queueSummary: catFile.queueSummary,
+    queueSummary,
     formatChecks: [],
     segmentFormatChecks: {},
     intelligence: intelligenceFor(catFile),

--- a/apps/hyperlocalise-web/src/components/cat/project-file-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/project-file-cat-workspace.tsx
@@ -12,7 +12,6 @@ import type {
   ProjectFileCatTranslation,
   ProjectFileCatVisualContextResponse,
 } from "@/api/routes/project/project.schema";
-import { Spinner } from "@/components/ui/spinner";
 import {
   Select,
   SelectContent,
@@ -27,6 +26,7 @@ import { mapCatConcordanceForAiRecommendation } from "@/lib/translation/map-cat-
 import { cn } from "@/lib/primitives/cn";
 
 import { CatWorkspaceContainer } from "./cat-workspace-container";
+import { CatWorkspaceSkeleton } from "./cat-workspace-skeleton";
 import { buildCatSegmentShareUrl } from "./cat-segment-share-link";
 import { resolveAvailableCatQueueFilters } from "./cat-queue-filter";
 import {
@@ -36,6 +36,7 @@ import {
   validateSegmentFormat,
 } from "./project-file-cat-mapper";
 import { useCatSegmentDetail, useInvalidateCatSegmentDetail } from "./use-cat-segment-detail";
+import { useCatQueueSummary, useInvalidateCatQueueSummary } from "./use-cat-queue-summary";
 import { useCatSegmentQuery } from "./use-cat-segment-query";
 import type {
   CatGlossaryTerm,
@@ -79,6 +80,7 @@ export function ProjectFileCatWorkspace({
   const intl = useIntl();
   const [activeSegmentId, setActiveSegmentId] = useState<string | null>(null);
   const invalidateSegmentDetail = useInvalidateCatSegmentDetail();
+  const invalidateQueueSummary = useInvalidateCatQueueSummary();
   const [targetLocaleState, setTargetLocaleState] = useState(
     () => targetLocaleProp ?? initialTargetLocale(targetLocales ?? [], highlightLocale),
   );
@@ -116,6 +118,15 @@ export function ProjectFileCatWorkspace({
     goToPreviousPage,
     goToNextPage,
   } = useCatSegmentQuery({
+    organizationSlug,
+    projectId,
+    sourcePath,
+    targetLocale,
+    repositoryFullName,
+    enabled: Boolean(targetLocale),
+  });
+
+  const queueSummaryQuery = useCatQueueSummary({
     organizationSlug,
     projectId,
     sourcePath,
@@ -165,7 +176,16 @@ export function ProjectFileCatWorkspace({
       return body.translation;
     },
     onSuccess: async () => {
-      await invalidateCurrentPage();
+      await Promise.all([
+        invalidateCurrentPage(),
+        invalidateQueueSummary({
+          organizationSlug,
+          projectId,
+          sourcePath,
+          targetLocale,
+          repositoryFullName,
+        }),
+      ]);
     },
   });
   const saveTranslation = saveMutation.mutateAsync;
@@ -204,15 +224,24 @@ export function ProjectFileCatWorkspace({
       return body.comment;
     },
     onSuccess: async (_data, variables) => {
-      await invalidateCurrentPage();
-      await invalidateSegmentDetail({
-        organizationSlug,
-        projectId,
-        sourcePath,
-        targetLocale,
-        externalStringId: variables.externalStringId,
-        repositoryFullName,
-      });
+      await Promise.all([
+        invalidateCurrentPage(),
+        invalidateQueueSummary({
+          organizationSlug,
+          projectId,
+          sourcePath,
+          targetLocale,
+          repositoryFullName,
+        }),
+        invalidateSegmentDetail({
+          organizationSlug,
+          projectId,
+          sourcePath,
+          targetLocale,
+          externalStringId: variables.externalStringId,
+          repositoryFullName,
+        }),
+      ]);
     },
   });
   const postComment = commentMutation.mutateAsync;
@@ -245,23 +274,41 @@ export function ProjectFileCatWorkspace({
       return body.comment;
     },
     onSuccess: async (_data, variables) => {
-      await invalidateCurrentPage();
-      await invalidateSegmentDetail({
-        organizationSlug,
-        projectId,
-        sourcePath,
-        targetLocale,
-        externalStringId: variables.externalStringId,
-        repositoryFullName,
-      });
+      await Promise.all([
+        invalidateCurrentPage(),
+        invalidateQueueSummary({
+          organizationSlug,
+          projectId,
+          sourcePath,
+          targetLocale,
+          repositoryFullName,
+        }),
+        invalidateSegmentDetail({
+          organizationSlug,
+          projectId,
+          sourcePath,
+          targetLocale,
+          externalStringId: variables.externalStringId,
+          repositoryFullName,
+        }),
+      ]);
     },
   });
   const resolveComment = resolveCommentMutation.mutateAsync;
 
-  const workspaceState = useMemo(
-    () => (catQuery.data ? projectFileCatToWorkspaceState(catQuery.data, intl) : null),
-    [catQuery.data, intl],
-  );
+  const workspaceState = useMemo(() => {
+    if (!catQuery.data) {
+      return null;
+    }
+
+    return projectFileCatToWorkspaceState(
+      {
+        ...catQuery.data,
+        queueSummary: queueSummaryQuery.data ?? catQuery.data.queueSummary,
+      },
+      intl,
+    );
+  }, [catQuery.data, intl, queueSummaryQuery.data]);
 
   useEffect(() => {
     if (!workspaceState) {
@@ -295,6 +342,9 @@ export function ProjectFileCatWorkspace({
     repositoryFullName,
     enabled: Boolean(catQuery.data),
   });
+
+  const isSegmentDetailLoading =
+    Boolean(activeSegmentId) && segmentDetailQuery.isFetching && !segmentDetailQuery.data;
 
   const enrichedWorkspaceState = useMemo(() => {
     if (!workspaceState || !catQuery.data || !segmentDetailQuery.data) {
@@ -526,13 +576,21 @@ export function ProjectFileCatWorkspace({
   }
 
   const isFullscreen = layout === "fullscreen";
+  const isQueueSummaryLoading = queueSummaryQuery.isFetching && !queueSummaryQuery.data;
+
+  const isQueueLoading =
+    isSearchPending ||
+    (catQuery.isFetching && Boolean(catQuery.data) && catQuery.isPlaceholderData);
 
   if (catQuery.isLoading && !catQuery.data) {
     return (
-      <div className="flex min-h-0 flex-1 items-center justify-center gap-2 text-muted-foreground">
-        <Spinner />
-        <TypographyP className="text-sm">Loading CAT workspace...</TypographyP>
-      </div>
+      <CatWorkspaceSkeleton
+        className={cn(
+          "min-h-0 flex-1",
+          isFullscreen && "rounded-lg border border-border",
+          className,
+        )}
+      />
     );
   }
 
@@ -549,7 +607,11 @@ export function ProjectFileCatWorkspace({
     );
   }
 
-  if (!enrichedWorkspaceState || enrichedWorkspaceState.segments.length === 0) {
+  if (
+    (!enrichedWorkspaceState || enrichedWorkspaceState.segments.length === 0) &&
+    !isQueueLoading &&
+    !catQuery.isFetching
+  ) {
     return (
       <div className="flex min-h-0 flex-1 items-center justify-center text-muted-foreground">
         <TypographyP className="text-sm">
@@ -561,6 +623,11 @@ export function ProjectFileCatWorkspace({
         </TypographyP>
       </div>
     );
+  }
+
+  const workspaceForRender = enrichedWorkspaceState ?? workspaceState;
+  if (!workspaceForRender) {
+    return null;
   }
 
   return (
@@ -599,7 +666,7 @@ export function ProjectFileCatWorkspace({
 
       <CatWorkspaceContainer
         key={`${sourcePath}:${targetLocale}:${repositoryFullName ?? "default"}:${debouncedSearch}:${queueFilter}:${pagination?.offset ?? 0}`}
-        initialState={enrichedWorkspaceState}
+        initialState={workspaceForRender}
         className={cn("min-h-0 flex-1", isFullscreen && "rounded-lg border border-border")}
         navigation={{
           onSelectSegment: (segmentId) => {
@@ -633,6 +700,9 @@ export function ProjectFileCatWorkspace({
         availableQueueFilters={availableQueueFilters}
         isQueueSearchPending={isSearchPending}
         isQueueFetchingPage={catQuery.isFetching && !catQuery.isLoading}
+        isQueueLoading={isQueueLoading}
+        isQueueSummaryLoading={isQueueSummaryLoading}
+        isSegmentDetailLoading={isSegmentDetailLoading}
         queuePagination={pagination}
         onQueuePreviousPage={goToPreviousPage}
         onQueueNextPage={goToNextPage}

--- a/apps/hyperlocalise-web/src/components/cat/project-file-cat-workspace.tsx
+++ b/apps/hyperlocalise-web/src/components/cat/project-file-cat-workspace.tsx
@@ -578,9 +578,9 @@ export function ProjectFileCatWorkspace({
   const isFullscreen = layout === "fullscreen";
   const isQueueSummaryLoading = queueSummaryQuery.isFetching && !queueSummaryQuery.data;
 
-  const isQueueLoading =
-    isSearchPending ||
-    (catQuery.isFetching && Boolean(catQuery.data) && catQuery.isPlaceholderData);
+  // useCatSegmentQuery seeds placeholderData with keepPreviousData, so isPlaceholderData
+  // stays true while paginating or changing filters/search with prior rows still visible.
+  const isQueueLoading = isSearchPending || (catQuery.isFetching && catQuery.isPlaceholderData);
 
   if (catQuery.isLoading && !catQuery.data) {
     return (

--- a/apps/hyperlocalise-web/src/components/cat/use-cat-queue-summary.ts
+++ b/apps/hyperlocalise-web/src/components/cat/use-cat-queue-summary.ts
@@ -1,0 +1,105 @@
+"use client";
+
+import { keepPreviousData, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+
+import type { ProjectFileCatQueueSummary } from "@/api/routes/project/project.schema";
+import { readApiError } from "@/lib/api-error";
+import { apiClient } from "@/lib/api-client-instance";
+
+export function projectFileCatQueueSummaryQueryKey(input: {
+  organizationSlug: string;
+  projectId: string;
+  sourcePath: string;
+  targetLocale: string;
+  repositoryFullName: string | null;
+}) {
+  return [
+    "project-file-cat-queue-summary",
+    input.organizationSlug,
+    input.projectId,
+    input.sourcePath,
+    input.targetLocale,
+    input.repositoryFullName,
+  ] as const;
+}
+
+export async function fetchProjectFileCatQueueSummary(input: {
+  organizationSlug: string;
+  projectId: string;
+  sourcePath: string;
+  targetLocale: string;
+  repositoryFullName: string | null;
+}) {
+  const response = await apiClient.api.orgs[":organizationSlug"].projects[
+    ":projectId"
+  ].files.detail.cat.queue.summary.$get({
+    param: { organizationSlug: input.organizationSlug, projectId: input.projectId },
+    query: {
+      sourcePath: input.sourcePath,
+      targetLocale: input.targetLocale,
+      ...(input.repositoryFullName ? { repositoryFullName: input.repositoryFullName } : {}),
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(await readApiError(response, "Failed to load queue summary"));
+  }
+
+  const body = (await response.json()) as { queueSummary: ProjectFileCatQueueSummary };
+  return body.queueSummary;
+}
+
+export function useCatQueueSummary(input: {
+  organizationSlug: string;
+  projectId: string;
+  sourcePath: string;
+  targetLocale: string;
+  repositoryFullName?: string | null;
+  enabled?: boolean;
+}) {
+  const repositoryFullName = input.repositoryFullName ?? null;
+
+  return useQuery({
+    queryKey: projectFileCatQueueSummaryQueryKey({
+      organizationSlug: input.organizationSlug,
+      projectId: input.projectId,
+      sourcePath: input.sourcePath,
+      targetLocale: input.targetLocale,
+      repositoryFullName,
+    }),
+    enabled: input.enabled !== false && Boolean(input.targetLocale) && Boolean(input.sourcePath),
+    staleTime: 60_000,
+    placeholderData: keepPreviousData,
+    queryFn: () =>
+      fetchProjectFileCatQueueSummary({
+        organizationSlug: input.organizationSlug,
+        projectId: input.projectId,
+        sourcePath: input.sourcePath,
+        targetLocale: input.targetLocale,
+        repositoryFullName,
+      }),
+  });
+}
+
+export function useInvalidateCatQueueSummary() {
+  const queryClient = useQueryClient();
+
+  return useCallback(
+    async (input: {
+      organizationSlug: string;
+      projectId: string;
+      sourcePath: string;
+      targetLocale: string;
+      repositoryFullName?: string | null;
+    }) => {
+      await queryClient.invalidateQueries({
+        queryKey: projectFileCatQueueSummaryQueryKey({
+          ...input,
+          repositoryFullName: input.repositoryFullName ?? null,
+        }),
+      });
+    },
+    [queryClient],
+  );
+}

--- a/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-service.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/native-cat-service.ts
@@ -57,6 +57,7 @@ export class NativeCatService extends ProjectServiceBase {
     targetLocale: string;
     canEditTranslations: boolean;
     pagination?: ProjectFileCatPaginationInput;
+    includeQueueSummary?: boolean;
   }): Promise<ProjectFileCatResponse["catFile"] | null> {
     const sourceFile = await this.translations.getRepositorySourceFileByPath({
       organizationId: input.organizationId,
@@ -76,6 +77,8 @@ export class NativeCatService extends ProjectServiceBase {
       paginated: false,
     };
 
+    const includeQueueSummary = input.includeQueueSummary !== false;
+
     if (!paginationInput.paginated) {
       const keys = await this.translations.listKeysForFile({
         organizationId: input.organizationId,
@@ -86,12 +89,14 @@ export class NativeCatService extends ProjectServiceBase {
 
       const truncated = keys.length > legacyNativeCatSegmentLimit;
       const visibleKeys = truncated ? keys.slice(0, legacyNativeCatSegmentLimit) : keys;
-      const queueSummary = await countNativeFileQueueSummary(this.translations, {
-        organizationId: input.organizationId,
-        projectId: input.projectId,
-        repositorySourceFileId: sourceFile.id,
-        targetLocale: input.targetLocale,
-      });
+      const queueSummary = includeQueueSummary
+        ? await countNativeFileQueueSummary(this.translations, {
+            organizationId: input.organizationId,
+            projectId: input.projectId,
+            repositorySourceFileId: sourceFile.id,
+            targetLocale: input.targetLocale,
+          })
+        : undefined;
 
       return this.buildCatFileResponse({
         input,
@@ -121,12 +126,14 @@ export class NativeCatService extends ProjectServiceBase {
         search: paginationInput.search,
         queueFilter: paginationInput.queueFilter,
       }),
-      countNativeFileQueueSummary(this.translations, {
-        organizationId: input.organizationId,
-        projectId: input.projectId,
-        repositorySourceFileId: sourceFile.id,
-        targetLocale: input.targetLocale,
-      }),
+      includeQueueSummary
+        ? countNativeFileQueueSummary(this.translations, {
+            organizationId: input.organizationId,
+            projectId: input.projectId,
+            repositorySourceFileId: sourceFile.id,
+            targetLocale: input.targetLocale,
+          })
+        : Promise.resolve(undefined),
     ]);
 
     const pagination = buildCatFilePagination({
@@ -156,7 +163,7 @@ export class NativeCatService extends ProjectServiceBase {
     visibleKeys: Awaited<ReturnType<ProjectTranslationService["listKeysForFile"]>>;
     truncated: boolean;
     pagination: ReturnType<typeof buildCatFilePagination> | undefined;
-    queueSummary: Awaited<ReturnType<typeof countNativeFileQueueSummary>>;
+    queueSummary: Awaited<ReturnType<typeof countNativeFileQueueSummary>> | undefined;
   }): Promise<ProjectFileCatResponse["catFile"]> {
     const translationKeyIds = input.visibleKeys.map((key) => key.id);
     const [translations, commentCounts] = await Promise.all([
@@ -185,7 +192,7 @@ export class NativeCatService extends ProjectServiceBase {
       canEditTranslations: input.input.canEditTranslations,
       truncated: input.truncated,
       pagination: input.pagination,
-      queueSummary: input.queueSummary,
+      ...(input.queueSummary ? { queueSummary: input.queueSummary } : {}),
       segments: input.visibleKeys.map((key) => {
         const translation = translationByKeyId.get(key.id);
         const counts = commentCounts.get(key.id);
@@ -520,12 +527,40 @@ export class NativeCatService extends ProjectServiceBase {
       segments: hydratedSegments,
     };
   }
+
+  async getQueueSummary(input: {
+    organizationId: string;
+    projectId: string;
+    sourcePath: string;
+    targetLocale: string;
+  }): Promise<ProjectFileCatResponse["catFile"]["queueSummary"] | null> {
+    const sourceFile = await this.translations.getRepositorySourceFileByPath({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      sourcePath: input.sourcePath,
+    });
+
+    if (!sourceFile) {
+      return null;
+    }
+
+    return countNativeFileQueueSummary(this.translations, {
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      repositorySourceFileId: sourceFile.id,
+      targetLocale: input.targetLocale,
+    });
+  }
 }
 
 export const nativeCatService = new NativeCatService();
 
 export const getNativeProjectCatFile = (input: Parameters<NativeCatService["getCatFile"]>[0]) =>
   nativeCatService.getCatFile(input);
+
+export const getNativeProjectCatQueueSummary = (
+  input: Parameters<NativeCatService["getQueueSummary"]>[0],
+) => nativeCatService.getQueueSummary(input);
 
 export const getNativeProjectCatSegmentDetail = (
   input: Parameters<NativeCatService["getSegmentDetail"]>[0],

--- a/apps/hyperlocalise-web/src/lib/projects/cat/project-file-cat-pagination.ts
+++ b/apps/hyperlocalise-web/src/lib/projects/cat/project-file-cat-pagination.ts
@@ -56,6 +56,12 @@ export function resolveProviderLegacyCatLimit(paginated: boolean) {
   return paginated ? maxProjectFileCatPageLimit : legacyProviderCatSegmentLimit;
 }
 
+export function resolveProjectFileCatIncludeQueueSummary(
+  query: Pick<ProjectFileCatQuery, "includeQueueSummary">,
+) {
+  return query.includeQueueSummary !== "false";
+}
+
 export function buildCatFilePagination(input: {
   offset: number;
   limit: number;

--- a/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/adapters/crowdin/crowdin-api.ts
@@ -766,6 +766,7 @@ export class CrowdinApiClient {
     filter: {
       type?: "comment" | "issue";
       issueStatus?: "resolved" | "unresolved";
+      targetLanguageId?: string;
     },
   ): Promise<CrowdinStringComment[]> {
     const comments: CrowdinStringComment[] = [];
@@ -778,6 +779,7 @@ export class CrowdinApiClient {
             stringId,
             type: filter.type,
             issueStatus: filter.issueStatus,
+            targetLanguageId: filter.targetLanguageId,
           }),
         ),
       );

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live-cat.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live-cat.test.ts
@@ -1054,7 +1054,7 @@ describe("getTmsProviderLiveCatFile", () => {
             queueFilter: "has_issues",
           }),
       ).length,
-    ).toBeGreaterThanOrEqual(2);
+    ).toBeGreaterThanOrEqual(1);
   });
 });
 

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live-cat.test.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live-cat.test.ts
@@ -1044,17 +1044,172 @@ describe("getTmsProviderLiveCatFile", () => {
     for (const croql of expectedQueueSummaryCroqls) {
       expect(queueSummaryCroqls).toContain(croql);
     }
-    expect(
-      queueSummaryCroqls.filter(
-        (croql) =>
-          croql ===
-          buildCrowdinFileQueueCroql({
-            fileId: 101,
-            targetLocale: "fr",
-            queueFilter: "has_issues",
+  });
+
+  it("marks every visible has_issues segment with unresolved issue flags", async () => {
+    const { organization, user } = await fixture.createLocalWorkosIdentity(
+      fixture.createWorkosIdentityWithRole("admin"),
+    );
+    await setupCrowdinPatCredential({
+      organizationId: organization.id,
+      userId: user.id,
+    });
+
+    const issueCommentRequests: string[] = [];
+    const fetchMock = vi.fn(async (url) => {
+      const path = String(url);
+
+      if (isCrowdinGetProjectRequest(path)) {
+        return mockCrowdinProject42Response();
+      }
+
+      if (path.includes("/projects/42/branches?")) {
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }
+
+      if (path.includes("/projects/42/directories?")) {
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }
+
+      if (path.includes("/projects/42/files?")) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  id: 101,
+                  branchId: null,
+                  directoryId: null,
+                  name: "home.json",
+                  title: "home.json",
+                  type: "json",
+                  path: "/home.json",
+                  status: "active",
+                  revisionId: 7,
+                },
+              },
+            ],
           }),
-      ).length,
-    ).toBeGreaterThanOrEqual(1);
+          { status: 200 },
+        );
+      }
+
+      if (path.includes("/projects/42/files/101/revisions?")) {
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }
+
+      if (
+        path.includes("/projects/42/strings?") &&
+        path.includes("croql=") &&
+        path.includes("has+unresolved+issue")
+      ) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  id: 1001,
+                  projectId: 42,
+                  fileId: 101,
+                  branchId: null,
+                  directoryId: null,
+                  identifier: "homepage.hero.title",
+                  text: "Hero title",
+                  type: "text",
+                  context: null,
+                  labelIds: null,
+                },
+              },
+              {
+                data: {
+                  id: 1002,
+                  projectId: 42,
+                  fileId: 101,
+                  branchId: null,
+                  directoryId: null,
+                  identifier: "homepage.hero.cta",
+                  text: "Hero CTA",
+                  type: "text",
+                  context: null,
+                  labelIds: null,
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (
+        path.includes("/projects/42/languages/fr/translations?") &&
+        path.includes("stringIds=1001%2C1002")
+      ) {
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }
+
+      if (
+        path.includes("/projects/42/approvals?") &&
+        path.includes("languageId=fr") &&
+        path.includes("fileId=101")
+      ) {
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }
+
+      if (path.includes("/projects/42/comments?") && path.includes("type=issue")) {
+        const requestUrl = new URL(path);
+        const stringId = requestUrl.searchParams.get("stringId");
+        if (stringId) {
+          issueCommentRequests.push(stringId);
+        }
+
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                data: {
+                  id: Number(`50${stringId}`),
+                  text: `Issue on ${stringId}`,
+                  userId: 1,
+                  stringId: Number(stringId),
+                  languageId: "fr",
+                  type: "issue",
+                  issueStatus: "unresolved",
+                  createdAt: "2026-06-08T00:02:00Z",
+                  projectId: 42,
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const catFile = await getTmsProviderLiveCatFile(organization.id, "42", "home.json", "fr", {
+      actorUserId: user.id,
+      canEditTranslations: true,
+      includeQueueSummary: false,
+      pagination: {
+        offset: 0,
+        limit: 25,
+        paginated: true,
+        queueFilter: "has_issues",
+      },
+    });
+
+    expect(catFile?.pagination).toMatchObject({
+      offset: 0,
+      limit: 25,
+      returnedCount: 2,
+      totalCount: 2,
+      hasMore: false,
+    });
+    expect(catFile?.segments).toHaveLength(2);
+    expect(catFile?.segments.every((segment) => segment.unresolvedIssueCount === 1)).toBe(true);
+    expect(issueCommentRequests).toEqual(expect.arrayContaining(["1001", "1002"]));
   });
 });
 

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
@@ -987,40 +987,86 @@ async function countCrowdinSourceStrings(
   return Math.min(total, ceiling);
 }
 
-async function loadCrowdinStringIdsWithUnresolvedIssues(
+async function loadCrowdinVisibleStringIdsWithUnresolvedIssues(
   client: CrowdinApiClient,
   projectId: number,
-  fileId: number,
+  stringIds: number[],
   targetLocale: string,
 ) {
-  const croql = buildCrowdinFileQueueCroql({
-    fileId,
-    targetLocale,
-    queueFilter: "has_issues",
-  });
-  const stringIds = new Set<number>();
-  let offset = 0;
-  const limit = 500;
-
-  while (true) {
-    const page = await client.listSourceStringsPage(projectId, {
-      croql,
-      offset,
-      limit,
-    });
-
-    for (const sourceString of page.strings) {
-      stringIds.add(sourceString.id);
-    }
-
-    if (!page.hasMore || page.strings.length === 0) {
-      break;
-    }
-
-    offset += page.strings.length;
+  if (stringIds.length === 0) {
+    return new Set<number>();
   }
 
-  return stringIds;
+  const issues = await client.listStringCommentsForStrings(projectId, stringIds, {
+    type: "issue",
+    issueStatus: "unresolved",
+    targetLanguageId: targetLocale,
+  });
+
+  const unresolvedIssueStringIds = new Set<number>();
+  for (const issue of crowdinCatCommentsForTargetLocale(issues, targetLocale)) {
+    unresolvedIssueStringIds.add(issue.stringId);
+  }
+
+  return unresolvedIssueStringIds;
+}
+
+async function loadCrowdinTranslationsByStringId(
+  client: CrowdinApiClient,
+  projectId: number,
+  targetLocale: string,
+  sourceStringIds: number[],
+) {
+  const translationsByStringId = new Map<number, CrowdinLanguageTranslation[]>();
+  if (sourceStringIds.length === 0) {
+    return translationsByStringId;
+  }
+
+  const chunks: number[][] = [];
+  for (let index = 0; index < sourceStringIds.length; index += 25) {
+    chunks.push(sourceStringIds.slice(index, index + 25));
+  }
+
+  const chunkResults = await mapWithConcurrency(chunks, 3, (chunk) =>
+    client.listLanguageTranslations(projectId, targetLocale, {
+      stringIds: chunk,
+    }),
+  );
+
+  for (const translations of chunkResults) {
+    for (const translation of translations) {
+      const existing = translationsByStringId.get(translation.stringId) ?? [];
+      existing.push(translation);
+      translationsByStringId.set(translation.stringId, existing);
+    }
+  }
+
+  return translationsByStringId;
+}
+
+async function getCrowdinLiveCatQueueSummary(input: {
+  context: ActiveTmsProviderContext;
+  file: TmsProviderLiveFile;
+  targetLocale: string;
+}): Promise<ProjectFileCatResponse["catFile"]["queueSummary"]> {
+  const projectId = Number(input.file.provider?.externalProjectId);
+  const fileId = Number(input.file.provider?.externalResourceId);
+  if (Number.isNaN(projectId) || Number.isNaN(fileId)) {
+    throw new TmsProviderLiveError(
+      "invalid_crowdin_project_or_file_id",
+      "Crowdin project or file identifier is invalid.",
+    );
+  }
+
+  const client = new CrowdinApiClient({
+    token: input.context.secretMaterial,
+    baseUrl: input.context.credential.baseUrl ?? undefined,
+  });
+
+  const knownTotal = await countCrowdinSourceStrings(client, projectId, { fileId });
+  return countCrowdinFileQueueSummary(client, projectId, fileId, input.targetLocale, {
+    knownTotal,
+  });
 }
 
 async function buildCrowdinLiveCatFile(input: {
@@ -1029,6 +1075,7 @@ async function buildCrowdinLiveCatFile(input: {
   targetLocale: string;
   canEditTranslations: boolean;
   pagination?: ProjectFileCatPaginationInput;
+  includeQueueSummary?: boolean;
 }): Promise<TmsProviderLiveCatFile> {
   const projectId = Number(input.file.provider?.externalProjectId);
   const fileId = Number(input.file.provider?.externalResourceId);
@@ -1109,44 +1156,30 @@ async function buildCrowdinLiveCatFile(input: {
     }
 
     const sourceStringIds = visibleStrings.map((sourceString) => sourceString.id);
+    const includeQueueSummary = input.includeQueueSummary !== false;
 
-    const queueSummaryPromise = countCrowdinFileQueueSummary(
-      client,
-      projectId,
-      fileId,
-      input.targetLocale,
-      { knownTotal: knownFileTotal },
-    );
+    const [translationsByStringId, approvals, unresolvedIssueStringIds, queueSummary] =
+      await Promise.all([
+        loadCrowdinTranslationsByStringId(client, projectId, input.targetLocale, sourceStringIds),
+        client.listTranslationApprovalsForSourceStrings(
+          projectId,
+          input.targetLocale,
+          visibleStrings,
+        ),
+        loadCrowdinVisibleStringIdsWithUnresolvedIssues(
+          client,
+          projectId,
+          sourceStringIds,
+          input.targetLocale,
+        ),
+        includeQueueSummary
+          ? countCrowdinFileQueueSummary(client, projectId, fileId, input.targetLocale, {
+              knownTotal: knownFileTotal,
+            })
+          : Promise.resolve(undefined),
+      ]);
 
-    const translationsByStringId = new Map<number, CrowdinLanguageTranslation[]>();
-    const approvalsPromise = client.listTranslationApprovals(projectId, input.targetLocale, {
-      fileId,
-    });
-    try {
-      for (let index = 0; index < sourceStringIds.length; index += 25) {
-        const chunk = sourceStringIds.slice(index, index + 25);
-        const translations = await client.listLanguageTranslations(projectId, input.targetLocale, {
-          stringIds: chunk,
-        });
-
-        for (const translation of translations) {
-          const existing = translationsByStringId.get(translation.stringId) ?? [];
-          existing.push(translation);
-          translationsByStringId.set(translation.stringId, existing);
-        }
-      }
-    } catch (loopError) {
-      await approvalsPromise.catch(() => undefined);
-      throw loopError;
-    }
-
-    const approvals = await approvalsPromise;
     const approvedTranslationIds = new Set(approvals.map((approval) => approval.translationId));
-
-    const [queueSummary, unresolvedIssueStringIds] = await Promise.all([
-      queueSummaryPromise,
-      loadCrowdinStringIdsWithUnresolvedIssues(client, projectId, fileId, input.targetLocale),
-    ]);
 
     return {
       sourcePath: input.file.sourcePath,
@@ -1156,7 +1189,7 @@ async function buildCrowdinLiveCatFile(input: {
       canEditTranslations: input.canEditTranslations,
       truncated,
       pagination,
-      queueSummary,
+      ...(queueSummary ? { queueSummary } : {}),
       segments: visibleStrings.map((sourceString) => {
         const target = preferredLanguageTranslation(
           translationsByStringId.get(sourceString.id) ?? [],
@@ -2019,6 +2052,7 @@ export async function getTmsProviderLiveCatFile(
     actorUserId?: string | null;
     canEditTranslations?: boolean;
     pagination?: ProjectFileCatPaginationInput;
+    includeQueueSummary?: boolean;
   },
 ): Promise<TmsProviderLiveCatFile | null> {
   const context = await loadActiveTmsProviderContext(organizationId, {
@@ -2063,6 +2097,57 @@ export async function getTmsProviderLiveCatFile(
     targetLocale,
     canEditTranslations: options?.canEditTranslations ?? false,
     pagination: options?.pagination,
+    includeQueueSummary: options?.includeQueueSummary,
+  });
+}
+
+export async function getTmsProviderLiveCatQueueSummary(
+  organizationId: string,
+  externalProjectId: string,
+  sourcePath: string,
+  targetLocale: string,
+  options?: { actorUserId?: string | null },
+): Promise<ProjectFileCatResponse["catFile"]["queueSummary"] | null> {
+  const context = await loadActiveTmsProviderContext(organizationId, {
+    actorUserId: options?.actorUserId,
+  });
+  const files = await listTmsProviderLiveFilesForProject(organizationId, externalProjectId, {
+    context,
+    limit: 1000,
+  });
+  const file = files.find((item) => item.sourcePath === sourcePath);
+  if (!file) {
+    return null;
+  }
+
+  if (!supportsLiveProviderCat(context.providerKind, file)) {
+    throw new TmsProviderLiveError(
+      "provider_cat_unsupported",
+      "CAT editing is not available for this provider file yet.",
+    );
+  }
+
+  if (context.providerKind === "phrase") {
+    try {
+      const catFile = await buildPhraseLiveCatFile({
+        secretMaterial: context.secretMaterial,
+        region: context.credential.region,
+        baseUrl: context.credential.baseUrl,
+        externalProjectId,
+        file,
+        targetLocale,
+        canEditTranslations: false,
+      });
+      return catFile.queueSummary;
+    } catch (error) {
+      mapPhraseLiveCatError(error);
+    }
+  }
+
+  return getCrowdinLiveCatQueueSummary({
+    context,
+    file,
+    targetLocale,
   });
 }
 

--- a/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
+++ b/apps/hyperlocalise-web/src/lib/providers/tms-provider-live.ts
@@ -2087,7 +2087,7 @@ export async function getTmsProviderLiveCatFile(
         pagination: options?.pagination,
       });
     } catch (error) {
-      mapPhraseLiveCatError(error);
+      return mapPhraseLiveCatError(error);
     }
   }
 
@@ -2138,9 +2138,16 @@ export async function getTmsProviderLiveCatQueueSummary(
         targetLocale,
         canEditTranslations: false,
       });
-      return catFile.queueSummary;
+      const queueSummary = catFile.queueSummary;
+      if (!queueSummary) {
+        throw new TmsProviderLiveError(
+          "phrase_cat_queue_summary_missing",
+          "Failed to compute CAT queue summary for this Phrase file.",
+        );
+      }
+      return queueSummary;
     } catch (error) {
-      mapPhraseLiveCatError(error);
+      return mapPhraseLiveCatError(error);
     }
   }
 


### PR DESCRIPTION
## What changed

Split the CAT workspace into per-section API calls and improved loading UX:

- **API:** Added `GET .../cat/queue/summary` and `GET .../cat/queue`; kept legacy `GET .../cat` for compatibility. Crowdin queue builds skip summary on page fetches and scope approvals/issues to the visible page.
- **Client:** Separate React Query hooks for queue summary, queue page, and segment detail; skeleton list replaces stale rows during filter/search/pagination refetch.
- **Layout:** Compact job CAT toolbar; each panel scrolls independently within a fixed viewport height.
- **Skeleton polish:** Full 3-panel shell on cold start, summary/progress skeletons while counts load, comment skeletons on segment detail fetch.

## How to test

- Open a Crowdin job file in CAT (`/jobs/.../strings?sourcePath=...`).
- Confirm cold start shows the 3-panel skeleton (not a centered spinner).
- Change queue filter/search and confirm the list shows skeleton rows instead of stale segments.
- Select a segment and confirm comments skeleton briefly while detail loads.
- Run `cd apps/hyperlocalise-web && vp check && vp test src/components/cat/project-file-cat-api.test.ts src/lib/providers/tms-provider-live-cat.test.ts`.

## Checklist

- [x] I ran relevant checks locally (`make fmt`, `make lint`, `make test`)
- [ ] I updated docs, comments, or examples when needed
- [x] This PR is scoped and ready for review

Made with [Cursor](https://cursor.com)