### PR TITLE
🧪 Scout: add unit tests for usage context helpers

### DIFF
--- a/internal/i18n/translator/usage_test.go
+++ b/internal/i18n/translator/usage_test.go
@@ -203,17 +203,20 @@ func TestUsageContextHelpers(t *testing.T) {
 	t.Parallel()
 
 	t.Run("collects and normalizes usage", func(t *testing.T) {
+		t.Parallel()
 		var collected Usage
 		ctx := WithUsageCollector(context.Background(), &collected)
 
 		SetUsage(ctx, Usage{InputTokens: 10, OutputTokens: 5})
 
-		if collected.InputTokens != 10 || collected.OutputTokens != 5 || collected.TotalTokens != 15 {
+		if collected.InputTokens != 10 || collected.OutputTokens != 5 || collected.TotalTokens != 15 ||
+			collected.PromptTokens != 10 || collected.CompletionTokens != 5 {
 			t.Errorf("expected normalized usage in collector, got %+v", collected)
 		}
 	})
 
 	t.Run("nil collector returns original context", func(t *testing.T) {
+		t.Parallel()
 		ctx := context.Background()
 		got := WithUsageCollector(ctx, nil)
 		if got != ctx {
@@ -222,6 +225,7 @@ func TestUsageContextHelpers(t *testing.T) {
 	})
 
 	t.Run("no collector in context is no-op", func(t *testing.T) {
+		t.Parallel()
 		// Should not panic
 		SetUsage(context.Background(), Usage{InputTokens: 10})
 	})

--- a/internal/i18n/translator/usage_test.go
+++ b/internal/i18n/translator/usage_test.go
@@ -1,6 +1,7 @@
 package translator
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -196,6 +197,34 @@ func TestUsageHasValues(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestUsageContextHelpers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("collects and normalizes usage", func(t *testing.T) {
+		var collected Usage
+		ctx := WithUsageCollector(context.Background(), &collected)
+
+		SetUsage(ctx, Usage{InputTokens: 10, OutputTokens: 5})
+
+		if collected.InputTokens != 10 || collected.OutputTokens != 5 || collected.TotalTokens != 15 {
+			t.Errorf("expected normalized usage in collector, got %+v", collected)
+		}
+	})
+
+	t.Run("nil collector returns original context", func(t *testing.T) {
+		ctx := context.Background()
+		got := WithUsageCollector(ctx, nil)
+		if got != ctx {
+			t.Errorf("expected original context when collector is nil")
+		}
+	})
+
+	t.Run("no collector in context is no-op", func(t *testing.T) {
+		// Should not panic
+		SetUsage(context.Background(), Usage{InputTokens: 10})
+	})
 }
 
 func TestNormalizeUsage(t *testing.T) {


### PR DESCRIPTION
💡 What: Added `TestUsageContextHelpers` to `internal/i18n/translator/usage_test.go`.
🎯 Why: To verify the core behavior of `WithUsageCollector` and `SetUsage`, ensuring reliable token usage tracking through context.
🧩 Scope: `internal/i18n/translator/usage_test.go` and its usage of `context`.
✅ Verification: Ran `go test -v -run TestUsageContextHelpers ./internal/i18n/translator/...` and `go test ./...`. All passed.
🛡️ Confidence: Protects against regressions in usage tracking and ensures safe handling of context boundaries.

---
*PR created automatically by Jules for task [3253387551898898052](https://jules.google.com/task/3253387551898898052) started by @cungminh2710*